### PR TITLE
[FIX] Ignore scale on entity transform when setting body transform

### DIFF
--- a/src/framework/components/rigid-body/component.js
+++ b/src/framework/components/rigid-body/component.js
@@ -594,7 +594,7 @@ Object.assign(pc, function () {
          * @function
          * @name pc.RigidBodyComponent#_getEntityTransform
          * @description Writes an entity transform into an Ammo.btTransform but ignoring scale.
-         * @param {Ammo.btTransform} transform - The ammo transform to write the entity transform to.
+         * @param {object} transform - The ammo transform to write the entity transform to.
          */
         _getEntityTransform: function (transform) {
             var pos = this.entity.getPosition();

--- a/src/framework/components/rigid-body/component.js
+++ b/src/framework/components/rigid-body/component.js
@@ -185,14 +185,7 @@ Object.assign(pc, function () {
 
                 var mass = this.type === pc.BODYTYPE_DYNAMIC ? this.mass : 0;
 
-                var pos = entity.getPosition();
-                var rot = entity.getRotation();
-
-                ammoVec1.setValue(pos.x, pos.y, pos.z);
-                ammoQuat.setValue(rot.x, rot.y, rot.z, rot.w);
-
-                ammoTransform.setOrigin(ammoVec1);
-                ammoTransform.setRotation(ammoQuat);
+                this._getEntityTransform(ammoTransform);
 
                 var body = this.system.createBody(mass, shape, ammoTransform);
 
@@ -251,6 +244,8 @@ Object.assign(pc, function () {
             if (this.entity.collision && this.entity.collision.enabled && !this.data.simulationEnabled) {
                 var body = this.body;
                 if (body) {
+                    this.system.addBody(body, this.group, this.mask);
+
                     switch (this.type) {
                         case pc.BODYTYPE_DYNAMIC:
                             this.system._dynamic.push(this);
@@ -270,7 +265,6 @@ Object.assign(pc, function () {
                         this.system._compounds.push(this.entity.collision);
                     }
 
-                    this.system.addBody(body, this.group, this.mask);
                     body.activate();
 
                     this.data.simulationEnabled = true;
@@ -595,6 +589,23 @@ Object.assign(pc, function () {
             return (this.type === pc.BODYTYPE_KINEMATIC);
         },
 
+        /**
+         * @private
+         * @function
+         * @name pc.RigidBodyComponent#_getEntityTransform
+         * @description Writes an entity transform into an Ammo.btTransform but ignoring scale.
+         * @param {Ammo.btTransform} transform - The ammo transform to write the entity transform to.
+         */
+        _getEntityTransform: function (transform) {
+            var pos = this.entity.getPosition();
+            var rot = this.entity.getRotation();
+
+            ammoVec1.setValue(pos.x, pos.y, pos.z);
+            ammoQuat.setValue(rot.x, rot.y, rot.z, rot.w);
+
+            transform.setOrigin(ammoVec1);
+            transform.setRotation(ammoQuat);
+        },
 
         /**
          * @private
@@ -607,8 +618,7 @@ Object.assign(pc, function () {
         syncEntityToBody: function () {
             var body = this.data.body;
             if (body) {
-                var wtm = this.entity.getWorldTransform();
-                ammoTransform.setFromOpenGLMatrix(wtm.data);
+                this._getEntityTransform(ammoTransform);
 
                 body.setWorldTransform(ammoTransform);
 
@@ -660,8 +670,7 @@ Object.assign(pc, function () {
             var body = this.data.body;
             var motionState = body.getMotionState();
             if (motionState) {
-                var wtm = this.entity.getWorldTransform();
-                ammoTransform.setFromOpenGLMatrix(wtm.data);
+                this._getEntityTransform(ammoTransform);
                 motionState.setWorldTransform(ammoTransform);
             }
         },


### PR DESCRIPTION
Fixes a bug in PR #1997. That PR optimized the setting of a body's transform from an entity's world transformation matrix. However, this resulted in an entity's scale being set on the body's transform. Previously, the engine would ignore scale and just set position and rotation. This behavior has been restored in this fix.

This PR also takes the opportunity to unify PlayCanvas entity transform to Ammo btTransform conversion into a single function.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
