### PR TITLE
Use the timestamp passed to requestAnimationFrame callback

### DIFF
--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -1323,7 +1323,7 @@ pc.extend(pc, function () {
     // create tick function to be wrapped in closure
     var makeTick = function (_app) {
         var app = _app;
-        return function () {
+        return function (timestamp) {
             if (! app.graphicsDevice)
                 return;
 
@@ -1332,7 +1332,7 @@ pc.extend(pc, function () {
             // have current application pointer in pc
             pc.app = app;
 
-            var now = pc.now();
+            var now = timestamp || pc.now();
             var ms = now - (app._time || now);
             var dt = ms / 1000.0;
             dt *= app.timeScale;


### PR DESCRIPTION
performance.now seems to give unreliable values, especially compared to the RAF callback timestamp, which almost exactly returns 16.666ms between frames when running at 60fps.