### PR TITLE
[Anim Component] ANY state fix

### DIFF
--- a/src/framework/components/anim/component.js
+++ b/src/framework/components/anim/component.js
@@ -5,7 +5,7 @@ import { AnimEvaluator } from '../../../anim/anim.js';
 import { Component } from '../component.js';
 
 import {
-    ANIM_PARAMETER_BOOLEAN, ANIM_PARAMETER_FLOAT, ANIM_PARAMETER_INTEGER, ANIM_PARAMETER_TRIGGER
+    ANIM_PARAMETER_BOOLEAN, ANIM_PARAMETER_FLOAT, ANIM_PARAMETER_INTEGER, ANIM_PARAMETER_TRIGGER, ANIM_STATE_START, ANIM_STATE_END, ANIM_STATE_ANY
 } from './constants.js';
 import { AnimComponentBinder } from './binder.js';
 import { AnimComponentLayer } from './layer.js';
@@ -81,7 +81,7 @@ Object.assign(AnimComponent.prototype, {
             var layerName = layer.name;
             for (var j = 0; j < layer.states.length; j++) {
                 var stateName = layer.states[j];
-                if (stateName !== 'START' && stateName !== 'END') {
+                if (stateName !== ANIM_STATE_START && stateName !== ANIM_STATE_END && stateName !== ANIM_STATE_ANY) {
                     var stateKey = layerName + ':' + stateName;
                     if (!this.data.animationAssets[stateKey]) {
                         this.data.animationAssets[stateKey] = {

--- a/src/framework/components/anim/controller.js
+++ b/src/framework/components/anim/controller.js
@@ -376,7 +376,7 @@ Object.defineProperties(AnimState.prototype, {
     },
     playable: {
         get: function () {
-            return (this.name === ANIM_STATE_START || this.name === ANIM_STATE_END || this.animations.length === this.nodeCount);
+            return (this.name === ANIM_STATE_START || this.name === ANIM_STATE_END || this.name === ANIM_STATE_ANY || this.animations.length === this.nodeCount);
         }
     },
     looping: {
@@ -699,7 +699,7 @@ Object.assign(AnimController.prototype, {
     },
 
     _getActiveStateProgressForTime: function (time) {
-        if (this.activeStateName === ANIM_STATE_START || this.activeStateName === ANIM_STATE_END)
+        if (this.activeStateName === ANIM_STATE_START || this.activeStateName === ANIM_STATE_END || this.activeStateName === ANIM_STATE_ANY)
             return 1.0;
 
         var activeClip = this._animEvaluator.findClip(this.activeStateAnimations[0].name);


### PR DESCRIPTION
It's currently necessary to assign an animation to the ANY state in order for a state graph to become playable. The editor also currently generates an asset input slot for the ANY state which shouldn't be present.

This PR resolves both issues.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
