### PR TITLE
aabb fix sync issue, and small optimisation

### DIFF
--- a/src/resources/parser_jsonmodel.js
+++ b/src/resources/parser_jsonmodel.js
@@ -268,8 +268,9 @@ pc.extend(pc, function () {
             for (i = 0; i < modelData.meshes.length; i++) {
                 var meshData = modelData.meshes[i];
 
-                var min = meshData.aabb.min;
-                var max = meshData.aabb.max;
+                var meshAabb = meshData.aabb;
+                var min = meshAabb.min;
+                var max = meshAabb.max;
                 var aabb = new pc.shape.Aabb(
                     new pc.Vec3((max[0] + min[0]) * 0.5, (max[1] + min[1]) * 0.5, (max[2] + min[2]) * 0.5),
                     new pc.Vec3((max[0] - min[0]) * 0.5, (max[1] - min[1]) * 0.5, (max[2] - min[2]) * 0.5)

--- a/src/scene/scene_forwardrenderer.js
+++ b/src/scene/scene_forwardrenderer.js
@@ -575,11 +575,11 @@ pc.extend(pc, function () {
                     // Only alpha sort and cull mesh instances in the main world
                     if (meshInstance.layer === pc.LAYER_WORLD) {
 
-                        meshPos = meshInstance.aabb.center;
                         if (camera.frustumCulling && drawCall.cull) {
-                            if (!meshInstance.aabb._radius) meshInstance.aabb._radius = meshInstance.aabb.halfExtents.length();
+                            meshPos = meshInstance.aabb.center;
+                            if (!meshInstance._aabb._radius) meshInstance._aabb._radius = meshInstance._aabb.halfExtents.length();
                             tempSphere.center = meshPos;
-                            tempSphere.radius = meshInstance.aabb._radius;
+                            tempSphere.radius = meshInstance._aabb._radius;
                             if (!camera._frustum.containsSphere(tempSphere)) {
                                 visible = false;
                             }
@@ -588,7 +588,7 @@ pc.extend(pc, function () {
                         if (visible) {
                             if ((meshInstance.material.blendType === pc.BLEND_NORMAL) || (meshInstance.material.blendType === pc.BLEND_PREMULTIPLIED)) {
                                 // alpha sort
-                                meshInstance.syncAabb();
+                                if (! meshPos) meshPos = meshInstance.aabb.center;
                                 var tempx = meshPos.x - camPos.x;
                                 var tempy = meshPos.y - camPos.y;
                                 var tempz = meshPos.z - camPos.z;

--- a/src/scene/scene_mesh.js
+++ b/src/scene/scene_mesh.js
@@ -146,7 +146,7 @@ pc.extend(pc, function () {
                     this._aabb.add(this._boneAabb[i]);
                 }
             } else {
-                this._aabb.setFromTransformedAabb(this.mesh.aabb, this.node.worldTransform);
+                this._aabb.setFromTransformedAabb(this.mesh.aabb, this.node.getWorldTransform());
             }
             return this._aabb;
         },

--- a/src/scene/scene_mesh.js
+++ b/src/scene/scene_mesh.js
@@ -146,7 +146,7 @@ pc.extend(pc, function () {
                     this._aabb.add(this._boneAabb[i]);
                 }
             } else {
-                this._aabb.setFromTransformedAabb(this.mesh.aabb, this.node.getWorldTransform());
+                this._aabb.setFromTransformedAabb(this.mesh.aabb, this.node.worldTransform);
             }
             return this._aabb;
         },


### PR DESCRIPTION
Aabb did not respected dirty matrices and used to use unsynced worldTransform of entities.
An it looks as property, but is a method, and due to that it is more pricy to be called, so calling `.aabb` only when necessary.