### PR TITLE
Fixed First Person Jump

### DIFF
--- a/examples/assets/scripts/camera/first-person-camera.js
+++ b/examples/assets/scripts/camera/first-person-camera.js
@@ -8,7 +8,7 @@ CharacterController.attributes.add('jumpImpulse', { type: 'number', default: 400
 
 // initialize code called once per entity
 CharacterController.prototype.initialize = function () {
-    this.groundCheckRay = new pc.Vec3(0, -1.2, 0);
+    this.groundCheckRay = new pc.Vec3(0, -0.5, 0);
     this.rayEnd = new pc.Vec3();
 
     this.groundNormal = new pc.Vec3();


### PR DESCRIPTION
When the player jumps and falls, it goes up normally and falls with a normal behaviour in the first half of the fall but as it approaches the ground it slows down and you can can see it falls really slowly until it touches the ground. This happens every time you jump.

This commit fixes that.

Fixes #2461 

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
