### PR TITLE
Revert "Fix normals when mesh has both two-sided material and negativ…

### DIFF
--- a/src/graphics/program-lib/programs/standard.js
+++ b/src/graphics/program-lib/programs/standard.js
@@ -1333,20 +1333,15 @@ var standard = {
         code = this._fsAddStartCode(code, device, chunks, options);
 
         if (needsNormal) {
-            code += "   getViewDir();\n";
-        }
-
-        if (needsNormal) {
             if (options.twoSidedLighting) {
-                code += "   float normalDirSign = sign(dot(vNormalW, dViewDirW));\n";
-                code += "   dVertexNormalW = normalDirSign * vNormalW;\n";
+                code += "   dVertexNormalW = gl_FrontFacing ? vNormalW : -vNormalW;\n";
             } else {
                 code += "   dVertexNormalW = vNormalW;\n";
             }
             if ((options.heightMap || options.normalMap) && options.hasTangents) {
                 if (options.twoSidedLighting) {
-                    code += "   dTangentW = normalDirSign * vTangentW;\n";
-                    code += "   dBinormalW = normalDirSign * vBinormalW;\n";
+                    code += "   dTangentW = gl_FrontFacing ? vTangentW : -vTangentW;\n";
+                    code += "   dBinormalW = gl_FrontFacing ? vBinormalW : -vBinormalW;\n";
                 } else {
                     code += "   dTangentW = vTangentW;\n";
                     code += "   dBinormalW = vBinormalW;\n";
@@ -1371,6 +1366,7 @@ var standard = {
         var getGlossinessCalled = false;
 
         if (needsNormal) {
+            code += "   getViewDir();\n";
             if (options.heightMap || options.normalMap || options.clearCoatNormalMap || options.enableGGXSpecular) {
                 code += "   getTBN();\n";
             }


### PR DESCRIPTION
…e scale (#2375)"

This reverts commit 4d5f59da79d5bbc21a3cb1b328d236c39f05c0b1.

PR #2375 unfortunately introduced bad edge artifacts on some models (look at top right shoulder in pictures below - top is without artifacts bottom is with artifacts) found by @slimbuck - we believe it is related to using vertex normals which do not exactly line up with face normals. 

![image](https://user-images.githubusercontent.com/11779961/92258335-92b17b00-eece-11ea-9e63-a8cbfcc29b65.png)
![image](https://user-images.githubusercontent.com/11779961/92258371-a230c400-eece-11ea-8967-4d318943f5b8.png)

@aidinabedi - it would be great to to discuss alternative solutions with you - but for now we will revert PR #2375.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
