### PR TITLE
Better collectAttribs function

### DIFF
--- a/src/graphics/chunks.js
+++ b/src/graphics/chunks.js
@@ -25,9 +25,6 @@ pc.extend(pc, (function () {
             var semantic = attrib2Semantic[attribName];
             if (semantic!==undefined) {
                 attribs[attribName] = semantic;
-            } else {
-                attribs[attribName] = "ATTR" + attrs;
-                attrs++;
             }
 
             found = vsCode.indexOf("attribute", found + 1);

--- a/src/graphics/chunks.js
+++ b/src/graphics/chunks.js
@@ -4,6 +4,14 @@ pc.extend(pc, (function () {
     var shaderChunks = {};
     var shaderCache = {};
 
+    var attrib2Semantic = {};
+    attrib2Semantic["vertex_position"] = pc.SEMANTIC_POSITION;
+    attrib2Semantic["vertex_normal"] = pc.SEMANTIC_NORMAL;
+    attrib2Semantic["vertex_tangent"] = pc.SEMANTIC_TANGENT;
+    attrib2Semantic["vertex_texCoord0"] = pc.SEMANTIC_TEXCOORD0;
+    attrib2Semantic["vertex_texCoord1"] = pc.SEMANTIC_TEXCOORD1;
+    attrib2Semantic["vertex_color"] = pc.SEMANTIC_COLOR;
+
     shaderChunks.collectAttribs = function (vsCode) {
         var attribs = {};
         var attrs = 0;
@@ -14,8 +22,9 @@ pc.extend(pc, (function () {
             var startOfAttribName = vsCode.lastIndexOf(' ', endOfLine);
             var attribName = vsCode.substr(startOfAttribName + 1, endOfLine - (startOfAttribName + 1));
 
-            if (attribName == "aPosition") {
-                attribs.aPosition = pc.SEMANTIC_POSITION;
+            var semantic = attrib2Semantic[attribName];
+            if (semantic!==undefined) {
+                attribs[attribName] = semantic;
             } else {
                 attribs[attribName] = "ATTR" + attrs;
                 attrs++;

--- a/src/graphics/program-lib/chunks/fullscreenQuad.vert
+++ b/src/graphics/program-lib/chunks/fullscreenQuad.vert
@@ -1,10 +1,10 @@
-attribute vec2 aPosition;
+attribute vec2 vertex_position;
 
 varying vec2 vUv0;
 
 void main(void)
 {
-    gl_Position = vec4(aPosition, 0.5, 1.0);
-    vUv0 = aPosition.xy*0.5+0.5;
+    gl_Position = vec4(vertex_position, 0.5, 1.0);
+    vUv0 = vertex_position.xy*0.5+0.5;
 }
 

--- a/src/graphics/program-lib/skybox.js
+++ b/src/graphics/program-lib/skybox.js
@@ -1,6 +1,6 @@
 pc.programlib.skybox = {
     generateKey: function (device, options) {
-        var key = "skybox" + options.rgbm + " " + options.hdr + " " + options.fixSeams + "" + 
+        var key = "skybox" + options.rgbm + " " + options.hdr + " " + options.fixSeams + "" +
                   options.toneMapping + "" + options.gamma + "" + options.useIntensity + "" + options.mip;
         return key;
     },


### PR DESCRIPTION
Useful for creating and using custom shaders without the burden of manually listing attributes. The function was added by me a long time ago, but wasn't really useful, as it only reacted on "aPosition" attribute. Now it reacts on all common attribute names.

collectAttribs is (was) internally called by pc.shaderChunks.createShaderFromCode, so you could do things like

material.setShader( pc.shaderChunks.createShaderFromCode(device, vsCode, psCode, "name") );