### PR TITLE
Clear reference to material when destroying mesh instance

### DIFF
--- a/src/scene/mesh.js
+++ b/src/scene/mesh.js
@@ -270,10 +270,12 @@ pc.extend(pc, function () {
 
             this._material = material;
 
-            // Record that the material is referenced by this mesh instance
-            this._material.meshInstances.push(this);
+            if (this._material) {
+                // Record that the material is referenced by this mesh instance
+                this._material.meshInstances.push(this);
 
-            this.updateKey();
+                this.updateKey();
+            }
         }
     });
 

--- a/src/scene/model.js
+++ b/src/scene/model.js
@@ -143,11 +143,11 @@ pc.extend(pc, function () {
          * It is recommended to use asset.unload() instead, which will also remove the model from the scene.
          */
         destroy: function () {
-            var meshes = this.meshInstances;
+            var meshInstances = this.meshInstances;
             var meshInstance, mesh, skin, ib, boneTex, j;
             var device;
-            for(var i=0; i<meshes.length; i++) {
-                meshInstance = meshes[i];
+            for(var i = 0; i < meshInstances.length; i++) {
+                meshInstance = meshInstances[i];
 
                 mesh = meshInstance.mesh;
                 if (mesh) {
@@ -176,6 +176,7 @@ pc.extend(pc, function () {
                     }
                 }
                 meshInstance.skinInstance = null;
+                meshInstance.material = null; // make sure instance and material clear references
             }
             if (device) device.onVertexBufferDeleted();
         },


### PR DESCRIPTION
(this reference prevents mesh instance getting GC’d because material references back)