### PR TITLE
Don't destroy particle shaders

### DIFF
--- a/src/scene/particle-emitter.js
+++ b/src/scene/particle-emitter.js
@@ -1538,9 +1538,10 @@ pc.extend(pc, function() {
             if (this.rtParticleTexIN) this.rtParticleTexIN.destroy();
             if (this.rtParticleTexOUT) this.rtParticleTexOUT.destroy();
 
-            if (this.shaderParticleUpdateRespawn) this.shaderParticleUpdateRespawn.destroy();
-            if (this.shaderParticleUpdateNoRespawn) this.shaderParticleUpdateNoRespawn.destroy();
-            if (this.shaderParticleUpdateOnStop) this.shaderParticleUpdateOnStop.destroy();
+            // TODO: delete shaders from cache with reference counting
+            //if (this.shaderParticleUpdateRespawn) this.shaderParticleUpdateRespawn.destroy();
+            //if (this.shaderParticleUpdateNoRespawn) this.shaderParticleUpdateNoRespawn.destroy();
+            //if (this.shaderParticleUpdateOnStop) this.shaderParticleUpdateOnStop.destroy();
 
             this.particleTexIN = null;
             this.particleTexOUT = null;


### PR DESCRIPTION
For now.
TODO: add reference counting for meshes, shaders etc, and destroy properly.