### PR TITLE
fix skin.matrixPalette create twice

### DIFF
--- a/src/scene/skin.js
+++ b/src/scene/skin.js
@@ -57,7 +57,6 @@ pc.extend(pc, function () {
             else
                 size = 8;
 
-            this.matrixPalette = new Float32Array(size * size * 4);
             this.boneTexture = new pc.Texture(device, {
                 width: size,
                 height: size,


### PR DESCRIPTION
```boneTexture.lock()``` will create Float32Array.