### PR TITLE
Add optional data-array-parameter to vectors, matrices, quaternion and color constructors

### DIFF
--- a/src/core/color.js
+++ b/src/core/color.js
@@ -3,9 +3,9 @@ pc.extend(pc, (function () {
     * @name pc.Color
     * @class Representation of an RGBA color
     * @description Create a new Color object
-    * @param {Number} r The value of the red component (0-1)
-    * @param {Number} g The value of the green component (0-1)
-    * @param {Number} b The value of the blue component (0-1)
+    * @param {Number} [r] The value of the red component (0-1). If r is an array of length 4, the array will be used to populate all components.
+    * @param {Number} [g] The value of the green component (0-1)
+    * @param {Number} [b] The value of the blue component (0-1)
     * @param {Number} [a] The value of the alpha component (0-1)
     * @property {Number} r The red component of the color
     * @property {Number} g The green component of the color

--- a/src/core/color.js
+++ b/src/core/color.js
@@ -13,10 +13,12 @@ pc.extend(pc, (function () {
     * @property {Number} a The alpha component of the color
     */
     var Color = function (r, g, b, a) {
-        this.buffer = new ArrayBuffer(4 * 4);
+        if (r && r.length === 4) {
+            this.data = new Float32Array(r);
+            return;
+        }
 
-        this.data = new Float32Array(this.buffer, 0, 4);
-        this.data3 = new Float32Array(this.buffer, 0, 3);
+        this.data = new Float32Array(4);
 
         this.data[0] = r || 0;
         this.data[1] = g || 0;

--- a/src/core/color.js
+++ b/src/core/color.js
@@ -18,7 +18,8 @@ pc.extend(pc, (function () {
         this.data = new Float32Array(this.buffer, 0, 4);
         this.data3 = new Float32Array(this.buffer, 0, 3);
 
-        if (r && (r.length === 3 || r.length === 4)) {
+        var length = r && r.length;
+        if (length === 3 || length === 4) {
             this.data[0] = r[0];
             this.data[1] = r[1];
             this.data[2] = r[2];

--- a/src/core/color.js
+++ b/src/core/color.js
@@ -3,7 +3,7 @@ pc.extend(pc, (function () {
     * @name pc.Color
     * @class Representation of an RGBA color
     * @description Create a new Color object
-    * @param {Number} [r] The value of the red component (0-1). If r is an array of length 4, the array will be used to populate all components.
+    * @param {Number} [r] The value of the red component (0-1). If r is an array of length 3 or 4, the array will be used to populate all components.
     * @param {Number} [g] The value of the green component (0-1)
     * @param {Number} [b] The value of the blue component (0-1)
     * @param {Number} [a] The value of the alpha component (0-1)
@@ -13,17 +13,22 @@ pc.extend(pc, (function () {
     * @property {Number} a The alpha component of the color
     */
     var Color = function (r, g, b, a) {
-        if (r && r.length === 4) {
-            this.data = new Float32Array(r);
-            return;
+        this.buffer = new ArrayBuffer(4 * 4);
+
+        this.data = new Float32Array(this.buffer, 0, 4);
+        this.data3 = new Float32Array(this.buffer, 0, 3);
+
+        if (r && (r.length === 3 || r.length === 4)) {
+            this.data[0] = r[0];
+            this.data[1] = r[1];
+            this.data[2] = r[2];
+            this.data[3] = r[3] !== undefined ? r[3] : 1.0;
+        } else {
+            this.data[0] = r || 0;
+            this.data[1] = g || 0;
+            this.data[2] = b || 0;
+            this.data[3] = a !== undefined ? a : 1.0;
         }
-
-        this.data = new Float32Array(4);
-
-        this.data[0] = r || 0;
-        this.data[1] = g || 0;
-        this.data[2] = b || 0;
-        this.data[3] = a !== undefined ? a : 1.0;
     };
 
     Color.prototype = {

--- a/src/math/mat3.js
+++ b/src/math/mat3.js
@@ -7,6 +7,15 @@ pc.extend(pc, (function () {
     * @name pc.Mat3
     * @class A 3x3 matrix.
     * @description Creates a new Mat3 object
+    * @param {Number} [v0] The value in row 0, column 0. If v0 is an array of length 9, the array will be used to populate all components.
+    * @param {Number} [v1] The value in row 1, column 0.
+    * @param {Number} [v2] The value in row 2, column 0.
+    * @param {Number} [v3] The value in row 0, column 1.
+    * @param {Number} [v4] The value in row 1, column 1.
+    * @param {Number} [v5] The value in row 2, column 1.
+    * @param {Number} [v6] The value in row 0, column 2.
+    * @param {Number} [v7] The value in row 1, column 2.
+    * @param {Number} [v8] The value in row 2, column 2.
     */
     var Mat3 = function (v0, v1, v2, v3, v4, v5, v6, v7, v8) {
         if (v0 && v0.length === 9) {

--- a/src/math/mat3.js
+++ b/src/math/mat3.js
@@ -9,6 +9,11 @@ pc.extend(pc, (function () {
     * @description Creates a new Mat3 object
     */
     var Mat3 = function (v0, v1, v2, v3, v4, v5, v6, v7, v8) {
+        if (v0 && v0.length === 9) {
+            this.data = new Float32Array(v0);
+            return;
+        }
+
         this.data = new Float32Array(9);
 
         if (typeof(v0) === typeNumber) {

--- a/src/math/mat4.js
+++ b/src/math/mat4.js
@@ -897,7 +897,7 @@ pc.extend(pc, (function () {
 
             m[12] = tx;
             m[13] = ty;
-            m[14 = 2 + 4 * 3] = tz;
+            m[14] = tz;
             m[15] = 1;
 
             return this;

--- a/src/math/mat4.js
+++ b/src/math/mat4.js
@@ -9,6 +9,11 @@ pc.extend(pc, (function () {
     * @description Creates a new Mat4 object
     */
     var Mat4 = function (v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15) {
+        if (v0 && v0.length === 16) {
+            this.data = new Float32Array(v0);
+            return;
+        }
+
         this.data = new Float32Array(16);
 
         if (typeof(v0) === typeNumber) {

--- a/src/math/mat4.js
+++ b/src/math/mat4.js
@@ -7,6 +7,22 @@ pc.extend(pc, (function () {
     * @name pc.Mat4
     * @class A 4x4 matrix.
     * @description Creates a new Mat4 object
+    * @param {Number} [v0] The value in row 0, column 0. If v0 is an array of length 16, the array will be used to populate all components.
+    * @param {Number} [v1] The value in row 1, column 0.
+    * @param {Number} [v2] The value in row 2, column 0.
+    * @param {Number} [v3] The value in row 3, column 0.
+    * @param {Number} [v4] The value in row 0, column 1.
+    * @param {Number} [v5] The value in row 1, column 1.
+    * @param {Number} [v6] The value in row 2, column 1.
+    * @param {Number} [v7] The value in row 3, column 1.
+    * @param {Number} [v8] The value in row 0, column 2.
+    * @param {Number} [v9] The value in row 1, column 2.
+    * @param {Number} [v10] The value in row 2, column 2.
+    * @param {Number} [v11] The value in row 3, column 2.
+    * @param {Number} [v12] The value in row 0, column 3.
+    * @param {Number} [v13] The value in row 1, column 3.
+    * @param {Number} [v14] The value in row 2, column 3.
+    * @param {Number} [v15] The value in row 3, column 3.
     */
     var Mat4 = function (v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15) {
         if (v0 && v0.length === 16) {
@@ -881,7 +897,7 @@ pc.extend(pc, (function () {
 
             m[12] = tx;
             m[13] = ty;
-            m[14] = tz;
+            m[14 = 2 + 4 * 3] = tz;
             m[15] = 1;
 
             return this;

--- a/src/math/quat.js
+++ b/src/math/quat.js
@@ -5,7 +5,7 @@ pc.extend(pc, (function () {
     * @name pc.Quat
     * @class A quaternion.
     * @description Create a new Quat object
-    * @param {Number} [x] The quaternion's x component. Default value 0.
+    * @param {Number} [x] The quaternion's x component. Default value 0. If x is an array of length 4, the array will be used to populate all components.
     * @param {Number} [y] The quaternion's y component. Default value 0.
     * @param {Number} [z] The quaternion's z component. Default value 0.
     * @param {Number} [w] The quaternion's w component. Default value 1.
@@ -67,10 +67,17 @@ pc.extend(pc, (function () {
      * quat.w = 0;
      */
     var Quat = function (x, y, z, w) {
-        this.x = (x === undefined) ? 0 : x;
-        this.y = (y === undefined) ? 0 : y;
-        this.z = (z === undefined) ? 0 : z;
-        this.w = (w === undefined) ? 1 : w;
+        if (x && x.length === 4) {
+            this.x = x[0];
+            this.y = x[1];
+            this.z = x[2];
+            this.w = x[3];
+        } else {
+            this.x = (x === undefined) ? 0 : x;
+            this.y = (y === undefined) ? 0 : y;
+            this.z = (z === undefined) ? 0 : z;
+            this.w = (w === undefined) ? 1 : w;
+        }
     };
 
     Quat.prototype = {

--- a/src/math/vec2.js
+++ b/src/math/vec2.js
@@ -5,21 +5,19 @@ pc.extend(pc, (function () {
     * @name pc.Vec2
     * @class A 2-dimensional vector.
     * @description Creates a new Vec2 object
+    * @param {Number} [x] The x value
+    * @param {Number} [y] The y value
     */
-    var Vec2 = function (data) {
-        if (data && data.length === 2) {
-            this.data = new Float32Array(data);
+    var Vec2 = function (x, y) {
+        if (x && x.length === 2) {
+            this.data = new Float32Array(x);
             return;
         }
 
         this.data = new Float32Array(2);
 
-        if (arguments.length === 2) {
-            this.data.set(arguments);
-        } else {
-            this.data[0] = 0;
-            this.data[1] = 0;
-        }
+        this.data[0] = x || 0;
+        this.data[1] = y || 0;
     };
 
     Vec2.prototype = {

--- a/src/math/vec2.js
+++ b/src/math/vec2.js
@@ -5,7 +5,7 @@ pc.extend(pc, (function () {
     * @name pc.Vec2
     * @class A 2-dimensional vector.
     * @description Creates a new Vec2 object
-    * @param {Number} [x] The x value
+    * @param {Number} [x] The x value. If x is an array of length 2, the array will be used to populate all components.
     * @param {Number} [y] The y value
     */
     var Vec2 = function (x, y) {

--- a/src/math/vec2.js
+++ b/src/math/vec2.js
@@ -6,7 +6,12 @@ pc.extend(pc, (function () {
     * @class A 2-dimensional vector.
     * @description Creates a new Vec2 object
     */
-    var Vec2 = function () {
+    var Vec2 = function (data) {
+        if (data && data.length === 2) {
+            this.data = new Float32Array(data);
+            return;
+        }
+
         this.data = new Float32Array(2);
 
         if (arguments.length === 2) {

--- a/src/math/vec3.js
+++ b/src/math/vec3.js
@@ -5,7 +5,7 @@ pc.extend(pc, (function () {
     * @name pc.Vec3
     * @class A 3-dimensional vector.
     * @description Creates a new Vec3 object
-    * @param {Number} [x] The x value
+    * @param {Number} [x] The x value. If x is an array of length 3, the array will be used to populate all components.
     * @param {Number} [y] The y value
     * @param {Number} [z] The z value
     * @example

--- a/src/math/vec3.js
+++ b/src/math/vec3.js
@@ -12,6 +12,11 @@ pc.extend(pc, (function () {
     * var v = new pc.Vec3(1,2,3);
     */
     var Vec3 = function(x, y, z) {
+        if (x && x.length === 3) {
+            this.data = new Float32Array(x);
+            return;
+        }
+
         this.data = new Float32Array(3);
 
         this.data[0] = x || 0;

--- a/src/math/vec4.js
+++ b/src/math/vec4.js
@@ -5,7 +5,7 @@ pc.extend(pc, (function () {
     * @name pc.Vec4
     * @class A 4-dimensional vector.
     * @description Creates a new Vec4 object
-    * @param {Number} [x] The x value
+    * @param {Number} [x] The x value. If x is an array of length 4, the array will be used to populate all components.
     * @param {Number} [y] The y value
     * @param {Number} [z] The z value
     * @param {Number} [w] The w value

--- a/src/math/vec4.js
+++ b/src/math/vec4.js
@@ -5,23 +5,23 @@ pc.extend(pc, (function () {
     * @name pc.Vec4
     * @class A 4-dimensional vector.
     * @description Creates a new Vec4 object
+    * @param {Number} [x] The x value
+    * @param {Number} [y] The y value
+    * @param {Number} [z] The z value
+    * @param {Number} [w] The w value
     */
-    var Vec4 = function (data) {
-        if (data && data.length === 4) {
-            this.data = new Float32Array(data);
+    var Vec4 = function (x, y, z, w) {
+        if (x && x.length === 4) {
+            this.data = new Float32Array(x);
             return;
         }
 
         this.data = new Float32Array(4);
 
-        if (arguments.length === 4) {
-            this.data.set(arguments);
-        } else {
-            this.data[0] = 0;
-            this.data[1] = 0;
-            this.data[2] = 0;
-            this.data[3] = 0;
-        }
+        this.data[0] = x || 0;
+        this.data[1] = y || 0;
+        this.data[2] = z || 0;
+        this.data[2] = w || 0;
     };
 
     Vec4.prototype = {

--- a/src/math/vec4.js
+++ b/src/math/vec4.js
@@ -21,7 +21,7 @@ pc.extend(pc, (function () {
         this.data[0] = x || 0;
         this.data[1] = y || 0;
         this.data[2] = z || 0;
-        this.data[2] = w || 0;
+        this.data[3] = w || 0;
     };
 
     Vec4.prototype = {

--- a/src/math/vec4.js
+++ b/src/math/vec4.js
@@ -6,7 +6,12 @@ pc.extend(pc, (function () {
     * @class A 4-dimensional vector.
     * @description Creates a new Vec4 object
     */
-    var Vec4 = function () {
+    var Vec4 = function (data) {
+        if (data && data.length === 4) {
+            this.data = new Float32Array(data);
+            return;
+        }
+
         this.data = new Float32Array(4);
 
         if (arguments.length === 4) {


### PR DESCRIPTION
This PR, implements a popular and well requested feature that allows developers to optionally pass a single pure data array as only parameter to all relevant math (and color) primitives (`Vec2`/`3`/`4`, `Mat2`/`3`, `Quat` and `Color`). The passed data array is copied in the constructor (as optimized as possible) and thus used to populate all components instead of manually having to write:
```javascript
var data = [1, 2, 3, 4];
var vector = new pc.Vec4(data[0], data[1], data[2], data[3]); // even worse for Mat3 and Mat4 :)
```
This PR finally lets us just write:
```javascript
var data = [1, 2, 3, 4];
var vector = new pc.Vec4(data); // works for all vectors, matrices, quaternion and color!
```

In addition to alleviating a big annoyance :), this PR also removes the usage of `arguments` in the `Vec2` and `Vec4` constructor, to minimize chance of JS function deoptimisations. And finally as a bonus, the PR also fully documents all original parameters in each constructor (which where missing), in addition to the new optional array parameter of course.

Summary:
- Completely backwards-compatible.
- Full API documentation.
- Tested.
- New optional APIs:
- - `new pc.Vec2(data)`
- - `new pc.Vec3(data)`
- - `new pc.Vec4(data)`
- - `new pc.Mat3(data)`
- - `new pc.Mat3(data)`
- - `new pc.Quat(data)`
- - `new pc.Color(data)`
