### PR TITLE
Remove Vec2 allocation

### DIFF
--- a/src/framework/components/layout-group/layout-calculator.js
+++ b/src/framework/components/layout-group/layout-calculator.js
@@ -50,12 +50,13 @@ pc.extend(pc, function () {
         APPLY_SHRINKING: 'APPLY_SHRINKING'
     };
 
+    var availableSpace = new pc.Vec2();
+
     // The layout logic is largely identical for the horizontal and vertical orientations,
     // with the exception of a few bits of swizzling re the primary and secondary axes to
     // use etc. This function generates a calculator for a given orientation, with each of
     // the swizzled properties conveniently placed in closure scope.
     function createCalculator(orientation) {
-        var availableSpace;
         var options;
 
         // Choose which axes to operate on based on the orientation that we're using. For
@@ -75,10 +76,8 @@ pc.extend(pc, function () {
         function calculateAll(allElements, layoutOptions) {
             options = layoutOptions;
 
-            availableSpace = new pc.Vec2(
-                options.containerSize.x - options.padding.data[0] - options.padding.data[2],
-                options.containerSize.y - options.padding.data[1] - options.padding.data[3]
-            );
+            availableSpace.x = options.containerSize.x - options.padding.data[0] - options.padding.data[2];
+            availableSpace.y = options.containerSize.y - options.padding.data[1] - options.padding.data[3];
 
             resetAnchors(allElements);
 


### PR DESCRIPTION
Removes a redundant `Vec2` allocation in `LayoutCalculator`.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
