### PR TITLE
Added blended output resolution to the screen component and a way to get the appropriate screen resolution-dependent position with the WorldToScreen function in the camera component

### DIFF
--- a/src/framework/components/camera/component.js
+++ b/src/framework/components/camera/component.js
@@ -206,11 +206,19 @@ Object.assign(pc, function () {
          * @description Convert a point from 3D world space to 2D screen space.
          * @param {pc.Vec3} worldCoord The world space coordinate.
          * @param {pc.Vec3} [screenCoord] 3D vector to receive screen coordinate result.
+         * @param {pc.Vec2} screenResolution The resolution of the screen to convert the point to. If unspecified, the client resolution is assumed.
          * @returns {pc.Vec3} The screen space coordinate.
          */
-        worldToScreen: function (worldCoord, screenCoord) {
-            var device = this.system.app.graphicsDevice;
-            return this.data.camera.worldToScreen(worldCoord, device.clientRect.width, device.clientRect.height, screenCoord);
+        worldToScreen: function (worldCoord, screenCoord, screenResolution) {
+	        if (screenResolution === undefined) {
+		        var cw = this.system.app.graphicsDevice.clientRect.width;
+		        var ch = this.system.app.graphicsDevice.clientRect.height;
+            }
+            else {
+	            var cw = screenResolution.x;
+	            var ch = screenResolution.y;
+            }
+	        return this.data.camera.worldToScreen(worldCoord, cw, ch, screenCoord);
         },
 
         onSetAspectRatioMode: function (name, oldValue, newValue) {


### PR DESCRIPTION
Fixes #2
Added a blended resolution variable to the screen component in order to get screen scaling-independant way to transform screen elements.

Added a custom resolution input in order to scale to given screen. Backwards compatibility should remain.

It is now much simpler to place screen elements over world positions with only three lines even if the screen is scaled with the browser console.

`var screen = this.entity.element.screen.screen.blendedResolution;
this.camera.worldToScreen(this.worldEntity.getPosition(), this.coords, screen);
this.entity.setLocalPosition(this.coords.x,-this.coords.y, 0); `

If there is a better way to accomplish the above, please delete this pull request, and add the better way to the documentation.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
