### PR TITLE
Optimized culling solution for skinned meshes

### DIFF
--- a/src/scene/batching.js
+++ b/src/scene/batching.js
@@ -98,10 +98,10 @@ SkinBatchInstance.prototype = Object.create(SkinBatchInstance.prototype);
 SkinBatchInstance.prototype.constructor = SkinBatchInstance;
 
 Object.assign(SkinBatchInstance.prototype, {
-    updateMatrices: function (rootNode) {
+    updateMatrices: function (rootNode, skinUpdateIndex) {
     },
 
-    updateMatrixPalette: function () {
+    updateMatrixPalette: function (rootNode, skinUpdateIndex) {
         var pe;
         var mp = this.matrixPalette;
         var base;

--- a/src/scene/forward-renderer.js
+++ b/src/scene/forward-renderer.js
@@ -117,6 +117,8 @@ var skipRenderCamera = null;
 var _skipRenderCounter = 0;
 var skipRenderAfter = 0;
 
+var _skinUpdateIndex = 0;
+
 // The 8 points of the camera frustum transformed to light space
 var frustumPoints = [];
 for (var fp = 0; fp < 8; fp++) {
@@ -1180,6 +1182,9 @@ Object.assign(ForwardRenderer.prototype, {
     },
 
     updateCpuSkinMatrices: function (drawCalls) {
+
+        _skinUpdateIndex++;
+
         var drawCallsCount = drawCalls.length;
         if (drawCallsCount === 0) return;
 
@@ -1187,12 +1192,12 @@ Object.assign(ForwardRenderer.prototype, {
         var skinTime = now();
         // #endif
 
-        var i, skin;
+        var i, si;
         for (i = 0; i < drawCallsCount; i++) {
-            skin = drawCalls[i].skinInstance;
-            if (skin) {
-                skin.updateMatrices(drawCalls[i].node);
-                skin._dirty = true;
+            si = drawCalls[i].skinInstance;
+            if (si) {
+                si.updateMatrices(drawCalls[i].node, _skinUpdateIndex);
+                si._dirty = true;
             }
         }
 
@@ -1213,7 +1218,7 @@ Object.assign(ForwardRenderer.prototype, {
             skin = drawCalls[i].skinInstance;
             if (skin) {
                 if (skin._dirty) {
-                    skin.updateMatrixPalette();
+                    skin.updateMatrixPalette(drawCalls[i].node, _skinUpdateIndex);
                     skin._dirty = false;
                 }
             }

--- a/src/scene/mesh-instance.js
+++ b/src/scene/mesh-instance.js
@@ -294,6 +294,8 @@ Object.defineProperty(MeshInstance.prototype, 'skinInstance', {
         for (var i = 0; i < this._shader.length; i++) {
             this._shader[i] = null;
         }
+
+        this._setupSkinUpdate();
     }
 });
 
@@ -511,6 +513,23 @@ Object.assign(MeshInstance.prototype, {
                 }
                 parameter.scopeId.setValue(parameter.data);
             }
+        }
+    },
+
+    setOverrideAabb: function (aabb) {
+        this._updateAabb = !aabb;
+        if (aabb) {
+            this.aabb.copy(aabb);
+        }
+
+        this._setupSkinUpdate();
+    },
+
+    _setupSkinUpdate() {
+
+        // set if bones need to be updated before culling
+        if (this._skinInstance) {
+            this._skinInstance._updateBeforeCull = this._updateAabb;
         }
     }
 });

--- a/src/scene/mesh-instance.js
+++ b/src/scene/mesh-instance.js
@@ -525,7 +525,7 @@ Object.assign(MeshInstance.prototype, {
         this._setupSkinUpdate();
     },
 
-    _setupSkinUpdate() {
+    _setupSkinUpdate: function () {
 
         // set if bones need to be updated before culling
         if (this._skinInstance) {


### PR DESCRIPTION
Fixes #2352

new API:
**ModelComponent.aabb** - allows oversized bounds to be specified, and turns off their update if not null

Performance impact - tested in a scene with 100 characters, about 100 bones each:
- culling. Originally took **9ms** to update aabb for characters. With oversized aabb specified, this drops to **1.6ms**.
- bone updates. Bone matrices are now processed (matrices multiplied, bones prepared for GPU consumption) only when skinned mesh is visible, instead of always. When all 100 characters are invisible, this saved about **8ms** in the test scene.

Integration to Editor still TBD.