### PR TITLE
split out texture parsers and coalesce texture types into a single enum

### DIFF
--- a/build/dependencies.txt
+++ b/build/dependencies.txt
@@ -261,6 +261,11 @@
 ../src/resources/font.js
 ../src/resources/texture-atlas.js
 ../src/resources/sprite.js
+../src/resources/parser/texture/basis.js
+../src/resources/parser/texture/dds.js
+../src/resources/parser/texture/img.js
+../src/resources/parser/texture/ktx.js
+../src/resources/parser/texture/legacy-dds.js
 ../src/resources/parser/json-model.js
 ../src/resources/parser/glb-parser.js
 ../src/resources/parser/glb-model.js

--- a/src/framework/components/anim/component.js
+++ b/src/framework/components/anim/component.js
@@ -319,11 +319,11 @@ Object.assign(pc, function () {
                 if (_asset.resource) {
                     this.data.stateGraph = _asset.resource;
                 } else {
-                    asset.on('load', function (asset) {
+                    _asset.on('load', function (asset) {
                         this.data.stateGraph = asset.resource;
                         this.loadStateGraph(this.data.stateGraph);
                     }.bind(this));
-                    this.system.app.assets.load(asset);
+                    this.system.app.assets.load(_asset);
                 }
                 this.data.stateGraphAsset = _id;
             }

--- a/src/graphics/graphics.js
+++ b/src/graphics/graphics.js
@@ -1014,6 +1014,38 @@
          */
         TEXTURELOCK_WRITE: 2,
 
+        /**
+         * @constant
+         * @name pc.TEXTURETYPE_GENERAL
+         * @type {number}
+         * @description Texture is a general type.
+         */
+        TEXTURETYPE_GENERAL: 1,
+
+        /**
+         * @constant
+         * @name pc.TEXTURETYPE_RGBM
+         * @type {number}
+         * @description Texture stores high dynamic range data in RGBM format
+         */
+        TEXTURETYPE_RGBM: 2,
+
+        /**
+         * @constant
+         * @name pc.TEXTURETYPE_GENERAL
+         * @type {number}
+         * @description Texture stores high dynamic range data in RGBE format
+         */
+        TEXTURETYPE_RGBE: 3,
+
+        /**
+         * @constant
+         * @name pc.TEXTURETYPE_GENERAL
+         * @type {number}
+         * @description Texture stores normalmap data swizzled in GGGR format
+         */
+        TEXTURETYPE_SWIZZLEGGGR: 4,
+
         TEXHINT_NONE: 0,
         TEXHINT_SHADOWMAP: 1,
         TEXHINT_ASSET: 2,

--- a/src/graphics/texture.js
+++ b/src/graphics/texture.js
@@ -48,7 +48,9 @@ Object.assign(pc, function () {
      * @param {boolean} [options.mipmaps] - When enabled try to generate or use mipmaps for this texture. Default is true
      * @param {boolean} [options.cubemap] - Specifies whether the texture is to be a cubemap. Defaults to false.
      * @param {boolean} [options.volume] - Specifies whether the texture is to be a 3D volume (WebGL2 only). Defaults to false.
+     * @param {number} [options.type] - Specifies the image type, see {@link pc.TEXTURETYPE_GENERAL}
      * @param {boolean} [options.rgbm] - Specifies whether the texture contains RGBM-encoded HDR data. Defaults to false.
+     * @param {boolean} [options.rgbe] - Specifies whther the texture contains RGBE-encoded HDR data. Defaults to false.
      * @param {boolean} [options.swizzleGGGR] - Specifies whether the texture contains swizzled GGGR data for use with tangent space normal
      * maps. The R component is stored in alpha and G is stored in RGB. This packing can result in higher quality when the texture data
      * is compressed. Defaults to false.
@@ -100,8 +102,7 @@ Object.assign(pc, function () {
         this._depth = 1;
 
         this._format = pc.PIXELFORMAT_R8_G8_B8_A8;
-        this.rgbm = false;
-        this.swizzleGGGR = false;
+        this.type = pc.TEXTURETYPE_GENERAL;
 
         this._cubemap = false;
         this._volume = false;
@@ -133,8 +134,16 @@ Object.assign(pc, function () {
             this._height = (options.height !== undefined) ? options.height : this._height;
 
             this._format = (options.format !== undefined) ? options.format : this._format;
-            this.rgbm = (options.rgbm !== undefined) ? options.rgbm : this.rgbm;
-            this.swizzleGGGR = (options.swizzleGGGR !== undefined) ? options.swizzleGGGR : this.swizzleGGGR;
+
+            if (options.type !== undefined) {
+                this.type = options.type;
+            } else if (options.rgbm !== undefined) {
+                this.type = !!options.rgbm ? pc.TEXTURETYPE_RGBM : pc.TEXTURETYPE_GENERAL;
+            } else if (options.rgbe !== undefined) {
+                this.type = !!options.rgbe ? pc.TEXTURETYPE_RGBE : pc.TEXTURETYPE_GENERAL;
+            } else if (options.swizzleGGGR !== undefined) {
+                this.type = !!options.swizzleGGGR ? pc.TEXTURETYPE_SWIZZLEGGGR : pc.TEXTURETYPE_GENERAL;
+            }
 
             if (options.mipmaps !== undefined) {
                 this._mipmaps = options.mipmaps;
@@ -542,6 +551,33 @@ Object.assign(pc, function () {
     Object.defineProperty(Texture.prototype, 'pot',  {
         get: function () {
             return pc.math.powerOfTwo(this._width) && pc.math.powerOfTwo(this._height);
+        }
+    });
+
+    Object.defineProperty(Texture.prototype, 'rgbm', {
+        get: function () {
+            return this.type === pc.TEXTURETYPE_RGBM;
+        },
+        set: function (rgbm) {
+            this.type = rgbm ? pc.TEXTURETYPE_RGBM : pc.TEXTURETYPE_GENERAL;
+        }
+    });
+
+    Object.defineProperty(Texture.prototype, 'rgbe', {
+        get: function () {
+            return this.type === pc.TEXTURETYPE_RGBE;
+        },
+        set: function (rgbe) {
+            this.type = rgbe ? pc.TEXTURETYPE_RGBE : pc.TEXTURETYPE_GENERAL;
+        }
+    });
+
+    Object.defineProperty(Texture.prototype, 'swizzleGGGR', {
+        get: function () {
+            return this.type === pc.TEXTURETYPE_SWIZZLEGGGR;
+        },
+        set: function (swizzleGGGR) {
+            this.type = swizzleGGGR ? pc.TEXTURETYPE_SWIZZLEGGGR : pc.TEXTURETYPE_GENERAL;
         }
     });
 

--- a/src/resources/parser/glb-parser.js
+++ b/src/resources/parser/glb-parser.js
@@ -1285,6 +1285,7 @@ Object.assign(pc, function () {
             var mimeTypeFileExtensions = {
                 'image/png': 'png',
                 'image/jpg': 'jpg',
+                'image/jpeg': 'jpeg',
                 'image/basis': 'basis',
                 'image/ktx': 'ktx',
                 'image/vnd-ms.dds': 'dds'

--- a/src/resources/parser/texture/basis.js
+++ b/src/resources/parser/texture/basis.js
@@ -1,0 +1,70 @@
+Object.assign(pc, function () {
+
+    /**
+     * @class
+     * @name pc.BasisParser
+     * @implements {pc.TextureParser}
+     * @classdesc Parser for basis files.
+     */
+    var BasisParser = function (retryRequests) {
+        this.retryRequests = !!retryRequests;
+    };
+
+    Object.assign(BasisParser.prototype, {
+        load: function (url, callback, asset) {
+            var options = {
+                cache: true,
+                responseType: "arraybuffer",
+                retry: this.retryRequests
+            };
+            pc.http.get(
+                url.load,
+                options,
+                function (err, result) {
+                    if (err) {
+                        callback(err, result);
+                    } else {
+                        // massive hack for pvr textures (i.e. apple devices)
+                        // the quality of GGGR normal maps under PVR compression is still terrible
+                        // so here we instruct the basis transcoder to unswizzle the normal map data
+                        // and pack to 565
+                        var unswizzleGGGR = pc.basisTargetFormat() === 'pvr' &&
+                                            asset && asset.file && asset.file.variants &&
+                                            asset.file.variants.basis &&
+                                            ((asset.file.variants.basis.opt & 8) !== 0);
+                        if (unswizzleGGGR) {
+                            // remove the swizzled flag from the asset
+                            asset.file.variants.basis.opt &= ~8;
+                        }
+                        pc.basisTranscode(url.load, result, callback, { unswizzleGGGR: unswizzleGGGR });
+                    }
+                }
+            );
+        },
+
+        // our async transcode call provides the neat structure we need to create the texture instance
+        open: function (url, data, device) {
+            var texture = new pc.Texture(device, {
+                name: url,
+                // #ifdef PROFILER
+                profilerHint: pc.TEXHINT_ASSET,
+                // #endif
+                addressU: data.cubemap ? pc.ADDRESS_CLAMP_TO_EDGE : pc.ADDRESS_REPEAT,
+                addressV: data.cubemap ? pc.ADDRESS_CLAMP_TO_EDGE : pc.ADDRESS_REPEAT,
+                width: data.width,
+                height: data.height,
+                format: data.format,
+                cubemap: data.cubemap,
+                levels: data.levels
+            });
+
+            texture.upload();
+
+            return texture;
+        }
+    });
+
+    return {
+        BasisParser: BasisParser
+    };
+}());

--- a/src/resources/parser/texture/dds.js
+++ b/src/resources/parser/texture/dds.js
@@ -1,0 +1,248 @@
+Object.assign(pc, function () {
+
+    /* eslint-disable no-unused-vars */
+
+    // Defined here:
+    // https://docs.microsoft.com/en-us/windows/desktop/direct3ddds/dds-header
+    var DDSD_CAPS = 0x1;            // Required in every .dds file.
+    var DDSD_HEIGHT = 0x2;          // Required in every .dds file.
+    var DDSD_WIDTH = 0x4;           // Required in every .dds file.
+    var DDSD_PITCH = 0x8;           // Required when pitch is provided for an uncompressed texture.
+    var DDSD_PIXELFORMAT = 0x1000;  // Required in every .dds file.
+    var DDSD_MIPMAPCOUNT = 0x20000; // Required in a mipmapped texture.
+    var DDSD_LINEARSIZE = 0x80000;  // Required when pitch is provided for a compressed texture.
+    var DDSD_DEPTH = 0x800000;      // Required in a depth texture.
+
+    var DDSCAPS2_CUBEMAP = 0x200;
+    var DDSCAPS2_CUBEMAP_POSITIVEX = 0x400;
+    var DDSCAPS2_CUBEMAP_NEGATIVEX = 0x800;
+    var DDSCAPS2_CUBEMAP_POSITIVEY = 0x1000;
+    var DDSCAPS2_CUBEMAP_NEGATIVEY = 0x2000;
+    var DDSCAPS2_CUBEMAP_POSITIVEZ = 0x4000;
+    var DDSCAPS2_CUBEMAP_NEGATIVEZ = 0x8000;
+
+    var DDS_CUBEMAP_ALLFACES = DDSCAPS2_CUBEMAP |
+        DDSCAPS2_CUBEMAP_POSITIVEX | DDSCAPS2_CUBEMAP_NEGATIVEX |
+        DDSCAPS2_CUBEMAP_POSITIVEY | DDSCAPS2_CUBEMAP_NEGATIVEY |
+        DDSCAPS2_CUBEMAP_POSITIVEZ | DDSCAPS2_CUBEMAP_NEGATIVEZ;
+
+    // Defined here:
+    // https://docs.microsoft.com/en-us/windows/desktop/direct3ddds/dds-pixelformat
+    var DDPF_ALPHAPIXELS = 0x1;
+    var DDPF_ALPHA = 0x2;
+    var DDPF_FOURCC = 0x4;
+    var DDPF_RGB = 0x40;
+    var DDPF_YUV = 0x200;
+    var DDPF_LUMINANCE = 0x20000;
+
+    /* eslint-enable no-unused-vars */
+
+    // FourCC construction
+    var makeFourCC = function (str) {
+        return str.charCodeAt(0) +
+               (str.charCodeAt(1) << 8) +
+               (str.charCodeAt(2) << 16) +
+               (str.charCodeAt(3) << 24);
+    };
+
+    var DDS_MAGIC = makeFourCC('DDS ');
+
+    // Standard
+    var FCC_DXT1 = makeFourCC('DXT1');
+    var FCC_DXT5 = makeFourCC('DXT5');
+    var FCC_DX10 = makeFourCC('DX10');
+    var FCC_FP32 = 116; // RGBA32f
+
+    // Non-standard
+    var FCC_ETC1 = makeFourCC('ETC1');
+    var FCC_PVRTC_2BPP_RGB_1 = makeFourCC('P231');
+    var FCC_PVRTC_2BPP_RGBA_1 = makeFourCC('P241');
+    var FCC_PVRTC_4BPP_RGB_1 = makeFourCC('P431');
+    var FCC_PVRTC_4BPP_RGBA_1 = makeFourCC('P441');
+
+    var fccToFormat = {};
+    fccToFormat[FCC_FP32] = pc.PIXELFORMAT_RGBA32F;
+    fccToFormat[FCC_DXT1] = pc.PIXELFORMAT_DXT1;
+    fccToFormat[FCC_DXT5] = pc.PIXELFORMAT_DXT5;
+    fccToFormat[FCC_ETC1] = pc.PIXELFORMAT_ETC1;
+    fccToFormat[FCC_PVRTC_2BPP_RGB_1] = pc.PIXELFORMAT_PVRTC_2BPP_RGB_1;
+    fccToFormat[FCC_PVRTC_2BPP_RGBA_1] = pc.PIXELFORMAT_PVRTC_2BPP_RGBA_1;
+    fccToFormat[FCC_PVRTC_4BPP_RGB_1] = pc.PIXELFORMAT_PVRTC_4BPP_RGB_1;
+    fccToFormat[FCC_PVRTC_4BPP_RGBA_1] = pc.PIXELFORMAT_PVRTC_4BPP_RGBA_1;
+
+    /**
+     * @class
+     * @name pc.DdsParser
+     * @implements {pc.TextureParser}
+     * @classdesc Texture parser for dds files.
+     */
+    var DdsParser = function (retryRequests) {
+        this.retryRequests = !!retryRequests;
+    };
+
+    Object.assign(DdsParser.prototype, {
+
+        load: function (url, callback, asset) {
+            var options = {
+                cache: true,
+                responseType: "arraybuffer",
+                retry: this.retryRequests
+            };
+            pc.http.get(url.load, options, callback);
+        },
+
+        open: function (url, data, device) {
+            var textureData = this.parse(data);
+
+            if (!textureData) {
+                return null;
+            }
+
+            var texture = new pc.Texture(device, {
+                name: url,
+                // #ifdef PROFILER
+                profilerHint: pc.TEXHINT_ASSET,
+                // #endif
+                addressU: textureData.cubemap ? pc.ADDRESS_CLAMP_TO_EDGE : pc.ADDRESS_REPEAT,
+                addressV: textureData.cubemap ? pc.ADDRESS_CLAMP_TO_EDGE : pc.ADDRESS_REPEAT,
+                width: textureData.width,
+                height: textureData.height,
+                format: textureData.format,
+                cubemap: textureData.cubemap,
+                levels: textureData.levels
+            });
+
+            texture.upload();
+
+            return texture;
+        },
+
+        parse: function (data) {
+            var arrayBuffer = data;
+
+            var headerU32 = new Uint32Array(arrayBuffer, 0, 32);
+
+            // Check magic number
+            var magic = headerU32[0];
+            if (magic !== DDS_MAGIC) {
+                // #ifdef DEBUG
+                console.warn("Invalid magic number found in DDS file. Expected 0x20534444. Got " + magic + ".");
+                // #endif
+                return null;
+            }
+
+            var header = {
+                size: headerU32[1],
+                flags: headerU32[2],
+                height: headerU32[3],
+                width: headerU32[4],
+                pitchOrLinearSize: headerU32[5],
+                depth: headerU32[6],
+                mipMapCount: Math.max(headerU32[7], 1),
+                // DWORDSs 8 - 18 are reserved
+                ddspf: {
+                    size: headerU32[19],
+                    flags: headerU32[20],
+                    fourCc: headerU32[21],
+                    rgbBitCount: headerU32[22],
+                    rBitMask: headerU32[23],
+                    gBitMask: headerU32[24],
+                    bBitMask: headerU32[25],
+                    aBitMask: headerU32[26]
+                },
+                caps: headerU32[27],
+                caps2: headerU32[28],
+                caps3: headerU32[29],
+                caps4: headerU32[30]
+                // DWORD 31 is reserved
+            };
+
+            // Verify DDS header size
+            if (header.size !== 124) {
+                // #ifdef DEBUG
+                console.warn("Invalid size for DDS header. Expected 124. Got " + header.size + ".");
+                // #endif
+                return null;
+            }
+
+            // Byte offset locating the first byte of texture level data
+            var offset = 4 + header.size;
+
+            // If the ddspf.flags property is set to DDPF_FOURCC and ddspf.fourCc is set to
+            // "DX10" an additional DDS_HEADER_DXT10 structure will be present.
+            // https://docs.microsoft.com/en-us/windows/desktop/direct3ddds/dds-header-dxt10
+            // var header10; // not used
+            var isFcc = header.ddspf.flags & DDPF_FOURCC;
+            var fcc = header.ddspf.fourCc;
+            if (isFcc && (fcc === FCC_DX10)) {
+                headerU32 = new Uint32Array(arrayBuffer, 128, 5);
+                // header10 = {
+                //     dxgiFormat: headerU32[0],
+                //     resourceDimension: headerU32[1],
+                //     miscFlag: headerU32[2],
+                //     arraySize: headerU32[3],
+                //     miscFlags2: headerU32[4]
+                // };
+                offset += 20;
+            }
+
+            // Read texture data
+            // var bpp = header.ddspf.rgbBitCount; // not used
+            var isCubeMap = header.caps2 === DDS_CUBEMAP_ALLFACES;
+            var numFaces = isCubeMap ? 6 : 1;
+            var numMips = header.flags & DDSD_MIPMAPCOUNT ? header.mipMapCount : 1;
+            var levels = [];
+            if (isCubeMap) {
+                for (var mipCnt = 0; mipCnt < numMips; mipCnt++) {
+                    levels.push([]);
+                }
+            }
+            for (var face = 0; face < numFaces; face++) {
+                var mipWidth = header.width;
+                var mipHeight = header.height;
+
+                for (var mip = 0; mip < numMips; mip++) {
+                    var mipSize;
+                    if ((fcc === FCC_DXT1) || (fcc === FCC_DXT5) || (fcc === FCC_ETC1)) {
+                        var bytesPerBlock = (fcc === FCC_DXT5) ? 16 : 8;
+                        mipSize = Math.floor((mipWidth + 3) / 4) * Math.floor((mipHeight + 3) / 4) * bytesPerBlock;
+                    } else if ((fcc === FCC_PVRTC_2BPP_RGB_1 || fcc === FCC_PVRTC_2BPP_RGBA_1)) {
+                        mipSize = Math.max(mipWidth, 16) * Math.max(mipHeight, 8) / 4;
+                    } else if ((fcc === FCC_PVRTC_4BPP_RGB_1 || fcc === FCC_PVRTC_4BPP_RGBA_1)) {
+                        mipSize = Math.max(mipWidth, 8) * Math.max(mipHeight, 8) / 2;
+                    } else if (header.ddspf.rgbBitCount === 32) {
+                        // f32 or uncompressed rgba
+                        // 4 floats per texel
+                        mipSize = mipWidth * mipHeight * 4;
+                    } else {
+                        // Unsupported format
+                        return null;
+                    }
+
+                    var mipData = (fcc === FCC_FP32) ? new Float32Array(arrayBuffer, offset, mipSize) : new Uint8Array(arrayBuffer, offset, mipSize);
+                    if (isCubeMap) {
+                        levels[mip][face] = mipData;
+                    } else {
+                        levels.push(mipData);
+                    }
+
+                    offset += (fcc === FCC_FP32) ? mipSize * 4 : mipSize;
+                    mipWidth = Math.max(mipWidth * 0.5, 1);
+                    mipHeight = Math.max(mipHeight * 0.5, 1);
+                }
+            }
+
+            return {
+                format: fccToFormat[fcc] || pc.PIXELFORMAT_R8_G8_B8_A8,
+                width: header.width,
+                height: header.height,
+                levels: levels,
+                cubemap: isCubeMap
+            };
+        }
+    });
+
+    return {
+        DdsParser: DdsParser
+    };
+}());

--- a/src/resources/parser/texture/img.js
+++ b/src/resources/parser/texture/img.js
@@ -1,0 +1,89 @@
+Object.assign(pc, function () {
+
+    /**
+     * @class
+     * @name pc.ImgParser
+     * @implements {pc.TextureParser}
+     * @classdesc Parser for browser-supported image formats.
+     */
+    var ImgParser = function (registry, retryRequests) {
+        // by default don't try cross-origin, because some browsers send different cookies (e.g. safari) if this is set.
+        this.crossOrigin = registry.prefix ? 'anonymous' : undefined;
+        this.retryRequests = !!retryRequests;
+    };
+
+    Object.assign(ImgParser.prototype, {
+        load: function (url, callback, asset) {
+            var crossOrigin;
+
+            // only apply cross-origin setting if this is an absolute URL, relative URLs can never be cross-origin
+            if (this.crossOrigin !== undefined && pc.ABSOLUTE_URL.test(url.load)) {
+                crossOrigin = self.crossOrigin;
+            }
+
+            this._loadImage(url.load, url.original, crossOrigin, callback);
+        },
+
+        open: function (url, data, device) {
+            var ext = pc.path.getExtension(url).toLowerCase();
+            var format = (ext === ".jpg" || ext === ".jpeg") ? pc.PIXELFORMAT_R8_G8_B8 : pc.PIXELFORMAT_R8_G8_B8_A8;
+            var texture = new pc.Texture(device, {
+                name: url,
+                // #ifdef PROFILER
+                profilerHint: pc.TEXHINT_ASSET,
+                // #endif
+                width: data.width,
+                height: data.height,
+                format: format
+            });
+            texture.setSource(data);
+            return texture;
+        },
+
+        _loadImage: function (url, originalUrl, crossOrigin, callback) {
+            var image = new Image();
+            if (crossOrigin) {
+                image.crossOrigin = crossOrigin;
+            }
+
+            var retries = 0;
+            var maxRetries = 5;
+            var retryTimeout;
+            var retryRequests = this.retryRequests;
+
+            // Call success callback after opening Texture
+            image.onload = function () {
+                callback(null, image);
+            };
+
+            image.onerror = function () {
+                // Retry a few times before failing
+                if (retryTimeout) return;
+
+                if (retryRequests && ++retries <= maxRetries) {
+                    var retryDelay = Math.pow(2, retries) * 100;
+                    console.log(pc.string.format("Error loading Texture from: '{0}' - Retrying in {1}ms...", originalUrl, retryDelay));
+
+                    var idx = url.indexOf('?');
+                    var separator = idx >= 0 ? '&' : '?';
+
+                    retryTimeout = setTimeout(function () {
+                        // we need to add a cache busting argument if we are trying to re-load an image element
+                        // with the same URL
+                        image.src = url + separator + 'retry=' + Date.now();
+                        retryTimeout = null;
+                    }, retryDelay);
+                } else {
+                    // Call error callback with details.
+                    callback(pc.string.format("Error loading Texture from: '{0}'", originalUrl));
+                }
+            };
+
+            image.src = url;
+        }
+    });
+
+    return {
+        ImgParser: ImgParser
+    };
+}());

--- a/src/resources/parser/texture/ktx.js
+++ b/src/resources/parser/texture/ktx.js
@@ -1,0 +1,165 @@
+Object.assign(pc, function () {
+    // Defined here: https://www.khronos.org/opengles/sdk/tools/KTX/file_format_spec/
+    var IDENTIFIER = [0x58544BAB, 0xBB313120, 0x0A1A0A0D]; // «KTX 11»\r\n\x1A\n
+    var KNOWN_FORMATS = {
+        0x83F0: pc.PIXELFORMAT_DXT1,
+        0x83F2: pc.PIXELFORMAT_DXT3,
+        0x83F3: pc.PIXELFORMAT_DXT5,
+        0x8D64: pc.PIXELFORMAT_ETC1,
+        0x9274: pc.PIXELFORMAT_ETC2_RGB,
+        0x9278: pc.PIXELFORMAT_ETC2_RGBA,
+        0x8C00: pc.PIXELFORMAT_PVRTC_4BPP_RGB_1,
+        0x8C01: pc.PIXELFORMAT_PVRTC_2BPP_RGB_1,
+        0x8C02: pc.PIXELFORMAT_PVRTC_4BPP_RGBA_1,
+        0x8C03: pc.PIXELFORMAT_PVRTC_2BPP_RGBA_1
+    };
+
+    /**
+     * @class
+     * @name pc.KtxParser
+     * @implements {pc.TextureParser}
+     * @classdesc Texture parser for ktx files.
+     */
+    var KtxParser = function (registry, retryRequests) {
+        this.retryRequests = !!retryRequests;
+    };
+
+    Object.assign(KtxParser.prototype, {
+
+        load: function (url, callback, asset) {
+            var options = {
+                cache: true,
+                responseType: "arraybuffer",
+                retry: this.retryRequests
+            };
+            pc.http.get(url.load, options, callback);
+        },
+
+        open: function (url, data, device) {
+            var textureData = this.parse(data);
+
+            if (!textureData) {
+                return null;
+            }
+
+            var texture = new pc.Texture(device, {
+                name: url,
+                // #ifdef PROFILER
+                profilerHint: pc.TEXHINT_ASSET,
+                // #endif
+                addressU: textureData.cubemap ? pc.ADDRESS_CLAMP_TO_EDGE : pc.ADDRESS_REPEAT,
+                addressV: textureData.cubemap ? pc.ADDRESS_CLAMP_TO_EDGE : pc.ADDRESS_REPEAT,
+                width: textureData.width,
+                height: textureData.height,
+                format: textureData.format,
+                cubemap: textureData.cubemap,
+                levels: textureData.levels
+            });
+
+            texture.upload();
+
+            return texture;
+        },
+
+        parse: function (data) {
+            var headerU32 = new Uint32Array(data, 0, 16);
+
+            if (IDENTIFIER[0] !== headerU32[0] || IDENTIFIER[1] !== headerU32[1] || IDENTIFIER[2] !== headerU32[2]) {
+                // #ifdef DEBUG
+                console.warn("Invalid definition header found in KTX file. Expected 0xAB4B5458, 0x203131BB, 0x0D0A1A0A");
+                // #endif
+                return null;
+            }
+
+            var header = {
+                endianness: headerU32[3], // todo: Use this information
+                glType: headerU32[4],
+                glTypeSize: headerU32[5],
+                glFormat: headerU32[6],
+                glInternalFormat: headerU32[7],
+                glBaseInternalFormat: headerU32[8],
+                pixelWidth: headerU32[9],
+                pixelHeight: headerU32[10],
+                pixelDepth: headerU32[11],
+                numberOfArrayElements: headerU32[12],
+                numberOfFaces: headerU32[13],
+                numberOfMipmapLevels: headerU32[14],
+                bytesOfKeyValueData: headerU32[15]
+            };
+
+            if (header.pixelDepth > 1) {
+                // #ifdef DEBUG
+                console.warn("More than 1 pixel depth not supported!");
+                // #endif
+                return null;
+            }
+
+            if (header.numberOfArrayElements > 1) {
+                // #ifdef DEBUG
+                console.warn("Array texture not supported!");
+                // #endif
+                return null;
+            }
+
+            if (header.glFormat !== 0) {
+                // #ifdef DEBUG
+                console.warn("We only support compressed formats!");
+                // #endif
+                return null;
+            }
+
+            if (!KNOWN_FORMATS[header.glInternalFormat]) {
+                // #ifdef DEBUG
+                console.warn("Unknown glInternalFormat: " + header.glInternalFormat);
+                // #endif
+                return null;
+            }
+
+            // Byte offset locating the first byte of texture level data
+            var offset = (16 * 4) + header.bytesOfKeyValueData;
+
+            var levels = [];
+            var isCubeMap = false;
+            for (var mipmapLevel = 0; mipmapLevel < (header.numberOfMipmapLevels || 1); mipmapLevel++) {
+                var imageSizeInBytes = new Uint32Array(data.slice(offset, offset + 4))[0];
+                offset += 4;
+                // Currently array textures not supported. Keeping this here for referance.
+                // for (var arrayElement = 0; arrayElement < (header.numberOfArrayElements || 1); arrayElement++) {
+                var faceSizeInBytes = imageSizeInBytes / (header.numberOfFaces || 1);
+                // Create array for cubemaps
+                if (header.numberOfFaces > 1) {
+                    isCubeMap = true;
+                    levels.push([]);
+                }
+                for (var face = 0; face < header.numberOfFaces; face++) {
+                    // Currently more than 1 pixel depth not supported. Keeping this here for referance.
+                    // for (var  zSlice = 0; zSlice < (header.pixelDepth || 1); zSlice++) {
+                    var mipData = new Uint8Array(data, offset, faceSizeInBytes);
+                    // Handle cubemaps
+                    if (header.numberOfFaces > 1) {
+                        levels[mipmapLevel].push(mipData);
+                    } else {
+                        levels.push(mipData);
+                    }
+                    offset += faceSizeInBytes;
+                // }
+                }
+                offset += 3 - ((offset + 3) % 4);
+                // }
+                // offset += 3 - ((offset + 3) % 4);
+            }
+
+            return {
+                format: KNOWN_FORMATS[header.glInternalFormat],
+                width: header.pixelWidth,
+                height: header.pixelHeight,
+                levels: levels,
+                cubemap: isCubeMap
+            };
+        }
+    });
+
+    return {
+        KtxParser: KtxParser
+    };
+}());

--- a/src/resources/parser/texture/legacy-dds.js
+++ b/src/resources/parser/texture/legacy-dds.js
@@ -1,0 +1,159 @@
+Object.assign(pc, function () {
+
+    /**
+     * @class
+     * @name pc.LegacyDdsParser
+     * @implements {pc.TextureParser}
+     * @classdesc Legacy texture parser for dds files.
+     */
+    var LegacyDdsParser = function (registry, retryRequests) {
+        this.retryRequests = retryRequests;
+    };
+
+    Object.assign(LegacyDdsParser.prototype, {
+        load: function (url, callback, asset) {
+            var options = {
+                cache: true,
+                responseType: "arraybuffer",
+                retry: this.retryRequests
+            };
+            pc.http.get(url.load, options, callback);
+        },
+
+        open: function (url, data, device) {
+            var header = new Uint32Array(data, 0, 128 / 4);
+
+            var width = header[4];
+            var height = header[3];
+            var mips = Math.max(header[7], 1);
+            var isFourCc = header[20] === 4;
+            var fcc = header[21];
+            var bpp = header[22];
+            var isCubemap = header[28] === 65024; // TODO: check by bitflag
+
+            var FCC_DXT1 = 827611204; // DXT1
+            var FCC_DXT5 = 894720068; // DXT5
+            var FCC_FP32 = 116; // RGBA32f
+
+            // non standard
+            var FCC_ETC1 = 826496069;
+            var FCC_PVRTC_2BPP_RGB_1 = 825438800;
+            var FCC_PVRTC_2BPP_RGBA_1 = 825504336;
+            var FCC_PVRTC_4BPP_RGB_1 = 825439312;
+            var FCC_PVRTC_4BPP_RGBA_1 = 825504848;
+
+            var compressed = false;
+            var floating = false;
+            var etc1 = false;
+            var pvrtc2 = false;
+            var pvrtc4 = false;
+            var format = null;
+
+            var texture;
+
+            if (isFourCc) {
+                if (fcc === FCC_DXT1) {
+                    format = pc.PIXELFORMAT_DXT1;
+                    compressed = true;
+                } else if (fcc === FCC_DXT5) {
+                    format = pc.PIXELFORMAT_DXT5;
+                    compressed = true;
+                } else if (fcc === FCC_FP32) {
+                    format = pc.PIXELFORMAT_RGBA32F;
+                    floating = true;
+                } else if (fcc === FCC_ETC1) {
+                    format = pc.PIXELFORMAT_ETC1;
+                    compressed = true;
+                    etc1 = true;
+                } else if (fcc === FCC_PVRTC_2BPP_RGB_1 || fcc === FCC_PVRTC_2BPP_RGBA_1) {
+                    format = fcc === FCC_PVRTC_2BPP_RGB_1 ? pc.PIXELFORMAT_PVRTC_2BPP_RGB_1 : pc.PIXELFORMAT_PVRTC_2BPP_RGBA_1;
+                    compressed = true;
+                    pvrtc2 = true;
+                } else if (fcc === FCC_PVRTC_4BPP_RGB_1 || fcc === FCC_PVRTC_4BPP_RGBA_1) {
+                    format = fcc === FCC_PVRTC_4BPP_RGB_1 ? pc.PIXELFORMAT_PVRTC_4BPP_RGB_1 : pc.PIXELFORMAT_PVRTC_4BPP_RGBA_1;
+                    compressed = true;
+                    pvrtc4 = true;
+                }
+            } else {
+                if (bpp === 32) {
+                    format = pc.PIXELFORMAT_R8_G8_B8_A8;
+                }
+            }
+
+            if (!format) {
+                // #ifdef DEBUG
+                console.error("This DDS pixel format is currently unsupported. Empty texture will be created instead.");
+                // #endif
+                texture = new pc.Texture(device, {
+                    width: 4,
+                    height: 4,
+                    format: pc.PIXELFORMAT_R8_G8_B8
+                });
+                texture.name = 'dds-legacy-empty';
+                return texture;
+            }
+
+            texture = new pc.Texture(device, {
+                name: url,
+                // #ifdef PROFILER
+                profilerHint: pc.TEXHINT_ASSET,
+                // #endif
+                addressU: isCubemap ? pc.ADDRESS_CLAMP_TO_EDGE : pc.ADDRESS_REPEAT,
+                addressV: isCubemap ? pc.ADDRESS_CLAMP_TO_EDGE : pc.ADDRESS_REPEAT,
+                width: width,
+                height: height,
+                format: format,
+                cubemap: isCubemap
+            });
+
+            var offset = 128;
+            var faces = isCubemap ? 6 : 1;
+            var mipSize;
+            var DXT_BLOCK_WIDTH = 4;
+            var DXT_BLOCK_HEIGHT = 4;
+            var blockSize = fcc === FCC_DXT1 ? 8 : 16;
+            var numBlocksAcross, numBlocksDown, numBlocks;
+            for (var face = 0; face < faces; face++) {
+                var mipWidth = width;
+                var mipHeight = height;
+                for (var i = 0; i < mips; i++) {
+                    if (compressed) {
+                        if (etc1) {
+                            mipSize = Math.floor((mipWidth + 3) / 4) * Math.floor((mipHeight + 3) / 4) * 8;
+                        } else if (pvrtc2) {
+                            mipSize = Math.max(mipWidth, 16) * Math.max(mipHeight, 8) / 4;
+                        } else if (pvrtc4) {
+                            mipSize = Math.max(mipWidth, 8) * Math.max(mipHeight, 8) / 2;
+                        } else {
+                            numBlocksAcross = Math.floor((mipWidth + DXT_BLOCK_WIDTH - 1) / DXT_BLOCK_WIDTH);
+                            numBlocksDown = Math.floor((mipHeight + DXT_BLOCK_HEIGHT - 1) / DXT_BLOCK_HEIGHT);
+                            numBlocks = numBlocksAcross * numBlocksDown;
+                            mipSize = numBlocks * blockSize;
+                        }
+                    } else {
+                        mipSize = mipWidth * mipHeight * 4;
+                    }
+
+                    var mipBuff = floating ? new Float32Array(data, offset, mipSize) : new Uint8Array(data, offset, mipSize);
+                    if (!isCubemap) {
+                        texture._levels[i] = mipBuff;
+                    } else {
+                        if (!texture._levels[i]) texture._levels[i] = [];
+                        texture._levels[i][face] = mipBuff;
+                    }
+                    offset += floating ? mipSize * 4 : mipSize;
+                    mipWidth = Math.max(mipWidth * 0.5, 1);
+                    mipHeight = Math.max(mipHeight * 0.5, 1);
+                }
+            }
+
+            texture.upload();
+
+            return texture;
+        }
+    });
+
+    return {
+        LegacyDdsParser: LegacyDdsParser
+    };
+}());

--- a/src/resources/texture.js
+++ b/src/resources/texture.js
@@ -16,172 +16,48 @@ Object.assign(pc, function () {
         "linear_mip_linear": pc.FILTER_LINEAR_MIPMAP_LINEAR
     };
 
-    function arrayBufferCopy(src, dst, dstByteOffset, numBytes) {
-        var i;
-        var dst32Offset = dstByteOffset / 4;
-        var tail = (numBytes % 4);
-        var src32 = new Uint32Array(src.buffer, 0, (numBytes - tail) / 4);
-        var dst32 = new Uint32Array(dst.buffer);
-        for (i = 0; i < src32.length; i++) {
-            dst32[dst32Offset + i] = src32[i];
+    /**
+     * @interface
+     * @name pc.TextureParser
+     * @description Interface to a texture parser. Implementations of this interface handle the loading
+     * and opening of texture assets.
+     */
+    var TextureParser = function () { };
+
+    Object.assign(TextureParser.prototype, {
+        /**
+         * @function
+         * @name pc.TextureParser#load
+         * @description Load the texture from the remote URL. When loaded (or failed),
+         * use the callback to return an the raw resource data (or error).
+         * @param {object} url - The URL of the resource to load.
+         * @param {string} url.load - The URL to use for loading the resource
+         * @param {string} url.original - The original URL useful for identifying the resource type
+         * @param {pc.callbacks.ResourceHandler} callback - The callback used when the resource is loaded or an error occurs.
+         * @param {pc.Asset} [asset] - Optional asset that is passed by ResourceLoader.
+         */
+        /* eslint-disable jsdoc/require-returns-check */
+        load: function (url, callback, asset) {
+            throw new Error('not implemented');
+        },
+        /* eslint-enable jsdoc/require-returns-check */
+
+        /**
+         * @function
+         * @name pc.TextureParser#open
+         * @description Convert raw resource data into a resource instance. E.g. Take 3D model format JSON and return a pc.Model.
+         * @param {string} url - The URL of the resource to open.
+         * @param {*} data - The raw resource data passed by callback from {@link pc.ResourceHandler#load}.
+         * @param {pc.Asset|null} asset - Optional asset which is passed in by ResourceLoader.
+         * @param {pc.GraphicsDevice} device - The graphics device
+         * @returns {pc.Texture} The parsed resource data.
+         */
+        /* eslint-disable jsdoc/require-returns-check */
+        open: function (url, data, device) {
+            throw new Error('not implemented');
         }
-        for (i = numBytes - tail; i < numBytes; i++) {
-            dst[dstByteOffset + i] = src[i];
-        }
-    }
-
-    var _legacyDdsLoader = function (url, data, graphicsDevice) {
-
-        var ext = pc.path.getExtension(url).toLowerCase();
-
-        if (ext === ".crn") {
-            // Copy loaded file into Emscripten-managed memory
-            var srcSize = data.byteLength;
-            var bytes = new Uint8Array(data);
-            var src = Module._malloc(srcSize);
-            arrayBufferCopy(bytes, Module.HEAPU8, src, srcSize);
-
-            // Decompress CRN to DDS (minus the header)
-            var dst = Module._crn_decompress_get_data(src, srcSize);
-            var dstSize = Module._crn_decompress_get_size(src, srcSize);
-
-            data = Module.HEAPU8.buffer.slice(dst, dst + dstSize);
-        }
-
-        // DDS loading
-        var header = new Uint32Array(data, 0, 128 / 4);
-
-        var width = header[4];
-        var height = header[3];
-        var mips = Math.max(header[7], 1);
-        var isFourCc = header[20] === 4;
-        var fcc = header[21];
-        var bpp = header[22];
-        var isCubemap = header[28] === 65024; // TODO: check by bitflag
-
-        var FCC_DXT1 = 827611204; // DXT1
-        var FCC_DXT5 = 894720068; // DXT5
-        var FCC_FP32 = 116; // RGBA32f
-
-        // non standard
-        var FCC_ETC1 = 826496069;
-        var FCC_PVRTC_2BPP_RGB_1 = 825438800;
-        var FCC_PVRTC_2BPP_RGBA_1 = 825504336;
-        var FCC_PVRTC_4BPP_RGB_1 = 825439312;
-        var FCC_PVRTC_4BPP_RGBA_1 = 825504848;
-
-        var compressed = false;
-        var floating = false;
-        var etc1 = false;
-        var pvrtc2 = false;
-        var pvrtc4 = false;
-        var format = null;
-
-        var texture;
-
-        if (isFourCc) {
-            if (fcc === FCC_DXT1) {
-                format = pc.PIXELFORMAT_DXT1;
-                compressed = true;
-            } else if (fcc === FCC_DXT5) {
-                format = pc.PIXELFORMAT_DXT5;
-                compressed = true;
-            } else if (fcc === FCC_FP32) {
-                format = pc.PIXELFORMAT_RGBA32F;
-                floating = true;
-            } else if (fcc === FCC_ETC1) {
-                format = pc.PIXELFORMAT_ETC1;
-                compressed = true;
-                etc1 = true;
-            } else if (fcc === FCC_PVRTC_2BPP_RGB_1 || fcc === FCC_PVRTC_2BPP_RGBA_1) {
-                format = fcc === FCC_PVRTC_2BPP_RGB_1 ? pc.PIXELFORMAT_PVRTC_2BPP_RGB_1 : pc.PIXELFORMAT_PVRTC_2BPP_RGBA_1;
-                compressed = true;
-                pvrtc2 = true;
-            } else if (fcc === FCC_PVRTC_4BPP_RGB_1 || fcc === FCC_PVRTC_4BPP_RGBA_1) {
-                format = fcc === FCC_PVRTC_4BPP_RGB_1 ? pc.PIXELFORMAT_PVRTC_4BPP_RGB_1 : pc.PIXELFORMAT_PVRTC_4BPP_RGBA_1;
-                compressed = true;
-                pvrtc4 = true;
-            }
-        } else {
-            if (bpp === 32) {
-                format = pc.PIXELFORMAT_R8_G8_B8_A8;
-            }
-        }
-
-        if (!format) {
-            // #ifdef DEBUG
-            console.error("This DDS pixel format is currently unsupported. Empty texture will be created instead.");
-            // #endif
-            texture = new pc.Texture(graphicsDevice, {
-                width: 4,
-                height: 4,
-                format: pc.PIXELFORMAT_R8_G8_B8
-            });
-            texture.name = 'dds-legacy-empty';
-            return texture;
-        }
-
-        var texOptions = {
-            // #ifdef PROFILER
-            profilerHint: pc.TEXHINT_ASSET,
-            // #endif
-            width: width,
-            height: height,
-            format: format,
-            cubemap: isCubemap
-        };
-        texture = new pc.Texture(graphicsDevice, texOptions);
-        if (isCubemap) {
-            texture.addressU = pc.ADDRESS_CLAMP_TO_EDGE;
-            texture.addressV = pc.ADDRESS_CLAMP_TO_EDGE;
-        }
-
-        var offset = 128;
-        var faces = isCubemap ? 6 : 1;
-        var mipSize;
-        var DXT_BLOCK_WIDTH = 4;
-        var DXT_BLOCK_HEIGHT = 4;
-        var blockSize = fcc === FCC_DXT1 ? 8 : 16;
-        var numBlocksAcross, numBlocksDown, numBlocks;
-        for (var face = 0; face < faces; face++) {
-            var mipWidth = width;
-            var mipHeight = height;
-            for (var i = 0; i < mips; i++) {
-                if (compressed) {
-                    if (etc1) {
-                        mipSize = Math.floor((mipWidth + 3) / 4) * Math.floor((mipHeight + 3) / 4) * 8;
-                    } else if (pvrtc2) {
-                        mipSize = Math.max(mipWidth, 16) * Math.max(mipHeight, 8) / 4;
-                    } else if (pvrtc4) {
-                        mipSize = Math.max(mipWidth, 8) * Math.max(mipHeight, 8) / 2;
-                    } else {
-                        numBlocksAcross = Math.floor((mipWidth + DXT_BLOCK_WIDTH - 1) / DXT_BLOCK_WIDTH);
-                        numBlocksDown = Math.floor((mipHeight + DXT_BLOCK_HEIGHT - 1) / DXT_BLOCK_HEIGHT);
-                        numBlocks = numBlocksAcross * numBlocksDown;
-                        mipSize = numBlocks * blockSize;
-                    }
-                } else {
-                    mipSize = mipWidth * mipHeight * 4;
-                }
-
-                var mipBuff = floating ? new Float32Array(data, offset, mipSize) : new Uint8Array(data, offset, mipSize);
-                if (!isCubemap) {
-                    texture._levels[i] = mipBuff;
-                } else {
-                    if (!texture._levels[i]) texture._levels[i] = [];
-                    texture._levels[i][face] = mipBuff;
-                }
-                offset += floating ? mipSize * 4 : mipSize;
-                mipWidth = Math.max(mipWidth * 0.5, 1);
-                mipHeight = Math.max(mipHeight * 0.5, 1);
-            }
-        }
-
-        texture.name = url;
-        texture.upload();
-
-        return texture;
-    };
+        /* eslint-enable jsdoc/require-returns-check */
+    });
 
     // In the case where a texture has more than 1 level of mip data specified, but not the full
     // mip chain, we generate the missing levels here.
@@ -267,17 +143,27 @@ Object.assign(pc, function () {
         this._assets = assets;
         this._loader = loader;
 
-        // by default don't try cross-origin, because some browsers send different cookies (e.g. safari) if this is set.
-        this.crossOrigin = undefined;
-        if (assets.prefix) {
-            // ensure we send cookies if we load images.
-            this.crossOrigin = 'anonymous';
-        }
+        // img parser handles all broswer-supported image formats, this
+        // parser will be used when other more specific parsers are not found.
+        this.imgParser = new pc.ImgParser(assets, false);
 
-        this.retryRequests = false;
+        this.parsers = {
+            dds: new pc.LegacyDdsParser(assets, false),
+            ktx: new pc.KtxParser(assets, false),
+            basis: new pc.BasisParser(assets, false)
+        };
     };
 
     Object.assign(TextureHandler.prototype, {
+        _getUrlWithoutParams: function (url) {
+            return url.indexOf('?') >= 0 ? url.split('?')[0] : url;
+        },
+
+        _getParser: function (url) {
+            var ext = pc.path.getExtension(this._getUrlWithoutParams(url)).toLowerCase().replace('.', '');
+            return this.parsers[ext] || this.imgParser;
+        },
+
         load: function (url, callback, asset) {
             if (typeof url === 'string') {
                 url = {
@@ -286,240 +172,83 @@ Object.assign(pc, function () {
                 };
             }
 
-            var self = this;
-            var options;
-
-            var urlWithoutParams = url.original.indexOf('?') >= 0 ? url.original.split('?')[0] : url.original;
-
-            var ext = pc.path.getExtension(urlWithoutParams).toLowerCase();
-            if (ext === '.dds' || ext === '.ktx') {
-                options = {
-                    cache: true,
-                    responseType: "arraybuffer",
-                    retry: this.retryRequests
-                };
-                pc.http.get(url.load, options, callback);
-            } else if (ext === '.basis') {
-                options = {
-                    cache: true,
-                    responseType: "arraybuffer",
-                    retry: this.retryRequests
-                };
-                pc.http.get(
-                    url.load,
-                    options,
-                    function (err, result) {
-                        if (err) {
-                            callback(err, result);
-                        } else {
-                            // massive hack for pvr textures (i.e. apple devices)
-                            // the quality of GGGR normal maps under PVR compression is still terrible
-                            // so here we instruct the basis transcoder to unswizzle the normal map data
-                            // and pack to 565
-                            var unswizzleGGGR = pc.basisTargetFormat() === 'pvr' &&
-                                                asset && asset.file && asset.file.variants &&
-                                                asset.file.variants.basis &&
-                                                ((asset.file.variants.basis.opt & 8) !== 0);
-                            if (unswizzleGGGR) {
-                                // remove the swizzled flag from the asset
-                                asset.file.variants.basis.opt &= ~8;
-                            }
-                            pc.basisTranscode(url.load, result, callback, { unswizzleGGGR: unswizzleGGGR });
-                        }
-                    });
-            } else if ((ext === '.jpg') || (ext === '.jpeg') || (ext === '.gif') || (ext === '.png')) {
-                var crossOrigin;
-                // only apply cross-origin setting if this is an absolute URL, relative URLs can never be cross-origin
-                if (self.crossOrigin !== undefined && pc.ABSOLUTE_URL.test(url.load)) {
-                    crossOrigin = self.crossOrigin;
-                }
-
-                self._loadImage(url.load, url.original, crossOrigin, callback);
-            } else {
-                var blobStart = urlWithoutParams.indexOf("blob:");
-                if (blobStart >= 0) {
-                    urlWithoutParams = urlWithoutParams.substr(blobStart);
-                    url = urlWithoutParams;
-
-                    self._loadImage(url, url, null, callback);
-                } else {
-                    // Unsupported texture extension
-                    // Use timeout because asset events can be hooked up after load gets called in some
-                    // cases. For example, material loads a texture on 'add' event.
-                    setTimeout(function () {
-                        callback(pc.string.format("Error loading Texture: format not supported: '{0}'", ext));
-                    }, 0);
-                }
-            }
-        },
-
-        _loadImage: function (url, originalUrl, crossOrigin, callback) {
-            var image = new Image();
-            if (crossOrigin) {
-                image.crossOrigin = crossOrigin;
-            }
-
-            var retries = 0;
-            var maxRetries = 5;
-            var retryTimeout;
-            var retryRequests = this.retryRequests;
-
-            // Call success callback after opening Texture
-            image.onload = function () {
-                callback(null, image);
-            };
-
-            image.onerror = function () {
-                // Retry a few times before failing
-                if (retryTimeout) return;
-
-                if (retryRequests && ++retries <= maxRetries) {
-                    var retryDelay = Math.pow(2, retries) * 100;
-                    console.log(pc.string.format("Error loading Texture from: '{0}' - Retrying in {1}ms...", originalUrl, retryDelay));
-
-                    var idx = url.indexOf('?');
-                    var separator = idx >= 0 ? '&' : '?';
-
-                    retryTimeout = setTimeout(function () {
-                        // we need to add a cache busting argument if we are trying to re-load an image element
-                        // with the same URL
-                        image.src = url + separator + 'retry=' + Date.now();
-                        retryTimeout = null;
-                    }, retryDelay);
-                } else {
-                    // Call error callback with details.
-                    callback(pc.string.format("Error loading Texture from: '{0}'", originalUrl));
-                }
-            };
-
-            image.src = url;
+            this._getParser(url.original).load(url, callback, asset);
         },
 
         open: function (url, data, asset) {
             if (!url)
                 return;
 
-            var texture;
-            var ext = pc.path.getExtension(url).toLowerCase();
-            var format = null;
+            var texture = this._getParser(url).open(url, data, this._device);
 
-            // Every browser seems to pass data as an Image type. For some reason, the XDK
-            // passes an HTMLImageElement. TODO: figure out why!
-            // DDS textures are ArrayBuffers
-            if ((data instanceof Image) || (data instanceof HTMLImageElement)) { // PNG, JPG or GIF
-                var img = data;
-
-                format = (ext === ".jpg" || ext === ".jpeg") ? pc.PIXELFORMAT_R8_G8_B8 : pc.PIXELFORMAT_R8_G8_B8_A8;
+            if (texture === null) {
                 texture = new pc.Texture(this._device, {
-                    // #ifdef PROFILER
-                    profilerHint: pc.TEXHINT_ASSET,
-                    // #endif
-                    width: img.width,
-                    height: img.height,
-                    format: format,
-                    flipY: asset && asset.data.hasOwnProperty('flipY') ? !!asset.data.flipY : true
+                    width: 4,
+                    height: 4,
+                    format: pc.PIXELFORMAT_R8_G8_B8
                 });
-                texture.name = url;
-                texture.setSource(img);
-            } else { // Container format
-
-                if (ext === '.dds') {
-                    texture = _legacyDdsLoader(url, data, this._device);
-                } else {
-                    var textureData;
-
-                    if (ext === '.basis') {
-                        textureData = data;
-                        // console.log('transcode time=' + data.transcodeTime + ' url=' + data.url.split('#').shift().split('?').shift().split('/').pop());
-                    } else if (data instanceof ArrayBuffer) {
-                        switch (ext) {
-                            case '.dds':
-                                textureData = new pc.DdsParser(data);
-                                break;
-                            case '.ktx':
-                                textureData = new pc.KtxParser(data);
-                                break;
-                            case '.pvr':
-                                console.warn('PVR container not supported.');
-                                break;
-                        }
-                    }
-
-                    if (!textureData) {
-                        // #ifdef DEBUG
-                        console.warn("This DDS or KTX pixel format is currently unsupported. Empty texture will be created instead.");
-                        // #endif
-                        texture = new pc.Texture(this._device, {
-                            width: 4,
-                            height: 4,
-                            format: pc.PIXELFORMAT_R8_G8_B8
-                        });
-                        texture.name = 'unsupported-empty';
-                        return texture;
-                    }
-
-                    texture = new pc.Texture(this._device, {
-                        // #ifdef PROFILER
-                        profilerHint: pc.TEXHINT_ASSET,
-                        // #endif
-                        addressU: textureData.cubemap ? pc.ADDRESS_CLAMP_TO_EDGE : pc.ADDRESS_REPEAT,
-                        addressV: textureData.cubemap ? pc.ADDRESS_CLAMP_TO_EDGE : pc.ADDRESS_REPEAT,
-                        width: textureData.width,
-                        height: textureData.height,
-                        format: textureData.format,
-                        cubemap: textureData.cubemap,
-                        levels: textureData.levels
-                    });
-
-                    texture.name = url;
-                    texture.upload();
-                }
+            } else {
+                // check if the texture has only a partial mipmap chain specified and generate the
+                // missing levels if possible.
+                _completePartialMipmapChain(texture);
             }
-
-            // check if the texture has only a partial mipmap chain specified and generate the
-            // missing levels if possible.
-            _completePartialMipmapChain(texture);
 
             return texture;
         },
 
-
         patch: function (asset, assets) {
             var texture = asset.resource;
-
-            if (!texture)
+            if (!texture) {
                 return;
+            }
 
-            if (texture.name !== asset.name)
+            if (asset.name && asset.name.length > 0) {
                 texture.name = asset.name;
+            }
 
-            if (asset.data.hasOwnProperty('minfilter') && texture.minFilter !== JSON_FILTER_MODE[asset.data.minfilter])
-                texture.minFilter = JSON_FILTER_MODE[asset.data.minfilter];
+            var assetData = asset.data;
 
-            if (asset.data.hasOwnProperty('magfilter') && texture.magFilter !== JSON_FILTER_MODE[asset.data.magfilter])
-                texture.magFilter = JSON_FILTER_MODE[asset.data.magfilter];
+            if (assetData.hasOwnProperty('minfilter')) {
+                texture.minFilter = JSON_FILTER_MODE[assetData.minfilter];
+            }
 
-            if (asset.data.hasOwnProperty('addressu') && texture.addressU !== JSON_ADDRESS_MODE[asset.data.addressu])
-                texture.addressU = JSON_ADDRESS_MODE[asset.data.addressu];
+            if (assetData.hasOwnProperty('magfilter')) {
+                texture.magFilter = JSON_FILTER_MODE[assetData.magfilter];
+            }
 
-            if (asset.data.hasOwnProperty('addressv') && texture.addressV !== JSON_ADDRESS_MODE[asset.data.addressv])
-                texture.addressV = JSON_ADDRESS_MODE[asset.data.addressv];
+            if (!texture.cubemap) {
+                if (assetData.hasOwnProperty('addressu')) {
+                    texture.addressU = JSON_ADDRESS_MODE[assetData.addressu];
+                }
 
-            if (asset.data.hasOwnProperty('mipmaps') && texture.mipmaps !== asset.data.mipmaps)
-                texture.mipmaps = asset.data.mipmaps;
+                if (assetData.hasOwnProperty('addressv')) {
+                    texture.addressV = JSON_ADDRESS_MODE[assetData.addressv];
+                }
+            }
 
-            if (asset.data.hasOwnProperty('anisotropy') && texture.anisotropy !== asset.data.anisotropy)
-                texture.anisotropy = asset.data.anisotropy;
+            if (assetData.hasOwnProperty('mipmaps')) {
+                texture.mipmaps = assetData.mipmaps;
+            }
 
-            var rgbm = !!asset.data.rgbm;
-            if (asset.data.hasOwnProperty('rgbm') && texture.rgbm !== rgbm)
-                texture.rgbm = rgbm;
+            if (assetData.hasOwnProperty('anisotropy')) {
+                texture.anisotropy = assetData.anisotropy;
+            }
 
-            if (asset.file && asset.getPreferredFile) {
+            if (assetData.hasOwnProperty('flipY')) {
+                texture.flipY = !!assetData.flipY;
+            }
+
+            // extract asset type (this is bit of a mess)
+            if (assetData.hasOwnProperty('type')) {
+                texture.type = assetData.type;
+            } else if (assetData.hasOwnProperty('rgbm') && !!assetData.rgbm) {
+                texture.type = pc.TEXTURETYPE_RGBM;
+            } else if (asset.file && asset.getPreferredFile) {
+                // basis normalmaps flag the variant as swizzled
                 var preferredFile = asset.getPreferredFile();
                 if (preferredFile) {
                     if (preferredFile.opt && ((preferredFile.opt & 8) !== 0)) {
-                        texture.swizzleGGGR = true;
+                        texture.type = pc.TEXTURETYPE_SWIZZLEGGGR;
                     }
                 }
             }
@@ -527,6 +256,7 @@ Object.assign(pc, function () {
     });
 
     return {
-        TextureHandler: TextureHandler
+        TextureHandler: TextureHandler,
+        TextureParser: TextureParser
     };
 }());


### PR DESCRIPTION
This PR splits out the texture resource handler parsers for file formats.

It also introduces a new enum for texture type:
```
TEXTURETYPE_GENERAL: 1,
TEXTURETYPE_RGBM: 2,
TEXTURETYPE_RGBE: 3,
TEXTURETYPE_SWIZZLEGGGR: 4,

```

This enum replaces the previous boolean flags on pc.Texture for rgbm and swizzleGGGR with a 'type' parameter instead.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
