### PR TITLE
Handle gltfTextures correctly and update process callbacks

### DIFF
--- a/src/resources/container.js
+++ b/src/resources/container.js
@@ -80,6 +80,7 @@ Object.assign(ContainerResource.prototype, {
  * | node        |      x      |      x      |             |      x      |
  * | animation   |      x      |             |             |      x      |
  * | material    |      x      |      x      |             |      x      |
+ * | image       |      x      |             |      x      |      x      |
  * | texture     |      x      |             |      x      |      x      |
  * | buffer      |      x      |             |      x      |      x      |
  * | bufferView  |      x      |             |      x      |      x      |

--- a/src/resources/parser/glb-parser.js
+++ b/src/resources/parser/glb-parser.js
@@ -1323,7 +1323,7 @@ var createScenes = function (gltf, nodes) {
 };
 
 // create engine resources from the downloaded GLB data
-var createResources = function (device, gltf, bufferViews, textures, options, callback) {
+var createResources = function (device, gltf, bufferViews, textureAssets, options, callback) {
 
     var preprocess = options && options.global && options.global.preprocess;
     var postprocess = options && options.global && options.global.postprocess;
@@ -1340,9 +1340,9 @@ var createResources = function (device, gltf, bufferViews, textures, options, ca
     var nodes = createNodes(gltf, options);
     var scenes = createScenes(gltf, nodes);
     var animations = createAnimations(gltf, nodes, bufferViews, options);
-    var materials = createMaterials(gltf, gltf.textures ? gltf.textures.map(function (t) {
-        return textures[t.source].resource;
-    }) : [], options, disableFlipV);
+    var materials = createMaterials(gltf, textureAssets.map(function (textureAsset) {
+        return textureAsset.resource;
+    }), options, disableFlipV);
     var meshes = createMeshes(device, gltf, bufferViews, callback, disableFlipV);
     var skins = createSkins(device, gltf, nodes, bufferViews);
 
@@ -1351,7 +1351,7 @@ var createResources = function (device, gltf, bufferViews, textures, options, ca
         'nodes': nodes,
         'scenes': scenes,
         'animations': animations,
-        'textures': textures,
+        'textures': textureAssets,
         'materials': materials,
         'meshes': meshes,
         'skins': skins
@@ -1402,40 +1402,22 @@ var applySampler = function (texture, gltfSampler) {
     }
 };
 
-// load textures using the asset system
-var loadTexturesAsync = function (gltf, bufferViews, urlBase, registry, options, callback) {
-    var result = [];
-
-    if (!gltf.hasOwnProperty('images') || gltf.images.length === 0 ||
-        !gltf.hasOwnProperty('textures') || gltf.textures.length === 0) {
-        callback(null, result);
-        return;
-    }
-
-    var preprocess = options && options.texture && options.texture.preprocess;
-    var processAsync = (options && options.texture && options.texture.processAsync) || function (gltfImage, callback) {
+// load an image
+var loadImageAsync = function (gltfImage, index, bufferViews, urlBase, registry, options, callback) {
+    var preprocess = options && options.image && options.image.preprocess;
+    var processAsync = (options && options.image && options.image.processAsync) || function (gltfImage, callback) {
         callback(null, null);
     };
-    var postprocess = options && options.texture && options.texture.postprocess;
+    var postprocess = options && options.image && options.image.postprocess;
 
-    var remaining = gltf.images.length;
-    var onLoad = function (index, textureAsset) {
-        result[index] = textureAsset;
+    var onLoad = function (textureAsset) {
         if (postprocess) {
-            postprocess(gltf.images[index], textureAsset);
+            postprocess(gltfImage, textureAsset);
         }
-        if (--remaining === 0) {
-            // apply samplers
-            for (var t = 0; t < gltf.textures.length; ++t) {
-                var texture = gltf.textures[t];
-                applySampler(result[texture.source].resource, (gltf.samplers || [])[texture.sampler]);
-            }
-
-            callback(null, result);
-        }
+        callback(null, textureAsset);
     };
 
-    var loadTexture = function (index, url, mimeType, crossOrigin, isBlobUrl) {
+    var loadTexture = function (url, mimeType, crossOrigin, isBlobUrl) {
         var mimeTypeFileExtensions = {
             'image/png': 'png',
             'image/jpeg': 'jpg',
@@ -1459,7 +1441,7 @@ var loadTexturesAsync = function (gltf, bufferViews, urlBase, registry, options,
             if (isBlobUrl) {
                 URL.revokeObjectURL(url);
             }
-            onLoad(index, asset);
+            onLoad(asset);
         });
         asset.on('error', function (err, asset) {
             callback(err);
@@ -1468,36 +1450,88 @@ var loadTexturesAsync = function (gltf, bufferViews, urlBase, registry, options,
         registry.load(asset);
     };
 
-    for (var i = 0; i < gltf.images.length; ++i) {
-        var gltfImage = gltf.images[i];
+    if (preprocess) {
+        preprocess(gltfImage);
+    }
+
+    processAsync(gltfImage, function (err, textureAsset) {
+        if (err) {
+            callback(err);
+        } else if (textureAsset) {
+            onLoad(textureAsset);
+        } else {
+            if (gltfImage.hasOwnProperty('uri')) {
+                // uri specified
+                if (isDataURI(gltfImage.uri)) {
+                    loadTexture(gltfImage.uri, getDataURIMimeType(gltfImage.uri));
+                } else {
+                    loadTexture(path.join(urlBase, gltfImage.uri), null, "anonymous");
+                }
+            } else if (gltfImage.hasOwnProperty('bufferView') && gltfImage.hasOwnProperty('mimeType')) {
+                // bufferview
+                var blob = new Blob([bufferViews[gltfImage.bufferView]], { type: gltfImage.mimeType });
+                loadTexture(URL.createObjectURL(blob), gltfImage.mimeType, null, true);
+            } else {
+                // fail
+                callback("Invalid image found in gltf (neither uri or bufferView found). index=" + index);
+            }
+        }
+    });
+};
+
+// load textures using the asset system
+var loadTexturesAsync = function (gltf, bufferViews, urlBase, registry, options, callback) {
+    var result = [];
+
+    if (!gltf.hasOwnProperty('images') || gltf.images.length === 0 ||
+        !gltf.hasOwnProperty('textures') || gltf.textures.length === 0) {
+        callback(null, result);
+        return;
+    }
+
+    var preprocess = options && options.texture && options.texture.preprocess;
+    var processAsync = (options && options.texture && options.texture.processAsync) || function (gltfTexture, gltfImages, callback) {
+        callback(null, null);
+    };
+    var postprocess = options && options.texture && options.texture.postprocess;
+
+    var remaining = gltf.textures.length;
+    var onLoad = function (index, textureAsset) {
+        // apply sampler state to the loaded texture
+        applySampler(textureAsset.resource, (gltf.samplers || [])[gltf.textures[index].sampler]);
+        result[index] = textureAsset;
+        if (postprocess) {
+            postprocess(gltf.textures[index], textureAsset);
+        }
+        if (--remaining === 0) {
+            callback(null, result);
+        }
+    };
+
+    for (var i = 0; i < gltf.textures.length; ++i) {
+        var gltfTexture = gltf.textures[i];
 
         if (preprocess) {
-            preprocess(gltfImage);
+            preprocess(gltfTexture);
         }
 
-        processAsync(gltfImage, function (i, gltfImage, err, textureAsset) {
+        processAsync(gltfTexture, gltf.images, function (i, gltfTexture, err, gltfImage) {
             if (err) {
                 callback(err);
-            } else if (textureAsset) {
-                onLoad(i, textureAsset);
             } else {
-                if (gltfImage.hasOwnProperty('uri')) {
-                    // uri specified
-                    if (isDataURI(gltfImage.uri)) {
-                        loadTexture(i, gltfImage.uri, getDataURIMimeType(gltfImage.uri));
-                    } else {
-                        loadTexture(i, path.join(urlBase, gltfImage.uri), null, "anonymous");
-                    }
-                } else if (gltfImage.hasOwnProperty('bufferView') && gltfImage.hasOwnProperty('mimeType')) {
-                    // bufferview
-                    var blob = new Blob([bufferViews[gltfImage.bufferView]], { type: gltfImage.mimeType });
-                    loadTexture(i, URL.createObjectURL(blob), gltfImage.mimeType, null, true);
-                } else {
-                    // fail
-                    callback("Invalid image found in gltf (neither uri or bufferView found). index=" + i);
+                if (!gltfImage) {
+                    gltfImage = gltf.images[gltfTexture.source];
                 }
+
+                loadImageAsync(gltfImage, i, bufferViews, urlBase, registry, options, function (err, textureAsset) {
+                    if (err) {
+                        callback(err);
+                    } else {
+                        onLoad(i, textureAsset);
+                    }
+                });
             }
-        }.bind(null, i, gltfImage));
+        }.bind(null, i, gltfTexture));
     }
 };
 
@@ -1759,13 +1793,13 @@ GlbParser.parseAsync = function (filename, urlBase, data, device, registry, opti
                     }
 
                     // async load images
-                    loadTexturesAsync(gltf, bufferViews, urlBase, registry, options, function (err, textures) {
+                    loadTexturesAsync(gltf, bufferViews, urlBase, registry, options, function (err, textureAssets) {
                         if (err) {
                             callback(err);
                             return;
                         }
 
-                        createResources(device, gltf, bufferViews, textures, options, callback);
+                        createResources(device, gltf, bufferViews, textureAssets, options, callback);
                     });
                 });
             });


### PR DESCRIPTION
Fixes #2224
Fixes #2060

This PR changes texture and image handling in the glb parser.

Texture callbacks are changed to take the following structure:
```javascript
preprocess(gltfTexture);
processAsync(gltfTexture, gltfImages, callback);
postprocess(gltfTexture, textureAsset);
```

Image callbacks are also introduced, which look as follows:
```javascript
preprocess(gltfImage)
processAsync(gltfImage, callback)
postprocess(gltfImage, textureAsset)
```

We also create a texture per gltfTexture instead of creating one per gltfImage, thus addressing the failure of https://cx20.github.io/gltf-test/examples/playcanvas/index.html?category=tutorialModels&model=TextureSettingsTest&scale=0.2&type=glTF.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
