### PR TITLE
Added -m option to build.js to allow source mapped output

### DIFF
--- a/build/build.js
+++ b/build/build.js
@@ -38,6 +38,7 @@ try {
 
 var DEFAULT_OUTPUT = "output/playcanvas-latest.js";
 var DEFAULT_TEMP = "_tmp";
+var DEFAULT_SOURCE = "../src";
 var SRC_DIR = "../";
 
 var COMPILER_LEVEL = [
@@ -48,7 +49,9 @@ var COMPILER_LEVEL = [
 
 var debug = false;
 var profiler = false;
+var sourceMap = false;
 var outputPath = DEFAULT_OUTPUT;
+var sourcePath = DEFAULT_SOURCE;
 var tempPath = DEFAULT_TEMP;
 var compilerLevel = COMPILER_LEVEL[0];
 var formattingLevel = undefined;
@@ -158,11 +161,15 @@ var preprocess = function (dependencies) {
         var buffer = fs.readFileSync(filepath);
 
         var pp = new Preprocessor(buffer.toString());
-        var src = pp.process({
-            PROFILER: profiler || debug,
-            DEBUG: debug
-        });
-
+        var src;
+        // TODO: source mapped build doesn't support preprocessor yet
+        if(this.sourceMap)
+            src = buffer;
+        else 
+            src = pp.process({
+                PROFILER: profiler || debug,
+                DEBUG: debug
+            });
         var dir = path.dirname(_out);
         fse.ensureDirSync(dir);
 
@@ -234,6 +241,25 @@ var run = function () {
             if (compilerLevel === "WHITESPACE_ONLY") {
                 options.formatting = "pretty_print";
             }
+
+            if(sourceMap) {
+                var outputfilename = path.basename(outputPath);
+
+                var wrapperContent = fs.readFileSync("./umd-wrapper.js");
+                var wrapperPostamble = "\n//# sourceMappingURL=" + outputfilename + ".map";
+
+                var tempWrapperPath = path.join(tempPath, "./_umd-wrapper.js");
+                fs.writeFileSync(tempWrapperPath, wrapperContent + wrapperPostamble);
+
+                var mapFilePath = outputPath + ".map";
+                var relativeSourcePath = path.relative(path.dirname(outputPath), sourcePath);
+
+                options.output_wrapper_file = tempWrapperPath;
+                options.create_source_map = mapFilePath;
+                options.source_map_location_mapping = "_tmp/src|" + relativeSourcePath;
+                options.source_map_include_content = undefined;
+            }
+
             var closureCompiler = new ClosureCompiler(options);
 
             // compile
@@ -275,7 +301,7 @@ var arguments = function () {
     process.argv.forEach(function (arg) {
         if (arg === '-h') {
             console.log("Build Script for PlayCanvas Engine\n");
-            console.log("Usage: node build.js -l [COMPILER_LEVEL] -o [OUTPUT_PATH]\n");
+            console.log("Usage: node build.js -l [COMPILER_LEVEL] -o [OUTPUT_PATH] -m [SOURCE_PATH]\n");
             console.log("Arguments:");
             console.log("-h: show this help");
             console.log("-l COMPILER_LEVEL: Set compiler level");
@@ -285,6 +311,7 @@ var arguments = function () {
             console.log("-o PATH: output file path [output/playcanvas-latest.js]");
             console.log("-d: build debug engine configuration");
             console.log("-p: build profiler engine configuration");
+            console.log("-m SOURCE_PATH: build engine and generate source map next to output file. [../src]");
             process.exit();
         }
 
@@ -309,6 +336,13 @@ var arguments = function () {
             outputPath = arg;
         }
 
+        if (arg === '-m') {
+            sourceMap = true;
+        }
+
+        if (_last === '-m' && !arg.startsWith('-')) {
+            sourcePath = arg;
+        }
         _last = arg;
     });
 };


### PR DESCRIPTION
While developing #1505 using a source mapped `playcanvas-latest.js` was really, really helpful.

The new `-m` option takes an optional path to where the source files are mapped to.
Unfortunately this new option doesn't support the debug `-d` or profiler `-p` option (because of  the preprocessor).

Example use:
`node build.js -m -l 1`
`node build.js -m ..\differentSourcePath -l 2`

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
