### PR TITLE
Do not use workers when untarring bundles in the preload phase

### DIFF
--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -459,7 +459,7 @@ Object.assign(pc, function () {
         this._scriptPrefix = options.scriptPrefix || '';
 
         if (this.enableBundles) {
-            this.loader.addHandler("bundle", new pc.BundleHandler(this.assets));
+            this.loader.addHandler("bundle", new pc.BundleHandler(this));
         }
 
         this.loader.addHandler("animation", new pc.AnimationHandler());

--- a/src/resources/bundle.js
+++ b/src/resources/bundle.js
@@ -34,7 +34,6 @@ Object.assign(pc, function () {
             }, function (err, response) {
                 if (! err) {
                     try {
-                        console.log('Untar ' + url.original);
                         self._untar(response, callback);
                     } catch (ex) {
                         callback("Error loading bundle resource " + url.original + ": " + ex);
@@ -54,7 +53,6 @@ Object.assign(pc, function () {
             // because it will be faster and we don't need this
             // to run asynchronously in the preload phase
             if (pc.platform.workers && !this._preloading) {
-                console.log('Untar using worker');
                 // create web worker if necessary
                 if (!self._worker) {
                     self._worker = new pc.UntarWorker(self._assets.prefix);
@@ -71,7 +69,6 @@ Object.assign(pc, function () {
                     }
                 });
             } else {
-                console.log('Untar on main thread');
                 var archive = new pc.Untar(response);
                 var files = archive.untar(self._assets.prefix);
                 callback(null, files);


### PR DESCRIPTION
Haven't yet determined the performance impact but it should be faster.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
