### PR TITLE
Some improvements to pc.VrManager

### DIFF
--- a/examples/webvr/index.html
+++ b/examples/webvr/index.html
@@ -106,7 +106,7 @@
             };
 
             app.mouse.on("mousedown", function () {
-                if (app.vr && app.vr.available) {
+                if (app.vr && app.vr.display) {
                     c.camera.enterVr(function (err) {
                         if (err) {console.error(err);}
                     });

--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -709,6 +709,7 @@ pc.extend(pc, function () {
             // Perform ComponentSystem update
             if (pc.script.legacy)
                 pc.ComponentSystem.fixedUpdate(1.0 / 60.0, this._inTools);
+
             pc.ComponentSystem.update(dt, this._inTools);
             pc.ComponentSystem.postUpdate(dt, this._inTools);
 

--- a/src/vr/vr-display.js
+++ b/src/vr/vr-display.js
@@ -66,7 +66,7 @@ pc.extend(pc, function () {
 
             if (display === self.display) {
                 self.presenting = (self.display && self.display.isPresenting);
-                self.fire("presentchange", self);
+                self.fire('presentchange', self);
             }
         };
         window.addEventListener('vrdisplaypresentchange', self._presentChange, false);
@@ -193,12 +193,12 @@ pc.extend(pc, function () {
         */
         requestPresent: function (callback) {
             if (!this.display) {
-                if (callback) callback("No VrDisplay to requestPresent");
+                if (callback) callback(new Error("No VrDisplay to requestPresent"));
                 return;
             }
 
             if (this.presenting) {
-                if (callback) callback("VrDisplay already presenting");
+                if (callback) callback(new Error("VrDisplay already presenting"));
                 return;
             }
 
@@ -218,18 +218,18 @@ pc.extend(pc, function () {
         */
         exitPresent: function (callback) {
             if (!this.display) {
-                if (callback) callback("No VrDisplay to exitPresent");
+                if (callback) callback(new Error("No VrDisplay to exitPresent"));
             }
 
             if (!this.presenting) {
-                if (callback) callback("VrDisplay not presenting");
+                if (callback) callback(new Error("VrDisplay not presenting"));
                 return;
             }
 
             this.display.exitPresent().then(function () {
                 if (callback) callback();
             }, function () {
-                if (callback) callback("exitPresent failed");
+                if (callback) callback(new Error("exitPresent failed"));
             });
         },
 

--- a/src/vr/vr-display.js
+++ b/src/vr/vr-display.js
@@ -7,6 +7,7 @@ pc.extend(pc, function () {
      * @description Represents a single Display for VR content. This could be a Head Mounted display that can present content on a separate screen
      * or a phone which can display content full screen on the same screen. This object contains the native `navigator.VRDisplay` object
      * from the WebVR API.
+     * @property {Number} id An identifier for this distinct VRDisplay
      * @property {VRDisplay} display The native VRDisplay object from the WebVR API
      * @property {Boolean} presenting True if this display is currently presenting VR content
      * @property {VRDisplayCapabilities} capabilities Returns the <a href="https://w3c.github.io/webvr/#interface-vrdisplaycapabilities" target="_blank">VRDisplayCapabilities</a> object from the VRDisplay.
@@ -18,6 +19,8 @@ pc.extend(pc, function () {
 
         this._app = app;
         this._device = app.graphicsDevice;
+
+        this.id = display.displayId;
 
         this._frameData = null;
         if (window.VRFrameData) {

--- a/src/vr/vr-manager.js
+++ b/src/vr/vr-manager.js
@@ -6,20 +6,23 @@ pc.extend(pc, function () {
      * @param {pc.Application} app The main application
      * @property {pc.VrDisplay[]} displays The list of {@link pc.VrDisplay}s that are attached to this device
      * @property {pc.VrDisplay} display The default {@link pc.VrDisplay} to be used. Usually the first in the `displays` list
+     * @property {Boolean} isSupported Reports whether this device supports the WebVR API
+     * @property {Boolean} usesPolyfill Reports whether this device supports the WebVR API using a polyfill
      */
     var VrManager = function (app) {
         pc.events.attach(this);
 
         var self = this;
 
-        this._polyfill = false;
-        // if required initialize webvr polyfill
-        if (window.InitializeWebVRPolyfill) {
-            window.InitializeWebVRPolyfill();
-            this._polyfill = true;
-        }
+        this.isSupported = VrManager.isSupported;
+        this.usesPolyfill = VrManager.usesPolyfill;
 
-        this.displays = [];
+        // if required initialize webvr polyfill
+        if (window.InitializeWebVRPolyfill)
+            window.InitializeWebVRPolyfill();
+
+        this._index = { }
+        this.displays = [ ];
         this.display = null; // primary display (usually the first in list)
 
         this._app = app;
@@ -27,71 +30,47 @@ pc.extend(pc, function () {
         // bind functions for event callbacks
         this._onDisplayConnect = this._onDisplayConnect.bind(this);
         this._onDisplayDisconnect = this._onDisplayDisconnect.bind(this);
-        this._onDisplayActivate = this._onDisplayActivate.bind(this);
-        this._onDisplayDeactivate = this._onDisplayDeactivate.bind(this);
-        this._onDisplayBlur = this._onDisplayBlur.bind(this);
-        this._onDisplayFocus = this._onDisplayFocus.bind(this);
 
         self._attach();
 
         this._getDisplays(function (err, displays) {
             if (err) {
                 // webvr not available
-                self.fire("error", err);
+                self.fire('error', err);
             } else {
-                self.displays = [];
-                for (var i = 0; i < displays.length; i++) {
-                    self.displays.push(new pc.VrDisplay(self._app, displays[i]));
-                }
-                if (self.displays.length) {
-                    self.display = self.displays[0];
-                } else {
-                    self.display = null;
-                }
-                self.fire("ready", self.displays);
+                for (var i = 0; i < displays.length; i++)
+                    self._addDisplay(displays[i]);
+
+                self.fire('ready', self.displays);
             }
         });
-
     };
 
     /**
-     * @function
-     * @name pc.VrManager.hasWebVr
+     * @property
+     * @name pc.VrManager.isSupported
      * @description Reports whether this device supports the WebVR API
      * @returns true if WebVR API is available
      */
-    VrManager.hasWebVr = function () {
-        return !!(navigator.getVRDisplays);
-    };
+    VrManager.isSupported = !! window.getVRDisplays;
 
     /**
-     * @function
-     * @name pc.VrManager.hasPolyfillWebVr
+     * @property
+     * @name pc.VrManager.usesPolyfill
      * @description Reports whether this device supports the WebVR API using a polyfill
      * @returns true if WebVR API is available using a polyfill
      */
-    VrManager.hasPolyfillWebVr = function () {
-        return !!(window.InitializeWebVRPolyfill);
-    };
+    VrManager.usesPolyfill = !! window.InitializeWebVRPolyfill;
 
     VrManager.prototype = {
-
         _attach: function () {
-            window.addEventListener("vrdisplayconnect", this._onDisplayConnect);
-            window.addEventListener("vrdisplaydisconnect", this._onDisplayDisconnect);
-            window.addEventListener("vrdisplayactivate", this._onDisplayActivate);
-            window.addEventListener("vrdisplaydeactivate", this._onDisplayDeactivate);
-            window.addEventListener("vrdisplayblur", this._onDisplayBlur);
-            window.addEventListener("vrdisplayfocus", this._onDisplayFocus);
+            window.addEventListener('vrdisplayconnect', this._onDisplayConnect);
+            window.addEventListener('vrdisplaydisconnect', this._onDisplayDisconnect);
         },
 
         _detach: function () {
-            window.removeEventListener("vrdisplayconnect", this._onDisplayConnect);
-            window.removeEventListener("vrdisplaydisconnect", this._onDisplayDisconnect);
-            window.removeEventListener("vrdisplayactivate", this._onDisplayActivate);
-            window.removeEventListener("vrdisplaydeactivate", this._onDisplayDeactivate);
-            window.removeEventListener("vrdisplayblur", this._onDisplayBlur);
-            window.removeEventListener("vrdisplayfocus", this._onDisplayFocus);
+            window.removeEventListener('vrdisplayconnect', this._onDisplayConnect);
+            window.removeEventListener('vrdisplaydisconnect', this._onDisplayDisconnect);
         },
 
         /**
@@ -108,7 +87,7 @@ pc.extend(pc, function () {
          * @name pc.VrManager#poll
          * @description Called once per frame to poll all attached displays
          */
-         poll: function () {
+        poll: function () {
             var l = this.displays.length;
             if (!l) return;
             for (var i = 0; i < l; i++) {
@@ -119,74 +98,55 @@ pc.extend(pc, function () {
         _getDisplays: function (callback) {
             var self = this;
             if (navigator.getVRDisplays) {
-                navigator.getVRDisplays().then(function (displays) {
+                navigator.getVRDisplays().then(function(displays) {
                     if (callback) callback(null, displays);
                 });
             } else {
-                if (callback) callback("WebVR not supported");
+                if (callback) callback(new Error('WebVR not supported'));
             }
         },
 
-        _getDisplayIndex: function(display) {
-            for (var i = 0; i < this.displays.length; i++) {
-                if (this.displays[i].display === display) {
-                    return i;
-                }
-            }
+        _addDisplay: function(vrDisplay) {
+            if (this._index[vrDisplay.displayId])
+                return;
 
-            return -1;
+            var display = new pc.VrDisplay(this._app, vrDisplay);
+            this._index[display.id] = display;
+            this.displays.push(display);
+
+            if (! this.display)
+                this.display = display;
+
+            this.fire('displayconnect', display);
         },
 
         _onDisplayConnect: function (e) {
-            var i = this._getDisplayIndex(e.display);
-            if (i < 0) {
-                var display = new pc.VrDisplay(this._app, e.display);
-                this.displays.push(e.display);
-                this.available = true;
-                if (this.displays.length === 1) {
-                    this.display = e.display;
-                }
-
-                this.fire("displayconnect", display);
-            }
+            this._addDisplay(e.display);
         },
 
         _onDisplayDisconnect: function (e) {
-            var i = this._getDisplayIndex(e.display);
-            if (i >= 0) {
-                this.fire("displaydisconnect", this.displays[i]);
+            var display = this._index[e.display.displayId];
+            if (! display)
+                return;
 
-                this.displays[i].destroy();
-                if (this.display === this.displays[i]) this.display = null;
-                this.displays.splice(i,1);
-                if (this.displays.length === 0) {
-                    this.available = false;
+            display.destroy();
+
+            delete this._index[display.id];
+
+            var ind = this.displays.indexOf(display);
+            this.displays.splice(ind, 1);
+
+            if (this.display === display) {
+                if (this.displays.length) {
+                    this.display = this.displays[0];
+                } else {
+                    this.display = null;
                 }
             }
-        },
 
-        _onDisplayActivate: function (e) {
-            // not supported
-        },
-
-        _onDisplayDeactivate: function (e) {
-            // not supported
-        },
-
-        _onDisplayBlur: function (e) {
-            // not supported
-        },
-
-        _onDisplayFocus: function (e) {
-            // not supported
+            this.fire('displaydisconnect', display);
         }
     };
-
-    Object.defineProperty(VrManager.prototype, "available", {
-        get: function () {
-            return !!this.displays.length;
-        }
-    });
 
     return {
         VrManager: VrManager


### PR DESCRIPTION
`available` property on `VrManager` is unnecessary as it is same as checking if `display` is not falsy.
`id` is exposed on `VrDisplay` to help identifying displays.
`hasWebVr` is renamed to `isSupported` to match with `is` convention around engine. And is mirrored on `VrManager` instances.
`hasPolyfillWebVr` is renamed to `usesPolyfill`.
Removed unused event listeners on VrManager.
`error` message now returns Error rather than String.
VrDisplay returned Error or String in different cases for callbacks, now only Error is returned.
Adding/Removing displays internally now uses `displayId` to remove array search.
Fixed `displayconnect` and `displaydisconnect` used to return native VRDisplay instead of pc.VrDisplay.
Fixed when multiple displays available, `displaydisconnect` could unset `device` property on VrManager even if there was available displays.