### PR TITLE
Defer work done by material.update until a material is actually used.

### DIFF
--- a/src/backwards-compatibility.js
+++ b/src/backwards-compatibility.js
@@ -297,3 +297,31 @@ Object.defineProperty(pc.Color.prototype, "data3", {
         return this._data3;
     }
 });
+
+pc.Material.prototype.getName = function () {
+    // #ifdef DEBUG
+    console.warn('DEPRECATED: pc.Material#getName is deprecated. Get the pc.Material#name property instead.');
+    // #endif
+    return this.name;
+};
+
+pc.Material.prototype.setName = function (name) {
+    // #ifdef DEBUG
+    console.warn('DEPRECATED: pc.Material#getName is deprecated. Set the pc.Material#name property instead.');
+    // #endif
+    this.name = name;
+};
+
+pc.Material.prototype.getShader = function () {
+    // #ifdef DEBUG
+    console.warn('DEPRECATED: pc.Material#getShader is deprecated. Get the pc.Material#shader property instead.');
+    // #endif
+    return this.shader;
+};
+
+pc.Material.prototype.setShader = function (shader) {
+    // #ifdef DEBUG
+    console.warn('DEPRECATED: pc.Material#setShader is deprecated. Set the pc.Material#shader property instead.');
+    // #endif
+    this.shader = shader;
+};

