### PR TITLE
[FIX] pc.GraphNode#find now processes the supplied node

### DIFF
--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -306,7 +306,7 @@ Object.assign(pc, function () {
          * var entities = parent.find('name', 'Test');
          */
         find: function (attr, value) {
-            var results = [];
+            var result, results = [];
             var len = this._children.length;
             var i, descendants;
 

--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -313,10 +313,11 @@ Object.assign(pc, function () {
             if (attr instanceof Function) {
                 var fn = attr;
 
-                for (i = 0; i < len; i++) {
-                    if (fn(this._children[i]))
-                        results.push(this._children[i]);
+                result = fn(this);
+                if (result)
+                    results.push(this);
 
+                for (i = 0; i < len; i++) {
                     descendants = this._children[i].find(fn);
                     if (descendants.length)
                         results = results.concat(descendants);

--- a/tests/scene/test_graphnode.js
+++ b/tests/scene/test_graphnode.js
@@ -23,6 +23,36 @@ describe('pc.GraphNode', function () {
         return g1;
     }
 
+    it('GraphNode: find', function () {
+        var root, found;
+        root = buildGraph();
+        found = root.find('name', 'g1');
+        equal(found.length, 1);
+        equal(found[0], root);
+        found = root.find('name', 'g2');
+        equal(found.length, 1);
+        equal(found[0].parent, root);
+        found = root.find('name', 'g3');
+        equal(found.length, 1);
+        equal(found[0].parent.parent, root);
+
+        found = root.find(function (node) {
+            return node.name === 'g1';
+        });
+        equal(found.length, 1);
+        equal(found[0], root);
+        found = root.find(function (node) {
+            return node.name === 'g2';
+        });
+        equal(found.length, 1);
+        equal(found[0].parent, root);
+        found = root.find(function (node) {
+            return node.name === 'g3';
+        });
+        equal(found.length, 1);
+        equal(found[0].parent.parent, root);
+    });
+
     it('GraphNode: findByName same entity', function () {
         var node = buildGraph();
         var found = node.findByName('g1');


### PR DESCRIPTION
Fixes #1689 

Currently, the API ref says:

```
Search the graph node and all of its descendants for the nodes that satisfy some search criteria.
```

However, the specified graph node is only checked if find is called with a string/value pair. If you pass a function parameter, the specified node is ignored. This is different to the behavior of pc.GraphNode#findOne which _does_ check the specified node for both function signatures.

This PR updates pc.GraphNode#find to include the specified node in the search if the function parameter is a function. 

This could potentially break an existing app that depends on the current behavior but this scenario should be very unlikely/rare.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
