### PR TITLE
small reflection chunks cleanup

### DIFF
--- a/src/graphics/program-lib/chunks/reflectionCC.frag
+++ b/src/graphics/program-lib/chunks/reflectionCC.frag
@@ -1,6 +1,6 @@
 #ifdef CLEARCOAT
 uniform float material_clearCoatReflectivity;
 void addReflectionCC() {    
-    ccReflection += calcReflection(ccReflDirW, ccGlossiness, material_clearCoatReflectivity); 
+    ccReflection += vec4(calcReflection(ccReflDirW, ccGlossiness), material_clearCoatReflectivity); 
 }
 #endif

--- a/src/graphics/program-lib/chunks/reflectionCube.frag
+++ b/src/graphics/program-lib/chunks/reflectionCube.frag
@@ -1,11 +1,11 @@
 uniform samplerCube texture_cubeMap;
-vec4 calcReflection(vec3 tReflDirW, float tGlossiness, float tmaterial_reflectivity) {
+vec3 calcReflection(vec3 tReflDirW, float tGlossiness) {
     vec3 lookupVec = fixSeams(cubeMapProject(tReflDirW));
     lookupVec.x *= -1.0;
-    return vec4($textureCubeSAMPLE(texture_cubeMap, lookupVec).rgb, tmaterial_reflectivity);
+    return $textureCubeSAMPLE(texture_cubeMap, lookupVec).rgb;
 }
 
 uniform float material_reflectivity;
 void addReflection() {   
-    dReflection += calcReflection(dReflDirW, dGlossiness, material_reflectivity);
+    dReflection += vec4(calcReflection(dReflDirW, dGlossiness), material_reflectivity);
 }

--- a/src/graphics/program-lib/chunks/reflectionDpAtlas.frag
+++ b/src/graphics/program-lib/chunks/reflectionDpAtlas.frag
@@ -24,7 +24,7 @@ vec2 getDpAtlasUv(vec2 uv, float mip) {
     return uv;
 }
 
-vec4 calcReflection(vec3 tReflDirW, float tGlossiness, float tmaterial_reflectivity) {
+vec3 calcReflection(vec3 tReflDirW, float tGlossiness) {
     vec3 reflDir = normalize(cubeMapProject(tReflDirW));
 
     // Convert vector to DP coords
@@ -48,10 +48,10 @@ vec4 calcReflection(vec3 tReflDirW, float tGlossiness, float tmaterial_reflectiv
     tex1 = mix(tex1, tex2, fract(bias));
     tex1 = processEnvironment(tex1);
 
-    return vec4(tex1, tmaterial_reflectivity);
+    return tex1;
 }
 
 uniform float material_reflectivity;
 void addReflection() {   
-    dReflection += calcReflection(dReflDirW, dGlossiness, material_reflectivity);
+    dReflection += vec4(calcReflection(dReflDirW, dGlossiness), material_reflectivity);
 }

--- a/src/graphics/program-lib/chunks/reflectionPrefilteredCube.frag
+++ b/src/graphics/program-lib/chunks/reflectionPrefilteredCube.frag
@@ -7,7 +7,7 @@ uniform samplerCube texture_prefilteredCubeMap8;
 #define PMREM4
 uniform samplerCube texture_prefilteredCubeMap4;
 #endif
-vec4 calcReflection(vec3 tReflDirW, float tGlossiness, float tmaterial_reflectivity) {
+vec3 calcReflection(vec3 tReflDirW, float tGlossiness) {
     // Unfortunately, WebGL doesn't allow us using textureCubeLod. Therefore bunch of nasty workarounds is required.
     // We fix mip0 to 128x128, so code is rather static.
     // Mips smaller than 4x4 aren't great even for diffuse. Don't forget that we don't have bilinear filtering between different faces.
@@ -56,10 +56,10 @@ vec4 calcReflection(vec3 tReflDirW, float tGlossiness, float tmaterial_reflectiv
     vec4 cubeFinal = mix(cube[0], cube[1], fract(bias));
     vec3 refl = processEnvironment($DECODE(cubeFinal).rgb);
 
-    return vec4(refl, tmaterial_reflectivity);
+    return refl;
 }
 
 uniform float material_reflectivity;
 void addReflection() {   
-    dReflection += calcReflection(dReflDirW, dGlossiness, material_reflectivity);
+    dReflection += vec4(calcReflection(dReflDirW, dGlossiness), material_reflectivity);
 }

--- a/src/graphics/program-lib/chunks/reflectionPrefilteredCubeLod.frag
+++ b/src/graphics/program-lib/chunks/reflectionPrefilteredCubeLod.frag
@@ -4,17 +4,17 @@
 #extension GL_EXT_shader_texture_lod : enable
 uniform samplerCube texture_prefilteredCubeMap128;
 #endif
-vec4 calcReflection(vec3 tReflDirW, float tGlossiness, float tmaterial_reflectivity) {
+vec3 calcReflection(vec3 tReflDirW, float tGlossiness) {
     float bias = saturate(1.0 - tGlossiness) * 5.0; // multiply by max mip level
     vec3 fixedReflDir = fixSeams(cubeMapProject(tReflDirW), bias);
     fixedReflDir.x *= -1.0;
 
     vec3 refl = processEnvironment($DECODE( textureCubeLodEXT(texture_prefilteredCubeMap128, fixedReflDir, bias) ).rgb);
 
-    return vec4(refl, tmaterial_reflectivity);
+    return refl;
 }
 
 uniform float material_reflectivity;
 void addReflection() {   
-    dReflection += calcReflection(dReflDirW, dGlossiness, material_reflectivity);
+    dReflection += vec4(calcReflection(dReflDirW, dGlossiness), material_reflectivity);
 }

--- a/src/graphics/program-lib/chunks/reflectionSphere.frag
+++ b/src/graphics/program-lib/chunks/reflectionSphere.frag
@@ -3,16 +3,16 @@
 uniform mat4 matrix_view;
 #endif
 uniform sampler2D texture_sphereMap;
-vec4 calcReflection(vec3 tReflDirW, float tGlossiness, float tmaterial_reflectivity) {
+vec3 calcReflection(vec3 tReflDirW, float tGlossiness) {
     vec3 reflDirV = (mat3(matrix_view) * tReflDirW).xyz;
 
     float m = 2.0 * sqrt( dot(reflDirV.xy, reflDirV.xy) + (reflDirV.z+1.0)*(reflDirV.z+1.0) );
     vec2 sphereMapUv = reflDirV.xy / m + 0.5;
 
-    return vec4($texture2DSAMPLE(texture_sphereMap, sphereMapUv).rgb, tmaterial_reflectivity);
+    return $texture2DSAMPLE(texture_sphereMap, sphereMapUv).rgb;
 }
 
 uniform float material_reflectivity;
 void addReflection() {   
-    dReflection += calcReflection(dReflDirW, dGlossiness, material_reflectivity);
+    dReflection += vec4(calcReflection(dReflDirW, dGlossiness), material_reflectivity);
 }

--- a/src/graphics/program-lib/chunks/reflectionSphereLow.frag
+++ b/src/graphics/program-lib/chunks/reflectionSphereLow.frag
@@ -1,14 +1,13 @@
 uniform sampler2D texture_sphereMap;
 
-vec4 calcReflection(vec3 tReflDirW, float tGlossiness, float tmaterial_reflectivity) {
+vec3 calcReflection(vec3 tReflDirW, float tGlossiness) {
     vec3 reflDirV = vNormalV;
 
     vec2 sphereMapUv = reflDirV.xy * 0.5 + 0.5;
-    return vec4($texture2DSAMPLE(texture_sphereMap, sphereMapUv).rgb, tmaterial_reflectivity);      
+    return $texture2DSAMPLE(texture_sphereMap, sphereMapUv).rgb;
 }
 
 uniform float material_reflectivity;
 void addReflection() {   
-    dReflection += calcReflection(dReflDirW, dGlossiness, material_reflectivity);
+    dReflection += vec4(calcReflection(dReflDirW, dGlossiness), material_reflectivity);
 }
-


### PR DESCRIPTION
Reflection chunks all pass material_reflectivity into the calcReflection() function just to have it package the value and return it to the caller. This seems unnecessary and so this PR sets the value in a more straightforward way.

@raytranuk - do you think this is an improvement? If not, I'm also happy to pull it.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
