### PR TITLE
[FIX] Don't free raycast structures twice

### DIFF
--- a/src/framework/components/rigid-body/system.js
+++ b/src/framework/components/rigid-body/system.js
@@ -298,9 +298,6 @@ Object.assign(pc, function () {
                         new pc.Vec3(normal.x(), normal.y(), normal.z())
                     );
 
-                    Ammo.destroy(point);
-                    Ammo.destroy(normal);
-
                     // keeping for backwards compatibility
                     if (arguments.length > 2) {
                         var callback = arguments[2];
@@ -362,9 +359,6 @@ Object.assign(pc, function () {
                         results.push(result);
                     }
                 }
-
-                Ammo.destroy(points);
-                Ammo.destroy(normals);
             }
 
             Ammo.destroy(rayCallback);


### PR DESCRIPTION
Raycast functions were attempting to destroy/free statically allocated structures within a structure (`RayResultCallback`) that is itself destroyed a few lines later.

Fixes #2038 

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
