### PR TITLE
EntityRef memory leak issue fixed

### DIFF
--- a/src/framework/utils/entity-reference.js
+++ b/src/framework/utils/entity-reference.js
@@ -169,7 +169,7 @@ Object.assign(pc, function () {
             this._parentComponent.system[onOrOff]('beforeremove', this._onParentComponentRemove, this);
 
             pc.ComponentSystem[onOrOff]('postInitialize', this._onPostInitialize, this);
-            this._app.on('tools:sceneloaded', this._onSceneLoaded, this);
+            this._app[onOrOff]('tools:sceneloaded', this._onSceneLoaded, this);
 
             // For any event listeners that relate to the gain/loss of a component, register
             // listeners that will forward the add/remove component events


### PR DESCRIPTION
_toggleLifecycleListeners method is being called second time from _onParentComponentRemove with 'off' argument that should unsubscribe all callbacks, instead it was binding another callback for 'tools:sceneloaded'

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
