### PR TITLE
Update documentation for pc.events.attach

### DIFF
--- a/src/core/events.js
+++ b/src/core/events.js
@@ -19,7 +19,7 @@ pc.events = {
     /**
     * @function
     * @name pc.events.attach
-    * @description Attach event methods 'on', 'off', 'fire' and 'hasEvent' to the target object
+    * @description Attach event methods 'on', 'off', 'fire', 'once' and 'hasEvent' to the target object
     * @param {Object} target The object to add events to.
     * @return {Object} The target object
     * @example


### PR DESCRIPTION
Update pc.events.attach description to mention that the 'once' event method is also attached to the target object along with the other event methods.