### PR TITLE
console.warning -> console.warn

### DIFF
--- a/src/graphics/texture.js
+++ b/src/graphics/texture.js
@@ -134,12 +134,12 @@ Object.assign(pc, function () {
                 this.type = options.type;
             } else if (options.hasOwnProperty('rgbm')) {
                 // #ifdef DEBUG
-                console.warning("DEPRECATED: options.rgbm is deprecated. Use options.type instead.");
+                console.warn("DEPRECATED: options.rgbm is deprecated. Use options.type instead.");
                 // #endif
                 this.type = options.rgbm ? pc.TEXTURETYPE_RGBM : pc.TEXTURETYPE_DEFAULT;
             } else if (options.hasOwnProperty('swizzleGGGR')) {
                 // #ifdef DEBUG
-                console.warning("DEPRECATED: options.swizzleGGGR is deprecated. Use options.type instead.");
+                console.warn("DEPRECATED: options.swizzleGGGR is deprecated. Use options.type instead.");
                 // #endif
                 this.type = options.swizzleGGGR ? pc.TEXTURETYPE_SWIZZLEGGGR : pc.TEXTURETYPE_DEFAULT;
             }


### PR DESCRIPTION
Fix newly introduced deprecate warnings in texture.js.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
