### PR TITLE
use load url for extracting the base

### DIFF
--- a/src/resources/container.js
+++ b/src/resources/container.js
@@ -97,7 +97,7 @@ Object.assign(pc, function () {
 
                 if (!err) {
                     pc.GlbParser.parseAsync(self._getUrlWithoutParams(url.original),
-                                            pc.path.extractPath(url.original),
+                                            pc.path.extractPath(url.load),
                                             response,
                                             self._device,
                                             asset.registry,


### PR DESCRIPTION
Fixes #2139

The container handler was extracting url base from the original url (used for identifying assets) instead of the load url (used for loading assets).

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
