### PR TITLE
Updated property documentation for pc.ModelComponent#material

### DIFF
--- a/src/framework/components/model/component.js
+++ b/src/framework/components/model/component.js
@@ -38,8 +38,7 @@ import { Component } from '../component.js';
  * @property {pc.Asset|number} asset The asset for the model (only applies to models of type 'asset') - can also be an asset id.
  * @property {boolean} castShadows If true, this model will cast shadows for lights that have shadow casting enabled.
  * @property {boolean} receiveShadows If true, shadows will be cast on this model.
- * @property {pc.Material} material The material {@link pc.Material} that will be used to render the model. Setting
- * this property will apply the material to all mesh instances of the model.
+ * @property {pc.Material} material The material {@link pc.Material} that will be used to render the model (not used on models of type 'asset').
  * @property {pc.Asset|number} materialAsset The material {@link pc.Asset} that will be used to render the model (not used on models of type 'asset').
  * @property {pc.Model} model The model that is added to the scene graph. It can be not set or loaded, so will return null.
  * @property {object} mapping A dictionary that holds material overrides for each mesh instance. Only applies to model


### PR DESCRIPTION
It doesn't apply the material to all mesh instances

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
