### PR TITLE
[Bugfix] line batch do not destroy old vertex buffer

### DIFF
--- a/src/scene/immediate.js
+++ b/src/scene/immediate.js
@@ -69,7 +69,10 @@ Object.assign(pc.Application.prototype, function () {
 
             // Increase buffer size, if it's not enough
             while ((this.linesUsed + linesToAdd) > this.numLinesAllocated) {
-                this.vb = null;
+                if (this.vb) {
+                    this.vb.destroy();
+                    this.vb = null;
+                }
                 this.numLinesAllocated *= 2;
             }
 


### PR DESCRIPTION
When increase line batch's vertex buffer size, we should destroy the old vertex buffer before create a new one.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
