### PR TITLE
Fix discrepency in pc.KeyboardEvent documentation

### DIFF
--- a/src/input/keyboard.js
+++ b/src/input/keyboard.js
@@ -4,7 +4,7 @@ pc.extend(pc, function(){
     * @class The KeyboardEvent is passed into all event callbacks from the {@link pc.Keyboard}. It corresponds to a key press or release.
     * @description Create a new KeyboardEvent
     * @param {pc.Keyboard} keyboard The keyboard object which is firing the event.
-    * @param {pc.KeyboardEvent} event The original browser event that was fired.
+    * @param {KeyboardEvent} event The original browser event that was fired.
     * @property {Number} key The keyCode of the key that has changed. See the pc.KEY_* constants.
     * @property {Element} element The element that fired the keyboard event.
     * @property {KeyboardEvent} event The original browser event which was fired.


### PR DESCRIPTION
In the docs for pc.KeyboardEvent for the `event` param, it is said that it is 'the original browser event that was fired' but the type assigned for it in the docs is `pc.KeyboardEvent`. Unless I'm mistaken, it should be the `KeyboardEvent` object from the web API. This would correspond to the `event` property which has the same description but is typed `KeyboardEvent`.