### PR TITLE
Modify sorting key to have more layers

### DIFF
--- a/src/scene/mesh.js
+++ b/src/scene/mesh.js
@@ -3,12 +3,12 @@ pc.extend(pc, function () {
         // Key definition:
         // Bit
         // 31      : sign bit (leave)
-        // 28 - 30 : layer
-        // 26 - 27 : translucency type (opaque: 3, normal, additive, subtractive)
+        // 27 - 30 : layer
+        // 26      : translucency type (opaque/transparent)
         // 25      : Command bit (1: this key is for a command, 0: it's a mesh instance)
         // 0 - 24  : Material ID (if oqaque) or 0 (if transparent - will be depth)
-        return ((layer & 0x7) << 28) |
-               ((blendType & 0x3) << 26) |
+        return ((layer & 0x0f) << 27) |
+               ((blendType===pc.BLEND_NONE? 0 : 1) << 26) |
                ((isCommand ? 1 : 0) << 25) |
                ((materialId & 0x1ffffff) << 0);
     }

--- a/src/scene/mesh.js
+++ b/src/scene/mesh.js
@@ -8,7 +8,7 @@ pc.extend(pc, function () {
         // 25      : Command bit (1: this key is for a command, 0: it's a mesh instance)
         // 0 - 24  : Material ID (if oqaque) or 0 (if transparent - will be depth)
         return ((layer & 0x0f) << 27) |
-               ((blendType===pc.BLEND_NONE? 0 : 1) << 26) |
+               ((blendType===pc.BLEND_NONE? 1 : 0) << 26) |
                ((isCommand ? 1 : 0) << 25) |
                ((materialId & 0x1ffffff) << 0);
     }

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -95,7 +95,8 @@
         LAYER_HUD: 0,
         LAYER_GIZMO: 1,
         LAYER_FX: 2,
-        LAYER_WORLD: 3,
+        // 3 - 14 are custom user layers
+        LAYER_WORLD: 15,
 
         /**
          * @enum pc.LIGHTTYPE


### PR DESCRIPTION
We don't really need more than 1 bit for translucency, because no matter which blending formula is used, we sort all non-opaque draw calls by distance. Therefore I donated this bit to layers.