### PR TITLE
Shader key generator cache for min-options (shadow-map pass).

### DIFF
--- a/src/graphics/program-lib/standard.js
+++ b/src/graphics/program-lib/standard.js
@@ -138,20 +138,33 @@ pc.programlib.standard = {
         transformUv1: { n: "transformVS", f: _oldChunkTransformUv1 }
     },
 
+    // Shared Sandard Material option structures
+    optionsContext: {},
+    optionsContextMin: {},
+
     generateKey: function (options) {
-        if (!this.props) {
-            this.props = [];
+        var buildPropertiesList = function (options) {
+            var props = [];
             for (var prop in options) {
                 if (options.hasOwnProperty(prop) && prop !== "chunks" && prop !== "lights")
-                    this.props.push(prop);
+                    props.push(prop);
             }
-            this.props.sort();
+            return props.sort();
+        };
+        var props;
+        if (options === this.optionsContextMin) {
+            if (!this.propsMin) this.propsMin = buildPropertiesList(options);
+            props = this.propsMin;
+        } else if (options === this.optionsContext) {
+            if (!this.props) this.props = buildPropertiesList(options);
+            props = this.props;
+        } else {
+            props = buildPropertiesList(options);
         }
 
         var key = "standard";
 
         var i;
-        var props = this.props;
         for (i = 0; i < props.length; i++) {
             if (options[props[i]])
                 key += props[i] + options[props[i]];

--- a/src/graphics/program-library.js
+++ b/src/graphics/program-library.js
@@ -7,10 +7,6 @@ Object.assign(pc, function () {
         this._cache = {};
         this._generators = {};
         this._isClearingCache = false;
-
-        // Shared Sandard Material option structures
-        this.optionsContext = {};
-        this.optionsContextMin = {};
     };
 
     ProgramLibrary.prototype.register = function (name, generator) {

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -894,11 +894,10 @@ Object.assign(pc, function () {
                 }
             }
 
-            var library = device.getProgramLibrary();
+            var generator = pc.programlib.standard;
             // Minimal options for Depth and Shadow passes
             var minimalOptions = pass > pc.SHADER_FORWARDHDR && pass <= pc.SHADER_PICK;
-
-            var options = minimalOptions ? library.optionsContextMin : library.optionsContext;
+            var options = minimalOptions ? generator.optionsContextMin : generator.optionsContext;
 
             if (minimalOptions)
                 this.shaderOptBuilder.updateMinRef(options, device, scene, this, objDefs, staticLightList, pass, sortedLights, prefilteredCubeMap128);
@@ -909,6 +908,7 @@ Object.assign(pc, function () {
                 options = this.onUpdateShader(options);
             }
 
+            var library = device.getProgramLibrary();
             this.shader = library.getProgram('standard', options);
 
             if (!objDefs) {


### PR DESCRIPTION
Fix for an issue where material changes does not affect preview and viewport.
Options context moved to standard gen.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
