### PR TITLE
Fixed infinite raycast bug in aabb intersectsRay

### DIFF
--- a/src/shape/bounding-box.js
+++ b/src/shape/bounding-box.js
@@ -124,7 +124,7 @@ pc.extend(pc, function () {
             var minMax = Math.min(Math.min(realMax[0], realMax[1]), realMax[2]);
             var maxMin = Math.max(Math.max(realMin[0], realMin[1]), realMin[2]);
 
-            var intersects = minMax >= maxMin;
+            var intersects = minMax >= maxMin && maxMin >= 0;
 
             if (intersects)
                 point.copy(ray.direction).scale(maxMin).add(ray.origin);


### PR DESCRIPTION
The bug is that the raycast will also intersect with the aabb behind the ray's position

This project shows the bug: https://playcanvas.com/project/449277/overview

Pressing 1 on the keyboard will put the box in front of the ray (represented by the cone).
Pressing 2 will put the box behind the ray and you can see the ray's intersection point by the red sphere.

With the fix, the intersection only shows when the box is in front of the ray.