### PR TITLE
Directional lightmap fix

### DIFF
--- a/src/graphics/program-lib/chunks/lightmapDir.frag
+++ b/src/graphics/program-lib/chunks/lightmapDir.frag
@@ -14,6 +14,7 @@ void addLightMap() {
         float nlight = (flight / max(vlight, 0.01)) * 0.5;
 
         dDiffuseLight += color * nlight * 2.0;
-        dSpecularLight += color * getLightSpecular();
     }
+
+    dSpecularLight += color * getLightSpecular();
 }

--- a/src/graphics/program-lib/chunks/lightmapDir.frag
+++ b/src/graphics/program-lib/chunks/lightmapDir.frag
@@ -2,29 +2,18 @@ uniform sampler2D texture_lightMap;
 uniform sampler2D texture_dirLightMap;
 
 void addLightMap() {
-
     vec3 color = $texture2DSAMPLE(texture_lightMap, $UV).$CH;
-    vec4 dir = texture2D(texture_dirLightMap, $UV);
-
-    if (dot(dir.xyz,vec3(1.0)) < 0.00001) {
+    vec3 dir = texture2D(texture_dirLightMap, $UV).xyz;
+    if (dot(dir, vec3(1.0)) < 0.00001) {
         dDiffuseLight += color;
-        return;
+    } else {
+        dLightDirNormW = normalize(dir * 2.0 - vec3(1.0));
+
+        float vlight = saturate(dot(dLightDirNormW, -dVertexNormalW));
+        float flight = saturate(dot(dLightDirNormW, -dNormalW));
+        float nlight = (flight / max(vlight, 0.01)) * 0.5;
+
+        dDiffuseLight += color * nlight * 2.0;
+        dSpecularLight += color * getLightSpecular();
     }
-
-    dLightDirNormW = normalize(dir.xyz * 2.0 - vec3(1.0));
-
-    float vlight = saturate(dot(dLightDirNormW, -dVertexNormalW));
-    float flight = saturate(dot(dLightDirNormW, -dNormalW));
-    float nlight = (flight / max(vlight,0.01)) * 0.5;
-
-    dDiffuseLight += color * nlight * 2.0;
-}
-
-void addDirLightMap() {
-    vec4 dir = texture2D(texture_dirLightMap, $UV);
-    if (dot(dir.xyz,vec3(1.0)) < 0.00001) return;
-    vec3 color = $texture2DSAMPLE(texture_lightMap, $UV).$CH;
-
-    dLightDirNormW = normalize(dir.xyz * 2.0 - vec3(1.0));
-    dSpecularLight += vec3(getLightSpecular()) * color;
 }

--- a/src/graphics/program-lib/programs/standard.js
+++ b/src/graphics/program-lib/programs/standard.js
@@ -1454,10 +1454,6 @@ var standard = {
                 code += "   addReflection();\n";
             }
 
-            if (options.dirLightMap) {
-                code += "   addDirLightMap();\n";
-            }
-
             for (i = 0; i < options.lights.length; i++) {
                 // The following code is not decoupled to separate shader files, because most of it can be actually changed to achieve different behaviors like:
                 // - different falloffs


### PR DESCRIPTION
Fixes #2545

The issue was lack of specular for metal objects:
![change](https://user-images.githubusercontent.com/11276292/101025300-4c22f980-356d-11eb-8bfa-0b4906e6507d.png)

Also simplified the shader chunk by sampling textures twice.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
