### PR TITLE
Better texture mem profiling

### DIFF
--- a/src/graphics/device.js
+++ b/src/graphics/device.js
@@ -647,6 +647,11 @@ pc.extend(pc, function () {
             this._renderTargetCreationTime = 0;
 
             this._vram = {
+                // #ifdef PROFILER
+                texShadow: 0,
+                texAsset: 0,
+                texLightmap: 0,
+                // #endif
                 tex: 0,
                 vb: 0,
                 ib: 0
@@ -1201,6 +1206,15 @@ pc.extend(pc, function () {
             if (texture._gpuSize) this._vram.tex -= texture._gpuSize;
             texture._gpuSize = gpuTexSize(gl, texture);
             this._vram.tex += texture._gpuSize;
+            // #ifdef PROFILER
+            if (texture.profilerHint===pc.TEXHINT_SHADOWMAP) {
+                this._vram.texShadow += texture._gpuSize;
+            } else if (texture.profilerHint===pc.TEXHINT_ASSET) {
+                this._vram.texAsset += texture._gpuSize;
+            } else if (texture.profilerHint===pc.TEXHINT_LIGHTMAP) {
+                this._vram.texLightmap += texture._gpuSize;
+            }
+            // #endif
         },
 
         setTexture: function (texture, textureUnit) {

--- a/src/graphics/graphics.js
+++ b/src/graphics/graphics.js
@@ -667,6 +667,11 @@
          */
         TEXTURELOCK_WRITE: 2,
 
+        TEXHINT_NONE: 0,
+        TEXHINT_SHADOWMAP: 1,
+        TEXHINT_ASSET: 2,
+        TEXHINT_LIGHTMAP: 3,
+
         UNIFORMTYPE_BOOL: 0,
         UNIFORMTYPE_INT: 1,
         UNIFORMTYPE_FLOAT: 2,

--- a/src/graphics/texture.js
+++ b/src/graphics/texture.js
@@ -69,6 +69,9 @@ pc.extend(pc, function () {
         var cubemap = false;
         var rgbm = false;
         var fixCubemapSeams = false;
+        // #ifdef PROFILER
+        var hint = 0;
+        // #endif
 
         if (options !== undefined) {
             width = (options.width !== undefined) ? options.width : width;
@@ -77,12 +80,19 @@ pc.extend(pc, function () {
             cubemap = (options.cubemap !== undefined) ? options.cubemap : cubemap;
             rgbm = (options.rgbm !== undefined)? options.rgbm : rgbm;
             fixCubemapSeams = (options.fixCubemapSeams !== undefined)? options.fixCubemapSeams : fixCubemapSeams;
+            // #ifdef PROFILER
+            hint = (options.profilerHint !== undefined)? options.profilerHint : 0;
+            // #endif
         }
 
         // PUBLIC
         this.name = null;
         this.rgbm = rgbm;
         this.fixCubemapSeams = fixCubemapSeams;
+
+        // #ifdef PROFILER
+        this.profilerHint = hint;
+        // #endif
 
         // PRIVATE
         this._cubemap = cubemap;
@@ -348,7 +358,18 @@ pc.extend(pc, function () {
             if (this._glTextureId) {
                 var gl = this.device.gl;
                 gl.deleteTexture(this._glTextureId);
+
                 this.device._vram.tex -= this._gpuSize;
+                // #ifdef PROFILER
+                if (this.profilerHint===pc.TEXHINT_SHADOWMAP) {
+                    this.device._vram.texShadow -= this._gpuSize;
+                } else if (this.profilerHint===pc.TEXHINT_ASSET) {
+                    this.device._vram.texAsset -= this._gpuSize;
+                } else if (this.profilerHint===pc.TEXHINT_LIGHTMAP) {
+                    this.device._vram.texLightmap -= this._gpuSize;
+                }
+                // #endif
+
                 this._glTextureId = null;
             }
         },

--- a/src/resources/texture.js
+++ b/src/resources/texture.js
@@ -108,6 +108,9 @@ pc.extend(pc, function () {
 
                 format = (ext === ".jpg" || ext === ".jpeg") ? pc.PIXELFORMAT_R8_G8_B8 : pc.PIXELFORMAT_R8_G8_B8_A8;
                 texture = new pc.Texture(this._device, {
+                    // #ifdef PROFILER
+                    profilerHint: pc.TEXHINT_ASSET,
+                    // #endif
                     width: img.width,
                     height: img.height,
                     format: format
@@ -204,6 +207,9 @@ pc.extend(pc, function () {
                 }
 
                 var texOptions = {
+                    // #ifdef PROFILER
+                    profilerHint: pc.TEXHINT_ASSET,
+                    // #endif
                     width: width,
                     height: height,
                     format: format,

--- a/src/scene/forward-renderer.js
+++ b/src/scene/forward-renderer.js
@@ -352,6 +352,9 @@ pc.extend(pc, function () {
     function createShadowMap(device, width, height, shadowType) {
         var format = getShadowFormat(shadowType);
         var shadowMap = new pc.Texture(device, {
+            // #ifdef PROFILER
+            profilerHint: pc.TEXHINT_SHADOWMAP,
+            // #endif
             format: format,
             width: width,
             height: height,
@@ -367,6 +370,9 @@ pc.extend(pc, function () {
 
     function createShadowCubeMap(device, size) {
         var cubemap = new pc.Texture(device, {
+            // #ifdef PROFILER
+            profilerHint: pc.TEXHINT_SHADOWMAP,
+            // #endif
             format: pc.PIXELFORMAT_R8_G8_B8_A8,
             width: size,
             height: size,

--- a/src/scene/lightmapper.js
+++ b/src/scene/lightmapper.js
@@ -87,7 +87,6 @@ pc.extend(pc, function () {
         this._stats = {
             renderPasses: 0,
             lightmapCount: 0,
-            lightmapMem: 0,
             totalRenderTime: 0,
             forwardTime: 0,
             fboTime: 0,
@@ -176,7 +175,7 @@ pc.extend(pc, function () {
             var pass;
 
             // #ifdef PROFILER
-            stats.renderPasses = stats.lightmapMem = stats.shadowMapTime = stats.forwardTime = 0;
+            stats.renderPasses = stats.shadowMapTime = stats.forwardTime = 0;
             var startShaders = device._shaderStats.linked;
             var startFboTime = device._renderTargetCreationTime;
             var startCompileTime = device._shaderStats.compileTime;
@@ -262,7 +261,11 @@ pc.extend(pc, function () {
                 size = this.calculateLightmapSize(nodes[i]);
                 texSize.push(size);
                 for(pass=0; pass<passCount; pass++) {
-                    tex = new pc.Texture(device, {width:size,
+                    tex = new pc.Texture(device, {
+                                                  // #ifdef PROFILER
+                                                  profilerHint: pc.TEXHINT_LIGHTMAP,
+                                                  // #endif
+                                                  width:size,
                                                   height:size,
                                                   format:pc.PIXELFORMAT_R8_G8_B8_A8,
                                                   autoMipmap:false,
@@ -272,11 +275,14 @@ pc.extend(pc, function () {
                     tex._minFilter = pc.FILTER_NEAREST;
                     tex._magFilter = pc.FILTER_NEAREST
                     lmaps[pass].push(tex);
-                    stats.lightmapMem += size * size * 4;
                 }
 
                 if (!texPool[size]) {
-                    var tex2 = new pc.Texture(device, {width:size,
+                    var tex2 = new pc.Texture(device, {
+                                              // #ifdef PROFILER
+                                              profilerHint: pc.TEXHINT_LIGHTMAP,
+                                              // #endif
+                                              width:size,
                                               height:size,
                                               format:pc.PIXELFORMAT_R8_G8_B8_A8,
                                               autoMipmap:false,


### PR DESCRIPTION
New stats:
- stats.vram.texAsset
- stats.vram.texLightmap
- stats.vram.texShadow

Together they should approximately equal stats.vram.tex, the rest are special texture (like used in particles) or user-created ones.

stats.lightmapper.lightmapMem was moved to stats.vram.texLightmap.
