### PR TITLE
PhongMaterial's default shadingModel is not consistent.

### DIFF
--- a/src/scene/phong-material.js
+++ b/src/scene/phong-material.js
@@ -963,7 +963,7 @@ pc.extend(pc, function () {
         _defineFlag(obj, "normalizeNormalMap", true);
         _defineFlag(obj, "conserveEnergy", true);
         _defineFlag(obj, "occludeSpecular", pc.SPECOCC_AO);
-        _defineFlag(obj, "shadingModel", pc.SPECULAR_PHONG);
+        _defineFlag(obj, "shadingModel", pc.SPECULAR_BLINN);
         _defineFlag(obj, "fresnelModel", pc.FRESNEL_NONE);
         _defineFlag(obj, "cubeMapProjection", pc.CUBEPROJ_NONE);
         _defineFlag(obj, "shadowSampleType", pc.SHADOWSAMPLE_PCF3X3);

--- a/src/scene/phong-material.js
+++ b/src/scene/phong-material.js
@@ -408,6 +408,15 @@ pc.extend(pc, function () {
 
     PhongMaterial = pc.inherits(PhongMaterial, pc.Material);
 
+    function Chunks(){}
+    Chunks.prototype.copy = function(from) {
+        for(var p in from) {
+            if (from.hasOwnProperty(p) && p!=="copy") {
+                this[p] = from[p];
+            }
+        }
+    };
+
     pc.extend(PhongMaterial.prototype, {
 
         reset: function () {
@@ -425,14 +434,7 @@ pc.extend(pc, function () {
                 this[ _propsInternalVec3[i] ] = new Float32Array(3);
             }
 
-            this._chunks = {};
-            this._chunks.copy = function(from) {
-                for(var p in from) {
-                    if (from.hasOwnProperty(p) && p!=="copy") {
-                        this[p] = from[p];
-                    }
-                }
-            };
+            this._chunks = new Chunks();
 
             this.cubeMapMinUniform = new Float32Array(3);
             this.cubeMapMaxUniform = new Float32Array(3);


### PR DESCRIPTION
In the current version, newly created PhongMaterial has `shadingModel` of `pc.SPECULAR_PHONG`
```
var material = new pc.PhongMaterial();
console.log( material.shadingModel == pc.SPECULAR_PHONG ); // true
```

while newly created model's material is `pc.SPECULAR_BLINN`
```
var entity = new pc.Entity()
entity.addComponent( "model", {type:"box"} );
console.log( entity.model.material.shadingModel == pc.SPECULAR_BLINN ); // also true
```