### PR TITLE
Added new methods and rewrited constructor in math_vec3.js

### DIFF
--- a/src/math/math_vec3.js
+++ b/src/math/math_vec3.js
@@ -525,7 +525,7 @@ pc.extend(pc, (function () {
         },
         
         toJSON: function () {
-            return "[" + this.data[0] + ", " + this.data[1] + ", " + this.data[2] + "]";
+            return this.get();
         }
         
     };

--- a/src/math/math_vec3.js
+++ b/src/math/math_vec3.js
@@ -468,13 +468,13 @@ pc.extend(pc, (function () {
             return this;
         },
         //reflect vector of normal
-        //ex: (-1,1,0).reflect(0,1,0) -> (-1,1,0)
+        //ex: (-1,1,0).reflect(0,1,0) -> (1,1,0)
         reflect: function(n){
             var _n = n.data;
             var _tmp = [_n[0] ,_n[1] ,_n[2] ];
             var _v = this.data;
             
-            var d = 2* (_n[0]*_b[0] + _n[1]*_b[1] + _n[2]*_b[2]);
+            var d = 2* ( _n[0] * _v[0] + _n[1] * _v[1] + _n[2] * _v[2]);
             
             _tmp[0] *= d; 
             _tmp[1] *= d; 

--- a/src/math/math_vec3.js
+++ b/src/math/math_vec3.js
@@ -471,18 +471,18 @@ pc.extend(pc, (function () {
         //ex: (-1,1,0).reflect(0,1,0) -> (-1,1,0)
         reflect: function(n){
             var _n = n.data;
-            var _tmp = [_n[0],_n[1],_n[2]];
+            var _tmp = [_n[0] ,_n[1] ,_n[2] ];
             var _v = this.data;
             
-            var d = 2*(_n[0]*_b[0]+_n[1]*_b[1]+_n[2]*_b[2]);
+            var d = 2* (_n[0]*_b[0] + _n[1]*_b[1] + _n[2]*_b[2]);
             
-            _tmp[0]*=d; 
-            _tmp[1]*=d; 
-            _tmp[2]*=d;
+            _tmp[0] *= d; 
+            _tmp[1] *= d; 
+            _tmp[2] *= d;
             
-            _v[0]-=_tmp[0];
-            _v[1]-=_tmp[1];
-            _v[2]-=_tmp[2];
+            _v[0] -= _tmp[0];
+            _v[1] -= _tmp[1];
+            _v[2] -= _tmp[2];
             
             return  this;  
         },

--- a/src/math/math_vec3.js
+++ b/src/math/math_vec3.js
@@ -469,12 +469,22 @@ pc.extend(pc, (function () {
         },
         //reflect vector of normal
         //ex: (-1,1,0).reflect(0,1,0) -> (-1,1,0)
-        
-	    reflect: function(n){
-            var _n = n.clone();
-            var _b = this;
-            _n.scale(_n.dot(_b)*2);
-            return  this.sub(_n);  
+        reflect: function(n){
+            var _n = n.data;
+            var _tmp = [_n[0],_n[1],_n[2]];
+            var _v = this.data;
+            
+            var d = 2*(_n[0]*_b[0]+_n[1]*_b[1]+_n[2]*_b[2]);
+            
+            _tmp[0]*=d; 
+            _tmp[1]*=d; 
+            _tmp[2]*=d;
+            
+            _v[0]-=_tmp[0];
+            _v[1]-=_tmp[1];
+            _v[2]-=_tmp[2];
+            
+            return  this;  
         },
         //return maximum of 2 vectors
         max: function(lhs, rhs){

--- a/src/math/math_vec3.js
+++ b/src/math/math_vec3.js
@@ -9,15 +9,21 @@ pc.extend(pc, (function () {
     * @param {Number} [y] The y value
     * @param {Number} [z] The z value
     */
+    // fixed
     var Vec3 = function () {
         this.data = new Float32Array(3);
+        
+        if (arguments.length==1 && (arguments[0] instanceof Array))
+            {
+                this.data[0] = arguments[0][0] || 0; 
+                this.data[1] = arguments[0][1] || 0; 
+                this.data[2] = arguments[0][2] || 0; 
+                
+        }else{
+                this.data[0] = arguments[0] || 0; 
+                this.data[1] = arguments[1] || 0; 
+                this.data[2] = arguments[2] || 0; 
 
-        if (arguments.length === 3) {
-            this.data.set(arguments);
-        } else {
-            this.data[0] = 0;
-            this.data[1] = 0;
-            this.data[2] = 0;
         }
     };
 
@@ -402,7 +408,11 @@ pc.extend(pc, (function () {
 
             return this;
         },
-
+        //return array[3] of vector data 
+        get: function (x, y, z) {
+            var v = this.data;
+            return [v[0],v[1],v[2]];
+        },
         /**
          * @function
          * @name pc.Vec3#sub
@@ -457,6 +467,38 @@ pc.extend(pc, (function () {
 
             return this;
         },
+        //reflect vector of normal
+        //ex: (-1,1,0).reflect(0,1,0) -> (-1,1,0)
+        
+	    reflect: function(n){
+            var _n = n.clone();
+            var _b = this;
+            _n.scale(_n.dot(_b)*2);
+            return  this.sub(_n);  
+        },
+        //return maximum of 2 vectors
+        max: function(lhs, rhs){
+            if(!lhs) return rhs;
+            if(!rhs) return lhs ;
+            
+            if(lhs.length()>rhs.length()){
+                return lhs;
+            }
+            
+            return rhs;
+        },
+        
+        //return minimum of 2 vectors
+        min: function(lhs, rhs){
+            if(!lhs) return rhs;
+            if(!rhs) return lhs ;
+            
+            if(lhs.length()<rhs.length()){
+                return lhs;
+            }
+            
+            return rhs;
+        },
 
         /**
          * @function
@@ -470,7 +512,12 @@ pc.extend(pc, (function () {
          */
         toString: function () {
             return "[" + this.data[0] + ", " + this.data[1] + ", " + this.data[2] + "]";
+        },
+        
+        toJSON: function () {
+            return "[" + this.data[0] + ", " + this.data[1] + ", " + this.data[2] + "]";
         }
+        
     };
 
     /**

--- a/src/math/math_vec3.js
+++ b/src/math/math_vec3.js
@@ -487,7 +487,7 @@ pc.extend(pc, (function () {
             return  this;  
         },
         //return maximum of 2 vectors
-        max: function(lhs, rhs){
+        maxLength: function(lhs, rhs){
             if(!lhs) return rhs;
             if(!rhs) return lhs ;
             
@@ -499,7 +499,7 @@ pc.extend(pc, (function () {
         },
         
         //return minimum of 2 vectors
-        min: function(lhs, rhs){
+        minLength: function(lhs, rhs){
             if(!lhs) return rhs;
             if(!rhs) return lhs ;
             


### PR DESCRIPTION
Add new methods:
- reflect - It reflects one vector from the normal. Ex: (-1,1,0).reflect(0,1,0) = (-1,1,0)
- maxLength,minLength - return maximum and minimum between the two vectors of length 
- toJSON - return JSON data, see JSON.stringify()
- get - return array of vector data

Rewrited constructor. Now it takes array[3]/[2]/[1] and from 1 to 3 arguments as number
