### PR TITLE
Feature/combined script files

### DIFF
--- a/src/framework/components/script/script_component.js
+++ b/src/framework/components/script/script_component.js
@@ -98,7 +98,10 @@ pc.extend(pc.fw, function () {
                 var namesDict = {};
                 for(var i = 0; i < scripts.length; ++i) {
                     urlsDict[scripts[i].url] = true;
-                    namesDict[scripts[i].name] = true;
+
+                    if(scripts[i].name !== undefined) {
+                        namesDict[scripts[i].name] = true;
+                    }
                 }
 
                 var urls = [];
@@ -167,24 +170,25 @@ pc.extend(pc.fw, function () {
             }
 
             for (var i=0, len=cached.length; i<len; i++) {
-                var ScriptType = cached[i];
+                var cachedResource = cached[i];
 
                 // check if this is a regular JS file
-                if (ScriptType == true) {
+                if (cachedResource == true) {
                     continue;
                 }
 
-                // ScriptType may be null if the script component is loading an ordinary javascript lib rather than a PlayCanvas script
-                // Make sure that script component hasn't been removed since we started loading
-                // Also make sure to not load this if this script was in the same file as other scripts and it is not actually required
-                if (ScriptType && this.entity.script && names.indexOf(ScriptType._pcScriptName) >= 0) {
-                    // Make sure that we haven't already instaciated another identical script while loading
-                    // e.g. if you do addComponent, removeComponent, addComponent, in quick succession
-                    if (!this.entity.script.instances[ScriptType._pcScriptName]) {
-                        var instance = new ScriptType(this.entity);
-                        this.system._preRegisterInstance(this.entity, urls[i], ScriptType._pcScriptName, instance);
+                cachedResource.scripts.forEach(function (ScriptType, index) {
+                    // Make sure that script component hasn't been removed since we started loading
+                    // Also make sure to not load this if this script was in the same file as other scripts and it is not actually required
+                    if (ScriptType && this.entity.script && (!names.length || names.indexOf(ScriptType._pcScriptName) >= 0)) {
+                        // Make sure that we haven't already instaciated another identical script while loading
+                        // e.g. if you do addComponent, removeComponent, addComponent, in quick succession
+                        if (!this.entity.script.instances[ScriptType._pcScriptName]) {
+                            var instance = new ScriptType(this.entity);
+                            this.system._preRegisterInstance(this.entity, urls[i], ScriptType._pcScriptName, instance);
+                        }
                     }
-                }
+                }, this); 
             }
 
             if (this.data) {
@@ -218,7 +222,7 @@ pc.extend(pc.fw, function () {
                         loadResult.scripts.forEach(function (ScriptType, index) {
                             // Make sure that script component hasn't been removed since we started loading
                             // Also make sure to not load this if this script was in the same file as other scripts and it is not actually required
-                            if (ScriptType && this.entity.script && names.indexOf(ScriptType._pcScriptName) >= 0) {
+                            if (ScriptType && this.entity.script && (!names.length || names.indexOf(ScriptType._pcScriptName) >= 0)) {
                                 // Make sure that we haven't already instaciated another identical script while loading
                                 // e.g. if you do addComponent, removeComponent, addComponent, in quick succession
                                 if (!this.entity.script.instances[ScriptType._pcScriptName]) {

--- a/src/framework/components/script/script_system.js
+++ b/src/framework/components/script/script_system.js
@@ -406,7 +406,7 @@ pc.extend(pc.fw, function () {
 
             for (i=0; i<len; i++) {
                 var script = entity.script.scripts[i];
-                if (script.url === url) {
+                if (script.url === url && script.name === instance.name) {
                     var attributes = script.attributes;
                     if (script.name && attributes) {
                         attributes.forEach(function (attribute, index) {
@@ -452,7 +452,7 @@ pc.extend(pc.fw, function () {
             for (i=0; i<len; i++) {
                 scriptComponent = entity.script;
                 script = scriptComponent.scripts[i];
-                if (script.url === url) {
+                if (script.url === url && script.name === instance.name) {
                     name = script.name;
                     attributes = script.attributes;
                     if (name) {

--- a/src/script/resources/resources_script.js
+++ b/src/script/resources/resources_script.js
@@ -158,8 +158,9 @@ pc.extend(pc.resources, function () {
                     self._loaded[canonicalUrl] = scriptTypes;
                     // add the script to the resource loader's cache
                     self._loader.registerHash(canonicalUrl, canonicalUrl);
-                    self._loader.addToCache(canonicalUrl, ScriptType);
-                    success({url: url, scripts: scriptTypes});
+                    var resource = {url: url, scripts: scriptTypes};
+                    self._loader.addToCache(canonicalUrl, resource);
+                    success(resource);
                 } else {
                     // loaded a regular javascript script, so no ScriptType to instantiate.
                     // However, we still need to register that we've loaded it in case there is a timeout

--- a/tests/framework/scripts/multiple_scripts.js
+++ b/tests/framework/scripts/multiple_scripts.js
@@ -1,0 +1,31 @@
+pc.script.create("test_mult_1", function(context) {
+    var Mult1 = function Script(entity) {
+        this.entity = entity;
+        this.value = 'foo';
+    };
+    
+    Mult1.prototype = {
+        concat: function (v) {
+            return v + this.value;
+        }
+    };
+
+    return Mult1;
+    
+});
+
+pc.script.create("test_mult_2", function(context) {
+    var Mult2 = function Script(entity) {
+        this.entity = entity;
+        this.value = 'bar';
+    };
+    
+    Mult2.prototype = {
+        concat: function (v) {
+            return v + this.value;
+        }
+    };
+
+    return Mult2;
+    
+});

--- a/tests/framework/test_script.js
+++ b/tests/framework/test_script.js
@@ -421,6 +421,23 @@ test("Clone entity initializes scripts synchronously", function () {
     stop();
 });
 
+asyncTest("Load multiple scripts from the same URL", function () {
+    var sc = new pc.fw.ScriptComponentSystem(context);
+
+    var e = new pc.fw.Entity();
+    var c = sc.addComponent(e);
+    e.script.scripts = [{name: 'test_mult_1', url: 'scripts/multiple_scripts.js'}, {name: 'test_mult_2', url: 'scripts/multiple_scripts.js'}];
+
+    var str = "";
+    setTimeout(function () {
+        str = e.script.send("test_mult_1", "concat", str);
+        equal(str, "foo");
+        str = e.script.send("test_mult_2", "concat", str);
+        equal(str, "foobar");
+        start();
+    }, 500);
+});
+
 /*
 test("Scripts Initialize called in correct order", function () {
     window.script = {};


### PR DESCRIPTION
This branch allows you to have multiple pc.script.create calls in a single file and each script will be pulled out and put on an entity correctly.  It passes the test cases currently in master and I added a new test case.  It should maintain backward compatibility as well.  

Here's a few things to note:
1. You should now make sure to specify a script with both the url and the name.  Ex: e.script.scripts = [{name: "somename", url: "somefile.js"}]
2. When a script is loaded onto the document and passed back to _loadScripts / _loadFromCache, the <url, name> pair is checked for each loaded pc.script instead of just the url UNLESS the names are unspecified - then it just checks the url.  If using the PlayCanvas designer, the name field should always be there, but if someone is putting scripts together manually, they should continue to work with this patch.

This patch is in reference to my question: http://answers.playcanvas.com/questions/694/multiple-scripts-in-the-same-file