### PR TITLE
Add debug message when using a destroyed texture

### DIFF
--- a/src/graphics/device.js
+++ b/src/graphics/device.js
@@ -1785,6 +1785,12 @@ Object.assign(GraphicsDevice.prototype, {
     },
 
     uploadTexture: function (texture) {
+        // #ifdef DEBUG
+        if (!texture.device) {
+            console.error("attempting to use a texture that has been destroyed.");
+        }
+        // #endif
+
         var gl = this.gl;
 
         if (!texture._needsUpload && ((texture._needsMipmapsUpload && texture._mipmapsUploaded) || !texture.pot))

--- a/src/graphics/device.js
+++ b/src/graphics/device.js
@@ -688,6 +688,10 @@ var GraphicsDevice = function (canvas, options) {
     this.createGrabPass();
 
     VertexFormat.init(this);
+
+    // #ifdef DEBUG
+    this._destroyedTextures = new Set();    // list of textures that have already been reported as destroyed
+    // #endif
 };
 GraphicsDevice.prototype = Object.create(EventHandler.prototype);
 GraphicsDevice.prototype.constructor = GraphicsDevice;
@@ -1787,7 +1791,10 @@ Object.assign(GraphicsDevice.prototype, {
     uploadTexture: function (texture) {
         // #ifdef DEBUG
         if (!texture.device) {
-            console.error("attempting to use a texture that has been destroyed.");
+            if (!this._destroyedTextures.has(texture)) {
+                this._destroyedTextures.add(texture);
+                console.error("attempting to use a texture that has been destroyed.");
+            }
         }
         // #endif
 


### PR DESCRIPTION
Following on from #2515, issue an error message in development builds when a destroyed texture is referenced in the scene.