### PR TITLE
[DOCS] Document drawQuadWithShader and copyRenderTarget

### DIFF
--- a/src/graphics/device.js
+++ b/src/graphics/device.js
@@ -1077,7 +1077,7 @@ Object.assign(pc, function () {
         /**
          * @function
          * @name pc.GraphicsDevice#copyRenderTarget
-         * @description Copies source render target into destination render target. Mostly used for by post-effects.
+         * @description Copies source render target into destination render target. Mostly used by post-effects.
          * @param {pc.RenderTarget} source - The source render target.
          * @param {pc.RenderTarget} [dest] - The destination render target. Defaults to frame buffer.
          * @param {boolean} [color] - If true will copy the color buffer. Defaults to false.

--- a/src/graphics/device.js
+++ b/src/graphics/device.js
@@ -1082,7 +1082,7 @@ Object.assign(pc, function () {
          * @param {pc.RenderTarget} [dest] - The destination render target. Defaults to frame buffer.
          * @param {boolean} [color] - If true will copy the color buffer. Defaults to false.
          * @param {boolean} [depth] - If true will copy the depth buffer. Defaults to false.
-         * @returns {boolean} True if copy has been initiated.
+         * @returns {boolean} True if the copy was successful, false otherwise.
          */
         copyRenderTarget: function (source, dest, color, depth) {
             var gl = this.gl;

--- a/src/graphics/device.js
+++ b/src/graphics/device.js
@@ -1074,6 +1074,16 @@ Object.assign(pc, function () {
             }
         },
 
+        /**
+         * @function
+         * @name pc.GraphicsDevice#copyRenderTarget
+         * @description Copies source render target into destination render target. Mostly used for by post-effects.
+         * @param {pc.RenderTarget} source - The source render target.
+         * @param {pc.RenderTarget} [dest] - The destination render target. Defaults to frame buffer.
+         * @param {boolean} [color] - If true will copy the color buffer. Defaults to false.
+         * @param {boolean} [depth] - If true will copy the depth buffer. Defaults to false.
+         * @returns {boolean} True if copy has been initiated.
+         */
         copyRenderTarget: function (source, dest, color, depth) {
             var gl = this.gl;
 

--- a/src/graphics/render-target.js
+++ b/src/graphics/render-target.js
@@ -173,9 +173,9 @@ Object.assign(pc, function () {
          * @description Copies color and/or depth contents of source render target to this one. Formats, sizes and anti-aliasing samples must match.
          * Depth buffer can only be copied on WebGL 2.0.
          * @param {pc.RenderTarget} source - Source render target to copy from.
-         * @param {boolean} color - Copy color buffer.
-         * @param {boolean} depth - Copy depth buffer.
-         * @returns {boolean} True if the copy was successfull, false otherwise.
+         * @param {boolean} [color] - If true will copy the color buffer. Defaults to false.
+         * @param {boolean} [depth] - If true will copy the depth buffer. Defaults to false.
+         * @returns {boolean} True if the copy was successful, false otherwise.
          */
         copy: function (source, color, depth) {
             if (!this._device) {

--- a/src/graphics/simple-post-effect.js
+++ b/src/graphics/simple-post-effect.js
@@ -10,6 +10,17 @@ Object.assign(pc, (function () {
         indexed: false
     };
 
+    /**
+     * @function
+     * @name pc.drawQuadWithShader
+     * @description Draws a screen-space quad using a specific shader. Mostly used by post-effects.
+     * @param {pc.GraphicsDevice} device - The graphics device used to draw the quad.
+     * @param {pc.RenderTarget|undefined} target - The destination render target. If undefined, target is the frame buffer.
+     * @param {pc.Shader} shader - The shader used for rendering the quad.
+     * @param {pc.Vec4} [rect] - The viewport rectangle of the quad, in pixels. Defaults to fullscreen (`[0, 0, target.width, target.height]`).
+     * @param {pc.Vec4} [scissorRect] - The scissor rectangle of the quad, in pixels. Defaults to fullscreen (`[0, 0, target.width, target.height]`).
+     * @param {boolean} [useBlend] - True to enable blending. Defaults to false, disabling blending.
+     */
     function drawQuadWithShader(device, target, shader, rect, scissorRect, useBlend) {
         if (_postEffectQuadVB === null) {
             var vertexFormat = new pc.VertexFormat(device, [{

--- a/src/graphics/simple-post-effect.js
+++ b/src/graphics/simple-post-effect.js
@@ -16,9 +16,9 @@ Object.assign(pc, (function () {
      * @description Draws a screen-space quad using a specific shader. Mostly used by post-effects.
      * @param {pc.GraphicsDevice} device - The graphics device used to draw the quad.
      * @param {pc.RenderTarget|undefined} target - The destination render target. If undefined, target is the frame buffer.
-     * @param {pc.Shader} shader - The shader used for rendering the quad.
-     * @param {pc.Vec4} [rect] - The viewport rectangle of the quad, in pixels. Defaults to fullscreen (`[0, 0, target.width, target.height]`).
-     * @param {pc.Vec4} [scissorRect] - The scissor rectangle of the quad, in pixels. Defaults to fullscreen (`[0, 0, target.width, target.height]`).
+     * @param {pc.Shader} shader - The shader used for rendering the quad. Vertex shader should contain `attribute vec2 vertex_position`.
+     * @param {pc.Vec4} [rect] - The viewport rectangle of the quad, in pixels. Defaults to fullscreen (`0, 0, target.width, target.height`).
+     * @param {pc.Vec4} [scissorRect] - The scissor rectangle of the quad, in pixels. Defaults to fullscreen (`0, 0, target.width, target.height`).
      * @param {boolean} [useBlend] - True to enable blending. Defaults to false, disabling blending.
      */
     function drawQuadWithShader(device, target, shader, rect, scissorRect, useBlend) {


### PR DESCRIPTION
PR includes the following pure JSDOC changes:
- document `pc.drawQuadWithShader`
- document `pc.GraphicsDevice#copyRenderTarget`
- improve documentation for `pc.RenderTarget#copy`

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
