### PR TITLE
Add vehicle physics example

### DIFF
--- a/examples/assets/scripts/camera/tracking-camera.js
+++ b/examples/assets/scripts/camera/tracking-camera.js
@@ -3,7 +3,7 @@ var TrackingCamera = pc.createScript('trackingCamera');
 TrackingCamera.attributes.add('target', { type: 'entity' });
 
 // update code called every frame
-TrackingCamera.prototype.postUpdate = function(dt) {
+TrackingCamera.prototype.postUpdate = function (dt) {
     if (this.target) {
         var targetPos = this.target.getPosition();
         this.entity.lookAt(targetPos);

--- a/examples/assets/scripts/camera/tracking-camera.js
+++ b/examples/assets/scripts/camera/tracking-camera.js
@@ -1,0 +1,11 @@
+var TrackingCamera = pc.createScript('trackingCamera');
+
+TrackingCamera.attributes.add('target', { type: 'entity' });
+
+// update code called every frame
+TrackingCamera.prototype.postUpdate = function(dt) {
+    if (this.target) {
+        var targetPos = this.target.getPosition();
+        this.entity.lookAt(targetPos);
+    }
+};

--- a/examples/assets/scripts/physics/render-physics.js
+++ b/examples/assets/scripts/physics/render-physics.js
@@ -1,12 +1,12 @@
-var DebugPhysics = pc.createScript('debugPhysics');
+var RenderPhysics = pc.createScript('renderPhysics');
 
-DebugPhysics.attributes.add('drawShapes', {
+RenderPhysics.attributes.add('drawShapes', {
     type: 'boolean',
     default: false,
     title: 'Draw Shapes',
     description: 'Draw representations of physics collision shapes'
 });
-DebugPhysics.attributes.add('opacity', {
+RenderPhysics.attributes.add('opacity', {
     type: 'number',
     default: 0.5,
     min: 0,
@@ -14,7 +14,7 @@ DebugPhysics.attributes.add('opacity', {
     title: 'Opacity',
     description: 'Opacity of physics collision shapes'
 });
-DebugPhysics.attributes.add('castShadows', {
+RenderPhysics.attributes.add('castShadows', {
     type: 'boolean',
     default: true,
     title: 'Cast Shadows',
@@ -22,7 +22,7 @@ DebugPhysics.attributes.add('castShadows', {
 });
 
 // initialize code called once per entity
-DebugPhysics.prototype.initialize = function () {
+RenderPhysics.prototype.initialize = function () {
     // Handle attribute change events
     this.on('attr:castShadows', function (value, prev) {
         this.debugRoot.children.forEach(function (child) {
@@ -59,7 +59,7 @@ DebugPhysics.prototype.initialize = function () {
     });
 };
 
-DebugPhysics.prototype.createModel = function (mesh, material) {
+RenderPhysics.prototype.createModel = function (mesh, material) {
     var node = new pc.GraphNode();
     var meshInstance = new pc.MeshInstance(node, mesh, material);
     var model = new pc.Model();
@@ -68,7 +68,7 @@ DebugPhysics.prototype.createModel = function (mesh, material) {
     return model;
 };
 
-DebugPhysics.prototype.postUpdate = function (dt) {
+RenderPhysics.prototype.postUpdate = function (dt) {
     // For any existing debug shapes, mark them as not updated (yet)
     this.debugRoot.children.forEach(function (child) {
         child.updated = false;

--- a/examples/assets/scripts/physics/reset-physics.js
+++ b/examples/assets/scripts/physics/reset-physics.js
@@ -1,7 +1,7 @@
 var ResetPhysics = pc.createScript('resetPhysics');
 
 // initialize code called once per entity
-ResetPhysics.prototype.postInitialize = function() {
+ResetPhysics.prototype.postInitialize = function () {
     // Record the start state of all dynamic rigid bodies
     this.bodies = [];
     this.app.root.findComponents('rigidbody').forEach(function (bodyComponent) {
@@ -16,7 +16,7 @@ ResetPhysics.prototype.postInitialize = function() {
 };
 
 // update code called every frame
-ResetPhysics.prototype.update = function(dt) {
+ResetPhysics.prototype.update = function (dt) {
     if (this.app.keyboard.wasPressed(pc.KEY_R)) {
         this.bodies.forEach(function (body) {
             // Reset all dynamic bodies to their initial state

--- a/examples/assets/scripts/physics/reset-physics.js
+++ b/examples/assets/scripts/physics/reset-physics.js
@@ -1,0 +1,28 @@
+var ResetPhysics = pc.createScript('resetPhysics');
+
+// initialize code called once per entity
+ResetPhysics.prototype.postInitialize = function() {
+    // Record the start state of all dynamic rigid bodies
+    this.bodies = [];
+    this.app.root.findComponents('rigidbody').forEach(function (bodyComponent) {
+        if (bodyComponent.type === 'dynamic') {
+            this.bodies.push({
+                entity: bodyComponent.entity,
+                initialPos: bodyComponent.entity.getPosition().clone(),
+                initialRot: bodyComponent.entity.getRotation().clone()
+            });
+        }
+    }, this);
+};
+
+// update code called every frame
+ResetPhysics.prototype.update = function(dt) {
+    if (this.app.keyboard.wasPressed(pc.KEY_R)) {
+        this.bodies.forEach(function (body) {
+            // Reset all dynamic bodies to their initial state
+            body.entity.rigidbody.teleport(body.initialPos, body.initialRot);
+            body.entity.rigidbody.linearVelocity = pc.Vec3.ZERO;
+            body.entity.rigidbody.angularVelocity = pc.Vec3.ZERO;
+        });
+    }
+};

--- a/examples/assets/scripts/physics/vehicle.js
+++ b/examples/assets/scripts/physics/vehicle.js
@@ -17,7 +17,7 @@ Vehicle.attributes.add('maxBrakingForce', {
 });
 Vehicle.attributes.add('maxSteering', {
     type: 'number',
-    default: 0.2,
+    default: 0.3,
     title: 'Max Steering'
 });
 
@@ -155,7 +155,7 @@ VehicleWheel.attributes.add('isFront', {
 });
 VehicleWheel.attributes.add('radius', {
     type: 'number',
-    default: 0.5,
+    default: 0.4,
     title: 'Radius'
 });
 VehicleWheel.attributes.add('width', {
@@ -165,7 +165,7 @@ VehicleWheel.attributes.add('width', {
 });
 VehicleWheel.attributes.add('suspensionStiffness', {
     type: 'number',
-    default: 20,
+    default: 10,
     title: 'Suspension Stiffness'
 });
 VehicleWheel.attributes.add('suspensionDamping', {
@@ -180,7 +180,7 @@ VehicleWheel.attributes.add('suspensionCompression', {
 });
 VehicleWheel.attributes.add('suspensionRestLength', {
     type: 'number',
-    default: 0.6,
+    default: 0.2,
     title: 'Suspension Rest Length'
 });
 VehicleWheel.attributes.add('rollInfluence', {

--- a/examples/assets/scripts/physics/vehicle.js
+++ b/examples/assets/scripts/physics/vehicle.js
@@ -1,0 +1,359 @@
+var Vehicle = pc.createScript('vehicle');
+
+Vehicle.attributes.add('wheels', {
+    type: 'entity',
+    array: true,
+    title: 'Wheels'
+});
+Vehicle.attributes.add('maxEngineForce', {
+    type: 'number',
+    default: 2000,
+    title: 'Max Engine Force'
+});
+Vehicle.attributes.add('maxBrakingForce', {
+    type: 'number',
+    default: 100,
+    title: 'Max Braking Force'
+});
+Vehicle.attributes.add('maxSteering', {
+    type: 'number',
+    default: 0.2,
+    title: 'Max Steering'
+});
+
+Object.defineProperty(Vehicle.prototype, 'speed', {
+    get: function () {
+        return this.vehicle ? this.vehicle.getCurrentSpeedKmHour() : 0;
+    }
+});
+
+// initialize code called once per entity
+Vehicle.prototype.initialize = function () {
+    var body = this.entity.rigidbody.body;
+    var dynamicsWorld = this.app.systems.rigidbody.dynamicsWorld;
+
+    // Create vehicle
+    var tuning = new Ammo.btVehicleTuning();
+    var vehicleRayCaster = new Ammo.btDefaultVehicleRaycaster(dynamicsWorld);
+    var vehicle = new Ammo.btRaycastVehicle(tuning, body, vehicleRayCaster);
+    vehicle.setCoordinateSystem(0, 1, 2);
+
+    // Never deactivate the vehicle
+    var DISABLE_DEACTIVATION = 4;
+    body.setActivationState(DISABLE_DEACTIVATION);
+
+    // Add wheels to the vehicle
+    var wheelAxle = new Ammo.btVector3(-1, 0, 0);
+    var wheelDirection = new Ammo.btVector3(0, -1, 0);
+    var connectionPoint = new Ammo.btVector3(0, 0, 0);
+
+    this.wheels.forEach(function (wheelEntity) {
+        var wheelScript = wheelEntity.script.vehicleWheel;
+
+        var frictionSlip = wheelScript.frictionSlip;
+        var isFront = wheelScript.isFront;
+        var radius = wheelScript.radius;
+        var rollInfluence = wheelScript.rollInfluence;
+        var suspensionCompression = wheelScript.suspensionCompression;
+        var suspensionDamping = wheelScript.suspensionDamping;
+        var suspensionRestLength = wheelScript.suspensionRestLength;
+        var suspensionStiffness = wheelScript.suspensionStiffness;
+
+        var wheelPos = wheelEntity.getLocalPosition();
+        connectionPoint.setValue(wheelPos.x, wheelPos.y, wheelPos.z);
+        var wheelInfo = vehicle.addWheel(connectionPoint, wheelDirection, wheelAxle, suspensionRestLength, radius, tuning, isFront);
+
+        wheelInfo.set_m_suspensionStiffness(suspensionStiffness);
+        wheelInfo.set_m_wheelsDampingRelaxation(suspensionDamping);
+        wheelInfo.set_m_wheelsDampingCompression(suspensionCompression);
+        wheelInfo.set_m_frictionSlip(frictionSlip);
+        wheelInfo.set_m_rollInfluence(rollInfluence);
+    }, this);
+
+    Ammo.destroy(wheelAxle);
+    Ammo.destroy(wheelDirection);
+    Ammo.destroy(connectionPoint);
+
+    // Add the vehicle to the dynamics world
+    dynamicsWorld.addAction(vehicle);
+
+    this.vehicle = vehicle;
+
+    this.engineForce = 0;
+    this.brakingForce = 0;
+    this.steering = 0;
+
+    // Event handling
+    this.on("enable", function () {
+        dynamicsWorld.addAction(vehicle);
+    });
+
+    this.on("disable", function () {
+        dynamicsWorld.removeAction(vehicle);
+    });
+
+    this.on("destroy", function () {
+        dynamicsWorld.removeAction(vehicle);
+
+        Ammo.destroy(vehicleRayCaster);
+        Ammo.destroy(vehicle);
+    });
+
+    this.on('vehicle:controls', function (steering, throttle) {
+        this.steering = pc.math.lerp(this.steering, steering * this.maxSteering, 0.3);
+
+        if (throttle > 0) {
+            this.brakingForce = 0;
+            this.engineForce = this.maxEngineForce;
+        } else if (throttle < 0) {
+            this.brakingForce = 0;
+            this.engineForce = -this.maxEngineForce;
+        } else {
+            this.brakingForce = this.maxBrakingForce;
+            this.engineForce = 0;
+        }
+    });
+};
+
+// update code called every frame
+Vehicle.prototype.update = function (dt) {
+    var vehicle = this.vehicle;
+    var i;
+
+    // Apply steering to the front wheels
+    vehicle.setSteeringValue(this.steering, 0);
+    vehicle.setSteeringValue(this.steering, 1);
+
+    // Apply engine and braking force to the back wheels
+    vehicle.applyEngineForce(this.engineForce, 2);
+    vehicle.setBrake(this.brakingForce, 2);
+    vehicle.applyEngineForce(this.engineForce, 3);
+    vehicle.setBrake(this.brakingForce, 3);
+
+    var numWheels = vehicle.getNumWheels();
+    for (i = 0; i < numWheels; i++) {
+        // synchronize the wheels with the (interpolated) chassis worldtransform
+        vehicle.updateWheelTransform(i, true);
+        var t = this.vehicle.getWheelTransformWS(i);
+
+        var p = t.getOrigin();
+        var q = t.getRotation();
+
+        var wheel = this.wheels[i];
+        wheel.setPosition(p.x(), p.y(), p.z());
+        wheel.setRotation(q.x(), q.y(), q.z(), q.w());
+    }
+};
+
+
+var VehicleWheel = pc.createScript('vehicleWheel');
+
+VehicleWheel.attributes.add('isFront', {
+    type: 'boolean',
+    default: true,
+    title: 'Front Wheel'
+});
+VehicleWheel.attributes.add('radius', {
+    type: 'number',
+    default: 0.5,
+    title: 'Radius'
+});
+VehicleWheel.attributes.add('width', {
+    type: 'number',
+    default: 0.4,
+    title: 'Width'
+});
+VehicleWheel.attributes.add('suspensionStiffness', {
+    type: 'number',
+    default: 20,
+    title: 'Suspension Stiffness'
+});
+VehicleWheel.attributes.add('suspensionDamping', {
+    type: 'number',
+    default: 2.3,
+    title: 'Suspension Damping'
+});
+VehicleWheel.attributes.add('suspensionCompression', {
+    type: 'number',
+    default: 4.4,
+    title: 'Suspension Compression'
+});
+VehicleWheel.attributes.add('suspensionRestLength', {
+    type: 'number',
+    default: 0.6,
+    title: 'Suspension Rest Length'
+});
+VehicleWheel.attributes.add('rollInfluence', {
+    type: 'number',
+    default: 0.2,
+    title: 'Roll Influence'
+});
+VehicleWheel.attributes.add('frictionSlip', {
+    type: 'number',
+    default: 1000,
+    title: 'Friction Slip'
+});
+VehicleWheel.attributes.add('debugRender', {
+    type: 'boolean',
+    default: false,
+    title: 'Debug Render'
+});
+
+VehicleWheel.prototype.initialize = function () {
+    var createDebugWheel = function (radius, width) {
+        var debugWheel = new pc.Entity();
+        debugWheel.addComponent('model', {
+            type: 'cylinder',
+            castShadows: true
+        });
+        debugWheel.setLocalEulerAngles(0, 0, 90);
+        debugWheel.setLocalScale(radius * 2, width, radius * 2);
+        return debugWheel;
+    };
+
+    if (this.debugRender) {
+        this.debugWheel = createDebugWheel(this.radius, this.width);
+        this.entity.addChild(this.debugWheel);
+    }
+
+    this.on('attr:debugRender', function (value, prev) {
+        if (value) {
+            this.debugWheel = createDebugWheel(this.radius, this.width);
+            this.entity.addChild(this.debugWheel);
+        } else {
+            if (this.debugWheel) {
+                this.debugWheel.destroy();
+                this.debugWheel = null;
+            }
+        }
+    });
+};
+
+
+var VehicleControls = pc.createScript('vehicleControls');
+
+VehicleControls.attributes.add('targetVehicle', {
+    type: 'entity',
+    title: 'Target Vehicle'
+});
+VehicleControls.attributes.add('leftButton', {
+    type: 'entity',
+    title: 'Left Button'
+});
+VehicleControls.attributes.add('rightButton', {
+    type: 'entity',
+    title: 'Right Button'
+});
+VehicleControls.attributes.add('forwardButton', {
+    type: 'entity',
+    title: 'Forward Button'
+});
+VehicleControls.attributes.add('reverseButton', {
+    type: 'entity',
+    title: 'Reverse Button'
+});
+
+VehicleControls.prototype.initialize = function () {
+    this.leftButtonPressed = false;
+    this.rightButtonPressed = false;
+    this.upButtonPressed = false;
+    this.downButtonPressed = false;
+    this.leftKeyPressed = false;
+    this.rightKeyPressed = false;
+    this.upKeyPressed = false;
+    this.downKeyPressed = false;
+
+    if (this.leftButton) {
+        this.leftButton.enabled = pc.platform.mobile;
+        this.leftButton.button.on('pressedstart', function () {
+            this.leftButtonPressed = true;
+        }, this);
+        this.leftButton.button.on('pressedend', function () {
+            this.leftButtonPressed = false;
+        }, this);
+    }
+    if (this.rightButton) {
+        this.rightButton.enabled = pc.platform.mobile;
+        this.rightButton.button.on('pressedstart', function () {
+            this.rightButtonPressed = true;
+        }, this);
+        this.rightButton.button.on('pressedend', function () {
+            this.rightButtonPressed = false;
+        }, this);
+    }
+    if (this.forwardButton) {
+        this.forwardButton.enabled = pc.platform.mobile;
+        this.forwardButton.button.on('pressedstart', function () {
+            this.upButtonPressed = true;
+        }, this);
+        this.forwardButton.button.on('pressedend', function () {
+            this.upButtonPressed = false;
+        }, this);
+    }
+    if (this.reverseButton) {
+        this.reverseButton.enabled = pc.platform.mobile;
+        this.reverseButton.button.on('pressedstart', function () {
+            this.downButtonPressed = true;
+        }, this);
+        this.reverseButton.button.on('pressedend', function () {
+            this.downButtonPressed = false;
+        }, this);
+    }
+
+    this.app.keyboard.on('keydown', function (e) {
+        switch (e.key) {
+            case pc.KEY_A:
+            case pc.KEY_LEFT:
+                this.leftKeyPressed = true;
+                break;
+            case pc.KEY_D:
+            case pc.KEY_RIGHT:
+                this.rightKeyPressed = true;
+                break;
+            case pc.KEY_W:
+            case pc.KEY_UP:
+                this.upKeyPressed = true;
+                break;
+            case pc.KEY_S:
+            case pc.KEY_DOWN:
+                this.downKeyPressed = true;
+                break;
+        }
+    }, this);
+    this.app.keyboard.on('keyup', function (e) {
+        switch (e.key) {
+            case pc.KEY_A:
+            case pc.KEY_LEFT:
+                this.leftKeyPressed = false;
+                break;
+            case pc.KEY_D:
+            case pc.KEY_RIGHT:
+                this.rightKeyPressed = false;
+                break;
+            case pc.KEY_W:
+            case pc.KEY_UP:
+                this.upKeyPressed = false;
+                break;
+            case pc.KEY_S:
+            case pc.KEY_DOWN:
+                this.downKeyPressed = false;
+                break;
+        }
+    }, this);
+};
+
+VehicleControls.prototype.update = function (dt) {
+    var targetVehicle = this.targetVehicle ? this.targetVehicle : this.entity;
+
+    if (targetVehicle) {
+        var steering = 0;
+        var throttle = 0;
+
+        if (this.leftButtonPressed || this.leftKeyPressed) steering++;
+        if (this.rightButtonPressed || this.rightKeyPressed) steering--;
+        if (this.upButtonPressed || this.upKeyPressed) throttle++;
+        if (this.downButtonPressed || this.downKeyPressed) throttle--;
+
+        targetVehicle.script.vehicle.fire('vehicle:controls', steering, throttle);
+    }
+};

--- a/examples/assets/scripts/physics/vehicle.js
+++ b/examples/assets/scripts/physics/vehicle.js
@@ -120,6 +120,10 @@ Vehicle.prototype.update = function (dt) {
     var vehicle = this.vehicle;
     var i;
 
+    var body = this.entity.rigidbody.body;
+    var DISABLE_DEACTIVATION = 4;
+    body.setActivationState(DISABLE_DEACTIVATION);
+
     // Apply steering to the front wheels
     vehicle.setSteeringValue(this.steering, 0);
     vehicle.setSteeringValue(this.steering, 1);
@@ -180,7 +184,7 @@ VehicleWheel.attributes.add('suspensionCompression', {
 });
 VehicleWheel.attributes.add('suspensionRestLength', {
     type: 'number',
-    default: 0.2,
+    default: 0.4,
     title: 'Suspension Rest Length'
 });
 VehicleWheel.attributes.add('rollInfluence', {

--- a/examples/examples.js
+++ b/examples/examples.js
@@ -71,7 +71,8 @@ var categories = [
         examples: [
             "compound-collision",
             "falling-shapes",
-            "raycast"
+            "raycast",
+            "vehicle"
         ]
     }, {
         name: "sound",

--- a/examples/physics/vehicle.html
+++ b/examples/physics/vehicle.html
@@ -82,6 +82,7 @@
         });
 
         function run() {
+            // Create a static ground shape for our car to drive on
             var ground = new pc.Entity('Ground');
             ground.addComponent('rigidbody', {
                 type: 'static'
@@ -93,28 +94,7 @@
             ground.setLocalPosition(0, -0.5, 0);
             app.root.addChild(ground);
 
-            var vehicle = new pc.Entity('Vehicle');
-            vehicle.addComponent('rigidbody', {
-                mass: 800,
-                type: 'dynamic'
-            });
-            vehicle.addComponent('collision', {
-                type: 'compound'
-            });
-            vehicle.addComponent('script');
-            vehicle.script.create('vehicleControls');
-            vehicle.setLocalPosition(0, 2, 0);
-            app.root.addChild(vehicle);
-
-            // Create the car chassis, offset upwards in Y from the compound body
-            var chassis = new pc.Entity('Chassis');
-            chassis.addComponent('collision', {
-                type: 'box',
-                halfExtents: [0.6, 0.35, 1.65]
-            });
-            chassis.setLocalPosition(0, 0.65, -0.05);
-            vehicle.addChild(chassis);
-
+            // Create 4 wheels for our vehicle
             var wheels = [];
             [
                 { name: 'Front Left Wheel', pos: new pc.Vec3(0.8, 0.4, 1.2), front: true },
@@ -132,16 +112,43 @@
                     }
                 });
                 wheel.setLocalPosition(wheelDef.pos);
-                vehicle.addChild(wheel);
                 wheels.push(wheel);
             });
 
+            // Create a physical vehicle
+            var vehicle = new pc.Entity('Vehicle');
+            vehicle.addComponent('rigidbody', {
+                mass: 800,
+                type: 'dynamic'
+            });
+            vehicle.addComponent('collision', {
+                type: 'compound'
+            });
+            vehicle.addComponent('script');
             vehicle.script.create('vehicle', {
                 attributes: {
                     wheels: wheels
                 }
             });
+            vehicle.script.create('vehicleControls');
+            vehicle.setLocalPosition(0, 2, 0);
 
+            // Create the car chassis, offset upwards in Y from the compound body
+            var chassis = new pc.Entity('Chassis');
+            chassis.addComponent('collision', {
+                type: 'box',
+                halfExtents: [0.6, 0.35, 1.65]
+            });
+            chassis.setLocalPosition(0, 0.65, -0.05);
+
+            // Add the vehicle to the hierarchy
+            wheels.forEach(function (wheel) {
+                vehicle.addChild(wheel);
+            });
+            vehicle.addChild(chassis);
+            app.root.addChild(vehicle);
+
+            // Build a wall of blocks for the car to smash through
             for (var i = 0; i < 10; i++) {
                 for (var j = 0; j < 5; j++) {
                     var block = new pc.Entity('Block');
@@ -163,7 +170,7 @@
                 color: new pc.Color(1, 1, 1),
                 castShadows: true,
                 shadowBias: 0.2,
-                shadowDistance: 16,
+                shadowDistance: 40,
                 normalOffsetBias: 0.05,
                 shadowResolution: 2048
             });
@@ -183,7 +190,7 @@
             camera.lookAt(0, 0, 0);
             app.root.addChild(camera);
 
-            // Enable rendering of all rigid bodies in the scene
+            // Enable rendering and resetting of all rigid bodies in the scene
             app.root.addComponent('script');
             app.root.script.create('renderPhysics', {
                 attributes: {

--- a/examples/physics/vehicle.html
+++ b/examples/physics/vehicle.html
@@ -139,13 +139,22 @@
                 type: 'box',
                 halfExtents: [0.6, 0.35, 1.65]
             });
-            chassis.setLocalPosition(0, 0.65, -0.05);
+            chassis.setLocalPosition(0, 0.65, 0);
+
+            // Create the car chassis, offset upwards in Y from the compound body
+            var cab = new pc.Entity('Cab');
+            cab.addComponent('collision', {
+                type: 'box',
+                halfExtents: [0.5, 0.2, 1]
+            });
+            cab.setLocalPosition(0, 1.2, -0.25);
 
             // Add the vehicle to the hierarchy
             wheels.forEach(function (wheel) {
                 vehicle.addChild(wheel);
             });
             vehicle.addChild(chassis);
+            vehicle.addChild(cab);
             app.root.addChild(vehicle);
 
             // Build a wall of blocks for the car to smash through
@@ -186,7 +195,7 @@
                     target: vehicle
                 }
             });
-            camera.translate(0, 10, 25);
+            camera.translate(0, 10, 15);
             camera.lookAt(0, 0, 0);
             app.root.addChild(camera);
 

--- a/examples/physics/vehicle.html
+++ b/examples/physics/vehicle.html
@@ -1,0 +1,199 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>PlayCanvas Vehicle</title>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
+    <link rel="icon" type="image/png" href="../playcanvas-favicon.png" />
+    <script src="../../build/playcanvas.js"></script>
+    <script src="../../build/playcanvas-extras.js"></script>
+    <script src="../wasm-loader.js"></script>
+    <style>
+        body { 
+            margin: 0;
+            overflow-y: hidden;
+        }
+    </style>
+</head>
+
+<body>
+    <!-- The canvas element -->
+    <canvas id="application-canvas"></canvas>
+
+    <!-- The script -->
+    <script>
+    if (wasmSupported()) {
+        loadWasmModuleAsync('Ammo', '../lib/ammo/ammo.wasm.js', '../lib/ammo/ammo.wasm.wasm', demo);
+    } else {
+        loadWasmModuleAsync('Ammo', '../lib/ammo/ammo.js', '', demo);
+    }
+
+    function demo() {
+        var canvas = document.getElementById("application-canvas");
+
+        // Create the application and start the update loop
+        var app = new pc.Application(canvas, {
+            keyboard: new pc.Keyboard(window)
+        });
+        app.start();
+
+        // Set the canvas to fill the window and automatically change resolution to be the same as the canvas size
+        app.setCanvasFillMode(pc.FILLMODE_FILL_WINDOW);
+        app.setCanvasResolution(pc.RESOLUTION_AUTO);
+
+        window.addEventListener("resize", function () {
+            app.resizeCanvas(canvas.width, canvas.height);
+        });
+
+        var miniStats = new pcx.MiniStats(app);
+
+        // A list of assets that need to be loaded
+        var assetManifest = [
+            {
+                type: "script",
+                url: "../assets/scripts/camera/tracking-camera.js"
+            },
+            {
+                type: "script",
+                url: "../assets/scripts/physics/render-physics.js"
+            },
+            {
+                type: "script",
+                url: "../assets/scripts/physics/reset-physics.js"
+            },
+            {
+                type: "script",
+                url: "../assets/scripts/physics/vehicle.js"
+            }
+        ];
+
+        // Load all assets and then run the example
+        var assetsToLoad = assetManifest.length;
+        assetManifest.forEach(function (entry) {
+            app.assets.loadFromUrl(entry.url, entry.type, function (err, asset) {
+                if (!err && asset) {
+                    assetsToLoad--;
+                    entry.asset = asset;
+                    if (assetsToLoad === 0) {
+                        run();
+                    }
+                }
+            });
+        });
+
+        function run() {
+            var ground = new pc.Entity('Ground');
+            ground.addComponent('rigidbody', {
+                type: 'static'
+            });
+            ground.addComponent('collision', {
+                type: 'box',
+                halfExtents: new pc.Vec3(50, 0.5, 50)
+            });
+            ground.setLocalPosition(0, -0.5, 0);
+            app.root.addChild(ground);
+
+            var vehicle = new pc.Entity('Vehicle');
+            vehicle.addComponent('rigidbody', {
+                mass: 800,
+                type: 'dynamic'
+            });
+            vehicle.addComponent('collision', {
+                type: 'compound'
+            });
+            vehicle.addComponent('script');
+            vehicle.script.create('vehicleControls');
+            vehicle.setLocalPosition(0, 2, 0);
+            app.root.addChild(vehicle);
+
+            // Create the car chassis, offset upwards in Y from the compound body
+            var chassis = new pc.Entity('Chassis');
+            chassis.addComponent('collision', {
+                type: 'box',
+                halfExtents: [0.6, 0.35, 1.65]
+            });
+            chassis.setLocalPosition(0, 0.65, -0.05);
+            vehicle.addChild(chassis);
+
+            var wheels = [];
+            [
+                { name: 'Front Left Wheel', pos: new pc.Vec3(0.8, 0.4, 1.2), front: true },
+                { name: 'Front Right Wheel', pos: new pc.Vec3(-0.8, 0.4, 1.2), front: true },
+                { name: 'Back Left Wheel', pos: new pc.Vec3(0.8, 0.4, -1.2), front: false },
+                { name: 'Back Right Wheel', pos: new pc.Vec3(-0.8, 0.4, -1.2), front: false }
+            ].forEach(function (wheelDef) {
+                // Create a wheel
+                var wheel = new pc.Entity(wheelDef.name);
+                wheel.addComponent('script');
+                wheel.script.create('vehicleWheel', {
+                    attributes: {
+                        debugRender: true,
+                        isFront: wheelDef.front
+                    }
+                });
+                wheel.setLocalPosition(wheelDef.pos);
+                vehicle.addChild(wheel);
+                wheels.push(wheel);
+            });
+
+            vehicle.script.create('vehicle', {
+                attributes: {
+                    wheels: wheels
+                }
+            });
+
+            for (var i = 0; i < 10; i++) {
+                for (var j = 0; j < 5; j++) {
+                    var block = new pc.Entity('Block');
+                    block.addComponent('rigidbody', {
+                        type: 'dynamic'
+                    });
+                    block.addComponent('collision', {
+                        type: 'box'
+                    });
+                    block.setLocalPosition(i - 4.5, j + 0.5, -10);
+                    app.root.addChild(block);
+                }
+            }
+
+            // Create a directional light source
+            var light = new pc.Entity('Directional Light');
+            light.addComponent("light", {
+                type: "directional",
+                color: new pc.Color(1, 1, 1),
+                castShadows: true,
+                shadowBias: 0.2,
+                shadowDistance: 16,
+                normalOffsetBias: 0.05,
+                shadowResolution: 2048
+            });
+            light.setLocalEulerAngles(45, 30, 0);
+            app.root.addChild(light);
+
+            // Create a camera to render the scene
+            var camera = new pc.Entity('Camera');
+            camera.addComponent("camera");
+            camera.addComponent('script');
+            camera.script.create('trackingCamera', {
+                attributes: {
+                    target: vehicle
+                }
+            });
+            camera.translate(0, 10, 25);
+            camera.lookAt(0, 0, 0);
+            app.root.addChild(camera);
+
+            // Enable rendering of all rigid bodies in the scene
+            app.root.addComponent('script');
+            app.root.script.create('renderPhysics', {
+                attributes: {
+                    drawShapes: true,
+                    opacity: 1
+                }
+            });
+            app.root.script.create('resetPhysics');
+        }
+    }
+    </script>
+</body>
+</html>


### PR DESCRIPTION
Adds a new vehicle physics example to the engine. It is based on the `btRaycastVehicle` API in ammo.js. The example creates a regular dynamic, compound collision body and augments it to be a raycast vehicle.

![car-basic](https://user-images.githubusercontent.com/697563/88543238-97e9f300-d00f-11ea-86dc-da8fbabe807e.gif)

The example also adds some additional scripts:

* A tracking camera script that simply looks at a specified target entity as it moves around.
* A reset physics script which will reset all dynamic rigid bodies back to their start position/rotation on pressing the R key.

There is also an Editor project that uses the same scripts to implement a graphically more interesting scene:

![car-buggy3](https://user-images.githubusercontent.com/697563/88544285-12674280-d011-11ea-844d-15eef43e50c4.gif)

It is available here:

https://playcanvas.com/project/643289/overview/vehicle-physics


I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
