### PR TITLE
use 16 as default lightmap size multiplier

### DIFF
--- a/src/scene/lightmapper.js
+++ b/src/scene/lightmapper.js
@@ -87,7 +87,7 @@ pc.extend(pc, function () {
     Lightmapper.prototype = {
 
         calculateLightmapSize: function(node, nodesMeshInstances) {
-            var sizeMult = this.scene.lightmapSizeMultiplier || 1;
+            var sizeMult = this.scene.lightmapSizeMultiplier || 16;
             var scale = tempVec;
             var parent;
             var area = {x:1, y:1, z:1, uv:1};


### PR DESCRIPTION
(to be consistent with default editor scene value)