### PR TITLE
If 'in' is used for Indonesian locales replace it with 'id'

### DIFF
--- a/src/i18n/i18n.js
+++ b/src/i18n/i18n.js
@@ -31,7 +31,7 @@ Object.assign(pc, (function () {
         }
 
         return desiredLang;
-    }
+    };
 
     var DEFAULT_LOCALE = 'en-US';
 

--- a/src/i18n/i18n.js
+++ b/src/i18n/i18n.js
@@ -23,6 +23,16 @@ Object.assign(pc, (function () {
         return locale;
     };
 
+    // Replaces the language in the specified locale and returns the result
+    var replaceLang = function (locale, desiredLang) {
+        var idx = locale.indexOf('-');
+        if (idx !== -1) {
+            return desiredLang + locale.substring(idx);
+        }
+
+        return desiredLang;
+    }
+
     var DEFAULT_LOCALE = 'en-US';
 
     // default locale fallbacks if a specific locale
@@ -467,10 +477,22 @@ Object.assign(pc, (function () {
                 return;
             }
 
+            // replace 'in' language with 'id'
+            // for Indonesian because both codes are valid
+            // so that users only need to use the 'id' code
+            var lang = getLang(value);
+            if (lang === 'in') {
+                lang = 'id';
+                value = replaceLang(value, lang);
+                if (this._locale === value) {
+                    return;
+                }
+            }
+
             var old = this._locale;
             // cache locale, lang and plural function
             this._locale = value;
-            this._lang = getLang(value);
+            this._lang = lang;
             this._pluralFn = getPluralFn(this._lang);
 
             // raise event

--- a/tests/i18n/test_i18n.js
+++ b/tests/i18n/test_i18n.js
@@ -598,4 +598,25 @@ describe('I18n tests', function () {
         app.assets.add(asset);
         app.assets.load(asset);
     });
+
+    it('locale for Indonesian should always start with "id"', function () {
+        app.i18n.locale = 'id';
+        expect(app.i18n.locale).to.equal('id');
+
+        app.i18n.locale = 'id-ID';
+        expect(app.i18n.locale).to.equal('id-ID');
+
+        app.i18n.locale = 'in';
+        expect(app.i18n.locale).to.equal('id');
+
+        app.i18n.locale = 'in-ID';
+        expect(app.i18n.locale).to.equal('id-ID');
+
+        // sanity checks
+        app.i18n.locale = 'en';
+        expect(app.i18n.locale).to.equal('en');
+
+        app.i18n.locale = 'en-US';
+        expect(app.i18n.locale).to.equal('en-US');
+    });
 });


### PR DESCRIPTION
Indonesian can have both 'id' and 'in' for the first part of its locale so always use 'id' so developers do not have to duplicate their localizations just for Indonesian.