### PR TITLE
Batcher updateMatrices args consistent with SkinInstance

### DIFF
--- a/src/scene/batching.js
+++ b/src/scene/batching.js
@@ -91,7 +91,7 @@ Object.assign(pc, function () {
     };
 
     Object.assign(SkinBatchInstance.prototype, {
-        updateMatrices: function () {
+        updateMatrices: function (rootNode) {
         },
 
         updateMatrixPalette: function () {


### PR DESCRIPTION
Micro optimisation. Batcher skin instance to have the same updateMatrices args count as normal SkinInstance.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
