### PR TITLE
Optimize pc.SceneParser#_openComponentData.

### DIFF
--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -166,7 +166,6 @@ Object.assign(pc, function () {
 
         this.graphicsDevice = new pc.GraphicsDevice(canvas, options.graphicsDeviceOptions);
         this.stats = new pc.ApplicationStats(this.graphicsDevice);
-        this.systems = new pc.ComponentSystemRegistry();
         this._audioManager = new pc.SoundManager(options);
         this.loader = new pc.ResourceLoader();
 
@@ -464,30 +463,31 @@ Object.assign(pc, function () {
         this.loader.addHandler("textureatlas", new pc.TextureAtlasHandler(this.loader));
         this.loader.addHandler("sprite", new pc.SpriteHandler(this.assets, this.graphicsDevice));
 
-        new pc.RigidBodyComponentSystem(this);
-        new pc.CollisionComponentSystem(this);
-        new pc.AnimationComponentSystem(this);
-        new pc.ModelComponentSystem(this);
-        new pc.CameraComponentSystem(this);
-        new pc.LightComponentSystem(this);
+        this.systems = new pc.ComponentSystemRegistry();
+        this.systems.add(new pc.RigidBodyComponentSystem(this));
+        this.systems.add(new pc.CollisionComponentSystem(this));
+        this.systems.add(new pc.AnimationComponentSystem(this));
+        this.systems.add(new pc.ModelComponentSystem(this));
+        this.systems.add(new pc.CameraComponentSystem(this));
+        this.systems.add(new pc.LightComponentSystem(this));
         if (pc.script.legacy) {
-            new pc.ScriptLegacyComponentSystem(this);
+            this.systems.add(new pc.ScriptLegacyComponentSystem(this));
         } else {
-            new pc.ScriptComponentSystem(this);
+            this.systems.add(new pc.ScriptComponentSystem(this));
         }
-        new pc.AudioSourceComponentSystem(this, this._audioManager);
-        new pc.SoundComponentSystem(this, this._audioManager);
-        new pc.AudioListenerComponentSystem(this, this._audioManager);
-        new pc.ParticleSystemComponentSystem(this);
-        new pc.ScreenComponentSystem(this);
-        new pc.ElementComponentSystem(this);
-        new pc.ButtonComponentSystem(this);
-        new pc.ScrollViewComponentSystem(this);
-        new pc.ScrollbarComponentSystem(this);
-        new pc.SpriteComponentSystem(this);
-        new pc.LayoutGroupComponentSystem(this);
-        new pc.LayoutChildComponentSystem(this);
-        new pc.ZoneComponentSystem(this);
+        this.systems.add(new pc.AudioSourceComponentSystem(this, this._audioManager));
+        this.systems.add(new pc.SoundComponentSystem(this, this._audioManager));
+        this.systems.add(new pc.AudioListenerComponentSystem(this, this._audioManager));
+        this.systems.add(new pc.ParticleSystemComponentSystem(this));
+        this.systems.add(new pc.ScreenComponentSystem(this));
+        this.systems.add(new pc.ElementComponentSystem(this));
+        this.systems.add(new pc.ButtonComponentSystem(this));
+        this.systems.add(new pc.ScrollViewComponentSystem(this));
+        this.systems.add(new pc.ScrollbarComponentSystem(this));
+        this.systems.add(new pc.SpriteComponentSystem(this));
+        this.systems.add(new pc.LayoutGroupComponentSystem(this));
+        this.systems.add(new pc.LayoutChildComponentSystem(this));
+        this.systems.add(new pc.ZoneComponentSystem(this));
 
         this._visibilityChangeHandler = this.onVisibilityChange.bind(this);
 

--- a/src/framework/components/animation/system.js
+++ b/src/framework/components/animation/system.js
@@ -31,8 +31,6 @@ Object.assign(pc, function () {
         this.id = 'animation';
         this.description = "Specifies the animation assets that can run on the model specified by the Entity's model Component.";
 
-        app.systems.add(this);
-
         this.ComponentType = pc.AnimationComponent;
         this.DataType = pc.AnimationComponentData;
 

--- a/src/framework/components/animation/system.js
+++ b/src/framework/components/animation/system.js
@@ -31,7 +31,7 @@ Object.assign(pc, function () {
         this.id = 'animation';
         this.description = "Specifies the animation assets that can run on the model specified by the Entity's model Component.";
 
-        app.systems.add(this.id, this);
+        app.systems.add(this);
 
         this.ComponentType = pc.AnimationComponent;
         this.DataType = pc.AnimationComponentData;

--- a/src/framework/components/audio-listener/system.js
+++ b/src/framework/components/audio-listener/system.js
@@ -15,7 +15,6 @@ Object.assign(pc, function () {
 
         this.id = "audiolistener";
         this.description = "Specifies the location of the listener for 3D audio playback.";
-        app.systems.add(this);
 
         this.ComponentType = pc.AudioListenerComponent;
         this.DataType = pc.AudioListenerComponentData;

--- a/src/framework/components/audio-listener/system.js
+++ b/src/framework/components/audio-listener/system.js
@@ -15,7 +15,7 @@ Object.assign(pc, function () {
 
         this.id = "audiolistener";
         this.description = "Specifies the location of the listener for 3D audio playback.";
-        app.systems.add(this.id, this);
+        app.systems.add(this);
 
         this.ComponentType = pc.AudioListenerComponent;
         this.DataType = pc.AudioListenerComponentData;

--- a/src/framework/components/audio-source/system.js
+++ b/src/framework/components/audio-source/system.js
@@ -30,7 +30,7 @@ Object.assign(pc, function () {
 
         this.id = "audiosource";
         this.description = "Specifies audio assets that can be played at the position of the Entity.";
-        app.systems.add(this.id, this);
+        app.systems.add(this);
 
         this.ComponentType = pc.AudioSourceComponent;
         this.DataType = pc.AudioSourceComponentData;

--- a/src/framework/components/audio-source/system.js
+++ b/src/framework/components/audio-source/system.js
@@ -30,7 +30,6 @@ Object.assign(pc, function () {
 
         this.id = "audiosource";
         this.description = "Specifies audio assets that can be played at the position of the Entity.";
-        app.systems.add(this);
 
         this.ComponentType = pc.AudioSourceComponent;
         this.DataType = pc.AudioSourceComponentData;

--- a/src/framework/components/button/system.js
+++ b/src/framework/components/button/system.js
@@ -30,7 +30,6 @@ Object.assign(pc, function () {
 
         this.id = 'button';
         this.app = app;
-        app.systems.add(this);
 
         this.ComponentType = pc.ButtonComponent;
         this.DataType = pc.ButtonComponentData;

--- a/src/framework/components/button/system.js
+++ b/src/framework/components/button/system.js
@@ -30,7 +30,7 @@ Object.assign(pc, function () {
 
         this.id = 'button';
         this.app = app;
-        app.systems.add(this.id, this);
+        app.systems.add(this);
 
         this.ComponentType = pc.ButtonComponent;
         this.DataType = pc.ButtonComponentData;

--- a/src/framework/components/camera/system.js
+++ b/src/framework/components/camera/system.js
@@ -43,7 +43,6 @@ Object.assign(pc, function () {
 
         this.id = 'camera';
         this.description = "Renders the scene from the location of the Entity.";
-        app.systems.add(this);
 
         this.ComponentType = pc.CameraComponent;
         this.DataType = pc.CameraComponentData;

--- a/src/framework/components/camera/system.js
+++ b/src/framework/components/camera/system.js
@@ -43,7 +43,7 @@ Object.assign(pc, function () {
 
         this.id = 'camera';
         this.description = "Renders the scene from the location of the Entity.";
-        app.systems.add(this.id, this);
+        app.systems.add(this);
 
         this.ComponentType = pc.CameraComponent;
         this.DataType = pc.CameraComponentData;

--- a/src/framework/components/collision/system.js
+++ b/src/framework/components/collision/system.js
@@ -385,7 +385,6 @@ Object.assign(pc, function () {
 
         this.id = "collision";
         this.description = "Specifies a collision volume.";
-        app.systems.add(this);
 
         this.ComponentType = pc.CollisionComponent;
         this.DataType = pc.CollisionComponentData;

--- a/src/framework/components/collision/system.js
+++ b/src/framework/components/collision/system.js
@@ -385,7 +385,7 @@ Object.assign(pc, function () {
 
         this.id = "collision";
         this.description = "Specifies a collision volume.";
-        app.systems.add(this.id, this);
+        app.systems.add(this);
 
         this.ComponentType = pc.CollisionComponent;
         this.DataType = pc.CollisionComponentData;

--- a/src/framework/components/element/system.js
+++ b/src/framework/components/element/system.js
@@ -13,7 +13,6 @@ Object.assign(pc, function () {
 
         this.id = 'element';
         this.app = app;
-        app.systems.add(this);
 
         this.ComponentType = pc.ElementComponent;
         this.DataType = pc.ElementComponentData;

--- a/src/framework/components/element/system.js
+++ b/src/framework/components/element/system.js
@@ -13,7 +13,7 @@ Object.assign(pc, function () {
 
         this.id = 'element';
         this.app = app;
-        app.systems.add(this.id, this);
+        app.systems.add(this);
 
         this.ComponentType = pc.ElementComponent;
         this.DataType = pc.ElementComponentData;

--- a/src/framework/components/layout-child/system.js
+++ b/src/framework/components/layout-child/system.js
@@ -14,7 +14,6 @@ Object.assign(pc, function () {
 
         this.id = 'layoutchild';
         this.app = app;
-        app.systems.add(this);
 
         this.ComponentType = pc.LayoutChildComponent;
         this.DataType = pc.LayoutChildComponentData;

--- a/src/framework/components/layout-child/system.js
+++ b/src/framework/components/layout-child/system.js
@@ -14,7 +14,7 @@ Object.assign(pc, function () {
 
         this.id = 'layoutchild';
         this.app = app;
-        app.systems.add(this.id, this);
+        app.systems.add(this);
 
         this.ComponentType = pc.LayoutChildComponent;
         this.DataType = pc.LayoutChildComponentData;

--- a/src/framework/components/layout-group/system.js
+++ b/src/framework/components/layout-group/system.js
@@ -16,7 +16,6 @@ Object.assign(pc, function () {
 
         this.id = 'layoutgroup';
         this.app = app;
-        app.systems.add(this);
 
         this.ComponentType = pc.LayoutGroupComponent;
         this.DataType = pc.LayoutGroupComponentData;

--- a/src/framework/components/layout-group/system.js
+++ b/src/framework/components/layout-group/system.js
@@ -16,7 +16,7 @@ Object.assign(pc, function () {
 
         this.id = 'layoutgroup';
         this.app = app;
-        app.systems.add(this.id, this);
+        app.systems.add(this);
 
         this.ComponentType = pc.LayoutGroupComponent;
         this.DataType = pc.LayoutGroupComponentData;

--- a/src/framework/components/light/system.js
+++ b/src/framework/components/light/system.js
@@ -18,7 +18,6 @@ Object.assign(pc, function () {
 
         this.id = 'light';
         this.description = "Enables the Entity to emit light.";
-        app.systems.add(this);
 
         this.ComponentType = pc.LightComponent;
         this.DataType = pc.LightComponentData;

--- a/src/framework/components/light/system.js
+++ b/src/framework/components/light/system.js
@@ -18,7 +18,7 @@ Object.assign(pc, function () {
 
         this.id = 'light';
         this.description = "Enables the Entity to emit light.";
-        app.systems.add(this.id, this);
+        app.systems.add(this);
 
         this.ComponentType = pc.LightComponent;
         this.DataType = pc.LightComponentData;

--- a/src/framework/components/model/system.js
+++ b/src/framework/components/model/system.js
@@ -31,7 +31,6 @@ Object.assign(pc, function () {
 
         this.id = 'model';
         this.description = "Renders a 3D model at the location of the Entity.";
-        app.systems.add(this);
 
         this.ComponentType = pc.ModelComponent;
         this.DataType = pc.ModelComponentData;

--- a/src/framework/components/model/system.js
+++ b/src/framework/components/model/system.js
@@ -31,7 +31,7 @@ Object.assign(pc, function () {
 
         this.id = 'model';
         this.description = "Renders a 3D model at the location of the Entity.";
-        app.systems.add(this.id, this);
+        app.systems.add(this);
 
         this.ComponentType = pc.ModelComponent;
         this.DataType = pc.ModelComponentData;

--- a/src/framework/components/particle-system/system.js
+++ b/src/framework/components/particle-system/system.js
@@ -66,7 +66,7 @@ Object.assign(pc, function () {
 
         this.id = 'particlesystem';
         this.description = "Updates and renders particle system in the scene.";
-        app.systems.add(this.id, this);
+        app.systems.add(this);
 
         this.ComponentType = pc.ParticleSystemComponent;
         this.DataType = pc.ParticleSystemComponentData;

--- a/src/framework/components/particle-system/system.js
+++ b/src/framework/components/particle-system/system.js
@@ -66,7 +66,6 @@ Object.assign(pc, function () {
 
         this.id = 'particlesystem';
         this.description = "Updates and renders particle system in the scene.";
-        app.systems.add(this);
 
         this.ComponentType = pc.ParticleSystemComponent;
         this.DataType = pc.ParticleSystemComponentData;

--- a/src/framework/components/registry.js
+++ b/src/framework/components/registry.js
@@ -6,6 +6,8 @@ Object.assign(pc, function () {
      * @description Create a new ComponentSystemRegistry
      */
     var ComponentSystemRegistry = function () {
+        // An array of pc.ComponentSystem objects
+        this.list = [];
     };
 
     Object.assign(ComponentSystemRegistry.prototype, {
@@ -18,12 +20,15 @@ Object.assign(pc, function () {
          * @param {Object} system The {pc.ComponentSystem} instance
          */
         add: function (name, system) {
-            if (!this[name]) {
-                this[name] = system;
-                system.name = name;
-            } else {
+            if (this[name]) {
                 throw new Error(pc.string.format("ComponentSystem name '{0}' already registered or not allowed", name));
             }
+
+            this[name] = system;
+            system.name = name;
+
+            // Update the component system array
+            this.list.push(system);
         },
         /**
          * @private
@@ -38,55 +43,12 @@ Object.assign(pc, function () {
             }
 
             delete this[name];
-        },
 
-        /**
-         * @private
-         * @function
-         * @name pc.ComponentSystemRegistry#list
-         * @description Return the contents of the registry as an array, this order of the array
-         * is the order in which the ComponentSystems must be initialized.
-         * @returns {pc.ComponentSystem[]} An array of component systems.
-         */
-        list: function () {
-            var list = Object.keys(this);
-            var defaultPriority = 1;
-            var priorities = {
-                'collisionrect': 0.5,
-                'collisioncircle': 0.5
-            };
-
-            list.sort(function (a, b) {
-                var pa = priorities[a] || defaultPriority;
-                var pb = priorities[b] || defaultPriority;
-
-                if (pa < pb) {
-                    return -1;
-                } else if (pa > pb) {
-                    return 1;
-                }
-
-                return 0;
-            });
-
-            return list.map(function (key) {
-                return this[key];
-            }, this);
-        },
-
-        getComponentSystemOrder: function () {
-            var index;
-            var names = Object.keys(this);
-
-            index = names.indexOf('collisionrect');
-            names.splice(index, 1);
-            names.unshift('collisionrect');
-
-            index = names.indexOf('collisioncircle');
-            names.splice(index, 1);
-            names.unshift('collisioncircle');
-
-            return names;
+            // Update the component system array
+            var index = this.list.indexOf(this[name]);
+            if (index !== -1) {
+                this.list.splice(index, 1);
+            }
         }
     });
 

--- a/src/framework/components/registry.js
+++ b/src/framework/components/registry.js
@@ -15,37 +15,38 @@ Object.assign(pc, function () {
          * @private
          * @function
          * @name pc.ComponentSystemRegistry#add
-         * @description Add a new Component type
-         * @param {Object} name The name of the Component
+         * @description Add a component system to the registry.
          * @param {Object} system The {pc.ComponentSystem} instance
          */
-        add: function (name, system) {
-            if (this[name]) {
-                throw new Error(pc.string.format("ComponentSystem name '{0}' already registered or not allowed", name));
+        add: function (system) {
+            var id = system.id;
+            if (this[id]) {
+                throw new Error(pc.string.format("ComponentSystem name '{0}' already registered or not allowed", id));
             }
 
-            this[name] = system;
-            system.name = name;
+            this[id] = system;
 
             // Update the component system array
             this.list.push(system);
         },
+
         /**
          * @private
          * @function
          * @name pc.ComponentSystemRegistry#remove
-         * @description Remove a Component type
-         * @param {Object} name The name of the Component remove
+         * @description Remove a component system from the registry.
+         * @param {Object} system The {pc.ComponentSystem} instance
          */
-        remove: function (name) {
-            if (!this[name]) {
-                throw new Error(pc.string.format("No ComponentSystem named '{0}' registered", name));
+        remove: function (system) {
+            var id = system.id;
+            if (!this[id]) {
+                throw new Error(pc.string.format("No ComponentSystem named '{0}' registered", id));
             }
 
-            delete this[name];
+            delete this[id];
 
             // Update the component system array
-            var index = this.list.indexOf(this[name]);
+            var index = this.list.indexOf(this[id]);
             if (index !== -1) {
                 this.list.splice(index, 1);
             }

--- a/src/framework/components/rigid-body/system.js
+++ b/src/framework/components/rigid-body/system.js
@@ -146,7 +146,6 @@ Object.assign(pc, function () {
 
         this.id = 'rigidbody';
         this.description = "Adds the entity to the scene's physical simulation.";
-        app.systems.add(this);
         this._stats = app.stats.frame;
 
         this.ComponentType = pc.RigidBodyComponent;

--- a/src/framework/components/rigid-body/system.js
+++ b/src/framework/components/rigid-body/system.js
@@ -146,7 +146,7 @@ Object.assign(pc, function () {
 
         this.id = 'rigidbody';
         this.description = "Adds the entity to the scene's physical simulation.";
-        app.systems.add(this.id, this);
+        app.systems.add(this);
         this._stats = app.stats.frame;
 
         this.ComponentType = pc.RigidBodyComponent;

--- a/src/framework/components/screen/system.js
+++ b/src/framework/components/screen/system.js
@@ -14,7 +14,6 @@ Object.assign(pc, function () {
 
         this.id = 'screen';
         this.app = app;
-        app.systems.add(this);
 
         this.ComponentType = pc.ScreenComponent;
         this.DataType = pc.ScreenComponentData;

--- a/src/framework/components/screen/system.js
+++ b/src/framework/components/screen/system.js
@@ -14,7 +14,7 @@ Object.assign(pc, function () {
 
         this.id = 'screen';
         this.app = app;
-        app.systems.add(this.id, this);
+        app.systems.add(this);
 
         this.ComponentType = pc.ScreenComponent;
         this.DataType = pc.ScreenComponentData;

--- a/src/framework/components/script-legacy/system.js
+++ b/src/framework/components/script-legacy/system.js
@@ -21,7 +21,6 @@ Object.assign(pc, function () {
 
         this.id = 'script';
         this.description = "Allows the Entity to run JavaScript fragments to implement custom behavior.";
-        app.systems.add(this);
 
         this.ComponentType = pc.ScriptLegacyComponent;
         this.DataType = pc.ScriptLegacyComponentData;

--- a/src/framework/components/script-legacy/system.js
+++ b/src/framework/components/script-legacy/system.js
@@ -21,7 +21,7 @@ Object.assign(pc, function () {
 
         this.id = 'script';
         this.description = "Allows the Entity to run JavaScript fragments to implement custom behavior.";
-        app.systems.add(this.id, this);
+        app.systems.add(this);
 
         this.ComponentType = pc.ScriptLegacyComponent;
         this.DataType = pc.ScriptLegacyComponentData;

--- a/src/framework/components/script/system.js
+++ b/src/framework/components/script/system.js
@@ -27,7 +27,7 @@ Object.assign(pc, function () {
 
         this.id = 'script';
         this.app = app;
-        app.systems.add(this.id, this);
+        app.systems.add(this);
 
         this.ComponentType = pc.ScriptComponent;
         this.DataType = pc.ScriptComponentData;

--- a/src/framework/components/script/system.js
+++ b/src/framework/components/script/system.js
@@ -27,7 +27,6 @@ Object.assign(pc, function () {
 
         this.id = 'script';
         this.app = app;
-        app.systems.add(this);
 
         this.ComponentType = pc.ScriptComponent;
         this.DataType = pc.ScriptComponentData;

--- a/src/framework/components/scroll-view/system.js
+++ b/src/framework/components/scroll-view/system.js
@@ -30,7 +30,6 @@ Object.assign(pc, function () {
 
         this.id = 'scrollview';
         this.app = app;
-        app.systems.add(this);
 
         this.ComponentType = pc.ScrollViewComponent;
         this.DataType = pc.ScrollViewComponentData;

--- a/src/framework/components/scroll-view/system.js
+++ b/src/framework/components/scroll-view/system.js
@@ -30,7 +30,7 @@ Object.assign(pc, function () {
 
         this.id = 'scrollview';
         this.app = app;
-        app.systems.add(this.id, this);
+        app.systems.add(this);
 
         this.ComponentType = pc.ScrollViewComponent;
         this.DataType = pc.ScrollViewComponentData;

--- a/src/framework/components/scrollbar/system.js
+++ b/src/framework/components/scrollbar/system.js
@@ -20,7 +20,6 @@ Object.assign(pc, function () {
 
         this.id = 'scrollbar';
         this.app = app;
-        app.systems.add(this);
 
         this.ComponentType = pc.ScrollbarComponent;
         this.DataType = pc.ScrollbarComponentData;

--- a/src/framework/components/scrollbar/system.js
+++ b/src/framework/components/scrollbar/system.js
@@ -20,7 +20,7 @@ Object.assign(pc, function () {
 
         this.id = 'scrollbar';
         this.app = app;
-        app.systems.add(this.id, this);
+        app.systems.add(this);
 
         this.ComponentType = pc.ScrollbarComponent;
         this.DataType = pc.ScrollbarComponentData;

--- a/src/framework/components/sound/system.js
+++ b/src/framework/components/sound/system.js
@@ -29,7 +29,6 @@ Object.assign(pc, function () {
 
         this.id = "sound";
         this.description = "Allows an Entity to play sounds";
-        app.systems.add(this);
 
         this.ComponentType = pc.SoundComponent;
         this.DataType = pc.SoundComponentData;

--- a/src/framework/components/sound/system.js
+++ b/src/framework/components/sound/system.js
@@ -29,7 +29,7 @@ Object.assign(pc, function () {
 
         this.id = "sound";
         this.description = "Allows an Entity to play sounds";
-        app.systems.add(this.id, this);
+        app.systems.add(this);
 
         this.ComponentType = pc.SoundComponent;
         this.DataType = pc.SoundComponentData;

--- a/src/framework/components/sprite/system.js
+++ b/src/framework/components/sprite/system.js
@@ -16,7 +16,6 @@ Object.assign(pc, function () {
 
         this.id = 'sprite';
         this.app = app;
-        app.systems.add(this);
 
         this.ComponentType = pc.SpriteComponent;
         this.DataType = pc.SpriteComponentData;

--- a/src/framework/components/sprite/system.js
+++ b/src/framework/components/sprite/system.js
@@ -16,7 +16,7 @@ Object.assign(pc, function () {
 
         this.id = 'sprite';
         this.app = app;
-        app.systems.add(this.id, this);
+        app.systems.add(this);
 
         this.ComponentType = pc.SpriteComponent;
         this.DataType = pc.SpriteComponentData;

--- a/src/framework/components/zone/system.js
+++ b/src/framework/components/zone/system.js
@@ -15,7 +15,7 @@ Object.assign(pc, function () {
 
         this.id = 'zone';
         this.app = app;
-        app.systems.add(this.id, this);
+        app.systems.add(this);
 
         this.ComponentType = pc.ZoneComponent;
         this.DataType = pc.ZoneComponentData;

--- a/src/framework/components/zone/system.js
+++ b/src/framework/components/zone/system.js
@@ -15,7 +15,6 @@ Object.assign(pc, function () {
 
         this.id = 'zone';
         this.app = app;
-        app.systems.add(this);
 
         this.ComponentType = pc.ZoneComponent;
         this.DataType = pc.ZoneComponentData;

--- a/src/framework/utils/entity-reference.js
+++ b/src/framework/utils/entity-reference.js
@@ -282,7 +282,7 @@ Object.assign(pc, function () {
         },
 
         _onComponentAdd: function (entity, component) {
-            var componentName = component.system.name;
+            var componentName = component.system.id;
 
             if (entity === this._entity) {
                 this._callGainOrLoseListener(componentName, this._gainListeners);
@@ -291,7 +291,7 @@ Object.assign(pc, function () {
         },
 
         _onComponentRemove: function (entity, component) {
-            var componentName = component.system.name;
+            var componentName = component.system.id;
 
             if (entity === this._entity) {
                 this._callGainOrLoseListener(componentName, this._loseListeners);

--- a/src/resources/parser/scene.js
+++ b/src/resources/parser/scene.js
@@ -69,21 +69,23 @@ Object.assign(pc, function () {
         },
 
         _openComponentData: function (entity, entities) {
-            // Create Components in order
-            var systems = this._app.systems.list();
-            var i, len = systems.length;
-            var edata = entities[entity._guid];
+            // Create components in order
+            var systemsList = this._app.systems.list;
+
+            var i, len = systemsList.length;
+            var entityData = entities[entity._guid];
             for (i = 0; i < len; i++) {
-                var componentData = edata.components[systems[i].id];
+                var system = systemsList[i];
+                var componentData = entityData.components[system.name];
                 if (componentData) {
-                    this._app.systems[systems[i].id].addComponent(entity, componentData);
+                    system.addComponent(entity, componentData);
                 }
             }
 
             // Open all children and add them to the node
-            var length = edata.children.length;
+            len = entityData.children.length;
             var children = entity._children;
-            for (i = 0; i < length; i++) {
+            for (i = 0; i < len; i++) {
                 children[i] = this._openComponentData(children[i], entities);
             }
 

--- a/src/resources/parser/scene.js
+++ b/src/resources/parser/scene.js
@@ -76,7 +76,7 @@ Object.assign(pc, function () {
             var entityData = entities[entity._guid];
             for (i = 0; i < len; i++) {
                 var system = systemsList[i];
-                var componentData = entityData.components[system.name];
+                var componentData = entityData.components[system.id];
                 if (componentData) {
                     system.addComponent(entity, componentData);
                 }

--- a/tests/framework/test_entity.js
+++ b/tests/framework/test_entity.js
@@ -3,8 +3,7 @@ describe("pc.Entity", function () {
 
     beforeEach(function () {
         app = new pc.Application(document.createElement("canvas"));
-
-        new pc.DummyComponentSystem(app);
+        app.systems.add(new pc.DummyComponentSystem(app));
     });
 
     afterEach(function () {

--- a/tests/framework/utils/test_entityreference.js
+++ b/tests/framework/utils/test_entityreference.js
@@ -7,8 +7,7 @@ describe("pc.EntityReference", function () {
 
     beforeEach(function () {
         app = new pc.Application(document.createElement("canvas"));
-
-        new pc.DummyComponentSystem(app);
+        app.systems.add(new pc.DummyComponentSystem(app));
 
         testEntity = new pc.Entity("testEntity", app);
         testComponent = testEntity.addComponent("dummy", {});

--- a/tests/helpers/dummy/system.js
+++ b/tests/helpers/dummy/system.js
@@ -8,7 +8,6 @@ Object.assign(pc, (function () {
     var DummyComponentSystem = function DummyComponentSystem(app) {
         this.id = 'dummy';
         this.app = app;
-        app.systems.add(this.id, this);
 
         this.ComponentType = pc.DummyComponent;
         this.DataType = pc.DummyComponentData;


### PR DESCRIPTION
Fixes #1354.

No longer generate the component system list every time pc.SceneParser#_openComponentData is called, but only when a component system is added/removed from the registry.

Also, deleted pc.ComponentSystemRegistry#getComponentSystemOrder and confirmed it's not used in the Editor codebase.

Shaves a few percent off time spent in pc.SceneParser#_openComponentData.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
