### PR TITLE
Glb-parser improvements

### DIFF
--- a/src/resources/parser/glb-parser.js
+++ b/src/resources/parser/glb-parser.js
@@ -1311,16 +1311,26 @@ var createNodes = function (gltf, options) {
 var createScenes = function (gltf, nodes) {
 
     var scenes = [];
-    for (var i = 0; i < gltf.scenes.length; i++) {
-        var scene = gltf.scenes[i];
-        var sceneRoot = new GraphNode(scene.name);
+    var count = gltf.scenes.length;
 
-        for (var n = 0; n < scene.nodes.length; n++) {
-            var childNode = nodes[scene.nodes[n]];
-            sceneRoot.addChild(childNode);
+    // if there's a single scene with a single node in it, don't create wrapper nodes
+    if (count === 1 && gltf.scenes[0].nodes.length === 1) {
+        var nodeIndex = gltf.scenes[0].nodes[0];
+        scenes.push(nodes[nodeIndex]);
+    } else {
+
+        // create root node per scene
+        for (var i = 0; i < count; i++) {
+            var scene = gltf.scenes[i];
+            var sceneRoot = new GraphNode(scene.name);
+
+            for (var n = 0; n < scene.nodes.length; n++) {
+                var childNode = nodes[scene.nodes[n]];
+                sceneRoot.addChild(childNode);
+            }
+
+            scenes.push(sceneRoot);
         }
-
-        scenes.push(sceneRoot);
     }
 
     return scenes;

--- a/src/resources/parser/glb-parser.js
+++ b/src/resources/parser/glb-parser.js
@@ -1811,26 +1811,10 @@ GlbParser.createModel = function (glb, defaultMaterial) {
         }
     }
 
-    // function to mark nodes in hierarchy with a property
-    var markNodes = function (node, name, value) {
-        if (value) {
-            node[name] = true;  // add property
-        } else {
-            delete node[name];  // remove property
-        }
-        for (var idx = 0; idx < node._children.length; idx++) {
-            markNodes(node._children[idx], name, value);
-        }
-    };
-
-    // temporarily mark nodes in hierarchy as used
-    var markName = "__tempNodeUsed";
-    markNodes(model.graph, markName, true);
-
     // create mesh instance for meshes on nodes that are part of hierarchy
     for (var i = 0; i < glb.nodes.length; i++) {
         var node = glb.nodes[i];
-        if (node.__tempNodeUsed) {
+        if (node.root === model.graph) {
             var gltfNode = glb.gltf.nodes[i];
             if (gltfNode.hasOwnProperty('mesh')) {
                 var meshGroup = glb.meshes[gltfNode.mesh];
@@ -1840,9 +1824,6 @@ GlbParser.createModel = function (glb, defaultMaterial) {
             }
         }
     }
-
-    // remove marks
-    markNodes(model.graph, markName, false);
 
     return model;
 };


### PR DESCRIPTION
Changes to glb-parser:
- using scenes from gltf instead of assuming all nodes without parent are roots
- not creating MeshInstances for nodes that are not part of the scene, as we end up with MeshInstance with undefined nodes and crash rendering (Fixes https://github.com/playcanvas/playcanvas-gltf/issues/100)
- creating single SkinInstances for each Skin instead of per MeshInstance to drop number of bone Matrices engine needs to handle 

