### PR TITLE
Fix tags remove error

### DIFF
--- a/src/core/tags.js
+++ b/src/core/tags.js
@@ -56,7 +56,7 @@ Object.assign(TagsCache.prototype, {
         }
 
         // by position in list
-        var ind = this._index[tag].indexOf(item);
+        var ind = this._index[tag].list.indexOf(item);
         if (ind === -1)
             return;
 


### PR DESCRIPTION
When asset is removed (easy to test in Editor), if it had tags, then it should be removed from tags index on asset registry. This small error been sitting there for very long time (5 years actually). Well, looks like removing assets from asset registry with tags is a rare case.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
