### PR TITLE
Skinning and morphing matrices optimization

### DIFF
--- a/src/graphics/device.js
+++ b/src/graphics/device.js
@@ -25,7 +25,7 @@ import {
     UNIFORMTYPE_VEC4, UNIFORMTYPE_IVEC2, UNIFORMTYPE_IVEC3, UNIFORMTYPE_IVEC4, UNIFORMTYPE_BVEC2,
     UNIFORMTYPE_BVEC3, UNIFORMTYPE_BVEC4, UNIFORMTYPE_MAT2, UNIFORMTYPE_MAT3, UNIFORMTYPE_MAT4,
     UNIFORMTYPE_TEXTURE2D, UNIFORMTYPE_TEXTURECUBE, UNIFORMTYPE_FLOATARRAY, UNIFORMTYPE_TEXTURE2D_SHADOW,
-    UNIFORMTYPE_TEXTURECUBE_SHADOW, UNIFORMTYPE_TEXTURE3D, UNIFORMTYPE_VEC4ARRAY
+    UNIFORMTYPE_TEXTURECUBE_SHADOW, UNIFORMTYPE_TEXTURE3D, UNIFORMTYPE_VEC2ARRAY, UNIFORMTYPE_VEC3ARRAY, UNIFORMTYPE_VEC4ARRAY
 } from './graphics.js';
 
 import { drawQuadWithShader } from './simple-post-effect.js';
