### PR TITLE
Cleanup build script

### DIFF
--- a/build/build.py
+++ b/build/build.py
@@ -16,6 +16,7 @@ import getopt
 import subprocess
 import shutil
 import json
+import time
 
 ROOT = "."
 OUTPUT = "output/playcanvas-%s.js" % ('latest')
@@ -174,6 +175,7 @@ def create_package_json():
 
 
 if __name__ == "__main__":
+    start = time.time()
     setup()
     output_path = os.path.join(ROOT, OUTPUT)
 
@@ -183,3 +185,4 @@ if __name__ == "__main__":
 
     insert_versions(output_path)
     create_package_json()
+    print("Build completed in %s seconds!" % (time.time() - start))


### PR DESCRIPTION
The build script was a bit messy and inconsistent, it also printed out the get_revision mercurial stderr in an unclear format, making it seem as if the build script itself had failed. I made only minor changes to the actual codepaths, but instead made a few lexical/organizational and readability changes. Along with this, I included some better error printing for get_revision, PEP8 cleanup, and various other minor tweaks to make the script more "pythonic". Also, I noticed a few instances of murderous intent towards cute little kittens (semicolons), which where removed abruptly.

Hopefully this helps make the build script more extendable and usable in the future.
