### PR TITLE
Minor improvement of grabpass initialization

### DIFF
--- a/src/graphics/device.js
+++ b/src/graphics/device.js
@@ -960,7 +960,6 @@ Object.assign(pc, function () {
                 colorBuffer: grabPassTexture,
                 depth: false
             });
-            this.initRenderTarget(grabPassRenderTarget);
 
             this.grabPassRenderTarget = grabPassRenderTarget;
             this.grabPassTextureId = grabPassTextureId;
@@ -981,7 +980,10 @@ Object.assign(pc, function () {
 
                 var currentFrameBuffer = renderTarget ? renderTarget._glFrameBuffer : null;
                 var resolvedFrameBuffer = renderTarget ? renderTarget._glResolveFrameBuffer || renderTarget._glFrameBuffer : null;
+
+                this.initRenderTarget(this.grabPassRenderTarget);
                 var grabPassFrameBuffer = this.grabPassRenderTarget._glFrameBuffer;
+
                 gl.bindFramebuffer(gl.READ_FRAMEBUFFER, resolvedFrameBuffer);
                 gl.bindFramebuffer(gl.DRAW_FRAMEBUFFER, grabPassFrameBuffer);
                 gl.blitFramebuffer(0, 0, width, height, 0, 0, width, height, gl.COLOR_BUFFER_BIT, gl.NEAREST);


### PR DESCRIPTION
PR tweaks grabpass initialization to be lazier, so that the internal rendertarget is only initialized if and only if actually needed (instead of always). When WebGL 2 is not supported there is no need for the grabpass rendertarget.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
