### PR TITLE
Don't crash when using destroyed textures

### DIFF
--- a/src/graphics/texture.js
+++ b/src/graphics/texture.js
@@ -665,7 +665,7 @@ Object.assign(Texture.prototype, {
             this.device.destroyTexture(this);
         }
         this.device = null;
-        this._levels = null;
+        this._levels = this._cubemap ? [[null, null, null, null, null, null]] : [null];
     },
 
     // Force a full resubmission of the texture to WebGL (used on a context restore event)


### PR DESCRIPTION
Fixes #2513

This PR fixes a crash that happens when a texture which has already been destroyed is still referenced by a material in the scene.

When the scene is next rendered, the texture will have its WebGL interfaces created etc and will ultimately crash at https://github.com/playcanvas/engine/blob/master/src/graphics/device.js#L1799 because `_levels` is `null`.

This PR sets `texture._levels` to the constructor default value instead of `null` thereby circumventing the crash.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
