### PR TITLE
Override 'enabled' property for script components 

### DIFF
--- a/src/framework/components/script/component.js
+++ b/src/framework/components/script/component.js
@@ -22,6 +22,10 @@ Object.assign(pc, function () {
         this._scriptsData = null;
         this._oldState = true;
 
+        // override default 'enabled' property of base pc.Component
+        // because this is faster
+        this._enabled = true;
+
         // whether this component is currently being enabled
         this._beingEnabled = false;
         // if true then we are currently looping through
@@ -718,6 +722,16 @@ Object.assign(pc, function () {
         }
     });
 
+    Object.defineProperty(ScriptComponent.prototype, 'enabled', {
+        get: function () {
+            return this._enabled;
+        },
+        set: function (value) {
+            var oldValue = this._enabled;
+            this._enabled = value;
+            this.fire('set', 'enabled', oldValue, value);
+        }
+    });
 
     Object.defineProperty(ScriptComponent.prototype, 'scripts', {
         get: function () {

--- a/src/framework/components/script/system.js
+++ b/src/framework/components/script/system.js
@@ -1,6 +1,4 @@
 Object.assign(pc, function () {
-    var _schema = ['enabled'];
-
     var METHOD_INITIALIZE_ATTRIBUTES = '_onInitializeAttributes';
     var METHOD_INITIALIZE = '_onInitialize';
     var METHOD_POST_INITIALIZE = '_onPostInitialize';
@@ -34,8 +32,6 @@ Object.assign(pc, function () {
         this.ComponentType = pc.ScriptComponent;
         this.DataType = pc.ScriptComponentData;
 
-        this.schema = _schema;
-
         // list of all entities script components
         // we are using pc.SortedLoopArray because it is
         // safe to modify while looping through it
@@ -65,10 +61,8 @@ Object.assign(pc, function () {
     ScriptComponentSystem.prototype = Object.create(pc.ComponentSystem.prototype);
     ScriptComponentSystem.prototype.constructor = ScriptComponentSystem;
 
-    pc.Component._buildAccessors(pc.ScriptComponent.prototype, _schema);
-
     Object.assign(ScriptComponentSystem.prototype, {
-        initializeComponentData: function (component, data, properties) {
+        initializeComponentData: function (component, data) {
             // Set execution order to an ever-increasing number
             // and add to the end of the components array.
             component._executionOrder = executionOrderCounter++;


### PR DESCRIPTION
Override 'enabled' property for script components to server a local variable instead of using the data store

Fixes #

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
