### PR TITLE
Allow Timer to use window.performance.now where available

### DIFF
--- a/src/core/time.js
+++ b/src/core/time.js
@@ -20,7 +20,7 @@ pc.extend(pc, (function () {
          */
         start: function () {
             this._isRunning = true;
-            this._a = (new Date()).getTime();
+            this._a = pc.now();
         },
 
         /**
@@ -31,7 +31,7 @@ pc.extend(pc, (function () {
          */
         stop: function() {
             this._isRunning = false;
-            this._b = (new Date()).getTime();
+            this._b = pc.now();
         },
 
         /**


### PR DESCRIPTION
The current consensus on timing in the browser seem to suggest the use of window.performance.now() where possible and Date.now() as a fallback, as the former is more precise and the later more performant than new Date.getTime().

https://stackoverflow.com/questions/12517359/performance-date-now-vs-date-gettime https://stackoverflow.com/questions/30795525/performance-now-vs-date-now https://www.sitepoint.com/discovering-the-high-resolution-time-api/