### PR TITLE
[DOCS] Document pc.AnimationComponent#skeleton and pc.AnimationComponent#animations

### DIFF
--- a/src/framework/components/animation/component.js
+++ b/src/framework/components/animation/component.js
@@ -478,12 +478,6 @@ Object.assign(pc, function () {
             get: function () {
                 return this.data.animations[this.data.currAnim].duration;
             }
-        },
-
-        skeleton: {
-            get: function () {
-                return this.data.skeleton;
-            }
         }
     });
 

--- a/src/framework/components/animation/component.js
+++ b/src/framework/components/animation/component.js
@@ -13,7 +13,8 @@ Object.assign(pc, function () {
      * @property {boolean} activate If true the first animation asset will begin playing when the scene is loaded.
      * @property {pc.Asset[]|number[]} assets The array of animation assets - can also be an array of asset ids.
      * @property {number} currentTime Get or Set the current time position (in seconds) of the animation.
-     * @property {number} duration Get the duration in seconds of the current animation.
+     * @property {number} duration Get the duration in seconds of the current animation. [read only]
+     * @property {pc.Skeleton} skeleton Get the skeleton for the current model. [read only]
      */
     var AnimationComponent = function (system, entity) {
         pc.Component.call(this, system, entity);
@@ -118,16 +119,6 @@ Object.assign(pc, function () {
          */
         getAnimation: function (name) {
             return this.data.animations[name];
-        },
-
-        /**
-         * @function
-         * @name pc.AnimationComponent#getSkeleton
-         * @description Return the current skeleton.
-         * @returns {pc.Skeleton} A skeleton.
-         */
-        getSkeleton: function () {
-            return this.data.skeleton;
         },
 
         setModel: function (model) {
@@ -486,6 +477,12 @@ Object.assign(pc, function () {
         duration: {
             get: function () {
                 return this.data.animations[this.data.currAnim].duration;
+            }
+        },
+
+        skeleton: {
+            get: function () {
+                return this.data.skeleton;
             }
         }
     });

--- a/src/framework/components/animation/component.js
+++ b/src/framework/components/animation/component.js
@@ -15,7 +15,7 @@ Object.assign(pc, function () {
      * @property {number} currentTime Get or Set the current time position (in seconds) of the animation.
      * @property {number} duration Get the duration in seconds of the current animation. [read only]
      * @property {pc.Skeleton} skeleton Get or Set the skeleton for the current model.
-     * @property {Object<string, pc.Animation} animations Get or Set dictionary of animations by name.
+     * @property {Object<string, pc.Animation>} animations Get or Set dictionary of animations by name.
      */
     var AnimationComponent = function (system, entity) {
         pc.Component.call(this, system, entity);

--- a/src/framework/components/animation/component.js
+++ b/src/framework/components/animation/component.js
@@ -14,7 +14,7 @@ Object.assign(pc, function () {
      * @property {pc.Asset[]|number[]} assets The array of animation assets - can also be an array of asset ids.
      * @property {number} currentTime Get or Set the current time position (in seconds) of the animation.
      * @property {number} duration Get the duration in seconds of the current animation. [read only]
-     * @property {pc.Skeleton} skeleton Get or Set the skeleton for the current model.
+     * @property {pc.Skeleton} skeleton Get the skeleton for the current model. [read only]
      * @property {object<string, pc.Animation>} animations Get or Set dictionary of animations by name.
      */
     var AnimationComponent = function (system, entity) {

--- a/src/framework/components/animation/component.js
+++ b/src/framework/components/animation/component.js
@@ -15,7 +15,7 @@ Object.assign(pc, function () {
      * @property {number} currentTime Get or Set the current time position (in seconds) of the animation.
      * @property {number} duration Get the duration in seconds of the current animation. [read only]
      * @property {pc.Skeleton} skeleton Get or Set the skeleton for the current model.
-     * @property {Object<string, pc.Animation>} animations Get or Set dictionary of animations by name.
+     * @property {object<string, pc.Animation>} animations Get or Set dictionary of animations by name.
      */
     var AnimationComponent = function (system, entity) {
         pc.Component.call(this, system, entity);

--- a/src/framework/components/animation/component.js
+++ b/src/framework/components/animation/component.js
@@ -120,6 +120,16 @@ Object.assign(pc, function () {
             return this.data.animations[name];
         },
 
+        /**
+         * @function
+         * @name pc.AnimationComponent#getSkeleton
+         * @description Return the current skeleton.
+         * @returns {pc.Skeleton} A skeleton.
+         */
+        getSkeleton: function () {
+            return this.data.skeleton;
+        },
+
         setModel: function (model) {
             var data = this.data;
 

--- a/src/framework/components/animation/component.js
+++ b/src/framework/components/animation/component.js
@@ -14,7 +14,7 @@ Object.assign(pc, function () {
      * @property {pc.Asset[]|number[]} assets The array of animation assets - can also be an array of asset ids.
      * @property {number} currentTime Get or Set the current time position (in seconds) of the animation.
      * @property {number} duration Get the duration in seconds of the current animation. [read only]
-     * @property {pc.Skeleton} skeleton Get the skeleton for the current model. [read only]
+     * @property {pc.Skeleton|null} skeleton Get the skeleton for the current model; unless model is from glTF/glb, then skeleton is null. [read only]
      * @property {object<string, pc.Animation>} animations Get or Set dictionary of animations by name.
      */
     var AnimationComponent = function (system, entity) {

--- a/src/framework/components/animation/component.js
+++ b/src/framework/components/animation/component.js
@@ -14,7 +14,8 @@ Object.assign(pc, function () {
      * @property {pc.Asset[]|number[]} assets The array of animation assets - can also be an array of asset ids.
      * @property {number} currentTime Get or Set the current time position (in seconds) of the animation.
      * @property {number} duration Get the duration in seconds of the current animation. [read only]
-     * @property {pc.Skeleton} skeleton Get the skeleton for the current model. [read only]
+     * @property {pc.Skeleton} skeleton Get or Set the skeleton for the current model.
+     * @property {Object<string, pc.Animation} animations Get or Set dictionary of animations by name.
      */
     var AnimationComponent = function (system, entity) {
         pc.Component.call(this, system, entity);


### PR DESCRIPTION
Currently, there is no documented or type-safe way to get the `pc.Skeleton` associated with `pc.AnimationComponent`. This is necessary when exporting PlayCanvas to glTF. This PR fixes that.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
