### PR TITLE
WebXR input source squeeze

### DIFF
--- a/src/xr/xr-hand.js
+++ b/src/xr/xr-hand.js
@@ -147,27 +147,51 @@ XrHand.prototype.update = function (frame) {
         this._inputSource._rayLocal.direction.lerp(vecC, vecA, 0.5).normalize();
     }
 
-    // emulate select events by touching thumb tip and index tips
-    if (j4 && j9) {
-        vecA.copy(j4._localPosition);
-        var d = vecA.distance(j9._localPosition);
+    // emulate squeeze events by folding all 4 fingers
+    var squeezing = false;
+    var squeezeTolerance = -0.8;
 
-        if (d < 0.015) { // 15 mm
-            if (! this._inputSource._selecting) {
-                this._inputSource._selecting = true;
-                this._inputSource.fire('selectstart');
-                this._manager.input.fire('selectstart', this._inputSource);
+    // first finger
+    vecA.sub2(this._fingers[1].joints[0]._localPosition, this._fingers[1].joints[1]._localPosition).normalize();
+    vecB.sub2(this._fingers[1].joints[2]._localPosition, this._fingers[1].joints[3]._localPosition).normalize();
+    if (vecA.dot(vecB) < squeezeTolerance) {
+
+        // second finger
+        vecA.sub2(this._fingers[2].joints[0]._localPosition, this._fingers[2].joints[1]._localPosition).normalize();
+        vecB.sub2(this._fingers[2].joints[2]._localPosition, this._fingers[2].joints[3]._localPosition).normalize();
+        if (vecA.dot(vecB) < squeezeTolerance) {
+
+            // third finger
+            vecA.sub2(this._fingers[3].joints[0]._localPosition, this._fingers[3].joints[1]._localPosition).normalize();
+            vecB.sub2(this._fingers[3].joints[2]._localPosition, this._fingers[3].joints[3]._localPosition).normalize();
+
+            if (vecA.dot(vecB) < squeezeTolerance) {
+                // fourth finger
+                vecA.sub2(this._fingers[4].joints[0]._localPosition, this._fingers[4].joints[1]._localPosition).normalize();
+                vecB.sub2(this._fingers[4].joints[2]._localPosition, this._fingers[4].joints[3]._localPosition).normalize();
+
+                if (vecA.dot(vecB) < squeezeTolerance) {
+                    squeezing = true;
+                }
             }
-        } else {
-            if (this._inputSource._selecting) {
-                this._inputSource._selecting = false;
+        }
+    }
 
-                this._inputSource.fire('select');
-                this._manager.input.fire('select', this._inputSource);
+    if (squeezing) {
+        if (! this._inputSource._squeezing) {
+            this._inputSource._squeezing = true;
+            this._inputSource.fire('squeezestart');
+            this._manager.input.fire('squeezestart', this._inputSource);
+        }
+    } else {
+        if (this._inputSource._squeezing) {
+            this._inputSource._squeezing = false;
 
-                this._inputSource.fire('selectend');
-                this._manager.input.fire('selectend', this._inputSource);
-            }
+            this._inputSource.fire('squeeze');
+            this._manager.input.fire('squeeze', this._inputSource);
+
+            this._inputSource.fire('squeezeend');
+            this._manager.input.fire('squeezeend', this._inputSource);
         }
     }
 };

--- a/src/xr/xr-hand.js
+++ b/src/xr/xr-hand.js
@@ -148,34 +148,7 @@ XrHand.prototype.update = function (frame) {
     }
 
     // emulate squeeze events by folding all 4 fingers
-    var squeezing = false;
-    var squeezeTolerance = -0.8;
-
-    // first finger
-    vecA.sub2(this._fingers[1].joints[0]._localPosition, this._fingers[1].joints[1]._localPosition).normalize();
-    vecB.sub2(this._fingers[1].joints[2]._localPosition, this._fingers[1].joints[3]._localPosition).normalize();
-    if (vecA.dot(vecB) < squeezeTolerance) {
-
-        // second finger
-        vecA.sub2(this._fingers[2].joints[0]._localPosition, this._fingers[2].joints[1]._localPosition).normalize();
-        vecB.sub2(this._fingers[2].joints[2]._localPosition, this._fingers[2].joints[3]._localPosition).normalize();
-        if (vecA.dot(vecB) < squeezeTolerance) {
-
-            // third finger
-            vecA.sub2(this._fingers[3].joints[0]._localPosition, this._fingers[3].joints[1]._localPosition).normalize();
-            vecB.sub2(this._fingers[3].joints[2]._localPosition, this._fingers[3].joints[3]._localPosition).normalize();
-
-            if (vecA.dot(vecB) < squeezeTolerance) {
-                // fourth finger
-                vecA.sub2(this._fingers[4].joints[0]._localPosition, this._fingers[4].joints[1]._localPosition).normalize();
-                vecB.sub2(this._fingers[4].joints[2]._localPosition, this._fingers[4].joints[3]._localPosition).normalize();
-
-                if (vecA.dot(vecB) < squeezeTolerance) {
-                    squeezing = true;
-                }
-            }
-        }
-    }
+    var squeezing = this._fingerIsClosed(1) && this._fingerIsClosed(2) && this._fingerIsClosed(3) && this._fingerIsClosed(4);
 
     if (squeezing) {
         if (! this._inputSource._squeezing) {
@@ -194,6 +167,13 @@ XrHand.prototype.update = function (frame) {
             this._manager.input.fire('squeezeend', this._inputSource);
         }
     }
+};
+
+XrHand.prototype._fingerIsClosed = function (index) {
+    var finger = this._fingers[index];
+    vecA.sub2(finger.joints[0]._localPosition, finger.joints[1]._localPosition).normalize();
+    vecB.sub2(finger.joints[2]._localPosition, finger.joints[3]._localPosition).normalize();
+    return vecA.dot(vecB) < -0.8;
 };
 
 /**

--- a/src/xr/xr-input-source.js
+++ b/src/xr/xr-input-source.js
@@ -122,12 +122,6 @@ XrInputSource.prototype.constructor = XrInputSource;
  * @name pc.XrInputSource#squeeze
  * @description Fired when input source has triggered squeeze action. This is associated with "grabbing" action on the controllers.
  * @param {object} evt - XRInputSourceEvent event data from WebXR API
- * @example
- * inputSource.on('squeeze', function (evt) {
- *     if (obj.containsPoint(inputSource.getPosition())) {
- *         // grabbed an object with input source
- *     }
- * });
  */
 
 /**
@@ -135,6 +129,12 @@ XrInputSource.prototype.constructor = XrInputSource;
  * @name pc.XrInputSource#squeezestart
  * @description Fired when input source has started to trigger sqeeze action.
  * @param {object} evt - XRInputSourceEvent event data from WebXR API
+ * @example
+ * inputSource.on('squeezestart', function (evt) {
+ *     if (obj.containsPoint(inputSource.getPosition())) {
+ *         // grabbed an object
+ *     }
+ * });
  */
 
 /**

--- a/src/xr/xr-input-source.js
+++ b/src/xr/xr-input-source.js
@@ -38,6 +38,7 @@ var ids = 0;
  * @property {pc.XrHand|null} hand If input source is a tracked hand, then it will point to {@link pc.XrHand} otherwise it is null.
  * @property {Gamepad|null} gamepad If input source has buttons, triggers, thumbstick or touchpad, then this object provides access to its states.
  * @property {boolean} selecting True if input source is in active primary action between selectstart and selectend events.
+ * @property {boolean} squeezing True if input source is in active squeeze action between squeezestart and squeezeend events.
  * @property {boolean} elementInput Set to true to allow input source to interact with Element components. Defaults to true.
  * @property {pc.Entity} elementEntity If {@link pc.XrInputSource#elementInput} is true, this property will hold entity with Element component at which this input source is hovering, or null if not hovering over any element.
  * @property {pc.XrHitTestSource[]} hitTestSources list of active {@link pc.XrHitTestSource} created by this input source.
@@ -67,6 +68,7 @@ function XrInputSource(manager, xrInputSource) {
     this._dirtyLocal = true;
 
     this._selecting = false;
+    this._squeezing = false;
 
     this._elementInput = true;
     this._elementEntity = null;
@@ -112,6 +114,33 @@ XrInputSource.prototype.constructor = XrInputSource;
  * @event
  * @name pc.XrInputSource#selectend
  * @description Fired when input source has ended triggerring primary action.
+ * @param {object} evt - XRInputSourceEvent event data from WebXR API
+ */
+
+/**
+ * @event
+ * @name pc.XrInputSource#squeeze
+ * @description Fired when input source has triggered squeeze action. This is associated with "grabbing" action on the controllers.
+ * @param {object} evt - XRInputSourceEvent event data from WebXR API
+ * @example
+ * inputSource.on('squeeze', function (evt) {
+ *     if (obj.containsPoint(inputSource.getPosition())) {
+ *         // grabbed an object with input source
+ *     }
+ * });
+ */
+
+/**
+ * @event
+ * @name pc.XrInputSource#squeezestart
+ * @description Fired when input source has started to trigger sqeeze action.
+ * @param {object} evt - XRInputSourceEvent event data from WebXR API
+ */
+
+/**
+ * @event
+ * @name pc.XrInputSource#squeezeend
+ * @description Fired when input source has ended triggerring sqeeze action.
  * @param {object} evt - XRInputSourceEvent event data from WebXR API
  */
 
@@ -413,6 +442,12 @@ Object.defineProperty(XrInputSource.prototype, 'gamepad', {
 Object.defineProperty(XrInputSource.prototype, 'selecting', {
     get: function () {
         return this._selecting;
+    }
+});
+
+Object.defineProperty(XrInputSource.prototype, 'squeezing', {
+    get: function () {
+        return this._squeezing;
     }
 });
 

--- a/src/xr/xr-input.js
+++ b/src/xr/xr-input.js
@@ -90,12 +90,6 @@ XrInput.prototype.constructor = XrInput;
  * @description Fired when {pc.XrInputSource} has triggered squeeze action. This is associated with "grabbing" action on the controllers.
  * @param {pc.XrInputSource} inputSource - Input source that triggered squeeze event
  * @param {object} evt - XRInputSourceEvent event data from WebXR API
- * @example
- * app.xr.input.on('squeeze', function (inputSource, evt) {
- *     if (obj.containsPoint(inputSource.getPosition())) {
- *         // grabbed an object with input source
- *     }
- * });
  */
 
 /**
@@ -104,6 +98,12 @@ XrInput.prototype.constructor = XrInput;
  * @description Fired when {pc.XrInputSource} has started to trigger sqeeze action.
  * @param {pc.XrInputSource} inputSource - Input source that triggered squeezestart event
  * @param {object} evt - XRInputSourceEvent event data from WebXR API
+ * @example
+ * app.xr.input.on('squeezestart', function (inputSource, evt) {
+ *     if (obj.containsPoint(inputSource.getPosition())) {
+ *         // grabbed an object
+ *     }
+ * });
  */
 
 /**

--- a/src/xr/xr-input.js
+++ b/src/xr/xr-input.js
@@ -84,6 +84,36 @@ XrInput.prototype.constructor = XrInput;
  * @param {object} evt - XRInputSourceEvent event data from WebXR API
  */
 
+/**
+ * @event
+ * @name pc.XrInput#squeeze
+ * @description Fired when {pc.XrInputSource} has triggered squeeze action. This is associated with "grabbing" action on the controllers.
+ * @param {pc.XrInputSource} inputSource - Input source that triggered squeeze event
+ * @param {object} evt - XRInputSourceEvent event data from WebXR API
+ * @example
+ * app.xr.input.on('squeeze', function (inputSource, evt) {
+ *     if (obj.containsPoint(inputSource.getPosition())) {
+ *         // grabbed an object with input source
+ *     }
+ * });
+ */
+
+/**
+ * @event
+ * @name pc.XrInput#squeezestart
+ * @description Fired when {pc.XrInputSource} has started to trigger sqeeze action.
+ * @param {pc.XrInputSource} inputSource - Input source that triggered squeezestart event
+ * @param {object} evt - XRInputSourceEvent event data from WebXR API
+ */
+
+/**
+ * @event
+ * @name pc.XrInput#squeezeend
+ * @description Fired when {pc.XrInputSource} has ended triggerring sqeeze action.
+ * @param {pc.XrInputSource} inputSource - Input source that triggered squeezeend event
+ * @param {object} evt - XRInputSourceEvent event data from WebXR API
+ */
+
 XrInput.prototype._onSessionStart = function () {
     this._session = this.manager.session;
     this._session.addEventListener('inputsourceschange', this._onInputSourcesChangeEvt);
@@ -109,6 +139,27 @@ XrInput.prototype._onSessionStart = function () {
         inputSource._selecting = false;
         inputSource.fire('selectend', evt);
         self.fire('selectend', inputSource, evt);
+    });
+
+    this._session.addEventListener('squeeze', function (evt) {
+        var inputSource = self._getByInputSource(evt.inputSource);
+        inputSource.update(evt.frame);
+        inputSource.fire('squeeze', evt);
+        self.fire('squeeze', inputSource, evt);
+    });
+    this._session.addEventListener('squeezestart', function (evt) {
+        var inputSource = self._getByInputSource(evt.inputSource);
+        inputSource.update(evt.frame);
+        inputSource._squeezing = true;
+        inputSource.fire('squeezestart', evt);
+        self.fire('squeezestart', inputSource, evt);
+    });
+    this._session.addEventListener('squeezeend', function (evt) {
+        var inputSource = self._getByInputSource(evt.inputSource);
+        inputSource.update(evt.frame);
+        inputSource._squeezing = false;
+        inputSource.fire('squeezeend', evt);
+        self.fire('squeezeend', inputSource, evt);
     });
 
     // add input sources


### PR DESCRIPTION
Fixes #2631

Implements `squeeze`, `squeezestart`, `squeezeend` events for input source. These are "squeezing" or "grabbing" action as [defined by WebXR Specs](https://www.w3.org/TR/webxr/#ref-for-xr-input-source%E2%91%A0%E2%91%A7).

Oculus Browser (13) currently does not implements squeeze events for hand inputs, so it is emulated on our side in engine.
Also removed emulated `select` event from hand input source, as Oculus Browser (13) now implements it in UA.

### New APIs:
```javascript
// pc.XrInput
app.xr.input.on('squeeze', function(inputSource, evt) { }); // when device is squeezed
app.xr.input.on('squeezestart', function(inputSource, evt) { }); // when devices starts to be squeezed
app.xr.input.on('squeezeend', function(inputSource, evt) { }); // when devices ends being squeezed

// pc.XrInputSource
inputSource.squeezing // True if input source is currently in squeezing/grabbing state
inputSource.on('squeeze', function(evt) { }); // when device is squeezed
inputSource.on('squeezestart', function(evt) { }); // when devices starts to be squeezed
inputSource.on('squeezeend', function(evt) { }); // when device ends being squeezed
```

### Example:
```js
inputSource.on('squeezestart', function (evt) {
    if (aabb.containsPoint(inputSource.getPosition())) {
        // grabbed an object
    }
});
```

### Testing:
Project: https://playcanvas.com/project/709052/overview/webxr-hands--physics
Build: https://playcanv.as/p/EvnwWzol/

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
