### PR TITLE
Use buffers setup in draw call for left eye when drawing right eye

### DIFF
--- a/src/scene/forward-renderer.js
+++ b/src/scene/forward-renderer.js
@@ -1308,13 +1308,7 @@ Object.assign(ForwardRenderer.prototype, {
         if (instancingData) {
             if (instancingData.count > 0) {
                 this._instancedDrawCalls++;
-                device.setVertexBuffer(instancingData.vertexBuffer);
-                device.draw(mesh.primitive[style], instancingData.count);
-                if (instancingData.vertexBuffer === _autoInstanceBuffer) {
-                    this._removedByInstancing += instancingData.count;
-                    meshInstance.instancingData = null;
-                    return instancingData.count - 1;
-                }
+                device.draw(mesh.primitive[style], instancingData.count, true);
             }
         } else {
             // matrices are already set


### PR DESCRIPTION
Fixes #2444

The right eye should use the same buffers setup by the left eye. The draw call for the left eye clears the GraphicsDevice's vertex buffer array so calling draw with keepBuffers set to false for the right eye was not drawing all meshes.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
