### PR TITLE
Fix json material loading

### DIFF
--- a/src/asset/asset-reference.js
+++ b/src/asset/asset-reference.js
@@ -46,9 +46,9 @@ Object.assign(pc, function () {
         }
 
         if (this.url) {
-            if (this._onAssetLoad) this._registry.on("load:url:" + this.id, this._onLoad, this);
-            if (this._onAssetAdd) this._registry.once("add:url:" + this.id, this._onAdd, this);
-            if (this._onAssetRemove) this._registry.on("remove:url:" + this.id, this._onRemove, this);
+            if (this._onAssetLoad) this._registry.on("load:url:" + this.url, this._onLoad, this);
+            if (this._onAssetAdd) this._registry.once("add:url:" + this.url, this._onAdd, this);
+            if (this._onAssetRemove) this._registry.on("remove:url:" + this.url, this._onRemove, this);
         }
     };
 

--- a/src/asset/asset-registry.js
+++ b/src/asset/asset-registry.js
@@ -480,7 +480,6 @@ Object.assign(pc, function () {
             var basename = pc.path.getBasename(url);
             var ext = pc.path.getExtension(url);
 
-
             var _loadAsset = function (assetToLoad) {
                 asset.once("load", function (loadedAsset) {
                     callback(null, loadedAsset);
@@ -545,36 +544,40 @@ Object.assign(pc, function () {
                     count--;
                 }
             }
-
-
         },
 
         // private method used for engine-only loading of model data
-        _loadTextures: function (materials, callback) {
+        _loadTextures: function (materialAssets, callback) {
             var self = this;
             var i, j;
             var used = {}; // prevent duplicate urls
             var urls = [];
             var textures = [];
             var count = 0;
-            for (i = 0; i < materials.length; i++) {
-                if (materials[i].data.parameters) {
-                    // old material format
-                    var params = materials[i].data.parameters;
-                    for (j = 0; j < params.length; j++) {
-                        if (params[j].type === "texture") {
-                            var url = materials[i].getFileUrl();
-                            var dir = pc.path.getDirectory(url);
-                            url = pc.path.join(dir, params[j].data);
-                            if (!used[url]) {
-                                used[url] = true;
-                                urls.push(url);
-                                count++;
-                            }
+            for (i = 0; i < materialAssets.length; i++) {
+                var materialData = materialAssets[i].data;
+
+                if (materialData.mappingFormat !== 'path') {
+                    console.warn('Skipping: ' + materialAssets[i].name + ', material files must be mappingFormat: "path" to be loaded from URL');
+                    continue;
+                }
+
+                var url = materialAssets[i].getFileUrl();
+                var dir = pc.path.getDirectory(url);
+                var textureUrl;
+
+                for (var pi = 0; pi < pc.StandardMaterial.TEXTURE_PARAMETERS.length; pi++) {
+                    var paramName = pc.StandardMaterial.TEXTURE_PARAMETERS[pi];
+
+                    if (materialData[paramName]) {
+                        var texturePath = materialData[paramName];
+                        textureUrl = pc.path.join(dir, texturePath);
+                        if (!used[textureUrl]) {
+                            used[textureUrl] = true;
+                            urls.push(textureUrl);
+                            count++;
                         }
                     }
-                } else {
-                    console.warn("Update material asset loader to support new material format");
                 }
             }
 

--- a/src/asset/asset-registry.js
+++ b/src/asset/asset-registry.js
@@ -550,7 +550,7 @@ Object.assign(pc, function () {
         // private method used for engine-only loading of model data
         _loadTextures: function (materialAssets, callback) {
             var self = this;
-            var i, j;
+            var i;
             var used = {}; // prevent duplicate urls
             var urls = [];
             var textures = [];

--- a/src/asset/asset-registry.js
+++ b/src/asset/asset-registry.js
@@ -539,7 +539,8 @@ Object.assign(pc, function () {
             for (i = 0; i < mapping.mapping.length; i++) {
                 var path = mapping.mapping[i].path;
                 if (path) {
-                    self.loadFromUrl(pc.path.join(dir, path), "material", onLoadAsset);
+                    path = pc.path.normalize(pc.path.join(dir, path));
+                    self.loadFromUrl(path, "material", onLoadAsset);
                 } else {
                     count--;
                 }
@@ -571,7 +572,7 @@ Object.assign(pc, function () {
 
                     if (materialData[paramName]) {
                         var texturePath = materialData[paramName];
-                        textureUrl = pc.path.join(dir, texturePath);
+                        textureUrl = pc.path.normalize(pc.path.join(dir, texturePath));
                         if (!used[textureUrl]) {
                             used[textureUrl] = true;
                             urls.push(textureUrl);

--- a/src/core/path.js
+++ b/src/core/path.js
@@ -64,7 +64,7 @@ pc.path = function () {
                 if (parts[i] === '') continue;
                 if (parts[i] === '.') continue;
                 if (parts[i] === '..' && cleaned.length > 0) {
-                    cleaned = cleaned.slice(0, cleaned.length-2);
+                    cleaned = cleaned.slice(0, cleaned.length - 2);
                     continue;
                 }
 
@@ -73,12 +73,12 @@ pc.path = function () {
             }
 
 
-            var result = cleaned.join('');
+            result = cleaned.join('');
             if (!lead && result[0] === pc.path.delimiter) {
                 result = result.slice(1);
             }
 
-            if (trail && result[result.length-1] !== pc.path.delimiter) {
+            if (trail && result[result.length - 1] !== pc.path.delimiter) {
                 result += pc.path.delimiter;
             }
 

--- a/src/core/path.js
+++ b/src/core/path.js
@@ -45,6 +45,48 @@ pc.path = function () {
 
         /**
          * @function
+         * @name  pc.path.normalize
+         * @description  Normalize the path by removing '.' and '..' instances
+         * @param  {String} path The path to normalize
+         * @returns {String} The normalized path
+         */
+        normalize: function (path) {
+            var lead = path.startsWith(pc.path.delimiter);
+            var trail = path.endsWith(pc.path.delimiter);
+
+            var parts = path.split('/');
+
+            var result = '';
+
+            var cleaned = [];
+
+            for (var i = 0; i < parts.length; i++) {
+                if (parts[i] === '') continue;
+                if (parts[i] === '.') continue;
+                if (parts[i] === '..' && cleaned.length > 0) {
+                    cleaned = cleaned.slice(0, cleaned.length-2);
+                    continue;
+                }
+
+                if (i > 0) cleaned.push(pc.path.delimiter);
+                cleaned.push(parts[i]);
+            }
+
+
+            var result = cleaned.join('');
+            if (!lead && result[0] === pc.path.delimiter) {
+                result = result.slice(1);
+            }
+
+            if (trail && result[result.length-1] !== pc.path.delimiter) {
+                result += pc.path.delimiter;
+            }
+
+            return result;
+        },
+
+        /**
+         * @function
          * @name pc.path.split
          * @description Split the pathname path into a pair [head, tail] where tail is the final part of the path
          * after the last delimiter and head is everything leading up to that. tail will never contain a slash

--- a/src/resources/material.js
+++ b/src/resources/material.js
@@ -47,6 +47,7 @@ Object.assign(pc, function () {
             // temp storage for engine-only as we need this during patching
             if (data._engine) {
                 material._data = data;
+                delete data._engine;
             }
 
             return material;

--- a/src/resources/material.js
+++ b/src/resources/material.js
@@ -188,6 +188,9 @@ Object.assign(pc, function () {
 
             var TEXTURES = pc.StandardMaterial.TEXTURE_PARAMETERS;
 
+            // texture paths are measured from the material directory
+            var dir = pc.path.getDirectory(materialAsset.getFileUrl());
+
             var i, name, assetReference;
             // iterate through all texture parameters
             for (i = 0; i < TEXTURES.length; i++) {
@@ -208,7 +211,7 @@ Object.assign(pc, function () {
                     }
 
                     if (pathMapping) {
-                        assetReference.url = data[name];
+                        assetReference.url = pc.path.normalize(pc.path.join(dir, data[name]));
                     } else {
                         assetReference.id = data[name];
                     }

--- a/src/resources/model.js
+++ b/src/resources/model.js
@@ -107,7 +107,7 @@ Object.assign(pc, function () {
                         // url mapping
                         var fileUrl = asset.getFileUrl();
                         var dirUrl = pc.path.getDirectory(fileUrl);
-                        var path = pc.path.join(dirUrl, data.mapping[i].path);
+                        var path = pc.path.normalize(pc.path.join(dirUrl, data.mapping[i].path));
                         material = assets.getByUrl(path);
 
                         if (material) {

--- a/src/scene/materials/standard-material-parameters.js
+++ b/src/scene/materials/standard-material-parameters.js
@@ -4,6 +4,9 @@
         name: 'string',
         chunks: 'chunks',
 
+        mappingFormat: 'string',
+        _engine: 'boolean', // internal param for engine-only loading
+
         ambient: 'rgb',
         ambientTint: 'boolean',
 

--- a/src/scene/materials/standard-material-validator.js
+++ b/src/scene/materials/standard-material-validator.js
@@ -56,6 +56,8 @@ Object.assign(pc, function () {
         var type;
         var i;
 
+        var pathMapping = (data.mappingFormat === "path");
+
         for (var key in data) {
             type = TYPES[key];
 
@@ -96,12 +98,20 @@ Object.assign(pc, function () {
                     this.setInvalid(key, data);
                 }
             } else if (type === 'texture') {
-                if (typeof(data[key]) === 'number' || data[key] === null) {
-                    // materials are often initialized with the asset id of textures which are assigned later
-                    // this counts as a valid input
-                    // null texture reference is also valid
-                } else if (!(data[key] instanceof pc.Texture)) {
-                    this.setInvalid(key, data);
+                if (!pathMapping) {
+                    if (typeof(data[key]) === 'number' || data[key] === null) {
+                        // materials are often initialized with the asset id of textures which are assigned later
+                        // this counts as a valid input
+                        // null texture reference is also valid
+                    } else if (!(data[key] instanceof pc.Texture)) {
+                        this.setInvalid(key, data);
+                    }
+                } else {
+                    if (typeof(data[key]) === 'string' || data[key === null]) {
+                        // fpr path mapped we expect a string not an asset id
+                    } else if (!(data[key] instanceof pc.Texture)) {
+                        this.setInvalid(key, data);
+                    }
                 }
             } else if (type === 'boundingbox') {
                 if (!(data[key].center && data[key].center instanceof Array && data[key].center.length === 3)) {


### PR DESCRIPTION
See: https://forum.playcanvas.com/t/getting-major-issue-in-loading-models-from-remote-json-model-is-loading-but-not-the-texture/7799

loadFromUrl has special behaviour when loading models to load and link up materials and textures. The new material validation broke this and this changes fixes it.

Also added pc.path.normalize for cleaning up URLs before use (not required, but nicer)