### PR TITLE
Changed collision checks to properly check on each each internal physics world time step.

### DIFF
--- a/src/framework/components/rigid-body/system.js
+++ b/src/framework/components/rigid-body/system.js
@@ -185,7 +185,9 @@ Object.assign(pc, function () {
                     var checkForCollisionsPointer = Ammo.addFunction(this._checkForCollisions.bind(this), 'vif');
                     this.dynamicsWorld.setInternalTickCallback(checkForCollisionsPointer);
                 } else {
+                    // #ifdef DEBUG
                     console.warn("WARNING: This version of ammo.js can potentially fail to report contacts. Please update it to the latest version.");
+                    // #endif
                 }
 
                 // Lazily create temp vars
@@ -534,8 +536,8 @@ Object.assign(pc, function () {
          * @function
          * @name pc.RigidBodyComponentSystem#_checkForCollisions
          * @description Checks for collisions and fires collision events
-         * @param {pc.Entity} dynamicsWorld - The pointer to the dynamics world that invoked this callback.
-         * @param {pc.Entity} timeStep - The amount of simulation time processed in the last simulation tick.
+         * @param {object | number} dynamicsWorld - Either The integer pointer to the dynamics world that invoked this callback or the underlying world.
+         * @param {number} timeStep - The amount of simulation time processed in the last simulation tick.
          * @returns {void}
          */
         _checkForCollisions: function (dynamicsWorld, timeStep) {
@@ -725,7 +727,7 @@ Object.assign(pc, function () {
             }
 
             if (!this.dynamicsWorld.setInternalTickCallback)
-                this._checkForCollisions();
+                this._checkForCollisions(this.dynamicsWorld, dt);
 
             // #ifdef PROFILER
             this._stats.physicsTime = pc.now() - this._stats.physicsStart;

--- a/src/framework/components/rigid-body/system.js
+++ b/src/framework/components/rigid-body/system.js
@@ -184,7 +184,7 @@ Object.assign(pc, function () {
                 if (this.dynamicsWorld.setInternalTickCallback) {
                     var checkForCollisionsPointer = Ammo.addFunction(this._checkForCollisions.bind(this), 'vif');
                     this.dynamicsWorld.setInternalTickCallback(checkForCollisionsPointer);
-                  } else {
+                } else {
                     console.warn("WARNING: This version of ammo.js can potentially fail to report contacts. Please update it to the latest version.");
                 }
 
@@ -533,7 +533,7 @@ Object.assign(pc, function () {
          * @private
          * @function
          * @name pc.RigidBodyComponentSystem#_checkForCollisions
-         * @description Checks for collisions and fires collision events 
+         * @description Checks for collisions and fires collision events
          * @param {pc.Entity} dynamicsWorld - The pointer to the dynamics world that invoked this callback.
          * @param {pc.Entity} timeStep - The amount of simulation time processed in the last simulation tick.
          * @returns {void}


### PR DESCRIPTION
Fixes #2072 

Separates the check collision logic into its own function and lets Ammo handle calling it on each internal time step. Provides warning if user is using older version that does not support setInternalTickCallback and falls back to calling after each stepSimulation if unavailable. 

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
