### PR TITLE
Fixes using the local file system in special browser mode

### DIFF
--- a/src/net/http.js
+++ b/src/net/http.js
@@ -448,6 +448,20 @@ Object.assign(Http.prototype, {
     _onReadyStateChange: function (method, url, options, xhr) {
         if (xhr.readyState === 4) {
             switch (xhr.status) {
+                case 0: {
+                    // If status code 0, it is assumed that the browser has cancelled the request
+
+                    // Add support for running Chrome browsers in 'allow-file-access-from-file'
+                    // This is to allow for specialised programs and libraries such as CefSharp
+                    // which embed Chromium in the native app.
+                    if (xhr.responseURL && xhr.responseURL.startsWith('file:///')) {
+                        // Assume that any file loaded from disk is fine
+                        this._onSuccess(method, url, options, xhr);
+                    } else {
+                        this._onError(method, url, options, xhr);
+                    }
+                    break;
+                }
                 case 200:
                 case 201:
                 case 206:


### PR DESCRIPTION
Solves the issue where the browser returns status code 0 on XHR requests file requests when the browser is using '--allow-file-access-from-file' flag.

See https://cmatskas.com/interacting-with-local-data-files-using-chrome/

This is needed in special cases such as using CefSharp which embeds a Chromium browser into a C# app under special settings

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
