### PR TITLE
A hot-fix for sprites batching drawOrder issue

### DIFF
--- a/src/scene/batching.js
+++ b/src/scene/batching.js
@@ -429,7 +429,7 @@ Object.assign(pc, function () {
                 if (node.sprite && node.sprite._meshInstance) {
                     arr.push(node.sprite._meshInstance);
                     node.sprite.removeModelFromLayers();
-                    this._sprite = true;
+                    group._sprite = true;
                     node.sprite._batchGroup = group;
                 }
             }


### PR DESCRIPTION
A minor fix for an issue introduced with merge. Caused depth order sorting failure.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
