### PR TITLE
Include gltf base path in subsequent requests for external assets

### DIFF
--- a/src/resources/container.js
+++ b/src/resources/container.js
@@ -80,7 +80,7 @@ Object.assign(pc, function () {
                 };
             }
 
-            var basePath = url.load.substring(0, url.load.lastIndexOf("/")) + "/";
+            var basePath = pc.path.extractPath(url.load);
 
             var options = {
                 responseType: pc.Http.ResponseType.ARRAY_BUFFER,

--- a/src/resources/container.js
+++ b/src/resources/container.js
@@ -80,6 +80,8 @@ Object.assign(pc, function () {
                 };
             }
 
+            var basePath = url.load.substring(0, url.load.lastIndexOf("/")) + "/";
+
             var options = {
                 responseType: pc.Http.ResponseType.ARRAY_BUFFER,
                 retry: false
@@ -93,7 +95,7 @@ Object.assign(pc, function () {
 
                 if (!err) {
                     var filename = (asset.file && asset.file.filename) ? asset.file.filename : asset.name;
-                    pc.GlbParser.parseAsync(filename, response, self._device, function (err, result) {
+                    pc.GlbParser.parseAsync(filename, response, self._device, basePath, function (err, result) {
                         if (err) {
                             callback(err);
                         } else {

--- a/src/resources/parser/glb-parser.js
+++ b/src/resources/parser/glb-parser.js
@@ -1053,7 +1053,7 @@ Object.assign(pc, function () {
                     img.src = imgData.uri;
                 } else {
                     img.crossOrigin = "anonymous";
-                    img.src = basePath + imgData.uri;
+                    img.src = pc.path.join(basePath, imgData.uri);
                 }
             } else if (imgData.hasOwnProperty('bufferView') && imgData.hasOwnProperty('mimeType')) {
                 // bufferview
@@ -1115,7 +1115,7 @@ Object.assign(pc, function () {
                 } else {
                     var xhr = new XMLHttpRequest();
                     xhr.responseType = 'arraybuffer';
-                    xhr.open('GET', basePath + buffer.uri, true);
+                    xhr.open('GET', pc.path.join(basePath, buffer.uri), true);
                     xhr.onload = (function (index) {
                         return function () {
                             onLoad(new LintHack(this.response), index);

--- a/src/resources/parser/glb-parser.js
+++ b/src/resources/parser/glb-parser.js
@@ -1019,7 +1019,7 @@ Object.assign(pc, function () {
     };
 
     // load gltf images asynchronously, returning the images in callback
-    var loadImagesAsync = function (device, gltf, buffers, callback) {
+    var loadImagesAsync = function (device, gltf, buffers, basePath, callback) {
         var result = [];
 
         if (!gltf.hasOwnProperty('images') || gltf.images.length === 0 ||
@@ -1053,7 +1053,7 @@ Object.assign(pc, function () {
                     img.src = imgData.uri;
                 } else {
                     img.crossOrigin = "anonymous";
-                    img.src = imgData.uri;
+                    img.src = basePath + imgData.uri;
                 }
             } else if (imgData.hasOwnProperty('bufferView') && imgData.hasOwnProperty('mimeType')) {
                 // bufferview
@@ -1074,7 +1074,7 @@ Object.assign(pc, function () {
     };
 
     // load gltf buffers asynchronously, returning them in the callback
-    var loadBuffersAsync = function (gltf, binaryChunk, callback) {
+    var loadBuffersAsync = function (gltf, binaryChunk, basePath, callback) {
         var result = [];
 
         if (gltf.buffers === null || gltf.buffers.length === 0) {
@@ -1115,7 +1115,7 @@ Object.assign(pc, function () {
                 } else {
                     var xhr = new XMLHttpRequest();
                     xhr.responseType = 'arraybuffer';
-                    xhr.open('GET', buffer.uri, true);
+                    xhr.open('GET', basePath + buffer.uri, true);
                     xhr.onload = (function (index) {
                         return function () {
                             onLoad(new LintHack(this.response), index);
@@ -1230,7 +1230,7 @@ Object.assign(pc, function () {
     var GlbParser = function () { };
 
     // parse the gltf or glb data asynchronously, loading external resources
-    GlbParser.parseAsync = function (filename, data, device, callback) {
+    GlbParser.parseAsync = function (filename, data, device, basePath, callback) {
         // parse the data
         parseChunk(filename, data, function (err, chunks) {
             if (err) {
@@ -1246,14 +1246,14 @@ Object.assign(pc, function () {
                 }
 
                 // async load external buffers
-                loadBuffersAsync(gltf, chunks.binaryChunk, function (err, buffers) {
+                loadBuffersAsync(gltf, chunks.binaryChunk, basePath, function (err, buffers) {
                     if (err) {
                         callback(err);
                         return;
                     }
 
                     // async load images
-                    loadImagesAsync(device, gltf, buffers, function (err, images) {
+                    loadImagesAsync(device, gltf, buffers, basePath, function (err, images) {
                         if (err) {
                             callback(err);
                             return;


### PR DESCRIPTION
Fixes #1936

PR contains the following changes:
* Add base path of loaded gltf to subsequent asset requests made in `loadImagesAsync` and `loadBuffersAsync`.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
