### PR TITLE
Move deprecated pc.GraphNode API into backwards compatibility file.

### DIFF
--- a/src/backwards-compatibility.js
+++ b/src/backwards-compatibility.js
@@ -328,12 +328,111 @@ pc.Material.prototype.setShader = function (shader) {
 
 pc.GraphNode.prototype._dirtify = function (local) {
     // #ifdef DEBUG
-    console.warn('DEPRECATED: pc.GraphNode#_dirtify is deprecated. Use the pc.GraphNode#_dirtifyLocal or _dirtifyWorld respectively instead.');
+    console.warn('DEPRECATED: pc.GraphNode#_dirtify is deprecated. Use pc.GraphNode#_dirtifyLocal or _dirtifyWorld respectively instead.');
     // #endif
     if (local)
         this._dirtifyLocal();
     else
         this._dirtifyWorld();
+};
+
+pc.GraphNode.prototype.addLabel = function (label) {
+    // #ifdef DEBUG
+    console.warn('DEPRECATED: pc.GraphNode#addLabel is deprecated. Use pc.GraphNode#tags instead.');
+    // #endif
+
+    this._labels[label] = true;
+};
+
+pc.GraphNode.prototype.getLabels = function () {
+    // #ifdef DEBUG
+    console.warn('DEPRECATED: pc.GraphNode#getLabels is deprecated. Use pc.GraphNode#tags instead.');
+    // #endif
+
+    return Object.keys(this._labels);
+};
+
+pc.GraphNode.prototype.hasLabel = function (label) {
+    // #ifdef DEBUG
+    console.warn('DEPRECATED: pc.GraphNode#hasLabel is deprecated. Use pc.GraphNode#tags instead.');
+    // #endif
+
+    return !!this._labels[label];
+};
+
+pc.GraphNode.prototype.removeLabel = function (label) {
+    // #ifdef DEBUG
+    console.warn('DEPRECATED: pc.GraphNode#removeLabel is deprecated. Use pc.GraphNode#tags instead.');
+    // #endif
+
+    delete this._labels[label];
+};
+
+pc.GraphNode.prototype.findByLabel = function (label, results) {
+    // #ifdef DEBUG
+    console.warn('DEPRECATED: pc.GraphNode#findByLabel is deprecated. Use pc.GraphNode#tags instead.');
+    // #endif
+
+    var i, length = this._children.length;
+    results = results || [];
+
+    if (this.hasLabel(label)) {
+        results.push(this);
+    }
+
+    for (i = 0; i < length; ++i) {
+        results = this._children[i].findByLabel(label, results);
+    }
+
+    return results;
+};
+
+pc.GraphNode.prototype.getChildren = function () {
+    // #ifdef DEBUG
+    console.warn('DEPRECATED: pc.GraphNode#getChildren is deprecated. Use pc.GraphNode#children instead.');
+    // #endif
+
+    return this.children;
+};
+
+pc.GraphNode.prototype.getName = function () {
+    // #ifdef DEBUG
+    console.warn('DEPRECATED: pc.GraphNode#getName is deprecated. Use pc.GraphNode#name instead.');
+    // #endif
+
+    return this.name;
+};
+
+pc.GraphNode.prototype.getPath = function () {
+    // #ifdef DEBUG
+    console.warn('DEPRECATED: pc.GraphNode#getPath is deprecated. Use pc.GraphNode#path instead.');
+    // #endif
+
+    return this.path;
+};
+
+pc.GraphNode.prototype.getRoot = function () {
+    // #ifdef DEBUG
+    console.warn('DEPRECATED: pc.GraphNode#getRoot is deprecated. Use pc.GraphNode#root instead.');
+    // #endif
+
+    return this.root;
+};
+
+pc.GraphNode.prototype.getParent = function () {
+    // #ifdef DEBUG
+    console.warn('DEPRECATED: pc.GraphNode#getParent is deprecated. Use pc.GraphNode#parent instead.');
+    // #endif
+
+    return this.parent;
+};
+
+pc.GraphNode.prototype.setName = function (name) {
+    // #ifdef DEBUG
+    console.warn('DEPRECATED: pc.GraphNode#setName is deprecated. Use pc.GraphNode#name instead.');
+    // #endif
+
+    this.name = name;
 };
 
 pc.Application.prototype.isFullscreen = function () {

--- a/src/backwards-compatibility.js
+++ b/src/backwards-compatibility.js
@@ -300,28 +300,28 @@ Object.defineProperty(pc.Color.prototype, "data3", {
 
 pc.Material.prototype.getName = function () {
     // #ifdef DEBUG
-    console.warn('DEPRECATED: pc.Material#getName is deprecated. Get the pc.Material#name property instead.');
+    console.warn('DEPRECATED: pc.Material#getName is deprecated. Use pc.Material#name instead.');
     // #endif
     return this.name;
 };
 
 pc.Material.prototype.setName = function (name) {
     // #ifdef DEBUG
-    console.warn('DEPRECATED: pc.Material#getName is deprecated. Set the pc.Material#name property instead.');
+    console.warn('DEPRECATED: pc.Material#setName is deprecated. Use pc.Material#name instead.');
     // #endif
     this.name = name;
 };
 
 pc.Material.prototype.getShader = function () {
     // #ifdef DEBUG
-    console.warn('DEPRECATED: pc.Material#getShader is deprecated. Get the pc.Material#shader property instead.');
+    console.warn('DEPRECATED: pc.Material#getShader is deprecated. Use pc.Material#shader instead.');
     // #endif
     return this.shader;
 };
 
 pc.Material.prototype.setShader = function (shader) {
     // #ifdef DEBUG
-    console.warn('DEPRECATED: pc.Material#setShader is deprecated. Set the pc.Material#shader property instead.');
+    console.warn('DEPRECATED: pc.Material#setShader is deprecated. Use pc.Material#shader instead.');
     // #endif
     this.shader = shader;
 };

--- a/src/framework/components/element/component.js
+++ b/src/framework/components/element/component.js
@@ -383,7 +383,7 @@ Object.assign(pc, function () {
                 // search up the hierarchy until we find an entity which has:
                 // - no parent
                 // - screen component on parent
-                var next = current.getParent();
+                var next = current.parent;
                 if ((next === null || next.screen) && current.element) {
                     if (!this.system._prerender || !this.system._prerender.length) {
                         this.system._prerender = [];
@@ -461,7 +461,7 @@ Object.assign(pc, function () {
             this._anchorDirty = true;
 
             // update all child screens
-            var children = this.entity.getChildren();
+            var children = this.entity.children;
             for (var i = 0, l = children.length; i < l; i++) {
                 if (children[i].element) children[i].element._updateScreen(screen);
             }
@@ -546,7 +546,7 @@ Object.assign(pc, function () {
                 }
 
                 // recurse through all children
-                children = this.entity.getChildren();
+                children = this.entity.children;
                 for (i = 0, l = children.length; i < l; i++) {
                     if (children[i].element) {
                         children[i].element._updateMask(currentMask, depth);
@@ -583,7 +583,7 @@ Object.assign(pc, function () {
                 }
 
                 // recurse through all children
-                children = this.entity.getChildren();
+                children = this.entity.children;
                 for (i = 0, l = children.length; i < l; i++) {
                     if (children[i].element) {
                         children[i].element._updateMask(currentMask, depth);

--- a/src/framework/components/element/image-element.js
+++ b/src/framework/components/element/image-element.js
@@ -118,7 +118,7 @@ Object.assign(pc, function () {
 
         var getLastChild = function (e) {
             var last;
-            var c = e.getChildren();
+            var c = e.children;
             var l = c.length;
             if (l) {
                 for (var i = 0; i < l; i++) {

--- a/src/framework/components/screen/component.js
+++ b/src/framework/components/screen/component.js
@@ -79,7 +79,7 @@ Object.assign(pc, function () {
                 }
             }
 
-            var children = e.getChildren();
+            var children = e.children;
             for (var j = 0; j < children.length; j++) {
                 i = this._recurseDrawOrderSync(children[j], i);
             }

--- a/src/framework/components/sound/component.js
+++ b/src/framework/components/sound/component.js
@@ -245,7 +245,7 @@ Object.assign(pc, function () {
         addSlot: function (name, options) {
             var slots = this.data.slots;
             if (slots[name]) {
-                logWARNING('A sound slot with name ' + name + ' already exists on Entity ' + this.entity.getPath());
+                logWARNING('A sound slot with name ' + name + ' already exists on Entity ' + this.entity.path);
                 return null;
             }
 

--- a/src/resources/parser/json-model.js
+++ b/src/resources/parser/json-model.js
@@ -82,8 +82,7 @@ Object.assign(pc, function () {
             for (i = 0; i < modelData.nodes.length; i++) {
                 var nodeData = modelData.nodes[i];
 
-                var node = new pc.GraphNode();
-                node.setName(nodeData.name);
+                var node = new pc.GraphNode(nodeData.name);
                 node.setLocalPosition(nodeData.position[0], nodeData.position[1], nodeData.position[2]);
                 node.setLocalEulerAngles(nodeData.rotation[0], nodeData.rotation[1], nodeData.rotation[2]);
                 node.setLocalScale(nodeData.scale[0], nodeData.scale[1], nodeData.scale[2]);

--- a/src/scene/forward-renderer.js
+++ b/src/scene/forward-renderer.js
@@ -547,7 +547,7 @@ Object.assign(pc, function () {
         updateCameraFrustum: function (camera) {
             if (camera.vrDisplay && camera.vrDisplay.presenting) {
                 projMat = camera.vrDisplay.combinedProj;
-                var parent = camera._node.getParent();
+                var parent = camera._node.parent;
                 if (parent) {
                     viewMat.copy(parent.getWorldTransform()).mul(camera.vrDisplay.combinedViewInv).invert();
                 } else {
@@ -633,7 +633,7 @@ Object.assign(pc, function () {
                     viewR.copy(viewInvR).invert();
                     viewMat.copy(viewInvMat).invert();
                 } else {
-                    var parent = camera._node.getParent();
+                    var parent = camera._node.parent;
                     if (parent) {
                         var transform = parent.getWorldTransform();
 

--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -20,7 +20,7 @@ Object.assign(pc, function () {
         this.name = typeof name === "string" ? name : "Untitled"; // Non-unique human readable name
         this.tags = new pc.Tags(this);
 
-        this._labels = { };
+        this._labels = {};
 
         // Local-space properties of transform (only first 3 are settable by the user)
         this.localPosition = new pc.Vec3(0, 0, 0);
@@ -141,6 +141,31 @@ Object.assign(pc, function () {
     Object.defineProperty(GraphNode.prototype, 'parent', {
         get: function () {
             return this._parent;
+        }
+    });
+
+    /**
+     * @readonly
+     * @name pc.GraphNode#path
+     * @type pc.GraphNode
+     * @description A read-only property to get the path of the graph node relative to
+     * the root of the hierarchy
+     */
+    Object.defineProperty(GraphNode.prototype, 'path', {
+        get: function () {
+            var parent = this._parent;
+            if (parent) {
+                var path = this.name;
+                var format = "{0}/{1}";
+
+                while (parent && parent._parent) {
+                    path = pc.string.format(format, parent.name, path);
+                    parent = parent._parent;
+                }
+
+                return path;
+            }
+            return '';
         }
     });
 
@@ -476,69 +501,6 @@ Object.assign(pc, function () {
 
         /**
          * @function
-         * @name  pc.GraphNode#getPath
-         * @description Gets the path of the entity relative to the root of the hierarchy
-         * @returns {String} The path
-         * @example
-         * var path = this.entity.getPath();
-         */
-        getPath: function () {
-            var parent = this._parent;
-            if (parent) {
-                var path = this.name;
-                var format = "{0}/{1}";
-
-                while (parent && parent._parent) {
-                    path = pc.string.format(format, parent.name, path);
-                    parent = parent._parent;
-                }
-
-                return path;
-            }
-            return '';
-
-        },
-
-
-        /**
-         * @private
-         * @deprecated
-         * @function
-         * @name pc.GraphNode#getRoot
-         * @description Get the highest ancestor node from this graph node.
-         * @returns {pc.GraphNode} The root node of the hierarchy to which this node belongs.
-         * @example
-         * var root = this.entity.getRoot();
-         */
-        getRoot: function () {
-            var parent = this._parent;
-            if (!parent) {
-                return this;
-            }
-
-            while (parent._parent) {
-                parent = parent._parent;
-            }
-
-            return parent;
-        },
-
-        /**
-         * @private
-         * @deprecated
-         * @function
-         * @name pc.GraphNode#getParent
-         * @description Get the parent GraphNode
-         * @returns {pc.GraphNode} The parent node
-         * @example
-         * var parent = this.entity.getParent();
-         */
-        getParent: function () {
-            return this._parent;
-        },
-
-        /**
-         * @function
          * @name pc.GraphNode#isDescendantOf
          * @description Check if node is descendant of another node.
          * @param {pc.GraphNode} node Potential ancestor of node.
@@ -572,23 +534,6 @@ Object.assign(pc, function () {
          */
         isAncestorOf: function (node) {
             return node.isDescendantOf(this);
-        },
-
-        /**
-         * @private
-         * @deprecated
-         * @function
-         * @name pc.GraphNode#getChildren
-         * @description Get the children of this graph node.
-         * @returns {pc.GraphNode[]} The child array of this node.
-         * @example
-         * var children = this.entity.getChildren();
-         * for (i = 0; i < children.length; i++) {
-         * // children[i]
-         * }
-         */
-        getChildren: function () {
-            return this._children;
         },
 
         /**
@@ -688,23 +633,6 @@ Object.assign(pc, function () {
                 this._dirtyLocal = false;
             }
             return this.localTransform;
-        },
-
-        /**
-         * @private
-         * @deprecated
-         * @function
-         * @name pc.GraphNode#getName
-         * @description Get the human-readable name for this graph node. Note the name
-         * is not guaranteed to be unique. For Entities, this is the name that is set in the PlayCanvas Editor.
-         * @returns {String} The name of the node.
-         * @example
-         * if (this.entity.getName() === "My Entity") {
-         *     console.log("My Entity Found");
-         * }
-         */
-        getName: function () {
-            return this.name;
         },
 
         /**
@@ -896,20 +824,6 @@ Object.assign(pc, function () {
 
             if (!this._dirtyLocal)
                 this._dirtifyLocal();
-        },
-
-        /**
-         * @private
-         * @deprecated
-         * @function
-         * @name pc.GraphNode#setName
-         * @description Sets the non-unique name for this graph node.
-         * @param {String} name The name for the node.
-         * @example
-         * this.entity.setName("My Entity");
-         */
-        setName: function (name) {
-            this.name = name;
         },
 
         _dirtifyLocal: function () {
@@ -1193,83 +1107,6 @@ Object.assign(pc, function () {
                     return;
                 }
             }
-        },
-
-        /**
-         * @private
-         * @deprecated
-         * @function
-         * @name pc.GraphNode#addLabel
-         * @description Add a string label to this graph node, labels can be used to group
-         * and filter nodes. For example, the 'enemies' label could be applied to a group of NPCs
-         * who are enemies.
-         * @param {String} label The label to apply to this graph node.
-         */
-        addLabel: function (label) {
-            this._labels[label] = true;
-        },
-
-        /**
-         * @private
-         * @deprecated
-         * @function
-         * @name pc.GraphNode#getLabels
-         * @description Get an array of all labels applied to this graph node.
-         * @returns {String[]} An array of all labels.
-         */
-        getLabels: function () {
-            return Object.keys(this._labels);
-        },
-
-        /**
-         * @private
-         * @deprecated
-         * @function
-         * @name pc.GraphNode#hasLabel
-         * @description Test if a label has been applied to this graph node.
-         * @param {String} label The label to test for.
-         * @returns {Boolean} True if the label has been added to this GraphNode.
-         *
-         */
-        hasLabel: function (label) {
-            return !!this._labels[label];
-        },
-
-        /**
-         * @private
-         * @deprecated
-         * @function
-         * @name pc.GraphNode#removeLabel
-         * @description Remove label from this graph node.
-         * @param {String} label The label to remove from this node.
-         */
-        removeLabel: function (label) {
-            delete this._labels[label];
-        },
-
-        /**
-         * @private
-         * @deprecated
-         * @function
-         * @name pc.GraphNode#findByLabel
-         * @description Find all graph nodes from the root and all descendants with the label.
-         * @param {String} label The label to search for.
-         * @param {pc.GraphNode[]} [results] An array to store the results in.
-         * @returns {pc.GraphNode[]} The array passed in or a new array of results.
-         */
-        findByLabel: function (label, results) {
-            var i, length = this._children.length;
-            results = results || [];
-
-            if (this.hasLabel(label)) {
-                results.push(this);
-            }
-
-            for (i = 0; i < length; ++i) {
-                results = this._children[i].findByLabel(label, results);
-            }
-
-            return results;
         },
 
         _sync: function () {


### PR DESCRIPTION
There is a substantial amount of deprecated API in the graph-node.js file. I have moved it all to backwards-compatibility.js and added the correct deprecation warning messages. I've also updated ```pc.GraphNode#getPath``` to a read only property ```path```. All engine code has been updated to no longer call deprecated pc.GraphNode API.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
