### PR TITLE
remove child compound trimesh to avoid memory leak

### DIFF
--- a/src/framework/components/collision/system.js
+++ b/src/framework/components/collision/system.js
@@ -453,10 +453,7 @@ Object.assign(pc, function () {
             var data = component.data;
 
             if (data.model) {
-                if (data.shape) {
-                    Ammo.destroy(data.shape);
-                    data.shape = null;
-                }
+                this.destroyShape(data);
 
                 data.shape = this.createPhysicalShape(entity, data);
 
@@ -497,15 +494,22 @@ Object.assign(pc, function () {
             pc.CollisionSystemImpl.prototype.updateTransform.call(this, component, position, rotation, scale);
         },
 
-        remove: function (entity, data) {
-            if (data.shape) {
-                var numShapes = data.shape.getNumChildShapes();
-                for (var i = 0; i < numShapes; i++) {
-                    var shape = data.shape.getChildShape(i);
-                    Ammo.destroy(shape);
-                }
+        destroyShape: function(data) {
+            if (! data.shape)
+                return;
+
+            var numShapes = data.shape.getNumChildShapes();
+            for (var i = 0; i < numShapes; i++) {
+                var shape = data.shape.getChildShape(i);
+                Ammo.destroy(shape);
             }
 
+            Ammo.destroy(data.shape);
+            data.shape = null;
+        },
+
+        remove: function (entity, data) {
+            this.destroyShape(data);
             CollisionSystemImpl.prototype.remove.call(this, entity, data);
         }
     });

--- a/src/framework/components/collision/system.js
+++ b/src/framework/components/collision/system.js
@@ -494,8 +494,8 @@ Object.assign(pc, function () {
             pc.CollisionSystemImpl.prototype.updateTransform.call(this, component, position, rotation, scale);
         },
 
-        destroyShape: function(data) {
-            if (! data.shape)
+        destroyShape: function (data) {
+            if (!data.shape)
                 return;
 
             var numShapes = data.shape.getNumChildShapes();


### PR DESCRIPTION
Fixes #1786

But fix is not full, as it ensures it deletes child shapes of trimesh, but btMotionState cannot be removed, as it is issue described here: https://github.com/kripken/ammo.js/issues/284 which has related ticket in emscripten: https://github.com/emscripten-core/emscripten/issues/9854

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
