### PR TITLE
Update sound component to current format

### DIFF
--- a/src/deprecated.js
+++ b/src/deprecated.js
@@ -710,6 +710,7 @@ import { ComponentData } from './framework/components/data.js';
 import { ComponentSystem } from './framework/components/system.js';
 import { Entity } from './framework/entity.js';
 import { LightComponent } from './framework/components/light/component.js';
+import { ModelComponent } from './framework/components/model/component.js';
 import {
     BODYFLAG_KINEMATIC_OBJECT, BODYFLAG_NORESPONSE_OBJECT, BODYFLAG_STATIC_OBJECT,
     BODYSTATE_ACTIVE_TAG, BODYSTATE_DISABLE_DEACTIVATION, BODYSTATE_DISABLE_SIMULATION, BODYSTATE_ISLAND_SLEEPING, BODYSTATE_WANTS_DEACTIVATION,

--- a/src/deprecated.js
+++ b/src/deprecated.js
@@ -822,6 +822,13 @@ Object.defineProperty(LightComponent.prototype, "enable", {
     }
 });
 
+ModelComponent.prototype.setVisible = function (visible) {
+    // #ifdef DEBUG
+    console.warn("DEPRECATED: pc.ModelComponent#setVisible is deprecated. Use pc.ModelComponent#enabled instead.");
+    // #endif
+    this.enabled = visible;
+};
+
 Object.defineProperty(RigidBodyComponent.prototype, "bodyType", {
     get: function () {
         // #ifdef DEBUG

--- a/src/framework/components/model/component.js
+++ b/src/framework/components/model/component.js
@@ -99,11 +99,6 @@ ModelComponent.prototype = Object.create(Component.prototype);
 ModelComponent.prototype.constructor = ModelComponent;
 
 Object.assign(ModelComponent.prototype, {
-    setVisible: function (visible) {
-        console.warn("WARNING: setVisible: Function is deprecated. Set enabled property instead.");
-        this.enabled = visible;
-    },
-
     addModelToLayers: function () {
         var layer;
         var layers = this.system.app.scene.layers;

--- a/src/framework/components/model/system.js
+++ b/src/framework/components/model/system.js
@@ -8,9 +8,7 @@ import { ComponentSystem } from '../system.js';
 import { ModelComponent } from './component.js';
 import { ModelComponentData } from './data.js';
 
-var _schema = [
-    'enabled'
-];
+var _schema = ['enabled'];
 
 /**
  * @class

--- a/src/framework/components/sound/component.js
+++ b/src/framework/components/sound/component.js
@@ -50,15 +50,6 @@ function SoundComponent(system, entity) {
     this._slots = {};
 
     this._playingBeforeDisable = {};
-
-    this.on('set_slots', this.onSetSlots, this);
-    this.on('set_volume', this.onSetVolume, this);
-    this.on('set_pitch', this.onSetPitch, this);
-    this.on("set_refDistance", this.onSetRefDistance, this);
-    this.on("set_maxDistance", this.onSetMaxDistance, this);
-    this.on("set_rollOffFactor", this.onSetRollOffFactor, this);
-    this.on("set_distanceModel", this.onSetDistanceModel, this);
-    this.on("set_positional", this.onSetPositional, this);
 }
 SoundComponent.prototype = Object.create(Component.prototype);
 SoundComponent.prototype.constructor = SoundComponent;

--- a/src/framework/components/sound/component.js
+++ b/src/framework/components/sound/component.js
@@ -66,7 +66,7 @@ function defineSoundPropertyBasic(publicName, privateName) {
             var slots = this._slots;
             for (var key in slots) {
                 var slot = slots[key];
-                // change refDistance of non-overlapping instances
+                // only change value of non-overlapping instances
                 if (!slot.overlap) {
                     var instances = slot.instances;
                     for (var i = 0, len = instances.length; i < len; i++) {
@@ -89,7 +89,7 @@ function defineSoundPropertyFactor(publicName, privateName) {
             var slots = this._slots;
             for (var key in slots) {
                 var slot = slots[key];
-                // change refDistance of non-overlapping instances
+                // only change value of non-overlapping instances
                 if (!slot.overlap) {
                     var instances = slot.instances;
                     for (var i = 0, len = instances.length; i < len; i++) {

--- a/src/framework/components/sound/component.js
+++ b/src/framework/components/sound/component.js
@@ -15,11 +15,12 @@ import { SoundSlot } from './slot.js';
  * component.
  * @param {pc.Entity} entity - The entity that the Component is attached to.
  * @property {number} volume The volume modifier to play the audio with. In range 0-1.
+ * Defaults to 1.
  * @property {number} pitch The pitch modifier to play the audio with. Must be larger
- * than 0.01.
+ * than 0.01. Defaults to 1.
  * @property {boolean} positional If true the audio will play back at the location
  * of the Entity in space, so the audio will be affected by the position of the
- * {@link pc.AudioListenerComponent}.
+ * {@link pc.AudioListenerComponent}. Defaults to true.
  * @property {string} distanceModel Determines which algorithm to use to reduce the
  * volume of the sound as it moves away from the listener. Can be:
  *
@@ -27,15 +28,15 @@ import { SoundSlot } from './slot.js';
  * * {@link pc.DISTANCE_INVERSE}
  * * {@link pc.DISTANCE_EXPONENTIAL}
  *
- * Default is {@link pc.DISTANCE_LINEAR}.
+ * Defaults to {@link pc.DISTANCE_LINEAR}.
  * @property {number} refDistance The reference distance for reducing volume as the
- * sound source moves further from the listener.
+ * sound source moves further from the listener. Defaults to 1.
  * @property {number} maxDistance The maximum distance from the listener at which audio
  * falloff stops. Note the volume of the audio is not 0 after this distance, but just
- * doesn't fall off anymore.
- * @property {number} rollOffFactor The factor used in the falloff equation.
+ * doesn't fall off anymore. Defaults to 10000.
+ * @property {number} rollOffFactor The factor used in the falloff equation. Defaults to 1.
  * @property {object} slots A dictionary that contains the {@link pc.SoundSlot}s managed
- * by this Component.
+ * by this SoundComponent.
  */
 function SoundComponent(system, entity) {
     Component.call(this, system, entity);

--- a/src/framework/components/sound/data.js
+++ b/src/framework/components/sound/data.js
@@ -1,19 +1,5 @@
-import { DISTANCE_LINEAR } from '../../../audio/constants.js';
-
 function SoundComponentData() {
-    // serialized
     this.enabled = true;
-    this.volume = 1;
-    this.pitch = 1;
-    this.positional = true;
-    this.refDistance = 1;
-    this.maxDistance = 10000;
-    this.rollOffFactor = 1;
-    this.distanceModel = DISTANCE_LINEAR;
-    this.slots = {};
-
-    // non serialized
-    this.playingBeforeDisable = {};
 }
 
 export { SoundComponentData };

--- a/src/framework/components/sound/slot.js
+++ b/src/framework/components/sound/slot.js
@@ -63,11 +63,13 @@ var instanceOptions = {
 function SoundSlot(component, name, options) {
     EventHandler.call(this);
 
-    options = options || {};
     this._component = component;
     this._assets = component.system.app.assets;
     this._manager = component.system.manager;
-    this._name = name || 'Untitled';
+
+    this.name = name || 'Untitled';
+
+    options = options || {};
     this._volume = options.volume !== undefined ? math.clamp(Number(options.volume) || 0, 0, 1) : 1;
     this._pitch = options.pitch !== undefined ? Math.max(0.01, Number(options.pitch) || 0) : 1;
     this._loop = !!(options.loop !== undefined ? options.loop : false);
@@ -111,7 +113,7 @@ Object.assign(SoundSlot.prototype, {
         // If not loaded and doesn't have asset - then we cannot play it.  Warn and exit.
         if (!this.isLoaded && !this._hasAsset()) {
             // #ifdef DEBUG
-            console.warn("Trying to play SoundSlot " + this._name + " but it is not loaded and doesn't have an asset.");
+            console.warn("Trying to play SoundSlot " + this.name + " but it is not loaded and doesn't have an asset.");
             // #endif
             return;
         }
@@ -437,15 +439,6 @@ Object.assign(SoundSlot.prototype, {
         for (var i = 0, len = instances.length; i < len; i++) {
             instances[i].position = position;
         }
-    }
-});
-
-Object.defineProperty(SoundSlot.prototype, 'name', {
-    get: function () {
-        return this._name;
-    },
-    set: function (value) {
-        this._name = value;
     }
 });
 

--- a/src/framework/components/sound/system.js
+++ b/src/framework/components/sound/system.js
@@ -5,7 +5,6 @@ import { ComponentSystem } from '../system.js';
 
 import { SoundComponent } from './component.js';
 import { SoundComponentData } from './data.js';
-import { SoundSlot } from './slot.js';
 
 var _schema = ['enabled'];
 

--- a/src/framework/components/sound/system.js
+++ b/src/framework/components/sound/system.js
@@ -46,14 +46,14 @@ Component._buildAccessors(SoundComponent.prototype, _schema);
 Object.assign(SoundComponentSystem.prototype, {
     initializeComponentData: function (component, data, properties) {
         properties = [
-            'distanceModel',
-            'maxDistance',
+            'volume',
             'pitch',
             'positional',
             'refDistance',
+            'maxDistance',
             'rollOffFactor',
-            'slots',
-            'volume'
+            'distanceModel',
+            'slots'
         ];
 
         for (var i = 0; i < properties.length; i++) {


### PR DESCRIPTION
This PR updates the sound component to use the current recommended structure for an engine component. The `data` block is now no longer used.

It also moves ModelComponent#setVisible to the deprecated.js file.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
