### PR TITLE
Fix CubeMap Seams bug on A12 and A12X chips

### DIFF
--- a/src/graphics/device.js
+++ b/src/graphics/device.js
@@ -532,6 +532,11 @@ Object.assign(pc, function () {
         if (this.unmaskedRenderer === 'Apple A8 GPU') {
             this.forceCpuParticles = true;
         }
+        
+        // Workaround for A12 and A12X chips that removed smooth seams from CubeMaps
+        if (this.unmaskedRenderer === 'Apple A12 GPU' || this.unmaskedRenderer === 'Apple A12X GPU') {
+            this.useTexCubeLod = false;
+        }
 
         // Profiler stats
         this._drawCallsPerFrame = 0;


### PR DESCRIPTION
A12 and A12X chips (late 2018 iPhones and iPads) had a regression in their WebGL implementation which removed a feature of CubeMaps seams filtering on the faces edges.
So disabling the `unmaskedRenderer` forces engine to use manual seams path which avoids an issue.

Linked issue: #1464

Fixes #

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
