### PR TITLE
MeshInstance frustum culling - small refactor

### DIFF
--- a/src/scene/forward-renderer.js
+++ b/src/scene/forward-renderer.js
@@ -103,7 +103,6 @@ var worldMatZ = new Vec3();
 
 var frustumDiagonal = new Vec3();
 var tempSphere = { center: null, radius: 0 };
-var meshPos;
 var visibleSceneAabb = new BoundingBox();
 var boneTextureSize = [0, 0, 0, 0];
 var boneTexture, instancingData, modelMatrix, normalMatrix;
@@ -563,26 +562,6 @@ Object.assign(ForwardRenderer.prototype, {
 
     lightCompare: function (lightA, lightB) {
         return lightA.key - lightB.key;
-    },
-
-    _isVisible: function (camera, meshInstance) {
-        if (!meshInstance.visible) return false;
-
-        // custom visibility method on MeshInstance
-        if (meshInstance.isVisibleFunc) {
-            return meshInstance.isVisibleFunc(camera);
-        }
-
-        meshPos = meshInstance.aabb.center;
-        if (meshInstance._aabb._radiusVer !== meshInstance._aabbVer) {
-            meshInstance._aabb._radius = meshInstance._aabb.halfExtents.length();
-            meshInstance._aabb._radiusVer = meshInstance._aabbVer;
-        }
-
-        tempSphere.radius = meshInstance._aabb._radius;
-        tempSphere.center = meshPos;
-
-        return camera.frustum.containsSphere(tempSphere);
     },
 
     getShadowCamera: function (device, light) {
@@ -1159,7 +1138,7 @@ Object.assign(ForwardRenderer.prototype, {
                 if (drawCall.mask && (drawCall.mask & cullingMask) === 0) continue;
 
                 if (drawCall.cull) {
-                    visible = this._isVisible(camera, drawCall);
+                    visible = drawCall._isVisible(camera);
                     // #ifdef PROFILER
                     numDrawCallsCulled++;
                     // #endif
@@ -2510,7 +2489,7 @@ Object.assign(ForwardRenderer.prototype, {
                 meshInstance = drawCalls[i];
                 visible = true;
                 if (meshInstance.cull) {
-                    visible = this._isVisible(shadowCam, meshInstance);
+                    visible = meshInstance._isVisible(shadowCam);
                 }
                 if (visible) {
                     visibleList[vlen] = meshInstance;
@@ -2615,7 +2594,7 @@ Object.assign(ForwardRenderer.prototype, {
             meshInstance = drawCalls[i];
             visible = true;
             if (meshInstance.cull) {
-                visible = this._isVisible(shadowCam, meshInstance);
+                visible = meshInstance._isVisible(shadowCam);
             }
             if (visible) {
                 visibleList[vlen] = meshInstance;

--- a/src/scene/lightmapper.js
+++ b/src/scene/lightmapper.js
@@ -612,7 +612,7 @@ Object.assign(Lightmapper.prototype, {
                 if (lights[i]._type === LIGHTTYPE_SPOT) {
                     var nodeVisible = false;
                     for (j = 0; j < rcv.length; j++) {
-                        if (this.renderer._isVisible(shadowCam, rcv[j])) {
+                        if (rcv[j]._isVisible(shadowCam)) {
                             nodeVisible = true;
                             break;
                         }

--- a/src/scene/mesh-instance.js
+++ b/src/scene/mesh-instance.js
@@ -1,4 +1,5 @@
 import { BoundingBox } from '../shape/bounding-box.js';
+import { BoundingSphere } from '../shape/bounding-sphere.js';
 
 import {
     BLEND_NONE, BLEND_NORMAL,
@@ -13,7 +14,7 @@ import {
 
 var _tmpAabb = new BoundingBox();
 var _tempBoneAabb = new BoundingBox();
-var _tempSphere = { center: null, radius: 0 };
+var _tempSphere = new BoundingSphere(null, 0);
 
 /**
  * @class

--- a/src/scene/mesh-instance.js
+++ b/src/scene/mesh-instance.js
@@ -13,6 +13,7 @@ import {
 
 var _tmpAabb = new BoundingBox();
 var _tempBoneAabb = new BoundingBox();
+var _tempSphere = { center: null, radius: 0 };
 
 /**
  * @class
@@ -370,6 +371,32 @@ Object.defineProperty(MeshInstance.prototype, 'instancingCount', {
 Object.assign(MeshInstance.prototype, {
     syncAabb: function () {
         // Deprecated
+    },
+
+    // test if meshInstance is visible by camera. It requires the frustum of the camera to be up to date, which forward-renderer
+    // takes care of. This function should  not be called elsewhere.
+    _isVisible: function (camera) {
+
+        if (this.visible) {
+
+            // custom visibility method of MeshInstance
+            if (this.isVisibleFunc) {
+                return this.isVisibleFunc(camera);
+            }
+
+            var pos = this.aabb.center;
+            if (this._aabb._radiusVer !== this._aabbVer) {
+                this._aabb._radius = this._aabb.halfExtents.length();
+                this._aabb._radiusVer = this._aabbVer;
+            }
+
+            _tempSphere.radius = this._aabb._radius;
+            _tempSphere.center = pos;
+
+            return camera.frustum.containsSphere(_tempSphere);
+        }
+
+        return false;
     },
 
     updateKey: function () {

--- a/src/scene/mesh-instance.js
+++ b/src/scene/mesh-instance.js
@@ -14,7 +14,7 @@ import {
 
 var _tmpAabb = new BoundingBox();
 var _tempBoneAabb = new BoundingBox();
-var _tempSphere = new BoundingSphere(null, 0);
+var _tempSphere = new BoundingSphere();
 
 /**
  * @class

--- a/src/shape/bounding-box.js
+++ b/src/shape/bounding-box.js
@@ -275,42 +275,30 @@ Object.assign(BoundingBox.prototype, {
      * @param {pc.Mat4} m - Transformation matrix to apply to source AABB.
      */
     setFromTransformedAabb: function (aabb, m) {
-        var bc = this.center;
-        var br = this.halfExtents;
         var ac = aabb.center;
         var ar = aabb.halfExtents;
 
-        m = m.data;
-        var mx0 = m[0];
-        var mx1 = m[4];
-        var mx2 = m[8];
-        var my0 = m[1];
-        var my1 = m[5];
-        var my2 = m[9];
-        var mz0 = m[2];
-        var mz1 = m[6];
-        var mz2 = m[10];
+        var d = m.data;
+        var mx0 = d[0];
+        var mx1 = d[4];
+        var mx2 = d[8];
+        var my0 = d[1];
+        var my1 = d[5];
+        var my2 = d[9];
+        var mz0 = d[2];
+        var mz1 = d[6];
+        var mz2 = d[10];
 
-        var mx0a = Math.abs(mx0);
-        var mx1a = Math.abs(mx1);
-        var mx2a = Math.abs(mx2);
-        var my0a = Math.abs(my0);
-        var my1a = Math.abs(my1);
-        var my2a = Math.abs(my2);
-        var mz0a = Math.abs(mz0);
-        var mz1a = Math.abs(mz1);
-        var mz2a = Math.abs(mz2);
-
-        bc.set(
-            m[12] + mx0 * ac.x + mx1 * ac.y + mx2 * ac.z,
-            m[13] + my0 * ac.x + my1 * ac.y + my2 * ac.z,
-            m[14] + mz0 * ac.x + mz1 * ac.y + mz2 * ac.z
+        this.center.set(
+            d[12] + mx0 * ac.x + mx1 * ac.y + mx2 * ac.z,
+            d[13] + my0 * ac.x + my1 * ac.y + my2 * ac.z,
+            d[14] + mz0 * ac.x + mz1 * ac.y + mz2 * ac.z
         );
 
-        br.set(
-            mx0a * ar.x + mx1a * ar.y + mx2a * ar.z,
-            my0a * ar.x + my1a * ar.y + my2a * ar.z,
-            mz0a * ar.x + mz1a * ar.y + mz2a * ar.z
+        this.halfExtents.set(
+            Math.abs(mx0) * ar.x + Math.abs(mx1) * ar.y + Math.abs(mx2) * ar.z,
+            Math.abs(my0) * ar.x + Math.abs(my1) * ar.y + Math.abs(my2) * ar.z,
+            Math.abs(mz0) * ar.x + Math.abs(mz1) * ar.y + Math.abs(mz2) * ar.z
         );
     },
 


### PR DESCRIPTION
- small refactor - moving _isVisible from ForwardRenderer to MeshInstance, where it belongs
- small optimization in BoundingBox.setFromTransformedAabb - saves about 5% in my test.