### PR TITLE
Fix WebGL 2.0 PCF3 shadow issue.

### DIFF
--- a/src/scene/forward-renderer.js
+++ b/src/scene/forward-renderer.js
@@ -395,7 +395,7 @@ pc.extend(pc, function () {
 
         if (shadowType === pc.SHADOW_PCF5 || (shadowType === pc.SHADOW_PCF3 && device.webgl2)) {
             shadowMap.compareOnRead = true;
-            shadowMap.compareFunc = pc.FUNC_LESS;
+            shadowMap.compareFunc = pc.FUNC_NOTEQUAL;
             // depthbuffer only
             return new pc.RenderTarget({
                 depthBuffer: shadowMap


### PR DESCRIPTION
Use playcanvas-latest.js in default playcanvas project(only Camera, Light, Box, Plane), and do not display model surface correctly.

So I PR.