### PR TITLE
Hide text/image element objects. 

### DIFF
--- a/examples/ui/button.js
+++ b/examples/ui/button.js
@@ -88,11 +88,11 @@ Button.prototype._onHoverState = function (state) {
     if (this._disabled) return;
 
     if (state) {
-        this.entity.element.image.textureAsset = this.hoverTexture;
-        this.entity.element.image.rect = this.hoverUvs;
+        this.entity.element.textureAsset = this.hoverTexture;
+        this.entity.element.rect = this.hoverUvs;
     } else {
-        this.entity.element.image.textureAsset = this.default;
-        this.entity.element.image.rect = this.defaultUvs;
+        this.entity.element.textureAsset = this.default;
+        this.entity.element.rect = this.defaultUvs;
     }
 }
 
@@ -100,15 +100,15 @@ Button.prototype._onActiveState = function (state) {
     if (this._disabled) return;
 
     if (state) {
-        this.entity.element.image.textureAsset = this.activatedTexture;
-        this.entity.element.image.rect = this.activatedUvs;
+        this.entity.element.textureAsset = this.activatedTexture;
+        this.entity.element.rect = this.activatedUvs;
     } else {
         if (this.hover) {
-            this.entity.element.image.textureAsset = this.hoverTexture;
-            this.entity.element.image.rect = this.hoverUvs
+            this.entity.element.textureAsset = this.hoverTexture;
+            this.entity.element.rect = this.hoverUvs
         } else {
-            this.entity.element.image.textureAsset = this.defaultTexture;
-            this.entity.element.image.rect = this.defaultUvs;
+            this.entity.element.textureAsset = this.defaultTexture;
+            this.entity.element.rect = this.defaultUvs;
         }
 
     }
@@ -116,17 +116,17 @@ Button.prototype._onActiveState = function (state) {
 
 Button.prototype._onDisabledState = function (state) {
     if (state) {
-        this.entity.element.image.textureAsset = this.disabledTexture;
-        this.entity.element.image.rect = this.disabledUvs;
-        this.entity.element.image.opacity = 0.75;
+        this.entity.element.textureAsset = this.disabledTexture;
+        this.entity.element.rect = this.disabledUvs;
+        this.entity.element.opacity = 0.75;
     } else {
-        this.entity.element.image.opacity = 1;
+        this.entity.element.opacity = 1;
         if (this.hover) {
-            this.entity.element.image.textureAsset = this.highlightTexture;
-            this.entity.element.image.rect = this.highlightUvs
+            this.entity.element.textureAsset = this.highlightTexture;
+            this.entity.element.rect = this.highlightUvs
         } else {
-            this.entity.element.image.textureAsset = this.defaultTexture;
-            this.entity.element.image.rect = this.defaultUvs;
+            this.entity.element.textureAsset = this.defaultTexture;
+            this.entity.element.rect = this.defaultUvs;
         }
     }
 };

--- a/examples/ui/index.html
+++ b/examples/ui/index.html
@@ -130,7 +130,7 @@
                         disabledUvs: [0,0,1,0.25],
                     }
                 });
-                button.element.image.rect = [0, 0.75, 1, 0.25];
+                button.element.rect = [0, 0.75, 1, 0.25];
                 button.setLocalPosition(x, y, 0);
                 button.script.button.on("press", callback);
 
@@ -152,9 +152,9 @@
 
                 button.script.button.on("disabledstate", function (state) {
                     if (state) {
-                        label.element.text.color = new pc.Color(0,0,0,0.5);
+                        label.element.color = new pc.Color(0,0,0,0.5);
                     } else {
-                        label.element.text.color = new pc.Color(1,1,1,0.5);
+                        label.element.color = new pc.Color(1,1,1,0.5);
                     }
                 });
 
