### PR TITLE
Added "layerCullingMask" feature to Camera.

### DIFF
--- a/src/scene/camera.js
+++ b/src/scene/camera.js
@@ -17,6 +17,7 @@ pc.extend(pc, function () {
         this._aspect = 16 / 9;
         this._horizontalFov = false;
         this.frustumCulling = false;
+        this.layerCullingMask = 0xffffffff;
         this._renderDepthRequests = 0;
 
         this._projMatDirty = true;
@@ -65,6 +66,7 @@ pc.extend(pc, function () {
             clone.setRenderTarget(this.getRenderTarget());
             clone.setClearOptions(this.getClearOptions());
             clone.frustumCulling = this.frustumCulling;
+            clone.layerCullingMask = this.layerCullingMask;
             return clone;
         },
 

--- a/src/scene/forward-renderer.js
+++ b/src/scene/forward-renderer.js
@@ -974,11 +974,17 @@ pc.extend(pc, function () {
             var i, drawCall, visible;
             var drawCallsCount = drawCalls.length;
 
+            var layerCullingMask = camera.layerCullingMask || 0xffffffff; // if missing assume camera's default value
+
             if (!camera.frustumCulling) {
                 for (i = 0; i < drawCallsCount; i++) {
                     // need to copy array anyway because sorting will happen and it'll break original draw call order assumption
                     drawCall = drawCalls[i];
                     if (!drawCall.visible && !drawCall.command) continue;
+
+                    // if the object's layer AND the camera's layerCullingMask is zero then the game object will be invisible from this camera
+                    if (drawCall.layer && ((1 < drawCall.layer) & layerCullingMask) === 0) continue;
+
                     culled.push(drawCall);
                 }
                 return culled;
@@ -989,6 +995,9 @@ pc.extend(pc, function () {
                 if (!drawCall.command) {
                     if (!drawCall.visible) continue; // use visible property to quickly hide/show meshInstances
                     visible = true;
+
+                    // if the object's layer AND the camera's layerCullingMask is zero then the game object will be invisible from this camera
+                    if (drawCall.layer && ((1 < drawCall.layer) & layerCullingMask) === 0) continue;
 
                     // Don't cull fx/hud/gizmo
                     if (drawCall.layer > pc.LAYER_FX) {


### PR DESCRIPTION
**Description:**
Include or omit which layers of objects are to be rendered by a Camera.

**Motiviation:**
Currently there is no way to control which layers are rendered by a camera. This is a significant limitation, especially when rendering to texture, as you usually want to hide layers such as LAYER_HUD etc. A very common use case is to have multiple cameras in the same scene that render different objects, and combine the results in post effects (such as outlining in the PlayCanvas Editor). In addition, this feature has also been requested in the [forums](http://forum.playcanvas.com/t/camera-mask-to-control-which-instance-to-render/940).

**API changes:**
- New property `Camera.layerCullingMask`.

**Implementation:**
The implementation is quite simple and reuses the existing layer property [`MeshInstance.layer`](http://developer.playcanvas.com/en/api/pc.MeshInstance.html#layer). Only minor changes are made in the scene's internal culling method. The new `Camera.layerCullingMask` property is inspired by familiar APIs such as [Unity's Camera.cullingMask](https://docs.unity3d.com/ScriptReference/Camera-cullingMask.html).
