### PR TITLE
[Fixed Bug] npm ERR when running npm run build:all

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "build:debug": "cd build && node build.js -d -o output/playcanvas.dbg.js", 
     "build:profiler": "cd build && node build.js -p -o output/playcanvas.prf.js", 
     "build:min": "cd build && node build.js -l 1 -o output/playcanvas.min.js", 
-    "build:all": "npm run build; npm run build:debug; npm run build:profiler; npm run build:min", 
+    "build:all": "npm run build && npm run build:debug && npm run build:profiler && npm run build:min", 
     "docs": "jsdoc -c conf-api.json", 
     "serve": "npm run build; ./node_modules/.bin/http-server build/output -a localhost -p 51000", 
     "closure": "java -jar node_modules/google-closure-compiler/compiler.jar --compilation_level=SIMPLE --warning_level=VERBOSE --jscomp_off=checkTypes --externs build/externs.js --language_in=ECMASCRIPT5_STRICT --js build/output/playcanvas-latest.js --js_output_file build/output/playcanvas.min.js", 


### PR DESCRIPTION
Replaced `;` with `&&` in `package.json` for `build:all` script.
This would resolve `npm ERR! missing script: build;` when running `npm run build:all`.

Fixes #1770

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
