### PR TITLE
[FIX] Exception on rigidbody component removal

### DIFF
--- a/src/framework/components/particle-system/component.js
+++ b/src/framework/components/particle-system/component.js
@@ -726,7 +726,7 @@ Object.assign(pc, function () {
             }
         },
 
-        onRemove: function () {
+        onBeforeRemove: function () {
             if (this.enabled) {
                 this.enabled = false;
             }

--- a/src/framework/components/particle-system/system.js
+++ b/src/framework/components/particle-system/system.js
@@ -103,7 +103,7 @@ Object.assign(pc, function () {
             scaleGraph2: 'curve'
         };
 
-        this.on('beforeremove', this.onRemove, this);
+        this.on('beforeremove', this.onBeforeRemove, this);
         pc.ComponentSystem.bind('update', this.onUpdate, this);
     };
     ParticleSystemComponentSystem.prototype = Object.create(pc.ComponentSystem.prototype);
@@ -258,8 +258,8 @@ Object.assign(pc, function () {
             }
         },
 
-        onRemove: function (entity, component) {
-            component.onRemove();
+        onBeforeRemove: function (entity, component) {
+            component.onBeforeRemove();
         }
     });
 

--- a/src/framework/components/rigid-body/system.js
+++ b/src/framework/components/rigid-body/system.js
@@ -167,6 +167,7 @@ Object.assign(pc, function () {
         this._triggers = [];
         this._compounds = [];
 
+        this.on('beforeremove', this.onBeforeRemove, this);
         this.on('remove', this.onRemove, this);
     };
     RigidBodyComponentSystem.prototype = Object.create(pc.ComponentSystem.prototype);
@@ -196,6 +197,7 @@ Object.assign(pc, function () {
                 // Lazily create temp vars
                 ammoRayStart = new Ammo.btVector3();
                 ammoRayEnd = new Ammo.btVector3();
+
                 pc.ComponentSystem.bind('update', this.onUpdate, this);
             } else {
                 // Unbind the update function if we haven't loaded Ammo by now
@@ -248,6 +250,12 @@ Object.assign(pc, function () {
             };
 
             this.addComponent(clone, data);
+        },
+
+        onBeforeRemove: function (entity, component) {
+            if (component.enabled) {
+                component.enabled = false;
+            }
         },
 
         onRemove: function (entity, data) {


### PR DESCRIPTION
Ensure rigidbody components are disabled before removal. This ensure the ammo.js body is removed from the simulation.

This PR also makes it clear that the `pc.ParticleSystemComponentSystem` handler for the `beforeremove` event is appropriately named.

Fixes #2144 

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
