### PR TITLE
Enable parallel shader compilation.

### DIFF
--- a/src/graphics/device.js
+++ b/src/graphics/device.js
@@ -642,6 +642,7 @@ Object.assign(pc, function () {
             this.extCompressedTextureETC = getExtension('WEBGL_compressed_texture_etc');
             this.extCompressedTexturePVRTC = getExtension('WEBGL_compressed_texture_pvrtc', 'WEBKIT_WEBGL_compressed_texture_pvrtc');
             this.extCompressedTextureS3TC = getExtension('WEBGL_compressed_texture_s3tc', 'WEBKIT_WEBGL_compressed_texture_s3tc');
+            this.extParallelShaderCompile = getExtension('KHR_parallel_shader_compile');
         },
 
         initializeCapabilities: function () {


### PR DESCRIPTION
Enable the use of the [KHR_parallel_shader_compile](https://www.khronos.org/registry/webgl/extensions/KHR_parallel_shader_compile/) extension to speed up shader compilation and hence app load times.

Note: at time of writing, KHR_parallel_shader_compile is only enabled in Chrome Canary AFAIK (and even then, you must enable WebGL draft extensions via chrome://flags).

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
