### PR TITLE
More comprehensive destruction of textures.

### DIFF
--- a/src/graphics/texture.js
+++ b/src/graphics/texture.js
@@ -170,8 +170,6 @@ Object.assign(pc, function () {
         this.dirtyAll();
 
         this._gpuSize = 0;
-
-        this.device.textures.push(this);
     };
 
     // Public properties
@@ -579,34 +577,11 @@ Object.assign(pc, function () {
          * @description Forcibly free up the underlying WebGL resource owned by the texture.
          */
         destroy: function () {
-            var device = this.device;
-            var idx = device.textures.indexOf(this);
-            if (idx !== -1) {
-                device.textures.splice(idx, 1);
-            }
-
-            if (this._glTextureId) {
-                var gl = this.device.gl;
-                gl.deleteTexture(this._glTextureId);
-
-                this.device._vram.tex -= this._gpuSize;
-                // #ifdef PROFILER
-                if (this.profilerHint === pc.TEXHINT_SHADOWMAP) {
-                    this.device._vram.texShadow -= this._gpuSize;
-                } else if (this.profilerHint === pc.TEXHINT_ASSET) {
-                    this.device._vram.texAsset -= this._gpuSize;
-                } else if (this.profilerHint === pc.TEXHINT_LIGHTMAP) {
-                    this.device._vram.texLightmap -= this._gpuSize;
-                }
-                // #endif
-
-                this._glTextureId = null;
-            }
+            this.device.destroyTexture(this);
         },
 
         // Force a full resubmission of the texture to WebGL (used on a context restore event)
         dirtyAll: function () {
-            this._glTextureId = undefined;
             this._levelsUpdated = this._cubemap ? [[true, true, true, true, true, true]] : [true];
 
             this._needsUpload = true;


### PR DESCRIPTION
Refactor of texture destruction. All WebGL related properties for textures moved to device.js. Texture unit shadow state no longer retains destroyed textures.

Fixes #1288.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
