### PR TITLE
Element component support blur event

### DIFF
--- a/src/framework/components/element/component.js
+++ b/src/framework/components/element/component.js
@@ -1362,6 +1362,13 @@ pc.extend(pc, function () {
 
 /**
 * @event
+* @name pc.ElementComponent#blur
+* @description Fired when the component is blurred. Only fired when useInput is true.
+* @param {pc.ElementMouseEvent|pc.ElementTouchEvent} event The event
+*/
+
+/**
+* @event
 * @name pc.ElementComponent#touchstart
 * @description Fired when a touch starts on the component. Only fired when useInput is true.
 * @param {pc.ElementTouchEvent} event The event


### PR DESCRIPTION
As blur event is really common in UI programming, it's better to support it.
This PR is trying to support blur event for element component.

The main logic is:
- When clicking on element1, and then clicking on non-element stuff, blur event for element1 trigger.
- When clicking on element1, and then clicking on element2, blur event for element1 trigger, then click event for element2 trigger.

What do you think about the implementation @vkalpias  ?