### PR TITLE
Fixed WebVR transform update from vrDisplay

### DIFF
--- a/src/framework/components/camera/system.js
+++ b/src/framework/components/camera/system.js
@@ -139,11 +139,12 @@ Object.assign(CameraComponentSystem.prototype, {
             for (var id in components) {
                 var component = components[id];
 
-                if (component.enabled && component.entity.enabled) {
-                    var vrDisplay = component.vrDisplay;
+                if (component.data.enabled && component.entity.enabled) {
+                    var cameraComponent = component.entity.camera;
+                    var vrDisplay = cameraComponent.vrDisplay;
                     if (vrDisplay) {
                         // Change WebVR near/far planes based on the stereo camera
-                        vrDisplay.setClipPlanes(component.nearClip, component.farClip);
+                        vrDisplay.setClipPlanes(cameraComponent.nearClip, cameraComponent.farClip);
 
                         // update camera node transform from VrDisplay
                         if (component.entity) {


### PR DESCRIPTION
Fixes bug where the camera local transform was not updated to match the direction that display was facing.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
