### PR TITLE
Shapes API refractor #779 and #644

### DIFF
--- a/src/backwards-compatibility.js
+++ b/src/backwards-compatibility.js
@@ -131,3 +131,5 @@ pc.time = {
 };
 
 pc.PhongMaterial = pc.StandardMaterial;
+
+pc.BoundingSphere.prototype.intersectRay = pc.BoundingSphere.prototype.intersectsRay;

--- a/src/shape/bounding-box.js
+++ b/src/shape/bounding-box.js
@@ -108,28 +108,14 @@ pc.extend(pc, function () {
             var dir = ray.direction.data;
 
             // Ensure that we are not dividing it by zero
-            if (dir[0] === 0) {
-                tMin[0] = tMin[0] < 0 ? -Number.MAX_VALUE : Number.MAX_VALUE;
-                tMax[0] = tMax[0] < 0 ? -Number.MAX_VALUE : Number.MAX_VALUE;
-            } else {
-                tMin[0] /= dir[0];
-                tMax[0] /= dir[0];
-            }
-
-            if (dir[1] === 0) {
-                tMin[1] = tMin[1] < 0 ? -Number.MAX_VALUE : Number.MAX_VALUE;
-                tMax[1] = tMax[1] < 0 ? -Number.MAX_VALUE : Number.MAX_VALUE;
-            } else {
-                tMin[1] /= dir[1];
-                tMax[1] /= dir[1];
-            }
-
-            if (dir[2] === 0) {
-                tMin[2] = tMin[2] < 0 ? -Number.MAX_VALUE : Number.MAX_VALUE;
-                tMax[2] = tMax[2] < 0 ? -Number.MAX_VALUE : Number.MAX_VALUE;
-            } else {
-                tMin[2] /= dir[2];
-                tMax[2] /= dir[2];
+            for (var i = 0; i < 3; i++) {
+                if (dir[i] === 0) {
+                    tMin[i] = tMin[i] < 0 ? -Number.MAX_VALUE : Number.MAX_VALUE;
+                    tMax[i] = tMax[i] < 0 ? -Number.MAX_VALUE : Number.MAX_VALUE;
+                } else {
+                    tMin[i] /= dir[i];
+                    tMax[i] /= dir[i];
+                }
             }
 
             var realMin = tmpVecC.set(Math.min(tMin[0], tMax[0]), Math.min(tMin[1], tMax[1]), Math.min(tMin[2], tMax[2])).data;

--- a/src/shape/bounding-box.js
+++ b/src/shape/bounding-box.js
@@ -111,27 +111,40 @@ pc.extend(pc, function () {
          * @returns {Boolean} True if there is an intersection.
          */
         intersectsRay: function (ray, point) {
-            var rDirection = tmpVecE.set(
-                ray.direction.x === 0 ? Number.MIN_VALUE : ray.direction.x,
-                ray.direction.y === 0 ? Number.MIN_VALUE : ray.direction.y,
-                ray.direction.z === 0 ? Number.MIN_VALUE : ray.direction.z
-            );
+            var tMin = tmpVecA.copy(this.getMin()).sub(ray.origin).data;
+            var tMax = tmpVecB.copy(this.getMax()).sub(ray.origin).data;
+            var dir = ray.direction.data;
 
-            var tMin = tmpVecA.copy(this.getMin()).sub(ray.origin);
-            tMin.x /= ray.direction.x;
-            tMin.y /= ray.direction.y;
-            tMin.z /= ray.direction.z;
+            // Ensure that we are not dividing it by zero
+            if (dir[0] === 0) {
+                tMin[0] = tMin[0] < 0 ? -Number.MAX_VALUE : Number.MAX_VALUE;
+                tMax[0] = tMax[0] < 0 ? -Number.MAX_VALUE : Number.MAX_VALUE;
+            } else {
+                tMin[0] /= dir[0];
+                tMax[0] /= dir[0];
+            }
 
-            var tMax = tmpVecB.copy(this.getMax()).sub(ray.origin);
-            tMax.x /= ray.direction.x;
-            tMax.y /= ray.direction.y;
-            tMax.z /= ray.direction.z;
+            if (dir[1] === 0) {
+                tMin[1] = tMin[1] < 0 ? -Number.MAX_VALUE : Number.MAX_VALUE;
+                tMax[1] = tMax[1] < 0 ? -Number.MAX_VALUE : Number.MAX_VALUE;
+            } else {
+                tMin[1] /= dir[1];
+                tMax[1] /= dir[1];
+            }
 
-            var realMin = tmpVecC.set(Math.min(tMin.x, tMax.x), Math.min(tMin.y, tMax.y), Math.min(tMin.z, tMax.z));
-            var realMax = tmpVecD.set(Math.max(tMin.x, tMax.x), Math.max(tMin.y, tMax.y), Math.max(tMin.z, tMax.z));
+            if (dir[2] === 0) {
+                tMin[2] = tMin[2] < 0 ? -Number.MAX_VALUE : Number.MAX_VALUE;
+                tMax[2] = tMax[2] < 0 ? -Number.MAX_VALUE : Number.MAX_VALUE;
+            } else {
+                tMin[2] /= dir[2];
+                tMax[2] /= dir[2];
+            }
 
-            var minMax = Math.min(Math.min(realMax.x, realMax.y), realMax.z);
-            var maxMin = Math.max(Math.max(realMin.x, realMin.y), realMin.z);
+            var realMin = tmpVecC.set(Math.min(tMin[0], tMax[0]), Math.min(tMin[1], tMax[1]), Math.min(tMin[2], tMax[2])).data;
+            var realMax = tmpVecD.set(Math.max(tMin[0], tMax[0]), Math.max(tMin[1], tMax[1]), Math.max(tMin[2], tMax[2])).data;
+
+            var minMax = Math.min(Math.min(realMax[0], realMax[1]), realMax[2]);
+            var maxMin = Math.max(Math.max(realMin[0], realMin[1]), realMin[2]);
 
             var intersects = minMax >= maxMin;
 

--- a/src/shape/bounding-box.js
+++ b/src/shape/bounding-box.js
@@ -8,14 +8,14 @@ pc.extend(pc, function () {
 
     /**
      * @name pc.BoundingBox
-     * @description Create a new axis-aligned bounding box
-     * @class Axis-Aligned Bounding Box
-     * @param {pc.Vec3} center - center of box
-     * @param {pc.Vec3} halfExtents - half the distance across the box in each axis
+     * @description Create a new axis-aligned bounding box.
+     * @class Axis-Aligned Bounding Box.
+     * @param {pc.Vec3} center - center of box.
+     * @param {pc.Vec3} halfExtents - half the distance across the box in each axis.
      */
     var BoundingBox = function BoundingBox(center, halfExtents) {
-        this.center = center || new pc.Vec3(0, 0, 0);
-        this.halfExtents = halfExtents || new pc.Vec3(0.5, 0.5, 0.5);
+        this.center = center ? center.clone() : new pc.Vec3(0, 0, 0);
+        this.halfExtents = halfExtents ? halfExtents.clone() : new pc.Vec3(0.5, 0.5, 0.5);
         this._min = new pc.Vec3();
         this._max = new pc.Vec3();
     };
@@ -25,8 +25,8 @@ pc.extend(pc, function () {
         /**
          * @function
          * @name pc.BoundingBox#add
-         * @description Combines two bounding boxes into one, enclosing both
-         * @param {pc.BoundingBox} other Bounding box to add
+         * @description Combines two bounding boxes into one, enclosing both.
+         * @param {pc.BoundingBox} other Bounding box to add.
          */
         add: function (other) {
             var tc = this.center.data;
@@ -88,8 +88,8 @@ pc.extend(pc, function () {
          * @function
          * @name pc.BoundingBox#intersects
          * @description Test whether two axis-aligned bounding boxes intersect.
-         * @param {pc.BoundingBox} other Bounding box to test against
-         * @returns {Boolean} True if there is an intersection
+         * @param {pc.BoundingBox} other Bounding box to test against.
+         * @returns {Boolean} True if there is an intersection.
          */
         intersects: function (other) {
             var aMax = this.getMax();
@@ -105,10 +105,10 @@ pc.extend(pc, function () {
         /**
          * @function
          * @name pc.BoundingBox#intersectsRay
-         * @description Test if a ray intersects with the AABB
-         * @param {pc.Ray} ray Ray to test against (direction must be normalized)
-         * @param {pc.Vec3} [point] If there is an intersection, the intersection point will be copied into here
-         * @returns {Boolean} True if there is an intersection
+         * @description Test if a ray intersects with the AABB.
+         * @param {pc.Ray} ray Ray to test against (direction must be normalized).
+         * @param {pc.Vec3} [point] If there is an intersection, the intersection point will be copied into here.
+         * @returns {Boolean} True if there is an intersection.
          */
         intersectsRay: function (ray, point) {
             var rDirection = tmpVecE.set(
@@ -150,7 +150,7 @@ pc.extend(pc, function () {
          * @function
          * @name pc.BoundingBox#getMin
          * @description Return the minimum corner of the AABB.
-         * @returns {pc.Vec3} minimum corner
+         * @returns {pc.Vec3} minimum corner.
          */
         getMin: function () {
             return this._min.copy(this.center).sub(this.halfExtents);
@@ -160,7 +160,7 @@ pc.extend(pc, function () {
          * @function
          * @name pc.BoundingBox#getMax
          * @description Return the maximum corner of the AABB.
-         * @returns {pc.Vec3} maximum corner
+         * @returns {pc.Vec3} maximum corner.
          */
         getMax: function () {
             return this._max.copy(this.center).add(this.halfExtents);
@@ -169,9 +169,9 @@ pc.extend(pc, function () {
         /**
          * @function
          * @name pc.BoundingBox#containsPoint
-         * @description Test if a point is inside a AABB
-         * @param {pc.Vec3} point Point to test
-         * @returns {Boolean} true if the point is inside the AABB and false otherwise
+         * @description Test if a point is inside a AABB.
+         * @param {pc.Vec3} point Point to test.
+         * @returns {Boolean} true if the point is inside the AABB and false otherwise.
          */
         containsPoint: function (point) {
             var min = this.getMin();

--- a/src/shape/bounding-box.js
+++ b/src/shape/bounding-box.js
@@ -111,8 +111,6 @@ pc.extend(pc, function () {
          * @returns {Boolean} True if there is an intersection
          */
         intersectsRay: function (ray, point) {
-            // Taken from http://www.gamedev.net/topic/495636-raybox-collision-intersection-point/#entry4233865
-            // Variant of http://www.siggraph.org/education/materials/HyperGraph/raytrace/rtinter3.htm
             var rDirection = tmpVecE.set(
                 ray.direction.x === 0 ? Number.MIN_VALUE : ray.direction.x,
                 ray.direction.y === 0 ? Number.MIN_VALUE : ray.direction.y,

--- a/src/shape/bounding-box.js
+++ b/src/shape/bounding-box.js
@@ -10,8 +10,8 @@ pc.extend(pc, function () {
      * @name pc.BoundingBox
      * @description Create a new axis-aligned bounding box.
      * @class Axis-Aligned Bounding Box.
-     * @param {pc.Vec3} center - center of box.
-     * @param {pc.Vec3} halfExtents - half the distance across the box in each axis.
+     * @param {pc.Vec3} [center] Center of box.
+     * @param {pc.Vec3} [halfExtents] Half the distance across the box in each axis.
      */
     var BoundingBox = function BoundingBox(center, halfExtents) {
         this.center = center ? center.clone() : new pc.Vec3(0, 0, 0);

--- a/src/shape/bounding-box.js
+++ b/src/shape/bounding-box.js
@@ -102,7 +102,7 @@ pc.extend(pc, function () {
                    (aMin.z <= bMax.z) && (aMax.z >= bMin.z);
         },
 
-        _intersectsRay : function (ray, point) {
+        _intersectsRay: function (ray, point) {
             var tMin = tmpVecA.copy(this.getMin()).sub(ray.origin).data;
             var tMax = tmpVecB.copy(this.getMax()).sub(ray.origin).data;
             var dir = ray.direction.data;
@@ -146,7 +146,7 @@ pc.extend(pc, function () {
             return intersects;
         },
 
-        _fastIntersectsRay : function (ray) {
+        _fastIntersectsRay: function (ray) {
             var diff = tmpVecA;
             var cross = tmpVecB;
             var prod = tmpVecC;
@@ -173,13 +173,13 @@ pc.extend(pc, function () {
             cross.cross(rayDir, diff);
             cross.set(Math.abs(cross.x), Math.abs(cross.y), Math.abs(cross.z));
 
-            if (cross.x > this.halfExtents.y*absDir.z + this.halfExtents.z*absDir.y)
+            if (cross.x > this.halfExtents.y * absDir.z + this.halfExtents.z * absDir.y)
                 return false;
 
-            if (cross.y > this.halfExtents.x*absDir.z + this.halfExtents.z*absDir.x)
+            if (cross.y > this.halfExtents.x * absDir.z + this.halfExtents.z * absDir.x)
                 return false;
 
-            if (cross.z > this.halfExtents.x*absDir.y + this.halfExtents.y*absDir.x)
+            if (cross.z > this.halfExtents.x * absDir.y + this.halfExtents.y * absDir.x)
                 return false;
 
             return true;

--- a/src/shape/bounding-box.js
+++ b/src/shape/bounding-box.js
@@ -10,12 +10,12 @@ pc.extend(pc, function () {
      * @name pc.BoundingBox
      * @description Create a new axis-aligned bounding box.
      * @class Axis-Aligned Bounding Box.
-     * @param {pc.Vec3} [center] Center of box.
-     * @param {pc.Vec3} [halfExtents] Half the distance across the box in each axis.
+     * @param {pc.Vec3} [center] Center of box. The constructor takes a reference of this parameter.
+     * @param {pc.Vec3} [halfExtents] Half the distance across the box in each axis. The constructor takes a reference of this parameter.
      */
     var BoundingBox = function BoundingBox(center, halfExtents) {
-        this.center = center ? center.clone() : new pc.Vec3(0, 0, 0);
-        this.halfExtents = halfExtents ? halfExtents.clone() : new pc.Vec3(0.5, 0.5, 0.5);
+        this.center = center || new pc.Vec3(0, 0, 0);
+        this.halfExtents = halfExtents || new pc.Vec3(0.5, 0.5, 0.5);
         this._min = new pc.Vec3();
         this._max = new pc.Vec3();
     };

--- a/src/shape/bounding-sphere.js
+++ b/src/shape/bounding-sphere.js
@@ -69,16 +69,6 @@ pc.extend(pc, function () {
             this.radius = Math.sqrt(maxDistSq);
         },
 
-        intersectRay: function (ray) {
-            // Backwards compatible
-            console.warn('[DEPRECATED]: pc.BoundingSphere#intersectRay. Please use pc.BoundingSphere#intersectsRay instead.');
-            var point = new pc.Vec3();
-            if (this.intersectsRay(ray, point))
-                return point;
-
-            return null;
-        },
-
         /**
          * @function
          * @name pc.BoundingSphere#intersectsRay

--- a/src/shape/bounding-sphere.js
+++ b/src/shape/bounding-sphere.js
@@ -102,9 +102,6 @@ pc.extend(pc, function () {
         }
     };
 
-    // For backwards compatibility
-    BoundingSphere.prototype.intersectRay = BoundingSphere.prototype.intersectsRay;
-
     return {
         BoundingSphere: BoundingSphere
     };

--- a/src/shape/bounding-sphere.js
+++ b/src/shape/bounding-sphere.js
@@ -70,6 +70,19 @@ pc.extend(pc, function () {
         },
 
         intersectRay: function (ray) {
+            console.warn('[DEPRECATED]: pc.BoundingSphere#intersectRay. Please use pc.BoundingSphere#intersectsRay instead.');
+            return this.intersectsRay(ray);
+        },
+
+        /**
+         * @function
+         * @name pc.BoundingSphere#intersectsRay
+         * @description Test if a ray intersects with the sphere
+         * @param {pc.Ray} ray Ray to test against (direction must be normalized)
+         * @param {pc.Vec3} [point] If there is an intersection, the intersection point will be copied into here
+         * @returns {Boolean} True if there is an intersection
+         */
+        intersectsRay: function (ray, point) {
             var m = tmpVecA.copy(ray.origin).sub(this.center);
             var b = m.dot(tmpVecB.copy(ray.direction).normalize());
             var c = m.dot(m) - this.radius * this.radius;
@@ -81,13 +94,16 @@ pc.extend(pc, function () {
             var discr = b * b - c;
             // a negative discriminant corresponds to ray missing sphere
             if (discr < 0)
-                return null;
+                return false;
 
             // ray intersects sphere, compute smallest t value of intersection
             var t = Math.abs(-b - Math.sqrt(discr));
 
             // if t is negative, ray started inside sphere so clamp t to zero
-            return ray.direction.clone().scale(t).add(ray.origin);
+            if (point)
+                point.copy(ray.direction).scale(t).add(ray.origin);
+
+            return true;
         }
     };
 

--- a/src/shape/bounding-sphere.js
+++ b/src/shape/bounding-sphere.js
@@ -15,7 +15,7 @@ pc.extend(pc, function () {
      * @param {Number} [radius] The radius of the bounding sphere. Defaults to 0.5.
      */
     function BoundingSphere(center, radius) {
-        this.center = center || new pc.Vec3(0, 0, 0);
+        this.center = center ? center.clone() : new pc.Vec3(0, 0, 0);
         this.radius = radius === undefined ? 0.5 : radius;
     }
 
@@ -72,10 +72,10 @@ pc.extend(pc, function () {
         /**
          * @function
          * @name pc.BoundingSphere#intersectsRay
-         * @description Test if a ray intersects with the sphere
-         * @param {pc.Ray} ray Ray to test against (direction must be normalized)
-         * @param {pc.Vec3} [point] If there is an intersection, the intersection point will be copied into here
-         * @returns {Boolean} True if there is an intersection
+         * @description Test if a ray intersects with the sphere.
+         * @param {pc.Ray} ray Ray to test against (direction must be normalized).
+         * @param {pc.Vec3} [point] If there is an intersection, the intersection point will be copied into here.
+         * @returns {Boolean} True if there is an intersection.
          */
         intersectsRay: function (ray, point) {
             var m = tmpVecA.copy(ray.origin).sub(this.center);

--- a/src/shape/bounding-sphere.js
+++ b/src/shape/bounding-sphere.js
@@ -11,11 +11,11 @@ pc.extend(pc, function () {
      * @example
      * // Create a new bounding sphere centered on the origin with a radius of 0.5
      * var sphere = new pc.BoundingSphere();
-     * @param {pc.Vec3} [center] The world space coordinate marking the center of the sphere.
+     * @param {pc.Vec3} [center] The world space coordinate marking the center of the sphere. The constructor takes a reference of this parameter.
      * @param {Number} [radius] The radius of the bounding sphere. Defaults to 0.5.
      */
     function BoundingSphere(center, radius) {
-        this.center = center ? center.clone() : new pc.Vec3(0, 0, 0);
+        this.center = center || new pc.Vec3(0, 0, 0);
         this.radius = radius === undefined ? 0.5 : radius;
     }
 

--- a/src/shape/bounding-sphere.js
+++ b/src/shape/bounding-sphere.js
@@ -70,8 +70,13 @@ pc.extend(pc, function () {
         },
 
         intersectRay: function (ray) {
+            // Backwards compatible
             console.warn('[DEPRECATED]: pc.BoundingSphere#intersectRay. Please use pc.BoundingSphere#intersectsRay instead.');
-            return this.intersectsRay(ray);
+            var point = new pc.Vec3();
+            if (this.intersectsRay(ray, point))
+                return point;
+
+            return null;
         },
 
         /**

--- a/src/shape/bounding-sphere.js
+++ b/src/shape/bounding-sphere.js
@@ -102,6 +102,9 @@ pc.extend(pc, function () {
         }
     };
 
+    // For backwards compatibility
+    BoundingSphere.prototype.intersectRay = BoundingSphere.prototype.intersectsRay;
+
     return {
         BoundingSphere: BoundingSphere
     };

--- a/src/shape/plane.js
+++ b/src/shape/plane.js
@@ -5,31 +5,54 @@ pc.extend(pc, function () {
     /**
      * @private
      * @name pc.Plane
-     * @class An infinite plane
-     * @description Create an infinite plane
+     * @class An infinite plane.
+     * @description Create an infinite plane.
+     * @param {pc.Vec3} point Point position on the plane.
+     * @param {pc.Vec3} normal Normal of the plane.
      */
     var Plane = function Plane (point, normal) {
-        this.normal = normal || new pc.Vec3(0, 0, 1);
-        this.point  = point || new pc.Vec3(0, 0, 0);
+        this.normal = normal ? normal.clone() : new pc.Vec3(0, 0, 1);
+        this.point = point ? point.clone() : new pc.Vec3(0, 0, 0);
         this.d = -this.normal.dot(this.point);
     };
 
     Plane.prototype = {
-        distance: function (pos) {
-            return this.normal.dot(pos) + this.d;
+         /**
+         * @function
+         * @name pc.Plane#set
+         * @description Sets the plane point and normal. Use this method when moving the plane.
+         * @param {pc.Vec3} point Point position on the plane.
+         * @param {pc.Vec3} normal Normal of the plane.
+         */
+        set: function (point, normal) {
+            this.normal.copy(normal);
+            this.point.copy(point);
+            this.d = -this.normal.dot(this.point);
         },
 
-        intersect: function (p0, p1) {
-            var d0 = this.distance(p0);
-            var d1 = this.distance(p1);
+        _intersect: function (p0, p1) {
+            var d0 = this.normal.dot(p0) + this.d;
+            var d1 = this.normal.dot(p1) + this.d;
 
             return d0 / (d0 - d1);
         },
 
-        intersectPosition: function (p0, p1) {
-            var t = this.intersect(p0, p1);
-            var r = tmpVecA.lerp(p0, p1, t);
-            return r;
+        /**
+         * @function
+         * @name pc.Plane#intersectsPoint
+         * @description Test if the plane intersects between two points.
+         * @param {pc.Vec3} p0 First point position.
+         * @param {pc.Vec3} p1 Second point position.
+         * @param {pc.Vec3} [point] If there is an intersection, the intersection point will be copied into here.
+         * @returns {Boolean} True if there is an intersection.
+         */
+        intersectsPoint: function (p0, p1, point) {
+            var t = this._intersect(p0, p1);
+            var intersects = t >= 0;
+            if (intersects && point)
+                point.lerp(p0, p1, t);
+
+            return intersects;
         },
 
         /**

--- a/src/shape/plane.js
+++ b/src/shape/plane.js
@@ -1,4 +1,7 @@
 pc.extend(pc, function () {
+    var rayDepth = 100000;
+    var tmpVecA = new pc.Vec3();
+
     /**
      * @private
      * @name pc.Plane
@@ -28,7 +31,28 @@ pc.extend(pc, function () {
             var r = new pc.Vec3();
             r.lerp(p0, p1, t);
             return r;
-        }
+        },
+
+        /**
+         * @function
+         * @name pc.Plane#intersectsRay
+         * @description Test if a ray intersects with the infinite plane
+         * @param {pc.Ray} ray Ray to test against (direction must be normalized)
+         * @param {pc.Vec3} [point] If there is an intersection, the intersection point will be copied into here
+         * @returns {Boolean} True if there is an intersection
+         */
+        intersectsRay: function (ray, point) {
+            var p0 = ray.origin;
+            var p1 = tmpVecA.copy(ray.direction).scale(rayDepth).add(p0);
+
+            var t = this.intersect(p0, p1);
+
+            var intersects = t >= 0;
+            if (intersects && point)
+                point.copy(ray.direction).scale(t * rayDepth).add(ray.origin);
+
+            return intersects;
+        },
     };
 
     return {

--- a/src/shape/plane.js
+++ b/src/shape/plane.js
@@ -6,12 +6,12 @@ pc.extend(pc, function () {
      * @name pc.Plane
      * @class An infinite plane.
      * @description Create an infinite plane.
-     * @param {pc.Vec3} [point] Point position on the plane.
-     * @param {pc.Vec3} [normal] Normal of the plane.
+     * @param {pc.Vec3} [point] Point position on the plane. The constructor takes a reference of this parameter.
+     * @param {pc.Vec3} [normal] Normal of the plane. The constructor takes a reference of this parameter.
      */
     var Plane = function Plane (point, normal) {
-        this.normal = normal ? normal.clone() : new pc.Vec3(0, 0, 1);
-        this.point = point ? point.clone() : new pc.Vec3(0, 0, 0);
+        this.normal = normal || new pc.Vec3(0, 0, 1);
+        this.point = point || new pc.Vec3(0, 0, 0);
     };
 
     Plane.prototype = {

--- a/src/shape/plane.js
+++ b/src/shape/plane.js
@@ -41,14 +41,12 @@ pc.extend(pc, function () {
          * @returns {Boolean} True if there is an intersection
          */
         intersectsRay: function (ray, point) {
-            var p0 = ray.origin;
-            var p1 = tmpVecA.copy(ray.direction).scale(rayDepth).add(p0);
-
-            var t = this.intersect(p0, p1);
-
+            var pointToOrigin = tmpVecA.sub2(this.point, ray.origin);
+            var t = this.normal.dot(pointToOrigin) / this.normal.dot(ray.direction);
             var intersects = t >= 0;
+
             if (intersects && point)
-                point.copy(ray.direction).scale(t * rayDepth).add(ray.origin);
+                point.copy(ray.direction).scale(t).add(ray.origin);
 
             return intersects;
         },

--- a/src/shape/plane.js
+++ b/src/shape/plane.js
@@ -1,5 +1,4 @@
 pc.extend(pc, function () {
-    var rayDepth = 100000;
     var tmpVecA = new pc.Vec3();
 
     /**
@@ -11,42 +10,29 @@ pc.extend(pc, function () {
      * @param {pc.Vec3} normal Normal of the plane.
      */
     var Plane = function Plane (point, normal) {
-        this.normal = normal ? normal.clone() : new pc.Vec3(0, 0, 1);
-        this.point = point ? point.clone() : new pc.Vec3(0, 0, 0);
-        this.d = -this.normal.dot(this.point);
+        this._normal = normal ? normal.clone() : new pc.Vec3(0, 0, 1);
+        this._point = point ? point.clone() : new pc.Vec3(0, 0, 0);
+        this._d = -this._normal.dot(this._point);
     };
 
     Plane.prototype = {
-         /**
-         * @function
-         * @name pc.Plane#set
-         * @description Sets the plane point and normal. Use this method when moving the plane.
-         * @param {pc.Vec3} point Point position on the plane.
-         * @param {pc.Vec3} normal Normal of the plane.
-         */
-        set: function (point, normal) {
-            this.normal.copy(normal);
-            this.point.copy(point);
-            this.d = -this.normal.dot(this.point);
-        },
-
         _intersect: function (p0, p1) {
-            var d0 = this.normal.dot(p0) + this.d;
-            var d1 = this.normal.dot(p1) + this.d;
+            var d0 = this._normal.dot(p0) + this._d;
+            var d1 = this._normal.dot(p1) + this._d;
 
             return d0 / (d0 - d1);
         },
 
         /**
          * @function
-         * @name pc.Plane#intersectsPoint
+         * @name pc.Plane#intersectsLine
          * @description Test if the plane intersects between two points.
          * @param {pc.Vec3} p0 First point position.
          * @param {pc.Vec3} p1 Second point position.
          * @param {pc.Vec3} [point] If there is an intersection, the intersection point will be copied into here.
          * @returns {Boolean} True if there is an intersection.
          */
-        intersectsPoint: function (p0, p1, point) {
+        intersectsLine: function (p0, p1, point) {
             var t = this._intersect(p0, p1);
             var intersects = t >= 0;
             if (intersects && point)
@@ -64,8 +50,8 @@ pc.extend(pc, function () {
          * @returns {Boolean} True if there is an intersection
          */
         intersectsRay: function (ray, point) {
-            var pointToOrigin = tmpVecA.sub2(this.point, ray.origin);
-            var t = this.normal.dot(pointToOrigin) / this.normal.dot(ray.direction);
+            var pointToOrigin = tmpVecA.sub2(this._point, ray.origin);
+            var t = this._normal.dot(pointToOrigin) / this._normal.dot(ray.direction);
             var intersects = t >= 0;
 
             if (intersects && point)
@@ -74,6 +60,36 @@ pc.extend(pc, function () {
             return intersects;
         },
     };
+
+    /**
+     * @name pc.Plane#normal
+     * @type pc.Vec3
+     * @description The normal of the plane.
+     */
+    Object.defineProperty(Plane.prototype, 'normal', {
+        get: function () {
+            return this._normal;
+        },
+        set: function (value) {
+            this._normal.copy(value);
+            this._d = -this._normal.dot(this._point);
+        }
+    });
+
+    /**
+     * @name pc.Plane#point
+     * @type pc.Vec3
+     * @description A point on the plane.
+     */
+    Object.defineProperty(Plane.prototype, 'point', {
+        get: function () {
+            return this._point;
+        },
+        set: function (value) {
+            this._point.copy(value);
+            this._d = -this._normal.dot(this._point);
+        }
+    });
 
     return {
         Plane: Plane

--- a/src/shape/plane.js
+++ b/src/shape/plane.js
@@ -10,15 +10,15 @@ pc.extend(pc, function () {
      * @param {pc.Vec3} [normal] Normal of the plane.
      */
     var Plane = function Plane (point, normal) {
-        this._normal = normal ? normal.clone() : new pc.Vec3(0, 0, 1);
-        this._point = point ? point.clone() : new pc.Vec3(0, 0, 0);
-        this._d = -this._normal.dot(this._point);
+        this.normal = normal ? normal.clone() : new pc.Vec3(0, 0, 1);
+        this.point = point ? point.clone() : new pc.Vec3(0, 0, 0);
     };
 
     Plane.prototype = {
         _intersect: function (p0, p1) {
-            var d0 = this._normal.dot(p0) + this._d;
-            var d1 = this._normal.dot(p1) + this._d;
+            var d = -this.normal.dot(this.point);
+            var d0 = this.normal.dot(p0) + d;
+            var d1 = this.normal.dot(p1) + d;
 
             return d0 / (d0 - d1);
         },
@@ -50,8 +50,8 @@ pc.extend(pc, function () {
          * @returns {Boolean} True if there is an intersection
          */
         intersectsRay: function (ray, point) {
-            var pointToOrigin = tmpVecA.sub2(this._point, ray.origin);
-            var t = this._normal.dot(pointToOrigin) / this._normal.dot(ray.direction);
+            var pointToOrigin = tmpVecA.sub2(this.point, ray.origin);
+            var t = this.normal.dot(pointToOrigin) / this.normal.dot(ray.direction);
             var intersects = t >= 0;
 
             if (intersects && point)
@@ -60,36 +60,6 @@ pc.extend(pc, function () {
             return intersects;
         },
     };
-
-    /**
-     * @name pc.Plane#normal
-     * @type pc.Vec3
-     * @description The normal of the plane.
-     */
-    Object.defineProperty(Plane.prototype, 'normal', {
-        get: function () {
-            return this._normal;
-        },
-        set: function (value) {
-            this._normal.copy(value);
-            this._d = -this._normal.dot(this._point);
-        }
-    });
-
-    /**
-     * @name pc.Plane#point
-     * @type pc.Vec3
-     * @description A point on the plane.
-     */
-    Object.defineProperty(Plane.prototype, 'point', {
-        get: function () {
-            return this._point;
-        },
-        set: function (value) {
-            this._point.copy(value);
-            this._d = -this._normal.dot(this._point);
-        }
-    });
 
     return {
         Plane: Plane

--- a/src/shape/plane.js
+++ b/src/shape/plane.js
@@ -15,14 +15,6 @@ pc.extend(pc, function () {
     };
 
     Plane.prototype = {
-        _intersect: function (p0, p1) {
-            var d = -this.normal.dot(this.point);
-            var d0 = this.normal.dot(p0) + d;
-            var d1 = this.normal.dot(p1) + d;
-
-            return d0 / (d0 - d1);
-        },
-
         /**
          * @function
          * @name pc.Plane#intersectsLine
@@ -33,7 +25,11 @@ pc.extend(pc, function () {
          * @returns {Boolean} True if there is an intersection.
          */
         intersectsLine: function (start, end, point) {
-            var t = this._intersect(start, end);
+            var d = -this.normal.dot(this.point);
+            var d0 = this.normal.dot(p0) + d;
+            var d1 = this.normal.dot(p1) + d;
+
+            var t = d0 / (d0 - d1);
             var intersects = t >= 0 && t <= 1;
             if (intersects && point)
                 point.lerp(start, end, t);

--- a/src/shape/plane.js
+++ b/src/shape/plane.js
@@ -6,8 +6,8 @@ pc.extend(pc, function () {
      * @name pc.Plane
      * @class An infinite plane.
      * @description Create an infinite plane.
-     * @param {pc.Vec3} point Point position on the plane.
-     * @param {pc.Vec3} normal Normal of the plane.
+     * @param {pc.Vec3} [point] Point position on the plane.
+     * @param {pc.Vec3} [normal] Normal of the plane.
      */
     var Plane = function Plane (point, normal) {
         this._normal = normal ? normal.clone() : new pc.Vec3(0, 0, 1);

--- a/src/shape/plane.js
+++ b/src/shape/plane.js
@@ -28,8 +28,7 @@ pc.extend(pc, function () {
 
         intersectPosition: function (p0, p1) {
             var t = this.intersect(p0, p1);
-            var r = new pc.Vec3();
-            r.lerp(p0, p1, t);
+            var r = tmpVecA.lerp(p0, p1, t);
             return r;
         },
 

--- a/src/shape/plane.js
+++ b/src/shape/plane.js
@@ -27,16 +27,16 @@ pc.extend(pc, function () {
          * @function
          * @name pc.Plane#intersectsLine
          * @description Test if the plane intersects between two points.
-         * @param {pc.Vec3} p0 First point position.
-         * @param {pc.Vec3} p1 Second point position.
+         * @param {pc.Vec3} start Start position of line.
+         * @param {pc.Vec3} end End position of line.
          * @param {pc.Vec3} [point] If there is an intersection, the intersection point will be copied into here.
          * @returns {Boolean} True if there is an intersection.
          */
-        intersectsLine: function (p0, p1, point) {
-            var t = this._intersect(p0, p1);
-            var intersects = t >= 0;
+        intersectsLine: function (start, end, point) {
+            var t = this._intersect(start, end);
+            var intersects = t >= 0 && t <= 1;
             if (intersects && point)
-                point.lerp(p0, p1, t);
+                point.lerp(start, end, t);
 
             return intersects;
         },

--- a/src/shape/ray.js
+++ b/src/shape/ray.js
@@ -7,9 +7,9 @@ pc.extend(pc, function () {
      * // Create a new ray starting at the position of this entity and pointing down
      * // the entity's negative Z axis
      * var ray = new pc.Ray(this.entity.getPosition(), this.entity.forward);
-     * @param {pc.Vec3} [origin] The starting point of the ray. The constructor takes a copy of this parameter.
+     * @param {pc.Vec3} [origin] The starting point of the ray. The constructor takes a reference of this parameter.
      * Defaults to the origin (0, 0, 0).
-     * @param {pc.Vec3} [direction] The direction of the ray.  The constructor takes a copy of this parameter.
+     * @param {pc.Vec3} [direction] The direction of the ray. The constructor takes a reference of this parameter.
      * Defaults to a direction down the world negative Z axis (0, 0, -1).
      */
     var Ray = function Ray(origin, direction) {


### PR DESCRIPTION
pc.Plane, pc.BoundingBox and pc.BoundingSphere now have a standardised function for intersectsRay and all are capable of calculating the intersection point.

Added documentation for intersectsRay.

Constructors now clone the params that are passed rather than store a reference.

Removed any allocations of pc.Vec3 in the functions.