### PR TITLE
Skybox for Orthographic camera

### DIFF
--- a/src/graphics/program-lib/chunks/skybox.vert
+++ b/src/graphics/program-lib/chunks/skybox.vert
@@ -5,7 +5,7 @@ attribute vec3 aPosition;
 uniform mat4 matrix_view;
 #endif
 
-uniform mat4 matrix_projection_skybox;
+uniform mat4 matrix_projectionSkybox;
 
 varying vec3 vViewDir;
 
@@ -13,7 +13,7 @@ void main(void)
 {
     mat4 view = matrix_view;
     view[3][0] = view[3][1] = view[3][2] = 0.0;
-    gl_Position = matrix_projection_skybox * view * vec4(aPosition, 1.0);
+    gl_Position = matrix_projectionSkybox * view * vec4(aPosition, 1.0);
 
     // Force skybox to far Z, regardless of the clip planes on the camera
     // Subtract a tiny fudge factor to ensure floating point errors don't

--- a/src/graphics/program-lib/chunks/skybox.vert
+++ b/src/graphics/program-lib/chunks/skybox.vert
@@ -5,7 +5,7 @@ attribute vec3 aPosition;
 uniform mat4 matrix_view;
 #endif
 
-uniform mat4 matrix_projection;
+uniform mat4 matrix_projection_skybox;
 
 varying vec3 vViewDir;
 
@@ -13,7 +13,7 @@ void main(void)
 {
     mat4 view = matrix_view;
     view[3][0] = view[3][1] = view[3][2] = 0.0;
-    gl_Position = matrix_projection * view * vec4(aPosition, 1.0);
+    gl_Position = matrix_projection_skybox * view * vec4(aPosition, 1.0);
 
     // Force skybox to far Z, regardless of the clip planes on the camera
     // Subtract a tiny fudge factor to ensure floating point errors don't

--- a/src/scene/camera.js
+++ b/src/scene/camera.js
@@ -26,6 +26,7 @@ Object.assign(pc, function () {
 
         this._projMatDirty = true;
         this._projMat = new pc.Mat4();
+        this._projMatSkybox = new pc.Mat4();    // projection matrix used by skybox rendering shader is always perspective
         this._viewMatDirty = true;
         this._viewMat = new pc.Mat4();
         this._viewProjMatDirty = true;
@@ -203,21 +204,16 @@ Object.assign(pc, function () {
             return this._clearOptions;
         },
 
-        /**
-         * @private
-         * @function
-         * @name pc.Camera#getProjectionMatrix
-         * @description Retrieves the projection matrix for the specified camera.
-         * @returns {pc.Mat4} The camera's projection matrix.
-         */
-        getProjectionMatrix: function () {
+        _evaluateProjectionMatrix: function () {
             if (this._projMatDirty) {
                 if (this._projection === pc.PROJECTION_PERSPECTIVE) {
                     this._projMat.setPerspective(this._fov, this._aspect, this._nearClip, this._farClip, this._horizontalFov);
+                    this._projMatSkybox.copy(this._projMat);
                 } else {
                     var y = this._orthoHeight;
                     var x = y * this._aspect;
                     this._projMat.setOrtho(-x, x, -y, y, this._nearClip, this._farClip);
+                    this._projMatSkybox.setPerspective(90, this._aspect, this._nearClip, this._farClip);
                 }
 
                 var n = this._nearClip;
@@ -229,7 +225,23 @@ Object.assign(pc, function () {
 
                 this._projMatDirty = false;
             }
+        },
+
+        /**
+         * @private
+         * @function
+         * @name pc.Camera#getProjectionMatrix
+         * @description Retrieves the projection matrix for the specified camera.
+         * @returns {pc.Mat4} The camera's projection matrix.
+         */
+        getProjectionMatrix: function () {
+            this._evaluateProjectionMatrix();
             return this._projMat;
+        },
+
+        getProjectionMatrixSkybox: function () {
+            this._evaluateProjectionMatrix();
+            return this._projMatSkybox;
         },
 
         /**

--- a/src/scene/camera.js
+++ b/src/scene/camera.js
@@ -213,7 +213,7 @@ Object.assign(pc, function () {
                     var y = this._orthoHeight;
                     var x = y * this._aspect;
                     this._projMat.setOrtho(-x, x, -y, y, this._nearClip, this._farClip);
-                    this._projMatSkybox.setPerspective(90, this._aspect, this._nearClip, this._farClip);
+                    this._projMatSkybox.setPerspective(this._fov, this._aspect, this._nearClip, this._farClip);
                 }
 
                 var n = this._nearClip;

--- a/src/scene/forward-renderer.js
+++ b/src/scene/forward-renderer.js
@@ -371,7 +371,7 @@ Object.assign(pc, function () {
         // Uniforms
         var scope = device.scope;
         this.projId = scope.resolve('matrix_projection');
-        this.projSkyboxId = scope.resolve('matrix_projection_skybox');
+        this.projSkyboxId = scope.resolve('matrix_projectionSkybox');
         this.viewId = scope.resolve('matrix_view');
         this.viewId3 = scope.resolve('matrix_view3');
         this.viewInvId = scope.resolve('matrix_viewInverse');

--- a/src/scene/forward-renderer.js
+++ b/src/scene/forward-renderer.js
@@ -371,6 +371,7 @@ Object.assign(pc, function () {
         // Uniforms
         var scope = device.scope;
         this.projId = scope.resolve('matrix_projection');
+        this.projSkyboxId = scope.resolve('matrix_projection_skybox');
         this.viewId = scope.resolve('matrix_view');
         this.viewId3 = scope.resolve('matrix_view3');
         this.viewInvId = scope.resolve('matrix_viewInverse');
@@ -679,6 +680,9 @@ Object.assign(pc, function () {
                 projMat = camera.getProjectionMatrix();
                 if (camera.overrideCalculateProjection) camera.calculateProjection(projMat, pc.VIEW_CENTER);
                 this.projId.setValue(projMat.data);
+
+                // Skybox Projection Matrix
+                this.projSkyboxId.setValue(camera.getProjectionMatrixSkybox().data);
 
                 // ViewInverse Matrix
                 if (camera.overrideCalculateTransform) {
@@ -1769,6 +1773,7 @@ Object.assign(pc, function () {
                         // Left
                         device.setViewport(0, 0, halfWidth, device.height);
                         this.projId.setValue(projL.data);
+                        this.projSkyboxId.setValue(projL.data);
                         this.viewInvId.setValue(viewInvL.data);
                         this.viewId.setValue(viewL.data);
                         this.viewId3.setValue(viewMat3L.data);
@@ -1783,6 +1788,7 @@ Object.assign(pc, function () {
                         // Right
                         device.setViewport(halfWidth, 0, halfWidth, device.height);
                         this.projId.setValue(projR.data);
+                        this.projSkyboxId.setValue(projR.data);
                         this.viewInvId.setValue(viewInvR.data);
                         this.viewId.setValue(viewR.data);
                         this.viewId3.setValue(viewMat3R.data);
@@ -1802,6 +1808,7 @@ Object.assign(pc, function () {
                             device.setViewport(view.viewport.x, view.viewport.y, view.viewport.z, view.viewport.w);
 
                             this.projId.setValue(view.projMat.data);
+                            this.projSkyboxId.setValue(view.projMat.data);
                             this.viewId.setValue(view.viewOffMat.data);
                             this.viewInvId.setValue(view.viewInvOffMat.data);
                             this.viewId3.setValue(view.viewMat3.data);

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -1076,7 +1076,8 @@ Object.assign(pc, function () {
                     usedTex = mipTex;
             }
             material.setParameter("texture_cubeMap", usedTex);
-            material.cull = pc.CULLFACE_NONE;
+            material.cull = pc.CULLFACE_FRONT;
+            material.depthWrite = false;
 
             var skyLayer = this.layers.getLayerById(pc.LAYERID_SKYBOX);
             if (skyLayer) {


### PR DESCRIPTION
Fixes #1984

Skybox rendering changes:
- support for skybox when Orthographic camera is used. Skybox is rendered using 90 degree perspective projection matrix
- turn on back face culling and turn off depth write when rendering skybox (optimization)