### PR TITLE
Depth map management

### DIFF
--- a/src/framework/components/particlesystem/particlesystem_component.js
+++ b/src/framework/components/particlesystem/particlesystem_component.js
@@ -433,6 +433,7 @@ pc.extend(pc, function() {
                 if (!this.system.app.scene.containsModel(this.data.model)) {
                     if (this.emitter.colorMap) {
                         this.system.app.scene.addModel(this.data.model);
+                        this.emitter.onEnable();
                     }
                 }
             }
@@ -445,6 +446,7 @@ pc.extend(pc, function() {
             if (this.data.model) {
                 if (this.system.app.scene.containsModel(this.data.model)) {
                     this.system.app.scene.removeModel(this.data.model);
+                    this.emitter.onDisable();
                 }
             }
         },

--- a/src/graphics/graphics_device.js
+++ b/src/graphics/graphics_device.js
@@ -1041,6 +1041,9 @@ pc.extend(pc, function () {
             for (i = 0, len = samplers.length; i < len; i++) {
                 sampler = samplers[i];
                 samplerValue = sampler.scopeId.value;
+                if (!samplerValue) {
+                    continue; // Because unset constants shouldn't raise random errors
+                }
 
                 if (samplerValue instanceof pc.Texture) {
                     texture = samplerValue;

--- a/src/graphics/programlib/chunks/particle.frag
+++ b/src/graphics/programlib/chunks/particle.frag
@@ -4,7 +4,6 @@ uniform sampler2D colorMap;
 uniform sampler2D internalTex3;
 uniform float graphSampleSize;
 uniform float graphNumSamples;
-uniform vec4 screenSize;
 uniform float camera_far;
 uniform float softening;
 uniform float colorMult;

--- a/src/graphics/programlib/chunks/particle_soft.frag
+++ b/src/graphics/programlib/chunks/particle_soft.frag
@@ -1,5 +1,5 @@
 
-    vec2 screenTC = gl_FragCoord.xy / screenSize.xy;
+    vec2 screenTC = gl_FragCoord.xy * uScreenSize.zw;
     float depth = unpackFloat( texture2D(uDepthMap, screenTC) ) * camera_far;
     float particleDepth = gl_FragCoord.z / gl_FragCoord.w;
     float depthDiff = saturate(abs(particleDepth - depth) * softening);

--- a/src/graphics/programlib/programlib_particle.js
+++ b/src/graphics/programlib/programlib_particle.js
@@ -66,7 +66,7 @@ pc.programlib.particle = {
         }
 
         if (options.normal == 2) fshader +=     "\nuniform sampler2D normalMap;\n";
-        if (options.soft > 0) fshader +=        "\nuniform sampler2D uDepthMap;\n";
+        if (options.soft > 0) fshader +=        "\nuniform sampler2D uDepthMap;\n uniform vec4 uScreenSize;\n";
         fshader +=                                  chunk.particlePS;
         if (options.soft > 0) fshader +=            chunk.particle_softPS;
         if (options.normal == 1) fshader +=         "\nvec3 normal = Normal;\n"

--- a/src/scene/scene_camera.js
+++ b/src/scene/scene_camera.js
@@ -13,6 +13,7 @@ pc.extend(pc, function () {
         this._aspect = 16 / 9;
         this._horizontalFov = false;
         this.frustumCulling = false;
+        this._renderDepthRequests = 0;
 
         this._projMatDirty = true;
         this._projMat = new pc.Mat4();
@@ -30,6 +31,7 @@ pc.extend(pc, function () {
 
         // Create a full size viewport onto the backbuffer
         this._renderTarget = null;
+        this._depthTarget = null;
 
         // Create the clear options
         this._clearOptions = {
@@ -396,6 +398,14 @@ pc.extend(pc, function () {
          */
         setRenderTarget: function (target) {
             this._renderTarget = target;
+        },
+
+        requestDepthMap: function () {
+            this._renderDepthRequests++;
+        },
+
+        releaseDepthMap: function () {
+            this._renderDepthRequests--;
         }
     };
 

--- a/src/scene/scene_forwardrenderer.js
+++ b/src/scene/scene_forwardrenderer.js
@@ -381,6 +381,7 @@ pc.extend(pc, function () {
             device.setViewport(x, y, w, h);
             device.setScissor(x, y, w, h);
 
+            device.setColorWrite(true, true, true, true);
             device.clear(camera.getClearOptions());
 
             if (cullBorder) device.setScissor(1, 1, pixelWidth-2, pixelHeight-2);

--- a/src/scene/scene_particleemitter.js
+++ b/src/scene/scene_particleemitter.js
@@ -152,28 +152,6 @@ pc.extend(pc, function() {
         return colors;
     }
 
-    function createOffscreenTarget(gd, camera) {
-        var rect = camera._rect;
-
-        var width = Math.floor(rect.width * gd.width);
-        var height = Math.floor(rect.height * gd.height);
-
-        var colorBuffer = new pc.Texture(gd, {
-            format: pc.PIXELFORMAT_R8_G8_B8_A8,
-            width: width,
-            height: height
-        });
-
-        colorBuffer.minFilter = pc.FILTER_NEAREST;
-        colorBuffer.magFilter = pc.FILTER_NEAREST;
-        colorBuffer.addressU = pc.ADDRESS_CLAMP_TO_EDGE;
-        colorBuffer.addressV = pc.ADDRESS_CLAMP_TO_EDGE;
-
-        return new pc.RenderTarget(gd, colorBuffer, {
-            depth: true
-        });
-    }
-
     var ParticleEmitter = function (graphicsDevice, options) {
         this.graphicsDevice = graphicsDevice;
         var gd = graphicsDevice;

--- a/src/scene/scene_particleemitter.js
+++ b/src/scene/scene_particleemitter.js
@@ -838,13 +838,13 @@ pc.extend(pc, function() {
             this.endTime = calcEndTime(this);
         },
 
-        onEnable: function() {
+        onEnableDepth: function() {
             if (this.depthSoftening > 0 && this.camera) {
                 this.camera.requestDepthMap();
             }
         },
 
-        onDisable: function() {
+        onDisableDepth: function() {
             if (this.depthSoftening > 0 && this.camera) {
                 this.camera.releaseDepthMap();
             }


### PR DESCRIPTION
Moved all depth map management to camera/renderer instead of being scattered in post effects and particles, leading to possible conflicts.
- scene_camera has methods requestDepthMap and releaseDepthMap which increment/decrement a reference counter. The depth map will be created if ref count > 0 and destroyed otherwise.
- particle emitters with depth softening request depth map
- post effects request depth map if needsDepthBuffer is set (tested DoF effect)
- renderer now provides global uDepthMap (if depth rendering enabled) and uScreenSize (always) uniforms.

Additional:
- device now silently ignores unset samplers, because it's better than crash.
- fixed renderer.setCamera not selecting color channels to clear (reason of background color flickering with fixed particles)

