### PR TITLE
Changes to Camera.screenToWorld to improve precision with large frustum depth range

### DIFF
--- a/src/math/mat4.js
+++ b/src/math/mat4.js
@@ -1,6 +1,9 @@
 import { math } from './math.js';
+import { Vec2 } from './vec2.js';
 import { Vec3 } from './vec3.js';
 import { Vec4 } from './vec4.js';
+
+var _halfSize = new Vec2();
 
 /**
  * @class
@@ -16,6 +19,17 @@ function Mat4() {
     data[0] = data[5] = data[10] = data[15] = 1;
     this.data = data;
 }
+
+// Static function which evaluates perspective projection matrix half size at the near plane
+Mat4._getPerspectiveHalfSize = function (halfSize, fov, aspect, znear, fovIsHorizontal) {
+    if (fovIsHorizontal) {
+        halfSize.x = znear * Math.tan(fov * Math.PI / 360);
+        halfSize.y = halfSize.x / aspect;
+    } else {
+        halfSize.y = znear * Math.tan(fov * Math.PI / 360);
+        halfSize.x = halfSize.y * aspect;
+    }
+};
 
 Object.assign(Mat4.prototype, {
     /**
@@ -587,17 +601,8 @@ Object.assign(Mat4.prototype, {
      * var persp = pc.Mat4().setPerspective(45, 16 / 9, 1, 1000);
      */
     setPerspective: function (fov, aspect, znear, zfar, fovIsHorizontal) {
-        var xmax, ymax;
-
-        if (!fovIsHorizontal) {
-            ymax = znear * Math.tan(fov * Math.PI / 360);
-            xmax = ymax * aspect;
-        } else {
-            xmax = znear * Math.tan(fov * Math.PI / 360);
-            ymax = xmax / aspect;
-        }
-
-        return this.setFrustum(-xmax, xmax, -ymax, ymax, znear, zfar);
+        Mat4._getPerspectiveHalfSize(_halfSize, fov, aspect, znear, fovIsHorizontal);
+        return this.setFrustum(-_halfSize.x, _halfSize.x, -_halfSize.y, _halfSize.y, znear, zfar);
     },
 
     /**

--- a/src/scene/camera.js
+++ b/src/scene/camera.js
@@ -13,8 +13,8 @@ import {
 
 // pre-allocated temp variables
 var _deviceCoord = new Vec3();
-var _far = new Vec3();
-var _farW = new Vec3();
+var _halfSize = new Vec3();
+var _point = new Vec3();
 var _invViewProjMat = new Mat4();
 
 /**
@@ -383,6 +383,15 @@ Object.assign(Camera.prototype, {
         this.vrDisplay = other.vrDisplay;
     },
 
+    _updateViewProjMat: function () {
+        if (this._projMatDirty || this._viewMatDirty || this._viewProjMatDirty) {
+            var projMat = this.projectionMatrix;
+            var viewMat = this.viewMatrix;
+            this._viewProjMat.mul2(projMat, viewMat);
+            this._viewProjMatDirty = false;
+        }
+    },
+
     /**
      * @private
      * @function
@@ -399,12 +408,7 @@ Object.assign(Camera.prototype, {
             screenCoord = new Vec3();
         }
 
-        if (this._projMatDirty || this._viewMatDirty || this._viewProjMatDirty) {
-            var projMat = this.projectionMatrix;
-            var viewMat = this.viewMatrix;
-            this._viewProjMat.mul2(projMat, viewMat);
-            this._viewProjMatDirty = false;
-        }
+        this._updateViewProjMat();
         this._viewProjMat.transformPoint(worldCoord, screenCoord);
 
         // calculate w co-coord
@@ -438,40 +442,39 @@ Object.assign(Camera.prototype, {
             worldCoord = new Vec3();
         }
 
-        if (this._projMatDirty || this._viewMatDirty || this._viewProjMatDirty) {
-            var projMat = this.projectionMatrix;
-            var viewMat = this.viewMatrix;
-            this._viewProjMat.mul2(projMat, viewMat);
-            this._viewProjMatDirty = false;
-        }
-        _invViewProjMat.copy(this._viewProjMat).invert();
+        // Calculate the screen click as a point on the far plane of the normalized device coordinate 'box' (z=1)
+        var range = this._farClip - this._nearClip;
+        _deviceCoord.set(x / cw, (ch - y) / ch, z / range);
+        _deviceCoord.scale(2);
+        _deviceCoord.sub(Vec3.ONE);
 
         if (this._projection === PROJECTION_PERSPECTIVE) {
-            // Calculate the screen click as a point on the far plane of the
-            // normalized device coordinate 'box' (z=1)
-            _far.set(x / cw * 2 - 1, (ch - y) / ch * 2 - 1, 1);
 
-            // Transform to world space
-            _invViewProjMat.transformPoint(_far, _farW);
+            // calculate half width and height at the near clip plane
+            Mat4._getPerspectiveHalfSize(_halfSize, this._fov, this._aspectRatio, this._nearClip, this._horizontalFov);
 
-            var w = _far.x * _invViewProjMat.data[3] +
-                    _far.y * _invViewProjMat.data[7] +
-                    _far.z * _invViewProjMat.data[11] +
-                    _invViewProjMat.data[15];
+            // scale by normalized screen coordinates
+            _halfSize.x *= _deviceCoord.x;
+            _halfSize.y *= _deviceCoord.y;
 
-            _farW.scale(1 / w);
+            // transform to world space
+            var invView = this._node.getWorldTransform();
+            _halfSize.z = -this._nearClip;
+            invView.transformPoint(_halfSize, _point);
 
-            var alpha = z / this._farClip;
-            worldCoord.lerp(this._node.getPosition(), _farW, alpha);
+            // point along camera->_point ray at distance z from the camera
+            var cameraPos = this._node.getPosition();
+            worldCoord.sub2(_point, cameraPos);
+            worldCoord.normalize();
+            worldCoord.scale(z);
+            worldCoord.add(cameraPos);
+
         } else {
-            // Calculate the screen click as a point on the far plane of the
-            // normalized device coordinate 'box' (z=1)
-            var range = this._farClip - this._nearClip;
-            _deviceCoord.set(x / cw, (ch - y) / ch, z / range);
-            _deviceCoord.scale(2);
-            _deviceCoord.sub(Vec3.ONE);
 
-            // Transform to world space
+            this._updateViewProjMat();
+            _invViewProjMat.copy(this._viewProjMat).invert();
+
+                // Transform to world space
             _invViewProjMat.transformPoint(_deviceCoord, worldCoord);
         }
 


### PR DESCRIPTION
Fixes #2399

Changed the implementation of Camera.screenToWorld to avoid dependency on inverse view-projection matrix to improve precision with large depth range of the frustum.