### PR TITLE
Update lightmapper.js for negative scales

### DIFF
--- a/src/scene/lightmapper.js
+++ b/src/scene/lightmapper.js
@@ -136,6 +136,8 @@ pc.extend(pc, function () {
             var totalArea = area.x * scale.y * scale.z +
                             area.y * scale.x * scale.z +
                             area.z * scale.x * scale.y;
+            
+            totalArea = Math.abs(totalArea); // Account for negative scales, we still want the same size lightmap.
             totalArea /= area.uv;
             totalArea = Math.sqrt(totalArea);
 


### PR DESCRIPTION
If a model has a negative scale (say, for mirroring it) the lightmap size calculation returns 1 instead of a real resolution.

This kills the lightmap.

I updated totalArea to always be positive by applying Math.abs() to it, because negatively scaled objects need the same size lightmap as their positively scaled brethren.