### PR TITLE
[DOC] Add more documentation for callbacks

### DIFF
--- a/src/asset/asset-registry.js
+++ b/src/asset/asset-registry.js
@@ -433,13 +433,20 @@ Object.assign(pc, function () {
         },
 
         /**
+        * @callback pc.AssetRegistryLoadCallback
+        * @description Function called when asset is loaded using {@link pc.AssetRegistry#loadFromUrl}.
+        * @param {String|Null} err The error message is null if no errors were encountered.
+        * @param {pc.Asset} asset The loaded asset.
+        */
+
+        /**
          * @function
          * @name pc.AssetRegistry#loadFromUrl
          * @description Use this to load and create an asset if you don't have assets created. Usually you would only use this
          * if you are not integrated with the PlayCanvas Editor
          * @param {String} url The url to load
          * @param {String} type The type of asset to load
-         * @param {Function} callback Function called when asset is loaded, passed (err, asset), where err is null if no errors were encountered
+         * @param {pc.AssetRegistryLoadCallback} callback Function called when asset is loaded, passed (err, asset), where err is null if no errors were encountered
          * @example
          * app.assets.loadFromUrl("../path/to/texture.jpg", "texture", function (err, asset) {
          *     var texture = asset.resource;
@@ -671,10 +678,17 @@ Object.assign(pc, function () {
         },
 
         /**
+        * @callback pc.AssetRegistryFilterCallback
+        * @description Function used to filter assets when passed into {@link pc.AssetRegistry#filter}.
+        * @param {pc.Asset} asset The current asset to filter.
+        * @returns {Boolean} Return `true` to include asset to result list.
+        */
+
+        /**
          * @function
          * @name pc.AssetRegistry#filter
          * @description Return all Assets that satisfy filter callback
-         * @param {Function} callback The callback function that is used to filter assets, return `true` to include asset to result list
+         * @param {pc.AssetRegistryFilterCallback} callback The callback function that is used to filter assets, return `true` to include asset to result list
          * @returns {pc.Asset[]} A list of all Assets found
          * @example
          * var assets = app.assets.filter(function(asset) {

--- a/src/asset/asset-registry.js
+++ b/src/asset/asset-registry.js
@@ -434,7 +434,7 @@ Object.assign(pc, function () {
 
         /**
         * @callback pc.AssetRegistryLoadCallback
-        * @description Function called when asset is loaded using {@link pc.AssetRegistry#loadFromUrl}.
+        * @description Callback function used by {@link pc.AssetRegistry#loadFromUrl} and called when an asset is loaded (or an error occurs).
         * @param {String|Null} err The error message is null if no errors were encountered.
         * @param {pc.Asset} asset The loaded asset.
         */
@@ -679,7 +679,7 @@ Object.assign(pc, function () {
 
         /**
         * @callback pc.AssetRegistryFilterCallback
-        * @description Function used to filter assets when passed into {@link pc.AssetRegistry#filter}.
+        * @description Callback function used by {@link pc.AssetRegistry#filter} to filter assets.
         * @param {pc.Asset} asset The current asset to filter.
         * @returns {Boolean} Return `true` to include asset to result list.
         */

--- a/src/asset/asset-registry.js
+++ b/src/asset/asset-registry.js
@@ -436,7 +436,7 @@ Object.assign(pc, function () {
         * @callback pc.AssetRegistry.loadCallback
         * @description Callback function used by {@link pc.AssetRegistry#loadFromUrl} and called when an asset is loaded (or an error occurs).
         * @param {String|Null} err The error message is null if no errors were encountered.
-        * @param {pc.Asset} asset The loaded asset.
+        * @param {pc.Asset} [asset] The loaded asset if no errors were encountered.
         */
 
         /**

--- a/src/asset/asset-registry.js
+++ b/src/asset/asset-registry.js
@@ -433,11 +433,11 @@ Object.assign(pc, function () {
         },
 
         /**
-        * @callback pc.AssetRegistry.loadCallback
-        * @description Callback function used by {@link pc.AssetRegistry#loadFromUrl} and called when an asset is loaded (or an error occurs).
-        * @param {String|Null} err The error message is null if no errors were encountered.
-        * @param {pc.Asset} [asset] The loaded asset if no errors were encountered.
-        */
+         * @callback pc.AssetRegistry.loadCallback
+         * @description Callback function used by {@link pc.AssetRegistry#loadFromUrl} and called when an asset is loaded (or an error occurs).
+         * @param {String|Null} err The error message is null if no errors were encountered.
+         * @param {pc.Asset} [asset] The loaded asset if no errors were encountered.
+         */
 
         /**
          * @function
@@ -678,11 +678,11 @@ Object.assign(pc, function () {
         },
 
         /**
-        * @callback pc.AssetRegistry.filterCallback
-        * @description Callback function used by {@link pc.AssetRegistry#filter} to filter assets.
-        * @param {pc.Asset} asset The current asset to filter.
-        * @returns {Boolean} Return `true` to include asset to result list.
-        */
+         * @callback pc.AssetRegistry.filterCallback
+         * @description Callback function used by {@link pc.AssetRegistry#filter} to filter assets.
+         * @param {pc.Asset} asset The current asset to filter.
+         * @returns {Boolean} Return `true` to include asset to result list.
+         */
 
         /**
          * @function

--- a/src/asset/asset-registry.js
+++ b/src/asset/asset-registry.js
@@ -433,7 +433,7 @@ Object.assign(pc, function () {
         },
 
         /**
-        * @callback pc.AssetRegistryLoadCallback
+        * @callback pc.AssetRegistry.loadCallback
         * @description Callback function used by {@link pc.AssetRegistry#loadFromUrl} and called when an asset is loaded (or an error occurs).
         * @param {String|Null} err The error message is null if no errors were encountered.
         * @param {pc.Asset} asset The loaded asset.
@@ -446,7 +446,7 @@ Object.assign(pc, function () {
          * if you are not integrated with the PlayCanvas Editor
          * @param {String} url The url to load
          * @param {String} type The type of asset to load
-         * @param {pc.AssetRegistryLoadCallback} callback Function called when asset is loaded, passed (err, asset), where err is null if no errors were encountered
+         * @param {pc.AssetRegistry.loadCallback} callback Function called when asset is loaded, passed (err, asset), where err is null if no errors were encountered
          * @example
          * app.assets.loadFromUrl("../path/to/texture.jpg", "texture", function (err, asset) {
          *     var texture = asset.resource;
@@ -678,7 +678,7 @@ Object.assign(pc, function () {
         },
 
         /**
-        * @callback pc.AssetRegistryFilterCallback
+        * @callback pc.AssetRegistry.filterCallback
         * @description Callback function used by {@link pc.AssetRegistry#filter} to filter assets.
         * @param {pc.Asset} asset The current asset to filter.
         * @returns {Boolean} Return `true` to include asset to result list.
@@ -688,7 +688,7 @@ Object.assign(pc, function () {
          * @function
          * @name pc.AssetRegistry#filter
          * @description Return all Assets that satisfy filter callback
-         * @param {pc.AssetRegistryFilterCallback} callback The callback function that is used to filter assets, return `true` to include asset to result list
+         * @param {pc.AssetRegistry.filterCallback} callback The callback function that is used to filter assets, return `true` to include asset to result list
          * @returns {pc.Asset[]} A list of all Assets found
          * @example
          * var assets = app.assets.filter(function(asset) {

--- a/src/asset/asset.js
+++ b/src/asset/asset.js
@@ -253,10 +253,16 @@ Object.assign(pc, function () {
         },
 
         /**
+        * @callback pc.AssetReadyCallback
+        * @description Function passed to {@link pc.Asset#ready} and callbed when the {@link pc.Asset} is ready.
+        * @param {pc.Asset} asset The ready asset.
+        */
+
+        /**
          * @function
          * @name pc.Asset#ready
          * @description Take a callback which is called as soon as the asset is loaded. If the asset is already loaded the callback is called straight away
-         * @param {Function} callback The function called when the asset is ready. Passed the (asset) arguments
+         * @param {pc.AssetReadyCallback} callback The function called when the asset is ready. Passed the (asset) arguments
          * @param {Object} scope Scope object to use when calling the callback
          * @example
          * var asset = app.assets.find("My Asset");

--- a/src/asset/asset.js
+++ b/src/asset/asset.js
@@ -254,7 +254,7 @@ Object.assign(pc, function () {
 
         /**
         * @callback pc.AssetReadyCallback
-        * @description Function passed to {@link pc.Asset#ready} and callbed when the {@link pc.Asset} is ready.
+        * @description Callback function used by {@link pc.Asset#ready} and called when an asset is ready.
         * @param {pc.Asset} asset The ready asset.
         */
 

--- a/src/asset/asset.js
+++ b/src/asset/asset.js
@@ -253,7 +253,7 @@ Object.assign(pc, function () {
         },
 
         /**
-        * @callback pc.AssetReadyCallback
+        * @callback pc.Asset.readyCallback
         * @description Callback function used by {@link pc.Asset#ready} and called when an asset is ready.
         * @param {pc.Asset} asset The ready asset.
         */
@@ -262,7 +262,7 @@ Object.assign(pc, function () {
          * @function
          * @name pc.Asset#ready
          * @description Take a callback which is called as soon as the asset is loaded. If the asset is already loaded the callback is called straight away
-         * @param {pc.AssetReadyCallback} callback The function called when the asset is ready. Passed the (asset) arguments
+         * @param {pc.Asset.readyCallback} callback The function called when the asset is ready. Passed the (asset) arguments
          * @param {Object} scope Scope object to use when calling the callback
          * @example
          * var asset = app.assets.find("My Asset");

--- a/src/asset/asset.js
+++ b/src/asset/asset.js
@@ -253,10 +253,10 @@ Object.assign(pc, function () {
         },
 
         /**
-        * @callback pc.Asset.readyCallback
-        * @description Callback function used by {@link pc.Asset#ready} and called when an asset is ready.
-        * @param {pc.Asset} asset The ready asset.
-        */
+         * @callback pc.Asset.readyCallback
+         * @description Callback function used by {@link pc.Asset#ready} and called when an asset is ready.
+         * @param {pc.Asset} asset The ready asset.
+         */
 
         /**
          * @function

--- a/src/core/events.js
+++ b/src/core/events.js
@@ -38,11 +38,24 @@ pc.events = {
     },
 
     /**
+    * @callback pc.events.callback
+    * @description Callback function used by {@link pc.events} functions. Note the callback is limited to 8 arguments.
+    * @param {*} [arg1]
+    * @param {*} [arg2]
+    * @param {*} [arg3]
+    * @param {*} [arg4]
+    * @param {*} [arg5]
+    * @param {*} [arg6]
+    * @param {*} [arg7]
+    * @param {*} [arg8]
+    */
+
+    /**
      * @function
      * @name pc.events.on
      * @description Attach an event handler to an event
      * @param {String} name Name of the event to bind the callback to
-     * @param {Function} callback Function that is called when event is fired. Note the callback is limited to 8 arguments.
+     * @param {pc.events.callback} callback Function that is called when event is fired. Note the callback is limited to 8 arguments.
      * @param {Object} [scope] Object to use as 'this' when the event is fired, defaults to current this
      * @returns {*} 'this' for chaining
      * @example
@@ -75,7 +88,7 @@ pc.events = {
      * @description Detach an event handler from an event. If callback is not provided then all callbacks are unbound from the event,
      * if scope is not provided then all events with the callback will be unbound.
      * @param {String} [name] Name of the event to unbind
-     * @param {Function} [callback] Function to be unbound
+     * @param {pc.events.callback} [callback] Function to be unbound.
      * @param {Object} [scope] Scope that was used as the this when the event is fired
      * @returns {*} 'this' for chaining
      * @example
@@ -190,7 +203,7 @@ pc.events = {
      * @name pc.events.once
      * @description Attach an event handler to an event. This handler will be removed after being fired once.
      * @param {String} name Name of the event to bind the callback to
-     * @param {Function} callback Function that is called when event is fired. Note the callback is limited to 8 arguments.
+     * @param {pc.events.callback} callback Function that is called when event is fired. Note the callback is limited to 8 arguments.
      * @param {Object} [scope] Object to use as 'this' when the event is fired, defaults to current this
      * @returns {*} 'this' for chaining
      * @example

--- a/src/core/events.js
+++ b/src/core/events.js
@@ -38,17 +38,17 @@ pc.events = {
     },
 
     /**
-    * @callback pc.events.callback
-    * @description Callback function used by {@link pc.events} functions. Note the callback is limited to 8 arguments.
-    * @param {*} [arg1]
-    * @param {*} [arg2]
-    * @param {*} [arg3]
-    * @param {*} [arg4]
-    * @param {*} [arg5]
-    * @param {*} [arg6]
-    * @param {*} [arg7]
-    * @param {*} [arg8]
-    */
+     * @callback pc.events.callback
+     * @description Callback function used by {@link pc.events} functions. Note the callback is limited to 8 arguments.
+     * @param {*} [arg1] First argument that is passed from caller
+     * @param {*} [arg2] Second argument that is passed from caller
+     * @param {*} [arg3] Third argument that is passed from caller
+     * @param {*} [arg4] Fourth argument that is passed from caller
+     * @param {*} [arg5] Fifth argument that is passed from caller
+     * @param {*} [arg6] Sixth argument that is passed from caller
+     * @param {*} [arg7] Seventh argument that is passed from caller
+     * @param {*} [arg8] Eighth argument that is passed from caller
+     */
 
     /**
      * @function

--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -758,6 +758,7 @@ Object.assign(pc, function () {
         },
 
         /**
+         * @private
          * @callback pc.Application.loadSceneCallback
          * @description Callback function used by {@link pc.Application#loadScene}.
          * @param {String|Null} err The error message in the case where the loading or parsing fails.
@@ -765,6 +766,7 @@ Object.assign(pc, function () {
          */
 
         /**
+         * @private
          * @function
          * @name pc.Application#loadScene
          * @description Load a scene file.

--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -557,11 +557,17 @@ Object.assign(pc, function () {
 
     Object.assign(Application.prototype, {
         /**
+         * @callback pc.Application.configureCallback
+         * @description Callback function used by {@link pc.Application#configure} when configuration file is loaded and parsed (or an error occurs).
+         * @param {String|Null} err The error message in the case where the loading or parsing fails.
+         */
+
+        /**
          * @function
          * @name pc.Application#configure
          * @description Load the application configuration file and apply application properties and fill the asset registry
          * @param {String} url The URL of the configuration file to load
-         * @param {Function} callback The Function called when the configuration file is loaded and parsed
+         * @param {pc.Application.configureCallback} callback The Function called when the configuration file is loaded and parsed (or an error occurs).
          */
         configure: function (url, callback) {
             var self = this;
@@ -589,10 +595,15 @@ Object.assign(pc, function () {
         },
 
         /**
+         * @callback pc.Application.preloadCallback
+         * @description Callback function used by {@link pc.Application#preload} when all assets (marked as 'preload') are loaded.
+         */
+
+        /**
          * @function
          * @name pc.Application#preload
          * @description Load all assets in the asset registry that are marked as 'preload'
-         * @param {Function} callback Function called when all assets are loaded
+         * @param {pc.Application.preloadCallback} callback Function called when all assets are loaded
          */
         preload: function (callback) {
             var self = this;
@@ -683,12 +694,19 @@ Object.assign(pc, function () {
         },
 
         /**
+         * @callback pc.Application.loadSceneHierarchyCallback
+         * @description Callback function used by {@link pc.Application#loadSceneHierarchy}.
+         * @param {String|Null} err The error message in the case where the loading or parsing fails.
+         * @param {pc.Entity} [entity] The loaded root entity if no errors were encountered.
+         */
+
+        /**
          * @function
          * @name pc.Application#loadSceneHierarchy
          * @description Load a scene file, create and initialize the Entity hierarchy
          * and add the hierarchy to the application root Entity.
          * @param {String} url The URL of the scene file. Usually this will be "scene_id.json"
-         * @param {Function} callback The function to call after loading, passed (err, entity) where err is null if no errors occurred.
+         * @param {pc.Application.loadSceneHierarchyCallback} callback The function to call after loading, passed (err, entity) where err is null if no errors occurred.
          * @example
          *
          * app.loadSceneHierarchy("1000.json", function (err, entity) {
@@ -705,11 +723,17 @@ Object.assign(pc, function () {
         },
 
         /**
+         * @callback pc.Application.loadSceneSettingsCallback
+         * @description Callback function used by {@link pc.Application#loadSceneSettings}.
+         * @param {String|Null} err The error message in the case where the loading or parsing fails.
+         */
+
+        /**
          * @function
          * @name pc.Application#loadSceneSettings
          * @description Load a scene file and apply the scene settings to the current scene
          * @param {String} url The URL of the scene file. Usually this will be "scene_id.json"
-         * @param {Function} callback The function called after the settings are applied. Passed (err) where err is null if no error occurred.
+         * @param {pc.Application.loadSceneSettingsCallback} callback The function called after the settings are applied. Passed (err) where err is null if no error occurred.
          * @example
          * app.loadSceneSettings("1000.json", function (err) {
          *     if (!err) {

--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -748,6 +748,30 @@ Object.assign(pc, function () {
             this._sceneRegistry.loadSceneSettings(url, callback);
         },
 
+        /**
+         * @callback pc.Application.loadSceneCallback
+         * @description Callback function used by {@link pc.Application#loadScene}.
+         * @param {String|Null} err The error message in the case where the loading or parsing fails.
+         * @param {pc.Entity} [entity] The loaded root entity if no errors were encountered.
+         */
+
+        /**
+         * @function
+         * @name pc.Application#loadScene
+         * @description Load a scene file.
+         * @param {String} url The URL of the scene file. Usually this will be "scene_id.json"
+         * @param {pc.Application.loadSceneCallback} callback The function to call after loading, passed (err, entity) where err is null if no errors occurred.
+         * @example
+         *
+         * app.loadScene("1000.json", function (err, entity) {
+         *     if (!err) {""
+         *       var e = app.root.find("My New Entity");
+         *     } else {
+         *       // error
+         *     }
+         *   }
+         * });
+         */
         loadScene: function (url, callback) {
             this._sceneRegistry.loadScene(url, callback);
         },

--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -537,6 +537,15 @@ Object.assign(pc, function () {
 
     Application._currentApplication = null;
     Application._applications = {};
+
+    /**
+     * @static
+     * @function
+     * @name pc.Application.getApplication
+     * @description Get the current application (alternatively get application based on the canvas id)
+     * @param {String} [id] If not `undefined`, the returned application should use the canvas which has this id. Otherwise current application will be returned.
+     * @returns {pc.Application} The running application.
+     */
     Application.getApplication = function (id) {
         return id ? Application._applications[id] : Application._currentApplication;
     };

--- a/src/framework/components/camera/component.js
+++ b/src/framework/components/camera/component.js
@@ -1,5 +1,12 @@
 Object.assign(pc, function () {
     /**
+     * @callback pc.CameraComponent.calculateCallback
+     * @description Callback function used by {@link pc.Application#calculateTransform} and {@link pc.Application#calculateProjection}.
+     * @param {pc.Mat4} transformMatrix Output of the function.
+     * @param {Number} view Type of view. Can be pc.VIEW_CENTER, pc.VIEW_LEFT or pc.VIEW_RIGHT. Left and right are only used in stereo rendering.
+     */
+
+    /**
      * @component
      * @constructor
      * @name pc.CameraComponent
@@ -51,11 +58,11 @@ Object.assign(pc, function () {
      * @property {Boolean} frustumCulling Controls the culling of mesh instances against the camera frustum, i.e. if objects outside of camera should be omitted from rendering.
      * If true, culling is enabled.
      * If false, all mesh instances in the scene are rendered by the camera, regardless of visibility. Defaults to false.
-     * @property {Function} calculateTransform Custom function you can provide to calculate the camera transformation matrix manually. Can be used for complex effects like reflections. Function is called using component's scope.
+     * @property {pc.CameraComponent.calculateCallback} calculateTransform Custom function you can provide to calculate the camera transformation matrix manually. Can be used for complex effects like reflections. Function is called using component's scope.
      * Arguments:
      *     <li>{pc.Mat4} transformMatrix: output of the function</li>
      *     <li>{Number} view: Type of view. Can be pc.VIEW_CENTER, pc.VIEW_LEFT or pc.VIEW_RIGHT. Left and right are only used in stereo rendering.</li>
-     * @property {Function} calculateProjection Custom function you can provide to calculate the camera projection matrix manually. Can be used for complex effects like doing oblique projection. Function is called using component's scope.
+     * @property {pc.CameraComponent.calculateCallback} calculateProjection Custom function you can provide to calculate the camera projection matrix manually. Can be used for complex effects like doing oblique projection. Function is called using component's scope.
      * Arguments:
      *     <li>{pc.Mat4} transformMatrix: output of the function</li>
      *     <li>{Number} view: Type of view. Can be pc.VIEW_CENTER, pc.VIEW_LEFT or pc.VIEW_RIGHT. Left and right are only used in stereo rendering.</li>
@@ -448,13 +455,18 @@ Object.assign(pc, function () {
             this.data.isRendering = false;
         },
 
+        /**
+         * @callback pc.CameraComponent.vrCallback
+         * @description Callback function used by {@link pc.CameraComponent#enterVr} and {@link pc.CameraComponent#exitVr}.
+         * @param {String|Null} err On success it is null on failure it is the error message.
+         */
 
         /**
          * @function
          * @name pc.CameraComponent#enterVr
          * @variation 1
          * @description Attempt to start presenting this camera to a {@link pc.VrDisplay}.
-         * @param {Function} callback Function called once to indicate success of failure. The callback takes one argument (err).
+         * @param {pc.CameraComponent.vrCallback} callback Function called once to indicate success of failure. The callback takes one argument (err).
          * On success it returns null on failure it returns the error message.
          * @example
          * // On an entity with a camera component
@@ -472,7 +484,7 @@ Object.assign(pc, function () {
          * @variation 2
          * @description Attempt to start presenting this camera to a {@link pc.VrDisplay}.
          * @param {pc.VrDisplay} display The VrDisplay to present. If not supplied this uses {@link pc.VrManager#display} as the default
-         * @param {Function} callback Function called once to indicate success of failure. The callback takes one argument (err).
+         * @param {pc.CameraComponent.vrCallback} callback Function called once to indicate success of failure. The callback takes one argument (err).
          * On success it returns null on failure it returns the error message.
          * @example
          * // On an entity with a camera component
@@ -532,7 +544,7 @@ Object.assign(pc, function () {
          * @function
          * @name pc.CameraComponent#exitVr
          * @description Attempt to stop presenting this camera.
-         * @param {Function} callback Function called once to indicate success of failure. The callback takes one argument (err).
+         * @param {pc.CameraComponent.vrCallback} callback Function called once to indicate success of failure. The callback takes one argument (err).
          * On success it returns null on failure it returns the error message.
          * @example
          * this.entity.camera.exitVr(function (err) {

--- a/src/framework/script.js
+++ b/src/framework/script.js
@@ -16,7 +16,7 @@ pc.script = (function () {
         app: null,
 
         /**
-        * @callback pc.ScriptCreateCallback
+        * @callback pc.script.createCallback
         * @description Callback function used by {@link pc.script.create}.
         * @param {pc.Application} app The application.
         * @returns {Object} Return the Type of the script resource to be instanced for each Entity.
@@ -28,7 +28,7 @@ pc.script = (function () {
          * @description Create a script resource object. A script file should contain a single call to pc.script.create and the callback should return a script object which will be
          * instantiated when attached to Entities.
          * @param {String} name The name of the script object.
-         * @param {pc.ScriptCreateCallback} callback The callback function which is passed an {pc.Application} object,
+         * @param {pc.script.createCallback} callback The callback function which is passed an {pc.Application} object,
          * which is used to access Entities and Components, and should return the Type of the script resource
          * to be instanced for each Entity.
          * @example
@@ -115,7 +115,7 @@ pc.script = (function () {
         },
 
         /**
-        * @callback pc.ScriptCreateLoadingScreenCallback
+        * @callback pc.script.createLoadingScreenCallback
         * @description Callback function used by {@link pc.script.createLoadingScreen}.
         * @param {pc.Application} app The application.
         */
@@ -126,7 +126,7 @@ pc.script = (function () {
          * @description Handles the creation of the loading screen of the application. A script can subscribe to
          * the events of a {@link pc.Application} to show a loading screen, progress bar etc. In order for this to work
          * you need to set the project's loading screen script to the script that calls this method.
-         * @param  {pc.ScriptCreateLoadingScreenCallback} callback A function which can set up and tear down a customised loading screen.
+         * @param  {pc.script.createLoadingScreenCallback} callback A function which can set up and tear down a customised loading screen.
          * @example
          * pc.script.createLoadingScreen(function (app) {
          *     var showSplashScreen = function () { // }

--- a/src/framework/script.js
+++ b/src/framework/script.js
@@ -17,7 +17,7 @@ pc.script = (function () {
 
         /**
         * @callback pc.ScriptCreateCallback
-        * @description Function passed into {@link pc.script.create}.
+        * @description Callback function used by {@link pc.script.create}.
         * @param {pc.Application} app The application.
         * @returns {Object} Return the Type of the script resource to be instanced for each Entity.
         */
@@ -116,7 +116,7 @@ pc.script = (function () {
 
         /**
         * @callback pc.ScriptCreateLoadingScreenCallback
-        * @description Function passed into {@link pc.script.createLoadingScreen}.
+        * @description Callback function used by {@link pc.script.createLoadingScreen}.
         * @param {pc.Application} app The application.
         */
 

--- a/src/framework/script.js
+++ b/src/framework/script.js
@@ -16,11 +16,11 @@ pc.script = (function () {
         app: null,
 
         /**
-        * @callback pc.script.createCallback
-        * @description Callback function used by {@link pc.script.create}.
-        * @param {pc.Application} app The application.
-        * @returns {Object} Return the Type of the script resource to be instanced for each Entity.
-        */
+         * @callback pc.script.createCallback
+         * @description Callback function used by {@link pc.script.create}.
+         * @param {pc.Application} app The application.
+         * @returns {Object} Return the Type of the script resource to be instanced for each Entity.
+         */
 
         /**
          * @function
@@ -115,10 +115,10 @@ pc.script = (function () {
         },
 
         /**
-        * @callback pc.script.createLoadingScreenCallback
-        * @description Callback function used by {@link pc.script.createLoadingScreen}.
-        * @param {pc.Application} app The application.
-        */
+         * @callback pc.script.createLoadingScreenCallback
+         * @description Callback function used by {@link pc.script.createLoadingScreen}.
+         * @param {pc.Application} app The application.
+         */
 
         /**
          * @function

--- a/src/framework/script.js
+++ b/src/framework/script.js
@@ -16,12 +16,19 @@ pc.script = (function () {
         app: null,
 
         /**
+        * @callback pc.ScriptCreateCallback
+        * @description Function passed into {@link pc.script.create}.
+        * @param {pc.Application} app The application.
+        * @returns {Object} Return the Type of the script resource to be instanced for each Entity.
+        */
+
+        /**
          * @function
          * @name pc.script.create
          * @description Create a script resource object. A script file should contain a single call to pc.script.create and the callback should return a script object which will be
          * instantiated when attached to Entities.
          * @param {String} name The name of the script object.
-         * @param {Function} callback The callback function which is passed an {pc.Application} object,
+         * @param {pc.ScriptCreateCallback} callback The callback function which is passed an {pc.Application} object,
          * which is used to access Entities and Components, and should return the Type of the script resource
          * to be instanced for each Entity.
          * @example
@@ -108,12 +115,18 @@ pc.script = (function () {
         },
 
         /**
+        * @callback pc.ScriptCreateLoadingScreenCallback
+        * @description Function passed into {@link pc.script.createLoadingScreen}.
+        * @param {pc.Application} app The application.
+        */
+
+        /**
          * @function
          * @name pc.script.createLoadingScreen
          * @description Handles the creation of the loading screen of the application. A script can subscribe to
          * the events of a {@link pc.Application} to show a loading screen, progress bar etc. In order for this to work
          * you need to set the project's loading screen script to the script that calls this method.
-         * @param  {Function} callback A function which can set up and tear down a customised loading screen.
+         * @param  {pc.ScriptCreateLoadingScreenCallback} callback A function which can set up and tear down a customised loading screen.
          * @example
          * pc.script.createLoadingScreen(function (app) {
          *     var showSplashScreen = function () { // }

--- a/src/input/mouse.js
+++ b/src/input/mouse.js
@@ -215,6 +215,11 @@ Object.assign(pc, function () {
         },
 
         /**
+         * @callback pc.Mouse.pointerLockCallback
+         * @description Callback function used by {@link pc.Mouse#enablePointerLock} and {@link pc.Application#disablePointerLock}.
+         */
+
+        /**
          * @function
          * @name pc.Mouse#enablePointerLock
          * @description Request that the browser hides the mouse cursor and locks the mouse to the element.
@@ -224,8 +229,8 @@ Object.assign(pc, function () {
          * <li>In some browsers this will only work when the browser is running in fullscreen mode. See {@link pc.Application#enableFullscreen}
          * <li>Enabling pointer lock can only be initiated by a user action e.g. in the event handler for a mouse or keyboard input.
          * </ul>
-         * @param {Function} [success] Function called if the request for mouse lock is successful.
-         * @param {Function} [error] Function called if the request for mouse lock is unsuccessful.
+         * @param {pc.Mouse.pointerLockCallback} [success] Function called if the request for mouse lock is successful.
+         * @param {pc.Mouse.pointerLockCallback} [error] Function called if the request for mouse lock is unsuccessful.
          */
         enablePointerLock: function (success, error) {
             if (!document.body.requestPointerLock) {
@@ -259,7 +264,7 @@ Object.assign(pc, function () {
          * @function
          * @name pc.Mouse#disablePointerLock
          * @description Return control of the mouse cursor to the user
-         * @param {Function} [success] Function called when the mouse lock is disabled
+         * @param {pc.Mouse.pointerLockCallback} [success] Function called when the mouse lock is disabled
          */
         disablePointerLock: function (success) {
             if (!document.exitPointerLock) {

--- a/src/net/http.js
+++ b/src/net/http.js
@@ -54,12 +54,19 @@ Object.assign(pc, function () {
         binaryExtensions: Http.binaryExtensions,
 
         /**
+         * @callback pc.Http.callback
+         * @description Callback function used by {@link pc.Http#get}, {@link pc.Http#post}, {@link pc.Http#put}, {@link pc.Http#del}, and {@link pc.Http#request}.
+         * @param {Number|String|Error|Null} err The error code, message, or exception in the case where the request fails.
+         * @param {*} [response] The response data if no errors were encountered. (format depends on response type: text, Object, ArrayBuffer, XML).
+         */
+
+        /**
          * @function
          * @name pc.Http#get
          * @variation 1
          * @description Perform an HTTP GET request to the given url.
          * @param {String} url The URL to make the request to.
-         * @param {Function} callback The callback used when the response has returned. Passed (err, data)
+         * @param {pc.Http.callback} callback The callback used when the response has returned. Passed (err, data)
          * where data is the response (format depends on response type: text, Object, ArrayBuffer, XML) and
          * err is the error code.
          * @example
@@ -86,7 +93,7 @@ Object.assign(pc, function () {
          * @param {Boolean} [options.retry] If true then if the request fails it will be retried with an exponential backoff.
          * @param {Number} [options.maxRetries] If options.retry is true this specifies the maximum number of retries. Defaults to 5.
          * @param {Number} [options.maxRetryDelay] If options.retry is true this specifies the maximum amount of time to wait between retries in milliseconds. Defaults to 5000.
-         * @param {Function} callback The callback used when the response has returned. Passed (err, data)
+         * @param {pc.Http.callback} callback The callback used when the response has returned. Passed (err, data)
          * where data is the response (format depends on response type: text, Object, ArrayBuffer, XML) and
          * err is the error code.
          * @returns {XMLHttpRequest} The request object.
@@ -109,7 +116,7 @@ Object.assign(pc, function () {
          * Some content types are handled automatically. If postdata is an XML Document, it is handled. If
          * the Content-Type header is set to 'application/json' then the postdata is JSON stringified.
          * Otherwise, by default, the data is sent as form-urlencoded.
-         * @param {Function} callback The callback used when the response has returned. Passed (err, data)
+         * @param {pc.Http.callback} callback The callback used when the response has returned. Passed (err, data)
          * where data is the response (format depends on response type: text, Object, ArrayBuffer, XML) and
          * err is the error code.
          * @returns {XMLHttpRequest} The request object.
@@ -132,7 +139,7 @@ Object.assign(pc, function () {
          * @param {Boolean} [options.retry] If true then if the request fails it will be retried with an exponential backoff.
          * @param {Number} [options.maxRetries] If options.retry is true this specifies the maximum number of retries. Defaults to 5.
          * @param {Number} [options.maxRetryDelay] If options.retry is true this specifies the maximum amount of time to wait between retries in milliseconds. Defaults to 5000.
-         * @param {Function} callback The callback used when the response has returned. Passed (err, data)
+         * @param {pc.Http.callback} callback The callback used when the response has returned. Passed (err, data)
          * where data is the response (format depends on response type: text, Object, ArrayBuffer, XML) and
          * err is the error code.
          * @returns {XMLHttpRequest} The request object.
@@ -156,7 +163,7 @@ Object.assign(pc, function () {
          * Some content types are handled automatically. If postdata is an XML Document, it is handled. If
          * the Content-Type header is set to 'application/json' then the postdata is JSON stringified.
          * Otherwise, by default, the data is sent as form-urlencoded.
-         * @param {Function} callback The callback used when the response has returned. Passed (err, data)
+         * @param {pc.Http.callback} callback The callback used when the response has returned. Passed (err, data)
          * where data is the response (format depends on response type: text, Object, ArrayBuffer, XML) and
          * err is the error code.
          * @returns {XMLHttpRequest} The request object.
@@ -179,7 +186,7 @@ Object.assign(pc, function () {
          * @param {Boolean} [options.retry] If true then if the request fails it will be retried with an exponential backoff.
          * @param {Number} [options.maxRetries] If options.retry is true this specifies the maximum number of retries. Defaults to 5.
          * @param {Number} [options.maxRetryDelay] If options.retry is true this specifies the maximum amount of time to wait between retries in milliseconds. Defaults to 5000.
-         * @param {Function} callback The callback used when the response has returned. Passed (err, data)
+         * @param {pc.Http.callback} callback The callback used when the response has returned. Passed (err, data)
          * where data is the response (format depends on response type: text, Object, ArrayBuffer, XML) and
          * err is the error code.
          * @returns {XMLHttpRequest} The request object.
@@ -199,7 +206,7 @@ Object.assign(pc, function () {
          * @variation 1
          * @description Perform an HTTP DELETE request to the given url
          * @param {Object} url The URL to make the request to
-         * @param {Function} callback The callback used when the response has returned. Passed (err, data)
+         * @param {pc.Http.callback} callback The callback used when the response has returned. Passed (err, data)
          * where data is the response (format depends on response type: text, Object, ArrayBuffer, XML) and
          * err is the error code.
          * @returns {XMLHttpRequest} The request object.
@@ -222,7 +229,7 @@ Object.assign(pc, function () {
          * @param {Boolean} [options.retry] If true then if the request fails it will be retried with an exponential backoff.
          * @param {Number} [options.maxRetries] If options.retry is true this specifies the maximum number of retries. Defaults to 5.
          * @param {Number} [options.maxRetryDelay] If options.retry is true this specifies the maximum amount of time to wait between retries in milliseconds. Defaults to 5000.
-         * @param {Function} callback The callback used when the response has returned. Passed (err, data)
+         * @param {pc.Http.callback} callback The callback used when the response has returned. Passed (err, data)
          * where data is the response (format depends on response type: text, Object, ArrayBuffer, XML) and
          * err is the error code.
          * @returns {XMLHttpRequest} The request object.
@@ -242,7 +249,7 @@ Object.assign(pc, function () {
          * @description Make a general purpose HTTP request.
          * @param {String} method The HTTP method "GET", "POST", "PUT", "DELETE"
          * @param {String} url The url to make the request to
-         * @param {Function} callback The callback used when the response has returned. Passed (err, data)
+         * @param {pc.Http.callback} callback The callback used when the response has returned. Passed (err, data)
          * where data is the response (format depends on response type: text, Object, ArrayBuffer, XML) and
          * err is the error code.
          * @returns {XMLHttpRequest} The request object.
@@ -266,7 +273,7 @@ Object.assign(pc, function () {
          * Some content types are handled automatically. If postdata is an XML Document, it is handled. If
          * the Content-Type header is set to 'application/json' then the postdata is JSON stringified.
          * Otherwise, by default, the data is sent as form-urlencoded.
-         * @param {Function} callback The callback used when the response has returned. Passed (err, data)
+         * @param {pc.Http.callback} callback The callback used when the response has returned. Passed (err, data)
          * where data is the response (format depends on response type: text, Object, ArrayBuffer, XML) and
          * err is the error code.
          * @returns {XMLHttpRequest} The request object.

--- a/src/resources/handler.js
+++ b/src/resources/handler.js
@@ -13,7 +13,7 @@ Object.assign(pc, function () {
         * @callback pc.ResourceHandler.loadCallback
         * @description Callback function used by {@link pc.ResourceHandler#load} when a resource is loaded (or an error occurs).
         * @param {String|Null} err The error message in the case where the load fails.
-        * @param {*} response The raw data that has been successfully loaded.
+        * @param {*} [response] The raw data that has been successfully loaded.
         */
 
         /**

--- a/src/resources/handler.js
+++ b/src/resources/handler.js
@@ -10,11 +10,11 @@ Object.assign(pc, function () {
     Object.assign(ResourceHandler.prototype, {
 
         /**
-        * @callback pc.ResourceHandler.loadCallback
-        * @description Callback function used by {@link pc.ResourceHandler#load} when a resource is loaded (or an error occurs).
-        * @param {String|Null} err The error message in the case where the load fails.
-        * @param {*} [response] The raw data that has been successfully loaded.
-        */
+         * @callback pc.ResourceHandler.loadCallback
+         * @description Callback function used by {@link pc.ResourceHandler#load} when a resource is loaded (or an error occurs).
+         * @param {String|Null} err The error message in the case where the load fails.
+         * @param {*} [response] The raw data that has been successfully loaded.
+         */
 
         /**
          * @function

--- a/src/resources/handler.js
+++ b/src/resources/handler.js
@@ -10,7 +10,7 @@ Object.assign(pc, function () {
     Object.assign(ResourceHandler.prototype, {
 
         /**
-        * @callback pc.ResourceHandlerLoadCallback
+        * @callback pc.ResourceHandler.loadCallback
         * @description Callback function used by {@link pc.ResourceHandler#load} when a resource is loaded (or an error occurs).
         * @param {String|Null} err The error message in the case where the load fails.
         * @param {*} response The raw data that has been successfully loaded.
@@ -22,7 +22,7 @@ Object.assign(pc, function () {
          * @description Load a resource from a remote URL. When loaded (or failed),
          * use the callback to return an the raw resource data (or error).
          * @param {String} url The URL of the resource to load.
-         * @param {pc.ResourceHandlerLoadCallback} callback The callback used when the resource is loaded or an error occurs.
+         * @param {pc.ResourceHandler.loadCallback} callback The callback used when the resource is loaded or an error occurs.
          * @param {pc.Asset} [asset] Optional asset that is passed by ResourceLoader.
          */
         load: function (url, callback, asset) {

--- a/src/resources/handler.js
+++ b/src/resources/handler.js
@@ -11,7 +11,7 @@ Object.assign(pc, function () {
 
         /**
         * @callback pc.ResourceHandlerLoadCallback
-        * @description Callback function called when the {@link pc.ResourceHandler#load} completes.
+        * @description Callback function used by {@link pc.ResourceHandler#load} when a resource is loaded (or an error occurs).
         * @param {String|Null} err The error message in the case where the load fails.
         * @param {*} response The raw data that has been successfully loaded.
         */

--- a/src/resources/handler.js
+++ b/src/resources/handler.js
@@ -10,12 +10,19 @@ Object.assign(pc, function () {
     Object.assign(ResourceHandler.prototype, {
 
         /**
+        * @callback pc.ResourceHandlerLoadCallback
+        * @description Callback function called when the {@link pc.ResourceHandler#load} completes.
+        * @param {String|Null} err The error message in the case where the load fails.
+        * @param {*} response The raw data that has been successfully loaded.
+        */
+
+        /**
          * @function
          * @name pc.ResourceHandler#load
          * @description Load a resource from a remote URL. When loaded (or failed),
          * use the callback to return an the raw resource data (or error).
          * @param {String} url The URL of the resource to load.
-         * @param {Function} callback The callback used when the resource is loaded or an error occurs.
+         * @param {pc.ResourceHandlerLoadCallback} callback The callback used when the resource is loaded or an error occurs.
          * @param {pc.Asset} [asset] Optional asset that is passed by ResourceLoader.
          */
         load: function (url, callback, asset) {

--- a/src/resources/loader.js
+++ b/src/resources/loader.js
@@ -42,7 +42,7 @@ Object.assign(pc, function () {
 
         /**
         * @callback pc.ResourceLoaderCallback
-        * @description The callback passed into {@link pc.ResourceLoader#load} and called when the resource is loaded or an error occur.
+        * @description Callback function used by {@link pc.ResourceLoader#load} when a resource is loaded (or an error occurs).
         * @param {String|Null} err The error message in the case where the load fails.
         * @param {*} resource The resource that has been successfully loaded.
         */

--- a/src/resources/loader.js
+++ b/src/resources/loader.js
@@ -41,7 +41,7 @@ Object.assign(pc, function () {
         },
 
         /**
-        * @callback pc.ResourceLoaderCallback
+        * @callback pc.ResourceLoader.loadCallback
         * @description Callback function used by {@link pc.ResourceLoader#load} when a resource is loaded (or an error occurs).
         * @param {String|Null} err The error message in the case where the load fails.
         * @param {*} resource The resource that has been successfully loaded.
@@ -55,7 +55,7 @@ Object.assign(pc, function () {
          * the resource.
          * @param {String} url The URL of the resource to load.
          * @param {String} type The type of resource expected.
-         * @param {pc.ResourceLoaderCallback} callback The callback used when the resource is loaded or an error occurs.
+         * @param {pc.ResourceLoader.loadCallback} callback The callback used when the resource is loaded or an error occurs.
          * @param {pc.Asset} [asset] Optional asset that is passed into handler
          * Passed (err, resource) where err is null if there are no errors.
          * @example

--- a/src/resources/loader.js
+++ b/src/resources/loader.js
@@ -41,6 +41,13 @@ Object.assign(pc, function () {
         },
 
         /**
+        * @callback pc.ResourceLoaderCallback
+        * @description The callback passed into {@link pc.ResourceLoader#load} and called when the resource is loaded or an error occur.
+        * @param {String|Null} err The error message in the case where the load fails.
+        * @param {*} resource The resource that has been successfully loaded.
+        */
+
+        /**
          * @function
          * @name pc.ResourceLoader#load
          * @description Make a request for a resource from a remote URL. Parse the returned data using the
@@ -48,7 +55,7 @@ Object.assign(pc, function () {
          * the resource.
          * @param {String} url The URL of the resource to load.
          * @param {String} type The type of resource expected.
-         * @param {Function} callback The callback used when the resource is loaded or an error occurs.
+         * @param {pc.ResourceLoaderCallback} callback The callback used when the resource is loaded or an error occurs.
          * @param {pc.Asset} [asset] Optional asset that is passed into handler
          * Passed (err, resource) where err is null if there are no errors.
          * @example

--- a/src/resources/loader.js
+++ b/src/resources/loader.js
@@ -44,7 +44,7 @@ Object.assign(pc, function () {
         * @callback pc.ResourceLoader.loadCallback
         * @description Callback function used by {@link pc.ResourceLoader#load} when a resource is loaded (or an error occurs).
         * @param {String|Null} err The error message in the case where the load fails.
-        * @param {*} resource The resource that has been successfully loaded.
+        * @param {*} [resource] The resource that has been successfully loaded.
         */
 
         /**

--- a/src/resources/loader.js
+++ b/src/resources/loader.js
@@ -41,11 +41,11 @@ Object.assign(pc, function () {
         },
 
         /**
-        * @callback pc.ResourceLoader.loadCallback
-        * @description Callback function used by {@link pc.ResourceLoader#load} when a resource is loaded (or an error occurs).
-        * @param {String|Null} err The error message in the case where the load fails.
-        * @param {*} [resource] The resource that has been successfully loaded.
-        */
+         * @callback pc.ResourceLoader.loadCallback
+         * @description Callback function used by {@link pc.ResourceLoader#load} when a resource is loaded (or an error occurs).
+         * @param {String|Null} err The error message in the case where the load fails.
+         * @param {*} [resource] The resource that has been successfully loaded.
+         */
 
         /**
          * @function

--- a/src/resources/model.js
+++ b/src/resources/model.js
@@ -141,7 +141,7 @@ Object.assign(pc, function () {
 
         /**
         * @callback pc.ModelHandlerParserCallback
-        * @description Function that decides on which parser to use, when passed into {@link pc.ModelHandler#addParser}.
+        * @description Callback function used by {@link pc.ModelHandler#addParser} to decide on which parser to use.
         * @param {String} url The resource url.
         * @param {Object} data The raw model data.
         * @returns {Boolean} Return true if this parser should be used to parse the data into a {@link pc.Model}

--- a/src/resources/model.js
+++ b/src/resources/model.js
@@ -140,12 +140,20 @@ Object.assign(pc, function () {
         },
 
         /**
+        * @callback pc.ModelHandlerParserCallback
+        * @description Function that decides on which parser to use, when passed into {@link pc.ModelHandler#addParser}.
+        * @param {String} url The resource url.
+        * @param {Object} data The raw model data.
+        * @returns {Boolean} Return true if this parser should be used to parse the data into a {@link pc.Model}
+        */
+
+        /**
          * @function
          * @name pc.ModelHandler#addParser
          * @description Add a parser that converts raw data into a {@link pc.Model}
          * Default parser is for JSON models
          * @param {Object} parser See JsonModelParser for example
-         * @param {Function} decider Function that decides on which parser to use.
+         * @param {ModelHandlerParserCallback} decider Function that decides on which parser to use.
          * Function should take (url, data) arguments and return true if this parser should be used to parse the data into a {@link pc.Model}.
          * The first parser to return true is used.
          */

--- a/src/resources/model.js
+++ b/src/resources/model.js
@@ -26,7 +26,7 @@ Object.assign(pc, function () {
          * @param {String} url The URL of the model data.
          * @param {pc.ResourceHandlerLoadCallback} callback Callback function called when the load completes. The
          * callback is of the form fn(err, response), where err is a String error message in
-         * the case where the load fails, and repsponse is the model data that has been
+         * the case where the load fails, and response is the model data that has been
          * successfully loaded.
          */
         load: function (url, callback) {

--- a/src/resources/model.js
+++ b/src/resources/model.js
@@ -140,12 +140,12 @@ Object.assign(pc, function () {
         },
 
         /**
-        * @callback pc.ModelHandler.addParserCallback
-        * @description Callback function used by {@link pc.ModelHandler#addParser} to decide on which parser to use.
-        * @param {String} url The resource url.
-        * @param {Object} data The raw model data.
-        * @returns {Boolean} Return true if this parser should be used to parse the data into a {@link pc.Model}
-        */
+         * @callback pc.ModelHandler.addParserCallback
+         * @description Callback function used by {@link pc.ModelHandler#addParser} to decide on which parser to use.
+         * @param {String} url The resource url.
+         * @param {Object} data The raw model data.
+         * @returns {Boolean} Return true if this parser should be used to parse the data into a {@link pc.Model}
+         */
 
         /**
          * @function

--- a/src/resources/model.js
+++ b/src/resources/model.js
@@ -24,7 +24,7 @@ Object.assign(pc, function () {
          * @name pc.ModelHandler#load
          * @description Fetch model data from a remote url
          * @param {String} url The URL of the model data.
-         * @param {Function} callback Callback function called when the load completes. The
+         * @param {pc.ResourceHandlerLoadCallback} callback Callback function called when the load completes. The
          * callback is of the form fn(err, response), where err is a String error message in
          * the case where the load fails, and repsponse is the model data that has been
          * successfully loaded.

--- a/src/resources/model.js
+++ b/src/resources/model.js
@@ -24,7 +24,7 @@ Object.assign(pc, function () {
          * @name pc.ModelHandler#load
          * @description Fetch model data from a remote url
          * @param {String} url The URL of the model data.
-         * @param {pc.ResourceHandlerLoadCallback} callback Callback function called when the load completes. The
+         * @param {pc.ResourceHandler.loadCallback} callback Callback function called when the load completes. The
          * callback is of the form fn(err, response), where err is a String error message in
          * the case where the load fails, and response is the model data that has been
          * successfully loaded.
@@ -140,7 +140,7 @@ Object.assign(pc, function () {
         },
 
         /**
-        * @callback pc.ModelHandlerParserCallback
+        * @callback pc.ModelHandler.addParserCallback
         * @description Callback function used by {@link pc.ModelHandler#addParser} to decide on which parser to use.
         * @param {String} url The resource url.
         * @param {Object} data The raw model data.
@@ -153,7 +153,7 @@ Object.assign(pc, function () {
          * @description Add a parser that converts raw data into a {@link pc.Model}
          * Default parser is for JSON models
          * @param {Object} parser See JsonModelParser for example
-         * @param {ModelHandlerParserCallback} decider Function that decides on which parser to use.
+         * @param {pc.ModelHandler.addParserCallback} decider Function that decides on which parser to use.
          * Function should take (url, data) arguments and return true if this parser should be used to parse the data into a {@link pc.Model}.
          * The first parser to return true is used.
          */

--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -279,7 +279,7 @@ Object.assign(pc, function () {
         },
 
         /**
-        * @callback pc.GraphNodeFindCallback
+        * @callback pc.GraphNode.findCallback
         * @description Callback function used by {@link pc.GraphNode#find} to search through a graph node and all of its descendants.
         * @param {pc.GraphNode} node The current graph node.
         * @returns {Boolean} Returning `true` from the function will include the node into the results from {@link pc.GraphNode#find}.
@@ -289,7 +289,7 @@ Object.assign(pc, function () {
          * @function
          * @name pc.GraphNode#find
          * @description Search the graph node and all of its descendants for the nodes that satisfy some search criteria.
-         * @param {pc.GraphNodeFindCallback|String} attr This can either be a function or a string. If it's a function, it is executed
+         * @param {pc.GraphNode.findCallback|String} attr This can either be a function or a string. If it's a function, it is executed
          * for each descendant node to test if node satisfies the search logic. Returning true from the function will
          * include the node into the results. If it's a string then it represents the name of a field or a method of the
          * node. If this is the name of a field then the value passed as the second argument will be checked for equality.
@@ -347,7 +347,7 @@ Object.assign(pc, function () {
         },
 
         /**
-        * @callback pc.GraphNodeFindOneCallback
+        * @callback pc.GraphNode.findOneCallback
         * @description Callback function used by {@link pc.GraphNode#findOne} to search through a graph node and all of its descendants.
         * @param {pc.GraphNode} node The current graph node.
         * @returns {Boolean} Returning `true` from the function will result in that node being returned from {@link pc.GraphNode#findOne}.
@@ -357,7 +357,7 @@ Object.assign(pc, function () {
          * @function
          * @name pc.GraphNode#findOne
          * @description Search the graph node and all of its descendants for the first node that satisfies some search criteria.
-         * @param {pc.GraphNodeFindOneCallback|String} attr This can either be a function or a string. If it's a function, it is executed
+         * @param {pc.GraphNode.findOneCallback|String} attr This can either be a function or a string. If it's a function, it is executed
          * for each descendant node to test if node satisfies the search logic. Returning true from the function will
          * result in that node being returned from findOne. If it's a string then it represents the name of a field or a method of the
          * node. If this is the name of a field then the value passed as the second argument will be checked for equality.
@@ -515,7 +515,7 @@ Object.assign(pc, function () {
         },
 
         /**
-        * @callback pc.GraphNodeForEachCallback
+        * @callback pc.GraphNode.forEachCallback
         * @description Callback function used by {@link pc.GraphNode#forEach} to iterate through a graph node and all of its descendants.
         * @param {pc.GraphNode} node The current graph node.
         */
@@ -524,7 +524,7 @@ Object.assign(pc, function () {
          * @function
          * @name pc.GraphNode#forEach
          * @description Executes a provided function once on this graph node and all of its descendants.
-         * @param {pc.GraphNodeForEachCallback} callback The function to execute on the graph node and each descendant.
+         * @param {pc.GraphNode.forEachCallback} callback The function to execute on the graph node and each descendant.
          * @param {Object} [thisArg] Optional value to use as this when executing callback function.
          * @example
          * // Log the path and name of each node in descendant tree starting with "parent"

--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -279,10 +279,17 @@ Object.assign(pc, function () {
         },
 
         /**
+        * @callback pc.GraphNodeFindCallback
+        * @description Callback function used by {@link pc.GraphNode#find} to search through a graph node and all of its descendants.
+        * @param {pc.GraphNode} node The current graph node.
+        * @returns {Boolean} Returning `true` from the function will include the node into the results from {@link pc.GraphNode#find}.
+        */
+
+        /**
          * @function
          * @name pc.GraphNode#find
          * @description Search the graph node and all of its descendants for the nodes that satisfy some search criteria.
-         * @param {Function|String} attr This can either be a function or a string. If it's a function, it is executed
+         * @param {pc.GraphNodeFindCallback|String} attr This can either be a function or a string. If it's a function, it is executed
          * for each descendant node to test if node satisfies the search logic. Returning true from the function will
          * include the node into the results. If it's a string then it represents the name of a field or a method of the
          * node. If this is the name of a field then the value passed as the second argument will be checked for equality.
@@ -340,10 +347,17 @@ Object.assign(pc, function () {
         },
 
         /**
+        * @callback pc.GraphNodeFindOneCallback
+        * @description Callback function used by {@link pc.GraphNode#findOne} to search through a graph node and all of its descendants.
+        * @param {pc.GraphNode} node The current graph node.
+        * @returns {Boolean} Returning `true` from the function will result in that node being returned from {@link pc.GraphNode#findOne}.
+        */
+
+        /**
          * @function
          * @name pc.GraphNode#findOne
          * @description Search the graph node and all of its descendants for the first node that satisfies some search criteria.
-         * @param {Function|String} attr This can either be a function or a string. If it's a function, it is executed
+         * @param {pc.GraphNodeFindOneCallback|String} attr This can either be a function or a string. If it's a function, it is executed
          * for each descendant node to test if node satisfies the search logic. Returning true from the function will
          * result in that node being returned from findOne. If it's a string then it represents the name of a field or a method of the
          * node. If this is the name of a field then the value passed as the second argument will be checked for equality.
@@ -501,10 +515,16 @@ Object.assign(pc, function () {
         },
 
         /**
+        * @callback pc.GraphNodeForEachCallback
+        * @description Callback function used by {@link pc.GraphNode#forEach} to iterate through a graph node and all of its descendants.
+        * @param {pc.GraphNode} node The current graph node.
+        */
+
+        /**
          * @function
          * @name pc.GraphNode#forEach
          * @description Executes a provided function once on this graph node and all of its descendants.
-         * @param {Function} callback The function to execute on the graph node and each descendant.
+         * @param {pc.GraphNodeForEachCallback} callback The function to execute on the graph node and each descendant.
          * @param {Object} [thisArg] Optional value to use as this when executing callback function.
          * @example
          * // Log the path and name of each node in descendant tree starting with "parent"

--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -279,11 +279,11 @@ Object.assign(pc, function () {
         },
 
         /**
-        * @callback pc.GraphNode.findCallback
-        * @description Callback function used by {@link pc.GraphNode#find} to search through a graph node and all of its descendants.
-        * @param {pc.GraphNode} node The current graph node.
-        * @returns {Boolean} Returning `true` from the function will include the node into the results from {@link pc.GraphNode#find}.
-        */
+         * @callback pc.GraphNode.findCallback
+         * @description Callback function used by {@link pc.GraphNode#find} to search through a graph node and all of its descendants.
+         * @param {pc.GraphNode} node The current graph node.
+         * @returns {Boolean} Returning `true` from the function will include the node into the results from {@link pc.GraphNode#find}.
+         */
 
         /**
          * @function
@@ -347,11 +347,11 @@ Object.assign(pc, function () {
         },
 
         /**
-        * @callback pc.GraphNode.findOneCallback
-        * @description Callback function used by {@link pc.GraphNode#findOne} to search through a graph node and all of its descendants.
-        * @param {pc.GraphNode} node The current graph node.
-        * @returns {Boolean} Returning `true` from the function will result in that node being returned from {@link pc.GraphNode#findOne}.
-        */
+         * @callback pc.GraphNode.findOneCallback
+         * @description Callback function used by {@link pc.GraphNode#findOne} to search through a graph node and all of its descendants.
+         * @param {pc.GraphNode} node The current graph node.
+         * @returns {Boolean} Returning `true` from the function will result in that node being returned from {@link pc.GraphNode#findOne}.
+         */
 
         /**
          * @function
@@ -515,10 +515,10 @@ Object.assign(pc, function () {
         },
 
         /**
-        * @callback pc.GraphNode.forEachCallback
-        * @description Callback function used by {@link pc.GraphNode#forEach} to iterate through a graph node and all of its descendants.
-        * @param {pc.GraphNode} node The current graph node.
-        */
+         * @callback pc.GraphNode.forEachCallback
+         * @description Callback function used by {@link pc.GraphNode#forEach} to iterate through a graph node and all of its descendants.
+         * @param {pc.GraphNode} node The current graph node.
+         */
 
         /**
          * @function

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -1,5 +1,13 @@
 Object.assign(pc, function () {
     /**
+     * @callback pc.StandardMaterial.onUpdateShaderCallback
+     * @description Callback function used by {@link pc.Application#onUpdateShader}.
+     * @param {Object} options An object with shader generator settings (based on current material and scene properties), that you can change and then return.
+     * Properties of the object passed into this function are documented in {@link pc.Application#onUpdateShader}.
+     * @returns {Object} Returned settings will be used by the shader.
+     */
+
+    /**
      * @constructor
      * @name pc.StandardMaterial
      * @classdesc A Standard material is the main, general purpose material that is most often used for rendering.
@@ -163,7 +171,7 @@ Object.assign(pc, function () {
      * @property {Boolean} pixelSnap Align vertices to pixel co-ordinates when rendering. Useful for pixel perfect 2D graphics
      * @property {Boolean} twoSidedLighting Calculate proper normals (and therefore lighting) on backfaces
      *
-     * @property {Function} onUpdateShader A custom function that will be called after all shader generator properties are collected and before shader code is generated.
+     * @property {pc.StandardMaterial.onUpdateShaderCallback} onUpdateShader A custom function that will be called after all shader generator properties are collected and before shader code is generated.
      * This function will receive an object with shader generator settings (based on current material and scene properties), that you can change and then return.
      * Returned value will be used instead. This is mostly useful when rendering the same set of objects, but with different shader variations based on the same material.
      * For example, you may wish to render a depth or normal pass using textures assigned to the material, a reflection pass with simpler shaders and so on.

--- a/src/vr/vr-display.js
+++ b/src/vr/vr-display.js
@@ -210,10 +210,16 @@ Object.assign(pc, function () {
         },
 
         /**
+         * @callback pc.VrDisplay.presentCallback
+         * @description Callback function used by {@link pc.VrDisplay#requestPresent} and {@link pc.VrDisplay#exitPresent}.
+         * @param {String|Null} err The error message if presenting fails, or null if the call succeeds.
+         */
+
+        /**
          * @function
          * @name pc.VrDisplay#requestPresent
          * @description Try to present full screen VR content on this display
-         * @param {Function} callback Called when the request is completed. Callback takes a single argument (err) that is the error message return
+         * @param {pc.VrDisplay.presentCallback} callback Called when the request is completed. Callback takes a single argument (err) that is the error message return
          * if presenting fails, or null if the call succeeds. Usually called by {@link pc.CameraComponent#enterVr}.
          */
         requestPresent: function (callback) {
@@ -238,7 +244,7 @@ Object.assign(pc, function () {
          * @function
          * @name pc.VrDisplay#exitPresent
          * @description Try to stop presenting VR content on this display
-         * @param {Function} callback Called when the request is completed. Callback takes a single argument (err) that is the error message return
+         * @param {pc.VrDisplay.presentCallback} callback Called when the request is completed. Callback takes a single argument (err) that is the error message return
          * if presenting fails, or null if the call succeeds. Usually called by {@link pc.CameraComponent#exitVr}.
          */
         exitPresent: function (callback) {
@@ -259,10 +265,15 @@ Object.assign(pc, function () {
         },
 
         /**
+         * @callback pc.VrDisplay.requestAnimationFrameCallback
+         * @description Callback function used by {@link pc.VrDisplay#requestAnimationFrame}.
+         */
+
+        /**
          * @function
          * @name pc.VrDisplay#requestAnimationFrame
          * @description Used in the main application loop instead of the regular `window.requestAnimationFrame`. Usually only called from inside {@link pc.Application}
-         * @param {Function} fn Function called when it is time to update the frame.
+         * @param {pc.VrDisplay.requestAnimationFrameCallback} fn Function called when it is time to update the frame.
          */
         requestAnimationFrame: function (fn) {
             if (this.display) this.display.requestAnimationFrame(fn);


### PR DESCRIPTION
The PR adds proper jsdoc `@callback` tags for all callbacks used by:
- `pc.Asset#ready`
- `pc.AssetRegistry#load`
- `pc.AssetRegistry#filter`
- `pc.script.create`
- `pc.script.createLoadingScreen`
- `pc.ResourceHandler#load`
- `pc.ModelHandler#addParser`
- `pc.ResourceLoader#load`
- `pc.ResourceLoader#load`
- `pc.GraphNode#find`
- `pc.GraphNode#findOne`
- `pc.GraphNode#forEach`
- `pc.Application#configure`
- `pc.Application#repload`
- `pc.Application#loadSceneHierarchy`
- `pc.Application#loadSceneSettings`
- `pc.CameraComponent#calculateTransform`
- `pc.CameraComponent#calculateProjection`
- `pc.CameraComponent#enterVr`
- `pc.CameraComponent#exitVr`
- `pc.Mouse#enablePointerLock`
- `pc.Mouse#disablePointerLock`
- `pc.Http#get`
- `pc.Http#post`
- `pc.Http#put`
- `pc.Http#del`
- `pc.Http#request`
- `pc.StandardMaterial#onUpdateShader`
- `pc.VrDisplay#requestPresent`
- `pc.VrDisplay#exitPresent`
- `pc.VrDisplay#requestAnimationFrame`

All callbacks are namespaced to the same scope as the function or property that uses them. The `@callback` tag adds a new entry in the jsdoc output (both `html` and `d.ts`). For more info see: https://jsdoc.app/tags-callback.html

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
