### PR TITLE
Feature/autodraw

### DIFF
--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -110,6 +110,9 @@ pc.extend(pc, function () {
         this._time = 0;
         this.timeScale = 1;
 
+        this.autoDraw = true; // enable this to call tick everyframe
+        this.redraw = false; // if autoDraw is false enable this false every frame you wish to render
+
         this._librariesLoaded = false;
         this._fillMode = pc.FILLMODE_KEEP_ASPECT;
         this._resolutionMode = pc.RESOLUTION_FIXED;
@@ -1251,13 +1254,6 @@ pc.extend(pc, function () {
             // have current application pointer in pc
             pc.app = app;
 
-            // Submit a request to queue up a new animation frame immediately
-            if (app.vr && app.vr.display && app.vr.display.presenting) {
-                app.vr.display.requestAnimationFrame(app.tick);
-            } else {
-                window.requestAnimationFrame(app.tick);
-            }
-
             var now = pc.now();
             var ms = now - (app._time || now);
             var dt = ms / 1000.0;
@@ -1267,12 +1263,23 @@ pc.extend(pc, function () {
             dt = pc.math.clamp(dt, 0, 0.1); // Maximum delta is 0.1s or 10 fps.
             dt *= app.timeScale;
 
+            // Submit a request to queue up a new animation frame immediately
+            if (app.vr && app.vr.display && app.vr.display.presenting) {
+                app.vr.display.requestAnimationFrame(app.tick);
+            } else {
+                window.requestAnimationFrame(app.tick);
+            }
+
             // #ifdef PROFILER
             app._fillFrameStats(now, dt, ms);
             // #endif
 
             app.update(dt);
-            app.render();
+
+            if (app.autoDraw || app.redraw) {
+                app.render();
+                app.redraw = false;
+            }
 
             // set event data
             _frameEndData.timestamp = pc.now();
@@ -1284,6 +1291,7 @@ pc.extend(pc, function () {
             if (app.vr && app.vr.display && app.vr.display.presenting) {
                 app.vr.display.submitFrame();
             }
+
         }
     };
     // static data

--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -95,6 +95,18 @@ pc.extend(pc, function () {
      * @description The Script Registry of the Application
      */
 
+     /**
+     * @name pc.Application#autoRender
+     * @type Boolean
+     * @description When true (the default) the application's render function is called every frame.
+     */
+
+     /**
+     * @name pc.Application#renderNextFrame
+     * @type Boolean
+     * @description If {@link pc.Application#autoRender} is false, set `app.renderNextFrame` true to force application to render the scene once in the next update.
+     */
+
     var Application = function (canvas, options) {
         options = options || {};
 
@@ -110,8 +122,9 @@ pc.extend(pc, function () {
         this._time = 0;
         this.timeScale = 1;
 
-        this.autoDraw = true; // enable this to call tick everyframe
-        this.redraw = false; // if autoDraw is false enable this false every frame you wish to render
+
+        this.autoRender = true; // enable this to call tick everyframe
+        this.renderNextFrame = false; // if autoRender is false enable this every frame you wish to render
 
         this._librariesLoaded = false;
         this._fillMode = pc.FILLMODE_KEEP_ASPECT;
@@ -1276,9 +1289,9 @@ pc.extend(pc, function () {
 
             app.update(dt);
 
-            if (app.autoDraw || app.redraw) {
+            if (app.autoRender || app.renderNextFrame) {
                 app.render();
-                app.redraw = false;
+                app.renderNextFrame = false;
             }
 
             // set event data


### PR DESCRIPTION
Added `autoDraw` flag in application, defaults to true.
If `app.autoDraw` is false then render function is not called in main tick. This can be used if an application does not usually update the rendered scene. 

To render a new frame set `app.redraw=true` every time the frame has changed.
