### PR TITLE
Fix support for rendering points in standard & basic material

### DIFF
--- a/src/graphics/program-lib/basic.js
+++ b/src/graphics/program-lib/basic.js
@@ -64,6 +64,7 @@ pc.programlib.basic = {
         // VERTEX SHADER BODY
         code += pc.programlib.begin();
 
+        code += "   gl_PointSize = 1.0;\n";
         code += "   gl_Position = getPosition();\n";
 
         if (options.pass === pc.SHADER_DEPTH) {

--- a/src/graphics/program-lib/chunks/start.vert
+++ b/src/graphics/program-lib/chunks/start.vert
@@ -1,3 +1,4 @@
 
 void main(void) {
+    gl_PointSize = 1.0;
     gl_Position = getPosition();


### PR DESCRIPTION
Fixes #1972 

PR changes:
- Add `gl_PointSize = 1.0;` at the start of the vertex shader (for standard and basic material), which is required for points to be displayed. Other primitives (lines and triangles) will ignore this value in the shader.

NOTE: the point size is set to `1.0` per glTF's specification: https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#point-and-line-materials

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
