### PR TITLE
refactor events, now it avoids allocations

### DIFF
--- a/src/core/events.js
+++ b/src/core/events.js
@@ -1,201 +1,222 @@
 /**
  * @name pc.events
  * @namespace
- * @description Extend any normal object with events
+ * @description global namespace that allows to extend other objects with events
+ * Additionally it can handle global events it self.
+ * @example
+ * var obj = { };
+ * pc.events.attach(obj);
  *
- * @example var o = {};
- * o = pc.extend(o, pc.events);
- *
- * // attach event
- * o.on("event_name", function() {
- *   alert('event_name fired');
- * }, this);
+ * // subscribe to an event
+ * obj.on('hello', function(str) {
+ *     console.log('event hello is fired', str);
+ * });
  *
  * // fire event
- * o.fire("event_name");
- *
- * // detach all events from object
- * o.off('event_name');
+ * obj.fire('hello', 'world');
  */
-pc.events = function () {
+pc.events = {
+    /**
+    * @function
+    * @name pc.events.attach
+    * @description Attach event methods 'on', 'off', 'fire' and 'hasEvent' to the target object
+    * @param {Object} target The object to add events to.
+    * @return {Object} The target object
+    * @example
+    * var obj = { };
+    * pc.events.attach(obj);
+    */
+    attach: function (target) {
+        var ev = pc.events;
+        target.on = ev.on;
+        target.off = ev.off;
+        target.fire = ev.fire;
+        target.once = ev.once;
+        target.hasEvent = ev.hasEvent;
+        target._callbackActive = { };
+        return target;
+    },
 
-    var Events = {
-        /**
-        * @function
-        * @name pc.events.attach
-        * @description Attach event methods 'on', 'off', 'fire' and 'hasEvent' to the target object
-        * @param  {Object} target The object to add events to.
-        * @return {Object} The target object
-        */
-        attach: function (target) {
-            var ev = pc.events;
-            target.on = ev.on;
-            target.off = ev.off;
-            target.fire = ev.fire;
-            target.once = ev.once;
-            target.hasEvent = ev.hasEvent;
-            target.bind = ev.on;
-            target.unbind = ev.off;
-            return target;
-        },
-
-        /**
-         * @function
-         * @name pc.events.on
-         * @description Attach an event handler to an event
-         * @param {String} name Name of the event to bind the callback to
-         * @param {Function} callback Function that is called when event is fired. Note the callback is limited to 8 arguments.
-         * @param {Object} [scope] Object to use as 'this' when the event is fired, defaults to current this
-         * @example var o = {};
-         * pc.events.attach(o);
-         * o.on('event_name', function (a, b) {
-         *   console.log(a + b);
-         * });
-         * o.fire('event_name', 1, 2); // prints 3 to the console
-         */
-        on: function (name, callback, scope) {
-            if(pc.type(name) != "string") {
-                throw new TypeError("Event name must be a string");
-            }
-            var callbacks = this._callbacks || (this._callbacks = {});
-            var events = callbacks[name] || (callbacks[name] = []);
-            events.push({
-                callback: callback,
-                scope: scope || this
-            });
-
+    /**
+     * @function
+     * @name pc.events.on
+     * @description Attach an event handler to an event
+     * @param {String} name Name of the event to bind the callback to
+     * @param {Function} callback Function that is called when event is fired. Note the callback is limited to 8 arguments.
+     * @param {Object} [scope] Object to use as 'this' when the event is fired, defaults to current this
+     * @example
+     * obj.on('test', function (a, b) {
+     *     console.log(a + b);
+     * });
+     * obj.fire('test', 1, 2); // prints 3 to the console
+     */
+    on: function (name, callback, scope) {
+        if (! name || typeof(name) !== 'string' || ! callback)
             return this;
-        },
 
-        /**
-         * @function
-         * @name pc.events.off
-         * @description Detach an event handler from an event. If callback is not provided then all callbacks are unbound from the event,
-         * if scope is not provided then all events with the callback will be unbound.
-         * @param {String} name Name of the event to unbind
-         * @param {Function} [callback] Function to be unbound
-         * @param {Object} [scope] Scope that was used as the this when the event is fired
-         * @example
-         * var handler = function () {
-         * };
-         * var o = {};
-         * pc.events.attach(o);
-         * o.on('event_name', handler);
-         *
-         * o.off('event_name'); // Remove all events called 'event_name'
-         * o.off('event_name', handler); // Remove all handler functions, called 'event_name'
-         * o.off('event_name', handler, this); // Remove all hander functions, called 'event_name' with scope this
-         */
-        off: function (name, callback, scope) {
-            var callbacks = this._callbacks;
-            var events;
-            var index;
+        if (! this._callbacks)
+            this._callbacks = { };
 
-            if (!callbacks) {
-                return; // no callbacks at all
-            }
+        if (! this._callbacks[name])
+            this._callbacks[name] = [ ];
 
-            if (!callback) {
-                // Clear all callbacks
-                callbacks[name] = [];
+        if (! this._callbackActive)
+            this._callbackActive = { };
+
+        if (this._callbackActive[name] && this._callbackActive[name] === this._callbacks[name])
+            this._callbackActive[name] = this._callbackActive[name].slice();
+
+        this._callbacks[name].push({
+            callback: callback,
+            scope: scope || this
+        });
+
+        return this;
+    },
+
+    /**
+     * @function
+     * @name pc.events.off
+     * @description Detach an event handler from an event. If callback is not provided then all callbacks are unbound from the event,
+     * if scope is not provided then all events with the callback will be unbound.
+     * @param {String} [name] Name of the event to unbind
+     * @param {Function} [callback] Function to be unbound
+     * @param {Object} [scope] Scope that was used as the this when the event is fired
+     * @example
+     * var handler = function () {
+     * };
+     * obj.on('test', handler);
+     *
+     * obj.off(); // Removes all events
+     * obj.off('test'); // Removes all events called 'test'
+     * obj.off('test', handler); // Removes all handler functions, called 'test'
+     * obj.off('test', handler, this); // Removes all hander functions, called 'test' with scope this
+     */
+    off: function (name, callback, scope) {
+        if (! this._callbacks)
+            return this;
+
+        if (this._callbackActive) {
+            if (name) {
+                if (this._callbackActive[name] && this._callbackActive[name] === this._callbacks[name])
+                    this._callbackActive[name] = this._callbackActive[name].slice();
             } else {
-                events = callbacks[name];
-                if (!events) {
-                    return this;
-                }
+                for(var key in this._callbackActive) {
+                    if (! this._callbacks[key])
+                        continue;
 
-                for (index = 0; index < events.length; index++) {
-                    if (events[index].callback === callback) {
-                        if (!scope || (scope === events[index].scope)) {
-                            events.splice(index, 1);
-                            index--;
-                        }
-                    }
+                    if (this._callbacks[key] !== this._callbackActive[key])
+                        continue;
+
+                    this._callbackActive[key] = this._callbackActive[key].slice();
                 }
             }
-
-            return this;
-        },
-
-        /**
-         * @function
-         * @name pc.events.fire
-         * @description Fire an event, all additional arguments are passed on to the event listener
-         * @param {Object} name Name of event to fire
-         * @param {*} [...] Arguments that are passed to the event handler
-         * @example
-         * var o = {};
-         * pc.events.attach(o);
-         * o.on('event_name', function (msg) {
-         *   alert('event_name fired: ' + msg);
-         * });
-         * o.fire('event_name', 'This is the message');
-         */
-        fire: function (name, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) {
-            var index;
-            var length;
-            var args;
-            var callbacks;
-
-            if (this._callbacks && this._callbacks[name]) {
-                length = this._callbacks[name].length;
-                if (length) {
-                    callbacks = this._callbacks[name].slice(); // clone list so that deleting inside callbacks works
-                    var originalIndex = 0;
-                    for(index = 0; index < length; ++index) {
-                        var scope = callbacks[index].scope;
-                        callbacks[index].callback.call(scope, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
-                        if (callbacks[index].callback.once) {
-                            this._callbacks[name].splice(originalIndex, 1);
-                        } else {
-                            originalIndex++;
-                        }
-                    }
-                }
-            }
-
-            return this;
-        },
-
-        /**
-         * @function
-         * @name pc.events.once
-         * @description Attach an event handler to an event. This handler will be removed after being fired once.
-         * @param {String} name Name of the event to bind the callback to
-         * @param {Function} callback Function that is called when event is fired. Note the callback is limited to 8 arguments.
-         * @param {Object} [scope] Object to use as 'this' when the event is fired, defaults to current this
-         * @example var o = {};
-         * pc.events.attach(o);
-         * o.once('event_name', function (a, b) {
-         *   console.log(a + b);
-         * });
-         * o.fire('event_name', 1, 2); // prints 3 to the console
-         * o.fire('event_name', 1, 2); // not going to get handled
-         */
-        once: function (name, callback, scope) {
-            callback.once = true;
-            this.on(name, callback, scope);
-        },
-
-        /**
-        * @function
-        * @name pc.events.hasEvent
-        * @description Test if there are any handlers bound to an event name
-        * @param {String} name The name of the event to test
-        * @example
-        * var o = {};
-        * pc.events.attach(o); // add events to o
-        * o.on('event_name', function () {}); // bind an event to 'event_name'
-        * o.hasEvent('event_name'); // returns true
-        */
-        hasEvent: function (name) {
-            return (this._callbacks !== undefined && this._callbacks[name] !== undefined && this._callbacks[name].length > 0);
         }
-    };
 
-    // For compatibility
-    Events.bind = Events.on;
-    Events.unbind = Events.off;
+        if (! name) {
+            this._callbacks = null;
+        } else if (! callback) {
+            if (this._callbacks[name])
+                delete this._callbacks[name];
+        } else {
+            var events = this._callbacks[name];
+            if (! events)
+                return this;
 
-    return Events;
-} ();
+            var i = events.length;
+
+            while(i--) {
+                if (events[i].callback !== callback)
+                    continue;
+
+                if (scope && events[i].scope !== scope)
+                    continue;
+
+                events.splice(i, 1);
+            }
+        }
+
+        return this;
+    },
+
+    /**
+     * @function
+     * @name pc.events.fire
+     * @description Fire an event, all additional arguments are passed on to the event listener
+     * @param {Object} name Name of event to fire
+     * @param {*} [...] Arguments that are passed to the event handler
+     * @example
+     * obj.fire('test', 'This is the message');
+     */
+    fire: function (name, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) {
+        if (! name || ! this._callbacks || ! this._callbacks[name])
+            return this;
+
+        var callbacks;
+
+        if (! this._callbackActive)
+            this._callbackActive = { };
+
+        if (! this._callbackActive[name]) {
+            this._callbackActive[name] = this._callbacks[name];
+        } else {
+            if (this._callbackActive[name] === this._callbacks[name])
+                this._callbackActive[name] = this._callbackActive[name].slice();
+
+            callbacks = this._callbacks[name].slice();
+        }
+
+        for(var i = 0; i < (callbacks || this._callbackActive[name]).length; i++) {
+            var evt = (callbacks || this._callbackActive[name])[i];
+            evt.callback.call(evt.scope, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
+
+            if (evt.callback.once) {
+                var ind = this._callbacks[name].indexOf(evt);
+                if (ind !== -1) {
+                    if (this._callbackActive[name] === this._callbacks[name])
+                        this._callbackActive[name] = this._callbackActive[name].slice();
+
+                    this._callbacks[name].splice(ind, 1);
+                }
+            }
+        }
+
+        if (! callbacks)
+            this._callbackActive[name] = null;
+
+        return this;
+    },
+
+    /**
+     * @function
+     * @name pc.events.once
+     * @description Attach an event handler to an event. This handler will be removed after being fired once.
+     * @param {String} name Name of the event to bind the callback to
+     * @param {Function} callback Function that is called when event is fired. Note the callback is limited to 8 arguments.
+     * @param {Object} [scope] Object to use as 'this' when the event is fired, defaults to current this
+     * @example
+     * obj.once('test', function (a, b) {
+     *     console.log(a + b);
+     * });
+     * obj.fire('test', 1, 2); // prints 3 to the console
+     * obj.fire('test', 1, 2); // not going to get handled
+     */
+    once: function (name, callback, scope) {
+        callback.once = true;
+        this.on(name, callback, scope);
+        return this;
+    },
+
+    /**
+    * @function
+    * @name pc.events.hasEvent
+    * @description Test if there are any handlers bound to an event name
+    * @param {String} name The name of the event to test
+    * @example
+    * obj.on('test', function () { }); // bind an event to 'test'
+    * obj.hasEvent('test'); // returns true
+    */
+    hasEvent: function (name) {
+        return this._callbacks && this._callbacks[name] && this._callbacks[name].length !== 0;
+    }
+};

--- a/tests/core/test_events.js
+++ b/tests/core/test_events.js
@@ -271,41 +271,6 @@ test("hasEvent() handler removed", function () {
   equal(o.hasEvent('event_name'), false);
 });
 
-test("Deprecated bind()", function() {
-   var o = {};
-   var called = false;
-
-   o = pc.extend(o, pc.events);
-
-   var cb = function() {
-       called = true;
-   };
-
-   o.bind("test", cb);
-
-   o.fire("test");
-
-   ok(called);
-});
-
-test("Deprecated bind and unbind", function() {
-   var o = {};
-
-   o = pc.extend(o, pc.events);
-
-   var f1 = function() {};
-   var f2 = function() {};
-
-   o.bind("test", f1);
-   o.bind("test", f2);
-   strictEqual(o._callbacks["test"].length, 2);
-
-   o.unbind("test", f1);
-
-   strictEqual(o._callbacks["test"].length, 1);
-   strictEqual(o._callbacks["test"][0].callback, f2);
-});
-
 test("Fire 1 argument", function () {
     var o = {};
     var value = "1234";


### PR DESCRIPTION
Long standing issue of constant allocation of callbacks array in `fire` method of events is now resolved.
The events behavior is identical to what it used to be.

Allocation will only happen if any of this happens:
1. While executing callback another subscription (`on` or `once`) to same object and same event name is called.
2. While executing callback `off` is called on same object with no name, or same name.
3. While executing callback, another `fire` on same object with same name is called.
4. If any of the executed callbacks has been added by `once`.

**Through tests, this eliminates 90%+ of events `fire` allocations, in some cases up to 99%!**