### PR TITLE
avoid use of 'arguments' to minimise chance of JS function deoptimisations

### DIFF
--- a/src/core/color.js
+++ b/src/core/color.js
@@ -12,23 +12,16 @@ pc.extend(pc, (function () {
     * @property {Number} b The blue component of the color
     * @property {Number} a The alpha component of the color
     */
-    var Color = function () {
+    var Color = function (r, g, b, a) {
         this.buffer = new ArrayBuffer(4 * 4);
 
         this.data = new Float32Array(this.buffer, 0, 4);
         this.data3 = new Float32Array(this.buffer, 0, 3);
 
-        if (arguments.length >= 3) {
-            this.data[0] = arguments[0];
-            this.data[1] = arguments[1];
-            this.data[2] = arguments[2];
-            this.data[3] = (arguments.length >= 4) ? arguments[3] : 1;
-        } else {
-            this.data[0] = 0;
-            this.data[1] = 0;
-            this.data[2] = 0;
-            this.data[3] = 1;
-        }
+        this.data[0] = r || 0;
+        this.data[1] = g || 0;
+        this.data[2] = b || 0;
+        this.data[3] = a !== undefined ? a : 1.0;
     };
 
     Color.prototype = {

--- a/src/core/events.js
+++ b/src/core/events.js
@@ -131,7 +131,7 @@ pc.events = function () {
          * });
          * o.fire('event_name', 'This is the message');
          */
-        fire: function (name) {
+        fire: function (name, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) {
             var index;
             var length;
             var args;
@@ -144,7 +144,7 @@ pc.events = function () {
                     var originalIndex = 0;
                     for(index = 0; index < length; ++index) {
                         var scope = callbacks[index].scope;
-                        callbacks[index].callback.call(scope, arguments[1], arguments[2], arguments[3], arguments[4], arguments[5], arguments[6], arguments[7], arguments[8]);
+                        callbacks[index].callback.call(scope, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
                         if (callbacks[index].callback.once) {
                             this._callbacks[name].splice(originalIndex, 1);
                         } else {

--- a/src/core/inheritance.js
+++ b/src/core/inheritance.js
@@ -11,8 +11,7 @@
  * @param {Object} Super
  */
 Function.prototype.extendsFrom = function (Super) {
-    var Self;
-    var Func;
+    var Self, Func;
 	var Temp = function () {};
 
 	Self = this;
@@ -57,9 +56,9 @@ pc.extend(pc, function () {
          */
         inherits: function (Self, Super) {
             var Temp = function () {};
-            var Func = function () {
-                Super.apply(this, arguments);
-                Self.apply(this, arguments);
+            var Func = function (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) {
+                Super.call(this, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
+                Self.call(this, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
                 // this.constructor = Self;
             };
             Func._super = Super.prototype;

--- a/src/framework/components/camera/component.js
+++ b/src/framework/components/camera/component.js
@@ -324,7 +324,7 @@ pc.extend(pc, function () {
         * });
         */
         enterVr: function (display, callback) {
-            if (arguments.length === 1) {
+            if ((display instanceof Function) && ! callback) {
                 callback = display;
                 display = null;
             }

--- a/src/framework/components/element/component.js
+++ b/src/framework/components/element/component.js
@@ -88,11 +88,11 @@ pc.extend(pc, function () {
             var position = new pc.Vec3();
             var invParentWtm = new pc.Mat4();
 
-            return function () {
-                if (arguments.length === 1) {
-                    position.copy(arguments[0]);
+            return function (x, y, z) {
+                if (x instanceof pc.Vec3) {
+                    position.copy(x);
                 } else {
-                    position.set(arguments[0], arguments[1], arguments[2]);
+                    position.set(x, y, z);
                 }
 
                 if (this._parent === null || this._parent && !this._parent.element) {
@@ -537,4 +537,3 @@ pc.extend(pc, function () {
         ElementComponent: ElementComponent
     };
 }());
-

--- a/src/math/mat3.js
+++ b/src/math/mat3.js
@@ -1,16 +1,26 @@
 pc.extend(pc, (function () {
     'use strict';
 
+    var typeNumber = 'number';
+
     /**
     * @name pc.Mat3
     * @class A 3x3 matrix.
     * @description Creates a new Mat3 object
     */
-    var Mat3 = function () {
+    var Mat3 = function (v0, v1, v2, v3, v4, v5, v6, v7, v8) {
         this.data = new Float32Array(9);
 
-        if (arguments.length === 9) {
-            this.data.set(arguments);
+        if (typeof(v0) === typeNumber) {
+            this.data[0] = v0;
+            this.data[1] = v1;
+            this.data[2] = v2;
+            this.data[3] = v3;
+            this.data[4] = v4;
+            this.data[5] = v5;
+            this.data[6] = v6;
+            this.data[7] = v7;
+            this.data[8] = v8;
         } else {
             this.setIdentity();
         }

--- a/src/math/mat4.js
+++ b/src/math/mat4.js
@@ -1,16 +1,33 @@
 pc.extend(pc, (function () {
     'use strict';
 
+    var typeNumber = 'number';
+
     /**
     * @name pc.Mat4
     * @class A 4x4 matrix.
     * @description Creates a new Mat4 object
     */
-    var Mat4 = function () {
+    var Mat4 = function (v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15) {
         this.data = new Float32Array(16);
 
-        if (arguments.length === 16) {
-            this.data.set(arguments);
+        if (typeof(v0) === typeNumber) {
+            this.data[0] = v0;
+            this.data[1] = v1;
+            this.data[2] = v2;
+            this.data[3] = v3;
+            this.data[4] = v4;
+            this.data[5] = v5;
+            this.data[6] = v6;
+            this.data[7] = v7;
+            this.data[8] = v8;
+            this.data[9] = v9;
+            this.data[10] = v10;
+            this.data[11] = v11;
+            this.data[12] = v12;
+            this.data[13] = v13;
+            this.data[14] = v14;
+            this.data[15] = v15;
         } else {
             this.setIdentity();
         }

--- a/src/math/vec3.js
+++ b/src/math/vec3.js
@@ -11,16 +11,12 @@ pc.extend(pc, (function () {
     * @example
     * var v = new pc.Vec3(1,2,3);
     */
-    var Vec3 = function () {
+    var Vec3 = function(x, y, z) {
         this.data = new Float32Array(3);
 
-        if (arguments.length === 3) {
-            this.data.set(arguments);
-        } else {
-            this.data[0] = 0;
-            this.data[1] = 0;
-            this.data[2] = 0;
-        }
+        this.data[0] = x || 0;
+        this.data[1] = y || 0;
+        this.data[2] = z || 0;
     };
 
     Vec3.prototype = {

--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -741,22 +741,12 @@ pc.extend(pc, function () {
          * var angles = new pc.Vec3(0, 90, 0);
          * this.entity.setLocalEulerAngles(angles); // Set rotation of 90 degress around y-axis.
          */
-        setLocalEulerAngles: function () {
-            var ex, ey, ez;
-            switch (arguments.length) {
-                case 1:
-                    ex = arguments[0].x;
-                    ey = arguments[0].y;
-                    ez = arguments[0].z;
-                    break;
-                case 3:
-                    ex = arguments[0];
-                    ey = arguments[1];
-                    ez = arguments[2];
-                    break;
+        setLocalEulerAngles: function (x, y, z) {
+            if (x instanceof pc.Vec3) {
+                this.localRotation.setFromEulerAngles(x.data[0], x.data[1], x.data[2]);
+            } else {
+                this.localRotation.setFromEulerAngles(x, y, z);
             }
-
-            this.localRotation.setFromEulerAngles(ex, ey, ez);
             this.dirtyLocal = true;
         },
 
@@ -779,11 +769,11 @@ pc.extend(pc, function () {
          * var pos = new pc.Vec3(0, 10, 0);
          * this.entity.setLocalPosition(pos)
          */
-        setLocalPosition: function () {
-            if (arguments.length === 1) {
-                this.localPosition.copy(arguments[0]);
+        setLocalPosition: function (x, y, z) {
+            if (x instanceof pc.Vec3) {
+                this.localPosition.copy(x);
             } else {
-                this.localPosition.set(arguments[0], arguments[1], arguments[2]);
+                this.localPosition.set(x, y, z);
             }
             this.dirtyLocal = true;
         },
@@ -808,11 +798,11 @@ pc.extend(pc, function () {
          * // Set to the identity quaternion
          * this.entity.setLocalRotation(0, 0, 0, 1);
          */
-        setLocalRotation: function (q) {
-            if (arguments.length === 1) {
-                this.localRotation.copy(arguments[0]);
+        setLocalRotation: function (x, y, z, w) {
+            if (x instanceof pc.Quat) {
+                this.localRotation.copy(x);
             } else {
-                this.localRotation.set(arguments[0], arguments[1], arguments[2], arguments[3]);
+                this.localRotation.set(x, y, z, w);
             }
             this.dirtyLocal = true;
         },
@@ -836,11 +826,11 @@ pc.extend(pc, function () {
          * var scale = new pc.Vec3(10, 10, 10);
          * this.entity.setLocalScale(scale);
          */
-        setLocalScale: function () {
-            if (arguments.length === 1) {
-                this.localScale.copy(arguments[0]);
+        setLocalScale: function (x, y, z) {
+            if (x instanceof pc.Vec3) {
+                this.localScale.copy(x);
             } else {
-                this.localScale.set(arguments[0], arguments[1], arguments[2]);
+                this.localScale.set(x, y, z);
             }
             this.dirtyLocal = true;
         },
@@ -882,11 +872,11 @@ pc.extend(pc, function () {
             var position = new pc.Vec3();
             var invParentWtm = new pc.Mat4();
 
-            return function () {
-                if (arguments.length === 1) {
-                    position.copy(arguments[0]);
+            return function (x, y, z) {
+                if (x instanceof pc.Vec3) {
+                    position.copy(x);
                 } else {
-                    position.set(arguments[0], arguments[1], arguments[2]);
+                    position.set(x, y, z);
                 }
 
                 if (this._parent === null) {
@@ -925,11 +915,11 @@ pc.extend(pc, function () {
             var rotation = new pc.Quat();
             var invParentRot = new pc.Quat();
 
-            return function () {
-                if (arguments.length === 1) {
-                    rotation.copy(arguments[0]);
+            return function (x, y, z, w) {
+                if (x instanceof pc.Quat) {
+                    rotation.copy(x);
                 } else {
-                    rotation.set(arguments[0], arguments[1], arguments[2], arguments[3]);
+                    rotation.set(x, y, z, w);
                 }
 
                 if (this._parent === null) {
@@ -967,22 +957,12 @@ pc.extend(pc, function () {
         setEulerAngles: function () {
             var invParentRot = new pc.Quat();
 
-            return function () {
-                var ex, ey, ez;
-                switch (arguments.length) {
-                    case 1:
-                        ex = arguments[0].x;
-                        ey = arguments[0].y;
-                        ez = arguments[0].z;
-                        break;
-                    case 3:
-                        ex = arguments[0];
-                        ey = arguments[1];
-                        ez = arguments[2];
-                        break;
+            return function (x, y, z) {
+                if (x instanceof pc.Vec3) {
+                    this.localRotation.setFromEulerAngles(x.data[0], x.data[1], x.data[2]);
+                } else {
+                    this.localRotation.setFromEulerAngles(x, y, z);
                 }
-
-                this.localRotation.setFromEulerAngles(ex, ey, ez);
 
                 if (this._parent !== null) {
                     var parentRot = this._parent.getRotation();
@@ -1270,24 +1250,25 @@ pc.extend(pc, function () {
             var up = new pc.Vec3();
             var rotation = new pc.Quat();
 
-            return function () {
-                switch (arguments.length) {
-                    case 1:
-                        target.copy(arguments[0]);
+            return function (tx, ty, tz, ux, uy, uz) {
+                if (tx instanceof pc.Vec3) {
+                    target.copy(tx);
+
+                    if (ty instanceof pc.Vec3) { // vec3, vec3
+                        up.copy(ty);
+                    } else { // vec3
                         up.copy(pc.Vec3.UP);
-                        break;
-                    case 2:
-                        target.copy(arguments[0]);
-                        up.copy(arguments[1]);
-                        break;
-                    case 3:
-                        target.set(arguments[0], arguments[1], arguments[2]);
+                    }
+                } else if (tz === undefined) {
+                    return;
+                } else {
+                    target.set(tx, ty, tz);
+
+                    if (ux !== undefined) { // number, number, number, number, number, number
+                        up.set(ux, uy, uz);
+                    } else { // number, number, number
                         up.copy(pc.Vec3.UP);
-                        break;
-                    case 6:
-                        target.set(arguments[0], arguments[1], arguments[2]);
-                        up.set(arguments[3], arguments[4], arguments[5]);
-                        break;
+                    }
                 }
 
                 matrix.setLookAt(this.getPosition(), target, up);
@@ -1318,14 +1299,11 @@ pc.extend(pc, function () {
         translate: function () {
             var translation = new pc.Vec3();
 
-            return function () {
-                switch (arguments.length) {
-                    case 1:
-                        translation.copy(arguments[0]);
-                        break;
-                    case 3:
-                        translation.set(arguments[0], arguments[1], arguments[2]);
-                        break;
+            return function (x, y, z) {
+                if (x instanceof pc.Vec3) {
+                    translation.copy(x);
+                } else {
+                    translation.set(x, y, z);
                 }
 
                 translation.add(this.getPosition());
@@ -1355,14 +1333,11 @@ pc.extend(pc, function () {
         translateLocal: function () {
             var translation = new pc.Vec3();
 
-            return function () {
-                switch (arguments.length) {
-                    case 1:
-                        translation.copy(arguments[0]);
-                        break;
-                    case 3:
-                        translation.set(arguments[0], arguments[1], arguments[2]);
-                        break;
+            return function (x, y, z) {
+                if (x instanceof pc.Vec3) {
+                    translation.copy(x);
+                } else {
+                    translation.set(x, y, z);
                 }
 
                 this.localRotation.transformVector(translation, translation);
@@ -1396,22 +1371,12 @@ pc.extend(pc, function () {
             var quaternion = new pc.Quat();
             var invParentRot = new pc.Quat();
 
-            return function () {
-                var ex, ey, ez;
-                switch (arguments.length) {
-                    case 1:
-                        ex = arguments[0].x;
-                        ey = arguments[0].y;
-                        ez = arguments[0].z;
-                        break;
-                    case 3:
-                        ex = arguments[0];
-                        ey = arguments[1];
-                        ez = arguments[2];
-                        break;
+            return function (x, y, z) {
+                if (x instanceof pc.Vec3) {
+                    quaternion.setFromEulerAngles(x.data[0], x.data[1], x.data[2]);
+                } else {
+                    quaternion.setFromEulerAngles(x, y, z);
                 }
-
-                quaternion.setFromEulerAngles(ex, ey, ez);
 
                 if (this._parent === null) {
                     this.localRotation.mul2(quaternion, this.localRotation);
@@ -1452,22 +1417,12 @@ pc.extend(pc, function () {
         rotateLocal: function () {
             var quaternion = new pc.Quat();
 
-            return function () {
-                var ex, ey, ez;
-                switch (arguments.length) {
-                    case 1:
-                        ex = arguments[0].x;
-                        ey = arguments[0].y;
-                        ez = arguments[0].z;
-                        break;
-                    case 3:
-                        ex = arguments[0];
-                        ey = arguments[1];
-                        ez = arguments[2];
-                        break;
+            return function (x, y, z) {
+                if (x instanceof pc.Vec3) {
+                    quaternion.setFromEulerAngles(x.data[0], x.data[1], x.data[2]);
+                } else {
+                    quaternion.setFromEulerAngles(x, y, z);
                 }
-
-                quaternion.setFromEulerAngles(ex, ey, ez);
 
                 this.localRotation.mul(quaternion);
                 this.dirtyLocal = true;


### PR DESCRIPTION
This PR removes as much as possible use of arguments in places that are called often.
It allocates methods and then checks for instance types if necessary. This is to avoid browsers of being unable to optimise JS functions into byte code, potentially reducing performance significantly of those methods.

In certain places code looks even better. In certain, not too much, but we used to make some internal functions crazy, e.g. `Mat4.mul2`.

And this PR reduced a bit of code in total.