### PR TITLE
Fix memory leak with Text Elements

### DIFF
--- a/src/framework/components/element/text-element.js
+++ b/src/framework/components/element/text-element.js
@@ -128,6 +128,10 @@ Object.assign(pc, function () {
             this._element.off('screen:set:screenspace', this._onScreenSpaceChange, this);
             this._element.off('set:draworder', this._onDrawOrderChange, this);
             this._element.off('set:pivot', this._onPivotChange, this);
+
+            this._system.app.i18n.off('set:locale', this._resetLocalizedText, this);
+            this._system.app.i18n.off('data:add', this._onLocalizationData, this);
+            this._system.app.i18n.off('data:remove', this._onLocalizationData, this);
         },
 
         _onParentResize: function (width, height) {

--- a/tests/framework/components/element/test_textelement.js
+++ b/tests/framework/components/element/test_textelement.js
@@ -1143,4 +1143,16 @@ describe("pc.TextElement", function () {
         expect(clone.element.key).to.equal(null);
         expect(clone.element.text).to.equal('text');
     });
+
+    it('text element removes i18n event listeners on destroy', function () {
+        expect(app.i18n.hasEvent('set:locale')).to.equal(true);
+        expect(app.i18n.hasEvent('data:add')).to.equal(true);
+        expect(app.i18n.hasEvent('data:remove')).to.equal(true);
+
+        element.entity.destroy();
+
+        expect(app.i18n.hasEvent('set:locale')).to.equal(false);
+        expect(app.i18n.hasEvent('data:add')).to.equal(false);
+        expect(app.i18n.hasEvent('data:remove')).to.equal(false);
+    });
 });


### PR DESCRIPTION
Fix memory leak with Text Elements not unsubscribing from i18n events on destroy

Fixes #

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
