### PR TITLE
Texture based skinning precision issue on iOS

### DIFF
--- a/src/graphics/program-lib/chunks/skinBatchTex.vert
+++ b/src/graphics/program-lib/chunks/skinBatchTex.vert
@@ -1,6 +1,6 @@
-attribute float vertex_boneIndices;
-uniform sampler2D texture_poseMap;
-uniform vec2 texture_poseMapSize;
+attribute highp float vertex_boneIndices;
+uniform highp sampler2D texture_poseMap;
+uniform highp vec2 texture_poseMapSize;
 mat4 getBoneMatrix(const in float i) {
     float j = i * 4.0;
     float x = mod(j, float(texture_poseMapSize.x));

--- a/src/graphics/program-lib/chunks/skinBatchTex.vert
+++ b/src/graphics/program-lib/chunks/skinBatchTex.vert
@@ -1,6 +1,6 @@
-attribute highp float vertex_boneIndices;
+attribute float vertex_boneIndices;
 uniform highp sampler2D texture_poseMap;
-uniform highp vec2 texture_poseMapSize;
+uniform vec2 texture_poseMapSize;
 mat4 getBoneMatrix(const in float i) {
     float j = i * 4.0;
     float x = mod(j, float(texture_poseMapSize.x));

--- a/src/graphics/program-lib/chunks/skinTex.vert
+++ b/src/graphics/program-lib/chunks/skinTex.vert
@@ -1,8 +1,8 @@
-attribute vec4 vertex_boneWeights;
-attribute vec4 vertex_boneIndices;
+attribute highp vec4 vertex_boneWeights;
+attribute highp vec4 vertex_boneIndices;
 
-uniform sampler2D texture_poseMap;
-uniform vec2 texture_poseMapSize;
+uniform highp sampler2D texture_poseMap;
+uniform highp  vec2 texture_poseMapSize;
 
 mat4 getBoneMatrix(const in float i)
 {

--- a/src/graphics/program-lib/chunks/skinTex.vert
+++ b/src/graphics/program-lib/chunks/skinTex.vert
@@ -1,8 +1,8 @@
-attribute highp vec4 vertex_boneWeights;
-attribute highp vec4 vertex_boneIndices;
+attribute vec4 vertex_boneWeights;
+attribute vec4 vertex_boneIndices;
 
 uniform highp sampler2D texture_poseMap;
-uniform highp vec2 texture_poseMapSize;
+uniform vec2 texture_poseMapSize;
 
 mat4 getBoneMatrix(const in float i)
 {

--- a/src/graphics/program-lib/chunks/skinTex.vert
+++ b/src/graphics/program-lib/chunks/skinTex.vert
@@ -2,7 +2,7 @@ attribute highp vec4 vertex_boneWeights;
 attribute highp vec4 vertex_boneIndices;
 
 uniform highp sampler2D texture_poseMap;
-uniform highp  vec2 texture_poseMapSize;
+uniform highp vec2 texture_poseMapSize;
 
 mat4 getBoneMatrix(const in float i)
 {


### PR DESCRIPTION
forcing vertex shader uniforms related to texture based skinning to high precision, as it seems to default to mid precision giving us shaky animations on iOS

Fixes #1267

it seems https://developer.mozilla.org/en-US/docs/Web/API/WebGL_API/WebGL_best_practices confirms this, as it states these are default precisions in vertex shader:

precision highp float;
precision highp int;
precision lowp sampler2D;
precision lowp samplerCube;