### PR TITLE
Fixed errors in TypeScript Declarations

### DIFF
--- a/build/dependencies.txt
+++ b/build/dependencies.txt
@@ -207,6 +207,7 @@
 ../src/framework/utils/entity-reference.js
 ../src/framework/utils/sorted-loop-array.js
 ../src/resources/loader.js
+../src/resources/handler.js
 ../src/resources/bundle.js
 ../src/resources/untar.js
 ../src/resources/animation.js

--- a/src/asset/asset.js
+++ b/src/asset/asset.js
@@ -58,7 +58,7 @@ Object.assign(pc, function () {
      * @property {String} [file.hash] The MD5 hash of the resource file data and the Asset data field
      * @property {Object} data JSON data that contains either the complete resource data (e.g. in the case of a material) or additional data (e.g. in the case of a model it contains mappings from mesh to material)
      * @property {Object} resource A reference to the resource when the asset is loaded. e.g. a {@link pc.Texture} or a {@link pc.Model}
-     * @property {Array} resources A reference to the resources of the asset when it's loaded. An asset can hold more runtime resources than one e.g. cubemaps
+     * @property {Any[]} resources A reference to the resources of the asset when it's loaded. An asset can hold more runtime resources than one e.g. cubemaps
      * @property {Boolean} preload If true the asset will be loaded during the preload phase of application set up.
      * @property {Boolean} loaded True if the resource is loaded. e.g. if asset.resource is not null
      * @property {pc.AssetRegistry} registry The asset registry that this Asset belongs to

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -44,7 +44,7 @@ var pc = {
      * @description Convert an array-like object into a normal array.
      * For example, this is useful for converting the arguments object into an array.
      * @param {Object} arr The array to convert
-     * @returns {Array} An array
+     * @returns {Any[]} An array
      */
     makeArray: function (arr) {
         var i,

--- a/src/core/path.js
+++ b/src/core/path.js
@@ -92,7 +92,7 @@ pc.path = function () {
          * @description Split the pathname path into a pair [head, tail] where tail is the final part of the path
          * after the last delimiter and head is everything leading up to that. tail will never contain a slash
          * @param {String} path The path to split.
-         * @returns {Array} The split path which is an array of two strings, the path and the filename.
+         * @returns {String[]} The split path which is an array of two strings, the path and the filename.
          */
         split: function (path) {
             var parts = path.split(pc.path.delimiter);

--- a/src/framework/components/camera/component.js
+++ b/src/framework/components/camera/component.js
@@ -61,7 +61,7 @@ Object.assign(pc, function () {
      *     <li>{Number} view: Type of view. Can be pc.VIEW_CENTER, pc.VIEW_LEFT or pc.VIEW_RIGHT. Left and right are only used in stereo rendering.</li>
      * @property {Boolean} cullFaces If true the camera will take material.cull into account. Otherwise both front and back faces will be rendered.
      * @property {Boolean} flipFaces If true the camera will invert front and back faces. Can be useful for reflection rendering.
-     * @property {Array} layers An array of layer IDs ({@link pc.Layer#id}) to which this camera should belong.
+     * @property {Number[]} layers An array of layer IDs ({@link pc.Layer#id}) to which this camera should belong.
      * Don't push/pop/splice or modify this array, if you want to change it - set a new one instead.
      */
     var CameraComponent = function CameraComponent(system, entity) {

--- a/src/framework/components/camera/component.js
+++ b/src/framework/components/camera/component.js
@@ -452,8 +452,26 @@ Object.assign(pc, function () {
         /**
          * @function
          * @name pc.CameraComponent#enterVr
+         * @variation 1
          * @description Attempt to start presenting this camera to a {@link pc.VrDisplay}.
-         * @param {pc.VrDisplay} [display] The VrDisplay to present. If not supplied this uses {@link pc.VrManager#display} as the default
+         * @param {Function} callback Function called once to indicate success of failure. The callback takes one argument (err).
+         * On success it returns null on failure it returns the error message.
+         * @example
+         * // On an entity with a camera component
+         * this.entity.camera.enterVr(function (err) {
+         *     if (err) {
+         *         console.error(err);
+         *         return;
+         *     } else {
+         *         // in VR!
+         *     }
+         * });
+         *//**
+         * @function
+         * @name pc.CameraComponent#enterVr
+         * @variation 2
+         * @description Attempt to start presenting this camera to a {@link pc.VrDisplay}.
+         * @param {pc.VrDisplay} display The VrDisplay to present. If not supplied this uses {@link pc.VrManager#display} as the default
          * @param {Function} callback Function called once to indicate success of failure. The callback takes one argument (err).
          * On success it returns null on failure it returns the error message.
          * @example

--- a/src/framework/components/element/component.js
+++ b/src/framework/components/element/component.js
@@ -100,7 +100,7 @@ Object.assign(pc, function () {
      * @property {Boolean} rtlReorder Reorder the text for RTL languages using a function registered by <code>app.systems.element.registerUnicodeConverter</code>.
      * @property {Boolean} unicodeConverter Convert unicode characters using a function registered by <code>app.systems.element.registerUnicodeConverter</code>.
      * @property {Number} batchGroupId Assign element to a specific batch group (see {@link pc.BatchGroup}). Default value is -1 (no group).
-     * @property {Array} layers An array of layer IDs ({@link pc.Layer#id}) to which this element should belong.
+     * @property {Number[]} layers An array of layer IDs ({@link pc.Layer#id}) to which this element should belong.
      * Don't push/pop/splice or modify this array, if you want to change it - set a new one instead.
      * @property {Boolean} enableMarkup Flag for enabling markup processing. Only works for {@link pc.ELEMENTTYPE_TEXT} types.
      * @property {Number} rangeStart Index of the first character to render. Only works for {@link pc.ELEMENTTYPE_TEXT} types.

--- a/src/framework/components/layout-child/system.js
+++ b/src/framework/components/layout-child/system.js
@@ -2,6 +2,7 @@ Object.assign(pc, function () {
     var _schema = ['enabled'];
 
     /**
+     * @constructor
      * @name pc.LayoutChildComponentSystem
      * @description Create a new LayoutChildComponentSystem
      * @classdesc Manages creation of {@link pc.LayoutChildComponent}s.

--- a/src/framework/components/layout-child/system.js
+++ b/src/framework/components/layout-child/system.js
@@ -2,7 +2,6 @@ Object.assign(pc, function () {
     var _schema = ['enabled'];
 
     /**
-     * @private
      * @name pc.LayoutChildComponentSystem
      * @description Create a new LayoutChildComponentSystem
      * @classdesc Manages creation of {@link pc.LayoutChildComponent}s.

--- a/src/framework/components/layout-group/system.js
+++ b/src/framework/components/layout-group/system.js
@@ -4,6 +4,7 @@ Object.assign(pc, function () {
     var MAX_ITERATIONS = 100;
 
     /**
+     * @constructor
      * @name pc.LayoutGroupComponentSystem
      * @description Create a new LayoutGroupComponentSystem
      * @classdesc Manages creation of {@link pc.LayoutGroupComponent}s.

--- a/src/framework/components/layout-group/system.js
+++ b/src/framework/components/layout-group/system.js
@@ -4,7 +4,6 @@ Object.assign(pc, function () {
     var MAX_ITERATIONS = 100;
 
     /**
-     * @private
      * @name pc.LayoutGroupComponentSystem
      * @description Create a new LayoutGroupComponentSystem
      * @classdesc Manages creation of {@link pc.LayoutGroupComponent}s.

--- a/src/framework/components/light/component.js
+++ b/src/framework/components/light/component.js
@@ -97,7 +97,7 @@ Object.assign(pc, function () {
      * @property {pc.Vec2} cookieScale Spotlight cookie scale.
      * @property {pc.Vec2} cookieOffset Spotlight cookie position offset.
      * @property {Boolean} isStatic Mark light as non-movable (optimization)
-     * @property {Array} layers An array of layer IDs ({@link pc.Layer#id}) to which this light should belong.
+     * @property {Number[]} layers An array of layer IDs ({@link pc.Layer#id}) to which this light should belong.
      * Don't push/pop/splice or modify this array, if you want to change it - set a new one instead.
      * @extends pc.Component
      */

--- a/src/framework/components/model/component.js
+++ b/src/framework/components/model/component.js
@@ -31,7 +31,7 @@ Object.assign(pc, function () {
      * @property {Boolean} isStatic Mark model as non-movable (optimization)
      * @property {pc.MeshInstance[]} meshInstances An array of meshInstances contained in the component's model. If model is not set or loaded for component it will return null.
      * @property {Number} batchGroupId Assign model to a specific batch group (see {@link pc.BatchGroup}). Default value is -1 (no group).
-     * @property {Array} layers An array of layer IDs ({@link pc.Layer#id}) to which this model should belong.
+     * @property {Number[]} layers An array of layer IDs ({@link pc.Layer#id}) to which this model should belong.
      * Don't push/pop/splice or modify this array, if you want to change it - set a new one instead.
      */
 

--- a/src/framework/components/particle-system/component.js
+++ b/src/framework/components/particle-system/component.js
@@ -156,7 +156,7 @@ Object.assign(pc, function () {
      * @property {pc.Curve} scaleGraph2 If not null, particles pick random values between scaleGraph and scaleGraph2.
      * @property {pc.Curve} alphaGraph Alpha over lifetime.
      * @property {pc.Curve} alphaGraph2 If not null, particles pick random values between alphaGraph and alphaGraph2.
-     * @property {Array} layers An array of layer IDs ({@link pc.Layer#id}) to which this particle system should belong.
+     * @property {Number[]} layers An array of layer IDs ({@link pc.Layer#id}) to which this particle system should belong.
      * Don't push/pop/splice or modify this array, if you want to change it - set a new one instead.
      */
     var ParticleSystemComponent = function ParticleSystemComponent(system, entity) {

--- a/src/framework/components/sprite/component.js
+++ b/src/framework/components/sprite/component.js
@@ -49,7 +49,7 @@ Object.assign(pc, function () {
      * @property {Number} speed A global speed modifier used when playing sprite animation clips.
      * @property {Number} batchGroupId Assign sprite to a specific batch group (see {@link pc.BatchGroup}). Default value is -1 (no group).
      * @property {String} autoPlayClip The name of the clip to play automatically when the component is enabled and the clip exists.
-     * @property {Array} layers An array of layer IDs ({@link pc.Layer#id}) to which this sprite should belong.
+     * @property {Number[]} layers An array of layer IDs ({@link pc.Layer#id}) to which this sprite should belong.
      * @property {Number} drawOrder The draw order of the component. A higher value means that the component will be rendered on top of other components in the same layer.
      */
     var SpriteComponent = function SpriteComponent(system, entity) {

--- a/src/framework/components/sprite/system.js
+++ b/src/framework/components/sprite/system.js
@@ -4,7 +4,6 @@ Object.assign(pc, function () {
     var _schema = ['enabled'];
 
     /**
-     * @private
      * @constructor
      * @name pc.SpriteComponentSystem
      * @classdesc Manages creation of {@link pc.SpriteComponent}s.

--- a/src/framework/components/system.js
+++ b/src/framework/components/system.js
@@ -194,7 +194,7 @@ Object.assign(pc, function () {
          * This can be overridden by derived Component Systems and either called by the derived System or replaced entirely
          * @param {pc.Component} component The component being initialized.
          * @param {Object} data The data block used to initialize the component.
-         * @param {Array} properties The array of property descriptors for the component. A descriptor can be either a plain property name, or an object specifying the name and type.
+         * @param {String[]|Object[]} properties The array of property descriptors for the component. A descriptor can be either a plain property name, or an object specifying the name and type.
          */
         initializeComponentData: function (component, data, properties) {
             data = data || {};
@@ -243,7 +243,7 @@ Object.assign(pc, function () {
          * @name pc.ComponentSystem#getPropertiesOfType
          * @description Searches the component schema for properties that match the specified type.
          * @param {String} type The type to search for
-         * @returns {Array} An array of property descriptors matching the specified type.
+         * @returns {String[]|Object[]} An array of property descriptors matching the specified type.
          */
         getPropertiesOfType: function (type) {
             var matchingProperties = [];

--- a/src/framework/script.js
+++ b/src/framework/script.js
@@ -70,7 +70,7 @@ pc.script = (function () {
          *   <li>{Number} decimalPrecision: A number that specifies the number of decimal digits allowed for the value</li>
          *   <li>{Object[]} enumerations: An array of name, value pairs from which the user can select one if the attribute type is an enumeration</li>
          *   <li>{String[]} curves: (For 'curve' attributes only) An array of strings that define the names of each curve in the curve editor.</li>
-         *   <li>{Array} color: (For 'curve' attributes only) If true then the curve attribute will be a color curve.</li>
+         *   <li>{Boolean} color: (For 'curve' attributes only) If true then the curve attribute will be a color curve.</li>
          * </ul>
          * @example
          * pc.script.attribute('speed', 'number', 5);

--- a/src/graphics/texture.js
+++ b/src/graphics/texture.js
@@ -699,7 +699,7 @@ Object.assign(pc, function () {
          * @name pc.Texture#setSource
          * @description Set the pixel data of the texture from a canvas, image, video DOM element. If the
          * texture is a cubemap, the supplied source must be an array of 6 canvases, images or videos.
-         * @param {HTMLCanvasElement|HTMLImageElement|HTMLVideoElement|Array} source A canvas, image or video element,
+         * @param {HTMLCanvasElement|HTMLImageElement|HTMLVideoElement|HTMLCanvasElement[]|HTMLImageElement[]|HTMLVideoElement[]} source A canvas, image or video element,
          * or an array of 6 canvas, image or video elements.
          * @param {Number} mipLevel A non-negative integer specifying the image level of detail. Defaults to 0, which represents the base image source.
          * A level value of N, that is greater than 0, represents the image source for the Nth mipmap reduction level.

--- a/src/math/curve-set.js
+++ b/src/math/curve-set.js
@@ -6,7 +6,7 @@ Object.assign(pc, (function () {
      * @name pc.CurveSet
      * @classdesc A curve set is a collection of curves.
      * @description Creates a new curve set.
-     * @param {Array} [curveKeys] An array of arrays of keys (pairs of numbers with
+     * @param {Array<Number[]>} [curveKeys] An array of arrays of keys (pairs of numbers with
      * the time first and value second).
      */
     var CurveSet = function () {
@@ -55,10 +55,10 @@ Object.assign(pc, (function () {
          * @description Returns the interpolated value of all curves in the curve
          * set at the specified time.
          * @param {Number} time The time at which to calculate the value
-         * @param {Array} [result] The interpolated curve values at the specified time.
+         * @param {Number[]} [result] The interpolated curve values at the specified time.
          * If this parameter is not supplied, the function allocates a new array internally
          * to return the result.
-         * @returns {Array} The interpolated curve values at the specified time
+         * @returns {Number[]} The interpolated curve values at the specified time
          */
         value: function (time, result) {
             var length = this.curves.length;
@@ -117,7 +117,7 @@ Object.assign(pc, (function () {
          * @param {Number} precision The number of samples to return.
          * @param {Number} min The minimum output value.
          * @param {Number} max The maximum output value.
-         * @returns {Array} The set of quantized values.
+         * @returns {Number[]} The set of quantized values.
          */
         quantizeClamped: function (precision, min, max) {
             var result = this.quantize(precision);

--- a/src/math/curve.js
+++ b/src/math/curve.js
@@ -164,7 +164,7 @@ Object.assign(pc, (function () {
          * @name pc.Curve#quantize
          * @description Sample the curve at regular intervals over the range [0..1]
          * @param {Number} precision The number of samples to return.
-         * @returns {Array} The set of quantized values.
+         * @returns {Float32Array} The set of quantized values.
          */
         quantize: function (precision) {
             precision = Math.max(precision, 2);
@@ -190,7 +190,7 @@ Object.assign(pc, (function () {
          * @param {Number} precision The number of samples to return.
          * @param {Number} min The minimum output value.
          * @param {Number} max The maximum output value.
-         * @returns {Array} The set of quantized values.
+         * @returns {Float32Array} The set of quantized values.
          */
         quantizeClamped: function (precision, min, max) {
             var result = this.quantize(precision);

--- a/src/math/mat3.js
+++ b/src/math/mat3.js
@@ -64,7 +64,7 @@ Object.assign(pc, (function () {
          * @function
          * @name pc.Mat3#set
          * @description Copies the contents of a source array[9] to a destination 3x3 matrix.
-         * @param {Array} src An array[9] to be copied.
+         * @param {Number[]} src An array[9] to be copied.
          * @returns {pc.Mat3} Self for chaining
          * @example
          * var dst = new pc.Mat3();

--- a/src/math/mat4.js
+++ b/src/math/mat4.js
@@ -772,7 +772,7 @@ Object.assign(pc, (function () {
          * @function
          * @name pc.Mat4#set
          * @description Sets matrix data from an array.
-         * @param {Array} src Source array. Must have 16 values.
+         * @param {Number[]} src Source array. Must have 16 values.
          * @returns {pc.Mat4} Self for chaining.
          */
         set: function (src) {

--- a/src/net/http.js
+++ b/src/net/http.js
@@ -56,9 +56,24 @@ Object.assign(pc, function () {
         /**
          * @function
          * @name pc.Http#get
+         * @variation 1
          * @description Perform an HTTP GET request to the given url.
          * @param {String} url The URL to make the request to.
-         * @param {Object} [options] Additional options
+         * @param {Function} callback The callback used when the response has returned. Passed (err, data)
+         * where data is the response (format depends on response type: text, Object, ArrayBuffer, XML) and
+         * err is the error code.
+         * @example
+         * pc.http.get("http://example.com/", function (err, response) {
+         *     console.log(response);
+         * });
+         * @returns {XMLHttpRequest} The request object.
+         *//**
+         * @function
+         * @name pc.Http#get
+         * @variation 2
+         * @description Perform an HTTP GET request to the given url.
+         * @param {String} url The URL to make the request to.
+         * @param {Object} options Additional options
          * @param {Object} [options.headers] HTTP headers to add to the request
          * @param {Boolean} [options.async] Make the request asynchronously. Defaults to true.
          * @param {Object} [options.cache] If false, then add a timestamp to the request to prevent caching
@@ -74,10 +89,6 @@ Object.assign(pc, function () {
          * @param {Function} callback The callback used when the response has returned. Passed (err, data)
          * where data is the response (format depends on response type: text, Object, ArrayBuffer, XML) and
          * err is the error code.
-         * @example
-         * pc.http.get("http://example.com/", function (err, response) {
-         *     console.log(response);
-         * });
          * @returns {XMLHttpRequest} The request object.
          */
         get: function (url, options, callback) {
@@ -91,13 +102,28 @@ Object.assign(pc, function () {
         /**
          * @function
          * @name pc.Http#post
+         * @variation 1
          * @description Perform an HTTP POST request to the given url.
          * @param {String} url The URL to make the request to.
          * @param {Object} data Data to send in the body of the request.
          * Some content types are handled automatically. If postdata is an XML Document, it is handled. If
          * the Content-Type header is set to 'application/json' then the postdata is JSON stringified.
          * Otherwise, by default, the data is sent as form-urlencoded.
-         * @param {Object} [options] Additional options
+         * @param {Function} callback The callback used when the response has returned. Passed (err, data)
+         * where data is the response (format depends on response type: text, Object, ArrayBuffer, XML) and
+         * err is the error code.
+         * @returns {XMLHttpRequest} The request object.
+         *//**
+         * @function
+         * @name pc.Http#post
+         * @variation 2
+         * @description Perform an HTTP POST request to the given url.
+         * @param {String} url The URL to make the request to.
+         * @param {Object} data Data to send in the body of the request.
+         * Some content types are handled automatically. If postdata is an XML Document, it is handled. If
+         * the Content-Type header is set to 'application/json' then the postdata is JSON stringified.
+         * Otherwise, by default, the data is sent as form-urlencoded.
+         * @param {Object} options Additional options
          * @param {Object} [options.headers] HTTP headers to add to the request
          * @param {Boolean} [options.async] Make the request asynchronously. Defaults to true.
          * @param {Object} [options.cache] If false, then add a timestamp to the request to prevent caching
@@ -123,13 +149,28 @@ Object.assign(pc, function () {
         /**
          * @function
          * @name pc.Http#put
+         * @variation 1
          * @description Perform an HTTP PUT request to the given url.
          * @param {String} url The URL to make the request to.
          * @param {Document | Object} data Data to send in the body of the request.
          * Some content types are handled automatically. If postdata is an XML Document, it is handled. If
          * the Content-Type header is set to 'application/json' then the postdata is JSON stringified.
          * Otherwise, by default, the data is sent as form-urlencoded.
-         * @param {Object} [options] Additional options
+         * @param {Function} callback The callback used when the response has returned. Passed (err, data)
+         * where data is the response (format depends on response type: text, Object, ArrayBuffer, XML) and
+         * err is the error code.
+         * @returns {XMLHttpRequest} The request object.
+         *//**
+         * @function
+         * @name pc.Http#put
+         * @variation 2
+         * @description Perform an HTTP PUT request to the given url.
+         * @param {String} url The URL to make the request to.
+         * @param {Document | Object} data Data to send in the body of the request.
+         * Some content types are handled automatically. If postdata is an XML Document, it is handled. If
+         * the Content-Type header is set to 'application/json' then the postdata is JSON stringified.
+         * Otherwise, by default, the data is sent as form-urlencoded.
+         * @param {Object} options Additional options
          * @param {Object} [options.headers] HTTP headers to add to the request
          * @param {Boolean} [options.async] Make the request asynchronously. Defaults to true.
          * @param {Object} [options.cache] If false, then add a timestamp to the request to prevent caching
@@ -155,9 +196,20 @@ Object.assign(pc, function () {
         /**
          * @function
          * @name pc.Http#del
+         * @variation 1
          * @description Perform an HTTP DELETE request to the given url
          * @param {Object} url The URL to make the request to
-         * @param {Object} [options] Additional options
+         * @param {Function} callback The callback used when the response has returned. Passed (err, data)
+         * where data is the response (format depends on response type: text, Object, ArrayBuffer, XML) and
+         * err is the error code.
+         * @returns {XMLHttpRequest} The request object.
+         *//**
+         * @function
+         * @name pc.Http#del
+         * @variation 2
+         * @description Perform an HTTP DELETE request to the given url
+         * @param {Object} url The URL to make the request to
+         * @param {Object} options Additional options
          * @param {Object} [options.headers] HTTP headers to add to the request
          * @param {Boolean} [options.async] Make the request asynchronously. Defaults to true.
          * @param {Object} [options.cache] If false, then add a timestamp to the request to prevent caching
@@ -186,10 +238,22 @@ Object.assign(pc, function () {
         /**
          * @function
          * @name pc.Http#request
+         * @variation 1
          * @description Make a general purpose HTTP request.
          * @param {String} method The HTTP method "GET", "POST", "PUT", "DELETE"
          * @param {String} url The url to make the request to
-         * @param {Object} [options] Additional options
+         * @param {Function} callback The callback used when the response has returned. Passed (err, data)
+         * where data is the response (format depends on response type: text, Object, ArrayBuffer, XML) and
+         * err is the error code.
+         * @returns {XMLHttpRequest} The request object.
+         *//**
+         * @function
+         * @name pc.Http#request
+         * @variation 2
+         * @description Make a general purpose HTTP request.
+         * @param {String} method The HTTP method "GET", "POST", "PUT", "DELETE"
+         * @param {String} url The url to make the request to
+         * @param {Object} options Additional options
          * @param {Object} [options.headers] HTTP headers to add to the request
          * @param {Boolean} [options.async] Make the request asynchronously. Defaults to true.
          * @param {Object} [options.cache] If false, then add a timestamp to the request to prevent caching

--- a/src/net/http.js
+++ b/src/net/http.js
@@ -524,6 +524,11 @@ Object.assign(pc, function () {
         }
     });
 
+    /**
+     * @name pc.http
+     * @description Default instance of {@link pc.Http}.
+     * @type pc.Http
+     */
     return {
         Http: Http,
         http: new Http()

--- a/src/resources/handler.js
+++ b/src/resources/handler.js
@@ -3,7 +3,7 @@ Object.assign(pc, function () {
 
     /**
      * @interface pc.ResourceHandler
-     * @description Interface for ResourceHandlers
+     * @description Interface for ResourceHandlers used by {@link pc.ResourceLoader}.
      */
     var ResourceHandler = function () {};
 
@@ -12,22 +12,39 @@ Object.assign(pc, function () {
         /**
          * @function
          * @name pc.ResourceHandler#load
+         * @description Load a resource from a remote URL. When loaded (or failed),
+         * use the callback to return an the raw resource data (or error).
          * @param {String} url The URL of the resource to load.
          * @param {Function} callback The callback used when the resource is loaded or an error occurs.
+         * @param {pc.Asset} [asset] Optional asset that is passed by ResourceLoader.
          */
-        load: function (url, callback) {
+        load: function (url, callback, asset) {
             throw new Error('not implemented');
         },
 
         /**
          * @function
          * @name pc.ResourceHandler#open
+         * @description Convert raw resource data into a resource instance. e.g. take 3D model format JSON and return a pc.Model.
          * @param {String} url The URL of the resource to open.
-         * @param {Any} data The data passed into the callback from {@link pc.ResourceHandler#load}.
+         * @param {*} data The raw resource data passed by callback from {@link pc.ResourceHandler#load}.
          * @param {pc.Asset} [asset] Optional asset that is passed by ResourceLoader.
+         * @returns {*} The parsed resource data.
          */
         open: function (url, data, asset) {
             throw new Error('not implemented');
+        },
+
+        /**
+         * @function
+         * @name pc.ResourceHandler#patch
+         * @description Optional function to perform any operations on a resource, that requires a dependency on its asset data
+         * or any other asset data.
+         * @param {pc.Asset} asset The asset to patch.
+         * @param {pc.AssetRegistry} assets The asset registry.
+         */
+        patch: function (asset, assets) {
+            // optional function
         }
     });
 

--- a/src/resources/handler.js
+++ b/src/resources/handler.js
@@ -1,0 +1,37 @@
+Object.assign(pc, function () {
+    'use strict';
+
+    /**
+     * @interface pc.ResourceHandler
+     * @description Interface for ResourceHandlers
+     */
+    var ResourceHandler = function () {};
+
+    Object.assign(ResourceHandler.prototype, {
+
+        /**
+         * @function
+         * @name pc.ResourceHandler#load
+         * @param {String} url The URL of the resource to load.
+         * @param {Function} callback The callback used when the resource is loaded or an error occurs.
+         */
+        load: function (url, callback) {
+            throw new Error('not implemented');
+        },
+
+        /**
+         * @function
+         * @name pc.ResourceHandler#open
+         * @param {String} url The URL of the resource to open.
+         * @param {Any} data The data passed into the callback from {@link pc.ResourceHandler#load}.
+         * @param {pc.Asset} [asset] Optional asset that is passed by ResourceLoader.
+         */
+        open: function (url, data, asset) {
+            throw new Error('not implemented');
+        }
+    });
+
+    return {
+        ResourceHandler: ResourceHandler
+    };
+}());

--- a/src/scene/batching.js
+++ b/src/scene/batching.js
@@ -6,10 +6,10 @@ Object.assign(pc, function () {
      * @constructor
      * @name pc.Batch
      * @classdesc Holds information about batched mesh instances. Created in {@link pc.BatchManager#create}.
-     * @param {Array} meshInstances The mesh instances to be batched.
+     * @param {pc.MeshInstance[]} meshInstances The mesh instances to be batched.
      * @param {Boolean} dynamic Whether this batch is dynamic (supports transforming mesh instances at runtime).
      * @param {Number} batchGroupId Link this batch to a specific batch group. This is done automatically with default batches.
-     * @property {Array} origMeshInstances An array of original mesh instances, from which this batch was generated.
+     * @property {pc.MeshInstance[]} origMeshInstances An array of original mesh instances, from which this batch was generated.
      * @property {pc.MeshInstance} meshInstance A single combined mesh instance, the result of batching.
      * @property {pc.Model} model A handy model object
      * @property {Boolean} dynamic Whether this batch is dynamic (supports transforming mesh instances at runtime).
@@ -441,7 +441,7 @@ Object.assign(pc, function () {
      * @function
      * @name pc.BatchManager#generate
      * @description Destroys all batches and creates new based on scene models. Hides original models. Called by engine automatically on app start, and if batchGroupIds on models are changed.
-     * @param {Array} [groupIds] Optional array of batch group IDs to update. Otherwise all groups are updated.
+     * @param {Number[]} [groupIds] Optional array of batch group IDs to update. Otherwise all groups are updated.
      */
     BatchManager.prototype.generate = function (groupIds) {
         var i, j;
@@ -569,12 +569,12 @@ Object.assign(pc, function () {
      *     <li>Too many instances for a single batch (hardware-dependent, expect 128 on low-end and 1024 on high-end)</li>
      *     <li>Bounding box of a batch is larger than maxAabbSize in any dimension</li>
      * </ul>
-     * @param {Array} meshInstances Input list of mesh instances
+     * @param {pc.MeshInstance[]} meshInstances Input list of mesh instances
      * @param {Boolean} dynamic Are we preparing for a dynamic batch? Instance count will matter then (otherwise not).
      * @param {Number} maxAabbSize Maximum size of any dimension of a bounding box around batched objects.
      * @param {Boolean} translucent Are we batching UI elements or sprites
      * This is useful to keep a balance between the number of draw calls and the number of drawn triangles, because smaller batches can be hidden when not visible in camera.
-     * @returns {Array} An array of arrays of mesh instances, each valid to pass to {@link pc.BatchManager#create}.
+     * @returns {pc.MeshInstance[]} An array of arrays of mesh instances, each valid to pass to {@link pc.BatchManager#create}.
      */
     BatchManager.prototype.prepare = function (meshInstances, dynamic, maxAabbSize, translucent) {
         if (meshInstances.length === 0) return [];
@@ -702,7 +702,7 @@ Object.assign(pc, function () {
      * @function
      * @name pc.BatchManager#create
      * @description Takes a mesh instance list that has been prepared by {@link pc.BatchManager#prepare}, and returns a {@link pc.Batch} object. This method assumes that all mesh instances provided can be rendered in a single draw call.
-     * @param {Array} meshInstances Input list of mesh instances
+     * @param {pc.MeshInstance[]} meshInstances Input list of mesh instances
      * @param {Boolean} dynamic Is it a static or dynamic batch? Will objects be transformed after batching?
      * @param {Number} [batchGroupId] Link this batch to a specific batch group. This is done automatically with default batches.
      * @returns {pc.Batch} The resulting batch object.
@@ -1090,7 +1090,7 @@ Object.assign(pc, function () {
      * @name pc.BatchManager#clone
      * @description Clones a batch. This method doesn't rebuild batch geometry, but only creates a new model and batch objects, linked to different source mesh instances.
      * @param {pc.Batch} batch A batch object
-     * @param {Array} clonedMeshInstances New mesh instances
+     * @param {pc.MeshInstance[]} clonedMeshInstances New mesh instances
      * @returns {pc.Batch} New batch object
      */
     BatchManager.prototype.clone = function (batch, clonedMeshInstances) {

--- a/src/scene/forward-renderer.js
+++ b/src/scene/forward-renderer.js
@@ -339,7 +339,6 @@ Object.assign(pc, function () {
     }
 
     /**
-     * @private
      * @constructor
      * @name pc.ForwardRenderer
      * @classdesc The forward renderer render scene objects.

--- a/src/scene/layer-composition.js
+++ b/src/scene/layer-composition.js
@@ -5,12 +5,12 @@ Object.assign(pc, function () {
      * @name pc.LayerComposition
      * @classdesc Layer Composition is a collection of {@link pc.Layer} that is fed to {@link pc.Scene#layers} to define rendering order.
      * @description Create a new layer composition.
-     * @property {Array} layerList A read-only array of {@link pc.Layer} sorted in the order they will be rendered.
-     * @property {Array} subLayerList A read-only array of boolean values, matching {@link pc.Layer#layerList}.
+     * @property {pc.Layer[]} layerList A read-only array of {@link pc.Layer} sorted in the order they will be rendered.
+     * @property {Boolean[]} subLayerList A read-only array of boolean values, matching {@link pc.Layer#layerList}.
      * True means only semi-transparent objects are rendered, and false means opaque.
-     * @property {Array} subLayerEnabled A read-only array of boolean values, matching {@link pc.Layer#layerList}.
+     * @property {Boolean[]} subLayerEnabled A read-only array of boolean values, matching {@link pc.Layer#layerList}.
      * True means the layer is rendered, false means it's skipped.
-     * @property {Array} cameras A read-only array of {@link pc.CameraComponent} that can be used during rendering, e.g. inside
+     * @property {pc.CameraComponent[]} cameras A read-only array of {@link pc.CameraComponent} that can be used during rendering, e.g. inside
      * {@link pc.Layer#onPreCull}, {@link pc.Layer#onPostCull}, {@link pc.Layer#onPreRender}, {@link pc.Layer#onPostRender}.
      */
     // Composition can hold only 2 sublayers of each layer

--- a/src/scene/layer.js
+++ b/src/scene/layer.js
@@ -374,7 +374,7 @@ Object.assign(pc, function () {
      * @function
      * @name pc.Layer#addMeshInstances
      * @description Adds an array of mesh instances to this layer.
-     * @param {Array} meshInstances Array of {@link pc.MeshInstance}.
+     * @param {pc.MeshInstance[]} meshInstances Array of {@link pc.MeshInstance}.
      * @param {Boolean} [skipShadowCasters] Set it to true if you don't want these mesh instances to cast shadows in this layer.
      */
     Layer.prototype.addMeshInstances = function (meshInstances, skipShadowCasters) {
@@ -407,7 +407,7 @@ Object.assign(pc, function () {
      * @function
      * @name pc.Layer#removeMeshInstances
      * @description Removes multiple mesh instances from this layer.
-     * @param {Array} meshInstances Array of {@link pc.MeshInstance}. If they were added to this layer, they will be removed.
+     * @param {pc.MeshInstance[]} meshInstances Array of {@link pc.MeshInstance}. If they were added to this layer, they will be removed.
      * @param {Boolean} [skipShadowCasters] Set it to true if you want to still cast shadows from removed mesh instances or if they never did cast shadows before.
      */
     Layer.prototype.removeMeshInstances = function (meshInstances, skipShadowCasters) {
@@ -531,7 +531,7 @@ Object.assign(pc, function () {
      * @function
      * @name pc.Layer#addShadowCasters
      * @description Adds an array of mesh instances to this layer, but only as shadow casters (they will not be rendered anywhere, but only cast shadows on other objects).
-     * @param {Array} meshInstances Array of {@link pc.MeshInstance}.
+     * @param {pc.MeshInstance[]} meshInstances Array of {@link pc.MeshInstance}.
      */
     Layer.prototype.addShadowCasters = function (meshInstances) {
         var m;
@@ -548,7 +548,7 @@ Object.assign(pc, function () {
      * @function
      * @name pc.Layer#removeShadowCasters
      * @description Removes multiple mesh instances from the shadow casters list of this layer, meaning they will stop casting shadows.
-     * @param {Array} meshInstances Array of {@link pc.MeshInstance}. If they were added to this layer, they will be removed.
+     * @param {pc.MeshInstance[]} meshInstances Array of {@link pc.MeshInstance}. If they were added to this layer, they will be removed.
      */
     Layer.prototype.removeShadowCasters = function (meshInstances) {
         var id;

--- a/src/scene/lightmapper.js
+++ b/src/scene/lightmapper.js
@@ -80,7 +80,7 @@ Object.assign(pc, function () {
      * @param {pc.Entity} root The root entity of the scene.
      * @param {pc.Scene} scene The scene to lightmap.
      * @param {pc.ForwardRenderer} renderer The renderer.
-     * @param {Array} assets Array of assets to lightmap.
+     * @param {pc.AssetRegistry} assets Registry of assets to lightmap.
      */
     var Lightmapper = function (device, root, scene, renderer, assets) {
         this.device = device;

--- a/src/scene/materials/material.js
+++ b/src/scene/materials/material.js
@@ -345,7 +345,7 @@ Object.assign(pc, function () {
      * @name pc.Material#setParameter
      * @description Sets a shader parameter on a material.
      * @param {String} name The name of the parameter to set.
-     * @param {Number|Array|pc.Texture} data The value for the specified parameter.
+     * @param {Number|Number[]|pc.Texture} data The value for the specified parameter.
      * @param {Number} [passFlags] Mask describing which passes the material should be included in.
      */
     Material.prototype.setParameter = function (name, data, passFlags) {

--- a/src/scene/sprite.js
+++ b/src/scene/sprite.js
@@ -49,12 +49,12 @@ Object.assign(pc, function () {
      * @param {pc.GraphicsDevice} device The graphics device of the application.
      * @param {Object} options Options for creating the pc.Sprite.
      * @param {Number} [options.pixelsPerUnit] The number of pixels that map to one PlayCanvas unit.
-     * @param {pc.SPRITE_RENDERMODE} [options.renderMode] The rendering mode of the Sprite.
+     * @param {Number} [options.renderMode] The rendering mode of the Sprite, see {@link pc.SPRITE_RENDERMODE}.
      * @param {pc.TextureAtlas} [options.atlas] The texture atlas.
      * @property {String[]} [options.frameKeys] The keys of the frames in the sprite atlas that this sprite is using.
      * @property {Number} pixelsPerUnit The number of pixels that map to one PlayCanvas unit.
      * @property {pc.TextureAtlas} atlas The texture atlas.
-     * @property {pc.SPRITE_RENDERMODE} renderMode The rendering mode of the Sprite.
+     * @property {Number} renderMode The rendering mode of the Sprite, see {@link pc.SPRITE_RENDERMODE}.
      * @property {String[]} frameKeys The keys of the frames in the sprite atlas that this sprite is using.
      * @property {pc.Mesh[]} meshes An array that contains a mesh for each frame.
      */

--- a/src/script/script.js
+++ b/src/script/script.js
@@ -135,7 +135,7 @@ Object.assign(pc, function () {
      * @param {Object} args Object with Arguments for an attribute
      * @param {String} args.type Type of an attribute value, list of possible types:
      * boolean, number, string, json, asset, entity, rgb, rgba, vec2, vec3, vec4, curve
-     * @param {?} [args.default] Default attribute value
+     * @param {Any} [args.default] Default attribute value
      * @param {String} [args.title] Title for Editor's for field UI
      * @param {String} [args.description] Description for Editor's for field UI
      * @param {(String|String[])} [args.placeholder] Placeholder for Editor's for field UI.

--- a/src/script/script.js
+++ b/src/script/script.js
@@ -135,10 +135,10 @@ Object.assign(pc, function () {
      * @param {Object} args Object with Arguments for an attribute
      * @param {String} args.type Type of an attribute value, list of possible types:
      * boolean, number, string, json, asset, entity, rgb, rgba, vec2, vec3, vec4, curve
-     * @param {Any} [args.default] Default attribute value
+     * @param {*} [args.default] Default attribute value
      * @param {String} [args.title] Title for Editor's for field UI
      * @param {String} [args.description] Description for Editor's for field UI
-     * @param {(String|String[])} [args.placeholder] Placeholder for Editor's for field UI.
+     * @param {String|String[]} [args.placeholder] Placeholder for Editor's for field UI.
      * For multi-field types, such as vec2, vec3, and others use array of strings.
      * @param {Boolean} [args.array] If attribute can hold single or multiple values
      * @param {Number} [args.size] If attribute is array, maximum number of values can be set

--- a/src/sound/sound.js
+++ b/src/sound/sound.js
@@ -5,10 +5,10 @@ Object.assign(pc, function () {
      * @constructor
      * @name pc.Sound
      * @classdesc Represents the resource of an audio asset.
-     * @param {Audio|AudioBuffer} resource If the Web Audio API is supported, pass an AudioBuffer object, otherwise
+     * @param {HTMLAudioElement|AudioBuffer} resource If the Web Audio API is supported, pass an AudioBuffer object, otherwise
      * an Audio object.
      * @property {AudioBuffer} buffer If the Web Audio API is supported this contains the audio data
-     * @property {Audio} audio If the Web Audio API is not supported this contains the audio data
+     * @property {HTMLAudioElement} audio If the Web Audio API is not supported this contains the audio data
      * @property {Number} duration Returns the duration of the sound. If the sound is not loaded it returns 0.
      */
     var Sound = function (resource) {


### PR DESCRIPTION
Fixes #1656

PR includes:
- Fixed ambiguous arrays by using type-specific arrays in jsdoc comments.
- Fixed unrecognized types (`?` and `Audio`) in jsdoc comments.
- Fixed issue `required parameter following optional parameter` by adding jsdoc function varations.
- Fixed missing types referenced in public documentation by removing some `@private` tags.
- Fixed unresolved types by adding missing `@constructor` tags.
- Fixed missing reference to `pc.ResourceHandler` by adding simple interface declaration.
- Fixed issue with using type `pc.SPRITE_RENDERMODE` in jsdoc, since it is not a strict jsdoc enum type.
- Added missing jsdoc comments for default instance `pc.http`. 

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
