### PR TITLE
Pin circleci docker image to last known working version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/openjdk:8-jdk-node-browsers
+      - image: circleci/openjdk@sha256:0405d443a664898c7b59f97b4cfebbe8d369370b2edf4f82b8fc1945bdd3b2e0
 
     working_directory: ~/repo
 


### PR DESCRIPTION
Latest docker image in circleci seems to break all the tests (updated Chrome??)

This change pins it to a working version until we've figured out why it broke.