### PR TITLE
Add asset options object, fix gltf texture loading

### DIFF
--- a/src/asset/asset.js
+++ b/src/asset/asset.js
@@ -61,6 +61,7 @@ Object.assign(pc, function () {
      * var asset = new pc.Asset("a texture", "texture", {
      *     url: "http://example.com/my/assets/here/texture.png"
      * });
+     * @param {object} [options] - a JSON object containing load-time options specific to the asset.
      * @property {string} name The name of the asset
      * @property {number} id The asset id
      * @property {string} type The type of the asset. One of ["animation", "audio", "binary", "cubemap", "css", "font", "json", "html", "material", "model", "script", "shader", "text", "texture"]
@@ -78,7 +79,7 @@ Object.assign(pc, function () {
      * @property {boolean} loading True if the resource is currently being loaded
      * @property {pc.AssetRegistry} registry The asset registry that this Asset belongs to
      */
-    var Asset = function (name, type, file, data) {
+    var Asset = function (name, type, file, data, options) {
         pc.EventHandler.call(this);
 
         this._id = assetIdCounter--;
@@ -92,6 +93,7 @@ Object.assign(pc, function () {
 
         this._file = null;
         this._data = data || { };
+        this.options = options || { };
 
         // This is where the loaded resource(s) will be
         this._resources = [];

--- a/src/resources/parser/glb-parser.js
+++ b/src/resources/parser/glb-parser.js
@@ -1257,6 +1257,7 @@ Object.assign(pc, function () {
 
             var url;
             var mimeType;
+            var options = {};
             if (imgData.hasOwnProperty('uri')) {
                 // uri specified
                 if (isDataURI(imgData.uri)) {
@@ -1264,6 +1265,7 @@ Object.assign(pc, function () {
                     mimeType = getDataURIMimeType(imgData.uri);
                 } else {
                     url = pc.path.join(urlBase, imgData.uri);
+                    options.crossOrigin = "anonymous";
                 }
             } else if (imgData.hasOwnProperty('bufferView') && imgData.hasOwnProperty('mimeType')) {
                 // bufferview
@@ -1300,7 +1302,7 @@ Object.assign(pc, function () {
             }
 
             // create and load the asset
-            var asset = new pc.Asset('texture_' + i, 'texture',  file, { flipY: false });
+            var asset = new pc.Asset('texture_' + i, 'texture',  file, { flipY: false }, options);
             asset.on('load', onLoad.bind(null, i));
             registry.add(asset);
             registry.load(asset);

--- a/src/resources/texture.js
+++ b/src/resources/texture.js
@@ -329,8 +329,10 @@ Object.assign(pc, function () {
                     });
             } else if ((ext === '.jpg') || (ext === '.jpeg') || (ext === '.gif') || (ext === '.png')) {
                 var crossOrigin;
-                // only apply cross-origin setting if this is an absolute URL, relative URLs can never be cross-origin
-                if (self.crossOrigin !== undefined && pc.ABSOLUTE_URL.test(url.load)) {
+                if (asset && asset.options && asset.options.hasOwnProperty('crossOrigin')) {
+                    crossOrigin = asset.options.crossOrigin;
+                } else if (self.crossOrigin !== undefined && pc.ABSOLUTE_URL.test(url.load)) {
+                    // only apply cross-origin setting if this is an absolute URL, relative URLs can never be cross-origin
                     crossOrigin = self.crossOrigin;
                 }
 


### PR DESCRIPTION
glTF files containing urls to external resources must have crossOrigin specified. This PR adds an options object to pc.Asset for purposes of specifying load time options to the asset handler.

(In future the options object can also be used for specifying other load-specific settings to the resource handlers too).

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
