### PR TITLE
Glb morph fix

### DIFF
--- a/src/resources/parser/glb-parser.js
+++ b/src/resources/parser/glb-parser.js
@@ -598,6 +598,8 @@ Object.assign(pc, function () {
                     if (meshData.hasOwnProperty('extras') &&
                         meshData.extras.hasOwnProperty('targetNames')) {
                         options.name = meshData.extras.targetNames[index];
+                    } else {
+                        options.name = targets.length.toString(10);
                     }
 
                     targets.push(new pc.MorphTarget(options));


### PR DESCRIPTION
In the case a glb morph target hasn't been named, we name it by its index.


I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
