### PR TITLE
Disable translucent canvas by default in engine

### DIFF
--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -419,6 +419,8 @@ function Application(canvas, options) {
 
     options.graphicsDeviceOptions.xrCompatible = true;
 
+    options.graphicsDeviceOptions.alpha = options.graphicsDeviceOptions.alpha || false;
+
     this.graphicsDevice = new GraphicsDevice(canvas, options.graphicsDeviceOptions);
     this.stats = new ApplicationStats(this.graphicsDevice);
     this._soundManager = new SoundManager(options);


### PR DESCRIPTION
Fixes Engine examples that use translucent materials.

This PR does not affect editor projects - which by default sets `alpha: false` using Settings->RENDERING->Transparent Canvas tick box (which is not ticked by default).

There is a possibility that some engine-only projects expect and rely on the canvas to be translucent by default and this change may cause these projects to break until they enable translucent canvas manually.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
