### PR TITLE
Shape constructors copy parameters

### DIFF
--- a/src/shape/bounding-box.js
+++ b/src/shape/bounding-box.js
@@ -10,14 +10,14 @@ Object.assign(pc, function () {
      * @name pc.BoundingBox
      * @description Create a new axis-aligned bounding box.
      * @classdesc Axis-Aligned Bounding Box.
-     * @param {pc.Vec3} [center] - Center of box. The constructor takes a reference of this parameter.
-     * @param {pc.Vec3} [halfExtents] - Half the distance across the box in each axis. The constructor takes a reference of this parameter.
+     * @param {pc.Vec3} [center] - Center of box. The constructor takes a copy of this parameter.
+     * @param {pc.Vec3} [halfExtents] - Half the distance across the box in each axis. The constructor takes a copy of this parameter.
      * @property {pc.Vec3} center Center of box.
      * @property {pc.Vec3} halfExtents Half the distance across the box in each axis.
      */
     var BoundingBox = function BoundingBox(center, halfExtents) {
-        this.center = center || new pc.Vec3(0, 0, 0);
-        this.halfExtents = halfExtents || new pc.Vec3(0.5, 0.5, 0.5);
+        this.center = center ? center.clone() : new pc.Vec3(0, 0, 0);
+        this.halfExtents = halfExtents ? halfExtents.clone() : new pc.Vec3(0.5, 0.5, 0.5);
         this._min = new pc.Vec3();
         this._max = new pc.Vec3();
     };

--- a/src/shape/bounding-sphere.js
+++ b/src/shape/bounding-sphere.js
@@ -12,11 +12,11 @@ Object.assign(pc, function () {
      * @example
      * // Create a new bounding sphere centered on the origin with a radius of 0.5
      * var sphere = new pc.BoundingSphere();
-     * @param {pc.Vec3} [center] - The world space coordinate marking the center of the sphere. The constructor takes a reference of this parameter.
+     * @param {pc.Vec3} [center] - The world space coordinate marking the center of the sphere. The constructor takes a copy of this parameter.
      * @param {number} [radius] - The radius of the bounding sphere. Defaults to 0.5.
      */
     function BoundingSphere(center, radius) {
-        this.center = center || new pc.Vec3(0, 0, 0);
+        this.center = center ? center.clone() : new pc.Vec3(0, 0, 0);
         this.radius = radius === undefined ? 0.5 : radius;
     }
 

--- a/src/shape/frustum.js
+++ b/src/shape/frustum.js
@@ -15,8 +15,8 @@ Object.assign(pc, function () {
      * @param {pc.Mat4} viewMatrix - The inverse of the world transformation matrix for the frustum.
      */
     var Frustum = function Frustum(projectionMatrix, viewMatrix) {
-        projectionMatrix = projectionMatrix || new pc.Mat4().setPerspective(90, 16 / 9, 0.1, 1000);
-        viewMatrix = viewMatrix || new pc.Mat4();
+        projectionMatrix = projectionMatrix ? projectionMatrix.clone() : new pc.Mat4().setPerspective(90, 16 / 9, 0.1, 1000);
+        viewMatrix = viewMatrix ? viewMatrix.clone() : new pc.Mat4();
 
         this.planes = [];
         for (var i = 0; i < 6; i++)

--- a/src/shape/oriented-box.js
+++ b/src/shape/oriented-box.js
@@ -11,12 +11,12 @@ Object.assign(pc, function () {
      * @classdesc Oriented Box.
      * @property {pc.Mat4} [worldTransform] The world transform of the OBB.
      * @param {pc.Mat4} [worldTransform] - Transform that has the orientation and position of the box. Scale is assumed to be one.
-     * @param {pc.Vec3} [halfExtents] - Half the distance across the box in each local axis. The constructor takes a reference of this parameter.
+     * @param {pc.Vec3} [halfExtents] - Half the distance across the box in each local axis. The constructor takes a copy of this parameter.
      */
     var OrientedBox = function OrientedBox(worldTransform, halfExtents) {
-        this.halfExtents = halfExtents || new pc.Vec3(0.5, 0.5, 0.5);
+        this.halfExtents = halfExtents ? halfExtents.clone() : new pc.Vec3(0.5, 0.5, 0.5);
 
-        worldTransform = worldTransform || tmpMat4.setIdentity();
+        worldTransform = worldTransform ? worldTransform.clone() : tmpMat4.setIdentity();
         this._modelTransform = worldTransform.clone().invert();
 
         this._worldTransform = worldTransform.clone(); // temp - currently only used in the worldTransform accessor, see future PR for more use

--- a/src/shape/plane.js
+++ b/src/shape/plane.js
@@ -7,12 +7,12 @@ Object.assign(pc, function () {
      * @name pc.Plane
      * @classdesc An infinite plane.
      * @description Create an infinite plane.
-     * @param {pc.Vec3} [point] - Point position on the plane. The constructor takes a reference of this parameter.
-     * @param {pc.Vec3} [normal] - Normal of the plane. The constructor takes a reference of this parameter.
+     * @param {pc.Vec3} [point] - Point position on the plane. The constructor takes a copy of this parameter.
+     * @param {pc.Vec3} [normal] - Normal of the plane. The constructor takes a copy of this parameter.
      */
     var Plane = function Plane(point, normal) {
-        this.normal = normal || new pc.Vec3(0, 0, 1);
-        this.point = point || new pc.Vec3(0, 0, 0);
+        this.normal = normal ? normal.clone() : new pc.Vec3(0, 0, 1);
+        this.point = point ? point.clone() : new pc.Vec3(0, 0, 0);
     };
 
     Object.assign(Plane.prototype, {

--- a/src/shape/ray.js
+++ b/src/shape/ray.js
@@ -8,16 +8,16 @@ Object.assign(pc, function () {
      * // Create a new ray starting at the position of this entity and pointing down
      * // the entity's negative Z axis
      * var ray = new pc.Ray(this.entity.getPosition(), this.entity.forward);
-     * @param {pc.Vec3} [origin] - The starting point of the ray. The constructor takes a reference of this parameter.
+     * @param {pc.Vec3} [origin] - The starting point of the ray. The constructor takes a copy of this parameter.
      * Defaults to the origin (0, 0, 0).
-     * @param {pc.Vec3} [direction] - The direction of the ray. The constructor takes a reference of this parameter.
+     * @param {pc.Vec3} [direction] - The direction of the ray. The constructor takes a copy of this parameter.
      * Defaults to a direction down the world negative Z axis (0, 0, -1).
      * @property {pc.Vec3} origin The starting point of the ray.
      * @property {pc.Vec3} direction The direction of the ray.
      */
     var Ray = function Ray(origin, direction) {
-        this.origin = origin || new pc.Vec3(0, 0, 0);
-        this.direction = direction || new pc.Vec3(0, 0, -1);
+        this.origin = origin ? origin.clone() : new pc.Vec3(0, 0, 0);
+        this.direction = direction ? direction.clone() : new pc.Vec3(0, 0, -1);
     };
 
     /**


### PR DESCRIPTION
Lets consider making shape constructors take copy of parameters instead of reference, to avoid possible errors of type:

var b = new pc.BoundingBox(pc.Vec3.ZERO, pc.Vec3.ZERO);
b._calculateAabb( ...) - this changes content of Vec3.ZERO !!

@slimbuck expressed concern that some code depends on existing behavior and so this cannot be simple submitted.
