### PR TITLE
[FIX] Don't assume prefiltering lighting data is RGBM

### DIFF
--- a/src/resources/cubemap.js
+++ b/src/resources/cubemap.js
@@ -118,7 +118,7 @@ Object.assign(CubemapHandler.prototype, {
                     var prelit = new Texture(this._device, {
                         name: cubemapAsset.name + '_prelitCubemap' + (tex.width >> i),
                         cubemap: true,
-                        type: getType() || TEXTURETYPE_RGBM,
+                        type: getType() || tex.type,
                         width: tex.width >> i,
                         height: tex.height >> i,
                         format: tex.format,


### PR DESCRIPTION
This fixes over-bright scenes generated from jpg skydomes.