### PR TITLE
Fix bug preventing default attributes if instance attributes not defined

### DIFF
--- a/src/framework/components/script/component.js
+++ b/src/framework/components/script/component.js
@@ -318,7 +318,7 @@ pc.extend(pc, function () {
                         app: this.system.app,
                         entity: this.entity,
                         enabled: args.hasOwnProperty('enabled') ? args.enabled : true,
-                        attributes: args.attributes || null
+                        attributes: args.attributes || { }
                     });
 
                     var ind = -1;

--- a/src/script/script.js
+++ b/src/script/script.js
@@ -374,6 +374,9 @@ pc.extend(pc, function () {
 
         // initialize attributes
         script.prototype.__initializeAttributes = function() {
+            if (! this.__attributesRaw)
+                return;
+
             // set attributes values
             for(var key in script.attributes.index) {
                 if (this.__attributesRaw && this.__attributesRaw.hasOwnProperty(key)) {

--- a/src/script/script.js
+++ b/src/script/script.js
@@ -374,9 +374,6 @@ pc.extend(pc, function () {
 
         // initialize attributes
         script.prototype.__initializeAttributes = function() {
-            if (! this.__attributesRaw)
-                return;
-
             // set attributes values
             for(var key in script.attributes.index) {
                 if (this.__attributesRaw && this.__attributesRaw.hasOwnProperty(key)) {


### PR DESCRIPTION
This simple PR just removes a bad check, that will incorrectly abort initialization of attributes just because the instance attributes "holder" object (i.e. `__attributesRaw`) is not defined. Even if the instance attributes object `__attributesRaw` is not defined, default attributes should still be assigned to a newly created script instance. In addition, the check is also redundant since it is being done (correctly) later in the same function.
