### PR TITLE
Feature/scripts autocomplete

### DIFF
--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -22,6 +22,7 @@ pc.extend(pc, function () {
      * @property {pc.Mouse} mouse The mouse device.
      * @property {pc.TouchDevice} touch Used to get touch events input.
      * @property {pc.GamePads} gamepads Used to access GamePad input.
+     * @property {pc.ScriptRegistry} scripts The script registry of the application.
      *
      * @example
      * // Create application

--- a/src/framework/components/collision/system.js
+++ b/src/framework/components/collision/system.js
@@ -176,7 +176,8 @@ pc.extend(pc, function () {
     });
 
     /**
-    * Collision system implementations
+    * @private
+    * @description Collision system implementations
     */
     var CollisionSystemImpl = function (system) {
         this.system = system;
@@ -297,7 +298,8 @@ pc.extend(pc, function () {
     };
 
     /**
-    /* Box Collision System
+    * @private
+    * @description Box Collision System
     */
     var CollisionBoxSystemImpl = function (system) {};
 
@@ -316,7 +318,8 @@ pc.extend(pc, function () {
     });
 
     /**
-    /* Sphere Collision System
+    * @private
+    * @description Sphere Collision System
     */
 
     var CollisionSphereSystemImpl = function (system) {};
@@ -334,7 +337,8 @@ pc.extend(pc, function () {
     });
 
     /**
-    /* Capsule Collision System
+    * @private
+    * @description Capsule Collision System
     */
 
     var CollisionCapsuleSystemImpl = function (system) {};
@@ -366,7 +370,8 @@ pc.extend(pc, function () {
     });
 
     /**
-    /* Cylinder Collision System
+    * @private
+    * @description Cylinder Collision System
     */
 
     var CollisionCylinderSystemImpl = function (system) {};
@@ -402,7 +407,8 @@ pc.extend(pc, function () {
     });
 
     /**
-    /* Mesh Collision System
+    * @private
+    * @description Mesh Collision System
     */
 
     var CollisionMeshSystemImpl = function (system) { };

--- a/src/framework/components/script/component.js
+++ b/src/framework/components/script/component.js
@@ -7,7 +7,7 @@ pc.extend(pc, function () {
     * @param {pc.ScriptComponentSystem} system The ComponentSystem that created this Component
     * @param {pc.Entity} entity The Entity that this Component is attached to.
     * @extends pc.Component
-    * @property {ScriptInstance[]} scripts An array of all Script Instances attached to an entity. This Array shall not be modified by developer.
+    * @property {ScriptType[]} scripts An array of all script instances attached to an entity. This Array shall not be modified by developer.
     */
 
     var ScriptComponent = function ScriptComponent(system, entity) {
@@ -74,9 +74,9 @@ pc.extend(pc, function () {
     /**
     * @event
     * @name pc.ScriptComponent#create
-    * @description Fired when Script Instance is created and attached to component
-    * @param {String} name The Name of Script Instance created
-    * @param {ScriptInstance} scriptInstance Script Instance that has been created
+    * @description Fired when a script instance is created and attached to component
+    * @param {String} name The name of the Script Type
+    * @param {ScriptType} scriptInstance The instance of the {@link ScriptType} that has been created
     * @example
     * entity.script.on('create', function (name, scriptInstance) {
     *     // new script instance added to component
@@ -86,8 +86,8 @@ pc.extend(pc, function () {
     /**
     * @event
     * @name pc.ScriptComponent#create:[name]
-    * @description Fired when Script Instance is created and attached to component
-    * @param {ScriptInstance} scriptInstance Script Instance that has been created
+    * @description Fired when a script instance is created and attached to component
+    * @param {ScriptType} scriptInstance The instance of the {@link ScriptType} that has been created
     * @example
     * entity.script.on('create:playerController', function (scriptInstance) {
     *     // new script instance 'playerController' is added to component
@@ -97,9 +97,9 @@ pc.extend(pc, function () {
     /**
     * @event
     * @name pc.ScriptComponent#destroy
-    * @description Fired when Script Instance is destroyed and removed from component
-    * @param {String} name The Name of Script Instance destroyed
-    * @param {ScriptInstance} scriptInstance Script Instance that has been destroyed
+    * @description Fired when a script instance is destroyed and removed from component
+    * @param {String} name The name of the Script Type
+    * @param {ScriptType} scriptInstance The instance of the {@link ScriptType} that has been destroyed
     * @example
     * entity.script.on('destroy', function (name, scriptInstance) {
     *     // script instance has been destroyed and removed from component
@@ -109,8 +109,8 @@ pc.extend(pc, function () {
     /**
     * @event
     * @name pc.ScriptComponent#destroy:[name]
-    * @description Fired when Script Instance is destroyed and removed from component
-    * @param {ScriptInstance} scriptInstance Script Instance that has been destroyed
+    * @description Fired when a script instance is destroyed and removed from component
+    * @param {ScriptType} scriptInstance The instance of the {@link ScriptType} that has been destroyed
     * @example
     * entity.script.on('destroy:playerController', function (scriptInstance) {
     *     // script instance 'playerController' has been destroyed and removed from component
@@ -120,10 +120,10 @@ pc.extend(pc, function () {
     /**
     * @event
     * @name pc.ScriptComponent#error
-    * @description Fired when Script Instance had an exception
-    * @param {ScriptInstance} scriptInstance Script Instance exception happened in
+    * @description Fired when a script instance had an exception
+    * @param {ScriptType} scriptInstance The instance of the {@link ScriptType} that raised the exception
     * @param {Error} err Native JS Error object with details of an error
-    * @param {String} method Script Instance method exception originated from
+    * @param {String} method The method of the script instance that the exception originated from.
     * @example
     * entity.script.on('error', function (scriptInstance, err, method) {
     *     // script instance caught an exception
@@ -260,7 +260,7 @@ pc.extend(pc, function () {
          * @function
          * @name pc.ScriptComponent#has
          * @description Detect if script is attached to an entity using name of {@link ScriptType}.
-         * @param {String} name The name of Script Type
+         * @param {String} name The name of the Script Type
          * @returns {Boolean} If script is attached to an entity
          * @example
          * if (entity.script.has('playerController')) {
@@ -280,14 +280,14 @@ pc.extend(pc, function () {
         /**
          * @function
          * @name pc.ScriptComponent#create
-         * @description Create {@link ScriptInstance} using name of a {@link ScriptType} and attach to an entity script component.
-         * @param {String} name The name of Script Type
+         * @description Create a script instance using name of a {@link ScriptType} and attach to an entity script component.
+         * @param {String} name The name of the Script Type
          * @param {Object} [args] Object with arguments for a script
-         * @param {Boolean} [args.enabled] if Script Instance is enabled after creation
+         * @param {Boolean} [args.enabled] if script instance is enabled after creation
          * @param {Object} [args.attributes] Object with values for attributes, where key is name of an attribute
-         * @returns {?ScriptInstance} if successfuly attached to an entity,
-         * or Null if failed due to same script name been added already
-         * or Script Type is not found by name in {@link pc.ScriptRegistry}
+         * @returns {ScriptType} Returns an instance of a {@link ScriptType} if successfuly attached to an entity,
+         * or null if it failed because a script with a same name has already been added
+         * or if the {@link ScriptType} cannot be found by name in the {@link pc.ScriptRegistry}.
          * @example
          * entity.script.create('playerController', {
          *     attributes: {
@@ -375,8 +375,8 @@ pc.extend(pc, function () {
         /**
          * @function
          * @name pc.ScriptComponent#destroy
-         * @description Destroy {@link ScriptInstance} that is attached to an entity.
-         * @param {String} name The name of Script Type
+         * @description Destroy the script instance that is attached to an entity.
+         * @param {String} name The name of the Script Type
          * @returns {Boolean} If it was successfuly destroyed
          * @example
          * entity.script.destroy('playerController');
@@ -457,8 +457,8 @@ pc.extend(pc, function () {
         /**
          * @function
          * @name pc.ScriptComponent#move
-         * @description Move Script Instance to different position to alter update order of scripts within entity.
-         * @param {String} name The name of Script Type
+         * @description Move script instance to different position to alter update order of scripts within entity.
+         * @param {String} name The name of the Script Type
          * @param {Number} ind New position index
          * @returns {Boolean} If it was successfuly moved
          * @example

--- a/src/resources/script.js
+++ b/src/resources/script.js
@@ -3,9 +3,9 @@ pc.extend(pc, function () {
 
     /**
      * @name pc.ScriptHandler
-     * @class ResourceHandler for loading javascript files dynamically
-     * Two types of javascript file can be loaded, PlayCanvas ScriptType files which must contain a call to pc.script.create() to be called when the script executes,
-     * or regular javascript files, such as third-party libraries.
+     * @class ResourceHandler for loading JavaScript files dynamically
+     * Two types of JavaScript files can be loaded, PlayCanvas scripts which contain calls to <a href="/pc.html#createScript">pc.createScript</a>,
+     * or regular JavaScripts files, such as third-party libraries.
      * @param {pc.Application} app The running {pc.Application}
      */
     var ScriptHandler = function (app) {

--- a/src/script/script-registry.js
+++ b/src/script/script-registry.js
@@ -2,8 +2,8 @@ pc.extend(pc, function () {
     /**
     * @name pc.ScriptRegistry
     * @class Container for all Script Types that are available to this application
-    * @description Create an instance of an ScriptRegistry.
-    * Note: PlayCanvas scripts are provided with an ScriptRegistry instance as 'app.scripts'.
+    * @description Create an instance of a pc.ScriptRegistry.
+    * Note: PlayCanvas scripts can access the Script Registry with from inside the application with `this.app.scripts'.
     * @param {pc.Application} app Application to attach registry to.
     */
     var ScriptRegistry = function (app) {
@@ -18,12 +18,12 @@ pc.extend(pc, function () {
     /**
      * @function
      * @name pc.ScriptRegistry#add
-     * @description Add Script Type to registry.
-     * Note: when {@link pc.createScript} is called, it will add script to {@link pc.ScriptRegistry} automatically.
-     * If script already exists in registry, and new Script Type has `swap` method defined,
-     * it will perform code hot swapping automatically in async manner
-     * @param {ScriptType} scriptType Script Type that is created using {@link pc.createScript}
-     * @returns {Boolean} True if first time added or false if script already exists
+     * @description Add {@link ScriptType} to registry.
+     * Note: when <a href="/pc.html#createScript">pc.createScript</a> is called, it will add the {@link ScriptType} to the registry automatically.
+     * If a script already exists in registry, and the new script has a `swap` method defined,
+     * it will perform code hot swapping automatically in async manner.
+     * @param {ScriptType} scriptType Script Type that is created using <a href="/pc.html#createScript">pc.createScript</a>
+     * @returns {Boolean} True if added for the first time or false if script already exists
      * @example
      * var PlayerController = pc.createScript('playerController');
      * // playerController Script Type will be added to pc.ScriptRegistry automatically
@@ -115,8 +115,8 @@ pc.extend(pc, function () {
     /**
      * @function
      * @name pc.ScriptRegistry#remove
-     * @description Remove Script Type.
-     * @param {String} name Name of a Script Type to remove
+     * @description Remove {@link ScriptType}.
+     * @param {String} name Name of a {@link ScriptType} to remove
      * @returns {Boolean} True if removed or False if already not in registry
      * @example
      * app.scripts.remove('playerController');
@@ -145,9 +145,9 @@ pc.extend(pc, function () {
     /**
      * @function
      * @name pc.ScriptRegistry#get
-     * @description Get Script Type by name.
-     * @param {String} name Name of a Script Type
-     * @returns {?ScriptType} Script Type will be returned if it is in registry otherwise null will be returned
+     * @description Get {@link ScriptType} by name.
+     * @param {String} name Name of a {@link ScriptType}.
+     * @returns {ScriptType} The Script Type if it exists in the registry or null otherwise.
      * @example
      * var PlayerController = app.scripts.get('playerController');
      */
@@ -158,9 +158,9 @@ pc.extend(pc, function () {
     /**
      * @function
      * @name pc.ScriptRegistry#has
-     * @description Detect by name of Script Type if it's in registry
-     * @param {String} name Name of a Script Type
-     * @returns {Boolean} True if Script Type is in registry
+     * @description Check if a {@link ScriptType} with the specified name is in the registry.
+     * @param {String} name Name of a {@link ScriptType}
+     * @returns {Boolean} True if {@link ScriptType} is in registry
      * @example
      * if (app.scripts.has('playerController')) {
      *     // playerController is in pc.ScriptRegistry
@@ -173,8 +173,8 @@ pc.extend(pc, function () {
     /**
      * @function
      * @name pc.ScriptRegistry#list
-     * @description Get list of all Script Type's from registry.
-     * @returns {ScriptType[]} list of all Script Type's in registry
+     * @description Get list of all {@link ScriptType}s from registry.
+     * @returns {ScriptType[]} list of all {@link ScriptType}s in registry
      * @example
      * // logs array of all Script Type names available in registry
      * console.log(app.scripts.list().map(function(o) {

--- a/src/script/script.js
+++ b/src/script/script.js
@@ -119,9 +119,8 @@ pc.extend(pc, function () {
 
     /**
     * @name pc.ScriptAttributes
-    * @class Container of Script Attributes definition
-    * @description Implements an interface to add/remove attributes and store their definition for Script Type.
-    * Note: Instance of pc.ScriptAttributes is created automatically by each Script Type
+    * @class Container of Script Attribute definitions. Implements an interface to add/remove attributes and store their definition for a {@link ScriptType}.
+    * Note: An instance of pc.ScriptAttributes is created automatically by each {@link ScriptType}.
     * @param {ScriptType} scriptType Script Type that attributes relate to.
     */
     var ScriptAttributes = function(scriptType) {
@@ -252,19 +251,20 @@ pc.extend(pc, function () {
 
 
     /**
-    * @class createScript
+    * @static
+    * @function
     * @name pc.createScript
     * @description Method to create named {@link ScriptType}.
     * It returns new function (class) "Script Type", which is auto-registered to {@link pc.ScriptRegistry} using it's name.
-    * This is main interface to create Script Types, to define custom logic using javascript, that is used to create interaction for entities.
+    * This is the main interface to create Script Types, to define custom logic using JavaScript, that is used to create interaction for entities.
     * @param {String} name unique Name of a Script Type.
-    * If Script Type of same name already registered and new one has `swap` method defined in prototype,
+    * If a Script Type with the same name has already been registered and the new one has a `swap` method defined in its prototype,
     * then it will perform hot swapping of existing Script Instances on entities using this new Script Type.
-    * Note: there is a reserved list of names that cannot be used, such as list below as well as some starting from `_` (underscore):
+    * Note: There is a reserved list of names that cannot be used, such as list below as well as some starting from `_` (underscore):
     * system, entity, create, destroy, swap, move, scripts, onEnable, onDisable, onPostStateChange, has, on, off, fire, once, hasEvent
-    * @param {pc.Application} [app] Optional application handler, to choose which pc.ScriptRegistry to add a script to.
-    * By default it will use `pc.Application.getApplication()` to get current pc.Application.
-    * @returns {ScriptType} Function so called {@link ScriptType}, that developer is meant to extend by adding attributes and prototype methods.
+    * @param {pc.Application} [app] Optional application handler, to choose which {@link pc.ScriptRegistry} to add a script to.
+    * By default it will use `pc.Application.getApplication()` to get current {@link pc.Application}.
+    * @returns {Function} The constructor of a {@link ScriptType}, which the developer is meant to extend by adding attributes and prototype methods.
     * @example
     * var Turning = pc.createScript('turn');
     *
@@ -286,18 +286,19 @@ pc.extend(pc, function () {
 
         /**
         * @name ScriptType
-        * @class Function that is returned by {@link pc.createScript}. Also referred as Script Type.<br />
-        * This function is expected to be extended using JavaScript prototype. There is a <strong>list of expected methods</strong>
-        * that will be executed by the engine, such as: initialize, postInitialize, update, postUpdate and swap.<br />
-        * <strong>initialize</strong> and <strong>postInitialize</strong> - are called if defined when script is about to run for the first time. postInitialize will run after all initialize methods are executed in the same tick or enabling chain of actions.<br />
+        * @class Represents the type of a script. It is returned by <a href="/pc.html#createScript">pc.createScript</a>. Also referred to as Script Type.<br />
+        * The type is to be extended using its JavaScript prototype. There is a <strong>list of methods</strong>
+        * that will be executed by the engine on instances of this type, such as: <ul><li>initialize</li><li>postInitialize</li><li>update</li><li>postUpdate</li><li>swap</li></ul>
+        * <strong>initialize</strong> and <strong>postInitialize</strong> - are called if defined when script is about to run for the first time - postInitialize will run after all initialize methods are executed in the same tick or enabling chain of actions.<br />
         * <strong>update</strong> and <strong>postUpdate</strong> - methods are called if defined for enabled (running state) scripts on each tick.<br />
-        * <strong>swap</strong> - method will be called when new Script Type of already existing name in registry been defined.
-        * If new Script Type defines `swap` method in prototype, then it will be executed to perform code hot-reload in runtime.
-        * @description Script Type are the functions (classes) that are created using {@link pc.createScript}.
-        * And extended using attributes and prototype to define custom logic.
-        * When instanced by engine, the object is referred as {@link ScriptInstance}.
-        * Note: this class is created using {@link pc.createScript}.
-        * Note: instances of this class are created by the engine when script is added to {@link pc.ScriptComponent}
+        * <strong>swap</strong> - This method will be called when a {@link ScriptType} that already exists in the registry gets redefined.
+        * If the new {@link ScriptType} has a `swap` method in its prototype, then it will be executed to perform hot-reload at runtime.
+        * @property {pc.Application} app The {@link pc.Application} that the instance of this type belongs to.
+        * @property {pc.Entity} entity The {@link pc.Entity} that the instance of this type belongs to.
+        * @property {Boolean} enabled True if the instance of this type is in running state. False when script is not running,
+        * because the Entity or any of its parents are disabled or the Script Component is disabled or the Script Instance is disabled.
+        * When disabled no update methods will be called on each tick.
+        * initialize and postInitialize methods will run once when the script instance is in `enabled` state during app tick.
         */
         var script = function(args) {
             if (! args || ! args.app || ! args.entity)
@@ -318,19 +319,19 @@ pc.extend(pc, function () {
          * @private
          * @readonly
          * @static
-         * @name ScriptType#__name
+         * @name ScriptType.__name
          * @type String
          * @description Name of a Script Type.
          */
         script.__name = name;
 
         /**
-         * @readonly
+         * @field
          * @static
-         * @name ScriptType#attributes
-         * @type {pc.ScriptAttributes}
-         * @description The interface to define attributes for Script Types.
-         * Refer to {@link pc.ScriptAttributes}
+         * @readonly
+         * @type pc.ScriptAttributes
+         * @name ScriptType.attributes
+         * @description The interface to define attributes for Script Types. Refer to {@link pc.ScriptAttributes}
          * @example
          * var PlayerController = pc.createScript('playerController');
          *
@@ -366,7 +367,7 @@ pc.extend(pc, function () {
          * @readonly
          * @static
          * @function
-         * @name ScriptType#extend
+         * @name ScriptType.extend
          * @param {Object} methods Object with methods, where key - is name of method, and value - is function.
          * @description Shorthand function to extend Script Type prototype with list of methods.
          * @example
@@ -391,18 +392,9 @@ pc.extend(pc, function () {
         };
 
         /**
-        * @name ScriptInstance
-        * @class Instance of {@link ScriptType} which is defined by developer
-        * @property {pc.Application} app Pointer to {@link pc.Application} that Script Instance belongs to.
-        * @property {pc.Entity} entity Pointer to entity that Script Instance belongs to.
-        * @property {Boolean} enabled True if Script Instance is in running state.
-        * @description Script Instance is created by engine during script being created for {@link pc.ScriptComponent}
-        */
-
-        /**
         * @event
-        * @name ScriptInstance#enabled
-        * @description Fired when Script Instance becomes enabled
+        * @name ScriptType#enabled
+        * @description Fired when a script instance becomes enabled
         * @example
         * PlayerController.prototype.initialize = function() {
         *     this.on('enabled', function() {
@@ -413,8 +405,8 @@ pc.extend(pc, function () {
 
         /**
         * @event
-        * @name ScriptInstance#disabled
-        * @description Fired when Script Instance becomes disabled
+        * @name ScriptType#disabled
+        * @description Fired when a script instance becomes disabled
         * @example
         * PlayerController.prototype.initialize = function() {
         *     this.on('disabled', function() {
@@ -425,8 +417,8 @@ pc.extend(pc, function () {
 
         /**
         * @event
-        * @name ScriptInstance#state
-        * @description Fired when Script Instance changes state to enabled or disabled
+        * @name ScriptType#state
+        * @description Fired when a script instance changes state to enabled or disabled
         * @param {Boolean} enabled True if now enabled, False if disabled
         * @example
         * PlayerController.prototype.initialize = function() {
@@ -438,8 +430,8 @@ pc.extend(pc, function () {
 
         /**
         * @event
-        * @name ScriptInstance#destroy
-        * @description Fired when Script Instance is destroyed and removed from component
+        * @name ScriptType#destroy
+        * @description Fired when a script instance is destroyed and removed from component
         * @example
         * PlayerController.prototype.initialize = function() {
         *     this.on('destroy', function() {
@@ -451,11 +443,11 @@ pc.extend(pc, function () {
 
         /**
         * @event
-        * @name ScriptInstance#attr
-        * @description Fired when any script attribute been changed
-        * @param {String} name Name of attribute changed
-        * @param value New value
-        * @param valueOld Old value
+        * @name ScriptType#attr
+        * @description Fired when any script attribute has been changed
+        * @param {String} name Name of attribute
+        * @param {Object} value New value
+        * @param {Object} valueOld Old value
         * @example
         * PlayerController.prototype.initialize = function() {
         *     this.on('attr', function(name, value, valueOld) {
@@ -466,10 +458,10 @@ pc.extend(pc, function () {
 
         /**
         * @event
-        * @name ScriptInstance#attr:[name]
-        * @description Fired when specific script attribute been changed
-        * @param value New value
-        * @param valueOld Old value
+        * @name ScriptType#attr:[name]
+        * @description Fired when a specific script attribute has been changed
+        * @param {Object} value New value
+        * @param {Object} valueOld Old value
         * @example
         * PlayerController.prototype.initialize = function() {
         *     this.on('attr:speed', function(value, valueOld) {
@@ -480,11 +472,10 @@ pc.extend(pc, function () {
 
         /**
         * @event
-        * @name ScriptInstance#error
-        * @description Fired when Script Instance had an exception.
-        * Script Instance will be automatically disabled
-        * @param {Error} err Native JS Error object with details of error
-        * @param {String} method Script Instance method exception originated from
+        * @name ScriptType#error
+        * @description Fired when a script instance had an exception. The script instance will be automatically disabled.
+        * @param {Error} err Native JavaScript Error object with details of error
+        * @param {String} method The method of the script instance that the exception originated from.
         * @example
         * PlayerController.prototype.initialize = function() {
         *     this.on('error', function(err, method) {
@@ -494,13 +485,6 @@ pc.extend(pc, function () {
         * };
         */
 
-        /**
-         * @name ScriptInstance#enabled
-         * @type Boolean
-         * @description False when script will not be running, due to disabled state of any of: Entity (including any parents), ScriptComponent, ScriptInstance.
-         * When disabled will not run any update methods on each tick.
-         * initialize and postInitialize methods will run once when Script Instance is in `enabled` state during app tick.
-         */
         Object.defineProperty(script.prototype, 'enabled', {
             get: function() {
                 return this._enabled && this.entity.script.enabled && this.entity.enabled;


### PR DESCRIPTION
This removes the ScriptInstance class from the docs - Uses ScriptType instead but in each comment it makes a distinction between the type of the instance of the type so that it's clear. 

Fixes auto-complete for new script system. 