### PR TITLE
fix for iphone xr and xs cubemaps

### DIFF
--- a/src/graphics/device.js
+++ b/src/graphics/device.js
@@ -1511,6 +1511,43 @@ Object.assign(pc, function () {
             }
         },
 
+        // In the case where a texture has more than 1 level of mip data specified, but doesn't have
+        // the full mip chain, we generate the missing levels here.
+        // This is to overcome an issue where iphone xr and xs ignores further updates to the mip data
+        // after invoking gl.generateMipmap on the texture (which was the previous method of ensuring
+        // the texture's full mip chain was complete).
+        // NOTE: this function copies texture data from the previous mip level instead of downsampling it.
+        _completePartialMipmapChain: function (texture) {
+
+            var requiredMipLevels = Math.log2(Math.max(texture._width, texture._height)) + 1;
+
+            if (texture._levels.length === 1 ||
+                texture._levels.length === requiredMipLevels ||
+                !(texture._levels[0] instanceof Array) ||
+                texture._compressed ||
+                texture._volume) {
+                return;
+            }
+
+            // step through levels
+            var elementsPerPixel = (texture._cubemap ? texture._levels[0][0] : texture._levels[0]).length / (texture._width * texture._height);
+            for (var level = texture._levels.length; level < requiredMipLevels; ++level) {
+                var width = Math.max(1, texture._width >> level);
+                var height = Math.max(1, texture._height >> level);
+                var size = Math.floor(width * height * elementsPerPixel);
+                if (texture._cubemap) {
+                    var mips = [];
+                    for (var face = 0; face < 6; ++face) {
+                        mips.push(texture._levels[level - 1][face].subarray(0, size));
+                    }
+                    texture._levels.push(mips);
+                } else {
+                    texture._levels.push(texture._levels[level - 1].subarray(0, size));
+                }
+            }
+            texture._levelsUpdated = texture._cubemap ? [[true, true, true, true, true, true]] : [true];
+        },
+
         uploadTexture: function (texture) {
             var gl = this.gl;
 
@@ -1520,6 +1557,8 @@ Object.assign(pc, function () {
             var mipLevel = 0;
             var mipObject;
             var resMult;
+
+            this._completePartialMipmapChain(texture);
 
             while (texture._levels[mipLevel] || mipLevel === 0) {
                 // Upload all existing mip levels. Initialize 0 mip anyway.
@@ -1532,13 +1571,6 @@ Object.assign(pc, function () {
                 }
 
                 mipObject = texture._levels[mipLevel];
-
-                if (mipLevel == 1 && !texture._compressed) {
-                    // We have more than one mip levels we want to assign, but we need all mips to make
-                    // the texture complete. Therefore first generate all mip chain from 0, then assign custom mips.
-                    gl.generateMipmap(texture._glTarget);
-                    texture._mipmapsUploaded = true;
-                }
 
                 if (texture._cubemap) {
                     // ----- CUBEMAP -----

--- a/src/graphics/prefilter-cubemap.js
+++ b/src/graphics/prefilter-cubemap.js
@@ -41,9 +41,9 @@ Object.assign(pc, (function () {
         var format = sourceCubemap.format;
 
         var cmapsList = [[], options.filteredFixed, options.filteredRgbm, options.filteredFixedRgbm];
-        var gloss = method === 0 ? [0.9, 0.85, 0.7, 0.4, 0.25] : [512, 128, 32, 8, 2]; // TODO: calc more correct values depending on mip
-        var mipSize = [64, 32, 16, 8, 4]; // TODO: make non-static?
-        var numMips = 5;
+        var gloss = method === 0 ? [0.9, 0.85, 0.7, 0.4, 0.25, 0.15, 0.1] : [512, 128, 32, 8, 2, 1, 1]; // TODO: calc more correct values depending on mip
+        var mipSize = [64, 32, 16, 8, 4, 2, 1]; // TODO: make non-static?
+        var numMips = 7;                        // generate all mips down to 1x1
         var targ;
         var i, face, pass;
 
@@ -207,15 +207,7 @@ Object.assign(pc, (function () {
 
         var mips;
         if (cpuSync && options.singleFilteredFixed) {
-            mips = [
-                sourceCubemap,
-                options.filteredFixed[0],
-                options.filteredFixed[1],
-                options.filteredFixed[2],
-                options.filteredFixed[3],
-                options.filteredFixed[4],
-                options.filteredFixed[5]
-            ];
+            mips = [sourceCubemap].concat(options.filteredFixed);
             cubemap = new pc.Texture(device, {
                 cubemap: true,
                 rgbm: rgbmSource,
@@ -227,7 +219,7 @@ Object.assign(pc, (function () {
                 addressV: pc.ADDRESS_CLAMP_TO_EDGE
             });
             cubemap.name = 'prefiltered-cube';
-            for (i = 0; i < 6; i++)
+            for (i = 0; i < mips.length; i++)
                 cubemap._levels[i] = mips[i]._levels[0];
 
             cubemap.upload();
@@ -236,15 +228,7 @@ Object.assign(pc, (function () {
         }
 
         if (cpuSync && options.singleFilteredFixedRgbm && options.filteredFixedRgbm) {
-            mips = [
-                sourceCubemapRgbm,
-                options.filteredFixedRgbm[0],
-                options.filteredFixedRgbm[1],
-                options.filteredFixedRgbm[2],
-                options.filteredFixedRgbm[3],
-                options.filteredFixedRgbm[4],
-                options.filteredFixedRgbm[5]
-            ];
+            mips = [sourceCubemapRgbm].concat(options.filteredFixedRgbm);
             cubemap = new pc.Texture(device, {
                 cubemap: true,
                 rgbm: true,
@@ -256,7 +240,7 @@ Object.assign(pc, (function () {
                 addressV: pc.ADDRESS_CLAMP_TO_EDGE
             });
             cubemap.name = 'prefiltered-cube';
-            for (i = 0; i < 6; i++) {
+            for (i = 0; i < mips.length; i++) {
                 cubemap._levels[i] = mips[i]._levels[0];
             }
             cubemap.upload();


### PR DESCRIPTION
- generate prefiltered cubemaps with full mip chain
- patch textures with partial mip chains

Fixes #

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
