### PR TITLE
Camera matrix cache

### DIFF
--- a/src/framework/components/camera/component.js
+++ b/src/framework/components/camera/component.js
@@ -91,7 +91,6 @@ Object.assign(pc, function () {
         this.on("set_cullFaces", this.onSetCullFaces, this);
         this.on("set_flipFaces", this.onSetFlipFaces, this);
         this.on("set_layers", this.onSetLayers, this);
-        this.system.app.on("prerender", this.onPrerender, this);
     };
     CameraComponent.prototype = Object.create(pc.Component.prototype);
     CameraComponent.prototype.constructor = CameraComponent;
@@ -409,7 +408,6 @@ Object.assign(pc, function () {
         },
 
         onRemove: function () {
-            this.system.app.off("prerender", this.onPrerender, this);
             this.off();
         },
 

--- a/src/framework/components/camera/component.js
+++ b/src/framework/components/camera/component.js
@@ -91,6 +91,7 @@ Object.assign(pc, function () {
         this.on("set_cullFaces", this.onSetCullFaces, this);
         this.on("set_flipFaces", this.onSetFlipFaces, this);
         this.on("set_layers", this.onSetLayers, this);
+        this.system.app.on("prerender", this.onPrerender, this);
     };
     CameraComponent.prototype = Object.create(pc.Component.prototype);
     CameraComponent.prototype.constructor = CameraComponent;
@@ -115,8 +116,7 @@ Object.assign(pc, function () {
      */
     Object.defineProperty(CameraComponent.prototype, "viewMatrix", {
         get: function () {
-            var wtm = this.data.camera._node.getWorldTransform();
-            return wtm.clone().invert();
+            return this.data.camera.getViewMatrix();
         }
     });
 
@@ -198,6 +198,11 @@ Object.assign(pc, function () {
         screenToWorld: function (screenx, screeny, cameraz, worldCoord) {
             var device = this.system.app.graphicsDevice;
             return this.data.camera.screenToWorld(screenx, screeny, cameraz, device.clientRect.width, device.clientRect.height, worldCoord);
+        },
+
+        onPrerender: function () {
+            this.data.camera._viewMatDirty = true;
+            this.data.camera._viewProjMatDirty = true;
         },
 
         /**
@@ -404,6 +409,7 @@ Object.assign(pc, function () {
         },
 
         onRemove: function () {
+            this.system.app.off("prerender", this.onPrerender, this);
             this.off();
         },
 

--- a/src/framework/components/camera/system.js
+++ b/src/framework/components/camera/system.js
@@ -54,6 +54,7 @@ Object.assign(pc, function () {
 
         this.on('beforeremove', this.onBeforeRemove, this);
         this.on('remove', this.onRemove, this);
+        this.app.on("prerender", this.onPrerender, this);
 
         pc.ComponentSystem.bind('update', this.onUpdate, this);
     };
@@ -178,6 +179,12 @@ Object.assign(pc, function () {
                         }
                     }
                 }
+            }
+        },
+
+        onPrerender: function () {
+            for (var i = 0, len = this.cameras.length; i < len; i++) {
+                this.cameras[i].onPrerender();
             }
         },
 

--- a/src/framework/components/particle-system/system.js
+++ b/src/framework/components/particle-system/system.js
@@ -224,17 +224,10 @@ Object.assign(pc, function () {
 
                         if (!data.paused) {
                             emitter.simTime += dt;
-                            numSteps = 0;
                             if (emitter.simTime > emitter.fixedTimeStep) {
-                                numSteps = Math.floor(emitter.simTime / emitter.fixedTimeStep);
-                                emitter.simTime -= numSteps * emitter.fixedTimeStep;
-                            }
-                            if (numSteps) {
-                                numSteps = Math.min(numSteps, emitter.maxSubSteps);
-                                for (i = 0; i < numSteps; i++) {
-                                    emitter.addTime(emitter.fixedTimeStep);
-                                }
-                                stats._updatesPerFrame += numSteps;
+                                emitter.addTime(emitter.simTime);
+                                emitter.simTime = 0;
+                                stats._updatesPerFrame++;
                                 stats._frameTime += emitter._addTimeTime;
                                 emitter._addTimeTime = 0;
                             }

--- a/src/framework/components/particle-system/system.js
+++ b/src/framework/components/particle-system/system.js
@@ -224,10 +224,17 @@ Object.assign(pc, function () {
 
                         if (!data.paused) {
                             emitter.simTime += dt;
+                            numSteps = 0;
                             if (emitter.simTime > emitter.fixedTimeStep) {
-                                emitter.addTime(emitter.simTime);
-                                emitter.simTime = 0;
-                                stats._updatesPerFrame++;
+                                numSteps = Math.floor(emitter.simTime / emitter.fixedTimeStep);
+                                emitter.simTime -= numSteps * emitter.fixedTimeStep;
+                            }
+                            if (numSteps) {
+                                numSteps = Math.min(numSteps, emitter.maxSubSteps);
+                                for (i = 0; i < numSteps; i++) {
+                                    emitter.addTime(emitter.fixedTimeStep);
+                                }
+                                stats._updatesPerFrame += numSteps;
                                 stats._frameTime += emitter._addTimeTime;
                                 emitter._addTimeTime = 0;
                             }

--- a/src/scene/camera.js
+++ b/src/scene/camera.js
@@ -26,7 +26,9 @@ Object.assign(pc, function () {
 
         this._projMatDirty = true;
         this._projMat = new pc.Mat4();
+        this._viewMatDirty = true;
         this._viewMat = new pc.Mat4();
+        this._viewProjMatDirty = true;
         this._viewProjMat = new pc.Mat4();
 
         this.vrDisplay = null;
@@ -111,10 +113,12 @@ Object.assign(pc, function () {
                 screenCoord = new pc.Vec3();
             }
 
-            var projMat = this.getProjectionMatrix();
-            var wtm = this._node.getWorldTransform();
-            this._viewMat.copy(wtm).invert();
-            this._viewProjMat.mul2(projMat, this._viewMat);
+            if (this._projMatDirty || this._viewMatDirty || this._viewProjMatDirty) {
+                var projMat = this.getProjectionMatrix();
+                var viewMat = this.getViewMatrix();
+                this._viewProjMat.mul2(projMat, viewMat);
+                this._viewProjMatDirty = false;
+            }
             this._viewProjMat.transformPoint(worldCoord, screenCoord);
 
             // calculate w co-coord
@@ -148,10 +152,12 @@ Object.assign(pc, function () {
                 worldCoord = new pc.Vec3();
             }
 
-            var projMat = this.getProjectionMatrix();
-            var wtm = this._node.getWorldTransform();
-            this._viewMat.copy(wtm).invert();
-            this._viewProjMat.mul2(projMat, this._viewMat);
+            if (this._projMatDirty || this._viewMatDirty || this._viewProjMatDirty) {
+                var projMat = this.getProjectionMatrix();
+                var viewMat = this.getViewMatrix();
+                this._viewProjMat.mul2(projMat, viewMat);
+                this._viewProjMatDirty = false;
+            }
             _invViewProjMat.copy(this._viewProjMat).invert();
 
             if (this._projection === pc.PROJECTION_PERSPECTIVE) {
@@ -224,6 +230,22 @@ Object.assign(pc, function () {
                 this._projMatDirty = false;
             }
             return this._projMat;
+        },
+
+        /**
+         * @private
+         * @function
+         * @name pc.Camera#getViewMatrix
+         * @description Retrieves the view matrix for the specified camera based on the entity world transformation.
+         * @returns {pc.Mat4} The camera's view matrix.
+         */
+        getViewMatrix: function () {
+            if (this._viewMatDirty) {
+                var wtm = this._node.getWorldTransform();
+                this._viewMat.copy(wtm).invert();
+                this._viewMatDirty = false;
+            }
+            return this._viewMat;
         },
 
         getRect: function () {


### PR DESCRIPTION
Camera component caches transformations (view and view-projection) on the frame.
This improves performance slightly.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
