### PR TITLE
Multiple morph instance animation fix

### DIFF
--- a/src/anim/anim.js
+++ b/src/anim/anim.js
@@ -697,10 +697,11 @@ Object.assign(pc, function () {
                     !object.model.model.morphInstances) {
                     return null;
                 }
+                var meshInstances = object.model.model.meshInstances;
                 var morphInstance;
-                for (var i = 0; i < object.model.model.meshInstances.length; i++) {
-                    if (object.model.model.meshInstances[i].node.name === node.name) {
-                        morphInstance = object.model.model.meshInstances[i].morphInstance;
+                for (var i = 0; i < meshInstances.length; ++i) {
+                    if (meshInstances[i].node.name === node.name) {
+                        morphInstance = meshInstances[i].morphInstance;
                         break;
                     }
                 }

--- a/src/anim/anim.js
+++ b/src/anim/anim.js
@@ -694,17 +694,25 @@ Object.assign(pc, function () {
                 if (!object ||
                     !object.model ||
                     !object.model.model ||
-                    !object.model.model.morphInstances ||
-                    !object.model.model.morphInstances[0]) {
+                    !object.model.model.morphInstances) {
                     return null;
                 }
-                object = object.model.model.morphInstances[0];
+                var morphInstance;
+                for (var i = 0; i < object.model.model.meshInstances.length; i++) {
+                    if (object.model.model.meshInstances[0].node.name === node.name) {
+                        morphInstance = object.model.model.meshInstances[0].morphInstance;
+                        break;
+                    }
+                }
+                if (!morphInstance) {
+                    return null;
+                }
                 var func = function (value) {
                     for (var i = 0; i < value.length; ++i) {
-                        object.setWeight(i, value[i]);
+                        morphInstance.setWeight(i, value[i]);
                     }
                 };
-                return new pc.AnimTarget(func, 'vector', object.morph._targets.length);
+                return new pc.AnimTarget(func, 'vector', morphInstance.morph._targets.length);
             }
         };
     };

--- a/src/anim/anim.js
+++ b/src/anim/anim.js
@@ -697,7 +697,7 @@ Object.assign(pc, function () {
                     !object.model.model.morphInstances) {
                     return null;
                 }
-                var meshInstances = object.model.model.meshInstances;
+                var meshInstances = object.model.meshInstances;
                 var morphInstance;
                 for (var i = 0; i < meshInstances.length; ++i) {
                     if (meshInstances[i].node.name === node.name) {

--- a/src/anim/anim.js
+++ b/src/anim/anim.js
@@ -699,8 +699,8 @@ Object.assign(pc, function () {
                 }
                 var morphInstance;
                 for (var i = 0; i < object.model.model.meshInstances.length; i++) {
-                    if (object.model.model.meshInstances[0].node.name === node.name) {
-                        morphInstance = object.model.model.meshInstances[0].morphInstance;
+                    if (object.model.model.meshInstances[i].node.name === node.name) {
+                        morphInstance = object.model.model.meshInstances[i].morphInstance;
                         break;
                     }
                 }


### PR DESCRIPTION
Handle the case where an animation contains morph target weights on multiple morph instances

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
