### PR TITLE
Material system refactor 2

### DIFF
--- a/src/graphics/programlib/chunks/normalMap.frag
+++ b/src/graphics/programlib/chunks/normalMap.frag
@@ -1,5 +1,5 @@
 uniform sampler2D texture_normalMap;
-uniform float material_bumpMapFactor;
+uniform float material_bumpiness;
 void getNormal(inout psInternalData data) {
     vec3 normalMap = unpackNormal(texture2D(texture_normalMap, $UV));
     data.normalMap = normalMap;

--- a/src/graphics/programlib/chunks/normalMapFloat.frag
+++ b/src/graphics/programlib/chunks/normalMapFloat.frag
@@ -1,9 +1,9 @@
 uniform sampler2D texture_normalMap;
-uniform float material_bumpMapFactor;
+uniform float material_bumpiness;
 void getNormal(inout psInternalData data) {
     vec3 normalMap = unpackNormal(texture2D(texture_normalMap, $UV));
     data.normalMap = normalMap;
-    normalMap = normalize(mix(vec3(0.0, 0.0, 1.0), normalMap, material_bumpMapFactor));
+    normalMap = normalize(mix(vec3(0.0, 0.0, 1.0), normalMap, material_bumpiness));
     data.normalW = data.TBN * normalMap;
 }
 

--- a/src/graphics/programlib/chunks/normalMapFloatTBNfast.frag
+++ b/src/graphics/programlib/chunks/normalMapFloatTBNfast.frag
@@ -1,9 +1,9 @@
 uniform sampler2D texture_normalMap;
-uniform float material_bumpMapFactor;
+uniform float material_bumpiness;
 void getNormal(inout psInternalData data) {
     vec3 normalMap = unpackNormal(texture2D(texture_normalMap, $UV));
     data.normalMap = normalMap;
-    normalMap = mix(vec3(0.0, 0.0, 1.0), normalMap, material_bumpMapFactor);
+    normalMap = mix(vec3(0.0, 0.0, 1.0), normalMap, material_bumpiness);
     data.normalW = normalize(data.TBN * normalMap);
 }
 

--- a/src/graphics/programlib/chunks/reflectionCube.frag
+++ b/src/graphics/programlib/chunks/reflectionCube.frag
@@ -1,7 +1,7 @@
 uniform samplerCube texture_cubeMap;
-uniform float material_reflectionFactor;
+uniform float material_reflectivity;
 void addReflection(inout psInternalData data) {
     vec3 lookupVec = fixSeams(cubeMapProject(data.reflDirW));
     lookupVec.x *= -1.0;
-    data.reflection += vec4($textureCubeSAMPLE(texture_cubeMap, lookupVec).rgb, material_reflectionFactor);
+    data.reflection += vec4($textureCubeSAMPLE(texture_cubeMap, lookupVec).rgb, material_reflectivity);
 }

--- a/src/graphics/programlib/chunks/reflectionDpAtlas.frag
+++ b/src/graphics/programlib/chunks/reflectionDpAtlas.frag
@@ -1,5 +1,5 @@
 uniform sampler2D texture_sphereMap;
-uniform float material_reflectionFactor;
+uniform float material_reflectivity;
 
 vec2 getDpAtlasUv(vec2 uv, float mip) {
 
@@ -50,7 +50,7 @@ void addReflection(inout psInternalData data) {
     tex1 = mix(tex1, tex2, fract(bias));
     tex1 = processEnvironment(tex1);
 
-    data.reflection += vec4(tex1, material_reflectionFactor);
+    data.reflection += vec4(tex1, material_reflectivity);
 }
 
 

--- a/src/graphics/programlib/chunks/reflectionPrefilteredCube.frag
+++ b/src/graphics/programlib/chunks/reflectionPrefilteredCube.frag
@@ -4,7 +4,7 @@ uniform samplerCube texture_prefilteredCubeMap32;
 uniform samplerCube texture_prefilteredCubeMap16;
 uniform samplerCube texture_prefilteredCubeMap8;
 uniform samplerCube texture_prefilteredCubeMap4;
-uniform float material_reflectionFactor;
+uniform float material_reflectivity;
 
 void addReflection(inout psInternalData data) {
 
@@ -56,6 +56,6 @@ void addReflection(inout psInternalData data) {
     vec4 cubeFinal = mix(cube[0], cube[1], fract(bias));
     vec3 refl = processEnvironment($DECODE(cubeFinal).rgb);
 
-    data.reflection += vec4(refl, material_reflectionFactor);
+    data.reflection += vec4(refl, material_reflectivity);
 }
 

--- a/src/graphics/programlib/chunks/reflectionPrefilteredCubeLod.frag
+++ b/src/graphics/programlib/chunks/reflectionPrefilteredCubeLod.frag
@@ -1,7 +1,7 @@
 #extension GL_EXT_shader_texture_lod : enable
 
 uniform samplerCube texture_prefilteredCubeMap128;
-uniform float material_reflectionFactor;
+uniform float material_reflectivity;
 
 void addReflection(inout psInternalData data) {
 
@@ -11,6 +11,6 @@ void addReflection(inout psInternalData data) {
 
     vec3 refl = processEnvironment($DECODE( textureCubeLodEXT(texture_prefilteredCubeMap128, fixedReflDir, bias) ).rgb);
 
-    data.reflection += vec4(refl, material_reflectionFactor);
+    data.reflection += vec4(refl, material_reflectivity);
 }
 

--- a/src/graphics/programlib/chunks/reflectionSphere.frag
+++ b/src/graphics/programlib/chunks/reflectionSphere.frag
@@ -1,6 +1,6 @@
 uniform mat4 matrix_view;
 uniform sampler2D texture_sphereMap;
-uniform float material_reflectionFactor;
+uniform float material_reflectivity;
 void addReflection(inout psInternalData data) {
 
     vec3 reflDirV = (mat3(matrix_view) * data.reflDirW).xyz;
@@ -8,7 +8,7 @@ void addReflection(inout psInternalData data) {
     float m = 2.0 * sqrt( dot(reflDirV.xy, reflDirV.xy) + (reflDirV.z+1.0)*(reflDirV.z+1.0) );
     vec2 sphereMapUv = reflDirV.xy / m + 0.5;
 
-    data.reflection += vec4($texture2DSAMPLE(texture_sphereMap, sphereMapUv).rgb, material_reflectionFactor);
+    data.reflection += vec4($texture2DSAMPLE(texture_sphereMap, sphereMapUv).rgb, material_reflectivity);
 }
 
 

--- a/src/graphics/programlib/chunks/reflectionSphereLow.frag
+++ b/src/graphics/programlib/chunks/reflectionSphereLow.frag
@@ -1,10 +1,10 @@
 uniform sampler2D texture_sphereMap;
-uniform float material_reflectionFactor;
+uniform float material_reflectivity;
 void addReflection(inout psInternalData data) {
 
     vec3 reflDirV = vNormalV;
 
     vec2 sphereMapUv = reflDirV.xy * 0.5 + 0.5;
-    data.reflection += vec4($texture2DSAMPLE(texture_sphereMap, sphereMapUv).rgb, material_reflectionFactor);
+    data.reflection += vec4($texture2DSAMPLE(texture_sphereMap, sphereMapUv).rgb, material_reflectivity);
 }
 

--- a/src/graphics/programlib/chunks/refraction.frag
+++ b/src/graphics/programlib/chunks/refraction.frag
@@ -1,4 +1,4 @@
-uniform float material_refraction, material_refractionIor;
+uniform float material_refraction, material_refractionIndex;
 
 vec3 refract2(vec3 viewVec, vec3 Normal, float IOR) {
     float vn = dot(viewVec, Normal);
@@ -13,7 +13,7 @@ void addRefraction(inout psInternalData data) {
     vec3 tmp = data.reflDirW;
     vec4 tmp2 = data.reflection;
     data.reflection = vec4(0.0);
-    data.reflDirW = refract2(-data.viewDirW, data.normalW, material_refractionIor);
+    data.reflDirW = refract2(-data.viewDirW, data.normalW, material_refractionIndex);
 
     addReflection(data);
 

--- a/src/graphics/programlib/chunks/specularAaToksvigFloat.frag
+++ b/src/graphics/programlib/chunks/specularAaToksvigFloat.frag
@@ -1,6 +1,6 @@
 float antiAliasGlossiness(inout psInternalData data, float power) {
     float rlen = 1.0 / saturate(length(data.normalMap));
     float toksvig = 1.0 / (1.0 + power * (rlen - 1.0));
-    return power * mix(1.0, toksvig, material_bumpMapFactor);
+    return power * mix(1.0, toksvig, material_bumpiness);
 }
 

--- a/src/graphics/programlib/programlib_programlib.js
+++ b/src/graphics/programlib/programlib_programlib.js
@@ -115,7 +115,7 @@ pc.programlib = {
                                  // V, the view vector (vertex to eye)
                     code += '    vec3 map = texture2D( texture_normalMap, uv ).xyz;\n';
                     code += '    map = map * 255./127. - 128./127.;\n';
-                    code += '    map.xy = map.xy * material_bumpMapFactor;\n';
+                    code += '    map.xy = map.xy * material_bumpiness;\n';
                     code += '    mat3 TBN = cotangent_frame( N, -V, uv );\n';
                     code += '    return normalize( TBN * map );\n';
                     code += '}\n\n';

--- a/src/scene/scene_material.js
+++ b/src/scene/scene_material.js
@@ -220,7 +220,17 @@ pc.extend(pc, function () {
      * @name {number|Array|pc.Texture} data The value for the specified parameter.
      * @author Will Eastcott
      */
-    Material.prototype.setParameter = function (name, data) {
+    Material.prototype.setParameter = function (arg, data) {
+
+        var name;
+        if (data===undefined) {
+            var uniformObject = arg;
+            name = uniformObject.name;
+            data = uniformObject.value;
+        } else {
+            name = arg;
+        }
+
         var param = this.parameters[name];
         if (param) {
             param.data = data;

--- a/src/scene/scene_material.js
+++ b/src/scene/scene_material.js
@@ -227,6 +227,7 @@ pc.extend(pc, function () {
             var uniformObject = arg;
             if (uniformObject.length) {
                 for(var i=0; i<uniformObject.length; i++) this.setParameter(uniformObject[i]);
+                    return;
             } else {
                 name = uniformObject.name;
                 data = uniformObject.value;

--- a/src/scene/scene_material.js
+++ b/src/scene/scene_material.js
@@ -225,8 +225,12 @@ pc.extend(pc, function () {
         var name;
         if (data===undefined) {
             var uniformObject = arg;
-            name = uniformObject.name;
-            data = uniformObject.value;
+            if (uniformObject.length) {
+                for(var i=0; i<uniformObject.length; i++) this.setParameter(uniformObject[i]);
+            } else {
+                name = uniformObject.name;
+                data = uniformObject.value;
+            }
         } else {
             name = arg;
         }

--- a/src/scene/scene_phongmaterial.js
+++ b/src/scene/scene_phongmaterial.js
@@ -195,7 +195,7 @@ pc.extend(pc, function () {
                 val,
                 mat[privMapOffset]
             );
-            return {name:("texture_" + mapTransform), value:tform};
+            return {name:("texture_" + mapTransform), value:tform.data};
         }
 
 
@@ -215,7 +215,7 @@ pc.extend(pc, function () {
                 mat[privMapTiling],
                 val
             );
-            return {name:("texture_" + mapTransform), value:tform};
+            return {name:("texture_" + mapTransform), value:tform.data};
         }
 
 

--- a/src/scene/scene_phongmaterial.js
+++ b/src/scene/scene_phongmaterial.js
@@ -212,7 +212,7 @@ pc.extend(pc, function () {
         _prop2Uniform[mapOffset] = function (mat, val, changeMat) {
             var tform = mat._updateMapTransform(
                 changeMat? mat[mapTransform] : null,
-                this[privMapTiling],
+                mat[privMapTiling],
                 val
             );
             return {name:("texture_" + mapTransform), value:tform};

--- a/src/scene/scene_phongmaterial.js
+++ b/src/scene/scene_phongmaterial.js
@@ -902,8 +902,8 @@ pc.extend(pc, function () {
         });
 
         _defineObject(obj, "cubeMapProjectionBox", function (mat, val, changeMat) {
-                var bmin = changeMat? this.cubeMapMinUniform : new Float32Array(3);
-                var bmax = changeMat? this.cubeMapMaxUniform : new Float32Array(3);
+                var bmin = changeMat? mat.cubeMapMinUniform : new Float32Array(3);
+                var bmax = changeMat? mat.cubeMapMaxUniform : new Float32Array(3);
 
                 bmin[0] = val.center.x - val.halfExtents.x;
                 bmin[1] = val.center.y - val.halfExtents.y;

--- a/src/scene/scene_phongmaterial.js
+++ b/src/scene/scene_phongmaterial.js
@@ -278,8 +278,9 @@ pc.extend(pc, function () {
         _propsColor.push(name);
         _prop2Uniform[name] = function (mat, val, changeMat) {
             var arr = changeMat? mat[uform] : new Float32Array(3);
+            var scene = mat._scene || pc.Application.getApplication().scene;
             for(var c=0; c<3; c++) {
-                if (mat._scene.gammaCorrection) {
+                if (scene.gammaCorrection) {
                     arr[c] = Math.pow(val.data[c], 2.2);
                 } else {
                     arr[c] = val.data[c];
@@ -307,8 +308,9 @@ pc.extend(pc, function () {
             _propsSerial.push(mult);
             _prop2Uniform[mult] = function (mat, val, changeMat) {
                 var arr = changeMat? mat[uform] : new Float32Array(3);
+                var scene = mat._scene || pc.Application.getApplication().scene;
                 for(var c=0; c<3; c++) {
-                    if (mat._scene.gammaCorrection) {
+                    if (scene.gammaCorrection) {
                         arr[c] = Math.pow(mat[priv].data[c], 2.2);
                     } else {
                         arr[c] = mat[priv].data[c];

--- a/src/scene/scene_phongmaterial.js
+++ b/src/scene/scene_phongmaterial.js
@@ -513,14 +513,7 @@ pc.extend(pc, function () {
                 }
             }
 
-            // Shininess is 0-100 value
-            // which is actually a 0-1 glosiness value.
-            // Can be converted to specular power using exp2(shininess * 0.01 * 11)
-            if (this.shadingModel===pc.SPECULAR_PHONG) {
-                this.setParameter('material_shininess', Math.pow(2, this.shininess * 0.01 * 11)); // legacy: expand back to specular power
-            } else {
-                this.setParameter('material_shininess', this.shininess * 0.01); // correct
-            }
+            this.setParameter(this.getUniform("shininess", this.shininess));
 
             if (!this.emissiveMap || this.emissiveMapTint) {
                 this.setParameter('material_emissive', this.emissiveUniform);
@@ -856,6 +849,9 @@ pc.extend(pc, function () {
         _defineColor(obj, "emissive", new pc.Color(0, 0, 0), "emissiveIntensity");
 
         _defineFloat(obj, "shininess", 25, function(mat, shininess) {
+            // Shininess is 0-100 value
+            // which is actually a 0-1 glosiness value.
+            // Can be converted to specular power using exp2(shininess * 0.01 * 11)
             var value;
             if (this.shadingModel===pc.SPECULAR_PHONG) {
                 value = Math.pow(2, shininess * 0.01 * 11); // legacy: expand back to specular power


### PR DESCRIPTION
- fixed a few bugs from previous PR.

- phongmaterial.getUniform("phongmaterial property name", value to set)
returns you a "uniform object", that looks like this: {name:uniformName, value:uniformValue} or an 
array: [uniformObject, uniformObject].
- material.setParameter accepts such objects/arrays.

can be used to simplify usage of https://github.com/playcanvas/engine/pull/318
So instead of writing:
```javascript
            var tform = new pc.Vec4(0.11, 1, this.offset, 0);
            obj.setParameter("texture_diffuseMapTransform", tform.data);
```
You can write:
```javascript
            var overrideOffset = obj.material.getUniform("diffuseMapOffset", new pc.Vec2(this.offset, 0));
            obj.setParameter(overrideOffset);
```
or Instead of
```javascript
obj.setParameter("material_diffuse", color.data);
```
you can do
```javascript
            var override = obj.material.getUniform("diffuse", color);
            obj.setParameter(override);
```