### PR TITLE
Changed tag opening/ending signs to HTML Entities

### DIFF
--- a/src/asset/asset_asset.js
+++ b/src/asset/asset_asset.js
@@ -73,7 +73,7 @@ pc.extend(pc.asset, function () {
         * @returns {String} The URL
         * @example
         * var assets = app.assets.find("My Image", pc.asset.ASSET_IMAGE);
-        * var img = "<img src='" + assets[0].getFileUrl() + "'></img>";
+        * var img = "&lt;img src='" + assets[0].getFileUrl() + "'&gt;";
         */
         getFileUrl: function () {
             if (!this.file) {


### PR DESCRIPTION
As img element was rendered in API Reference (http://developer.playcanvas.com/en/engine/api/stable/symbols/pc.asset.Asset.html#getFileUrl), instead of being shown as code.
Removed img's end tag, it isn't required in HTML.