### PR TITLE
WebGL2 transform feedback usage

### DIFF
--- a/build/dependencies.txt
+++ b/build/dependencies.txt
@@ -37,6 +37,7 @@
 ../src/graphics/vertex-format.js
 ../src/graphics/vertex-buffer.js
 ../src/graphics/index-buffer.js
+../src/graphics/transform-feedback.js
 ../src/graphics/texture.js
 ../src/graphics/render-target.js
 ../src/graphics/shader-input.js

--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -1247,6 +1247,7 @@ pc.extend(pc, function () {
             this.context = null;
 
             this.graphicsDevice.clearShaderCache();
+            this.graphicsDevice.destroy();
             this.graphicsDevice.destroyed = true;
             this.graphicsDevice = null;
 

--- a/src/graphics/chunks.js
+++ b/src/graphics/chunks.js
@@ -59,7 +59,7 @@ pc.extend(pc, (function () {
         var cached = shaderCache[uName];
         if (cached !== undefined) return cached;
 
-        psCode = pc.programlib.precisionCode(device) + "\n" + psCode;
+        psCode = pc.programlib.precisionCode(device) + "\n" + (psCode || pc.programlib.dummyFragmentCode());
         var attribs = this.collectAttribs(vsCode);
 
         if (device.webgl2) {

--- a/src/graphics/chunks.js
+++ b/src/graphics/chunks.js
@@ -36,7 +36,7 @@ pc.extend(pc, (function () {
     };
 
 
-    shaderChunks.createShader = function(device, vsName, psName) {
+    shaderChunks.createShader = function(device, vsName, psName, useTransformFeedback) {
         var vsCode = shaderChunks[vsName];
         var psCode = pc.programlib.precisionCode(device) + "\n" + shaderChunks[psName];
         var attribs = this.collectAttribs(vsCode);
@@ -49,11 +49,12 @@ pc.extend(pc, (function () {
         return new pc.Shader(device, {
             attributes: attribs,
             vshader: vsCode,
-            fshader: psCode
+            fshader: psCode,
+            useTransformFeedback: useTransformFeedback
         });
     };
 
-    shaderChunks.createShaderFromCode = function(device, vsCode, psCode, uName) {
+    shaderChunks.createShaderFromCode = function(device, vsCode, psCode, uName, useTransformFeedback) {
         var shaderCache = device.programLib._cache;
         var cached = shaderCache[uName];
         if (cached !== undefined) return cached;
@@ -69,7 +70,8 @@ pc.extend(pc, (function () {
         shaderCache[uName] = new pc.Shader(device, {
             attributes: attribs,
             vshader: vsCode,
-            fshader: psCode
+            fshader: psCode,
+            useTransformFeedback: useTransformFeedback
         });
         return shaderCache[uName];
     };

--- a/src/graphics/device.js
+++ b/src/graphics/device.js
@@ -212,7 +212,7 @@ pc.extend(pc, function () {
 
         // Retrieve the WebGL context
         if (canvas)
-            var preferWebGl2 = options.preferWebGl2 !== undefined ? options.preferWebGl2 : true;
+            var preferWebGl2 = false;///options.preferWebGl2 !== undefined ? options.preferWebGl2 : true;
 
             var names = preferWebGl2 ? ["webgl2", "experimental-webgl2", "webgl", "experimental-webgl"] :
                                        ["webgl", "experimental-webgl"];

--- a/src/graphics/device.js
+++ b/src/graphics/device.js
@@ -417,6 +417,7 @@ pc.extend(pc, function () {
                 this.extDrawBuffers = true;
                 this.maxDrawBuffers = gl.getParameter(gl.MAX_DRAW_BUFFERS);
                 this.maxColorAttachments = gl.getParameter(gl.MAX_COLOR_ATTACHMENTS);
+                this.feedback = gl.createTransformFeedback();
             } else {
                 this.extTextureFloat = gl.getExtension("OES_texture_float");
                 this.extTextureHalfFloat = gl.getExtension("OES_texture_half_float");
@@ -598,6 +599,8 @@ pc.extend(pc, function () {
             this.setStencilTest(false);
             this.setStencilFunc(pc.FUNC_ALWAYS, 0, 0xFF);
             this.setStencilOperation(pc.STENCILOP_KEEP, pc.STENCILOP_KEEP, pc.STENCILOP_KEEP);
+            this.setTransformFeedbackBuffer(null);
+            this.setRaster(true);
 
             this.setClearDepth(1);
             this.setClearColor(0, 0, 0, 0);
@@ -1577,6 +1580,14 @@ pc.extend(pc, function () {
             this._drawCallsPerFrame++;
             this._primsPerFrame[primitive.type] += primitive.count * (numInstances > 1? numInstances : 1);
 
+            if (this.webgl2) {
+                if (this.transformFeedbackBuffer) {
+                    // Enable TF, start writing to out buffer
+                    gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 0, this.transformFeedbackBuffer.bufferId);
+                    gl.beginTransformFeedback(gl.POINTS);
+                }
+            }
+
             if (primitive.indexed) {
                 if (numInstances > 1) {
                     this.extInstancing.drawElementsInstancedANGLE(
@@ -1612,6 +1623,14 @@ pc.extend(pc, function () {
                         primitive.base,
                         primitive.count
                     );
+                }
+            }
+
+            if (this.webgl2) {
+                if (this.transformFeedbackBuffer) {
+                    // disable TF
+                    gl.endTransformFeedback();
+                    gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 0, null);
                 }
             }
         },
@@ -1834,6 +1853,46 @@ pc.extend(pc, function () {
                 this.writeGreen = writeGreen;
                 this.writeBlue = writeBlue;
                 this.writeAlpha = writeAlpha;
+            }
+        },
+
+        /**
+         * @function
+         * @name pc.GraphicsDevice#setTransformFeedbackBuffer
+         * @description Sets the output vertex buffer. It will be written to by a shader with transform feedback varyings.
+         * @param {pc.VertexBuffer} tf The output vertex buffer
+         */
+        setTransformFeedbackBuffer: function (tf) {
+            if (this.transformFeedbackBuffer !== tf) {
+                if (this.webgl2) {
+                    var gl = this.gl;
+                    if (tf) {
+                        gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, this.feedback);
+                    } else {
+                        gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, null);
+                    }
+                }
+                this.transformFeedbackBuffer = tf;
+            }
+        },
+
+        /**
+         * @function
+         * @name pc.GraphicsDevice#setRaster
+         * @description Enables or disables rasterization. Useful with transform feedback, when you only need to process the data without drawing.
+         * @param {Boolean} on True to enable rasterization and false to disable it.
+         */
+        setRaster: function (on) {
+            if (this.raster !== on) {
+                if (this.webgl2) {
+                    var gl = this.gl;
+                    if (on) {
+                        gl.disable(gl.RASTERIZER_DISCARD);
+                    } else {
+                        gl.enable(gl.RASTERIZER_DISCARD);
+                    }
+                }
+                this.raster = on;
             }
         },
 
@@ -2241,6 +2300,12 @@ pc.extend(pc, function () {
 
         removeShaderFromCache: function (shader) {
             this.programLib.removeFromCache(shader);
+        },
+
+        destroy: function () {
+            if (this.webgl2 && this.feedback) {
+                this.gl.deleteTransformFeedback(this.feedback);
+            }
         }
     };
 

--- a/src/graphics/device.js
+++ b/src/graphics/device.js
@@ -1854,7 +1854,7 @@ pc.extend(pc, function () {
 
         /**
          * @function
-         * @name pc.GraphicsDevice#setTransformFeedbackBuffer
+         * @name @private pc.GraphicsDevice#setTransformFeedbackBuffer
          * @description Sets the output vertex buffer. It will be written to by a shader with transform feedback varyings.
          * @param {pc.VertexBuffer} tf The output vertex buffer
          */
@@ -1876,21 +1876,22 @@ pc.extend(pc, function () {
 
         /**
          * @function
-         * @name pc.GraphicsDevice#setRaster
+         * @name @private pc.GraphicsDevice#setRaster
          * @description Enables or disables rasterization. Useful with transform feedback, when you only need to process the data without drawing.
          * @param {Boolean} on True to enable rasterization and false to disable it.
          */
         setRaster: function (on) {
-            if (this.raster !== on) {
-                if (this.webgl2) {
-                    var gl = this.gl;
-                    if (on) {
-                        gl.disable(gl.RASTERIZER_DISCARD);
-                    } else {
-                        gl.enable(gl.RASTERIZER_DISCARD);
-                    }
+            if (this.raster === on) return;
+
+            this.raster = on;
+
+            if (this.webgl2) {
+                var gl = this.gl;
+                if (on) {
+                    gl.disable(gl.RASTERIZER_DISCARD);
+                } else {
+                    gl.enable(gl.RASTERIZER_DISCARD);
                 }
-                this.raster = on;
             }
         },
 

--- a/src/graphics/device.js
+++ b/src/graphics/device.js
@@ -1853,8 +1853,9 @@ pc.extend(pc, function () {
         },
 
         /**
+         * @private
          * @function
-         * @name @private pc.GraphicsDevice#setTransformFeedbackBuffer
+         * @name pc.GraphicsDevice#setTransformFeedbackBuffer
          * @description Sets the output vertex buffer. It will be written to by a shader with transform feedback varyings.
          * @param {pc.VertexBuffer} tf The output vertex buffer
          */
@@ -1875,8 +1876,9 @@ pc.extend(pc, function () {
         },
 
         /**
+         * @private
          * @function
-         * @name @private pc.GraphicsDevice#setRaster
+         * @name pc.GraphicsDevice#setRaster
          * @description Enables or disables rasterization. Useful with transform feedback, when you only need to process the data without drawing.
          * @param {Boolean} on True to enable rasterization and false to disable it.
          */

--- a/src/graphics/device.js
+++ b/src/graphics/device.js
@@ -1580,12 +1580,10 @@ pc.extend(pc, function () {
             this._drawCallsPerFrame++;
             this._primsPerFrame[primitive.type] += primitive.count * (numInstances > 1? numInstances : 1);
 
-            if (this.webgl2) {
-                if (this.transformFeedbackBuffer) {
-                    // Enable TF, start writing to out buffer
-                    gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 0, this.transformFeedbackBuffer.bufferId);
-                    gl.beginTransformFeedback(gl.POINTS);
-                }
+            if (this.webgl2 && this.transformFeedbackBuffer) {
+                // Enable TF, start writing to out buffer
+                gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 0, this.transformFeedbackBuffer.bufferId);
+                gl.beginTransformFeedback(gl.POINTS);
             }
 
             if (primitive.indexed) {
@@ -1626,12 +1624,10 @@ pc.extend(pc, function () {
                 }
             }
 
-            if (this.webgl2) {
-                if (this.transformFeedbackBuffer) {
-                    // disable TF
-                    gl.endTransformFeedback();
-                    gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 0, null);
-                }
+            if (this.webgl2 && this.transformFeedbackBuffer) {
+                // disable TF
+                gl.endTransformFeedback();
+                gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 0, null);
             }
         },
 

--- a/src/graphics/device.js
+++ b/src/graphics/device.js
@@ -1859,16 +1859,18 @@ pc.extend(pc, function () {
          * @param {pc.VertexBuffer} tf The output vertex buffer
          */
         setTransformFeedbackBuffer: function (tf) {
-            if (this.transformFeedbackBuffer !== tf) {
-                if (this.webgl2) {
-                    var gl = this.gl;
-                    if (tf) {
-                        gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, this.feedback);
-                    } else {
-                        gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, null);
-                    }
+            if (this.transformFeedbackBuffer === tf)
+                return;
+
+            this.transformFeedbackBuffer = tf;
+
+            if (this.webgl2) {
+                var gl = this.gl;
+                if (tf) {
+                    gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, this.feedback);
+                } else {
+                    gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, null);
                 }
-                this.transformFeedbackBuffer = tf;
             }
         },
 

--- a/src/graphics/device.js
+++ b/src/graphics/device.js
@@ -212,7 +212,7 @@ pc.extend(pc, function () {
 
         // Retrieve the WebGL context
         if (canvas)
-            var preferWebGl2 = false;///options.preferWebGl2 !== undefined ? options.preferWebGl2 : true;
+            var preferWebGl2 = options.preferWebGl2 !== undefined ? options.preferWebGl2 : true;
 
             var names = preferWebGl2 ? ["webgl2", "experimental-webgl2", "webgl", "experimental-webgl"] :
                                        ["webgl", "experimental-webgl"];

--- a/src/graphics/graphics.js
+++ b/src/graphics/graphics.js
@@ -131,6 +131,12 @@
          * @description The data store contents will be modified once and used at most a few times.
          */
         BUFFER_STREAM: 2,
+        /**
+         * @enum pc.BUFFER
+         * @name pc.BUFFER_GPUDYNAMIC
+         * @description The data store contents will be modified repeatedly on the GPU and used many times. Optimal for transform feedback usage (WebGL2 only).
+         */
+        BUFFER_GPUDYNAMIC: 3,
 
         /**
          * @enum pc.CLEARFLAG

--- a/src/graphics/index-buffer.js
+++ b/src/graphics/index-buffer.js
@@ -117,6 +117,13 @@ pc.extend(pc, function () {
                 case pc.BUFFER_STREAM:
                     glUsage = gl.STREAM_DRAW;
                     break;
+                case pc.BUFFER_GPUDYNAMIC:
+                    if (this.device.webgl2) {
+                        glUsage = gl.DYNAMIC_COPY;
+                    } else {
+                        glUsage = gl.STATIC_DRAW;
+                    }
+                    break;
             }
 
             gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, this.bufferId);

--- a/src/graphics/program-lib/program-lib.js
+++ b/src/graphics/program-lib/program-lib.js
@@ -47,6 +47,10 @@ pc.programlib = {
         return device.webgl2 ? "#version 300 es\n" : "";
     },
 
+    dummyFragmentCode: function() {
+        return "void main(void) {gl_FragColor = vec4(0.0);}";
+    },
+
     begin: function() {
         return 'void main(void)\n{\n';
     },

--- a/src/graphics/shader.js
+++ b/src/graphics/shader.js
@@ -123,18 +123,16 @@ pc.extend(pc, function () {
             });
             // #endif
 
-            if (this.device.webgl2) {
-                if (this.definition.useTransformFeedback) {
-                    // Collect all "out_" attributes and use them for output
-                    var attrs = this.definition.attributes;
-                    var outNames = [];
-                    for (var attr in attrs) {
-                        if (attrs.hasOwnProperty(attr)) {
-                            outNames.push("out_" + attr);
-                        }
+            if (this.device.webgl2 && this.definition.useTransformFeedback) {
+                // Collect all "out_" attributes and use them for output
+                var attrs = this.definition.attributes;
+                var outNames = [];
+                for (var attr in attrs) {
+                    if (attrs.hasOwnProperty(attr)) {
+                        outNames.push("out_" + attr);
                     }
-                    gl.transformFeedbackVaryings(this.program, outNames, gl.INTERLEAVED_ATTRIBS);
                 }
+                gl.transformFeedbackVaryings(this.program, outNames, gl.INTERLEAVED_ATTRIBS);
             }
 
             gl.linkProgram(this.program);

--- a/src/graphics/shader.js
+++ b/src/graphics/shader.js
@@ -46,6 +46,7 @@ pc.extend(pc, function () {
      * shader.
      * @param {String} definition.vshader Vertex shader source (GLSL code).
      * @param {String} definition.fshader Fragment shader source (GLSL code).
+     * @param {Boolean} definition.useTransformFeedback Specifies that this shader outputs post-VS data to a buffer
      * @example
      * // Create a shader that renders primitives with a solid red color
      * var shaderDefinition = {
@@ -121,6 +122,20 @@ pc.extend(pc, function () {
                 target: this
             });
             // #endif
+
+            if (this.device.webgl2) {
+                if (this.definition.useTransformFeedback) {
+                    // Collect all "out_" attributes and use them for output
+                    var attrs = this.definition.attributes;
+                    var outNames = [];
+                    for (var attr in attrs) {
+                        if (attrs.hasOwnProperty(attr)) {
+                            outNames.push("out_" + attr);
+                        }
+                    }
+                    gl.transformFeedbackVaryings(this.program, outNames, gl.INTERLEAVED_ATTRIBS);
+                }
+            }
 
             gl.linkProgram(this.program);
 

--- a/src/graphics/transform-feedback.js
+++ b/src/graphics/transform-feedback.js
@@ -5,6 +5,13 @@ pc.extend(pc, function () {
      * @name pc.TransformFeedback
      * @class Transform feedback helper object
      * @description This object allows you to configure and use the transform feedback feature (WebGL2 only).
+     *  How to use:
+     *  1. First, check that you're on WebGL2, by looking at the app.graphicsDevice.webgl2 value.
+     *  2. Define the outputs in your vertex shader. The syntax is out vec3 out_vertex_position, note that there must be out_ in the name. You can then simply assign values to these outputs in VS. The order and size of shader outputs must match the output buffer layout.
+     *  3. Create the shader using pc.shaderChunks.createShaderFromCode(device, vsCode, null, yourShaderName, true). The last "true" means that the vertex shader will be intended to use with the transform feedback. Note that you can also skip the fragment shader by passing null.
+     *  4. Create/acquire the input vertex buffer. Can be any pc.VertexBuffer, either manually created, or from a pc.Mesh.
+     *  5. Create the pc.TransformFeedback object: var tf = new pc.TransformFeedback(inputBuffer). This object will internally create an output buffer.
+     *  6. Run the shader: tf.process(shader). Shader will take the input buffer, process it and write to the ouput buffer, then the input/output buffers will be automatically swapped, so you'll immediately see the result.
      * @param {pc.VertexBuffer} inputBuffer The input vertex buffer
      * @param {Number} [usage] The usage type of the output vertex buffer (see pc.BUFFER_*). pc.BUFFER_GPUDYNAMIC is recommended for continious update, and is the default value.
      */

--- a/src/graphics/transform-feedback.js
+++ b/src/graphics/transform-feedback.js
@@ -103,7 +103,7 @@ pc.extend(pc, function () {
      * @readonly
      * @name pc.TransformFeedback#outputBuffer
      * @type pc.VertexBuffer
-     * @description The current outputBuffer buffer
+     * @description The current output buffer
      */
     Object.defineProperty(TransformFeedback.prototype, 'outputBuffer', {
         get: function () { return this._outVb; },

--- a/src/graphics/transform-feedback.js
+++ b/src/graphics/transform-feedback.js
@@ -9,12 +9,12 @@ pc.extend(pc, function () {
      *  How to use:
      *  1. First, check that you're on WebGL2, by looking at the app.graphicsDevice.webgl2 value.
      *  2. Define the outputs in your vertex shader. The syntax is out vec3 out_vertex_position, note that there must be out_ in the name. You can then simply assign values to these outputs in VS. The order and size of shader outputs must match the output buffer layout.
-     *  3. Create the shader using pc.shaderChunks.createShaderFromCode(device, vsCode, null, yourShaderName, true). The last "true" means that the vertex shader will be intended to use with the transform feedback. Note that you can also skip the fragment shader by passing null.
+     *  3. Create the shader using pc.TransformFeedback.createShader(device, vsCode, yourShaderName).
      *  4. Create/acquire the input vertex buffer. Can be any pc.VertexBuffer, either manually created, or from a pc.Mesh.
      *  5. Create the pc.TransformFeedback object: var tf = new pc.TransformFeedback(inputBuffer). This object will internally create an output buffer.
      *  6. Run the shader: tf.process(shader). Shader will take the input buffer, process it and write to the ouput buffer, then the input/output buffers will be automatically swapped, so you'll immediately see the result.
      * @param {pc.VertexBuffer} inputBuffer The input vertex buffer
-     * @param {Number} [usage] The usage type of the output vertex buffer (see pc.BUFFER_*). pc.BUFFER_GPUDYNAMIC is recommended for continious update, and is the default value.
+     * @param {Number} [usage] The optional usage type of the output vertex buffer (see pc.BUFFER_*). pc.BUFFER_GPUDYNAMIC is recommended for continious update, and is the default value.
      */
     var TransformFeedback = function (inputBuffer, usage) {
         usage = usage || pc.BUFFER_GPUDYNAMIC;
@@ -29,6 +29,10 @@ pc.extend(pc, function () {
         }
 
         this.outVb = new pc.VertexBuffer(inputBuffer.device, inputBuffer.format, inputBuffer.numVertices, usage, inputBuffer.storage);
+    };
+
+    TransformFeedback.createShader = function (device, vsCode, name) {
+        return pc.shaderChunks.createShaderFromCode(device, vsCode, null, name, true);
     };
 
     TransformFeedback.prototype = {

--- a/src/graphics/transform-feedback.js
+++ b/src/graphics/transform-feedback.js
@@ -43,7 +43,7 @@ pc.extend(pc, function () {
             device.updateBegin();
             device.setVertexBuffer(this.inVb, 0);
             device.setRaster(false);
-            device.setTransformFeedback(this.outVb);
+            device.setTransformFeedbackBuffer(this.outVb);
             device.setShader(shader);
             device.draw({
                 type: pc.PRIMITIVE_POINTS,
@@ -51,7 +51,7 @@ pc.extend(pc, function () {
                 count: this.inVb.numVertices,
                 indexed: false
             });
-            device.setTransformFeedback(null);
+            device.setTransformFeedbackBuffer(null);
             device.setRaster(true);
             device.updateEnd();
 

--- a/src/graphics/transform-feedback.js
+++ b/src/graphics/transform-feedback.js
@@ -1,0 +1,78 @@
+pc.extend(pc, function () {
+    'use strict';
+
+    /**
+     * @name pc.TransformFeedback
+     * @class (Short description)
+     * @description (Long description)
+     * @param {pc.GraphicsDevice} graphicsDevice The graphics device
+     */
+    var TransformFeedback = function (inputBuffer, usage) {
+        usage = usage || pc.BUFFER_GPUDYNAMIC;
+        this.device = inputBuffer.device;
+        var gl = this.device.gl;
+
+        this.inVb = inputBuffer;
+        if (usage===pc.BUFFER_GPUDYNAMIC && inputBuffer.usage!==usage) {
+            // have to recreate input buffer with other usage
+            gl.bindBuffer(gl.ARRAY_BUFFER, inputBuffer.bufferId);
+            gl.bufferData(gl.ARRAY_BUFFER, inputBuffer.storage, gl.DYNAMIC_COPY);
+        }
+
+        this.outVb = new pc.VertexBuffer(inputBuffer.device, inputBuffer.format, inputBuffer.numVertices, usage, inputBuffer.storage);
+    };
+
+    TransformFeedback.prototype = {
+        /**
+         * @function
+         * @name pc.TransformFeedback#destroy
+         * @description ()
+         */
+        destroy: function () {
+            this.outVb.destroy();
+        },
+
+        /**
+         * @function
+         * @name pc.TransformFeedback#process
+         * @description ()
+         */
+        process: function (shader) {
+            var device = this.device;
+            device.setRenderTarget(null);
+            device.updateBegin();
+            device.setVertexBuffer(this.inVb, 0);
+            device.setRaster(false);
+            device.setTransformFeedback(this.outVb);
+            device.setShader(shader);
+            device.draw({
+                type: pc.PRIMITIVE_POINTS,
+                base: 0,
+                count: this.inVb.numVertices,
+                indexed: false
+            });
+            device.setTransformFeedback(null);
+            device.setRaster(true);
+            device.updateEnd();
+
+            // swap buffers
+            var tmp = this.inVb.bufferId;
+            this.inVb.bufferId = this.outVb.bufferId;
+            this.outVb.bufferId = tmp;
+        },
+
+        /**
+         * @function
+         * @name pc.TransformFeedback#getOutputBuffer
+         * @description ()
+         * @returns ()
+         */
+        getOutputBuffer: function () {
+            return this.outVb;
+        }
+    };
+
+    return {
+        TransformFeedback: TransformFeedback
+    };
+}());

--- a/src/graphics/transform-feedback.js
+++ b/src/graphics/transform-feedback.js
@@ -39,10 +39,7 @@ pc.extend(pc, function () {
      * TransformExample.attributes.add('material', { type: 'asset', assetType: 'material' });
      *
      * TransformExample.prototype.initialize = function() {
-     *     // if webgl2 is not supported, TF is not available
      *     var device = this.app.graphicsDevice;
-     *     if (!device.webgl2) return;
-     *
      *     var mesh = pc.createTorus(device, {tubeRadius:0.01, ringRadius:3});
      *     var node = new pc.GraphNode();
      *     var meshInstance = new pc.MeshInstance(node, mesh, this.material.resource);
@@ -51,6 +48,8 @@ pc.extend(pc, function () {
      *     model.meshInstances = [meshInstance];
      *     this.app.scene.addModel(model);
      *
+     *     // if webgl2 is not supported, TF is not available
+     *     if (!device.webgl2) return;
      *     var inputBuffer = mesh.vertexBuffer;
      *     this.tf = new pc.TransformFeedback(inputBuffer);
      *     this.shader = pc.TransformFeedback.createShader(device, this.shaderCode.resource, "tfMoveUp");

--- a/src/graphics/transform-feedback.js
+++ b/src/graphics/transform-feedback.js
@@ -3,9 +3,10 @@ pc.extend(pc, function () {
 
     /**
      * @name pc.TransformFeedback
-     * @class (Short description)
-     * @description (Long description)
-     * @param {pc.GraphicsDevice} graphicsDevice The graphics device
+     * @class Transform feedback helper object
+     * @description This object allows you to configure and use the transform feedback feature (WebGL2 only).
+     * @param {pc.VertexBuffer} inputBuffer The input vertex buffer
+     * @param {Number} [usage] The usage type of the output vertex buffer (see pc.BUFFER_*). pc.BUFFER_GPUDYNAMIC is recommended for continious update, and is the default value.
      */
     var TransformFeedback = function (inputBuffer, usage) {
         usage = usage || pc.BUFFER_GPUDYNAMIC;

--- a/src/graphics/transform-feedback.js
+++ b/src/graphics/transform-feedback.js
@@ -5,6 +5,7 @@ pc.extend(pc, function () {
      * @name pc.TransformFeedback
      * @class Transform feedback helper object
      * @description This object allows you to configure and use the transform feedback feature (WebGL2 only).
+     * @example
      *  How to use:
      *  1. First, check that you're on WebGL2, by looking at the app.graphicsDevice.webgl2 value.
      *  2. Define the outputs in your vertex shader. The syntax is out vec3 out_vertex_position, note that there must be out_ in the name. You can then simply assign values to these outputs in VS. The order and size of shader outputs must match the output buffer layout.
@@ -34,7 +35,7 @@ pc.extend(pc, function () {
         /**
          * @function
          * @name pc.TransformFeedback#destroy
-         * @description ()
+         * @description Destroys the transform feedback helper object
          */
         destroy: function () {
             this.outVb.destroy();
@@ -43,7 +44,7 @@ pc.extend(pc, function () {
         /**
          * @function
          * @name pc.TransformFeedback#process
-         * @description ()
+         * @description Runs the specified shader on the input buffer, writes the results into the new buffer, then swaps input/output.
          */
         process: function (shader) {
             var device = this.device;
@@ -72,7 +73,7 @@ pc.extend(pc, function () {
         /**
          * @function
          * @name pc.TransformFeedback#getOutputBuffer
-         * @description ()
+         * @description Returns the output buffer
          * @returns ()
          */
         getOutputBuffer: function () {

--- a/src/graphics/transform-feedback.js
+++ b/src/graphics/transform-feedback.js
@@ -40,12 +40,12 @@ pc.extend(pc, function () {
      *
      * TransformExample.prototype.initialize = function() {
      *     var device = this.app.graphicsDevice;
-     *     var mesh = pc.createTorus(device, {tubeRadius:0.01, ringRadius:3});
+     *     var mesh = pc.createTorus(device, { tubeRadius: 0.01, ringRadius: 3 });
      *     var node = new pc.GraphNode();
      *     var meshInstance = new pc.MeshInstance(node, mesh, this.material.resource);
      *     var model = new pc.Model();
      *     model.graph = node;
-     *     model.meshInstances = [meshInstance];
+     *     model.meshInstances = [ meshInstance ];
      *     this.app.scene.addModel(model);
      *
      *     // if webgl2 is not supported, TF is not available

--- a/src/graphics/transform-feedback.js
+++ b/src/graphics/transform-feedback.js
@@ -5,7 +5,6 @@ pc.extend(pc, function () {
      * @name pc.TransformFeedback
      * @class Transform feedback helper object
      * @description This object allows you to configure and use the transform feedback feature (WebGL2 only).
-     * @example
      *  How to use:
      *  1. First, check that you're on WebGL2, by looking at the app.graphicsDevice.webgl2 value.
      *  2. Define the outputs in your vertex shader. The syntax is out vec3 out_vertex_position, note that there must be out_ in the name. You can then simply assign values to these outputs in VS. The order and size of shader outputs must match the output buffer layout.
@@ -13,6 +12,28 @@ pc.extend(pc, function () {
      *  4. Create/acquire the input vertex buffer. Can be any pc.VertexBuffer, either manually created, or from a pc.Mesh.
      *  5. Create the pc.TransformFeedback object: var tf = new pc.TransformFeedback(inputBuffer). This object will internally create an output buffer.
      *  6. Run the shader: tf.process(shader). Shader will take the input buffer, process it and write to the ouput buffer, then the input/output buffers will be automatically swapped, so you'll immediately see the result.
+     * @example
+     *  // Vertex shader code
+     *  in vec3 vertex_position;
+     *  out vec3 out_vertex_position;
+     *  void main(void) {
+     *      out_vertex_position = vertex_position + vec3(0, 0.01, 0); // move position upwards a bit
+     *  }
+     *
+     *  // JS code
+     *  function initTF() {
+     *      var device = app.graphicsDevice;
+     *      var mesh = pc.scene.procedural.createMesh(device, positionValues);
+     *      if (!device.webgl2) return;
+     *      var inputBuffer = mesh.vertexBuffer;
+     *      tf = new pc.TransformFeedback(inputBuffer);
+     *      shader = pc.TransformFeedback.createShader(device, vsCode, "tfMoveUp")
+     *  }
+     *  function processMesh() {
+     *      var device = app.graphicsDevice;
+     *      if (!device.webgl2) return;
+     *      tf.process(shader);
+     *   }
      * @param {pc.VertexBuffer} inputBuffer The input vertex buffer
      * @param {Number} [usage] The optional usage type of the output vertex buffer (see pc.BUFFER_*). pc.BUFFER_GPUDYNAMIC is recommended for continious update, and is the default value.
      */
@@ -21,14 +42,14 @@ pc.extend(pc, function () {
         this.device = inputBuffer.device;
         var gl = this.device.gl;
 
-        this._inVb = inputBuffer;
+        this._inputBuffer = inputBuffer;
         if (usage===pc.BUFFER_GPUDYNAMIC && inputBuffer.usage!==usage) {
             // have to recreate input buffer with other usage
             gl.bindBuffer(gl.ARRAY_BUFFER, inputBuffer.bufferId);
             gl.bufferData(gl.ARRAY_BUFFER, inputBuffer.storage, gl.DYNAMIC_COPY);
         }
 
-        this._outVb = new pc.VertexBuffer(inputBuffer.device, inputBuffer.format, inputBuffer.numVertices, usage, inputBuffer.storage);
+        this._outputBuffer = new pc.VertexBuffer(inputBuffer.device, inputBuffer.format, inputBuffer.numVertices, usage, inputBuffer.storage);
     };
 
     /**
@@ -51,13 +72,14 @@ pc.extend(pc, function () {
          * @description Destroys the transform feedback helper object
          */
         destroy: function () {
-            this._outVb.destroy();
+            this._outputBuffer.destroy();
         },
 
         /**
          * @function
          * @name pc.TransformFeedback#process
          * @description Runs the specified shader on the input buffer, writes results into the new buffer, then optionally swaps input/output.
+         * @param {pc.Shader} shader A vertex shader to run. Should be created with pc.TransformFeedback.createShader.
          * @param {Boolean} [swap] Swap input/output buffer data. Useful for continious buffer processing. Default is true.
          */
         process: function (shader, swap) {
@@ -66,14 +88,14 @@ pc.extend(pc, function () {
             var device = this.device;
             device.setRenderTarget(null);
             device.updateBegin();
-            device.setVertexBuffer(this._inVb, 0);
+            device.setVertexBuffer(this._inputBuffer, 0);
             device.setRaster(false);
-            device.setTransformFeedbackBuffer(this._outVb);
+            device.setTransformFeedbackBuffer(this._outputBuffer);
             device.setShader(shader);
             device.draw({
                 type: pc.PRIMITIVE_POINTS,
                 base: 0,
-                count: this._inVb.numVertices,
+                count: this._inputBuffer.numVertices,
                 indexed: false
             });
             device.setTransformFeedbackBuffer(null);
@@ -82,9 +104,9 @@ pc.extend(pc, function () {
 
             // swap buffers
             if (swap) {
-                var tmp = this._inVb.bufferId;
-                this._inVb.bufferId = this._outVb.bufferId;
-                this._outVb.bufferId = tmp;
+                var tmp = this._inputBuffer.bufferId;
+                this._inputBuffer.bufferId = this._outputBuffer.bufferId;
+                this._outputBuffer.bufferId = tmp;
             }
         }
     };
@@ -96,7 +118,7 @@ pc.extend(pc, function () {
      * @description The current input buffer
      */
     Object.defineProperty(TransformFeedback.prototype, 'inputBuffer', {
-        get: function () { return this._inVb; },
+        get: function () { return this._inputBuffer; },
     });
 
     /**
@@ -106,7 +128,7 @@ pc.extend(pc, function () {
      * @description The current output buffer
      */
     Object.defineProperty(TransformFeedback.prototype, 'outputBuffer', {
-        get: function () { return this._outVb; },
+        get: function () { return this._outputBuffer; },
     });
 
     return {

--- a/src/graphics/vertex-buffer.js
+++ b/src/graphics/vertex-buffer.js
@@ -117,6 +117,13 @@ pc.extend(pc, function () {
                 case pc.BUFFER_STREAM:
                     glUsage = gl.STREAM_DRAW;
                     break;
+                case pc.BUFFER_GPUDYNAMIC:
+                    if (this.device.webgl2) {
+                        glUsage = gl.DYNAMIC_COPY;
+                    } else {
+                        glUsage = gl.STATIC_DRAW;
+                    }
+                    break;
             }
 
             gl.bindBuffer(gl.ARRAY_BUFFER, this.bufferId);


### PR DESCRIPTION
How to use:

0. First, check that you're on WebGL2, by looking at the `app.graphicsDevice.webgl2` value.
1. Define the outputs in your vertex shader. The syntax is `out vec3 out_vertex_position`, note that there must be `out_` in the name. You can then simply assign values to these outputs in VS. The order and size of shader outputs must match the output buffer layout.
2. Create the shader using `pc.TransformFeedback.createShader(device, vsCode, yourShaderName)`.
3. Create/acquire the input vertex buffer. Can be any pc.VertexBuffer, either manually created, or from a pc.Mesh.
4. Create the pc.TransformFeedback object: `var tf = new pc.TransformFeedback(inputBuffer)`. This object will internally create an output buffer.
5. Run the shader: `tf.process(shader)`. Shader will take the input buffer, process it and write to the ouput buffer, then the input/output buffers will be automatically swapped, so you'll immediately see the result.

This link should work with this PR: http://playcanvas.com/editor/scene/478298/launch
