### PR TITLE
Light cookies

### DIFF
--- a/src/framework/components/light/component.js
+++ b/src/framework/components/light/component.js
@@ -102,6 +102,7 @@ pc.extend(pc, function () {
         this.on("set_vsmBlurSize", this.onSetVsmBlurSize, this);
         this.on("set_vsmBlurMode", this.onSetVsmBlurMode, this);
         this.on("set_vsmBias", this.onSetVsmBias, this);
+        this.on("set_cookie", this.onSetCookie, this);
         this.on("set_shadowUpdateMode", this.onSetShadowUpdateMode, this);
         this.on("set_mask", this.onSetMask, this);
         this.on("set_affectDynamic", this.onSetAffectDynamic, this);
@@ -150,6 +151,7 @@ pc.extend(pc, function () {
             this.onSetVsmBlurSize("vsmBlurSize", this.vsmBlurSize, this.vsmBlurSize);
             this.onSetVsmBlurMode("vsmBlurMode", this.vsmBlurMode, this.vsmBlurMode);
             this.onSetVsmBias("vsmBias", this.vsmBias, this.vsmBias);
+            this.onSetCookie("cookie", this.cookie, this.cookie);
             this.onSetShadowUpdateMode("shadowUpdateMode", this.shadowUpdateMode, this.shadowUpdateMode);
             this.onSetMask("mask", this.light.mask, this.light.mask);
             this.onSetAffectDynamic("affectDynamic", this.affectDynamic, this.affectDynamic);
@@ -238,6 +240,10 @@ pc.extend(pc, function () {
 
         onSetVsmBias: function (name, oldValue, newValue) {
             this.light.setVsmBias(newValue);
+        },
+
+        onSetCookie: function (name, oldValue, newValue) {
+            this.light.setCookie(newValue);
         },
 
         onSetShadowUpdateMode: function (name, oldValue, newValue) {

--- a/src/framework/components/light/component.js
+++ b/src/framework/components/light/component.js
@@ -103,6 +103,9 @@ pc.extend(pc, function () {
         this.on("set_vsmBlurMode", this.onSetVsmBlurMode, this);
         this.on("set_vsmBias", this.onSetVsmBias, this);
         this.on("set_cookie", this.onSetCookie, this);
+        this.on("set_cookieIntensity", this.onSetCookieIntensity, this);
+        this.on("set_cookieFalloff", this.onSetCookieFalloff, this);
+        this.on("set_cookieChannel", this.onSetCookieChannel, this);
         this.on("set_shadowUpdateMode", this.onSetShadowUpdateMode, this);
         this.on("set_mask", this.onSetMask, this);
         this.on("set_affectDynamic", this.onSetAffectDynamic, this);
@@ -152,6 +155,9 @@ pc.extend(pc, function () {
             this.onSetVsmBlurMode("vsmBlurMode", this.vsmBlurMode, this.vsmBlurMode);
             this.onSetVsmBias("vsmBias", this.vsmBias, this.vsmBias);
             this.onSetCookie("cookie", this.cookie, this.cookie);
+            this.onSetCookieIntensity("cookieIntensity", this.cookieIntensity, this.cookieIntensity);
+            this.onSetCookieFalloff("cookieFalloff", this.cookieFalloff, this.cookieFalloff);
+            this.onSetCookieChannel("cookieChannel", this.cookieChannel, this.cookieChannel);
             this.onSetShadowUpdateMode("shadowUpdateMode", this.shadowUpdateMode, this.shadowUpdateMode);
             this.onSetMask("mask", this.light.mask, this.light.mask);
             this.onSetAffectDynamic("affectDynamic", this.affectDynamic, this.affectDynamic);
@@ -244,6 +250,18 @@ pc.extend(pc, function () {
 
         onSetCookie: function (name, oldValue, newValue) {
             this.light.setCookie(newValue);
+        },
+
+        onSetCookieIntensity: function (name, oldValue, newValue) {
+            this.light.setCookieIntensity(newValue);
+        },
+
+        onSetCookieFalloff: function (name, oldValue, newValue) {
+            this.light.setCookieFalloff(newValue);
+        },
+
+        onSetCookieChannel: function (name, oldValue, newValue) {
+            this.light.setCookieChannel(newValue);
         },
 
         onSetShadowUpdateMode: function (name, oldValue, newValue) {

--- a/src/framework/components/light/component.js
+++ b/src/framework/components/light/component.js
@@ -82,6 +82,10 @@ pc.extend(pc, function () {
      * <li>{@link pc.BLUR_GAUSSIAN}: Gaussian filter. May look smoother than box, but requires more samples.</li>
      * </ul>
      * @property {Number} vsmBlurSize Number of samples used for blurring a variance shadow map. Only uneven numbers work, even are incremented. Minimum value is 1, maximum is 25.
+     * @property {pc.Texture} cookie Projection texture. Must be 2D for spot and cubemap for point (ignored if incorrect type is used).
+     * @property {Number} cookieIntensity Projection texture intensity (default is 1).
+     * @property {Boolean} cookieFalloff Toggle normal spotlight falloff when projection texture is used. When set to false, spotlight will work like a pure texture projector (only fading with distance). Default is false.
+     * @property {String} cookieChannel  Color channels of the projection texture to use. Can be "r", "g", "b", "a", "rgb" or any swizzled combination.
      * @extends pc.Component
      */
 

--- a/src/framework/components/light/data.js
+++ b/src/framework/components/light/data.js
@@ -18,6 +18,7 @@ pc.extend(pc, function () {
         this.vsmBlurSize = 11;
         this.vsmBlurMode = pc.BLUR_GAUSSIAN;
         this.vsmBias = 0.01 * 0.25;
+        this.cookie = null;
         this.shadowUpdateMode = pc.SHADOWUPDATE_REALTIME;
         this.mask = 1;
         this.affectDynamic = true;

--- a/src/framework/components/light/data.js
+++ b/src/framework/components/light/data.js
@@ -19,6 +19,9 @@ pc.extend(pc, function () {
         this.vsmBlurMode = pc.BLUR_GAUSSIAN;
         this.vsmBias = 0.01 * 0.25;
         this.cookie = null;
+        this.cookieIntensity = 1;
+        this.cookieFalloff = true;
+        this.cookieChannel = "rgb";
         this.shadowUpdateMode = pc.SHADOWUPDATE_REALTIME;
         this.mask = 1;
         this.affectDynamic = true;

--- a/src/framework/components/light/system.js
+++ b/src/framework/components/light/system.js
@@ -36,6 +36,7 @@ pc.extend(pc, function () {
             'vsmBlurSize',
             'vsmBlurMode',
             'vsmBias',
+            'cookie',
             'shadowUpdateMode',
             'mask',
             'affectDynamic',
@@ -54,7 +55,7 @@ pc.extend(pc, function () {
 
     pc.extend(LightComponentSystem.prototype, {
         initializeComponentData: function (component, _data, properties) {
-            properties = ['type', 'light', 'model', 'enabled', 'color', 'intensity', 'range', 'falloffMode', 'innerConeAngle', 'outerConeAngle', 'castShadows', 'shadowDistance', 'shadowResolution', 'shadowUpdateMode', 'shadowBias', 'normalOffsetBias', 'mask', 'affectDynamic', 'affectLightmapped', 'bake', 'shadowType', 'vsmBlurSize', 'vsmBlurMode', 'vsmBias'];
+            properties = ['type', 'light', 'model', 'enabled', 'color', 'intensity', 'range', 'falloffMode', 'innerConeAngle', 'outerConeAngle', 'castShadows', 'shadowDistance', 'shadowResolution', 'shadowUpdateMode', 'shadowBias', 'normalOffsetBias', 'mask', 'affectDynamic', 'affectLightmapped', 'bake', 'shadowType', 'vsmBlurSize', 'vsmBlurMode', 'vsmBias', 'cookie'];
 
             // duplicate because we're modifying the data
             var data = {};
@@ -114,7 +115,8 @@ pc.extend(pc, function () {
                 shadowType: light.shadowType,
                 vsmBlurSize: light.vsmBlurSize,
                 vsmBlurMode: light.vsmBlurMode,
-                vsmBias: light.vsmBias
+                vsmBias: light.vsmBias,
+                cookie: light.cookie
             };
 
             this.addComponent(clone, data);

--- a/src/framework/components/light/system.js
+++ b/src/framework/components/light/system.js
@@ -37,6 +37,9 @@ pc.extend(pc, function () {
             'vsmBlurMode',
             'vsmBias',
             'cookie',
+            'cookieIntensity',
+            'cookieFalloff',
+            'cookieChannel',
             'shadowUpdateMode',
             'mask',
             'affectDynamic',
@@ -55,7 +58,7 @@ pc.extend(pc, function () {
 
     pc.extend(LightComponentSystem.prototype, {
         initializeComponentData: function (component, _data, properties) {
-            properties = ['type', 'light', 'model', 'enabled', 'color', 'intensity', 'range', 'falloffMode', 'innerConeAngle', 'outerConeAngle', 'castShadows', 'shadowDistance', 'shadowResolution', 'shadowUpdateMode', 'shadowBias', 'normalOffsetBias', 'mask', 'affectDynamic', 'affectLightmapped', 'bake', 'shadowType', 'vsmBlurSize', 'vsmBlurMode', 'vsmBias', 'cookie'];
+            properties = ['type', 'light', 'model', 'enabled', 'color', 'intensity', 'range', 'falloffMode', 'innerConeAngle', 'outerConeAngle', 'castShadows', 'shadowDistance', 'shadowResolution', 'shadowUpdateMode', 'shadowBias', 'normalOffsetBias', 'mask', 'affectDynamic', 'affectLightmapped', 'bake', 'shadowType', 'vsmBlurSize', 'vsmBlurMode', 'vsmBias', 'cookie', 'cookieIntensity', 'cookieFalloff', 'cookieChannel'];
 
             // duplicate because we're modifying the data
             var data = {};
@@ -116,7 +119,10 @@ pc.extend(pc, function () {
                 vsmBlurSize: light.vsmBlurSize,
                 vsmBlurMode: light.vsmBlurMode,
                 vsmBias: light.vsmBias,
-                cookie: light.cookie
+                cookie: light.cookie,
+                cookieIntensity: light.cookieIntensity,
+                cookieFalloff: light.cookieFalloff,
+                cookieChannel: light.cookieChannel
             };
 
             this.addComponent(clone, data);

--- a/src/graphics/program-lib/chunks/cookie.frag
+++ b/src/graphics/program-lib/chunks/cookie.frag
@@ -1,0 +1,8 @@
+vec3 getCookie2D(sampler2D tex) {
+    return vec3(1.0);
+}
+
+vec3 getCookieCube(samplerCube tex) {
+    return textureCube(tex, dLightDirW).rgb;
+}
+

--- a/src/graphics/program-lib/chunks/cookie.frag
+++ b/src/graphics/program-lib/chunks/cookie.frag
@@ -1,10 +1,17 @@
-vec3 getCookie2D(sampler2D tex, mat4 transform) {
+vec3 getCookie2D(sampler2D tex, mat4 transform, float intensity) {
     vec4 projPos = transform * vec4(vPositionW, 1.0);
     projPos.xy /= projPos.w;
-    return texture2D(tex, projPos.xy).rgb;
+    return mix(vec3(1.0), texture2D(tex, projPos.xy).rgb, intensity);
 }
 
-vec3 getCookieCube(samplerCube tex, mat4 transform) {
-    return textureCube(tex, dLightDirNormW * mat3(transform)).rgb;
+vec3 getCookie2DClip(sampler2D tex, mat4 transform, float intensity) {
+    vec4 projPos = transform * vec4(vPositionW, 1.0);
+    projPos.xy /= projPos.w;
+    if (projPos.x < 0.0 || projPos.x > 1.0 || projPos.y < 0.0 || projPos.y > 1.0 || projPos.z < 0.0) return vec3(0.0);
+    return mix(vec3(1.0), texture2D(tex, projPos.xy).rgb, intensity);
+}
+
+vec3 getCookieCube(samplerCube tex, mat4 transform, float intensity) {
+    return mix(vec3(1.0), textureCube(tex, dLightDirNormW * mat3(transform)).rgb, intensity);
 }
 

--- a/src/graphics/program-lib/chunks/cookie.frag
+++ b/src/graphics/program-lib/chunks/cookie.frag
@@ -1,5 +1,7 @@
 vec3 getCookie2D(sampler2D tex, mat4 transform) {
-    return vec3(1.0);
+    vec4 projPos = transform * vec4(vPositionW, 1.0);
+    projPos.xy /= projPos.w;
+    return texture2D(tex, projPos.xy).rgb;
 }
 
 vec3 getCookieCube(samplerCube tex, mat4 transform) {

--- a/src/graphics/program-lib/chunks/cookie.frag
+++ b/src/graphics/program-lib/chunks/cookie.frag
@@ -1,8 +1,8 @@
-vec3 getCookie2D(sampler2D tex) {
+vec3 getCookie2D(sampler2D tex, mat4 transform) {
     return vec3(1.0);
 }
 
-vec3 getCookieCube(samplerCube tex) {
-    return textureCube(tex, dLightDirW).rgb;
+vec3 getCookieCube(samplerCube tex, mat4 transform) {
+    return textureCube(tex, dLightDirNormW * mat3(transform)).rgb;
 }
 

--- a/src/graphics/program-lib/standard.js
+++ b/src/graphics/program-lib/standard.js
@@ -824,11 +824,11 @@ pc.programlib.standard = {
                     }
                 }
 
-                code += "   dDiffuseLight += dAtten * light"+i+"_color" + (light._cookie? " * dAtten3" : "") + ";\n";
+                code += "   dDiffuseLight += dAtten * light"+i+"_color" + (usesCookieNow? " * dAtten3" : "") + ";\n";
 
                 if (options.useSpecular) {
                     code += "   dAtten *= getLightSpecular();\n";
-                    code += "   dSpecularLight += dAtten * light"+i+"_color" + (light._cookie? " * dAtten3" : "") + ";\n";
+                    code += "   dSpecularLight += dAtten * light"+i+"_color" + (usesCookieNow? " * dAtten3" : "") + ";\n";
                 }
                 code += "\n";
             }

--- a/src/graphics/program-lib/standard.js
+++ b/src/graphics/program-lib/standard.js
@@ -729,6 +729,7 @@ pc.programlib.standard = {
 
                 light = options.lights[i];
                 lightType = light.getType();
+                usesCookieNow = false;
 
                 if (lightType===pc.LIGHTTYPE_DIRECTIONAL) {
                     // directional
@@ -736,7 +737,6 @@ pc.programlib.standard = {
                     code += "   dAtten = 1.0;\n";
                 } else {
 
-                    usesCookieNow = false;
                     if (light._cookie) {
                         if (lightType===pc.LIGHTTYPE_SPOT && !light._cookie._cubemap) {
                             usesCookie = true;

--- a/src/graphics/program-lib/standard.js
+++ b/src/graphics/program-lib/standard.js
@@ -421,12 +421,12 @@ pc.programlib.standard = {
                 if (light._cookie._cubemap) {
                     if (lightType===pc.LIGHTTYPE_POINT) {
                         code += "uniform samplerCube light" + i + "_cookie;\n";
-                        code += "uniform mat4 light" + i + "_matrix;\n";
+                        if (!light.getCastShadows() || options.noShadow) code += "uniform mat4 light" + i + "_shadowMatrix;\n";
                     }
                 } else {
                     if (lightType===pc.LIGHTTYPE_SPOT) {
                         code += "uniform sampler2D light" + i + "_cookie;\n";
-                        code += "uniform mat4 light" + i + "_matrix;\n";
+                        if (!light.getCastShadows() || options.noShadow) code += "uniform mat4 light" + i + "_shadowMatrix;\n";
                     }
                 }
             }
@@ -794,10 +794,10 @@ pc.programlib.standard = {
 
                 if (light._cookie) {
                     if (lightType===pc.LIGHTTYPE_SPOT && !light._cookie._cubemap) {
-                        code += "   dAtten3 = getCookie2D(light"+i+"_cookie, light"+i+"_matrix);\n";
+                        code += "   dAtten3 = getCookie2D(light"+i+"_cookie, light"+i+"_shadowMatrix);\n";
                         usesCookie = true;
                     } else if (lightType===pc.LIGHTTYPE_POINT && light._cookie._cubemap) {
-                        code += "   dAtten3 = getCookieCube(light"+i+"_cookie, light"+i+"_matrix);\n";
+                        code += "   dAtten3 = getCookieCube(light"+i+"_cookie, light"+i+"_shadowMatrix);\n";
                         usesCookie = true;
                     }
                 }

--- a/src/graphics/program-lib/standard.js
+++ b/src/graphics/program-lib/standard.js
@@ -419,9 +419,15 @@ pc.programlib.standard = {
             }
             if (light._cookie) {
                 if (light._cookie._cubemap) {
-                    if (lightType===pc.LIGHTTYPE_POINT) code += "uniform samplerCube light" + i + "_cookie;\n";
+                    if (lightType===pc.LIGHTTYPE_POINT) {
+                        code += "uniform samplerCube light" + i + "_cookie;\n";
+                        code += "uniform mat4 light" + i + "_matrix;\n";
+                    }
                 } else {
-                    if (lightType===pc.LIGHTTYPE_SPOT) code += "uniform sampler2D light" + i + "_cookie;\n";
+                    if (lightType===pc.LIGHTTYPE_SPOT) {
+                        code += "uniform sampler2D light" + i + "_cookie;\n";
+                        code += "uniform mat4 light" + i + "_matrix;\n";
+                    }
                 }
             }
         }
@@ -788,10 +794,10 @@ pc.programlib.standard = {
 
                 if (light._cookie) {
                     if (lightType===pc.LIGHTTYPE_SPOT && !light._cookie._cubemap) {
-                        code += "   dAtten3 = getCookie2D(light"+i+"_cookie);\n";
+                        code += "   dAtten3 = getCookie2D(light"+i+"_cookie, light"+i+"_matrix);\n";
                         usesCookie = true;
                     } else if (lightType===pc.LIGHTTYPE_POINT && light._cookie._cubemap) {
-                        code += "   dAtten3 = getCookieCube(light"+i+"_cookie);\n";
+                        code += "   dAtten3 = getCookieCube(light"+i+"_cookie, light"+i+"_matrix);\n";
                         usesCookie = true;
                     }
                 }

--- a/src/math/mat3.js
+++ b/src/math/mat3.js
@@ -3,7 +3,7 @@ pc.extend(pc, (function () {
 
     /**
     * @name pc.Mat3
-    * @class A 4x4 matrix.
+    * @class A 3x3 matrix.
     * @description Creates a new Mat3 object
     */
     var Mat3 = function () {
@@ -35,8 +35,8 @@ pc.extend(pc, (function () {
         /**
          * @function
          * @name pc.Mat3#copy
-         * @description Copies the contents of a source 4x4 matrix to a destination 4x4 matrix.
-         * @param {pc.Mat3} src A 4x4 matrix to be copied.
+         * @description Copies the contents of a source 3x3 matrix to a destination 3x3 matrix.
+         * @param {pc.Mat3} src A 3x3 matrix to be copied.
          * @returns {pc.Mat3} Self for chaining
          * @example
          * var src = new pc.Mat3().translate(10, 20, 30);

--- a/src/scene/forward-renderer.js
+++ b/src/scene/forward-renderer.js
@@ -592,6 +592,7 @@ pc.extend(pc, function () {
         this.lightOutAngleId = [];
         this.lightPosVsId = [];
         this.lightCookieId = [];
+        this.lightCookieMatrixId = [];
 
         this.depthMapId = scope.resolve('uDepthMap');
         this.screenSizeId = scope.resolve('uScreenSize');
@@ -770,6 +771,7 @@ pc.extend(pc, function () {
             this.lightOutAngleId[i] = scope.resolve(light + "_outerConeAngle");
             this.lightPosVsId[i] = scope.resolve(light + "_positionVS");
             this.lightCookieId[i] = scope.resolve(light + "_cookie");
+            this.lightCookieMatrixId[i] = scope.resolve(light + "_matrix");
         },
 
         dispatchDirectLights: function (scene, mask) {
@@ -881,6 +883,7 @@ pc.extend(pc, function () {
                 }
                 if (point._cookie) {
                     this.lightCookieId[cnt].setValue(point._cookie);
+                    this.lightCookieMatrixId[cnt].setValue(wtm.data);
                 }
                 cnt++;
             }
@@ -938,6 +941,7 @@ pc.extend(pc, function () {
                 }
                 if (spot._cookie) {
                     this.lightCookieId[cnt].setValue(spot._cookie);
+                    this.lightCookieMatrixId[cnt].setValue(wtm.data);
                 }
                 cnt++;
             }

--- a/src/scene/forward-renderer.js
+++ b/src/scene/forward-renderer.js
@@ -591,6 +591,7 @@ pc.extend(pc, function () {
         this.lightInAngleId = [];
         this.lightOutAngleId = [];
         this.lightPosVsId = [];
+        this.lightCookieId = [];
 
         this.depthMapId = scope.resolve('uDepthMap');
         this.screenSizeId = scope.resolve('uScreenSize');
@@ -768,6 +769,7 @@ pc.extend(pc, function () {
             this.lightInAngleId[i] = scope.resolve(light + "_innerConeAngle");
             this.lightOutAngleId[i] = scope.resolve(light + "_outerConeAngle");
             this.lightPosVsId[i] = scope.resolve(light + "_positionVS");
+            this.lightCookieId[i] = scope.resolve(light + "_cookie");
         },
 
         dispatchDirectLights: function (scene, mask) {
@@ -877,6 +879,9 @@ pc.extend(pc, function () {
                     params[3] = 1.0 / point.getAttenuationEnd();
                     this.lightShadowParamsId[cnt].setValue(params);
                 }
+                if (point._cookie) {
+                    this.lightCookieId[cnt].setValue(point._cookie);
+                }
                 cnt++;
             }
 
@@ -930,6 +935,9 @@ pc.extend(pc, function () {
                         this.lightPosVsId[cnt].setValue(spot._position.data);
                         this.mainLight = i;
                     }
+                }
+                if (spot._cookie) {
+                    this.lightCookieId[cnt].setValue(spot._cookie);
                 }
                 cnt++;
             }

--- a/src/scene/forward-renderer.js
+++ b/src/scene/forward-renderer.js
@@ -592,7 +592,6 @@ pc.extend(pc, function () {
         this.lightOutAngleId = [];
         this.lightPosVsId = [];
         this.lightCookieId = [];
-        this.lightCookieMatrixId = [];
 
         this.depthMapId = scope.resolve('uDepthMap');
         this.screenSizeId = scope.resolve('uScreenSize');
@@ -771,7 +770,6 @@ pc.extend(pc, function () {
             this.lightOutAngleId[i] = scope.resolve(light + "_outerConeAngle");
             this.lightPosVsId[i] = scope.resolve(light + "_positionVS");
             this.lightCookieId[i] = scope.resolve(light + "_cookie");
-            this.lightCookieMatrixId[i] = scope.resolve(light + "_matrix");
         },
 
         dispatchDirectLights: function (scene, mask) {
@@ -872,7 +870,6 @@ pc.extend(pc, function () {
                                 point._shadowCamera._renderTarget._depthTexture :
                                 point._shadowCamera._renderTarget.colorBuffer;
                     this.lightShadowMapId[cnt].setValue(shadowMap);
-                    this.lightShadowMatrixId[cnt].setValue(point._shadowMatrix.data);
                     var params = point._rendererParams;
                     if (params.length!==4) params.length = 4;
                     params[0] = point._shadowResolution;
@@ -883,7 +880,7 @@ pc.extend(pc, function () {
                 }
                 if (point._cookie) {
                     this.lightCookieId[cnt].setValue(point._cookie);
-                    this.lightCookieMatrixId[cnt].setValue(wtm.data);
+                    this.lightShadowMatrixId[cnt].setValue(wtm.data);
                 }
                 cnt++;
             }
@@ -941,7 +938,23 @@ pc.extend(pc, function () {
                 }
                 if (spot._cookie) {
                     this.lightCookieId[cnt].setValue(spot._cookie);
-                    this.lightCookieMatrixId[cnt].setValue(wtm.data);
+                    if (!spot.getCastShadows()) {
+                        var shadowCam = this.getShadowCamera(this.device, spot);
+                        var shadowCamNode = shadowCam._node;
+
+                        shadowCamNode.setPosition(spot._node.getPosition());
+                        shadowCamNode.setRotation(spot._node.getRotation());
+                        shadowCamNode.rotateLocal(-90, 0, 0);
+
+                        shadowCam.setProjection(pc.PROJECTION_PERSPECTIVE);
+                        shadowCam.setAspectRatio(1);
+                        shadowCam.setFov(spot.getOuterConeAngle() * 2);
+
+                        shadowCamView.setTRS(shadowCamNode.getPosition(), shadowCamNode.getRotation(), pc.Vec3.ONE).invert();
+                        shadowCamViewProj.mul2(shadowCam.getProjectionMatrix(), shadowCamView);
+                        spot._shadowMatrix.mul2(scaleShift, shadowCamViewProj);
+                    }
+                    this.lightShadowMatrixId[cnt].setValue(spot._shadowMatrix.data);
                 }
                 cnt++;
             }

--- a/src/scene/forward-renderer.js
+++ b/src/scene/forward-renderer.js
@@ -592,6 +592,7 @@ pc.extend(pc, function () {
         this.lightOutAngleId = [];
         this.lightPosVsId = [];
         this.lightCookieId = [];
+        this.lightCookieIntId = [];
 
         this.depthMapId = scope.resolve('uDepthMap');
         this.screenSizeId = scope.resolve('uScreenSize');
@@ -770,6 +771,7 @@ pc.extend(pc, function () {
             this.lightOutAngleId[i] = scope.resolve(light + "_outerConeAngle");
             this.lightPosVsId[i] = scope.resolve(light + "_positionVS");
             this.lightCookieId[i] = scope.resolve(light + "_cookie");
+            this.lightCookieIntId[i] = scope.resolve(light + "_cookieIntensity");
         },
 
         dispatchDirectLights: function (scene, mask) {
@@ -881,6 +883,7 @@ pc.extend(pc, function () {
                 if (point._cookie) {
                     this.lightCookieId[cnt].setValue(point._cookie);
                     this.lightShadowMatrixId[cnt].setValue(wtm.data);
+                    this.lightCookieIntId[cnt].setValue(point._cookieIntensity);
                 }
                 cnt++;
             }
@@ -955,6 +958,7 @@ pc.extend(pc, function () {
                         spot._shadowMatrix.mul2(scaleShift, shadowCamViewProj);
                     }
                     this.lightShadowMatrixId[cnt].setValue(spot._shadowMatrix.data);
+                    this.lightCookieIntId[cnt].setValue(spot._cookieIntensity);
                 }
                 cnt++;
             }

--- a/src/scene/light.js
+++ b/src/scene/light.js
@@ -27,6 +27,9 @@ pc.extend(pc, function () {
         this._vsmBlurMode = pc.BLUR_GAUSSIAN;
         this._vsmBias = 0.01 * 0.25;
         this._cookie = null; // light cookie texture (2D for spot, cubemap for point)
+        this._cookieIntensity = 1;
+        this._cookieFalloff = true;
+        this._cookieChannel = "rgb";
 
         // Spot properties
         this._innerConeAngle = 40;
@@ -141,6 +144,18 @@ pc.extend(pc, function () {
 
         getCookie: function () {
             return this._cookie;
+        },
+
+        getCookieIntensity: function () {
+            return this._cookieIntensity;
+        },
+
+        getCookieFalloff: function () {
+            return this._cookieFalloff;
+        },
+
+        getCookieChannel: function () {
+            return this._cookieChannel;
         },
 
         /**
@@ -333,6 +348,29 @@ pc.extend(pc, function () {
 
         setCookie: function (tex) {
             this._cookie = tex;
+            if (this._scene !== null) {
+                this._scene.updateShaders = true;
+            }
+        },
+
+        setCookieIntensity: function (value) {
+            this._cookieIntensity = value;
+        },
+
+        setCookieFalloff: function (value) {
+            this._cookieFalloff = value;
+            if (this._scene !== null) {
+                this._scene.updateShaders = true;
+            }
+        },
+
+        setCookieChannel: function (value) {
+            if (value.length < 3) {
+                var chr = value.charAt(value.length - 1);
+                var addLen = 3 - value.length;
+                for (var i = 0; i < addLen; i++) value += chr;
+            }
+            this._cookieChannel = value;
             if (this._scene !== null) {
                 this._scene.updateShaders = true;
             }

--- a/src/scene/light.js
+++ b/src/scene/light.js
@@ -16,6 +16,7 @@ pc.extend(pc, function () {
         this._intensity = 1;
         this._castShadows = false;
         this._enabled = false;
+        this.mask = 1;
 
         // Point and spot properties
         this._attenuationStart = 10;
@@ -25,7 +26,7 @@ pc.extend(pc, function () {
         this._vsmBlurSize = 11;
         this._vsmBlurMode = pc.BLUR_GAUSSIAN;
         this._vsmBias = 0.01 * 0.25;
-        this.mask = 1;
+        this._cookie = null; // light cookie texture (2D for spot, cubemap for point)
 
         // Spot properties
         this._innerConeAngle = 40;
@@ -136,6 +137,10 @@ pc.extend(pc, function () {
 
         getVsmBias: function () {
             return this._vsmBias;
+        },
+
+        getCookie: function () {
+            return this._cookie;
         },
 
         /**
@@ -324,6 +329,13 @@ pc.extend(pc, function () {
 
         setVsmBias: function (mode) {
             this._vsmBias = mode;
+        },
+
+        setCookie: function (tex) {
+            this._cookie = tex;
+            if (this._scene !== null) {
+                this._scene.updateShaders = true;
+            }
         },
 
         setMask: function (_mask) {


### PR DESCRIPTION
![img_04072016_174926](https://cloud.githubusercontent.com/assets/7008423/16568364/e7fd7abc-4231-11e6-8683-e36052b364d0.png)

Now you can project textures from spot/point lights. New parameters:
- light.cookie: projection texture, must be 2D for spot and cubemap for point (ignored if incorrect type is used);
- light.cookieIntensity: projection texture intensity (default is 1);
- light.cookieFalloff (boolean): enable/disable normal spotlight falloff. When set to false, spotlight will work like a pure texture projector (with only distance fade). Default is false;
- light.cookieChannel (string): allows specifying projection texture's channels to use, the same way as for standard material textures. Default is "rgb".