### PR TITLE
Particle system fixes (new)

### DIFF
--- a/src/framework/components/particlesystem/particlesystem_component.js
+++ b/src/framework/components/particlesystem/particlesystem_component.js
@@ -12,7 +12,6 @@ pc.extend(pc.fw, function() {
     var COMPLEX_PROPERTIES = [
         'numParticles',
         'lifetime',
-        'lifetime2',
         'rate',
         'rate2',
         'startAngle',
@@ -159,7 +158,11 @@ pc.extend(pc.fw, function() {
                 this.emitter[name] = newValue;
                 this.emitter.resetTime();
                 if (oldValue && !newValue) {
-                    this.emitter.oneShotEndTime = this.emitter.totalTime;
+                    //this.emitter.oneShotEndTime = this.emitter.totalTime;
+                    this.reset();
+                    this.emitter.resetMaterial();
+                    this.enabled = true;
+                    this.rebuild();
                 }
             }
         },
@@ -183,6 +186,7 @@ pc.extend(pc.fw, function() {
         onSetComplexProperty: function (name, oldValue, newValue) {
             if (this.emitter) {
                 this.emitter[name] = newValue;
+                this.reset();
                 this.emitter.resetMaterial();
                 this.rebuild();
             }
@@ -213,7 +217,6 @@ pc.extend(pc.fw, function() {
                     wrap: this.data.wrap,
                     wrapBounds: this.data.wrapBounds,
                     lifetime: this.data.lifetime,
-                    lifetime2: this.data.lifetime2,
                     rate: this.data.rate,
                     rate2: this.data.rate2,
 

--- a/src/framework/components/particlesystem/particlesystem_data.js
+++ b/src/framework/components/particlesystem/particlesystem_data.js
@@ -7,10 +7,8 @@ pc.extend(pc.fw, function() {
         this.startAngle = 0;
         this.startAngle2 = null;
         this.lifetime = 50;                     // Particle lifetime
-        this.lifetime2 = null;
         this.spawnBounds = new pc.Vec3();       // Spawn point divergence
         this.wrapBounds = new pc.Vec3();
-        this.smoothness = 4;                    // Blurring width for graphs
         this.colorMap = null;
         this.colorMapAsset = null;
         this.normalMap = null;
@@ -50,7 +48,7 @@ pc.extend(pc.fw, function() {
         this.rotationSpeedGraph = null;
         this.rotationSpeedGraph2 = null;
 
-        this.blendType = pc.scene.BLEND_PREMULTIPLIED;
+        this.blendType = pc.scene.BLEND_NORMAL;
 
         this.model = null;
 

--- a/src/framework/components/particlesystem/particlesystem_system.js
+++ b/src/framework/components/particlesystem/particlesystem_system.js
@@ -36,17 +36,6 @@ pc.extend(pc.fw, function() {
                     step: 0.01
                 }
             }, {
-                name: "lifetime2",
-                displayName: "Lifetime 2",
-                description: "",
-                type: "number",
-                exposed: false,
-                defaultValue: 5,
-                options: {
-                    min: 0,
-                    step: 0.01
-                }
-            }, {
                 name: "rate",
                 displayName: "Emission Rate",
                 description: "Delay between emission of each particle in seconds",
@@ -112,7 +101,6 @@ pc.extend(pc.fw, function() {
                 description: "Starts particles in the middle of simulation",
                 type: "boolean",
                 defaultValue: false,
-                exposed: false,
                 filter: {
                     oneShot: false
                 }
@@ -187,9 +175,6 @@ pc.extend(pc.fw, function() {
                 type: "enumeration",
                 options: {
                     enumerations: [{
-                        name: 'Premultiplied Alpha',
-                        value: pc.scene.BLEND_PREMULTIPLIED
-                    }, {
                         name: 'Alpha',
                         value: pc.scene.BLEND_NORMAL
                     }, {
@@ -200,7 +185,7 @@ pc.extend(pc.fw, function() {
                         value: pc.scene.BLEND_MULTIPLICATIVE
                     }]
                 },
-                defaultValue: pc.scene.BLEND_PREMULTIPLIED,
+                defaultValue: pc.scene.BLEND_NORMAL,
             }, {
                 name: "stretch",
                 displayName: "Stretch",

--- a/src/graphics/programlib/chunks/gamma1_0.ps
+++ b/src/graphics/programlib/chunks/gamma1_0.ps
@@ -10,3 +10,11 @@ vec3 gammaCorrectOutput(vec3 color) {
     return color;
 }
 
+vec3 gammaCorrectInput(vec3 color) {
+    return color;
+}
+
+float gammaCorrectInput(float color) {
+    return color;
+}
+

--- a/src/graphics/programlib/chunks/gamma2_2.ps
+++ b/src/graphics/programlib/chunks/gamma2_2.ps
@@ -1,12 +1,20 @@
+vec3 gammaCorrectInput(vec3 color) {
+    return pow(color, vec3(2.2));
+}
+
+float gammaCorrectInput(float color) {
+    return pow(color, 2.2);
+}
+
 vec4 texture2DSRGB(sampler2D tex, vec2 uv) {
     vec4 rgba = texture2D(tex, uv);
-    rgba.rgb = pow(rgba.rgb, vec3(2.2));
+    rgba.rgb = gammaCorrectInput(rgba.rgb);
     return rgba;
 }
 
 vec4 textureCubeSRGB(samplerCube tex, vec3 uvw) {
     vec4 rgba = textureCube(tex, uvw);
-    rgba.rgb = pow(rgba.rgb, vec3(2.2));
+    rgba.rgb = gammaCorrectInput(rgba.rgb);
     return rgba;
 }
 

--- a/src/graphics/programlib/chunks/particle2.ps
+++ b/src/graphics/programlib/chunks/particle2.ps
@@ -26,7 +26,7 @@ float unpackFloat(vec4 rgbaDepth) {
 void main(void) {
     vec4 tex         = texture2DSRGB(colorMap, texCoordsAlphaLife.xy);
     vec4 ramp     = tex1Dlod_lerp(internalTex3, vec2(texCoordsAlphaLife.w, 0.0));
-    ramp *= colorMult;
+    ramp.rgb *= colorMult;
 
     ramp.a += texCoordsAlphaLife.z;
 

--- a/src/graphics/programlib/chunks/particle2.vs
+++ b/src/graphics/programlib/chunks/particle2.vs
@@ -12,7 +12,7 @@ uniform float graphNumSamples;
 uniform float stretch;
 uniform vec3 wrapBounds;
 uniform vec3 emitterScale;
-uniform float rate, rateDiv, lifetime, deltaRandomnessStatic, totalTime, totalTimePrev, scaleDivMult, alphaDivMult, oneShotStartTime, seed, lifetimeDiv;
+uniform float rate, rateDiv, lifetime, deltaRandomnessStatic, totalTime, totalTimePrev, scaleDivMult, alphaDivMult, oneShotStartTime, seed;
 uniform sampler2D particleTexOUT, particleTexIN;
 uniform sampler2D internalTex0;
 uniform sampler2D internalTex1;
@@ -85,7 +85,7 @@ void main(void) {
     float angle = particleTex.w;
 
     float particleRate = rate + rateDiv * rndFactor;
-    float particleLifetime = lifetime + lifetimeDiv * rndFactor;
+    float particleLifetime = lifetime;
     float startSpawnTime = -particleRate * id;
     float accumLife = max(totalTime + startSpawnTime + particleRate, 0.0);
     float life = mod(accumLife, particleLifetime + particleRate) - particleRate;

--- a/src/graphics/programlib/chunks/particle2_blendAdd.ps
+++ b/src/graphics/programlib/chunks/particle2_blendAdd.ps
@@ -1,0 +1,4 @@
+
+    rgb *= gammaCorrectInput(a);
+    if ((rgb.r + rgb.g + rgb.b) < 0.000001) discard;
+

--- a/src/graphics/programlib/chunks/particle2_blendMultiply.ps
+++ b/src/graphics/programlib/chunks/particle2_blendMultiply.ps
@@ -1,0 +1,4 @@
+
+    rgb = mix(vec3(1.0), rgb, vec3(a));
+    if (rgb.r + rgb.g + rgb.b > 2.99) discard;
+

--- a/src/graphics/programlib/chunks/particle2_blendNormal.ps
+++ b/src/graphics/programlib/chunks/particle2_blendNormal.ps
@@ -1,0 +1,2 @@
+
+    if (a < 0.01) discard;

--- a/src/graphics/programlib/chunks/particle2_end.ps
+++ b/src/graphics/programlib/chunks/particle2_end.ps
@@ -1,5 +1,3 @@
-
-    if (a < 0.01) discard;
-    gl_FragColor = vec4(rgb*a, a);
+    rgb = gammaCorrectOutput(rgb);
+    gl_FragColor = vec4(rgb, a);
 }
-

--- a/src/graphics/programlib/chunks/particle2_end_nopremul.ps
+++ b/src/graphics/programlib/chunks/particle2_end_nopremul.ps
@@ -1,5 +1,0 @@
-
-    if (a < 0.01) discard;
-    gl_FragColor = vec4(rgb, a);
-}
-

--- a/src/graphics/programlib/chunks/particle2_end_srgb.ps
+++ b/src/graphics/programlib/chunks/particle2_end_srgb.ps
@@ -1,5 +1,0 @@
-
-    if (a < 0.01) discard;
-    gl_FragColor = vec4(pow(rgb,vec3(0.45))*a, a);
-}
-

--- a/src/graphics/programlib/chunks/particle2_end_srgb_nopremul.ps
+++ b/src/graphics/programlib/chunks/particle2_end_srgb_nopremul.ps
@@ -1,5 +1,0 @@
-
-    if (a < 0.01) discard;
-    gl_FragColor = vec4(pow(rgb,vec3(0.45)), a);
-}
-

--- a/src/graphics/programlib/chunks/particleUpdaterStart.ps
+++ b/src/graphics/programlib/chunks/particleUpdaterStart.ps
@@ -4,7 +4,7 @@ uniform sampler2D particleTexIN;
 uniform vec3 emitterPos, frameRandom, localVelocityDivMult, velocityDivMult;
 uniform mat3 spawnBounds;
 uniform mat3 emitterMatrix;
-uniform float delta, rate, rateDiv, lifetime, lifetimeDiv, numParticles, totalTime, totalTimePrev, rotSpeedDivMult, oneShotStartTime, oneShotEndTime, seed;
+uniform float delta, rate, rateDiv, lifetime, numParticles, totalTime, totalTimePrev, rotSpeedDivMult, oneShotStartTime, oneShotEndTime, seed;
 uniform float startAngle, startAngle2;
 
 uniform float graphSampleSize;
@@ -47,7 +47,7 @@ void main(void)
     vec3 rndFactor3 = vec3(rndFactor, fract(rndFactor*10.0), fract(rndFactor*100.0));
 
     float particleRate = rate + rateDiv * rndFactor;
-    float particleLifetime = lifetime + lifetimeDiv * rndFactor;
+    float particleLifetime = lifetime;
     float startSpawnTime = -particleRate * (gl_FragCoord.x - 0.5);
     float accumLife = max(totalTime + startSpawnTime + particleRate, 0.0);
     float life = mod(accumLife, particleLifetime + particleRate) - particleRate;

--- a/src/graphics/programlib/programlib_particle2.js
+++ b/src/graphics/programlib/programlib_particle2.js
@@ -1,6 +1,6 @@
 pc.gfx.programlib.particle2 = {
     generateKey: function(device, options) {
-        var key = "particle2" + options.mode + options.normal + options.halflambert + options.stretch + options.soft + options.mesh + options.srgb + options.wrap + options.premul;
+        var key = "particle2" + options.mode + options.normal + options.halflambert + options.stretch + options.soft + options.mesh + options.srgb + options.wrap + options.blend;
         return key;
     },
 
@@ -43,6 +43,8 @@ pc.gfx.programlib.particle2 = {
             }
             fshader +=                              "\nuniform vec3 lightCube[6];\n";
         }
+
+        if (options.normal==0) options.srgb = false; // don't have to perform all gamma conversions when no lighting is used
         fshader += options.srgb ? chunk.gamma2_2PS : chunk.gamma1_0PS;
         fshader +=                                  chunk.particle2PS;
         if (options.soft > 0) fshader +=            chunk.particle2_softPS;
@@ -50,11 +52,14 @@ pc.gfx.programlib.particle2 = {
         if (options.normal == 2) fshader +=         chunk.particle2_normalMapPS;
         if (options.normal > 0) fshader +=          options.halflambert ? chunk.particle2_halflambertPS : chunk.particle2_lambertPS;
         if (options.normal > 0) fshader +=          chunk.particle2_lightingPS;
-        if (options.srgb) {
-            fshader += options.premul? chunk.particle2_end_srgbPS : chunk.particle2_end_srgb_nopremulPS;
-        } else {
-            fshader += options.premul? chunk.particle2_endPS : chunk.particle2_end_nopremulPS;
+        if (options.blend==pc.scene.BLEND_NORMAL) {
+            fshader += chunk.particle2_blendNormalPS;
+        } else if (options.blend==pc.scene.BLEND_ADDITIVE) {
+            fshader += chunk.particle2_blendAddPS;
+        } else if (options.blend==pc.scene.BLEND_MULTIPLICATIVE) {
+            fshader += chunk.particle2_blendMultiplyPS;
         }
+        fshader += chunk.particle2_endPS;
 
         var attributes = pc.gfx.shaderChunks.collectAttribs(vshader);
 

--- a/src/scene/scene_particleemitter2.js
+++ b/src/scene/scene_particleemitter2.js
@@ -181,8 +181,7 @@ pc.extend(pc.scene, function() {
             // 1x1 white opaque
             //defaultParamTex = _createTexture(gd, 1, 1, [1,1,1,1], pc.gfx.PIXELFORMAT_R8_G8_B8_A8, 1.0);
 
-
-            // white almost radial gradient
+            // white radial gradient
             var resolution = 16;
             var centerPoint = resolution * 0.5 + 0.5;
             var dtex = new Float32Array(resolution * resolution * 4);
@@ -211,7 +210,6 @@ pc.extend(pc.scene, function() {
         setProperty("rate", 1);                                  // Emission rate
         setProperty("rate2", this.rate);
         setProperty("lifetime", 50);                             // Particle lifetime
-        setProperty("lifetime2", this.lifetime);
         setProperty("spawnBounds", new pc.Vec3(0, 0, 0));        // Spawn point divergence
         setProperty("wrap", false);
         setProperty("wrapBounds", null);
@@ -232,7 +230,7 @@ pc.extend(pc.scene, function() {
         setProperty("mesh", null);                               // Mesh to be used as particle. Vertex buffer is supposed to hold vertex position in first 3 floats of each vertex
                                                                  // Leave undefined to use simple quads
         setProperty("depthTest", false);
-        setProperty("blendType", pc.scene.BLEND_PREMULTIPLIED);
+        setProperty("blendType", pc.scene.BLEND_NORMAL);
         setProperty("node", null);
         setProperty("startAngle", 0);
         setProperty("startAngle2", this.startAngle);
@@ -279,7 +277,6 @@ pc.extend(pc.scene, function() {
         this.constantRate = gd.scope.resolve("rate");
         this.constantRateDiv = gd.scope.resolve("rateDiv");
         this.constantLifetime = gd.scope.resolve("lifetime");
-        this.constantLifetimeDiv = gd.scope.resolve("lifetimeDiv");
         this.constantLightCube = gd.scope.resolve("lightCube[0]");
         this.constantGraphSampleSize = gd.scope.resolve("graphSampleSize");
         this.constantGraphNumSamples = gd.scope.resolve("graphNumSamples");
@@ -302,6 +299,12 @@ pc.extend(pc.scene, function() {
 
         this.lightCube = new Float32Array(6 * 3);
         this.lightCubeDir = new Array(6);
+        this.lightCubeDir[0] = new pc.Vec3(-1, 0, 0);
+        this.lightCubeDir[1] = new pc.Vec3(1, 0, 0);
+        this.lightCubeDir[2] = new pc.Vec3(0, -1, 0);
+        this.lightCubeDir[3] = new pc.Vec3(0, 1, 0);
+        this.lightCubeDir[4] = new pc.Vec3(0, 0, -1);
+        this.lightCubeDir[5] = new pc.Vec3(0, 0, 1);
 
         this.internalTex0 = null;
         this.internalTex1 = null;
@@ -334,7 +337,7 @@ pc.extend(pc.scene, function() {
     };
 
     function calcEndTime(emitter) {
-        var interval = (emitter.rate * emitter.numParticles + emitter.lifetime);
+        var interval = (Math.max(emitter.rate, emitter.rate2) * emitter.numParticles + emitter.lifetime);
         interval = Math.min(interval, emitter.maxEmissionTime);
         return Date.now() + interval * 1000;
     }
@@ -410,18 +413,6 @@ pc.extend(pc.scene, function() {
                         this.camera._depthTarget = this.camera.camera.camera._depthTarget;
                     }
                 }
-            }
-
-            if (this.lighting) {
-                // this.lightCube = new Float32Array(6 * 3);
-
-                // this.lightCubeDir = new Array(6);
-                this.lightCubeDir[0] = new pc.Vec3(-1, 0, 0);
-                this.lightCubeDir[1] = new pc.Vec3(1, 0, 0);
-                this.lightCubeDir[2] = new pc.Vec3(0, -1, 0);
-                this.lightCubeDir[3] = new pc.Vec3(0, 1, 0);
-                this.lightCubeDir[4] = new pc.Vec3(0, 0, -1);
-                this.lightCubeDir[5] = new pc.Vec3(0, 0, 1);
             }
 
             this.rebuildGraphs();
@@ -520,7 +511,7 @@ pc.extend(pc.scene, function() {
                     mesh: this.emitter.isMesh,
                     srgb: this.emitter.scene ? this.emitter.scene.gammaCorrection : false,
                     wrap: this.emitter.wrap && this.emitter.wrapBounds,
-                    premul: this.blendType === pc.scene.BLEND_PREMULTIPLIED
+                    blend: this.blendType
                 });
                 this.setShader(shader);
             };
@@ -534,7 +525,8 @@ pc.extend(pc.scene, function() {
 
             this._initializeTextures();
 
-            this.addTime(this._getStartTime()); // fill dynamic textures and constants with initial data
+            this.addTime(0); // fill dynamic textures and constants with initial data
+            if (this.preWarm) this.prewarm(this.lifetime);
 
             this.resetTime();
         },
@@ -612,10 +604,6 @@ pc.extend(pc.scene, function() {
             return false;
         },
 
-        _getStartTime: function () {
-            return this.preWarm && !this.oneShot ? this.lifetime : 0;
-        },
-
         resetMaterial: function() {
             var material = this.material;
             var gd = this.graphicsDevice;
@@ -632,7 +620,6 @@ pc.extend(pc.scene, function() {
             material.setParameter('numParticles', this.numParticles);
             material.setParameter('numParticlesPot', this.numParticlesPot);
             material.setParameter('lifetime', this.lifetime);
-            material.setParameter('lifetimeDiv', this.lifetime2 - this.lifetime);
             material.setParameter('rate', this.rate);
             material.setParameter('rateDiv', this.rate2 - this.rate);
             material.setParameter('seed', this.seed);
@@ -779,10 +766,19 @@ pc.extend(pc.scene, function() {
                 this.particleTexIN = this.particleTexStart;
                 this.particleTexIN = oldTexIN;
             }
-            var startTime = this.preWarm ? this.lifetime : 0;
             this.totalTime = this.totalTimePrev = this.oneShotStartTime = this.oneShotEndTime = 0;
-            this.addTime(this._getStartTime());
+            this.addTime(0);
+            if (this.preWarm) this.prewarm(this.lifetime);
             this.resetTime();
+        },
+
+        prewarm: function(time) {
+            var lifetimeFraction = time / this.lifetime;
+            var iterations = Math.min(Math.floor(lifetimeFraction * this.precision), this.precision);
+            var stepDelta = time / iterations;
+            for(var i=0; i<iterations; i++) {
+                this.addTime(stepDelta);
+            }
         },
 
         resetTime: function() {
@@ -873,7 +869,6 @@ pc.extend(pc.scene, function() {
 
                 this.constantSeed.setValue(this.seed);
                 this.constantLifetime.setValue(this.lifetime);
-                this.constantLifetimeDiv.setValue(this.lifetime2 - this.lifetime);
                 this.constantEmitterScale.setValue(emitterScale);
                 this.constantEmitterMatrix.setValue(emitterMatrix3.data);
 
@@ -917,7 +912,7 @@ pc.extend(pc.scene, function() {
                     rndFactor3Vec.z = (rndFactor * 100.0) % 1.0;
 
                     var particleRate = pc.math.lerp(this.rate, this.rate2, rndFactor);
-                    var particleLifetime = pc.math.lerp(this.lifetime, this.lifetime2, rndFactor);
+                    var particleLifetime = this.lifetime;
                     var startSpawnTime = -particleRate * id;
                     var accumLife = Math.max(this.totalTime + startSpawnTime + particleRate, 0.0);
                     var life = (accumLife % (particleLifetime + particleRate)) - particleRate;
@@ -927,7 +922,7 @@ pc.extend(pc.scene, function() {
                     var respawn = Math.floor(accumLife / (particleLifetime + particleRate)) != Math.floor(accumLifePrev / (particleLifetime + particleRate));
 
                     var scale = 0;
-                    var alphaRnd = 0;
+                    var alphaDiv = 0;
 
                     if (life > 0.0) {
                         localVelocityVec.data =  tex1D(this.qLocalVelocity, nlife, 3, localVelocityVec.data);
@@ -938,6 +933,8 @@ pc.extend(pc.scene, function() {
                         var rotSpeed2 =          tex1D(this.qRotSpeed2, nlife);
                         scale =                  tex1D(this.qScale, nlife);
                         var scale2 =             tex1D(this.qScale2, nlife);
+                        var alpha =              tex1D(this.qAlpha, nlife);
+                        var alpha2 =             tex1D(this.qAlpha2, nlife);
 
                         localVelocityVec.x = pc.math.lerp(localVelocityVec.x, localVelocityVec2.x, rndFactor3Vec.x);
                         localVelocityVec.y = pc.math.lerp(localVelocityVec.y, localVelocityVec2.y, rndFactor3Vec.y);
@@ -948,7 +945,8 @@ pc.extend(pc.scene, function() {
                         velocityVec.z = pc.math.lerp(velocityVec.z, velocityVec2.z, rndFactor3Vec.z);
 
                         rotSpeed = pc.math.lerp(rotSpeed, rotSpeed2, rndFactor3Vec.y);
-                        scale = pc.math.lerp(scale, scale2, (rndFactor*10000.0) % 1.0) * uniformScale;
+                        scale = pc.math.lerp(scale, scale2, (rndFactor * 10000.0) % 1.0) * uniformScale;
+                        alphaDiv = (alpha2 - alpha) * ((rndFactor * 1000.0) % 1.0);
 
                         if (this.meshInstance.node) {
                             rotMat.transformPoint(localVelocityVec, localVelocityVec);
@@ -1021,7 +1019,7 @@ pc.extend(pc.scene, function() {
                         data[w + 3] = nlife;
                         data[w + 4] = this.particleTex[id * 4 + 3];
                         data[w + 5] = scale;
-                        data[w + 6] = alphaRnd * (((rndFactor * 1000.0) % 1) * 2.0 - 1.0);
+                        data[w + 6] = alphaDiv;
                         //data[w+7] =   (quadX*0.5+0.5) + (quadY*0.5+0.5) * 0.1;
                         data[w + 8] = quadX;
                         data[w + 9] = quadY;


### PR DESCRIPTION
Fixed appearance of different blends, removed premultiplied blend from particles;
Fixed lifetime change weirdness, removed lifetime2;
Fixed alpha2 not working in CPU mode;
Fixed preWarm;
Fixed bug with color intensity multiplying alpha;
Particle gamma correction is now off when no lighting is enabled on particles;
Fixed possible error on dynamic 'lighting' parameter change;
Fixed system disappearing after changing oneShot a few times;
Fixed endTime calculation for oneShot emitters (didn't take rate2 into account).
