### PR TITLE
Fixed EOL build issue on Windows

### DIFF
--- a/build/build.js
+++ b/build/build.js
@@ -124,7 +124,7 @@ var getVersion = function (callback) {
 var loadDependencies = function (fullpath, callback) {
     fs.readFile(fullpath, function (err, data) {
         if (err) callback(err);
-        callback(data.toString().trim().split(os.EOL))
+        callback(data.toString().trim().split(new RegExp("[\\r\\n]+", 'g')));
     });
 };
 
@@ -144,7 +144,7 @@ var concatentateShaders = function (callback) {
             if (ext) {
                 var fullpath = dir + file;
 
-                var content = replaceAll(fs.readFileSync(fullpath).toString(), os.EOL, "\\n");
+                var content = replaceAll(fs.readFileSync(fullpath).toString(), "[\\r\\n]+", "\\n");
                 var name = file.split(".")[0] + ext;
                 var data = util.format('pc.shaderChunks.%s = "%s";\n', name, content);
                 fs.writeSync(fd, data);


### PR DESCRIPTION
This PR will fix a EOL build issue #705 on Windows as [reported here](https://github.com/playcanvas/engine/issues/705).

The issue is caused by an assumption in the build script. The assumptions is that read files will always use the local OS's end-of-line (i.e. os.EOL). However this is not the case since by default git does not auto-convert line-endings during checkout. In addition, the system or even nodejs may transparently convert line-endings to be more portable.

The fix replaces the use of `os.EOL` with the OS-agnostic regex pattern `[\r\n]+`, which will work for any line-ending-style.