### PR TITLE
[DOC] Fix missing type in Vec2/3/4/Quat/Color constructors

### DIFF
--- a/src/core/color.js
+++ b/src/core/color.js
@@ -4,7 +4,7 @@ Object.assign(pc, (function () {
      * @name pc.Color
      * @classdesc Representation of an RGBA color
      * @description Create a new Color object
-     * @param {Number} [r] The value of the red component (0-1). If r is an array of length 3 or 4, the array will be used to populate all components.
+     * @param {Number|Number[]} [r] The value of the red component (0-1). If r is an array of length 3 or 4, the array will be used to populate all components.
      * @param {Number} [g] The value of the green component (0-1)
      * @param {Number} [b] The value of the blue component (0-1)
      * @param {Number} [a] The value of the alpha component (0-1)

--- a/src/math/quat.js
+++ b/src/math/quat.js
@@ -6,7 +6,7 @@ Object.assign(pc, (function () {
      * @name pc.Quat
      * @classdesc A quaternion.
      * @description Create a new Quat object.
-     * @param {Number} [x] The quaternion's x component. Default value 0. If x is an array of length 4, the array will be used to populate all components.
+     * @param {Number|Number[]} [x] The quaternion's x component. Default value 0. If x is an array of length 4, the array will be used to populate all components.
      * @param {Number} [y] The quaternion's y component. Default value 0.
      * @param {Number} [z] The quaternion's z component. Default value 0.
      * @param {Number} [w] The quaternion's w component. Default value 1.

--- a/src/math/vec2.js
+++ b/src/math/vec2.js
@@ -6,7 +6,7 @@ Object.assign(pc, (function () {
      * @name pc.Vec2
      * @classdesc A 2-dimensional vector.
      * @description Creates a new Vec2 object.
-     * @param {Number} [x] The x value. If x is an array of length 2, the array will be used to populate all components.
+     * @param {Number|Number[]} [x] The x value. If x is an array of length 2, the array will be used to populate all components.
      * @param {Number} [y] The y value.
      * @example
      * var v = new pc.Vec2(1, 2);

--- a/src/math/vec3.js
+++ b/src/math/vec3.js
@@ -6,7 +6,7 @@ Object.assign(pc, (function () {
      * @name pc.Vec3
      * @classdesc A 3-dimensional vector.
      * @description Creates a new Vec3 object.
-     * @param {Number} [x] The x value. If x is an array of length 3, the array will be used to populate all components.
+     * @param {Number|Number[]} [x] The x value. If x is an array of length 3, the array will be used to populate all components.
      * @param {Number} [y] The y value.
      * @param {Number} [z] The z value.
      * @example

--- a/src/math/vec4.js
+++ b/src/math/vec4.js
@@ -6,7 +6,7 @@ Object.assign(pc, (function () {
      * @name pc.Vec4
      * @classdesc A 4-dimensional vector.
      * @description Creates a new Vec4 object.
-     * @param {Number} [x] The x value. If x is an array of length 4, the array will be used to populate all components.
+     * @param {Number|Number[]} [x] The x value. If x is an array of length 4, the array will be used to populate all components.
      * @param {Number} [y] The y value.
      * @param {Number} [z] The z value.
      * @param {Number} [w] The w value.


### PR DESCRIPTION
PR adds missing type info for the first parameter in the constructors of `pc.Vec2`,  `pc.Vec3`,  `pc.Vec4`, `pc.Quat`, and `pc.Color`.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
