### PR TITLE
Specular over alpha

### DIFF
--- a/src/graphics/program-lib/chunks/base.frag
+++ b/src/graphics/program-lib/chunks/base.frag
@@ -15,3 +15,8 @@ vec3 saturate(vec3 x) {
     return clamp(x, vec3(0.0), vec3(1.0));
 }
 
+float getLuminance(vec3 color) {
+    // https://en.wikipedia.org/wiki/Relative_luminance
+    return saturate(dot(color, vec3(0.2126, 0.7152, 0.0722)));
+}
+

--- a/src/graphics/program-lib/chunks/combineDiffuseSpecular.frag
+++ b/src/graphics/program-lib/chunks/combineDiffuseSpecular.frag
@@ -1,5 +1,9 @@
 vec3 combineColor() {
     vec3 combinedSpecular = dSpecularLight + dReflection.rgb * dReflection.a;
+
+    float specularOverAlpha = getLuminance(combinedSpecular * dSpecularity);
+    dAlpha = saturate(dAlpha + specularOverAlpha * specularOverAlpha);
+
     return mix(dAlbedo * dDiffuseLight, combinedSpecular, dSpecularity);
 }
 

--- a/src/graphics/program-lib/chunks/combineDiffuseSpecular.frag
+++ b/src/graphics/program-lib/chunks/combineDiffuseSpecular.frag
@@ -1,8 +1,10 @@
 vec3 combineColor() {
     vec3 combinedSpecular = dSpecularLight + dReflection.rgb * dReflection.a;
 
+#ifdef SPECULAROVERALPHA
     float specularOverAlpha = getLuminance(combinedSpecular * dSpecularity);
     dAlpha = saturate(dAlpha + specularOverAlpha * specularOverAlpha);
+#endif
 
     return mix(dAlbedo * dDiffuseLight, combinedSpecular, dSpecularity);
 }

--- a/src/graphics/program-lib/chunks/combineDiffuseSpecular.frag
+++ b/src/graphics/program-lib/chunks/combineDiffuseSpecular.frag
@@ -1,4 +1,5 @@
 vec3 combineColor() {
-    return mix(dAlbedo * dDiffuseLight, dSpecularLight + dReflection.rgb * dReflection.a, dSpecularity);
+    vec3 combinedSpecular = dSpecularLight + dReflection.rgb * dReflection.a;
+    return mix(dAlbedo * dDiffuseLight, combinedSpecular, dSpecularity);
 }
 

--- a/src/graphics/program-lib/chunks/combineDiffuseSpecularNoConserve.frag
+++ b/src/graphics/program-lib/chunks/combineDiffuseSpecularNoConserve.frag
@@ -1,5 +1,9 @@
 vec3 combineColor() {
     vec3 combinedSpecular = (dSpecularLight + dReflection.rgb * dReflection.a) * dSpecularity;
+
+    float specularOverAlpha = getLuminance(combinedSpecular);
+    dAlpha = saturate(dAlpha + specularOverAlpha * specularOverAlpha);
+
     return dAlbedo * dDiffuseLight + combinedSpecular;
 }
 

--- a/src/graphics/program-lib/chunks/combineDiffuseSpecularNoConserve.frag
+++ b/src/graphics/program-lib/chunks/combineDiffuseSpecularNoConserve.frag
@@ -1,8 +1,10 @@
 vec3 combineColor() {
     vec3 combinedSpecular = (dSpecularLight + dReflection.rgb * dReflection.a) * dSpecularity;
 
+#ifdef SPECULAROVERALPHA
     float specularOverAlpha = getLuminance(combinedSpecular);
     dAlpha = saturate(dAlpha + specularOverAlpha * specularOverAlpha);
+#endif
 
     return dAlbedo * dDiffuseLight + combinedSpecular;
 }

--- a/src/graphics/program-lib/chunks/combineDiffuseSpecularNoConserve.frag
+++ b/src/graphics/program-lib/chunks/combineDiffuseSpecularNoConserve.frag
@@ -1,4 +1,5 @@
 vec3 combineColor() {
-    return dAlbedo * dDiffuseLight + (dSpecularLight + dReflection.rgb * dReflection.a) * dSpecularity;
+    vec3 combinedSpecular = (dSpecularLight + dReflection.rgb * dReflection.a) * dSpecularity;
+    return dAlbedo * dDiffuseLight + combinedSpecular;
 }
 

--- a/src/graphics/program-lib/chunks/combineDiffuseSpecularNoRefl.frag
+++ b/src/graphics/program-lib/chunks/combineDiffuseSpecularNoRefl.frag
@@ -1,4 +1,5 @@
 vec3 combineColor() {
-    return dAlbedo * dDiffuseLight + dSpecularLight * dSpecularity;
+    vec3 combinedSpecular = dSpecularLight * dSpecularity;
+    return dAlbedo * dDiffuseLight + combinedSpecular;
 }
 

