### PR TITLE
Change A12 CubeMap fix to use DP path (1 texture).

### DIFF
--- a/src/graphics/device.js
+++ b/src/graphics/device.js
@@ -507,6 +507,12 @@ Object.assign(pc, function () {
 
         this.supportsBoneTextures = this.extTextureFloat && this.maxVertexTextures > 0;
         this.useTexCubeLod = this.extTextureLod && this.maxTextures < 16;
+        this.forceCubeMapDp = false;
+        
+        // Workaround for A12 and A12X chips that removed smooth seams from CubeMaps
+        if (this.unmaskedRenderer === 'Apple A12 GPU' || this.unmaskedRenderer === 'Apple A12X GPU') {
+            this.forceCubeMapDp = true;
+        }
 
         // Calculate an estimate of the maximum number of bones that can be uploaded to the GPU
         // based on the number of available uniforms and the number of uniforms required for non-
@@ -531,11 +537,6 @@ Object.assign(pc, function () {
 
         if (this.unmaskedRenderer === 'Apple A8 GPU') {
             this.forceCpuParticles = true;
-        }
-
-        // Workaround for A12 and A12X chips that removed smooth seams from CubeMaps
-        if (this.unmaskedRenderer === 'Apple A12 GPU' || this.unmaskedRenderer === 'Apple A12X GPU') {
-            this.useTexCubeLod = false;
         }
 
         // Profiler stats

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -831,7 +831,7 @@ Object.assign(pc, function () {
             }
 
             var useTexCubeLod = device.useTexCubeLod;
-            var useDp = !device.extTextureLod; // no basic extension? likely slow device, force dp
+            var useDp = !device.extTextureLod || device.forceCubeMapDp; // no basic extension? likely slow device, force dp
 
             var globalSky128, globalSky64, globalSky32, globalSky16, globalSky8, globalSky4;
             if (this.useSkybox) {


### PR DESCRIPTION
After a discussion here: https://github.com/playcanvas/engine/issues/1464
And consulting with @guycalledfrank we found a better solution to such issue.

Disabling useTexCubeLod - forces engine to follow path of using 6 textures for IBL instead of one. But there is a third path, which uses DP, and I've added a way to force it for A12 and A12X chips. It forces them to use single texture path.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
