### PR TITLE
Add instructions on creating sourcemap

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,11 +192,13 @@ You can develop TypeScript applications against the PlayCanvas engine. To genera
 
 This will output to build/output/playcanvas.d.ts
 
-## Generating Sourcemap
+## Generating Source Map
 
-Building the sourcemap to allow for easier debugging can be done using:
+To build the source map to allow for easier engine debugging, use the following command:
 
     npm run build -- -m
+
+This will output to build/output/playcanvas.js.map
 
 ## Getting Help
 

--- a/README.md
+++ b/README.md
@@ -192,6 +192,12 @@ You can develop TypeScript applications against the PlayCanvas engine. To genera
 
 This will output to build/output/playcanvas.d.ts
 
+## Generating Sourcemap
+
+Building the sourcemap to allow for easier debugging can be done using:
+
+    npm run build -- -m
+
 ## Getting Help
 
 [**Forums**](https://forum.playcanvas.com) - Use the forum to ask/answer questions about PlayCanvas.


### PR DESCRIPTION
Added build command on creating sourcemap to allow for easier debugging of the engine code

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
