### PR TITLE
[DOC] Fix duplicate jsdoc in pc.ScriptComponent

### DIFF
--- a/src/framework/components/script/component.js
+++ b/src/framework/components/script/component.js
@@ -8,7 +8,6 @@ Object.assign(pc, function () {
      * to be executed with access to the Entity. For more details on scripting see <a href="//developer.playcanvas.com/user-manual/scripting/">Scripting</a>.
      * @param {pc.ScriptComponentSystem} system The ComponentSystem that created this Component
      * @param {pc.Entity} entity The Entity that this Component is attached to.
-     * @extends pc.Component
      * @property {ScriptType[]} scripts An array of all script instances attached to an entity. This Array shall not be modified by developer.
      */
 


### PR DESCRIPTION
I'm sorry. Managed somehow to include duplicate `@extends` tags in one of my previous PR (#1663). Should have done better.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
