### PR TITLE
check mouse device in ElementDragHelper

### DIFF
--- a/src/framework/components/element/element-drag-helper.js
+++ b/src/framework/components/element/element-drag-helper.js
@@ -71,8 +71,10 @@ Object.assign(pc, function () {
             // Note that we handle release events directly on the window object, rather than
             // on app.mouse or app.touch. This is in order to correctly handle cases where the
             // user releases the mouse/touch outside of the window.
-            this._app.mouse[onOrOff]('mousemove', this._onMove, this);
-            window[addOrRemoveEventListener]('mouseup', this._handleMouseUpOrTouchEnd, false);
+            if (this._app.mouse) {
+                this._app.mouse[onOrOff]('mousemove', this._onMove, this);
+                window[addOrRemoveEventListener]('mouseup', this._handleMouseUpOrTouchEnd, false);
+            }
 
             if (pc.platform.touch) {
                 this._app.touch[onOrOff]('touchmove', this._onMove, this);


### PR DESCRIPTION
`app.mouse` won't exist if a mouse deivice is not passed as an option to `Application`. We encountered an exception thrown from this when the `ElementDragHelper` is being destroyed.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
