### PR TITLE
Only ever include one reflection chunk

### DIFF
--- a/src/graphics/program-lib/standard.js
+++ b/src/graphics/program-lib/standard.js
@@ -867,7 +867,11 @@ pc.programlib.standard = {
 
         var reflectionDecode = options.rgbmReflection ? "decodeRGBM" : (options.hdrReflection ? "" : "gammaCorrectInput");
 
-        if (cubemapReflection) {
+        if (options.sphereMap) {
+            var scode = device.fragmentUniformsCount > 16 ? chunks.reflectionSpherePS : chunks.reflectionSphereLowPS;
+            scode = scode.replace(/\$texture2DSAMPLE/g, options.rgbmReflection ? "texture2DRGBM" : (options.hdrReflection ? "texture2D" : "texture2DSRGB"));
+            code += scode;
+        } else if (cubemapReflection) {
             if (options.prefilteredCubemap) {
                 if (useTexCubeLod) {
                     code += chunks.reflectionPrefilteredCubeLodPS.replace(/\$DECODE/g, reflectionDecode);
@@ -879,15 +883,7 @@ pc.programlib.standard = {
                 code += chunks.reflectionCubePS.replace(/\$textureCubeSAMPLE/g,
                                                         options.rgbmReflection ? "textureCubeRGBM" : (options.hdrReflection ? "textureCube" : "textureCubeSRGB"));
             }
-        }
-
-        if (options.sphereMap) {
-            var scode = device.fragmentUniformsCount > 16 ? chunks.reflectionSpherePS : chunks.reflectionSphereLowPS;
-            scode = scode.replace(/\$texture2DSAMPLE/g, options.rgbmReflection ? "texture2DRGBM" : (options.hdrReflection ? "texture2D" : "texture2DSRGB"));
-            code += scode;
-        }
-
-        if (options.dpAtlas) {
+        } else if (options.dpAtlas) {
             code += chunks.reflectionDpAtlasPS.replace(/\$texture2DSAMPLE/g, options.rgbmReflection ? "texture2DRGBM" : (options.hdrReflection ? "texture2D" : "texture2DSRGB"));
         }
 


### PR DESCRIPTION
On devices that fall back from cubemap based IBL to a dual-paraboloid sphere map technique (when EXT_texture_lod is not available), it is possible for more than one reflection chunk to be included if a sphere map already specified on the material. This PR uses if...else to ensure only a single reflection chunk is included and has the sphere map take precedence.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
