### PR TITLE
[JSDOC] Document API properties related to skinned mesh animations

### DIFF
--- a/src/scene/mesh.js
+++ b/src/scene/mesh.js
@@ -31,6 +31,7 @@ Object.assign(pc, function () {
      * @property {boolean} [primitive[].indexed] True to interpret the primitive as indexed, thereby using the currently set index buffer and false otherwise.
      * {@link pc.GraphicsDevice#draw}. The primitive is ordered based on render style like the indexBuffer property.
      * @property {pc.BoundingBox} aabb The axis-aligned bounding box for the object space vertices of this mesh.
+     * @property {pc.Skin} [skin] The skin data (if any) that drives skinned mesh animations for this mesh.
      */
     var Mesh = function () {
         this._refCount = 0;

--- a/src/scene/model.js
+++ b/src/scene/model.js
@@ -9,7 +9,8 @@ Object.assign(pc, function () {
      * // Create a new model
      * var model = new pc.Model();
      * @property {pc.GraphNode} graph The root node of the model's graph node hierarchy.
-     * @property {pc.MeshInstance[]} meshInstances An array of meshInstances contained in this model.
+     * @property {pc.MeshInstance[]} meshInstances An array of MeshInstances contained in this model.
+     * @property {pc.SkinInstance[]} skinInstances An array of SkinInstances contained in this model.
      */
     var Model = function Model() {
         this.graph = null;

--- a/src/scene/skin.js
+++ b/src/scene/skin.js
@@ -26,6 +26,7 @@ Object.assign(pc, function () {
      * skin vertices from object space to world space.
      * @param {pc.Skin} skin - The skin that will provide the inverse bind pose matrices to
      * generate the final matrix palette.
+     * @property {pc.GraphNode[]} bones An array of nodes representing each bone in this skin instance.
      */
     var SkinInstance = function (skin) {
         this.skin = skin;


### PR DESCRIPTION
The PR adds the following API documentation (and consequently fixes missing typings):
- Document property `pc.Mesh#skin`.
- Document property `pc.Model#skinInstances`.
- Document property `pc.SkinInstance#bones`.

(Additionally PR also trims some whitespaces at a few line endings.)


I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).