### PR TITLE
fix material resource loader

### DIFF
--- a/src/resources/material.js
+++ b/src/resources/material.js
@@ -300,7 +300,7 @@ Object.assign(MaterialHandler.prototype, {
                 }
 
                 if (assetReference.asset) {
-                    if (assetReference.asset.resource) {
+                    if (assetReference.asset.loaded) {
                         // asset loaded
                         this._assignCubemap(name, materialAsset, assetReference.asset.resources);
                     }


### PR DESCRIPTION
Fixes #2262

The material handler checks for the presence of the cubemap faces but should instead be checking the asset.loaded flag.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
