### PR TITLE
Disable tangent generation in JSON model parser.

### DIFF
--- a/src/resources/parser/json-model.js
+++ b/src/resources/parser/json-model.js
@@ -531,19 +531,6 @@ Object.assign(pc, function () {
             for (i = 0; i < modelData.vertices.length; i++) {
                 var vertexData = modelData.vertices[i];
 
-                // Check to see if we need to generate tangents
-                if (!vertexData.tangent && vertexData.position && vertexData.normal && vertexData.texCoord0) {
-                    var indices = [];
-                    for (j = 0; j < modelData.meshes.length; j++) {
-                        if (modelData.meshes[j].vertices === i) {
-                            indices = indices.concat(modelData.meshes[j].indices);
-                        }
-                    }
-                    // Calculate main tangents
-                    var tangents = pc.calculateTangents(vertexData.position.data, vertexData.normal.data, vertexData.texCoord0.data, indices);
-                    vertexData.tangent = { type: "float32", components: 4, data: tangents };
-                }
-
                 var formatDesc = [];
                 for (attributeName in vertexData) {
                     attribute = vertexData[attributeName];


### PR DESCRIPTION
Never calculate tangents for models loaded from the JSON format. If the models have normal mapped materials, the shader generator will generate shaders that utilize derivative mapping, where tangents are calculated in the fragment shader. This speeds up JSON model loading and lowers the memory usage of a PlayCanvas app.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
