### PR TITLE
Prefilter shader fix

### DIFF
--- a/examples/graphics/material-clear-coat.html
+++ b/examples/graphics/material-clear-coat.html
@@ -44,7 +44,7 @@
         // Create an entity with a camera component
         var camera = new pc.Entity();
         camera.addComponent("camera");
-        camera.translate(0, 0, 3);
+        camera.translate(0, 0, 2);
         app.root.addChild(camera);
 
         // Create an entity with a directional light component
@@ -136,8 +136,8 @@
         app.on("update", function (dt) {
             // rotate camera around the objects
             time += dt;
-            camera.setLocalPosition(3 * Math.sin(time * 0.5), 0, 3 * Math.cos(time * 0.5));
-            camera.lookAt(pc.Vec3.ZERO);
+            //camera.setLocalPosition(3 * Math.sin(time * 0.5), 0, 3 * Math.cos(time * 0.5));
+            //camera.lookAt(pc.Vec3.ZERO);
         });
     </script>
 </body>

--- a/examples/graphics/material-clear-coat.html
+++ b/examples/graphics/material-clear-coat.html
@@ -44,7 +44,7 @@
         // Create an entity with a camera component
         var camera = new pc.Entity();
         camera.addComponent("camera");
-        camera.translate(0, 0, 2);
+        camera.translate(0, 0, 3);
         app.root.addChild(camera);
 
         // Create an entity with a directional light component
@@ -136,8 +136,8 @@
         app.on("update", function (dt) {
             // rotate camera around the objects
             time += dt;
-            //camera.setLocalPosition(3 * Math.sin(time * 0.5), 0, 3 * Math.cos(time * 0.5));
-            //camera.lookAt(pc.Vec3.ZERO);
+            camera.setLocalPosition(3 * Math.sin(time * 0.5), 0, 3 * Math.cos(time * 0.5));
+            camera.lookAt(pc.Vec3.ZERO);
         });
     </script>
 </body>

--- a/src/graphics/program-lib/chunks/fixCubemapSeamsNone.frag
+++ b/src/graphics/program-lib/chunks/fixCubemapSeamsNone.frag
@@ -15,5 +15,5 @@ vec3 calcSeam(vec3 vec) {
 }
 
 vec3 applySeam(vec3 vec, vec3 seam, vec3 scale) {
-    return vec * (seam * scale + vec3(1) - seam);
+    return vec;
 }

