### PR TITLE
Make gamma/toneMap don't affect global pc scope

### DIFF
--- a/build/dependencies.txt
+++ b/build/dependencies.txt
@@ -51,7 +51,6 @@
 ../src/graphics/graphics_simpleposteffect.js
 ../src/graphics/graphics_prefiltercubemap.js
 ../src/graphics/programlib/chunks/generated_shaderchunks.js
-../src/graphics/graphics_defaultShaderChunks.js
 ../src/graphics/programlib/programlib_programlib.js
 ../src/graphics/programlib/programlib_basic.js
 ../src/graphics/programlib/programlib_depth.js

--- a/src/backwards_compatibility.js
+++ b/src/backwards_compatibility.js
@@ -66,8 +66,6 @@ pc.fw = {
 };
 
 pc.extend(pc.gfx, {
-    defaultGamma: pc.defaultGamma,
-    defaultTonemapping: pc.defaultTonemapping,
     drawQuadWithShader: pc.drawQuadWithShader,
     precalculatedTangents: pc.precalculatedTangents,
     programlib: pc.programlib,

--- a/src/graphics/graphics_defaultShaderChunks.js
+++ b/src/graphics/graphics_defaultShaderChunks.js
@@ -1,9 +1,0 @@
-pc.extend(pc.shaderChunks, (function () {
-    'use strict';
-
-    return {
-        defaultGamma: pc.shaderChunks.gamma1_0PS,
-        defaultTonemapping: pc.shaderChunks.tonemappingLinearPS
-    };
-}()));
-

--- a/src/graphics/programlib/programlib_particle.js
+++ b/src/graphics/programlib/programlib_particle.js
@@ -51,9 +51,9 @@ pc.programlib.particle = {
         }
 
         if ((options.normal==0) && (options.fog=="none")) options.srgb = false; // don't have to perform all gamma conversions when no lighting and fogging is used
-        fshader += options.srgb ? chunk.gamma2_2PS : chunk.gamma1_0PS;
+        fshader += this.gammaCode(options.gamma);
         fshader += "struct psInternalData {float dummy;};\n";
-        fshader += chunk.defaultTonemapping;
+        fshader += this.tonemapCode(options.toneMap);
 
         if (options.fog === 'linear') {
             fshader += chunk.fogLinearPS;

--- a/src/graphics/programlib/programlib_particle.js
+++ b/src/graphics/programlib/programlib_particle.js
@@ -51,9 +51,9 @@ pc.programlib.particle = {
         }
 
         if ((options.normal==0) && (options.fog=="none")) options.srgb = false; // don't have to perform all gamma conversions when no lighting and fogging is used
-        fshader += this.gammaCode(options.gamma);
+        fshader += pc.programlib.gammaCode(options.gamma);
         fshader += "struct psInternalData {float dummy;};\n";
-        fshader += this.tonemapCode(options.toneMap);
+        fshader += pc.programlib.tonemapCode(options.toneMap);
 
         if (options.fog === 'linear') {
             fshader += chunk.fogLinearPS;

--- a/src/graphics/programlib/programlib_phong.js
+++ b/src/graphics/programlib/programlib_phong.js
@@ -390,8 +390,8 @@ pc.programlib.phong = {
             }
         }
 
-        code += this.gammaCode(options.gamma);
-        code += this.tonemapCode(options.toneMap);
+        code += pc.programlib.gammaCode(options.gamma);
+        code += pc.programlib.tonemapCode(options.toneMap);
 
         if (options.fog === 'linear') {
             code += chunks.fogLinearPS;

--- a/src/graphics/programlib/programlib_phong.js
+++ b/src/graphics/programlib/programlib_phong.js
@@ -390,8 +390,8 @@ pc.programlib.phong = {
             }
         }
 
-        code += chunks.defaultGamma;
-        code += chunks.defaultTonemapping;
+        code += this.gammaCode(options.gamma);
+        code += this.tonemapCode(options.toneMap);
 
         if (options.fog === 'linear') {
             code += chunks.fogLinearPS;

--- a/src/graphics/programlib/programlib_programlib.js
+++ b/src/graphics/programlib/programlib_programlib.js
@@ -181,12 +181,12 @@ pc.programlib = {
         }
 
         return code;
-    }
+    },
 
     gammaCode: function (value) {
         return value===pc.GAMMA_NONE? pc.shaderChunks.gamma1_0PS :
               (value===pc.GAMMA_SRGBFAST? pc.shaderChunks.gamma2_2FastPS : pc.shaderChunks.gamma2_2PS);
-    }
+    },
 
     tonemapCode: function (value) {
         return value ? pc.shaderChunks.tonemappingFilmicPS : pc.shaderChunks.tonemappingLinearPS;

--- a/src/graphics/programlib/programlib_programlib.js
+++ b/src/graphics/programlib/programlib_programlib.js
@@ -182,4 +182,14 @@ pc.programlib = {
 
         return code;
     }
+
+    gammaCode: function (value) {
+        return value===pc.GAMMA_NONE? pc.shaderChunks.gamma1_0PS :
+              (value===pc.GAMMA_SRGBFAST? pc.shaderChunks.gamma2_2FastPS : pc.shaderChunks.gamma2_2PS);
+    }
+
+    tonemapCode: function (value) {
+        return value ? pc.shaderChunks.tonemappingFilmicPS : pc.shaderChunks.tonemappingLinearPS;
+    }
+
 };

--- a/src/graphics/programlib/programlib_skybox.js
+++ b/src/graphics/programlib/programlib_skybox.js
@@ -36,7 +36,7 @@ pc.programlib.skybox = {
             ].join('\n'),
             fshader: getSnippet(device, 'fs_precision') +
                 (options.fixSeams? chunks.fixCubemapSeamsStretchPS : chunks.fixCubemapSeamsNonePS) +
-                (options.hdr? this.gammaCode(options.gamma) + this.tonemapCode(options.toneMapping) + chunks.rgbmPS +
+                (options.hdr? pc.programlib.gammaCode(options.gamma) + pc.programlib.tonemapCode(options.toneMapping) + chunks.rgbmPS +
                  chunks.skyboxHDRPS.replace(/\$textureCubeSAMPLE/g,
                     options.rgbm? "textureCubeRGBM" : (options.hdr? "textureCube" : "textureCubeSRGB")) : chunks.skyboxPS)
         }

--- a/src/graphics/programlib/programlib_skybox.js
+++ b/src/graphics/programlib/programlib_skybox.js
@@ -36,7 +36,7 @@ pc.programlib.skybox = {
             ].join('\n'),
             fshader: getSnippet(device, 'fs_precision') +
                 (options.fixSeams? chunks.fixCubemapSeamsStretchPS : chunks.fixCubemapSeamsNonePS) +
-                (options.hdr? chunks.defaultGamma + chunks.defaultTonemapping + chunks.rgbmPS +
+                (options.hdr? this.gammaCode(options.gamma) + this.tonemapCode(options.toneMapping) + chunks.rgbmPS +
                  chunks.skyboxHDRPS.replace(/\$textureCubeSAMPLE/g,
                     options.rgbm? "textureCubeRGBM" : (options.hdr? "textureCube" : "textureCubeSRGB")) : chunks.skyboxPS)
         }

--- a/src/scene/scene_particleemitter.js
+++ b/src/scene/scene_particleemitter.js
@@ -627,7 +627,7 @@ pc.extend(pc, function() {
                     alignToMotion: this.emitter.alignToMotion,
                     soft: this.emitter.depthSoftening && this.emitter._hasDepthTarget(),
                     mesh: this.emitter.useMesh,
-                    srgb: this.emitter.scene ? this.emitter.scene.gammaCorrection : false,
+                    gamma: this.emitter.scene ? this.emitter.scene.gammaCorrection : 0,
                     toneMap: this.emitter.scene ? this.emitter.scene.toneMapping : 0,
                     fog: this.emitter.scene ? this.emitter.scene.fog : "none",
                     wrap: this.emitter.wrap && this.emitter.wrapBounds,

--- a/src/scene/scene_scene.js
+++ b/src/scene/scene_scene.js
@@ -236,10 +236,6 @@ pc.extend(pc, function () {
         set: function (value) {
             if (value !== this._gammaCorrection) {
                 this._gammaCorrection = value;
-
-                pc.shaderChunks.defaultGamma = value===pc.GAMMA_NONE? pc.shaderChunks.gamma1_0PS :
-                (value===pc.GAMMA_SRGBFAST? pc.shaderChunks.gamma2_2FastPS : pc.shaderChunks.gamma2_2PS);
-
                 this.updateShaders = true;
             }
         }
@@ -252,7 +248,6 @@ pc.extend(pc, function () {
         set: function (value) {
             if (value !== this._toneMapping) {
                 this._toneMapping = value;
-                pc.shaderChunks.defaultTonemapping = value ? pc.shaderChunks.tonemappingFilmicPS : pc.shaderChunks.tonemappingLinearPS;
                 this.updateShaders = true;
             }
         }


### PR DESCRIPTION
Should be strictly scene-dependent now