### PR TITLE
Alpha test

### DIFF
--- a/src/graphics/programlib/programlib_phong.js
+++ b/src/graphics/programlib/programlib_phong.js
@@ -386,10 +386,6 @@ pc.programlib.phong = {
             }
         }
 
-        if (options.alphaTest) {
-            code += getSnippet(device, 'fs_alpha_test_decl');
-        }
-
         code += "\n"; // End of uniform declarations
 
 
@@ -550,6 +546,11 @@ pc.programlib.phong = {
         // FRAGMENT SHADER BODY
         code += chunks.startPS;
 
+        code += "   getOpacity(data);\n";
+        if (options.alphaTest) {
+            code += "   if (data.alpha < alpha_ref) discard;"
+        }
+
         if (lighting || reflections) {
             code += "   getViewDir(data);\n";
             if (options.heightMap || options.normalMap) {
@@ -568,11 +569,6 @@ pc.programlib.phong = {
             code += "   getSpecularity(data);\n";
             code += "   getGlossiness(data);\n";
             if (options.fresnelModel > 0) code += "   getFresnel(data);\n";
-        }
-
-        code += "   getOpacity(data);\n";
-        if (options.alphaTest) {
-            code += "   if (data.alpha < alpha_ref) discard;"
         }
 
         code += "   addAmbient(data);\n";

--- a/src/graphics/programlib/programlib_phong.js
+++ b/src/graphics/programlib/programlib_phong.js
@@ -543,12 +543,16 @@ pc.programlib.phong = {
             code += "uniform vec3 material_ambient;\n"
         }
 
+        if (options.alphaTest) {
+            code += "   uniform float alpha_ref;\n";
+        }
+
         // FRAGMENT SHADER BODY
         code += chunks.startPS;
 
         code += "   getOpacity(data);\n";
         if (options.alphaTest) {
-            code += "   if (data.alpha < alpha_ref) discard;"
+            code += "   if (data.alpha < alpha_ref) discard;\n"
         }
 
         if (lighting || reflections) {

--- a/src/scene/scene_phongmaterial.js
+++ b/src/scene/scene_phongmaterial.js
@@ -184,7 +184,7 @@ pc.extend(pc, function () {
             this.emissive = new pc.Color(0, 0, 0);
             this.opacity = 1;
             this.blendType = pc.BLEND_NONE;
-            this.useAlphaTest = false;
+            this.alphaTest = 0;
             this.bumpiness = 1;
             this.heightMapFactor = 1;
 
@@ -591,7 +591,7 @@ pc.extend(pc, function () {
                 glossTint:                  true,
                 emissiveTint:               (this.emissive.r!=1 || this.emissive.g!=1 || this.emissive.b!=1 || this.emissiveIntensity!=1) && this.emissiveMapTint,
                 opacityTint:                this.opacity!=1,
-                alphaTest:                  this.useAlphaTest,
+                alphaTest:                  this.alphaTest > 0,
                 needsNormalFloat:           this.normalizeNormalMap,
 
                 sphereMap:                  !!this.sphereMap,
@@ -696,12 +696,6 @@ pc.extend(pc, function () {
                 this.clearVariants();
                 this.variants[0] = this.shader;
             }
-        }
-    });
-
-    Object.defineProperty(PhongMaterial.prototype, 'alphaTest', {
-        get: function () {
-            return 1.0 - this.opacity; // alpha ref value for renderer
         }
     });
 

--- a/src/scene/scene_phongmaterial.js
+++ b/src/scene/scene_phongmaterial.js
@@ -184,6 +184,7 @@ pc.extend(pc, function () {
             this.emissive = new pc.Color(0, 0, 0);
             this.opacity = 1;
             this.blendType = pc.BLEND_NONE;
+            this.useAlphaTest = false;
             this.bumpiness = 1;
             this.heightMapFactor = 1;
 
@@ -590,6 +591,7 @@ pc.extend(pc, function () {
                 glossTint:                  true,
                 emissiveTint:               (this.emissive.r!=1 || this.emissive.g!=1 || this.emissive.b!=1 || this.emissiveIntensity!=1) && this.emissiveMapTint,
                 opacityTint:                this.opacity!=1,
+                alphaTest:                  this.useAlphaTest,
                 needsNormalFloat:           this.normalizeNormalMap,
 
                 sphereMap:                  !!this.sphereMap,
@@ -694,6 +696,12 @@ pc.extend(pc, function () {
                 this.clearVariants();
                 this.variants[0] = this.shader;
             }
+        }
+    });
+
+    Object.defineProperty(PhongMaterial.prototype, 'alphaTest', {
+        get: function () {
+            return 1.0 - this.opacity; // alpha ref value for renderer
         }
     });
 


### PR DESCRIPTION
It's time to expose it already.
(Max calls it "mask": https://github.com/playcanvas/engine/issues/267)
(People have issues: http://answers.playcanvas.com/questions/1654/can-playcanvas-fix-this)
Now phongmaterial has alphaTest property (0 - 1, default 0).

Editor suggestions:
- always show opacity map even if no blend is set;
- always show the alpha test slider. You can call it differently, like "cutout".