### PR TITLE
Fix fire invalid event from ScriptComponent issue.

### DIFF
--- a/src/framework/components/script/component.js
+++ b/src/framework/components/script/component.js
@@ -166,7 +166,7 @@ pc.extend(pc, function () {
 
             this._oldState = state;
 
-            this.fire('enable');
+            this.fire(this.enabled ? 'enable' : 'disable');
             this.fire('state', this.enabled);
 
             var script;


### PR DESCRIPTION
Fire 'disable' event when ScriptComponent becomes disabled.