### PR TITLE
Updated mul and mul2 descriptions to clarify the difference

### DIFF
--- a/src/math/vec2.js
+++ b/src/math/vec2.js
@@ -216,7 +216,7 @@ pc.extend(pc, (function () {
         /**
          * @function
          * @name pc.Vec2#mul
-         * @description Returns the result of multiplying the specified 2-dimensional vectors together.
+         * @description Multiplies a 2-dimensional vector to another in place.
          * @param {pc.Vec2} rhs The 2-dimensional vector used as the second multiplicand of the operation.
          * @returns {pc.Vec2} Self for chaining.
          * @example

--- a/src/math/vec3.js
+++ b/src/math/vec3.js
@@ -258,7 +258,7 @@ pc.extend(pc, (function () {
         /**
          * @function
          * @name pc.Vec3#mul
-         * @description Returns the result of multiplying the specified 3-dimensional vectors together.
+         * @description Multiplies a 3-dimensional vector to another in place.
          * @param {pc.Vec3} rhs The 3-dimensional vector used as the second multiplicand of the operation.
          * @returns {pc.Vec3} Self for chaining.
          * @example

--- a/src/math/vec4.js
+++ b/src/math/vec4.js
@@ -228,7 +228,7 @@ pc.extend(pc, (function () {
         /**
          * @function
          * @name pc.Vec4#mul
-         * @description Returns the result of multiplying the specified 4-dimensional vectors together.
+         * @description Multiplies a 4-dimensional vector to another in place.
          * @param {pc.Vec4} rhs The 4-dimensional vector used as the second multiplicand of the operation.
          * @returns {pc.Vec4} Self for chaining.
          * @example


### PR DESCRIPTION
As per @daredevildave 's suggestion in this thread (https://forum.playcanvas.com/t/ambigious-docs-on-mul-vs-mul2/3305/2), this is a proposed update to the API reference to clarify that `mul` multiplies a sigle vector in place, and `mul2` multiples two given vectors. 

This also makes the wording more consistent with `add`, `add2`, `sub` and `sub2`