### PR TITLE
Batching supports async model load.

### DIFF
--- a/src/framework/components/model/component.js
+++ b/src/framework/components/model/component.js
@@ -266,7 +266,10 @@ Object.assign(pc, function () {
             }
 
             if (this._batchGroupId >= 0) {
-                app.batcher.insert(pc.BatchGroup.MODEL, this.batchGroupId, this.entity);
+                if (this._model)
+                    app.batcher.insert(pc.BatchGroup.MODEL, this.batchGroupId, this.entity);
+                else
+                    app.batcher.register(pc.BatchGroup.MODEL, this.batchGroupId, this.entity);
             }
         },
 
@@ -281,7 +284,10 @@ Object.assign(pc, function () {
             }
 
             if (this._batchGroupId >= 0) {
-                app.batcher.remove(pc.BatchGroup.MODEL, this.batchGroupId, this.entity);
+                if (this._model)
+                    app.batcher.remove(pc.BatchGroup.MODEL, this.batchGroupId, this.entity);
+                else
+                    app.batcher.unregister(pc.BatchGroup.MODEL, this.batchGroupId, this.entity);
             }
 
             if (this._model) {
@@ -608,8 +614,13 @@ Object.assign(pc, function () {
                 return;
             }
 
+            var batcher = this.system.app.batcher;
             if (this._model) {
-                this.removeModelFromLayers(this._model);
+                if (this._batchGroupId >= 0) {
+                    batcher.remove(pc.BatchGroup.MODEL, _batchGroupId, this.entity);
+                } else {
+                    this.removeModelFromLayers(this._model);
+                }
                 this.entity.removeChild(this._model.getGraph());
                 delete this._model._entity;
 
@@ -635,7 +646,11 @@ Object.assign(pc, function () {
                 this.entity.addChild(this._model.graph);
 
                 if (this.enabled && this.entity.enabled) {
-                    this.addModelToLayers();
+                    if (this._batchGroupId >= 0) {
+                        batcher.insert(pc.BatchGroup.MODEL, this._batchGroupId, this.entity);
+                    } else {
+                        this.addModelToLayers();
+                    }
                 }
 
                 // Store the entity that owns this model
@@ -838,10 +853,16 @@ Object.assign(pc, function () {
 
             var batcher = this.system.app.batcher;
             if (this.entity.enabled && this._batchGroupId >= 0) {
-                batcher.remove(pc.BatchGroup.MODEL, this.batchGroupId, this.entity);
+                if (this._model)
+                    batcher.remove(pc.BatchGroup.MODEL, this.batchGroupId, this.entity);
+                else
+                    batcher.unregister(pc.BatchGroup.MODEL, this.batchGroupId, this.entity);
             }
             if (this.entity.enabled && value >= 0) {
-                batcher.insert(pc.BatchGroup.MODEL, value, this.entity);
+                if (this._model)
+                    batcher.insert(pc.BatchGroup.MODEL, value, this.entity);
+                else
+                    batcher.register(pc.BatchGroup.MODEL, value, this.entity);
             }
 
             if (value < 0 && this._batchGroupId >= 0 && this.enabled && this.entity.enabled) {

--- a/src/scene/batching.js
+++ b/src/scene/batching.js
@@ -51,6 +51,7 @@ Object.assign(pc, function () {
         this.name = name;
         this.layers = layers === undefined ? [pc.LAYERID_WORLD] : layers;
         this._ui = false;
+        this._deferred = 0; // async models loading counter
         this._obj = {
             model: [],
             element: [],
@@ -315,8 +316,15 @@ Object.assign(pc, function () {
         if (group) {
             if (group._obj[type].indexOf(node) < 0) {
                 group._obj[type].push(node);
-                this.markGroupDirty(groupId);
+            } else {
+                group._deferred--;
+                // #ifdef DEBUG
+                if (group._deferred < 0)
+                    console.error('Invalid batch' + groupId + ' async loading counter');
+                // #endif
             }
+            if (group._deferred == 0)
+                this.markGroupDirty(groupId);
         } else {
             // #ifdef DEBUG
             console.warn('Invalid batch ' + groupId + ' insertion');
@@ -330,11 +338,51 @@ Object.assign(pc, function () {
             var idx = group._obj[type].indexOf(node);
             if (idx >= 0) {
                 group._obj[type].splice(idx, 1);
-                this.markGroupDirty(groupId);
+                if (group._deferred == 0)
+                    this.markGroupDirty(groupId);
             }
         } else {
             // #ifdef DEBUG
             console.warn('Invalid batch ' + groupId + ' insertion');
+            // #endif
+        }
+    };
+
+    BatchManager.prototype.register = function (type, groupId, node) {
+        var group = this._batchGroups[groupId];
+        if (group) {
+            if (group._obj[type].indexOf(node) < 0) {
+                group._deferred++;
+                group._obj[type].push(node);
+                var idx = this._dirtyGroups.indexOf(groupId);
+                if (idx >= 0) {
+                    this._dirtyGroups.splice(idx, 1);
+                }
+            }
+        } else {
+            // #ifdef DEBUG
+            console.warn('Invalid batch ' + groupId + ' register');
+            // #endif
+        }
+    };
+
+    BatchManager.prototype.unregister = function (type, groupId, node) {
+        var group = this._batchGroups[groupId];
+        if (group) {
+            var idx = group._obj[type].indexOf(node);
+            if (idx >= 0) {
+                group._obj[type].splice(idx, 1);
+                group._deferred--;
+                // #ifdef DEBUG
+                if (group._deferred < 0)
+                    console.error('Invalid batch' + groupId + ' async loading counter');
+                // #endif
+            }
+            if (group._deferred == 0)
+                this.markGroupDirty(groupId);
+        } else {
+            // #ifdef DEBUG
+            console.warn('Invalid batch ' + groupId + ' unregister');
             // #endif
         }
     };

--- a/tests/batching/test_batching.js
+++ b/tests/batching/test_batching.js
@@ -10,7 +10,7 @@ describe('pc.Batcher', function () {
         this.app.destroy();
     });
 
-    it("generate: removes model component mesh instances from layer", function() {
+    it("generate: removes model component mesh instances from layer", function () {
         var e1 = new pc.Entity();
         e1.name = "e1";
         e1.addComponent("model", {
@@ -34,7 +34,7 @@ describe('pc.Batcher', function () {
         var instances = layer.opaqueMeshInstances;
 
         expect(instances.length).to.equal(1); // "Too many mesh instances in layer");
-        expect(instances[0]).not.to.equal(e1.model.model.meshInstances[0]); //"e1 still references instance in layer");
+        expect(instances[0]).not.to.equal(e1.model.model.meshInstances[0]); // "e1 still references instance in layer");
         expect(instances[1]).not.to.equal(e2.model.model.meshInstances[0]); // "e2 still references instance in layer");
     });
 
@@ -66,7 +66,7 @@ describe('pc.Batcher', function () {
     //     ok(instances[1] !== e2.model.model.meshInstances[0], "e2 still references instance in layer");
     // });
 
-    it("disable model component, marks batch group dirty", function() {
+    it("disable model component, marks batch group dirty", function () {
         var e1 = new pc.Entity();
         e1.name = "e1";
         e1.addComponent("model", {
@@ -126,6 +126,101 @@ describe('pc.Batcher', function () {
 
         expect(this.app.batcher._batchList.length).to.equal(0);
 
-    })
-})
+    });
 
+    it("async models loading doesn't triggers batch regen", function () {
+        var e1 = new pc.Entity();
+        e1.name = "e1";
+        e1.addComponent("model", {
+            type: "asset",
+            batchGroupId: this.bg.id
+        });
+
+        var e2 = new pc.Entity();
+        e2.name = "e2";
+        e2.addComponent("model", {
+            type: "asset",
+            batchGroupId: this.bg.id
+        });
+
+        this.app.root.addChild(e1);
+        this.app.root.addChild(e2);
+
+        expect(this.app.batcher._dirtyGroups.length).to.equal(0);
+    });
+
+    it("async models loading completion triggers batch regen", function () {
+        var e1 = new pc.Entity();
+        e1.name = "e1";
+        e1.addComponent("model", {
+            type: "asset",
+            batchGroupId: this.bg.id
+        });
+
+        var e2 = new pc.Entity();
+        e2.name = "e2";
+        e2.addComponent("model", {
+            type: "asset",
+            batchGroupId: this.bg.id
+        });
+
+        this.app.root.addChild(e1);
+        this.app.root.addChild(e2);
+
+        e1.model.type = "box";
+        e2.model.type = "box";
+
+        expect(this.app.batcher._dirtyGroups[0]).to.equal(this.bg.id);
+
+    });
+
+    it("mixed instant and async models loading", function () {
+        var e1 = new pc.Entity();
+        e1.name = "e1";
+        e1.addComponent("model", {
+            type: "asset",
+            batchGroupId: this.bg.id
+        });
+
+        var e2 = new pc.Entity();
+        e2.name = "e2";
+        e2.addComponent("model", {
+            type: "box",
+            batchGroupId: this.bg.id
+        });
+
+        this.app.root.addChild(e1);
+        this.app.root.addChild(e2);
+
+        expect(this.app.batcher._dirtyGroups.length).to.equal(0);
+
+        e1.model.type = "box";
+
+        expect(this.app.batcher._dirtyGroups[0]).to.equal(this.bg.id);
+    });
+
+    it("disabling the only model in loading stage triggers batch regen", function () {
+        var e1 = new pc.Entity();
+        e1.name = "e1";
+        e1.addComponent("model", {
+            type: "asset",
+            batchGroupId: this.bg.id
+        });
+
+        var e2 = new pc.Entity();
+        e2.name = "e2";
+        e2.addComponent("model", {
+            type: "box",
+            batchGroupId: this.bg.id
+        });
+
+        this.app.root.addChild(e1);
+        this.app.root.addChild(e2);
+
+        expect(this.app.batcher._dirtyGroups.length).to.equal(0);
+
+        e1.enabled = false;
+
+        expect(this.app.batcher._dirtyGroups[0]).to.equal(this.bg.id);
+    });
+});


### PR DESCRIPTION
Batch group internal counter for async loading models (_deferred). This blocks the group from (re)generating batch-models until all models are loaded.
Several tests added to cover new functionality.

Not fully tested yet.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
