### PR TITLE
Mark batch groups as dirty on component change

### DIFF
--- a/src/framework/components/element/component.js
+++ b/src/framework/components/element/component.js
@@ -702,6 +702,10 @@ pc.extend(pc, function () {
                 this._topMask = false;
             }
 
+            if (this._batchGroupId >= 0) {
+                this.system.app.batcher.markGroupDirty(this.batchGroupId);
+            }
+
             this.fire("disableelement");
         },
 
@@ -1318,8 +1322,8 @@ pc.extend(pc, function () {
             if (this._batchGroupId === value)
                 return;
 
-            if (this._batchGroupId >= 0) this.system.app.batcher._markGroupDirty(this._batchGroupId);
-            if (value >= 0) this.system.app.batcher._markGroupDirty(value);
+            if (this._batchGroupId >= 0) this.system.app.batcher.markGroupDirty(this._batchGroupId);
+            if (value >= 0) this.system.app.batcher.markGroupDirty(value);
 
             if (value < 0 && this._batchGroupId >= 0 && this.enabled && this.entity.enabled) {
                 // re-add model to scene, in case it was removed by batching

--- a/src/framework/components/model/component.js
+++ b/src/framework/components/model/component.js
@@ -374,8 +374,8 @@ pc.extend(pc, function () {
         },
 
         onSetBatchGroupId: function (name, oldValue, newValue) {
-            if (oldValue >= 0) this.system.app.batcher._markGroupDirty(oldValue);
-            if (newValue >= 0) this.system.app.batcher._markGroupDirty(newValue);
+            if (oldValue >= 0) this.system.app.batcher.markGroupDirty(oldValue);
+            if (newValue >= 0) this.system.app.batcher.markGroupDirty(newValue);
 
             if (newValue < 0 && oldValue >= 0 && this.enabled && this.entity.enabled) {
                 // re-add model to scene, in case it was removed by batching
@@ -735,6 +735,10 @@ pc.extend(pc, function () {
             if (this.system.app.scene.layers) {
                 this.system.app.scene.layers.off("add", this.onLayerAdded, this);
                 this.system.app.scene.layers.off("remove", this.onLayerRemoved, this);
+            }
+
+            if (this.batchGroupId >= 0) {
+                this.system.app.batcher.markGroupDirty(this.batchGroupId);
             }
 
             var model = this.data.model;

--- a/src/framework/components/sprite/component.js
+++ b/src/framework/components/sprite/component.js
@@ -132,6 +132,10 @@ pc.extend(pc, function () {
 
             this.stop();
             this._hideModel();
+
+            if (this._batchGroupId >= 0) {
+                this.system.app.batcher.markGroupDirty(this.batchGroupId);
+            }
         },
 
         onDestroy: function () {
@@ -783,11 +787,11 @@ pc.extend(pc, function () {
             this._batchGroupId = value;
 
             if (prev >= 0) {
-                this.system.app.batcher._markGroupDirty(prev);
+                this.system.app.batcher.markGroupDirty(prev);
             }
 
             if (this._batchGroupId >= 0) {
-                this.system.app.batcher._markGroupDirty(this._batchGroupId);
+                this.system.app.batcher.markGroupDirty(this._batchGroupId);
             } else {
                 // re-add model to scene in case it was removed by batching
                 if (prev >= 0) {

--- a/src/scene/batching.js
+++ b/src/scene/batching.js
@@ -1047,6 +1047,13 @@ pc.extend(pc, function () {
         return batch2;
     };
 
+    /**
+     * @private
+     * @function
+     * @name pc.BatchManager#destroy
+     * @description Mark the batches ref counter to 0, remove the batch model out of all layers and destroy it
+     * @param {pc.Batch} batch A batch object
+     */
     BatchManager.prototype.destroy = function (batch) {
         batch.refCounter = 0;
         var layers = this._batchGroups[batch.batchGroupId].layers;
@@ -1054,11 +1061,11 @@ pc.extend(pc, function () {
             this.scene.layers.getLayerById(layers[i]).removeMeshInstances(batch.model.meshInstances);
         }
         batch.model.destroy();
-    };etes.krujgadfjgh
+    };
 
     /**
      * @private
-     * @functionetes.krujgadfjgh
+     * @function
      * @name pc.BatchManager#decrement
      * @description Decrements reference counter on a batch. If it's zero, the batch is removed from scene, and its geometry is deleted from memory.
      * @param {pc.Batch} batch A batch object


### PR DESCRIPTION
When model, sprite or element components are enable/disabled/destroyed.

