### PR TITLE
Particles interface and stuff

### DIFF
--- a/examples/particle_system/simple/index.html
+++ b/examples/particle_system/simple/index.html
@@ -10,15 +10,6 @@
     <canvas id="application-canvas"></canvas>
 
     <script>
-        function createMaterial(colors) {
-            var material = new pc.scene.PhongMaterial();
-            for (var param in colors) {
-                material[param] = colors[param];
-            }
-            material.update();
-            return material;
-        }
-
         var canvas = document.getElementById("application-canvas");
 
         // Create the application and start the update loop
@@ -51,30 +42,24 @@
         application.context.root.addChild(lightDirEntity);
 
 
-        // Offset position down 5 metres
-        var posCurve = new pc.CurveSet([
-            [0, 0, 1, 0],  // x
-            [0, 0, 1, -5], // y
-            [0, 0, 1, 0] // z
+        // set up random downwards velocity from -0.4 to -0.7
+        var velocityCurve = new pc.CurveSet([
+            [0, 0],     // x
+            [0, -0.7],  // y
+            [0, 0]      // z
+        ]);
+        var velocityCurve2 = new pc.CurveSet([
+            [0, 0],   // x
+            [0, -0.4],// y
+            [0, 0]    // z
         ]);
 
-        posCurve.type = pc.CURVE_LINEAR;
+        // set up random rotation speed from -100 to 100 degrees per second
+        var rotCurve = new pc.Curve([0, 100]);
+        var rotCurve2 = new pc.Curve([0, -100]);
 
         // scale is constant at 0.1
-        var scaleCurve = new pc.Curve([0, 0.1, 1, 0.1]);
-
-        // rotate snowflakes
-        var angleCurve = new pc.Curve([0, 0, 1, 360 * 2]);
-
-        // randomize rotation
-        var angleDivCurve = new pc.Curve([0, 0, 1, 1]);
-
-        // color is constant white
-        var colorCurve = new pc.CurveSet([
-            [0, 1, 1, 1], // red channel
-            [0, 1, 1, 1], // green channel
-            [0, 1, 1, 1] // blue channel
-        ]);
+        var scaleCurve = new pc.Curve([0, 0.1]);
 
         // Create entity for particle system
         var entity = new pc.fw.Entity();
@@ -88,13 +73,14 @@
                 numParticles: 100,
                 lifetime: 10,
                 rate: 0.1,
-                constantSpeedDiv: 0.5,
+                startAngle: 360,
+                startAngle2: -360,
                 spawnBounds: new pc.Vec3(5, 0, 0),
-                offsetGraph: posCurve,
+                velocityGraph: velocityCurve,
+                velocityGraph2: velocityCurve2,
                 scaleGraph: scaleCurve,
-                angleGraph: angleCurve,
-                angleDivGraph: angleDivCurve,
-                colorGraph: colorCurve,
+                rotationSpeedGraph: rotCurve,
+                rotationSpeedGraph2: rotCurve2,
                 colorMap: result.resource
             });
         });

--- a/examples/particle_system/sparks/index.html
+++ b/examples/particle_system/sparks/index.html
@@ -59,34 +59,39 @@
         ]);
         localPosCurve.type = pc.CURVE_LINEAR;
 
