### PR TITLE
set entity._template to true for template root

### DIFF
--- a/src/framework/entity.js
+++ b/src/framework/entity.js
@@ -82,6 +82,10 @@ function Entity(name, app) {
 
     // used by component systems to speed up destruction
     this._destroying = false;
+
+    // used to differentiate between the entities of a template root instance,
+    // which have it set to true, and the cloned instance entities (set to false)
+    this._template = false;
 }
 Entity.prototype = Object.create(GraphNode.prototype);
 Entity.prototype.constructor = Entity;

--- a/src/resources/parser/scene.js
+++ b/src/resources/parser/scene.js
@@ -58,7 +58,9 @@ Object.assign(SceneParser.prototype, {
         entity.setLocalScale(s[0], s[1], s[2]);
         entity._enabled = data.enabled !== undefined ? data.enabled : true;
 
-        if (!this._isTemplate) {
+        if (this._isTemplate) {
+            entity._template = true;
+        } else {
             entity._enabledInHierarchy = entity._enabled;
         }
 


### PR DESCRIPTION
This PR adds a private boolean field on Entity called _template. 
It can be used to differentiate between the entities of a template root instance,
used internally by the template instantiation mechanism, and the template instances
created by users at runtime (their entities have this flag set to false).
Template instances are created by cloning the root instance.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
