### PR TITLE
ImageBitmap loader

### DIFF
--- a/src/graphics/device.js
+++ b/src/graphics/device.js
@@ -1767,10 +1767,10 @@ Object.assign(GraphicsDevice.prototype, {
     },
 
     _isBrowserBased: function (texture) {
-        return texture instanceof HTMLCanvasElement || 
-               texture instanceof HTMLImageElement ||
-               texture instanceof HTMLVideoElement ||
-               texture instanceof ImageBitmap;
+        return (typeof HTMLCanvasElement !== 'undefined' && texture instanceof HTMLCanvasElement) || 
+               (typeof HTMLImageElement !== 'undefined' && texture instanceof HTMLImageElement) ||
+               (typeof HTMLVideoElement !== 'undefined' && texture instanceof HTMLVideoElement) ||
+               (typeof ImageBitmap !== 'undefined' && texture instanceof ImageBitmap);
     },
 
     uploadTexture: function (texture) {

--- a/src/graphics/device.js
+++ b/src/graphics/device.js
@@ -1766,7 +1766,7 @@ Object.assign(GraphicsDevice.prototype, {
         }
     },
 
-    _isBrowserBased: function (texture) {
+    _isBrowserInterface: function (texture) {
         return (typeof HTMLCanvasElement !== 'undefined' && texture instanceof HTMLCanvasElement) || 
                (typeof HTMLImageElement !== 'undefined' && texture instanceof HTMLImageElement) ||
                (typeof HTMLVideoElement !== 'undefined' && texture instanceof HTMLVideoElement) ||
@@ -1809,7 +1809,7 @@ Object.assign(GraphicsDevice.prototype, {
                 // ----- CUBEMAP -----
                 var face;
 
-                if (this._isBrowserBased(mipObject[0])) {
+                if (this._isBrowserInterface(mipObject[0])) {
                     // Upload the image, canvas or video
                     for (face = 0; face < 6; face++) {
                         if (!texture._levelsUpdated[0][face])
@@ -1903,7 +1903,7 @@ Object.assign(GraphicsDevice.prototype, {
                 }
             } else {
                 // ----- 2D -----
-                if (this._isBrowserBased(mipObject)) {
+                if (this._isBrowserInterface(mipObject)) {
                     // Downsize images that are too large to be used as textures
                     if (mipObject instanceof HTMLImageElement) {
                         if (mipObject.width > this.maxTextureSize || mipObject.height > this.maxTextureSize) {

--- a/src/graphics/device.js
+++ b/src/graphics/device.js
@@ -1766,6 +1766,13 @@ Object.assign(GraphicsDevice.prototype, {
         }
     },
 
+    _isBrowserBased: function (texture) {
+        return texture instanceof HTMLCanvasElement || 
+               texture instanceof HTMLImageElement ||
+               texture instanceof HTMLVideoElement ||
+               texture instanceof ImageBitmap;
+    },
+
     uploadTexture: function (texture) {
         var gl = this.gl;
 
@@ -1802,7 +1809,7 @@ Object.assign(GraphicsDevice.prototype, {
                 // ----- CUBEMAP -----
                 var face;
 
-                if ((mipObject[0] instanceof HTMLCanvasElement) || (mipObject[0] instanceof HTMLImageElement) || (mipObject[0] instanceof HTMLVideoElement)) {
+                if (this._isBrowserBased(mipObject[0])) {
                     // Upload the image, canvas or video
                     for (face = 0; face < 6; face++) {
                         if (!texture._levelsUpdated[0][face])
@@ -1896,7 +1903,7 @@ Object.assign(GraphicsDevice.prototype, {
                 }
             } else {
                 // ----- 2D -----
-                if ((mipObject instanceof HTMLCanvasElement) || (mipObject instanceof HTMLImageElement) || (mipObject instanceof HTMLVideoElement)) {
+                if (this._isBrowserBased(mipObject)) {
                     // Downsize images that are too large to be used as textures
                     if (mipObject instanceof HTMLImageElement) {
                         if (mipObject.width > this.maxTextureSize || mipObject.height > this.maxTextureSize) {

--- a/src/graphics/texture.js
+++ b/src/graphics/texture.js
@@ -782,10 +782,7 @@ Object.assign(Texture.prototype, {
                     if (!face ||                  // face is missing
                         face.width !== width ||   // face is different width
                         face.height !== height || // face is different height
-                        !((typeof HTMLImageElement !== 'undefined' && face instanceof HTMLImageElement) ||   // not image or
-                          (typeof HTMLCanvasElement !== 'undefined' && face instanceof HTMLCanvasElement) || // canvas or
-                          (typeof HTMLVideoElement !== 'undefined' && face instanceof HTMLVideoElement) ||   // video
-                          (typeof ImageBitmap !== 'undefined' && face instanceof ImageBitmap))) {            // new image bitmap
+                        !this.device._isBrowserBased(face)) {            // new image bitmap
                         invalid = true;
                         break;
                     }
@@ -804,10 +801,7 @@ Object.assign(Texture.prototype, {
             }
         } else {
             // check if source is valid type of element
-            if (!((typeof HTMLImageElement !== 'undefined' && source instanceof HTMLImageElement) ||
-                  (typeof HTMLCanvasElement !== 'undefined' && source instanceof HTMLCanvasElement) ||
-                  (typeof HTMLVideoElement !== 'undefined' && source instanceof HTMLVideoElement) ||
-                  (typeof ImageBitmap !== 'undefined' && source instanceof ImageBitmap)))
+            if (!this.device._isBrowserBased(source))
                 invalid = true;
 
             if (!invalid) {

--- a/src/graphics/texture.js
+++ b/src/graphics/texture.js
@@ -784,7 +784,8 @@ Object.assign(Texture.prototype, {
                         face.height !== height || // face is different height
                         !((typeof HTMLImageElement !== 'undefined' && face instanceof HTMLImageElement) ||   // not image or
                           (typeof HTMLCanvasElement !== 'undefined' && face instanceof HTMLCanvasElement) || // canvas or
-                          (typeof HTMLVideoElement !== 'undefined' && face instanceof HTMLVideoElement))) {  // video
+                          (typeof HTMLVideoElement !== 'undefined' && face instanceof HTMLVideoElement) ||   // video
+                          (typeof ImageBitmap !== 'undefined' && face instanceof ImageBitmap))) {            // new image bitmap
                         invalid = true;
                         break;
                     }
@@ -805,7 +806,8 @@ Object.assign(Texture.prototype, {
             // check if source is valid type of element
             if (!((typeof HTMLImageElement !== 'undefined' && source instanceof HTMLImageElement) ||
                   (typeof HTMLCanvasElement !== 'undefined' && source instanceof HTMLCanvasElement) ||
-                  (typeof HTMLVideoElement !== 'undefined' && source instanceof HTMLVideoElement)))
+                  (typeof HTMLVideoElement !== 'undefined' && source instanceof HTMLVideoElement) ||
+                  (typeof ImageBitmap !== 'undefined' && source instanceof ImageBitmap)))
                 invalid = true;
 
             if (!invalid) {

--- a/src/graphics/texture.js
+++ b/src/graphics/texture.js
@@ -782,7 +782,7 @@ Object.assign(Texture.prototype, {
                     if (!face ||                  // face is missing
                         face.width !== width ||   // face is different width
                         face.height !== height || // face is different height
-                        !this.device._isBrowserBased(face)) {            // new image bitmap
+                        !this.device._isBrowserInterface(face)) {            // new image bitmap
                         invalid = true;
                         break;
                     }
@@ -801,7 +801,7 @@ Object.assign(Texture.prototype, {
             }
         } else {
             // check if source is valid type of element
-            if (!this.device._isBrowserBased(source))
+            if (!this.device._isBrowserInterface(source))
                 invalid = true;
 
             if (!invalid) {

--- a/src/resources/parser/texture/img.js
+++ b/src/resources/parser/texture/img.js
@@ -1,4 +1,5 @@
 import { path } from '../../../core/path.js';
+import { http } from '../../../net/http.js';
 
 import { PIXELFORMAT_R8_G8_B8, PIXELFORMAT_R8_G8_B8_A8, TEXHINT_ASSET } from '../../../graphics/graphics.js';
 import { Texture } from '../../../graphics/texture.js';
@@ -92,17 +93,26 @@ Object.assign(ImgParser.prototype, {
     },
 
     _loadImageBitmap: function (url, originalUrl, crossOrigin, callback) {
-		fetch( url ).then( function ( res ) {
-			return res.blob();
-		} ).then( function ( blob ) {
-			return createImageBitmap( blob, {
-                premultiplyAlpha: 'none'
-            } );
-		} ).then( function ( imageBitmap ) {
-			callback(null, imageBitmap);
-		} ).catch( function ( e ) {
-			callback(e);
-        } );
+        var options = {
+            cache: true,
+            responseType: "blob",
+            retry: this.retryRequests
+        };
+        pc.http.get(url, options, function (err, blob) {
+            if (err) {
+                callback(err);
+            } else {
+                createImageBitmap(blob, {
+                    premultiplyAlpha: 'none'
+                })
+                .then( function (imageBitmap) {
+                    callback(null, imageBitmap);
+                })
+                .catch( function (e) {
+                    callback(e);
+                });
+            }
+        });
     }
 });
 

--- a/src/resources/parser/texture/img.js
+++ b/src/resources/parser/texture/img.js
@@ -15,6 +15,7 @@ function ImgParser(registry, retryRequests) {
     // by default don't try cross-origin, because some browsers send different cookies (e.g. safari) if this is set.
     this.crossOrigin = registry.prefix ? 'anonymous' : null;
     this.retryRequests = !!retryRequests;
+    this.useImageBitmap = typeof ImageBitmap !== 'undefined' && /Firefox/.test( navigator.userAgent ) === false;
 }
 
 Object.assign(ImgParser.prototype, {
@@ -25,7 +26,7 @@ Object.assign(ImgParser.prototype, {
         } else if (ABSOLUTE_URL.test(url.load)) {
             crossOrigin = this.crossOrigin;
         }
-        if (typeof ImageBitmap !== 'undefined') {
+        if (this.useImageBitmap) {
             this._loadImageBitmap(url.load, url.original, crossOrigin, callback);
         } else {
             this._loadImage(url.load, url.original, crossOrigin, callback);

--- a/src/resources/parser/texture/img.js
+++ b/src/resources/parser/texture/img.js
@@ -25,7 +25,11 @@ Object.assign(ImgParser.prototype, {
         } else if (ABSOLUTE_URL.test(url.load)) {
             crossOrigin = this.crossOrigin;
         }
-        this._loadImage(url.load, url.original, crossOrigin, callback);
+        if (typeof ImageBitmap !== 'undefined') {
+            this._loadImageBitmap(url.load, url.original, crossOrigin, callback);
+        } else {
+            this._loadImage(url.load, url.original, crossOrigin, callback);
+        }
     },
 
     open: function (url, data, device) {
@@ -84,6 +88,20 @@ Object.assign(ImgParser.prototype, {
         };
 
         image.src = url;
+    },
+
+    _loadImageBitmap: function (url, originalUrl, crossOrigin, callback) {
+		fetch( url ).then( function ( res ) {
+			return res.blob();
+		} ).then( function ( blob ) {
+			return createImageBitmap( blob, {
+                premultiplyAlpha: 'none'
+            } );
+		} ).then( function ( imageBitmap ) {
+			callback(null, imageBitmap);
+		} ).catch( function ( e ) {
+			callback(e);
+        } );
     }
 });
 

--- a/src/resources/parser/texture/legacy-dds.js
+++ b/src/resources/parser/texture/legacy-dds.js
@@ -18,7 +18,7 @@ import { Texture } from '../../../graphics/texture.js';
  * @classdesc Legacy texture parser for dds files.
  */
 function LegacyDdsParser(registry, retryRequests) {
-    this.retryRequests = retryRequests;
+    this.retryRequests = !!retryRequests;
 }
 
 Object.assign(LegacyDdsParser.prototype, {


### PR DESCRIPTION
Fixes #2185

Uses ImageBitmap interface to load images in Chrome. ImageBitmap spends less time on the main thread decoding images compared to Image.

Notes/Issues:
- ImageBitmap is disabled on Firefox, which doesn't yet support the options object on construction.
- ImageBitmap interface uses promises, probably the only place in the engine right now.
- ImageBitmap takes flipY and premultipliedAlpha flags in the constructor and ignores the WebGL device state to control these.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
