### PR TITLE
Material texture placeholders

### DIFF
--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -154,7 +154,7 @@ pc.extend(pc, function () {
 
         this.loader.addHandler("animation", new pc.AnimationHandler());
         this.loader.addHandler("model", new pc.ModelHandler(this.graphicsDevice));
-        this.loader.addHandler("material", new pc.MaterialHandler(this.assets));
+        this.loader.addHandler("material", new pc.MaterialHandler(this));
         this.loader.addHandler("texture", new pc.TextureHandler(this.graphicsDevice, this.assets, this.loader));
         this.loader.addHandler("text", new pc.TextHandler());
         this.loader.addHandler("json", new pc.JsonHandler());


### PR DESCRIPTION
Use texture placeholders on material while texture is loading to reduce number of shader recompilations.
This affects async loading of assets a lot, leading in some cases to twice less shader recompilation.

Editor loading time spent in freezes during shader recompilations is reduced in some cases twice.