### PR TITLE
Support ray intersects mesh instances

### DIFF
--- a/src/framework/components/camera/system.js
+++ b/src/framework/components/camera/system.js
@@ -185,6 +185,21 @@ pc.extend(pc, function () {
             this.cameras.sort(function (a, b) {
                 return a.priority - b.priority;
             });
+        },
+
+        raycastMeshInstances: function (ray, meshInstances) {
+            var i = 0;
+            var intersects = [];
+
+            for (i = 0; i < meshInstances.length; i++) {
+                meshInstances[i].intersectsRay(ray, intersects);
+            }
+
+            if (intersects.length === 0) {
+                return null;
+            }
+
+            return intersects.sort(function (a, b) { return a.distance - b.distance; });
         }
     });
 

--- a/src/scene/mesh.js
+++ b/src/scene/mesh.js
@@ -180,6 +180,12 @@ pc.extend(pc, function () {
 
             if (meshInstance.skinInstance) {
                 localTransform.transformPoint(localCoord, localCoord);
+            } else {
+                worldTransform.transformPoint(worldCoord, worldCoord);
+                worldTransform.transformPoint(a, a);
+                worldTransform.transformPoint(b, b);
+                worldTransform.transformPoint(c, c);
+                worldTransform.transformVector(normal, normal);
             }
 
             distance.sub2(worldCoord, ray.origin);

--- a/src/shape/ray.js
+++ b/src/shape/ray.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+pc.extend(pc, function() {
     /**
      * @name pc.Ray
      * @class An infinite ray
@@ -16,6 +16,50 @@ pc.extend(pc, function () {
         this.origin = origin || new pc.Vec3(0, 0, 0);
         this.direction = direction || new pc.Vec3(0, 0, -1);
     };
+
+    Ray.prototype.intersectTriangle = (function() {
+        var diff = new pc.Vec3();
+        var edge1 = new pc.Vec3();
+        var edge2 = new pc.Vec3();
+        var normal = new pc.Vec3();
+
+        return function intersectTriangle(a, b, c, backfaceCulling, res) {
+            res = (res === undefined) ? new pc.Vec3() : res;
+            edge1.sub2(b, a);
+            edge2.sub2(c, a);
+            normal.cross(edge1, edge2);
+
+            var DdN = this.direction.dot(normal);
+            var sign;
+
+            if (DdN > 0) {
+                if (backfaceCulling) return null;
+                sign = 1;
+            } else if (DdN < 0) {
+                sign = -1;
+                DdN = -DdN;
+            } else {
+                return null;
+            }
+
+            diff.sub2(this.origin, a);
+
+            var DdQxE2 = sign * this.direction.dot(edge2.cross(diff, edge2));
+
+            if (DdQxE2 < 0) return null;
+
+            var DdE1xQ = sign * this.direction.dot(edge1.cross(edge1, diff));
+
+            if (DdE1xQ < 0) return null;
+            if (DdQxE2 + DdE1xQ > DdN) return null;
+
+            var QdN = -sign * diff.dot(normal);
+
+            if (QdN < 0) return null;
+
+            return res.copy(this.direction).scale(QdN / DdN).add(this.origin);
+        };
+    })();
 
     return {
         Ray: Ray


### PR DESCRIPTION
This is a solution for https://forum.playcanvas.com/t/way-to-get-mesh-instance/4646 .
And the code is migrated from THREE.js 😃 

Usage is learned from `app.systems.rigidbody.raycastFirst`:

```js
var meshInstances = entity.model.model.meshInstances;
app.mouse.on('mousemove', function(e) {
    camera.camera.screenToWorld(e.x, e.y, camera.camera.nearClip, fromPoint);
    camera.camera.screenToWorld(e.x, e.y, camera.camera.farClip, toPoint);
    ray.origin.copy(fromPoint);
    ray.direction.copy(toPoint).sub(ray.origin).normalize();
  
    var results = app.systems.camera.raycastMeshInstances(ray, meshInstances);
    console.log(results);
});
```

The result:
```js
[
    {
        index: Number, // the index of triangle based on IndexBuffer
        distance: Number, // the distance between ray.origin and the hit point
        point: Vec3, // the hit point of world
        localPoint: Vec3, // the hit point of local
        normal: Vec3, // the triangle's normal
        vertices: [Vec3, Vec3, Vec3], // the triangles's vertices
        meshInstance: meshInstance // the meshInstance of this triangle
    }
]

```

I've made a demo in https://scarletsky.github.io/engine/, you can open the console and see the performance and the result.