### PR TITLE
Update webvr-polyfill and its initialisation

### DIFF
--- a/examples/webvr/index.html
+++ b/examples/webvr/index.html
@@ -5,7 +5,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no">
         <title>PlayCanvas WebVR Example</title>
         <script src="../../build/output/playcanvas-latest.js"></script>
-        <script src="https://code.playcanvas.com/webvr-polyfill.91fbc44.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/webvr-polyfill@0.10.4/build/webvr-polyfill.min.js"></script>
         <style>
             body {
                 margin: 0;

--- a/src/vr/vr-manager.js
+++ b/src/vr/vr-manager.js
@@ -19,8 +19,26 @@ pc.extend(pc, function () {
         this.usesPolyfill = VrManager.usesPolyfill;
 
         // if required initialize webvr polyfill
-        if (window.InitializeWebVRPolyfill)
-            window.InitializeWebVRPolyfill();
+        if (window.WebVRPolyfill) {
+            var options = {
+                ADDITIONAL_VIEWERS: [],
+                DEFAULT_VIEWER: '',
+                PROVIDE_MOBILE_VRDISPLAY: true,
+                GET_VR_DISPLAYS_TIMEOUT: 1000,
+                MOBILE_WAKE_LOCK: true,
+                DEBUG: false,
+                DPDB_URL: 'https://dpdb.webvr.rocks/dpdb.json',
+                K_FILTER: 0.98,
+                PREDICTION_TIME_S: 0.040,
+                TOUCH_PANNER_DISABLED: true,
+                CARDBOARD_UI_DISABLED: false,
+                ROTATE_INSTRUCTIONS_DISABLED: false,
+                YAW_ONLY: false,
+                BUFFER_SCALE: 0.5,
+                DIRTY_SUBMIT_FRAME_BINDINGS: false
+            };
+            var polyfill = new window.WebVRPolyfill(options);
+        }
 
         this._index = { };
         this.displays = [];
@@ -84,7 +102,7 @@ pc.extend(pc, function () {
      * @type Boolean
      * @description Reports whether this device supports the WebVR API using a polyfill
      */
-    VrManager.usesPolyfill = !!window.InitializeWebVRPolyfill;
+    VrManager.usesPolyfill = !!window.WebVRPolyfill;
 
     VrManager.prototype = {
         _attach: function () {


### PR DESCRIPTION
Fixes issue that DeviceMotionEvent.rotationRate units have changed from degrees per second to radians on Chrome m66, causing camera to jump around like crazy. Update to recent version of webvr-polyfill (>10.x) is needed including different initialisation.

Fixes #1219

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
