### PR TITLE
[FIX] Mouse wheel is now consistent across browsers

### DIFF
--- a/src/core/platform.js
+++ b/src/core/platform.js
@@ -135,8 +135,9 @@ Object.assign(pc, function () {
 
         try {
             var opts = Object.defineProperty({}, 'passive', {
-                get: function() {
+                get: function () {
                     platform.passiveEvents = true;
+                    return false;
                 }
             });
             window.addEventListener("testpassive", null, opts);

--- a/src/core/platform.js
+++ b/src/core/platform.js
@@ -88,7 +88,18 @@ Object.assign(pc, function () {
          * @name pc.platform.workers
          * @description If the platform supports Web Workers.
          */
-        workers: false
+        workers: false,
+
+        /**
+         * @private
+         * @static
+         * @readonly
+         * @type {boolean}
+         * @name pc.platform.passiveEvents
+         * @description If the platform supports an options object as the third parameter
+         * to `EventTarget.addEventListener()` and the passive property is supported.
+         */
+        passiveEvents: false
     };
 
     if (typeof navigator !== 'undefined') {
@@ -121,6 +132,16 @@ Object.assign(pc, function () {
         platform.gamepads = 'getGamepads' in navigator;
 
         platform.workers = (typeof(Worker) !== 'undefined');
+
+        try {
+            var opts = Object.defineProperty({}, 'passive', {
+                get: function() {
+                    platform.passiveEvents = true;
+                }
+            });
+            window.addEventListener("testpassive", null, opts);
+            window.removeEventListener("testpassive", null, opts);
+        } catch (e) {}
     }
 
     return {

--- a/src/input/element-input.js
+++ b/src/input/element-input.js
@@ -257,16 +257,16 @@ Object.assign(pc, function () {
             this._target = domElement;
             this._attached = true;
 
-            var opt = pc.platform.passiveEvents ? { passive: true } : false;
+            var opts = pc.platform.passiveEvents ? { passive: true } : false;
             if (this._useMouse) {
-                window.addEventListener('mouseup', this._upHandler, opt);
-                window.addEventListener('mousedown', this._downHandler, opt);
-                window.addEventListener('mousemove', this._moveHandler, opt);
-                window.addEventListener('wheel', this._wheelHandler, opt);
+                window.addEventListener('mouseup', this._upHandler, opts);
+                window.addEventListener('mousedown', this._downHandler, opts);
+                window.addEventListener('mousemove', this._moveHandler, opts);
+                window.addEventListener('wheel', this._wheelHandler, opts);
             }
 
             if (this._useTouch && pc.platform.touch) {
-                this._target.addEventListener('touchstart', this._touchstartHandler, opt);
+                this._target.addEventListener('touchstart', this._touchstartHandler, opts);
                 // Passive is not used for the touchend event because some components need to be
                 // able to call preventDefault(). See notes in button/component.js for more details.
                 this._target.addEventListener('touchend', this._touchendHandler, false);
@@ -284,16 +284,16 @@ Object.assign(pc, function () {
             if (!this._attached) return;
             this._attached = false;
 
-            var opt = pc.platform.passiveEvents ? { passive: true } : false;
+            var opts = pc.platform.passiveEvents ? { passive: true } : false;
             if (this._useMouse) {
-                window.removeEventListener('mouseup', this._upHandler, opt);
-                window.removeEventListener('mousedown', this._downHandler, opt);
-                window.removeEventListener('mousemove', this._moveHandler, opt);
-                window.removeEventListener('wheel', this._wheelHandler, opt);
+                window.removeEventListener('mouseup', this._upHandler, opts);
+                window.removeEventListener('mousedown', this._downHandler, opts);
+                window.removeEventListener('mousemove', this._moveHandler, opts);
+                window.removeEventListener('wheel', this._wheelHandler, opts);
             }
 
             if (this._useTouch) {
-                this._target.removeEventListener('touchstart', this._touchstartHandler, opt);
+                this._target.removeEventListener('touchstart', this._touchstartHandler, opts);
                 this._target.removeEventListener('touchend', this._touchendHandler, false);
                 this._target.removeEventListener('touchmove', this._touchmoveHandler, false);
                 this._target.removeEventListener('touchcancel', this._touchcancelHandler, false);


### PR DESCRIPTION
This PR does the following:

* Removes dependence on deprecated `mousewheel` and `DOMMouseScroll` events and switches to use the now standard `wheel` event (successfully tested in IE11, Edge and via BrowserStack in Chrome 37, Firefox 32).
* Makes all browsers report the same wheel delta.
* Respects the `passive` option for `addEventListener` for mouse events, which gets rid of a console warning in Chrome for event handlers that call `preventDefault`.
* Maintains `pc.MouseEvent#wheel` behavior for the purpose of backwards compatibility. The user has to actively update to `pc.MouseEvent#wheelDelta` to get the consistent behavior.

@daredevildave - you wrote this code originally, so I'm including you for your opinion.

Fixes #1761 
Fixes #1831 

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
