### PR TITLE
Fix for undefined 'constantLightCube' in particles

### DIFF
--- a/src/scene/particle-system/gpu-updater.js
+++ b/src/scene/particle-system/gpu-updater.js
@@ -43,7 +43,6 @@ Object.assign(pc, function () {
         this.constantRate = gd.scope.resolve("rate");
         this.constantRateDiv = gd.scope.resolve("rateDiv");
         this.constantLifetime = gd.scope.resolve("lifetime");
-        this.constantLightCube = gd.scope.resolve("lightCube[0]");
         this.constantGraphSampleSize = gd.scope.resolve("graphSampleSize");
         this.constantGraphNumSamples = gd.scope.resolve("graphNumSamples");
         this.constantInternalTex0 = gd.scope.resolve("internalTex0");

--- a/src/scene/particle-system/particle-emitter.js
+++ b/src/scene/particle-system/particle-emitter.js
@@ -215,6 +215,7 @@ Object.assign(pc, function () {
         this._gpuUpdater = new pc.ParticleGPUUpdater(this, gd);
         this._cpuUpdater = new pc.ParticleCPUUpdater(this);
 
+        this.constantLightCube = gd.scope.resolve("lightCube[0]");
         this.emitterPosUniform = new Float32Array(3);
         this.wrapBoundsUniform = new Float32Array(3);
         this.emitterScaleUniform = new Float32Array([1, 1, 1]);


### PR DESCRIPTION
Hot fix for particles lighting crash. 'constantLightCube' is shared between CPU and GPU modes.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
