### PR TITLE
[FIX] glTF parser not handling vertex attributes that need normalizing

### DIFF
--- a/src/resources/parser/glb-parser.js
+++ b/src/resources/parser/glb-parser.js
@@ -254,7 +254,8 @@ Object.assign(pc, function () {
                     vertexDesc.push({
                         semantic: semantic,
                         components: getNumComponents(accessor.type),
-                        type: getComponentType(accessor.componentType)
+                        type: getComponentType(accessor.componentType),
+                        normalize: accessor.normalized
                     });
                     // store the info we'll need to copy this data into the vertex buffer
                     var size = getNumComponents(accessor.type) * getComponentSizeInBytes(accessor.componentType);


### PR DESCRIPTION
Fixes #2053

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
