### PR TITLE
Ignoreable layout children and reflow event

### DIFF
--- a/src/framework/components/layout-child/component.js
+++ b/src/framework/components/layout-child/component.js
@@ -13,6 +13,7 @@ pc.extend(pc, function () {
      * @property {Number} maxHeight The maximum height the element should be rendered at.
      * @property {Number} fitWidthProportion The amount of additional horizontal space that the element should take up, if necessary to satisfy a Stretch/Shrink fitting calculation. This is specified as a proportion, taking into account the proportion values of other siblings.
      * @property {Number} fitHeightProportion The amount of additional vertical space that the element should take up, if necessary to satisfy a Stretch/Shrink fitting calculation. This is specified as a proportion, taking into account the proportion values of other siblings.
+     * @property {Number} excludeFromLayout If set to true, the child will be excluded from all layout calculations.
      */
     var LayoutChildComponent = function LayoutChildComponent(system, entity) {
         this._minWidth = 0;
@@ -21,6 +22,7 @@ pc.extend(pc, function () {
         this._maxHeight = null;
         this._fitWidthProportion = 0;
         this._fitHeightProportion = 0;
+        this._excludeFromLayout = false;
     };
     LayoutChildComponent = pc.inherits(LayoutChildComponent, pc.Component);
 
@@ -47,6 +49,7 @@ pc.extend(pc, function () {
     defineResizeProperty('maxHeight');
     defineResizeProperty('fitWidthProportion');
     defineResizeProperty('fitHeightProportion');
+    defineResizeProperty('excludeFromLayout');
 
     return {
         LayoutChildComponent: LayoutChildComponent

--- a/src/framework/components/layout-child/system.js
+++ b/src/framework/components/layout-child/system.js
@@ -32,6 +32,7 @@ pc.extend(pc, function () {
             if (data.maxHeight !== undefined) component.maxHeight = data.maxHeight;
             if (data.fitWidthProportion !== undefined) component.fitWidthProportion = data.fitWidthProportion;
             if (data.fitHeightProportion !== undefined) component.fitHeightProportion = data.fitHeightProportion;
+            if (data.excludeFromLayout !== undefined) component.excludeFromLayout = data.excludeFromLayout;
 
             LayoutChildComponentSystem._super.initializeComponentData.call(this, component, data, properties);
         },
@@ -46,7 +47,8 @@ pc.extend(pc, function () {
                 maxWidth: layoutChild.maxWidth,
                 maxHeight: layoutChild.maxHeight,
                 fitWidthProportion: layoutChild.fitWidthProportion,
-                fitHeightProportion: layoutChild.fitHeightProportion
+                fitHeightProportion: layoutChild.fitHeightProportion,
+                excludeFromLayout: layoutChild.excludeFromLayout
             });
         }
     });

--- a/src/framework/components/layout-group/component.js
+++ b/src/framework/components/layout-group/component.js
@@ -152,8 +152,6 @@ pc.extend(pc, function () {
             var layoutInfo = this._layoutCalculator.calculateLayout(elements, options);
             this._isPerformingReflow = false;
 
-            console.log(layoutInfo);
-
             this.fire('reflow', layoutInfo);
         },
 

--- a/src/framework/components/layout-group/component.js
+++ b/src/framework/components/layout-group/component.js
@@ -149,8 +149,12 @@ pc.extend(pc, function () {
             // a child element triggers another reflow on the next frame, and so on)
             // we flag that a reflow is currently in progress.
             this._isPerformingReflow = true;
-            this._layoutCalculator.calculateLayout(elements, options);
+            var layoutInfo = this._layoutCalculator.calculateLayout(elements, options);
             this._isPerformingReflow = false;
+
+            console.log(layoutInfo);
+
+            this.fire('reflow', layoutInfo);
         },
 
         onEnable: function() {

--- a/src/framework/components/layout-group/layout-calculator.js
+++ b/src/framework/components/layout-group/layout-calculator.js
@@ -73,6 +73,7 @@ pc.extend(pc, function () {
         function maxExtentB(element, size) { return  size[b.size] * (1 - element.pivot[b.axis]); } // eslint-disable-line
 
         function calculateAll(allElements, layoutOptions) {
+            allElements = allElements.filter(shouldIncludeInLayout);
             options = layoutOptions;
 
             availableSpace = new pc.Vec2(
@@ -88,6 +89,12 @@ pc.extend(pc, function () {
 
             applyAlignmentAndPadding(lines, sizes, positions);
             applySizesAndPositions(lines, sizes, positions);
+
+            return createLayoutInfo(lines, sizes, positions);
+        }
+
+        function shouldIncludeInLayout(element) {
+            return !element.entity.layoutchild || !element.entity.layoutchild.excludeFromLayout;
         }
 
         // Setting the anchors of child elements to anything other than 0,0,0,0 results
@@ -386,6 +393,8 @@ pc.extend(pc, function () {
             cursor[a.axis] = 0;
             cursor[b.axis] = 0;
 
+            lines[a.size] = Number.NEGATIVE_INFINITY;
+
             var positionsAllLines = [];
 
             for (var lineIndex = 0; lineIndex < lines.length; ++lineIndex) {
@@ -417,6 +426,9 @@ pc.extend(pc, function () {
                 // Record the size of the overall line
                 line[a.size] = cursor[a.axis] - options.spacing[a.axis];
                 line[b.size] = line.largestSize[b.size];
+
+                // Keep track of the longest line
+                lines[a.size] = Math.max(lines[a.size], line[a.size]);
 
                 // Move the cursor to the next line
                 cursor[a.axis] = 0;
@@ -484,6 +496,13 @@ pc.extend(pc, function () {
                     }
                 }
             }
+        }
+
+        function createLayoutInfo(lines) {
+            // TODO Implement properly
+            return {
+                bounds: new pc.Vec4(0, lines[b.size], lines[a.size], 0)
+            };
         }
 
         // Reads all size-related properties for each element and applies some basic
@@ -639,7 +658,7 @@ pc.extend(pc, function () {
             if (!calculateFn) {
                 throw new Error('Unrecognized orientation value: ' + options.orientation);
             } else {
-                calculateFn(elements, options);
+                return calculateFn(elements, options);
             }
         }
     };

--- a/src/framework/components/layout-group/layout-calculator.js
+++ b/src/framework/components/layout-group/layout-calculator.js
@@ -499,9 +499,19 @@ pc.extend(pc, function () {
         }
 
         function createLayoutInfo(lines) {
-            // TODO Implement properly
+            var layoutWidth = lines.width;
+            var layoutHeight = lines.height;
+
+            var xOffset = (availableSpace.x - layoutWidth) * options.alignment.x + options.padding.x;
+            var yOffset = (availableSpace.y - layoutHeight) * options.alignment.y + options.padding.y;
+
             return {
-                bounds: new pc.Vec4(0, lines[b.size], lines[a.size], 0)
+                bounds: new pc.Vec4(
+                    xOffset,
+                    yOffset,
+                    layoutWidth,
+                    layoutHeight
+                )
             };
         }
 

--- a/src/framework/components/layout-group/layout-calculator.js
+++ b/src/framework/components/layout-group/layout-calculator.js
@@ -94,7 +94,9 @@ pc.extend(pc, function () {
         }
 
         function shouldIncludeInLayout(element) {
-            return !element.entity.layoutchild || !element.entity.layoutchild.excludeFromLayout;
+            var layoutChildComponent = element.entity.layoutchild;
+
+            return !layoutChildComponent || !layoutChildComponent.enabled || !layoutChildComponent.excludeFromLayout;
         }
 
         // Setting the anchors of child elements to anything other than 0,0,0,0 results

--- a/src/framework/components/layout-group/system.js
+++ b/src/framework/components/layout-group/system.js
@@ -110,8 +110,12 @@ pc.extend(pc, function () {
             });
 
             while (this._reflowQueue.length > 0) {
-                var component = this._reflowQueue.shift();
-                component.reflow();
+                // Note that we leave the current item in the queue while performing its reflow
+                // and then remove it afterwards, rather than removing it first and then reflowing
+                // it. This is safer because the item cannot re-enter the queue while it is
+                // already in there (due to the check performed in the scheduleReflow() method).
+                this._reflowQueue[0].reflow();
+                this._reflowQueue.shift();
             }
 
             this._reflowQueue = [];

--- a/tests/framework/components/layout-group/test_layoutcalculator.html
+++ b/tests/framework/components/layout-group/test_layoutcalculator.html
@@ -180,6 +180,10 @@
         <script type="text/javascript" src="../../../../src/framework/components/element/data.js"></script>
         <script type="text/javascript" src="../../../../src/framework/components/element/image-element.js"></script>
         <script type="text/javascript" src="../../../../src/framework/components/element/text-element.js"></script>
+        <script type="text/javascript" src="../../../../src/framework/components/button/constants.js"></script>
+        <script type="text/javascript" src="../../../../src/framework/components/button/component.js"></script>
+        <script type="text/javascript" src="../../../../src/framework/components/button/system.js"></script>
+        <script type="text/javascript" src="../../../../src/framework/components/button/data.js"></script>
         <script type="text/javascript" src="../../../../src/framework/components/layout-group/constants.js"></script>
         <script type="text/javascript" src="../../../../src/framework/components/layout-group/component.js"></script>
         <script type="text/javascript" src="../../../../src/framework/components/layout-group/system.js"></script>

--- a/tests/framework/components/layout-group/test_layoutcalculator.js
+++ b/tests/framework/components/layout-group/test_layoutcalculator.js
@@ -513,8 +513,8 @@ test("{ wrap: false } can reverse elements on the x axis", function () {
 
     this.calculate();
 
-    this.assertValues('x', [0, 30, 50, 150, 200]);
-    this.assertValues('y', [0,  0,  0,   0,   0]);
+    this.assertValues('x', [200, 150, 50, 30, 0]);
+    this.assertValues('y', [0,     0,  0,  0, 0]);
 });
 
 test("{ wrap: false } can reverse elements on the y axis", function () {
@@ -526,8 +526,8 @@ test("{ wrap: false } can reverse elements on the y axis", function () {
 
     this.calculate();
 
-    this.assertValues('x', [0,  0,  0,   0,   0]);
-    this.assertValues('y', [0, 30, 50, 150, 200]);
+    this.assertValues('x', [0,     0,  0,  0, 0]);
+    this.assertValues('y', [200, 150, 50, 30, 0]);
 });
 
 test("{ wrap: false } can align to [1, 0.5]", function () {
@@ -558,6 +558,18 @@ test("{ wrap: false } can align to [0.5, 1]", function () {
 
     this.assertValues('x', [-20,  80, 130, 230, 250]);
     this.assertValues('y', [300, 300, 300, 300, 300]);
+});
+
+test("{ wrap: false } can exclude elements from the layout", function () {
+    this.elements = this.mixedWidthElementsWithLayoutChildComponents;
+    this.options.orientation = pc.ORIENTATION_HORIZONTAL;
+
+    this.elements[1].entity.layoutchild.excludeFromLayout = true;
+
+    this.calculate();
+
+    this.assertValues('x', [0, 0, 100, 200, 220]);
+    this.assertValues('y', [0, 0,   0,   0,   0]);
 });
 
 test("{ wrap: true } pc.FITTING_NONE does not adjust the size or position of elements to match the container size", function () {
@@ -773,4 +785,19 @@ test("{ wrap: true } can align to [0.5, 1]", function () {
 
     this.assertValues('x', [  5, 105, 155, 105, 125]);
     this.assertValues('y', [200, 200, 200, 300, 300]);
+});
+
+test("{ wrap: false } can exclude elements from the layout", function () {
+    this.elements = this.mixedWidthElementsWithLayoutChildComponents;
+    this.options.wrap = true;
+    this.options.orientation = pc.ORIENTATION_HORIZONTAL;
+    this.options.widthFitting = pc.FITTING_NONE;
+    this.options.containerSize.x = 260;
+
+    this.elements[1].entity.layoutchild.excludeFromLayout = true;
+
+    this.calculate();
+
+    this.assertValues('x', [0, 0, 100, 200, 220]);
+    this.assertValues('y', [0, 0,   0,   0,   0]);
 });

--- a/tests/framework/components/layout-group/test_layoutcalculator.js
+++ b/tests/framework/components/layout-group/test_layoutcalculator.js
@@ -291,6 +291,34 @@ test("takes into account each element's pivot when calculating vertical position
     this.assertValues('y', [50, 110, 150, 250, 270], { approx: true });
 });
 
+test("returns a layoutInfo object containing the layout bounds", function () {
+    this.elements = this.mixedWidthElementsWithLayoutChildComponents;
+    this.options.wrap = true;
+    this.options.orientation = pc.ORIENTATION_HORIZONTAL;
+    this.options.widthFitting = pc.FITTING_NONE;
+
+    var layoutInfo;
+
+    this.options.alignment.x = 0;
+    this.options.alignment.y = 0;
+    layoutInfo = this.calculate();
+    deepEqual(layoutInfo.bounds.data, new Float32Array([0, 0, 300, 100]));
+
+    this.options.alignment.x = 1;
+    this.options.alignment.y = 0.5;
+    layoutInfo = this.calculate();
+    deepEqual(layoutInfo.bounds.data, new Float32Array([200, 150, 300, 100]));
+
+    this.options.alignment.x = 0.5;
+    this.options.alignment.y = 1;
+    layoutInfo = this.calculate();
+    deepEqual(layoutInfo.bounds.data, new Float32Array([100, 300, 300, 100]));
+
+    this.options.widthFitting = pc.FITTING_STRETCH;
+    layoutInfo = this.calculate();
+    deepEqual(layoutInfo.bounds.data, new Float32Array([0, 300, 500, 100]));
+});
+
 test("{ wrap: false } pc.FITTING_NONE does not adjust the size or position of elements to match the container size", function () {
     this.elements = this.mixedWidthElements;
     this.options.orientation = pc.ORIENTATION_HORIZONTAL;


### PR DESCRIPTION
- Adds the ability to exclude individual `LayoutChild` elements from reflow calculations.
- Adds a `reflow` event, fired by `LayoutGroups` after each reflow.

Allows layout backgrounds to be created using scripts similar to the following:

```
var LayoutBackground = pc.createScript('layout-background');

LayoutBackground.prototype.initialize = function() {
    this.entity.parent.layoutgroup.on('reflow', function(layoutInfo) {
        var layoutBounds = layoutInfo.bounds.data;
        this.entity.setLocalPosition(new pc.Vec3(layoutBounds[0], layoutBounds[1], 0));
        this.entity.element.width = layoutBounds[2];
        this.entity.element.height = layoutBounds[3];
    }, this);
};
```

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
