### PR TITLE
Remove IE11 workaround for no UNSIGNED_BYTE support for vertexAttribPointer

### DIFF
--- a/src/graphics/device.js
+++ b/src/graphics/device.js
@@ -64,18 +64,6 @@ Object.assign(pc, function () {
         return true;
     }
 
-    function testUnsignedByteAttribute(gl) {
-        var storage = new ArrayBuffer(16);
-        var bufferId = gl.createBuffer();
-        gl.bindBuffer(gl.ARRAY_BUFFER, bufferId);
-        gl.bufferData(gl.ARRAY_BUFFER, storage, gl.STATIC_DRAW);
-        gl.getError(); // Clear error flag
-        gl.vertexAttribPointer(0, 4, gl.UNSIGNED_BYTE, false, 4, 0);
-        var supported = (gl.getError() === 0);
-        gl.deleteBuffer(bufferId);
-        return supported;
-    }
-
     /**
      * @readonly
      * @name pc.GraphicsDevice#precision
@@ -488,9 +476,6 @@ Object.assign(pc, function () {
                 materialShaders: 0,
                 compileTime: 0
             };
-
-            // Handle IE11's inability to take UNSIGNED_BYTE as a param for vertexAttribPointer
-            this.supportsUnsignedByte = testUnsignedByteAttribute(gl);
 
             this.constantTexSource = this.scope.resolve("source");
 

--- a/src/resources/parser/json-model.js
+++ b/src/resources/parser/json-model.js
@@ -548,20 +548,10 @@ Object.assign(pc, function () {
                 for (attributeName in vertexData) {
                     attribute = vertexData[attributeName];
 
-                    var attribType = attribute.type;
-                    if (!this._device.supportsUnsignedByte) {
-                        if (attribType === "uint8") {
-                            attribType = "float32";
-                        }
-                        if (attribType === "int8") {
-                            attribType = "float32";
-                        }
-                    }
-
                     formatDesc.push({
                         semantic: attributeMap[attributeName],
                         components: attribute.components,
-                        type: JSON_VERTEX_ELEMENT_TYPE[attribType],
+                        type: JSON_VERTEX_ELEMENT_TYPE[attribute.type],
                         normalize: (attributeMap[attributeName] === pc.SEMANTIC_COLOR)
                     });
                 }

--- a/src/scene/standard-material.js
+++ b/src/scene/standard-material.js
@@ -721,8 +721,9 @@ Object.assign(pc, function () {
         },
 
         _setParameter: function (name, value) {
+            if (!this.parameters[name])
+                 this._propsSet.push(name);
             this.setParameter(name, value);
-            this._propsSet.push(name);
         },
 
         _clearParameters: function () {
@@ -759,6 +760,7 @@ Object.assign(pc, function () {
         },
 
         update: function () {
+            var uniform;
             this._clearParameters();
 
             this._setParameter('material_ambient', this.ambientUniform);
@@ -777,7 +779,8 @@ Object.assign(pc, function () {
                 }
             }
 
-            this._setParameter(this.getUniform("shininess", this.shininess, true));
+            uniform = this.getUniform("shininess", this.shininess, true);
+            this._setParameter(uniform.name, uniform.value);
 
             if (!this.emissiveMap || this.emissiveTint) {
                 this._setParameter('material_emissive', this.emissiveUniform);
@@ -814,7 +817,8 @@ Object.assign(pc, function () {
             }
 
             if (this.heightMap) {
-                this._setParameter(this.getUniform('heightMapFactor', this.heightMapFactor, true));
+                uniform = this.getUniform('heightMapFactor', this.heightMapFactor, true);
+                this._setParameter(uniform.name, uniform.value);
             }
 
             if (this.cubeMap) {

--- a/src/scene/standard-material.js
+++ b/src/scene/standard-material.js
@@ -721,9 +721,8 @@ Object.assign(pc, function () {
         },
 
         _setParameter: function (name, value) {
-            if (!this.parameters[name])
-                 this._propsSet.push(name);
             this.setParameter(name, value);
+            this._propsSet.push(name);
         },
 
         _clearParameters: function () {
@@ -760,7 +759,6 @@ Object.assign(pc, function () {
         },
 
         update: function () {
-            var uniform;
             this._clearParameters();
 
             this._setParameter('material_ambient', this.ambientUniform);
@@ -779,8 +777,7 @@ Object.assign(pc, function () {
                 }
             }
 
-            uniform = this.getUniform("shininess", this.shininess, true);
-            this._setParameter(uniform.name, uniform.value);
+            this._setParameter(this.getUniform("shininess", this.shininess, true));
 
             if (!this.emissiveMap || this.emissiveTint) {
                 this._setParameter('material_emissive', this.emissiveUniform);
@@ -817,8 +814,7 @@ Object.assign(pc, function () {
             }
 
             if (this.heightMap) {
-                uniform = this.getUniform('heightMapFactor', this.heightMapFactor, true);
-                this._setParameter(uniform.name, uniform.value);
+                this._setParameter(this.getUniform('heightMapFactor', this.heightMapFactor, true));
             }
 
             if (this.cubeMap) {


### PR DESCRIPTION
No longer required as IE 11.0.3 fixed this in Feb 2014.

Also, removing this shaves several ms off the graphics device constructor.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