@@ -330,7 +330,7 @@
                 if (hud && hud.enabled) {
                     // increment score
                     points += 10;
-                    score.element.text.text = points;
+                    score.element.text = points;
 
                     // "lose" lives
                     if (points > 1000) {
@@ -346,7 +346,10 @@
 
                     // update world space FPS counter
                     averageFps = pc.math.lerp(averageFps, (1/dt), 0.01); // smooth fps
-                    fps.element.text.text = "Hello World!\n" + averageFps.toPrecision(3) + "fps";
+                    fps.element.text = "Hello World!\n" + averageFps.toPrecision(3) + "fps";
+                    if (fps.element.type === "image") {
+                        fps.element.rect = [1,1,1,1];
+                    }
                     fps.setLocalPosition(
                         0.5*Math.sin(2*a),
                         0.125*Math.sin(3*a),

--- a/src/framework/components/element/component.js
+++ b/src/framework/components/element/component.js
@@ -30,9 +30,9 @@ pc.extend(pc, function () {
         this._type = pc.ELEMENTTYPE_GROUP;
 
         // element types
-        this.image = null;
-        this.text = null;
-        this.group = null;
+        this._image = null;
+        this._text = null;
+        this._group = null;
 
         if (!_warning) {
             console.warn("Message from PlayCanvas: The element component is currently in Beta. APIs may change without notice.");
@@ -317,16 +317,16 @@ pc.extend(pc, function () {
 
         onEnable: function () {
             ElementComponent._super.onEnable.call(this);
-            if (this.image) this.image.onEnable();
-            if (this.text) this.text.onEnable();
-            if (this.group) this.group.onEnable();
+            if (this._image) this._image.onEnable();
+            if (this._text) this._text.onEnable();
+            if (this._group) this._group.onEnable();
         },
 
         onDisable: function () {
             ElementComponent._super.onDisable.call(this);
-            if (this.image) this.image.onDisable();
-            if (this.text) this.text.onDisable();
-            if (this.group) this.group.onDisable();
+            if (this._image) this._image.onDisable();
+            if (this._text) this._text.onDisable();
+            if (this._group) this._group.onDisable();
         }
     });
 
@@ -337,18 +337,18 @@ pc.extend(pc, function () {
 
         set: function (value) {
             if (value !== this._type) {
-                if (this.image) {
-                    this.image.destroy();
+                if (this._image) {
+                    this._image.destroy();
                 }
-                if (this.text) {
-                    this.text.destroy();
+                if (this._text) {
+                    this._text.destroy();
                 }
 
 
                 if (value === pc.ELEMENTTYPE_IMAGE) {
-                    this.image = new pc.ImageElement(this);
+                    this._image = new pc.ImageElement(this);
                 } else if (value === pc.ELEMENTTYPE_TEXT) {
-                    this.text = new pc.TextElement(this);
+                    this._text = new pc.TextElement(this);
                 }
 
             }
@@ -489,6 +489,42 @@ pc.extend(pc, function () {
             this.fire('set:anchor', this._anchor);
         }
     });
+
+    var _define = function (name) {
+        Object.defineProperty(ElementComponent.prototype, name, {
+            get: function () {
+                if (this._text) {
+                    return this._text[name];
+                } else if (this._image) {
+                    return this._image[name];
+                } else {
+                    return null;
+                }
+            },
+            set: function (value) {
+                if (this._text) {
+                    this._text[name] = value;
+                } else if (this._image) {
+                    this._image[name] = value;
+                }
+            }
+        })
+    };
+
+    _define("fontSize");
+    _define("color");
+    _define("font");
+    _define("fontAsset");
+    _define("spacing");
+    _define("lineHeight");
+
+    _define("text");
+    _define("texture");
+    _define("textureAsset");
+    _define("material");
+    _define("materialAsset");
+    _define("opacity");
+    _define("rect");
 
     return {
         ElementComponent: ElementComponent

--- a/src/framework/components/element/system.js
+++ b/src/framework/components/element/system.js
@@ -100,39 +100,39 @@ pc.extend(pc, function () {
                 component.type = pc.ELEMENTTYPE_IMAGE;
                 if (data.image.rect !== undefined) {
                     if (data.image.rect instanceof pc.Vec4) {
-                        component.image.rect.copy(data.image.rect);
+                        component._image.rect.copy(data.image.rect);
                     } else {
-                        component.image.rect.set(data.image.rect[0], data.image.rect[1], data.image.rect[2], data.image.rect[3])
+                        component._image.rect.set(data.image.rect[0], data.image.rect[1], data.image.rect[2], data.image.rect[3])
                     }
                 }
-                if (data.image.materialAsset !== undefined) component.image.materialAsset = data.image.materialAsset;
-                if (data.image.material !== undefined) component.image.material = data.image.material;
-                if (data.image.opacity !== undefined) component.image.opacity = data.image.opacity;
-                if (data.image.textureAsset !== undefined) component.image.textureAsset = data.image.textureAsset;
-                if (data.image.texture !== undefined) component.image.texture = data.image.texture;
+                if (data.image.materialAsset !== undefined) component._image.materialAsset = data.image.materialAsset;
+                if (data.image.material !== undefined) component._image.material = data.image.material;
+                if (data.image.opacity !== undefined) component._image.opacity = data.image.opacity;
+                if (data.image.textureAsset !== undefined) component._image.textureAsset = data.image.textureAsset;
+                if (data.image.texture !== undefined) component._image.texture = data.image.texture;
             }
 
             if (data.text) {
                 component.type = pc.ELEMENTTYPE_TEXT;
-                if (data.text.text !== undefined) component.text.text = data.text.text;
+                if (data.text.text !== undefined) component._text.text = data.text.text;
                 if (data.text.color !== undefined) {
                     if (data.text.color instanceof pc.Color) {
-                        component.text.color.copy(data.text.color);
+                        component._text.color.copy(data.text.color);
                     } else {
-                        component.text.color.r = data.text.color[0];
-                        component.text.color.g = data.text.color[1];
-                        component.text.color.b = data.text.color[2];
-                        component.text.color.a = data.text.color[3];
+                        component._text.color.r = data.text.color[0];
+                        component._text.color.g = data.text.color[1];
+                        component._text.color.b = data.text.color[2];
+                        component._text.color.a = data.text.color[3];
                     }
                 }
-                if (data.text.spacing !== undefined) component.text.spacing = data.text.spacing;
+                if (data.text.spacing !== undefined) component._text.spacing = data.text.spacing;
                 if (data.text.fontSize !== undefined) {
-                    component.text.fontSize = data.text.fontSize;
-                    if (!data.text.lineHeight) component.text.lineHeight = data.text.fontSize;
+                    component._text.fontSize = data.text.fontSize;
+                    if (!data.text.lineHeight) component._text.lineHeight = data.text.fontSize;
                 }
-                if (data.text.lineHeight !== undefined) component.text.lineHeight = data.text.lineHeight;
-                if (data.text.fontAsset !== undefined) component.text.fontAsset = data.text.fontAsset;
-                if (data.text.font !== undefined) component.text.font = data.text.font;
+                if (data.text.lineHeight !== undefined) component._text.lineHeight = data.text.lineHeight;
+                if (data.text.fontAsset !== undefined) component._text.fontAsset = data.text.fontAsset;
+                if (data.text.font !== undefined) component._text.font = data.text.font;
             }
 
             // find screen


### PR DESCRIPTION
Move image and text API onto element component.

So instead of `entity.element.image.rect = new pc.Vec4()` you do `entity.element.rect = new pc.Vec4()` and similar for text `entity.element.text.text = "string";` is now `entity.element.text = "string";`