### PR TITLE
[JSDOC] Document APIs related to morph animations

### DIFF
--- a/src/scene/mesh.js
+++ b/src/scene/mesh.js
@@ -31,6 +31,7 @@ Object.assign(pc, function () {
      * @property {boolean} [primitive[].indexed] True to interpret the primitive as indexed, thereby using the currently set index buffer and false otherwise.
      * {@link pc.GraphicsDevice#draw}. The primitive is ordered based on render style like the indexBuffer property.
      * @property {pc.BoundingBox} aabb The axis-aligned bounding box for the object space vertices of this mesh.
+     * @property {pc.Morph} [morph] The list of pc.MorphTarget (if any) for this mesh.
      */
     var Mesh = function () {
         this._refCount = 0;

--- a/src/scene/mesh.js
+++ b/src/scene/mesh.js
@@ -32,7 +32,7 @@ Object.assign(pc, function () {
      * {@link pc.GraphicsDevice#draw}. The primitive is ordered based on render style like the indexBuffer property.
      * @property {pc.BoundingBox} aabb The axis-aligned bounding box for the object space vertices of this mesh.
      * @property {pc.Skin} [skin] The skin data (if any) that drives skinned mesh animations for this mesh.
-     * @property {pc.Morph} [morph] The list of pc.MorphTarget (if any) for this mesh.
+     * @property {pc.Morph} [morph] The morph data (if any) that drives morph target animations for this mesh.
      */
     var Mesh = function () {
         this._refCount = 0;

--- a/src/scene/model.js
+++ b/src/scene/model.js
@@ -10,6 +10,7 @@ Object.assign(pc, function () {
      * var model = new pc.Model();
      * @property {pc.GraphNode} graph The root node of the model's graph node hierarchy.
      * @property {pc.MeshInstance[]} meshInstances An array of meshInstances contained in this model.
+     * @property {pc.MorphInstance[]} morphInstances An array of MorphInstances contained in this model.
      */
     var Model = function Model() {
         this.graph = null;

--- a/src/scene/morph.js
+++ b/src/scene/morph.js
@@ -39,7 +39,7 @@ Object.assign(pc, function () {
      * @class
      * @name pc.Morph
      * @classdesc Contains a list of pc.MorphTarget, a combined AABB and some associated data.
-     * @param {pc.MoprhTarget[]} targets - A list of morph targets.
+     * @param {pc.MorphTarget[]} targets - A list of morph targets.
      */
     var Morph = function (targets) {
         this.aabb = new pc.BoundingBox();
@@ -138,7 +138,7 @@ Object.assign(pc, function () {
          * @function
          * @name pc.Morph#addTarget
          * @description Adds a new morph target to the list.
-         * @param {pc.MoprhTarget} target - A new morph target.
+         * @param {pc.MorphTarget} target - A new morph target.
          */
         addTarget: function (target) {
             this._targets.push(target);
@@ -149,7 +149,7 @@ Object.assign(pc, function () {
          * @function
          * @name pc.Morph#removeTarget
          * @description Remove the specified morph target from the list.
-         * @param {pc.MoprhTarget} target - A morph target to delete.
+         * @param {pc.MorphTarget} target - A morph target to delete.
          */
         removeTarget: function (target) {
             var index = this._targets.indexOf(target);

--- a/src/scene/morph.js
+++ b/src/scene/morph.js
@@ -3,7 +3,6 @@ Object.assign(pc, function () {
     var _morphMax = new pc.Vec3();
 
     /**
-     * @private
      * @class
      * @name pc.MorphTarget
      * @classdesc A Morph Target (also known as Blend Shape) contains deformation data to apply to existing mesh.
@@ -37,7 +36,6 @@ Object.assign(pc, function () {
     };
 
     /**
-     * @private
      * @class
      * @name pc.Morph
      * @classdesc Contains a list of pc.MorphTarget, a combined AABB and some associated data.
@@ -137,7 +135,6 @@ Object.assign(pc, function () {
         },
 
         /**
-         * @private
          * @function
          * @name pc.Morph#addTarget
          * @description Adds a new morph target to the list.
@@ -149,7 +146,6 @@ Object.assign(pc, function () {
         },
 
         /**
-         * @private
          * @function
          * @name pc.Morph#removeTarget
          * @description Remove the specified morph target from the list.
@@ -164,7 +160,6 @@ Object.assign(pc, function () {
         },
 
         /**
-         * @private
          * @function
          * @name pc.Morph#getTarget
          * @description Gets the morph target by index.
@@ -177,7 +172,6 @@ Object.assign(pc, function () {
     });
 
     /**
-     * @private
      * @class
      * @name pc.MorphInstance
      * @classdesc An instance of pc.Morph. Contains weights to assign to every pc.MorphTarget, holds morphed buffer and associated data.
@@ -209,7 +203,6 @@ Object.assign(pc, function () {
         },
 
         /**
-         * @private
          * @function
          * @name pc.MorphInstance#destroy
          * @description Frees video memory allocated by this object.
@@ -222,7 +215,6 @@ Object.assign(pc, function () {
         },
 
         /**
-         * @private
          * @function
          * @name pc.MorphInstance#getWeight
          * @description Gets current weight of the specified morph target.
@@ -234,7 +226,6 @@ Object.assign(pc, function () {
         },
 
         /**
-         * @private
          * @function
          * @name pc.MorphInstance#setWeight
          * @description Sets weight of the specified morph target.
@@ -247,7 +238,6 @@ Object.assign(pc, function () {
         },
 
         /**
-         * @private
          * @function
          * @name pc.MorphInstance#updateBounds
          * @param {pc.Mesh} mesh - Base mesh for the morph.
@@ -267,7 +257,6 @@ Object.assign(pc, function () {
         },
 
         /**
-         * @private
          * @function
          * @name pc.MorphInstance#update
          * @param {pc.Mesh} mesh - Base mesh for the morph.


### PR DESCRIPTION
The PR includes the following pure JSDOC changes:

- Fix misspelling `pc.MoprhTarget` to `pc.MorphTarget`.
- Document property `pc.Mesh#morph`.
- Document property `pc.Model#morphInstances`.
- Remove jsdoc tag `@private` for `pc.Morph`, `pc.MorphTarget`, and `pc.MorphInstance`, because these should be public to allow run-time loading or generation. And similar types in both PC (like `pc.Skin`, `pc.SkinInstance`, and `pc.Skeleton` etc) and other engines are already public.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).