### PR TITLE
Fix destroying scripts

### DIFF
--- a/src/framework/components/script/component.js
+++ b/src/framework/components/script/component.js
@@ -206,7 +206,7 @@ pc.extend(pc, function () {
             return looping;
         },
 
-        // Restores isLoopingThroughScrits to the specified parameter
+        // Restores isLoopingThroughScripts to the specified parameter
         // If all loops are over then remove destroyed scripts form the _scripts array
         _endLooping: function (wasLoopingBefore) {
             this._isLoopingThroughScripts = wasLoopingBefore;

--- a/src/framework/components/script/component.js
+++ b/src/framework/components/script/component.js
@@ -11,11 +11,14 @@ pc.extend(pc, function () {
     */
 
     var ScriptComponent = function ScriptComponent(system, entity) {
-        this._scripts = [ ];
-        this._scriptsIndex = { };
+        this._scripts = [];
+        this._scriptsIndex = {};
+        this._destroyedScripts = [];
+        this._destroyed = false;
         this._scriptsData = null;
         this._oldState = true;
         this._beingEnabled = false;
+        this._isLoopingThroughScripts = false;
         this.on('set_enabled', this._onSetEnabled, this);
     };
     ScriptComponent = pc.inherits(ScriptComponent, pc.Component);
@@ -178,6 +181,9 @@ pc.extend(pc, function () {
 
         onPostStateChange: function() {
             var script;
+
+            var wasLooping = this._beginLooping();
+
             for (var i = 0, len = this.scripts.length; i < len; i++) {
                 script = this.scripts[i];
 
@@ -187,6 +193,25 @@ pc.extend(pc, function () {
                     if (script.postInitialize)
                         this._scriptMethod(script, ScriptComponent.scriptMethods.postInitialize);
                 }
+            }
+
+            this._endLooping(wasLooping);
+        },
+
+        // Sets isLoopingThroughScripts to false and returns
+        // its previous value
+        _beginLooping: function () {
+            var looping = this._isLoopingThroughScripts;
+            this._isLoopingThroughScripts = true;
+            return looping;
+        },
+
+        // Restores isLoopingThroughScrits to the specified parameter
+        // If all loops are over then remove destroyed scripts form the _scripts array
+        _endLooping: function (wasLoopingBefore) {
+            this._isLoopingThroughScripts = wasLoopingBefore;
+            if (! this._isLoopingThroughScripts) {
+                this._removeDestroyedScripts();
             }
         },
 
@@ -209,20 +234,45 @@ pc.extend(pc, function () {
             this.fire(state ? 'enable' : 'disable');
             this.fire('state', state);
 
+            var wasLooping = this._beginLooping();
+
             var script;
             for (var i = 0, len = this.scripts.length; i < len; i++) {
                 script = this.scripts[i];
                 script.enabled = script._enabled;
             }
+
+            this._endLooping(wasLooping);
         },
 
         _onBeforeRemove: function() {
             this.fire('remove');
 
+            var wasLooping = this._beginLooping();
+
             // destroy all scripts
-            var destroyed = true;
-            while (this.scripts.length > 0 && destroyed)
-                destroyed = this.destroy(this.scripts[0].__scriptType.__name);
+            for (var i = 0; i < this.scripts.length; i++) {
+                var script = this.scripts[i];
+                if (! script) continue;
+
+                this.destroy(script.__scriptType.__name);
+            }
+
+            this._endLooping(wasLooping);
+        },
+
+        _removeDestroyedScripts: function () {
+            var len = this._destroyedScripts.length;
+            if (! len) return;
+
+            for (var i = 0; i < len; i++) {
+                var idx = this._scripts.indexOf(this._destroyedScripts[i]);
+                if (idx >= 0) {
+                    this._scripts.splice(idx, 1);
+                }
+            }
+
+            this._destroyedScripts.length = 0;
         },
 
         _onInitializeAttributes: function() {
@@ -250,6 +300,8 @@ pc.extend(pc, function () {
         _onInitialize: function() {
             var script, scripts = this._scripts;
 
+            var wasLooping = this._beginLooping();
+
             for (var i = 0, len = scripts.length; i < len; i++) {
                 script = scripts[i];
                 if (! script._initialized && script.enabled) {
@@ -258,6 +310,8 @@ pc.extend(pc, function () {
                         this._scriptMethod(script, ScriptComponent.scriptMethods.initialize);
                 }
             }
+
+            this._endLooping(wasLooping);
         },
 
         _onPostInitialize: function() {
@@ -267,21 +321,32 @@ pc.extend(pc, function () {
         _onUpdate: function(dt) {
             var script, scripts = this._scripts;
 
+            var wasLooping = this._beginLooping();
+
             for (var i = 0, len = scripts.length; i < len; i++) {
                 script = scripts[i];
                 if (script.update && script.enabled)
                     this._scriptMethod(script, ScriptComponent.scriptMethods.update, dt);
             }
+
+            this._endLooping(wasLooping);
         },
 
         _onPostUpdate: function(dt) {
+            var i;
+            var len;
+
+            var wasLooping = this._beginLooping();
+
             var script, scripts = this._scripts;
 
-            for (var i = 0, len = scripts.length; i < len; i++) {
+            for (i = 0, len = scripts.length; i < len; i++) {
                 script = scripts[i];
                 if (script.postUpdate && script.enabled)
                     this._scriptMethod(script, ScriptComponent.scriptMethods.postUpdate, dt);
             }
+
+            this._endLooping(wasLooping);
         },
 
         /**
@@ -430,9 +495,20 @@ pc.extend(pc, function () {
             delete this._scriptsIndex[scriptName];
             if (! scriptData) return false;
 
-            if (scriptData.instance) {
-                var ind = this._scripts.indexOf(scriptData.instance);
-                this._scripts.splice(ind, 1);
+            if (scriptData.instance && ! scriptData.instance._destroyed) {
+                scriptData.instance.enabled = false;
+                scriptData.instance._destroyed = true;
+
+                // if we are not currently looping through our scripts
+                // then it's safe to remove the script
+                if (! this._isLoopingThroughScripts) {
+                    var ind = this._scripts.indexOf(scriptData.instance);
+                    this._scripts.splice(ind, 1);
+                } else {
+                    // otherwise push the script in _destroyedScripts and
+                    // remove it from _scripts when the loop is over
+                    this._destroyedScripts.push(scriptData.instance);
+                }
             }
 
             // remove swap event

--- a/src/framework/components/script/system.js
+++ b/src/framework/components/script/system.js
@@ -93,8 +93,9 @@ pc.extend(pc, function () {
             var wasLooping = this._beginLooping();
 
             for (var i = 0; i < this._components.length; i++) {
-                if (! this._components[i].entity.enabled || ! this._components[i].enabled || this._components[i]._destroyed)
+                if (this._components[i]._destroyed || ! this._components[i].entity.enabled || ! this._components[i].enabled) {
                     continue;
+                }
 
                 this._components[i][name](dt);
             }

--- a/src/script/script.js
+++ b/src/script/script.js
@@ -347,6 +347,7 @@ pc.extend(pc, function () {
             this.entity = args.entity;
             this._enabled = typeof(args.enabled) === 'boolean' ? args.enabled : true;
             this._enabledOld = this.enabled;
+            this.__destroyed = false;
             this.__attributes = { };
             this.__attributesRaw = args.attributes || null;
             this.__scriptType = script;
@@ -526,7 +527,7 @@ pc.extend(pc, function () {
 
         Object.defineProperty(script.prototype, 'enabled', {
             get: function() {
-                return this._enabled && this.entity.script.enabled && this.entity.enabled;
+                return this._enabled && !this._destroyed && this.entity.script.enabled && this.entity.enabled;
             },
             set: function(value) {
                 this._enabled = !!value;
@@ -589,7 +590,7 @@ pc.extend(pc, function () {
 
     // reserved script attribute names
     createScript.reservedAttributes = [
-        'app', 'entity', 'enabled', '_enabled', '_enabledOld',
+        'app', 'entity', 'enabled', '_enabled', '_enabledOld', '_destroyed',
         '__attributes', '__attributesRaw', '__scriptType',
         '_callbacks', 'has', 'on', 'off', 'fire', 'once', 'hasEvent'
     ];

--- a/tests/framework/components/script/destroyer.js
+++ b/tests/framework/components/script/destroyer.js
@@ -1,0 +1,68 @@
+var Destroyer = pc.createScript('destroyer');
+
+Destroyer.attributes.add('methodName', {type: 'string'});
+Destroyer.attributes.add('destroyEntity', {type: 'boolean'});
+Destroyer.attributes.add('destroyScriptComponent', {type: 'boolean'});
+Destroyer.attributes.add('destroyScriptInstance', {type: 'boolean'});
+
+Destroyer.prototype.initialize = function() {
+    window.initializeCalls.push(this.entity.getGuid() + ' initialize destroyer');
+
+    this.on('state', function (state) {
+        window.initializeCalls.push(this.entity.getGuid() + ' state ' + state + ' destroyer');
+    });
+    this.on('disable', function () {
+        window.initializeCalls.push(this.entity.getGuid() + ' disable destroyer');
+    });
+    this.on('enable', function () {
+        window.initializeCalls.push(this.entity.getGuid() + ' enable destroyer');
+    });
+    this.on('destroy', function () {
+        window.initializeCalls.push(this.entity.getGuid() + ' destroy destroyer');
+    });
+
+    if (this.methodName === 'initialize') {
+        this.destroySomething();
+    }
+};
+
+Destroyer.prototype.postInitialize = function () {
+    window.initializeCalls.push(this.entity.getGuid() + ' postInitialize destroyer');
+
+    if (this.methodName === 'postInitialize') {
+        this.destroySomething();
+    }
+};
+
+Destroyer.prototype.update = function () {
+    window.initializeCalls.push(this.entity.getGuid() + ' update destroyer');
+
+    if (!this.methodName || this.methodName === 'update')  {
+        this.destroySomething();
+    }
+};
+
+Destroyer.prototype.postUpdate = function () {
+    window.initializeCalls.push(this.entity.getGuid() + ' postUpdate destroyer');
+
+    if (this.methodName === 'postUpdate') {
+        this.destroySomething();
+    }
+};
+
+
+Destroyer.prototype.destroySomething = function () {
+    if (this.destroyEntity) {
+        return this.entity.destroy();
+    }
+
+    if (this.destroyScriptComponent) {
+        return this.entity.removeComponent('script');
+    }
+
+    if (this.destroyScriptInstance) {
+        if (this.entity.script.scriptA) {
+            return this.entity.script.destroy('scriptA');
+        }
+    }
+};

--- a/tests/framework/components/script/scene2.json
+++ b/tests/framework/components/script/scene2.json
@@ -1,0 +1,148 @@
+{
+  "name": "scene2",
+  "created": "2018-04-23T20:43:30.039Z",
+  "settings": {
+    "physics": {
+      "gravity": [
+        0,
+        -9.8,
+        0
+      ]
+    },
+    "render": {
+      "fog_end": 1000,
+      "tonemapping": 0,
+      "skybox": null,
+      "fog_density": 0.01,
+      "gamma_correction": 1,
+      "exposure": 1,
+      "fog_start": 1,
+      "global_ambient": [
+        0.2,
+        0.2,
+        0.2
+      ],
+      "skyboxIntensity": 1,
+      "fog_color": [
+        0,
+        0,
+        0
+      ],
+      "lightmapMode": 1,
+      "fog": "none",
+      "lightmapMaxResolution": 2048,
+      "skyboxMip": 0,
+      "lightmapSizeMultiplier": 16
+    }
+  },
+  "entities": {
+    "fb0ad8e6-4736-11e8-854d-784f436c1506": {
+      "position": [
+        0,
+        0,
+        0
+      ],
+      "scale": [
+        1,
+        1,
+        1
+      ],
+      "name": "Root",
+      "parent": null,
+      "resource_id": "fb0ad8e6-4736-11e8-854d-784f436c1506",
+      "components": {},
+      "rotation": [
+        0,
+        0,
+        0
+      ],
+      "tags": [],
+      "enabled": true,
+      "children": [
+        "ef3666d7-1fa4-4aef-99d7-aafe446dde65",
+        "70655a5c-f518-4115-9608-d703f8e48f81"
+      ]
+    },
+    "ef3666d7-1fa4-4aef-99d7-aafe446dde65": {
+      "name": "A",
+      "tags": [],
+      "enabled": true,
+      "resource_id": "ef3666d7-1fa4-4aef-99d7-aafe446dde65",
+      "parent": "fb0ad8e6-4736-11e8-854d-784f436c1506",
+      "children": [],
+      "position": [
+        0,
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        0,
+        0
+      ],
+      "scale": [
+        1,
+        1,
+        1
+      ],
+      "components": {
+        "script": {
+          "enabled": true,
+          "order": [
+            "destroyer"
+          ],
+          "scripts": {
+            "destroyer": {
+              "enabled": true,
+              "attributes": {
+                "methodName": "initialize",
+                "destroyEntity": true,
+                "destroyScriptComponent": false,
+                "destroyScriptInstance": false
+              }
+            }
+          }
+        }
+      }
+    },
+    "70655a5c-f518-4115-9608-d703f8e48f81": {
+      "name": "B",
+      "tags": [],
+      "enabled": true,
+      "resource_id": "70655a5c-f518-4115-9608-d703f8e48f81",
+      "parent": "fb0ad8e6-4736-11e8-854d-784f436c1506",
+      "children": [],
+      "position": [
+        0,
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        0,
+        0
+      ],
+      "scale": [
+        1,
+        1,
+        1
+      ],
+      "components": {
+        "script": {
+          "enabled": true,
+          "order": [
+            "scriptA"
+          ],
+          "scripts": {
+            "scriptA": {
+              "enabled": true,
+              "attributes": {}
+            }
+          }
+        }
+      }
+    }
+  },
+  "_o": "5adf71675827be8250323b04",
+  "id": 528
+}

--- a/tests/framework/components/script/scriptA.js
+++ b/tests/framework/components/script/scriptA.js
@@ -21,8 +21,19 @@ ScriptA.prototype.initialize = function() {
     this.on('state', function (enabled) {
         window.initializeCalls.push(guid + ' state ' + enabled + ' scriptA');
     });
+    this.on('destroy', function () {
+        window.initializeCalls.push(this.entity.getGuid() + ' destroy scriptA');
+    });
 };
 
 ScriptA.prototype.postInitialize = function() {
     window.initializeCalls.push(this.entity.getGuid() + ' postInitialize scriptA');
+};
+
+ScriptA.prototype.update = function () {
+    window.initializeCalls.push(this.entity.getGuid() + ' update scriptA');
+};
+
+ScriptA.prototype.postUpdate = function () {
+    window.initializeCalls.push(this.entity.getGuid() + ' postUpdate scriptA');
 };

--- a/tests/framework/components/script/scriptB.js
+++ b/tests/framework/components/script/scriptB.js
@@ -12,8 +12,20 @@ ScriptB.prototype.initialize = function() {
     this.entity.script.on('state', function (enabled) {
         window.initializeCalls.push(guid + ' state ' + enabled + ' scriptB');
     });
+    this.on('destroy', function () {
+        window.initializeCalls.push(this.entity.getGuid() + ' destroy scriptB');
+    });
 };
 
 ScriptB.prototype.postInitialize = function() {
     window.initializeCalls.push(this.entity.getGuid() + ' postInitialize scriptB');
 };
+
+ScriptB.prototype.update = function () {
+    window.initializeCalls.push(this.entity.getGuid() + ' update scriptB');
+};
+
+ScriptB.prototype.postUpdate = function () {
+    window.initializeCalls.push(this.entity.getGuid() + ' postUpdate scriptB');
+};
+


### PR DESCRIPTION
Fix various issues with destroying scripts during initialize, postInitialize, update, postUpdate.

Before when an Entity was destroyed its script instances would fire `disable` before `destroy`. This wouldn't happen if you removed the Script component or if you destroyed a script instance with `entity.script.destroy(name)`. Now the `disable` event will be fired on script instances before `destroy` always.

Before if you destroyed an entity / script component / script instance during update, then you would either get an error or you would skip updating some scripts. Now the update loop will not update the rest of the scripts if you destroy the entity or remove the component during the update loop, and you will not get errors if you just destroy a single script instance during update.

Before if you destroyed / entity / script component during update then some Entities would not be updated for 1 frame. This is now fixed.

Fixes #1100 

