### PR TITLE
[FIX] removed basis URL from cache after transcode

### DIFF
--- a/src/resources/basis.js
+++ b/src/resources/basis.js
@@ -323,6 +323,8 @@ Object.assign(pc, function () {
         for (i = 0; i < callback.length; ++i) {
             (callback[i])(null, data);
         }
+
+        delete callbacks[url];
     };
 
     // post a transcode job to the web worker


### PR DESCRIPTION
Fixes a bug where after the basis is unloaded, it doesn't perform the transcode on the next asset load

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
