### PR TITLE
[DOC] Add documentation for more resource handlers

### DIFF
--- a/src/resources/animation.js
+++ b/src/resources/animation.js
@@ -1,6 +1,12 @@
 Object.assign(pc, function () {
     'use strict';
 
+    /**
+     * @constructor
+     * @name pc.AnimationHandler
+     * @implements {pc.ResourceHandler}
+     * @classdesc Resource handler used for loading {@link pc.Animation} resources
+     */
     var AnimationHandler = function () {
         this.retryRequests = false;
     };

--- a/src/resources/audio.js
+++ b/src/resources/audio.js
@@ -21,6 +21,13 @@ Object.assign(pc, function () {
         return false;
     })();
 
+    /**
+     * @constructor
+     * @name pc.AudioHandler
+     * @implements {pc.ResourceHandler}
+     * @classdesc Resource handler used for loading {@link pc.Sound} resources
+     * @param {pc.SoundManager} manager The sound manager
+     */
     var AudioHandler = function (manager) {
         this.manager = manager;
         this.retryRequests = false;

--- a/src/resources/bundle.js
+++ b/src/resources/bundle.js
@@ -4,6 +4,7 @@ Object.assign(pc, function () {
      * @private
      * @constructor
      * @name pc.BundleHandler
+     * @implements {pc.ResourceHandler}
      * @param {pc.AssetRegistry} assets The asset registry
      * @classdesc Loads Bundle Assets
      */

--- a/src/resources/cubemap.js
+++ b/src/resources/cubemap.js
@@ -1,4 +1,14 @@
 Object.assign(pc, function () {
+
+    /**
+     * @constructor
+     * @name pc.CubemapHandler
+     * @implements {pc.ResourceHandler}
+     * @classdesc Resource handler used for loading cubemap {@link pc.Texture} resources
+     * @param {pc.GraphicsDevice} device The graphics device
+     * @param {pc.AssetRegistry} assets The asset registry
+     * @param {pc.ResourceLoader} loader The resource loader
+     */
     var CubemapHandler = function (device, assets, loader) {
         this._device = device;
         this._assets = assets;

--- a/src/resources/font.js
+++ b/src/resources/font.js
@@ -25,6 +25,13 @@ Object.assign(pc, function () {
         return data;
     }
 
+    /**
+     * @constructor
+     * @name pc.FontHandler
+     * @implements {pc.ResourceHandler}
+     * @classdesc Resource handler used for loading {@link pc.Font} resources
+     * @param {pc.ResourceLoader} loader The resource loader
+     */
     var FontHandler = function (loader) {
         this._loader = loader;
         this.retryRequests = false;

--- a/src/resources/loader.js
+++ b/src/resources/loader.js
@@ -19,9 +19,9 @@ Object.assign(pc, function () {
         /**
          * @function
          * @name pc.ResourceLoader#addHandler
-         * @description Add a handler for a resource type. Handler should support: load(url, callback) and open(url, data).
+         * @description Add a {@link pc.ResourceHandler} for a resource type. Handler should support: load(url, callback) and open(url, data).
          * Handlers can optionally support patch(asset, assets) to handle dependencies on other assets
-         * @param {String} type The name of the type that the handler will load
+         * @param {String} type The name of the resource type that the handler will be registerd with.
          * @param {pc.ResourceHandler} handler An instance of a resource handler supporting load() and open().
          * @example
          * var loader = new ResourceLoader();
@@ -32,10 +32,23 @@ Object.assign(pc, function () {
             handler._loader = this;
         },
 
+        /**
+         * @function
+         * @name pc.ResourceLoader#removeHandler
+         * @description Remove a {@link pc.ResourceHandler} for a resource type.
+         * @param {String} type The name of the type that the handler will be removed.
+         */
         removeHandler: function (type) {
             delete this._handlers[type];
         },
 
+        /**
+         * @function
+         * @name pc.ResourceLoader#getHandler
+         * @description Get a {@link pc.ResourceHandler} for a resource type.
+         * @param {String} type The name of the resource type that the handler is registerd with.
+         * @returns {pc.ResourceHandler} The registerd handler.
+         */
         getHandler: function (type) {
             return this._handlers[type];
         },

--- a/src/resources/material.js
+++ b/src/resources/material.js
@@ -15,6 +15,13 @@ Object.assign(pc, function () {
         lightMap: 'white'
     };
 
+    /**
+     * @constructor
+     * @name pc.MaterialHandler
+     * @implements {pc.ResourceHandler}
+     * @classdesc Resource handler used for loading {@link pc.Material} resources
+     * @param {pc.Application} app The running {@link pc.Application}
+     */
     var MaterialHandler = function (app) {
         this._assets = app.assets;
         this._device = app.graphicsDevice;

--- a/src/resources/model.js
+++ b/src/resources/model.js
@@ -2,8 +2,8 @@ Object.assign(pc, function () {
     /**
      * @constructor
      * @name pc.ModelHandler
-     * @classdesc Resource Handler for creating pc.Model resources
-     * @description {@link pc.ResourceHandler} use to load 3D model resources
+     * @implements {pc.ResourceHandler}
+     * @classdesc Resource handler used for loading {@link pc.Model} resources
      * @param {pc.GraphicsDevice} device The graphics device that will be rendering
      * @param {pc.StandardMaterial} defaultMaterial The shared default material that is used in any place that a material is not specified
      */

--- a/src/resources/scene.js
+++ b/src/resources/scene.js
@@ -1,6 +1,13 @@
 Object.assign(pc, function () {
     'use strict';
 
+    /**
+     * @constructor
+     * @name pc.SceneHandler
+     * @implements {pc.ResourceHandler}
+     * @classdesc Resource handler used for loading {@link pc.Scene} resources
+     * @param {pc.Application} app The running {@link pc.Application}
+     */
     var SceneHandler = function (app) {
         this._app = app;
         this.retryRequests = false;

--- a/src/resources/script.js
+++ b/src/resources/script.js
@@ -4,10 +4,11 @@ Object.assign(pc, function () {
     /**
      * @constructor
      * @name pc.ScriptHandler
-     * @classdesc ResourceHandler for loading JavaScript files dynamically
+     * @implements {pc.ResourceHandler}
+     * @classdesc Resource handler for loading JavaScript files dynamically
      * Two types of JavaScript files can be loaded, PlayCanvas scripts which contain calls to {@link pc.createScript},
      * or regular JavaScript files, such as third-party libraries.
-     * @param {pc.Application} app The running {pc.Application}
+     * @param {pc.Application} app The running {@link pc.Application}
      */
     var ScriptHandler = function (app) {
         this._app = app;

--- a/src/resources/sprite.js
+++ b/src/resources/sprite.js
@@ -1,4 +1,13 @@
 Object.assign(pc, function () {
+
+    /**
+     * @constructor
+     * @name pc.SpriteHandler
+     * @implements {pc.ResourceHandler}
+     * @classdesc Resource handler used for loading {@link pc.Sprite} resources
+     * @param {pc.AssetRegistry} assets The asset registry
+     * @param {pc.GraphicsDevice} device The graphics device
+     */
     var SpriteHandler = function (assets, device) {
         this._assets = assets;
         this._device = device;

--- a/src/resources/texture-atlas.js
+++ b/src/resources/texture-atlas.js
@@ -16,6 +16,13 @@ Object.assign(pc, function () {
 
     var regexFrame = /^data\.frames\.(\d+)$/;
 
+    /**
+     * @constructor
+     * @name pc.TextureAtlasHandler
+     * @implements {pc.ResourceHandler}
+     * @classdesc Resource handler used for loading {@link pc.TextureAtlas} resources
+     * @param {pc.ResourceLoader} loader The resource loader
+     */
     var TextureAtlasHandler = function (loader) {
         this._loader = loader;
         this.retryRequests = false;

--- a/src/resources/texture.js
+++ b/src/resources/texture.js
@@ -253,6 +253,15 @@ Object.assign(pc, function () {
         texture._levelsUpdated = texture._cubemap ? [[true, true, true, true, true, true]] : [true];
     };
 
+    /**
+     * @constructor
+     * @name pc.TextureHandler
+     * @implements {pc.ResourceHandler}
+     * @classdesc Resource handler used for loading 2D and 3D {@link pc.Texture} resources
+     * @param {pc.GraphicsDevice} device The graphics device
+     * @param {pc.AssetRegistry} assets The asset registry
+     * @param {pc.ResourceLoader} loader The resource loader
+     */
     var TextureHandler = function (device, assets, loader) {
         this._device = device;
         this._assets = assets;


### PR DESCRIPTION
PR improves jsdoc comments for the following already documented resource handlers:
- `pc.ModelHandler`
- `pc.ScriptHandler`
- `pc.BundleHandler` (still private)

PR also adds jsdoc comments for the following currently undocumented resource handlers:
- `pc.AnimationHandler`
- `pc.AudioHandler`
- `pc.CubemapHandler`
- `pc.FontHandler`
- `pc.MaterialHandler`
- `pc.SceneHandler`
- `pc.SpriteHandler`
- `pc.TextureAtlasHandler`
- `pc.TextureHandler`

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
