### PR TITLE
Deprecate pc.Frustum#update

### DIFF
--- a/src/deprecated.js
+++ b/src/deprecated.js
@@ -205,6 +205,18 @@ export var shape = {
 
 BoundingSphere.prototype.intersectRay = BoundingSphere.prototype.intersectsRay;
 
+Frustum.prototype.update = function (projectionMatrix, viewMatrix) {
+    // #ifdef DEBUG
+    console.warn('DEPRECATED: pc.Frustum#update is deprecated. Use pc.Frustum#setFromMatrix instead.');
+    // #endif
+
+    var viewProj = new Mat4();
+
+    viewProj.mul2(projectionMatrix, viewMatrix);
+
+    this.setFromMatrix(viewProj);
+};
+
 // GRAPHICS
 import {
     ADDRESS_CLAMP_TO_EDGE, ADDRESS_MIRRORED_REPEAT, ADDRESS_REPEAT,

--- a/src/deprecated.js
+++ b/src/deprecated.js
@@ -195,6 +195,7 @@ Object.defineProperty(Vec4.prototype, "data", {
 // SHAPE
 import { BoundingBox } from './shape/bounding-box.js';
 import { BoundingSphere } from './shape/bounding-sphere.js';
+import { Frustum } from './shape/frustum.js';
 import { Plane } from './shape/plane.js';
 
 export var shape = {

--- a/src/deprecated.js
+++ b/src/deprecated.js
@@ -207,14 +207,14 @@ BoundingSphere.prototype.intersectRay = BoundingSphere.prototype.intersectsRay;
 
 Frustum.prototype.update = function (projectionMatrix, viewMatrix) {
     // #ifdef DEBUG
-    console.warn('DEPRECATED: pc.Frustum#update is deprecated. Use pc.Frustum#setFromMatrix instead.');
+    console.warn('DEPRECATED: pc.Frustum#update is deprecated. Use pc.Frustum#setFromMat4 instead.');
     // #endif
 
     var viewProj = new Mat4();
 
     viewProj.mul2(projectionMatrix, viewMatrix);
 
-    this.setFromMatrix(viewProj);
+    this.setFromMat4(viewProj);
 };
 
 // GRAPHICS

--- a/src/scene/camera.js
+++ b/src/scene/camera.js
@@ -58,7 +58,7 @@ function Camera() {
         height: 1
     };
 
-    this.frustum = new Frustum(this._projMat, this._viewMat);
+    this.frustum = new Frustum();
 
     // Create a full size viewport onto the backbuffer
     this.renderTarget = null;

--- a/src/scene/forward-renderer.js
+++ b/src/scene/forward-renderer.js
@@ -614,11 +614,13 @@ Object.assign(ForwardRenderer.prototype, {
             }
             viewInvMat.copy(viewMat).invert();
             this.viewInvId.setValue(viewInvMat.data);
-            camera.frustum.update(projMat, viewMat);
+            viewProjMat.mul2(projMat, viewMat);
+            camera.frustum.setFromMatrix(viewProjMat);
         } else if (camera.xr && camera.xr.views.length) {
             // calculate frustum based on XR view
             var view = camera.xr.views[0];
-            camera.frustum.update(view.projMat, view.viewOffMat);
+            viewProjMat.mul2(view.projMat, view.viewOffMat);
+            camera.frustum.setFromMatrix(viewProjMat);
             return;
         }
 
@@ -635,7 +637,8 @@ Object.assign(ForwardRenderer.prototype, {
         }
         viewMat.copy(viewInvMat).invert();
 
-        camera.frustum.update(projMat, viewMat);
+        viewProjMat.mul2(projMat, viewMat);
+        camera.frustum.setFromMatrix(viewProjMat);
     },
 
     // make sure colorWrite is set to true to all channels, if you want to fully clear the target
@@ -707,7 +710,8 @@ Object.assign(ForwardRenderer.prototype, {
             viewPosR.y = viewInvR.data[13];
             viewPosR.z = viewInvR.data[14];
 
-            camera.frustum.update(projMat, viewMat);
+            viewProjMat.mul2(projMat, viewMat);
+            camera.frustum.setFromMatrix(viewProjMat);
         } else if (camera.xr && camera.xr.session) {
             parent = camera._node.parent;
             if (parent) transform = parent.getWorldTransform();
@@ -732,7 +736,7 @@ Object.assign(ForwardRenderer.prototype, {
                 view.position[1] = view.viewInvOffMat.data[13];
                 view.position[2] = view.viewInvOffMat.data[14];
 
-                camera.frustum.update(view.projMat, view.viewOffMat);
+                camera.frustum.setFromMatrix(view.projViewOffMat);
             }
         } else {
             // Projection Matrix
@@ -773,7 +777,7 @@ Object.assign(ForwardRenderer.prototype, {
 
             this.viewPosId.setValue(this.viewPos);
 
-            camera.frustum.update(projMat, viewMat);
+            camera.frustum.setFromMatrix(viewProjMat);
         }
 
         // Near and far clip values

--- a/src/scene/forward-renderer.js
+++ b/src/scene/forward-renderer.js
@@ -615,12 +615,12 @@ Object.assign(ForwardRenderer.prototype, {
             viewInvMat.copy(viewMat).invert();
             this.viewInvId.setValue(viewInvMat.data);
             viewProjMat.mul2(projMat, viewMat);
-            camera.frustum.setFromMatrix(viewProjMat);
+            camera.frustum.setFromMat4(viewProjMat);
         } else if (camera.xr && camera.xr.views.length) {
             // calculate frustum based on XR view
             var view = camera.xr.views[0];
             viewProjMat.mul2(view.projMat, view.viewOffMat);
-            camera.frustum.setFromMatrix(viewProjMat);
+            camera.frustum.setFromMat4(viewProjMat);
             return;
         }
 
@@ -638,7 +638,7 @@ Object.assign(ForwardRenderer.prototype, {
         viewMat.copy(viewInvMat).invert();
 
         viewProjMat.mul2(projMat, viewMat);
-        camera.frustum.setFromMatrix(viewProjMat);
+        camera.frustum.setFromMat4(viewProjMat);
     },
 
     // make sure colorWrite is set to true to all channels, if you want to fully clear the target
@@ -711,7 +711,7 @@ Object.assign(ForwardRenderer.prototype, {
             viewPosR.z = viewInvR.data[14];
 
             viewProjMat.mul2(projMat, viewMat);
-            camera.frustum.setFromMatrix(viewProjMat);
+            camera.frustum.setFromMat4(viewProjMat);
         } else if (camera.xr && camera.xr.session) {
             parent = camera._node.parent;
             if (parent) transform = parent.getWorldTransform();
@@ -736,7 +736,7 @@ Object.assign(ForwardRenderer.prototype, {
                 view.position[1] = view.viewInvOffMat.data[13];
                 view.position[2] = view.viewInvOffMat.data[14];
 
-                camera.frustum.setFromMatrix(view.projViewOffMat);
+                camera.frustum.setFromMat4(view.projViewOffMat);
             }
         } else {
             // Projection Matrix
@@ -777,7 +777,7 @@ Object.assign(ForwardRenderer.prototype, {
 
             this.viewPosId.setValue(this.viewPos);
 
-            camera.frustum.setFromMatrix(viewProjMat);
+            camera.frustum.setFromMat4(viewProjMat);
         }
 
         // Near and far clip values

--- a/src/shape/bounding-box.js
+++ b/src/shape/bounding-box.js
@@ -16,7 +16,7 @@ var tmpVecE = new Vec3();
  * @property {pc.Vec3} center Center of box.
  * @property {pc.Vec3} halfExtents Half the distance across the box in each axis.
  */
-export function BoundingBox(center, halfExtents) {
+function BoundingBox(center, halfExtents) {
     this.center = center || new Vec3(0, 0, 0);
     this.halfExtents = halfExtents || new Vec3(0.5, 0.5, 0.5);
     this._min = new Vec3();
@@ -395,3 +395,5 @@ Object.assign(BoundingBox.prototype, {
         this.setMinMax(tmpVecA, tmpVecB);
     }
 });
+
+export { BoundingBox };

--- a/src/shape/bounding-sphere.js
+++ b/src/shape/bounding-sphere.js
@@ -16,7 +16,7 @@ var tmpVecD = new Vec3();
  * @param {pc.Vec3} [center] - The world space coordinate marking the center of the sphere. The constructor takes a reference of this parameter.
  * @param {number} [radius] - The radius of the bounding sphere. Defaults to 0.5.
  */
-export function BoundingSphere(center, radius) {
+function BoundingSphere(center, radius) {
     this.center = center || new Vec3(0, 0, 0);
     this.radius = radius === undefined ? 0.5 : radius;
 }
@@ -120,3 +120,5 @@ Object.assign(BoundingSphere.prototype, {
         return false;
     }
 });
+
+export { BoundingSphere };

--- a/src/shape/frustum.js
+++ b/src/shape/frustum.js
@@ -1,27 +1,17 @@
-import { Mat4 } from '../math/mat4.js';
-
 /**
  * @class
  * @name pc.Frustum
- * @classdesc A frustum is a shape that defines the viewing space of a camera.
+ * @classdesc A frustum is a shape that defines the viewing space of a camera. It can be
+ * use to determine visibility of points and bounding spheres. Typically, you would not
+ * create a Frustum shape directly, but instead query {@link pc.CameraComponent#frustum}.
  * @description Creates a new frustum shape.
  * @example
- * // Create a new frustum equivalent to one held by a camera component
- * var projectionMatrix = entity.camera.projectionMatrix;
- * var viewMatrix = entity.camera.viewMatrix;
- * var frustum = new pc.Frustum(projectionMatrix, viewMatrix);
- * @param {pc.Mat4} projectionMatrix - The projection matrix describing the shape of the frustum.
- * @param {pc.Mat4} viewMatrix - The inverse of the world transformation matrix for the frustum.
+ * var frustum = new pc.Frustum();
  */
-function Frustum(projectionMatrix, viewMatrix) {
-    projectionMatrix = projectionMatrix || new Mat4().setPerspective(90, 16 / 9, 0.1, 1000);
-    viewMatrix = viewMatrix || new Mat4();
-
+function Frustum() {
     this.planes = [];
     for (var i = 0; i < 6; i++)
         this.planes[i] = [];
-
-    this.update(projectionMatrix, viewMatrix);
 }
 
 Object.assign(Frustum.prototype, {
@@ -30,6 +20,14 @@ Object.assign(Frustum.prototype, {
      * @name pc.Frustum#setFromMat4
      * @description Updates the frustum shape based on the supplied 4x4 matrix.
      * @param {pc.Mat4} matrix - The matrix describing the shape of the frustum.
+     * @example
+     * // Create a perspective projection matrix
+     * var projMat = pc.Mat4();
+     * projMat.setPerspective(45, 16 / 9, 1, 1000);
+     *
+     * // Create a frustum shape that is represented by the matrix
+     * var frustum = new pc.Frustum();
+     * frustum.setFromMat4(projMat);
      */
     setFromMat4: function (matrix) {
         var vpm = matrix.data;

--- a/src/shape/frustum.js
+++ b/src/shape/frustum.js
@@ -2,7 +2,7 @@
  * @class
  * @name pc.Frustum
  * @classdesc A frustum is a shape that defines the viewing space of a camera. It can be
- * use to determine visibility of points and bounding spheres. Typically, you would not
+ * used to determine visibility of points and bounding spheres. Typically, you would not
  * create a Frustum shape directly, but instead query {@link pc.CameraComponent#frustum}.
  * @description Creates a new frustum shape.
  * @example

--- a/src/shape/frustum.js
+++ b/src/shape/frustum.js
@@ -1,7 +1,5 @@
 import { Mat4 } from '../math/mat4.js';
 
-var viewProj = new Mat4();
-
 /**
  * @class
  * @name pc.Frustum
@@ -15,7 +13,7 @@ var viewProj = new Mat4();
  * @param {pc.Mat4} projectionMatrix - The projection matrix describing the shape of the frustum.
  * @param {pc.Mat4} viewMatrix - The inverse of the world transformation matrix for the frustum.
  */
-export function Frustum(projectionMatrix, viewMatrix) {
+function Frustum(projectionMatrix, viewMatrix) {
     projectionMatrix = projectionMatrix || new Mat4().setPerspective(90, 16 / 9, 0.1, 1000);
     viewMatrix = viewMatrix || new Mat4();
 
@@ -29,86 +27,93 @@ export function Frustum(projectionMatrix, viewMatrix) {
 Object.assign(Frustum.prototype, {
     /**
      * @function
-     * @name pc.Frustum#update
-     * @description Updates the frustum shape based on a view matrix and a projection matrix.
-     * @param {pc.Mat4} projectionMatrix - The projection matrix describing the shape of the frustum.
-     * @param {pc.Mat4} viewMatrix - The inverse of the world transformation matrix for the frustum.
+     * @name pc.Frustum#setFromMatrix
+     * @description Updates the frustum shape based on the supplied 4x4 matrix.
+     * @param {pc.Mat4} matrix - The matrix describing the shape of the frustum.
      */
-    update: function (projectionMatrix, viewMatrix) {
-        viewProj.mul2(projectionMatrix, viewMatrix);
-        var vpm = viewProj.data;
+    setFromMatrix: function (matrix) {
+        var vpm = matrix.data;
+
+        var plane;
+        var planes = this.planes;
 
         // Extract the numbers for the RIGHT plane
-        this.planes[0][0] = vpm[3] - vpm[0];
-        this.planes[0][1] = vpm[7] - vpm[4];
-        this.planes[0][2] = vpm[11] - vpm[8];
-        this.planes[0][3] = vpm[15] - vpm[12];
+        plane = planes[0];
+        plane[0] = vpm[3] - vpm[0];
+        plane[1] = vpm[7] - vpm[4];
+        plane[2] = vpm[11] - vpm[8];
+        plane[3] = vpm[15] - vpm[12];
         // Normalize the result
-        var t = Math.sqrt(this.planes[0][0] * this.planes[0][0] + this.planes[0][1] * this.planes[0][1] + this.planes[0][2] * this.planes[0][2]);
-        this.planes[0][0] /= t;
-        this.planes[0][1] /= t;
-        this.planes[0][2] /= t;
-        this.planes[0][3] /= t;
+        var t = Math.sqrt(plane[0] * plane[0] + plane[1] * plane[1] + plane[2] * plane[2]);
+        plane[0] /= t;
+        plane[1] /= t;
+        plane[2] /= t;
+        plane[3] /= t;
 
         // Extract the numbers for the LEFT plane
-        this.planes[1][0] = vpm[3] + vpm[0];
-        this.planes[1][1] = vpm[7] + vpm[4];
-        this.planes[1][2] = vpm[11] + vpm[8];
-        this.planes[1][3] = vpm[15] + vpm[12];
+        plane = planes[1];
+        plane[0] = vpm[3] + vpm[0];
+        plane[1] = vpm[7] + vpm[4];
+        plane[2] = vpm[11] + vpm[8];
+        plane[3] = vpm[15] + vpm[12];
         // Normalize the result
-        t = Math.sqrt(this.planes[1][0] * this.planes[1][0] + this.planes[1][1] * this.planes[1][1] + this.planes[1][2] * this.planes[1][2]);
-        this.planes[1][0] /= t;
-        this.planes[1][1] /= t;
-        this.planes[1][2] /= t;
-        this.planes[1][3] /= t;
+        t = Math.sqrt(plane[0] * plane[0] + plane[1] * plane[1] + plane[2] * plane[2]);
+        plane[0] /= t;
+        plane[1] /= t;
+        plane[2] /= t;
+        plane[3] /= t;
 
         // Extract the BOTTOM plane
-        this.planes[2][0] = vpm[3] + vpm[1];
-        this.planes[2][1] = vpm[7] + vpm[5];
-        this.planes[2][2] = vpm[11] + vpm[9];
-        this.planes[2][3] = vpm[15] + vpm[13];
+        plane = planes[2];
+        plane[0] = vpm[3] + vpm[1];
+        plane[1] = vpm[7] + vpm[5];
+        plane[2] = vpm[11] + vpm[9];
+        plane[3] = vpm[15] + vpm[13];
         // Normalize the result
-        t = Math.sqrt(this.planes[2][0] * this.planes[2][0] + this.planes[2][1] * this.planes[2][1] + this.planes[2][2] * this.planes[2][2] );
-        this.planes[2][0] /= t;
-        this.planes[2][1] /= t;
-        this.planes[2][2] /= t;
-        this.planes[2][3] /= t;
+        t = Math.sqrt(plane[0] * plane[0] + plane[1] * plane[1] + plane[2] * plane[2]);
+        plane[0] /= t;
+        plane[1] /= t;
+        plane[2] /= t;
+        plane[3] /= t;
 
         // Extract the TOP plane
-        this.planes[3][0] = vpm[3] - vpm[1];
-        this.planes[3][1] = vpm[7] - vpm[5];
-        this.planes[3][2] = vpm[11] - vpm[9];
-        this.planes[3][3] = vpm[15] - vpm[13];
+        plane = planes[3];
+        plane[0] = vpm[3] - vpm[1];
+        plane[1] = vpm[7] - vpm[5];
+        plane[2] = vpm[11] - vpm[9];
+        plane[3] = vpm[15] - vpm[13];
         // Normalize the result
-        t = Math.sqrt(this.planes[3][0] * this.planes[3][0] + this.planes[3][1] * this.planes[3][1] + this.planes[3][2] * this.planes[3][2]);
-        this.planes[3][0] /= t;
-        this.planes[3][1] /= t;
-        this.planes[3][2] /= t;
-        this.planes[3][3] /= t;
+        t = Math.sqrt(plane[0] * plane[0] + plane[1] * plane[1] + plane[2] * plane[2]);
+        plane[0] /= t;
+        plane[1] /= t;
+        plane[2] /= t;
+        plane[3] /= t;
 
         // Extract the FAR plane
-        this.planes[4][0] = vpm[3] - vpm[2];
-        this.planes[4][1] = vpm[7] - vpm[6];
-        this.planes[4][2] = vpm[11] - vpm[10];
-        this.planes[4][3] = vpm[15] - vpm[14];
+        plane = planes[4];
+        plane[0] = vpm[3] - vpm[2];
+        plane[1] = vpm[7] - vpm[6];
+        plane[2] = vpm[11] - vpm[10];
+        plane[3] = vpm[15] - vpm[14];
         // Normalize the result
-        t = Math.sqrt(this.planes[4][0] * this.planes[4][0] + this.planes[4][1] * this.planes[4][1] + this.planes[4][2] * this.planes[4][2]);
-        this.planes[4][0] /= t;
-        this.planes[4][1] /= t;
-        this.planes[4][2] /= t;
-        this.planes[4][3] /= t;
+        t = Math.sqrt(plane[0] * plane[0] + plane[1] * plane[1] + plane[2] * plane[2]);
+        plane[0] /= t;
+        plane[1] /= t;
+        plane[2] /= t;
+        plane[3] /= t;
 
         // Extract the NEAR plane
-        this.planes[5][0] = vpm[3] + vpm[2];
-        this.planes[5][1] = vpm[7] + vpm[6];
-        this.planes[5][2] = vpm[11] + vpm[10];
-        this.planes[5][3] = vpm[15] + vpm[14];
+        plane = planes[5];
+        plane[0] = vpm[3] + vpm[2];
+        plane[1] = vpm[7] + vpm[6];
+        plane[2] = vpm[11] + vpm[10];
+        plane[3] = vpm[15] + vpm[14];
         // Normalize the result
-        t = Math.sqrt(this.planes[5][0] * this.planes[5][0] + this.planes[5][1] * this.planes[5][1] + this.planes[5][2] * this.planes[5][2]);
-        this.planes[5][0] /= t;
-        this.planes[5][1] /= t;
-        this.planes[5][2] /= t;
-        this.planes[5][3] /= t;
+        t = Math.sqrt(plane[0] * plane[0] + plane[1] * plane[1] + plane[2] * plane[2]);
+        plane[0] /= t;
+        plane[1] /= t;
+        plane[2] /= t;
+        plane[3] /= t;
     },
 
     /**
@@ -120,12 +125,13 @@ Object.assign(Frustum.prototype, {
      * @returns {boolean} True if the point is inside the frustum, false otherwise.
      */
     containsPoint: function (point) {
-        for (var p = 0; p < 6; p++)
-            if (this.planes[p][0] * point.x +
-                this.planes[p][1] * point.y +
-                this.planes[p][2] * point.z +
-                this.planes[p][3] <= 0)
+        var p, plane;
+        for (p = 0; p < 6; p++) {
+            plane = this.planes[p];
+            if (plane[0] * point.x + plane[1] * point.y + plane[2] * point.z + plane[3] <= 0) {
                 return false;
+            }
+        }
         return true;
     },
 
@@ -165,3 +171,5 @@ Object.assign(Frustum.prototype, {
         return (c === 6) ? 2 : 1;
     }
 });
+
+export { Frustum };

--- a/src/shape/frustum.js
+++ b/src/shape/frustum.js
@@ -27,11 +27,11 @@ function Frustum(projectionMatrix, viewMatrix) {
 Object.assign(Frustum.prototype, {
     /**
      * @function
-     * @name pc.Frustum#setFromMatrix
+     * @name pc.Frustum#setFromMat4
      * @description Updates the frustum shape based on the supplied 4x4 matrix.
      * @param {pc.Mat4} matrix - The matrix describing the shape of the frustum.
      */
-    setFromMatrix: function (matrix) {
+    setFromMat4: function (matrix) {
         var vpm = matrix.data;
 
         var plane;

--- a/src/shape/oriented-box.js
+++ b/src/shape/oriented-box.js
@@ -19,7 +19,7 @@ var tmpMat4 = new Mat4();
  * @param {pc.Mat4} [worldTransform] - Transform that has the orientation and position of the box. Scale is assumed to be one.
  * @param {pc.Vec3} [halfExtents] - Half the distance across the box in each local axis. The constructor takes a reference of this parameter.
  */
-export function OrientedBox(worldTransform, halfExtents) {
+function OrientedBox(worldTransform, halfExtents) {
     this.halfExtents = halfExtents || new Vec3(0.5, 0.5, 0.5);
 
     worldTransform = worldTransform || tmpMat4.setIdentity();
@@ -91,3 +91,5 @@ Object.defineProperty(OrientedBox.prototype, 'worldTransform', {
         this._modelTransform.copy(value).invert();
     }
 });
+
+export { OrientedBox };

--- a/src/shape/plane.js
+++ b/src/shape/plane.js
@@ -11,7 +11,7 @@ var tmpVecA = new Vec3();
  * @param {pc.Vec3} [point] - Point position on the plane. The constructor takes a reference of this parameter.
  * @param {pc.Vec3} [normal] - Normal of the plane. The constructor takes a reference of this parameter.
  */
-export function Plane(point, normal) {
+function Plane(point, normal) {
     this.normal = normal || new Vec3(0, 0, 1);
     this.point = point || new Vec3(0, 0, 0);
 }
@@ -60,3 +60,5 @@ Object.assign(Plane.prototype, {
         return intersects;
     }
 });
+
+export { Plane };

--- a/src/shape/ray.js
+++ b/src/shape/ray.js
@@ -16,7 +16,7 @@ import { Vec3 } from '../math/vec3.js';
  * @property {pc.Vec3} origin The starting point of the ray.
  * @property {pc.Vec3} direction The direction of the ray.
  */
-export function Ray(origin, direction) {
+function Ray(origin, direction) {
     this.origin = origin || new Vec3(0, 0, 0);
     this.direction = direction || new Vec3(0, 0, -1);
 }
@@ -34,3 +34,5 @@ Ray.prototype.set = function (origin, direction) {
     this.direction.copy(direction);
     return this;
 };
+
+export { Ray };


### PR DESCRIPTION
Currently, the API has `pc.Frustum#update` which takes two matrices (view and projection). It would be cleaner to have a function which sets the frustum planes from a single generic matrix. Therefore, this PR deprecates `pc.Frustum#update` and replaces it with the better named `pc.Frustum#setFromMat4` (which is consistent with `pc.Quat#setFromMat4` too). This eliminates a matrix mult op every frame in the forward renderer too.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
