### PR TITLE
Ensure shadow receiving is disabled when there are no lights

### DIFF
--- a/src/scene/materials/standard-material-options-builder.js
+++ b/src/scene/materials/standard-material-options-builder.js
@@ -192,7 +192,7 @@ Object.assign(pc, function () {
         }
 
         if (options.lights.length === 0) {
-            options.noShadow = false;
+            options.noShadow = true;
         }
     };
 


### PR DESCRIPTION
This looks like a logic error in the standard material shader generator. When there are no lights specified, noShadow should be true (meaning no shadowmapping shadow chunk is ever going to be required.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
