### PR TITLE
[AnimComponent] Fix for zero or null duration transitions 

### DIFF
--- a/src/framework/components/anim/controller.js
+++ b/src/framework/components/anim/controller.js
@@ -876,13 +876,10 @@ Object.assign(AnimController.prototype, {
             }
         }
 
-        // start a new transition based on the current transitions information
-        if (transition.time > 0) {
-            this._isTransitioning = true;
-            this._totalTransitionTime = transition.time;
-            this._currTransitionTime = 0;
-            this._transitionInterruptionSource = transition.interruptionSource;
-        }
+        this._isTransitioning = true;
+        this._totalTransitionTime = transition.time;
+        this._currTransitionTime = 0;
+        this._transitionInterruptionSource = transition.interruptionSource;
 
         var hasTransitionOffset = transition.transitionOffset && transition.transitionOffset > 0.0 && transition.transitionOffset < 1.0;
         var activeState = this.activeState;


### PR DESCRIPTION
Fixes #2605 

Transitions that have a duration of 0 or null should behave the same as all other transitions. There is no longer a need to differentiate them in _updateStateFromTransition function.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
