### PR TITLE
Fix parsing of ES6 scripts

### DIFF
--- a/src/script/script-type.js
+++ b/src/script/script-type.js
@@ -1,4 +1,7 @@
 Object.assign(pc, function () {
+
+    var funcNameRegex = new RegExp('^\\s*function(?:\\s|\\s*\\/\\*.*\\*\\/\\s*)+([^\\(\\s\\/]*)\\s*');
+
     /**
      * @class
      * @name pc.ScriptType
@@ -75,6 +78,14 @@ Object.assign(pc, function () {
      * @description Name of a Script Type.
      */
     ScriptType.__name = null; // Will be assigned when calling createScript or registerScript.
+
+    ScriptType.__getScriptName = function (constructorFn) {
+        if (typeof constructorFn !== 'function') return undefined;
+        if ('name' in Function.prototype) return constructorFn.name;
+        if (constructorFn === Function || constructorFn === Function.prototype.constructor) return 'Function';
+        var match = ("" + constructorFn).match(funcNameRegex);
+        return match ? match[1] : undefined;
+    };
 
     /**
      * @field

--- a/src/script/script.js
+++ b/src/script/script.js
@@ -1,14 +1,4 @@
 Object.assign(pc, function () {
-    var funcNameRegex = new RegExp('^\\s*function(?:\\s|\\s*\\/\\*.*\\*\\/\\s*)+([^\\(\\s\\/]*)\\s*');
-
-    var _getFuncName = function (func) {
-        if (typeof func !== 'function') return undefined;
-        if ('name' in Function.prototype) return func.name;
-        if (func === Function || func === Function.prototype.constructor) return 'Function';
-        var match = ("" + func).match(funcNameRegex);
-        return match ? match[1] : undefined;
-    };
-
     /* eslint-disable jsdoc/no-undefined-types */
     /**
      * @static
@@ -115,9 +105,9 @@ Object.assign(pc, function () {
             throw new Error('script class: \'' + script + '\' must be a constructor function (i.e. class).');
 
         if (!(script.prototype instanceof pc.ScriptType))
-            throw new Error('script class: \'' + _getFuncName(script) + '\' does not extend pc.ScriptType.');
+            throw new Error('script class: \'' + pc.ScriptType.__getScriptName(script) + '\' does not extend pc.ScriptType.');
 
-        name = name || script.__name || _getFuncName(script);
+        name = name || script.__name || pc.ScriptType.__getScriptName(script);
 
         if (createScript.reservedScripts[name])
             throw new Error('script name: \'' + name + '\' is reserved, please change script name');

--- a/src/script/script.js
+++ b/src/script/script.js
@@ -90,6 +90,9 @@ Object.assign(pc, function () {
      *
      * // register the class as a script
      * pc.registerScript(PlayerController);
+     *
+     * // declare script attributes (Must be after pc.registerScript())
+     * PlayerController.attributes.add('attribute1', {type: 'number'});
      */
     /* eslint-enable jsdoc/check-examples */
     /* eslint-enable jsdoc/no-undefined-types */


### PR DESCRIPTION
Define _getFuncName in pc.ScriptType.__getScriptName so that it is visible from the Editor in order to parse pc.ScriptType scripts.
