### PR TITLE
Add new compound collision example

### DIFF
--- a/examples/examples.js
+++ b/examples/examples.js
@@ -60,6 +60,7 @@ var categories = [
     }, {
         name: "physics",
         examples: [
+            "compound-collision",
             "falling-shapes",
             "raycast"
         ]

--- a/examples/physics/compound-collision.html
+++ b/examples/physics/compound-collision.html
@@ -55,10 +55,12 @@
             return material;
         }
 
-        // create a few materials for our objects
+        // Create a couple of materials for our objects
         var red = createMaterial(new pc.Color(1, 0.3, 0.3));
         var gray = createMaterial(new pc.Color(0.7, 0.7, 0.7));
 
+        // Define a scene hierarchy in JSON format. This is loaded/parsed in
+        // the parseScene function below
         var scene = [
             {
                 // The Chair entity has a collision component of type 'compound' and a
@@ -109,7 +111,7 @@
                                         }
                                     }
                                 ]
-                            }                        
+                            }
                         ]
                     }, {
                         name: 'Seat Back',
@@ -136,7 +138,7 @@
                                         }
                                     }
                                 ]
-                            }                        
+                            }
                         ]
                     }, {
                         name: 'Leg 1',
@@ -164,7 +166,7 @@
                                         }
                                     }
                                 ]
-                            }                        
+                            }
                         ]
                     }, {
                         name: 'Leg 2',
@@ -192,7 +194,7 @@
                                         }
                                     }
                                 ]
-                            }                        
+                            }
                         ]
                     }, {
                         name: 'Leg 3',
@@ -220,7 +222,7 @@
                                         }
                                     }
                                 ]
-                            }                        
+                            }
                         ]
                     }, {
                         name: 'Leg 4',
@@ -248,7 +250,7 @@
                                         }
                                     }
                                 ]
-                            }                        
+                            }
                         ]
                     }
                 ]
@@ -283,7 +285,7 @@
                                 }
                             }
                         ]
