### PR TITLE
Add pc.AnimationComponent#getAnimations

### DIFF
--- a/src/framework/components/animation/component.js
+++ b/src/framework/components/animation/component.js
@@ -111,6 +111,25 @@ Object.assign(pc, function () {
 
         /**
          * @function
+         * @name pc.AnimationComponent#getAnimations
+         * @description Return all loaded animation assets.
+         * @returns {pc.Animation[]} Array of animation assets.
+         */
+        getAnimations: function () {
+            var animations = this.data.animations;
+            var array = [];
+
+            for (var key in animations) {
+                if (animations.hasOwnProperty(key)) {
+                    array.push(animations[key]);
+                }
+            }
+
+            return array;
+        },
+
+        /**
+         * @function
          * @name pc.AnimationComponent#getAnimation
          * @description Return an animation.
          * @param {string} name - The name of the animation asset.


### PR DESCRIPTION
Currently, there is no way to get a list of animations made available in `pc.AnimationComponent`. This PR fixes that.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
