### PR TITLE
[FIX] Correctly undirty WebGL 2 related texture properties.

### DIFF
--- a/src/graphics/device.js
+++ b/src/graphics/device.js
@@ -1632,16 +1632,18 @@ Object.assign(pc, function () {
                     }
                     texture._addressVDirty = false;
                 }
-                if (this.webgl2) {
-                    if (texture._addressWDirty) {
+                if (texture._addressWDirty) {
+                    if (this.webgl2) {
                         gl.texParameteri(texture._glTarget, gl.TEXTURE_WRAP_R, this.glAddress[texture._addressW]);
-                        texture._addressWDirty = false;
                     }
-                    if (texture._compareModeDirty) {
+                    texture._addressWDirty = false;
+                }
+                if (texture._compareModeDirty) {
+                    if (this.webgl2) {
                         gl.texParameteri(texture._glTarget, gl.TEXTURE_COMPARE_MODE, texture._compareOnRead ? gl.COMPARE_REF_TO_TEXTURE : gl.NONE);
                         gl.texParameteri(texture._glTarget, gl.TEXTURE_COMPARE_FUNC, this.glComparison[texture._compareFunc]);
-                        texture._compareModeDirty = false;
                     }
+                    texture._compareModeDirty = false;
                 }
                 if (texture._anisotropyDirty) {
                     var ext = this.extTextureFilterAnisotropic;


### PR DESCRIPTION
Under WebGL 1.0, the pc.Texture#compareMode property would always be marked as dirty and therefore the texture would always be set regardless of whether it was already set on a texture unit. This did not affect WebGL 2.0.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
