### PR TITLE
ParticleSystem GPU precision

### DIFF
--- a/src/graphics/program-lib/chunks/particleUpdaterInit.frag
+++ b/src/graphics/program-lib/chunks/particleUpdaterInit.frag
@@ -1,10 +1,10 @@
 varying vec2 vUv0;
 
-uniform sampler2D particleTexIN;
-uniform sampler2D internalTex0;
-uniform sampler2D internalTex1;
-uniform sampler2D internalTex2;
-uniform sampler2D internalTex3;
+uniform highp sampler2D particleTexIN;
+uniform highp sampler2D internalTex0;
+uniform highp sampler2D internalTex1;
+uniform highp sampler2D internalTex2;
+uniform highp sampler2D internalTex3;
 
 uniform mat3 emitterMatrix, emitterMatrixInv;
 uniform vec3 emitterScale;

--- a/src/graphics/program-lib/chunks/particle_cpu.vert
+++ b/src/graphics/program-lib/chunks/particle_cpu.vert
@@ -28,9 +28,9 @@ uniform float seed;
 //uniform float graphNumSamples;
 uniform vec3 wrapBounds, emitterScale, faceTangent, faceBinorm;
 uniform sampler2D texLifeAndSourcePosOUT;
-uniform sampler2D internalTex0;
-uniform sampler2D internalTex1;
-uniform sampler2D internalTex2;
+uniform highp sampler2D internalTex0;
+uniform highp sampler2D internalTex1;
+uniform highp sampler2D internalTex2;
 uniform vec3 emitterPos;
 
 varying vec4 texCoordsAlphaLife;

--- a/src/graphics/program-lib/chunks/particle_init.vert
+++ b/src/graphics/program-lib/chunks/particle_init.vert
@@ -21,9 +21,9 @@ uniform vec3 wrapBounds;
 uniform vec3 emitterScale, emitterPos, faceTangent, faceBinorm;
 uniform float rate, rateDiv, lifetime, deltaRandomnessStatic, scaleDivMult, alphaDivMult, seed, delta;
 uniform sampler2D particleTexOUT, particleTexIN;
-uniform sampler2D internalTex0;
-uniform sampler2D internalTex1;
-uniform sampler2D internalTex2;
+uniform highp sampler2D internalTex0;
+uniform highp sampler2D internalTex1;
+uniform highp sampler2D internalTex2;
 
 #ifndef CAMERAPLANES
 #define CAMERAPLANES


### PR DESCRIPTION
- sampling ParticleSystem textures using highp sampler as it seems it defaults to medp even in highp fragment shaders.
- makes examples/#graphics/particles-snow.html behave correctly in iOS devices