### PR TITLE
WebXR DOM Overlay

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -272,6 +272,7 @@ export { XrLightEstimation } from './xr/xr-light-estimation.js';
 export { XrManager } from './xr/xr-manager.js';
 export { XrHitTest } from './xr/xr-hit-test.js';
 export { XrHitTestSource } from './xr/xr-hit-test-source.js';
+export { XrDomOverlay } from './xr/xr-dom-overlay.js';
 
 // BACKWARDS COMPATIBILITY
 export * from './deprecated.js';

--- a/src/xr/xr-dom-overlay.js
+++ b/src/xr/xr-dom-overlay.js
@@ -1,0 +1,71 @@
+/**
+ * @class
+ * @name pc.XrDomOverlay
+ * @classdesc DOM Overlay provides ability to use DOM elements as overlay in WebXR AR session. It requires that root DOM element is provided for session start. That way input source select events, first are tested against DOM Elements first, and then propagated down to XR Session. If this propagation is not desirable, use `beforexrselect` event on DOM element, and `preventDefault` function to stop propagation.
+ * @description DOM Overlay provides ability to use DOM elements as overlay in WebXR AR session. It requires that root DOM element is provided for session start. That way input source select events, first are tested against DOM Elements first, and then propagated down to XR Session. If this propagation is not desirable, use `beforexrselect` event on DOM element, and `preventDefault` function to stop propagation.
+ * @param {pc.XrManager} manager - WebXR Manager.
+ * @property {boolean} supported True if DOM Overlay is supported.
+ * @property {boolean} available True if DOM Overlay is available. It can only be available if it is supported, during valid WebXR session and if valid root element is provided.
+ * @property {string|null} state State of the DOM Overlay, which defines how root DOM element is rendered. Possible options:
+ *
+ * * screen: Screen - this type indicates that DOM element is covering whole physical screen, mathcing XR viewports.
+ * * floating: Floating - indicates that underlying platform renders DOM element as floating in space, which can move during WebXR session or allow developer to move element.
+ * * head-locked: Head Locked - indicates that DOM element follows the user’s head movement consistently, appearing similar to a helmet heads-up display.
+ *
+ * @example
+ * app.xr.domOverlay.root = element;
+ * app.xr.start(camera, pc.XRTYPE_AR, pc.XRSPACE_LOCALFLOOR);
+ * @example
+ * // disable input source firing `select` event when some descendant element of DOM overlay root is touched/clicked. This is usefull when user interacts with UI elements, and there should not be `select` events behind UI.
+ * someElement.addEventListener('beforexrselect', function (evt) {
+ *     evt.preventDefault();
+ * });
+ */
+function XrDomOverlay(manager) {
+    this._manager = manager;
+    this._supported = !! window.XRDOMOverlayState;
+    this._root = null;
+}
+
+Object.defineProperty(XrDomOverlay.prototype, 'supported', {
+    get: function () {
+        return this._supported;
+    }
+});
+
+Object.defineProperty(XrDomOverlay.prototype, 'available', {
+    get: function () {
+        return this._supported && this._manager.active && this._manager._session.domOverlayState !== null;
+    }
+});
+
+Object.defineProperty(XrDomOverlay.prototype, 'state', {
+    get: function () {
+        if (! this._supported || ! this._manager.active || ! this._manager._session.domOverlayState)
+            return null;
+
+        return this._manager._session.domOverlayState.type;
+    }
+});
+
+/**
+ * @name pc.XrDomOverlay#root
+ * @type {object|null}
+ * @description DOM element to be used as root for DOM Overlay. Can be changed only outside of active WebXR session.
+ * @example
+ * app.xr.domOverlay.root = element;
+ * app.xr.start(camera, pc.XRTYPE_AR, pc.XRSPACE_LOCALFLOOR);
+ */
+Object.defineProperty(XrDomOverlay.prototype, 'root', {
+    set: function (value) {
+        if (! this._supported || this._manager.active)
+            return;
+
+        this._root = value;
+    },
+    get: function () {
+        return this._root;
+    }
+});
+
+export { XrDomOverlay };

