### PR TITLE
Fix a flaw in the batch group setter

### DIFF
--- a/src/framework/components/model/component.js
+++ b/src/framework/components/model/component.js
@@ -831,8 +831,6 @@ Object.assign(pc, function () {
         set: function (value) {
             if (this._batchGroupId === value) return;
 
-            this._batchGroupId = value;
-
             var batcher = this.system.app.batcher;
             if (this._batchGroupId >= 0) batcher.markGroupDirty(this._batchGroupId);
             if (value >= 0) batcher.markGroupDirty(value);
@@ -841,6 +839,8 @@ Object.assign(pc, function () {
                 // re-add model to scene, in case it was removed by batching
                 this.addModelToLayers();
             }
+
+            this._batchGroupId = value;
         }
     });
 


### PR DESCRIPTION
Minor fix for setter method:
addModelToLayers() and markGroupDirty(this._batchGroupId) were never happen.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
