### PR TITLE
Specify basis URL config

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -115,7 +115,7 @@ export { Bundle } from './bundles/bundle.js';
 export { BundleRegistry } from './bundles/bundle-registry.js';
 
 // RESOURCES
-export { basisDownload, basisDownloadFromConfig, basisInitialize, basisTargetFormat, basisTranscode } from './resources/basis.js';
+export { basisDownload, basisSetDownloadConfig, basisDownloadFromConfig, basisInitialize, basisTargetFormat, basisTranscode } from './resources/basis.js';
 export { AnimClipHandler } from './resources/anim-clip.js';
 export { AnimStateGraphHandler } from './resources/anim-state-graph.js';
 export { AnimationHandler } from './resources/animation.js';

--- a/src/resources/basis.js
+++ b/src/resources/basis.js
@@ -480,7 +480,7 @@ function basisDownloadFromConfig(callback) {
                       downloadConfig.fallbackUrl,
                       callback);
     } else {
-        // grab config from global PC config structure
+        // get config from global PC config structure
         var modules = (window.config ? window.config.wasmModules : window.PRELOAD_MODULES) || [];
         var wasmModule = modules.find(function (m) {
             return m.moduleName === 'BASIS';
@@ -491,6 +491,10 @@ function basisDownloadFromConfig(callback) {
                           urlBase + wasmModule.wasmUrl,
                           urlBase + wasmModule.fallbackUrl,
                           callback);
+        } else {
+            // #ifdef DEBUG
+            console.warn("WARNING: unable to load basis wasm module - no config was specified");
+            // #endif
         }
     }
 }

--- a/src/resources/basis.js
+++ b/src/resources/basis.js
@@ -291,6 +291,7 @@ var worker = null;
 var callbacks = { };
 var format = null;
 var transcodeQueue = [];
+var downloadConfig = null;
 
 function basisTargetFormat() {
     if (!format) {
@@ -461,18 +462,36 @@ function basisDownload(glueUrl, wasmUrl, fallbackUrl, callback) {
     }
 }
 
+// set the wasm url config to be used if basisDownloadFromConfig is invoked
+function basisSetDownloadConfig(glueUrl, wasmUrl, fallbackUrl) {
+    downloadConfig = {
+        glueUrl: glueUrl,
+        wasmUrl: wasmUrl,
+        fallbackUrl: fallbackUrl
+    };
+}
+
 // search for wasm module in the global config and initialize basis
 function basisDownloadFromConfig(callback) {
-    var modules = (window.config ? window.config.wasmModules : window.PRELOAD_MODULES) || [];
-    var wasmModule = modules.find(function (m) {
-        return m.moduleName === 'BASIS';
-    });
-    if (wasmModule) {
-        var urlBase = window.ASSET_PREFIX ? window.ASSET_PREFIX : "";
-        basisDownload(urlBase + wasmModule.glueUrl,
-                      urlBase + wasmModule.wasmUrl,
-                      urlBase + wasmModule.fallbackUrl,
+    if (downloadConfig) {
+        // config was user-specified
+        basisDownload(downloadConfig.glueUrl,
+                      downloadConfig.wasmUrl,
+                      downloadConfig.fallbackUrl,
                       callback);
+    } else {
+        // grab config from global PC config structure
+        var modules = (window.config ? window.config.wasmModules : window.PRELOAD_MODULES) || [];
+        var wasmModule = modules.find(function (m) {
+            return m.moduleName === 'BASIS';
+        });
+        if (wasmModule) {
+            var urlBase = window.ASSET_PREFIX ? window.ASSET_PREFIX : "";
+            basisDownload(urlBase + wasmModule.glueUrl,
+                          urlBase + wasmModule.wasmUrl,
+                          urlBase + wasmModule.fallbackUrl,
+                          callback);
+        }
     }
 }
 
@@ -494,4 +513,11 @@ function basisTranscode(url, data, callback, options) {
     }
 }
 
-export { basisDownload, basisDownloadFromConfig, basisInitialize, basisTargetFormat, basisTranscode };
+export {
+    basisDownload,
+    basisSetDownloadConfig,
+    basisDownloadFromConfig,
+    basisInitialize,
+    basisTargetFormat,
+    basisTranscode
+};

--- a/src/resources/container.js
+++ b/src/resources/container.js
@@ -179,7 +179,7 @@ Object.assign(ContainerHandler.prototype, {
         var i;
 
         // create model asset
-        var model = createAsset('model', GlbParser.createModel(data, this._defaultMaterial), 0);
+        var model = (data.meshes.length === 0) ? null : createAsset('model', GlbParser.createModel(data, this._defaultMaterial), 0);
 
         // create material assets
         var materials = [];

--- a/src/resources/container.js
+++ b/src/resources/container.js
@@ -179,7 +179,7 @@ Object.assign(ContainerHandler.prototype, {
         var i;
 
         // create model asset
-        var model = (data.meshes.length === 0) ? null : createAsset('model', GlbParser.createModel(data, this._defaultMaterial), 0);
+        var model = createAsset('model', GlbParser.createModel(data, this._defaultMaterial), 0);
 
         // create material assets
         var materials = [];


### PR DESCRIPTION
It would be better for the playcanvas viewer to download and instantiate the basis wasm module on demand rather than always doing so at startup.

This PR adds the option of specifying a basis wasm module URL config ahead of time, ready for use when a basis file is encountered and the module is initialised on demand.

Also, log a warning message if download is requested but no URL config is found.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
