### PR TITLE
Mojiworks/update typescript bindings

### DIFF
--- a/src/asset/asset.js
+++ b/src/asset/asset.js
@@ -71,6 +71,7 @@ Object.assign(pc, function () {
      * @property {Array} resources A reference to the resources of the asset when it's loaded. An asset can hold more runtime resources than one e.g. cubemaps
      * @property {Boolean} preload If true the asset will be loaded during the preload phase of application set up.
      * @property {Boolean} loaded True if the resource is loaded. e.g. if asset.resource is not null
+     * @property {Boolean} loading True if the resource is currently being loaded
      * @property {pc.AssetRegistry} registry The asset registry that this Asset belongs to
      */
     var Asset = function (name, type, file, data) {

--- a/src/framework/components/animation/component.js
+++ b/src/framework/components/animation/component.js
@@ -11,9 +11,9 @@ Object.assign(pc, function () {
      * @property {Number} speed Speed multiplier for animation play back speed. 1.0 is playback at normal speed, 0.0 pauses the animation
      * @property {Boolean} loop If true the animation will restart from the beginning when it reaches the end
      * @property {Boolean} activate If true the first animation asset will begin playing when the scene is loaded
-     * @property {pc.Asset[]} assets The array of animation assets - can also be an array of asset ids.
-     * @property {Number} currentTime Get or Set the current time position (in seconds) of the animation
-     * @property {Number} duration Get the duration in seconds of the current animation.
+     * @property {pc.Asset[]|number[]} assets The array of animation assets - can also be an array of asset ids.
+     * @property {number} currentTime Get or Set the current time position (in seconds) of the animation
+     * @property {number} duration Get the duration in seconds of the current animation.
      */
     var AnimationComponent = function (system, entity) {
         pc.Component.call(this, system, entity);

--- a/src/input/element-input.js
+++ b/src/input/element-input.js
@@ -74,6 +74,7 @@ Object.assign(pc, function () {
      * @param {pc.CameraComponent} camera The CameraComponent that this event was originally raised via.
      * @property {MouseEvent|TouchEvent} event The MouseEvent or TouchEvent that was originally raised.
      * @property {pc.ElementComponent} element The ElementComponent that this event was originally raised on.
+     * @property {pc.CameraComponent} camera The CameraComponent that this event was originally raised via.
      */
     var ElementInputEvent = function (event, element, camera) {
         this.event = event;

--- a/src/math/curve-set.js
+++ b/src/math/curve-set.js
@@ -58,7 +58,7 @@ Object.assign(pc, (function () {
          * @param {Number[]} [result] The interpolated curve values at the specified time.
          * If this parameter is not supplied, the function allocates a new array internally
          * to return the result.
-         * @returns {Number[]} The interpolated curve values at the specified time
+         * @returns {number[]} The interpolated curve values at the specified time
          */
         value: function (time, result) {
             var length = this.curves.length;

--- a/src/script/script.js
+++ b/src/script/script.js
@@ -260,7 +260,7 @@ Object.assign(pc, function () {
      * @description Get object with attribute arguments.
      * Note: Changing argument properties will not affect existing Script Instances.
      * @param {String} name Name of an attribute
-     * @returns {?Object} Arguments with attribute properties
+     * @returns {pc.ScriptAttributeArgs|null} Arguments with attribute properties
      * @example
      * // changing default value for an attribute 'fullName'
      * var attr = PlayerController.attributes.get('fullName');

--- a/src/script/script.js
+++ b/src/script/script.js
@@ -115,44 +115,28 @@ Object.assign(pc, function () {
     };
 
     /**
-     * @typedef {'boolean'|'number'|'string'|'json'|'asset'|'entity'|'rgb'|'rgba'|'vec2'|'vec3'|'vec4'|'curve' } pc.ScriptAttributesType
+     * @typedef {'boolean'|'number'|'string'|'json'|'asset'|'entity'|'rgb'|'rgba'|'vec2'|'vec3'|'vec4'|'curve'} pc.ScriptAttributesType
      */
 
     /**
-     * @constructor
-     * @name pc.ScriptAttributes
-     * @classdesc Container of Script Attribute definitions. Implements an interface to add/remove attributes and store their definition for a {@link pc.ScriptType}.
-     * Note: An instance of pc.ScriptAttributes is created automatically by each {@link pc.ScriptType}.
-     * @param {pc.ScriptType} scriptType Script Type that attributes relate to.
-     */
-    var ScriptAttributes = function (scriptType) {
-        this.scriptType = scriptType;
-        this.index = { };
-    };
-
-    /**
-     * @function
-     * @name pc.ScriptAttributes#add
-     * @description Add Attribute
-     * @param {String} name Name of an attribute
-     * @param {Object} args Object with Arguments for an attribute
-     * @param {pc.ScriptAttributesType} args.type Type of an attribute value
-     * @param {*} [args.default] Default attribute value
-     * @param {String} [args.title] Title for Editor's for field UI
-     * @param {String} [args.description] Description for Editor's for field UI
-     * @param {String|String[]} [args.placeholder] Placeholder for Editor's for field UI.
+     * @typedef {Object} pc.ScriptAttributeArgs
+     * @property {pc.ScriptAttributesType} type Type of an attribute value
+     * @property {*} [default] Default attribute value
+     * @property {String} [title] Title for Editor's for field UI
+     * @property {String} [description] Description for Editor's for field UI
+     * @property {String|String[]} [placeholder] Placeholder for Editor's for field UI.
      * For multi-field types, such as vec2, vec3, and others use array of strings.
-     * @param {Boolean} [args.array] If attribute can hold single or multiple values
-     * @param {Number} [args.size] If attribute is array, maximum number of values can be set
-     * @param {Number} [args.min] Minimum value for type 'number', if max and min defined, slider will be rendered in Editor's UI
-     * @param {Number} [args.max] Maximum value for type 'number', if max and min defined, slider will be rendered in Editor's UI
-     * @param {Number} [args.precision] Level of precision for field type 'number' with floating values
-     * @param {Number} [args.step] Step value for type 'number'. The amount used to increment the value when using the arrow keys in the Editor's UI.
-     * @param {String} [args.assetType] Name of asset type to be used in 'asset' type attribute picker in Editor's UI, defaults to '*' (all)
-     * @param {String[]} [args.curves] List of names for Curves for field type 'curve'
-     * @param {String} [args.color] String of color channels for Curves for field type 'curve', can be any combination of `rgba` characters.
+     * @property {Boolean} [array] If attribute can hold single or multiple values
+     * @property {Number} [size] If attribute is array, maximum number of values can be set
+     * @property {Number} [min] Minimum value for type 'number', if max and min defined, slider will be rendered in Editor's UI
+     * @property {Number} [max] Maximum value for type 'number', if max and min defined, slider will be rendered in Editor's UI
+     * @property {Number} [precision] Level of precision for field type 'number' with floating values
+     * @property {Number} [step] Step value for type 'number'. The amount used to increment the value when using the arrow keys in the Editor's UI.
+     * @property {String} [assetType] Name of asset type to be used in 'asset' type attribute picker in Editor's UI, defaults to '*' (all)
+     * @property {String[]} [curves] List of names for Curves for field type 'curve'
+     * @property {String} [color] String of color channels for Curves for field type 'curve', can be any combination of `rgba` characters.
      * Defining this property will render Gradient in Editor's field UI
-     * @param {Object[]} [args.enum] List of fixed choices for field, defined as array of objects, where key in object is a title of an option
+     * @property {Object[]} [enum] List of fixed choices for field, defined as array of objects, where key in object is a title of an option
      * @example
      * PlayerController.attributes.add('fullName', {
      *     type: 'string',
@@ -174,6 +158,26 @@ Object.assign(pc, function () {
      *        { '128x128': 128 }
      *     ]
      * });
+    */
+
+    /**
+     * @constructor
+     * @name pc.ScriptAttributes
+     * @classdesc Container of Script Attribute definitions. Implements an interface to add/remove attributes and store their definition for a {@link pc.ScriptType}.
+     * Note: An instance of pc.ScriptAttributes is created automatically by each {@link pc.ScriptType}.
+     * @param {pc.ScriptType} scriptType Script Type that attributes relate to.
+     */
+    var ScriptAttributes = function (scriptType) {
+        this.scriptType = scriptType;
+        this.index = { };
+    };
+
+    /**
+     * @function
+     * @name pc.ScriptAttributes#add
+     * @description Add Attribute
+     * @param {String} name Name of an attribute
+     * @param {pc.ScriptAttributeArgs} args Object with Arguments for an attribute
      */
     ScriptAttributes.prototype.add = function (name, args) {
         if (this.index[name]) {

--- a/src/script/script.js
+++ b/src/script/script.js
@@ -114,6 +114,9 @@ Object.assign(pc, function () {
         return value;
     };
 
+    /**
+     * @typedef {'boolean'|'number'|'string'|'json'|'asset'|'entity'|'rgb'|'rgba'|'vec2'|'vec3'|'vec4'|'curve' } pc.ScriptAttributesType
+     */
 
     /**
      * @constructor
@@ -133,7 +136,7 @@ Object.assign(pc, function () {
      * @description Add Attribute
      * @param {String} name Name of an attribute
      * @param {Object} args Object with Arguments for an attribute
-     * @param {("boolean"|"number"|"string"|"json"|"asset"|"entity"|"rgb"|"rgba"|"vec2"|"vec3"|"vec4"|"curve")} args.type Type of an attribute value
+     * @param {pc.ScriptAttributesType} args.type Type of an attribute value
      * @param {*} [args.default] Default attribute value
      * @param {String} [args.title] Title for Editor's for field UI
      * @param {String} [args.description] Description for Editor's for field UI

--- a/src/shape/bounding-box.js
+++ b/src/shape/bounding-box.js
@@ -23,6 +23,20 @@ Object.assign(pc, function () {
     Object.assign(BoundingBox.prototype, {
 
         /**
+        * @member
+        * @name pc.BoundingBox#center
+        * @type {pc.Vec3}
+        * @description Center of box.
+        */
+
+        /**
+        * @member
+        * @name pc.BoundingBox#halfExtents
+        * @type {pc.Vec3}
+        * @description Half the distance across the box in each axis.
+        */
+
+        /**
          * @function
          * @name pc.BoundingBox#add
          * @description Combines two bounding boxes into one, enclosing both.

--- a/src/shape/ray.js
+++ b/src/shape/ray.js
@@ -18,6 +18,22 @@ Object.assign(pc, function () {
         this.direction = direction || new pc.Vec3(0, 0, -1);
     };
 
+    /**
+    * @member
+    * @name pc.Ray#origin
+    * @type {pc.Vec3}
+    * @description The starting point of the ray. The constructor takes a reference of this parameter.
+    * Defaults to the origin (0, 0, 0).
+    */
+
+    /**
+    * @member
+    * @name pc.Ray#direction
+    * @type {pc.Vec3}
+    * @description he direction of the ray. The constructor takes a reference of this parameter.
+    * Defaults to a direction down the world negative Z axis (0, 0, -1).
+    */
+
     return {
         Ray: Ray
     };


### PR DESCRIPTION
Here at Mojiworks we're using Typescript exclusively with Playcanvas. We found a few bumps for us, mainly the odd missing type/function declarations

We have also found it useful to declare first-class types for certain things we use in our Typescript that are currently long-hand in Playcanvas.

## Declarations
+ Add `loading` flag to `Asset` - we use this to check on status of loading assets.
+ Camera component property added to `pc.ElementInputEvent`
+ Add `origin` and `direction` to `Ray` type
+ Add `center` and `halfExtents` to bounding box

## Added types for Typescript
+ Declare `pc.ScriptAttributesType` rather than union type so we can refer to the type in our Typescript code
~ `pc.ScriptAttributes.get` return type as the named type rather than `any`
~ Move script attributes argument out into its own type so we can use that as a stand-alone type

## Assets in the Animation component
Per the documentation, the `assets` array in the Animation component can be assets or asset ids. The current docs declare assets, but we find ids in the arrays. So, change to be either so we can get type-safe results.

## Use of `Number` versus `number`
Typescript complains: _'number' is a primitive, but 'Number' is a wrapper object. Prefer using 'number' when possible._
Their advice per [Typescript Handbook - Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html#general-types
) is to use `number`. This does seem to conflict with JSDoc annoyingly though, but changing to `number` does work and removes Typescript complaints!

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
