### PR TITLE
Shader ref counter removed. Fix for WebGL errors.

### DIFF
--- a/src/graphics/shader.js
+++ b/src/graphics/shader.js
@@ -56,9 +56,6 @@ Object.assign(pc, function () {
 
         this.ready = false;
 
-        // Used for shader variants (see pc.Material)
-        this._refCount = 0;
-
         this.device.createShader(this);
     };
 

--- a/src/scene/materials/material.js
+++ b/src/scene/materials/material.js
@@ -106,11 +106,7 @@ Object.assign(pc, function () {
             return this._shader;
         },
         set: function (shader) {
-            if (this._shader) {
-                this._shader._refCount--;
-            }
             this._shader = shader;
-            if (shader) shader._refCount++;
         }
     });
 
@@ -323,11 +319,6 @@ Object.assign(pc, function () {
 
     Material.prototype.clearVariants = function () {
         var meshInstance;
-        for (var s in this.variants) {
-            if (this.variants.hasOwnProperty(s)) {
-                this.variants[s]._refCount--;
-            }
-        }
         this.variants = {};
         var j;
         for (var i = 0; i < this.meshInstances.length; i++) {
@@ -416,24 +407,6 @@ Object.assign(pc, function () {
      * @description Removes this material from the scene and possibly frees up memory from its shaders (if there are no other materials using it).
      */
     Material.prototype.destroy = function () {
-        if (this.shader) {
-            this.shader._refCount--;
-            if (this.shader._refCount < 1) {
-                this.shader.destroy();
-            }
-        }
-
-        var variant;
-        for (var s in this.variants) {
-            if (this.variants.hasOwnProperty(s)) {
-                variant = this.variants[s];
-                if (variant === this.shader) continue;
-                variant._refCount--;
-                if (variant._refCount < 1) {
-                    variant.destroy();
-                }
-            }
-        }
         this.variants = {};
         this.shader = null;
 

--- a/src/scene/particle-emitter.js
+++ b/src/scene/particle-emitter.js
@@ -669,6 +669,7 @@ Object.assign(pc, function () {
             mesh.primitive[0].indexed = true;
 
             this.material = new pc.Material();
+            this.material.name = this.node.name;
             this.material.cull = pc.CULLFACE_NONE;
             this.material.alphaWrite = false;
             this.material.blend = true;


### PR DESCRIPTION
 In some cases shader miscounting destroys GL program being in use and triggers WebGL error. Actual shaders are only destroyed on engine shutdown, so this not making much difference in terms of resource management.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
