### PR TITLE
Update XR input source to better work with world/local space

### DIFF
--- a/examples/xr/vr-controllers.html
+++ b/examples/xr/vr-controllers.html
@@ -163,8 +163,8 @@
                         if (inputSource.grip) {
                             // some controllers can be gripped
                             controllers[i].enabled = true;
-                            controllers[i].setPosition(inputSource.position);
-                            controllers[i].setRotation(inputSource.rotation);
+                            controllers[i].setLocalPosition(inputSource.getLocalPosition());
+                            controllers[i].setLocalRotation(inputSource.getLocalRotation());
                         } else {
                             // some controllers cannot be gripped
                             controllers[i].enabled = false;

--- a/examples/xr/vr-movement.html
+++ b/examples/xr/vr-movement.html
@@ -239,25 +239,13 @@
                     }
 
                     // after movement and rotation is done
-                    // we can get camera parent position and rotation
-                    // to offset controller ray and model
-                    var parentPosition = cameraParent.getPosition();
-                    var parentRotation = cameraParent.getRotation();
-
-                    // then we update/render controllers
+                    // we update/render controllers
                     for(var i = 0; i < controllers.length; i++) {
                         var inputSource = controllers[i].inputSource;
 
-                        // transform ray into parent space
-                        //      position
-                        tmpVec3A.copy(inputSource.ray.origin);
-                        parentRotation.transformVector(tmpVec3A, tmpVec3A);
-                        tmpVec3A.add(parentPosition);
-                        //      rotation
-                        tmpVec3B.copy(inputSource.ray.direction);
-                        parentRotation.transformVector(tmpVec3B, tmpVec3B);
-
                         // render controller ray
+                        tmpVec3A.copy(inputSource.getOrigin());
+                        tmpVec3B.copy(inputSource.getDirection());
                         tmpVec3B.scale(100).add(tmpVec3A);
                         app.renderLine(tmpVec3A, tmpVec3B, lineColor);
 
@@ -265,8 +253,8 @@
                         if (inputSource.grip) {
                             // some controllers can be gripped
                             controllers[i].model.enabled = true;
-                            controllers[i].setLocalPosition(inputSource.position);
-                            controllers[i].setLocalRotation(inputSource.rotation);
+                            controllers[i].setLocalPosition(inputSource.getLocalPosition);
+                            controllers[i].setLocalRotation(inputSource.getLocalRotation);
                         } else {
                             // some controllers cannot be gripped
                             controllers[i].model.enabled = false;

--- a/examples/xr/xr-picking.html
+++ b/examples/xr/xr-picking.html
@@ -135,6 +135,7 @@
 
                 // when input source is triggers select
                 // pick closest box and change its color
+                var ray = new pc.Ray();
                 app.xr.input.on('select', function(inputSource) {
                     var candidate = null;
                     var candidateDist = Infinity;
@@ -143,7 +144,8 @@
                         var mesh = cubes[i].model.meshInstances[0];
 
                         // check if mesh bounding box intersects with input source ray
-                        if (mesh.aabb.intersectsRay(inputSource.ray)) {
+                        ray.set(inputSource.getOrigin(), inputSource.getDirection());
+                        if (mesh.aabb.intersectsRay(ray)) {
                             // check distance to camera
                             var dist = mesh.aabb.center.distance(c.getPosition());
 
@@ -174,10 +176,10 @@
                     for(var i = 0; i < app.xr.input.inputSources.length; i++) {
                         var inputSource = app.xr.input.inputSources[i];
 
-                        tmpVec.copy(inputSource.ray.direction);
-                        tmpVec.scale(100).add(inputSource.ray.origin);
+                        tmpVec.copy(inputSource.getDirection());
+                        tmpVec.scale(100).add(inputSource.getOrigin());
 
-                        app.renderLine(inputSource.ray.origin, tmpVec, lineColor);
+                        app.renderLine(inputSource.getOrigin(), tmpVec, lineColor);
                     }
                 });
             } else {

--- a/src/backwards-compatibility.js
+++ b/src/backwards-compatibility.js
@@ -526,3 +526,30 @@ Object.defineProperty(pc.MouseEvent.prototype, 'wheel', {
         return this.wheelDelta * -2;
     }
 });
+
+Object.defineProperty(pc.XrInputSource.prototype, 'ray', {
+    get: function () {
+        // #ifdef DEBUG
+        console.warn('DEPRECATED: pc.XrInputSource#ray is deprecated. Use pc.XrInputSource#getOrigin and pc.XrInputSource#getDirection instead.');
+        // #endif
+        return this._rayLocal;
+    }
+});
+
+Object.defineProperty(pc.XrInputSource.prototype, 'position', {
+    get: function () {
+        // #ifdef DEBUG
+        console.warn('DEPRECATED: pc.XrInputSource#position is deprecated. Use pc.XrInputSource#getLocalPosition instead.');
+        // #endif
+        return this._localPosition;
+    }
+});
+
+Object.defineProperty(pc.XrInputSource.prototype, 'rotation', {
+    get: function () {
+        // #ifdef DEBUG
+        console.warn('DEPRECATED: pc.XrInputSource#rotation is deprecated. Use pc.XrInputSource#getLocalRotation instead.');
+        // #endif
+        return this._localRotation;
+    }
+});

--- a/src/shape/ray.js
+++ b/src/shape/ray.js
@@ -20,6 +20,20 @@ Object.assign(pc, function () {
         this.direction = direction || new pc.Vec3(0, 0, -1);
     };
 
+    /**
+     * @function
+     * @name pc.Ray#set
+     * @description Sets origin and direction to the supplied vector values.
+     * @param {pc.Vec3} origin - The starting point of the ray.
+     * @param {pc.Vec3} direction - The direction of the ray.
+     * @returns {pc.Ray} Self for chaining.
+     */
+    Ray.prototype.set = function (origin, direction) {
+        this.origin.copy(origin);
+        this.direction.copy(direction);
+        return this;
+    };
+
     return {
         Ray: Ray
     };

--- a/src/xr/xr-input-source.js
+++ b/src/xr/xr-input-source.js
@@ -95,10 +95,8 @@ Object.assign(pc, function () {
         this._worldTransform = null;
         this._position = new pc.Vec3();
         this._rotation = new pc.Quat();
-        this._eulerAngles = null;
         this._localPosition = null;
         this._localRotation = null;
-        this._localEulerAngles = null;
         this._dirtyLocal = true;
 
         this._selecting = false;
@@ -197,11 +195,8 @@ Object.assign(pc, function () {
                     this._localTransform = new pc.Mat4();
                     this._worldTransform = new pc.Mat4();
 
-                    this._eulerAngles = new pc.Vec3();
-
                     this._localPosition = new pc.Vec3();
                     this._localRotation = new pc.Quat();
-                    this._localEulerAngles = new pc.Vec3();
                 }
                 this._dirtyLocal = true;
                 this._localPosition.copy(gripPose.transform.position);
@@ -315,34 +310,6 @@ Object.assign(pc, function () {
      */
     XrInputSource.prototype.getLocalRotation = function () {
         return this._localRotation;
-    };
-
-    /**
-     * @function
-     * @name pc.XrInputSource#getEulerAngles
-     * @description Get the world space rotation in euler angles of input source if it is handheld ({@link pc.XrInputSource#grip} is true). Otherwise it will return null.
-     * @returns {pc.Vec3|null} The world space rotation in euler angles of handheld input source.
-     */
-    XrInputSource.prototype.getEulerAngles = function() {
-        if (! this._eulerAngles) return null;
-
-        this._updateTransforms()
-        this._worldTransform.getEulerAngles(this._eulerAngles);
-
-        return this._eulerAngles;
-    };
-
-    /**
-     * @function
-     * @name pc.XrInputSource#getLocalEulerAngles
-     * @description Get the local space rotation in euler angles of input source if it is handheld ({@link pc.XrInputSource#grip} is true). Local space is relative to parent of the XR camera. Otherwise it will return null.
-     * @returns {pc.Vec3|null} The world space rotation in euler angles of handheld input source.
-     */
-    XrInputSource.prototype.getLocalEulerAngles = function() {
-        if (! this._localEulerAngles) return null;
-
-        this._localRotation.getEulerAngles(this._localEulerAngles);
-        return this._localEulerAngles;
     };
 
     /**

--- a/src/xr/xr-input.js
+++ b/src/xr/xr-input.js
@@ -56,8 +56,10 @@ Object.assign(pc, function () {
      * @param {pc.XrInputSource} inputSource - Input source that triggered select event
      * @param {object} evt - XRInputSourceEvent event data from WebXR API
      * @example
+     * var ray = new pc.Ray();
      * app.xr.input.on('select', function (inputSource, evt) {
-     *     if (obj.intersectsRay(inputSource.ray)) {
+     *     ray.set(inputSource.getOrigin(), inputSource.getDirection());
+     *     if (obj.intersectsRay(ray)) {
      *         // selected an object with input source
      *     }
      * });

--- a/src/xr/xr-manager.js
+++ b/src/xr/xr-manager.js
@@ -128,8 +128,8 @@ Object.assign(pc, function () {
         this._pose = null;
         this.views = [];
         this.viewsPool = [];
-        this.position = new pc.Vec3();
-        this.rotation = new pc.Quat();
+        this._localPosition = new pc.Vec3();
+        this._localRotation = new pc.Quat();
 
         this._depthNear = 0.1;
         this._depthFar = 1000;
@@ -481,8 +481,8 @@ Object.assign(pc, function () {
             // reset position
             var posePosition = this._pose.transform.position;
             var poseOrientation = this._pose.transform.orientation;
-            this.position.set(posePosition.x, posePosition.y, posePosition.z);
-            this.rotation.set(poseOrientation.x, poseOrientation.y, poseOrientation.z, poseOrientation.w);
+            this._localPosition.set(posePosition.x, posePosition.y, posePosition.z);
+            this._localRotation.set(poseOrientation.x, poseOrientation.y, poseOrientation.z, poseOrientation.w);
 
             layer = frame.session.renderState.baseLayer;
 
@@ -504,8 +504,8 @@ Object.assign(pc, function () {
         }
 
         // position and rotate camera based on calculated vectors
-        this._camera.camera._node.setLocalPosition(this.position);
-        this._camera.camera._node.setLocalRotation(this.rotation);
+        this._camera.camera._node.setLocalPosition(this._localPosition);
+        this._camera.camera._node.setLocalRotation(this._localRotation);
 
         this.input.update(frame);
 


### PR DESCRIPTION
Update XRInputSource so it has functions to get world and local position and rotation.
And changed the way Ray data is accessed.

### Rationale:
**Ray** - in most cases it is used for ray casting, entity picking, etc. And it is almost always done in world space. Previously `ray` property was in local space to reference space of XR session. Now there are two methods: `getOrigin` and `getDirection` - to get origin and direction of ray. Why we just don't transform `ray` property to world - because parent node of XR camera, can be modified since ray origin and direction was calculated. This will lead to wrong transforms.

**position/rotation** - for handheld input sources, it is common to use local and world spaces, like for positioning model for controller in local space. Or calculating distances between entities in world space. So now we have: `getPosition, getRotation` and `getLocalPosition, getLocalRotation`. Why we don't expose simply `position` and `localPosition` vectors: same as for Ray, and GraphNode - because parent might have been modified, so transform matrix has to be updated accordingly.

This change simplifies many examples, as I've noticed I had to transform Ray to world space in every case I've used it. And now model entity for controller can be child of any entity, and not strictly of same parent as XR camera.

### New APIs:
```javascript
// pc.InputSource
inputSource.getPosition(); // position in world space or null if can't be held
inputSource.getRotation(); // rotation in world space or null if can't be held
inputSource.getLocalPosition(); // position in local space or null if can't be held
inputSource.getLocalRotation(); // rotation in local space or null if can't be held
inputSource.getOrigin(); // origin of ray in world space
inputSource.getDirection(); // direction of ray in world space

// pc.Ray
ray.set(origin, direction) // shorthand for updating origin and direction
```
### Deprecated:
```javascript
// pc.InputSource
inputSource.ray // use getOrigin and getDirection instead
inputSource.position // use getLocalPosition instead
inputSource.rotation // use getLocalRotation instead
```
I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