-                    }                        
+                    }
                 ]
             }, {
                 name: 'Directional Light',

--- a/examples/physics/compound-collision.html
+++ b/examples/physics/compound-collision.html
@@ -47,11 +47,11 @@
 
         app.scene.ambientLight = new pc.Color(0.2, 0.2, 0.2);
 
-        function createMaterial (color) {
+        function createMaterial(color) {
             var material = new pc.StandardMaterial();
             material.diffuse = color;
-            // we need to call material.update when we change its properties
             material.update()
+
             return material;
         }
 
@@ -61,6 +61,11 @@
 
         var scene = [
             {
+                // The Chair entity has a collision component of type 'compound' and a
+                // rigidbody component. This means that any descendent entity with a
+                // collision component is added to a compound collision shape on the
+                // Chair entity. You can use compound collision shapes to define
+                // complex, rigid shapes.
                 name: 'Chair',
                 pos: [0, 1, 0],
                 components: [
@@ -290,7 +295,7 @@
                             type: 'directional',
                             castShadows: true,
                             shadowDistance: 8,
-                            shadowBias: 0.05,
+                            shadowBias: 0.1,
                             normalOffsetBias: 0.05
                         }
                     }
@@ -310,6 +315,7 @@
             }
         ];
 
+        // Convert an entity definition in the structure above to a pc.Entity object
         function parseEntity(e) {
             var entity = new pc.Entity(e.name);
 
@@ -338,6 +344,7 @@
             return entity;
         }
 
+        // Parse the scene data above into entities and add them to the scene's root entity
         function parseScene(s) {
             s.forEach(function (e) {
                 app.root.addChild(parseEntity(e));
@@ -348,6 +355,7 @@
 
         var numChairs = 0;
 
+        // Clone the chair entity hierarchy and add it to the scene root
         function spawnChair() {
             var chair = app.root.findByName('Chair');
             var clone = chair.clone();
@@ -359,6 +367,7 @@
         // Set an update function on the application's update event
         var time = 0;
         app.on("update", function (dt) {
+            // Add a new chair every 250 ms
             time += dt;
             if (time > 0.25 && numChairs < 100) {
                 spawnChair();

--- a/examples/physics/compound-collision.html
+++ b/examples/physics/compound-collision.html
@@ -62,6 +62,7 @@
         var scene = [
             {
                 name: 'Chair',
+                pos: [0, 1, 0],
                 components: [
                     {
                         type: 'collision',
@@ -81,7 +82,6 @@
                 children: [
                     {
                         name: 'Seat',
-                        pos: [ 0, 0.5, 0 ],
                         components: [
                             {
                                 type: 'collision',
@@ -108,7 +108,7 @@
                         ]
                     }, {
                         name: 'Seat Back',
-                        pos: [ 0, 0.8, -0.2 ],
+                        pos: [ 0, 0.3, -0.2 ],
                         components: [
                             {
                                 type: 'collision',
@@ -135,7 +135,7 @@
                         ]
                     }, {
                         name: 'Leg 1',
-                        pos: [ 0.2, 0.25, 0.2 ],
+                        pos: [ 0.2, -0.25, 0.2 ],
                         components: [
                             {
                                 type: 'collision',
@@ -163,7 +163,7 @@
                         ]
                     }, {
                         name: 'Leg 2',
-                        pos: [ -0.2, 0.25, 0.2 ],
+                        pos: [ -0.2, -0.25, 0.2 ],
                         components: [
                             {
                                 type: 'collision',
@@ -191,7 +191,7 @@
                         ]
                     }, {
                         name: 'Leg 3',
-                        pos: [ 0.2, 0.5, -0.2 ],
+                        pos: [ 0.2, 0, -0.2 ],
                         components: [
                             {
                                 type: 'collision',
@@ -219,7 +219,7 @@
                         ]
                     }, {
                         name: 'Leg 4',
-                        pos: [ -0.2, 0.5, -0.2 ],
+                        pos: [ -0.2, 0, -0.2 ],
                         components: [
                             {
                                 type: 'collision',
@@ -346,36 +346,25 @@
 
         parseScene(scene);
 
-        var chair = app.root.findByName('Chair');
         var numChairs = 0;
 
-        var interval = setInterval(function () {
+        function spawnChair() {
+            var chair = app.root.findByName('Chair');
             var clone = chair.clone();
-            clone.setLocalPosition(Math.random() * 4 - 2, Math.random() * 4, Math.random() * 4 - 2)
+            clone.setLocalPosition(Math.random() * 5 - 2.5, Math.random() * 2 + 1, Math.random() * 5 - 2.5)
             app.root.addChild(clone);
-
             numChairs++;
-            if (numChairs >= 100) {
-                clearInterval(interval);
-            }
-        }, 250);
-
-        function createMaterial(color) {
-            var material = new pc.StandardMaterial();
-            material.diffuse = color;
-            material.update()
-
-            return material;
         }
-
-        // Create a couple of materials
-        var red = createMaterial(new pc.Color(1, 0, 0));
-        var green = createMaterial(new pc.Color(0, 1, 0));
-
 
         // Set an update function on the application's update event
         var time = 0;
         app.on("update", function (dt) {
+            time += dt;
+            if (time > 0.25 && numChairs < 100) {
+                spawnChair();
+                time = 0;
+            }
+
             // Show active bodies in red and frozen bodies in gray
             app.root.findComponents('rigidbody').forEach(function (body) {
                 body.entity.findComponents('model').forEach(function (model) {

--- a/examples/physics/compound-collision.html
+++ b/examples/physics/compound-collision.html
@@ -1,0 +1,389 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>PlayCanvas Compound Collision</title>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
+    <link rel="icon" type="image/png" href="../playcanvas-favicon.png" />
+    <script src="../../build/output/playcanvas.js"></script>
+    <script src="../../build/output/playcanvas-extras.js"></script>
+    <script src="../wasm-loader.js"></script>
+    <style>
+        body { 
+            margin: 0;
+            overflow-y: hidden;
+        }
+    </style>
+</head>
+
+<body>
+    <!-- The canvas element -->
+    <canvas id="application-canvas"></canvas>
+
+    <!-- The script -->
+    <script>
+    if (wasmSupported()) {
+        loadWasmModuleAsync('Ammo', '../lib/ammo/ammo.wasm.js', '../lib/ammo/ammo.wasm.wasm', demo);
+    } else {
+        loadWasmModuleAsync('Ammo', '../lib/ammo/ammo.js', '', demo);
+    }
+
+    function demo() {
+        var canvas = document.getElementById("application-canvas");
+
+        // Create the application and start the update loop
+        var app = new pc.Application(canvas);
+        app.start();
+
+        // Set the canvas to fill the window and automatically change resolution to be the same as the canvas size
+        app.setCanvasFillMode(pc.FILLMODE_FILL_WINDOW);
+        app.setCanvasResolution(pc.RESOLUTION_AUTO);
+
+        window.addEventListener("resize", function () {
+            app.resizeCanvas(canvas.width, canvas.height);
+        });
+
+        var miniStats = new pc.MiniStats(app);
+
+        app.scene.ambientLight = new pc.Color(0.2, 0.2, 0.2);
+
+        function createMaterial (color) {
+            var material = new pc.StandardMaterial();
+            material.diffuse = color;
+            // we need to call material.update when we change its properties
+            material.update()
+            return material;
+        }
+
+        // create a few materials for our objects
+        var red = createMaterial(new pc.Color(1, 0.3, 0.3));
+        var gray = createMaterial(new pc.Color(0.7, 0.7, 0.7));
+
+        var scene = [
+            {
+                name: 'Chair',
+                components: [
+                    {
+                        type: 'collision',
+                        options: {
+                            type: 'compound'
+                        }
+                    }, {
+                        type: 'rigidbody',
+                        options: {
+                            type: 'dynamic',
+                            friction: 0.5,
+                            mass: 10,
+                            restitution: 0.5
+                        }
+                    }
+                ],
+                children: [
+                    {
+                        name: 'Seat',
+                        pos: [ 0, 0.5, 0 ],
+                        components: [
+                            {
+                                type: 'collision',
+                                options: {
+                                    type: 'box',
+                                    halfExtents: [ 0.25, 0.025, 0.25 ]
+                                }
+                            }
+                        ],
+                        children: [
+                            {
+                                name: 'Seat Model',
+                                scl: [ 0.5, 0.05, 0.5 ],
+                                components: [
+                                    {
+                                        type: 'model',
+                                        options: {
+                                            type: 'box',
+                                            material: gray
+                                        }
+                                    }
+                                ]
+                            }                        
+                        ]
+                    }, {
+                        name: 'Seat Back',
+                        pos: [ 0, 0.8, -0.2 ],
+                        components: [
+                            {
+                                type: 'collision',
+                                options: {
+                                    type: 'box',
+                                    halfExtents: [ 0.25, 0.2, 0.025 ]
+                                }
+                            }
+                        ],
+                        children: [
+                            {
+                                name: 'Seat Back Model',
+                                scl: [ 0.5, 0.4, 0.05 ],
+                                components: [
+                                    {
+                                        type: 'model',
+                                        options: {
+                                            type: 'box',
+                                            material: gray
+                                        }
+                                    }
+                                ]
+                            }                        
+                        ]
+                    }, {
+                        name: 'Leg 1',
+                        pos: [ 0.2, 0.25, 0.2 ],
+                        components: [
+                            {
+                                type: 'collision',
+                                options: {
+                                    type: 'cylinder',
+                                    height: 0.5,
+                                    radius: 0.025
+                                }
+                            }
+                        ],
+                        children: [
+                            {
+                                name: 'Leg 1 Model',
+                                scl: [ 0.05, 0.5, 0.05 ],
+                                components: [
+                                    {
+                                        type: 'model',
+                                        options: {
+                                            type: 'cylinder',
+                                            material: gray
+                                        }
+                                    }
+                                ]
+                            }                        
+                        ]
+                    }, {
+                        name: 'Leg 2',
+                        pos: [ -0.2, 0.25, 0.2 ],
+                        components: [
+                            {
+                                type: 'collision',
+                                options: {
+                                    type: 'cylinder',
+                                    height: 0.5,
+                                    radius: 0.025
+                                }
+                            }
+                        ],
+                        children: [
+                            {
+                                name: 'Leg 2 Model',
+                                scl: [ 0.05, 0.5, 0.05 ],
+                                components: [
+                                    {
+                                        type: 'model',
+                                        options: {
+                                            type: 'cylinder',
+                                            material: gray
+                                        }
+                                    }
+                                ]
+                            }                        
+                        ]
+                    }, {
+                        name: 'Leg 3',
+                        pos: [ 0.2, 0.5, -0.2 ],
+                        components: [
+                            {
+                                type: 'collision',
+                                options: {
+                                    type: 'cylinder',
+                                    height: 1,
+                                    radius: 0.025
+                                }
+                            }
+                        ],
+                        children: [
+                            {
+                                name: 'Leg 3 Model',
+                                scl: [ 0.05, 1, 0.05 ],
+                                components: [
+                                    {
+                                        type: 'model',
+                                        options: {
+                                            type: 'cylinder',
+                                            material: gray
+                                        }
+                                    }
+                                ]
+                            }                        
+                        ]
+                    }, {
+                        name: 'Leg 4',
+                        pos: [ -0.2, 0.5, -0.2 ],
+                        components: [
+                            {
+                                type: 'collision',
+                                options: {
+                                    type: 'cylinder',
+                                    height: 1,
+                                    radius: 0.025
+                                }
+                            }
+                        ],
+                        children: [
+                            {
+                                name: 'Leg 4 Model',
+                                scl: [ 0.05, 1, 0.05 ],
+                                components: [
+                                    {
+                                        type: 'model',
+                                        options: {
+                                            type: 'cylinder',
+                                            material: gray
+                                        }
+                                    }
+                                ]
+                            }                        
+                        ]
+                    }
+                ]
+            }, {
+                name: 'Ground',
+                pos: [ 0, -0.5, 0 ],
+                components: [
+                    {
+                        type: 'collision',
+                        options: {
+                            type: 'box',
+                            halfExtents: [ 5, 0.5, 5 ]
+                        }
+                    }, {
+                        type: 'rigidbody',
+                        options: {
+                            type: 'static',
+                            restitution: 0.5
+                        }
+                    }
+                ],
+                children: [
+                    {
+                        name: 'Ground Model',
+                        scl: [ 10, 1, 10 ],
+                        components: [
+                            {
+                                type: 'model',
+                                options: {
+                                    type: 'box',
+                                    material: gray
+                                }
+                            }
+                        ]
+                    }                        
+                ]
+            }, {
+                name: 'Directional Light',
+                rot: [ 45, 30, 0 ],
+                components: [
+                    {
+                        type: 'light',
+                        options: {
+                            type: 'directional',
+                            castShadows: true,
+                            shadowDistance: 8,
+                            shadowBias: 0.05,
+                            normalOffsetBias: 0.05
+                        }
+                    }
+                ]
+            }, {
+                name: 'Camera',
+                pos: [ 0, 4, 7 ],
+                rot: [ -30, 0, 0 ],
+                components: [
+                    {
+                        type: 'camera',
+                        options: {
+                            color: [ 0.5, 0.5, 0.5 ]
+                        }
+                    }
+                ]
+            }
+        ];
+
+        function parseEntity(e) {
+            var entity = new pc.Entity(e.name);
+
+            if (e.pos) {
+                entity.setLocalPosition(e.pos[0], e.pos[1], e.pos[2]);
+            }
+            if (e.rot) {
+                entity.setLocalEulerAngles(e.rot[0], e.rot[1], e.rot[2]);
+            }
+            if (e.scl) {
+                entity.setLocalScale(e.scl[0], e.scl[1], e.scl[2]);
+            }
+
+            if (e.components) {
+                e.components.forEach(function (c) {
+                    entity.addComponent(c.type, c.options);
+                });
+            }
+
+            if (e.children) {
+                e.children.forEach(function (child) {
+                    entity.addChild(parseEntity(child));
+                });
+            }
+
+            return entity;
+        }
+
+        function parseScene(s) {
+            s.forEach(function (e) {
+                app.root.addChild(parseEntity(e));
+            });
+        }
+
+        parseScene(scene);
+
+        var chair = app.root.findByName('Chair');
+        var numChairs = 0;
+
+        var interval = setInterval(function () {
+            var clone = chair.clone();
+            clone.setLocalPosition(Math.random() * 4 - 2, Math.random() * 4, Math.random() * 4 - 2)
+            app.root.addChild(clone);
+
+            numChairs++;
+            if (numChairs >= 100) {
+                clearInterval(interval);
+            }
+        }, 250);
+
+        function createMaterial(color) {
+            var material = new pc.StandardMaterial();
+            material.diffuse = color;
+            material.update()
+
+            return material;
+        }
+
+        // Create a couple of materials
+        var red = createMaterial(new pc.Color(1, 0, 0));
+        var green = createMaterial(new pc.Color(0, 1, 0));
+
+
+        // Set an update function on the application's update event
+        var time = 0;
+        app.on("update", function (dt) {
+            // Show active bodies in red and frozen bodies in gray
+            app.root.findComponents('rigidbody').forEach(function (body) {
+                body.entity.findComponents('model').forEach(function (model) {
+                    model.material = body.isActive() ? red : gray;
+                });
+            });
+        });
+    }
+    </script>
+</body>
+</html>


### PR DESCRIPTION
This PR adds a new engine example demonstrating compound collision shapes.

![image](https://user-images.githubusercontent.com/697563/81471409-c0b8d400-91e8-11ea-9904-cef2271e0fa5.png)

An interesting aspect of this example is that it defines the scene in JSON format and then parses it, a bit like how Editor projects manage scenes. This is actually way easier to follow for the user because it separates scene definition from scene construction code. It also gives the developer an alternative approach for creating scenes using just the engine.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
