### PR TITLE
Shader system update 6

### DIFF
--- a/src/framework/components/light/light_component.js
+++ b/src/framework/components/light/light_component.js
@@ -35,6 +35,7 @@ pc.extend(pc.fw, function () {
         this.on("set_castShadows", this.onSetCastShadows, this);
         this.on("set_shadowResolution", this.onSetShadowResolution, this);
         this.on("set_range", this.onSetRange, this);
+        this.on("set_falloffMode", this.onSetFalloffMode, this);
         this.on("set_innerConeAngle", this.onSetInnerConeAngle, this);
         this.on("set_outerConeAngle", this.onSetOuterConeAngle, this);
     };
@@ -69,6 +70,7 @@ pc.extend(pc.fw, function () {
             this.onSetIntensity("intensity", this.intensity, this.intensity);
             this.onSetShadowResolution("shadowResolution", this.shadowResolution, this.shadowResolution);
             this.onSetRange("range", this.range, this.range);
+            this.onSetFalloffMode("falloffMode", this.falloffMode, this.falloffMode);
             this.onSetInnerConeAngle("innerConeAngle", this.innerConeAngle, this.innerConeAngle);
             this.onSetOuterConeAngle("outerConeAngle", this.outerConeAngle, this.outerConeAngle);
 
@@ -78,10 +80,10 @@ pc.extend(pc.fw, function () {
         },
 
         onSetCastShadows: function (name, oldValue, newValue) {
-            if (this.data.type === 'directional' || this.data.type === 'spot') {
+            //if (this.data.type === 'directional' || this.data.type === 'spot') {
                 var light = this.data.model.lights[0];
                 light.setCastShadows(newValue);
-            }
+            //}
         },
 
         onSetColor: function (name, oldValue, newValue) {
@@ -105,6 +107,13 @@ pc.extend(pc.fw, function () {
             if (this.data.type === 'point' || this.data.type === 'spot') {
                 var light = this.data.model.lights[0];
                 light.setAttenuationEnd(newValue);
+            }
+        },
+
+        onSetFalloffMode: function (name, oldValue, newValue) {
+            if (this.data.type === 'point' || this.data.type === 'spot') {
+                var light = this.data.model.lights[0];
+                light.setFalloffMode(newValue);
             }
         },
 

--- a/src/framework/components/light/light_data.js
+++ b/src/framework/components/light/light_data.js
@@ -10,6 +10,7 @@ pc.extend(pc.fw, function () {
         this.range = 10;
         this.innerConeAngle = 40;
         this.outerConeAngle = 45;
+        this.falloffMode = 0;
 
         // Non-serialized
         this.model = null;

--- a/src/framework/components/light/light_system.js
+++ b/src/framework/components/light/light_system.js
@@ -71,6 +71,9 @@ pc.extend(pc.fw, function () {
             type: "enumeration",
             options: {
                 enumerations: [{
+                    name: '128',
+                    value: 128
+                }, {
                     name: '256',
                     value: 256
                 }, {
@@ -97,6 +100,24 @@ pc.extend(pc.fw, function () {
             options: {
                 min: 0
             },
+            filter: {
+                type: ['point', 'spot']
+            }
+        }, {
+            name: "falloffMode",
+            displayName: "Falloff mode",
+            description: "",
+            type: "enumeration",
+            options: {
+                enumerations: [{
+                    name: 'Linear',
+                    value: 0
+                }, {
+                    name: 'Inverse squared',
+                    value: 1
+                }]
+            },
+            defaultValue: 0,
             filter: {
                 type: ['point', 'spot']
             }
@@ -159,7 +180,7 @@ pc.extend(pc.fw, function () {
             var implementation = this._createImplementation(data.type);
             implementation.initialize(component, data);
 
-            properties = ['type', 'model', 'enabled', 'color', 'intensity', 'range', 'innerConeAngle', 'outerConeAngle', 'castShadows', 'shadowResolution'];
+            properties = ['type', 'model', 'enabled', 'color', 'intensity', 'range', 'falloffMode', 'innerConeAngle', 'outerConeAngle', 'castShadows', 'shadowResolution'];
             LightComponentSystem._super.initializeComponentData.call(this, component, data, properties);
         },
 
@@ -198,6 +219,7 @@ pc.extend(pc.fw, function () {
                 color: [entity.light.color.r, entity.light.color.g, entity.light.color.b],
                 intensity: entity.light.intensity,
                 range: entity.light.range,
+                falloffMode: entity.light.falloffMode,
                 innerConeAngle: entity.light.innerConeAngle,
                 outerConeAngle: entity.light.outerConeAngle,
                 castShadows: entity.light.castShadows,

--- a/src/graphics/programlib/chunks/base.ps
+++ b/src/graphics/programlib/chunks/base.ps
@@ -55,9 +55,23 @@ float getFalloffLinear(inout psInternalData data, float lightRadius) {
     return max(((lightRadius - d) / lightRadius), 0.0);
 }
 
-float getFalloffInvSquared(inout psInternalData data) {
+float square(float x) {
+    return x*x;
+}
+
+float saturate(float x) {
+    return clamp(x, 0.0, 1.0);
+}
+
+float getFalloffInvSquared(inout psInternalData data, float lightRadius) {
     float sqrDist = dot(data.lightDirW, data.lightDirW);
-    return 1.0 / sqrDist;
+    float falloff = 1.0 / (sqrDist + 1.0);
+    float invRadius = 1.0 / lightRadius;
+
+    falloff *= 16.0;
+    falloff *= square( saturate( 1.0 - square( sqrDist * square(invRadius) ) ) );
+
+    return falloff;
 }
 
 float getSpotEffect(inout psInternalData data, vec3 lightSpotDirW, float lightInnerConeAngle, float lightOuterConeAngle) {

--- a/src/graphics/programlib/chunks/shadow.ps
+++ b/src/graphics/programlib/chunks/shadow.ps
@@ -74,3 +74,7 @@ float getShadowPCF3x3(inout psInternalData data, sampler2D shadowMap, vec3 shado
     return 1.0;
 }
 
+float getShadowPoint(inout psInternalData data, samplerCube shadowMap, vec4 shadowParams) {
+    return float(unpackFloat(textureCube(shadowMap, data.lightDirNormW)) > (length(data.lightDirW)/shadowParams.w + shadowParams.z));
+}
+

--- a/src/graphics/programlib/programlib_depthrgba.js
+++ b/src/graphics/programlib/programlib_depthrgba.js
@@ -3,6 +3,7 @@ pc.gfx.programlib.depthrgba = {
         var key = "depthrgba";
         if (options.skin) key += "_skin";
         if (options.opacityMap) key += "_opam";
+        if (options.point) key += "_pnt";
         return key;
     },
 
@@ -39,6 +40,12 @@ pc.gfx.programlib.depthrgba = {
             code += 'varying vec2 vUv0;\n\n';
         }
 
+        if (options.point) {
+            code += 'uniform vec3 view_position;\n\n';
+            code += 'uniform float light_radius;\n\n';
+            code += 'varying float vDistance;\n\n';
+        }
+
         // VERTEX SHADER BODY
         code += getSnippet(device, 'common_main_begin');
 
@@ -61,8 +68,12 @@ pc.gfx.programlib.depthrgba = {
             code += '    vUv0 = vertex_texCoord0;\n';
         }
 
+        if (options.point) {
+            code += '    vDistance = distance(view_position, positionW.xyz) / light_radius;\n';
+        }
+
         code += getSnippet(device, 'common_main_end');
-        
+
         var vshader = code;
 
         //////////////////////////////
@@ -73,6 +84,10 @@ pc.gfx.programlib.depthrgba = {
         if (options.opacityMap) {
             code += 'varying vec2 vUv0;\n\n';
             code += 'uniform sampler2D texture_opacityMap;\n\n';
+        }
+
+        if (options.point) {
+            code += 'varying float vDistance;\n\n';
         }
 
         // Packing a float in GLSL with multiplication and mod
@@ -94,7 +109,11 @@ pc.gfx.programlib.depthrgba = {
             code += '    if (texture2D(texture_opacityMap, vUv0).r < 0.25) discard;\n\n';
         }
 
-        code += '    gl_FragData[0] = packFloat(gl_FragCoord.z);\n';
+        if (options.point) {
+            code += "   gl_FragData[0] = packFloat(vDistance);\n"
+        } else {
+            code += '    gl_FragData[0] = packFloat(gl_FragCoord.z);\n';
+        }
 
         code += getSnippet(device, 'common_main_end');
 

--- a/src/scene/scene_forwardrenderer.js
+++ b/src/scene/scene_forwardrenderer.js
@@ -102,13 +102,35 @@ pc.extend(pc.scene, function () {
         var shadowMap = new pc.gfx.Texture(device, {
             format: pc.gfx.PIXELFORMAT_R8_G8_B8_A8,
             width: width,
-            height: height
+            height: height,
         });
         shadowMap.minFilter = pc.gfx.FILTER_NEAREST;
         shadowMap.magFilter = pc.gfx.FILTER_NEAREST;
         shadowMap.addressU = pc.gfx.ADDRESS_CLAMP_TO_EDGE;
         shadowMap.addressV = pc.gfx.ADDRESS_CLAMP_TO_EDGE;
         return new pc.gfx.RenderTarget(device, shadowMap, true);
+    };
+
+    function createShadowCubeMap(device, size) {
+        var cubemap = new pc.gfx.Texture(device, {
+            format: pc.gfx.PIXELFORMAT_R8_G8_B8_A8,
+            width: size,
+            height: size,
+            cubemap: true
+        });
+        cubemap.minFilter = pc.gfx.FILTER_NEAREST;
+        cubemap.magFilter = pc.gfx.FILTER_NEAREST;
+        cubemap.addressU = pc.gfx.ADDRESS_CLAMP_TO_EDGE;
+        cubemap.addressV = pc.gfx.ADDRESS_CLAMP_TO_EDGE;
+        var targets = [];
+        for (var i = 0; i < 6; i++) {
+            var target = new pc.gfx.RenderTarget(device, cubemap, {
+                face: i,
+                depth: true
+            });
+            targets.push(target);
+        }
+        return targets;
     };
 
     function createShadowCamera(device) {
@@ -126,20 +148,29 @@ pc.extend(pc.scene, function () {
         return shadowCam;
     };
 
+    function createShadowBuffer(device, light) {
+        var shadowBuffer;
+        if (light.getType() === pc.scene.LIGHTTYPE_POINT) {
+            shadowBuffer = createShadowCubeMap(device, light._shadowResolution);
+            light._shadowCamera.setRenderTarget(shadowBuffer[0]);
+            light._shadowCubeMap = shadowBuffer;
+        } else {
+            shadowBuffer = createShadowMap(device, light._shadowResolution, light._shadowResolution);
+            light._shadowCamera.setRenderTarget(shadowBuffer);
+        }
+    };
+
     function getShadowCamera(device, light) {
         var shadowCam = light._shadowCamera;
         var shadowBuffer;
 
         if (shadowCam === null) {
-            shadowCam = createShadowCamera(device);
-            shadowBuffer = createShadowMap(device, light._shadowResolution, light._shadowResolution);
-            shadowCam.setRenderTarget(shadowBuffer);
-            light._shadowCamera = shadowCam;
+            shadowCam = light._shadowCamera = createShadowCamera(device);
+            createShadowBuffer(device, light);
         } else {
             shadowBuffer = shadowCam.getRenderTarget();
             if ((shadowBuffer.width !== light._shadowResolution) || (shadowBuffer.height !== light._shadowResolution)) {
-                shadowBuffer = createShadowMap(device, light._shadowResolution, light._shadowResolution);
-                shadowCam.setRenderTarget(shadowBuffer);
+                createShadowBuffer(device, light);
             }
         }
 
@@ -174,6 +205,29 @@ pc.extend(pc.scene, function () {
             opacityMap: true
         });
 
+
+        this._depthProgStaticPoint = library.getProgram('depthrgba', {
+            skin: false,
+            opacityMap: false,
+            point: true
+        });
+        this._depthProgSkinPoint = library.getProgram('depthrgba', {
+            skin: true,
+            opacityMap: false,
+            point: true
+        });
+        this._depthProgStaticOpPoint = library.getProgram('depthrgba', {
+            skin: false,
+            opacityMap: true,
+            point: true
+        });
+        this._depthProgSkinOpPoint = library.getProgram('depthrgba', {
+            skin: true,
+            opacityMap: true,
+            point: true
+        });
+
+
         this._depthShaderStatic = library.getProgram('depth', {
             skin: false
         });
@@ -189,6 +243,7 @@ pc.extend(pc.scene, function () {
         this.viewInvId = scope.resolve('matrix_viewInverse');
         this.viewProjId = scope.resolve('matrix_viewProjection');
         this.viewPosId = scope.resolve('view_position');
+        this.lightRadiusId = scope.resolve('light_radius');
         this.nearClipId = scope.resolve('camera_near');
         this.farClipId = scope.resolve('camera_far');
 
@@ -336,6 +391,15 @@ pc.extend(pc.scene, function () {
                 scope.resolve(light + "_color").setValue(point._finalColor.data);
                 wtm.getTranslation(point._position);
                 scope.resolve(light + "_position").setValue(point._position.data);
+
+                if (point.getCastShadows()) {
+                    var shadowMap = this.device.extDepthTexture ?
+                            point._shadowCamera._renderTarget._depthTexture :
+                            point._shadowCamera._renderTarget.colorBuffer;
+                    scope.resolve(light + "_shadowMap").setValue(shadowMap);
+                    scope.resolve(light + "_shadowMatrix").setValue(point._shadowMatrix.data);
+                    scope.resolve(light + "_shadowParams").setValue([point._shadowResolution, point._shadowResolution, point._shadowBias, point.getAttenuationEnd()]);
+                }
             }
 
             for (i = 0; i < numSpts; i++) {
@@ -488,13 +552,15 @@ pc.extend(pc.scene, function () {
                 var light = lights[i];
                 var type = light.getType();
 
-                // Point light shadow casting currently unsupported
+                /*// Point light shadow casting currently unsupported
                 if (type === pc.scene.LIGHTTYPE_POINT) {
                     continue;
-                }
+                }*/
 
                 if (light.getCastShadows() && light.getEnabled()) {
                     var shadowCam = getShadowCamera(device, light);
+                    var passes = 1;
+                    var pass;
 
                     if (type === pc.scene.LIGHTTYPE_DIRECTIONAL) {
                         // 1. Starting at the centroid of the view frustum, back up in the opposite
@@ -541,6 +607,7 @@ pc.extend(pc.scene, function () {
                         shadowCam.setFarClip((maxz - minz) * 1.5);
                         shadowCam.setAspectRatio((maxx - minx) / (maxy - miny));
                         shadowCam.setOrthoHeight((maxy - miny) * 0.5);
+
                     } else if (type === pc.scene.LIGHTTYPE_SPOT) {
                         shadowCam.setProjection(pc.scene.Projection.PERSPECTIVE);
                         shadowCam.setNearClip(light.getAttenuationEnd() / 1000);
@@ -550,57 +617,100 @@ pc.extend(pc.scene, function () {
 
                         var lightWtm = light.worldTransform;
                         shadowCamWtm.mul2(lightWtm, camToLight);
+
+                    } else if (type === pc.scene.LIGHTTYPE_POINT) {
+                        shadowCam.setProjection(pc.scene.Projection.PERSPECTIVE);
+                        shadowCam.setNearClip(light.getAttenuationEnd() / 1000);
+                        shadowCam.setFarClip(light.getAttenuationEnd());
+                        shadowCam.setAspectRatio(1);
+                        shadowCam.setFov(90);
+
+                        passes = 6;
+                        this.viewPosId.setValue(shadowCam.getPosition().data);
+                        this.lightRadiusId.setValue(light.getAttenuationEnd());
                     }
 
-                    shadowCamView.copy(shadowCamWtm).invert();
-                    shadowCamViewProj.mul2(shadowCam.getProjectionMatrix(), shadowCamView);
-                    light._shadowMatrix.mul2(scaleShift, shadowCamViewProj);
+                    if (type != pc.scene.LIGHTTYPE_POINT) {
+                        shadowCamView.copy(shadowCamWtm).invert();
+                        shadowCamViewProj.mul2(shadowCam.getProjectionMatrix(), shadowCamView);
+                        light._shadowMatrix.mul2(scaleShift, shadowCamViewProj);
+                    }
 
                     // Point the camera along direction of light
                     shadowCam.worldTransform.copy(shadowCamWtm);
 
-                    device.setBlending(false);
-                    device.setColorWrite(true, true, true, true);
-                    device.setCullMode(pc.gfx.CULLFACE_BACK);
-                    device.setDepthWrite(true);
-                    device.setDepthTest(true);
+                    for(pass=0; pass<passes; pass++){
 
-                    if (device.extDepthTexture) {
-                        device.setColorWrite(false, false, false, false);
-                    }
-
-                    this.setCamera(shadowCam);
-
-                    for (j = 0, numInstances = shadowCasters.length; j < numInstances; j++) {
-                        meshInstance = shadowCasters[j];
-                        mesh = meshInstance.mesh;
-                        material = meshInstance.material;
-
-                        this.modelMatrixId.setValue(meshInstance.node.worldTransform.data);
-                        if (material.opacityMap) {
-                            scope.resolve('texture_opacityMap').setValue(material.opacityMap);
-                        }
-                        if (meshInstance.skinInstance) {
-                            if (device.supportsBoneTextures) {
-                                this.boneTextureId.setValue(meshInstance.skinInstance.boneTexture);
-                                var w = meshInstance.skinInstance.boneTexture.width;
-                                var h = meshInstance.skinInstance.boneTexture.height;
-                                this.boneTextureSizeId.setValue([w, h])
-                            } else {
-                                this.poseMatrixId.setValue(meshInstance.skinInstance.matrixPalette);
+                        if (type === pc.scene.LIGHTTYPE_POINT) {
+                            if (pass===0) {
+                                shadowCam.setEulerAngles(0, 90, 180);
+                            } else if (pass===1) {
+                                shadowCam.setEulerAngles(0, -90, 180);
+                            } else if (pass===2) {
+                                shadowCam.setEulerAngles(90, 0, 0);
+                            } else if (pass===3) {
+                                shadowCam.setEulerAngles(-90, 0, 0);
+                            } else if (pass===4) {
+                                shadowCam.setEulerAngles(0, 180, 180);
+                            } else if (pass===5) {
+                                shadowCam.setEulerAngles(0, 0, 180);
                             }
-                            device.setShader(material.opacityMap ? this._depthProgSkinOp : this._depthProgSkin);
-                        } else {
-                            device.setShader(material.opacityMap ? this._depthProgStaticOp : this._depthProgStatic);
+                            shadowCam.setPosition(light.getPosition());
+
+                            shadowCam.setRenderTarget(light._shadowCubeMap[pass]);
                         }
 
-                        style = meshInstance.renderStyle;
+                        device.setBlending(false);
+                        device.setColorWrite(true, true, true, true);
+                        device.setCullMode(pc.gfx.CULLFACE_BACK);
+                        device.setDepthWrite(true);
+                        device.setDepthTest(true);
 
-                        device.setVertexBuffer(mesh.vertexBuffer, 0);
-                        device.setIndexBuffer(mesh.indexBuffer[style]);
+                        if (device.extDepthTexture) {
+                            device.setColorWrite(false, false, false, false);
+                        }
 
-                        device.draw(mesh.primitive[style]);
-                    }
+                        this.setCamera(shadowCam);
+
+                        for (j = 0, numInstances = shadowCasters.length; j < numInstances; j++) {
+                            meshInstance = shadowCasters[j];
+                            mesh = meshInstance.mesh;
+                            material = meshInstance.material;
+
+                            this.modelMatrixId.setValue(meshInstance.node.worldTransform.data);
+                            if (material.opacityMap) {
+                                scope.resolve('texture_opacityMap').setValue(material.opacityMap);
+                            }
+                            if (meshInstance.skinInstance) {
+                                if (device.supportsBoneTextures) {
+                                    this.boneTextureId.setValue(meshInstance.skinInstance.boneTexture);
+                                    var w = meshInstance.skinInstance.boneTexture.width;
+                                    var h = meshInstance.skinInstance.boneTexture.height;
+                                    this.boneTextureSizeId.setValue([w, h])
+                                } else {
+                                    this.poseMatrixId.setValue(meshInstance.skinInstance.matrixPalette);
+                                }
+                                if (type === pc.scene.LIGHTTYPE_POINT) {
+                                    device.setShader(material.opacityMap ? this._depthProgSkinOpPoint : this._depthProgSkinPoint);
+                                } else {
+                                    device.setShader(material.opacityMap ? this._depthProgSkinOp : this._depthProgSkin);
+                                }
+                            } else {
+                                if (type === pc.scene.LIGHTTYPE_POINT) {
+                                    device.setShader(material.opacityMap ? this._depthProgStaticOpPoint : this._depthProgStaticPoint);
+                                } else {
+                                    device.setShader(material.opacityMap ? this._depthProgStaticOp : this._depthProgStatic);
+                                }
+                            }
+
+                            style = meshInstance.renderStyle;
+
+                            device.setVertexBuffer(mesh.vertexBuffer, 0);
+                            device.setIndexBuffer(mesh.indexBuffer[style]);
+
+                            device.draw(mesh.primitive[style]);
+                        }
+                    } // end pass
                 }
             }
 

--- a/src/scene/scene_lightnode.js
+++ b/src/scene/scene_lightnode.js
@@ -16,6 +16,8 @@ pc.extend(pc.scene, function () {
         this._attenuationStart = 10;
         this._attenuationEnd = 10;
 
+        this._falloffMode = 0;
+
         // Spot properties
         this._innerConeAngle = 40;
         this._outerConeAngle = 45;
@@ -63,6 +65,8 @@ pc.extend(pc.scene, function () {
             clone.setAttenuationStart(this.getAttenuationStart());
             clone.setAttenuationEnd(this.getAttenuationEnd());
 
+            clone.setFalloffMode(this.getFalloffMode());
+
             // Spot properties
             clone.setInnerConeAngle(this.getInnerConeAngle());
             clone.setOuterConeAngle(this.getOuterConeAngle());
@@ -93,6 +97,10 @@ pc.extend(pc.scene, function () {
          */
         getAttenuationEnd: function () {
             return this._attenuationEnd;
+        },
+
+        getFalloffMode: function () {
+            return this._falloffMode;
         },
 
         /**
@@ -212,6 +220,10 @@ pc.extend(pc.scene, function () {
          */
         setAttenuationEnd: function (radius) {
             this._attenuationEnd = radius;
+        },
+
+        setFalloffMode: function (mode) {
+            this._falloffMode = mode;
         },
 
         /**

--- a/src/scene/scene_phongmaterial.js
+++ b/src/scene/scene_phongmaterial.js
@@ -403,13 +403,11 @@ pc.extend(pc.scene, function () {
             return transform;
         },
 
-        _collectLights: function(lType, lights, typeArray, shadowArray) {
+        _collectLights: function(lType, lights, lightsSorted) {
             for (var i = 0; i < lights.length; i++) {
                 if (lights[i].getEnabled()) {
-                    var lightType = lights[i].getType();
-                    if (lightType==lType) {
-                        typeArray.push(lightType);
-                        shadowArray.push(lights[i].getCastShadows());
+                    if (lights[i].getType()==lType) {
+                        lightsSorted.push(lights[i]);
                     }
                 }
             }
@@ -612,16 +610,12 @@ pc.extend(pc.scene, function () {
             };
 
 
-            var lightType = [];
-            var lightShadow = [];
-            this._collectLights(pc.scene.LIGHTTYPE_DIRECTIONAL, lights, lightType, lightShadow);
-            this._collectLights(pc.scene.LIGHTTYPE_POINT,       lights, lightType, lightShadow);
-            this._collectLights(pc.scene.LIGHTTYPE_SPOT,        lights, lightType, lightShadow);
+            var lightsSorted = [];
+            this._collectLights(pc.scene.LIGHTTYPE_DIRECTIONAL, lights, lightsSorted);
+            this._collectLights(pc.scene.LIGHTTYPE_POINT,       lights, lightsSorted);
+            this._collectLights(pc.scene.LIGHTTYPE_SPOT,        lights, lightsSorted);
 
-
-            options.numLights = lightType.length;
-            options.lightType = lightType;
-            options.lightShadow = lightShadow;
+            options.lights = lightsSorted;
 
             var library = device.getProgramLibrary();
             this.shader = library.getProgram('phong', options);


### PR DESCRIPTION
Point light shadows can be used by simply enabling castShadows as with any other lights. But they are still work in progress and look pixelated and may be not greatly optimized.

Lights have now falloffMode parameter you can set to either 0 (Linear, default) or 1 (Inverse squared, more physically correct).

Also some fixes.
