### PR TITLE
add error handling to promises in WebXR

### DIFF
--- a/src/xr/xr-manager.js
+++ b/src/xr/xr-manager.js
@@ -194,11 +194,11 @@ Object.assign(pc, function () {
      /**
       * @event
       * @name pc.XrManager#error
-      * @param {Error} error - Error object related to failure of session start.
-      * @description Fired when XR session is failed to start
+      * @param {Error} error - Error object related to failure of session start or check of session type support.
+      * @description Fired when XR session is failed to start or failed to check for session type support.
       * @example
       * app.xr.on('error', function (ex) {
-      *     // XR session has failed to start
+      *     // XR session has failed to start, or failed to check for session type support
       * });
       */
 
@@ -260,6 +260,9 @@ Object.assign(pc, function () {
         }).then(function (session) {
             self._onSessionStart(session, spaceType, callback);
         }).catch(function (ex) {
+            // #ifdef DEBUG
+            console.warn('WebXR: xr.requestSession failed to execute', ex);
+            // #endif
             self._camera.camera.xr = null;
             self._camera = null;
             self._type = null;
@@ -329,6 +332,11 @@ Object.assign(pc, function () {
             self._available[type] = available;
             self.fire('available', type, available);
             self.fire('available:' + type, available);
+        }).catch(function (ex) {
+            // #ifdef DEBUG
+            console.warn('WebXR: xr.isSessionSupported failed to execute', ex);
+            // #endif
+            self.fire('error', ex);
         });
     };
 
@@ -400,6 +408,9 @@ Object.assign(pc, function () {
             if (callback) callback(null);
             self.fire('start');
         }).catch(function (ex) {
+            // #ifdef DEBUG
+            console.warn('WebXR: session.requestReferenceSpace failed to execute', ex);
+            // #endif
             failed = true;
             session.end();
             if (callback) callback(ex);


### PR DESCRIPTION
Fixes issues when there is a Security Error due to lack of `xr-spatial-tracking` policy in Chrome 79.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
