### PR TITLE
Texture fixes

### DIFF
--- a/src/graphics/device.js
+++ b/src/graphics/device.js
@@ -1164,7 +1164,8 @@ Object.assign(pc, function () {
                 // If the active render target is auto-mipmapped, generate its mip chain
                 var colorBuffer = target._colorBuffer;
                 if (colorBuffer && colorBuffer._glTexture && colorBuffer.mipmaps && colorBuffer._pot) {
-                    this.bindTexture(this.maxCombinedTextures - 1, colorBuffer._glTarget, colorBuffer._glTexture);
+                    this.activeTexture(this.maxCombinedTextures - 1);
+                    this.bindTexture(colorBuffer);
                     gl.generateMipmap(colorBuffer._glTarget);
                 }
 

--- a/src/graphics/device.js
+++ b/src/graphics/device.js
@@ -61,6 +61,9 @@ Object.assign(pc, function () {
     }
 
     function testTextureFloatHighPrecision(device) {
+        if (!this.textureFloatRenderable)
+            return false;
+
         var gl = device.gl;
         var chunks = pc.shaderChunks;
         var test1 = chunks.createShaderFromCode(device, chunks.fullscreenQuadVS, chunks.precisionTestPS, "ptest1");
@@ -1358,7 +1361,15 @@ Object.assign(pc, function () {
                     this.textures.splice(idx, 1);
                 }
 
-                // Update shadowed texture unit state to remove texture from current unit
+                // Remove texture from any uniforms
+                for (var uniformName in this.scope.variables) {
+                    var uniform = this.scope.variables[uniformName];
+                    if (uniform.value === texture) {
+                        uniform.value = null;
+                    }
+                }
+
+                // Update shadowed texture unit state to remove texture from any units
                 for (var i = 0; i < this.textureUnits.length; i++) {
                     var textureUnit = this.textureUnits[i];
                     for (var j = 0; j < textureUnit.length; j++) {

--- a/src/graphics/device.js
+++ b/src/graphics/device.js
@@ -61,7 +61,7 @@ Object.assign(pc, function () {
     }
 
     function testTextureFloatHighPrecision(device) {
-        if (!this.textureFloatRenderable)
+        if (!device.textureFloatRenderable)
             return false;
 
         var gl = device.gl;


### PR DESCRIPTION
* Don't run high precision float render test of float render is not supported by device.
* Correctly bind render target texture for mipmap generation.
* Unset a destroyed texture from any scope ids.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
