### PR TITLE
Revert sync queue optimization.

### DIFF
--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -174,7 +174,6 @@ Object.assign(pc, function () {
         this._entityIndex = {};
 
         this.scene = new pc.Scene();
-        this.syncQueue = new pc.SyncQueue();
         this.root = new pc.Entity(this);
         this.root._enabledInHierarchy = true;
         this._enableList = [];
@@ -1028,7 +1027,7 @@ Object.assign(pc, function () {
             // #endif
 
             this.fire("prerender");
-            this.syncQueue.runSync();
+            this.root.syncHierarchy();
             this.batcher.updateAll();
             pc._skipRenderCounter = 0;
             this.renderer.renderComposition(this.scene.layers);

--- a/src/framework/components/element/component.js
+++ b/src/framework/components/element/component.js
@@ -357,14 +357,9 @@ Object.assign(pc, function () {
 
             var result = this._parseUpToScreen();
 
-            this._updateScreen(result.screen);
+            this.entity._dirtifyWorld();
 
-            if (this.entity._dirtyLocal || this.entity._dirtyWorld) {
-                this.entity._cancelSync();
-                this.entity._queueSync();
-            } else {
-                this.entity._dirtifyWorld();
-            }
+            this._updateScreen(result.screen);
 
             this._dirtifyMask();
         },
@@ -629,13 +624,6 @@ Object.assign(pc, function () {
             // if there is a screen and it is not being destroyed
             if (this.screen && !this.screen._destroying) {
                 this._updateScreen(null);
-
-                if (this.entity._dirtyLocal || this.entity._dirtyWorld) {
-                    this.entity._cancelSync();
-                    this.entity._queueSync();
-                } else {
-                    this.entity._dirtifyWorld();
-                }
             }
         },
 
@@ -718,13 +706,9 @@ Object.assign(pc, function () {
             }
 
             this.fire("enableelement");
-
-            this.entity._queueSync();
         },
 
         onDisable: function () {
-            this.entity._cancelSync();
-
             this.system.app.scene.off("set:layers", this.onLayersChanged, this);
             if (this.system.app.scene.layers) {
                 this.system.app.scene.layers.off("add", this.onLayerAdded, this);
@@ -760,13 +744,6 @@ Object.assign(pc, function () {
             if (this.screen && this.screen.screen) {
                 this._unbindScreen(this.screen.screen);
                 this.screen.screen.syncDrawOrder();
-            }
-
-            if (this.entity._dirtyLocal || this.entity._dirtyWorld) {
-                this.entity._cancelSync();
-                this.entity._queueSync();
-            } else {
-                this.entity._dirtifyWorld();
             }
 
             this.off();
@@ -1312,7 +1289,7 @@ Object.assign(pc, function () {
             this._screenCorners[3].set(this._absLeft, this._absTop, 0);
 
             // transform corners to screen space
-            var screenSpace = this._isScreenSpace();
+            var screenSpace = this.screen.screen.screenSpace;
             for (var i = 0; i < 4; i++) {
                 this._screenTransform.transformPoint(this._screenCorners[i], this._screenCorners[i]);
                 if (screenSpace)

--- a/src/framework/entity.js
+++ b/src/framework/entity.js
@@ -315,7 +315,9 @@ Object.assign(pc, function () {
         var children = this._children;
         var child = children.shift();
         while (child) {
-            child.destroy();
+            if (child instanceof pc.Entity) {
+                child.destroy();
+            }
 
             // make sure child._parent is null because
             // we have removed it from the children array before calling
@@ -335,8 +337,6 @@ Object.assign(pc, function () {
         if (this._guid) {
             delete this._app._entityIndex[this._guid];
         }
-
-        pc.GraphNode.prototype.destroy.call(this);
 
         this._destroying = false;
     };


### PR DESCRIPTION
The sync queue optimization that speeds up hierarchy synchronization still has an outstanding bug. (The first two garages of the SWERVE projects are not rendered). Also, we still don't have performance stats for how it performs on low end iOS devices. So I'm reverting for now until both of these things are addressed.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
