### PR TITLE
Draco decompression uses normalized flag from attribute

### DIFF
--- a/src/resources/parser/glb-parser.js
+++ b/src/resources/parser/glb-parser.js
@@ -332,7 +332,8 @@ Object.assign(pc, function () {
                 values: values,
                 numComponents: attribute.num_components(),
                 componentSizeInBytes: componentSizeInBytes,
-                storageType: storageType
+                storageType: storageType,
+                normalized: attribute.normalized()
             };
         };
 
@@ -350,7 +351,7 @@ Object.assign(pc, function () {
                     semantic: semantic,
                     components: attributeInfo.numComponents,
                     type: attributeInfo.storageType,
-                    normalize: semanticMap[attrib].normalize
+                    normalize: attributeInfo.normalized
                 });
 
                 // store the info we'll need to copy this data into the vertex buffer


### PR DESCRIPTION
related to #2053 but for draco compressed meshes.
testing needs to wait for when our pipeline can write meshes in this format. I've tried to convert mentioned mesh to draco using gltf-pipeline, but it gets stored as 16bit per component color stream, and normalize() on that attribute returns false.