### PR TITLE
Assign better defaults to JSON script attribute fields

### DIFF
--- a/src/script/script-attributes.js
+++ b/src/script/script-attributes.js
@@ -48,8 +48,8 @@ var rawToValue = function (app, args, value, old) {
                     if (field.array) {
                         result[field.name] = [];
 
-                        var arr = Array.isArray(value[field.name]) ? value[field.name]: [];
-                        
+                        var arr = Array.isArray(value[field.name]) ? value[field.name] : [];
+
                         for (j = 0; j < arr.length; j++) {
                             result[field.name].push(rawToValue(app, field, arr[j]));
                         }

--- a/src/script/script-attributes.js
+++ b/src/script/script-attributes.js
@@ -47,13 +47,17 @@ var rawToValue = function (app, args, value, old) {
 
                     if (field.array) {
                         result[field.name] = [];
-                        if (Array.isArray(value[field.name])) {
-                            for (j = 0; j < value[field.name].length; j++) {
-                                result[field.name].push(rawToValue(app, field, value[field.name][j]));
-                            }
+
+                        var arr = Array.isArray(value[field.name]) ? value[field.name]: [];
+                        
+                        for (j = 0; j < arr.length; j++) {
+                            result[field.name].push(rawToValue(app, field, arr[j]));
                         }
                     } else {
-                        result[field.name] = rawToValue(app, field, value[field.name]);
+                        // use the value of the field as it's passed into rawToValue otherwise
+                        // use the default field value
+                        var val = value.hasOwnProperty(field.name) ? value[field.name] : field.default;
+                        result[field.name] = rawToValue(app, field, val);
                     }
                 }
             }

--- a/tests/framework/components/script/scriptWithAttributes.js
+++ b/tests/framework/components/script/scriptWithAttributes.js
@@ -11,10 +11,16 @@ ScriptWithAttributes.attributes.add('attribute2', {
 
 var schema = [{
     name: 'fieldNumber',
-    type: 'number'
+    type: 'number',
+    default: 1
 }, {
     name: 'fieldEntity',
     type: 'entity'
+}, {
+    name: 'fieldNumberArray',
+    type: 'number',
+    array: true,
+    default: 5
 }];
 
 ScriptWithAttributes.attributes.add('attribute3', {

--- a/tests/framework/components/script/test_script_component.js
+++ b/tests/framework/components/script/test_script_component.js
@@ -1146,7 +1146,10 @@ describe("pc.ScriptComponent", function () {
                         }, {
                             fieldNumber: 'shouldBeNull'
                         }, {
-                            missing: true
+                            missing: true,
+                            fieldNumberArray: ['shouldBecomeNull']
+                        }, {
+                            fieldNumberArray: [1,2,3]
                         }]
                     }
                 }
@@ -1162,8 +1165,12 @@ describe("pc.ScriptComponent", function () {
         expect(e.script.scriptWithAttributes.attribute4[0].fieldNumber).to.equal(2);
 
         expect(e.script.scriptWithAttributes.attribute4[1].fieldNumber).to.equal(null);
-        expect(e.script.scriptWithAttributes.attribute4[2].fieldNumber).to.equal(null);
+
+        expect(e.script.scriptWithAttributes.attribute4[2].fieldNumber).to.equal(1);
         expect(e.script.scriptWithAttributes.attribute4[2].missing).to.equal(undefined);
+        expect(e.script.scriptWithAttributes.attribute4[2].fieldNumberArray).to.deep.equal([null]);
+
+        expect(e.script.scriptWithAttributes.attribute4[3].fieldNumberArray).to.deep.equal([1, 2, 3]);
     });
 
     it('json script attributes are cloned correctly', function () {
@@ -1230,6 +1237,38 @@ describe("pc.ScriptComponent", function () {
 
         expect(e.script.scriptWithAttributes.attribute4.length).to.equal(1);
         expect(e.script.scriptWithAttributes.attribute4[0].fieldNumber).to.equal(2);
+    });
+
+    it('default values work for script attributes', function () {
+        var e = new pc.Entity();
+        e.addComponent('script');
+        e.script.create('scriptWithAttributes');
+
+        app.root.addChild(e);
+
+
+        expect(e.script.scriptWithAttributes.attribute2).to.equal(2);
+        expect(e.script.scriptWithAttributes.attribute3).to.exist;
+        expect(e.script.scriptWithAttributes.attribute3.fieldNumber).to.equal(1);
+    });
+
+    it('default values work for partially initialized script attributes', function () {
+        var e = new pc.Entity();
+        e.addComponent('script');
+        e.script.create('scriptWithAttributes', {
+            attributes: {
+                attribute2: 3,
+                attribute4: [{
+                    fieldEntity: null
+                }]
+            }
+        });
+
+        app.root.addChild(e);
+
+        expect(e.script.scriptWithAttributes.attribute2).to.equal(3);
+        expect(e.script.scriptWithAttributes.attribute4[0].fieldNumber).to.equal(1);
+        expect(e.script.scriptWithAttributes.attribute4[0].fieldNumberArray).to.deep.equal([]);
     });
 
     it('enable is fired when entity becomes enabled', function () {


### PR DESCRIPTION
Assign better defaults to JSON script attribute fields in cases where only some defaults are specified

