### PR TITLE
Add meshAsset property to particlesystem

### DIFF
--- a/src/framework/components/particle-system/data.js
+++ b/src/framework/components/particle-system/data.js
@@ -28,6 +28,7 @@ Object.assign(pc, function () {
         this.stretch = 0.0;
         this.alignToMotion = false;
         this.depthSoftening = 0;
+        this.meshAsset = null;
         this.mesh = null;                       // Mesh to be used as particle. Vertex buffer is supposed to hold vertex position in first 3 floats of each vertex
                                                 // Leave undefined to use simple quads
         this.depthWrite = false;

--- a/src/framework/components/particle-system/system.js
+++ b/src/framework/components/particle-system/system.js
@@ -30,6 +30,7 @@ Object.assign(pc, function () {
         'colorMapAsset',
         'normalMapAsset',
         'mesh',
+        'meshAsset',
         'localVelocityGraph',
         'localVelocityGraph2',
         'velocityGraph',
@@ -105,6 +106,14 @@ Object.assign(pc, function () {
             properties = [];
             var types = this.propertyTypes;
             var type;
+
+            // we store the mesh asset id as "mesh" (it should be "meshAsset")
+            // this re-maps "mesh" into "meshAsset" if it is an asset or an asset id
+            if (_data['mesh'] instanceof pc.Asset || typeof _data['mesh'] === 'number') {
+                // migrate into meshAsset property
+                _data['meshAsset'] = _data['mesh'];
+                delete _data['mesh'];
+            }
 
             for (var prop in _data) {
                 if (_data.hasOwnProperty(prop)) {

--- a/tests/framework/components/particlesystem/test_particlesystemcomponent.js
+++ b/tests/framework/components/particlesystem/test_particlesystemcomponent.js
@@ -1,0 +1,75 @@
+module("pc.ParticleSystemComponent", {
+    setup: function () {
+        this.app = new pc.Application(document.createElement('canvas'));
+    },
+
+    teardown: function () {
+        this.app.destroy();
+    },
+
+    loadAsset: function (name, url, type, callback) {
+        var asset = new pc.Asset(name, type, {
+            url: url
+        });
+
+        this.app.assets.add(asset);
+
+        this.app.assets.once("load", callback, this);
+
+        this.app.assets.load(asset);
+    }
+});
+
+test("Add particlesystem", function () {
+    var e = new pc.Entity();
+
+    e.addComponent("particlesystem");
+
+    ok(e.particlesystem);
+});
+
+test("Remove particlesystem", function () {
+    var e = new pc.Entity();
+
+    e.addComponent("particlesystem");
+    e.removeComponent("particlesystem");
+
+    ok(!e.particlesystem);
+});
+
+test("colorMapAsset removes events", function () {
+    var e = new pc.Entity();
+
+    stop();
+
+    this.loadAsset('RedPng', '../../../test-assets/sprite/red-atlas.png', 'texture', function (asset) {
+        start();
+
+        e.addComponent('particlesystem', {
+            colorMapAsset: asset.id
+        });
+
+        e.removeComponent('particlesystem');
+
+
+        equal(asset.hasEvent('remove'), false);
+    });
+});
+
+test("meshAsset removes events", function () {
+    var e = new pc.Entity();
+
+    stop();
+
+    this.loadAsset('Box', '../../../test-assets/box/box.json', 'model', function (asset) {
+        start();
+
+        e.addComponent('particlesystem', {
+            mesh: asset.id
+        });
+
+        e.removeComponent('particlesystem');
+
+        equal(asset.hasEvent('remove'), false);
+    });
+});


### PR DESCRIPTION
Add meshAsset which should be used instead of mesh property for assets

Patch "mesh" property to handle being set as asset or mesh
Fixes memory leak with uncleared event handlers.
