### PR TITLE
More LM stats

### DIFF
--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -615,6 +615,7 @@ pc.extend(pc, function () {
             stats.materials = this.renderer._materialSwitches;
             stats.shaders = this.graphicsDevice._shaderSwitchesPerFrame;
             stats.shadowMapUpdates = this.renderer._shadowMapUpdates;
+            stats.shadowMapTime = this.renderer._shadowMapTime;
             var prims = this.graphicsDevice._primsPerFrame;
             stats.triangles = prims[pc.PRIMITIVE_TRIANGLES]/3 +
                 Math.max(prims[pc.PRIMITIVE_TRISTRIP]-2, 0) +

--- a/src/framework/stats.js
+++ b/src/framework/stats.js
@@ -18,6 +18,7 @@ pc.ApplicationStats = function(device) {
         materials: 0,
         cameras: 0,
         shadowMapUpdates: 0,
+        shadowMapTime: 0,
 
         _timeToCountFrames: 0,
         _fpsAccum: 0

--- a/src/graphics/device.js
+++ b/src/graphics/device.js
@@ -521,6 +521,7 @@ pc.extend(pc, function () {
             for(i=pc.PRIMITIVE_POINTS; i<=pc.PRIMITIVE_TRIFAN; i++) {
                 this._primsPerFrame[i] = 0;
             }
+            this._renderTargetCreationTime = 0;
 
             this._vram = {
                 tex: 0,
@@ -624,6 +625,9 @@ pc.extend(pc, function () {
             if (target) {
                 // Create a new WebGL frame buffer object
                 if (!target._glFrameBuffer) {
+
+                    var startTime = pc.now();
+
                     target._glFrameBuffer = gl.createFramebuffer();
                     gl.bindFramebuffer(gl.FRAMEBUFFER, target._glFrameBuffer);
 
@@ -674,6 +678,10 @@ pc.extend(pc, function () {
                         default:
                             break;
                     }
+
+
+                    this._renderTargetCreationTime += pc.now() - startTime;
+
                 } else {
                     gl.bindFramebuffer(gl.FRAMEBUFFER, target._glFrameBuffer);
                 }

--- a/src/scene/forward-renderer.js
+++ b/src/scene/forward-renderer.js
@@ -399,6 +399,7 @@ pc.extend(pc, function () {
         this._camerasRendered = 0;
         this._materialSwitches = 0;
         this._shadowMapUpdates = 0;
+        this._shadowMapTime = 0;
         this._cullTime = 0;
 
         // Shaders
@@ -965,6 +966,7 @@ pc.extend(pc, function () {
 
             // Render all shadowmaps
             var minx, miny, minz, maxx, maxy, maxz, centerx, centery;
+            var shadowMapStartTime = pc.now();
             for (i = 0; i < lights.length; i++) {
                 light = lights[i];
                 var type = light.getType();
@@ -1209,6 +1211,7 @@ pc.extend(pc, function () {
                     } // end pass
                 }
             }
+            this._shadowMapTime = pc.now() - shadowMapStartTime;
 
             // Set up the camera
             this.setCamera(camera);

--- a/src/scene/lightmapper.js
+++ b/src/scene/lightmapper.js
@@ -79,7 +79,10 @@ pc.extend(pc, function () {
             renderPasses: 0,
             lightmapCount: 0,
             lightmapMem: 0,
-            renderTime: 0,
+            totalRenderTime: 0,
+            shadowMapTime: 0,
+            fboTime: 0,
+            shadowMapTime: 0,
             shadersLinked: 0
         };
     };
@@ -148,8 +151,10 @@ pc.extend(pc, function () {
             var scene = this.scene;
             var stats = this._stats;
 
-            stats.renderPasses = 0;
+            stats.renderPasses = stats.lightmapMem = 0;
             var startShaders = device._shaderStats.linked;
+            var startFboTime = device._renderTargetCreationTime;
+            var startShadowTime = this.renderer._shadowMapTime;
 
             var allNodes = [];
             var nodesMeshInstances = [];
@@ -569,8 +574,10 @@ pc.extend(pc, function () {
                 target: this
             });
 
-            stats.renderTime = pc.now() - startTime;
+            stats.totalRenderTime = pc.now() - startTime;
             stats.shadersLinked = device._shaderStats.linked - startShaders;
+            stats.fboTime = device._renderTargetCreationTime - startFboTime;
+            stats.shadowMapTime = renderer._shadowMapTime - startShadowTime;
         }
     };
 

--- a/src/scene/lightmapper.js
+++ b/src/scene/lightmapper.js
@@ -151,10 +151,9 @@ pc.extend(pc, function () {
             var scene = this.scene;
             var stats = this._stats;
 
-            stats.renderPasses = stats.lightmapMem = 0;
+            stats.renderPasses = stats.lightmapMem = stats.shadowMapTime = 0;
             var startShaders = device._shaderStats.linked;
             var startFboTime = device._renderTargetCreationTime;
-            var startShadowTime = this.renderer._shadowMapTime;
 
             var allNodes = [];
             var nodesMeshInstances = [];
@@ -478,6 +477,7 @@ pc.extend(pc, function () {
                     //console.log("Baking light "+lights[i]._node.name + " on model " + nodes[node].name);
 
                     this.renderer.render(scene, lmCamera);
+                    stats.shadowMapTime += this.renderer._shadowMapTime;
                     stats.renderPasses++;
 
                     lmaps[node] = texTmp;
@@ -577,7 +577,6 @@ pc.extend(pc, function () {
             stats.totalRenderTime = pc.now() - startTime;
             stats.shadersLinked = device._shaderStats.linked - startShaders;
             stats.fboTime = device._renderTargetCreationTime - startFboTime;
-            stats.shadowMapTime = renderer._shadowMapTime - startShadowTime;
         }
     };
 


### PR DESCRIPTION
- Fixed LM memory counter;
- renderTime renamed to totalRenderTime;
- added stats.lightmapper.fboTime to measure time spent on render target creation;
- added stats.lightmapper.shadowMapTime to measure time spent on rendering shadow maps;
- added stats.frame.shadowMapTime to measure per-frame shadow map rendering time