### PR TITLE
[FIX] VAO usage fix

### DIFF
--- a/src/framework/components/element/text-element.js
+++ b/src/framework/components/element/text-element.js
@@ -384,7 +384,6 @@ Object.assign(TextElement.prototype, {
                 // destroy old mesh
                 if (meshInfo.meshInstance) {
                     this._removeMeshInstance(meshInfo.meshInstance);
-                    meshInfo.meshInstance.material = null;
                 }
 
                 // if there are no letters for this mesh continue
@@ -503,19 +502,12 @@ Object.assign(TextElement.prototype, {
     },
 
     _removeMeshInstance: function (meshInstance) {
-        var ib;
-        var iblen;
+
+        meshInstance.material = null;
 
         var oldMesh = meshInstance.mesh;
         if (oldMesh) {
-            if (oldMesh.vertexBuffer) {
-                oldMesh.vertexBuffer.destroy();
-            }
-
-            if (oldMesh.indexBuffer) {
-                for (ib = 0, iblen = oldMesh.indexBuffer.length; ib < iblen; ib++)
-                    oldMesh.indexBuffer[ib].destroy();
-            }
+            oldMesh.destroy();
         }
 
         var idx = this._model.meshInstances.indexOf(meshInstance);

--- a/src/graphics/device.js
+++ b/src/graphics/device.js
@@ -1475,6 +1475,10 @@ Object.assign(GraphicsDevice.prototype, {
     updateEnd: function () {
         var gl = this.gl;
 
+        // unbind VAO from device to protect it from being changed
+        this.boundVao = null;
+        this.gl.bindVertexArray(null);
+
         // Unset the render target
         var target = this.renderTarget;
         if (target) {
@@ -2266,7 +2270,7 @@ Object.assign(GraphicsDevice.prototype, {
      * @param {number} primitive.count - The number of indices or vertices to dispatch in the draw call.
      * @param {boolean} [primitive.indexed] - True to interpret the primitive as indexed, thereby using the currently set index buffer and false otherwise.
      * @param {number} [numInstances=1] - The number of instances to render when using ANGLE_instanced_arrays. Defaults to 1.
-     * @param {boolean} [keepBuffers] - Optionally keep the current set of vertex buffers / VAO. This is used when rendering of
+     * @param {boolean} [keepBuffers] - Optionally keep the current set of vertex / index buffers / VAO. This is used when rendering of
      * multiple views, for example under WebXR.
      * @example
      * // Render a single, unindexed triangle

--- a/src/scene/forward-renderer.js
+++ b/src/scene/forward-renderer.js
@@ -1263,10 +1263,10 @@ Object.assign(ForwardRenderer.prototype, {
         if (instancingData) {
             if (instancingData.count > 0) {
                 this._instancedDrawCalls++;
-                this._removedByInstancing += instancingData.count;
                 device.setVertexBuffer(instancingData.vertexBuffer);
                 device.draw(mesh.primitive[style], instancingData.count);
                 if (instancingData.vertexBuffer === _autoInstanceBuffer) {
+                    this._removedByInstancing += instancingData.count;
                     meshInstance.instancingData = null;
                     return instancingData.count - 1;
                 }
@@ -1296,17 +1296,17 @@ Object.assign(ForwardRenderer.prototype, {
         if (instancingData) {
             if (instancingData.count > 0) {
                 this._instancedDrawCalls++;
-                this._removedByInstancing += instancingData.count;
                 device.setVertexBuffer(instancingData.vertexBuffer);
                 device.draw(mesh.primitive[style], instancingData.count);
                 if (instancingData.vertexBuffer === _autoInstanceBuffer) {
+                    this._removedByInstancing += instancingData.count;
                     meshInstance.instancingData = null;
                     return instancingData.count - 1;
                 }
             }
         } else {
             // matrices are already set
-            device.draw(mesh.primitive[style], null, true);
+            device.draw(mesh.primitive[style], undefined, true);
         }
         return 0;
     },
@@ -1911,7 +1911,7 @@ Object.assign(ForwardRenderer.prototype, {
                         if (v === 0) {
                             i += this.drawInstance(device, drawCall, mesh, style, true);
                         } else {
-                            i += this.drawInstance2(device, drawCall, mesh, style, true);
+                            i += this.drawInstance2(device, drawCall, mesh, style);
                         }
 
                         this._forwardDrawCalls++;


### PR DESCRIPTION
Fixes #2311 (both projects)

- unbind VAO at the end of block of rendering, to protect VAO bind on device getting modified by locking VB / IB and similar operations
- cleanup to text-element - removed duplicate and calling `mesh.destroy()` instead, also making sure `meshInstance.material` is set to null in both cases (one was not)
- improved usage of `device._removedByInstancing` - this only counts saving by autoinstancing (which is currently not used), and not when user sets up instancing.