-        // local position divergence
-        var localPosDivCurve = new pc.CurveSet([
-            [0, 1, 1, 1],
-            [0, 1, 1, 1],
+        // make particles move in different directions
+        var localVelocityCurve = new pc.CurveSet([
+            [0, 0, 1, 8],
+            [0, 0, 1, 6],
+            [0, 0, 1, 0]
+        ]);
+        var localVelocityCurve2 = new pc.CurveSet([
+            [0, 0, 1, -8],
+            [0, 0, 1, -6],
             [0, 0, 1, 0]
         ]);
 
-        // world position graph
-        var worldPosCurve = new pc.CurveSet([
-            [0, 0, 1, 0],
-            [0, 0, 0.2, 3, 1, -3],
-            [0, 0, 1, 0]
+        // increasing gravity
+        var worldVelocityCurve = new pc.CurveSet([
+            [0, 0],
+            [0, 0, 0.2, 6, 1, -48],
+            [0, 0]
         ]);
 
         // gradually make sparks bigger
         var scaleCurve = new pc.Curve(
-            [0, 0, 0.5, 0.2, 1, 0]
+            [0, 0, 0.5, 0.3, 0.8, 0.2, 1, 0.1]
         );
 
-        // rotate sparks
+        // rotate sparks 360 degrees per second
         var angleCurve = new pc.Curve(
-            [0, 0, 1, 360]
+            [0, 360]
         );
 
         // color changes throughout lifetime
         var colorCurve = new pc.CurveSet([
-            [0, 1, 0.5, 1, 0.75, 0.5, 1, 0],
-            [0, 0, 0.25, 0.25, 0.5, 0.5, 0.75, 0.75, 1, 1],
+            [0, 1, 0.25, 1, 0.375, 0.5, 0.5, 0],
+            [0, 0, 0.125, 0.25, 0.25, 0.5, 0.375, 0.75, 0.5, 1],
             [0, 0, 1, 0]
         ]);
 
@@ -102,13 +107,13 @@
                 numParticles: 200,
                 lifetime: 2,
                 rate: 0.01,
-                localOffsetGraph: localPosCurve,
-                offsetGraph: worldPosCurve,
-                localPosDivGraph: localPosDivCurve,
                 scaleGraph: scaleCurve,
-                angleGraph: angleCurve,
+                rotationSpeedGraph: angleCurve,
                 colorGraph: colorCurve,
-                colorMap: result.resource
+                colorMap: result.resource,
+                velocityGraph: worldVelocityCurve,
+                localVelocityGraph: localVelocityCurve,
+                localVelocityGraph2: localVelocityCurve2
             });
         });
 

