### PR TITLE
Removed odd syntax in JS Doc params

### DIFF
--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -413,7 +413,7 @@ Object.assign(pc, function () {
          * Query can be simply a string, or comma separated strings,
          * to have inclusive results of assets that match at least one query.
          * A query that consists of an array of tags can be used to match graph nodes that have each tag of array.
-         * @param {...(string|string[])} query - Name of a tag or array of tags.
+         * @param {string|string[]} query - Name of a tag or array of tags.
          * @returns {pc.GraphNode[]} A list of all graph nodes that match the query.
          * @example
          * // Return all graph nodes that tagged by `animal`


### PR DESCRIPTION
Fixes ? JS docs parsing in the code editor on PlayCanvas.com 

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
