### PR TITLE
[DOC] Rename and move all callbacks

### DIFF
--- a/src/asset/asset-registry.js
+++ b/src/asset/asset-registry.js
@@ -433,13 +433,6 @@ Object.assign(pc, function () {
         },
 
         /**
-         * @callback pc.LoadAssetCallback
-         * @description Callback function used by {@link pc.AssetRegistry#loadFromUrl} and called when an asset is loaded (or an error occurs).
-         * @param {String|Null} err The error message is null if no errors were encountered.
-         * @param {pc.Asset} [asset] The loaded asset if no errors were encountered.
-         */
-
-        /**
          * @function
          * @name pc.AssetRegistry#loadFromUrl
          * @description Use this to load and create an asset if you don't have assets created. Usually you would only use this
@@ -676,13 +669,6 @@ Object.assign(pc, function () {
         findByTag: function () {
             return this._tags.find(arguments);
         },
-
-        /**
-         * @callback pc.FilterAssetCallback
-         * @description Callback function used by {@link pc.AssetRegistry#filter} to filter assets.
-         * @param {pc.Asset} asset The current asset to filter.
-         * @returns {Boolean} Return `true` to include asset to result list.
-         */
 
         /**
          * @function

--- a/src/asset/asset-registry.js
+++ b/src/asset/asset-registry.js
@@ -439,7 +439,7 @@ Object.assign(pc, function () {
          * if you are not integrated with the PlayCanvas Editor
          * @param {String} url The url to load
          * @param {String} type The type of asset to load
-         * @param {pc.LoadAssetCallback} callback Function called when asset is loaded, passed (err, asset), where err is null if no errors were encountered
+         * @param {pc.callbacks.LoadAsset} callback Function called when asset is loaded, passed (err, asset), where err is null if no errors were encountered
          * @example
          * app.assets.loadFromUrl("../path/to/texture.jpg", "texture", function (err, asset) {
          *     var texture = asset.resource;
@@ -674,7 +674,7 @@ Object.assign(pc, function () {
          * @function
          * @name pc.AssetRegistry#filter
          * @description Return all Assets that satisfy filter callback
-         * @param {pc.FilterAssetCallback} callback The callback function that is used to filter assets, return `true` to include asset to result list
+         * @param {pc.callbacks.FilterAsset} callback The callback function that is used to filter assets, return `true` to include asset to result list
          * @returns {pc.Asset[]} A list of all Assets found
          * @example
          * var assets = app.assets.filter(function(asset) {

--- a/src/asset/asset-registry.js
+++ b/src/asset/asset-registry.js
@@ -433,7 +433,7 @@ Object.assign(pc, function () {
         },
 
         /**
-         * @callback pc.AssetRegistry.loadCallback
+         * @callback pc.LoadAssetCallback
          * @description Callback function used by {@link pc.AssetRegistry#loadFromUrl} and called when an asset is loaded (or an error occurs).
          * @param {String|Null} err The error message is null if no errors were encountered.
          * @param {pc.Asset} [asset] The loaded asset if no errors were encountered.
@@ -446,7 +446,7 @@ Object.assign(pc, function () {
          * if you are not integrated with the PlayCanvas Editor
          * @param {String} url The url to load
          * @param {String} type The type of asset to load
-         * @param {pc.AssetRegistry.loadCallback} callback Function called when asset is loaded, passed (err, asset), where err is null if no errors were encountered
+         * @param {pc.LoadAssetCallback} callback Function called when asset is loaded, passed (err, asset), where err is null if no errors were encountered
          * @example
          * app.assets.loadFromUrl("../path/to/texture.jpg", "texture", function (err, asset) {
          *     var texture = asset.resource;
@@ -678,7 +678,7 @@ Object.assign(pc, function () {
         },
 
         /**
-         * @callback pc.AssetRegistry.filterCallback
+         * @callback pc.FilterAssetCallback
          * @description Callback function used by {@link pc.AssetRegistry#filter} to filter assets.
          * @param {pc.Asset} asset The current asset to filter.
          * @returns {Boolean} Return `true` to include asset to result list.
@@ -688,7 +688,7 @@ Object.assign(pc, function () {
          * @function
          * @name pc.AssetRegistry#filter
          * @description Return all Assets that satisfy filter callback
-         * @param {pc.AssetRegistry.filterCallback} callback The callback function that is used to filter assets, return `true` to include asset to result list
+         * @param {pc.FilterAssetCallback} callback The callback function that is used to filter assets, return `true` to include asset to result list
          * @returns {pc.Asset[]} A list of all Assets found
          * @example
          * var assets = app.assets.filter(function(asset) {

--- a/src/asset/asset.js
+++ b/src/asset/asset.js
@@ -253,7 +253,7 @@ Object.assign(pc, function () {
         },
 
         /**
-         * @callback pc.Asset.readyCallback
+         * @callback pc.AssetReadyCallback
          * @description Callback function used by {@link pc.Asset#ready} and called when an asset is ready.
          * @param {pc.Asset} asset The ready asset.
          */
@@ -262,7 +262,7 @@ Object.assign(pc, function () {
          * @function
          * @name pc.Asset#ready
          * @description Take a callback which is called as soon as the asset is loaded. If the asset is already loaded the callback is called straight away
-         * @param {pc.Asset.readyCallback} callback The function called when the asset is ready. Passed the (asset) arguments
+         * @param {pc.AssetReadyCallback} callback The function called when the asset is ready. Passed the (asset) arguments
          * @param {Object} [scope] Scope object to use when calling the callback
          * @example
          * var asset = app.assets.find("My Asset");

--- a/src/asset/asset.js
+++ b/src/asset/asset.js
@@ -253,12 +253,6 @@ Object.assign(pc, function () {
         },
 
         /**
-         * @callback pc.AssetReadyCallback
-         * @description Callback function used by {@link pc.Asset#ready} and called when an asset is ready.
-         * @param {pc.Asset} asset The ready asset.
-         */
-
-        /**
          * @function
          * @name pc.Asset#ready
          * @description Take a callback which is called as soon as the asset is loaded. If the asset is already loaded the callback is called straight away

--- a/src/asset/asset.js
+++ b/src/asset/asset.js
@@ -256,7 +256,7 @@ Object.assign(pc, function () {
          * @function
          * @name pc.Asset#ready
          * @description Take a callback which is called as soon as the asset is loaded. If the asset is already loaded the callback is called straight away
-         * @param {pc.AssetReadyCallback} callback The function called when the asset is ready. Passed the (asset) arguments
+         * @param {pc.callbacks.AssetReady} callback The function called when the asset is ready. Passed the (asset) arguments
          * @param {Object} [scope] Scope object to use when calling the callback
          * @example
          * var asset = app.assets.find("My Asset");

--- a/src/callbacks.js
+++ b/src/callbacks.js
@@ -1,0 +1,159 @@
+'use strict';
+
+/**
+ * @callback pc.EventCallback
+ * @description Callback function used by {@link pc.events} functions. Note the callback is limited to 8 arguments.
+ * @param {*} [arg1] First argument that is passed from caller
+ * @param {*} [arg2] Second argument that is passed from caller
+ * @param {*} [arg3] Third argument that is passed from caller
+ * @param {*} [arg4] Fourth argument that is passed from caller
+ * @param {*} [arg5] Fifth argument that is passed from caller
+ * @param {*} [arg6] Sixth argument that is passed from caller
+ * @param {*} [arg7] Seventh argument that is passed from caller
+ * @param {*} [arg8] Eighth argument that is passed from caller
+ */
+
+/**
+ * @callback pc.LoadAssetCallback
+ * @description Callback function used by {@link pc.AssetRegistry#loadFromUrl} and called when an asset is loaded (or an error occurs).
+ * @param {String|Null} err The error message is null if no errors were encountered.
+ * @param {pc.Asset} [asset] The loaded asset if no errors were encountered.
+ */
+
+/**
+ * @callback pc.FilterAssetCallback
+ * @description Callback function used by {@link pc.AssetRegistry#filter} to filter assets.
+ * @param {pc.Asset} asset The current asset to filter.
+ * @returns {Boolean} Return `true` to include asset to result list.
+ */
+
+/**
+ * @callback pc.AssetReadyCallback
+ * @description Callback function used by {@link pc.Asset#ready} and called when an asset is ready.
+ * @param {pc.Asset} asset The ready asset.
+ */
+
+/**
+ * @callback pc.ConfigureCallback
+ * @description Callback function used by {@link pc.Application#configure} when configuration file is loaded and parsed (or an error occurs).
+ * @param {String|Null} err The error message in the case where the loading or parsing fails.
+ */
+
+/**
+ * @callback pc.PreloadCallback
+ * @description Callback function used by {@link pc.Application#preload} when all assets (marked as 'preload') are loaded.
+ */
+
+/**
+ * @callback pc.LoadHierarchyCallback
+ * @description Callback function used by {@link pc.Application#loadSceneHierarchy}.
+ * @param {String|Null} err The error message in the case where the loading or parsing fails.
+ * @param {pc.Entity} [entity] The loaded root entity if no errors were encountered.
+ */
+
+/**
+ * @callback pc.LoadSettingsCallback
+ * @description Callback function used by {@link pc.Application#loadSceneSettings}.
+ * @param {String|Null} err The error message in the case where the loading or parsing fails.
+ */
+
+/**
+ * @private
+ * @callback pc.LoadSceneCallback
+ * @description Callback function used by {@link pc.Application#loadScene}.
+ * @param {String|Null} err The error message in the case where the loading or parsing fails.
+ * @param {pc.Entity} [entity] The loaded root entity if no errors were encountered.
+ */
+
+/**
+ * @callback pc.CalculateCallback
+ * @description Callback function used by {@link pc.Application#calculateTransform} and {@link pc.Application#calculateProjection}.
+ * @param {pc.Mat4} transformMatrix Output of the function.
+ * @param {Number} view Type of view. Can be pc.VIEW_CENTER, pc.VIEW_LEFT or pc.VIEW_RIGHT. Left and right are only used in stereo rendering.
+ */
+
+/**
+ * @callback pc.CameraVrCallback
+ * @description Callback function used by {@link pc.CameraComponent#enterVr} and {@link pc.CameraComponent#exitVr}.
+ * @param {String|Null} err On success it is null on failure it is the error message.
+ */
+
+/**
+ * @private
+ * @callback pc.CreateScriptCallback
+ * @description Callback function used by {@link pc.script.create}.
+ * @param {pc.Application} app The application.
+ * @returns {Object} Return the Type of the script resource to be instanced for each Entity.
+ */
+
+/**
+ * @callback pc.CreateScreenCallback
+ * @description Callback function used by {@link pc.script.createLoadingScreen}.
+ * @param {pc.Application} app The application.
+ */
+
+/**
+ * @callback pc.LockMouseCallback
+ * @description Callback function used by {@link pc.Mouse#enablePointerLock} and {@link pc.Application#disablePointerLock}.
+ */
+
+/**
+ * @callback pc.HttpCallback
+ * @description Callback function used by {@link pc.Http#get}, {@link pc.Http#post}, {@link pc.Http#put}, {@link pc.Http#del}, and {@link pc.Http#request}.
+ * @param {Number|String|Error|Null} err The error code, message, or exception in the case where the request fails.
+ * @param {*} [response] The response data if no errors were encountered. (format depends on response type: text, Object, ArrayBuffer, XML).
+ */
+
+/**
+ * @callback pc.HandlerCallback
+ * @description Callback function used by {@link pc.ResourceHandler#load} when a resource is loaded (or an error occurs).
+ * @param {String|Null} err The error message in the case where the load fails.
+ * @param {*} [response] The raw data that has been successfully loaded.
+ */
+
+/**
+ * @callback pc.LoaderCallback
+ * @description Callback function used by {@link pc.ResourceLoader#load} when a resource is loaded (or an error occurs).
+ * @param {String|Null} err The error message in the case where the load fails.
+ * @param {*} [resource] The resource that has been successfully loaded.
+ */
+
+/**
+ * @callback pc.ParserCallback
+ * @description Callback function used by {@link pc.ModelHandler#addParser} to decide on which parser to use.
+ * @param {String} url The resource url.
+ * @param {Object} data The raw model data.
+ * @returns {Boolean} Return true if this parser should be used to parse the data into a {@link pc.Model}
+ */
+
+/**
+ * @callback pc.FindNodeCallback
+ * @description Callback function used by {@link pc.GraphNode#find} and {@link pc.GraphNode#findOne} to search through a graph node and all of its descendants.
+ * @param {pc.GraphNode} node The current graph node.
+ * @returns {Boolean} Returning `true` will result in that node being returned from {@link pc.GraphNode#find} or {@link pc.GraphNode#findOne}.
+ */
+
+/**
+ * @callback pc.ForEachNodeCallback
+ * @description Callback function used by {@link pc.GraphNode#forEach} to iterate through a graph node and all of its descendants.
+ * @param {pc.GraphNode} node The current graph node.
+ */
+
+/**
+ * @callback pc.UpdateShaderCallback
+ * @description Callback function used by {@link pc.Application#onUpdateShader}.
+ * @param {Object} options An object with shader generator settings (based on current material and scene properties), that you can change and then return.
+ * Properties of the object passed into this function are documented in {@link pc.Application#onUpdateShader}.
+ * @returns {Object} Returned settings will be used by the shader.
+ */
+
+/**
+ * @callback pc.VrDisplayCallback
+ * @description Callback function used by {@link pc.VrDisplay#requestPresent} and {@link pc.VrDisplay#exitPresent}.
+ * @param {String|Null} err The error message if presenting fails, or null if the call succeeds.
+ */
+
+/**
+ * @callback pc.VrFrameCallback
+ * @description Callback function used by {@link pc.VrDisplay#requestAnimationFrame}.
+ */

--- a/src/callbacks.js
+++ b/src/callbacks.js
@@ -3,7 +3,7 @@
 /**
  * @name pc.callbacks
  * @namespace
- * @description Namespace for callback type definitions.
+ * @description Namespace for callback definitions.
  */
 
 /**
@@ -73,7 +73,7 @@
 
 /**
  * @callback pc.callbacks.Calculate
- * @description Callback function used by {@link pc.Application#calculateTransform} and {@link pc.Application#calculateProjection}.
+ * @description Callback function used by {@link pc.CameraComponent#calculateTransform} and {@link pc.CameraComponent#calculateProjection}.
  * @param {pc.Mat4} transformMatrix Output of the function.
  * @param {Number} view Type of view. Can be pc.VIEW_CENTER, pc.VIEW_LEFT or pc.VIEW_RIGHT. Left and right are only used in stereo rendering.
  */
@@ -147,9 +147,9 @@
 
 /**
  * @callback pc.callbacks.UpdateShader
- * @description Callback function used by {@link pc.Application#onUpdateShader}.
+ * @description Callback function used by {@link pc.StandardMaterial#onUpdateShader}.
  * @param {Object} options An object with shader generator settings (based on current material and scene properties), that you can change and then return.
- * Properties of the object passed into this function are documented in {@link pc.Application#onUpdateShader}.
+ * Properties of the object passed into this function are documented in {@link pc.StandardMaterial#onUpdateShader}.
  * @returns {Object} Returned settings will be used by the shader.
  */
 

--- a/src/callbacks.js
+++ b/src/callbacks.js
@@ -1,7 +1,13 @@
 'use strict';
 
 /**
- * @callback pc.EventCallback
+ * @name pc.callbacks
+ * @namespace
+ * @description Namespace for callback type definitions.
+ */
+
+/**
+ * @callback pc.callbacks.Event
  * @description Callback function used by {@link pc.events} functions. Note the callback is limited to 8 arguments.
  * @param {*} [arg1] First argument that is passed from caller
  * @param {*} [arg2] Second argument that is passed from caller
@@ -14,112 +20,112 @@
  */
 
 /**
- * @callback pc.LoadAssetCallback
+ * @callback pc.callbacks.LoadAsset
  * @description Callback function used by {@link pc.AssetRegistry#loadFromUrl} and called when an asset is loaded (or an error occurs).
  * @param {String|Null} err The error message is null if no errors were encountered.
  * @param {pc.Asset} [asset] The loaded asset if no errors were encountered.
  */
 
 /**
- * @callback pc.FilterAssetCallback
+ * @callback pc.callbacks.FilterAsset
  * @description Callback function used by {@link pc.AssetRegistry#filter} to filter assets.
  * @param {pc.Asset} asset The current asset to filter.
  * @returns {Boolean} Return `true` to include asset to result list.
  */
 
 /**
- * @callback pc.AssetReadyCallback
+ * @callback pc.callbacks.AssetReady
  * @description Callback function used by {@link pc.Asset#ready} and called when an asset is ready.
  * @param {pc.Asset} asset The ready asset.
  */
 
 /**
- * @callback pc.ConfigureCallback
+ * @callback pc.callbacks.Configure
  * @description Callback function used by {@link pc.Application#configure} when configuration file is loaded and parsed (or an error occurs).
  * @param {String|Null} err The error message in the case where the loading or parsing fails.
  */
 
 /**
- * @callback pc.PreloadCallback
+ * @callback pc.callbacks.Preload
  * @description Callback function used by {@link pc.Application#preload} when all assets (marked as 'preload') are loaded.
  */
 
 /**
- * @callback pc.LoadHierarchyCallback
+ * @callback pc.callbacks.LoadHierarchy
  * @description Callback function used by {@link pc.Application#loadSceneHierarchy}.
  * @param {String|Null} err The error message in the case where the loading or parsing fails.
  * @param {pc.Entity} [entity] The loaded root entity if no errors were encountered.
  */
 
 /**
- * @callback pc.LoadSettingsCallback
+ * @callback pc.callbacks.LoadSettings
  * @description Callback function used by {@link pc.Application#loadSceneSettings}.
  * @param {String|Null} err The error message in the case where the loading or parsing fails.
  */
 
 /**
  * @private
- * @callback pc.LoadSceneCallback
+ * @callback pc.callbacks.LoadScene
  * @description Callback function used by {@link pc.Application#loadScene}.
  * @param {String|Null} err The error message in the case where the loading or parsing fails.
  * @param {pc.Entity} [entity] The loaded root entity if no errors were encountered.
  */
 
 /**
- * @callback pc.CalculateCallback
+ * @callback pc.callbacks.Calculate
  * @description Callback function used by {@link pc.Application#calculateTransform} and {@link pc.Application#calculateProjection}.
  * @param {pc.Mat4} transformMatrix Output of the function.
  * @param {Number} view Type of view. Can be pc.VIEW_CENTER, pc.VIEW_LEFT or pc.VIEW_RIGHT. Left and right are only used in stereo rendering.
  */
 
 /**
- * @callback pc.CameraVrCallback
+ * @callback pc.callbacks.CameraVr
  * @description Callback function used by {@link pc.CameraComponent#enterVr} and {@link pc.CameraComponent#exitVr}.
  * @param {String|Null} err On success it is null on failure it is the error message.
  */
 
 /**
  * @private
- * @callback pc.CreateScriptCallback
+ * @callback pc.callbacks.CreateScript
  * @description Callback function used by {@link pc.script.create}.
  * @param {pc.Application} app The application.
  * @returns {Object} Return the Type of the script resource to be instanced for each Entity.
  */
 
 /**
- * @callback pc.CreateScreenCallback
+ * @callback pc.callbacks.CreateScreen
  * @description Callback function used by {@link pc.script.createLoadingScreen}.
  * @param {pc.Application} app The application.
  */
 
 /**
- * @callback pc.LockMouseCallback
+ * @callback pc.callbacks.LockMouse
  * @description Callback function used by {@link pc.Mouse#enablePointerLock} and {@link pc.Application#disablePointerLock}.
  */
 
 /**
- * @callback pc.HttpCallback
+ * @callback pc.callbacks.Http
  * @description Callback function used by {@link pc.Http#get}, {@link pc.Http#post}, {@link pc.Http#put}, {@link pc.Http#del}, and {@link pc.Http#request}.
  * @param {Number|String|Error|Null} err The error code, message, or exception in the case where the request fails.
  * @param {*} [response] The response data if no errors were encountered. (format depends on response type: text, Object, ArrayBuffer, XML).
  */
 
 /**
- * @callback pc.HandlerCallback
+ * @callback pc.callbacks.Handler
  * @description Callback function used by {@link pc.ResourceHandler#load} when a resource is loaded (or an error occurs).
  * @param {String|Null} err The error message in the case where the load fails.
  * @param {*} [response] The raw data that has been successfully loaded.
  */
 
 /**
- * @callback pc.LoaderCallback
+ * @callback pc.callbacks.Loader
  * @description Callback function used by {@link pc.ResourceLoader#load} when a resource is loaded (or an error occurs).
  * @param {String|Null} err The error message in the case where the load fails.
  * @param {*} [resource] The resource that has been successfully loaded.
  */
 
 /**
- * @callback pc.ParserCallback
+ * @callback pc.callbacks.Parser
  * @description Callback function used by {@link pc.ModelHandler#addParser} to decide on which parser to use.
  * @param {String} url The resource url.
  * @param {Object} data The raw model data.
@@ -127,20 +133,20 @@
  */
 
 /**
- * @callback pc.FindNodeCallback
+ * @callback pc.callbacks.FindNode
  * @description Callback function used by {@link pc.GraphNode#find} and {@link pc.GraphNode#findOne} to search through a graph node and all of its descendants.
  * @param {pc.GraphNode} node The current graph node.
  * @returns {Boolean} Returning `true` will result in that node being returned from {@link pc.GraphNode#find} or {@link pc.GraphNode#findOne}.
  */
 
 /**
- * @callback pc.ForEachNodeCallback
+ * @callback pc.callbacks.ForEachNode
  * @description Callback function used by {@link pc.GraphNode#forEach} to iterate through a graph node and all of its descendants.
  * @param {pc.GraphNode} node The current graph node.
  */
 
 /**
- * @callback pc.UpdateShaderCallback
+ * @callback pc.callbacks.UpdateShader
  * @description Callback function used by {@link pc.Application#onUpdateShader}.
  * @param {Object} options An object with shader generator settings (based on current material and scene properties), that you can change and then return.
  * Properties of the object passed into this function are documented in {@link pc.Application#onUpdateShader}.
@@ -148,12 +154,12 @@
  */
 
 /**
- * @callback pc.VrDisplayCallback
+ * @callback pc.callbacks.VrDisplay
  * @description Callback function used by {@link pc.VrDisplay#requestPresent} and {@link pc.VrDisplay#exitPresent}.
  * @param {String|Null} err The error message if presenting fails, or null if the call succeeds.
  */
 
 /**
- * @callback pc.VrFrameCallback
+ * @callback pc.callbacks.VrFrame
  * @description Callback function used by {@link pc.VrDisplay#requestAnimationFrame}.
  */

--- a/src/callbacks.js
+++ b/src/callbacks.js
@@ -7,8 +7,8 @@
  */
 
 /**
- * @callback pc.callbacks.Event
- * @description Callback function used by {@link pc.events} functions. Note the callback is limited to 8 arguments.
+ * @callback pc.callbacks.HandleEvent
+ * @description Callback used by {@link pc.events} functions. Note the callback is limited to 8 arguments.
  * @param {*} [arg1] First argument that is passed from caller
  * @param {*} [arg2] Second argument that is passed from caller
  * @param {*} [arg3] Third argument that is passed from caller
@@ -21,112 +21,112 @@
 
 /**
  * @callback pc.callbacks.LoadAsset
- * @description Callback function used by {@link pc.AssetRegistry#loadFromUrl} and called when an asset is loaded (or an error occurs).
+ * @description Callback used by {@link pc.AssetRegistry#loadFromUrl} and called when an asset is loaded (or an error occurs).
  * @param {String|Null} err The error message is null if no errors were encountered.
  * @param {pc.Asset} [asset] The loaded asset if no errors were encountered.
  */
 
 /**
  * @callback pc.callbacks.FilterAsset
- * @description Callback function used by {@link pc.AssetRegistry#filter} to filter assets.
+ * @description Callback used by {@link pc.AssetRegistry#filter} to filter assets.
  * @param {pc.Asset} asset The current asset to filter.
  * @returns {Boolean} Return `true` to include asset to result list.
  */
 
 /**
  * @callback pc.callbacks.AssetReady
- * @description Callback function used by {@link pc.Asset#ready} and called when an asset is ready.
+ * @description Callback used by {@link pc.Asset#ready} and called when an asset is ready.
  * @param {pc.Asset} asset The ready asset.
  */
 
 /**
- * @callback pc.callbacks.Configure
- * @description Callback function used by {@link pc.Application#configure} when configuration file is loaded and parsed (or an error occurs).
+ * @callback pc.callbacks.ConfigureApp
+ * @description Callback used by {@link pc.Application#configure} when configuration file is loaded and parsed (or an error occurs).
  * @param {String|Null} err The error message in the case where the loading or parsing fails.
  */
 
 /**
- * @callback pc.callbacks.Preload
- * @description Callback function used by {@link pc.Application#preload} when all assets (marked as 'preload') are loaded.
+ * @callback pc.callbacks.PreloadApp
+ * @description Callback used by {@link pc.Application#preload} when all assets (marked as 'preload') are loaded.
  */
 
 /**
  * @callback pc.callbacks.LoadHierarchy
- * @description Callback function used by {@link pc.Application#loadSceneHierarchy}.
+ * @description Callback used by {@link pc.Application#loadSceneHierarchy}.
  * @param {String|Null} err The error message in the case where the loading or parsing fails.
  * @param {pc.Entity} [entity] The loaded root entity if no errors were encountered.
  */
 
 /**
  * @callback pc.callbacks.LoadSettings
- * @description Callback function used by {@link pc.Application#loadSceneSettings}.
+ * @description Callback used by {@link pc.Application#loadSceneSettings}.
  * @param {String|Null} err The error message in the case where the loading or parsing fails.
  */
 
 /**
  * @private
  * @callback pc.callbacks.LoadScene
- * @description Callback function used by {@link pc.Application#loadScene}.
+ * @description Callback used by {@link pc.Application#loadScene}.
  * @param {String|Null} err The error message in the case where the loading or parsing fails.
  * @param {pc.Entity} [entity] The loaded root entity if no errors were encountered.
  */
 
 /**
- * @callback pc.callbacks.Calculate
- * @description Callback function used by {@link pc.CameraComponent#calculateTransform} and {@link pc.CameraComponent#calculateProjection}.
+ * @callback pc.callbacks.CalculateMatrix
+ * @description Callback used by {@link pc.CameraComponent#calculateTransform} and {@link pc.CameraComponent#calculateProjection}.
  * @param {pc.Mat4} transformMatrix Output of the function.
  * @param {Number} view Type of view. Can be pc.VIEW_CENTER, pc.VIEW_LEFT or pc.VIEW_RIGHT. Left and right are only used in stereo rendering.
  */
 
 /**
- * @callback pc.callbacks.CameraVr
- * @description Callback function used by {@link pc.CameraComponent#enterVr} and {@link pc.CameraComponent#exitVr}.
+ * @callback pc.callbacks.VrCamera
+ * @description Callback used by {@link pc.CameraComponent#enterVr} and {@link pc.CameraComponent#exitVr}.
  * @param {String|Null} err On success it is null on failure it is the error message.
  */
 
 /**
  * @private
  * @callback pc.callbacks.CreateScript
- * @description Callback function used by {@link pc.script.create}.
+ * @description Callback used by {@link pc.script.create}.
  * @param {pc.Application} app The application.
  * @returns {Object} Return the Type of the script resource to be instanced for each Entity.
  */
 
 /**
  * @callback pc.callbacks.CreateScreen
- * @description Callback function used by {@link pc.script.createLoadingScreen}.
+ * @description Callback used by {@link pc.script.createLoadingScreen}.
  * @param {pc.Application} app The application.
  */
 
 /**
  * @callback pc.callbacks.LockMouse
- * @description Callback function used by {@link pc.Mouse#enablePointerLock} and {@link pc.Application#disablePointerLock}.
+ * @description Callback used by {@link pc.Mouse#enablePointerLock} and {@link pc.Application#disablePointerLock}.
  */
 
 /**
- * @callback pc.callbacks.Http
- * @description Callback function used by {@link pc.Http#get}, {@link pc.Http#post}, {@link pc.Http#put}, {@link pc.Http#del}, and {@link pc.Http#request}.
+ * @callback pc.callbacks.HttpResponse
+ * @description Callback used by {@link pc.Http#get}, {@link pc.Http#post}, {@link pc.Http#put}, {@link pc.Http#del}, and {@link pc.Http#request}.
  * @param {Number|String|Error|Null} err The error code, message, or exception in the case where the request fails.
  * @param {*} [response] The response data if no errors were encountered. (format depends on response type: text, Object, ArrayBuffer, XML).
  */
 
 /**
- * @callback pc.callbacks.Handler
- * @description Callback function used by {@link pc.ResourceHandler#load} when a resource is loaded (or an error occurs).
+ * @callback pc.callbacks.ResourceHandler
+ * @description Callback used by {@link pc.ResourceHandler#load} when a resource is loaded (or an error occurs).
  * @param {String|Null} err The error message in the case where the load fails.
  * @param {*} [response] The raw data that has been successfully loaded.
  */
 
 /**
- * @callback pc.callbacks.Loader
- * @description Callback function used by {@link pc.ResourceLoader#load} when a resource is loaded (or an error occurs).
+ * @callback pc.callbacks.ResourceLoader
+ * @description Callback used by {@link pc.ResourceLoader#load} when a resource is loaded (or an error occurs).
  * @param {String|Null} err The error message in the case where the load fails.
  * @param {*} [resource] The resource that has been successfully loaded.
  */
 
 /**
- * @callback pc.callbacks.Parser
- * @description Callback function used by {@link pc.ModelHandler#addParser} to decide on which parser to use.
+ * @callback pc.callbacks.AddParser
+ * @description Callback used by {@link pc.ModelHandler#addParser} to decide on which parser to use.
  * @param {String} url The resource url.
  * @param {Object} data The raw model data.
  * @returns {Boolean} Return true if this parser should be used to parse the data into a {@link pc.Model}
@@ -134,20 +134,20 @@
 
 /**
  * @callback pc.callbacks.FindNode
- * @description Callback function used by {@link pc.GraphNode#find} and {@link pc.GraphNode#findOne} to search through a graph node and all of its descendants.
+ * @description Callback used by {@link pc.GraphNode#find} and {@link pc.GraphNode#findOne} to search through a graph node and all of its descendants.
  * @param {pc.GraphNode} node The current graph node.
  * @returns {Boolean} Returning `true` will result in that node being returned from {@link pc.GraphNode#find} or {@link pc.GraphNode#findOne}.
  */
 
 /**
- * @callback pc.callbacks.ForEachNode
- * @description Callback function used by {@link pc.GraphNode#forEach} to iterate through a graph node and all of its descendants.
+ * @callback pc.callbacks.ForEach
+ * @description Callback used by {@link pc.GraphNode#forEach} to iterate through a graph node and all of its descendants.
  * @param {pc.GraphNode} node The current graph node.
  */
 
 /**
  * @callback pc.callbacks.UpdateShader
- * @description Callback function used by {@link pc.StandardMaterial#onUpdateShader}.
+ * @description Callback used by {@link pc.StandardMaterial#onUpdateShader}.
  * @param {Object} options An object with shader generator settings (based on current material and scene properties), that you can change and then return.
  * Properties of the object passed into this function are documented in {@link pc.StandardMaterial#onUpdateShader}.
  * @returns {Object} Returned settings will be used by the shader.
@@ -155,11 +155,11 @@
 
 /**
  * @callback pc.callbacks.VrDisplay
- * @description Callback function used by {@link pc.VrDisplay#requestPresent} and {@link pc.VrDisplay#exitPresent}.
+ * @description Callback used by {@link pc.VrDisplay#requestPresent} and {@link pc.VrDisplay#exitPresent}.
  * @param {String|Null} err The error message if presenting fails, or null if the call succeeds.
  */
 
 /**
  * @callback pc.callbacks.VrFrame
- * @description Callback function used by {@link pc.VrDisplay#requestAnimationFrame}.
+ * @description Callback used by {@link pc.VrDisplay#requestAnimationFrame}.
  */

--- a/src/core/events.js
+++ b/src/core/events.js
@@ -38,7 +38,7 @@ pc.events = {
     },
 
     /**
-     * @callback pc.events.callback
+     * @callback pc.EventCallback
      * @description Callback function used by {@link pc.events} functions. Note the callback is limited to 8 arguments.
      * @param {*} [arg1] First argument that is passed from caller
      * @param {*} [arg2] Second argument that is passed from caller
@@ -55,7 +55,7 @@ pc.events = {
      * @name pc.events.on
      * @description Attach an event handler to an event
      * @param {String} name Name of the event to bind the callback to
-     * @param {pc.events.callback} callback Function that is called when event is fired. Note the callback is limited to 8 arguments.
+     * @param {pc.EventCallback} callback Function that is called when event is fired. Note the callback is limited to 8 arguments.
      * @param {Object} [scope] Object to use as 'this' when the event is fired, defaults to current this
      * @returns {*} 'this' for chaining
      * @example
@@ -88,7 +88,7 @@ pc.events = {
      * @description Detach an event handler from an event. If callback is not provided then all callbacks are unbound from the event,
      * if scope is not provided then all events with the callback will be unbound.
      * @param {String} [name] Name of the event to unbind
-     * @param {pc.events.callback} [callback] Function to be unbound.
+     * @param {pc.EventCallback} [callback] Function to be unbound.
      * @param {Object} [scope] Scope that was used as the this when the event is fired
      * @returns {*} 'this' for chaining
      * @example
@@ -210,7 +210,7 @@ pc.events = {
      * @name pc.events.once
      * @description Attach an event handler to an event. This handler will be removed after being fired once.
      * @param {String} name Name of the event to bind the callback to
-     * @param {pc.events.callback} callback Function that is called when event is fired. Note the callback is limited to 8 arguments.
+     * @param {pc.EventCallback} callback Function that is called when event is fired. Note the callback is limited to 8 arguments.
      * @param {Object} [scope] Object to use as 'this' when the event is fired, defaults to current this
      * @returns {*} 'this' for chaining
      * @example

--- a/src/core/events.js
+++ b/src/core/events.js
@@ -42,7 +42,7 @@ pc.events = {
      * @name pc.events.on
      * @description Attach an event handler to an event
      * @param {String} name Name of the event to bind the callback to
-     * @param {pc.callbacks.Event} callback Function that is called when event is fired. Note the callback is limited to 8 arguments.
+     * @param {pc.callbacks.HandleEvent} callback Function that is called when event is fired. Note the callback is limited to 8 arguments.
      * @param {Object} [scope] Object to use as 'this' when the event is fired, defaults to current this
      * @returns {*} 'this' for chaining
      * @example
@@ -75,7 +75,7 @@ pc.events = {
      * @description Detach an event handler from an event. If callback is not provided then all callbacks are unbound from the event,
      * if scope is not provided then all events with the callback will be unbound.
      * @param {String} [name] Name of the event to unbind
-     * @param {pc.callbacks.Event} [callback] Function to be unbound.
+     * @param {pc.callbacks.HandleEvent} [callback] Function to be unbound.
      * @param {Object} [scope] Scope that was used as the this when the event is fired
      * @returns {*} 'this' for chaining
      * @example
@@ -197,7 +197,7 @@ pc.events = {
      * @name pc.events.once
      * @description Attach an event handler to an event. This handler will be removed after being fired once.
      * @param {String} name Name of the event to bind the callback to
-     * @param {pc.callbacks.Event} callback Function that is called when event is fired. Note the callback is limited to 8 arguments.
+     * @param {pc.callbacks.HandleEvent} callback Function that is called when event is fired. Note the callback is limited to 8 arguments.
      * @param {Object} [scope] Object to use as 'this' when the event is fired, defaults to current this
      * @returns {*} 'this' for chaining
      * @example

--- a/src/core/events.js
+++ b/src/core/events.js
@@ -42,7 +42,7 @@ pc.events = {
      * @name pc.events.on
      * @description Attach an event handler to an event
      * @param {String} name Name of the event to bind the callback to
-     * @param {pc.EventCallback} callback Function that is called when event is fired. Note the callback is limited to 8 arguments.
+     * @param {pc.callbacks.Event} callback Function that is called when event is fired. Note the callback is limited to 8 arguments.
      * @param {Object} [scope] Object to use as 'this' when the event is fired, defaults to current this
      * @returns {*} 'this' for chaining
      * @example
@@ -75,7 +75,7 @@ pc.events = {
      * @description Detach an event handler from an event. If callback is not provided then all callbacks are unbound from the event,
      * if scope is not provided then all events with the callback will be unbound.
      * @param {String} [name] Name of the event to unbind
-     * @param {pc.EventCallback} [callback] Function to be unbound.
+     * @param {pc.callbacks.Event} [callback] Function to be unbound.
      * @param {Object} [scope] Scope that was used as the this when the event is fired
      * @returns {*} 'this' for chaining
      * @example
@@ -197,7 +197,7 @@ pc.events = {
      * @name pc.events.once
      * @description Attach an event handler to an event. This handler will be removed after being fired once.
      * @param {String} name Name of the event to bind the callback to
-     * @param {pc.EventCallback} callback Function that is called when event is fired. Note the callback is limited to 8 arguments.
+     * @param {pc.callbacks.Event} callback Function that is called when event is fired. Note the callback is limited to 8 arguments.
      * @param {Object} [scope] Object to use as 'this' when the event is fired, defaults to current this
      * @returns {*} 'this' for chaining
      * @example

--- a/src/core/events.js
+++ b/src/core/events.js
@@ -38,19 +38,6 @@ pc.events = {
     },
 
     /**
-     * @callback pc.EventCallback
-     * @description Callback function used by {@link pc.events} functions. Note the callback is limited to 8 arguments.
-     * @param {*} [arg1] First argument that is passed from caller
-     * @param {*} [arg2] Second argument that is passed from caller
-     * @param {*} [arg3] Third argument that is passed from caller
-     * @param {*} [arg4] Fourth argument that is passed from caller
-     * @param {*} [arg5] Fifth argument that is passed from caller
-     * @param {*} [arg6] Sixth argument that is passed from caller
-     * @param {*} [arg7] Seventh argument that is passed from caller
-     * @param {*} [arg8] Eighth argument that is passed from caller
-     */
-
-    /**
      * @function
      * @name pc.events.on
      * @description Attach an event handler to an event

--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -578,7 +578,7 @@ Object.assign(pc, function () {
          * @name pc.Application#configure
          * @description Load the application configuration file and apply application properties and fill the asset registry
          * @param {String} url The URL of the configuration file to load
-         * @param {pc.callbacks.Configure} callback The Function called when the configuration file is loaded and parsed (or an error occurs).
+         * @param {pc.callbacks.ConfigureApp} callback The Function called when the configuration file is loaded and parsed (or an error occurs).
          */
         configure: function (url, callback) {
             var self = this;
@@ -609,7 +609,7 @@ Object.assign(pc, function () {
          * @function
          * @name pc.Application#preload
          * @description Load all assets in the asset registry that are marked as 'preload'
-         * @param {pc.callbacks.Preload} callback Function called when all assets are loaded
+         * @param {pc.callbacks.PreloadApp} callback Function called when all assets are loaded
          */
         preload: function (callback) {
             var self = this;

--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -578,7 +578,7 @@ Object.assign(pc, function () {
          * @name pc.Application#configure
          * @description Load the application configuration file and apply application properties and fill the asset registry
          * @param {String} url The URL of the configuration file to load
-         * @param {pc.ConfigureCallback} callback The Function called when the configuration file is loaded and parsed (or an error occurs).
+         * @param {pc.callbacks.Configure} callback The Function called when the configuration file is loaded and parsed (or an error occurs).
          */
         configure: function (url, callback) {
             var self = this;
@@ -609,7 +609,7 @@ Object.assign(pc, function () {
          * @function
          * @name pc.Application#preload
          * @description Load all assets in the asset registry that are marked as 'preload'
-         * @param {pc.PreloadCallback} callback Function called when all assets are loaded
+         * @param {pc.callbacks.Preload} callback Function called when all assets are loaded
          */
         preload: function (callback) {
             var self = this;
@@ -705,7 +705,7 @@ Object.assign(pc, function () {
          * @description Load a scene file, create and initialize the Entity hierarchy
          * and add the hierarchy to the application root Entity.
          * @param {String} url The URL of the scene file. Usually this will be "scene_id.json"
-         * @param {pc.LoadHierarchyCallback} callback The function to call after loading, passed (err, entity) where err is null if no errors occurred.
+         * @param {pc.callbacks.LoadHierarchy} callback The function to call after loading, passed (err, entity) where err is null if no errors occurred.
          * @example
          *
          * app.loadSceneHierarchy("1000.json", function (err, entity) {
@@ -726,7 +726,7 @@ Object.assign(pc, function () {
          * @name pc.Application#loadSceneSettings
          * @description Load a scene file and apply the scene settings to the current scene
          * @param {String} url The URL of the scene file. Usually this will be "scene_id.json"
-         * @param {pc.LoadSettingsCallback} callback The function called after the settings are applied. Passed (err) where err is null if no error occurred.
+         * @param {pc.callbacks.LoadSettings} callback The function called after the settings are applied. Passed (err) where err is null if no error occurred.
          * @example
          * app.loadSceneSettings("1000.json", function (err) {
          *     if (!err) {
@@ -747,7 +747,7 @@ Object.assign(pc, function () {
          * @name pc.Application#loadScene
          * @description Load a scene file.
          * @param {String} url The URL of the scene file. Usually this will be "scene_id.json"
-         * @param {pc.LoadSceneCallback} callback The function to call after loading, passed (err, entity) where err is null if no errors occurred.
+         * @param {pc.callbacks.LoadScene} callback The function to call after loading, passed (err, entity) where err is null if no errors occurred.
          * @example
          *
          * app.loadScene("1000.json", function (err, entity) {

--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -574,12 +574,6 @@ Object.assign(pc, function () {
 
     Object.assign(Application.prototype, {
         /**
-         * @callback pc.ConfigureCallback
-         * @description Callback function used by {@link pc.Application#configure} when configuration file is loaded and parsed (or an error occurs).
-         * @param {String|Null} err The error message in the case where the loading or parsing fails.
-         */
-
-        /**
          * @function
          * @name pc.Application#configure
          * @description Load the application configuration file and apply application properties and fill the asset registry
@@ -610,11 +604,6 @@ Object.assign(pc, function () {
                 });
             });
         },
-
-        /**
-         * @callback pc.PreloadCallback
-         * @description Callback function used by {@link pc.Application#preload} when all assets (marked as 'preload') are loaded.
-         */
 
         /**
          * @function
@@ -711,13 +700,6 @@ Object.assign(pc, function () {
         },
 
         /**
-         * @callback pc.LoadHierarchyCallback
-         * @description Callback function used by {@link pc.Application#loadSceneHierarchy}.
-         * @param {String|Null} err The error message in the case where the loading or parsing fails.
-         * @param {pc.Entity} [entity] The loaded root entity if no errors were encountered.
-         */
-
-        /**
          * @function
          * @name pc.Application#loadSceneHierarchy
          * @description Load a scene file, create and initialize the Entity hierarchy
@@ -740,12 +722,6 @@ Object.assign(pc, function () {
         },
 
         /**
-         * @callback pc.LoadSettingsCallback
-         * @description Callback function used by {@link pc.Application#loadSceneSettings}.
-         * @param {String|Null} err The error message in the case where the loading or parsing fails.
-         */
-
-        /**
          * @function
          * @name pc.Application#loadSceneSettings
          * @description Load a scene file and apply the scene settings to the current scene
@@ -764,14 +740,6 @@ Object.assign(pc, function () {
         loadSceneSettings: function (url, callback) {
             this._sceneRegistry.loadSceneSettings(url, callback);
         },
-
-        /**
-         * @private
-         * @callback pc.LoadSceneCallback
-         * @description Callback function used by {@link pc.Application#loadScene}.
-         * @param {String|Null} err The error message in the case where the loading or parsing fails.
-         * @param {pc.Entity} [entity] The loaded root entity if no errors were encountered.
-         */
 
         /**
          * @private

--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -574,7 +574,7 @@ Object.assign(pc, function () {
 
     Object.assign(Application.prototype, {
         /**
-         * @callback pc.Application.configureCallback
+         * @callback pc.ConfigureCallback
          * @description Callback function used by {@link pc.Application#configure} when configuration file is loaded and parsed (or an error occurs).
          * @param {String|Null} err The error message in the case where the loading or parsing fails.
          */
@@ -584,7 +584,7 @@ Object.assign(pc, function () {
          * @name pc.Application#configure
          * @description Load the application configuration file and apply application properties and fill the asset registry
          * @param {String} url The URL of the configuration file to load
-         * @param {pc.Application.configureCallback} callback The Function called when the configuration file is loaded and parsed (or an error occurs).
+         * @param {pc.ConfigureCallback} callback The Function called when the configuration file is loaded and parsed (or an error occurs).
          */
         configure: function (url, callback) {
             var self = this;
@@ -612,7 +612,7 @@ Object.assign(pc, function () {
         },
 
         /**
-         * @callback pc.Application.preloadCallback
+         * @callback pc.PreloadCallback
          * @description Callback function used by {@link pc.Application#preload} when all assets (marked as 'preload') are loaded.
          */
 
@@ -620,7 +620,7 @@ Object.assign(pc, function () {
          * @function
          * @name pc.Application#preload
          * @description Load all assets in the asset registry that are marked as 'preload'
-         * @param {pc.Application.preloadCallback} callback Function called when all assets are loaded
+         * @param {pc.PreloadCallback} callback Function called when all assets are loaded
          */
         preload: function (callback) {
             var self = this;
@@ -711,7 +711,7 @@ Object.assign(pc, function () {
         },
 
         /**
-         * @callback pc.Application.loadSceneHierarchyCallback
+         * @callback pc.LoadHierarchyCallback
          * @description Callback function used by {@link pc.Application#loadSceneHierarchy}.
          * @param {String|Null} err The error message in the case where the loading or parsing fails.
          * @param {pc.Entity} [entity] The loaded root entity if no errors were encountered.
@@ -723,7 +723,7 @@ Object.assign(pc, function () {
          * @description Load a scene file, create and initialize the Entity hierarchy
          * and add the hierarchy to the application root Entity.
          * @param {String} url The URL of the scene file. Usually this will be "scene_id.json"
-         * @param {pc.Application.loadSceneHierarchyCallback} callback The function to call after loading, passed (err, entity) where err is null if no errors occurred.
+         * @param {pc.LoadHierarchyCallback} callback The function to call after loading, passed (err, entity) where err is null if no errors occurred.
          * @example
          *
          * app.loadSceneHierarchy("1000.json", function (err, entity) {
@@ -740,7 +740,7 @@ Object.assign(pc, function () {
         },
 
         /**
-         * @callback pc.Application.loadSceneSettingsCallback
+         * @callback pc.LoadSettingsCallback
          * @description Callback function used by {@link pc.Application#loadSceneSettings}.
          * @param {String|Null} err The error message in the case where the loading or parsing fails.
          */
@@ -750,7 +750,7 @@ Object.assign(pc, function () {
          * @name pc.Application#loadSceneSettings
          * @description Load a scene file and apply the scene settings to the current scene
          * @param {String} url The URL of the scene file. Usually this will be "scene_id.json"
-         * @param {pc.Application.loadSceneSettingsCallback} callback The function called after the settings are applied. Passed (err) where err is null if no error occurred.
+         * @param {pc.LoadSettingsCallback} callback The function called after the settings are applied. Passed (err) where err is null if no error occurred.
          * @example
          * app.loadSceneSettings("1000.json", function (err) {
          *     if (!err) {
@@ -767,7 +767,7 @@ Object.assign(pc, function () {
 
         /**
          * @private
-         * @callback pc.Application.loadSceneCallback
+         * @callback pc.LoadSceneCallback
          * @description Callback function used by {@link pc.Application#loadScene}.
          * @param {String|Null} err The error message in the case where the loading or parsing fails.
          * @param {pc.Entity} [entity] The loaded root entity if no errors were encountered.
@@ -779,7 +779,7 @@ Object.assign(pc, function () {
          * @name pc.Application#loadScene
          * @description Load a scene file.
          * @param {String} url The URL of the scene file. Usually this will be "scene_id.json"
-         * @param {pc.Application.loadSceneCallback} callback The function to call after loading, passed (err, entity) where err is null if no errors occurred.
+         * @param {pc.LoadSceneCallback} callback The function to call after loading, passed (err, entity) where err is null if no errors occurred.
          * @example
          *
          * app.loadScene("1000.json", function (err, entity) {

--- a/src/framework/components/camera/component.js
+++ b/src/framework/components/camera/component.js
@@ -451,7 +451,6 @@ Object.assign(pc, function () {
         /**
          * @function
          * @name pc.CameraComponent#enterVr
-         * @variation 1
          * @description Attempt to start presenting this camera to a {@link pc.VrDisplay}.
          * @param {pc.callbacks.CameraVr} callback Function called once to indicate success of failure. The callback takes one argument (err).
          * On success it returns null on failure it returns the error message.

--- a/src/framework/components/camera/component.js
+++ b/src/framework/components/camera/component.js
@@ -51,11 +51,11 @@ Object.assign(pc, function () {
      * @property {Boolean} frustumCulling Controls the culling of mesh instances against the camera frustum, i.e. if objects outside of camera should be omitted from rendering.
      * If true, culling is enabled.
      * If false, all mesh instances in the scene are rendered by the camera, regardless of visibility. Defaults to false.
-     * @property {pc.callbacks.Calculate} calculateTransform Custom function you can provide to calculate the camera transformation matrix manually. Can be used for complex effects like reflections. Function is called using component's scope.
+     * @property {pc.callbacks.CalculateMatrix} calculateTransform Custom function you can provide to calculate the camera transformation matrix manually. Can be used for complex effects like reflections. Function is called using component's scope.
      * Arguments:
      *     <li>{pc.Mat4} transformMatrix: output of the function</li>
      *     <li>{Number} view: Type of view. Can be pc.VIEW_CENTER, pc.VIEW_LEFT or pc.VIEW_RIGHT. Left and right are only used in stereo rendering.</li>
-     * @property {pc.callbacks.Calculate} calculateProjection Custom function you can provide to calculate the camera projection matrix manually. Can be used for complex effects like doing oblique projection. Function is called using component's scope.
+     * @property {pc.callbacks.CalculateMatrix} calculateProjection Custom function you can provide to calculate the camera projection matrix manually. Can be used for complex effects like doing oblique projection. Function is called using component's scope.
      * Arguments:
      *     <li>{pc.Mat4} transformMatrix: output of the function</li>
      *     <li>{Number} view: Type of view. Can be pc.VIEW_CENTER, pc.VIEW_LEFT or pc.VIEW_RIGHT. Left and right are only used in stereo rendering.</li>
@@ -452,7 +452,7 @@ Object.assign(pc, function () {
          * @function
          * @name pc.CameraComponent#enterVr
          * @description Attempt to start presenting this camera to a {@link pc.VrDisplay}.
-         * @param {pc.callbacks.CameraVr} callback Function called once to indicate success of failure. The callback takes one argument (err).
+         * @param {pc.callbacks.VrCamera} callback Function called once to indicate success of failure. The callback takes one argument (err).
          * On success it returns null on failure it returns the error message.
          * @example
          * // On an entity with a camera component
@@ -470,7 +470,7 @@ Object.assign(pc, function () {
          * @variation 2
          * @description Attempt to start presenting this camera to a {@link pc.VrDisplay}.
          * @param {pc.VrDisplay} display The VrDisplay to present. If not supplied this uses {@link pc.VrManager#display} as the default
-         * @param {pc.callbacks.CameraVr} callback Function called once to indicate success of failure. The callback takes one argument (err).
+         * @param {pc.callbacks.VrCamera} callback Function called once to indicate success of failure. The callback takes one argument (err).
          * On success it returns null on failure it returns the error message.
          * @example
          * // On an entity with a camera component
@@ -530,7 +530,7 @@ Object.assign(pc, function () {
          * @function
          * @name pc.CameraComponent#exitVr
          * @description Attempt to stop presenting this camera.
-         * @param {pc.callbacks.CameraVr} callback Function called once to indicate success of failure. The callback takes one argument (err).
+         * @param {pc.callbacks.VrCamera} callback Function called once to indicate success of failure. The callback takes one argument (err).
          * On success it returns null on failure it returns the error message.
          * @example
          * this.entity.camera.exitVr(function (err) {

--- a/src/framework/components/camera/component.js
+++ b/src/framework/components/camera/component.js
@@ -51,11 +51,11 @@ Object.assign(pc, function () {
      * @property {Boolean} frustumCulling Controls the culling of mesh instances against the camera frustum, i.e. if objects outside of camera should be omitted from rendering.
      * If true, culling is enabled.
      * If false, all mesh instances in the scene are rendered by the camera, regardless of visibility. Defaults to false.
-     * @property {pc.CalculateCallback} calculateTransform Custom function you can provide to calculate the camera transformation matrix manually. Can be used for complex effects like reflections. Function is called using component's scope.
+     * @property {pc.callbacks.Calculate} calculateTransform Custom function you can provide to calculate the camera transformation matrix manually. Can be used for complex effects like reflections. Function is called using component's scope.
      * Arguments:
      *     <li>{pc.Mat4} transformMatrix: output of the function</li>
      *     <li>{Number} view: Type of view. Can be pc.VIEW_CENTER, pc.VIEW_LEFT or pc.VIEW_RIGHT. Left and right are only used in stereo rendering.</li>
-     * @property {pc.CalculateCallback} calculateProjection Custom function you can provide to calculate the camera projection matrix manually. Can be used for complex effects like doing oblique projection. Function is called using component's scope.
+     * @property {pc.callbacks.Calculate} calculateProjection Custom function you can provide to calculate the camera projection matrix manually. Can be used for complex effects like doing oblique projection. Function is called using component's scope.
      * Arguments:
      *     <li>{pc.Mat4} transformMatrix: output of the function</li>
      *     <li>{Number} view: Type of view. Can be pc.VIEW_CENTER, pc.VIEW_LEFT or pc.VIEW_RIGHT. Left and right are only used in stereo rendering.</li>
@@ -453,7 +453,7 @@ Object.assign(pc, function () {
          * @name pc.CameraComponent#enterVr
          * @variation 1
          * @description Attempt to start presenting this camera to a {@link pc.VrDisplay}.
-         * @param {pc.CameraVrCallback} callback Function called once to indicate success of failure. The callback takes one argument (err).
+         * @param {pc.callbacks.CameraVr} callback Function called once to indicate success of failure. The callback takes one argument (err).
          * On success it returns null on failure it returns the error message.
          * @example
          * // On an entity with a camera component
@@ -471,7 +471,7 @@ Object.assign(pc, function () {
          * @variation 2
          * @description Attempt to start presenting this camera to a {@link pc.VrDisplay}.
          * @param {pc.VrDisplay} display The VrDisplay to present. If not supplied this uses {@link pc.VrManager#display} as the default
-         * @param {pc.CameraVrCallback} callback Function called once to indicate success of failure. The callback takes one argument (err).
+         * @param {pc.callbacks.CameraVr} callback Function called once to indicate success of failure. The callback takes one argument (err).
          * On success it returns null on failure it returns the error message.
          * @example
          * // On an entity with a camera component
@@ -531,7 +531,7 @@ Object.assign(pc, function () {
          * @function
          * @name pc.CameraComponent#exitVr
          * @description Attempt to stop presenting this camera.
-         * @param {pc.CameraVrCallback} callback Function called once to indicate success of failure. The callback takes one argument (err).
+         * @param {pc.callbacks.CameraVr} callback Function called once to indicate success of failure. The callback takes one argument (err).
          * On success it returns null on failure it returns the error message.
          * @example
          * this.entity.camera.exitVr(function (err) {

--- a/src/framework/components/camera/component.js
+++ b/src/framework/components/camera/component.js
@@ -1,6 +1,6 @@
 Object.assign(pc, function () {
     /**
-     * @callback pc.CameraComponent.calculateCallback
+     * @callback pc.CalculateCallback
      * @description Callback function used by {@link pc.Application#calculateTransform} and {@link pc.Application#calculateProjection}.
      * @param {pc.Mat4} transformMatrix Output of the function.
      * @param {Number} view Type of view. Can be pc.VIEW_CENTER, pc.VIEW_LEFT or pc.VIEW_RIGHT. Left and right are only used in stereo rendering.
@@ -58,11 +58,11 @@ Object.assign(pc, function () {
      * @property {Boolean} frustumCulling Controls the culling of mesh instances against the camera frustum, i.e. if objects outside of camera should be omitted from rendering.
      * If true, culling is enabled.
      * If false, all mesh instances in the scene are rendered by the camera, regardless of visibility. Defaults to false.
-     * @property {pc.CameraComponent.calculateCallback} calculateTransform Custom function you can provide to calculate the camera transformation matrix manually. Can be used for complex effects like reflections. Function is called using component's scope.
+     * @property {pc.CalculateCallback} calculateTransform Custom function you can provide to calculate the camera transformation matrix manually. Can be used for complex effects like reflections. Function is called using component's scope.
      * Arguments:
      *     <li>{pc.Mat4} transformMatrix: output of the function</li>
      *     <li>{Number} view: Type of view. Can be pc.VIEW_CENTER, pc.VIEW_LEFT or pc.VIEW_RIGHT. Left and right are only used in stereo rendering.</li>
-     * @property {pc.CameraComponent.calculateCallback} calculateProjection Custom function you can provide to calculate the camera projection matrix manually. Can be used for complex effects like doing oblique projection. Function is called using component's scope.
+     * @property {pc.CalculateCallback} calculateProjection Custom function you can provide to calculate the camera projection matrix manually. Can be used for complex effects like doing oblique projection. Function is called using component's scope.
      * Arguments:
      *     <li>{pc.Mat4} transformMatrix: output of the function</li>
      *     <li>{Number} view: Type of view. Can be pc.VIEW_CENTER, pc.VIEW_LEFT or pc.VIEW_RIGHT. Left and right are only used in stereo rendering.</li>
@@ -456,7 +456,7 @@ Object.assign(pc, function () {
         },
 
         /**
-         * @callback pc.CameraComponent.vrCallback
+         * @callback pc.CameraVrCallback
          * @description Callback function used by {@link pc.CameraComponent#enterVr} and {@link pc.CameraComponent#exitVr}.
          * @param {String|Null} err On success it is null on failure it is the error message.
          */
@@ -466,7 +466,7 @@ Object.assign(pc, function () {
          * @name pc.CameraComponent#enterVr
          * @variation 1
          * @description Attempt to start presenting this camera to a {@link pc.VrDisplay}.
-         * @param {pc.CameraComponent.vrCallback} callback Function called once to indicate success of failure. The callback takes one argument (err).
+         * @param {pc.CameraVrCallback} callback Function called once to indicate success of failure. The callback takes one argument (err).
          * On success it returns null on failure it returns the error message.
          * @example
          * // On an entity with a camera component
@@ -484,7 +484,7 @@ Object.assign(pc, function () {
          * @variation 2
          * @description Attempt to start presenting this camera to a {@link pc.VrDisplay}.
          * @param {pc.VrDisplay} display The VrDisplay to present. If not supplied this uses {@link pc.VrManager#display} as the default
-         * @param {pc.CameraComponent.vrCallback} callback Function called once to indicate success of failure. The callback takes one argument (err).
+         * @param {pc.CameraVrCallback} callback Function called once to indicate success of failure. The callback takes one argument (err).
          * On success it returns null on failure it returns the error message.
          * @example
          * // On an entity with a camera component
@@ -544,7 +544,7 @@ Object.assign(pc, function () {
          * @function
          * @name pc.CameraComponent#exitVr
          * @description Attempt to stop presenting this camera.
-         * @param {pc.CameraComponent.vrCallback} callback Function called once to indicate success of failure. The callback takes one argument (err).
+         * @param {pc.CameraVrCallback} callback Function called once to indicate success of failure. The callback takes one argument (err).
          * On success it returns null on failure it returns the error message.
          * @example
          * this.entity.camera.exitVr(function (err) {

--- a/src/framework/components/camera/component.js
+++ b/src/framework/components/camera/component.js
@@ -1,12 +1,5 @@
 Object.assign(pc, function () {
     /**
-     * @callback pc.CalculateCallback
-     * @description Callback function used by {@link pc.Application#calculateTransform} and {@link pc.Application#calculateProjection}.
-     * @param {pc.Mat4} transformMatrix Output of the function.
-     * @param {Number} view Type of view. Can be pc.VIEW_CENTER, pc.VIEW_LEFT or pc.VIEW_RIGHT. Left and right are only used in stereo rendering.
-     */
-
-    /**
      * @component
      * @constructor
      * @name pc.CameraComponent
@@ -454,12 +447,6 @@ Object.assign(pc, function () {
         frameEnd: function () {
             this.data.isRendering = false;
         },
-
-        /**
-         * @callback pc.CameraVrCallback
-         * @description Callback function used by {@link pc.CameraComponent#enterVr} and {@link pc.CameraComponent#exitVr}.
-         * @param {String|Null} err On success it is null on failure it is the error message.
-         */
 
         /**
          * @function

--- a/src/framework/script.js
+++ b/src/framework/script.js
@@ -17,14 +17,6 @@ pc.script = (function () {
 
         /**
          * @private
-         * @callback pc.CreateScriptCallback
-         * @description Callback function used by {@link pc.script.create}.
-         * @param {pc.Application} app The application.
-         * @returns {Object} Return the Type of the script resource to be instanced for each Entity.
-         */
-
-        /**
-         * @private
          * @function
          * @name pc.script.create
          * @description Create a script resource object. A script file should contain a single call to pc.script.create and the callback should return a script object which will be
@@ -116,12 +108,6 @@ pc.script = (function () {
         attribute: function (name, type, defaultValue, options) {
             // only works when parsing the script...
         },
-
-        /**
-         * @callback pc.CreateScreenCallback
-         * @description Callback function used by {@link pc.script.createLoadingScreen}.
-         * @param {pc.Application} app The application.
-         */
 
         /**
          * @function

--- a/src/framework/script.js
+++ b/src/framework/script.js
@@ -17,7 +17,7 @@ pc.script = (function () {
 
         /**
          * @private
-         * @callback pc.script.createCallback
+         * @callback pc.CreateScriptCallback
          * @description Callback function used by {@link pc.script.create}.
          * @param {pc.Application} app The application.
          * @returns {Object} Return the Type of the script resource to be instanced for each Entity.
@@ -30,7 +30,7 @@ pc.script = (function () {
          * @description Create a script resource object. A script file should contain a single call to pc.script.create and the callback should return a script object which will be
          * instantiated when attached to Entities.
          * @param {String} name The name of the script object.
-         * @param {pc.script.createCallback} callback The callback function which is passed an {pc.Application} object,
+         * @param {pc.CreateScriptCallback} callback The callback function which is passed an {pc.Application} object,
          * which is used to access Entities and Components, and should return the Type of the script resource
          * to be instanced for each Entity.
          * @example
@@ -118,7 +118,7 @@ pc.script = (function () {
         },
 
         /**
-         * @callback pc.script.createLoadingScreenCallback
+         * @callback pc.CreateScreenCallback
          * @description Callback function used by {@link pc.script.createLoadingScreen}.
          * @param {pc.Application} app The application.
          */
@@ -129,7 +129,7 @@ pc.script = (function () {
          * @description Handles the creation of the loading screen of the application. A script can subscribe to
          * the events of a {@link pc.Application} to show a loading screen, progress bar etc. In order for this to work
          * you need to set the project's loading screen script to the script that calls this method.
-         * @param  {pc.script.createLoadingScreenCallback} callback A function which can set up and tear down a customised loading screen.
+         * @param  {pc.CreateScreenCallback} callback A function which can set up and tear down a customised loading screen.
          * @example
          * pc.script.createLoadingScreen(function (app) {
          *     var showSplashScreen = function () { // }

--- a/src/framework/script.js
+++ b/src/framework/script.js
@@ -22,7 +22,7 @@ pc.script = (function () {
          * @description Create a script resource object. A script file should contain a single call to pc.script.create and the callback should return a script object which will be
          * instantiated when attached to Entities.
          * @param {String} name The name of the script object.
-         * @param {pc.CreateScriptCallback} callback The callback function which is passed an {pc.Application} object,
+         * @param {pc.callbacks.CreateScript} callback The callback function which is passed an {pc.Application} object,
          * which is used to access Entities and Components, and should return the Type of the script resource
          * to be instanced for each Entity.
          * @example
@@ -115,7 +115,7 @@ pc.script = (function () {
          * @description Handles the creation of the loading screen of the application. A script can subscribe to
          * the events of a {@link pc.Application} to show a loading screen, progress bar etc. In order for this to work
          * you need to set the project's loading screen script to the script that calls this method.
-         * @param  {pc.CreateScreenCallback} callback A function which can set up and tear down a customised loading screen.
+         * @param  {pc.callbacks.CreateScreen} callback A function which can set up and tear down a customised loading screen.
          * @example
          * pc.script.createLoadingScreen(function (app) {
          *     var showSplashScreen = function () { // }

--- a/src/input/mouse.js
+++ b/src/input/mouse.js
@@ -224,8 +224,8 @@ Object.assign(pc, function () {
          * <li>In some browsers this will only work when the browser is running in fullscreen mode. See {@link pc.Application#enableFullscreen}
          * <li>Enabling pointer lock can only be initiated by a user action e.g. in the event handler for a mouse or keyboard input.
          * </ul>
-         * @param {pc.LockMouseCallback} [success] Function called if the request for mouse lock is successful.
-         * @param {pc.LockMouseCallback} [error] Function called if the request for mouse lock is unsuccessful.
+         * @param {pc.callbacks.LockMouse} [success] Function called if the request for mouse lock is successful.
+         * @param {pc.callbacks.LockMouse} [error] Function called if the request for mouse lock is unsuccessful.
          */
         enablePointerLock: function (success, error) {
             if (!document.body.requestPointerLock) {
@@ -259,7 +259,7 @@ Object.assign(pc, function () {
          * @function
          * @name pc.Mouse#disablePointerLock
          * @description Return control of the mouse cursor to the user
-         * @param {pc.LockMouseCallback} [success] Function called when the mouse lock is disabled
+         * @param {pc.callbacks.LockMouse} [success] Function called when the mouse lock is disabled
          */
         disablePointerLock: function (success) {
             if (!document.exitPointerLock) {

--- a/src/input/mouse.js
+++ b/src/input/mouse.js
@@ -215,11 +215,6 @@ Object.assign(pc, function () {
         },
 
         /**
-         * @callback pc.LockMouseCallback
-         * @description Callback function used by {@link pc.Mouse#enablePointerLock} and {@link pc.Application#disablePointerLock}.
-         */
-
-        /**
          * @function
          * @name pc.Mouse#enablePointerLock
          * @description Request that the browser hides the mouse cursor and locks the mouse to the element.

--- a/src/input/mouse.js
+++ b/src/input/mouse.js
@@ -215,7 +215,7 @@ Object.assign(pc, function () {
         },
 
         /**
-         * @callback pc.Mouse.pointerLockCallback
+         * @callback pc.LockMouseCallback
          * @description Callback function used by {@link pc.Mouse#enablePointerLock} and {@link pc.Application#disablePointerLock}.
          */
 
@@ -229,8 +229,8 @@ Object.assign(pc, function () {
          * <li>In some browsers this will only work when the browser is running in fullscreen mode. See {@link pc.Application#enableFullscreen}
          * <li>Enabling pointer lock can only be initiated by a user action e.g. in the event handler for a mouse or keyboard input.
          * </ul>
-         * @param {pc.Mouse.pointerLockCallback} [success] Function called if the request for mouse lock is successful.
-         * @param {pc.Mouse.pointerLockCallback} [error] Function called if the request for mouse lock is unsuccessful.
+         * @param {pc.LockMouseCallback} [success] Function called if the request for mouse lock is successful.
+         * @param {pc.LockMouseCallback} [error] Function called if the request for mouse lock is unsuccessful.
          */
         enablePointerLock: function (success, error) {
             if (!document.body.requestPointerLock) {
@@ -264,7 +264,7 @@ Object.assign(pc, function () {
          * @function
          * @name pc.Mouse#disablePointerLock
          * @description Return control of the mouse cursor to the user
-         * @param {pc.Mouse.pointerLockCallback} [success] Function called when the mouse lock is disabled
+         * @param {pc.LockMouseCallback} [success] Function called when the mouse lock is disabled
          */
         disablePointerLock: function (success) {
             if (!document.exitPointerLock) {

--- a/src/net/http.js
+++ b/src/net/http.js
@@ -54,13 +54,6 @@ Object.assign(pc, function () {
         binaryExtensions: Http.binaryExtensions,
 
         /**
-         * @callback pc.HttpCallback
-         * @description Callback function used by {@link pc.Http#get}, {@link pc.Http#post}, {@link pc.Http#put}, {@link pc.Http#del}, and {@link pc.Http#request}.
-         * @param {Number|String|Error|Null} err The error code, message, or exception in the case where the request fails.
-         * @param {*} [response] The response data if no errors were encountered. (format depends on response type: text, Object, ArrayBuffer, XML).
-         */
-
-        /**
          * @function
          * @name pc.Http#get
          * @variation 1

--- a/src/net/http.js
+++ b/src/net/http.js
@@ -56,7 +56,6 @@ Object.assign(pc, function () {
         /**
          * @function
          * @name pc.Http#get
-         * @variation 1
          * @description Perform an HTTP GET request to the given url.
          * @param {String} url The URL to make the request to.
          * @param {pc.callbacks.Http} callback The callback used when the response has returned. Passed (err, data)
@@ -102,7 +101,6 @@ Object.assign(pc, function () {
         /**
          * @function
          * @name pc.Http#post
-         * @variation 1
          * @description Perform an HTTP POST request to the given url.
          * @param {String} url The URL to make the request to.
          * @param {Object} data Data to send in the body of the request.
@@ -149,7 +147,6 @@ Object.assign(pc, function () {
         /**
          * @function
          * @name pc.Http#put
-         * @variation 1
          * @description Perform an HTTP PUT request to the given url.
          * @param {String} url The URL to make the request to.
          * @param {Document | Object} data Data to send in the body of the request.
@@ -196,7 +193,6 @@ Object.assign(pc, function () {
         /**
          * @function
          * @name pc.Http#del
-         * @variation 1
          * @description Perform an HTTP DELETE request to the given url
          * @param {Object} url The URL to make the request to
          * @param {pc.callbacks.Http} callback The callback used when the response has returned. Passed (err, data)
@@ -238,7 +234,6 @@ Object.assign(pc, function () {
         /**
          * @function
          * @name pc.Http#request
-         * @variation 1
          * @description Make a general purpose HTTP request.
          * @param {String} method The HTTP method "GET", "POST", "PUT", "DELETE"
          * @param {String} url The url to make the request to

--- a/src/net/http.js
+++ b/src/net/http.js
@@ -59,7 +59,7 @@ Object.assign(pc, function () {
          * @variation 1
          * @description Perform an HTTP GET request to the given url.
          * @param {String} url The URL to make the request to.
-         * @param {pc.HttpCallback} callback The callback used when the response has returned. Passed (err, data)
+         * @param {pc.callbacks.Http} callback The callback used when the response has returned. Passed (err, data)
          * where data is the response (format depends on response type: text, Object, ArrayBuffer, XML) and
          * err is the error code.
          * @example
@@ -86,7 +86,7 @@ Object.assign(pc, function () {
          * @param {Boolean} [options.retry] If true then if the request fails it will be retried with an exponential backoff.
          * @param {Number} [options.maxRetries] If options.retry is true this specifies the maximum number of retries. Defaults to 5.
          * @param {Number} [options.maxRetryDelay] If options.retry is true this specifies the maximum amount of time to wait between retries in milliseconds. Defaults to 5000.
-         * @param {pc.HttpCallback} callback The callback used when the response has returned. Passed (err, data)
+         * @param {pc.callbacks.Http} callback The callback used when the response has returned. Passed (err, data)
          * where data is the response (format depends on response type: text, Object, ArrayBuffer, XML) and
          * err is the error code.
          * @returns {XMLHttpRequest} The request object.
@@ -109,7 +109,7 @@ Object.assign(pc, function () {
          * Some content types are handled automatically. If postdata is an XML Document, it is handled. If
          * the Content-Type header is set to 'application/json' then the postdata is JSON stringified.
          * Otherwise, by default, the data is sent as form-urlencoded.
-         * @param {pc.HttpCallback} callback The callback used when the response has returned. Passed (err, data)
+         * @param {pc.callbacks.Http} callback The callback used when the response has returned. Passed (err, data)
          * where data is the response (format depends on response type: text, Object, ArrayBuffer, XML) and
          * err is the error code.
          * @returns {XMLHttpRequest} The request object.
@@ -132,7 +132,7 @@ Object.assign(pc, function () {
          * @param {Boolean} [options.retry] If true then if the request fails it will be retried with an exponential backoff.
          * @param {Number} [options.maxRetries] If options.retry is true this specifies the maximum number of retries. Defaults to 5.
          * @param {Number} [options.maxRetryDelay] If options.retry is true this specifies the maximum amount of time to wait between retries in milliseconds. Defaults to 5000.
-         * @param {pc.HttpCallback} callback The callback used when the response has returned. Passed (err, data)
+         * @param {pc.callbacks.Http} callback The callback used when the response has returned. Passed (err, data)
          * where data is the response (format depends on response type: text, Object, ArrayBuffer, XML) and
          * err is the error code.
          * @returns {XMLHttpRequest} The request object.
@@ -156,7 +156,7 @@ Object.assign(pc, function () {
          * Some content types are handled automatically. If postdata is an XML Document, it is handled. If
          * the Content-Type header is set to 'application/json' then the postdata is JSON stringified.
          * Otherwise, by default, the data is sent as form-urlencoded.
-         * @param {pc.HttpCallback} callback The callback used when the response has returned. Passed (err, data)
+         * @param {pc.callbacks.Http} callback The callback used when the response has returned. Passed (err, data)
          * where data is the response (format depends on response type: text, Object, ArrayBuffer, XML) and
          * err is the error code.
          * @returns {XMLHttpRequest} The request object.
@@ -179,7 +179,7 @@ Object.assign(pc, function () {
          * @param {Boolean} [options.retry] If true then if the request fails it will be retried with an exponential backoff.
          * @param {Number} [options.maxRetries] If options.retry is true this specifies the maximum number of retries. Defaults to 5.
          * @param {Number} [options.maxRetryDelay] If options.retry is true this specifies the maximum amount of time to wait between retries in milliseconds. Defaults to 5000.
-         * @param {pc.HttpCallback} callback The callback used when the response has returned. Passed (err, data)
+         * @param {pc.callbacks.Http} callback The callback used when the response has returned. Passed (err, data)
          * where data is the response (format depends on response type: text, Object, ArrayBuffer, XML) and
          * err is the error code.
          * @returns {XMLHttpRequest} The request object.
@@ -199,7 +199,7 @@ Object.assign(pc, function () {
          * @variation 1
          * @description Perform an HTTP DELETE request to the given url
          * @param {Object} url The URL to make the request to
-         * @param {pc.HttpCallback} callback The callback used when the response has returned. Passed (err, data)
+         * @param {pc.callbacks.Http} callback The callback used when the response has returned. Passed (err, data)
          * where data is the response (format depends on response type: text, Object, ArrayBuffer, XML) and
          * err is the error code.
          * @returns {XMLHttpRequest} The request object.
@@ -222,7 +222,7 @@ Object.assign(pc, function () {
          * @param {Boolean} [options.retry] If true then if the request fails it will be retried with an exponential backoff.
          * @param {Number} [options.maxRetries] If options.retry is true this specifies the maximum number of retries. Defaults to 5.
          * @param {Number} [options.maxRetryDelay] If options.retry is true this specifies the maximum amount of time to wait between retries in milliseconds. Defaults to 5000.
-         * @param {pc.HttpCallback} callback The callback used when the response has returned. Passed (err, data)
+         * @param {pc.callbacks.Http} callback The callback used when the response has returned. Passed (err, data)
          * where data is the response (format depends on response type: text, Object, ArrayBuffer, XML) and
          * err is the error code.
          * @returns {XMLHttpRequest} The request object.
@@ -242,7 +242,7 @@ Object.assign(pc, function () {
          * @description Make a general purpose HTTP request.
          * @param {String} method The HTTP method "GET", "POST", "PUT", "DELETE"
          * @param {String} url The url to make the request to
-         * @param {pc.HttpCallback} callback The callback used when the response has returned. Passed (err, data)
+         * @param {pc.callbacks.Http} callback The callback used when the response has returned. Passed (err, data)
          * where data is the response (format depends on response type: text, Object, ArrayBuffer, XML) and
          * err is the error code.
          * @returns {XMLHttpRequest} The request object.
@@ -266,7 +266,7 @@ Object.assign(pc, function () {
          * Some content types are handled automatically. If postdata is an XML Document, it is handled. If
          * the Content-Type header is set to 'application/json' then the postdata is JSON stringified.
          * Otherwise, by default, the data is sent as form-urlencoded.
-         * @param {pc.HttpCallback} callback The callback used when the response has returned. Passed (err, data)
+         * @param {pc.callbacks.Http} callback The callback used when the response has returned. Passed (err, data)
          * where data is the response (format depends on response type: text, Object, ArrayBuffer, XML) and
          * err is the error code.
          * @returns {XMLHttpRequest} The request object.

--- a/src/net/http.js
+++ b/src/net/http.js
@@ -54,7 +54,7 @@ Object.assign(pc, function () {
         binaryExtensions: Http.binaryExtensions,
 
         /**
-         * @callback pc.Http.callback
+         * @callback pc.HttpCallback
          * @description Callback function used by {@link pc.Http#get}, {@link pc.Http#post}, {@link pc.Http#put}, {@link pc.Http#del}, and {@link pc.Http#request}.
          * @param {Number|String|Error|Null} err The error code, message, or exception in the case where the request fails.
          * @param {*} [response] The response data if no errors were encountered. (format depends on response type: text, Object, ArrayBuffer, XML).
@@ -66,7 +66,7 @@ Object.assign(pc, function () {
          * @variation 1
          * @description Perform an HTTP GET request to the given url.
          * @param {String} url The URL to make the request to.
-         * @param {pc.Http.callback} callback The callback used when the response has returned. Passed (err, data)
+         * @param {pc.HttpCallback} callback The callback used when the response has returned. Passed (err, data)
          * where data is the response (format depends on response type: text, Object, ArrayBuffer, XML) and
          * err is the error code.
          * @example
@@ -93,7 +93,7 @@ Object.assign(pc, function () {
          * @param {Boolean} [options.retry] If true then if the request fails it will be retried with an exponential backoff.
          * @param {Number} [options.maxRetries] If options.retry is true this specifies the maximum number of retries. Defaults to 5.
          * @param {Number} [options.maxRetryDelay] If options.retry is true this specifies the maximum amount of time to wait between retries in milliseconds. Defaults to 5000.
-         * @param {pc.Http.callback} callback The callback used when the response has returned. Passed (err, data)
+         * @param {pc.HttpCallback} callback The callback used when the response has returned. Passed (err, data)
          * where data is the response (format depends on response type: text, Object, ArrayBuffer, XML) and
          * err is the error code.
          * @returns {XMLHttpRequest} The request object.
@@ -116,7 +116,7 @@ Object.assign(pc, function () {
          * Some content types are handled automatically. If postdata is an XML Document, it is handled. If
          * the Content-Type header is set to 'application/json' then the postdata is JSON stringified.
          * Otherwise, by default, the data is sent as form-urlencoded.
-         * @param {pc.Http.callback} callback The callback used when the response has returned. Passed (err, data)
+         * @param {pc.HttpCallback} callback The callback used when the response has returned. Passed (err, data)
          * where data is the response (format depends on response type: text, Object, ArrayBuffer, XML) and
          * err is the error code.
          * @returns {XMLHttpRequest} The request object.
@@ -139,7 +139,7 @@ Object.assign(pc, function () {
          * @param {Boolean} [options.retry] If true then if the request fails it will be retried with an exponential backoff.
          * @param {Number} [options.maxRetries] If options.retry is true this specifies the maximum number of retries. Defaults to 5.
          * @param {Number} [options.maxRetryDelay] If options.retry is true this specifies the maximum amount of time to wait between retries in milliseconds. Defaults to 5000.
-         * @param {pc.Http.callback} callback The callback used when the response has returned. Passed (err, data)
+         * @param {pc.HttpCallback} callback The callback used when the response has returned. Passed (err, data)
          * where data is the response (format depends on response type: text, Object, ArrayBuffer, XML) and
          * err is the error code.
          * @returns {XMLHttpRequest} The request object.
@@ -163,7 +163,7 @@ Object.assign(pc, function () {
          * Some content types are handled automatically. If postdata is an XML Document, it is handled. If
          * the Content-Type header is set to 'application/json' then the postdata is JSON stringified.
          * Otherwise, by default, the data is sent as form-urlencoded.
-         * @param {pc.Http.callback} callback The callback used when the response has returned. Passed (err, data)
+         * @param {pc.HttpCallback} callback The callback used when the response has returned. Passed (err, data)
          * where data is the response (format depends on response type: text, Object, ArrayBuffer, XML) and
          * err is the error code.
          * @returns {XMLHttpRequest} The request object.
@@ -186,7 +186,7 @@ Object.assign(pc, function () {
          * @param {Boolean} [options.retry] If true then if the request fails it will be retried with an exponential backoff.
          * @param {Number} [options.maxRetries] If options.retry is true this specifies the maximum number of retries. Defaults to 5.
          * @param {Number} [options.maxRetryDelay] If options.retry is true this specifies the maximum amount of time to wait between retries in milliseconds. Defaults to 5000.
-         * @param {pc.Http.callback} callback The callback used when the response has returned. Passed (err, data)
+         * @param {pc.HttpCallback} callback The callback used when the response has returned. Passed (err, data)
          * where data is the response (format depends on response type: text, Object, ArrayBuffer, XML) and
          * err is the error code.
          * @returns {XMLHttpRequest} The request object.
@@ -206,7 +206,7 @@ Object.assign(pc, function () {
          * @variation 1
          * @description Perform an HTTP DELETE request to the given url
          * @param {Object} url The URL to make the request to
-         * @param {pc.Http.callback} callback The callback used when the response has returned. Passed (err, data)
+         * @param {pc.HttpCallback} callback The callback used when the response has returned. Passed (err, data)
          * where data is the response (format depends on response type: text, Object, ArrayBuffer, XML) and
          * err is the error code.
          * @returns {XMLHttpRequest} The request object.
@@ -229,7 +229,7 @@ Object.assign(pc, function () {
          * @param {Boolean} [options.retry] If true then if the request fails it will be retried with an exponential backoff.
          * @param {Number} [options.maxRetries] If options.retry is true this specifies the maximum number of retries. Defaults to 5.
          * @param {Number} [options.maxRetryDelay] If options.retry is true this specifies the maximum amount of time to wait between retries in milliseconds. Defaults to 5000.
-         * @param {pc.Http.callback} callback The callback used when the response has returned. Passed (err, data)
+         * @param {pc.HttpCallback} callback The callback used when the response has returned. Passed (err, data)
          * where data is the response (format depends on response type: text, Object, ArrayBuffer, XML) and
          * err is the error code.
          * @returns {XMLHttpRequest} The request object.
@@ -249,7 +249,7 @@ Object.assign(pc, function () {
          * @description Make a general purpose HTTP request.
          * @param {String} method The HTTP method "GET", "POST", "PUT", "DELETE"
          * @param {String} url The url to make the request to
-         * @param {pc.Http.callback} callback The callback used when the response has returned. Passed (err, data)
+         * @param {pc.HttpCallback} callback The callback used when the response has returned. Passed (err, data)
          * where data is the response (format depends on response type: text, Object, ArrayBuffer, XML) and
          * err is the error code.
          * @returns {XMLHttpRequest} The request object.
@@ -273,7 +273,7 @@ Object.assign(pc, function () {
          * Some content types are handled automatically. If postdata is an XML Document, it is handled. If
          * the Content-Type header is set to 'application/json' then the postdata is JSON stringified.
          * Otherwise, by default, the data is sent as form-urlencoded.
-         * @param {pc.Http.callback} callback The callback used when the response has returned. Passed (err, data)
+         * @param {pc.HttpCallback} callback The callback used when the response has returned. Passed (err, data)
          * where data is the response (format depends on response type: text, Object, ArrayBuffer, XML) and
          * err is the error code.
          * @returns {XMLHttpRequest} The request object.

--- a/src/net/http.js
+++ b/src/net/http.js
@@ -58,7 +58,7 @@ Object.assign(pc, function () {
          * @name pc.Http#get
          * @description Perform an HTTP GET request to the given url.
          * @param {String} url The URL to make the request to.
-         * @param {pc.callbacks.Http} callback The callback used when the response has returned. Passed (err, data)
+         * @param {pc.callbacks.HttpResponse} callback The callback used when the response has returned. Passed (err, data)
          * where data is the response (format depends on response type: text, Object, ArrayBuffer, XML) and
          * err is the error code.
          * @example
@@ -85,7 +85,7 @@ Object.assign(pc, function () {
          * @param {Boolean} [options.retry] If true then if the request fails it will be retried with an exponential backoff.
          * @param {Number} [options.maxRetries] If options.retry is true this specifies the maximum number of retries. Defaults to 5.
          * @param {Number} [options.maxRetryDelay] If options.retry is true this specifies the maximum amount of time to wait between retries in milliseconds. Defaults to 5000.
-         * @param {pc.callbacks.Http} callback The callback used when the response has returned. Passed (err, data)
+         * @param {pc.callbacks.HttpResponse} callback The callback used when the response has returned. Passed (err, data)
          * where data is the response (format depends on response type: text, Object, ArrayBuffer, XML) and
          * err is the error code.
          * @returns {XMLHttpRequest} The request object.
@@ -107,7 +107,7 @@ Object.assign(pc, function () {
          * Some content types are handled automatically. If postdata is an XML Document, it is handled. If
          * the Content-Type header is set to 'application/json' then the postdata is JSON stringified.
          * Otherwise, by default, the data is sent as form-urlencoded.
-         * @param {pc.callbacks.Http} callback The callback used when the response has returned. Passed (err, data)
+         * @param {pc.callbacks.HttpResponse} callback The callback used when the response has returned. Passed (err, data)
          * where data is the response (format depends on response type: text, Object, ArrayBuffer, XML) and
          * err is the error code.
          * @returns {XMLHttpRequest} The request object.
@@ -130,7 +130,7 @@ Object.assign(pc, function () {
          * @param {Boolean} [options.retry] If true then if the request fails it will be retried with an exponential backoff.
          * @param {Number} [options.maxRetries] If options.retry is true this specifies the maximum number of retries. Defaults to 5.
          * @param {Number} [options.maxRetryDelay] If options.retry is true this specifies the maximum amount of time to wait between retries in milliseconds. Defaults to 5000.
-         * @param {pc.callbacks.Http} callback The callback used when the response has returned. Passed (err, data)
+         * @param {pc.callbacks.HttpResponse} callback The callback used when the response has returned. Passed (err, data)
          * where data is the response (format depends on response type: text, Object, ArrayBuffer, XML) and
          * err is the error code.
          * @returns {XMLHttpRequest} The request object.
@@ -153,7 +153,7 @@ Object.assign(pc, function () {
          * Some content types are handled automatically. If postdata is an XML Document, it is handled. If
          * the Content-Type header is set to 'application/json' then the postdata is JSON stringified.
          * Otherwise, by default, the data is sent as form-urlencoded.
-         * @param {pc.callbacks.Http} callback The callback used when the response has returned. Passed (err, data)
+         * @param {pc.callbacks.HttpResponse} callback The callback used when the response has returned. Passed (err, data)
          * where data is the response (format depends on response type: text, Object, ArrayBuffer, XML) and
          * err is the error code.
          * @returns {XMLHttpRequest} The request object.
@@ -176,7 +176,7 @@ Object.assign(pc, function () {
          * @param {Boolean} [options.retry] If true then if the request fails it will be retried with an exponential backoff.
          * @param {Number} [options.maxRetries] If options.retry is true this specifies the maximum number of retries. Defaults to 5.
          * @param {Number} [options.maxRetryDelay] If options.retry is true this specifies the maximum amount of time to wait between retries in milliseconds. Defaults to 5000.
-         * @param {pc.callbacks.Http} callback The callback used when the response has returned. Passed (err, data)
+         * @param {pc.callbacks.HttpResponse} callback The callback used when the response has returned. Passed (err, data)
          * where data is the response (format depends on response type: text, Object, ArrayBuffer, XML) and
          * err is the error code.
          * @returns {XMLHttpRequest} The request object.
@@ -195,7 +195,7 @@ Object.assign(pc, function () {
          * @name pc.Http#del
          * @description Perform an HTTP DELETE request to the given url
          * @param {Object} url The URL to make the request to
-         * @param {pc.callbacks.Http} callback The callback used when the response has returned. Passed (err, data)
+         * @param {pc.callbacks.HttpResponse} callback The callback used when the response has returned. Passed (err, data)
          * where data is the response (format depends on response type: text, Object, ArrayBuffer, XML) and
          * err is the error code.
          * @returns {XMLHttpRequest} The request object.
@@ -218,7 +218,7 @@ Object.assign(pc, function () {
          * @param {Boolean} [options.retry] If true then if the request fails it will be retried with an exponential backoff.
          * @param {Number} [options.maxRetries] If options.retry is true this specifies the maximum number of retries. Defaults to 5.
          * @param {Number} [options.maxRetryDelay] If options.retry is true this specifies the maximum amount of time to wait between retries in milliseconds. Defaults to 5000.
-         * @param {pc.callbacks.Http} callback The callback used when the response has returned. Passed (err, data)
+         * @param {pc.callbacks.HttpResponse} callback The callback used when the response has returned. Passed (err, data)
          * where data is the response (format depends on response type: text, Object, ArrayBuffer, XML) and
          * err is the error code.
          * @returns {XMLHttpRequest} The request object.
@@ -237,7 +237,7 @@ Object.assign(pc, function () {
          * @description Make a general purpose HTTP request.
          * @param {String} method The HTTP method "GET", "POST", "PUT", "DELETE"
          * @param {String} url The url to make the request to
-         * @param {pc.callbacks.Http} callback The callback used when the response has returned. Passed (err, data)
+         * @param {pc.callbacks.HttpResponse} callback The callback used when the response has returned. Passed (err, data)
          * where data is the response (format depends on response type: text, Object, ArrayBuffer, XML) and
          * err is the error code.
          * @returns {XMLHttpRequest} The request object.
@@ -261,7 +261,7 @@ Object.assign(pc, function () {
          * Some content types are handled automatically. If postdata is an XML Document, it is handled. If
          * the Content-Type header is set to 'application/json' then the postdata is JSON stringified.
          * Otherwise, by default, the data is sent as form-urlencoded.
-         * @param {pc.callbacks.Http} callback The callback used when the response has returned. Passed (err, data)
+         * @param {pc.callbacks.HttpResponse} callback The callback used when the response has returned. Passed (err, data)
          * where data is the response (format depends on response type: text, Object, ArrayBuffer, XML) and
          * err is the error code.
          * @returns {XMLHttpRequest} The request object.

--- a/src/resources/handler.js
+++ b/src/resources/handler.js
@@ -15,7 +15,7 @@ Object.assign(pc, function () {
          * @description Load a resource from a remote URL. When loaded (or failed),
          * use the callback to return an the raw resource data (or error).
          * @param {String} url The URL of the resource to load.
-         * @param {pc.HandlerCallback} callback The callback used when the resource is loaded or an error occurs.
+         * @param {pc.callbacks.Handler} callback The callback used when the resource is loaded or an error occurs.
          * @param {pc.Asset} [asset] Optional asset that is passed by ResourceLoader.
          */
         load: function (url, callback, asset) {

--- a/src/resources/handler.js
+++ b/src/resources/handler.js
@@ -10,13 +10,6 @@ Object.assign(pc, function () {
     Object.assign(ResourceHandler.prototype, {
 
         /**
-         * @callback pc.HandlerCallback
-         * @description Callback function used by {@link pc.ResourceHandler#load} when a resource is loaded (or an error occurs).
-         * @param {String|Null} err The error message in the case where the load fails.
-         * @param {*} [response] The raw data that has been successfully loaded.
-         */
-
-        /**
          * @function
          * @name pc.ResourceHandler#load
          * @description Load a resource from a remote URL. When loaded (or failed),

--- a/src/resources/handler.js
+++ b/src/resources/handler.js
@@ -10,7 +10,7 @@ Object.assign(pc, function () {
     Object.assign(ResourceHandler.prototype, {
 
         /**
-         * @callback pc.ResourceHandler.loadCallback
+         * @callback pc.HandlerCallback
          * @description Callback function used by {@link pc.ResourceHandler#load} when a resource is loaded (or an error occurs).
          * @param {String|Null} err The error message in the case where the load fails.
          * @param {*} [response] The raw data that has been successfully loaded.
@@ -22,7 +22,7 @@ Object.assign(pc, function () {
          * @description Load a resource from a remote URL. When loaded (or failed),
          * use the callback to return an the raw resource data (or error).
          * @param {String} url The URL of the resource to load.
-         * @param {pc.ResourceHandler.loadCallback} callback The callback used when the resource is loaded or an error occurs.
+         * @param {pc.HandlerCallback} callback The callback used when the resource is loaded or an error occurs.
          * @param {pc.Asset} [asset] Optional asset that is passed by ResourceLoader.
          */
         load: function (url, callback, asset) {

--- a/src/resources/handler.js
+++ b/src/resources/handler.js
@@ -15,7 +15,7 @@ Object.assign(pc, function () {
          * @description Load a resource from a remote URL. When loaded (or failed),
          * use the callback to return an the raw resource data (or error).
          * @param {String} url The URL of the resource to load.
-         * @param {pc.callbacks.Handler} callback The callback used when the resource is loaded or an error occurs.
+         * @param {pc.callbacks.ResourceHandler} callback The callback used when the resource is loaded or an error occurs.
          * @param {pc.Asset} [asset] Optional asset that is passed by ResourceLoader.
          */
         load: function (url, callback, asset) {

--- a/src/resources/loader.js
+++ b/src/resources/loader.js
@@ -76,7 +76,7 @@ Object.assign(pc, function () {
          * the resource.
          * @param {String} url The URL of the resource to load.
          * @param {String} type The type of resource expected.
-         * @param {pc.callbacks.Loader} callback The callback used when the resource is loaded or an error occurs.
+         * @param {pc.callbacks.ResourceLoader} callback The callback used when the resource is loaded or an error occurs.
          * @param {pc.Asset} [asset] Optional asset that is passed into handler
          * Passed (err, resource) where err is null if there are no errors.
          * @example

--- a/src/resources/loader.js
+++ b/src/resources/loader.js
@@ -69,13 +69,6 @@ Object.assign(pc, function () {
         },
 
         /**
-         * @callback pc.LoaderCallback
-         * @description Callback function used by {@link pc.ResourceLoader#load} when a resource is loaded (or an error occurs).
-         * @param {String|Null} err The error message in the case where the load fails.
-         * @param {*} [resource] The resource that has been successfully loaded.
-         */
-
-        /**
          * @function
          * @name pc.ResourceLoader#load
          * @description Make a request for a resource from a remote URL. Parse the returned data using the

--- a/src/resources/loader.js
+++ b/src/resources/loader.js
@@ -69,7 +69,7 @@ Object.assign(pc, function () {
         },
 
         /**
-         * @callback pc.ResourceLoader.loadCallback
+         * @callback pc.LoaderCallback
          * @description Callback function used by {@link pc.ResourceLoader#load} when a resource is loaded (or an error occurs).
          * @param {String|Null} err The error message in the case where the load fails.
          * @param {*} [resource] The resource that has been successfully loaded.
@@ -83,7 +83,7 @@ Object.assign(pc, function () {
          * the resource.
          * @param {String} url The URL of the resource to load.
          * @param {String} type The type of resource expected.
-         * @param {pc.ResourceLoader.loadCallback} callback The callback used when the resource is loaded or an error occurs.
+         * @param {pc.LoaderCallback} callback The callback used when the resource is loaded or an error occurs.
          * @param {pc.Asset} [asset] Optional asset that is passed into handler
          * Passed (err, resource) where err is null if there are no errors.
          * @example

--- a/src/resources/loader.js
+++ b/src/resources/loader.js
@@ -76,7 +76,7 @@ Object.assign(pc, function () {
          * the resource.
          * @param {String} url The URL of the resource to load.
          * @param {String} type The type of resource expected.
-         * @param {pc.LoaderCallback} callback The callback used when the resource is loaded or an error occurs.
+         * @param {pc.callbacks.Loader} callback The callback used when the resource is loaded or an error occurs.
          * @param {pc.Asset} [asset] Optional asset that is passed into handler
          * Passed (err, resource) where err is null if there are no errors.
          * @example

--- a/src/resources/model.js
+++ b/src/resources/model.js
@@ -24,7 +24,7 @@ Object.assign(pc, function () {
          * @name pc.ModelHandler#load
          * @description Fetch model data from a remote url
          * @param {String} url The URL of the model data.
-         * @param {pc.HandlerCallback} callback Callback function called when the load completes. The
+         * @param {pc.callbacks.Handler} callback Callback function called when the load completes. The
          * callback is of the form fn(err, response), where err is a String error message in
          * the case where the load fails, and response is the model data that has been
          * successfully loaded.
@@ -145,7 +145,7 @@ Object.assign(pc, function () {
          * @description Add a parser that converts raw data into a {@link pc.Model}
          * Default parser is for JSON models
          * @param {Object} parser See JsonModelParser for example
-         * @param {pc.ParserCallback} decider Function that decides on which parser to use.
+         * @param {pc.callbacks.Parser} decider Function that decides on which parser to use.
          * Function should take (url, data) arguments and return true if this parser should be used to parse the data into a {@link pc.Model}.
          * The first parser to return true is used.
          */

--- a/src/resources/model.js
+++ b/src/resources/model.js
@@ -24,7 +24,7 @@ Object.assign(pc, function () {
          * @name pc.ModelHandler#load
          * @description Fetch model data from a remote url
          * @param {String} url The URL of the model data.
-         * @param {pc.callbacks.Handler} callback Callback function called when the load completes. The
+         * @param {pc.callbacks.ResourceHandler} callback Callback function called when the load completes. The
          * callback is of the form fn(err, response), where err is a String error message in
          * the case where the load fails, and response is the model data that has been
          * successfully loaded.
@@ -145,7 +145,7 @@ Object.assign(pc, function () {
          * @description Add a parser that converts raw data into a {@link pc.Model}
          * Default parser is for JSON models
          * @param {Object} parser See JsonModelParser for example
-         * @param {pc.callbacks.Parser} decider Function that decides on which parser to use.
+         * @param {pc.callbacks.AddParser} decider Function that decides on which parser to use.
          * Function should take (url, data) arguments and return true if this parser should be used to parse the data into a {@link pc.Model}.
          * The first parser to return true is used.
          */

--- a/src/resources/model.js
+++ b/src/resources/model.js
@@ -24,7 +24,7 @@ Object.assign(pc, function () {
          * @name pc.ModelHandler#load
          * @description Fetch model data from a remote url
          * @param {String} url The URL of the model data.
-         * @param {pc.ResourceHandler.loadCallback} callback Callback function called when the load completes. The
+         * @param {pc.HandlerCallback} callback Callback function called when the load completes. The
          * callback is of the form fn(err, response), where err is a String error message in
          * the case where the load fails, and response is the model data that has been
          * successfully loaded.
@@ -140,7 +140,7 @@ Object.assign(pc, function () {
         },
 
         /**
-         * @callback pc.ModelHandler.addParserCallback
+         * @callback pc.ParserCallback
          * @description Callback function used by {@link pc.ModelHandler#addParser} to decide on which parser to use.
          * @param {String} url The resource url.
          * @param {Object} data The raw model data.
@@ -153,7 +153,7 @@ Object.assign(pc, function () {
          * @description Add a parser that converts raw data into a {@link pc.Model}
          * Default parser is for JSON models
          * @param {Object} parser See JsonModelParser for example
-         * @param {pc.ModelHandler.addParserCallback} decider Function that decides on which parser to use.
+         * @param {pc.ParserCallback} decider Function that decides on which parser to use.
          * Function should take (url, data) arguments and return true if this parser should be used to parse the data into a {@link pc.Model}.
          * The first parser to return true is used.
          */

--- a/src/resources/model.js
+++ b/src/resources/model.js
@@ -140,14 +140,6 @@ Object.assign(pc, function () {
         },
 
         /**
-         * @callback pc.ParserCallback
-         * @description Callback function used by {@link pc.ModelHandler#addParser} to decide on which parser to use.
-         * @param {String} url The resource url.
-         * @param {Object} data The raw model data.
-         * @returns {Boolean} Return true if this parser should be used to parse the data into a {@link pc.Model}
-         */
-
-        /**
          * @function
          * @name pc.ModelHandler#addParser
          * @description Add a parser that converts raw data into a {@link pc.Model}

--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -282,7 +282,7 @@ Object.assign(pc, function () {
          * @function
          * @name pc.GraphNode#find
          * @description Search the graph node and all of its descendants for the nodes that satisfy some search criteria.
-         * @param {pc.FindNodeCallback|String} attr This can either be a function or a string. If it's a function, it is executed
+         * @param {pc.callbacks.FindNode|String} attr This can either be a function or a string. If it's a function, it is executed
          * for each descendant node to test if node satisfies the search logic. Returning true from the function will
          * include the node into the results. If it's a string then it represents the name of a field or a method of the
          * node. If this is the name of a field then the value passed as the second argument will be checked for equality.
@@ -343,7 +343,7 @@ Object.assign(pc, function () {
          * @function
          * @name pc.GraphNode#findOne
          * @description Search the graph node and all of its descendants for the first node that satisfies some search criteria.
-         * @param {pc.FindNodeCallback|String} attr This can either be a function or a string. If it's a function, it is executed
+         * @param {pc.callbacks.FindNode|String} attr This can either be a function or a string. If it's a function, it is executed
          * for each descendant node to test if node satisfies the search logic. Returning true from the function will
          * result in that node being returned from findOne. If it's a string then it represents the name of a field or a method of the
          * node. If this is the name of a field then the value passed as the second argument will be checked for equality.
@@ -504,7 +504,7 @@ Object.assign(pc, function () {
          * @function
          * @name pc.GraphNode#forEach
          * @description Executes a provided function once on this graph node and all of its descendants.
-         * @param {pc.ForEachNodeCallback} callback The function to execute on the graph node and each descendant.
+         * @param {pc.callbacks.ForEachNode} callback The function to execute on the graph node and each descendant.
          * @param {Object} [thisArg] Optional value to use as this when executing callback function.
          * @example
          * // Log the path and name of each node in descendant tree starting with "parent"

--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -279,13 +279,6 @@ Object.assign(pc, function () {
         },
 
         /**
-         * @callback pc.FindNodeCallback
-         * @description Callback function used by {@link pc.GraphNode#find} and {@link pc.GraphNode#findOne} to search through a graph node and all of its descendants.
-         * @param {pc.GraphNode} node The current graph node.
-         * @returns {Boolean} Returning `true` will result in that node being returned from {@link pc.GraphNode#find} or {@link pc.GraphNode#findOne}.
-         */
-
-        /**
          * @function
          * @name pc.GraphNode#find
          * @description Search the graph node and all of its descendants for the nodes that satisfy some search criteria.
@@ -506,12 +499,6 @@ Object.assign(pc, function () {
 
             return result;
         },
-
-        /**
-         * @callback pc.ForEachNodeCallback
-         * @description Callback function used by {@link pc.GraphNode#forEach} to iterate through a graph node and all of its descendants.
-         * @param {pc.GraphNode} node The current graph node.
-         */
 
         /**
          * @function

--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -279,17 +279,17 @@ Object.assign(pc, function () {
         },
 
         /**
-         * @callback pc.GraphNode.findCallback
-         * @description Callback function used by {@link pc.GraphNode#find} to search through a graph node and all of its descendants.
+         * @callback pc.FindNodeCallback
+         * @description Callback function used by {@link pc.GraphNode#find} and {@link pc.GraphNode#findOne} to search through a graph node and all of its descendants.
          * @param {pc.GraphNode} node The current graph node.
-         * @returns {Boolean} Returning `true` from the function will include the node into the results from {@link pc.GraphNode#find}.
+         * @returns {Boolean} Returning `true` will result in that node being returned from {@link pc.GraphNode#find} or {@link pc.GraphNode#findOne}.
          */
 
         /**
          * @function
          * @name pc.GraphNode#find
          * @description Search the graph node and all of its descendants for the nodes that satisfy some search criteria.
-         * @param {pc.GraphNode.findCallback|String} attr This can either be a function or a string. If it's a function, it is executed
+         * @param {pc.FindNodeCallback|String} attr This can either be a function or a string. If it's a function, it is executed
          * for each descendant node to test if node satisfies the search logic. Returning true from the function will
          * include the node into the results. If it's a string then it represents the name of a field or a method of the
          * node. If this is the name of a field then the value passed as the second argument will be checked for equality.
@@ -347,17 +347,10 @@ Object.assign(pc, function () {
         },
 
         /**
-         * @callback pc.GraphNode.findOneCallback
-         * @description Callback function used by {@link pc.GraphNode#findOne} to search through a graph node and all of its descendants.
-         * @param {pc.GraphNode} node The current graph node.
-         * @returns {Boolean} Returning `true` from the function will result in that node being returned from {@link pc.GraphNode#findOne}.
-         */
-
-        /**
          * @function
          * @name pc.GraphNode#findOne
          * @description Search the graph node and all of its descendants for the first node that satisfies some search criteria.
-         * @param {pc.GraphNode.findOneCallback|String} attr This can either be a function or a string. If it's a function, it is executed
+         * @param {pc.FindNodeCallback|String} attr This can either be a function or a string. If it's a function, it is executed
          * for each descendant node to test if node satisfies the search logic. Returning true from the function will
          * result in that node being returned from findOne. If it's a string then it represents the name of a field or a method of the
          * node. If this is the name of a field then the value passed as the second argument will be checked for equality.
@@ -515,7 +508,7 @@ Object.assign(pc, function () {
         },
 
         /**
-         * @callback pc.GraphNode.forEachCallback
+         * @callback pc.ForEachNodeCallback
          * @description Callback function used by {@link pc.GraphNode#forEach} to iterate through a graph node and all of its descendants.
          * @param {pc.GraphNode} node The current graph node.
          */
@@ -524,7 +517,7 @@ Object.assign(pc, function () {
          * @function
          * @name pc.GraphNode#forEach
          * @description Executes a provided function once on this graph node and all of its descendants.
-         * @param {pc.GraphNode.forEachCallback} callback The function to execute on the graph node and each descendant.
+         * @param {pc.ForEachNodeCallback} callback The function to execute on the graph node and each descendant.
          * @param {Object} [thisArg] Optional value to use as this when executing callback function.
          * @example
          * // Log the path and name of each node in descendant tree starting with "parent"

--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -504,7 +504,7 @@ Object.assign(pc, function () {
          * @function
          * @name pc.GraphNode#forEach
          * @description Executes a provided function once on this graph node and all of its descendants.
-         * @param {pc.callbacks.ForEachNode} callback The function to execute on the graph node and each descendant.
+         * @param {pc.callbacks.ForEach} callback The function to execute on the graph node and each descendant.
          * @param {Object} [thisArg] Optional value to use as this when executing callback function.
          * @example
          * // Log the path and name of each node in descendant tree starting with "parent"

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -1,13 +1,5 @@
 Object.assign(pc, function () {
     /**
-     * @callback pc.UpdateShaderCallback
-     * @description Callback function used by {@link pc.Application#onUpdateShader}.
-     * @param {Object} options An object with shader generator settings (based on current material and scene properties), that you can change and then return.
-     * Properties of the object passed into this function are documented in {@link pc.Application#onUpdateShader}.
-     * @returns {Object} Returned settings will be used by the shader.
-     */
-
-    /**
      * @constructor
      * @name pc.StandardMaterial
      * @classdesc A Standard material is the main, general purpose material that is most often used for rendering.

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -164,7 +164,7 @@ Object.assign(pc, function () {
      * @property {Boolean} twoSidedLighting Calculate proper normals (and therefore lighting) on backfaces
      * @property {Object} chunks Object containing custom shader chunks that will replace default ones.
      *
-     * @property {pc.UpdateShaderCallback} onUpdateShader A custom function that will be called after all shader generator properties are collected and before shader code is generated.
+     * @property {pc.callbacks.UpdateShader} onUpdateShader A custom function that will be called after all shader generator properties are collected and before shader code is generated.
      * This function will receive an object with shader generator settings (based on current material and scene properties), that you can change and then return.
      * Returned value will be used instead. This is mostly useful when rendering the same set of objects, but with different shader variations based on the same material.
      * For example, you may wish to render a depth or normal pass using textures assigned to the material, a reflection pass with simpler shaders and so on.

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -1,6 +1,6 @@
 Object.assign(pc, function () {
     /**
-     * @callback pc.StandardMaterial.onUpdateShaderCallback
+     * @callback pc.UpdateShaderCallback
      * @description Callback function used by {@link pc.Application#onUpdateShader}.
      * @param {Object} options An object with shader generator settings (based on current material and scene properties), that you can change and then return.
      * Properties of the object passed into this function are documented in {@link pc.Application#onUpdateShader}.
@@ -172,7 +172,7 @@ Object.assign(pc, function () {
      * @property {Boolean} twoSidedLighting Calculate proper normals (and therefore lighting) on backfaces
      * @property {Object} chunks Object containing custom shader chunks that will replace default ones.
      *
-     * @property {pc.StandardMaterial.onUpdateShaderCallback} onUpdateShader A custom function that will be called after all shader generator properties are collected and before shader code is generated.
+     * @property {pc.UpdateShaderCallback} onUpdateShader A custom function that will be called after all shader generator properties are collected and before shader code is generated.
      * This function will receive an object with shader generator settings (based on current material and scene properties), that you can change and then return.
      * Returned value will be used instead. This is mostly useful when rendering the same set of objects, but with different shader variations based on the same material.
      * For example, you may wish to render a depth or normal pass using textures assigned to the material, a reflection pass with simpler shaders and so on.

--- a/src/vr/vr-display.js
+++ b/src/vr/vr-display.js
@@ -210,12 +210,6 @@ Object.assign(pc, function () {
         },
 
         /**
-         * @callback pc.VrDisplayCallback
-         * @description Callback function used by {@link pc.VrDisplay#requestPresent} and {@link pc.VrDisplay#exitPresent}.
-         * @param {String|Null} err The error message if presenting fails, or null if the call succeeds.
-         */
-
-        /**
          * @function
          * @name pc.VrDisplay#requestPresent
          * @description Try to present full screen VR content on this display
@@ -263,11 +257,6 @@ Object.assign(pc, function () {
                 if (callback) callback(new Error("exitPresent failed"));
             });
         },
-
-        /**
-         * @callback pc.VrFrameCallback
-         * @description Callback function used by {@link pc.VrDisplay#requestAnimationFrame}.
-         */
 
         /**
          * @function

--- a/src/vr/vr-display.js
+++ b/src/vr/vr-display.js
@@ -210,7 +210,7 @@ Object.assign(pc, function () {
         },
 
         /**
-         * @callback pc.VrDisplay.presentCallback
+         * @callback pc.VrDisplayCallback
          * @description Callback function used by {@link pc.VrDisplay#requestPresent} and {@link pc.VrDisplay#exitPresent}.
          * @param {String|Null} err The error message if presenting fails, or null if the call succeeds.
          */
@@ -219,7 +219,7 @@ Object.assign(pc, function () {
          * @function
          * @name pc.VrDisplay#requestPresent
          * @description Try to present full screen VR content on this display
-         * @param {pc.VrDisplay.presentCallback} callback Called when the request is completed. Callback takes a single argument (err) that is the error message return
+         * @param {pc.VrDisplayCallback} callback Called when the request is completed. Callback takes a single argument (err) that is the error message return
          * if presenting fails, or null if the call succeeds. Usually called by {@link pc.CameraComponent#enterVr}.
          */
         requestPresent: function (callback) {
@@ -242,9 +242,9 @@ Object.assign(pc, function () {
 
         /**
          * @function
-         * @name pc.VrDisplay#exitPresent
+         * @name pc.VrExitPresent
          * @description Try to stop presenting VR content on this display
-         * @param {pc.VrDisplay.presentCallback} callback Called when the request is completed. Callback takes a single argument (err) that is the error message return
+         * @param {pc.VrDisplayCallback} callback Called when the request is completed. Callback takes a single argument (err) that is the error message return
          * if presenting fails, or null if the call succeeds. Usually called by {@link pc.CameraComponent#exitVr}.
          */
         exitPresent: function (callback) {
@@ -265,7 +265,7 @@ Object.assign(pc, function () {
         },
 
         /**
-         * @callback pc.VrDisplay.requestAnimationFrameCallback
+         * @callback pc.VrFrameCallback
          * @description Callback function used by {@link pc.VrDisplay#requestAnimationFrame}.
          */
 
@@ -273,7 +273,7 @@ Object.assign(pc, function () {
          * @function
          * @name pc.VrDisplay#requestAnimationFrame
          * @description Used in the main application loop instead of the regular `window.requestAnimationFrame`. Usually only called from inside {@link pc.Application}
-         * @param {pc.VrDisplay.requestAnimationFrameCallback} fn Function called when it is time to update the frame.
+         * @param {pc.VrFrameCallback} fn Function called when it is time to update the frame.
          */
         requestAnimationFrame: function (fn) {
             if (this.display) this.display.requestAnimationFrame(fn);

--- a/src/vr/vr-display.js
+++ b/src/vr/vr-display.js
@@ -236,7 +236,7 @@ Object.assign(pc, function () {
 
         /**
          * @function
-         * @name pc.VrExitPresent
+         * @name pc.VrDisplay#exitPresent
          * @description Try to stop presenting VR content on this display
          * @param {pc.callbacks.VrDisplay} callback Called when the request is completed. Callback takes a single argument (err) that is the error message return
          * if presenting fails, or null if the call succeeds. Usually called by {@link pc.CameraComponent#exitVr}.

--- a/src/vr/vr-display.js
+++ b/src/vr/vr-display.js
@@ -213,7 +213,7 @@ Object.assign(pc, function () {
          * @function
          * @name pc.VrDisplay#requestPresent
          * @description Try to present full screen VR content on this display
-         * @param {pc.VrDisplayCallback} callback Called when the request is completed. Callback takes a single argument (err) that is the error message return
+         * @param {pc.callbacks.VrDisplay} callback Called when the request is completed. Callback takes a single argument (err) that is the error message return
          * if presenting fails, or null if the call succeeds. Usually called by {@link pc.CameraComponent#enterVr}.
          */
         requestPresent: function (callback) {
@@ -238,7 +238,7 @@ Object.assign(pc, function () {
          * @function
          * @name pc.VrExitPresent
          * @description Try to stop presenting VR content on this display
-         * @param {pc.VrDisplayCallback} callback Called when the request is completed. Callback takes a single argument (err) that is the error message return
+         * @param {pc.callbacks.VrDisplay} callback Called when the request is completed. Callback takes a single argument (err) that is the error message return
          * if presenting fails, or null if the call succeeds. Usually called by {@link pc.CameraComponent#exitVr}.
          */
         exitPresent: function (callback) {
@@ -262,7 +262,7 @@ Object.assign(pc, function () {
          * @function
          * @name pc.VrDisplay#requestAnimationFrame
          * @description Used in the main application loop instead of the regular `window.requestAnimationFrame`. Usually only called from inside {@link pc.Application}
-         * @param {pc.VrFrameCallback} fn Function called when it is time to update the frame.
+         * @param {pc.callbacks.VrFrame} fn Function called when it is time to update the frame.
          */
         requestAnimationFrame: function (fn) {
             if (this.display) this.display.requestAnimationFrame(fn);


### PR DESCRIPTION
Together with https://github.com/playcanvas/playcanvas-jsdoc-template/pull/4, this PR fixes https://github.com/playcanvas/engine/pull/1668#issuecomment-525363110.

PR changes:
- Rename and shorten calllbacks to look nicer in the API docs template.
- Move callbacks to separate namespace `pc.callbacks` (to fix broken links in the template) and separate file `src/callbacks.js` (which only contains jsdoc comments).
- Fix some minor @link typos.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
