### PR TITLE
Removing try/catch from script call in not DEBUG configuration.

### DIFF
--- a/src/framework/components/script/component.js
+++ b/src/framework/components/script/component.js
@@ -310,8 +310,11 @@ Object.assign(pc, function () {
         },
 
         _scriptMethod: function (script, method, arg) {
+            // #ifdef DEBUG
             try {
+            // #endif
                 script[method](arg);
+            // #ifdef DEBUG
             } catch (ex) {
                 // disable script if it fails to call method
                 script.enabled = false;
@@ -324,6 +327,7 @@ Object.assign(pc, function () {
                 script.fire('error', ex, method);
                 this.fire('error', script, ex, method);
             }
+            // #endif
         },
 
         _onInitialize: function () {


### PR DESCRIPTION
Optimisation. Removing try/catch from script call in configurations other than Debug to avoid JIT deopt and it overhead.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
