### PR TITLE
fix: add missing TouchEvent and KeyboardEvent to pc namespace

### DIFF
--- a/src/input/keyboard.js
+++ b/src/input/keyboard.js
@@ -318,6 +318,7 @@ pc.extend(pc, function(){
     };
 
     return {
-        Keyboard: Keyboard
+        Keyboard: Keyboard,
+        KeyboardEvent: KeyboardEvent
     };
 }());

--- a/src/input/touch.js
+++ b/src/input/touch.js
@@ -185,6 +185,7 @@ pc.extend(pc, function () {
             };
         },
 
-        TouchDevice: TouchDevice
+        TouchDevice: TouchDevice,
+        TouchEvent: TouchEvent
     };
 }());


### PR DESCRIPTION
From https://forum.playcanvas.com/t/is-there-any-way-to-prevent-mouse-event-propagation/6077, I notice that we can not access `pc.TouchEvent` and `pc.KeyboardEvent` because of `TouchEvent` and `KeyboardEvent` are not exposed to `pc` namespace.