--- a/src/graphics/program-lib/chunks/combineDiffuseSpecularNoRefl.frag
+++ b/src/graphics/program-lib/chunks/combineDiffuseSpecularNoRefl.frag
@@ -1,8 +1,10 @@
 vec3 combineColor() {
     vec3 combinedSpecular = dSpecularLight * dSpecularity;
 
+#ifdef SPECULAROVERALPHA
     float specularOverAlpha = getLuminance(combinedSpecular);
     dAlpha = saturate(dAlpha + specularOverAlpha * specularOverAlpha);
+#endif
 
     return dAlbedo * dDiffuseLight + combinedSpecular;
 }

--- a/src/graphics/program-lib/chunks/combineDiffuseSpecularNoRefl.frag
+++ b/src/graphics/program-lib/chunks/combineDiffuseSpecularNoRefl.frag
@@ -1,5 +1,9 @@
 vec3 combineColor() {
     vec3 combinedSpecular = dSpecularLight * dSpecularity;
+
+    float specularOverAlpha = getLuminance(combinedSpecular);
+    dAlpha = saturate(dAlpha + specularOverAlpha * specularOverAlpha);
+
     return dAlbedo * dDiffuseLight + combinedSpecular;
 }
 

--- a/src/graphics/program-lib/chunks/combineDiffuseSpecularNoReflSeparateAmbient.frag
+++ b/src/graphics/program-lib/chunks/combineDiffuseSpecularNoReflSeparateAmbient.frag
@@ -2,8 +2,10 @@ uniform vec3 material_ambient;
 vec3 combineColor() {
     vec3 combinedSpecular = dSpecularLight * dSpecularity;
 
+#ifdef SPECULAROVERALPHA
     float specularOverAlpha = getLuminance(combinedSpecular);
     dAlpha = saturate(dAlpha + specularOverAlpha * specularOverAlpha);
+#endif
 
     return (dDiffuseLight - light_globalAmbient) * dAlbedo + combinedSpecular + material_ambient * light_globalAmbient;
 }

--- a/src/graphics/program-lib/chunks/combineDiffuseSpecularNoReflSeparateAmbient.frag
+++ b/src/graphics/program-lib/chunks/combineDiffuseSpecularNoReflSeparateAmbient.frag
@@ -1,5 +1,6 @@
 uniform vec3 material_ambient;
 vec3 combineColor() {
-    return (dDiffuseLight - light_globalAmbient) * dAlbedo + dSpecularLight * dSpecularity + material_ambient * light_globalAmbient;
+    vec3 combinedSpecular = dSpecularLight * dSpecularity;
+    return (dDiffuseLight - light_globalAmbient) * dAlbedo + combinedSpecular + material_ambient * light_globalAmbient;
 }
 

--- a/src/graphics/program-lib/chunks/combineDiffuseSpecularNoReflSeparateAmbient.frag
+++ b/src/graphics/program-lib/chunks/combineDiffuseSpecularNoReflSeparateAmbient.frag
@@ -1,6 +1,10 @@
 uniform vec3 material_ambient;
 vec3 combineColor() {
     vec3 combinedSpecular = dSpecularLight * dSpecularity;
+
+    float specularOverAlpha = getLuminance(combinedSpecular);
+    dAlpha = saturate(dAlpha + specularOverAlpha * specularOverAlpha);
+
     return (dDiffuseLight - light_globalAmbient) * dAlbedo + combinedSpecular + material_ambient * light_globalAmbient;
 }
 

--- a/src/graphics/program-lib/chunks/combineDiffuseSpecularOld.frag
+++ b/src/graphics/program-lib/chunks/combineDiffuseSpecularOld.frag
@@ -1,8 +1,10 @@
 vec3 combineColor() {
     vec3 combinedSpecular = dSpecularLight * dSpecularity;
 
+#ifdef SPECULAROVERALPHA
     float specularOverAlpha = getLuminance(mix(combinedSpecular, dReflection.rgb, dReflection.a));
     dAlpha = saturate(dAlpha + specularOverAlpha * specularOverAlpha);
+#endif
 
     return mix(dAlbedo * dDiffuseLight + combinedSpecular, dReflection.rgb, dReflection.a);
 }

--- a/src/graphics/program-lib/chunks/combineDiffuseSpecularOld.frag
+++ b/src/graphics/program-lib/chunks/combineDiffuseSpecularOld.frag
@@ -1,4 +1,5 @@
 vec3 combineColor() {
-    return mix(dAlbedo * dDiffuseLight + dSpecularLight * dSpecularity, dReflection.rgb, dReflection.a);
+    vec3 combinedSpecular = dSpecularLight * dSpecularity;
+    return mix(dAlbedo * dDiffuseLight + combinedSpecular, dReflection.rgb, dReflection.a);
 }
 

