### PR TITLE
Separate alpha blend and MIN/MAX blends

### DIFF
--- a/src/graphics/device.js
+++ b/src/graphics/device.js
@@ -2175,28 +2175,48 @@ pc.extend(pc, function () {
          * </ul>
          * @param {Number} blendSrc The source blend function.
          * @param {Number} blendDst The destination blend function.
-         * @param {Number} [blendSrcAlpha] The separate source blend function for the alpha channel.
-         * @param {Number} [blendDstAlpha] The separate destination blend function for the alpha channel.
          */
-        setBlendFunction: function (blendSrc, blendDst, blendSrcAlpha, blendDstAlpha) {
-            if (blendSrcAlpha===undefined) blendSrcAlpha = blendSrc;
-            if (blendDstAlpha===undefined) blendDstAlpha = blendDst;
-            if (this.blendSrc!==blendSrc || this.blendDst!==blendDst || this.blendSrcAlpha!==blendSrcAlpha || this.blendDstAlpha!==blendDstAlpha) {
-                if (blendSrcAlpha===blendSrc && blendDstAlpha===blendDst) {
-                    // Simple alphablend
-                    this.gl.blendFunc(this.glBlendFunction[blendSrc], this.glBlendFunction[blendDst]);
-                    this.blendSrc = blendSrc;
-                    this.blendDst = blendDst;
-                    this.blendSrcAlpha = blendSrc;
-                    this.blendDstAlpha = blendDst;
-                } else {
-                    this.gl.blendFuncSeparate(this.glBlendFunction[blendSrc], this.glBlendFunction[blendDst],
-                                              this.glBlendFunction[blendSrcAlpha], this.glBlendFunction[blendDstAlpha]);
-                    this.blendSrc = blendSrc;
-                    this.blendDst = blendDst;
-                    this.blendSrcAlpha = blendSrcAlpha;
-                    this.blendDstAlpha = blendDstAlpha;
-                }
+        setBlendFunction: function (blendSrc, blendDst) {
+            if (this.blendSrc!==blendSrc || this.blendDst!==blendDst || this.separateAlphaBlend) {
+                this.gl.blendFunc(this.glBlendFunction[blendSrc], this.glBlendFunction[blendDst]);
+                this.blendSrc = blendSrc;
+                this.blendDst = blendDst;
+                this.separateAlphaBlend = false;
+            }
+        },
+
+        /**
+         * @function
+         * @name pc.GraphicsDevice#setBlendFunctionSeparate
+         * @description Configures blending operations. Both source and destination
+         * blend modes can take the following values:
+         * <ul>
+         *     <li>pc.BLENDMODE_ZERO</li>
+         *     <li>pc.BLENDMODE_ONE</li>
+         *     <li>pc.BLENDMODE_SRC_COLOR</li>
+         *     <li>pc.BLENDMODE_ONE_MINUS_SRC_COLOR</li>
+         *     <li>pc.BLENDMODE_DST_COLOR</li>
+         *     <li>pc.BLENDMODE_ONE_MINUS_DST_COLOR</li>
+         *     <li>pc.BLENDMODE_SRC_ALPHA</li>
+         *     <li>pc.BLENDMODE_SRC_ALPHA_SATURATE</li>
+         *     <li>pc.BLENDMODE_ONE_MINUS_SRC_ALPHA</li>
+         *     <li>pc.BLENDMODE_DST_ALPHA</li>
+         *     <li>pc.BLENDMODE_ONE_MINUS_DST_ALPHA</li>
+         * </ul>
+         * @param {Number} blendSrc The source blend function.
+         * @param {Number} blendDst The destination blend function.
+         * @param {Number} blendSrcAlpha The separate source blend function for the alpha channel.
+         * @param {Number} blendDstAlpha The separate destination blend function for the alpha channel.
+         */
+        setBlendFunctionSeparate: function (blendSrc, blendDst, blendSrcAlpha, blendDstAlpha) {
+            if (this.blendSrc!==blendSrc || this.blendDst!==blendDst || this.blendSrcAlpha!==blendSrcAlpha || this.blendDstAlpha!==blendDstAlpha || !this.separateAlphaBlend) {
+                this.gl.blendFuncSeparate(this.glBlendFunction[blendSrc], this.glBlendFunction[blendDst],
+                                          this.glBlendFunction[blendSrcAlpha], this.glBlendFunction[blendDstAlpha]);
+                this.blendSrc = blendSrc;
+                this.blendDst = blendDst;
+                this.blendSrcAlpha = blendSrcAlpha;
+                this.blendDstAlpha = blendDstAlpha;
+                this.separateAlphaBlend = true;
             }
         },
 
@@ -2213,23 +2233,38 @@ pc.extend(pc, function () {
          *     <li>pc.BLENDEQUATION_MIN</li>
          *     <li>pc.BLENDEQUATION_MAX</li>
          * Note that MIN and MAX modes require either EXT_blend_minmax or WebGL2 to work (check device.extBlendMinmax).
-         * @param {Number} [blendAlphaEquation] A separate blend equation for the alpha channel. Accepts same values as blendEquation.
          * </ul>
          */
-        setBlendEquation: function (blendEquation, blendAlphaEquation) {
-            if (blendAlphaEquation===undefined) blendAlphaEquation = blendEquation;
-            if (this.blendEquation!==blendEquation || this.blendAlphaEquation!==blendAlphaEquation) {
-                if (blendEquation===blendAlphaEquation) {
-                    // Simple alphablend
-                    this.gl.blendEquation(this.glBlendEquation[blendEquation]);
-                    this.blendEquation = blendEquation;
-                    this.blendAlphaEquation = blendEquation;
-                } else {
-                    // Separate alphablend
-                    this.gl.blendEquationSeparate(this.glBlendEquation[blendEquation], this.glBlendEquation[blendAlphaEquation]);
-                    this.blendEquation = blendEquation;
-                    this.blendAlphaEquation = blendAlphaEquation;
-                }
+        setBlendEquation: function (blendEquation) {
+            if (this.blendEquation!==blendEquation || this.separateAlphaEquation) {
+                this.gl.blendEquation(this.glBlendEquation[blendEquation]);
+                this.blendEquation = blendEquation;
+                this.separateAlphaEquation = false;
+            }
+        },
+
+        /**
+         * @function
+         * @name pc.GraphicsDevice#setBlendEquationSeparate
+         * @description Configures the blending equation. The default blend equation is
+         * pc.BLENDEQUATION_ADD.
+         * @param {Number} blendEquation The blend equation. Can be:
+         * <ul>
+         *     <li>pc.BLENDEQUATION_ADD</li>
+         *     <li>pc.BLENDEQUATION_SUBTRACT</li>
+         *     <li>pc.BLENDEQUATION_REVERSE_SUBTRACT</li>
+         *     <li>pc.BLENDEQUATION_MIN</li>
+         *     <li>pc.BLENDEQUATION_MAX</li>
+         * Note that MIN and MAX modes require either EXT_blend_minmax or WebGL2 to work (check device.extBlendMinmax).
+         * @param {Number} blendAlphaEquation A separate blend equation for the alpha channel. Accepts same values as blendEquation.
+         * </ul>
+         */
+        setBlendEquationSeparate: function (blendEquation, blendAlphaEquation) {
+            if (this.blendEquation!==blendEquation || this.blendAlphaEquation!==blendAlphaEquation || !this.separateAlphaEquation) {
+                this.gl.blendEquationSeparate(this.glBlendEquation[blendEquation], this.glBlendEquation[blendAlphaEquation]);
+                this.blendEquation = blendEquation;
+                this.blendAlphaEquation = blendAlphaEquation;
+                this.separateAlphaEquation = true;
             }
         },
 

--- a/src/graphics/device.js
+++ b/src/graphics/device.js
@@ -316,7 +316,9 @@ pc.extend(pc, function () {
             this.glBlendEquation = [
                 gl.FUNC_ADD,
                 gl.FUNC_SUBTRACT,
-                gl.FUNC_REVERSE_SUBTRACT
+                gl.FUNC_REVERSE_SUBTRACT,
+                gl.MIN,
+                gl.MAX
             ];
 
             this.glBlendFunction = [
@@ -2162,8 +2164,13 @@ pc.extend(pc, function () {
          * @param {Number} blendSrc The source blend function.
          * @param {Number} blendDst The destination blend function.
          */
-        setBlendFunction: function (blendSrc, blendDst) {
-            if ((this.blendSrc !== blendSrc) || (this.blendDst !== blendDst)) {
+        setBlendFunction: function (blendSrc, blendDst, blendSrcAlpha, blendDstAlpha) {
+            if (blendSrcAlpha!==undefined) {
+                this.gl.blendFuncSeparate(this.glBlendFunction[blendSrc], this.glBlendFunction[blendDst],
+                                          this.glBlendFunction[blendSrcAlpha], this.glBlendFunction[blendDstAlpha]);
+                this.blendSrc = null;
+                this.blendDst = null;
+            } else if (this.blendSrc !== blendSrc || this.blendDst !== blendDst) {
                 this.gl.blendFunc(this.glBlendFunction[blendSrc], this.glBlendFunction[blendDst]);
                 this.blendSrc = blendSrc;
                 this.blendDst = blendDst;
@@ -2180,12 +2187,16 @@ pc.extend(pc, function () {
          *     <li>pc.BLENDEQUATION_ADD</li>
          *     <li>pc.BLENDEQUATION_SUBTRACT</li>
          *     <li>pc.BLENDEQUATION_REVERSE_SUBTRACT</li>
+         *     <li>pc.BLENDEQUATION_MIN</li>
+         *     <li>pc.BLENDEQUATION_MAX</li>
          * </ul>
          */
-        setBlendEquation: function (blendEquation) {
-            if (this.blendEquation !== blendEquation) {
-                var gl = this.gl;
-                gl.blendEquation(this.glBlendEquation[blendEquation]);
+        setBlendEquation: function (blendEquation, blendAlphaEquation) {
+            if (blendAlphaEquation!==undefined) {
+                this.gl.blendEquationSeparate(this.glBlendEquation[blendEquation], this.glBlendEquation[blendAlphaEquation]);
+                this.blendEquation = null;
+            } else if (this.blendEquation !== blendEquation) {
+                this.gl.blendEquation(this.glBlendEquation[blendEquation]);
                 this.blendEquation = blendEquation;
             }
         },

--- a/src/graphics/device.js
+++ b/src/graphics/device.js
@@ -2177,7 +2177,7 @@ pc.extend(pc, function () {
          * @param {Number} blendDst The destination blend function.
          */
         setBlendFunction: function (blendSrc, blendDst) {
-            if (this.blendSrc!==blendSrc || this.blendDst!==blendDst || this.separateAlphaBlend) {
+            if (this.blendSrc !== blendSrc || this.blendDst !== blendDst || this.separateAlphaBlend) {
                 this.gl.blendFunc(this.glBlendFunction[blendSrc], this.glBlendFunction[blendDst]);
                 this.blendSrc = blendSrc;
                 this.blendDst = blendDst;
@@ -2209,7 +2209,7 @@ pc.extend(pc, function () {
          * @param {Number} blendDstAlpha The separate destination blend function for the alpha channel.
          */
         setBlendFunctionSeparate: function (blendSrc, blendDst, blendSrcAlpha, blendDstAlpha) {
-            if (this.blendSrc!==blendSrc || this.blendDst!==blendDst || this.blendSrcAlpha!==blendSrcAlpha || this.blendDstAlpha!==blendDstAlpha || !this.separateAlphaBlend) {
+            if (this.blendSrc !== blendSrc || this.blendDst !== blendDst || this.blendSrcAlpha !== blendSrcAlpha || this.blendDstAlpha !== blendDstAlpha || !this.separateAlphaBlend) {
                 this.gl.blendFuncSeparate(this.glBlendFunction[blendSrc], this.glBlendFunction[blendDst],
                                           this.glBlendFunction[blendSrcAlpha], this.glBlendFunction[blendDstAlpha]);
                 this.blendSrc = blendSrc;
@@ -2236,7 +2236,7 @@ pc.extend(pc, function () {
          * </ul>
          */
         setBlendEquation: function (blendEquation) {
-            if (this.blendEquation!==blendEquation || this.separateAlphaEquation) {
+            if (this.blendEquation !== blendEquation || this.separateAlphaEquation) {
                 this.gl.blendEquation(this.glBlendEquation[blendEquation]);
                 this.blendEquation = blendEquation;
                 this.separateAlphaEquation = false;
@@ -2260,7 +2260,7 @@ pc.extend(pc, function () {
          * </ul>
          */
         setBlendEquationSeparate: function (blendEquation, blendAlphaEquation) {
-            if (this.blendEquation!==blendEquation || this.blendAlphaEquation!==blendAlphaEquation || !this.separateAlphaEquation) {
+            if (this.blendEquation !== blendEquation || this.blendAlphaEquation !== blendAlphaEquation || !this.separateAlphaEquation) {
                 this.gl.blendEquationSeparate(this.glBlendEquation[blendEquation], this.glBlendEquation[blendAlphaEquation]);
                 this.blendEquation = blendEquation;
                 this.blendAlphaEquation = blendAlphaEquation;

--- a/src/graphics/graphics.js
+++ b/src/graphics/graphics.js
@@ -114,6 +114,19 @@
         BLENDEQUATION_REVERSE_SUBTRACT: 2,
 
         /**
+         * @enum pc.BLENDEQUATION
+         * @name pc.BLENDEQUATION_MIN
+         * @description Use the smallest value. Works only when either EXT_blend_minmax or WebGL2 is available.
+         */
+        BLENDEQUATION_MIN: 3,
+        /**
+         * @enum pc.BLENDEQUATION
+         * @name pc.BLENDEQUATION_MAX
+         * @description Use the largest value. Works only when either EXT_blend_minmax or WebGL2 is available.
+         */
+        BLENDEQUATION_MAX: 4,
+
+        /**
          * @enum pc.BUFFER
          * @name pc.BUFFER_STATIC
          * @description The data store contents will be modified once and used many times.

--- a/src/graphics/graphics.js
+++ b/src/graphics/graphics.js
@@ -116,13 +116,13 @@
         /**
          * @enum pc.BLENDEQUATION
          * @name pc.BLENDEQUATION_MIN
-         * @description Use the smallest value. Works only when either EXT_blend_minmax or WebGL2 is available.
+         * @description Use the smallest value. Check app.graphicsDevice.extBlendMinmax for support.
          */
         BLENDEQUATION_MIN: 3,
         /**
          * @enum pc.BLENDEQUATION
          * @name pc.BLENDEQUATION_MAX
-         * @description Use the largest value. Works only when either EXT_blend_minmax or WebGL2 is available.
+         * @description Use the largest value. Check app.graphicsDevice.extBlendMinmax for support.
          */
         BLENDEQUATION_MAX: 4,
 

--- a/src/scene/forward-renderer.js
+++ b/src/scene/forward-renderer.js
@@ -2017,8 +2017,13 @@ pc.extend(pc, function () {
 
                         device.setBlending(material.blend);
                         if (material.blend) {
-                            device.setBlendFunction(material.blendSrc, material.blendDst, material.blendSrcAlpha, material.blendDstAlpha);
-                            device.setBlendEquation(material.blendEquation, material.blendAlphaEquation);
+                            if (material.separateAlphaBlend) {
+                                device.setBlendFunctionSeparate(material.blendSrc, material.blendDst, material.blendSrcAlpha, material.blendDstAlpha);
+                                device.setBlendEquationSeparate(material.blendEquation, material.blendAlphaEquation);
+                            } else {
+                                device.setBlendFunction(material.blendSrc, material.blendDst);
+                                device.setBlendEquation(material.blendEquation);
+                            }
                         }
                         device.setColorWrite(material.redWrite, material.greenWrite, material.blueWrite, material.alphaWrite);
                         device.setCullMode(material.cull);

--- a/src/scene/forward-renderer.js
+++ b/src/scene/forward-renderer.js
@@ -2016,8 +2016,10 @@ pc.extend(pc, function () {
                         this.alphaTestId.setValue(material.alphaTest);
 
                         device.setBlending(material.blend);
-                        device.setBlendFunction(material.blendSrc, material.blendDst, material._blendSrcAlpha, material._blendDstAlpha);
-                        device.setBlendEquation(material.blendEquation, material._blendAlphaEquation);
+                        if (material.blend) {
+                            device.setBlendFunction(material.blendSrc, material.blendDst, material.blendSrcAlpha, material.blendDstAlpha);
+                            device.setBlendEquation(material.blendEquation, material.blendAlphaEquation);
+                        }
                         device.setColorWrite(material.redWrite, material.greenWrite, material.blueWrite, material.alphaWrite);
                         device.setCullMode(material.cull);
                         device.setDepthWrite(material.depthWrite);

--- a/src/scene/forward-renderer.js
+++ b/src/scene/forward-renderer.js
@@ -2016,8 +2016,8 @@ pc.extend(pc, function () {
                         this.alphaTestId.setValue(material.alphaTest);
 
                         device.setBlending(material.blend);
-                        device.setBlendFunction(material.blendSrc, material.blendDst);
-                        device.setBlendEquation(material.blendEquation);
+                        device.setBlendFunction(material.blendSrc, material.blendDst, material._blendSrcAlpha, material._blendDstAlpha);
+                        device.setBlendEquation(material.blendEquation, material._blendAlphaEquation);
                         device.setColorWrite(material.redWrite, material.greenWrite, material.blueWrite, material.alphaWrite);
                         device.setCullMode(material.cull);
                         device.setDepthWrite(material.depthWrite);

--- a/src/scene/material.js
+++ b/src/scene/material.js
@@ -65,9 +65,9 @@ pc.extend(pc, function () {
         this.blendDst = pc.BLENDMODE_ZERO;
         this.blendEquation = pc.BLENDEQUATION_ADD;
 
-        this._blendSrcAlpha = undefined;
-        this._blendDstAlpha = undefined;
-        this._blendAlphaEquation = undefined;
+        this.blendSrcAlpha = pc.BLENDMODE_ONE;
+        this.blendDstAlpha = pc.BLENDMODE_ZERO;
+        this.blendAlphaEquation = pc.BLENDEQUATION_ADD;
 
         this.cull = pc.CULLFACE_BACK;
 
@@ -125,6 +125,16 @@ pc.extend(pc, function () {
                        (this.blendDst === pc.BLENDMODE_ONE) &&
                        (this.blendEquation === pc.BLENDEQUATION_ADD)) {
                 return pc.BLEND_SCREEN;
+            } else if ((this.blend) &&
+                       (this.blendSrc === pc.BLENDMODE_ONE) &&
+                       (this.blendDst === pc.BLENDMODE_ONE) &&
+                       (this.blendEquation === pc.BLENDEQUATION_MIN)) {
+                return pc.BLEND_MIN;
+            } else if ((this.blend) &&
+                       (this.blendSrc === pc.BLENDMODE_ONE) &&
+                       (this.blendDst === pc.BLENDMODE_ONE) &&
+                       (this.blendEquation === pc.BLENDEQUATION_MAX)) {
+                return pc.BLEND_MAX;
             } else if ((this.blend) &&
                        (this.blendSrc === pc.BLENDMODE_DST_COLOR) &&
                        (this.blendDst === pc.BLENDMODE_ZERO) &&
@@ -188,6 +198,18 @@ pc.extend(pc, function () {
                     this.blendSrc = pc.BLENDMODE_DST_COLOR;
                     this.blendDst = pc.BLENDMODE_ZERO;
                     this.blendEquation = pc.BLENDEQUATION_ADD;
+                    break;
+                case pc.BLEND_MIN:
+                    this.blend = true;
+                    this.blendSrc = pc.BLENDMODE_ONE;
+                    this.blendDst = pc.BLENDMODE_ONE;
+                    this.blendEquation = pc.BLENDEQUATION_MIN;
+                    break;
+                case pc.BLEND_MAX:
+                    this.blend = true;
+                    this.blendSrc = pc.BLENDMODE_ONE;
+                    this.blendDst = pc.BLENDMODE_ONE;
+                    this.blendEquation = pc.BLENDEQUATION_MAX;
                     break;
             }
             this._updateMeshInstanceKeys();

--- a/src/scene/material.js
+++ b/src/scene/material.js
@@ -65,6 +65,10 @@ pc.extend(pc, function () {
         this.blendDst = pc.BLENDMODE_ZERO;
         this.blendEquation = pc.BLENDEQUATION_ADD;
 
+        this._blendSrcAlpha = undefined;
+        this._blendDstAlpha = undefined;
+        this._blendAlphaEquation = undefined;
+
         this.cull = pc.CULLFACE_BACK;
 
         this.depthTest = true;

--- a/src/scene/material.js
+++ b/src/scene/material.js
@@ -65,6 +65,7 @@ pc.extend(pc, function () {
         this.blendDst = pc.BLENDMODE_ZERO;
         this.blendEquation = pc.BLENDEQUATION_ADD;
 
+        this.separateAlphaBlend = false;
         this.blendSrcAlpha = pc.BLENDMODE_ONE;
         this.blendDstAlpha = pc.BLENDMODE_ZERO;
         this.blendAlphaEquation = pc.BLENDEQUATION_ADD;

--- a/src/scene/material.js
+++ b/src/scene/material.js
@@ -238,6 +238,11 @@ pc.extend(pc, function () {
         clone.blendDst = this.blendDst;
         clone.blendEquation = this.blendEquation;
 
+        clone.separateAlphaBlend = this.separateAlphaBlend;
+        clone.blendSrcAlpha = this.blendSrcAlpha;
+        clone.blendDstAlpha = this.blendDstAlpha;
+        clone.blendAlphaEquation = this.blendAlphaEquation;
+
         clone.cull = this.cull;
 
         clone.depthTest = this.depthTest;

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -65,6 +65,20 @@
         BLEND_SCREEN: 8,
 
         /**
+         * @enum pc.BLEND
+         * @name pc.BLEND_MIN
+         * @description Minimum color. Check app.graphicsDevice.extBlendMinmax for support.
+         */
+        BLEND_MIN: 9,
+
+        /**
+         * @enum pc.BLEND
+         * @name pc.BLEND_MAX
+         * @description Maximum color. Check app.graphicsDevice.extBlendMinmax for support.
+         */
+        BLEND_MAX: 10,
+
+        /**
          * @enum pc.FOG
          * @name pc.FOG_NONE
          * @description No fog is applied to the scene.


### PR DESCRIPTION
New API:
- Use device.extBlendMinmax to check if you support min/max blends (needs either EXT_blend_minmax or WebGL2). If not supported, ADD (default) equation will be used;
- Material.blendType can be pc.BLEND_MIN and pc.BLEND_MAX;
- Material.separateAlphaBlend (bool, default is false);
- Material.blendSrcAlpha (only used when separateAlphaBlend is true);
- Material.blendDstAlpha (only used when separateAlphaBlend is true);
- Materila.blendAlphaEquation (only used when separateAlphaBlend is true);
- pc.BLENDEQUATION_MIN, pc.BLENDEQUATION_MAX;
- device.setBlendFunctionSeparate;
- device.setBlendEquationSeparate.

BTW: https://github.com/playcanvas/engine/issues/835