### PR TITLE
Check precision of floating-point RT on device init

### DIFF
--- a/src/graphics/device.js
+++ b/src/graphics/device.js
@@ -627,6 +627,65 @@ pc.extend(pc, function () {
             gl.vertexAttribPointer(0, 4, gl.UNSIGNED_BYTE, false, 4, 0);
             this.supportsUnsignedByte = (gl.getError() === 0);
             gl.deleteBuffer(bufferId);
+
+
+            if (this.extTextureFloatRenderable) {
+                var device = this;
+                var chunks = pc.shaderChunks;
+                var test1 = chunks.createShaderFromCode(device, chunks.fullscreenQuadVS, chunks.precisionTestPS, "ptest1");
+                var test2 = chunks.createShaderFromCode(device, chunks.fullscreenQuadVS, chunks.precisionTest2PS, "ptest2");
+                var size = 1;
+
+                var tex = new pc.Texture(device, {
+                    format: pc.PIXELFORMAT_RGBA32F,
+                    width: size,
+                    height: size,
+                    autoMipmap: false
+                });
+                tex.minFilter = pc.FILTER_NEAREST;
+                tex.magFilter = pc.FILTER_NEAREST;
+                tex.addressU = pc.ADDRESS_CLAMP_TO_EDGE;
+                tex.addressV = pc.ADDRESS_CLAMP_TO_EDGE;
+                var targ = new pc.RenderTarget(device, tex, {
+                    depth: false
+                });
+                pc.drawQuadWithShader(device, targ, test1);
+
+                var tex2 = new pc.Texture(device, {
+                    format: pc.PIXELFORMAT_R8_G8_B8_A8,
+                    width: size,
+                    height: size,
+                    autoMipmap: false
+                });
+                tex2.minFilter = pc.FILTER_NEAREST;
+                tex2.magFilter = pc.FILTER_NEAREST;
+                tex2.addressU = pc.ADDRESS_CLAMP_TO_EDGE;
+                tex2.addressV = pc.ADDRESS_CLAMP_TO_EDGE;
+                var targ2 = new pc.RenderTarget(device, tex2, {
+                    depth: false
+                });
+                var constantTexSource = device.scope.resolve("source");
+                constantTexSource.setValue(tex);
+                pc.drawQuadWithShader(device, targ2, test2);
+
+                var pixels = new Uint8Array(size * size * 4);
+                gl.bindFramebuffer(gl.FRAMEBUFFER, targ2._glFrameBuffer);
+                gl.readPixels(0, 0, size, size, gl.RGBA, gl.UNSIGNED_BYTE, pixels);
+
+                var x = pixels[0] / 255.0;
+                var y = pixels[1] / 255.0;
+                var z = pixels[2] / 255.0;
+                var w = pixels[3] / 255.0;
+                var f = x/(256.0 * 256.0 * 256.0) + y/(256.0 * 256.0) + z/256.0 + w;
+
+                this.extTextureFloatHighPrecision = f===0.0;
+
+                tex.destroy();
+                targ.destroy();
+                tex2.destroy();
+                targ2.destroy();
+            }
+
         }).call(this);
     };
 

--- a/src/graphics/program-lib/chunks/precisionTest.frag
+++ b/src/graphics/program-lib/chunks/precisionTest.frag
@@ -1,0 +1,4 @@
+void main(void) {
+    gl_FragColor = vec4(2147483648.0);
+}
+

--- a/src/graphics/program-lib/chunks/precisionTest2.frag
+++ b/src/graphics/program-lib/chunks/precisionTest2.frag
@@ -1,0 +1,17 @@
+uniform sampler2D source;
+
+vec4 packFloat(float depth) {
+    const vec4 bit_shift = vec4(256.0 * 256.0 * 256.0, 256.0 * 256.0, 256.0, 1.0);
+    const vec4 bit_mask  = vec4(0.0, 1.0 / 256.0, 1.0 / 256.0, 1.0 / 256.0);
+
+    vec4 res = mod(depth * bit_shift * vec4(255), vec4(256) ) / vec4(255);
+    res -= res.xxyz * bit_mask;
+    return res;
+}
+
+void main(void) {
+    float c = texture2D(source, vec2(0.0)).r;
+    float diff = abs(c - 2147483648.0) / 2147483648.0;
+    gl_FragColor = packFloat(diff);
+}
+

--- a/src/graphics/program-lib/depth-rgba.js
+++ b/src/graphics/program-lib/depth-rgba.js
@@ -83,7 +83,11 @@ pc.programlib.depthrgba = {
         code = pc.programlib.precisionCode(device);
 
         if (options.shadowType===pc.SHADOW_VSM32) {
-            code += '#define VSM_EXPONENT 15.0\n\n';
+            if (device.extTextureFloatHighPrecision) {
+                code += '#define VSM_EXPONENT 15.0\n\n';
+            } else {
+                code += '#define VSM_EXPONENT 5.54\n\n';
+            }
         } else if (options.shadowType===pc.SHADOW_VSM16) {
             code += '#define VSM_EXPONENT 5.54\n\n';
         }

--- a/src/graphics/program-lib/standard.js
+++ b/src/graphics/program-lib/standard.js
@@ -742,7 +742,11 @@ pc.programlib.standard = {
                         evsmExp = "5.54";
                     } else if (light._shadowType===pc.SHADOW_VSM32) {
                         shadowReadMode = "VSM32";
-                        evsmExp = "15.0";
+                        if (device.extTextureFloatHighPrecision) {
+                            evsmExp = "15.0";
+                        } else {
+                            evsmExp = "5.54";
+                        }
                     } else if (options.shadowSampleType===pc.SHADOWSAMPLE_HARD) {
                         shadowReadMode = "Hard";
                     } else if (options.shadowSampleType===pc.SHADOWSAMPLE_PCF3X3) {

--- a/src/scene/light.js
+++ b/src/scene/light.js
@@ -295,7 +295,7 @@ pc.extend(pc, function () {
         setShadowType: function (mode) {
             var device = pc.Application.getApplication().graphicsDevice;
 
-            if (mode===pc.SHADOW_VSM32 && !device.extTextureFloatRenderable) {
+            if (mode===pc.SHADOW_VSM32 && !device.extTextureFloatHighPrecision) {
                 mode = pc.SHADOW_VSM16;
             }
             if (mode===pc.SHADOW_VSM16 && !device.extTextureHalfFloatRenderable) {

--- a/src/scene/light.js
+++ b/src/scene/light.js
@@ -295,7 +295,7 @@ pc.extend(pc, function () {
         setShadowType: function (mode) {
             var device = pc.Application.getApplication().graphicsDevice;
 
-            if (mode===pc.SHADOW_VSM32 && !device.extTextureFloatHighPrecision) {
+            if (mode===pc.SHADOW_VSM32 && !device.extTextureFloatRenderable) {
                 mode = pc.SHADOW_VSM16;
             }
             if (mode===pc.SHADOW_VSM16 && !device.extTextureHalfFloatRenderable) {


### PR DESCRIPTION
And don't use high exponent value for VSM32 if precision is not enough.