### PR TITLE
Add support for torus primitive to ModelComponent

### DIFF
--- a/src/framework/components/model/component.js
+++ b/src/framework/components/model/component.js
@@ -18,6 +18,7 @@ Object.assign(pc, function () {
      * * "cylinder": The component will render a cylinder (radius 0.5, height 1)
      * * "plane": The component will render a plane (1 unit in each dimension)
      * * "sphere": The component will render a sphere (radius 0.5)
+     * * "torus": The component will render a torus (ring radius 0.35, tube radius 0.15)
      *
      * @property {pc.Asset|number} asset The asset for the model (only applies to models of type 'asset') - can also be an asset id.
      * @property {boolean} castShadows If true, this model will cast shadows for lights that have shadow casting enabled.
@@ -572,6 +573,16 @@ Object.assign(pc, function () {
                         }
                         mesh = system.sphere;
                         this._area = { x: Math.PI, y: Math.PI, z: Math.PI, uv: 1 };
+                        break;
+                    case 'torus':
+                        if (!system.torus) {
+                            system.torus = pc.createTorus(gd, {
+                                tubeRadius: 0.15,
+                                ringRadius: 0.35,
+                            });
+                        }
+                        mesh = system.torus;
+                        this._area = { x: 1, y: 1, z: 1, uv: 1 }; // TODO: calculate this correctly
                         break;
                     default:
                         throw new Error("Invalid model type: " + value);

--- a/src/framework/components/model/component.js
+++ b/src/framework/components/model/component.js
@@ -9,7 +9,7 @@ Object.assign(pc, function () {
      * @description Create a new ModelComponent.
      * @param {pc.ModelComponentSystem} system - The ComponentSystem that created this Component.
      * @param {pc.Entity} entity - The Entity that this Component is attached to.
-     * @property {string} type The type of the model, which can be one of the following values:
+     * @property {string} type The type of the model, for example the name of a primitive. The following values are available:
      *
      * * "asset": The component will render a model asset
      * * "box": The component will render a box (1 unit in each dimension)

--- a/src/framework/components/model/component.js
+++ b/src/framework/components/model/component.js
@@ -582,7 +582,7 @@ Object.assign(pc, function () {
                             });
                         }
                         mesh = system.torus;
-                        this._area = { x: 1, y: 1, z: 1, uv: 1 }; // TODO: calculate this correctly
+                        this._area = { x: 2, y: 2, z: 2, uv: 2 / 3 };
                         break;
                     default:
                         throw new Error("Invalid model type: " + value);

--- a/src/framework/components/model/component.js
+++ b/src/framework/components/model/component.js
@@ -578,7 +578,7 @@ Object.assign(pc, function () {
                         if (!system.torus) {
                             system.torus = pc.createTorus(gd, {
                                 tubeRadius: 0.15,
-                                ringRadius: 0.35,
+                                ringRadius: 0.35
                             });
                         }
                         mesh = system.torus;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3101405/73178800-4b7e3300-4112-11ea-8ed7-e76efdde6bda.png)

I noticed that there's code for [generating torus meshes](https://github.com/playcanvas/engine/blob/6923c43fc8a147b9ee5df37cda010ba3262d5db2/src/scene/procedural.js#L324), but no support for a torus primitive in [ModelComponent](https://github.com/playcanvas/engine/blob/6923c43fc8a147b9ee5df37cda010ba3262d5db2/src/framework/components/model/component.js#L12), so I attempted to add that.

However, I didn't understand how to calculate the `_area` property. Any help or hints about that would be appreciated.

~~By the way, I found it a bit confusing that the summary section of the API reference page for ModelComponent ([here](https://developer.playcanvas.com/en/api/pc.ModelComponent.html)) doesn't indicate that there are more types of primitives than the tree listed (see picture below). I assume that the summary is generated algorithmically and to avoid this problem I suggest that an [ellipsis](https://en.wikipedia.org/wiki/Ellipsis) is added at the bottom of the excerpt if there's more content than what is selected to be shown in the summary.~~ EDIT: Question [answered](https://github.com/playcanvas/engine/pull/1842#issuecomment-578702282). Problem [solved](https://github.com/playcanvas/engine/pull/1842/commits/45792472c046fd61d9d55fdbb0ad87f3770f323a).

![2020-01-27 10_18_22-pc ModelComponent _ PlayCanvas API Reference](https://user-images.githubusercontent.com/3101405/73163361-224cab00-40f0-11ea-9f28-f9debfdc707e.png)

If [type](https://developer.playcanvas.com/en/api/pc.ModelComponent.html#type) is clicked the full list is shown, of course. But that's in another place.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
