### PR TITLE
anim binder handles empty named nodes

### DIFF
--- a/src/anim/anim.js
+++ b/src/anim/anim.js
@@ -705,7 +705,7 @@ Object.assign(DefaultAnimBinder.prototype, {
     resolve: function (path) {
         var pathSections = this.propertyLocator.decode(path);
 
-        var node = this.nodes[pathSections[0][0]];
+        var node = this.nodes[pathSections[0][0] || ""];
         if (!node) {
             return null;
         }


### PR DESCRIPTION
Empty node name was not being bound correctly. This fixes that issue.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
