### PR TITLE
iOS particle velocity fix

### DIFF
--- a/src/graphics/program-lib/chunks/particle.vert
+++ b/src/graphics/program-lib/chunks/particle.vert
@@ -10,11 +10,11 @@ float saturate(float x) {
     return clamp(x, 0.0, 1.0);
 }
 
-vec4 tex1Dlod_lerp(sampler2D tex, vec2 tc) {
+vec4 tex1Dlod_lerp(highp sampler2D tex, vec2 tc) {
     return mix( texture2D(tex,tc), texture2D(tex,tc + graphSampleSize), fract(tc.x*graphNumSamples) );
 }
 
-vec4 tex1Dlod_lerp(sampler2D tex, vec2 tc, out vec3 w) {
+vec4 tex1Dlod_lerp(highp sampler2D tex, vec2 tc, out vec3 w) {
     vec4 a = texture2D(tex,tc);
     vec4 b = texture2D(tex,tc + graphSampleSize);
     float c = fract(tc.x*graphNumSamples);

--- a/src/graphics/program-lib/chunks/particleUpdaterStart.frag
+++ b/src/graphics/program-lib/chunks/particleUpdaterStart.frag
@@ -9,7 +9,7 @@ vec3 unpack3NFloats(float src) {
     return vec3(r, g, b);
 }
 
-vec3 tex1Dlod_lerp(sampler2D tex, vec2 tc, out vec3 w) {
+vec3 tex1Dlod_lerp(highp sampler2D tex, vec2 tc, out vec3 w) {
     vec4 a = texture2D(tex, tc);
     vec4 b = texture2D(tex, tc + graphSampleSize);
     float c = fract(tc.x * graphNumSamples);


### PR DESCRIPTION
The particle systems velocity curves are packed into 1D textures that are then unpacked by the tex1Dlod_lerp function. The sampling of these curves are imprecise on iOS currently. Setting the precision of the texture sampler to high looks to resolve this issue.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
