### PR TITLE
[JSDOC] Document some scene APIs related to skybox

### DIFF
--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -1109,6 +1109,12 @@ Object.assign(pc, function () {
         this.updateSkybox = true;
     };
 
+    /**
+     * @function
+     * @name pc.Scene#setSkybox
+     * @description Sets the cubemap for the scene skybox.
+     * @param {pc.Texture[]} [cubemaps] - An array of 7 cubemap textures (index 0 is original and index 1-6 are prefiltered). If undefined scene will remove skybox.
+     */
     Scene.prototype.setSkybox = function (cubemaps) {
         var i;
         if (!cubemaps)

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -750,8 +750,13 @@ Object.assign(pc, function () {
      * Defaults to pc.TONEMAP_LINEAR.
      * @property {number} exposure The exposure value tweaks the overall brightness of
      * the scene. Defaults to 1.
-     * @property {pc.Texture} skybox A cube map texture used as the scene's skybox. Defaults
-     * to null.
+     * @property {pc.Texture} skybox The base cubemap texture used as the scene's skybox, if mip level is 0. Defaults to null.
+     * @property {pc.Texture} skyboxPrefiltered128 The prefiltered cubemap texture (size 128x128) used as the scene's skybox, if mip level 1. Defaults to null.
+     * @property {pc.Texture} skyboxPrefiltered64 The prefiltered cubemap texture (size 64x64) used as the scene's skybox, if mip level 2. Defaults to null.
+     * @property {pc.Texture} skyboxPrefiltered32 The prefiltered cubemap texture (size 32x32) used as the scene's skybox, if mip level 3. Defaults to null.
+     * @property {pc.Texture} skyboxPrefiltered16 The prefiltered cubemap texture (size 16x16) used as the scene's skybox, if mip level 4. Defaults to null.
+     * @property {pc.Texture} skyboxPrefiltered8 The prefiltered cubemap texture (size 8x8) used as the scene's skybox, if mip level 5. Defaults to null.
+     * @property {pc.Texture} skyboxPrefiltered4 The prefiltered cubemap texture (size 4x4) used as the scene's skybox, if mip level 6. Defaults to null.
      * @property {number} skyboxIntensity Multiplier for skybox intensity. Defaults to 1.
      * @property {number} skyboxMip The mip level of the skybox to be displayed. Only valid
      * for prefiltered cubemap skyboxes. Defaults to 0 (base level).

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -1113,7 +1113,9 @@ Object.assign(pc, function () {
      * @function
      * @name pc.Scene#setSkybox
      * @description Sets the cubemap for the scene skybox.
-     * @param {pc.Texture[]} [cubemaps] - An array of 7 cubemap textures (index 0 is original and index 1-6 are prefiltered). If undefined scene will remove skybox.
+     * @param {pc.Texture[]} [cubemaps] - An array of cubemaps corresponding to the skybox at different mip levels. If undefined, scene will remove skybox.
+     * Cubemap array should be of size 7, with the first element (index 0) corresponding to the base cubemap (mip level 0) with original resolution.
+     * Each remaining element (index 1-6) corresponds to a fixed prefiltered resolution (128x128, 64x64, 32x32, 16x16, 8x8, 4x4).
      */
     Scene.prototype.setSkybox = function (cubemaps) {
         var i;


### PR DESCRIPTION
The PR adds the following API documentation (and consequently fixes missing typings):
- Document property `pc.Scene#skyboxPrefiltered128`.
- Document property `pc.Scene#skyboxPrefiltered64`.
- Document property `pc.Scene#skyboxPrefiltered32`.
- Document property `pc.Scene#skyboxPrefiltered16`.
- Document property `pc.Scene#skyboxPrefiltered8`.
- Document property `pc.Scene#skyboxPrefiltered4`.
- Document method `pc.Scene#setSkybox`.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
