### PR TITLE
Small compatibility change

### DIFF
--- a/src/graphics/vertex-iterator.js
+++ b/src/graphics/vertex-iterator.js
@@ -286,7 +286,6 @@ Object.assign(pc, function () {
         end: function () {
             // Unlock the vertex buffer
             this.vertexBuffer.unlock();
-            this.vertexBuffer = null;
         },
 
         // Copies data for specified semantic into vertex buffer.


### PR DESCRIPTION
VertexAccessor is not setting vertexBuffer to null in .End