### PR TITLE
[FIX] Pass Float32Array instead of pc.Vec4 to setValue.

### DIFF
--- a/src/framework/components/camera/post-effect-pass.js
+++ b/src/framework/components/camera/post-effect-pass.js
@@ -186,7 +186,7 @@ Object.assign(pc, function () {
                 _constScreenSizeValueUniform[1] = _constScreenSizeValue.y;
                 _constScreenSizeValueUniform[2] = _constScreenSizeValue.z;
                 _constScreenSizeValueUniform[3] = _constScreenSizeValue.w;
-                _constScreenSize.setValue(_constScreenSizeValue);
+                _constScreenSize.setValue(_constScreenSizeValueUniform);
 
                 if (this._postEffectCombined && this._postEffectCombined < 0) {
                     if (self.setup) self.setup(device, self, _constScreenSizeValue, null, this.renderTarget);


### PR DESCRIPTION
I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
