### PR TITLE
More generic mesh batching

### DIFF
--- a/src/graphics/graphics.js
+++ b/src/graphics/graphics.js
@@ -1040,6 +1040,14 @@
 
     Object.assign(pc, enums);
 
+    // map of engine pc.TYPE_*** enums to their corresponding typed array constructors and byte sizes
+    pc.typedArrayTypes = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array, Float32Array];
+    pc.typedArrayTypesByteSize = [1, 1, 2, 2, 4, 4, 4];
+
+    // map of engine pc.INDEXFORMAT_*** to their corresponding typed array constructors and byte sizes
+    pc.typedArrayIndexFormats = [Uint8Array, Uint16Array, Uint32Array];
+    pc.typedArrayIndexFormatsByteSize = [1, 2, 4];
+
     // For backwards compatibility
     pc.gfx = {};
     Object.assign(pc.gfx, enums);

--- a/src/graphics/vertex-format.js
+++ b/src/graphics/vertex-format.js
@@ -177,6 +177,8 @@ Object.assign(pc, function () {
         if (vertexCount) {
             this.verticesByteSize = offset;
         }
+
+        this.batchingHash = this._evaluateBatchingHash();
     };
 
     VertexFormat.init = function (graphicsDevice) {
@@ -204,6 +206,32 @@ Object.assign(pc, function () {
                 return this._defaultInstancingFormat;
             };
         }())
+    });
+
+    Object.assign(VertexFormat.prototype, {
+
+        // evaluates hash value for the format allowing fast compare of batching compatibility
+        _evaluateBatchingHash: function () {
+
+            // create string description of each element that is relevant for batching
+            var stringElement, stringElements = [];
+            var i, len = this.elements.length, element;
+            for (i = 0; i < len; i++) {
+                element = this.elements[i];
+
+                stringElement = element.name;
+                stringElement += element.dataType;
+                stringElement += element.numComponents;
+                stringElement += element.normalize;
+
+                stringElements.push(stringElement);
+            }
+
+            // sort them alphabetically to make hash order independent
+            stringElements.sort();
+
+            return pc.hashCode(stringElements.join());
+        }
     });
 
     return {

--- a/src/graphics/vertex-iterator.js
+++ b/src/graphics/vertex-iterator.js
@@ -348,7 +348,7 @@ Object.assign(pc, function () {
                     // extract data from interleaved buffer by looping over vertices and copying them manually
                     if  (Array.isArray(data))
                         data.length = 0;
-                        
+
                     element.index = 0;
                     var offset = 0;
                     for (i = 0; i < count; i++) {

--- a/src/graphics/vertex-iterator.js
+++ b/src/graphics/vertex-iterator.js
@@ -346,7 +346,9 @@ Object.assign(pc, function () {
                 if (this.vertexBuffer.getFormat().interleaved) {
 
                     // extract data from interleaved buffer by looping over vertices and copying them manually
-                    data.length = 0;
+                    if  (Array.isArray(data))
+                        data.length = 0;
+                        
                     element.index = 0;
                     var offset = 0;
                     for (i = 0; i < count; i++) {

--- a/src/graphics/vertex-iterator.js
+++ b/src/graphics/vertex-iterator.js
@@ -1,9 +1,6 @@
 Object.assign(pc, function () {
     'use strict';
 
-    // map of engine pc.TYPE_*** enums to their corresponding typed array constructors
-    var typesMap = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array, Float32Array];
-
     /**
      * @class
      * @name pc.VertexIteratorAccessor
@@ -57,9 +54,9 @@ Object.assign(pc, function () {
 
         // create the typed array based on the element data type
         if (vertexFormat.interleaved) {
-            this.array = new typesMap[vertexElement.dataType](buffer, vertexElement.offset);
+            this.array = new pc.typedArrayTypes[vertexElement.dataType](buffer, vertexElement.offset);
         } else {
-            this.array = new typesMap[vertexElement.dataType](buffer, vertexElement.offset, vertexFormat.vertexCount * vertexElement.numComponents);
+            this.array = new pc.typedArrayTypes[vertexElement.dataType](buffer, vertexElement.offset, vertexFormat.vertexCount * vertexElement.numComponents);
         }
 
         // BYTES_PER_ELEMENT is on the instance and constructor for Chrome, Safari and Firefox, but just the constructor for Opera
@@ -344,12 +341,11 @@ Object.assign(pc, function () {
             var count = 0;
             if (element) {
                 count = this.vertexBuffer.numVertices;
-                var i;
+                var i, numComponents = element.numComponents;
 
                 if (this.vertexBuffer.getFormat().interleaved) {
 
                     // extract data from interleaved buffer by looping over vertices and copying them manually
-                    var numComponents = element.numComponents;
                     data.length = 0;
                     element.index = 0;
                     var offset = 0;
@@ -364,7 +360,8 @@ Object.assign(pc, function () {
                     } else {
                         // destination data is array
                         data.length = 0;
-                        for (i = 0; i < count; i++)
+                        var copyCount = count * numComponents;
+                        for (i = 0; i < copyCount; i++)
                             data[i] = element.array[i];
                     }
                 }

--- a/src/scene/mesh.js
+++ b/src/scene/mesh.js
@@ -35,16 +35,23 @@ Object.assign(pc, function () {
             this.indices = null;
         },
 
+        _validateVertexCount: function (count, semantic) {
+
+            // #ifdef DEBUG
+            if (this.vertexCount !== count) {
+                console.error("Vertex stream " + semantic + " has " + count + " vertices, which does not match already set streams with " + this.vertexCount + " vertices.");
+            }
+            // #endif
+        },
+
         // function called when vertex stream is requested to be updated, and validates / updates currently used vertex count
         _changeVertexCount: function (count, semantic) {
 
             // update vertex count and validate it with existing streams
             if (!this.vertexCount) {
                 this.vertexCount = count;
-            } else if (this.vertexCount !== count) {
-                // #ifdef DEBUG
-                console.error("Vertex stream " + semantic + " has " + count + " vertices, which does not match already set streams with " + this.vertexCount + " vertices.");
-                // #endif
+            } else {
+                this._validateVertexCount(count, semantic);
             }
         }
     });
@@ -101,6 +108,11 @@ Object.assign(pc, function () {
      * mesh.setIndices(indices);
      * mesh.update();
      * ~~~
+     *
+     * This example demonstrated that vertex attributes such as position and normals, and also indices can be provided using Arrays ([]) and also Typed Arrays
+     * (Float32Array and similar). Note that typed arrays have higher performance, and are generaly recommended for per-frame operations or larger meshes,
+     * but their construction using new operator is costly operation. If you only need to operate on small number of vertices or indices, consider using the
+     * Arrays instead to avoid Type Array allocation overhead.
      *
      * Follow these links for more complex examples showing the functionality.
      * * {@link http://playcanvas.github.io/#graphics/mesh-decals.html}


### PR DESCRIPTION
**Batching code changes implemented using new Mesh API**
- simpler and easier to maintain code
- supports any vertex streams instead of just few common types
- supports batching meshes with interleaved and non-interleaved vertex formats
- supports batching meshes with different index buffer formats
- generates non-interleaved meshes
- about 20% slower due to copying using intermediate buffers instead of VB to VB directly

**Other changes**
- fix to VertexIterator.readData when non-interleaved vertex stream was copied to Array
- Graphics - exposed corresponding TypedArray and byteSize for pc.TYPE_*** and pc.INDEXFORMAT_*** enums to avoid switch statements in code