### PR TITLE
Particle world bounds cpu fix

### DIFF
--- a/src/scene/particle-system/particle-emitter.js
+++ b/src/scene/particle-system/particle-emitter.js
@@ -384,15 +384,18 @@ Object.assign(pc, function () {
             this.prevWorldBoundsSize.copy(this.worldBoundsSize);
             this.prevWorldBoundsCenter.copy(this.worldBounds.center);
 
-            var recalculateLocalBounds = false;
-            if (this.emitterShape === pc.EMITTERSHAPE_BOX) {
-                recalculateLocalBounds = !this.emitterExtents.equals(this.prevEmitterExtents);
-            } else {
-                recalculateLocalBounds = !(this.emitterRadius === this.prevEmitterRadius);
+            if (!this.useCpu) {
+                var recalculateLocalBounds = false;
+                if (this.emitterShape === pc.EMITTERSHAPE_BOX) {
+                    recalculateLocalBounds = !this.emitterExtents.equals(this.prevEmitterExtents);
+                } else {
+                    recalculateLocalBounds = !(this.emitterRadius === this.prevEmitterRadius);
+                }
+                if (recalculateLocalBounds) {
+                    this.calculateLocalBounds();
+                }
             }
-            if (recalculateLocalBounds) {
-                this.calculateLocalBounds();
-            }
+
 
             var nodeWT = this.node.getWorldTransform();
             if (this.localSpace) {
@@ -1088,9 +1091,7 @@ Object.assign(pc, function () {
 
             this.simTimeTotal += delta;
 
-            if (!this.useCpu) {
-                this.calculateWorldBounds();
-            }
+            this.calculateWorldBounds();
 
             if (this._isAnimated()) {
                 var tilesParams = this.animTilesParams;


### PR DESCRIPTION
Resolves the issue found by @yaustar where world bounds are not recalculated when using the cpu pathway.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
