### PR TITLE
Null a potentially dangling screen entity reference on remove

### DIFF
--- a/src/framework/components/element/component.js
+++ b/src/framework/components/element/component.js
@@ -634,9 +634,15 @@ Object.assign(ElementComponent.prototype, {
     },
 
     _onScreenRemove: function () {
-        // if there is a screen and it is not being destroyed
-        if (this.screen && !this.screen._destroying) {
-            this._updateScreen(null);
+        if (this.screen) {
+            if (this.screen._destroying) {
+                // If the screen entity is being destroyed, we don't call
+                // _updateScreen() as an optimization but we should still
+                // set it to null to clean up dangling references
+                this.screen = null;
+            } else {
+                this._updateScreen(null);
+            }
         }
     },
 


### PR DESCRIPTION
Fixes an edge case where a user may remove an element entity when the screen entity is being destroyed by nulling a potentially dangling reference to the screen entity.

Repo: https://playcanvas.com/editor/scene/1023656 (press 1)

The existing code assumed (as an optimisation) that if the screen entity is being destroyed, then there is no need to call _updateScreen as it is going to get destroyed too.

I do feel like the edge case will have problems as it relies on the order of operations of entities being destroyed that are internal to the engine and that child elements should be removed before the parent is destroyed.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
