### PR TITLE
ParticleSystem rendering in UI space

### DIFF
--- a/examples/examples.js
+++ b/examples/examples.js
@@ -79,6 +79,7 @@ var categories = [
         name: "user-interface",
         examples: [
             "button-basic",
+            "button-particle",
             "button-sprite",
             "text-basic",
             "text-canvas-font",

--- a/examples/user-interface/button-particle.html
+++ b/examples/user-interface/button-particle.html
@@ -1,0 +1,173 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>PlayCanvas Particle Button</title>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
+    <link rel="icon" type="image/png" href="../playcanvas-favicon.png" />
+    <script src="../../build/output/playcanvas.js"></script>
+    <script src="../../build/output/playcanvas-extras.js"></script>
+    <style>
+        body { 
+            margin: 0;
+            overflow-y: hidden;
+        }
+    </style>
+</head>
+
+<body>
+    <!-- The canvas element -->
+    <canvas id="application-canvas"></canvas>
+
+    <!-- The script -->
+    <script>
+        var canvas = document.getElementById("application-canvas");
+
+        // Create the application and start the update loop
+        var app = new pc.Application(canvas, {
+            mouse: new pc.Mouse(document.body),
+            touch: new pc.TouchDevice(document.body),
+            elementInput: new pc.ElementInput(canvas)
+        });
+        app.start();
+
+        // Set the canvas to fill the window and automatically change resolution to be the same as the canvas size
+        app.setCanvasFillMode(pc.FILLMODE_FILL_WINDOW);
+        app.setCanvasResolution(pc.RESOLUTION_AUTO);
+
+        window.addEventListener("resize", function () {
+            app.resizeCanvas(canvas.width, canvas.height);
+        });
+
+        var miniStats = new pc.MiniStats(app);
+
+        // Create a camera
+        var camera = new pc.Entity();
+        camera.addComponent("camera", {
+            clearColor: new pc.Color(0, 0, 0)
+        });
+        app.root.addChild(camera);
+
+        // Create a 2D screen
+        var screen = new pc.Entity();
+        screen.addComponent("screen", {
+            referenceResolution: new pc.Vec2(1280, 720),
+            scaleBlend: 0.5,
+            scaleMode: pc.SCALEMODE_BLEND,
+            screenSpace: true
+        });
+        app.root.addChild(screen);
+
+        // Create a simple button
+        var button = new pc.Entity();
+        button.addComponent("button", {
+            imageEntity: button
+        });
+        button.addComponent("element", {
+            anchor: [ 0.5, 0.5, 0.5, 0.5 ],
+            color: new pc.Color(0.4, 0.4, 0.4),
+            height: 40,
+            pivot: [ 0.5, 0.5 ],
+            type: pc.ELEMENTTYPE_IMAGE,
+            width: 175,
+            useInput: true
+        });
+        screen.addChild(button);
+
+        // Create a label for the button
+        var label = new pc.Entity();
+        label.addComponent("element", {
+            anchor: [ 0.5, 0.5, 0.5, 0.5 ],
+            color: new pc.Color(1, 1, 0),
+            fontSize: 36,
+            height: 64,
+            pivot: [ 0.5, 0.5 ],
+            text: "LABEL",
+            type: pc.ELEMENTTYPE_TEXT,
+            width: 128,
+            wrapLines: true
+        });
+        button.addChild(label);
+
+        // Load a font
+        var fontAsset = new pc.Asset('courier.json', "font", {url: "../assets/fonts/courier.json"});
+        fontAsset.on('load', function () {
+            // Apply the font to the text element
+            label.element.fontAsset = fontAsset;
+        });
+
+        // load spark texture for particle system
+        app.assets.loadFromUrl('../assets/textures/spark.png', 'texture', function (err, asset) {
+
+            // Create entity for particle system
+            var particles = new pc.Entity();
+
+            // insert sparks as a child of the button, but before Label - that is the order for rendering
+            button.insertChild(particles, 0);
+
+            // particles will render in UI layer
+            var UILayer = app.scene.layers.getLayerByName("UI");
+
+            // particle size
+            var scaleCurve = new pc.Curve(
+                [0, 0.03]
+            );
+
+            // color changes throughout lifetime
+            var colorCurve = new pc.CurveSet([
+                [0, 1, 0.25, 1, 0.375, 0.5, 0.5, 0],
+                [0, 0, 0.125, 0.25, 0.25, 0.5, 0.375, 0.75, 0.5, 1],
+                [0, 0, 1, 0]
+            ]);
+
+            // increasing gravity to get them to move
+            var worldVelocityCurve = new pc.CurveSet([
+                [0, 0],
+                [0, 0, 0.1, 0.1, 0.1, -0.1],
+                [0, 0]
+            ]);
+
+            // rotate sparks 360 degrees per second
+            var angleCurve = new pc.Curve(
+                [0, 360]
+            );
+
+            // when texture is loaded add particlesystem component to entity
+            particles.addComponent("particlesystem", {
+                numParticles: 100,
+                lifetime: 1,
+                rate: 0.01,
+
+                // make them follow the buttn in screen-space
+                localSpace: true,
+                screenSpace: true,
+
+                emitterShape: pc.EMITTERSHAPE_SPHERE,
+                emitterRadius: 100,
+
+                scaleGraph: scaleCurve,
+                rotationSpeedGraph: angleCurve,
+                colorGraph: colorCurve,
+                velocityGraph: worldVelocityCurve,
+
+                colorMap: asset.resource,
+                layers: [UILayer.id]
+            });
+
+            // sort all screen elements
+            screen.screen.syncDrawOrder();
+        });
+
+        var time = 0, previousTime;
+        app.on("update", function (dt) {
+            time += dt * 0.3;
+
+            // move buttons along the circular path
+            button.setLocalPosition(300 * Math.sin(time), 300 * Math.cos(time), 0);
+        });
+
+        app.assets.add(fontAsset);
+        app.assets.load(fontAsset);
+    </script>
+</body>
+</html>

--- a/src/framework/components/particle-system/component.js
+++ b/src/framework/components/particle-system/component.js
@@ -43,6 +43,7 @@ Object.assign(pc, function () {
         'animLoop',
         'colorMap',
         'localSpace',
+        'screenSpace',
         'orientation'
     ];
 
@@ -101,6 +102,7 @@ Object.assign(pc, function () {
      * @property {boolean} depthWrite If enabled, the particles will write to the depth buffer. If disabled, the depth buffer is left unchanged and particles will be guaranteed to overwrite one another in the order in which they are rendered.
      * @property {boolean} noFog Disable fogging.
      * @property {boolean} localSpace Binds particles to emitter transformation rather then world space.
+     * @property {boolean} screenSpace Renders particles in 2D screen space. This needs to be set when particle system is part of hierarchy with {@link pc.ScreenComponent} at its root, and allows particle system to integrate with the rendering of {@link pc.ElementComponent}s. Note that an entity with ParticleSystem component cannot be parented directly to {@link pc.ScreenComponent}, but has to be a child of a {@link pc.ElementComponent}, for example {@link pc.LayoutGroupComponent}.
      * @property {number} numParticles Maximum number of simulated particles.
      * @property {number} rate Minimal interval in seconds between particle births.
      * @property {number} rate2 Maximal interval in seconds between particle births.
@@ -202,9 +204,24 @@ Object.assign(pc, function () {
         }.bind(this));
 
         this._requestedDepth = false;
+        this._drawOrder = 0;
     };
     ParticleSystemComponent.prototype = Object.create(pc.Component.prototype);
     ParticleSystemComponent.prototype.constructor = ParticleSystemComponent;
+
+    Object.defineProperties(ParticleSystemComponent.prototype, {
+        drawOrder: {
+            get: function () {
+                return this._drawOrder;
+            },
+            set: function (drawOrder) {
+                this._drawOrder = drawOrder;
+                if (this.emitter) {
+                    this.emitter.drawOrder = drawOrder;
+                }
+            }
+        }
+    });
 
     Object.assign(ParticleSystemComponent.prototype, {
         addModelToLayers: function () {
@@ -616,6 +633,7 @@ Object.assign(pc, function () {
                     initialVelocity: data.initialVelocity,
                     wrap: data.wrap,
                     localSpace: data.localSpace,
+                    screenSpace: data.screenSpace,
                     wrapBounds: data.wrapBounds,
                     lifetime: data.lifetime,
                     rate: data.rate,
@@ -678,6 +696,7 @@ Object.assign(pc, function () {
                 });
 
                 this.emitter.meshInstance.node = this.entity;
+                this.emitter.drawOrder = this.drawOrder;
 
                 this.psys = new pc.Model();
                 this.psys.graph = this.entity;

--- a/src/framework/components/particle-system/data.js
+++ b/src/framework/components/particle-system/data.js
@@ -15,6 +15,7 @@ Object.assign(pc, function () {
         this.initialVelocity = 0;
         this.wrapBounds = new pc.Vec3();
         this.localSpace = false;
+        this.screenSpace = false;
         this.colorMap = null;
         this.colorMapAsset = null;
         this.normalMap = null;

--- a/src/framework/components/particle-system/system.js
+++ b/src/framework/components/particle-system/system.js
@@ -29,6 +29,7 @@ Object.assign(pc, function () {
         'wrap',
         'wrapBounds',
         'localSpace',
+        'screenSpace',
         'colorMapAsset',
         'normalMapAsset',
         'mesh',

--- a/src/framework/components/screen/component.js
+++ b/src/framework/components/screen/component.js
@@ -81,6 +81,11 @@ Object.assign(pc, function () {
                 }
             }
 
+            // child particle system inside 2D screen sub-hierarachy gets sorted along other 2D elements
+            if (e.particlesystem) {
+                e.particlesystem.drawOrder = i++;
+            }
+
             var children = e.children;
             for (var j = 0; j < children.length; j++) {
                 i = this._recurseDrawOrderSync(children[j], i);

--- a/src/graphics/program-lib/chunks/particle_end.vert
+++ b/src/graphics/program-lib/chunks/particle_end.vert
@@ -2,4 +2,8 @@
     localPos *= scale * emitterScale;
     localPos += particlePos;
 
-    gl_Position = matrix_viewProjection * vec4(localPos.xyz, 1.0);
+    #ifdef SCREEN_SPACE
+        gl_Position = vec4(localPos.x, localPos.y, 0.0, 1.0);
+    #else
+        gl_Position = matrix_viewProjection * vec4(localPos.xyz, 1.0);
+    #endif

--- a/src/graphics/program-lib/particle.js
+++ b/src/graphics/program-lib/particle.js
@@ -30,6 +30,7 @@ pc.programlib.particle = {
         vshader += "#define VERTEXSHADER\n";
         if (options.mesh) vshader += "#define USE_MESH\n";
         if (options.localSpace) vshader += "#define LOCAL_SPACE\n";
+        if (options.screenSpace) vshader += "#define SCREEN_SPACE\n";
 
         if (options.animTex) vshader += "\nuniform vec2 animTexTilesParams;\n";
         if (options.animTex) vshader += "\nuniform vec4 animTexParams;\n";

--- a/src/scene/particle-system/particle-emitter.js
+++ b/src/scene/particle-system/particle-emitter.js
@@ -180,6 +180,7 @@ Object.assign(pc, function () {
         setProperty("initialVelocity", 1);
         setProperty("wrap", false);
         setProperty("localSpace", false);
+        setProperty("screenSpace", false);
         setProperty("wrapBounds", null);
         setProperty("colorMap", ParticleEmitter.DEFAULT_PARAM_TEXTURE);
         setProperty("normalMap", null);
@@ -300,6 +301,7 @@ Object.assign(pc, function () {
 
         this.material = null;
         this.meshInstance = null;
+        this.drawOrder = 0;
 
         this.seed = Math.random();
 
@@ -807,6 +809,8 @@ Object.assign(pc, function () {
                     }
                 }
 
+                var inTools = this.emitter.node._app._inTools;
+
                 var shader = programLib.getProgram("particle", {
                     useCpu: this.emitter.useCpu,
                     normal: this.emitter.normalOption,
@@ -820,6 +824,10 @@ Object.assign(pc, function () {
                     fog: (this.emitter.scene && !this.emitter.noFog) ? this.emitter.scene.fog : "none",
                     wrap: this.emitter.wrap && this.emitter.wrapBounds,
                     localSpace: this.emitter.localSpace,
+
+                    // in Editor, screen space particles (children of 2D Screen) are still rendered in 3d space
+                    screenSpace: inTools ? false : this.emitter.screenSpace,
+
                     blend: this.blendType,
                     animTex: this.emitter._isAnimated(),
                     animTexLoop: this.emitter.animLoop,
@@ -1156,6 +1164,10 @@ Object.assign(pc, function () {
                     if (this.onFinished) this.onFinished();
                     this.meshInstance.visible = false;
                 }
+            }
+
+            if (this.meshInstance) {
+                this.meshInstance.drawOrder = this.drawOrder;
             }
 
             // #ifdef PROFILER


### PR DESCRIPTION
ParticleSystem component can be used on Entity inside hierarchy with parent being Screen component, allowing particles getting rendered integrated in UI layer (under button, on top of button ..)

instructions:
- add entity with ParticleSystem into hierarchy with root Screen. Note that it cannot be added as a child of screen, and its parent needs to be one of the Element components (Image, Group ..)
- tick on 'ScreenSpace' option on the ParticleSystem
- make sure the Layer is set to UI (same layer as the Screen) - otherwise sorting does not work

engine example: engine/examples/#user-interface/button-particle.html