### PR TITLE
Increasing num particles fix

### DIFF
--- a/src/framework/components/particle-system/component.js
+++ b/src/framework/components/particle-system/component.js
@@ -560,9 +560,9 @@ Object.assign(pc, function () {
         onSetComplexProperty: function (name, oldValue, newValue) {
             if (this.emitter) {
                 this.emitter[name] = newValue;
-                this.reset();
                 this.emitter.resetMaterial();
                 this.rebuild();
+                this.reset();
             }
         },
 


### PR DESCRIPTION
When a particle system component complex property is updated, it should rebuild the emitter and then reset it.

This stops update methods that are invoked by the reset function from attempting to access data structures which haven't yet been rebuilt using the new property.

Fixes https://github.com/playcanvas/editor/issues/68

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
