### PR TITLE
Fixed orientation on physics renders on capsules and cylinders based on axis creation

### DIFF
--- a/examples/assets/scripts/physics/render-physics.js
+++ b/examples/assets/scripts/physics/render-physics.js
@@ -199,8 +199,7 @@ RenderPhysics.prototype.postUpdate = function (dt) {
                     collision._debugShape.setRotation(collision.entity.getRotation());
                 }
 
-                // If the shape is a cylinder or a capsule, rotate it so that it's axis is
-                // taken into account
+                // If the shape is a capsule, cone or cylinder, rotate it so that its axis is taken into account
                 if (collision.type === 'capsule' || collision.type === 'cone' || collision.type === 'cylinder') {
                     if (collision._debugShape._axis === 0) {
                         // X

--- a/examples/assets/scripts/physics/render-physics.js
+++ b/examples/assets/scripts/physics/render-physics.js
@@ -139,6 +139,7 @@ RenderPhysics.prototype.postUpdate = function (dt) {
                             });
                             debugShape._height = collision.height;
                             debugShape._radius = collision.radius;
+                            debugShape._axis = collision.axis;
                             break;
                         case 'cylinder':
                             mesh = pc.createCylinder(this.app.graphicsDevice, {
@@ -200,7 +201,7 @@ RenderPhysics.prototype.postUpdate = function (dt) {
 
                 // If the shape is a cylinder or a capsule, rotate it so that it's axis is
                 // taken into account
-                if (collision.type == 'cylinder' || collision.type == 'capsule') {
+                if (collision.type == 'cylinder' || collision.type == 'capsule' || collision.type == 'cone') {
                     if (collision._debugShape._axis === 0) {
                         // X
                         collision._debugShape.rotateLocal(0, 0, 90);

--- a/examples/assets/scripts/physics/render-physics.js
+++ b/examples/assets/scripts/physics/render-physics.js
@@ -147,6 +147,7 @@ RenderPhysics.prototype.postUpdate = function (dt) {
                             });
                             debugShape._height = collision.height;
                             debugShape._radius = collision.radius;
+                            debugShape._axis = collision.axis;
                             break;
                         case 'sphere':
                             mesh = pc.createSphere(this.app.graphicsDevice, {
@@ -161,6 +162,7 @@ RenderPhysics.prototype.postUpdate = function (dt) {
                             });
                             debugShape._height = collision.height;
                             debugShape._radius = collision.radius;
+                            debugShape._axis = collision.axis;
                             break;
                     }
 
@@ -194,6 +196,18 @@ RenderPhysics.prototype.postUpdate = function (dt) {
                 } else {
                     collision._debugShape.setPosition(collision.entity.getPosition());
                     collision._debugShape.setRotation(collision.entity.getRotation());
+                }
+
+                // If the shape is a cylinder or a capsule, rotate it so that it's axis is
+                // taken into account
+                if (collision.type == 'cylinder' || collision.type == 'capsule') {
+                    if (collision._debugShape._axis === 0) {
+                        // X
+                        collision._debugShape.rotateLocal(0, 0, 90);
+                    } else if (collision._debugShape._axis === 2) {
+                        // Z
+                        collision._debugShape.rotateLocal(90, 0, 0);
+                    }
                 }
 
                 collision._debugShape.updated = true;

--- a/examples/assets/scripts/physics/render-physics.js
+++ b/examples/assets/scripts/physics/render-physics.js
@@ -201,7 +201,7 @@ RenderPhysics.prototype.postUpdate = function (dt) {
 
                 // If the shape is a cylinder or a capsule, rotate it so that it's axis is
                 // taken into account
-                if (collision.type == 'cylinder' || collision.type == 'capsule' || collision.type == 'cone') {
+                if (collision.type == 'capsule' || collision.type == 'cone' || collision.type == 'cylinder') {
                     if (collision._debugShape._axis === 0) {
                         // X
                         collision._debugShape.rotateLocal(0, 0, 90);

--- a/examples/assets/scripts/physics/render-physics.js
+++ b/examples/assets/scripts/physics/render-physics.js
@@ -201,7 +201,7 @@ RenderPhysics.prototype.postUpdate = function (dt) {
 
                 // If the shape is a cylinder or a capsule, rotate it so that it's axis is
                 // taken into account
-                if (collision.type == 'capsule' || collision.type == 'cone' || collision.type == 'cylinder') {
+                if (collision.type === 'capsule' || collision.type === 'cone' || collision.type === 'cylinder') {
                     if (collision._debugShape._axis === 0) {
                         // X
                         collision._debugShape.rotateLocal(0, 0, 90);


### PR DESCRIPTION
Fixes an issue where the orientation of capsules and cylinders are not correct based on the axis.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
