### PR TITLE
Set script attributes to default on script.create()

### DIFF
--- a/src/framework/components/script/component.js
+++ b/src/framework/components/script/component.js
@@ -372,7 +372,7 @@ pc.extend(pc, function () {
                     this[scriptType.__name] = scriptInstance;
 
                     if (! args.preloading)
-                        scriptInstance.__initializeAttributes();
+                        scriptInstance.__initializeAttributes(true);
 
                     this.fire('create', scriptType.__name, scriptInstance);
                     this.fire('create:' + scriptType.__name, scriptInstance);


### PR DESCRIPTION
Fixed an error where a script's attributes would not be initialized to their default values when calling pc.script.create()

#1052 