--- a/src/xr/xr-dom-overlay.js
+++ b/src/xr/xr-dom-overlay.js
@@ -1,22 +1,23 @@
 /**
  * @class
  * @name pc.XrDomOverlay
- * @classdesc DOM Overlay provides ability to use DOM elements as overlay in WebXR AR session. It requires that root DOM element is provided for session start. That way input source select events, first are tested against DOM Elements first, and then propagated down to XR Session. If this propagation is not desirable, use `beforexrselect` event on DOM element, and `preventDefault` function to stop propagation.
- * @description DOM Overlay provides ability to use DOM elements as overlay in WebXR AR session. It requires that root DOM element is provided for session start. That way input source select events, first are tested against DOM Elements first, and then propagated down to XR Session. If this propagation is not desirable, use `beforexrselect` event on DOM element, and `preventDefault` function to stop propagation.
+ * @classdesc DOM Overlay provides the ability to use DOM elements as an overlay in a WebXR AR session. It requires that the root DOM element is provided for session start. That way, input source select events are first tested against DOM Elements and then propagated down to the XR Session. If this propagation is not desirable, use the `beforexrselect` event on a DOM element and the `preventDefault` function to stop propagation.
+ * @description DOM Overlay provides the ability to use DOM elements as an overlay in a WebXR AR session. It requires that the root DOM element is provided for session start. That way, input source select events are first tested against DOM Elements and then propagated down to the XR Session. If this propagation is not desirable, use the `beforexrselect` event on a DOM element and the `preventDefault` function to stop propagation.
  * @param {pc.XrManager} manager - WebXR Manager.
  * @property {boolean} supported True if DOM Overlay is supported.
- * @property {boolean} available True if DOM Overlay is available. It can only be available if it is supported, during valid WebXR session and if valid root element is provided.
- * @property {string|null} state State of the DOM Overlay, which defines how root DOM element is rendered. Possible options:
+ * @property {boolean} available True if DOM Overlay is available. It can only be available if it is supported, during a valid WebXR session and if a valid root element is provided.
+ * @property {string|null} state State of the DOM Overlay, which defines how the root DOM element is rendered. Possible options:
  *
- * * screen: Screen - this type indicates that DOM element is covering whole physical screen, mathcing XR viewports.
- * * floating: Floating - indicates that underlying platform renders DOM element as floating in space, which can move during WebXR session or allow developer to move element.
- * * head-locked: Head Locked - indicates that DOM element follows the user’s head movement consistently, appearing similar to a helmet heads-up display.
+ * * screen: Screen - indicates that the DOM element is covering whole physical screen, matching XR viewports.
+ * * floating: Floating - indicates that the underlying platform renders the DOM element as floating in space, which can move during the WebXR session or allow the application to move the element.
+ * * head-locked: Head Locked - indicates that the DOM element follows the user's head movement consistently, appearing similar to a helmet heads-up display.
  *
  * @example
  * app.xr.domOverlay.root = element;
  * app.xr.start(camera, pc.XRTYPE_AR, pc.XRSPACE_LOCALFLOOR);
  * @example
- * // disable input source firing `select` event when some descendant element of DOM overlay root is touched/clicked. This is usefull when user interacts with UI elements, and there should not be `select` events behind UI.
+ * // Disable input source firing `select` event when some descendant element of DOM overlay root is touched/clicked.
+ * // This is useful when the user interacts with UI elements and there should not be `select` events behind UI.
  * someElement.addEventListener('beforexrselect', function (evt) {
  *     evt.preventDefault();
  * });
@@ -51,7 +52,7 @@ Object.defineProperty(XrDomOverlay.prototype, 'state', {
 /**
  * @name pc.XrDomOverlay#root
  * @type {object|null}
- * @description DOM element to be used as root for DOM Overlay. Can be changed only outside of active WebXR session.
+ * @description The DOM element to be used as the root for DOM Overlay. Can be changed only outside of an active WebXR session.
  * @example
  * app.xr.domOverlay.root = element;
  * app.xr.start(camera, pc.XRTYPE_AR, pc.XRSPACE_LOCALFLOOR);


### PR DESCRIPTION
Implements [WebXR DOM Overlays Module](https://immersive-web.github.io/dom-overlays/#dictdef-xrdomoverlaystate) Specs. It allows using regular DOM elements in AR session.

This API is already available today in release Chrome on Android, and no flags/origin trials are required for it.

### New APIs:
```js
// pc.XrManager
app.xr.domOverlay // interface to access dom overlay

// pc.XrDomOverlay
domOverlay.supported // true if dom overlay is supported
domOverlay.available // true if dom overlay is currently available, this is only possible if supported, during active AR session and if root were provided before the session start
domOverlay.state // string of DOM overlay state, which indicates how the root element is rendered by the browser, possible options are: screen, floating, head-tracked
domOverlay.root // DOM element to be used as the root for overlay
```

### Example:
```js
this.app.xr.domOverlay.root = element;
this.app.xr.start(camera, pc.XRTYPE_AR, pc.XRSPACE_LOCALFLOOR);
```

To prevent Input Sources firing `select` events behind DOM elements, a new event is available:
```js
someElement.addEventListener('beforexrselect', function (evt) {
    evt.preventDefault();
});
```

**Test project:** https://playcanvas.com/project/747233/overview/webxr-ar-dom-overlay
**Test Demo:** https://playcanv.as/p/S01LYTIU/

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
