### PR TITLE
scripts2 better error handling by developer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 *.DS_Store
 /build/output
-/build/node_modules
-/package.json
 /src/graphics/program-lib/chunks/generated-shader-chunks.js
+package.json
 node_modules/

--- a/src/framework/components/script/component.js
+++ b/src/framework/components/script/component.js
@@ -19,6 +19,14 @@ pc.extend(pc, function () {
     };
     ScriptComponent = pc.inherits(ScriptComponent, pc.Component);
 
+    ScriptComponent.scriptMethods = {
+        initialize: 'initialize',
+        postInitialize: 'postInitialize',
+        update: 'update',
+        postUpdate: 'postUpdate',
+        swap: 'swap'
+    };
+
     /**
     * @event
     * @name pc.ScriptComponent#enabled
@@ -109,6 +117,19 @@ pc.extend(pc, function () {
     * });
     */
 
+    /**
+    * @event
+    * @name pc.ScriptComponent#error
+    * @description Fired when Script Instance had an exception
+    * @param {String} script Script Instance exception happened in
+    * @param {Error} err Native JS Error object with details of error
+    * @param {String} method Script Instance method exception originated from
+    * @example
+    * entity.script.on('error', function (scriptInstance, err, method) {
+    *     // script instance caught an exception
+    * });
+    */
+
     pc.extend(ScriptComponent.prototype, {
         onEnable: function () {
             ScriptComponent._super.onEnable.call(this);
@@ -129,7 +150,7 @@ pc.extend(pc, function () {
                     script._postInitialized = true;
 
                     if (script.postInitialize)
-                        script.postInitialize();
+                        this._scriptMethod(script, ScriptComponent.scriptMethods.postInitialize);
                 }
             }
         },
@@ -157,7 +178,7 @@ pc.extend(pc, function () {
                     script._initialized = true;
 
                     if (script.initialize)
-                        script.initialize();
+                        this._scriptMethod(script, ScriptComponent.scriptMethods.initialize);
                 }
             }
         },
@@ -176,6 +197,26 @@ pc.extend(pc, function () {
                 this.scripts[i].__initializeAttributes();
         },
 
+        _scriptMethod: function(script, method, arg) {
+            try {
+                script[method](arg);
+            } catch(ex) {
+                // disable script if it fails to call method
+                script.enabled = false;
+
+                if (! script._callbacks || ! script._callbacks.error) {
+                    console.warn('unhandled exception while calling "' + method + '" for "' + script.__scriptObject.__name + '" script: ', ex);
+
+                    // #ifdef DEBUG
+                    console.error(ex.stack);
+                    // #endif
+                }
+
+                script.fire('error', ex, method);
+                this.fire('error', script, ex, method);
+            }
+        },
+
         _onInitialize: function() {
             var script;
             for(var i = 0, len = this.scripts.length; i < len; i++) {
@@ -183,7 +224,7 @@ pc.extend(pc, function () {
                 if (script.enabled && ! script._initialized) {
                     script._initialized = true;
                     if (script.initialize)
-                        script.initialize();
+                        this._scriptMethod(script, ScriptComponent.scriptMethods.initialize);
                 }
             }
         },
@@ -195,7 +236,7 @@ pc.extend(pc, function () {
                 if (script.enabled && ! script._postInitialized) {
                     script._postInitialized = true;
                     if (script.postInitialize)
-                        script.postInitialize();
+                        this._scriptMethod(script, ScriptComponent.scriptMethods.postInitialize);
                 }
             }
         },
@@ -205,16 +246,7 @@ pc.extend(pc, function () {
             for(var i = 0, len = this.scripts.length; i < len; i++) {
                 script = this.scripts[i];
                 if (script.enabled && script.update)
-                    script.update(dt);
-            }
-        },
-
-        _onFixedUpdate: function(dt) {
-            var script;
-            for(var i = 0, len = this.scripts.length; i < len; i++) {
-                script = this.scripts[i];
-                if (script.enabled && script.fixedUpdate)
-                    script.fixedUpdate(dt);
+                    this._scriptMethod(script, ScriptComponent.scriptMethods.update, dt);
             }
         },
 
@@ -223,7 +255,7 @@ pc.extend(pc, function () {
             for(var i = 0, len = this.scripts.length; i < len; i++) {
                 script = this.scripts[i];
                 if (script.enabled && script.postUpdate)
-                    script.postUpdate(dt);
+                    this._scriptMethod(script, ScriptComponent.scriptMethods.postUpdate, dt);
             }
         },
 
@@ -322,10 +354,10 @@ pc.extend(pc, function () {
                         scriptInstance._postInitialized = true;
 
                         if (scriptInstance.initialize)
-                            scriptInstance.initialize();
+                            this._scriptMethod(scriptInstance, ScriptComponent.scriptMethods.initialize);
 
                         if (scriptInstance.postInitialize)
-                            scriptInstance.postInitialize();
+                            this._scriptMethod(scriptInstance, ScriptComponent.scriptMethods.postInitialize);
                     }
 
                     return scriptInstance;
@@ -415,7 +447,7 @@ pc.extend(pc, function () {
             this._scriptsIndex[scriptObject.__name].instance = scriptInstance;
             this[scriptObject.__name] = scriptInstance;
 
-            scriptInstance.swap(scriptInstanceOld);
+            this._scriptMethod(scriptInstance, ScriptComponent.scriptMethods.swap, scriptInstanceOld);
 
             this.fire('swap', scriptObject.__name, scriptInstance);
             this.fire('swap:' + scriptObject.__name, scriptInstance);

--- a/src/script/script.js
+++ b/src/script/script.js
@@ -42,7 +42,7 @@ pc.extend(pc, function () {
                 }
                 break;
             case 'entity':
-                if (value instanceof pc.Entity) {
+                if (value instanceof pc.GraphNode) {
                     return value;
                 } else if (typeof(value) === 'string') {
                     return app.root.findByGuid(value);
@@ -459,6 +459,23 @@ pc.extend(pc, function () {
         */
 
         /**
+        * @event
+        * @name ScriptInstance#error
+        * @description Fired when Script Instance had an exception.
+        * Script Instance will be automatically disabled if exception
+        * has not been handled within initialize or postInitialize methods
+        * @param {Error} err Native JS Error object with details of error
+        * @param {String} method Script Instance method exception originated from
+        * @example
+        * PlayerController.prototype.initialize = function() {
+        *     this.on('error', function(err, method) {
+        *         // caught an exception
+        *         console.log(err.stack);
+        *     });
+        * };
+        */
+
+        /**
          * @name ScriptInstance#enabled
          * @type Boolean
          * @description False when script will not be running, due to disabled state of any of: Entity (including any parents), ScriptComponent, ScriptInstance.
@@ -497,7 +514,7 @@ pc.extend(pc, function () {
         'enabled', '_oldState', 'onEnable', 'onDisable', 'onPostStateChange',
         '_onSetEnabled', '_checkState', '_onBeforeRemove',
         '_onInitializeAttributes', '_onInitialize', '_onPostInitialize',
-        '_onUpdate', '_onFixedUpdate', '_onPostUpdate',
+        '_onUpdate', '_onPostUpdate',
         '_callbacks', 'has', 'on', 'off', 'fire', 'once', 'hasEvent'
     ];
     var reservedScripts = { };


### PR DESCRIPTION
Introduce `error` event for scripts2 ScriptComponent and ScriptInstance, so that developer can handle exceptions in their app code.
ScriptInstance will be disabled if exception occurs to prevent contentious spam of errors on each tick.
Each ScriptInstance method is handled individually so it prevents breaking chain of execution within script ScriptComponent as well as hierarchy entities, if any of scripts throws an exception.