### PR TITLE
add jpeg mime type to glb-parser

### DIFF
--- a/src/resources/parser/glb-parser.js
+++ b/src/resources/parser/glb-parser.js
@@ -1284,7 +1284,7 @@ Object.assign(pc, function () {
 
             var mimeTypeFileExtensions = {
                 'image/png': 'png',
-                'image/jpeg': 'jpeg',
+                'image/jpeg': 'jpg',
                 'image/basis': 'basis',
                 'image/ktx': 'ktx',
                 'image/vnd-ms.dds': 'dds'

--- a/src/resources/parser/glb-parser.js
+++ b/src/resources/parser/glb-parser.js
@@ -1285,6 +1285,7 @@ Object.assign(pc, function () {
             var mimeTypeFileExtensions = {
                 'image/png': 'png',
                 'image/jpg': 'jpg',
+                'image/jpeg': 'jpeg',
                 'image/basis': 'basis',
                 'image/ktx': 'ktx',
                 'image/vnd-ms.dds': 'dds'

--- a/src/resources/parser/glb-parser.js
+++ b/src/resources/parser/glb-parser.js
@@ -1284,7 +1284,6 @@ Object.assign(pc, function () {
 
             var mimeTypeFileExtensions = {
                 'image/png': 'png',
-                'image/jpg': 'jpg',
                 'image/jpeg': 'jpeg',
                 'image/basis': 'basis',
                 'image/ktx': 'ktx',


### PR DESCRIPTION
Add jpeg to list of mime types which is needed to load some gltf embedded files.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
