### PR TITLE
OES_element_index_uint

### DIFF
--- a/src/graphics/graphics_device.js
+++ b/src/graphics/graphics_device.js
@@ -255,6 +255,8 @@ pc.extend(pc, function () {
             this.extTextureFloatLinear = gl.getExtension("OES_texture_float_linear");
             this.extTextureHalfFloat = gl.getExtension("OES_texture_half_float");
 
+            this.extUintElement = gl.getExtension("OES_element_index_uint");
+
             this.maxVertexTextures = gl.getParameter(gl.MAX_VERTEX_TEXTURE_IMAGE_UNITS);
             this.supportsBoneTextures = this.extTextureFloat && this.maxVertexTextures > 0;
 

--- a/src/resources/parser_jsonmodel.js
+++ b/src/resources/parser_jsonmodel.js
@@ -248,8 +248,13 @@ pc.extend(pc, function () {
 
             // Create an index buffer big enough to store all indices in the model
             if (numIndices > 0) {
-                indexBuffer = new pc.IndexBuffer(this._device, pc.INDEXFORMAT_UINT16, numIndices);
-                indexData = new Uint16Array(indexBuffer.lock());
+                if (numIndices > 0xFFFF && this._device.extUintElement) {
+                    indexBuffer = new pc.IndexBuffer(this._device, pc.INDEXFORMAT_UINT32, numIndices);
+                    indexData = new Uint32Array(indexBuffer.lock());
+                } else {
+                    indexBuffer = new pc.IndexBuffer(this._device, pc.INDEXFORMAT_UINT16, numIndices);
+                    indexData = new Uint16Array(indexBuffer.lock());
+                }
             }
 
             return {


### PR DESCRIPTION
Use OES_element_index_uint for large meshes.
Still requires server-side model converter to be fixed.