### PR TITLE
Scripts 2.0

### DIFF
--- a/build/dependencies.txt
+++ b/build/dependencies.txt
@@ -93,6 +93,8 @@
 ../src/input/touch.js
 ../src/input/controller.js
 ../src/net/http.js
+../src/script/script-registry.js
+../src/script/script.js
 ../src/framework/script.js
 ../src/framework/content-file.js
 ../src/framework/pack.js
@@ -118,6 +120,9 @@
 ../src/framework/components/script/system.js
 ../src/framework/components/script/component.js
 ../src/framework/components/script/data.js
+../src/framework/components/script-legacy/system.js
+../src/framework/components/script-legacy/component.js
+../src/framework/components/script-legacy/data.js
 ../src/framework/components/sound/constants.js
 ../src/framework/components/sound/slot.js
 ../src/framework/components/sound/system.js

--- a/src/asset/asset-registry.js
+++ b/src/asset/asset-registry.js
@@ -341,7 +341,11 @@ pc.extend(pc, function () {
 
                 asset.loading = true;
 
-                self._loader.load(url, asset.type, function (err, resource) {
+                if (! pc.script.legacy && asset.type === 'script') {
+                    var loader = self._loader.getHandler('script');
+                }
+
+                self._loader.load(url, asset.type, function (err, resource, extra) {
                     asset.loaded = true;
                     asset.loading = false;
 
@@ -355,6 +359,17 @@ pc.extend(pc, function () {
                         asset.resources = resource;
                     } else {
                         asset.resource = resource;
+                    }
+
+                    if (! pc.script.legacy && asset.type === 'script') {
+                        var loader = self._loader.getHandler('script');
+
+                        if (loader._cache[asset.id]) {
+                            // remove old element
+                            document.head.removeChild(loader._cache[asset.id]);
+                        }
+
+                        loader._cache[asset.id] = extra;
                     }
 
                     self._loader.patch(asset, self);

--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -61,7 +61,11 @@ pc.extend(pc, function () {
         this.scene = new pc.Scene();
         this.root = new pc.Entity(this);
         this.root._enabledInHierarchy = true;
+        this._enableList = [ ];
+        this._enableList.size = 0;
         this.assets = new pc.AssetRegistry(this.loader);
+        this.scriptsOrder = options.scriptsOrder || [ ];
+        this.scripts = new pc.ScriptRegistry(this);
         this.renderer = new pc.ForwardRenderer(this.graphicsDevice);
         this.lightmapper = new pc.Lightmapper(this.graphicsDevice, this.root, this.scene, this.renderer, this.assets);
         this.once('prerender', this._firstBake, this);
@@ -100,7 +104,11 @@ pc.extend(pc, function () {
         var modelsys = new pc.ModelComponentSystem(this);
         var camerasys = new pc.CameraComponentSystem(this);
         var lightsys = new pc.LightComponentSystem(this);
-        var scriptsys = new pc.ScriptComponentSystem(this, options.scriptPrefix);
+        if (pc.script.legacy) {
+            new pc.ScriptLegacyComponentSystem(this, options.scriptPrefix);
+        } else {
+            new pc.ScriptComponentSystem(this);
+        }
         var audiosourcesys = new pc.AudioSourceComponentSystem(this, this._audioManager);
         var soundsys = new pc.SoundComponentSystem(this, this._audioManager);
         var audiolistenersys = new pc.AudioListenerComponentSystem(this, this._audioManager);
@@ -225,7 +233,6 @@ pc.extend(pc, function () {
 
             var i;
             if (_assets.length) {
-
                 var onAssetLoad = function(asset) {
                     _assets.inc();
                     self.fire('preload:progress', count() / total);
@@ -242,6 +249,30 @@ pc.extend(pc, function () {
                         done();
                 };
 
+                if (! pc.script.legacy) {
+                    // build preloading scripts index
+                    var preloadScriptsIndex = { };
+                    for (i = 0; i < this.scriptsOrder.length; i++)
+                        preloadScriptsIndex[this.scriptsOrder[i]] = i;
+
+                    // sort preloading assets
+                    assets.sort(function(a, b) {
+                        if (a.type === 'script' && b.type === 'script') {
+                            var aInd = preloadScriptsIndex.hasOwnProperty(a.id) ? preloadScriptsIndex[a.id] : Number.MAX_SAFE_INTEGER;
+                            var bInd = preloadScriptsIndex.hasOwnProperty(b.id) ? preloadScriptsIndex[b.id] : Number.MAX_SAFE_INTEGER;
+                            // sort scripts based on preloading order
+                            return aInd - bInd;
+                        } else if ((a.type === 'script' || b.type === 'script') && a.type !== b.type) {
+                            // preload scripts first
+                            return a.type === 'script' ? -1 : 1;
+                        } else {
+                            // no sorting
+                            return 0;
+                        }
+                    });
+                }
+
+                // for each asset
                 for (i = 0; i < _assets.length; i++) {
                     if (!assets[i].loaded) {
                         assets[i].once('load', onAssetLoad);
@@ -388,6 +419,11 @@ pc.extend(pc, function () {
         },
 
         _preloadScripts: function (sceneData, callback) {
+            if (pc.script.legacy) {
+                callback();
+                return;
+            }
+
             var self = this;
 
             self.systems.script.preloading = true;

--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -715,6 +715,9 @@ pc.extend(pc, function () {
 
             Application._currentApplication = this;
 
+            // have current application pointer in pc
+            pc.app = this;
+
             // Submit a request to queue up a new animation frame immediately
             window.requestAnimationFrame(this.tick.bind(this));
 

--- a/src/framework/components/component.js
+++ b/src/framework/components/component.js
@@ -76,11 +76,11 @@ pc.extend(pc, function () {
             }
         },
 
-        onEnable: function () {
-        },
+        onEnable: function () { },
 
-        onDisable: function () {
-        }
+        onDisable: function () { },
+
+        onPostStateChange: function() { }
     };
 
     return {

--- a/src/framework/components/model/data.js
+++ b/src/framework/components/model/data.js
@@ -12,7 +12,7 @@ pc.extend(pc, function() {
         this.enabled = true;
         this.type = 'asset';
         this.asset = null;
-        this.castShadows = false;
+        this.castShadows = true;
         this.receiveShadows = true;
         this.materialAsset = null;
         this.mapping = null;

--- a/src/framework/components/script-legacy/component.js
+++ b/src/framework/components/script-legacy/component.js
@@ -1,35 +1,10 @@
 pc.extend(pc, function () {
-    /**
-    * @component
-    * @name pc.ScriptLegacyComponent
-    * @class The ScriptLegacyComponent allows you to extend the functionality of an Entity by attaching your own javascript files
-    * to be executed with access to the Entity. For more details on scripting see <a href="//developer.playcanvas.com/user-manual/scripting/">Scripting</a>.
-    * @param {pc.ScriptLegacyComponentSystem} system The ComponentSystem that created this Component
-    * @param {pc.Entity} entity The Entity that this Component is attached to.
-    * @extends pc.Component
-    * @property {Array} scripts An array of all the scripts to load. Each script object has this format:
-    * {url: 'url.js', name: 'url', 'attributes': [attribute1, attribute2, ...]}
-    */
-
     var ScriptLegacyComponent = function ScriptLegacyComponent(system, entity) {
         this.on("set_scripts", this.onSetScripts, this);
     };
     ScriptLegacyComponent = pc.inherits(ScriptLegacyComponent, pc.Component);
 
     pc.extend(ScriptLegacyComponent.prototype, {
-        /**
-         * @private
-         * @function
-         * @name pc.ScriptLegacyComponent#send
-         * @description Send a message to a script attached to the entity.
-         * Sending a message to a script is similar to calling a method on a Script Object, except that the message will not fail if the method isn't present.
-         * @param {String} name The name of the script to send the message to
-         * @param {String} functionName The name of the function to call on the script
-         * @returns The result of the function call
-         * @example
-         * // Call doDamage(10) on the script object called 'enemy' attached to entity.
-         * entity.script.send('enemy', 'doDamage', 10);
-         */
         send: function (name, functionName) {
             console.warn("DEPRECATED: ScriptLegacyComponent.send() is deprecated and will be removed soon. Please use: http://developer.playcanvas.com/user-manual/scripting/communication/");
             var args = pc.makeArray(arguments).slice(2);
@@ -230,51 +205,6 @@ pc.extend(pc, function () {
                 }.bind(this));
             }.bind(this));
         },
-
-        // Load each script url asynchronously using the resource loader
-        // _loadScripts: function (urls) {
-        //     // Load and register new scripts and instances
-        //     var requests = urls.map(function (url) {
-        //         return new pc.resources.ScriptRequest(url);
-        //     });
-
-        //     var options = {
-        //         parent: this.entity.getRequest()
-        //     };
-
-        //     var promise = this.system.app.loader.request(requests, options);
-        //     promise.then(function (resources) {
-        //         resources.forEach(function (ScriptType, index) {
-        //             // ScriptType may be null if the script component is loading an ordinary javascript lib rather than a PlayCanvas script
-        //             // Make sure that script component hasn't been removed since we started loading
-        //             if (ScriptType && this.entity.script) {
-        //                 // Make sure that we haven't already instaciated another identical script while loading
-        //                 // e.g. if you do addComponent, removeComponent, addComponent, in quick succession
-        //                 if (!this.entity.script.instances[ScriptType._pcScriptName]) {
-        //                     var instance = new ScriptType(this.entity);
-        //                     this.system._preRegisterInstance(this.entity, urls[index], ScriptType._pcScriptName, instance);
-        //                 }
-        //             }
-        //         }, this);
-
-        //         if (this.data) {
-        //             this.data.areScriptsLoaded = true;
-        //         }
-
-        //         // If there is no request batch, then this is not part of a load request and so we need
-        //         // to register the instances immediately to call the initialize function
-        //         if (!options.parent) {
-        //             this.system.onInitialize(this.entity);
-        //             this.system.onPostInitialize(this.entity);
-        //         }
-        //     }.bind(this)).then(null, function (error) {
-        //         // Re-throw any exceptions from the Script constructor to stop them being swallowed by the Promises lib
-        //         setTimeout(function () {
-        //             throw error;
-        //         })
-        //     });
-        // }
-
     });
 
     return {

--- a/src/framework/components/script-legacy/component.js
+++ b/src/framework/components/script-legacy/component.js
@@ -1,0 +1,283 @@
+pc.extend(pc, function () {
+    /**
+    * @component
+    * @name pc.ScriptLegacyComponent
+    * @class The ScriptLegacyComponent allows you to extend the functionality of an Entity by attaching your own javascript files
+    * to be executed with access to the Entity. For more details on scripting see <a href="//developer.playcanvas.com/user-manual/scripting/">Scripting</a>.
+    * @param {pc.ScriptLegacyComponentSystem} system The ComponentSystem that created this Component
+    * @param {pc.Entity} entity The Entity that this Component is attached to.
+    * @extends pc.Component
+    * @property {Array} scripts An array of all the scripts to load. Each script object has this format:
+    * {url: 'url.js', name: 'url', 'attributes': [attribute1, attribute2, ...]}
+    */
+
+    var ScriptLegacyComponent = function ScriptLegacyComponent(system, entity) {
+        this.on("set_scripts", this.onSetScripts, this);
+    };
+    ScriptLegacyComponent = pc.inherits(ScriptLegacyComponent, pc.Component);
+
+    pc.extend(ScriptLegacyComponent.prototype, {
+        /**
+         * @private
+         * @function
+         * @name pc.ScriptLegacyComponent#send
+         * @description Send a message to a script attached to the entity.
+         * Sending a message to a script is similar to calling a method on a Script Object, except that the message will not fail if the method isn't present.
+         * @param {String} name The name of the script to send the message to
+         * @param {String} functionName The name of the function to call on the script
+         * @returns The result of the function call
+         * @example
+         * // Call doDamage(10) on the script object called 'enemy' attached to entity.
+         * entity.script.send('enemy', 'doDamage', 10);
+         */
+        send: function (name, functionName) {
+            console.warn("DEPRECATED: ScriptLegacyComponent.send() is deprecated and will be removed soon. Please use: http://developer.playcanvas.com/user-manual/scripting/communication/");
+            var args = pc.makeArray(arguments).slice(2);
+            var instances = this.entity.script.instances;
+            var fn;
+
+            if(instances && instances[name]) {
+                fn = instances[name].instance[functionName];
+                if (fn) {
+                    return fn.apply(instances[name].instance, args);
+                }
+
+            }
+        },
+
+        onEnable: function () {
+            ScriptLegacyComponent._super.onEnable.call(this);
+
+            // if the scripts of the component have been loaded
+            // then call the appropriate methods on the component
+            if (this.data.areScriptsLoaded && !this.system.preloading) {
+                if (!this.data.initialized) {
+                    this.system._initializeScriptComponent(this);
+                } else {
+                    this.system._enableScriptComponent(this);
+                }
+
+                if (!this.data.postInitialized) {
+                    this.system._postInitializeScriptComponent(this);
+                }
+            }
+        },
+
+        onDisable: function () {
+            ScriptLegacyComponent._super.onDisable.call(this);
+            this.system._disableScriptComponent(this);
+        },
+
+        onSetScripts: function(name, oldValue, newValue) {
+            if (!this.system._inTools || this.runInTools) {
+                // if we only need to update script attributes then update them and return
+                if (this._updateScriptAttributes(oldValue, newValue)) {
+                    return;
+                }
+
+                // disable the script first
+                if (this.enabled) {
+                    this.system._disableScriptComponent(this);
+                }
+
+                this.system._destroyScriptComponent(this);
+
+                this.data.areScriptsLoaded = false;
+
+                // get the urls
+                var scripts = newValue;
+                var urls = scripts.map(function (s) {
+                    return s.url;
+                });
+
+                // try to load the scripts synchronously first
+                if (this._loadFromCache(urls)) {
+                    return;
+                }
+
+                // not all scripts are in the cache so load them asynchronously
+                this._loadScripts(urls);
+            }
+        },
+
+        // Check if only script attributes need updating in which
+        // case just update the attributes and return otherwise return false
+        _updateScriptAttributes: function (oldValue, newValue) {
+            var onlyUpdateAttributes = true;
+
+            if (oldValue.length !== newValue.length) {
+                onlyUpdateAttributes = false;
+            } else {
+                var i; len = newValue.length;
+                for (i=0; i<len; i++) {
+                    if (oldValue[i].url !== newValue[i].url) {
+                        onlyUpdateAttributes = false;
+                        break;
+                    }
+                }
+            }
+
+            if (onlyUpdateAttributes) {
+                for (var key in this.instances) {
+                    if (this.instances.hasOwnProperty(key)) {
+                        this.system._updateAccessors(this.entity, this.instances[key]);
+                    }
+                }
+            }
+
+            return onlyUpdateAttributes;
+        },
+
+        // Load each url from the cache synchronously. If one of the urls is not in the cache
+        // then stop and return false.
+        _loadFromCache: function (urls) {
+            var i, len;
+            var cached = [];
+
+            var prefix = this.system._prefix || "";
+            var regex = /^http(s)?:\/\//i;
+
+            for (i = 0, len = urls.length; i < len; i++) {
+                var url = urls[i];
+                if (! regex.test(url)) {
+                    url = pc.path.join(prefix, url);
+                }
+
+                var type = this.system.app.loader.getFromCache(url, 'script');
+
+                // if we cannot find the script in the cache then return and load
+                // all scripts with the resource loader
+                if (!type) {
+                    return false;
+                } else {
+                    cached.push(type);
+                }
+            }
+
+            for (i = 0, len = cached.length; i < len; i++) {
+                var ScriptType = cached[i];
+
+                // check if this is a regular JS file
+                if (ScriptType === true) {
+                    continue;
+                }
+
+                // ScriptType may be null if the script component is loading an ordinary javascript lib rather than a PlayCanvas script
+                // Make sure that script component hasn't been removed since we started loading
+                if (ScriptType && this.entity.script) {
+                    // Make sure that we haven't already instanciated another identical script while loading
+                    // e.g. if you do addComponent, removeComponent, addComponent, in quick succession
+                    if (!this.entity.script.instances[ScriptType._pcScriptName]) {
+                        var instance = new ScriptType(this.entity);
+                        this.system._preRegisterInstance(this.entity, urls[i], ScriptType._pcScriptName, instance);
+                    }
+                }
+            }
+
+            if (this.data) {
+                this.data.areScriptsLoaded = true;
+            }
+
+            // We only need to initalize after preloading is complete
+            // During preloading all scripts are initialized after everything is loaded
+            if (!this.system.preloading) {
+                this.system.onInitialize(this.entity);
+                this.system.onPostInitialize(this.entity);
+            }
+
+            return true;
+        },
+
+        _loadScripts: function (urls) {
+            var count = urls.length;
+
+            var prefix = this.system._prefix || "";
+
+            urls.forEach(function (url) {
+                var _url = null;
+                var _unprefixed = null;
+                // support absolute URLs (for now)
+                if (url.toLowerCase().startsWith("http://") || url.toLowerCase().startsWith("https://")) {
+                    _unprefixed = url;
+                    _url = url;
+                } else {
+                    _unprefixed = url;
+                    _url = pc.path.join(prefix, url);
+                }
+                this.system.app.loader.load(_url, "script", function (err, ScriptType) {
+                    count--;
+                    if (!err) {
+                        // ScriptType is null if the script is not a PlayCanvas script
+                        if (ScriptType && this.entity.script) {
+                            if (!this.entity.script.instances[ScriptType._pcScriptName]) {
+                                var instance = new ScriptType(this.entity);
+                                this.system._preRegisterInstance(this.entity, _unprefixed, ScriptType._pcScriptName, instance);
+                            }
+                        }
+                    } else {
+                        console.error(err);
+                    }
+                    if (count === 0) {
+                        this.data.areScriptsLoaded = true;
+
+                        // We only need to initalize after preloading is complete
+                        // During preloading all scripts are initialized after everything is loaded
+                        if (!this.system.preloading) {
+                            this.system.onInitialize(this.entity);
+                            this.system.onPostInitialize(this.entity);
+                        }
+                    }
+                }.bind(this));
+            }.bind(this));
+        },
+
+        // Load each script url asynchronously using the resource loader
+        // _loadScripts: function (urls) {
+        //     // Load and register new scripts and instances
+        //     var requests = urls.map(function (url) {
+        //         return new pc.resources.ScriptRequest(url);
+        //     });
+
+        //     var options = {
+        //         parent: this.entity.getRequest()
+        //     };
+
+        //     var promise = this.system.app.loader.request(requests, options);
+        //     promise.then(function (resources) {
+        //         resources.forEach(function (ScriptType, index) {
+        //             // ScriptType may be null if the script component is loading an ordinary javascript lib rather than a PlayCanvas script
+        //             // Make sure that script component hasn't been removed since we started loading
+        //             if (ScriptType && this.entity.script) {
+        //                 // Make sure that we haven't already instaciated another identical script while loading
+        //                 // e.g. if you do addComponent, removeComponent, addComponent, in quick succession
+        //                 if (!this.entity.script.instances[ScriptType._pcScriptName]) {
+        //                     var instance = new ScriptType(this.entity);
+        //                     this.system._preRegisterInstance(this.entity, urls[index], ScriptType._pcScriptName, instance);
+        //                 }
+        //             }
+        //         }, this);
+
+        //         if (this.data) {
+        //             this.data.areScriptsLoaded = true;
+        //         }
+
+        //         // If there is no request batch, then this is not part of a load request and so we need
+        //         // to register the instances immediately to call the initialize function
+        //         if (!options.parent) {
+        //             this.system.onInitialize(this.entity);
+        //             this.system.onPostInitialize(this.entity);
+        //         }
+        //     }.bind(this)).then(null, function (error) {
+        //         // Re-throw any exceptions from the Script constructor to stop them being swallowed by the Promises lib
+        //         setTimeout(function () {
+        //             throw error;
+        //         })
+        //     });
+        // }
+
+    });
+
+    return {
+        ScriptLegacyComponent: ScriptLegacyComponent
+    };
+}());

--- a/src/framework/components/script-legacy/data.js
+++ b/src/framework/components/script-legacy/data.js
@@ -1,0 +1,21 @@
+pc.extend(pc, function () {
+    var ScriptLegacyComponentData = function () {
+        // serialized
+        this.scripts = [];
+        this.enabled = true;
+
+        // not serialized
+        this.instances = {};
+        this._instances = {};
+        this.runInTools = false;
+        this.attributes = {};
+        this.initialized = false;
+        this.postInitialized = false;
+        this.areScriptsLoaded = false;
+    };
+    ScriptLegacyComponentData = pc.inherits(ScriptLegacyComponentData, pc.ComponentData);
+
+    return {
+        ScriptLegacyComponentData: ScriptLegacyComponentData
+    };
+}());

--- a/src/framework/components/script-legacy/system.js
+++ b/src/framework/components/script-legacy/system.js
@@ -1,0 +1,589 @@
+pc.extend(pc, function () {
+
+    var INITIALIZE = "initialize";
+    var POST_INITIALIZE = "postInitialize";
+    var UPDATE = "update";
+    var POST_UPDATE = "postUpdate";
+    var FIXED_UPDATE = "fixedUpdate";
+    var TOOLS_UPDATE = "toolsUpdate";
+    var ON_ENABLE = 'onEnable';
+    var ON_DISABLE = 'onDisable';
+
+    /**
+     * @name pc.ScriptLegacyComponentSystem
+     * @description Create a new ScriptLegacyComponentSystem
+     * @class Allows scripts to be attached to an Entity and executed
+     * @param {pc.Application} app The application
+     * @param {String} [prefix] An optional prefix that will be applied to all script URLs.
+     * @extends pc.ComponentSystem
+     */
+    var ScriptLegacyComponentSystem = function ScriptLegacyComponentSystem(app, prefix) {
+        this.id = 'script';
+        this.description = "Allows the Entity to run JavaScript fragments to implement custom behavior.";
+        app.systems.add(this.id, this);
+
+        this.ComponentType = pc.ScriptLegacyComponent;
+        this.DataType = pc.ScriptLegacyComponentData;
+        this._prefix = prefix || null;
+        this.schema = [
+            'enabled',
+            'scripts',
+            'instances',
+            'runInTools'
+        ];
+
+        // used by application during preloading phase to ensure scripts aren't
+        // initialized until everything is loaded
+        this.preloading = false;
+
+        // arrays to cache script instances for fast iteration
+        this.instancesWithUpdate = [];
+        this.instancesWithFixedUpdate = [];
+        this.instancesWithPostUpdate = [];
+        this.instancesWithToolsUpdate = [];
+
+        this.on('beforeremove', this.onBeforeRemove, this);
+        pc.ComponentSystem.on(INITIALIZE, this.onInitialize, this);
+        pc.ComponentSystem.on(POST_INITIALIZE, this.onPostInitialize, this);
+        pc.ComponentSystem.on(UPDATE, this.onUpdate, this);
+        pc.ComponentSystem.on(FIXED_UPDATE, this.onFixedUpdate, this);
+        pc.ComponentSystem.on(POST_UPDATE, this.onPostUpdate, this);
+        pc.ComponentSystem.on(TOOLS_UPDATE, this.onToolsUpdate, this);
+    };
+    ScriptLegacyComponentSystem = pc.inherits(ScriptLegacyComponentSystem, pc.ComponentSystem);
+
+    pc.extend(ScriptLegacyComponentSystem.prototype, {
+        initializeComponentData: function (component, data, properties) {
+            properties = ['runInTools', 'enabled', 'scripts'];
+
+            // convert attributes array to dictionary
+            if (data.scripts && data.scripts.length) {
+                data.scripts.forEach(function (script) {
+                    if (script.attributes && pc.type(script.attributes) === 'array') {
+                        var dict = {};
+                        for (var i = 0; i < script.attributes.length; i++) {
+                            dict[script.attributes[i].name] = script.attributes[i];
+                        }
+
+                        script.attributes = dict;
+                    }
+                });
+            }
+
+            ScriptLegacyComponentSystem._super.initializeComponentData.call(this, component, data, properties);
+        },
+
+        cloneComponent: function (entity, clone) {
+            // overridden to make sure urls list is duplicated
+            var src = this.dataStore[entity.getGuid()];
+            var data = {
+                runInTools: src.data.runInTools,
+                scripts: [],
+                enabled: src.data.enabled
+            };
+
+            // manually clone scripts so that we don't clone attributes with pc.extend
+            // which will result in a stack overflow when extending 'entity' script attributes
+            var scripts = src.data.scripts;
+            for (var i = 0, len = scripts.length; i < len; i++) {
+                var attributes = scripts[i].attributes;
+                if (attributes) {
+                    delete scripts[i].attributes;
+                }
+
+                data.scripts.push(pc.extend({}, scripts[i]));
+
+                if (attributes) {
+                    data.scripts[i].attributes = this._cloneAttributes(attributes);
+                    scripts[i].attributes = attributes;
+                }
+            }
+
+            return this.addComponent(clone, data);
+        },
+
+        /**
+        * @private
+        * @name pc.ScriptLegacyComponentSystem#onBeforeRemove
+        * @description Handler for 'beforeremove' event which is fired when a script component is about to be removed from an entity;
+        * @param {pc.Entity} entity The entity that the component will be removed from
+        * @param {pc.Component} component The component about to be removed
+        */
+        onBeforeRemove: function (entity, component) {
+            // if the script component is enabled
+            // call onDisable on all its instances first
+            if (component.enabled) {
+                this._disableScriptComponent(component);
+            }
+
+            // then call destroy on all the script instances
+            this._destroyScriptComponent(component);
+        },
+
+        /**
+         * @function
+         * @private
+         * @name pc.ScriptLegacyComponentSystem#onInitialize
+         * @description Handler for the 'initialize' event which is fired immediately after the Entity hierarchy is loaded, but before the first update loop
+         * @param {pc.Entity} root The root of the hierarchy to initialize.
+         */
+        onInitialize: function (root) {
+            this._registerInstances(root);
+
+            if (root.enabled) {
+                if (root.script && root.script.enabled) {
+                    this._initializeScriptComponent(root.script);
+                }
+
+                var children = root.getChildren();
+                var i, len = children.length;
+                for (i = 0; i < len; i++) {
+                    if (children[i] instanceof pc.Entity) {
+                        this.onInitialize(children[i]);
+                    }
+                }
+            }
+        },
+
+        /**
+         * @function
+         * @private
+         * @name pc.ScriptLegacyComponentSystem#onPostInitialize
+         * @description Handler for the 'postInitialize' event which is fired immediately after the 'initialize' event and before the first update loop
+         * @param {pc.Entity} root The root of the hierarchy to initialize.
+         */
+        onPostInitialize: function (root) {
+            if (root.enabled) {
+                if (root.script && root.script.enabled) {
+                    this._postInitializeScriptComponent(root.script);
+                }
+
+                var children = root.getChildren();
+                var i, len = children.length;
+                for (i = 0; i < len; i++) {
+                    if (children[i] instanceof pc.Entity) {
+                        this.onPostInitialize(children[i]);
+                    }
+                }
+            }
+        },
+
+        _callInstancesMethod: function (script, method) {
+            var instances = script.data.instances;
+            for (var name in instances) {
+                if (instances.hasOwnProperty(name)) {
+                    var instance = instances[name].instance;
+                    if (instance[method]) {
+                        instance[method].call(instance);
+                    }
+                }
+            }
+        },
+
+        _initializeScriptComponent: function (script) {
+            this._callInstancesMethod(script, INITIALIZE);
+            script.data.initialized = true;
+
+            // check again if the script and the entity are enabled
+            // in case they got disabled during initialize
+            if (script.enabled && script.entity.enabled) {
+                this._enableScriptComponent(script);
+            }
+        },
+
+        _enableScriptComponent: function (script) {
+            this._callInstancesMethod(script, ON_ENABLE);
+        },
+
+        _disableScriptComponent: function (script) {
+            this._callInstancesMethod(script, ON_DISABLE);
+        },
+
+        _destroyScriptComponent: function (script) {
+            var index;
+            var instances = script.data.instances;
+            for (var name in instances) {
+                if (instances.hasOwnProperty(name)) {
+                    var instance = instances[name].instance;
+                    if(instance.destroy) {
+                        instance.destroy();
+                    }
+
+                    if (instance.update) {
+                        index = this.instancesWithUpdate.indexOf(instance);
+                        if (index >= 0) {
+                            this.instancesWithUpdate.splice(index, 1);
+                        }
+                    }
+
+                    if (instance.fixedUpdate) {
+                        index = this.instancesWithFixedUpdate.indexOf(instance);
+                        if (index >= 0) {
+                            this.instancesWithFixedUpdate.splice(index, 1);
+                        }
+                    }
+
+                    if (instance.postUpdate) {
+                        index = this.instancesWithPostUpdate.indexOf(instance);
+                        if (index >= 0) {
+                            this.instancesWithPostUpdate.splice(index, 1);
+                        }
+                    }
+
+                    if (instance.toolsUpdate) {
+                        index = this.instancesWithToolsUpdate.indexOf(instance);
+                        if (index >= 0) {
+                            this.instancesWithToolsUpdate.splice(index, 1);
+                        }
+                    }
+
+                    if (script.instances[name].instance === script[name]) {
+                        delete script[name];
+                    }
+                    delete script.instances[name];
+                }
+            }
+        },
+
+        _postInitializeScriptComponent: function (script) {
+            this._callInstancesMethod(script, POST_INITIALIZE);
+            script.data.postInitialized = true;
+        },
+
+        _updateInstances: function (method, updateList, dt) {
+            var item;
+            for (var i=0, len=updateList.length; i<len; i++) {
+                item = updateList[i];
+                if (item && item.entity && item.entity.enabled && item.entity.script.enabled) {
+                    item[method].call(item, dt);
+                }
+            }
+        },
+
+        /**
+        * @private
+        * @function
+        * @name pc.ScriptLegacyComponentSystem#onUpdate
+        * @description Handler for the 'update' event which is fired every frame
+        * @param {Number} dt The time delta since the last update in seconds
+        */
+        onUpdate: function (dt) {
+            this._updateInstances(UPDATE, this.instancesWithUpdate, dt);
+        },
+
+        /**
+        * @private
+        * @function
+        * @name pc.ScriptLegacyComponentSystem#onFixedUpdate
+        * @description Handler for the 'fixedUpdate' event which is fired every frame just before the 'update' event but with a fixed timestep
+        * @param {Number} dt A fixed timestep of 1/60 seconds
+        */
+        onFixedUpdate: function (dt) {
+            this._updateInstances(FIXED_UPDATE, this.instancesWithFixedUpdate, dt);
+        },
+
+        /**
+        * @private
+        * @function
+        * @name pc.ScriptLegacyComponentSystem#onPostUpdate
+        * @description Handler for the 'postUpdate' event which is fired every frame just after the 'update' event
+        * @param {Number} dt The time delta since the last update in seconds
+        */
+        onPostUpdate: function (dt) {
+            this._updateInstances(POST_UPDATE, this.instancesWithPostUpdate, dt);
+        },
+
+        onToolsUpdate: function (dt) {
+            this._updateInstances(TOOLS_UPDATE, this.instancesWithToolsUpdate, dt);
+        },
+
+        /**
+         * @private
+         * @function
+         * @name pc.ScriptLegacyComponentSystem#broadcast
+         * @description Send a message to all Script Objects with a specific name.
+         * Sending a message is similar to calling a method on a Script Object, except that the message will not fail if the method isn't present
+         * @param {String} name The name of the script to send the message to
+         * @param {String} functionName The name of the functio nto call on the Script Object
+         * @example
+         * // Call doDamage(10) on all 'enemy' scripts
+         * entityEntity.script.broadcast('enemy', 'doDamage', 10);
+         */
+        broadcast: function (name, functionName) {
+            console.warn("DEPRECATED: ScriptLegacyComponentSystem.broadcast() is deprecated and will be removed soon. Please use: http://developer.playcanvas.com/user-manual/scripting/communication/");
+            var args = pc.makeArray(arguments).slice(2);
+
+            var id, data, fn;
+            var dataStore = this.store;
+            // var results = [];
+
+            for (id in dataStore) {
+                if (dataStore.hasOwnProperty(id)) {
+                    data = dataStore[id].data;
+                    if (data.instances[name]) {
+                        fn = data.instances[name].instance[functionName];
+                        if(fn) {
+                            fn.apply(data.instances[name].instance, args);
+                        }
+                    }
+                }
+            }
+        },
+
+        /**
+        * @private
+        * @function
+        * @name pc.ScriptLegacyComponentSystem#_preRegisterInstance
+        * @description Internal method used to store a instance of a script created while loading. Instances are preregistered while loadeding
+        * and then all registered at the same time once loading is complete
+        * @param {pc.Entity} entity The Entity the script instance is attached to
+        * @param {String} url The url of the script
+        * @param {String} name The name of the script
+        * @param {Object} instance The instance of the Script Object
+        */
+        _preRegisterInstance: function (entity, url, name, instance) {
+            if (entity.script) {
+                entity.script.data._instances = entity.script.data._instances || {};
+                if (entity.script.data._instances[name]) {
+                    throw Error(pc.string.format("Script name collision '{0}'. Scripts from '{1}' and '{2}' {{3}}", name, url, entity.script.data._instances[name].url, entity.getGuid()));
+                }
+                entity.script.data._instances[name] = {
+                    url: url,
+                    name: name,
+                    instance: instance
+                };
+            }
+        },
+
+        /**
+        * @private
+        * @function
+        * @name pc.ScriptLegacyComponentSystem#_registerInstance
+        * @description Get all preregistered instances for an entity and 'register' then. This means storing the instance in the ComponentData
+        * and binding events for the update, fixedUpdate, postUpdate and toolsUpdate methods.
+        * This function is recursive and calls itself for the complete hierarchy down from the supplied Entity
+        * @param {pc.Entity} entity The Entity the instances are attached to
+        */
+        _registerInstances: function (entity) {
+            var preRegistered, instance, instanceName;
+
+            if (entity.script) {
+                if (entity.script.data._instances) {
+                    entity.script.instances = entity.script.data._instances;
+
+                    for (instanceName in entity.script.instances) {
+                        preRegistered = entity.script.instances[instanceName];
+                        instance = preRegistered.instance;
+
+                        pc.events.attach(instance);
+
+                        if (instance.update) {
+                            this.instancesWithUpdate.push(instance);
+                        }
+
+                        if (instance.fixedUpdate) {
+                            this.instancesWithFixedUpdate.push(instance);
+                        }
+
+                        if (instance.postUpdate) {
+                            this.instancesWithPostUpdate.push(instance);
+                        }
+
+                        if (instance.toolsUpdate) {
+                            this.instancesWithToolsUpdate.push(instance);
+                        }
+
+                        if (entity.script.scripts) {
+                            this._createAccessors(entity, preRegistered);
+                        }
+
+                        // Make instance accessible from the script component of the Entity
+                        if (entity.script[instanceName]) {
+                            throw Error(pc.string.format("Script with name '{0}' is already attached to Script Component", instanceName));
+                        } else {
+                            entity.script[instanceName] = instance;
+                        }
+                    }
+
+                    // Remove temp storage
+                    delete entity.script.data._instances;
+                }
+
+            }
+
+            var children = entity.getChildren();
+            var i, len = children.length;
+            for (i = 0; i < len; i++) {
+                if (children[i] instanceof pc.Entity) {
+                    this._registerInstances(children[i]);
+                }
+            }
+        },
+
+        _cloneAttributes: function (attributes) {
+            var result = {};
+
+            for (var key in attributes) {
+                if (!attributes.hasOwnProperty(key))
+                    continue;
+
+                if (attributes[key].type !== 'entity') {
+                    result[key] = pc.extend({}, attributes[key]);
+                } else {
+                    // don't pc.extend an entity
+                    var val = attributes[key].value;
+                    delete attributes[key].value;
+
+                    result[key] = pc.extend({}, attributes[key]);
+                    result[key].value = val;
+
+                    attributes[key].value = val;
+                }
+            }
+
+            return result;
+        },
+
+        _createAccessors: function (entity, instance) {
+            var self = this;
+            var i;
+            var len = entity.script.scripts.length;
+            var url = instance.url;
+
+            for (i=0; i<len; i++) {
+                var script = entity.script.scripts[i];
+                if (script.url === url) {
+                    var attributes = script.attributes;
+                    if (script.name && attributes) {
+                        for (var key in attributes) {
+                            if (attributes.hasOwnProperty(key)) {
+                                self._createAccessor(attributes[key], instance);
+                            }
+                        }
+
+                        entity.script.data.attributes[script.name] = self._cloneAttributes(attributes);
+                    }
+                    break;
+                }
+            }
+        },
+
+        _createAccessor: function (attribute, instance) {
+            var self = this;
+
+            // create copy of attribute data
+            // to avoid overwritting the same attribute values
+            // that are used by the Editor
+            attribute = {
+                name: attribute.name,
+                value: attribute.value,
+                type: attribute.type
+            };
+
+            self._convertAttributeValue(attribute);
+
+            Object.defineProperty(instance.instance, attribute.name, {
+                get: function () {
+                    return attribute.value;
+                },
+                set: function (value) {
+                    var oldValue = attribute.value;
+                    attribute.value = value;
+                    self._convertAttributeValue(attribute);
+                    instance.instance.fire("set", attribute.name, oldValue, attribute.value);
+                },
+                configurable: true
+            });
+        },
+
+        _updateAccessors: function (entity, instance) {
+            var self = this;
+            var i;
+            var len = entity.script.scripts.length;
+            var key;
+            var url = instance.url;
+            var scriptComponent, script, name, attributes;
+            var previousAttributes;
+            var oldAttribute;
+
+            for (i=0; i<len; i++) {
+                scriptComponent = entity.script;
+                script = scriptComponent.scripts[i];
+                if (script.url === url) {
+                    name = script.name;
+                    attributes = script.attributes;
+                    if (name) {
+                        if (attributes) {
+                            // create / update attribute accessors
+                            for (key in attributes) {
+                                if (attributes.hasOwnProperty(key)) {
+                                    self._createAccessor(attributes[key], instance);
+                                }
+                            }
+                        }
+
+                        // delete accessors for attributes that no longer exist
+                        // and fire onAttributeChange when an attribute value changed
+                        previousAttributes = scriptComponent.data.attributes[name];
+                        if (previousAttributes) {
+                            for (key in previousAttributes) {
+                                oldAttribute = previousAttributes[key];
+                                if (!(key in attributes)) {
+                                    delete instance.instance[oldAttribute.name];
+                                } else {
+                                    if (attributes[key].value !== oldAttribute.value) {
+                                        if (instance.instance.onAttributeChanged) {
+                                            instance.instance.onAttributeChanged(oldAttribute.name, oldAttribute.value, attributes[key].value);
+                                        }
+                                    }
+                                }
+                            }
+                        }
+
+                        if (attributes) {
+                            scriptComponent.data.attributes[name] = self._cloneAttributes(attributes);
+                        } else {
+                            delete scriptComponent.data.attributes[name];
+                        }
+                    }
+
+                    break;
+                }
+            }
+        },
+
+        _convertAttributeValue: function (attribute) {
+            if (attribute.type === 'rgb' || attribute.type === 'rgba') {
+                if (pc.type(attribute.value) === 'array') {
+                    attribute.value = attribute.value.length === 3 ?
+                                      new pc.Color(attribute.value[0], attribute.value[1], attribute.value[2]) :
+                                      new pc.Color(attribute.value[0], attribute.value[1], attribute.value[2], attribute.value[3]);
+                }
+            } else if (attribute.type === 'vec2') {
+                if (pc.type(attribute.value) === 'array')
+                    attribute.value = new pc.Vec2(attribute.value[0], attribute.value[1]);
+
+            } else if (attribute.type === 'vec3' || attribute.type === 'vector') {
+                if (pc.type(attribute.value) === 'array')
+                    attribute.value = new pc.Vec3(attribute.value[0], attribute.value[1], attribute.value[2]);
+
+            } else if (attribute.type === 'vec4') {
+                if (pc.type(attribute.value) === 'array')
+                    attribute.value = new pc.Vec4(attribute.value[0], attribute.value[1], attribute.value[2], attribute.value[3]);
+
+            } else if (attribute.type === 'entity') {
+                if (attribute.value !== null && typeof attribute.value === 'string')
+                    attribute.value = this.app.root.findByGuid(attribute.value);
+
+            } else if (attribute.type === 'curve' || attribute.type === 'colorcurve') {
+                var curveType = attribute.value.keys[0] instanceof Array ? pc.CurveSet : pc.Curve;
+                attribute.value = new curveType(attribute.value.keys);
+                attribute.value.type = attribute.value.type;
+            }
+        }
+    });
+
+    return {
+        ScriptLegacyComponentSystem: ScriptLegacyComponentSystem
+    };
+}());

--- a/src/framework/components/script-legacy/system.js
+++ b/src/framework/components/script-legacy/system.js
@@ -9,14 +9,6 @@ pc.extend(pc, function () {
     var ON_ENABLE = 'onEnable';
     var ON_DISABLE = 'onDisable';
 
-    /**
-     * @name pc.ScriptLegacyComponentSystem
-     * @description Create a new ScriptLegacyComponentSystem
-     * @class Allows scripts to be attached to an Entity and executed
-     * @param {pc.Application} app The application
-     * @param {String} [prefix] An optional prefix that will be applied to all script URLs.
-     * @extends pc.ComponentSystem
-     */
     var ScriptLegacyComponentSystem = function ScriptLegacyComponentSystem(app, prefix) {
         this.id = 'script';
         this.description = "Allows the Entity to run JavaScript fragments to implement custom behavior.";
@@ -102,13 +94,6 @@ pc.extend(pc, function () {
             return this.addComponent(clone, data);
         },
 
-        /**
-        * @private
-        * @name pc.ScriptLegacyComponentSystem#onBeforeRemove
-        * @description Handler for 'beforeremove' event which is fired when a script component is about to be removed from an entity;
-        * @param {pc.Entity} entity The entity that the component will be removed from
-        * @param {pc.Component} component The component about to be removed
-        */
         onBeforeRemove: function (entity, component) {
             // if the script component is enabled
             // call onDisable on all its instances first
@@ -120,13 +105,6 @@ pc.extend(pc, function () {
             this._destroyScriptComponent(component);
         },
 
-        /**
-         * @function
-         * @private
-         * @name pc.ScriptLegacyComponentSystem#onInitialize
-         * @description Handler for the 'initialize' event which is fired immediately after the Entity hierarchy is loaded, but before the first update loop
-         * @param {pc.Entity} root The root of the hierarchy to initialize.
-         */
         onInitialize: function (root) {
             this._registerInstances(root);
 
@@ -145,13 +123,6 @@ pc.extend(pc, function () {
             }
         },
 
-        /**
-         * @function
-         * @private
-         * @name pc.ScriptLegacyComponentSystem#onPostInitialize
-         * @description Handler for the 'postInitialize' event which is fired immediately after the 'initialize' event and before the first update loop
-         * @param {pc.Entity} root The root of the hierarchy to initialize.
-         */
         onPostInitialize: function (root) {
             if (root.enabled) {
                 if (root.script && root.script.enabled) {
@@ -260,35 +231,14 @@ pc.extend(pc, function () {
             }
         },
 
-        /**
-        * @private
-        * @function
-        * @name pc.ScriptLegacyComponentSystem#onUpdate
-        * @description Handler for the 'update' event which is fired every frame
-        * @param {Number} dt The time delta since the last update in seconds
-        */
         onUpdate: function (dt) {
             this._updateInstances(UPDATE, this.instancesWithUpdate, dt);
         },
 
-        /**
-        * @private
-        * @function
-        * @name pc.ScriptLegacyComponentSystem#onFixedUpdate
-        * @description Handler for the 'fixedUpdate' event which is fired every frame just before the 'update' event but with a fixed timestep
-        * @param {Number} dt A fixed timestep of 1/60 seconds
-        */
         onFixedUpdate: function (dt) {
             this._updateInstances(FIXED_UPDATE, this.instancesWithFixedUpdate, dt);
         },
 
-        /**
-        * @private
-        * @function
-        * @name pc.ScriptLegacyComponentSystem#onPostUpdate
-        * @description Handler for the 'postUpdate' event which is fired every frame just after the 'update' event
-        * @param {Number} dt The time delta since the last update in seconds
-        */
         onPostUpdate: function (dt) {
             this._updateInstances(POST_UPDATE, this.instancesWithPostUpdate, dt);
         },
@@ -297,18 +247,6 @@ pc.extend(pc, function () {
             this._updateInstances(TOOLS_UPDATE, this.instancesWithToolsUpdate, dt);
         },
 
-        /**
-         * @private
-         * @function
-         * @name pc.ScriptLegacyComponentSystem#broadcast
-         * @description Send a message to all Script Objects with a specific name.
-         * Sending a message is similar to calling a method on a Script Object, except that the message will not fail if the method isn't present
-         * @param {String} name The name of the script to send the message to
-         * @param {String} functionName The name of the functio nto call on the Script Object
-         * @example
-         * // Call doDamage(10) on all 'enemy' scripts
-         * entityEntity.script.broadcast('enemy', 'doDamage', 10);
-         */
         broadcast: function (name, functionName) {
             console.warn("DEPRECATED: ScriptLegacyComponentSystem.broadcast() is deprecated and will be removed soon. Please use: http://developer.playcanvas.com/user-manual/scripting/communication/");
             var args = pc.makeArray(arguments).slice(2);
@@ -330,17 +268,6 @@ pc.extend(pc, function () {
             }
         },
 
-        /**
-        * @private
-        * @function
-        * @name pc.ScriptLegacyComponentSystem#_preRegisterInstance
-        * @description Internal method used to store a instance of a script created while loading. Instances are preregistered while loadeding
-        * and then all registered at the same time once loading is complete
-        * @param {pc.Entity} entity The Entity the script instance is attached to
-        * @param {String} url The url of the script
-        * @param {String} name The name of the script
-        * @param {Object} instance The instance of the Script Object
-        */
         _preRegisterInstance: function (entity, url, name, instance) {
             if (entity.script) {
                 entity.script.data._instances = entity.script.data._instances || {};
@@ -355,15 +282,6 @@ pc.extend(pc, function () {
             }
         },
 
-        /**
-        * @private
-        * @function
-        * @name pc.ScriptLegacyComponentSystem#_registerInstance
-        * @description Get all preregistered instances for an entity and 'register' then. This means storing the instance in the ComponentData
-        * and binding events for the update, fixedUpdate, postUpdate and toolsUpdate methods.
-        * This function is recursive and calls itself for the complete hierarchy down from the supplied Entity
-        * @param {pc.Entity} entity The Entity the instances are attached to
-        */
         _registerInstances: function (entity) {
             var preRegistered, instance, instanceName;
 

--- a/src/framework/components/script/component.js
+++ b/src/framework/components/script/component.js
@@ -7,14 +7,14 @@ pc.extend(pc, function () {
     * @param {pc.ScriptComponentSystem} system The ComponentSystem that created this Component
     * @param {pc.Entity} entity The Entity that this Component is attached to.
     * @extends pc.Component
-    * @property {Array} scripts An array of all Script Instances attached to an entity
+    * @property {Array} scripts An array of all Script Instances attached to an entity. This Array shall not be modified by developer.
     */
 
     var ScriptComponent = function ScriptComponent(system, entity) {
         this._scripts = [ ];
         this._scriptsIndex = { };
         this._oldState = true;
-        this.on('set_enabled', this.onSetEnabled, this);
+        this.on('set_enabled', this._onSetEnabled, this);
     };
     ScriptComponent = pc.inherits(ScriptComponent, pc.Component);
 
@@ -133,7 +133,7 @@ pc.extend(pc, function () {
             }
         },
 
-        onSetEnabled: function(prop, old, value) {
+        _onSetEnabled: function(prop, old, value) {
             this._checkState();
         },
 
@@ -161,18 +161,18 @@ pc.extend(pc, function () {
             }
         },
 
-        onBeforeRemove: function() {
+        _onBeforeRemove: function() {
             this.fire('remove');
             for(var i = 0, len = this.scripts.length; i < len; i++)
                 this.scripts[i].fire('destroy');
         },
 
-        onInitializeAttributes: function() {
+        _onInitializeAttributes: function() {
             for(var i = 0, len = this.scripts.length; i < len; i++)
                 this.scripts[i].__initializeAttributes();
         },
 
-        onInitialize: function() {
+        _onInitialize: function() {
             var script;
             for(var i = 0, len = this.scripts.length; i < len; i++) {
                 script = this.scripts[i];
@@ -184,7 +184,7 @@ pc.extend(pc, function () {
             }
         },
 
-        onPostInitialize: function() {
+        _onPostInitialize: function() {
             var script;
             for(var i = 0, len = this.scripts.length; i < len; i++) {
                 script = this.scripts[i];
@@ -196,7 +196,7 @@ pc.extend(pc, function () {
             }
         },
 
-        onUpdate: function(dt) {
+        _onUpdate: function(dt) {
             var script;
             for(var i = 0, len = this.scripts.length; i < len; i++) {
                 script = this.scripts[i];
@@ -205,7 +205,7 @@ pc.extend(pc, function () {
             }
         },
 
-        onFixedUpdate: function(dt) {
+        _onFixedUpdate: function(dt) {
             var script;
             for(var i = 0, len = this.scripts.length; i < len; i++) {
                 script = this.scripts[i];
@@ -214,7 +214,7 @@ pc.extend(pc, function () {
             }
         },
 
-        onPostUpdate: function(dt) {
+        _onPostUpdate: function(dt) {
             var script;
             for(var i = 0, len = this.scripts.length; i < len; i++) {
                 script = this.scripts[i];
@@ -267,10 +267,14 @@ pc.extend(pc, function () {
             args = args || { };
 
             var scriptObject = script;
+            var scriptName = script;
 
             // shorthand using script name
-            if (typeof(scriptObject) === 'string')
+            if (typeof(scriptObject) === 'string') {
                 scriptObject = this.system.app.scripts.get(scriptObject);
+            } else if (scriptObject) {
+                scriptName = scriptObject.name;
+            }
 
             if (scriptObject) {
                 if (! this._scriptsIndex[scriptObject.name]) {
@@ -313,10 +317,10 @@ pc.extend(pc, function () {
 
                     return scriptInstance;
                 } else {
-                    console.warn('script \'' + name + '\' is already added to entity \'' + this.entity.name + '\'');
+                    console.warn('script \'' + scriptName + '\' is already added to entity \'' + this.entity.name + '\'');
                 }
             } else {
-                console.warn('script \'' + name + '\' is not found, could not add to entity \'' + this.entity.name + '\'');
+                console.warn('script \'' + scriptName + '\' is not found, could not add to entity \'' + this.entity.name + '\'');
             }
 
             return null;
@@ -352,6 +356,7 @@ pc.extend(pc, function () {
 
             this.fire('destroy', scriptObject.name, scriptData.instance);
             this.fire('destroy:' + scriptObject.name, scriptData.instance);
+            scriptData.instance.fire('destroy');
 
             return true;
         },
@@ -390,6 +395,10 @@ pc.extend(pc, function () {
             this.fire('swap:' + scriptObject.name, scriptInstance);
 
             return true;
+        },
+
+        move: function(script, ind) {
+            throw new Error('not implemented');
         }
     });
 

--- a/src/framework/components/script/data.js
+++ b/src/framework/components/script/data.js
@@ -1,17 +1,6 @@
 pc.extend(pc, function () {
     var ScriptComponentData = function () {
-        // serialized
-        this.scripts = [];
         this.enabled = true;
-
-        // not serialized
-        this.instances = {};
-        this._instances = {};
-        this.runInTools = false;
-        this.attributes = {};
-        this.initialized = false;
-        this.postInitialized = false;
-        this.areScriptsLoaded = false;
     };
     ScriptComponentData = pc.inherits(ScriptComponentData, pc.ComponentData);
 

--- a/src/framework/components/script/system.js
+++ b/src/framework/components/script/system.js
@@ -18,19 +18,19 @@ pc.extend(pc, function () {
         this.schema = [ 'enabled' ];
 
         // list of all entities script components
-        this.components = [ ];
+        this._components = [ ];
 
-        this.on('beforeremove', this.onBeforeRemove, this);
-        pc.ComponentSystem.on('initialize', this.onInitialize, this);
-        pc.ComponentSystem.on('postInitialize', this.onPostInitialize, this);
-        pc.ComponentSystem.on('update', this.onUpdate, this);
-        pc.ComponentSystem.on('postUpdate', this.onPostUpdate, this);
+        this.on('beforeremove', this._onBeforeRemove, this);
+        pc.ComponentSystem.on('initialize', this._onInitialize, this);
+        pc.ComponentSystem.on('postInitialize', this._onPostInitialize, this);
+        pc.ComponentSystem.on('update', this._onUpdate, this);
+        pc.ComponentSystem.on('postUpdate', this._onPostUpdate, this);
     };
     ScriptComponentSystem = pc.inherits(ScriptComponentSystem, pc.ComponentSystem);
 
     pc.extend(ScriptComponentSystem.prototype, {
         initializeComponentData: function(component, data, properties) {
-            this.components.push(component);
+            this._components.push(component);
 
             component.enabled = !! data.enabled;
 
@@ -49,39 +49,39 @@ pc.extend(pc, function () {
             throw new Error('not implemented');
         },
 
-        callComponentMethod: function(name, dt) {
-            for(var i = 0; i < this.components.length; i++) {
-                if (! this.components[i].entity.enabled || ! this.components[i].enabled)
+        _callComponentMethod: function(name, dt) {
+            for(var i = 0; i < this._components.length; i++) {
+                if (! this._components[i].entity.enabled || ! this._components[i].enabled)
                     continue;
 
-                this.components[i][name](dt);
+                this._components[i][name](dt);
             }
         },
 
-        onInitialize: function() {
+        _onInitialize: function() {
             // initialize attributes
-            for(var i = 0; i < this.components.length; i++)
-                this.components[i].onInitializeAttributes();
+            for(var i = 0; i < this._components.length; i++)
+                this._components[i]._onInitializeAttributes();
 
-            this.callComponentMethod('onInitialize');
+            this._callComponentMethod('_onInitialize');
         },
-        onPostInitialize: function() {
-            this.callComponentMethod('onPostInitialize');
+        _onPostInitialize: function() {
+            this._callComponentMethod('_onPostInitialize');
         },
-        onUpdate: function(dt) {
-            this.callComponentMethod('onUpdate', dt);
+        _onUpdate: function(dt) {
+            this._callComponentMethod('_onUpdate', dt);
         },
-        onPostUpdate: function(dt) {
-            this.callComponentMethod('onPostUpdate', dt);
+        _onPostUpdate: function(dt) {
+            this._callComponentMethod('_onPostUpdate', dt);
         },
 
-        onBeforeRemove: function(entity, component) {
-            var ind = this.components.indexOf(component);
+        _onBeforeRemove: function(entity, component) {
+            var ind = this._components.indexOf(component);
             if (ind === -1) return;
 
-            component.onBeforeRemove();
+            component._onBeforeRemove();
 
-            this.components.splice(ind, 1);
+            this._components.splice(ind, 1);
         }
     });
 

--- a/src/framework/components/script/system.js
+++ b/src/framework/components/script/system.js
@@ -1,587 +1,88 @@
 pc.extend(pc, function () {
-
-    var INITIALIZE = "initialize";
-    var POST_INITIALIZE = "postInitialize";
-    var UPDATE = "update";
-    var POST_UPDATE = "postUpdate";
-    var FIXED_UPDATE = "fixedUpdate";
-    var TOOLS_UPDATE = "toolsUpdate";
-    var ON_ENABLE = 'onEnable';
-    var ON_DISABLE = 'onDisable';
-
     /**
      * @name pc.ScriptComponentSystem
      * @description Create a new ScriptComponentSystem
      * @class Allows scripts to be attached to an Entity and executed
      * @param {pc.Application} app The application
-     * @param {String} [prefix] An optional prefix that will be applied to all script URLs.
      * @extends pc.ComponentSystem
      */
-    var ScriptComponentSystem = function ScriptComponentSystem(app, prefix) {
+
+    var ScriptComponentSystem = function ScriptComponentSystem(app) {
         this.id = 'script';
-        this.description = "Allows the Entity to run JavaScript fragments to implement custom behavior.";
+        this.app = app;
         app.systems.add(this.id, this);
 
         this.ComponentType = pc.ScriptComponent;
         this.DataType = pc.ScriptComponentData;
-        this._prefix = prefix || null;
-        this.schema = [
-            'enabled',
-            'scripts',
-            'instances',
-            'runInTools'
-        ];
 
-        // used by application during preloading phase to ensure scripts aren't
-        // initialized until everything is loaded
-        this.preloading = false;
+        this.schema = [ 'enabled' ];
 
-        // arrays to cache script instances for fast iteration
-        this.instancesWithUpdate = [];
-        this.instancesWithFixedUpdate = [];
-        this.instancesWithPostUpdate = [];
-        this.instancesWithToolsUpdate = [];
+        // list of all entities script components
+        this.components = [ ];
 
         this.on('beforeremove', this.onBeforeRemove, this);
-        pc.ComponentSystem.on(INITIALIZE, this.onInitialize, this);
-        pc.ComponentSystem.on(POST_INITIALIZE, this.onPostInitialize, this);
-        pc.ComponentSystem.on(UPDATE, this.onUpdate, this);
-        pc.ComponentSystem.on(FIXED_UPDATE, this.onFixedUpdate, this);
-        pc.ComponentSystem.on(POST_UPDATE, this.onPostUpdate, this);
-        pc.ComponentSystem.on(TOOLS_UPDATE, this.onToolsUpdate, this);
+        pc.ComponentSystem.on('initialize', this.onInitialize, this);
+        pc.ComponentSystem.on('postInitialize', this.onPostInitialize, this);
+        pc.ComponentSystem.on('update', this.onUpdate, this);
+        pc.ComponentSystem.on('postUpdate', this.onPostUpdate, this);
     };
     ScriptComponentSystem = pc.inherits(ScriptComponentSystem, pc.ComponentSystem);
 
     pc.extend(ScriptComponentSystem.prototype, {
-        initializeComponentData: function (component, data, properties) {
-            properties = ['runInTools', 'enabled', 'scripts'];
+        initializeComponentData: function(component, data, properties) {
+            this.components.push(component);
 
-            // convert attributes array to dictionary
-            if (data.scripts && data.scripts.length) {
-                data.scripts.forEach(function (script) {
-                    if (script.attributes && pc.type(script.attributes) === 'array') {
-                        var dict = {};
-                        for (var i = 0; i < script.attributes.length; i++) {
-                            dict[script.attributes[i].name] = script.attributes[i];
-                        }
+            component.enabled = !! data.enabled;
 
-                        script.attributes = dict;
-                    }
-                });
-            }
-
-            ScriptComponentSystem._super.initializeComponentData.call(this, component, data, properties);
-        },
-
-        cloneComponent: function (entity, clone) {
-            // overridden to make sure urls list is duplicated
-            var src = this.dataStore[entity.getGuid()];
-            var data = {
-                runInTools: src.data.runInTools,
-                scripts: [],
-                enabled: src.data.enabled
-            };
-
-            // manually clone scripts so that we don't clone attributes with pc.extend
-            // which will result in a stack overflow when extending 'entity' script attributes
-            var scripts = src.data.scripts;
-            for (var i = 0, len = scripts.length; i < len; i++) {
-                var attributes = scripts[i].attributes;
-                if (attributes) {
-                    delete scripts[i].attributes;
-                }
-
-                data.scripts.push(pc.extend({}, scripts[i]));
-
-                if (attributes) {
-                    data.scripts[i].attributes = this._cloneAttributes(attributes);
-                    scripts[i].attributes = attributes;
-                }
-            }
-
-            return this.addComponent(clone, data);
-        },
-
-        /**
-        * @private
-        * @name pc.ScriptComponentSystem#onBeforeRemove
-        * @description Handler for 'beforeremove' event which is fired when a script component is about to be removed from an entity;
-        * @param {pc.Entity} entity The entity that the component will be removed from
-        * @param {pc.Component} component The component about to be removed
-        */
-        onBeforeRemove: function (entity, component) {
-            // if the script component is enabled
-            // call onDisable on all its instances first
-            if (component.enabled) {
-                this._disableScriptComponent(component);
-            }
-
-            // then call destroy on all the script instances
-            this._destroyScriptComponent(component);
-        },
-
-        /**
-         * @function
-         * @private
-         * @name pc.ScriptComponentSystem#onInitialize
-         * @description Handler for the 'initialize' event which is fired immediately after the Entity hierarchy is loaded, but before the first update loop
-         * @param {pc.Entity} root The root of the hierarchy to initialize.
-         */
-        onInitialize: function (root) {
-            this._registerInstances(root);
-
-            if (root.enabled) {
-                if (root.script && root.script.enabled) {
-                    this._initializeScriptComponent(root.script);
-                }
-
-                var children = root.getChildren();
-                var i, len = children.length;
-                for (i = 0; i < len; i++) {
-                    if (children[i] instanceof pc.Entity) {
-                        this.onInitialize(children[i]);
-                    }
+            if (data.hasOwnProperty('order') && data.hasOwnProperty('scripts')) {
+                for(var i = 0; i < data.order.length; i++) {
+                    component.create(data.order[i], {
+                        enabled: data.scripts[data.order[i]].enabled,
+                        attributes: data.scripts[data.order[i]].attributes,
+                        preloading: true
+                    });
                 }
             }
         },
 
-        /**
-         * @function
-         * @private
-         * @name pc.ScriptComponentSystem#onPostInitialize
-         * @description Handler for the 'postInitialize' event which is fired immediately after the 'initialize' event and before the first update loop
-         * @param {pc.Entity} root The root of the hierarchy to initialize.
-         */
-        onPostInitialize: function (root) {
-            if (root.enabled) {
-                if (root.script && root.script.enabled) {
-                    this._postInitializeScriptComponent(root.script);
-                }
-
-                var children = root.getChildren();
-                var i, len = children.length;
-                for (i = 0; i < len; i++) {
-                    if (children[i] instanceof pc.Entity) {
-                        this.onPostInitialize(children[i]);
-                    }
-                }
-            }
+        cloneComponent: function() {
+            throw new Error('not implemented');
         },
 
-        _callInstancesMethod: function (script, method) {
-            var instances = script.data.instances;
-            for (var name in instances) {
-                if (instances.hasOwnProperty(name)) {
-                    var instance = instances[name].instance;
-                    if (instance[method]) {
-                        instance[method].call(instance);
-                    }
-                }
-            }
-        },
-
-        _initializeScriptComponent: function (script) {
-            this._callInstancesMethod(script, INITIALIZE);
-            script.data.initialized = true;
-
-            // check again if the script and the entity are enabled
-            // in case they got disabled during initialize
-            if (script.enabled && script.entity.enabled) {
-                this._enableScriptComponent(script);
-            }
-        },
-
-        _enableScriptComponent: function (script) {
-            this._callInstancesMethod(script, ON_ENABLE);
-        },
-
-        _disableScriptComponent: function (script) {
-            this._callInstancesMethod(script, ON_DISABLE);
-        },
-
-        _destroyScriptComponent: function (script) {
-            var index;
-            var instances = script.data.instances;
-            for (var name in instances) {
-                if (instances.hasOwnProperty(name)) {
-                    var instance = instances[name].instance;
-                    if(instance.destroy) {
-                        instance.destroy();
-                    }
-
-                    if (instance.update) {
-                        index = this.instancesWithUpdate.indexOf(instance);
-                        if (index >= 0) {
-                            this.instancesWithUpdate.splice(index, 1);
-                        }
-                    }
-
-                    if (instance.fixedUpdate) {
-                        index = this.instancesWithFixedUpdate.indexOf(instance);
-                        if (index >= 0) {
-                            this.instancesWithFixedUpdate.splice(index, 1);
-                        }
-                    }
-
-                    if (instance.postUpdate) {
-                        index = this.instancesWithPostUpdate.indexOf(instance);
-                        if (index >= 0) {
-                            this.instancesWithPostUpdate.splice(index, 1);
-                        }
-                    }
-
-                    if (instance.toolsUpdate) {
-                        index = this.instancesWithToolsUpdate.indexOf(instance);
-                        if (index >= 0) {
-                            this.instancesWithToolsUpdate.splice(index, 1);
-                        }
-                    }
-
-                    if (script.instances[name].instance === script[name]) {
-                        delete script[name];
-                    }
-                    delete script.instances[name];
-                }
-            }
-        },
-
-        _postInitializeScriptComponent: function (script) {
-            this._callInstancesMethod(script, POST_INITIALIZE);
-            script.data.postInitialized = true;
-        },
-
-        _updateInstances: function (method, updateList, dt) {
-            var item;
-            for (var i=0, len=updateList.length; i<len; i++) {
-                item = updateList[i];
-                if (item && item.entity && item.entity.enabled && item.entity.script.enabled) {
-                    item[method].call(item, dt);
-                }
-            }
-        },
-
-        /**
-        * @private
-        * @function
-        * @name pc.ScriptComponentSystem#onUpdate
-        * @description Handler for the 'update' event which is fired every frame
-        * @param {Number} dt The time delta since the last update in seconds
-        */
-        onUpdate: function (dt) {
-            this._updateInstances(UPDATE, this.instancesWithUpdate, dt);
-        },
-
-        /**
-        * @private
-        * @function
-        * @name pc.ScriptComponentSystem#onFixedUpdate
-        * @description Handler for the 'fixedUpdate' event which is fired every frame just before the 'update' event but with a fixed timestep
-        * @param {Number} dt A fixed timestep of 1/60 seconds
-        */
-        onFixedUpdate: function (dt) {
-            this._updateInstances(FIXED_UPDATE, this.instancesWithFixedUpdate, dt);
-        },
-
-        /**
-        * @private
-        * @function
-        * @name pc.ScriptComponentSystem#onPostUpdate
-        * @description Handler for the 'postUpdate' event which is fired every frame just after the 'update' event
-        * @param {Number} dt The time delta since the last update in seconds
-        */
-        onPostUpdate: function (dt) {
-            this._updateInstances(POST_UPDATE, this.instancesWithPostUpdate, dt);
-        },
-
-        onToolsUpdate: function (dt) {
-            this._updateInstances(TOOLS_UPDATE, this.instancesWithToolsUpdate, dt);
-        },
-
-        /**
-         * @private
-         * @function
-         * @name pc.ScriptComponentSystem#broadcast
-         * @description Send a message to all Script Objects with a specific name.
-         * Sending a message is similar to calling a method on a Script Object, except that the message will not fail if the method isn't present
-         * @param {String} name The name of the script to send the message to
-         * @param {String} functionName The name of the functio nto call on the Script Object
-         * @example
-         * // Call doDamage(10) on all 'enemy' scripts
-         * entityEntity.script.broadcast('enemy', 'doDamage', 10);
-         */
-        broadcast: function (name, functionName) {
-            console.warn("DEPRECATED: ScriptComponentSystem.broadcast() is deprecated and will be removed soon. Please use: http://developer.playcanvas.com/user-manual/scripting/communication/");
-            var args = pc.makeArray(arguments).slice(2);
-
-            var id, data, fn;
-            var dataStore = this.store;
-            // var results = [];
-
-            for (id in dataStore) {
-                if (dataStore.hasOwnProperty(id)) {
-                    data = dataStore[id].data;
-                    if (data.instances[name]) {
-                        fn = data.instances[name].instance[functionName];
-                        if(fn) {
-                            fn.apply(data.instances[name].instance, args);
-                        }
-                    }
-                }
-            }
-        },
-
-        /**
-        * @private
-        * @function
-        * @name pc.ScriptComponentSystem#_preRegisterInstance
-        * @description Internal method used to store a instance of a script created while loading. Instances are preregistered while loadeding
-        * and then all registered at the same time once loading is complete
-        * @param {pc.Entity} entity The Entity the script instance is attached to
-        * @param {String} url The url of the script
-        * @param {String} name The name of the script
-        * @param {Object} instance The instance of the Script Object
-        */
-        _preRegisterInstance: function (entity, url, name, instance) {
-            if (entity.script) {
-                entity.script.data._instances = entity.script.data._instances || {};
-                if (entity.script.data._instances[name]) {
-                    throw Error(pc.string.format("Script name collision '{0}'. Scripts from '{1}' and '{2}' {{3}}", name, url, entity.script.data._instances[name].url, entity.getGuid()));
-                }
-                entity.script.data._instances[name] = {
-                    url: url,
-                    name: name,
-                    instance: instance
-                };
-            }
-        },
-
-        /**
-        * @private
-        * @function
-        * @name pc.ScriptComponentSystem#_registerInstance
-        * @description Get all preregistered instances for an entity and 'register' then. This means storing the instance in the ComponentData
-        * and binding events for the update, fixedUpdate, postUpdate and toolsUpdate methods.
-        * This function is recursive and calls itself for the complete hierarchy down from the supplied Entity
-        * @param {pc.Entity} entity The Entity the instances are attached to
-        */
-        _registerInstances: function (entity) {
-            var preRegistered, instance, instanceName;
-
-            if (entity.script) {
-                if (entity.script.data._instances) {
-                    entity.script.instances = entity.script.data._instances;
-
-                    for (instanceName in entity.script.instances) {
-                        preRegistered = entity.script.instances[instanceName];
-                        instance = preRegistered.instance;
-
-                        pc.events.attach(instance);
-
-                        if (instance.update) {
-                            this.instancesWithUpdate.push(instance);
-                        }
-
-                        if (instance.fixedUpdate) {
-                            this.instancesWithFixedUpdate.push(instance);
-                        }
-
-                        if (instance.postUpdate) {
-                            this.instancesWithPostUpdate.push(instance);
-                        }
-
-                        if (instance.toolsUpdate) {
-                            this.instancesWithToolsUpdate.push(instance);
-                        }
-
-                        if (entity.script.scripts) {
-                            this._createAccessors(entity, preRegistered);
-                        }
-
-                        // Make instance accessible from the script component of the Entity
-                        if (entity.script[instanceName]) {
-                            throw Error(pc.string.format("Script with name '{0}' is already attached to Script Component", instanceName));
-                        } else {
-                            entity.script[instanceName] = instance;
-                        }
-                    }
-
-                    // Remove temp storage
-                    delete entity.script.data._instances;
-                }
-
-            }
-
-            var children = entity.getChildren();
-            var i, len = children.length;
-            for (i = 0; i < len; i++) {
-                if (children[i] instanceof pc.Entity) {
-                    this._registerInstances(children[i]);
-                }
-            }
-        },
-
-        _cloneAttributes: function (attributes) {
-            var result = {};
-
-            for (var key in attributes) {
-                if (!attributes.hasOwnProperty(key))
+        callComponentMethod: function(name, dt) {
+            for(var i = 0; i < this.components.length; i++) {
+                if (! this.components[i].entity.enabled || ! this.components[i].enabled)
                     continue;
 
-                if (attributes[key].type !== 'entity') {
-                    result[key] = pc.extend({}, attributes[key]);
-                } else {
-                    // don't pc.extend an entity
-                    var val = attributes[key].value;
-                    delete attributes[key].value;
-
-                    result[key] = pc.extend({}, attributes[key]);
-                    result[key].value = val;
-
-                    attributes[key].value = val;
-                }
-            }
-
-            return result;
-        },
-
-        _createAccessors: function (entity, instance) {
-            var self = this;
-            var i;
-            var len = entity.script.scripts.length;
-            var url = instance.url;
-
-            for (i=0; i<len; i++) {
-                var script = entity.script.scripts[i];
-                if (script.url === url) {
-                    var attributes = script.attributes;
-                    if (script.name && attributes) {
-                        for (var key in attributes) {
-                            if (attributes.hasOwnProperty(key)) {
-                                self._createAccessor(attributes[key], instance);
-                            }
-                        }
-
-                        entity.script.data.attributes[script.name] = self._cloneAttributes(attributes);
-                    }
-                    break;
-                }
+                this.components[i][name](dt);
             }
         },
 
-        _createAccessor: function (attribute, instance) {
-            var self = this;
+        onInitialize: function() {
+            // initialize attributes
+            for(var i = 0; i < this.components.length; i++)
+                this.components[i].onInitializeAttributes();
 
-            // create copy of attribute data
-            // to avoid overwritting the same attribute values
-            // that are used by the Editor
-            attribute = {
-                name: attribute.name,
-                value: attribute.value,
-                type: attribute.type
-            };
-
-            self._convertAttributeValue(attribute);
-
-            Object.defineProperty(instance.instance, attribute.name, {
-                get: function () {
-                    return attribute.value;
-                },
-                set: function (value) {
-                    var oldValue = attribute.value;
-                    attribute.value = value;
-                    self._convertAttributeValue(attribute);
-                    instance.instance.fire("set", attribute.name, oldValue, attribute.value);
-                },
-                configurable: true
-            });
+            this.callComponentMethod('onInitialize');
+        },
+        onPostInitialize: function() {
+            this.callComponentMethod('onPostInitialize');
+        },
+        onUpdate: function(dt) {
+            this.callComponentMethod('onUpdate', dt);
+        },
+        onPostUpdate: function(dt) {
+            this.callComponentMethod('onPostUpdate', dt);
         },
 
-        _updateAccessors: function (entity, instance) {
-            var self = this;
-            var i;
-            var len = entity.script.scripts.length;
-            var key;
-            var url = instance.url;
-            var scriptComponent, script, name, attributes;
-            var previousAttributes;
-            var oldAttribute;
+        onBeforeRemove: function(entity, component) {
+            var ind = this.components.indexOf(component);
+            if (ind === -1) return;
 
-            for (i=0; i<len; i++) {
-                scriptComponent = entity.script;
-                script = scriptComponent.scripts[i];
-                if (script.url === url) {
-                    name = script.name;
-                    attributes = script.attributes;
-                    if (name) {
-                        if (attributes) {
-                            // create / update attribute accessors
-                            for (key in attributes) {
-                                if (attributes.hasOwnProperty(key)) {
-                                    self._createAccessor(attributes[key], instance);
-                                }
-                            }
-                        }
+            component.onBeforeRemove();
 
-                        // delete accessors for attributes that no longer exist
-                        // and fire onAttributeChange when an attribute value changed
-                        previousAttributes = scriptComponent.data.attributes[name];
-                        if (previousAttributes) {
-                            for (key in previousAttributes) {
-                                oldAttribute = previousAttributes[key];
-                                if (!(key in attributes)) {
-                                    delete instance.instance[oldAttribute.name];
-                                } else {
-                                    if (attributes[key].value !== oldAttribute.value) {
-                                        if (instance.instance.onAttributeChanged) {
-                                            instance.instance.onAttributeChanged(oldAttribute.name, oldAttribute.value, attributes[key].value);
-                                        }
-                                    }
-                                }
-                            }
-                        }
-
-                        if (attributes) {
-                            scriptComponent.data.attributes[name] = self._cloneAttributes(attributes);
-                        } else {
-                            delete scriptComponent.data.attributes[name];
-                        }
-                    }
-
-                    break;
-                }
-            }
-        },
-
-        _convertAttributeValue: function (attribute) {
-            if (attribute.type === 'rgb' || attribute.type === 'rgba') {
-                if (pc.type(attribute.value) === 'array') {
-                    attribute.value = attribute.value.length === 3 ?
-                                      new pc.Color(attribute.value[0], attribute.value[1], attribute.value[2]) :
-                                      new pc.Color(attribute.value[0], attribute.value[1], attribute.value[2], attribute.value[3]);
-                }
-            } else if (attribute.type === 'vec2') {
-                if (pc.type(attribute.value) === 'array')
-                    attribute.value = new pc.Vec2(attribute.value[0], attribute.value[1]);
-
-            } else if (attribute.type === 'vec3' || attribute.type === 'vector') {
-                if (pc.type(attribute.value) === 'array')
-                    attribute.value = new pc.Vec3(attribute.value[0], attribute.value[1], attribute.value[2]);
-
-            } else if (attribute.type === 'vec4') {
-                if (pc.type(attribute.value) === 'array')
-                    attribute.value = new pc.Vec4(attribute.value[0], attribute.value[1], attribute.value[2], attribute.value[3]);
-
-            } else if (attribute.type === 'entity') {
-                if (attribute.value !== null && typeof attribute.value === 'string')
-                    attribute.value = this.app.root.findByGuid(attribute.value);
-
-            } else if (attribute.type === 'curve' || attribute.type === 'colorcurve') {
-                var curveType = attribute.value.keys[0] instanceof Array ? pc.CurveSet : pc.Curve;
-                attribute.value = new curveType(attribute.value.keys);
-                attribute.value.type = attribute.value.type;
-            }
+            this.components.splice(ind, 1);
         }
-
     });
 
     return {

--- a/src/framework/components/script/system.js
+++ b/src/framework/components/script/system.js
@@ -35,6 +35,8 @@ pc.extend(pc, function () {
             component.enabled = !! data.enabled;
 
             if (data.hasOwnProperty('order') && data.hasOwnProperty('scripts')) {
+                component._scriptsData = data.scripts;
+
                 for(var i = 0; i < data.order.length; i++) {
                     component.create(data.order[i], {
                         enabled: data.scripts[data.order[i]].enabled,
@@ -45,8 +47,38 @@ pc.extend(pc, function () {
             }
         },
 
-        cloneComponent: function() {
-            throw new Error('not implemented');
+        cloneComponent: function(entity, clone) {
+            var order = [ ];
+            var scripts = { };
+
+            for(var i = 0; i < entity.script._scripts.length; i++) {
+                var scriptInstance = entity.script._scripts[i];
+                var scriptName = scriptInstance.__scriptObject.name;
+                order.push(scriptName);
+
+                var attributes = { };
+                for(var key in scriptInstance.__attributes)
+                    attributes[key] = scriptInstance.__attributes[key];
+
+                scripts[scriptName] = {
+                    enabled: scriptInstance.enabled,
+                    attributes: attributes
+                };
+            }
+
+            for(var key in entity.script._scriptsIndex) {
+                var scriptData = entity.script._scriptsIndex[key];
+                if (key.awayting)
+                    order.splice(key.ind, 0, key);
+            }
+
+            var data = {
+                enabled: entity.script.enabled,
+                order: order,
+                scripts: scripts
+            };
+
+            return this.addComponent(clone, data);
         },
 
         _callComponentMethod: function(name, dt) {

--- a/src/framework/script.js
+++ b/src/framework/script.js
@@ -2,10 +2,12 @@
  * @name pc.script
  * @namespace
  * @description Functions for creating user scripts for the script component
+ * @property {Boolean} legacy If True, then engine will use legacy scripting system, defaults to true (subject to change)
  */
 pc.script = (function () {
     var _main = null;
     var _loader = null;
+    var _legacy = true;
 
     var script = {
         // set during script load to be used for initializing script
@@ -34,9 +36,11 @@ pc.script = (function () {
          * }
          */
         create: function (name, callback) {
-            if (callback === undefined) {
+            if (! _legacy)
+                return;
+
+            if (callback === undefined)
                 callback = attributes;
-            }
 
             // get the ScriptType from the callback
             var ScriptType = callback(pc.script.app);
@@ -126,6 +130,15 @@ pc.script = (function () {
             callback(app);
         }
     };
+
+    Object.defineProperty(script, 'legacy', {
+        get: function() {
+            return _legacy;
+        },
+        set: function(value) {
+            _legacy = value;
+        }
+    });
 
     pc.events.attach(script);
 

--- a/src/resources/loader.js
+++ b/src/resources/loader.js
@@ -26,6 +26,7 @@ pc.extend(pc, function () {
         */
         addHandler: function (type, handler) {
             this._handlers[type] = handler;
+            handler._loader = this;
         },
 
         removeHandler: function (type) {
@@ -76,15 +77,10 @@ pc.extend(pc, function () {
 
                     var i, len = this._requests[key].length;
                     if (!err) {
-                        if (! pc.script.legacy && type === 'script') {
-                            for (i = 0; i < len; i++)
-                                this._requests[key][i](null, data, extra);
-                        } else {
-                            var resource = handler.open(url, data);
-                            this._cache[key] = resource;
-                            for (i = 0; i < len; i++)
-                                this._requests[key][i](null, resource);
-                        }
+                        var resource = handler.open(url, data);
+                        this._cache[key] = resource;
+                        for (i = 0; i < len; i++)
+                            this._requests[key][i](null, resource, extra);
                     } else {
                         for (i = 0; i < len; i++)
                             this._requests[key][i](err);

--- a/src/resources/loader.js
+++ b/src/resources/loader.js
@@ -68,7 +68,7 @@ pc.extend(pc, function () {
             } else {
                 // new request
                 this._requests[key] = [callback];
-                handler.load(url, function (err, data) {
+                handler.load(url, function (err, data, extra) {
                     // make sure key exists because loader
                     // might have been destroyed by now
                     if (!this._requests[key])
@@ -76,10 +76,15 @@ pc.extend(pc, function () {
 
                     var i, len = this._requests[key].length;
                     if (!err) {
-                        var resource = handler.open(url, data);
-                        this._cache[key] = resource;
-                        for (i = 0; i < len; i++)
-                            this._requests[key][i](null, resource);
+                        if (! pc.script.legacy && type === 'script') {
+                            for (i = 0; i < len; i++)
+                                this._requests[key][i](null, data, extra);
+                        } else {
+                            var resource = handler.open(url, data);
+                            this._cache[key] = resource;
+                            for (i = 0; i < len; i++)
+                                this._requests[key][i](null, resource);
+                        }
                     } else {
                         for (i = 0; i < len; i++)
                             this._requests[key][i](err);

--- a/src/resources/script.js
+++ b/src/resources/script.js
@@ -15,7 +15,7 @@ pc.extend(pc, function () {
 
     ScriptHandler._types = [];
     ScriptHandler._push = function (Type) {
-        if (ScriptHandler._types.length > 0) {
+        if (pc.script.legacy && ScriptHandler._types.length > 0) {
             console.assert("Script Ordering Error. Contact support@playcanvas.com");
         } else {
             ScriptHandler._types.push(Type);
@@ -27,21 +27,32 @@ pc.extend(pc, function () {
             pc.script.app = this._app;
             this._loadScript(url, function (err, url) {
                 if (!err) {
-                    var Type = null;
-                    // pop the type from the loading stack
-                    if (ScriptHandler._types.length) {
-                        Type = ScriptHandler._types.pop();
-                    }
+                    if (pc.script.legacy) {
+                        var Type = null;
+                        // pop the type from the loading stack
+                        if (ScriptHandler._types.length) {
+                            Type = ScriptHandler._types.pop();
+                        }
 
-                    if (Type) {
-                        // store indexed by URL
-                        this._scripts[url] = Type;
+                        if (Type) {
+                            // store indexed by URL
+                            this._scripts[url] = Type;
+                        } else {
+                            Type = null;
+                        }
+
+                        // return the resource
+                        callback(null, Type);
                     } else {
-                        Type = null;
-                    }
+                        var obj = { };
 
-                    // return the resource
-                    callback(null, Type);
+                        for(var i = 0; i < ScriptHandler._types.length; i++)
+                            obj[ScriptHandler._types[i].name] = ScriptHandler._types[i];
+
+                        ScriptHandler._types.length = 0;
+
+                        callback(null, obj);
+                    }
                 } else {
                     callback(err);
                 }

--- a/src/resources/script.js
+++ b/src/resources/script.js
@@ -10,7 +10,8 @@ pc.extend(pc, function () {
      */
     var ScriptHandler = function (app) {
         this._app = app;
-        this._scripts = {};
+        this._scripts = { };
+        this._cache = { };
     };
 
     ScriptHandler._types = [];
@@ -25,7 +26,8 @@ pc.extend(pc, function () {
     ScriptHandler.prototype = {
         load: function (url, callback) {
             pc.script.app = this._app;
-            this._loadScript(url, function (err, url) {
+
+            this._loadScript(url, function (err, url, extra) {
                 if (!err) {
                     if (pc.script.legacy) {
                         var Type = null;
@@ -42,7 +44,7 @@ pc.extend(pc, function () {
                         }
 
                         // return the resource
-                        callback(null, Type);
+                        callback(null, Type, extra);
                     } else {
                         var obj = { };
 
@@ -51,7 +53,7 @@ pc.extend(pc, function () {
 
                         ScriptHandler._types.length = 0;
 
-                        callback(null, obj);
+                        callback(null, obj, extra);
                     }
                 } else {
                     callback(err);
@@ -63,27 +65,25 @@ pc.extend(pc, function () {
             return data;
         },
 
-        patch: function (asset, assets) {
-
-        },
+        patch: function (asset, assets) { },
 
         _loadScript: function (url, callback) {
-            var self = this;
-            var head = document.getElementsByTagName("head")[0];
-            var element = document.createElement("script");
+            var head = document.head;
+            var element = document.createElement('script');
+            this._cache[url] = element;
+
             // use async=false to force scripts to execute in order
             element.async = false;
 
-            element.addEventListener("error", function (e) {
-                // error
+            element.addEventListener('error', function (e) {
                 callback(pc.string.format("Script: {0} failed to load", e.target.src));
-            });
+            }, false);
 
             var done = false;
             element.onload = element.onreadystatechange = function () {
                 if(!done && (!this.readyState || (this.readyState == "loaded" || this.readyState == "complete"))) {
                     done = true; // prevent double event firing
-                    callback(null, url);
+                    callback(null, url, element);
                 }
             };
             // set the src attribute after the onload callback is set, to avoid an instant loading failing to fire the callback

--- a/src/resources/script.js
+++ b/src/resources/script.js
@@ -25,6 +25,7 @@ pc.extend(pc, function () {
 
     ScriptHandler.prototype = {
         load: function (url, callback) {
+            var self = this;
             pc.script.app = this._app;
 
             this._loadScript(url, function (err, url, extra) {
@@ -54,6 +55,9 @@ pc.extend(pc, function () {
                         ScriptHandler._types.length = 0;
 
                         callback(null, obj, extra);
+
+                        // no cache for scripts
+                        delete self._loader._cache[url + 'script'];
                     }
                 } else {
                     callback(err);

--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -90,10 +90,8 @@ pc.extend(pc, function () {
             if (this._enabled !== enabled) {
                 this._enabled = enabled;
 
-                if (!this._parent || this._parent.enabled) {
+                if (! this._parent || this._parent.enabled)
                     this._notifyHierarchyStateChanged(this, enabled);
-                }
-
             }
         }
     });
@@ -104,9 +102,8 @@ pc.extend(pc, function () {
 
             var c = node._children;
             for (var i=0, len=c.length; i<len; i++) {
-                if (c[i]._enabled) {
+                if (c[i]._enabled)
                     this._notifyHierarchyStateChanged(c[i], enabled);
-                }
             }
         },
 

--- a/src/script/script-registry.js
+++ b/src/script/script-registry.js
@@ -1,0 +1,138 @@
+pc.extend(pc, function () {
+    /**
+    * @name pc.ScriptRegistry
+    * @class Container for all scripts that are available to this application
+    * @description Create an instance of an ScriptRegistry.
+    * Note: PlayCanvas scripts are provided with an ScriptRegistry instance as 'app.scripts'.
+    * @param {pc.Application} app Application to attach registry to.
+    */
+    var ScriptRegistry = function (app) {
+        pc.events.attach(this);
+
+        this.app = app;
+        this._scripts = { };
+        this._list = [ ];
+    };
+
+
+    /**
+     * @function
+     * @name pc.ScriptRegistry#add
+     * @description Add Script Object to pc.ScriptRegistry.
+     * Note: when `new pc.Script` is called, it will add script to pc.ScriptRegistry automatically.
+     * If script already exists in registry, and new Script Object has `swap` method defined,
+     * it will perform code hot swapping automatically in async manner
+     * @param {function} scriptObject Script Object that is created using {pc.Script}
+     * @returns {Boolean} True if first time added or false if script already exists
+     * @example
+     * var PlayerController = new pc.Script('playerController');
+     * // playerController Script Object will be added to pc.ScriptRegistry automatically
+     * app.scripts.has('playerController') === true; // true
+     */
+    ScriptRegistry.prototype.add = function(script) {
+        if (this._scripts.hasOwnProperty(script.name)) {
+            var self = this;
+            setTimeout(function() {
+                if (script.prototype.swap) {
+                    // swapping
+                    var old = self._scripts[script.name];
+                    var ind = self._list.indexOf(old);
+                    self._list[ind] = script;
+                    self._scripts[script.name] = script;
+
+                    self.fire('swap', script.name, script);
+                    self.fire('swap:' + script.name, script);
+                } else {
+                    console.warn('script registry already has \'' + script.name + '\' script, define \'swap\' method to script object to enable code hot swapping');
+                }
+            });
+            return false;
+        }
+
+        this._scripts[script.name] = script;
+        this._list.push(script);
+
+        this.fire('add', script.name, script);
+        this.fire('add:' + script.name, script);
+
+        return true;
+    };
+
+    /**
+     * @function
+     * @name pc.ScriptRegistry#remove
+     * @description Remove Script Object from pc.ScriptRegistry.
+     * @param {String} script Name of a Script Object to remove from pc.ScriptRegistry
+     * @returns {Boolean} True if removed or False if not in pc.ScriptRegistry
+     * @example
+     * app.scripts.remove('playerController');
+     */
+    ScriptRegistry.prototype.remove = function(script) {
+        var name = script;
+
+        if (typeof(script) === 'function')
+            name = script.name;
+
+        if (! this._scripts.hasOwnProperty(name))
+            return false;
+
+        var item = this._scripts[name];
+        delete this._scripts[name];
+
+        var ind = this._list.indexOf(item);
+        this._list.splice(ind, 1);
+
+        this.fire('remove', name, item);
+        this.fire('remove:' + name, item);
+
+        return true;
+    };
+
+    /**
+     * @function
+     * @name pc.ScriptRegistry#get
+     * @description Get Script Object by name from pc.ScriptRegistry.
+     * @param {String} script Name of a Script Object
+     * @returns {function} Script Object will be returned if in pc.ScriptRegistry or Null
+     * @example
+     * var PlayerController = app.scripts.get('playerController');
+     */
+    ScriptRegistry.prototype.get = function(name) {
+        return this._scripts[name] || null;
+    };
+
+    /**
+     * @function
+     * @name pc.ScriptRegistry#has
+     * @description Detect if Script Object is in pc.ScriptRegistry by name.
+     * @param {String} script Name of a Script Object
+     * @returns {Boolean} True if Script Object is in pc.ScriptRegistry
+     * @example
+     * if (app.scripts.has('playerController')) {
+     *     // playerController is in pc.ScriptRegistry
+     * }
+     */
+    ScriptRegistry.prototype.has = function(name) {
+        return this._scripts.hasOwnProperty(name);
+    };
+
+    /**
+     * @function
+     * @name pc.ScriptRegistry#list
+     * @description Get list of all Script Object's from pc.ScriptRegistry.
+     * @returns {function[]} list of all Script Object's in pc.ScriptRegistry
+     * @example
+     * // logs array of all Script Object names from registry
+     * console.log(app.scripts.list().map(function(o) {
+     *     return o.name;
+     * }));
+     */
+    ScriptRegistry.prototype.list = function() {
+        return this._list;
+    };
+
+
+    return {
+        ScriptRegistry: ScriptRegistry
+    };
+}());

--- a/src/script/script.js
+++ b/src/script/script.js
@@ -292,6 +292,7 @@ pc.extend(pc, function () {
             this._enabledOld = this.enabled;
             this.__attributes = { };
             this.__attributesRaw = args.attributes || null;
+            this.__scriptObject = script;
         };
 
         /**
@@ -335,8 +336,6 @@ pc.extend(pc, function () {
                 } else if (script.attributes.index[key].hasOwnProperty('default')) {
                     this[key] = script.attributes.index[key].default;
                 } else {
-                    // TODO scripts2
-                    // set default value based on property type
                     this[key] = null;
                 }
             }
@@ -492,43 +491,33 @@ pc.extend(pc, function () {
         return script;
     };
 
-    Script.reservedScripts = {
-        'system': 1,
-        'entity': 1,
-        'create': 1,
-        'destroy': 1,
-        'swap': 1,
-        'move': 1,
-        'scripts': 1,
-        '_scripts': 1,
-        '_scriptsIndex': 1,
-        '_oldState': 1,
-        'onEnable': 1,
-        'onDisable': 1,
-        'onPostStateChange': 1,
-        '_onSetEnabled': 1,
-        '_checkState': 1,
-        '_onBeforeRemove': 1,
-        '_onInitializeAttributes': 1,
-        '_onInitialize': 1,
-        '_onPostInitialize': 1,
-        '_onUpdate': 1,
-        '_onFixedUpdate': 1,
-        '_onPostUpdate': 1,
-        '_callbacks': 1,
-        'has': 1,
-        'on': 1,
-        'off': 1,
-        'fire': 1,
-        'once': 1,
-        'hasEvent': 1
-    };
+    // reserved scripts
+    Script.reservedScripts = [
+        'system', 'entity', 'create', 'destroy', 'swap', 'move',
+        'scripts', '_scripts', '_scriptsIndex', '_scriptsData',
+        'enabled', '_oldState', 'onEnable', 'onDisable', 'onPostStateChange',
+        '_onSetEnabled', '_checkState', '_onBeforeRemove',
+        '_onInitializeAttributes', '_onInitialize', '_onPostInitialize',
+        '_onUpdate', '_onFixedUpdate', '_onPostUpdate',
+        '_callbacks', 'has', 'on', 'off', 'fire', 'once', 'hasEvent'
+    ];
+    var reservedScripts = { };
+    for(var i = 0; i < Script.reservedScripts.length; i++)
+        reservedScripts[Script.reservedScripts[i]] = 1;
+    Script.reservedScripts = reservedScripts;
 
-    Script.reservedAttributes = {
-        'enabled': 1,
-        'entity': 1,
-        'app': 1
-    };
+
+    // reserved script attribute names
+    Script.reservedAttributes = [
+        'app', 'entity', 'enabled', '_enabled', '_enabledOld',
+        '__attributes', '__attributesRaw', '__scriptObject',
+        '_callbacks', 'has', 'on', 'off', 'fire', 'once', 'hasEvent'
+    ];
+    var reservedAttributes = { };
+    for(var i = 0; i < Script.reservedAttributes.length; i++)
+        reservedAttributes[Script.reservedAttributes[i]] = 1;
+    Script.reservedAttributes = reservedAttributes;
+
 
     return {
         Script: Script

--- a/src/script/script.js
+++ b/src/script/script.js
@@ -260,12 +260,17 @@ pc.extend(pc, function () {
     * to define custom logic using javascript, that is used to create interaction for entities
     * @param {String} name unique Name of a Script Object.
     * If same name will be used and Script Object has `swap` method defined in prototype,
-    * then it will perform hot swapping of existing Script Instances on entities using this new Script Object
+    * then it will perform hot swapping of existing Script Instances on entities using this new Script Object.
+    * Note: there is a reserved list of names that cannot be used, such as list below as well as some starting from `_` (underscore):
+    * system, entity, create, destroy, swap, move, scripts, onEnable, onDisable, onPostStateChange, has, on, off, fire, once, hasEvent
     * @param {pc.Application} [app] Optional application handler, to choose which pc.ScriptRegistry to add a script.
     * By default it will use `pc.Application.getApplication()` to get current pc.Application.
     * @returns {function} So called Script Object, that developer is meant to extend by adding attributes and prototype methods.
     */
     var Script = function (name, app) {
+        if (Script.reservedScripts[name])
+            throw new Error('script name: \'' + name + '\' is reserved, please change script name');
+
         /**
         * @name ScriptObject
         * @class Class that is returned by {@link pc.Script}. Also referred as Script Object
@@ -482,7 +487,41 @@ pc.extend(pc, function () {
         var registry = app ? app.scripts : pc.Application.getApplication().scripts;
         registry.add(script);
 
+        pc.ScriptHandler._push(script);
+
         return script;
+    };
+
+    Script.reservedScripts = {
+        'system': 1,
+        'entity': 1,
+        'create': 1,
+        'destroy': 1,
+        'swap': 1,
+        'move': 1,
+        'scripts': 1,
+        '_scripts': 1,
+        '_scriptsIndex': 1,
+        '_oldState': 1,
+        'onEnable': 1,
+        'onDisable': 1,
+        'onPostStateChange': 1,
+        '_onSetEnabled': 1,
+        '_checkState': 1,
+        '_onBeforeRemove': 1,
+        '_onInitializeAttributes': 1,
+        '_onInitialize': 1,
+        '_onPostInitialize': 1,
+        '_onUpdate': 1,
+        '_onFixedUpdate': 1,
+        '_onPostUpdate': 1,
+        '_callbacks': 1,
+        'has': 1,
+        'on': 1,
+        'off': 1,
+        'fire': 1,
+        'once': 1,
+        'hasEvent': 1
     };
 
     Script.reservedAttributes = {

--- a/src/script/script.js
+++ b/src/script/script.js
@@ -1,0 +1,498 @@
+pc.extend(pc, function () {
+    var rawToValue = function(app, args, value, old) {
+        // TODO scripts2
+        // arrays
+        switch(args.type) {
+            case 'boolean':
+                return !! value;
+                break;
+            case 'number':
+                if (typeof(value) === 'number') {
+                    return value;
+                } else if (typeof(value) === 'string') {
+                    var v = parseInt(value, 10);
+                    if (isNaN(v)) return null;
+                    return v;
+                } else if (typeof(value) === 'boolean') {
+                    return 0 + value;
+                } else {
+                    return null;
+                }
+                break;
+            case 'json':
+                if (typeof(value) === 'object') {
+                    return value;
+                } else {
+                    try {
+                        return JSON.parse(value);
+                    } catch(ex) {
+                        return null;
+                    }
+                }
+                break;
+            case 'asset':
+                if (value instanceof pc.Asset) {
+                    return value;
+                } else if (typeof(value) === 'number') {
+                    return app.assets.get(value) || null;
+                } else if (typeof(value) === 'string') {
+                    return app.assets.get(parseInt(value, 10)) || null;
+                } else {
+                    return null;
+                }
+                break;
+            case 'entity':
+                if (value instanceof pc.Entity) {
+                    return value;
+                } else if (typeof(value) === 'string') {
+                    return app.root.findByGuid(value);
+                } else {
+                    return null;
+                }
+                break;
+            case 'rgb':
+            case 'rgba':
+                if (value instanceof pc.Color) {
+                    if (old instanceof pc.Color) {
+                        old.copy(value);
+                        return old;
+                    } else {
+                        return value;
+                    }
+                } else if (value instanceof Array && value.length >= 3 && value.length <= 4) {
+                    for(var i = 0; i < value.length; i++) {
+                        if (typeof(value[i]) !== 'number')
+                            return null;
+                    }
+                    if (! old) old = new pc.Color();
+
+                    for(var i = 0; i < 4; i++)
+                        old.data[i] = (i === 4 && value.length === 3) ? 1 : value[i];
+
+                    return old;
+                } else if (typeof(value) === 'string' && /#([0-9abcdef]{2}){3,4}/i.test(value)) {
+                    if (! old)
+                        old = new pc.Color();
+
+                    old.fromString(value);
+                    return old;
+                } else {
+                    return null;
+                }
+                break;
+            case 'vec2':
+            case 'vec3':
+            case 'vec4':
+                var len = parseInt(args.type.slice(3), 10);
+
+                if (value instanceof pc['Vec' + len]) {
+                    if (old instanceof pc['Vec' + len]) {
+                        old.copy(value);
+                        return old;
+                    } else {
+                        return value;
+                    }
+                } else if (value instanceof Array && value.length === len) {
+                    for(var i = 0; i < value.length; i++) {
+                        if (typeof(value[i]) !== 'number')
+                            return null;
+                    }
+                    if (! old) old = new pc['Vec' + len];
+
+                    for(var i = 0; i < len; i++)
+                        old.data[i] = value[i];
+
+                    return old;
+                } else {
+                    return null;
+                }
+                break;
+            case 'curve':
+                // TODO scripts2
+                // curves
+                break;
+        }
+
+        return value;
+    };
+
+
+    /**
+    * @name pc.ScriptAttributes
+    * @class Container of Script Attributes definition
+    * @description Implements an interface to add/remove attributes and store their definition for Script Object.
+    * Note: This object is created automatically by each Script Object
+    * @param {function} scriptObject Script Object that attributes relate to.
+    */
+    var ScriptAttributes = function(scriptObject) {
+        this.scriptObject = scriptObject;
+        this.index = { };
+    };
+
+    /**
+     * @function
+     * @name pc.ScriptAttributes#add
+     * @description Add Attribute
+     * @param {String} name Name of an attribute
+     * @param {Object} args Object with Arguments for an attribute
+     * @param {String} args.type Type of an attribute value, list of possible types:
+     * boolean, number, string, json, asset, entity, rgb, rgba, vec2, vec3, vec4, curve
+     * @param {?} [args.default] Default attribute value
+     * @param {String} [args.title] Title for Editor's for field UI
+     * @param {String} [args.description] Description for Editor's for field UI
+     * @param {(String|String[])} [args.placeholder] Placeholder for Editor's for field UI.
+     * For multi-field types, such as vec2, vec3, and others use array of strings.
+     * @param {Boolean} [args.array] If attribute can hold single or multiple values
+     * @param {Number} [args.size] If attribute is array, maximum number of values can be set
+     * @param {Number} [args.min] Minimum value for type 'number', if max and min defined, slider will be rendered in Editor's UI
+     * @param {Number} [args.max] Maximum value for type 'number', if max and min defined, slider will be rendered in Editor's UI
+     * @param {Number} [args.precision] Level of precision for field type 'number' with floating values
+     * @param {String} [args.assetType] Name of asset type to be used in 'asset' type attribute picker in Editor's UI, defaults to '*' (all)
+     * @param {Strings[]} [args.curves] List of names for Curves for field type 'curve'
+     * @param {String} [args.color] String of color channels for Curves for field type 'curve', can be any combination of `rgba` characters.
+     * Defining this property will render Gradient in Editor's field UI
+     * @param {Object[]} [args.enum] List of fixed choices for field, defined as array of objects, where key in object is a title of an option
+     * @example
+     * PlayerController.attributes.add('fullName', {
+     *     type: 'string',
+     * });
+     * @example
+     * PlayerController.attributes.add('speed', {
+     *     type: 'number',
+     *     title: 'Speed',
+     *     placeholder: 'km/h',
+     *     default: 22.2
+     * });
+     * @example
+     * PlayerController.attributes.add('resolution', {
+     *     type: 'number',
+     *     default: 32,
+     *     enum: [
+     *        { '32x32': 32 },
+     *        { '64x64': 64 },
+     *        { '128x128': 128 }
+     *     ]
+     * });
+     */
+    ScriptAttributes.prototype.add = function(name, args) {
+        if (this.index[name]) {
+            console.warn('attribute \'' + name + '\' is already defined for script object \'' + this.scriptObject.name + '\'');
+            return;
+        } else if (pc.Script.reservedAttributes[name]) {
+            console.warn('attribute \'' + name + '\' is a reserved attribute name');
+            return;
+        }
+
+        this.index[name] = args;
+
+        Object.defineProperty(this.scriptObject.prototype, name, {
+            get: function() {
+                return this.__attributes[name];
+            },
+            set: function(raw) {
+                var old = this.__attributes[name];
+
+                // convert to appropriate type
+                this.__attributes[name] = rawToValue(this.app, args, raw, old);
+
+                this.fire('attr', name, this.__attributes[name], old);
+                this.fire('attr:' + name, this.__attributes[name], old);
+            }
+        });
+    };
+
+    /**
+     * @function
+     * @name pc.ScriptAttributes#remove
+     * @description Remove Attribute
+     * @param {String} name Name of an attribute
+     * @returns {Boolean} True if removed or false if not defined
+     * @example
+     * PlayerController.attributes.remove('fullName');
+     */
+    ScriptAttributes.prototype.remove = function(name) {
+        if (! this.index[name])
+            return false;
+
+        delete this.index[name];
+        delete this.scriptObject.prototype[name];
+        return true;
+    };
+
+    /**
+     * @function
+     * @name pc.ScriptAttributes#has
+     * @description Detect if Attribute is added
+     * @param {String} name Name of an attribute
+     * @returns {Boolean} True if Attribute is defined
+     * @example
+     * if (PlayerController.attributes.has('fullName')) {
+     *     // attribute `fullName` is defined
+     * });
+     */
+    ScriptAttributes.prototype.has = function(name) {
+        return !! this.index[name];
+    };
+
+    /**
+     * @function
+     * @name pc.ScriptAttributes#get
+     * @description Get object with attribute arguments.
+     * Note: Changing argument properties will not affect existing Script Instances
+     * @param {String} name Name of an attribute
+     * @returns {?Object} Arguments with attribute properties
+     * @example
+     * // changing default value for an attribute 'fullName'
+     * var attr = PlayerController.attributes.get('fullName');
+     * if (attr) attr.default = 'Unknown';
+     */
+    ScriptAttributes.prototype.get = function(name) {
+        return this.index[name] || null;
+    };
+
+
+    /**
+    * @name pc.Script
+    * @class Class to create named Script Objects.
+    * It returns new class function "Script Object",
+    * which is auto-registered to pc.ScriptRegistry using it's name.
+    * @description This is main interface to create Script Objects,
+    * to define custom logic using javascript, that is used to create interaction for entities
+    * @param {String} name unique Name of a Script Object.
+    * If same name will be used and Script Object has `swap` method defined in prototype,
+    * then it will perform hot swapping of existing Script Instances on entities using this new Script Object
+    * @param {pc.Application} [app] Optional application handler, to choose which pc.ScriptRegistry to add a script.
+    * By default it will use `pc.Application.getApplication()` to get current pc.Application.
+    * @returns {function} So called Script Object, that developer is meant to extend by adding attributes and prototype methods.
+    */
+    var Script = function (name, app) {
+        /**
+        * @name ScriptObject
+        * @class Class that is returned by {@link pc.Script}. Also referred as Script Object
+        * @description Script Object are the functions (classes) that are created using {@link pc.Script}.
+        * And extended using attributes and prototype to define custom logic.
+        * When instanced by engine, the object is referred as Script Instance.
+        * Note: this class is created by using pc.Script.
+        * Note: instances using this class are created by engine when script is added to {@link pc.ScriptComponent}
+        */
+        var script = function(args) {
+            if (! args || ! args.app || ! args.entity)
+                console.warn('script \'' + name + '\' has missing arguments in consructor');
+
+            pc.events.attach(this);
+
+            this.app = args.app;
+            this.entity = args.entity;
+            this._enabled = typeof(args.enabled) === 'boolean' ? args.enabled : true;
+            this._enabledOld = this.enabled;
+            this.__attributes = { };
+            this.__attributesRaw = args.attributes || null;
+        };
+
+        /**
+         * @readonly
+         * @static
+         * @name ScriptObject#name
+         * @type String
+         * @description Name of a Script Object.
+         */
+        Object.defineProperty(script, 'name', {
+            value: name
+        });
+
+        /**
+         * @readonly
+         * @static
+         * @name ScriptObject#attributes
+         * @description The interface to define attributes for Script Objects.
+         * Refer to {@link pc.ScriptAttributes}
+         * @example
+         * var PlayerController = new pc.Script('playerController');
+         *
+         * PlayerController.attributes.add('speed', {
+         *     type: 'number',
+         *     title: 'Speed',
+         *     placeholder: 'km/h',
+         *     default: 22.2
+         * });
+         */
+        script.attributes = new ScriptAttributes(script);
+
+        // initialize attributes
+        script.prototype.__initializeAttributes = function() {
+            if (! this.__attributesRaw)
+                return;
+
+            // set attributes values
+            for(var key in script.attributes.index) {
+                if (this.__attributesRaw && this.__attributesRaw.hasOwnProperty(key)) {
+                    this[key] = this.__attributesRaw[key];
+                } else if (script.attributes.index[key].hasOwnProperty('default')) {
+                    this[key] = script.attributes.index[key].default;
+                } else {
+                    // TODO scripts2
+                    // set default value based on property type
+                    this[key] = null;
+                }
+            }
+
+            this.__attributesRaw = null;
+        };
+
+        /**
+         * @readonly
+         * @static
+         * @function
+         * @name ScriptObject#extend
+         * @param {Object} methods Object with methods, where key - is name of method, and value - is function.
+         * @description Shorthand function to extend Script Object prototype with list of methods.
+         * @example
+         * var PlayerController = new pc.Script('playerController');
+         *
+         * PlayerController.extend({
+         *     initialize: function() {
+         *         // called once on initialize
+         *     },
+         *     update: function(dt) {
+         *         // called each tick
+         *     }
+         * })
+         */
+        @function
+        script.extend = function(methods) {
+            for(var key in methods) {
+                if (! methods.hasOwnProperty(key))
+                    continue;
+
+                script.prototype[key] = methods[key];
+            }
+        };
+
+        /**
+        * @name ScriptInstance
+        * @class Instance of ScriptObject
+        * @property {pc.Application} app Pointer to {@link pc.Application} that Script Instance belongs to.
+        * @property {pc.Entity} entity Pointer to entity that Script Instance belongs to.
+        * @property {Boolean} enabled True if Script Instance is in running state.
+        * @description Script Instance is created by engine during script being created for {@link pc.ScriptComponent}
+        */
+
+        /**
+        * @event
+        * @name ScriptInstance#enabled
+        * @description Fired when Script Instance becomes enabled
+        * @example
+        * PlayerController.prototype.initialize = function() {
+        *     this.on('enabled', function() {
+        *         // Script Instance is now enabled
+        *     });
+        * };
+        */
+
+        /**
+        * @event
+        * @name ScriptInstance#disabled
+        * @description Fired when Script Instance becomes disabled
+        * @example
+        * PlayerController.prototype.initialize = function() {
+        *     this.on('disabled', function() {
+        *         // Script Instance is now disabled
+        *     });
+        * };
+        */
+
+        /**
+        * @event
+        * @name ScriptInstance#state
+        * @description Fired when Script Instance changes state to enabled or disabled
+        * @param {Boolean} enabled True if now enabled, False if disabled
+        * @example
+        * PlayerController.prototype.initialize = function() {
+        *     this.on('state', function(enabled) {
+        *         console.log('Script Instance is now ' + (enabled ? 'enabled' : 'disabled'));
+        *     });
+        * };
+        */
+
+        /**
+        * @event
+        * @name ScriptInstance#destroy
+        * @description Fired when Script Instance is destroyed and removed from component
+        * @example
+        * PlayerController.prototype.initialize = function() {
+        *     this.on('destroy', function() {
+        *         // no more part of an entity
+        *         // good place to cleanup entity from destroyed script
+        *     });
+        * };
+        */
+
+        /**
+        * @event
+        * @name ScriptInstance#attr
+        * @description Fired when any script attribute been changed
+        * @param {String} name Name of attribute changed
+        * @param {} value New value
+        * @param {} valueOld Old value
+        * @example
+        * PlayerController.prototype.initialize = function() {
+        *     this.on('attr', function(name, value, valueOld) {
+        *         console.log(name + ' been changed from ' + valueOld + ' to ' + value);
+        *     });
+        * };
+        */
+
+        /**
+        * @event
+        * @name ScriptInstance#attr:[name]
+        * @description Fired when specific script attribute been changed
+        * @param {} value New value
+        * @param {} valueOld Old value
+        * @example
+        * PlayerController.prototype.initialize = function() {
+        *     this.on('attr:speed', function(value, valueOld) {
+        *         console.log('speed been changed from ' + valueOld + ' to ' + value);
+        *     });
+        * };
+        */
+
+        /**
+         * @name ScriptInstance#enabled
+         * @type Boolean
+         * @description False when script will not be running, due to disabled state of any of: Entity (including any parents), ScriptComponent, ScriptInstance.
+         * When disabled will not run any update methods on each tick.
+         * initialize and postInitialize methods will run once when Script Instance is `enabled` during app tick.
+         */
+        Object.defineProperty(script.prototype, 'enabled', {
+            get: function() {
+                return this._enabled && this.entity.script.enabled && this.entity.enabled;
+            },
+            set: function(value) {
+                if (this._enabled !== !! value)
+                    this._enabled = !! value;
+
+                if (this.enabled !== this._enabledOld) {
+                    this._enabledOld = this.enabled;
+                    this.fire(this.enabled ? 'enabled' : 'disabled');
+                    this.fire('state', this.enabled);
+                }
+            }
+        });
+
+        // add to scripts registry
+        var registry = app ? app.scripts : pc.Application.getApplication().scripts;
+        registry.add(script);
+
+        return script;
+    };
+
+    Script.reservedAttributes = {
+        'enabled': 1,
+        'entity': 1,
+        'app': 1
+    };
+
+    return {
+        Script: Script
+    };
+}());

--- a/src/script/script.js
+++ b/src/script/script.js
@@ -358,7 +358,6 @@ pc.extend(pc, function () {
          *     }
          * })
          */
-        @function
         script.extend = function(methods) {
             for(var key in methods) {
                 if (! methods.hasOwnProperty(key))


### PR DESCRIPTION
New scripts system which is incompatible with old one.
By default for now new system is disabled and old one is used, to avoid "rude" breaking for existing users. Although this will change once new system is fully tested and satisfies quality requirements for users.

In order to use new system, use flag:
`pc.script.legacy = false;` after loading engine, before creating `pc.Application`.

New system simplifies use of script component.
Script boilerplate is tiny and simple,  very useful for engine-only users, allowing organising scripts in better ways.
Some of notable new features of script system are:
* good async loading asset handling
* code live hot swap
* runtime script attributes
* scripts as assets
* and more

Old system will co-exist with new one, but eventually will go.