### PR TITLE
Clear visible instances lists when removing a camera from a layer

### DIFF
--- a/src/scene/layer.js
+++ b/src/scene/layer.js
@@ -51,6 +51,18 @@ Object.assign(pc, function () {
         this.visibleTransparent = [];
     };
 
+    InstanceList.prototype.clearVisibleLists = function (cameraPass) {
+        if (this.visibleOpaque[cameraPass]) {
+            this.visibleOpaque[cameraPass].length = 0;
+            this.visibleOpaque[cameraPass].list.length = 0;
+        }
+
+        if (this.visibleTransparent[cameraPass]) {
+            this.visibleTransparent[cameraPass].length = 0;
+            this.visibleTransparent[cameraPass].list.length = 0;
+        }
+    };
+
     /**
      * @constructor
      * @name pc.Layer
@@ -617,6 +629,10 @@ Object.assign(pc, function () {
         if (id < 0) return;
         this.cameras.splice(id, 1);
         this._generateCameraHash();
+
+        // visible lists in layer are not updated after camera is removed
+        // so clear out any remaining mesh instances
+        this.instances.clearVisibleLists(id);
     };
 
     /**


### PR DESCRIPTION
Prevent memory leak where visible instance lists held onto all mesh instances that were rendered in a camera after camera is removed from a layer.
