### PR TITLE
Display a proper error when Java isn’t available at build time

### DIFF
--- a/build/build.py
+++ b/build/build.py
@@ -92,7 +92,11 @@ def build(dst):
     for file in dependencies:
         cmd.append("--js=" + os.path.join(ROOT, file.strip()))
 
-    retcode = subprocess.call(cmd)
+    try:
+        retcode = subprocess.call(cmd)
+    except OSError:
+        print("ERROR: java binary not found, exiting")
+        return 127  # Error code for a non-existing executable
 
     # Copy OUTPUT to build directory
     if not os.path.exists(os.path.dirname(dst)):


### PR DESCRIPTION
Java is required for the closure compiler to do its work, so abort properly with an error message when it isn’t available.