### PR TITLE
Add PARTICLE #define to particle shaders

### DIFF
--- a/src/graphics/program-lib/programs/particle.js
+++ b/src/graphics/program-lib/programs/particle.js
@@ -25,6 +25,7 @@ var particle = {
     createShaderDefinition: function (device, options) {
         var vshader = "";
         var fshader = precisionCode(device) + "\n";
+        fshader += '#define PARTICLE\n';
 
         if (device.webgl2) {
             vshader += "#define GL2\n";


### PR DESCRIPTION
In order to branch shader chunks logic, it is useful to know in shader if it is used for particles or something else.
Use case where I've faced issues is for example writing custom Fog shader chunk. When making for dependant on vPositionW (world position of fragment) in particle shader this variable is not available. So overriding global shader chunk for fog in such case is not possible, or requires extra work to add vPositionW to vertex shaders.

In such case, it is useful to know in shader if it is used for particle or anything else.

This change has no effect on existing project.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
