### PR TITLE
[FIX] Make Transform Feedback work with VAOs

### DIFF
--- a/src/graphics/transform-feedback.js
+++ b/src/graphics/transform-feedback.js
@@ -150,6 +150,11 @@ Object.assign(TransformFeedback.prototype, {
             var tmp = this._inputBuffer.bufferId;
             this._inputBuffer.bufferId = this._outputBuffer.bufferId;
             this._outputBuffer.bufferId = tmp;
+
+            // swap VAO
+            tmp = this._inputBuffer._vao;
+            this._inputBuffer._vao = this._outputBuffer._vao;
+            this._outputBuffer._vao = tmp;
         }
     }
 });


### PR DESCRIPTION
- transform feedback is switching bufferIds of VertexBuffers, and so needs to swap _vao as well.