### PR TITLE
Layer composition updates shadow casters

### DIFF
--- a/src/scene/layer-composition.js
+++ b/src/scene/layer-composition.js
@@ -159,7 +159,7 @@ Object.assign(pc, function () {
         // Note that if the check for (result & pc.COMPUPDATED_INSTANCES) is not present
         // then shadow casting mesh instances are left in a layer when disabling model
         // components that are shadow casters
-        if (this._dirtyLights || (result & pc.COMPUPDATED_INSTANCES)) {
+        if (this._dirtyLights) {
             result |= pc.COMPUPDATED_LIGHTS;
             this._lights.length = 0;
             this._lightShadowCasters.length = 0;
@@ -205,6 +205,12 @@ Object.assign(pc, function () {
                     lid = this._lights.indexOf(light);
                     casters = this._lightShadowCasters[lid];
                     var meshInstances = layer.shadowCasters;
+                    for (k = 0; k < casters.length; k++) {
+                        if (!this._meshInstances.includes(casters[k])) {
+                            casters[k] = casters[casters.length - 1];
+                            casters.length -= 1;
+                        }
+                    }
                     for (k = 0; k < meshInstances.length; k++) {
                         if (casters.indexOf(meshInstances[k]) < 0) casters.push(meshInstances[k]);
                     }

--- a/src/scene/layer-composition.js
+++ b/src/scene/layer-composition.js
@@ -156,9 +156,6 @@ Object.assign(pc, function () {
         this._dirty = false;
 
         var casters, lid, light;
-        // Note that if the check for (result & pc.COMPUPDATED_INSTANCES) is not present
-        // then shadow casting mesh instances are left in a layer when disabling model
-        // components that are shadow casters
         if (this._dirtyLights) {
             result |= pc.COMPUPDATED_LIGHTS;
             this._lights.length = 0;

--- a/src/scene/layer-composition.js
+++ b/src/scene/layer-composition.js
@@ -205,10 +205,12 @@ Object.assign(pc, function () {
                     lid = this._lights.indexOf(light);
                     casters = this._lightShadowCasters[lid];
                     var meshInstances = layer.shadowCasters;
-                    for (k = 0; k < casters.length; k++) {
+                    for (k = 0; k < casters.length;) {
                         if (!this._meshInstances.includes(casters[k])) {
                             casters[k] = casters[casters.length - 1];
                             casters.length -= 1;
+                        } else {
+                            k++;
                         }
                     }
                     for (k = 0; k < meshInstances.length; k++) {

--- a/src/scene/layer-composition.js
+++ b/src/scene/layer-composition.js
@@ -206,7 +206,7 @@ Object.assign(pc, function () {
                     casters = this._lightShadowCasters[lid];
                     var meshInstances = layer.shadowCasters;
                     for (k = 0; k < casters.length;) {
-                        if (!this._meshInstances.includes(casters[k])) {
+                        if (this._meshInstances.indexOf(casters[k]) < 0) {
                             casters[k] = casters[casters.length - 1];
                             casters.length -= 1;
                         } else {


### PR DESCRIPTION
Layer composition removes shadow-casters without UPDATED_LIGHTS. This reduces number of shader updates in forward renderer.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
