### PR TITLE
Apply flip v transform later in the pipeline

### DIFF
--- a/src/resources/parser/glb-parser.js
+++ b/src/resources/parser/glb-parser.js
@@ -784,8 +784,12 @@ var createMaterial = function (gltfMaterial, textures, disableFlipV) {
         }
 
         for (map = 0; map < maps.length; ++map) {
-            material[maps[map] + 'MapTiling'] = new Vec2(scale[0], disableFlipV ? scale[1] : -scale[1]);
-            material[maps[map] + 'MapOffset'] = new Vec2(offset[0], disableFlipV ? offset[1] : 1.0 - offset[1]);
+            material[maps[map] + 'MapTiling'] = new Vec2(scale[0], scale[1]);
+            material[maps[map] + 'MapOffset'] = new Vec2(offset[0], offset[1]);
+        }
+
+        if (!disableFlipV) {
+            material._flipV = true;
         }
     };
 

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -684,12 +684,13 @@ Object.assign(StandardMaterial.prototype, {
     },
 
     _updateMapTransform: function (transform, tiling, offset) {
-        if (tiling.x === 1 && tiling.y === 1 && offset.x === 0 && offset.y === 0) {
+        if (!this._flipV && (tiling.x === 1 && tiling.y === 1 && offset.x === 0 && offset.y === 0)) {
             return null;
         }
 
         transform = transform || new Vec4();
-        transform.set(tiling.x, tiling.y, offset.x, offset.y);
+        transform.set(tiling.x, tiling.y * (this._flipV ? -1 : 1),
+                      offset.x, (this._flipV ? 1.0 - offset.y : offset.y));
         return transform;
     },
 
@@ -729,12 +730,12 @@ Object.assign(StandardMaterial.prototype, {
                 if (!uniform) {
                     uniform = new Float32Array(4);
                     this[uname] = uniform;
-                    this._setParameter('texture_' + tname, uniform);
                 }
                 uniform[0] = transform.x;
                 uniform[1] = transform.y;
                 uniform[2] = transform.z;
                 uniform[3] = transform.w;
+                this._setParameter('texture_' + tname, uniform);
             }
         }
     },


### PR DESCRIPTION
Instead of setting the texture transform directly, we apply flip V at the point uniforms are generated. This means UI can work as before.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
