### PR TITLE
Fixed assets.find to match APIs and return null if asset is not found

### DIFF
--- a/src/asset/asset-registry.js
+++ b/src/asset/asset-registry.js
@@ -667,7 +667,7 @@ Object.assign(AssetRegistry.prototype, {
      * var asset = app.assets.find("myTextureAsset", "texture");
      */
     find: function (name, type) {
-        // findAll returns an empty array the asset cannot be found so asset is
+        // findAll returns an empty array the if the asset cannot be found so `asset` is
         // never null/undefined
         var asset = this.findAll(name, type);
         return asset.length > 0 ? asset[0] : null;

--- a/src/asset/asset-registry.js
+++ b/src/asset/asset-registry.js
@@ -667,8 +667,10 @@ Object.assign(AssetRegistry.prototype, {
      * var asset = app.assets.find("myTextureAsset", "texture");
      */
     find: function (name, type) {
+        // findAll returns an empty array the asset cannot be found so asset is
+        // never null/undefined
         var asset = this.findAll(name, type);
-        return asset ? asset[0] : null;
+        return asset.length > 0 ? asset[0] : null;
     }
 });
 

--- a/tests/assets/test_asset_registry.js
+++ b/tests/assets/test_asset_registry.js
@@ -139,7 +139,7 @@ describe('pc.AssetRegistry', () => {
 
         this.assets.remove(asset1);
 
-        expect(this.assets.find(asset1.name)).to.equal(undefined);
+        expect(this.assets.find(asset1.name)).to.equal(null);
         expect(this.assets.find(asset2.name)).to.equal(asset2);
         expect(this.assets.find(asset3.name)).to.equal(asset3);
     });


### PR DESCRIPTION
The docs say that assets.find should return null if the asset is not found and the original code implies that null should be returned.

This is a potentially breaking change. I don't think undefined should be a valid return type in general but very wary about merging this as developers could be relying on the current behaviour of returning undefined

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
