### PR TITLE
[Fix] Texture based morphing would not update when all weights are 0

### DIFF
--- a/src/scene/morph-instance.js
+++ b/src/scene/morph-instance.js
@@ -41,7 +41,6 @@ function MorphInstance(morph) {
 
         // max number of morph targets rendered at a time (each uses single texture slot)
         this.maxSubmitCount = this.device.maxTextures;
-        this.maxSubmitCount = 2;
 
         // array for max number of weights
         this._shaderMorphWeights = new Float32Array(this.maxSubmitCount);
@@ -75,7 +74,10 @@ function MorphInstance(morph) {
             this["morphBlendTex" + i] = this.device.scope.resolve("morphBlendTex" + i);
         }
 
-        this.morphFactor =  this.device.scope.resolve("morphFactor[0]");
+        this.morphFactor = this.device.scope.resolve("morphFactor[0]");
+
+        // true indicates render target textures are full of zeros to avoid rendering to them when all weights are zero
+        this.zeroTextures = false;
 
     } else {    // vertex attribute based morphing
 
@@ -246,8 +248,8 @@ Object.assign(MorphInstance.prototype, {
             }
         }
 
-        // leftover batch
-        if (usedCount > 0) {
+        // leftover batch, or just to clear texture
+        if (usedCount > 0 || (count === 0 && !this.zeroTextures)) {
             submitBatch(usedCount, blending);
         }
     },
@@ -260,11 +262,15 @@ Object.assign(MorphInstance.prototype, {
         device.pushMarker("MorphUpdate");
         // #endif
 
-        if (this._activeTargets.length > 0) {
+        // update textures if active targets, or no active targets and textures need to be cleared
+        if (this._activeTargets.length > 0 || !this.zeroTextures) {
 
             // blend morph targets into render targets
             this._updateTextureRenderTarget(this.rtPositions, 'texturePositions');
             this._updateTextureRenderTarget(this.rtNormals, 'textureNormals');
+
+            // textures were cleared if no active targets
+            this.zeroTextures = this._activeTargets.length === 0;
         }
 
         // #ifdef DEBUG


### PR DESCRIPTION
- when all weights are 0, we do one frame render to clear texture targets
- also removed forgotten debug line causing more than needed render passes