### PR TITLE
Added asset file contents

### DIFF
--- a/src/asset/asset.js
+++ b/src/asset/asset.js
@@ -59,6 +59,8 @@ var VARIANT_DEFAULT_PRIORITY = ['pvr', 'dxt', 'etc2', 'etc1', 'basis'];
  * @property {string} [file.filename] The filename of the resource file
  * @property {number} [file.size] The size of the resource file
  * @property {string} [file.hash] The MD5 hash of the resource file data and the Asset data field
+ * @property {ArrayBuffer} [file.contents] Optional file contents. This is faster than wrapping the data
+ * in a (base64 encoded) blob. Currently only used by container assets.
  * @property {object} [data] Optional JSON data that contains either the complete resource data (e.g. in the case of a material) or additional data (e.g. in the case of a model it contains mappings from mesh to material)
  * @property {object} [options] - Optional JSON data that contains the asset handler options.
  * @property {object} resource A reference to the resource when the asset is loaded. e.g. a {@link pc.Texture} or a {@link pc.Model}
@@ -375,6 +377,7 @@ Object.defineProperty(Asset.prototype, 'file', {
                 this._file.hash = value.hash;
                 this._file.size = value.size;
                 this._file.variants = this.variants;
+                this._file.contents = value.contents;
 
                 if (value.hasOwnProperty('variants')) {
                     this.variants.clear();


### PR DESCRIPTION
Add the option of specifying to the asset system file contents. This is faster than encoding the data to base64 and wrapping in a blob object.

Example usage:
```javascript
// construct a container asset with file contents
var asset = new pc.Asset(filename, "container", { url: filename, contents: data });
```

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
