### PR TITLE
[Fix] Shader parameters set on Material or MeshInstance are used in all passes

### DIFF
--- a/src/framework/components/sprite/component.js
+++ b/src/framework/components/sprite/component.js
@@ -379,10 +379,9 @@ Object.assign(SpriteComponent.prototype, {
 
             // update outer scale
             if (this._meshInstance) {
-                // use outerScale in ALL passes (depth, picker, etc) so the shape is correct
                 this._outerScaleUniform[0] = this._outerScale.x;
                 this._outerScaleUniform[1] = this._outerScale.y;
-                this._meshInstance.setParameter(PARAM_OUTER_SCALE, this._outerScaleUniform, 0xFFFFFFFF);
+                this._meshInstance.setParameter(PARAM_OUTER_SCALE, this._outerScaleUniform);
             }
         }
 

--- a/src/scene/forward-renderer.js
+++ b/src/scene/forward-renderer.js
@@ -1356,9 +1356,6 @@ Object.assign(ForwardRenderer.prototype, {
         var settings;
         var visibleList, visibleLength;
 
-        var passFlag = 1 << SHADER_SHADOW;
-        var paramName, parameter, parameters;
-
         for (i = 0; i < lights.length; i++) {
             light = lights[i];
             type = light._type;
@@ -1492,30 +1489,14 @@ Object.assign(ForwardRenderer.prototype, {
                         }
 
                         if (material.chunks) {
-                            // Uniforms I (shadow): material
-                            parameters = material.parameters;
-                            for (paramName in parameters) {
-                                parameter = parameters[paramName];
-                                if (parameter.passFlags & passFlag) {
-                                    if (!parameter.scopeId) {
-                                        parameter.scopeId = device.scope.resolve(paramName);
-                                    }
-                                    parameter.scopeId.setValue(parameter.data);
-                                }
-                            }
+
                             this.setCullMode(true, false, meshInstance);
 
+                            // Uniforms I (shadow): material
+                            material.setParameters(device);
+
                             // Uniforms II (shadow): meshInstance overrides
-                            parameters = meshInstance.parameters;
-                            for (paramName in parameters) {
-                                parameter = parameters[paramName];
-                                if (parameter.passFlags & passFlag) {
-                                    if (!parameter.scopeId) {
-                                        parameter.scopeId = device.scope.resolve(paramName);
-                                    }
-                                    parameter.scopeId.setValue(parameter.data);
-                                }
-                            }
+                            meshInstance.setParameters(device);
                         }
 
                         // set shader
@@ -1712,8 +1693,6 @@ Object.assign(ForwardRenderer.prototype, {
         var device = this.device;
         var scene = this.scene;
         var vrDisplay = camera.vrDisplay;
-        var passFlag = 1 << pass;
-
         var lightHash = layer ? layer._lightHash : 0;
 
         // #ifdef PROFILER
@@ -1796,16 +1775,7 @@ Object.assign(ForwardRenderer.prototype, {
                     }
 
                     // Uniforms I: material
-                    parameters = material.parameters;
-                    for (paramName in parameters) {
-                        parameter = parameters[paramName];
-                        if (parameter.passFlags & passFlag) {
-                            if (!parameter.scopeId) {
-                                parameter.scopeId = device.scope.resolve(paramName);
-                            }
-                            parameter.scopeId.setValue(parameter.data);
-                        }
-                    }
+                    material.setParameters(device);
 
                     if (!prevMaterial || lightMask !== prevLightMask) {
                         usedDirLights = this.dispatchDirectLights(sortedLights[LIGHTTYPE_DIRECTIONAL], scene, lightMask);
@@ -1874,16 +1844,7 @@ Object.assign(ForwardRenderer.prototype, {
                 }
 
                 // Uniforms II: meshInstance overrides
-                parameters = drawCall.parameters;
-                for (paramName in parameters) {
-                    parameter = parameters[paramName];
-                    if (parameter.passFlags & passFlag) {
-                        if (!parameter.scopeId) {
-                            parameter.scopeId = device.scope.resolve(paramName);
-                        }
-                        parameter.scopeId.setValue(parameter.data);
-                    }
-                }
+                drawCall.setParameters(device);
 
                 this.setVertexBuffers(device, mesh);
                 this.setMorphing(device, drawCall.morphInstance);

--- a/src/scene/forward-renderer.js
+++ b/src/scene/forward-renderer.js
@@ -1701,7 +1701,6 @@ Object.assign(ForwardRenderer.prototype, {
 
         var i, drawCall, mesh, material, objDefs, variantKey, lightMask, style, usedDirLights;
         var prevMaterial = null, prevObjDefs, prevLightMask, prevStatic;
-        var paramName, parameter, parameters;
         var stencilFront, stencilBack;
 
         var halfWidth = device.width * 0.5;
@@ -1917,15 +1916,7 @@ Object.assign(ForwardRenderer.prototype, {
 
                 // Unset meshInstance overrides back to material values if next draw call will use the same material
                 if (i < drawCallsCount - 1 && drawCalls[i + 1].material === material) {
-                    for (paramName in parameters) {
-                        parameter = material.parameters[paramName];
-                        if (parameter) {
-                            if (!parameter.scopeId) {
-                                parameter.scopeId = device.scope.resolve(paramName);
-                            }
-                            parameter.scopeId.setValue(parameter.data);
-                        }
-                    }
+                    material.setParameters(device, drawCall.parameters);
                 }
 
                 prevMaterial = material;

--- a/src/scene/materials/material.js
+++ b/src/scene/materials/material.js
@@ -401,14 +401,18 @@ Material.prototype.deleteParameter = function (name) {
 };
 
 // used to apply parameters from this material into scope of uniforms, called internally by forward-renderer
-Material.prototype.setParameters = function (device) {
+// optional list of parameter names to be set can be specified, otherwise all parameters are set
+Material.prototype.setParameters = function (device, names) {
     var parameter, parameters = this.parameters;
-    for (var paramName in parameters) {
+    if (names === undefined) names = parameters;
+    for (var paramName in names) {
         parameter = parameters[paramName];
-        if (!parameter.scopeId) {
-            parameter.scopeId = device.scope.resolve(paramName);
+        if (parameter) {
+            if (!parameter.scopeId) {
+                parameter.scopeId = device.scope.resolve(paramName);
+            }
+            parameter.scopeId.setValue(parameter.data);
         }
-        parameter.scopeId.setValue(parameter.data);
     }
 };
 

--- a/src/scene/materials/material.js
+++ b/src/scene/materials/material.js
@@ -362,10 +362,8 @@ Material.prototype.getParameter = function (name) {
  * @description Sets a shader parameter on a material.
  * @param {string} name - The name of the parameter to set.
  * @param {number|number[]|pc.Texture} data - The value for the specified parameter.
- * @param {number} [passFlags] - Mask describing which passes the material should be included in.
  */
-Material.prototype.setParameter = function (name, data, passFlags) {
-    if (passFlags === undefined) passFlags = -524285; // All bits set except 2 - 18 range
+Material.prototype.setParameter = function (name, data) {
 
     if (data === undefined && typeof name === 'object') {
         var uniformObject = name;
@@ -382,12 +380,10 @@ Material.prototype.setParameter = function (name, data, passFlags) {
     var param = this.parameters[name];
     if (param) {
         param.data = data;
-        param.passFlags = passFlags;
     } else {
         this.parameters[name] = {
             scopeId: null,
-            data: data,
-            passFlags: passFlags
+            data: data
         };
     }
 };
@@ -404,15 +400,14 @@ Material.prototype.deleteParameter = function (name) {
     }
 };
 
-/**
- * @function
- * @name pc.Material#setParameters
- * @description Pushes all material parameters into scope.
- */
-Material.prototype.setParameters = function () {
-    // Push each shader parameter into scope
-    for (var paramName in this.parameters) {
-        var parameter = this.parameters[paramName];
+// used to apply parameters from this material into scope of uniforms, called internally by forward-renderer
+Material.prototype.setParameters = function (device) {
+    var parameter, parameters = this.parameters;
+    for (var paramName in parameters) {
+        parameter = parameters[paramName];
+        if (!parameter.scopeId) {
+            parameter.scopeId = device.scope.resolve(paramName);
+        }
         parameter.scopeId.setValue(parameter.data);
     }
 };

--- a/src/scene/mesh-instance.js
+++ b/src/scene/mesh-instance.js
@@ -411,12 +411,26 @@ Object.assign(MeshInstance.prototype, {
         return this.parameters;
     },
 
+    /**
+     * @function
+     * @name pc.MeshInstance#getParameter
+     * @description Retrieves the specified shader parameter from a mesh instance.
+     * @param {string} name - The name of the parameter to query.
+     * @returns {object} The named parameter.
+     */
     getParameter: function (name) {
         return this.parameters[name];
     },
 
-    setParameter: function (name, data, passFlags) {
-        if (passFlags === undefined) passFlags = -524285; // All bits set except 2 - 18 range
+    /**
+     * @function
+     * @name pc.MeshInstance#setParameter
+     * @description Sets a shader parameter on a mesh instance. Note that this parameter will take precedence over parameter of the same name
+     * if set on Material this mesh instance uses for rendering.
+     * @param {string} name - The name of the parameter to set.
+     * @param {number|number[]|pc.Texture} data - The value for the specified parameter.
+     */
+    setParameter: function (name, data) {
 
         if (data === undefined && typeof name === 'object') {
             var uniformObject = name;
@@ -433,26 +447,34 @@ Object.assign(MeshInstance.prototype, {
         var param = this.parameters[name];
         if (param) {
             param.data = data;
-            param.passFlags = passFlags;
         } else {
             this.parameters[name] = {
                 scopeId: null,
-                data: data,
-                passFlags: passFlags
+                data: data
             };
         }
     },
 
+     /**
+      * @function
+      * @name pc.MeshInstance#deleteParameter
+      * @description Deletes a shader parameter on a mesh instance.
+      * @param {string} name - The name of the parameter to delete.
+      */
     deleteParameter: function (name) {
         if (this.parameters[name]) {
             delete this.parameters[name];
         }
     },
 
-    setParameters: function () {
-        // Push each shader parameter into scope
-        for (var paramName in this.parameters) {
-            var parameter = this.parameters[paramName];
+    // used to apply parameters from this mesh instance into scope of uniforms, called internally by forward-renderer
+    setParameters: function (device) {
+        var parameter, parameters = this.parameters;
+        for (var paramName in parameters) {
+            parameter = parameters[paramName];
+            if (!parameter.scopeId) {
+                parameter.scopeId = device.scope.resolve(paramName);
+            }
             parameter.scopeId.setValue(parameter.data);
         }
     }


### PR DESCRIPTION
In previous implementation, a passFlag parameter would be used to control which passes (depth, main camera ...) a parameter would apply to, and by default it would not apply parameters in shadow passes, making shaders changing positions of vertices not behave correctly.
I've change this behavior and now all parameters are available in all passes - if shader needs it, it will have access to up to date data. The cost for this is negligible, only a single assignment and increment executes in addition to existing dictionary search.

This PR also removes some duplicate functions from forward-renderer.