### PR TITLE
Deprecate pc.makeArray

### DIFF
--- a/src/core/core.js
+++ b/src/core/core.js
@@ -30,27 +30,6 @@ var data = { }; // Storage for exported entity data
 /**
  * @private
  * @function
- * @name pc.makeArray
- * @description Convert an array-like object into a normal array.
- * For example, this is useful for converting the arguments object into an array.
- * @param {object} arr - The array to convert.
- * @returns {Array} An array.
- */
-function makeArray(arr) {
-    var i,
-        ret = [],
-        length = arr.length;
-
-    for (i = 0; i < length; ++i) {
-        ret.push(arr[i]);
-    }
-
-    return ret;
-}
-
-/**
- * @private
- * @function
  * @name pc.type
  * @description Extended typeof() function, returns the type of the object.
  * @param {object} obj - The object to get the type of.
@@ -127,4 +106,4 @@ function isDefined(o) {
     return (o !== a);
 }
 
-export { apps, common, config, data, extend, isDefined, makeArray, revision, type, version };
+export { apps, common, config, data, extend, isDefined, revision, type, version };

--- a/src/deprecated.js
+++ b/src/deprecated.js
@@ -129,6 +129,13 @@ export function inherits(Self, Super) {
     return Func;
 }
 
+export function makeArray(arr) {
+    // #ifdef DEBUG
+    console.warn('pc.makeArray is not public API and should not be used. Use Array.prototype.slice.call instead.');
+    // #endif
+    return Array.prototype.slice.call(arr);
+}
+
 // MATH
 import { math } from './math/math.js';
 import { Vec2 } from './math/vec2.js';

--- a/src/framework/components/script-legacy/component.js
+++ b/src/framework/components/script-legacy/component.js
@@ -1,4 +1,3 @@
-import { makeArray } from '../../../core/core.js';
 import { path } from '../../../core/path.js';
 
 import { Component } from '../component.js';
@@ -13,8 +12,10 @@ ScriptLegacyComponent.prototype.constructor = ScriptLegacyComponent;
 
 Object.assign(ScriptLegacyComponent.prototype, {
     send: function (name, functionName) {
+        // #ifdef DEBUG
         console.warn("DEPRECATED: ScriptLegacyComponent.send() is deprecated and will be removed soon. Please use: http://developer.playcanvas.com/user-manual/scripting/communication/");
-        var args = makeArray(arguments).slice(2);
+        // #endif
+        var args = Array.prototype.slice.call(arguments, 2);
         var instances = this.entity.script.instances;
         var fn;
 

--- a/src/framework/components/script-legacy/system.js
+++ b/src/framework/components/script-legacy/system.js
@@ -1,4 +1,4 @@
-import { extend, makeArray } from '../../../core/core.js';
+import { extend } from '../../../core/core.js';
 import { events } from '../../../core/events.js';
 import { Color } from '../../../core/color.js';
 
@@ -268,12 +268,13 @@ Object.assign(ScriptLegacyComponentSystem.prototype, {
     },
 
     broadcast: function (name, functionName) {
+        // #ifdef DEBUG
         console.warn("DEPRECATED: ScriptLegacyComponentSystem.broadcast() is deprecated and will be removed soon. Please use: http://developer.playcanvas.com/user-manual/scripting/communication/");
-        var args = makeArray(arguments).slice(2);
+        // #endif
+        var args = Array.prototype.slice.call(arguments, 2);
 
         var id, data, fn;
         var dataStore = this.store;
-        // var results = [];
 
         for (id in dataStore) {
             if (dataStore.hasOwnProperty(id)) {

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ import './polyfill/string.js';
 import './polyfill/OESVertexArrayObject.js';
 
 // CORE
-export { apps, common, config, data, extend, isDefined, makeArray, revision, type, version } from './core/core.js';
+export { apps, common, config, data, extend, isDefined, revision, type, version } from './core/core.js';
 export { debug } from './core/debug.js';
 export { events } from './core/events.js';
 export { guid } from './core/guid.js';


### PR DESCRIPTION
`pc.makeArray` is private API. But it's pretty useless considering its behavior can be achieved with `Array.prototype.slice.call`. It's been officially moved to `deprecated.js`.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
