### PR TITLE
Added a material flag to disable material opacity fading out specular and added a value to specifically alpha fade out materials (including specular)

### DIFF
--- a/examples/examples.js
+++ b/examples/examples.js
@@ -26,6 +26,7 @@ var categories = [
             "material-anisotropic",
             "material-clear-coat",
             "material-physical",
+            "material-translucent-specular",
             "mesh-decals",
             "mesh-deformation",
             "mesh-generation",

--- a/examples/graphics/material-translucent-specular.html
+++ b/examples/graphics/material-translucent-specular.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title>PlayCanvas translucent material specular</title>
+    <title>PlayCanvas Translucent Material Specular</title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
     <link rel="icon" type="image/png" href="../playcanvas-favicon.png" />
@@ -25,6 +25,7 @@
 
         // Create the application and start the update loop
         var app = new pc.Application(canvas);
+        app.start();
 
         // Set the canvas to fill the window and automatically change resolution to be the same as the canvas size
         app.setCanvasFillMode(pc.FILLMODE_FILL_WINDOW);
@@ -40,21 +41,24 @@
         app.scene.toneMapping = pc.TONEMAP_ACES;
         // Set the skybox to the 128x128 cubemap mipmap level
         app.scene.skyboxMip = 1;
+        app.scene.skyboxIntensity = 1;
 
         // Create an entity with a camera component
         var camera = new pc.Entity();
         camera.addComponent("camera");
-        camera.translate(0, 0, 3);
+        camera.translate(0, 0, 8);
+        camera.rotate(0, 0, 0);
         app.root.addChild(camera);
 
-        // Create an entity with a directional light component
-        var light = new pc.Entity();
-        light.addComponent("light", {
-            type: "directional",
-            color: new pc.Color(1, 0.8, 0.25)
-        });
-        app.root.addChild(light);
-        light.setLocalEulerAngles(85, -100, 0);
+         // Create an entities with a directional light components
+        for (var i = 0; i < 3; i++) {
+            var light = new pc.Entity();
+            light.addComponent("light", {
+                type: "directional"
+            });
+            app.root.addChild(light);
+            light.rotateLocal(60+10*i, 30+90*i, 0);
+        }
 
         // Load a cubemap asset. This DDS file was 'prefiltered' in the
         // PlayCanvas Editor and then downloaded.
@@ -69,127 +73,63 @@
             app.scene.setSkybox(cubemapAsset.resources);
         });
 
