### PR TITLE
Update lightmapper.js for negative scales

### DIFF
--- a/src/scene/lightmapper.js
+++ b/src/scene/lightmapper.js
@@ -132,6 +132,11 @@ pc.extend(pc, function () {
                 scale.mul(parent.localScale);
                 parent = parent._parent;
             }
+            
+            // Negatively scaled nodes still need full size lightmaps.
+            scale.x = Math.abs(scale.x);
+            scale.y = Math.abs(scale.y);
+            scale.z = Math.abs(scale.z);
 
             var totalArea = area.x * scale.y * scale.z +
                             area.y * scale.x * scale.z +


### PR DESCRIPTION
If a model has a negative scale (say, for mirroring it) the lightmap size calculation returns 1 instead of a real resolution.

This kills the lightmap.

I updated totalArea to not get corrupted by negative scaling by applying Math.abs() to the scale prior to the calculation. Negatively scaled objects need the same size lightmap as their positively scaled brethren.