### PR TITLE
handle PVR non-square-pot textures

### DIFF
--- a/src/resources/basis.js
+++ b/src/resources/basis.js
@@ -76,6 +76,17 @@ Object.assign(pc, function () {
             // select format based on supported formats
             var basisFormat = hasAlpha ? alphaMapping[format] : opaqueMapping[format];
 
+            // PVR does not support non-square or non-pot textures. In these cases we
+            // transcode to an uncompressed format.
+            if ((basisFormat === BASIS_FORMAT.cTFPVRTC1_4_RGB ||
+                 basisFormat === BASIS_FORMAT.cTFPVRTC1_4_RGBA)) {
+                // if not power-of-two or not square
+                if (((width & (width - 1)) !== 0) || (width !== height)) {
+                    basisFormat = (basisFormat === BASIS_FORMAT.cTFPVRTC1_4_RGB) ?
+                        BASIS_FORMAT.cTFRGB565 : BASIS_FORMAT.cTFRGBA4444;
+                }
+            }
+
             if (!basisFile.startTranscoding()) {
                 basisFile.close();
                 basisFile.delete();
@@ -94,7 +105,7 @@ Object.assign(pc, function () {
                 }
 
                 var i;
-                if (basisFormat === 14 /* BASIS_FORMAT.cTFRGB565 */ || basisFormat === 16 /* BASIS_FORMAT.cTFRGBA4444 */) {
+                if (basisFormat === BASIS_FORMAT.cTFRGB565 || basisFormat === BASIS_FORMAT.cTFRGBA4444) {
                     // 16 bit formats require Uint16 typed array
                     var dst16 = new Uint16Array(dstSize / 2);
                     for (i = 0; i < dstSize / 2; ++i) {

--- a/src/resources/basis.js
+++ b/src/resources/basis.js
@@ -16,8 +16,9 @@ Object.assign(pc, function () {
             cTFATC_RGB: 11,                     // ATC rgb
             cTFATC_RGBA_INTERPOLATED_ALPHA: 12, // ATC rgba
             // uncompressed (fallback) formats
+            cTFRGBA32: 13,                      // rgba 8888
             cTFRGB565: 14,                      // rgb 565
-            cTFRGBA4444: 16                     // rgbq 4444
+            cTFRGBA4444: 16                     // rgba 4444
         };
 
         // Map GPU to basis format for textures without alpha
@@ -53,6 +54,7 @@ Object.assign(pc, function () {
         basisToEngineMapping[BASIS_FORMAT.cTFASTC_4x4]      = pc.PIXELFORMAT_ASTC_4x4;
         basisToEngineMapping[BASIS_FORMAT.cTFATC_RGB]       = pc.PIXELFORMAT_ATC_RGB;
         basisToEngineMapping[BASIS_FORMAT.cTFATC_RGBA_INTERPOLATED_ALPHA] = pc.PIXELFORMAT_ATC_RGBA;
+        basisToEngineMapping[BASIS_FORMAT.cTFRGBA32]        = pc.PIXELFORMAT_R8_G8_B8_A8;
         basisToEngineMapping[BASIS_FORMAT.cTFRGB565]        = pc.PIXELFORMAT_R5_G6_B5;
         basisToEngineMapping[BASIS_FORMAT.cTFRGBA4444]      = pc.PIXELFORMAT_R4_G4_B4_A4;
 
@@ -83,7 +85,7 @@ Object.assign(pc, function () {
                 // if not power-of-two or not square
                 if (((width & (width - 1)) !== 0) || (width !== height)) {
                     basisFormat = (basisFormat === BASIS_FORMAT.cTFPVRTC1_4_RGB) ?
-                        BASIS_FORMAT.cTFRGB565 : BASIS_FORMAT.cTFRGBA4444;
+                        BASIS_FORMAT.cTFRGB565 : BASIS_FORMAT.cTFRGBA32;
                 }
             }
 


### PR DESCRIPTION
Fall back to uncompressed format when PVR is requested for a non-square or non-power-of-two texture.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
