### PR TITLE
Sync hierarchy ios performance

### DIFF
--- a/src/anim/skeleton.js
+++ b/src/anim/skeleton.js
@@ -342,7 +342,8 @@ Object.assign(pc, function () {
                     transform.localRotation.copy(interpKey._quat);
                     transform.localScale.copy(interpKey._scale);
 
-                    transform._dirtifyLocal();
+                    if (!transform._dirtyLocal)
+                        transform._dirtifyLocal();
 
                     interpKey._written = false;
                 }

--- a/src/framework/components/element/component.js
+++ b/src/framework/components/element/component.js
@@ -205,7 +205,8 @@ Object.assign(pc, function () {
                 invParentWtm.copy(this.element._screenToWorld).invert();
                 invParentWtm.transformPoint(position, this.localPosition);
 
-                this._dirtifyLocal();
+                if (!this._dirtyLocal)
+                    this._dirtifyLocal();
             };
         }(),
 
@@ -225,7 +226,8 @@ Object.assign(pc, function () {
             element._margin.y = p.y - element._calculatedHeight * pvt.y;
             element._margin.w = (element._localAnchor.w - element._localAnchor.y) - element._calculatedHeight - element._margin.y;
 
-            this._dirtifyLocal();
+            if (!this._dirtyLocal)
+                this._dirtifyLocal();
         },
 
         // this method overwrites GraphNode#sync and so operates in scope of the Entity.
@@ -1242,7 +1244,8 @@ Object.assign(pc, function () {
 
             this._anchorDirty = true;
 
-            this.entity._dirtifyLocal();
+            if (!this.entity._dirtyLocal)
+                this.entity._dirtifyLocal();
 
             this.fire('set:anchor', this._anchor);
         }

--- a/src/framework/components/screen/component.js
+++ b/src/framework/components/screen/component.js
@@ -161,7 +161,8 @@ Object.assign(pc, function () {
 
             this._calcProjectionMatrix();
 
-            this.entity._dirtifyLocal();
+            if (!this.entity._dirtyLocal)
+                this.entity._dirtifyLocal();
 
             this.fire("set:resolution", this._resolution);
         },
@@ -176,7 +177,8 @@ Object.assign(pc, function () {
             this._updateScale();
             this._calcProjectionMatrix();
 
-            this.entity._dirtifyLocal();
+            if (!this.entity._dirtyLocal)
+                this.entity._dirtifyLocal();
 
             this.fire("set:referenceresolution", this._resolution);
         },
@@ -197,7 +199,8 @@ Object.assign(pc, function () {
             }
             this.resolution = this._resolution; // force update either way
 
-            this.entity._dirtifyLocal();
+            if (!this.entity._dirtyLocal)
+                this.entity._dirtifyLocal();
 
             this.fire('set:screenspace', this._screenSpace);
         },
@@ -233,7 +236,8 @@ Object.assign(pc, function () {
             this._updateScale();
             this._calcProjectionMatrix();
 
-            this.entity._dirtifyLocal();
+            if (!this.entity._dirtyLocal)
+                this.entity._dirtifyLocal();
 
             this.fire("set:scaleblend", this._scaleBlend);
         },

--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -797,7 +797,8 @@ Object.assign(pc, function () {
                 this.localRotation.setFromEulerAngles(x, y, z);
             }
 
-            this._dirtifyLocal();
+            if (!this._dirtyLocal)
+                this._dirtifyLocal();
         },
 
         /**
@@ -825,7 +826,8 @@ Object.assign(pc, function () {
                 this.localPosition.set(x, y, z);
             }
 
-            this._dirtifyLocal();
+            if (!this._dirtyLocal)
+                this._dirtifyLocal();
         },
 
         /**
@@ -854,7 +856,8 @@ Object.assign(pc, function () {
                 this.localRotation.set(x, y, z, w);
             }
 
-            this._dirtifyLocal();
+            if (!this._dirtyLocal)
+                this._dirtifyLocal();
         },
 
         /**
@@ -882,7 +885,8 @@ Object.assign(pc, function () {
                 this.localScale.set(x, y, z);
             }
 
-            this._dirtifyLocal();
+            if (!this._dirtyLocal)
+                this._dirtifyLocal();
         },
 
         /**
@@ -902,7 +906,8 @@ Object.assign(pc, function () {
         _dirtifyLocal: function () {
             if (!this._dirtyLocal) {
                 this._dirtyLocal = true;
-                this._dirtifyWorld();
+                if (!this._dirtyWorld)
+                    this._dirtifyWorld();
             }
         },
 
@@ -954,7 +959,8 @@ Object.assign(pc, function () {
                     invParentWtm.transformPoint(position, this.localPosition);
                 }
 
-                this._dirtifyLocal();
+                if (!this._dirtyLocal)
+                    this._dirtifyLocal();
             };
         }(),
 
@@ -996,7 +1002,8 @@ Object.assign(pc, function () {
                     this.localRotation.copy(invParentRot).mul(rotation);
                 }
 
-                this._dirtifyLocal();
+                if (!this._dirtyLocal)
+                    this._dirtifyLocal();
             };
         }(),
 
@@ -1035,7 +1042,8 @@ Object.assign(pc, function () {
                     this.localRotation.mul2(invParentRot, this.localRotation);
                 }
 
-                this._dirtifyLocal();
+                if (!this._dirtyLocal)
+                    this._dirtifyLocal();
             };
         }(),
 
@@ -1447,7 +1455,8 @@ Object.assign(pc, function () {
                 this.localRotation.transformVector(translation, translation);
                 this.localPosition.add(translation);
 
-                this._dirtifyLocal();
+                if (!this._dirtyLocal)
+                    this._dirtifyLocal();
             };
         }(),
 
@@ -1491,7 +1500,8 @@ Object.assign(pc, function () {
                     this.localRotation.mul2(quaternion, rot);
                 }
 
-                this._dirtifyLocal();
+                if (!this._dirtyLocal)
+                    this._dirtifyLocal();
             };
         }(),
 
@@ -1525,7 +1535,8 @@ Object.assign(pc, function () {
 
                 this.localRotation.mul(quaternion);
 
-                this._dirtifyLocal();
+                if (!this._dirtyLocal)
+                    this._dirtifyLocal();
             };
         }()
     });

--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -1311,7 +1311,9 @@ Object.assign(pc, function () {
             if (!this._enabled)
                 return;
 
-            this._sync();
+            if (this._dirtyLocal || this._dirtyWorld) {
+                this._sync();
+            }
 
             var children = this._children;
             for (var i = 0, len = children.length; i < len; i++) {


### PR DESCRIPTION
Part of initial Sync Hierarchy optimisation is reverted since it reduce performance on low end IOS devices. Moving condition check for entire scope of a function out of function appeared to perform faster.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
