### PR TITLE
Added blob prefix check to absolute URL check

### DIFF
--- a/src/asset/asset.js
+++ b/src/asset/asset.js
@@ -18,6 +18,9 @@ Object.assign(pc, function () {
 
             // Data URL (RFC 2397), simplified
             'data:' +
+
+            // Blob data
+            '|blob:' +
         ')',
         'i' // non case-sensitive flag
     );


### PR DESCRIPTION
Blob URLs still get prefixed with the registry prefix. Added check for absolute URL.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
