### PR TITLE
[FIX] Compound collision shape due to ammo API change

### DIFF
--- a/src/framework/components/collision/system.js
+++ b/src/framework/components/collision/system.js
@@ -745,11 +745,14 @@ Object.assign(pc, function () {
         },
 
         _removeCompoundChild: function (collision, shape) {
-            // TODO
-            // use removeChildShape once it is exposed in ammo.js
-            var ind = collision._getCompoundChildShapeIndex(shape);
-            if (ind !== null)
-                collision.shape.removeChildShapeByIndex(ind);
+            if (collision.shape.removeChildShape) {
+                collision.shape.removeChildShape(shape);
+            } else {
+                var ind = collision._getCompoundChildShapeIndex(shape);
+                if (ind !== null) {
+                    collision.shape.removeChildShapeByIndex(ind);
+                }
+            }
         },
 
         onTransformChanged: function (component, position, rotation, scale) {
@@ -792,6 +795,7 @@ Object.assign(pc, function () {
 
                 pos = vec3;
                 rot = quat;
+
                 mat4.getTranslation(pos);
                 rot.setFromMat4(mat4);
             } else {


### PR DESCRIPTION
There was a change in ammo.js API, and removing compound child behaves differently, so added a fix that uses now exposed method `removeChildShape`.

Fixes https://forum.playcanvas.com/t/compound-collision-shapes-do-not-work-in-projects-made-from-blank-projects/11588

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