--- a/src/graphics/program-lib/chunks/fixCubemapSeamsNone.frag
+++ b/src/graphics/program-lib/chunks/fixCubemapSeamsNone.frag
@@ -9,3 +9,11 @@ vec3 fixSeams(vec3 vec) {
 vec3 fixSeamsStatic(vec3 vec, float invRecMipSize) {
     return vec;
 }
+
+vec3 calcSeam(vec3 vec) {
+    return vec3(0)
+}
+
+vec3 applySeam(vec3 vec, vec3 seam, vec3 scale) {
+    return vec * (seam * scale + vec3(1) - seam);
+}

--- a/src/graphics/program-lib/chunks/fixCubemapSeamsStretch.frag
+++ b/src/graphics/program-lib/chunks/fixCubemapSeamsStretch.frag
@@ -34,5 +34,5 @@ vec3 calcSeam(vec3 vec) {
 }
 
 vec3 applySeam(vec3 vec, vec3 seam, float scale) {
-    return vec * (seam * scale + vec3(1.0) - seam);
+    return vec * (seam * -scale + vec3(1.0));
 }

--- a/src/graphics/program-lib/chunks/fixCubemapSeamsStretch.frag
+++ b/src/graphics/program-lib/chunks/fixCubemapSeamsStretch.frag
@@ -27,12 +27,12 @@ vec3 fixSeamsStatic(vec3 vec, float invRecMipSize) {
 
 vec3 calcSeam(vec3 vec) {
     vec3 avec = abs(vec);
-    float M = max(vec.x, max(vec.y, vec.z));
-    return vec3(avec.x != M ? 1 : 0,
-                avec.y != M ? 1 : 0,
-                avec.z != M ? 1 : 0);
+    float M = max(avec.x, max(avec.y, avec.z));
+    return vec3(avec.x != M ? 1.0 : 0.0,
+                avec.y != M ? 1.0 : 0.0,
+                avec.z != M ? 1.0 : 0.0);
 }
 
 vec3 applySeam(vec3 vec, vec3 seam, float scale) {
-    return vec * (seam * scale + vec3(1) - seam);
+    return vec * (seam * scale + vec3(1.0) - seam);
 }

--- a/src/graphics/program-lib/chunks/fixCubemapSeamsStretch.frag
+++ b/src/graphics/program-lib/chunks/fixCubemapSeamsStretch.frag
@@ -24,3 +24,15 @@ vec3 fixSeamsStatic(vec3 vec, float invRecMipSize) {
     if (abs(vec.z) != M) vec.z *= scale;
     return vec;
 }
+
+vec3 calcSeam(vec3 vec) {
+    vec3 avec = abs(vec);
+    float M = max(vec.x, max(vec.y, vec.z));
+    return vec3(avec.x != M ? 1 : 0,
+                avec.y != M ? 1 : 0,
+                avec.z != M ? 1 : 0);
+}
+
+vec3 applySeam(vec3 vec, vec3 seam, float scale) {
+    return vec * (seam * scale + vec3(1) - seam);
+}

--- a/src/graphics/program-lib/chunks/reflectionPrefilteredCube.frag
+++ b/src/graphics/program-lib/chunks/reflectionPrefilteredCube.frag
@@ -14,16 +14,14 @@ vec3 calcReflection(vec3 tReflDirW, float tGlossiness) {
     // We fix mip0 to 128x128, so code is rather static.
     // Mips smaller than 4x4 aren't great even for diffuse. Don't forget that we don't have bilinear filtering between different faces.
 
-    vec3 refl = cubeMapProject(tReflDirW);
-    refl.x *= -1.0;
+    vec3 refl = cubeMapProject(tReflDirW) * vec3(-1.0, 1.0, 1.0);
     vec3 seam = calcSeam(refl);
-
-    vec4 c0 = textureCube(texture_prefilteredCubeMap128, applySeam(refl, seam, 1.0 - 1.0 / 128.0));
-    vec4 c1 = textureCube(texture_prefilteredCubeMap64, applySeam(refl, seam, 1.0 - 2.0 / 128.0));
-    vec4 c2 = textureCube(texture_prefilteredCubeMap32, applySeam(refl, seam, 1.0 - 4.0 / 128.0));
-    vec4 c3 = textureCube(texture_prefilteredCubeMap16, applySeam(refl, seam, 1.0 - 8.0 / 128.0));
-    vec4 c4 = textureCube(texture_prefilteredCubeMap8, applySeam(refl, seam, 1.0 - 16.0 / 128.0));
-    vec4 c5 = textureCube(texture_prefilteredCubeMap4, applySeam(refl, seam, 1.0 - 32.0 / 128.0));
+    vec4 c0 = textureCube(texture_prefilteredCubeMap128, applySeam(refl, seam, 1.0 / 128.0));
+    vec4 c1 = textureCube(texture_prefilteredCubeMap64, applySeam(refl, seam, 2.0 / 128.0));
+    vec4 c2 = textureCube(texture_prefilteredCubeMap32, applySeam(refl, seam, 4.0 / 128.0));
+    vec4 c3 = textureCube(texture_prefilteredCubeMap16, applySeam(refl, seam, 8.0 / 128.0));
+    vec4 c4 = textureCube(texture_prefilteredCubeMap8, applySeam(refl, seam, 16.0 / 128.0));
+    vec4 c5 = textureCube(texture_prefilteredCubeMap4, applySeam(refl, seam, 32.0 / 128.0));
 
     float bias = saturate(1.0 - tGlossiness) * 5.0; // multiply by max mip level
     vec4 cubes0;

--- a/src/graphics/program-lib/chunks/reflectionPrefilteredCube.frag
+++ b/src/graphics/program-lib/chunks/reflectionPrefilteredCube.frag
@@ -14,30 +14,39 @@ vec3 calcReflection(vec3 tReflDirW, float tGlossiness) {
     // We fix mip0 to 128x128, so code is rather static.
     // Mips smaller than 4x4 aren't great even for diffuse. Don't forget that we don't have bilinear filtering between different faces.
 
-    float bias = saturate(1.0 - tGlossiness) * 5.0; // multiply by max mip level
-    vec3 mirror = vec3(-1.0, 1.0, 1.0);
     vec3 refl = cubeMapProject(tReflDirW);
+    refl.x *= -1.0;
+    vec3 seam = calcSeam(refl);
+
+    vec4 c0 = textureCube(texture_prefilteredCubeMap128, applySeam(refl, seam, 1.0 - 1.0 / 128.0));
+    vec4 c1 = textureCube(texture_prefilteredCubeMap64, applySeam(refl, seam, 1.0 - 2.0 / 128.0));
+    vec4 c2 = textureCube(texture_prefilteredCubeMap32, applySeam(refl, seam, 1.0 - 4.0 / 128.0));
+    vec4 c3 = textureCube(texture_prefilteredCubeMap16, applySeam(refl, seam, 1.0 - 8.0 / 128.0));
+    vec4 c4 = textureCube(texture_prefilteredCubeMap8, applySeam(refl, seam, 1.0 - 16.0 / 128.0));
+    vec4 c5 = textureCube(texture_prefilteredCubeMap4, applySeam(refl, seam, 1.0 - 32.0 / 128.0));
+
+    float bias = saturate(1.0 - tGlossiness) * 5.0; // multiply by max mip level
     vec4 cubes0;
     vec4 cubes1;
     if (bias < 1.0) {
-        cubes0 = textureCube(texture_prefilteredCubeMap128, fixSeams(refl, 0.0) * mirror);
-        cubes1 = textureCube(texture_prefilteredCubeMap64, fixSeams(refl, 1.0) * mirror);
+        cubes0 = c0;
+        cubes1 = c1;
     } else if (bias < 2.0) {
-        cubes0 = textureCube(texture_prefilteredCubeMap64, fixSeams(refl, 1.0) * mirror);
-        cubes1 = textureCube(texture_prefilteredCubeMap32, fixSeams(refl, 2.0) * mirror);
+        cubes0 = c1;
+        cubes1 = c2;
     } else if (bias < 3.0) {
-        cubes0 = textureCube(texture_prefilteredCubeMap32, fixSeams(refl, 2.0) * mirror);
-        cubes1 = textureCube(texture_prefilteredCubeMap16, fixSeams(refl, 3.0) * mirror);
+        cubes0 = c2;
+        cubes1 = c3;
     } else if (bias < 4.0) {
-        cubes0 = textureCube(texture_prefilteredCubeMap16, fixSeams(refl, 3.0) * mirror);
-        cubes1 = textureCube(texture_prefilteredCubeMap8, fixSeams(refl, 4.0) * mirror);
+        cubes0 = c3;
+        cubes1 = c4;
     } else {
-        cubes0 = textureCube(texture_prefilteredCubeMap8, fixSeams(refl, 4.0) * mirror);
-        cubes1 = textureCube(texture_prefilteredCubeMap4, fixSeams(refl, 5.0) * mirror);
+        cubes0 = c4;
+        cubes1 = c5;
     }
 
     vec4 cubeFinal = mix(cubes0, cubes1, fract(bias));
-    return processEnvironment($DECODE(cubeFinal).rgb);
+    return processEnvironment($DECODE(cubeFinal).rgb) * 0.5;
 }
 
 void addReflection() {   

--- a/src/graphics/program-lib/chunks/reflectionPrefilteredCube.frag
+++ b/src/graphics/program-lib/chunks/reflectionPrefilteredCube.frag
@@ -46,7 +46,7 @@ vec3 calcReflection(vec3 tReflDirW, float tGlossiness) {
     }
 
     vec4 cubeFinal = mix(cubes0, cubes1, fract(bias));
-    return processEnvironment($DECODE(cubeFinal).rgb) * 0.5;
+    return processEnvironment($DECODE(cubeFinal).rgb);
 }
 
 void addReflection() {   


### PR DESCRIPTION
The clear coat material was rendering incorrectly on iOS with the recently updated prefilter shader (see #2522).

This PR reimplements the shader to work on iOS (while unfortunately re-introducing 6 texture samples), but keeps the seams fix.

It will be worth re-investigating whether the original fix can work on iOS.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
