### PR TITLE
Prevent initialize() overwriting textures to null if they are waiting…

### DIFF
--- a/src/resources/parser/material/json-standard-material.js
+++ b/src/resources/parser/material/json-standard-material.js
@@ -53,12 +53,18 @@ Object.assign(pc, function () {
             } else if (type === 'texture') {
                 if (value instanceof pc.Texture) {
                     material[key] = value;
+                } else if (material[key] instanceof pc.Texture && typeof(value) === 'number' && value > 0) {
+                    // material already has a texture assigned, but data contains a valid asset id (which means the asset isn't yet loaded)
+                    // leave current texture (probably a placeholder) until the asset is loaded
                 } else {
                     material[key] = null;
                 }
             } else if (type === 'cubemap') {
                 if (value instanceof pc.Texture) {
                     material[key] = value;
+                } else if (material[key] instanceof pc.Texture && typeof(value) === 'number' && value > 0) {
+                    // material already has a texture assigned, but data contains a valid asset id (which means the asset isn't yet loaded)
+                    // leave current texture (probably a placeholder) until the asset is loaded
                 } else {
                     material[key] = null;
                 }


### PR DESCRIPTION
… on an asset to be loaded

initialize() is called on a material immediately after the placeholder textures are assigned. The source data currently replaces asset id with the actual texture and initialize would clear to null if the data didn't contain the texture. Instead we now also check if it is an asset id, in which case we can wait until the asset is loaded and leave the placeholder texture.

This prevents additional shader compilation calls (because the number of textures on the material changes).
