### PR TITLE
Check if need to calculate tangents when parsing json model

### DIFF
--- a/src/resources/parser/json-model.js
+++ b/src/resources/parser/json-model.js
@@ -542,7 +542,7 @@ pc.extend(pc, function () {
                 var vertexData = modelData.vertices[i];
 
                 // Check to see if we need to generate tangents
-                if (vertexData.position && vertexData.normal && vertexData.texCoord0) {
+                if (!vertexData.tangent && vertexData.position && vertexData.normal && vertexData.texCoord0) {
                     var indices = [];
                     for (j = 0; j < modelData.meshes.length; j++) {
                         if (modelData.meshes[j].vertices === i) {


### PR DESCRIPTION
If `tangent` data already in vertices field of JSON model, we don't need to recalculate it.