### PR TITLE
[AnimComponent] Ensure parameters are copied when loading a state graph

### DIFF
--- a/src/framework/components/anim/component.js
+++ b/src/framework/components/anim/component.js
@@ -40,9 +40,18 @@ Object.assign(AnimComponent.prototype, {
      * @param {object} stateGraph - The state graph asset to load into the component. Contains the states, transitions and parameters used to define a complete animation controller.
      */
     loadStateGraph: function (stateGraph) {
+        var i;
         var data = this.data;
         data.stateGraph = stateGraph;
-        data.parameters = stateGraph.parameters;
+        data.parameters = {};
+        var paramKeys = Object.keys(stateGraph.parameters);
+        for (i = 0; i < paramKeys.length; i++) {
+            var paramKey = paramKeys[i];
+            data.parameters[paramKey] = {
+                type: stateGraph.parameters[paramKey].type,
+                value: stateGraph.parameters[paramKey].value
+            };
+        }
         data.layers = [];
 
         var graph;
@@ -70,7 +79,7 @@ Object.assign(AnimComponent.prototype, {
             data.layerIndices[name] = order;
         }
 
-        for (var i = 0; i < stateGraph.layers.length; i++) {
+        for (i = 0; i < stateGraph.layers.length; i++) {
             var layer = stateGraph.layers[i];
             addLayer.bind(this)(layer.name, layer.states, layer.transitions, i);
         }


### PR DESCRIPTION
Fixes #2606 

Anim components which used the same state graph were sharing the same parameter values. This PR addresses this.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
