### PR TITLE
Add pc.Application#fillMode and #resolutionMode getters

### DIFF
--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -691,6 +691,21 @@ Object.assign(pc, function () {
         }
     });
 
+    /**
+     * @readonly
+     * @name pc.Application#resolutionMode
+     * @type {string}
+     * @description The current resolution mode of the canvas, Can be:
+     *
+     * * {@link pc.RESOLUTION_AUTO}: if width and height are not provided, canvas will be resized to match canvas client size.
+     * * {@link pc.RESOLUTION_FIXED}: resolution of canvas will be fixed.
+     */
+    Object.defineProperty(Application.prototype, 'resolutionMode', {
+        get: function () {
+            return this._resolutionMode;
+        }
+    });
+
     Object.assign(Application.prototype, {
         /**
          * @function

--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -675,6 +675,22 @@ Object.assign(pc, function () {
         };
     };
 
+    /**
+     * @readonly
+     * @name pc.Application#fillMode
+     * @type {string}
+     * @description The current fill mode of the canvas. Can be:
+     *
+     * * {@link pc.FILLMODE_NONE}: the canvas will always match the size provided.
+     * * {@link pc.FILLMODE_FILL_WINDOW}: the canvas will simply fill the window, changing aspect ratio.
+     * * {@link pc.FILLMODE_KEEP_ASPECT}: the canvas will grow to fill the window as best it can while maintaining the aspect ratio.
+     */
+    Object.defineProperty(Application.prototype, 'fillMode', {
+        get: function () {
+            return this._fillMode;
+        }
+    });
+
     Object.assign(Application.prototype, {
         /**
          * @function


### PR DESCRIPTION
Fixes #1946

PR adds the following read-only properties:
- `pc.Application#fillMode`
- `pc.Application#resolutionMode`

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
