### PR TITLE
Expose glTF bufferView to callbacks

### DIFF
--- a/extras/mini-stats/mini-stats.js
+++ b/extras/mini-stats/mini-stats.js
@@ -311,9 +311,9 @@ Object.assign(Graph.prototype, {
             }
 
             // write latest sample to the texture
+            var gl = this.device.gl;
             this.device.bindTexture(this.texture);
 
-            var gl = this.device.gl;
             gl.texSubImage2D(gl.TEXTURE_2D,
                              0,
                              this.cursor,

--- a/extras/mini-stats/mini-stats.js
+++ b/extras/mini-stats/mini-stats.js
@@ -311,8 +311,9 @@ Object.assign(Graph.prototype, {
             }
 
             // write latest sample to the texture
-            var gl = this.device.gl;
             this.device.bindTexture(this.texture);
+
+            var gl = this.device.gl;
             gl.texSubImage2D(gl.TEXTURE_2D,
                              0,
                              this.cursor,
@@ -387,6 +388,9 @@ function MiniStats(app) {
         dest.set([0, 0, 0, 255], i * 4);
     }
     texture.unlock();
+
+    // ensure texture is uploaded
+    device.setTexture(texture, 0);
 
     // create graphs
     var graphs = [

--- a/extras/mini-stats/mini-stats.js
+++ b/extras/mini-stats/mini-stats.js
@@ -313,7 +313,6 @@ Object.assign(Graph.prototype, {
             // write latest sample to the texture
             var gl = this.device.gl;
             this.device.bindTexture(this.texture);
-
             gl.texSubImage2D(gl.TEXTURE_2D,
                              0,
                              this.cursor,

--- a/src/deprecated.js
+++ b/src/deprecated.js
@@ -137,11 +137,11 @@ export function makeArray(arr) {
 }
 
 // MATH
+import { Mat4 } from './math/mat4.js';
 import { math } from './math/math.js';
 import { Vec2 } from './math/vec2.js';
 import { Vec3 } from './math/vec3.js';
 import { Vec4 } from './math/vec4.js';
-import { Mat4 } from './math/mat4.js';
 
 math.INV_LOG2 = Math.LOG2E;
 

--- a/src/deprecated.js
+++ b/src/deprecated.js
@@ -141,6 +141,7 @@ import { math } from './math/math.js';
 import { Vec2 } from './math/vec2.js';
 import { Vec3 } from './math/vec3.js';
 import { Vec4 } from './math/vec4.js';
+import { Mat4 } from './math/mat4.js';
 
 math.INV_LOG2 = Math.LOG2E;
 

--- a/src/resources/container.js
+++ b/src/resources/container.js
@@ -69,8 +69,9 @@ Object.assign(ContainerResource.prototype, {
  * @implements {pc.ResourceHandler}
  * @classdesc Loads files that contain multiple resources. For example glTF files can contain
  * textures, models and animations.
- * The asset options object can be used for passing in load time callbacks to handle the various resources
- * at different stages of loading as follows:
+ * The asset options object can be used to pass load time callbacks for handling the various resources
+ * at different stages of loading. The table below lists the resource types and the corresponding
+ * supported process functions.
  * ```
  * |---------------------------------------------------------------------|
  * |  resource   |  preprocess |   process   |processAsync | postprocess |
@@ -81,6 +82,7 @@ Object.assign(ContainerResource.prototype, {
  * | material    |      x      |      x      |             |      x      |
  * | texture     |      x      |             |      x      |      x      |
  * | buffer      |      x      |             |      x      |      x      |
+ * | bufferView  |      x      |             |      x      |      x      |
  * |---------------------------------------------------------------------|
  * ```
  * For example, to receive a texture preprocess callback:

--- a/src/resources/parser/glb-parser.js
+++ b/src/resources/parser/glb-parser.js
@@ -1677,6 +1677,12 @@ var parseBufferViewsAsync = function (gltf, buffers, options, callback) {
 
     var result = [];
 
+    var preprocess = options && options.bufferView && options.bufferView.preprocess;
+    var processAsync = (options && options.bufferView && options.bufferView.processAsync) || function (gltfBufferView, buffers, callback) {
+        callback(null, null);
+    };
+    var postprocess = options && options.bufferView && options.bufferView.postprocess;
+
     var remaining = gltf.bufferViews.length;
     var onLoad = function (index, bufferView) {
         var gltfBufferView = gltf.bufferViews[index];
@@ -1685,17 +1691,20 @@ var parseBufferViewsAsync = function (gltf, buffers, options, callback) {
         }
 
         result[index] = bufferView;
+        if (postprocess) {
+            postprocess(gltfBufferView, bufferView);
+        }
         if (--remaining === 0) {
             callback(null, result);
         }
     };
 
-    var processAsync = (options && options.bufferView && options.bufferView.processAsync) || function (gltfBufferView, buffers, callback) {
-        callback(null, null);
-    };
-
     for (var i = 0; i < gltf.bufferViews.length; ++i) {
         var gltfBufferView = gltf.bufferViews[i];
+
+        if (preprocess) {
+            preprocess(gltfBufferView);
+        }
 
         processAsync(gltfBufferView, buffers, function (i, gltfBufferView, err, result) {       // eslint-disable-line no-loop-func
             if (err) {

--- a/src/resources/parser/glb-parser.js
+++ b/src/resources/parser/glb-parser.js
@@ -105,45 +105,27 @@ var getComponentDataType = function (componentType) {
     }
 };
 
-var getAccessorData = function (accessor, bufferViews, buffers) {
-    var bufferViewIdx;
-    var count;
-    if (accessor.hasOwnProperty("sparse")) {
-        bufferViewIdx = accessor.sparse.values.bufferView;
-        count = accessor.sparse.count;
-    } else {
-        bufferViewIdx = accessor.bufferView;
-        count = accessor.count;
+var getAccessorData = function (gltfAccessor, bufferViews) {
+    var bufferView = bufferViews[gltfAccessor.bufferView];
+    var dataType = getComponentDataType(gltfAccessor.componentType);
+    if (!dataType) {
+        return null;
     }
-
-    var bufferView = bufferViews[bufferViewIdx];
-    var typedArray = buffers[bufferView.buffer];
-    var accessorByteOffset = accessor.hasOwnProperty('byteOffset') ? accessor.byteOffset : 0;
-    var bufferViewByteOffset = bufferView.hasOwnProperty('byteOffset') ? bufferView.byteOffset : 0;
-    var byteOffset = typedArray.byteOffset + accessorByteOffset + bufferViewByteOffset;
-    var length = count * getNumComponents(accessor.type);
-
-    var dataType = getComponentDataType(accessor.componentType);
-    return dataType ? new dataType(typedArray.buffer, byteOffset, length) : null;
+    return new dataType(bufferView.buffer,
+                        bufferView.byteOffset + (gltfAccessor.hasOwnProperty('byteOffset') ? gltfAccessor.byteOffset : 0),
+                        gltfAccessor.count * getNumComponents(gltfAccessor.type));
 };
 
-var getSparseAccessorIndices = function (accessor, bufferViews, buffers) {
-    var bufferView = bufferViews[accessor.sparse.indices.bufferView];
-    var typedArray = buffers[bufferView.buffer];
-    var bufferViewByteOffset = bufferView.hasOwnProperty('byteOffset') ? bufferView.byteOffset : 0;
-    var byteOffset = typedArray.byteOffset + bufferViewByteOffset;
-    var length = accessor.sparse.count;
-
-    switch (accessor.sparse.indices.componentType) {
-        case 5120: return new Int8Array(typedArray.buffer, byteOffset, length);
-        case 5121: return new Uint8Array(typedArray.buffer, byteOffset, length);
-        case 5122: return new Int16Array(typedArray.buffer, byteOffset, length);
-        case 5123: return new Uint16Array(typedArray.buffer, byteOffset, length);
-        case 5124: return new Int32Array(typedArray.buffer, byteOffset, length);
-        case 5125: return new Uint32Array(typedArray.buffer, byteOffset, length);
-        case 5126: return new Float32Array(typedArray.buffer, byteOffset, length);
-        default: return null;
+var getSparseAccessorIndices = function (gltfAccessor, bufferViews) {
+    var bufferView = bufferViews[gltfAccessor.sparse.indices.bufferView];
+    var dataType = getComponentDataType(gltfAccessor.sparse.indices.componentType);
+    if (!dataType) {
+        return null;
     }
+
+    return new dataType(bufferView.buffer,
+                        bufferView.byteOffset + (bufferView.hasOwnProperty('byteOffset') ? bufferView.byteOffset : 0),
+                        gltfAccessor.sparse.count);
 };
 
 var getPrimitiveType = function (primitive) {
@@ -355,33 +337,27 @@ var createVertexBufferInternal = function (device, sourceDesc, disableFlipV) {
     return vertexBuffer;
 };
 
-var createVertexBuffer = function (device, attributes, indices, accessors, bufferViews, buffers, semanticMap, disableFlipV) {
-
+var createVertexBuffer = function (device, attributes, indices, accessors, bufferViews, semanticMap, disableFlipV) {
     // build vertex buffer format desc and source
     var sourceDesc = {};
     for (var attrib in attributes) {
-        if (attributes.hasOwnProperty(attrib)) {
+        if (attributes.hasOwnProperty(attrib) && semanticMap.hasOwnProperty(attrib)) {
             var accessor = accessors[attributes[attrib]];
+            var accessorData = getAccessorData(accessor, bufferViews);
             var bufferView = bufferViews[accessor.bufferView];
-
-            if (semanticMap.hasOwnProperty(attrib)) {
-                var semantic = semanticMap[attrib].semantic;
-                // store the info we'll need to copy this data into the vertex buffer
-                var size = getNumComponents(accessor.type) * getComponentSizeInBytes(accessor.componentType);
-                var buffer = buffers[bufferView.buffer];
-                sourceDesc[semantic] = {
-                    buffer: buffer.buffer,
-                    size: size,
-                    offset: (accessor.hasOwnProperty('byteOffset') ? accessor.byteOffset : 0) +
-                            (bufferView.hasOwnProperty('byteOffset') ? bufferView.byteOffset : 0) +
-                            (buffer.byteOffset),
-                    stride: bufferView.hasOwnProperty('byteStride') ? bufferView.byteStride : size,
-                    count: accessor.count,
-                    components: getNumComponents(accessor.type),
-                    type: getComponentType(accessor.componentType),
-                    normalize: accessor.normalized
-                };
-            }
+            var semantic = semanticMap[attrib].semantic;
+            var size = getNumComponents(accessor.type) * getComponentSizeInBytes(accessor.componentType);
+            var stride = bufferView.hasOwnProperty('byteStride') ? bufferView.byteStride : size;
+            sourceDesc[semantic] = {
+                buffer: accessorData.buffer,
+                size: size,
+                offset: accessorData.byteOffset,
+                stride: stride,
+                count: accessor.count,
+                components: getNumComponents(accessor.type),
+                type: getComponentType(accessor.componentType),
+                normalize: accessor.normalized
+            };
         }
     }
 
@@ -477,14 +453,14 @@ var createVertexBufferDraco = function (device, outputGeometry, extDraco, decode
     return createVertexBufferInternal(device, sourceDesc, disableFlipV);
 };
 
-var createSkin = function (device, gltfSkin, accessors, bufferViews, nodes, buffers) {
+var createSkin = function (device, gltfSkin, accessors, bufferViews, nodes) {
     var i, j, bindMatrix;
     var joints = gltfSkin.joints;
     var numJoints = joints.length;
     var ibp = [];
     if (gltfSkin.hasOwnProperty('inverseBindMatrices')) {
         var inverseBindMatrices = gltfSkin.inverseBindMatrices;
-        var ibmData = getAccessorData(accessors[inverseBindMatrices], bufferViews, buffers);
+        var ibmData = getAccessorData(accessors[inverseBindMatrices], bufferViews);
         var ibmValues = [];
 
         for (i = 0; i < numJoints; i++) {
@@ -523,7 +499,7 @@ var createSkin = function (device, gltfSkin, accessors, bufferViews, nodes, buff
 var tempMat = new Mat4();
 var tempVec = new Vec3();
 
-var createMesh = function (device, gltfMesh, accessors, bufferViews, buffers, callback, disableFlipV) {
+var createMesh = function (device, gltfMesh, accessors, bufferViews, callback, disableFlipV) {
     var meshes = [];
 
     var semanticMap = {
@@ -554,9 +530,7 @@ var createMesh = function (device, gltfMesh, accessors, bufferViews, buffers, ca
                 if (decoderModule) {
                     var extDraco = extensions.KHR_draco_mesh_compression;
                     if (extDraco.hasOwnProperty('attributes')) {
-                        var bufferView = bufferViews[extDraco.bufferView];
-                        var arrayBuffer = buffers[bufferView.buffer];
-                        var uint8Buffer = new Uint8Array(arrayBuffer.buffer, arrayBuffer.byteOffset + bufferView.byteOffset, bufferView.byteLength);
+                        var uint8Buffer = bufferViews[extDraco.bufferView];
                         var buffer = new decoderModule.DecoderBuffer();
                         buffer.Init(uint8Buffer, uint8Buffer.length);
 
@@ -626,8 +600,8 @@ var createMesh = function (device, gltfMesh, accessors, bufferViews, buffers, ca
 
         // if mesh was not constructed from draco data, use uncompressed
         if (!vertexBuffer) {
-            indices = primitive.hasOwnProperty('indices') ? getAccessorData(accessors[primitive.indices], bufferViews, buffers) : null;
-            vertexBuffer = createVertexBuffer(device, primitive.attributes, indices, accessors, bufferViews, buffers, semanticMap, disableFlipV);
+            indices = primitive.hasOwnProperty('indices') ? getAccessorData(accessors[primitive.indices], bufferViews) : null;
+            vertexBuffer = createVertexBuffer(device, primitive.attributes, indices, accessors, bufferViews, semanticMap, disableFlipV);
             primitiveType = getPrimitiveType(primitive);
         }
 
@@ -692,12 +666,14 @@ var createMesh = function (device, gltfMesh, accessors, bufferViews, buffers, ca
                     accessor = accessors[target.POSITION];
                     dataType = getComponentDataType(accessor.componentType);
 
-                    options.deltaPositions = getAccessorData(accessor, bufferViews, buffers);
+                    options.deltaPositions = getAccessorData(accessor, bufferViews);
                     options.deltaPositionsType = typedArrayToType[dataType.name];
 
                     if (accessor.sparse) {
-                        options.deltaPositions = sparseToFull(options.deltaPositions, getSparseAccessorIndices(accessor, bufferViews, buffers),
-                                                              dataType, mesh.vertexBuffer.numVertices);
+                        options.deltaPositions = sparseToFull(options.deltaPositions,
+                                                              getSparseAccessorIndices(accessor, bufferViews),
+                                                              dataType,
+                                                              mesh.vertexBuffer.numVertices);
 
                     }
 
@@ -712,12 +688,14 @@ var createMesh = function (device, gltfMesh, accessors, bufferViews, buffers, ca
                     accessor = accessors[target.NORMAL];
                     dataType = getComponentDataType(accessor.componentType);
 
-                    options.deltaNormals = getAccessorData(accessor, bufferViews, buffers);
+                    options.deltaNormals = getAccessorData(accessor, bufferViews);
                     options.deltaNormalsType = typedArrayToType[dataType.name];
 
                     if (accessor.sparse) {
-                        options.deltaNormals = sparseToFull(options.deltaNormals, getSparseAccessorIndices(accessor, bufferViews, buffers),
-                                                            dataType, mesh.vertexBuffer.numVertices);
+                        options.deltaNormals = sparseToFull(options.deltaNormals,
+                                                            getSparseAccessorIndices(accessor, bufferViews),
+                                                            dataType,
+                                                            mesh.vertexBuffer.numVertices);
                     }
                 }
 
@@ -1045,13 +1023,13 @@ var createMaterial = function (gltfMaterial, textures, disableFlipV) {
 };
 
 // create the anim structure
-var createAnimation = function (gltfAnimation, animationIndex, accessors, bufferViews, nodes, buffers) {
+var createAnimation = function (gltfAnimation, animationIndex, gltfAccessors, bufferViews, nodes) {
 
     // create animation data block for the accessor
-    var createAnimData = function (accessor) {
-        var data = getAccessorData(accessor, bufferViews, buffers);
+    var createAnimData = function (gltfAccessor) {
+        var data = getAccessorData(gltfAccessor, bufferViews);
         // TODO: this assumes data is tightly packed, handle the case data is interleaved
-        return new AnimData(getNumComponents(accessor.type), new data.constructor(data));
+        return new AnimData(getNumComponents(gltfAccessor.type), new data.constructor(data));
     };
 
     var interpMap = {
@@ -1077,13 +1055,13 @@ var createAnimation = function (gltfAnimation, animationIndex, accessors, buffer
         // get input data
         if (!inputMap.hasOwnProperty(sampler.input)) {
             inputMap[sampler.input] = inputs.length;
-            inputs.push(createAnimData(accessors[sampler.input]));
+            inputs.push(createAnimData(gltfAccessors[sampler.input]));
         }
 
         // get output data
         if (!outputMap.hasOwnProperty(sampler.output)) {
             outputMap[sampler.output] = outputs.length;
-            outputs.push(createAnimData(accessors[sampler.output]));
+            outputs.push(createAnimData(gltfAccessors[sampler.output]));
         }
 
         var interpolation =
@@ -1215,16 +1193,16 @@ var createNode = function (gltfNode, nodeIndex) {
     return entity;
 };
 
-var createSkins = function (device, gltf, nodes, buffers) {
+var createSkins = function (device, gltf, nodes, bufferViews) {
     if (!gltf.hasOwnProperty('skins') || gltf.skins.length === 0) {
         return [];
     }
     return gltf.skins.map(function (gltfSkin) {
-        return createSkin(device, gltfSkin, gltf.accessors, gltf.bufferViews, nodes, buffers);
+        return createSkin(device, gltfSkin, gltf.accessors, bufferViews, nodes);
     });
 };
 
-var createMeshes = function (device, gltf, buffers, callback, disableFlipV) {
+var createMeshes = function (device, gltf, bufferViews, callback, disableFlipV) {
     if (!gltf.hasOwnProperty('meshes') || gltf.meshes.length === 0 ||
         !gltf.hasOwnProperty('accessors') || gltf.accessors.length === 0 ||
         !gltf.hasOwnProperty('bufferViews') || gltf.bufferViews.length === 0) {
@@ -1232,7 +1210,7 @@ var createMeshes = function (device, gltf, buffers, callback, disableFlipV) {
     }
 
     return gltf.meshes.map(function (gltfMesh) {
-        return createMesh(device, gltfMesh, gltf.accessors, gltf.bufferViews, buffers, callback, disableFlipV);
+        return createMesh(device, gltfMesh, gltf.accessors, bufferViews, callback, disableFlipV);
     });
 };
 
@@ -1257,7 +1235,7 @@ var createMaterials = function (gltf, textures, options, disableFlipV) {
     });
 };
 
-var createAnimations = function (gltf, nodes, buffers, options) {
+var createAnimations = function (gltf, nodes, bufferViews, options) {
     if (!gltf.hasOwnProperty('animations') || gltf.animations.length === 0) {
         return [];
     }
@@ -1269,7 +1247,7 @@ var createAnimations = function (gltf, nodes, buffers, options) {
         if (preprocess) {
             preprocess(gltfAnimation);
         }
-        var animation = createAnimation(gltfAnimation, index, gltf.accessors, gltf.bufferViews, nodes, buffers);
+        var animation = createAnimation(gltfAnimation, index, gltf.accessors, bufferViews, nodes);
         if (postprocess) {
             postprocess(gltfAnimation, animation);
         }
@@ -1343,7 +1321,7 @@ var createScenes = function (gltf, nodes) {
 };
 
 // create engine resources from the downloaded GLB data
-var createResources = function (device, gltf, buffers, textures, options, callback) {
+var createResources = function (device, gltf, bufferViews, textures, options, callback) {
 
     var preprocess = options && options.global && options.global.preprocess;
     var postprocess = options && options.global && options.global.postprocess;
@@ -1359,12 +1337,12 @@ var createResources = function (device, gltf, buffers, textures, options, callba
 
     var nodes = createNodes(gltf, options);
     var scenes = createScenes(gltf, nodes);
-    var animations = createAnimations(gltf, nodes, buffers, options);
+    var animations = createAnimations(gltf, nodes, bufferViews, options);
     var materials = createMaterials(gltf, gltf.textures ? gltf.textures.map(function (t) {
         return textures[t.source].resource;
     }) : [], options, disableFlipV);
-    var meshes = createMeshes(device, gltf, buffers, callback, disableFlipV);
-    var skins = createSkins(device, gltf, nodes, buffers);
+    var meshes = createMeshes(device, gltf, bufferViews, callback, disableFlipV);
+    var skins = createSkins(device, gltf, nodes, bufferViews);
 
     var result = {
         'gltf': gltf,
@@ -1423,7 +1401,7 @@ var applySampler = function (texture, gltfSampler) {
 };
 
 // load textures using the asset system
-var loadTexturesAsync = function (gltf, buffers, urlBase, registry, options, callback) {
+var loadTexturesAsync = function (gltf, bufferViews, urlBase, registry, options, callback) {
     var result = [];
 
     if (!gltf.hasOwnProperty('images') || gltf.images.length === 0 ||
@@ -1433,7 +1411,9 @@ var loadTexturesAsync = function (gltf, buffers, urlBase, registry, options, cal
     }
 
     var preprocess = options && options.texture && options.texture.preprocess;
-    var processAsync = options && options.texture && options.texture.processAsync;
+    var processAsync = (options && options.texture && options.texture.processAsync) || function (gltfImage, callback) {
+        callback(null, null);
+    };
     var postprocess = options && options.texture && options.texture.postprocess;
 
     var remaining = gltf.images.length;
@@ -1493,38 +1473,29 @@ var loadTexturesAsync = function (gltf, buffers, urlBase, registry, options, cal
             preprocess(gltfImage);
         }
 
-        if (gltfImage.hasOwnProperty('uri')) {
-            // uri specified
-            if (isDataURI(gltfImage.uri)) {
-                loadTexture(i, gltfImage.uri, getDataURIMimeType(gltfImage.uri));
+        processAsync(gltfImage, function (i, gltfImage, err, textureAsset) {
+            if (err) {
+                callback(err);
+            } else if (textureAsset) {
+                onLoad(i, textureAsset);
             } else {
-                if (processAsync) {
-                    processAsync(gltfImage, function (index, err, textureAsset) {
-                        if (err) {
-                            callback(err);
-                        } else {
-                            onLoad(index, textureAsset);
-                        }
-                    }.bind(null, i));
+                if (gltfImage.hasOwnProperty('uri')) {
+                    // uri specified
+                    if (isDataURI(gltfImage.uri)) {
+                        loadTexture(i, gltfImage.uri, getDataURIMimeType(gltfImage.uri));
+                    } else {
+                        loadTexture(i, path.join(urlBase, gltfImage.uri), null, "anonymous");
+                    }
+                } else if (gltfImage.hasOwnProperty('bufferView') && gltfImage.hasOwnProperty('mimeType')) {
+                    // bufferview
+                    var blob = new Blob([bufferViews[gltfImage.bufferView]], { type: gltfImage.mimeType });
+                    loadTexture(i, URL.createObjectURL(blob), gltfImage.mimeType, null, true);
                 } else {
-                    loadTexture(i, path.join(urlBase, gltfImage.uri), null, "anonymous");
+                    // fail
+                    callback("Invalid image found in gltf (neither uri or bufferView found). index=" + i);
                 }
             }
-        } else if (gltfImage.hasOwnProperty('bufferView') && gltfImage.hasOwnProperty('mimeType')) {
-            // bufferview
-            var bufferView = gltf.bufferViews[gltfImage.bufferView];
-            var byteOffset = bufferView.hasOwnProperty('byteOffset') ? bufferView.byteOffset : 0;
-            var byteLength = bufferView.byteLength;
-
-            var buffer = buffers[bufferView.buffer];
-            var imageBuffer = new Uint8Array(buffer.buffer, buffer.byteOffset + byteOffset, byteLength);
-            var blob = new Blob([imageBuffer], { type: gltfImage.mimeType });
-            loadTexture(i, URL.createObjectURL(blob), gltfImage.mimeType, null, true);
-        } else {
-            // fail
-            callback("Invalid image found in gltf (neither uri or bufferView found). index=" + i);
-            return;
-        }
+        }.bind(null, i, gltfImage));
     }
 };
 
@@ -1538,7 +1509,9 @@ var loadBuffersAsync = function (gltf, binaryChunk, urlBase, options, callback) 
     }
 
     var preprocess = options && options.buffer && options.buffer.preprocess;
-    var processAsync = options && options.buffer && options.buffer.processAsync;
+    var processAsync = (options && options.buffer && options.buffer.processAsync) || function (gltfBuffer, callback) {
+        callback(null, null);
+    };
     var postprocess = options && options.buffer && options.buffer.postprocess;
 
     var remaining = gltf.buffers.length;
@@ -1559,51 +1532,46 @@ var loadBuffersAsync = function (gltf, binaryChunk, urlBase, options, callback) 
             preprocess(gltfBuffer);
         }
 
-        if (gltfBuffer.hasOwnProperty('uri')) {
-            if (isDataURI(gltfBuffer.uri)) {
-                // convert base64 to raw binary data held in a string
-                // doesn't handle URLEncoded DataURIs - see SO answer #6850276 for code that does this
-                var byteString = atob(gltfBuffer.uri.split(',')[1]);
-
-                // write the bytes of the string to an ArrayBuffer
-                var arrayBuffer = new ArrayBuffer(byteString.length);
-
-                // create a view into the buffer
-                var binaryArray = new Uint8Array(arrayBuffer);
-
-                // set the bytes of the buffer to the correct values
-                for (var j = 0; j < byteString.length; j++) {
-                    binaryArray[j] = byteString.charCodeAt(j);
-                }
-
-                onLoad(i, binaryArray);
+        processAsync(gltfBuffer, function (i, gltfBuffer, err, arrayBuffer) {           // eslint-disable-line no-loop-func
+            if (err) {
+                callback(err);
+            } else if (arrayBuffer) {
+                onLoad(i, new Uint8Array(arrayBuffer));
             } else {
-                if (processAsync) {
-                    processAsync(gltfBuffer, function (index, err, arrayBuffer) {           // eslint-disable-line no-loop-func
-                        if (err) {
-                            callback(err);
-                        } else {
-                            onLoad(index, new Uint8Array(arrayBuffer));
+                if (gltfBuffer.hasOwnProperty('uri')) {
+                    if (isDataURI(gltfBuffer.uri)) {
+                        // convert base64 to raw binary data held in a string
+                        // doesn't handle URLEncoded DataURIs - see SO answer #6850276 for code that does this
+                        var byteString = atob(gltfBuffer.uri.split(',')[1]);
+
+                        // create a view into the buffer
+                        var binaryArray = new Uint8Array(byteString.length);
+
+                        // set the bytes of the buffer to the correct values
+                        for (var j = 0; j < byteString.length; j++) {
+                            binaryArray[j] = byteString.charCodeAt(j);
                         }
-                    }.bind(null, i));
+
+                        onLoad(i, binaryArray);
+                    } else {
+                        http.get(
+                            path.join(urlBase, gltfBuffer.uri),
+                            { cache: true, responseType: 'arraybuffer', retry: false },
+                            function (i, err, result) {                         // eslint-disable-line no-loop-func
+                                if (err) {
+                                    callback(err);
+                                } else {
+                                    onLoad(i, new Uint8Array(result));
+                                }
+                            }.bind(null, i)
+                        );
+                    }
                 } else {
-                    http.get(
-                        path.join(urlBase, gltfBuffer.uri),
-                        { cache: true, responseType: 'arraybuffer', retry: false },
-                        function (index, err, result) {                         // eslint-disable-line no-loop-func
-                            if (err) {
-                                callback(err);
-                            } else {
-                                onLoad(index, new Uint8Array(result));
-                            }
-                        }.bind(null, i)
-                    );
+                    // glb buffer reference
+                    onLoad(i, binaryChunk);
                 }
             }
-        } else {
-            // glb buffer reference
-            onLoad(i, binaryChunk);
-        }
+        }.bind(null, i, gltfBuffer));
     }
 };
 
@@ -1704,6 +1672,47 @@ var parseChunk = function (filename, data, callback) {
     }
 };
 
+// create buffer views
+var parseBufferViewsAsync = function (gltf, buffers, options, callback) {
+
+    var result = [];
+
+    var remaining = gltf.bufferViews.length;
+    var onLoad = function (index, bufferView) {
+        var gltfBufferView = gltf.bufferViews[index];
+        if (gltfBufferView.hasOwnProperty('byteStride')) {
+            bufferView.byteStride = gltfBufferView.byteStride;
+        }
+
+        result[index] = bufferView;
+        if (--remaining === 0) {
+            callback(null, result);
+        }
+    };
+
+    var processAsync = (options && options.bufferView && options.bufferView.processAsync) || function (gltfBufferView, buffers, callback) {
+        callback(null, null);
+    };
+
+    for (var i = 0; i < gltf.bufferViews.length; ++i) {
+        var gltfBufferView = gltf.bufferViews[i];
+
+        processAsync(gltfBufferView, buffers, function (i, gltfBufferView, err, result) {       // eslint-disable-line no-loop-func
+            if (err) {
+                callback(err);
+            } else if (result) {
+                onLoad(i, result);
+            } else {
+                var buffer = buffers[gltfBufferView.buffer];
+                var typedArray = new Uint8Array(buffer.buffer,
+                                                buffer.byteOffset + (gltfBufferView.hasOwnProperty('byteOffset') ? gltfBufferView.byteOffset : 0),
+                                                gltfBufferView.byteLength);
+                onLoad(i, typedArray);
+            }
+        }.bind(null, i, gltfBufferView));
+    }
+};
+
 // -- GlbParser
 
 function GlbParser() {}
@@ -1731,14 +1740,22 @@ GlbParser.parseAsync = function (filename, urlBase, data, device, registry, opti
                     return;
                 }
 
-                // async load images
-                loadTexturesAsync(gltf, buffers, urlBase, registry, options, function (err, textures) {
+                // async load buffer views
+                parseBufferViewsAsync(gltf, buffers, options, function (err, bufferViews) {
                     if (err) {
                         callback(err);
                         return;
                     }
 
-                    createResources(device, gltf, buffers, textures, options, callback);
+                    // async load images
+                    loadTexturesAsync(gltf, bufferViews, urlBase, registry, options, function (err, textures) {
+                        if (err) {
+                            callback(err);
+                            return;
+                        }
+
+                        createResources(device, gltf, bufferViews, textures, options, callback);
+                    });
                 });
             });
         });
@@ -1748,6 +1765,8 @@ GlbParser.parseAsync = function (filename, urlBase, data, device, registry, opti
 // parse the gltf or glb data synchronously. external resources (buffers and images) are ignored.
 GlbParser.parse = function (filename, data, device, options) {
     var result = null;
+
+    options = options || { };
 
     // parse the data
     parseChunk(filename, data, function (err, chunks) {
@@ -1759,15 +1778,19 @@ GlbParser.parse = function (filename, data, device, options) {
                 if (err) {
                     console.error(err);
                 } else {
-                    var buffers = [chunks.binaryChunk];
-                    var textures = [];
-
-                    // create resources
-                    createResources(device, gltf, buffers, textures, options || { }, function (err, result_) {
+                    // parse buffer views
+                    parseBufferViewsAsync(gltf, [chunks.binaryChunk], options, function (err, bufferViews) {
                         if (err) {
                             console.error(err);
                         } else {
-                            result = result_;
+                            // create resources
+                            createResources(device, gltf, bufferViews, [], options, function (err, result_) {
+                                if (err) {
+                                    console.error(err);
+                                } else {
+                                    result = result_;
+                                }
+                            });
                         }
                     });
                 }


### PR DESCRIPTION
This PR simplifies the way bufferViews are handled in GlbParser and adds support for `preprocess`, `processAsync` and `postprocess` callbacks. This callback support will allow us to easily integrate bufferView-based compression schemes, for example https://github.com/zeux/meshoptimizer.

ContainerHandler's asynchronous callbacks were changed. The `processAsync` handlers are now always called, but if the handler invokes the continuation without an error or result (i.e. `callback(null, null);`), this indicates the resource was unhandled and GlbParser continues to load the resource as usual.

Also fixed a bug with MiniStats sometimes failing to update it's dynamic texture.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
