### PR TITLE
Remove unnecessary escape in regular expression.

### DIFF
--- a/src/core/uri.js
+++ b/src/core/uri.js
@@ -67,7 +67,7 @@ pc.extend(pc, function() {
          */
         URI: function (uri) {
             // See http://tools.ietf.org/html/rfc2396#appendix-B for details of RegExp
-            var re = /^(([^:\/?\#]+):)?(\/\/([^\/?\#]*))?([^?\#]*)(\?([^\#]*))?(\#(.*))?/,
+            var re = /^(([^:\/?#]+):)?(\/\/([^\/?#]*))?([^?#]*)(\?([^#]*))?(#(.*))?/,
             result = uri.match(re);
 
             /**

--- a/src/graphics/device.js
+++ b/src/graphics/device.js
@@ -54,7 +54,7 @@ pc.extend(pc, function () {
     function _isIE() {
         var ua = window.navigator.userAgent;
         var msie = ua.indexOf("MSIE ");
-        var trident = navigator.userAgent.match(/Trident.*rv\:11\./);
+        var trident = navigator.userAgent.match(/Trident.*rv:11\./);
 
         return (msie > 0 || !!trident);
     }
@@ -2011,7 +2011,7 @@ pc.extend(pc, function () {
             }
         },
 
-         /**
+        /**
          * @function
          * @name pc.GraphicsDevice#setDepthFunc
          * @description Configures the depth test.


### PR DESCRIPTION
'#' and ':' do not need escape so remove unnecessary escape.