### PR TITLE
Shader system update 2

### DIFF
--- a/src/graphics/programlib/chunks/albedoTex.ps
+++ b/src/graphics/programlib/chunks/albedoTex.ps
@@ -1,6 +1,6 @@
 uniform sampler2D texture_diffuseMap;
 void getAlbedo(inout psInternalData data) {
-    vec4 tex = texture2DAlbedo(texture_diffuseMap, $UV);
+    vec4 tex = texture2DSRGB(texture_diffuseMap, $UV);
     data.albedo = tex.rgb;
 }
 

--- a/src/graphics/programlib/chunks/albedoTexColor.ps
+++ b/src/graphics/programlib/chunks/albedoTexColor.ps
@@ -1,7 +1,7 @@
 uniform sampler2D texture_diffuseMap;
 uniform vec3 material_diffuse;
 void getAlbedo(inout psInternalData data) {
-    vec4 tex = texture2DAlbedo(texture_diffuseMap, $UV);
+    vec4 tex = texture2DSRGB(texture_diffuseMap, $UV);
     data.albedo = tex.rgb * material_diffuse;
 }
 

--- a/src/graphics/programlib/chunks/fresnelSchlick.ps
+++ b/src/graphics/programlib/chunks/fresnelSchlick.ps
@@ -1,0 +1,7 @@
+// Schlick's approximation
+uniform float material_fresnelFactor; // unused
+void getFresnel(inout psInternalData data) {
+    float fresnel = 1.0 - max(dot(data.normalW, data.viewDirW), 0.0);
+    data.specularity = data.specularity + (1.0 - data.specularity) * fresnel * fresnel * fresnel * fresnel * fresnel;
+}
+

--- a/src/graphics/programlib/chunks/gamma1_0.ps
+++ b/src/graphics/programlib/chunks/gamma1_0.ps
@@ -1,5 +1,9 @@
-vec4 texture2DAlbedo(sampler2D tex, vec2 uv) {
+vec4 texture2DSRGB(sampler2D tex, vec2 uv) {
     return texture2D(tex, uv);
+}
+
+vec4 textureCubeSRGB(samplerCube tex, vec3 uvw) {
+    return textureCube(tex, uvw);
 }
 
 vec3 gammaCorrectOutput(vec3 color) {

--- a/src/graphics/programlib/chunks/gamma2_2.ps
+++ b/src/graphics/programlib/chunks/gamma2_2.ps
@@ -1,5 +1,11 @@
-vec4 texture2DAlbedo(sampler2D tex, vec2 uv) {
+vec4 texture2DSRGB(sampler2D tex, vec2 uv) {
     vec4 rgba = texture2D(tex, uv);
+    rgba.rgb = pow(rgba.rgb, vec3(2.2));
+    return rgba;
+}
+
+vec4 textureCubeSRGB(samplerCube tex, vec3 uvw) {
+    vec4 rgba = textureCube(tex, uvw);
     rgba.rgb = pow(rgba.rgb, vec3(2.2));
     return rgba;
 }

--- a/src/graphics/programlib/chunks/reflectionCube.ps
+++ b/src/graphics/programlib/chunks/reflectionCube.ps
@@ -1,6 +1,6 @@
 uniform samplerCube texture_cubeMap;
 uniform float material_reflectionFactor;
 void addCubemapReflection(inout psInternalData data) {
-    data.reflection += vec4(textureCube(texture_cubeMap, data.reflDirW).rgb, material_reflectionFactor);
+    data.reflection += vec4(textureCubeSRGB(texture_cubeMap, data.reflDirW).rgb, material_reflectionFactor);
 }
 

--- a/src/graphics/programlib/chunks/reflectionSphere.ps
+++ b/src/graphics/programlib/chunks/reflectionSphere.ps
@@ -8,7 +8,7 @@ void addSpheremapReflection(inout psInternalData data) {
     float m = 2.0 * sqrt( dot(reflDirV.xy, reflDirV.xy) + (reflDirV.z+1.0)*(reflDirV.z+1.0) );
     vec2 sphereMapUv = reflDirV.xy / m + 0.5;
 
-    data.reflection += vec4(texture2D(texture_sphereMap, sphereMapUv).rgb, material_reflectionFactor);
+    data.reflection += vec4(texture2DSRGB(texture_sphereMap, sphereMapUv).rgb, material_reflectionFactor);
 }
 
 

--- a/src/graphics/programlib/chunks/reflectionSphereLow.ps
+++ b/src/graphics/programlib/chunks/reflectionSphereLow.ps
@@ -5,6 +5,6 @@ void addSpheremapReflection(inout psInternalData data) {
     vec3 reflDirV = vNormalV;
 
     vec2 sphereMapUv = reflDirV.xy * 0.5 + 0.5;
-    data.reflection += vec4(texture2D(texture_sphereMap, sphereMapUv).rgb, material_reflectionFactor);
+    data.reflection += vec4(texture2DSRGB(texture_sphereMap, sphereMapUv).rgb, material_reflectionFactor);
 }
 


### PR DESCRIPTION
As we don't have any in-engine cube/spheremap rendering pipeline, most cubemaps come from users in sRGB space. Therefore I changed their lookups accordingly.

Note that fresnelFactor is just a switch when using Schlick's approximation, but a floating value for other fresnel modes.
