### PR TITLE
[FIX] A rigid body's motion state no longer leaks

### DIFF
--- a/src/framework/components/rigid-body/system.js
+++ b/src/framework/components/rigid-body/system.js
@@ -237,9 +237,16 @@ Object.assign(pc, function () {
         },
 
         onRemove: function (entity, data) {
-            if (data.body) {
-                this.removeBody(data.body);
-                Ammo.destroy(data.body);
+            var body = data.body;
+            if (body) {
+                this.removeBody(body);
+
+                // The motion state needs to be destroyed explicitly (if present)
+                var motionState = body.getMotionState();
+                if (motionState) {
+                    Ammo.destroy(motionState);
+                }
+                Ammo.destroy(body);
 
                 data.body = null;
             }


### PR DESCRIPTION
It turns out that calling `Ammo.destroy` on a `btRigidBody` does not destroy its `btMotionState`. That has to be destroyed explicitly.

You can see the official Bullet demos doing just that:

https://github.com/kripken/ammo.js/blob/master/bullet/Demos/OpenGL/GlutDemoApplication.cpp#L55

Fixes #2067 (the script in the issue now runs indefinitely without hitting an OOM error)

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
