### PR TITLE
Add npm support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 *.DS_Store
 /build/output
 /src/graphics/program-lib/chunks/generated-shader-chunks.js
-package.json
 node_modules/
 .idea/
+npm-debug.log

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+/examples
+/tests

--- a/build/build.js
+++ b/build/build.js
@@ -40,22 +40,6 @@ var DEFAULT_OUTPUT = "output/playcanvas-latest.js";
 var DEFAULT_TEMP = "_tmp";
 var SRC_DIR = "../";
 
-var DEFAULT_PACKAGE = {
-    "author": "PlayCanvas <support@playcanvas.com>",
-    "description": "PlayCanvas WebGL Engine.",
-    "engines": {
-        "node": ">= 0.6.12"
-    },
-    "files": [
-        "build/output/playcanvas-latest.js"
-    ],
-    "homepage": "https://playcanvas.com",
-    "main": "build/output/playcanvas-latest.js",
-    "name": "playcanvas",
-    "repository": "https://github.com/playcanvas/engine",
-    "version": ""
-};
-
 var COMPILER_LEVEL = [
     'WHITESPACE_ONLY',
     'SIMPLE',
@@ -212,13 +196,6 @@ var insertVersions = function (filepath, callback) {
     });
 };
 
-// write package.json needed for a nodejs package
-var packageJson = function (version) {
-    var json = DEFAULT_PACKAGE;
-    json.version = version;
-    fs.writeFileSync("package.json", JSON.stringify(json, null, 4));
-};
-
 // remove temporary files
 var cleanup = function () {
     if (directoryExists(tempPath)) {
@@ -241,6 +218,7 @@ var run = function () {
               compilation_level: compilerLevel,
               language_in: "ECMASCRIPT5",
               js_output_file: outputPath,
+              output_wrapper_file: "./umd-wrapper.js",
               manage_closure_dependencies: true,
               jscomp_off: [
                   "nonStandardJsDocs",  // docs warnings
@@ -275,7 +253,6 @@ var run = function () {
                             process.exit();
                         }
 
-                        packageJson(version);
                         cleanup();
 
                         // done

--- a/build/umd-wrapper.js
+++ b/build/umd-wrapper.js
@@ -2,15 +2,22 @@
     if (typeof define === 'function' && define.amd) {
         define([], factory);
     } else if (typeof module === 'object' && module.exports) {
-        var JSDOM = require("jsdom").JSDOM;
-        var DOM = new JSDOM();
-        var window = DOM.window;
-        var navigator = window.navigator;
-        module.exports = factory(window, navigator);
+        try {
+            var JSDOM = require("jsdom").JSDOM;
+            var DOM = new JSDOM();
+            var window = DOM.window;
+            var navigator = window.navigator;
+            module.exports = factory(window, navigator);
+        } catch (error) {
+            module.exports = factory();
+        }
     } else {
         root.pc = factory(root, root.navigator);
   }
-}(this, function (window, navigator) {
+}(this, function (_window, _navigator) {
+  window = _window || window;
+  navigator = _navigator || navigator;
+
   %output%
   return pc;
 }));

--- a/build/umd-wrapper.js
+++ b/build/umd-wrapper.js
@@ -1,0 +1,16 @@
+;(function (root, factory) {
+    if (typeof define === 'function' && define.amd) {
+        define([], factory);
+    } else if (typeof module === 'object' && module.exports) {
+        var JSDOM = require("jsdom").JSDOM;
+        var DOM = new JSDOM();
+        var window = DOM.window;
+        var navigator = window.navigator;
+        module.exports = factory(window, navigator);
+    } else {
+        root.pc = factory(root, root.navigator);
+  }
+}(this, function (window, navigator) {
+  %output%
+  return pc;
+}));

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "type": "git",
     "url": "git+https://github.com/playcanvas/engine.git"
   },
-  "dependencies": {
+  "optionalDependencies": {
     "jsdom": "^11.5.1"
   },
   "devDependencies": {
@@ -22,7 +22,7 @@
     "preprocessor": "^1.4.0"
   },
   "scripts": {
-    "prepublish": "cd build && node build.js"
+    "prepublishOnly": "cd build && node build.js"
   },
   "engines": {
     "node": ">= 0.6.12"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "playcanvas",
+  "version": "0.221.0",
+  "author": "PlayCanvas <support@playcanvas.com>",
+  "homepage": "https://playcanvas.com",
+  "description": "PlayCanvas WebGL Engine.",
+  "license": "MIT",
+  "main": "build/output/playcanvas-latest.js",
+  "bugs": {
+    "url": "https://github.com/playcanvas/engine/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/playcanvas/engine.git"
+  },
+  "dependencies": {
+    "jsdom": "^11.5.1"
+  },
+  "devDependencies": {
+    "fs-extra": "^3.0.1",
+    "google-closure-compiler": "^20170423.0.0",
+    "preprocessor": "^1.4.0"
+  },
+  "scripts": {
+    "prepublish": "cd build && node build.js"
+  },
+  "engines": {
+    "node": ">= 0.6.12"
+  }
+}


### PR DESCRIPTION
Refer to https://github.com/playcanvas/engine/pull/832, add npm support for playcanvas.


**Update:**

For those guys who want to install an unofficial playcanvas, you can try:

```
npm install @scarletsky/playcanvas
or
npm install @scarletsky/playcanvas --no-optional

$ node
> const pc = require('@scarletsky/playcanvas')
undefined
> pc.Vec3
[Function: Vec3]
> pc.math
{ DEG_TO_RAD: 0.017453292519943295,
  RAD_TO_DEG: 57.29577951308232,
  INV_LOG2: 1.4426950408889634,
  clamp: [Function: clamp],
  intToBytes24: [Function: intToBytes24],
  intToBytes32: [Function: intToBytes32],
  bytesToInt24: [Function: bytesToInt24],
  bytesToInt32: [Function: bytesToInt32],
  lerp: [Function: lerp],
  lerpAngle: [Function: lerpAngle],
  powerOfTwo: [Function: powerOfTwo],
  nextPowerOfTwo: [Function: nextPowerOfTwo],
  random: [Function: random],
  smoothstep: [Function: smoothstep],
  smootherstep: [Function: smootherstep],
  intToBytes: [Function: intToBytes32],
  bytesToInt: [Function: bytesToInt32] }
>
```

Happy hacking 😄  !