### PR TITLE
Fix directional light problems

### DIFF
--- a/src/scene/forward-renderer.js
+++ b/src/scene/forward-renderer.js
@@ -180,7 +180,7 @@ pc.extend(pc, function () {
         return true;
     };
 
-    var _sceneAABB = [
+    var _sceneAABB_LS = [
         new pc.Vec3(), new pc.Vec3(), new pc.Vec3(), new pc.Vec3(),
         new pc.Vec3(), new pc.Vec3(), new pc.Vec3(), new pc.Vec3()
     ];
@@ -193,15 +193,15 @@ pc.extend(pc, function () {
         2,3,6,  3,6,7
     ];
     function _getZFromAABB(w2sc, aabbMin, aabbMax, lcamMinX, lcamMaxX, lcamMinY, lcamMaxY) {
-        _sceneAABB[0].x = _sceneAABB[1].x = _sceneAABB[2].x = _sceneAABB[3].x = aabbMin.x;
-        _sceneAABB[1].y = _sceneAABB[3].y = _sceneAABB[7].y = _sceneAABB[5].y = aabbMin.y;
-        _sceneAABB[2].z = _sceneAABB[3].z = _sceneAABB[6].z = _sceneAABB[7].z = aabbMin.z;
-        _sceneAABB[4].x = _sceneAABB[5].x = _sceneAABB[6].x = _sceneAABB[7].x = aabbMax.x;
-        _sceneAABB[0].y = _sceneAABB[2].y = _sceneAABB[4].y = _sceneAABB[6].y = aabbMax.y;
-        _sceneAABB[0].z = _sceneAABB[1].z = _sceneAABB[4].z = _sceneAABB[5].z = aabbMax.z;
+        _sceneAABB_LS[0].x = _sceneAABB_LS[1].x = _sceneAABB_LS[2].x = _sceneAABB_LS[3].x = aabbMin.x;
+        _sceneAABB_LS[1].y = _sceneAABB_LS[3].y = _sceneAABB_LS[7].y = _sceneAABB_LS[5].y = aabbMin.y;
+        _sceneAABB_LS[2].z = _sceneAABB_LS[3].z = _sceneAABB_LS[6].z = _sceneAABB_LS[7].z = aabbMin.z;
+        _sceneAABB_LS[4].x = _sceneAABB_LS[5].x = _sceneAABB_LS[6].x = _sceneAABB_LS[7].x = aabbMax.x;
+        _sceneAABB_LS[0].y = _sceneAABB_LS[2].y = _sceneAABB_LS[4].y = _sceneAABB_LS[6].y = aabbMax.y;
+        _sceneAABB_LS[0].z = _sceneAABB_LS[1].z = _sceneAABB_LS[4].z = _sceneAABB_LS[5].z = aabbMax.z;
 
         for ( var i = 0; i < 8; ++i ) {
-            w2sc.transformPoint( _sceneAABB[i], _sceneAABB[i] );
+            w2sc.transformPoint( _sceneAABB_LS[i], _sceneAABB_LS[i] );
         }
 
         var minz = 9999999999;
@@ -214,9 +214,9 @@ pc.extend(pc, function () {
         var zs            = [];
 
         for (var AABBTriIter = 0; AABBTriIter < 12; ++AABBTriIter) {
-          vertice[0] = _sceneAABB[iAABBTriIndexes[AABBTriIter * 3 + 0]];
-          vertice[1] = _sceneAABB[iAABBTriIndexes[AABBTriIter * 3 + 1]];
-          vertice[2] = _sceneAABB[iAABBTriIndexes[AABBTriIter * 3 + 2]];
+          vertice[0] = _sceneAABB_LS[iAABBTriIndexes[AABBTriIter * 3 + 0]];
+          vertice[1] = _sceneAABB_LS[iAABBTriIndexes[AABBTriIter * 3 + 1]];
+          vertice[2] = _sceneAABB_LS[iAABBTriIndexes[AABBTriIter * 3 + 2]];
 
           var verticeWithinBound = 0;
 

--- a/src/scene/forward-renderer.js
+++ b/src/scene/forward-renderer.js
@@ -234,7 +234,7 @@ pc.extend(pc, function () {
         var vertices = intersectCache.vertices;
         var positive = intersectCache.positive;
         var zs       = intersectCache.zCollection;
-        zs.length = 0;
+        zs.size = 0;
 
         for (var AABBTriIter = 0; AABBTriIter < 12; ++AABBTriIter) {
           vertices[0] = _sceneAABB_LS[iAABBTriIndexes[AABBTriIter * 3 + 0]];
@@ -266,7 +266,7 @@ pc.extend(pc, function () {
         }
 
         var z;
-        for (var j = 0, len = zs.length; j < len; j++) {
+        for (var j = 0, len = zs.size; j < len; j++) {
             z = zs(j);
             if (z < minz) minz = z;
             if (z > maxz) maxz = z;

--- a/src/scene/forward-renderer.js
+++ b/src/scene/forward-renderer.js
@@ -104,7 +104,8 @@ pc.extend(pc, function () {
         vertices      : new Array(3),
         negative      : new StaticArray(3),
         positive      : new StaticArray(3),
-        intersections : new StaticArray(3)
+        intersections : new StaticArray(3),
+        zCollection   : new StaticArray(36)
     };
     function _groupVertices(coord, face, smallerIsNegative) {
         var intersections = intersectCache.intersections;
@@ -230,9 +231,10 @@ pc.extend(pc, function () {
         var minz = 9999999999;
         var maxz = -9999999999;
 
-        var vertices      = intersectCache.vertices;
-        var positive      = intersectCache.positive;
-        var zs            = [];
+        var vertices = intersectCache.vertices;
+        var positive = intersectCache.positive;
+        var zs       = intersectCache.zCollection;
+        zs.length = 0;
 
         for (var AABBTriIter = 0; AABBTriIter < 12; ++AABBTriIter) {
           vertices[0] = _sceneAABB_LS[iAABBTriIndexes[AABBTriIter * 3 + 0]];
@@ -265,7 +267,7 @@ pc.extend(pc, function () {
 
         var z;
         for (var j = 0, len = zs.length; j < len; j++) {
-            z = zs[j];
+            z = zs(j);
             if (z < minz) minz = z;
             if (z > maxz) maxz = z;
         }

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -278,7 +278,20 @@ pc.extend(pc, function () {
 
         this._updateShaders = true;
         this._sceneShadersVersion = 0;
+
+        this._aabb = null;
     };
+
+    // If aabb is not set or not large enough to cover the whole scene, some shadow might disappear.
+    Object.defineProperty(Scene.prototype, 'aabb', {
+        get: function () {
+            return this._aabb;
+        },
+        set: function (value) {
+            this._aabb = value;
+        }
+    });
+
 
     Object.defineProperty(Scene.prototype, 'updateShaders', {
         get: function () {

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -278,20 +278,7 @@ pc.extend(pc, function () {
 
         this._updateShaders = true;
         this._sceneShadersVersion = 0;
-
-        this._aabb = null;
     };
-
-    // If aabb is not set or not large enough to cover the whole scene, some shadow might disappear.
-    Object.defineProperty(Scene.prototype, 'aabb', {
-        get: function () {
-            return this._aabb;
-        },
-        set: function (value) {
-            this._aabb = value;
-        }
-    });
-
 
     Object.defineProperty(Scene.prototype, 'updateShaders', {
         get: function () {


### PR DESCRIPTION
Problems including:
1. Missing shadows for object between light source and view frustum
2. Shadow shimmering.

The fix merely does what this link said:
https://msdn.microsoft.com/en-us/library/windows/desktop/ee416324(v=vs.85).aspx

------

Notice that, in order to make shadow works correctly, one must __set the scene's AABB__ before rendering.

For example, in
https://playcanvas.com/project/336533/overview/sponza-atrium,
one can set the scene's AABB to:
`app.scene.aabb = new pc.BoundingBox(new pc.Vec3(0, 6, 0), new pc.Vec3(50, 30, 50))`

There's a function called `_calculateSceneAabb()` in the renderer, though it currently fails to work.

------

I also did some cleanup, and I didn't test if point light and spot light are fine about the patch. So do heavy tests before merging.