### PR TITLE
Add support for OES_vertex_array_object

### DIFF
--- a/examples/graphics/hierarchy.html
+++ b/examples/graphics/hierarchy.html
@@ -70,8 +70,9 @@
                 var offset = spacing * (gridSize - 1) * 0.5;
                 for (var x = 0; x < gridSize; x++) {
                     for (var y = 0; y < gridSize; y++) {
+                        var shape = Math.random() < 0.5 ? "box" : "sphere";
                         var position = new pc.Vec3(x * spacing - offset, spacing, y * spacing - offset);
-                        var entity = createPrimitive("box", position, new pc.Vec3(scale, scale, scale));
+                        var entity = createPrimitive(shape, position, new pc.Vec3(scale, scale, scale));
 
                         parent.addChild(entity);
                         entities.push(entity);

--- a/src/graphics/device.js
+++ b/src/graphics/device.js
@@ -2210,8 +2210,7 @@ Object.assign(GraphicsDevice.prototype, {
                 vertexBuffer._vao = this.createVertexArray(this.vertexBuffers);
             }
             vao = vertexBuffer._vao;
-        }
-        else {
+        } else {
             // obtain temporary VAO for multiple vertex buffers
             vao = this.createVertexArray(this.vertexBuffers);
         }

--- a/src/graphics/device.js
+++ b/src/graphics/device.js
@@ -1,3 +1,4 @@
+import '../polyfill/OESVertexArrayObject.js';
 import { EventHandler } from '../core/event-handler.js';
 import { now } from '../core/time.js';
 
@@ -25,7 +26,8 @@ import {
     UNIFORMTYPE_VEC4, UNIFORMTYPE_IVEC2, UNIFORMTYPE_IVEC3, UNIFORMTYPE_IVEC4, UNIFORMTYPE_BVEC2,
     UNIFORMTYPE_BVEC3, UNIFORMTYPE_BVEC4, UNIFORMTYPE_MAT2, UNIFORMTYPE_MAT3, UNIFORMTYPE_MAT4,
     UNIFORMTYPE_TEXTURE2D, UNIFORMTYPE_TEXTURECUBE, UNIFORMTYPE_FLOATARRAY, UNIFORMTYPE_TEXTURE2D_SHADOW,
-    UNIFORMTYPE_TEXTURECUBE_SHADOW, UNIFORMTYPE_TEXTURE3D, UNIFORMTYPE_VEC2ARRAY, UNIFORMTYPE_VEC3ARRAY, UNIFORMTYPE_VEC4ARRAY
+    UNIFORMTYPE_TEXTURECUBE_SHADOW, UNIFORMTYPE_TEXTURE3D, UNIFORMTYPE_VEC2ARRAY, UNIFORMTYPE_VEC3ARRAY, UNIFORMTYPE_VEC4ARRAY,
+    semanticToLocation
 } from './graphics.js';
 
 import { drawQuadWithShader } from './simple-post-effect.js';
@@ -248,15 +250,11 @@ var GraphicsDevice = function (canvas, options) {
     this.shader = null;
     this.indexBuffer = null;
     this.vertexBuffers = [];
-    this.vbOffsets = [];
     this._enableAutoInstancing = false;
     this.autoInstancingMaxObjects = 16384;
-    this.attributesInvalidated = true;
     this.defaultFramebuffer = null;
-    this.boundBuffer = null;
+    this.boundVao = null;
     this.boundElementBuffer = null;
-    this.instancedAttribs = { };
-    this.enabledAttributes = { };
     this.transformFeedbackBuffer = null;
     this.activeFramebuffer = null;
     this.textureUnit = 0;
@@ -284,6 +282,9 @@ var GraphicsDevice = function (canvas, options) {
     this.textures = [];
     this.targets = [];
 
+    // cache of VAOs
+    this._vaoMap = new Map();
+
     // Add handlers for when the WebGL context is lost or restored
     this.contextLost = false;
 
@@ -304,9 +305,6 @@ var GraphicsDevice = function (canvas, options) {
         this.contextLost = false;
         this.fire('devicerestored');
     }.bind(this);
-
-    canvas.addEventListener("webglcontextlost", this._contextLostHandler, false);
-    canvas.addEventListener("webglcontextrestored", this._contextRestoredHandler, false);
 
     // Retrieve the WebGL context
     var preferWebGl2 = (options && options.preferWebGl2 !== undefined) ? options.preferWebGl2 : true;
@@ -332,6 +330,12 @@ var GraphicsDevice = function (canvas, options) {
     }
 
     this.gl = gl;
+
+    // init polyfill for VAOs
+    setupVertexArrayObject(gl);
+
+    canvas.addEventListener("webglcontextlost", this._contextLostHandler, false);
+    canvas.addEventListener("webglcontextrestored", this._contextRestoredHandler, false);
 
     this.initializeExtensions();
     this.initializeCapabilities();
@@ -985,11 +989,9 @@ Object.assign(GraphicsDevice.prototype, {
             this.buffers[i].bufferId = undefined;
             this.buffers[i].unlock();
         }
-        this.boundBuffer = null;
+        this.boundVao = null;
         this.boundElementBuffer = null;
         this.indexBuffer = null;
-        this.attributesInvalidated = true;
-        this.enabledAttributes = {};
         this.vertexBuffers = [];
 
         // Force all textures to be recreated and reuploaded
@@ -1437,7 +1439,7 @@ Object.assign(GraphicsDevice.prototype, {
      * and pc.GraphicsDevice#updateEnd must not be nested.
      */
     updateBegin: function () {
-        this.boundBuffer = null;
+        this.boundVao = null;
         this.boundElementBuffer = null;
 
         // clear texture units once a frame on desktop safari
@@ -2129,69 +2131,99 @@ Object.assign(GraphicsDevice.prototype, {
         }
     },
 
-    setBuffers: function (numInstances) {
-        var gl = this.gl;
-        var attribute, element, vertexBuffer, vbOffset, bufferId, locationId;
-        var attributes = this.shader.attributes;
+    // function creates VertexArrayObject from list of vertex buffers
+    createVertexArray: function (vertexBuffers) {
 
-        // Commit the vertex buffer inputs
-        if (this.attributesInvalidated) {
-            for (var i = 0, len = attributes.length; i < len; i++) {
-                attribute = attributes[i];
+        var i, vertexBuffer, key;
+        var vao;
 
-                // Retrieve vertex element for this shader attribute
-                element = attribute.scopeId.value;
+        // only use cache when more than 1 vertex buffer, otherwise it's unique
+        var useCache = vertexBuffers.length > 1;
+        if (useCache) {
 
-                // Check the vertex element is valid
-                if (element !== null) {
-                    // Retrieve the vertex buffer that contains this element
-                    vertexBuffer = this.vertexBuffers[element.stream];
-                    if (vertexBuffer) {
-                        vbOffset = this.vbOffsets[element.stream] || 0;
+            // generate unique key for the vertex buffers
+            key = "";
+            for (i = 0; i < vertexBuffers.length; i++) {
+                vertexBuffer = vertexBuffers[i];
+                key += vertexBuffer.id + vertexBuffer.format.renderingingHash;
+            }
 
-                        // Set the active vertex buffer object
-                        bufferId = vertexBuffer.bufferId;
-                        if (this.boundBuffer !== bufferId) {
-                            gl.bindBuffer(gl.ARRAY_BUFFER, bufferId);
-                            this.boundBuffer = bufferId;
-                        }
+            // try to get VAO from cache
+            vao = this._vaoMap.get(key);
+        }
 
-                        // Hook the vertex buffer to the shader program
-                        locationId = attribute.locationId;
-                        if (!this.enabledAttributes[locationId]) {
-                            gl.enableVertexAttribArray(locationId);
-                            this.enabledAttributes[locationId] = true;
-                        }
-                        gl.vertexAttribPointer(
-                            locationId,
-                            element.numComponents,
-                            this.glType[element.dataType],
-                            element.normalize,
-                            element.stride,
-                            element.offset + vbOffset
-                        );
+        // need to create new vao
+        if (!vao) {
 
-                        if (element.stream === 1 && numInstances > 0) {
-                            if (!this.instancedAttribs[locationId]) {
-                                gl.vertexAttribDivisor(locationId, 1);
-                                this.instancedAttribs[locationId] = true;
-                            }
-                        } else if (this.instancedAttribs[locationId]) {
-                            gl.vertexAttribDivisor(locationId, 0);
-                            this.instancedAttribs[locationId] = false;
-                        }
-                    }
-                } else {
-                    // disable the attribute (shader will get default value 0, 0, 0, 1)
-                    if (this.enabledAttributes[attribute.locationId]) {
-                        gl.disableVertexAttribArray(attribute.locationId);
-                        this.enabledAttributes[attribute.locationId] = false;
+            // create VA object
+            var gl = this.gl;
+            vao = gl.createVertexArray();
+            gl.bindVertexArray(vao);
+
+            var e, elements;
+            for (i = 0; i < vertexBuffers.length; i++) {
+
+                // bind buffer
+                vertexBuffer = vertexBuffers[i];
+                gl.bindBuffer(gl.ARRAY_BUFFER, vertexBuffer.bufferId);
+
+                // for each attribute
+                elements = vertexBuffer.format.elements;
+                for (var j = 0; j < elements.length; j++) {
+                    e = elements[j];
+                    var loc = semanticToLocation[e.name];
+
+                    gl.vertexAttribPointer(loc, e.numComponents, this.glType[e.dataType], e.normalize, e.stride, e.offset);
+                    gl.enableVertexAttribArray(loc);
+
+                    if (vertexBuffer.instancing) {
+                        gl.vertexAttribDivisor(loc, 1);
                     }
                 }
             }
 
-            this.attributesInvalidated = false;
+            // end of VA object
+            gl.bindVertexArray(null);
+
+            // unbind any array buffer
+            gl.bindBuffer(gl.ARRAY_BUFFER, null);
+
+            // add it to cache
+            if (useCache) {
+                this._vaoMap.set(key, vao);
+            }
         }
+
+        return vao;
+    },
+
+    setBuffers: function () {
+        var gl = this.gl;
+        var vertexBuffer, bufferId, vao;
+
+        // create VAO for specified vertex buffers
+        if (this.vertexBuffers.length === 1) {
+
+            // single VB keeps its VAO
+            vertexBuffer = this.vertexBuffers[0];
+            if (!vertexBuffer._vao) {
+                vertexBuffer._vao = this.createVertexArray(this.vertexBuffers);
+            }
+            vao = vertexBuffer._vao;
+        }
+        else {
+            // obtain temporary VAO for multiple vertex buffers
+            vao = this.createVertexArray(this.vertexBuffers);
+        }
+
+        // set active VAO
+        if (this.boundVao !== vao) {
+            this.boundVao = vao;
+            gl.bindVertexArray(vao);
+        }
+
+        // empty array of vertex buffers
+        this.vertexBuffers.length = 0;
 
         // Set the active index buffer object
         bufferId = this.indexBuffer ? this.indexBuffer.bufferId : null;
@@ -2237,12 +2269,8 @@ Object.assign(GraphicsDevice.prototype, {
         var samplers = shader.samplers;
         var uniforms = shader.uniforms;
 
-        if (numInstances > 0) {
-            this.boundBuffer = null;
-            this.attributesInvalidated = true;
-        }
-
-        this.setBuffers(numInstances);
+        // vertex buffers
+        this.setBuffers();
 
         // Commit the shader program variables
         var textureUnit = 0;
@@ -3054,47 +3082,14 @@ Object.assign(GraphicsDevice.prototype, {
     /**
      * @function
      * @name pc.GraphicsDevice#setVertexBuffer
-     * @description Sets the current vertex buffer for a specific stream index on the graphics
-     * device. On subsequent calls to pc.GraphicsDevice#draw, the specified vertex buffer will be
-     * used to provide vertex data for any primitives.
+     * @description Sets the current vertex buffer on the graphics device. On subsequent calls to
+     * {@link pc.GraphicsDevice#draw}, the specified vertex buffer(s) will be used to provide vertex data for any primitives.
      * @param {pc.VertexBuffer} vertexBuffer - The vertex buffer to assign to the device.
-     * @param {number} stream - The stream index for the vertex buffer, indexed from 0 upwards.
-     * @param {number} [vbOffset=0] - The byte offset into the vertex buffer data. Defaults to 0.
      */
-    setVertexBuffer: function (vertexBuffer, stream, vbOffset) {
-        if (this.vertexBuffers[stream] !== vertexBuffer || this.vbOffsets[stream] !== vbOffset) {
-            // Store the vertex buffer for this stream index
-            this.vertexBuffers[stream] = vertexBuffer;
-            this.vbOffsets[stream] = vbOffset;
+    setVertexBuffer: function (vertexBuffer) {
 
-            // Push each vertex element in scope
-            if (vertexBuffer) {
-                var vertexFormat = vertexBuffer.getFormat();
-                var i = 0;
-                var elements = vertexFormat.elements;
-                var numElements = elements.length;
-                while (i < numElements) {
-                    var vertexElement = elements[i++];
-                    vertexElement.stream = stream;
-                    vertexElement.scopeId.setValue(vertexElement);
-                }
-            }
-
-            this.attributesInvalidated = true;
-        }
-    },
-
-    // Function to disable vertex elements coming from vertex buffer and using constant default value instead (0,0,0,1)
-    // this is similar to setVertexBuffer with null vertex buffer, where access to vertexFormat is replaced by providing list of element semantics
-    disableVertexBufferElements: function (elementNames) {
-
-        for (var i = 0; i < elementNames.length; i++) {
-            // Resolve the ScopeId for the attribute name
-            var scopeId = this.scope.resolve(elementNames[i]);
-            if (scopeId.value) {
-                this.attributesInvalidated = true;
-                scopeId.setValue(null);
-            }
+        if (vertexBuffer) {
+            this.vertexBuffers.push(vertexBuffer);
         }
     },
 
@@ -3146,6 +3141,7 @@ Object.assign(GraphicsDevice.prototype, {
         var gl = this.gl;
 
         var definition = shader.definition;
+        var attr, attrs = definition.attributes;
         var glVertexShader = this.compileShaderSource(definition.vshader, true);
         var glFragmentShader = this.compileShaderSource(definition.fshader, false);
 
@@ -3156,14 +3152,31 @@ Object.assign(GraphicsDevice.prototype, {
 
         if (this.webgl2 && definition.useTransformFeedback) {
             // Collect all "out_" attributes and use them for output
-            var attrs = definition.attributes;
             var outNames = [];
-            for (var attr in attrs) {
+            for (attr in attrs) {
                 if (attrs.hasOwnProperty(attr)) {
                     outNames.push("out_" + attr);
                 }
             }
             gl.transformFeedbackVaryings(glProgram, outNames, gl.INTERLEAVED_ATTRIBS);
+        }
+
+        // map all vertex input attributes to fixed locations
+        var locations = {};
+        for (attr in attrs) {
+            if (attrs.hasOwnProperty(attr)) {
+                var semantic = attrs[attr];
+                var loc = semanticToLocation[semantic];
+
+                if (locations.hasOwnProperty(loc)) {
+                    // #ifdef DEBUG
+                    console.warn("WARNING: Two attribues are mapped to the same location in a shader: " + locations[loc] + " and " + attr);
+                    // #endif
+                }
+
+                locations[loc] = attr;
+                gl.bindAttribLocation(glProgram, loc, attr);
+            }
         }
 
         gl.linkProgram(glProgram);
@@ -3414,6 +3427,21 @@ Object.assign(GraphicsDevice.prototype, {
         this.programLib.clearCache();
     },
 
+    /**
+     * @function
+     * @name pc.GraphicsDevice#clearVertexArrayObjectCache
+     * @description Frees memory from all vertex array objects ever allocated with this device.
+     */
+    clearVertexArrayObjectCache: function () {
+
+        var gl = this.gl;
+        this._vaoMap.forEach(function (item, key, mapObj) {
+            gl.deleteVertexArray(item);
+        });
+
+        this._vaoMap.clear();
+    },
+
     removeShaderFromCache: function (shader) {
         this.programLib.removeFromCache(shader);
     },
@@ -3428,6 +3456,7 @@ Object.assign(GraphicsDevice.prototype, {
         }
 
         this.clearShaderCache();
+        this.clearVertexArrayObjectCache();
 
         this.canvas.removeEventListener('webglcontextlost', this._contextLostHandler, false);
         this.canvas.removeEventListener('webglcontextrestored', this._contextRestoredHandler, false);

--- a/src/graphics/graphics.js
+++ b/src/graphics/graphics.js
@@ -1093,3 +1093,39 @@ export var typedArrayToType = {
 // map of engine pc.INDEXFORMAT_*** to their corresponding typed array constructors and byte sizes
 export var typedArrayIndexFormats = [Uint8Array, Uint16Array, Uint32Array];
 export var typedArrayIndexFormatsByteSize = [1, 2, 4];
+
+// map of engine semantics into location on device in range 0..15 (note - semantics mapping to
+// the same location cannot be used at the same time)
+// organized in a way that ATTR0-ATTR7 do not overlap with common important semantics
+export var semanticToLocation = {};
+semanticToLocation[SEMANTIC_POSITION] = 0;
+semanticToLocation[SEMANTIC_NORMAL] = 1;
+semanticToLocation[SEMANTIC_BLENDWEIGHT] = 2;
+semanticToLocation[SEMANTIC_BLENDINDICES] = 3;
+semanticToLocation[SEMANTIC_COLOR] = 4;
+semanticToLocation[SEMANTIC_TEXCOORD0] = 5;
+semanticToLocation[SEMANTIC_TEXCOORD1] = 6;
+semanticToLocation[SEMANTIC_TEXCOORD2] = 7;
+semanticToLocation[SEMANTIC_TEXCOORD3] = 8;
+semanticToLocation[SEMANTIC_TEXCOORD4] = 9;
+semanticToLocation[SEMANTIC_TEXCOORD5] = 10;
+semanticToLocation[SEMANTIC_TEXCOORD6] = 11;
+semanticToLocation[SEMANTIC_TEXCOORD7] = 12;
+semanticToLocation[SEMANTIC_TANGENT] = 13;
+
+semanticToLocation[SEMANTIC_ATTR0] = 15;
+semanticToLocation[SEMANTIC_ATTR1] = 14;
+semanticToLocation[SEMANTIC_ATTR2] = 13;
+semanticToLocation[SEMANTIC_ATTR3] = 12;
+semanticToLocation[SEMANTIC_ATTR4] = 11;
+semanticToLocation[SEMANTIC_ATTR5] = 10;
+semanticToLocation[SEMANTIC_ATTR6] = 9;
+semanticToLocation[SEMANTIC_ATTR7] = 8;
+semanticToLocation[SEMANTIC_ATTR8] = 7;
+semanticToLocation[SEMANTIC_ATTR9] = 6;
+semanticToLocation[SEMANTIC_ATTR10] = 5;
+semanticToLocation[SEMANTIC_ATTR11] = 4;
+semanticToLocation[SEMANTIC_ATTR12] = 3;
+semanticToLocation[SEMANTIC_ATTR13] = 2;
+semanticToLocation[SEMANTIC_ATTR14] = 1;
+semanticToLocation[SEMANTIC_ATTR15] = 0;

--- a/src/graphics/vertex-buffer.js
+++ b/src/graphics/vertex-buffer.js
@@ -1,5 +1,7 @@
 import { BUFFER_DYNAMIC, BUFFER_GPUDYNAMIC, BUFFER_STATIC, BUFFER_STREAM } from './graphics.js';
 
+var id = 0;
+
 /**
  * @class
  * @name pc.VertexBuffer
@@ -17,6 +19,7 @@ function VertexBuffer(graphicsDevice, format, numVertices, usage, initialData) {
     this.usage = usage || BUFFER_STATIC;
     this.format = format;
     this.numVertices = numVertices;
+    this.id = id++;
 
     // Calculate the size. If format contains verticesByteSize (non-interleaved format), use it
     this.numBytes = format.verticesByteSize ? format.verticesByteSize : format.size * numVertices;
@@ -49,20 +52,16 @@ Object.assign(VertexBuffer.prototype, {
         }
 
         if (this.bufferId) {
+
+            // clear up bound vertex buffers
             var gl = device.gl;
+            device.boundVao = null;
+            gl.bindVertexArray(null);
+
+            // delete buffer
             gl.deleteBuffer(this.bufferId);
             device._vram.vb -= this.storage.byteLength;
             this.bufferId = null;
-
-            // If this buffer was bound, must clean up attribute-buffer bindings to prevent GL errors
-            device.boundBuffer = null;
-            device.vertexBuffers.length = 0;
-            device.vbOffsets.length = 0;
-            device.attributesInvalidated = true;
-            for (var loc in device.enabledAttributes) {
-                gl.disableVertexAttribArray(Number(loc));
-            }
-            device.enabledAttributes = {};
         }
     },
 

--- a/src/graphics/vertex-format.js
+++ b/src/graphics/vertex-format.js
@@ -91,7 +91,6 @@ import {
  * unchanged. If this property is unspecified, false is assumed.
  * @property {number} elements[].offset The number of initial bytes at the start of a vertex that are not relevant to this attribute.
  * @property {number} elements[].stride The number of total bytes that are between the start of one vertex, and the start of the next.
- * @property {pc.ScopeId} elements[].scopeId The shader input variable corresponding to the attribute.
  * @property {number} elements[].size The size of the attribute in bytes.
  * @example
  * // Specify 3-component positions (x, y, z)
@@ -145,8 +144,6 @@ function VertexFormat(graphicsDevice, description, vertexCount) {
             name: elementDesc.semantic,
             offset: (vertexCount ? offset : (elementDesc.hasOwnProperty('offset') ? elementDesc.offset : offset)),
             stride: (vertexCount ? elementSize : (elementDesc.hasOwnProperty('stride') ? elementDesc.stride : this.size)),
-            stream: -1,
-            scopeId: graphicsDevice.scope.resolve(elementDesc.semantic),
             dataType: elementDesc.type,
             numComponents: elementDesc.components,
             normalize: (elementDesc.normalize === undefined) ? false : elementDesc.normalize,
@@ -175,7 +172,7 @@ function VertexFormat(graphicsDevice, description, vertexCount) {
         this.verticesByteSize = offset;
     }
 
-    this.batchingHash = this._evaluateBatchingHash();
+    this.update();
 }
 
 VertexFormat.init = function (graphicsDevice) {
@@ -207,27 +204,45 @@ Object.defineProperty(VertexFormat, 'defaultInstancingFormat', {
 
 Object.assign(VertexFormat.prototype, {
 
-    // evaluates hash value for the format allowing fast compare of batching compatibility
-    _evaluateBatchingHash: function () {
+    /**
+     * @function
+     * @name pc.VertexFormat#update
+     * @description Applies any changes made to the VertexFormat's properties.
+     */
+    update: function () {
+        this._evaluateHash();
+    },
 
-        // create string description of each element that is relevant for batching
-        var stringElement, stringElements = [];
+    // evaluates hash valuees for the format allowing fast compare of batching / rendering compatibility
+    _evaluateHash: function () {
+
+        var stringElementBatch, stringElementsBatch = [];
+        var stringElementRender, stringElementsRender = [];
         var i, len = this.elements.length, element;
         for (i = 0; i < len; i++) {
             element = this.elements[i];
 
-            stringElement = element.name;
-            stringElement += element.dataType;
-            stringElement += element.numComponents;
-            stringElement += element.normalize;
+            // create string description of each element that is relevant for batching
+            stringElementBatch = element.name;
+            stringElementBatch += element.dataType;
+            stringElementBatch += element.numComponents;
+            stringElementBatch += element.normalize;
+            stringElementsBatch.push(stringElementBatch);
 
-            stringElements.push(stringElement);
+            // create string description of each element that is relevant for rendering
+            stringElementRender = stringElementBatch;
+            stringElementRender += element.offset;
+            stringElementRender += element.stride;
+            stringElementRender += element.size;
+            stringElementsRender.push(stringElementRender);
         }
 
-        // sort them alphabetically to make hash order independent
-        stringElements.sort();
+        // sort batching ones them alphabetically to make hash order independent
+        stringElementsBatch.sort();
+        this.batchingHash = hashCode(stringElementsBatch.join());
 
-        return hashCode(stringElements.join());
+        // rendering hash
+        this.renderingingHash = hashCode(stringElementsRender.join());
     }
 });
 

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ import './polyfill/object-assign.js';
 import './polyfill/pointer-lock.js';
 import './polyfill/request-animation-frame.js';
 import './polyfill/string.js';
+import './polyfill/OESVertexArrayObject.js';
 
 // CORE
 export { apps, common, config, data, extend, isDefined, makeArray, revision, type, version } from './core/core.js';

--- a/src/polyfill/OESVertexArrayObject.js
+++ b/src/polyfill/OESVertexArrayObject.js
@@ -1,0 +1,321 @@
+// https://github.com/KhronosGroup/WebGL/blob/master/sdk/demos/google/resources/OESVertexArrayObject.js
+
+(function() {
+"use strict";
+
+var glErrorShadow = { };
+
+function error(msg) {
+    if (window.console && window.console.error) {
+        window.console.error(msg);
+    }
+}
+
+function log(msg) {
+    if (window.console && window.console.log) {
+        window.console.log(msg);
+    }
+}
+
+function synthesizeGLError(err, opt_msg) {
+    glErrorShadow[err] = true;
+    if (opt_msg !== undefined) {
+        error(opt_msg)
+    }
+}
+
+function wrapGLError(gl) {
+    var f = gl.getError;
+    gl.getError = function() {
+        var err;
+        do {
+            err = f.apply(gl);
+            if (err != gl.NO_ERROR) {
+                glErrorShadow[err] = true;
+            }
+        } while (err != gl.NO_ERROR);
+        for (var err in glErrorShadow) {
+            if (glErrorShadow[err]) {
+                delete glErrorShadow[err];
+                return parseInt(err);
+            }
+        }
+        return gl.NO_ERROR;
+    };
+}
+
+var WebGLVertexArrayObjectOES = function WebGLVertexArrayObjectOES(ext) {
+    var gl = ext.gl;
+    
+    this.ext = ext;
+    this.isAlive = true;
+    this.hasBeenBound = false;
+    
+    this.elementArrayBuffer = null;
+    this.attribs = new Array(ext.maxVertexAttribs);
+    for (var n = 0; n < this.attribs.length; n++) {
+        var attrib = new WebGLVertexArrayObjectOES.VertexAttrib(gl);
+        this.attribs[n] = attrib;
+    }
+    
+    this.maxAttrib = 0;
+};
+
+WebGLVertexArrayObjectOES.VertexAttrib = function VertexAttrib(gl) {
+    this.enabled = false;
+    this.buffer = null;
+    this.size = 4;
+    this.type = gl.FLOAT;
+    this.normalized = false;
+    this.stride = 16;
+    this.offset = 0;
+    
+    this.cached = "";
+    this.recache();
+};
+WebGLVertexArrayObjectOES.VertexAttrib.prototype.recache = function recache() {
+    this.cached = [this.size, this.type, this.normalized, this.stride, this.offset].join(":");
+};
+
+var OESVertexArrayObject = function OESVertexArrayObject(gl) {
+    var self = this;
+    this.gl = gl;
+
+    wrapGLError(gl);
+    
+    var original = this.original = {
+        getParameter: gl.getParameter,
+        enableVertexAttribArray: gl.enableVertexAttribArray,
+        disableVertexAttribArray: gl.disableVertexAttribArray,
+        bindBuffer: gl.bindBuffer,
+        getVertexAttrib: gl.getVertexAttrib,
+        vertexAttribPointer: gl.vertexAttribPointer
+    };
+    
+    gl.getParameter = function getParameter(pname) {
+        if (pname == self.VERTEX_ARRAY_BINDING_OES) {
+            if (self.currentVertexArrayObject == self.defaultVertexArrayObject) {
+                return null;
+            } else {
+                return self.currentVertexArrayObject;
+            }
+        }
+        return original.getParameter.apply(this, arguments);
+    };
+    
+    gl.enableVertexAttribArray = function enableVertexAttribArray(index) {
+        var vao = self.currentVertexArrayObject;
+        vao.maxAttrib = Math.max(vao.maxAttrib, index);
+        var attrib = vao.attribs[index];
+        attrib.enabled = true;
+        return original.enableVertexAttribArray.apply(this, arguments);
+    };
+    gl.disableVertexAttribArray = function disableVertexAttribArray(index) {
+        var vao = self.currentVertexArrayObject;
+        vao.maxAttrib = Math.max(vao.maxAttrib, index);
+        var attrib = vao.attribs[index];
+        attrib.enabled = false;
+        return original.disableVertexAttribArray.apply(this, arguments);
+    };
+    
+    gl.bindBuffer = function bindBuffer(target, buffer) {
+        switch (target) {
+            case gl.ARRAY_BUFFER:
+                self.currentArrayBuffer = buffer;
+                break;
+            case gl.ELEMENT_ARRAY_BUFFER:
+                self.currentVertexArrayObject.elementArrayBuffer = buffer;
+                break;
+        }
+        return original.bindBuffer.apply(this, arguments);
+    };
+    
+    gl.getVertexAttrib = function getVertexAttrib(index, pname) {
+        var vao = self.currentVertexArrayObject;
+        var attrib = vao.attribs[index];
+        switch (pname) {
+            case gl.VERTEX_ATTRIB_ARRAY_BUFFER_BINDING:
+                return attrib.buffer;
+            case gl.VERTEX_ATTRIB_ARRAY_ENABLED:
+                return attrib.enabled;
+            case gl.VERTEX_ATTRIB_ARRAY_SIZE:
+                return attrib.size;
+            case gl.VERTEX_ATTRIB_ARRAY_STRIDE:
+                return attrib.stride;
+            case gl.VERTEX_ATTRIB_ARRAY_TYPE:
+                return attrib.type;
+            case gl.VERTEX_ATTRIB_ARRAY_NORMALIZED:
+                return attrib.normalized;
+            default:
+                return original.getVertexAttrib.apply(this, arguments);
+        }
+    };
+    
+    gl.vertexAttribPointer = function vertexAttribPointer(indx, size, type, normalized, stride, offset) {
+        var vao = self.currentVertexArrayObject;
+        vao.maxAttrib = Math.max(vao.maxAttrib, indx);
+        var attrib = vao.attribs[indx];
+        attrib.buffer = self.currentArrayBuffer;
+        attrib.size = size;
+        attrib.type = type;
+        attrib.normalized = normalized;
+        attrib.stride = stride;
+        attrib.offset = offset;
+        attrib.recache();
+        return original.vertexAttribPointer.apply(this, arguments);
+    };
+    
+    if (gl.instrumentExtension) {
+        gl.instrumentExtension(this, "OES_vertex_array_object");
+    }
+
+    gl.canvas.addEventListener('webglcontextrestored', function() {
+        log("OESVertexArrayObject emulation library context restored");
+        self.reset_();
+    }, true);
+
+    this.reset_();
+};
+
+OESVertexArrayObject.prototype.VERTEX_ARRAY_BINDING_OES = 0x85B5;
+
+OESVertexArrayObject.prototype.reset_ = function reset_() {
+    var contextWasLost = this.vertexArrayObjects !== undefined;
+    if (contextWasLost) {
+        for (var ii = 0; ii < this.vertexArrayObjects.length; ++ii) {
+            this.vertexArrayObjects.isAlive = false;
+        }
+    }
+    var gl = this.gl;
+    this.maxVertexAttribs = gl.getParameter(gl.MAX_VERTEX_ATTRIBS);
+
+    this.defaultVertexArrayObject = new WebGLVertexArrayObjectOES(this);
+    this.currentVertexArrayObject = null;
+    this.currentArrayBuffer = null;
+    this.vertexArrayObjects = [this.defaultVertexArrayObject];
+    
+    this.bindVertexArrayOES(null);
+};
+
+OESVertexArrayObject.prototype.createVertexArrayOES = function createVertexArrayOES() {
+    var arrayObject = new WebGLVertexArrayObjectOES(this);
+    this.vertexArrayObjects.push(arrayObject);
+    return arrayObject;
+};
+
+OESVertexArrayObject.prototype.deleteVertexArrayOES = function deleteVertexArrayOES(arrayObject) {
+    arrayObject.isAlive = false;
+    this.vertexArrayObjects.splice(this.vertexArrayObjects.indexOf(arrayObject), 1);
+    if (this.currentVertexArrayObject == arrayObject) {
+        this.bindVertexArrayOES(null);
+    }
+};
+
+OESVertexArrayObject.prototype.isVertexArrayOES = function isVertexArrayOES(arrayObject) {
+    if (arrayObject && arrayObject instanceof WebGLVertexArrayObjectOES) {
+        if (arrayObject.hasBeenBound && arrayObject.ext == this) {
+            return true;
+        }
+    }
+    return false;
+};
+
+OESVertexArrayObject.prototype.bindVertexArrayOES = function bindVertexArrayOES(arrayObject) {
+    var gl = this.gl;
+    if (arrayObject && !arrayObject.isAlive) {
+        synthesizeGLError(gl.INVALID_OPERATION, "bindVertexArrayOES: attempt to bind deleted arrayObject");
+        return;
+    }
+    var original = this.original;
+
+    var oldVAO = this.currentVertexArrayObject;
+    this.currentVertexArrayObject = arrayObject || this.defaultVertexArrayObject;
+    this.currentVertexArrayObject.hasBeenBound = true;
+    var newVAO = this.currentVertexArrayObject;
+    
+    if (oldVAO == newVAO) {
+        return;
+    }
+    
+    if (!oldVAO || newVAO.elementArrayBuffer != oldVAO.elementArrayBuffer) {
+        original.bindBuffer.call(gl, gl.ELEMENT_ARRAY_BUFFER, newVAO.elementArrayBuffer);
+    }
+    
+    var currentBinding = this.currentArrayBuffer;
+    var maxAttrib = Math.max(oldVAO ? oldVAO.maxAttrib : 0, newVAO.maxAttrib);
+    for (var n = 0; n <= maxAttrib; n++) {
+        var attrib = newVAO.attribs[n];
+        var oldAttrib = oldVAO ? oldVAO.attribs[n] : null;
+        
+        if (!oldVAO || attrib.enabled != oldAttrib.enabled) {
+            if (attrib.enabled) {
+                original.enableVertexAttribArray.call(gl, n);
+            } else {
+                original.disableVertexAttribArray.call(gl, n);
+            }
+        }
+        
+        if (attrib.enabled) {
+            var bufferChanged = false;
+            if (!oldVAO || attrib.buffer != oldAttrib.buffer) {
+                if (currentBinding != attrib.buffer) {
+                    original.bindBuffer.call(gl, gl.ARRAY_BUFFER, attrib.buffer);
+                    currentBinding = attrib.buffer;
+                }
+                bufferChanged = true;
+            }
+            
+            if (bufferChanged || attrib.cached != oldAttrib.cached) {
+                original.vertexAttribPointer.call(gl, n, attrib.size, attrib.type, attrib.normalized, attrib.stride, attrib.offset);
+            }
+        }
+    }
+    
+    if (this.currentArrayBuffer != currentBinding) {
+        original.bindBuffer.call(gl, gl.ARRAY_BUFFER, this.currentArrayBuffer);
+    }
+};
+
+// You MUST call this BEFORE adding event listeners for 'webglcontextrestored'
+window.setupVertexArrayObject = function(gl) {
+    // Ignore if already installed (or the browser provides the extension)
+    // FIXME: when all stable browsers support getSupportedExtensions
+    // and getExtension, remove the workarounds below.
+    if (gl.getSupportedExtensions) {
+        var exts = gl.getSupportedExtensions();
+        if (exts.indexOf("OES_vertex_array_object") != -1) {
+            return;
+        }
+    } else if (gl.getExtension) {
+        var vao = gl.getExtension("OES_vertex_array_object");
+        if (vao) {
+            return;
+        }
+    }
+
+    if (gl.getSupportedExtensions) {
+        var original_getSupportedExtensions = gl.getSupportedExtensions;
+        gl.getSupportedExtensions = function getSupportedExtensions() {
+            var list = original_getSupportedExtensions.call(this) || [];
+            list.push("OES_vertex_array_object");
+            return list;
+        };
+    }
+    
+    var original_getExtension = gl.getExtension;
+    gl.getExtension = function getExtension(name) {
+        if (name == "OES_vertex_array_object") {
+            if (!gl.__OESVertexArrayObject) {
+                gl.__OESVertexArrayObject = new OESVertexArrayObject(gl);
+            }
+            return gl.__OESVertexArrayObject;
+        }
+        if (original_getExtension) {
+            return original_getExtension.call(this, name);
+        } else {
+            return null;
+        }
+    };
+};
+
+}());

--- a/src/scene/forward-renderer.js
+++ b/src/scene/forward-renderer.js
@@ -500,9 +500,6 @@ function ForwardRenderer(graphicsDevice) {
 
     this.fogColor = new Float32Array(3);
     this.ambientColor = new Float32Array(3);
-
-    // temp arrays to avoid allocations
-    this.tempSemanticArray = [];
 }
 
 function mat3FromMat4(m3, m4) {
@@ -1263,7 +1260,7 @@ Object.assign(ForwardRenderer.prototype, {
             if (instancingData.count > 0) {
                 this._instancedDrawCalls++;
                 this._removedByInstancing += instancingData.count;
-                device.setVertexBuffer(instancingData.vertexBuffer, 1, instancingData.offset);
+                device.setVertexBuffer(instancingData.vertexBuffer);
                 device.draw(mesh.primitive[style], instancingData.count);
                 if (instancingData.vertexBuffer === _autoInstanceBuffer) {
                     meshInstance.instancingData = null;
@@ -1296,7 +1293,7 @@ Object.assign(ForwardRenderer.prototype, {
             if (instancingData.count > 0) {
                 this._instancedDrawCalls++;
                 this._removedByInstancing += instancingData.count;
-                device.setVertexBuffer(instancingData.vertexBuffer, 1, instancingData.offset);
+                device.setVertexBuffer(instancingData.vertexBuffer);
                 device.draw(mesh.primitive[style], instancingData.count);
                 if (instancingData.vertexBuffer === _autoInstanceBuffer) {
                     meshInstance.instancingData = null;
@@ -1629,8 +1626,8 @@ Object.assign(ForwardRenderer.prototype, {
 
     setVertexBuffers: function (device, mesh) {
 
-            // main vertex buffer
-        device.setVertexBuffer(mesh.vertexBuffer, 0);
+        // main vertex buffer
+        device.setVertexBuffer(mesh.vertexBuffer);
     },
 
     setMorphing: function (device, morphInstance) {
@@ -1639,40 +1636,32 @@ Object.assign(ForwardRenderer.prototype, {
 
             if (morphInstance.morph.useTextureMorph) {
 
-                    // vertex buffer with vertex ids
-                device.setVertexBuffer(morphInstance.morph.vertexBufferIds, 1);
+                // vertex buffer with vertex ids
+                device.setVertexBuffer(morphInstance.morph.vertexBufferIds);
 
-                    // textures
+                // textures
                 this.morphPositionTex.setValue(morphInstance.texturePositions);
                 this.morphNormalTex.setValue(morphInstance.textureNormals);
 
-                    // texture params
+                // texture params
                 this.morphTexParams.setValue(morphInstance._textureParams);
 
             } else {    // vertex attributes based morphing
 
-                this.tempSemanticArray.length = 0;
-                var tempVertexBuffer;
+                var vb, semantic;
                 for (var t = 0; t < morphInstance._activeVertexBuffers.length; t++) {
 
-                    var semantic = SEMANTIC_ATTR + t;
-                    tempVertexBuffer = morphInstance._activeVertexBuffers[t];
+                    vb = morphInstance._activeVertexBuffers[t];
+                    if (vb) {
 
-                    if (tempVertexBuffer) {
                         // patch semantic for the buffer to current ATTR slot
-                        tempVertexBuffer.format.elements[0].name = semantic;
-                        tempVertexBuffer.format.elements[0].scopeId = device.scope.resolve(semantic);
+                        semantic = SEMANTIC_ATTR + t;
+                        vb.format.elements[0].name = semantic;
+                        vb.format.elements[0].scopeId = device.scope.resolve(semantic);
+                        vb.format.update();
 
-                        device.setVertexBuffer(tempVertexBuffer, t + 1);
-                    } else {
-                        // for null morph buffers set attributes to default constant value
-                        device.setVertexBuffer(null, t + 1);
-                        this.tempSemanticArray.push(semantic);
+                        device.setVertexBuffer(vb);
                     }
-                }
-
-                if (this.tempSemanticArray.length) {
-                    device.disableVertexBufferElements(this.tempSemanticArray);
                 }
 
                 // set all 8 weights

--- a/src/scene/mesh-instance.js
+++ b/src/scene/mesh-instance.js
@@ -389,8 +389,10 @@ Object.assign(MeshInstance.prototype, {
     setInstancing: function (vertexBuffer) {
         if (vertexBuffer) {
             this.instancingData = new InstancingData(vertexBuffer.numVertices);
-            this.instancingData.offset = 0;
             this.instancingData.vertexBuffer = vertexBuffer;
+
+            // mark vertex buffer as instancing data
+            vertexBuffer.instancing = true;
 
             // turn off culling - we do not do per-instance culling, all instances are submitted to GPU
             this.cull = false;
@@ -475,7 +477,6 @@ Object.defineProperty(Command.prototype, 'key', {
 function InstancingData(numObjects) {
     this.count = numObjects;
     this.vertexBuffer = null;
-    this.offset = 0;
 }
 
 function getKey(layer, blendType, isCommand, materialId) {


### PR DESCRIPTION
Using VAOs to set up vertex buffer attributes mapping to vertex shader, to minimize number of calls to WebGL and improve performance.

<img width="630" alt="Screen Shot 2020-07-07 at 12 51 02 PM" src="https://user-images.githubusercontent.com/59932779/86777908-aae15700-c051-11ea-88dd-51f1ffb33cfc.png">

Implementation details:
- if drawing is using a single vertex buffer (VB) - which is the majority of cases, a VAO object is created and attached to the VB and is used for rendering
- if drawing is using multiple vertex buffers - which is the case of both implementation of morphing (morph targets in attributes, or vertex_id attribute), and also hardware instancing (per instance vertex attributes) - VAO is generated for the combination of VBs and is stored in cache in Device class.
- IE11 does not support the extension, and so polyfill is used to provide it
- we now use fixed mapping from attribute name to attribute location (see semanticToLocation in graphics.js) to allow VAO for VB to be used for all shaders, instead of requiring VAO per shader variant. WebGl gives us 16 locations on all devices, and so currently existing 30 semantics are mapped to 16 locations with some overlap, but this is unlikely to cause problems as the overlap takes place on rarely used semantic names (ATTR10-ATTR15 overlap TEXCOORD2-TEXCOORD7 range)

Performance:
- testing on a scene with just over 5000 objects, frame duration on CPU dropped from 15.3ms to 12.5ms, which is saving of about 18%. Impact will be lower on scenes with smaller number of rendered objects.

Fixes #2204