### PR TITLE
Hide WebVR-related API now replaced with WebXR API

### DIFF
--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -1587,6 +1587,7 @@ Object.assign(pc, function () {
         },
 
         /**
+         * @private
          * @function
          * @name pc.Application#enableVr
          * @description Create and assign a {@link pc.VrManager} object to allow this application render in VR.
@@ -1598,6 +1599,7 @@ Object.assign(pc, function () {
         },
 
         /**
+         * @private
          * @function
          * @name pc.Application#disableVr
          * @description Destroy the {@link pc.VrManager}.

--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -1588,6 +1588,7 @@ Object.assign(pc, function () {
 
         /**
          * @private
+         * @deprecated
          * @function
          * @name pc.Application#enableVr
          * @description Create and assign a {@link pc.VrManager} object to allow this application render in VR.
@@ -1600,6 +1601,7 @@ Object.assign(pc, function () {
 
         /**
          * @private
+         * @deprecated
          * @function
          * @name pc.Application#disableVr
          * @description Destroy the {@link pc.VrManager}.

--- a/src/framework/components/camera/component.js
+++ b/src/framework/components/camera/component.js
@@ -134,6 +134,7 @@ Object.assign(pc, function () {
     });
 
     /**
+     * @private
      * @name pc.CameraComponent#vrDisplay
      * @type {pc.VrDisplay}
      * @description The {@link pc.VrDisplay} that the camera is current displaying to. This is set automatically by calls to {@link pc.CameraComponent#enterVr}
@@ -452,6 +453,7 @@ Object.assign(pc, function () {
         },
 
         /**
+         * @private
          * @function
          * @name pc.CameraComponent#enterVr
          * @description Attempt to start presenting this camera to a {@link pc.VrDisplay}.
@@ -468,6 +470,7 @@ Object.assign(pc, function () {
          * });
          */
         /**
+         * @private
          * @function
          * @name pc.CameraComponent#enterVr
          * @variation 2
@@ -529,6 +532,7 @@ Object.assign(pc, function () {
         },
 
         /**
+         * @private
          * @function
          * @name pc.CameraComponent#exitVr
          * @description Attempt to stop presenting this camera.

--- a/src/framework/components/camera/component.js
+++ b/src/framework/components/camera/component.js
@@ -135,6 +135,7 @@ Object.assign(pc, function () {
 
     /**
      * @private
+     * @deprecated
      * @name pc.CameraComponent#vrDisplay
      * @type {pc.VrDisplay}
      * @description The {@link pc.VrDisplay} that the camera is current displaying to. This is set automatically by calls to {@link pc.CameraComponent#enterVr}
@@ -454,6 +455,7 @@ Object.assign(pc, function () {
 
         /**
          * @private
+         * @deprecated
          * @function
          * @name pc.CameraComponent#enterVr
          * @description Attempt to start presenting this camera to a {@link pc.VrDisplay}.
@@ -471,6 +473,7 @@ Object.assign(pc, function () {
          */
         /**
          * @private
+         * @deprecated
          * @function
          * @name pc.CameraComponent#enterVr
          * @variation 2
@@ -533,6 +536,7 @@ Object.assign(pc, function () {
 
         /**
          * @private
+         * @deprecated
          * @function
          * @name pc.CameraComponent#exitVr
          * @description Attempt to stop presenting this camera.

--- a/src/vr/vr-display.js
+++ b/src/vr/vr-display.js
@@ -1,6 +1,7 @@
 Object.assign(pc, function () {
     /**
      * @private
+     * @deprecated
      * @class
      * @name pc.VrDisplay
      * @augments pc.EventHandler
@@ -106,6 +107,7 @@ Object.assign(pc, function () {
     Object.assign(VrDisplay.prototype, {
         /**
          * @private
+         * @deprecated
          * @function
          * @name pc.VrDisplay#destroy
          * @description Destroy this display object.
@@ -118,6 +120,7 @@ Object.assign(pc, function () {
 
         /**
          * @private
+         * @deprecated
          * @function
          * @name pc.VrDisplay#poll
          * @description Called once per frame to update the current status from the display. Usually called by {@link pc.VrManager}.
@@ -217,6 +220,7 @@ Object.assign(pc, function () {
 
         /**
          * @private
+         * @deprecated
          * @function
          * @name pc.VrDisplay#requestPresent
          * @description Try to present full screen VR content on this display.
@@ -243,6 +247,7 @@ Object.assign(pc, function () {
 
         /**
          * @private
+         * @deprecated
          * @function
          * @name pc.VrDisplay#exitPresent
          * @description Try to stop presenting VR content on this display.
@@ -268,6 +273,7 @@ Object.assign(pc, function () {
 
         /**
          * @private
+         * @deprecated
          * @function
          * @name pc.VrDisplay#requestAnimationFrame
          * @description Used in the main application loop instead of the regular `window.requestAnimationFrame`. Usually only called from inside {@link pc.Application}.
@@ -279,6 +285,7 @@ Object.assign(pc, function () {
 
         /**
          * @private
+         * @deprecated
          * @function
          * @name pc.VrDisplay#submitFrame
          * @description Called when animation update is complete and the frame is ready to be sent to the display. Usually only called from inside {@link pc.Application}.
@@ -289,6 +296,7 @@ Object.assign(pc, function () {
 
         /**
          * @private
+         * @deprecated
          * @function
          * @name pc.VrDisplay#reset
          * @description Called to reset the pose of the pc.VrDisplay. Treating its current pose as the origin/zero. This should only be called in 'sitting' experiences.
@@ -299,6 +307,7 @@ Object.assign(pc, function () {
 
         /**
          * @private
+         * @deprecated
          * @function
          * @name pc.VrDisplay#setClipPlanes
          * @description Set the near and far depth plans of the display. This enables mapping of values in the
@@ -315,6 +324,7 @@ Object.assign(pc, function () {
 
         /**
          * @private
+         * @deprecated
          * @function
          * @name pc.VrDisplay#getFrameData
          * @description Return the current frame data that is updated during polling.

--- a/src/vr/vr-display.js
+++ b/src/vr/vr-display.js
@@ -1,5 +1,6 @@
 Object.assign(pc, function () {
     /**
+     * @private
      * @class
      * @name pc.VrDisplay
      * @augments pc.EventHandler
@@ -104,6 +105,7 @@ Object.assign(pc, function () {
 
     Object.assign(VrDisplay.prototype, {
         /**
+         * @private
          * @function
          * @name pc.VrDisplay#destroy
          * @description Destroy this display object.
@@ -115,6 +117,7 @@ Object.assign(pc, function () {
         },
 
         /**
+         * @private
          * @function
          * @name pc.VrDisplay#poll
          * @description Called once per frame to update the current status from the display. Usually called by {@link pc.VrManager}.
@@ -213,6 +216,7 @@ Object.assign(pc, function () {
         },
 
         /**
+         * @private
          * @function
          * @name pc.VrDisplay#requestPresent
          * @description Try to present full screen VR content on this display.
@@ -238,6 +242,7 @@ Object.assign(pc, function () {
         },
 
         /**
+         * @private
          * @function
          * @name pc.VrDisplay#exitPresent
          * @description Try to stop presenting VR content on this display.
@@ -262,6 +267,7 @@ Object.assign(pc, function () {
         },
 
         /**
+         * @private
          * @function
          * @name pc.VrDisplay#requestAnimationFrame
          * @description Used in the main application loop instead of the regular `window.requestAnimationFrame`. Usually only called from inside {@link pc.Application}.
@@ -272,6 +278,7 @@ Object.assign(pc, function () {
         },
 
         /**
+         * @private
          * @function
          * @name pc.VrDisplay#submitFrame
          * @description Called when animation update is complete and the frame is ready to be sent to the display. Usually only called from inside {@link pc.Application}.
@@ -281,6 +288,7 @@ Object.assign(pc, function () {
         },
 
         /**
+         * @private
          * @function
          * @name pc.VrDisplay#reset
          * @description Called to reset the pose of the pc.VrDisplay. Treating its current pose as the origin/zero. This should only be called in 'sitting' experiences.
@@ -290,6 +298,7 @@ Object.assign(pc, function () {
         },
 
         /**
+         * @private
          * @function
          * @name pc.VrDisplay#setClipPlanes
          * @description Set the near and far depth plans of the display. This enables mapping of values in the
@@ -305,6 +314,7 @@ Object.assign(pc, function () {
         },
 
         /**
+         * @private
          * @function
          * @name pc.VrDisplay#getFrameData
          * @description Return the current frame data that is updated during polling.

--- a/src/vr/vr-manager.js
+++ b/src/vr/vr-manager.js
@@ -1,6 +1,7 @@
 Object.assign(pc, function () {
     /**
      * @private
+     * @deprecated
      * @class
      * @name pc.VrManager
      * @augments pc.EventHandler
@@ -48,6 +49,7 @@ Object.assign(pc, function () {
 
     /**
      * @private
+     * @deprecated
      * @event
      * @name pc.VrManager#displayconnect
      * @description Fired when an VR display is connected.
@@ -60,6 +62,7 @@ Object.assign(pc, function () {
 
     /**
      * @private
+     * @deprecated
      * @event
      * @name pc.VrManager#displaydisconnect
      * @description Fired when an VR display is disconnected.
@@ -72,6 +75,7 @@ Object.assign(pc, function () {
 
     /**
      * @private
+     * @deprecated
      * @static
      * @name pc.VrManager.isSupported
      * @type {boolean}
@@ -96,6 +100,7 @@ Object.assign(pc, function () {
 
         /**
          * @private
+         * @deprecated
          * @function
          * @name pc.VrManager#destroy
          * @description Remove events and clear up manager.
@@ -106,6 +111,7 @@ Object.assign(pc, function () {
 
         /**
          * @private
+         * @deprecated
          * @function
          * @name pc.VrManager#poll
          * @description Called once per frame to poll all attached displays.

--- a/src/vr/vr-manager.js
+++ b/src/vr/vr-manager.js
@@ -1,5 +1,6 @@
 Object.assign(pc, function () {
     /**
+     * @private
      * @class
      * @name pc.VrManager
      * @augments pc.EventHandler
@@ -46,6 +47,7 @@ Object.assign(pc, function () {
     VrManager.prototype.constructor = VrManager;
 
     /**
+     * @private
      * @event
      * @name pc.VrManager#displayconnect
      * @description Fired when an VR display is connected.
@@ -57,6 +59,7 @@ Object.assign(pc, function () {
      */
 
     /**
+     * @private
      * @event
      * @name pc.VrManager#displaydisconnect
      * @description Fired when an VR display is disconnected.
@@ -68,6 +71,7 @@ Object.assign(pc, function () {
      */
 
     /**
+     * @private
      * @static
      * @name pc.VrManager.isSupported
      * @type {boolean}
@@ -91,6 +95,7 @@ Object.assign(pc, function () {
         },
 
         /**
+         * @private
          * @function
          * @name pc.VrManager#destroy
          * @description Remove events and clear up manager.
@@ -100,6 +105,7 @@ Object.assign(pc, function () {
         },
 
         /**
+         * @private
          * @function
          * @name pc.VrManager#poll
          * @description Called once per frame to poll all attached displays.


### PR DESCRIPTION
The newly arrived WebXR related API means we can now hide the WebVR related API.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
