### PR TITLE
Update the GraphNode findbytag parameter types so it can take one or more strings or string arrays

### DIFF
--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -414,7 +414,7 @@ Object.assign(pc, function () {
          * Query can be simply a string, or comma separated strings,
          * to have inclusive results of assets that match at least one query.
          * A query that consists of an array of tags can be used to match graph nodes that have each tag of array.
-         * @param {string} query - Name of a tag or array of tags.
+         * @param {...(string|string[])} query - Name of a tag or array of tags.
          * @returns {pc.GraphNode[]} A list of all graph nodes that match the query.
          * @example
          * // Return all graph nodes that tagged by `animal`


### PR DESCRIPTION
`GraphNode`'s `findbytag` typings only specify a string parameter, but in fact takes a variable argument list of `string` or `string[]` parameters. This updates the JSDoc so the docs and generated Typescript typings reflect this.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
