### PR TITLE
Remove all redundant calls to gl.bindTexture.

### DIFF
--- a/src/graphics/device.js
+++ b/src/graphics/device.js
@@ -310,6 +310,12 @@ Object.assign(pc, function () {
                 gl.FLOAT
             ];
 
+            this.targetToSlot = {
+                gl.TEXTURE_2D: 0,
+                gl.TEXTURE_CUBE_MAP: 1,
+                gl.TEXTURE_3D: 2
+            };
+
             // Define the uniform commit functions
             var scopeX, scopeY, scopeZ, scopeW;
             var uniformValue;
@@ -425,7 +431,7 @@ Object.assign(pc, function () {
             pc.events.attach(this);
 
             this.supportsBoneTextures = this.extTextureFloat && this.maxVertexTextures > 0;
-            this.useTexCubeLod = this.extTextureLod && this.samplerCount < 16;
+            this.useTexCubeLod = this.extTextureLod && this.maxTextures < 16;
 
             // Calculate an estimate of the maximum number of bones that can be uploaded to the GPU
             // based on the number of available uniforms and the number of uniforms required for non-
@@ -666,7 +672,8 @@ Object.assign(pc, function () {
             this.maxTextureSize = gl.getParameter(gl.MAX_TEXTURE_SIZE);
             this.maxCubeMapSize = gl.getParameter(gl.MAX_CUBE_MAP_TEXTURE_SIZE);
             this.maxRenderBufferSize = gl.getParameter(gl.MAX_RENDERBUFFER_SIZE);
-            this.samplerCount = gl.getParameter(gl.MAX_TEXTURE_IMAGE_UNITS);
+            this.maxTextures = gl.getParameter(gl.MAX_TEXTURE_IMAGE_UNITS);
+            this.maxCombinedTextures = gl.getParameter(gl.MAX_COMBINED_TEXTURE_IMAGE_UNITS);
             this.maxVertexTextures = gl.getParameter(gl.MAX_VERTEX_TEXTURE_IMAGE_UNITS);
             this.vertexUniformsCount = gl.getParameter(gl.MAX_VERTEX_UNIFORM_VECTORS);
             this.fragmentUniformsCount = gl.getParameter(gl.MAX_FRAGMENT_UNIFORM_VECTORS);
@@ -804,7 +811,10 @@ Object.assign(pc, function () {
                 texture.dirtyAll();
             }
             this.activeTexture = 0;
-            this.textureUnits = [];
+            this.textureUnits.length = 0;
+            for (i = 0; i < this.maxCombinedTextures; i++) {
+                this.textureUnits.push([null, null, null]);
+            }
 
             // Reset all render targets so they'll be recreated as required.
             // TODO: a solution for the case where a render target contains something
@@ -1143,10 +1153,6 @@ Object.assign(pc, function () {
             } else {
                 this.setFramebuffer(null);
             }
-
-            for (var i = 0; i < 16; i++) {
-                this.textureUnits[i] = null;
-            }
         },
 
         /**
@@ -1165,7 +1171,7 @@ Object.assign(pc, function () {
                 // If the active render target is auto-mipmapped, generate its mip chain
                 var colorBuffer = target._colorBuffer;
                 if (colorBuffer && colorBuffer._glTextureId && colorBuffer.mipmaps && colorBuffer._pot) {
-                    gl.bindTexture(colorBuffer._glTarget, colorBuffer._glTextureId);
+                    this.bindTexture(this.maxCombinedTextures - 1, colorBuffer._glTarget, colorBuffer._glTextureId);
                     gl.generateMipmap(colorBuffer._glTarget);
                 }
 
@@ -1184,7 +1190,6 @@ Object.assign(pc, function () {
 
             texture._glTarget = texture._cubemap ? gl.TEXTURE_CUBE_MAP :
                 (texture._volume ? gl.TEXTURE_3D : gl.TEXTURE_2D);
-
 
             switch (texture._format) {
                 case pc.PIXELFORMAT_A8:
@@ -1578,25 +1583,30 @@ Object.assign(pc, function () {
             // #endif
         },
 
+        bindTexture: function (textureUnit, textureTarget, textureObject) {
+            var slot = this.targetToSlot[textureTarget];
+
+            if (this.textureUnits[textureUnit][slot] !== textureObject) {
+                if (this.activeTexture !== textureUnit) {
+                    gl.activeTexture(gl.TEXTURE0 + textureUnit);
+                    this.activeTexture = textureUnit;
+                }
+                gl.bindTexture(textureTarget, textureObject);
+                this.textureUnits[textureUnit][slot] = textureObject;
+            }
+        },
+
         setTexture: function (texture, textureUnit) {
             var gl = this.gl;
 
             if (!texture._glTextureId)
                 this.initializeTexture(texture);
 
+            this.bindTexture(textureUnit, texture._glTarget, texture._glTextureId);
+
             var paramDirty = texture._minFilterDirty || texture._magFilterDirty ||
                              texture._addressUDirty || texture._addressVDirty || texture._addressWDirty ||
                              texture._anisotropyDirty || texture._compareModeDirty;
-
-            if ((this.textureUnits[textureUnit] !== texture) || paramDirty) {
-                if (this.activeTexture !== textureUnit) {
-                    gl.activeTexture(gl.TEXTURE0 + textureUnit);
-                    this.activeTexture = textureUnit;
-                }
-                gl.bindTexture(texture._glTarget, texture._glTextureId);
-                this.textureUnits[textureUnit] = texture;
-            }
-
             if (paramDirty) {
                 if (texture._minFilterDirty) {
                     var filter = texture._minFilter;


### PR DESCRIPTION
Previously, the engine assumed that you could only bind a single texture to a texture unit. But actually, WebGL maintains state for one texture _per texture target_ (gl.TEXTURE_2D, gl.TEXTURE_CUBE_MAP and gl.TEXTURE_3D) on each texture unit. This means that the engine's shadow state of WebGL wasn't accurate and would result in redundant sets via gl.bindTexture.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
