### PR TITLE
Fix restart PlayCanvas Application issue.

### DIFF
--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -1278,6 +1278,8 @@ pc.extend(pc, function () {
             // remove default particle texture
             pc.ParticleEmitter.DEFAULT_PARAM_TEXTURE = null;
 
+            pc.ModelHandler.resetDefaultMaterial();
+
             pc.destroyPostEffectQuad();
         }
     };

--- a/src/graphics/scope-id.js
+++ b/src/graphics/scope-id.js
@@ -21,7 +21,7 @@ pc.extend(pc, function () {
             this.versionObject.increment();
         },
 
-        getValue: function(value) {
+        getValue: function() {
             return this.value;
         }
     };

--- a/src/resources/model.js
+++ b/src/resources/model.js
@@ -9,7 +9,11 @@ pc.extend(pc, function () {
         this._device = device;
     };
 
-    ModelHandler.DEFAULT_MATERIAL = pc.Scene.defaultMaterial;
+    ModelHandler._ORIGINAL_DEFAULT_MATERIAL = pc.Scene.defaultMaterial;
+    ModelHandler.DEFAULT_MATERIAL = ModelHandler._ORIGINAL_DEFAULT_MATERIAL.clone();
+    ModelHandler.resetDefaultMaterial = function () {
+        ModelHandler.DEFAULT_MATERIAL = ModelHandler._ORIGINAL_DEFAULT_MATERIAL.clone();
+    };
 
     ModelHandler.prototype = {
         /**
@@ -30,7 +34,7 @@ pc.extend(pc, function () {
             });
         },
 
-         /**
+        /**
          * @function
          * @name pc.ModelHandler#open
          * @description Process data in deserialized format into a pc.Model object


### PR DESCRIPTION
**Test code**
https://github.com/H1Gdev/restart_playcanvas

1. new Application
2. start Application
3. wait 5[s]
4. destroy Application
5. new Application
6. start Application

**Expect**
-> cube entity color is the same as the first time.
**Actual**
-> cube entity color is black.

use pc.ModelHandler.DEFAULT_MATERIAL global variable directly, and keep instance at the first time.
(pc.ModelHandler.DEFAULT_MATERIAL.parameters.material_diffuse.scopeId etc.)

So use clone the following global default variables.

- pc.Scene.defaultMaterial
- pc.ModelHandler.DEFAULT_MATERIAL