### PR TITLE
Fix glTF texture transform

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,7 +3,6 @@
 /extras
 /src
 /tests
-/tools
 /conf-api.json
 /conf-tsd.json
 /externs.js

--- a/examples/graphics/shader-burn.html
+++ b/examples/graphics/shader-burn.html
@@ -31,7 +31,7 @@
 
         void main(void)
         {
-            vUv0 = aUv0;
+            vUv0 = vec2(aUv0.x, 1.0 - aUv0.y);
             gl_Position = matrix_viewProjection * matrix_model * vec4(aPosition, 1.0);
         }
     </script>

--- a/examples/graphics/shader-wobble.html
+++ b/examples/graphics/shader-wobble.html
@@ -34,7 +34,7 @@
         {
             vec4 pos = matrix_model * vec4(aPosition, 1.0);
             pos.x += sin(uTime + pos.y * 4.0) * 0.1;
-            vUv0 = aUv0;
+            vUv0 = vec2(aUv0.x, 1.0 - aUv0.y);
             gl_Position = matrix_viewProjection * pos;
         }
     </script>

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
   },
   "scripts": {
     "build": "rollup -c",
+    "build:all": "npm run build && npm run closure",
     "closure": "google-closure-compiler --compilation_level=SIMPLE --warning_level=VERBOSE --jscomp_off=nonStandardJsDocs --jscomp_off=checkTypes --externs externs.js --language_in=ECMASCRIPT5_STRICT --js build/playcanvas.js --js_output_file build/playcanvas.min.js",
     "docs": "jsdoc -c conf-api.json",
     "lint": "eslint --ext .js examples extras src rollup.config.js",

--- a/src/resources/parser/glb-parser.js
+++ b/src/resources/parser/glb-parser.js
@@ -1182,7 +1182,7 @@ var createMeshes = function (device, gltf, buffers, callback) {
     });
 };
 
-var createMaterials = function (gltf, textures, options, disableFlipV) {
+var createMaterials = function (gltf, textures, options) {
     if (!gltf.hasOwnProperty('materials') || gltf.materials.length === 0) {
         return [];
     }

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -684,10 +684,12 @@ Object.assign(StandardMaterial.prototype, {
     },
 
     _updateMapTransform: function (transform, tiling, offset) {
+        if (tiling.x === 1 && tiling.y === 1 && offset.x === 0 && offset.y === 0) {
+           return null;
+        }
+
         transform = transform || new Vec4();
         transform.set(tiling.x, tiling.y, offset.x, offset.y);
-
-        if ((transform.x === 1) && (transform.y === 1) && (transform.z === 0) && (transform.w === 0)) return null;
         return transform;
     },
 
@@ -707,25 +709,32 @@ Object.assign(StandardMaterial.prototype, {
 
     _updateMap: function (p) {
         var mname = p + "Map";
-        if (this[mname]) {
-            this._setParameter("texture_" + mname, this[mname]);
+        var map = this[mname];
+        if (map) {
+            this._setParameter("texture_" + mname, map);
+
+            // update transform
             var tname = mname + "Transform";
-            var uname = mname + "TransformUniform";
-            if (!this[tname]) {
-                this[uname] = new Float32Array(4);
-            }
             this[tname] = this._updateMapTransform(
                 this[tname],
                 this[mname + "Tiling"],
                 this[mname + "Offset"]
             );
 
-            if (this[tname]) {
-                this[uname][0] = this[tname].x;
-                this[uname][1] = this[tname].y;
-                this[uname][2] = this[tname].z;
-                this[uname][3] = this[tname].w;
-                this._setParameter('texture_' + tname, this[uname]);
+            // update uniform
+            var transform = this[tname];
+            if (transform) {
+                var uname = mname + "TransformUniform";
+                var uniform = this[uname];
+                if (!uniform) {
+                    uniform = new Float32Array(4);
+                    this[uname] = uniform;
+                    this._setParameter('texture_' + tname, uniform);
+                }
+                uniform[0] = transform.x;
+                uniform[1] = transform.y;
+                uniform[2] = transform.z;
+                uniform[3] = transform.w;
             }
         }
     },

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -685,7 +685,7 @@ Object.assign(StandardMaterial.prototype, {
 
     _updateMapTransform: function (transform, tiling, offset) {
         if (tiling.x === 1 && tiling.y === 1 && offset.x === 0 && offset.y === 0) {
-           return null;
+            return null;
         }
 
         transform = transform || new Vec4();


### PR DESCRIPTION
Fixes #2060 

This PR includes the following updates:
- apply glTF texture transform coordinates correctly
- use texture transform to flip all V coordinates instead of modifying vertex buffers at load time
- add build:all npm run target
- remove /tools from list of lint folders
- fix custom example shaders to flip glTF V texture coords correctly

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
