### PR TITLE
Fixed raycastFirst documentation

### DIFF
--- a/src/framework/components/rigid-body/system.js
+++ b/src/framework/components/rigid-body/system.js
@@ -300,7 +300,7 @@ pc.extend(pc, function () {
         * @function
         * @name pc.RigidBodyComponentSystem#raycastFirst
         * @description Raycast the world and return the first entity the ray hits. Fire a ray into the world from start to end,
-        * if the ray hits an entity with a rigidbody component, it returns a {@link pc.RaycastResult}, otherwise returns null.
+        * if the ray hits an entity with a collision component, it returns a {@link pc.RaycastResult}, otherwise returns null.
         * @param {pc.Vec3} start The world space point where the ray starts
         * @param {pc.Vec3} end The world space point where the ray ends
         * @returns {pc.RaycastResult} The result of the raycasting or null if there was no hit.


### PR DESCRIPTION
Original documentation suggested that only entities with rigidBody components would be hit. collision components that are acting as triggers are also rigidBodies in ammo.js under the hood so they also get hit by the raycast.

Reference thread: https://forum.playcanvas.com/t/raycast-is-hitting-a-trigger-volume/6293

Contributor License Agreement has been signed.