--- a/src/graphics/program-lib/chunks/combineDiffuseSpecularOld.frag
+++ b/src/graphics/program-lib/chunks/combineDiffuseSpecularOld.frag
@@ -1,5 +1,9 @@
 vec3 combineColor() {
     vec3 combinedSpecular = dSpecularLight * dSpecularity;
+
+    float specularOverAlpha = getLuminance(mix(combinedSpecular, dReflection.rgb, dReflection.a));
+    dAlpha = saturate(dAlpha + specularOverAlpha * specularOverAlpha);
+
     return mix(dAlbedo * dDiffuseLight + combinedSpecular, dReflection.rgb, dReflection.a);
 }
 

--- a/src/graphics/program-lib/standard.js
+++ b/src/graphics/program-lib/standard.js
@@ -879,6 +879,10 @@ pc.programlib.standard = {
         var codeBegin = code;
         code = "";
 
+        if (options.useSpecularOverAlpha) {
+            code += '#define SPECULAROVERALPHA 1\n';
+        }
+
         if (options.clearCoat > 0) {
             code += '#define CLEARCOAT 1\n';
         }

--- a/src/scene/materials/standard-material-options-builder.js
+++ b/src/scene/materials/standard-material-options-builder.js
@@ -103,6 +103,7 @@ Object.assign(pc, function () {
         options.dpAtlas = !!stdMat.dpAtlas;
         options.ambientSH = !!stdMat.ambientSH;
         options.useSpecular = useSpecular;
+        options.useSpecularOverAlpha = stdMat.useSpecularOverAlpha;
         options.emissiveFormat = stdMat.emissiveMap ? (stdMat.emissiveMap.rgbm ? 1 : (stdMat.emissiveMap.format === pc.PIXELFORMAT_RGBA32F ? 2 : 0)) : null;
         options.lightMapFormat = stdMat.lightMap ? (stdMat.lightMap.rgbm ? 1 : (stdMat.lightMap.format === pc.PIXELFORMAT_RGBA32F ? 2 : 0)) : null;
         options.specularAntialias = stdMat.specularAntialias && (!!stdMat.normalMap) && (!!stdMat.normalMap.mipmaps) && !isPackedNormalMap;

--- a/src/scene/materials/standard-material-parameters.js
+++ b/src/scene/materials/standard-material-parameters.js
@@ -143,6 +143,7 @@
         useLighting: 'boolean',
         useSkybox: 'boolean',
         useGammaTonemap: 'boolean',
+        useSpecularOverAlpha: 'boolean',
 
         prefilteredCubeMap128: 'texture',
         prefilteredCubeMap64: 'texture',

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -183,6 +183,8 @@ Object.assign(pc, function () {
      * @property {boolean} useLighting Apply lighting
      * @property {boolean} useSkybox Apply scene skybox as prefiltered environment map
      * @property {boolean} useGammaTonemap Apply gamma correction and tonemapping (as configured in scene settings)
+     * @property {boolean} useSpecularOverAlpha Keep specular highlights on a transparent surface.
+     * For example, the spot on a glass surface where the sun reflects, is less transparent than the overall surface.
      * @property {boolean} pixelSnap Align vertices to pixel co-ordinates when rendering. Useful for pixel perfect 2D graphics
      * @property {boolean} twoSidedLighting Calculate proper normals (and therefore lighting) on backfaces
      * @property {object} chunks Object containing custom shader chunks that will replace default ones.
@@ -1055,6 +1057,7 @@ Object.assign(pc, function () {
         _defineFlag(obj, "useFog", true);
         _defineFlag(obj, "useLighting", true);
         _defineFlag(obj, "useGammaTonemap", true);
+        _defineFlag(obj, "useSpecularOverAlpha", false);
         _defineFlag(obj, "useSkybox", true);
         _defineFlag(obj, "forceUv1", false);
         _defineFlag(obj, "pixelSnap", false);


### PR DESCRIPTION
Fixes #2018

PR changes:
- Add new property `pc.StandardMaterial#useSpecularOverAlpha` (default value: `false`)
- Define macro `SPECULAROVERALPHA` in frag shader when `useSpecularOverAlpha` enabled
- Calculate `specularOverAlpha` term differently based on specular mode (`combineDiffuse*.frag`)
- Increase `dAlpha` with `specularOverAlpha` squared (gives best visual result)
- Add shader utility function `getLuminance` (in `base.frag`)


----

All changes have been tested using a [public PlayCanvas project](https://playcanvas.com/project/681384/overview/specular-over-alpha-test) (simply run it with and without the PR):

### With PR:
![image](https://user-images.githubusercontent.com/255073/80316749-d0efad00-87ff-11ea-9ee4-bef8b2c830be.png)
(Press SPACE, double-click, or double-tap to toggle `useSpecularOverAlpha` on and off)



### Without PR:
![image](https://user-images.githubusercontent.com/255073/80316753-d64cf780-87ff-11ea-868c-0e27fe13115d.png)




I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
