### PR TITLE
[FIX] Cubemap filtering on safari

### DIFF
--- a/src/resources/cubemap.js
+++ b/src/resources/cubemap.js
@@ -119,7 +119,9 @@ Object.assign(CubemapHandler.prototype, {
                         height: tex.height >> i,
                         format: tex.format,
                         levels: prelitLevels,
-                        fixCubemapSeams: true
+                        fixCubemapSeams: true,
+                        addressU: ADDRESS_CLAMP_TO_EDGE,
+                        addressV: ADDRESS_CLAMP_TO_EDGE
                     });
 
                     resources[i + 1] = prelit;


### PR DESCRIPTION
Explicitly set cubemap filtering on safari.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
