### PR TITLE
Fixed Gamepad "Cannot read property ‘pad’ of undefined"

### DIFF
--- a/src/input/game-pads.js
+++ b/src/input/game-pads.js
@@ -108,7 +108,7 @@ pc.extend(pc, function () {
             var buttonsLen;
             for (i = 0; i < len; i++) {
                 // Initialize the previous and current for each gamepad
-                if(this.previous[i] === null) {
+                if(this.previous[i] === undefined) {
                     this.previous[i] = { pad: { buttons: [ ] }, map:{ } };
                     this.current[i] = { pad: { buttons: [ ] }, map:{ } };
                 }


### PR DESCRIPTION
This fixes the error in https://forum.playcanvas.com/t/uncaught-typeerror-cannot-read-property-pad-of-undefined/5051

When doing the final style changes, I switched:

```
if(this.previous[i] == null) {
```
to
```
if(this.previous[i] === null) {
```

Which will never be true because an undefined array index is `undefined` and not `null`.

I tested this using the gamepad input example under `examples/` and it does fix this error. 