### PR TITLE
Fixes textures created from NaN array in particles.

### DIFF
--- a/src/graphics/program-lib/chunks/particleUpdaterStart.frag
+++ b/src/graphics/program-lib/chunks/particleUpdaterStart.frag
@@ -60,7 +60,7 @@ void main(void)
 #else
     vec3 radialVel = radialSpeed * normalize(inPos);
 #endif
-    radialVel += (2.0 * radialSpeedDiv - 1.0) * radialSpeedDivMult * rndFactor.z;
+    radialVel += (radialSpeedDiv * vec3(2.0) - vec3(1.0)) * radialSpeedDivMult * rndFactor.xyz;
 
     localVelocity +=    (localVelocityDiv * vec3(2.0) - vec3(1.0)) * localVelocityDivMult * rndFactor.xyz;
     velocity +=         (velocityDiv * vec3(2.0) - vec3(1.0)) * velocityDivMult * rndFactor.xyz;

--- a/src/scene/particle-emitter.js
+++ b/src/scene/particle-emitter.js
@@ -429,7 +429,7 @@ Object.assign(pc, function () {
         var values = A.length / chans;
         for (i = 0; i < values; i++) {
             for (j = 0; j < chans; j++) {
-                A[i * chans + j] /= uMax[j];
+                A[i * chans + j] /= (uMax[j] == 0 ? 1 : uMax[j]);
                 A[i * chans + j] *= 0.5;
                 A[i * chans + j] += 0.5;
             }

--- a/src/scene/particle-emitter.js
+++ b/src/scene/particle-emitter.js
@@ -429,7 +429,7 @@ Object.assign(pc, function () {
         var values = A.length / chans;
         for (i = 0; i < values; i++) {
             for (j = 0; j < chans; j++) {
-                A[i * chans + j] /= (uMax[j] == 0 ? 1 : uMax[j]);
+                A[i * chans + j] /= (uMax[j] === 0 ? 1 : uMax[j]);
                 A[i * chans + j] *= 0.5;
                 A[i * chans + j] += 0.5;
             }


### PR DESCRIPTION
Zero max in both graphs (initialised by default) caused Div array contains only NaN. The textures created from this array leads to undefined behaviour.
Minor discrepancy in shader for Radial Speed fixed (+= vec3)

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
