### PR TITLE
User-defined material parameters support.

### DIFF
--- a/tests/scene/test_material.js
+++ b/tests/scene/test_material.js
@@ -31,4 +31,21 @@ describe('pc.GraphNode', function () {
         notEqual(m1.parameters["str-value"].data, m2.parameters["str-value"].data);
         equal(m2.parameters["str-value"].data, "42");
     });
+
+    it('Material: vector type custom parameter support', function () {
+        var m1 = new pc.Material();
+        var vec = new Float32Array([1, 2, 3]);
+        m1.addCustomParameter("vec-value", vec, function (v) {
+            return new Float32Array(v);
+        });
+
+        var m2 = m1.clone();
+
+        notEqual(m1.parameters["vec-value"].data, m2.parameters["vec-value"].data);
+
+        vec[0] = 42;
+
+        equal(m1.parameters["vec-value"].data[0], 42);
+        equal(m2.parameters["vec-value"].data[0], 1);
+    });
 });

--- a/tests/scene/test_material.js
+++ b/tests/scene/test_material.js
@@ -1,0 +1,34 @@
+describe('pc.GraphNode', function () {
+    beforeEach(function () {
+        this.app = new pc.Application(document.createElement('canvas'));
+    });
+
+    afterEach(function () {
+        this.app.destroy();
+    });
+
+    it('Material: trivial custom parameter support', function () {
+        var m1 = new pc.Material();
+        m1.addCustomParameter("int-value", 42);
+
+        var m2 = m1.clone();
+
+        m1.setParameter("int-value", 24);
+
+        notEqual(m1.parameters["int-value"].data, m2.parameters["int-value"].data);
+        equal(m2.parameters["int-value"].data, 42);
+    });
+
+    it('Material: string type custom parameter support', function () {
+        var m1 = new pc.Material();
+        m1.addCustomParameter("str-value", "42", function (s) {
+            return s.slice(0);
+        });
+
+        var m2 = m1.clone();
+
+        m1.setParameter("str-value", "24");
+        notEqual(m1.parameters["str-value"].data, m2.parameters["str-value"].data);
+        equal(m2.parameters["str-value"].data, "42");
+    });
+});


### PR DESCRIPTION
Fixes missing user-definer shader params after cloning - a new material method allows to add tracking for the custom parameter. Also, user can define a cloning strategy for this parameters.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
