### PR TITLE
Msdf text rescaled + uniform shadow offset

### DIFF
--- a/src/framework/components/element/text-element.js
+++ b/src/framework/components/element/text-element.js
@@ -334,8 +334,9 @@ Object.assign(pc, function () {
                     this._shadowColorUniform[2] = this._shadowColor.b;
                     this._shadowColorUniform[3] = this._shadowColor.a;
                     mi.setParameter("shadow_color", this._shadowColorUniform);
+                    var ratio = this._font.data.info.maps[i].width / this._font.data.info.maps[i].height;
                     this._shadowOffsetUniform[0] = this._shadowOffsetScale * this._shadowOffset.x;
-                    this._shadowOffsetUniform[1] = this._shadowOffsetScale * this._shadowOffset.y;
+                    this._shadowOffsetUniform[1] = ratio * this._shadowOffsetScale * this._shadowOffset.y;
                     mi.setParameter("shadow_offset", this._shadowOffsetUniform);
 
                     meshInfo.meshInstance = mi;
@@ -1340,15 +1341,13 @@ Object.assign(pc, function () {
             }
             this._shadowOffset.set(x, y);
 
-            if (this._font) {
-                if (this._model) {
+            if (this._font && this._model) {
+                for (var i = 0, len = this._model.meshInstances.length; i < len; i++) {
+                    var ratio = this._font.data.info.maps[i].width / this._font.data.info.maps[i].height;
                     this._shadowOffsetUniform[0] = this._shadowOffsetScale * this._shadowOffset.x;
-                    this._shadowOffsetUniform[1] = this._shadowOffsetScale * this._shadowOffset.y;
-
-                    for (var i = 0, len = this._model.meshInstances.length; i < len; i++) {
-                        var mi = this._model.meshInstances[i];
-                        mi.setParameter("shadow_offset", this._shadowOffsetUniform);
-                    }
+                    this._shadowOffsetUniform[1] = ratio * this._shadowOffsetScale * this._shadowOffset.y;
+                    var mi = this._model.meshInstances[i];
+                    mi.setParameter("shadow_offset", this._shadowOffsetUniform);
                 }
             }
         }

--- a/src/framework/components/element/text-element.js
+++ b/src/framework/components/element/text-element.js
@@ -792,8 +792,8 @@ Object.assign(pc, function () {
             var keys = Object.keys(this._font.data.chars);
             for (var i = 0; i < keys.length; i++) {
                 var char = this._font.data.chars[keys[i]];
-                if (char.scale && char.range) {
-                    return char.scale * char.range;
+                if (char.range) {
+                    return (char.scale || 1) * char.range;
                 }
             }
             return 2; // default

--- a/src/graphics/program-lib/chunks/msdf.frag
+++ b/src/graphics/program-lib/chunks/msdf.frag
@@ -38,14 +38,14 @@ vec4 applyMsdf(vec4 color) {
     #ifdef USE_FWIDTH
         // smoothing depends on size of texture on screen
         vec2 w = fwidth(vUv0);
-        float smoothing = clamp(0.2 * w.x * font_textureWidth / font_pxrange, 0.0, 0.5);
+        float smoothing = clamp(w.x * font_textureWidth / font_pxrange, 0.0, 0.5);
     #else
         float font_size = 16.0; // TODO fix this
         // smoothing gets smaller as the font size gets bigger
         // don't have fwidth we can approximate from font size, this doesn't account for scaling
         // so a big font scaled down will be wrong...
 
-        float smoothing = clamp(0.2 * font_pxrange / font_size, 0.0, 0.5);
+        float smoothing = clamp(font_pxrange / font_size, 0.0, 0.5);
     #endif
     float mapMin = 0.05;
     float mapMax = clamp(1.0 - font_sdfIntensity, mapMin, 1.0);

--- a/src/graphics/program-lib/chunks/msdf.frag
+++ b/src/graphics/program-lib/chunks/msdf.frag
@@ -16,18 +16,6 @@ float map (float min, float max, float v) {
     return (v - min) / (max - min);
 }
 
-// msdf way
-// vec4 applyMsdf(vec4 color) {
-//     vec3 tsample = texture(texture_msdfMap, vUv0).rgb;
-   
-//     // separate
-//     vec2 msdfUnit = 4.0 / vec2(512.0, 256.0);
-//     float sigDist = median(tsample.r, tsample.g, tsample.b) - 0.5;
-//     sigDist *= dot(msdfUnit, 0.5/fwidth(vUv0));
-//     float distance = clamp(sigDist + 0.5, 0.0, 1.0);
-//     return mix(vec4(0.0), color, distance);
-// }
-
 
 uniform float font_sdfIntensity; // intensity is used to boost the value read from the SDF, 0 is no boost, 1.0 is max boost
 uniform float font_pxrange;      // the number of pixels between inside and outside the font in SDF
@@ -50,17 +38,14 @@ vec4 applyMsdf(vec4 color) {
     #ifdef USE_FWIDTH
         // smoothing depends on size of texture on screen
         vec2 w = fwidth(vUv0);
-        float smoothing = clamp(w.x * font_textureWidth / font_pxrange, 0.0, 0.5);
+        float smoothing = clamp(0.2 * w.x * font_textureWidth / font_pxrange, 0.0, 0.5);
     #else
         float font_size = 16.0; // TODO fix this
         // smoothing gets smaller as the font size gets bigger
         // don't have fwidth we can approximate from font size, this doesn't account for scaling
         // so a big font scaled down will be wrong...
 
-        float smoothing = clamp(2.0 * font_pxrange / font_size, 0.0, 0.5);
-        // for small fonts we remap the distance field to intensify it
-        // float mapMin = 0.05;
-        // float mapMax = clamp(((font_size * 0.4 / 40.0) + 0.52), mapMin, 1.0);
+        float smoothing = clamp(0.2 * font_pxrange / font_size, 0.0, 0.5);
     #endif
     float mapMin = 0.05;
     float mapMax = clamp(1.0 - font_sdfIntensity, mapMin, 1.0);


### PR DESCRIPTION
1. Changes in pipeline (constant scale of 1 for all characters) causing  MSDF shader to become to blurry, 0.2 coefficient fixing this.
2. Shadow offset Y ration to fix nonuniform shift.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
