### PR TITLE
[FIX] assets.remove does not remove asset

### DIFF
--- a/src/asset/asset-registry.js
+++ b/src/asset/asset-registry.js
@@ -220,7 +220,13 @@ pc.extend(pc, function () {
         remove: function (asset) {
             delete this._cache[asset.id];
             delete this._names[asset.name];
+
             var url = asset.file ? asset.file.url : null;
+            var index = this._assets.indexOf(asset);
+
+            if (index > -1)
+                this._assets.splice(index, 1);
+
             if (url)
                 delete this._urls[url];
 


### PR DESCRIPTION
When calling `assets.remove(asset)`, the `asset` is still in `assets._assets` list.
This PR is trying to fix it.