### PR TITLE
Graph node micro-optimisation

### DIFF
--- a/src/anim/skeleton.js
+++ b/src/anim/skeleton.js
@@ -342,8 +342,7 @@ Object.assign(pc, function () {
                     transform.localRotation.copy(interpKey._quat);
                     transform.localScale.copy(interpKey._scale);
 
-                    if (!transform._dirtyLocal)
-                        transform._dirtify(true);
+                    transform._dirtifyLocal();
 
                     interpKey._written = false;
                 }

--- a/src/backwards-compatibility.js
+++ b/src/backwards-compatibility.js
@@ -325,3 +325,13 @@ pc.Material.prototype.setShader = function (shader) {
     // #endif
     this.shader = shader;
 };
+
+pc.GraphNode.prototype._dirtify = function (local) {
+    // #ifdef DEBUG
+    console.warn('DEPRECATED: pc.GraphNode#_dirtify is deprecated. Use the pc.GraphNode#_dirtifyLocal or _dirtifyWorld respectively instead.');
+    // #endif
+    if (local)
+        this._dirtifyLocal();
+    else
+        this._dirtifyWorld();
+};

--- a/src/framework/components/camera/system.js
+++ b/src/framework/components/camera/system.js
@@ -173,7 +173,7 @@ Object.assign(pc, function () {
                         if (cam._node) {
                             cam._node.localTransform.copy(vrDisplay.combinedViewInv);
                             cam._node._dirtyLocal = false;
-                            cam._node._dirtify();
+                            cam._node._dirtifyWorld();
                         }
                     }
                 }

--- a/src/framework/components/element/component.js
+++ b/src/framework/components/element/component.js
@@ -205,8 +205,7 @@ Object.assign(pc, function () {
                 invParentWtm.copy(this.element._screenToWorld).invert();
                 invParentWtm.transformPoint(position, this.localPosition);
 
-                if (!this._dirtyLocal)
-                    this._dirtify(true);
+                this._dirtifyLocal();
             };
         }(),
 
@@ -226,8 +225,7 @@ Object.assign(pc, function () {
             element._margin.y = p.y - element._calculatedHeight * pvt.y;
             element._margin.w = (element._localAnchor.w - element._localAnchor.y) - element._calculatedHeight - element._margin.y;
 
-            if (!this._dirtyLocal)
-                this._dirtify(true);
+            this._dirtifyLocal();
         },
 
         // this method overwrites GraphNode#sync and so operates in scope of the Entity.
@@ -357,7 +355,7 @@ Object.assign(pc, function () {
 
             var result = this._parseUpToScreen();
 
-            this.entity._dirtify();
+            this.entity._dirtifyWorld();
 
             this._updateScreen(result.screen);
 
@@ -1187,8 +1185,7 @@ Object.assign(pc, function () {
 
             this._anchorDirty = true;
 
-            if (!this.entity._dirtyLocal)
-                this.entity._dirtify(true);
+            this.entity._dirtifyLocal();
 
             this.fire('set:anchor', this._anchor);
         }

--- a/src/framework/components/screen/component.js
+++ b/src/framework/components/screen/component.js
@@ -159,8 +159,7 @@ Object.assign(pc, function () {
 
             this._calcProjectionMatrix();
 
-            if (!this.entity._dirtyLocal)
-                this.entity._dirtify(true);
+            this.entity._dirtifyLocal();
 
             this.fire("set:resolution", this._resolution);
         },
@@ -175,8 +174,7 @@ Object.assign(pc, function () {
             this._updateScale();
             this._calcProjectionMatrix();
 
-            if (!this.entity._dirtyLocal)
-                this.entity._dirtify(true);
+            this.entity._dirtifyLocal();
 
             this.fire("set:referenceresolution", this._resolution);
         },
@@ -197,8 +195,7 @@ Object.assign(pc, function () {
             }
             this.resolution = this._resolution; // force update either way
 
-            if (!this.entity._dirtyLocal)
-                this.entity._dirtify(true);
+            this.entity._dirtifyLocal();
 
             this.fire('set:screenspace', this._screenSpace);
         },
@@ -234,8 +231,7 @@ Object.assign(pc, function () {
             this._updateScale();
             this._calcProjectionMatrix();
 
-            if (!this.entity._dirtyLocal)
-                this.entity._dirtify(true);
+            this.entity._dirtifyLocal();
 
             this.fire("set:scaleblend", this._scaleBlend);
         },

--- a/src/math/mat3.js
+++ b/src/math/mat3.js
@@ -5,32 +5,14 @@ Object.assign(pc, (function () {
      * @constructor
      * @name pc.Mat3
      * @classdesc A 3x3 matrix.
-     * @description Creates a new Mat3 object.
-     * @param {Number} [v0] The value in row 0, column 0. If v0 is an array of length 9, the array will be used to populate all components.
-     * @param {Number} [v1] The value in row 1, column 0.
-     * @param {Number} [v2] The value in row 2, column 0.
-     * @param {Number} [v3] The value in row 0, column 1.
-     * @param {Number} [v4] The value in row 1, column 1.
-     * @param {Number} [v5] The value in row 2, column 1.
-     * @param {Number} [v6] The value in row 0, column 2.
-     * @param {Number} [v7] The value in row 1, column 2.
-     * @param {Number} [v8] The value in row 2, column 2.
+     * @description Creates a new identity Mat3 object.
      */
     var Mat3 = function () {
         var data;
-        if (arguments.length === 0) {
-            // Create an identity matrix. Note that a new Float32Array has all elements set
-            // to zero by default, so we only need to set the relevant elements to one.
-            data = new Float32Array(9);
-            data[0] = data[4] = data[8] = 1;
-        } else if (arguments.length === 1) {
-            data = new Float32Array(arguments[0]);
-        } else { // 9 values should have been passed
-            data = new Float32Array(9);
-            for (var i = 0; i < 9; i++) {
-                data[i] = arguments[i];
-            }
-        }
+        // Create an identity matrix. Note that a new Float32Array has all elements set
+        // to zero by default, so we only need to set the relevant elements to one.
+        data = new Float32Array(9);
+        data[0] = data[4] = data[8] = 1;
         this.data = data;
     };
 
@@ -63,6 +45,33 @@ Object.assign(pc, (function () {
          */
         copy: function (rhs) {
             var src = rhs.data;
+            var dst = this.data;
+
+            dst[0] = src[0];
+            dst[1] = src[1];
+            dst[2] = src[2];
+            dst[3] = src[3];
+            dst[4] = src[4];
+            dst[5] = src[5];
+            dst[6] = src[6];
+            dst[7] = src[7];
+            dst[8] = src[8];
+
+            return this;
+        },
+
+        /**
+         * @function
+         * @name pc.Mat3#set
+         * @description Copies the contents of a source array[9] to a destination 3x3 matrix.
+         * @param {Array} src An array[9] to be copied.
+         * @returns {pc.Mat3} Self for chaining
+         * @example
+         * var src = [0, 1, 2, 3, 4, 5, ,6, 7, 8];
+         * var dst = new pc.Mat3();
+         * dst.copy(src);
+         */
+        set: function (src) {
             var dst = this.data;
 
             dst[0] = src[0];
@@ -222,7 +231,7 @@ Object.assign(pc, (function () {
      */
     Object.defineProperty(Mat3, 'ZERO', {
         get: function () {
-            var zero = new Mat3(0, 0, 0, 0, 0, 0, 0, 0, 0);
+            var zero = new Mat3().set([0, 0, 0, 0, 0, 0, 0, 0, 0]);
             return function () {
                 return zero;
             };

--- a/src/math/mat3.js
+++ b/src/math/mat3.js
@@ -67,7 +67,7 @@ Object.assign(pc, (function () {
          * @param {Array} src An array[9] to be copied.
          * @returns {pc.Mat3} Self for chaining
          * @example
-         * var src = [0, 1, 2, 3, 4, 5, ,6, 7, 8];
+         * var src = [0, 1, 2, 3, 4, 5, 6, 7, 8];
          * var dst = new pc.Mat3();
          * dst.copy(src);
          */

--- a/src/math/mat4.js
+++ b/src/math/mat4.js
@@ -24,20 +24,10 @@ Object.assign(pc, (function () {
      * @param {Number} [v15] The value in row 3, column 3.
      */
     var Mat4 = function () {
-        var data;
-        if (arguments.length === 0) {
-            // Create an identity matrix. Note that a new Float32Array has all elements set
-            // to zero by default, so we only need to set the relevant elements to one.
-            data = new Float32Array(16);
-            data[0] = data[5] = data[10] = data[15] = 1;
-        } else if (arguments.length === 1) {
-            data = new Float32Array(arguments[0]);
-        } else { // 16 values should have been passed
-            data = new Float32Array(16);
-            for (var i = 0; i < 16; i++) {
-                data[i] = arguments[i];
-            }
-        }
+        var data = new Float32Array(16);
+        // Create an identity matrix. Note that a new Float32Array has all elements set
+        // to zero by default, so we only need to set the relevant elements to one.
+        data[0] = data[5] = data[10] = data[15] = 1;
         this.data = data;
     };
 

--- a/src/math/mat4.js
+++ b/src/math/mat4.js
@@ -5,23 +5,7 @@ Object.assign(pc, (function () {
      * @constructor
      * @name pc.Mat4
      * @classdesc A 4x4 matrix.
-     * @description Creates a new Mat4 object.
-     * @param {Number} [v0] The value in row 0, column 0. If v0 is an array of length 16, the array will be used to populate all components.
-     * @param {Number} [v1] The value in row 1, column 0.
-     * @param {Number} [v2] The value in row 2, column 0.
-     * @param {Number} [v3] The value in row 3, column 0.
-     * @param {Number} [v4] The value in row 0, column 1.
-     * @param {Number} [v5] The value in row 1, column 1.
-     * @param {Number} [v6] The value in row 2, column 1.
-     * @param {Number} [v7] The value in row 3, column 1.
-     * @param {Number} [v8] The value in row 0, column 2.
-     * @param {Number} [v9] The value in row 1, column 2.
-     * @param {Number} [v10] The value in row 2, column 2.
-     * @param {Number} [v11] The value in row 3, column 2.
-     * @param {Number} [v12] The value in row 0, column 3.
-     * @param {Number} [v13] The value in row 1, column 3.
-     * @param {Number} [v14] The value in row 2, column 3.
-     * @param {Number} [v15] The value in row 3, column 3.
+     * @description Creates a new identity Mat4 object.
      */
     var Mat4 = function () {
         var data = new Float32Array(16);

--- a/src/math/mat4.js
+++ b/src/math/mat4.js
@@ -1275,7 +1275,7 @@ Object.assign(pc, (function () {
      */
     Object.defineProperty(Mat4, 'ZERO', {
         get: (function () {
-            var zero = new Mat4(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+            var zero = new Mat4().set([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
             return function () {
                 return zero;
             };

--- a/src/resources/parser/json-model.js
+++ b/src/resources/parser/json-model.js
@@ -115,10 +115,7 @@ Object.assign(pc, function () {
                 var inverseBindMatrices = [];
                 for (j = 0; j < skinData.inverseBindMatrices.length; j++) {
                     var ibm = skinData.inverseBindMatrices[j];
-                    inverseBindMatrices[j] = new pc.Mat4(ibm[0], ibm[1], ibm[2], ibm[3],
-                                                         ibm[4], ibm[5], ibm[6], ibm[7],
-                                                         ibm[8], ibm[9], ibm[10], ibm[11],
-                                                         ibm[12], ibm[13], ibm[14], ibm[15]);
+                    inverseBindMatrices[j] = new pc.Mat4().set(ibm);
                 }
 
                 var skin = new pc.Skin(this._device, inverseBindMatrices, skinData.boneNames);

--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -797,8 +797,7 @@ Object.assign(pc, function () {
                 this.localRotation.setFromEulerAngles(x, y, z);
             }
 
-            if (!this._dirtyLocal)
-                this._dirtify(true);
+            this._dirtifyLocal();
         },
 
         /**
@@ -826,8 +825,7 @@ Object.assign(pc, function () {
                 this.localPosition.set(x, y, z);
             }
 
-            if (!this._dirtyLocal)
-                this._dirtify(true);
+            this._dirtifyLocal();
         },
 
         /**
@@ -856,8 +854,7 @@ Object.assign(pc, function () {
                 this.localRotation.set(x, y, z, w);
             }
 
-            if (!this._dirtyLocal)
-                this._dirtify(true);
+            this._dirtifyLocal();
         },
 
         /**
@@ -885,8 +882,7 @@ Object.assign(pc, function () {
                 this.localScale.set(x, y, z);
             }
 
-            if (!this._dirtyLocal)
-                this._dirtify(true);
+            this._dirtifyLocal();
         },
 
         /**
@@ -903,25 +899,21 @@ Object.assign(pc, function () {
             this.name = name;
         },
 
-        _dirtify: function (local) {
-            if ((!local || (local && this._dirtyLocal)) && this._dirtyWorld)
-                return;
-
-            if (local)
+        _dirtifyLocal: function () {
+            if (!this._dirtyLocal) {
                 this._dirtyLocal = true;
+                this._dirtifyWorld();
+            }
+        },
 
+        _dirtifyWorld: function () {
             if (!this._dirtyWorld) {
                 this._dirtyWorld = true;
-
-                var i = this._children.length;
-                while (i--) {
-                    if (this._children[i]._dirtyWorld)
-                        continue;
-
-                    this._children[i]._dirtify();
+                for (var i = 0; i < this._children.length; i++) {
+                    if (!this._children[i]._dirtyWorld)
+                        this._children[i]._dirtifyWorld();
                 }
             }
-
             this._dirtyNormal = true;
             this._aabbVer++;
         },
@@ -962,8 +954,7 @@ Object.assign(pc, function () {
                     invParentWtm.transformPoint(position, this.localPosition);
                 }
 
-                if (!this._dirtyLocal)
-                    this._dirtify(true);
+                this._dirtifyLocal();
             };
         }(),
 
@@ -1005,8 +996,7 @@ Object.assign(pc, function () {
                     this.localRotation.copy(invParentRot).mul(rotation);
                 }
 
-                if (!this._dirtyLocal)
-                    this._dirtify(true);
+                this._dirtifyLocal();
             };
         }(),
 
@@ -1045,8 +1035,7 @@ Object.assign(pc, function () {
                     this.localRotation.mul2(invParentRot, this.localRotation);
                 }
 
-                if (!this._dirtyLocal)
-                    this._dirtify(true);
+                this._dirtifyLocal();
             };
         }(),
 
@@ -1126,7 +1115,7 @@ Object.assign(pc, function () {
             node._updateGraphDepth();
 
             // The child (plus subhierarchy) will need world transforms to be recalculated
-            node._dirtify();
+            node._dirtifyWorld();
 
             // alert an entity that it has been inserted
             if (node.fire) node.fire('insert', this);
@@ -1322,8 +1311,7 @@ Object.assign(pc, function () {
             if (!this._enabled)
                 return;
 
-            if (this._dirtyLocal || this._dirtyWorld)
-                this._sync();
+            this._sync();
 
             var children = this._children;
             for (var i = 0, len = children.length; i < len; i++) {
@@ -1457,8 +1445,7 @@ Object.assign(pc, function () {
                 this.localRotation.transformVector(translation, translation);
                 this.localPosition.add(translation);
 
-                if (!this._dirtyLocal)
-                    this._dirtify(true);
+                this._dirtifyLocal();
             };
         }(),
 
@@ -1502,8 +1489,7 @@ Object.assign(pc, function () {
                     this.localRotation.mul2(quaternion, rot);
                 }
 
-                if (!this._dirtyLocal)
-                    this._dirtify(true);
+                this._dirtifyLocal();
             };
         }(),
 
@@ -1537,8 +1523,7 @@ Object.assign(pc, function () {
 
                 this.localRotation.mul(quaternion);
 
-                if (!this._dirtyLocal)
-                    this._dirtify(true);
+                this._dirtifyLocal();
             };
         }()
     });

--- a/tests/math/test_mat4.js
+++ b/tests/math/test_mat4.js
@@ -2,12 +2,12 @@ describe("pc.Mat4", function () {
     function approx(actual, expected, message) {
         var epsilon = 0.00001;
         var delta = actual - expected;
-        ok( Math.abs(delta) < epsilon, message);
+        ok(Math.abs(delta) < epsilon, message);
     }
 
-    /** clip to 3 decimal places and convert to string for comparison **/
+    // clip to 3 decimal places and convert to string for comparison
     var clip = function (m) {
-        var i,l = m.length;
+        var i, l = m.length;
         var a = [];
         for (i = 0; i < l; i++) {
             a[i] = parseFloat(m[i].toFixed(3));
@@ -16,27 +16,27 @@ describe("pc.Mat4", function () {
         return a;
     };
 
-    it("create", function() {
+    it("create", function () {
         var m = new pc.Mat4();
         ok(m);
 
         // Check the matrix is identity
-        var identity = new Float32Array([1,0,0,0,0,1,0,0,0,0,1,0,0,0,0,1]);
-        for(var i=0 ; i<16; ++i) {
+        var identity = new Float32Array([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]);
+        for (var i = 0; i < 16; ++i) {
             equal(m.data[i], identity[i]);
         }
     });
 
-    it("clone", function() {
-        var m = new pc.Mat4(1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16);
+    it("clone", function () {
+        var m = new pc.Mat4().set([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
         var c = m.clone();
 
-        for(var i=0;i<16;++i) {
-           equal(m.data[i], c.data[i]);
+        for (var i = 0; i < 16; ++i) {
+            equal(m.data[i], c.data[i]);
         }
     });
 
-    it("mul2: I*I = I", function() {
+    it("mul2: I*I = I", function () {
         var m1 = new pc.Mat4();
         var m2 = new pc.Mat4();
         var m3 = new pc.Mat4();
@@ -46,7 +46,7 @@ describe("pc.Mat4", function () {
         deepEqual(m3.data, m4.data);
     });
 
-    it("mul2: I*A = A", function() {
+    it("mul2: I*A = A", function () {
         var m1 = new pc.Mat4();
         var m2 = new pc.Mat4().setFromAxisAngle(pc.Vec3.UP, 180 / 8);
         var m3 = new pc.Mat4();
@@ -55,7 +55,7 @@ describe("pc.Mat4", function () {
         deepEqual(m2.data, m3.data);
     });
 
-    it("mul2: A*I = A", function() {
+    it("mul2: A*I = A", function () {
         var m1 = new pc.Mat4().setFromAxisAngle(pc.Vec3.UP, 180 / 8);
         var m2 = new pc.Mat4();
         var m3 = new pc.Mat4();
@@ -64,7 +64,7 @@ describe("pc.Mat4", function () {
         deepEqual(m1.data, m3.data);
     });
 
-    it("transformPoint", function() {
+    it("transformPoint", function () {
         var t = new pc.Mat4();
         var v = new pc.Vec3(1, 0, 0);
         var r = new pc.Vec3();
@@ -77,7 +77,7 @@ describe("pc.Mat4", function () {
         expect(r.z).to.be.closeTo(0, 0.00001);
     });
 
-    it("transformPoint: src and result same", function() {
+    it("transformPoint: src and result same", function () {
         var t = new pc.Mat4();
         var v = new pc.Vec3(1, 0, 0);
 
@@ -89,10 +89,10 @@ describe("pc.Mat4", function () {
         expect(v.z).to.be.closeTo(0, 0.00001);
     });
 
-    it("setLookAt", function() {
+    it("setLookAt", function () {
         var position = new pc.Vec3(0, 0, 10);
-        var target   = new pc.Vec3(0, 0, 0);
-        var up       = new pc.Vec3(0, 1, 0);
+        var target = new pc.Vec3(0, 0, 0);
+        var up = new pc.Vec3(0, 1, 0);
 
         var lookAt = new pc.Mat4().setLookAt(position, target, up);
 
@@ -122,12 +122,12 @@ describe("pc.Mat4", function () {
         m.setFromAxisAngle(pc.Vec3.UP, 90);
         var r = new pc.Mat4();
         var heading = new pc.Vec3(-m.data[8], -m.data[9], -m.data[10]);
-        var left    = new pc.Vec3(m.data[0], m.data[1], m.data[2]);
-        var up      = new pc.Vec3(m.data[4], m.data[5], m.data[6]);
+        var left = new pc.Vec3(m.data[0], m.data[1], m.data[2]);
+        var up = new pc.Vec3(m.data[4], m.data[5], m.data[6]);
 
         r.setLookAt(new pc.Vec3(), heading, up);
 
-        for(var index = 0; index < 16; index++) {
+        for (var index = 0; index < 16; index++) {
             equal(r.data[index], m.data[index]);
         }
     });
@@ -137,17 +137,17 @@ describe("pc.Mat4", function () {
         m.setFromAxisAngle(pc.Vec3.UP, 90);
         var r = new pc.Mat4();
         var heading = new pc.Vec3(-m.data[8], -m.data[9], -m.data[10]);
-        var left    = new pc.Vec3(m.data[0], m.data[1], m.data[2]);
-        var up      = new pc.Vec3(m.data[4], m.data[5], m.data[6]);
+        var left = new pc.Vec3(m.data[0], m.data[1], m.data[2]);
+        var up = new pc.Vec3(m.data[4], m.data[5], m.data[6]);
 
         r.setLookAt(new pc.Vec3(), heading, up);
 
-        for(var index = 0; index < 16; index++) {
+        for (var index = 0; index < 16; index++) {
             equal(r.data[index], m.data[index]);
         }
     });
 
-    it("setTranslate", function() {
+    it("setTranslate", function () {
         var x = 10;
         var y = 20;
         var z = 30;
@@ -167,7 +167,7 @@ describe("pc.Mat4", function () {
     });
 
 
-    it("transpose", function() {
+    it("transpose", function () {
         var x = 10;
         var y = 20;
         var z = 30;
@@ -179,7 +179,7 @@ describe("pc.Mat4", function () {
         deepEqual(m.data, mTransTrans.data);
     });
 
-    it("invert", function() {
+    it("invert", function () {
         var x = 10;
         var y = 20;
         var z = 30;
@@ -193,7 +193,7 @@ describe("pc.Mat4", function () {
     });
 
     it("getX", function () {
-        var m = new pc.Mat4(1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16);
+        var m = new pc.Mat4().set([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
         var v1 = m.getX();
 
         equal(v1.x, 1);
@@ -210,7 +210,7 @@ describe("pc.Mat4", function () {
     });
 
     it("getY", function () {
-        var m = new pc.Mat4(1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16);
+        var m = new pc.Mat4().set([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
         var v1 = m.getY();
 
         equal(v1.x, 5);
@@ -227,7 +227,7 @@ describe("pc.Mat4", function () {
     });
 
     it("getZ", function () {
-        var m = new pc.Mat4(1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16);
+        var m = new pc.Mat4().set([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
         var v1 = m.getZ();
 
         equal(v1.x, 9);
@@ -243,8 +243,8 @@ describe("pc.Mat4", function () {
         equal(v2.z, 11);
     });
 
-    it("getTranslation", function() {
-        var m = new pc.Mat4(1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16);
+    it("getTranslation", function () {
+        var m = new pc.Mat4().set([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
         var v1 = m.getTranslation();
 
         equal(v1.x, 13);
@@ -260,8 +260,8 @@ describe("pc.Mat4", function () {
         equal(v2.z, 15);
     });
 
-    it("getScale", function() {
-        var m = new pc.Mat4(2,0,0,1,0,3,0,1,0,0,4,1,0,0,0,1);
+    it("getScale", function () {
+        var m = new pc.Mat4().set([2, 0, 0, 1, 0, 3, 0, 1, 0, 0, 4, 1, 0, 0, 0, 1]);
         var v1 = m.getScale();
 
         equal(v1.x, 2);
@@ -281,38 +281,38 @@ describe("pc.Mat4", function () {
     it("getEulerAngles", function () {
         var m, e;
 
-        m = new pc.Mat4(1,0,0,0,0,1,0,0,0,0,1,0,0,0,0,1);
+        m = new pc.Mat4().set([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]);
         e = new pc.Vec3();
         m.getEulerAngles(e);
         equal(e.x, 0);
         equal(e.y, 0);
         equal(e.z, 0);
 
-        m = new pc.Mat4(1,0,0,0, 0,0,1,0, 0,-1,0,0, 0,0,0,1);
+        m = new pc.Mat4().set([1, 0, 0, 0, 0, 0, 1, 0, 0, -1, 0, 0, 0, 0, 0, 1]);
         m.getEulerAngles(e);
         approx(e.x, 90, e.x.toString() + " ~= " + 90);
         equal(e.y, 0);
         equal(e.z, 0);
 
-        m = new pc.Mat4(1,0,0,0 ,0,1,0,0, 0,0,1,0, 0,0,0,1);
+        m = new pc.Mat4().set([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]);
         m.getEulerAngles(e);
         equal(e.x, 0);
         equal(e.y, 0);
         equal(e.z, 0);
 
-        m = new pc.Mat4(0.7071067811865476,0,0.7071067811865476,0,0,1,0,0,-0.7071067811865476,0,0.7071067811865476,0,0,0,0,1);
+        m = new pc.Mat4().set([0.7071067811865476, 0, 0.7071067811865476, 0, 0, 1, 0, 0, -0.7071067811865476, 0, 0.7071067811865476, 0, 0, 0, 0, 1]);
         m.getEulerAngles(e);
         equal(e.x, 0);
         approx(e.y, -45, e.y.toString() + " ~= " + -45);
         equal(e.z, 0);
 
-        m = new pc.Mat4(1,0,0,0, 0,0.7071067811865476,-0.7071067811865476,0, 0,0.7071067811865476,0.7071067811865476,0, 0,0,0,1);
+        m = new pc.Mat4().set([1, 0, 0, 0, 0, 0.7071067811865476, -0.7071067811865476, 0, 0, 0.7071067811865476, 0.7071067811865476, 0, 0, 0, 0, 1]);
         m.getEulerAngles(e);
         approx(e.x, -45, e.x.toString() + " ~= " + -45);
         equal(e.y, 0);
         equal(e.z, 0);
 
-        m = new pc.Mat4(0.7071067811865476,-0.7071067811865476,0,0, 0.7071067811865476,0.7071067811865476,0,0, 0,0,1,0, 0,0,0,1);
+        m = new pc.Mat4().set([0.7071067811865476, -0.7071067811865476, 0, 0, 0.7071067811865476, 0.7071067811865476, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]);
         m.getEulerAngles(e);
         equal(e.x, 0);
         equal(e.y, 0);
@@ -322,31 +322,29 @@ describe("pc.Mat4", function () {
     it("setFromEulerAngles", function () {
         var m, mr, mrx, mry, mrz, x, y, z;
 
-
-
         // no rotation -> identity
         x = y = z = 0;
-        m = new pc.Mat4().setFromEulerAngles(x,y,z);
-        deepEqual(clip(m.data), [1,0,0,0,0,1,0,0,0,0,1,0,0,0,0,1]);
+        m = new pc.Mat4().setFromEulerAngles(x, y, z);
+        deepEqual(clip(m.data), [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]);
 
         // Rotate 45 around y
         y = 45;
         x = z = 0;
-        m = new pc.Mat4().setFromEulerAngles(x,y,z);
+        m = new pc.Mat4().setFromEulerAngles(x, y, z);
         var m1 = new pc.Mat4().setFromAxisAngle(pc.Vec3.UP, y);
-        deepEqual(clip(m.data), [0.707,0,-0.707,0,0,1,0,0,0.707,0,0.707,0, 0,0,0,1]);
+        deepEqual(clip(m.data), [0.707, 0, -0.707, 0, 0, 1, 0, 0, 0.707, 0, 0.707, 0, 0, 0, 0, 1]);
 
         // Rotate 45 around x
         x = 45;
         y = z = 0;
-        m = new pc.Mat4().setFromEulerAngles(x,y,z);
-        deepEqual(clip(m.data), [1,0,0,0, 0,0.707,0.707,0, 0,-0.707,0.707,0, 0,0,0,1]);
+        m = new pc.Mat4().setFromEulerAngles(x, y, z);
+        deepEqual(clip(m.data), [1, 0, 0, 0, 0, 0.707, 0.707, 0, 0, -0.707, 0.707, 0, 0, 0, 0, 1]);
 
         // Rotate 45 around z
         z = 45;
         y = x = 0;
-        m = new pc.Mat4().setFromEulerAngles(x,y,z);
-        deepEqual(clip(m.data), [0.707,0.707,0,0, -0.707,0.707,0,0, 0,0,1,0, 0,0,0,1]);
+        m = new pc.Mat4().setFromEulerAngles(x, y, z);
+        deepEqual(clip(m.data), [0.707, 0.707, 0, 0, -0.707, 0.707, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]);
 
         // Arbitrary rotation
         x = 33;
@@ -363,17 +361,17 @@ describe("pc.Mat4", function () {
 
     it("fromEuler and back", function () {
 
-        var m1 = new pc.Mat4(0.7071067811865476,0,0.7071067811865476,0,0,1,0,0,-0.7071067811865476,0,0.7071067811865476,0, 0,0,0,1);
+        var m1 = new pc.Mat4().set([0.7071067811865476, 0, 0.7071067811865476, 0, 0, 1, 0, 0, -0.7071067811865476, 0, 0.7071067811865476, 0, 0, 0, 0, 1]);
         var m2;
 
         var r = new pc.Vec3();
         m1.getEulerAngles(r);
         m2 = new pc.Mat4().setFromEulerAngles(r.x, r.y, r.z);
 
-        deepEqual(clip(m1.data),clip(m2.data));
+        deepEqual(clip(m1.data), clip(m2.data));
     });
 
-    it("setTRS", function() {
+    it("setTRS", function () {
 
         var tx = 10;
         var ty = 20;
@@ -390,7 +388,8 @@ describe("pc.Mat4", function () {
         var temp = new pc.Mat4().mul2(mt, mr);
         var m2 = new pc.Mat4().mul2(temp, ms);
 
-        for (var i = 0; i < m1.length; i++) {
+        var i;
+        for (i = 0; i < m1.length; i++) {
             close(m1.data[i], m2.data[i], 0.0001);
         }
 
@@ -400,27 +399,20 @@ describe("pc.Mat4", function () {
         m1 = new pc.Mat4().setTRS(t, r, s);
         m2 = [0, 0, -2, 0, 0, 3, 0, 0, 4, 0, 0, 0, 10, 20, 30, 1];
 
-        for (var i = 0; i < m1.length; i++) {
+        for (i = 0; i < m1.length; i++) {
             expect(m1.data[i]).to.equal(m2.data[i]);
         }
     });
 
+    // it("makeRotate", function() {
+    //     ok(false, "Not written");
+    // });
 
-    /*
+    // it("makeFrustum", function() {
+    //     ok(false, "Not written")
+    // });
 
-    it("makeRotate", function() {
-        ok(false, "Not written");
-    });
-
-    it("makeFrustum", function() {
-        ok(false, "Not written")
-    });
-
-    it("makePerspective", function() {
-        ok(false, "Not written");
-    });
-
-    */
-
+    // it("makePerspective", function() {
+    //     ok(false, "Not written");
+    // });
 });
-


### PR DESCRIPTION
Node _dirtify method was deoptimised by compiler due to num. agrs. ambiguity.
Same for Mat4 and Mat3 constructors. Requires user-code changes.  

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
