### PR TITLE
BoundingBox, BoundingSphere, OrientedBox extra methods. (#858)

### DIFF
--- a/src/shape/bounding-box.js
+++ b/src/shape/bounding-box.js
@@ -10,7 +10,9 @@ pc.extend(pc, function () {
      * @name pc.BoundingBox
      * @description Create a new axis-aligned bounding box.
      * @classdesc Axis-Aligned Bounding Box.
-     * @param {pc.Vec3} [center] Center of box. The constructor takes a reference of this parameter.
+     * @property {pc.Vec3} [center] The center of the Bounding Box.
+     * @property {pc.Vec3} [halfExtents] Half the distance across the box in each axis.
+     * @param {pc.Vec3} [center] The center of the Bounding Box. The constructor takes a reference of this parameter.
      * @param {pc.Vec3} [halfExtents] Half the distance across the box in each axis. The constructor takes a reference of this parameter.
      */
     var BoundingBox = function BoundingBox(center, halfExtents) {
@@ -86,12 +88,12 @@ pc.extend(pc, function () {
 
         /**
          * @function
-         * @name pc.BoundingBox#intersects
+         * @name pc.BoundingBox#intersectsBoundingBox
          * @description Test whether two axis-aligned bounding boxes intersect.
          * @param {pc.BoundingBox} other Bounding box to test against.
          * @returns {Boolean} True if there is an intersection.
          */
-        intersects: function (other) {
+        intersectsBoundingBox: function (other) {
             var aMax = this.getMax();
             var aMin = this.getMin();
             var bMax = other.getMax();
@@ -100,6 +102,17 @@ pc.extend(pc, function () {
             return (aMin.x <= bMax.x) && (aMax.x >= bMin.x) &&
                    (aMin.y <= bMax.y) && (aMax.y >= bMin.y) &&
                    (aMin.z <= bMax.z) && (aMax.z >= bMin.z);
+        },
+
+        /**
+         * @function
+         * @name pc.BoundingBox#intersectsOrientedBox
+         * @description Test if an OBB intersects with the AABB.
+         * @param {pc.OrientedBox} orientedBox Oriented box to test against.
+         * @returns {Boolean} True if there is an intersection.
+         */
+        intersectsOrientedBox: function (orientedBox) {
+            return orientedBox.intersectsBoundingBox(this);
         },
 
         _intersectsRay: function (ray, point) {
@@ -342,8 +355,32 @@ pc.extend(pc, function () {
             }
 
             return sq;
+        },
+        
+        // backwards compatibility
+        intersects: function (other) {
+            console.warn("DEPRECATED: intersects(); use intersectsBoundingBox() instead");
+            return this.intersectsBoundingBox(other);
         }
     };
+
+    Object.defineProperty(BoundingBox.prototype, 'center', {
+        get: function () {
+            return this._center;
+        },
+        set: function (value) {
+            this._center = value;
+        }
+    });
+
+    Object.defineProperty(BoundingBox.prototype, 'halfExtents', {
+        get: function () {
+            return this._halfExtents;
+        },
+        set: function (value) {
+            this._halfExtents = value;
+        }
+    });
 
     return {
         BoundingBox: BoundingBox

--- a/src/shape/bounding-sphere.js
+++ b/src/shape/bounding-sphere.js
@@ -14,6 +14,8 @@ pc.extend(pc, function () {
      * var sphere = new pc.BoundingSphere();
      * @param {pc.Vec3} [center] The world space coordinate marking the center of the sphere. The constructor takes a reference of this parameter.
      * @param {Number} [radius] The radius of the bounding sphere. Defaults to 0.5.
+     * @property {pc.Vec3} [center] The world space coordinate marking the center of the sphere.
+     * @property {Number} [radius] The radius of the bounding sphere.
      */
     function BoundingSphere(center, radius) {
         this.center = center || new pc.Vec3(0, 0, 0);
@@ -104,6 +106,28 @@ pc.extend(pc, function () {
 
         /**
          * @function
+         * @name pc.BoundingSphere#intersectsBoundingBox
+         * @description Test if a Bounding Box is overlapping, enveloping, or inside this Bounding Sphere.
+         * @param {pc.BoundingBox} boundingBox Bounding Box to test.
+         * @returns {Boolean} true if the Bounding Box is overlapping, enveloping, or inside this Bounding Sphere and false otherwise.
+         */
+        intersectsBoundingBox: function (boundingBox) {
+            return boundingBox.intersectsBoundingSphere(this);
+        },
+
+        /**
+         * @function
+         * @name pc.BoundingSphere#intersectsOrientedBox
+         * @description Test if a Oriented Box is overlapping, enveloping, or inside this Bounding Sphere.
+         * @param {pc.OrientedBox} orientedBox Oriented Box to test.
+         * @returns {Boolean} true if the Oriented Box is overlapping, enveloping, or inside this Bounding Sphere and false otherwise.
+         */
+        intersectsOrientedBox: function (orientedBox) {
+            return orientedBox.intersectsBoundingSphere(this);
+        },
+
+        /**
+         * @function
          * @name pc.BoundingSphere#intersectsBoundingSphere
          * @description Test if a Bounding Sphere is overlapping, enveloping, or inside this Bounding Sphere.
          * @param {pc.BoundingSphere} sphere Bounding Sphere to test.
@@ -119,6 +143,24 @@ pc.extend(pc, function () {
             return false;
         }
     };
+
+    Object.defineProperty(BoundingSphere.prototype, 'center', {
+        get: function () {
+            return this._center;
+        },
+        set: function (value) {
+            this._center = value;
+        }
+    });
+
+    Object.defineProperty(BoundingSphere.prototype, 'radius', {
+        get: function () {
+            return this._radius;
+        },
+        set: function (value) {
+            this._radius = value;
+        }
+    });
 
     return {
         BoundingSphere: BoundingSphere

--- a/src/shape/oriented-box.js
+++ b/src/shape/oriented-box.js
@@ -9,16 +9,16 @@ pc.extend(pc, function () {
      * @name pc.OrientedBox
      * @description Create a new oriented box.
      * @classdesc Oriented Box.
-     * @property {pc.Mat4} [worldTransform] The world transform of the OBB
+     * @property {pc.Mat4} [worldTransform] Transform that has the orientation and position of the box. Scale is assumed to be one.
+     * @property {pc.Vec3} [halfExtents] Half the distance across the box in each local axis.
      * @param {pc.Mat4} [worldTransform] Transform that has the orientation and position of the box. Scale is assumed to be one.
      * @param {pc.Vec3} [halfExtents] Half the distance across the box in each local axis. The constructor takes a reference of this parameter.
      */
     var OrientedBox = function OrientedBox(worldTransform, halfExtents) {
+        this._aabb = new pc.BoundingBox();
+        this._modelTransform = new pc.Mat4();
         this.halfExtents = halfExtents || new pc.Vec3(0.5, 0.5, 0.5);
-
-        worldTransform = worldTransform || tmpMat4.setIdentity();
-        this._modelTransform = worldTransform.clone().invert();
-        this._aabb = new pc.BoundingBox(new pc.Vec3(), this.halfExtents);
+        this.worldTransform = worldTransform || tmpMat4.setIdentity();
     };
 
     OrientedBox.prototype = {
@@ -57,6 +57,91 @@ pc.extend(pc, function () {
 
         /**
          * @function
+         * @name pc.OrientedBox#intersectsBoundingBox
+         * @description Test if a Bounding Box is overlapping, enveloping, or inside this OBB.
+         * @param {pc.BoundingBox} boundingBox Bounding Box to test.
+         * @returns {Boolean} true if the Bounding Box is overlapping, enveloping or inside this OBB and false otherwise.
+         */
+        intersectsBoundingBox: function (boundingBox) {
+            var obb = new pc.OrientedBox();
+            obb._aabb.center = boundingBox.center;
+            obb.halfExtents = boundingBox.halfExtents;
+            return this.intersectsOrientedBox(obb);
+        },
+
+        _getCorners: function (obb) {
+            var center = obb._aabb.center;
+            var halfExtents = obb.halfExtents;
+            var x = obb.worldTransform.getX().scale(halfExtents.x);
+            var y = obb.worldTransform.getY().scale(halfExtents.y);
+            var z = obb.worldTransform.getZ().scale(halfExtents.z);
+            var corners = [ ];
+            corners.push(center.clone().sub(x).sub(y).sub(z));
+            corners.push(center.clone().sub(x).sub(y).add(z));
+            corners.push(center.clone().sub(x).add(y).sub(z));
+            corners.push(center.clone().sub(x).add(y).add(z));
+            corners.push(center.clone().add(x).sub(y).sub(z));
+            corners.push(center.clone().add(x).sub(y).add(z));
+            corners.push(center.clone().add(x).add(y).sub(z));
+            corners.push(center.clone().add(x).add(y).add(z));
+            return corners;
+        },
+
+        _getInterval: function (corners, axis) {
+            var i;
+            var interval = [ ];
+            var projection = axis.dot(corners[0]);
+            interval.push(projection);
+            interval.push(projection);
+            for (i = 1; i < 8; i++) {
+                projection = axis.dot(corners[i]);
+                if (projection < interval[0]) {
+                    interval[0] = projection;
+                }
+                else if (projection > interval[1]) {
+                    interval[1] = projection;
+                }
+            }
+            return interval;
+        },
+
+        /**
+         * @function
+         * @name pc.OrientedBox#intersectsOrientedBox
+         * @description Test if an Oriented Box is overlapping, enveloping, or inside this OBB.
+         * @param {pc.OrientedBox} orientedBox Oriented Box to test.
+         * @returns {Boolean} true if the Oriented Box is overlapping, enveloping or inside this OBB and false otherwise.
+         */
+        intersectsOrientedBox: function (orientedBox) {
+            var i;
+            var aInterval;
+            var bInterval;
+            var axes = [ ];
+            var aCorners = this._getCorners(this);
+            var bCorners = this._getCorners(orientedBox);
+            axes.push(this.worldTransform.getX());
+            axes.push(this.worldTransform.getY());
+            axes.push(this.worldTransform.getZ());
+            axes.push(orientedBox.worldTransform.getX());
+            axes.push(orientedBox.worldTransform.getY());
+            axes.push(orientedBox.worldTransform.getZ());
+            for (i = 0; i < 3; i++) {
+                axes.push((new pc.Vec3).cross(axes[i + 3], axes[0]));
+                axes.push((new pc.Vec3).cross(axes[i + 3], axes[1]));
+                axes.push((new pc.Vec3).cross(axes[i + 3], axes[2]));
+            }
+            for (i = 0; i < axes.length; i++) {
+                aInterval = this._getInterval(aCorners, axes[i]);
+                bInterval = this._getInterval(bCorners, axes[i]);
+                if ((bInterval[0] > aInterval[1]) || (aInterval[0] > bInterval[1])) {
+                    return false;
+                }
+            }
+            return true;
+        },
+
+        /**
+         * @function
          * @name pc.OrientedBox#intersectsBoundingSphere
          * @description Test if a Bounding Sphere is overlapping, enveloping, or inside this OBB.
          * @param {pc.BoundingSphere} sphere Bounding Sphere to test.
@@ -74,9 +159,24 @@ pc.extend(pc, function () {
         }
     };
 
-    Object.defineProperty(OrientedBox.prototype, 'worldTransform', {
+    Object.defineProperty(OrientedBox.prototype, 'halfExtents', {
+        get: function () {
+            return this._halfExtents;
+        },
         set: function (value) {
+            this._halfExtents = value;
+            this._aabb.halfExtents = value;
+        }
+    });
+
+    Object.defineProperty(OrientedBox.prototype, 'worldTransform', {
+        get: function () {
+            return this._worldTransform;
+        },
+        set: function (value) {
+            this._worldTransform = value;
             this._modelTransform.copy(value).invert();
+            this._modelTransform.transformPoint(new pc.Vec3(), this._aabb.center);
         }
     });
 


### PR DESCRIPTION
BoundingBox
-Deprecated intersects() and added intersectsBoundingBox() method
-Added intersectsOrientedBox() method
-Added center and halfExtents properties

BoundingSphere
-Added intersectsBoundingBox() method
-Added intersectsOrientedBox() method
-Added center and radius properties

OrientedBox
-Added intersectsBoundingBox() method
-Added intersectsOrientedBox() method
-Added halfExtents property and updated worldTransform property

Fixes #858 

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
