### PR TITLE
Fix entity references not resolved when Entity#clone() is called

### DIFF
--- a/src/framework/components/button/component.js
+++ b/src/framework/components/button/component.js
@@ -431,6 +431,7 @@ Object.assign(pc, function () {
         },
 
         onEnable: function () {
+            this._imageReference.onParentComponentEnable();
             this._toggleHitElementListeners('on');
             this._forceReapplyVisualState();
         },

--- a/src/framework/components/scroll-view/component.js
+++ b/src/framework/components/scroll-view/component.js
@@ -470,6 +470,10 @@ Object.assign(pc, function () {
         },
 
         onEnable: function () {
+            this._viewportReference.onParentComponentEnable();
+            this._contentReference.onParentComponentEnable();
+            this._scrollbarReferences[pc.ORIENTATION_HORIZONTAL].onParentComponentEnable();
+            this._scrollbarReferences[pc.ORIENTATION_VERTICAL].onParentComponentEnable();
             this._setScrollbarComponentsEnabled(true);
             this._setContentDraggingEnabled(true);
 

--- a/src/framework/components/scrollbar/component.js
+++ b/src/framework/components/scrollbar/component.js
@@ -155,6 +155,7 @@ Object.assign(pc, function () {
         },
 
         onEnable: function () {
+            this._handleReference.onParentComponentEnable();
             this._setHandleDraggingEnabled(true);
         },
 

--- a/src/framework/utils/entity-reference.js
+++ b/src/framework/utils/entity-reference.js
@@ -219,6 +219,20 @@ Object.assign(pc, function () {
             this._updateEntityReference();
         },
 
+        /**
+         * Must be called from the parent component's onEnable() method in order for entity
+         * references to be correctly resolved when {@link pc.Entity#clone} is called.
+         */
+        onParentComponentEnable: function() {
+            // When an entity is cloned via the JS API, we won't be able to resolve the
+            // entity reference until the cloned entity has been added to the scene graph.
+            // We can detect this by waiting for the parent component to be enabled, in the
+            // specific case where we haven't yet been able to resolve an entity reference.
+            if (!this._entity) {
+                this._updateEntityReference();
+            }
+        },
+
         // When running within the editor, postInitialize is fired before the scene graph
         // has been fully constructed. As such we use the special tools:sceneloaded event
         // in order to know when the graph is ready to traverse.
@@ -236,7 +250,10 @@ Object.assign(pc, function () {
                 nextEntityGuid = nextEntity.getGuid();
                 this._parentComponent.data[this._entityPropertyName] = nextEntityGuid;
             } else {
-                nextEntity = nextEntityGuid ? this._parentComponent.system.app.root.findByGuid(nextEntityGuid) : null;
+                var root = this._parentComponent.system.app.root;
+                var isOnSceneGraph = this._parentComponent.entity.isDescendantOf(root);
+
+                nextEntity = (isOnSceneGraph && nextEntityGuid) ? root.findByGuid(nextEntityGuid) : null;
             }
 
             var hasChanged = this._entity !== nextEntity;

--- a/tests/framework/utils/test_entityreference.js
+++ b/tests/framework/utils/test_entityreference.js
@@ -50,6 +50,31 @@
         strictEqual(reference.entity, this.otherEntity1);
     });
 
+    test("does not attempt to resolve the entity reference if the parent component is not on the scene graph yet", function () {
+        this.app.root.removeChild(this.testEntity);
+
+        sinon.spy(this.app.root, "findByGuid");
+
+        var reference = new pc.EntityReference(this.testComponent, "myEntity1");
+        this.testComponent.myEntity1 = this.otherEntity1.getGuid();
+
+        strictEqual(reference.entity, null);
+        strictEqual(this.app.root.findByGuid.callCount, 0);
+    });
+
+    test("resolves the entity reference when onParentComponentEnable() is called", function () {
+        this.app.root.removeChild(this.testEntity);
+
+        var reference = new pc.EntityReference(this.testComponent, "myEntity1");
+        this.testComponent.myEntity1 = this.otherEntity1.getGuid();
+        strictEqual(reference.entity, null);
+
+        this.app.root.addChild(this.testEntity);
+        reference.onParentComponentEnable();
+
+        strictEqual(reference.entity, this.otherEntity1);
+    });
+
     test("nullifies the reference when the guid is nullified", function () {
         var reference = new pc.EntityReference(this.testComponent, "myEntity1");
         this.testComponent.myEntity1 = this.otherEntity1.getGuid();


### PR DESCRIPTION
Fixes the majority of issues reported in https://github.com/playcanvas/engine/issues/1263.

When entities are cloned via `Entity#clone()`, any entity reference properties that refer to entities within the cloned object's own subtree will not be retrievable via `root.findByGuid()` until the cloned entity has been added to the scene graph. This change addresses that by deferring the call to `root.findByGuid()` until the cloned entity has been added to the graph.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
