### PR TITLE
Shadow map update rate control

### DIFF
--- a/src/framework/components/light/light_component.js
+++ b/src/framework/components/light/light_component.js
@@ -49,6 +49,7 @@ pc.extend(pc, function () {
         this.on("set_innerConeAngle", this.onSetInnerConeAngle, this);
         this.on("set_outerConeAngle", this.onSetOuterConeAngle, this);
         this.on("set_falloffMode", this.onSetFalloffMode, this);
+        this.on("set_shadowUpdateMode", this.onSetShadowUpdateMode, this);
     };
 
     LightComponent = pc.inherits(LightComponent, pc.Component);
@@ -87,6 +88,7 @@ pc.extend(pc, function () {
             this.onSetInnerConeAngle("innerConeAngle", this.innerConeAngle, this.innerConeAngle);
             this.onSetOuterConeAngle("outerConeAngle", this.outerConeAngle, this.outerConeAngle);
             this.onSetFalloffMode("falloffMode", this.falloffMode, this.falloffMode);
+            this.onSetShadowUpdateMode("shadowUpdateMode", this.shadowUpdateMode, this.shadowUpdateMode);
 
             if (this.enabled && this.entity.enabled) {
                 this.onEnable();
@@ -146,6 +148,10 @@ pc.extend(pc, function () {
             if (this.data.type === 'point' || this.data.type === 'spot') {
                 this.light.setFalloffMode(newValue);
             }
+        },
+
+        onSetShadowUpdateMode: function (name, oldValue, newValue) {
+            this.light.shadowUpdateMode = newValue;
         },
 
         onEnable: function () {

--- a/src/framework/components/light/light_component.js
+++ b/src/framework/components/light/light_component.js
@@ -97,6 +97,10 @@ pc.extend(pc, function () {
             }
         },
 
+        updateShadow: function() {
+            this.light.updateShadow();
+        },
+
         onSetCastShadows: function (name, oldValue, newValue) {
             this.light.setCastShadows(newValue);
         },

--- a/src/framework/components/light/light_data.js
+++ b/src/framework/components/light/light_data.js
@@ -14,6 +14,7 @@ pc.extend(pc, function () {
         this.innerConeAngle = 40;
         this.outerConeAngle = 45;
         this.falloffMode = pc.LIGHTFALLOFF_LINEAR;
+        this.shadowUpdateMode = pc.SHADOWUPDATE_REALTIME;
 
         // Non-serialized
         this.light = null;

--- a/src/framework/components/light/light_system.js
+++ b/src/framework/components/light/light_system.js
@@ -163,6 +163,9 @@ pc.extend(pc, function () {
                 type: ['point', 'spot']
             }
         }, {
+            name: "shadowUpdateMode",
+            exposed: false
+        }, {
             name: "innerConeAngle",
             displayName: "Inner Cone Angle",
             description: "Spotlight inner cone angle",
@@ -224,7 +227,7 @@ pc.extend(pc, function () {
             var implementation = this._createImplementation(data.type);
             implementation.initialize(component, data);
 
-            properties = ['type', 'light', 'model', 'enabled', 'color', 'intensity', 'range', 'falloffMode', 'innerConeAngle', 'outerConeAngle', 'castShadows', 'shadowDistance', 'shadowResolution', 'shadowBias', 'normalOffsetBias'];
+            properties = ['type', 'light', 'model', 'enabled', 'color', 'intensity', 'range', 'falloffMode', 'innerConeAngle', 'outerConeAngle', 'castShadows', 'shadowDistance', 'shadowResolution', 'shadowUpdateMode', 'shadowBias', 'normalOffsetBias'];
             LightComponentSystem._super.initializeComponentData.call(this, component, data, properties);
         },
 
@@ -271,6 +274,7 @@ pc.extend(pc, function () {
                 shadowDistance: light.shadowDistance,
                 shadowResolution: light.shadowResolution,
                 falloffMode: light.falloffMode,
+                shadowUpdateMode: light.shadowUpdateMode,
                 shadowBias: light.shadowBias,
                 normalOffsetBias: light.normalOffsetBias
             };

--- a/src/scene/scene_forwardrenderer.js
+++ b/src/scene/scene_forwardrenderer.js
@@ -564,7 +564,8 @@ pc.extend(pc, function () {
                 var light = lights[i];
                 var type = light.getType();
 
-                if (light.getCastShadows() && light.getEnabled()) {
+                if (light.getCastShadows() && light.getEnabled() && light.shadowUpdateMode!==pc.SHADOW_UPDATE_NONE) {
+                    if (light.shadowUpdateMode===pc.SHADOW_UPDATE_THISFRAME) light.shadowUpdateMode = pc.SHADOW_UPDATE_NONE;
                     var shadowCam = getShadowCamera(device, light);
                     var passes = 1;
                     var pass;

--- a/src/scene/scene_forwardrenderer.js
+++ b/src/scene/scene_forwardrenderer.js
@@ -564,8 +564,8 @@ pc.extend(pc, function () {
                 var light = lights[i];
                 var type = light.getType();
 
-                if (light.getCastShadows() && light.getEnabled() && light.shadowUpdateMode!==pc.SHADOW_UPDATE_NONE) {
-                    if (light.shadowUpdateMode===pc.SHADOW_UPDATE_THISFRAME) light.shadowUpdateMode = pc.SHADOW_UPDATE_NONE;
+                if (light.getCastShadows() && light.getEnabled() && light.shadowUpdateMode!==pc.SHADOWUPDATE_NONE) {
+                    if (light.shadowUpdateMode===pc.SHADOWUPDATE_THISFRAME) light.shadowUpdateMode = pc.SHADOWUPDATE_NONE;
                     var shadowCam = getShadowCamera(device, light);
                     var passes = 1;
                     var pass;

--- a/src/scene/scene_light.js
+++ b/src/scene/scene_light.js
@@ -37,7 +37,7 @@ pc.extend(pc, function () {
         this._shadowResolution = 1024;
         this._shadowBias = -0.0005;
         this._normalOffsetBias = 0.0;
-        this.shadowUpdateMode = pc.SHADOW_UPDATE_REALTIME;
+        this.shadowUpdateMode = pc.SHADOWUPDATE_REALTIME;
 
         this._scene = null;
         this._node = null;
@@ -448,8 +448,8 @@ pc.extend(pc, function () {
         },
 
         updateShadow: function() {
-            if (this.shadowUpdateMode!==pc.SHADOW_UPDATE_REALTIME) {
-                this.shadowUpdateMode = pc.SHADOW_UPDATE_THISFRAME;
+            if (this.shadowUpdateMode!==pc.SHADOWUPDATE_REALTIME) {
+                this.shadowUpdateMode = pc.SHADOWUPDATE_THISFRAME;
             }
         }
     };

--- a/src/scene/scene_light.js
+++ b/src/scene/scene_light.js
@@ -37,6 +37,7 @@ pc.extend(pc, function () {
         this._shadowResolution = 1024;
         this._shadowBias = -0.0005;
         this._normalOffsetBias = 0.0;
+        this.shadowUpdateMode = pc.SHADOW_UPDATE_REALTIME;
 
         this._scene = null;
         this._node = null;
@@ -64,6 +65,7 @@ pc.extend(pc, function () {
             clone.setAttenuationStart(this.getAttenuationStart());
             clone.setAttenuationEnd(this.getAttenuationEnd());
             clone.setFalloffMode(this.getFalloffMode());
+            clone.shadowUpdateMode = this.shadowUpdateMode;
 
             // Spot properties
             clone.setInnerConeAngle(this.getInnerConeAngle());
@@ -443,6 +445,12 @@ pc.extend(pc, function () {
          */
         setType: function (type) {
             this._type = type;
+        },
+
+        updateShadow: function() {
+            if (this.shadowUpdateMode!==pc.SHADOW_UPDATE_REALTIME) {
+                this.shadowUpdateMode = pc.SHADOW_UPDATE_THISFRAME;
+            }
         }
     };
 

--- a/src/scene/scene_scene.js
+++ b/src/scene/scene_scene.js
@@ -133,9 +133,9 @@
         TONEMAP_LINEAR: 0,
         TONEMAP_FILMIC: 1,
 
-        SHADOW_UPDATE_NONE: 0,
-        SHADOW_UPDATE_THISFRAME: 1,
-        SHADOW_UPDATE_REALTIME: 2
+        SHADOWUPDATE_NONE: 0,
+        SHADOWUPDATE_THISFRAME: 1,
+        SHADOWUPDATE_REALTIME: 2
     };
 
     pc.extend(pc, enums);

--- a/src/scene/scene_scene.js
+++ b/src/scene/scene_scene.js
@@ -131,7 +131,11 @@
         SPECULAR_BLINN: 1,
 
         TONEMAP_LINEAR: 0,
-        TONEMAP_FILMIC: 1
+        TONEMAP_FILMIC: 1,
+
+        SHADOW_UPDATE_NONE: 0,
+        SHADOW_UPDATE_THISFRAME: 1,
+        SHADOW_UPDATE_REALTIME: 2
     };
 
     pc.extend(pc, enums);


### PR DESCRIPTION
Not every shadow map has to be updated each frame. Some can be updated less often and some shouldn’t even update unless shadow-casting objects or light move, or other game event happens. New API:
- light.shadowUpdateMode
- light.updateShadow()

Mode can be:
- pc.SHADOW_UPDATE_NONE (don't update shadow map)
- pc.SHADOW_UPDATE_THISFRAME (this is set when you call updateShadow() - refreshes shadows at this frame only)
- pc.SHADOW_UPDATE_REALTIME (this is the default value/behaviour)

Note, that API is only for scene_light, it's not exposed in light component, and probably shouldn't.

test scene:
http://playcanvas.com/designer/339455/scene/356052