### PR TITLE
[DOC] Minor jsdoc fixes and improvements

### DIFF
--- a/src/asset/asset-reference.js
+++ b/src/asset/asset-reference.js
@@ -1,5 +1,6 @@
 Object.assign(pc, function () {
     /**
+     * @constructor
      * @name pc.AssetReference
      * @description An object that manages the case where an object holds a reference to an asset and needs to be notified when
      * changes occur in the asset. e.g. notifications include load, add and remove events.

--- a/src/core/tags.js
+++ b/src/core/tags.js
@@ -146,8 +146,9 @@ Object.assign(pc, (function () {
 
 
     /**
+     * @constructor
      * @name pc.Tags
-     * @class Set of tag names
+     * @classdesc Set of tag names
      * @description Create an instance of a Tags.
      * @param {Object} [parent] Parent object who tags belong to.
      * Note: Tags are used as addition of `pc.Entity` and `pc.Asset` as `tags` field.

--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -1,7 +1,8 @@
 Object.assign(pc, function () {
     /**
+     * @constrcutor
      * @name pc.Application
-     * @class Default application which performs general setup code and initiates the main game loop.
+     * @classdec Default application which performs general setup code and initiates the main game loop.
      * @description Create a new Application.
      * @param {Element} canvas The canvas element
      * @param {Object} options

--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -1,6 +1,6 @@
 Object.assign(pc, function () {
     /**
-     * @constrcutor
+     * @constructor
      * @name pc.Application
      * @classdec Default application which performs general setup code and initiates the main game loop.
      * @description Create a new Application.

--- a/src/framework/components/script/component.js
+++ b/src/framework/components/script/component.js
@@ -1,8 +1,9 @@
 Object.assign(pc, function () {
     /**
      * @component
+     * @constructor
      * @name pc.ScriptComponent
-     * @class The ScriptComponent allows you to extend the functionality of an Entity by attaching your own Script Types defined in JavaScript files
+     * @classdesc The ScriptComponent allows you to extend the functionality of an Entity by attaching your own Script Types defined in JavaScript files
      * to be executed with access to the Entity. For more details on scripting see <a href="//developer.playcanvas.com/user-manual/scripting/">Scripting</a>.
      * @param {pc.ScriptComponentSystem} system The ComponentSystem that created this Component
      * @param {pc.Entity} entity The Entity that this Component is attached to.

--- a/src/framework/components/script/component.js
+++ b/src/framework/components/script/component.js
@@ -3,6 +3,7 @@ Object.assign(pc, function () {
      * @component
      * @constructor
      * @name pc.ScriptComponent
+     * @extends pc.Component
      * @classdesc The ScriptComponent allows you to extend the functionality of an Entity by attaching your own Script Types defined in JavaScript files
      * to be executed with access to the Entity. For more details on scripting see <a href="//developer.playcanvas.com/user-manual/scripting/">Scripting</a>.
      * @param {pc.ScriptComponentSystem} system The ComponentSystem that created this Component

--- a/src/framework/components/script/system.js
+++ b/src/framework/components/script/system.js
@@ -15,13 +15,13 @@ Object.assign(pc, function () {
     var executionOrderCounter = 0;
 
     /**
+     * @constructor
      * @name pc.ScriptComponentSystem
      * @description Create a new ScriptComponentSystem
-     * @class Allows scripts to be attached to an Entity and executed
+     * @classdesc Allows scripts to be attached to an Entity and executed
      * @param {pc.Application} app The application
      * @extends pc.ComponentSystem
      */
-
     var ScriptComponentSystem = function ScriptComponentSystem(app) {
         pc.ComponentSystem.call(this, app);
 

--- a/src/framework/components/zone/component.js
+++ b/src/framework/components/zone/component.js
@@ -2,9 +2,10 @@ Object.assign(pc, function () {
     /**
      * @private
      * @component
+     * @constrcutor
      * @name pc.ZoneComponent
      * @extends pc.Component
-     * @class The ZoneComponent allows you to define an area in world space of certain size.
+     * @classdesc The ZoneComponent allows you to define an area in world space of certain size.
      * This can be used in various ways, such as affecting audio reverb when audiolistener is within zone.
      * Or create culling system with portals between zones to hide whole indoor sections for performance reasons.
      * And many other possible options. Zones are building blocks and meant to be used in many different ways.

--- a/src/framework/components/zone/component.js
+++ b/src/framework/components/zone/component.js
@@ -2,7 +2,7 @@ Object.assign(pc, function () {
     /**
      * @private
      * @component
-     * @constrcutor
+     * @constructor
      * @name pc.ZoneComponent
      * @extends pc.Component
      * @classdesc The ZoneComponent allows you to define an area in world space of certain size.

--- a/src/framework/utils/entity-reference.js
+++ b/src/framework/utils/entity-reference.js
@@ -1,6 +1,7 @@
 Object.assign(pc, function () {
     /**
      * @private
+     * @constructor
      * @name pc.EntityReference
      * @description Helper class used for managing component properties that represent entity references.
      * @classdesc An EntityReference can be used in scenarios where a component has one or more properties that

--- a/src/framework/utils/sorted-loop-array.js
+++ b/src/framework/utils/sorted-loop-array.js
@@ -3,8 +3,9 @@ Object.assign(pc, function () {
 
     /**
     * @private
+    * @constructor
     * @name pc.SortedLoopArray
-    * @class Helper class used to hold an array of items in a specific order. This array is safe to modify
+    * @classdesc Helper class used to hold an array of items in a specific order. This array is safe to modify
     * while we loop through it. The class assumes that it holds objects that need to be sorted based on
     * one of their fields.
     * @param {Object} args Arguments


### PR DESCRIPTION
PR changes only the following jsdoc comments:
- Fixes missing `@constructor` tags for `pc.AssetReference` and `pc.EntityReference`.
- Replaced `@class` tags (with `@constructor`) for jsdoc consistency.
- Added missing `@extends` tag for `pc.ScriptComponent`. 

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
