### PR TITLE
[FIX] Prevent corruption in text element when CanvasFont atlas is re-rendered

### DIFF
--- a/examples/canvas-font/index.html
+++ b/examples/canvas-font/index.html
@@ -47,7 +47,6 @@
             var asset = new pc.Asset("CanvasFont", "font", {});
             app.assets.add(asset);
             asset.resource = cf;
-            asset.data = cf.data;
             asset.loaded = true;
 
             var fontAsset = new pc.Asset("Verdana", "font", {
@@ -108,20 +107,6 @@
                 alignment: [1, 0]
             });
 
-            setTimeout(function () {
-                var str = "🇨🇦🇦🇺🇨🇳"
-
-                cf.updateTextures(str);
-
-                if (showCanvasAtlasForDebug) {
-                    renderAtlases();
-                }
-
-                // asset.fire('change', asset, 'data', cf.data, cf.data);
-
-                canvasElementEntity1.element.text = str + canvasElementEntity1.element.text;
-            }, 1000)
-
             cf.updateTextures(secondline);
             var canvasElementEntity2 = new pc.Entity();
             canvasElementEntity2.addComponent("element", {
@@ -174,7 +159,8 @@
                 document.body.appendChild(wrapper);
             }
             // purely for debugging: do not do this in a real application
-            var showCanvasAtlasForDebug = true;
+            var showCanvasAtlasForDebug = false;
+            renderAtlases();
 
         </script>
     </body>

--- a/examples/canvas-font/index.html
+++ b/examples/canvas-font/index.html
@@ -47,6 +47,7 @@
             var asset = new pc.Asset("CanvasFont", "font", {});
             app.assets.add(asset);
             asset.resource = cf;
+            asset.data = cf.data;
             asset.loaded = true;
 
             var fontAsset = new pc.Asset("Verdana", "font", {
@@ -107,6 +108,20 @@
                 alignment: [1, 0]
             });
 
+            setTimeout(function () {
+                var str = "🇨🇦🇦🇺🇨🇳"
+
+                cf.updateTextures(str);
+
+                if (showCanvasAtlasForDebug) {
+                    renderAtlases();
+                }
+
+                // asset.fire('change', asset, 'data', cf.data, cf.data);
+
+                canvasElementEntity1.element.text = str + canvasElementEntity1.element.text;
+            }, 1000)
+
             cf.updateTextures(secondline);
             var canvasElementEntity2 = new pc.Entity();
             canvasElementEntity2.addComponent("element", {
@@ -146,9 +161,7 @@
             backing.addChild(msdfElementEntity);
             msdfElementEntity.translateLocal(0, -elSize*3, 0);
 
-            // purely for debugging: do not do this in a real application
-            var showCanvasAtlasForDebug = false;
-            if (showCanvasAtlasForDebug) {
+            function renderAtlases () {
                 var wrapper = document.createElement('div');
                 for (var i = 0; i < cf.textures.length; i++) {
                     var canvas = cf.textures[i].getSource();
@@ -160,6 +173,8 @@
                 wrapper.style.top = '0px';
                 document.body.appendChild(wrapper);
             }
+            // purely for debugging: do not do this in a real application
+            var showCanvasAtlasForDebug = true;
 
         </script>
     </body>

--- a/src/framework/components/element/text-element.js
+++ b/src/framework/components/element/text-element.js
@@ -1027,7 +1027,7 @@ Object.assign(pc, function () {
                 if (!this._meshInfo[i]) {
                     this._meshInfo[i] = new MeshInfo();
                 } else {
-                    // keep exist ing entry but set correct parameters to mesh instance
+                    // keep existing entry but set correct parameters to mesh instance
                     var mi = this._meshInfo[i].meshInstance;
                     if (mi) {
                         mi.setParameter("font_sdfIntensity", this._font.intensity);

--- a/src/framework/components/text/canvas-font.js
+++ b/src/framework/components/text/canvas-font.js
@@ -54,6 +54,8 @@ Object.assign(pc, function () {
 
         this.chars = "";
         this.data = {};
+
+        pc.events.attach(this);
     };
 
     /**
@@ -162,11 +164,9 @@ Object.assign(pc, function () {
     CanvasFont.prototype.renderCharacter = function (context, char, x, y, color) {
         context.fillStyle = color;
         context.fillText(char, x, y);
-
     };
 
     CanvasFont.prototype._renderAtlas = function (charsArray) {
-
         this.chars = charsArray;
 
         var numTextures = 1;
@@ -284,6 +284,9 @@ Object.assign(pc, function () {
             }
             this.textures.splice(numTextures);
         }
+
+        // alert text-elements that the font has been re-rendered
+        this.fire("render");
     };
 
     CanvasFont.prototype._createJson = function (chars, fontName, width, height) {

--- a/tests/framework/components/element/test_textelement.js
+++ b/tests/framework/components/element/test_textelement.js
@@ -299,6 +299,56 @@ describe("pc.TextElement", function () {
         expect(assets.font.hasEvent('remove')).to.be.false;
     });
 
+    it('CanvasFont render event is unbound when reset', function () {
+        var cf = new pc.CanvasFont(app, {
+            fontName: 'Arial'
+        });
+
+        cf.createTextures('abc');
+
+        expect(cf.hasEvent('render')).to.be.false;
+
+        var e = new pc.Entity();
+        e.addComponent('element', {
+            type: 'text',
+            text: 'abc'
+        });
+        app.root.addChild(e);
+
+        e.element.font = cf;
+
+        expect(cf.hasEvent('render')).to.be.true;
+
+        e.element.font = null;
+
+        expect(cf.hasEvent('render')).to.be.false;
+    });
+
+    it('CanvasFont render event is unbound on destroy', function () {
+        var cf = new pc.CanvasFont(app, {
+            fontName: 'Arial'
+        });
+
+        cf.createTextures('abc');
+
+        expect(cf.hasEvent('render')).to.be.false;
+
+        var e = new pc.Entity();
+        e.addComponent('element', {
+            type: 'text',
+            text: 'abc'
+        });
+        app.root.addChild(e);
+
+        e.element.font = cf;
+
+        expect(cf.hasEvent('render')).to.be.true;
+
+        e.destroy();
+
+        expect(cf.hasEvent('render')).to.be.false;
+    });
+
     it("defaults to white color and opacity 1", function () {
         expect(element.color.r).to.equal(1);
         expect(element.color.g).to.equal(1);


### PR DESCRIPTION
Changes to CanvasFont atlas force update in text element
