### PR TITLE
Remove type function

### DIFF
--- a/src/framework/components/camera/system.js
+++ b/src/framework/components/camera/system.js
@@ -1,4 +1,3 @@
-import { type } from '../../../core/core.js';
 import { Color } from '../../../core/color.js';
 
 import { Vec4 } from '../../../math/vec4.js';
@@ -113,21 +112,21 @@ Object.assign(CameraComponentSystem.prototype, {
             data[property] = _data[property];
         }
 
-        if (data.layers && type(data.layers) === 'array') {
+        if (data.layers && Array.isArray(data.layers)) {
             data.layers = data.layers.slice(0);
         }
 
-        if (data.clearColor && type(data.clearColor) === 'array') {
+        if (data.clearColor && Array.isArray(data.clearColor)) {
             var c = data.clearColor;
             data.clearColor = new Color(c[0], c[1], c[2], c[3]);
         }
 
-        if (data.rect && type(data.rect) === 'array') {
+        if (data.rect && Array.isArray(data.rect)) {
             var rect = data.rect;
             data.rect = new Vec4(rect[0], rect[1], rect[2], rect[3]);
         }
 
-        if (data.scissorRect && type(data.scissorRect) === 'array') {
+        if (data.scissorRect && Array.isArray(data.scissorRect)) {
             var scissorRect = data.scissorRect;
             data.scissorRect = new Vec4(scissorRect[0], scissorRect[1], scissorRect[2], scissorRect[3]);
         }

--- a/src/framework/components/collision/system.js
+++ b/src/framework/components/collision/system.js
@@ -1,5 +1,3 @@
-import { type } from '../../../core/core.js';
-
 import { Mat4 } from '../../../math/mat4.js';
 import { Quat } from '../../../math/quat.js';
 import { Vec3 } from '../../../math/vec3.js';
@@ -641,7 +639,7 @@ Object.assign(CollisionComponentSystem.prototype, {
         }
         component.data.type = data.type;
 
-        if (data.halfExtents && type(data.halfExtents) === 'array') {
+        if (data.halfExtents && Array.isArray(data.halfExtents)) {
             data.halfExtents = new Vec3(data.halfExtents[0], data.halfExtents[1], data.halfExtents[2]);
         }
 

--- a/src/framework/components/element/system.js
+++ b/src/framework/components/element/system.js
@@ -1,4 +1,3 @@
-import { type } from '../../../core/core.js';
 import { Color } from '../../../core/color.js';
 
 import { Vec2 } from '../../../math/vec2.js';
@@ -173,7 +172,7 @@ Object.assign(ElementComponentSystem.prototype, {
 
         component.batchGroupId = data.batchGroupId === undefined || data.batchGroupId === null ? -1 : data.batchGroupId;
 
-        if (data.layers && type(data.layers) === 'array') {
+        if (data.layers && Array.isArray(data.layers)) {
             component.layers = data.layers.slice(0);
         }
 

--- a/src/framework/components/light/system.js
+++ b/src/framework/components/light/system.js
@@ -1,4 +1,3 @@
-import { type } from '../../../core/core.js';
 import { Color } from '../../../core/color.js';
 
 import { Vec2 } from '../../../math/vec2.js';
@@ -54,11 +53,11 @@ Object.assign(LightComponentSystem.prototype, {
 
         component.data.type = data.type;
 
-        if (data.layers && type(data.layers) === 'array') {
+        if (data.layers && Array.isArray(data.layers)) {
             data.layers = data.layers.slice(0);
         }
 
-        if (data.color && type(data.color) === 'array')
+        if (data.color && Array.isArray(data.color))
             data.color = new Color(data.color[0], data.color[1], data.color[2]);
 
         if (data.cookieOffset && data.cookieOffset instanceof Array)

--- a/src/framework/components/particle-system/system.js
+++ b/src/framework/components/particle-system/system.js
@@ -1,5 +1,3 @@
-import { type } from '../../../core/core.js';
-
 import { Curve } from '../../../math/curve.js';
 import { CurveSet } from '../../../math/curve-set.js';
 import { Vec3 } from '../../../math/vec3.js';
@@ -151,7 +149,7 @@ Object.assign(ParticleSystemComponentSystem.prototype, {
             }
 
             if (types[prop] === 'vec3') {
-                if (type(data[prop]) === 'array') {
+                if (Array.isArray(data[prop])) {
                     data[prop] = new Vec3(data[prop][0], data[prop][1], data[prop][2]);
                 }
             } else if (types[prop] === 'curve') {
@@ -169,7 +167,7 @@ Object.assign(ParticleSystemComponentSystem.prototype, {
             }
 
             // duplicate layer list
-            if (data.layers && type(data.layers) === 'array') {
+            if (data.layers && Array.isArray(data.layers)) {
                 data.layers = data.layers.slice(0);
             }
         }

--- a/src/framework/components/rigid-body/system.js
+++ b/src/framework/components/rigid-body/system.js
@@ -1,5 +1,4 @@
 import { now } from '../../../core/time.js';
-import { type } from '../../../core/core.js';
 import { AllocatePool } from '../../../core/object-pool.js';
 
 import { Vec3 } from '../../../math/vec3.js';
@@ -238,10 +237,10 @@ Object.assign(RigidBodyComponentSystem.prototype, {
             // #endif
         }
 
-        if (data.linearFactor && type(data.linearFactor) === 'array') {
+        if (data.linearFactor && Array.isArray(data.linearFactor)) {
             data.linearFactor = new Vec3(data.linearFactor[0], data.linearFactor[1], data.linearFactor[2]);
         }
-        if (data.angularFactor && type(data.angularFactor) === 'array') {
+        if (data.angularFactor && Array.isArray(data.angularFactor)) {
             data.angularFactor = new Vec3(data.angularFactor[0], data.angularFactor[1], data.angularFactor[2]);
         }
 

--- a/src/framework/components/script-legacy/system.js
+++ b/src/framework/components/script-legacy/system.js
@@ -1,4 +1,4 @@
-import { extend, makeArray, type } from '../../../core/core.js';
+import { extend, makeArray } from '../../../core/core.js';
 import { events } from '../../../core/events.js';
 import { Color } from '../../../core/color.js';
 
@@ -71,7 +71,7 @@ Object.assign(ScriptLegacyComponentSystem.prototype, {
         // convert attributes array to dictionary
         if (data.scripts && data.scripts.length) {
             data.scripts.forEach(function (script) {
-                if (script.attributes && type(script.attributes) === 'array') {
+                if (script.attributes && Array.isArray(script.attributes)) {
                     var dict = {};
                     for (var i = 0; i < script.attributes.length; i++) {
                         dict[script.attributes[i].name] = script.attributes[i];
@@ -492,21 +492,21 @@ Object.assign(ScriptLegacyComponentSystem.prototype, {
 
     _convertAttributeValue: function (attribute) {
         if (attribute.type === 'rgb' || attribute.type === 'rgba') {
-            if (type(attribute.value) === 'array') {
+            if (Array.isArray(attribute.value)) {
                 attribute.value = attribute.value.length === 3 ?
                     new Color(attribute.value[0], attribute.value[1], attribute.value[2]) :
                     new Color(attribute.value[0], attribute.value[1], attribute.value[2], attribute.value[3]);
             }
         } else if (attribute.type === 'vec2') {
-            if (type(attribute.value) === 'array')
+            if (Array.isArray(attribute.value))
                 attribute.value = new Vec2(attribute.value[0], attribute.value[1]);
 
         } else if (attribute.type === 'vec3' || attribute.type === 'vector') {
-            if (type(attribute.value) === 'array')
+            if (Array.isArray(attribute.value))
                 attribute.value = new Vec3(attribute.value[0], attribute.value[1], attribute.value[2]);
 
         } else if (attribute.type === 'vec4') {
-            if (type(attribute.value) === 'array')
+            if (Array.isArray(attribute.value))
                 attribute.value = new Vec4(attribute.value[0], attribute.value[1], attribute.value[2], attribute.value[3]);
 
         } else if (attribute.type === 'entity') {

--- a/src/framework/components/sprite/system.js
+++ b/src/framework/components/sprite/system.js
@@ -1,4 +1,3 @@
-import { type } from '../../../core/core.js';
 import { Color } from '../../../core/color.js';
 
 import {
@@ -144,7 +143,7 @@ Object.assign(SpriteComponentSystem.prototype, {
 
         component.type = data.type;
 
-        if (data.layers && type(data.layers) === 'array') {
+        if (data.layers && Array.isArray(data.layers)) {
             component.layers = data.layers.slice(0);
         }
 

--- a/src/math/curve-set.js
+++ b/src/math/curve-set.js
@@ -1,5 +1,3 @@
-import { type } from '../core/core.js';
-
 import { CURVE_SMOOTHSTEP } from './constants.js';
 import { Curve } from './curve.js';
 import { CurveEvaluator } from './curve-evaluator.js';
@@ -27,7 +25,7 @@ function CurveSet() {
             this.curves.push(new Curve());
         } else {
             var arg = arguments[0];
-            if (type(arg) === 'number') {
+            if (typeof arg === 'number') {
                 for (i = 0; i < arg; i++) {
                     this.curves.push(new Curve());
                 }


### PR DESCRIPTION
Various places in the codebase use the `type` function defined in `core.js`. However, it's faster, more succinct and more readable to just use alternatives like `Array.isArray` and `typeof` directly.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
