### PR TITLE
Fix directional light's shadow projection.

### DIFF
--- a/src/scene/forward-renderer.js
+++ b/src/scene/forward-renderer.js
@@ -800,7 +800,7 @@ pc.extend(pc, function () {
                         }
 
                         // 4. Use your min and max values to create an off-center orthographic projection.
-                        shadowCam._node.translateLocal(-(maxx + minx) * 0.5, (maxy + miny) * 0.5, maxz + (maxz - minz) * 0.25);
+                        shadowCam._node.translateLocal((maxx + minx) * 0.5, (maxy + miny) * 0.5, maxz + (maxz - minz) * 0.25);
                         shadowCamWtm.copy(shadowCam._node.getWorldTransform());
 
                         shadowCam.setProjection(pc.PROJECTION_ORTHOGRAPHIC);


### PR DESCRIPTION
There's an error when calculating shadow projection for directional lights.

Here's a scene to reproduce the error: ( one of the box's shadow is missing. )
http://playcanvas.com/editor/scene/401144/launch

The missing shadow should be visible after applying this patch.