### PR TITLE
Fixes bug where the entity has moved but not the rigidbody

### DIFF
--- a/examples/assets/scripts/debug/debug-physics.js
+++ b/examples/assets/scripts/debug/debug-physics.js
@@ -180,7 +180,7 @@ DebugPhysics.prototype.postUpdate = function (dt) {
                     collision._debugShape = debugShape;
                 }
 
-                // Use the rigid body position if we have it 
+                // Use the rigid body position if we have it
                 if (collision.entity.rigidbody) {
                     var body = collision.entity.rigidbody.data.body;
                     if (body) {
@@ -189,7 +189,7 @@ DebugPhysics.prototype.postUpdate = function (dt) {
                         var p = t.getOrigin();
                         var q = t.getRotation();
                         collision._debugShape.setPosition(p.x(), p.y(), p.z());
-                        collision._debugShape.setRotation(q.x(), q.y(), q.z(), q.w());                        
+                        collision._debugShape.setRotation(q.x(), q.y(), q.z(), q.w());
                     }
                 } else {
                     collision._debugShape.setPosition(collision.entity.getPosition());

--- a/examples/assets/scripts/debug/debug-physics.js
+++ b/examples/assets/scripts/debug/debug-physics.js
@@ -180,8 +180,21 @@ DebugPhysics.prototype.postUpdate = function (dt) {
                     collision._debugShape = debugShape;
                 }
 
-                collision._debugShape.setPosition(collision.entity.getPosition());
-                collision._debugShape.setRotation(collision.entity.getRotation());
+                // Use the rigid body position if we have it 
+                if (collision.entity.rigidbody) {
+                    var body = collision.entity.rigidbody.data.body;
+                    if (body) {
+                        var t = body.getWorldTransform();
+
+                        var p = t.getOrigin();
+                        var q = t.getRotation();
+                        collision._debugShape.setPosition(p.x(), p.y(), p.z());
+                        collision._debugShape.setRotation(q.x(), q.y(), q.z(), q.w());                        
+                    }
+                } else {
+                    collision._debugShape.setPosition(collision.entity.getPosition());
+                    collision._debugShape.setRotation(collision.entity.getRotation());
+                }
 
                 collision._debugShape.updated = true;
             }


### PR DESCRIPTION
In case of an entity is moved instead of teleporting the rigid body, the entity is rendered in the new position but the rigidbody is still in the old position in the simulation world. 

This PR is now using the rigidbody transform to position the debug shape to help highlight these issues.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
