### PR TITLE
Correct varyings

### DIFF
--- a/src/graphics/programlib/chunks/base.frag
+++ b/src/graphics/programlib/chunks/base.frag
@@ -1,18 +1,7 @@
 
-// Compiler should remove unneeded stuff
 uniform vec3 view_position;
 
 uniform vec3 light_globalAmbient;
-
-varying vec3 vPositionW;
-varying vec3 vNormalW;
-varying vec3 vTangentW;
-varying vec3 vBinormalW;
-varying vec2 vUv0;
-varying vec2 vUv1;
-//varying vec4 vVertexColor;
-varying vec3 vNormalV;
-varying vec4 vMainShadowUv;
 
 struct psInternalData {
     vec3 albedo;

--- a/src/graphics/programlib/chunks/base.vert
+++ b/src/graphics/programlib/chunks/base.vert
@@ -1,5 +1,4 @@
 
-// Compiler should remove unneeded stuff
 attribute vec3 vertex_position;
 attribute vec3 vertex_normal;
 attribute vec4 vertex_tangent;
@@ -10,16 +9,6 @@ attribute vec4 vertex_color;
 uniform mat4 matrix_viewProjection;
 uniform mat4 matrix_model;
 uniform mat3 matrix_normal;
-
-varying vec3 vPositionW;
-varying vec3 vNormalW;
-varying vec3 vTangentW;
-varying vec3 vBinormalW;
-varying vec2 vUv0;
-varying vec2 vUv1;
-//varying vec4 vVertexColor;
-varying vec3 vNormalV;
-varying vec4 vMainShadowUv;
 
 struct vsInternalData {
     vec3 positionW;


### PR DESCRIPTION
Now shaders don't have unused varyings, as many compilers don't remove them. Should reduce cases of https://github.com/playcanvas/engine/issues/71
Additionally it should fix this: https://github.com/playcanvas/engine/issues/209