### PR TITLE
Fix webxr rendering with vao

### DIFF
--- a/src/graphics/device.js
+++ b/src/graphics/device.js
@@ -2275,7 +2275,7 @@ Object.assign(GraphicsDevice.prototype, {
      *     indexed: false
      * });
      */
-    draw: function (primitive, numInstances) {
+    draw: function (primitive, numInstances, keepBuffers) {
         var gl = this.gl;
 
         var i, j, len; // Loop counting
@@ -2286,7 +2286,9 @@ Object.assign(GraphicsDevice.prototype, {
         var uniforms = shader.uniforms;
 
         // vertex buffers
-        this.setBuffers();
+        if (!keepBuffers) {
+            this.setBuffers();
+        }
 
         // Commit the shader program variables
         var textureUnit = 0;

--- a/src/graphics/device.js
+++ b/src/graphics/device.js
@@ -2266,6 +2266,8 @@ Object.assign(GraphicsDevice.prototype, {
      * @param {number} primitive.count - The number of indices or vertices to dispatch in the draw call.
      * @param {boolean} [primitive.indexed] - True to interpret the primitive as indexed, thereby using the currently set index buffer and false otherwise.
      * @param {number} [numInstances=1] - The number of instances to render when using ANGLE_instanced_arrays. Defaults to 1.
+     * @param {boolean} [keepBuffers] - Optionally keep the current set of vertex buffers / VAO. This is used when rendering of
+     * multiple views, for example under WebXR.
      * @example
      * // Render a single, unindexed triangle
      * device.draw({

--- a/src/scene/forward-renderer.js
+++ b/src/scene/forward-renderer.js
@@ -1302,7 +1302,7 @@ Object.assign(ForwardRenderer.prototype, {
             }
         } else {
             // matrices are already set
-            device.draw(mesh.primitive[style]);
+            device.draw(mesh.primitive[style], null, true);
         }
         return 0;
     },


### PR DESCRIPTION
Fixes #2301

The VAO method of setBuffers wasn't respecting the multiple draw call approach of webxr rendering.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
