### PR TITLE
Graphics fixes from Seemore

### DIFF
--- a/src/graphics/programlib/chunks/emissiveTex.ps
+++ b/src/graphics/programlib/chunks/emissiveTex.ps
@@ -1,5 +1,5 @@
 uniform sampler2D texture_emissiveMap;
 vec3 getEmission(inout psInternalData data) {
-    return texture2D(texture_emissiveMap, $UV).$CH;
+    return $texture2DSAMPLE(texture_emissiveMap, $UV).$CH;
 }
 

--- a/src/graphics/programlib/chunks/emissiveTexConst.ps
+++ b/src/graphics/programlib/chunks/emissiveTexConst.ps
@@ -1,6 +1,6 @@
 uniform sampler2D texture_emissiveMap;
 uniform vec3 material_emissive;
 vec3 getEmission(inout psInternalData data) {
-    return texture2D(texture_emissiveMap, $UV).$CH * material_emissive;
+    return $texture2DSAMPLE(texture_emissiveMap, $UV).$CH * material_emissive;
 }
 

--- a/src/graphics/programlib/programlib_phong.js
+++ b/src/graphics/programlib/programlib_phong.js
@@ -37,7 +37,7 @@ pc.programlib.phong = {
         return id==0? "vUv" + uv : ("vUv"+uv+"_" + id);
     },
 
-    _addMap: function(p, options, chunks, uvOffset, subCode) {
+    _addMap: function(p, options, chunks, uvOffset, subCode, format) {
         var mname = p + "Map";
         if (options[mname]) {
             var tname = mname + "Transform";
@@ -50,6 +50,10 @@ pc.programlib.phong = {
                 } else {
                     subCode = chunks[p + "TexPS"];
                 }
+            }
+            if (format!==undefined) {
+                var fmt = format===0? "texture2DSRGB" : (format===1? "texture2DRGBM" : "texture2D");
+                subCode = subCode.replace(/\$texture2DSAMPLE/g, fmt);
             }
             return subCode.replace(/\$UV/g, uv).replace(/\$CH/g, options[cname]);
         } else {
@@ -269,7 +273,7 @@ pc.programlib.phong = {
 
         code += this._addMap("diffuse", options, chunks, uvOffset);
         code += this._addMap("opacity", options, chunks, uvOffset);
-        code += this._addMap("emissive", options, chunks, uvOffset);
+        code += this._addMap("emissive", options, chunks, uvOffset, null, options.emissiveFormat);
 
         if (options.useSpecular) {
             if (options.specularAA && options.normalMap) {
@@ -398,7 +402,7 @@ pc.programlib.phong = {
         if (options.modulateAmbient) {
             code += "   data.diffuseLight *= material_ambient;\n"
         }
-        if (options.aoMap) {
+        if (options.aoMap && !options.occludeDirect) {
                 code += "    applyAO(data);\n";
         }
 
@@ -474,8 +478,13 @@ pc.programlib.phong = {
         }
         code += "\n";
 
-        if (options.aoMap && options.occludeSpecular) {
+        if (options.aoMap) {
+            if (options.occludeDirect) {
+                    code += "    applyAO(data);\n";
+            }
+            if (options.occludeSpecular) {
                 code += "    occludeSpecular(data);\n";
+            }
         }
 
         code += chunks.endPS;

--- a/src/math/math_math.js
+++ b/src/math/math_math.js
@@ -250,7 +250,7 @@ pc.math.bytesToInt = pc.math.bytesToInt32;
 // IE doesn't have native log2
 if (!Math.log2) {
     Math.log2 = function(x) {
-        return Math.log(x) * this.INV_LOG2;
+        return Math.log(x) * pc.math.INV_LOG2;
     }
 }
 

--- a/src/scene/scene_forwardrenderer.js
+++ b/src/scene/scene_forwardrenderer.js
@@ -623,8 +623,10 @@ pc.extend(pc, function () {
                         shadowCam.setAspectRatio(1);
                         shadowCam.setFov(light.getOuterConeAngle() * 2);
 
-                        var lightWtm = light._node.worldTransform;
-                        shadowCamWtm.mul2(lightWtm, camToLight);
+                        var spos = light._node.getPosition();
+                        var srot = light._node.getRotation();
+                        shadowCamWtm.setTRS(spos, srot, pc.Vec3.ONE);
+                        shadowCamWtm.mul2(shadowCamWtm, camToLight);
                     } else if (type === pc.LIGHTTYPE_POINT) {
                         shadowCam.setProjection(pc.PROJECTION_PERSPECTIVE);
                         shadowCam.setNearClip(light.getAttenuationEnd() / 1000);

--- a/src/scene/scene_phongmaterial.js
+++ b/src/scene/scene_phongmaterial.js
@@ -211,6 +211,8 @@ pc.extend(pc, function () {
             this.emissiveMapTint = false;
             this.emissiveIntensity = 1;
 
+            this.occludeDirect = false;
+
             _endProperties(this);
 
             // Array to pass uniforms to renderer
@@ -516,9 +518,11 @@ pc.extend(pc, function () {
 
                 fixSeams:                   prefilteredCubeMap? prefilteredCubeMap128.fixCubemapSeams : (this.cubeMap? this.cubeMap.fixCubemapSeams : false),
                 prefilteredCubemap:         prefilteredCubeMap,
+                emissiveFormat:             this.emissiveMap? (this.emissiveMap.rgbm? 1 : (this.emissiveMap.format===pc.PIXELFORMAT_RGBA32F? 2 : 0)) : null,
                 specularAA:                 this.specularAntialias,
                 conserveEnergy:             this.conserveEnergy,
                 occludeSpecular:            this.occludeSpecular,
+                occludeDirect:              this.occludeDirect,
                 shadingModel:               this.shadingModel,
                 fresnelModel:               this.fresnelModel,
                 packedNormal:               this.normalMap? this.normalMap._compressed : false,


### PR DESCRIPTION
Github still refuses to properly list shader diffs.

- Emissive map can be now sRGB/float HDR/RGBM (fixes wrong gamma look of emissive maps)
- material.occludeDirect - non-PBR but useful trick to allow AO occlude direct lighting. It's useful because you don't always have accurate real-time shadows for small details.
- IE11 Math.log2 fix (it didn't work at all before)
- Shadow map camera matrix fix (ignore scale)
