### PR TITLE
[FIX] When cloning a model make sure we also assign the same material…

### DIFF
--- a/src/framework/components/model/system.js
+++ b/src/framework/components/model/system.js
@@ -130,6 +130,9 @@ pc.extend(pc, function () {
                 var meshInstancesClone = component.model.meshInstances;
                 for (var i = 0; i < meshInstances.length; i++) {
                     meshInstancesClone[i].mask = meshInstances[i].mask;
+                    meshInstancesClone[i].material = meshInstances[i].material;
+                    meshInstancesClone[i].layer = meshInstances[i].layer;
+                    meshInstancesClone[i].receiveShadow = meshInstances[i].receiveShadow;
                 }
             }
         },


### PR DESCRIPTION
…, layer and receiveShadow properties to the cloned mesh instances as the original