### PR TITLE
Add documentation for shader parameter methods in pc.MeshInstance

### DIFF
--- a/src/scene/mesh-instance.js
+++ b/src/scene/mesh-instance.js
@@ -411,10 +411,25 @@ Object.assign(MeshInstance.prototype, {
         return this.parameters;
     },
 
+    /**
+     * @function
+     * @name pc.MeshInstance#getParameter
+     * @description Retrieves the specified shader parameter from a mesh instance.
+     * @param {string} name - The name of the parameter to query.
+     * @returns {object} The named parameter.
+     */
     getParameter: function (name) {
         return this.parameters[name];
     },
 
+    /**
+     * @function
+     * @name pc.MeshInstance#setParameter
+     * @description Sets a shader parameter on a mesh instance.
+     * @param {string} name - The name of the parameter to set.
+     * @param {number|number[]|pc.Texture} data - The value for the specified parameter.
+     * @param {number} [passFlags] - Mask describing which passes should be included.
+     */
     setParameter: function (name, data, passFlags) {
         if (passFlags === undefined) passFlags = -524285; // All bits set except 2 - 18 range
 
@@ -443,14 +458,24 @@ Object.assign(MeshInstance.prototype, {
         }
     },
 
+    /**
+     * @function
+     * @name pc.MeshInstance#deleteParameter
+     * @description Deletes a shader parameter on a mesh instance.
+     * @param {string} name - The name of the parameter to delete.
+     */
     deleteParameter: function (name) {
         if (this.parameters[name]) {
             delete this.parameters[name];
         }
     },
 
+    /**
+     * @function
+     * @name pc.MeshInstance#setParameters
+     * @description Pushes all shader parameters into scope.
+     */
     setParameters: function () {
-        // Push each shader parameter into scope
         for (var paramName in this.parameters) {
             var parameter = this.parameters[paramName];
             parameter.scopeId.setValue(parameter.data);


### PR DESCRIPTION
PR adds jsdoc documentation for the following:
- `pc.MeshInstance#getParameter`
- `pc.MeshInstance#setParameter`
- `pc.MeshInstance#setParameters`
- `pc.MeshInstance#deleteParameter`

These methods are analogous to the similar (`xxxParameter`) methods in `pc.Material` which are already documented.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
