### PR TITLE
[FIX] Do not scale lineHeight for text elements that do not have autoFit enabled

### DIFF
--- a/src/framework/components/element/text-element.js
+++ b/src/framework/components/element/text-element.js
@@ -511,7 +511,11 @@ Object.assign(pc, function () {
 
                 // if auto-fitting then scale the line height
                 // according to the current fontSize value relative to the max font size
-                this._scaledLineHeight = this._lineHeight * this._fontSize / (this._maxFontSize || 0.0001);
+                if (autoFit) {
+                    this._scaledLineHeight = this._lineHeight * this._fontSize / (this._maxFontSize || 0.0001);
+                } else {
+                    this._scaledLineHeight = this._lineHeight;
+                }
 
                 this.width = 0;
                 this.height = 0;

--- a/tests/framework/components/element/test_textelement.js
+++ b/tests/framework/components/element/test_textelement.js
@@ -1,4 +1,4 @@
-describe("pc.TextElement", function () {
+describe.only("pc.TextElement", function () {
     var app;
     var assets;
     var entity;
@@ -342,9 +342,12 @@ describe("pc.TextElement", function () {
         element.fontAsset = fontAsset;
         element.autoWidth = false;
         element.autoHeight = false;
+        element.fontSize = 20;
+        element.lineHeight = 20;
         element.width = 10;
         element.text = "ab";
-        expect(element.fontSize).to.equal(32);
+        expect(element.fontSize).to.equal(20);
+        expect(element._text._scaledLineHeight).to.equal(20);
     });
 
     it("does not reduce font size when autoFitWidth and autoWidth are both true", function () {
@@ -418,9 +421,12 @@ describe("pc.TextElement", function () {
         element.fontAsset = fontAsset;
         element.autoWidth = false;
         element.autoHeight = false;
+        element.fontSize = 20;
+        element.lineHeight = 20;
         element.height = 50;
         element.text = "ab\nab";
-        expect(element.fontSize).to.equal(32);
+        expect(element.fontSize).to.equal(20);
+        expect(element._text._scaledLineHeight).to.equal(20);
     });
 
     it("does not reduce font size when autoFitHeight and autoHeight are both true", function () {

--- a/tests/framework/components/element/test_textelement.js
+++ b/tests/framework/components/element/test_textelement.js
@@ -1,4 +1,4 @@
-describe.only("pc.TextElement", function () {
+describe("pc.TextElement", function () {
     var app;
     var assets;
     var entity;


### PR DESCRIPTION


Fixes #

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
