### PR TITLE
Use Object.assign instead of pc.extend

### DIFF
--- a/src/anim/animation.js
+++ b/src/anim/animation.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     var Key = function Key(time, position, rotation, scale) {
         this.time = time;
         this.position = position;

--- a/src/anim/skeleton.js
+++ b/src/anim/skeleton.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     function InterpolatedKey() {
         this._written = false;
         this._name = "";
@@ -13,7 +13,7 @@ pc.extend(pc, function () {
         this._targetNode = null;
     }
 
-    InterpolatedKey.prototype = {
+    Object.assign(InterpolatedKey.prototype, {
         getTarget: function () {
             return this._targetNode;
         },
@@ -21,7 +21,7 @@ pc.extend(pc, function () {
         setTarget: function (node) {
             this._targetNode = node;
         }
-    };
+    });
 
     /**
      * @constructor

--- a/src/asset/asset-registry.js
+++ b/src/asset/asset-registry.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     /**
      * @constructor
      * @name pc.AssetRegistry
@@ -19,7 +19,7 @@ pc.extend(pc, function () {
 
         this.prefix = null;
 
-        pc.extend(this, pc.events);
+        Object.assign(this, pc.events);
     };
 
     /**
@@ -150,7 +150,7 @@ pc.extend(pc, function () {
      * app.assets.load(asset);
      */
 
-    AssetRegistry.prototype = {
+    Object.assign(AssetRegistry.prototype, {
         /**
          * @function
          * @name pc.AssetRegistry#list
@@ -676,8 +676,7 @@ pc.extend(pc, function () {
             console.warn("DEPRECATED: getAssetById() use get() instead");
             return this.get(id);
         }
-
-    };
+    });
 
     return {
         AssetRegistry: AssetRegistry

--- a/src/asset/asset-variants.js
+++ b/src/asset/asset-variants.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
 
     var properties = [];
 

--- a/src/asset/asset.js
+++ b/src/asset/asset.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
 
     // auto incrementing number for asset ids
     var assetIdCounter = 0;
@@ -113,7 +113,7 @@ pc.extend(pc, function () {
      * @param {*} oldValue The old property value
      */
 
-    Asset.prototype = {
+    Object.assign(Asset.prototype, {
         /**
          * @name pc.Asset#getFileUrl
          * @function
@@ -226,8 +226,7 @@ pc.extend(pc, function () {
                 this.registry._loader.clearCache(this.getFileUrl(), this.type);
             }
         }
-    };
-
+    });
 
     Object.defineProperty(Asset.prototype, 'id', {
         get: function () {

--- a/src/audio/channel.js
+++ b/src/audio/channel.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     'use strict';
 
     var Channel;
@@ -38,7 +38,7 @@ pc.extend(pc, function () {
             this.gain = context.createGain();
         };
 
-        Channel.prototype = {
+        Object.assign(Channel.prototype, {
             /**
              * @private
              * @function
@@ -195,7 +195,7 @@ pc.extend(pc, function () {
                     }
                 }
             }
-        };
+        });
     } else if (pc.AudioManager.hasAudio()) {
         Channel = function (manager, sound, options) {
             this.volume = options.volume || 1;
@@ -215,7 +215,7 @@ pc.extend(pc, function () {
             }
         };
 
-        Channel.prototype = {
+        Object.assign(Channel.prototype, {
             play: function () {
                 if (this.source) {
                     this.paused = false;
@@ -288,14 +288,14 @@ pc.extend(pc, function () {
             isPlaying: function () {
                 return !this.source.paused;
             }
-        };
+        });
     } else {
         Channel = function () {
         };
     }
 
     // Add functions which don't depend on source type
-    pc.extend(Channel.prototype, {
+    Object.assign(Channel.prototype, {
         /**
          * @private
          * @function

--- a/src/audio/channel3d.js
+++ b/src/audio/channel3d.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     'use strict';
 
     // default maxDistance, same as Web Audio API
@@ -16,7 +16,7 @@ pc.extend(pc, function () {
         };
         Channel3d = pc.inherits(Channel3d, pc.Channel);
 
-        Channel3d.prototype = pc.extend(Channel3d.prototype, {
+        Object.assign(Channel3d.prototype, {
             getPosition: function () {
                 return this.position;
             },
@@ -130,7 +130,7 @@ pc.extend(pc, function () {
         };
         Channel3d = pc.inherits(Channel3d, pc.Channel);
 
-        Channel3d.prototype = pc.extend(Channel3d.prototype, {
+        Object.assign(Channel3d.prototype, {
             getPosition: function () {
                 return this.position;
             },

--- a/src/backwards-compatibility.js
+++ b/src/backwards-compatibility.js
@@ -72,7 +72,7 @@ pc.fw = {
     }
 };
 
-pc.extend(pc.gfx, {
+Object.assign(pc.gfx, {
     drawQuadWithShader: pc.drawQuadWithShader,
     precalculatedTangents: pc.precalculatedTangents,
     programlib: pc.programlib,
@@ -110,7 +110,7 @@ pc.extend(pc.gfx, {
     pc.UnsupportedBrowserError = UnsupportedBrowserError;
 })();
 
-pc.extend(pc.input, {
+Object.assign(pc.input, {
     getTouchTargetCoords: pc.getTouchTargetCoords,
     Controller: pc.Controller,
     GamePads: pc.GamePads,
@@ -142,7 +142,7 @@ pc.posteffect = {
     PostEffectQueue: pc.PostEffectQueue
 };
 
-pc.extend(pc.scene, {
+Object.assign(pc.scene, {
     partitionSkin: pc.partitionSkin,
     procedural: {
         calculateTangents: pc.calculateTangents,

--- a/src/core/color.js
+++ b/src/core/color.js
@@ -1,4 +1,4 @@
-pc.extend(pc, (function () {
+Object.assign(pc, (function () {
     /**
      * @constructor
      * @name pc.Color
@@ -33,7 +33,7 @@ pc.extend(pc, (function () {
         }
     };
 
-    Color.prototype = {
+    Object.assign(Color.prototype, {
         /**
          * @function
          * @name pc.Color#clone
@@ -141,7 +141,7 @@ pc.extend(pc, (function () {
 
             return s;
         }
-    };
+    });
 
     Object.defineProperty(Color.prototype, 'r', {
         get: function () {

--- a/src/core/hash.js
+++ b/src/core/hash.js
@@ -1,4 +1,4 @@
-pc.extend(pc, (function () {
+Object.assign(pc, (function () {
     return {
         /**
          * @private

--- a/src/core/inheritance.js
+++ b/src/core/inheritance.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     return {
         /**
          * @private

--- a/src/core/log.js
+++ b/src/core/log.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     var log = {
         /**
          * @private

--- a/src/core/object-pool.js
+++ b/src/core/object-pool.js
@@ -1,4 +1,4 @@
-pc.extend(pc, (function () {
+Object.assign(pc, (function () {
     var AllocatePool = function (constructor, size) {
         this._constructor = constructor;
         this._pool = [];
@@ -7,7 +7,7 @@ pc.extend(pc, (function () {
         this._resize(size);
     };
 
-    AllocatePool.prototype = {
+    Object.assign(AllocatePool.prototype, {
         _resize: function (size) {
             if (size > this._pool.length) {
                 for (var i = this._pool.length; i < size; i++) {
@@ -26,7 +26,7 @@ pc.extend(pc, (function () {
         freeAll: function () {
             this._count = 0;
         }
-    };
+    });
 
     return {
         AllocatePool: AllocatePool

--- a/src/core/platform.js
+++ b/src/core/platform.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     /**
      * @name pc.platform
      * @namespace

--- a/src/core/tags.js
+++ b/src/core/tags.js
@@ -1,10 +1,10 @@
-pc.extend(pc, (function () {
+Object.assign(pc, (function () {
     var TagsCache = function (key) {
         this._index = { };
         this._key = key || null;
     };
 
-    TagsCache.prototype = {
+    Object.assign(TagsCache.prototype, {
         addItem: function (item) {
             var tags = item.tags._list;
 
@@ -142,7 +142,7 @@ pc.extend(pc, (function () {
 
             return items;
         }
-    };
+    });
 
 
     /**
@@ -183,7 +183,7 @@ pc.extend(pc, (function () {
         pc.events.attach(this);
     };
 
-    Tags.prototype = {
+    Object.assign(Tags.prototype, {
         /**
          * @function
          * @name pc.Tags#add
@@ -392,7 +392,7 @@ pc.extend(pc, (function () {
 
             return tags;
         }
-    };
+    });
 
     /**
      * @field

--- a/src/core/time.js
+++ b/src/core/time.js
@@ -1,4 +1,4 @@
-pc.extend(pc, (function () {
+Object.assign(pc, (function () {
     /**
      * @private
      * @constructor
@@ -12,7 +12,7 @@ pc.extend(pc, (function () {
         this._b = 0;
     };
 
-    Timer.prototype = {
+    Object.assign(Timer.prototype, {
         /**
          * @private
          * @function
@@ -45,7 +45,7 @@ pc.extend(pc, (function () {
         getMilliseconds: function () {
             return this._b - this._a;
         }
-    };
+    });
 
     return {
         Timer: Timer,

--- a/src/core/uri.js
+++ b/src/core/uri.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     return {
         /**
          * @private

--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     /**
      * @name pc.Application
      * @class Default application which performs general setup code and initiates the main game loop.
@@ -523,7 +523,7 @@ pc.extend(pc, function () {
         };
     };
 
-    Application.prototype = {
+    Object.assign(Application.prototype, {
         /**
          * @function
          * @name pc.Application#configure
@@ -1527,7 +1527,7 @@ pc.extend(pc, function () {
 
             pc.destroyPostEffectQuad();
         }
-    };
+    });
 
     // static data
     var _frameEndData = {};

--- a/src/framework/components/animation/component.js
+++ b/src/framework/components/animation/component.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     /**
      * @component Animation
      * @constructor
@@ -27,7 +27,7 @@ pc.extend(pc, function () {
     };
     AnimationComponent = pc.inherits(AnimationComponent, pc.Component);
 
-    pc.extend(AnimationComponent.prototype, {
+    Object.assign(AnimationComponent.prototype, {
         /**
          * @function
          * @name pc.AnimationComponent#play

--- a/src/framework/components/animation/data.js
+++ b/src/framework/components/animation/data.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     var AnimationComponentData = function () {
         // Serialized
         this.assets = [];

--- a/src/framework/components/animation/system.js
+++ b/src/framework/components/animation/system.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     var _schema = [
         'enabled',
         'assets',
@@ -45,7 +45,7 @@ pc.extend(pc, function () {
 
     pc.Component._buildAccessors(pc.AnimationComponent.prototype, _schema);
 
-    pc.extend(AnimationComponentSystem.prototype, {
+    Object.assign(AnimationComponentSystem.prototype, {
         initializeComponentData: function (component, data, properties) {
             properties = ['activate', 'enabled', 'loop', 'speed', 'assets'];
             AnimationComponentSystem._super.initializeComponentData.call(this, component, data, properties);

--- a/src/framework/components/audio-listener/component.js
+++ b/src/framework/components/audio-listener/component.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     /**
      * @component
      * @constructor
@@ -14,7 +14,7 @@ pc.extend(pc, function () {
 
     AudioListenerComponent = pc.inherits(AudioListenerComponent, pc.Component);
 
-    pc.extend(AudioListenerComponent.prototype, {
+    Object.assign(AudioListenerComponent.prototype, {
         setCurrentListener: function () {
             if (this.enabled && this.entity.audiolistener && this.entity.enabled) {
                 this.system.current = this.entity;

--- a/src/framework/components/audio-listener/data.js
+++ b/src/framework/components/audio-listener/data.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     var AudioListenerComponentData = function () {
         // Serialized
         this.enabled = true;

--- a/src/framework/components/audio-listener/system.js
+++ b/src/framework/components/audio-listener/system.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     var _schema = ['enabled'];
 
     /**
@@ -29,7 +29,7 @@ pc.extend(pc, function () {
 
     pc.Component._buildAccessors(pc.AudioListenerComponent.prototype, _schema);
 
-    pc.extend(AudioListenerComponentSystem.prototype, {
+    Object.assign(AudioListenerComponentSystem.prototype, {
         initializeComponentData: function (component, data, properties) {
             properties = ['enabled'];
 

--- a/src/framework/components/audio-source/component.js
+++ b/src/framework/components/audio-source/component.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     /**
      * @private
      * @component
@@ -34,7 +34,7 @@ pc.extend(pc, function () {
     };
     AudioSourceComponent = pc.inherits(AudioSourceComponent, pc.Component);
 
-    pc.extend(AudioSourceComponent.prototype, {
+    Object.assign(AudioSourceComponent.prototype, {
         /**
          * @private
          * @function

--- a/src/framework/components/audio-source/system.js
+++ b/src/framework/components/audio-source/system.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     var _schema = [
         'enabled',
         'assets',
@@ -48,7 +48,7 @@ pc.extend(pc, function () {
 
     pc.Component._buildAccessors(pc.AudioSourceComponent.prototype, _schema);
 
-    pc.extend(AudioSourceComponentSystem.prototype, {
+    Object.assign(AudioSourceComponentSystem.prototype, {
         initializeComponentData: function (component, data, properties) {
             properties = ['activate', 'volume', 'pitch', 'loop', '3d', 'minDistance', 'maxDistance', 'rollOffFactor', 'distanceModel', 'enabled', 'assets'];
             AudioSourceComponentSystem._super.initializeComponentData.call(this, component, data, properties);

--- a/src/framework/components/button/component.js
+++ b/src/framework/components/button/component.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     var VisualState = {
         DEFAULT: 'DEFAULT',
         HOVER: 'HOVER',
@@ -62,7 +62,7 @@ pc.extend(pc, function () {
     };
     ButtonComponent = pc.inherits(ButtonComponent, pc.Component);
 
-    pc.extend(ButtonComponent.prototype, {
+    Object.assign(ButtonComponent.prototype, {
         _toggleLifecycleListeners: function (onOrOff, system) {
             this[onOrOff]('set_active', this._onSetActive, this);
             this[onOrOff]('set_transitionMode', this._onSetTransitionMode, this);

--- a/src/framework/components/button/constants.js
+++ b/src/framework/components/button/constants.js
@@ -1,4 +1,4 @@
-pc.extend(pc, {
+Object.assign(pc, {
     /**
      * @private
      * @enum pc.BUTTON_TRANSITION_MODE

--- a/src/framework/components/button/data.js
+++ b/src/framework/components/button/data.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     var ButtonComponentData = function () {
         this.enabled = true;
     };

--- a/src/framework/components/button/system.js
+++ b/src/framework/components/button/system.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     var _schema = [
         'enabled',
         'active',
@@ -41,7 +41,7 @@ pc.extend(pc, function () {
 
     pc.Component._buildAccessors(pc.ButtonComponent.prototype, _schema);
 
-    pc.extend(ButtonComponentSystem.prototype, {
+    Object.assign(ButtonComponentSystem.prototype, {
         initializeComponentData: function (component, data, properties) {
             ButtonComponentSystem._super.initializeComponentData.call(this, component, data, _schema);
         },

--- a/src/framework/components/camera/component.js
+++ b/src/framework/components/camera/component.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     /**
      * @component
      * @constructor
@@ -172,7 +172,7 @@ pc.extend(pc, function () {
         }
     });
 
-    pc.extend(CameraComponent.prototype, {
+    Object.assign(CameraComponent.prototype, {
         /**
          * @function
          * @name pc.CameraComponent#screenToWorld

--- a/src/framework/components/camera/data.js
+++ b/src/framework/components/camera/data.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     /**
      * @private
      * @constructor

--- a/src/framework/components/camera/post-effect-pass.js
+++ b/src/framework/components/camera/post-effect-pass.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
 
     var _backbufferRt = [null, null]; // 2 RTs may be needed for ping-ponging
     var _constInput = null;

--- a/src/framework/components/camera/post-effect-queue.js
+++ b/src/framework/components/camera/post-effect-queue.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     /**
      * @constructor
      * @name pc.PostEffectQueue
@@ -32,7 +32,7 @@ pc.extend(pc, function () {
         camera.on('set_rect', this.onCameraRectChanged, this);
     }
 
-    PostEffectQueue.prototype = {
+    Object.assign(PostEffectQueue.prototype, {
         /**
          * @private
          * @function
@@ -373,7 +373,7 @@ pc.extend(pc, function () {
                 this.resizeRenderTargets();
             }
         }
-    };
+    });
 
     return {
         PostEffectQueue: PostEffectQueue

--- a/src/framework/components/camera/system.js
+++ b/src/framework/components/camera/system.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     var _schema = [
         'enabled',
         'clearColorBuffer',
@@ -60,7 +60,7 @@ pc.extend(pc, function () {
 
     pc.Component._buildAccessors(pc.CameraComponent.prototype, _schema);
 
-    pc.extend(CameraComponentSystem.prototype, {
+    Object.assign(CameraComponentSystem.prototype, {
         initializeComponentData: function (component, _data, properties) {
             properties = [
                 'postEffects',

--- a/src/framework/components/collision/component.js
+++ b/src/framework/components/collision/component.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     /**
      * @component
      * @constructor
@@ -115,7 +115,7 @@ pc.extend(pc, function () {
      * @param {pc.Entity} other The {@link pc.Entity} that exited this collision volume.
      */
 
-    pc.extend(CollisionComponent.prototype, {
+    Object.assign(CollisionComponent.prototype, {
 
         onSetType: function (name, oldValue, newValue) {
             if (oldValue !== newValue) {

--- a/src/framework/components/collision/data.js
+++ b/src/framework/components/collision/data.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     var CollisionComponentData = function () {
         this.enabled = true;
         this.type = 'box';

--- a/src/framework/components/collision/system.js
+++ b/src/framework/components/collision/system.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     var _schema = [
         'enabled',
         'type',
@@ -16,7 +16,7 @@ pc.extend(pc, function () {
         this.system = system;
     };
 
-    CollisionSystemImpl.prototype = {
+    Object.assign(CollisionSystemImpl.prototype, {
         // Called before the call to system.super.initializeComponentData is made
         beforeInitialize: function (component, data) {
             data.shape = this.createPhysicalShape(component.entity, data);
@@ -106,14 +106,14 @@ pc.extend(pc, function () {
 
             return this.system.addComponent(clone, data);
         }
-    };
+    });
 
     // Box Collision System
     var CollisionBoxSystemImpl = function (system) {};
 
     CollisionBoxSystemImpl = pc.inherits(CollisionBoxSystemImpl, CollisionSystemImpl);
 
-    CollisionBoxSystemImpl.prototype = pc.extend(CollisionBoxSystemImpl.prototype, {
+    Object.assign(CollisionBoxSystemImpl.prototype, {
         createPhysicalShape: function (entity, data) {
             if (typeof Ammo !== 'undefined') {
                 var he = data.halfExtents;
@@ -129,7 +129,7 @@ pc.extend(pc, function () {
 
     CollisionSphereSystemImpl = pc.inherits(CollisionSphereSystemImpl, CollisionSystemImpl);
 
-    CollisionSphereSystemImpl.prototype = pc.extend(CollisionSphereSystemImpl.prototype, {
+    Object.assign(CollisionSphereSystemImpl.prototype, {
         createPhysicalShape: function (entity, data) {
             if (typeof Ammo !== 'undefined') {
                 return new Ammo.btSphereShape(data.radius);
@@ -143,7 +143,7 @@ pc.extend(pc, function () {
 
     CollisionCapsuleSystemImpl = pc.inherits(CollisionCapsuleSystemImpl, CollisionSystemImpl);
 
-    CollisionCapsuleSystemImpl.prototype = pc.extend(CollisionCapsuleSystemImpl.prototype, {
+    Object.assign(CollisionCapsuleSystemImpl.prototype, {
         createPhysicalShape: function (entity, data) {
             var shape = null;
             var axis = (data.axis !== undefined) ? data.axis : 1;
@@ -172,7 +172,7 @@ pc.extend(pc, function () {
 
     CollisionCylinderSystemImpl = pc.inherits(CollisionCylinderSystemImpl, CollisionSystemImpl);
 
-    CollisionCylinderSystemImpl.prototype = pc.extend(CollisionCylinderSystemImpl.prototype, {
+    Object.assign(CollisionCylinderSystemImpl.prototype, {
         createPhysicalShape: function (entity, data) {
             var halfExtents = null;
             var shape = null;
@@ -205,7 +205,7 @@ pc.extend(pc, function () {
 
     CollisionMeshSystemImpl = pc.inherits(CollisionMeshSystemImpl, CollisionSystemImpl);
 
-    CollisionMeshSystemImpl.prototype = pc.extend(CollisionMeshSystemImpl.prototype, {
+    Object.assign(CollisionMeshSystemImpl.prototype, {
         // override for the mesh implementation because the asset model needs
         // special handling
         beforeInitialize: function (component, data) {},
@@ -391,7 +391,7 @@ pc.extend(pc, function () {
 
     pc.Component._buildAccessors(pc.CollisionComponent.prototype, _schema);
 
-    CollisionComponentSystem.prototype = pc.extend(CollisionComponentSystem.prototype, {
+    Object.assign(CollisionComponentSystem.prototype, {
         onLibraryLoaded: function () {
             if (typeof Ammo !== 'undefined') {
                 //

--- a/src/framework/components/collision/trigger.js
+++ b/src/framework/components/collision/trigger.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
 
     var ammoVec1, ammoQuat;
 
@@ -25,7 +25,7 @@ pc.extend(pc, function () {
         this.initialize(data);
     };
 
-    Trigger.prototype =  {
+    Object.assign(Trigger.prototype,  {
         initialize: function (data) {
             var entity = this.entity;
             var shape = data.shape;
@@ -117,10 +117,9 @@ pc.extend(pc, function () {
             // that it properly deactivates after we remove it from the physics world
             body.forceActivationState(pc.BODYSTATE_DISABLE_SIMULATION);
         }
-    };
+    });
 
     return {
         Trigger: Trigger
     };
-
 }());

--- a/src/framework/components/component.js
+++ b/src/framework/components/component.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     /**
      * @constructor
      * @name pc.Component

--- a/src/framework/components/data.js
+++ b/src/framework/components/data.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     /**
      * @private
      * @constructor

--- a/src/framework/components/element/component.js
+++ b/src/framework/components/element/component.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     var topMasks = [];
 
     var _debugLogging = false;
@@ -159,7 +159,7 @@ pc.extend(pc, function () {
     ElementComponent = pc.inherits(ElementComponent, pc.Component);
 
 
-    pc.extend(ElementComponent.prototype, {
+    Object.assign(ElementComponent.prototype, {
         _patch: function () {
             this.entity._sync = this._sync;
             this.entity.setPosition = this._setPosition;

--- a/src/framework/components/element/data.js
+++ b/src/framework/components/element/data.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     var ElementComponentData = function () {
         this.enabled = true;
     };

--- a/src/framework/components/element/element-drag-helper.js
+++ b/src/framework/components/element/element-drag-helper.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     var _inputScreenPosition = new pc.Vec2();
     var _inputWorldPosition = new pc.Vec3();
     var _rayOrigin = new pc.Vec3();
@@ -45,7 +45,7 @@ pc.extend(pc, function () {
         this._toggleLifecycleListeners('on');
     };
 
-    pc.extend(ElementDragHelper.prototype, {
+    Object.assign(ElementDragHelper.prototype, {
         _toggleLifecycleListeners: function (onOrOff) {
             this._element[onOrOff]('mousedown', this._onMouseDownOrTouchStart, this);
             this._element[onOrOff]('touchstart', this._onMouseDownOrTouchStart, this);

--- a/src/framework/components/element/image-element.js
+++ b/src/framework/components/element/image-element.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
 
     var ImageElement = function ImageElement(element) {
         this._element = element;
@@ -61,7 +61,7 @@ pc.extend(pc, function () {
         this._element.on('screen:set:resolution', this._onResolutionChange, this);
     };
 
-    pc.extend(ImageElement.prototype, {
+    Object.assign(ImageElement.prototype, {
         destroy: function () {
             if (this._model) {
                 this._element.removeModelFromLayers(this._model);

--- a/src/framework/components/element/system.js
+++ b/src/framework/components/element/system.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     var _schema = ['enabled'];
 
     var nineSliceBasePS = [
@@ -193,7 +193,7 @@ pc.extend(pc, function () {
 
     pc.Component._buildAccessors(pc.ElementComponent.prototype, _schema);
 
-    pc.extend(ElementComponentSystem.prototype, {
+    Object.assign(ElementComponentSystem.prototype, {
         initializeComponentData: function (component, data, properties) {
             if (data.anchor !== undefined) {
                 if (data.anchor instanceof pc.Vec4) {

--- a/src/framework/components/element/text-element.js
+++ b/src/framework/components/element/text-element.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
 
     var TextElement = function TextElement(element) {
         this._element = element;
@@ -57,7 +57,7 @@ pc.extend(pc, function () {
     var WHITESPACE_CHAR = /^[ \t]$/;
     var WORD_BOUNDARY_CHAR = /^[ \t\-]$/;
 
-    pc.extend(TextElement.prototype, {
+    Object.assign(TextElement.prototype, {
         destroy: function () {
             if (this._model) {
                 this._element.removeModelFromLayers(this._model);

--- a/src/framework/components/layout-child/component.js
+++ b/src/framework/components/layout-child/component.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     /**
      * @component
      * @constructor

--- a/src/framework/components/layout-child/data.js
+++ b/src/framework/components/layout-child/data.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     var LayoutChildComponentData = function () {
         this.enabled = true;
     };

--- a/src/framework/components/layout-child/system.js
+++ b/src/framework/components/layout-child/system.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     var _schema = ['enabled'];
 
     /**
@@ -23,7 +23,7 @@ pc.extend(pc, function () {
 
     pc.Component._buildAccessors(pc.LayoutChildComponent.prototype, _schema);
 
-    pc.extend(LayoutChildComponentSystem.prototype, {
+    Object.assign(LayoutChildComponentSystem.prototype, {
         initializeComponentData: function (component, data, properties) {
             if (data.enabled !== undefined) component.enabled = data.enabled;
             if (data.minWidth !== undefined) component.minWidth = data.minWidth;

--- a/src/framework/components/layout-group/component.js
+++ b/src/framework/components/layout-group/component.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     /**
      * @component
      * @constructor
@@ -73,7 +73,7 @@ pc.extend(pc, function () {
     };
     LayoutGroupComponent = pc.inherits(LayoutGroupComponent, pc.Component);
 
-    pc.extend(LayoutGroupComponent.prototype, {
+    Object.assign(LayoutGroupComponent.prototype, {
         _isSelfOrChild: function (entity) {
             return (entity === this.entity) || (this.entity.children.indexOf(entity) !== -1);
         },

--- a/src/framework/components/layout-group/constants.js
+++ b/src/framework/components/layout-group/constants.js
@@ -1,4 +1,4 @@
-pc.extend(pc, {
+Object.assign(pc, {
     /**
      * @enum pc.FITTING
      * @name pc.FITTING_NONE

--- a/src/framework/components/layout-group/data.js
+++ b/src/framework/components/layout-group/data.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     var LayoutGroupComponentData = function () {
         this.enabled = true;
     };

--- a/src/framework/components/layout-group/layout-calculator.js
+++ b/src/framework/components/layout-group/layout-calculator.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     /**
      * @private
      * @constructor
@@ -650,7 +650,7 @@ pc.extend(pc, function () {
     CALCULATE_FNS[pc.ORIENTATION_HORIZONTAL] = createCalculator(pc.ORIENTATION_HORIZONTAL);
     CALCULATE_FNS[pc.ORIENTATION_VERTICAL] = createCalculator(pc.ORIENTATION_VERTICAL);
 
-    LayoutCalculator.prototype = {
+    Object.assign(LayoutCalculator.prototype, {
         calculateLayout: function (elements, options) {
             var calculateFn = CALCULATE_FNS[options.orientation];
 
@@ -660,7 +660,7 @@ pc.extend(pc, function () {
                 return calculateFn(elements, options);
             }
         }
-    };
+    });
 
     return {
         LayoutCalculator: LayoutCalculator

--- a/src/framework/components/layout-group/system.js
+++ b/src/framework/components/layout-group/system.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     var _schema = ['enabled'];
 
     /**
@@ -30,7 +30,7 @@ pc.extend(pc, function () {
 
     pc.Component._buildAccessors(pc.LayoutGroupComponent.prototype, _schema);
 
-    pc.extend(LayoutGroupComponentSystem.prototype, {
+    Object.assign(LayoutGroupComponentSystem.prototype, {
         initializeComponentData: function (component, data, properties) {
             if (data.enabled !== undefined) component.enabled = data.enabled;
             if (data.orientation !== undefined) component.orientation = data.orientation;

--- a/src/framework/components/light/component.js
+++ b/src/framework/components/light/component.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     /**
      * @component
      * @constructor
@@ -325,7 +325,7 @@ pc.extend(pc, function () {
         }
     });
 
-    pc.extend(LightComponent.prototype, {
+    Object.assign(LightComponent.prototype, {
 
         addLightToLayers: function () {
             var layer;

--- a/src/framework/components/light/data.js
+++ b/src/framework/components/light/data.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     var LightComponentData = function () {
         var _props = pc._lightProps;
         var _propsDefault = pc._lightPropsDefault;

--- a/src/framework/components/light/system.js
+++ b/src/framework/components/light/system.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     /**
      * @constructor
      * @name pc.LightComponentSystem
@@ -23,7 +23,7 @@ pc.extend(pc, function () {
     };
     LightComponentSystem = pc.inherits(LightComponentSystem, pc.ComponentSystem);
 
-    pc.extend(LightComponentSystem.prototype, {
+    Object.assign(LightComponentSystem.prototype, {
         initializeComponentData: function (component, _data) {
             // duplicate because we're modifying the data
             var data = {};

--- a/src/framework/components/model/component.js
+++ b/src/framework/components/model/component.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     /**
      * @component
      * @constructor
@@ -68,7 +68,7 @@ pc.extend(pc, function () {
     };
     ModelComponent = pc.inherits(ModelComponent, pc.Component);
 
-    pc.extend(ModelComponent.prototype, {
+    Object.assign(ModelComponent.prototype, {
         setVisible: function (visible) {
             console.warn("WARNING: setVisible: Function is deprecated. Set enabled property instead.");
             this.enabled = visible;

--- a/src/framework/components/model/data.js
+++ b/src/framework/components/model/data.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
 
     /**
      * @private

--- a/src/framework/components/model/system.js
+++ b/src/framework/components/model/system.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     var _schema = [
         'enabled',
         'type',
@@ -70,7 +70,7 @@ pc.extend(pc, function () {
 
     pc.Component._buildAccessors(pc.ModelComponent.prototype, _schema);
 
-    pc.extend(ModelComponentSystem.prototype, {
+    Object.assign(ModelComponentSystem.prototype, {
         initializeComponentData: function (component, _data, properties) {
 
             // order matters here

--- a/src/framework/components/particle-system/component.js
+++ b/src/framework/components/particle-system/component.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
 
     // properties that do not need rebuilding the particle system
     var SIMPLE_PROPERTIES = [
@@ -163,7 +163,7 @@ pc.extend(pc, function () {
 
     ParticleSystemComponent = pc.inherits(ParticleSystemComponent, pc.Component);
 
-    pc.extend(ParticleSystemComponent.prototype, {
+    Object.assign(ParticleSystemComponent.prototype, {
         addModelToLayers: function () {
             if (!this.data.model) return;
             var layer;

--- a/src/framework/components/particle-system/data.js
+++ b/src/framework/components/particle-system/data.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     var ParticleSystemComponentData = function () {
 
         this.numParticles = 1;                  // Amount of particles allocated (max particles = max GL texture width at this moment)

--- a/src/framework/components/particle-system/system.js
+++ b/src/framework/components/particle-system/system.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     var _schema = [
         'enabled',
         'autoPlay',
@@ -94,7 +94,7 @@ pc.extend(pc, function () {
 
     pc.Component._buildAccessors(pc.ParticleSystemComponent.prototype, _schema);
 
-    pc.extend(ParticleSystemComponentSystem.prototype, {
+    Object.assign(ParticleSystemComponentSystem.prototype, {
 
         initializeComponentData: function (component, _data, properties) {
             var data = {};

--- a/src/framework/components/registry.js
+++ b/src/framework/components/registry.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     /**
      * @constructor
      * @name pc.ComponentSystemRegistry
@@ -8,7 +8,7 @@ pc.extend(pc, function () {
     var ComponentSystemRegistry = function () {
     };
 
-    ComponentSystemRegistry.prototype = {
+    Object.assign(ComponentSystemRegistry.prototype, {
         /**
          * @private
          * @function
@@ -88,7 +88,7 @@ pc.extend(pc, function () {
 
             return names;
         }
-    };
+    });
 
     return {
         ComponentSystemRegistry: ComponentSystemRegistry

--- a/src/framework/components/rigid-body/component.js
+++ b/src/framework/components/rigid-body/component.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     // Shared math variable to avoid excessive allocation
     var ammoTransform;
     var ammoVec1, ammoVec2, ammoQuat, ammoOrigin;
@@ -130,7 +130,7 @@ pc.extend(pc, function () {
         }
     });
 
-    pc.extend(RigidBodyComponent.prototype, {
+    Object.assign(RigidBodyComponent.prototype, {
         /**
          * @private
          * @function

--- a/src/framework/components/rigid-body/constants.js
+++ b/src/framework/components/rigid-body/constants.js
@@ -1,4 +1,4 @@
-pc.extend(pc, {
+Object.assign(pc, {
     // types
     BODYTYPE_STATIC: 'static',
     BODYTYPE_DYNAMIC: 'dynamic',

--- a/src/framework/components/rigid-body/data.js
+++ b/src/framework/components/rigid-body/data.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     /**
      * @private
      * @constructor

--- a/src/framework/components/rigid-body/system.js
+++ b/src/framework/components/rigid-body/system.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     var ammoRayStart, ammoRayEnd;
 
     var collisions = {};
@@ -165,7 +165,7 @@ pc.extend(pc, function () {
 
     pc.Component._buildAccessors(pc.RigidBodyComponent.prototype, _schema);
 
-    pc.extend(RigidBodyComponentSystem.prototype, {
+    Object.assign(RigidBodyComponentSystem.prototype, {
         onLibraryLoaded: function () {
             // Create the Ammo physics world
             if (typeof Ammo !== 'undefined') {

--- a/src/framework/components/screen/component.js
+++ b/src/framework/components/screen/component.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     /**
      * @enum pc.SCALEMODE
      * @name pc.SCALEMODE_NONE
@@ -43,7 +43,7 @@ pc.extend(pc, function () {
 
     var _transform = new pc.Mat4();
 
-    pc.extend(ScreenComponent.prototype, {
+    Object.assign(ScreenComponent.prototype, {
         /**
          * @function
          * @name pc.ScreenComponent#syncDrawOrder

--- a/src/framework/components/screen/data.js
+++ b/src/framework/components/screen/data.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     var ScreenComponentData = function () {
         this.enabled = true;
     };

--- a/src/framework/components/screen/system.js
+++ b/src/framework/components/screen/system.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     var _schema = ['enabled'];
 
     /**
@@ -30,7 +30,7 @@ pc.extend(pc, function () {
 
     pc.Component._buildAccessors(pc.ScreenComponent.prototype, _schema);
 
-    pc.extend(ScreenComponentSystem.prototype, {
+    Object.assign(ScreenComponentSystem.prototype, {
         initializeComponentData: function (component, data, properties) {
             if (data.screenSpace !== undefined) component.screenSpace = data.screenSpace;
             if (data.scaleMode !== undefined) component.scaleMode = data.scaleMode;

--- a/src/framework/components/script-legacy/component.js
+++ b/src/framework/components/script-legacy/component.js
@@ -1,10 +1,10 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     var ScriptLegacyComponent = function ScriptLegacyComponent(system, entity) {
         this.on("set_scripts", this.onSetScripts, this);
     };
     ScriptLegacyComponent = pc.inherits(ScriptLegacyComponent, pc.Component);
 
-    pc.extend(ScriptLegacyComponent.prototype, {
+    Object.assign(ScriptLegacyComponent.prototype, {
         send: function (name, functionName) {
             console.warn("DEPRECATED: ScriptLegacyComponent.send() is deprecated and will be removed soon. Please use: http://developer.playcanvas.com/user-manual/scripting/communication/");
             var args = pc.makeArray(arguments).slice(2);

--- a/src/framework/components/script-legacy/data.js
+++ b/src/framework/components/script-legacy/data.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     var ScriptLegacyComponentData = function () {
         // serialized
         this.scripts = [];

--- a/src/framework/components/script-legacy/system.js
+++ b/src/framework/components/script-legacy/system.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
 
     var _schema = [
         'enabled',
@@ -47,7 +47,7 @@ pc.extend(pc, function () {
 
     pc.Component._buildAccessors(pc.ScriptLegacyComponent.prototype, _schema);
 
-    pc.extend(ScriptLegacyComponentSystem.prototype, {
+    Object.assign(ScriptLegacyComponentSystem.prototype, {
         initializeComponentData: function (component, data, properties) {
             properties = ['runInTools', 'enabled', 'scripts'];
 

--- a/src/framework/components/script/component.js
+++ b/src/framework/components/script/component.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     /**
      * @component
      * @name pc.ScriptComponent
@@ -161,7 +161,7 @@ pc.extend(pc, function () {
      * });
      */
 
-    pc.extend(ScriptComponent.prototype, {
+    Object.assign(ScriptComponent.prototype, {
         onEnable: function () {
             ScriptComponent._super.onEnable.call(this);
             this._beingEnabled = true;

--- a/src/framework/components/script/data.js
+++ b/src/framework/components/script/data.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     var ScriptComponentData = function () {
         this.enabled = true;
     };

--- a/src/framework/components/script/system.js
+++ b/src/framework/components/script/system.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     var _schema = ['enabled'];
 
     /**
@@ -36,7 +36,7 @@ pc.extend(pc, function () {
 
     pc.Component._buildAccessors(pc.ScriptComponent.prototype, _schema);
 
-    pc.extend(ScriptComponentSystem.prototype, {
+    Object.assign(ScriptComponentSystem.prototype, {
         initializeComponentData: function (component, data, properties) {
             this._components.push(component);
 

--- a/src/framework/components/scroll-view/component.js
+++ b/src/framework/components/scroll-view/component.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     var _tempScrollValue = new pc.Vec2();
 
     /**
@@ -58,7 +58,7 @@ pc.extend(pc, function () {
     };
     ScrollViewComponent = pc.inherits(ScrollViewComponent, pc.Component);
 
-    pc.extend(ScrollViewComponent.prototype, {
+    Object.assign(ScrollViewComponent.prototype, {
         _toggleLifecycleListeners: function (onOrOff, system) {
             this[onOrOff]('set_horizontal', this._onSetHorizontalScrollingEnabled, this);
             this[onOrOff]('set_vertical', this._onSetVerticalScrollingEnabled, this);

--- a/src/framework/components/scroll-view/constants.js
+++ b/src/framework/components/scroll-view/constants.js
@@ -1,4 +1,4 @@
-pc.extend(pc, {
+Object.assign(pc, {
     /**
      * @private
      * @enum pc.SCROLL_MODE

--- a/src/framework/components/scroll-view/data.js
+++ b/src/framework/components/scroll-view/data.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     var ScrollViewComponentData = function () {
         this.enabled = true;
     };

--- a/src/framework/components/scroll-view/system.js
+++ b/src/framework/components/scroll-view/system.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     var _schema = [
         { name: 'enabled', type: 'boolean' },
         { name: 'horizontal', type: 'boolean' },
@@ -38,7 +38,7 @@ pc.extend(pc, function () {
 
     pc.Component._buildAccessors(pc.ScrollViewComponent.prototype, _schema);
 
-    pc.extend(ScrollViewComponentSystem.prototype, {
+    Object.assign(ScrollViewComponentSystem.prototype, {
         initializeComponentData: function (component, data, properties) {
             ScrollViewComponentSystem._super.initializeComponentData.call(this, component, data, _schema);
         },

--- a/src/framework/components/scrollbar/component.js
+++ b/src/framework/components/scrollbar/component.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     /**
      * @private
      * @component
@@ -25,7 +25,7 @@ pc.extend(pc, function () {
     };
     ScrollbarComponent = pc.inherits(ScrollbarComponent, pc.Component);
 
-    pc.extend(ScrollbarComponent.prototype, {
+    Object.assign(ScrollbarComponent.prototype, {
         _toggleLifecycleListeners: function (onOrOff) {
             this[onOrOff]('set_value', this._onSetValue, this);
             this[onOrOff]('set_handleSize', this._onSetHandleSize, this);

--- a/src/framework/components/scrollbar/data.js
+++ b/src/framework/components/scrollbar/data.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     var ScrollbarComponentData = function () {
         this.enabled = true;
     };

--- a/src/framework/components/scrollbar/system.js
+++ b/src/framework/components/scrollbar/system.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     var _schema = [
         { name: 'enabled', type: 'boolean' },
         { name: 'orientation', type: 'number' },
@@ -31,7 +31,7 @@ pc.extend(pc, function () {
 
     pc.Component._buildAccessors(pc.ScrollbarComponent.prototype, _schema);
 
-    pc.extend(ScrollbarComponentSystem.prototype, {
+    Object.assign(ScrollbarComponentSystem.prototype, {
         initializeComponentData: function (component, data, properties) {
             ScrollbarComponentSystem._super.initializeComponentData.call(this, component, data, _schema);
         },

--- a/src/framework/components/sound/component.js
+++ b/src/framework/components/sound/component.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     /**
      * @component
      * @constructor
@@ -30,7 +30,7 @@ pc.extend(pc, function () {
 
     SoundComponent = pc.inherits(SoundComponent, pc.Component);
 
-    pc.extend(SoundComponent.prototype, {
+    Object.assign(SoundComponent.prototype, {
         onSetSlots: function (name, oldValue, newValue) {
             var key;
 

--- a/src/framework/components/sound/constants.js
+++ b/src/framework/components/sound/constants.js
@@ -1,5 +1,5 @@
 // distance model
-pc.extend(pc, {
+Object.assign(pc, {
     /**
      * @static
      * @readOnly

--- a/src/framework/components/sound/slot.js
+++ b/src/framework/components/sound/slot.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     'use strict';
 
     // temporary object for creating
@@ -84,7 +84,7 @@ pc.extend(pc, function () {
         pc.events.attach(this);
     };
 
-    SoundSlot.prototype = {
+    Object.assign(SoundSlot.prototype, {
         /**
          * @function pc.SoundSlot#play
          * @description Plays a sound. If {@link pc.SoundSlot#overlap} is true the new sound
@@ -410,7 +410,7 @@ pc.extend(pc, function () {
                 instances[i].position = position;
             }
         }
-    };
+    });
 
     Object.defineProperty(SoundSlot.prototype, 'name', {
         get: function () {

--- a/src/framework/components/sound/system.js
+++ b/src/framework/components/sound/system.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     var _schema = [
         'enabled',
         'volume',
@@ -44,7 +44,7 @@ pc.extend(pc, function () {
 
     pc.Component._buildAccessors(pc.SoundComponent.prototype, _schema);
 
-    pc.extend(SoundComponentSystem.prototype, {
+    Object.assign(SoundComponentSystem.prototype, {
         initializeComponentData: function (component, data, properties) {
             properties = ['volume', 'pitch', 'positional', 'refDistance', 'maxDistance', 'rollOffFactor', 'distanceModel', 'slots', 'enabled'];
             SoundComponentSystem._super.initializeComponentData.call(this, component, data, properties);

--- a/src/framework/components/sprite/component.js
+++ b/src/framework/components/sprite/component.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     'use strict';
 
     /**
@@ -106,7 +106,7 @@ pc.extend(pc, function () {
     };
     SpriteComponent = pc.inherits(SpriteComponent, pc.Component);
 
-    pc.extend(SpriteComponent.prototype, {
+    Object.assign(SpriteComponent.prototype, {
         onEnable: function () {
             SpriteComponent._super.onEnable.call(this);
 

--- a/src/framework/components/sprite/data.js
+++ b/src/framework/components/sprite/data.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     var SpriteComponentData = function () {
         this.enabled = true;
     };

--- a/src/framework/components/sprite/sprite-animation-clip.js
+++ b/src/framework/components/sprite/sprite-animation-clip.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
 
     /**
      * @private
@@ -39,7 +39,7 @@ pc.extend(pc, function () {
         pc.events.attach(this);
     };
 
-    SpriteAnimationClip.prototype = {
+    Object.assign(SpriteAnimationClip.prototype, {
         // When sprite asset is added bind it
         _onSpriteAssetAdded: function (asset) {
             this._component.system.app.assets.off('add:' + asset.id, this._onSpriteAssetAdded, this);
@@ -256,8 +256,7 @@ pc.extend(pc, function () {
             this.fire('stop');
             this._component.fire('stop', this);
         }
-    };
-
+    });
 
     Object.defineProperty(SpriteAnimationClip.prototype, "spriteAsset", {
         get: function () {

--- a/src/framework/components/sprite/system.js
+++ b/src/framework/components/sprite/system.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     'use strict';
 
     var _schema = ['enabled'];
@@ -99,7 +99,7 @@ pc.extend(pc, function () {
 
     pc.Component._buildAccessors(pc.SpriteComponent.prototype, _schema);
 
-    pc.extend(SpriteComponentSystem.prototype, {
+    Object.assign(SpriteComponentSystem.prototype, {
         initializeComponentData: function (component, data, properties) {
             if (data.enabled !== undefined) {
                 component.enabled = data.enabled;

--- a/src/framework/components/system.js
+++ b/src/framework/components/system.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     /**
      * @constructor
      * @name pc.ComponentSystem
@@ -14,7 +14,7 @@ pc.extend(pc, function () {
     };
 
     // Class methods
-    pc.extend(ComponentSystem, {
+    Object.assign(ComponentSystem, {
         initialize: function (root) {
             ComponentSystem.fire('initialize', root);
         },

--- a/src/framework/components/text/font.js
+++ b/src/framework/components/text/font.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     pc.FONT_MSDF = 'msdf';
 
     /**
@@ -24,9 +24,6 @@ pc.extend(pc, function () {
         // json data
         this._data = null;
         this.data = data;
-    };
-
-    Font.prototype = {
     };
 
     Object.defineProperty(Font.prototype, "data", {

--- a/src/framework/components/zone/component.js
+++ b/src/framework/components/zone/component.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     /**
      * @private
      * @component
@@ -67,7 +67,7 @@ pc.extend(pc, function () {
      * });
      */
 
-    pc.extend(ZoneComponent.prototype, {
+    Object.assign(ZoneComponent.prototype, {
         onEnable: function () {
             ZoneComponent._super.onEnable.call(this);
             this._checkState();

--- a/src/framework/components/zone/data.js
+++ b/src/framework/components/zone/data.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     var ZoneComponentData = function () {
         this.enabled = true;
     };

--- a/src/framework/components/zone/system.js
+++ b/src/framework/components/zone/system.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     var _schema = ['enabled'];
 
     /**
@@ -26,7 +26,7 @@ pc.extend(pc, function () {
 
     pc.Component._buildAccessors(pc.ZoneComponent.prototype, _schema);
 
-    pc.extend(ZoneComponentSystem.prototype, {
+    Object.assign(ZoneComponentSystem.prototype, {
         initializeComponentData: function (component, data, properties) {
             component.enabled = data.hasOwnProperty('enabled') ? !!data.enabled : true;
 

--- a/src/framework/entity.js
+++ b/src/framework/entity.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     /**
      * @constructor
      * @name pc.Entity

--- a/src/framework/scene-registry.js
+++ b/src/framework/scene-registry.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
 
     /**
      * @private

--- a/src/framework/utils/entity-reference.js
+++ b/src/framework/utils/entity-reference.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     /**
      * @private
      * @name pc.EntityReference
@@ -126,7 +126,7 @@ pc.extend(pc, function () {
         this._toggleLifecycleListeners('on');
     }
 
-    pc.extend(EntityReference.prototype, {
+    Object.assign(EntityReference.prototype, {
         _configureEventListeners: function (externalEventConfig, internalEventConfig) {
             var externalEventListenerConfigs = this._parseEventListenerConfig(externalEventConfig, 'external', this._parentComponent);
             var internalEventListenerConfigs = this._parseEventListenerConfig(internalEventConfig, 'internal', this);

--- a/src/graphics/chunks.js
+++ b/src/graphics/chunks.js
@@ -1,4 +1,4 @@
-pc.extend(pc, (function () {
+Object.assign(pc, (function () {
     'use strict';
 
     var shaderChunks = {};

--- a/src/graphics/device.js
+++ b/src/graphics/device.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     'use strict';
 
     var EVENT_RESIZE = 'resizecanvas';
@@ -570,7 +570,7 @@ pc.extend(pc, function () {
         }).call(this);
     };
 
-    GraphicsDevice.prototype = {
+    Object.assign(GraphicsDevice.prototype, {
         getPrecision: function () {
             var gl = this.gl;
             var precision = "highp";
@@ -2749,7 +2749,7 @@ pc.extend(pc, function () {
                 this.gl.deleteTransformFeedback(this.feedback);
             }
         }
-    };
+    });
 
     /**
      * @readonly

--- a/src/graphics/graphics.js
+++ b/src/graphics/graphics.js
@@ -757,9 +757,9 @@
         UNIFORMTYPE_TEXTURE3D: 20
     };
 
-    pc.extend(pc, enums);
+    Object.assign(pc, enums);
 
     // For backwards compatibility
     pc.gfx = {};
-    pc.extend(pc.gfx, enums);
+    Object.assign(pc.gfx, enums);
 }());

--- a/src/graphics/index-buffer.js
+++ b/src/graphics/index-buffer.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     'use strict';
 
     /**
@@ -53,7 +53,7 @@ pc.extend(pc, function () {
         this.device.buffers.push(this);
     };
 
-    IndexBuffer.prototype = {
+    Object.assign(IndexBuffer.prototype, {
         /**
          * @function
          * @name pc.IndexBuffer#destroy
@@ -156,7 +156,7 @@ pc.extend(pc, function () {
             this.unlock();
             return true;
         }
-    };
+    });
 
     return {
         IndexBuffer: IndexBuffer

--- a/src/graphics/paraboloid.js
+++ b/src/graphics/paraboloid.js
@@ -1,4 +1,4 @@
-pc.extend(pc, (function () {
+Object.assign(pc, (function () {
     'use strict';
 
     var dpMult = 2.0;

--- a/src/graphics/post-effect.js
+++ b/src/graphics/post-effect.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
 
     // Primitive for drawFullscreenQuad
     var primitive = {
@@ -25,7 +25,7 @@ pc.extend(pc, function () {
         this.needsDepthBuffer = false;
     };
 
-    PostEffect.prototype = {
+    Object.assign(PostEffect.prototype, {
         /**
          * @function
          * @name pc.PostEffect#render
@@ -37,7 +37,7 @@ pc.extend(pc, function () {
          */
         render: function (inputTarget, outputTarget, rect) {
         }
-    };
+    });
 
     function createFullscreenQuad(device) {
         // Create the vertex format

--- a/src/graphics/prefilter-cubemap.js
+++ b/src/graphics/prefilter-cubemap.js
@@ -1,4 +1,4 @@
-pc.extend(pc, (function () {
+Object.assign(pc, (function () {
     'use strict';
 
     function syncToCpu(device, targ, face) {

--- a/src/graphics/program-library.js
+++ b/src/graphics/program-library.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     'use strict';
 
     // Public interface

--- a/src/graphics/render-target.js
+++ b/src/graphics/render-target.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     'use strict';
 
     var defaultOptions = {
@@ -94,7 +94,7 @@ pc.extend(pc, function () {
         this._glMsaaDepthBuffer = null;
     };
 
-    RenderTarget.prototype = {
+    Object.assign(RenderTarget.prototype, {
         /**
          * @function
          * @name pc.RenderTarget#destroy
@@ -190,7 +190,7 @@ pc.extend(pc, function () {
             }
             return this._device.copyRenderTarget(source, this, color, depth);
         }
-    };
+    });
 
     /**
      * @readonly

--- a/src/graphics/scope-id.js
+++ b/src/graphics/scope-id.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     'use strict';
 
     var ScopeId = function (name) {
@@ -12,7 +12,7 @@ pc.extend(pc, function () {
         this.versionObject = new pc.VersionedObject();
     };
 
-    ScopeId.prototype = {
+    Object.assign(ScopeId.prototype, {
         setValue: function (value) {
             // Set the new value
             this.value = value;
@@ -24,7 +24,7 @@ pc.extend(pc, function () {
         getValue: function (value) {
             return this.value;
         }
-    };
+    });
 
     return {
         ScopeId: ScopeId

--- a/src/graphics/scope-space.js
+++ b/src/graphics/scope-space.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     'use strict';
 
     var ScopeSpace = function (name) {
@@ -10,7 +10,7 @@ pc.extend(pc, function () {
         this.namespaces = {};
     };
 
-    ScopeSpace.prototype = {
+    Object.assign(ScopeSpace.prototype, {
         resolve: function (name) {
             // Check if the ScopeId already exists
             if (!this.variables.hasOwnProperty(name)) {
@@ -32,7 +32,7 @@ pc.extend(pc, function () {
             // Now return the ScopeNamespace instance
             return this.namespaces[name];
         }
-    };
+    });
 
     return {
         ScopeSpace: ScopeSpace

--- a/src/graphics/shader-input.js
+++ b/src/graphics/shader-input.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     'use strict';
 
     var ShaderInput = function (graphicsDevice, name, type, locationId) {

--- a/src/graphics/shader.js
+++ b/src/graphics/shader.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     'use strict';
 
     function addLineNumbers(src) {
@@ -86,7 +86,7 @@ pc.extend(pc, function () {
         this.device.shaders.push(this);
     };
 
-    Shader.prototype = {
+    Object.assign(Shader.prototype, {
         compile: function () {
             this.ready = false;
 
@@ -261,7 +261,7 @@ pc.extend(pc, function () {
                 this.device.removeShaderFromCache(this);
             }
         }
-    };
+    });
 
     return {
         Shader: Shader

--- a/src/graphics/simple-post-effect.js
+++ b/src/graphics/simple-post-effect.js
@@ -1,4 +1,4 @@
-pc.extend(pc, (function () {
+Object.assign(pc, (function () {
     'use strict';
 
     // Draws shaded full-screen quad in a single call

--- a/src/graphics/texture.js
+++ b/src/graphics/texture.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     'use strict';
 
     /**
@@ -570,7 +570,7 @@ pc.extend(pc, function () {
     });
 
     // Public methods
-    pc.extend(Texture.prototype, {
+    Object.assign(Texture.prototype, {
         /**
          * @function
          * @name pc.Texture#destroy

--- a/src/graphics/transform-feedback.js
+++ b/src/graphics/transform-feedback.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     'use strict';
 
     /**
@@ -93,7 +93,7 @@ pc.extend(pc, function () {
         return pc.shaderChunks.createShaderFromCode(graphicsDevice, vsCode, null, name, true);
     };
 
-    TransformFeedback.prototype = {
+    Object.assign(TransformFeedback.prototype, {
         /**
          * @function
          * @name pc.TransformFeedback#destroy
@@ -137,7 +137,7 @@ pc.extend(pc, function () {
                 this._outputBuffer.bufferId = tmp;
             }
         }
-    };
+    });
 
     /**
      * @readonly

--- a/src/graphics/version.js
+++ b/src/graphics/version.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     'use strict';
 
     var Version = function () {
@@ -7,7 +7,7 @@ pc.extend(pc, function () {
         this.revision = 0;
     };
 
-    Version.prototype = {
+    Object.assign(Version.prototype, {
         equals: function (other) {
             return this.globalId === other.globalId &&
                    this.revision === other.revision;
@@ -27,7 +27,7 @@ pc.extend(pc, function () {
             this.globalId = 0;
             this.revision = 0;
         }
-    };
+    });
 
     return {
         Version: Version

--- a/src/graphics/versioned-object.js
+++ b/src/graphics/versioned-object.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     'use strict';
 
     var idCounter = 0;
@@ -14,12 +14,12 @@ pc.extend(pc, function () {
         this.version.globalId = idCounter;
     };
 
-    VersionedObject.prototype = {
+    Object.assign(VersionedObject.prototype, {
         increment: function () {
             // Increment the revision number
             this.version.revision++;
         }
-    };
+    });
 
     return {
         VersionedObject: VersionedObject

--- a/src/graphics/vertex-buffer.js
+++ b/src/graphics/vertex-buffer.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     'use strict';
 
     /**
@@ -36,7 +36,7 @@ pc.extend(pc, function () {
         this.device.buffers.push(this);
     };
 
-    VertexBuffer.prototype = {
+    Object.assign(VertexBuffer.prototype, {
         /**
          * @function
          * @name pc.VertexBuffer#destroy
@@ -157,7 +157,7 @@ pc.extend(pc, function () {
             this.unlock();
             return true;
         }
-    };
+    });
 
     return {
         VertexBuffer: VertexBuffer

--- a/src/graphics/vertex-format.js
+++ b/src/graphics/vertex-format.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     'use strict';
 
     var _typeSize = [];

--- a/src/graphics/vertex-iterator.js
+++ b/src/graphics/vertex-iterator.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     'use strict';
 
     function VertexIteratorSetter(buffer, vertexElement) {
@@ -86,7 +86,7 @@ pc.extend(pc, function () {
         }
     }
 
-    VertexIterator.prototype = {
+    Object.assign(VertexIterator.prototype, {
         /**
          * @function
          * @name pc.VertexIterator#next
@@ -137,7 +137,7 @@ pc.extend(pc, function () {
             // Unlock the vertex buffer
             this.vertexBuffer.unlock();
         }
-    };
+    });
 
     return {
         VertexIterator: VertexIterator

--- a/src/input/controller.js
+++ b/src/input/controller.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
 
     /**
      * @constructor

--- a/src/input/element-input.js
+++ b/src/input/element-input.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     var targetX, targetY;
     var vecA = new pc.Vec3();
     var vecB = new pc.Vec3();
@@ -82,7 +82,7 @@ pc.extend(pc, function () {
         this._stopPropagation = false;
     };
 
-    ElementInputEvent.prototype = {
+    Object.assign(ElementInputEvent.prototype, {
         /**
          * @function
          * @name pc.ElementInputEvent#stopPropagation
@@ -93,8 +93,7 @@ pc.extend(pc, function () {
             this.event.stopImmediatePropagation();
             this.event.stopPropagation();
         }
-
-    };
+    });
 
     /**
      * @constructor
@@ -215,7 +214,7 @@ pc.extend(pc, function () {
         this.attach(domElement);
     };
 
-    ElementInput.prototype = {
+    Object.assign(ElementInput.prototype, {
         /**
          * @function
          * @name pc.ElementInput#attach
@@ -772,7 +771,7 @@ pc.extend(pc, function () {
 
             return false;
         }
-    };
+    });
 
     Object.defineProperty(ElementInput.prototype, 'enabled', {
         get: function () {

--- a/src/input/game-pads.js
+++ b/src/input/game-pads.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     /**
      * @constructor
      * @name pc.GamePads
@@ -96,7 +96,7 @@ pc.extend(pc, function () {
         'Product: 0268': 'PS3'
     };
 
-    GamePads.prototype = {
+    Object.assign(GamePads.prototype, {
         /**
          * @function
          * @name pc.GamePads#update
@@ -219,7 +219,7 @@ pc.extend(pc, function () {
             }
             return value;
         }
-    };
+    });
 
     return {
         GamePads: GamePads

--- a/src/input/input.js
+++ b/src/input/input.js
@@ -709,9 +709,9 @@
         PAD_R_STICK_Y: 3
     };
 
-    pc.extend(pc, enums);
+    Object.assign(pc, enums);
 
     // For backwards compatibility
     pc.input = {};
-    pc.extend(pc.input, enums);
+    Object.assign(pc.input, enums);
 }());

--- a/src/input/keyboard.js
+++ b/src/input/keyboard.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function (){
+Object.assign(pc, function () {
     /**
      * @constructor
      * @name pc.KeyboardEvent

--- a/src/input/mouse.js
+++ b/src/input/mouse.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     /**
      * @constructor
      * @name pc.MouseEvent
@@ -157,7 +157,7 @@ pc.extend(pc, function () {
         return !!(document.pointerLockElement || document.mozPointerLockElement || document.webkitPointerLockElement);
     };
 
-    Mouse.prototype = {
+    Object.assign(Mouse.prototype, {
         /**
          * @function
          * @name pc.Mouse#attach
@@ -393,7 +393,7 @@ pc.extend(pc, function () {
                 y: event.clientY - top
             };
         }
-    };
+    });
 
     // Public Interface
     return  {

--- a/src/input/touch.js
+++ b/src/input/touch.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     /**
      * @constructor
      * @name pc.Touch
@@ -56,7 +56,7 @@ pc.extend(pc, function () {
         }
     };
 
-    TouchEvent.prototype = {
+    Object.assign(TouchEvent.prototype, {
         /**
          * @function
          * @name pc.TouchEvent#getTouchById
@@ -76,7 +76,7 @@ pc.extend(pc, function () {
 
             return null;
         }
-    };
+    });
 
     /**
      * @constructor
@@ -98,7 +98,7 @@ pc.extend(pc, function () {
         pc.events.attach(this);
     };
 
-    TouchDevice.prototype = {
+    Object.assign(TouchDevice.prototype, {
         /**
          * @function
          * @name pc.TouchDevice#attach
@@ -152,7 +152,7 @@ pc.extend(pc, function () {
         _handleTouchCancel: function (e) {
             this.fire('touchcancel', new TouchEvent(this, e));
         }
-    };
+    });
 
     return {
         /**

--- a/src/math/curve-set.js
+++ b/src/math/curve-set.js
@@ -1,4 +1,4 @@
-pc.extend(pc, (function () {
+Object.assign(pc, (function () {
     'use strict';
 
     /**
@@ -37,7 +37,7 @@ pc.extend(pc, (function () {
         }
     };
 
-    CurveSet.prototype = {
+    Object.assign(CurveSet.prototype, {
         /**
          * @function
          * @name pc.CurveSet#get
@@ -112,8 +112,7 @@ pc.extend(pc, (function () {
 
             return values;
         }
-
-    };
+    });
 
     /**
      * @readonly

--- a/src/math/curve.js
+++ b/src/math/curve.js
@@ -1,4 +1,4 @@
-pc.extend(pc, (function () {
+Object.assign(pc, (function () {
     'use strict';
 
     /**
@@ -51,7 +51,7 @@ pc.extend(pc, (function () {
         this.sort();
     };
 
-    Curve.prototype = {
+    Object.assign(Curve.prototype, {
         /**
          * @function
          * @name pc.Curve#add
@@ -260,7 +260,7 @@ pc.extend(pc, (function () {
 
             return values;
         }
-    };
+    });
 
     Object.defineProperty(Curve.prototype, 'length', {
         get: function () {

--- a/src/math/mat3.js
+++ b/src/math/mat3.js
@@ -1,4 +1,4 @@
-pc.extend(pc, (function () {
+Object.assign(pc, (function () {
     'use strict';
 
     var typeNumber = 'number';
@@ -41,7 +41,7 @@ pc.extend(pc, (function () {
         }
     };
 
-    Mat3.prototype = {
+    Object.assign(Mat3.prototype, {
         /**
          * @function
          * @name pc.Mat3#clone
@@ -200,7 +200,7 @@ pc.extend(pc, (function () {
 
             return this;
         }
-    };
+    });
 
     /**
      * @field

--- a/src/math/mat4.js
+++ b/src/math/mat4.js
@@ -1,4 +1,4 @@
-pc.extend(pc, (function () {
+Object.assign(pc, (function () {
     'use strict';
 
     var typeNumber = 'number';
@@ -55,7 +55,7 @@ pc.extend(pc, (function () {
         }
     };
 
-    Mat4.prototype = {
+    Object.assign(Mat4.prototype, {
         /**
          * @function
          * @name pc.Mat4#add2
@@ -1295,7 +1295,7 @@ pc.extend(pc, (function () {
             t += ']';
             return t;
         }
-    };
+    });
 
     /**
      * @field

--- a/src/math/quat.js
+++ b/src/math/quat.js
@@ -1,4 +1,4 @@
-pc.extend(pc, (function () {
+Object.assign(pc, (function () {
     'use strict';
 
     /**
@@ -82,7 +82,7 @@ pc.extend(pc, (function () {
      * quat.w = 0;
      */
 
-    Quat.prototype = {
+    Object.assign(Quat.prototype, {
         /**
          * @function
          * @name pc.Quat#clone
@@ -702,7 +702,7 @@ pc.extend(pc, (function () {
         toString: function () {
             return '[' + this.x + ', ' + this.y + ', ' + this.z + ', ' + this.w + ']';
         }
-    };
+    });
 
     /**
      * @field

--- a/src/math/vec2.js
+++ b/src/math/vec2.js
@@ -1,4 +1,4 @@
-pc.extend(pc, (function () {
+Object.assign(pc, (function () {
     'use strict';
 
     /**
@@ -23,7 +23,7 @@ pc.extend(pc, (function () {
         this.data[1] = y || 0;
     };
 
-    Vec2.prototype = {
+    Object.assign(Vec2.prototype, {
         /**
          * @function
          * @name pc.Vec2#add
@@ -413,7 +413,7 @@ pc.extend(pc, (function () {
         toString: function () {
             return '[' + this.data[0] + ', ' + this.data[1] + ']';
         }
-    };
+    });
 
     /**
      * @field

--- a/src/math/vec3.js
+++ b/src/math/vec3.js
@@ -1,4 +1,4 @@
-pc.extend(pc, (function () {
+Object.assign(pc, (function () {
     'use strict';
 
     /**
@@ -25,7 +25,7 @@ pc.extend(pc, (function () {
         this.data[2] = z || 0;
     };
 
-    Vec3.prototype = {
+    Object.assign(Vec3.prototype, {
         /**
          * @function
          * @name pc.Vec3#add
@@ -488,7 +488,7 @@ pc.extend(pc, (function () {
         toString: function () {
             return '[' + this.data[0] + ', ' + this.data[1] + ', ' + this.data[2] + ']';
         }
-    };
+    });
 
     /**
      * @name pc.Vec3#x

--- a/src/math/vec4.js
+++ b/src/math/vec4.js
@@ -1,4 +1,4 @@
-pc.extend(pc, (function () {
+Object.assign(pc, (function () {
     'use strict';
 
     /**
@@ -27,7 +27,7 @@ pc.extend(pc, (function () {
         this.data[3] = w || 0;
     };
 
-    Vec4.prototype = {
+    Object.assign(Vec4.prototype, {
         /**
          * @function
          * @name pc.Vec4#add
@@ -441,7 +441,7 @@ pc.extend(pc, (function () {
         toString: function () {
             return '[' + this.data[0] + ', ' + this.data[1] + ', ' + this.data[2] + ', ' + this.data[3] + ']';
         }
-    };
+    });
 
     /**
      * @field

--- a/src/net/http.js
+++ b/src/net/http.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     /**
      * @constructor
      * @name pc.Http
@@ -44,7 +44,7 @@ pc.extend(pc, function () {
         '.dds'
     ];
 
-    Http.prototype = {
+    Object.assign(Http.prototype, {
 
         ContentType: Http.ContentType,
         ResponseType: Http.ResponseType,
@@ -403,7 +403,7 @@ pc.extend(pc, function () {
         _onError: function (method, url, options, xhr) {
             options.callback(xhr.status, null);
         }
-    };
+    });
 
     return {
         Http: Http,

--- a/src/resources/animation.js
+++ b/src/resources/animation.js
@@ -1,10 +1,10 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     'use strict';
 
     var AnimationHandler = function () {
     };
 
-    AnimationHandler.prototype = {
+    Object.assign(AnimationHandler.prototype, {
         load: function (url, callback) {
             pc.http.get(url, function (err, response) {
                 if (err) {
@@ -92,7 +92,7 @@ pc.extend(pc, function () {
 
             return anim;
         }
-    };
+    });
 
     return {
         AnimationHandler: AnimationHandler

--- a/src/resources/audio.js
+++ b/src/resources/audio.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     'use strict';
 
     // checks if user is running IE
@@ -25,7 +25,7 @@ pc.extend(pc, function () {
         this.manager = manager;
     };
 
-    AudioHandler.prototype = {
+    Object.assign(AudioHandler.prototype, {
         _isSupported: function (url) {
             var toMIME = {
                 '.ogg': 'audio/ogg',
@@ -71,7 +71,7 @@ pc.extend(pc, function () {
         open: function (url, data) {
             return data;
         }
-    };
+    });
 
     if (pc.SoundManager.hasAudioContext()) {
         /**

--- a/src/resources/binary.js
+++ b/src/resources/binary.js
@@ -1,11 +1,11 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     'use strict';
 
     var BinaryHandler = function () {
 
     };
 
-    BinaryHandler.prototype = {
+    Object.assign(BinaryHandler.prototype, {
         load: function (url, callback) {
             pc.http.get(url, { responseType: pc.Http.ResponseType.ARRAY_BUFFER }, function (err, response) {
                 if (!err) {
@@ -22,7 +22,7 @@ pc.extend(pc, function () {
 
         patch: function (asset, assets) {
         }
-    };
+    });
 
     return {
         BinaryHandler: BinaryHandler

--- a/src/resources/css.js
+++ b/src/resources/css.js
@@ -1,9 +1,9 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     'use strict';
 
     var CssHandler = function () {};
 
-    CssHandler.prototype = {
+    Object.assign(CssHandler.prototype, {
         load: function (url, callback) {
             pc.http.get(url, function (err, response) {
                 if (!err) {
@@ -20,7 +20,7 @@ pc.extend(pc, function () {
 
         patch: function (asset, assets) {
         }
-    };
+    });
 
     /**
      * @function

--- a/src/resources/cubemap.js
+++ b/src/resources/cubemap.js
@@ -1,11 +1,11 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     var CubemapHandler = function (device, assets, loader) {
         this._device = device;
         this._assets = assets;
         this._loader = loader;
     };
 
-    CubemapHandler.prototype = {
+    Object.assign(CubemapHandler.prototype, {
         load: function (url, callback) { },
 
         open: function (url, data) { },
@@ -189,7 +189,7 @@ pc.extend(pc, function () {
                 }
             });
         }
-    };
+    });
 
     return {
         CubemapHandler: CubemapHandler

--- a/src/resources/folder.js
+++ b/src/resources/folder.js
@@ -1,10 +1,10 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     'use strict';
 
     var FolderHandler = function () {
     };
 
-    FolderHandler.prototype = {
+    Object.assign(FolderHandler.prototype, {
         load: function (url, callback) {
             callback(null, null);
         },
@@ -12,7 +12,7 @@ pc.extend(pc, function () {
         open: function (url, data) {
             return data;
         }
-    };
+    });
 
     return {
         FolderHandler: FolderHandler

--- a/src/resources/font.js
+++ b/src/resources/font.js
@@ -1,11 +1,11 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     'use strict';
 
     var FontHandler = function (loader) {
         this._loader = loader;
     };
 
-    FontHandler.prototype = {
+    Object.assign(FontHandler.prototype, {
         load: function (url, callback, asset) {
             var self = this;
             if (pc.path.getExtension(url) === '.json') {
@@ -94,7 +94,7 @@ pc.extend(pc, function () {
                 asset.data = font.data;
             }
         }
-    };
+    });
 
     return {
         FontHandler: FontHandler

--- a/src/resources/hierarchy.js
+++ b/src/resources/hierarchy.js
@@ -1,11 +1,11 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     'use strict';
 
     var HierarchyHandler = function (app) {
         this._app = app;
     };
 
-    HierarchyHandler.prototype = {
+    Object.assign(HierarchyHandler.prototype, {
         load: function (url, callback) {
             pc.http.get(url, function (err, response) {
                 if (!err) {
@@ -28,7 +28,7 @@ pc.extend(pc, function () {
 
             return parent;
         }
-    };
+    });
 
     return {
         HierarchyHandler: HierarchyHandler

--- a/src/resources/html.js
+++ b/src/resources/html.js
@@ -1,9 +1,9 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     'use strict';
 
     var HtmlHandler = function () {};
 
-    HtmlHandler.prototype = {
+    Object.assign(HtmlHandler.prototype, {
         load: function (url, callback) {
             pc.http.get(url, function (err, response) {
                 if (!err) {
@@ -20,7 +20,7 @@ pc.extend(pc, function () {
 
         patch: function (asset, assets) {
         }
-    };
+    });
 
     return {
         HtmlHandler: HtmlHandler

--- a/src/resources/json.js
+++ b/src/resources/json.js
@@ -1,11 +1,11 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     'use strict';
 
     var JsonHandler = function () {
 
     };
 
-    JsonHandler.prototype = {
+    Object.assign(JsonHandler.prototype, {
         load: function (url, callback) {
             pc.http.get(url, function (err, response) {
                 if (!err) {
@@ -22,7 +22,7 @@ pc.extend(pc, function () {
 
         patch: function (asset, assets) {
         }
-    };
+    });
 
     return {
         JsonHandler: JsonHandler

--- a/src/resources/loader.js
+++ b/src/resources/loader.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     'use strict';
 
     /**
@@ -13,7 +13,7 @@ pc.extend(pc, function () {
         this._cache = {};
     };
 
-    ResourceLoader.prototype = {
+    Object.assign(ResourceLoader.prototype, {
         /**
          * @function
          * @name pc.ResourceLoader#addHandler
@@ -160,7 +160,7 @@ pc.extend(pc, function () {
             this._requests = {};
             this._cache = {};
         }
-    };
+    });
 
     return {
         ResourceLoader: ResourceLoader

--- a/src/resources/material.js
+++ b/src/resources/material.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     'use strict';
 
     var PARAMETER_TYPES = {
@@ -148,7 +148,7 @@ pc.extend(pc, function () {
         this._createPlaceholders();
     };
 
-    MaterialHandler.prototype = {
+    Object.assign(MaterialHandler.prototype, {
         load: function (url, callback) {
             // Loading from URL (engine-only)
             pc.http.get(url, function (err, response) {
@@ -451,7 +451,7 @@ pc.extend(pc, function () {
 
             material.init(data);
         }
-    };
+    });
 
     return {
         MaterialHandler: MaterialHandler,

--- a/src/resources/model.js
+++ b/src/resources/model.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     /**
      * @constructor
      * @name pc.ModelHandler
@@ -17,7 +17,7 @@ pc.extend(pc, function () {
 
     ModelHandler.DEFAULT_MATERIAL = pc.Scene.defaultMaterial;
 
-    ModelHandler.prototype = {
+    Object.assign(ModelHandler.prototype, {
         /**
          * @function
          * @name pc.ModelHandler#load
@@ -136,7 +136,7 @@ pc.extend(pc, function () {
                 decider: decider
             });
         }
-    };
+    });
 
     return {
         ModelHandler: ModelHandler

--- a/src/resources/parser/json-model.js
+++ b/src/resources/parser/json-model.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     'use strict';
 
     var JSON_PRIMITIVE_TYPE = {
@@ -26,7 +26,7 @@ pc.extend(pc, function () {
         this._device = device;
     };
 
-    JsonModelParser.prototype = {
+    Object.assign(JsonModelParser.prototype, {
         parse: function (data) {
             var modelData = data.model;
             if (!modelData) {
@@ -721,7 +721,7 @@ pc.extend(pc, function () {
 
             return meshInstances;
         }
-    };
+    });
 
     return {
         JsonModelParser: JsonModelParser

--- a/src/resources/parser/obj-model.js
+++ b/src/resources/parser/obj-model.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     // Sample Obj model parser. This is not added to built into the engine library by default.
     //
     // To use, first register the parser:
@@ -20,7 +20,7 @@ pc.extend(pc, function () {
         this._device = device;
     };
 
-    ObjModelParser.prototype = {
+    Object.assign(ObjModelParser.prototype, {
         // First draft obj parser
         // probably doesn't handle a lot of the obj spec
         // Known issues:
@@ -127,7 +127,7 @@ pc.extend(pc, function () {
             }
             return result;
         }
-    };
+    });
 
     return {
         ObjModelParser: ObjModelParser

--- a/src/resources/parser/scene.js
+++ b/src/resources/parser/scene.js
@@ -1,11 +1,11 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     'use strict';
 
     var SceneParser = function (app) {
         this._app = app;
     };
 
-    SceneParser.prototype = {
+    Object.assign(SceneParser.prototype, {
         parse: function (data) {
             var entities = {};
             var id, i;
@@ -89,7 +89,7 @@ pc.extend(pc, function () {
 
             return entity;
         }
-    };
+    });
 
     return {
         SceneParser: SceneParser

--- a/src/resources/scene-settings.js
+++ b/src/resources/scene-settings.js
@@ -1,11 +1,11 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     'use strict';
 
     var SceneSettingsHandler = function (app) {
         this._app = app;
     };
 
-    SceneSettingsHandler.prototype = {
+    Object.assign(SceneSettingsHandler.prototype, {
         load: function (url, callback) {
             pc.http.get(url, function (err, response) {
                 if (!err) {
@@ -19,7 +19,7 @@ pc.extend(pc, function () {
         open: function (url, data) {
             return data.settings;
         }
-    };
+    });
 
     return {
         SceneSettingsHandler: SceneSettingsHandler

--- a/src/resources/scene.js
+++ b/src/resources/scene.js
@@ -1,11 +1,11 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     'use strict';
 
     var SceneHandler = function (app) {
         this._app = app;
     };
 
-    SceneHandler.prototype = {
+    Object.assign(SceneHandler.prototype, {
         load: function (url, callback) {
             pc.http.get(url, function (err, response) {
                 if (!err) {
@@ -38,7 +38,7 @@ pc.extend(pc, function () {
 
         patch: function (asset, assets) {
         }
-    };
+    });
 
     return {
         SceneHandler: SceneHandler

--- a/src/resources/script.js
+++ b/src/resources/script.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     'use strict';
 
     /**
@@ -24,7 +24,7 @@ pc.extend(pc, function () {
         }
     };
 
-    ScriptHandler.prototype = {
+    Object.assign(ScriptHandler.prototype, {
         load: function (url, callback) {
             var self = this;
             pc.script.app = this._app;
@@ -96,7 +96,7 @@ pc.extend(pc, function () {
 
             head.appendChild(element);
         }
-    };
+    });
 
     return {
         ScriptHandler: ScriptHandler

--- a/src/resources/shader.js
+++ b/src/resources/shader.js
@@ -1,9 +1,9 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     'use strict';
 
     var ShaderHandler = function () {};
 
-    ShaderHandler.prototype = {
+    Object.assign(ShaderHandler.prototype, {
         load: function (url, callback) {
             pc.http.get(url, function (err, response) {
                 if (!err) {
@@ -20,7 +20,7 @@ pc.extend(pc, function () {
 
         patch: function (asset, assets) {
         }
-    };
+    });
 
     return {
         ShaderHandler: ShaderHandler

--- a/src/resources/sprite.js
+++ b/src/resources/sprite.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     var SpriteHandler = function (assets, device) {
         this._assets = assets;
         this._device = device;
@@ -18,7 +18,7 @@ pc.extend(pc, function () {
         spriteAsset.registry.load(atlasAsset);
     };
 
-    SpriteHandler.prototype = {
+    Object.assign(SpriteHandler.prototype, {
         load: function (url, callback) {
             // if given a json file (probably engine-only use case)
             if (pc.path.getExtension(url) === '.json') {
@@ -108,7 +108,7 @@ pc.extend(pc, function () {
                 }
             }
         }
-    };
+    });
 
     return {
         SpriteHandler: SpriteHandler

--- a/src/resources/text.js
+++ b/src/resources/text.js
@@ -1,11 +1,11 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     'use strict';
 
     var TextHandler = function () {
 
     };
 
-    TextHandler.prototype = {
+    Object.assign(TextHandler.prototype, {
         load: function (url, callback) {
             pc.http.get(url, function (err, response) {
                 if (!err) {
@@ -22,7 +22,7 @@ pc.extend(pc, function () {
 
         patch: function (asset, assets) {
         }
-    };
+    });
 
     return {
         TextHandler: TextHandler

--- a/src/resources/texture-atlas.js
+++ b/src/resources/texture-atlas.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     var JSON_ADDRESS_MODE = {
         "repeat": pc.ADDRESS_REPEAT,
         "clamp": pc.ADDRESS_CLAMP_TO_EDGE,
@@ -20,7 +20,7 @@ pc.extend(pc, function () {
         this._loader = loader;
     };
 
-    TextureAtlasHandler.prototype = {
+    Object.assign(TextureAtlasHandler.prototype, {
         // Load the texture atlas texture using the texture resource loader
         load: function (url, callback) {
             var self = this;
@@ -177,7 +177,7 @@ pc.extend(pc, function () {
                 }
             }
         }
-    };
+    });
 
     return {
         TextureAtlasHandler: TextureAtlasHandler

--- a/src/resources/texture.js
+++ b/src/resources/texture.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     'use strict';
 
     var JSON_ADDRESS_MODE = {
@@ -43,7 +43,7 @@ pc.extend(pc, function () {
         }
     };
 
-    TextureHandler.prototype = {
+    Object.assign(TextureHandler.prototype, {
         load: function (url, callback) {
             var self = this;
             var image;
@@ -312,7 +312,7 @@ pc.extend(pc, function () {
             if (asset.data.hasOwnProperty('rgbm') && texture.rgbm !== rgbm)
                 texture.rgbm = rgbm;
         }
-    };
+    });
 
     return {
         TextureHandler: TextureHandler

--- a/src/scene/basic-material.js
+++ b/src/scene/basic-material.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
 
     /**
      * @constructor
@@ -31,7 +31,7 @@ pc.extend(pc, function () {
 
     BasicMaterial = pc.inherits(BasicMaterial, pc.Material);
 
-    pc.extend(BasicMaterial.prototype, {
+    Object.assign(BasicMaterial.prototype, {
         /**
          * @function
          * @name pc.BasicMaterial#clone

--- a/src/scene/batching.js
+++ b/src/scene/batching.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
 
     // TODO: split by new layers
 
@@ -89,8 +89,7 @@ pc.extend(pc, function () {
         }
     };
 
-    SkinBatchInstance.prototype = {
-
+    Object.assign(SkinBatchInstance.prototype, {
         updateMatrices: function () {
         },
 
@@ -127,7 +126,7 @@ pc.extend(pc, function () {
                 this.boneTexture.unlock();
             }
         }
-    };
+    });
 
     /**
      * @constructor

--- a/src/scene/camera.js
+++ b/src/scene/camera.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     // pre-allocated temp variables
     var _deviceCoord = new pc.Vec3();
     var _far = new pc.Vec3();
@@ -71,7 +71,7 @@ pc.extend(pc, function () {
         this._component = null;
     };
 
-    Camera.prototype = {
+    Object.assign(Camera.prototype, {
         /**
          * @private
          * @function
@@ -272,7 +272,7 @@ pc.extend(pc, function () {
         releaseDepthMap: function () {
             this._renderDepthRequests--;
         }
-    };
+    });
 
     /**
      * @private

--- a/src/scene/depth-material.js
+++ b/src/scene/depth-material.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
 
     /**
      * @private
@@ -11,7 +11,7 @@ pc.extend(pc, function () {
 
     DepthMaterial = pc.inherits(DepthMaterial, pc.Material);
 
-    pc.extend(DepthMaterial.prototype, {
+    Object.assign(DepthMaterial.prototype, {
         /**
          * @private
          * @function

--- a/src/scene/forward-renderer.js
+++ b/src/scene/forward-renderer.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
 
     // Global shadowmap resources
     var scaleShift = new pc.Mat4().mul2(
@@ -449,7 +449,7 @@ pc.extend(pc, function () {
         m3.data[8] = m4.data[10];
     }
 
-    pc.extend(ForwardRenderer.prototype, {
+    Object.assign(ForwardRenderer.prototype, {
 
         sortCompare: function (drawCallA, drawCallB) {
             if (drawCallA.layer === drawCallB.layer) {

--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     var scaleCompensatePosTransform = new pc.Mat4();
     var scaleCompensatePos = new pc.Vec3();
     var scaleCompensateRot = new pc.Quat();
@@ -171,7 +171,7 @@ pc.extend(pc, function () {
         }
     });
 
-    pc.extend(GraphNode.prototype, {
+    Object.assign(GraphNode.prototype, {
         _notifyHierarchyStateChanged: function (node, enabled) {
             node._onHierarchyStateChanged(enabled);
 
@@ -201,7 +201,7 @@ pc.extend(pc, function () {
             for (var i = 0; i < tags.length; i++)
                 clone.tags.add(tags[i]);
 
-            clone._labels = pc.extend(this._labels, {});
+            clone._labels = Object.assign({}, this._labels);
 
             clone.localPosition.copy(this.localPosition);
             clone.localRotation.copy(this.localRotation);

--- a/src/scene/immediate.js
+++ b/src/scene/immediate.js
@@ -1,4 +1,4 @@
-pc.extend(pc.Application.prototype, function () {
+Object.assign(pc.Application.prototype, function () {
 
     var tempGraphNode = new pc.GraphNode();
     var identityGraphNode = new pc.GraphNode();
@@ -49,7 +49,7 @@ pc.extend(pc.Application.prototype, function () {
         this.layer = null;
     };
 
-    LineBatch.prototype = {
+    Object.assign(LineBatch.prototype, {
         init: function (device, vertexFormat, layer, linesToAdd) {
             // Allocate basic stuff once per batch
             if (!this.mesh) {
@@ -118,7 +118,7 @@ pc.extend(pc.Application.prototype, function () {
                 this.linesUsed = 0;
             }
         }
-    };
+    });
 
     function _initImmediate() {
         // Init global line drawing data once

--- a/src/scene/layer-composition.js
+++ b/src/scene/layer-composition.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
 
     /**
      * @constructor

--- a/src/scene/layer.js
+++ b/src/scene/layer.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     var keyA, keyB, sortPos, sortDir;
 
     function sortManual(drawCallA, drawCallB) {

--- a/src/scene/light.js
+++ b/src/scene/light.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
 
     var spotCenter = new pc.Vec3();
     var spotEndPoint = new pc.Vec3();
@@ -78,7 +78,7 @@ pc.extend(pc, function () {
         this._visibleCameraSettings = []; // camera settings used in each directional light pass
     };
 
-    Light.prototype = {
+    Object.assign(Light.prototype, {
         destroy: function () {
             this._destroyShadowMap();
         },
@@ -274,7 +274,7 @@ pc.extend(pc, function () {
 
             this.key = key;
         }
-    };
+    });
 
     Object.defineProperty(Light.prototype, 'enabled', {
         get: function () {

--- a/src/scene/lightmapper.js
+++ b/src/scene/lightmapper.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
 
     var maxSize = 2048;
     var maskBaked = 2;
@@ -103,7 +103,7 @@ pc.extend(pc, function () {
         // #endif
     };
 
-    Lightmapper.prototype = {
+    Object.assign(Lightmapper.prototype, {
 
         calculateLightmapSize: function (node) {
             var data, parent;
@@ -796,7 +796,7 @@ pc.extend(pc, function () {
             stats.fboTime = device._renderTargetCreationTime - startFboTime;
             // #endif
         }
-    };
+    });
 
     return {
         Lightmapper: Lightmapper

--- a/src/scene/material.js
+++ b/src/scene/material.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     var id = 0;
 
     /**

--- a/src/scene/mesh.js
+++ b/src/scene/mesh.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     var id = 0;
     var _tmpAabb = new pc.BoundingBox();
 
@@ -486,7 +486,7 @@ pc.extend(pc, function () {
         }
     });
 
-    pc.extend(MeshInstance.prototype, {
+    Object.assign(MeshInstance.prototype, {
         syncAabb: function () {
             // Deprecated
         },
@@ -530,13 +530,13 @@ pc.extend(pc, function () {
         this._buffer = null;
     };
 
-    InstancingData.prototype = {
+    Object.assign(InstancingData.prototype, {
         update: function () {
             if (this._buffer) {
                 this._buffer.setData(this.buffer);
             }
         }
-    };
+    });
 
     function getKey(layer, blendType, isCommand, materialId) {
         // Key definition:

--- a/src/scene/model.js
+++ b/src/scene/model.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     /**
      * @constructor
      * @name pc.Model
@@ -23,7 +23,7 @@ pc.extend(pc, function () {
         this._shadersVersion = 0;
     };
 
-    Model.prototype = {
+    Object.assign(Model.prototype, {
         getGraph: function () {
             return this.graph;
         },
@@ -269,7 +269,7 @@ pc.extend(pc, function () {
                 mesh.indexBuffer[pc.RENDERSTYLE_WIREFRAME] = wireBuffer;
             }
         }
-    };
+    });
 
     return {
         Model: Model

--- a/src/scene/morph.js
+++ b/src/scene/morph.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     var _morphMin = new pc.Vec3();
     var _morphMax = new pc.Vec3();
 
@@ -59,7 +59,7 @@ pc.extend(pc, function () {
         this._vertSizeF = 0;
     };
 
-    pc.extend(Morph.prototype, {
+    Object.assign(Morph.prototype, {
 
         // called if the mesh is changed
         _setBaseMesh: function (baseMesh) {
@@ -192,7 +192,7 @@ pc.extend(pc, function () {
         this._dirty = true;
     };
 
-    MorphInstance.prototype = {
+    Object.assign(MorphInstance.prototype, {
 
         // called if the mesh is changed
         _setBaseMesh: function (baseMesh) {
@@ -332,7 +332,7 @@ pc.extend(pc, function () {
 
             this._vertexBuffer.unlock();
         }
-    };
+    });
 
     return {
         MorphTarget: MorphTarget,

--- a/src/scene/particle-emitter.js
+++ b/src/scene/particle-emitter.js
@@ -1,5 +1,5 @@
 // Mr F
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     var particleVerts = [
         [-1, -1],
         [1, -1],
@@ -43,6 +43,33 @@ pc.extend(pc, function () {
         return texture;
     };
 
+    function frac(f) {
+        return f - Math.floor(f);
+    }
+
+    function encodeFloatRGBA( v ) {
+        var encX = frac(v);
+        var encY = frac(255.0 * v);
+        var encZ = frac(65025.0 * v);
+        var encW = frac(160581375.0 * v);
+
+        encX -= encY / 255.0;
+        encY -= encZ / 255.0;
+        encZ -= encW / 255.0;
+        encW -= encW / 255.0;
+
+        return [encX, encY, encZ, encW];
+    }
+
+    function encodeFloatRG( v ) {
+        var encX = frac(v);
+        var encY = frac(255.0 * v);
+
+        encX -= encY / 255.0;
+        encY -= encY / 255.0;
+
+        return [encX, encY];
+    }
 
     function saturate(x) {
         return Math.max(Math.min(x, 1), 0);
@@ -391,7 +418,7 @@ pc.extend(pc, function () {
         mat3.data[8] = mat4.data[10];
     }
 
-    ParticleEmitter.prototype = {
+    Object.assign(ParticleEmitter.prototype, {
 
         onChangeCamera: function () {
             this.regenShader();
@@ -1473,37 +1500,9 @@ pc.extend(pc, function () {
             this.shaderParticleUpdateNoRespawn = null;
             this.shaderParticleUpdateOnStop = null;
         }
-    };
+    });
 
     return {
         ParticleEmitter: ParticleEmitter
     };
 }());
-
-function frac(f) {
-    return f - Math.floor(f);
-}
-
-function encodeFloatRGBA( v ) {
-    var encX = frac(v);
-    var encY = frac(255.0 * v);
-    var encZ = frac(65025.0 * v);
-    var encW = frac(160581375.0 * v);
-
-    encX -= encY / 255.0;
-    encY -= encZ / 255.0;
-    encZ -= encW / 255.0;
-    encW -= encW / 255.0;
-
-    return [encX, encY, encZ, encW];
-}
-
-function encodeFloatRG( v ) {
-    var encX = frac(v);
-    var encY = frac(255.0 * v);
-
-    encX -= encY / 255.0;
-    encY -= encY / 255.0;
-
-    return [encX, encY];
-}

--- a/src/scene/pick.js
+++ b/src/scene/pick.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
 
     var _deviceDeprecationWarning = false;
     var _getSelectionDeprecationWarning = false;

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -352,14 +352,14 @@
         ORIENTATION_VERTICAL: 1
     };
 
-    pc.extend(pc, enums);
+    Object.assign(pc, enums);
 
     // For backwards compatibility
     pc.scene = {};
-    pc.extend(pc.scene, enums);
+    Object.assign(pc.scene, enums);
 }());
 
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     /**
      * @constructor
      * @name pc.Scene

--- a/src/scene/skin-partition.js
+++ b/src/scene/skin-partition.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
 
     function PartitionedVertex() {
         this.index = 0;
@@ -25,7 +25,7 @@ pc.extend(pc, function () {
         this.indexMap = {};
     }
 
-    SkinPartition.prototype = {
+    Object.assign(SkinPartition.prototype, {
         addVertex: function (vertex, idx, vertexArray) {
             var remappedIndex = -1;
             if (this.indexMap[idx] !== undefined) {
@@ -101,7 +101,7 @@ pc.extend(pc, function () {
             }
             return -1;
         }
-    };
+    });
 
     function indicesToReferences(model) {
         var i;

--- a/src/scene/skin.js
+++ b/src/scene/skin.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     /**
      * @constructor
      * @name pc.Skin
@@ -76,7 +76,7 @@ pc.extend(pc, function () {
         }
     };
 
-    SkinInstance.prototype = {
+    Object.assign(SkinInstance.prototype, {
 
         updateMatrices: function (rootNode) {
 
@@ -121,7 +121,7 @@ pc.extend(pc, function () {
                 this.boneTexture.unlock();
             }
         }
-    };
+    });
 
     return {
         Skin: Skin,

--- a/src/scene/sprite.js
+++ b/src/scene/sprite.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     'use strict';
 
     /**

--- a/src/scene/standard-material.js
+++ b/src/scene/standard-material.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     /**
      * @constructor
      * @name pc.StandardMaterial
@@ -549,7 +549,6 @@ pc.extend(pc, function () {
     };
 
     var _defineChunks = function (obj) {
-        this._chunks = null;
         Object.defineProperty(StandardMaterial.prototype, "chunks", {
             get: function () {
                 this.dirtyShader = true;
@@ -588,7 +587,7 @@ pc.extend(pc, function () {
 
     StandardMaterial = pc.inherits(StandardMaterial, pc.Material);
 
-    pc.extend(StandardMaterial.prototype, {
+    Object.assign(StandardMaterial.prototype, {
 
         reset: function () {
             this.blendType = pc.BLEND_NONE;

--- a/src/scene/stencil-parameters.js
+++ b/src/scene/stencil-parameters.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     /**
      * @constructor
      * @name pc.StencilParameters

--- a/src/scene/texture-atlas.js
+++ b/src/scene/texture-atlas.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     'use strict';
 
     /**

--- a/src/script/script-registry.js
+++ b/src/script/script-registry.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     /**
      * @constructor
      * @name pc.ScriptRegistry

--- a/src/script/script.js
+++ b/src/script/script.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     var rawToValue = function (app, args, value, old) {
         var i;
 

--- a/src/shape/bounding-box.js
+++ b/src/shape/bounding-box.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     var tmpVecA = new pc.Vec3();
     var tmpVecB = new pc.Vec3();
     var tmpVecC = new pc.Vec3();
@@ -20,7 +20,7 @@ pc.extend(pc, function () {
         this._max = new pc.Vec3();
     };
 
-    BoundingBox.prototype = {
+    Object.assign(BoundingBox.prototype, {
 
         /**
          * @function
@@ -343,7 +343,7 @@ pc.extend(pc, function () {
 
             return sq;
         }
-    };
+    });
 
     return {
         BoundingBox: BoundingBox

--- a/src/shape/bounding-sphere.js
+++ b/src/shape/bounding-sphere.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     var tmpVecA = new pc.Vec3();
     var tmpVecB = new pc.Vec3();
     var tmpVecC = new pc.Vec3();
@@ -20,7 +20,7 @@ pc.extend(pc, function () {
         this.radius = radius === undefined ? 0.5 : radius;
     }
 
-    BoundingSphere.prototype = {
+    Object.assign(BoundingSphere.prototype, {
         containsPoint: function (point) {
             var lenSq = tmpVecA.sub2(point, this.center).lengthSq();
             var r = this.radius;
@@ -118,7 +118,7 @@ pc.extend(pc, function () {
 
             return false;
         }
-    };
+    });
 
     return {
         BoundingSphere: BoundingSphere

--- a/src/shape/frustum.js
+++ b/src/shape/frustum.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     var viewProj = new pc.Mat4();
 
     /**
@@ -25,7 +25,7 @@ pc.extend(pc, function () {
         this.update(projectionMatrix, viewMatrix);
     };
 
-    Frustum.prototype = {
+    Object.assign(Frustum.prototype, {
         /**
          * @function
          * @name pc.Frustum#update
@@ -163,7 +163,7 @@ pc.extend(pc, function () {
 
             return (c === 6) ? 2 : 1;
         }
-    };
+    });
 
     return {
         Frustum: Frustum

--- a/src/shape/oriented-box.js
+++ b/src/shape/oriented-box.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     var tmpRay = new pc.Ray();
     var tmpVec3 = new pc.Vec3();
     var tmpSphere = new pc.BoundingSphere();
@@ -21,7 +21,7 @@ pc.extend(pc, function () {
         this._aabb = new pc.BoundingBox(new pc.Vec3(), this.halfExtents);
     };
 
-    OrientedBox.prototype = {
+    Object.assign(OrientedBox.prototype, {
         /**
          * @function
          * @name pc.OrientedBox#intersectsRay
@@ -72,7 +72,7 @@ pc.extend(pc, function () {
 
             return false;
         }
-    };
+    });
 
     Object.defineProperty(OrientedBox.prototype, 'worldTransform', {
         set: function (value) {

--- a/src/shape/plane.js
+++ b/src/shape/plane.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     var tmpVecA = new pc.Vec3();
 
     /**
@@ -15,7 +15,7 @@ pc.extend(pc, function () {
         this.point = point || new pc.Vec3(0, 0, 0);
     };
 
-    Plane.prototype = {
+    Object.assign(Plane.prototype, {
         /**
          * @function
          * @name pc.Plane#intersectsLine
@@ -56,7 +56,7 @@ pc.extend(pc, function () {
 
             return intersects;
         }
-    };
+    });
 
     return {
         Plane: Plane

--- a/src/shape/ray.js
+++ b/src/shape/ray.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     /**
      * @constructor
      * @name pc.Ray

--- a/src/sound/instance.js
+++ b/src/sound/instance.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     'use strict';
 
     var SoundInstance;
@@ -110,7 +110,7 @@ pc.extend(pc, function () {
             this.source = null;
         };
 
-        SoundInstance.prototype = {
+        Object.assign(SoundInstance.prototype, {
             /**
              * @function
              * @private
@@ -463,7 +463,7 @@ pc.extend(pc, function () {
                     this.source = null;
                 }
             }
-        };
+        });
 
         Object.defineProperty(SoundInstance.prototype, 'volume', {
             get: function () {
@@ -614,7 +614,7 @@ pc.extend(pc, function () {
             this._createSource();
         };
 
-        SoundInstance.prototype = {
+        Object.assign(SoundInstance.prototype, {
             play: function () {
                 if (this._state !== STATE_STOPPED) {
                     this.stop();
@@ -779,7 +779,7 @@ pc.extend(pc, function () {
                     this.source.pause();
                 }
             }
-        };
+        });
 
         Object.defineProperty(SoundInstance.prototype, 'volume', {
             get: function () {
@@ -861,7 +861,7 @@ pc.extend(pc, function () {
     }
 
     // Add functions which don't depend on source type
-    pc.extend(SoundInstance.prototype, {
+    Object.assign(SoundInstance.prototype, {
 
         _onPlay: function () {
             this.fire('play');

--- a/src/sound/instance3d.js
+++ b/src/sound/instance3d.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     'use strict';
 
     // default maxDistance, same as Web Audio API
@@ -50,7 +50,7 @@ pc.extend(pc, function () {
         };
         SoundInstance3d = pc.inherits(SoundInstance3d, pc.SoundInstance);
 
-        SoundInstance3d.prototype = pc.extend(SoundInstance3d.prototype, {
+        Object.assign(SoundInstance3d.prototype, {
             _initializeNodes: function () {
                 this.gain = this._manager.context.createGain();
                 this.panner = this._manager.context.createPanner();

--- a/src/sound/listener.js
+++ b/src/sound/listener.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     'use strict';
 
     /**
@@ -18,7 +18,7 @@ pc.extend(pc, function () {
         }
     };
 
-    Listener.prototype = {
+    Object.assign(Listener.prototype, {
         getPosition: function () {
             return this.position;
         },
@@ -52,7 +52,7 @@ pc.extend(pc, function () {
         getOrientation: function () {
             return this.orientation;
         }
-    };
+    });
 
     return {
         Listener: Listener

--- a/src/sound/manager.js
+++ b/src/sound/manager.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     'use strict';
 
     /**
@@ -80,7 +80,7 @@ pc.extend(pc, function () {
     SoundManager.hasAudio = hasAudio;
     SoundManager.hasAudioContext = hasAudioContext;
 
-    SoundManager.prototype = {
+    Object.assign(SoundManager.prototype, {
 
         suspend: function  () {
             this.suspended = true;
@@ -178,7 +178,7 @@ pc.extend(pc, function () {
 
             return channel;
         }
-    };
+    });
 
     Object.defineProperty(SoundManager.prototype, 'volume', {
         get: function () {

--- a/src/sound/sound.js
+++ b/src/sound/sound.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     'use strict';
 
     /**

--- a/src/vr/vr-display.js
+++ b/src/vr/vr-display.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     /**
      * @constructor
      * @name pc.VrDisplay
@@ -99,7 +99,7 @@ pc.extend(pc, function () {
         pc.events.attach(this);
     };
 
-    VrDisplay.prototype = {
+    Object.assign(VrDisplay.prototype, {
         /**
          * @function
          * @name pc.VrDisplay#destroy
@@ -310,7 +310,7 @@ pc.extend(pc, function () {
         getFrameData: function () {
             if (this.display) return this._frameData;
         }
-    };
+    });
 
     Object.defineProperty(VrDisplay.prototype, "capabilities", {
         get: function () {

--- a/src/vr/vr-manager.js
+++ b/src/vr/vr-manager.js
@@ -1,4 +1,4 @@
-pc.extend(pc, function () {
+Object.assign(pc, function () {
     /**
      * @constructor
      * @name pc.VrManager
@@ -86,7 +86,7 @@ pc.extend(pc, function () {
      */
     VrManager.usesPolyfill = !!window.InitializeWebVRPolyfill;
 
-    VrManager.prototype = {
+    Object.assign(VrManager.prototype, {
         _attach: function () {
             window.addEventListener('vrdisplayconnect', this._onDisplayConnect);
             window.addEventListener('vrdisplaydisconnect', this._onDisplayDisconnect);
@@ -185,7 +185,7 @@ pc.extend(pc, function () {
 
             this.fire('displaydisconnect', display);
         }
-    };
+    });
 
     return {
         VrManager: VrManager


### PR DESCRIPTION
* Use browser-native Object.assign instead of pc.extend.
* Remove all pollution of global namespace (leaving only 'pc').
* Ensure the constructor property is available on all PlayCanvas object prototypes.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
