### PR TITLE
[Physics] Fix Ammo dynamics world memory never being released 

### DIFF
--- a/src/framework/components/rigid-body/system.js
+++ b/src/framework/components/rigid-body/system.js
@@ -735,7 +735,7 @@ Object.assign(pc, function () {
         },
 
         destroy: function () {
-            if (Ammo) {
+            if (typeof Ammo !== 'undefined') {
                 Ammo.destroy(this.dynamicsWorld);
                 Ammo.destroy(this.solver);
                 Ammo.destroy(this.overlappingPairCache);

--- a/src/framework/components/rigid-body/system.js
+++ b/src/framework/components/rigid-body/system.js
@@ -175,11 +175,11 @@ Object.assign(pc, function () {
         onLibraryLoaded: function () {
             // Create the Ammo physics world
             if (typeof Ammo !== 'undefined') {
-                var collisionConfiguration = new Ammo.btDefaultCollisionConfiguration();
-                var dispatcher = new Ammo.btCollisionDispatcher(collisionConfiguration);
-                var overlappingPairCache = new Ammo.btDbvtBroadphase();
-                var solver = new Ammo.btSequentialImpulseConstraintSolver();
-                this.dynamicsWorld = new Ammo.btDiscreteDynamicsWorld(dispatcher, overlappingPairCache, solver, collisionConfiguration);
+                this.collisionConfiguration = new Ammo.btDefaultCollisionConfiguration();
+                this.dispatcher = new Ammo.btCollisionDispatcher(this.collisionConfiguration);
+                this.overlappingPairCache = new Ammo.btDbvtBroadphase();
+                this.solver = new Ammo.btSequentialImpulseConstraintSolver();
+                this.dynamicsWorld = new Ammo.btDiscreteDynamicsWorld(this.dispatcher, this.overlappingPairCache, this.solver, this.collisionConfiguration);
 
                 if (this.dynamicsWorld.setInternalTickCallback) {
                     var checkForCollisionsPointer = Ammo.addFunction(this._checkForCollisions.bind(this), 'vif');
@@ -732,6 +732,19 @@ Object.assign(pc, function () {
             // #ifdef PROFILER
             this._stats.physicsTime = pc.now() - this._stats.physicsStart;
             // #endif
+        },
+
+        destroy: function () {
+            Ammo.destroy(this.dynamicsWorld);
+            Ammo.destroy(this.solver);
+            Ammo.destroy(this.overlappingPairCache);
+            Ammo.destroy(this.dispatcher);
+            Ammo.destroy(this.collisionConfiguration);
+            this.dynamicsWorld = null;
+            this.solver = null;
+            this.overlappingPairCache = null;
+            this.dispatcher = null;
+            this.collisionConfiguration = null;
         }
     });
 

--- a/src/framework/components/rigid-body/system.js
+++ b/src/framework/components/rigid-body/system.js
@@ -735,16 +735,18 @@ Object.assign(pc, function () {
         },
 
         destroy: function () {
-            Ammo.destroy(this.dynamicsWorld);
-            Ammo.destroy(this.solver);
-            Ammo.destroy(this.overlappingPairCache);
-            Ammo.destroy(this.dispatcher);
-            Ammo.destroy(this.collisionConfiguration);
-            this.dynamicsWorld = null;
-            this.solver = null;
-            this.overlappingPairCache = null;
-            this.dispatcher = null;
-            this.collisionConfiguration = null;
+            if (Ammo) {
+                Ammo.destroy(this.dynamicsWorld);
+                Ammo.destroy(this.solver);
+                Ammo.destroy(this.overlappingPairCache);
+                Ammo.destroy(this.dispatcher);
+                Ammo.destroy(this.collisionConfiguration);
+                this.dynamicsWorld = null;
+                this.solver = null;
+                this.overlappingPairCache = null;
+                this.dispatcher = null;
+                this.collisionConfiguration = null;
+            }
         }
     });
 


### PR DESCRIPTION
Fixes #2064 

The rigidbody component system did not have a destroy function so each time Ammo was created the previous Ammo dynamics world objects were never released. 

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
