### PR TITLE
Preprocess GLSL chunks to make them smaller

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -49,7 +49,7 @@ function preprocessor(options) {
     };
 }
 
-function shaderChunks() {
+function shaderChunks(removeComments) {
     const filter = createFilter([
         '**/*.vert',
         '**/*.frag'
@@ -62,14 +62,22 @@ function shaderChunks() {
             // Remove carriage returns
             code = code.replace(/\r/g, '');
 
-            // Remove comments
-            code = code.replace(/\/\*[\s\S]*?\*\/|\/\/.*/g, '');
-
-            // Comment removal can leave an empty line to condense 2 or more to 1
-            code = code.replace( /\n{2,}/g, '\n' );
-
             // 4 spaces to tabs
             code = code.replace(/    /g, '\t'); // eslint-disable-line no-regex-spaces
+
+            if (removeComments) {
+                // Remove comments
+                code = code.replace(/\/\*[\s\S]*?\*\/|\/\/.*/g, '');
+
+                // Trim all whitespace from line endings
+                code = code.split('\n').map(line => line.trimEnd()).join('\n');
+
+                // Restore final new line
+                code += '\n';
+
+                // Comment removal can leave an empty line to condense 2 or more to 1
+                code = code.replace(/\n{2,}/g, '\n');
+            }
 
             return {
                 code: `export default ${JSON.stringify(code)};`,
@@ -94,7 +102,7 @@ export default [{
             DEBUG: false,
             RELEASE: true
         }),
-        shaderChunks(),
+        shaderChunks(true),
         replace({
             __REVISION__: revision,
             __CURRENT_SDK_VERSION__: version
@@ -119,7 +127,7 @@ export default [{
             DEBUG: true,
             RELEASE: false
         }),
-        shaderChunks(),
+        shaderChunks(false),
         replace({
             __REVISION__: revision,
             __CURRENT_SDK_VERSION__: version
@@ -144,7 +152,7 @@ export default [{
             DEBUG: false,
             RELEASE: false
         }),
-        shaderChunks(),
+        shaderChunks(false),
         replace({
             __REVISION__: revision,
             __CURRENT_SDK_VERSION__: version

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -58,6 +58,19 @@ function shaderChunks() {
     return {
         transform(code, id) {
             if (!filter(id)) return;
+
+            // Remove carriage returns
+            code = code.replace(/\r/g, '');
+
+            // Remove comments
+            code = code.replace(/\/\*[\s\S]*?\*\/|\/\/.*/g, '');
+
+            // Comment removal can leave an empty line to condense 2 or more to 1
+            code = code.replace( /\n{2,}/g, '\n' );
+
+            // 4 spaces to tabs
+            code = code.replace(/    /g, '\t'); // eslint-disable-line no-regex-spaces
+
             return {
                 code: `export default ${JSON.stringify(code)};`,
                 map: { mappings: '' }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -75,7 +75,7 @@ function shaderChunks(removeComments) {
                 // Restore final new line
                 code += '\n';
 
-                // Comment removal can leave an empty line to condense 2 or more to 1
+                // Comment removal can leave an empty line so condense 2 or more to 1
                 code = code.replace(/\n{2,}/g, '\n');
             }
 

--- a/src/graphics/program-lib/chunks/TBN.frag
+++ b/src/graphics/program-lib/chunks/TBN.frag
@@ -1,4 +1,3 @@
 void getTBN() {
     dTBN = mat3(normalize(dTangentW), normalize(dBinormalW), normalize(dVertexNormalW));
 }
-

--- a/src/graphics/program-lib/chunks/TBNObjectSpace.frag
+++ b/src/graphics/program-lib/chunks/TBNObjectSpace.frag
@@ -26,4 +26,3 @@ void getTBN() {
 
     dTBN = mat3(normalize(T), normalize(B), normalize(dVertexNormalW));
 }
-

--- a/src/graphics/program-lib/chunks/TBNderivative.frag
+++ b/src/graphics/program-lib/chunks/TBNderivative.frag
@@ -18,4 +18,3 @@ void getTBN() {
     float invmax = 1.0 / sqrt( max( dot(T,T), dot(B,B) ) );
     dTBN = mat3( T * invmax, B * invmax, dVertexNormalW );
 }
-

--- a/src/graphics/program-lib/chunks/TBNfast.frag
+++ b/src/graphics/program-lib/chunks/TBNfast.frag
@@ -1,4 +1,3 @@
 void getTBN() {
     dTBN = mat3(dTangentW, dBinormalW, dVertexNormalW);
 }
-

--- a/src/graphics/program-lib/chunks/alphaTest.frag
+++ b/src/graphics/program-lib/chunks/alphaTest.frag
@@ -1,5 +1,5 @@
 uniform float alpha_ref;
+
 void alphaTest(float a) {
     if (a < alpha_ref) discard;
 }
-

--- a/src/graphics/program-lib/chunks/ambientConstant.frag
+++ b/src/graphics/program-lib/chunks/ambientConstant.frag
@@ -1,4 +1,3 @@
-
 void addAmbient() {
     dDiffuseLight += light_globalAmbient;
 }

--- a/src/graphics/program-lib/chunks/ambientPrefilteredCube.frag
+++ b/src/graphics/program-lib/chunks/ambientPrefilteredCube.frag
@@ -2,9 +2,9 @@
 #define PMREM4
 uniform samplerCube texture_prefilteredCubeMap4;
 #endif
+
 void addAmbient() {
     vec3 fixedReflDir = fixSeamsStatic(dNormalW, 1.0 - 1.0 / 4.0);
     fixedReflDir.x *= -1.0;
     dDiffuseLight += processEnvironment($DECODE(textureCube(texture_prefilteredCubeMap4, fixedReflDir)).rgb);
 }
-

--- a/src/graphics/program-lib/chunks/ambientPrefilteredCubeLod.frag
+++ b/src/graphics/program-lib/chunks/ambientPrefilteredCubeLod.frag
@@ -3,9 +3,9 @@
 #extension GL_EXT_shader_texture_lod : enable
 uniform samplerCube texture_prefilteredCubeMap128;
 #endif
+
 void addAmbient() {
     vec3 fixedReflDir = fixSeamsStatic(dNormalW, 1.0 - 1.0 / 4.0);
     fixedReflDir.x *= -1.0;
     dDiffuseLight += processEnvironment($DECODE( textureCubeLodEXT(texture_prefilteredCubeMap128, fixedReflDir, 5.0) ).rgb);
 }
-

--- a/src/graphics/program-lib/chunks/ambientSH.frag
+++ b/src/graphics/program-lib/chunks/ambientSH.frag
@@ -1,18 +1,18 @@
 uniform vec3 ambientSH[9];
+
 void addAmbient() {
     vec3 n = dNormalW;
 
     vec3 color =
-                        ambientSH[0] +
-                        ambientSH[1] * n.x +
-                        ambientSH[2] * n.y +
-                        ambientSH[3] * n.z +
-                        ambientSH[4] * n.x * n.z +
-                        ambientSH[5] * n.z * n.y +
-                        ambientSH[6] * n.y * n.x +
-                        ambientSH[7] * (3.0 * n.z * n.z - 1.0) +
-                        ambientSH[8] * (n.x * n.x - n.y * n.y);
+        ambientSH[0] +
+        ambientSH[1] * n.x +
+        ambientSH[2] * n.y +
+        ambientSH[3] * n.z +
+        ambientSH[4] * n.x * n.z +
+        ambientSH[5] * n.z * n.y +
+        ambientSH[6] * n.y * n.x +
+        ambientSH[7] * (3.0 * n.z * n.z - 1.0) +
+        ambientSH[8] * (n.x * n.x - n.y * n.y);
 
     dDiffuseLight += processEnvironment(max(color, vec3(0.0)));
 }
-

--- a/src/graphics/program-lib/chunks/ao.frag
+++ b/src/graphics/program-lib/chunks/ao.frag
@@ -6,13 +6,12 @@ void applyAO() {
     dAo = 1.0;
 
     #ifdef MAPTEXTURE
-        dAo *= texture2D(texture_aoMap, $UV).$CH;
+    dAo *= texture2D(texture_aoMap, $UV).$CH;
     #endif
 
     #ifdef MAPVERTEX
-        dAo *= saturate(vVertexColor.$VC);
+    dAo *= saturate(vVertexColor.$VC);
     #endif
 
     dDiffuseLight *= dAo;
 }
-

--- a/src/graphics/program-lib/chunks/aoSpecOcc.frag
+++ b/src/graphics/program-lib/chunks/aoSpecOcc.frag
@@ -1,4 +1,5 @@
 uniform float material_occludeSpecularIntensity;
+
 void occludeSpecular() {
     // approximated specular occlusion from AO
     float specPow = exp2(dGlossiness * 11.0);
@@ -9,4 +10,3 @@ void occludeSpecular() {
     dSpecularLight *= specOcc;
     dReflection *= specOcc;
 }
-

--- a/src/graphics/program-lib/chunks/aoSpecOccConst.frag
+++ b/src/graphics/program-lib/chunks/aoSpecOccConst.frag
@@ -7,4 +7,3 @@ void occludeSpecular() {
     dSpecularLight *= specOcc;
     dReflection *= specOcc;
 }
-

--- a/src/graphics/program-lib/chunks/aoSpecOccConstSimple.frag
+++ b/src/graphics/program-lib/chunks/aoSpecOccConstSimple.frag
@@ -3,4 +3,3 @@ void occludeSpecular() {
     dSpecularLight *= specOcc;
     dReflection *= specOcc;
 }
-

--- a/src/graphics/program-lib/chunks/aoSpecOccSimple.frag
+++ b/src/graphics/program-lib/chunks/aoSpecOccSimple.frag
@@ -1,7 +1,7 @@
 uniform float material_occludeSpecularIntensity;
+
 void occludeSpecular() {
     float specOcc = mix(1.0, dAo, material_occludeSpecularIntensity);
     dSpecularLight *= specOcc;
     dReflection *= specOcc;
 }
-

--- a/src/graphics/program-lib/chunks/bakeDirLmEnd.frag
+++ b/src/graphics/program-lib/chunks/bakeDirLmEnd.frag
@@ -1,4 +1,3 @@
-
     vec4 dirLm = texture2D(texture_dirLightMap, vUv1);
 
     if (bakeDir > 0.5) {
@@ -15,4 +14,3 @@
         gl_FragColor.rgb = dirLm.xyz;
         gl_FragColor.a = max(dirLm.w, dAtten > 0.00001? (1.0/255.0) : 0.0);
     }
-

--- a/src/graphics/program-lib/chunks/bakeLmEnd.frag
+++ b/src/graphics/program-lib/chunks/bakeLmEnd.frag
@@ -1,8 +1,6 @@
-
-gl_FragColor.rgb = dDiffuseLight;
-gl_FragColor.rgb = pow(gl_FragColor.rgb, vec3(0.5));
-gl_FragColor.rgb /= 8.0;
-gl_FragColor.a = clamp( max( max( gl_FragColor.r, gl_FragColor.g ), max( gl_FragColor.b, 1.0 / 255.0 ) ), 0.0,1.0 );
-gl_FragColor.a = ceil(gl_FragColor.a * 255.0) / 255.0;
-gl_FragColor.rgb /= gl_FragColor.a;
-
+    gl_FragColor.rgb = dDiffuseLight;
+    gl_FragColor.rgb = pow(gl_FragColor.rgb, vec3(0.5));
+    gl_FragColor.rgb /= 8.0;
+    gl_FragColor.a = clamp( max( max( gl_FragColor.r, gl_FragColor.g ), max( gl_FragColor.b, 1.0 / 255.0 ) ), 0.0,1.0 );
+    gl_FragColor.a = ceil(gl_FragColor.a * 255.0) / 255.0;
+    gl_FragColor.rgb /= gl_FragColor.a;

--- a/src/graphics/program-lib/chunks/base.frag
+++ b/src/graphics/program-lib/chunks/base.frag
@@ -1,4 +1,3 @@
-
 uniform vec3 view_position;
 
 uniform vec3 light_globalAmbient;
@@ -14,4 +13,3 @@ float saturate(float x) {
 vec3 saturate(vec3 x) {
     return clamp(x, vec3(0.0), vec3(1.0));
 }
-

--- a/src/graphics/program-lib/chunks/base.vert
+++ b/src/graphics/program-lib/chunks/base.vert
@@ -1,4 +1,3 @@
-
 attribute vec3 vertex_position;
 attribute vec3 vertex_normal;
 attribute vec4 vertex_tangent;
@@ -16,4 +15,3 @@ mat3 dNormalMatrix;
 vec3 dLightPosW;
 vec3 dLightDirNormW;
 vec3 dNormalW;
-

--- a/src/graphics/program-lib/chunks/baseNineSliced.frag
+++ b/src/graphics/program-lib/chunks/baseNineSliced.frag
@@ -1,8 +1,8 @@
 #define NINESLICED
 
-
 varying vec2 vMask;
 varying vec2 vTiledUv;
+
 uniform mediump vec4 innerOffset;
 uniform mediump vec2 outerScale;
 uniform mediump vec4 atlasRect;

--- a/src/graphics/program-lib/chunks/baseNineSliced.vert
+++ b/src/graphics/program-lib/chunks/baseNineSliced.vert
@@ -1,8 +1,8 @@
 #define NINESLICED
 
-
 varying vec2 vMask;
 varying vec2 vTiledUv;
+
 uniform mediump vec4 innerOffset;
 uniform mediump vec2 outerScale;
 uniform mediump vec4 atlasRect;

--- a/src/graphics/program-lib/chunks/baseNineSlicedTiled.frag
+++ b/src/graphics/program-lib/chunks/baseNineSlicedTiled.frag
@@ -3,6 +3,7 @@
 
 varying vec2 vMask;
 varying vec2 vTiledUv;
+
 uniform mediump vec4 innerOffset;
 uniform mediump vec2 outerScale;
 uniform mediump vec4 atlasRect;

--- a/src/graphics/program-lib/chunks/biasConst.frag
+++ b/src/graphics/program-lib/chunks/biasConst.frag
@@ -1,5 +1,5 @@
 #define SHADOWBIAS
+
 float getShadowBias(float resolution, float maxBias) {
     return maxBias;
 }
-

--- a/src/graphics/program-lib/chunks/blurVSM.frag
+++ b/src/graphics/program-lib/chunks/blurVSM.frag
@@ -1,5 +1,5 @@
-
 varying vec2 vUv0;
+
 uniform sampler2D source;
 uniform vec2 pixelOffset;
 
@@ -13,17 +13,17 @@ float decodeFloatRG(vec2 rg) {
 }
 
 vec2 encodeFloatRG( float v ) {
-  vec2 enc = vec2(1.0, 255.0) * v;
-  enc = fract(enc);
-  enc -= enc.yy * vec2(1.0/255.0, 1.0/255.0);
-  return enc;
+    vec2 enc = vec2(1.0, 255.0) * v;
+    enc = fract(enc);
+    enc -= enc.yy * vec2(1.0/255.0, 1.0/255.0);
+    return enc;
 }
 #endif
 
 void main(void) {
     vec3 moments = vec3(0.0);
     vec2 uv = vUv0 - pixelOffset * (float(SAMPLES) * 0.5);
-    for(int i=0; i<SAMPLES; i++) {
+    for (int i=0; i<SAMPLES; i++) {
         vec4 c = texture2D(source, uv + pixelOffset * float(i));
 
         #ifdef PACKED
@@ -47,4 +47,3 @@ void main(void) {
     gl_FragColor = vec4(moments.x, moments.y, moments.z, 1.0);
     #endif
 }
-

--- a/src/graphics/program-lib/chunks/combineDiffuse.frag
+++ b/src/graphics/program-lib/chunks/combineDiffuse.frag
@@ -1,4 +1,3 @@
 vec3 combineColor() {
     return dAlbedo * dDiffuseLight;
 }
-

--- a/src/graphics/program-lib/chunks/combineDiffuseSpecular.frag
+++ b/src/graphics/program-lib/chunks/combineDiffuseSpecular.frag
@@ -1,4 +1,3 @@
 vec3 combineColor() {
     return mix(dAlbedo * dDiffuseLight, dSpecularLight + dReflection.rgb * dReflection.a, dSpecularity);
 }
-

--- a/src/graphics/program-lib/chunks/combineDiffuseSpecularNoConserve.frag
+++ b/src/graphics/program-lib/chunks/combineDiffuseSpecularNoConserve.frag
@@ -1,4 +1,3 @@
 vec3 combineColor() {
     return dAlbedo * dDiffuseLight + (dSpecularLight + dReflection.rgb * dReflection.a) * dSpecularity;
 }
-

--- a/src/graphics/program-lib/chunks/combineDiffuseSpecularNoRefl.frag
+++ b/src/graphics/program-lib/chunks/combineDiffuseSpecularNoRefl.frag
@@ -1,4 +1,3 @@
 vec3 combineColor() {
     return dAlbedo * dDiffuseLight + dSpecularLight * dSpecularity;
 }
-

--- a/src/graphics/program-lib/chunks/combineDiffuseSpecularNoReflSeparateAmbient.frag
+++ b/src/graphics/program-lib/chunks/combineDiffuseSpecularNoReflSeparateAmbient.frag
@@ -1,5 +1,5 @@
 uniform vec3 material_ambient;
+
 vec3 combineColor() {
     return (dDiffuseLight - light_globalAmbient) * dAlbedo + dSpecularLight * dSpecularity + material_ambient * light_globalAmbient;
 }
-

--- a/src/graphics/program-lib/chunks/combineDiffuseSpecularOld.frag
+++ b/src/graphics/program-lib/chunks/combineDiffuseSpecularOld.frag
@@ -1,4 +1,3 @@
 vec3 combineColor() {
     return mix(dAlbedo * dDiffuseLight + dSpecularLight * dSpecularity, dReflection.rgb, dReflection.a);
 }
-

--- a/src/graphics/program-lib/chunks/cookie.frag
+++ b/src/graphics/program-lib/chunks/cookie.frag
@@ -31,4 +31,3 @@ vec4 getCookie2DClipXform(sampler2D tex, mat4 transform, float intensity, vec4 c
 vec4 getCookieCube(samplerCube tex, mat4 transform, float intensity) {
     return mix(vec4(1.0), textureCube(tex, dLightDirNormW * mat3(transform)), intensity);
 }
-

--- a/src/graphics/program-lib/chunks/cubeMapProjectBox.frag
+++ b/src/graphics/program-lib/chunks/cubeMapProjectBox.frag
@@ -15,4 +15,3 @@ vec3 cubeMapProject(vec3 nrdir) {
     vec3 envBoxPos = (envBoxMin + envBoxMax) * 0.5;
     return posonbox - envBoxPos;
 }
-

--- a/src/graphics/program-lib/chunks/cubeMapProjectNone.frag
+++ b/src/graphics/program-lib/chunks/cubeMapProjectNone.frag
@@ -1,4 +1,3 @@
 vec3 cubeMapProject(vec3 dir) {
     return dir;
 }
-

--- a/src/graphics/program-lib/chunks/detailModes.frag
+++ b/src/graphics/program-lib/chunks/detailModes.frag
@@ -23,4 +23,3 @@ vec3 detailMode_min(vec3 c1, vec3 c2) {
 vec3 detailMode_max(vec3 c1, vec3 c2) {
     return max(c1, c2);
 }
-

--- a/src/graphics/program-lib/chunks/diffuse.frag
+++ b/src/graphics/program-lib/chunks/diffuse.frag
@@ -10,15 +10,14 @@ void getAlbedo() {
     dAlbedo = vec3(1.0);
 
     #ifdef MAPCOLOR
-        dAlbedo *= material_diffuse.rgb;
+    dAlbedo *= material_diffuse.rgb;
     #endif
 
     #ifdef MAPTEXTURE
-        dAlbedo *= gammaCorrectInput(addAlbedoDetail(texture2D(texture_diffuseMap, $UV).$CH));
+    dAlbedo *= gammaCorrectInput(addAlbedoDetail(texture2D(texture_diffuseMap, $UV).$CH));
     #endif
 
     #ifdef MAPVERTEX
-        dAlbedo *= gammaCorrectInput(saturate(vVertexColor.$VC));
+    dAlbedo *= gammaCorrectInput(saturate(vVertexColor.$VC));
     #endif
 }
-

--- a/src/graphics/program-lib/chunks/diffuseDetailMap.frag
+++ b/src/graphics/program-lib/chunks/diffuseDetailMap.frag
@@ -4,10 +4,9 @@ uniform sampler2D texture_diffuseDetailMap;
 
 vec3 addAlbedoDetail(vec3 albedo) {
     #ifdef MAPTEXTURE
-        vec3 albedoDetail = vec3(texture2D(texture_diffuseDetailMap, $UV).$CH);
-        return detailMode_$DETAILMODE(albedo, albedoDetail);
+    vec3 albedoDetail = vec3(texture2D(texture_diffuseDetailMap, $UV).$CH);
+    return detailMode_$DETAILMODE(albedo, albedoDetail);
     #else
-        return albedo;
+    return albedo;
     #endif
 }
-

--- a/src/graphics/program-lib/chunks/dilate.frag
+++ b/src/graphics/program-lib/chunks/dilate.frag
@@ -1,6 +1,8 @@
 varying vec2 vUv0;
+
 uniform sampler2D source;
 uniform vec2 pixelOffset;
+
 void main(void) {
     vec4 c = texture2D(source, vUv0);
     c = c.a>0.0? c : texture2D(source, vUv0 - pixelOffset);
@@ -13,4 +15,3 @@ void main(void) {
     c = c.a>0.0? c : texture2D(source, vUv0 + pixelOffset);
     gl_FragColor = c;
 }
-

--- a/src/graphics/program-lib/chunks/dpAtlasQuad.frag
+++ b/src/graphics/program-lib/chunks/dpAtlasQuad.frag
@@ -1,4 +1,5 @@
 varying vec2 vUv0;
+
 uniform sampler2D source;
 uniform vec4 params;
 

--- a/src/graphics/program-lib/chunks/emissive.frag
+++ b/src/graphics/program-lib/chunks/emissive.frag
@@ -14,21 +14,20 @@ vec3 getEmission() {
     vec3 emission = vec3(1.0);
 
     #ifdef MAPFLOAT
-        emission *= material_emissiveIntensity;
+    emission *= material_emissiveIntensity;
     #endif
 
     #ifdef MAPCOLOR
-        emission *= material_emissive;
+    emission *= material_emissive;
     #endif
 
     #ifdef MAPTEXTURE
-        emission *= $texture2DSAMPLE(texture_emissiveMap, $UV).$CH;
+    emission *= $texture2DSAMPLE(texture_emissiveMap, $UV).$CH;
     #endif
 
     #ifdef MAPVERTEX
-        emission *= gammaCorrectInput(saturate(vVertexColor.$VC));
+    emission *= gammaCorrectInput(saturate(vVertexColor.$VC));
     #endif
 
     return emission;
 }
-

--- a/src/graphics/program-lib/chunks/end.frag
+++ b/src/graphics/program-lib/chunks/end.frag
@@ -1,11 +1,13 @@
-  #ifdef CLEARCOAT
-   gl_FragColor.rgb = combineColorCC();
-  #else
-   gl_FragColor.rgb = combineColor();
-  #endif 
-   gl_FragColor.rgb += getEmission();
-   gl_FragColor.rgb = addFog(gl_FragColor.rgb);
-   #ifndef HDR
+    #ifdef CLEARCOAT
+    gl_FragColor.rgb = combineColorCC();
+    #else
+    gl_FragColor.rgb = combineColor();
+    #endif 
+
+    gl_FragColor.rgb += getEmission();
+    gl_FragColor.rgb = addFog(gl_FragColor.rgb);
+
+    #ifndef HDR
     gl_FragColor.rgb = toneMap(gl_FragColor.rgb);
     gl_FragColor.rgb = gammaCorrectOutput(gl_FragColor.rgb);
-   #endif
+    #endif

--- a/src/graphics/program-lib/chunks/envConst.frag
+++ b/src/graphics/program-lib/chunks/envConst.frag
@@ -1,4 +1,3 @@
 vec3 processEnvironment(vec3 color) {
     return color;
 }
-

--- a/src/graphics/program-lib/chunks/envMultiply.frag
+++ b/src/graphics/program-lib/chunks/envMultiply.frag
@@ -1,5 +1,5 @@
 uniform float skyboxIntensity;
+
 vec3 processEnvironment(vec3 color) {
     return color * skyboxIntensity;
 }
-

--- a/src/graphics/program-lib/chunks/falloffInvSquared.frag
+++ b/src/graphics/program-lib/chunks/falloffInvSquared.frag
@@ -8,4 +8,3 @@ float getFalloffInvSquared(float lightRadius) {
 
     return falloff;
 }
-

--- a/src/graphics/program-lib/chunks/falloffLinear.frag
+++ b/src/graphics/program-lib/chunks/falloffLinear.frag
@@ -2,4 +2,3 @@ float getFalloffLinear(float lightRadius) {
     float d = length(dLightDirW);
     return max(((lightRadius - d) / lightRadius), 0.0);
 }
-

--- a/src/graphics/program-lib/chunks/fixCubemapSeamsStretch.frag
+++ b/src/graphics/program-lib/chunks/fixCubemapSeamsStretch.frag
@@ -24,4 +24,3 @@ vec3 fixSeamsStatic(vec3 vec, float invRecMipSize) {
     if (abs(vec.z) != M) vec.z *= scale;
     return vec;
 }
-

--- a/src/graphics/program-lib/chunks/fogExp.frag
+++ b/src/graphics/program-lib/chunks/fogExp.frag
@@ -1,5 +1,6 @@
 uniform vec3 fog_color;
 uniform float fog_density;
+
 vec3 addFog(vec3 color) {
     float depth = gl_FragCoord.z / gl_FragCoord.w;
     float fogFactor = exp(-depth * fog_density);

--- a/src/graphics/program-lib/chunks/fogExp2.frag
+++ b/src/graphics/program-lib/chunks/fogExp2.frag
@@ -1,5 +1,6 @@
 uniform vec3 fog_color;
 uniform float fog_density;
+
 vec3 addFog(vec3 color) {
     float depth = gl_FragCoord.z / gl_FragCoord.w;
     float fogFactor = exp(-depth * depth * fog_density * fog_density);

--- a/src/graphics/program-lib/chunks/fogLinear.frag
+++ b/src/graphics/program-lib/chunks/fogLinear.frag
@@ -1,6 +1,7 @@
 uniform vec3 fog_color;
 uniform float fog_start;
 uniform float fog_end;
+
 vec3 addFog(vec3 color) {
     float depth = gl_FragCoord.z / gl_FragCoord.w;
     float fogFactor = (fog_end - depth) / (fog_end - fog_start);

--- a/src/graphics/program-lib/chunks/fogNone.frag
+++ b/src/graphics/program-lib/chunks/fogNone.frag
@@ -1,5 +1,3 @@
 vec3 addFog(vec3 color) {
     return color;
 }
-
-

--- a/src/graphics/program-lib/chunks/fresnelSchlick.frag
+++ b/src/graphics/program-lib/chunks/fresnelSchlick.frag
@@ -1,16 +1,18 @@
 // Schlick's approximation
 uniform float material_fresnelFactor; // unused
+
 void getFresnel() {
     float fresnel = 1.0 - max(dot(dNormalW, dViewDirW), 0.0);
     float fresnel2 = fresnel * fresnel;
     fresnel *= fresnel2 * fresnel2;
     fresnel *= dGlossiness * dGlossiness;
     dSpecularity = dSpecularity + (1.0 - dSpecularity) * fresnel;
+
     #ifdef CLEARCOAT
-        fresnel = 1.0 - max(dot(ccNormalW, dViewDirW), 0.0);
-        fresnel2 = fresnel * fresnel;
-        fresnel *= fresnel2 * fresnel2;
-        fresnel *= ccGlossiness * ccGlossiness;
-        ccSpecularity = ccSpecularity + (1.0 - ccSpecularity) * fresnel;
+    fresnel = 1.0 - max(dot(ccNormalW, dViewDirW), 0.0);
+    fresnel2 = fresnel * fresnel;
+    fresnel *= fresnel2 * fresnel2;
+    fresnel *= ccGlossiness * ccGlossiness;
+    ccSpecularity = ccSpecularity + (1.0 - ccSpecularity) * fresnel;
     #endif
 }

--- a/src/graphics/program-lib/chunks/fullscreenQuad.frag
+++ b/src/graphics/program-lib/chunks/fullscreenQuad.frag
@@ -1,4 +1,5 @@
 varying vec2 vUv0;
+
 uniform sampler2D source;
 
 void main(void) {

--- a/src/graphics/program-lib/chunks/fullscreenQuad.vert
+++ b/src/graphics/program-lib/chunks/fullscreenQuad.vert
@@ -7,4 +7,3 @@ void main(void)
     gl_Position = vec4(vertex_position, 0.5, 1.0);
     vUv0 = vertex_position.xy*0.5+0.5;
 }
-

--- a/src/graphics/program-lib/chunks/gamma2_2.frag
+++ b/src/graphics/program-lib/chunks/gamma2_2.frag
@@ -29,10 +29,10 @@ vec4 textureCubeSRGB(samplerCube tex, vec3 uvw) {
 }
 
 vec3 gammaCorrectOutput(vec3 color) {
-#ifdef HDR
+    #ifdef HDR
     return color;
-#else
+    #else
     color += vec3(0.0000001);
     return pow(color, vec3(0.45));
-#endif
+    #endif
 }

--- a/src/graphics/program-lib/chunks/gloss.frag
+++ b/src/graphics/program-lib/chunks/gloss.frag
@@ -14,23 +14,22 @@ void getGlossiness() {
     dGlossiness = 1.0;
 
     #ifdef MAPFLOAT
-        dGlossiness *= material_shininess;
+    dGlossiness *= material_shininess;
     #endif
 
     #ifdef MAPTEXTURE
-        dGlossiness *= texture2D(texture_glossMap, $UV).$CH;
+    dGlossiness *= texture2D(texture_glossMap, $UV).$CH;
     #endif
 
     #ifdef MAPVERTEX
-        dGlossiness *= saturate(vVertexColor.$VC);
+    dGlossiness *= saturate(vVertexColor.$VC);
     #endif
 
     dGlossiness += 0.0000001;
 
     #ifdef CLEARCOAT
-        ccGlossiness = 1.0;
-        ccGlossiness *= material_clearCoatGlossiness;
-        ccGlossiness += 0.0000001;
+    ccGlossiness = 1.0;
+    ccGlossiness *= material_clearCoatGlossiness;
+    ccGlossiness += 0.0000001;
     #endif
 }
-

--- a/src/graphics/program-lib/chunks/instancing.vert
+++ b/src/graphics/program-lib/chunks/instancing.vert
@@ -1,6 +1,4 @@
-
 attribute vec4 instance_line1;
 attribute vec4 instance_line2;
 attribute vec4 instance_line3;
 attribute vec4 instance_line4;
-

--- a/src/graphics/program-lib/chunks/lightDiffuseLambert.frag
+++ b/src/graphics/program-lib/chunks/lightDiffuseLambert.frag
@@ -1,4 +1,3 @@
 float getLightDiffuse() {
     return max(dot(dNormalW, -dLightDirNormW), 0.0);
 }
-

--- a/src/graphics/program-lib/chunks/lightDirPoint.frag
+++ b/src/graphics/program-lib/chunks/lightDirPoint.frag
@@ -3,4 +3,3 @@ void getLightDirPoint(vec3 lightPosW) {
     dLightDirNormW = normalize(dLightDirW);
     dLightPosW = lightPosW;
 }
-

--- a/src/graphics/program-lib/chunks/lightmapDir.frag
+++ b/src/graphics/program-lib/chunks/lightmapDir.frag
@@ -28,4 +28,3 @@ void addDirLightMap() {
     dLightDirNormW = normalize(dir.xyz * 2.0 - vec3(1.0));
     dSpecularLight += vec3(getLightSpecular()) * color;
 }
-

--- a/src/graphics/program-lib/chunks/lightmapSingle.frag
+++ b/src/graphics/program-lib/chunks/lightmapSingle.frag
@@ -6,13 +6,12 @@ void addLightMap() {
     vec3 lm = vec3(1.0);
 
     #ifdef MAPTEXTURE
-        lm *= $texture2DSAMPLE(texture_lightMap, $UV).$CH;
+    lm *= $texture2DSAMPLE(texture_lightMap, $UV).$CH;
     #endif
 
     #ifdef MAPVERTEX
-        lm *= saturate(vVertexColor.$VC);
+    lm *= saturate(vVertexColor.$VC);
     #endif
     
     dDiffuseLight += lm;
 }
-

--- a/src/graphics/program-lib/chunks/lightmapSingleVert.frag
+++ b/src/graphics/program-lib/chunks/lightmapSingleVert.frag
@@ -1,4 +1,3 @@
 void addLightMap() {
     dDiffuseLight += saturate(vVertexColor.$CH);
 }
-

--- a/src/graphics/program-lib/chunks/metalness.frag
+++ b/src/graphics/program-lib/chunks/metalness.frag
@@ -20,22 +20,21 @@ void getSpecularity() {
     float metalness = 1.0;
 
     #ifdef MAPFLOAT
-        metalness *= material_metalness;
+    metalness *= material_metalness;
     #endif
 
     #ifdef MAPTEXTURE
-        metalness *= texture2D(texture_metalnessMap, $UV).$CH;
+    metalness *= texture2D(texture_metalnessMap, $UV).$CH;
     #endif
 
     #ifdef MAPVERTEX
-        metalness *= saturate(vVertexColor.$VC);
+    metalness *= saturate(vVertexColor.$VC);
     #endif
 
     processMetalness(metalness);
 
     #ifdef CLEARCOAT
-        ccSpecularity = vec3(1.0);
-        ccSpecularity *= material_clearCoatSpecularity;
+    ccSpecularity = vec3(1.0);
+    ccSpecularity *= material_clearCoatSpecularity;
     #endif
 }
-

--- a/src/graphics/program-lib/chunks/msdf.frag
+++ b/src/graphics/program-lib/chunks/msdf.frag
@@ -16,7 +16,6 @@ float map (float min, float max, float v) {
     return (v - min) / (max - min);
 }
 
-
 uniform float font_sdfIntensity; // intensity is used to boost the value read from the SDF, 0 is no boost, 1.0 is max boost
 uniform float font_pxrange;      // the number of pixels between inside and outside the font in SDF
 uniform float font_textureWidth; // the width of the texture atlas
@@ -36,17 +35,17 @@ vec4 applyMsdf(vec4 color) {
     float sigDistShdw = median(ssample.r, ssample.g, ssample.b);
 
     #ifdef USE_FWIDTH
-        // smoothing depends on size of texture on screen
-        vec2 w = fwidth(vUv0);
-        float smoothing = clamp(w.x * font_textureWidth / font_pxrange, 0.0, 0.5);
+    // smoothing depends on size of texture on screen
+    vec2 w = fwidth(vUv0);
+    float smoothing = clamp(w.x * font_textureWidth / font_pxrange, 0.0, 0.5);
     #else
-        float font_size = 16.0; // TODO fix this
-        // smoothing gets smaller as the font size gets bigger
-        // don't have fwidth we can approximate from font size, this doesn't account for scaling
-        // so a big font scaled down will be wrong...
-
-        float smoothing = clamp(font_pxrange / font_size, 0.0, 0.5);
+    float font_size = 16.0; // TODO fix this
+    // smoothing gets smaller as the font size gets bigger
+    // don't have fwidth we can approximate from font size, this doesn't account for scaling
+    // so a big font scaled down will be wrong...
+    float smoothing = clamp(font_pxrange / font_size, 0.0, 0.5);
     #endif
+
     float mapMin = 0.05;
     float mapMax = clamp(1.0 - font_sdfIntensity, mapMin, 1.0);
 

--- a/src/graphics/program-lib/chunks/normal.vert
+++ b/src/graphics/program-lib/chunks/normal.vert
@@ -1,40 +1,39 @@
 #ifdef MORPHING_TEXTURE_BASED_NORMAL
-    uniform highp sampler2D morphNormalTex;
+uniform highp sampler2D morphNormalTex;
 #endif
 
 vec3 getNormal() {
     #ifdef SKIN
-        dNormalMatrix = mat3(dModelMatrix[0].xyz, dModelMatrix[1].xyz, dModelMatrix[2].xyz);
+    dNormalMatrix = mat3(dModelMatrix[0].xyz, dModelMatrix[1].xyz, dModelMatrix[2].xyz);
     #elif defined(INSTANCING)
-        dNormalMatrix = mat3(instance_line1.xyz, instance_line2.xyz, instance_line3.xyz);
+    dNormalMatrix = mat3(instance_line1.xyz, instance_line2.xyz, instance_line3.xyz);
     #else
-        dNormalMatrix = matrix_normal;
+    dNormalMatrix = matrix_normal;
     #endif
 
     vec3 tempNormal = vertex_normal;
 
     #ifdef MORPHING
-        #ifdef MORPHING_NRM03
-            tempNormal += morph_weights_a[0] * morph_nrm0;
-            tempNormal += morph_weights_a[1] * morph_nrm1;
-            tempNormal += morph_weights_a[2] * morph_nrm2;
-            tempNormal += morph_weights_a[3] * morph_nrm3;
-        #endif
-        #ifdef MORPHING_NRM47
-            tempNormal += morph_weights_b[0] * morph_nrm4;
-            tempNormal += morph_weights_b[1] * morph_nrm5;
-            tempNormal += morph_weights_b[2] * morph_nrm6;
-            tempNormal += morph_weights_b[3] * morph_nrm7;
-        #endif
+    #ifdef MORPHING_NRM03
+    tempNormal += morph_weights_a[0] * morph_nrm0;
+    tempNormal += morph_weights_a[1] * morph_nrm1;
+    tempNormal += morph_weights_a[2] * morph_nrm2;
+    tempNormal += morph_weights_a[3] * morph_nrm3;
+    #endif
+    #ifdef MORPHING_NRM47
+    tempNormal += morph_weights_b[0] * morph_nrm4;
+    tempNormal += morph_weights_b[1] * morph_nrm5;
+    tempNormal += morph_weights_b[2] * morph_nrm6;
+    tempNormal += morph_weights_b[3] * morph_nrm7;
+    #endif
     #endif
 
     #ifdef MORPHING_TEXTURE_BASED_NORMAL
-        // apply morph offset from texture
-        vec2 morphUV = getTextureMorphCoords();
-        vec3 morphNormal = texture2D(morphNormalTex, morphUV).xyz;
-        tempNormal += morphNormal;
+    // apply morph offset from texture
+    vec2 morphUV = getTextureMorphCoords();
+    vec3 morphNormal = texture2D(morphNormalTex, morphUV).xyz;
+    tempNormal += morphNormal;
     #endif
 
     return normalize(dNormalMatrix * tempNormal);
 }
-

--- a/src/graphics/program-lib/chunks/normalDetailMap.frag
+++ b/src/graphics/program-lib/chunks/normalDetailMap.frag
@@ -12,11 +12,10 @@ vec3 blendNormals(vec3 n1, vec3 n2) {
 
 vec3 addNormalDetail(vec3 normalMap) {
     #ifdef MAPTEXTURE
-        vec3 normalDetailMap = unpackNormal(texture2D(texture_normalDetailMap, $UV));
-        normalDetailMap = normalize(mix(vec3(0.0, 0.0, 1.0), normalDetailMap, material_normalDetailMapBumpiness));
-        return blendNormals(normalMap, normalDetailMap);
+    vec3 normalDetailMap = unpackNormal(texture2D(texture_normalDetailMap, $UV));
+    normalDetailMap = normalize(mix(vec3(0.0, 0.0, 1.0), normalDetailMap, material_normalDetailMapBumpiness));
+    return blendNormals(normalMap, normalDetailMap);
     #else
-        return normalMap;
+    return normalMap;
     #endif
 }
-

--- a/src/graphics/program-lib/chunks/normalInstanced.vert
+++ b/src/graphics/program-lib/chunks/normalInstanced.vert
@@ -2,4 +2,3 @@ vec3 getNormal() {
     dNormalMatrix = mat3(instance_line1.xyz, instance_line2.xyz, instance_line3.xyz);
     return normalize(dNormalMatrix * vertex_normal);
 }
-

--- a/src/graphics/program-lib/chunks/normalMap.frag
+++ b/src/graphics/program-lib/chunks/normalMap.frag
@@ -1,11 +1,13 @@
 uniform sampler2D texture_normalMap;
 uniform float material_bumpiness;
+
 void getNormal() {
     vec3 normalMap = unpackNormal(texture2D(texture_normalMap, $UV));
     normalMap = normalize(mix(vec3(0.0, 0.0, 1.0), normalMap, material_bumpiness));
     dNormalMap = addNormalDetail(normalMap);
     dNormalW = dTBN * dNormalMap;
+
     #ifdef CLEARCOAT
-        ccNormalW = normalize(dVertexNormalW);
+    ccNormalW = normalize(dVertexNormalW);
     #endif
 }

--- a/src/graphics/program-lib/chunks/normalMapFast.frag
+++ b/src/graphics/program-lib/chunks/normalMapFast.frag
@@ -1,9 +1,11 @@
 uniform sampler2D texture_normalMap;
+
 void getNormal() {
     vec3 normalMap = unpackNormal(texture2D(texture_normalMap, $UV));
     dNormalMap = addNormalDetail(normalMap);
     dNormalW = dTBN * dNormalMap;
+
     #ifdef CLEARCOAT
-        ccNormalW = normalize(dVertexNormalW);
+    ccNormalW = normalize(dVertexNormalW);
     #endif
 }

--- a/src/graphics/program-lib/chunks/normalSkinned.vert
+++ b/src/graphics/program-lib/chunks/normalSkinned.vert
@@ -2,4 +2,3 @@ vec3 getNormal() {
     dNormalMatrix = mat3(dModelMatrix[0].xyz, dModelMatrix[1].xyz, dModelMatrix[2].xyz);
     return normalize(dNormalMatrix * vertex_normal);
 }
-

--- a/src/graphics/program-lib/chunks/normalVertex.frag
+++ b/src/graphics/program-lib/chunks/normalVertex.frag
@@ -1,7 +1,7 @@
 void getNormal() {
     dNormalW = normalize(dVertexNormalW);
+
     #ifdef CLEARCOAT
-        ccNormalW = dNormalW;
+    ccNormalW = dNormalW;
     #endif
 }
-

--- a/src/graphics/program-lib/chunks/normalXY.frag
+++ b/src/graphics/program-lib/chunks/normalXY.frag
@@ -4,4 +4,3 @@ vec3 unpackNormal(vec4 nmap) {
     normal.z = sqrt(1.0 - saturate(dot(normal.xy, normal.xy)));
     return normal;
 }
-

--- a/src/graphics/program-lib/chunks/normalXYZ.frag
+++ b/src/graphics/program-lib/chunks/normalXYZ.frag
@@ -1,4 +1,3 @@
 vec3 unpackNormal(vec4 nmap) {
     return nmap.xyz * 2.0 - 1.0;
 }
-

--- a/src/graphics/program-lib/chunks/opacity.frag
+++ b/src/graphics/program-lib/chunks/opacity.frag
@@ -10,15 +10,15 @@ void getOpacity() {
     dAlpha = 1.0;
 
     #ifdef MAPFLOAT
-        dAlpha *= material_opacity;
+    dAlpha *= material_opacity;
     #endif
 
     #ifdef MAPTEXTURE
-        dAlpha *= texture2D(texture_opacityMap, $UV).$CH;
+    dAlpha *= texture2D(texture_opacityMap, $UV).$CH;
     #endif
 
     #ifdef MAPVERTEX
-        dAlpha *= clamp(vVertexColor.$VC, 0.0, 1.0);
+    dAlpha *= clamp(vVertexColor.$VC, 0.0, 1.0);
     #endif
 }
 

--- a/src/graphics/program-lib/chunks/outputCubemap.frag
+++ b/src/graphics/program-lib/chunks/outputCubemap.frag
@@ -41,4 +41,3 @@ void main(void) {
     gl_FragColor = textureCube(source, vec);
     if (params.w >= 2.0) gl_FragColor = encodeRGBM(gl_FragColor);
 }
-

--- a/src/graphics/program-lib/chunks/outputTex2D.frag
+++ b/src/graphics/program-lib/chunks/outputTex2D.frag
@@ -5,4 +5,3 @@ uniform sampler2D source;
 void main(void) {
     gl_FragColor = texture2D(source, vUv0);
 }
-

--- a/src/graphics/program-lib/chunks/packDepth.frag
+++ b/src/graphics/program-lib/chunks/packDepth.frag
@@ -9,5 +9,3 @@ vec4 packFloat(float depth) {
     res -= res.xxyz * bit_mask;
     return res;
 }
-
-

--- a/src/graphics/program-lib/chunks/packDepthMask.frag
+++ b/src/graphics/program-lib/chunks/packDepthMask.frag
@@ -8,4 +8,3 @@ vec4 packFloat(float depth) {
     res -= res.xxyz * bit_mask;
     return res;
 }
-

--- a/src/graphics/program-lib/chunks/parallax.frag
+++ b/src/graphics/program-lib/chunks/parallax.frag
@@ -1,5 +1,6 @@
 uniform sampler2D texture_heightMap;
 uniform float material_heightMapFactor;
+
 void getParallax() {
     float parallaxScale = material_heightMapFactor;
 
@@ -10,4 +11,3 @@ void getParallax() {
     viewDirT.z += 0.42;
     dUvOffset = height * (viewDirT.xy / viewDirT.z);
 }
-

--- a/src/graphics/program-lib/chunks/particle.frag
+++ b/src/graphics/program-lib/chunks/particle.frag
@@ -27,11 +27,11 @@ float unpackFloat(vec4 rgbaDepth) {
 #endif
 
 void main(void) {
-    vec4 tex         = texture2DSRGB(colorMap, texCoordsAlphaLife.xy);
-    vec4 ramp     = texture2DSRGB(colorParam, vec2(texCoordsAlphaLife.w, 0.0));
+    vec4 tex  = texture2DSRGB(colorMap, texCoordsAlphaLife.xy);
+    vec4 ramp = texture2DSRGB(colorParam, vec2(texCoordsAlphaLife.w, 0.0));
     ramp.rgb *= colorMult;
 
     ramp.a += texCoordsAlphaLife.z;
 
-    vec3 rgb =     tex.rgb * ramp.rgb;
-    float a =         tex.a * ramp.a;
+    vec3 rgb = tex.rgb * ramp.rgb;
+    float a  = tex.a * ramp.a;

--- a/src/graphics/program-lib/chunks/particle.vert
+++ b/src/graphics/program-lib/chunks/particle.vert
@@ -1,4 +1,3 @@
-
 vec3 unpack3NFloats(float src) {
     float r = fract(src);
     float g = fract(src * 256.0);
@@ -25,7 +24,6 @@ vec4 tex1Dlod_lerp(highp sampler2D tex, vec2 tc, out vec3 w) {
 
     return mix(a, b, c);
 }
-
 
 vec2 rotate(vec2 quadXY, float pRotation, out mat2 rotMatrix) {
     float c = cos(pRotation);

--- a/src/graphics/program-lib/chunks/particleAnimFrameClamp.vert
+++ b/src/graphics/program-lib/chunks/particleAnimFrameClamp.vert
@@ -1,3 +1,1 @@
-
     float animFrame = min(floor(texCoordsAlphaLife.w * animTexParams.y) + animTexParams.x, animTexParams.z);
-

--- a/src/graphics/program-lib/chunks/particleAnimFrameLoop.vert
+++ b/src/graphics/program-lib/chunks/particleAnimFrameLoop.vert
@@ -1,3 +1,1 @@
-
     float animFrame = floor(mod(texCoordsAlphaLife.w * animTexParams.y + animTexParams.x, animTexParams.z + 1.0));
-

--- a/src/graphics/program-lib/chunks/particleAnimTex.vert
+++ b/src/graphics/program-lib/chunks/particleAnimTex.vert
@@ -1,4 +1,3 @@
-
     float animationIndex;
 
     if (animTexIndexParams.y == 1.0) {
@@ -13,4 +12,3 @@
 
     texCoordsAlphaLife.xy *= animTexTilesParams.xy;
     texCoordsAlphaLife.xy += vec2(atlasX, atlasY);
-

--- a/src/graphics/program-lib/chunks/particleInputFloat.frag
+++ b/src/graphics/program-lib/chunks/particleInputFloat.frag
@@ -8,4 +8,3 @@ void readInput(float uv) {
     inShow = tex.w >= 0.0;
     inLife = tex2.w;
 }
-

--- a/src/graphics/program-lib/chunks/particleInputRgba8.frag
+++ b/src/graphics/program-lib/chunks/particleInputRgba8.frag
@@ -38,4 +38,3 @@ void readInput(float uv) {
     float maxPosLife = lifetime+1.0;
     inLife = inLife * (maxNegLife + maxPosLife) - maxNegLife;
 }
-

--- a/src/graphics/program-lib/chunks/particleOutputFloat.frag
+++ b/src/graphics/program-lib/chunks/particleOutputFloat.frag
@@ -5,4 +5,3 @@ void writeOutput() {
         gl_FragColor = vec4(outVel, outLife);
     }
 }
-

--- a/src/graphics/program-lib/chunks/particleOutputRgba8.frag
+++ b/src/graphics/program-lib/chunks/particleOutputRgba8.frag
@@ -2,22 +2,20 @@ uniform vec3 outBoundsMul;
 uniform vec3 outBoundsAdd;
 
 vec2 encodeFloatRG( float v ) {
-  vec2 enc = vec2(1.0, 255.0) * v;
-  enc = fract(enc);
-  enc -= enc.yy * vec2(1.0/255.0, 1.0/255.0);
-  return enc;
+    vec2 enc = vec2(1.0, 255.0) * v;
+    enc = fract(enc);
+    enc -= enc.yy * vec2(1.0/255.0, 1.0/255.0);
+    return enc;
 }
 
 vec4 encodeFloatRGBA( float v ) {
-  vec4 enc = vec4(1.0, 255.0, 65025.0, 160581375.0) * v;
-  enc = fract(enc);
-  enc -= enc.yzww * vec4(1.0/255.0,1.0/255.0,1.0/255.0,0.0);
-  return enc;
+    vec4 enc = vec4(1.0, 255.0, 65025.0, 160581375.0) * v;
+    enc = fract(enc);
+    enc -= enc.yzww * vec4(1.0/255.0,1.0/255.0,1.0/255.0,0.0);
+    return enc;
 }
 
 void writeOutput() {
-    //outPos = (outPos - outBoundsCenter) / outBoundsSize + vec3(0.5);
-
     outPos = outPos * outBoundsMul + outBoundsAdd;
     outAngle = fract(outAngle / PI2);
 
@@ -37,4 +35,3 @@ void writeOutput() {
         gl_FragColor = encodeFloatRGBA(outLife);
     }
 }
-

--- a/src/graphics/program-lib/chunks/particleUpdaterAABB.frag
+++ b/src/graphics/program-lib/chunks/particleUpdaterAABB.frag
@@ -1,5 +1,6 @@
 uniform mat3 spawnBounds;
 uniform vec3 spawnPosInnerRatio;
+
 vec3 calcSpawnPosition(vec3 inBounds, float rndFactor) {
     vec3 pos = inBounds - vec3(0.5);
 
@@ -8,7 +9,6 @@ vec3 calcSpawnPosition(vec3 inBounds, float rndFactor) {
 
     vec3 edge = maxPos + (vec3(0.5) - maxPos) * spawnPosInnerRatio;
 
-    //pos = edge * mix(2.0 * pos, sign(pos), equal(maxPos, posAbs));
     pos.x = edge.x * (maxPos.x == posAbs.x ? sign(pos.x) : 2.0 * pos.x);
     pos.y = edge.y * (maxPos.y == posAbs.y ? sign(pos.y) : 2.0 * pos.y);
     pos.z = edge.z * (maxPos.z == posAbs.z ? sign(pos.z) : 2.0 * pos.z);
@@ -23,4 +23,3 @@ vec3 calcSpawnPosition(vec3 inBounds, float rndFactor) {
 void addInitialVelocity(inout vec3 localVelocity, vec3 inBounds) {
     localVelocity -= vec3(0, 0, initialVelocity);
 }
-

--- a/src/graphics/program-lib/chunks/particleUpdaterEnd.frag
+++ b/src/graphics/program-lib/chunks/particleUpdaterEnd.frag
@@ -1,4 +1,2 @@
-
     writeOutput();
 }
-

--- a/src/graphics/program-lib/chunks/particleUpdaterInit.frag
+++ b/src/graphics/program-lib/chunks/particleUpdaterInit.frag
@@ -17,7 +17,6 @@ uniform float initialVelocity;
 uniform float graphSampleSize;
 uniform float graphNumSamples;
 
-
 vec3 inPos;
 vec3 inVel;
 float inAngle;

--- a/src/graphics/program-lib/chunks/particleUpdaterOnStop.frag
+++ b/src/graphics/program-lib/chunks/particleUpdaterOnStop.frag
@@ -1,2 +1,1 @@
     visMode = outLife < 0.0? -1.0: visMode;
-

--- a/src/graphics/program-lib/chunks/particleUpdaterRespawn.frag
+++ b/src/graphics/program-lib/chunks/particleUpdaterRespawn.frag
@@ -3,4 +3,3 @@
         visMode = 1.0;
     }
     visMode = outLife < 0.0? 1.0: visMode;
-

--- a/src/graphics/program-lib/chunks/particleUpdaterSphere.frag
+++ b/src/graphics/program-lib/chunks/particleUpdaterSphere.frag
@@ -1,5 +1,6 @@
 uniform float spawnBoundsSphere;
 uniform float spawnBoundsSphereInnerRatio;
+
 vec3 calcSpawnPosition(vec3 inBounds, float rndFactor) {
     float rnd4 = fract(rndFactor * 1000.0);
     vec3 norm = normalize(inBounds.xyz - vec3(0.5));
@@ -14,4 +15,3 @@ vec3 calcSpawnPosition(vec3 inBounds, float rndFactor) {
 void addInitialVelocity(inout vec3 localVelocity, vec3 inBounds) {
     localVelocity += normalize(inBounds - vec3(0.5)) * initialVelocity;
 }
-

--- a/src/graphics/program-lib/chunks/particleUpdaterStart.frag
+++ b/src/graphics/program-lib/chunks/particleUpdaterStart.frag
@@ -28,9 +28,7 @@ vec4 hash41(float p) {
     return fract(vec4((p4.x + p4.y)*p4.z, (p4.x + p4.z)*p4.y, (p4.y + p4.z)*p4.w, (p4.z + p4.w)*p4.x));
 }
 
-
-void main(void)
-{
+void main(void) {
     if (gl_FragCoord.x > numParticles) discard;
 
     readInput(vUv0.x);

--- a/src/graphics/program-lib/chunks/particle_TBN.vert
+++ b/src/graphics/program-lib/chunks/particle_TBN.vert
@@ -1,4 +1,2 @@
-
-    mat3 rot3 = mat3(rotMatrix[0][0], rotMatrix[0][1], 0.0,        rotMatrix[1][0], rotMatrix[1][1], 0.0,        0.0, 0.0, 1.0);
+    mat3 rot3 = mat3(rotMatrix[0][0], rotMatrix[0][1], 0.0, rotMatrix[1][0], rotMatrix[1][1], 0.0, 0.0, 0.0, 1.0);
     ParticleMat = mat3(-matrix_viewInverse[0].xyz, -matrix_viewInverse[1].xyz, matrix_viewInverse[2].xyz) * rot3;
-

--- a/src/graphics/program-lib/chunks/particle_billboard.vert
+++ b/src/graphics/program-lib/chunks/particle_billboard.vert
@@ -1,4 +1,2 @@
-
     quadXY = rotate(quadXY, inAngle, rotMatrix);
     vec3 localPos = billboard(particlePos, quadXY);
-

--- a/src/graphics/program-lib/chunks/particle_blendAdd.frag
+++ b/src/graphics/program-lib/chunks/particle_blendAdd.frag
@@ -1,4 +1,2 @@
-
     rgb *= saturate(gammaCorrectInput(a));
     if ((rgb.r + rgb.g + rgb.b) < 0.000001) discard;
-

--- a/src/graphics/program-lib/chunks/particle_blendMultiply.frag
+++ b/src/graphics/program-lib/chunks/particle_blendMultiply.frag
@@ -1,4 +1,2 @@
-
     rgb = mix(vec3(1.0), rgb, vec3(a));
     if (rgb.r + rgb.g + rgb.b > 2.99) discard;
-

--- a/src/graphics/program-lib/chunks/particle_blendNormal.frag
+++ b/src/graphics/program-lib/chunks/particle_blendNormal.frag
@@ -1,2 +1,1 @@
-
     if (a < 0.01) discard;

--- a/src/graphics/program-lib/chunks/particle_cpu.vert
+++ b/src/graphics/program-lib/chunks/particle_cpu.vert
@@ -1,13 +1,13 @@
-attribute vec4 particle_vertexData;     // XYZ = world pos, W = life
-attribute vec4 particle_vertexData2;     // X = angle, Y = scale, Z = alpha, W = velocity.x
-attribute vec4 particle_vertexData3;     // XYZ = particle local pos, W = velocity.y
-attribute float particle_vertexData4;     // particle id
+attribute vec4 particle_vertexData;   // XYZ = world pos, W = life
+attribute vec4 particle_vertexData2;  // X = angle, Y = scale, Z = alpha, W = velocity.x
+attribute vec4 particle_vertexData3;  // XYZ = particle local pos, W = velocity.y
+attribute float particle_vertexData4; // particle id
 #ifndef USE_MESH
 #define VDATA5TYPE vec2
 #else
 #define VDATA5TYPE vec4
 #endif
-attribute VDATA5TYPE particle_vertexData5;     // VDATA4TYPE depends on useMesh property. Start with X = velocity.z, Y = particle ID and for mesh particles proceeds with Z = mesh UV.x, W = mesh UV.y
+attribute VDATA5TYPE particle_vertexData5; // VDATA4TYPE depends on useMesh property. Start with X = velocity.z, Y = particle ID and for mesh particles proceeds with Z = mesh UV.x, W = mesh UV.y
 
 uniform mat4 matrix_viewProjection;
 uniform mat4 matrix_model;
@@ -24,8 +24,6 @@ uniform float numParticles;
 uniform float lifetime;
 uniform float stretch;
 uniform float seed;
-//uniform float graphSampleSize;
-//uniform float graphNumSamples;
 uniform vec3 wrapBounds, emitterScale, faceTangent, faceBinorm;
 uniform sampler2D texLifeAndSourcePosOUT;
 uniform highp sampler2D internalTex0;
@@ -34,7 +32,6 @@ uniform highp sampler2D internalTex2;
 uniform vec3 emitterPos;
 
 varying vec4 texCoordsAlphaLife;
-
 
 vec2 rotate(vec2 quadXY, float pRotation, out mat2 rotMatrix)
 {
@@ -88,4 +85,3 @@ void main(void)
     float inAngle = particle_vertexData2.x;
     vec3 particlePosMoved = vec3(0.0);
     vec3 meshLocalPos = particle_vertexData3.xyz;
-

--- a/src/graphics/program-lib/chunks/particle_cpu_end.vert
+++ b/src/graphics/program-lib/chunks/particle_cpu_end.vert
@@ -1,4 +1,3 @@
-
     localPos *= particle_vertexData2.y * emitterScale;
     localPos += particlePos;
 

--- a/src/graphics/program-lib/chunks/particle_customFace.vert
+++ b/src/graphics/program-lib/chunks/particle_customFace.vert
@@ -1,3 +1,2 @@
-
     quadXY = rotate(quadXY, inAngle, rotMatrix);
     vec3 localPos = customFace(particlePos, quadXY);

--- a/src/graphics/program-lib/chunks/particle_end.vert
+++ b/src/graphics/program-lib/chunks/particle_end.vert
@@ -1,10 +1,9 @@
-
     localPos *= scale * emitterScale;
     localPos += particlePos;
 
     #ifdef SCREEN_SPACE
-        gl_Position = vec4(localPos.x, localPos.y, 0.0, 1.0);
+    gl_Position = vec4(localPos.x, localPos.y, 0.0, 1.0);
     #else
-        gl_Position = matrix_viewProjection * vec4(localPos.xyz, 1.0);
+    gl_Position = matrix_viewProjection * vec4(localPos.xyz, 1.0);
     #endif
     

--- a/src/graphics/program-lib/chunks/particle_halflambert.frag
+++ b/src/graphics/program-lib/chunks/particle_halflambert.frag
@@ -1,7 +1,4 @@
-
     vec3 negNormal = normal*0.5+0.5;
     vec3 posNormal = -normal*0.5+0.5;
     negNormal *= negNormal;
     posNormal *= posNormal;
-
-

--- a/src/graphics/program-lib/chunks/particle_init.vert
+++ b/src/graphics/program-lib/chunks/particle_init.vert
@@ -37,4 +37,3 @@ vec3 inVel;
 float inAngle;
 bool inShow;
 float inLife;
-

--- a/src/graphics/program-lib/chunks/particle_lambert.frag
+++ b/src/graphics/program-lib/chunks/particle_lambert.frag
@@ -1,5 +1,2 @@
-
     vec3 negNormal = max(normal, vec3(0.0));
     vec3 posNormal = max(-normal, vec3(0.0));
-
-

--- a/src/graphics/program-lib/chunks/particle_lighting.frag
+++ b/src/graphics/program-lib/chunks/particle_lighting.frag
@@ -1,9 +1,5 @@
-
     vec3 light = negNormal.x*lightCube[0] + posNormal.x*lightCube[1] +
                         negNormal.y*lightCube[2] + posNormal.y*lightCube[3] +
                         negNormal.z*lightCube[4] + posNormal.z*lightCube[5];
 
-
     rgb *= light;
-
-

--- a/src/graphics/program-lib/chunks/particle_localShift.vert
+++ b/src/graphics/program-lib/chunks/particle_localShift.vert
@@ -1,2 +1,1 @@
     particlePos = (matrix_model * vec4(particlePos, 1.0)).xyz;
-

--- a/src/graphics/program-lib/chunks/particle_mesh.vert
+++ b/src/graphics/program-lib/chunks/particle_mesh.vert
@@ -1,8 +1,5 @@
-
     vec3 localPos = meshLocalPos;
     localPos.xy = rotate(localPos.xy, inAngle, rotMatrix);
     localPos.yz = rotate(localPos.yz, inAngle, rotMatrix);
 
     billboard(particlePos, quadXY);
-
-

--- a/src/graphics/program-lib/chunks/particle_normal.vert
+++ b/src/graphics/program-lib/chunks/particle_normal.vert
@@ -1,2 +1,1 @@
-
     Normal = normalize(localPos + matrix_viewInverse[2].xyz);

--- a/src/graphics/program-lib/chunks/particle_normalMap.frag
+++ b/src/graphics/program-lib/chunks/particle_normalMap.frag
@@ -1,7 +1,2 @@
-
-    vec3 normalMap         = normalize( texture2D(normalMap, texCoordsAlphaLife.xy).xyz * 2.0 - 1.0 );
+    vec3 normalMap = normalize(texture2D(normalMap, texCoordsAlphaLife.xy).xyz * 2.0 - 1.0);
     vec3 normal = ParticleMat * normalMap;
-
-
-
-

--- a/src/graphics/program-lib/chunks/particle_soft.frag
+++ b/src/graphics/program-lib/chunks/particle_soft.frag
@@ -1,4 +1,3 @@
-
     float depth = getLinearScreenDepth();
     float particleDepth = vDepth;
     float depthDiff = saturate(abs(particleDepth - depth) * softening);

--- a/src/graphics/program-lib/chunks/particle_soft.vert
+++ b/src/graphics/program-lib/chunks/particle_soft.vert
@@ -1,2 +1,1 @@
-
     vDepth = getLinearDepth(localPos);

--- a/src/graphics/program-lib/chunks/particle_stretch.vert
+++ b/src/graphics/program-lib/chunks/particle_stretch.vert
@@ -7,4 +7,3 @@
     float interpolation = dot(-velocityV, centerToVertexV) * 0.5 + 0.5;
 
     particlePos = mix(particlePos, posPrev, interpolation);
-

--- a/src/graphics/program-lib/chunks/particle_wrap.vert
+++ b/src/graphics/program-lib/chunks/particle_wrap.vert
@@ -1,8 +1,5 @@
-
     vec3 origParticlePos = particlePos;
     particlePos -= matrix_model[3].xyz;
     particlePos = mod(particlePos, wrapBounds) - wrapBounds * 0.5;
     particlePos += matrix_model[3].xyz;
     particlePosMoved = particlePos - origParticlePos;
-
-

--- a/src/graphics/program-lib/chunks/precisionTest.frag
+++ b/src/graphics/program-lib/chunks/precisionTest.frag
@@ -1,4 +1,3 @@
 void main(void) {
     gl_FragColor = vec4(2147483648.0);
 }
-

--- a/src/graphics/program-lib/chunks/precisionTest2.frag
+++ b/src/graphics/program-lib/chunks/precisionTest2.frag
@@ -14,4 +14,3 @@ void main(void) {
     float diff = abs(c - 2147483648.0) / 2147483648.0;
     gl_FragColor = packFloat(diff);
 }
-

--- a/src/graphics/program-lib/chunks/reflDir.frag
+++ b/src/graphics/program-lib/chunks/reflDir.frag
@@ -1,7 +1,7 @@
 void getReflDir() {
     dReflDirW = normalize(-reflect(dViewDirW, dNormalW));
+
     #ifdef CLEARCOAT
         ccReflDirW = normalize(-reflect(dViewDirW, ccNormalW));
     #endif    
 }
-

--- a/src/graphics/program-lib/chunks/reflDirAniso.frag
+++ b/src/graphics/program-lib/chunks/reflDirAniso.frag
@@ -6,8 +6,8 @@ void getReflDir() {
     vec3 anisotropicNormal = cross(anisotropicTangent, anisotropicDirection);
     vec3 bentNormal = normalize(mix(normalize(dNormalW), normalize(anisotropicNormal), anisotropy));
     dReflDirW = reflect(-dViewDirW, bentNormal);
+
     #ifdef CLEARCOAT
         ccReflDirW = normalize(-reflect(dViewDirW, ccNormalW));
     #endif    
 }
-

--- a/src/graphics/program-lib/chunks/reflectionCC.frag
+++ b/src/graphics/program-lib/chunks/reflectionCC.frag
@@ -1,5 +1,6 @@
 #ifdef CLEARCOAT
 uniform float material_clearCoatReflectivity;
+
 void addReflectionCC() {    
     ccReflection += vec4(calcReflection(ccReflDirW, ccGlossiness), material_clearCoatReflectivity); 
 }

--- a/src/graphics/program-lib/chunks/reflectionCube.frag
+++ b/src/graphics/program-lib/chunks/reflectionCube.frag
@@ -1,11 +1,12 @@
 uniform samplerCube texture_cubeMap;
+uniform float material_reflectivity;
+
 vec3 calcReflection(vec3 tReflDirW, float tGlossiness) {
     vec3 lookupVec = fixSeams(cubeMapProject(tReflDirW));
     lookupVec.x *= -1.0;
     return $textureCubeSAMPLE(texture_cubeMap, lookupVec).rgb;
 }
 
-uniform float material_reflectivity;
 void addReflection() {   
     dReflection += vec4(calcReflection(dReflDirW, dGlossiness), material_reflectivity);
 }

--- a/src/graphics/program-lib/chunks/reflectionDpAtlas.frag
+++ b/src/graphics/program-lib/chunks/reflectionDpAtlas.frag
@@ -1,4 +1,5 @@
 uniform sampler2D texture_sphereMap;
+uniform float material_reflectivity;
 
 vec2 getDpAtlasUv(vec2 uv, float mip) {
 
@@ -51,7 +52,6 @@ vec3 calcReflection(vec3 tReflDirW, float tGlossiness) {
     return tex1;
 }
 
-uniform float material_reflectivity;
 void addReflection() {   
     dReflection += vec4(calcReflection(dReflDirW, dGlossiness), material_reflectivity);
 }

--- a/src/graphics/program-lib/chunks/reflectionPrefilteredCube.frag
+++ b/src/graphics/program-lib/chunks/reflectionPrefilteredCube.frag
@@ -7,6 +7,8 @@ uniform samplerCube texture_prefilteredCubeMap8;
 #define PMREM4
 uniform samplerCube texture_prefilteredCubeMap4;
 #endif
+uniform float material_reflectivity;
+
 vec3 calcReflection(vec3 tReflDirW, float tGlossiness) {
     // Unfortunately, WebGL doesn't allow us using textureCubeLod. Therefore bunch of nasty workarounds is required.
     // We fix mip0 to 128x128, so code is rather static.
@@ -59,7 +61,6 @@ vec3 calcReflection(vec3 tReflDirW, float tGlossiness) {
     return refl;
 }
 
-uniform float material_reflectivity;
 void addReflection() {   
     dReflection += vec4(calcReflection(dReflDirW, dGlossiness), material_reflectivity);
 }

--- a/src/graphics/program-lib/chunks/reflectionPrefilteredCubeLod.frag
+++ b/src/graphics/program-lib/chunks/reflectionPrefilteredCubeLod.frag
@@ -1,9 +1,10 @@
-
 #ifndef PMREM4
 #define PMREM4
 #extension GL_EXT_shader_texture_lod : enable
 uniform samplerCube texture_prefilteredCubeMap128;
 #endif
+uniform float material_reflectivity;
+
 vec3 calcReflection(vec3 tReflDirW, float tGlossiness) {
     float bias = saturate(1.0 - tGlossiness) * 5.0; // multiply by max mip level
     vec3 fixedReflDir = fixSeams(cubeMapProject(tReflDirW), bias);
@@ -14,7 +15,6 @@ vec3 calcReflection(vec3 tReflDirW, float tGlossiness) {
     return refl;
 }
 
-uniform float material_reflectivity;
 void addReflection() {   
     dReflection += vec4(calcReflection(dReflDirW, dGlossiness), material_reflectivity);
 }

--- a/src/graphics/program-lib/chunks/reflectionSphere.frag
+++ b/src/graphics/program-lib/chunks/reflectionSphere.frag
@@ -3,6 +3,8 @@
 uniform mat4 matrix_view;
 #endif
 uniform sampler2D texture_sphereMap;
+uniform float material_reflectivity;
+
 vec3 calcReflection(vec3 tReflDirW, float tGlossiness) {
     vec3 reflDirV = (mat3(matrix_view) * tReflDirW).xyz;
 
@@ -12,7 +14,6 @@ vec3 calcReflection(vec3 tReflDirW, float tGlossiness) {
     return $texture2DSAMPLE(texture_sphereMap, sphereMapUv).rgb;
 }
 
-uniform float material_reflectivity;
 void addReflection() {   
     dReflection += vec4(calcReflection(dReflDirW, dGlossiness), material_reflectivity);
 }

--- a/src/graphics/program-lib/chunks/reflectionSphereLow.frag
+++ b/src/graphics/program-lib/chunks/reflectionSphereLow.frag
@@ -1,4 +1,5 @@
 uniform sampler2D texture_sphereMap;
+uniform float material_reflectivity;
 
 vec3 calcReflection(vec3 tReflDirW, float tGlossiness) {
     vec3 reflDirV = vNormalV;
@@ -7,7 +8,6 @@ vec3 calcReflection(vec3 tReflDirW, float tGlossiness) {
     return $texture2DSAMPLE(texture_sphereMap, sphereMapUv).rgb;
 }
 
-uniform float material_reflectivity;
 void addReflection() {   
     dReflection += vec4(calcReflection(dReflDirW, dGlossiness), material_reflectivity);
 }

--- a/src/graphics/program-lib/chunks/refraction.frag
+++ b/src/graphics/program-lib/chunks/refraction.frag
@@ -8,7 +8,6 @@ vec3 refract2(vec3 viewVec, vec3 Normal, float IOR) {
 }
 
 void addRefraction() {
-
     // use same reflection code with refraction vector
     vec3 tmp = dReflDirW;
     vec4 tmp2 = dReflection;
@@ -21,4 +20,3 @@ void addRefraction() {
     dReflDirW = tmp;
     dReflection = tmp2;
 }
-

--- a/src/graphics/program-lib/chunks/rgbm.frag
+++ b/src/graphics/program-lib/chunks/rgbm.frag
@@ -10,4 +10,3 @@ vec3 texture2DRGBM(sampler2D tex, vec2 uv) {
 vec3 textureCubeRGBM(samplerCube tex, vec3 uvw) {
     return decodeRGBM(textureCube(tex, uvw));
 }
-

--- a/src/graphics/program-lib/chunks/screenDepth.frag
+++ b/src/graphics/program-lib/chunks/screenDepth.frag
@@ -16,26 +16,26 @@ uniform vec4 camera_params; // 1 / camera_far,      camera_far,     (1 - f / n) 
 #endif
 
 #ifdef GL2
-    float linearizeDepth(float z) {
-        z = z * 2.0 - 1.0;
-        return 1.0 / (camera_params.z * z + camera_params.w);
-    }
+float linearizeDepth(float z) {
+    z = z * 2.0 - 1.0;
+    return 1.0 / (camera_params.z * z + camera_params.w);
+}
 #else
-    #ifndef UNPACKFLOAT
-    #define UNPACKFLOAT
-    float unpackFloat(vec4 rgbaDepth) {
-        const vec4 bitShift = vec4(1.0 / (256.0 * 256.0 * 256.0), 1.0 / (256.0 * 256.0), 1.0 / 256.0, 1.0);
-        return dot(rgbaDepth, bitShift);
-    }
-    #endif
+#ifndef UNPACKFLOAT
+#define UNPACKFLOAT
+float unpackFloat(vec4 rgbaDepth) {
+    const vec4 bitShift = vec4(1.0 / (256.0 * 256.0 * 256.0), 1.0 / (256.0 * 256.0), 1.0 / 256.0, 1.0);
+    return dot(rgbaDepth, bitShift);
+}
+#endif
 #endif
 
 // Retrieves rendered linear camera depth by UV
 float getLinearScreenDepth(vec2 uv) {
     #ifdef GL2
-        return linearizeDepth(texture2D(uDepthMap, uv).r) * camera_params.y;
+    return linearizeDepth(texture2D(uDepthMap, uv).r) * camera_params.y;
     #else
-        return unpackFloat(texture2D(uDepthMap, uv)) * camera_params.y;
+    return unpackFloat(texture2D(uDepthMap, uv)) * camera_params.y;
     #endif
 }
 

--- a/src/graphics/program-lib/chunks/shadowCommon.frag
+++ b/src/graphics/program-lib/chunks/shadowCommon.frag
@@ -4,4 +4,3 @@ void normalOffsetPointShadow(vec4 shadowParams) {
     vec3 dir = wPos - dLightPosW;
     dLightDirW = dir;
 }
-

--- a/src/graphics/program-lib/chunks/shadowCoord.frag
+++ b/src/graphics/program-lib/chunks/shadowCoord.frag
@@ -3,7 +3,7 @@ void _getShadowCoordOrtho(mat4 shadowMatrix, vec3 shadowParams, vec3 wPos) {
     dShadowCoord.z = saturate(dShadowCoord.z) - 0.0001;
 
     #ifdef SHADOWBIAS
-        dShadowCoord.z += getShadowBias(shadowParams.x, shadowParams.z);
+    dShadowCoord.z += getShadowBias(shadowParams.x, shadowParams.z);
     #endif
 }
 
@@ -14,7 +14,7 @@ void _getShadowCoordPersp(mat4 shadowMatrix, vec4 shadowParams, vec3 wPos) {
     dShadowCoord.z = length(dLightDirW) * shadowParams.w;
 
     #ifdef SHADOWBIAS
-        dShadowCoord.z += getShadowBias(shadowParams.x, shadowParams.z);
+    dShadowCoord.z += getShadowBias(shadowParams.x, shadowParams.z);
     #endif
 }
 
@@ -38,4 +38,3 @@ void getShadowCoordOrthoNormalOffset(mat4 shadowMatrix, vec3 shadowParams) {
 
     _getShadowCoordOrtho(shadowMatrix, shadowParams, wPos);
 }
-

--- a/src/graphics/program-lib/chunks/shadowCoord.vert
+++ b/src/graphics/program-lib/chunks/shadowCoord.vert
@@ -34,4 +34,3 @@ void getShadowCoordOrthoNormalOffset(mat4 shadowMatrix, vec3 shadowParams) {
 
     _getShadowCoordOrtho(shadowMatrix, shadowParams, wPos);
 }
-

--- a/src/graphics/program-lib/chunks/shadowCoordPerspZbuffer.frag
+++ b/src/graphics/program-lib/chunks/shadowCoordPerspZbuffer.frag
@@ -14,4 +14,3 @@ void getShadowCoordPerspZbufferNormalOffset(mat4 shadowMatrix, vec4 shadowParams
 void getShadowCoordPerspZbuffer(mat4 shadowMatrix, vec4 shadowParams) {
     _getShadowCoordPerspZbuffer(shadowMatrix, shadowParams, vPositionW);
 }
-

--- a/src/graphics/program-lib/chunks/shadowEVSM.frag
+++ b/src/graphics/program-lib/chunks/shadowEVSM.frag
@@ -10,4 +10,3 @@ float getShadowVSM$(sampler2D shadowMap, vec3 shadowParams, float exponent) {
 float getShadowSpotVSM$(sampler2D shadowMap, vec4 shadowParams, float exponent) {
     return VSM$(shadowMap, dShadowCoord.xy, shadowParams.x, length(dLightDirW) * shadowParams.w + shadowParams.z, shadowParams.y, exponent);
 }
-

--- a/src/graphics/program-lib/chunks/shadowEVSMn.frag
+++ b/src/graphics/program-lib/chunks/shadowEVSMn.frag
@@ -19,4 +19,3 @@ float getShadowVSM$(sampler2D shadowMap, vec3 shadowParams, float exponent) {
 float getShadowSpotVSM$(sampler2D shadowMap, vec4 shadowParams, float exponent) {
     return VSM$(shadowMap, dShadowCoord.xy, shadowParams.x, length(dLightDirW) * shadowParams.w + shadowParams.z, shadowParams.y, exponent);
 }
-

--- a/src/graphics/program-lib/chunks/shadowStandard.frag
+++ b/src/graphics/program-lib/chunks/shadowStandard.frag
@@ -13,103 +13,103 @@ float unpackFloat(vec4 rgbaDepth) {
 // ----- Direct/Spot Sampling -----
 
 #ifdef GL2
-    float _getShadowPCF3x3(sampler2DShadow shadowMap, vec3 shadowParams) {
-        float z = dShadowCoord.z;
-        vec2 uv = dShadowCoord.xy * shadowParams.x; // 1 unit - 1 texel
-        float shadowMapSizeInv = 1.0 / shadowParams.x;
-        vec2 base_uv = floor(uv + 0.5);
-        float s = (uv.x + 0.5 - base_uv.x);
-        float t = (uv.y + 0.5 - base_uv.y);
-        base_uv -= vec2(0.5);
-        base_uv *= shadowMapSizeInv;
+float _getShadowPCF3x3(sampler2DShadow shadowMap, vec3 shadowParams) {
+    float z = dShadowCoord.z;
+    vec2 uv = dShadowCoord.xy * shadowParams.x; // 1 unit - 1 texel
+    float shadowMapSizeInv = 1.0 / shadowParams.x;
+    vec2 base_uv = floor(uv + 0.5);
+    float s = (uv.x + 0.5 - base_uv.x);
+    float t = (uv.y + 0.5 - base_uv.y);
+    base_uv -= vec2(0.5);
+    base_uv *= shadowMapSizeInv;
 
-        float sum = 0.0;
+    float sum = 0.0;
 
-        float uw0 = (3.0 - 2.0 * s);
-        float uw1 = (1.0 + 2.0 * s);
+    float uw0 = (3.0 - 2.0 * s);
+    float uw1 = (1.0 + 2.0 * s);
 
-        float u0 = (2.0 - s) / uw0 - 1.0;
-        float u1 = s / uw1 + 1.0;
+    float u0 = (2.0 - s) / uw0 - 1.0;
+    float u1 = s / uw1 + 1.0;
 
-        float vw0 = (3.0 - 2.0 * t);
-        float vw1 = (1.0 + 2.0 * t);
+    float vw0 = (3.0 - 2.0 * t);
+    float vw1 = (1.0 + 2.0 * t);
 
-        float v0 = (2.0 - t) / vw0 - 1.0;
-        float v1 = t / vw1 + 1.0;
+    float v0 = (2.0 - t) / vw0 - 1.0;
+    float v1 = t / vw1 + 1.0;
 
-        u0 = u0 * shadowMapSizeInv + base_uv.x;
-        v0 = v0 * shadowMapSizeInv + base_uv.y;
+    u0 = u0 * shadowMapSizeInv + base_uv.x;
+    v0 = v0 * shadowMapSizeInv + base_uv.y;
 
-        u1 = u1 * shadowMapSizeInv + base_uv.x;
-        v1 = v1 * shadowMapSizeInv + base_uv.y;
+    u1 = u1 * shadowMapSizeInv + base_uv.x;
+    v1 = v1 * shadowMapSizeInv + base_uv.y;
 
-        sum += uw0 * vw0 * texture(shadowMap, vec3(u0, v0, z));
-        sum += uw1 * vw0 * texture(shadowMap, vec3(u1, v0, z));
-        sum += uw0 * vw1 * texture(shadowMap, vec3(u0, v1, z));
-        sum += uw1 * vw1 * texture(shadowMap, vec3(u1, v1, z));
+    sum += uw0 * vw0 * texture(shadowMap, vec3(u0, v0, z));
+    sum += uw1 * vw0 * texture(shadowMap, vec3(u1, v0, z));
+    sum += uw0 * vw1 * texture(shadowMap, vec3(u0, v1, z));
+    sum += uw1 * vw1 * texture(shadowMap, vec3(u1, v1, z));
 
-        sum *= 1.0f / 16.0;
-        return sum;
-    }
+    sum *= 1.0f / 16.0;
+    return sum;
+}
 
-    float getShadowPCF3x3(sampler2DShadow shadowMap, vec3 shadowParams) {
-        return _getShadowPCF3x3(shadowMap, shadowParams);
-    }
+float getShadowPCF3x3(sampler2DShadow shadowMap, vec3 shadowParams) {
+    return _getShadowPCF3x3(shadowMap, shadowParams);
+}
 
-    float getShadowSpotPCF3x3(sampler2DShadow shadowMap, vec4 shadowParams) {
-        return _getShadowPCF3x3(shadowMap, shadowParams.xyz);
-    }
+float getShadowSpotPCF3x3(sampler2DShadow shadowMap, vec4 shadowParams) {
+    return _getShadowPCF3x3(shadowMap, shadowParams.xyz);
+}
 #else
-    float _xgetShadowPCF3x3(mat3 depthKernel, sampler2D shadowMap, vec3 shadowParams) {
-        mat3 shadowKernel;
-        vec3 shadowCoord = dShadowCoord;
-        vec3 shadowZ = vec3(shadowCoord.z);
-        shadowKernel[0] = vec3(greaterThan(depthKernel[0], shadowZ));
-        shadowKernel[1] = vec3(greaterThan(depthKernel[1], shadowZ));
-        shadowKernel[2] = vec3(greaterThan(depthKernel[2], shadowZ));
+float _xgetShadowPCF3x3(mat3 depthKernel, sampler2D shadowMap, vec3 shadowParams) {
+    mat3 shadowKernel;
+    vec3 shadowCoord = dShadowCoord;
+    vec3 shadowZ = vec3(shadowCoord.z);
+    shadowKernel[0] = vec3(greaterThan(depthKernel[0], shadowZ));
+    shadowKernel[1] = vec3(greaterThan(depthKernel[1], shadowZ));
+    shadowKernel[2] = vec3(greaterThan(depthKernel[2], shadowZ));
 
-        vec2 fractionalCoord = fract( shadowCoord.xy * shadowParams.x );
+    vec2 fractionalCoord = fract( shadowCoord.xy * shadowParams.x );
 
-        shadowKernel[0] = mix(shadowKernel[0], shadowKernel[1], fractionalCoord.x);
-        shadowKernel[1] = mix(shadowKernel[1], shadowKernel[2], fractionalCoord.x);
+    shadowKernel[0] = mix(shadowKernel[0], shadowKernel[1], fractionalCoord.x);
+    shadowKernel[1] = mix(shadowKernel[1], shadowKernel[2], fractionalCoord.x);
 
-        vec4 shadowValues;
-        shadowValues.x = mix(shadowKernel[0][0], shadowKernel[0][1], fractionalCoord.y);
-        shadowValues.y = mix(shadowKernel[0][1], shadowKernel[0][2], fractionalCoord.y);
-        shadowValues.z = mix(shadowKernel[1][0], shadowKernel[1][1], fractionalCoord.y);
-        shadowValues.w = mix(shadowKernel[1][1], shadowKernel[1][2], fractionalCoord.y);
+    vec4 shadowValues;
+    shadowValues.x = mix(shadowKernel[0][0], shadowKernel[0][1], fractionalCoord.y);
+    shadowValues.y = mix(shadowKernel[0][1], shadowKernel[0][2], fractionalCoord.y);
+    shadowValues.z = mix(shadowKernel[1][0], shadowKernel[1][1], fractionalCoord.y);
+    shadowValues.w = mix(shadowKernel[1][1], shadowKernel[1][2], fractionalCoord.y);
 
-        return dot( shadowValues, vec4( 1.0 ) ) * 0.25;
-    }
+    return dot( shadowValues, vec4( 1.0 ) ) * 0.25;
+}
 
-    float _getShadowPCF3x3(sampler2D shadowMap, vec3 shadowParams) {
-        vec3 shadowCoord = dShadowCoord;
+float _getShadowPCF3x3(sampler2D shadowMap, vec3 shadowParams) {
+    vec3 shadowCoord = dShadowCoord;
 
-        float xoffset = 1.0 / shadowParams.x; // 1/shadow map width
-        float dx0 = -xoffset;
-        float dx1 = xoffset;
+    float xoffset = 1.0 / shadowParams.x; // 1/shadow map width
+    float dx0 = -xoffset;
+    float dx1 = xoffset;
 
-        mat3 depthKernel;
-        depthKernel[0][0] = unpackFloat(texture2D(shadowMap, shadowCoord.xy + vec2(dx0, dx0)));
-        depthKernel[0][1] = unpackFloat(texture2D(shadowMap, shadowCoord.xy + vec2(dx0, 0.0)));
-        depthKernel[0][2] = unpackFloat(texture2D(shadowMap, shadowCoord.xy + vec2(dx0, dx1)));
-        depthKernel[1][0] = unpackFloat(texture2D(shadowMap, shadowCoord.xy + vec2(0.0, dx0)));
-        depthKernel[1][1] = unpackFloat(texture2D(shadowMap, shadowCoord.xy));
-        depthKernel[1][2] = unpackFloat(texture2D(shadowMap, shadowCoord.xy + vec2(0.0, dx1)));
-        depthKernel[2][0] = unpackFloat(texture2D(shadowMap, shadowCoord.xy + vec2(dx1, dx0)));
-        depthKernel[2][1] = unpackFloat(texture2D(shadowMap, shadowCoord.xy + vec2(dx1, 0.0)));
-        depthKernel[2][2] = unpackFloat(texture2D(shadowMap, shadowCoord.xy + vec2(dx1, dx1)));
+    mat3 depthKernel;
+    depthKernel[0][0] = unpackFloat(texture2D(shadowMap, shadowCoord.xy + vec2(dx0, dx0)));
+    depthKernel[0][1] = unpackFloat(texture2D(shadowMap, shadowCoord.xy + vec2(dx0, 0.0)));
+    depthKernel[0][2] = unpackFloat(texture2D(shadowMap, shadowCoord.xy + vec2(dx0, dx1)));
+    depthKernel[1][0] = unpackFloat(texture2D(shadowMap, shadowCoord.xy + vec2(0.0, dx0)));
+    depthKernel[1][1] = unpackFloat(texture2D(shadowMap, shadowCoord.xy));
+    depthKernel[1][2] = unpackFloat(texture2D(shadowMap, shadowCoord.xy + vec2(0.0, dx1)));
+    depthKernel[2][0] = unpackFloat(texture2D(shadowMap, shadowCoord.xy + vec2(dx1, dx0)));
+    depthKernel[2][1] = unpackFloat(texture2D(shadowMap, shadowCoord.xy + vec2(dx1, 0.0)));
+    depthKernel[2][2] = unpackFloat(texture2D(shadowMap, shadowCoord.xy + vec2(dx1, dx1)));
 
-        return _xgetShadowPCF3x3(depthKernel, shadowMap, shadowParams);
-    }
+    return _xgetShadowPCF3x3(depthKernel, shadowMap, shadowParams);
+}
 
-    float getShadowPCF3x3(sampler2D shadowMap, vec3 shadowParams) {
-        return _getShadowPCF3x3(shadowMap, shadowParams);
-    }
+float getShadowPCF3x3(sampler2D shadowMap, vec3 shadowParams) {
+    return _getShadowPCF3x3(shadowMap, shadowParams);
+}
 
-    float getShadowSpotPCF3x3(sampler2D shadowMap, vec4 shadowParams) {
-        return _getShadowPCF3x3(shadowMap, shadowParams.xyz);
-    }
+float getShadowSpotPCF3x3(sampler2D shadowMap, vec4 shadowParams) {
+    return _getShadowPCF3x3(shadowMap, shadowParams.xyz);
+}
 #endif
 
 
@@ -180,4 +180,3 @@ float _getShadowPoint(samplerCube shadowMap, vec4 shadowParams, vec3 dir) {
 float getShadowPointPCF3x3(samplerCube shadowMap, vec4 shadowParams) {
     return _getShadowPoint(shadowMap, shadowParams, dLightDirW);
 }
-

--- a/src/graphics/program-lib/chunks/shadowStandardGL2VS.frag
+++ b/src/graphics/program-lib/chunks/shadowStandardGL2VS.frag
@@ -3,4 +3,3 @@ float getShadowPCF5x5VS(sampler2DShadow shadowMap, vec3 shadowParams) {
     dShadowCoord.z = saturate(dShadowCoord.z) - 0.0001; // prevent going to dark after the far plane
     return _getShadowPCF5x5(shadowMap, shadowParams);
 }
-

--- a/src/graphics/program-lib/chunks/shadowStandardVS.frag
+++ b/src/graphics/program-lib/chunks/shadowStandardVS.frag
@@ -9,9 +9,8 @@ float getShadowPCF3x3VS(SHADOW_SAMPLERVS shadowMap, vec3 shadowParams) {
     dShadowCoord.z = saturate(dShadowCoord.z) - 0.0001;
 
     #ifdef SHADOWBIAS
-        dShadowCoord.z += getShadowBias(shadowParams.x, shadowParams.z);
+    dShadowCoord.z += getShadowBias(shadowParams.x, shadowParams.z);
     #endif
 
     return _getShadowPCF3x3(shadowMap, shadowParams);
 }
-

--- a/src/graphics/program-lib/chunks/shadowVSMVS.frag
+++ b/src/graphics/program-lib/chunks/shadowVSMVS.frag
@@ -6,4 +6,3 @@ float getShadowVSM$VS(sampler2D shadowMap, vec3 shadowParams, float exponent) {
 
     return $VSM(shadowMap, dShadowCoord.xy, shadowParams.x, dShadowCoord.z, shadowParams.y, exponent);
 }
-

--- a/src/graphics/program-lib/chunks/shadowVSM_common.frag
+++ b/src/graphics/program-lib/chunks/shadowVSM_common.frag
@@ -3,7 +3,7 @@ float linstep(float a, float b, float v) {
 }
 
 float reduceLightBleeding(float pMax, float amount) {
-  // Remove the [0, amount] tail and linearly rescale (amount, 1].
+   // Remove the [0, amount] tail and linearly rescale (amount, 1].
    return linstep(amount, 1.0, pMax);
 }
 
@@ -33,4 +33,3 @@ float calculateEVSM(vec3 moments, float Z, float vsmBias, float exponent) {
     float minVariance1 = depthScale * depthScale;
     return chebyshevUpperBound(moments.xy, warpedDepth, minVariance1, 0.1);
 }
-

--- a/src/graphics/program-lib/chunks/skinBatchConst.vert
+++ b/src/graphics/program-lib/chunks/skinBatchConst.vert
@@ -1,8 +1,8 @@
 attribute float vertex_boneIndices;
+
 uniform vec4 matrix_pose[BONE_LIMIT * 3];
 
 mat4 getBoneMatrix(const in float i) {
-
     // read 4x3 matrix
     vec4 v1 = matrix_pose[int(3.0 * i)];
     vec4 v2 = matrix_pose[int(3.0 * i + 1.0)];
@@ -16,4 +16,3 @@ mat4 getBoneMatrix(const in float i) {
         v1.w, v2.w, v3.w, 1
     );
 }
-

--- a/src/graphics/program-lib/chunks/skinBatchTex.vert
+++ b/src/graphics/program-lib/chunks/skinBatchTex.vert
@@ -1,6 +1,8 @@
 attribute float vertex_boneIndices;
+
 uniform highp sampler2D texture_poseMap;
 uniform vec4 texture_poseMapSize;
+
 mat4 getBoneMatrix(const in float i) {
     float j = i * 3.0;
     float dx = texture_poseMapSize.z;
@@ -23,4 +25,3 @@ mat4 getBoneMatrix(const in float i) {
         v1.w, v2.w, v3.w, 1
     );
 }
-

--- a/src/graphics/program-lib/chunks/skinConst.vert
+++ b/src/graphics/program-lib/chunks/skinConst.vert
@@ -3,16 +3,14 @@ attribute vec4 vertex_boneIndices;
 
 uniform vec4 matrix_pose[BONE_LIMIT * 3];
 
-void getBoneMatrix(const in float i, out vec4 v1, out vec4 v2, out vec4 v3)
-{
+void getBoneMatrix(const in float i, out vec4 v1, out vec4 v2, out vec4 v3) {
     // read 4x3 matrix
     v1 = matrix_pose[int(3.0 * i)];
     v2 = matrix_pose[int(3.0 * i + 1.0)];
     v3 = matrix_pose[int(3.0 * i + 2.0)];
 }
 
-mat4 getSkinMatrix(const in vec4 indices, const in vec4 weights)
-{
+mat4 getSkinMatrix(const in vec4 indices, const in vec4 weights) {
     // get 4 bone matrices
     vec4 a1, a2, a3;
     getBoneMatrix(indices.x, a1, a2, a3);
@@ -42,4 +40,3 @@ mat4 getSkinMatrix(const in vec4 indices, const in vec4 weights)
         v1.w, v2.w, v3.w, one
     );
 }
-

--- a/src/graphics/program-lib/chunks/skinTex.vert
+++ b/src/graphics/program-lib/chunks/skinTex.vert
@@ -4,8 +4,7 @@ attribute vec4 vertex_boneIndices;
 uniform highp sampler2D texture_poseMap;
 uniform vec4 texture_poseMapSize;
 
-void getBoneMatrix(const in float i, out vec4 v1, out vec4 v2, out vec4 v3)
-{
+void getBoneMatrix(const in float i, out vec4 v1, out vec4 v2, out vec4 v3) {
     float j = i * 3.0;
     float dx = texture_poseMapSize.z;
     float dy = texture_poseMapSize.w;
@@ -20,8 +19,7 @@ void getBoneMatrix(const in float i, out vec4 v1, out vec4 v2, out vec4 v3)
     v3 = texture2D(texture_poseMap, vec2(dx * (x + 2.5), y));
 }
 
-mat4 getSkinMatrix(const in vec4 indices, const in vec4 weights)
-{
+mat4 getSkinMatrix(const in vec4 indices, const in vec4 weights) {
     // get 4 bone matrices
     vec4 a1, a2, a3;
     getBoneMatrix(indices.x, a1, a2, a3);
@@ -51,4 +49,3 @@ mat4 getSkinMatrix(const in vec4 indices, const in vec4 weights)
         v1.w, v2.w, v3.w, one
     );
 }
-

--- a/src/graphics/program-lib/chunks/skybox.frag
+++ b/src/graphics/program-lib/chunks/skybox.frag
@@ -1,7 +1,7 @@
 varying vec3 vViewDir;
+
 uniform samplerCube texture_cubeMap;
 
 void main(void) {
     gl_FragColor = textureCube(texture_cubeMap, fixSeams(vViewDir));
 }
-

--- a/src/graphics/program-lib/chunks/skybox.vert
+++ b/src/graphics/program-lib/chunks/skybox.vert
@@ -9,8 +9,7 @@ uniform mat4 matrix_projectionSkybox;
 
 varying vec3 vViewDir;
 
-void main(void)
-{
+void main(void) {
     mat4 view = matrix_view;
     view[3][0] = view[3][1] = view[3][2] = 0.0;
     gl_Position = matrix_projectionSkybox * view * vec4(aPosition, 1.0);
@@ -24,4 +23,3 @@ void main(void)
     vViewDir = aPosition;
     vViewDir.x *= -1.0;
 }
-

--- a/src/graphics/program-lib/chunks/skyboxHDR.frag
+++ b/src/graphics/program-lib/chunks/skyboxHDR.frag
@@ -1,4 +1,5 @@
 varying vec3 vViewDir;
+
 uniform samplerCube texture_cubeMap;
 
 void main(void) {
@@ -7,4 +8,3 @@ void main(void) {
     color = gammaCorrectOutput(color);
     gl_FragColor = vec4(color, 1.0);
 }
-

--- a/src/graphics/program-lib/chunks/skyboxPrefilteredCube.frag
+++ b/src/graphics/program-lib/chunks/skyboxPrefilteredCube.frag
@@ -1,4 +1,5 @@
 varying vec3 vViewDir;
+
 uniform samplerCube texture_cubeMap;
 
 vec3 fixSeamsStretch(vec3 vec, float mipmapIndex, float cubemapSize) {
@@ -16,4 +17,3 @@ void main(void) {
     color = gammaCorrectOutput(color);
     gl_FragColor = vec4(color, 1.0);
 }
-

--- a/src/graphics/program-lib/chunks/specular.frag
+++ b/src/graphics/program-lib/chunks/specular.frag
@@ -14,20 +14,19 @@ void getSpecularity() {
     dSpecularity = vec3(1.0);
 
     #ifdef MAPCOLOR
-        dSpecularity *= material_specular;
+    dSpecularity *= material_specular;
     #endif
 
     #ifdef MAPTEXTURE
-        dSpecularity *= texture2D(texture_specularMap, $UV).$CH;
+    dSpecularity *= texture2D(texture_specularMap, $UV).$CH;
     #endif
 
     #ifdef MAPVERTEX
-        dSpecularity *= saturate(vVertexColor.$VC);
+    dSpecularity *= saturate(vVertexColor.$VC);
     #endif
 
     #ifdef CLEARCOAT
-        ccSpecularity = vec3(1.0);
-        ccSpecularity *= material_clearCoatSpecularity;
+    ccSpecularity = vec3(1.0);
+    ccSpecularity *= material_clearCoatSpecularity;
     #endif
 }
-

--- a/src/graphics/program-lib/chunks/specularAaNone.frag
+++ b/src/graphics/program-lib/chunks/specularAaNone.frag
@@ -1,4 +1,3 @@
 float antiAliasGlossiness(float power) {
     return power;
 }
-

--- a/src/graphics/program-lib/chunks/specularAaToksvig.frag
+++ b/src/graphics/program-lib/chunks/specularAaToksvig.frag
@@ -3,4 +3,3 @@ float antiAliasGlossiness(float power) {
     float toksvig = 1.0 / (1.0 + power * (rlen - 1.0));
     return power * mix(1.0, toksvig, material_bumpiness);
 }
-

--- a/src/graphics/program-lib/chunks/specularAaToksvigFast.frag
+++ b/src/graphics/program-lib/chunks/specularAaToksvigFast.frag
@@ -3,4 +3,3 @@ float antiAliasGlossiness(float power) {
     float toksvig = 1.0 / (1.0 + power * (rlen - 1.0));
     return power * toksvig;
 }
-

--- a/src/graphics/program-lib/chunks/spot.frag
+++ b/src/graphics/program-lib/chunks/spot.frag
@@ -2,4 +2,3 @@ float getSpotEffect(vec3 lightSpotDirW, float lightInnerConeAngle, float lightOu
     float cosAngle = dot(dLightDirNormW, lightSpotDirW);
     return smoothstep(lightOuterConeAngle, lightInnerConeAngle, cosAngle);
 }
-

--- a/src/graphics/program-lib/chunks/start.frag
+++ b/src/graphics/program-lib/chunks/start.frag
@@ -5,7 +5,7 @@ void main(void) {
     dSpecularity = vec3(0);
 
     #ifdef CLEARCOAT
-        ccSpecularLight = vec3(0);
-        ccReflection = vec4(0);
-        ccSpecularity = vec3(0);
+    ccSpecularLight = vec3(0);
+    ccReflection = vec4(0);
+    ccSpecularity = vec3(0);
     #endif

--- a/src/graphics/program-lib/chunks/start.frag
+++ b/src/graphics/program-lib/chunks/start.frag
@@ -1,12 +1,11 @@
-
 void main(void) {
     dDiffuseLight = vec3(0);
     dSpecularLight = vec3(0);
     dReflection = vec4(0);
     dSpecularity = vec3(0);
+
     #ifdef CLEARCOAT
         ccSpecularLight = vec3(0);
         ccReflection = vec4(0);
         ccSpecularity = vec3(0);
     #endif
-    

--- a/src/graphics/program-lib/chunks/start.vert
+++ b/src/graphics/program-lib/chunks/start.vert
@@ -1,3 +1,2 @@
-
 void main(void) {
     gl_Position = getPosition();

--- a/src/graphics/program-lib/chunks/startNineSliced.frag
+++ b/src/graphics/program-lib/chunks/startNineSliced.frag
@@ -1,2 +1,1 @@
     nineSlicedUv = vUv0;
-

--- a/src/graphics/program-lib/chunks/startNineSlicedTiled.frag
+++ b/src/graphics/program-lib/chunks/startNineSlicedTiled.frag
@@ -1,6 +1,4 @@
-
     vec2 tileMask = step(vMask, vec2(0.99999));
     vec2 clampedUv = mix(innerOffset.xy*0.5, vec2(1.0) - innerOffset.zw*0.5, fract(vTiledUv));
     clampedUv = clampedUv * atlasRect.zw + atlasRect.xy;
     nineSlicedUv = vUv0 * tileMask + clampedUv * (vec2(1.0) - tileMask);
-

--- a/src/graphics/program-lib/chunks/storeEVSM.frag
+++ b/src/graphics/program-lib/chunks/storeEVSM.frag
@@ -3,4 +3,3 @@ float exponent = VSM_EXPONENT;
 depth = 2.0 * depth - 1.0;
 depth =  exp(exponent * depth);
 gl_FragColor = vec4(depth, depth*depth, 1.0, 1.0);
-

--- a/src/graphics/program-lib/chunks/tangentBinormal.vert
+++ b/src/graphics/program-lib/chunks/tangentBinormal.vert
@@ -1,4 +1,3 @@
-
 vec3 getTangent() {
     return normalize(dNormalMatrix * vertex_tangent.xyz);
 }
@@ -10,4 +9,3 @@ vec3 getBinormal() {
 vec3 getObjectSpaceUp() {
     return normalize(dNormalMatrix * vec3(0, 1, 0));
 }
-

--- a/src/graphics/program-lib/chunks/tonemappingFilmic.frag
+++ b/src/graphics/program-lib/chunks/tonemappingFilmic.frag
@@ -19,4 +19,3 @@ vec3 toneMap(vec3 color) {
 
     return color;
 }
-

--- a/src/graphics/program-lib/chunks/tonemappingHejl.frag
+++ b/src/graphics/program-lib/chunks/tonemappingHejl.frag
@@ -8,4 +8,3 @@ vec3 toneMap(vec3 color) {
     vec3 h = max( vec3(0.0), color - vec3(0.004) );
     return (h*((Scl*A)*h+Scl*vec3(C*B,C*B,C*B))+Scl*vec3(D*E,D*E,D*E)) / (h*(A*h+vec3(B,B,B))+vec3(D*F,D*F,D*F)) - Scl*vec3(E/F,E/F,E/F);
 }
-

--- a/src/graphics/program-lib/chunks/tonemappingLinear.frag
+++ b/src/graphics/program-lib/chunks/tonemappingLinear.frag
@@ -1,5 +1,5 @@
 uniform float exposure;
+
 vec3 toneMap(vec3 color) {
     return color * exposure;
 }
-

--- a/src/graphics/program-lib/chunks/tonemappingNone.frag
+++ b/src/graphics/program-lib/chunks/tonemappingNone.frag
@@ -1,4 +1,3 @@
 vec3 toneMap(vec3 color) {
     return color;
 }
-

--- a/src/graphics/program-lib/chunks/transform.vert
+++ b/src/graphics/program-lib/chunks/transform.vert
@@ -1,42 +1,42 @@
 #ifdef PIXELSNAP
-    uniform vec4 uScreenSize;
+uniform vec4 uScreenSize;
 #endif
 
 #ifdef MORPHING
-    uniform vec4 morph_weights_a;
-    uniform vec4 morph_weights_b;
+uniform vec4 morph_weights_a;
+uniform vec4 morph_weights_b;
 #endif
 
 #ifdef MORPHING_TEXTURE_BASED
-    uniform vec4 morph_tex_params;
+uniform vec4 morph_tex_params;
 
-    vec2 getTextureMorphCoords() {
-        float vertexId = morph_vertex_id;
-        vec2 textureSize = morph_tex_params.xy;
-        vec2 invTextureSize = morph_tex_params.zw;
+vec2 getTextureMorphCoords() {
+    float vertexId = morph_vertex_id;
+    vec2 textureSize = morph_tex_params.xy;
+    vec2 invTextureSize = morph_tex_params.zw;
 
-        // turn vertexId into int grid coordinates
-        float morphGridV = floor(vertexId * invTextureSize.x);
-        float morphGridU = vertexId - (morphGridV * textureSize.x);
+    // turn vertexId into int grid coordinates
+    float morphGridV = floor(vertexId * invTextureSize.x);
+    float morphGridU = vertexId - (morphGridV * textureSize.x);
 
-        // convert grid coordinates to uv coordinates with half pixel offset
-        return (vec2(morphGridU, morphGridV) * invTextureSize) + (0.5 * invTextureSize);
-    }
+    // convert grid coordinates to uv coordinates with half pixel offset
+    return (vec2(morphGridU, morphGridV) * invTextureSize) + (0.5 * invTextureSize);
+}
 #endif
 
 #ifdef MORPHING_TEXTURE_BASED_POSITION
-    uniform highp sampler2D morphPositionTex;
+uniform highp sampler2D morphPositionTex;
 #endif
 
 mat4 getModelMatrix() {
     #ifdef DYNAMICBATCH
-        return getBoneMatrix(vertex_boneIndices);
+    return getBoneMatrix(vertex_boneIndices);
     #elif defined(SKIN)
-        return matrix_model * getSkinMatrix(vertex_boneIndices, vertex_boneWeights);
+    return matrix_model * getSkinMatrix(vertex_boneIndices, vertex_boneWeights);
     #elif defined(INSTANCING)
-        return mat4(instance_line1, instance_line2, instance_line3, instance_line4);
+    return mat4(instance_line1, instance_line2, instance_line3, instance_line4);
     #else
-        return matrix_model;
+    return matrix_model;
     #endif
 }
 
@@ -45,67 +45,67 @@ vec4 getPosition() {
     vec3 localPos = vertex_position;
 
     #ifdef NINESLICED
-        // outer and inner vertices are at the same position, scale both
-        localPos.xz *= outerScale;
+    // outer and inner vertices are at the same position, scale both
+    localPos.xz *= outerScale;
 
-        // offset inner vertices inside
-        // (original vertices must be in [-1;1] range)
-        vec2 positiveUnitOffset = clamp(vertex_position.xz, vec2(0.0), vec2(1.0));
-        vec2 negativeUnitOffset = clamp(-vertex_position.xz, vec2(0.0), vec2(1.0));
-        localPos.xz += (-positiveUnitOffset * innerOffset.xy + negativeUnitOffset * innerOffset.zw) * vertex_texCoord0.xy;
+    // offset inner vertices inside
+    // (original vertices must be in [-1;1] range)
+    vec2 positiveUnitOffset = clamp(vertex_position.xz, vec2(0.0), vec2(1.0));
+    vec2 negativeUnitOffset = clamp(-vertex_position.xz, vec2(0.0), vec2(1.0));
+    localPos.xz += (-positiveUnitOffset * innerOffset.xy + negativeUnitOffset * innerOffset.zw) * vertex_texCoord0.xy;
 
-        vTiledUv = (localPos.xz - outerScale + innerOffset.xy) * -0.5 + 1.0; // uv = local pos - inner corner
+    vTiledUv = (localPos.xz - outerScale + innerOffset.xy) * -0.5 + 1.0; // uv = local pos - inner corner
 
-        localPos.xz *= -0.5; // move from -1;1 to -0.5;0.5
-        localPos = localPos.xzy;
+    localPos.xz *= -0.5; // move from -1;1 to -0.5;0.5
+    localPos = localPos.xzy;
     #endif
 
     #ifdef MORPHING
-        #ifdef MORPHING_POS03
-            localPos.xyz += morph_weights_a[0] * morph_pos0;
-            localPos.xyz += morph_weights_a[1] * morph_pos1;
-            localPos.xyz += morph_weights_a[2] * morph_pos2;
-            localPos.xyz += morph_weights_a[3] * morph_pos3;
-        #endif
-        #ifdef MORPHING_POS47
-            localPos.xyz += morph_weights_b[0] * morph_pos4;
-            localPos.xyz += morph_weights_b[1] * morph_pos5;
-            localPos.xyz += morph_weights_b[2] * morph_pos6;
-            localPos.xyz += morph_weights_b[3] * morph_pos7;
-        #endif
-    #endif
+    #ifdef MORPHING_POS03
+    localPos.xyz += morph_weights_a[0] * morph_pos0;
+    localPos.xyz += morph_weights_a[1] * morph_pos1;
+    localPos.xyz += morph_weights_a[2] * morph_pos2;
+    localPos.xyz += morph_weights_a[3] * morph_pos3;
+    #endif // MORPHING_POS03
+    #ifdef MORPHING_POS47
+    localPos.xyz += morph_weights_b[0] * morph_pos4;
+    localPos.xyz += morph_weights_b[1] * morph_pos5;
+    localPos.xyz += morph_weights_b[2] * morph_pos6;
+    localPos.xyz += morph_weights_b[3] * morph_pos7;
+    #endif // MORPHING_POS47
+    #endif // MORPHING
 
     #ifdef MORPHING_TEXTURE_BASED_POSITION
-        // apply morph offset from texture
-        vec2 morphUV = getTextureMorphCoords();
-        vec3 morphPos = texture2D(morphPositionTex, morphUV).xyz;
-        localPos += morphPos;
+    // apply morph offset from texture
+    vec2 morphUV = getTextureMorphCoords();
+    vec3 morphPos = texture2D(morphPositionTex, morphUV).xyz;
+    localPos += morphPos;
     #endif
 
     vec4 posW = dModelMatrix * vec4(localPos, 1.0);
     #ifdef SCREENSPACE
-        posW.zw = vec2(0.0, 1.0);
+    posW.zw = vec2(0.0, 1.0);
     #endif
     dPositionW = posW.xyz;
 
     vec4 screenPos;
     #ifdef UV1LAYOUT
-        screenPos = vec4(vertex_texCoord1.xy * 2.0 - 1.0, 0.5, 1);
+    screenPos = vec4(vertex_texCoord1.xy * 2.0 - 1.0, 0.5, 1);
     #else
-        #ifdef SCREENSPACE
-            screenPos = posW;
-        #else
-            screenPos = matrix_viewProjection * posW;
-        #endif
+    #ifdef SCREENSPACE
+    screenPos = posW;
+    #else
+    screenPos = matrix_viewProjection * posW;
+    #endif
 
-        #ifdef PIXELSNAP
-            // snap vertex to a pixel boundary
-            screenPos.xy = (screenPos.xy * 0.5) + 0.5;
-            screenPos.xy *= uScreenSize.xy;
-            screenPos.xy = floor(screenPos.xy);
-            screenPos.xy *= uScreenSize.zw;
-            screenPos.xy = (screenPos.xy * 2.0) - 1.0;
-        #endif
+    #ifdef PIXELSNAP
+    // snap vertex to a pixel boundary
+    screenPos.xy = (screenPos.xy * 0.5) + 0.5;
+    screenPos.xy *= uScreenSize.xy;
+    screenPos.xy = floor(screenPos.xy);
+    screenPos.xy *= uScreenSize.zw;
+    screenPos.xy = (screenPos.xy * 2.0) - 1.0;
+    #endif
     #endif
 
     return screenPos;

--- a/src/graphics/program-lib/chunks/transformDecl.vert
+++ b/src/graphics/program-lib/chunks/transformDecl.vert
@@ -1,7 +1,7 @@
 attribute vec3 vertex_position;
+
 uniform mat4 matrix_model;
 uniform mat4 matrix_viewProjection;
 
 vec3 dPositionW;
 mat4 dModelMatrix;
-

--- a/src/graphics/program-lib/chunks/uv0.vert
+++ b/src/graphics/program-lib/chunks/uv0.vert
@@ -20,4 +20,3 @@ vec2 getUv0() {
     return vertex_texCoord0;
 }
 #endif
-

--- a/src/graphics/program-lib/chunks/uv1.vert
+++ b/src/graphics/program-lib/chunks/uv1.vert
@@ -1,4 +1,3 @@
-
 vec2 getUv1() {
     return vertex_texCoord1;
 }

--- a/src/graphics/program-lib/chunks/viewDir.frag
+++ b/src/graphics/program-lib/chunks/viewDir.frag
@@ -1,4 +1,3 @@
 void getViewDir() {
     dViewDirW = normalize(view_position - vPositionW);
 }
-

--- a/src/graphics/program-lib/chunks/viewNormal.vert
+++ b/src/graphics/program-lib/chunks/viewNormal.vert
@@ -1,4 +1,3 @@
-
 #ifndef VIEWMATRIX
 #define VIEWMATRIX
 uniform mat4 matrix_view;


### PR DESCRIPTION
Process GLSL chunks to:

* remove comments
* remove carriage returns
* swap 4 spaces for tabs.

Reduces gzipped engine size by 4KB (~1.5%).

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
