### PR TITLE
Add pc.drawTexture to render texture to target using a shader

### DIFF
--- a/src/graphics/device.js
+++ b/src/graphics/device.js
@@ -1147,6 +1147,7 @@ Object.assign(pc, function () {
         },
 
         /**
+         * @private
          * @function
          * @name pc.GraphicsDevice#getCopyShader
          * @description Get copy shader for efficient rendering of fullscreen-quad with texture.

--- a/src/graphics/device.js
+++ b/src/graphics/device.js
@@ -1138,15 +1138,26 @@ Object.assign(pc, function () {
                 this.renderTarget = prevRt;
                 gl.bindFramebuffer(gl.FRAMEBUFFER, prevRt ? prevRt._glFrameBuffer : null);
             } else {
-                if (!this._copyShader) {
-                    var chunks = pc.shaderChunks;
-                    this._copyShader = chunks.createShaderFromCode(this, chunks.fullscreenQuadVS, chunks.outputTex2DPS, "outputTex2D");
-                }
+                var shader = this.getCopyShader();
                 this.constantTexSource.setValue(source._colorBuffer);
-                pc.drawQuadWithShader(this, dest, this._copyShader);
+                pc.drawQuadWithShader(this, dest, shader);
             }
 
             return true;
+        },
+
+        /**
+         * @function
+         * @name pc.GraphicsDevice#createFrameBuffer
+         * @description Get copy shader for efficient rendering of fullscreen-quad with texture.
+         * @returns {pc.Shader} The copy shader (based on `fullscreenQuadVS` and `outputTex2DPS` in `pc.shaderChunks`).
+         */
+        getCopyShader: function () {
+            if (!this._copyShader) {
+                var chunks = pc.shaderChunks;
+                this._copyShader = chunks.createShaderFromCode(this, chunks.fullscreenQuadVS, chunks.outputTex2DPS, "outputTex2D");
+            }
+            return this._copyShader;
         },
 
         /**

--- a/src/graphics/device.js
+++ b/src/graphics/device.js
@@ -1148,7 +1148,7 @@ Object.assign(pc, function () {
 
         /**
          * @function
-         * @name pc.GraphicsDevice#createFrameBuffer
+         * @name pc.GraphicsDevice#getCopyShader
          * @description Get copy shader for efficient rendering of fullscreen-quad with texture.
          * @returns {pc.Shader} The copy shader (based on `fullscreenQuadVS` and `outputTex2DPS` in `pc.shaderChunks`).
          */

--- a/src/graphics/simple-post-effect.js
+++ b/src/graphics/simple-post-effect.js
@@ -110,8 +110,22 @@ Object.assign(pc, (function () {
         }
     }
 
+    function drawTexture(device, texture, target, shader, rect, scissorRect, useBlend) {
+        if (!shader) {
+            if (!device._copyShader) {
+                var chunks = pc.shaderChunks;
+                device._copyShader = chunks.createShaderFromCode(device, chunks.fullscreenQuadVS, chunks.outputTex2DPS, "outputTex2D");
+            }
+            shader = device._copyShader;
+        }
+
+        device.constantTexSource.setValue(texture);
+        drawQuadWithShader(device, target, shader, rect, scissorRect, useBlend);
+    }
+
     return {
         drawQuadWithShader: drawQuadWithShader,
-        destroyPostEffectQuad: destroyPostEffectQuad
+        destroyPostEffectQuad: destroyPostEffectQuad,
+        drawTexture: drawTexture
     };
 }()));

--- a/src/graphics/simple-post-effect.js
+++ b/src/graphics/simple-post-effect.js
@@ -110,6 +110,18 @@ Object.assign(pc, (function () {
         }
     }
 
+    /**
+     * @function
+     * @name pc.drawTexture
+     * @description Draws a texture in screen-space. Mostly used by post-effects.
+     * @param {pc.GraphicsDevice} device - The graphics device used to draw the texture.
+     * @param {pc.Texture} texture - The source texture to be drawn. Accessible as `uniform sampler2D source` in shader.
+     * @param {pc.RenderTarget} [target] - The destination render target. Defaults to the frame buffer.
+     * @param {pc.Shader} [shader] - The shader used for rendering the texture. Defaults to `fullscreenQuadVS` and `outputTex2DPS` in `pc.shaderChunks`.
+     * @param {pc.Vec4} [rect] - The viewport rectangle to use for the texture, in pixels. Defaults to fullscreen (`0, 0, target.width, target.height`).
+     * @param {pc.Vec4} [scissorRect] - The scissor rectangle to use for the texture, in pixels. Defaults to fullscreen (`0, 0, target.width, target.height`).
+     * @param {boolean} [useBlend] - True to enable blending. Defaults to false, disabling blending.
+     */
     function drawTexture(device, texture, target, shader, rect, scissorRect, useBlend) {
         if (!shader) {
             if (!device._copyShader) {

--- a/src/graphics/simple-post-effect.js
+++ b/src/graphics/simple-post-effect.js
@@ -117,20 +117,13 @@ Object.assign(pc, (function () {
      * @param {pc.GraphicsDevice} device - The graphics device used to draw the texture.
      * @param {pc.Texture} texture - The source texture to be drawn. Accessible as `uniform sampler2D source` in shader.
      * @param {pc.RenderTarget} [target] - The destination render target. Defaults to the frame buffer.
-     * @param {pc.Shader} [shader] - The shader used for rendering the texture. Defaults to `fullscreenQuadVS` and `outputTex2DPS` in `pc.shaderChunks`.
+     * @param {pc.Shader} [shader] - The shader used for rendering the texture. Defaults to `pc.GraphicsDevice#getCopyShader()`.
      * @param {pc.Vec4} [rect] - The viewport rectangle to use for the texture, in pixels. Defaults to fullscreen (`0, 0, target.width, target.height`).
      * @param {pc.Vec4} [scissorRect] - The scissor rectangle to use for the texture, in pixels. Defaults to fullscreen (`0, 0, target.width, target.height`).
      * @param {boolean} [useBlend] - True to enable blending. Defaults to false, disabling blending.
      */
     function drawTexture(device, texture, target, shader, rect, scissorRect, useBlend) {
-        if (!shader) {
-            if (!device._copyShader) {
-                var chunks = pc.shaderChunks;
-                device._copyShader = chunks.createShaderFromCode(device, chunks.fullscreenQuadVS, chunks.outputTex2DPS, "outputTex2D");
-            }
-            shader = device._copyShader;
-        }
-
+        shader = shader || device.getCopyShader();
         device.constantTexSource.setValue(texture);
         drawQuadWithShader(device, target, shader, rect, scissorRect, useBlend);
     }


### PR DESCRIPTION
The PR includes the following:
- Add `pc.drawTexture`, so textures can easily, for example, be encoded/decoded using a shader to a destination target. Similar to Unity's popular [`Graphics.DrawTexture`](https://docs.unity3d.com/ScriptReference/Graphics.DrawTexture.html) or [`Graphics.Blit`](https://docs.unity3d.com/ScriptReference/Graphics.Blit.html) functions.
- Add `pc.GraphicsDevice#getCopyShader`, to avoid code duplication for creating default copy shader.

----

All changes have been tested using a [public PlayCanvas project](https://playcanvas.com/project/671572/overview/draw-texture-test) (simply run it with and without the PR):

### With PR:
![with_pr](https://user-images.githubusercontent.com/255073/76706095-5a7e6c00-66e5-11ea-8be5-4df90652d196.gif)

### Without PR:
![without_pr](https://user-images.githubusercontent.com/255073/76706098-5eaa8980-66e5-11ea-8c42-b4d2912f8333.gif)


I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
