### PR TITLE
Make gravity a property instead of a function.

### DIFF
--- a/examples/physics/falling_shapes/index.html
+++ b/examples/physics/falling_shapes/index.html
@@ -26,7 +26,7 @@
     app.scene.ambientLight = new pc.Color(0.2, 0.2, 0.2);
 
     // Set the gravity for our rigid bodies
-    app.systems.rigidbody.setGravity(0, -9.8, 0);
+    app.systems.rigidbody.gravity.set(0, -9.81, 0);
 
     function createMaterial (color) {
         var material = new pc.StandardMaterial();

--- a/src/backwards-compatibility.js
+++ b/src/backwards-compatibility.js
@@ -396,7 +396,7 @@ pc.Application.prototype.disableFullscreen = function (success) {
     document.exitFullscreen();
 };
 
-pc.RigidBodyComponentSystem.setGravity = function () {
+pc.RigidBodyComponentSystem.prototype.setGravity = function () {
     // #ifdef DEBUG
     console.warn('DEPRECATED: pc.RigidBodyComponentSystem#setGravity is deprecated. Use pc.RigidBodyComponentSystem#gravity instead.');
     // #endif

--- a/src/backwards-compatibility.js
+++ b/src/backwards-compatibility.js
@@ -401,17 +401,9 @@ pc.RigidBodyComponentSystem.prototype.setGravity = function () {
     console.warn('DEPRECATED: pc.RigidBodyComponentSystem#setGravity is deprecated. Use pc.RigidBodyComponentSystem#gravity instead.');
     // #endif
 
-    var x, y, z;
     if (arguments.length === 1) {
-        x = arguments[0].x;
-        y = arguments[0].y;
-        z = arguments[0].z;
+        this.gravity.copy(arguments[0]);
     } else {
-        x = arguments[0];
-        y = arguments[1];
-        z = arguments[2];
+        this.gravity.set(arguments[0], arguments[1], arguments[2]);
     }
-    var gravity = new Ammo.btVector3(x, y, z);
-    this.dynamicsWorld.setGravity(gravity);
-    Ammo.destroy(gravity);
 };

--- a/src/backwards-compatibility.js
+++ b/src/backwards-compatibility.js
@@ -395,3 +395,23 @@ pc.Application.prototype.disableFullscreen = function (success) {
 
     document.exitFullscreen();
 };
+
+pc.RigidBodyComponentSystem.setGravity = function () {
+    // #ifdef DEBUG
+    console.warn('DEPRECATED: pc.RigidBodyComponentSystem#setGravity is deprecated. Use pc.RigidBodyComponentSystem#gravity instead.');
+    // #endif
+
+    var x, y, z;
+    if (arguments.length === 1) {
+        x = arguments[0].x;
+        y = arguments[0].y;
+        z = arguments[0].z;
+    } else {
+        x = arguments[0];
+        y = arguments[1];
+        z = arguments[2];
+    }
+    var gravity = new Ammo.btVector3(x, y, z);
+    this.dynamicsWorld.setGravity(gravity);
+    Ammo.destroy(gravity);
+};

--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -1320,7 +1320,7 @@ Object.assign(pc, function () {
 
             if (this.systems.rigidbody && typeof Ammo !== 'undefined') {
                 var gravity = settings.physics.gravity;
-                this.systems.rigidbody.setGravity(gravity[0], gravity[1], gravity[2]);
+                this.systems.rigidbody.gravity.set(gravity[0], gravity[1], gravity[2]);
             }
 
             this.scene.applySettings(settings);

--- a/src/framework/components/rigid-body/system.js
+++ b/src/framework/components/rigid-body/system.js
@@ -162,7 +162,6 @@ Object.assign(pc, function () {
         this.fixedTimeStep = 1 / 60;
 
         this.gravity = new pc.Vec3(0, -9.81, 0);
-        this._lastGravity = new pc.Vec3();
 
         this.on('remove', this.onRemove, this);
     };
@@ -433,12 +432,10 @@ Object.assign(pc, function () {
             // #endif
 
             // Check to see whether we need to update gravity on the dynamics world
-            if (!this._lastGravity.equals(this.gravity)) {
-                var gravity = new Ammo.btVector3(this.gravity.x, this.gravity.y, this.gravity.z);
+            var gravity = this.dynamicsWorld.getGravity();
+            if (gravity.x() !== this.gravity.x || gravity.y() !== this.gravity.y || gravity.z() !== this.gravity.z) {
+                gravity.setValue(this.gravity.x, this.gravity.y, this.gravity.z);
                 this.dynamicsWorld.setGravity(gravity);
-                Ammo.destroy(gravity);
-
-                this._lastGravity.copy(this.gravity);
             }
 
             // Update the transforms of all bodies

--- a/src/framework/components/rigid-body/system.js
+++ b/src/framework/components/rigid-body/system.js
@@ -135,12 +135,15 @@ Object.assign(pc, function () {
     /**
      * @constructor
      * @name pc.RigidBodyComponentSystem
-     * @classdesc The RigidBodyComponentSystem maintains the dynamics world for simulating rigid bodies, it also controls global values for the world such as gravity.
-     * Note: The RigidBodyComponentSystem is only valid if 3D Physics is enabled in your application. You can enable this in the application settings for your Depot.
+     * @classdesc The RigidBodyComponentSystem maintains the dynamics world for simulating rigid bodies,
+     * it also controls global values for the world such as gravity. Note: The RigidBodyComponentSystem
+     * is only valid if 3D Physics is enabled in your application. You can enable this in the application
+     * settings for your project.
      * @description Create a new RigidBodyComponentSystem
      * @param {pc.Application} app The Application
      * @extends pc.ComponentSystem
-     * @property {pc.Vec3} gravity The gravity vector used by the physics simulation. Defaults to [0, -9.81, 0].
+     * @property {pc.Vec3} gravity The world space vector representing global gravity in the physics simulation.
+     * Defaults to [0, -9.81, 0] which is an approximation of the gravitational force on Earth.
      */
     var RigidBodyComponentSystem = function RigidBodyComponentSystem(app) {
         pc.ComponentSystem.call(this, app);

--- a/src/framework/components/rigid-body/system.js
+++ b/src/framework/components/rigid-body/system.js
@@ -160,7 +160,6 @@ Object.assign(pc, function () {
 
         this.maxSubSteps = 10;
         this.fixedTimeStep = 1 / 60;
-
         this.gravity = new pc.Vec3(0, -9.81, 0);
 
         this.on('remove', this.onRemove, this);

--- a/src/framework/scene-registry.js
+++ b/src/framework/scene-registry.js
@@ -271,7 +271,7 @@ Object.assign(pc, function () {
 
                     // Initialise pack settings
                     if (self._app.systems.rigidbody && typeof Ammo !== 'undefined') {
-                        self._app.systems.rigidbody.setGravity(scene._gravity.x, scene._gravity.y, scene._gravity.z);
+                        self._app.systems.rigidbody.gravity.set(scene._gravity.x, scene._gravity.y, scene._gravity.z);
                     }
 
                     if (callback) {


### PR DESCRIPTION
Fixes #1627.

There has never been a way to get the current gravity setting from the rigidbody componeny system. This PR makes gravity a vanilla property making it easy to get and set.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
