### PR TITLE
[FIX] pc.GraphNode#reparent error when passed self

### DIFF
--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -745,16 +745,6 @@ Object.assign(pc, function () {
         reparent: function (parent, index) {
             var current = this._parent;
 
-            // #ifdef DEBUG
-            if (this === parent) {
-                throw new Error('GraphNode cannot be a parent of itself');
-            }
-
-            if (parent.isDescendantOf(this)) {
-                throw new Error('GraphNode cannot set a descendant as parent');
-            }
-            // #endif
-
             if (current)
                 current.removeChild(this);
 

--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -745,9 +745,15 @@ Object.assign(pc, function () {
         reparent: function (parent, index) {
             var current = this._parent;
 
+            // #ifdef DEBUG
             if (this === parent) {
-                throw new Error('GraphNode cannot be parented to self');
+                throw new Error('GraphNode cannot be a parent of itself');
             }
+
+            if (parent.isDescendantOf(this)) {
+                throw new Error('GraphNode cannot set a descendant as parent');
+            }
+            // #endif
 
             if (current)
                 current.removeChild(this);
@@ -1051,11 +1057,19 @@ Object.assign(pc, function () {
             if (node._parent !== null)
                 throw new Error("GraphNode is already parented");
 
+            // #ifdef DEBUG
+            this._debugInsertChild(node);
+            // #endif
+
             this._children.push(node);
             this._onInsertChild(node);
         },
 
         addChildAndSaveTransform: function (node) {
+            // #ifdef DEBUG
+            this._debugInsertChild(node);
+            // #endif
+
             var wPos = node.getPosition();
             var wRot = node.getRotation();
 
@@ -1067,7 +1081,6 @@ Object.assign(pc, function () {
             node.setRotation(tmpQuat.copy(this.getRotation()).invert().mul(wRot));
 
             this._children.push(node);
-
             this._onInsertChild(node);
         },
 
@@ -1085,9 +1098,23 @@ Object.assign(pc, function () {
             if (node._parent !== null)
                 throw new Error("GraphNode is already parented");
 
+            // #ifdef DEBUG
+            this._debugInsertChild(node);
+            // #endif
+
             this._children.splice(index, 0, node);
             this._onInsertChild(node);
         },
+
+        // #ifdef DEBUG
+        _debugInsertChild: function (node) {
+            if (this === node)
+                throw new Error("GraphNode cannot be a child of itself");
+
+            if (this.isDescendantOf(node))
+                throw new Error("GraphNode cannot add an ancestor as a child");
+        },
+        // #endif
 
         _onInsertChild: function (node) {
             node._parent = this;

--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -744,6 +744,11 @@ Object.assign(pc, function () {
          */
         reparent: function (parent, index) {
             var current = this._parent;
+
+            if (this === parent) {
+                throw new Error('GraphNode cannot be parented to self');
+            }
+
             if (current)
                 current.removeChild(this);
 

--- a/tests/karma.conf.js
+++ b/tests/karma.conf.js
@@ -19,6 +19,10 @@ module.exports = function (config) {
         // base path that will be used to resolve all patterns (eg. files, exclude)
         basePath: '..',
 
+        client: {
+            args: process.argv
+        },
+
         // list of files / patterns to load in the browser
         files: sourceFiles.concat([
             // libraries

--- a/tests/scene/test_graphnode.js
+++ b/tests/scene/test_graphnode.js
@@ -125,6 +125,37 @@ describe('pc.GraphNode', function () {
         equal(g1.children[0], g2);
     });
 
+    it('GraphNode: addChild error on self child', function () {
+        var g1 = new pc.GraphNode('g1');
+
+        var error = {};
+        try {
+            g1.addChild(g1);
+        } catch (e) {
+            error = e;
+        }
+
+        equal(error.message, 'GraphNode cannot be a child of itself');
+    });
+
+    it('GraphNode: addChild error on ancestral child', function () {
+        var g1 = new pc.GraphNode('g1');
+        var g2 = new pc.GraphNode('g2');
+        var g3 = new pc.GraphNode('g3');
+
+        g1.addChild(g2);
+        g2.addChild(g3);
+
+        var error = {};
+        try {
+            g3.addChild(g1);
+        } catch (e) {
+            error = e;
+        }
+
+        equal(error.message, 'GraphNode cannot add an ancestor as a child');
+    });
+
     it('GraphNode: insertChild', function () {
         var g1 = new pc.GraphNode('g1');
         var g2 = new pc.GraphNode('g2');
@@ -135,6 +166,37 @@ describe('pc.GraphNode', function () {
 
         equal(g1.children[0], g3);
         equal(g1.children[1], g2);
+    });
+
+    it('GraphNode: insertChild error on self child', function () {
+        var g1 = new pc.GraphNode('g1');
+
+        var error = {};
+        try {
+            g1.insertChild(g1, 0);
+        } catch (e) {
+            error = e;
+        }
+
+        equal(error.message, 'GraphNode cannot be a child of itself');
+    });
+
+    it('GraphNode: insertChild error on ancestral child', function () {
+        var g1 = new pc.GraphNode('g1');
+        var g2 = new pc.GraphNode('g2');
+        var g3 = new pc.GraphNode('g3');
+
+        g1.insertChild(g2, 0);
+        g2.insertChild(g3, 0);
+
+        var error = {};
+        try {
+            g3.insertChild(g1, 0);
+        } catch (e) {
+            error = e;
+        }
+
+        equal(error.message, 'GraphNode cannot add an ancestor as a child');
     });
 
     it('GraphNode: removeChild', function () {
@@ -193,7 +255,25 @@ describe('pc.GraphNode', function () {
             error = e;
         }
 
-        equal(error.message, 'GraphNode cannot be parented to self');
+        equal(error.message, 'GraphNode cannot be a parent of itself');
+    });
+
+    it('GraphNode: reparent error on descendant parent', function () {
+        var g1 = new pc.GraphNode('g1');
+        var g2 = new pc.GraphNode('g2');
+        var g3 = new pc.GraphNode('g3');
+
+        g1.addChild(g2);
+        g2.addChild(g3);
+
+        var error = {};
+        try {
+            g1.reparent(g3);
+        } catch (e) {
+            error = e;
+        }
+
+        equal(error.message, 'GraphNode cannot set a descendant as parent');
     });
 
     it('GraphNode: children', function () {

--- a/tests/scene/test_graphnode.js
+++ b/tests/scene/test_graphnode.js
@@ -255,7 +255,7 @@ describe('pc.GraphNode', function () {
             error = e;
         }
 
-        equal(error.message, 'GraphNode cannot be a parent of itself');
+        equal(error.message, 'GraphNode cannot be a child of itself');
     });
 
     it('GraphNode: reparent error on descendant parent', function () {
@@ -273,7 +273,7 @@ describe('pc.GraphNode', function () {
             error = e;
         }
 
-        equal(error.message, 'GraphNode cannot set a descendant as parent');
+        equal(error.message, 'GraphNode cannot add an ancestor as a child');
     });
 
     it('GraphNode: children', function () {

--- a/tests/scene/test_graphnode.js
+++ b/tests/scene/test_graphnode.js
@@ -183,6 +183,19 @@ describe('pc.GraphNode', function () {
         equal(g3.children[1], g2);
     });
 
+    it('GraphNode: reparent error on self parent', function () {
+        var g1 = new pc.GraphNode('g1');
+
+        var error = {};
+        try {
+            g1.reparent(g1);
+        } catch (e) {
+            error = e;
+        }
+
+        equal(error.message, 'GraphNode cannot be parented to self');
+    });
+
     it('GraphNode: children', function () {
         var g1 = new pc.GraphNode('g1');
         var g2 = new pc.GraphNode('g2');

--- a/tests/scene/test_graphnode.js
+++ b/tests/scene/test_graphnode.js
@@ -1,4 +1,6 @@
 describe('pc.GraphNode', function () {
+    var PRODUCTION = __karma__.config.args.includes('--release');
+
     beforeEach(function () {
         this.app = new pc.Application(document.createElement('canvas'));
     });
@@ -125,36 +127,38 @@ describe('pc.GraphNode', function () {
         equal(g1.children[0], g2);
     });
 
-    it('GraphNode: addChild error on self child', function () {
-        var g1 = new pc.GraphNode('g1');
+    if (!PRODUCTION) {
+        it('GraphNode: addChild error on self child', function () {
+            var g1 = new pc.GraphNode('g1');
 
-        var error = {};
-        try {
-            g1.addChild(g1);
-        } catch (e) {
-            error = e;
-        }
+            var error = {};
+            try {
+                g1.addChild(g1);
+            } catch (e) {
+                error = e;
+            }
 
-        equal(error.message, 'GraphNode cannot be a child of itself');
-    });
+            equal(error.message, 'GraphNode cannot be a child of itself');
+        });
 
-    it('GraphNode: addChild error on ancestral child', function () {
-        var g1 = new pc.GraphNode('g1');
-        var g2 = new pc.GraphNode('g2');
-        var g3 = new pc.GraphNode('g3');
+        it('GraphNode: addChild error on ancestral child', function () {
+            var g1 = new pc.GraphNode('g1');
+            var g2 = new pc.GraphNode('g2');
+            var g3 = new pc.GraphNode('g3');
 
-        g1.addChild(g2);
-        g2.addChild(g3);
+            g1.addChild(g2);
+            g2.addChild(g3);
 
-        var error = {};
-        try {
-            g3.addChild(g1);
-        } catch (e) {
-            error = e;
-        }
+            var error = {};
+            try {
+                g3.addChild(g1);
+            } catch (e) {
+                error = e;
+            }
 
-        equal(error.message, 'GraphNode cannot add an ancestor as a child');
-    });
+            equal(error.message, 'GraphNode cannot add an ancestor as a child');
+        });
+    }
 
     it('GraphNode: insertChild', function () {
         var g1 = new pc.GraphNode('g1');
@@ -168,36 +172,38 @@ describe('pc.GraphNode', function () {
         equal(g1.children[1], g2);
     });
 
-    it('GraphNode: insertChild error on self child', function () {
-        var g1 = new pc.GraphNode('g1');
+    if (!PRODUCTION) {
+        it('GraphNode: insertChild error on self child', function () {
+            var g1 = new pc.GraphNode('g1');
 
-        var error = {};
-        try {
-            g1.insertChild(g1, 0);
-        } catch (e) {
-            error = e;
-        }
+            var error = {};
+            try {
+                g1.insertChild(g1, 0);
+            } catch (e) {
+                error = e;
+            }
 
-        equal(error.message, 'GraphNode cannot be a child of itself');
-    });
+            equal(error.message, 'GraphNode cannot be a child of itself');
+        });
 
-    it('GraphNode: insertChild error on ancestral child', function () {
-        var g1 = new pc.GraphNode('g1');
-        var g2 = new pc.GraphNode('g2');
-        var g3 = new pc.GraphNode('g3');
+        it('GraphNode: insertChild error on ancestral child', function () {
+            var g1 = new pc.GraphNode('g1');
+            var g2 = new pc.GraphNode('g2');
+            var g3 = new pc.GraphNode('g3');
 
-        g1.insertChild(g2, 0);
-        g2.insertChild(g3, 0);
+            g1.insertChild(g2, 0);
+            g2.insertChild(g3, 0);
 
-        var error = {};
-        try {
-            g3.insertChild(g1, 0);
-        } catch (e) {
-            error = e;
-        }
+            var error = {};
+            try {
+                g3.insertChild(g1, 0);
+            } catch (e) {
+                error = e;
+            }
 
-        equal(error.message, 'GraphNode cannot add an ancestor as a child');
-    });
+            equal(error.message, 'GraphNode cannot add an ancestor as a child');
+        });
+    }
 
     it('GraphNode: removeChild', function () {
         var g1 = new pc.GraphNode('g1');
@@ -245,36 +251,38 @@ describe('pc.GraphNode', function () {
         equal(g3.children[1], g2);
     });
 
-    it('GraphNode: reparent error on self parent', function () {
-        var g1 = new pc.GraphNode('g1');
+    if (!PRODUCTION) {
+        it('GraphNode: reparent error on self parent', function () {
+            var g1 = new pc.GraphNode('g1');
 
-        var error = {};
-        try {
-            g1.reparent(g1);
-        } catch (e) {
-            error = e;
-        }
+            var error = {};
+            try {
+                g1.reparent(g1);
+            } catch (e) {
+                error = e;
+            }
 
-        equal(error.message, 'GraphNode cannot be a child of itself');
-    });
+            equal(error.message, 'GraphNode cannot be a child of itself');
+        });
 
-    it('GraphNode: reparent error on descendant parent', function () {
-        var g1 = new pc.GraphNode('g1');
-        var g2 = new pc.GraphNode('g2');
-        var g3 = new pc.GraphNode('g3');
+        it('GraphNode: reparent error on descendant parent', function () {
+            var g1 = new pc.GraphNode('g1');
+            var g2 = new pc.GraphNode('g2');
+            var g3 = new pc.GraphNode('g3');
 
-        g1.addChild(g2);
-        g2.addChild(g3);
+            g1.addChild(g2);
+            g2.addChild(g3);
 
-        var error = {};
-        try {
-            g1.reparent(g3);
-        } catch (e) {
-            error = e;
-        }
+            var error = {};
+            try {
+                g1.reparent(g3);
+            } catch (e) {
+                error = e;
+            }
 
-        equal(error.message, 'GraphNode cannot add an ancestor as a child');
-    });
+            equal(error.message, 'GraphNode cannot add an ancestor as a child');
+        });
+    }
 
     it('GraphNode: children', function () {
         var g1 = new pc.GraphNode('g1');


### PR DESCRIPTION
fixes #1696

Currently there is no check for something like:

```
entity.reparent(entity);
```

Which gets stuck in a recursive loop.

This PR updates pc.GraphNode#reparent to check if the parent
is equal to `this` and throw an error before getting stuck in a
loop if so.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
