### PR TITLE
Cubemap prefiltering update

### DIFF
--- a/src/graphics/graphics_prefiltercubemap.js
+++ b/src/graphics/graphics_prefiltercubemap.js
@@ -42,7 +42,7 @@ pc.extend(pc, (function () {
         var rgbmSource = sourceCubemap.rgbm;
         var format = sourceCubemap.format;
 
-        var cmapsList = [[], options.filteredFixed, options.filteredRGBM, options.filteredFixedRGBM];
+        var cmapsList = [[], options.filteredFixed, options.filteredRgbm, options.filteredFixedRgbm];
         var gloss = method===0? [0.9, 0.85, 0.7, 0.4, 0.25] : [512, 128, 32, 8, 2]; // TODO: calc more correct values depending on mip
         var mipSize = [64, 32, 16, 8, 4]; // TODO: make non-static?
         var mips = 5;
@@ -126,8 +126,8 @@ pc.extend(pc, (function () {
         }
         options.sourceCubemap = sourceCubemap;
 
-        var sourceCubemapRGBM = null;
-        if (!rgbmSource && options.filteredFixedRGBM) {
+        var sourceCubemapRgbm = null;
+        if (!rgbmSource && options.filteredFixedRgbm) {
             var nextCubemap = new pc.gfx.Texture(device, {
                 cubemap: true,
                 rgbm: true,
@@ -154,7 +154,7 @@ pc.extend(pc, (function () {
                 pc.drawQuadWithShader(device, targ, shader2);
                 syncToCpu(device, targ, face);
             }
-            sourceCubemapRGBM = nextCubemap;
+            sourceCubemapRgbm = nextCubemap;
         }
 
         var unblurredGloss = method===0? 1 : 2048;
@@ -246,15 +246,15 @@ pc.extend(pc, (function () {
             options.singleFilteredFixed = cubemap;
         }
 
-        if (cpuSync && options.singleFilteredFixedRGBM && options.filteredFixedRGBM) {
+        if (cpuSync && options.singlefilteredFixedRgbm && options.filteredFixedRgbm) {
             var mips = [
-                        sourceCubemapRGBM,
-                        options.filteredFixedRGBM[0],
-                        options.filteredFixedRGBM[1],
-                        options.filteredFixedRGBM[2],
-                        options.filteredFixedRGBM[3],
-                        options.filteredFixedRGBM[4],
-                        options.filteredFixedRGBM[5]
+                        sourceCubemapRgbm,
+                        options.filteredFixedRgbm[0],
+                        options.filteredFixedRgbm[1],
+                        options.filteredFixedRgbm[2],
+                        options.filteredFixedRgbm[3],
+                        options.filteredFixedRgbm[4],
+                        options.filteredFixedRgbm[5]
                         ];
             var cubemap = new pc.gfx.Texture(device, {
                 cubemap: true,
@@ -272,7 +272,7 @@ pc.extend(pc, (function () {
             cubemap.minFilter = pc.FILTER_LINEAR_MIPMAP_LINEAR;
             cubemap.magFilter = pc.FILTER_LINEAR;
             cubemap._prefilteredMips = true;
-            options.singleFilteredFixedRGBM = cubemap;
+            options.singlefilteredFixedRgbm = cubemap;
         }
     }
 

--- a/src/graphics/graphics_prefiltercubemap.js
+++ b/src/graphics/graphics_prefiltercubemap.js
@@ -28,7 +28,6 @@ pc.extend(pc, (function () {
         var cpuSync = options.cpuSync;
         var chromeFix = options.chromeFix;
 
-        console.log("Filter 1")
         var chunks = pc.shaderChunks;
         var shader = chunks.createShaderFromCode(device, chunks.fullscreenQuadVS, chunks.rgbmPS +
             chunks.prefilterCubemapPS.
@@ -52,7 +51,6 @@ pc.extend(pc, (function () {
 
         var rgbFormat = format===pc.PIXELFORMAT_R8_G8_B8;
         if (rgbFormat && cpuSync) {
-            console.log("Filter 2")
             // WebGL can't read non-RGBA pixels
             format = pc.PIXELFORMAT_R8_G8_B8_A8;
             var nextCubemap = new pc.gfx.Texture(device, {
@@ -85,12 +83,10 @@ pc.extend(pc, (function () {
         }
 
         if (size > 128) {
-            console.log("Filter 3")
             // Downsample to 128 first
             var log128 = Math.round(Math.log2(128));
             var logSize = Math.round(Math.log2(size));
             var steps = logSize - log128;
-            console.log("Filter 3.1 " + logSize+" "+log128+" "+steps);
             var nextCubemap;
             for(i=0; i<steps; i++) {
                 size = sourceCubemap.width * 0.5;
@@ -121,9 +117,7 @@ pc.extend(pc, (function () {
 
                     if (chromeFix) fixChrome();
                     pc.drawQuadWithShader(device, targ, shader2);
-                    console.log("Filter 3.25 "+i)
                     if (i===steps-1 && cpuSync) {
-                        console.log("Filter 3.5")
                         syncToCpu(device, targ, face);
                     }
                 }
@@ -134,7 +128,6 @@ pc.extend(pc, (function () {
 
         var sourceCubemapRGBM = null;
         if (!rgbmSource && options.filteredFixedRGBM) {
-            console.log("Filter x")
             var nextCubemap = new pc.gfx.Texture(device, {
                 cubemap: true,
                 rgbm: true,
@@ -170,7 +163,6 @@ pc.extend(pc, (function () {
 
         // Initialize textures
         for(i=0; i<mips; i++) {
-            console.log("Filter 4")
             for(pass=startPass; pass<cmapsList.length; pass++) {
                 if (cmapsList[pass]!=null) {
                     cmapsList[pass][i] = new pc.gfx.Texture(device, {
@@ -197,7 +189,6 @@ pc.extend(pc, (function () {
         // Pass 2: filter + encode to RGBM
         // Pass 3: filter + edge fixup + encode to RGBM
         for(pass=startPass; pass<cmapsList.length; pass++) {
-            console.log("Filter 5")
             if (cmapsList[pass]!=null) {
                 if (pass>1 && rgbmSource) {
                     // already RGBM
@@ -229,7 +220,6 @@ pc.extend(pc, (function () {
         options.filtered = cmapsList[0];
 
         if (cpuSync && options.singleFilteredFixed) {
-            console.log("Filter 6")
             var mips = [sourceCubemap,
                         options.filteredFixed[0],
                         options.filteredFixed[1],
@@ -257,7 +247,6 @@ pc.extend(pc, (function () {
         }
 
         if (cpuSync && options.singleFilteredFixedRGBM && options.filteredFixedRGBM) {
-            console.log("Filter 7.0")
             var mips = [
                         sourceCubemapRGBM,
                         options.filteredFixedRGBM[0],
@@ -267,7 +256,6 @@ pc.extend(pc, (function () {
                         options.filteredFixedRGBM[4],
                         options.filteredFixedRGBM[5]
                         ];
-                        console.log("Filter 7.1")
             var cubemap = new pc.gfx.Texture(device, {
                 cubemap: true,
                 rgbm: true,
@@ -277,19 +265,15 @@ pc.extend(pc, (function () {
                 height: 128,
                 autoMipmap: false
             });
-            console.log("Filter 7.2")
             for(i=0; i<6; i++) {
                 cubemap._levels[i] = mips[i]._levels[0];
             }
-            console.log("Filter 7.3")
             cubemap.upload();
             cubemap.minFilter = pc.FILTER_LINEAR_MIPMAP_LINEAR;
             cubemap.magFilter = pc.FILTER_LINEAR;
             cubemap._prefilteredMips = true;
             options.singleFilteredFixedRGBM = cubemap;
         }
-
-        console.log("Filter 7")
     }
 
     return {

--- a/src/graphics/graphics_texture.js
+++ b/src/graphics/graphics_texture.js
@@ -361,7 +361,7 @@ pc.extend(pc, function () {
             this._needsUpload = true;
         },
 
-        getDDS: function () {
+        getDds: function () {
             if (this.format!=pc.PIXELFORMAT_R8_G8_B8_A8) {
                 console.error("This format is not implemented yet");
             }

--- a/src/graphics/programlib/chunks/outputCubemap.frag
+++ b/src/graphics/programlib/chunks/outputCubemap.frag
@@ -3,6 +3,21 @@ varying vec2 vUv0;
 uniform samplerCube source;
 uniform vec4 params;
 
+float saturate(float x) {
+    return clamp(x, 0.0, 1.0);
+}
+
+vec4 encodeRGBM(vec4 color) { // modified RGBM
+    color.rgb = pow(color.rgb, vec3(0.5));
+    color.rgb *= 1.0 / 8.0;
+
+    color.a = saturate( max( max( color.r, color.g ), max( color.b, 1.0 / 255.0 ) ) );
+    color.a = ceil(color.a * 255.0) / 255.0;
+
+    color.rgb /= color.a;
+    return color;
+}
+
 void main(void) {
 
     vec2 st = vUv0 * 2.0 - 1.0;
@@ -24,5 +39,6 @@ void main(void) {
     }
 
     gl_FragColor = textureCube(source, vec);
+    if (params.w >= 2.0) gl_FragColor = encodeRGBM(gl_FragColor);
 }
 


### PR DESCRIPTION
Fixes some bugs from the original version + covers some cases not accounted before.

Generating RGBM prefiltered cubemap from any input cubemap:

                    var options = {
                        device: app.context.graphicsDevice,
                        sourceCubemap: cubeMap,
                        method: 1,
                        samples: 4096,
                        cpuSync: true,
                        filtered: [],
                        filteredFixed: [],
                        filteredFixedRgbm: [],
                        singleFilteredFixed: true,
                        singleFilteredFixedRgbm: true
                    };
                    pc.prefilterCubemap(options);

Now **options.singleFilteredFixedRgbm** is the prefiltered texture. Use **options.singleFilteredFixedRgbm.getDds()** to acquire a DDS file ArrayBuffer you can save to server and load later.