### PR TITLE
font asset bug

### DIFF
--- a/src/resources/font.js
+++ b/src/resources/font.js
@@ -126,6 +126,10 @@ Object.assign(pc, function () {
                 // font data present in font but not in asset
                 asset.data = font.data;
             }
+
+            if (asset.data) {
+                asset.data = upgradeDataSchema(asset.data);
+            }
         }
     });
 


### PR DESCRIPTION
To reproduce the issue:
 - create a scene and add a ttf font asset
 - create a text element referencing the font asset
 - select the font asset and modify "intensity"
 - the screen goes black, the editor is unresponsive

It looks like the asset handler patch call is not upgrading the font asset correctly.

Question: why is the newly created font schema version 2 and not 3 to being with?

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
