### PR TITLE
Node transform cache

### DIFF
--- a/src/anim/skeleton.js
+++ b/src/anim/skeleton.js
@@ -349,7 +349,7 @@ pc.extend(pc, function () {
                     transform.localPosition.copy(interpKey._pos);
                     transform.localRotation.copy(interpKey._quat);
                     transform.localScale.copy(interpKey._scale);
-                    transform.dirtify(true);
+                    transform._dirtify(true);
 
                     interpKey._written = false;
                 }

--- a/src/anim/skeleton.js
+++ b/src/anim/skeleton.js
@@ -349,7 +349,9 @@ pc.extend(pc, function () {
                     transform.localPosition.copy(interpKey._pos);
                     transform.localRotation.copy(interpKey._quat);
                     transform.localScale.copy(interpKey._scale);
-                    transform._dirtify(true);
+
+                    if (! transform._dirtyLocal)
+                        transform._dirtify(true);
 
                     interpKey._written = false;
                 }

--- a/src/anim/skeleton.js
+++ b/src/anim/skeleton.js
@@ -349,7 +349,7 @@ pc.extend(pc, function () {
                     transform.localPosition.copy(interpKey._pos);
                     transform.localRotation.copy(interpKey._quat);
                     transform.localScale.copy(interpKey._scale);
-                    transform.dirtyLocal = true;
+                    transform.dirtify(true);
 
                     interpKey._written = false;
                 }

--- a/src/core/events.js
+++ b/src/core/events.js
@@ -166,7 +166,7 @@ pc.events = {
             callbacks = this._callbacks[name].slice();
         }
 
-        for(var i = 0; i < (callbacks || this._callbackActive[name]).length; i++) {
+        for(var i = 0; (callbacks || this._callbackActive[name]) && (i < (callbacks || this._callbackActive[name]).length); i++) {
             var evt = (callbacks || this._callbackActive[name])[i];
             evt.callback.call(evt.scope, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
 

--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -1282,12 +1282,19 @@ pc.extend(pc, function () {
         }
     };
 
+    window.max_graphTraverseCounter = 0;
+    window.max_graphTraverseDirtify = 0;
+    window.max_graphTraverseTransformL = 0;
+    window.max_graphTraverseTransformW = 0;
+
     // create tick function to be wrapped in closure
     var makeTick = function (_app) {
         var app = _app;
         return function () {
             window.graphTraverseCounter = 0;
             window.graphTraverseDirtify = 0;
+            window.graphTraverseTransformL = 0;
+            window.graphTraverseTransformW = 0;
 
             if (!app.graphicsDevice) {
                 return;
@@ -1336,9 +1343,16 @@ pc.extend(pc, function () {
                 app.vr.display.submitFrame();
             }
 
-            console.log('counters', {
+            window.max_graphTraverseCounter = Math.max(window.max_graphTraverseCounter, window.graphTraverseCounter);
+            window.max_graphTraverseDirtify = Math.max(window.max_graphTraverseDirtify, window.graphTraverseDirtify);
+            window.max_graphTraverseTransformL = Math.max(window.max_graphTraverseTransformL, window.graphTraverseTransformL);
+            window.max_graphTraverseTransformW = Math.max(window.max_graphTraverseTransformW, window.graphTraverseTransformW);
+
+            console.log({
                 sync: window.graphTraverseCounter,
-                diftify: window.graphTraverseDirtify
+                ditify: window.graphTraverseDirtify,
+                transformL: window.graphTraverseTransformL,
+                transformW: window.graphTraverseTransformW
             });
         }
     };

--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -1282,23 +1282,12 @@ pc.extend(pc, function () {
         }
     };
 
-    window.max_graphTraverseCounter = 0;
-    window.max_graphTraverseDirtify = 0;
-    window.max_graphTraverseTransformL = 0;
-    window.max_graphTraverseTransformW = 0;
-
     // create tick function to be wrapped in closure
     var makeTick = function (_app) {
         var app = _app;
         return function () {
-            window.graphTraverseCounter = 0;
-            window.graphTraverseDirtify = 0;
-            window.graphTraverseTransformL = 0;
-            window.graphTraverseTransformW = 0;
-
-            if (!app.graphicsDevice) {
+            if (! app.graphicsDevice)
                 return;
-            }
 
             Application._currentApplication = app;
 
@@ -1342,18 +1331,6 @@ pc.extend(pc, function () {
             if (app.vr && app.vr.display && app.vr.display.presenting) {
                 app.vr.display.submitFrame();
             }
-
-            window.max_graphTraverseCounter = Math.max(window.max_graphTraverseCounter, window.graphTraverseCounter);
-            window.max_graphTraverseDirtify = Math.max(window.max_graphTraverseDirtify, window.graphTraverseDirtify);
-            window.max_graphTraverseTransformL = Math.max(window.max_graphTraverseTransformL, window.graphTraverseTransformL);
-            window.max_graphTraverseTransformW = Math.max(window.max_graphTraverseTransformW, window.graphTraverseTransformW);
-
-            console.log({
-                sync: window.graphTraverseCounter,
-                ditify: window.graphTraverseDirtify,
-                transformL: window.graphTraverseTransformL,
-                transformW: window.graphTraverseTransformW
-            });
         }
     };
     // static data

--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -1286,6 +1286,9 @@ pc.extend(pc, function () {
     var makeTick = function (_app) {
         var app = _app;
         return function () {
+            window.graphTraverseCounter = 0;
+            window.graphTraverseDirtify = 0;
+
             if (!app.graphicsDevice) {
                 return;
             }
@@ -1333,6 +1336,10 @@ pc.extend(pc, function () {
                 app.vr.display.submitFrame();
             }
 
+            console.log('counters', {
+                sync: window.graphTraverseCounter,
+                diftify: window.graphTraverseDirtify
+            });
         }
     };
     // static data

--- a/src/framework/components/camera/system.js
+++ b/src/framework/components/camera/system.js
@@ -158,8 +158,8 @@ pc.extend(pc, function () {
                         if (cam._node) {
                             cam._node.localTransform.copy(vrDisplay.combinedViewInv);
                             cam._node.dirtyLocal = false;
-                            cam._node.dirtyWorld = true;
-                            cam._node.syncHierarchy();
+                            cam._node.dirtify();
+                            // cam._node.syncHierarchy();
                         }
                     }
                 }

--- a/src/framework/components/camera/system.js
+++ b/src/framework/components/camera/system.js
@@ -157,8 +157,8 @@ pc.extend(pc, function () {
                         // update camera node transform from VrDisplay
                         if (cam._node) {
                             cam._node.localTransform.copy(vrDisplay.combinedViewInv);
-                            cam._node.dirtyLocal = false;
-                            cam._node.dirtify();
+                            cam._node._dirtyLocal = false;
+                            cam._node._dirtify();
                             // cam._node.syncHierarchy();
                         }
                     }

--- a/src/framework/components/element/component.js
+++ b/src/framework/components/element/component.js
@@ -152,6 +152,7 @@ pc.extend(pc, function () {
         _onInsert: function (parent) {
             // when the entity is reparented find a possible new screen
             var screen = this._findScreen();
+
             this.entity._dirtify();
 
             this._updateScreen(screen);
@@ -573,7 +574,10 @@ pc.extend(pc, function () {
             this._calculateLocalAnchors();
 
             this._anchorDirty = true;
-            this._dirtify(true);
+
+            if (! this.entity._dirtyLocal)
+                this.entity._dirtify(true);
+
             this.fire('set:anchor', this._anchor);
         }
     });

--- a/src/framework/components/element/component.js
+++ b/src/framework/components/element/component.js
@@ -74,7 +74,8 @@ pc.extend(pc, function () {
                 invParentWtm.copy(this.element._screenToWorld).invert();
                 invParentWtm.transformPoint(position, this.localPosition);
 
-                this.dirtyLocal = true;
+                if (! this.dirtyLocal)
+                    this.dirtify(true);
             };
         }(),
 
@@ -87,8 +88,6 @@ pc.extend(pc, function () {
                 this.localTransform.setTRS(this.localPosition, this.localRotation, this.localScale);
 
                 this.dirtyLocal = false;
-                this.dirtyWorld = true;
-                this._aabbVer++;
             }
 
             var resx = 0;
@@ -147,20 +146,14 @@ pc.extend(pc, function () {
                 }
 
                 this.dirtyWorld = false;
-
-                var child;
-                for (var i = 0, len = this._children.length; i < len; i++) {
-                    child = this._children[i];
-                    child.dirtyWorld = true;
-                    child._aabbVer++;
-
-                }
             }
         },
 
         _onInsert: function (parent) {
             // when the entity is reparented find a possible new screen
             var screen = this._findScreen();
+            this.entity.dirtify();
+
             this._updateScreen(screen);
 
             this._calculateSize();
@@ -190,7 +183,6 @@ pc.extend(pc, function () {
             this.fire('set:screen', this.screen);
 
             this._anchorDirty = true;
-            this.entity.dirtyWorld = true;
 
             // update all child screens
             var children = this.entity.getChildren();
@@ -212,7 +204,6 @@ pc.extend(pc, function () {
 
         _onScreenResize: function (res) {
             this._anchorDirty = true;
-            this.entity.dirtyWorld = true;
 
             var minx = this._localAnchor.x;
             var miny = this._localAnchor.y;
@@ -229,7 +220,6 @@ pc.extend(pc, function () {
         },
 
         _onScreenSpaceChange: function () {
-            this.entity.dirtyWorld = true;
             this.fire('screen:set:screenspace', this.screen.screen.screenSpace);
         },
 
@@ -374,7 +364,6 @@ pc.extend(pc, function () {
                 } else if (value === pc.ELEMENTTYPE_TEXT) {
                     this._text = new pc.TextElement(this);
                 }
-
             }
         }
     });
@@ -584,7 +573,7 @@ pc.extend(pc, function () {
             this._calculateLocalAnchors();
 
             this._anchorDirty = true;
-            this.entity.dirtyWorld = true;
+            this.dirtify(true);
             this.fire('set:anchor', this._anchor);
         }
     });

--- a/src/framework/components/element/component.js
+++ b/src/framework/components/element/component.js
@@ -50,12 +50,12 @@ pc.extend(pc, function () {
 
     pc.extend(ElementComponent.prototype, {
         _patch: function () {
-            this.entity.sync = this._sync;
+            this.entity._sync = this._sync;
             this.entity.setPosition = this._setPosition;
         },
 
         _unpatch: function () {
-            this.entity.sync = pc.Entity.prototype.sync;
+            this.entity._sync = pc.Entity.prototype._sync;
             this.entity.setPosition = pc.Entity.prototype.setPosition;
         },
 
@@ -74,8 +74,8 @@ pc.extend(pc, function () {
                 invParentWtm.copy(this.element._screenToWorld).invert();
                 invParentWtm.transformPoint(position, this.localPosition);
 
-                if (! this.dirtyLocal)
-                    this.dirtify(true);
+                if (! this._dirtyLocal)
+                    this._dirtify(true);
             };
         }(),
 
@@ -84,10 +84,10 @@ pc.extend(pc, function () {
             var element = this.element;
             var parent = this.element._parent;
 
-            if (this.dirtyLocal) {
+            if (this._dirtyLocal) {
                 this.localTransform.setTRS(this.localPosition, this.localRotation, this.localScale);
 
-                this.dirtyLocal = false;
+                this._dirtyLocal = false;
             }
 
             var resx = 0;
@@ -119,7 +119,7 @@ pc.extend(pc, function () {
             }
 
 
-            if (this.dirtyWorld) {
+            if (this._dirtyWorld) {
                 if (this._parent === null) {
                     this.worldTransform.copy(this.localTransform);
                 } else {
@@ -145,14 +145,14 @@ pc.extend(pc, function () {
                     }
                 }
 
-                this.dirtyWorld = false;
+                this._dirtyWorld = false;
             }
         },
 
         _onInsert: function (parent) {
             // when the entity is reparented find a possible new screen
             var screen = this._findScreen();
-            this.entity.dirtify();
+            this.entity._dirtify();
 
             this._updateScreen(screen);
 
@@ -573,7 +573,7 @@ pc.extend(pc, function () {
             this._calculateLocalAnchors();
 
             this._anchorDirty = true;
-            this.dirtify(true);
+            this._dirtify(true);
             this.fire('set:anchor', this._anchor);
         }
     });

--- a/src/framework/components/screen/component.js
+++ b/src/framework/components/screen/component.js
@@ -149,7 +149,10 @@ pc.extend(pc, function () {
             this._updateScale();
 
             this._calcProjectionMatrix();
-            this.entity._dirtify(true);
+
+            if (! this.entity._dirtyLocal)
+                this.entity._dirtify(true);
+
             this.fire("set:resolution", this._resolution);
         },
         get: function () {
@@ -162,7 +165,10 @@ pc.extend(pc, function () {
             this._referenceResolution.set(value.x, value.y);
             this._updateScale();
             this._calcProjectionMatrix();
-            this.entity._dirtify(true);
+
+            if (! this.entity._dirtyLocal)
+                this.entity._dirtify(true);
+
             this.fire("set:referenceresolution", this._resolution);
         },
         get: function () {
@@ -181,7 +187,10 @@ pc.extend(pc, function () {
                 this._resolution.set(this.system.app.graphicsDevice.width, this.system.app.graphicsDevice.height);
             }
             this.resolution = this._resolution; // force update either way
-            this.entity._dirtify(true);
+
+            if (! this.entity._dirtyLocal)
+                this.entity._dirtify(true);
+
             this.fire('set:screenspace', this._screenSpace);
         },
         get: function () {
@@ -215,7 +224,10 @@ pc.extend(pc, function () {
             this._scaleBlend = value;
             this._updateScale();
             this._calcProjectionMatrix();
-            this.entity._dirtify(true);
+
+            if (! this.entity._dirtyLocal)
+                this.entity._dirtify(true);
+
             this.fire("set:scaleblend", this._scaleBlend);
         },
         get: function () {

--- a/src/framework/components/screen/component.js
+++ b/src/framework/components/screen/component.js
@@ -149,7 +149,7 @@ pc.extend(pc, function () {
             this._updateScale();
 
             this._calcProjectionMatrix();
-            this.entity.dirtify(true);
+            this.entity._dirtify(true);
             this.fire("set:resolution", this._resolution);
         },
         get: function () {
@@ -162,7 +162,7 @@ pc.extend(pc, function () {
             this._referenceResolution.set(value.x, value.y);
             this._updateScale();
             this._calcProjectionMatrix();
-            this.entity.dirtify(true);
+            this.entity._dirtify(true);
             this.fire("set:referenceresolution", this._resolution);
         },
         get: function () {
@@ -181,7 +181,7 @@ pc.extend(pc, function () {
                 this._resolution.set(this.system.app.graphicsDevice.width, this.system.app.graphicsDevice.height);
             }
             this.resolution = this._resolution; // force update either way
-            this.entity.dirtify(true);
+            this.entity._dirtify(true);
             this.fire('set:screenspace', this._screenSpace);
         },
         get: function () {
@@ -215,7 +215,7 @@ pc.extend(pc, function () {
             this._scaleBlend = value;
             this._updateScale();
             this._calcProjectionMatrix();
-            this.entity.dirtify(true);
+            this.entity._dirtify(true);
             this.fire("set:scaleblend", this._scaleBlend);
         },
         get: function () {

--- a/src/framework/components/screen/component.js
+++ b/src/framework/components/screen/component.js
@@ -149,6 +149,7 @@ pc.extend(pc, function () {
             this._updateScale();
 
             this._calcProjectionMatrix();
+            this.entity.dirtify(true);
             this.fire("set:resolution", this._resolution);
         },
         get: function () {
@@ -161,6 +162,7 @@ pc.extend(pc, function () {
             this._referenceResolution.set(value.x, value.y);
             this._updateScale();
             this._calcProjectionMatrix();
+            this.entity.dirtify(true);
             this.fire("set:referenceresolution", this._resolution);
         },
         get: function () {
@@ -179,6 +181,7 @@ pc.extend(pc, function () {
                 this._resolution.set(this.system.app.graphicsDevice.width, this.system.app.graphicsDevice.height);
             }
             this.resolution = this._resolution; // force update either way
+            this.entity.dirtify(true);
             this.fire('set:screenspace', this._screenSpace);
         },
         get: function () {
@@ -212,6 +215,7 @@ pc.extend(pc, function () {
             this._scaleBlend = value;
             this._updateScale();
             this._calcProjectionMatrix();
+            this.entity.dirtify(true);
             this.fire("set:scaleblend", this._scaleBlend);
         },
         get: function () {
@@ -223,4 +227,3 @@ pc.extend(pc, function () {
         ScreenComponent: ScreenComponent
     };
 }());
-

--- a/src/scene/forward-renderer.js
+++ b/src/scene/forward-renderer.js
@@ -1511,10 +1511,10 @@ pc.extend(pc, function () {
 
                 if (normal) {
                     normalMatrix = meshInstance.node.normalMatrix;
-                    if (meshInstance.node.dirtyNormal) {
+                    if (meshInstance.node._dirtyNormals) {
                         modelMatrix.invertTo3x3(normalMatrix);
                         normalMatrix.transpose();
-                        meshInstance.node.dirtyNormal = false;
+                        meshInstance.node._dirtyNormals = false;
                     }
                     this.normalMatrixId.setValue(normalMatrix.data);
                 }

--- a/src/scene/forward-renderer.js
+++ b/src/scene/forward-renderer.js
@@ -1511,10 +1511,10 @@ pc.extend(pc, function () {
 
                 if (normal) {
                     normalMatrix = meshInstance.node.normalMatrix;
-                    if (meshInstance.node._dirtyNormals) {
+                    if (meshInstance.node._dirtyNormal) {
                         modelMatrix.invertTo3x3(normalMatrix);
                         normalMatrix.transpose();
-                        meshInstance.node._dirtyNormals = false;
+                        meshInstance.node._dirtyNormal = false;
                     }
                     this.normalMatrixId.setValue(normalMatrix.data);
                 }

--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -693,25 +693,16 @@ pc.extend(pc, function () {
          * var transform = this.entity.getWorldTransform();
          */
         getWorldTransform: function () {
-            var syncList = [ ];
-
-            return function () {
-                if (this._dirtyLocal || this._dirtyWorld) {
-                    var current = this;
-                    syncList.length = 0;
-
-                    while (current !== null && (current._dirtyLocal || current._dirtyWorld)) {
-                        syncList.push(current);
-                        current = current._parent;
-                    }
-
-                    for (var i = syncList.length - 1; i >= 0; i--)
-                        syncList[i]._sync();
-                }
-
+            if (! this._dirtyLocal && ! this._dirtyWorld)
                 return this.worldTransform;
-            };
-        }(),
+
+            if (this._parent)
+                this._parent.getWorldTransform();
+
+            this._sync();
+
+            return this.worldTransform;
+        },
 
         /**
          * @function

--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -38,7 +38,7 @@ pc.extend(pc, function () {
         this._dirtyWorld = false;
 
         this.normalMatrix = new pc.Mat3();
-        this._dirtyNormals = true;
+        this._dirtyNormal = true;
 
         this._right = new pc.Vec3();
         this._up = new pc.Vec3();
@@ -202,7 +202,7 @@ pc.extend(pc, function () {
 
             clone.worldTransform.copy(this.worldTransform);
             clone._dirtyWorld = this._dirtyWorld;
-            clone._dirtyNormals = this._dirtyNormals;
+            clone._dirtyNormal = this._dirtyNormal;
             clone._aabbVer = this._aabbVer + 1;
 
             clone._enabled = this._enabled;
@@ -890,7 +890,7 @@ pc.extend(pc, function () {
                 }
             }
 
-            this._dirtyNormals = true;
+            this._dirtyNormal = true;
             this._aabbVer++;
         },
 

--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -1,8 +1,3 @@
-window.graphTraverseCounter = 0;
-window.graphTraverseDirtify = 0;
-window.graphTraverseTransformL = 0;
-window.graphTraverseTransformW = 0;
-
 pc.extend(pc, function () {
     var scaleCompensatePosTransform = new pc.Mat4();
     var scaleCompensatePos = new pc.Vec3();
@@ -50,7 +45,7 @@ pc.extend(pc, function () {
         this._forward = new pc.Vec3();
 
         this._parent = null;
-        this._children = [];
+        this._children = [ ];
 
         this._enabled = true;
         this._enabledInHierarchy = false;
@@ -636,9 +631,6 @@ pc.extend(pc, function () {
             if (this.dirtyLocal) {
                 this.localTransform.setTRS(this.localPosition, this.localRotation, this.localScale);
                 this.dirtyLocal = false;
-                this.dirtyWorld = true;
-                this.dirtyNormal = true;
-                this._aabbVer++;
             }
             return this.localTransform;
         },
@@ -701,7 +693,7 @@ pc.extend(pc, function () {
          * var transform = this.entity.getWorldTransform();
          */
         getWorldTransform: function () {
-            var syncList = [];
+            var syncList = [ ];
 
             return function () {
                 if (this.dirtyLocal || this.dirtyWorld) {
@@ -770,7 +762,7 @@ pc.extend(pc, function () {
                 this.localRotation.setFromEulerAngles(x, y, z);
             }
 
-            // if (! this.dirtyLocal)
+            if (! this.dirtyLocal)
                 this.dirtify(true);
         },
 
@@ -800,7 +792,7 @@ pc.extend(pc, function () {
                 this.localPosition.set(x, y, z);
             }
 
-            // if (! this.dirtyLocal)
+            if (! this.dirtyLocal)
                 this.dirtify(true);
         },
 
@@ -831,7 +823,7 @@ pc.extend(pc, function () {
                 this.localRotation.set(x, y, z, w);
             }
 
-            // if (! this.dirtyLocal)
+            if (! this.dirtyLocal)
                 this.dirtify(true);
         },
 
@@ -861,7 +853,7 @@ pc.extend(pc, function () {
                 this.localScale.set(x, y, z);
             }
 
-            // if (! this.dirtyLocal)
+            if (! this.dirtyLocal)
                 this.dirtify(true);
         },
 
@@ -880,8 +872,6 @@ pc.extend(pc, function () {
         },
 
         dirtify: function(local) {
-            window.graphTraverseDirtify++;
-
             if ((! local || (local && this.dirtyLocal)) && this.dirtyWorld)
                 return;
 
@@ -941,7 +931,7 @@ pc.extend(pc, function () {
                     invParentWtm.transformPoint(position, this.localPosition);
                 }
 
-                // if (! this.dirtyLocal)
+                if (! this.dirtyLocal)
                     this.dirtify(true);
             };
         }(),
@@ -987,7 +977,7 @@ pc.extend(pc, function () {
                     this.localRotation.copy(invParentRot).mul(rotation);
                 }
 
-                // if (! this.dirtyLocal)
+                if (! this.dirtyLocal)
                     this.dirtify(true);
             };
         }(),
@@ -1029,7 +1019,7 @@ pc.extend(pc, function () {
                     this.localRotation.mul2(invParentRot, this.localRotation);
                 }
 
-                // if (! this.dirtyLocal)
+                if (! this.dirtyLocal)
                     this.dirtify(true);
             };
         }(),
@@ -1217,20 +1207,13 @@ pc.extend(pc, function () {
         },
 
         sync: function () {
-            window.graphTraverseCounter++;
-
             if (this.dirtyLocal) {
-                window.graphTraverseTransformL++;
                 this.localTransform.setTRS(this.localPosition, this.localRotation, this.localScale);
 
                 this.dirtyLocal = false;
-                this.dirtyWorld = true;
-                this.dirtyNormal = true;
-                this._aabbVer++;
             }
 
             if (this.dirtyWorld) {
-                window.graphTraverseTransformW++;
                 if (this._parent === null) {
                     this.worldTransform.copy(this.localTransform);
                 } else {

--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -1,5 +1,7 @@
 window.graphTraverseCounter = 0;
 window.graphTraverseDirtify = 0;
+window.graphTraverseTransformL = 0;
+window.graphTraverseTransformW = 0;
 
 pc.extend(pc, function () {
     var scaleCompensatePosTransform = new pc.Mat4();
@@ -1216,6 +1218,7 @@ pc.extend(pc, function () {
             window.graphTraverseCounter++;
 
             if (this.dirtyLocal) {
+                window.graphTraverseTransformL++;
                 this.localTransform.setTRS(this.localPosition, this.localRotation, this.localScale);
 
                 this.dirtyLocal = false;
@@ -1225,6 +1228,7 @@ pc.extend(pc, function () {
             }
 
             if (this.dirtyWorld) {
+                window.graphTraverseTransformW++;
                 if (this._parent === null) {
                     this.worldTransform.copy(this.localTransform);
                 } else {

--- a/src/scene/immediate.js
+++ b/src/scene/immediate.js
@@ -50,7 +50,7 @@ pc.extend(pc.Application.prototype, function () {
 
                 if (!this.meshInstance) {
                     identityGraphNode.worldTransform = pc.Mat4.IDENTITY;
-                    identityGraphNode._dirtyWorld = identityGraphNode._dirtyNormals = false;
+                    identityGraphNode._dirtyWorld = identityGraphNode._dirtyNormal = false;
                     this.meshInstance = new pc.MeshInstance(identityGraphNode, this.mesh, this.material);
                 }
             }
@@ -263,7 +263,7 @@ pc.extend(pc.Application.prototype, function () {
     // Draw mesh at this frame
     function renderMesh(mesh, material, matrix) {
         tempGraphNode.worldTransform = matrix;
-        tempGraphNode._dirtyWorld = tempGraphNode._dirtyNormals = false;
+        tempGraphNode._dirtyWorld = tempGraphNode._dirtyNormal = false;
         var instance = new pc.MeshInstance(tempGraphNode, mesh, material);
         this.scene.immediateDrawCalls.push(instance);
     }
@@ -295,7 +295,7 @@ pc.extend(pc.Application.prototype, function () {
         }
         // Issue quad drawcall
         tempGraphNode.worldTransform = matrix;
-        tempGraphNode._dirtyWorld = tempGraphNode._dirtyNormals = false;
+        tempGraphNode._dirtyWorld = tempGraphNode._dirtyNormal = false;
         var quad = new pc.MeshInstance(tempGraphNode, quadMesh, material);
         if (layer) quad.layer = layer;
         this.scene.immediateDrawCalls.push(quad);

--- a/src/scene/immediate.js
+++ b/src/scene/immediate.js
@@ -50,7 +50,7 @@ pc.extend(pc.Application.prototype, function () {
 
                 if (!this.meshInstance) {
                     identityGraphNode.worldTransform = pc.Mat4.IDENTITY;
-                    identityGraphNode.dirtyWorld = identityGraphNode.dirtyNormal = false;
+                    identityGraphNode._dirtyWorld = identityGraphNode._dirtyNormals = false;
                     this.meshInstance = new pc.MeshInstance(identityGraphNode, this.mesh, this.material);
                 }
             }
@@ -263,7 +263,7 @@ pc.extend(pc.Application.prototype, function () {
     // Draw mesh at this frame
     function renderMesh(mesh, material, matrix) {
         tempGraphNode.worldTransform = matrix;
-        tempGraphNode.dirtyWorld = tempGraphNode.dirtyNormal = false;
+        tempGraphNode._dirtyWorld = tempGraphNode._dirtyNormals = false;
         var instance = new pc.MeshInstance(tempGraphNode, mesh, material);
         this.scene.immediateDrawCalls.push(instance);
     }
@@ -295,7 +295,7 @@ pc.extend(pc.Application.prototype, function () {
         }
         // Issue quad drawcall
         tempGraphNode.worldTransform = matrix;
-        tempGraphNode.dirtyWorld = tempGraphNode.dirtyNormal = false;
+        tempGraphNode._dirtyWorld = tempGraphNode._dirtyNormals = false;
         var quad = new pc.MeshInstance(tempGraphNode, quadMesh, material);
         if (layer) quad.layer = layer;
         this.scene.immediateDrawCalls.push(quad);


### PR DESCRIPTION
Change logic of how entities transformation is calculated and cached.

Previously to get transform, traversion from node to root and then sync from root to node back was required on every call that requires world transform. Like `getPosition` or `getRotation`, etc.
This would lead to huge number of `sync` calls which would do simple checks, but it would add up. In scenes with many entities, this would lead to thousands, sometimes tens thousands of sync calls.

Now the algorithm changes slightly. When transformation is modified, it will ensure that all descendants are dirtified. Consequent transformations will not re-dirtify. Due to this rule, if node is dirty, then all descendants should have `_dirtyWorld == true` as well. But not all ascendants should have `_dirtyWorld == true`.
This way we can limit traversion and know at the moment of getting transform if it needs to re-sync with hierarchy. And even in such case, not all the way to root, but only to earliest dirty node in a tree up towards root.

This reduces number of `sync` calls from 5 to 1000 times, and in more complex scenes even more.
Small extra price of transforming unchanged nodes with many descendants, but much cheaper retrieval of transformation, especially if nodes are "static".

No external code should modify private dirty flags, but can call `_dirtify` method if very-very needed.

Additional bug fix with `event.fire`, where in rare cases of some modification to same event during callback would lead to an exception.