### PR TITLE
[FIX] Free shadowmap VRAM on destroying lights

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "uglify-js": "^3.3.16"
   },
   "scripts": {
-    "build": "cd build && node build.js",
+    "build": "cd build && node build.js -p",
     "closure": "java -jar node_modules/google-closure-compiler/compiler.jar --compilation_level=SIMPLE --warning_level=VERBOSE --jscomp_off=checkTypes --externs build/externs.js --language_in=ECMASCRIPT5_STRICT --js build/output/playcanvas-latest.js --js_output_file build/output/playcanvas.min.js",
     "uglify": "uglifyjs build/output/playcanvas-latest.js --compress --mangle --output build/output/playcanvas.min.js",
     "lint": "eslint src"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "uglify-js": "^3.3.16"
   },
   "scripts": {
-    "build": "cd build && node build.js -p",
+    "build": "cd build && node build.js",
     "closure": "java -jar node_modules/google-closure-compiler/compiler.jar --compilation_level=SIMPLE --warning_level=VERBOSE --jscomp_off=checkTypes --externs build/externs.js --language_in=ECMASCRIPT5_STRICT --js build/output/playcanvas-latest.js --js_output_file build/output/playcanvas.min.js",
     "uglify": "uglifyjs build/output/playcanvas-latest.js --compress --mangle --output build/output/playcanvas.min.js",
     "lint": "eslint src"

--- a/src/framework/components/light/system.js
+++ b/src/framework/components/light/system.js
@@ -67,6 +67,11 @@ pc.extend(pc, function () {
             LightComponentSystem._super.initializeComponentData.call(this, component, data, _props);
         },
 
+        removeComponent: function (entity) {
+            var data = entity.light.data;
+            data.light.destroy();
+        },
+
         cloneComponent: function (entity, clone) {
             var light = entity.light;
 

--- a/src/framework/components/light/system.js
+++ b/src/framework/components/light/system.js
@@ -70,6 +70,8 @@ pc.extend(pc, function () {
         removeComponent: function (entity) {
             var data = entity.light.data;
             data.light.destroy();
+
+            LightComponentSystem._super.removeComponent.call(this, entity);
         },
 
         cloneComponent: function (entity, clone) {

--- a/src/framework/components/light/system.js
+++ b/src/framework/components/light/system.js
@@ -19,8 +19,6 @@ pc.extend(pc, function () {
 
         this.ComponentType = pc.LightComponent;
         this.DataType = pc.LightComponentData;
-
-        this.on('remove', this.onRemove, this);
     };
     LightComponentSystem = pc.inherits(LightComponentSystem, pc.ComponentSystem);
 

--- a/src/scene/light.js
+++ b/src/scene/light.js
@@ -79,6 +79,10 @@ pc.extend(pc, function () {
     };
 
     Light.prototype = {
+        destroy: function () {
+            this._destroyShadowMap();
+        },
+
         /**
          * @private
          * @function
@@ -217,6 +221,7 @@ pc.extend(pc, function () {
                             }
                         } else {
                             if (rt.colorBuffer) rt.colorBuffer.destroy();
+                            if (rt.depthBuffer) rt.depthBuffer.destroy();
                             rt.destroy();
                         }
                     }


### PR DESCRIPTION
Correctly free up VRAM associated with lights that cast shadowmaps.

Fixes #1050. 
Fixes #1183.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