@@ -577,6 +577,12 @@ var GraphicsDevice = function (canvas, options) {
     };
     this.commitFunction[UNIFORMTYPE_FLOATARRAY] = function (uniform, value) {
         gl.uniform1fv(uniform.locationId, value);
+    };
+    this.commitFunction[UNIFORMTYPE_VEC2ARRAY]  = function (uniform, value) {
+        gl.uniform2fv(uniform.locationId, value);
+    };
+    this.commitFunction[UNIFORMTYPE_VEC3ARRAY]  = function (uniform, value) {
+        gl.uniform3fv(uniform.locationId, value);
     };
     this.commitFunction[UNIFORMTYPE_VEC4ARRAY]  = function (uniform, value) {
         gl.uniform4fv(uniform.locationId, value);

--- a/src/graphics/device.js
+++ b/src/graphics/device.js
@@ -25,7 +25,7 @@ import {
     UNIFORMTYPE_VEC4, UNIFORMTYPE_IVEC2, UNIFORMTYPE_IVEC3, UNIFORMTYPE_IVEC4, UNIFORMTYPE_BVEC2,
     UNIFORMTYPE_BVEC3, UNIFORMTYPE_BVEC4, UNIFORMTYPE_MAT2, UNIFORMTYPE_MAT3, UNIFORMTYPE_MAT4,
     UNIFORMTYPE_TEXTURE2D, UNIFORMTYPE_TEXTURECUBE, UNIFORMTYPE_FLOATARRAY, UNIFORMTYPE_TEXTURE2D_SHADOW,
-    UNIFORMTYPE_TEXTURECUBE_SHADOW, UNIFORMTYPE_TEXTURE3D
+    UNIFORMTYPE_TEXTURECUBE_SHADOW, UNIFORMTYPE_TEXTURE3D, UNIFORMTYPE_VEC4ARRAY
 } from './graphics.js';
 
 import { drawQuadWithShader } from './simple-post-effect.js';
@@ -578,6 +578,9 @@ var GraphicsDevice = function (canvas, options) {
     this.commitFunction[UNIFORMTYPE_FLOATARRAY] = function (uniform, value) {
         gl.uniform1fv(uniform.locationId, value);
     };
+    this.commitFunction[UNIFORMTYPE_VEC4ARRAY]  = function (uniform, value) {
+        gl.uniform4fv(uniform.locationId, value);
+    };
 
     // Create the ScopeNamespace for shader attributes and variables
     this.scope = new ScopeSpace("Device");
@@ -599,7 +602,7 @@ var GraphicsDevice = function (canvas, options) {
     numUniforms -= 8;     // 8 lights max, each specifying a position vector
     numUniforms -= 1;     // Eye position
     numUniforms -= 4 * 4; // Up to 4 texture transforms
-    this.boneLimit = Math.floor(numUniforms / 4);
+    this.boneLimit = Math.floor(numUniforms / 3);   // each bone uses 3 uniforms
 
     // Put a limit on the number of supported bones before skin partitioning must be performed
     // Some GPUs have demonstrated performance issues if the number of vectors allocated to the

--- a/src/graphics/graphics.js
+++ b/src/graphics/graphics.js
@@ -1071,7 +1071,9 @@ export var UNIFORMTYPE_FLOATARRAY = 17;
 export var UNIFORMTYPE_TEXTURE2D_SHADOW = 18;
 export var UNIFORMTYPE_TEXTURECUBE_SHADOW = 19;
 export var UNIFORMTYPE_TEXTURE3D = 20;
-export var UNIFORMTYPE_VEC4ARRAY = 21;
+export var UNIFORMTYPE_VEC2ARRAY = 21;
+export var UNIFORMTYPE_VEC3ARRAY = 22;
+export var UNIFORMTYPE_VEC4ARRAY = 23;
 
 // map of engine pc.TYPE_*** enums to their corresponding typed array constructors and byte sizes
 export var typedArrayTypes = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array, Float32Array];

--- a/src/graphics/graphics.js
+++ b/src/graphics/graphics.js
@@ -1071,6 +1071,7 @@ export var UNIFORMTYPE_FLOATARRAY = 17;
 export var UNIFORMTYPE_TEXTURE2D_SHADOW = 18;
 export var UNIFORMTYPE_TEXTURECUBE_SHADOW = 19;
 export var UNIFORMTYPE_TEXTURE3D = 20;
+export var UNIFORMTYPE_VEC4ARRAY = 21;
 
 // map of engine pc.TYPE_*** enums to their corresponding typed array constructors and byte sizes
 export var typedArrayTypes = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array, Float32Array];

--- a/src/graphics/program-lib/chunks/skinBatchConst.vert
+++ b/src/graphics/program-lib/chunks/skinBatchConst.vert
@@ -1,7 +1,19 @@
 attribute float vertex_boneIndices;
-uniform mat4 matrix_pose[BONE_LIMIT];
+uniform vec4 matrix_pose[BONE_LIMIT * 3];
+
 mat4 getBoneMatrix(const in float i) {
-    mat4 bone = matrix_pose[int(i)];
-    return bone;
+
+    // read 4x3 matrix
+    vec4 v1 = matrix_pose[int(3.0 * i)];
+    vec4 v2 = matrix_pose[int(3.0 * i + 1.0)];
+    vec4 v3 = matrix_pose[int(3.0 * i + 2.0)];
+
+    // transpose to 4x4 matrix
+    return mat4(
+        v1.x, v2.x, v3.x, 0,
+        v1.y, v2.y, v3.y, 0,
+        v1.z, v2.z, v3.z, 0,
+        v1.w, v2.w, v3.w, 1
+    );
 }
 

--- a/src/graphics/program-lib/chunks/skinBatchTex.vert
+++ b/src/graphics/program-lib/chunks/skinBatchTex.vert
@@ -1,23 +1,26 @@
 attribute float vertex_boneIndices;
 uniform highp sampler2D texture_poseMap;
-uniform vec2 texture_poseMapSize;
+uniform vec4 texture_poseMapSize;
 mat4 getBoneMatrix(const in float i) {
-    float j = i * 4.0;
+    float j = i * 3.0;
+    float dx = texture_poseMapSize.z;
+    float dy = texture_poseMapSize.w;
+
     float x = mod(j, float(texture_poseMapSize.x));
-    float y = floor(j / float(texture_poseMapSize.x));
-
-    float dx = 1.0 / float(texture_poseMapSize.x);
-    float dy = 1.0 / float(texture_poseMapSize.y);
-
+    float y = floor(j * dx);
     y = dy * (y + 0.5);
 
+    // read elements of 4x3 matrix
     vec4 v1 = texture2D(texture_poseMap, vec2(dx * (x + 0.5), y));
     vec4 v2 = texture2D(texture_poseMap, vec2(dx * (x + 1.5), y));
     vec4 v3 = texture2D(texture_poseMap, vec2(dx * (x + 2.5), y));
-    vec4 v4 = texture2D(texture_poseMap, vec2(dx * (x + 3.5), y));
 
-    mat4 bone = mat4(v1, v2, v3, v4);
-
-    return bone;
+    // transpose to 4x4 matrix
+    return mat4(
+        v1.x, v2.x, v3.x, 0,
+        v1.y, v2.y, v3.y, 0,
+        v1.z, v2.z, v3.z, 0,
+        v1.w, v2.w, v3.w, 1
+    );
 }
 

--- a/src/graphics/program-lib/chunks/skinConst.vert
+++ b/src/graphics/program-lib/chunks/skinConst.vert
@@ -1,12 +1,45 @@
 attribute vec4 vertex_boneWeights;
 attribute vec4 vertex_boneIndices;
 
-uniform mat4 matrix_pose[BONE_LIMIT];
+uniform vec4 matrix_pose[BONE_LIMIT * 3];
 
-mat4 getBoneMatrix(const in float i)
+void getBoneMatrix(const in float i, out vec4 v1, out vec4 v2, out vec4 v3)
 {
-    mat4 bone = matrix_pose[int(i)];
+    // read 4x3 matrix
+    v1 = matrix_pose[int(3.0 * i)];
+    v2 = matrix_pose[int(3.0 * i + 1.0)];
+    v3 = matrix_pose[int(3.0 * i + 2.0)];
+}
 
-    return bone;
+mat4 getSkinMatrix(const in vec4 indices, const in vec4 weights)
+{
+    // get 4 bone matrices
+    vec4 a1, a2, a3;
+    getBoneMatrix(indices.x, a1, a2, a3);
+
+    vec4 b1, b2, b3;
+    getBoneMatrix(indices.y, b1, b2, b3);
+
+    vec4 c1, c2, c3;
+    getBoneMatrix(indices.z, c1, c2, c3);
+
+    vec4 d1, d2, d3;
+    getBoneMatrix(indices.w, d1, d2, d3);
+
+    // multiply them by weights and add up to get final 4x3 matrix
+    vec4 v1 = a1 * weights.x + b1 * weights.y + c1 * weights.z + d1 * weights.w;
+    vec4 v2 = a2 * weights.x + b2 * weights.y + c2 * weights.z + d2 * weights.w;
+    vec4 v3 = a3 * weights.x + b3 * weights.y + c3 * weights.z + d3 * weights.w;
+
+    // add up weights
+    float one = dot(weights, vec4(1.0));
+
+    // transpose to 4x4 matrix
+    return mat4(
+        v1.x, v2.x, v3.x, 0,
+        v1.y, v2.y, v3.y, 0,
+        v1.z, v2.z, v3.z, 0,
+        v1.w, v2.w, v3.w, one
+    );
 }
 

--- a/src/graphics/program-lib/chunks/skinTex.vert
+++ b/src/graphics/program-lib/chunks/skinTex.vert
@@ -2,26 +2,53 @@ attribute vec4 vertex_boneWeights;
 attribute vec4 vertex_boneIndices;
 
 uniform highp sampler2D texture_poseMap;
-uniform vec2 texture_poseMapSize;
+uniform vec4 texture_poseMapSize;
 
-mat4 getBoneMatrix(const in float i)
+void getBoneMatrix(const in float i, out vec4 v1, out vec4 v2, out vec4 v3)
 {
-    float j = i * 4.0;
+    float j = i * 3.0;
+    float dx = texture_poseMapSize.z;
+    float dy = texture_poseMapSize.w;
+    
     float x = mod(j, float(texture_poseMapSize.x));
-    float y = floor(j / float(texture_poseMapSize.x));
-
-    float dx = 1.0 / float(texture_poseMapSize.x);
-    float dy = 1.0 / float(texture_poseMapSize.y);
-
+    float y = floor(j * dx);
     y = dy * (y + 0.5);
 
-    vec4 v1 = texture2D(texture_poseMap, vec2(dx * (x + 0.5), y));
-    vec4 v2 = texture2D(texture_poseMap, vec2(dx * (x + 1.5), y));
-    vec4 v3 = texture2D(texture_poseMap, vec2(dx * (x + 2.5), y));
-    vec4 v4 = texture2D(texture_poseMap, vec2(dx * (x + 3.5), y));
+    // read elements of 4x3 matrix
+    v1 = texture2D(texture_poseMap, vec2(dx * (x + 0.5), y));
+    v2 = texture2D(texture_poseMap, vec2(dx * (x + 1.5), y));
+    v3 = texture2D(texture_poseMap, vec2(dx * (x + 2.5), y));
+}
 
-    mat4 bone = mat4(v1, v2, v3, v4);
+mat4 getSkinMatrix(const in vec4 indices, const in vec4 weights)
+{
+    // get 4 bone matrices
+    vec4 a1, a2, a3;
+    getBoneMatrix(indices.x, a1, a2, a3);
 
-    return bone;
+    vec4 b1, b2, b3;
+    getBoneMatrix(indices.y, b1, b2, b3);
+
+    vec4 c1, c2, c3;
+    getBoneMatrix(indices.z, c1, c2, c3);
+
+    vec4 d1, d2, d3;
+    getBoneMatrix(indices.w, d1, d2, d3);
+
+    // multiply them by weights and add up to get final 4x3 matrix
+    vec4 v1 = a1 * weights.x + b1 * weights.y + c1 * weights.z + d1 * weights.w;
+    vec4 v2 = a2 * weights.x + b2 * weights.y + c2 * weights.z + d2 * weights.w;
+    vec4 v3 = a3 * weights.x + b3 * weights.y + c3 * weights.z + d3 * weights.w;
+
+    // add up weights
+    float one = dot(weights, vec4(1.0));
+
+    // transpose to 4x4 matrix
+    return mat4(
+        v1.x, v2.x, v3.x, 0,
+        v1.y, v2.y, v3.y, 0,
+        v1.z, v2.z, v3.z, 0,
+        v1.w, v2.w, v3.w, one
+    );
 }
 

--- a/src/graphics/program-lib/chunks/transform.vert
+++ b/src/graphics/program-lib/chunks/transform.vert
@@ -32,10 +32,7 @@ mat4 getModelMatrix() {
     #ifdef DYNAMICBATCH
         return getBoneMatrix(vertex_boneIndices);
     #elif defined(SKIN)
-        return matrix_model * (getBoneMatrix(vertex_boneIndices.x) * vertex_boneWeights.x +
-               getBoneMatrix(vertex_boneIndices.y) * vertex_boneWeights.y +
-               getBoneMatrix(vertex_boneIndices.z) * vertex_boneWeights.z +
-               getBoneMatrix(vertex_boneIndices.w) * vertex_boneWeights.w);
+        return matrix_model * getSkinMatrix(vertex_boneIndices, vertex_boneWeights);
     #elif defined(INSTANCING)
         return mat4(instance_line1, instance_line2, instance_line3, instance_line4);
     #else

--- a/src/graphics/shader-input.js
+++ b/src/graphics/shader-input.js
@@ -1,4 +1,4 @@
-import { UNIFORMTYPE_FLOAT, UNIFORMTYPE_FLOATARRAY } from './graphics.js';
+import { UNIFORMTYPE_FLOAT, UNIFORMTYPE_FLOATARRAY, UNIFORMTYPE_VEC4, UNIFORMTYPE_VEC4ARRAY } from './graphics.js';
 import { Version } from './version.js';
 
 function ShaderInput(graphicsDevice, name, type, locationId) {
@@ -11,10 +11,16 @@ function ShaderInput(graphicsDevice, name, type, locationId) {
     // Create the version
     this.version = new Version();
 
-    // Set the data dataType
-    if (type === UNIFORMTYPE_FLOAT) {
-        if (name.substr(name.length - 3) === "[0]") type = UNIFORMTYPE_FLOATARRAY;
+    // custome data type for arrays
+    if (name.substr(name.length - 3) === "[0]") {
+        if (type === UNIFORMTYPE_FLOAT) {
+            type = UNIFORMTYPE_FLOATARRAY;
+        } else if (type === UNIFORMTYPE_VEC4) {
+            type = UNIFORMTYPE_VEC4ARRAY;
+        }
     }
+
+    // Set the data dataType
     this.dataType = type;
 
     this.value = [null, null, null, null];

--- a/src/graphics/shader-input.js
+++ b/src/graphics/shader-input.js
@@ -1,4 +1,5 @@
-import { UNIFORMTYPE_FLOAT, UNIFORMTYPE_FLOATARRAY, UNIFORMTYPE_VEC4, UNIFORMTYPE_VEC4ARRAY } from './graphics.js';
+import { UNIFORMTYPE_FLOAT, UNIFORMTYPE_FLOATARRAY, UNIFORMTYPE_VEC2, UNIFORMTYPE_VEC3, UNIFORMTYPE_VEC4,
+    UNIFORMTYPE_VEC2ARRAY, UNIFORMTYPE_VEC3ARRAY, UNIFORMTYPE_VEC4ARRAY } from './graphics.js';
 import { Version } from './version.js';
 
 function ShaderInput(graphicsDevice, name, type, locationId) {
@@ -13,10 +14,11 @@ function ShaderInput(graphicsDevice, name, type, locationId) {
 
     // custome data type for arrays
     if (name.substr(name.length - 3) === "[0]") {
-        if (type === UNIFORMTYPE_FLOAT) {
-            type = UNIFORMTYPE_FLOATARRAY;
-        } else if (type === UNIFORMTYPE_VEC4) {
-            type = UNIFORMTYPE_VEC4ARRAY;
+        switch (type) {
+            case UNIFORMTYPE_FLOAT: type = UNIFORMTYPE_FLOATARRAY; break;
+            case UNIFORMTYPE_VEC2: type = UNIFORMTYPE_VEC2ARRAY; break;
+            case UNIFORMTYPE_VEC3: type = UNIFORMTYPE_VEC3ARRAY; break;
+            case UNIFORMTYPE_VEC4: type = UNIFORMTYPE_VEC4ARRAY; break;
         }
     }
 

--- a/src/math/mat4.js
+++ b/src/math/mat4.js
@@ -273,6 +273,75 @@ Object.assign(Mat4.prototype, {
 
     /**
      * @function
+     * @name pc.Mat4#mulTransform2
+     * @description Multiplies the specified 4x4 matrices together and stores the result in
+     * the current instance. This function assumes the matrices are affine transformation matrices, where the upper left 3x3 elements
+     * are a rotation matrix, and the bottom left 3 elements are translation. The rightmost column is assumed to be [0, 0, 0, 1]. The parameters
+     * are not verified to be in the expected format. This function is faster than general {@link pc.Mat4#mul2}.
+     * @param {pc.Mat4} lhs - The affine transformation 4x4 matrix used as the first multiplicand of the operation.
+     * @param {pc.Mat4} rhs - The affine transformation 4x4 matrix used as the second multiplicand of the operation.
+     * @returns {pc.Mat4} Self for chaining.
+     */
+    mulTransform2: function (lhs, rhs) {
+        var a00, a01, a02,
+            a10, a11, a12,
+            a20, a21, a22,
+            a30, a31, a32,
+            b0, b1, b2,
+            a = lhs.data,
+            b = rhs.data,
+            r = this.data;
+
+        a00 = a[0];
+        a01 = a[1];
+        a02 = a[2];
+        a10 = a[4];
+        a11 = a[5];
+        a12 = a[6];
+        a20 = a[8];
+        a21 = a[9];
+        a22 = a[10];
+        a30 = a[12];
+        a31 = a[13];
+        a32 = a[14];
+
+        b0 = b[0];
+        b1 = b[1];
+        b2 = b[2];
+        r[0]  = a00 * b0 + a10 * b1 + a20 * b2;
+        r[1]  = a01 * b0 + a11 * b1 + a21 * b2;
+        r[2]  = a02 * b0 + a12 * b1 + a22 * b2;
+        r[3] = 0;
+
+        b0 = b[4];
+        b1 = b[5];
+        b2 = b[6];
+        r[4]  = a00 * b0 + a10 * b1 + a20 * b2;
+        r[5]  = a01 * b0 + a11 * b1 + a21 * b2;
+        r[6]  = a02 * b0 + a12 * b1 + a22 * b2;
+        r[7] = 0;
+
+        b0 = b[8];
+        b1 = b[9];
+        b2 = b[10];
+        r[8]  = a00 * b0 + a10 * b1 + a20 * b2;
+        r[9]  = a01 * b0 + a11 * b1 + a21 * b2;
+        r[10] = a02 * b0 + a12 * b1 + a22 * b2;
+        r[11] = 0;
+
+        b0 = b[12];
+        b1 = b[13];
+        b2 = b[14];
+        r[12] = a00 * b0 + a10 * b1 + a20 * b2 + a30;
+        r[13] = a01 * b0 + a11 * b1 + a21 * b2 + a31;
+        r[14] = a02 * b0 + a12 * b1 + a22 * b2 + a32;
+        r[15] = 1;
+
+        return this;
+    },
+
+    /**
+     * @function
      * @name pc.Mat4#mul
      * @description Multiplies the current instance by the specified 4x4 matrix.
      * @param {pc.Mat4} rhs - The 4x4 matrix used as the second multiplicand of the operation.

--- a/src/math/mat4.js
+++ b/src/math/mat4.js
@@ -273,7 +273,7 @@ Object.assign(Mat4.prototype, {
 
     /**
      * @function
-     * @name pc.Mat4#mulTransform2
+     * @name pc.Mat4#mulAffine2
      * @description Multiplies the specified 4x4 matrices together and stores the result in
      * the current instance. This function assumes the matrices are affine transformation matrices, where the upper left 3x3 elements
      * are a rotation matrix, and the bottom left 3 elements are translation. The rightmost column is assumed to be [0, 0, 0, 1]. The parameters
@@ -282,7 +282,7 @@ Object.assign(Mat4.prototype, {
      * @param {pc.Mat4} rhs - The affine transformation 4x4 matrix used as the second multiplicand of the operation.
      * @returns {pc.Mat4} Self for chaining.
      */
-    mulTransform2: function (lhs, rhs) {
+    mulAffine2: function (lhs, rhs) {
         var a00, a01, a02,
             a10, a11, a12,
             a20, a21, a22,

--- a/src/scene/batching.js
+++ b/src/scene/batching.js
@@ -106,27 +106,24 @@ Object.assign(SkinBatchInstance.prototype, {
         var mp = this.matrixPalette;
         var base;
 
-        for (var i = this.bones.length - 1; i >= 0; i--) {
+        var count = this.bones.length;
+        for (var i = 0; i < count; i++) {
             pe = this.bones[i].getWorldTransform().data;
 
-            // Copy the matrix into the palette, ready to be sent to the vertex shader
-            base = i * 16;
+            // Copy the matrix into the palette, ready to be sent to the vertex shader, transpose matrix from 4x4 to 4x3 format as well
+            base = i * 12;
             mp[base] = pe[0];
-            mp[base + 1] = pe[1];
-            mp[base + 2] = pe[2];
-            mp[base + 3] = pe[3];
-            mp[base + 4] = pe[4];
+            mp[base + 1] = pe[4];
+            mp[base + 2] = pe[8];
+            mp[base + 3] = pe[12];
+            mp[base + 4] = pe[1];
             mp[base + 5] = pe[5];
-            mp[base + 6] = pe[6];
-            mp[base + 7] = pe[7];
-            mp[base + 8] = pe[8];
-            mp[base + 9] = pe[9];
+            mp[base + 6] = pe[9];
+            mp[base + 7] = pe[13];
+            mp[base + 8] = pe[2];
+            mp[base + 9] = pe[6];
             mp[base + 10] = pe[10];
-            mp[base + 11] = pe[11];
-            mp[base + 12] = pe[12];
-            mp[base + 13] = pe[13];
-            mp[base + 14] = pe[14];
-            mp[base + 15] = pe[15];
+            mp[base + 11] = pe[14];
         }
 
         SkinInstance.prototype.uploadBones.call(this, this.device);

--- a/src/scene/forward-renderer.js
+++ b/src/scene/forward-renderer.js
@@ -102,7 +102,7 @@ var frustumDiagonal = new Vec3();
 var tempSphere = { center: null, radius: 0 };
 var meshPos;
 var visibleSceneAabb = new BoundingBox();
-var boneTextureSize = [0, 0];
+var boneTextureSize = [0, 0, 0, 0];
 var boneTexture, instancingData, modelMatrix, normalMatrix;
 
 var shadowMapCubeCache = {};
@@ -1247,6 +1247,8 @@ Object.assign(ForwardRenderer.prototype, {
                 this.boneTextureId.setValue(boneTexture);
                 boneTextureSize[0] = boneTexture.width;
                 boneTextureSize[1] = boneTexture.height;
+                boneTextureSize[2] = 1.0 / boneTexture.width;
+                boneTextureSize[3] = 1.0 / boneTexture.height;
                 this.boneTextureSizeId.setValue(boneTextureSize);
             } else {
                 this.poseMatrixId.setValue(meshInstance.skinInstance.matrixPalette);

--- a/src/scene/skin.js
+++ b/src/scene/skin.js
@@ -47,12 +47,15 @@ Object.assign(SkinInstance.prototype, {
 
         if (device.supportsBoneTextures) {
 
-            // texture size - square texture with power of two side, large enough to fit 4 pixels per bone
-            var size = numBones > 16 ? math.nextPowerOfTwo(Math.ceil(Math.sqrt(numBones * 4))) : 8;
+            // texture size - roughly square that fits all bones, width is multiply of 3 to simplify shader math
+            var numPixels = numBones * 3;
+            var width = Math.ceil(Math.sqrt(numPixels));
+            width = math.roundUp(width, 3);
+            var height = Math.ceil(numPixels / width);
 
             this.boneTexture = new Texture(device, {
-                width: size,
-                height: size,
+                width: width,
+                height: height,
                 format: PIXELFORMAT_RGBA32F,
                 mipmaps: false,
                 minFilter: FILTER_NEAREST,
@@ -63,7 +66,7 @@ Object.assign(SkinInstance.prototype, {
             this.matrixPalette = this.boneTexture.lock();
 
         } else {
-            this.matrixPalette = new Float32Array(numBones * 16);
+            this.matrixPalette = new Float32Array(numBones * 12);
         }
     },
 
@@ -96,8 +99,8 @@ Object.assign(SkinInstance.prototype, {
 
         _invMatrix.copy(rootNode.getWorldTransform()).invert();
         for (var i = this.bones.length - 1; i >= 0; i--) {
-            this.matrices[i].mul2(_invMatrix, this.bones[i].getWorldTransform()); // world space -> rootNode space
-            this.matrices[i].mul2(this.matrices[i], this.skin.inverseBindPose[i]); // rootNode space -> bind space
+            this.matrices[i].mulTransform2(_invMatrix, this.bones[i].getWorldTransform()); // world space -> rootNode space
+            this.matrices[i].mulTransform2(this.matrices[i], this.skin.inverseBindPose[i]); // rootNode space -> bind space
         }
     },
 
@@ -106,27 +109,24 @@ Object.assign(SkinInstance.prototype, {
         var mp = this.matrixPalette;
         var base;
 
-        for (var i = this.bones.length - 1; i >= 0; i--) {
+        var count = this.bones.length;
+        for (var i = 0; i < count; i++) {
             pe = this.matrices[i].data;
 
-            // Copy the matrix into the palette, ready to be sent to the vertex shader
-            base = i * 16;
+            // Copy the matrix into the palette, ready to be sent to the vertex shader, transpose matrix from 4x4 to 4x3 format as well
+            base = i * 12;
             mp[base] = pe[0];
-            mp[base + 1] = pe[1];
-            mp[base + 2] = pe[2];
-            mp[base + 3] = pe[3];
-            mp[base + 4] = pe[4];
+            mp[base + 1] = pe[4];
+            mp[base + 2] = pe[8];
+            mp[base + 3] = pe[12];
+            mp[base + 4] = pe[1];
             mp[base + 5] = pe[5];
-            mp[base + 6] = pe[6];
-            mp[base + 7] = pe[7];
-            mp[base + 8] = pe[8];
-            mp[base + 9] = pe[9];
+            mp[base + 6] = pe[9];
+            mp[base + 7] = pe[13];
+            mp[base + 8] = pe[2];
+            mp[base + 9] = pe[6];
             mp[base + 10] = pe[10];
-            mp[base + 11] = pe[11];
-            mp[base + 12] = pe[12];
-            mp[base + 13] = pe[13];
-            mp[base + 14] = pe[14];
-            mp[base + 15] = pe[15];
+            mp[base + 11] = pe[14];
         }
 
         this.uploadBones(this.skin.device);

--- a/src/scene/skin.js
+++ b/src/scene/skin.js
@@ -99,8 +99,8 @@ Object.assign(SkinInstance.prototype, {
 
         _invMatrix.copy(rootNode.getWorldTransform()).invert();
         for (var i = this.bones.length - 1; i >= 0; i--) {
-            this.matrices[i].mulTransform2(_invMatrix, this.bones[i].getWorldTransform()); // world space -> rootNode space
-            this.matrices[i].mulTransform2(this.matrices[i], this.skin.inverseBindPose[i]); // rootNode space -> bind space
+            this.matrices[i].mulAffine2(_invMatrix, this.bones[i].getWorldTransform()); // world space -> rootNode space
+            this.matrices[i].mulAffine2(this.matrices[i], this.skin.inverseBindPose[i]); // rootNode space -> bind space
         }
     },
 


### PR DESCRIPTION
Fixes #2202

Skinning / batching code on GPU now uses 4x3 matrix, instead of full 4x4 matrix.

Details:
- optimized affine transformation matrix multiplication added: Mat4.mulTransform2, used by skinning matrix array preparation. In test case of 20 characters, this resulted in this code taking 2.0ms instead of 2.7ms in Mac (more on mobile)
- skinning shader:
    - uniform based: uses 3 x Vec4 per bone instead of Mat4, allowing more bones 
    - texture based: 3 pixel per bone instead of 4. For 4 bone skinning, this means 4 texture samples less per vertex
    - both shader types: slightly more complicated math to generate transposed matrix
- morphing shader:
    - similar to skinning, but uses single bone per vertex instead of 4