### PR TITLE
Fix example error accessing null object

### DIFF
--- a/examples/graphics/material-anisotropic.html
+++ b/examples/graphics/material-anisotropic.html
@@ -62,14 +62,12 @@
         // PlayCanvas Editor and then downloaded.
         var cubemapAsset = new pc.Asset('helipad.dds', 'cubemap', {
             url: "../assets/cubemaps/helipad.dds"
+        }, {
+            type: pc.TEXTURETYPE_RGBM
         });
         app.assets.add(cubemapAsset);
         app.assets.load(cubemapAsset);
         cubemapAsset.ready(function () {
-            // Mark the cubemaps as RGBM format since it's an HDR cubemap
-            cubemapAsset.resources.forEach(function (cubemap) {
-                cubemap.type = pc.TEXTURETYPE_RGBM;
-            });
             app.scene.setSkybox(cubemapAsset.resources);
         });
 

--- a/examples/graphics/material-clear-coat.html
+++ b/examples/graphics/material-clear-coat.html
@@ -60,14 +60,12 @@
         // PlayCanvas Editor and then downloaded.
         var cubemapAsset = new pc.Asset('helipad.dds', 'cubemap', {
             url: "../assets/cubemaps/helipad.dds"
+        }, {
+            type: pc.TEXTURETYPE_RGBM
         });
         app.assets.add(cubemapAsset);
         app.assets.load(cubemapAsset);
         cubemapAsset.ready(function () {
-            // Mark the cubemaps as RGBM format since it's an HDR cubemap
-            cubemapAsset.resources.forEach(function (cubemap) {
-                cubemap.type = pc.TEXTURETYPE_RGBM;
-            });
             app.scene.setSkybox(cubemapAsset.resources);
         });
 

--- a/examples/graphics/material-physical.html
+++ b/examples/graphics/material-physical.html
@@ -52,14 +52,12 @@
         // PlayCanvas Editor and then downloaded.
         var cubemapAsset = new pc.Asset('helipad.dds', 'cubemap', {
             url: "../assets/cubemaps/helipad.dds"
+        }, {
+            type: pc.TEXTURETYPE_RGBM
         });
         app.assets.add(cubemapAsset);
         app.assets.load(cubemapAsset);
         cubemapAsset.ready(function () {
-            // Mark the cubemaps as RGBM format since it's an HDR cubemap
-            cubemapAsset.resources.forEach(function (cubemap) {
-                cubemap.type = pc.TEXTURETYPE_RGBM;
-            });
             app.scene.setSkybox(cubemapAsset.resources);
         });
 


### PR DESCRIPTION
Specify cubemap texture type at load time instead of after the fact.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
