### PR TITLE
Small refactor of pc.Application#destroy

### DIFF
--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -1522,9 +1522,9 @@ Object.assign(pc, function () {
             this.systems = [];
             this.context = null;
 
-            this.graphicsDevice.clearShaderCache();
+            pc.destroyPostEffectQuad();
+
             this.graphicsDevice.destroy();
-            this.graphicsDevice.destroyed = true;
             this.graphicsDevice = null;
 
             this.renderer = null;
@@ -1539,8 +1539,6 @@ Object.assign(pc, function () {
 
             // remove default particle texture
             pc.ParticleEmitter.DEFAULT_PARAM_TEXTURE = null;
-
-            pc.destroyPostEffectQuad();
         }
     });
 

--- a/src/graphics/device.js
+++ b/src/graphics/device.js
@@ -2881,6 +2881,8 @@ Object.assign(pc, function () {
             if (this.webgl2 && this.feedback) {
                 this.gl.deleteTransformFeedback(this.feedback);
             }
+
+            this.clearShaderCache();
         }
     });
 

--- a/src/graphics/simple-post-effect.js
+++ b/src/graphics/simple-post-effect.js
@@ -82,7 +82,10 @@ Object.assign(pc, (function () {
     }
 
     function destroyPostEffectQuad() {
-        _postEffectQuadVB = null;
+        if (_postEffectQuadVB) {
+            _postEffectQuadVB.destroy();
+            _postEffectQuadVB = null;
+        }
     }
 
     return {


### PR DESCRIPTION
Properly releases the post effect quad WebGL resource.
Remove destroyed property set on graphics device which is not used anywhere.
Move shader cache clearing into pc.GraphicsDevice#destroy.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
