### PR TITLE
[DOC] add jsdoc documentation for lots of constants

### DIFF
--- a/src/framework/components/rigid-body/constants.js
+++ b/src/framework/components/rigid-body/constants.js
@@ -1,7 +1,25 @@
 Object.assign(pc, {
     // types
+    /**
+     * @constant
+     * @type {String}
+     * @name pc.BODYTYPE_STATIC
+     * @description 
+     */
     BODYTYPE_STATIC: 'static',
+    /**
+     * @constant
+     * @type {String}
+     * @name pc.BODYTYPE_DYNAMIC
+     * @description 
+     */
     BODYTYPE_DYNAMIC: 'dynamic',
+    /**
+     * @constant
+     * @type {String}
+     * @name pc.BODYTYPE_KINEMATIC
+     * @description 
+     */
     BODYTYPE_KINEMATIC: 'kinematic',
 
     // Collision flags

--- a/src/framework/components/rigid-body/constants.js
+++ b/src/framework/components/rigid-body/constants.js
@@ -4,21 +4,21 @@ Object.assign(pc, {
      * @constant
      * @type {String}
      * @name pc.BODYTYPE_STATIC
-     * @description 
+     * @description Rigid body has infinite mass and cannot move.
      */
     BODYTYPE_STATIC: 'static',
     /**
      * @constant
      * @type {String}
      * @name pc.BODYTYPE_DYNAMIC
-     * @description 
+     * @description Rigid body is simulated according to applied forces.
      */
     BODYTYPE_DYNAMIC: 'dynamic',
     /**
      * @constant
      * @type {String}
      * @name pc.BODYTYPE_KINEMATIC
-     * @description 
+     * @description Rigid body has infinite mass and does not respond to forces but can still be moved by setting their velocity or position.
      */
     BODYTYPE_KINEMATIC: 'kinematic',
 

--- a/src/framework/components/script/component.js
+++ b/src/framework/components/script/component.js
@@ -8,7 +8,6 @@ Object.assign(pc, function () {
      * to be executed with access to the Entity. For more details on scripting see <a href="//developer.playcanvas.com/user-manual/scripting/">Scripting</a>.
      * @param {pc.ScriptComponentSystem} system The ComponentSystem that created this Component
      * @param {pc.Entity} entity The Entity that this Component is attached to.
-     * @extends pc.Component
      * @property {ScriptType[]} scripts An array of all script instances attached to an entity. This Array shall not be modified by developer.
      */
 

--- a/src/graphics/graphics.js
+++ b/src/graphics/graphics.js
@@ -317,56 +317,56 @@
          * @constant
          * @type {Number}
          * @name pc.FUNC_NEVER
-         * @description 
+         * @description Never pass.
          */
         FUNC_NEVER: 0,
         /**
          * @constant
          * @type {Number}
          * @name pc.FUNC_LESS
-         * @description 
+         * @description Pass if (ref & mask) < (stencil & mask).
          */
         FUNC_LESS: 1,
         /**
          * @constant
          * @type {Number}
          * @name pc.FUNC_EQUAL
-         * @description 
+         * @description Pass if (ref & mask) == (stencil & mask).
          */
         FUNC_EQUAL: 2,
         /**
          * @constant
          * @type {Number}
          * @name pc.FUNC_LESSEQUAL
-         * @description 
+         * @description Pass if (ref & mask) <= (stencil & mask).
          */
         FUNC_LESSEQUAL: 3,
         /**
          * @constant
          * @type {Number}
          * @name pc.FUNC_GREATER
-         * @description 
+         * @description Pass if (ref & mask) > (stencil & mask).
          */
         FUNC_GREATER: 4,
         /**
          * @constant
          * @type {Number}
          * @name pc.FUNC_NOTEQUAL
-         * @description 
+         * @description Pass if (ref & mask) != (stencil & mask).
          */
         FUNC_NOTEQUAL: 5,
         /**
          * @constant
          * @type {Number}
          * @name pc.FUNC_GREATEREQUAL
-         * @description 
+         * @description Pass if (ref & mask) >= (stencil & mask).
          */
         FUNC_GREATEREQUAL: 6,
         /**
          * @constant
          * @type {Number}
          * @name pc.FUNC_ALWAYS
-         * @description 
+         * @description Always pass.
          */
         FUNC_ALWAYS: 7,
 
@@ -526,7 +526,7 @@
          * @constant
          * @type {Number}
          * @name pc.PIXELFORMAT_ETC1
-         * @description
+         * @description ETC1 compressed format.
          */
         PIXELFORMAT_ETC1: 21,
 
@@ -534,7 +534,7 @@
          * @constant
          * @type {Number}
          * @name pc.PIXELFORMAT_ETC2_RGB
-         * @description
+         * @description ETC2 (RGB) compressed format.
          */
         PIXELFORMAT_ETC2_RGB: 22,
 
@@ -542,7 +542,7 @@
          * @constant
          * @type {Number}
          * @name pc.PIXELFORMAT_ETC2_RGBA
-         * @description
+         * @description ETC2 (RGBA) compressed format.
          */
         PIXELFORMAT_ETC2_RGBA: 23,
 
@@ -550,7 +550,7 @@
          * @constant
          * @type {Number}
          * @name pc.PIXELFORMAT_PVRTC_2BPP_RGB_1
-         * @description
+         * @description PVRTC (2BPP RGB) compressed format.
          */
         PIXELFORMAT_PVRTC_2BPP_RGB_1: 24,
 
@@ -558,7 +558,7 @@
          * @constant
          * @type {Number}
          * @name pc.PIXELFORMAT_PVRTC_2BPP_RGBA_1
-         * @description
+         * @description PVRTC (2BPP RGBA) compressed format.
          */
         PIXELFORMAT_PVRTC_2BPP_RGBA_1: 25,
 
@@ -566,7 +566,7 @@
          * @constant
          * @type {Number}
          * @name pc.PIXELFORMAT_PVRTC_4BPP_RGB_1
-         * @description
+         * @description PVRTC (4BPP RGB) compressed format.
          */
         PIXELFORMAT_PVRTC_4BPP_RGB_1: 26,
 
@@ -574,7 +574,7 @@
          * @constant
          * @type {Number}
          * @name pc.PIXELFORMAT_PVRTC_4BPP_RGBA_1
-         * @description
+         * @description PVRTC (4BPP RGBA) compressed format.
          */
         PIXELFORMAT_PVRTC_4BPP_RGBA_1: 27,
 
@@ -810,56 +810,56 @@
          * @constant
          * @type {Number}
          * @name pc.STENCILOP_KEEP
-         * @description 
+         * @description Don't change the stencil buffer value.
          */
         STENCILOP_KEEP: 0,
         /**
          * @constant
          * @type {Number}
          * @name pc.STENCILOP_ZERO
-         * @description 
+         * @description Set value to zero.
          */
         STENCILOP_ZERO: 1,
         /**
          * @constant
          * @type {Number}
          * @name pc.STENCILOP_REPLACE
-         * @description 
+         * @description Replace value with the reference value (see {@link pc.GraphicsDevice#setStencilFunc}).
          */
         STENCILOP_REPLACE: 2,
         /**
          * @constant
          * @type {Number}
          * @name pc.STENCILOP_INCREMENT
-         * @description 
+         * @description Increment the value.
          */
         STENCILOP_INCREMENT: 3,
         /**
          * @constant
          * @type {Number}
          * @name pc.STENCILOP_INCREMENTWRAP
-         * @description 
+         * @description Increment the value, but wrap it to zero when it's larger than a maximum representable value.
          */
         STENCILOP_INCREMENTWRAP: 4,
         /**
          * @constant
          * @type {Number}
          * @name pc.STENCILOP_DECREMENT
-         * @description 
+         * @description Decrement the value.
          */
         STENCILOP_DECREMENT: 5,
         /**
          * @constant
          * @type {Number}
          * @name pc.STENCILOP_DECREMENTWRAP
-         * @description 
+         * @description Decrement the value, but wrap it to a maximum representable value, if the current value is 0.
          */
         STENCILOP_DECREMENTWRAP: 6,
         /**
          * @constant
          * @type {Number}
          * @name pc.STENCILOP_INVERT
-         * @description 
+         * @description Invert the value bitwise.
          */
         STENCILOP_INVERT: 7,
 

--- a/src/graphics/graphics.js
+++ b/src/graphics/graphics.js
@@ -313,13 +313,61 @@
          */
         FILTER_LINEAR_MIPMAP_LINEAR: 5,
 
+        /**
+         * @constant
+         * @type {Number}
+         * @name pc.FUNC_NEVER
+         * @description 
+         */
         FUNC_NEVER: 0,
+        /**
+         * @constant
+         * @type {Number}
+         * @name pc.FUNC_LESS
+         * @description 
+         */
         FUNC_LESS: 1,
+        /**
+         * @constant
+         * @type {Number}
+         * @name pc.FUNC_EQUAL
+         * @description 
+         */
         FUNC_EQUAL: 2,
+        /**
+         * @constant
+         * @type {Number}
+         * @name pc.FUNC_LESSEQUAL
+         * @description 
+         */
         FUNC_LESSEQUAL: 3,
+        /**
+         * @constant
+         * @type {Number}
+         * @name pc.FUNC_GREATER
+         * @description 
+         */
         FUNC_GREATER: 4,
+        /**
+         * @constant
+         * @type {Number}
+         * @name pc.FUNC_NOTEQUAL
+         * @description 
+         */
         FUNC_NOTEQUAL: 5,
+        /**
+         * @constant
+         * @type {Number}
+         * @name pc.FUNC_GREATEREQUAL
+         * @description 
+         */
         FUNC_GREATEREQUAL: 6,
+        /**
+         * @constant
+         * @type {Number}
+         * @name pc.FUNC_ALWAYS
+         * @description 
+         */
         FUNC_ALWAYS: 7,
 
         /**

--- a/src/graphics/graphics.js
+++ b/src/graphics/graphics.js
@@ -522,13 +522,62 @@
          */
         PIXELFORMAT_SRGBA: 20,
 
+        /**
+         * @constant
+         * @type {Number}
+         * @name pc.PIXELFORMAT_ETC1
+         * @description
+         */
         PIXELFORMAT_ETC1: 21,
+
+        /**
+         * @constant
+         * @type {Number}
+         * @name pc.PIXELFORMAT_ETC2_RGB
+         * @description
+         */
         PIXELFORMAT_ETC2_RGB: 22,
+
+        /**
+         * @constant
+         * @type {Number}
+         * @name pc.PIXELFORMAT_ETC2_RGBA
+         * @description
+         */
         PIXELFORMAT_ETC2_RGBA: 23,
+
+        /**
+         * @constant
+         * @type {Number}
+         * @name pc.PIXELFORMAT_PVRTC_2BPP_RGB_1
+         * @description
+         */
         PIXELFORMAT_PVRTC_2BPP_RGB_1: 24,
+
+        /**
+         * @constant
+         * @type {Number}
+         * @name pc.PIXELFORMAT_PVRTC_2BPP_RGBA_1
+         * @description
+         */
         PIXELFORMAT_PVRTC_2BPP_RGBA_1: 25,
+
+        /**
+         * @constant
+         * @type {Number}
+         * @name pc.PIXELFORMAT_PVRTC_4BPP_RGB_1
+         * @description
+         */
         PIXELFORMAT_PVRTC_4BPP_RGB_1: 26,
+
+        /**
+         * @constant
+         * @type {Number}
+         * @name pc.PIXELFORMAT_PVRTC_4BPP_RGBA_1
+         * @description
+         */
         PIXELFORMAT_PVRTC_4BPP_RGBA_1: 27,
+
         // only add compressed formats next
 
         /**

--- a/src/graphics/graphics.js
+++ b/src/graphics/graphics.js
@@ -806,13 +806,61 @@
 
         SHADERTAG_MATERIAL: 1,
 
+        /**
+         * @constant
+         * @type {Number}
+         * @name pc.STENCILOP_KEEP
+         * @description 
+         */
         STENCILOP_KEEP: 0,
+        /**
+         * @constant
+         * @type {Number}
+         * @name pc.STENCILOP_ZERO
+         * @description 
+         */
         STENCILOP_ZERO: 1,
+        /**
+         * @constant
+         * @type {Number}
+         * @name pc.STENCILOP_REPLACE
+         * @description 
+         */
         STENCILOP_REPLACE: 2,
+        /**
+         * @constant
+         * @type {Number}
+         * @name pc.STENCILOP_INCREMENT
+         * @description 
+         */
         STENCILOP_INCREMENT: 3,
+        /**
+         * @constant
+         * @type {Number}
+         * @name pc.STENCILOP_INCREMENTWRAP
+         * @description 
+         */
         STENCILOP_INCREMENTWRAP: 4,
+        /**
+         * @constant
+         * @type {Number}
+         * @name pc.STENCILOP_DECREMENT
+         * @description 
+         */
         STENCILOP_DECREMENT: 5,
+        /**
+         * @constant
+         * @type {Number}
+         * @name pc.STENCILOP_DECREMENTWRAP
+         * @description 
+         */
         STENCILOP_DECREMENTWRAP: 6,
+        /**
+         * @constant
+         * @type {Number}
+         * @name pc.STENCILOP_INVERT
+         * @description 
+         */
         STENCILOP_INVERT: 7,
 
         /**

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -536,7 +536,19 @@
         // 17: PCF5 SPOT
         SHADER_PICK: 18,
 
+        /**
+         * @constant
+         * @type {Number}
+         * @name pc.BAKE_COLOR
+         * @description
+         */
         BAKE_COLOR: 0,
+        /**
+         * @constant
+         * @type {Number}
+         * @name pc.BAKE_COLORDIR
+         * @description
+         */
         BAKE_COLORDIR: 1,
 
         VIEW_CENTER: 0,

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -383,9 +383,34 @@
          */
         SPECULAR_BLINN: 1,
 
+        /**
+         * @constant
+         * @type {Number}
+         * @name pc.GAMMA_NONE
+         * @description 
+         */
         GAMMA_NONE: 0,
+        /**
+         * @constant
+         * @type {Number}
+         * @name pc.GAMMA_SRGB
+         * @description 
+         */
         GAMMA_SRGB: 1,
+        /**
+         * @deprecated
+         * @constant
+         * @type {Number}
+         * @name pc.GAMMA_SRGBFAST
+         * @description 
+         */
         GAMMA_SRGBFAST: 2, // deprecated
+        /**
+         * @constant
+         * @type {Number}
+         * @name pc.GAMMA_SRGBHDR
+         * @description 
+         */
         GAMMA_SRGBHDR: 3,
 
         TONEMAP_LINEAR: 0,

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -280,7 +280,20 @@
 
         PARTICLEMODE_GPU: 0,
         PARTICLEMODE_CPU: 1,
+
+        /**
+         * @constant
+         * @type {Number}
+         * @name pc.EMITTERSHAPE_BOX
+         * @description 
+         */
         EMITTERSHAPE_BOX: 0,
+        /**
+         * @constant
+         * @type {Number}
+         * @name pc.EMITTERSHAPE_SPHERE
+         * @description 
+         */
         EMITTERSHAPE_SPHERE: 1,
         PARTICLEORIENTATION_SCREEN: 0,
         PARTICLEORIENTATION_WORLD: 1,

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -295,8 +295,27 @@
          * @description 
          */
         EMITTERSHAPE_SPHERE: 1,
+
+        /**
+         * @constant
+         * @type {Number}
+         * @name pc.PARTICLEORIENTATION_SCREEN
+         * @description 
+         */
         PARTICLEORIENTATION_SCREEN: 0,
+        /**
+         * @constant
+         * @type {Number}
+         * @name pc.PARTICLEORIENTATION_WORLD
+         * @description 
+         */
         PARTICLEORIENTATION_WORLD: 1,
+        /**
+         * @constant
+         * @type {Number}
+         * @name pc.PARTICLEORIENTATION_EMITTER
+         * @description 
+         */
         PARTICLEORIENTATION_EMITTER: 2,
 
         /**

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -331,8 +331,26 @@
          */
         PROJECTION_ORTHOGRAPHIC: 1,
 
+        /**
+         * @constant
+         * @type {Number}
+         * @name pc.RENDERSTYLE_SOLID
+         * @description 
+         */
         RENDERSTYLE_SOLID: 0,
+        /**
+         * @constant
+         * @type {Number}
+         * @name pc.RENDERSTYLE_WIREFRAME
+         * @description 
+         */
         RENDERSTYLE_WIREFRAME: 1,
+        /**
+         * @constant
+         * @type {Number}
+         * @name pc.RENDERSTYLE_POINTS
+         * @description 
+         */
         RENDERSTYLE_POINTS: 2,
 
         CUBEPROJ_NONE: 0,

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -249,10 +249,35 @@
          */
         BLUR_GAUSSIAN: 1,
 
+        /**
+         * @constant
+         * @type {Number}
+         * @name pc.PARTICLESORT_NONE
+         * @description 
+         */
         PARTICLESORT_NONE: 0,
+        /**
+         * @constant
+         * @type {Number}
+         * @name pc.PARTICLESORT_DISTANCE
+         * @description 
+         */
         PARTICLESORT_DISTANCE: 1,
+        /**
+         * @constant
+         * @type {Number}
+         * @name pc.PARTICLESORT_NEWER_FIRST
+         * @description 
+         */
         PARTICLESORT_NEWER_FIRST: 2,
+        /**
+         * @constant
+         * @type {Number}
+         * @name pc.PARTICLESORT_OLDER_FIRST
+         * @description 
+         */
         PARTICLESORT_OLDER_FIRST: 3,
+
         PARTICLEMODE_GPU: 0,
         PARTICLEMODE_CPU: 1,
         EMITTERSHAPE_BOX: 0,

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -551,8 +551,26 @@
          */
         BAKE_COLORDIR: 1,
 
+        /**
+         * @constant
+         * @type {Number}
+         * @name pc.VIEW_CENTER
+         * @description
+         */
         VIEW_CENTER: 0,
+        /**
+         * @constant
+         * @type {Number}
+         * @name pc.VIEW_LEFT
+         * @description
+         */
         VIEW_LEFT: 1,
+        /**
+         * @constant
+         * @type {Number}
+         * @name pc.VIEW_RIGHT
+         * @description
+         */
         VIEW_RIGHT: 2,
 
         /**

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -176,7 +176,19 @@
          */
         LIGHTTYPE_SPOT: 2,
 
+        /**
+         * @constant
+         * @type {Number}
+         * @name pc.LIGHTFALLOFF_LINEAR
+         * @description 
+         */
         LIGHTFALLOFF_LINEAR: 0,
+        /**
+         * @constant
+         * @type {Number}
+         * @name pc.LIGHTFALLOFF_INVERSESQUARED
+         * @description 
+         */
         LIGHTFALLOFF_INVERSESQUARED: 1,
 
         SHADOW_PCF3: 0,

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -234,7 +234,19 @@
          */
         SHADOW_PCF5: 4,
 
+        /**
+         * @constant
+         * @type {Number}
+         * @name pc.BLUR_BOX
+         * @description 
+         */
         BLUR_BOX: 0,
+        /**
+         * @constant
+         * @type {Number}
+         * @name pc.BLUR_GAUSSIAN
+         * @description 
+         */
         BLUR_GAUSSIAN: 1,
 
         PARTICLESORT_NONE: 0,

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -353,7 +353,19 @@
          */
         RENDERSTYLE_POINTS: 2,
 
+        /**
+         * @constant
+         * @type {Number}
+         * @name pc.CUBEPROJ_NONE
+         * @description 
+         */
         CUBEPROJ_NONE: 0,
+        /**
+         * @constant
+         * @type {Number}
+         * @name pc.CUBEPROJ_BOX
+         * @description 
+         */
         CUBEPROJ_BOX: 1,
 
         SPECULAR_PHONG: 0,

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -107,14 +107,14 @@
          * @constant
          * @type {Number}
          * @name pc.FRESNEL_NONE
-         * @description 
+         * @description No Fresnel.
          */
         FRESNEL_NONE: 0,
         /**
          * @constant
          * @type {Number}
          * @name pc.FRESNEL_SCHLICK
-         * @description 
+         * @description Schlick's approximation of Fresnel.
          */
         FRESNEL_SCHLICK: 2,
 
@@ -180,14 +180,14 @@
          * @constant
          * @type {Number}
          * @name pc.LIGHTFALLOFF_LINEAR
-         * @description 
+         * @description Linear distance falloff model for light attenuation.
          */
         LIGHTFALLOFF_LINEAR: 0,
         /**
          * @constant
          * @type {Number}
          * @name pc.LIGHTFALLOFF_INVERSESQUARED
-         * @description 
+         * @description Inverse squared distance falloff model for light attenuation.
          */
         LIGHTFALLOFF_INVERSESQUARED: 1,
 
@@ -195,42 +195,36 @@
          * @constant
          * @type {Number}
          * @name pc.SHADOW_PCF3
-         * @description 
+         * @description Render depth (color-packed on WebGL 1.0), can be used for PCF 3x3 sampling.
          */
         SHADOW_PCF3: 0,
-        /**
-         * @constant
-         * @type {Number}
-         * @name pc.SHADOW_DEPTH
-         * @description 
-         */
         SHADOW_DEPTH: 0, // alias for SHADOW_PCF3 for backwards compatibility
         /**
          * @constant
          * @type {Number}
          * @name pc.SHADOW_VSM8
-         * @description 
+         * @description Render packed variance shadow map. All shadow receivers must also cast shadows for this mode to work correctly.
          */
         SHADOW_VSM8: 1,
         /**
          * @constant
          * @type {Number}
          * @name pc.SHADOW_VSM16
-         * @description 
+         * @description Render 16-bit exponential variance shadow map. Requires OES_texture_half_float extension. Falls back to pc.SHADOW_VSM8, if not supported.
          */
         SHADOW_VSM16: 2,
         /**
          * @constant
          * @type {Number}
          * @name pc.SHADOW_VSM32
-         * @description 
+         * @description Render 32-bit exponential variance shadow map. Requires OES_texture_float extension. Falls back to pc.SHADOW_VSM16, if not supported.
          */
         SHADOW_VSM32: 3,
         /**
          * @constant
          * @type {Number}
          * @name pc.SHADOW_PCF5
-         * @description 
+         * @description Render depth buffer only, can be used for hardware-accelerated PCF 5x5 sampling. Requires WebGL2. Falls back to pc.SHADOW_PCF3 on WebGL 1.0.
          */
         SHADOW_PCF5: 4,
 
@@ -238,14 +232,14 @@
          * @constant
          * @type {Number}
          * @name pc.BLUR_BOX
-         * @description 
+         * @description Box filter.
          */
         BLUR_BOX: 0,
         /**
          * @constant
          * @type {Number}
          * @name pc.BLUR_GAUSSIAN
-         * @description 
+         * @description Gaussian filter. May look smoother than box, but requires more samples.
          */
         BLUR_GAUSSIAN: 1,
 
@@ -253,28 +247,28 @@
          * @constant
          * @type {Number}
          * @name pc.PARTICLESORT_NONE
-         * @description 
+         * @description No sorting, particles are drawn in arbitary order. Can be simulated on GPU.
          */
         PARTICLESORT_NONE: 0,
         /**
          * @constant
          * @type {Number}
          * @name pc.PARTICLESORT_DISTANCE
-         * @description 
+         * @description Sorting based on distance to the camera. CPU only.
          */
         PARTICLESORT_DISTANCE: 1,
         /**
          * @constant
          * @type {Number}
          * @name pc.PARTICLESORT_NEWER_FIRST
-         * @description 
+         * @description Newer particles are drawn first. CPU only.
          */
         PARTICLESORT_NEWER_FIRST: 2,
         /**
          * @constant
          * @type {Number}
          * @name pc.PARTICLESORT_OLDER_FIRST
-         * @description 
+         * @description Older particles are drawn first. CPU only.
          */
         PARTICLESORT_OLDER_FIRST: 3,
 
@@ -285,14 +279,14 @@
          * @constant
          * @type {Number}
          * @name pc.EMITTERSHAPE_BOX
-         * @description 
+         * @description Box shape parameterized by emitterExtents. Initial velocity is directed towards local Z axis.
          */
         EMITTERSHAPE_BOX: 0,
         /**
          * @constant
          * @type {Number}
          * @name pc.EMITTERSHAPE_SPHERE
-         * @description 
+         * @description Sphere shape parameterized by emitterRadius. Initial velocity is directed outwards from the center.
          */
         EMITTERSHAPE_SPHERE: 1,
 
@@ -300,21 +294,21 @@
          * @constant
          * @type {Number}
          * @name pc.PARTICLEORIENTATION_SCREEN
-         * @description 
+         * @description Particles are facing camera.
          */
         PARTICLEORIENTATION_SCREEN: 0,
         /**
          * @constant
          * @type {Number}
          * @name pc.PARTICLEORIENTATION_WORLD
-         * @description 
+         * @description User defines world space normal (particleNormal) to set planes orientation.
          */
         PARTICLEORIENTATION_WORLD: 1,
         /**
          * @constant
          * @type {Number}
          * @name pc.PARTICLEORIENTATION_EMITTER
-         * @description 
+         * @description Similar to previous, but the normal is affected by emitter(entity) transformation.
          */
         PARTICLEORIENTATION_EMITTER: 2,
 
@@ -335,21 +329,21 @@
          * @constant
          * @type {Number}
          * @name pc.RENDERSTYLE_SOLID
-         * @description 
+         * @description Render mesh instance as solid geometry.
          */
         RENDERSTYLE_SOLID: 0,
         /**
          * @constant
          * @type {Number}
          * @name pc.RENDERSTYLE_WIREFRAME
-         * @description 
+         * @description Render mesh instance as wireframe.
          */
         RENDERSTYLE_WIREFRAME: 1,
         /**
          * @constant
          * @type {Number}
          * @name pc.RENDERSTYLE_POINTS
-         * @description 
+         * @description Render mesh instance as points.
          */
         RENDERSTYLE_POINTS: 2,
 
@@ -357,14 +351,14 @@
          * @constant
          * @type {Number}
          * @name pc.CUBEPROJ_NONE
-         * @description 
+         * @description The cube map is treated as if it is infinitely far away.
          */
         CUBEPROJ_NONE: 0,
         /**
          * @constant
          * @type {Number}
          * @name pc.CUBEPROJ_BOX
-         * @description 
+         * @description The cube map is box-projected based on a world space axis-aligned bounding box.
          */
         CUBEPROJ_BOX: 1,
 
@@ -372,14 +366,14 @@
          * @constant
          * @type {Number}
          * @name pc.SPECULAR_PHONG
-         * @description 
+         * @description Phong without energy conservation. You should only use it as a backwards compatibility with older projects.
          */
         SPECULAR_PHONG: 0,
         /**
          * @constant
          * @type {Number}
          * @name pc.SPECULAR_BLINN
-         * @description 
+         * @description Energy-conserving Blinn-Phong.
          */
         SPECULAR_BLINN: 1,
 
@@ -387,14 +381,14 @@
          * @constant
          * @type {Number}
          * @name pc.GAMMA_NONE
-         * @description 
+         * @description No gamma correction.
          */
         GAMMA_NONE: 0,
         /**
          * @constant
          * @type {Number}
          * @name pc.GAMMA_SRGB
-         * @description 
+         * @description Apply sRGB gamma correction.
          */
         GAMMA_SRGB: 1,
         /**
@@ -402,14 +396,14 @@
          * @constant
          * @type {Number}
          * @name pc.GAMMA_SRGBFAST
-         * @description 
+         * @description Apply sRGB (fast) gamma correction.
          */
         GAMMA_SRGBFAST: 2, // deprecated
         /**
          * @constant
          * @type {Number}
          * @name pc.GAMMA_SRGBHDR
-         * @description 
+         * @description Apply sRGB (HDR) gamma correction.
          */
         GAMMA_SRGBHDR: 3,
 
@@ -417,35 +411,35 @@
          * @constant
          * @type {Number}
          * @name pc.TONEMAP_LINEAR
-         * @description 
+         * @description Linear tonemapping.
          */
         TONEMAP_LINEAR: 0,
         /**
          * @constant
          * @type {Number}
          * @name pc.TONEMAP_FILMIC
-         * @description 
+         * @description Filmic tonemapping curve.
          */
         TONEMAP_FILMIC: 1,
         /**
          * @constant
          * @type {Number}
          * @name pc.TONEMAP_HEJL
-         * @description 
+         * @description Hejl filmic tonemapping curve.
          */
         TONEMAP_HEJL: 2,
         /**
          * @constant
          * @type {Number}
          * @name pc.TONEMAP_ACES
-         * @description 
+         * @description ACES filmic tonemapping curve.
          */
         TONEMAP_ACES: 3,
         /**
          * @constant
          * @type {Number}
          * @name pc.TONEMAP_ACES2
-         * @description 
+         * @description ACES v2 filmic tonemapping curve.
          */
         TONEMAP_ACES2: 4,
 
@@ -453,21 +447,21 @@
          * @constant
          * @type {Number}
          * @name pc.SPECOCC_NONE
-         * @description 
+         * @description No specular occlusion.
          */
         SPECOCC_NONE: 0,
         /**
          * @constant
          * @type {Number}
          * @name pc.SPECOCC_AO
-         * @description 
+         * @description Use AO directly to occlude specular.
          */
         SPECOCC_AO: 1,
         /**
          * @constant
          * @type {Number}
          * @name pc.SPECOCC_GLOSSDEPENDENT
-         * @description 
+         * @description Modify AO based on material glossiness/view angle to occlude specular.
          */
         SPECOCC_GLOSSDEPENDENT: 2,
 
@@ -540,14 +534,14 @@
          * @constant
          * @type {Number}
          * @name pc.BAKE_COLOR
-         * @description
+         * @description Single color lightmap.
          */
         BAKE_COLOR: 0,
         /**
          * @constant
          * @type {Number}
          * @name pc.BAKE_COLORDIR
-         * @description
+         * @description Single color lightmap + dominant light direction (used for bump/specular).
          */
         BAKE_COLORDIR: 1,
 
@@ -555,21 +549,21 @@
          * @constant
          * @type {Number}
          * @name pc.VIEW_CENTER
-         * @description
+         * @description Center of view.
          */
         VIEW_CENTER: 0,
         /**
          * @constant
          * @type {Number}
          * @name pc.VIEW_LEFT
-         * @description
+         * @description Left of view. Only used in stereo rendering.
          */
         VIEW_LEFT: 1,
         /**
          * @constant
          * @type {Number}
          * @name pc.VIEW_RIGHT
-         * @description
+         * @description Right of view. Only used in stereo rendering.
          */
         VIEW_RIGHT: 2,
 
@@ -625,14 +619,14 @@
          * @constant
          * @type {Number}
          * @name pc.ASPECT_AUTO
-         * @description
+         * @description Automatically set aspect ratio to current render target's width divided by height.
          */
         ASPECT_AUTO: 0,
         /**
          * @constant
          * @type {Number}
          * @name pc.ASPECT_MANUAL
-         * @description
+         * @description Use the manual aspect ratio value.
          */
         ASPECT_MANUAL: 1,
 

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -621,7 +621,19 @@
         COMPUPDATED_CAMERAS: 4,
         COMPUPDATED_BLEND: 8,
 
+        /**
+         * @constant
+         * @type {Number}
+         * @name pc.ASPECT_AUTO
+         * @description
+         */
         ASPECT_AUTO: 0,
+        /**
+         * @constant
+         * @type {Number}
+         * @name pc.ASPECT_MANUAL
+         * @description
+         */
         ASPECT_MANUAL: 1,
 
         /**

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -368,7 +368,19 @@
          */
         CUBEPROJ_BOX: 1,
 
+        /**
+         * @constant
+         * @type {Number}
+         * @name pc.SPECULAR_PHONG
+         * @description 
+         */
         SPECULAR_PHONG: 0,
+        /**
+         * @constant
+         * @type {Number}
+         * @name pc.SPECULAR_BLINN
+         * @description 
+         */
         SPECULAR_BLINN: 1,
 
         GAMMA_NONE: 0,

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -449,8 +449,26 @@
          */
         TONEMAP_ACES2: 4,
 
+        /**
+         * @constant
+         * @type {Number}
+         * @name pc.SPECOCC_NONE
+         * @description 
+         */
         SPECOCC_NONE: 0,
+        /**
+         * @constant
+         * @type {Number}
+         * @name pc.SPECOCC_AO
+         * @description 
+         */
         SPECOCC_AO: 1,
+        /**
+         * @constant
+         * @type {Number}
+         * @name pc.SPECOCC_GLOSSDEPENDENT
+         * @description 
+         */
         SPECOCC_GLOSSDEPENDENT: 2,
 
         SHADERDEF_NOSHADOW: 1,

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -191,11 +191,47 @@
          */
         LIGHTFALLOFF_INVERSESQUARED: 1,
 
+        /**
+         * @constant
+         * @type {Number}
+         * @name pc.SHADOW_PCF3
+         * @description 
+         */
         SHADOW_PCF3: 0,
+        /**
+         * @constant
+         * @type {Number}
+         * @name pc.SHADOW_DEPTH
+         * @description 
+         */
         SHADOW_DEPTH: 0, // alias for SHADOW_PCF3 for backwards compatibility
+        /**
+         * @constant
+         * @type {Number}
+         * @name pc.SHADOW_VSM8
+         * @description 
+         */
         SHADOW_VSM8: 1,
+        /**
+         * @constant
+         * @type {Number}
+         * @name pc.SHADOW_VSM16
+         * @description 
+         */
         SHADOW_VSM16: 2,
+        /**
+         * @constant
+         * @type {Number}
+         * @name pc.SHADOW_VSM32
+         * @description 
+         */
         SHADOW_VSM32: 3,
+        /**
+         * @constant
+         * @type {Number}
+         * @name pc.SHADOW_PCF5
+         * @description 
+         */
         SHADOW_PCF5: 4,
 
         BLUR_BOX: 0,

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -413,10 +413,40 @@
          */
         GAMMA_SRGBHDR: 3,
 
+        /**
+         * @constant
+         * @type {Number}
+         * @name pc.TONEMAP_LINEAR
+         * @description 
+         */
         TONEMAP_LINEAR: 0,
+        /**
+         * @constant
+         * @type {Number}
+         * @name pc.TONEMAP_FILMIC
+         * @description 
+         */
         TONEMAP_FILMIC: 1,
+        /**
+         * @constant
+         * @type {Number}
+         * @name pc.TONEMAP_HEJL
+         * @description 
+         */
         TONEMAP_HEJL: 2,
+        /**
+         * @constant
+         * @type {Number}
+         * @name pc.TONEMAP_ACES
+         * @description 
+         */
         TONEMAP_ACES: 3,
+        /**
+         * @constant
+         * @type {Number}
+         * @name pc.TONEMAP_ACES2
+         * @description 
+         */
         TONEMAP_ACES2: 4,
 
         SPECOCC_NONE: 0,

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -103,7 +103,19 @@
          */
         FOG_EXP2: 'exp2',
 
+        /**
+         * @constant
+         * @type {Number}
+         * @name pc.FRESNEL_NONE
+         * @description 
+         */
         FRESNEL_NONE: 0,
+        /**
+         * @constant
+         * @type {Number}
+         * @name pc.FRESNEL_SCHLICK
+         * @description 
+         */
         FRESNEL_SCHLICK: 2,
 
         // Legacy


### PR DESCRIPTION
The PR adds complete jsdoc comments for the following public constants:
- BODYTYPE_*
- FUNC_*
- PIXELFORMAT_* (compressed types)
- STENCILOP_*
- FRESNEL_*
- LIGHTFALLOFF_*
- SHADOW_*
- BLUR_*
- PARTICLESORT_*
- EMITTERSHAPE_*
- PARTICLEORIENTATION_*
- RENDERSTYLE_*
- CUBEPROJ_*
- SPECULAR_*
- GAMMA_*
- TONEMAP_*
- SPECOCC_*
- BAKE_*
- VIEW_*
- ASPECT_*

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
