### PR TITLE
Expose the original browser TouchEvent

### DIFF
--- a/src/input/touch.js
+++ b/src/input/touch.js
@@ -35,6 +35,7 @@ Object.assign(pc, function () {
      * @property {Element} element The target Element that the event was fired from.
      * @property {pc.Touch[]} touches A list of all touches currently in contact with the device.
      * @property {pc.Touch[]} changedTouches A list of touches that have changed since the last event.
+     * @property {TouchEvent} event - The original browser TouchEvent.
      */
     var TouchEvent = function (device, event) {
         this.element = event.target;


### PR DESCRIPTION
Related to the double tap issue on some iOS devices mentioned here: https://forum.playcanvas.com/t/double-tap-issue-ios/13245/33?u=yaustar

We already expose the original browser mouse event on pc.MouseEvent :) 

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
