### PR TITLE
COMPUPDATED_INSTANCES shouldn't trigger updateShaders 

### DIFF
--- a/src/scene/layer-composition.js
+++ b/src/scene/layer-composition.js
@@ -156,7 +156,7 @@ Object.assign(pc, function () {
         this._dirty = false;
 
         var casters, lid, light;
-        if (this._dirtyLights || (result & pc.COMPUPDATED_INSTANCES)) {
+        if (this._dirtyLights) {
             result |= pc.COMPUPDATED_LIGHTS;
             this._lights.length = 0;
             this._lightShadowCasters.length = 0;


### PR DESCRIPTION
performance
COMPUPDATED_LIGHTS is applied every time a new mesh added/removed
Causes all shaders rebuild

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
