### PR TITLE
GLTF empty node name fix

### DIFF
--- a/src/resources/parser/glb-parser.js
+++ b/src/resources/parser/glb-parser.js
@@ -1160,7 +1160,7 @@ var createAnimation = function (gltfAnimation, animationIndex, gltfAccessors, bu
 var createNode = function (gltfNode, nodeIndex) {
     var entity = new GraphNode();
 
-    if (gltfNode.hasOwnProperty('name')) {
+    if (gltfNode.hasOwnProperty('name') && gltfNode.name.length > 0) {
         entity.name = gltfNode.name;
     } else {
         entity.name = "node_" + nodeIndex;


### PR DESCRIPTION
When gltf nodes have an empty string as their name, their node index should be used as their name instead.