### PR TITLE
Make the build script usable on both Python 2.x and 3.x

### DIFF
--- a/build/build.py
+++ b/build/build.py
@@ -48,7 +48,7 @@ def get_revision():
 
         revision = out[0]
         if revision:
-            return revision
+            return revision.decode('utf-8')
         else:
             print("WARNING: Something went wrong trying to extract revision")
             return "-"
@@ -62,7 +62,7 @@ def get_version():
         f = open(version_file, "r")
         version = f.read()
         f.close()
-    except Exception, e:
+    except Exception as e:
         print(str(e))
         return "__CURRENT_SDK_VERSION__"
     return version
@@ -125,7 +125,7 @@ def setup():
     global ROOT, OUTPUT, COMPILATION_LEVEL
     try:
         opts, args = getopt.getopt(sys.argv[1:], "d:o:hl:")
-    except getopt.GetoptError, err:
+    except getopt.GetoptError as err:
         print(str(err))
         sys.exit(2)
 


### PR DESCRIPTION
This removes a few deprecated 2.x-only features and replace them with alternatives working on both.