### PR TITLE
Revert changes to texture coordinate flipping for glTF

### DIFF
--- a/examples/graphics/shader-burn.html
+++ b/examples/graphics/shader-burn.html
@@ -31,7 +31,7 @@
 
         void main(void)
         {
-            vUv0 = vec2(aUv0.x, 1.0 - aUv0.y);
+            vUv0 = aUv0;
             gl_Position = matrix_viewProjection * matrix_model * vec4(aPosition, 1.0);
         }
     </script>

--- a/examples/graphics/shader-wobble.html
+++ b/examples/graphics/shader-wobble.html
@@ -34,7 +34,7 @@
         {
             vec4 pos = matrix_model * vec4(aPosition, 1.0);
             pos.x += sin(uTime + pos.y * 4.0) * 0.1;
-            vUv0 = vec2(aUv0.x, 1.0 - aUv0.y);
+            vUv0 = aUv0;
             gl_Position = matrix_viewProjection * pos;
         }
     </script>

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -684,13 +684,12 @@ Object.assign(StandardMaterial.prototype, {
     },
 
     _updateMapTransform: function (transform, tiling, offset) {
-        if (!this._flipV && (tiling.x === 1 && tiling.y === 1 && offset.x === 0 && offset.y === 0)) {
+        if (tiling.x === 1 && tiling.y === 1 && offset.x === 0 && offset.y === 0) {
             return null;
         }
 
         transform = transform || new Vec4();
-        transform.set(tiling.x, tiling.y * (this._flipV ? -1 : 1),
-                      offset.x, (this._flipV ? 1.0 - offset.y : offset.y));
+        transform.set(tiling.x, tiling.y, offset.x, offset.y);
         return transform;
     },
 


### PR DESCRIPTION
We recently changed the way glTF texture coordinates are flipped by using the texture transform instead of modifying loaded texture coordinates. There are a few benefits to this approach, but unfortunately it doesn't work in the straightforward case of PC-backend generated glTF files. This is because materials are created on the backend without explicit knowledge of flipped texture coordinates (and the generated materials can be shared between json and glb models).

This PR makes the following changes:
- reintroduce flipping glTF texture coordinate V at load time
- adjust the texture transform to work correctly with flipped V
- fix examples

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
