### PR TITLE
Integration with SpectorJS markers

### DIFF
--- a/src/graphics/device.js
+++ b/src/graphics/device.js
@@ -623,7 +623,6 @@ Object.assign(pc, function () {
                 this._spectorMarkers.push(name);
                 this.updateMarker();
                 window.spector.setMarker(this._spectorCurrentMarker);
-                // console.log("PUSH " + name + "     GOT: " + this._spectorCurrentMarker + "\n Callstack: " + new Error().stack);
             }
         },
 
@@ -637,8 +636,6 @@ Object.assign(pc, function () {
                         window.spector.setMarker(this._spectorCurrentMarker);
                     else
                         window.spector.clearMarker();
-
-                    // console.log("POP " + name + "     GOT: " + this._spectorCurrentMarker + "\n Callstack: " + new Error().stack);
                 }
             }
         },

--- a/src/graphics/device.js
+++ b/src/graphics/device.js
@@ -602,7 +602,7 @@ Object.assign(pc, function () {
         // #ifdef DEBUG
         this._spectorMarkers = [];
         this._spectorCurrentMarker = "";
-        // endif
+        // #endif
 
         this.createGrabPass(options.alpha);
 
@@ -642,7 +642,7 @@ Object.assign(pc, function () {
                 }
             }
         },
-        // endif
+        // #endif
 
         getPrecision: function () {
             var gl = this.gl;

--- a/src/graphics/device.js
+++ b/src/graphics/device.js
@@ -603,7 +603,7 @@ Object.assign(pc, function () {
         this._spectorMarkers = [];
         this._spectorCurrentMarker = "";
         // endif
-        
+
         this.createGrabPass(options.alpha);
 
         pc.VertexFormat.init(this);
@@ -623,7 +623,7 @@ Object.assign(pc, function () {
                 this._spectorMarkers.push(name);
                 this.updateMarker();
                 window.spector.setMarker(this._spectorCurrentMarker);
-                //console.log("PUSH " + name + "     GOT: " + this._spectorCurrentMarker + "\n Callstack: " + new Error().stack);
+                // console.log("PUSH " + name + "     GOT: " + this._spectorCurrentMarker + "\n Callstack: " + new Error().stack);
             }
         },
 
@@ -637,13 +637,13 @@ Object.assign(pc, function () {
                         window.spector.setMarker(this._spectorCurrentMarker);
                     else
                         window.spector.clearMarker();
-    
-                    //console.log("POP " + name + "     GOT: " + this._spectorCurrentMarker + "\n Callstack: " + new Error().stack);
+
+                    // console.log("POP " + name + "     GOT: " + this._spectorCurrentMarker + "\n Callstack: " + new Error().stack);
                 }
             }
         },
         // endif
-        
+
         getPrecision: function () {
             var gl = this.gl;
             var precision = "highp";

--- a/src/graphics/device.js
+++ b/src/graphics/device.js
@@ -599,6 +599,11 @@ Object.assign(pc, function () {
 
         this._textureFloatHighPrecision = undefined;
 
+        // #ifdef DEBUG
+        this._spectorMarkers = [];
+        this._spectorCurrentMarker = "";
+        // endif
+        
         this.createGrabPass(options.alpha);
 
         pc.VertexFormat.init(this);
@@ -607,6 +612,38 @@ Object.assign(pc, function () {
     GraphicsDevice.prototype.constructor = GraphicsDevice;
 
     Object.assign(GraphicsDevice.prototype, {
+
+        // #ifdef DEBUG
+        updateMarker: function () {
+            this._spectorCurrentMarker = this._spectorMarkers.join(" | ") + " # ";
+        },
+
+        pushMarker: function (name) {
+            if (window.spector) {
+                this._spectorMarkers.push(name);
+                this.updateMarker();
+                window.spector.setMarker(this._spectorCurrentMarker);
+                //console.log("PUSH " + name + "     GOT: " + this._spectorCurrentMarker + "\n Callstack: " + new Error().stack);
+            }
+        },
+
+        popMarker: function () {
+            if (window.spector) {
+                if (this._spectorMarkers.length) {
+                    this._spectorMarkers.pop();
+                    this.updateMarker();
+
+                    if (this._spectorMarkers.length)
+                        window.spector.setMarker(this._spectorCurrentMarker);
+                    else
+                        window.spector.clearMarker();
+    
+                    //console.log("POP " + name + "     GOT: " + this._spectorCurrentMarker + "\n Callstack: " + new Error().stack);
+                }
+            }
+        },
+        // endif
+        
         getPrecision: function () {
             var gl = this.gl;
             var precision = "highp";

--- a/src/scene/forward-renderer.js
+++ b/src/scene/forward-renderer.js
@@ -1373,8 +1373,11 @@ Object.assign(pc, function () {
                     while (pass < passes) {
 
                         // #ifdef DEBUG
-                        if (passes > 1)
+                        var doPopMarker = false;
+                        if (passes > 1) {
                             this.device.pushMarker("PASS " + pass);
+                            doPopMarker = true;
+                        }
                         // #endif
 
                         if (type === pc.LIGHTTYPE_POINT) {
@@ -1454,7 +1457,8 @@ Object.assign(pc, function () {
                         if (type === pc.LIGHTTYPE_DIRECTIONAL) light._visibleLength[cameraPass] = -1; // prevent light from rendering more than once for this camera
 
                         // #ifdef DEBUG
-                        this.device.popMarker();
+                        if (doPopMarker)
+                            this.device.popMarker();
                         // #endif
 
                     } // end pass

--- a/src/scene/forward-renderer.js
+++ b/src/scene/forward-renderer.js
@@ -457,7 +457,7 @@ Object.assign(pc, function () {
     }
 
     Object.assign(ForwardRenderer.prototype, {
-        
+
         sortCompare: function (drawCallA, drawCallB) {
             if (drawCallA.layer === drawCallB.layer) {
                 if (drawCallA.drawOrder && drawCallB.drawOrder) {
@@ -1324,7 +1324,7 @@ Object.assign(pc, function () {
                     // #ifdef DEBUG
                     this.device.pushMarker("SHADOW " + light._node.name);
                     // #endif
-                    
+
                     if (type !== pc.LIGHTTYPE_POINT) {
                         shadowCamView.setTRS(shadowCamNode.getPosition(), shadowCamNode.getRotation(), pc.Vec3.ONE).invert();
                         shadowCamViewProj.mul2(shadowCam.getProjectionMatrix(), shadowCamView);
@@ -1464,7 +1464,7 @@ Object.assign(pc, function () {
                         // #ifdef DEBUG
                         this.device.pushMarker("VSM");
                         // #endif
-                    
+
                         var filterSize = light._vsmBlurSize;
                         if (filterSize > 1) {
                             var origShadowMap = shadowCam.renderTarget;
@@ -2656,7 +2656,7 @@ Object.assign(pc, function () {
                 if (!layer.enabled || !comp.subLayerEnabled[i]) continue;
                 transparent = comp.subLayerList[i];
                 objects = layer.instances;
-                
+
                 cameras = layer.cameras;
                 for (j = 0; j < cameras.length; j++) {
                     camera = cameras[j];

--- a/src/scene/forward-renderer.js
+++ b/src/scene/forward-renderer.js
@@ -457,7 +457,7 @@ Object.assign(pc, function () {
     }
 
     Object.assign(ForwardRenderer.prototype, {
-
+        
         sortCompare: function (drawCallA, drawCallB) {
             if (drawCallA.layer === drawCallB.layer) {
                 if (drawCallA.drawOrder && drawCallB.drawOrder) {
@@ -1321,6 +1321,10 @@ Object.assign(pc, function () {
 
                     }
 
+                    // #ifdef DEBUG
+                    this.device.pushMarker("SHADOW " + light._node.name);
+                    // #endif
+                    
                     if (type !== pc.LIGHTTYPE_POINT) {
                         shadowCamView.setTRS(shadowCamNode.getPosition(), shadowCamNode.getRotation(), pc.Vec3.ONE).invert();
                         shadowCamViewProj.mul2(shadowCam.getProjectionMatrix(), shadowCamView);
@@ -1367,6 +1371,12 @@ Object.assign(pc, function () {
                     }
 
                     while (pass < passes) {
+
+                        // #ifdef DEBUG
+                        if (passes > 1)
+                            this.device.pushMarker("PASS " + pass);
+                        // #endif
+
                         if (type === pc.LIGHTTYPE_POINT) {
                             shadowCamNode.setRotation(pointLightRotations[pass]);
                             shadowCam.renderTarget = light._shadowCubeMap[pass];
@@ -1442,9 +1452,19 @@ Object.assign(pc, function () {
                         }
                         pass++;
                         if (type === pc.LIGHTTYPE_DIRECTIONAL) light._visibleLength[cameraPass] = -1; // prevent light from rendering more than once for this camera
+
+                        // #ifdef DEBUG
+                        this.device.popMarker();
+                        // #endif
+
                     } // end pass
 
                     if (light._isVsm) {
+
+                        // #ifdef DEBUG
+                        this.device.pushMarker("VSM");
+                        // #endif
+                    
                         var filterSize = light._vsmBlurSize;
                         if (filterSize > 1) {
                             var origShadowMap = shadowCam.renderTarget;
@@ -1491,7 +1511,15 @@ Object.assign(pc, function () {
                             this.pixelOffsetId.setValue(pixelOffset);
                             pc.drawQuadWithShader(device, origShadowMap, blurShader, null, blurScissorRect);
                         }
+
+                        // #ifdef DEBUG
+                        this.device.popMarker();
+                        // #endif
                     }
+
+                    // #ifdef DEBUG
+                    this.device.popMarker();
+                    // #endif
                 }
             }
 
@@ -2628,7 +2656,7 @@ Object.assign(pc, function () {
                 if (!layer.enabled || !comp.subLayerEnabled[i]) continue;
                 transparent = comp.subLayerList[i];
                 objects = layer.instances;
-
+                
                 cameras = layer.cameras;
                 for (j = 0; j < cameras.length; j++) {
                     camera = cameras[j];
@@ -2747,6 +2775,11 @@ Object.assign(pc, function () {
                 cameraPass = comp._renderListCamera[i];
                 camera = layer.cameras[cameraPass];
 
+                // #ifdef DEBUG
+                this.device.pushMarker(layer.name);
+                this.device.pushMarker((camera.node ? camera.node.name : "noname"));
+                // #endif
+
                 // #ifdef PROFILER
                 drawTime = pc.now();
                 // #endif
@@ -2854,6 +2887,11 @@ Object.assign(pc, function () {
                         layer._postRenderCounter = layer._postRenderCounterMax;
                     }
                 }
+
+                // #ifdef DEBUG
+                this.device.popMarker();
+                this.device.popMarker();
+                // #endif
 
                // #ifdef PROFILER
                 layer._renderTime += pc.now() - drawTime;

--- a/src/scene/particle-system/gpu-updater.js
+++ b/src/scene/particle-system/gpu-updater.js
@@ -87,6 +87,11 @@ Object.assign(pc, function () {
 
     // This shouldn't change emitter state, only read from it
     ParticleGPUUpdater.prototype.update = function (device, spawnMatrix, extentsInnerRatioUniform, delta, isOnStop) {
+        
+        // #ifdef DEBUG
+        device.pushMarker("ParticleGPU");
+        // #endif
+        
         var emitter = this._emitter;
 
         device.setBlending(false);
@@ -190,6 +195,10 @@ Object.assign(pc, function () {
         emitter.prevWorldBoundsCenter.copy(emitter.worldBounds.center);
         if (emitter.pack8)
             this._setInputBounds();
+
+        // #ifdef DEBUG
+        device.popMarker("");
+        // #endif
     };
 
     return {

--- a/src/scene/particle-system/gpu-updater.js
+++ b/src/scene/particle-system/gpu-updater.js
@@ -87,11 +87,11 @@ Object.assign(pc, function () {
 
     // This shouldn't change emitter state, only read from it
     ParticleGPUUpdater.prototype.update = function (device, spawnMatrix, extentsInnerRatioUniform, delta, isOnStop) {
-        
+
         // #ifdef DEBUG
         device.pushMarker("ParticleGPU");
         // #endif
-        
+
         var emitter = this._emitter;
 
         device.setBlending(false);


### PR DESCRIPTION
Partially addresses: #1877

This allows us to attach name to each commands captured by SpectorJS. Currently these names are attached:
- Layer | Camera name - when rendering a Layer with a Camera
- SHADOW Lightname - when shadow map is generated for a light, additional face index is added for point lights rendering to cube maps
- ParticleGPU - when commands are generated by GPU Particle System

This is enabled when launched in DEBUG mode.

<img width="751" alt="Screen Shot 2020-03-11 at 3 18 59 PM" src="https://user-images.githubusercontent.com/59932779/76433739-a7dc9f80-63ac-11ea-85a5-4d3658ddea81.png">

The screenshot is showing one drawElements command submitted while rendering "World" Layer with"Camera" camera, and one drawElements command submitted while rendering "UI" Layer with "Camera.