### PR TITLE
pc.Light refactor

### DIFF
--- a/src/framework/components/light/component.js
+++ b/src/framework/components/light/component.js
@@ -144,46 +144,46 @@ pc.extend(pc, function () {
             this.light.setColor(newValue);
         });
         _defineProperty("intensity", 1, function(newValue, oldValue) {
-            this.light.setIntensity(newValue);
+            this.light.intensity = newValue;
         });
         _defineProperty("castShadows", false, function(newValue, oldValue) {
-            this.light.setCastShadows(newValue);
+            this.light.castShadows = newValue;
         });
         _defineProperty("shadowDistance", 40, function(newValue, oldValue) {
-            this.light.setShadowDistance(newValue);
+            this.light.shadowDistance = newValue;
         });
         _defineProperty("shadowResolution", 1024, function(newValue, oldValue) {
-            this.light.setShadowResolution(newValue);
+            this.light.shadowResolution = newValue;
         });
         _defineProperty("shadowBias", 0.05, function(newValue, oldValue) {
-            this.light.setShadowBias(-0.01 * newValue);
+            this.light.shadowBias = -0.01 * newValue;
         });
         _defineProperty("normalOffsetBias", 0, function(newValue, oldValue) {
-            this.light.setNormalOffsetBias(newValue);
+            this.light.normalOffsetBias = newValue;
         });
         _defineProperty("range", 10, function(newValue, oldValue) {
-            this.light.setAttenuationEnd(newValue);
+            this.light.attenuationEnd = newValue;
         });
         _defineProperty("innerConeAngle", 40, function(newValue, oldValue) {
-            this.light.setInnerConeAngle(newValue);
+            this.light.innerConeAngle = newValue;
         });
         _defineProperty("outerConeAngle", 45, function(newValue, oldValue) {
-            this.light.setOuterConeAngle(newValue);
+            this.light.outerConeAngle = newValue;
         });
         _defineProperty("falloffMode", pc.LIGHTFALLOFF_LINEAR, function(newValue, oldValue) {
-            this.light.setFalloffMode(newValue);
+            this.light.falloffMode = newValue;
         });
         _defineProperty("shadowType", pc.SHADOW_DEPTH, function(newValue, oldValue) {
-            this.light.setShadowType(newValue);
+            this.light.shadowType = newValue;
         });
         _defineProperty("vsmBlurSize", 11, function(newValue, oldValue) {
-            this.light.setVsmBlurSize(newValue);
+            this.light.vsmBlurSize = newValue;
         });
         _defineProperty("vsmBlurMode", pc.BLUR_GAUSSIAN, function(newValue, oldValue) {
-            this.light.setVsmBlurMode(newValue);
+            this.light.vsmBlurMode = newValue;
         });
         _defineProperty("vsmBias", 0.01 * 0.25, function(newValue, oldValue) {
-            this.light.setVsmBias(newValue);
+            this.light.vsmBias = newValue;
         });
         _defineProperty("cookieAsset", null, function(newValue, oldValue) {
             if (this._cookieAssetId && ((newValue instanceof pc.Asset && newValue.id === this._cookieAssetId) || newValue === this._cookieAssetId))
@@ -208,16 +208,16 @@ pc.extend(pc, function () {
             }
         });
         _defineProperty("cookie", null, function(newValue, oldValue) {
-            this.light.setCookie(newValue);
+            this.light.cookie = newValue;
         });
         _defineProperty("cookieIntensity", 1, function(newValue, oldValue) {
-            this.light.setCookieIntensity(newValue);
+            this.light.cookieIntensity = newValue;
         });
         _defineProperty("cookieFalloff", true, function(newValue, oldValue) {
-            this.light.setCookieFalloff(newValue);
+            this.light.cookieFalloff = newValue;
         });
         _defineProperty("cookieChannel", "rgb", function(newValue, oldValue) {
-            this.light.setCookieChannel(newValue);
+            this.light.cookieChannel = newValue;
         });
         _defineProperty("cookieAngle", 0, function(newValue, oldValue) {
             if (newValue!==0 || this.cookieScale!==null) {
@@ -231,9 +231,9 @@ pc.extend(pc, function () {
                 var c = Math.cos(newValue * pc.math.DEG_TO_RAD);
                 var s = Math.sin(newValue * pc.math.DEG_TO_RAD);
                 this._cookieMatrix.set(c/scx, -s/scx, s/scy, c/scy);
-                this.light.setCookieTransform(this._cookieMatrix);
+                this.light.cookieTransform = this._cookieMatrix;
             } else {
-                this.light.setCookieTransform(null);
+                this.light.cookieTransform = null;
             }
         });
         _defineProperty("cookieScale", null, function(newValue, oldValue) {
@@ -244,19 +244,19 @@ pc.extend(pc, function () {
                 var c = Math.cos(this.cookieAngle * pc.math.DEG_TO_RAD);
                 var s = Math.sin(this.cookieAngle * pc.math.DEG_TO_RAD);
                 this._cookieMatrix.set(c/scx, -s/scx, s/scy, c/scy);
-                this.light.setCookieTransform(this._cookieMatrix);
+                this.light.cookieTransform = this._cookieMatrix;
             } else {
-                this.light.setCookieTransform(null);
+                this.light.cookieTransform = null;
             }
         });
         _defineProperty("cookieOffset", null, function(newValue, oldValue) {
-            this.light.setCookieOffset(newValue);
+            this.light.cookieOffset = newValue;
         });
         _defineProperty("shadowUpdateMode", pc.SHADOWUPDATE_REALTIME, function(newValue, oldValue) {
             this.light.shadowUpdateMode = newValue;
         });
         _defineProperty("mask", 1, function(newValue, oldValue) {
-            this.light.setMask(newValue);
+            this.light.mask = newValue;
         });
         _defineProperty("affectDynamic", true, function(newValue, oldValue) {
             if (newValue) {
@@ -264,7 +264,7 @@ pc.extend(pc, function () {
             } else {
                 this.light.mask &= ~pc.MASK_DYNAMIC;
             }
-            this.light.setMask(this.light.mask);
+            this.light.mask = this.light._mask;
         });
         _defineProperty("affectLightmapped", false, function(newValue, oldValue) {
             if (newValue) {
@@ -274,7 +274,7 @@ pc.extend(pc, function () {
                 this.light.mask &= ~pc.MASK_BAKED;
                 if (this.bake) this.light.mask |= pc.MASK_LIGHTMAP;
             }
-            this.light.setMask(this.light.mask);
+            this.light.mask = this.light._mask;
         });
         _defineProperty("bake", false, function(newValue, oldValue) {
             if (newValue) {
@@ -284,7 +284,7 @@ pc.extend(pc, function () {
                 this.light.mask &= ~pc.MASK_LIGHTMAP;
                 if (this.affectLightmapped) this.light.mask |= pc.MASK_BAKED;
             }
-            this.light.setMask(this.light.mask);
+            this.light.mask = this.light._mask;
         });
         _defineProperty("bakeDir", true, function(newValue, oldValue) {
             this.light.bakeDir = newValue;
@@ -377,7 +377,7 @@ pc.extend(pc, function () {
 
         onEnable: function () {
             LightComponent._super.onEnable.call(this);
-            this.light.setEnabled(true);
+            this.light.enabled = true;
 
             if (this._cookieAsset && ! this.cookie)
                 this.onCookieAssetSet();
@@ -385,7 +385,7 @@ pc.extend(pc, function () {
 
         onDisable: function () {
             LightComponent._super.onDisable.call(this);
-            this.light.setEnabled(false);
+            this.light.enabled = false;
         }
     });
 

--- a/src/framework/components/light/system.js
+++ b/src/framework/components/light/system.js
@@ -55,7 +55,7 @@ pc.extend(pc, function () {
             }
 
             var light = new pc.Light();
-            light.setType(lightTypes[data.type]);
+            light.type = lightTypes[data.type];
             light._node = component.entity;
             this.app.scene.addLight(light);
             component.data.light = light;
@@ -88,7 +88,7 @@ pc.extend(pc, function () {
 
         changeType: function (component, oldValue, newValue) {
             if (oldValue!==newValue) {
-                component.light.setType(lightTypes[newValue]);
+                component.light.type = lightTypes[newValue];
             }
         }
     });

--- a/src/graphics/render-target.js
+++ b/src/graphics/render-target.js
@@ -44,6 +44,8 @@ pc.extend(pc, function () {
     var RenderTarget = function (graphicsDevice, colorBuffer, options) {
         this._device = graphicsDevice;
         this._colorBuffer = colorBuffer;
+        this._glFrameBuffer = null;
+        this._glDepthBuffer = null;
 
         // Process optional arguments
         options = (options !== undefined) ? options : defaultOptions;
@@ -60,9 +62,15 @@ pc.extend(pc, function () {
          */
         destroy: function () {
             var gl = this._device.gl;
-            gl.deleteFramebuffer(this._frameBuffer);
+
+            if (this._glFrameBuffer) {
+                gl.deleteFramebuffer(this._glFrameBuffer);
+                this._glFrameBuffer = null;
+            }
+
             if (this._glDepthBuffer) {
                 gl.deleteRenderbuffer(this._glDepthBuffer);
+                this._glDepthBuffer = null;
             }
         }
     };
@@ -74,7 +82,9 @@ pc.extend(pc, function () {
      * @description Color buffer set up on the render target.
      */
     Object.defineProperty(RenderTarget.prototype, 'colorBuffer', {
-        get: function() { return this._colorBuffer; }
+        get: function() {
+            return this._colorBuffer;
+        }
     });
 
     /**
@@ -93,7 +103,9 @@ pc.extend(pc, function () {
      * </ul>
      */
     Object.defineProperty(RenderTarget.prototype, 'face', {
-        get: function() { return this._face; },
+        get: function() {
+            return this._face;
+        },
     });
 
     /**
@@ -103,7 +115,9 @@ pc.extend(pc, function () {
      * @description Width of the render target in pixels.
      */
     Object.defineProperty(RenderTarget.prototype, 'width', {
-        get: function() { return this._colorBuffer.width; }
+        get: function() {
+            return this._colorBuffer.width;
+        }
     });
 
     /**
@@ -113,7 +127,9 @@ pc.extend(pc, function () {
      * @description Height of the render target in pixels.
      */
     Object.defineProperty(RenderTarget.prototype, 'height', {
-        get: function() { return this._colorBuffer.height; }
+        get: function() {
+            return this._colorBuffer.height;
+        }
     });
 
     return {

--- a/src/scene/light.js
+++ b/src/scene/light.js
@@ -4,7 +4,7 @@ pc.extend(pc, function () {
     var spotEndPoint = new pc.Vec3();
     var tmpVec = new pc.Vec3();
 
-    var chanId = {r:0, g:1, b:2, a:3};
+    var chanId = { r:0, g:1, b:2, a:3 };
 
     /**
      * @private
@@ -18,21 +18,21 @@ pc.extend(pc, function () {
         this._intensity = 1;
         this._castShadows = false;
         this._enabled = false;
-        this.mask = 1;
+        this._mask = 1;
         this.isStatic = false;
         this.key = 0;
         this.bakeDir = true;
 
         // Point and spot properties
-        this._attenuationStart = 10;
-        this._attenuationEnd = 10;
+        this.attenuationStart = 10;
+        this.attenuationEnd = 10;
         this._falloffMode = 0;
         this._shadowType = pc.SHADOW_DEPTH;
         this._vsmBlurSize = 11;
-        this._vsmBlurMode = pc.BLUR_GAUSSIAN;
-        this._vsmBias = 0.01 * 0.25;
+        this.vsmBlurMode = pc.BLUR_GAUSSIAN;
+        this.vsmBias = 0.01 * 0.25;
         this._cookie = null; // light cookie texture (2D for spot, cubemap for point)
-        this._cookieIntensity = 1;
+        this.cookieIntensity = 1;
         this._cookieFalloff = true;
         this._cookieChannel = "rgb";
         this._cookieTransform = null; // 2d rotation/scale matrix (spot only)
@@ -55,9 +55,9 @@ pc.extend(pc, function () {
         // Shadow mapping resources
         this._shadowCamera = null;
         this._shadowMatrix = new pc.Mat4();
-        this._shadowDistance = 40;
+        this.shadowDistance = 40;
         this._shadowResolution = 1024;
-        this._shadowBias = -0.0005;
+        this.shadowBias = -0.0005;
         this._normalOffsetBias = 0.0;
         this.shadowUpdateMode = pc.SHADOWUPDATE_REALTIME;
 
@@ -78,374 +78,51 @@ pc.extend(pc, function () {
             var clone = new pc.Light();
 
             // Clone Light properties
-            clone.setType(this.getType());
-            clone.setColor(this.getColor());
-            clone.setIntensity(this.getIntensity());
-            clone.setCastShadows(this.getCastShadows());
-            clone.setEnabled(this.getEnabled());
+            clone.type = this._type;
+            clone.setColor(this._color);
+            clone.intensity = this._intensity;
+            clone.castShadows = this.castShadows;
+            clone.enabled = this._enabled;
 
             // Point and spot properties
-            clone.setAttenuationStart(this.getAttenuationStart());
-            clone.setAttenuationEnd(this.getAttenuationEnd());
-            clone.setFalloffMode(this.getFalloffMode());
-            clone.setShadowType(this.getShadowType());
-            clone.setVsmBlurSize(this.getVsmBlurSize());
-            clone.setVsmBlurMode(this.getVsmBlurMode());
-            clone.setVsmBias(this.getVsmBias());
+            clone.attenuationStart = this.attenuationStart;
+            clone.attenuationEnd = this.attenuationEnd;
+            clone.falloffMode = this._falloffMode;
+            clone.shadowType = this._shadowType;
+            clone.vsmBlurSize = this._vsmBlurSize;
+            clone.vsmBlurMode = this.vsmBlurMode;
+            clone.vsmBias = this.vsmBias;
             clone.shadowUpdateMode = this.shadowUpdateMode;
-            clone.mask = this.mask;
+            clone.mask = this._mask;
 
             // Spot properties
-            clone.setInnerConeAngle(this.getInnerConeAngle());
-            clone.setOuterConeAngle(this.getOuterConeAngle());
+            clone.innerConeAngle = this._innerConeAngle;
+            clone.outerConeAngle = this._outerConeAngle;
 
             // Shadow properties
-            clone.setShadowBias(this.getShadowBias());
-            clone.setNormalOffsetBias(this.getNormalOffsetBias());
-            clone.setShadowResolution(this.getShadowResolution());
-            clone.setShadowDistance(this.getShadowDistance());
+            clone.shadowBias = this.shadowBias;
+            clone.normalOffsetBias = this._normalOffsetBias;
+            clone.shadowResolution = this._shadowResolution;
+            clone.shadowDistance = this.shadowDistance;
+
+            // Cookies properties
+            // clone.cookie = this._cookie;
+            // clone.cookieIntensity = this.cookieIntensity;
+            // clone.cookieFalloff = this._cookieFalloff;
+            // clone.cookieChannel = this._cookieChannel;
+            // clone.cookieTransform = this._cookieTransform;
+            // clone.cookieOffset = this._cookieOffset;
 
             return clone;
         },
 
-        /**
-         * @private
-         * @function
-         * @name pc.Light#getAttenuationEnd
-         * @description Queries the radius of the point or spot light. In other words, this is
-         * the distance at which the light's contribution falls to zero.
-         * @returns {Number} The radius of the point or spot light.
-         */
-        getAttenuationEnd: function () {
-            return this._attenuationEnd;
-        },
-
-        /**
-         * @private
-         * @function
-         * @name pc.Light#getAttenuationStart
-         * @description Queries the distance from the point or spot light that attenuation begins.
-         * @returns {Number} The radius from the light position where attenuation starts.
-         */
-        getAttenuationStart: function () {
-            return this._attenuationStart;
-        },
-
-        getFalloffMode: function () {
-            return this._falloffMode;
-        },
-
-        getShadowType: function () {
-            return this._shadowType;
-        },
-
-        getVsmBlurSize: function () {
-            return this._vsmBlurSize;
-        },
-
-        getVsmBlurMode: function () {
-            return this._vsmBlurMode;
-        },
-
-        getVsmBias: function () {
-            return this._vsmBias;
-        },
-
-        getCookie: function () {
-            return this._cookie;
-        },
-
-        getCookieIntensity: function () {
-            return this._cookieIntensity;
-        },
-
-        getCookieFalloff: function () {
-            return this._cookieFalloff;
-        },
-
-        getCookieChannel: function () {
-            return this._cookieChannel;
-        },
-
-        getCookieTransform: function () {
-            return this._cookieTransform;
-        },
-
-        getCookieOffset: function () {
-            return this._cookieOffset;
-        },
-
-        /**
-         * @private
-         * @function
-         * @name pc.Light#getCastShadows
-         * @description Queries whether the light casts shadows. Dynamic lights do not
-         * cast shadows by default.
-         * @returns {Boolean} true if the specified light casts shadows and false otherwise.
-         */
-        getCastShadows: function () {
-            return this._castShadows && this.mask!==pc.MASK_LIGHTMAP && this.mask!==0;
-        },
-
-        /**
-         * @private
-         * @function
-         * @name pc.Light#getColor
-         * @description Queries the diffuse color of the light. The PlayCanvas 'standard' shader uses this
-         * value by multiplying it by the diffuse color of a mesh's material and adding it to
-         * the total light contribution.
-         * @returns {pc.Color} The diffuse color of the light (RGB components ranging 0..1).
-         */
         getColor: function () {
             return this._color;
         },
 
-        /**
-         * @private
-         * @function
-         * @name pc.Light#getEnabled
-         * @description Queries whether the specified light is currently enabled.
-         * @returns {Boolean} true if the light is enabled and false otherwise.
-         */
-        getEnabled: function () {
-            return this._enabled;
-        },
-
-        /**
-         * @private
-         * @function
-         * @name pc.Light#getInnerConeAngle
-         * @description Queries the inner cone angle of the specified spot light. Note
-         * that this function is only valid for spotlights.
-         * @returns {Number} The inner cone angle of the specified light in degrees.
-         */
-        getInnerConeAngle: function () {
-            return this._innerConeAngle;
-        },
-
-        /**
-         * @private
-         * @function
-         * @name pc.Light#getIntensity
-         * @description Queries the intensity of the specified light.
-         * @returns {Number} The intensity of the specified light.
-         */
-        getIntensity: function () {
-            return this._intensity;
-        },
-
-        /**
-         * @private
-         * @function
-         * @name pc.Light#getOuterConeAngle
-         * @description Queries the outer cone angle of the specified spot light. Note
-         * that this function is only valid for spotlights.
-         * @returns {Number} The outer cone angle of the specified light in degrees.
-         */
-        getOuterConeAngle: function () {
-            return this._outerConeAngle;
-        },
-
-        /**
-         * @private
-         * @function
-         * @name pc.Light#getShadowBias
-         * @description Queries the shadow mapping depth bias for this light. Note
-         * that this function is only valid for directional lights and spotlights.
-         * @returns {Number} The shadow mapping depth bias.
-         */
-        getShadowBias: function () {
-            return this._shadowBias;
-        },
-
-        getNormalOffsetBias: function () {
-            return this._normalOffsetBias;
-        },
-
-        /**
-         * @private
-         * @function
-         * @name pc.Light#getShadowDistance
-         * @description Queries the distance in camera Z at which shadows will no
-         * longer be rendered. Note that this function is only valid for directional
-         * lights.
-         * @returns {Number} The shadow distance in world units.
-         */
-        getShadowDistance: function () {
-            return this._shadowDistance;
-        },
-
-        /**
-         * @private
-         * @function
-         * @name pc.Light#getShadowResolution
-         * @description Queries the shadow map pixel resolution for this light.
-         * @returns {Number} The shadow map resolution.
-         */
-        getShadowResolution: function () {
-            return this._shadowResolution;
-        },
-
-        /**
-         * @private
-         * @function
-         * @name pc.Light#getType
-         * @description Queries the type of the light. The light can be a directional light,
-         * a point light or a spotlight.
-         * @returns {pc.LightType} The type of the specified light.
-         */
-        getType: function () {
-            return this._type;
-        },
-
-        /**
-         * @private
-         * @function
-         * @name pc.Light#setAttenuationEnd
-         * @description Specifies the radius from the light position where the light's
-         * contribution falls to zero.
-         * @param {Number} radius The radius of influence of the light.
-         */
-        setAttenuationEnd: function (radius) {
-            this._attenuationEnd = radius;
-        },
-
-        /**
-         * @private
-         * @function
-         * @name pc.Light#setAttenuationStart
-         * @description Specifies the radius from the light position where the light
-         * contribution begins to attenuate.
-         * @param {Number} radius The radius at which the light begins to attenuate.
-         */
-        setAttenuationStart: function (radius) {
-            this._attenuationStart = radius;
-        },
-
-        setFalloffMode: function (mode) {
-            this._falloffMode = mode;
-            if (this._scene !== null) {
-                this._scene.updateShaders = true;
-            }
-            this.updateKey();
-        },
-
-        setShadowType: function (mode) {
-            var device = pc.Application.getApplication().graphicsDevice;
-
-            if (this._type===pc.LIGHTTYPE_POINT) {
-                mode = pc.SHADOW_DEPTH; // VSM for point lights is not supported yet
-            }
-
-            if (mode===pc.SHADOW_VSM32 && !device.extTextureFloatRenderable) {
-                mode = pc.SHADOW_VSM16;
-            }
-            if (mode===pc.SHADOW_VSM16 && !device.extTextureHalfFloatRenderable) {
-                mode = pc.SHADOW_VSM8;
-            }
-
-            this._shadowType = mode;
-            this._destroyShadowMap();
-            if (this._scene !== null) {
-                this._scene.updateShaders = true;
-            }
-            this.updateKey();
-        },
-
-        setVsmBlurSize: function (size) {
-            if (size % 2 === 0) size++; // don't allow even sizes
-            this._vsmBlurSize = size;
-        },
-
-        setVsmBlurMode: function (mode) {
-            this._vsmBlurMode = mode;
-        },
-
-        setVsmBias: function (mode) {
-            this._vsmBias = mode;
-        },
-
-        setCookie: function (tex) {
-            this._cookie = tex;
-            if (this._scene !== null) {
-                this._scene.updateShaders = true;
-            }
-            this.updateKey();
-        },
-
-        setCookieIntensity: function (value) {
-            this._cookieIntensity = value;
-        },
-
-        setCookieFalloff: function (value) {
-            this._cookieFalloff = value;
-            if (this._scene !== null) {
-                this._scene.updateShaders = true;
-            }
-            this.updateKey();
-        },
-
-        setCookieChannel: function (value) {
-            if (value.length < 3) {
-                var chr = value.charAt(value.length - 1);
-                var addLen = 3 - value.length;
-                for (var i = 0; i < addLen; i++) value += chr;
-            }
-            this._cookieChannel = value;
-            if (this._scene !== null) {
-                this._scene.updateShaders = true;
-            }
-            this.updateKey();
-        },
-
-        setCookieTransform: function (value) {
-            var xformOld = !!(this._cookieTransformSet || this._cookieOffsetSet);
-            var xformNew = !!(value || this._cookieOffsetSet);
-            if (xformOld!==xformNew) {
-                if (this._scene !== null) {
-                    this._scene.updateShaders = true;
-                }
-            }
-            this._cookieTransform = value;
-            this._cookieTransformSet = !!value;
-            if (value && !this._cookieOffset) {
-                this.setCookieOffset(new pc.Vec2()); // using transform forces using offset code
-                this._cookieOffsetSet = false;
-            }
-            this.updateKey();
-        },
-
-        setCookieOffset: function (value) {
-            var xformOld = !!(this._cookieTransformSet || this._cookieOffsetSet);
-            var xformNew = !!(this._cookieTransformSet || value);
-            if (xformOld!==xformNew) {
-                if (this._scene !== null) {
-                    this._scene.updateShaders = true;
-                }
-            }
-            if (xformNew && !value && this._cookieOffset) {
-                this._cookieOffset.set(0,0);
-            } else {
-                this._cookieOffset = value;
-            }
-            this._cookieOffsetSet = !!value;
-            if (value && !this._cookieTransform) {
-                this.setCookieTransform(new pc.Vec4(1,1,0,0)); // using offset forces using matrix code
-                this._cookieTransformSet = false;
-            }
-            this.updateKey();
-        },
-
-        setMask: function (_mask) {
-            this.mask = _mask;
-            if (this._scene !== null) {
-                this._scene.updateShaders = true;
-            }
-        },
-
         getBoundingSphere: function (sphere) {
             if (this._type===pc.LIGHTTYPE_SPOT) {
-                var range = this._attenuationEnd;
+                var range = this.attenuationEnd;
                 var angle = this._outerConeAngle;
                 var f = Math.cos(angle * pc.math.DEG_TO_RAD);
                 var node = this._node;
@@ -466,13 +143,13 @@ pc.extend(pc, function () {
 
             } else if (this._type===pc.LIGHTTYPE_POINT) {
                 sphere.center = this._node.getPosition();
-                sphere.radius = this._attenuationEnd;
+                sphere.radius = this.attenuationEnd;
             }
         },
 
         getBoundingBox: function (box) {
             if (this._type===pc.LIGHTTYPE_SPOT) {
-                var range = this._attenuationEnd;
+                var range = this.attenuationEnd;
                 var angle = this._outerConeAngle;
                 var node = this._node;
 
@@ -485,43 +162,10 @@ pc.extend(pc, function () {
 
             } else if (this._type===pc.LIGHTTYPE_POINT) {
                 box.center.copy(this._node.getPosition());
-                box.halfExtents.set(this._attenuationEnd, this._attenuationEnd, this._attenuationEnd);
+                box.halfExtents.set(this.attenuationEnd, this.attenuationEnd, this.attenuationEnd);
             }
         },
 
-        /**
-         * @private
-         * @function
-         * @name pc.Light#setCastShadows
-         * @description Toggles the casting of shadows from this light.
-         * @param {Boolean} castShadows True to enabled shadow casting, false otherwise.
-         */
-        setCastShadows: function (castShadows) {
-            this._castShadows = castShadows;
-            if (this._scene !== null) {
-                this._scene.updateShaders = true;
-            }
-            this.updateKey();
-        },
-
-        /**
-         * @private
-         * @function
-         * @name pc.Light#setColor
-         * @description Sets the RGB color of the light. RGB components should be
-         * specified in the range 0 to 1.
-         * @param {pc.Color} color The RGB color of the light.
-         */
-        /**
-         * @private
-         * @function
-         * @name pc.Light#setColor^2
-         * @description Sets the RGB color of the light. RGB components should be
-         * specified in the range 0 to 1.
-         * @param {Number} red The red component of the light color.
-         * @param {Number} green The green component of the light color.
-         * @param {Number} blue The blue component of the light color.
-         */
         setColor: function () {
             var r, g, b;
             if (arguments.length === 1) {
@@ -546,148 +190,6 @@ pc.extend(pc, function () {
                     this._linearFinalColor.data[c] = Math.pow(this._finalColor.data[c], 2.2);
                 }
             }
-        },
-
-        /**
-         * @private
-         * @function
-         * @name pc.Light#setEnabled
-         * @description Marks the specified light as enabled or disabled.
-         * @param {boolean} enable true to enable the light and false to disable it.
-         */
-        setEnabled: function (enable) {
-            if (this._enabled !== enable) {
-                this._enabled = enable;
-                if (this._scene !== null) {
-                    this._scene.updateShaders = true;
-                }
-            }
-        },
-
-        /**
-         * @private
-         * @function
-         * @name pc.Light#setInnerConeAngle
-         * @description Sets the inner cone angle of the light. Note that this
-         * function only affects spotlights. The contribution of the spotlight is
-         * zero outside the cone defined by this angle.
-         * @param {Number} angle The inner cone angle of the spotlight in degrees.
-         */
-        setInnerConeAngle: function (angle) {
-            this._innerConeAngle = angle;
-            this._innerConeAngleCos = Math.cos(angle * Math.PI / 180);
-        },
-
-        /**
-         * @private
-         * @function
-         * @name pc.Light#setIntensity
-         * @description Sets the intensity of the light. The intensity is used to
-         * scale the color of the light. Note that this makes it possible to take
-         * the light color's RGB components outside the range 0 to 1.
-         * @param {Number} intensity The intensity of the light.
-         */
-        setIntensity: function (intensity) {
-            this._intensity = intensity;
-
-            // Update final color
-            var c = this._color.data;
-            var r = c[0];
-            var g = c[1];
-            var b = c[2];
-            var i = this._intensity;
-            this._finalColor.set(r * i, g * i, b * i);
-            for(var j = 0; j < 3; j++) {
-                if (i >= 1) {
-                    this._linearFinalColor.data[j] = Math.pow(this._finalColor.data[j] / i, 2.2) * i;
-                } else {
-                    this._linearFinalColor.data[j] = Math.pow(this._finalColor.data[j], 2.2);
-                }
-            }
-        },
-
-        /**
-         * @private
-         * @function
-         * @name pc.Light#setOuterConeAngle
-         * @description Sets the outer cone angle of the light. Note that this
-         * function only affects spotlights. The contribution of the spotlight is
-         * zero outside the cone defined by this angle.
-         * @param {Number} angle The outer cone angle of the spotlight in degrees.
-         */
-        setOuterConeAngle: function (angle) {
-            this._outerConeAngle = angle;
-            this._outerConeAngleCos = Math.cos(angle * Math.PI / 180);
-        },
-
-        /**
-         * @private
-         * @function
-         * @name pc.Light#setShadowBias
-         * @description Sets the depth bias for tuning the appearance of the shadow
-         * mapping generated by this light.
-         * @param {Number} bias The shadow mapping depth bias (defaults to -0.0005)
-         */
-        setShadowBias: function (bias) {
-            this._shadowBias = bias;
-        },
-
-        setNormalOffsetBias: function (bias) {
-            if ((!this._normalOffsetBias && bias) || (this._normalOffsetBias && !bias)) {
-                if (this._scene !== null) {
-                    this._scene.updateShaders = true;
-                }
-                this.updateKey();
-            }
-            this._normalOffsetBias = bias;
-        },
-
-        /**
-         * @private
-         * @function
-         * @name pc.Light#setShadowDistance
-         * @description Sets the distance in camera Z at which the shadows cast by this
-         * light are no longer rendered. Note that this function only applies to directional
-         * lights.
-         * @param {Number} distance The shadow distance in world units
-         */
-        setShadowDistance: function (distance) {
-            this._shadowDistance = distance;
-        },
-
-        /**
-         * @private
-         * @function
-         * @name pc.Light#setShadowResolution
-         * @description Sets the pixel width and height of the shadow map associated with this
-         * light.
-         * @param {Number} resolution The pixel width and height of the shadow map
-         */
-        setShadowResolution: function (resolution) {
-            var device = pc.Application.getApplication().graphicsDevice;
-            if (this._type===pc.LIGHTTYPE_POINT) {
-                resolution = Math.min(resolution, device.maxCubeMapSize);
-            } else {
-                resolution = Math.min(resolution, device.maxTextureSize);
-            }
-            this._shadowResolution = resolution;
-        },
-
-        /**
-         * @private
-         * @function
-         * @name pc.Light#setType
-         * @description Sets the type of the light. Avialable lights types are directional,
-         * point and spot.
-         * @param {Number} type The light type (see pc.LIGHTTYPE).
-         */
-        setType: function (type) {
-            this._type = type;
-            this._destroyShadowMap();
-            if (this._scene !== null) {
-                this._scene.updateShaders = true;
-            }
-            this.updateKey();
         },
 
         _destroyShadowMap: function () {
@@ -753,6 +255,314 @@ pc.extend(pc, function () {
             this.key = key;
         }
     };
+
+    Object.defineProperty(Light.prototype, 'enabled', {
+        get: function() {
+            return this._type;
+        },
+        set: function(value) {
+            if (this._type === value)
+                return;
+
+            this._enabled = value;
+            if (this._scene !== null)
+                this._scene.updateShaders = true;
+        }
+    });
+
+    Object.defineProperty(Light.prototype, 'type', {
+        get: function() {
+            return this._type;
+        },
+        set: function(value) {
+            if (this._type === value)
+                return;
+
+            this._type = value;
+            this._destroyShadowMap();
+            if (this._scene !== null)
+                this._scene.updateShaders = true;
+            this.updateKey();
+        }
+    });
+
+    Object.defineProperty(Light.prototype, 'mask', {
+        get: function() {
+            return this._mask;
+        },
+        set: function(value) {
+            if (this._mask === value)
+                return;
+
+            this._mask = value;
+            if (this._scene !== null)
+                this._scene.updateShaders = true;
+        }
+    });
+
+    Object.defineProperty(Light.prototype, 'shadowType', {
+        get: function() {
+            return this._shadowType;
+        },
+        set: function(value) {
+            if (this._shadowType === value)
+                return;
+
+            var device = pc.Application.getApplication().graphicsDevice;
+
+            if (this._type === pc.LIGHTTYPE_POINT)
+                value = pc.SHADOW_DEPTH; // VSM for point lights is not supported yet
+
+            if (value === pc.SHADOW_VSM32 && ! device.extTextureFloatRenderable)
+                value = pc.SHADOW_VSM16;
+
+            if (value === pc.SHADOW_VSM16 && ! device.extTextureHalfFloatRenderable)
+                value = pc.SHADOW_VSM8;
+
+            this._shadowType = value;
+            this._destroyShadowMap();
+            if (this._scene !== null)
+                this._scene.updateShaders = true;
+            this.updateKey();
+        }
+    });
+
+    Object.defineProperty(Light.prototype, 'castShadows', {
+        get: function() {
+            return this._castShadows && this._mask !== pc.MASK_LIGHTMAP && this._mask !== 0;
+        },
+        set: function(value) {
+            if (this._castShadows === value)
+                return;
+
+            this._castShadows = value;
+            if (this._scene !== null)
+                this._scene.updateShaders = true;
+            this.updateKey();
+        }
+    });
+
+    Object.defineProperty(Light.prototype, 'shadowResolution', {
+        get: function() {
+            return this._shadowResolution;
+        },
+        set: function(value) {
+            if (this._shadowResolution === value)
+                return;
+
+            var device = pc.Application.getApplication().graphicsDevice;
+            if (this._type === pc.LIGHTTYPE_POINT) {
+                value = Math.min(value, device.maxCubeMapSize);
+            } else {
+                value = Math.min(value, device.maxTextureSize);
+            }
+            this._shadowResolution = value;
+        }
+    });
+
+
+
+    Object.defineProperty(Light.prototype, 'vsmBlurSize', {
+        get: function() {
+            return this._vsmBlurSize;
+        },
+        set: function(value) {
+            if (this._vsmBlurSize === value)
+                return;
+
+            if (value % 2 === 0) value++; // don't allow even size
+            this._vsmBlurSize = value;
+        }
+    });
+
+    Object.defineProperty(Light.prototype, 'normalOffsetBias', {
+        get: function() {
+            return this._normalOffsetBias;
+        },
+        set: function(value) {
+            if (this._normalOffsetBias === value)
+                return;
+
+            if ((! this._normalOffsetBias && value) || (this._normalOffsetBias && ! value)) {
+                if (this._scene !== null)
+                    this._scene.updateShaders = true;
+                this.updateKey();
+            }
+            this._normalOffsetBias = value;
+        }
+    });
+
+    Object.defineProperty(Light.prototype, 'falloffMode', {
+        get: function() {
+            return this._falloffMode;
+        },
+        set: function(value) {
+            if (this._falloffMode === value)
+                return;
+
+            this._falloffMode = value;
+            if (this._scene !== null)
+                this._scene.updateShaders = true;
+            this.updateKey();
+        }
+    });
+
+    Object.defineProperty(Light.prototype, 'innerConeAngle', {
+        get: function() {
+            return this._innerConeAngle;
+        },
+        set: function(value) {
+            if (this._innerConeAngle === value)
+                return;
+
+            this._innerConeAngle = value;
+            this._innerConeAngleCos = Math.cos(value * Math.PI / 180);
+        }
+    });
+
+    Object.defineProperty(Light.prototype, 'outerConeAngle', {
+        get: function() {
+            return this._outerConeAngle;
+        },
+        set: function(value) {
+            if (this._outerConeAngle === value)
+                return;
+
+            this._outerConeAngle = value;
+            this._outerConeAngleCos = Math.cos(value * Math.PI / 180);
+        }
+    });
+
+    Object.defineProperty(Light.prototype, 'intensity', {
+        get: function() {
+            return this._intensity;
+        },
+        set: function(value) {
+            if (this._intensity === value)
+                return;
+
+            this._intensity = value;
+
+            // Update final color
+            var c = this._color.data;
+            var r = c[0];
+            var g = c[1];
+            var b = c[2];
+            var i = this._intensity;
+            this._finalColor.set(r * i, g * i, b * i);
+            for(var j = 0; j < 3; j++) {
+                if (i >= 1) {
+                    this._linearFinalColor.data[j] = Math.pow(this._finalColor.data[j] / i, 2.2) * i;
+                } else {
+                    this._linearFinalColor.data[j] = Math.pow(this._finalColor.data[j], 2.2);
+                }
+            }
+        }
+    });
+
+    Object.defineProperty(Light.prototype, 'cookie', {
+        get: function() {
+            return this._cookie;
+        },
+        set: function(value) {
+            if (this._cookie === value)
+                return;
+
+            this._cookie = value;
+            if (this._scene !== null)
+                this._scene.updateShaders = true;
+            this.updateKey();
+        }
+    });
+
+    Object.defineProperty(Light.prototype, 'cookieFalloff', {
+        get: function() {
+            return this._cookieFalloff;
+        },
+        set: function(value) {
+            if (this._cookieFalloff === value)
+                return;
+
+            this._cookieFalloff = value;
+            if (this._scene !== null)
+                this._scene.updateShaders = true;
+            this.updateKey();
+        }
+    });
+
+    Object.defineProperty(Light.prototype, 'cookieChannel', {
+        get: function() {
+            return this._cookieChannel;
+        },
+        set: function(value) {
+            if (this._cookieChannel === value)
+                return;
+
+            if (value.length < 3) {
+                var chr = value.charAt(value.length - 1);
+                var addLen = 3 - value.length;
+                for (var i = 0; i < addLen; i++)
+                    value += chr;
+            }
+            this._cookieChannel = value;
+            if (this._scene !== null)
+                this._scene.updateShaders = true;
+            this.updateKey();
+        }
+    });
+
+    Object.defineProperty(Light.prototype, 'cookieTransform', {
+        get: function() {
+            return this._cookieTransform;
+        },
+        set: function(value) {
+            if (this._cookieTransform === value)
+                return;
+
+            var xformOld = !! (this._cookieTransformSet || this._cookieOffsetSet);
+            var xformNew = !! (value || this._cookieOffsetSet);
+            if (xformOld !== xformNew) {
+                if (this._scene !== null)
+                    this._scene.updateShaders = true;
+            }
+            this._cookieTransform = value;
+            this._cookieTransformSet = !! value;
+            if (value && ! this._cookieOffset) {
+                this.cookieOffset = new pc.Vec2(); // using transform forces using offset code
+                this._cookieOffsetSet = false;
+            }
+            this.updateKey();
+        }
+    });
+
+    Object.defineProperty(Light.prototype, 'cookieOffset', {
+        get: function() {
+            return this._cookieOffset;
+        },
+        set: function(value) {
+            if (this._cookieOffset === value)
+                return;
+
+            var xformOld = !! (this._cookieTransformSet || this._cookieOffsetSet);
+            var xformNew = !! (this._cookieTransformSet || value);
+            if (xformOld !== xformNew) {
+                if (this._scene !== null)
+                    this._scene.updateShaders = true;
+            }
+            if (xformNew && !value && this._cookieOffset) {
+                this._cookieOffset.set(0,0);
+            } else {
+                this._cookieOffset = value;
+            }
+            this._cookieOffsetSet = !! value;
+            if (value && ! this._cookieTransform) {
+                this.cookieTransform = new pc.Vec4(1,1,0,0); // using offset forces using matrix code
+                this._cookieTransformSet = false;
+            }
+            this.updateKey();
+        }
+    });
+
 
     return {
         Light: Light

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -598,10 +598,10 @@ pc.extend(pc, function () {
         for(var i=0; i<stats.lights; i++) {
             l = this._lights[i];
             if (l._enabled) {
-                if ((l.mask & pc.MASK_DYNAMIC) || (l.mask & pc.MASK_BAKED)) { // if affects dynamic or baked objects in real-time
+                if ((l._mask & pc.MASK_DYNAMIC) || (l._mask & pc.MASK_BAKED)) { // if affects dynamic or baked objects in real-time
                     stats.dynamicLights++;
                 }
-                if (l.mask & pc.MASK_LIGHTMAP) { // if baked into lightmaps
+                if (l._mask & pc.MASK_LIGHTMAP) { // if baked into lightmaps
                     stats.bakedLights++;
                 }
             }

--- a/src/scene/standard-material.js
+++ b/src/scene/standard-material.js
@@ -597,9 +597,9 @@ pc.extend(pc, function () {
             var i;
             for (i = 0; i < lights.length; i++) {
                 light = lights[i];
-                if (light.getEnabled()) {
-                    if (light.mask & mask) {
-                        if (light.getType()===lType) {
+                if (light._enabled) {
+                    if (light._mask & mask) {
+                        if (light._type===lType) {
                             if (lType!==pc.LIGHTTYPE_DIRECTIONAL) {
                                 if (light.isStatic) {
                                     continue;
@@ -614,7 +614,7 @@ pc.extend(pc, function () {
             if (staticLightList) {
                 for(i=0; i<staticLightList.length; i++) {
                     light = staticLightList[i];
-                    if (light.getType()===lType) {
+                    if (light._type===lType) {
                         lightsSorted.push(light);
                     }
                 }


### PR DESCRIPTION
Reduce unnecessary function calls in update loops and other places referencing pc.Light where it can simply access internal property.
As well rid off get/setWhatever and mostly use properties. Unfortunately `setColor` is overloaded to accept 1 or 3 arguments, this although can be changed too, so all fields are properties.