### PR TITLE
Construct node hierarchy even when no model exists

### DIFF
--- a/src/resources/container.js
+++ b/src/resources/container.js
@@ -179,7 +179,7 @@ Object.assign(ContainerHandler.prototype, {
         var i;
 
         // create model asset
-        var model = (data.meshes.length === 0) ? null : createAsset('model', GlbParser.createModel(data, this._defaultMaterial), 0);
+        var model = createAsset('model', GlbParser.createModel(data, this._defaultMaterial), 0);
 
         // create material assets
         var materials = [];


### PR DESCRIPTION
The GLB loader was testing for the presence of a model before constructing its hierarchy. This was an optimisation added because animation-only GLBs applied to some other model don't reference their own hierarchy (but rather use the model's).

However in some cases the hierarchy is needed. The present case being the playcanvas viewer: when a stand-alone animation GLB file is loaded it can not be displayed without it's hierarchy.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
