### PR TITLE
Frustum culling on camera created by code defaults to true

### DIFF
--- a/src/scene/camera.js
+++ b/src/scene/camera.js
@@ -39,7 +39,7 @@ function Camera() {
     this._farClip = 1000;
     this._flipFaces = false;
     this._fov = 45;
-    this._frustumCulling = false;
+    this._frustumCulling = true;
     this._horizontalFov = false;
     this._layers = [LAYERID_WORLD, LAYERID_DEPTH, LAYERID_SKYBOX, LAYERID_UI, LAYERID_IMMEDIATE];
     this._nearClip = 0.1;


### PR DESCRIPTION
This used to default to false, and by default no frustum culling was performed on cameras created by code.