### PR TITLE
Skybox controls

### DIFF
--- a/src/framework/framework_application.js
+++ b/src/framework/framework_application.js
@@ -203,6 +203,8 @@ pc.extend(pc, function () {
                     this.scene.gammaCorrection = pack.settings.render.gamma_correction;
                     this.scene.toneMapping = pack.settings.render.tonemapping;
                     this.scene.exposure = pack.settings.render.exposure;
+                    this.scene.skyboxIntensity = pack.settings.render.skyboxIntensity===undefined? 1 : pack.settings.render.skyboxIntensity;
+                    this.scene.skyboxMip = pack.settings.render.skyboxMip===undefined? 0 : pack.settings.render.skyboxMip;
 
                     if (pack.settings.render.skybox) {
                         var skybox = this.assets.getAssetById(pack.settings.render.skybox);
@@ -802,6 +804,8 @@ pc.extend(pc, function () {
             self.scene.gammaCorrection = settings.render.gamma_correction;
             self.scene.toneMapping = settings.render.tonemapping;
             self.scene.exposure = settings.render.exposure;
+            self.scene.skyboxIntensity = settings.render.skyboxIntensity===undefined? 1 : settings.render.skyboxIntensity;
+            self.scene.skyboxMip = settings.render.skyboxMip===undefined? 0 : settings.render.skyboxMip;
 
             if (settings.render.skybox) {
                 var skybox = self.assets.getAssetById(settings.render.skybox);

--- a/src/graphics/programlib/chunks/ambientPrefilteredCube.frag
+++ b/src/graphics/programlib/chunks/ambientPrefilteredCube.frag
@@ -1,6 +1,6 @@
 void addAmbient(inout psInternalData data) {
     vec3 fixedReflDir = fixSeamsStatic(data.normalW, 1.0 - 1.0 / 4.0);
     fixedReflDir.x *= -1.0;
-    data.diffuseLight = $DECODE(textureCube(texture_prefilteredCubeMap4, fixedReflDir)).rgb;
+    data.diffuseLight = processEnvironment($DECODE(textureCube(texture_prefilteredCubeMap4, fixedReflDir)).rgb);
 }
 

--- a/src/graphics/programlib/chunks/ambientPrefilteredCubeLod.frag
+++ b/src/graphics/programlib/chunks/ambientPrefilteredCubeLod.frag
@@ -1,6 +1,6 @@
 void addAmbient(inout psInternalData data) {
     vec3 fixedReflDir = fixSeamsStatic(data.normalW, 1.0 - 1.0 / 4.0);
     fixedReflDir.x *= -1.0;
-    data.diffuseLight = $DECODE( textureCubeLodEXT(texture_prefilteredCubeMap128, fixedReflDir, 5.0) ).rgb;
+    data.diffuseLight = processEnvironment($DECODE( textureCubeLodEXT(texture_prefilteredCubeMap128, fixedReflDir, 5.0) ).rgb);
 }
 

--- a/src/graphics/programlib/chunks/envConst.frag
+++ b/src/graphics/programlib/chunks/envConst.frag
@@ -1,0 +1,4 @@
+vec3 processEnvironment(vec3 color) {
+    return color;
+}
+

--- a/src/graphics/programlib/chunks/envMultiply.frag
+++ b/src/graphics/programlib/chunks/envMultiply.frag
@@ -1,0 +1,5 @@
+uniform float skyboxIntensity;
+vec3 processEnvironment(vec3 color) {
+    return color * skyboxIntensity;
+}
+

--- a/src/graphics/programlib/chunks/reflectionPrefilteredCube.frag
+++ b/src/graphics/programlib/chunks/reflectionPrefilteredCube.frag
@@ -54,7 +54,7 @@ void addReflection(inout psInternalData data) {
     }else if (index2==5){ cube[1]=cubes[5];}*/
 
     vec4 cubeFinal = mix(cube[0], cube[1], fract(bias));
-    vec3 refl = $DECODE(cubeFinal).rgb;
+    vec3 refl = processEnvironment($DECODE(cubeFinal).rgb);
 
     data.reflection += vec4(refl, material_reflectionFactor);
 }

--- a/src/graphics/programlib/chunks/reflectionPrefilteredCubeLod.frag
+++ b/src/graphics/programlib/chunks/reflectionPrefilteredCubeLod.frag
@@ -9,7 +9,7 @@ void addReflection(inout psInternalData data) {
     vec3 fixedReflDir = fixSeams(cubeMapProject(data.reflDirW), bias);
     fixedReflDir.x *= -1.0;
 
-    vec3 refl = $DECODE( textureCubeLodEXT(texture_prefilteredCubeMap128, fixedReflDir, bias) ).rgb;
+    vec3 refl = processEnvironment($DECODE( textureCubeLodEXT(texture_prefilteredCubeMap128, fixedReflDir, bias) ).rgb);
 
     data.reflection += vec4(refl, material_reflectionFactor);
 }

--- a/src/graphics/programlib/chunks/skyboxHDR.frag
+++ b/src/graphics/programlib/chunks/skyboxHDR.frag
@@ -2,7 +2,7 @@ varying vec3 vViewDir;
 uniform samplerCube texture_cubeMap;
 
 void main(void) {
-    vec3 color = $textureCubeSAMPLE(texture_cubeMap, fixSeams(vViewDir)).rgb;
+    vec3 color = processEnvironment($textureCubeSAMPLE(texture_cubeMap, fixSeamsStatic(vViewDir, $FIXCONST)).rgb);
     color = toneMap(color);
     color = gammaCorrectOutput(color);
     gl_FragColor = vec4(color, 1.0);

--- a/src/graphics/programlib/programlib_phong.js
+++ b/src/graphics/programlib/programlib_phong.js
@@ -429,6 +429,7 @@ pc.programlib.phong = {
         if (cubemapReflection || options.prefilteredCubemap) {
             code += options.fixSeams? chunks.fixCubemapSeamsStretchPS : chunks.fixCubemapSeamsNonePS;
             code += options.cubeMapProjection>0? chunks.cubeMapProjectBoxPS : chunks.cubeMapProjectNonePS;
+            code += options.skyboxIntensity? chunks.envMultiplyPS : chunks.envConstPS;
         }
 
         code += this._addMap("diffuse", options, chunks, uvOffset);

--- a/src/graphics/programlib/programlib_skybox.js
+++ b/src/graphics/programlib/programlib_skybox.js
@@ -1,12 +1,14 @@
 pc.programlib.skybox = {
     generateKey: function (device, options) {
-        var key = "skybox" + options.rgbm + " " + options.hdr + " " + options.fixSeams + "" + options.toneMapping + "" + options.gamma;
+        var key = "skybox" + options.rgbm + " " + options.hdr + " " + options.fixSeams + "" + options.toneMapping + "" + options.gamma
+        + "" + options.useIntensity + "" + options.mip;
         return key;
     },
 
     createShaderDefinition: function (device, options) {
         var getSnippet = pc.programlib.getSnippet;
         var chunks = pc.shaderChunks;
+        var mip2size = [128, 64, 32, 16, 8, 4];
 
         return {
             attributes: {
@@ -36,10 +38,11 @@ pc.programlib.skybox = {
                 '}'
             ].join('\n'),
             fshader: getSnippet(device, 'fs_precision') +
-                (options.fixSeams? chunks.fixCubemapSeamsStretchPS : chunks.fixCubemapSeamsNonePS) +
-                (options.hdr? pc.programlib.gammaCode(options.gamma) + pc.programlib.tonemapCode(options.toneMapping) + chunks.rgbmPS +
-                 chunks.skyboxHDRPS.replace(/\$textureCubeSAMPLE/g,
-                    options.rgbm? "textureCubeRGBM" : (options.hdr? "textureCube" : "textureCubeSRGB")) : chunks.skyboxPS)
+                (options.mip? chunks.fixCubemapSeamsStretchPS : chunks.fixCubemapSeamsNonePS) +
+                (options.useIntensity? chunks.envMultiplyPS : chunks.envConstPS) +
+                pc.programlib.gammaCode(options.gamma) + pc.programlib.tonemapCode(options.toneMapping) + chunks.rgbmPS +
+                chunks.skyboxHDRPS.replace(/\$textureCubeSAMPLE/g, options.rgbm? "textureCubeRGBM" : (options.hdr? "textureCube" : "textureCubeSRGB"))
+                .replace(/\$FIXCONST/g, (1.0 - 1.0 / mip2size[options.mip]) + "")
         }
     }
 };

--- a/src/scene/scene_forwardrenderer.js
+++ b/src/scene/scene_forwardrenderer.js
@@ -388,6 +388,7 @@ pc.extend(pc, function () {
             }
             scope.resolve("light_globalAmbient").setValue(this.ambientColor);
             scope.resolve("exposure").setValue(scene.exposure);
+            if (scene._skyboxModel) scope.resolve("skyboxIntensity").setValue(scene.skyboxIntensity);
         },
 
         dispatchDirectLights: function (scene, mask) {

--- a/src/scene/scene_phongmaterial.js
+++ b/src/scene/scene_phongmaterial.js
@@ -618,6 +618,7 @@ pc.extend(pc, function () {
                 refraction:                 !!this.refraction,
                 useMetalness:               this.useMetalness,
                 blendType:                  this.blendType,
+                skyboxIntensity:            (prefilteredCubeMap128===scene.skyboxPrefiltered128 && prefilteredCubeMap128) && (scene.skyboxIntensity!==1),
                 useTexCubeLod:              useTexCubeLod
             };
 


### PR DESCRIPTION
- Should fix skybox seams.
- LDR skyboxes now work with exposure/tonemap.
- scene.skyboxIntensity works as environment multiplier (affects skybox and materials). Useful for LDR skybox, to make it bright enough when using tonemapping.
- scene.skyboxMip (kinda) changes skybox mip level. 0 = original, and 1-5 are prefiltered mips. Useful for model presentations, when you don't want skybox to distract.