### PR TITLE
Small fixes to viewer and engine example

### DIFF
--- a/examples/user-interface/text-canvas-font.html
+++ b/examples/user-interface/text-canvas-font.html
@@ -58,7 +58,7 @@
         app.assets.add(fontAsset);
         app.assets.load(fontAsset);
         app.assets.on('load:' + fontAsset.id, function () {
-            app.start();
+            
         });
 
         // create camera
@@ -168,6 +168,8 @@
         var showCanvasAtlasForDebug = false;
         renderAtlases();
 
+        // start the application
+        app.start();
     </script>
 </body>
 </html>

--- a/examples/user-interface/text-canvas-font.html
+++ b/examples/user-interface/text-canvas-font.html
@@ -57,9 +57,6 @@
         });
         app.assets.add(fontAsset);
         app.assets.load(fontAsset);
-        app.assets.on('load:' + fontAsset.id, function () {
-            
-        });
 
         // create camera
         var c = new pc.Entity();

--- a/tools/glb-viewer/src/controls.js
+++ b/tools/glb-viewer/src/controls.js
@@ -21,6 +21,8 @@ document.getElementById('graphs').onclick = function (e) {
 
 var animList = document.getElementById('anim-list');
 
+/* eslint-disable no-unused-vars */
+
 // called when animations are loaded
 var onAnimationsLoaded = function (animationList) {
     // clear previous list
@@ -40,3 +42,5 @@ var onAnimationsLoaded = function (animationList) {
         animList.appendChild(li);
     }
 };
+
+/* eslint-enable no-unused-vars */

--- a/tools/glb-viewer/src/viewer.js
+++ b/tools/glb-viewer/src/viewer.js
@@ -39,6 +39,7 @@ var Viewer = function (canvas) {
         app.scene.toneMapping = pc.TONEMAP_ACES;
         app.scene.skyboxMip = 1;                        // Set the skybox to the 128x128 cubemap mipmap level
         app.scene.setSkybox(cubemapAsset.resources);
+        app.renderNextFrame = true;                     // ensure we render again when the cubemap arrives
     });
     app.assets.add(cubemapAsset);
     app.assets.load(cubemapAsset);
@@ -125,7 +126,7 @@ var Viewer = function (canvas) {
 
     function getUrlVars() {
         var vars = {};
-        var parts = window.location.href.replace(/[?&]+([^=&]+)=([^&]*)/gi, function (m, key, value) {
+        window.location.href.replace(/[?&]+([^=&]+)=([^&]*)/gi, function (m, key, value) {
             vars[key] = value;
         });
         return vars;
@@ -308,8 +309,10 @@ Object.assign(Viewer.prototype, {
     }
 });
 
-var viewer;
+/* eslint-disable no-unused-vars */
 
 var main = function () {
-    viewer = new Viewer(document.getElementById("application-canvas"));
+    new Viewer(document.getElementById("application-canvas"));
 };
+
+/* eslint-enable no-unused-vars */

--- a/tools/glb-viewer/src/viewer.js
+++ b/tools/glb-viewer/src/viewer.js
@@ -312,7 +312,7 @@ Object.assign(Viewer.prototype, {
 /* eslint-disable no-unused-vars */
 
 var main = function () {
-    new Viewer(document.getElementById("application-canvas"));
+    var viewer = new Viewer(document.getElementById("application-canvas"));
 };
 
 /* eslint-enable no-unused-vars */


### PR DESCRIPTION
Changes in this PR:
- squash lint warnings in the engine viewer
- get text-canvas-font example working with the visual tester