### PR TITLE
Added support for base64 URLs on handlers expecting array buffers

### DIFF
--- a/src/resources/animation.js
+++ b/src/resources/animation.js
@@ -34,7 +34,7 @@ Object.assign(AnimationHandler.prototype, {
             maxRetries: this.maxRetries
         };
 
-        if (url.load.startsWith('blob:')) {
+        if (url.load.startsWith('blob:') || url.load.startsWith('data:')) {
             if (path.getExtension(url.original).toLowerCase() === '.glb') {
                 options.responseType = Http.ResponseType.ARRAY_BUFFER;
             } else {

--- a/src/resources/audio.js
+++ b/src/resources/audio.js
@@ -125,7 +125,7 @@ if (hasAudioContext()) {
             maxRetries: this.maxRetries
         };
 
-        if (url.startsWith('blob:')) {
+        if (url.startsWith('blob:') || url.load.startsWith('data:')) {
             options.responseType = Http.ResponseType.ARRAY_BUFFER;
         }
 

--- a/src/resources/model.js
+++ b/src/resources/model.js
@@ -42,7 +42,7 @@ Object.assign(ModelHandler.prototype, {
             maxRetries: this.maxRetries
         };
 
-        if (url.load.startsWith('blob:')) {
+        if (url.load.startsWith('blob:') || url.load.startsWith('data:')) {
             if (path.getExtension(url.original).toLowerCase() === '.glb') {
                 options.responseType = Http.ResponseType.ARRAY_BUFFER;
             } else {


### PR DESCRIPTION
Needed to support single index.html builds for playable ads

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
