### PR TITLE
Don't request tangents if the mesh doesn't have them.

### DIFF
--- a/src/graphics/program-lib/standard.js
+++ b/src/graphics/program-lib/standard.js
@@ -412,7 +412,7 @@ pc.programlib.standard = {
                 codeBody += "   vNormalV    = getViewNormal();\n";
             }
 
-            if (options.heightMap || options.normalMap) {
+            if ((options.heightMap || options.normalMap) && options.hasTangents) {
                 attributes.vertex_tangent = pc.SEMANTIC_TANGENT;
                 code += chunks.tangentBinormalVS;
                 codeBody += "   vTangentW   = getTangent();\n";
@@ -1036,7 +1036,7 @@ pc.programlib.standard = {
             } else {
                 code += "   dVertexNormalW = vNormalW;\n";
             }
-            if (options.heightMap || options.normalMap) {
+            if ((options.heightMap || options.normalMap) && options.hasTangents) {
                 if (options.twoSidedLighting) {
                     code += "   dTangentW = gl_FrontFacing ? vTangentW : -vTangentW;\n";
                     code += "   dBinormalW = gl_FrontFacing ? vBinormalW : -vBinormalW;\n";


### PR DESCRIPTION
Currently, if derivative mapping is used, the shader generator still requests the tangent attribute and passes the tangent to the fragment shader via a varying. This PR prevents that.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
