### PR TITLE
Warning added when element input is enabled, but no pc.ElementInput is created to fire input events

### DIFF
--- a/src/framework/components/element/component.js
+++ b/src/framework/components/element/component.js
@@ -1445,8 +1445,8 @@ Object.defineProperty(ElementComponent.prototype, "useInput", {
                 this.system.app.elementInput.removeElement(this);
             }
         } else {
-            if (this._useInput === true){
-                console.warn("Elements will not get any input events because this.system.app.elementInput is not initialized")
+            if (this._useInput === true) {
+                console.warn("Elements will not get any input events because this.system.app.elementInput is not initialized");
             }
         }
 

--- a/src/framework/components/element/component.js
+++ b/src/framework/components/element/component.js
@@ -1444,6 +1444,10 @@ Object.defineProperty(ElementComponent.prototype, "useInput", {
             } else {
                 this.system.app.elementInput.removeElement(this);
             }
+        } else {
+            if (this._useInput === true){
+                console.warn("Elements will not get any input events because this.system.app.elementInput is not initialized")
+            }
         }
 
         this.fire('set:useInput', value);

--- a/src/framework/components/element/component.js
+++ b/src/framework/components/element/component.js
@@ -1446,7 +1446,7 @@ Object.defineProperty(ElementComponent.prototype, "useInput", {
             }
         } else {
             if (this._useInput === true) {
-                console.warn("Elements will not get any input events because this.system.app.elementInput is not initialized");
+                console.warn("Elements will not get any input events because this.system.app.elementInput is not created");
             }
         }
 


### PR DESCRIPTION
Warning added when element input is enabled, but no pc.ElementInput is created to fire input events

This will greatly help debugging a problem I wasted hours on - where element input event were not firing without any indication of why.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
