### PR TITLE
[Fix] Layer.addMeshInstances can add duplicate

### DIFF
--- a/src/scene/layer.js
+++ b/src/scene/layer.js
@@ -410,7 +410,7 @@ Layer.prototype.addMeshInstances = function (meshInstances, skipShadowCasters) {
 
         // test for meshInstance in both arrays, as material's alpha could have changed since LayerComposition's update to avoid duplicates
         // TODO - following uses of indexOf are expensive, to add 5000 meshInstances costs about 70ms on Mac. Consider using Set.
-        if (this.opaqueMeshInstances.indexOf(m) < 0 && this.transparentMeshInstances.indexOf(m)) {
+        if (this.opaqueMeshInstances.indexOf(m) < 0 && this.transparentMeshInstances.indexOf(m) < 0) {
             arr.push(m);
         }
 

--- a/src/scene/layer.js
+++ b/src/scene/layer.js
@@ -400,6 +400,7 @@ Layer.prototype.addMeshInstances = function (meshInstances, skipShadowCasters) {
     var casters = this.shadowCasters;
     for (var i = 0; i < meshInstances.length; i++) {
         m = meshInstances[i];
+
         mat = m.material;
         if (mat.blendType === BLEND_NONE) {
             arr = this.opaqueMeshInstances;
@@ -407,8 +408,12 @@ Layer.prototype.addMeshInstances = function (meshInstances, skipShadowCasters) {
             arr = this.transparentMeshInstances;
         }
 
+        // test for meshInstance in both arrays, as material's alpha could have changed since LayerCompositions to avoid duplicates
         // TODO - following uses of indexOf are expensive, to add 5000 meshInstances costs about 70ms on Mac. Consider using Set.
-        if (arr.indexOf(m) < 0) arr.push(m);
+        if (this.opaqueMeshInstances.indexOf(m) < 0 && this.transparentMeshInstances.indexOf(m)) {
+            arr.push(m);
+        }
+
         if (!skipShadowCasters && m.castShadow && casters.indexOf(m) < 0) casters.push(m);
 
         if (!this.passThrough && sceneShaderVer >= 0 && mat._shaderVersion !== sceneShaderVer) { // clear old shader if needed
@@ -422,6 +427,33 @@ Layer.prototype.addMeshInstances = function (meshInstances, skipShadowCasters) {
     if (!this.passThrough) this._dirty = true;
 };
 
+// internal function to remove meshInstance from an array
+Layer.prototype.removeMeshInstanceFromArray = function (m, arr) {
+
+    var drawCall;
+    var spliceOffset = -1;
+    var spliceCount = 0;
+    var len = arr.length;
+    for (var j = 0; j < len; j++) {
+        drawCall = arr[j];
+        if (drawCall === m) {
+            spliceOffset = j;
+            spliceCount = 1;
+            break;
+        }
+        if (drawCall._staticSource === m) {
+            if (spliceOffset < 0) spliceOffset = j;
+            spliceCount++;
+        } else if (spliceOffset >= 0) {
+            break;
+        }
+    }
+
+    if (spliceOffset >= 0) {
+        arr.splice(spliceOffset, spliceCount);
+    }
+};
+
 /**
  * @function
  * @name pc.Layer#removeMeshInstances
@@ -431,59 +463,28 @@ Layer.prototype.addMeshInstances = function (meshInstances, skipShadowCasters) {
  */
 Layer.prototype.removeMeshInstances = function (meshInstances, skipShadowCasters) {
 
-    var i, j, m, spliceOffset, spliceCount, len, drawCall;
+    var j, m;
     var opaque = this.opaqueMeshInstances;
     var transparent = this.transparentMeshInstances;
     var casters = this.shadowCasters;
 
-    for (i = 0; i < meshInstances.length; i++) {
+    for (var i = 0; i < meshInstances.length; i++) {
         m = meshInstances[i];
 
         // remove from opaque
-        spliceOffset = -1;
-        spliceCount = 0;
-        len = opaque.length;
-        for (j = 0; j < len; j++) {
-            drawCall = opaque[j];
-            if (drawCall === m) {
-                spliceOffset = j;
-                spliceCount = 1;
-                break;
-            }
-            if (drawCall._staticSource === m) {
-                if (spliceOffset < 0) spliceOffset = j;
-                spliceCount++;
-            } else if (spliceOffset >= 0) {
-                break;
-            }
-        }
-        if (spliceOffset >= 0) opaque.splice(spliceOffset, spliceCount);
+        this.removeMeshInstanceFromArray(m, opaque);
 
         // remove from transparent
-        spliceOffset = -1;
-        spliceCount = 0;
-        len = transparent.length;
-        for (j = 0; j < len; j++) {
-            drawCall = transparent[j];
-            if (drawCall === m) {
-                spliceOffset = j;
-                spliceCount = 1;
-                break;
-            }
-            if (drawCall._staticSource === m) {
-                if (spliceOffset < 0) spliceOffset = j;
-                spliceCount++;
-            } else if (spliceOffset >= 0) {
-                break;
-            }
-        }
-        if (spliceOffset >= 0) transparent.splice(spliceOffset, spliceCount);
+        this.removeMeshInstanceFromArray(m, transparent);
 
-        // remove from shadows
-        if (skipShadowCasters) continue;
-        j = casters.indexOf(m);
-        if (j >= 0) casters.splice(j, 1);
+        // remove from casters
+        if (!skipShadowCasters) {
+            j = casters.indexOf(m);
+            if (j >= 0)
+                casters.splice(j, 1);
+        }
     }
+
     this._dirty = true;
 };
 

--- a/src/scene/layer.js
+++ b/src/scene/layer.js
@@ -408,7 +408,7 @@ Layer.prototype.addMeshInstances = function (meshInstances, skipShadowCasters) {
             arr = this.transparentMeshInstances;
         }
 
-        // test for meshInstance in both arrays, as material's alpha could have changed since LayerCompositions to avoid duplicates
+        // test for meshInstance in both arrays, as material's alpha could have changed since LayerComposition's update to avoid duplicates
         // TODO - following uses of indexOf are expensive, to add 5000 meshInstances costs about 70ms on Mac. Consider using Set.
         if (this.opaqueMeshInstances.indexOf(m) < 0 && this.transparentMeshInstances.indexOf(m)) {
             arr.push(m);


### PR DESCRIPTION
problem:
- adding meshInstance (MI) to a layer would only test an array it belongs to to see if it's already added.
- if material of the meshInstance has changed alpha state since last update (LayerComposition moving MIs between opaque and transparent arrays), this would miss MI in the other array and add duplicate MI to a Layer, causing issue down the line when it's removed, but still visible due to only single instance getting removed. And double rendering.

solution:
- check if mesh instance is in either arrays before adding it

Also did light refactor of Layer.removeMeshInstances - moved duplicate code to its own function.