### PR TITLE
Fix fallback plural function for i18n

### DIFF
--- a/src/i18n/i18n.js
+++ b/src/i18n/i18n.js
@@ -247,6 +247,7 @@ Object.assign(pc, (function () {
         var translations = this._translations[locale];
         if (!translations) {
             locale = this._findFallbackLocale(lang);
+            lang = getLang(locale);
             pluralFn = getPluralFn(lang);
             translations = this._translations[locale];
         }

--- a/tests/i18n/test_i18n.js
+++ b/tests/i18n/test_i18n.js
@@ -130,6 +130,13 @@ describe('I18n tests', function () {
         expect(app.i18n.getPluralText('key', 1)).to.equal('english one');
     });
 
+    it('getPluralText() should return en-US plural form if the desired locale does not exist', function () {
+        addText('en-US', 'key', ['english one', 'english other']);
+        expect(app.i18n.getPluralText('key', 1, 'ar')).to.equal('english one');
+        app.i18n.locale = 'ar';
+        expect(app.i18n.getPluralText('key', 1)).to.equal('english one');
+    });
+
     it('getPluralText() should fall back to default locale for that language if the specific locale does not exist', function () {
         var lang;
         for (lang in DEFAULT_LOCALE_FALLBACKS) {


### PR DESCRIPTION
Use fallback plural function when desired locale does not have any translations

Fixes #

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