--- a/src/scene/forward-renderer.js
+++ b/src/scene/forward-renderer.js
@@ -1334,12 +1334,12 @@ Object.assign(pc, function () {
                             this.setBaseConstants(device, material);
                             this.setSkinning(device, meshInstance, material);
 
-                            if (material.chunks) {
-                                if (material.dirty) {
-                                    material.updateUniforms();
-                                    material.dirty = false;
-                                }
+                            if (material.dirty) {
+                                material.updateUniforms();
+                                material.dirty = false;
+                            }
 
+                            if (material.chunks) {
                                 // Uniforms I (shadow): material
                                 parameters = material.parameters;
                                 for (paramName in parameters) {
@@ -1514,6 +1514,12 @@ Object.assign(pc, function () {
 
                     if (material !== prevMaterial) {
                         this._materialSwitches++;
+
+                        if (material.dirty) {
+                            material.updateUniforms();
+                            material.dirty = false;
+                        }
+
                         if (!drawCall._shader[pass] || drawCall._shaderDefs !== objDefs || drawCall._lightHash !== lightHash) {
                             if (!drawCall.isStatic) {
                                 variantKey = pass + "_" + objDefs + "_" + lightHash;
@@ -1537,11 +1543,6 @@ Object.assign(pc, function () {
                         // #else
                         device.setShader(drawCall._shader[pass]);
                         // #endif
-
-                        if (material.dirty) {
-                            material.updateUniforms();
-                            material.dirty = false;
-                        }
 
                         // Uniforms I: material
                         parameters = material.parameters;

--- a/src/scene/forward-renderer.js
+++ b/src/scene/forward-renderer.js
@@ -1335,6 +1335,11 @@ Object.assign(pc, function () {
                             this.setSkinning(device, meshInstance, material);
 
                             if (material.chunks) {
+                                if (material.dirty) {
+                                    material.updateUniforms();
+                                    material.dirty = false;
+                                }
+
                                 // Uniforms I (shadow): material
                                 parameters = material.parameters;
                                 for (paramName in parameters) {
@@ -1532,6 +1537,11 @@ Object.assign(pc, function () {
                         // #else
                         device.setShader(drawCall._shader[pass]);
                         // #endif
+
+                        if (material.dirty) {
+                            material.updateUniforms();
+                            material.dirty = false;
+                        }
 
                         // Uniforms I: material
                         parameters = material.parameters;

--- a/src/scene/materials/basic-material.js
+++ b/src/scene/materials/basic-material.js
@@ -29,8 +29,6 @@ Object.assign(pc, function () {
 
         this.colorMap = null;
         this.vertexColors = false;
-
-        this.update();
     };
     BasicMaterial.prototype = Object.create(pc.Material.prototype);
     BasicMaterial.prototype.constructor = BasicMaterial;
@@ -52,11 +50,10 @@ Object.assign(pc, function () {
             clone.colorMap = this.colorMap;
             clone.vertexColors = this.vertexColors;
 
-            clone.update();
             return clone;
         },
 
-        update: function () {
+        updateUniforms: function () {
             this.clearParameters();
 
             this.colorUniform[0] = this.color.r;

--- a/src/scene/materials/depth-material.js
+++ b/src/scene/materials/depth-material.js
@@ -28,9 +28,6 @@ Object.assign(pc, function () {
             return clone;
         },
 
-        updateUniforms: function () {
-        },
-
         updateShader: function (device) {
             var options = {
                 skin: !!this.meshInstances[0].skinInstance

--- a/src/scene/materials/depth-material.js
+++ b/src/scene/materials/depth-material.js
@@ -25,11 +25,10 @@ Object.assign(pc, function () {
 
             pc.Material.prototype._cloneInternal.call(this, clone);
 
-            clone.update();
             return clone;
         },
 
-        update: function () {
+        updateUniforms: function () {
         },
 
         updateShader: function (device) {

--- a/src/scene/materials/material.js
+++ b/src/scene/materials/material.js
@@ -97,6 +97,8 @@ Object.assign(pc, function () {
         this._shaderVersion = 0;
         this._scene = null;
         this._dirtyBlend = false;
+
+        this.dirty = true;
     };
 
     Object.defineProperty(Material.prototype, 'shader', {
@@ -301,8 +303,20 @@ Object.assign(pc, function () {
         }
     };
 
+    Material.prototype.updateUniforms = function () {
+    },
+
     Material.prototype.updateShader = function (device, scene, objDefs) {
         // For vanilla materials, the shader can only be set by the user
+    };
+
+    /**
+     * @function
+     * @name pc.Material#update
+     * @description Applies any changes made to the material's properties.
+     */
+    Material.prototype.update = function () {
+        this.dirty = true;
     };
 
     // Parameter management
@@ -402,15 +416,6 @@ Object.assign(pc, function () {
             var parameter = this.parameters[paramName];
             parameter.scopeId.setValue(parameter.data);
         }
-    };
-
-    /**
-     * @function
-     * @name pc.Material#update
-     * @description Applies any changes made to the material's properties.
-     */
-    Material.prototype.update = function () {
-        throw Error("Not Implemented in base class");
     };
 
     /**

--- a/src/scene/materials/material.js
+++ b/src/scene/materials/material.js
@@ -106,7 +106,11 @@ Object.assign(pc, function () {
             return this._shader;
         },
         set: function (shader) {
-            this.setShader(shader);
+            if (this._shader) {
+                this._shader._refCount--;
+            }
+            this._shader = shader;
+            if (shader) shader._refCount++;
         }
     });
 
@@ -418,69 +422,6 @@ Object.assign(pc, function () {
     };
 
     /**
-     * @function
-     * @description Initializes the material with the properties in the specified data.
-     * @name pc.Material#init
-     * @param {Object} data The initial data for the material.
-     */
-    Material.prototype.init = function (data) {
-        throw Error("Not Implemented in base class");
-    };
-
-    // DEPRECATED
-    /**
-     * @private
-     * @function
-     * @name pc.Material#getName
-     * @description Returns the string name of the specified material. This name is not
-     * necessarily unique. Material names set by an artist within the modelling application
-     * should be preserved in the PlayCanvas runtime.
-     * @returns {String} The name of the material.
-     */
-    Material.prototype.getName = function () {
-        return this.name;
-    };
-
-    /**
-     * @private
-     * @function
-     * @name pc.Material#setName
-     * @description Sets the string name of the specified material. This name does not
-     * have to be unique.
-     * @param {String} name The name of the material.
-     */
-    Material.prototype.setName = function (name) {
-        this.name = name;
-    };
-
-    /**
-     * @private
-     * @function
-     * @name pc.Material#getShader
-     * @description Retrieves the shader assigned to the specified material.
-     * @returns {pc.Shader} The shader assigned to the material.
-     */
-    Material.prototype.getShader = function () {
-        return this.shader;
-    };
-
-    /**
-     * @private
-     * @function
-     * @name pc.Material#setShader
-     * @description Assigns a shader to the specified material.
-     * @param {pc.Shader} shader The shader to assign to the material.
-     */
-    Material.prototype.setShader = function (shader) {
-        if (this._shader) {
-            this._shader._refCount--;
-        }
-        this._shader = shader;
-        if (shader) shader._refCount++;
-    };
-
-    /**
-     * @private
      * @function
      * @name pc.Material#destroy
      * @description Removes this material from the scene and possibly frees up memory from its shaders (if there are no other materials using it).

--- a/src/scene/materials/material.js
+++ b/src/scene/materials/material.js
@@ -58,9 +58,9 @@ Object.assign(pc, function () {
     var Material = function Material() {
         this.name = "Untitled";
         this.id = id++;
+
         this._shader = null;
         this.variants = {};
-
         this.parameters = {};
 
         // Render states
@@ -246,16 +246,7 @@ Object.assign(pc, function () {
 
     Material.prototype._cloneInternal = function (clone) {
         clone.name = this.name;
-        clone.id = id++;
-        clone.variants = { }; // ?
         clone.shader = this.shader;
-        clone.parameters = { };
-
-        // and need copy parameters of that shader
-        for (var parameterName in this.parameters) {
-            if (this.parameters.hasOwnProperty(parameterName))
-                clone.parameters[parameterName] = { scopeId: null, data: this.parameters[parameterName].data, passFlags: this.parameters[parameterName].passFlags };
-        }
 
         // Render states
         clone.alphaTest = this.alphaTest;
@@ -290,8 +281,6 @@ Object.assign(pc, function () {
         clone.greenWrite = this.greenWrite;
         clone.blueWrite = this.blueWrite;
         clone.alphaWrite = this.alphaWrite;
-
-        clone.meshInstances = [];
     };
 
     Material.prototype.clone = function () {

--- a/src/scene/materials/material.js
+++ b/src/scene/materials/material.js
@@ -304,7 +304,7 @@ Object.assign(pc, function () {
     };
 
     Material.prototype.updateUniforms = function () {
-    },
+    };
 
     Material.prototype.updateShader = function (device, scene, objDefs) {
         // For vanilla materials, the shader can only be set by the user

--- a/src/scene/materials/material.js
+++ b/src/scene/materials/material.js
@@ -365,7 +365,6 @@ Object.assign(pc, function () {
      * @param {Number} [passFlags] Mask describing which passes the material should be included in.
      */
     Material.prototype.setParameter = function (name, data, passFlags) {
-
         if (passFlags === undefined) passFlags = -524285; // All bits set except 2 - 18 range
 
         if (data === undefined && typeof name === 'object') {

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -628,8 +628,6 @@ Object.assign(pc, function () {
          * @param  {Object} data The data block that is used to initialize
          */
         initialize: function (data) {
-            this.reset();
-
             // usual flow is that data is validated in resource loader
             // but if not, validate here.
             if (!data.validated) {
@@ -772,7 +770,7 @@ Object.assign(pc, function () {
             return null;
         },
 
-        update: function () {
+        updateUniforms: function () {
             var uniform;
             this._clearParameters();
 


### PR DESCRIPTION
During the loading process, material.update can be called 1 or more times. When loading a material, on every texture load, this function is called:

https://github.com/playcanvas/engine/blob/master/src/resources/material.js#L134

To avoid the cost of repeatedly calling material.update, this PR simply marks the material as dirty and then waits until the forward renderer executes before the material is fully updated.

Also, this PR:

- properly deprecates pc.Material#setName/getName and pc.Material#setShader/getShader.
- removes redundant property copying in the pc.Material#_cloneInternal function.


I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