--- a/src/framework/components/particlesystem/particlesystem_component.js
+++ b/src/framework/components/particlesystem/particlesystem_component.js
@@ -5,7 +5,7 @@ pc.extend(pc.fw, function() {
         'spawnBounds',
         'colorMap',
         'normalMap',
-        'oneShot'
+        'loop'
     ];
 
     // properties that need rebuilding the particle system
@@ -54,7 +54,7 @@ pc.extend(pc.fw, function() {
         this.on("set_colorMapAsset", this.onSetColorMapAsset, this);
         this.on("set_normalMapAsset", this.onSetNormalMapAsset, this);
         this.on("set_mesh", this.onSetMesh, this);
-        this.on("set_oneShot", this.onSetOneShot, this);
+        this.on("set_loop", this.onSetLoop, this);
         this.on("set_blendType", this.onSetBlendType, this);
 
         SIMPLE_PROPERTIES.forEach(function (prop) {
@@ -153,17 +153,10 @@ pc.extend(pc.fw, function() {
             }
         },
 
-        onSetOneShot: function (name, oldValue, newValue) {
+        onSetLoop: function (name, oldValue, newValue) {
             if (this.emitter) {
                 this.emitter[name] = newValue;
                 this.emitter.resetTime();
-                if (oldValue && !newValue) {
-                    //this.emitter.oneShotEndTime = this.emitter.totalTime;
-                    this.reset();
-                    this.emitter.resetMaterial();
-                    this.enabled = true;
-                    this.rebuild();
-                }
             }
         },
 
@@ -243,7 +236,7 @@ pc.extend(pc.fw, function() {
 
                     colorMap: this.data.colorMap,
                     normalMap: this.data.normalMap,
-                    oneShot: this.data.oneShot,
+                    loop: this.data.loop,
                     preWarm: this.data.preWarm,
                     sort: this.data.sort,
                     stretch: this.data.stretch,
@@ -269,10 +262,12 @@ pc.extend(pc.fw, function() {
                 this.data.model = this.psys;
                 this.emitter.psys = this.psys;
 
-                // called after oneShot emitter is finished. As you can dynamically change oneShot parameter, it should be always initialized
+                // called after non-looped emitter is finished. As you can dynamically change loop parameter, it should be always initialized
 				this.emitter.onFinished = function() {
 					this.enabled = false;
 				}.bind(this);
+
+                if (!this.data.loop) this.enabled = false;
             }
 
 
@@ -296,7 +291,36 @@ pc.extend(pc.fw, function() {
         },
 
         reset: function() {
+            this.stop();
+            this.emitter.addTime(1000);
+            //this.play();
+            this.onSetLoop("loop", false, this.data.loop);
             this.emitter.reset();
+        },
+
+        stop: function() {
+            this.onSetLoop("loop", false, false);
+            this.emitter.addTime(0, true); // remap life < 0 to life > lifetime to prevent spawning after stop
+        },
+
+        pause: function() {
+            this.data.enabled = false;
+        },
+
+        play: function() {
+            this.data.enabled = true;
+            this.enabled = true;
+            this.onEnable();
+            this.emitter.resetTime();
+            this.onSetLoop("loop", false, this.data.loop);
+        },
+
+        isPlaying: function() {
+            if (!this.enabled || !this.data.enabled) return false;
+            if (!this.emitter.loop) {
+                if (Date.now() > this.emitter.endTime) return false;
+            }
+            return true;
         },
 
         rebuild: function() {

--- a/src/framework/components/particlesystem/particlesystem_data.js
+++ b/src/framework/components/particlesystem/particlesystem_data.js
@@ -13,7 +13,7 @@ pc.extend(pc.fw, function() {
         this.colorMapAsset = null;
         this.normalMap = null;
         this.normalMapAsset = null;
-        this.oneShot = false;
+        this.loop = true;
         this.preWarm = false;
         this.sort = 0;                          // Sorting mode: 0 = none, 1 = by distance, 2 = by life, 3 = by -life;   Forces CPU mode if not 0
         this.mode = "GPU";

--- a/src/framework/components/particlesystem/particlesystem_system.js
+++ b/src/framework/components/particlesystem/particlesystem_system.js
@@ -76,11 +76,11 @@ pc.extend(pc.fw, function() {
                     step: 0.01
                 }
             }, {
-                name: "oneShot",
-                displayName: "One Shot",
-                description: "Disables looping",
+                name: "loop",
+                displayName: "Loop",
+                description: "Enables looping",
                 type: "boolean",
-                defaultValue: false,
+                defaultValue: true,
             }, {
                 name: "preWarm",
                 displayName: "Pre Warm",
@@ -88,7 +88,7 @@ pc.extend(pc.fw, function() {
                 type: "boolean",
                 defaultValue: false,
                 filter: {
-                    oneShot: false
+                    loop: true
                 }
             }, {
                 name: "lighting",

--- a/src/graphics/programlib/chunks/particle2.vs
+++ b/src/graphics/programlib/chunks/particle2.vs
@@ -12,7 +12,7 @@ uniform float graphNumSamples;
 uniform float stretch;
 uniform vec3 wrapBounds;
 uniform vec3 emitterScale;
-uniform float rate, rateDiv, lifetime, deltaRandomnessStatic, totalTime, totalTimePrev, scaleDivMult, alphaDivMult, oneShotStartTime, seed;
+uniform float rate, rateDiv, lifetime, deltaRandomnessStatic, scaleDivMult, alphaDivMult, seed;
 uniform sampler2D particleTexOUT, particleTexIN;
 uniform sampler2D internalTex0;
 uniform sampler2D internalTex1;
@@ -84,17 +84,14 @@ void main(void) {
     vec3 pos = particleTex.xyz;
     float angle = particleTex.w;
 
-    float particleRate = rate + rateDiv * rndFactor;
-    float particleLifetime = lifetime;
-    float startSpawnTime = -particleRate * id;
-    float accumLife = max(totalTime + startSpawnTime + particleRate, 0.0);
-    float life = mod(accumLife, particleLifetime + particleRate) - particleRate;
-    if (life <= 0.0) quadXY = vec2(0,0);
-    float nlife = clamp(life / particleLifetime, 0.0, 1.0);
+    vec4 particleTex2 = texture2D(particleTexOUT, vec2(id / numParticlesPot, 0.75));
+    vec3 particleVelocity = particleTex2.xyz;
+    float life = particleTex2.w;
 
-    float accumLifeOneShotStart = max(oneShotStartTime + startSpawnTime + particleRate, 0.0);
-    bool endOfSim = floor(accumLife / (particleLifetime + particleRate)) != floor(accumLifeOneShotStart / (particleLifetime + particleRate));
-    if (endOfSim) quadXY = vec2(0,0);
+    float particleLifetime = lifetime;
+
+    if (life <= 0.0 || life > particleLifetime) quadXY = vec2(0,0);
+    float nlife = clamp(life / particleLifetime, 0.0, 1.0);
 
     vec3 paramDiv;
     vec4 params =                 tex1Dlod_lerp(internalTex2, vec2(nlife, 0), paramDiv);

--- a/src/graphics/programlib/chunks/particle2_cpu.vs
+++ b/src/graphics/programlib/chunks/particle2_cpu.vs
@@ -1,6 +1,7 @@
 attribute vec4 particle_vertexData;     // XYZ = world pos, W = life
-attribute vec4 particle_vertexData2;     // X = angle, Y = scale, Z = alpha, W = velocityV.x
-attribute vec4 particle_vertexData3;     // XYZ = particle local pos, W = velocityV.y
+attribute vec4 particle_vertexData2;     // X = angle, Y = scale, Z = alpha, W = velocity.x
+attribute vec4 particle_vertexData3;     // XYZ = particle local pos, W = velocity.y
+attribute vec2 particle_vertexData4;     // X = velocity.z, W = unused
 
 uniform mat4 matrix_viewProjection;
 uniform mat4 matrix_model;
@@ -54,7 +55,9 @@ vec3 billboard(vec3 InstanceCoords, vec2 quadXY, out mat3 localMat)
 void main(void)
 {
     vec3 particlePos = particle_vertexData.xyz;
+    vec3 pos = particlePos;
     vec3 vertPos = particle_vertexData3.xyz;
+    vec3 particleVelocity = vec3(particle_vertexData2.w, particle_vertexData3.w, particle_vertexData4.x);
 
     vec2 quadXY = vertPos.xy;
     texCoordsAlphaLife = vec4(quadXY * -0.5 + 0.5, particle_vertexData2.z, particle_vertexData.w);

--- a/src/graphics/programlib/chunks/particle2_cpu_stretch.vs
+++ b/src/graphics/programlib/chunks/particle2_cpu_stretch.vs
@@ -1,8 +1,0 @@
-    vec2 velocityV = normalize(vec2(particle_vertexData2.w, particle_vertexData3.w));
-    vec2 centerToVertexV = normalize((mat3(matrix_view) * localPos).xy);
-    vec3 particleVelocityUnprojected = vec3(particle_vertexData2.w, particle_vertexData3.w, 0.0) * mat3(matrix_view);
-    vec3 moveDir = particleVelocityUnprojected * stretch;
-    vec3 posPrev = particlePos - moveDir;
-    float interpolation = dot(-velocityV, centerToVertexV) * 0.5 + 0.5;
-    particlePos = mix(particlePos, posPrev, interpolation);
-

--- a/src/graphics/programlib/chunks/particle2_stretch.vs
+++ b/src/graphics/programlib/chunks/particle2_stretch.vs
@@ -1,16 +1,11 @@
-    float accumLifePrev = max(totalTimePrev + startSpawnTime + particleRate, 0.0);
-    bool respawn = floor(accumLife / (particleLifetime + particleRate)) != floor(accumLifePrev / (particleLifetime + particleRate));
+    vec3 moveDir = particleVelocity * stretch;
+    vec3 posPrev = pos - moveDir;
+    posPrev += particlePosMoved;
 
-    if (!respawn) {
-        vec3 moveDir = particleVelocity * stretch;
-        vec3 posPrev = pos - moveDir;
-        posPrev += particlePosMoved;
+    vec2 velocityV = normalize((mat3(matrix_view) * particleVelocity).xy);
+    vec2 centerToVertexV = normalize((mat3(matrix_view) * localPos).xy);
 
-        vec2 velocityV = normalize((mat3(matrix_view) * particleVelocity).xy);
-        vec2 centerToVertexV = normalize((mat3(matrix_view) * localPos).xy);
+    float interpolation = dot(-velocityV, centerToVertexV) * 0.5 + 0.5;
 
-        float interpolation = dot(-velocityV, centerToVertexV) * 0.5 + 0.5;
-
-        particlePos = mix(particlePos, posPrev, interpolation);
-    }
+    particlePos = mix(particlePos, posPrev, interpolation);
 

--- a/src/graphics/programlib/chunks/particle2_velocity.vs
+++ b/src/graphics/programlib/chunks/particle2_velocity.vs
@@ -1,2 +1,0 @@
-    vec3 particleVelocity = texture2D(particleTexOUT, vec2(id / numParticlesPot, 0.75)).xyz;
-

--- a/src/graphics/programlib/chunks/particleUpdaterOnStop.ps
+++ b/src/graphics/programlib/chunks/particleUpdaterOnStop.ps
@@ -1,0 +1,4 @@
+    if (life < 0.0 && gl_FragCoord.y >= 1.0) {
+        tex.w = particleLifetime + 1.0;
+    }
+

--- a/src/graphics/programlib/chunks/particleUpdaterRespawn.ps
+++ b/src/graphics/programlib/chunks/particleUpdaterRespawn.ps
@@ -1,12 +1,4 @@
-    float accumLifePrev = max(totalTimePrev + startSpawnTime + particleRate, 0.0);
-    bool respawn = floor(accumLife / (particleLifetime + particleRate)) != floor(accumLifePrev / (particleLifetime + particleRate));
-
-    float accumLifeOneShotStart = max(oneShotStartTime + startSpawnTime + particleRate, 0.0);
-    bool endOfSim = floor(accumLife / (particleLifetime + particleRate)) != floor(accumLifeOneShotStart / (particleLifetime + particleRate));
-
-    if (respawn || endOfSim || life <= 0.0) {
-        vec3 inBounds = fract( vec3(rndFactor, rndFactor*10.0, rndFactor*100.0) + frameRandom );
-        tex.xyz = emitterPos + spawnBounds * (inBounds - vec3(0.5));
-        tex.w = mix(startAngle, startAngle2, rndFactor);
+    if (life > particleLifetime && gl_FragCoord.y >= 1.0) {
+        tex.w = -particleRate * gl_FragCoord.x;
     }
 

--- a/src/graphics/programlib/chunks/particleUpdaterStart.ps
+++ b/src/graphics/programlib/chunks/particleUpdaterStart.ps
@@ -4,7 +4,7 @@ uniform sampler2D particleTexIN;
 uniform vec3 emitterPos, frameRandom, localVelocityDivMult, velocityDivMult;
 uniform mat3 spawnBounds;
 uniform mat3 emitterMatrix;
-uniform float delta, rate, rateDiv, lifetime, numParticles, totalTime, totalTimePrev, rotSpeedDivMult, oneShotStartTime, oneShotEndTime, seed;
+uniform float delta, rate, rateDiv, lifetime, numParticles, rotSpeedDivMult, seed;
 uniform float startAngle, startAngle2;
 
 uniform float graphSampleSize;
@@ -41,30 +41,30 @@ void main(void)
 {
     if (gl_FragCoord.x > numParticles) discard;
 
-    vec4 tex = texture2D(particleTexIN, vec2(vUv0.x, 0));
+    vec4 tex = texture2D(particleTexIN, vec2(vUv0.x, 0.25));
+    vec4 tex2 = texture2D(particleTexIN, vec2(vUv0.x, 0.75));
 
     float rndFactor = fract(sin(gl_FragCoord.x + 0.5 + seed));
     vec3 rndFactor3 = vec3(rndFactor, fract(rndFactor*10.0), fract(rndFactor*100.0));
 
-    float particleRate = rate + rateDiv * rndFactor;
     float particleLifetime = lifetime;
-    float startSpawnTime = -particleRate * (gl_FragCoord.x - 0.5);
-    float accumLife = max(totalTime + startSpawnTime + particleRate, 0.0);
-    float life = mod(accumLife, particleLifetime + particleRate) - particleRate;
+    float life = tex2.w + delta;
+    float particleRate = rate + rateDiv * rndFactor;
 
     if (life > 0.0) {
-        life = clamp(life / particleLifetime, 0.0, 1.0);
+        float nlife = clamp(life / particleLifetime, 0.0, 1.0);
         vec3 localVelocityDiv;
         vec3 velocityDiv;
         vec3 paramDiv;
-        vec3 localVelocity =    tex1Dlod_lerp(internalTex0, vec2(life, 0), localVelocityDiv).xyz;
-        vec3 velocity =         tex1Dlod_lerp(internalTex1, vec2(life, 0), velocityDiv).xyz;
+        vec3 localVelocity =    tex1Dlod_lerp(internalTex0, vec2(nlife, 0), localVelocityDiv).xyz;
+        vec3 velocity =         tex1Dlod_lerp(internalTex1, vec2(nlife, 0), velocityDiv).xyz;
 
         localVelocity +=        (localVelocityDiv * vec3(2.0) - vec3(1.0)) * localVelocityDivMult * rndFactor3;
         velocity +=             (velocityDiv * vec3(2.0) - vec3(1.0)) * velocityDivMult * rndFactor3.zxy;
 
         if (gl_FragCoord.y < 1.0) {
-            vec4 params =           tex1Dlod_lerp(internalTex2, vec2(life, 0), paramDiv);
+            // Current particle state
+            vec4 params =           tex1Dlod_lerp(internalTex2, vec2(nlife, 0), paramDiv);
 
             float rotSpeed = params.x;
             float rotSpeedDiv = paramDiv.y;
@@ -74,9 +74,18 @@ void main(void)
             tex.xyz += (emitterMatrix * localVelocity.xyz + velocity.xyz * emitterScale) * delta;
             tex.w += rotSpeed * delta;
         } else {
-            // Only write velocity
+            // Velocity
             tex.xyz = (emitterMatrix * localVelocity.xyz + velocity.xyz * emitterScale);
-            tex.w = 1.0;
         }
+    }
+
+    if (gl_FragCoord.y < 1.0) {
+        if (life <= 0.0 || life > particleLifetime) {
+            vec3 inBounds = fract( vec3(rndFactor, rndFactor*10.0, rndFactor*100.0) + frameRandom );
+            tex.xyz = emitterPos + spawnBounds * (inBounds - vec3(0.5));
+            tex.w = mix(startAngle, startAngle2, rndFactor);
+        }
+    } else {
+        tex.w = life;
     }
 

--- a/src/graphics/programlib/programlib_particle2.js
+++ b/src/graphics/programlib/programlib_particle2.js
@@ -20,7 +20,6 @@ pc.gfx.programlib.particle2 = {
             if (options.normal == 2) vshader +=     "\nvarying mat3 ParticleMat;\n";
             vshader +=                              chunk.particle2VS;
             if (options.wrap) vshader +=                              chunk.particle2_wrapVS;
-            if ((options.stretch > 0.0) || (options.alignToMotion)) vshader +=   chunk.particle2_velocityVS;
             if (options.alignToMotion) vshader +=     chunk.particle2_pointAlongVS;
             vshader +=                              options.mesh ? chunk.particle2_meshVS : chunk.particle2_billboardVS;
             if (options.normal == 1) vshader +=     chunk.particle2_normalVS;
@@ -31,7 +30,7 @@ pc.gfx.programlib.particle2 = {
             if (options.normal == 1) vshader +=     "\nvarying vec3 Normal;\n";
             if (options.normal == 2) vshader +=     "\nvarying mat3 ParticleMat;\n";
             vshader +=                              chunk.particle2_cpuVS;
-            if (options.stretch > 0.0) vshader +=   chunk.particle2_cpu_stretchVS;
+            if (options.stretch > 0.0) vshader +=   chunk.particle2_stretchVS;
             //if (options.wrap) vshader +=                              chunk.particle2_wrapVS;
             if (options.mesh) vshader +=            chunk.particle2_cpu_meshVS;
             if (options.normal == 1) vshader +=     chunk.particle2_normalVS;

--- a/src/scene/scene_forwardrenderer.js
+++ b/src/scene/scene_forwardrenderer.js
@@ -523,7 +523,7 @@ pc.extend(pc.scene, function () {
 
                 for (i = 0, numDrawCalls = drawCalls.length; i < numDrawCalls; i++) {
                     drawCall = drawCalls[i];
-                    if (!drawCall.command) {
+                    if (!drawCall.command && drawCall.drawToDepth) {
                         meshInstance = drawCall;
                         mesh = meshInstance.mesh;
 

--- a/src/scene/scene_mesh.js
+++ b/src/scene/scene_mesh.js
@@ -49,6 +49,7 @@ pc.extend(pc.scene, function () {
         this.renderStyle = pc.scene.RENDERSTYLE_SOLID;
         this.castShadow = false;
         this.receiveShadow = true;
+        this.drawToDepth = true;
 
         // 64-bit integer key that defines render order of this mesh instance
         this.key = 0;
@@ -124,5 +125,5 @@ pc.extend(pc.scene, function () {
         Command: Command,
         Mesh: Mesh,
         MeshInstance: MeshInstance
-    }; 
+    };
 }());


### PR DESCRIPTION
New particle interface and underlying logic:
- reset() resets particle state, doesn't affect playing;
- stop() disables the emission of new particles, lets others to finish simulation;
- play() continues the emission, also unpauses;
- pause() freezes the emitter;
- isPlaying() tells if emission is in progress;
- "oneShot" parameter replaced with "loop" (same, but inversed);
- non-looped (oneShot) emitters do not start emission unless play() is called;

simple and sparks examples are updated.

Fixed CPU stretching.
Fixed WebGL warning spamming by disallowing particles being rendered into depth map. Added meshInstance.drawToDepth boolean to control it.
