### PR TITLE
disable imagebitmap

### DIFF
--- a/src/resources/parser/texture/img.js
+++ b/src/resources/parser/texture/img.js
@@ -16,7 +16,8 @@ function ImgParser(registry, retryRequests) {
     // by default don't try cross-origin, because some browsers send different cookies (e.g. safari) if this is set.
     this.crossOrigin = registry.prefix ? 'anonymous' : null;
     this.retryRequests = !!retryRequests;
-    this.useImageBitmap = typeof ImageBitmap !== 'undefined' && /Firefox/.test( navigator.userAgent ) === false;
+    // temporarily disable image bitmap till cubemaps are correctly dealt with.
+    this.useImageBitmap = false;// typeof ImageBitmap !== 'undefined' && /Firefox/.test( navigator.userAgent ) === false;
 }
 
 Object.assign(ImgParser.prototype, {


### PR DESCRIPTION
Cubemap faces are not correctly unflipped under imageBitmap, so disable for now.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
