### PR TITLE
Particles with animated textures

### DIFF
--- a/src/framework/components/particlesystem/particlesystem_component.js
+++ b/src/framework/components/particlesystem/particlesystem_component.js
@@ -4,12 +4,9 @@ pc.extend(pc, function() {
     var SIMPLE_PROPERTIES = [
         'emitterExtents',
         'emitterRadius',
-        'colorMap',
         'normalMap',
         'loop',
         'initialVelocity',
-        'animTexTilesX',
-        'animTexTilesY',
         'animTexNumFrames',
         'animTexSpeed'
     ];
@@ -34,7 +31,10 @@ pc.extend(pc, function() {
         'preWarm',
         'emitterShape',
         'isAnimTex',
-        'animTexLoop'
+        'animTexTilesX',
+        'animTexTilesY',
+        'animTexLoop',
+        'colorMap'
     ];
 
     var GRAPH_PROPERTIES = [

--- a/src/framework/components/particlesystem/particlesystem_component.js
+++ b/src/framework/components/particlesystem/particlesystem_component.js
@@ -7,7 +7,11 @@ pc.extend(pc, function() {
         'colorMap',
         'normalMap',
         'loop',
-        'initialVelocity'
+        'initialVelocity',
+        'animTexTilesX',
+        'animTexTilesY',
+        'animTexNumFrames',
+        'animTexSpeed'
     ];
 
     // properties that need rebuilding the particle system
@@ -28,7 +32,9 @@ pc.extend(pc, function() {
         'stretch',
         'alignToMotion',
         'preWarm',
-        'emitterShape'
+        'emitterShape',
+        'isAnimTex',
+        'animTexLoop'
     ];
 
     var GRAPH_PROPERTIES = [
@@ -394,6 +400,13 @@ pc.extend(pc, function() {
                     lifetime: this.data.lifetime,
                     rate: this.data.rate,
                     rate2: this.data.rate2,
+
+                    isAnimTex: this.data.isAnimTex,
+                    animTexTilesX: this.data.animTexTilesX,
+                    animTexTilesY: this.data.animTexTilesY,
+                    animTexNumFrames: this.data.animTexNumFrames,
+                    animTexSpeed: this.data.animTexSpeed,
+                    animTexLoop: this.data.animTexLoop,
 
                     startAngle: this.data.startAngle,
                     startAngle2: this.data.startAngle2,

--- a/src/framework/components/particlesystem/particlesystem_data.js
+++ b/src/framework/components/particlesystem/particlesystem_data.js
@@ -31,6 +31,13 @@ pc.extend(pc, function() {
                                                 // Leave undefined to use simple quads
         this.depthWrite = false;
 
+        this.isAnimTex = false;
+        this.animTexTilesX = 1;
+        this.animTexTilesY = 1;
+        this.animTexNumFrames = 1;
+        this.animTexSpeed = 1;
+        this.animTexLoop = true;
+
         // Time-dependent parameters
         this.scaleGraph = null;
         this.scaleGraph2 = null;

--- a/src/framework/components/particlesystem/particlesystem_system.js
+++ b/src/framework/components/particlesystem/particlesystem_system.js
@@ -57,7 +57,13 @@ pc.extend(pc, function() {
             'alphaGraph',
             'alphaGraph2',
             'colorMap',
-            'normalMap'
+            'normalMap',
+            'isAnimTex',
+            'animTexTilesX',
+            'animTexTilesY',
+            'animTexNumFrames',
+            'animTexSpeed',
+            'animTexLoop'
         ];
 
         this.propertyTypes = {

--- a/src/graphics/graphics_device.js
+++ b/src/graphics/graphics_device.js
@@ -902,7 +902,8 @@ pc.extend(pc, function () {
                 gl.generateMipmap(texture._glTarget);
             }
 
-            this._vram.tex += gpuTexSize(gl, texture);
+            texture._gpuSize = gpuTexSize(gl, texture);
+            this._vram.tex += texture._gpuSize;
         },
 
         setTexture: function (texture, textureUnit) {

--- a/src/graphics/graphics_texture.js
+++ b/src/graphics/graphics_texture.js
@@ -83,6 +83,8 @@ pc.extend(pc, function () {
         this._addressUDirty = true;
         this._addressVDirty = true;
         this._anisotropyDirty = true;
+
+        this._gpuSize = 0;
     };
 
     // Public properties
@@ -194,6 +196,7 @@ pc.extend(pc, function () {
             if (this._glTextureId) {
                 var gl = this.device.gl;
                 gl.deleteTexture(this._glTextureId);
+                this.device -= this._gpuSize;
             }
         },
 

--- a/src/graphics/graphics_texture.js
+++ b/src/graphics/graphics_texture.js
@@ -196,7 +196,7 @@ pc.extend(pc, function () {
             if (this._glTextureId) {
                 var gl = this.device.gl;
                 gl.deleteTexture(this._glTextureId);
-                this.device -= this._gpuSize;
+                this.device._vram.tex -= this._gpuSize;
             }
         },
 

--- a/src/graphics/programlib/chunks/outputTex2D.frag
+++ b/src/graphics/programlib/chunks/outputTex2D.frag
@@ -1,0 +1,7 @@
+varying vec2 vUv0;
+uniform sampler2D source;
+
+void main(void) {
+    gl_FragColor = texture2D(source, vUv0);
+}
+

--- a/src/graphics/programlib/chunks/outputTex2Dborder.frag
+++ b/src/graphics/programlib/chunks/outputTex2Dborder.frag
@@ -1,0 +1,11 @@
+varying vec2 vUv0;
+uniform sampler2D source;
+uniform vec4 params; // xy = single tile resolution, zw = same - 1
+
+void main(void) {
+    vec4 color = texture2D(source, vUv0);
+    vec2 tiles = mod(floor(gl_FragCoord.xy), params.xy);
+    bool border = tiles.x==0.0 || tiles.x==params.z || tiles.y==0.0 || tiles.y==params.w;
+    gl_FragColor = border? vec4(0.0) : color;
+}
+

--- a/src/graphics/programlib/chunks/particleAnimFrameClamp.vert
+++ b/src/graphics/programlib/chunks/particleAnimFrameClamp.vert
@@ -1,0 +1,3 @@
+
+    float animFrame = min(floor(texCoordsAlphaLife.w * animTexParams.z), animTexParams.w);
+

--- a/src/graphics/programlib/chunks/particleAnimFrameLoop.vert
+++ b/src/graphics/programlib/chunks/particleAnimFrameLoop.vert
@@ -1,0 +1,3 @@
+
+    float animFrame = floor(texCoordsAlphaLife.w * animTexParams.z);
+

--- a/src/graphics/programlib/chunks/particleAnimTex.vert
+++ b/src/graphics/programlib/chunks/particleAnimTex.vert
@@ -1,0 +1,10 @@
+
+    float atlasX = animFrame * animTexParams.x;
+    float atlasY = floor(atlasX) * animTexParams.y;
+    atlasX = fract(atlasX);
+
+    //texCoordsAlphaLife.xy = texCoordsAlphaLife.xy * 0.9 + vec2(0.05); // correctly generate mipmaps instead
+    texCoordsAlphaLife.xy *= animTexParams.xy;
+    texCoordsAlphaLife.xy += vec2(atlasX, atlasY);
+    texCoordsAlphaLife.y = 1.0 - texCoordsAlphaLife.y;
+

--- a/src/graphics/programlib/chunks/particleAnimTex.vert
+++ b/src/graphics/programlib/chunks/particleAnimTex.vert
@@ -3,7 +3,6 @@
     float atlasY = floor(atlasX) * animTexParams.y;
     atlasX = fract(atlasX);
 
-    //texCoordsAlphaLife.xy = texCoordsAlphaLife.xy * 0.9 + vec2(0.05); // correctly generate mipmaps instead
     texCoordsAlphaLife.xy *= animTexParams.xy;
     texCoordsAlphaLife.xy += vec2(atlasX, atlasY);
     texCoordsAlphaLife.y = 1.0 - texCoordsAlphaLife.y;

--- a/src/graphics/programlib/programlib_particle.js
+++ b/src/graphics/programlib/programlib_particle.js
@@ -9,6 +9,13 @@ pc.programlib.particle = {
         return key;
     },
 
+    _animTex: function(options, chunk) {
+        var vshader = "";
+        vshader +=         options.animTexLoop? chunk.particleAnimFrameLoopVS : chunk.particleAnimFrameClampVS;
+        vshader +=         chunk.particleAnimTexVS;
+        return vshader;
+    },
+
     createShaderDefinition: function(device, options) {
 
         var getSnippet = pc.programlib.getSnippet;
@@ -18,9 +25,11 @@ pc.programlib.particle = {
         var fshader = getSnippet(device, 'fs_precision') + "\n";
 
         if (!options.useCpu) {
-            if (options.normal == 1) vshader +=     "\nvarying vec3 Normal;\n";
+            if (options.animTex)     vshader +=     "\nuniform vec4 animTexParams;\n";
             if (options.normal == 2) vshader +=     "\nvarying mat3 ParticleMat;\n";
+            if (options.normal == 1) vshader +=     "\nvarying vec3 Normal;\n";
             vshader +=                              chunk.particleVS;
+            if (options.animTex)     vshader +=     this._animTex(options, chunk);
             if (options.wrap) vshader +=                              chunk.particle_wrapVS;
             if (options.alignToMotion) vshader +=     chunk.particle_pointAlongVS;
             vshader +=                              options.mesh ? chunk.particle_meshVS : chunk.particle_billboardVS;
@@ -29,9 +38,11 @@ pc.programlib.particle = {
             if (options.stretch > 0.0) vshader +=   chunk.particle_stretchVS;
             vshader += chunk.particle_endVS;
         } else {
-            if (options.normal == 1) vshader +=     "\nvarying vec3 Normal;\n";
+            if (options.animTex)     vshader +=     "\nuniform vec4 animTexParams;\n";
             if (options.normal == 2) vshader +=     "\nvarying mat3 ParticleMat;\n";
+            if (options.normal == 1) vshader +=     "\nvarying vec3 Normal;\n";
             vshader +=                              chunk.particle_cpuVS;
+            if (options.animTex)     vshader +=     this._animTex(options, chunk);
             //if (options.wrap) vshader +=                              chunk.particle_wrapVS;
             if (options.alignToMotion) vshader +=     chunk.particle_pointAlongVS;
             vshader +=                              options.mesh ? chunk.particle_meshVS : chunk.particle_billboardVS;

--- a/src/scene/scene_forwardrenderer.js
+++ b/src/scene/scene_forwardrenderer.js
@@ -381,7 +381,6 @@ pc.extend(pc, function () {
             device.setViewport(x, y, w, h);
             device.setScissor(x, y, w, h);
 
-            device.setColorWrite(true, true, true, true);
             device.clear(camera.getClearOptions());
 
             if (cullBorder) device.setScissor(1, 1, pixelWidth-2, pixelHeight-2);
@@ -1092,6 +1091,8 @@ pc.extend(pc, function () {
                     prevLightMask = lightMask;
                 }
             }
+
+            device.setColorWrite(true, true, true, true);
 
             if (scene.immediateDrawCalls.length > 0) {
                 scene.immediateDrawCalls = [];

--- a/src/scene/scene_particleemitter.js
+++ b/src/scene/scene_particleemitter.js
@@ -295,7 +295,6 @@ pc.extend(pc, function() {
         this.lightCubeDir[5] = new pc.Vec3(0, 0, 1);
 
         this.animTexParams = new pc.Vec4();
-        this.internalAtlas = null;
 
         this.internalTex0 = null;
         this.internalTex1 = null;
@@ -520,9 +519,6 @@ pc.extend(pc, function() {
             this.resetTime();
 
             if (this.isAnimTex && this.colorMap && this.colorMap._prtMipX!==this.animTexTilesX && this.colorMap._prtMipY!==this.animTexTilesY) {
-                if (this.internalAtlas) {
-                    this.internalAtlas.destroy();
-                }
                 var device = this.graphicsDevice;
                 var mipWidth = this.colorMap._width;
                 var mipHeight = this.colorMap._height;
@@ -555,6 +551,7 @@ pc.extend(pc, function() {
                 });
                 constantTexSource.setValue(this.colorMap);
                 pc.drawQuadWithShader(device, targ, shader);
+                targ._colorBuffer = this.colorMap;
                 syncToCpu(device, targ);
                 var lastMip = newTex;
 
@@ -585,10 +582,13 @@ pc.extend(pc, function() {
                     params.w = params.y - 1;
                     pc.drawQuadWithShader(device, targ, shader2);
                     syncToCpu(device, targ);
-                    newTex._levels[i] = mip._levels[0];
+                    this.colorMap._levels[i] = mip._levels[0];
                     lastMip = mip;
                 }
 
+                newTex = this.colorMap;
+                newTex.format = pc.PIXELFORMAT_R8_G8_B8_A8;
+                newTex.autoMipmap = false;
                 newTex.upload();
                 newTex.minFilter = pc.FILTER_LINEAR_MIPMAP_LINEAR;
                 newTex.magFilter = pc.FILTER_LINEAR;
@@ -596,8 +596,6 @@ pc.extend(pc, function() {
                 newTex.addressV = pc.ADDRESS_REPEAT;
                 newTex._prtMipX = this.animTexTilesX;
                 newTex._prtMipY = this.animTexTilesY;
-                this.colorMap = newTex;
-                this.internalAtlas = newTex;
                 this.material.setParameter('colorMap', this.colorMap);
             }
         },

--- a/src/scene/scene_particleemitter.js
+++ b/src/scene/scene_particleemitter.js
@@ -295,6 +295,7 @@ pc.extend(pc, function() {
         this.lightCubeDir[5] = new pc.Vec3(0, 0, 1);
 
         this.animTexParams = new pc.Vec4();
+        this.internalAtlas = null;
 
         this.internalTex0 = null;
         this.internalTex1 = null;
@@ -519,6 +520,9 @@ pc.extend(pc, function() {
             this.resetTime();
 
             if (this.isAnimTex && this.colorMap && this.colorMap._prtMipX!==this.animTexTilesX && this.colorMap._prtMipY!==this.animTexTilesY) {
+                if (this.internalAtlas) {
+                    this.internalAtlas.destroy();
+                }
                 var device = this.graphicsDevice;
                 var mipWidth = this.colorMap._width;
                 var mipHeight = this.colorMap._height;
@@ -588,11 +592,12 @@ pc.extend(pc, function() {
                 newTex.upload();
                 newTex.minFilter = pc.FILTER_LINEAR_MIPMAP_LINEAR;
                 newTex.magFilter = pc.FILTER_LINEAR;
-                newTex.addressU = pc.ADDRESS_CLAMP_TO_EDGE;
-                newTex.addressV = pc.ADDRESS_CLAMP_TO_EDGE;
+                newTex.addressU = pc.ADDRESS_REPEAT;
+                newTex.addressV = pc.ADDRESS_REPEAT;
                 newTex._prtMipX = this.animTexTilesX;
                 newTex._prtMipY = this.animTexTilesY;
                 this.colorMap = newTex;
+                this.internalAtlas = newTex;
                 this.material.setParameter('colorMap', this.colorMap);
             }
         },

--- a/src/scene/scene_particleemitter.js
+++ b/src/scene/scene_particleemitter.js
@@ -582,6 +582,7 @@ pc.extend(pc, function() {
                     params.w = params.y - 1;
                     pc.drawQuadWithShader(device, targ, shader2);
                     syncToCpu(device, targ);
+                    mip.destroy();
                     this.colorMap._levels[i] = mip._levels[0];
                     lastMip = mip;
                 }

--- a/src/scene/scene_particleemitter.js
+++ b/src/scene/scene_particleemitter.js
@@ -586,6 +586,7 @@ pc.extend(pc, function() {
                     lastMip = mip;
                 }
 
+                newTex.destroy();
                 newTex = this.colorMap;
                 newTex.format = pc.PIXELFORMAT_R8_G8_B8_A8;
                 newTex.autoMipmap = false;

--- a/src/scene/scene_particleemitter.js
+++ b/src/scene/scene_particleemitter.js
@@ -152,6 +152,16 @@ pc.extend(pc, function() {
         return colors;
     }
 
+    function syncToCpu(device, targ) {
+        var tex = targ._colorBuffer;
+        var pixels = new Uint8Array(tex.width * tex.height * 4);
+        var gl = device.gl;
+        gl.bindFramebuffer(gl.FRAMEBUFFER, targ._glFrameBuffer);
+        gl.readPixels(0, 0, tex.width, tex.height, gl.RGBA, gl.UNSIGNED_BYTE, pixels);
+        if (!tex._levels) tex._levels = [];
+        tex._levels[0] = pixels;
+    }
+
     var ParticleEmitter = function (graphicsDevice, options) {
         this.graphicsDevice = graphicsDevice;
         var gd = graphicsDevice;
@@ -507,6 +517,84 @@ pc.extend(pc, function() {
             if (this.preWarm) this.prewarm(this.lifetime);
 
             this.resetTime();
+
+            if (this.isAnimTex && this.colorMap && this.colorMap._prtMipX!==this.animTexTilesX && this.colorMap._prtMipY!==this.animTexTilesY) {
+                var device = this.graphicsDevice;
+                var mipWidth = this.colorMap._width;
+                var mipHeight = this.colorMap._height;
+                var mips = Math.round(Math.log2(Math.max(mipWidth, mipHeight)) + 1);
+                var constantTexSource = device.scope.resolve("source");
+                var constantParams = device.scope.resolve("params");
+                var params = new pc.Vec4();
+                var chunks = pc.shaderChunks;
+                var shader = chunks.createShaderFromCode(device, chunks.fullscreenQuadVS, chunks.outputTex2DPS, "outputTex2D");
+                var shader2 = chunks.createShaderFromCode(device, chunks.fullscreenQuadVS, chunks.outputTex2DborderPS, "outputTex2Dborder");
+
+                // Sync mip0 to CPU
+                this.colorMap.minFilter = pc.FILTER_LINEAR;
+                this.colorMap.magFilter = pc.FILTER_LINEAR;
+                this.colorMap.addressU = pc.ADDRESS_CLAMP_TO_EDGE;
+                this.colorMap.addressV = pc.ADDRESS_CLAMP_TO_EDGE;
+                var newTex = new pc.Texture(device, {
+                    cubemap: false,
+                    format: pc.PIXELFORMAT_R8_G8_B8_A8,
+                    width: mipWidth,
+                    height: mipHeight,
+                    autoMipmap: false
+                });
+                newTex.minFilter = pc.FILTER_LINEAR;
+                newTex.magFilter = pc.FILTER_LINEAR;
+                newTex.addressU = pc.ADDRESS_CLAMP_TO_EDGE;
+                newTex.addressV = pc.ADDRESS_CLAMP_TO_EDGE;
+                var targ = new pc.RenderTarget(device, newTex, {
+                    depth: false
+                });
+                constantTexSource.setValue(this.colorMap);
+                pc.drawQuadWithShader(device, targ, shader);
+                syncToCpu(device, targ);
+                var lastMip = newTex;
+
+                // Generate mipchain with borders
+                constantParams.setValue(params.data);
+                var mip;
+                for(i=1; i<mips; i++) {
+                    mipWidth = Math.max(mipWidth * 0.5, 1);
+                    mipHeight = Math.max(mipHeight * 0.5, 1);
+                    mip = new pc.Texture(device, {
+                        cubemap: false,
+                        format: pc.PIXELFORMAT_R8_G8_B8_A8,
+                        width: mipWidth,
+                        height: mipHeight,
+                        autoMipmap: false
+                    });
+                    mip.minFilter = pc.FILTER_LINEAR;
+                    mip.magFilter = pc.FILTER_LINEAR;
+                    mip.addressU = pc.ADDRESS_CLAMP_TO_EDGE;
+                    mip.addressV = pc.ADDRESS_CLAMP_TO_EDGE;
+                    targ = new pc.RenderTarget(device, mip, {
+                        depth: false
+                    });
+                    constantTexSource.setValue(lastMip);
+                    params.x = mipWidth / this.animTexTilesX;
+                    params.y = mipHeight / this.animTexTilesY;
+                    params.z = params.x - 1;
+                    params.w = params.y - 1;
+                    pc.drawQuadWithShader(device, targ, shader2);
+                    syncToCpu(device, targ);
+                    newTex._levels[i] = mip._levels[0];
+                    lastMip = mip;
+                }
+
+                newTex.upload();
+                newTex.minFilter = pc.FILTER_LINEAR_MIPMAP_LINEAR;
+                newTex.magFilter = pc.FILTER_LINEAR;
+                newTex.addressU = pc.ADDRESS_CLAMP_TO_EDGE;
+                newTex.addressV = pc.ADDRESS_CLAMP_TO_EDGE;
+                newTex._prtMipX = this.animTexTilesX;
+                newTex._prtMipY = this.animTexTilesY;
+                this.colorMap = newTex;
+                this.material.setParameter('colorMap', this.colorMap);
+            }
         },
 
         calcSpawnPosition: function(emitterPos, i) {


### PR DESCRIPTION
Use atlas with animation frames of equal size.
New parameters:
- isAnimTex: is colorMap an atlas of frames?
- animTexTilesX: number of horizontal tiles
- animTexTilesY: number of vertical tiles
- animTexNumFrames: frames to play (if there's some empty space in the end)
- animTexSpeed: speed (1 = particle lifetime, 2 = twice during lifetime...)
- animTexLoop: should animation repeat?

normalMap currently will animate together with colorMap. Perhaps it should be tweakable, but I'd like to avoid to copy all these properties for each map.