### PR TITLE
Fix small mistake in documentation

### DIFF
--- a/src/framework/components/particle-system/component.js
+++ b/src/framework/components/particle-system/component.js
@@ -75,7 +75,7 @@ pc.extend(pc, function() {
      * Particle rotation is specified by a single angle parameter: default billboard particles rotate around camera facing axis, while mesh particles rotate around 2 different view-independent axes.
      * Most of the simulation parameters are specified with pc.Curve or pc.CurveSet. Curves are interpolated based on each particle's lifetime, therefore parameters are able to change over time.
      * Most of the curve parameters can also be specified by 2 minimum/maximum curves, this way each particle will pick a random value in-between.
-     * @param {pc.ParticleSystemComponent} system The ComponentSystem that created this Component
+     * @param {pc.ParticleSystemComponentSystem} system The ComponentSystem that created this Component
      * @param {pc.Entity} entity The Entity this Component is attached to
      * @extends pc.Component
      * @property {Boolean} autoPlay Controls whether the particle system plays automatically on creation. If set to false, it is necessary to call {@link pc.ParticleSystemComponent#play} for the particle system to play. Defaults to true.


### PR DESCRIPTION
pc.ParticleSystemComponent's `system` parameter was erroneously typed as `pc.ParticleSystemComponent` when it should be typed as `pc.ParticleSystemComponentSystem`. 