### PR TITLE
Mesh API fix

### DIFF
--- a/src/graphics/index-buffer.js
+++ b/src/graphics/index-buffer.js
@@ -199,7 +199,7 @@ Object.assign(pc, function () {
             var indices = this._lockTypedArray();
             var count = this.numIndices;
 
-            if (ArrayBuffer.isView(data)) {
+            if (ArrayBuffer.isView(data.buffer)) {
                 // destination data is typed array
                 data.set(indices);
             } else {

--- a/src/graphics/index-buffer.js
+++ b/src/graphics/index-buffer.js
@@ -199,7 +199,7 @@ Object.assign(pc, function () {
             var indices = this._lockTypedArray();
             var count = this.numIndices;
 
-            if (ArrayBuffer.isView(data.buffer)) {
+            if (ArrayBuffer.isView(data)) {
                 // destination data is typed array
                 data.set(indices);
             } else {

--- a/src/graphics/vertex-iterator.js
+++ b/src/graphics/vertex-iterator.js
@@ -378,7 +378,7 @@ Object.assign(pc, function () {
                         offset += element.stride;
                     }
                 } else {
-                    if (ArrayBuffer.isView(data.buffer)) {
+                    if (ArrayBuffer.isView(data)) {
                         // destination data is typed array
                         data.set(element.array);
                     } else {


### PR DESCRIPTION
- reverting last minute change - we’re checking if underlaying array is typed array