### PR TITLE
[FIX] Fix data url not being recognized as an absolute url

### DIFF
--- a/src/asset/asset.js
+++ b/src/asset/asset.js
@@ -6,11 +6,19 @@ Object.assign(pc, function () {
     var ABSOLUTE_URL = new RegExp(
         '^' + // beginning of the url
         '\\s*' +  // ignore leading spaces (some browsers trim the url automatically, but we can't assume that)
-        '(?:' +  // beginning of protocol scheme (non-captured regex group)
-        '[a-z]+[a-z0-9\\-\\+\\.]*' + // protocol scheme must (RFC 3986) consist of "a letter and followed by any combination of letters, digits, plus ("+"), period ("."), or hyphen ("-")."
-        ':' + // protocol scheme must end with colon character
-        ')?' + // end of optional scheme group, the group is optional since the string may be a protocol-relative absolute URL
-        '//', // a absolute url must always begin with two forward slash characters (ignoring any leading spaces and protocol scheme)
+        '(?:' +  // beginning of a non-captured regex group
+            // `{protocol}://`
+            '(?:' +  // beginning of protocol scheme (non-captured regex group)
+                '[a-z]+[a-z0-9\\-\\+\\.]*' + // protocol scheme must (RFC 3986) consist of "a letter and followed by any combination of letters, digits, plus ("+"), period ("."), or hyphen ("-")."
+                ':' + // protocol scheme must end with colon character
+            ')?' + // end of optional scheme group, the group is optional since the string may be a protocol-relative absolute URL
+            '//' + // an absolute url must always begin with two forward slash characters (ignoring any leading spaces and protocol scheme)
+
+            '|' + // or another option(s):
+
+            // Data URL (RFC 2397), simplified
+            'data:' +
+        ')',
         'i' // non case-sensitive flag
     );
 


### PR DESCRIPTION
Fixes asset loading via data urls which were getting broken with an asset registry prefix due to false negative as an "absolute url"
