### PR TITLE
Feature/cubemap prefilter

### DIFF
--- a/build/dependencies.txt
+++ b/build/dependencies.txt
@@ -49,6 +49,7 @@
 ../src/graphics/graphics_device.js
 ../src/graphics/graphics_chunks.js
 ../src/graphics/graphics_simpleposteffect.js
+../src/graphics/graphics_prefiltercubemap.js
 ../src/graphics/programlib/chunks/generated_shaderchunks.js
 ../src/graphics/graphics_defaultShaderChunks.js
 ../src/graphics/programlib/programlib_programlib.js

--- a/src/graphics/graphics_prefiltercubemap.js
+++ b/src/graphics/graphics_prefiltercubemap.js
@@ -1,0 +1,91 @@
+pc.extend(pc, (function () {
+    'use strict';
+
+    function prefilterCubemap(device, sourceCubemap, method, samples, options, chromeFix) {
+        var chunks = pc.shaderChunks;
+        var shader = chunks.createShaderFromCode(device, chunks.fullscreenQuadVS, chunks.rgbmPS +
+            chunks.prefilterCubemapPS.
+                replace(/\$METHOD/g, method===0? "cos" : "phong").
+                replace(/\$NUMSAMPLES/g, samples),
+            "prefilter" + method + "" + samples);
+        var constantTexSource = device.scope.resolve("source");
+        var constantParams = device.scope.resolve("params");
+        var params = new pc.Vec4();
+        var size = sourceCubemap.width;
+        var rgbmSource = sourceCubemap.rgbm;
+        var format = sourceCubemap.format;
+
+        var cmapsList = [[], options.filteredFixed, options.filteredRGBM, options.filteredFixedRGBM];
+        var gloss = method===0? [0.9, 0.85, 0.7, 0.4, 0.25] : [512, 128, 32, 8, 2]; // TODO: calc more correct values depending on mip
+        var mipSize = [64, 32, 16, 8, 4]; // TODO: make non-static?
+        var mips = 5;
+        var targ;
+        var i, face, pass;
+
+        // Initialize textures
+        for(i=0; i<mips; i++) {
+            for(pass=0; pass<cmapsList.length; pass++) {
+                if (cmapsList[pass]!=null) {
+                    cmapsList[pass][i] = new pc.gfx.Texture(device, {
+                        cubemap: true,
+                        rgbm: pass<2? rgbmSource : true,
+                        format: pass<2? format : pc.PIXELFORMAT_R8_G8_B8_A8,
+                        fixCubemapSeams: pass===1 || pass===3,
+                        width: mipSize[i],
+                        height: mipSize[i],
+                        autoMipmap: false
+                    });
+                    cmapsList[pass][i].minFilter = pc.FILTER_LINEAR;
+                    cmapsList[pass][i].magFilter = pc.FILTER_LINEAR;
+                    cmapsList[pass][i].addressU = pc.ADDRESS_CLAMP_TO_EDGE;
+                    cmapsList[pass][i].addressV = pc.ADDRESS_CLAMP_TO_EDGE;
+                }
+            }
+        }
+
+        // Filter
+        // Pass 0: just filter
+        // Pass 1: filter + edge fixup
+        // Pass 2: filter + encode to RGBM
+        // Pass 3: filter + edge fixup + encode to RGBM
+        for(pass=0; pass<cmapsList.length; pass++) {
+            if (cmapsList[pass]!=null) {
+                if (pass>1 && rgbmSource) {
+                    // already RGBM
+                    cmapsList[pass] = cmapsList[pass - 2];
+                    continue;
+                }
+                for(i=0; i<mips; i++) {
+                    for(face=0; face<6; face++) {
+                        targ = new pc.RenderTarget(device, cmapsList[pass][i], { // TODO: less excessive allocations
+                            face: face,
+                            depth: false
+                        });
+                        params.x = face;
+                        params.y = gloss[i];
+                        params.z = mipSize[i];
+                        params.w = pass;
+                        constantTexSource.setValue(i===0? sourceCubemap : cmapsList[0][i - 1]);
+                        constantParams.setValue(params.data);
+
+                        if (chromeFix) {
+                            // https://code.google.com/p/chromium/issues/detail?id=447419
+                            // Workaround: wait a little
+                            var endTime = Date.now() + 10;
+                            while(Date.now() < endTime);
+                        }
+                        pc.drawQuadWithShader(device, targ, shader);
+                    }
+                }
+            }
+        }
+
+        options.filtered = cmapsList[0];
+
+    }
+
+    return {
+        prefilterCubemap: prefilterCubemap
+    };
+}()));
+

