### PR TITLE
Remove unused description property from component systems

### DIFF
--- a/src/framework/components/anim/system.js
+++ b/src/framework/components/anim/system.js
@@ -24,7 +24,6 @@ function AnimComponentSystem(app) {
     ComponentSystem.call(this, app);
 
     this.id = 'anim';
-    this.description = "State based animation system that can animate the models and component properties of this entity and its children";
 
     this.ComponentType = AnimComponent;
     this.DataType = AnimComponentData;

--- a/src/framework/components/animation/system.js
+++ b/src/framework/components/animation/system.js
@@ -34,7 +34,6 @@ function AnimationComponentSystem(app) {
     ComponentSystem.call(this, app);
 
     this.id = 'animation';
-    this.description = "Specifies the animation assets that can run on the model specified by the Entity's model Component.";
 
     this.ComponentType = AnimationComponent;
     this.DataType = AnimationComponentData;

--- a/src/framework/components/audio-listener/system.js
+++ b/src/framework/components/audio-listener/system.js
@@ -19,7 +19,6 @@ function AudioListenerComponentSystem(app, manager) {
     ComponentSystem.call(this, app);
 
     this.id = "audiolistener";
-    this.description = "Specifies the location of the listener for 3D audio playback.";
 
     this.ComponentType = AudioListenerComponent;
     this.DataType = AudioListenerComponentData;

--- a/src/framework/components/audio-source/system.js
+++ b/src/framework/components/audio-source/system.js
@@ -38,7 +38,6 @@ function AudioSourceComponentSystem(app, manager) {
     ComponentSystem.call(this, app);
 
     this.id = "audiosource";
-    this.description = "Specifies audio assets that can be played at the position of the Entity.";
 
     this.ComponentType = AudioSourceComponent;
     this.DataType = AudioSourceComponentData;

--- a/src/framework/components/camera/system.js
+++ b/src/framework/components/camera/system.js
@@ -55,7 +55,6 @@ var CameraComponentSystem = function (app) {
     ComponentSystem.call(this, app);
 
     this.id = 'camera';
-    this.description = "Renders the scene from the location of the Entity.";
 
     this.ComponentType = CameraComponent;
     this.DataType = CameraComponentData;

--- a/src/framework/components/collision/system.js
+++ b/src/framework/components/collision/system.js
@@ -591,7 +591,6 @@ var CollisionComponentSystem = function CollisionComponentSystem(app) {
     ComponentSystem.call(this, app);
 
     this.id = "collision";
-    this.description = "Specifies a collision volume.";
 
     this.ComponentType = CollisionComponent;
     this.DataType = CollisionComponentData;

--- a/src/framework/components/light/system.js
+++ b/src/framework/components/light/system.js
@@ -29,7 +29,6 @@ function LightComponentSystem(app) {
     ComponentSystem.call(this, app);
 
     this.id = 'light';
-    this.description = "Enables the Entity to emit light.";
 
     this.ComponentType = LightComponent;
     this.DataType = LightComponentData;

--- a/src/framework/components/model/system.js
+++ b/src/framework/components/model/system.js
@@ -25,7 +25,6 @@ function ModelComponentSystem(app) {
     ComponentSystem.call(this, app);
 
     this.id = 'model';
-    this.description = "Renders a 3D model at the location of the Entity.";
 
     this.ComponentType = ModelComponent;
     this.DataType = ModelComponentData;

--- a/src/framework/components/particle-system/system.js
+++ b/src/framework/components/particle-system/system.js
@@ -90,7 +90,6 @@ function ParticleSystemComponentSystem(app) {
     ComponentSystem.call(this, app);
 
     this.id = 'particlesystem';
-    this.description = "Updates and renders particle system in the scene.";
 
     this.ComponentType = ParticleSystemComponent;
     this.DataType = ParticleSystemComponentData;

--- a/src/framework/components/rigid-body/system.js
+++ b/src/framework/components/rigid-body/system.js
@@ -157,7 +157,6 @@ function RigidBodyComponentSystem(app) {
     ComponentSystem.call(this, app);
 
     this.id = 'rigidbody';
-    this.description = "Adds the entity to the scene's physical simulation.";
     this._stats = app.stats.frame;
 
     this.ComponentType = RigidBodyComponent;

--- a/src/framework/components/script-legacy/system.js
+++ b/src/framework/components/script-legacy/system.js
@@ -36,7 +36,6 @@ var ScriptLegacyComponentSystem = function ScriptLegacyComponentSystem(app) {
     ComponentSystem.call(this, app);
 
     this.id = 'script';
-    this.description = "Allows the Entity to run JavaScript fragments to implement custom behavior.";
 
     this.ComponentType = ScriptLegacyComponent;
     this.DataType = ScriptLegacyComponentData;

--- a/src/framework/components/sound/system.js
+++ b/src/framework/components/sound/system.js
@@ -36,7 +36,6 @@ var SoundComponentSystem = function (app, manager) {
     ComponentSystem.call(this, app);
 
     this.id = "sound";
-    this.description = "Allows an Entity to play sounds";
 
     this.ComponentType = SoundComponent;
     this.DataType = SoundComponentData;


### PR DESCRIPTION
The `description` property is set on just 13 of 22 component systems in the engine. It is unused in the engine. It could potentially be used in the Editor (although highly unlikely). So this PR removes them.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
