### PR TITLE
Layout Groups follow up

### DIFF
--- a/src/framework/components/element/component.js
+++ b/src/framework/components/element/component.js
@@ -209,7 +209,7 @@ pc.extend(pc, function () {
             element._margin.data[0] = p[0] - element._calculatedWidth * pvt[0];
             element._margin.data[2] = (element._localAnchor.data[2] - element._localAnchor.data[0]) - element._calculatedWidth - element._margin.data[0];
             element._margin.data[1] = p[1] - element._calculatedHeight * pvt[1];
-            element._margin.data[3] = (element._localAnchor.data[3]-element._localAnchor.data[1]) - element._calculatedHeight - element._margin.data[1];
+            element._margin.data[3] = (element._localAnchor.data[3] - element._localAnchor.data[1]) - element._calculatedHeight - element._margin.data[1];
 
             if (! this._dirtyLocal)
                 this._dirtify(true);
@@ -264,7 +264,7 @@ pc.extend(pc, function () {
                 element._margin.data[0] = p[0] - element._calculatedWidth * pvt[0];
                 element._margin.data[2] = (element._localAnchor.data[2] - element._localAnchor.data[0]) - element._calculatedWidth - element._margin.data[0];
                 element._margin.data[1] = p[1] - element._calculatedHeight * pvt[1];
-                element._margin.data[3] = (element._localAnchor.data[3]-element._localAnchor.data[1]) - element._calculatedHeight - element._margin.data[1];
+                element._margin.data[3] = (element._localAnchor.data[3] - element._localAnchor.data[1]) - element._calculatedHeight - element._margin.data[1];
 
                 this._dirtyLocal = false;
             }
@@ -789,7 +789,7 @@ pc.extend(pc, function () {
                 var p = this.entity.getLocalPosition().data;
                 var pvt = this._pivot.data;
                 this._margin.data[1] = p[1] - this._calculatedHeight * pvt[1];
-                this._margin.data[3] = (this._localAnchor.data[3]-this._localAnchor.data[1]) - this._calculatedHeight - this._margin.data[1];
+                this._margin.data[3] = (this._localAnchor.data[3] - this._localAnchor.data[1]) - this._calculatedHeight - this._margin.data[1];
             }
 
             this._flagChildrenAsDirty();
@@ -802,7 +802,7 @@ pc.extend(pc, function () {
         },
 
         _flagChildrenAsDirty: function() {
-            var i,l;
+            var i, l;
             var c = this.entity._children;
             for (i = 0, l = c.length; i < l; i++) {
                 if (c[i].element) {
@@ -967,7 +967,7 @@ pc.extend(pc, function () {
             this._setWidth(wr - wl);
 
             // update position
-            p.x = (this._localAnchor.data[2]-this._localAnchor.data[0]) - value - (this._calculatedWidth*(1-this._pivot.data[0]));
+            p.x = (this._localAnchor.data[2] - this._localAnchor.data[0]) - value - (this._calculatedWidth * (1 - this._pivot.data[0]));
             this.entity.setLocalPosition(p);
         }
     });
@@ -984,7 +984,7 @@ pc.extend(pc, function () {
             var wt = this._localAnchor.data[3] - value;
             this._setHeight(wt - wb);
 
-            p.y = (this._localAnchor.data[3] - this._localAnchor.data[1]) - value - this._calculatedHeight*(1-this._pivot.data[1]);
+            p.y = (this._localAnchor.data[3] - this._localAnchor.data[1]) - value - this._calculatedHeight * (1 - this._pivot.data[1]);
             this.entity.setLocalPosition(p);
         }
     });
@@ -1001,7 +1001,7 @@ pc.extend(pc, function () {
             var wb = this._localAnchor.data[1] + value;
             this._setHeight(wt - wb);
 
-            p.y = value + this._calculatedHeight*this._pivot.data[1];
+            p.y = value + this._calculatedHeight * this._pivot.data[1];
             this.entity.setLocalPosition(p);
         }
     });

--- a/src/framework/components/element/component.js
+++ b/src/framework/components/element/component.js
@@ -665,6 +665,8 @@ pc.extend(pc, function () {
                 this.system.app.scene.layers.on("add", this.onLayerAdded, this);
                 this.system.app.scene.layers.on("remove", this.onLayerRemoved, this);
             }
+
+            this.fire("enableelement");
         },
 
         onDisable: function () {
@@ -689,6 +691,8 @@ pc.extend(pc, function () {
                 if (index >= 0) topMasks.splice(index, 1);
                 this._topMask = false;
             }
+
+            this.fire("disableelement");
         },
 
         onRemove: function () {

--- a/src/framework/components/layout-child/component.js
+++ b/src/framework/components/layout-child/component.js
@@ -36,7 +36,6 @@ pc.extend(pc, function () {
             set: function (value) {
                 if (this[_name] !== value) {
                     this[_name] = value;
-                    this.fire('set:' + name, this[_name]);
                     this.fire('resize');
                 }
             }

--- a/src/framework/components/layout-child/component.js
+++ b/src/framework/components/layout-child/component.js
@@ -4,7 +4,7 @@ pc.extend(pc, function () {
      * @component
      * @name pc.LayoutChildComponent
      * @description Create a new LayoutChildComponent
-     * @class A LayoutChildComponent enables the Entity to control the sizing applied to it by its parent {@link pc.LayoutGroupComponent}.
+     * @classdesc A LayoutChildComponent enables the Entity to control the sizing applied to it by its parent {@link pc.LayoutGroupComponent}.
      * @param {pc.LayoutChildComponentSystem} system The ComponentSystem that created this Component
      * @param {pc.Entity} entity The Entity that this Component is attached to.
      * @extends pc.Component

--- a/src/framework/components/layout-child/system.js
+++ b/src/framework/components/layout-child/system.js
@@ -1,11 +1,11 @@
 pc.extend(pc, function () {
-    var _schema = [ 'enabled' ];
+    var _schema = ['enabled'];
 
     /**
      * @private
      * @name pc.LayoutChildComponentSystem
      * @description Create a new LayoutChildComponentSystem
-     * @class Manages creation of {@link pc.LayoutChildComponent}s.
+     * @classdesc Manages creation of {@link pc.LayoutChildComponent}s.
      * @param {pc.Application} app The application
      * @extends pc.ComponentSystem
      */

--- a/src/framework/components/layout-child/system.js
+++ b/src/framework/components/layout-child/system.js
@@ -25,6 +25,7 @@ pc.extend(pc, function () {
 
     pc.extend(LayoutChildComponentSystem.prototype, {
         initializeComponentData: function (component, data, properties) {
+            if (data.enabled !== undefined) component.enabled = data.enabled;
             if (data.minWidth !== undefined) component.minWidth = data.minWidth;
             if (data.minHeight !== undefined) component.minHeight = data.minHeight;
             if (data.maxWidth !== undefined) component.maxWidth = data.maxWidth;

--- a/src/framework/components/layout-group/component.js
+++ b/src/framework/components/layout-group/component.js
@@ -4,7 +4,7 @@ pc.extend(pc, function () {
      * @component
      * @name pc.LayoutGroupComponent
      * @description Create a new LayoutGroupComponent
-     * @class A LayoutGroupComponent enables the Entity to position and scale child {@link pc.ElementComponent}s according to configurable layout rules.
+     * @classdesc A LayoutGroupComponent enables the Entity to position and scale child {@link pc.ElementComponent}s according to configurable layout rules.
      * @param {pc.LayoutGroupComponentSystem} system The ComponentSystem that created this Component
      * @param {pc.Entity} entity The Entity that this Component is attached to.
      * @extends pc.Component

--- a/src/framework/components/layout-group/component.js
+++ b/src/framework/components/layout-group/component.js
@@ -53,11 +53,11 @@ pc.extend(pc, function () {
         this._layoutCalculator = new pc.LayoutCalculator();
 
         // Listen for the group container being resized
-        this._listenForResizeEvents(this.entity, 'on');
+        this._listenForReflowEvents(this.entity, 'on');
 
         // Listen to existing children being resized
         this.entity.children.forEach(function(child) {
-            this._listenForResizeEvents(child, 'on');
+            this._listenForReflowEvents(child, 'on');
         }.bind(this));
 
         // Listen to newly added children being resized
@@ -67,12 +67,10 @@ pc.extend(pc, function () {
         // Listen for ElementComponents and LayoutChildComponents being added
         // to self or to children - covers cases where they are not already
         // present at the point when this component is constructed.
-        system.app.systems.element.on('add', this._onElementComponentAdd, this);
-        system.app.systems.element.on('beforeremove', this._onElementComponentRemove, this);
-        system.app.systems.layoutchild.on('add', this._onLayoutChildComponentAdd, this);
-        system.app.systems.layoutchild.on('beforeremove', this._onLayoutChildComponentRemove, this);
-
-        this._scheduleReflow();
+        system.app.systems.element.on('add', this._onElementOrLayoutComponentAdd, this);
+        system.app.systems.element.on('beforeremove', this._onElementOrLayoutComponentRemove, this);
+        system.app.systems.layoutchild.on('add', this._onElementOrLayoutComponentAdd, this);
+        system.app.systems.layoutchild.on('beforeremove', this._onElementOrLayoutComponentRemove, this);
     };
     LayoutGroupComponent = pc.inherits(LayoutGroupComponent, pc.Component);
 
@@ -81,61 +79,49 @@ pc.extend(pc, function () {
             return (entity === this.entity) || (this.entity.children.indexOf(entity) !== -1);
         },
 
-        _listenForResizeEvents: function(target, onOff) {
+        _listenForReflowEvents: function(target, onOff) {
+            if (target[onOff]) {
+                target[onOff]('set_enabled', this._scheduleReflow, this);
+            }
+
             if (target.element) {
-                target.element[onOff]('resize', this._onResize, this);
-                target.element[onOff]('set:pivot', this._onSetPivot, this);
+                target.element[onOff]('set_enabled', this._scheduleReflow, this);
+                target.element[onOff]('resize', this._scheduleReflow, this);
+                target.element[onOff]('set:pivot', this._scheduleReflow, this);
             }
 
             if (target.layoutchild) {
-                target.layoutchild[onOff]('resize', this._onResize, this);
+                target.layoutchild[onOff]('set_enabled', this._scheduleReflow, this);
+                target.layoutchild[onOff]('resize', this._scheduleReflow, this);
             }
         },
 
-        _onElementComponentAdd: function(entity, component) {
+        _onElementOrLayoutComponentAdd: function(entity) {
             if (this._isSelfOrChild(entity)) {
-                component.on('resize', this._onResize, this);
+                this._listenForReflowEvents(entity, 'on');
+                this._scheduleReflow();
             }
         },
 
-        _onElementComponentRemove: function(entity, component) {
+        _onElementOrLayoutComponentRemove: function(entity) {
             if (this._isSelfOrChild(entity)) {
-                component.off('resize', this._onResize, this);
+                this._listenForReflowEvents(entity, 'off');
+                this._scheduleReflow();
             }
-        },
-
-        _onLayoutChildComponentAdd: function(entity, component) {
-            if (this._isSelfOrChild(entity)) {
-                component.on('resize', this._onResize, this);
-            }
-        },
-
-        _onLayoutChildComponentRemove: function(entity, component) {
-            if (this._isSelfOrChild(entity)) {
-                component.off('resize', this._onResize, this);
-            }
-        },
-
-        _onResize: function() {
-            this._scheduleReflow();
-        },
-
-        _onSetPivot: function() {
-            this._scheduleReflow();
         },
 
         _onChildInsert: function(child) {
-            this._listenForResizeEvents(child, 'on');
+            this._listenForReflowEvents(child, 'on');
             this._scheduleReflow();
         },
 
         _onChildRemove: function(child) {
-            this._listenForResizeEvents(child, 'off');
+            this._listenForReflowEvents(child, 'off');
             this._scheduleReflow();
         },
 
         _scheduleReflow: function() {
-            if (!this._isPerformingReflow) {
+            if (this.enabled && this.entity && this.entity.enabled && !this._isPerformingReflow) {
                 this.system.scheduleReflow(this);
             }
         },
@@ -172,12 +158,24 @@ pc.extend(pc, function () {
             this._isPerformingReflow = false;
         },
 
+        onEnable: function() {
+            this._scheduleReflow();
+        },
+
         onRemove: function () {
-            this.entity.off('insert', this._onResize, this);
+            this.entity.off('childinsert', this._onChildInsert, this);
+            this.entity.off('childremove', this._onChildRemove, this);
+
+            this._listenForReflowEvents(this.entity, 'off');
 
             this.entity.children.forEach(function(child) {
-                this._listenForResizeEvents(child, 'off');
+                this._listenForReflowEvents(child, 'off');
             }.bind(this));
+
+            this.system.app.systems.element.off('add', this._onElementOrLayoutComponentAdd, this);
+            this.system.app.systems.element.off('beforeremove', this._onElementOrLayoutComponentRemove, this);
+            this.system.app.systems.layoutchild.off('add', this._onElementOrLayoutComponentAdd, this);
+            this.system.app.systems.layoutchild.off('beforeremove', this._onElementOrLayoutComponentRemove, this);
         }
     });
 

--- a/src/framework/components/layout-group/component.js
+++ b/src/framework/components/layout-group/component.js
@@ -80,12 +80,9 @@ pc.extend(pc, function () {
         },
 
         _listenForReflowEvents: function(target, onOff) {
-            if (target[onOff]) {
-                target[onOff]('set_enabled', this._scheduleReflow, this);
-            }
-
             if (target.element) {
-                target.element[onOff]('set_enabled', this._scheduleReflow, this);
+                target.element[onOff]('enableelement', this._scheduleReflow, this);
+                target.element[onOff]('disableelement', this._scheduleReflow, this);
                 target.element[onOff]('resize', this._scheduleReflow, this);
                 target.element[onOff]('set:pivot', this._scheduleReflow, this);
             }

--- a/src/framework/components/layout-group/layout-calculator.js
+++ b/src/framework/components/layout-group/layout-calculator.js
@@ -532,8 +532,7 @@ pc.extend(pc, function () {
             var layoutChildComponent = element.entity.layoutchild;
 
             // First attempt to get the value from the element's LayoutChildComponent, if present.
-            // TODO Should this check if the LayoutChildComponent is enabled?
-            if (layoutChildComponent && layoutChildComponent[propertyName] !== undefined && layoutChildComponent[propertyName] !== null) {
+            if (layoutChildComponent && layoutChildComponent.enabled && layoutChildComponent[propertyName] !== undefined && layoutChildComponent[propertyName] !== null) {
                 return layoutChildComponent[propertyName];
             } else if (element[propertyName] !== undefined) {
                 return element[propertyName];

--- a/src/framework/components/layout-group/layout-calculator.js
+++ b/src/framework/components/layout-group/layout-calculator.js
@@ -1,9 +1,9 @@
 pc.extend(pc, function () {
     /**
      * @private
+     * @constructor
      * @name pc.LayoutCalculator
-     * @description Create a new LayoutCalculator
-     * @class Used to manage layout calculations for LayoutGroupComponents
+     * @classdesc Used to manage layout calculations for {@link pc.LayoutGroupComponent}s
      */
     function LayoutCalculator() {}
 
@@ -255,25 +255,25 @@ pc.extend(pc, function () {
                 case pc.FITTING_STRETCH:
                     if (currentSize < availableSize) {
                         return FITTING_ACTION.APPLY_STRETCHING;
-                    } else {
-                        return FITTING_ACTION.NONE;
                     }
+
+                    return FITTING_ACTION.NONE;
 
                 case pc.FITTING_SHRINK:
                     if (currentSize >= availableSize) {
                         return FITTING_ACTION.APPLY_SHRINKING;
-                    } else {
-                        return FITTING_ACTION.NONE;
                     }
+
+                    return FITTING_ACTION.NONE;
 
                 case pc.FITTING_BOTH:
                     if (currentSize < availableSize) {
                         return FITTING_ACTION.APPLY_STRETCHING;
                     } else if (currentSize >= availableSize) {
                         return FITTING_ACTION.APPLY_SHRINKING;
-                    } else {
-                        return FITTING_ACTION.NONE;
                     }
+
+                    return FITTING_ACTION.NONE;
 
                 default:
                     throw new Error('Unrecognized fitting mode: ' + fittingMode);
@@ -371,9 +371,9 @@ pc.extend(pc, function () {
 
             if (Math.abs(proportion) < 1e-5 && Math.abs(sumOfRemainingProportions) < 1e-5) {
                 return remainingAdjustment;
-            } else {
-                return remainingAdjustment * proportion / sumOfRemainingProportions;
             }
+
+            return remainingAdjustment * proportion / sumOfRemainingProportions;
         }
 
         // Calculate base positions based on the element sizes and spacing.
@@ -529,7 +529,7 @@ pc.extend(pc, function () {
         // on each element is optional, and each property value also has a set of fallback defaults
         // to be used in cases where no value is specified.
         function getProperty(element, propertyName) {
-            var layoutChildComponent = element.entity['layoutchild'];
+            var layoutChildComponent = element.entity.layoutchild;
 
             // First attempt to get the value from the element's LayoutChildComponent, if present.
             // TODO Should this check if the LayoutChildComponent is enabled?
@@ -537,9 +537,9 @@ pc.extend(pc, function () {
                 return layoutChildComponent[propertyName];
             } else if (element[propertyName] !== undefined) {
                 return element[propertyName];
-            } else {
-                return PROPERTY_DEFAULTS[propertyName];
             }
+
+            return PROPERTY_DEFAULTS[propertyName];
         }
 
         function clamp(value, min, max) {
@@ -590,12 +590,14 @@ pc.extend(pc, function () {
         function getTraversalOrder(items, orderBy, descending) {
             items.forEach(assignIndex);
 
+            /* eslint-disable dot-location */
             return items
                 .slice()
                 .sort(function(itemA, itemB) {
                     return descending ? itemB[orderBy] - itemA[orderBy] : itemA[orderBy] - itemB[orderBy];
                 })
                 .map(getIndex);
+            /* eslint-enable dot-location */
         }
 
         function assignIndex(item, index) {

--- a/src/framework/components/layout-group/layout-calculator.js
+++ b/src/framework/components/layout-group/layout-calculator.js
@@ -397,25 +397,25 @@ pc.extend(pc, function () {
                 var positionsThisLine = [];
                 var sizesThisLine = sizes[lineIndex];
 
-                // Move the cursor to account for the largest element's size and pivot
-                cursor[b.axis] -= minExtentB(line.largestElement, line.largestSize);
-
                 // Distribute elements along the line
                 for (var elementIndex = 0; elementIndex < line.length; ++elementIndex) {
                     var element = line[elementIndex];
+                    var sizesThisElement = sizesThisLine[elementIndex];
 
-                    cursor[a.axis] -= minExtentA(element, sizesThisLine[elementIndex]);
+                    cursor[b.axis] -= minExtentB(element, sizesThisElement);
+                    cursor[a.axis] -= minExtentA(element, sizesThisElement);
 
                     positionsThisLine[elementIndex] = {};
                     positionsThisLine[elementIndex][a.axis] = cursor[a.axis];
                     positionsThisLine[elementIndex][b.axis] = cursor[b.axis];
 
-                    cursor[a.axis] += maxExtentA(element, sizesThisLine[elementIndex]) + options.spacing[a.axis];
+                    cursor[b.axis] += minExtentB(element, sizesThisElement);
+                    cursor[a.axis] += maxExtentA(element, sizesThisElement) + options.spacing[a.axis];
                 }
 
                 // Record the size of the overall line
                 line[a.size] = cursor[a.axis] - options.spacing[a.axis];
-                line[b.size] = maxExtentB(line.largestElement, line.largestSize);
+                line[b.size] = line.largestSize[b.size];
 
                 // Move the cursor to the next line
                 cursor[a.axis] = 0;

--- a/src/framework/components/layout-group/layout-calculator.js
+++ b/src/framework/components/layout-group/layout-calculator.js
@@ -114,7 +114,7 @@ pc.extend(pc, function () {
             }
 
             var lines = [[]];
-            var idealSizes = getProperties(allElements, a.size);
+            var sizes = getElementSizeProperties(allElements);
             var runningSize = 0;
             var allowOverrun = (options[a.fitting] === pc.FITTING_SHRINK);
 
@@ -123,12 +123,13 @@ pc.extend(pc, function () {
                     runningSize += options.spacing[a.axis];
                 }
 
-                runningSize += idealSizes[i];
+                var idealElementSize = sizes[i][a.size];
+                runningSize += idealElementSize;
 
                 // For the None, Stretch and Both fitting modes, we should break to a new
                 // line before we overrun the available space in the container.
                 if (!allowOverrun && runningSize > availableSpace[a.axis] && lines[lines.length - 1].length !== 0) {
-                    runningSize = idealSizes[i];
+                    runningSize = idealElementSize;
                     lines.push([]);
                 }
 

--- a/src/framework/components/layout-group/layout-calculator.js
+++ b/src/framework/components/layout-group/layout-calculator.js
@@ -100,7 +100,6 @@ pc.extend(pc, function () {
                 var anchor = element.anchor.data;
 
                 if (anchor[0] !== 0 || anchor[1] !== 0 || anchor[2] !== 0 || anchor[3] !== 0) {
-                    console.log('setting anchor to 0. curr: ', anchor);
                     element.anchor = [0, 0, 0, 0];
                 }
             }
@@ -120,11 +119,15 @@ pc.extend(pc, function () {
             var allowOverrun = (options[a.fitting] === pc.FITTING_SHRINK);
 
             for (var i = 0; i < allElements.length; ++i) {
+                if (lines[lines.length - 1].length > 0) {
+                    runningSize += options.spacing[a.axis];
+                }
+
                 runningSize += idealSizes[i];
 
                 // For the None, Stretch and Both fitting modes, we should break to a new
                 // line before we overrun the available space in the container.
-                if (!allowOverrun && runningSize >= availableSpace[a.axis] && lines[lines.length - 1].length !== 0) {
+                if (!allowOverrun && runningSize > availableSpace[a.axis] && lines[lines.length - 1].length !== 0) {
                     runningSize = idealSizes[i];
                     lines.push([]);
                 }
@@ -133,7 +136,7 @@ pc.extend(pc, function () {
 
                 // For the Shrink fitting mode, we should break to a new line immediately
                 // after we've overrun the available space in the container.
-                if (allowOverrun && runningSize >= availableSpace[a.axis] && i !== allElements.length - 1) {
+                if (allowOverrun && runningSize > availableSpace[a.axis] && i !== allElements.length - 1) {
                     runningSize = 0;
                     lines.push([]);
                 }

--- a/src/framework/components/layout-group/system.js
+++ b/src/framework/components/layout-group/system.js
@@ -32,6 +32,7 @@ pc.extend(pc, function () {
 
     pc.extend(LayoutGroupComponentSystem.prototype, {
         initializeComponentData: function (component, data, properties) {
+            if (data.enabled !== undefined) component.enabled = data.enabled;
             if (data.orientation !== undefined) component.orientation = data.orientation;
             if (data.reverseX !== undefined) component.reverseX = data.reverseX;
             if (data.reverseY !== undefined) component.reverseY = data.reverseY;

--- a/src/framework/components/layout-group/system.js
+++ b/src/framework/components/layout-group/system.js
@@ -1,11 +1,11 @@
 pc.extend(pc, function () {
-    var _schema = [ 'enabled' ];
+    var _schema = ['enabled'];
 
     /**
      * @private
      * @name pc.LayoutGroupComponentSystem
      * @description Create a new LayoutGroupComponentSystem
-     * @class Manages creation of {@link pc.LayoutGroupComponent}s.
+     * @classdesc Manages creation of {@link pc.LayoutGroupComponent}s.
      * @param {pc.Application} app The application
      * @extends pc.ComponentSystem
      */

--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -108,8 +108,6 @@ pc.extend(pc, function () {
 
         set: function (enabled) {
             if (this._enabled !== enabled) {
-                var prevValue = this._enabled;
-
                 this._enabled = enabled;
 
                 if (! this._parent || this._parent.enabled)

--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -1133,7 +1133,7 @@ pc.extend(pc, function () {
                 this._graphDepth = 0;
             }
 
-            for (var i=0, len=this._children.length; i<len; i++) {
+            for (var i = 0, len = this._children.length; i < len; i++) {
                 this._children[i]._updateGraphDepth();
             }
         },

--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -112,13 +112,6 @@ pc.extend(pc, function () {
 
                 this._enabled = enabled;
 
-                if (this.fire) {
-                    // TODO Using set_enabled here because it matches the convention in
-                    //      components/component.js, but we also have set:foo elsewhere.
-                    //      Which one is preferred?
-                    this.fire('set_enabled', 'enabled', prevValue, enabled);
-                }
-
                 if (! this._parent || this._parent.enabled)
                     this._notifyHierarchyStateChanged(this, enabled);
             }

--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -108,7 +108,16 @@ pc.extend(pc, function () {
 
         set: function (enabled) {
             if (this._enabled !== enabled) {
+                var prevValue = this._enabled;
+
                 this._enabled = enabled;
+
+                if (this.fire) {
+                    // TODO Using set_enabled here because it matches the convention in
+                    //      components/component.js, but we also have set:foo elsewhere.
+                    //      Which one is preferred?
+                    this.fire('set_enabled', 'enabled', prevValue, enabled);
+                }
 
                 if (! this._parent || this._parent.enabled)
                     this._notifyHierarchyStateChanged(this, enabled);

--- a/tests/framework/components/layout-group/test_layoutcalculator.js
+++ b/tests/framework/components/layout-group/test_layoutcalculator.js
@@ -275,7 +275,7 @@ test("takes into account each element's pivot when calculating horizontal positi
     this.calculate();
 
     this.assertValues('x', [50, 110, 150, 250, 270], { approx: true });
-    this.assertValues('y', [10,  10,  10,  10,  10], { approx: true });
+    this.assertValues('y', [10,  10,   0,   0,   0], { approx: true });
 });
 
 test("takes into account each element's pivot when calculating vertical positions", function () {
@@ -287,7 +287,7 @@ test("takes into account each element's pivot when calculating vertical position
 
     this.calculate();
 
-    this.assertValues('x', [10,  10,  10,  10,  10], { approx: true });
+    this.assertValues('x', [10,  10,   0,   0,   0], { approx: true });
     this.assertValues('y', [50, 110, 150, 250, 270], { approx: true });
 });
 

--- a/tests/framework/components/layout-group/test_layoutcalculator.js
+++ b/tests/framework/components/layout-group/test_layoutcalculator.js
@@ -630,6 +630,26 @@ test("{ wrap: true } pc.FITTING_NONE includes spacing and padding in calculation
     this.assertValues('calculatedHeight', [100, 100, 100, 100, 100]);
 });
 
+test("{ wrap: true } pc.FITTING_NONE includes spacing when calculating line breaks", function () {
+    this.elements = this.mixedWidthElements;
+    this.elements[0].width = 100;
+    this.elements[1].width = 100;
+    this.elements[2].width = 100;
+    this.elements[3].width = 100;
+    this.elements[4].width = 100;
+
+    this.options.wrap = true;
+    this.options.orientation = pc.ORIENTATION_HORIZONTAL;
+    this.options.widthFitting = pc.FITTING_NONE;
+    this.options.spacing.x = 20;
+    this.options.containerSize.x = 500;
+
+    this.calculate();
+
+    this.assertValues('x', [0, 120, 240, 360,   0]);
+    this.assertValues('y', [0,    0,  0,   0, 100]);
+});
+
 test("{ wrap: true } pc.FITTING_STRETCH stretches elements proportionally when natural widths are less than container size", function () {
     this.elements = this.mixedWidthElementsWithLayoutChildComponents;
     this.options.wrap = true;


### PR DESCRIPTION
Fixes some issues found during testing:

- Handle additional enabled/disabled states for entity, children, `LayoutGroupComponents` and `LayoutChildComponents`.
- Include spacing when calculating line breaks.
- Adjust pivot handling so that elements align regardless of pivot postion.
- Ensure negative sizes are ignored in line wrapping calculation.
- Misc linting updates.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