--- a/src/graphics/graphics_prefiltercubemap.js
+++ b/src/graphics/graphics_prefiltercubemap.js
@@ -29,7 +29,7 @@ pc.extend(pc, (function () {
         // Initialize textures
         for(i=0; i<mips; i++) {
             for(pass=startPass; pass<cmapsList.length; pass++) {
-                if (cmapsList[pass]!=null || pass<0) {
+                if (cmapsList[pass]!=null) {
                     cmapsList[pass][i] = new pc.gfx.Texture(device, {
                         cubemap: true,
                         rgbm: pass<2? rgbmSource : true,

--- a/src/graphics/graphics_texture.js
+++ b/src/graphics/graphics_texture.js
@@ -28,7 +28,8 @@ pc.extend(pc, function () {
         var format = pc.PIXELFORMAT_R8_G8_B8_A8;
         var cubemap = false;
         var autoMipmap = true;
-        var hdr = false;
+        var rgbm = false;
+        var fixCubemapSeams = false;
 
         if (options !== undefined) {
             width = (options.width !== undefined) ? options.width : width;
@@ -36,13 +37,15 @@ pc.extend(pc, function () {
             format = (options.format !== undefined) ? options.format : format;
             cubemap = (options.cubemap !== undefined) ? options.cubemap : cubemap;
             autoMipmap = (options.autoMipmap !== undefined) ? options.autoMipmap : autoMipmap;
-            hdr = (options.hdr !== undefined)? options.hdr : hdr;
+            rgbm = (options.rgbm !== undefined)? options.rgbm : rgbm;
+            fixCubemapSeams = (options.fixCubemapSeams !== undefined)? options.fixCubemapSeams : fixCubemapSeams;
         }
 
         // PUBLIC
         this.name = null;
         this.autoMipmap = autoMipmap;
-        this.hdr = hdr;
+        this.rgbm = rgbm;
+        this.fixCubemapSeams = fixCubemapSeams;
 
         // PRIVATE
         this._cubemap = cubemap;

--- a/src/graphics/graphics_texture.js
+++ b/src/graphics/graphics_texture.js
@@ -30,6 +30,7 @@ pc.extend(pc, function () {
         var autoMipmap = true;
         var rgbm = false;
         var fixCubemapSeams = false;
+        var hdr = false; // deprecated property, only for backwards compatibility
 
         if (options !== undefined) {
             width = (options.width !== undefined) ? options.width : width;
@@ -38,6 +39,7 @@ pc.extend(pc, function () {
             cubemap = (options.cubemap !== undefined) ? options.cubemap : cubemap;
             autoMipmap = (options.autoMipmap !== undefined) ? options.autoMipmap : autoMipmap;
             rgbm = (options.rgbm !== undefined)? options.rgbm : rgbm;
+            hdr = (options.hdr !== undefined)? options.hdr : hdr;
             fixCubemapSeams = (options.fixCubemapSeams !== undefined)? options.fixCubemapSeams : fixCubemapSeams;
         }
 
@@ -46,6 +48,7 @@ pc.extend(pc, function () {
         this.autoMipmap = autoMipmap;
         this.rgbm = rgbm;
         this.fixCubemapSeams = fixCubemapSeams;
+        this.hdr = hdr;
 
         // PRIVATE
         this._cubemap = cubemap;

--- a/src/graphics/programlib/chunks/ambientPrefilteredCube.ps
+++ b/src/graphics/programlib/chunks/ambientPrefilteredCube.ps
@@ -1,14 +1,5 @@
-vec3 fixSeamsStretch(vec3 vec, float invRecMipSize) {
-    float scale = invRecMipSize;
-    float M = max(max(abs(vec.x), abs(vec.y)), abs(vec.z));
-    if (abs(vec.x) != M) vec.x *= scale;
-    if (abs(vec.y) != M) vec.y *= scale;
-    if (abs(vec.z) != M) vec.z *= scale;
-    return vec;
-}
-
-
 void addAmbient(inout psInternalData data) {
-    vec3 fixedReflDir = fixSeamsStretch(data.normalW, 1.0 - 1.0 / 4.0);
+    vec3 fixedReflDir = fixSeamsStatic(data.normalW, 1.0 - 1.0 / 4.0);
     data.diffuseLight = decodeRGBM(textureCube(texture_prefilteredCubeMap4, fixedReflDir));
 }
+

--- a/src/graphics/programlib/chunks/ambientPrefilteredCube.ps
+++ b/src/graphics/programlib/chunks/ambientPrefilteredCube.ps
@@ -1,5 +1,5 @@
 void addAmbient(inout psInternalData data) {
     vec3 fixedReflDir = fixSeamsStatic(data.normalW, 1.0 - 1.0 / 4.0);
-    data.diffuseLight = decodeRGBM(textureCube(texture_prefilteredCubeMap4, fixedReflDir));
+    data.diffuseLight = $DECODE(textureCube(texture_prefilteredCubeMap4, fixedReflDir)).rgb;
 }
 

--- a/src/graphics/programlib/chunks/ambientPrefilteredCubeLod.ps
+++ b/src/graphics/programlib/chunks/ambientPrefilteredCubeLod.ps
@@ -1,14 +1,5 @@
-vec3 fixSeamsStretch(vec3 vec, float invRecMipSize) {
-    float scale = invRecMipSize;
-    float M = max(max(abs(vec.x), abs(vec.y)), abs(vec.z));
-    if (abs(vec.x) != M) vec.x *= scale;
-    if (abs(vec.y) != M) vec.y *= scale;
-    if (abs(vec.z) != M) vec.z *= scale;
-    return vec;
-}
-
 void addAmbient(inout psInternalData data) {
-    vec3 fixedReflDir = fixSeamsStretch(data.normalW, 1.0 - 1.0 / 4.0);
+    vec3 fixedReflDir = fixSeamsStatic(data.normalW, 1.0 - 1.0 / 4.0);
     data.diffuseLight = decodeRGBM( textureCubeLodEXT(texture_prefilteredCubeMap128, fixedReflDir, 5.0) );
 }
 

--- a/src/graphics/programlib/chunks/ambientPrefilteredCubeLod.ps
+++ b/src/graphics/programlib/chunks/ambientPrefilteredCubeLod.ps
@@ -1,5 +1,5 @@
 void addAmbient(inout psInternalData data) {
     vec3 fixedReflDir = fixSeamsStatic(data.normalW, 1.0 - 1.0 / 4.0);
-    data.diffuseLight = decodeRGBM( textureCubeLodEXT(texture_prefilteredCubeMap128, fixedReflDir, 5.0) );
+    data.diffuseLight = $DECODE( textureCubeLodEXT(texture_prefilteredCubeMap128, fixedReflDir, 5.0) ).rgb;
 }
 

--- a/src/graphics/programlib/chunks/base.vs
+++ b/src/graphics/programlib/chunks/base.vs
@@ -10,7 +10,7 @@ attribute vec4 vertex_color;
 uniform mat4 matrix_viewProjection;
 uniform mat4 matrix_model;
 uniform mat3 matrix_normal;
-$sharedUniform vec3 view_position;
+uniform vec3 view_position;
 
 varying vec3 vPositionW;
 varying vec3 vNormalW;

--- a/src/graphics/programlib/chunks/base.vs
+++ b/src/graphics/programlib/chunks/base.vs
@@ -10,7 +10,7 @@ attribute vec4 vertex_color;
 uniform mat4 matrix_viewProjection;
 uniform mat4 matrix_model;
 uniform mat3 matrix_normal;
-uniform vec3 view_position;
+$sharedUniform vec3 view_position;
 
 varying vec3 vPositionW;
 varying vec3 vNormalW;

--- a/src/graphics/programlib/chunks/fixCubemapSeamsNone.ps
+++ b/src/graphics/programlib/chunks/fixCubemapSeamsNone.ps
@@ -1,0 +1,8 @@
+vec3 fixSeams(vec3 vec, float mipmapIndex) {
+    return vec;
+}
+
+vec3 fixSeams(vec3 vec) {
+    return vec;
+}
+

--- a/src/graphics/programlib/chunks/fixCubemapSeamsNone.ps
+++ b/src/graphics/programlib/chunks/fixCubemapSeamsNone.ps
@@ -6,3 +6,6 @@ vec3 fixSeams(vec3 vec) {
     return vec;
 }
 
+vec3 fixSeamsStatic(vec3 vec, float invRecMipSize) {
+    return vec;
+}

--- a/src/graphics/programlib/chunks/fixCubemapSeamsStretch.ps
+++ b/src/graphics/programlib/chunks/fixCubemapSeamsStretch.ps
@@ -1,0 +1,28 @@
+uniform float material_cubemapSize;
+vec3 fixSeams(vec3 vec, float mipmapIndex) {
+    float scale = 1.0 - exp2(mipmapIndex) / material_cubemapSize;
+    float M = max(max(abs(vec.x), abs(vec.y)), abs(vec.z));
+    if (abs(vec.x) != M) vec.x *= scale;
+    if (abs(vec.y) != M) vec.y *= scale;
+    if (abs(vec.z) != M) vec.z *= scale;
+    return vec;
+}
+
+vec3 fixSeams(vec3 vec) {
+    float scale = 1.0 - 1.0 / material_cubemapSize;
+    float M = max(max(abs(vec.x), abs(vec.y)), abs(vec.z));
+    if (abs(vec.x) != M) vec.x *= scale;
+    if (abs(vec.y) != M) vec.y *= scale;
+    if (abs(vec.z) != M) vec.z *= scale;
+    return vec;
+}
+
+vec3 fixSeamsStatic(vec3 vec, float invRecMipSize) {
+    float scale = invRecMipSize;
+    float M = max(max(abs(vec.x), abs(vec.y)), abs(vec.z));
+    if (abs(vec.x) != M) vec.x *= scale;
+    if (abs(vec.y) != M) vec.y *= scale;
+    if (abs(vec.z) != M) vec.z *= scale;
+    return vec;
+}
+

--- a/src/graphics/programlib/chunks/gamma1_0.ps
+++ b/src/graphics/programlib/chunks/gamma1_0.ps
@@ -18,3 +18,7 @@ float gammaCorrectInput(float color) {
     return color;
 }
 
+vec4 gammaCorrectInput(vec4 color) {
+    return color;
+}
+

--- a/src/graphics/programlib/chunks/gamma2_2.ps
+++ b/src/graphics/programlib/chunks/gamma2_2.ps
@@ -6,6 +6,10 @@ float gammaCorrectInput(float color) {
     return pow(color, 2.2);
 }
 
+vec4 gammaCorrectInput(vec4 color) {
+    return vec4(pow(color.rgb, vec3(2.2)), color.a);
+}
+
 vec4 texture2DSRGB(sampler2D tex, vec2 uv) {
     vec4 rgba = texture2D(tex, uv);
     rgba.rgb = gammaCorrectInput(rgba.rgb);

--- a/src/graphics/programlib/chunks/prefilterCubemap.ps
+++ b/src/graphics/programlib/chunks/prefilterCubemap.ps
@@ -1,0 +1,92 @@
+varying vec2 vUv0;
+
+uniform samplerCube source;
+uniform vec4 params;
+
+float saturate(float x) {
+    return clamp(x, 0.0, 1.0);
+}
+
+float rnd(vec2 uv) {
+    return fract(sin(dot(uv, vec2(12.9898, 78.233) * 2.0)) * 43758.5453);
+}
+
+const float PI = 3.14159265358979;
+vec3 hemisphereSample_cos(vec2 uv, mat3 vecSpace, vec3 cubeDir, float gloss) { // cos + lerped cone size (better than just lerped)
+    float phi = uv.y * 2.0 * PI;
+    float cosTheta = sqrt(1.0 - uv.x);
+    float sinTheta = sqrt(1.0 - cosTheta * cosTheta);
+    vec3 sampleDir = vec3(cos(phi) * sinTheta, sin(phi) * sinTheta, cosTheta);
+    return normalize(mix(vecSpace * sampleDir, cubeDir, params.y));
+}
+
+vec3 hemisphereSample_phong(vec2 uv, mat3 vecSpace, vec3 cubeDir, float specPow) {
+    float phi = uv.y * 2.0 * PI;
+    float cosTheta = pow(1.0 - uv.x, 1.0 / (specPow + 1.0));
+    float sinTheta = sqrt(1.0 - cosTheta * cosTheta);
+    vec3 sampleDir = vec3(cos(phi) * sinTheta, sin(phi) * sinTheta, cosTheta);
+    return vecSpace * sampleDir;
+}
+
+mat3 matrixFromVector(vec3 n) { // frisvad
+    float a = 1.0 / (1.0 + n.z);
+    float b = -n.x * n.y * a;
+    vec3 b1 = vec3(1.0 - n.x * n.x * a, b, -n.x);
+    vec3 b2 = vec3(b, 1.0 - n.y * n.y * a, -n.y);
+    return mat3(b1, b2, n);
+}
+
+vec4 encodeRGBM(vec4 color) { // modified RGBM
+    color.rgb = pow(color.rgb, vec3(0.5));
+    color.rgb *= 1.0 / 8.0;
+
+    color.a = saturate( max( max( color.r, color.g ), max( color.b, 1.0 / 255.0 ) ) );
+    color.a = ceil(color.a * 255.0) / 255.0;
+
+    color.rgb /= color.a;
+    return color;
+}
+
+void main(void) {
+
+    vec2 st = vUv0 * 2.0 - 1.0;
+
+    if (params.w==1.0 || params.w==3.0) {
+        st = 2.0 * floor(gl_FragCoord.xy) / (params.z - 1.0) - 1.0;
+    }
+
+    float face = params.x;
+
+    vec3 vec;
+    if (face==0.0) {
+        vec = vec3(1, -st.y, -st.x);
+    } else if (face==1.0) {
+        vec = vec3(-1, -st.y, st.x);
+    } else if (face==2.0) {
+        vec = vec3(st.x, 1, st.y);
+    } else if (face==3.0) {
+        vec = vec3(st.x, -1, -st.y);
+    } else if (face==4.0) {
+        vec = vec3(st.x, -st.y, 1);
+    } else {
+        vec = vec3(-st.x, -st.y, -1);
+    }
+
+    mat3 vecSpace = matrixFromVector(normalize(vec));
+
+    vec4 color = vec4(0.0);
+    const int samples = $NUMSAMPLES;
+    vec3 vect;
+    for(int i=0; i<samples; i++) {
+        float sini = sin(float(i));
+        float cosi = cos(float(i));
+        float rand = rnd(vec2(sini, cosi));
+
+        vect = hemisphereSample_$METHOD(vec2(float(i) / float(samples), rand), vecSpace, vec, params.y);
+
+        color += textureCube(source, vect);
+    }
+    color /= float(samples);
+
+    gl_FragColor = params.w < 2.0? color : encodeRGBM(color);
+}

--- a/src/graphics/programlib/chunks/reflectionCube.ps
+++ b/src/graphics/programlib/chunks/reflectionCube.ps
@@ -1,6 +1,6 @@
 uniform samplerCube texture_cubeMap;
 uniform float material_reflectionFactor;
 void addCubemapReflection(inout psInternalData data) {
-    data.reflection += vec4($textureCubeSAMPLE(texture_cubeMap, data.reflDirW).rgb, material_reflectionFactor);
+    data.reflection += vec4($textureCubeSAMPLE(texture_cubeMap, fixSeams(data.reflDirW)).rgb, material_reflectionFactor);
 }
 

--- a/src/graphics/programlib/chunks/reflectionPrefilteredCube.ps
+++ b/src/graphics/programlib/chunks/reflectionPrefilteredCube.ps
@@ -6,15 +6,6 @@ uniform samplerCube texture_prefilteredCubeMap8;
 uniform samplerCube texture_prefilteredCubeMap4;
 uniform float material_reflectionFactor;
 
-vec3 fixSeamsStretch(vec3 vec, float mipmapIndex, float cubemapSize) {
-    float scale = 1.0 - exp2(mipmapIndex) / cubemapSize;
-    float M = max(max(abs(vec.x), abs(vec.y)), abs(vec.z));
-    if (abs(vec.x) != M) vec.x *= scale;
-    if (abs(vec.y) != M) vec.y *= scale;
-    if (abs(vec.z) != M) vec.z *= scale;
-    return vec;
-}
-
 void addCubemapReflection(inout psInternalData data) {
 
     // Unfortunately, WebGL doesn't allow us using textureCubeLod. Therefore bunch of nasty workarounds is required.
@@ -25,7 +16,7 @@ void addCubemapReflection(inout psInternalData data) {
     int index1 = int(bias);
     int index2 = int(min(bias + 1.0, 7.0));
 
-    vec3 fixedReflDir = fixSeamsStretch(data.reflDirW, bias, 128.0);
+    vec3 fixedReflDir = fixSeams(data.reflDirW, bias, 128.0);
 
     vec4 cubes[6];
     cubes[0] = textureCube(texture_prefilteredCubeMap128, fixedReflDir);

--- a/src/graphics/programlib/chunks/reflectionPrefilteredCube.ps
+++ b/src/graphics/programlib/chunks/reflectionPrefilteredCube.ps
@@ -16,7 +16,7 @@ void addCubemapReflection(inout psInternalData data) {
     int index1 = int(bias);
     int index2 = int(min(bias + 1.0, 7.0));
 
-    vec3 fixedReflDir = fixSeams(data.reflDirW, bias, 128.0);
+    vec3 fixedReflDir = fixSeams(data.reflDirW, bias);
 
     vec4 cubes[6];
     cubes[0] = textureCube(texture_prefilteredCubeMap128, fixedReflDir);
@@ -53,7 +53,7 @@ void addCubemapReflection(inout psInternalData data) {
     }else if (index2==5){ cube[1]=cubes[5];}*/
 
     vec4 cubeFinal = mix(cube[0], cube[1], fract(bias));
-    vec3 refl = decodeRGBM(cubeFinal);
+    vec3 refl = $DECODE(cubeFinal).rgb;
 
     data.reflection += vec4(refl, material_reflectionFactor);
 }

--- a/src/graphics/programlib/chunks/reflectionPrefilteredCubeLod.ps
+++ b/src/graphics/programlib/chunks/reflectionPrefilteredCubeLod.ps
@@ -8,7 +8,7 @@ void addCubemapReflection(inout psInternalData data) {
     float bias = saturate(1.0 - data.glossiness) * 5.0; // multiply by max mip level
     vec3 fixedReflDir = fixSeams(data.reflDirW, bias);
 
-    vec3 refl = decodeRGBM( textureCubeLodEXT(texture_prefilteredCubeMap128, fixedReflDir, bias) );
+    vec3 refl = $DECODE( textureCubeLodEXT(texture_prefilteredCubeMap128, fixedReflDir, bias) ).rgb;
 
     data.reflection += vec4(refl, material_reflectionFactor);
 }

--- a/src/graphics/programlib/chunks/reflectionPrefilteredCubeLod.ps
+++ b/src/graphics/programlib/chunks/reflectionPrefilteredCubeLod.ps
@@ -3,19 +3,10 @@
 uniform samplerCube texture_prefilteredCubeMap128;
 uniform float material_reflectionFactor;
 
-vec3 fixSeamsStretch(vec3 vec, float mipmapIndex, float cubemapSize) {
-    float scale = 1.0 - exp2(mipmapIndex) / cubemapSize;
-    float M = max(max(abs(vec.x), abs(vec.y)), abs(vec.z));
-    if (abs(vec.x) != M) vec.x *= scale;
-    if (abs(vec.y) != M) vec.y *= scale;
-    if (abs(vec.z) != M) vec.z *= scale;
-    return vec;
-}
-
 void addCubemapReflection(inout psInternalData data) {
 
     float bias = saturate(1.0 - data.glossiness) * 5.0; // multiply by max mip level
-    vec3 fixedReflDir = fixSeamsStretch(data.reflDirW, bias, 128.0);
+    vec3 fixedReflDir = fixSeams(data.reflDirW, bias);
 
     vec3 refl = decodeRGBM( textureCubeLodEXT(texture_prefilteredCubeMap128, fixedReflDir, bias) );
 

--- a/src/graphics/programlib/chunks/skybox.ps
+++ b/src/graphics/programlib/chunks/skybox.ps
@@ -2,6 +2,6 @@ varying vec3 vViewDir;
 uniform samplerCube texture_cubeMap;
 
 void main(void) {
-    gl_FragColor = textureCube(texture_cubeMap, vViewDir);
+    gl_FragColor = textureCube(texture_cubeMap, fixSeams(vViewDir));
 }
 

--- a/src/graphics/programlib/chunks/skyboxHDR.ps
+++ b/src/graphics/programlib/chunks/skyboxHDR.ps
@@ -2,7 +2,7 @@ varying vec3 vViewDir;
 uniform samplerCube texture_cubeMap;
 
 void main(void) {
-    vec3 color = textureCubeRGBM(texture_cubeMap, vViewDir);
+    vec3 color = $textureCubeSAMPLE(texture_cubeMap, fixSeams(vViewDir)).rgb;
     color = toneMap(color);
     color = gammaCorrectOutput(color);
     gl_FragColor = vec4(color, 1.0);

--- a/src/graphics/programlib/programlib_phong.js
+++ b/src/graphics/programlib/programlib_phong.js
@@ -302,12 +302,15 @@ pc.programlib.phong = {
             code += chunks.parallaxPS.replace(/\$UV/g, this._uvSource(options.heightMapTransform));
         }
 
+        var reflectionDecode = options.rgbmReflection? "decodeRGBM" : (options.hdrReflection? "" : "gammaCorrectInput");
+
         if (options.cubeMap) {
             if (options.prefilteredCubemap) {
                 if (useTexCubeLod) {
-                    code += chunks.reflectionPrefilteredCubeLodPS;
+                    code += chunks.reflectionPrefilteredCubeLodPS.replace(/\$DECODE/g, reflectionDecode);
+
                 } else {
-                    code += chunks.reflectionPrefilteredCubePS;
+                    code += chunks.reflectionPrefilteredCubePS.replace(/\$DECODE/g, reflectionDecode);
                 }
             } else {
                 code += chunks.reflectionCubePS.replace(/\$textureCubeSAMPLE/g,
@@ -332,9 +335,9 @@ pc.programlib.phong = {
 
         if (options.prefilteredCubemap) {
             if (useTexCubeLod) {
-                code += chunks.ambientPrefilteredCubeLodPS;
+                code += chunks.ambientPrefilteredCubeLodPS.replace(/\$DECODE/g, reflectionDecode);
             } else {
-                code += chunks.ambientPrefilteredCubePS;
+                code += chunks.ambientPrefilteredCubePS.replace(/\$DECODE/g, reflectionDecode);
             }
         } else {
             code += chunks.ambientConstantPS;

--- a/src/graphics/programlib/programlib_phong.js
+++ b/src/graphics/programlib/programlib_phong.js
@@ -63,7 +63,7 @@ pc.programlib.phong = {
         var varyings = ""; // additional varyings for map transforms
 
         var chunks = pc.shaderChunks;
-        code += chunks.baseVS;
+        code += chunks.baseVS.replace(/\$sharedUniform/g, "uniform " + device.precision);
 
         var attributes = {
             vertex_position: pc.SEMANTIC_POSITION

--- a/src/graphics/programlib/programlib_skybox.js
+++ b/src/graphics/programlib/programlib_skybox.js
@@ -1,6 +1,6 @@
 pc.programlib.skybox = {
     generateKey: function (device, options) {
-        var key = "skybox" + options.hdr + options.prefiltered + "" + options.toneMapping + "" + options.gamma;
+        var key = "skybox" + options.rgbm + " " + options.hdr + " " + options.fixSeams + "" + options.toneMapping + "" + options.gamma;
         return key;
     },
 
@@ -35,8 +35,10 @@ pc.programlib.skybox = {
                 '}'
             ].join('\n'),
             fshader: getSnippet(device, 'fs_precision') +
+                (options.fixSeams? chunks.fixCubemapSeamsStretchPS : chunks.fixCubemapSeamsNonePS) +
                 (options.hdr? chunks.defaultGamma + chunks.defaultTonemapping + chunks.rgbmPS +
-                (options.prefiltered? chunks.skyboxPrefilteredCubePS : chunks.skyboxHDRPS) : chunks.skyboxPS)
+                 chunks.skyboxHDRPS.replace(/\$textureCubeSAMPLE/g,
+                    options.rgbm? "textureCubeRGBM" : (options.hdr? "textureCube" : "textureCubeSRGB")) : chunks.skyboxPS)
         }
     }
 };

--- a/src/resources/resources_texture.js
+++ b/src/resources/resources_texture.js
@@ -187,7 +187,7 @@ pc.extend(pc.resources, function () {
             };
             texture = new pc.Texture(this._device, texOptions);
 
-            var offset = floating? 128/4 : 128;
+            var offset = 128;
             var mipWidth = width;
             var mipHeight = height;
             var mipSize;
@@ -206,7 +206,7 @@ pc.extend(pc.resources, function () {
                 }
 
                 texture._levels[i] = floating? new Float32Array(data, offset, mipSize) : new Uint8Array(data, offset, mipSize);
-                offset += mipSize;
+                offset += floating? mipSize * 4 : mipSize;
                 mipWidth = Math.max(mipWidth * 0.5, 1);
                 mipHeight = Math.max(mipHeight * 0.5, 1);
             }

--- a/src/scene/scene_phongmaterial.js
+++ b/src/scene/scene_phongmaterial.js
@@ -660,9 +660,11 @@ pc.extend(pc, function () {
 
             if (this.cubeMap) {
                 this.setParameter('texture_cubeMap', this.cubeMap);
+                this.setParameter('material_cubemapSize', this.cubeMap.width);
             }
             if (this.prefilteredCubeMap128) {
                 this.setParameter('texture_prefilteredCubeMap128', this.prefilteredCubeMap128);
+                this.setParameter('material_cubemapSize', this.prefilteredCubeMap128.width);
             }
             if (this.prefilteredCubeMap64) {
                 this.setParameter('texture_prefilteredCubeMap64', this.prefilteredCubeMap64);
@@ -796,7 +798,13 @@ pc.extend(pc, function () {
                 aoUvSet:                    this.aoUvSet,
                 useSpecular:                (!!this.specularMap) || !(this.specular.r===0 && this.specular.g===0 && this.specular.b===0)
                                             || (!!this.sphereMap) || (!!this.cubeMap) || prefilteredCubeMap,
-                hdrReflection:              prefilteredCubeMap? prefilteredCubeMap128.hdr : (this.cubeMap? this.cubeMap.hdr : (this.sphereMap? this.sphereMap.hdr : false)),
+                rgbmReflection:             prefilteredCubeMap? prefilteredCubeMap128.rgbm : (this.cubeMap? this.cubeMap.rgbm : (this.sphereMap? this.sphereMap.rgbm : false)),
+
+                hdrReflection:              prefilteredCubeMap? prefilteredCubeMap128.rgbm || prefilteredCubeMap128.format===pc.PIXELFORMAT_RGBA32F
+                                          : (this.cubeMap? this.cubeMap.rgbm || this.cubeMap.format===pc.PIXELFORMAT_RGBA32F
+                                          : (this.sphereMap? this.sphereMap.rgbm || this.sphereMap.format===pc.pc.PIXELFORMAT_RGBA32F : false)),
+
+                fixSeams:                   prefilteredCubeMap? prefilteredCubeMap128.fixCubemapSeams : (this.cubeMap? this.cubeMap.fixCubemapSeams : false),
                 prefilteredCubemap:         prefilteredCubeMap,
                 specularAA:                 this.specularAntialias,
                 conserveEnergy:             this.conserveEnergy,

--- a/src/scene/scene_phongmaterial.js
+++ b/src/scene/scene_phongmaterial.js
@@ -764,9 +764,11 @@ pc.extend(pc, function () {
                 this.setParameter('texture_prefilteredCubeMap4', scene._prefilteredCubeMap4);
             }
 
-            // backwards compatibility
-            for(i=0; i<mips.length; i++) {
-                if (mips[i].hdr) mips[i].rgbm = mips[i].fixCubemapSeams = true;
+            if (prefilteredCubeMap) {
+                // backwards compatibility
+                for(i=0; i<mips.length; i++) {
+                    if (mips[i].hdr) mips[i].rgbm = mips[i].fixCubemapSeams = true;
+                }
             }
 
             var options = {

--- a/src/scene/scene_phongmaterial.js
+++ b/src/scene/scene_phongmaterial.js
@@ -741,12 +741,12 @@ pc.extend(pc, function () {
             var prefilteredCubeMap = prefilteredCubeMap128 && prefilteredCubeMap64 && prefilteredCubeMap32
                                    && prefilteredCubeMap16 && prefilteredCubeMap8 && prefilteredCubeMap4;
 
+            var mips = [prefilteredCubeMap128, prefilteredCubeMap64, prefilteredCubeMap32, prefilteredCubeMap16, prefilteredCubeMap8, prefilteredCubeMap4];
             if (prefilteredCubeMap && device.extTextureLod && device.samplerCount < 16) {
                 // Set up hires texture to contain the whole mip chain
                 if (!prefilteredCubeMap128._prefilteredMips) {
                     prefilteredCubeMap128.autoMipmap = false;
                     var mip, face;
-                    var mips = [prefilteredCubeMap128, prefilteredCubeMap64, prefilteredCubeMap32, prefilteredCubeMap16, prefilteredCubeMap8, prefilteredCubeMap4];
                     for(mip=1; mip<6; mip++) {
                         prefilteredCubeMap128._levels[mip] = mips[mip]._levels[0];
                     }
@@ -762,6 +762,11 @@ pc.extend(pc, function () {
                 this.setParameter('texture_prefilteredCubeMap16', scene._prefilteredCubeMap16);
                 this.setParameter('texture_prefilteredCubeMap8', scene._prefilteredCubeMap8);
                 this.setParameter('texture_prefilteredCubeMap4', scene._prefilteredCubeMap4);
+            }
+
+            // backwards compatibility
+            for(i=0; i<mips.length; i++) {
+                if (mips[i].hdr) mips[i].rgbm = mips[i].fixCubemapSeams = true;
             }
 
             var options = {

--- a/src/scene/scene_scene.js
+++ b/src/scene/scene_scene.js
@@ -265,12 +265,15 @@ pc.extend(pc, function () {
             var scene = this;
             material.updateShader = function() {
                 var library = device.getProgramLibrary();
-                var shader = library.getProgram('skybox', {hdr:scene._skyboxCubeMap.hdr, prefiltered:scene._skyboxCubeMap.hdr, gamma:scene.gammaCorrection, toneMapping:scene.toneMapping});
+                var shader = library.getProgram('skybox', {rgbm:scene._skyboxCubeMap.rgbm,
+                    hdr:(scene._skyboxCubeMap.rgbm || scene._skyboxCubeMap.format===pc.PIXELFORMAT_RGBA32F),
+                    fixSeams:scene._skyboxCubeMap.fixCubemapSeams, gamma:scene.gammaCorrection, toneMapping:scene.toneMapping});
                 this.setShader(shader);
             };
 
             material.updateShader();
             material.setParameter("texture_cubeMap", this._skyboxCubeMap);
+            material.setParameter('material_cubemapSize', this._skyboxCubeMap.width);
             material.cull = pc.CULLFACE_NONE;
 
             var node = new pc.GraphNode();


### PR DESCRIPTION
Added cubemap filtering utility.
Fixed RGBA32F DDS loading.
RGBA32F textures now can be transparently used for reflection/skybox.

Added new properties to texture:
- rgbm: specifies that texture is RGBM encoded;
- fixCubemapSeams: specifies that cubemap is prepared for seam fixing.

Removed hdr property from texture. Now texture can be considered HDR based on either format or rgbm property.

Filter utility syntax is:
pc.prefilterCubemap(device, sourceCubemap, method, samples, options, chromeFix)

Usage example:
                    var options = {
                        filtered: null,
                        filteredFixed: null,
                        filteredRGBM: null,
                        filteredFixedRGBM: []
                    };
                    pc.prefilterCubemap(app.context.graphicsDevice, cubeMaps[0], 0, 256, options, true);

options.filteredFixedRGBM will now contain mip levels as separate cubemaps. Those can be inserted into material.prefilteredCubemap* properties (which later might be concatenated together into a single mipmapped cubemap by engine depending on HW).

Source cubemap is better to be RGBA32F. It can be RGBM but then quality will suffer.

All options should be either null or empty array to be filled with cubemaps.
"Fixed" means applied edge fixup. This is required when WebGL is not emulated through DX11 (= almost always required).
filteredFixedRGBM is the version that should work on absolutely every browser.

There are currently 2 filtering methods: simple and blinn-phong importance sampling. Difference is on the pic.

Simple is fast (can be done in-game), but may produce a bit "flat" specular highlights. Usually 256 samples is enough for it.

Importance sampled requires more samples, 4096 looks fine, and it takes 1-2 sec, but looks much closer to reference.

![cubez2](https://cloud.githubusercontent.com/assets/7008423/5689406/53f30fa6-9875-11e4-9a47-81133ec58ad4.jpg)

