### PR TITLE
[DOC] Fix enums/constants issues in TypeScript declarations

### DIFF
--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -1622,31 +1622,36 @@ Object.assign(pc, function () {
 
     return {
         /**
-         * @enum pc.FILLMODE
+         * @constant
+         * @type {String}
          * @name pc.FILLMODE_NONE
          * @description When resizing the window the size of the canvas will not change.
          */
         FILLMODE_NONE: 'NONE',
         /**
-         * @enum pc.FILLMODE
+         * @constant
+         * @type {String}
          * @name pc.FILLMODE_FILL_WINDOW
          * @description When resizing the window the size of the canvas will change to fill the window exactly.
          */
         FILLMODE_FILL_WINDOW: 'FILL_WINDOW',
         /**
-         * @enum pc.FILLMODE
+         * @constant
+         * @type {String}
          * @name pc.FILLMODE_KEEP_ASPECT
          * @description When resizing the window the size of the canvas will change to fill the window as best it can, while maintaining the same aspect ratio.
          */
         FILLMODE_KEEP_ASPECT: 'KEEP_ASPECT',
         /**
-         * @enum pc.RESOLUTION
+         * @constant
+         * @type {String}
          * @name pc.RESOLUTION_AUTO
          * @description When the canvas is resized the resolution of the canvas will change to match the size of the canvas.
          */
         RESOLUTION_AUTO: 'AUTO',
         /**
-         * @enum pc.RESOLUTION
+         * @constant
+         * @type {String}
          * @name pc.RESOLUTION_FIXED
          * @description When the canvas is resized the resolution of the canvas will remain at the same value and the output will just be scaled to fit the canvas.
          */

--- a/src/framework/components/button/constants.js
+++ b/src/framework/components/button/constants.js
@@ -1,12 +1,14 @@
 Object.assign(pc, {
     /**
-     * @enum pc.BUTTON_TRANSITION_MODE
+     * @constant
+     * @type {Number}
      * @name pc.BUTTON_TRANSITION_MODE_TINT
      * @description Specifies different color tints for the hover, pressed and inactive states.
      */
     BUTTON_TRANSITION_MODE_TINT: 0,
     /**
-     * @enum pc.BUTTON_TRANSITION_MODE
+     * @constant
+     * @type {Number}
      * @name pc.BUTTON_TRANSITION_MODE_SPRITE_CHANGE
      * @description Specifies different sprites for the hover, pressed and inactive states.
      */

--- a/src/framework/components/element/component.js
+++ b/src/framework/components/element/component.js
@@ -4,19 +4,22 @@ Object.assign(pc, function () {
     // #endif
 
     /**
-     * @enum pc.ELEMENTTYPE
+     * @constant
+     * @type {String}
      * @name pc.ELEMENTTYPE_GROUP
      * @description A {@link pc.ElementComponent} that contains child {@link pc.ElementComponent}s.
      */
     pc.ELEMENTTYPE_GROUP = 'group';
     /**
-     * @enum pc.ELEMENTTYPE
+     * @constant
+     * @type {String}
      * @name pc.ELEMENTTYPE_IMAGE
      * @description A {@link pc.ElementComponent} that displays an image.
      */
     pc.ELEMENTTYPE_IMAGE = 'image';
     /**
-     * @enum pc.ELEMENTTYPE
+     * @constant
+     * @type {String}
      * @name pc.ELEMENTTYPE_TEXT
      * @description A {@link pc.ElementComponent} that displays text.
      */

--- a/src/framework/components/layout-group/constants.js
+++ b/src/framework/components/layout-group/constants.js
@@ -1,24 +1,28 @@
 Object.assign(pc, {
     /**
-     * @enum pc.FITTING
+     * @constant
+     * @type {Number}
      * @name pc.FITTING_NONE
      * @description Disable all fitting logic.
      */
     FITTING_NONE: 0,
     /**
-     * @enum pc.FITTING
+     * @constant
+     * @type {Number}
      * @name pc.FITTING_STRETCH
      * @description Stretch child elements to fit the parent container
      */
     FITTING_STRETCH: 1,
     /**
-     * @enum pc.FITTING
+     * @constant
+     * @type {Number}
      * @name pc.FITTING_SHRINK
      * @description Shrink child elements to fit the parent container
      */
     FITTING_SHRINK: 2,
     /**
-     * @enum pc.FITTING
+     * @constant
+     * @type {Number}
      * @name pc.FITTING_BOTH
      * @description Apply both STRETCH and SHRINK fitting logic where applicable.
      */

--- a/src/framework/components/screen/component.js
+++ b/src/framework/components/screen/component.js
@@ -1,12 +1,14 @@
 Object.assign(pc, function () {
     /**
-     * @enum pc.SCALEMODE
+     * @constant
+     * @type {String}
      * @name pc.SCALEMODE_NONE
      * @description Always use the application's resolution as the resolution for the {@link pc.ScreenComponent}.
      */
     pc.SCALEMODE_NONE = "none";
     /**
-     * @enum pc.SCALEMODE
+     * @constant
+     * @type {String}
      * @name pc.SCALEMODE_BLEND
      * @description Scale the {@link pc.ScreenComponent} when the application's resolution is different than the ScreenComponent's referenceResolution.
      */

--- a/src/framework/components/scroll-view/constants.js
+++ b/src/framework/components/scroll-view/constants.js
@@ -1,31 +1,36 @@
 Object.assign(pc, {
     /**
-     * @enum pc.SCROLL_MODE
+     * @constant
+     * @type {Number}
      * @name pc.SCROLL_MODE_CLAMP
      * @description Content does not scroll any further than its bounds.
      */
     SCROLL_MODE_CLAMP: 0,
     /**
-     * @enum pc.SCROLL_MODE
+     * @constant
+     * @type {Number}
      * @name pc.SCROLL_MODE_BOUNCE
      * @description Content scrolls past its bounds and then gently bounces back.
      */
     SCROLL_MODE_BOUNCE: 1,
     /**
-     * @enum pc.SCROLL_MODE
+     * @constant
+     * @type {Number}
      * @name pc.SCROLL_MODE_INFINITE
      * @description Content can scroll forever.
      */
     SCROLL_MODE_INFINITE: 2,
 
     /**
-     * @enum pc.SCROLLBAR_VISIBILITY
+     * @constant
+     * @type {Number}
      * @name pc.SCROLLBAR_VISIBILITY_SHOW_ALWAYS
      * @description The scrollbar will be visible all the time.
      */
     SCROLLBAR_VISIBILITY_SHOW_ALWAYS: 0,
     /**
-     * @enum pc.SCROLLBAR_VISIBILITY
+     * @constant
+     * @type {Number}
      * @name pc.SCROLLBAR_VISIBILITY_SHOW_WHEN_REQUIRED
      * @description The scrollbar will be visible only when content exceeds the size of the viewport.
      */

--- a/src/framework/components/sound/constants.js
+++ b/src/framework/components/sound/constants.js
@@ -1,27 +1,24 @@
 // distance model
 Object.assign(pc, {
     /**
-     * @static
-     * @readOnly
+     * @constant
+     * @type {String}
      * @name pc.DISTANCE_LINEAR
-     * @type String
      * @description Linear distance model
      */
     DISTANCE_LINEAR: 'linear',
 
     /**
-     * @static
-     * @readonly
-     * @type String
+     * @constant
+     * @type {String}
      * @name pc.DISTANCE_INVERSE
      * @description Inverse distance model
      */
     DISTANCE_INVERSE: 'inverse',
 
     /**
-     * @static
-     * @readonly
-     * @type String
+     * @constant
+     * @type {String}
      * @name pc.DISTANCE_EXPONENTIAL
      * @description Exponential distance model
      */

--- a/src/framework/components/sprite/component.js
+++ b/src/framework/components/sprite/component.js
@@ -2,7 +2,8 @@ Object.assign(pc, function () {
     'use strict';
 
     /**
-     * @enum pc.SPRITETYPE
+     * @constant
+     * @type {String}
      * @name pc.SPRITETYPE_SIMPLE
      * @description A {@link pc.SpriteComponent} that displays a single frame from a sprite asset.
      */
@@ -10,7 +11,8 @@ Object.assign(pc, function () {
 
 
     /**
-     * @enum pc.SPRITETYPE
+     * @constant
+     * @type {String}
      * @name pc.SPRITETYPE_ANIMATED
      * @description A {@link pc.SpriteComponent} that renders sprite animations.
      */

--- a/src/graphics/graphics.js
+++ b/src/graphics/graphics.js
@@ -527,181 +527,211 @@
         PRIMITIVE_TRIFAN: 6,
 
         /**
-         * @enum pc.SEMANTIC
+         * @constant
+         * @type {String}
          * @name pc.SEMANTIC_POSITION
          * @description Vertex attribute to be treated as a position.
          */
         SEMANTIC_POSITION: "POSITION",
         /**
-         * @enum pc.SEMANTIC
+         * @constant
+         * @type {String}
          * @name pc.SEMANTIC_NORMAL
          * @description Vertex attribute to be treated as a normal.
          */
         SEMANTIC_NORMAL: "NORMAL",
         /**
-         * @enum pc.SEMANTIC
+         * @constant
+         * @type {String}
          * @name pc.SEMANTIC_TANGENT
          * @description Vertex attribute to be treated as a tangent.
          */
         SEMANTIC_TANGENT: "TANGENT",
         /**
-         * @enum pc.SEMANTIC
+         * @constant
+         * @type {String}
          * @name pc.SEMANTIC_BLENDWEIGHT
          * @description Vertex attribute to be treated as skin blend weights.
          */
         SEMANTIC_BLENDWEIGHT: "BLENDWEIGHT",
         /**
-         * @enum pc.SEMANTIC
+         * @constant
+         * @type {String}
          * @name pc.SEMANTIC_BLENDINDICES
          * @description Vertex attribute to be treated as skin blend indices.
          */
         SEMANTIC_BLENDINDICES: "BLENDINDICES",
         /**
-         * @enum pc.SEMANTIC
+         * @constant
+         * @type {String}
          * @name pc.SEMANTIC_COLOR
          * @description Vertex attribute to be treated as a color.
          */
         SEMANTIC_COLOR: "COLOR",
         /**
-         * @enum pc.SEMANTIC
+         * @constant
+         * @type {String}
          * @name pc.SEMANTIC_TEXCOORD0
          * @description Vertex attribute to be treated as a texture coordinate (set 0).
          */
         SEMANTIC_TEXCOORD0: "TEXCOORD0",
         /**
-         * @enum pc.SEMANTIC
+         * @constant
+         * @type {String}
          * @name pc.SEMANTIC_TEXCOORD1
          * @description Vertex attribute to be treated as a texture coordinate (set 1).
          */
         SEMANTIC_TEXCOORD1: "TEXCOORD1",
         /**
-         * @enum pc.SEMANTIC
+         * @constant
+         * @type {String}
          * @name pc.SEMANTIC_TEXCOORD2
          * @description Vertex attribute to be treated as a texture coordinate (set 2).
          */
         SEMANTIC_TEXCOORD2: "TEXCOORD2",
         /**
-         * @enum pc.SEMANTIC
+         * @constant
+         * @type {String}
          * @name pc.SEMANTIC_TEXCOORD3
          * @description Vertex attribute to be treated as a texture coordinate (set 3).
          */
         SEMANTIC_TEXCOORD3: "TEXCOORD3",
         /**
-         * @enum pc.SEMANTIC
+         * @constant
+         * @type {String}
          * @name pc.SEMANTIC_TEXCOORD4
          * @description Vertex attribute to be treated as a texture coordinate (set 4).
          */
         SEMANTIC_TEXCOORD4: "TEXCOORD4",
         /**
-         * @enum pc.SEMANTIC
+         * @constant
+         * @type {String}
          * @name pc.SEMANTIC_TEXCOORD5
          * @description Vertex attribute to be treated as a texture coordinate (set 5).
          */
         SEMANTIC_TEXCOORD5: "TEXCOORD5",
         /**
-         * @enum pc.SEMANTIC
+         * @constant
+         * @type {String}
          * @name pc.SEMANTIC_TEXCOORD6
          * @description Vertex attribute to be treated as a texture coordinate (set 6).
          */
         SEMANTIC_TEXCOORD6: "TEXCOORD6",
         /**
-         * @enum pc.SEMANTIC
+         * @constant
+         * @type {String}
          * @name pc.SEMANTIC_TEXCOORD7
          * @description Vertex attribute to be treated as a texture coordinate (set 7).
          */
         SEMANTIC_TEXCOORD7: "TEXCOORD7",
         /**
-         * @enum pc.SEMANTIC
+         * @constant
+         * @type {String}
          * @name pc.SEMANTIC_ATTR0
          * @description Vertex attribute with a user defined semantic.
          */
         SEMANTIC_ATTR0: "ATTR0",
         /**
-         * @enum pc.SEMANTIC
+         * @constant
+         * @type {String}
          * @name pc.SEMANTIC_ATTR1
          * @description Vertex attribute with a user defined semantic.
          */
         SEMANTIC_ATTR1: "ATTR1",
         /**
-         * @enum pc.SEMANTIC
+         * @constant
+         * @type {String}
          * @name pc.SEMANTIC_ATTR2
          * @description Vertex attribute with a user defined semantic.
          */
         SEMANTIC_ATTR2: "ATTR2",
         /**
-         * @enum pc.SEMANTIC
+         * @constant
+         * @type {String}
          * @name pc.SEMANTIC_ATTR3
          * @description Vertex attribute with a user defined semantic.
          */
         SEMANTIC_ATTR3: "ATTR3",
         /**
-         * @enum pc.SEMANTIC
+         * @constant
+         * @type {String}
          * @name pc.SEMANTIC_ATTR4
          * @description Vertex attribute with a user defined semantic.
          */
         SEMANTIC_ATTR4: "ATTR4",
         /**
-         * @enum pc.SEMANTIC
+         * @constant
+         * @type {String}
          * @name pc.SEMANTIC_ATTR5
          * @description Vertex attribute with a user defined semantic.
          */
         SEMANTIC_ATTR5: "ATTR5",
         /**
-         * @enum pc.SEMANTIC
+         * @constant
+         * @type {String}
          * @name pc.SEMANTIC_ATTR6
          * @description Vertex attribute with a user defined semantic.
          */
         SEMANTIC_ATTR6: "ATTR6",
         /**
-         * @enum pc.SEMANTIC
+         * @constant
+         * @type {String}
          * @name pc.SEMANTIC_ATTR7
          * @description Vertex attribute with a user defined semantic.
          */
         SEMANTIC_ATTR7: "ATTR7",
         /**
-         * @enum pc.SEMANTIC
+         * @constant
+         * @type {String}
          * @name pc.SEMANTIC_ATTR8
          * @description Vertex attribute with a user defined semantic.
          */
         SEMANTIC_ATTR8: "ATTR8",
         /**
-         * @enum pc.SEMANTIC
+         * @constant
+         * @type {String}
          * @name pc.SEMANTIC_ATTR9
          * @description Vertex attribute with a user defined semantic.
          */
         SEMANTIC_ATTR9: "ATTR9",
         /**
-         * @enum pc.SEMANTIC
+         * @constant
+         * @type {String}
          * @name pc.SEMANTIC_ATTR10
          * @description Vertex attribute with a user defined semantic.
          */
         SEMANTIC_ATTR10: "ATTR10",
         /**
-         * @enum pc.SEMANTIC
+         * @constant
+         * @type {String}
          * @name pc.SEMANTIC_ATTR11
          * @description Vertex attribute with a user defined semantic.
          */
         SEMANTIC_ATTR11: "ATTR11",
         /**
-         * @enum pc.SEMANTIC
+         * @constant
+         * @type {String}
          * @name pc.SEMANTIC_ATTR12
          * @description Vertex attribute with a user defined semantic.
          */
         SEMANTIC_ATTR12: "ATTR12",
         /**
-         * @enum pc.SEMANTIC
+         * @constant
+         * @type {String}
          * @name pc.SEMANTIC_ATTR13
          * @description Vertex attribute with a user defined semantic.
          */
         SEMANTIC_ATTR13: "ATTR13",
         /**
-         * @enum pc.SEMANTIC
+         * @constant
+         * @type {String}
          * @name pc.SEMANTIC_ATTR14
          * @description Vertex attribute with a user defined semantic.
          */
         SEMANTIC_ATTR14: "ATTR14",
         /**
-         * @enum pc.SEMANTIC
+         * @constant
+         * @type {String}
          * @name pc.SEMANTIC_ATTR15
          * @description Vertex attribute with a user defined semantic.
          */

--- a/src/graphics/graphics.js
+++ b/src/graphics/graphics.js
@@ -28,205 +28,238 @@
         ADDRESS_MIRRORED_REPEAT: 2,
 
         /**
-         * @enum pc.BLENDMODE
+         * @constant
+         * @type {Number}
          * @name pc.BLENDMODE_ZERO
          * @description Multiply all fragment components by zero.
          */
         BLENDMODE_ZERO: 0,
         /**
-         * @enum pc.BLENDMODE
+         * @constant
+         * @type {Number}
          * @name pc.BLENDMODE_ONE
          * @description Multiply all fragment components by one.
          */
         BLENDMODE_ONE: 1,
         /**
-         * @enum pc.BLENDMODE
+         * @constant
+         * @type {Number}
          * @name pc.BLENDMODE_SRC_COLOR
          * @description Multiply all fragment components by the components of the source fragment.
          */
         BLENDMODE_SRC_COLOR: 2,
         /**
-         * @enum pc.BLENDMODE
+         * @constant
+         * @type {Number}
          * @name pc.BLENDMODE_ONE_MINUS_SRC_COLOR
          * @description Multiply all fragment components by one minus the components of the source fragment.
          */
         BLENDMODE_ONE_MINUS_SRC_COLOR: 3,
         /**
-         * @enum pc.BLENDMODE
+         * @constant
+         * @type {Number}
          * @name pc.BLENDMODE_DST_COLOR
          * @description Multiply all fragment components by the components of the destination fragment.
          */
         BLENDMODE_DST_COLOR: 4,
         /**
-         * @enum pc.BLENDMODE
+         * @constant
+         * @type {Number}
          * @name pc.BLENDMODE_ONE_MINUS_DST_COLOR
          * @description Multiply all fragment components by one minus the components of the destination fragment.
          */
         BLENDMODE_ONE_MINUS_DST_COLOR: 5,
         /**
-         * @enum pc.BLENDMODE
+         * @constant
+         * @type {Number}
          * @name pc.BLENDMODE_SRC_ALPHA
          * @description Multiply all fragment components by the alpha value of the source fragment.
          */
         BLENDMODE_SRC_ALPHA: 6,
         /**
-         * @enum pc.BLENDMODE
+         * @constant
+         * @type {Number}
          * @name pc.BLENDMODE_SRC_ALPHA_SATURATE
          * @description Multiply all fragment components by the alpha value of the source fragment.
          */
         BLENDMODE_SRC_ALPHA_SATURATE: 7,
         /**
-         * @enum pc.BLENDMODE
+         * @constant
+         * @type {Number}
          * @name pc.BLENDMODE_ONE_MINUS_SRC_ALPHA
          * @description Multiply all fragment components by one minus the alpha value of the source fragment.
          */
         BLENDMODE_ONE_MINUS_SRC_ALPHA: 8,
         /**
-         * @enum pc.BLENDMODE
+         * @constant
+         * @type {Number}
          * @name pc.BLENDMODE_DST_ALPHA
          * @description Multiply all fragment components by the alpha value of the destination fragment.
          */
         BLENDMODE_DST_ALPHA: 9,
         /**
-         * @enum pc.BLENDMODE
+         * @constant
+         * @type {Number}
          * @name pc.BLENDMODE_ONE_MINUS_DST_ALPHA
          * @description Multiply all fragment components by one minus the alpha value of the destination fragment.
          */
         BLENDMODE_ONE_MINUS_DST_ALPHA: 10,
 
         /**
-         * @enum pc.BLENDEQUATION
+         * @constant
+         * @type {Number}
          * @name pc.BLENDEQUATION_ADD
          * @description Add the results of the source and destination fragment multiplies.
          */
         BLENDEQUATION_ADD: 0,
         /**
-         * @enum pc.BLENDEQUATION
+         * @constant
+         * @type {Number}
          * @name pc.BLENDEQUATION_SUBTRACT
          * @description Subtract the results of the source and destination fragment multiplies.
          */
         BLENDEQUATION_SUBTRACT: 1,
         /**
-         * @enum pc.BLENDEQUATION
+         * @constant
+         * @type {Number}
          * @name pc.BLENDEQUATION_REVERSE_SUBTRACT
          * @description Reverse and subtract the results of the source and destination fragment multiplies.
          */
         BLENDEQUATION_REVERSE_SUBTRACT: 2,
 
         /**
-         * @enum pc.BLENDEQUATION
+         * @constant
+         * @type {Number}
          * @name pc.BLENDEQUATION_MIN
          * @description Use the smallest value. Check app.graphicsDevice.extBlendMinmax for support.
          */
         BLENDEQUATION_MIN: 3,
         /**
-         * @enum pc.BLENDEQUATION
+         * @constant
+         * @type {Number}
          * @name pc.BLENDEQUATION_MAX
          * @description Use the largest value. Check app.graphicsDevice.extBlendMinmax for support.
          */
         BLENDEQUATION_MAX: 4,
 
         /**
-         * @enum pc.BUFFER
+         * @constant
+         * @type {Number}
          * @name pc.BUFFER_STATIC
          * @description The data store contents will be modified once and used many times.
          */
         BUFFER_STATIC: 0,
         /**
-         * @enum pc.BUFFER
+         * @constant
+         * @type {Number}
          * @name pc.BUFFER_DYNAMIC
          * @description The data store contents will be modified repeatedly and used many times.
          */
         BUFFER_DYNAMIC: 1,
         /**
-         * @enum pc.BUFFER
+         * @constant
+         * @type {Number}
          * @name pc.BUFFER_STREAM
          * @description The data store contents will be modified once and used at most a few times.
          */
         BUFFER_STREAM: 2,
         /**
-         * @enum pc.BUFFER
+         * @constant
+         * @type {Number}
          * @name pc.BUFFER_GPUDYNAMIC
          * @description The data store contents will be modified repeatedly on the GPU and used many times. Optimal for transform feedback usage (WebGL2 only).
          */
         BUFFER_GPUDYNAMIC: 3,
 
         /**
-         * @enum pc.CLEARFLAG
+         * @constant
+         * @type {Number}
          * @name pc.CLEARFLAG_COLOR
          * @description Clear the color buffer.
          */
         CLEARFLAG_COLOR: 1,
         /**
-         * @enum pc.CLEARFLAG
+         * @constant
+         * @type {Number}
          * @name pc.CLEARFLAG_DEPTH
          * @description Clear the depth buffer.
          */
         CLEARFLAG_DEPTH: 2,
         /**
-         * @enum pc.CLEARFLAG
+         * @constant
+         * @type {Number}
          * @name pc.CLEARFLAG_STENCIL
          * @description Clear the stencil buffer.
          */
         CLEARFLAG_STENCIL: 4,
 
         /**
-         * @enum pc.CUBEFACE
+         * @constant
+         * @type {Number}
          * @name pc.CUBEFACE_POSX
          * @description The positive X face of a cubemap.
          */
         CUBEFACE_POSX: 0,
         /**
-         * @enum pc.CUBEFACE
+         * @constant
+         * @type {Number}
          * @name pc.CUBEFACE_NEGX
          * @description The negative X face of a cubemap.
          */
         CUBEFACE_NEGX: 1,
         /**
-         * @enum pc.CUBEFACE
+         * @constant
+         * @type {Number}
          * @name pc.CUBEFACE_POSY
          * @description The positive Y face of a cubemap.
          */
         CUBEFACE_POSY: 2,
         /**
-         * @enum pc.CUBEFACE
+         * @constant
+         * @type {Number}
          * @name pc.CUBEFACE_NEGY
          * @description The negative Y face of a cubemap.
          */
         CUBEFACE_NEGY: 3,
         /**
-         * @enum pc.CUBEFACE
+         * @constant
+         * @type {Number}
          * @name pc.CUBEFACE_POSZ
          * @description The positive Z face of a cubemap.
          */
         CUBEFACE_POSZ: 4,
         /**
-         * @enum pc.CUBEFACE
+         * @constant
+         * @type {Number}
          * @name pc.CUBEFACE_NEGZ
          * @description The negative Z face of a cubemap.
          */
         CUBEFACE_NEGZ: 5,
 
         /**
-         * @enum pc.CULLFACE
+         * @constant
+         * @type {Number}
          * @name pc.CULLFACE_NONE
          * @description No triangles are culled.
          */
         CULLFACE_NONE: 0,
         /**
-         * @enum pc.CULLFACE
+         * @constant
+         * @type {Number}
          * @name pc.CULLFACE_BACK
          * @description Triangles facing away from the view direction are culled.
          */
         CULLFACE_BACK: 1,
         /**
-         * @enum pc.CULLFACE
+         * @constant
+         * @type {Number}
          * @name pc.CULLFACE_FRONT
          * @description Triangles facing the view direction are culled.
          */
         CULLFACE_FRONT: 2,
         /**
-         * @enum pc.CULLFACE
+         * @constant
+         * @type {Number}
          * @name pc.CULLFACE_FRONTANDBACK
          * @description Triangles are culled regardless of their orientation with respect to the view
          * direction. Note that point or line primitives are unaffected by this render state.
@@ -234,80 +267,93 @@
         CULLFACE_FRONTANDBACK: 3,
 
         /**
-         * @enum pc.TYPE
+         * @constant
+         * @type {Number}
          * @name pc.TYPE_INT8
          * @description Signed byte vertex element type.
          */
         TYPE_INT8: 0,
         /**
-         * @enum pc.TYPE
+         * @constant
+         * @type {Number}
          * @name pc.TYPE_UINT8
          * @description Unsigned byte vertex element type.
          */
         TYPE_UINT8: 1,
         /**
-         * @enum pc.TYPE
+         * @constant
+         * @type {Number}
          * @name pc.TYPE_INT16
          * @description Signed short vertex element type.
          */
         TYPE_INT16: 2,
         /**
-         * @enum pc.TYPE
+         * @constant
+         * @type {Number}
          * @name pc.TYPE_UINT16
          * @description Unsigned short vertex element type.
          */
         TYPE_UINT16: 3,
         /**
-         * @enum pc.TYPE
+         * @constant
+         * @type {Number}
          * @name pc.TYPE_INT32
          * @description Signed integer vertex element type.
          */
         TYPE_INT32: 4,
         /**
-         * @enum pc.TYPE
+         * @constant
+         * @type {Number}
          * @name pc.TYPE_UINT32
          * @description Unsigned integer vertex element type.
          */
         TYPE_UINT32: 5,
         /**
-         * @enum pc.TYPE
+         * @constant
+         * @type {Number}
          * @name pc.TYPE_FLOAT32
          * @description Floating point vertex element type.
          */
         TYPE_FLOAT32: 6,
 
         /**
-         * @enum pc.FILTER
+         * @constant
+         * @type {Number}
          * @name pc.FILTER_NEAREST
          * @description Point sample filtering.
          */
         FILTER_NEAREST: 0,
         /**
-         * @enum pc.FILTER
+         * @constant
+         * @type {Number}
          * @name pc.FILTER_LINEAR
          * @description Bilinear filtering.
          */
         FILTER_LINEAR: 1,
         /**
-         * @enum pc.FILTER
+         * @constant
+         * @type {Number}
          * @name pc.FILTER_NEAREST_MIPMAP_NEAREST
          * @description Use the nearest neighbor in the nearest mipmap level.
          */
         FILTER_NEAREST_MIPMAP_NEAREST: 2,
         /**
-         * @enum pc.FILTER
+         * @constant
+         * @type {Number}
          * @name pc.FILTER_NEAREST_MIPMAP_LINEAR
          * @description Linearly interpolate in the nearest mipmap level.
          */
         FILTER_NEAREST_MIPMAP_LINEAR: 3,
         /**
-         * @enum pc.FILTER
+         * @constant
+         * @type {Number}
          * @name pc.FILTER_LINEAR_MIPMAP_NEAREST
          * @description Use the nearest neighbor after linearly interpolating between mipmap levels.
          */
         FILTER_LINEAR_MIPMAP_NEAREST: 4,
         /**
-         * @enum pc.FILTER
+         * @constant
+         * @type {Number}
          * @name pc.FILTER_LINEAR_MIPMAP_LINEAR
          * @description Linearly interpolate both the mipmap levels and between texels.
          */
@@ -323,152 +369,176 @@
         FUNC_ALWAYS: 7,
 
         /**
-         * @enum pc.INDEXFORMAT
+         * @constant
+         * @type {Number}
          * @name pc.INDEXFORMAT_UINT8
          * @description 8-bit unsigned vertex indices.
          */
         INDEXFORMAT_UINT8: 0,
         /**
-         * @enum pc.INDEXFORMAT
+         * @constant
+         * @type {Number}
          * @name pc.INDEXFORMAT_UINT16
          * @description 16-bit unsigned vertex indices.
          */
         INDEXFORMAT_UINT16: 1,
         /**
-         * @enum pc.INDEXFORMAT
+         * @constant
+         * @type {Number}
          * @name pc.INDEXFORMAT_UINT32
          * @description 32-bit unsigned vertex indices.
          */
         INDEXFORMAT_UINT32: 2,
 
         /**
-         * @enum pc.PIXELFORMAT
+         * @constant
+         * @type {Number}
          * @name pc.PIXELFORMAT_A8
          * @description 8-bit alpha.
          */
         PIXELFORMAT_A8: 0,
         /**
-         * @enum pc.PIXELFORMAT
+         * @constant
+         * @type {Number}
          * @name pc.PIXELFORMAT_L8
          * @description 8-bit luminance.
          */
         PIXELFORMAT_L8: 1,
         /**
-         * @enum pc.PIXELFORMAT
+         * @constant
+         * @type {Number}
          * @name pc.PIXELFORMAT_L8_A8
          * @description 8-bit luminance with 8-bit alpha.
          */
         PIXELFORMAT_L8_A8: 2,
         /**
-         * @enum pc.PIXELFORMAT
+         * @constant
+         * @type {Number}
          * @name pc.PIXELFORMAT_R5_G6_B5
          * @description 16-bit RGB (5-bits for red channel, 6 for green and 5 for blue).
          */
         PIXELFORMAT_R5_G6_B5: 3,
         /**
-         * @enum pc.PIXELFORMAT
+         * @constant
+         * @type {Number}
          * @name pc.PIXELFORMAT_R5_G5_B5_A1
          * @description 16-bit RGBA (5-bits for red channel, 5 for green, 5 for blue with 1-bit alpha).
          */
         PIXELFORMAT_R5_G5_B5_A1: 4,
         /**
-         * @enum pc.PIXELFORMAT
+         * @constant
+         * @type {Number}
          * @name pc.PIXELFORMAT_R4_G4_B4_A4
          * @description 16-bit RGBA (4-bits for red channel, 4 for green, 4 for blue with 4-bit alpha).
          */
         PIXELFORMAT_R4_G4_B4_A4: 5,
         /**
-         * @enum pc.PIXELFORMAT
+         * @constant
+         * @type {Number}
          * @name pc.PIXELFORMAT_R8_G8_B8
          * @description 24-bit RGB (8-bits for red channel, 8 for green and 8 for blue).
          */
         PIXELFORMAT_R8_G8_B8: 6,
         /**
-         * @enum pc.PIXELFORMAT
+         * @constant
+         * @type {Number}
          * @name pc.PIXELFORMAT_R8_G8_B8_A8
          * @description 32-bit RGBA (8-bits for red channel, 8 for green, 8 for blue with 8-bit alpha).
          */
         PIXELFORMAT_R8_G8_B8_A8: 7,
         /**
-         * @enum pc.PIXELFORMAT
+         * @constant
+         * @type {Number}
          * @name pc.PIXELFORMAT_DXT1
          * @description Block compressed format, storing 16 input pixels in 64 bits of output, consisting of two 16-bit RGB 5:6:5 color values and a 4x4 two bit lookup table.
          */
         PIXELFORMAT_DXT1: 8,
         /**
-         * @enum pc.PIXELFORMAT
+         * @constant
+         * @type {Number}
          * @name pc.PIXELFORMAT_DXT3
          * @description Block compressed format, storing 16 input pixels (corresponding to a 4x4 pixel block) into 128 bits of output, consisting of 64 bits of alpha channel data (4 bits for each pixel) followed by 64 bits of color data, encoded the same way as DXT1.
          */
         PIXELFORMAT_DXT3: 9,
         /**
-         * @enum pc.PIXELFORMAT
+         * @constant
+         * @type {Number}
          * @name pc.PIXELFORMAT_DXT5
          * @description Block compressed format, storing 16 input pixels into 128 bits of output, consisting of 64 bits of alpha channel data (two 8 bit alpha values and a 4x4 3 bit lookup table) followed by 64 bits of color data (encoded the same way as DXT1).
          */
         PIXELFORMAT_DXT5: 10,
         /**
-         * @enum pc.PIXELFORMAT
+         * @constant
+         * @type {Number}
          * @name pc.PIXELFORMAT_RGB16F
          * @description 16-bit floating point RGB (16-bit float for each red, green and blue channels).
          */
         PIXELFORMAT_RGB16F: 11,
         /**
-         * @enum pc.PIXELFORMAT
+         * @constant
+         * @type {Number}
          * @name pc.PIXELFORMAT_RGBA16F
          * @description 16-bit floating point RGBA (16-bit float for each red, green, blue and alpha channels).
          */
         PIXELFORMAT_RGBA16F: 12,
         /**
-         * @enum pc.PIXELFORMAT
+         * @constant
+         * @type {Number}
          * @name pc.PIXELFORMAT_RGB32F
          * @description 32-bit floating point RGB (32-bit float for each red, green and blue channels).
          */
         PIXELFORMAT_RGB32F: 13,
         /**
-         * @enum pc.PIXELFORMAT
+         * @constant
+         * @type {Number}
          * @name pc.PIXELFORMAT_RGBA32F
          * @description 32-bit floating point RGBA (32-bit float for each red, green, blue and alpha channels).
          */
         PIXELFORMAT_RGBA32F: 14,
 
         /**
-         * @enum pc.PIXELFORMAT
+         * @constant
+         * @type {Number}
          * @name pc.PIXELFORMAT_R32F
          * @description 32-bit floating point single channel format (WebGL2 only).
          */
         PIXELFORMAT_R32F: 15,
 
         /**
-         * @enum pc.PIXELFORMAT
+         * @constant
+         * @type {Number}
          * @name pc.PIXELFORMAT_DEPTH
          * @description A readable depth buffer format
          */
         PIXELFORMAT_DEPTH: 16,
 
         /**
-         * @enum pc.PIXELFORMAT
+         * @constant
+         * @type {Number}
          * @name pc.PIXELFORMAT_DEPTHSTENCIL
          * @description A readable depth/stencil buffer format (WebGL2 only).
          */
         PIXELFORMAT_DEPTHSTENCIL: 17,
 
         /**
-         * @enum pc.PIXELFORMAT
+         * @constant
+         * @type {Number}
          * @name pc.PIXELFORMAT_111110F
          * @description A floating-point color-only format with 11 bits for red and green channels, and 10 bits for the blue channel (WebGL2 only).
          */
         PIXELFORMAT_111110F: 18,
 
         /**
-         * @enum pc.PIXELFORMAT
+         * @constant
+         * @type {Number}
          * @name pc.PIXELFORMAT_SRGB
          * @description Color-only sRGB format (WebGL2 only).
          */
         PIXELFORMAT_SRGB: 19,
 
         /**
-         * @enum pc.PIXELFORMAT
+         * @constant
+         * @type {Number}
          * @name pc.PIXELFORMAT_SRGBA
          * @description Color sRGB format with additional alpha channel (WebGL2 only).
          */
@@ -484,43 +554,50 @@
         // only add compressed formats next
 
         /**
-         * @enum pc.PRIMITIVE
+         * @constant
+         * @type {Number}
          * @name pc.PRIMITIVE_POINTS
          * @description List of distinct points.
          */
         PRIMITIVE_POINTS: 0,
         /**
-         * @enum pc.PRIMITIVE
+         * @constant
+         * @type {Number}
          * @name pc.PRIMITIVE_LINES
          * @description Discrete list of line segments.
          */
         PRIMITIVE_LINES: 1,
         /**
-         * @enum pc.PRIMITIVE
+         * @constant
+         * @type {Number}
          * @name pc.PRIMITIVE_LINELOOP
          * @description List of points that are linked sequentially by line segments, with a closing line segment between the last and first points.
          */
         PRIMITIVE_LINELOOP: 2,
         /**
-         * @enum pc.PRIMITIVE
+         * @constant
+         * @type {Number}
          * @name pc.PRIMITIVE_LINESTRIP
          * @description List of points that are linked sequentially by line segments.
          */
         PRIMITIVE_LINESTRIP: 3,
         /**
-         * @enum pc.PRIMITIVE
+         * @constant
+         * @type {Number}
          * @name pc.PRIMITIVE_TRIANGLES
          * @description Discrete list of triangles.
          */
         PRIMITIVE_TRIANGLES: 4,
         /**
-         * @enum pc.PRIMITIVE
+         * @constant
+         * @type {Number}
          * @name pc.PRIMITIVE_TRISTRIP
          * @description Connected strip of triangles where a specified vertex forms a triangle using the previous two.
          */
         PRIMITIVE_TRISTRIP: 5,
         /**
-         * @enum pc.PRIMITIVE
+         * @constant
+         * @type {Number}
          * @name pc.PRIMITIVE_TRIFAN
          * @description Connected fan of triangles where the first vertex forms triangles with the following pairs of vertices.
          */
@@ -749,13 +826,15 @@
         STENCILOP_INVERT: 7,
 
         /**
-         * @enum pc.TEXTURELOCK
+         * @constant
+         * @type {Number}
          * @name pc.TEXTURELOCK_READ
          * @description Read only. Any changes to the locked mip level's pixels will not update the texture.
          */
         TEXTURELOCK_READ: 1,
         /**
-         * @enum pc.TEXTURELOCK
+         * @constant
+         * @type {Number}
          * @name pc.TEXTURELOCK_WRITE
          * @description Write only. The contents of the specified mip level will be entirely replaced.
          */

--- a/src/graphics/graphics.js
+++ b/src/graphics/graphics.js
@@ -2,24 +2,21 @@
     // Graphics engine enums
     var enums = {
         /**
-         * @static
-         * @readonly
+         * @constant
          * @type Number
          * @name pc.ADDRESS_REPEAT
          * @description Ignores the integer part of texture coordinates, using only the fractional part.
          */
         ADDRESS_REPEAT: 0,
         /**
-         * @static
-         * @readonly
+         * @constant
          * @type Number
          * @name pc.ADDRESS_CLAMP_TO_EDGE
          * @description Clamps texture coordinate to the range 0 to 1.
          */
         ADDRESS_CLAMP_TO_EDGE: 1,
         /**
-         * @static
-         * @readonly
+         * @constant
          * @type Number
          * @name pc.ADDRESS_MIRRORED_REPEAT
          * @description Texture coordinate to be set to the fractional part if the integer part is even; if the integer part is odd,

--- a/src/input/input.js
+++ b/src/input/input.js
@@ -14,63 +14,73 @@
         AXIS_KEY: 'key',
 
         /**
-         * @enum pc.EVENT
+         * @constant
+         * @type {String}
          * @name pc.EVENT_KEYDOWN
          * @description Name of event fired when a key is pressed
          */
         EVENT_KEYDOWN: 'keydown',
         /**
-         * @enum pc.EVENT
+         * @constant
+         * @type {String}
          * @name pc.EVENT_KEYUP
          * @description Name of event fired when a key is released
          */
         EVENT_KEYUP: 'keyup',
 
         /**
-         * @enum pc.EVENT
+         * @constant
+         * @type {String}
          * @name pc.EVENT_MOUSEDOWN
          * @description Name of event fired when a mouse button is pressed
          */
         EVENT_MOUSEDOWN: "mousedown",
         /**
-         * @enum pc.EVENT
+         * @constant
+         * @type {String}
          * @name pc.EVENT_MOUSEMOVE
          * @description Name of event fired when the mouse is moved
          */
         EVENT_MOUSEMOVE: "mousemove",
         /**
-         * @enum pc.EVENT
+         * @constant
+         * @type {String}
          * @name pc.EVENT_MOUSEUP
          * @description Name of event fired when a mouse button is released
          */
         EVENT_MOUSEUP: "mouseup",
         /**
-         * @enum pc.EVENT
+         * @constant
+         * @type {String}
          * @name pc.EVENT_MOUSEWHEEL
          * @description Name of event fired when the mouse wheel is rotated
          */
         EVENT_MOUSEWHEEL: "mousewheel",
 
         /**
-         * @enum pc.EVENT
+         * @constant
+         * @type {String}
          * @name pc.EVENT_TOUCHSTART
          * @description Name of event fired when a new touch occurs. For example, a finger is placed on the device.
          */
         EVENT_TOUCHSTART: 'touchstart',
         /**
-         * @enum pc.EVENT
+         * @constant
+         * @type {String}
          * @name pc.EVENT_TOUCHEND
          * @description Name of event fired when touch ends. For example, a finger is lifted off the device.
          */
         EVENT_TOUCHEND: 'touchend',
         /**
-         * @enum pc.EVENT
+         * @constant
+         * @type {String}
          * @name pc.EVENT_TOUCHMOVE
          * @description Name of event fired when a touch moves.
          */
         EVENT_TOUCHMOVE: 'touchmove',
         /**
-         * @enum pc.EVENT
+         * @constant
+         * @type {String}
          * @name pc.EVENT_TOUCHCANCEL
          * @description Name of event fired when a touch point is interrupted in some way.
          * The exact reasons for cancelling a touch can vary from device to device.

--- a/src/input/input.js
+++ b/src/input/input.js
@@ -90,678 +90,804 @@
         EVENT_TOUCHCANCEL: 'touchcancel',
 
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_BACKSPACE
          */
         KEY_BACKSPACE: 8,
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_TAB
          */
         KEY_TAB: 9,
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_RETURN
          */
         KEY_RETURN: 13,
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_ENTER
          */
         KEY_ENTER: 13,
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_SHIFT
          */
         KEY_SHIFT: 16,
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_CONTROL
          */
         KEY_CONTROL: 17,
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_ALT
          */
         KEY_ALT: 18,
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_PAUSE
          */
         KEY_PAUSE: 19,
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_CAPS_LOCK
          */
         KEY_CAPS_LOCK: 20,
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_ESCAPE
          */
         KEY_ESCAPE: 27,
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_SPACE
          */
         KEY_SPACE: 32,
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_PAGE_UP
          */
         KEY_PAGE_UP: 33,
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_PAGE_DOWN
          */
         KEY_PAGE_DOWN: 34,
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_END
          */
         KEY_END: 35,
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_HOME
          */
         KEY_HOME: 36,
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_LEFT
          */
         KEY_LEFT: 37,
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_UP
          */
         KEY_UP: 38,
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_RIGHT
          */
         KEY_RIGHT: 39,
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_DOWN
          */
         KEY_DOWN: 40,
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_PRINT_SCREEN
          */
         KEY_PRINT_SCREEN: 44,
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_INSERT
          */
         KEY_INSERT: 45,
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_DELETE
          */
         KEY_DELETE: 46,
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_0
          */
         KEY_0: 48,
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_1
          */
         KEY_1: 49,
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_2
          */
         KEY_2: 50,
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_3
          */
         KEY_3: 51,
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_4
          */
         KEY_4: 52,
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_5
          */
         KEY_5: 53,
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_6
          */
         KEY_6: 54,
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_7
          */
         KEY_7: 55,
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_8
          */
         KEY_8: 56,
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_9
          */
         KEY_9: 57,
 
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_SEMICOLON
          */
         KEY_SEMICOLON: 59,
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_EQUAL
          */
         KEY_EQUAL: 61,
 
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_A
          */
         KEY_A: 65,
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_B
          */
         KEY_B: 66,
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_C
          */
         KEY_C: 67,
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_D
          */
         KEY_D: 68,
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_E
          */
         KEY_E: 69,
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_F
          */
         KEY_F: 70,
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_G
          */
         KEY_G: 71,
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_H
          */
         KEY_H: 72,
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_I
          */
         KEY_I: 73,
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_J
          */
         KEY_J: 74,
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_K
          */
         KEY_K: 75,
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_L
          */
         KEY_L: 76,
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_M
          */
         KEY_M: 77,
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_N
          */
         KEY_N: 78,
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_O
          */
         KEY_O: 79,
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_P
          */
         KEY_P: 80,
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_Q
          */
         KEY_Q: 81,
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_R
          */
         KEY_R: 82,
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_S
          */
         KEY_S: 83,
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_T
          */
         KEY_T: 84,
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_U
          */
         KEY_U: 85,
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_V
          */
         KEY_V: 86,
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_W
          */
         KEY_W: 87,
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_X
          */
         KEY_X: 88,
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_Y
          */
         KEY_Y: 89,
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_Z
          */
         KEY_Z: 90,
 
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_WINDOWS
          */
         KEY_WINDOWS: 91,
 
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_CONTEXT_MENU
          */
         KEY_CONTEXT_MENU: 93,
 
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_NUMPAD_0
          */
         KEY_NUMPAD_0: 96,
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_NUMPAD_1
          */
         KEY_NUMPAD_1: 97,
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_NUMPAD_2
          */
         KEY_NUMPAD_2: 98,
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_NUMPAD_3
          */
         KEY_NUMPAD_3: 99,
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_NUMPAD_4
          */
         KEY_NUMPAD_4: 100,
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_NUMPAD_5
          */
         KEY_NUMPAD_5: 101,
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_NUMPAD_6
          */
         KEY_NUMPAD_6: 102,
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_NUMPAD_7
          */
         KEY_NUMPAD_7: 103,
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_NUMPAD_8
          */
         KEY_NUMPAD_8: 104,
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_NUMPAD_9
          */
         KEY_NUMPAD_9: 105,
 
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_MULTIPLY
          */
         KEY_MULTIPLY: 106,
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_ADD
          */
         KEY_ADD: 107,
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_SEPARATOR
          */
         KEY_SEPARATOR: 108,
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_SUBTRACT
          */
         KEY_SUBTRACT: 109,
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_DECIMAL
          */
         KEY_DECIMAL: 110,
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_DIVIDE
          */
         KEY_DIVIDE: 111,
 
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_F1
          */
         KEY_F1: 112,
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_F2
          */
         KEY_F2: 113,
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_F3
          */
         KEY_F3: 114,
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_F4
          */
         KEY_F4: 115,
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_F5
          */
         KEY_F5: 116,
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_F6
          */
         KEY_F6: 117,
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_F7
          */
         KEY_F7: 118,
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_F8
          */
         KEY_F8: 119,
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_F9
          */
         KEY_F9: 120,
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_F10
          */
         KEY_F10: 121,
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_F11
          */
         KEY_F11: 122,
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_F12
          */
         KEY_F12: 123,
 
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_COMMA
          */
         KEY_COMMA: 188,
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_PERIOD
          */
         KEY_PERIOD: 190,
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_SLASH
          */
         KEY_SLASH: 191,
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_OPEN_BRACKET
          */
         KEY_OPEN_BRACKET: 219,
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_BACK_SLASH
          */
         KEY_BACK_SLASH: 220,
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_CLOSE_BRACKET
          */
         KEY_CLOSE_BRACKET: 221,
 
         /**
-         * @enum pc.KEY
+         * @constant
+         * @type {Number}
          * @name pc.KEY_META
          */
         KEY_META: 224,
 
         /**
-         * @enum pc.MOUSEBUTTON
+         * @constant
+         * @type {Number}
          * @name pc.MOUSEBUTTON_NONE
          * @description No mouse buttons pressed
          */
         MOUSEBUTTON_NONE: -1,
         /**
-         * @enum pc.MOUSEBUTTON
+         * @constant
+         * @type {Number}
          * @name pc.MOUSEBUTTON_LEFT
          * @description The left mouse button
          */
         MOUSEBUTTON_LEFT: 0,
         /**
-         * @enum pc.MOUSEBUTTON
+         * @constant
+         * @type {Number}
          * @name pc.MOUSEBUTTON_MIDDLE
          * @description The middle mouse button
          */
         MOUSEBUTTON_MIDDLE: 1,
         /**
-         * @enum pc.MOUSEBUTTON
+         * @constant
+         * @type {Number}
          * @name pc.MOUSEBUTTON_RIGHT
          * @description The right mouse button
          */
         MOUSEBUTTON_RIGHT: 2,
 
         /**
-         * @enum pc.PAD
+         * @constant
+         * @type {Number}
          * @name pc.PAD_1
          * @description Index for pad 1
          */
         PAD_1: 0,
         /**
-         * @enum pc.PAD
+         * @constant
+         * @type {Number}
          * @name pc.PAD_2
          * @description Index for pad 2
          */
         PAD_2: 1,
         /**
-         * @enum pc.PAD
+         * @constant
+         * @type {Number}
          * @name pc.PAD_3
          * @description Index for pad 3
          */
         PAD_3: 2,
         /**
-         * @enum pc.PAD
+         * @constant
+         * @type {Number}
          * @name pc.PAD_4
          * @description Index for pad 4
          */
         PAD_4: 3,
 
         /**
-         * @enum pc.PAD
+         * @constant
+         * @type {Number}
          * @name pc.PAD_FACE_1
          * @description The first face button, from bottom going clockwise
          */
         PAD_FACE_1: 0,
         /**
-         * @enum pc.PAD
+         * @constant
+         * @type {Number}
          * @name pc.PAD_FACE_2
          * @description The second face button, from bottom going clockwise
          */
         PAD_FACE_2: 1,
         /**
-         * @enum pc.PAD
+         * @constant
+         * @type {Number}
          * @name pc.PAD_FACE_3
          * @description The third face button, from bottom going clockwise
          */
         PAD_FACE_3: 2,
         /**
-         * @enum pc.PAD
+         * @constant
+         * @type {Number}
          * @name pc.PAD_FACE_4
          * @description The fourth face button, from bottom going clockwise
          */
         PAD_FACE_4: 3,
 
         /**
-         * @enum pc.PAD
+         * @constant
+         * @type {Number}
          * @name pc.PAD_L_SHOULDER_1
          * @description The first shoulder button on the left
          */
         PAD_L_SHOULDER_1: 4,
         /**
-         * @enum pc.PAD
+         * @constant
+         * @type {Number}
          * @name pc.PAD_R_SHOULDER_1
          * @description The first shoulder button on the right
          */
         PAD_R_SHOULDER_1: 5,
         /**
-         * @enum pc.PAD
+         * @constant
+         * @type {Number}
          * @name pc.PAD_L_SHOULDER_2
          * @description The second shoulder button on the left
          */
         PAD_L_SHOULDER_2: 6,
         /**
-         * @enum pc.PAD
+         * @constant
+         * @type {Number}
          * @name pc.PAD_R_SHOULDER_2
          * @description The second shoulder button on the right
          */
         PAD_R_SHOULDER_2: 7,
 
         /**
-         * @enum pc.PAD
+         * @constant
+         * @type {Number}
          * @name pc.PAD_SELECT
          * @description The select button
          */
         PAD_SELECT: 8,
         /**
-         * @enum pc.PAD
+         * @constant
+         * @type {Number}
          * @name pc.PAD_START
          * @description The start button
          */
         PAD_START: 9,
 
         /**
-         * @enum pc.PAD
+         * @constant
+         * @type {Number}
          * @name pc.PAD_L_STICK_BUTTON
          * @description The button when depressing the left analogue stick
          */
         PAD_L_STICK_BUTTON: 10,
         /**
-         * @enum pc.PAD
+         * @constant
+         * @type {Number}
          * @name pc.PAD_R_STICK_BUTTON
          * @description The button when depressing the right analogue stick
          */
         PAD_R_STICK_BUTTON: 11,
 
         /**
-         * @enum pc.PAD
+         * @constant
+         * @type {Number}
          * @name pc.PAD_UP
          * @description Direction pad up
          */
         PAD_UP: 12,
         /**
-         * @enum pc.PAD
+         * @constant
+         * @type {Number}
          * @name pc.PAD_DOWN
          * @description Direction pad down
          */
         PAD_DOWN: 13,
         /**
-         * @enum pc.PAD
+         * @constant
+         * @type {Number}
          * @name pc.PAD_LEFT
          * @description Direction pad left
          */
         PAD_LEFT: 14,
         /**
-         * @enum pc.PAD
+         * @constant
+         * @type {Number}
          * @name pc.PAD_RIGHT
          * @description Direction pad right
          */
         PAD_RIGHT: 15,
 
         /**
-         * @enum pc.PAD
+         * @constant
+         * @type {Number}
          * @name pc.PAD_VENDOR
          * @description Vendor specific button
          */
         PAD_VENDOR: 16,
 
         /**
-         * @enum pc.PAD
+         * @constant
+         * @type {Number}
          * @name pc.PAD_L_STICK_X
          * @description Horizontal axis on the left analogue stick
          */
         PAD_L_STICK_X: 0,
         /**
-         * @enum pc.PAD
+         * @constant
+         * @type {Number}
          * @name pc.PAD_L_STICK_Y
          * @description Vertical axis on the left analogue stick
          */
         PAD_L_STICK_Y: 1,
         /**
-         * @enum pc.PAD
+         * @constant
+         * @type {Number}
          * @name pc.PAD_R_STICK_X
          * @description Horizontal axis on the right analogue stick
          */
         PAD_R_STICK_X: 2,
         /**
-         * @enum pc.PAD
+         * @constant
+         * @type {Number}
          * @name pc.PAD_R_STICK_Y
          * @description Vertical axis on the right analogue stick
          */

--- a/src/math/curve.js
+++ b/src/math/curve.js
@@ -2,39 +2,45 @@ Object.assign(pc, (function () {
     'use strict';
 
     /**
-     * @enum pc.CURVE
+     * @constant
+     * @type {Number}
      * @name pc.CURVE_LINEAR
      * @description A linear interpolation scheme.
      */
     var CURVE_LINEAR = 0;
     /**
-     * @enum pc.CURVE
+     * @constant
+     * @type {Number}
      * @name pc.CURVE_SMOOTHSTEP
      * @description A smooth step interpolation scheme.
      */
     var CURVE_SMOOTHSTEP = 1;
     /**
      * @deprecated
-     * @enum pc.CURVE
+     * @constant
+     * @type {Number}
      * @name pc.CURVE_CATMULL
      * @description A Catmull-Rom spline interpolation scheme. This interpolation scheme is deprecated. Use CURVE_SPLINE instead.
      */
     var CURVE_CATMULL = 2;
     /**
      * @deprecated
-     * @enum pc.CURVE
+     * @constant
+     * @type {Number}
      * @name pc.CURVE_CARDINAL
      * @description A cardinal spline interpolation scheme. This interpolation scheme is deprecated. Use CURVE_SPLINE instead.
      */
     var CURVE_CARDINAL = 3;
     /**
-     * @enum pc.CURVE
+     * @constant
+     * @type {Number}
      * @name pc.CURVE_SPLINE
      * @description Cardinal spline interpolation scheme. For Catmull-Rom, specify curve tension 0.5.
      */
     var CURVE_SPLINE = 4;
     /**
-     * @enum pc.CURVE
+     * @constant
+     * @type {Number}
      * @name pc.CURVE_STEP
      * @description A stepped interpolater, free from the shackles of blending.
      */

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -2,21 +2,24 @@
     // Scene API enums
     var enums = {
         /**
-         * @enum pc.BLEND
+         * @constant
+         * @type {Number}
          * @name pc.BLEND_SUBTRACTIVE
          * @description Subtract the color of the source fragment from the destination fragment
          * and write the result to the frame buffer.
          */
         BLEND_SUBTRACTIVE: 0,
         /**
-         * @enum pc.BLEND
+         * @constant
+         * @type {Number}
          * @name pc.BLEND_ADDITIVE
          * @description Add the color of the source fragment to the destination fragment
          * and write the result to the frame buffer.
          */
         BLEND_ADDITIVE: 1,
         /**
-         * @enum pc.BLEND
+         * @constant
+         * @type {Number}
          * @name pc.BLEND_NORMAL
          * @description Enable simple translucency for materials such as glass. This is
          * equivalent to enabling a source blend mode of pc.BLENDMODE_SRC_ALPHA and a destination
@@ -24,55 +27,63 @@
          */
         BLEND_NORMAL: 2,
         /**
-         * @enum pc.BLEND
+         * @constant
+         * @type {Number}
          * @name pc.BLEND_NONE
          * @description Disable blending.
          */
         BLEND_NONE: 3,
         /**
-         * @enum pc.BLEND
+         * @constant
+         * @type {Number}
          * @name pc.BLEND_PREMULTIPLIED
          * @description Similar to pc.BLEND_NORMAL expect the source fragment is assumed to have
          * already been multiplied by the source alpha value.
          */
         BLEND_PREMULTIPLIED: 4,
         /**
-         * @enum pc.BLEND
+         * @constant
+         * @type {Number}
          * @name pc.BLEND_MULTIPLICATIVE
          * @description Multiply the color of the source fragment by the color of the destination
          * fragment and write the result to the frame buffer.
          */
         BLEND_MULTIPLICATIVE: 5,
         /**
-         * @enum pc.BLEND
+         * @constant
+         * @type {Number}
          * @name pc.BLEND_ADDITIVEALPHA
          * @description Same as pc.BLEND_ADDITIVE except the source RGB is multiplied by the source alpha.
          */
         BLEND_ADDITIVEALPHA: 6,
 
         /**
-         * @enum pc.BLEND
+         * @constant
+         * @type {Number}
          * @name pc.BLEND_MULTIPLICATIVE2X
          * @description Multiplies colors and doubles the result
          */
         BLEND_MULTIPLICATIVE2X: 7,
 
         /**
-         * @enum pc.BLEND
+         * @constant
+         * @type {Number}
          * @name pc.BLEND_SCREEN
          * @description Softer version of additive
          */
         BLEND_SCREEN: 8,
 
         /**
-         * @enum pc.BLEND
+         * @constant
+         * @type {Number}
          * @name pc.BLEND_MIN
          * @description Minimum color. Check app.graphicsDevice.extBlendMinmax for support.
          */
         BLEND_MIN: 9,
 
         /**
-         * @enum pc.BLEND
+         * @constant
+         * @type {Number}
          * @name pc.BLEND_MAX
          * @description Maximum color. Check app.graphicsDevice.extBlendMinmax for support.
          */
@@ -119,50 +130,58 @@
 
         // New layers
         /**
-         * @enum pc.LAYERID
+         * @constant
+         * @type {Number}
          * @name pc.LAYERID_WORLD
          * @description The world layer.
          */
         LAYERID_WORLD: 0,
         /**
-         * @enum pc.LAYERID
+         * @constant
+         * @type {Number}
          * @name pc.LAYERID_DEPTH
          * @description The depth layer.
          */
         LAYERID_DEPTH: 1,
         /**
-         * @enum pc.LAYERID
+         * @constant
+         * @type {Number}
          * @name pc.LAYERID_SKYBOX
          * @description The skybox layer.
          */
         LAYERID_SKYBOX: 2,
         /**
-         * @enum pc.LAYERID
+         * @constant
+         * @type {Number}
          * @name pc.LAYERID_IMMEDIATE
          * @description The immediate layer.
          */
         LAYERID_IMMEDIATE: 3,
         /**
-         * @enum pc.LAYERID
+         * @constant
+         * @type {Number}
          * @name pc.LAYERID_UI
          * @description The UI layer.
          */
         LAYERID_UI: 4,
 
         /**
-         * @enum pc.LIGHTTYPE
+         * @constant
+         * @type {Number}
          * @name pc.LIGHTTYPE_DIRECTIONAL
          * @description Directional (global) light source.
          */
         LIGHTTYPE_DIRECTIONAL: 0,
         /**
-         * @enum pc.LIGHTTYPE
+         * @constant
+         * @type {Number}
          * @name pc.LIGHTTYPE_POINT
          * @description Point (local) light source.
          */
         LIGHTTYPE_POINT: 1,
         /**
-         * @enum pc.LIGHTTYPE
+         * @constant
+         * @type {Number}
          * @name pc.LIGHTTYPE_SPOT
          * @description Spot (local) light source.
          */
@@ -194,13 +213,15 @@
         PARTICLEORIENTATION_EMITTER: 2,
 
         /**
-         * @enum pc.PROJECTION
+         * @constant
+         * @type {Number}
          * @name pc.PROJECTION_PERSPECTIVE
          * @description A perspective camera projection where the frustum shape is essentially pyramidal.
          */
         PROJECTION_PERSPECTIVE: 0,
         /**
-         * @enum pc.PROJECTION
+         * @constant
+         * @type {Number}
          * @name pc.PROJECTION_ORTHOGRAPHIC
          * @description An orthographic camera projection where the frustum shape is essentially a cuboid.
          */
@@ -258,21 +279,24 @@
         MASK_LIGHTMAP: 4,
 
         /**
-         * @enum pc.SHADER
+         * @constant
+         * @type {Number}
          * @name pc.SHADER_FORWARD
          * @description Render shaded materials with gamma correction and tonemapping.
          */
         SHADER_FORWARD: 0,
 
         /**
-         * @enum pc.SHADER
+         * @constant
+         * @type {Number}
          * @name pc.SHADER_FORWARD
          * @description Render shaded materials without gamma correction and tonemapping.
          */
         SHADER_FORWARDHDR: 1,
 
         /**
-         * @enum pc.SHADER
+         * @constant
+         * @type {Number}
          * @name pc.SHADER_FORWARD
          * @description Render RGBA-encoded depth value.
          */
@@ -304,35 +328,40 @@
         VIEW_RIGHT: 2,
 
         /**
-         * @enum pc.SORTMODE
+         * @constant
+         * @type {Number}
          * @name pc.SORTMODE_NONE
          * @description No sorting is applied. Mesh instances are rendered in the same order they were added to a layer.
          */
         SORTMODE_NONE: 0,
 
         /**
-         * @enum pc.SORTMODE
+         * @constant
+         * @type {Number}
          * @name pc.SORTMODE_MANUAL
          * @description Mesh instances are sorted based on {@link pc.MeshInstance#drawOrder}.
          */
         SORTMODE_MANUAL: 1,
 
         /**
-         * @enum pc.SORTMODE
+         * @constant
+         * @type {Number}
          * @name pc.SORTMODE_MATERIALMESH
          * @description Mesh instances are sorted to minimize switching between materials and meshes to improve rendering performance.
          */
         SORTMODE_MATERIALMESH: 2,
 
         /**
-         * @enum pc.SORTMODE
+         * @constant
+         * @type {Number}
          * @name pc.SORTMODE_BACK2FRONT
          * @description Mesh instances are sorted back to front. This is the way to properly render many semi-transparent objects on different depth, one is blended on top of another.
          */
         SORTMODE_BACK2FRONT: 3,
 
         /**
-         * @enum pc.SORTMODE
+         * @constant
+         * @type {Number}
          * @name pc.SORTMODE_FRONT2BACK
          * @description Mesh instances are sorted front to back. Depending on GPU and the scene, this option may give better performance than pc.SORTMODE_MATERIALMESH due to reduced overdraw.
          */
@@ -340,7 +369,8 @@
 
         /**
          * @private
-         * @enum pc.SORTMODE
+         * @constant
+         * @type {Number}
          * @name  pc.SORTMODE_CUSTOM
          * @description Provide custom functions for sorting drawcalls and calculating distance
          */
@@ -355,13 +385,15 @@
         ASPECT_MANUAL: 1,
 
         /**
-         * @enum pc.ORIENTATION
+         * @constant
+         * @type {Number}
          * @name pc.ORIENTATION_HORIZONTAL
          * @description Horizontal orientation.
          */
         ORIENTATION_HORIZONTAL: 0,
         /**
-         * @enum pc.ORIENTATION
+         * @constant
+         * @type {Number}
          * @name pc.ORIENTATION_VERTICAL
          * @description Vertical orientation.
          */

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -79,25 +79,29 @@
         BLEND_MAX: 10,
 
         /**
-         * @enum pc.FOG
+         * @constant
+         * @type {String}
          * @name pc.FOG_NONE
          * @description No fog is applied to the scene.
          */
         FOG_NONE: 'none',
         /**
-         * @enum pc.FOG
+         * @constant
+         * @type {String}
          * @name pc.FOG_LINEAR
          * @description Fog rises linearly from zero to 1 between a start and end depth.
          */
         FOG_LINEAR: 'linear',
         /**
-         * @enum pc.FOG
+         * @constant
+         * @type {String}
          * @name pc.FOG_EXP
          * @description Fog rises according to an exponential curve controlled by a density value.
          */
         FOG_EXP: 'exp',
         /**
-         * @enum pc.FOG
+         * @constant
+         * @type {String}
          * @name pc.FOG_EXP2
          * @description Fog rises according to an exponential curve controlled by a density value.
          */

--- a/src/scene/sprite.js
+++ b/src/scene/sprite.js
@@ -2,14 +2,16 @@ Object.assign(pc, function () {
     'use strict';
 
     /**
-     * @enum pc.SPRITE_RENDERMODE
+     * @constant
+     * @type {Number}
      * @name pc.SPRITE_RENDERMODE_SIMPLE
      * @description This mode renders a sprite as a simple quad.
      */
     pc.SPRITE_RENDERMODE_SIMPLE = 0;
 
     /**
-     * @enum pc.SPRITE_RENDERMODE
+     * @constant
+     * @type {Number}
      * @name pc.SPRITE_RENDERMODE_SLICED
      * @description This mode renders a sprite using 9-slicing in 'sliced' mode. Sliced mode stretches the
      * top and bottom regions of the sprite horizontally, the left and right regions vertically and the middle region
@@ -18,7 +20,8 @@ Object.assign(pc, function () {
     pc.SPRITE_RENDERMODE_SLICED = 1;
 
     /**
-     * @enum pc.SPRITE_RENDERMODE
+     * @constant
+     * @type {Number}
      * @name pc.SPRITE_RENDERMODE_TILED
      * @description This mode renders a sprite using 9-slicing in 'tiled' mode. Tiled mode tiles the
      * top and bottom regions of the sprite horizontally, the left and right regions vertically and the middle region


### PR DESCRIPTION
Fixes #1661

PR only changes jsdoc comments and only for constants: 
- Replace `@enum` tags (with `@constant` and `@type`).
- Replace `@static` (and `@readonly`) with `@constant` (for consistency).

(The jsdoc `html` output is basically unchanged, some mentions of the keyword `@static` are just changed to `@constant`.) 

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
