### PR TITLE
Max Asset Retries

### DIFF
--- a/examples/assets/scripts/parsers/hdr-texture.js
+++ b/examples/assets/scripts/parsers/hdr-texture.js
@@ -46,8 +46,8 @@ Object.assign(Reader.prototype, {
  * @implements {pc.TextureParser}
  * @classdesc Texture parser for hdr files.
  */
-function HdrParser(registry, retryRequests) {
-    this.retryRequests = retryRequests;
+function HdrParser(registry, maxRetries) {
+    this.maxRetries = Math.max(maxRetries, 0) || 0;
 }
 
 Object.assign(HdrParser.prototype, {
@@ -55,7 +55,8 @@ Object.assign(HdrParser.prototype, {
         var options = {
             cache: true,
             responseType: "arraybuffer",
-            retry: this.retryRequests
+            retry: this.maxRetries > 0,
+            maxRetries: this.maxRetries
         };
         pc.http.get(url.load, options, callback);
     },

--- a/examples/assets/scripts/parsers/hdr-texture.js
+++ b/examples/assets/scripts/parsers/hdr-texture.js
@@ -46,8 +46,8 @@ Object.assign(Reader.prototype, {
  * @implements {pc.TextureParser}
  * @classdesc Texture parser for hdr files.
  */
-function HdrParser(registry, maxRetries) {
-    this.maxRetries = Math.max(maxRetries, 0) || 0;
+function HdrParser(registry) {
+    this.maxRetries = 0;
 }
 
 Object.assign(HdrParser.prototype, {

--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -1110,6 +1110,11 @@ Object.assign(Application.prototype, {
         var i;
         var len;
 
+        // configure retrying assets
+        if (typeof props.maxAssetRetries === 'number' && props.maxAssetRetries > 0) {
+            this.loader.enableRetry(props.maxAssetRetries);
+        }
+
         // TODO: remove this temporary block after migrating properties
         if (!props.useDevicePixelRatio)
             props.useDevicePixelRatio = props.use_device_pixel_ratio;

--- a/src/resources/anim-clip.js
+++ b/src/resources/anim-clip.js
@@ -10,7 +10,7 @@ import { AnimCurve, AnimData, AnimTrack } from '../anim/anim.js';
  * @classdesc Resource handler used for loading {@link pc.AnimClip} resources.
  */
 function AnimClipHandler() {
-    this.retryRequests = false;
+    this.maxRetries = 0;
 }
 
 Object.assign(AnimClipHandler.prototype, {
@@ -24,7 +24,8 @@ Object.assign(AnimClipHandler.prototype, {
 
         // we need to specify JSON for blob URLs
         var options = {
-            retry: this.retryRequests
+            retry: this.maxRetries > 0,
+            maxRetries: this.maxRetries
         };
 
         if (url.load.startsWith('blob:')) {

--- a/src/resources/anim-state-graph.js
+++ b/src/resources/anim-state-graph.js
@@ -10,7 +10,7 @@ import { AnimStateGraph } from '../framework/components/anim/state-graph.js';
  * @classdesc Resource handler used for loading {@link pc.AnimStateGraph} resources.
  */
 function AnimStateGraphHandler() {
-    this.retryRequests = false;
+    this.maxRetries = 0;
 }
 
 Object.assign(AnimStateGraphHandler.prototype, {
@@ -24,7 +24,8 @@ Object.assign(AnimStateGraphHandler.prototype, {
 
         // we need to specify JSON for blob URLs
         var options = {
-            retry: this.retryRequests
+            retry: this.maxRetries > 0,
+            maxRetries: this.maxRetries
         };
 
         if (url.load.startsWith('blob:')) {

--- a/src/resources/animation.js
+++ b/src/resources/animation.js
@@ -16,7 +16,7 @@ import { GlbParser } from '../resources/parser/glb-parser.js';
  * @classdesc Resource handler used for loading {@link pc.Animation} resources.
  */
 function AnimationHandler() {
-    this.retryRequests = false;
+    this.maxRetries = 0;
 }
 
 Object.assign(AnimationHandler.prototype, {
@@ -30,7 +30,8 @@ Object.assign(AnimationHandler.prototype, {
 
         // we need to specify JSON for blob URLs
         var options = {
-            retry: this.retryRequests
+            retry: this.maxRetries > 0,
+            maxRetries: this.maxRetries
         };
 
         if (url.load.startsWith('blob:')) {

--- a/src/resources/audio.js
+++ b/src/resources/audio.js
@@ -39,7 +39,7 @@ var ie = (function () {
  */
 function AudioHandler(manager) {
     this.manager = manager;
-    this.retryRequests = false;
+    this.maxRetries = 0;
 }
 
 Object.assign(AudioHandler.prototype, {
@@ -121,7 +121,8 @@ if (hasAudioContext()) {
 
         // if this is a blob URL we need to set the response type to arraybuffer
         var options = {
-            retry: this.retryRequests
+            retry: this.maxRetries > 0,
+            maxRetries: this.maxRetries
         };
 
         if (url.startsWith('blob:')) {

--- a/src/resources/binary.js
+++ b/src/resources/binary.js
@@ -1,7 +1,7 @@
 import { http, Http } from '../net/http.js';
 
 function BinaryHandler() {
-    this.retryRequests = false;
+    this.maxRetries = 0;
 }
 
 Object.assign(BinaryHandler.prototype, {
@@ -15,7 +15,8 @@ Object.assign(BinaryHandler.prototype, {
 
         http.get(url.load, {
             responseType: Http.ResponseType.ARRAY_BUFFER,
-            retry: this.retryRequests
+            retry: this.maxRetries > 0,
+            maxRetries: this.maxRetries
         }, function (err, response) {
             if (!err) {
                 callback(null, response);

--- a/src/resources/bundle.js
+++ b/src/resources/bundle.js
@@ -17,7 +17,7 @@ import { Untar, UntarWorker } from './untar.js';
 function BundleHandler(assets) {
     this._assets = assets;
     this._worker = null;
-    this.retryRequests = false;
+    this.maxRetries = 0;
 }
 
 Object.assign(BundleHandler.prototype, {
@@ -33,7 +33,8 @@ Object.assign(BundleHandler.prototype, {
 
         http.get(url.load, {
             responseType: Http.ResponseType.ARRAY_BUFFER,
-            retry: this.retryRequests
+            retry: this.maxRetries > 0,
+            maxRetries: this.maxRetries
         }, function (err, response) {
             if (! err) {
                 try {

--- a/src/resources/container.js
+++ b/src/resources/container.js
@@ -103,6 +103,7 @@ Object.assign(ContainerResource.prototype, {
 function ContainerHandler(device, defaultMaterial) {
     this._device = device;
     this._defaultMaterial = defaultMaterial;
+    this.maxRetries = 0;
 }
 
 Object.assign(ContainerHandler.prototype, {
@@ -120,7 +121,8 @@ Object.assign(ContainerHandler.prototype, {
 
         var options = {
             responseType: Http.ResponseType.ARRAY_BUFFER,
-            retry: false
+            retry: this.maxRetries > 0,
+            maxRetries: this.maxRetries
         };
 
         var self = this;

--- a/src/resources/css.js
+++ b/src/resources/css.js
@@ -1,7 +1,7 @@
 import { http } from '../net/http.js';
 
 function CssHandler() {
-    this.retryRequests = false;
+    this.maxRetries = 0;
 }
 
 Object.assign(CssHandler.prototype, {
@@ -14,7 +14,8 @@ Object.assign(CssHandler.prototype, {
         }
 
         http.get(url.load, {
-            retry: this.retryRequests
+            retry: this.maxRetries > 0,
+            maxRetries: this.maxRetries
         }, function (err, response) {
             if (!err) {
                 callback(null, response);

--- a/src/resources/font.js
+++ b/src/resources/font.js
@@ -38,7 +38,7 @@ function upgradeDataSchema(data) {
  */
 function FontHandler(loader) {
     this._loader = loader;
-    this.retryRequests = false;
+    this.maxRetries = 0;
 }
 
 Object.assign(FontHandler.prototype, {
@@ -54,7 +54,8 @@ Object.assign(FontHandler.prototype, {
         if (path.getExtension(url.original) === '.json') {
             // load json data then load texture of same name
             http.get(url.load, {
-                retry: this.retryRequests
+                retry: this.maxRetries > 0,
+                maxRetries: this.maxRetries
             }, function (err, response) {
                 // update asset data
                 if (!err) {

--- a/src/resources/hierarchy.js
+++ b/src/resources/hierarchy.js
@@ -6,7 +6,7 @@ import { TemplateUtils } from '../templates/template-utils.js';
 
 function HierarchyHandler(app) {
     this._app = app;
-    this.retryRequests = false;
+    this.maxRetries = 0;
 }
 
 Object.assign(HierarchyHandler.prototype, {
@@ -21,7 +21,8 @@ Object.assign(HierarchyHandler.prototype, {
         var assets = this._app.assets;
 
         http.get(url.load, {
-            retry: this.retryRequests
+            retry: this.maxRetries > 0,
+            maxRetries: this.maxRetries
         }, function (err, response) {
             if (!err) {
                 TemplateUtils.waitForTemplatesInScene(

--- a/src/resources/html.js
+++ b/src/resources/html.js
@@ -1,7 +1,7 @@
 import { http } from '../net/http.js';
 
 function HtmlHandler() {
-    this.retryRequests = false;
+    this.maxRetries = 0;
 }
 
 Object.assign(HtmlHandler.prototype, {
@@ -14,7 +14,8 @@ Object.assign(HtmlHandler.prototype, {
         }
 
         http.get(url.load, {
-            retry: this.retryRequests
+            retry: this.maxRetries > 0,
+            maxRetries: this.maxRetries
         }, function (err, response) {
             if (!err) {
                 callback(null, response);

--- a/src/resources/json.js
+++ b/src/resources/json.js
@@ -1,7 +1,7 @@
 import { http, Http } from '../net/http.js';
 
 function JsonHandler() {
-    this.retryRequests = false;
+    this.maxRetries = 0;
 }
 
 Object.assign(JsonHandler.prototype, {
@@ -15,7 +15,8 @@ Object.assign(JsonHandler.prototype, {
 
         // if this a blob URL we need to set the response type as json
         var options = {
-            retry: this.retryRequests
+            retry: this.maxRetries > 0,
+            maxRetries: this.maxRetries
         };
 
         if (url.load.startsWith('blob:')) {

--- a/src/resources/loader.js
+++ b/src/resources/loader.js
@@ -260,11 +260,18 @@ Object.assign(ResourceLoader.prototype, {
      * @private
      * @function
      * @name pc.ResourceLoader#enableRetry
+     * @param {Number} maxRetries - The maximum number of times to retry loading an asset. Defaults to 5.
      * @description Enables retrying of failed requests when loading assets.
      */
-    enableRetry: function () {
+    enableRetry: function (maxRetries) {
+        if (maxRetries === undefined) {
+            maxRetries = 5;
+        }
+
+        maxRetries = Math.max(0, maxRetries) || 0;
+
         for (var key in this._handlers) {
-            this._handlers[key].retryRequests = true;
+            this._handlers[key].maxRetries = maxRetries;
         }
     },
 
@@ -276,7 +283,7 @@ Object.assign(ResourceLoader.prototype, {
      */
     disableRetry: function () {
         for (var key in this._handlers) {
-            this._handlers[key].retryRequests = false;
+            this._handlers[key].maxRetries = 0;
         }
     },
 

--- a/src/resources/loader.js
+++ b/src/resources/loader.js
@@ -260,7 +260,7 @@ Object.assign(ResourceLoader.prototype, {
      * @private
      * @function
      * @name pc.ResourceLoader#enableRetry
-     * @param {Number} maxRetries - The maximum number of times to retry loading an asset. Defaults to 5.
+     * @param {number} maxRetries - The maximum number of times to retry loading an asset. Defaults to 5.
      * @description Enables retrying of failed requests when loading assets.
      */
     enableRetry: function (maxRetries) {

--- a/src/resources/material.js
+++ b/src/resources/material.js
@@ -38,7 +38,7 @@ function MaterialHandler(app) {
     this._placeholderTextures = null;
 
     this._parser = new JsonStandardMaterialParser();
-    this.retryRequests = false;
+    this.maxRetries = 0;
 }
 
 Object.assign(MaterialHandler.prototype, {
@@ -52,7 +52,8 @@ Object.assign(MaterialHandler.prototype, {
 
         // Loading from URL (engine-only)
         http.get(url.load, {
-            retry: this.retryRequests
+            retry: this.maxRetries > 0,
+            maxRetries: this.maxRetries
         }, function (err, response) {
             if (!err) {
                 if (callback) {

--- a/src/resources/model.js
+++ b/src/resources/model.js
@@ -17,7 +17,7 @@ function ModelHandler(device, defaultMaterial) {
     this._device = device;
     this._parsers = [];
     this._defaultMaterial = defaultMaterial;
-    this.retryRequests = false;
+    this.maxRetries = 0;
 
     this.addParser(new JsonModelParser(this._device), function (url, data) {
         return (path.getExtension(url) === '.json');
@@ -38,7 +38,8 @@ Object.assign(ModelHandler.prototype, {
 
         // we need to specify JSON for blob URLs
         var options = {
-            retry: this.retryRequests
+            retry: this.maxRetries > 0,
+            maxRetries: this.maxRetries
         };
 
         if (url.load.startsWith('blob:')) {

--- a/src/resources/parser/texture/basis.js
+++ b/src/resources/parser/texture/basis.js
@@ -11,8 +11,8 @@ import { basisTargetFormat, basisTranscode } from '../../basis.js';
  * @implements {pc.TextureParser}
  * @classdesc Parser for basis files.
  */
-function BasisParser(registry, retryRequests) {
-    this.retryRequests = !!retryRequests;
+function BasisParser(registry, maxRetries) {
+    this.maxRetries = Math.max(maxRetries, 0) || 0;
 }
 
 Object.assign(BasisParser.prototype, {
@@ -20,7 +20,8 @@ Object.assign(BasisParser.prototype, {
         var options = {
             cache: true,
             responseType: "arraybuffer",
-            retry: this.retryRequests
+            retry: this.maxRetries > 0,
+            maxRetries: this.maxRetries
         };
         http.get(
             url.load,

--- a/src/resources/parser/texture/basis.js
+++ b/src/resources/parser/texture/basis.js
@@ -11,8 +11,8 @@ import { basisTargetFormat, basisTranscode } from '../../basis.js';
  * @implements {pc.TextureParser}
  * @classdesc Parser for basis files.
  */
-function BasisParser(registry, maxRetries) {
-    this.maxRetries = Math.max(maxRetries, 0) || 0;
+function BasisParser(registry) {
+    this.maxRetries = 0;
 }
 
 Object.assign(BasisParser.prototype, {

--- a/src/resources/parser/texture/dds.js
+++ b/src/resources/parser/texture/dds.js
@@ -87,8 +87,8 @@ fccToFormat[FCC_PVRTC_4BPP_RGBA_1] = PIXELFORMAT_PVRTC_4BPP_RGBA_1;
  * @implements {pc.TextureParser}
  * @classdesc Texture parser for dds files.
  */
-function DdsParser(registry, maxRetries) {
-    this.maxRetries = Math.max(maxRetries, 0) || 0;
+function DdsParser(registry) {
+    this.maxRetries = 0;
 }
 
 Object.assign(DdsParser.prototype, {

--- a/src/resources/parser/texture/dds.js
+++ b/src/resources/parser/texture/dds.js
@@ -87,8 +87,8 @@ fccToFormat[FCC_PVRTC_4BPP_RGBA_1] = PIXELFORMAT_PVRTC_4BPP_RGBA_1;
  * @implements {pc.TextureParser}
  * @classdesc Texture parser for dds files.
  */
-function DdsParser(registry, retryRequests) {
-    this.retryRequests = !!retryRequests;
+function DdsParser(registry, maxRetries) {
+    this.maxRetries = Math.max(maxRetries, 0) || 0;
 }
 
 Object.assign(DdsParser.prototype, {
@@ -97,7 +97,8 @@ Object.assign(DdsParser.prototype, {
         var options = {
             cache: true,
             responseType: "arraybuffer",
-            retry: this.retryRequests
+            retry: this.maxRetries > 0,
+            maxRetries: this.maxRetries
         };
         http.get(url.load, options, callback);
     },

--- a/src/resources/parser/texture/img.js
+++ b/src/resources/parser/texture/img.js
@@ -12,10 +12,10 @@ import { ABSOLUTE_URL } from '../../../asset/constants.js';
  * @implements {pc.TextureParser}
  * @classdesc Parser for browser-supported image formats.
  */
-function ImgParser(registry, maxRetries) {
+function ImgParser(registry) {
     // by default don't try cross-origin, because some browsers send different cookies (e.g. safari) if this is set.
     this.crossOrigin = registry.prefix ? 'anonymous' : null;
-    this.maxRetries = Math.max(maxRetries, 0) || 0;
+    this.maxRetries = 0;
     // disable ImageBitmap
     this.useImageBitmap = false && typeof ImageBitmap !== 'undefined' && /Firefox/.test( navigator.userAgent ) === false;
 }

--- a/src/resources/parser/texture/img.js
+++ b/src/resources/parser/texture/img.js
@@ -12,10 +12,10 @@ import { ABSOLUTE_URL } from '../../../asset/constants.js';
  * @implements {pc.TextureParser}
  * @classdesc Parser for browser-supported image formats.
  */
-function ImgParser(registry, retryRequests) {
+function ImgParser(registry, maxRetries) {
     // by default don't try cross-origin, because some browsers send different cookies (e.g. safari) if this is set.
     this.crossOrigin = registry.prefix ? 'anonymous' : null;
-    this.retryRequests = !!retryRequests;
+    this.maxRetries = Math.max(maxRetries, 0) || 0;
     // disable ImageBitmap
     this.useImageBitmap = false && typeof ImageBitmap !== 'undefined' && /Firefox/.test( navigator.userAgent ) === false;
 }
@@ -58,9 +58,8 @@ Object.assign(ImgParser.prototype, {
         }
 
         var retries = 0;
-        var maxRetries = 5;
+        var maxRetries = this.maxRetries;
         var retryTimeout;
-        var retryRequests = this.retryRequests;
 
         // Call success callback after opening Texture
         image.onload = function () {
@@ -71,7 +70,7 @@ Object.assign(ImgParser.prototype, {
             // Retry a few times before failing
             if (retryTimeout) return;
 
-            if (retryRequests && ++retries <= maxRetries) {
+            if (maxRetries > 0 && ++retries <= maxRetries) {
                 var retryDelay = Math.pow(2, retries) * 100;
                 console.log("Error loading Texture from: '" + originalUrl + "' - Retrying in " + retryDelay + "ms...");
 
@@ -97,7 +96,8 @@ Object.assign(ImgParser.prototype, {
         var options = {
             cache: true,
             responseType: "blob",
-            retry: this.retryRequests
+            retry: this.maxRetries > 0,
+            maxRetries: this.maxRetries
         };
         http.get(url, options, function (err, blob) {
             if (err) {

--- a/src/resources/parser/texture/ktx.js
+++ b/src/resources/parser/texture/ktx.js
@@ -30,8 +30,8 @@ var KNOWN_FORMATS = {
  * @implements {pc.TextureParser}
  * @classdesc Texture parser for ktx files.
  */
-function KtxParser(registry, retryRequests) {
-    this.retryRequests = !!retryRequests;
+function KtxParser(registry, maxRetries) {
+    this.maxRetries = Math.max(maxRetries, 0) || 0;
 }
 
 Object.assign(KtxParser.prototype, {
@@ -40,7 +40,8 @@ Object.assign(KtxParser.prototype, {
         var options = {
             cache: true,
             responseType: "arraybuffer",
-            retry: this.retryRequests
+            retry: this.maxRetries > 0,
+            maxRetries: this.maxRetries
         };
         http.get(url.load, options, callback);
     },

--- a/src/resources/parser/texture/ktx.js
+++ b/src/resources/parser/texture/ktx.js
@@ -30,8 +30,8 @@ var KNOWN_FORMATS = {
  * @implements {pc.TextureParser}
  * @classdesc Texture parser for ktx files.
  */
-function KtxParser(registry, maxRetries) {
-    this.maxRetries = Math.max(maxRetries, 0) || 0;
+function KtxParser(registry) {
+    this.maxRetries = 0;
 }
 
 Object.assign(KtxParser.prototype, {

--- a/src/resources/parser/texture/legacy-dds.js
+++ b/src/resources/parser/texture/legacy-dds.js
@@ -17,8 +17,8 @@ import { Texture } from '../../../graphics/texture.js';
  * @implements {pc.TextureParser}
  * @classdesc Legacy texture parser for dds files.
  */
-function LegacyDdsParser(registry, retryRequests) {
-    this.retryRequests = !!retryRequests;
+function LegacyDdsParser(registry, maxRetries) {
+    this.maxRetries = Math.max(maxRetries, 0) || 0;
 }
 
 Object.assign(LegacyDdsParser.prototype, {
@@ -26,7 +26,8 @@ Object.assign(LegacyDdsParser.prototype, {
         var options = {
             cache: true,
             responseType: "arraybuffer",
-            retry: this.retryRequests
+            retry: this.maxRetries > 0,
+            maxRetries: this.maxRetries
         };
         http.get(url.load, options, callback);
     },

--- a/src/resources/parser/texture/legacy-dds.js
+++ b/src/resources/parser/texture/legacy-dds.js
@@ -17,8 +17,8 @@ import { Texture } from '../../../graphics/texture.js';
  * @implements {pc.TextureParser}
  * @classdesc Legacy texture parser for dds files.
  */
-function LegacyDdsParser(registry, maxRetries) {
-    this.maxRetries = Math.max(maxRetries, 0) || 0;
+function LegacyDdsParser(registry) {
+    this.maxRetries = 0;
 }
 
 Object.assign(LegacyDdsParser.prototype, {

--- a/src/resources/scene-settings.js
+++ b/src/resources/scene-settings.js
@@ -2,7 +2,7 @@ import { http } from '../net/http.js';
 
 function SceneSettingsHandler(app) {
     this._app = app;
-    this.retryRequests = false;
+    this.maxRetries = 0;
 }
 
 Object.assign(SceneSettingsHandler.prototype, {
@@ -15,7 +15,8 @@ Object.assign(SceneSettingsHandler.prototype, {
         }
 
         http.get(url.load, {
-            retry: this.retryRequests
+            retry: this.maxRetries > 0,
+            maxRetries: this.maxRetries
         }, function (err, response) {
             if (!err) {
                 callback(null, response);

--- a/src/resources/scene.js
+++ b/src/resources/scene.js
@@ -13,7 +13,7 @@ import { TemplateUtils } from '../templates/template-utils.js';
  */
 function SceneHandler(app) {
     this._app = app;
-    this.retryRequests = false;
+    this.maxRetries = 0;
 }
 
 Object.assign(SceneHandler.prototype, {
@@ -28,7 +28,8 @@ Object.assign(SceneHandler.prototype, {
         var assets = this._app.assets;
 
         http.get(url.load, {
-            retry: this.retryRequests
+            retry: this.maxRetries > 0,
+            maxRetries: this.maxRetries
         }, function (err, response) {
             if (!err) {
                 TemplateUtils.waitForTemplatesInScene(

--- a/src/resources/shader.js
+++ b/src/resources/shader.js
@@ -1,7 +1,7 @@
 import { http } from '../net/http.js';
 
 function ShaderHandler() {
-    this.retryRequests = false;
+    this.maxRetries = 0;
 }
 
 Object.assign(ShaderHandler.prototype, {
@@ -14,7 +14,8 @@ Object.assign(ShaderHandler.prototype, {
         }
 
         http.get(url.load, {
-            retry: this.retryRequests
+            retry: this.maxRetries > 0,
+            maxRetries: this.maxRetries
         }, function (err, response) {
             if (!err) {
                 callback(null, response);

--- a/src/resources/sprite.js
+++ b/src/resources/sprite.js
@@ -15,7 +15,7 @@ import { Sprite } from '../scene/sprite.js';
 function SpriteHandler(assets, device) {
     this._assets = assets;
     this._device = device;
-    this.retryRequests = false;
+    this.maxRetries = 0;
 }
 
 // The scope of this function is the sprite asset
@@ -44,7 +44,8 @@ Object.assign(SpriteHandler.prototype, {
         // if given a json file (probably engine-only use case)
         if (path.getExtension(url.original) === '.json') {
             http.get(url.load, {
-                retry: this.retryRequests
+                retry: this.maxRetries > 0,
+                maxRetries: this.maxRetries
             }, function (err, response) {
                 if (!err) {
                     callback(null, response);

--- a/src/resources/text.js
+++ b/src/resources/text.js
@@ -1,7 +1,7 @@
 import { http } from '../net/http.js';
 
 function TextHandler() {
-    this.retryRequests = false;
+    this.maxRetries = 0;
 }
 
 Object.assign(TextHandler.prototype, {
@@ -14,7 +14,8 @@ Object.assign(TextHandler.prototype, {
         }
 
         http.get(url.load, {
-            retry: this.retryRequests
+            retry: this.maxRetries > 0,
+            maxRetries: this.maxRetries
         }, function (err, response) {
             if (!err) {
                 callback(null, response);

--- a/src/resources/texture-atlas.js
+++ b/src/resources/texture-atlas.js
@@ -39,7 +39,7 @@ var regexFrame = /^data\.frames\.(\d+)$/;
  */
 function TextureAtlasHandler(loader) {
     this._loader = loader;
-    this.retryRequests = false;
+    this.maxRetries = 0;
 }
 
 Object.assign(TextureAtlasHandler.prototype, {
@@ -59,7 +59,8 @@ Object.assign(TextureAtlasHandler.prototype, {
         // load json data then load texture of same name
         if (path.getExtension(url.original) === '.json') {
             http.get(url.load, {
-                retry: this.retryRequests
+                retry: this.maxRetries > 0,
+                maxRetries: this.maxRetries
             }, function (err, response) {
                 if (!err) {
                     // load texture

--- a/src/resources/texture.js
+++ b/src/resources/texture.js
@@ -164,12 +164,12 @@ function TextureHandler(device, assets, loader) {
 
     // img parser handles all broswer-supported image formats, this
     // parser will be used when other more specific parsers are not found.
-    this.imgParser = new ImgParser(assets, false);
+    this.imgParser = new ImgParser(assets, 0);
 
     this.parsers = {
-        dds: new LegacyDdsParser(assets, false),
-        ktx: new KtxParser(assets, false),
-        basis: new BasisParser(assets, false)
+        dds: new LegacyDdsParser(assets, 0),
+        ktx: new KtxParser(assets, 0),
+        basis: new BasisParser(assets, 0)
     };
 }
 
@@ -183,15 +183,15 @@ Object.defineProperties(TextureHandler.prototype, {
         }
     },
 
-    retryRequests: {
+    maxRetries: {
         get: function () {
-            return this.imgParser.retryRequests;
+            return this.imgParser.maxRetries;
         },
         set: function (value) {
-            this.imgParser.retryRequests = value;
+            this.imgParser.maxRetries = value;
             for (var parser in this.parsers) {
                 if (this.parsers.hasOwnProperty(parser)) {
-                    this.parsers[parser].retryRequests = value;
+                    this.parsers[parser].maxRetries = value;
                 }
             }
         }

--- a/src/resources/texture.js
+++ b/src/resources/texture.js
@@ -164,12 +164,12 @@ function TextureHandler(device, assets, loader) {
 
     // img parser handles all broswer-supported image formats, this
     // parser will be used when other more specific parsers are not found.
-    this.imgParser = new ImgParser(assets, 0);
+    this.imgParser = new ImgParser(assets);
 
     this.parsers = {
-        dds: new LegacyDdsParser(assets, 0),
-        ktx: new KtxParser(assets, 0),
-        basis: new BasisParser(assets, 0)
+        dds: new LegacyDdsParser(assets),
+        ktx: new KtxParser(assets),
+        basis: new BasisParser(assets)
     };
 }
 


### PR DESCRIPTION
This PR changes the following:

* Change pc.ResourceLoader#enableRetry to take the maximum number of retries as an argument. 
* Change the retryRequests flags in the resource handlers with a maxRetries number. 
* Added maxAssetRetries project setting.
