### PR TITLE
Another version of ACES tonemapping

### DIFF
--- a/src/graphics/program-lib/chunks/tonemappingAces2.frag
+++ b/src/graphics/program-lib/chunks/tonemappingAces2.frag
@@ -1,0 +1,37 @@
+uniform float exposure;
+
+// ACES approximation by Stephen Hill
+
+// sRGB => XYZ => D65_2_D60 => AP1 => RRT_SAT
+const mat3 ACESInputMat = mat3(
+    0.59719, 0.35458, 0.04823,
+    0.07600, 0.90834, 0.01566,
+    0.02840, 0.13383, 0.83777
+);
+
+// ODT_SAT => XYZ => D60_2_D65 => sRGB
+const mat3 ACESOutputMat = mat3(
+     1.60475, -0.53108, -0.07367,
+    -0.10208,  1.10813, -0.00605,
+    -0.00327, -0.07276,  1.07602
+);
+
+vec3 RRTAndODTFit(vec3 v) {
+    vec3 a = v * (v + 0.0245786) - 0.000090537;
+    vec3 b = v * (0.983729 * v + 0.4329510) + 0.238081;
+    return a / b;
+}
+
+vec3 toneMap(vec3 color) {
+    color *= exposure;
+    color = color * ACESInputMat;
+
+    // Apply RRT and ODT
+    color = RRTAndODTFit(color);
+    color = color * ACESOutputMat;
+
+    // Clamp to [0, 1]
+    color = clamp(color, 0.0, 1.0);
+
+    return color;
+}

--- a/src/graphics/program-lib/program-lib.js
+++ b/src/graphics/program-lib/program-lib.js
@@ -13,6 +13,8 @@ pc.programlib = {
             return pc.shaderChunks.tonemappingHejlPS;
         } else if (value===pc.TONEMAP_ACES) {
             return pc.shaderChunks.tonemappingAcesPS;
+        } else if (value===pc.TONEMAP_ACES2) {
+            return pc.shaderChunks.tonemappingAces2PS;
         }
         return pc.shaderChunks.tonemappingNonePS;
     },

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -172,6 +172,7 @@
         TONEMAP_FILMIC: 1,
         TONEMAP_HEJL: 2,
         TONEMAP_ACES: 3,
+        TONEMAP_ACES2: 4,
 
         SPECOCC_NONE: 0,
         SPECOCC_AO: 1,
@@ -254,6 +255,7 @@ pc.extend(pc, function () {
      *     <li>pc.TONEMAP_FILMIC</li>
      *     <li>pc.TONEMAP_HEJL</li>
      *     <li>pc.TONEMAP_ACES</li>
+     *     <li>pc.TONEMAP_ACES2</li>
      * </ul>
      * Defaults to pc.TONEMAP_LINEAR.
      * @property {pc.Texture} skybox A cube map texture used as the scene's skybox. Defaults to null.


### PR DESCRIPTION
This one can be more correct than existing TONEMAP_ACES. Ideally, I would just replace the old one, but it seems that some projects are using it, so I'm adding it as additional mode.
Pic: old ACES vs new ACES
![aces2](https://cloud.githubusercontent.com/assets/7008423/19605819/222f9ee2-97c6-11e6-97d9-67a96a06e928.jpg)
