### PR TITLE
Adjust Vec3.normalize docs to reflect behaviour better

### DIFF
--- a/src/math/vec2.js
+++ b/src/math/vec2.js
@@ -257,7 +257,7 @@ Object.assign(pc, (function () {
         /**
          * @function
          * @name pc.Vec2#normalize
-         * @description Returns the specified 2-dimensional vector copied and converted to a unit vector.
+         * @description Returns this 2-dimensional vector converted to a unit vector in place.
          * If the vector has a length of zero, the vector's elements will be set to zero.
          * @returns {pc.Vec2} Self for chaining.
          * @example

--- a/src/math/vec3.js
+++ b/src/math/vec3.js
@@ -304,7 +304,7 @@ Object.assign(pc, (function () {
          *
          * v.normalize();
          *
-         * // Should output 1, 0, 0, 0
+         * // Should output 1, 0, 0
          * console.log("The result of the vector normalization is: " + v.toString());
          */
         normalize: function () {

--- a/src/math/vec3.js
+++ b/src/math/vec3.js
@@ -296,9 +296,9 @@ Object.assign(pc, (function () {
         /**
          * @function
          * @name pc.Vec3#normalize
-         * @description Returns the specified 3-dimensional vector copied and converted to a unit vector.
+         * @description Returns this 3-dimensional vector converted to a unit vector in place.
          * If the vector has a length of zero, the vector's elements will be set to zero.
-         * @returns {pc.Vec3} The result of the normalization.
+         * @returns {pc.Vec3} Self for chaining.
          * @example
          * var v = new pc.Vec3(25, 0, 0);
          *

--- a/src/math/vec4.js
+++ b/src/math/vec4.js
@@ -257,9 +257,9 @@ Object.assign(pc, (function () {
         /**
          * @function
          * @name pc.Vec4#normalize
-         * @description Returns the specified 4-dimensional vector copied and converted to a unit vector.
+         * @description Returns this 4-dimensional vector converted to a unit vector in place.
          * If the vector has a length of zero, the vector's elements will be set to zero.
-         * @returns {pc.Vec4} The result of the normalization.
+         * @returns {pc.Vec4} Self for chaining.
          * @example
          * var v = new pc.Vec4(25, 0, 0, 0);
          *


### PR DESCRIPTION
Fixes docs for pc.Vec3.normalize (plus some automatic line-ending normalisation, yay?)

I noticed that the `Vec3.normalize` docs are somewhat misleading:
> Returns the specified 3-dimensional vector copied and converted to a unit vector.

Based on experience, the example code given, and having looked at the source, I know that `normalize` actually normalises the vector in place.

(Let me know if you don't want to include the line ending fixes in this PR, I'll remove those changes. Wasn't intentional, git was being "helpful")

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
