### PR TITLE
Add pc.ScriptComponent#get

### DIFF
--- a/src/framework/components/script/component.js
+++ b/src/framework/components/script/component.js
@@ -480,13 +480,13 @@ Object.assign(pc, function () {
          * @name pc.ScriptComponent#get
          * @description Get a script instance (if attached) using name of {@link pc.ScriptType}.
          * @param {string} name - The name of the Script Type.
-         * @returns {pc.ScriptType|undefined} If script is attached, the instance is returned. Otherwise undefined is returned.
+         * @returns {pc.ScriptType|null} If script is attached, the instance is returned. Otherwise null is returned.
          * @example
          * var controller = entity.script.get('playerController');
          */
         get: function (name) {
             var index = this._scriptsIndex[name];
-            return index && index.instance;
+            return (index && index.instance) || null;
         },
 
         /* eslint-disable jsdoc/no-undefined-types */

--- a/src/framework/components/script/component.js
+++ b/src/framework/components/script/component.js
@@ -475,6 +475,20 @@ Object.assign(pc, function () {
             return !!this._scriptsIndex[name];
         },
 
+        /**
+         * @function
+         * @name pc.ScriptComponent#get
+         * @description Get a script instance (if attached) using name of {@link pc.ScriptType}.
+         * @param {string} name - The name of the Script Type.
+         * @returns {pc.ScriptType|undefined} If script is attached, the instance is returned. Otherwise undefined is returned.
+         * @example
+         * var controller = entity.script.get('playerController');
+         */
+        get: function (name) {
+            var index = this._scriptsIndex[name];
+            return index && index.instance;
+        },
+
         /* eslint-disable jsdoc/no-undefined-types */
         /**
          * @function

--- a/src/script/script.js
+++ b/src/script/script.js
@@ -152,7 +152,7 @@ Object.assign(pc, function () {
     createScript.reservedAttributes = [
         'app', 'entity', 'enabled', '_enabled', '_enabledOld', '_destroyed',
         '__attributes', '__attributesRaw', '__scriptType', '__executionOrder',
-        '_callbacks', 'has', `get`, 'on', 'off', 'fire', 'once', 'hasEvent'
+        '_callbacks', 'has', 'get', 'on', 'off', 'fire', 'once', 'hasEvent'
     ];
     var reservedAttributes = { };
     for (i = 0; i < createScript.reservedAttributes.length; i++)

--- a/src/script/script.js
+++ b/src/script/script.js
@@ -139,7 +139,7 @@ Object.assign(pc, function () {
         '_onSetEnabled', '_checkState', '_onBeforeRemove',
         '_onInitializeAttributes', '_onInitialize', '_onPostInitialize',
         '_onUpdate', '_onPostUpdate',
-        '_callbacks', 'has', 'on', 'off', 'fire', 'once', 'hasEvent'
+        '_callbacks', 'has', 'get', 'on', 'off', 'fire', 'once', 'hasEvent'
     ];
     var reservedScripts = { };
     var i;

--- a/src/script/script.js
+++ b/src/script/script.js
@@ -152,7 +152,7 @@ Object.assign(pc, function () {
     createScript.reservedAttributes = [
         'app', 'entity', 'enabled', '_enabled', '_enabledOld', '_destroyed',
         '__attributes', '__attributesRaw', '__scriptType', '__executionOrder',
-        '_callbacks', 'has', 'on', 'off', 'fire', 'once', 'hasEvent'
+        '_callbacks', 'has', `get`, 'on', 'off', 'fire', 'once', 'hasEvent'
     ];
     var reservedAttributes = { };
     for (i = 0; i < createScript.reservedAttributes.length; i++)


### PR DESCRIPTION
Currently, there is no way for a TypeScript developer to properly access a script instance in a `pc.ScriptComponent`. Accessing a property with an arbitrary name on an otherwise well-defined component is not type-safe.

PR adds `pc.ScriptComponent#get` (similar to `pc.ScriptComponent#has`), to help TypeScript developers maintain type-safety (which is the primary purpose of using TypeScript).


I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
