### PR TITLE
[Fix] Notify scene the blend has changed

### DIFF
--- a/src/scene/forward-renderer.js
+++ b/src/scene/forward-renderer.js
@@ -1599,7 +1599,7 @@ Object.assign(ForwardRenderer.prototype, {
     updateShader: function (meshInstance, objDefs, staticLightList, pass, sortedLights) {
         meshInstance.material._scene = this.scene;
 
-        // if material had alpha changed, notify scene here
+        // if material has dirtyBlend set, notify scene here
         if (meshInstance.material._dirtyBlend) {
             this.scene.layers._dirtyBlend = true;
         }

--- a/src/scene/forward-renderer.js
+++ b/src/scene/forward-renderer.js
@@ -1598,6 +1598,12 @@ Object.assign(ForwardRenderer.prototype, {
 
     updateShader: function (meshInstance, objDefs, staticLightList, pass, sortedLights) {
         meshInstance.material._scene = this.scene;
+
+        // if material had alpha changed, notify scene here
+        if (meshInstance.material._dirtyBlend) {
+            this.scene.layers._dirtyBlend = true;
+        }
+
         meshInstance.material.updateShader(this.device, this.scene, objDefs, staticLightList, pass, sortedLights);
         meshInstance._shader[pass] = meshInstance.material.shader;
     },


### PR DESCRIPTION
Fixes #2576

in some cases layer composition's _dirtyBlend flag was not updated when material changed blend type - cases when material's _scene property has not been set yet. Forwarding the flag at the point it gets set as well.