### PR TITLE
Remove engine support for webvr-polyfill

### DIFF
--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -782,8 +782,6 @@ Object.assign(pc, function () {
                 props.resolutionMode = props.resolution_mode;
             if (!props.fillMode)
                 props.fillMode = props.fill_mode;
-            if (!props.vrPolyfillUrl)
-                props.vrPolyfillUrl = props.vr_polyfill_url;
 
             this._width = props.width;
             this._height = props.height;
@@ -793,14 +791,6 @@ Object.assign(pc, function () {
 
             this.setCanvasResolution(props.resolutionMode, this._width, this._height);
             this.setCanvasFillMode(props.fillMode, this._width, this._height);
-
-            // if VR is enabled in the project and there is no native VR support
-            // load the polyfill
-            if (props.vr && props.vrPolyfillUrl) {
-                if (!pc.VrManager.isSupported || pc.platform.android) {
-                    props.libraries.push(props.vrPolyfillUrl);
-                }
-            }
 
             // set up layers
             if (props.layers && props.layerOrder) {

--- a/src/vr/vr-manager.js
+++ b/src/vr/vr-manager.js
@@ -8,7 +8,6 @@ Object.assign(pc, function () {
      * @property {pc.VrDisplay[]} displays The list of {@link pc.VrDisplay}s that are attached to this device
      * @property {pc.VrDisplay} display The default {@link pc.VrDisplay} to be used. Usually the first in the `displays` list
      * @property {Boolean} isSupported Reports whether this device supports the WebVR API
-     * @property {Boolean} usesPolyfill Reports whether this device supports the WebVR API using a polyfill
      */
     var VrManager = function (app) {
         pc.events.attach(this);
@@ -16,11 +15,6 @@ Object.assign(pc, function () {
         var self = this;
 
         this.isSupported = VrManager.isSupported;
-        this.usesPolyfill = VrManager.usesPolyfill;
-
-        // if required initialize webvr polyfill
-        if (window.InitializeWebVRPolyfill)
-            window.InitializeWebVRPolyfill();
 
         this._index = { };
         this.displays = [];
@@ -77,14 +71,6 @@ Object.assign(pc, function () {
      * @description Reports whether this device supports the WebVR API
      */
     VrManager.isSupported = !!navigator.getVRDisplays;
-
-    /**
-     * @static
-     * @name pc.VrManager.usesPolyfill
-     * @type Boolean
-     * @description Reports whether this device supports the WebVR API using a polyfill
-     */
-    VrManager.usesPolyfill = !!window.InitializeWebVRPolyfill;
 
     Object.assign(VrManager.prototype, {
         _attach: function () {


### PR DESCRIPTION
WebVR Polyfill should be loaded and initialized externally to the engine.

* Do not load webvr-polyfill library
* Remove polyfill initialization and references in VrManager
