### PR TITLE
Fix post-effect-queue

### DIFF
--- a/examples/post_effects/index.html
+++ b/examples/post_effects/index.html
@@ -28,7 +28,7 @@
     <script src="../../extras/posteffects/posteffect-bloom.js"></script>
     <script src="../../extras/posteffects/posteffect-sepia.js"></script>
     <script src="../../extras/posteffects/posteffect-vignette.js"></script>
-
+    <script src="../../extras/posteffects/posteffect-bokeh.js"></script>
     <!-- The script -->
     <script>
         // Start the update loop
@@ -131,6 +131,9 @@
         vignette.darkness = 2;
         camera.camera.postEffects.addEffect(vignette);
 
+        var bokeh = new pc.BokehEffect(app.graphicsDevice);
+        bokeh.focus = 0.4;
+        camera.camera.postEffects.addEffect(bokeh);
         // Add Entities into the scene hierarchy
         app.root.addChild(camera);
         app.root.addChild(light);
@@ -144,6 +147,27 @@
 
         var pointRadius = 5;
         var pointHeight = 10;
+
+        var hasEffects = true;
+        var onKeyDown = function (e) {
+            if (e.key === pc.KEY_SPACE) {
+                if(hasEffects) {
+                    camera.camera.postEffects.removeEffect(bokeh);
+                    camera.camera.postEffects.removeEffect(sepia);
+                    camera.camera.postEffects.removeEffect(vignette);
+                }
+                else {
+                    camera.camera.postEffects.addEffect(sepia);
+                    camera.camera.postEffects.addEffect(vignette);
+                    camera.camera.postEffects.addEffect(bokeh);
+                }
+                hasEffects = !hasEffects;
+            }
+            e.event.preventDefault(); // Use original browser event to prevent browser action.
+        };
+        var keyboard = new pc.Keyboard(document.body);
+        keyboard.on("keydown", onKeyDown, this);
+
         app.on("update", function (dt) {
             angle += 20*dt;
             if (angle > 360) {

--- a/src/framework/components/camera/post-effect-queue.js
+++ b/src/framework/components/camera/post-effect-queue.js
@@ -1,4 +1,5 @@
 Object.assign(pc, function () {
+    var depthLayer;
     /**
      * @constructor
      * @name pc.PostEffectQueue
@@ -56,20 +57,21 @@ Object.assign(pc, function () {
 
             var device = this.app.graphicsDevice;
             var format = hdr ? device.getHdrFormat() : pc.PIXELFORMAT_R8_G8_B8_A8;
+            var useStencil =  this.app.graphicsDevice.supportsStencil;
 
             var colorBuffer = new pc.Texture(device, {
                 format: format,
                 width: width,
                 height: height
             });
-            colorBuffer.name = 'posteffect';
+            colorBuffer.name = 'posteffect #' + this.effects.length;
 
             colorBuffer.minFilter = pc.FILTER_NEAREST;
             colorBuffer.magFilter = pc.FILTER_NEAREST;
             colorBuffer.addressU = pc.ADDRESS_CLAMP_TO_EDGE;
             colorBuffer.addressV = pc.ADDRESS_CLAMP_TO_EDGE;
 
-            return new pc.RenderTarget(this.app.graphicsDevice, colorBuffer, { depth: useDepth });
+            return new pc.RenderTarget(this.app.graphicsDevice, colorBuffer, { depth: useDepth, stencil: useStencil});
         },
 
         _resizeOffscreenTarget: function (rt) {
@@ -96,6 +98,15 @@ Object.assign(pc, function () {
             colorBuffer.addressV = pc.ADDRESS_CLAMP_TO_EDGE;
 
             rt._colorBuffer = colorBuffer;
+            rt.destroy();
+        },
+
+        _destroyOffscreenTarget : function (rt) {
+            if(rt._colorBuffer)
+                rt._colorBuffer.destroy();
+            if(rt._depthBuffer)
+                rt._depthBuffer.destroy();
+
             rt.destroy();
         },
 
@@ -158,15 +169,26 @@ Object.assign(pc, function () {
                         break;
                     }
                 }
-                for (i = start; i >= 0; i--) {
-                    if (layerList[i].cameras.indexOf(this.camera) >= 0) {
-                        if (order === 0) {
-                            order = i + 1;
+
+                this._sourceLayers = [];
+                
+                for(i = 0; i < this.camera.layers.length; i++) {
+                    var layerID = this.camera.layers[i];
+                    var layer = this.app.scene.layers.getLayerById(layerID);
+                    var index = this.app.scene.layers.layerList.indexOf(layer);
+
+                    if (index <= start) {
+                        if(layerID != pc.LAYERID_DEPTH) {
+                            layer.renderTarget = newEntry.inputTarget;
+                            this._sourceLayers.push(layer);
                         }
-                        layerList[i].renderTarget = newEntry.inputTarget;
+
+                        if(index > order)
+                            order = index;
                     }
                 }
-                this.app.scene.layers.insertOpaque(this.layer, order);
+                this.app.scene.layers.insertOpaque(this.layer, order + 1);
+                this._sourceTarget = newEntry.inputTarget;
                 this.layer._commandList = [];
                 this.layer.isPostEffect = true;
             }
@@ -179,7 +201,15 @@ Object.assign(pc, function () {
                 effects[len - 2].outputTarget = newEntry.inputTarget;
             }
 
+            // Request depthmap if needed
+            this._newPostEffect = effect;
+            if (effect.needsDepthBuffer) {
+                this._requestDepthMap();
+            }
+        
+
             this.enable();
+            this._newPostEffect = undefined;
         },
 
         /**
@@ -210,23 +240,27 @@ Object.assign(pc, function () {
                         // the input render target of the effect that will now become the first one
                         // has a depth buffer
                         if (!this.effects[1].inputTarget._depth) {
-                            this.effects[1].inputTarget.destroy();
+                            this._destroyOffscreenTarget(this.effects[1].inputTarget);
                             this.effects[1].inputTarget = this._createOffscreenTarget(true, this.effects[1].hdr);
+                            this._sourceTarget = this.effects[1].inputTarget;
                         }
-
-                        this.camera.renderTarget = this.effects[1].inputTarget;
+                        // Also apply to the source layers
+                        for(var i = 0; i < this._sourceLayers.length; i++) {
+                            this._sourceLayers[i].renderTarget = this.effects[1].inputTarget;
+                        }    
+                        
                     }
                 }
 
                 // release memory for removed effect
-                this.effects[index].inputTarget.destroy();
+                this._destroyOffscreenTarget(this.effects[index].inputTarget);
 
                 this.effects.splice(index, 1);
             }
 
             if (this.enabled) {
                 if (effect.needsDepthBuffer) {
-                    this.camera.releaseDepthMap();
+                    this._releaseDepthMap();
                 }
             }
 
@@ -235,22 +269,34 @@ Object.assign(pc, function () {
             }
         },
 
-        requestDepthMap: function () {
+        _requestDepthMaps: function () {
             for (var i = 0, len = this.effects.length; i < len; i++) {
                 var effect = this.effects[i].effect;
+                if(this._newPostEffect === effect)
+                    continue;
+
                 if (effect.needsDepthBuffer) {
-                    this.camera.camera.requestDepthMap();
+                    this._requestDepthMap();
                 }
             }
         },
 
-        releaseDepthMap: function () {
+        _releaseDepthMaps: function () {
             for (var i = 0, len = this.effects.length; i < len; i++) {
                 var effect = this.effects[i].effect;
                 if (effect.needsDepthBuffer) {
-                    this.camera.releaseDepthMap();
+                    this._releaseDepthMap();
                 }
             }
+        },
+
+        _requestDepthMap: function () {
+            if (!depthLayer) depthLayer = this.app.scene.layers.getLayerById(pc.LAYERID_DEPTH);
+            if (depthLayer) depthLayer.incrementCounter();
+        },
+
+        _releaseDepthMap: function () {
+            if (depthLayer) depthLayer.decrementCounter();
         },
 
         /**
@@ -279,7 +325,7 @@ Object.assign(pc, function () {
                 this.enabled = true;
 
                 var self = this;
-                this.requestDepthMap();
+                this._requestDepthMaps();
 
                 this.app.graphicsDevice.on('resizecanvas', this._onCanvasResized, this);
 
@@ -326,8 +372,8 @@ Object.assign(pc, function () {
 
                 this.app.graphicsDevice.off('resizecanvas', this._onCanvasResized, this);
 
-                this.camera.renderTarget = null;
-                this.releaseDepthMap();
+                this._releaseDepthMaps();
+                this._destroyOffscreenTarget(this._sourceTarget);
 
                 // remove the draw command
                 var i = this.layer._commandList.indexOf(this.command);


### PR DESCRIPTION
I tried to make most of the current post effects working again. I'm not sure if post-effect-queue is going to be superseded by post-effect-pass soon.
The `examples\post_effects\index.html` should work now as intended.

I mainly fixed these problems:
- If the camera is not preset in the scene when adding post effects, the index of the PostEffectLayer was wrong. This prevented the example scene to work.
- `addEffect:` The input target of the first effect also replaced the `depthLayer.renderTarget`
- the offscreen render target was incompatible to the depthbuffer blitting because it missed the stencil flag
- the `depthMap` is now requested by declaring `needsDepthBuffer` in the effect only. All other functions like `_requestDepthMap` are private now
- Added some clean up code for removing the offscreen targets 

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
