### PR TITLE
fix vertex attrib index type

### DIFF
--- a/src/graphics/vertex-buffer.js
+++ b/src/graphics/vertex-buffer.js
@@ -61,7 +61,7 @@ Object.assign(pc, function () {
                 device.vbOffsets.length = 0;
                 device.attributesInvalidated = true;
                 for (var loc in device.enabledAttributes) {
-                    gl.disableVertexAttribArray(loc);
+                    gl.disableVertexAttribArray(Number(loc));
                 }
                 device.enabledAttributes = {};
             }


### PR DESCRIPTION
JavaScript object keys are strings, but `gl.disableVertexAttribArray()` expects a number. I'm getting exceptions thrown on some Android devices complaining about this, which prevents further destroying processes from running.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
