### PR TITLE
Fix ScriptType initialization

### DIFF
--- a/src/framework/components/script/component.js
+++ b/src/framework/components/script/component.js
@@ -173,15 +173,6 @@ pc.extend(pc, function () {
             for(var i = 0, len = this.scripts.length; i < len; i++) {
                 script = this.scripts[i];
                 script.enabled = script._enabled;
-
-                if (! script._initialized && script.enabled) {
-                    script._initialized = true;
-
-                    script.__initializeAttributes(true);
-
-                    if (script.initialize)
-                        this._scriptMethod(script, ScriptComponent.scriptMethods.initialize);
-                }
             }
         },
 

--- a/src/script/script.js
+++ b/src/script/script.js
@@ -535,6 +535,13 @@ pc.extend(pc, function () {
                     this.fire(this.enabled ? 'enable' : 'disable');
                     this.fire('state', this.enabled);
                 }
+
+                if (this.enabled && !this._initialized) {
+                    this._initialized = true;
+                    this.__initializeAttributes(true);
+                    if (this.initialize)
+                        this.entity.script._scriptMethod(this, ScriptComponent.scriptMethods.initialize);
+                }
             }
         });
 


### PR DESCRIPTION
How to replay this bug:
- add script to object and disable it (f.e. in editor)
- in another script enable it
- initialize() will never call, but update() begin working

NOTE: Idk what to do with postInitialize() _(may be nothing?)_, need help
**Also, I can't check working it or not, but it should** :)