### PR TITLE
Support for webglcontextlost

### DIFF
--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -1327,7 +1327,7 @@ pc.extend(pc, function () {
     var makeTick = function (_app) {
         var app = _app;
         return function (timestamp) {
-            if (!app.graphicsDevice || app.graphicsDevice.contextLost) {
+            if (!app.graphicsDevice) {
                 return;
             }
 
@@ -1348,6 +1348,10 @@ pc.extend(pc, function () {
                 app.vr.display.requestAnimationFrame(app.tick);
             } else {
                 window.requestAnimationFrame(app.tick);
+            }
+
+            if (app.graphicsDevice.contextLost) {
+                return;
             }
 
             // #ifdef PROFILER

--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -1327,8 +1327,9 @@ pc.extend(pc, function () {
     var makeTick = function (_app) {
         var app = _app;
         return function (timestamp) {
-            if (! app.graphicsDevice)
+            if (!app.graphicsDevice || app.graphicsDevice.contextLost) {
                 return;
+            }
 
             Application._currentApplication = app;
 

--- a/src/graphics/device.js
+++ b/src/graphics/device.js
@@ -18,16 +18,6 @@ pc.extend(pc, function () {
     }
     ContextCreationError.prototype = Error.prototype;
 
-    var _contextLostHandler = function (event) {
-        event.preventDefault();
-        console.log('pc.GraphicsDevice: WebGL context lost.');
-    };
-
-    var _contextRestoredHandler = function () {
-        console.log('pc.GraphicsDevice: WebGL context restored.');
-        this.initializeContext();
-    };
-
     var _downsampleImage = function (image, size) {
         var srcW = image.width;
         var srcH = image.height;
@@ -225,10 +215,22 @@ pc.extend(pc, function () {
         if (! window.WebGLRenderingContext)
             throw new pc.UnsupportedBrowserError();
 
-        // Retrieve the WebGL context
-        canvas.addEventListener("webglcontextlost", _contextLostHandler.bind(this), false);
-        canvas.addEventListener("webglcontextrestored", _contextRestoredHandler.bind(this), false);
+        // Add handlers for when the WebGL context is lost or restored
+        this.contextLost = false;
 
+        canvas.addEventListener("webglcontextlost", function (event) {
+            event.preventDefault();
+            this.contextLost = true;
+            console.log('pc.GraphicsDevice: WebGL context lost.');
+        }.bind(this), false);
+
+        canvas.addEventListener("webglcontextrestored", function () {
+            console.log('pc.GraphicsDevice: WebGL context restored.');
+            this.initializeContext();
+            this.contextLost = false;
+        }.bind(this), false);
+
+        // Retrieve the WebGL context
         var preferWebGl2 = (options && options.preferWebGl2 !== undefined) ? options.preferWebGl2 : true;
 
         var names = preferWebGl2 ? ["webgl2", "experimental-webgl2", "webgl", "experimental-webgl"] :

--- a/src/graphics/device.js
+++ b/src/graphics/device.js
@@ -236,13 +236,19 @@ pc.extend(pc, function () {
         canvas.addEventListener("webglcontextlost", function (event) {
             event.preventDefault();
             this.contextLost = true;
+            // #ifdef DEBUG
             console.log('pc.GraphicsDevice: WebGL context lost.');
+            // #endif
+            this.fire('devicelost');
         }.bind(this), false);
 
         canvas.addEventListener("webglcontextrestored", function () {
+            // #ifdef DEBUG
             console.log('pc.GraphicsDevice: WebGL context restored.');
+            // #endif
             this.initializeContext();
             this.contextLost = false;
+            this.fire('devicerestored');
         }.bind(this), false);
 
         // Retrieve the WebGL context

--- a/src/graphics/device.js
+++ b/src/graphics/device.js
@@ -213,6 +213,7 @@ pc.extend(pc, function () {
         this.textureUnits = [];
         this._maxPixelRatio = 1;
         this.renderTarget = null;
+        this.feedback = null;
 
         // local width/height without pixelRatio applied
         this._width = 0;
@@ -404,10 +405,6 @@ pc.extend(pc, function () {
                 gl.UNSIGNED_INT,
                 gl.FLOAT
             ];
-
-            if (this.webgl2) {
-                this.feedback = gl.createTransformFeedback();
-            }
 
             this.supportsBoneTextures = this.extTextureFloat && this.maxVertexTextures > 0;
             this.useTexCubeLod = this.extTextureLod && this.samplerCount < 16;
@@ -891,6 +888,7 @@ pc.extend(pc, function () {
             }
             this.renderTarget = null;
             this.activeFramebuffer = null;
+            this.feedback = null;
         },
 
         updateClientRect: function () {
@@ -2214,6 +2212,9 @@ pc.extend(pc, function () {
             if (this.webgl2) {
                 var gl = this.gl;
                 if (tf) {
+                    if (!this.feedback) {
+                        this.feedback = gl.createTransformFeedback();
+                    }
                     gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, this.feedback);
                 } else {
                     gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, null);

--- a/src/graphics/device.js
+++ b/src/graphics/device.js
@@ -771,7 +771,8 @@ pc.extend(pc, function () {
             this.blendEquation = pc.BLENDEQUATION_ADD;
             this.blendAlphaEquation = pc.BLENDEQUATION_ADD;
             this.separateAlphaEquation = false;
-            gl.blendFuncSeparate(gl.ONE, gl.ZERO, gl.ONE, gl.ZERO);
+            gl.blendFunc(gl.ONE, gl.ZERO);
+            gl.blendEquation(gl.FUNC_ADD);
 
             this.writeRed = true;
             this.writeGreen = true;
@@ -798,29 +799,26 @@ pc.extend(pc, function () {
             this.stencilFuncFront = this.stencilFuncBack = pc.FUNC_ALWAYS;
             this.stencilRefFront = this.stencilRefBack = 0;
             this.stencilMaskFront = this.stencilMaskBack = 0xFF;
-            gl.stencilFuncSeparate(gl.FRONT, gl.ALWAYS, 0, 0xFF);
-            gl.stencilFuncSeparate(gl.BACK, gl.ALWAYS, 0, 0xFF);
+            gl.stencilFunc(gl.ALWAYS, 0, 0xFF);
 
             this.stencilFailFront = this.stencilFailBack = pc.STENCILOP_KEEP;
             this.stencilZfailFront = this.stencilZfailBack = pc.STENCILOP_KEEP;
             this.stencilZpassFront = this.stencilZpassBack = pc.STENCILOP_KEEP;
             this.stencilWriteMaskFront = 0xFF;
             this.stencilWriteMaskBack = 0xFF;
-            gl.stencilOpSeparate(gl.FRONT, gl.KEEP, gl.KEEP, gl.KEEP);
-            gl.stencilMaskSeparate(gl.FRONT, 0xFF);
-            gl.stencilOpSeparate(gl.BACK, gl.KEEP, gl.KEEP, gl.KEEP);
-            gl.stencilMaskSeparate(gl.BACK, 0xFF);
+            gl.stencilOp(gl.KEEP, gl.KEEP, gl.KEEP);
+            gl.stencilMask(0xFF);
 
             this.alphaToCoverage = false;
             if (this.webgl2) {
-                this.gl.disable(this.gl.SAMPLE_ALPHA_TO_COVERAGE);
+                gl.disable(gl.SAMPLE_ALPHA_TO_COVERAGE);
             }
 
             this.raster = true;
-            gl.disable(this.gl.RASTERIZER_DISCARD);
+            gl.disable(gl.RASTERIZER_DISCARD);
 
             this.depthBiasEnabled = false;
-            gl.disable(this.gl.POLYGON_OFFSET_FILL);
+            gl.disable(gl.POLYGON_OFFSET_FILL);
 
             this.clearDepth = 1;
             gl.clearDepth(1);
@@ -876,16 +874,7 @@ pc.extend(pc, function () {
             // Force all textures to be recreated and reuploaded
             for (i = 0, len = this.textures.length; i < len; i++) {
                 var texture = this.textures[i];
-                texture._glTextureId = undefined;
-                texture._mipmapsUploaded = false;
-                texture._minFilterDirty = true;
-                texture._magFilterDirty = true;
-                texture._addressUDirty = true;
-                texture._addressVDirty = true;
-                texture._addressWDirty = texture._volume;
-                texture._anisotropyDirty = true;
-                texture._compareModeDirty = true;
-                texture.upload();
+                texture.dirtyAll();
             }
             this.activeTexture = 0;
             this.textureUnits = [];

--- a/src/graphics/device.js
+++ b/src/graphics/device.js
@@ -113,7 +113,7 @@ pc.extend(pc, function () {
         return size;
     }
 
-    function testRenderable(gl, ext, pixelFormat) {
+    function testRenderable(gl, pixelFormat) {
         var __texture = gl.createTexture();
         gl.bindTexture(gl.TEXTURE_2D, __texture);
         gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
@@ -557,7 +557,7 @@ pc.extend(pc, function () {
                         this.extTextureFloatRenderable = this.extColorBufferFloat;
                     } else {
                         // In WebGL1 we should just try rendering into a float texture
-                        this.extTextureFloatRenderable = testRenderable(gl, this.extTextureFloat, gl.FLOAT);
+                        this.extTextureFloatRenderable = testRenderable(gl, gl.FLOAT);
                     }
                 }
                 if (this.extTextureHalfFloat) {
@@ -566,7 +566,7 @@ pc.extend(pc, function () {
                         this.extTextureHalfFloatRenderable = this.extColorBufferFloat;
                     } else {
                         // Manual render check for half float
-                        this.extTextureHalfFloatRenderable = testRenderable(gl, this.extTextureHalfFloat, this.extTextureHalfFloat.HALF_FLOAT_OES);
+                        this.extTextureHalfFloatRenderable = testRenderable(gl, this.extTextureHalfFloat.HALF_FLOAT_OES);
                     }
                 }
                 if (this.extTextureFloatRenderable) {

--- a/src/graphics/device.js
+++ b/src/graphics/device.js
@@ -75,9 +75,9 @@ pc.extend(pc, function () {
         }
 
         var mips = 1;
-        if (tex._pot && (tex._mipmaps || tex._minFilter === gl.NEAREST_MIPMAP_NEAREST ||
-            tex._minFilter === gl.NEAREST_MIPMAP_LINEAR || tex._minFilter === gl.LINEAR_MIPMAP_NEAREST ||
-            tex._minFilter === gl.LINEAR_MIPMAP_LINEAR) && ! (tex._compressed && tex._levels.length === 1)) {
+        if (tex._pot && (tex._mipmaps || tex._minFilter === pc.FILTER_NEAREST_MIPMAP_NEAREST ||
+            tex._minFilter === pc.FILTER_NEAREST_MIPMAP_LINEAR || tex._minFilter === pc.FILTER_LINEAR_MIPMAP_NEAREST ||
+            tex._minFilter === pc.FILTER_LINEAR_MIPMAP_LINEAR) && ! (tex._compressed && tex._levels.length === 1)) {
 
             mips = Math.round(Math.log2(Math.max(tex._width, tex._height)) + 1);
         }

--- a/src/graphics/device.js
+++ b/src/graphics/device.js
@@ -215,6 +215,10 @@ pc.extend(pc, function () {
         this._width = 0;
         this._height = 0;
 
+        // Array of WebGL objects that need to be re-initialized after a context restore event
+        this.shaders = [];
+        this.buffers = [];
+
         this.updateClientRect();
 
         if (! window.WebGLRenderingContext)
@@ -772,7 +776,7 @@ pc.extend(pc, function () {
 
         }).call(this);
 
-        this.initializeContext();
+        this.initializeRenderState();
     };
 
     GraphicsDevice.prototype = {
@@ -825,6 +829,22 @@ pc.extend(pc, function () {
 
         initializeContext: function () {
             this.initializeRenderState();
+
+            var i, len;
+            for (i = 0, len = this.shaders.length; i < len; i++) {
+                this.shaders[i].compile();
+            }
+            this.shader = null;
+
+            for (i = 0, len = this.buffers.length; i < len; i++) {
+                this.buffers[i].bufferId = undefined;
+                this.buffers[i].unlock();
+            }
+            this.boundBuffer = null;
+            this.indexBuffer = null;
+            this.attributesInvalidated = true;
+            this.enabledAttributes = {};
+            this.vertexBuffers = [];
         },
 
         updateClientRect: function () {

--- a/src/graphics/device.js
+++ b/src/graphics/device.js
@@ -20,11 +20,11 @@ pc.extend(pc, function () {
 
     var _contextLostHandler = function (event) {
         event.preventDefault();
-        console.log('PlayCanvas graphics device: WebGL context lost.');
+        console.log('pc.GraphicsDevice: WebGL context lost.');
     };
 
     var _contextRestoredHandler = function () {
-        console.log('PlayCanvas graphics device: WebGL context restored.');
+        console.log('pc.GraphicsDevice: WebGL context restored.');
         this.initializeContext();
     };
 
@@ -218,6 +218,7 @@ pc.extend(pc, function () {
         // Array of WebGL objects that need to be re-initialized after a context restore event
         this.shaders = [];
         this.buffers = [];
+        this.textures = [];
 
         this.updateClientRect();
 
@@ -845,6 +846,13 @@ pc.extend(pc, function () {
             this.attributesInvalidated = true;
             this.enabledAttributes = {};
             this.vertexBuffers = [];
+
+            for (i = 0, len = this.textures.length; i < len; i++) {
+                this.textures[i]._glTextureId = undefined;
+                this.textures[i].upload();
+            }
+            this.activeTexture = 0;
+            this.textureUnits = [];
         },
 
         updateClientRect: function () {

--- a/src/graphics/index-buffer.js
+++ b/src/graphics/index-buffer.js
@@ -48,8 +48,8 @@ pc.extend(pc, function () {
 
         this.numBytes = this.numIndices * bytesPerIndex;
 
-        if (initialData && this.setData(initialData)) {
-            return;
+        if (initialData) {
+            this.setData(initialData);
         } else {
             this.storage = new ArrayBuffer(this.numBytes);
         }

--- a/src/graphics/index-buffer.js
+++ b/src/graphics/index-buffer.js
@@ -62,6 +62,30 @@ pc.extend(pc, function () {
     IndexBuffer.prototype = {
         /**
          * @function
+         * @name pc.IndexBuffer#destroy
+         * @description Frees resources associated with this index buffer.
+         */
+        destroy: function () {
+            var device = this.device;
+            var idx = device.buffers.indexOf(this);
+            if (idx !== -1) {
+                device.buffers.splice(idx, 1);
+            }
+
+            if (this.bufferId) {
+                var gl = this.device.gl;
+                gl.deleteBuffer(this.bufferId);
+                this.device._vram.ib -= this.storage.byteLength;
+                this.bufferId = null;
+
+                if (this.device.indexBuffer === this) {
+                    this.device.indexBuffer = null;
+                }
+            }
+        },
+
+        /**
+         * @function
          * @name pc.IndexBuffer#getFormat
          * @description Returns the data format of the specified index buffer.
          * @returns {Number} The data format of the specified index buffer (see pc.INDEXFORMAT_*).
@@ -137,30 +161,6 @@ pc.extend(pc, function () {
             this.storage = data;
             this.unlock();
             return true;
-        },
-
-        /**
-         * @function
-         * @name pc.IndexBuffer#destroy
-         * @description Frees resources associated with this index buffer.
-         */
-        destroy: function () {
-            var device = this.device;
-            var idx = device.buffers.indexOf(this);
-            if (idx !== -1) {
-                device.buffers.splice(idx, 1);
-            }
-
-            if (this.bufferId) {
-                var gl = this.device.gl;
-                gl.deleteBuffer(this.bufferId);
-                this.device._vram.ib -= this.storage.byteLength;
-                this.bufferId = null;
-
-                if (this.device.indexBuffer === this) {
-                    this.device.indexBuffer = null;
-                }
-            }
         }
     };
 

--- a/src/graphics/render-target.js
+++ b/src/graphics/render-target.js
@@ -98,8 +98,14 @@ pc.extend(pc, function () {
          */
         destroy: function () {
             if (!this._device) return;
-            var gl = this._device.gl;
 
+            var device = this._device;
+            var idx = device.targets.indexOf(this);
+            if (idx !== -1) {
+                device.targets.splice(idx, 1);
+            }
+
+            var gl = device.gl;
             if (this._glFrameBuffer) {
                 gl.deleteFramebuffer(this._glFrameBuffer);
                 this._glFrameBuffer = null;

--- a/src/graphics/texture.js
+++ b/src/graphics/texture.js
@@ -489,14 +489,6 @@ pc.extend(pc, function () {
         },
 
         /**
-         * @private
-         * @function
-         * @name pc.Texture#bind
-         * @description Activates the specified texture on the current texture unit.
-         */
-        bind: function () { },
-
-        /**
          * @function
          * @name pc.Texture#lock
          * @description Locks a miplevel of the texture, returning a typed array to be filled with pixel data.

--- a/src/graphics/texture.js
+++ b/src/graphics/texture.js
@@ -163,21 +163,10 @@ pc.extend(pc, function () {
 
         // Mip levels
         this._invalid = false;
-        this._levels = this._cubemap ? [[ null, null, null, null, null, null ]] : [ null ];
-        this._levelsUpdated = this._cubemap ? [[ true, true, true, true, true, true ]] : [ true ];
         this._lockedLevel = -1;
+        this._levels = this._cubemap ? [[ null, null, null, null, null, null ]] : [ null ];
 
-        this._needsUpload = true;
-        this._needsMipmapsUpload = this._mipmaps;
-        this._mipmapsUploaded = false;
-
-        this._minFilterDirty = true;
-        this._magFilterDirty = true;
-        this._addressUDirty = true;
-        this._addressVDirty = true;
-        this._addressWDirty = this._volume;
-        this._anisotropyDirty = true;
-        this._compareModeDirty = true;
+        this.dirtyAll();
 
         this._gpuSize = 0;
 
@@ -481,6 +470,24 @@ pc.extend(pc, function () {
 
     // Public methods
     pc.extend(Texture.prototype, {
+        // Force a full resubmission of the texture to WebGL (used on a context restore event)
+        dirtyAll: function () {
+            this._glTextureId = undefined;
+            this._levelsUpdated = this._cubemap ? [[ true, true, true, true, true, true ]] : [ true ];
+
+            this._needsUpload = true;
+            this._needsMipmapsUpload = this._mipmaps;
+            this._mipmapsUploaded = false;
+
+            this._minFilterDirty = true;
+            this._magFilterDirty = true;
+            this._addressUDirty = true;
+            this._addressVDirty = true;
+            this._addressWDirty = this._volume;
+            this._anisotropyDirty = true;
+            this._compareModeDirty = true;
+        },
+
         /**
          * @private
          * @function

--- a/src/graphics/texture.js
+++ b/src/graphics/texture.js
@@ -470,6 +470,37 @@ pc.extend(pc, function () {
 
     // Public methods
     pc.extend(Texture.prototype, {
+        /**
+         * @function
+         * @name pc.Texture#destroy
+         * @description Forcibly free up the underlying WebGL resource owned by the texture.
+         */
+        destroy: function () {
+            var device = this.device;
+            var idx = device.textures.indexOf(this);
+            if (idx !== -1) {
+                device.textures.splice(idx, 1);
+            }
+
+            if (this._glTextureId) {
+                var gl = this.device.gl;
+                gl.deleteTexture(this._glTextureId);
+
+                this.device._vram.tex -= this._gpuSize;
+                // #ifdef PROFILER
+                if (this.profilerHint === pc.TEXHINT_SHADOWMAP) {
+                    this.device._vram.texShadow -= this._gpuSize;
+                } else if (this.profilerHint === pc.TEXHINT_ASSET) {
+                    this.device._vram.texAsset -= this._gpuSize;
+                } else if (this.profilerHint === pc.TEXHINT_LIGHTMAP) {
+                    this.device._vram.texLightmap -= this._gpuSize;
+                }
+                // #endif
+
+                this._glTextureId = null;
+            }
+        },
+
         // Force a full resubmission of the texture to WebGL (used on a context restore event)
         dirtyAll: function () {
             this._glTextureId = undefined;
@@ -784,37 +815,6 @@ pc.extend(pc, function () {
             }
 
             return buff;
-        },
-
-        /**
-         * @function
-         * @name pc.Texture#destroy
-         * @description Forcibly free up the underlying WebGL resource owned by the texture.
-         */
-        destroy: function () {
-            var device = this.device;
-            var idx = device.textures.indexOf(this);
-            if (idx !== -1) {
-                device.textures.splice(idx, 1);
-            }
-
-            if (this._glTextureId) {
-                var gl = this.device.gl;
-                gl.deleteTexture(this._glTextureId);
-
-                this.device._vram.tex -= this._gpuSize;
-                // #ifdef PROFILER
-                if (this.profilerHint === pc.TEXHINT_SHADOWMAP) {
-                    this.device._vram.texShadow -= this._gpuSize;
-                } else if (this.profilerHint === pc.TEXHINT_ASSET) {
-                    this.device._vram.texAsset -= this._gpuSize;
-                } else if (this.profilerHint === pc.TEXHINT_LIGHTMAP) {
-                    this.device._vram.texLightmap -= this._gpuSize;
-                }
-                // #endif
-
-                this._glTextureId = null;
-            }
         }
     });
 

--- a/src/graphics/vertex-buffer.js
+++ b/src/graphics/vertex-buffer.js
@@ -31,8 +31,8 @@ pc.extend(pc, function () {
         this.device = graphicsDevice;
 
         // Allocate the storage
-        if (initialData && this.setData(initialData)) {
-            return;
+        if (initialData) {
+            this.setData(initialData);
         } else {
             this.storage = new ArrayBuffer(this.numBytes);
         }

--- a/src/graphics/vertex-buffer.js
+++ b/src/graphics/vertex-buffer.js
@@ -43,6 +43,36 @@ pc.extend(pc, function () {
     VertexBuffer.prototype = {
         /**
          * @function
+         * @name pc.VertexBuffer#destroy
+         * @description Frees resources associated with this vertex buffer.
+         */
+        destroy: function () {
+            var device = this.device;
+            var idx = device.buffers.indexOf(this);
+            if (idx !== -1) {
+                device.buffers.splice(idx, 1);
+            }
+
+            if (this.bufferId) {
+                var gl = device.gl;
+                gl.deleteBuffer(this.bufferId);
+                device._vram.vb -= this.storage.byteLength;
+                this.bufferId = null;
+
+                // If this buffer was bound, must clean up attribute-buffer bindings to prevent GL errors
+                device.boundBuffer = null;
+                device.vertexBuffers.length = 0;
+                device.vbOffsets.length = 0;
+                device.attributesInvalidated = true;
+                for(var loc in device.enabledAttributes) {
+                    gl.disableVertexAttribArray(loc);
+                }
+                device.enabledAttributes = {};
+            }
+        },
+
+        /**
+         * @function
          * @name pc.VertexBuffer#getFormat
          * @description Returns the data format of the specified vertex buffer.
          * @returns {pc.VertexFormat} The data format of the specified vertex buffer.
@@ -130,36 +160,6 @@ pc.extend(pc, function () {
             this.storage = data;
             this.unlock();
             return true;
-        },
-
-        /**
-         * @function
-         * @name pc.VertexBuffer#destroy
-         * @description Frees resources associated with this vertex buffer.
-         */
-        destroy: function () {
-            var device = this.device;
-            var idx = device.buffers.indexOf(this);
-            if (idx !== -1) {
-                device.buffers.splice(idx, 1);
-            }
-
-            if (this.bufferId) {
-                var gl = device.gl;
-                gl.deleteBuffer(this.bufferId);
-                device._vram.vb -= this.storage.byteLength;
-                this.bufferId = null;
-
-                // If this buffer was bound, must clean up attribute-buffer bindings to prevent GL errors
-                device.boundBuffer = null;
-                device.vertexBuffers.length = 0;
-                device.vbOffsets.length = 0;
-                device.attributesInvalidated = true;
-                for(var loc in device.enabledAttributes) {
-                    gl.disableVertexAttribArray(loc);
-                }
-                device.enabledAttributes = {};
-            }
         }
     };
 


### PR DESCRIPTION
This PR implements support for 'webglcontextlost' and 'webglcontextrestored' events. It will reinitialize all WebGL resources managed by the engine including:

* Shaders
* Buffers (both index and vertex)
* Textures
* Render targets
* Transform feedback (this is actually catered for by restoring buffers)

When the context is lost, the pc.Application no longer calls update and render. 

The pc.GraphicsDevice now fires events to notify the application that the context has been lost/restored to allow the application to do things like regenerate the contents of render targets, say. The events are: 'devicelost' and 'devicerestored'. So, where necessary, you should be able to do something like:

    this.app.graphicsDevice.on('devicerestored', function () {
        setupRenderTargets();
    });

The pc.GraphicsDevice has been refactored quite significantly. I've tried to group similar operations and then encapsulate those groups in functions. For example:

* All calls to gl.getParameter.
* All calls to gl.getExtension.
* All calls to set WebGL render state.

Fixes #65.
Fixes #1104.