### PR TITLE
Feature/asset registry prefix

### DIFF
--- a/src/asset/asset_registry.js
+++ b/src/asset/asset_registry.js
@@ -15,6 +15,8 @@ pc.extend(pc, function () {
         this._tags = new pc.TagsCache('_id'); // index for looking up by tags
         this._urls = {}; // index for looking up assets by url
 
+        this.prefix = null;
+
         pc.extend(this, pc.events);
     };
 
@@ -195,6 +197,13 @@ pc.extend(pc, function () {
 
             var _load = function () {
                 var url = asset.file.url;
+
+                if (self.prefix) {
+                    if (url.startsWith('/')) {
+                        url = url.slice(1);
+                    }
+                    url = pc.path.join(self.prefix, url);
+                }
 
                 // add file hash to avoid caching
                 url += '?t=' + asset.file.hash;

--- a/src/asset/asset_registry.js
+++ b/src/asset/asset_registry.js
@@ -198,6 +198,7 @@ pc.extend(pc, function () {
             var _load = function () {
                 var url = asset.file.url;
 
+                // apply prefix if present
                 if (self.prefix) {
                     if (url.startsWith('/')) {
                         url = url.slice(1);

--- a/src/framework/framework_application.js
+++ b/src/framework/framework_application.js
@@ -72,7 +72,6 @@ pc.extend(pc, function () {
         this._skyboxLast = 0;
 
         this._scriptPrefix = options.scriptPrefix || '';
-        // this._scripts = [];
 
         this.loader.addHandler("animation", new pc.AnimationHandler());
         this.loader.addHandler("model", new pc.ModelHandler(this.graphicsDevice));
@@ -149,7 +148,7 @@ pc.extend(pc, function () {
     Application.prototype = {
         /**
         * @name pc.Application#configure
-        * @description Load a configuration file from
+        * @description Load the application configuration file
         */
         configure: function (url, callback) {
             var self = this;
@@ -432,6 +431,19 @@ pc.extend(pc, function () {
             if (props['use_device_pixel_ratio']) {
                 this.graphicsDevice.maxPixelRatio = window.devicePixelRatio;
             }
+
+            if (props['asset_prefix']) {
+                this.assets.prefix = props['asset_prefix'];
+
+                // prefix scripts as well
+                if (this.systems.script._prefix) {
+                    this.systems.script._prefix = pc.path.join(props['asset_prefix'], this.systems.script._prefix);
+                } else {
+                    this.systems.script._prefix = props['asset_prefix'];
+                }
+
+            }
+
 
             this.setCanvasResolution(props['resolution_mode'], this._width, this._height);
             this.setCanvasFillMode(props['fill_mode'], this._width, this._height);

--- a/src/framework/framework_application.js
+++ b/src/framework/framework_application.js
@@ -432,19 +432,6 @@ pc.extend(pc, function () {
                 this.graphicsDevice.maxPixelRatio = window.devicePixelRatio;
             }
 
-            if (props['asset_prefix']) {
-                this.assets.prefix = props['asset_prefix'];
-
-                // prefix scripts as well
-                if (this.systems.script._prefix) {
-                    this.systems.script._prefix = pc.path.join(props['asset_prefix'], this.systems.script._prefix);
-                } else {
-                    this.systems.script._prefix = props['asset_prefix'];
-                }
-
-            }
-
-
             this.setCanvasResolution(props['resolution_mode'], this._width, this._height);
             this.setCanvasFillMode(props['fill_mode'], this._width, this._height);
 


### PR DESCRIPTION
Allow users to set `prefix` property on `pc.AssetRegistry` which prefixes all asset requests with a path section. Resolves #316

e.g. Add this code before preloading assets

`app.assets.prefix = "/test-dir";`

All asset requests will be loaded from relative to `'/test-dir'`.



