### PR TITLE
name engine build based on build type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -648,9 +648,9 @@
       "dev": true
     },
     "clone": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
-      "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs=",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
       "dev": true
     },
     "clone-buffer": {

--- a/package.json
+++ b/package.json
@@ -46,9 +46,10 @@
     "jsdom": "^11.12.0"
   },
   "scripts": {
-    "build": "cd build && node build.js",
-    "build:debug": "cd build && node build.js -d",
-    "build:profiler": "cd build && node build.js -d -p",
+    "build": "cd build && node build.js -o output/playcanvas-latest.js",
+    "build:debug": "cd build && node build.js -d -o output/playcanvas-latest.dbg.js",
+    "build:profiler": "cd build && node build.js -d -p -o output/playcanvas-latest.prf.js",
+    "build:min": "cd build && node build.js -l 1 -o output/playcanvas-latest.min.js",
     "serve": "npm run build; ./node_modules/.bin/http-server build/output -a localhost -p 51000",
     "closure": "java -jar node_modules/google-closure-compiler/compiler.jar --compilation_level=SIMPLE --warning_level=VERBOSE --jscomp_off=checkTypes --externs build/externs.js --language_in=ECMASCRIPT5_STRICT --js build/output/playcanvas-latest.js --js_output_file build/output/playcanvas.min.js",
     "uglify": "uglifyjs build/output/playcanvas-latest.js --compress --mangle --output build/output/playcanvas.min.js",


### PR DESCRIPTION
All three engine builds were saving the engine to playcanvas-latest.js.

This change names the files according to build type as follows:
default build is named playcanvas-latest.js (as before)
debug build is named playcanvas-latest.dbg.js
profiler build is named playcanvas-latest.prf.js
minified build is named playcanvas-latest.min.js

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
