### PR TITLE
pc.Camera refactor

### DIFF
--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -832,7 +832,7 @@ pc.extend(pc, function () {
             this.renderer._removedByInstancing = 0;
             this.graphicsDevice._drawCallsPerFrame = 0;
 
-            this.stats.misc.renderTargetCreationTime = this.graphicsDevice._renderTargetCreationTime;
+            this.stats.misc.renderTargetCreationTime = this.graphicsDevice.renderTargetCreationTime;
 
             stats = this.stats.particles;
             stats.updatesPerFrame = stats._updatesPerFrame;

--- a/src/framework/components/camera/component.js
+++ b/src/framework/components/camera/component.js
@@ -106,7 +106,7 @@ pc.extend(pc, function () {
      */
     Object.defineProperty(CameraComponent.prototype, "frustum", {
         get: function() {
-            return this.data.camera.getFrustum();
+            return this.data.camera.frustum;
         }
     });
 
@@ -180,7 +180,7 @@ pc.extend(pc, function () {
         },
 
         onSetAspectRatio: function (name, oldValue, newValue) {
-            this.data.camera.setAspectRatio(newValue);
+            this.data.camera.aspectRatio = newValue;
         },
 
         onSetCamera: function (name, oldValue, newValue) {
@@ -192,31 +192,30 @@ pc.extend(pc, function () {
         },
 
         onSetClearColor: function (name, oldValue, newValue) {
-            var clearOptions = this.data.camera.getClearOptions();
-            clearOptions.color[0] = newValue.data[0];
-            clearOptions.color[1] = newValue.data[1];
-            clearOptions.color[2] = newValue.data[2];
-            clearOptions.color[3] = newValue.data[3];
+            this.data.camera.clearColor[0] = newValue.data[0];
+            this.data.camera.clearColor[1] = newValue.data[1];
+            this.data.camera.clearColor[2] = newValue.data[2];
+            this.data.camera.clearColor[3] = newValue.data[3];
         },
 
         onSetFov: function (name, oldValue, newValue) {
-            this.data.camera.setFov(newValue);
+            this.data.camera.fov = newValue;
         },
 
         onSetOrthoHeight: function (name, oldValue, newValue) {
-            this.data.camera.setOrthoHeight(newValue);
+            this.data.camera.orthoHeight = newValue;
         },
 
         onSetNearClip: function (name, oldValue, newValue) {
-            this.data.camera.setNearClip(newValue);
+            this.data.camera.nearClip = newValue;
         },
 
         onSetFarClip: function (name, oldValue, newValue) {
-            this.data.camera.setFarClip(newValue);
+            this.data.camera.farClip = newValue;
         },
 
         onSetHorizontalFov: function (name, oldValue, newValue) {
-            this.data.camera.setHorizontalFov(newValue);
+            this.data.camera.horizontalFov = newValue;
         },
 
         onSetFrustumCulling: function (name, oldValue, newValue) {
@@ -224,7 +223,7 @@ pc.extend(pc, function () {
         },
 
         onSetProjection: function (name, oldValue, newValue) {
-            this.data.camera.setProjection(newValue);
+            this.data.camera.projection = newValue;
         },
 
         onSetPriority: function (name, oldValue, newValue) {
@@ -232,25 +231,22 @@ pc.extend(pc, function () {
         },
 
         updateClearFlags: function () {
-            var clearOptions = this.data.camera.getClearOptions();
             var flags = 0;
-            if (this.clearColorBuffer) {
+
+            if (this.clearColorBuffer)
                 flags = flags | pc.CLEARFLAG_COLOR;
-            }
 
-            if (this.clearDepthBuffer) {
+            if (this.clearDepthBuffer)
                 flags = flags | pc.CLEARFLAG_DEPTH;
-            }
 
-            if (this.clearStencilBuffer) {
+            if (this.clearStencilBuffer)
                 flags = flags | pc.CLEARFLAG_STENCIL;
-            }
 
-            clearOptions.flags = flags;
+            this.data.camera.clearFlags = flags;
         },
 
         onSetRenderTarget: function (name, oldValue, newValue) {
-            this.data.camera.setRenderTarget(newValue);
+            this.data.camera.renderTarget = newValue;
         },
 
         onSetRect: function (name, oldValue, newValue) {
@@ -273,13 +269,10 @@ pc.extend(pc, function () {
         _resetAspectRatio: function () {
             var camera = this.camera;
             if (camera) {
-                if (camera.getRenderTarget()) return;
+                if (camera.renderTarget) return;
                 var device = this.system.app.graphicsDevice;
                 var rect = this.rect;
-                var aspect = (device.width * rect.z) / (device.height * rect.w);
-                if (aspect !== camera.getAspectRatio()) {
-                    camera.setAspectRatio(aspect);
-                }
+                camera.aspectRatio = (device.width * rect.z) / (device.height * rect.w);
             }
         },
 

--- a/src/framework/components/camera/post-effect-queue.js
+++ b/src/framework/components/camera/post-effect-queue.js
@@ -259,15 +259,11 @@ pc.extend(pc, function () {
 
             var rect = this.camera.rect;
             var device = this.app.graphicsDevice;
-            var aspect = (device.width * rect.z) / (device.height * rect.w);
-            if (aspect !== this.camera.camera.getAspectRatio()) {
-                this.camera.camera.setAspectRatio(aspect);
-            }
+            this.camera.camera.aspectRatio = (device.width * rect.z) / (device.height * rect.w);
 
             // avoid resizing the render targets too often by using a timeout
-            if (this.resizeTimeout) {
+            if (this.resizeTimeout)
                 clearTimeout(this.resizeTimeout);
-            }
 
             this.resizeTimeout = setTimeout(this.resizeRenderTargets.bind(this), 500);
         },

--- a/src/graphics/device.js
+++ b/src/graphics/device.js
@@ -1550,19 +1550,19 @@ pc.extend(pc, function () {
             var defaultOptions = this.defaultClearOptions;
             options = options || defaultOptions;
 
-            var flags = (options.flags === undefined) ? defaultOptions.flags : options.flags;
+            var flags = (options.flags == undefined) ? defaultOptions.flags : options.flags;
             if (flags !== 0) {
                 var gl = this.gl;
 
                 // Set the clear color
                 if (flags & pc.CLEARFLAG_COLOR) {
-                    var color = (options.color === undefined) ? defaultOptions.color : options.color;
+                    var color = (options.color == undefined) ? defaultOptions.color : options.color;
                     this.setClearColor(color[0], color[1], color[2], color[3]);
                 }
 
                 if (flags & pc.CLEARFLAG_DEPTH) {
                     // Set the clear depth
-                    var depth = (options.depth === undefined) ? defaultOptions.depth : options.depth;
+                    var depth = (options.depth == undefined) ? defaultOptions.depth : options.depth;
                     this.setClearDepth(depth);
                     if (!this.depthWrite) {
                         gl.depthMask(true);
@@ -1571,7 +1571,7 @@ pc.extend(pc, function () {
 
                 if (flags & pc.CLEARFLAG_STENCIL) {
                     // Set the clear stencil
-                    var stencil = (options.stencil === undefined) ? defaultOptions.stencil : options.stencil;
+                    var stencil = (options.stencil == undefined) ? defaultOptions.stencil : options.stencil;
                     this.setClearStencil(stencil);
                 }
 

--- a/src/scene/camera.js
+++ b/src/scene/camera.js
@@ -13,7 +13,7 @@ pc.extend(pc, function () {
         this._farClip = 10000;
         this._fov = 45;
         this._orthoHeight = 10;
-        this._aspect = 16 / 9;
+        this._aspectRatio = 16 / 9;
         this._horizontalFov = false;
         this.frustumCulling = false;
         this.cullingMask = 0xFFFFFFFF;
@@ -24,11 +24,6 @@ pc.extend(pc, function () {
         this._viewMat = new pc.Mat4();
         this._viewProjMat = new pc.Mat4();
 
-        // this._leftProjMat = new pc.Mat4();
-        // this._rightProjMat = new pc.Mat4();
-        // this._leftViewInvMat = new pc.Mat4();
-        // this._rightViewInvMat = new pc.Mat4();
-
         this.vrDisplay = null;
 
         this._rect = {
@@ -38,15 +33,15 @@ pc.extend(pc, function () {
             height: 1
         };
 
-        this._frustum = new pc.Frustum(this._projMat, this._viewMat);
+        this.frustum = new pc.Frustum(this._projMat, this._viewMat);
 
         // Create a full size viewport onto the backbuffer
-        this._renderTarget = null;
+        this.renderTarget = null;
         this._depthTarget = null;
 
         // Create the clear options
         this._clearOptions = {
-            color: [186.0 / 255.0, 186.0 / 255.0, 177.0 / 255.0, 1.0],
+            color: [ 0.5, 0.5, 0.5, 1.0 ],
             depth: 1.0,
             stencil: 0,
             flags: pc.CLEARFLAG_COLOR | pc.CLEARFLAG_DEPTH | pc.CLEARFLAG_STENCIL
@@ -65,12 +60,12 @@ pc.extend(pc, function () {
          */
         clone: function () {
             var clone = new pc.Camera();
-            clone.setProjection(this.getProjection());
-            clone.setNearClip(this.getNearClip());
-            clone.setFarClip(this.getFarClip());
-            clone.setFov(this.getFov());
-            clone.setAspectRatio(this.getAspectRatio());
-            clone.setRenderTarget(this.getRenderTarget());
+            clone.projection = this._projection;
+            clone.nearClip = this._nearClip;
+            clone.farClip = this._farClip;
+            clone.fov = this._fov;
+            clone.aspectRatio = this._aspectRatio;
+            clone.renderTarget = this.renderTarget;
             clone.setClearOptions(this.getClearOptions());
             clone.frustumCulling = this.frustumCulling;
             clone.cullingMask = this.cullingMask;
@@ -169,92 +164,12 @@ pc.extend(pc, function () {
         /**
          * @private
          * @function
-         * @name pc.Camera#getAspectRatio
-         * @description Retrieves the setting for the specified camera's aspect ratio.
-         * @returns {Number} The aspect ratio of the camera (width divided by height).
-         */
-        getAspectRatio: function () {
-            return this._aspect;
-        },
-
-        /**
-         * @private
-         * @function
          * @name pc.Camera#getClearOptions
          * @description Retrieves the options used to determine how the camera's render target will be cleared.
          * @return {Object} The options determining the behaviour of render target clears.
          */
         getClearOptions: function () {
             return this._clearOptions;
-        },
-
-        /**
-         * @private
-         * @function
-         * @name pc.Camera#getFarClip
-         * @description Retrieves the setting for the specified camera's far clipping plane. This
-         * is a Z-coordinate in eye coordinates.
-         * @returns {Number} The far clipping plane distance.
-         */
-        getFarClip: function () {
-            return this._farClip;
-        },
-
-        /**
-         * @private
-         * @function
-         * @name pc.Camera#getFov
-         * @description Retrieves the setting for the specified camera's vertical field of view. This
-         * angle is in degrees and is measured vertically between the top and bottom camera planes.
-         * @returns {Number} The vertical field of view in degrees.
-         */
-        getFov: function () {
-            return this._fov;
-        },
-
-        /**
-         * @private
-         * @function
-         * @name pc.Camera#getFrustum
-         * @description Retrieves the frustum shape for the specified camera.
-         * @returns {pc.Frustum} The camera's frustum shape.
-         */
-        getFrustum: function () {
-            return this._frustum;
-        },
-
-        /**
-         * @private
-         * @function
-         * @name pc.Camera#getNearClip
-         * @description Retrieves the setting for the specified camera's near clipping plane. This
-         * is a Z-coordinate in eye coordinates.
-         * @returns {Number} The near clipping plane distance.
-         */
-        getNearClip: function () {
-            return this._nearClip;
-        },
-
-        /**
-         * @private
-         * @function
-         * @name pc.Camera#getOrthoHeight
-         * @description Retrieves the half height of the orthographic camera's view window.
-         * @returns {Number} The half height of the orthographic view window in eye coordinates.
-         */
-        getOrthoHeight: function () {
-            return this._orthoHeight;
-        },
-
-        /**
-         * @private
-         * @function
-         * @name pc.Camera#getProjection
-         * @description Retrieves the projection type for the specified camera.
-         * @returns {pc.PROJECTION} The camera's projection type.
-         */
-        getProjection: function () {
-            return this._projection;
         },
 
         /**
@@ -267,10 +182,10 @@ pc.extend(pc, function () {
         getProjectionMatrix: function () {
             if (this._projMatDirty) {
                 if (this._projection === pc.PROJECTION_PERSPECTIVE) {
-                    this._projMat.setPerspective(this._fov, this._aspect, this._nearClip, this._farClip, this._horizontalFov);
+                    this._projMat.setPerspective(this._fov, this._aspectRatio, this._nearClip, this._farClip, this._horizontalFov);
                 } else {
                     var y = this._orthoHeight;
-                    var x = y * this._aspect;
+                    var x = y * this._aspectRatio;
                     this._projMat.setOrtho(-x, x, -y, y, this._nearClip, this._farClip);
                 }
 
@@ -286,30 +201,6 @@ pc.extend(pc, function () {
         /**
          * @private
          * @function
-         * @name pc.Camera#getRenderTarget
-         * @description Retrieves the render target currently set on the specified camera.
-         * @returns {pc.RenderTarget} The camera's render target.
-         */
-        getRenderTarget: function () {
-            return this._renderTarget;
-        },
-
-        /**
-         * @private
-         * @function
-         * @name pc.Camera#setAspectRatio
-         * @description Sets the specified camera's aspect ratio. This is normally the width
-         * of the viewport divided by height.
-         * @returns {Number} The aspect ratio of the camera.
-         */
-        setAspectRatio: function (aspect) {
-            this._aspect = aspect;
-            this._projMatDirty = true;
-        },
-
-        /**
-         * @private
-         * @function
          * @name pc.Camera#setClearOptions
          * @description Sets the options used to determine how the camera's render target will be cleared.
          * @param {Object} clearOptions The options determining the behaviour of subsequent render target clears.
@@ -318,82 +209,13 @@ pc.extend(pc, function () {
          * @param {pc.CLEARFLAG} clearOptions.flags The options determining the behaviour of subsequent render target clears.
          */
         setClearOptions: function (options) {
-            this._clearOptions = options;
-        },
-
-        /**
-         * @private
-         * @function
-         * @name pc.Camera#setFarClip
-         * @description Sets the specified camera's far clipping plane. This is a Z-coordinate in eye coordinates.
-         * @param {Number} far The far clipping plane distance.
-         */
-        setFarClip: function (far) {
-            this._farClip = far;
-            this._projMatDirty = true;
-        },
-
-        /**
-         * @private
-         * @function
-         * @name pc.Camera#setFov
-         * @description Sets the specified camera's vertical field of view. This angle is in degrees and is
-         * measured vertically from the view direction of the camera. Therefore, the angle is actually half
-         * the angle between the top and bottom camera planes.
-         * @param {Number} fov The vertical field of view in degrees.
-         */
-        setFov: function (fov) {
-            this._fov = fov;
-            this._projMatDirty = true;
-        },
-
-        /**
-         * @private
-         * @function
-         * @name pc.Camera#setNearClip
-         * @description Sets the specified camera's near clipping plane. This is a Z-coordinate in eye coordinates.
-         * @param {Number} near The near clipping plane distance.
-         */
-        setNearClip: function (near) {
-            this._nearClip = near;
-            this._projMatDirty = true;
-        },
-
-        /**
-         * @private
-         * @function
-         * @name pc.Camera#setOrthoHeight
-         * @description Sets the half height of the orthographic camera's view window.
-         * @param {Number} height The half height of the orthographic view window in eye coordinates.
-         */
-        setOrthoHeight: function (height) {
-            this._orthoHeight = height;
-            this._projMatDirty = true;
-        },
-
-        /**
-         * @private
-         * @function
-         * @name pc.Camera#setHorizontalFov
-         * @description Toggles horizontal/vertical FOV
-         * @param {Number} value true (horizontal) or false (vertical).
-         */
-        setHorizontalFov: function (value) {
-            this._horizontalFov = value;
-            this._projMatDirty = true;
-        },
-
-        /**
-         * @private
-         * @function
-         * @name pc.Camera#setProjection
-         * @description Sets the projection type for the specified camera. This determines whether the projection
-         * will be orthographic (parallel projection) or perspective.
-         * @param {pc.Projection} type The camera's projection type.
-         */
-        setProjection: function (type) {
-            this._projection = type;
-            this._projMatDirty = true;
+            this._clearOptions.color[0] = options.color[0];
+            this._clearOptions.color[1] = options.color[1];
+            this._clearOptions.color[2] = options.color[2];
+            this._clearOptions.color[3] = options.color[3];
+            this._clearOptions.depth = options.depth;
+            this._clearOptions.stencil = options.stencil;
+            this._clearOptions.flags = options.flags;
         },
 
         setRect: function (x, y, width, height) {
@@ -401,17 +223,6 @@ pc.extend(pc, function () {
             this._rect.y = y;
             this._rect.width = width;
             this._rect.height = height;
-        },
-
-        /**
-         * @private
-         * @function
-         * @name pc.Camera#setRenderTarget
-         * @description Sets the specified render target on the camera.
-         * @param {pc.RenderTarget} target The render target to set.
-         */
-        setRenderTarget: function (target) {
-            this._renderTarget = target;
         },
 
         requestDepthMap: function () {
@@ -422,6 +233,179 @@ pc.extend(pc, function () {
             this._renderDepthRequests--;
         }
     };
+
+    /**
+     * @private
+     * @type Number
+     * @name pc.Camera#aspectRatio
+     * @description Camera's aspect ratio.
+     */
+    Object.defineProperty(Camera.prototype, 'aspectRatio', {
+        get: function() { return this._aspectRatio; },
+        set: function(v) {
+            if (this._aspectRatio !== v) {
+                this._aspectRatio = v;
+                this._projMatDirty = true;
+            }
+        }
+    });
+
+    /**
+     * @private
+     * @type Number
+     * @name pc.Camera#projection
+     * @description Camera's projection type, to specify whether projection is orthographic (parallel projection) or perspective. Can be:
+     * <ul>
+     *     <li>{@link pc.PROJECTION_PERSPECTIVE}</li>
+     *     <li>{@link pc.PROJECTION_ORTHOGRAPHIC}</li>
+     * </ul>
+     */
+    Object.defineProperty(Camera.prototype, 'projection', {
+        get: function() { return this._projection; },
+        set: function(v) {
+            if (this._projection !== v) {
+                this._projection = v;
+                this._projMatDirty = true;
+            }
+        }
+    });
+
+    /**
+     * @private
+     * @type Number
+     * @name pc.Camera#nearClip
+     * @description Camera's distance to near clipping plane
+     */
+    Object.defineProperty(Camera.prototype, 'nearClip', {
+        get: function() { return this._nearClip; },
+        set: function(v) {
+            if (this._nearClip !== v) {
+                this._nearClip = v;
+                this._projMatDirty = true;
+            }
+        }
+    });
+
+    /**
+     * @private
+     * @type Number
+     * @name pc.Camera#farClip
+     * @description Camera's distance to far clipping plane
+     */
+    Object.defineProperty(Camera.prototype, 'farClip', {
+        get: function() { return this._farClip; },
+        set: function(v) {
+            if (this._farClip !== v) {
+                this._farClip = v;
+                this._projMatDirty = true;
+            }
+        }
+    });
+
+    /**
+     * @private
+     * @type Number
+     * @name pc.Camera#fov
+     * @description Camera's field of view in degrees. This angle is in degrees
+     * and is measured vertically or horizontally between the sides of camera planes.
+     * hirozontalFov property defines the fov axis - vertical or horizontal.
+     */
+    Object.defineProperty(Camera.prototype, 'fov', {
+        get: function() { return this._fov; },
+        set: function(v) {
+            if (this._fov !== v) {
+                this._fov = v;
+                this._projMatDirty = true;
+            }
+        }
+    });
+
+    /**
+     * @private
+     * @type Boolean
+     * @name pc.Camera#horizontalFov
+     * @description Camera's horizontal or vertical field of view.
+     */
+    Object.defineProperty(Camera.prototype, 'horizontalFov', {
+        get: function() { return this._horizontalFov; },
+        set: function(v) {
+            if (this._horizontalFov !== v) {
+                this._horizontalFov = v;
+                this._projMatDirty = true;
+            }
+        }
+    });
+
+    /**
+     * @private
+     * @type Number
+     * @name pc.Camera#orthoHeight
+     * @description Camera's half height of the orthographics view.
+     */
+    Object.defineProperty(Camera.prototype, 'orthoHeight', {
+        get: function() { return this._orthoHeight; },
+        set: function(v) {
+            if (this._orthoHeight !== v) {
+                this._orthoHeight = v;
+                this._projMatDirty = true;
+            }
+        }
+    });
+
+    /**
+     * @private
+     * @type Array
+     * @name pc.Camera#clearColor
+     * @description Camera's clear color.
+     */
+    Object.defineProperty(Camera.prototype, 'clearColor', {
+        get: function() { return this._clearOptions.color; },
+        set: function(v) {
+            this._clearOptions.color[0] = v[0];
+            this._clearOptions.color[1] = v[1];
+            this._clearOptions.color[2] = v[2];
+            this._clearOptions.color[3] = v[3];
+        }
+    });
+
+    /**
+     * @private
+     * @type Number
+     * @name pc.Camera#clearDepth
+     * @description Camera's clear depth value.
+     */
+    Object.defineProperty(Camera.prototype, 'clearDepth', {
+        get: function() { return this._clearOptions.depth; },
+        set: function(v) {
+            this._clearOptions.depth = v;
+        }
+    });
+
+    /**
+     * @private
+     * @type Number
+     * @name pc.Camera#clearStencil
+     * @description Camera's clear stencil value.
+     */
+    Object.defineProperty(Camera.prototype, 'clearStencil', {
+        get: function() { return this._clearOptions.stencil; },
+        set: function(v) {
+            this._clearOptions.stencil = v;
+        }
+    });
+
+    /**
+     * @private
+     * @type Number
+     * @name pc.Camera#clearFlags
+     * @description Camera's clear flags bits value.
+     */
+    Object.defineProperty(Camera.prototype, 'clearFlags', {
+        get: function() { return this._clearOptions.flags; },
+        set: function(v) {
+            this._clearOptions.flags = v;
+        }
+    });
 
     return {
         Camera: Camera

--- a/src/scene/camera.js
+++ b/src/scene/camera.js
@@ -13,7 +13,7 @@ pc.extend(pc, function () {
         this._farClip = 10000;
         this._fov = 45;
         this._orthoHeight = 10;
-        this._aspectRatio = 16 / 9;
+        this._aspect = 16 / 9;
         this._horizontalFov = false;
         this.frustumCulling = false;
         this.cullingMask = 0xFFFFFFFF;
@@ -64,7 +64,7 @@ pc.extend(pc, function () {
             clone.nearClip = this._nearClip;
             clone.farClip = this._farClip;
             clone.fov = this._fov;
-            clone.aspectRatio = this._aspectRatio;
+            clone.aspectRatio = this._aspect;
             clone.renderTarget = this.renderTarget;
             clone.setClearOptions(this.getClearOptions());
             clone.frustumCulling = this.frustumCulling;
@@ -182,10 +182,10 @@ pc.extend(pc, function () {
         getProjectionMatrix: function () {
             if (this._projMatDirty) {
                 if (this._projection === pc.PROJECTION_PERSPECTIVE) {
-                    this._projMat.setPerspective(this._fov, this._aspectRatio, this._nearClip, this._farClip, this._horizontalFov);
+                    this._projMat.setPerspective(this._fov, this._aspect, this._nearClip, this._farClip, this._horizontalFov);
                 } else {
                     var y = this._orthoHeight;
-                    var x = y * this._aspectRatio;
+                    var x = y * this._aspect;
                     this._projMat.setOrtho(-x, x, -y, y, this._nearClip, this._farClip);
                 }
 
@@ -241,10 +241,10 @@ pc.extend(pc, function () {
      * @description Camera's aspect ratio.
      */
     Object.defineProperty(Camera.prototype, 'aspectRatio', {
-        get: function() { return this._aspectRatio; },
+        get: function() { return this._aspect; },
         set: function(v) {
-            if (this._aspectRatio !== v) {
-                this._aspectRatio = v;
+            if (this._aspect !== v) {
+                this._aspect = v;
                 this._projMatDirty = true;
             }
         }

--- a/src/scene/forward-renderer.js
+++ b/src/scene/forward-renderer.js
@@ -88,7 +88,7 @@ pc.extend(pc, function () {
     function _getFrustumPoints(camera, farClip, points) {
         var nearClip = camera._nearClip;
         var fov = camera._fov * Math.PI / 180.0;
-        var aspect = camera._aspectRatio;
+        var aspect = camera._aspect;
         var projection = camera._projection;
 
         var x, y;

--- a/src/scene/forward-renderer.js
+++ b/src/scene/forward-renderer.js
@@ -452,6 +452,8 @@ pc.extend(pc, function () {
 
         shadowCam.clearDepth = 1;
         shadowCam.clearFlags = flags;
+        shadowCam.clearStencil = null;
+
         shadowCam._node = new pc.GraphNode();
 
         return shadowCam;

--- a/src/scene/light.js
+++ b/src/scene/light.js
@@ -196,7 +196,7 @@ pc.extend(pc, function () {
 
         _destroyShadowMap: function () {
             if (this._shadowCamera) {
-                var rt = this._shadowCamera._renderTarget;
+                var rt = this._shadowCamera.renderTarget;
                 var i;
                 if (rt) {
                     if (rt.length) {
@@ -209,7 +209,7 @@ pc.extend(pc, function () {
                         rt.destroy();
                     }
                 }
-                this._shadowCamera._renderTarget = null;
+                this._shadowCamera.renderTarget = null;
                 this._shadowCamera = null;
                 this._shadowCubeMap = null;
                 if (this.shadowUpdateMode===pc.SHADOWUPDATE_NONE) {

--- a/src/scene/lightmapper.js
+++ b/src/scene/lightmapper.js
@@ -290,7 +290,7 @@ pc.extend(pc, function () {
                         minFilter: pc.FILTER_NEAREST,
                         magFilter: pc.FILTER_NEAREST
                     });
-                    
+
                     var targ2 = new pc.RenderTarget(device, tex2, {
                         depth: false
                     });
@@ -359,7 +359,12 @@ pc.extend(pc, function () {
             if (!lmCamera) {
                 lmCamera = new pc.Camera();
                 lmCamera._node = new pc.GraphNode();
-                lmCamera.setClearOptions({color:[0.0, 0.0, 0.0, 0.0], depth:1, flags:pc.CLEARFLAG_COLOR});
+                lmCamera.clearColor[0] = 0;
+                lmCamera.clearColor[1] = 0;
+                lmCamera.clearColor[2] = 0;
+                lmCamera.clearColor[3] = 0;
+                lmCamera.clearDepth = 1;
+                lmCamera.clearFlags = pc.CLEARFLAG_COLOR;
                 lmCamera.frustumCulling = false;
             }
 
@@ -512,11 +517,11 @@ pc.extend(pc, function () {
                     shadowCam._node.setRotation(light._node.getRotation());
                     shadowCam._node.rotateLocal(-90, 0, 0);
 
-                    shadowCam.setProjection(pc.PROJECTION_PERSPECTIVE);
-                    shadowCam.setNearClip(light.attenuationEnd / 1000);
-                    shadowCam.setFarClip(light.attenuationEnd);
-                    shadowCam.setAspectRatio(1);
-                    shadowCam.setFov(light._outerConeAngle * 2);
+                    shadowCam.projection = pc.PROJECTION_PERSPECTIVE;
+                    shadowCam.nearClip = light.attenuationEnd / 1000;
+                    shadowCam.farClip = light.attenuationEnd;
+                    shadowCam.aspectRatio = 1;
+                    shadowCam.fov = light._outerConeAngle * 2;
 
                     this.renderer.updateCameraFrustum(shadowCam);
                 }
@@ -541,11 +546,11 @@ pc.extend(pc, function () {
 
                         var frustumSize = Math.max(bounds.halfExtents.x, bounds.halfExtents.z);
 
-                        lmCamera.setProjection( pc.PROJECTION_ORTHOGRAPHIC );
-                        lmCamera.setNearClip( 0 );
-                        lmCamera.setFarClip( bounds.halfExtents.y * 2 );
-                        lmCamera.setAspectRatio( 1 );
-                        lmCamera.setOrthoHeight( frustumSize );
+                        lmCamera.projection = pc.PROJECTION_ORTHOGRAPHIC;
+                        lmCamera.nearClip = 0;
+                        lmCamera.farClip = bounds.halfExtents.y * 2;
+                        lmCamera.aspectRatio = 1;
+                        lmCamera.orthoHeight = frustumSize;
                     } else {
                         if (!lightBounds.intersects(bounds)) {
                             continue;
@@ -582,7 +587,7 @@ pc.extend(pc, function () {
                         }
 
                         // ping-ponging output
-                        lmCamera.setRenderTarget(targTmp);
+                        lmCamera.renderTarget = targTmp;
 
                         if (pass===PASS_DIR) {
                             constantBakeDir.setValue(lights[i].bakeDir? 1 : 0);

--- a/src/scene/lightmapper.js
+++ b/src/scene/lightmapper.js
@@ -365,6 +365,7 @@ pc.extend(pc, function () {
                 lmCamera.clearColor[3] = 0;
                 lmCamera.clearDepth = 1;
                 lmCamera.clearFlags = pc.CLEARFLAG_COLOR;
+                lmCamera.clearStencil = null;
                 lmCamera.frustumCulling = false;
             }
 

--- a/src/scene/pick.js
+++ b/src/scene/pick.js
@@ -67,7 +67,7 @@ pc.extend(pc, function () {
         rect.height = rect.height || 1;
 
         // Cache active render target
-        var prevRenderTarget = device.getRenderTarget();
+        var prevRenderTarget = device.renderTarget;
 
         // Ready the device for rendering to the pick buffer
         device.setRenderTarget(this._pickBufferTarget);
@@ -116,7 +116,7 @@ pc.extend(pc, function () {
         this.scene = scene;
 
         // Cache active render target
-        var prevRenderTarget = device.getRenderTarget();
+        var prevRenderTarget = device.renderTarget;
 
         // Ready the device for rendering to the pick buffer
         device.setRenderTarget(this._pickBufferTarget);


### PR DESCRIPTION
Fixed camera clear options to not inherit actual object that would lead to "shared" clear options between cameras.
Refactored properties, so to be direct or indirect defined properties, with extra check if value is actually changed to reduce number of frustum matrix recalculations.
Avoided using functions to get camera properties, but directly used private properties as micro-optimisation.