### PR TITLE
Rephrase model component documentation for full display in API manual

### DIFF
--- a/src/framework/components/model/component.js
+++ b/src/framework/components/model/component.js
@@ -13,11 +13,11 @@ Object.assign(pc, function () {
      *
      * * "asset": The component will render a model asset
      * * "box": The component will render a box (1 unit in each dimension)
-     * * "capsule": The component will render a capsule (radius 0.5, height 2)
-     * * "cone": The component will render a cone (radius 0.5, height 1)
-     * * "cylinder": The component will render a cylinder (radius 0.5, height 1)
+     * * "capsule": The component will render a capsule (radius 1/2, height 2)
+     * * "cone": The component will render a cone (radius 1/2, height 1)
+     * * "cylinder": The component will render a cylinder (radius 1/2, height 1)
      * * "plane": The component will render a plane (1 unit in each dimension)
-     * * "sphere": The component will render a sphere (radius 0.5)
+     * * "sphere": The component will render a sphere (radius 1/2)
      *
      * @property {pc.Asset|number} asset The asset for the model (only applies to models of type 'asset') - can also be an asset id.
      * @property {boolean} castShadows If true, this model will cast shadows for lights that have shadow casting enabled.

--- a/src/framework/components/model/component.js
+++ b/src/framework/components/model/component.js
@@ -9,16 +9,14 @@ Object.assign(pc, function () {
      * @description Create a new ModelComponent.
      * @param {pc.ModelComponentSystem} system - The ComponentSystem that created this Component.
      * @param {pc.Entity} entity - The Entity that this Component is attached to.
-     * @property {string} type The type of the model, which can be one of the following values:
-     *
+     * @property {string} type The type of the model. Can be one of the following:
      * * "asset": The component will render a model asset
      * * "box": The component will render a box (1 unit in each dimension)
-     * * "capsule": The component will render a capsule (radius 1/2, height 2)
-     * * "cone": The component will render a cone (radius 1/2, height 1)
-     * * "cylinder": The component will render a cylinder (radius 1/2, height 1)
+     * * "capsule": The component will render a capsule (radius 0.5, height 2)
+     * * "cone": The component will render a cone (radius 0.5, height 1)
+     * * "cylinder": The component will render a cylinder (radius 0.5, height 1)
      * * "plane": The component will render a plane (1 unit in each dimension)
-     * * "sphere": The component will render a sphere (radius 1/2)
-     *
+     * * "sphere": The component will render a sphere (radius 0.5)
      * @property {pc.Asset|number} asset The asset for the model (only applies to models of type 'asset') - can also be an asset id.
      * @property {boolean} castShadows If true, this model will cast shadows for lights that have shadow casting enabled.
      * @property {boolean} receiveShadows If true, shadows will be cast on this model.


### PR DESCRIPTION
Currently, the [documentation](https://developer.playcanvas.com/en/api/pc.ModelComponent.html) for the `type` property of a model component is not displayed in full in the summary:
![2020-03-12 10_09_26-pc ModelComponent _ PlayCanvas API Reference](https://user-images.githubusercontent.com/3101405/76505702-32bfa780-644a-11ea-9eab-f883f6fe6f1a.png)
(screenshot from 2020-03-12 ([ISO8601](https://en.wikipedia.org/wiki/ISO_8601) date))

The source code from which the text seen in the image is generated, as far as I understand, resides in [src/framework/components/model/component.js](https://github.com/playcanvas/engine/blob/master/src/framework/components/model/component.js#L12):
```
     * @property {string} type The type of the model, which can be one of the following values:
     *
     * * "asset": The component will render a model asset
     * * "box": The component will render a box (1 unit in each dimension)
     * * "capsule": The component will render a capsule (radius 0.5, height 2)
     * * "cone": The component will render a cone (radius 0.5, height 1)
     * * "cylinder": The component will render a cylinder (radius 0.5, height 1)
     * * "plane": The component will render a plane (1 unit in each dimension)
     * * "sphere": The component will render a sphere (radius 0.5)
     *
```
Note how the summary text in the image stops just after the first period character in the source code. I believe the problem can be avoided by not using that character, and this PR does that.

Perhaps a more global solution to this problem would be that the logic that determines where to stop the summary text is changed to not stop at a single period but rather a period followed by a whitespace character or the end of the string.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
