### PR TITLE
Optimize BoundingBox and fix inaccuracy

### DIFF
--- a/src/resources/parser/glb-parser.js
+++ b/src/resources/parser/glb-parser.js
@@ -341,10 +341,8 @@ Object.assign(pc, function () {
             var accessor = accessors[primitive.attributes.POSITION];
             var min = accessor.min;
             var max = accessor.max;
-            var aabb = new pc.BoundingBox(
-                new pc.Vec3((max[0] + min[0]) / 2, (max[1] + min[1]) / 2, (max[2] + min[2]) / 2),
-                new pc.Vec3((max[0] - min[0]) / 2, (max[1] - min[1]) / 2, (max[2] - min[2]) / 2)
-            );
+            var aabb = new pc.BoundingBox();
+            aabb.setMinMax(min, max);
             mesh.aabb = aabb;
 
             if (primitive.hasOwnProperty('targets')) {

--- a/src/resources/parser/json-model.js
+++ b/src/resources/parser/json-model.js
@@ -157,10 +157,8 @@ Object.assign(pc, function () {
 
                         var min = targetAabb.min;
                         var max = targetAabb.max;
-                        var aabb = new pc.BoundingBox(
-                            new pc.Vec3((max[0] + min[0]) * 0.5, (max[1] + min[1]) * 0.5, (max[2] + min[2]) * 0.5),
-                            new pc.Vec3((max[0] - min[0]) * 0.5, (max[1] - min[1]) * 0.5, (max[2] - min[2]) * 0.5)
-                        );
+                        var aabb = new pc.BoundingBox();
+                        aabb.setMinMax(min, max);
 
                         morphTarget = new pc.MorphTarget({ indices: targets[j].indices,
                             deltaPositions: targets[j].deltaPositions,
@@ -624,10 +622,8 @@ Object.assign(pc, function () {
                 var meshAabb = meshData.aabb;
                 var min = meshAabb.min;
                 var max = meshAabb.max;
-                var aabb = new pc.BoundingBox(
-                    new pc.Vec3((max[0] + min[0]) * 0.5, (max[1] + min[1]) * 0.5, (max[2] + min[2]) * 0.5),
-                    new pc.Vec3((max[0] - min[0]) * 0.5, (max[1] - min[1]) * 0.5, (max[2] - min[2]) * 0.5)
-                );
+                var aabb = new pc.BoundingBox();
+                aabb.setMinMax(min, max);
 
                 var indexed = (meshData.indices !== undefined);
                 var mesh = new pc.Mesh();

--- a/src/shape/bounding-box.js
+++ b/src/shape/bounding-box.js
@@ -85,6 +85,8 @@ Object.assign(pc, function () {
             if (omax.y > tmax.y) tmax.y = omax.y;
             if (omin.z < tmin.z) tmin.z = omin.z;
             if (omax.z > tmax.z) tmax.z = omax.z;
+
+            this._syncMinMaxToCtrHlf();
         },
 
         /**

--- a/src/shape/bounding-box.js
+++ b/src/shape/bounding-box.js
@@ -338,7 +338,7 @@ Object.assign(pc, function () {
          * @function
          * @name pc.BoundingBox#compute
          * @description Compute the size of the AABB to encapsulate all specified vertices.
-         * @param {pc.Vec3[]} vertices - The vertices used to compute the new size for the AABB.
+         * @param {number[]|Float32Array} vertices - The vertices used to compute the new size for the AABB.
          */
         compute: function (vertices) {
             var min = tmpVecA.set(vertices[0], vertices[1], vertices[2]);

--- a/src/shape/bounding-box.js
+++ b/src/shape/bounding-box.js
@@ -237,10 +237,18 @@ Object.assign(pc, function () {
          * @param {pc.Vec3|number[]} max - The maximum corner of the AABB. Can be a {@link pc.Vec3} or an array (of length 3).
          */
         setMinMax: function (min, max) {
-            if (!Array.isArray(min)) this._min.copy(min);
-            else this._min.set(min[0], min[1], min[2]);
-            if (!Array.isArray(max)) this._max.copy(max);
-            else this._max.set(max[0], max[1], max[2]);
+            if (Array.isArray(min)) {
+                this._min.set(min[0], min[1], min[2]);
+            } else {
+                this._min.copy(min);
+            }
+
+            if (Array.isArray(max)) {
+                this._max.set(max[0], max[1], max[2]);
+            } else {
+                this._max.copy(max);
+            }
+
             this._syncMinMaxToCtrHlf();
         },
 

--- a/src/shape/bounding-box.js
+++ b/src/shape/bounding-box.js
@@ -243,6 +243,8 @@ Object.assign(pc, function () {
         },
 
         /**
+         * @private
+         * @deprecated
          * @function
          * @name pc.BoundingBox#getMin
          * @description Return the minimum corner of the AABB.
@@ -253,6 +255,8 @@ Object.assign(pc, function () {
         },
 
         /**
+         * @private
+         * @deprecated
          * @function
          * @name pc.BoundingBox#getMax
          * @description Return the maximum corner of the AABB.

--- a/src/shape/bounding-box.js
+++ b/src/shape/bounding-box.js
@@ -87,6 +87,12 @@ Object.assign(pc, function () {
             if (omax.z > tmax.z) tmax.z = omax.z;
         },
 
+        /**
+         * @function
+         * @name pc.BoundingBox#copy
+         * @description Copies the contents of a source AABB.
+         * @param {pc.BoundingBox} src - The AABB to copy from.
+         */
         copy: function (src) {
             this._center.copy(src._center);
             this._halfExtents.copy(src._halfExtents);
@@ -94,6 +100,12 @@ Object.assign(pc, function () {
             this._max.copy(src._max);
         },
 
+        /**
+         * @function
+         * @name pc.BoundingBox#clone
+         * @description Returns a clone of the AABB
+         * @returns {pc.BoundingBox} A duplicate AABB.
+         */
         clone: function () {
             var clone = new pc.BoundingBox();
             clone.copy(this);
@@ -214,6 +226,14 @@ Object.assign(pc, function () {
             return this._fastIntersectsRay(ray);
         },
 
+        /**
+         * @function
+         * @name pc.BoundingBox#setMinMax
+         * @description Sets the minimum and maximum corner of the AABB.
+         * Using this function is faster than assigning min and max separately.
+         * @param {pc.Vec3|number[]} min - The minimum corner of the AABB. Can be a {@link pc.Vec3} or an array (of length 3).
+         * @param {pc.Vec3|number[]} max - The maximum corner of the AABB. Can be a {@link pc.Vec3} or an array (of length 3).
+         */
         setMinMax: function (min, max) {
             if (!Array.isArray(min)) this._min.copy(min);
             else this._min.set(min[0], min[1], min[2]);
@@ -310,6 +330,12 @@ Object.assign(pc, function () {
             );
         },
 
+        /**
+         * @function
+         * @name pc.BoundingBox#compute
+         * @description Compute the size of the AABB to encapsulate all specified vertices.
+         * @param {pc.Vec3[]} vertices - The vertices used to compute the new size for the AABB.
+         */
         compute: function (vertices) {
             var min = tmpVecA.set(vertices[0], vertices[1], vertices[2]);
             var max = tmpVecB.set(vertices[0], vertices[1], vertices[2]);

--- a/src/shape/bounding-box.js
+++ b/src/shape/bounding-box.js
@@ -14,6 +14,8 @@ Object.assign(pc, function () {
      * @param {pc.Vec3} [halfExtents] - Half the distance across the box in each axis. The constructor takes a reference of this parameter.
      * @property {pc.Vec3} center Center of box.
      * @property {pc.Vec3} halfExtents Half the distance across the box in each axis.
+     * @property {pc.Vec3} min The minimum corner of the box.
+     * @property {pc.Vec3} max The maximum corner of the box.
      */
     var BoundingBox = function BoundingBox(center, halfExtents) {
         this.center = center || new pc.Vec3(0, 0, 0);
@@ -21,6 +23,46 @@ Object.assign(pc, function () {
         this._min = new pc.Vec3();
         this._max = new pc.Vec3();
     };
+
+    Object.defineProperty(BoundingBox.prototype, 'center', {
+        get: function () {
+            return this._center;
+        },
+        set: function (value) {
+            this._center.copy(value);
+            this._syncCtrHlfToMinMax();
+        }
+    });
+
+    Object.defineProperty(BoundingBox.prototype, 'halfExtents', {
+        get: function () {
+            return this._halfExtents;
+        },
+        set: function (value) {
+            this._halfExtents.copy(value);
+            this._syncCtrHlfToMinMax();
+        }
+    });
+
+    Object.defineProperty(BoundingBox.prototype, 'min', {
+        get: function () {
+            return this._min;
+        },
+        set: function (value) {
+            this._min.copy(value);
+            this._syncMinMaxToCtrHlf();
+        }
+    });
+
+    Object.defineProperty(BoundingBox.prototype, 'max', {
+        get: function () {
+            return this._max;
+        },
+        set: function (value) {
+            this._max.copy(value);
+            this._syncMinMaxToCtrHlf();
+        }
+    });
 
     Object.assign(BoundingBox.prototype, {
 
@@ -357,6 +399,16 @@ Object.assign(pc, function () {
             }
 
             return sq;
+        },
+
+        _syncCtrHlfToMinMax: function () {
+            this._min.copy(this._center).sub(this._halfExtents);
+            this._max.copy(this._center).add(this._halfExtents);
+        },
+
+        _syncMinMaxToCtrHlf: function () {
+            this._center.add2(this._max, this._min).scale(0.5);
+            this._halfExtents.sub2(this._max, this._min).scale(0.5);
         }
     });
 


### PR DESCRIPTION
Fixes #1903

PR includes the following:
- Fix documentation for all public `pc.BoundingBox` methods (`copy`, `clone`, `compute`, `setMinMax`).
- Optimize `pc.BoundingBox` for both `min`/`max` and `center`/`halfExtents` by always keeping in sync.
- Support arrays (of length 3) as paramters (in addition to `pc.Vec3`) in `pc.BoundingBox#setMinMax`.
- Use new optimized `pc.BoundingBox#setMinMax` in `glb-parser.js` and `json-model.js` parser.
- Add new properties `min` and `max` to `pc.BoundingBox` (without re-calcuating on every get).
- Deprecate old "getters" (`getMin` and `getMax`) in `pc.BoundingBox`, while keeping backward-compatibility.

**PLEASE NOTE:** The behavior of `pc.BoundingBox` is still exactly the same. Only the internals have been improved. This PR is fully backward-compatible.

----
I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).