### PR TITLE
Optimize Grab-Pass for WebGL 2 and fix when using anti-aliased RenderTarget

### DIFF
--- a/src/graphics/device.js
+++ b/src/graphics/device.js
@@ -963,11 +963,23 @@ Object.assign(pc, function () {
         updateGrabPass: function () {
             var gl = this.gl;
 
+            var target = this.renderTarget;
+            var resolve = target && target._glResolveFrameBuffer;
+
+            if (resolve) {
+                target.resolve(true);
+                gl.bindFramebuffer(gl.FRAMEBUFFER, target._glResolveFrameBuffer);
+            }
+
             var format = this.grabPassTexture._glFormat;
-            var source = (this.renderTarget && this.renderTarget.colorBuffer) || this.canvas;
+            var source = (this.target && this.target.colorBuffer) || this.canvas;
             gl.copyTexImage2D(gl.TEXTURE_2D, 0, format, 0, 0, source.width, source.height, 0);
             this.grabPassTexture._width = source.width;
             this.grabPassTexture._height = source.height;
+
+            if (resolve) {
+                gl.bindFramebuffer(gl.FRAMEBUFFER, target._glFrameBuffer);
+            }
         },
 
         destroyGrabPass: function () {

--- a/src/graphics/device.js
+++ b/src/graphics/device.js
@@ -956,6 +956,13 @@ Object.assign(pc, function () {
             var grabPassTextureId = this.scope.resolve(grabPassTexture.name);
             grabPassTextureId.setValue(grabPassTexture);
 
+            var grabPassRenderTarget = new pc.RenderTarget({
+                colorBuffer: grabPassTexture,
+                depth: false
+            });
+            this.createFrameBuffer(grabPassRenderTarget);
+
+            this.grabPassRenderTarget = grabPassRenderTarget;
             this.grabPassTextureId = grabPassTextureId;
             this.grabPassTexture = grabPassTexture;
         },
@@ -983,9 +990,12 @@ Object.assign(pc, function () {
         },
 
         destroyGrabPass: function () {
+            this.grabPassRenderTarget.destroy();
+            this.grabPassRenderTarget = null;
+
+            this.grabPassTextureId = null;
             this.grabPassTexture.destroy();
             this.grabPassTexture = null;
-            this.grabPassTextureId = null;
         },
 
         updateClientRect: function () {

--- a/src/graphics/device.js
+++ b/src/graphics/device.js
@@ -960,7 +960,7 @@ Object.assign(pc, function () {
                 colorBuffer: grabPassTexture,
                 depth: false
             });
-            this.createFrameBuffer(grabPassRenderTarget);
+            this.initRenderTarget(grabPassRenderTarget);
 
             this.grabPassRenderTarget = grabPassRenderTarget;
             this.grabPassTextureId = grabPassTextureId;
@@ -1190,11 +1190,11 @@ Object.assign(pc, function () {
         /**
          * @private
          * @function
-         * @name pc.GraphicsDevice#createFrameBuffer
-         * @description Create frame buffer for render target
-         * @param {pc.RenderTarget} target - The render target to create the frame buffer for.
+         * @name pc.GraphicsDevice#initRenderTarget
+         * @description Initialize render target before it can be used.
+         * @param {pc.RenderTarget} target - The render target to be initialized.
          */
-        createFrameBuffer: function (target) {
+        initRenderTarget: function (target) {
             if (target._glFrameBuffer) return;
 
             // #ifdef PROFILER
@@ -1347,7 +1347,7 @@ Object.assign(pc, function () {
             if (target) {
                 // Create a new WebGL frame buffer object
                 if (!target._glFrameBuffer) {
-                   this.createFrameBuffer(target);
+                    this.initRenderTarget(target);
 
                 } else {
                     this.setFramebuffer(target._glFrameBuffer);


### PR DESCRIPTION
Fixes #1917

The PR includes the following:
- Resolve current RenderTarget (if anti-aliased) when updating GrabPass.
- Add optimized WebGL 2 code-path for GrabPass by using `gl.blitFramebuffer`.
- Move framebuffer creation to `pc.GraphicsDevice#initRenderTarget` so that GrabPass's internal RenderTarget can be initialized.

----

All changes have been tested using a [public PlayCanvas project](https://playcanvas.com/project/630510/overview/grabpass-rendertarget-test) (simply run it with and without the PR):

### With PR:
![image](https://user-images.githubusercontent.com/255073/76704981-e8098e00-66dc-11ea-9d8d-f75dbe68bd87.png)

### Without PR:
![image](https://user-images.githubusercontent.com/255073/76704983-eb9d1500-66dc-11ea-8053-6fcf615a0024.png)

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
