### PR TITLE
Add attribute collecting to standard shader chunk

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,5 +38,8 @@
   },
   "engines": {
     "node": ">= 0.6.12"
+  },
+  "dependencies": {
+    "npm": "^5.8.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,8 +38,5 @@
   },
   "engines": {
     "node": ">= 0.6.12"
-  },
-  "dependencies": {
-    "npm": "^5.8.0"
   }
 }

--- a/src/graphics/program-lib/standard.js
+++ b/src/graphics/program-lib/standard.js
@@ -1304,6 +1304,8 @@ pc.programlib.standard = {
 
         fshader = code;
 
+        attributes = pc.extend(attributes, pc.shaderChunks.collectAttribs(vshader));
+
         return {
             attributes: attributes,
             vshader: vshader,


### PR DESCRIPTION
This pull request changes standard program lib in order to make in collect custom attributes from VertexShader by pc.shaderChunks.collectAttribs.

Afterwards, merges it with existing attributes.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
