### PR TITLE
Small refactor in Texture.setSource method.

### DIFF
--- a/src/graphics/texture.js
+++ b/src/graphics/texture.js
@@ -574,11 +574,11 @@ pc.extend(pc, function () {
             var width, height;
 
             if (this._cubemap) {
-                // rely on first face sizes
-                width = source[0] && source[0].width || 0;
-                height = source[0] && source[0].height || 0;
-
                 if (source[0]) {
+                    // rely on first face sizes
+                    width = source[0].width || 0;
+                    height = source[0].height || 0;
+
                     for (i = 0; i < 6; i++) {
                         // cubemap becomes invalid if any condition is not satisfied
                         if (! source[i] || // face is missing
@@ -589,6 +589,7 @@ pc.extend(pc, function () {
                             ! (source[i] instanceof HTMLVideoElement))) { // not video
 
                             invalid = true;
+                            break;
                         }
                     }
                 } else {
@@ -596,21 +597,26 @@ pc.extend(pc, function () {
                     invalid = true;
                 }
 
-                for (i = 0; i < 6; i++) {
-                    if (invalid || this._levels[0][i] !== source[i])
-                        this._levelsUpdated[0][i] = true;
+                if (!invalid) {
+                    // mark levels as updated
+                    for (i = 0; i < 6; i++) {
+                        if (this._levels[0][i] !== source[i])
+                            this._levelsUpdated[0][i] = true;
+                    }
                 }
             } else {
                 // cehck if source is valid type of element
                 if (! (source instanceof HTMLImageElement) && ! (source instanceof HTMLCanvasElement) && ! (source instanceof HTMLVideoElement))
                     invalid = true;
 
-                // mark level as updated
-                if (invalid || source !== this._levels[0])
-                    this._levelsUpdated[0] = true;
+                if (!invalid) {
+                    // mark level as updated
+                    if (source !== this._levels[0])
+                        this._levelsUpdated[0] = true;
 
-                width = source.width;
-                height = source.height;
+                    width = source.width;
+                    height = source.height;
+                }
             }
 
             if (invalid) {

--- a/src/graphics/texture.js
+++ b/src/graphics/texture.js
@@ -38,7 +38,7 @@ pc.extend(pc, function () {
      * Defaults to pc.PIXELFORMAT_R8_G8_B8_A8.
      * @param {Number} options.minFilter The minification filter type to use. Defaults to {@link pc.FILTER_LINEAR_MIPMAP_LINEAR}
      * @param {Number} options.magFilter The magnification filter type to use. Defaults to {@link pc.FILTER_LINEAR}
-     * @param {Number} options.anisotropy The level of anistropic filtering to use. Defaults to 1
+     * @param {Number} options.anisotropy The level of anisotropic filtering to use. Defaults to 1
      * @param {Number} options.addressU The repeat mode to use in the U direction. Defaults to {@link pc.ADDRESS_REPEAT}
      * @param {Number} options.addressV The repeat mode to use in the V direction. Defaults to {@link pc.ADDRESS_REPEAT}
      * @param {Boolean} options.mipmaps When enabled try to generate or use mipmaps for this texture. Default is true


### PR DESCRIPTION
Skip unnecessary loop when set invalid texture.