### PR TITLE
For sound slot, asset id type should be a number (or can be null) rather than string

### DIFF
--- a/src/framework/components/sound/slot.js
+++ b/src/framework/components/sound/slot.js
@@ -39,7 +39,7 @@ Object.assign(pc, function () {
      * @param {boolean} [options.autoPlay=false] - If true the slot will start playing as soon as its audio asset is loaded.
      * @param {number} [options.asset=null] - The asset id of the audio asset that is going to be played by this slot.
      * @property {string} name The name of the slot.
-     * @property {string} asset The asset id.
+     * @property {number|null} asset The asset id.
      * @property {boolean} autoPlay If true the slot will begin playing as soon as it is loaded.
      * @property {number} volume The volume modifier to play the sound with. In range 0-1.
      * @property {number} pitch The pitch modifier to play the sound with. Must be larger than 0.01.


### PR DESCRIPTION
We noticed the asset id in sound slots is typed as `string` but should be `number`. Checking the code, can also be `null`, so accounted for this also.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
