### PR TITLE
[Fix] Fix to basic material shader building with colorMap

### DIFF
--- a/src/scene/materials/basic-material.js
+++ b/src/scene/materials/basic-material.js
@@ -71,7 +71,7 @@ Object.assign(BasicMaterial.prototype, {
         var options = {
             skin: !!this.meshInstances[0].skinInstance,
             vertexColors: this.vertexColors,
-            diffuseMap: this.colorMap,
+            diffuseMap: !!this.colorMap,
             pass: pass
         };
         var library = device.getProgramLibrary();


### PR DESCRIPTION
- only true / false option is needed, not the actual texture.

Fixes #2186