### PR TITLE
Defer high precision floating point rendering test

### DIFF
--- a/src/graphics/device.js
+++ b/src/graphics/device.js
@@ -64,58 +64,52 @@ Object.assign(pc, function () {
         if (!device.textureFloatRenderable)
             return false;
 
-        var gl = device.gl;
         var chunks = pc.shaderChunks;
         var test1 = chunks.createShaderFromCode(device, chunks.fullscreenQuadVS, chunks.precisionTestPS, "ptest1");
         var test2 = chunks.createShaderFromCode(device, chunks.fullscreenQuadVS, chunks.precisionTest2PS, "ptest2");
-        var size = 1;
 
-        var tex = new pc.Texture(device, {
+        var textureOptions = {
             format: pc.PIXELFORMAT_RGBA32F,
-            width: size,
-            height: size,
+            width: 1,
+            height: 1,
             mipmaps: false,
             minFilter: pc.FILTER_NEAREST,
             magFilter: pc.FILTER_NEAREST
-        });
-        var targ = new pc.RenderTarget(device, tex, {
+        };
+        var tex1 = new pc.Texture(device, textureOptions);
+        var targ1 = new pc.RenderTarget(device, tex1, {
             depth: false
         });
-        pc.drawQuadWithShader(device, targ, test1);
+        pc.drawQuadWithShader(device, targ1, test1);
 
-        var tex2 = new pc.Texture(device, {
-            format: pc.PIXELFORMAT_R8_G8_B8_A8,
-            width: size,
-            height: size,
-            mipmaps: false,
-            minFilter: pc.FILTER_NEAREST,
-            magFilter: pc.FILTER_NEAREST
-        });
+        textureOptions.format = pc.PIXELFORMAT_R8_G8_B8_A8;
+        var tex2 = new pc.Texture(device, textureOptions);
         var targ2 = new pc.RenderTarget(device, tex2, {
             depth: false
         });
-        device.constantTexSource.setValue(tex);
+        device.constantTexSource.setValue(tex1);
         pc.drawQuadWithShader(device, targ2, test2);
 
-        gl.bindFramebuffer(gl.FRAMEBUFFER, targ2._glFrameBuffer);
+        var prevFramebuffer = device.activeFramebuffer;
+        device.setFramebuffer(targ2._glFrameBuffer);
 
-        var pixels = new Uint8Array(size * size * 4);
-        gl.readPixels(0, 0, size, size, gl.RGBA, gl.UNSIGNED_BYTE, pixels);
+        var pixels = new Uint8Array(4);
+        device.readPixels(0, 0, 1, 1, pixels);
 
-        gl.bindFramebuffer(gl.FRAMEBUFFER, device.activeFramebuffer);
+        device.setFramebuffer(prevFramebuffer);
 
-        var x = pixels[0] / 255.0;
-        var y = pixels[1] / 255.0;
-        var z = pixels[2] / 255.0;
-        var w = pixels[3] / 255.0;
-        var f = x / (256.0 * 256.0 * 256.0) + y / (256.0 * 256.0) + z / 256.0 + w;
+        var x = pixels[0] / 255;
+        var y = pixels[1] / 255;
+        var z = pixels[2] / 255;
+        var w = pixels[3] / 255;
+        var f = x / (256 * 256 * 256) + y / (256 * 256) + z / 256 + w;
 
-        tex.destroy();
-        targ.destroy();
+        tex1.destroy();
+        targ1.destroy();
         tex2.destroy();
         targ2.destroy();
 
-        return f === 0.0;
+        return f === 0;
     }
 
     /**
@@ -590,7 +584,7 @@ Object.assign(pc, function () {
             this.textureHalfFloatRenderable = false;
         }
 
-        this.textureFloatHighPrecision = testTextureFloatHighPrecision(this);
+        this._textureFloatHighPrecision = undefined;
 
         this.initializeGrabPassTexture();
     };
@@ -3235,6 +3229,15 @@ Object.assign(pc, function () {
         set: function (ratio) {
             this._maxPixelRatio = ratio;
             this.resizeCanvas(this._width, this._height);
+        }
+    });
+
+    Object.defineProperty(GraphicsDevice.prototype, 'textureFloatHighPrecision', {
+        get: function () {
+            if (this._textureFloatHighPrecision === undefined) {
+                this._textureFloatHighPrecision = testTextureFloatHighPrecision(this);
+            }
+            return this._textureFloatHighPrecision;
         }
     });
 

--- a/src/graphics/post-effect.js
+++ b/src/graphics/post-effect.js
@@ -101,7 +101,7 @@ Object.assign(pc, function () {
         device.setBlending(false);
         device.setDepthTest(false);
         device.setDepthWrite(false);
-        device.setCullMode(pc.CULLFACE_BACK);
+        device.setCullMode(pc.CULLFACE_NONE);
         device.setColorWrite(true, true, true, true);
 
         device.setVertexBuffer(vertexBuffer, 0);

--- a/src/graphics/post-effect.js
+++ b/src/graphics/post-effect.js
@@ -65,8 +65,8 @@ Object.assign(pc, function () {
     function drawFullscreenQuad(device, target, vertexBuffer, shader, rect) {
         var oldRt = device.getRenderTarget();
         device.setRenderTarget(target);
-
         device.updateBegin();
+
         var w = (target !== null) ? target.width : device.width;
         var h = (target !== null) ? target.height : device.height;
         var x = 0;
@@ -104,9 +104,7 @@ Object.assign(pc, function () {
         device.setCullMode(pc.CULLFACE_BACK);
         device.setColorWrite(true, true, true, true);
 
-        var oldVb = device.vertexBuffers[0];
         device.setVertexBuffer(vertexBuffer, 0);
-        var oldShader = device.getShader();
         device.setShader(shader);
 
         device.draw(primitive);

--- a/src/graphics/post-effect.js
+++ b/src/graphics/post-effect.js
@@ -63,7 +63,9 @@ Object.assign(pc, function () {
     }
 
     function drawFullscreenQuad(device, target, vertexBuffer, shader, rect) {
+        var oldRt = device.getRenderTarget();
         device.setRenderTarget(target);
+
         device.updateBegin();
         var w = (target !== null) ? target.width : device.width;
         var h = (target !== null) ? target.height : device.height;
@@ -77,7 +79,15 @@ Object.assign(pc, function () {
             h *= rect.w;
         }
 
+        var oldVx = device.vx;
+        var oldVy = device.vy;
+        var oldVw = device.vw;
+        var oldVh = device.vh;
         device.setViewport(x, y, w, h);
+        var oldSx = device.sx;
+        var oldSy = device.sy;
+        var oldSw = device.sw;
+        var oldSh = device.sh;
         device.setScissor(x, y, w, h);
 
         var oldBlending = device.getBlending();
@@ -93,15 +103,27 @@ Object.assign(pc, function () {
         device.setDepthWrite(false);
         device.setCullMode(pc.CULLFACE_BACK);
         device.setColorWrite(true, true, true, true);
+
+        var oldVb = device.vertexBuffers[0];
         device.setVertexBuffer(vertexBuffer, 0);
+        var oldShader = device.getShader();
         device.setShader(shader);
+
         device.draw(primitive);
+
         device.setBlending(oldBlending);
         device.setDepthTest(oldDepthTest);
         device.setDepthWrite(oldDepthWrite);
         device.setCullMode(oldCullMode);
         device.setColorWrite(oldWR, oldWG, oldWB, oldWA);
+
         device.updateEnd();
+
+        device.setRenderTarget(oldRt);
+        device.updateBegin();
+
+        device.setViewport(oldVx, oldVy, oldVw, oldVh);
+        device.setScissor(oldSx, oldSy, oldSw, oldSh);
     }
 
     return {

--- a/src/graphics/simple-post-effect.js
+++ b/src/graphics/simple-post-effect.js
@@ -33,6 +33,7 @@ Object.assign(pc, (function () {
         var oldRt = device.renderTarget;
         device.setRenderTarget(target);
         device.updateBegin();
+
         var x, y, w, h;
         var sx, sy, sw, sh;
         if (!rect) {
@@ -59,7 +60,15 @@ Object.assign(pc, (function () {
             sh = scissorRect.w;
         }
 
+        var oldVx = device.vx;
+        var oldVy = device.vy;
+        var oldVw = device.vw;
+        var oldVh = device.vh;
         device.setViewport(x, y, w, h);
+        var oldSx = device.sx;
+        var oldSy = device.sy;
+        var oldSw = device.sw;
+        var oldSh = device.sh;
         device.setScissor(sx, sy, sw, sh);
 
         var oldDepthTest = device.getDepthTest();
@@ -69,16 +78,23 @@ Object.assign(pc, (function () {
         device.setDepthWrite(false);
         device.setCullMode(pc.CULLFACE_NONE);
         if (!useBlend) device.setBlending(false);
+
         device.setVertexBuffer(_postEffectQuadVB, 0);
         device.setShader(shader);
+
         device.draw(_postEffectQuadDraw);
+
         device.setDepthTest(oldDepthTest);
         device.setDepthWrite(oldDepthWrite);
         device.setCullMode(oldCull);
+
         device.updateEnd();
 
         device.setRenderTarget(oldRt);
         device.updateBegin();
+
+        device.setViewport(oldVx, oldVy, oldVw, oldVh);
+        device.setScissor(oldSx, oldSy, oldSw, oldSh);
     }
 
     function destroyPostEffectQuad() {

--- a/src/graphics/simple-post-effect.js
+++ b/src/graphics/simple-post-effect.js
@@ -73,10 +73,15 @@ Object.assign(pc, (function () {
 
         var oldDepthTest = device.getDepthTest();
         var oldDepthWrite = device.getDepthWrite();
-        var oldCull = device.getCullMode();
+        var oldCullMode = device.getCullMode();
+        var oldWR = device.writeRed;
+        var oldWG = device.writeGreen;
+        var oldWB = device.writeBlue;
+        var oldWA = device.writeAlpha;
         device.setDepthTest(false);
         device.setDepthWrite(false);
         device.setCullMode(pc.CULLFACE_NONE);
+        device.setColorWrite(true, true, true, true);
         if (!useBlend) device.setBlending(false);
 
         device.setVertexBuffer(_postEffectQuadVB, 0);
@@ -86,7 +91,8 @@ Object.assign(pc, (function () {
 
         device.setDepthTest(oldDepthTest);
         device.setDepthWrite(oldDepthWrite);
-        device.setCullMode(oldCull);
+        device.setCullMode(oldCullMode);
+        device.setColorWrite(oldWR, oldWG, oldWB, oldWA);
 
         device.updateEnd();
 


### PR DESCRIPTION
Defer running the test for high precision floating point render targets since it generates 2 shader programs and is only used for 32-bit VSM which is very rarely used.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
