### PR TITLE
Change pc.AudioManager references to pc.SoundManager

### DIFF
--- a/src/audio/channel.js
+++ b/src/audio/channel.js
@@ -3,13 +3,13 @@ pc.extend(pc, function () {
 
     var Channel;
 
-    if (pc.AudioManager.hasAudioContext()) {
+    if (pc.SoundManager.hasAudioContext()) {
         /**
         * @private
         * @name pc.Channel
-        * @class A channel is created when the pc.AudioManager begins playback of a pc.Sound. Usually created internally by
-        * pc.AudioManager#playSound or pc.AudioManager#playSound3d. Developers usually won't have to create Channels manually.
-        * @param {pc.AudioManager} manager The AudioManager instance
+        * @class A channel is created when the pc.SoundManager begins playback of a pc.Sound. Usually created internally by
+        * pc.SoundManager#playSound or pc.SoundManager#playSound3d. Developers usually won't have to create Channels manually.
+        * @param {pc.SoundManager} manager The SoundManager instance
         * @param {pc.Sound} sound The sound to playback
         * @param {Object} options
         * @param {Number} [options.volume=1] The playback volume, between 0 and 1.
@@ -198,7 +198,7 @@ pc.extend(pc, function () {
                 }
             }
         };
-    } else if (pc.AudioManager.hasAudio()) {
+    } else if (pc.SoundManager.hasAudio()) {
         Channel = function (manager, sound, options) {
             this.volume = options.volume || 1;
             this.loop = options.loop || false;

--- a/src/audio/channel3d.js
+++ b/src/audio/channel3d.js
@@ -6,7 +6,7 @@ pc.extend(pc, function () {
 
     var Channel3d;
 
-    if (pc.AudioManager.hasAudioContext()) {
+    if (pc.SoundManager.hasAudioContext()) {
         Channel3d = function (manager, sound, options) {
             this.position = new pc.Vec3();
             this.velocity = new pc.Vec3();
@@ -90,7 +90,7 @@ pc.extend(pc, function () {
                 }
             }
         });
-    } else if (pc.AudioManager.hasAudio()) {
+    } else if (pc.SoundManager.hasAudio()) {
         // temp vector storage
         var offset = new pc.Vec3();
 

--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -153,7 +153,7 @@ pc.extend(pc, function () {
         this.graphicsDevice = new pc.GraphicsDevice(canvas, options.graphicsDeviceOptions);
         this.stats = new pc.ApplicationStats(this.graphicsDevice);
         this.systems = new pc.ComponentSystemRegistry();
-        this._audioManager = new pc.SoundManager(options);
+        this._soundManager = new pc.SoundManager(options);
         this.loader = new pc.ResourceLoader();
 
         this.scene = new pc.Scene();
@@ -197,7 +197,7 @@ pc.extend(pc, function () {
         this.loader.addHandler("texture", new pc.TextureHandler(this.graphicsDevice, this.assets, this.loader));
         this.loader.addHandler("text", new pc.TextHandler());
         this.loader.addHandler("json", new pc.JsonHandler());
-        this.loader.addHandler("audio", new pc.AudioHandler(this._audioManager));
+        this.loader.addHandler("audio", new pc.AudioHandler(this._soundManager));
         this.loader.addHandler("script", new pc.ScriptHandler(this));
         this.loader.addHandler("scene", new pc.SceneHandler(this));
         this.loader.addHandler("cubemap", new pc.CubemapHandler(this.graphicsDevice, this.assets, this.loader));
@@ -221,9 +221,9 @@ pc.extend(pc, function () {
         } else {
             new pc.ScriptComponentSystem(this);
         }
-        var audiosourcesys = new pc.AudioSourceComponentSystem(this, this._audioManager);
-        var soundsys = new pc.SoundComponentSystem(this, this._audioManager);
-        var audiolistenersys = new pc.AudioListenerComponentSystem(this, this._audioManager);
+        var audiosourcesys = new pc.AudioSourceComponentSystem(this, this._soundManager);
+        var soundsys = new pc.SoundComponentSystem(this, this._soundManager);
+        var audiolistenersys = new pc.AudioListenerComponentSystem(this, this._soundManager);
         var particlesystemsys = new pc.ParticleSystemComponentSystem(this);
         var screensys = new pc.ScreenComponentSystem(this);
         var elementsys = new pc.ElementComponentSystem(this);
@@ -1044,9 +1044,9 @@ pc.extend(pc, function () {
         */
         onVisibilityChange: function (e) {
             if (this.isHidden()) {
-                this._audioManager.suspend();
+                this._soundManager.suspend();
             } else {
-                this._audioManager.resume();
+                this._soundManager.resume();
             }
         },
 
@@ -1306,9 +1306,9 @@ pc.extend(pc, function () {
 
             this.renderer = null;
 
-            if (this._audioManager) {
-                this._audioManager.destroy();
-                this._audioManager = null;
+            if (this._soundManager) {
+                this._soundManager.destroy();
+                this._soundManager = null;
             }
 
             pc.http = new pc.Http();

--- a/src/sound/listener.js
+++ b/src/sound/listener.js
@@ -11,7 +11,7 @@ pc.extend(pc, function () {
         this.velocity = new pc.Vec3();
         this.orientation = new pc.Mat4();
 
-        if (pc.AudioManager.hasAudioContext()) {
+        if (pc.SoundManager.hasAudioContext()) {
             this.listener = manager.context.listener;
         }
     };

--- a/tests/audio/test_audio.js
+++ b/tests/audio/test_audio.js
@@ -4,30 +4,30 @@ test('pc.audio.isSupported MP3', function () {
     var url = '/test/file.mp3';
     var a = new Audio();
 
-    equal(pc.AudioManager.isSupported(url), true);
-    equal(pc.AudioManager.isSupported(url, a), true);
+    equal(pc.SoundManager.isSupported(url), true);
+    equal(pc.SoundManager.isSupported(url, a), true);
 });
 
 test('pc.audio.isSupported ogg', function () {
     var url = '/test/file.ogg';
     var a = new Audio();
 
-    equal(pc.AudioManager.isSupported(url), true);
-    equal(pc.AudioManager.isSupported(url, a), true);
+    equal(pc.SoundManager.isSupported(url), true);
+    equal(pc.SoundManager.isSupported(url, a), true);
 });
 
 test('pc.audio.isSupported wav', function () {
     var url = '/test/file.wav';
     var a = new Audio();
 
-    equal(pc.AudioManager.isSupported(url), true);
-    equal(pc.AudioManager.isSupported(url, a), true);
+    equal(pc.SoundManager.isSupported(url), true);
+    equal(pc.SoundManager.isSupported(url, a), true);
 });
 
 test('pc.audio.isSupported other', function () {
     var url = '/test/file.other';
     var a = new Audio();
 
-    equal(pc.AudioManager.isSupported(url), false);
-    equal(pc.AudioManager.isSupported(url, a), false);
+    equal(pc.SoundManager.isSupported(url), false);
+    equal(pc.SoundManager.isSupported(url, a), false);
 });


### PR DESCRIPTION
Change all references to `pc.AudioManager` in the code and the documentation to refer to `pc.SoundManager` since it seems to have replaced it completly.

Leave the backward compatibilty reference in `pc.SoundManager` itself.