### PR TITLE
fix(jsdoc): `pc.Entity.findComponents` returns an array

### DIFF
--- a/src/framework/entity.js
+++ b/src/framework/entity.js
@@ -196,7 +196,7 @@ Entity.prototype.findComponent = function (type) {
  * @name pc.Entity#findComponents
  * @description Search the entity and all of its descendants for all components of specified type.
  * @param {string} type - The name of the component type to retrieve.
- * @returns {pc.Component} All components of specified type in the entity or any of its descendants.
+ * @returns {pc.Component[]} All components of specified type in the entity or any of its descendants.
  * Returns empty array if none found.
  * @example
  * // Get all light components in the hierarchy tree that starts with this entity


### PR DESCRIPTION
We noticed that `pc.Entity.findComponents` return type needs a slight amendment to return array not a single object, per documentation.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
