### PR TITLE
Fixed bug where new sound instances aren't kept

### DIFF
--- a/src/framework/components/sound/component.js
+++ b/src/framework/components/sound/component.js
@@ -120,19 +120,17 @@ Object.defineProperty(SoundComponent.prototype, "positional", {
             var slot = slots[key];
             // recreate non overlapping sounds
             if (!slot.overlap) {
-                var oldInstances = slot.instances;
-                var newInstances = [];
+                var instances = slot.instances;
+                var oldLength = instances.length;
 
                 // When the instance is stopped, it gets removed from the slot.instances array
                 // so we are going backwards to compenstate for that
 
-                // We are also going to create a new array to hold the new instances created
-                // and assign to slot at the end
-                for (var i = oldInstances.length - 1; i >= 0; i--) {
-                    var isPlaying = oldInstances[i].isPlaying || oldInstances[i].isSuspended;
-                    var currentTime = oldInstances[i].currentTime;
+                for (var i = oldLength - 1; i >= 0; i--) {
+                    var isPlaying = instances[i].isPlaying || instances[i].isSuspended;
+                    var currentTime = instances[i].currentTime;
                     if (isPlaying)
-                        oldInstances[i].stop();
+                        instances[i].stop();
 
                     var instance = slot._createInstance();
                     if (isPlaying) {
@@ -140,10 +138,8 @@ Object.defineProperty(SoundComponent.prototype, "positional", {
                         instance.currentTime = currentTime;
                     }
 
-                    newInstances.push(instance);
+                    instances.push(instance);
                 }
-
-                slot.instances = newInstances;
             }
         }
     }

--- a/src/framework/components/sound/component.js
+++ b/src/framework/components/sound/component.js
@@ -120,19 +120,30 @@ Object.defineProperty(SoundComponent.prototype, "positional", {
             var slot = slots[key];
             // recreate non overlapping sounds
             if (!slot.overlap) {
-                var instances = slot.instances;
-                for (var i = 0, len = instances.length; i < len; i++) {
-                    var isPlaying = instances[i].isPlaying || instances[i].isSuspended;
-                    var currentTime = instances[i].currentTime;
-                    if (isPlaying)
-                        instances[i].stop();
+                var oldInstances = slot.instances;
+                var newInstances = [];
 
-                    instances[i] = slot._createInstance();
+                // When the instance is stopped, it gets removed from the slot.instances array
+                // so we are going backwards to compenstate for that
+
+                // We are also going to create a new array to hold the new instances created
+                // and assign to slot at the end
+                for (var i = oldInstances.length - 1; i >= 0; i--) {
+                    var isPlaying = oldInstances[i].isPlaying || oldInstances[i].isSuspended;
+                    var currentTime = oldInstances[i].currentTime;
+                    if (isPlaying)
+                        oldInstances[i].stop();
+
+                    var instance = slot._createInstance();
                     if (isPlaying) {
-                        instances[i].play();
-                        instances[i].currentTime = currentTime;
+                        instance.play();
+                        instance.currentTime = currentTime;
                     }
+
+                    newInstances.push(instance);
                 }
+
+                slot.instances = newInstances;
             }
         }
     }


### PR DESCRIPTION
When `sound.positional` is set by the developer, the new instances created are no longer kept in slot.instances. This means that the sound is audible but the slot.isPlaying property is false because it has no instances and the developer can no longer stop the sound.

Reproduced in: https://playcanvas.com/project/747427/overview/sound-positional-issues

Open up dev console in the browser

Press 1 to play the sound, 4 to toggle positional property.

Notice that isPlaying is false in the console (press 3) and that pressing 2 to stop the sound doesn't stop the sound.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
