### PR TITLE
Moved compound and trigger update back to 1.27.4 order

### DIFF
--- a/src/framework/components/collision/component.js
+++ b/src/framework/components/collision/component.js
@@ -273,6 +273,10 @@ Object.assign(CollisionComponent.prototype, {
         if (this.entity.rigidbody) {
             if (this.entity.rigidbody.enabled) {
                 this.entity.rigidbody.enableSimulation();
+
+                if (this.data.type === 'compound') {
+                    this.system._compounds.push(this);
+                }
             }
         } else if (this._compoundParent && this !== this._compoundParent) {
             if (this._compoundParent.shape.getNumChildShapes() === 0) {
@@ -293,6 +297,11 @@ Object.assign(CollisionComponent.prototype, {
     onDisable: function () {
         if (this.entity.rigidbody) {
             this.entity.rigidbody.disableSimulation();
+
+            var idx = this.system._compounds.indexOf(this);
+            if (idx > -1) {
+                this.system._compounds.splice(idx, 1);
+            }
         } else if (this._compoundParent && this !== this._compoundParent) {
             if (! this._compoundParent.entity._destroying) {
                 this.system._removeCompoundChild(this._compoundParent, this.data.shape);

--- a/src/framework/components/collision/system.js
+++ b/src/framework/components/collision/system.js
@@ -601,8 +601,13 @@ var CollisionComponentSystem = function CollisionComponentSystem(app) {
 
     this._triMeshCache = { };
 
+    this._triggers = [];
+    this._compounds = [];
+
     this.on('beforeremove', this.onBeforeRemove, this);
     this.on('remove', this.onRemove, this);
+
+    ComponentSystem.bind('update', this.onUpdate, this);
 };
 CollisionComponentSystem.prototype = Object.create(ComponentSystem.prototype);
 CollisionComponentSystem.prototype.constructor = CollisionComponentSystem;
@@ -793,6 +798,19 @@ Object.assign(CollisionComponentSystem.prototype, {
         Ammo.destroy(origin);
 
         return transform;
+    },
+
+    onUpdate: function (dt) {
+        var i, len;
+        var compounds = this._compounds;
+        for (i = 0, len = compounds.length; i < len; i++) {
+            compounds[i]._updateCompound();
+        }
+
+        var triggers = this._triggers;
+        for (i = 0, len = triggers.length; i < len; i++) {
+            triggers[i].updateTransform();
+        }
     },
 
     destroy: function () {

--- a/src/framework/components/collision/trigger.js
+++ b/src/framework/components/collision/trigger.js
@@ -101,7 +101,7 @@ Object.assign(Trigger.prototype,  {
 
         var systems = this.app.systems;
         systems.rigidbody.addBody(body, BODYGROUP_TRIGGER, BODYMASK_NOT_STATIC ^ BODYGROUP_TRIGGER);
-        systems.rigidbody._triggers.push(this);
+        systems.collision._triggers.push(this);
 
         // set the body's activation state to active so that it is
         // simulated properly again
@@ -117,7 +117,7 @@ Object.assign(Trigger.prototype,  {
         var systems = this.app.systems;
         var idx = systems.rigidbody._triggers.indexOf(this);
         if (idx > -1) {
-            systems.rigidbody._triggers.splice(idx, 1);
+            systems.collision._triggers.splice(idx, 1);
         }
         systems.rigidbody.removeBody(body);
 

--- a/src/framework/components/rigid-body/component.js
+++ b/src/framework/components/rigid-body/component.js
@@ -273,10 +273,6 @@ Object.assign(RigidBodyComponent.prototype, {
                         break;
                 }
 
-                if (this.entity.collision.type === 'compound') {
-                    this.system._compounds.push(this.entity.collision);
-                }
-
                 body.activate();
 
                 this.data.simulationEnabled = true;
@@ -288,11 +284,6 @@ Object.assign(RigidBodyComponent.prototype, {
         var body = this.body;
         if (body && this.data.simulationEnabled) {
             var idx;
-
-            idx = this.system._compounds.indexOf(this.entity.collision);
-            if (idx > -1) {
-                this.system._compounds.splice(idx, 1);
-            }
 
             idx = this.system._dynamic.indexOf(this);
             if (idx > -1) {

--- a/src/framework/components/rigid-body/system.js
+++ b/src/framework/components/rigid-body/system.js
@@ -175,8 +175,6 @@ function RigidBodyComponentSystem(app) {
     // Arrays of pc.RigidBodyComponents filtered on body type
     this._dynamic = [];
     this._kinematic = [];
-    this._triggers = [];
-    this._compounds = [];
 
     this.on('beforeremove', this.onBeforeRemove, this);
     this.on('remove', this.onRemove, this);
@@ -740,16 +738,6 @@ Object.assign(RigidBodyComponentSystem.prototype, {
         if (gravity.x() !== this.gravity.x || gravity.y() !== this.gravity.y || gravity.z() !== this.gravity.z) {
             gravity.setValue(this.gravity.x, this.gravity.y, this.gravity.z);
             this.dynamicsWorld.setGravity(gravity);
-        }
-
-        var triggers = this._triggers;
-        for (i = 0, len = triggers.length; i < len; i++) {
-            triggers[i].updateTransform();
-        }
-
-        var compounds = this._compounds;
-        for (i = 0, len = compounds.length; i < len; i++) {
-            compounds[i]._updateCompound();
         }
 
         // Update all kinematic bodies based on their current entity transform


### PR DESCRIPTION
Fixes #2152

The order of updates of compound and trigger objects are back in the order that they were in 1.27.4

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
