### PR TITLE
WebXR Input Sources: retrieve most relevant transforms of the parent

### DIFF
--- a/src/xr/xr-input-source.js
+++ b/src/xr/xr-input-source.js
@@ -198,8 +198,7 @@ XrInputSource.prototype._updateTransforms = function () {
 
     var parent = this._manager.camera.parent;
     if (parent) {
-        dirty = dirty || parent._dirtyLocal || parent._dirtyWorld;
-        if (dirty) this._worldTransform.mul2(parent.getWorldTransform(), this._localTransform);
+        this._worldTransform.mul2(parent.getWorldTransform(), this._localTransform);
     } else {
         this._worldTransform.copy(this._localTransform);
     }
@@ -211,18 +210,14 @@ XrInputSource.prototype._updateRayTransforms = function () {
 
     var parent = this._manager.camera.parent;
     if (parent) {
-        dirty = dirty || parent._dirtyLocal || parent._dirtyWorld;
+        var parentTransform = this._manager.camera.parent.getWorldTransform();
 
-        if (dirty) {
-            var parentTransform = this._manager.camera.parent.getWorldTransform();
+        parentTransform.getTranslation(this._position);
+        this._rotation.setFromMat4(parentTransform);
 
-            parentTransform.getTranslation(this._position);
-            this._rotation.setFromMat4(parentTransform);
-
-            this._rotation.transformVector(this._rayLocal.origin, this._ray.origin);
-            this._ray.origin.add(this._position);
-            this._rotation.transformVector(this._rayLocal.direction, this._ray.direction);
-        }
+        this._rotation.transformVector(this._rayLocal.origin, this._ray.origin);
+        this._ray.origin.add(this._position);
+        this._rotation.transformVector(this._rayLocal.direction, this._ray.direction);
     } else if (dirty) {
         this._ray.origin.copy(this._rayLocal.origin);
         this._ray.direction.copy(this._rayLocal.direction);

--- a/src/xr/xr-input-source.js
+++ b/src/xr/xr-input-source.js
@@ -188,10 +188,7 @@ XrInputSource.prototype.update = function (frame) {
 };
 
 XrInputSource.prototype._updateTransforms = function () {
-    var dirty;
-
     if (this._dirtyLocal) {
-        dirty = true;
         this._dirtyLocal = false;
         this._localTransform.setTRS(this._localPosition, this._localRotation, Vec3.ONE);
     }

--- a/src/xr/xr-joint.js
+++ b/src/xr/xr-joint.js
@@ -74,10 +74,7 @@ XrJoint.prototype.update = function (pose) {
 };
 
 XrJoint.prototype._updateTransforms = function () {
-    var dirty;
-
     if (this._dirtyLocal) {
-        dirty = true;
         this._dirtyLocal = false;
         this._localTransform.setTRS(this._localPosition, this._localRotation, Vec3.ONE);
     }

--- a/src/xr/xr-joint.js
+++ b/src/xr/xr-joint.js
@@ -86,8 +86,7 @@ XrJoint.prototype._updateTransforms = function () {
     var parent = manager.camera.parent;
 
     if (parent) {
-        dirty = dirty || parent._dirtyLocal || parent._dirtyWorld;
-        if (dirty) this._worldTransform.mul2(parent.getWorldTransform(), this._localTransform);
+        this._worldTransform.mul2(parent.getWorldTransform(), this._localTransform);
     } else {
         this._worldTransform.copy(this._localTransform);
     }


### PR DESCRIPTION
XR session camera parent transforms might change during update cycle, and their **dirty** flags might be false, leading to input sources using outdated transforms. We have no signalling from GraphNode transforms change or version increment, so we have to retrieve its transforms every time, instead of caching as before.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
