### PR TITLE
Clear up more data when app is destroyed

### DIFF
--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -443,7 +443,7 @@ Object.assign(pc, function () {
         this._scriptPrefix = options.scriptPrefix || '';
 
         this.loader.addHandler("animation", new pc.AnimationHandler());
-        this.loader.addHandler("model", new pc.ModelHandler(this.graphicsDevice));
+        this.loader.addHandler("model", new pc.ModelHandler(this.graphicsDevice, this.scene.defaultMaterial));
         this.loader.addHandler("material", new pc.MaterialHandler(this));
         this.loader.addHandler("texture", new pc.TextureHandler(this.graphicsDevice, this.assets, this.loader));
         this.loader.addHandler("text", new pc.TextHandler());
@@ -1461,10 +1461,12 @@ Object.assign(pc, function () {
             }
 
             this.off('librariesloaded');
-            document.removeEventListener('visibilitychange', this._visibilityChangeHandler);
-            document.removeEventListener('mozvisibilitychange', this._visibilityChangeHandler);
-            document.removeEventListener('msvisibilitychange', this._visibilityChangeHandler);
-            document.removeEventListener('webkitvisibilitychange', this._visibilityChangeHandler);
+            document.removeEventListener('visibilitychange', this._visibilityChangeHandler, false);
+            document.removeEventListener('mozvisibilitychange', this._visibilityChangeHandler, false);
+            document.removeEventListener('msvisibilitychange', this._visibilityChangeHandler, false);
+            document.removeEventListener('webkitvisibilitychange', this._visibilityChangeHandler, false);
+            this._visibilityChangeHandler = null;
+            this.onVisibilityChange = null;
 
             this.root.destroy();
             this.root = null;
@@ -1507,7 +1509,16 @@ Object.assign(pc, function () {
             var assets = this.assets.list();
             for (i = 0; i < assets.length; i++) {
                 assets[i].unload();
+                assets[i].off();
             }
+            this.assets.off();
+
+            for (var key in this.loader.getHandler('script')._cache) {
+                var element = this.loader.getHandler('script')._cache[key];
+                var parent = element.parentNode;
+                if (parent) parent.removeChild(element);
+            }
+            this.loader.getHandler('script')._cache = {};
 
             this.loader.destroy();
             this.loader = null;
@@ -1532,7 +1543,6 @@ Object.assign(pc, function () {
             this.batcher = null;
 
             this._entityIndex = {};
-            this._visibilityChangeHandler = null;
 
             this.defaultLayerDepth.onPreRenderOpaque = null;
             this.defaultLayerDepth.onPostRenderOpaque = null;
@@ -1557,7 +1567,7 @@ Object.assign(pc, function () {
             }
 
             pc.http = new pc.Http();
-
+            pc.script.app = null;
             // remove default particle texture
             pc.ParticleEmitter.DEFAULT_PARAM_TEXTURE = null;
         }

--- a/src/framework/components/element/system.js
+++ b/src/framework/components/element/system.js
@@ -62,6 +62,10 @@ Object.assign(pc, function () {
     pc.Component._buildAccessors(pc.ElementComponent.prototype, _schema);
 
     Object.assign(ElementComponentSystem.prototype, {
+        destroy: function () {
+            this._defaultTexture.destroy();
+        },
+
         initializeComponentData: function (component, data, properties) {
             component._beingInitialized = true;
 

--- a/src/framework/components/model/component.js
+++ b/src/framework/components/model/component.js
@@ -50,7 +50,7 @@ Object.assign(pc, function () {
         this._receiveShadows = true;
 
         this._materialAsset = null;
-        this._material = pc.ModelHandler.DEFAULT_MATERIAL;
+        this._material = system.defaultMaterial;
 
         this._castShadowsLightmap = true;
         this._lightmapped = false;
@@ -201,14 +201,14 @@ Object.assign(pc, function () {
                     meshInstance.material = materialAsset.resource;
 
                     this._setMaterialEvent(index, 'remove', materialAsset.id, function () {
-                        meshInstance.material = pc.ModelHandler.DEFAULT_MATERIAL;
+                        meshInstance.material = this.system.defaultMaterial;
                     });
                 } else {
                     this._setMaterialEvent(index, 'load', materialAsset.id, function (asset) {
                         meshInstance.material = asset.resource;
 
                         this._setMaterialEvent(index, 'remove', materialAsset.id, function () {
-                            meshInstance.material = pc.ModelHandler.DEFAULT_MATERIAL;
+                            meshInstance.material = this.system.defaultMaterial;
                         });
                     });
 
@@ -370,7 +370,7 @@ Object.assign(pc, function () {
         },
 
         _onMaterialAssetUnload: function (asset) {
-            this.material = pc.ModelHandler.DEFAULT_MATERIAL;
+            this.material = this.system.defaultMaterial;
         },
 
         _onMaterialAssetRemove: function (asset) {
@@ -871,13 +871,13 @@ Object.assign(pc, function () {
                 if (this._materialAsset) {
                     var asset = assets.get(this._materialAsset);
                     if (!asset) {
-                        this.material = pc.ModelHandler.DEFAULT_MATERIAL;
+                        this.material = this.system.defaultMaterial;
                         assets.on('add:' + this._materialAsset, this._onMaterialAdded, this);
                     } else {
                         this._bindMaterialAsset(asset);
                     }
                 } else {
-                    this.material = pc.ModelHandler.DEFAULT_MATERIAL;
+                    this.material = this.system.defaultMaterial;
                 }
             }
         }
@@ -934,7 +934,7 @@ Object.assign(pc, function () {
                         asset = this.system.app.assets.get(value[i]);
                         this._loadAndSetMeshInstanceMaterial(asset, meshInstances[i], i);
                     } else {
-                        meshInstances[i].material = pc.ModelHandler.DEFAULT_MATERIAL;
+                        meshInstances[i].material = this.system.defaultMaterial;
                     }
                 } else if (assetMapping) {
                     if (assetMapping[i] && (assetMapping[i].material || assetMapping[i].path)) {
@@ -948,7 +948,7 @@ Object.assign(pc, function () {
                         }
                         this._loadAndSetMeshInstanceMaterial(asset, meshInstances[i], i);
                     } else {
-                        meshInstances[i].material = pc.ModelHandler.DEFAULT_MATERIAL;
+                        meshInstances[i].material = this.system.defaultMaterial;
                     }
                 }
             }

--- a/src/framework/components/model/system.js
+++ b/src/framework/components/model/system.js
@@ -30,7 +30,7 @@ Object.assign(pc, function () {
         this.plane = null;
         this.sphere = null;
 
-        this.defaultMaterial = new pc.StandardMaterial();
+        this.defaultMaterial = app.scene.defaultMaterial;
 
         this.on('beforeremove', this.onRemove, this);
     };
@@ -104,7 +104,7 @@ Object.assign(pc, function () {
 
             var material = entity.model.material;
             if (!material ||
-                material === pc.ModelHandler.DEFAULT_MATERIAL ||
+                material === this.defaultMaterial ||
                 !materialAsset ||
                 material === materialAsset.resource) {
 

--- a/src/framework/components/sprite/system.js
+++ b/src/framework/components/sprite/system.js
@@ -72,6 +72,11 @@ Object.assign(pc, function () {
     pc.Component._buildAccessors(pc.SpriteComponent.prototype, _schema);
 
     Object.assign(SpriteComponentSystem.prototype, {
+        destroy: function () {
+            this._defaultTexture.destroy();
+            this._defaultTexture = null;
+        },
+
         initializeComponentData: function (component, data, properties) {
             if (data.enabled !== undefined) {
                 component.enabled = data.enabled;

--- a/src/graphics/device.js
+++ b/src/graphics/device.js
@@ -2927,10 +2927,15 @@ Object.assign(pc, function () {
                 this.gl.deleteTransformFeedback(this.feedback);
             }
 
+            this.grabPassTexture.destroy();
+
             this.clearShaderCache();
 
             this.canvas.removeEventListener('webglcontextlost', this._contextLostHandler, false);
             this.canvas.removeEventListener('webglcontextrestored', this._contextRestoredHandler, false);
+
+            this._contextLostHandler = null;
+            this._contextRestoredHandler = null;
 
             this.canvas = null;
             this.gl = null;

--- a/src/graphics/texture.js
+++ b/src/graphics/texture.js
@@ -597,7 +597,11 @@ Object.assign(pc, function () {
          * @description Forcibly free up the underlying WebGL resource owned by the texture.
          */
         destroy: function () {
-            this.device.destroyTexture(this);
+            if (this.device) {
+                this.device.destroyTexture(this);
+            }
+            this.device = null;
+            this._levels = [];
         },
 
         // Force a full resubmission of the texture to WebGL (used on a context restore event)

--- a/src/resources/model.js
+++ b/src/resources/model.js
@@ -6,16 +6,15 @@ Object.assign(pc, function () {
      * @description {@link pc.ResourceHandler} use to load 3D model resources
      * @param {pc.GraphicsDevice} device The graphics device that will be rendering
      */
-    var ModelHandler = function (device) {
+    var ModelHandler = function (device, defaultMaterial) {
         this._device = device;
         this._parsers = [];
+        this._defaultMaterial = defaultMaterial;
 
         this.addParser(new pc.JsonModelParser(this._device), function (url, data) {
             return (pc.path.getExtension(url) === '.json');
         });
     };
-
-    ModelHandler.DEFAULT_MATERIAL = pc.Scene.defaultMaterial;
 
     Object.assign(ModelHandler.prototype, {
         /**
@@ -78,13 +77,14 @@ Object.assign(pc, function () {
                         }
 
                         asset.once('remove', function (asset) {
-                            if (meshInstance.material === asset.resource)
-                                meshInstance.material = pc.ModelHandler.DEFAULT_MATERIAL;
+                            if (meshInstance.material === asset.resource) {
+                                meshInstance.material = this._defaultMaterial;
+                            }
                         });
                     };
 
                     if (!data.mapping[i]) {
-                        meshInstance.material = pc.ModelHandler.DEFAULT_MATERIAL;
+                        meshInstance.material = this._defaultMaterial;
                         return;
                     }
 
@@ -94,7 +94,7 @@ Object.assign(pc, function () {
 
                     if (id !== undefined) { // id mapping
                         if (!id) {
-                            meshInstance.material = pc.ModelHandler.DEFAULT_MATERIAL;
+                            meshInstance.material = this._defaultMaterial;
                         } else {
                             material = assets.get(id);
                             if (material) {

--- a/src/resources/parser/json-model.js
+++ b/src/resources/parser/json-model.js
@@ -24,6 +24,7 @@ Object.assign(pc, function () {
     // Take PlayCanvas JSON model data and create pc.Model
     var JsonModelParser = function (device) {
         this._device = device;
+        this._defaultMaterial = pc.getDefaultMaterial();
     };
 
     Object.assign(JsonModelParser.prototype, {
@@ -668,7 +669,7 @@ Object.assign(pc, function () {
                 var node = nodes[meshInstanceData.node];
                 var mesh = meshes[meshInstanceData.mesh];
 
-                var meshInstance = new pc.MeshInstance(node, mesh, pc.ModelHandler.DEFAULT_MATERIAL);
+                var meshInstance = new pc.MeshInstance(node, mesh, this._defaultMaterial);
 
                 if (mesh.skin) {
                     var skinIndex = skins.indexOf(mesh.skin);

--- a/src/resources/parser/obj-model.js
+++ b/src/resources/parser/obj-model.js
@@ -18,6 +18,7 @@ Object.assign(pc, function () {
     // this.app.assets.load(asset);
     var ObjModelParser = function (device) {
         this._device = device;
+        this._defaultMaterial = pc.getDefaultMaterial();
     };
 
     Object.assign(ObjModelParser.prototype, {
@@ -108,7 +109,7 @@ Object.assign(pc, function () {
                     normals: currentGroup.normals,
                     uvs: currentGroup.uvs
                 });
-                var mi = new pc.MeshInstance(new pc.GraphNode(), mesh, pc.ModelHandler.DEFAULT_MATERIAL);
+                var mi = new pc.MeshInstance(new pc.GraphNode(), mesh, this._defaultMaterial);
                 model.meshInstances.push(mi);
                 root.addChild(mi.node);
             }

--- a/src/scene/forward-renderer.js
+++ b/src/scene/forward-renderer.js
@@ -1547,7 +1547,7 @@ Object.assign(pc, function () {
                         // #ifdef DEBUG
                         if (!device.setShader(drawCall._shader[pass])) {
                             console.error('Error in material "' + material.name + '" with flags ' + objDefs);
-                            drawCall.material = pc.Scene.defaultMaterial;
+                            drawCall.material = scene.defaultMaterial;
                         }
                         // #else
                         device.setShader(drawCall._shader[pass]);

--- a/src/scene/materials/default-material.js
+++ b/src/scene/materials/default-material.js
@@ -1,3 +1,3 @@
-pc.Scene.defaultMaterial = new pc.StandardMaterial();
-// set default material to physical shading
-pc.Scene.defaultMaterial.shadingModel = pc.SPECULAR_BLINN;
+pc.getDefaultMaterial = function () {
+    return pc.Application.getApplication().scene.defaultMaterial;
+}

--- a/src/scene/materials/material.js
+++ b/src/scene/materials/material.js
@@ -444,8 +444,9 @@ Object.assign(pc, function () {
                 meshInstance._shader[j] = null;
             }
             meshInstance._material = null;
-            if (this !== pc.Scene.defaultMaterial) {
-                meshInstance.material = pc.Scene.defaultMaterial;
+            var defaultMaterial = pc.getDefaultMaterial();
+            if (this !== defaultMaterial) {
+                meshInstance.material = defaultMaterial;
             }
         }
     };

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -474,11 +474,17 @@ Object.assign(pc, function () {
         // backwards compatibilty only
         this._models = [];
 
+        // default material used in case no other material is available
+        this.defaultMaterial = new pc.StandardMaterial();
+        this.defaultMaterial.shadingModel = pc.SPECULAR_BLINN;
+
         pc.events.attach(this);
     };
 
     Scene.prototype.destroy = function () {
         this.root = null;
+        this.defaultMaterial.destroy();
+        this.defaultMaterial = null;
         this.off();
     };
 

--- a/tests/batching/test_batching.js
+++ b/tests/batching/test_batching.js
@@ -1,6 +1,7 @@
 describe('pc.Batcher', function () {
     beforeEach(function () {
         this.app = new pc.Application(document.createElement("canvas"));
+
         this.bg = this.app.batcher.addGroup("Test Group", false, 100);
 
     });

--- a/tests/framework/components/layout-group/test_layoutcalculator.js
+++ b/tests/framework/components/layout-group/test_layoutcalculator.js
@@ -2,6 +2,7 @@ describe("pc.LayoutCalculator", function () {
     var app;
     var calculator;
     var options;
+    var elements;
     var mixedWidthElements;
     var mixedHeightElements;
     var mixedWidthElementsWithLayoutChildComponents;

--- a/tests/framework/components/model/test_modelcomponent.js
+++ b/tests/framework/components/model/test_modelcomponent.js
@@ -4,7 +4,6 @@ describe("pc.ModelComponent", function () {
 
     beforeEach(function (done) {
         app = new pc.Application(document.createElement("canvas"));
-
         loadAssets(function () {
             done();
         });

--- a/tests/framework/utils/test_entityreference.js
+++ b/tests/framework/utils/test_entityreference.js
@@ -23,6 +23,7 @@ describe("pc.EntityReference", function () {
 
     afterEach(function () {
         sinon.restore();
+        app.destroy();
     });
 
     // Assertion helpers that rely on checking some private state. Usually I wouldn't do


### PR DESCRIPTION
Remove static default material and replace with material stored in scene
Remove script elements from cache in app destroy
Remove all asset events on app destroy
Clear pc.script.app on app destroy

All help to make tests more stable
