### PR TITLE
update skybox before frame layer update

### DIFF
--- a/src/scene/forward-renderer.js
+++ b/src/scene/forward-renderer.js
@@ -2271,11 +2271,6 @@ Object.assign(pc, function () {
             var meshInstances = comp._meshInstances;
             var lights = comp._lights;
 
-            if (scene.updateSkybox) {
-                scene._updateSkybox(device);
-                scene.updateSkybox = false;
-            }
-
             // Update shaders if needed
             // all mesh instances (TODO: ideally can update less if only lighting changed)
             if (scene.updateShaders) {
@@ -2643,6 +2638,12 @@ Object.assign(pc, function () {
             var renderedByCam = comp._renderedByCam;
             var renderedLayer = comp._renderedLayer;
             var i, layer, transparent, cameras, j, rt, k, processedThisCamera, processedThisCameraAndLayer, processedThisCameraAndRt;
+
+            // update the skybox, since this might change _meshInstances
+            if (this.scene.updateSkybox) {
+                this.scene._updateSkybox(device);
+                this.scene.updateSkybox = false;
+            }
 
             this.beginLayers(comp);
 

--- a/src/scene/forward-renderer.js
+++ b/src/scene/forward-renderer.js
@@ -2266,7 +2266,6 @@ Object.assign(pc, function () {
         },
 
         beginFrame: function (comp) {
-            var device = this.device;
             var scene = this.scene;
             var meshInstances = comp._meshInstances;
             var lights = comp._lights;


### PR DESCRIPTION
Move the skybox update call to earlier in the render frame.

Sometimes the call to ```updateSkybox()``` results in a new meshInstance being created and added to the layer system. This should happen before the layer and frame updates in order for the new meshInstances and materials to take effect on this frame.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
