### PR TITLE
 [FIX] elementInput do not detach when destroying app.

### DIFF
--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -1546,6 +1546,12 @@ pc.extend(pc, function () {
                 this.touch = null;
             }
 
+            if (this.elementInput) {
+                this.elementInput.detach();
+
+                this.elementInput = null;
+            }
+
             if (this.controller) {
                 this.controller = null;
             }

--- a/src/input/element-input.js
+++ b/src/input/element-input.js
@@ -225,7 +225,6 @@ pc.extend(pc, function () {
         detach: function () {
             if (! this._attached) return;
             this._attached = false;
-            this._target = null;
 
             window.removeEventListener('mouseup', this._upHandler, false);
             window.removeEventListener('mousedown', this._downHandler, false);
@@ -237,6 +236,8 @@ pc.extend(pc, function () {
             this._target.removeEventListener('touchend', this._touchendHandler, false);
             this._target.removeEventListener('touchmove', this._touchmoveHandler, false);
             this._target.removeEventListener('touchcancel', this._touchcancelHandler, false);
+
+            this._target = null;
         },
 
         /**


### PR DESCRIPTION
Fix elementInput do not detach when destroying app. This should be done in #1086 , but I forgot to add it. 😢 

