### PR TITLE
AnimBinder no model fix

### DIFF
--- a/src/framework/components/anim/binder.js
+++ b/src/framework/components/anim/binder.js
@@ -41,7 +41,7 @@ Object.assign(AnimComponentBinder.prototype, {
                 propertyComponent = entity;
                 break;
             case 'graph':
-                if (!this.nodes[entityHierarchy[0]]) {
+                if (!this.nodes || !this.nodes[entityHierarchy[0]]) {
                     return null;
                 }
                 propertyComponent = this.nodes[entityHierarchy[0]].node;

--- a/src/framework/components/anim/binder.js
+++ b/src/framework/components/anim/binder.js
@@ -59,7 +59,7 @@ Object.assign(AnimComponentBinder.prototype, {
         // flag active nodes as dirty
         var activeNodes = this.activeNodes;
         if (activeNodes) {
-            for (var i = 0; i < activeNodes.length; ++i) {
+            for (var i = 0; i < activeNodes.length; i++) {
                 activeNodes[i]._dirtifyLocal();
             }
         }


### PR DESCRIPTION
This PR allows the AnimBinder to skip model animation bindings when the entity does not yet have a model component attached. The engine would previously crash in the scenario.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
