### PR TITLE
Add hit-test to optional XR features

### DIFF
--- a/src/xr/xr-manager.js
+++ b/src/xr/xr-manager.js
@@ -190,8 +190,10 @@ XrManager.prototype.start = function (camera, type, spaceType, callback) {
 
     var optionalFeatures = [];
 
-    if (type === XRTYPE_AR)
+    if (type === XRTYPE_AR) {
         optionalFeatures.push('light-estimation');
+        optionalFeatures.push('hit-test');
+    }
 
     if (type === XRTYPE_VR)
         optionalFeatures.push('hand-tracking');


### PR DESCRIPTION
Fixes hit-test when launched on hand held device (phone)

Fixes: https://forum.playcanvas.com/t/webxr-hit-test-module-ar-picking-real-world-geometry/12338/19?u=yaustar

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).

There is a question on whether these optionalFeatures should be hard coded in the engine or allow the user to define this themselves when calling `startXr` in the camera component:

https://github.com/playcanvas/engine/blob/master/src/framework/components/camera/component.js#L562