### PR TITLE
Update all references of pc.AudioManager to pc.SoundManager

### DIFF
--- a/src/audio/channel.js
+++ b/src/audio/channel.js
@@ -3,14 +3,14 @@ Object.assign(pc, function () {
 
     var Channel;
 
-    if (pc.AudioManager.hasAudioContext()) {
+    if (pc.SoundManager.hasAudioContext()) {
         /**
          * @private
          * @class
          * @name pc.Channel
-         * @classdesc A channel is created when the pc.AudioManager begins playback of a pc.Sound. Usually created internally by
-         * pc.AudioManager#playSound or pc.AudioManager#playSound3d. Developers usually won't have to create Channels manually.
-         * @param {pc.AudioManager} manager - The AudioManager instance.
+         * @classdesc A channel is created when the pc.SoundManager begins playback of a pc.Sound. Usually created internally by
+         * pc.SoundManager#playSound or pc.SoundManager#playSound3d. Developers usually won't have to create Channels manually.
+         * @param {pc.SoundManager} manager - The SoundManager instance.
          * @param {pc.Sound} sound - The sound to playback.
          * @param {object} [options] - Optional options object.
          * @param {number} [options.volume=1] - The playback volume, between 0 and 1.
@@ -196,7 +196,7 @@ Object.assign(pc, function () {
                 }
             }
         });
-    } else if (pc.AudioManager.hasAudio()) {
+    } else if (pc.SoundManager.hasAudio()) {
         Channel = function (manager, sound, options) {
             this.volume = options.volume || 1;
             this.loop = options.loop || false;

--- a/src/audio/channel3d.js
+++ b/src/audio/channel3d.js
@@ -6,7 +6,7 @@ Object.assign(pc, function () {
 
     var Channel3d;
 
-    if (pc.AudioManager.hasAudioContext()) {
+    if (pc.SoundManager.hasAudioContext()) {
         Channel3d = function (manager, sound, options) {
             pc.Channel.call(this, manager, sound, options);
 
@@ -93,7 +93,7 @@ Object.assign(pc, function () {
                 }
             }
         });
-    } else if (pc.AudioManager.hasAudio()) {
+    } else if (pc.SoundManager.hasAudio()) {
         // temp vector storage
         var offset = new pc.Vec3();
 

--- a/src/backwards-compatibility.js
+++ b/src/backwards-compatibility.js
@@ -345,6 +345,8 @@ pc.AssetRegistry.prototype.getAssetById = function (id) {
     return this.get(id);
 };
 
+pc.AudioManager = pc.SoundManager;
+
 pc.GraphNode.prototype._dirtify = function (local) {
     // #ifdef DEBUG
     console.warn('DEPRECATED: pc.GraphNode#_dirtify is deprecated. Use pc.GraphNode#_dirtifyLocal or _dirtifyWorld respectively instead.');

--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -290,7 +290,7 @@ Object.assign(pc, function () {
 
         this.graphicsDevice = new pc.GraphicsDevice(canvas, options.graphicsDeviceOptions);
         this.stats = new pc.ApplicationStats(this.graphicsDevice);
-        this._audioManager = new pc.SoundManager(options);
+        this._soundManager = new pc.SoundManager(options);
         this.loader = new pc.ResourceLoader(this);
 
         // stores all entities that have been created
@@ -582,7 +582,7 @@ Object.assign(pc, function () {
         this.loader.addHandler("texture", new pc.TextureHandler(this.graphicsDevice, this.assets, this.loader));
         this.loader.addHandler("text", new pc.TextHandler());
         this.loader.addHandler("json", new pc.JsonHandler());
-        this.loader.addHandler("audio", new pc.AudioHandler(this._audioManager));
+        this.loader.addHandler("audio", new pc.AudioHandler(this._soundManager));
         this.loader.addHandler("script", new pc.ScriptHandler(this));
         this.loader.addHandler("scene", new pc.SceneHandler(this));
         this.loader.addHandler("cubemap", new pc.CubemapHandler(this.graphicsDevice, this.assets, this.loader));
@@ -611,9 +611,9 @@ Object.assign(pc, function () {
         } else {
             this.systems.add(new pc.ScriptComponentSystem(this));
         }
-        this.systems.add(new pc.AudioSourceComponentSystem(this, this._audioManager));
-        this.systems.add(new pc.SoundComponentSystem(this, this._audioManager));
-        this.systems.add(new pc.AudioListenerComponentSystem(this, this._audioManager));
+        this.systems.add(new pc.AudioSourceComponentSystem(this, this._soundManager));
+        this.systems.add(new pc.SoundComponentSystem(this, this._soundManager));
+        this.systems.add(new pc.AudioListenerComponentSystem(this, this._soundManager));
         this.systems.add(new pc.ParticleSystemComponentSystem(this));
         this.systems.add(new pc.ScreenComponentSystem(this));
         this.systems.add(new pc.ElementComponentSystem(this));
@@ -1440,9 +1440,9 @@ Object.assign(pc, function () {
          */
         onVisibilityChange: function () {
             if (this.isHidden()) {
-                this._audioManager.suspend();
+                this._soundManager.suspend();
             } else {
-                this._audioManager.resume();
+                this._soundManager.resume();
             }
         },
 
@@ -1841,9 +1841,9 @@ Object.assign(pc, function () {
 
             this.off(); // remove all events
 
-            if (this._audioManager) {
-                this._audioManager.destroy();
-                this._audioManager = null;
+            if (this._soundManager) {
+                this._soundManager.destroy();
+                this._soundManager = null;
             }
 
             pc.http = new pc.Http();

--- a/src/sound/listener.js
+++ b/src/sound/listener.js
@@ -13,7 +13,7 @@ Object.assign(pc, function () {
         this.velocity = new pc.Vec3();
         this.orientation = new pc.Mat4();
 
-        if (pc.AudioManager.hasAudioContext()) {
+        if (pc.SoundManager.hasAudioContext()) {
             this.listener = manager.context.listener;
         }
     };

--- a/src/sound/manager.js
+++ b/src/sound/manager.js
@@ -192,9 +192,6 @@ Object.assign(pc, function () {
         }
     });
 
-    // backwards compatibility
-    pc.AudioManager = SoundManager;
-
     return {
         SoundManager: SoundManager
     };


### PR DESCRIPTION
Remove all references of (deprecated) `pc.AudioManager` from the main codebase and updates them to the official naming of `pc.SoundManager`. Backwards compatibility moved to `backwards-compatibility.js`.

Closes #1063 (easier to recreate that old PR rather than resolve conflicts manually)

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
