### PR TITLE
[FIX] Triggers on scaled entities now work again

### DIFF
--- a/src/framework/components/collision/trigger.js
+++ b/src/framework/components/collision/trigger.js
@@ -76,9 +76,19 @@ Object.assign(pc, function () {
             this.app.systems.rigidbody.destroyBody(body);
         },
 
+        _getEntityTransform: function (transform) {
+            var pos = this.entity.getPosition();
+            var rot = this.entity.getRotation();
+
+            ammoVec1.setValue(pos.x, pos.y, pos.z);
+            ammoQuat.setValue(rot.x, rot.y, rot.z, rot.w);
+
+            transform.setOrigin(ammoVec1);
+            transform.setRotation(ammoQuat);
+        },
+
         updateTransform: function () {
-            var wtm = this.entity.getWorldTransform();
-            ammoTransform.setFromOpenGLMatrix(wtm.data);
+            this._getEntityTransform(ammoTransform);
 
             var body = this.body;
             body.setWorldTransform(ammoTransform);


### PR DESCRIPTION
Triggers on entities with a scale applied would break because the trigger body's world transform should only contain position and rotation.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
