### PR TITLE
Minification via package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,11 +25,14 @@
   },
   "devDependencies": {
     "fs-extra": "^3.0.1",
-    "google-closure-compiler": "^20170423.0.0",
-    "preprocessor": "^1.4.0"
+    "google-closure-compiler": "^20180204.0.0",
+    "preprocessor": "^1.4.0",
+    "uglify-js": "^3.3.16"
   },
   "scripts": {
-    "prepublishOnly": "cd build && node build.js"
+    "build": "cd build && node build.js",
+    "closure": "java -jar node_modules/google-closure-compiler/compiler.jar --compilation_level=SIMPLE --warning_level=VERBOSE --jscomp_off=checkTypes --externs build/externs.js --language_in=ECMASCRIPT5_STRICT --js build/output/playcanvas-latest.js --js_output_file build/output/playcanvas.min.js",
+    "uglify": "uglifyjs build/output/playcanvas-latest.js --compress --mangle --output build/output/playcanvas.min.js"
   },
   "engines": {
     "node": ">= 0.6.12"


### PR DESCRIPTION
This PR supports a choice of minifying the engine via Closure Compiler or UglifyJS via the package.json. If we can figure out a super-simple way to concatenate the engine source, we could move the whole build step into a package.json script entry. So this is a step towards that rather than a replacement for the current build system.