### PR TITLE
[DOCS] Make pc.Application#loadScene public

### DIFF
--- a/src/callbacks.js
+++ b/src/callbacks.js
@@ -64,7 +64,6 @@
  */
 
 /**
- * @private
  * @callback pc.callbacks.LoadScene
  * @description Callback used by {@link pc.Application#loadScene}.
  * @param {string|null} err - The error message in the case where the loading or parsing fails.

--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -842,7 +842,6 @@ Object.assign(pc, function () {
         },
 
         /**
-         * @private
          * @function
          * @name pc.Application#loadScene
          * @description Load a scene file.


### PR DESCRIPTION
Fixes #1944

PR makes the following public:
- `pc.Application#loadScene`
- `pc.callbacks.LoadScene`

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
