### PR TITLE
Clear asset when sprite or texture is set directly

### DIFF
--- a/src/framework/components/element/image-element.js
+++ b/src/framework/components/element/image-element.js
@@ -1023,6 +1023,13 @@ Object.assign(pc, function () {
         set: function (value) {
             if (this._texture === value) return;
 
+            if (this._textureAsset) {
+                var textureAsset = this._system.app.assets.get(this._textureAsset);
+                if (textureAsset && textureAsset.resource !== value) {
+                    this.textureAsset = null;
+                }
+            }
+
             this._texture = value;
 
             if (value) {
@@ -1138,6 +1145,13 @@ Object.assign(pc, function () {
 
             if (this._sprite) {
                 this._unbindSprite(this._sprite);
+            }
+
+            if (this._spriteAsset) {
+                var spriteAsset = this._system.app.assets.get(this._spriteAsset);
+                if (spriteAsset && spriteAsset.resource !== value) {
+                    this.spriteAsset = null;
+                }
             }
 
             this._sprite = value;

--- a/tests/framework/components/element/test_imageelement.js
+++ b/tests/framework/components/element/test_imageelement.js
@@ -836,7 +836,7 @@ describe('pc.ImageElement', function () {
 
     });
 
-    it.only('TextureAtlas asset events are unbound if sprite is changed while loading', function (done) {
+    it('TextureAtlas asset events are unbound if sprite is changed while loading', function (done) {
 
         app.assets.list().forEach(function (asset) {
             asset.unload();
@@ -873,7 +873,146 @@ describe('pc.ImageElement', function () {
             });
 
             done();
-        })
+        });
+    });
 
-    })
+    it.only('Cloning image element with texture works', function () {
+        var e = new pc.Entity();
+        e.addComponent('element', {
+            type: 'image',
+            textureAsset: assets.texture.id
+        });
+
+        var copy = e.clone();
+
+        expect(copy.element.textureAsset).to.equal(assets.texture.id);
+        expect(copy.element.texture).to.equal(e.element.texture);
+    });
+
+    it.only('Setting texture on image element clears texture asset', function () {
+        var e = new pc.Entity();
+        e.addComponent('element', {
+            type: 'image',
+            textureAsset: assets.texture.id
+        });
+
+        var texture = new pc.Texture();
+
+        e.element.texture = texture;
+
+        expect(e.element.textureAsset).to.be.null;
+        expect(e.element.texture).to.be.equal(texture);
+    });
+
+    it.only('Setting texture on image element clears sprite asset', function () {
+        var e = new pc.Entity();
+        e.addComponent('element', {
+            type: 'image',
+            spriteAsset: assets.sprite.id
+        });
+
+        expect(e.element.spriteAsset).to.be.not.null;
+        // expect(e.element.sprite).to.be.not.null;
+
+        var texture = new pc.Texture();
+
+        e.element.texture = texture;
+
+        expect(e.element.spriteAsset).to.be.null;
+        expect(e.element.sprite).to.be.null;
+        expect(e.element.texture).to.be.equal(texture);
+    });
+
+    it.only('Setting texture on image element then cloning works', function () {
+        var e = new pc.Entity();
+        e.addComponent('element', {
+            type: 'image',
+            textureAsset: assets.texture.id
+        });
+
+        var texture = new pc.Texture();
+
+        e.element.texture = texture;
+
+        var copy = e.clone();
+
+        expect(e.element.textureAsset).to.be.null;
+        expect(e.element.texture).to.equal(texture);
+
+        expect(copy.element.textureAsset).to.be.null;
+        expect(copy.element.texture).to.equal(e.element.texture);
+    });
+
+    it.only('Cloning image element with sprite works', function () {
+        var e = new pc.Entity();
+        e.addComponent('element', {
+            type: 'image',
+            spriteAsset: assets.sprite.id
+        });
+
+        var copy = e.clone();
+
+        expect(copy.element.spriteAsset).to.equal(assets.sprite.id);
+        expect(copy.element.sprite).to.equal(e.element.sprite);
+    });
+
+    it.only('Setting sprite on image element clears sprite asset', function () {
+        var e = new pc.Entity();
+        e.addComponent('element', {
+            type: 'image',
+            spriteAsset: assets.sprite
+        });
+
+        var sprite = new pc.Sprite(app.graphicsDevice, {
+            frameKeys: []
+        });
+
+        e.element.sprite = sprite;
+
+        expect(e.element.spriteAsset).to.be.null;
+        expect(e.element.sprite).to.be.equal(sprite);
+    });
+
+    it.only('Setting sprite on image element clears texture asset', function () {
+        var e = new pc.Entity();
+        e.addComponent('element', {
+            type: 'image',
+            textureAsset: assets.texture
+        });
+
+        expect(e.element.textureAsset).to.be.not.null;
+        // expect(e.element.texture).to.be.not.null;
+
+        var sprite = new pc.Sprite(app.graphicsDevice, {
+            frameKeys: []
+        });
+
+        e.element.sprite = sprite;
+
+        expect(e.element.textureAsset).to.be.null;
+        expect(e.element.texture).to.be.null;
+        expect(e.element.sprite).to.be.equal(sprite);
+    });
+
+    it.only('Setting sprite on image element then cloning works', function () {
+        var e = new pc.Entity();
+        e.addComponent('element', {
+            type: 'image',
+            spriteAsset: assets.sprite
+        });
+
+        var sprite = new pc.Sprite(app.graphicsDevice, {
+            frameKeys: []
+        });
+
+        e.element.sprite = sprite;
+
+        var copy = e.clone();
+
+        expect(e.element.spriteAsset).to.be.null;
+        expect(e.element.sprite).to.equal(e.element.sprite);
+
+        expect(copy.element.spriteAsset).to.be.null;
+        expect(copy.element.sprite).to.equal(e.element.sprite);
+    });
 });


### PR DESCRIPTION
Image Elements now clear the textureAsset field if a different texture is set
Image Elements now clear the spriteAsset field if a different sprite is set

Fixes #1380 
