### PR TITLE
Cloning particle emitter data API discussion

### DIFF
--- a/src/framework/components/particle-system/component.js
+++ b/src/framework/components/particle-system/component.js
@@ -582,8 +582,9 @@ Object.assign(pc, function () {
          * @function
          * @name pc.ParticleSystemComponent#prepare
          * @description Prepares the simulation. Should be used when creating many {@link pc.Particlesystem}s (such as in a pool) and called before enabling the {@link pc.Entity} where a framerate drop is allowable (e.g changing scenes).
+         * @param sourceParticleSystem (Optional) If passed, it will use it's data as a base instead of recalculating everything
          */
-        prepare: function () {
+        prepare: function (sourceParticleSystem) {
             if (!this.emitter) {
                 var data = this.data;
                 var mesh = data.mesh;
@@ -663,6 +664,12 @@ Object.assign(pc, function () {
                     node: this.entity,
                     blendType: data.blendType
                 });
+
+                if (sourceParticleSystem && sourceParticleSystem.emitter) {
+                    this.emitter.buildFrom(sourceParticleSystem.emitter);
+                } else {
+                    this.emitter.rebuild();
+                }
 
                 this.emitter.meshInstance.node = this.entity;
 

--- a/src/scene/particle-system/particle-emitter.js
+++ b/src/scene/particle-system/particle-emitter.js
@@ -773,6 +773,55 @@ Object.assign(pc, function () {
             this.colorParam = _createTexture(gd, precision, 1, packTextureRGBA(this.qColor, this.qAlpha), pc.PIXELFORMAT_R8_G8_B8_A8, 1.0, true);
         },
 
+        cloneGraphs: function (sourceEmitter) {
+            var precision = this.precision;
+            var gd = this.graphicsDevice;
+
+            this.qLocalVelocity = sourceEmitter.qLocalVelocity.slice();
+            this.qVelocity =      sourceEmitter.qVelocity.slice();
+            this.qColor =         sourceEmitter.qColor.slice();
+            this.qRotSpeed =      sourceEmitter.qRotSpeed.slice();
+            this.qScale =         sourceEmitter.qScale.slice();
+            this.qAlpha =         sourceEmitter.qAlpha.slice();
+            this.qRadialSpeed =   sourceEmitter.qRadialSpeed.slice();
+
+            this.qLocalVelocity2 = sourceEmitter.qLocalVelocity2.slice();
+            this.qVelocity2 =      sourceEmitter.qVelocity2.slice();
+            this.qColor2 =         sourceEmitter.qColor2.slice();
+            this.qRotSpeed2 =      sourceEmitter.qRotSpeed2.slice();
+            this.qScale2 =         sourceEmitter.qScale2.slice();
+            this.qAlpha2 =         sourceEmitter.qAlpha2.slice();
+            this.qRadialSpeed2 =   sourceEmitter.qRadialSpeed2.slice();
+
+            this.localVelocityUMax = sourceEmitter.localVelocityUMax.slice();
+            this.velocityUMax =      sourceEmitter.velocityUMax.slice();
+            this.colorUMax =         sourceEmitter.colorUMax.slice();
+            this.rotSpeedUMax =      sourceEmitter.rotSpeedUMax.slice();
+            this.scaleUMax =         sourceEmitter.scaleUMax.slice();
+            this.alphaUMax =         sourceEmitter.alphaUMax.slice();
+            this.radialSpeedUMax =   sourceEmitter.radialSpeedUMax.slice();
+            this.qLocalVelocityDiv = sourceEmitter.qLocalVelocityDiv.slice();
+            this.qVelocityDiv =      sourceEmitter.qVelocityDiv.slice();
+            this.qColorDiv =         sourceEmitter.qColorDiv.slice();
+            this.qRotSpeedDiv =      sourceEmitter.qRotSpeedDiv.slice();
+            this.qScaleDiv =         sourceEmitter.qScaleDiv.slice();
+            this.qAlphaDiv =         sourceEmitter.qAlphaDiv.slice();
+            this.qRadialSpeedDiv =   sourceEmitter.qRadialSpeedDiv.slice();
+
+            if (this.pack8) {
+                this.maxVel = sourceEmitter.maxVel;
+            }
+
+            if (!this.useCpu) {
+                this.internalTex0 = _createTexture(gd, precision, 1, packTextureXYZ_NXYZ(this.qLocalVelocity, this.qLocalVelocityDiv));
+                this.internalTex1 = _createTexture(gd, precision, 1, packTextureXYZ_NXYZ(this.qVelocity, this.qVelocityDiv));
+                this.internalTex2 = _createTexture(gd, precision, 1, packTexture5Floats(this.qRotSpeed, this.qScale, this.qScaleDiv, this.qRotSpeedDiv, this.qAlphaDiv));
+                this.internalTex3 = _createTexture(gd, precision, 1, packTexture2Floats(this.qRadialSpeed, this.qRadialSpeedDiv));
+            }
+            
+            this.colorParam = _createTexture(gd, precision, 1, packTextureRGBA(this.qColor, this.qAlpha), pc.PIXELFORMAT_R8_G8_B8_A8, 1.0, true);
+        }, 
+
         _initializeTextures: function () {
             if (this.colorMap) {
                 this.material.setParameter('colorMap', this.colorMap);


### PR DESCRIPTION
This is R&D in improving the performance of the particle emitter. 

By using a base emitter to clone data from, it cuts the cost by about 40%. 

150 emitters on Mac, using emitter.rebuild (old)  
```
        this.setText('Preparing the particle systems');
        startTime = performance.now();
        for (i = 0; i < this._pool.length; ++i) {
            this._pool[i].particlesystem.prepare();
        }
        endTime = performance.now();
        
        console.log('Preparing rebuild took ' + (endTime - startTime) + ' ms');
```
```
Preparing rebuild took 127.36500000028173 ms
Preparing rebuild took 98.79999999975553 ms
Preparing rebuild took 76.43499999903725 ms
Preparing rebuild took 61.49999999979627 ms
Preparing rebuild took 55.87500000183354 ms
Preparing rebuild took 52.21000000165077 ms
Preparing rebuild took 57.16499999834923 ms
Preparing rebuild took 50.15999999886844 ms
Preparing rebuild took 51.269999999931315 ms
Preparing rebuild took 49.56500000116648 ms
Preparing rebuild took 51.359999997657724 ms
Preparing rebuild took 51.78000000159955 ms
Preparing rebuild took 53.19000000235974 ms
Preparing rebuild took 49.1199999996752 ms
Preparing rebuild took 46.5650000005553 ms
Preparing rebuild took 54.38499999945634 ms
Preparing rebuild took 50.3099999987171 ms
Preparing rebuild took 50.31500000040978 ms
Preparing rebuild took 48.95500000202446 ms
Preparing rebuild took 50.19499999980326 ms
Preparing rebuild took 51.83000000033644 ms
Preparing rebuild took 49.96499999833759 ms
Preparing rebuild took 50.11000000013155 ms
Preparing rebuild took 50.54500000187545 ms
Preparing rebuild took 52.315000000817236 ms
Preparing rebuild took 49.89500000010594 ms
Preparing rebuild took 52.03500000061467 ms
```

150 emitters on Mac, emitter.buildFrom (new)
```
        this.setText('Cloning the particle systems graphs');
        
        startTime = performance.now();
        this._pool[0].particlesystem.prepare();
        for (i = 1; i < this._pool.length; ++i) {
            this._pool[i].particlesystem.prepare(this._pool[0].particlesystem);
        }
        endTime = performance.now();
        
        console.log('Cloning builds took ' + (endTime - startTime) + ' ms');
```
 ```
Cloning builds took 78.26999999815598 ms
Cloning builds took 69.42499999786378 ms
Cloning builds took 43.4400000012829 ms
Cloning builds took 50.40999999982887 ms
Cloning builds took 40.24500000014086 ms
Cloning builds took 41.40499999994063 ms
Cloning builds took 32.62499999982538 ms
Cloning builds took 36.00000000005821 ms
Cloning builds took 35.97499999887077 ms
Cloning builds took 34.33999999833759 ms
Cloning builds took 33.395000002201414 ms
Cloning builds took 30.844999997498235 ms
Cloning builds took 34.01999999914551 ms
Cloning builds took 27.64999999999418 ms
Cloning builds took 30.539999999746215 ms
Cloning builds took 29.67999999964377 ms
Cloning builds took 31.125000001338776 ms
Cloning builds took 28.350000000500586 ms
```

The question I have is how to expose this for an API in the use case of making a pool of particle emitters. The way I've done this for R&D is not great. 

I was thinking on either: 
* Having a pc.ParticleSystem#clone function that could be used to create a component clone and the user can manually attach it to an entity.
* Creating an extension function that would take an entity with a particle system component and return an array for a pool. This would allow us to wrap some of that complexity.

Open to any other thoughts on this too!

Fixes #1712 

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).

