### PR TITLE
Add getAxisAngle method to pc.Quat

### DIFF
--- a/src/math/quat.js
+++ b/src/math/quat.js
@@ -137,6 +137,50 @@ pc.extend(pc, (function () {
          */
         equals: function (that) {
             return ((this.x === that.x) && (this.y === that.y) && (this.z === that.z) && (this.w === that.w));
+        },        
+
+        /**
+         * @function
+         * @name pc.Quat#getAxisAngle
+         * @description Gets the rotation axis and angle for a given
+         *  quaternion. If a quaternion is created with
+         *  setFromAxisAngle, this method will return the same
+         *  values as provided in the original parameter list
+         *  OR functionally equivalent values.
+         * @param {pc.Vec3} axis The 3-dimensional vector to receive the axis of rotation.
+         * @returns {Number} Angle, in degrees, of the rotation
+         * @example
+         * var q = new pc.Quat();
+         * q.setFromAxisAngle(new pc.Vec3(0, 1, 0), 90);
+         * var v = new pc.Vec3();
+         * var angle = q.getAxisAngle(v);
+         * // Should output 90
+         * console.log(angle)
+         * // Should output [0, 1, 0]
+         * console.log(v.toString());
+         * @author Philippe Vaillancourt
+         */
+        getAxisAngle: function (axis) {
+            let rad = Math.acos(this.w) * 2.0;
+            let s = Math.sin(rad / 2.0);
+            if (s != 0.0) {
+                axis.x = this.x / s;
+                axis.y = this.y / s;
+                axis.z = this.z / s;
+                if (axis.x < 0 || axis.y < 0 || axis.z < 0) {
+                    // Flip the sign
+                    axis.x *= -1;
+                    axis.y *= -1;
+                    axis.z *= -1;
+                    rad *= -1;
+                }
+            } else {
+                // If s is zero, return any axis (no rotation - axis does not matter)
+                axis.x = 1;
+                axis.y = 0;
+                axis.z = 0;
+            }
+            return rad * pc.math.RAD_TO_DEG;
         },
 
         /**


### PR DESCRIPTION
The Quat class has both a setFromEulerAngles and getEulerAngles method but only a setFromAxisAngle and no corresponding getAxisAngle method. Issue #1058.