### PR TITLE
AssetsRegistry.loadFromUrl material now will load textures too

### DIFF
--- a/src/asset/asset-registry.js
+++ b/src/asset/asset-registry.js
@@ -470,7 +470,17 @@ Object.assign(pc, function () {
             }
 
             asset.once("load", function (loadedAsset) {
-                callback(null, loadedAsset);
+                if (type === 'material') {
+                    self._loadTextures([ asset ], function (err, textures) {
+                        if (err) {
+                            callback(err);
+                        } else {
+                            callback(null, loadedAsset);
+                        }
+                    });
+                } else {
+                    callback(null, loadedAsset);
+                }
             });
             asset.once("error", function (err) {
                 callback(err);

--- a/src/asset/asset-registry.js
+++ b/src/asset/asset-registry.js
@@ -471,7 +471,7 @@ Object.assign(pc, function () {
 
             asset.once("load", function (loadedAsset) {
                 if (type === 'material') {
-                    self._loadTextures([ asset ], function (err, textures) {
+                    self._loadTextures([ loadedAsset ], function (err, textures) {
                         if (err) {
                             callback(err);
                         } else {


### PR DESCRIPTION
Fixes #1096

Now textures are loaded too, when loading material asset from url.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
