### PR TITLE
Entity tags

### DIFF
--- a/src/core/tags.js
+++ b/src/core/tags.js
@@ -312,9 +312,12 @@ pc.extend(pc, (function() {
             if (! this._list.length)
                 return false;
 
-            var tags = this._processArguments(arguments);
+            return this._has(this._processArguments(arguments));
+        },
 
-            if (! tags.length)
+
+        _has: function(tags) {
+            if (! this._list.length || ! tags.length)
                 return false;
 
             for(var i = 0; i < tags.length; i++) {

--- a/src/framework/entity.js
+++ b/src/framework/entity.js
@@ -217,7 +217,7 @@ pc.extend(pc, function () {
         if(child instanceof pc.Entity) {
             var _debug = true;
             if (_debug) {
-                var root = this.getRoot();
+                var root = this.root;
                 var dupe = root.findOne("getGuid", child._guid);
                 if (dupe) {
                     throw new Error("GUID already exists in graph");
@@ -255,7 +255,6 @@ pc.extend(pc, function () {
     * firstChild.destroy(); // delete child, all components and remove from hierarchy
     */
     Entity.prototype.destroy = function () {
-        var parent = this.getParent();
         var childGuids;
         var name;
 
@@ -270,9 +269,8 @@ pc.extend(pc, function () {
         }
 
         // Detach from parent
-        if (parent) {
-            parent.removeChild(this);
-        }
+        if (this._parent)
+            this._parent.removeChild(this);
 
         var children = this.getChildren();
         var length = children.length;
@@ -293,7 +291,7 @@ pc.extend(pc, function () {
     * @returns {pc.Entity} A new Entity which is a deep copy of the original.
     * @example
     *   var e = this.entity.clone(); // Clone Entity
-    *   this.entity.getParent().addChild(e); // Add it as a sibling to the original
+    *   this.entity.parent.addChild(e); // Add it as a sibling to the original
     */
     Entity.prototype.clone = function () {
         var type;

--- a/src/resources/parser/scene.js
+++ b/src/resources/parser/scene.js
@@ -55,6 +55,12 @@ pc.extend(pc, function () {
             entity._enabledInHierarchy = entity._enabled;
             entity.template = data.template;
 
+            if (data.tags) {
+                for(var i = 0; i < data.tags.length; i++) {
+                    entity.tags.add(data.tags[i]);
+                }
+            }
+
             if (data.labels) {
                 data.labels.forEach(function (label) {
                     entity.addLabel(label);

--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -2,6 +2,7 @@ pc.extend(pc, function () {
     /**
      * @name pc.GraphNode
      * @class A hierarchical scene node.
+     * @param {pc.Tags} tags Interface for taggin. Allows to manage tags for nodes and find nodes using findByTag method.
      */
     var GraphNode = function GraphNode() {
         this.name = "Untitled"; // Non-unique human readable name

--- a/src/scene/lightmapper.js
+++ b/src/scene/lightmapper.js
@@ -119,10 +119,10 @@ pc.extend(pc, function () {
             area.z *= areaMult;
 
             scale.copy(node.getLocalScale());
-            parent = node.getParent();
+            parent = node._parent;
             while(parent) {
                 scale.mul(parent.getLocalScale());
-                parent = parent.getParent();
+                parent = parent._parent;
             }
 
             var totalArea = area.x * scale.y * scale.z +
@@ -202,7 +202,7 @@ pc.extend(pc, function () {
                     timestamp: pc.now(),
                     target: this
                 });
-                
+
                 return;
             }
 


### PR DESCRIPTION
GraphNode `find` and `findOne` methods been updated to work with one argument: method, works same as Array.filter - return true from method and tested node will be included in results.

`GraphNode.tags` - interface for tagging. Uses pc.Tags, same class that is used for assets, with identical API.
`GraphNode.findByTag` - interface to find nodes using tags queries. Same as `AssetRegistry.findByTag`.

`GraphNode.isDescendantOf` - tests if node is descendant of another node.
`GraphNode.isAncestorOf` - tests if node is ancestor of another node.
`GraphNode.name` - documented.
`GraphNode.parent` - new read-only property, alternative to `getParent()`.
`GraphNode.root` - new read-only property, alternative to `getRoot()`.
`GraphNode.children` - new read-only property, alternative to `getChildren()`.

Small optimisations around to reference internal properties instead of calling methods/properties.