### PR TITLE
Status code 0 should always error out

### DIFF
--- a/src/net/http.js
+++ b/src/net/http.js
@@ -448,18 +448,6 @@ Object.assign(Http.prototype, {
     _onReadyStateChange: function (method, url, options, xhr) {
         if (xhr.readyState === 4) {
             switch (xhr.status) {
-                case 0: {
-
-                    // If this is a local resource then continue (IOS) otherwise the request
-                    // didn't complete, possibly an exception or attempt to do cross-domain request
-                    if (url[0] != '/') {
-                        this._onSuccess(method, url, options, xhr);
-                    } else {
-                        this._onError(method, url, options, xhr);
-                    }
-
-                    break;
-                }
                 case 200:
                 case 201:
                 case 206:


### PR DESCRIPTION
This is to allow for retrying loading of assets when the browser blocks the asset request

Fixes a specific issue where the browser/webview may cancel a request with the status code 0. If the app allows for retrying, then now when status code 0 is returned, the engine will call onError which will allow for retrying of assets.

The original code was added on this PR: https://github.com/playcanvas/engine/commit/b7ef2b87965e7e091bbc3cadfc0385fd1f6a4523?w=1

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
