### PR TITLE
Enhancement: Access to the pc.scriptType's name (with Typescript typings)

### DIFF
--- a/src/script/script-type.js
+++ b/src/script/script-type.js
@@ -91,6 +91,20 @@ Object.assign(pc, function () {
      * @field
      * @static
      * @readonly
+     * @name pc.ScriptType.scriptName
+     * @type {string|null}
+     * @description Name of a Script Type
+     */
+    Object.defineProperty(ScriptType, 'scriptName', {
+        get: function () {
+            return this.__name;
+        }
+    });
+
+    /**
+     * @field
+     * @static
+     * @readonly
      * @name pc.ScriptType.attributes
      * @type {pc.ScriptAttributes}
      * @description The interface to define attributes for Script Types. Refer to {@link pc.ScriptAttributes}.


### PR DESCRIPTION
Fixes: https://github.com/playcanvas/engine/issues/2014

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
