### PR TITLE
Update only shaders that depends on lighting on COMPUPDATED_LIGHTS

### DIFF
--- a/src/scene/forward-renderer.js
+++ b/src/scene/forward-renderer.js
@@ -2096,6 +2096,32 @@ Object.assign(pc, function () {
             // #endif
         },
 
+        updateLitShaders: function (drawCalls) {
+            // #ifdef PROFILER
+            var time = pc.now();
+            // #endif
+
+            for (var i = 0; i < drawCalls.length; i++) {
+                var drawCall = drawCalls[i];
+                if (drawCall.material !== undefined) {
+                    var mat = drawCall.material;
+                    if (mat.updateShader !== pc.Material.prototype.updateShader) {
+                        if (mat.useLighting === false || (mat.emitter && !mat.emitter.lighting)) {
+                            // skip unlit standard and particles materials
+                            continue;
+                        }
+                        mat.clearVariants();
+                        mat.shader = null;
+                    }
+                }
+            }
+
+            // #ifdef PROFILER
+            this.scene._stats.updateShadersTime += pc.now() - time;
+            // #endif
+        },
+
+
         beginFrame: function (comp) {
             var device = this.device;
             var scene = this.scene;
@@ -2112,6 +2138,11 @@ Object.assign(pc, function () {
             if (scene.updateShaders) {
                 this.updateShaders(meshInstances);
                 scene.updateShaders = false;
+                scene.updateLitShaders = false;
+                scene._shaderVersion++;
+            } else if (scene.updateLitShaders) {
+                this.updateLitShaders(meshInstances);
+                scene.updateLitShaders = false;
                 scene._shaderVersion++;
             }
 
@@ -2467,7 +2498,7 @@ Object.assign(pc, function () {
             // Update static layer data, if something's changed
             var updated = comp._update();
             if (updated & pc.COMPUPDATED_LIGHTS) {
-                this.scene.updateShaders = true;
+                this.scene.updateLitShaders = true;
             }
 
             // #ifdef PROFILER

--- a/src/scene/light.js
+++ b/src/scene/light.js
@@ -303,8 +303,6 @@ Object.assign(pc, function () {
                 return;
 
             this._enabled = value;
-            if (this._scene !== null)
-                this._scene.updateShaders = true;
         }
     });
 
@@ -318,8 +316,6 @@ Object.assign(pc, function () {
 
             this._type = value;
             this._destroyShadowMap();
-            if (this._scene !== null)
-                this._scene.updateShaders = true;
             this.updateKey();
 
             var stype = this._shadowType;
@@ -339,8 +335,6 @@ Object.assign(pc, function () {
                 return;
 
             this._mask = value;
-            if (this._scene !== null)
-                this._scene.updateShaders = true;
         }
     });
 
@@ -372,8 +366,6 @@ Object.assign(pc, function () {
 
             this._shadowType = value;
             this._destroyShadowMap();
-            if (this._scene !== null)
-                this._scene.updateShaders = true;
             this.updateKey();
         }
     });
@@ -387,8 +379,6 @@ Object.assign(pc, function () {
                 return;
 
             this._castShadows = value;
-            if (this._scene !== null)
-                this._scene.updateShaders = true;
             this.updateKey();
         }
     });
@@ -433,8 +423,6 @@ Object.assign(pc, function () {
                 return;
 
             if ((!this._normalOffsetBias && value) || (this._normalOffsetBias && !value)) {
-                if (this._scene !== null)
-                    this._scene.updateShaders = true;
                 this.updateKey();
             }
             this._normalOffsetBias = value;
@@ -450,8 +438,6 @@ Object.assign(pc, function () {
                 return;
 
             this._falloffMode = value;
-            if (this._scene !== null)
-                this._scene.updateShaders = true;
             this.updateKey();
         }
     });
@@ -503,8 +489,6 @@ Object.assign(pc, function () {
                 return;
 
             this._cookie = value;
-            if (this._scene !== null)
-                this._scene.updateShaders = true;
             this.updateKey();
         }
     });
@@ -518,8 +502,6 @@ Object.assign(pc, function () {
                 return;
 
             this._cookieFalloff = value;
-            if (this._scene !== null)
-                this._scene.updateShaders = true;
             this.updateKey();
         }
     });
@@ -539,8 +521,6 @@ Object.assign(pc, function () {
                     value += chr;
             }
             this._cookieChannel = value;
-            if (this._scene !== null)
-                this._scene.updateShaders = true;
             this.updateKey();
         }
     });
@@ -553,12 +533,6 @@ Object.assign(pc, function () {
             if (this._cookieTransform === value)
                 return;
 
-            var xformOld = !!(this._cookieTransformSet || this._cookieOffsetSet);
-            var xformNew = !!(value || this._cookieOffsetSet);
-            if (xformOld !== xformNew) {
-                if (this._scene !== null)
-                    this._scene.updateShaders = true;
-            }
             this._cookieTransform = value;
             this._cookieTransformSet = !!value;
             if (value && !this._cookieOffset) {
@@ -577,12 +551,8 @@ Object.assign(pc, function () {
             if (this._cookieOffset === value)
                 return;
 
-            var xformOld = !!(this._cookieTransformSet || this._cookieOffsetSet);
             var xformNew = !!(this._cookieTransformSet || value);
-            if (xformOld !== xformNew) {
-                if (this._scene !== null)
-                    this._scene.updateShaders = true;
-            }
+
             if (xformNew && !value && this._cookieOffset) {
                 this._cookieOffset.set(0, 0);
             } else {


### PR DESCRIPTION
Whenever COMPUPDATED_LIGHTS is fired keep unaffected by light shaders (some standard materials and unlit particles). Do not directly force shaders rebuild from the light entitities, should propagate update through COMPUPDATED_LIGHTS.  

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
