### PR TITLE
[FIX] Don’t capture Index Buffer in VAO

### DIFF
--- a/src/graphics/device.js
+++ b/src/graphics/device.js
@@ -2160,6 +2160,10 @@ Object.assign(GraphicsDevice.prototype, {
             vao = gl.createVertexArray();
             gl.bindVertexArray(vao);
 
+            // don't capture index buffer in VAO
+            gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, null);
+            this.boundElementBuffer = null;
+
             var e, elements;
             for (i = 0; i < vertexBuffers.length; i++) {
 


### PR DESCRIPTION
fixes rendering with VAOs mentioned in https://github.com/playcanvas/engine/pull/2250