### PR TITLE
small fixes for safari

### DIFF
--- a/src/graphics/vertex-iterator.js
+++ b/src/graphics/vertex-iterator.js
@@ -59,25 +59,25 @@ Object.assign(pc, function () {
 
         switch (vertexElement.dataType) {
             case pc.TYPE_INT8:
-                this.array = new Int8Array(buffer, vertexElement.offset, bufferLength);
+                this.array = bufferLength ? new Int8Array(buffer, vertexElement.offset, bufferLength) : new Int8Array(buffer, vertexElement.offset);
                 break;
             case pc.TYPE_UINT8:
-                this.array = new Uint8Array(buffer, vertexElement.offset, bufferLength);
+                this.array = bufferLength ? new Uint8Array(buffer, vertexElement.offset, bufferLength) : new Uint8Array(buffer, vertexElement.offset);
                 break;
             case pc.TYPE_INT16:
-                this.array = new Int16Array(buffer, vertexElement.offset, bufferLength);
+                this.array = bufferLength ? new Int16Array(buffer, vertexElement.offset, bufferLength) : new Int16Array(buffer, vertexElement.offset);
                 break;
             case pc.TYPE_UINT16:
-                this.array = new Uint16Array(buffer, vertexElement.offset, bufferLength);
+                this.array = bufferLength ? new Uint16Array(buffer, vertexElement.offset, bufferLength) : new Uint16Array(buffer, vertexElement.offset);
                 break;
             case pc.TYPE_INT32:
-                this.array = new Int32Array(buffer, vertexElement.offset, bufferLength);
+                this.array = bufferLength ? new Int32Array(buffer, vertexElement.offset, bufferLength) : new Int32Array(buffer, vertexElement.offset);
                 break;
             case pc.TYPE_UINT32:
-                this.array = new Uint32Array(buffer, vertexElement.offset, bufferLength);
+                this.array = bufferLength ? new Uint32Array(buffer, vertexElement.offset, bufferLength) : new Uint32Array(buffer, vertexElement.offset);
                 break;
             case pc.TYPE_FLOAT32:
-                this.array = new Float32Array(buffer, vertexElement.offset, bufferLength);
+                this.array = bufferLength ? new Float32Array(buffer, vertexElement.offset, bufferLength) : new Float32Array(buffer, vertexElement.offset);
                 break;
         }
 

--- a/src/graphics/vertex-iterator.js
+++ b/src/graphics/vertex-iterator.js
@@ -52,33 +52,12 @@ Object.assign(pc, function () {
         this.index = 0;
         this.numComponents = vertexElement.numComponents;
 
-        // map only section of underlaying buffer for non-interleaved format
-        var bufferLength;
-        if (!vertexFormat.interleaved)
-            bufferLength = vertexFormat.vertexCount * vertexElement.numComponents;
-
-        switch (vertexElement.dataType) {
-            case pc.TYPE_INT8:
-                this.array = bufferLength ? new Int8Array(buffer, vertexElement.offset, bufferLength) : new Int8Array(buffer, vertexElement.offset);
-                break;
-            case pc.TYPE_UINT8:
-                this.array = bufferLength ? new Uint8Array(buffer, vertexElement.offset, bufferLength) : new Uint8Array(buffer, vertexElement.offset);
-                break;
-            case pc.TYPE_INT16:
-                this.array = bufferLength ? new Int16Array(buffer, vertexElement.offset, bufferLength) : new Int16Array(buffer, vertexElement.offset);
-                break;
-            case pc.TYPE_UINT16:
-                this.array = bufferLength ? new Uint16Array(buffer, vertexElement.offset, bufferLength) : new Uint16Array(buffer, vertexElement.offset);
-                break;
-            case pc.TYPE_INT32:
-                this.array = bufferLength ? new Int32Array(buffer, vertexElement.offset, bufferLength) : new Int32Array(buffer, vertexElement.offset);
-                break;
-            case pc.TYPE_UINT32:
-                this.array = bufferLength ? new Uint32Array(buffer, vertexElement.offset, bufferLength) : new Uint32Array(buffer, vertexElement.offset);
-                break;
-            case pc.TYPE_FLOAT32:
-                this.array = bufferLength ? new Float32Array(buffer, vertexElement.offset, bufferLength) : new Float32Array(buffer, vertexElement.offset);
-                break;
+        // create the typed array based on the element data type
+        var typesMap = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array, Float32Array];
+        if (vertexFormat.interleaved) {
+            this.array = new typesMap[vertexElement.dataType](buffer, vertexElement.offset);
+        } else {
+            this.array = new typesMap[vertexElement.dataType](buffer, vertexElement.offset, vertexFormat.vertexCount * vertexElement.numComponents);
         }
 
         // BYTES_PER_ELEMENT is on the instance and constructor for Chrome, Safari and Firefox, but just the constructor for Opera

--- a/src/graphics/vertex-iterator.js
+++ b/src/graphics/vertex-iterator.js
@@ -1,6 +1,9 @@
 Object.assign(pc, function () {
     'use strict';
 
+    // map of engine pc.TYPE_*** enums to their corresponding typed array constructors
+    var typesMap = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array, Float32Array];
+
     /**
      * @class
      * @name pc.VertexIteratorAccessor

--- a/src/graphics/vertex-iterator.js
+++ b/src/graphics/vertex-iterator.js
@@ -56,7 +56,6 @@ Object.assign(pc, function () {
         this.numComponents = vertexElement.numComponents;
 
         // create the typed array based on the element data type
-        var typesMap = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array, Float32Array];
         if (vertexFormat.interleaved) {
             this.array = new typesMap[vertexElement.dataType](buffer, vertexElement.offset);
         } else {

--- a/src/scene/mesh.js
+++ b/src/scene/mesh.js
@@ -459,7 +459,7 @@ Object.assign(pc, function () {
                 var streamIndices = this._geometryData.indices;
                 count = this._geometryData.indexCount;
 
-                if (ArrayBuffer.isView(data)) {
+                if (ArrayBuffer.isView(indices)) {
                     // destination data is typed array
                     indices.set(streamIndices);
                 } else {


### PR DESCRIPTION
For some reason safari fails when passing an undefined or null parameter to the typed array constructor.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
