### PR TITLE
Hide pc.AudioSourceComponent and pc.Listener from API docs.

### DIFF
--- a/src/framework/components/audio-source/component.js
+++ b/src/framework/components/audio-source/component.js
@@ -1,5 +1,6 @@
 pc.extend(pc, function () {
     /**
+     * @private
      * @component
      * @name pc.AudioSourceComponent
      * @class The AudioSource Component controls playback of an audio sample. This class will be deprecated in favor of {@link pc.SoundComponent}.
@@ -34,6 +35,7 @@ pc.extend(pc, function () {
 
     pc.extend(AudioSourceComponent.prototype, {
         /**
+         * @private
          * @function
          * @name pc.AudioSourceComponent#play
          * @description Begin playback of an audio asset in the component attached to an entity
@@ -66,6 +68,7 @@ pc.extend(pc, function () {
         },
 
         /**
+         * @private
          * @function
          * @name pc.AudioSourceComponent#pause
          * @description Pause playback of the audio that is playing on the Entity. Playback can be resumed by calling {@link pc.AudioSourceComponent#unpause}
@@ -77,6 +80,7 @@ pc.extend(pc, function () {
         },
 
         /**
+         * @private
          * @function
          * @name pc.AudioSourceComponent#unpause
          * @description Resume playback of the audio if paused. Playback is resumed at the time it was paused.
@@ -88,6 +92,7 @@ pc.extend(pc, function () {
         },
 
         /**
+         * @private
          * @function
          * @name pc.AudioSourceComponent#stop
          * @description Stop playback on an Entity. Playback can not be resumed after being stopped.

--- a/src/framework/components/audio-source/system.js
+++ b/src/framework/components/audio-source/system.js
@@ -17,6 +17,7 @@ pc.extend(pc, function () {
     ];
 
     /**
+     * @private
      * @name pc.AudioSourceComponentSystem
      * @class Controls playback of an audio sample. This class will be deprecated in favor of {@link pc.SoundComponentSystem}.
      * @param {pc.Application} app The Application
@@ -100,6 +101,7 @@ pc.extend(pc, function () {
         },
 
         /**
+         * @private
          * @name pc.AudioSourceComponentSystem#setVolume()
          * @function
          * @description Set the volume for the entire AudioSource system. All sources will have their volume multiplied by this value

--- a/src/sound/listener.js
+++ b/src/sound/listener.js
@@ -2,6 +2,7 @@ pc.extend(pc, function () {
     'use strict';
 
     /**
+     * @private
      * @name pc.Listener
      * @class Represents an audio listener - used internally.
      * @param {pc.SoundManager} manager The sound manager

--- a/src/sound/manager.js
+++ b/src/sound/manager.js
@@ -30,7 +30,6 @@ pc.extend(pc, function () {
      * @description Creates a new sound manager.
      * @param {Object} [options]
      * @param {Boolean} [options.forceWebAudioApi] Always use the Web Audio API even check indicates that it if not available
-     * @property {pc.Listener} listener Gets / sets the audio listener
      * @property {Number} volume Global volume for the manager. All {@link pc.SoundInstance}s will scale their volume with this volume. Valid between [0, 1].
      */
     var SoundManager = function (options) {


### PR DESCRIPTION
Remove some audio interfaces from API ref docs which we should strongly discourage developers from using. Hides:

- pc.Listener
- pc.AudioSourceComponent
- pc.AudioSourceComponentSystem