### PR TITLE
[JSDOC] Fix incorrect naming syntax for ScriptType.attributes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "playcanvas",
-  "version": "1.26.0-dev",
+  "version": "1.27.0-dev",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/script/script-type.js
+++ b/src/script/script-type.js
@@ -80,7 +80,7 @@ Object.assign(pc, function () {
      * @field
      * @static
      * @readonly
-     * @name pc.ScriptType#attributes
+     * @name pc.ScriptType.attributes
      * @type {pc.ScriptAttributes}
      * @description The interface to define attributes for Script Types. Refer to {@link pc.ScriptAttributes}.
      * @example


### PR DESCRIPTION
Fixes incorrect syntax used in jsdoc `@name` tag for static property `pc.ScriptType.attributes`.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
