### PR TITLE
unswizzle 2-component normal maps under PVR

### DIFF
--- a/src/resources/texture.js
+++ b/src/resources/texture.js
@@ -278,7 +278,7 @@ Object.assign(pc, function () {
     };
 
     Object.assign(TextureHandler.prototype, {
-        load: function (url, callback) {
+        load: function (url, callback, asset) {
             if (typeof url === 'string') {
                 url = {
                     load: url,
@@ -312,7 +312,19 @@ Object.assign(pc, function () {
                         if (err) {
                             callback(err, result);
                         } else {
-                            pc.basisTranscode(url.load, result, callback);
+                            // massive hack for pvr textures (i.e. apple devices)
+                            // the quality of GGGR normal maps under PVR compression is still terrible
+                            // so here we instruct the basis transcoder to unswizzle the normal map data
+                            // and pack to 565
+                            var unswizzleGGGR = pc.basisTargetFormat() === 'pvr' &&
+                                                asset && asset.file && asset.file.variants &&
+                                                asset.file.variants.basis &&
+                                                ((asset.file.variants.basis.opt & 8) !== 0);
+                            if (unswizzleGGGR) {
+                                // remove the swizzled flag from the asset
+                                asset.file.variants.basis.opt &= ~8;
+                            }
+                            pc.basisTranscode(url.load, result, callback, { unswizzleGGGR: unswizzleGGGR });
                         }
                     });
             } else if ((ext === '.jpg') || (ext === '.jpeg') || (ext === '.gif') || (ext === '.png')) {


### PR DESCRIPTION
- added option to unswizzle normal maps in the basis transcoder
- unswizzle 2-component normal maps under PVR, because quality
- slight cleanup of basis code

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
