### PR TITLE
[FIX] Scrollview now correctly updates after touch ends

### DIFF
--- a/src/framework/components/button/component.js
+++ b/src/framework/components/button/component.js
@@ -87,7 +87,8 @@ Object.assign(pc, function () {
             this[onOrOff]('set_inactiveSpriteAsset', this._onSetTransitionValue, this);
             this[onOrOff]('set_inactiveSpriteFrame', this._onSetTransitionValue, this);
 
-            pc.ComponentSystem[onOrOff]('update', this._onUpdate, this);
+            var bindEvent = (onOrOff === 'on') ? 'bind' : 'unbind';
+            pc.ComponentSystem[bindEvent]('update', this._onUpdate, this);
 
             system.app.systems.element[onOrOff]('add', this._onElementComponentAdd, this);
             system.app.systems.element[onOrOff]('beforeremove', this._onElementComponentRemove, this);

--- a/src/framework/components/scroll-view/component.js
+++ b/src/framework/components/scroll-view/component.js
@@ -74,7 +74,8 @@ Object.assign(pc, function () {
             this[onOrOff]('set_horizontal', this._onSetHorizontalScrollingEnabled, this);
             this[onOrOff]('set_vertical', this._onSetVerticalScrollingEnabled, this);
 
-            pc.ComponentSystem[onOrOff]('update', this._onUpdate, this);
+            var bindEvent = (onOrOff === 'on') ? 'bind' : 'unbind';
+            pc.ComponentSystem[bindEvent]('update', this._onUpdate, this);
 
             system.app.systems.element[onOrOff]('add', this._onElementComponentAdd, this);
             system.app.systems.element[onOrOff]('beforeremove', this._onElementComponentRemove, this);

--- a/src/framework/utils/entity-reference.js
+++ b/src/framework/utils/entity-reference.js
@@ -168,7 +168,9 @@ Object.assign(pc, function () {
             this._parentComponent[onOrOff]('set_' + this._entityPropertyName, this._onSetEntity, this);
             this._parentComponent.system[onOrOff]('beforeremove', this._onParentComponentRemove, this);
 
-            pc.ComponentSystem[onOrOff]('postInitialize', this._onPostInitialize, this);
+            var bindEvent = (onOrOff === 'on') ? 'bind' : 'unbind';
+            pc.ComponentSystem[bindEvent]('postInitialize', this._onPostInitialize, this);
+
             this._app[onOrOff]('tools:sceneloaded', this._onSceneLoaded, this);
 
             // For any event listeners that relate to the gain/loss of a component, register


### PR DESCRIPTION
Changes to component events caused regression with scrollview, button and entity-references
