### PR TITLE
fix: app.destroy do not destroy all textures

### DIFF
--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -1497,6 +1497,11 @@ Object.assign(pc, function () {
             }
             this.assets.off();
 
+            // destroy all textures created by new pc.Texture.
+            // they are NOT pc.Asset and can not be destroyed by asset.unload.
+            while (this.graphicsDevice.textures.length > 0) {
+                this.graphicsDevice.textures[0].destroy();
+            }
 
             // destroy bundle registry
             this.bundles.destroy();


### PR DESCRIPTION
When calling `app.destroy`, it only destroy textures in `app.assets`. But not all textures are assets, many textures are created by user via `new pc.Texture` directly.

Here is the starter kit:

![image](https://user-images.githubusercontent.com/2386165/62602950-7936ac00-b927-11e9-8c61-f2a52d23d4da.png)

You can see vram is not freed after you call `app.destroy`.

This PR is trying to solve that.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