-        // function to create sphere
-        var createSphere = function (x, y, z, material, scale) {
+        var NUM_SPHERES_X = 10;
+        var NUM_SPHERES_Z = 5;
+
+        var createSphere = function (x, y, z) {
+            var material = new pc.StandardMaterial();
+            material.diffuse = new pc.Color(0.7, 0.7, 0.7);
+            material.metalness = 0.0;
+            material.shininess = ((z) / (NUM_SPHERES_Z - 1) * 50)+50;
+            material.useMetalness = true;
+            material.blendType = pc.BLEND_NORMAL;
+            material.opacity = (x>=5)? ((x-5)/5+0.2)*((x-5)/5+0.2): (x/5+0.2)*(x/5+0.2);
+            material.opacityFadesSpecRefl = (x>=5)? false : true;
+            material.alphaWrite = false;
+
+            material.update();
+
             var sphere = new pc.Entity();
 
             sphere.addComponent("model", {
                 material: material,
                 type: "sphere"
             });
-            sphere.setLocalPosition(x, y, z);
-            if (scale) {sphere.setLocalScale(scale, scale, scale);}
-            else {sphere.setLocalScale(0.7, 0.7, 0.7);}
+            sphere.setLocalPosition(x - (NUM_SPHERES_X - 1) * 0.5, z - (NUM_SPHERES_Z - 1) * 0.5, 0);
+            sphere.setLocalScale(0.7, 0.7, 0.7);
             app.root.addChild(sphere);
         };
 
-        var material;
-        var clearCoatMaterial;
-
-        // async load a textures, create materials and spheres, then start app
-        app.assets.loadFromUrl("../assets/textures/flakes5n.png", "texture", function (err, asset) {
-            var normalMap = asset.resource;
-            app.assets.loadFromUrl("../assets/textures/flakes5c.png", "texture", function (err, asset) {
-                var diffuseMap = asset.resource;
-                app.assets.loadFromUrl("../assets/textures/flakes5o.png", "texture", function (err, asset) {
-                    var otherMap = asset.resource;
-
-                    material0 = new pc.StandardMaterial();
-                    material0.diffuseMap = diffuseMap;
-                    //material0.metalnessMap = otherMap;
-                    //material0.metalnessMapChannel = 'r';
-                    material0.glossMap = otherMap;
-                    material0.glossMapChannel = 'g';
-                    material0.normalMap = normalMap;
-                    material0.diffuse = new pc.Color(0.6, 0.6, 0.9);
-                    material0.diffuseTint = true;
-                    material0.metalness = 1.0;
-                    material0.shininess = 0.0;
-                    material0.bumpiness = 0.7;
-                    material0.useMetalness = true;
-
-                    material0.update();
-
-                    //createSphere(-0.5, 0, -1, material0,2);
-                    //createSphere( 0.5, 0, -1, material0,2);
-
-                    material = new pc.StandardMaterial();
-                    material.diffuseMap = diffuseMap;
-                    material.metalnessMap = otherMap;
-                    material.metalnessMapChannel = 'r';
-                    material.glossMap = otherMap;
-                    material.glossMapChannel = 'g';
-                    material.normalMap = normalMap;
-                    material.diffuse = new pc.Color(0.6, 0.6, 0.9);
-                    material.diffuseTint = true;
-                    material.metalness = 1.0;
-                    material.shininess = 90.0;
-                    material.bumpiness = 0.7;
-                    material.useMetalness = true;
-
-                    material.clearCoat = 0.25;
-                    material.clearCoatGlossiness = 0.9;
-
-                    material.blendType = pc.BLEND_NORMAL;
-                    material.opacity = 0.5;
-                    material.opacityFadesSpecRefl = true;
-                    material.alphaWrite = false;
-
-                    material.update();
-
-                    createSphere(-0.5, 0, 0, material);
-
-                    clearCoatMaterial = new pc.StandardMaterial();
-                    clearCoatMaterial.diffuseMap = diffuseMap;
-                    clearCoatMaterial.metalnessMap = otherMap;
-                    clearCoatMaterial.metalnessMapChannel = 'r';
-                    clearCoatMaterial.glossMap = otherMap;
-                    clearCoatMaterial.glossMapChannel = 'g';
-                    clearCoatMaterial.normalMap = normalMap;
-                    clearCoatMaterial.diffuse = new pc.Color(0.6, 0.6, 0.9);
-                    clearCoatMaterial.diffuseTint = true;
-                    clearCoatMaterial.metalness = 1.0;
-                    clearCoatMaterial.shininess = 90;
-                    clearCoatMaterial.bumpiness = 0.7;
-                    clearCoatMaterial.useMetalness = true;
-
-                    clearCoatMaterial.clearCoat = 0.25;
-                    clearCoatMaterial.clearCoatGlossiness = 0.9;
-
-                    clearCoatMaterial.blendType = pc.BLEND_PREMULTIPLIED;
-                    clearCoatMaterial.opacity = 0.5;
-                    clearCoatMaterial.opacityFadesSpecRefl = false;
-                    clearCoatMaterial.alphaWrite = false;
-
-                    clearCoatMaterial.update();
-
-                    createSphere(0.5, 0, 0, clearCoatMaterial);
-
-                    app.start();
-                });
+        var createText = function (fontAsset, message, x, y, z, rotx, roty) {
+            // Create a text element-based entity
+            var text = new pc.Entity();
+            text.addComponent("element", {
+                anchor: [0.5, 0.5, 0.5, 0.5],
+                fontAsset: fontAsset,
+                fontSize: 0.5,
+                pivot: [0.5, 0.5],
+                text: message,
+                type: pc.ELEMENTTYPE_TEXT
             });
-        });
+            text.setLocalPosition(x, y, z);
+            text.setLocalEulerAngles(rotx, roty, 0);
+            app.root.addChild(text);
+        };
 
-        // update things each frame
-        var time = 0;
-        app.on("update", function (dt) {
-            // rotate camera around the objects
-            time += dt;
-            camera.setLocalPosition(3 * Math.sin(time * 0.5), 0, 3 * Math.cos(time * 0.5));
-            camera.lookAt(pc.Vec3.ZERO);
+        for (var i = 0; i < NUM_SPHERES_Z; i++) {
+            for (var j = 0; j < NUM_SPHERES_X; j++) {
+                createSphere(j, 0, i);
+            }
+        }
 
-            var opac = Math.sin(time)*0.5+0.5;
-            if (material) 
-            {   
-                material.opacity = opac;
-                material.update();
-            }
-            if (clearCoatMaterial) 
-            {
-                clearCoatMaterial.opacity = opac;
-                clearCoatMaterial.update();
-            }
+        // Load a font
+        var fontAsset = new pc.Asset('arial.json', "font", { url: "../assets/fonts/arial.json" });
+        fontAsset.on('load', function () {
+            createText(fontAsset, 'Spec Fade On', -NUM_SPHERES_X * 0.25, ((NUM_SPHERES_Z + 1) * -0.5), 0, -0, 0);
+            createText(fontAsset, 'Spec Fade Off', NUM_SPHERES_X * 0.25, ((NUM_SPHERES_Z + 1) * -0.5), 0, -0, 0);
         });
+        app.assets.add(fontAsset);
+        app.assets.load(fontAsset);
     </script>
 </body>
 </html>

--- a/examples/graphics/material-translucent-specular.html
+++ b/examples/graphics/material-translucent-specular.html
@@ -1,0 +1,195 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>PlayCanvas translucent material specular</title>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
+    <link rel="icon" type="image/png" href="../playcanvas-favicon.png" />
+    <script src="../../build/playcanvas.js"></script>
+    <script src="../../build/playcanvas-extras.js"></script>
+    <style>
+        body { 
+            margin: 0;
+            overflow-y: hidden;
+        }
+    </style>
+</head>
+
+<body>
+    <!-- The canvas element -->
+    <canvas id="application-canvas"></canvas>
+
+    <!-- The script -->
+    <script>
+        var canvas = document.getElementById("application-canvas");
+
+        // Create the application and start the update loop
+        var app = new pc.Application(canvas);
+
+        // Set the canvas to fill the window and automatically change resolution to be the same as the canvas size
+        app.setCanvasFillMode(pc.FILLMODE_FILL_WINDOW);
+        app.setCanvasResolution(pc.RESOLUTION_AUTO);
+
+        window.addEventListener("resize", function () {
+            app.resizeCanvas(canvas.width, canvas.height);
+        });
+
+        var miniStats = new pcx.MiniStats(app);
+
+        app.scene.gammaCorrection = pc.GAMMA_SRGB;
+        app.scene.toneMapping = pc.TONEMAP_ACES;
+        // Set the skybox to the 128x128 cubemap mipmap level
+        app.scene.skyboxMip = 1;
+
+        // Create an entity with a camera component
+        var camera = new pc.Entity();
+        camera.addComponent("camera");
+        camera.translate(0, 0, 3);
+        app.root.addChild(camera);
+
+        // Create an entity with a directional light component
+        var light = new pc.Entity();
+        light.addComponent("light", {
+            type: "directional",
+            color: new pc.Color(1, 0.8, 0.25)
+        });
+        app.root.addChild(light);
+        light.setLocalEulerAngles(85, -100, 0);
+
+        // Load a cubemap asset. This DDS file was 'prefiltered' in the
+        // PlayCanvas Editor and then downloaded.
+        var cubemapAsset = new pc.Asset('helipad.dds', 'cubemap', {
+            url: "../assets/cubemaps/helipad.dds"
+        }, {
+            type: pc.TEXTURETYPE_RGBM
+        });
+        app.assets.add(cubemapAsset);
+        app.assets.load(cubemapAsset);
+        cubemapAsset.ready(function () {
+            app.scene.setSkybox(cubemapAsset.resources);
+        });
+
+        // function to create sphere
+        var createSphere = function (x, y, z, material, scale) {
+            var sphere = new pc.Entity();
+
+            sphere.addComponent("model", {
+                material: material,
+                type: "sphere"
+            });
+            sphere.setLocalPosition(x, y, z);
+            if (scale) {sphere.setLocalScale(scale, scale, scale);}
+            else {sphere.setLocalScale(0.7, 0.7, 0.7);}
+            app.root.addChild(sphere);
+        };
+
+        var material;
+        var clearCoatMaterial;
+
+        // async load a textures, create materials and spheres, then start app
+        app.assets.loadFromUrl("../assets/textures/flakes5n.png", "texture", function (err, asset) {
+            var normalMap = asset.resource;
+            app.assets.loadFromUrl("../assets/textures/flakes5c.png", "texture", function (err, asset) {
+                var diffuseMap = asset.resource;
+                app.assets.loadFromUrl("../assets/textures/flakes5o.png", "texture", function (err, asset) {
+                    var otherMap = asset.resource;
+
+                    material0 = new pc.StandardMaterial();
+                    material0.diffuseMap = diffuseMap;
+                    //material0.metalnessMap = otherMap;
+                    //material0.metalnessMapChannel = 'r';
+                    material0.glossMap = otherMap;
+                    material0.glossMapChannel = 'g';
+                    material0.normalMap = normalMap;
+                    material0.diffuse = new pc.Color(0.6, 0.6, 0.9);
+                    material0.diffuseTint = true;
+                    material0.metalness = 1.0;
+                    material0.shininess = 0.0;
+                    material0.bumpiness = 0.7;
+                    material0.useMetalness = true;
+
+                    material0.update();
+
+                    //createSphere(-0.5, 0, -1, material0,2);
+                    //createSphere( 0.5, 0, -1, material0,2);
+
+                    material = new pc.StandardMaterial();
+                    material.diffuseMap = diffuseMap;
+                    material.metalnessMap = otherMap;
+                    material.metalnessMapChannel = 'r';
+                    material.glossMap = otherMap;
+                    material.glossMapChannel = 'g';
+                    material.normalMap = normalMap;
+                    material.diffuse = new pc.Color(0.6, 0.6, 0.9);
+                    material.diffuseTint = true;
+                    material.metalness = 1.0;
+                    material.shininess = 90.0;
+                    material.bumpiness = 0.7;
+                    material.useMetalness = true;
+
+                    material.clearCoat = 0.25;
+                    material.clearCoatGlossiness = 0.9;
+
+                    material.blendType = pc.BLEND_NORMAL;
+                    material.opacity = 0.5;
+                    material.opacityFadesSpecRefl = true;
+                    material.alphaWrite = false;
+
+                    material.update();
+
+                    createSphere(-0.5, 0, 0, material);
+
+                    clearCoatMaterial = new pc.StandardMaterial();
+                    clearCoatMaterial.diffuseMap = diffuseMap;
+                    clearCoatMaterial.metalnessMap = otherMap;
+                    clearCoatMaterial.metalnessMapChannel = 'r';
+                    clearCoatMaterial.glossMap = otherMap;
+                    clearCoatMaterial.glossMapChannel = 'g';
+                    clearCoatMaterial.normalMap = normalMap;
+                    clearCoatMaterial.diffuse = new pc.Color(0.6, 0.6, 0.9);
+                    clearCoatMaterial.diffuseTint = true;
+                    clearCoatMaterial.metalness = 1.0;
+                    clearCoatMaterial.shininess = 90;
+                    clearCoatMaterial.bumpiness = 0.7;
+                    clearCoatMaterial.useMetalness = true;
+
+                    clearCoatMaterial.clearCoat = 0.25;
+                    clearCoatMaterial.clearCoatGlossiness = 0.9;
+
+                    clearCoatMaterial.blendType = pc.BLEND_PREMULTIPLIED;
+                    clearCoatMaterial.opacity = 0.5;
+                    clearCoatMaterial.opacityFadesSpecRefl = false;
+                    clearCoatMaterial.alphaWrite = false;
+
+                    clearCoatMaterial.update();
+
+                    createSphere(0.5, 0, 0, clearCoatMaterial);
+
+                    app.start();
+                });
+            });
+        });
+
+        // update things each frame
+        var time = 0;
+        app.on("update", function (dt) {
+            // rotate camera around the objects
+            time += dt;
+            camera.setLocalPosition(3 * Math.sin(time * 0.5), 0, 3 * Math.cos(time * 0.5));
+            camera.lookAt(pc.Vec3.ZERO);
+
+            var opac = Math.sin(time)*0.5+0.5;
+            if (material) 
+            {   
+                material.opacity = opac;
+                material.update();
+            }
+            if (clearCoatMaterial) 
+            {
+                clearCoatMaterial.opacity = opac;
+                clearCoatMaterial.update();
+            }
+        });
+    </script>
+</body>
+</html>

--- a/examples/graphics/material-translucent-specular.html
+++ b/examples/graphics/material-translucent-specular.html
@@ -84,7 +84,7 @@
             material.useMetalness = true;
             material.blendType = pc.BLEND_NORMAL;
             material.opacity = (x>=5)? ((x-5)/5+0.2)*((x-5)/5+0.2): (x/5+0.2)*(x/5+0.2);
-            material.opacityFadesSpecRefl = (x>=5)? false : true;
+            material.opacityFadesSpecular = (x>=5)? false : true;
             material.alphaWrite = false;
 
             material.update();

--- a/src/graphics/program-lib/programs/standard.js
+++ b/src/graphics/program-lib/programs/standard.js
@@ -985,6 +985,10 @@ var standard = {
             code += '#define CLEARCOAT\n';
         }
 
+        if (options.opacityFadesSpecRefl === false) {
+            code += 'uniform float material_alphaFade;\n';
+        }
+
         // FRAGMENT SHADER INPUTS: UNIFORMS
         var numShadowLights = 0;
         var shadowTypeUsed = [];
@@ -1565,6 +1569,17 @@ var standard = {
             if (options.occludeSpecular) {
                 code += "    occludeSpecular();\n";
             }
+        }
+
+        if (options.opacityFadesSpecRefl === false)
+        { 
+            if (options.blendType === BLEND_NORMAL || options.blendType === BLEND_PREMULTIPLIED) 
+            {
+                code += "float specLum = dot((dSpecularLight + dReflection.rgb * dReflection.a) * dSpecularity, vec3( 0.2126, 0.7152, 0.0722 ));\n";
+                code += "#ifdef CLEARCOAT\n specLum += dot(ccSpecularLight * ccSpecularity + ccReflection.rgb * ccReflection.a * ccSpecularity, vec3( 0.2126, 0.7152, 0.0722 ));\n#endif\n";
+                code += "dAlpha = clamp(dAlpha + gammaCorrectInput(specLum), 0.0, 1.0);\n";
+            }
+            code += "dAlpha *= material_alphaFade;\n";
         }
 
         code += chunks.endPS;

--- a/src/graphics/program-lib/programs/standard.js
+++ b/src/graphics/program-lib/programs/standard.js
@@ -1571,10 +1571,8 @@ var standard = {
             }
         }
 
-        if (options.opacityFadesSpecRefl === false)
-        { 
-            if (options.blendType === BLEND_NORMAL || options.blendType === BLEND_PREMULTIPLIED) 
-            {
+        if (options.opacityFadesSpecRefl === false) {
+            if (options.blendType === BLEND_NORMAL || options.blendType === BLEND_PREMULTIPLIED) {
                 code += "float specLum = dot((dSpecularLight + dReflection.rgb * dReflection.a) * dSpecularity, vec3( 0.2126, 0.7152, 0.0722 ));\n";
                 code += "#ifdef CLEARCOAT\n specLum += dot(ccSpecularLight * ccSpecularity + ccReflection.rgb * ccReflection.a * ccSpecularity, vec3( 0.2126, 0.7152, 0.0722 ));\n#endif\n";
                 code += "dAlpha = clamp(dAlpha + gammaCorrectInput(specLum), 0.0, 1.0);\n";

--- a/src/graphics/program-lib/programs/standard.js
+++ b/src/graphics/program-lib/programs/standard.js
@@ -985,7 +985,7 @@ var standard = {
             code += '#define CLEARCOAT\n';
         }
 
-        if (options.opacityFadesSpecRefl === false) {
+        if (options.opacityFadesSpecular === false) {
             code += 'uniform float material_alphaFade;\n';
         }
 
@@ -1571,7 +1571,7 @@ var standard = {
             }
         }
 
-        if (options.opacityFadesSpecRefl === false) {
+        if (options.opacityFadesSpecular === false) {
             if (options.blendType === BLEND_NORMAL || options.blendType === BLEND_PREMULTIPLIED) {
                 code += "float specLum = dot((dSpecularLight + dReflection.rgb * dReflection.a) * dSpecularity, vec3( 0.2126, 0.7152, 0.0722 ));\n";
                 code += "#ifdef CLEARCOAT\n specLum += dot(ccSpecularLight * ccSpecularity + ccReflection.rgb * ccReflection.a * ccSpecularity, vec3( 0.2126, 0.7152, 0.0722 ));\n#endif\n";

--- a/src/resources/parser/glb-parser.js
+++ b/src/resources/parser/glb-parser.js
@@ -922,6 +922,9 @@ var createMaterial = function (gltfMaterial, textures, disableFlipV) {
     // glTF dooesn't define how to occlude specular
     material.occludeSpecular = true;
 
+    // glTF dooesn't expect material opacity to fade specular lighting
+    material.opacityFadesSpecRefl = false;
+
     material.diffuseTint = true;
     material.diffuseVertexColor = true;
 

--- a/src/resources/parser/glb-parser.js
+++ b/src/resources/parser/glb-parser.js
@@ -919,11 +919,11 @@ var createMaterial = function (gltfMaterial, textures, disableFlipV) {
 
     var material = new StandardMaterial();
 
-    // glTF dooesn't define how to occlude specular
+    // glTF doesn't define how to occlude specular
     material.occludeSpecular = true;
 
-    // glTF dooesn't expect material opacity to fade specular lighting
-    material.opacityFadesSpecRefl = false;
+    // glTF doesn't expect material opacity to fade specular lighting
+    material.opacityFadesSpecRefl = true;// false
 
     material.diffuseTint = true;
     material.diffuseVertexColor = true;

--- a/src/resources/parser/glb-parser.js
+++ b/src/resources/parser/glb-parser.js
@@ -919,11 +919,8 @@ var createMaterial = function (gltfMaterial, textures, disableFlipV) {
 
     var material = new StandardMaterial();
 
-    // glTF doesn't define how to occlude specular
+    // glTF dooesn't define how to occlude specular
     material.occludeSpecular = true;
-
-    // glTF doesn't expect material opacity to fade specular lighting
-    material.opacityFadesSpecRefl = true;// false
 
     material.diffuseTint = true;
     material.diffuseVertexColor = true;

--- a/src/scene/materials/standard-material-options-builder.js
+++ b/src/scene/materials/standard-material-options-builder.js
@@ -125,7 +125,7 @@ StandardMaterialOptionsBuilder.prototype._updateMaterialOptions = function (opti
     options.lightMapFormat = stdMat.lightMap ? (stdMat.lightMap.type === TEXTURETYPE_RGBM ? 1 : (stdMat.lightMap.format === PIXELFORMAT_RGBA32F ? 2 : 0)) : null;
     options.specularAntialias = stdMat.specularAntialias && (!!stdMat.normalMap) && (!!stdMat.normalMap.mipmaps) && !isPackedNormalMap;
     options.conserveEnergy = stdMat.conserveEnergy;
-    options.opacityFadesSpecRefl = stdMat.opacityFadesSpecRefl;
+    options.opacityFadesSpecular = stdMat.opacityFadesSpecular;
     options.alphaFade = stdMat.alphaFade;
     options.occludeSpecular = stdMat.occludeSpecular;
     options.occludeSpecularFloat = (stdMat.occludeSpecularIntensity !== 1.0);

--- a/src/scene/materials/standard-material-options-builder.js
+++ b/src/scene/materials/standard-material-options-builder.js
@@ -125,6 +125,8 @@ StandardMaterialOptionsBuilder.prototype._updateMaterialOptions = function (opti
     options.lightMapFormat = stdMat.lightMap ? (stdMat.lightMap.type === TEXTURETYPE_RGBM ? 1 : (stdMat.lightMap.format === PIXELFORMAT_RGBA32F ? 2 : 0)) : null;
     options.specularAntialias = stdMat.specularAntialias && (!!stdMat.normalMap) && (!!stdMat.normalMap.mipmaps) && !isPackedNormalMap;
     options.conserveEnergy = stdMat.conserveEnergy;
+    options.opacityFadesSpecRefl = stdMat.opacityFadesSpecRefl;
+    options.alphaFade = stdMat.alphaFade;
     options.occludeSpecular = stdMat.occludeSpecular;
     options.occludeSpecularFloat = (stdMat.occludeSpecularIntensity !== 1.0);
     options.occludeDirect = stdMat.occludeDirect;

--- a/src/scene/materials/standard-material-parameters.js
+++ b/src/scene/materials/standard-material-parameters.js
@@ -123,6 +123,7 @@ var standardMaterialParameterTypes = {
 
     alphaToCoverage: 'boolean',
     alphaTest: 'number',
+    alphaFade: 'number',
     opacity: 'number',
     opacityVertexColor: 'boolean',
     opacityVertexColorChannel: 'string',
@@ -131,6 +132,7 @@ var standardMaterialParameterTypes = {
     opacityMapUv: 'number',
     opacityMapTiling: 'vec2',
     opacityMapOffset: 'vec2',
+    opacityFadesSpecRefl: 'boolean',
 
     reflectivity: 'number',
     refraction: 'number',
@@ -161,6 +163,7 @@ var standardMaterialParameterTypes = {
     useLighting: 'boolean',
     useSkybox: 'boolean',
     useGammaTonemap: 'boolean',
+    
 
     prefilteredCubeMap128: 'texture',
     prefilteredCubeMap64: 'texture',

--- a/src/scene/materials/standard-material-parameters.js
+++ b/src/scene/materials/standard-material-parameters.js
@@ -163,7 +163,6 @@ var standardMaterialParameterTypes = {
     useLighting: 'boolean',
     useSkybox: 'boolean',
     useGammaTonemap: 'boolean',
-    
 
     prefilteredCubeMap128: 'texture',
     prefilteredCubeMap64: 'texture',

--- a/src/scene/materials/standard-material-parameters.js
+++ b/src/scene/materials/standard-material-parameters.js
@@ -132,7 +132,7 @@ var standardMaterialParameterTypes = {
     opacityMapUv: 'number',
     opacityMapTiling: 'vec2',
     opacityMapOffset: 'vec2',
-    opacityFadesSpecRefl: 'boolean',
+    opacityFadesSpecular: 'boolean',
 
     reflectivity: 'number',
     refraction: 'number',

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -154,6 +154,9 @@ import { standardMaterialCubemapParameters, standardMaterialTextureParameters } 
  * @property {boolean} opacityVertexColor Use mesh vertex colors for opacity. If opacityMap is set, it'll be multiplied by vertex colors.
  * @property {string} opacityVertexColorChannel Vertex color channels to use for opacity. Can be "r", "g", "b" or "a".
  *
+ * @property {boolean} opacityFadesSpecRefl: used to specify whether specular and reflections are faded out using {@link pc.Material#opacity}. Default is true. When set to false use {@link pc.Material#alphaFade} to fade out materials.
+ * @property {number} alphaFade: used to fade out materials when {@link pc.Material#opacityFadesSpecRefl} is set to false.
+ *
  * @property {pc.Texture|null} normalMap The main (primary) normal map of the material (default is null).
  * The texture must contains normalized, tangent space normals.
  * @property {number} normalMapUv Main (primary) normal map UV channel.
@@ -262,8 +265,8 @@ import { standardMaterialCubemapParameters, standardMaterialTextureParameters } 
  * * occludeSpecularFloat: defines if {@link pc.StandardMaterial#occludeSpecularIntensity} constant should affect specular occlusion.
  * * alphaTest: enable alpha testing. See {@link pc.Material#alphaTest}.
  * * alphaToCoverage: enable alpha to coverage. See {@link pc.Material#alphaToCoverage}.
- * * opacityFadesSpecRefl: used to specify whether specular and reflections are faded out using opacity. Default is true. When set to false use alphaFade to fade out materials.
- * * alphaFade: used to fade out materials when opacityFadesSpecRefl is set to false.
+ * * opacityFadesSpecRefl: enable specular fade. See {@link pc.Material#opacityFadesSpecRefl}.
+ * * alphaFade: fade value. See {@link pc.Material#alphaFade}.
  * * sphereMap: if {@link pc.StandardMaterial#sphereMap} is used.
  * * cubeMap: if {@link pc.StandardMaterial#cubeMap} is used.
  * * dpAtlas: if dual-paraboloid reflection is used. Dual paraboloid reflections replace prefiltered cubemaps on certain platform (mostly Android) for performance reasons.

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -262,6 +262,8 @@ import { standardMaterialCubemapParameters, standardMaterialTextureParameters } 
  * * occludeSpecularFloat: defines if {@link pc.StandardMaterial#occludeSpecularIntensity} constant should affect specular occlusion.
  * * alphaTest: enable alpha testing. See {@link pc.Material#alphaTest}.
  * * alphaToCoverage: enable alpha to coverage. See {@link pc.Material#alphaToCoverage}.
+ * * opacityFadesSpecRefl: used to specify whether specular and reflections are faded out using opacity. Default is true. When set to false use alphaFade to fade out materials.
+ * * alphaFade: used to fade out materials when opacityFadesSpecRefl is set to false.
  * * sphereMap: if {@link pc.StandardMaterial#sphereMap} is used.
  * * cubeMap: if {@link pc.StandardMaterial#cubeMap} is used.
  * * dpAtlas: if dual-paraboloid reflection is used. Dual paraboloid reflections replace prefiltered cubemaps on certain platform (mostly Android) for performance reasons.
@@ -815,6 +817,11 @@ Object.assign(StandardMaterial.prototype, {
 
         this._setParameter('material_opacity', this.opacity);
 
+        if (this.opacityFadesSpecRefl === false)
+        {
+            this._setParameter('material_alphaFade', this.alphaFade);
+        }
+
         if (this.occludeSpecular) {
             this._setParameter('material_occludeSpecularIntensity', this.occludeSpecularIntensity);
         }
@@ -1053,6 +1060,7 @@ var _defineMaterialProps = function (obj) {
         return { name: 'material_heightMapFactor', value: height * 0.025 };
     });
     _defineFloat(obj, "opacity", 1);
+    _defineFloat(obj, "alphaFade", 1);
     _defineFloat(obj, "alphaTest", 0);
     _defineFloat(obj, "bumpiness", 1);
     _defineFloat(obj, "normalDetailMapBumpiness", 1);
@@ -1100,6 +1108,7 @@ var _defineMaterialProps = function (obj) {
     _defineFlag(obj, "occludeDirect", false);
     _defineFlag(obj, "normalizeNormalMap", true);
     _defineFlag(obj, "conserveEnergy", true);
+    _defineFlag(obj, "opacityFadesSpecRefl", true);
     _defineFlag(obj, "occludeSpecular", SPECOCC_AO);
     _defineFlag(obj, "shadingModel", SPECULAR_BLINN);
     _defineFlag(obj, "fresnelModel", FRESNEL_NONE);

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -154,8 +154,8 @@ import { standardMaterialCubemapParameters, standardMaterialTextureParameters } 
  * @property {boolean} opacityVertexColor Use mesh vertex colors for opacity. If opacityMap is set, it'll be multiplied by vertex colors.
  * @property {string} opacityVertexColorChannel Vertex color channels to use for opacity. Can be "r", "g", "b" or "a".
  *
- * @property {boolean} opacityFadesSpecRefl: used to specify whether specular and reflections are faded out using {@link pc.Material#opacity}. Default is true. When set to false use {@link pc.Material#alphaFade} to fade out materials.
- * @property {number} alphaFade: used to fade out materials when {@link pc.Material#opacityFadesSpecRefl} is set to false.
+ * @property {boolean} opacityFadesSpecRefl used to specify whether specular and reflections are faded out using {@link pc.Material#opacity}. Default is true. When set to false use {@link pc.Material#alphaFade} to fade out materials.
+ * @property {number} alphaFade used to fade out materials when {@link pc.Material#opacityFadesSpecRefl} is set to false.
  *
  * @property {pc.Texture|null} normalMap The main (primary) normal map of the material (default is null).
  * The texture must contains normalized, tangent space normals.

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -154,8 +154,8 @@ import { standardMaterialCubemapParameters, standardMaterialTextureParameters } 
  * @property {boolean} opacityVertexColor Use mesh vertex colors for opacity. If opacityMap is set, it'll be multiplied by vertex colors.
  * @property {string} opacityVertexColorChannel Vertex color channels to use for opacity. Can be "r", "g", "b" or "a".
  *
- * @property {boolean} opacityFadesSpecRefl used to specify whether specular and reflections are faded out using {@link pc.Material#opacity}. Default is true. When set to false use {@link pc.Material#alphaFade} to fade out materials.
- * @property {number} alphaFade used to fade out materials when {@link pc.Material#opacityFadesSpecRefl} is set to false.
+ * @property {boolean} opacityFadesSpecular used to specify whether specular and reflections are faded out using {@link pc.Material#opacity}. Default is true. When set to false use {@link pc.Material#alphaFade} to fade out materials.
+ * @property {number} alphaFade used to fade out materials when {@link pc.Material#opacityFadesSpecular} is set to false.
  *
  * @property {pc.Texture|null} normalMap The main (primary) normal map of the material (default is null).
  * The texture must contains normalized, tangent space normals.
@@ -265,7 +265,7 @@ import { standardMaterialCubemapParameters, standardMaterialTextureParameters } 
  * * occludeSpecularFloat: defines if {@link pc.StandardMaterial#occludeSpecularIntensity} constant should affect specular occlusion.
  * * alphaTest: enable alpha testing. See {@link pc.Material#alphaTest}.
  * * alphaToCoverage: enable alpha to coverage. See {@link pc.Material#alphaToCoverage}.
- * * opacityFadesSpecRefl: enable specular fade. See {@link pc.Material#opacityFadesSpecRefl}.
+ * * opacityFadesSpecular: enable specular fade. See {@link pc.Material#opacityFadesSpecular}.
  * * alphaFade: fade value. See {@link pc.Material#alphaFade}.
  * * sphereMap: if {@link pc.StandardMaterial#sphereMap} is used.
  * * cubeMap: if {@link pc.StandardMaterial#cubeMap} is used.
@@ -820,7 +820,7 @@ Object.assign(StandardMaterial.prototype, {
 
         this._setParameter('material_opacity', this.opacity);
 
-        if (this.opacityFadesSpecRefl === false) {
+        if (this.opacityFadesSpecular === false) {
             this._setParameter('material_alphaFade', this.alphaFade);
         }
 
@@ -1110,7 +1110,7 @@ var _defineMaterialProps = function (obj) {
     _defineFlag(obj, "occludeDirect", false);
     _defineFlag(obj, "normalizeNormalMap", true);
     _defineFlag(obj, "conserveEnergy", true);
-    _defineFlag(obj, "opacityFadesSpecRefl", true);
+    _defineFlag(obj, "opacityFadesSpecular", true);
     _defineFlag(obj, "occludeSpecular", SPECOCC_AO);
     _defineFlag(obj, "shadingModel", SPECULAR_BLINN);
     _defineFlag(obj, "fresnelModel", FRESNEL_NONE);

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -817,8 +817,7 @@ Object.assign(StandardMaterial.prototype, {
 
         this._setParameter('material_opacity', this.opacity);
 
-        if (this.opacityFadesSpecRefl === false)
-        {
+        if (this.opacityFadesSpecRefl === false) {
             this._setParameter('material_alphaFade', this.alphaFade);
         }
 


### PR DESCRIPTION
Fixes #2018 

Implementation is based on #2019 - but with different naming and differing location of some code changes and support for clear coat specular included.

Screen grab from the material-translucent-specular engine example:
![image](https://user-images.githubusercontent.com/11779961/96987863-74a1e780-151b-11eb-8de5-0880950ce10f.png)

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
