### PR TITLE
Add pc.GraphNode#getScale to return world scale of a node.

### DIFF
--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -109,23 +109,6 @@ Object.assign(pc, function () {
     });
 
     /**
-     * @private
-     * @readonly
-     * @name pc.GraphNode#scale
-     * @description The world scale of the graph node. The scale will only be correct if the graph node
-     * in question is not skewed as a result of scales and rotations applied higher in the hierarchy.
-     * @type pc.Vec3
-     */
-    Object.defineProperty(GraphNode.prototype, 'scale', {
-        get: function () {
-            if (!this._scale) {
-                this._scale = new pc.Vec3();
-            }
-            return this.getWorldTransform().getScale(this._scale);
-        }
-    });
-
-    /**
      * @name pc.GraphNode#enabled
      * @type Boolean
      * @description Enable or disable a GraphNode. If one of the GraphNode's parents is disabled
@@ -755,6 +738,25 @@ Object.assign(pc, function () {
         getRotation: function () {
             this.rotation.setFromMat4(this.getWorldTransform());
             return this.rotation;
+        },
+
+        /**
+         * @private
+         * @function
+         * @name pc.GraphNode#getScale
+         * @description Get the world space scale for the specified GraphNode. The returned value
+         * will only be correct for graph nodes that have a non-skewed world transform. The value
+         * returned by this function should be considered read-only. Note that it is not possible
+         * to set the world space scale of a graph node.
+         * @returns {pc.Vec3} The world space scale of the graph node.
+         * @example
+         * var scale = this.entity.getScale();
+         */
+        getScale: function () {
+            if (!this._scale) {
+                this._scale = new pc.Vec3();
+            }
+            return this.getWorldTransform().getScale(this._scale);
         },
 
         /**

--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -745,9 +745,10 @@ Object.assign(pc, function () {
          * @function
          * @name pc.GraphNode#getScale
          * @description Get the world space scale for the specified GraphNode. The returned value
-         * will only be correct for graph nodes that have a non-skewed world transform. The value
-         * returned by this function should be considered read-only. Note that it is not possible
-         * to set the world space scale of a graph node.
+         * will only be correct for graph nodes that have a non-skewed world transform (a skew can
+         * be introduced by the compounding of rotations and scales higher in the graph node
+         * hierarchy). The value returned by this function should be considered read-only. Note
+         * that it is not possible to set the world space scale of a graph node directly.
          * @returns {pc.Vec3} The world space scale of the graph node.
          * @example
          * var scale = this.entity.getScale();

--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -32,6 +32,7 @@ Object.assign(pc, function () {
         this.position = new pc.Vec3(0, 0, 0);
         this.rotation = new pc.Quat(0, 0, 0, 1);
         this.eulerAngles = new pc.Vec3(0, 0, 0);
+        this._scale = null;
 
         this.localTransform = new pc.Mat4();
         this._dirtyLocal = false;
@@ -104,6 +105,23 @@ Object.assign(pc, function () {
                 this._forward = new pc.Vec3();
             }
             return this.getWorldTransform().getZ(this._forward).normalize().scale(-1);
+        }
+    });
+
+    /**
+     * @private
+     * @readonly
+     * @name pc.GraphNode#scale
+     * @description The world scale of the graph node. The scale will only be correct if the graph node
+     * in question is not skewed as a result of scales and rotations applied higher in the hierarchy.
+     * @type pc.Vec3
+     */
+    Object.defineProperty(GraphNode.prototype, 'scale', {
+        get: function () {
+            if (!this._scale) {
+                this._scale = new pc.Vec3();
+            }
+            return this.getWorldTransform().getScale(this._scale);
         }
     });
 


### PR DESCRIPTION
Add a function ```getScale``` to pc.GraphNode that returns the world scale of a node. This is a read only property. It should only be correct for nodes that have no skew transform.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
