### PR TITLE
Only update cpu matrices on mesh instances that are visible.  This he…

### DIFF
--- a/src/scene/forward-renderer.js
+++ b/src/scene/forward-renderer.js
@@ -1310,7 +1310,11 @@ pc.extend(pc, function () {
 
             var i, skin;
             for (i = 0; i < drawCallsCount; i++) {
-                skin = drawCalls[i].skinInstance;
+                var drawCall = drawCalls[i].skinInstance;
+                //Only update for visible mesh instances
+                if(drawCall instanceof pc.MeshInstance && drawCall.visible === false) continue;
+
+                skin = drawCall.skinInstance;
                 if (skin) {
                     skin.updateMatrices();
                     skin._dirty = true;


### PR DESCRIPTION
…lps with certain assets that contain multiple skinned characters on the same skeleton, otherwise significant CPU is used skinning invisible meshes.