### PR TITLE
Optimize pc.GraphNode#syncHierarchy

### DIFF
--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -1319,17 +1319,26 @@ Object.assign(pc, function () {
          * @description Updates the world transformation matrices at this node and all of its descendants.
          */
         syncHierarchy: function () {
-            if (!this._enabled)
-                return;
+            var stack = [];
 
-            if (this._dirtyLocal || this._dirtyWorld)
-                this._sync();
+            return function () {
+                var i, len, node, children;
+                stack.push(this);
+                while (stack.length > 0) {
+                    node = stack.pop();
 
-            var children = this._children;
-            for (var i = 0, len = children.length; i < len; i++) {
-                children[i].syncHierarchy();
-            }
-        },
+                    if (node._enabled) {
+                        if (node._dirtyLocal || node._dirtyWorld)
+                            node._sync();
+
+                        children = node._children;
+                        for (i = 0, len = children.length; i < len; i++) {
+                            stack.push(children[i]);
+                        }
+                    }
+                }
+            };
+        }(),
 
         /**
          * @function


### PR DESCRIPTION
Change pc.GraphNode#syncHierarchy to use an iterative pre-order tree traversal instead of a recursive algorithm.

Reduces the cost of pc.GraphNode#syncHierarchy by between 30% and 50% (according to the Profiler in Chrome Dev Tools).

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
