### PR TITLE
Added "cullingMask" feature to Camera. (updated)

### DIFF
--- a/src/scene/camera.js
+++ b/src/scene/camera.js
@@ -17,7 +17,7 @@ pc.extend(pc, function () {
         this._aspect = 16 / 9;
         this._horizontalFov = false;
         this.frustumCulling = false;
-        this.cullingMask = 0xffffffff;
+        this.cullingMask = 0xFFFFFFFF;
         this._renderDepthRequests = 0;
 
         this._projMatDirty = true;

--- a/src/scene/camera.js
+++ b/src/scene/camera.js
@@ -17,7 +17,7 @@ pc.extend(pc, function () {
         this._aspect = 16 / 9;
         this._horizontalFov = false;
         this.frustumCulling = false;
-        this.layerCullingMask = 0xffffffff;
+        this.cullingMask = 0xffffffff;
         this._renderDepthRequests = 0;
 
         this._projMatDirty = true;
@@ -66,7 +66,7 @@ pc.extend(pc, function () {
             clone.setRenderTarget(this.getRenderTarget());
             clone.setClearOptions(this.getClearOptions());
             clone.frustumCulling = this.frustumCulling;
-            clone.layerCullingMask = this.layerCullingMask;
+            clone.cullingMask = this.cullingMask;
             return clone;
         },
 

--- a/src/scene/camera.js
+++ b/src/scene/camera.js
@@ -17,6 +17,7 @@ pc.extend(pc, function () {
         this._aspect = 16 / 9;
         this._horizontalFov = false;
         this.frustumCulling = false;
+        this.layerCullingMask = 0xffffffff;
         this._renderDepthRequests = 0;
 
         this._projMatDirty = true;
@@ -65,6 +66,7 @@ pc.extend(pc, function () {
             clone.setRenderTarget(this.getRenderTarget());
             clone.setClearOptions(this.getClearOptions());
             clone.frustumCulling = this.frustumCulling;
+            clone.layerCullingMask = this.layerCullingMask;
             return clone;
         },
 

--- a/src/scene/forward-renderer.js
+++ b/src/scene/forward-renderer.js
@@ -974,7 +974,7 @@ pc.extend(pc, function () {
             var i, drawCall, visible;
             var drawCallsCount = drawCalls.length;
 
-            var layerCullingMask = camera.layerCullingMask || 0xffffffff; // if missing assume camera's default value
+            var cullingMask = camera.cullingMask || 0xffffffff; // if missing assume camera's default value
 
             if (!camera.frustumCulling) {
                 for (i = 0; i < drawCallsCount; i++) {
@@ -982,8 +982,8 @@ pc.extend(pc, function () {
                     drawCall = drawCalls[i];
                     if (!drawCall.visible && !drawCall.command) continue;
 
-                    // if the object's layer AND the camera's layerCullingMask is zero then the game object will be invisible from this camera
-                    if (drawCall.layer && ((1 << drawCall.layer) & layerCullingMask) === 0) continue;
+                    // if the object's mask AND the camera's cullingMask is zero then the game object will be invisible from this camera
+                    if (drawCall.mask && ((1 << drawCall.mask) & cullingMask) === 0) continue;
 
                     culled.push(drawCall);
                 }
@@ -996,8 +996,8 @@ pc.extend(pc, function () {
                     if (!drawCall.visible) continue; // use visible property to quickly hide/show meshInstances
                     visible = true;
 
-                    // if the object's layer AND the camera's layerCullingMask is zero then the game object will be invisible from this camera
-                    if (drawCall.layer && ((1 << drawCall.layer) & layerCullingMask) === 0) continue;
+                    // if the object's mask AND the camera's cullingMask is zero then the game object will be invisible from this camera
+                    if (drawCall.mask && ((1 << drawCall.mask) & cullingMask) === 0) continue;
 
                     // Don't cull fx/hud/gizmo
                     if (drawCall.layer > pc.LAYER_FX) {

--- a/src/scene/forward-renderer.js
+++ b/src/scene/forward-renderer.js
@@ -983,7 +983,7 @@ pc.extend(pc, function () {
                     if (!drawCall.visible && !drawCall.command) continue;
 
                     // if the object's layer AND the camera's layerCullingMask is zero then the game object will be invisible from this camera
-                    if (drawCall.layer && ((1 < drawCall.layer) & layerCullingMask) === 0) continue;
+                    if (drawCall.layer && ((1 << drawCall.layer) & layerCullingMask) === 0) continue;
 
                     culled.push(drawCall);
                 }
@@ -997,7 +997,7 @@ pc.extend(pc, function () {
                     visible = true;
 
                     // if the object's layer AND the camera's layerCullingMask is zero then the game object will be invisible from this camera
-                    if (drawCall.layer && ((1 < drawCall.layer) & layerCullingMask) === 0) continue;
+                    if (drawCall.layer && ((1 << drawCall.layer) & layerCullingMask) === 0) continue;
 
                     // Don't cull fx/hud/gizmo
                     if (drawCall.layer > pc.LAYER_FX) {

--- a/src/scene/forward-renderer.js
+++ b/src/scene/forward-renderer.js
@@ -983,7 +983,7 @@ pc.extend(pc, function () {
                     if (!drawCall.visible && !drawCall.command) continue;
 
                     // if the object's mask AND the camera's cullingMask is zero then the game object will be invisible from the camera
-                    if (drawCall.mask && ((1 << drawCall.mask) & cullingMask) === 0) continue;
+                    if (drawCall.mask && (drawCall.mask & cullingMask) === 0) continue;
 
                     culled.push(drawCall);
                 }
@@ -997,7 +997,7 @@ pc.extend(pc, function () {
                     visible = true;
 
                     // if the object's mask AND the camera's cullingMask is zero then the game object will be invisible from the camera
-                    if (drawCall.mask && ((1 << drawCall.mask) & cullingMask) === 0) continue;
+                    if (drawCall.mask && (drawCall.mask & cullingMask) === 0) continue;
 
                     // Don't cull fx/hud/gizmo
                     if (drawCall.layer > pc.LAYER_FX) {

--- a/src/scene/forward-renderer.js
+++ b/src/scene/forward-renderer.js
@@ -974,7 +974,7 @@ pc.extend(pc, function () {
             var i, drawCall, visible;
             var drawCallsCount = drawCalls.length;
 
-            var cullingMask = camera.cullingMask || 0xffffffff; // if missing assume camera's default value
+            var cullingMask = camera.cullingMask || 0xFFFFFFFF; // if missing assume camera's default value
 
             if (!camera.frustumCulling) {
                 for (i = 0; i < drawCallsCount; i++) {
@@ -982,7 +982,7 @@ pc.extend(pc, function () {
                     drawCall = drawCalls[i];
                     if (!drawCall.visible && !drawCall.command) continue;
 
-                    // if the object's mask AND the camera's cullingMask is zero then the game object will be invisible from this camera
+                    // if the object's mask AND the camera's cullingMask is zero then the game object will be invisible from the camera
                     if (drawCall.mask && ((1 << drawCall.mask) & cullingMask) === 0) continue;
 
                     culled.push(drawCall);
@@ -996,7 +996,7 @@ pc.extend(pc, function () {
                     if (!drawCall.visible) continue; // use visible property to quickly hide/show meshInstances
                     visible = true;
 
-                    // if the object's mask AND the camera's cullingMask is zero then the game object will be invisible from this camera
+                    // if the object's mask AND the camera's cullingMask is zero then the game object will be invisible from the camera
                     if (drawCall.mask && ((1 << drawCall.mask) & cullingMask) === 0) continue;
 
                     // Don't cull fx/hud/gizmo

--- a/src/scene/forward-renderer.js
+++ b/src/scene/forward-renderer.js
@@ -974,11 +974,17 @@ pc.extend(pc, function () {
             var i, drawCall, visible;
             var drawCallsCount = drawCalls.length;
 
+            var layerCullingMask = camera.layerCullingMask || 0xffffffff; // if missing assume camera's default value
+
             if (!camera.frustumCulling) {
                 for (i = 0; i < drawCallsCount; i++) {
                     // need to copy array anyway because sorting will happen and it'll break original draw call order assumption
                     drawCall = drawCalls[i];
                     if (!drawCall.visible && !drawCall.command) continue;
+
+                    // if the object's layer AND the camera's layerCullingMask is zero then the game object will be invisible from this camera
+                    if (drawCall.layer && ((1 < drawCall.layer) & layerCullingMask) === 0) continue;
+
                     culled.push(drawCall);
                 }
                 return culled;
@@ -989,6 +995,9 @@ pc.extend(pc, function () {
                 if (!drawCall.command) {
                     if (!drawCall.visible) continue; // use visible property to quickly hide/show meshInstances
                     visible = true;
+
+                    // if the object's layer AND the camera's layerCullingMask is zero then the game object will be invisible from this camera
+                    if (drawCall.layer && ((1 < drawCall.layer) & layerCullingMask) === 0) continue;
 
                     // Don't cull fx/hud/gizmo
                     if (drawCall.layer > pc.LAYER_FX) {


### PR DESCRIPTION
**Update:**
This is an updated pull request based on comments and feedback from the [old an (removed) pull request](https://github.com/playcanvas/engine/pull/674).

**Description:**
Include or omit which objects are to be rendered by a Camera.

**Motiviation:**
Currently there is no way to control which objects are rendered by a camera. This is a significant limitation, especially when rendering to texture, as you typically want to hide some objects that may be an obstruction from another camera angle or interfere with render target results. Another example is to have multiple cameras in the same scene that render different objects, and combine the results in post effects (such as outlining in the PlayCanvas Editor). In addition, this feature has also been requested in the [forums](http://forum.playcanvas.com/t/camera-mask-to-control-which-instance-to-render/940).

**API changes:**
- New property `Camera.cullingMask`.

**Implementation:**
The implementation is quite simple and reuses the existing mask property [`MeshInstance.mask`](http://developer.playcanvas.com/en/api/pc.MeshInstance.html#mask). If the object's mask AND the camera's cullingMask is zero then the game object will be invisible from the camera. To achieve this feature only minor changes where necessary in the scene's internal culling method. The new `Camera.cullingMask` property is inspired by familiar APIs such as [Unity's Camera.cullingMask](https://docs.unity3d.com/ScriptReference/Camera-cullingMask.html).
