### PR TITLE
Texture mipmaps

### DIFF
--- a/src/graphics/device.js
+++ b/src/graphics/device.js
@@ -34,10 +34,10 @@ pc.extend(pc, function () {
         for (var i = 0; i < names.length; i++) {
             try {
                 context = canvas.getContext(names[i], options);
-            } catch(e) {}
-            if (context) {
+            } catch(e) { }
+
+            if (context)
                 break;
-            }
         }
         return context;
     };
@@ -106,18 +106,18 @@ pc.extend(pc, function () {
         var size = 0;
 
         for(var i=0; i<mips; i++) {
-            if (!tex._compressed) {
+            if (! tex._compressed) {
                 size += mipWidth * mipHeight * _pixelFormat2Size[tex._format];
-            } else if (tex._format===pc.PIXELFORMAT_ETC1) {
+            } else if (tex._format === pc.PIXELFORMAT_ETC1) {
                 size += Math.floor((mipWidth + 3) / 4) * Math.floor((mipHeight + 3) / 4) * 8;
-            } else if (tex._format===pc.PIXELFORMAT_PVRTC_2BPP_RGB_1 || tex._format===pc.PIXELFORMAT_PVRTC_2BPP_RGBA_1) {
+            } else if (tex._format === pc.PIXELFORMAT_PVRTC_2BPP_RGB_1 || tex._format === pc.PIXELFORMAT_PVRTC_2BPP_RGBA_1) {
                 size += Math.max(mipWidth, 16) * Math.max(mipHeight, 8) / 4;
-            } else if (tex._format===pc.PIXELFORMAT_PVRTC_4BPP_RGB_1 || tex._format===pc.PIXELFORMAT_PVRTC_4BPP_RGBA_1) {
+            } else if (tex._format === pc.PIXELFORMAT_PVRTC_4BPP_RGB_1 || tex._format === pc.PIXELFORMAT_PVRTC_4BPP_RGBA_1) {
                 size += Math.max(mipWidth, 8) * Math.max(mipHeight, 8) / 2;
             } else {
                 var DXT_BLOCK_WIDTH = 4;
                 var DXT_BLOCK_HEIGHT = 4;
-                var blockSize = tex._format===pc.PIXELFORMAT_DXT1? 8 : 16;
+                var blockSize = tex._format === pc.PIXELFORMAT_DXT1? 8 : 16;
                 var numBlocksAcross = Math.floor((mipWidth + DXT_BLOCK_WIDTH - 1) / DXT_BLOCK_WIDTH);
                 var numBlocksDown = Math.floor((mipHeight + DXT_BLOCK_HEIGHT - 1) / DXT_BLOCK_HEIGHT);
                 var numBlocks = numBlocksAcross * numBlocksDown;
@@ -199,17 +199,17 @@ pc.extend(pc, function () {
         this.canvas = canvas;
         this.shader = null;
         this.indexBuffer = null;
-        this.vertexBuffers = [];
-        this.vbOffsets = [];
+        this.vertexBuffers = [ ];
+        this.vbOffsets = [ ];
         this.precision = "highp";
         this._enableAutoInstancing = false;
         this.autoInstancingMaxObjects = 16384;
         this.attributesInvalidated = true;
         this.boundBuffer = null;
-        this.instancedAttribs = {};
-        this.enabledAttributes = {};
-        this.textureUnits = [];
-        this.commitFunction = {};
+        this.instancedAttribs = { };
+        this.enabledAttributes = { };
+        this.textureUnits = [ ];
+        this.commitFunction = { };
         this._maxPixelRatio = 1;
         // local width/height without pixelRatio applied
         this._width = 0;
@@ -217,18 +217,15 @@ pc.extend(pc, function () {
 
         this.updateClientRect();
 
-        if (!window.WebGLRenderingContext) {
+        if (! window.WebGLRenderingContext)
             throw new pc.UnsupportedBrowserError();
-        }
 
         // Retrieve the WebGL context
-        if (canvas) {
+        if (canvas)
             this.gl = _createContext(canvas, options);
-        }
 
-        if (!this.gl) {
+        if (! this.gl)
             throw new pc.ContextCreationError();
-        }
 
         var gl = this.gl;
 
@@ -241,12 +238,12 @@ pc.extend(pc, function () {
             canvas.addEventListener("webglcontextlost", _contextLostHandler, false);
             canvas.addEventListener("webglcontextrestored", _contextRestoredHandler, false);
 
-            this.canvas        = canvas;
-            this.shader        = null;
-            this.indexBuffer   = null;
-            this.vertexBuffers = [];
-            this.vbOffsets = [];
-            this.precision     = "highp";
+            this.canvas = canvas;
+            this.shader = null;
+            this.indexBuffer = null;
+            this.vertexBuffers = [ ];
+            this.vbOffsets = [ ];
+            this.precision = "highp";
 
             this.maxTextureSize = gl.getParameter(gl.MAX_TEXTURE_SIZE);
             this.maxCubeMapSize = gl.getParameter(gl.MAX_CUBE_MAP_TEXTURE_SIZE);
@@ -419,26 +416,20 @@ pc.extend(pc, function () {
 
             this.extDepthTexture = null; //gl.getExtension("WEBKIT_WEBGL_depth_texture");
             this.extStandardDerivatives = gl.getExtension("OES_standard_derivatives");
-            if (this.extStandardDerivatives) {
+            if (this.extStandardDerivatives)
                 gl.hint(this.extStandardDerivatives.FRAGMENT_SHADER_DERIVATIVE_HINT_OES, gl.NICEST);
-            }
 
             this.extTextureFilterAnisotropic = gl.getExtension('EXT_texture_filter_anisotropic');
-            if (!this.extTextureFilterAnisotropic) {
+            if (!this.extTextureFilterAnisotropic)
                 this.extTextureFilterAnisotropic = gl.getExtension('WEBKIT_EXT_texture_filter_anisotropic');
-            }
 
             this.extCompressedTextureS3TC = gl.getExtension('WEBGL_compressed_texture_s3tc');
-            if (!this.extCompressedTextureS3TC) {
+            if (!this.extCompressedTextureS3TC)
                 this.extCompressedTextureS3TC = gl.getExtension('WEBKIT_WEBGL_compressed_texture_s3tc');
-            }
 
-            if (this.extCompressedTextureS3TC) {
-                if (_isIE()) {
-                    // IE 11 can't use mip maps with S3TC
-                    this.extCompressedTextureS3TC = false;
-                }
-            }
+            // IE 11 can't use mip maps with S3TC
+            if (this.extCompressedTextureS3TC && _isIE())
+                this.extCompressedTextureS3TC = false;
 
             if (this.extCompressedTextureS3TC) {
                 var formats = gl.getParameter(gl.COMPRESSED_TEXTURE_FORMATS);
@@ -594,9 +585,8 @@ pc.extend(pc, function () {
             gl.enable(gl.SCISSOR_TEST);
 
             this.programLib = new pc.ProgramLibrary(this);
-            for (var generator in pc.programlib) {
+            for (var generator in pc.programlib)
                 this.programLib.register(generator, pc.programlib[generator]);
-            }
 
             // Calculate a estimate of the maximum number of bones that can be uploaded to the GPU
             // based on the number of available uniforms and the number of uniforms required for non-
@@ -865,11 +855,13 @@ pc.extend(pc, function () {
                         this.setTexture(colorBuffer, 0);
                     }
 
-                    gl.framebufferTexture2D(gl.FRAMEBUFFER,
-                                            gl.COLOR_ATTACHMENT0,
-                                            colorBuffer._cubemap ? gl.TEXTURE_CUBE_MAP_POSITIVE_X + target._face : gl.TEXTURE_2D,
-                                            colorBuffer._glTextureId,
-                                            0);
+                    gl.framebufferTexture2D(
+                        gl.FRAMEBUFFER,
+                        gl.COLOR_ATTACHMENT0,
+                        colorBuffer._cubemap ? gl.TEXTURE_CUBE_MAP_POSITIVE_X + target._face : gl.TEXTURE_2D,
+                        colorBuffer._glTextureId,
+                        0
+                    );
 
                     if (target._depth) {
                         if (!target._glDepthBuffer) {
@@ -1067,21 +1059,32 @@ pc.extend(pc, function () {
         uploadTexture: function (texture) {
             var gl = this.gl;
 
+            if (! texture._needsUpload && ((texture._needsMipmapsUpload && texture._mipmapsUploaded) || ! texture._pot))
+                return;
+
             var mipLevel = 0;
             var mipObject;
             var resMult;
 
-            while (texture._levels[mipLevel] || mipLevel === 0) { // Upload all existing mip levels. Initialize 0 mip anyway.
-                mipObject = texture._levels[mipLevel];
+            while (texture._levels[mipLevel] || mipLevel === 0) {
+                // Upload all existing mip levels. Initialize 0 mip anyway.
 
-                console.log('upload', mipLevel);
+                if (! texture._needsUpload && mipLevel === 0) {
+                    mipLevel++;
+                    continue;
+                } else if (mipLevel && (! texture._needsMipmapsUpload || ! texture._mipmaps)) {
+                    break;
+                }
+
+                mipObject = texture._levels[mipLevel];
 
                 if (mipLevel == 1 && ! texture._compressed) {
                     // We have more than one mip levels we want to assign, but we need all mips to make
                     // the texture complete. Therefore first generate all mip chain from 0, then assign custom mips.
                     gl.generateMipmap(texture._glTarget);
+                    texture._mipmapsUploaded = true;
 
-                    console.log('generateMipmap 1', mipLevel);
+                    if (texture.name) ('generateMipmap 1', mipLevel);
                 }
 
                 if (texture._cubemap) {
@@ -1108,12 +1111,14 @@ pc.extend(pc, function () {
                                 }
                             }
 
-                            gl.texImage2D(gl.TEXTURE_CUBE_MAP_POSITIVE_X + face,
-                                          mipLevel,
-                                          texture._glInternalFormat,
-                                          texture._glFormat,
-                                          texture._glPixelType,
-                                          src);
+                            gl.texImage2D(
+                                gl.TEXTURE_CUBE_MAP_POSITIVE_X + face,
+                                mipLevel,
+                                texture._glInternalFormat,
+                                texture._glFormat,
+                                texture._glPixelType,
+                                src
+                            );
                         }
                     } else {
                         // Upload the byte array
@@ -1124,23 +1129,27 @@ pc.extend(pc, function () {
 
                             var texData = mipObject[face];
                             if (texture._compressed) {
-                                gl.compressedTexImage2D(gl.TEXTURE_CUBE_MAP_POSITIVE_X + face,
-                                                        mipLevel,
-                                                        texture._glInternalFormat,
-                                                        Math.max(texture._width * resMult, 1),
-                                                        Math.max(texture._height * resMult, 1),
-                                                        0,
-                                                        texData);
+                                gl.compressedTexImage2D(
+                                    gl.TEXTURE_CUBE_MAP_POSITIVE_X + face,
+                                    mipLevel,
+                                    texture._glInternalFormat,
+                                    Math.max(texture._width * resMult, 1),
+                                    Math.max(texture._height * resMult, 1),
+                                    0,
+                                    texData
+                                );
                             } else {
-                                gl.texImage2D(gl.TEXTURE_CUBE_MAP_POSITIVE_X + face,
-                                              mipLevel,
-                                              texture._glInternalFormat,
-                                              Math.max(texture._width * resMult, 1),
-                                              Math.max(texture._height * resMult, 1),
-                                              0,
-                                              texture._glFormat,
-                                              texture._glPixelType,
-                                              texData);
+                                gl.texImage2D(
+                                    gl.TEXTURE_CUBE_MAP_POSITIVE_X + face,
+                                    mipLevel,
+                                    texture._glInternalFormat,
+                                    Math.max(texture._width * resMult, 1),
+                                    Math.max(texture._height * resMult, 1),
+                                    0,
+                                    texture._glFormat,
+                                    texture._glPixelType,
+                                    texData
+                                );
                             }
                         }
                     }
@@ -1160,53 +1169,68 @@ pc.extend(pc, function () {
                         // Upload the image, canvas or video
                         gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, true);
                         gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, false);
-                        gl.texImage2D(gl.TEXTURE_2D,
-                                      mipLevel,
-                                      texture._glInternalFormat,
-                                      texture._glFormat,
-                                      texture._glPixelType,
-                                      mipObject);
+                        gl.texImage2D(
+                            gl.TEXTURE_2D,
+                            mipLevel,
+                            texture._glInternalFormat,
+                            texture._glFormat,
+                            texture._glPixelType,
+                            mipObject
+                        );
                     } else {
                         // Upload the byte array
                         gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, false);
                         resMult = 1 / Math.pow(2, mipLevel);
                         if (texture._compressed) {
-                            gl.compressedTexImage2D(gl.TEXTURE_2D,
-                                                    mipLevel,
-                                                    texture._glInternalFormat,
-                                                    Math.max(texture._width * resMult, 1),
-                                                    Math.max(texture._height * resMult, 1),
-                                                    0,
-                                                    mipObject);
+                            gl.compressedTexImage2D(
+                                gl.TEXTURE_2D,
+                                mipLevel,
+                                texture._glInternalFormat,
+                                Math.max(texture._width * resMult, 1),
+                                Math.max(texture._height * resMult, 1),
+                                0,
+                                mipObject
+                            );
                         } else {
-                            gl.texImage2D(gl.TEXTURE_2D,
-                                          mipLevel,
-                                          texture._glInternalFormat,
-                                          Math.max(texture._width * resMult, 1),
-                                          Math.max(texture._height * resMult, 1),
-                                          0,
-                                          texture._glFormat,
-                                          texture._glPixelType,
-                                          mipObject);
+                            gl.texImage2D(
+                                gl.TEXTURE_2D,
+                                mipLevel,
+                                texture._glInternalFormat,
+                                Math.max(texture._width * resMult, 1),
+                                Math.max(texture._height * resMult, 1),
+                                0,
+                                texture._glFormat,
+                                texture._glPixelType,
+                                mipObject
+                            );
                         }
+                    }
+
+                    if (mipLevel === 0) {
+                        texture._mipmapsUploaded = false;
+                    } else {
+                        texture._mipmapsUploaded = true;
                     }
                 }
                 mipLevel++;
             }
 
-            if (texture._cubemap) {
-                for(var i = 0; i < 6; i++)
-                    texture._levelsUpdated[0][i] = false;
-            } else {
-                texture._levelsUpdated[0] = false;
+            if (texture._needsUpload) {
+                if (texture._cubemap) {
+                    for(var i = 0; i < 6; i++)
+                        texture._levelsUpdated[0][i] = false;
+                } else {
+                    texture._levelsUpdated[0] = false;
+                }
             }
 
-            if (! texture._compressed && texture._mipmaps && texture._pot && texture._levels.length === 1) {
+            if (! texture._compressed && texture._mipmaps && texture._needsMipmapsUpload && texture._pot && texture._levels.length === 1) {
                 gl.generateMipmap(texture._glTarget);
-                console.log('generateMipmap 2');
+                texture._mipmapsUploaded = true;
             }
 
             if (texture._gpuSize) this._vram.tex -= texture._gpuSize;
+
             texture._gpuSize = gpuTexSize(gl, texture);
             this._vram.tex += texture._gpuSize;
             // #ifdef PROFILER
@@ -1223,12 +1247,11 @@ pc.extend(pc, function () {
         setTexture: function (texture, textureUnit) {
             var gl = this.gl;
 
-            if (!texture._glTextureId) {
+            if (!texture._glTextureId)
                 this.initializeTexture(texture);
-            }
 
             var paramDirty = texture._minFilterDirty || texture._magFilterDirty ||
-                             texture._addressUDirty  || texture._addressVDirty  ||
+                             texture._addressUDirty || texture._addressVDirty ||
                              texture._anisotropyDirty;
 
             if ((this.textureUnits[textureUnit] !== texture) || paramDirty) {
@@ -1242,7 +1265,15 @@ pc.extend(pc, function () {
 
             if (paramDirty) {
                 if (texture._minFilterDirty) {
-                    gl.texParameteri(texture._glTarget, gl.TEXTURE_MIN_FILTER, this.glFilter[texture._minFilter]);
+                    var filter = texture._minFilter;
+                    if (! texture._pot || ! texture._mipmaps || texture._levels.length === 1) {
+                        if (filter === pc.FILTER_NEAREST_MIPMAP_NEAREST || filter === pc.FILTER_NEAREST_MIPMAP_LINEAR) {
+                            filter = pc.FILTER_NEAREST;
+                        } else if (filter === pc.FILTER_LINEAR_MIPMAP_NEAREST || filter === pc.FILTER_LINEAR_MIPMAP_LINEAR) {
+                            filter = pc.FILTER_LINEAR;
+                        }
+                    }
+                    gl.texParameteri(texture._glTarget, gl.TEXTURE_MIN_FILTER, this.glFilter[filter]);
                     texture._minFilterDirty = false;
                 }
                 if (texture._magFilterDirty) {
@@ -1250,28 +1281,24 @@ pc.extend(pc, function () {
                     texture._magFilterDirty = false;
                 }
                 if (texture._addressUDirty) {
-                    gl.texParameteri(texture._glTarget, gl.TEXTURE_WRAP_S, this.glAddress[texture._addressU]);
+                    gl.texParameteri(texture._glTarget, gl.TEXTURE_WRAP_S, this.glAddress[texture._pot ? texture._addressU : pc.ADDRESS_CLAMP_TO_EDGE]);
                     texture._addressUDirty = false;
                 }
                 if (texture._addressVDirty) {
-                    gl.texParameteri(texture._glTarget, gl.TEXTURE_WRAP_T, this.glAddress[texture._addressV]);
+                    gl.texParameteri(texture._glTarget, gl.TEXTURE_WRAP_T, this.glAddress[texture._pot ? texture._addressV : pc.ADDRESS_CLAMP_TO_EDGE]);
                     texture._addressVDirty = false;
                 }
                 if (texture._anisotropyDirty) {
                     var ext = this.extTextureFilterAnisotropic;
-                    if (ext) {
-                        var maxAnisotropy = this.maxAnisotropy;
-                        var anisotropy = texture.anisotropy;
-                        anisotropy = Math.min(anisotropy, maxAnisotropy);
-                        gl.texParameterf(texture._glTarget, ext.TEXTURE_MAX_ANISOTROPY_EXT, anisotropy);
-                    }
+                    if (ext) gl.texParameterf(texture._glTarget, ext.TEXTURE_MAX_ANISOTROPY_EXT, Math.max(1, Math.min(Math.round(texture._anisotropy), this.maxAnisotropy)));
                     texture._anisotropyDirty = false;
                 }
             }
 
-            if (texture._needsUpload) {
+            if (texture._needsUpload || texture._needsMipmapsUpload) {
                 this.uploadTexture(texture);
                 texture._needsUpload = false;
+                texture._needsMipmapsUpload = false;
             }
         },
 

--- a/src/graphics/paraboloid.js
+++ b/src/graphics/paraboloid.js
@@ -21,12 +21,8 @@ pc.extend(pc, (function () {
             format: format,
             width: size * 2,
             height: size,
-            autoMipmap: false
+            mipmaps: false
         });
-        tex.minFilter = pc.FILTER_LINEAR;
-        tex.magFilter = pc.FILTER_LINEAR;
-        tex.addressU = pc.ADDRESS_CLAMP_TO_EDGE;
-        tex.addressV = pc.ADDRESS_CLAMP_TO_EDGE;
 
         var targ = new pc.RenderTarget(device, tex, {
             depth: false
@@ -71,12 +67,8 @@ pc.extend(pc, (function () {
             format: sixCubemaps[0].format,
             width: size,
             height: size,
-            autoMipmap: false
+            mipmaps: false
         });
-        tex.minFilter = pc.FILTER_LINEAR;
-        tex.magFilter = pc.FILTER_LINEAR;
-        tex.addressU = pc.ADDRESS_CLAMP_TO_EDGE;
-        tex.addressV = pc.ADDRESS_CLAMP_TO_EDGE;
         var targ = new pc.RenderTarget(device, tex, {
             depth: false
         });
@@ -109,4 +101,3 @@ pc.extend(pc, (function () {
         generateDpAtlas: generateDpAtlas
     };
 }()));
-

--- a/src/graphics/prefilter-cubemap.js
+++ b/src/graphics/prefilter-cubemap.js
@@ -70,12 +70,8 @@ pc.extend(pc, (function () {
                 format: format,
                 width: size,
                 height: size,
-                autoMipmap: false
+                mipmaps: false
             });
-            nextCubemap.minFilter = pc.FILTER_LINEAR;
-            nextCubemap.magFilter = pc.FILTER_LINEAR;
-            nextCubemap.addressU = pc.ADDRESS_CLAMP_TO_EDGE;
-            nextCubemap.addressV = pc.ADDRESS_CLAMP_TO_EDGE;
             for(face=0; face<6; face++) {
                 targ = new pc.RenderTarget(device, nextCubemap, {
                     face: face,
@@ -107,12 +103,8 @@ pc.extend(pc, (function () {
                     format: format,
                     width: size,
                     height: size,
-                    autoMipmap: false
+                    mipmaps: false
                 });
-                nextCubemap.minFilter = pc.FILTER_LINEAR;
-                nextCubemap.magFilter = pc.FILTER_LINEAR;
-                nextCubemap.addressU = pc.ADDRESS_CLAMP_TO_EDGE;
-                nextCubemap.addressV = pc.ADDRESS_CLAMP_TO_EDGE;
                 for(face=0; face<6; face++) {
                     targ = new pc.RenderTarget(device, nextCubemap, {
                         face: face,
@@ -144,12 +136,8 @@ pc.extend(pc, (function () {
                 format: pc.PIXELFORMAT_R8_G8_B8_A8,
                 width: size,
                 height: size,
-                autoMipmap: false
+                mipmaps: false
             });
-            nextCubemap.minFilter = pc.FILTER_LINEAR;
-            nextCubemap.magFilter = pc.FILTER_LINEAR;
-            nextCubemap.addressU = pc.ADDRESS_CLAMP_TO_EDGE;
-            nextCubemap.addressV = pc.ADDRESS_CLAMP_TO_EDGE;
             for(face=0; face<6; face++) {
                 targ = new pc.RenderTarget(device, nextCubemap, {
                     face: face,
@@ -182,12 +170,8 @@ pc.extend(pc, (function () {
                         fixCubemapSeams: pass===1 || pass===3,
                         width: mipSize[i],
                         height: mipSize[i],
-                        autoMipmap: false
+                        mipmaps: false
                     });
-                    cmapsList[pass][i].minFilter = pc.FILTER_LINEAR;
-                    cmapsList[pass][i].magFilter = pc.FILTER_LINEAR;
-                    cmapsList[pass][i].addressU = pc.ADDRESS_CLAMP_TO_EDGE;
-                    cmapsList[pass][i].addressV = pc.ADDRESS_CLAMP_TO_EDGE;
                 }
             }
         }
@@ -247,16 +231,13 @@ pc.extend(pc, (function () {
                 format: format,
                 width: 128,
                 height: 128,
-                autoMipmap: false
+                addressU: pc.ADDRESS_CLAMP_TO_EDGE,
+                addressV: pc.ADDRESS_CLAMP_TO_EDGE
             });
-            for(i=0; i<6; i++) {
+            for(i=0; i<6; i++)
                 cubemap._levels[i] = mips[i]._levels[0];
-            }
-            cubemap.addressU = pc.ADDRESS_CLAMP_TO_EDGE;
-            cubemap.addressV = pc.ADDRESS_CLAMP_TO_EDGE;
+
             cubemap.upload();
-            cubemap.minFilter = pc.FILTER_LINEAR_MIPMAP_LINEAR;
-            cubemap.magFilter = pc.FILTER_LINEAR;
             cubemap._prefilteredMips = true;
             options.singleFilteredFixed = cubemap;
         }
@@ -278,16 +259,13 @@ pc.extend(pc, (function () {
                 format: pc.PIXELFORMAT_R8_G8_B8_A8,
                 width: 128,
                 height: 128,
-                autoMipmap: false
+                addressU: pc.ADDRESS_CLAMP_TO_EDGE,
+                addressV: pc.ADDRESS_CLAMP_TO_EDGE
             });
             for(i=0; i<6; i++) {
                 cubemap._levels[i] = mips[i]._levels[0];
             }
-            cubemap.addressU = pc.ADDRESS_CLAMP_TO_EDGE;
-            cubemap.addressV = pc.ADDRESS_CLAMP_TO_EDGE;
             cubemap.upload();
-            cubemap.minFilter = pc.FILTER_LINEAR_MIPMAP_LINEAR;
-            cubemap.magFilter = pc.FILTER_LINEAR;
             cubemap._prefilteredMips = true;
             options.singleFilteredFixedRgbm = cubemap;
         }
@@ -352,33 +330,25 @@ pc.extend(pc, (function () {
                 for(face=0; face<6; face++) {
                     var img = source._levels[0][face];
 
-                    var tex = new pc.gfx.Texture(device, {
+                    var tex = new pc.Texture(device, {
                         cubemap: false,
                         rgbm: false,
                         format: source.format,
                         width: cubeSize,
                         height: cubeSize,
-                        autoMipmap: false
+                        mipmaps: false
                     });
-                    tex.minFilter = pc.FILTER_NEAREST;
-                    tex.magFilter = pc.FILTER_NEAREST;
-                    tex.addressU = pc.ADDRESS_CLAMP_TO_EDGE;
-                    tex.addressV = pc.ADDRESS_CLAMP_TO_EDGE;
                     tex._levels[0] = img;
                     tex.upload();
 
-                    var tex2 = new pc.gfx.Texture(device, {
+                    var tex2 = new pc.Texture(device, {
                         cubemap: false,
                         rgbm: false,
                         format: source.format,
                         width: cubeSize,
                         height: cubeSize,
-                        autoMipmap: false
+                        mipmaps: false
                     });
-                    tex2.minFilter = pc.FILTER_NEAREST;
-                    tex2.magFilter = pc.FILTER_NEAREST;
-                    tex2.addressU = pc.ADDRESS_CLAMP_TO_EDGE;
-                    tex2.addressV = pc.ADDRESS_CLAMP_TO_EDGE;
 
                     var targ = new pc.RenderTarget(device, tex2, {
                         depth: false
@@ -514,4 +484,3 @@ pc.extend(pc, (function () {
         shFromCubemap: shFromCubemap
     };
 }()));
-

--- a/src/graphics/texture.js
+++ b/src/graphics/texture.js
@@ -104,7 +104,7 @@ pc.extend(pc, function () {
 
             this._minFilter = (options.minFilter !== undefined) ? options.minFilter : this._minFilter;
             this._magFilter = (options.magFilter !== undefined) ? options.magFilter : this._magFilter;
-            this._anisotropy = (options.anisotropy !== undefined) ? pc.math.clamp(options.anisotropy, 1, this.device.maxAnisotropy) : this._anisotropy;
+            this._anisotropy = (options.anisotropy !== undefined) ? options.anisotropy : this._anisotropy;
             this._addressU = (options.addressU !== undefined) ? options.addressU : this._addressU;
             this._addressV = (options.addressV !== undefined) ? options.addressV : this._addressV;
 
@@ -125,6 +125,8 @@ pc.extend(pc, function () {
         this._lockedLevel = -1;
 
         this._needsUpload = true;
+        this._needsMipmapsUpload = this._mipmaps;
+        this._mipmapsUploaded = false;
 
         this._minFilterDirty = true;
         this._magFilterDirty = true;
@@ -240,7 +242,12 @@ pc.extend(pc, function () {
     Object.defineProperty(Texture.prototype, 'mipmaps', {
         get: function() { return this._mipmaps; },
         set: function(v) {
-            this._mipmaps = v;
+            if (this._mipmaps !== v) {
+                this._mipmaps = v;
+                this._minFilterDirty = true;
+
+                if (v) this._needsMipmapsUpload = true;
+            }
         }
     });
 
@@ -551,6 +558,7 @@ pc.extend(pc, function () {
          */
         upload: function () {
             this._needsUpload = true;
+            this._needsMipmapsUpload = this._mipmaps;
         },
 
         getDds: function () {

--- a/src/math/vec2.js
+++ b/src/math/vec2.js
@@ -283,9 +283,9 @@ pc.extend(pc, (function () {
         /**
          * @function
          * @name pc.Vec2#scale
-         * @description Scales each dimension of the specified 2-dimensional vector by the supplied
+         * @description Scales each component of the specified 2-dimensional vector by the supplied
          * scalar value.
-         * @param {Number} scalar The value by which each vector dimension is multiplied.
+         * @param {Number} scalar The value by which each vector component is multiplied.
          * @returns {pc.Vec2} Self for chaining.
          * @example
          * var v = new pc.Vec2(2, 4);
@@ -312,8 +312,8 @@ pc.extend(pc, (function () {
          * @function
          * @name pc.Vec2#set
          * @description Sets the specified 2-dimensional vector to the supplied numerical values.
-         * @param {Number} x The value to set on the first dimension of the vector.
-         * @param {Number} y The value to set on the second dimension of the vector.
+         * @param {Number} x The value to set on the first component of the vector.
+         * @param {Number} y The value to set on the second component of the vector.
          * @example
          * var v = new pc.Vec2();
          * v.set(5, 10);

--- a/src/math/vec3.js
+++ b/src/math/vec3.js
@@ -358,7 +358,7 @@ pc.extend(pc, (function () {
          * @name pc.Vec3#scale
          * @description Scales each dimension of the specified 3-dimensional vector by the supplied
          * scalar value.
-         * @param {Number} scalar The value by which each vector dimension is multiplied.
+         * @param {Number} scalar The value by which each vector component is multiplied.
          * @returns {pc.Vec3} Self for chaining.
          * @example
          * var v = new pc.Vec3(2, 4, 8);
@@ -386,9 +386,9 @@ pc.extend(pc, (function () {
          * @function
          * @name pc.Vec3#set
          * @description Sets the specified 3-dimensional vector to the supplied numerical values.
-         * @param {Number} x The value to set on the first dimension of the vector.
-         * @param {Number} y The value to set on the second dimension of the vector.
-         * @param {Number} z The value to set on the third dimension of the vector.
+         * @param {Number} x The value to set on the first component of the vector.
+         * @param {Number} y The value to set on the second component of the vector.
+         * @param {Number} z The value to set on the third component of the vector.
          * @example
          * var v = new pc.Vec3();
          * v.set(5, 10, 20);
@@ -479,7 +479,7 @@ pc.extend(pc, (function () {
     /**
      * @name pc.Vec3#x
      * @type Number
-     * @description The first element of the vector.
+     * @description The first component of the vector.
      * @example
      * var vec = new pc.Vec3(10, 20, 30);
      *
@@ -501,7 +501,7 @@ pc.extend(pc, (function () {
     /**
      * @name pc.Vec3#y
      * @type Number
-     * @description The second element of the vector.
+     * @description The second component of the vector.
      * @example
      * var vec = new pc.Vec3(10, 20, 30);
      *
@@ -523,7 +523,7 @@ pc.extend(pc, (function () {
     /**
      * @name pc.Vec3#z
      * @type Number
-     * @description The third element of the vector.
+     * @description The third component of the vector.
      * @example
      * var vec = new pc.Vec3(10, 20, 30);
      *

--- a/src/resources/cubemap.js
+++ b/src/resources/cubemap.js
@@ -18,7 +18,7 @@ pc.extend(pc, function () {
                 assetCubeMap.resources[0] = new pc.Texture(this._device, {
                     format : pc.PIXELFORMAT_R8_G8_B8_A8,
                     cubemap: true,
-                    autoMipmap: true,
+                    mipmaps: true,
                     fixCubemapSeams: !! assetCubeMap._dds
                 });
 
@@ -59,26 +59,22 @@ pc.extend(pc, function () {
 
                 // set prefiltered textures
                 assetCubeMap._dds.fixCubemapSeams = true;
-                assetCubeMap._dds.autoMipmap = this._device.useTexCubeLod ? false : true;
-                assetCubeMap._dds.minFilter = this._device.useTexCubeLod ? pc.FILTER_LINEAR_MIPMAP_LINEAR : pc.FILTER_LINEAR;
-                assetCubeMap._dds.magFilter = pc.FILTER_LINEAR;
+                assetCubeMap._dds.mipmaps = this._device.useTexCubeLod ? false : true;
                 assetCubeMap._dds.addressU = pc.ADDRESS_CLAMP_TO_EDGE;
                 assetCubeMap._dds.addressV = pc.ADDRESS_CLAMP_TO_EDGE;
                 assetCubeMap.resources.push(assetCubeMap._dds);
 
                 for (var i = 1; i < 6; i++) {
                     // create a cubemap for each mip in the prefiltered cubemap
-                    var mip = new pc.gfx.Texture(this._device, {
+                    var mip = new pc.Texture(this._device, {
                         cubemap: true,
                         fixCubemapSeams: true,
-                        autoMipmap: true,
+                        mipmaps: false,
                         format: assetCubeMap._dds.format,
                         rgbm: assetCubeMap._dds.rgbm,
                         width: Math.pow(2, 7 - i),
                         height: Math.pow(2, 7 - i)
                     });
-                    mip.addressU = pc.ADDRESS_CLAMP_TO_EDGE;
-                    mip.addressV = pc.ADDRESS_CLAMP_TO_EDGE;
 
                     mip._levels[0] = assetCubeMap._dds._levels[i];
                     mip.upload();

--- a/src/resources/texture.js
+++ b/src/resources/texture.js
@@ -188,9 +188,6 @@ pc.extend(pc, function () {
                     }
                 }
 
-                // var requiredMips = Math.round(Math.log2(Math.max(width, height)) + 1);
-                // var cantLoad = !format || (mips !== requiredMips && compressed);
-
                 if (! format) {
                     // #ifdef DEBUG
                     console.error("This DDS pixel format is currently unsupported. Empty texture will be created instead.");

--- a/src/resources/texture.js
+++ b/src/resources/texture.js
@@ -188,16 +188,13 @@ pc.extend(pc, function () {
                     }
                 }
 
-                var requiredMips = Math.round(Math.log2(Math.max(width, height)) + 1);
-                var cantLoad = !format || (mips !== requiredMips && compressed);
+                // var requiredMips = Math.round(Math.log2(Math.max(width, height)) + 1);
+                // var cantLoad = !format || (mips !== requiredMips && compressed);
 
-                if (cantLoad) {
-                    var errEnd = ". Empty texture will be created instead.";
-                    if (!format) {
-                        console.error("This DDS pixel format is currently unsupported" + errEnd);
-                    } else {
-                        console.error("DDS has " + mips + " mips, but engine requires " + requiredMips + " for DXT format. " + errEnd);
-                    }
+                if (! format) {
+                    // #ifdef DEBUG
+                    console.error("This DDS pixel format is currently unsupported. Empty texture will be created instead.");
+                    // #endif
                     texture = new pc.Texture(this._device, {
                         width: 4,
                         height: 4,
@@ -287,6 +284,9 @@ pc.extend(pc, function () {
 
             if (asset.data.hasOwnProperty('addressv') && texture.addressV !== JSON_ADDRESS_MODE[asset.data.addressv])
                 texture.addressV = JSON_ADDRESS_MODE[asset.data.addressv];
+
+            if (asset.data.hasOwnProperty('mipmaps') && texture.mipmaps !== asset.data.mipmaps)
+                texture.mipmaps = asset.data.mipmaps;
 
             if (asset.data.hasOwnProperty('anisotropy') && texture.anisotropy !== asset.data.anisotropy)
                 texture.anisotropy = asset.data.anisotropy;

--- a/src/scene/forward-renderer.js
+++ b/src/scene/forward-renderer.js
@@ -354,18 +354,20 @@ pc.extend(pc, function () {
     }
 
     function getShadowFiltering(device, shadowType) {
-        if (shadowType===pc.SHADOW_DEPTH) {
+        if (shadowType === pc.SHADOW_DEPTH) {
             return pc.FILTER_NEAREST;
-        } else if (shadowType===pc.SHADOW_VSM32) {
-            return device.extTextureFloatLinear? pc.FILTER_LINEAR : pc.FILTER_NEAREST;
-        } else if (shadowType===pc.SHADOW_VSM16) {
-            return device.extTextureHalfFloatLinear? pc.FILTER_LINEAR : pc.FILTER_NEAREST;
+        } else if (shadowType === pc.SHADOW_VSM32) {
+            return device.extTextureFloatLinear ? pc.FILTER_LINEAR : pc.FILTER_NEAREST;
+        } else if (shadowType === pc.SHADOW_VSM16) {
+            return device.extTextureHalfFloatLinear ? pc.FILTER_LINEAR : pc.FILTER_NEAREST;
         }
         return pc.FILTER_LINEAR;
     }
 
     function createShadowMap(device, width, height, shadowType) {
         var format = getShadowFormat(shadowType);
+        var filter = getShadowFiltering(device, shadowType);
+
         var shadowMap = new pc.Texture(device, {
             // #ifdef PROFILER
             profilerHint: pc.TEXHINT_SHADOWMAP,
@@ -373,13 +375,11 @@ pc.extend(pc, function () {
             format: format,
             width: width,
             height: height,
-            autoMipmap: false
+            mipmaps: false,
+            minFilter: filter,
+            magFilter: filter
         });
-        var filter = getShadowFiltering(device, shadowType);
-        shadowMap.minFilter = filter;
-        shadowMap.magFilter = filter;
-        shadowMap.addressU = pc.ADDRESS_CLAMP_TO_EDGE;
-        shadowMap.addressV = pc.ADDRESS_CLAMP_TO_EDGE;
+
         return new pc.RenderTarget(device, shadowMap, true);
     }
 
@@ -392,13 +392,12 @@ pc.extend(pc, function () {
             width: size,
             height: size,
             cubemap: true,
-            autoMipmap: false
+            mipmaps: false,
+            minFilter: pc.FILTER_NEAREST,
+            magFilter: pc.FILTER_NEAREST
         });
-        cubemap.minFilter = pc.FILTER_NEAREST;
-        cubemap.magFilter = pc.FILTER_NEAREST;
-        cubemap.addressU = pc.ADDRESS_CLAMP_TO_EDGE;
-        cubemap.addressV = pc.ADDRESS_CLAMP_TO_EDGE;
-        var targets = [];
+
+        var targets = [ ];
         for (var i = 0; i < 6; i++) {
             var target = new pc.RenderTarget(device, cubemap, {
                 face: i,

--- a/src/scene/lightmapper.js
+++ b/src/scene/lightmapper.js
@@ -262,35 +262,35 @@ pc.extend(pc, function () {
                 texSize.push(size);
                 for(pass=0; pass<passCount; pass++) {
                     tex = new pc.Texture(device, {
-                                                  // #ifdef PROFILER
-                                                  profilerHint: pc.TEXHINT_LIGHTMAP,
-                                                  // #endif
-                                                  width:size,
-                                                  height:size,
-                                                  format:pc.PIXELFORMAT_R8_G8_B8_A8,
-                                                  autoMipmap:false,
-                                                  rgbm:(pass===PASS_COLOR)});
-                    tex.addressU = pc.ADDRESS_CLAMP_TO_EDGE;
-                    tex.addressV = pc.ADDRESS_CLAMP_TO_EDGE;
-                    tex._minFilter = pc.FILTER_NEAREST;
-                    tex._magFilter = pc.FILTER_NEAREST
+                        // #ifdef PROFILER
+                        profilerHint: pc.TEXHINT_LIGHTMAP,
+                        // #endif
+                        width: size,
+                        height: size,
+                        format: pc.PIXELFORMAT_R8_G8_B8_A8,
+                        mipmaps: false,
+                        rgbm: (pass === PASS_COLOR),
+                        minFilter: pc.FILTER_NEAREST,
+                        magFilter: pc.FILTER_NEAREST
+                    });
+
                     lmaps[pass].push(tex);
                 }
 
                 if (!texPool[size]) {
                     var tex2 = new pc.Texture(device, {
-                                              // #ifdef PROFILER
-                                              profilerHint: pc.TEXHINT_LIGHTMAP,
-                                              // #endif
-                                              width:size,
-                                              height:size,
-                                              format:pc.PIXELFORMAT_R8_G8_B8_A8,
-                                              autoMipmap:false,
-                                              rgbm:true});
-                    tex2.addressU = pc.ADDRESS_CLAMP_TO_EDGE;
-                    tex2.addressV = pc.ADDRESS_CLAMP_TO_EDGE;
-                    tex2._minFilter = pc.FILTER_NEAREST;
-                    tex2._magFilter = pc.FILTER_NEAREST;
+                        // #ifdef PROFILER
+                        profilerHint: pc.TEXHINT_LIGHTMAP,
+                        // #endif
+                        width: size,
+                        height: size,
+                        format: pc.PIXELFORMAT_R8_G8_B8_A8,
+                        mipmaps: false,
+                        rgbm: true,
+                        minFilter: pc.FILTER_NEAREST,
+                        magFilter: pc.FILTER_NEAREST
+                    });
+                    
                     var targ2 = new pc.RenderTarget(device, tex2, {
                         depth: false
                     });

--- a/src/scene/particle-emitter.js
+++ b/src/scene/particle-emitter.js
@@ -9,26 +9,24 @@ pc.extend(pc, function() {
 
     var _createTexture = function(device, width, height, pixelData, format, mult8Bit, filter) {
         if (!format) format = pc.PIXELFORMAT_RGBA32F;
+
+        var mipFilter = pc.FILTER_NEAREST;
+        if (filter && format === pc.PIXELFORMAT_R8_G8_B8_A8)
+            mipFilter = pc.FILTER_LINEAR;
+
         var texture = new pc.Texture(device, {
             width: width,
             height: height,
             format: format,
             cubemap: false,
-            autoMipmap: false
+            mipmaps: false,
+            minFilter: mipFilter,
+            magFilter: mipFilter
         });
-        texture.addressU = pc.ADDRESS_CLAMP_TO_EDGE;
-        texture.addressV = pc.ADDRESS_CLAMP_TO_EDGE;
-        texture.minFilter = pc.FILTER_NEAREST;
-        texture.magFilter = pc.FILTER_NEAREST;
 
         var pixels = texture.lock();
 
-        if (format == pc.PIXELFORMAT_R8_G8_B8_A8) {
-            if (filter) {
-                texture.minFilter = pc.FILTER_LINEAR;
-                texture.magFilter = pc.FILTER_LINEAR;
-            }
-
+        if (format === pc.PIXELFORMAT_R8_G8_B8_A8) {
             var temp = new Uint8Array(pixelData.length);
             for (var i = 0; i < pixelData.length; i++) {
                 temp[i] = pixelData[i] * mult8Bit * 255;

--- a/src/scene/pick.js
+++ b/src/scene/pick.js
@@ -242,12 +242,10 @@ pc.extend(pc, function () {
             format: pc.PIXELFORMAT_R8_G8_B8_A8,
             width: width,
             height: height,
-            autoMipmap: false
+            mipmaps: false,
+            minFilter: pc.FILTER_NEAREST,
+            magFilter: pc.FILTER_NEAREST
         });
-        colorBuffer.minFilter = pc.FILTER_NEAREST;
-        colorBuffer.magFilter = pc.FILTER_NEAREST;
-        colorBuffer.addressU = pc.ADDRESS_CLAMP_TO_EDGE;
-        colorBuffer.addressV = pc.ADDRESS_CLAMP_TO_EDGE;
         this._pickBufferTarget = new pc.RenderTarget(this.device, colorBuffer, { depth: true });
     };
 

--- a/src/scene/skin.js
+++ b/src/scene/skin.js
@@ -62,10 +62,10 @@ pc.extend(pc, function () {
                 width: size,
                 height: size,
                 format: pc.PIXELFORMAT_RGBA32F,
-                autoMipmap: false
+                mipmaps: false,
+                minFilter: pc.FILTER_NEAREST,
+                magFilter: pc.FILTER_NEAREST
             });
-            this.boneTexture.minFilter = pc.FILTER_NEAREST;
-            this.boneTexture.magFilter = pc.FILTER_NEAREST;
             this.matrixPalette = this.boneTexture.lock();
         } else {
             this.matrixPalette = new Float32Array(numBones * 16);


### PR DESCRIPTION
Refactored pc.Texture, now `minFilter`, `magFilter`, `addressU`, `addressV` and `anisotropy` are not changed to consumable by device values on set. They will stay what user has set.
Then when applied on device, sensible value will be set.

Deprecated `autoMipmap` property on texture, and changed it to `mipmaps` property.
It is backwards compatible with `autoMipmap` logic, but additionally it now allows to disable mipmaps by simply setting it to `false`.
If texture has `mipmaps` as false, then mips wont be auto-generated nor uploaded when provided by other means, such as for compressed textures.
This flag can be switched on demand. Having it disabled does saves up to 30% of VRAM on textures.
One of good use cases - lightmaps, as they rarely need mips.