### PR TITLE
Transition to modern JavaScript

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# CONTRIBUTING
+# CONTRIBUTING
 
 # HOW TO CONTRIBUTE
 
@@ -8,7 +8,7 @@
 4. Keep PR simple and focused - one PR per feature.
 5. Make a Pull Request.
 6. Complete the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
-7. Happy Days! :)
+7. Happy Days! 🎉
 
 #### Tips
 
@@ -22,7 +22,7 @@ Try to keep PR focused on a single feature, small PR's are easier to review and 
 
 ## General
 
-These coding standards are based on the [Google JavaScript Coding Standards](https://google.github.io/styleguide/javascriptguide.xml). If something is not defined here, use this guide as a backup.
+Our coding standards are derived from the [Google JavaScript Coding Standards](https://google.github.io/styleguide/javascriptguide.xml) which are based on ES5 (ECMA2009). Also we have a whitelist of modern JavaScript features (ES6+), explicitly listed below.
 
 ### Keep it simple
 
@@ -31,6 +31,14 @@ Simple code is always better. Modular (horizontal dependencies) code is easier t
 ### Use International/American English spelling
 
 For example, use "Initialize" instead of "Initialise", and "color" instead of "colour".
+
+### Whitelisted ES6+ features:
+
+* `let`, `const` instead of `var`
+* `for of` loop
+* `class` instead of `prototype`
+* `import`/`export` handled by build scripts for bundling
+* function default parameters
 
 ### Opening braces should be on the same line as the statement
 
@@ -68,16 +76,16 @@ On save, set your text editor to remove trailing spaces and ensure there is an e
 ### Use spaces between operators
 
 ```javascript
-var foo = 16 + 32 / 4;
+let foo = 16 + 32 / 4;
 
-for (var i = 0, len = list.length; i < len; i++) {
+for (let i = 0; i < list.length; i++) {
     // ...
 }
 ```
 
 ### Leave a space after the function keyword for anonymous functions
 ```javascript
-var fn = function () {
+let fn = function () {
 
 };
 ```
@@ -88,51 +96,34 @@ foo();
 bar(1, 2);
 ```
 
-### Use spaces between [ ] and { } brackets
+### Use spaces between [ ] and { } brackets, unless they are empty
 ```javascript
-var a = { };
-var b = { key: 'value' };
-var c = [ ];
-var d = [ 32, 64 ];
+let a = {};
+let b = { key: 'value' };
+let c = [];
+let d = [ 32, 64 ];
 ```
 
-### No semicolon on closing function brace
-
-Semicolons are not needed to delimit the ends of functions. Follow the convention below:
-```javascript
-function class() {
-} // Note the lack of semicolon here
-```
-
-Semicolons **are** needed if you're function is declared as a variable
-```javascript
-var fn = function () {
-}; // Note the semicolon here
-```
-
-### Put all variable declarations at the top of functions
-
-Variable declarations should all be placed first or close to the top of functions. This is because variables have a function-level scope.
-
-Variables should be declared one per line.
+### `let` and `const` instead of `var` (ES6)
 
 ```javascript
-function fn() {
-    var a = 0;
-    var b = 1;
-    var c = 2;
+for (let i = 0; i < items.length; i++) {
+    const item = items[i];
 }
+
+var a = 10; // not good
 ```
+
+### For of loop (ES6)
 ```javascript
-function fn() {
-    var i;
-    var bar = 0;
+// ok
+for (let i = 0; i < items.length; i++) {
+    const item = items[i];
+}
 
-    for(i = 0; i < 32; ++i) {
-        bar += i;
-    }
+// more readable but generally slower
+for (const item of items) {
 
-    for(var i = 0; i < 32; i++) { } // don't do this, as i is already defined
 }
 ```
 
@@ -140,7 +131,7 @@ function fn() {
 
 In functions exit early to simplify logic flow and avoid building indention-hell:
 ```javascript
-var foo = function (bar) {
+let foo = function (bar) {
     if (! bar)
         return;
 
@@ -150,7 +141,7 @@ var foo = function (bar) {
 
 Same for iterators:
 ```javascript
-for(var i = 0; i < items.length; i++) {
+for (let i = 0; i < items.length; i++) {
     if (! items[i].test)
         continue;
 
@@ -164,36 +155,36 @@ for(var i = 0; i < items.length; i++) {
 
 ```javascript
 // Namespace should have short lowercase names
-var namespace = { };
+let namespace = { };
 
-// Classes (or rather Constructors) should be CamelCase
-var MyClass = function () { };
+// Classes should be CamelCase
+class MyClass { }
 
 // Variables should be mixedCase
-var mixedCase = 1;
+let mixedCase = 1;
 
 // Function are usually variables so should be mixedCase
 // (unless they are class constructors)
-var myFunction = function () { };
+let myFunction = function () { };
 
 // Constants should be ALL_CAPITALS separated by underscores.
 // Note, ES5 doesn't support constants,
 // so this is just convention.
-var THIS_IS_CONSTANT = "well, kind of";
+let THIS_IS_CONSTANT = "well, kind of";
 
 // Private variables should start with a leading underscore.
 // Note, you should attempt to make private variables actually private using
 // a closure.
-var _private = "private";
-var _privateFn = function () { };
+let _private = "private";
+let _privateFn = function () { };
 ```
 
 ### Acronyms should not be upper-case, they should follow coding standards
 
 Treat acronyms like a normal word. e.g.
 ```javascript
-var json = ""; // not "JSON";
-var id = 1; // not "ID";
+let json = ""; // not "JSON";
+let id = 1; // not "ID";
 
 function getId() { }; // not "getID"
 function loadJson() { }; // not "loadJSON"
@@ -223,7 +214,7 @@ function asyncFunction(callback) {
 It is often useful to be able to cache the 'this' object to get around the scoping behavior of JavaScript. If you need to do this, cache it in a variable called 'self'.
 
 ```javascript
-var self = this;
+let self = this;
 ```
 
 ### Avoid using function.bind(scope)
@@ -236,11 +227,29 @@ setTimeout(function() {
 
 Instead use `self` reference in upper scope:
 ```javascript
-var self = this;
+let self = this;
 setTimeout(function() {
     self.foo();
 });
 ```
+
+### Default function parameters (ES6)
+
+Use this notation for function default parameters:
+```javascript
+// good
+function foo(a, b = 10) {
+    return a + b;
+}
+
+// not good
+function foo(a, b) {
+    if (b === undefined)
+        b = 10;
+    return a + b;
+}
+```
+
 
 ## Privacy
 
@@ -248,14 +257,17 @@ setTimeout(function() {
 
 Variables that should be accessible only within class should start with `_`:
 ```javascript
-var Item = function () {
-    this._a = "private";
-};
-Item.prototype.bar = function() {
-    this._a += "!";
-};
+class Item {
+    constructor() {
+        this._a = "private";
+    }
 
-var foo = new Item();
+    bar() {
+        this._a += "!";
+    }
+}
+
+let foo = new Item();
 foo._a += "?"; // not good
 ```
 
@@ -264,7 +276,7 @@ foo._a += "?"; // not good
 The hasOwnProperty() function should be used when iterating over an object's members. This is to avoid accidentally picking up unintended members that may have been added to the object's prototype. For example:
 
 ```javascript
-for (var key in values) {
+for (let key in values) {
     if (! values.hasOwnProperty(key))
         continue;
 
@@ -285,51 +297,48 @@ asset-registry.js
 graph-node.js
 ```
 
-## Namespaces and Classes
+## Namespaces and Classes (ES6)
 
-The entire PlayCanvas API must be declared under the ```pc``` namespace. The vast majority of the PlayCanvas codebase is made up of 'class' definitions. These have the following structure (which should be adhered to):
+The entire PlayCanvas API must be declared under the ```pc``` namespace. This is handled by build script, so ES6 notation of `import`/`export` should be used. The vast majority of the PlayCanvas codebase is made up of `class` definitions. These have the following structure (which should be adhered to):
 
 ```javascript
-Object.assign(pc, function() {
-    // Closure to define new class
+class Class {
+    someFunc(x) { }
+}
 
-    var Class = function () {
-    };
-
-    Object.assign(Class.prototype, {
-        someFunc: function () {
-
-        }
-    });
-
-    return {
-        Class: Class
-    };
-}());
+export { Class };
 ```
 
-You can also subclass existing classes:
+You can also extend existing classes:
 
 ```javascript
-Object.assign(pc, function() {
-    // Closure to define new class
+import { Class } from './class.js';
 
-    var SubClass = function () {
-        pc.SuperClass.call(this);
-    };
+class SubClass extends Class {
+    constructor() {
+        // call parent class constructor
+        super();
+    }
 
-    // optionally can inherit
-    SubClass.prototype = Object.create(pc.SuperClass.prototype);
-    SubClass.prototype.constructor = SubClass;
+    someFunc(x) {
+        // if method is overriden
+        // this is the way to call parent class method
+        super.someFunc(x);
+    }
+}
 
-    Object.assign(SubClass.prototype, {
-        someFunc: function () {
-            SuperClass.prototype.someFunc.call(this);
-        }
-    });
+export { SubClass };
+```
 
-    return {
-        SubClass: SubClass
-    };
-}());
+Use `class` instead of `prototype` for defining Classes:
+
+```javascript
+// good
+class Class {
+    someFunc() { }
+}
+
+// not good
+function Class() { }
+Class.prototype.someFunc = function() { };
 ```

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -170,7 +170,7 @@ let myFunction = function () { };
 // Constants should be ALL_CAPITALS separated by underscores.
 // Note, ES5 doesn't support constants,
 // so this is just convention.
-let THIS_IS_CONSTANT = "well, kind of";
+const THIS_IS_CONSTANT = "well, kind of";
 
 // Private variables should start with a leading underscore.
 // Note, you should attempt to make private variables actually private using

--- a/extras/mini-stats/cpu-timer.js
+++ b/extras/mini-stats/cpu-timer.js
@@ -1,21 +1,21 @@
-function CpuTimer(app) {
-    this._frameIndex = 0;
-    this._frameTimings = [];
-    this._timings = [];
-    this._prevTimings = [];
-    this.unitsName = "ms";
-    this.decimalPlaces = 1;
+class CpuTimer {
+    constructor(app) {
+        this._frameIndex = 0;
+        this._frameTimings = [];
+        this._timings = [];
+        this._prevTimings = [];
+        this.unitsName = "ms";
+        this.decimalPlaces = 1;
 
-    this.enabled = true;
+        this.enabled = true;
 
-    app.on('frameupdate', this.begin.bind(this, 'update'));
-    app.on('framerender', this.mark.bind(this, 'render'));
-    app.on('frameend', this.mark.bind(this, 'other'));
-}
+        app.on('frameupdate', this.begin.bind(this, 'update'));
+        app.on('framerender', this.mark.bind(this, 'render'));
+        app.on('frameend', this.mark.bind(this, 'other'));
+    }
 
-Object.assign(CpuTimer.prototype, {
     // mark the beginning of the frame
-    begin: function (name) {
+    begin(name) {
         if (!this.enabled) {
             return;
         }
@@ -31,10 +31,10 @@ Object.assign(CpuTimer.prototype, {
         this._frameIndex = 0;
 
         this.mark(name);
-    },
+    }
 
     // mark
-    mark: function (name) {
+    mark(name) {
         if (!this.enabled) {
             return;
         }
@@ -60,16 +60,14 @@ Object.assign(CpuTimer.prototype, {
         }
         this._frameIndex++;
     }
-});
 
-Object.defineProperty(CpuTimer.prototype, 'timings', {
-    get: function () {
+    get timings() {
         // remove the last time point from the list (which is the time spent outside
         // of playcanvas)
         return this._timings.slice(0, -1).map(function (v) {
             return v[1];
         });
     }
-});
+}
 
 export { CpuTimer };

--- a/extras/mini-stats/gpu-timer.js
+++ b/extras/mini-stats/gpu-timer.js
@@ -1,34 +1,33 @@
-function GpuTimer(app) {
-    this._gl = app.graphicsDevice.gl;
-    this._ext = app.graphicsDevice.extDisjointTimerQuery;
+class GpuTimer {
+    constructor(app) {
+        this._gl = app.graphicsDevice.gl;
+        this._ext = app.graphicsDevice.extDisjointTimerQuery;
 
-    this._freeQueries = [];                     // pool of free queries
-    this._frameQueries = [];                    // current frame's queries
-    this._frames = [];                          // list of previous frame queries
-
-    this._timings = [];
-    this._prevTimings = [];
-
-    this.enabled = true;
-    this.unitsName = "ms";
-    this.decimalPlaces = 1;
-
-    app.on('frameupdate', this.begin.bind(this, 'update'));
-    app.on('framerender', this.mark.bind(this, 'render'));
-    app.on('frameend', this.end.bind(this));
-}
-
-Object.assign(GpuTimer.prototype, {
-
-    // called when context was lost, function releases all context related resources
-    loseContext: function () {
         this._freeQueries = [];                     // pool of free queries
         this._frameQueries = [];                    // current frame's queries
         this._frames = [];                          // list of previous frame queries
-    },
+
+        this._timings = [];
+        this._prevTimings = [];
+
+        this.enabled = true;
+        this.unitsName = "ms";
+        this.decimalPlaces = 1;
+
+        app.on('frameupdate', this.begin.bind(this, 'update'));
+        app.on('framerender', this.mark.bind(this, 'render'));
+        app.on('frameend', this.end.bind(this));
+    }
+
+    // called when context was lost, function releases all context related resources
+    loseContext() {
+        this._freeQueries = [];                     // pool of free queries
+        this._frameQueries = [];                    // current frame's queries
+        this._frames = [];                          // list of previous frame queries
+    }
 
     // mark the beginning of the frame
-    begin: function (name) {
+    begin(name) {
         if (!this.enabled) {
             return;
         }
@@ -55,10 +54,10 @@ Object.assign(GpuTimer.prototype, {
         }
 
         this.mark(name);
-    },
+    }
 
     // mark
-    mark: function (name) {
+    mark(name) {
         if (!this.enabled) {
             return;
         }
@@ -73,10 +72,10 @@ Object.assign(GpuTimer.prototype, {
         query[0] = name;
         this._gl.beginQuery(this._ext.TIME_ELAPSED_EXT, query[1]);
         this._frameQueries.push(query);
-    },
+    }
 
     // end of frame
-    end: function () {
+    end() {
         if (!this.enabled) {
             return;
         }
@@ -84,11 +83,11 @@ Object.assign(GpuTimer.prototype, {
         this._gl.endQuery(this._ext.TIME_ELAPSED_EXT);
         this._frames.push(this._frameQueries);
         this._frameQueries = [];
-    },
+    }
 
     // check if the gpu has been interrupted thereby invalidating all
     // in-flight queries
-    _checkDisjoint: function () {
+    _checkDisjoint() {
         var disjoint = this._gl.getParameter(this._ext.GPU_DISJOINT_EXT);
         if (disjoint) {
             // return all queries to the free list
@@ -96,16 +95,16 @@ Object.assign(GpuTimer.prototype, {
             this._frameQueries = [];
             this._frames = [];
         }
-    },
+    }
 
     // either returns a previously free'd query or if there aren't any allocates a new one
-    _allocateQuery: function () {
+    _allocateQuery() {
         return (this._freeQueries.length > 0) ?
             this._freeQueries.splice(-1, 1)[0] : ["", this._gl.createQuery()];
-    },
+    }
 
     // attempt to resolve one frame's worth of timings
-    _resolveFrameTimings: function (frame, timings) {
+    _resolveFrameTimings(frame, timings) {
         // wait for the last query in the frame to be available
         if (!this._gl.getQueryParameter(frame[frame.length - 1][1], this._gl.QUERY_RESULT_AVAILABLE)) {
             return false;
@@ -117,14 +116,12 @@ Object.assign(GpuTimer.prototype, {
 
         return true;
     }
-});
 
-Object.defineProperty(GpuTimer.prototype, 'timings', {
-    get: function () {
+    get timings() {
         return this._timings.map(function (v) {
             return v[1];
         });
     }
-});
+}
 
 export { GpuTimer };

--- a/extras/mini-stats/graph.js
+++ b/extras/mini-stats/graph.js
@@ -1,39 +1,38 @@
 // Realtime performance graph visual
-function Graph(name, app, watermark, textRefreshRate, timer) {
-    this.name = name;
-    this.device = app.graphicsDevice;
-    this.timer = timer;
-    this.watermark = watermark;
-    this.enabled = false;
-    this.textRefreshRate = textRefreshRate;
+class Graph {
+    constructor(name, app, watermark, textRefreshRate, timer) {
+        this.name = name;
+        this.device = app.graphicsDevice;
+        this.timer = timer;
+        this.watermark = watermark;
+        this.enabled = false;
+        this.textRefreshRate = textRefreshRate;
 
-    this.avgTotal = 0;
-    this.avgTimer = 0;
-    this.avgCount = 0;
-    this.timingText = "";
+        this.avgTotal = 0;
+        this.avgTimer = 0;
+        this.avgCount = 0;
+        this.timingText = "";
 
-    this.texture = null;
-    this.yOffset = 0;
-    this.cursor = 0;
-    this.sample = new Uint8ClampedArray(4);
-    this.sample.set([0, 0, 0, 255]);
+        this.texture = null;
+        this.yOffset = 0;
+        this.cursor = 0;
+        this.sample = new Uint8ClampedArray(4);
+        this.sample.set([0, 0, 0, 255]);
 
-    app.on('frameupdate', this.update.bind(this));
+        app.on('frameupdate', this.update.bind(this));
 
-    this.counter = 0;
-}
-
-Object.assign(Graph.prototype, {
+        this.counter = 0;
+    }
 
     // called when context was lost, function releases all context related resources
-    loseContext: function () {
+    loseContext() {
         // if timer implements loseContext
         if (this.timer && (typeof this.timer.loseContext === 'function')) {
             this.timer.loseContext();
         }
-    },
+    }
 
-    update: function (ms) {
+    update(ms) {
         var timings = this.timer.timings;
 
         // calculate stacked total
@@ -86,9 +85,9 @@ Object.assign(Graph.prototype, {
                 this.cursor = 0;
             }
         }
-    },
+    }
 
-    render: function (render2d, x, y, w, h) {
+    render(render2d, x, y, w, h) {
         render2d.quad(this.texture,
                       x + w,
                       y,
@@ -99,6 +98,6 @@ Object.assign(Graph.prototype, {
                       -w, 0,
                       this.enabled);
     }
-});
+}
 
 export { Graph };

--- a/extras/mini-stats/mini-stats.js
+++ b/extras/mini-stats/mini-stats.js
@@ -4,238 +4,228 @@ import { StatsTimer } from './stats-timer.js';
 import { Graph } from './graph.js';
 import { WordAtlas } from './word-atlas.js';
 import { Render2d } from './render2d.js';
-import { Color } from '../../src/core/color.js';
-import { math } from '../../src/math/math.js';
 
 // MiniStats rendering of CPU and GPU timing information
-function MiniStats(app, options) {
+class MiniStats {
+    constructor(app, options) {
 
-    var device = app.graphicsDevice;
+        var device = app.graphicsDevice;
 
-    // handle context lost
-    this._contextLostHandler = function (event) {
-        event.preventDefault();
+        // handle context lost
+        this._contextLostHandler = function (event) {
+            event.preventDefault();
 
-        if (this.graphs) {
-            for (var i = 0; i < this.graphs.length; i++) {
-                this.graphs[i].loseContext();
+            if (this.graphs) {
+                for (var i = 0; i < this.graphs.length; i++) {
+                    this.graphs[i].loseContext();
+                }
             }
-        }
-    }.bind(this);
-    device.canvas.addEventListener("webglcontextlost", this._contextLostHandler, false);
+        }.bind(this);
+        device.canvas.addEventListener("webglcontextlost", this._contextLostHandler, false);
 
-    options = options || MiniStats.getDefaultOptions();
+        options = options || MiniStats.getDefaultOptions();
 
-    // create graphs based on options
-    var graphs = this.initGraphs(app, device, options);
+        // create graphs based on options
+        var graphs = this.initGraphs(app, device, options);
 
-    // extract words needed
-    var words = ["", "ms", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "."];
+        // extract words needed
+        var words = ["", "ms", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "."];
 
-    // graph names
-    graphs.forEach(function (graph) {
-        words.push(graph.name);
-    });
-
-    // stats units
-    if (options.stats) {
-        options.stats.forEach(function (stat) {
-            if (stat.unitsName)
-                words.push(stat.unitsName);
+        // graph names
+        graphs.forEach(function (graph) {
+            words.push(graph.name);
         });
+
+        // stats units
+        if (options.stats) {
+            options.stats.forEach(function (stat) {
+                if (stat.unitsName)
+                    words.push(stat.unitsName);
+            });
+        }
+
+        // remove duplicates
+        words = words.filter(function (item, index) {
+            return words.indexOf(item) >= index;
+        });
+
+        // create word atlas
+        var maxWidth = options.sizes.reduce(function (max, v) {
+            return v.width > max ? v.width : max;
+        }, 0);
+        var wordAtlasData = this.initWordAtlas(device, words, maxWidth, graphs.length);
+        var texture = wordAtlasData.texture;
+
+        // assign texture to graphs
+        graphs.forEach(function (graph, i) {
+            graph.texture = texture;
+            graph.yOffset = i;
+        });
+
+        this.sizes = options.sizes;
+        this._activeSizeIndex = options.startSizeIndex;
+
+        var self = this;
+
+        // create click region so we can resize
+        var div = document.createElement('div');
+        div.style.cssText = 'position:fixed;bottom:0;left:0;background:transparent;';
+        document.body.appendChild(div);
+
+        div.addEventListener('mouseenter', function (event) {
+            self.opacity = 1.0;
+        });
+
+        div.addEventListener('mouseleave', function (event) {
+            self.opacity = 0.5;
+        });
+
+        div.addEventListener('click', function (event) {
+            event.preventDefault();
+            if (self._enabled) {
+                self.activeSizeIndex = (self.activeSizeIndex + 1) % self.sizes.length;
+                self.resize(self.sizes[self.activeSizeIndex].width, self.sizes[self.activeSizeIndex].height, self.sizes[self.activeSizeIndex].graphs);
+            }
+        });
+
+        device.on("resizecanvas", function () {
+            self.updateDiv();
+        });
+
+        app.on('postrender', function () {
+            if (self._enabled) {
+                self.render();
+            }
+        });
+
+        this.device = device;
+        this.texture = texture;
+        this.wordAtlas = wordAtlasData.atlas;
+        this.render2d = new Render2d(device, options.colors);
+        this.graphs = graphs;
+        this.div = div;
+
+        this.width = 0;
+        this.height = 0;
+        this.gspacing = 2;
+        this.clr = [1, 1, 1, 0.5];
+
+        this._enabled = true;
+
+        // initial resize
+        this.activeSizeIndex = this._activeSizeIndex;
     }
 
-    // remove duplicates
-    words = words.filter(function (item, index) {
-        return words.indexOf(item) >= index;
-    });
+    static getDefaultOptions() {
+        return {
 
-    // create word atlas
-    var maxWidth = options.sizes.reduce(function (max, v) {
-        return v.width > max ? v.width : max;
-    }, 0);
-    var wordAtlasData = this.initWordAtlas(device, words, maxWidth, graphs.length);
-    var texture = wordAtlasData.texture;
+            // sizes of area to render individual graphs in and spacing between indivudual graphs
+            sizes: [
+                { width: 100, height: 16, spacing: 0, graphs: false },
+                { width: 128, height: 32, spacing: 2, graphs: true },
+                { width: 256, height: 64, spacing: 2, graphs: true }
+            ],
 
-    // assign texture to graphs
-    graphs.forEach(function (graph, i) {
-        graph.texture = texture;
-        graph.yOffset = i;
-    });
+            // index into sizes array for initial setting
+            startSizeIndex: 0,
 
-    this.sizes = options.sizes;
-    this._activeSizeIndex = options.startSizeIndex;
+            // refresh rate of text stats in ms
+            textRefreshRate: 500,
 
-    var self = this;
+            // colors used to render graphs
+            colors: {
+                graph0: new pc.Color(0.7, 0.2, 0.2, 1),
+                graph1: new pc.Color(0.2, 0.7, 0.2, 1),
+                graph2: new pc.Color(0.2, 0.2, 0.7, 1),
+                watermark: new pc.Color(0.4, 0.4, 0.2, 1),
+                background: new pc.Color(0, 0, 0, 1.0)
+            },
 
-    // create click region so we can resize
-    var div = document.createElement('div');
-    div.style.cssText = 'position:fixed;bottom:0;left:0;background:transparent;';
-    document.body.appendChild(div);
-
-    div.addEventListener('mouseenter', function (event) {
-        self.opacity = 1.0;
-    });
-
-    div.addEventListener('mouseleave', function (event) {
-        self.opacity = 0.5;
-    });
-
-    div.addEventListener('click', function (event) {
-        event.preventDefault();
-        if (self._enabled) {
-            self.activeSizeIndex = (self.activeSizeIndex + 1) % self.sizes.length;
-            self.resize(self.sizes[self.activeSizeIndex].width, self.sizes[self.activeSizeIndex].height, self.sizes[self.activeSizeIndex].graphs);
-        }
-    });
-
-    device.on("resizecanvas", function () {
-        self.updateDiv();
-    });
-
-    app.on('postrender', function () {
-        if (self._enabled) {
-            self.render();
-        }
-    });
-
-    this.device = device;
-    this.texture = texture;
-    this.wordAtlas = wordAtlasData.atlas;
-    this.render2d = new Render2d(device, options.colors);
-    this.graphs = graphs;
-    this.div = div;
-
-    this.width = 0;
-    this.height = 0;
-    this.gspacing = 2;
-    this.clr = [1, 1, 1, 0.5];
-
-    this._enabled = true;
-
-    // initial resize
-    this.activeSizeIndex = this._activeSizeIndex;
-}
-
-MiniStats.getDefaultOptions = function () {
-    return {
-
-        // sizes of area to render individual graphs in and spacing between indivudual graphs
-        sizes: [
-            { width: 100, height: 16, spacing: 0, graphs: false },
-            { width: 128, height: 32, spacing: 2, graphs: true },
-            { width: 256, height: 64, spacing: 2, graphs: true }
-        ],
-
-        // index into sizes array for initial setting
-        startSizeIndex: 0,
-
-        // refresh rate of text stats in ms
-        textRefreshRate: 500,
-
-        // colors used to render graphs
-        colors: {
-            graph0: new Color(0.7, 0.2, 0.2, 1),
-            graph1: new Color(0.2, 0.7, 0.2, 1),
-            graph2: new Color(0.2, 0.2, 0.7, 1),
-            watermark: new Color(0.4, 0.4, 0.2, 1),
-            background: new Color(0, 0, 0, 1.0)
-        },
-
-        // cpu graph options
-        cpu: {
-            enabled: true,
-            watermark: 33
-        },
-
-        // gpu graph options
-        gpu: {
-            enabled: true,
-            watermark: 33
-        },
-
-        // array of options to render additional graphs based on stats collected into pc.Application.stats
-        stats: [
-            {
-                // display name
-                name: "Frame",
-
-                // path to data inside pc.Application.stats
-                stats: ["frame.ms"],
-
-                // number of decimal places (defaults to none)
-                decimalPlaces: 1,
-
-                // units (defaults to "")
-                unitsName: "ms",
-
-                // watermark - shown as a line on the graph, useful for displaying a budget
+            // cpu graph options
+            cpu: {
+                enabled: true,
                 watermark: 33
             },
 
-            // total number of draw calls
-            {
-                name: "DrawCalls",
-                stats: ["drawCalls.total"],
-                watermark: 1000
-            }
-        ]
-    };
-};
+            // gpu graph options
+            gpu: {
+                enabled: true,
+                watermark: 33
+            },
 
-Object.defineProperties(MiniStats.prototype, {
-    activeSizeIndex: {
-        get: function () {
-            return this._activeSizeIndex;
-        },
-        set: function (value) {
-            this._activeSizeIndex = value;
-            this.gspacing = this.sizes[value].spacing;
-            this.resize(this.sizes[value].width, this.sizes[value].height, this.sizes[value].graphs);
-        }
-    },
+            // array of options to render additional graphs based on stats collected into pc.Application.stats
+            stats: [
+                {
+                    // display name
+                    name: "Frame",
 
-    opacity: {
-        get: function () {
-            return this.clr[3];
-        },
-        set: function (value) {
-            this.clr[3] = value;
-        }
-    },
+                    // path to data inside pc.Application.stats
+                    stats: ["frame.ms"],
 
-    overallHeight: {
-        get: function () {
-            var graphs = this.graphs;
-            var spacing = this.gspacing;
-            return this.height * graphs.length + spacing * (graphs.length - 1);
-        }
-    },
+                    // number of decimal places (defaults to none)
+                    decimalPlaces: 1,
 
-    enabled: {
-        get: function () {
-            return this._enabled;
-        },
-        set: function (value) {
-            if (value !== this._enabled) {
-                this._enabled = value;
-                for (var i = 0; i < this.graphs.length; ++i) {
-                    this.graphs[i].enabled = value;
-                    this.graphs[i].timer.enabled = value;
+                    // units (defaults to "")
+                    unitsName: "ms",
+
+                    // watermark - shown as a line on the graph, useful for displaying a budget
+                    watermark: 33
+                },
+
+                // total number of draw calls
+                {
+                    name: "DrawCalls",
+                    stats: ["drawCalls.total"],
+                    watermark: 1000
                 }
+            ]
+        };
+    }
+
+    get activeSizeIndex() {
+        return this._activeSizeIndex;
+    }
+
+    set activeSizeIndex(value) {
+        this._activeSizeIndex = value;
+        this.gspacing = this.sizes[value].spacing;
+        this.resize(this.sizes[value].width, this.sizes[value].height, this.sizes[value].graphs);
+    }
+
+    get opacity() {
+        return this.clr[3];
+    }
+
+    set opacity(value) {
+        this.clr[3] = value;
+    }
+
+    get overallHeight() {
+        var graphs = this.graphs;
+        var spacing = this.gspacing;
+        return this.height * graphs.length + spacing * (graphs.length - 1);
+    }
+
+    get enabled() {
+        return this._enabled;
+    }
+
+    set enabled(value) {
+        if (value !== this._enabled) {
+            this._enabled = value;
+            for (var i = 0; i < this.graphs.length; ++i) {
+                this.graphs[i].enabled = value;
+                this.graphs[i].timer.enabled = value;
             }
         }
     }
-});
 
-Object.assign(MiniStats.prototype, {
-
-    initWordAtlas: function (device, words, maxWidth, numGraphs) {
+    initWordAtlas(device, words, maxWidth, numGraphs) {
 
         // create the texture for storing word atlas and graph data
         var texture = new pc.Texture(device, {
             name: 'mini-stats',
-            width: math.nextPowerOfTwo(maxWidth),
+            width: pc.math.nextPowerOfTwo(maxWidth),
             height: 64,
             mipmaps: false,
             minFilter: pc.FILTER_NEAREST,
@@ -254,9 +244,9 @@ Object.assign(MiniStats.prototype, {
         device.setTexture(texture, 0);
 
         return { atlas: wordAtlas, texture: texture };
-    },
+    }
 
-    initGraphs: function (app, device, options) {
+    initGraphs(app, device, options) {
 
         var graphs = [];
         if (options.cpu.enabled) {
@@ -274,9 +264,9 @@ Object.assign(MiniStats.prototype, {
         }
 
         return graphs;
-    },
+    }
 
-    render: function () {
+    render() {
         var graphs = this.graphs;
         var wordAtlas = this.wordAtlas;
         var render2d = this.render2d;
@@ -315,9 +305,9 @@ Object.assign(MiniStats.prototype, {
         }
 
         render2d.render(this.clr, height);
-    },
+    }
 
-    resize: function (width, height, showGraphs) {
+    resize(width, height, showGraphs) {
         var graphs = this.graphs;
         for (var i = 0; i < graphs.length; ++i) {
             graphs[i].enabled = showGraphs;
@@ -327,15 +317,15 @@ Object.assign(MiniStats.prototype, {
         this.height = height;
 
         this.updateDiv();
-    },
+    }
 
-    updateDiv: function () {
+    updateDiv() {
         var rect = this.device.canvas.getBoundingClientRect();
         this.div.style.left = rect.left + "px";
         this.div.style.bottom = (window.innerHeight - rect.bottom) + "px";
         this.div.style.width = this.width + "px";
         this.div.style.height = this.overallHeight + "px";
     }
-});
+}
 
 export { MiniStats };

--- a/extras/mini-stats/stats-timer.js
+++ b/extras/mini-stats/stats-timer.js
@@ -1,39 +1,39 @@
 // Stats timer interface for graph
-var StatsTimer = function (app, statNames, decimalPlaces, unitsName, multiplier) {
-    this.app = app;
-    this.values = [];
+class StatsTimer {
+    constructor(app, statNames, decimalPlaces, unitsName, multiplier) {
+        this.app = app;
+        this.values = [];
 
-    // supporting up to 3 stats
-    this.statNames = statNames;
-    if (this.statNames.length > 3)
-        this.statNames.length = 3;
+        // supporting up to 3 stats
+        this.statNames = statNames;
+        if (this.statNames.length > 3)
+            this.statNames.length = 3;
 
-    this.unitsName = unitsName;
-    this.decimalPlaces = decimalPlaces;
-    this.multiplier = multiplier || 1;
+        this.unitsName = unitsName;
+        this.decimalPlaces = decimalPlaces;
+        this.multiplier = multiplier || 1;
 
-    var self = this;
+        var self = this;
 
-    // recursively look up properties of objects specified in a string
-    function resolve(path, obj) {
-        return path.split('.').reduce(function (prev, curr) {
-            return prev ? prev[curr] : null;
-        }, obj || self);
+        // recursively look up properties of objects specified in a string
+        function resolve(path, obj) {
+            return path.split('.').reduce(function (prev, curr) {
+                return prev ? prev[curr] : null;
+            }, obj || self);
+        }
+
+        app.on('frameupdate', function (ms) {
+            for (var i = 0; i < self.statNames.length; i++) {
+
+                // read specified stat from app.stats object
+                self.values[i] = resolve(self.statNames[i], self.app.stats) * self.multiplier;
+            }
+        });
     }
 
-    app.on('frameupdate', function (ms) {
-        for (var i = 0; i < self.statNames.length; i++) {
-
-            // read specified stat from app.stats object
-            self.values[i] = resolve(self.statNames[i], self.app.stats) * self.multiplier;
-        }
-    });
-};
-
-Object.defineProperty(StatsTimer.prototype, 'timings', {
-    get: function () {
+    get timings() {
         return this.values;
     }
-});
+}
 
 export { StatsTimer };

--- a/extras/mini-stats/word-atlas.js
+++ b/extras/mini-stats/word-atlas.js
@@ -1,89 +1,89 @@
 // Word atlas
-function WordAtlas(texture, words) {
-    var canvas = document.createElement('canvas');
-    canvas.width = texture.width;
-    canvas.height = texture.height;
+class WordAtlas {
+    constructor(texture, words) {
+        var canvas = document.createElement('canvas');
+        canvas.width = texture.width;
+        canvas.height = texture.height;
 
-    // configure the context
-    var context = canvas.getContext('2d', { alpha: true });
-    context.font = '10px "Lucida Console", Monaco, monospace';
-    context.textAlign = "left";
-    context.textBaseline = "alphabetic";
-    context.fillStyle = "rgb(255, 255, 255)";
+        // configure the context
+        var context = canvas.getContext('2d', { alpha: true });
+        context.font = '10px "Lucida Console", Monaco, monospace';
+        context.textAlign = "left";
+        context.textBaseline = "alphabetic";
+        context.fillStyle = "rgb(255, 255, 255)";
 
-    var padding = 5;
-    var x = padding;
-    var y = padding;
-    var placements = [];
-    var i;
+        var padding = 5;
+        var x = padding;
+        var y = padding;
+        var placements = [];
+        var i;
 
-    for (i = 0; i < words.length; ++i) {
-        // measure the word
-        var measurement = context.measureText(words[i]);
+        for (i = 0; i < words.length; ++i) {
+            // measure the word
+            var measurement = context.measureText(words[i]);
 
-        var l = Math.ceil(-measurement.actualBoundingBoxLeft);
-        var r = Math.ceil(measurement.actualBoundingBoxRight);
-        var a = Math.ceil(measurement.actualBoundingBoxAscent);
-        var d = Math.ceil(measurement.actualBoundingBoxDescent);
+            var l = Math.ceil(-measurement.actualBoundingBoxLeft);
+            var r = Math.ceil(measurement.actualBoundingBoxRight);
+            var a = Math.ceil(measurement.actualBoundingBoxAscent);
+            var d = Math.ceil(measurement.actualBoundingBoxDescent);
 
-        var w = l + r;
-        var h = a + d;
+            var w = l + r;
+            var h = a + d;
 
-        // wrap text
-        if (x + w >= canvas.width) {
-            x = padding;
-            y += 16;
+            // wrap text
+            if (x + w >= canvas.width) {
+                x = padding;
+                y += 16;
+            }
+
+            // digits and '.' are white, the rest grey
+            context.fillStyle = words[i].length === 1 ? "rgb(255, 255, 255)" : "rgb(150, 150, 150)";
+
+            // render the word
+            context.fillText(words[i], x - l, y + a);
+
+            placements.push({
+                l: l, r: r, a: a, d: d,
+                x: x, y: y, w: w, h: h
+            });
+
+            x += w + padding;
         }
 
-        // digits and '.' are white, the rest grey
-        context.fillStyle = words[i].length === 1 ? "rgb(255, 255, 255)" : "rgb(150, 150, 150)";
-
-        // render the word
-        context.fillText(words[i], x - l, y + a);
-
-        placements.push({
-            l: l, r: r, a: a, d: d,
-            x: x, y: y, w: w, h: h
+        var wordMap = { };
+        words.forEach(function (w, i) {
+            wordMap[w] = i;
         });
 
-        x += w + padding;
-    }
+        this.words = words;
+        this.wordMap = wordMap;
+        this.placements = placements;
+        this.texture = texture;
 
-    var wordMap = { };
-    words.forEach(function (w, i) {
-        wordMap[w] = i;
-    });
+        // copy pixel data to target
+        var source = context.getImageData(0, 0, canvas.width, canvas.height);
+        var dest = texture.lock();
+        var red, alpha;
+        for (y = 0; y < source.height; ++y) {
+            for (x = 0; x < source.width; ++x) {
+                var offset = (x + y * texture.width) * 4;
 
-    this.words = words;
-    this.wordMap = wordMap;
-    this.placements = placements;
-    this.texture = texture;
+                // set .rgb white to allow shader to identify text
+                dest[offset] = 255;
+                dest[offset + 1] = 255;
+                dest[offset + 2] = 255;
 
-    // copy pixel data to target
-    var source = context.getImageData(0, 0, canvas.width, canvas.height);
-    var dest = texture.lock();
-    var red, alpha;
-    for (y = 0; y < source.height; ++y) {
-        for (x = 0; x < source.width; ++x) {
-            var offset = (x + y * texture.width) * 4;
+                // red red and alpha from image
+                red = source.data[(x + (source.height - 1 - y) * source.width) * 4];
+                alpha = source.data[(x + (source.height - 1 - y) * source.width) * 4 + 3];
 
-            // set .rgb white to allow shader to identify text
-            dest[offset] = 255;
-            dest[offset + 1] = 255;
-            dest[offset + 2] = 255;
-
-            // red red and alpha from image
-            red = source.data[(x + (source.height - 1 - y) * source.width) * 4];
-            alpha = source.data[(x + (source.height - 1 - y) * source.width) * 4 + 3];
-
-            // alpha contains greyscale letters, use red to make non-digits darker
-            dest[offset + 3] = alpha * (red > 150 ? 1 : 0.7);
+                // alpha contains greyscale letters, use red to make non-digits darker
+                dest[offset + 3] = alpha * (red > 150 ? 1 : 0.7);
+            }
         }
     }
-}
 
-Object.assign(WordAtlas.prototype, {
-    render: function (render2d, word, x, y) {
+    render(render2d, word, x, y) {
         var p = this.placements[this.wordMap[word]];
         if (p) {
             var padding = 1;
@@ -100,6 +100,6 @@ Object.assign(WordAtlas.prototype, {
         }
         return 0;
     }
-});
+}
 
 export { WordAtlas };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1443,6 +1443,28 @@
       "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
       "dev": true
     },
+    "babel-eslint": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.1.0.tgz",
+      "integrity": "sha512-ifWaTHQ0ce+448CYop8AdrQiBsGrnC+bMgfyKFdi6EsPLTAWG+QfyDeM6OH+FmWnKvEq5NnBMLvlBUPKQZoDSg==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@babel/parser": "^7.7.0",
+        "@babel/traverse": "^7.7.0",
+        "@babel/types": "^7.7.0",
+        "eslint-visitor-keys": "^1.0.0",
+        "resolve": "^1.12.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+          "dev": true
+        }
+      }
+    },
     "babel-plugin-dynamic-import-node": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz",
@@ -2909,6 +2931,15 @@
         "binary-extensions": "^2.0.0"
       }
     },
+    "is-core-module": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
+      "integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.3"
+      }
+    },
     "is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -2959,17 +2990,6 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
-    },
-    "js-cleanup": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/js-cleanup/-/js-cleanup-1.2.0.tgz",
-      "integrity": "sha512-JeDD0yiiSt80fXzAVa/crrS0JDPQljyBG/RpOtaSbyDq03VHa9szJWMaWOYU/bcTn412uMN2MxApXq8v79cUiQ==",
-      "dev": true,
-      "requires": {
-        "magic-string": "^0.25.7",
-        "perf-regexes": "^1.0.1",
-        "skip-regex": "^1.0.2"
-      }
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -3801,6 +3821,12 @@
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "dev": true
     },
+    "path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "dev": true
+    },
     "path-to-regexp": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
@@ -3822,12 +3848,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
       "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
-      "dev": true
-    },
-    "perf-regexes": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/perf-regexes/-/perf-regexes-1.0.1.tgz",
-      "integrity": "sha512-L7MXxUDtqr4PUaLFCDCXBfGV/6KLIuSEccizDI7JxT+c9x1G1v04BQ4+4oag84SHaCdrBgQAIs/Cqn+flwFPng==",
       "dev": true
     },
     "picomatch": {
@@ -4106,6 +4126,16 @@
         "lodash": "^4.17.14"
       }
     },
+    "resolve": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
+      "integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
+      "dev": true,
+      "requires": {
+        "is-core-module": "^2.1.0",
+        "path-parse": "^1.0.6"
+      }
+    },
     "resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -4134,33 +4164,6 @@
       "dev": true,
       "requires": {
         "fsevents": "~2.1.2"
-      }
-    },
-    "rollup-plugin-cleanup": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-cleanup/-/rollup-plugin-cleanup-3.2.1.tgz",
-      "integrity": "sha512-zuv8EhoO3TpnrU8MX8W7YxSbO4gmOR0ny06Lm3nkFfq0IVKdBUtHwhVzY1OAJyNCIAdLiyPnOrU0KnO0Fri1GQ==",
-      "dev": true,
-      "requires": {
-        "js-cleanup": "^1.2.0",
-        "rollup-pluginutils": "^2.8.2"
-      }
-    },
-    "rollup-pluginutils": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
-      "integrity": "sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==",
-      "dev": true,
-      "requires": {
-        "estree-walker": "^0.6.1"
-      },
-      "dependencies": {
-        "estree-walker": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
-          "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
-          "dev": true
-        }
       }
     },
     "safe-buffer": {
@@ -4260,12 +4263,6 @@
           }
         }
       }
-    },
-    "skip-regex": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/skip-regex/-/skip-regex-1.0.2.tgz",
-      "integrity": "sha512-pEjMUbwJ5Pl/6Vn6FsamXHXItJXSRftcibixDmNCWbWhic0hzHrwkMZo0IZ7fMRH9KxcWDFSkzhccB4285PutA==",
-      "dev": true
     },
     "slice-ansi": {
       "version": "4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,11 +13,356 @@
         "@babel/highlight": "^7.10.4"
       }
     },
+    "@babel/compat-data": {
+      "version": "7.12.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.12.7.tgz",
+      "integrity": "sha512-YaxPMGs/XIWtYqrdEOZOCPsVWfEoriXopnsz3/i7apYPXQ3698UFhS6dVT1KN5qOsWmVgw/FOrmQgpRaZayGsw==",
+      "dev": true
+    },
+    "@babel/core": {
+      "version": "7.12.10",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.12.10.tgz",
+      "integrity": "sha512-eTAlQKq65zHfkHZV0sIVODCPGVgoo1HdBlbSLi9CqOzuZanMv2ihzY+4paiKr1mH+XmYESMAmJ/dpZ68eN6d8w==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/generator": "^7.12.10",
+        "@babel/helper-module-transforms": "^7.12.1",
+        "@babel/helpers": "^7.12.5",
+        "@babel/parser": "^7.12.10",
+        "@babel/template": "^7.12.7",
+        "@babel/traverse": "^7.12.10",
+        "@babel/types": "^7.12.10",
+        "convert-source-map": "^1.7.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.1",
+        "json5": "^2.1.2",
+        "lodash": "^4.17.19",
+        "semver": "^5.4.1",
+        "source-map": "^0.5.0"
+      },
+      "dependencies": {
+        "@babel/parser": {
+          "version": "7.12.11",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.11.tgz",
+          "integrity": "sha512-N3UxG+uuF4CMYoNj8AhnbAcJF0PiuJ9KHuy1lQmkYsxTer/MAH9UBNHsBoAX/4s6NvlDD047No8mYVGGzLL4hg==",
+          "dev": true
+        },
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "lodash": {
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
+      }
+    },
+    "@babel/generator": {
+      "version": "7.12.11",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.11.tgz",
+      "integrity": "sha512-Ggg6WPOJtSi8yYQvLVjG8F/TlpWDlKx0OpS4Kt+xMQPs5OaGYWy+v1A+1TvxI6sAMGZpKWWoAQ1DaeQbImlItA==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.12.11",
+        "jsesc": "^2.5.1",
+        "source-map": "^0.5.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
+      }
+    },
+    "@babel/helper-annotate-as-pure": {
+      "version": "7.12.10",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.12.10.tgz",
+      "integrity": "sha512-XplmVbC1n+KY6jL8/fgLVXXUauDIB+lD5+GsQEh6F6GBF1dq1qy4DP4yXWzDKcoqXB3X58t61e85Fitoww4JVQ==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.12.10"
+      }
+    },
+    "@babel/helper-builder-binary-assignment-operator-visitor": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.10.4.tgz",
+      "integrity": "sha512-L0zGlFrGWZK4PbT8AszSfLTM5sDU1+Az/En9VrdT8/LmEiJt4zXt+Jve9DCAnQcbqDhCI+29y/L93mrDzddCcg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-explode-assignable-expression": "^7.10.4",
+        "@babel/types": "^7.10.4"
+      }
+    },
+    "@babel/helper-compilation-targets": {
+      "version": "7.12.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.12.5.tgz",
+      "integrity": "sha512-+qH6NrscMolUlzOYngSBMIOQpKUGPPsc61Bu5W10mg84LxZ7cmvnBHzARKbDoFxVvqqAbj6Tg6N7bSrWSPXMyw==",
+      "dev": true,
+      "requires": {
+        "@babel/compat-data": "^7.12.5",
+        "@babel/helper-validator-option": "^7.12.1",
+        "browserslist": "^4.14.5",
+        "semver": "^5.5.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/helper-create-class-features-plugin": {
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.12.1.tgz",
+      "integrity": "sha512-hkL++rWeta/OVOBTRJc9a5Azh5mt5WgZUGAKMD8JM141YsE08K//bp1unBBieO6rUKkIPyUE0USQ30jAy3Sk1w==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-function-name": "^7.10.4",
+        "@babel/helper-member-expression-to-functions": "^7.12.1",
+        "@babel/helper-optimise-call-expression": "^7.10.4",
+        "@babel/helper-replace-supers": "^7.12.1",
+        "@babel/helper-split-export-declaration": "^7.10.4"
+      }
+    },
+    "@babel/helper-create-regexp-features-plugin": {
+      "version": "7.12.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.12.7.tgz",
+      "integrity": "sha512-idnutvQPdpbduutvi3JVfEgcVIHooQnhvhx0Nk9isOINOIGYkZea1Pk2JlJRiUnMefrlvr0vkByATBY/mB4vjQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.10.4",
+        "regexpu-core": "^4.7.1"
+      }
+    },
+    "@babel/helper-define-map": {
+      "version": "7.10.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.10.5.tgz",
+      "integrity": "sha512-fMw4kgFB720aQFXSVaXr79pjjcW5puTCM16+rECJ/plGS+zByelE8l9nCpV1GibxTnFVmUuYG9U8wYfQHdzOEQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-function-name": "^7.10.4",
+        "@babel/types": "^7.10.5",
+        "lodash": "^4.17.19"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/helper-explode-assignable-expression": {
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.12.1.tgz",
+      "integrity": "sha512-dmUwH8XmlrUpVqgtZ737tK88v07l840z9j3OEhCLwKTkjlvKpfqXVIZ0wpK3aeOxspwGrf/5AP5qLx4rO3w5rA==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.12.1"
+      }
+    },
+    "@babel/helper-function-name": {
+      "version": "7.12.11",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.11.tgz",
+      "integrity": "sha512-AtQKjtYNolKNi6nNNVLQ27CP6D9oFR6bq/HPYSizlzbp7uC1M59XJe8L+0uXjbIaZaUJF99ruHqVGiKXU/7ybA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-get-function-arity": "^7.12.10",
+        "@babel/template": "^7.12.7",
+        "@babel/types": "^7.12.11"
+      }
+    },
+    "@babel/helper-get-function-arity": {
+      "version": "7.12.10",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.10.tgz",
+      "integrity": "sha512-mm0n5BPjR06wh9mPQaDdXWDoll/j5UpCAPl1x8fS71GHm7HA6Ua2V4ylG1Ju8lvcTOietbPNNPaSilKj+pj+Ag==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.12.10"
+      }
+    },
+    "@babel/helper-hoist-variables": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.10.4.tgz",
+      "integrity": "sha512-wljroF5PgCk2juF69kanHVs6vrLwIPNp6DLD+Lrl3hoQ3PpPPikaDRNFA+0t81NOoMt2DL6WW/mdU8k4k6ZzuA==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.10.4"
+      }
+    },
+    "@babel/helper-member-expression-to-functions": {
+      "version": "7.12.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.7.tgz",
+      "integrity": "sha512-DCsuPyeWxeHgh1Dus7APn7iza42i/qXqiFPWyBDdOFtvS581JQePsc1F/nD+fHrcswhLlRc2UpYS1NwERxZhHw==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.12.7"
+      }
+    },
+    "@babel/helper-module-imports": {
+      "version": "7.12.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.12.5.tgz",
+      "integrity": "sha512-SR713Ogqg6++uexFRORf/+nPXMmWIn80TALu0uaFb+iQIUoR7bOC7zBWyzBs5b3tBBJXuyD0cRu1F15GyzjOWA==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.12.5"
+      }
+    },
+    "@babel/helper-module-transforms": {
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.12.1.tgz",
+      "integrity": "sha512-QQzehgFAZ2bbISiCpmVGfiGux8YVFXQ0abBic2Envhej22DVXV9nCFaS5hIQbkyo1AdGb+gNME2TSh3hYJVV/w==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.12.1",
+        "@babel/helper-replace-supers": "^7.12.1",
+        "@babel/helper-simple-access": "^7.12.1",
+        "@babel/helper-split-export-declaration": "^7.11.0",
+        "@babel/helper-validator-identifier": "^7.10.4",
+        "@babel/template": "^7.10.4",
+        "@babel/traverse": "^7.12.1",
+        "@babel/types": "^7.12.1",
+        "lodash": "^4.17.19"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/helper-optimise-call-expression": {
+      "version": "7.12.10",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.10.tgz",
+      "integrity": "sha512-4tpbU0SrSTjjt65UMWSrUOPZTsgvPgGG4S8QSTNHacKzpS51IVWGDj0yCwyeZND/i+LSN2g/O63jEXEWm49sYQ==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.12.10"
+      }
+    },
+    "@babel/helper-plugin-utils": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
+      "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==",
+      "dev": true
+    },
+    "@babel/helper-remap-async-to-generator": {
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.12.1.tgz",
+      "integrity": "sha512-9d0KQCRM8clMPcDwo8SevNs+/9a8yWVVmaE80FGJcEP8N1qToREmWEGnBn8BUlJhYRFz6fqxeRL1sl5Ogsed7A==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.10.4",
+        "@babel/helper-wrap-function": "^7.10.4",
+        "@babel/types": "^7.12.1"
+      }
+    },
+    "@babel/helper-replace-supers": {
+      "version": "7.12.11",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.12.11.tgz",
+      "integrity": "sha512-q+w1cqmhL7R0FNzth/PLLp2N+scXEK/L2AHbXUyydxp828F4FEa5WcVoqui9vFRiHDQErj9Zof8azP32uGVTRA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-member-expression-to-functions": "^7.12.7",
+        "@babel/helper-optimise-call-expression": "^7.12.10",
+        "@babel/traverse": "^7.12.10",
+        "@babel/types": "^7.12.11"
+      }
+    },
+    "@babel/helper-simple-access": {
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.12.1.tgz",
+      "integrity": "sha512-OxBp7pMrjVewSSC8fXDFrHrBcJATOOFssZwv16F3/6Xtc138GHybBfPbm9kfiqQHKhYQrlamWILwlDCeyMFEaA==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.12.1"
+      }
+    },
+    "@babel/helper-skip-transparent-expression-wrappers": {
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.12.1.tgz",
+      "integrity": "sha512-Mf5AUuhG1/OCChOJ/HcADmvcHM42WJockombn8ATJG3OnyiSxBK/Mm5x78BQWvmtXZKHgbjdGL2kin/HOLlZGA==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.12.1"
+      }
+    },
+    "@babel/helper-split-export-declaration": {
+      "version": "7.12.11",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.11.tgz",
+      "integrity": "sha512-LsIVN8j48gHgwzfocYUSkO/hjYAOJqlpJEc7tGXcIm4cubjVUf8LGW6eWRyxEu7gA25q02p0rQUWoCI33HNS5g==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.12.11"
+      }
+    },
     "@babel/helper-validator-identifier": {
       "version": "7.12.11",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
       "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
       "dev": true
+    },
+    "@babel/helper-validator-option": {
+      "version": "7.12.11",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.12.11.tgz",
+      "integrity": "sha512-TBFCyj939mFSdeX7U7DDj32WtzYY7fDcalgq8v3fBZMNOJQNn7nOYzMaUCiPxPYfCup69mtIpqlKgMZLvQ8Xhw==",
+      "dev": true
+    },
+    "@babel/helper-wrap-function": {
+      "version": "7.12.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.12.3.tgz",
+      "integrity": "sha512-Cvb8IuJDln3rs6tzjW3Y8UeelAOdnpB8xtQ4sme2MSZ9wOxrbThporC0y/EtE16VAtoyEfLM404Xr1e0OOp+ow==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-function-name": "^7.10.4",
+        "@babel/template": "^7.10.4",
+        "@babel/traverse": "^7.10.4",
+        "@babel/types": "^7.10.4"
+      }
+    },
+    "@babel/helpers": {
+      "version": "7.12.5",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.12.5.tgz",
+      "integrity": "sha512-lgKGMQlKqA8meJqKsW6rUnc4MdUk35Ln0ATDqdM1a/UpARODdI4j5Y5lVfUScnSNkJcdCRAaWkspykNoFg9sJA==",
+      "dev": true,
+      "requires": {
+        "@babel/template": "^7.10.4",
+        "@babel/traverse": "^7.12.5",
+        "@babel/types": "^7.12.5"
+      }
     },
     "@babel/highlight": {
       "version": "7.10.4",
@@ -48,6 +393,762 @@
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.5.tgz",
       "integrity": "sha512-FVM6RZQ0mn2KCf1VUED7KepYeUWoVShczewOCfm3nzoBybaih51h+sYVVGthW9M6lPByEPTQf+xm27PBdlpwmQ==",
       "dev": true
+    },
+    "@babel/plugin-proposal-async-generator-functions": {
+      "version": "7.12.12",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.12.12.tgz",
+      "integrity": "sha512-nrz9y0a4xmUrRq51bYkWJIO5SBZyG2ys2qinHsN0zHDHVsUaModrkpyWWWXfGqYQmOL3x9sQIcTNN/pBGpo09A==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "@babel/helper-remap-async-to-generator": "^7.12.1",
+        "@babel/plugin-syntax-async-generators": "^7.8.0"
+      }
+    },
+    "@babel/plugin-proposal-class-properties": {
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.12.1.tgz",
+      "integrity": "sha512-cKp3dlQsFsEs5CWKnN7BnSHOd0EOW8EKpEjkoz1pO2E5KzIDNV9Ros1b0CnmbVgAGXJubOYVBOGCT1OmJwOI7w==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-create-class-features-plugin": "^7.12.1",
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-proposal-dynamic-import": {
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.12.1.tgz",
+      "integrity": "sha512-a4rhUSZFuq5W8/OO8H7BL5zspjnc1FLd9hlOxIK/f7qG4a0qsqk8uvF/ywgBA8/OmjsapjpvaEOYItfGG1qIvQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "@babel/plugin-syntax-dynamic-import": "^7.8.0"
+      }
+    },
+    "@babel/plugin-proposal-export-namespace-from": {
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-export-namespace-from/-/plugin-proposal-export-namespace-from-7.12.1.tgz",
+      "integrity": "sha512-6CThGf0irEkzujYS5LQcjBx8j/4aQGiVv7J9+2f7pGfxqyKh3WnmVJYW3hdrQjyksErMGBPQrCnHfOtna+WLbw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "@babel/plugin-syntax-export-namespace-from": "^7.8.3"
+      }
+    },
+    "@babel/plugin-proposal-json-strings": {
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.12.1.tgz",
+      "integrity": "sha512-GoLDUi6U9ZLzlSda2Df++VSqDJg3CG+dR0+iWsv6XRw1rEq+zwt4DirM9yrxW6XWaTpmai1cWJLMfM8qQJf+yw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "@babel/plugin-syntax-json-strings": "^7.8.0"
+      }
+    },
+    "@babel/plugin-proposal-logical-assignment-operators": {
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-logical-assignment-operators/-/plugin-proposal-logical-assignment-operators-7.12.1.tgz",
+      "integrity": "sha512-k8ZmVv0JU+4gcUGeCDZOGd0lCIamU/sMtIiX3UWnUc5yzgq6YUGyEolNYD+MLYKfSzgECPcqetVcJP9Afe/aCA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4"
+      }
+    },
+    "@babel/plugin-proposal-nullish-coalescing-operator": {
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.12.1.tgz",
+      "integrity": "sha512-nZY0ESiaQDI1y96+jk6VxMOaL4LPo/QDHBqL+SF3/vl6dHkTwHlOI8L4ZwuRBHgakRBw5zsVylel7QPbbGuYgg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0"
+      }
+    },
+    "@babel/plugin-proposal-numeric-separator": {
+      "version": "7.12.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.12.7.tgz",
+      "integrity": "sha512-8c+uy0qmnRTeukiGsjLGy6uVs/TFjJchGXUeBqlG4VWYOdJWkhhVPdQ3uHwbmalfJwv2JsV0qffXP4asRfL2SQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "@babel/plugin-syntax-numeric-separator": "^7.10.4"
+      }
+    },
+    "@babel/plugin-proposal-object-rest-spread": {
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.12.1.tgz",
+      "integrity": "sha512-s6SowJIjzlhx8o7lsFx5zmY4At6CTtDvgNQDdPzkBQucle58A6b/TTeEBYtyDgmcXjUTM+vE8YOGHZzzbc/ioA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "@babel/plugin-syntax-object-rest-spread": "^7.8.0",
+        "@babel/plugin-transform-parameters": "^7.12.1"
+      }
+    },
+    "@babel/plugin-proposal-optional-catch-binding": {
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.12.1.tgz",
+      "integrity": "sha512-hFvIjgprh9mMw5v42sJWLI1lzU5L2sznP805zeT6rySVRA0Y18StRhDqhSxlap0oVgItRsB6WSROp4YnJTJz0g==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.8.0"
+      }
+    },
+    "@babel/plugin-proposal-optional-chaining": {
+      "version": "7.12.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.12.7.tgz",
+      "integrity": "sha512-4ovylXZ0PWmwoOvhU2vhnzVNnm88/Sm9nx7V8BPgMvAzn5zDou3/Awy0EjglyubVHasJj+XCEkr/r1X3P5elCA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.12.1",
+        "@babel/plugin-syntax-optional-chaining": "^7.8.0"
+      }
+    },
+    "@babel/plugin-proposal-private-methods": {
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-methods/-/plugin-proposal-private-methods-7.12.1.tgz",
+      "integrity": "sha512-mwZ1phvH7/NHK6Kf8LP7MYDogGV+DKB1mryFOEwx5EBNQrosvIczzZFTUmWaeujd5xT6G1ELYWUz3CutMhjE1w==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-create-class-features-plugin": "^7.12.1",
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-proposal-unicode-property-regex": {
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.12.1.tgz",
+      "integrity": "sha512-MYq+l+PvHuw/rKUz1at/vb6nCnQ2gmJBNaM62z0OgH7B2W1D9pvkpYtlti9bGtizNIU1K3zm4bZF9F91efVY0w==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-create-regexp-features-plugin": "^7.12.1",
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-syntax-async-generators": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
+      "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-class-properties": {
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.1.tgz",
+      "integrity": "sha512-U40A76x5gTwmESz+qiqssqmeEsKvcSyvtgktrm0uzcARAmM9I1jR221f6Oq+GmHrcD+LvZDag1UTOTe2fL3TeA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-syntax-dynamic-import": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.8.3.tgz",
+      "integrity": "sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-export-namespace-from": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-export-namespace-from/-/plugin-syntax-export-namespace-from-7.8.3.tgz",
+      "integrity": "sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3"
+      }
+    },
+    "@babel/plugin-syntax-json-strings": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
+      "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-logical-assignment-operators": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
+      "integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-syntax-nullish-coalescing-operator": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
+      "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-numeric-separator": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
+      "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-syntax-object-rest-spread": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
+      "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-optional-catch-binding": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
+      "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-optional-chaining": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
+      "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-top-level-await": {
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.12.1.tgz",
+      "integrity": "sha512-i7ooMZFS+a/Om0crxZodrTzNEPJHZrlMVGMTEpFAj6rYY/bKCddB0Dk/YxfPuYXOopuhKk/e1jV6h+WUU9XN3A==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-transform-arrow-functions": {
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.12.1.tgz",
+      "integrity": "sha512-5QB50qyN44fzzz4/qxDPQMBCTHgxg3n0xRBLJUmBlLoU/sFvxVWGZF/ZUfMVDQuJUKXaBhbupxIzIfZ6Fwk/0A==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-transform-async-to-generator": {
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.12.1.tgz",
+      "integrity": "sha512-SDtqoEcarK1DFlRJ1hHRY5HvJUj5kX4qmtpMAm2QnhOlyuMC4TMdCRgW6WXpv93rZeYNeLP22y8Aq2dbcDRM1A==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.12.1",
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "@babel/helper-remap-async-to-generator": "^7.12.1"
+      }
+    },
+    "@babel/plugin-transform-block-scoped-functions": {
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.12.1.tgz",
+      "integrity": "sha512-5OpxfuYnSgPalRpo8EWGPzIYf0lHBWORCkj5M0oLBwHdlux9Ri36QqGW3/LR13RSVOAoUUMzoPI/jpE4ABcHoA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-transform-block-scoping": {
+      "version": "7.12.12",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.12.12.tgz",
+      "integrity": "sha512-VOEPQ/ExOVqbukuP7BYJtI5ZxxsmegTwzZ04j1aF0dkSypGo9XpDHuOrABsJu+ie+penpSJheDJ11x1BEZNiyQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-transform-classes": {
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.12.1.tgz",
+      "integrity": "sha512-/74xkA7bVdzQTBeSUhLLJgYIcxw/dpEpCdRDiHgPJ3Mv6uC11UhjpOhl72CgqbBCmt1qtssCyB2xnJm1+PFjog==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.10.4",
+        "@babel/helper-define-map": "^7.10.4",
+        "@babel/helper-function-name": "^7.10.4",
+        "@babel/helper-optimise-call-expression": "^7.10.4",
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "@babel/helper-replace-supers": "^7.12.1",
+        "@babel/helper-split-export-declaration": "^7.10.4",
+        "globals": "^11.1.0"
+      },
+      "dependencies": {
+        "globals": {
+          "version": "11.12.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+          "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/plugin-transform-computed-properties": {
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.12.1.tgz",
+      "integrity": "sha512-vVUOYpPWB7BkgUWPo4C44mUQHpTZXakEqFjbv8rQMg7TC6S6ZhGZ3otQcRH6u7+adSlE5i0sp63eMC/XGffrzg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-transform-destructuring": {
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.12.1.tgz",
+      "integrity": "sha512-fRMYFKuzi/rSiYb2uRLiUENJOKq4Gnl+6qOv5f8z0TZXg3llUwUhsNNwrwaT/6dUhJTzNpBr+CUvEWBtfNY1cw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-transform-dotall-regex": {
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.12.1.tgz",
+      "integrity": "sha512-B2pXeRKoLszfEW7J4Hg9LoFaWEbr/kzo3teWHmtFCszjRNa/b40f9mfeqZsIDLLt/FjwQ6pz/Gdlwy85xNckBA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-create-regexp-features-plugin": "^7.12.1",
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-transform-duplicate-keys": {
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.12.1.tgz",
+      "integrity": "sha512-iRght0T0HztAb/CazveUpUQrZY+aGKKaWXMJ4uf9YJtqxSUe09j3wteztCUDRHs+SRAL7yMuFqUsLoAKKzgXjw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-transform-exponentiation-operator": {
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.12.1.tgz",
+      "integrity": "sha512-7tqwy2bv48q+c1EHbXK0Zx3KXd2RVQp6OC7PbwFNt/dPTAV3Lu5sWtWuAj8owr5wqtWnqHfl2/mJlUmqkChKug==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-builder-binary-assignment-operator-visitor": "^7.10.4",
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-transform-for-of": {
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.12.1.tgz",
+      "integrity": "sha512-Zaeq10naAsuHo7heQvyV0ptj4dlZJwZgNAtBYBnu5nNKJoW62m0zKcIEyVECrUKErkUkg6ajMy4ZfnVZciSBhg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-transform-function-name": {
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.12.1.tgz",
+      "integrity": "sha512-JF3UgJUILoFrFMEnOJLJkRHSk6LUSXLmEFsA23aR2O5CSLUxbeUX1IZ1YQ7Sn0aXb601Ncwjx73a+FVqgcljVw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-function-name": "^7.10.4",
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-transform-literals": {
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.12.1.tgz",
+      "integrity": "sha512-+PxVGA+2Ag6uGgL0A5f+9rklOnnMccwEBzwYFL3EUaKuiyVnUipyXncFcfjSkbimLrODoqki1U9XxZzTvfN7IQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-transform-member-expression-literals": {
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.12.1.tgz",
+      "integrity": "sha512-1sxePl6z9ad0gFMB9KqmYofk34flq62aqMt9NqliS/7hPEpURUCMbyHXrMPlo282iY7nAvUB1aQd5mg79UD9Jg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-transform-modules-amd": {
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.12.1.tgz",
+      "integrity": "sha512-tDW8hMkzad5oDtzsB70HIQQRBiTKrhfgwC/KkJeGsaNFTdWhKNt/BiE8c5yj19XiGyrxpbkOfH87qkNg1YGlOQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-transforms": "^7.12.1",
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "babel-plugin-dynamic-import-node": "^2.3.3"
+      }
+    },
+    "@babel/plugin-transform-modules-commonjs": {
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.12.1.tgz",
+      "integrity": "sha512-dY789wq6l0uLY8py9c1B48V8mVL5gZh/+PQ5ZPrylPYsnAvnEMjqsUXkuoDVPeVK+0VyGar+D08107LzDQ6pag==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-transforms": "^7.12.1",
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "@babel/helper-simple-access": "^7.12.1",
+        "babel-plugin-dynamic-import-node": "^2.3.3"
+      }
+    },
+    "@babel/plugin-transform-modules-systemjs": {
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.12.1.tgz",
+      "integrity": "sha512-Hn7cVvOavVh8yvW6fLwveFqSnd7rbQN3zJvoPNyNaQSvgfKmDBO9U1YL9+PCXGRlZD9tNdWTy5ACKqMuzyn32Q==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-hoist-variables": "^7.10.4",
+        "@babel/helper-module-transforms": "^7.12.1",
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "@babel/helper-validator-identifier": "^7.10.4",
+        "babel-plugin-dynamic-import-node": "^2.3.3"
+      }
+    },
+    "@babel/plugin-transform-modules-umd": {
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.12.1.tgz",
+      "integrity": "sha512-aEIubCS0KHKM0zUos5fIoQm+AZUMt1ZvMpqz0/H5qAQ7vWylr9+PLYurT+Ic7ID/bKLd4q8hDovaG3Zch2uz5Q==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-transforms": "^7.12.1",
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-transform-named-capturing-groups-regex": {
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.12.1.tgz",
+      "integrity": "sha512-tB43uQ62RHcoDp9v2Nsf+dSM8sbNodbEicbQNA53zHz8pWUhsgHSJCGpt7daXxRydjb0KnfmB+ChXOv3oADp1Q==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-create-regexp-features-plugin": "^7.12.1"
+      }
+    },
+    "@babel/plugin-transform-new-target": {
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.12.1.tgz",
+      "integrity": "sha512-+eW/VLcUL5L9IvJH7rT1sT0CzkdUTvPrXC2PXTn/7z7tXLBuKvezYbGdxD5WMRoyvyaujOq2fWoKl869heKjhw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-transform-object-super": {
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.12.1.tgz",
+      "integrity": "sha512-AvypiGJH9hsquNUn+RXVcBdeE3KHPZexWRdimhuV59cSoOt5kFBmqlByorAeUlGG2CJWd0U+4ZtNKga/TB0cAw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "@babel/helper-replace-supers": "^7.12.1"
+      }
+    },
+    "@babel/plugin-transform-parameters": {
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.12.1.tgz",
+      "integrity": "sha512-xq9C5EQhdPK23ZeCdMxl8bbRnAgHFrw5EOC3KJUsSylZqdkCaFEXxGSBuTSObOpiiHHNyb82es8M1QYgfQGfNg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-transform-property-literals": {
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.12.1.tgz",
+      "integrity": "sha512-6MTCR/mZ1MQS+AwZLplX4cEySjCpnIF26ToWo942nqn8hXSm7McaHQNeGx/pt7suI1TWOWMfa/NgBhiqSnX0cQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-transform-regenerator": {
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.12.1.tgz",
+      "integrity": "sha512-gYrHqs5itw6i4PflFX3OdBPMQdPbF4bj2REIUxlMRUFk0/ZOAIpDFuViuxPjUL7YC8UPnf+XG7/utJvqXdPKng==",
+      "dev": true,
+      "requires": {
+        "regenerator-transform": "^0.14.2"
+      }
+    },
+    "@babel/plugin-transform-reserved-words": {
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.12.1.tgz",
+      "integrity": "sha512-pOnUfhyPKvZpVyBHhSBoX8vfA09b7r00Pmm1sH+29ae2hMTKVmSp4Ztsr8KBKjLjx17H0eJqaRC3bR2iThM54A==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-transform-shorthand-properties": {
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.12.1.tgz",
+      "integrity": "sha512-GFZS3c/MhX1OusqB1MZ1ct2xRzX5ppQh2JU1h2Pnfk88HtFTM+TWQqJNfwkmxtPQtb/s1tk87oENfXJlx7rSDw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-transform-spread": {
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.12.1.tgz",
+      "integrity": "sha512-vuLp8CP0BE18zVYjsEBZ5xoCecMK6LBMMxYzJnh01rxQRvhNhH1csMMmBfNo5tGpGO+NhdSNW2mzIvBu3K1fng==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.12.1"
+      }
+    },
+    "@babel/plugin-transform-sticky-regex": {
+      "version": "7.12.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.12.7.tgz",
+      "integrity": "sha512-VEiqZL5N/QvDbdjfYQBhruN0HYjSPjC4XkeqW4ny/jNtH9gcbgaqBIXYEZCNnESMAGs0/K/R7oFGMhOyu/eIxg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-transform-template-literals": {
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.12.1.tgz",
+      "integrity": "sha512-b4Zx3KHi+taXB1dVRBhVJtEPi9h1THCeKmae2qP0YdUHIFhVjtpqqNfxeVAa1xeHVhAy4SbHxEwx5cltAu5apw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-transform-typeof-symbol": {
+      "version": "7.12.10",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.12.10.tgz",
+      "integrity": "sha512-JQ6H8Rnsogh//ijxspCjc21YPd3VLVoYtAwv3zQmqAt8YGYUtdo5usNhdl4b9/Vir2kPFZl6n1h0PfUz4hJhaA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-transform-unicode-escapes": {
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.12.1.tgz",
+      "integrity": "sha512-I8gNHJLIc7GdApm7wkVnStWssPNbSRMPtgHdmH3sRM1zopz09UWPS4x5V4n1yz/MIWTVnJ9sp6IkuXdWM4w+2Q==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-transform-unicode-regex": {
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.12.1.tgz",
+      "integrity": "sha512-SqH4ClNngh/zGwHZOOQMTD+e8FGWexILV+ePMyiDJttAWRh5dhDL8rcl5lSgU3Huiq6Zn6pWTMvdPAb21Dwdyg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-create-regexp-features-plugin": "^7.12.1",
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/preset-env": {
+      "version": "7.12.11",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.12.11.tgz",
+      "integrity": "sha512-j8Tb+KKIXKYlDBQyIOy4BLxzv1NUOwlHfZ74rvW+Z0Gp4/cI2IMDPBWAgWceGcE7aep9oL/0K9mlzlMGxA8yNw==",
+      "dev": true,
+      "requires": {
+        "@babel/compat-data": "^7.12.7",
+        "@babel/helper-compilation-targets": "^7.12.5",
+        "@babel/helper-module-imports": "^7.12.5",
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "@babel/helper-validator-option": "^7.12.11",
+        "@babel/plugin-proposal-async-generator-functions": "^7.12.1",
+        "@babel/plugin-proposal-class-properties": "^7.12.1",
+        "@babel/plugin-proposal-dynamic-import": "^7.12.1",
+        "@babel/plugin-proposal-export-namespace-from": "^7.12.1",
+        "@babel/plugin-proposal-json-strings": "^7.12.1",
+        "@babel/plugin-proposal-logical-assignment-operators": "^7.12.1",
+        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.12.1",
+        "@babel/plugin-proposal-numeric-separator": "^7.12.7",
+        "@babel/plugin-proposal-object-rest-spread": "^7.12.1",
+        "@babel/plugin-proposal-optional-catch-binding": "^7.12.1",
+        "@babel/plugin-proposal-optional-chaining": "^7.12.7",
+        "@babel/plugin-proposal-private-methods": "^7.12.1",
+        "@babel/plugin-proposal-unicode-property-regex": "^7.12.1",
+        "@babel/plugin-syntax-async-generators": "^7.8.0",
+        "@babel/plugin-syntax-class-properties": "^7.12.1",
+        "@babel/plugin-syntax-dynamic-import": "^7.8.0",
+        "@babel/plugin-syntax-export-namespace-from": "^7.8.3",
+        "@babel/plugin-syntax-json-strings": "^7.8.0",
+        "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0",
+        "@babel/plugin-syntax-numeric-separator": "^7.10.4",
+        "@babel/plugin-syntax-object-rest-spread": "^7.8.0",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.8.0",
+        "@babel/plugin-syntax-optional-chaining": "^7.8.0",
+        "@babel/plugin-syntax-top-level-await": "^7.12.1",
+        "@babel/plugin-transform-arrow-functions": "^7.12.1",
+        "@babel/plugin-transform-async-to-generator": "^7.12.1",
+        "@babel/plugin-transform-block-scoped-functions": "^7.12.1",
+        "@babel/plugin-transform-block-scoping": "^7.12.11",
+        "@babel/plugin-transform-classes": "^7.12.1",
+        "@babel/plugin-transform-computed-properties": "^7.12.1",
+        "@babel/plugin-transform-destructuring": "^7.12.1",
+        "@babel/plugin-transform-dotall-regex": "^7.12.1",
+        "@babel/plugin-transform-duplicate-keys": "^7.12.1",
+        "@babel/plugin-transform-exponentiation-operator": "^7.12.1",
+        "@babel/plugin-transform-for-of": "^7.12.1",
+        "@babel/plugin-transform-function-name": "^7.12.1",
+        "@babel/plugin-transform-literals": "^7.12.1",
+        "@babel/plugin-transform-member-expression-literals": "^7.12.1",
+        "@babel/plugin-transform-modules-amd": "^7.12.1",
+        "@babel/plugin-transform-modules-commonjs": "^7.12.1",
+        "@babel/plugin-transform-modules-systemjs": "^7.12.1",
+        "@babel/plugin-transform-modules-umd": "^7.12.1",
+        "@babel/plugin-transform-named-capturing-groups-regex": "^7.12.1",
+        "@babel/plugin-transform-new-target": "^7.12.1",
+        "@babel/plugin-transform-object-super": "^7.12.1",
+        "@babel/plugin-transform-parameters": "^7.12.1",
+        "@babel/plugin-transform-property-literals": "^7.12.1",
+        "@babel/plugin-transform-regenerator": "^7.12.1",
+        "@babel/plugin-transform-reserved-words": "^7.12.1",
+        "@babel/plugin-transform-shorthand-properties": "^7.12.1",
+        "@babel/plugin-transform-spread": "^7.12.1",
+        "@babel/plugin-transform-sticky-regex": "^7.12.7",
+        "@babel/plugin-transform-template-literals": "^7.12.1",
+        "@babel/plugin-transform-typeof-symbol": "^7.12.10",
+        "@babel/plugin-transform-unicode-escapes": "^7.12.1",
+        "@babel/plugin-transform-unicode-regex": "^7.12.1",
+        "@babel/preset-modules": "^0.1.3",
+        "@babel/types": "^7.12.11",
+        "core-js-compat": "^3.8.0",
+        "semver": "^5.5.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/preset-modules": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.4.tgz",
+      "integrity": "sha512-J36NhwnfdzpmH41M1DrnkkgAqhZaqr/NBdPfQ677mLzlaXo+oDiv1deyCDtgAhz8p328otdob0Du7+xgHGZbKg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-proposal-unicode-property-regex": "^7.4.4",
+        "@babel/plugin-transform-dotall-regex": "^7.4.4",
+        "@babel/types": "^7.4.4",
+        "esutils": "^2.0.2"
+      }
+    },
+    "@babel/runtime": {
+      "version": "7.12.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
+      "integrity": "sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==",
+      "dev": true,
+      "requires": {
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
+    "@babel/template": {
+      "version": "7.12.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.7.tgz",
+      "integrity": "sha512-GkDzmHS6GV7ZeXfJZ0tLRBhZcMcY0/Lnb+eEbXDBfCAcZCjrZKe6p3J4we/D24O9Y8enxWAg1cWwof59yLh2ow==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/parser": "^7.12.7",
+        "@babel/types": "^7.12.7"
+      },
+      "dependencies": {
+        "@babel/parser": {
+          "version": "7.12.11",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.11.tgz",
+          "integrity": "sha512-N3UxG+uuF4CMYoNj8AhnbAcJF0PiuJ9KHuy1lQmkYsxTer/MAH9UBNHsBoAX/4s6NvlDD047No8mYVGGzLL4hg==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/traverse": {
+      "version": "7.12.12",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.12.tgz",
+      "integrity": "sha512-s88i0X0lPy45RrLM8b9mz8RPH5FqO9G9p7ti59cToE44xFm1Q+Pjh5Gq4SXBbtb88X7Uy7pexeqRIQDDMNkL0w==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.12.11",
+        "@babel/generator": "^7.12.11",
+        "@babel/helper-function-name": "^7.12.11",
+        "@babel/helper-split-export-declaration": "^7.12.11",
+        "@babel/parser": "^7.12.11",
+        "@babel/types": "^7.12.12",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0",
+        "lodash": "^4.17.19"
+      },
+      "dependencies": {
+        "@babel/parser": {
+          "version": "7.12.11",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.11.tgz",
+          "integrity": "sha512-N3UxG+uuF4CMYoNj8AhnbAcJF0PiuJ9KHuy1lQmkYsxTer/MAH9UBNHsBoAX/4s6NvlDD047No8mYVGGzLL4hg==",
+          "dev": true
+        },
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "globals": {
+          "version": "11.12.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+          "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+          "dev": true
+        },
+        "lodash": {
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/types": {
+      "version": "7.12.12",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.12.tgz",
+      "integrity": "sha512-lnIX7piTxOH22xE7fDXDbSHg9MM1/6ORnafpJmov5rs0kX5g4BZxeXNJLXsMRiO0U5Rb8/FvMS6xlTnTHvxonQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-validator-identifier": "^7.12.11",
+        "lodash": "^4.17.19",
+        "to-fast-properties": "^2.0.0"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
+        }
+      }
     },
     "@eslint/eslintrc": {
       "version": "0.2.2",
@@ -106,6 +1207,29 @@
       "dev": true,
       "requires": {
         "handlebars": "^4.7.6"
+      }
+    },
+    "@rollup/plugin-babel": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-5.2.2.tgz",
+      "integrity": "sha512-MjmH7GvFT4TW8xFdIeFS3wqIX646y5tACdxkTO+khbHvS3ZcVJL6vkAHLw2wqPmkhwCfWHoNsp15VYNwW6JEJA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.10.4",
+        "@rollup/pluginutils": "^3.1.0"
+      },
+      "dependencies": {
+        "@rollup/pluginutils": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+          "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+          "dev": true,
+          "requires": {
+            "@types/estree": "0.0.39",
+            "estree-walker": "^1.0.1",
+            "picomatch": "^2.2.2"
+          }
+        }
       }
     },
     "@rollup/plugin-replace": {
@@ -319,6 +1443,15 @@
       "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
       "dev": true
     },
+    "babel-plugin-dynamic-import-node": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz",
+      "integrity": "sha512-jZVI+s9Zg3IqA/kdi0i6UDCybUI3aSBLnglhYbSSjKlV7yF1F/5LWv8MakQmvYpnbJDS6fcBL2KzHSxNCMtWSQ==",
+      "dev": true,
+      "requires": {
+        "object.assign": "^4.1.0"
+      }
+    },
     "backo2": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
@@ -436,11 +1569,34 @@
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
     },
+    "browserslist": {
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.0.tgz",
+      "integrity": "sha512-/j6k8R0p3nxOC6kx5JGAxsnhc9ixaWJfYc+TNTzxg6+ARaESAvQGV7h0uNOB4t+pLQJZWzcrMxXOxjgsCj3dqQ==",
+      "dev": true,
+      "requires": {
+        "caniuse-lite": "^1.0.30001165",
+        "colorette": "^1.2.1",
+        "electron-to-chromium": "^1.3.621",
+        "escalade": "^3.1.1",
+        "node-releases": "^1.1.67"
+      }
+    },
     "bytes": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
       "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==",
       "dev": true
+    },
+    "call-bind": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.0.tgz",
+      "integrity": "sha512-AEXsYIyyDY3MCzbwdhzG3Jx1R0J2wetQyUynn6dYHAO+bg8l1k7jwZtRv4ryryFs7EP+NDlikJlVe59jr0cM2w==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.0"
+      }
     },
     "callsite": {
       "version": "1.0.0",
@@ -458,6 +1614,12 @@
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true
+    },
+    "caniuse-lite": {
+      "version": "1.0.30001170",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001170.tgz",
+      "integrity": "sha512-Dd4d/+0tsK0UNLrZs3CvNukqalnVTRrxb5mcQm8rHL49t7V5ZaTygwXkrq+FB+dVDf++4ri8eJnFEJAB8332PA==",
       "dev": true
     },
     "catharsis": {
@@ -636,6 +1798,12 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
+    "colorette": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.1.tgz",
+      "integrity": "sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw==",
+      "dev": true
+    },
     "colors": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.1.tgz",
@@ -701,11 +1869,38 @@
       "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
       "dev": true
     },
+    "convert-source-map": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
+      "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.1"
+      }
+    },
     "cookie": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
       "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
       "dev": true
+    },
+    "core-js-compat": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.8.1.tgz",
+      "integrity": "sha512-a16TLmy9NVD1rkjUGbwuyWkiDoN0FDpAwrfLONvHFQx0D9k7J9y0srwMT8QP/Z6HE3MIFaVynEeYwZwPX1o5RQ==",
+      "dev": true,
+      "requires": {
+        "browserslist": "^4.15.0",
+        "semver": "7.0.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
+          "integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==",
+          "dev": true
+        }
+      }
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -783,6 +1978,15 @@
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
+    "define-properties": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "dev": true,
+      "requires": {
+        "object-keys": "^1.0.12"
+      }
+    },
     "depd": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
@@ -846,6 +2050,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
+      "dev": true
+    },
+    "electron-to-chromium": {
+      "version": "1.3.633",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.633.tgz",
+      "integrity": "sha512-bsVCsONiVX1abkWdH7KtpuDAhsQ3N3bjPYhROSAXE78roJKet0Y5wznA14JE9pzbwSZmSMAW6KiKYf1RvbTJkA==",
       "dev": true
     },
     "emoji-regex": {
@@ -971,6 +2181,12 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.3.tgz",
       "integrity": "sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ==",
+      "dev": true
+    },
+    "escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
       "dev": true
     },
     "escape-html": {
@@ -1357,10 +2573,22 @@
       "dev": true,
       "optional": true
     },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
     "functional-red-black-tree": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
+    },
+    "gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
       "dev": true
     },
     "get-caller-file": {
@@ -1374,6 +2602,17 @@
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
       "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
       "dev": true
+    },
+    "get-intrinsic": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.0.2.tgz",
+      "integrity": "sha512-aeX0vrFm21ILl3+JpFFRNe9aUvp6VFZb2/CTbgLb8j75kOhvoNYjt9d8KA/tJG4gSo8nzEDedRl0h7vDmBYRVg==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1"
+      }
     },
     "glob": {
       "version": "7.1.6",
@@ -1502,6 +2741,15 @@
         }
       }
     },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
     "has-binary2": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has-binary2/-/has-binary2-1.0.3.tgz",
@@ -1529,6 +2777,12 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
+    "has-symbols": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
       "dev": true
     },
     "he": {
@@ -1784,6 +3038,12 @@
       "integrity": "sha512-UCQBZ3xCUBv/PLfwKAJhp6jmGOSLFNKzrotXGNgbKhWvz27wPsCsVeP7gIcHPElQw2agBmynAitXqhxR58XAmA==",
       "dev": true
     },
+    "jsesc": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "dev": true
+    },
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -1795,6 +3055,23 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
+    },
+    "json5": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
+      "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.5"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "dev": true
+        }
+      }
     },
     "jsonfile": {
       "version": "4.0.0",
@@ -2375,6 +3652,12 @@
         "path-to-regexp": "^1.7.0"
       }
     },
+    "node-releases": {
+      "version": "1.1.67",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.67.tgz",
+      "integrity": "sha512-V5QF9noGFl3EymEwUYzO+3NTDpGfQB4ve6Qfnzf3UNydMhjQRVPR1DZTuvWiLzaFJYw2fmDwAfnRNEVb64hSIg==",
+      "dev": true
+    },
     "normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -2386,6 +3669,24 @@
       "resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz",
       "integrity": "sha1-8MaapQ78lbhmwYb0AKM3acsvEpE=",
       "dev": true
+    },
+    "object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true
+    },
+    "object.assign": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+      "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3",
+        "has-symbols": "^1.0.1",
+        "object-keys": "^1.1.1"
+      }
     },
     "on-finished": {
       "version": "2.3.0",
@@ -2687,17 +3988,84 @@
         "picomatch": "^2.2.1"
       }
     },
+    "regenerate": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
+      "integrity": "sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==",
+      "dev": true
+    },
+    "regenerate-unicode-properties": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-8.2.0.tgz",
+      "integrity": "sha512-F9DjY1vKLo/tPePDycuH3dn9H1OTPIkVD9Kz4LODu+F2C75mgjAJ7x/gwy6ZcSNRAAkhNlJSOHRe8k3p+K9WhA==",
+      "dev": true,
+      "requires": {
+        "regenerate": "^1.4.0"
+      }
+    },
+    "regenerator-runtime": {
+      "version": "0.13.7",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
+      "dev": true
+    },
+    "regenerator-transform": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.14.5.tgz",
+      "integrity": "sha512-eOf6vka5IO151Jfsw2NO9WpGX58W6wWmefK3I1zEGr0lOD0u8rwPaNqQL1aRxUaxLeKO3ArNh3VYg1KbaD+FFw==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.8.4"
+      }
+    },
     "regexpp": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
       "integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
       "dev": true
     },
+    "regexpu-core": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.7.1.tgz",
+      "integrity": "sha512-ywH2VUraA44DZQuRKzARmw6S66mr48pQVva4LBeRhcOltJ6hExvWly5ZjFLYo67xbIxb6W1q4bAGtgfEl20zfQ==",
+      "dev": true,
+      "requires": {
+        "regenerate": "^1.4.0",
+        "regenerate-unicode-properties": "^8.2.0",
+        "regjsgen": "^0.5.1",
+        "regjsparser": "^0.6.4",
+        "unicode-match-property-ecmascript": "^1.0.4",
+        "unicode-match-property-value-ecmascript": "^1.2.0"
+      }
+    },
     "regextras": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/regextras/-/regextras-0.7.1.tgz",
       "integrity": "sha512-9YXf6xtW+qzQ+hcMQXx95MOvfqXFgsKDZodX3qZB0x2n5Z94ioetIITsBtvJbiOyxa/6s9AtyweBLCdPmPko/w==",
       "dev": true
+    },
+    "regjsgen": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.2.tgz",
+      "integrity": "sha512-OFFT3MfrH90xIW8OOSyUrk6QHD5E9JOTeGodiJeBS3J6IwlgzJMNE/1bZklWz5oTg+9dCMyEetclvCVXOPoN3A==",
+      "dev": true
+    },
+    "regjsparser": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.4.tgz",
+      "integrity": "sha512-64O87/dPDgfk8/RQqC4gkZoGyyWFIEUTTh80CU6CWuK5vkCGyekIx+oKcEIYtP/RAxSQltCZHCNu/mdd7fqlJw==",
+      "dev": true,
+      "requires": {
+        "jsesc": "~0.5.0"
+      },
+      "dependencies": {
+        "jsesc": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+          "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+          "dev": true
+        }
+      }
     },
     "remove-trailing-separator": {
       "version": "1.1.0",
@@ -3320,6 +4688,12 @@
       "integrity": "sha1-F+bBH3PdTz10zaek/zI46a2b+JA=",
       "dev": true
     },
+    "to-fast-properties": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+      "dev": true
+    },
     "to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -3411,6 +4785,34 @@
       "version": "1.10.2",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.10.2.tgz",
       "integrity": "sha512-N4P+Q/BuyuEKFJ43B9gYuOj4TQUHXX+j2FqguVOpjkssLUUrnJofCcBccJSCoeturDoZU6GorDTHSvUDlSQbTg==",
+      "dev": true
+    },
+    "unicode-canonical-property-names-ecmascript": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
+      "integrity": "sha512-jDrNnXWHd4oHiTZnx/ZG7gtUTVp+gCcTTKr8L0HjlwphROEW3+Him+IpvC+xcJEFegapiMZyZe02CyuOnRmbnQ==",
+      "dev": true
+    },
+    "unicode-match-property-ecmascript": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
+      "integrity": "sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==",
+      "dev": true,
+      "requires": {
+        "unicode-canonical-property-names-ecmascript": "^1.0.4",
+        "unicode-property-aliases-ecmascript": "^1.0.4"
+      }
+    },
+    "unicode-match-property-value-ecmascript": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.2.0.tgz",
+      "integrity": "sha512-wjuQHGQVofmSJv1uVISKLE5zO2rNGzM/KCYZch/QQvez7C1hUhBIuZ701fYXExuufJFMPhv2SyL8CyoIfMLbIQ==",
+      "dev": true
+    },
+    "unicode-property-aliases-ecmascript": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.1.0.tgz",
+      "integrity": "sha512-PqSoPh/pWetQ2phoj5RLiaqIk4kCNwoV3CI+LfGmWLKI3rE3kl1h59XpX2BjgDrmbxD9ARtQobPGU1SguCYuQg==",
       "dev": true
     },
     "union": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "url": "https://github.com/playcanvas/engine.git"
   },
   "eslintConfig": {
-    "extends": "@playcanvas/eslint-config"
+    "extends": "@playcanvas/eslint-config",
+    "parser": "babel-eslint"
   },
   "eslintIgnore": [
     "examples/lib/*",
@@ -42,6 +43,7 @@
     "@rollup/plugin-babel": "^5.2.2",
     "@rollup/plugin-replace": "^2.3.4",
     "@rollup/pluginutils": "^4.1.0",
+    "babel-eslint": "10.1.0",
     "chai": "^4.2.0",
     "eslint": "^7.16.0",
     "google-closure-compiler": "^20201207.0.0",

--- a/package.json
+++ b/package.json
@@ -34,8 +34,12 @@
     "src/polyfill/*"
   ],
   "devDependencies": {
+    "@babel/core": "^7.12.10",
+    "@babel/plugin-proposal-class-properties": "^7.12.1",
+    "@babel/preset-env": "^7.12.11",
     "@playcanvas/eslint-config": "^1.0.6",
     "@playcanvas/jsdoc-template": "^1.0.15",
+    "@rollup/plugin-babel": "^5.2.2",
     "@rollup/plugin-replace": "^2.3.4",
     "@rollup/pluginutils": "^4.1.0",
     "chai": "^4.2.0",
@@ -50,7 +54,6 @@
     "mocha": "^8.2.1",
     "preprocessor": "^1.4.0",
     "rollup": "^2.35.1",
-    "rollup-plugin-cleanup": "^3.2.1",
     "sinon": "^9.2.2",
     "tsd-jsdoc": "^2.5.0",
     "typescript": "^4.1.3",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   ],
   "license": "MIT",
   "main": "build/playcanvas.js",
+  "module": "build/playcanvas.mjs",
   "types": "index.d.ts",
   "bugs": {
     "url": "https://github.com/playcanvas/engine/issues"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -122,6 +122,7 @@ const moduleOptions = {
     presets: [
         [
             '@babel/preset-env', {
+                bugfixes: true,
                 loose: true,
                 modules: false,
                 targets: {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,6 +1,6 @@
+import babel from '@rollup/plugin-babel';
 import replace from '@rollup/plugin-replace';
 import { createFilter } from '@rollup/pluginutils';
-import cleanup from 'rollup-plugin-cleanup';
 import { version } from './package.json';
 import Preprocessor from 'preprocessor';
 
@@ -26,7 +26,7 @@ function spacesToTabs() {
         transform(code, id) {
             if (!filter(id)) return;
             return {
-                code: code.replace(/    /g, '\t'), // eslint-disable-line no-regex-spaces
+                code: code.replace(/  /g, '\t'), // eslint-disable-line no-regex-spaces
                 map: { mappings: '' }
             };
         }
@@ -87,6 +87,32 @@ function shaderChunks(removeComments) {
     };
 }
 
+const babelOptions = {
+    babelHelpers: 'bundled',
+    babelrc: false,
+    comments: false,
+    compact: false,
+    minified: false,
+    presets: [
+        [
+            '@babel/preset-env', {
+                loose: true,
+                modules: false,
+                targets: {
+                    "ie": "11"
+                }
+            }
+        ]
+    ],
+    plugins: [
+        [
+            '@babel/plugin-proposal-class-properties', {
+                loose: true
+            }
+        ]
+    ]
+};
+
 export default [{
     input: 'src/index.js',
     output: {
@@ -107,9 +133,7 @@ export default [{
             __REVISION__: revision,
             __CURRENT_SDK_VERSION__: version
         }),
-        cleanup({
-            comments: 'some'
-        }),
+        babel(babelOptions),
         spacesToTabs()
     ]
 }, {
@@ -132,9 +156,7 @@ export default [{
             __REVISION__: revision,
             __CURRENT_SDK_VERSION__: version
         }),
-        cleanup({
-            comments: 'some'
-        }),
+        babel(babelOptions),
         spacesToTabs()
     ]
 }, {
@@ -157,9 +179,7 @@ export default [{
             __REVISION__: revision,
             __CURRENT_SDK_VERSION__: version
         }),
-        cleanup({
-            comments: 'some'
-        }),
+        babel(babelOptions),
         spacesToTabs()
     ]
 }, {
@@ -172,9 +192,7 @@ export default [{
         name: 'pcx'
     },
     plugins: [
-        cleanup({
-            comments: 'some'
-        }),
+        babel(babelOptions),
         spacesToTabs()
     ]
 }];

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -87,7 +87,7 @@ function shaderChunks(removeComments) {
     };
 }
 
-const babelOptions = {
+const es5Options = {
     babelHelpers: 'bundled',
     babelrc: false,
     comments: false,
@@ -99,7 +99,33 @@ const babelOptions = {
                 loose: true,
                 modules: false,
                 targets: {
-                    "ie": "11"
+                    ie: "11"
+                }
+            }
+        ]
+    ],
+    plugins: [
+        [
+            '@babel/plugin-proposal-class-properties', {
+                loose: true
+            }
+        ]
+    ]
+};
+
+const moduleOptions = {
+    babelHelpers: 'bundled',
+    babelrc: false,
+    comments: false,
+    compact: false,
+    minified: false,
+    presets: [
+        [
+            '@babel/preset-env', {
+                loose: true,
+                modules: false,
+                targets: {
+                    esmodules: true
                 }
             }
         ]
@@ -133,7 +159,30 @@ export default [{
             __REVISION__: revision,
             __CURRENT_SDK_VERSION__: version
         }),
-        babel(babelOptions),
+        babel(es5Options),
+        spacesToTabs()
+    ]
+}, {
+    input: 'src/index.js',
+    output: {
+        banner: getBanner(''),
+        file: 'build/playcanvas.mjs',
+        format: 'es',
+        indent: '\t',
+        name: 'pc'
+    },
+    plugins: [
+        preprocessor({
+            PROFILER: false,
+            DEBUG: false,
+            RELEASE: true
+        }),
+        shaderChunks(true),
+        replace({
+            __REVISION__: revision,
+            __CURRENT_SDK_VERSION__: version
+        }),
+        babel(moduleOptions),
         spacesToTabs()
     ]
 }, {
@@ -156,7 +205,7 @@ export default [{
             __REVISION__: revision,
             __CURRENT_SDK_VERSION__: version
         }),
-        babel(babelOptions),
+        babel(es5Options),
         spacesToTabs()
     ]
 }, {
@@ -179,7 +228,7 @@ export default [{
             __REVISION__: revision,
             __CURRENT_SDK_VERSION__: version
         }),
-        babel(babelOptions),
+        babel(es5Options),
         spacesToTabs()
     ]
 }, {
@@ -192,7 +241,7 @@ export default [{
         name: 'pcx'
     },
     plugins: [
-        babel(babelOptions),
+        babel(es5Options),
         spacesToTabs()
     ]
 }];

--- a/src/bundles/bundle-registry.js
+++ b/src/bundles/bundle-registry.js
@@ -5,25 +5,25 @@
  * @param {pc.AssetRegistry} assets - The asset registry.
  * @classdesc Keeps track of which assets are in bundles and loads files from bundles.
  */
-function BundleRegistry(assets) {
-    this._assets = assets;
+class BundleRegistry {
+    constructor(assets) {
+        this._assets = assets;
 
-    // index of bundle assets
-    this._bundleAssets = {};
-    // index asset id to one more bundle assets
-    this._assetsInBundles = {};
-    // index file urls to one or more bundle assets
-    this._urlsInBundles = {};
-    // contains requests to load file URLs indexed by URL
-    this._fileRequests = {};
+        // index of bundle assets
+        this._bundleAssets = {};
+        // index asset id to one more bundle assets
+        this._assetsInBundles = {};
+        // index file urls to one or more bundle assets
+        this._urlsInBundles = {};
+        // contains requests to load file URLs indexed by URL
+        this._fileRequests = {};
 
-    this._assets.on('add', this._onAssetAdded, this);
-    this._assets.on('remove', this._onAssetRemoved, this);
-}
+        this._assets.on('add', this._onAssetAdded, this);
+        this._assets.on('remove', this._onAssetRemoved, this);
+    }
 
-Object.assign(BundleRegistry.prototype, {
     // Add asset in internal indexes
-    _onAssetAdded: function (asset) {
+    _onAssetAdded(asset) {
         // if this is a bundle asset then add it and
         // index its referenced assets
         if (asset.type === 'bundle') {
@@ -40,21 +40,21 @@ Object.assign(BundleRegistry.prototype, {
                 this._indexAssetFileUrls(asset);
             }
         }
-    },
+    }
 
-    _registerBundleEventListeners: function (bundleAssetId) {
+    _registerBundleEventListeners(bundleAssetId) {
         this._assets.on('load:' + bundleAssetId, this._onBundleLoaded, this);
         this._assets.on('error:' + bundleAssetId, this._onBundleError, this);
-    },
+    }
 
-    _unregisterBundleEventListeners: function (bundleAssetId) {
+    _unregisterBundleEventListeners(bundleAssetId) {
         this._assets.off('load:' + bundleAssetId, this._onBundleLoaded, this);
         this._assets.off('error:' + bundleAssetId, this._onBundleError, this);
-    },
+    }
 
     // Index the specified asset id and its file URLs so that
     // the registry knows that the asset is in that bundle
-    _indexAssetInBundle: function (assetId, bundleAsset) {
+    _indexAssetInBundle(assetId, bundleAsset) {
         if (! this._assetsInBundles[assetId]) {
             this._assetsInBundles[assetId] = [bundleAsset];
         } else {
@@ -69,10 +69,10 @@ Object.assign(BundleRegistry.prototype, {
         if (asset) {
             this._indexAssetFileUrls(asset);
         }
-    },
+    }
 
     // Index the file URLs of the specified asset
-    _indexAssetFileUrls: function (asset) {
+    _indexAssetFileUrls(asset) {
         var urls = this._getAssetFileUrls(asset);
         if (! urls) return;
 
@@ -85,10 +85,10 @@ Object.assign(BundleRegistry.prototype, {
             // be removed too.
             this._urlsInBundles[url] = this._assetsInBundles[asset.id];
         }
-    },
+    }
 
     // Get all the possible URLs of an asset
-    _getAssetFileUrls: function (asset) {
+    _getAssetFileUrls(asset) {
         var url = asset.getFileUrl();
         if (! url) return null;
 
@@ -105,15 +105,15 @@ Object.assign(BundleRegistry.prototype, {
         }
 
         return urls;
-    },
+    }
 
     // Removes query parameters from a URL
-    _normalizeUrl: function (url) {
+    _normalizeUrl(url) {
         return url && url.split('?')[0];
-    },
+    }
 
     // Remove asset from internal indexes
-    _onAssetRemoved: function (asset) {
+    _onAssetRemoved(asset) {
         if (asset.type === 'bundle') {
             // remove bundle from index
             delete this._bundleAssets[asset.id];
@@ -155,13 +155,12 @@ Object.assign(BundleRegistry.prototype, {
                 delete this._urlsInBundles[urls[i]];
             }
         }
-
-    },
+    }
 
     // If we have any pending file requests
     // that can be satisfied by the specified bundle
     // then resolve them
-    _onBundleLoaded: function (bundleAsset) {
+    _onBundleLoaded(bundleAsset) {
         // this can happen if the bundleAsset failed
         // to create its resource
         if (! bundleAsset.resource) {
@@ -200,14 +199,14 @@ Object.assign(BundleRegistry.prototype, {
                 delete this._fileRequests[url];
             }
         }.bind(this));
-    },
+    }
 
     // If we have outstanding file requests for any
     // of the URLs in the specified bundle then search for
     // other bundles that can satisfy these requests.
     // If we do not find any other bundles then fail
     // those pending file requests with the specified error.
-    _onBundleError: function (err, bundleAsset) {
+    _onBundleError(err, bundleAsset) {
         for (var url in this._fileRequests) {
             var bundle = this._findLoadedOrLoadingBundleForUrl(url);
             if (! bundle) {
@@ -220,11 +219,11 @@ Object.assign(BundleRegistry.prototype, {
 
             }
         }
-    },
+    }
 
     // Finds a bundle that contains the specified URL but
     // only returns the bundle if it's either loaded or being loaded
-    _findLoadedOrLoadingBundleForUrl: function (url) {
+    _findLoadedOrLoadingBundleForUrl(url) {
         var bundles = this._urlsInBundles[url];
         if (! bundles) return null;
 
@@ -247,7 +246,7 @@ Object.assign(BundleRegistry.prototype, {
         }
 
         return null;
-    },
+    }
 
     /**
      * @private
@@ -257,9 +256,9 @@ Object.assign(BundleRegistry.prototype, {
      * @param {pc.Asset} asset - The asset.
      * @returns {pc.Asset[]} An array of bundle assets or null if the asset is not in any bundle.
      */
-    listBundlesForAsset: function (asset) {
+    listBundlesForAsset(asset) {
         return this._assetsInBundles[asset.id] || null;
-    },
+    }
 
     /**
      * @private
@@ -268,14 +267,14 @@ Object.assign(BundleRegistry.prototype, {
      * @description Lists all of the available bundles. This includes bundles that are not loaded.
      * @returns {pc.Asset[]} An array of bundle assets.
      */
-    list: function () {
+    list() {
         var result = [];
         for (var id in this._bundleAssets) {
             result.push(this._bundleAssets[id]);
         }
 
         return result;
-    },
+    }
 
     /**
      * @private
@@ -285,9 +284,9 @@ Object.assign(BundleRegistry.prototype, {
      * @param {string} url - The url.
      * @returns {boolean} True or false.
      */
-    hasUrl: function (url) {
+    hasUrl(url) {
         return !!this._urlsInBundles[url];
-    },
+    }
 
     /**
      * @private
@@ -298,9 +297,9 @@ Object.assign(BundleRegistry.prototype, {
      * @param {string} url - The url.
      * @returns {boolean} True or false.
      */
-    canLoadUrl: function (url) {
+    canLoadUrl(url) {
         return !!this._findLoadedOrLoadingBundleForUrl(url);
-    },
+    }
 
     /**
      * @private
@@ -316,7 +315,7 @@ Object.assign(BundleRegistry.prototype, {
      *     // do something with the blob URL
      * });
      */
-    loadUrl: function (url, callback) {
+    loadUrl(url, callback) {
         var bundle = this._findLoadedOrLoadingBundleForUrl(url);
         if (! bundle) {
             callback('URL ' + url + ' not found in any bundles');
@@ -337,7 +336,7 @@ Object.assign(BundleRegistry.prototype, {
         } else {
             this._fileRequests[url] = [callback];
         }
-    },
+    }
 
     /**
      * @private
@@ -346,7 +345,7 @@ Object.assign(BundleRegistry.prototype, {
      * @description Destroys the registry, and releases its resources. Does not unload bundle assets
      * as these should be unloaded by the {@link pc.AssetRegistry}.
      */
-    destroy: function () {
+    destroy() {
         this._assets.off('add', this._onAssetAdded, this);
         this._assets.off('remove', this._onAssetRemoved, this);
 
@@ -360,6 +359,6 @@ Object.assign(BundleRegistry.prototype, {
         this._urlsInBundles = null;
         this._fileRequests = null;
     }
-});
+}
 
 export { BundleRegistry };

--- a/src/bundles/bundle.js
+++ b/src/bundles/bundle.js
@@ -5,52 +5,53 @@
  * @param {object[]} files - An array of objects that have a name field and contain a getBlobUrl() function.
  * @classdesc Represents the resource of a Bundle Asset, which contains an index that maps URLs to blob URLs.
  */
-function Bundle(files) {
-    this._blobUrls = {};
+class Bundle {
+    constructor(files) {
+        this._blobUrls = {};
 
-    for (var i = 0, len = files.length; i < len; i++) {
-        if (files[i].url) {
-            this._blobUrls[files[i].name] = files[i].url;
+        for (var i = 0, len = files.length; i < len; i++) {
+            if (files[i].url) {
+                this._blobUrls[files[i].name] = files[i].url;
+            }
         }
     }
-}
 
-/**
- * @private
- * @function
- * @name pc.Bundle#hasBlobUrl
- * @description Returns true if the specified URL exists in the loaded bundle.
- * @param {string} url - The original file URL. Make sure you have called decodeURIComponent on the URL first.
- * @returns {boolean} True of false.
- */
-Bundle.prototype.hasBlobUrl = function (url) {
-    return !!this._blobUrls[url];
-};
-
-/**
- * @private
- * @function
- * @name pc.Bundle#getBlobUrl
- * @description Returns a blob URL for the specified URL.
- * @param {string} url - The original file URL. Make sure you have called decodeURIComponent on the URL first.
- * @returns {string} A blob URL.
- */
-Bundle.prototype.getBlobUrl = function (url) {
-    return this._blobUrls[url];
-};
-
-
-/**
- * @private
- * @function
- * @name pc.Bundle#destroy
- * @description Destroys the bundle and frees up blob URLs.
- */
-Bundle.prototype.destroy = function () {
-    for (var key in this._blobUrls) {
-        URL.revokeObjectURL(this._blobUrls[key]);
+    /**
+     * @private
+     * @function
+     * @name pc.Bundle#hasBlobUrl
+     * @description Returns true if the specified URL exists in the loaded bundle.
+     * @param {string} url - The original file URL. Make sure you have called decodeURIComponent on the URL first.
+     * @returns {boolean} True of false.
+     */
+    hasBlobUrl(url) {
+        return !!this._blobUrls[url];
     }
-    this._blobUrls = null;
-};
+
+    /**
+     * @private
+     * @function
+     * @name pc.Bundle#getBlobUrl
+     * @description Returns a blob URL for the specified URL.
+     * @param {string} url - The original file URL. Make sure you have called decodeURIComponent on the URL first.
+     * @returns {string} A blob URL.
+     */
+    getBlobUrl(url) {
+        return this._blobUrls[url];
+    }
+
+    /**
+     * @private
+     * @function
+     * @name pc.Bundle#destroy
+     * @description Destroys the bundle and frees up blob URLs.
+     */
+    destroy() {
+        for (var key in this._blobUrls) {
+            URL.revokeObjectURL(this._blobUrls[key]);
+        }
+        this._blobUrls = null;
+    }
+}
 
 export { Bundle };

--- a/src/compress/decompress.js
+++ b/src/compress/decompress.js
@@ -4,20 +4,19 @@ import { CompressUtils } from './compress-utils';
  * @private
  * @class
  * @name pc.Decompress
- * @classdesc Reconstruct original object field names in a
- *   compressed scene
- * @param {object} node - The current node of the object being
- *   decompressed, initially the 'entities' field of a scene
+ * @classdesc Reconstruct original object field names in a compressed scene
+ * @param {object} node - The current node of the object being decompressed,
+ * initially the 'entities' field of a scene
  * @param {object} data - Compression metadata
  */
-function Decompress(node, data) {
-    this._node = node;
+class Decompress {
+    constructor(node, data) {
+        this._node = node;
 
-    this._data = data;
-}
+        this._data = data;
+    }
 
-Object.assign(Decompress.prototype, {
-    run: function () {
+    run() {
         var type = Object.prototype.toString.call(this._node);
 
         if (type === '[object Object]') {
@@ -31,17 +30,17 @@ Object.assign(Decompress.prototype, {
         }
 
         return this._result;
-    },
+    }
 
-    _handleMap: function () {
+    _handleMap() {
         this._result = {};
 
         var a = Object.keys(this._node);
 
         a.forEach(this._handleKey, this);
-    },
+    }
 
-    _handleKey: function (origKey) {
+    _handleKey(origKey) {
         var newKey = origKey;
 
         var len = origKey.length;
@@ -53,19 +52,19 @@ Object.assign(Decompress.prototype, {
         }
 
         this._result[newKey] = new Decompress(this._node[origKey], this._data).run();
-    },
+    }
 
-    _handleArray: function () {
+    _handleArray() {
         this._result = [];
 
         this._node.forEach(this._handleArElt, this);
-    },
+    }
 
-    _handleArElt: function (elt) {
+    _handleArElt(elt) {
         var v = new Decompress(elt, this._data).run();
 
         this._result.push(v);
     }
-});
+}
 
 export { Decompress };

--- a/src/core/color.js
+++ b/src/core/color.js
@@ -16,7 +16,7 @@ import { math } from '../math/math.js';
  */
 class Color {
     constructor(r = 0, g = 0, b = 0, a = 1) {
-        var length = r && r.length;
+        var length = r.length;
         if (length === 3 || length === 4) {
             this.r = r[0];
             this.g = r[1];

--- a/src/core/color.js
+++ b/src/core/color.js
@@ -88,11 +88,11 @@ class Color {
      * @param {number} [a] - The value for the alpha (0-1), defaults to 1.
      * @returns {pc.Color} Self for chaining.
      */
-    set(r, g, b, a) {
+    set(r, g, b, a = 1) {
         this.r = r;
         this.g = g;
         this.b = b;
-        this.a = (a === undefined) ? 1 : a;
+        this.a = a;
 
         return this;
     }

--- a/src/core/color.js
+++ b/src/core/color.js
@@ -14,31 +14,31 @@ import { math } from '../math/math.js';
  * @property {number} b The blue component of the color.
  * @property {number} a The alpha component of the color.
  */
-function Color(r, g, b, a) {
-    var length = r && r.length;
-    if (length === 3 || length === 4) {
-        this.r = r[0];
-        this.g = r[1];
-        this.b = r[2];
-        this.a = r[3] !== undefined ? r[3] : 1;
-    } else {
-        this.r = r || 0;
-        this.g = g || 0;
-        this.b = b || 0;
-        this.a = a !== undefined ? a : 1;
+class Color {
+    constructor(r = 0, g = 0, b = 0, a = 1) {
+        var length = r && r.length;
+        if (length === 3 || length === 4) {
+            this.r = r[0];
+            this.g = r[1];
+            this.b = r[2];
+            this.a = r[3] !== undefined ? r[3] : 1;
+        } else {
+            this.r = r;
+            this.g = g;
+            this.b = b;
+            this.a = a;
+        }
     }
-}
 
-Object.assign(Color.prototype, {
     /**
      * @function
      * @name pc.Color#clone
      * @description Returns a clone of the specified color.
      * @returns {pc.Color} A duplicate color object.
      */
-    clone: function () {
+    clone() {
         return new Color(this.r, this.g, this.b, this.a);
-    },
+    }
 
     /**
      * @function
@@ -54,14 +54,14 @@ Object.assign(Color.prototype, {
      *
      * console.log("The two colors are " + (dst.equals(src) ? "equal" : "different"));
      */
-    copy: function (rhs) {
+    copy(rhs) {
         this.r = rhs.r;
         this.g = rhs.g;
         this.b = rhs.b;
         this.a = rhs.a;
 
         return this;
-    },
+    }
 
     /**
      * @function
@@ -74,9 +74,9 @@ Object.assign(Color.prototype, {
      * var b = new pc.Color(1, 1, 0, 1);
      * console.log("The two colors are " + (a.equals(b) ? "equal" : "different"));
      */
-    equals: function (rhs) {
+    equals(rhs) {
         return this.r === rhs.r && this.g === rhs.g && this.b === rhs.b && this.a === rhs.a;
-    },
+    }
 
     /**
      * @function
@@ -88,15 +88,14 @@ Object.assign(Color.prototype, {
      * @param {number} [a] - The value for the alpha (0-1), defaults to 1.
      * @returns {pc.Color} Self for chaining.
      */
-    set: function (r, g, b, a) {
+    set(r, g, b, a) {
         this.r = r;
         this.g = g;
         this.b = b;
         this.a = (a === undefined) ? 1 : a;
 
         return this;
-    },
-
+    }
 
     /**
      * @function
@@ -117,14 +116,14 @@ Object.assign(Color.prototype, {
      * r.lerp(a, b, 0.5); // r is 0.5, 0.5, 0.25
      * r.lerp(a, b, 1);   // r is equal to b
      */
-    lerp: function (lhs, rhs, alpha) {
+    lerp(lhs, rhs, alpha) {
         this.r = lhs.r + alpha * (rhs.r - lhs.r);
         this.g = lhs.g + alpha * (rhs.g - lhs.g);
         this.b = lhs.b + alpha * (rhs.b - lhs.b);
         this.a = lhs.a + alpha * (rhs.a - lhs.a);
 
         return this;
-    },
+    }
 
     /**
      * @function
@@ -134,7 +133,7 @@ Object.assign(Color.prototype, {
      * This is the same format used in HTML/CSS.
      * @returns {pc.Color} Self for chaining.
      */
-    fromString: function (hex) {
+    fromString(hex) {
         var i = parseInt(hex.replace('#', '0x'), 16);
         var bytes;
         if (hex.length > 7) {
@@ -147,7 +146,7 @@ Object.assign(Color.prototype, {
         this.set(bytes[0] / 255, bytes[1] / 255, bytes[2] / 255, bytes[3] / 255);
 
         return this;
-    },
+    }
 
     /**
      * @function
@@ -162,7 +161,7 @@ Object.assign(Color.prototype, {
      * // Should output '#ffffffff'
      * console.log(c.toString());
      */
-    toString: function (alpha) {
+    toString(alpha) {
         var s = "#" + ((1 << 24) + (Math.round(this.r * 255) << 16) + (Math.round(this.g * 255) << 8) + Math.round(this.b * 255)).toString(16).slice(1);
         if (alpha === true) {
             var a = Math.round(this.a * 255).toString(16);
@@ -176,109 +175,96 @@ Object.assign(Color.prototype, {
 
         return s;
     }
-});
 
-/**
- * @field
- * @static
- * @readonly
- * @name pc.Color.BLACK
- * @type {pc.Color}
- * @description A constant color set to black [0, 0, 0, 1].
- */
+    /**
+     * @field
+     * @static
+     * @readonly
+     * @name pc.Color.BLACK
+     * @type {pc.Color}
+     * @description A constant color set to black [0, 0, 0, 1].
+     */
+    static BLACK = Object.freeze(new Color(0, 0, 0, 1));
 
-/**
- * @field
- * @static
- * @readonly
- * @name pc.Color.BLUE
- * @type {pc.Color}
- * @description A constant color set to blue [0, 0, 1, 1].
- */
+    /**
+     * @field
+     * @static
+     * @readonly
+     * @name pc.Color.BLUE
+     * @type {pc.Color}
+     * @description A constant color set to blue [0, 0, 1, 1].
+     */
+    static BLUE = Object.freeze(new Color(0, 0, 1, 1));
 
-/**
- * @field
- * @static
- * @readonly
- * @name pc.Color.CYAN
- * @type {pc.Color}
- * @description A constant color set to cyan [0, 1, 1, 1].
- */
+    /**
+     * @field
+     * @static
+     * @readonly
+     * @name pc.Color.CYAN
+     * @type {pc.Color}
+     * @description A constant color set to cyan [0, 1, 1, 1].
+     */
+    static CYAN = Object.freeze(new Color(0, 1, 1, 1));
 
-/**
- * @field
- * @static
- * @readonly
- * @name pc.Color.GRAY
- * @type {pc.Color}
- * @description A constant color set to gray [0.5, 0.5, 0.5, 1].
- */
+    /**
+     * @field
+     * @static
+     * @readonly
+     * @name pc.Color.GRAY
+     * @type {pc.Color}
+     * @description A constant color set to gray [0.5, 0.5, 0.5, 1].
+     */
+    static GRAY = Object.freeze(new Color(0.5, 0.5, 0.5, 1));
 
-/**
- * @field
- * @static
- * @readonly
- * @name pc.Color.GREEN
- * @type {pc.Color}
- * @description A constant color set to green [0, 1, 0, 1].
- */
+    /**
+     * @field
+     * @static
+     * @readonly
+     * @name pc.Color.GREEN
+     * @type {pc.Color}
+     * @description A constant color set to green [0, 1, 0, 1].
+     */
+    static GREEN = Object.freeze(new Color(0, 1, 0, 1));
 
-/**
- * @field
- * @static
- * @readonly
- * @name pc.Color.MAGENTA
- * @type {pc.Color}
- * @description A constant color set to magenta [1, 0, 1, 1].
- */
+    /**
+     * @field
+     * @static
+     * @readonly
+     * @name pc.Color.MAGENTA
+     * @type {pc.Color}
+     * @description A constant color set to magenta [1, 0, 1, 1].
+     */
+    static MAGENTA = Object.freeze(new Color(1, 0, 1, 1));
 
-/**
- * @field
- * @static
- * @readonly
- * @name pc.Color.RED
- * @type {pc.Color}
- * @description A constant color set to red [1, 0, 0, 1].
- */
+    /**
+     * @field
+     * @static
+     * @readonly
+     * @name pc.Color.RED
+     * @type {pc.Color}
+     * @description A constant color set to red [1, 0, 0, 1].
+     */
+    static RED = Object.freeze(new Color(1, 0, 0, 1));
 
-/**
- * @field
- * @static
- * @readonly
- * @name pc.Color.WHITE
- * @type {pc.Color}
- * @description A constant color set to white [1, 1, 1, 1].
- */
+    /**
+     * @field
+     * @static
+     * @readonly
+     * @name pc.Color.WHITE
+     * @type {pc.Color}
+     * @description A constant color set to white [1, 1, 1, 1].
+     */
+    static WHITE = Object.freeze(new Color(1, 1, 1, 1));
 
-/**
- * @field
- * @static
- * @readonly
- * @name pc.Color.YELLOW
- * @type {pc.Color}
- * @description A constant color set to yellow [1, 1, 0, 1].
- */
-
-Object.defineProperties(Color, {
-    BLACK: { value: new Color(0, 0, 0, 1) },
-    WHITE: { value: new Color(1, 1, 1, 1) },
-    YELLOW: { value: new Color(1, 1, 0, 1) },
-    RED: { value: new Color(1, 0, 0, 1) },
-    MAGENTA: { value: new Color(1, 0, 1, 1) },
-    GREEN: { value: new Color(0, 1, 0, 1) },
-    GRAY: { value: new Color(0.5, 0.5, 0.5, 1) },
-    CYAN: { value: new Color(0, 1, 1, 1) },
-    BLUE: { value: new Color(0, 0, 1, 1) }
-});
-
-Object.freeze(Color.BLACK);
-Object.freeze(Color.WHITE);
-Object.freeze(Color.YELLOW);
-Object.freeze(Color.RED);
-Object.freeze(Color.MAGENTA);
-Object.freeze(Color.GREEN);
-Object.freeze(Color.GRAY);
-Object.freeze(Color.CYAN);
-Object.freeze(Color.BLUE);
+    /**
+     * @field
+     * @static
+     * @readonly
+     * @name pc.Color.YELLOW
+     * @type {pc.Color}
+     * @description A constant color set to yellow [1, 1, 0, 1].
+     */
+    static YELLOW = Object.freeze(new Color(1, 1, 0, 1));
+}
 
 export { Color };

--- a/src/core/indexed-list.js
+++ b/src/core/indexed-list.js
@@ -4,12 +4,12 @@
  * @name pc.IndexedList
  * @classdesc A ordered list-type data structure that can provide item look up by key, but also return return a list.\.
  */
-function IndexedList() {
-    this._list = [];
-    this._index = {};
-}
+class IndexedList {
+    constructor() {
+        this._list = [];
+        this._index = {};
+    }
 
-Object.assign(IndexedList.prototype, {
     /**
      * @private
      * @function
@@ -18,13 +18,13 @@ Object.assign(IndexedList.prototype, {
      * @param {string} key -  Key used to look up item in index.
      * @param {object} item - Item to be stored.
      */
-    push: function (key, item) {
+    push(key, item) {
         if (this._index[key]) {
             throw Error("Key already in index " + key);
         }
         var location = this._list.push(item) - 1;
         this._index[key] = location;
-    },
+    }
 
     /**
      * @private
@@ -34,9 +34,9 @@ Object.assign(IndexedList.prototype, {
      * @param {string} key - The key to test.
      * @returns {boolean} Returns true if key is in the index, false if not.
      */
-    has: function (key) {
+    has(key) {
         return this._index[key] !== undefined;
-    },
+    }
 
     /**
      * @private
@@ -46,13 +46,13 @@ Object.assign(IndexedList.prototype, {
      * @param {string} key - The key of the item to retrieve.
      * @returns {object} The item stored at key.
      */
-    get: function (key) {
+    get(key) {
         var location = this._index[key];
         if (location !== undefined) {
             return this._list[location];
         }
         return null;
-    },
+    }
 
     /**
      * @private
@@ -62,7 +62,7 @@ Object.assign(IndexedList.prototype, {
      * @param {string} key - The key at which to remove the item.
      * @returns {boolean} Returns true if the key exists and an item was removed, returns false if no item was removed.
      */
-    remove: function (key) {
+    remove(key) {
         var location = this._index[key];
         if (location !== undefined) {
             this._list.splice(location, 1);
@@ -79,7 +79,7 @@ Object.assign(IndexedList.prototype, {
         }
 
         return false;
-    },
+    }
 
     /**
      * @private
@@ -88,9 +88,9 @@ Object.assign(IndexedList.prototype, {
      * @description Returns the list of items.
      * @returns {object[]} The list of items.
      */
-    list: function () {
+    list() {
         return this._list;
-    },
+    }
 
     /**
      * @private
@@ -98,13 +98,13 @@ Object.assign(IndexedList.prototype, {
      * @name pc.IndexedList#clear
      * @description Remove all items from the list.
      */
-    clear: function () {
+    clear() {
         this._list.length = 0;
 
         for (var prop in this._index) {
             delete this._index[prop];
         }
     }
-});
+}
 
 export { IndexedList };

--- a/src/core/object-pool.js
+++ b/src/core/object-pool.js
@@ -1,30 +1,30 @@
-function AllocatePool(constructor, size) {
-    this._constructor = constructor;
-    this._pool = [];
-    this._count = 0;
+class AllocatePool {
+    constructor(constructorFunc, size) {
+        this._constructor = constructorFunc;
+        this._pool = [];
+        this._count = 0;
 
-    this._resize(size);
-}
+        this._resize(size);
+    }
 
-Object.assign(AllocatePool.prototype, {
-    _resize: function (size) {
+    _resize(size) {
         if (size > this._pool.length) {
             for (var i = this._pool.length; i < size; i++) {
                 this._pool[i] = new this._constructor();
             }
         }
-    },
+    }
 
-    allocate: function () {
+    allocate() {
         if (this._count >= this._pool.length) {
             this._resize(this._pool.length * 2);
         }
         return this._pool[this._count++];
-    },
+    }
 
-    freeAll: function () {
+    freeAll() {
         this._count = 0;
     }
-});
+}
 
 export { AllocatePool };

--- a/src/core/time.js
+++ b/src/core/time.js
@@ -16,23 +16,23 @@ var now = (typeof window !== 'undefined') && window.performance && window.perfor
  * @description Create a new Timer instance.
  * @classdesc A Timer counts milliseconds from when start() is called until when stop() is called.
  */
-function Timer() {
-    this._isRunning = false;
-    this._a = 0;
-    this._b = 0;
-}
+class Timer {
+    constructor() {
+        this._isRunning = false;
+        this._a = 0;
+        this._b = 0;
+    }
 
-Object.assign(Timer.prototype, {
     /**
      * @private
      * @function
      * @name pc.Timer#start
      * @description Start the timer.
      */
-    start: function () {
+    start() {
         this._isRunning = true;
         this._a = now();
-    },
+    }
 
     /**
      * @private
@@ -40,10 +40,10 @@ Object.assign(Timer.prototype, {
      * @name pc.Timer#stop
      * @description Stop the timer.
      */
-    stop: function () {
+    stop() {
         this._isRunning = false;
         this._b = now();
-    },
+    }
 
     /**
      * @private
@@ -52,9 +52,9 @@ Object.assign(Timer.prototype, {
      * @description Get the number of milliseconds that passed between start() and stop() being called.
      * @returns {number} The elapsed milliseconds.
      */
-    getMilliseconds: function () {
+    getMilliseconds() {
         return this._b - this._a;
     }
-});
+}
 
 export { now, Timer };

--- a/src/math/constants.js
+++ b/src/math/constants.js
@@ -4,14 +4,14 @@
  * @name pc.CURVE_LINEAR
  * @description A linear interpolation scheme.
  */
-export var CURVE_LINEAR = 0;
+export const CURVE_LINEAR = 0;
 /**
  * @constant
  * @type {number}
  * @name pc.CURVE_SMOOTHSTEP
  * @description A smooth step interpolation scheme.
  */
-export var CURVE_SMOOTHSTEP = 1;
+export const CURVE_SMOOTHSTEP = 1;
 /**
  * @deprecated
  * @constant
@@ -19,7 +19,7 @@ export var CURVE_SMOOTHSTEP = 1;
  * @name pc.CURVE_CATMULL
  * @description A Catmull-Rom spline interpolation scheme. This interpolation scheme is deprecated. Use CURVE_SPLINE instead.
  */
-export var CURVE_CATMULL = 2;
+export const CURVE_CATMULL = 2;
 /**
  * @deprecated
  * @constant
@@ -27,18 +27,18 @@ export var CURVE_CATMULL = 2;
  * @name pc.CURVE_CARDINAL
  * @description A cardinal spline interpolation scheme. This interpolation scheme is deprecated. Use CURVE_SPLINE instead.
  */
-export var CURVE_CARDINAL = 3;
+export const CURVE_CARDINAL = 3;
 /**
  * @constant
  * @type {number}
  * @name pc.CURVE_SPLINE
  * @description Cardinal spline interpolation scheme. For Catmull-Rom, specify curve tension 0.5.
  */
-export var CURVE_SPLINE = 4;
+export const CURVE_SPLINE = 4;
 /**
  * @constant
  * @type {number}
  * @name pc.CURVE_STEP
  * @description A stepped interpolator, free from the shackles of blending.
  */
-export var CURVE_STEP = 5;
+export const CURVE_STEP = 5;

--- a/src/math/curve-evaluator.js
+++ b/src/math/curve-evaluator.js
@@ -1,23 +1,22 @@
 import { CURVE_CARDINAL, CURVE_CATMULL, CURVE_LINEAR, CURVE_SMOOTHSTEP, CURVE_SPLINE, CURVE_STEP } from './constants.js';
 import { math } from './math.js';
 
-function CurveEvaluator(curve, time) {
-    this._curve = curve;
-    this._left = -Infinity;
-    this._right = Infinity;
-    this._recip = 0;
-    this._p0 = 0;
-    this._p1 = 0;
-    this._m0 = 0;
-    this._m1 = 0;
-    this._reset(time || 0);
-}
-
-Object.assign(CurveEvaluator.prototype, {
+class CurveEvaluator {
+    constructor(curve, time) {
+        this._curve = curve;
+        this._left = -Infinity;
+        this._right = Infinity;
+        this._recip = 0;
+        this._p0 = 0;
+        this._p1 = 0;
+        this._m0 = 0;
+        this._m1 = 0;
+        this._reset(time || 0);
+    }
 
     // Evaluate the curve at the given time. Specify forceReset if the
     // underlying curve keys have changed since the last evaluation.
-    evaluate: function (time, forceReset) {
+    evaluate(time, forceReset) {
         if (forceReset || time < this._left || time >= this._right) {
             this._reset(time);
         }
@@ -44,10 +43,10 @@ Object.assign(CurveEvaluator.prototype, {
             }
         }
         return result;
-    },
+    }
 
     // Calculate weights for the curve interval at the given time
-    _reset: function (time) {
+    _reset(time) {
         var keys = this._curve.keys;
         var len = keys.length;
 
@@ -93,17 +92,17 @@ Object.assign(CurveEvaluator.prototype, {
                 }
             }
         }
-    },
+    }
 
     // returns true if the curve is a hermite and false otherwise
-    _isHermite: function () {
+    _isHermite() {
         return this._curve.type === CURVE_CATMULL ||
                this._curve.type === CURVE_CARDINAL ||
                this._curve.type === CURVE_SPLINE;
-    },
+    }
 
     // calculate tangents for the hermite curve
-    _calcTangents: function (keys, index) {
+    _calcTangents(keys, index) {
         var a;
         var b = keys[index];
         var c = keys[index + 1];
@@ -143,9 +142,9 @@ Object.assign(CurveEvaluator.prototype, {
             this._m0 = tension * (c[1] - a_);
             this._m1 = tension * (d_ - b[1]);
         }
-    },
+    }
 
-    _evaluateHermite: function (p0, p1, m0, m1, t) {
+    _evaluateHermite(p0, p1, m0, m1, t) {
         var t2 = t * t;
         var twot = t + t;
         var omt = 1 - t;
@@ -155,6 +154,6 @@ Object.assign(CurveEvaluator.prototype, {
                p1 * (t2 * (3 - twot)) +
                m1 * (t2 * (t - 1));
     }
-});
+}
 
 export { CurveEvaluator };

--- a/src/math/curve-set.js
+++ b/src/math/curve-set.js
@@ -76,9 +76,8 @@ class CurveSet {
      * to return the result.
      * @returns {number[]} The interpolated curve values at the specified time.
      */
-    value(time, result) {
+    value(time, result = []) {
         var length = this.curves.length;
-        result = result || [];
         result.length = length;
 
         for (var i = 0; i < length; i++) {

--- a/src/math/curve-set.js
+++ b/src/math/curve-set.js
@@ -25,35 +25,35 @@ import { CurveEvaluator } from './curve-evaluator.js';
  *     ]
  * ]);
  */
-function CurveSet() {
-    var i;
+class CurveSet {
+    constructor() {
+        var i;
 
-    this.curves = [];
-    this._type = CURVE_SMOOTHSTEP;
+        this.curves = [];
+        this._type = CURVE_SMOOTHSTEP;
 
-    if (arguments.length > 1) {
-        for (i = 0; i < arguments.length; i++) {
-            this.curves.push(new Curve(arguments[i]));
-        }
-    } else {
-        if (arguments.length === 0) {
-            this.curves.push(new Curve());
+        if (arguments.length > 1) {
+            for (i = 0; i < arguments.length; i++) {
+                this.curves.push(new Curve(arguments[i]));
+            }
         } else {
-            var arg = arguments[0];
-            if (typeof arg === 'number') {
-                for (i = 0; i < arg; i++) {
-                    this.curves.push(new Curve());
-                }
+            if (arguments.length === 0) {
+                this.curves.push(new Curve());
             } else {
-                for (i = 0; i < arg.length; i++) {
-                    this.curves.push(new Curve(arg[i]));
+                var arg = arguments[0];
+                if (typeof arg === 'number') {
+                    for (i = 0; i < arg; i++) {
+                        this.curves.push(new Curve());
+                    }
+                } else {
+                    for (i = 0; i < arg.length; i++) {
+                        this.curves.push(new Curve(arg[i]));
+                    }
                 }
             }
         }
     }
-}
 
-Object.assign(CurveSet.prototype, {
     /**
      * @function
      * @name pc.CurveSet#get
@@ -61,9 +61,9 @@ Object.assign(CurveSet.prototype, {
      * @param {number} index - The index of the curve to return.
      * @returns {pc.Curve} The curve at the specified index.
      */
-    get: function (index) {
+    get(index) {
         return this.curves[index];
-    },
+    }
 
     /**
      * @function
@@ -76,7 +76,7 @@ Object.assign(CurveSet.prototype, {
      * to return the result.
      * @returns {number[]} The interpolated curve values at the specified time.
      */
-    value: function (time, result) {
+    value(time, result) {
         var length = this.curves.length;
         result = result || [];
         result.length = length;
@@ -86,7 +86,7 @@ Object.assign(CurveSet.prototype, {
         }
 
         return result;
-    },
+    }
 
     /**
      * @function
@@ -94,7 +94,7 @@ Object.assign(CurveSet.prototype, {
      * @description Returns a clone of the specified curve set object.
      * @returns {pc.CurveSet} A clone of the specified curve set.
      */
-    clone: function () {
+    clone() {
         var result = new CurveSet();
 
         result.curves = [];
@@ -105,9 +105,9 @@ Object.assign(CurveSet.prototype, {
         result._type = this._type;
 
         return result;
-    },
+    }
 
-    quantize: function (precision) {
+    quantize(precision) {
         precision = Math.max(precision, 2);
 
         var numCurves = this.curves.length;
@@ -122,7 +122,7 @@ Object.assign(CurveSet.prototype, {
         }
 
         return values;
-    },
+    }
 
     /**
      * @private
@@ -135,50 +135,46 @@ Object.assign(CurveSet.prototype, {
      * @param {number} max - The maximum output value.
      * @returns {number[]} The set of quantized values.
      */
-    quantizeClamped: function (precision, min, max) {
+    quantizeClamped(precision, min, max) {
         var result = this.quantize(precision);
         for (var i = 0; i < result.length; ++i) {
             result[i] = Math.min(max, Math.max(min, result[i]));
         }
         return result;
     }
-});
 
-/**
- * @readonly
- * @name pc.CurveSet#length
- * @type {number}
- * @description The number of curves in the curve set.
- */
-Object.defineProperty(CurveSet.prototype, 'length', {
-    get: function () {
+    /**
+     * @readonly
+     * @name pc.CurveSet#length
+     * @type {number}
+     * @description The number of curves in the curve set.
+     */
+    get length() {
         return this.curves.length;
     }
-});
 
-/**
- * @name pc.CurveSet#type
- * @type {number}
- * @description The interpolation scheme applied to all curves in the curve set. Can be:
- *
- * * {@link pc.CURVE_LINEAR}
- * * {@link pc.CURVE_SMOOTHSTEP}
- * * {@link pc.CURVE_SPLINE}
- * * {@link pc.CURVE_STEP}
- *
- * Defaults to {@link pc.CURVE_SMOOTHSTEP}.
- */
-Object.defineProperty(CurveSet.prototype, 'type', {
-    get: function () {
+    /**
+     * @name pc.CurveSet#type
+     * @type {number}
+     * @description The interpolation scheme applied to all curves in the curve set. Can be:
+     *
+     * * {@link pc.CURVE_LINEAR}
+     * * {@link pc.CURVE_SMOOTHSTEP}
+     * * {@link pc.CURVE_SPLINE}
+     * * {@link pc.CURVE_STEP}
+     *
+     * Defaults to {@link pc.CURVE_SMOOTHSTEP}.
+     */
+    get type() {
         return this._type;
-    },
+    }
 
-    set: function (value) {
+    set type(value) {
         this._type = value;
         for (var i = 0; i < this.curves.length; i++) {
             this.curves[i].type = value;
         }
     }
-});
+}
 
 export { CurveSet };

--- a/src/math/curve.js
+++ b/src/math/curve.js
@@ -32,22 +32,22 @@ import { CurveEvaluator } from './curve-evaluator.js';
  *     [1, 3]
  * ]);
  */
-function Curve(data) {
-    this.keys = [];
-    this.type = CURVE_SMOOTHSTEP;
-    this.tension = 0.5;                     // used for CURVE_SPLINE
-    this._eval = new CurveEvaluator(this);
+class Curve {
+    constructor(data) {
+        this.keys = [];
+        this.type = CURVE_SMOOTHSTEP;
+        this.tension = 0.5;                     // used for CURVE_SPLINE
+        this._eval = new CurveEvaluator(this);
 
-    if (data) {
-        for (var i = 0; i < data.length - 1; i += 2) {
-            this.keys.push([data[i], data[i + 1]]);
+        if (data) {
+            for (var i = 0; i < data.length - 1; i += 2) {
+                this.keys.push([data[i], data[i + 1]]);
+            }
         }
+
+        this.sort();
     }
 
-    this.sort();
-}
-
-Object.assign(Curve.prototype, {
     /**
      * @function
      * @name pc.Curve#add
@@ -56,7 +56,7 @@ Object.assign(Curve.prototype, {
      * @param {number} value - Value of new key.
      * @returns {number[]} [time, value] pair.
      */
-    add: function (time, value) {
+    add(time, value) {
         var keys = this.keys;
         var len = keys.length;
         var i = 0;
@@ -70,7 +70,7 @@ Object.assign(Curve.prototype, {
         var key = [time, value];
         this.keys.splice(i, 0, key);
         return key;
-    },
+    }
 
     /**
      * @function
@@ -79,20 +79,20 @@ Object.assign(Curve.prototype, {
      * @param {number} index - The index of the key to return.
      * @returns {number[]} The key at the specified index.
      */
-    get: function (index) {
+    get(index) {
         return this.keys[index];
-    },
+    }
 
     /**
      * @function
      * @name pc.Curve#sort
      * @description Sort keys by time.
      */
-    sort: function () {
+    sort() {
         this.keys.sort(function (a, b) {
             return a[0] - b[0];
         });
-    },
+    }
 
     /**
      * @function
@@ -101,13 +101,13 @@ Object.assign(Curve.prototype, {
      * @param {number} time - The time at which to calculate the value.
      * @returns {number} The interpolated value.
      */
-    value: function (time) {
+    value(time) {
         // we for the evaluation because keys may have changed since the last evaluate
         // (we can't know)
         return this._eval.evaluate(time, true);
-    },
+    }
 
-    closest: function (time) {
+    closest(time) {
         var keys = this.keys;
         var length = keys.length;
         var min = 2;
@@ -124,7 +124,7 @@ Object.assign(Curve.prototype, {
         }
 
         return result;
-    },
+    }
 
     /**
      * @function
@@ -132,13 +132,13 @@ Object.assign(Curve.prototype, {
      * @description Returns a clone of the specified curve object.
      * @returns {pc.Curve} A clone of the specified curve.
      */
-    clone: function () {
+    clone() {
         var result = new Curve();
         result.keys = extend(result.keys, this.keys);
         result.type = this.type;
         result.tension = this.tension;
         return result;
-    },
+    }
 
     /**
      * @private
@@ -148,7 +148,7 @@ Object.assign(Curve.prototype, {
      * @param {number} precision - The number of samples to return.
      * @returns {Float32Array} The set of quantized values.
      */
-    quantize: function (precision) {
+    quantize(precision) {
         precision = Math.max(precision, 2);
 
         var values = new Float32Array(precision);
@@ -161,7 +161,7 @@ Object.assign(Curve.prototype, {
         }
 
         return values;
-    },
+    }
 
     /**
      * @private
@@ -174,19 +174,17 @@ Object.assign(Curve.prototype, {
      * @param {number} max - The maximum output value.
      * @returns {Float32Array} The set of quantized values.
      */
-    quantizeClamped: function (precision, min, max) {
+    quantizeClamped(precision, min, max) {
         var result = this.quantize(precision);
         for (var i = 0; i < result.length; ++i) {
             result[i] = Math.min(max, Math.max(min, result[i]));
         }
         return result;
     }
-});
 
-Object.defineProperty(Curve.prototype, 'length', {
-    get: function () {
+    get length() {
         return this.keys.length;
     }
-});
+}
 
 export { Curve };

--- a/src/math/mat3.js
+++ b/src/math/mat3.js
@@ -209,6 +209,7 @@ class Mat3 {
      * @description A constant matrix set to the identity.
      */
     static IDENTITY = Object.freeze(new Mat3());
+
     /**
      * @field
      * @static

--- a/src/math/mat3.js
+++ b/src/math/mat3.js
@@ -5,16 +5,16 @@
  * @description Creates a new identity Mat3 object.
  * @property {Float32Array} data Matrix elements in the form of a flat array.
  */
-function Mat3() {
-    var data;
-    // Create an identity matrix. Note that a new Float32Array has all elements set
-    // to zero by default, so we only need to set the relevant elements to one.
-    data = new Float32Array(9);
-    data[0] = data[4] = data[8] = 1;
-    this.data = data;
-}
+class Mat3 {
+    constructor() {
+        var data;
+        // Create an identity matrix. Note that a new Float32Array has all elements set
+        // to zero by default, so we only need to set the relevant elements to one.
+        data = new Float32Array(9);
+        data[0] = data[4] = data[8] = 1;
+        this.data = data;
+    }
 
-Object.assign(Mat3.prototype, {
     /**
      * @function
      * @name pc.Mat3#clone
@@ -25,9 +25,9 @@ Object.assign(Mat3.prototype, {
      * var dst = src.clone();
      * console.log("The two matrices are " + (src.equals(dst) ? "equal" : "different"));
      */
-    clone: function () {
+    clone() {
         return new Mat3().copy(this);
-    },
+    }
 
     /**
      * @function
@@ -41,7 +41,7 @@ Object.assign(Mat3.prototype, {
      * dst.copy(src);
      * console.log("The two matrices are " + (src.equals(dst) ? "equal" : "different"));
      */
-    copy: function (rhs) {
+    copy(rhs) {
         var src = rhs.data;
         var dst = this.data;
 
@@ -56,7 +56,7 @@ Object.assign(Mat3.prototype, {
         dst[8] = src[8];
 
         return this;
-    },
+    }
 
     /**
      * @function
@@ -68,7 +68,7 @@ Object.assign(Mat3.prototype, {
      * var dst = new pc.Mat3();
      * dst.set([0, 1, 2, 3, 4, 5, 6, 7, 8]);
      */
-    set: function (src) {
+    set(src) {
         var dst = this.data;
 
         dst[0] = src[0];
@@ -82,7 +82,7 @@ Object.assign(Mat3.prototype, {
         dst[8] = src[8];
 
         return this;
-    },
+    }
 
     /**
      * @function
@@ -95,7 +95,7 @@ Object.assign(Mat3.prototype, {
      * var b = new pc.Mat3();
      * console.log("The two matrices are " + (a.equals(b) ? "equal" : "different"));
      */
-    equals: function (rhs) {
+    equals(rhs) {
         var l = this.data;
         var r = rhs.data;
 
@@ -108,7 +108,7 @@ Object.assign(Mat3.prototype, {
                 (l[6] === r[6]) &&
                 (l[7] === r[7]) &&
                 (l[8] === r[8]));
-    },
+    }
 
     /**
      * @function
@@ -119,7 +119,7 @@ Object.assign(Mat3.prototype, {
      * var m = new pc.Mat3();
      * console.log("The matrix is " + (m.isIdentity() ? "identity" : "not identity"));
      */
-    isIdentity: function () {
+    isIdentity() {
         var m = this.data;
         return ((m[0] === 1) &&
                 (m[1] === 0) &&
@@ -130,7 +130,7 @@ Object.assign(Mat3.prototype, {
                 (m[6] === 0) &&
                 (m[7] === 0) &&
                 (m[8] === 1));
-    },
+    }
 
     /**
      * @function
@@ -141,7 +141,7 @@ Object.assign(Mat3.prototype, {
      * m.setIdentity();
      * console.log("The matrix is " + (m.isIdentity() ? "identity" : "not identity"));
      */
-    setIdentity: function () {
+    setIdentity() {
         var m = this.data;
         m[0] = 1;
         m[1] = 0;
@@ -156,7 +156,7 @@ Object.assign(Mat3.prototype, {
         m[8] = 1;
 
         return this;
-    },
+    }
 
     /**
      * @function
@@ -168,7 +168,7 @@ Object.assign(Mat3.prototype, {
      * // Should output '[1, 0, 0, 0, 1, 0, 0, 0, 1]'
      * console.log(m.toString());
      */
-    toString: function () {
+    toString() {
         var t = '[';
         for (var i = 0; i < 9; i++) {
             t += this.data[i];
@@ -176,7 +176,7 @@ Object.assign(Mat3.prototype, {
         }
         t += ']';
         return t;
-    },
+    }
 
     /**
      * @function
@@ -189,7 +189,7 @@ Object.assign(Mat3.prototype, {
      * // Transpose in place
      * m.transpose();
      */
-    transpose: function () {
+    transpose() {
         var m = this.data;
 
         var tmp;
@@ -199,32 +199,25 @@ Object.assign(Mat3.prototype, {
 
         return this;
     }
-});
 
-/**
- * @field
- * @static
- * @readonly
- * @name pc.Mat3.IDENTITY
- * @type {pc.Mat3}
- * @description A constant matrix set to the identity.
- */
-
-/**
- * @field
- * @static
- * @readonly
- * @name pc.Mat3.ZERO
- * @type {pc.Mat3}
- * @description A constant matrix with all elements set to 0.
- */
-
-Object.defineProperties(Mat3, {
-    ZERO: { value: new Mat3().set([0, 0, 0, 0, 0, 0, 0, 0, 0]) },
-    IDENTITY: { value: new Mat3() }
-});
-
-Object.freeze(Mat3.ZERO);
-Object.freeze(Mat3.IDENTITY);
+    /**
+     * @field
+     * @static
+     * @readonly
+     * @name pc.Mat3.IDENTITY
+     * @type {pc.Mat3}
+     * @description A constant matrix set to the identity.
+     */
+    static IDENTITY = Object.freeze(new Mat3());
+    /**
+     * @field
+     * @static
+     * @readonly
+     * @name pc.Mat3.ZERO
+     * @type {pc.Mat3}
+     * @description A constant matrix with all elements set to 0.
+     */
+    static ZERO = Object.freeze(new Mat3().set([0, 0, 0, 0, 0, 0, 0, 0, 0]));
+}
 
 export { Mat3 };

--- a/src/math/mat4.js
+++ b/src/math/mat4.js
@@ -395,7 +395,7 @@ class Mat4 {
      *
      * var tv = m.transformPoint(v);
      */
-    transformPoint(vec, res) {
+    transformPoint(vec, res = new Vec3()) {
         var x, y, z, m;
 
         m = this.data;
@@ -403,8 +403,6 @@ class Mat4 {
         x = vec.x;
         y = vec.y;
         z = vec.z;
-
-        res = (res === undefined) ? new Vec3() : res;
 
         res.x = x * m[0] + y * m[4] + z * m[8] + m[12];
         res.y = x * m[1] + y * m[5] + z * m[9] + m[13];
@@ -429,7 +427,7 @@ class Mat4 {
      *
      * var tv = m.transformVector(v);
      */
-    transformVector(vec, res) {
+    transformVector(vec, res = new Vec3()) {
         var x, y, z, m;
 
         m = this.data;
@@ -437,8 +435,6 @@ class Mat4 {
         x = vec.x;
         y = vec.y;
         z = vec.z;
-
-        res = (res === undefined) ? new Vec3() : res;
 
         res.x = x * m[0] + y * m[4] + z * m[8];
         res.y = x * m[1] + y * m[5] + z * m[9];
@@ -466,7 +462,7 @@ class Mat4 {
      *
      * m.transformVec4(v, result);
      */
-    transformVec4(vec, res) {
+    transformVec4(vec, res = new Vec4()) {
         var x, y, z, w, m;
 
         m = this.data;
@@ -475,8 +471,6 @@ class Mat4 {
         y = vec.y;
         z = vec.z;
         w = vec.w;
-
-        res = (res === undefined) ? new Vec4() : res;
 
         res.x = x * m[0] + y * m[4] + z * m[8] + w * m[12];
         res.y = x * m[1] + y * m[5] + z * m[9] + w * m[13];
@@ -1073,9 +1067,7 @@ class Mat4 {
      * var t = new pc.Vec3();
      * m.getTranslation(t);
      */
-    getTranslation(t) {
-        t = (t === undefined) ? new Vec3() : t;
-
+    getTranslation(t = new Vec3()) {
         return t.set(this.data[12], this.data[13], this.data[14]);
     }
 
@@ -1093,9 +1085,7 @@ class Mat4 {
      * var x = new pc.Vec3();
      * m.getX(x);
      */
-    getX(x) {
-        x = (x === undefined) ? new Vec3() : x;
-
+    getX(x = new Vec3()) {
         return x.set(this.data[0], this.data[1], this.data[2]);
     }
 
@@ -1113,9 +1103,7 @@ class Mat4 {
      * var y = new pc.Vec3();
      * m.getY(y);
      */
-    getY(y) {
-        y = (y === undefined) ? new Vec3() : y;
-
+    getY(y = new Vec3()) {
         return y.set(this.data[4], this.data[5], this.data[6]);
     }
 
@@ -1133,9 +1121,7 @@ class Mat4 {
      * var z = new pc.Vec3();
      * m.getZ(z);
      */
-    getZ(z) {
-        z = (z === undefined) ? new Vec3() : z;
-
+    getZ(z = new Vec3()) {
         return z.set(this.data[8], this.data[9], this.data[10]);
     }
 
@@ -1152,9 +1138,7 @@ class Mat4 {
      * // Query the scale component
      * var scale = m.getScale();
      */
-    getScale(scale) {
-        scale = (scale === undefined) ? new Vec3() : scale;
-
+    getScale(scale = new Vec3()) {
         this.getX(x);
         this.getY(y);
         this.getZ(z);
@@ -1233,10 +1217,8 @@ class Mat4 {
      *
      * var eulers = m.getEulerAngles();
      */
-    getEulerAngles(eulers) {
+    getEulerAngles(eulers = new Vec3()) {
         var x, y, z, sx, sy, sz, m, halfPi;
-
-        eulers = (eulers === undefined) ? new Vec3() : eulers;
 
         this.getScale(scale);
         sx = scale.x;

--- a/src/math/mat4.js
+++ b/src/math/mat4.js
@@ -4,6 +4,11 @@ import { Vec3 } from './vec3.js';
 import { Vec4 } from './vec4.js';
 
 var _halfSize = new Vec2();
+var x = new Vec3();
+var y = new Vec3();
+var z = new Vec3();
+var scale = new Vec3();
+
 
 /**
  * @class
@@ -12,26 +17,26 @@ var _halfSize = new Vec2();
  * @description Creates a new identity Mat4 object.
  * @property {Float32Array} data Matrix elements in the form of a flat array.
  */
-function Mat4() {
-    var data = new Float32Array(16);
-    // Create an identity matrix. Note that a new Float32Array has all elements set
-    // to zero by default, so we only need to set the relevant elements to one.
-    data[0] = data[5] = data[10] = data[15] = 1;
-    this.data = data;
-}
-
-// Static function which evaluates perspective projection matrix half size at the near plane
-Mat4._getPerspectiveHalfSize = function (halfSize, fov, aspect, znear, fovIsHorizontal) {
-    if (fovIsHorizontal) {
-        halfSize.x = znear * Math.tan(fov * Math.PI / 360);
-        halfSize.y = halfSize.x / aspect;
-    } else {
-        halfSize.y = znear * Math.tan(fov * Math.PI / 360);
-        halfSize.x = halfSize.y * aspect;
+class Mat4 {
+    constructor() {
+        var data = new Float32Array(16);
+        // Create an identity matrix. Note that a new Float32Array has all elements set
+        // to zero by default, so we only need to set the relevant elements to one.
+        data[0] = data[5] = data[10] = data[15] = 1;
+        this.data = data;
     }
-};
 
-Object.assign(Mat4.prototype, {
+    // Static function which evaluates perspective projection matrix half size at the near plane
+    static _getPerspectiveHalfSize(halfSize, fov, aspect, znear, fovIsHorizontal) {
+        if (fovIsHorizontal) {
+            halfSize.x = znear * Math.tan(fov * Math.PI / 360);
+            halfSize.y = halfSize.x / aspect;
+        } else {
+            halfSize.y = znear * Math.tan(fov * Math.PI / 360);
+            halfSize.x = halfSize.y * aspect;
+        }
+    }
+
     /**
      * @function
      * @name pc.Mat4#add2
@@ -47,7 +52,7 @@ Object.assign(Mat4.prototype, {
      *
      * console.log("The result of the addition is: " + m.toString());
      */
-    add2: function (lhs, rhs) {
+    add2(lhs, rhs) {
         var a = lhs.data,
             b = rhs.data,
             r = this.data;
@@ -70,7 +75,7 @@ Object.assign(Mat4.prototype, {
         r[15] = a[15] + b[15];
 
         return this;
-    },
+    }
 
     /**
      * @function
@@ -85,9 +90,9 @@ Object.assign(Mat4.prototype, {
      *
      * console.log("The result of the addition is: " + m.toString());
      */
-    add: function (rhs) {
+    add(rhs) {
         return this.add2(this, rhs);
-    },
+    }
 
     /**
      * @function
@@ -99,9 +104,9 @@ Object.assign(Mat4.prototype, {
      * var dst = src.clone();
      * console.log("The two matrices are " + (src.equals(dst) ? "equal" : "different"));
      */
-    clone: function () {
+    clone() {
         return new Mat4().copy(this);
-    },
+    }
 
     /**
      * @function
@@ -115,7 +120,7 @@ Object.assign(Mat4.prototype, {
      * dst.copy(src);
      * console.log("The two matrices are " + (src.equals(dst) ? "equal" : "different"));
      */
-    copy: function (rhs) {
+    copy(rhs) {
         var src = rhs.data,
             dst = this.data;
 
@@ -137,7 +142,7 @@ Object.assign(Mat4.prototype, {
         dst[15] = src[15];
 
         return this;
-    },
+    }
 
     /**
      * @function
@@ -150,7 +155,7 @@ Object.assign(Mat4.prototype, {
      * var b = new pc.Mat4();
      * console.log("The two matrices are " + (a.equals(b) ? "equal" : "different"));
      */
-    equals: function (rhs) {
+    equals(rhs) {
         var l = this.data,
             r = rhs.data;
 
@@ -170,7 +175,7 @@ Object.assign(Mat4.prototype, {
                 (l[13] === r[13]) &&
                 (l[14] === r[14]) &&
                 (l[15] === r[15]));
-    },
+    }
 
     /**
      * @function
@@ -181,7 +186,7 @@ Object.assign(Mat4.prototype, {
      * var m = new pc.Mat4();
      * console.log("The matrix is " + (m.isIdentity() ? "identity" : "not identity"));
      */
-    isIdentity: function () {
+    isIdentity() {
         var m = this.data;
 
         return ((m[0] === 1) &&
@@ -200,7 +205,7 @@ Object.assign(Mat4.prototype, {
                 (m[13] === 0) &&
                 (m[14] === 0) &&
                 (m[15] === 1));
-    },
+    }
 
     /**
      * @function
@@ -220,7 +225,7 @@ Object.assign(Mat4.prototype, {
      *
      * console.log("The result of the multiplication is: " + r.toString());
      */
-    mul2: function (lhs, rhs) {
+    mul2(lhs, rhs) {
         var a00, a01, a02, a03,
             a10, a11, a12, a13,
             a20, a21, a22, a23,
@@ -284,7 +289,7 @@ Object.assign(Mat4.prototype, {
         r[15] = a03 * b0 + a13 * b1 + a23 * b2 + a33 * b3;
 
         return this;
-    },
+    }
 
     /**
      * @function
@@ -297,7 +302,7 @@ Object.assign(Mat4.prototype, {
      * @param {pc.Mat4} rhs - The affine transformation 4x4 matrix used as the second multiplicand of the operation.
      * @returns {pc.Mat4} Self for chaining.
      */
-    mulAffine2: function (lhs, rhs) {
+    mulAffine2(lhs, rhs) {
         var a00, a01, a02,
             a10, a11, a12,
             a20, a21, a22,
@@ -353,7 +358,7 @@ Object.assign(Mat4.prototype, {
         r[15] = 1;
 
         return this;
-    },
+    }
 
     /**
      * @function
@@ -370,9 +375,9 @@ Object.assign(Mat4.prototype, {
      *
      * console.log("The result of the multiplication is: " + a.toString());
      */
-    mul: function (rhs) {
+    mul(rhs) {
         return this.mul2(this, rhs);
-    },
+    }
 
     /**
      * @function
@@ -390,7 +395,7 @@ Object.assign(Mat4.prototype, {
      *
      * var tv = m.transformPoint(v);
      */
-    transformPoint: function (vec, res) {
+    transformPoint(vec, res) {
         var x, y, z, m;
 
         m = this.data;
@@ -406,7 +411,7 @@ Object.assign(Mat4.prototype, {
         res.z = x * m[2] + y * m[6] + z * m[10] + m[14];
 
         return res;
-    },
+    }
 
     /**
      * @function
@@ -424,7 +429,7 @@ Object.assign(Mat4.prototype, {
      *
      * var tv = m.transformVector(v);
      */
-    transformVector: function (vec, res) {
+    transformVector(vec, res) {
         var x, y, z, m;
 
         m = this.data;
@@ -440,7 +445,7 @@ Object.assign(Mat4.prototype, {
         res.z = x * m[2] + y * m[6] + z * m[10];
 
         return res;
-    },
+    }
 
     /**
      * @function
@@ -461,7 +466,7 @@ Object.assign(Mat4.prototype, {
      *
      * m.transformVec4(v, result);
      */
-    transformVec4: function (vec, res) {
+    transformVec4(vec, res) {
         var x, y, z, w, m;
 
         m = this.data;
@@ -479,7 +484,7 @@ Object.assign(Mat4.prototype, {
         res.w = x * m[3] + y * m[7] + z * m[11] + w * m[15];
 
         return res;
-    },
+    }
 
     /**
      * @function
@@ -500,41 +505,33 @@ Object.assign(Mat4.prototype, {
      * var up = new pc.Vec3(0, 1, 0);
      * var m = new pc.Mat4().setLookAt(position, target, up);
      */
-    setLookAt: (function () {
-        var x, y, z;
+    setLookAt(position, target, up) {
+        z.sub2(position, target).normalize();
+        y.copy(up).normalize();
+        x.cross(y, z).normalize();
+        y.cross(z, x);
 
-        x = new Vec3();
-        y = new Vec3();
-        z = new Vec3();
+        var r = this.data;
 
-        return function (position, target, up) {
-            z.sub2(position, target).normalize();
-            y.copy(up).normalize();
-            x.cross(y, z).normalize();
-            y.cross(z, x);
+        r[0]  = x.x;
+        r[1]  = x.y;
+        r[2]  = x.z;
+        r[3]  = 0;
+        r[4]  = y.x;
+        r[5]  = y.y;
+        r[6]  = y.z;
+        r[7]  = 0;
+        r[8]  = z.x;
+        r[9]  = z.y;
+        r[10] = z.z;
+        r[11] = 0;
+        r[12] = position.x;
+        r[13] = position.y;
+        r[14] = position.z;
+        r[15] = 1;
 
-            var r = this.data;
-
-            r[0]  = x.x;
-            r[1]  = x.y;
-            r[2]  = x.z;
-            r[3]  = 0;
-            r[4]  = y.x;
-            r[5]  = y.y;
-            r[6]  = y.z;
-            r[7]  = 0;
-            r[8]  = z.x;
-            r[9]  = z.y;
-            r[10] = z.z;
-            r[11] = 0;
-            r[12] = position.x;
-            r[13] = position.y;
-            r[14] = position.z;
-            r[15] = 1;
-
-            return this;
-        };
-    }()),
+        return this;
+    }
 
     /**
      * @private
@@ -553,7 +550,7 @@ Object.assign(Mat4.prototype, {
      * // Create a 4x4 perspective projection matrix
      * var f = pc.Mat4().setFrustum(-2, 2, -1, 1, 1, 1000);
      */
-    setFrustum: function (left, right, bottom, top, znear, zfar) {
+    setFrustum(left, right, bottom, top, znear, zfar) {
         var temp1, temp2, temp3, temp4, r;
 
         temp1 = 2 * znear;
@@ -580,7 +577,7 @@ Object.assign(Mat4.prototype, {
         r[15] = 0;
 
         return this;
-    },
+    }
 
     /**
      * @function
@@ -600,10 +597,10 @@ Object.assign(Mat4.prototype, {
      * // Create a 4x4 perspective projection matrix
      * var persp = pc.Mat4().setPerspective(45, 16 / 9, 1, 1000);
      */
-    setPerspective: function (fov, aspect, znear, zfar, fovIsHorizontal) {
+    setPerspective(fov, aspect, znear, zfar, fovIsHorizontal) {
         Mat4._getPerspectiveHalfSize(_halfSize, fov, aspect, znear, fovIsHorizontal);
         return this.setFrustum(-_halfSize.x, _halfSize.x, -_halfSize.y, _halfSize.y, znear, zfar);
-    },
+    }
 
     /**
      * @function
@@ -621,7 +618,7 @@ Object.assign(Mat4.prototype, {
      * // Create a 4x4 orthographic projection matrix
      * var ortho = pc.Mat4().ortho(-2, 2, -2, 2, 1, 1000);
      */
-    setOrtho: function (left, right, bottom, top, near, far) {
+    setOrtho(left, right, bottom, top, near, far) {
         var r = this.data;
 
         r[0] = 2 / (right - left);
@@ -642,7 +639,7 @@ Object.assign(Mat4.prototype, {
         r[15] = 1;
 
         return this;
-    },
+    }
 
     /**
      * @function
@@ -656,7 +653,7 @@ Object.assign(Mat4.prototype, {
      * // Create a 4x4 rotation matrix
      * var rm = new pc.Mat4().setFromAxisAngle(pc.Vec3.UP, 90);
      */
-    setFromAxisAngle: function (axis, angle) {
+    setFromAxisAngle(axis, angle) {
         var x, y, z, c, s, t, tx, ty, m;
 
         angle *= math.DEG_TO_RAD;
@@ -689,7 +686,7 @@ Object.assign(Mat4.prototype, {
         m[15] = 1;
 
         return this;
-    },
+    }
 
     /**
      * @private
@@ -704,7 +701,7 @@ Object.assign(Mat4.prototype, {
      * // Create a 4x4 translation matrix
      * var tm = new pc.Mat4().setTranslate(10, 10, 10);
      */
-    setTranslate: function (x, y, z) {
+    setTranslate(x, y, z) {
         var m = this.data;
 
         m[0] = 1;
@@ -725,7 +722,7 @@ Object.assign(Mat4.prototype, {
         m[15] = 1;
 
         return this;
-    },
+    }
 
     /**
      * @private
@@ -740,7 +737,7 @@ Object.assign(Mat4.prototype, {
      * // Create a 4x4 scale matrix
      * var sm = new pc.Mat4().setScale(10, 10, 10);
      */
-    setScale: function (x, y, z) {
+    setScale(x, y, z) {
         var m = this.data;
 
         m[0] = x;
@@ -761,7 +758,7 @@ Object.assign(Mat4.prototype, {
         m[15] = 1;
 
         return this;
-    },
+    }
 
     /**
      * @function
@@ -775,7 +772,7 @@ Object.assign(Mat4.prototype, {
      * // Invert in place
      * rot.invert();
      */
-    invert: function () {
+    invert() {
         var a00, a01, a02, a03,
             a10, a11, a12, a13,
             a20, a21, a22, a23,
@@ -842,7 +839,7 @@ Object.assign(Mat4.prototype, {
 
 
         return this;
-    },
+    }
 
     /**
      * @function
@@ -851,7 +848,7 @@ Object.assign(Mat4.prototype, {
      * @param {number[]} src - Source array. Must have 16 values.
      * @returns {pc.Mat4} Self for chaining.
      */
-    set: function (src) {
+    set(src) {
         var dst = this.data;
         dst[0] = src[0];
         dst[1] = src[1];
@@ -871,7 +868,7 @@ Object.assign(Mat4.prototype, {
         dst[15] = src[15];
 
         return this;
-    },
+    }
 
     /**
      * @function
@@ -882,7 +879,7 @@ Object.assign(Mat4.prototype, {
      * m.setIdentity();
      * console.log("The matrix is " + (m.isIdentity() ? "identity" : "not identity"));
      */
-    setIdentity: function () {
+    setIdentity() {
         var m = this.data;
         m[0] = 1;
         m[1] = 0;
@@ -902,7 +899,7 @@ Object.assign(Mat4.prototype, {
         m[15] = 1;
 
         return this;
-    },
+    }
 
     /**
      * @function
@@ -921,7 +918,7 @@ Object.assign(Mat4.prototype, {
      * var m = new pc.Mat4();
      * m.setTRS(t, r, s);
      */
-    setTRS: function (t, r, s) {
+    setTRS(t, r, s) {
         var qx, qy, qz, qw, sx, sy, sz,
             x2, y2, z2, xx, xy, xz, yy, yz, zz, wx, wy, wz, m;
 
@@ -970,7 +967,7 @@ Object.assign(Mat4.prototype, {
         m[15] = 1;
 
         return this;
-    },
+    }
 
     /**
      * @function
@@ -983,7 +980,7 @@ Object.assign(Mat4.prototype, {
      * // Transpose in place
      * m.transpose();
      */
-    transpose: function () {
+    transpose() {
         var tmp, m = this.data;
 
         tmp = m[1];
@@ -1011,9 +1008,9 @@ Object.assign(Mat4.prototype, {
         m[14] = tmp;
 
         return this;
-    },
+    }
 
-    invertTo3x3: function (res) {
+    invertTo3x3(res) {
         var a11, a21, a31, a12, a22, a32, a13, a23, a33,
             m, r, det, idet;
 
@@ -1060,7 +1057,7 @@ Object.assign(Mat4.prototype, {
         r[8] = idet * a33;
 
         return this;
-    },
+    }
 
     /**
      * @function
@@ -1076,11 +1073,11 @@ Object.assign(Mat4.prototype, {
      * var t = new pc.Vec3();
      * m.getTranslation(t);
      */
-    getTranslation: function (t) {
+    getTranslation(t) {
         t = (t === undefined) ? new Vec3() : t;
 
         return t.set(this.data[12], this.data[13], this.data[14]);
-    },
+    }
 
     /**
      * @function
@@ -1096,11 +1093,11 @@ Object.assign(Mat4.prototype, {
      * var x = new pc.Vec3();
      * m.getX(x);
      */
-    getX: function (x) {
+    getX(x) {
         x = (x === undefined) ? new Vec3() : x;
 
         return x.set(this.data[0], this.data[1], this.data[2]);
-    },
+    }
 
     /**
      * @function
@@ -1116,11 +1113,11 @@ Object.assign(Mat4.prototype, {
      * var y = new pc.Vec3();
      * m.getY(y);
      */
-    getY: function (y) {
+    getY(y) {
         y = (y === undefined) ? new Vec3() : y;
 
         return y.set(this.data[4], this.data[5], this.data[6]);
-    },
+    }
 
     /**
      * @function
@@ -1136,11 +1133,11 @@ Object.assign(Mat4.prototype, {
      * var z = new pc.Vec3();
      * m.getZ(z);
      */
-    getZ: function (z) {
+    getZ(z) {
         z = (z === undefined) ? new Vec3() : z;
 
         return z.set(this.data[8], this.data[9], this.data[10]);
-    },
+    }
 
     /**
      * @function
@@ -1155,24 +1152,16 @@ Object.assign(Mat4.prototype, {
      * // Query the scale component
      * var scale = m.getScale();
      */
-    getScale: (function () {
-        var x, y, z;
+    getScale(scale) {
+        scale = (scale === undefined) ? new Vec3() : scale;
 
-        x = new Vec3();
-        y = new Vec3();
-        z = new Vec3();
+        this.getX(x);
+        this.getY(y);
+        this.getZ(z);
+        scale.set(x.length(), y.length(), z.length());
 
-        return function (scale) {
-            scale = (scale === undefined) ? new Vec3() : scale;
-
-            this.getX(x);
-            this.getY(y);
-            this.getZ(z);
-            scale.set(x.length(), y.length(), z.length());
-
-            return scale;
-        };
-    }()),
+        return scale;
+    }
 
     /**
      * @function
@@ -1190,7 +1179,7 @@ Object.assign(Mat4.prototype, {
     // http://en.wikipedia.org/wiki/Rotation_matrix#Conversion_from_and_to_axis-angle
     // The 3D space is right-handed, so the rotation around each axis will be counterclockwise
     // for an observer placed so that the axis goes in his or her direction (Right-hand rule).
-    setFromEulerAngles: function (ex, ey, ez) {
+    setFromEulerAngles(ex, ey, ez) {
         var s1, c1, s2, c2, s3, c3, m;
 
         ex *= math.DEG_TO_RAD;
@@ -1229,7 +1218,7 @@ Object.assign(Mat4.prototype, {
         m[15] = 1;
 
         return this;
-    },
+    }
 
     /**
      * @function
@@ -1244,42 +1233,38 @@ Object.assign(Mat4.prototype, {
      *
      * var eulers = m.getEulerAngles();
      */
-    getEulerAngles: (function () {
-        var scale = new Vec3();
+    getEulerAngles(eulers) {
+        var x, y, z, sx, sy, sz, m, halfPi;
 
-        return function (eulers) {
-            var x, y, z, sx, sy, sz, m, halfPi;
+        eulers = (eulers === undefined) ? new Vec3() : eulers;
 
-            eulers = (eulers === undefined) ? new Vec3() : eulers;
+        this.getScale(scale);
+        sx = scale.x;
+        sy = scale.y;
+        sz = scale.z;
 
-            this.getScale(scale);
-            sx = scale.x;
-            sy = scale.y;
-            sz = scale.z;
+        m = this.data;
 
-            m = this.data;
+        y = Math.asin(-m[2] / sx);
+        halfPi = Math.PI * 0.5;
 
-            y = Math.asin(-m[2] / sx);
-            halfPi = Math.PI * 0.5;
-
-            if (y < halfPi) {
-                if (y > -halfPi) {
-                    x = Math.atan2(m[6] / sy, m[10] / sz);
-                    z = Math.atan2(m[1] / sx, m[0] / sx);
-                } else {
-                    // Not a unique solution
-                    z = 0;
-                    x = -Math.atan2(m[4] / sy, m[5] / sy);
-                }
+        if (y < halfPi) {
+            if (y > -halfPi) {
+                x = Math.atan2(m[6] / sy, m[10] / sz);
+                z = Math.atan2(m[1] / sx, m[0] / sx);
             } else {
                 // Not a unique solution
                 z = 0;
-                x = Math.atan2(m[4] / sy, m[5] / sy);
+                x = -Math.atan2(m[4] / sy, m[5] / sy);
             }
+        } else {
+            // Not a unique solution
+            z = 0;
+            x = Math.atan2(m[4] / sy, m[5] / sy);
+        }
 
-            return eulers.set(x, y, z).scale(math.RAD_TO_DEG);
-        };
-    }()),
+        return eulers.set(x, y, z).scale(math.RAD_TO_DEG);
+    }
 
     /**
      * @function
@@ -1291,7 +1276,7 @@ Object.assign(Mat4.prototype, {
      * // Should output '[1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]'
      * console.log(m.toString());
      */
-    toString: function () {
+    toString() {
         var i, t;
 
         t = '[';
@@ -1302,32 +1287,25 @@ Object.assign(Mat4.prototype, {
         t += ']';
         return t;
     }
-});
 
-/**
- * @field
- * @static
- * @readonly
- * @name pc.Mat4.IDENTITY
- * @type {pc.Mat4}
- * @description A constant matrix set to the identity.
- */
-
-/**
- * @field
- * @static
- * @readonly
- * @name pc.Mat4.ZERO
- * @type {pc.Mat4}
- * @description A constant matrix with all elements set to 0.
- */
-
-Object.defineProperties(Mat4, {
-    ZERO: { value: new Mat4().set([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]) },
-    IDENTITY: { value: new Mat4() }
-});
-
-Object.freeze(Mat4.ZERO);
-Object.freeze(Mat4.IDENTITY);
+    /**
+     * @field
+     * @static
+     * @readonly
+     * @name pc.Mat4.IDENTITY
+     * @type {pc.Mat4}
+     * @description A constant matrix set to the identity.
+     */
+    static IDENTITY = Object.freeze(new Mat4());
+    /**
+     * @field
+     * @static
+     * @readonly
+     * @name pc.Mat4.ZERO
+     * @type {pc.Mat4}
+     * @description A constant matrix with all elements set to 0.
+     */
+    static ZERO = Object.freeze(new Mat4().set([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]));
+}
 
 export { Mat4 };

--- a/src/math/mat4.js
+++ b/src/math/mat4.js
@@ -1297,6 +1297,7 @@ class Mat4 {
      * @description A constant matrix set to the identity.
      */
     static IDENTITY = Object.freeze(new Mat4());
+
     /**
      * @field
      * @static

--- a/src/math/quat.js
+++ b/src/math/quat.js
@@ -712,6 +712,7 @@ class Quat {
      * @description A constant quaternion set to [0, 0, 0, 1] (the identity).
      */
     static IDENTITY = Object.freeze(new Quat(0, 0, 0, 1));
+
     /**
      * @field
      * @static

--- a/src/math/quat.js
+++ b/src/math/quat.js
@@ -68,17 +68,17 @@ import { Vec3 } from './vec3.js';
  * quat.w = 0;
  */
 class Quat {
-    constructor(x, y, z, w) {
+    constructor(x = 0, y = 0, z = 0, w = 0) {
         if (x && x.length === 4) {
             this.x = x[0];
             this.y = x[1];
             this.z = x[2];
             this.w = x[3];
         } else {
-            this.x = (x === undefined) ? 0 : x;
-            this.y = (y === undefined) ? 0 : y;
-            this.z = (z === undefined) ? 0 : z;
-            this.w = (w === undefined) ? 1 : w;
+            this.x = x;
+            this.y = y;
+            this.z = z;
+            this.w = w;
         }
     }
 
@@ -192,10 +192,8 @@ class Quat {
      * @returns {pc.Vec3} The 3-dimensional vector holding the Euler angles that
      * correspond to the supplied quaternion.
      */
-    getEulerAngles(eulers) {
+    getEulerAngles(eulers = new Vec3()) {
         var x, y, z, qx, qy, qz, qw, a2;
-
-        eulers = (eulers === undefined) ? new Vec3() : eulers;
 
         qx = this.x;
         qy = this.y;
@@ -667,11 +665,7 @@ class Quat {
      *
      * var tv = q.transformVector(v);
      */
-    transformVector(vec, res) {
-        if (res === undefined) {
-            res = new Vec3();
-        }
-
+    transformVector(vec, res = new Vec3()) {
         var x = vec.x, y = vec.y, z = vec.z;
         var qx = this.x, qy = this.y, qz = this.z, qw = this.w;
 

--- a/src/math/quat.js
+++ b/src/math/quat.js
@@ -68,7 +68,7 @@ import { Vec3 } from './vec3.js';
  * quat.w = 0;
  */
 class Quat {
-    constructor(x = 0, y = 0, z = 0, w = 0) {
+    constructor(x = 0, y = 0, z = 0, w = 1) {
         if (x && x.length === 4) {
             this.x = x[0];
             this.y = x[1];

--- a/src/math/quat.js
+++ b/src/math/quat.js
@@ -11,20 +11,6 @@ import { Vec3 } from './vec3.js';
  * @param {number} [z] - The quaternion's z component. Default value 0.
  * @param {number} [w] - The quaternion's w component. Default value 1.
  */
-function Quat(x, y, z, w) {
-    if (x && x.length === 4) {
-        this.x = x[0];
-        this.y = x[1];
-        this.z = x[2];
-        this.w = x[3];
-    } else {
-        this.x = (x === undefined) ? 0 : x;
-        this.y = (y === undefined) ? 0 : y;
-        this.z = (z === undefined) ? 0 : z;
-        this.w = (w === undefined) ? 1 : w;
-    }
-}
-
 /**
  * @field
  * @name pc.Quat#x
@@ -81,8 +67,21 @@ function Quat(x, y, z, w) {
  * // Set w
  * quat.w = 0;
  */
+class Quat {
+    constructor(x, y, z, w) {
+        if (x && x.length === 4) {
+            this.x = x[0];
+            this.y = x[1];
+            this.z = x[2];
+            this.w = x[3];
+        } else {
+            this.x = (x === undefined) ? 0 : x;
+            this.y = (y === undefined) ? 0 : y;
+            this.z = (z === undefined) ? 0 : z;
+            this.w = (w === undefined) ? 1 : w;
+        }
+    }
 
-Object.assign(Quat.prototype, {
     /**
      * @function
      * @name pc.Quat#clone
@@ -94,17 +93,17 @@ Object.assign(Quat.prototype, {
      *
      * console.log("The result of the cloning is: " + q.toString());
      */
-    clone: function () {
+    clone() {
         return new Quat(this.x, this.y, this.z, this.w);
-    },
+    }
 
-    conjugate: function () {
+    conjugate() {
         this.x *= -1;
         this.y *= -1;
         this.z *= -1;
 
         return this;
-    },
+    }
 
     /**
      * @function
@@ -118,14 +117,14 @@ Object.assign(Quat.prototype, {
      * dst.copy(src, src);
      * console.log("The two quaternions are " + (src.equals(dst) ? "equal" : "different"));
      */
-    copy: function (rhs) {
+    copy(rhs) {
         this.x = rhs.x;
         this.y = rhs.y;
         this.z = rhs.z;
         this.w = rhs.w;
 
         return this;
-    },
+    }
 
     /**
      * @function
@@ -138,9 +137,9 @@ Object.assign(Quat.prototype, {
      * var b = new pc.Quat();
      * console.log("The two quaternions are " + (a.equals(b) ? "equal" : "different"));
      */
-    equals: function (rhs) {
+    equals(rhs) {
         return ((this.x === rhs.x) && (this.y === rhs.y) && (this.z === rhs.z) && (this.w === rhs.w));
-    },
+    }
 
     /**
      * @function
@@ -162,7 +161,7 @@ Object.assign(Quat.prototype, {
      * // Should output [0, 1, 0]
      * console.log(v.toString());
      */
-    getAxisAngle: function (axis) {
+    getAxisAngle(axis) {
         var rad = Math.acos(this.w) * 2;
         var s = Math.sin(rad / 2);
         if (s !== 0) {
@@ -183,7 +182,7 @@ Object.assign(Quat.prototype, {
             axis.z = 0;
         }
         return rad * math.RAD_TO_DEG;
-    },
+    }
 
     /**
      * @function
@@ -193,7 +192,7 @@ Object.assign(Quat.prototype, {
      * @returns {pc.Vec3} The 3-dimensional vector holding the Euler angles that
      * correspond to the supplied quaternion.
      */
-    getEulerAngles: function (eulers) {
+    getEulerAngles(eulers) {
         var x, y, z, qx, qy, qz, qw, a2;
 
         eulers = (eulers === undefined) ? new Vec3() : eulers;
@@ -219,7 +218,7 @@ Object.assign(Quat.prototype, {
         }
 
         return eulers.set(x, y, z).scale(math.RAD_TO_DEG);
-    },
+    }
 
     /**
      * @function
@@ -233,9 +232,9 @@ Object.assign(Quat.prototype, {
      * // Invert in place
      * rot.invert();
      */
-    invert: function () {
+    invert() {
         return this.conjugate().normalize();
-    },
+    }
 
     /**
      * @function
@@ -248,9 +247,9 @@ Object.assign(Quat.prototype, {
      * // Should output 5
      * console.log("The length of the quaternion is: " + len);
      */
-    length: function () {
+    length() {
         return Math.sqrt(this.x * this.x + this.y * this.y + this.z * this.z + this.w * this.w);
-    },
+    }
 
     /**
      * @function
@@ -263,9 +262,9 @@ Object.assign(Quat.prototype, {
      * // Should output 25
      * console.log("The length squared of the quaternion is: " + lenSq);
      */
-    lengthSq: function () {
+    lengthSq() {
         return this.x * this.x + this.y * this.y + this.z * this.z + this.w * this.w;
-    },
+    }
 
     /**
      * @function
@@ -283,7 +282,7 @@ Object.assign(Quat.prototype, {
      *
      * console.log("The result of the multiplication is: " + a.toString());
      */
-    mul: function (rhs) {
+    mul(rhs) {
         var q1x, q1y, q1z, q1w, q2x, q2y, q2z, q2w;
 
         q1x = this.x;
@@ -302,7 +301,7 @@ Object.assign(Quat.prototype, {
         this.w = q1w * q2w - q1x * q2x - q1y * q2y - q1z * q2z;
 
         return this;
-    },
+    }
 
     /**
      * @function
@@ -322,7 +321,7 @@ Object.assign(Quat.prototype, {
      *
      * console.log("The result of the multiplication is: " + r.toString());
      */
-    mul2: function (lhs, rhs) {
+    mul2(lhs, rhs) {
         var q1x, q1y, q1z, q1w, q2x, q2y, q2z, q2w;
 
         q1x = lhs.x;
@@ -341,7 +340,7 @@ Object.assign(Quat.prototype, {
         this.w = q1w * q2w - q1x * q2x - q1y * q2y - q1z * q2z;
 
         return this;
-    },
+    }
 
     /**
      * @function
@@ -356,7 +355,7 @@ Object.assign(Quat.prototype, {
      * // Should output 0, 0, 0, 1
      * console.log("The result of the vector normalization is: " + v.toString());
      */
-    normalize: function () {
+    normalize() {
         var len = this.length();
         if (len === 0) {
             this.x = this.y = this.z = 0;
@@ -370,7 +369,7 @@ Object.assign(Quat.prototype, {
         }
 
         return this;
-    },
+    }
 
     /**
      * @function
@@ -388,14 +387,14 @@ Object.assign(Quat.prototype, {
      * // Should output 1, 0, 0, 0
      * console.log("The result of the vector set is: " + q.toString());
      */
-    set: function (x, y, z, w) {
+    set(x, y, z, w) {
         this.x = x;
         this.y = y;
         this.z = z;
         this.w = w;
 
         return this;
-    },
+    }
 
     /**
      * @function
@@ -408,7 +407,7 @@ Object.assign(Quat.prototype, {
      * var q = new pc.Quat();
      * q.setFromAxisAngle(pc.Vec3.UP, 90);
      */
-    setFromAxisAngle: function (axis, angle) {
+    setFromAxisAngle(axis, angle) {
         var sa, ca;
 
         angle *= 0.5 * math.DEG_TO_RAD;
@@ -422,7 +421,7 @@ Object.assign(Quat.prototype, {
         this.w = ca;
 
         return this;
-    },
+    }
 
     /**
      * @function
@@ -436,7 +435,7 @@ Object.assign(Quat.prototype, {
      * var q = new pc.Quat();
      * q.setFromEulerAngles(45, 90, 180);
      */
-    setFromEulerAngles: function (ex, ey, ez) {
+    setFromEulerAngles(ex, ey, ez) {
         var sx, cx, sy, cy, sz, cz, halfToRad;
 
         halfToRad = 0.5 * math.DEG_TO_RAD;
@@ -457,7 +456,7 @@ Object.assign(Quat.prototype, {
         this.w = cx * cy * cz + sx * sy * sz;
 
         return this;
-    },
+    }
 
     /**
      * @function
@@ -474,7 +473,7 @@ Object.assign(Quat.prototype, {
      * // Convert to a quaternion
      * var q = new pc.Quat().setFromMat4(rot);
      */
-    setFromMat4: function (m) {
+    setFromMat4(m) {
         var m00, m01, m02, m10, m11, m12, m20, m21, m22,
             tr, s, rs, lx, ly, lz;
 
@@ -572,7 +571,7 @@ Object.assign(Quat.prototype, {
         }
 
         return this;
-    },
+    }
 
     /**
      * @function
@@ -594,7 +593,7 @@ Object.assign(Quat.prototype, {
      * result = new pc.Quat().slerp(q1, q2, 0.5); // Return the midpoint interpolant
      * result = new pc.Quat().slerp(q1, q2, 1);   // Return q2
      */
-    slerp: function (lhs, rhs, alpha) {
+    slerp(lhs, rhs, alpha) {
         // Algorithm sourced from:
         // http://www.euclideanspace.com/maths/algebra/realNormedAlgebra/quaternions/slerp/
         var lx, ly, lz, lw, rx, ry, rz, rw;
@@ -650,7 +649,7 @@ Object.assign(Quat.prototype, {
         this.y = (ly * ratioA + ry * ratioB);
         this.z = (lz * ratioA + rz * ratioB);
         return this;
-    },
+    }
 
     /**
      * @function
@@ -668,7 +667,7 @@ Object.assign(Quat.prototype, {
      *
      * var tv = q.transformVector(v);
      */
-    transformVector: function (vec, res) {
+    transformVector(vec, res) {
         if (res === undefined) {
             res = new Vec3();
         }
@@ -688,7 +687,7 @@ Object.assign(Quat.prototype, {
         res.z = iz * qw + iw * -qz + ix * -qy - iy * -qx;
 
         return res;
-    },
+    }
 
     /**
      * @function
@@ -700,35 +699,28 @@ Object.assign(Quat.prototype, {
      * // Should output '[0, 0, 0, 1]'
      * console.log(v.toString());
      */
-    toString: function () {
+    toString() {
         return '[' + this.x + ', ' + this.y + ', ' + this.z + ', ' + this.w + ']';
     }
-});
 
-/**
- * @field
- * @static
- * @readonly
- * @name pc.Quat.IDENTITY
- * @type {pc.Quat}
- * @description A constant quaternion set to [0, 0, 0, 1] (the identity).
- */
-
-/**
- * @field
- * @static
- * @readonly
- * @name pc.Quat.ZERO
- * @type {pc.Quat}
- * @description A constant quaternion set to [0, 0, 0, 0].
- */
-
-Object.defineProperties(Quat, {
-    ZERO: { value: new Quat(0, 0, 0, 0) },
-    IDENTITY: { value: new Quat(0, 0, 0, 1) }
-});
-
-Object.freeze(Quat.ZERO);
-Object.freeze(Quat.IDENTITY);
+    /**
+     * @field
+     * @static
+     * @readonly
+     * @name pc.Quat.IDENTITY
+     * @type {pc.Quat}
+     * @description A constant quaternion set to [0, 0, 0, 1] (the identity).
+     */
+    static IDENTITY = Object.freeze(new Quat(0, 0, 0, 1));
+    /**
+     * @field
+     * @static
+     * @readonly
+     * @name pc.Quat.ZERO
+     * @type {pc.Quat}
+     * @description A constant quaternion set to [0, 0, 0, 0].
+     */
+    static ZERO = Object.freeze(new Quat(0, 0, 0, 0));
+}
 
 export { Quat };

--- a/src/math/quat.js
+++ b/src/math/quat.js
@@ -69,7 +69,7 @@ import { Vec3 } from './vec3.js';
  */
 class Quat {
     constructor(x = 0, y = 0, z = 0, w = 1) {
-        if (x && x.length === 4) {
+        if (x.length === 4) {
             this.x = x[0];
             this.y = x[1];
             this.z = x[2];

--- a/src/math/vec2.js
+++ b/src/math/vec2.js
@@ -8,382 +8,6 @@
  * @example
  * var v = new pc.Vec2(1, 2);
  */
-function Vec2(x, y) {
-    if (x && x.length === 2) {
-        this.x = x[0];
-        this.y = x[1];
-    } else {
-        this.x = x || 0;
-        this.y = y || 0;
-    }
-}
-
-Object.assign(Vec2.prototype, {
-    /**
-     * @function
-     * @name pc.Vec2#add
-     * @description Adds a 2-dimensional vector to another in place.
-     * @param {pc.Vec2} rhs - The vector to add to the specified vector.
-     * @returns {pc.Vec2} Self for chaining.
-     * @example
-     * var a = new pc.Vec2(10, 10);
-     * var b = new pc.Vec2(20, 20);
-     *
-     * a.add(b);
-     *
-     * // Should output [30, 30]
-     * console.log("The result of the addition is: " + a.toString());
-     */
-    add: function (rhs) {
-        this.x += rhs.x;
-        this.y += rhs.y;
-
-        return this;
-    },
-
-    /**
-     * @function
-     * @name pc.Vec2#add2
-     * @description Adds two 2-dimensional vectors together and returns the result.
-     * @param {pc.Vec2} lhs - The first vector operand for the addition.
-     * @param {pc.Vec2} rhs - The second vector operand for the addition.
-     * @returns {pc.Vec2} Self for chaining.
-     * @example
-     * var a = new pc.Vec2(10, 10);
-     * var b = new pc.Vec2(20, 20);
-     * var r = new pc.Vec2();
-     *
-     * r.add2(a, b);
-     * // Should output [30, 30]
-     *
-     * console.log("The result of the addition is: " + r.toString());
-     */
-    add2: function (lhs, rhs) {
-        this.x = lhs.x + rhs.x;
-        this.y = lhs.y + rhs.y;
-
-        return this;
-    },
-
-    /**
-     * @function
-     * @name pc.Vec2#clone
-     * @description Returns an identical copy of the specified 2-dimensional vector.
-     * @returns {pc.Vec2} A 2-dimensional vector containing the result of the cloning.
-     * @example
-     * var v = new pc.Vec2(10, 20);
-     * var vclone = v.clone();
-     * console.log("The result of the cloning is: " + vclone.toString());
-     */
-    clone: function () {
-        return new Vec2().copy(this);
-    },
-
-    /**
-     * @function
-     * @name pc.Vec2#copy
-     * @description Copied the contents of a source 2-dimensional vector to a destination 2-dimensional vector.
-     * @param {pc.Vec2} rhs - A vector to copy to the specified vector.
-     * @returns {pc.Vec2} Self for chaining.
-     * @example
-     * var src = new pc.Vec2(10, 20);
-     * var dst = new pc.Vec2();
-     *
-     * dst.copy(src);
-     *
-     * console.log("The two vectors are " + (dst.equals(src) ? "equal" : "different"));
-     */
-    copy: function (rhs) {
-        this.x = rhs.x;
-        this.y = rhs.y;
-
-        return this;
-    },
-
-    /**
-     * @function
-     * @name pc.Vec2#distance
-     * @description Returns the distance between the two specified 2-dimensional vectors.
-     * @param {pc.Vec2} rhs - The second 2-dimensional vector to test.
-     * @returns {number} The distance between the two vectors.
-     * @example
-     * var v1 = new pc.Vec2(5, 10);
-     * var v2 = new pc.Vec2(10, 20);
-     * var d = v1.distance(v2);
-     * console.log("The between v1 and v2 is: " + d);
-     */
-    distance: function (rhs) {
-        var x = this.x - rhs.x;
-        var y = this.y - rhs.y;
-        return Math.sqrt(x * x + y * y);
-    },
-
-    /**
-     * @function
-     * @name pc.Vec2#dot
-     * @description Returns the result of a dot product operation performed on the two specified 2-dimensional vectors.
-     * @param {pc.Vec2} rhs - The second 2-dimensional vector operand of the dot product.
-     * @returns {number} The result of the dot product operation.
-     * @example
-     * var v1 = new pc.Vec2(5, 10);
-     * var v2 = new pc.Vec2(10, 20);
-     * var v1dotv2 = v1.dot(v2);
-     * console.log("The result of the dot product is: " + v1dotv2);
-     */
-    dot: function (rhs) {
-        return this.x * rhs.x + this.y * rhs.y;
-    },
-
-    /**
-     * @function
-     * @name pc.Vec2#equals
-     * @description Reports whether two vectors are equal.
-     * @param {pc.Vec2} rhs - The vector to compare to the specified vector.
-     * @returns {boolean} True if the vectors are equal and false otherwise.
-     * @example
-     * var a = new pc.Vec2(1, 2);
-     * var b = new pc.Vec2(4, 5);
-     * console.log("The two vectors are " + (a.equals(b) ? "equal" : "different"));
-     */
-    equals: function (rhs) {
-        return this.x === rhs.x && this.y === rhs.y;
-    },
-
-    /**
-     * @function
-     * @name pc.Vec2#length
-     * @description Returns the magnitude of the specified 2-dimensional vector.
-     * @returns {number} The magnitude of the specified 2-dimensional vector.
-     * @example
-     * var vec = new pc.Vec2(3, 4);
-     * var len = vec.length();
-     * // Should output 5
-     * console.log("The length of the vector is: " + len);
-     */
-    length: function () {
-        return Math.sqrt(this.x * this.x + this.y * this.y);
-    },
-
-    /**
-     * @function
-     * @name pc.Vec2#lengthSq
-     * @description Returns the magnitude squared of the specified 2-dimensional vector.
-     * @returns {number} The magnitude of the specified 2-dimensional vector.
-     * @example
-     * var vec = new pc.Vec2(3, 4);
-     * var len = vec.lengthSq();
-     * // Should output 25
-     * console.log("The length squared of the vector is: " + len);
-     */
-    lengthSq: function () {
-        return this.x * this.x + this.y * this.y;
-    },
-
-    /**
-     * @function
-     * @name pc.Vec2#lerp
-     * @description Returns the result of a linear interpolation between two specified 2-dimensional vectors.
-     * @param {pc.Vec2} lhs - The 2-dimensional to interpolate from.
-     * @param {pc.Vec2} rhs - The 2-dimensional to interpolate to.
-     * @param {number} alpha - The value controlling the point of interpolation. Between 0 and 1, the linear interpolant
-     * will occur on a straight line between lhs and rhs. Outside of this range, the linear interpolant will occur on
-     * a ray extrapolated from this line.
-     * @returns {pc.Vec2} Self for chaining.
-     * @example
-     * var a = new pc.Vec2(0, 0);
-     * var b = new pc.Vec2(10, 10);
-     * var r = new pc.Vec2();
-     *
-     * r.lerp(a, b, 0);   // r is equal to a
-     * r.lerp(a, b, 0.5); // r is 5, 5
-     * r.lerp(a, b, 1);   // r is equal to b
-     */
-    lerp: function (lhs, rhs, alpha) {
-        this.x = lhs.x + alpha * (rhs.x - lhs.x);
-        this.y = lhs.y + alpha * (rhs.y - lhs.y);
-
-        return this;
-    },
-
-    /**
-     * @function
-     * @name pc.Vec2#mul
-     * @description Multiplies a 2-dimensional vector to another in place.
-     * @param {pc.Vec2} rhs - The 2-dimensional vector used as the second multiplicand of the operation.
-     * @returns {pc.Vec2} Self for chaining.
-     * @example
-     * var a = new pc.Vec2(2, 3);
-     * var b = new pc.Vec2(4, 5);
-     *
-     * a.mul(b);
-     *
-     * // Should output 8, 15
-     * console.log("The result of the multiplication is: " + a.toString());
-     */
-    mul: function (rhs) {
-        this.x *= rhs.x;
-        this.y *= rhs.y;
-
-        return this;
-    },
-
-    /**
-     * @function
-     * @name pc.Vec2#mul2
-     * @description Returns the result of multiplying the specified 2-dimensional vectors together.
-     * @param {pc.Vec2} lhs - The 2-dimensional vector used as the first multiplicand of the operation.
-     * @param {pc.Vec2} rhs - The 2-dimensional vector used as the second multiplicand of the operation.
-     * @returns {pc.Vec2} Self for chaining.
-     * @example
-     * var a = new pc.Vec2(2, 3);
-     * var b = new pc.Vec2(4, 5);
-     * var r = new pc.Vec2();
-     *
-     * r.mul2(a, b);
-     *
-     * // Should output 8, 15
-     * console.log("The result of the multiplication is: " + r.toString());
-     */
-    mul2: function (lhs, rhs) {
-        this.x = lhs.x * rhs.x;
-        this.y = lhs.y * rhs.y;
-
-        return this;
-    },
-
-    /**
-     * @function
-     * @name pc.Vec2#normalize
-     * @description Returns this 2-dimensional vector converted to a unit vector in place.
-     * If the vector has a length of zero, the vector's elements will be set to zero.
-     * @returns {pc.Vec2} Self for chaining.
-     * @example
-     * var v = new pc.Vec2(25, 0);
-     *
-     * v.normalize();
-     *
-     * // Should output 1, 0
-     * console.log("The result of the vector normalization is: " + v.toString());
-     */
-    normalize: function () {
-        var lengthSq = this.x * this.x + this.y * this.y;
-        if (lengthSq > 0) {
-            var invLength = 1 / Math.sqrt(lengthSq);
-            this.x *= invLength;
-            this.y *= invLength;
-        }
-
-        return this;
-    },
-
-    /**
-     * @function
-     * @name pc.Vec2#scale
-     * @description Scales each component of the specified 2-dimensional vector by the supplied
-     * scalar value.
-     * @param {number} scalar - The value by which each vector component is multiplied.
-     * @returns {pc.Vec2} Self for chaining.
-     * @example
-     * var v = new pc.Vec2(2, 4);
-     *
-     * // Multiply by 2
-     * v.scale(2);
-     *
-     * // Negate
-     * v.scale(-1);
-     *
-     * // Divide by 2
-     * v.scale(0.5);
-     */
-    scale: function (scalar) {
-        this.x *= scalar;
-        this.y *= scalar;
-
-        return this;
-    },
-
-    /**
-     * @function
-     * @name pc.Vec2#set
-     * @description Sets the specified 2-dimensional vector to the supplied numerical values.
-     * @param {number} x - The value to set on the first component of the vector.
-     * @param {number} y - The value to set on the second component of the vector.
-     * @returns {pc.Vec2} Self for chaining.
-     * @example
-     * var v = new pc.Vec2();
-     * v.set(5, 10);
-     *
-     * // Should output 5, 10
-     * console.log("The result of the vector set is: " + v.toString());
-     */
-    set: function (x, y) {
-        this.x = x;
-        this.y = y;
-
-        return this;
-    },
-
-    /**
-     * @function
-     * @name pc.Vec2#sub
-     * @description Subtracts a 2-dimensional vector from another in place.
-     * @param {pc.Vec2} rhs - The vector to add to the specified vector.
-     * @returns {pc.Vec2} Self for chaining.
-     * @example
-     * var a = new pc.Vec2(10, 10);
-     * var b = new pc.Vec2(20, 20);
-     *
-     * a.sub(b);
-     *
-     * // Should output [-10, -10]
-     * console.log("The result of the subtraction is: " + a.toString());
-     */
-    sub: function (rhs) {
-        this.x -= rhs.x;
-        this.y -= rhs.y;
-
-        return this;
-    },
-
-    /**
-     * @function
-     * @name pc.Vec2#sub2
-     * @description Subtracts two 2-dimensional vectors from one another and returns the result.
-     * @param {pc.Vec2} lhs - The first vector operand for the addition.
-     * @param {pc.Vec2} rhs - The second vector operand for the addition.
-     * @returns {pc.Vec2} Self for chaining.
-     * @example
-     * var a = new pc.Vec2(10, 10);
-     * var b = new pc.Vec2(20, 20);
-     * var r = new pc.Vec2();
-     *
-     * r.sub2(a, b);
-     *
-     * // Should output [-10, -10]
-     * console.log("The result of the subtraction is: " + r.toString());
-     */
-    sub2: function (lhs, rhs) {
-        this.x = lhs.x - rhs.x;
-        this.y = lhs.y - rhs.y;
-
-        return this;
-    },
-
-    /**
-     * @function
-     * @name pc.Vec2#toString
-     * @description Converts the vector to string form.
-     * @returns {string} The vector in string form.
-     * @example
-     * var v = new pc.Vec2(20, 10);
-     * // Should output '[20, 10]'
-     * console.log(v.toString());
-     */
-    toString: function () {
-        return '[' + this.x + ', ' + this.y + ']';
-    }
-});
-
 /**
  * @field
  * @name pc.Vec2#x
@@ -412,75 +36,435 @@ Object.assign(Vec2.prototype, {
  * // Set y
  * vec.y = 0;
  */
+class Vec2 {
+    constructor(x, y) {
+        if (x && x.length === 2) {
+            this.x = x[0];
+            this.y = x[1];
+        } else {
+            this.x = x || 0;
+            this.y = y || 0;
+        }
+    }
 
-/**
- * @field
- * @static
- * @readonly
- * @name pc.Vec2.ONE
- * @type {pc.Vec2}
- * @description A constant vector set to [1, 1].
- */
+    /**
+     * @function
+     * @name pc.Vec2#add
+     * @description Adds a 2-dimensional vector to another in place.
+     * @param {pc.Vec2} rhs - The vector to add to the specified vector.
+     * @returns {pc.Vec2} Self for chaining.
+     * @example
+     * var a = new pc.Vec2(10, 10);
+     * var b = new pc.Vec2(20, 20);
+     *
+     * a.add(b);
+     *
+     * // Should output [30, 30]
+     * console.log("The result of the addition is: " + a.toString());
+     */
+    add(rhs) {
+        this.x += rhs.x;
+        this.y += rhs.y;
 
-/**
- * @field
- * @static
- * @readonly
- * @name pc.Vec2.RIGHT
- * @type {pc.Vec2}
- * @description A constant vector set to [1, 0].
- */
+        return this;
+    }
 
-/**
- * @field
- * @static
- * @readonly
- * @name pc.Vec2.LEFT
- * @type {pc.Vec2}
- * @description A constant vector set to [-1, 0].
- */
+    /**
+     * @function
+     * @name pc.Vec2#add2
+     * @description Adds two 2-dimensional vectors together and returns the result.
+     * @param {pc.Vec2} lhs - The first vector operand for the addition.
+     * @param {pc.Vec2} rhs - The second vector operand for the addition.
+     * @returns {pc.Vec2} Self for chaining.
+     * @example
+     * var a = new pc.Vec2(10, 10);
+     * var b = new pc.Vec2(20, 20);
+     * var r = new pc.Vec2();
+     *
+     * r.add2(a, b);
+     * // Should output [30, 30]
+     *
+     * console.log("The result of the addition is: " + r.toString());
+     */
+    add2(lhs, rhs) {
+        this.x = lhs.x + rhs.x;
+        this.y = lhs.y + rhs.y;
 
-/**
- * @field
- * @static
- * @readonly
- * @name pc.Vec2.UP
- * @type {pc.Vec2}
- * @description A constant vector set to [0, 1].
- */
+        return this;
+    }
 
- /**
-  * @field
-  * @static
-  * @readonly
-  * @name pc.Vec2.DOWN
-  * @type {pc.Vec2}
-  * @description A constant vector set to [0, -1].
-  */
+    /**
+     * @function
+     * @name pc.Vec2#clone
+     * @description Returns an identical copy of the specified 2-dimensional vector.
+     * @returns {pc.Vec2} A 2-dimensional vector containing the result of the cloning.
+     * @example
+     * var v = new pc.Vec2(10, 20);
+     * var vclone = v.clone();
+     * console.log("The result of the cloning is: " + vclone.toString());
+     */
+    clone() {
+        return new Vec2().copy(this);
+    }
 
-/**
- * @field
- * @static
- * @readonly
- * @name pc.Vec2.ZERO
- * @type {pc.Vec2}
- * @description A constant vector set to [0, 0].
- */
+    /**
+     * @function
+     * @name pc.Vec2#copy
+     * @description Copied the contents of a source 2-dimensional vector to a destination 2-dimensional vector.
+     * @param {pc.Vec2} rhs - A vector to copy to the specified vector.
+     * @returns {pc.Vec2} Self for chaining.
+     * @example
+     * var src = new pc.Vec2(10, 20);
+     * var dst = new pc.Vec2();
+     *
+     * dst.copy(src);
+     *
+     * console.log("The two vectors are " + (dst.equals(src) ? "equal" : "different"));
+     */
+    copy(rhs) {
+        this.x = rhs.x;
+        this.y = rhs.y;
 
-Object.defineProperties(Vec2, {
-    ZERO: { value: new Vec2(0, 0) },
-    ONE: { value: new Vec2(1, 1) },
-    UP: { value: new Vec2(0, 1) },
-    DOWN: { value: new Vec2(0, -1) },
-    RIGHT: { value: new Vec2(1, 0) },
-    LEFT: { value: new Vec2(-1, 0) }
-});
+        return this;
+    }
 
-Object.freeze(Vec2.ZERO);
-Object.freeze(Vec2.ONE);
-Object.freeze(Vec2.UP);
-Object.freeze(Vec2.DOWN);
-Object.freeze(Vec2.RIGHT);
-Object.freeze(Vec2.LEFT);
+    /**
+     * @function
+     * @name pc.Vec2#distance
+     * @description Returns the distance between the two specified 2-dimensional vectors.
+     * @param {pc.Vec2} rhs - The second 2-dimensional vector to test.
+     * @returns {number} The distance between the two vectors.
+     * @example
+     * var v1 = new pc.Vec2(5, 10);
+     * var v2 = new pc.Vec2(10, 20);
+     * var d = v1.distance(v2);
+     * console.log("The between v1 and v2 is: " + d);
+     */
+    distance(rhs) {
+        var x = this.x - rhs.x;
+        var y = this.y - rhs.y;
+        return Math.sqrt(x * x + y * y);
+    }
+
+    /**
+     * @function
+     * @name pc.Vec2#dot
+     * @description Returns the result of a dot product operation performed on the two specified 2-dimensional vectors.
+     * @param {pc.Vec2} rhs - The second 2-dimensional vector operand of the dot product.
+     * @returns {number} The result of the dot product operation.
+     * @example
+     * var v1 = new pc.Vec2(5, 10);
+     * var v2 = new pc.Vec2(10, 20);
+     * var v1dotv2 = v1.dot(v2);
+     * console.log("The result of the dot product is: " + v1dotv2);
+     */
+    dot(rhs) {
+        return this.x * rhs.x + this.y * rhs.y;
+    }
+
+    /**
+     * @function
+     * @name pc.Vec2#equals
+     * @description Reports whether two vectors are equal.
+     * @param {pc.Vec2} rhs - The vector to compare to the specified vector.
+     * @returns {boolean} True if the vectors are equal and false otherwise.
+     * @example
+     * var a = new pc.Vec2(1, 2);
+     * var b = new pc.Vec2(4, 5);
+     * console.log("The two vectors are " + (a.equals(b) ? "equal" : "different"));
+     */
+    equals(rhs) {
+        return this.x === rhs.x && this.y === rhs.y;
+    }
+
+    /**
+     * @function
+     * @name pc.Vec2#length
+     * @description Returns the magnitude of the specified 2-dimensional vector.
+     * @returns {number} The magnitude of the specified 2-dimensional vector.
+     * @example
+     * var vec = new pc.Vec2(3, 4);
+     * var len = vec.length();
+     * // Should output 5
+     * console.log("The length of the vector is: " + len);
+     */
+    length() {
+        return Math.sqrt(this.x * this.x + this.y * this.y);
+    }
+
+    /**
+     * @function
+     * @name pc.Vec2#lengthSq
+     * @description Returns the magnitude squared of the specified 2-dimensional vector.
+     * @returns {number} The magnitude of the specified 2-dimensional vector.
+     * @example
+     * var vec = new pc.Vec2(3, 4);
+     * var len = vec.lengthSq();
+     * // Should output 25
+     * console.log("The length squared of the vector is: " + len);
+     */
+    lengthSq() {
+        return this.x * this.x + this.y * this.y;
+    }
+
+    /**
+     * @function
+     * @name pc.Vec2#lerp
+     * @description Returns the result of a linear interpolation between two specified 2-dimensional vectors.
+     * @param {pc.Vec2} lhs - The 2-dimensional to interpolate from.
+     * @param {pc.Vec2} rhs - The 2-dimensional to interpolate to.
+     * @param {number} alpha - The value controlling the point of interpolation. Between 0 and 1, the linear interpolant
+     * will occur on a straight line between lhs and rhs. Outside of this range, the linear interpolant will occur on
+     * a ray extrapolated from this line.
+     * @returns {pc.Vec2} Self for chaining.
+     * @example
+     * var a = new pc.Vec2(0, 0);
+     * var b = new pc.Vec2(10, 10);
+     * var r = new pc.Vec2();
+     *
+     * r.lerp(a, b, 0);   // r is equal to a
+     * r.lerp(a, b, 0.5); // r is 5, 5
+     * r.lerp(a, b, 1);   // r is equal to b
+     */
+    lerp(lhs, rhs, alpha) {
+        this.x = lhs.x + alpha * (rhs.x - lhs.x);
+        this.y = lhs.y + alpha * (rhs.y - lhs.y);
+
+        return this;
+    }
+
+    /**
+     * @function
+     * @name pc.Vec2#mul
+     * @description Multiplies a 2-dimensional vector to another in place.
+     * @param {pc.Vec2} rhs - The 2-dimensional vector used as the second multiplicand of the operation.
+     * @returns {pc.Vec2} Self for chaining.
+     * @example
+     * var a = new pc.Vec2(2, 3);
+     * var b = new pc.Vec2(4, 5);
+     *
+     * a.mul(b);
+     *
+     * // Should output 8, 15
+     * console.log("The result of the multiplication is: " + a.toString());
+     */
+    mul(rhs) {
+        this.x *= rhs.x;
+        this.y *= rhs.y;
+
+        return this;
+    }
+
+    /**
+     * @function
+     * @name pc.Vec2#mul2
+     * @description Returns the result of multiplying the specified 2-dimensional vectors together.
+     * @param {pc.Vec2} lhs - The 2-dimensional vector used as the first multiplicand of the operation.
+     * @param {pc.Vec2} rhs - The 2-dimensional vector used as the second multiplicand of the operation.
+     * @returns {pc.Vec2} Self for chaining.
+     * @example
+     * var a = new pc.Vec2(2, 3);
+     * var b = new pc.Vec2(4, 5);
+     * var r = new pc.Vec2();
+     *
+     * r.mul2(a, b);
+     *
+     * // Should output 8, 15
+     * console.log("The result of the multiplication is: " + r.toString());
+     */
+    mul2(lhs, rhs) {
+        this.x = lhs.x * rhs.x;
+        this.y = lhs.y * rhs.y;
+
+        return this;
+    }
+
+    /**
+     * @function
+     * @name pc.Vec2#normalize
+     * @description Returns this 2-dimensional vector converted to a unit vector in place.
+     * If the vector has a length of zero, the vector's elements will be set to zero.
+     * @returns {pc.Vec2} Self for chaining.
+     * @example
+     * var v = new pc.Vec2(25, 0);
+     *
+     * v.normalize();
+     *
+     * // Should output 1, 0
+     * console.log("The result of the vector normalization is: " + v.toString());
+     */
+    normalize() {
+        var lengthSq = this.x * this.x + this.y * this.y;
+        if (lengthSq > 0) {
+            var invLength = 1 / Math.sqrt(lengthSq);
+            this.x *= invLength;
+            this.y *= invLength;
+        }
+
+        return this;
+    }
+
+    /**
+     * @function
+     * @name pc.Vec2#scale
+     * @description Scales each component of the specified 2-dimensional vector by the supplied
+     * scalar value.
+     * @param {number} scalar - The value by which each vector component is multiplied.
+     * @returns {pc.Vec2} Self for chaining.
+     * @example
+     * var v = new pc.Vec2(2, 4);
+     *
+     * // Multiply by 2
+     * v.scale(2);
+     *
+     * // Negate
+     * v.scale(-1);
+     *
+     * // Divide by 2
+     * v.scale(0.5);
+     */
+    scale(scalar) {
+        this.x *= scalar;
+        this.y *= scalar;
+
+        return this;
+    }
+
+    /**
+     * @function
+     * @name pc.Vec2#set
+     * @description Sets the specified 2-dimensional vector to the supplied numerical values.
+     * @param {number} x - The value to set on the first component of the vector.
+     * @param {number} y - The value to set on the second component of the vector.
+     * @returns {pc.Vec2} Self for chaining.
+     * @example
+     * var v = new pc.Vec2();
+     * v.set(5, 10);
+     *
+     * // Should output 5, 10
+     * console.log("The result of the vector set is: " + v.toString());
+     */
+    set(x, y) {
+        this.x = x;
+        this.y = y;
+
+        return this;
+    }
+
+    /**
+     * @function
+     * @name pc.Vec2#sub
+     * @description Subtracts a 2-dimensional vector from another in place.
+     * @param {pc.Vec2} rhs - The vector to add to the specified vector.
+     * @returns {pc.Vec2} Self for chaining.
+     * @example
+     * var a = new pc.Vec2(10, 10);
+     * var b = new pc.Vec2(20, 20);
+     *
+     * a.sub(b);
+     *
+     * // Should output [-10, -10]
+     * console.log("The result of the subtraction is: " + a.toString());
+     */
+    sub(rhs) {
+        this.x -= rhs.x;
+        this.y -= rhs.y;
+
+        return this;
+    }
+
+    /**
+     * @function
+     * @name pc.Vec2#sub2
+     * @description Subtracts two 2-dimensional vectors from one another and returns the result.
+     * @param {pc.Vec2} lhs - The first vector operand for the addition.
+     * @param {pc.Vec2} rhs - The second vector operand for the addition.
+     * @returns {pc.Vec2} Self for chaining.
+     * @example
+     * var a = new pc.Vec2(10, 10);
+     * var b = new pc.Vec2(20, 20);
+     * var r = new pc.Vec2();
+     *
+     * r.sub2(a, b);
+     *
+     * // Should output [-10, -10]
+     * console.log("The result of the subtraction is: " + r.toString());
+     */
+    sub2(lhs, rhs) {
+        this.x = lhs.x - rhs.x;
+        this.y = lhs.y - rhs.y;
+
+        return this;
+    }
+
+    /**
+     * @function
+     * @name pc.Vec2#toString
+     * @description Converts the vector to string form.
+     * @returns {string} The vector in string form.
+     * @example
+     * var v = new pc.Vec2(20, 10);
+     * // Should output '[20, 10]'
+     * console.log(v.toString());
+     */
+    toString() {
+        return '[' + this.x + ', ' + this.y + ']';
+    }
+
+    /**
+     * @field
+     * @static
+     * @readonly
+     * @name pc.Vec2.ZERO
+     * @type {pc.Vec2}
+     * @description A constant vector set to [0, 0].
+     */
+    static ZERO = Object.freeze(new Vec2(0, 0));
+    /**
+     * @field
+     * @static
+     * @readonly
+     * @name pc.Vec2.ONE
+     * @type {pc.Vec2}
+     * @description A constant vector set to [1, 1].
+     */
+    static ONE = Object.freeze(new Vec2(1, 1));
+    /**
+     * @field
+     * @static
+     * @readonly
+     * @name pc.Vec2.UP
+     * @type {pc.Vec2}
+     * @description A constant vector set to [0, 1].
+     */
+    static UP = Object.freeze(new Vec2(0, 1));
+    /**
+     * @field
+     * @static
+     * @readonly
+     * @name pc.Vec2.DOWN
+     * @type {pc.Vec2}
+     * @description A constant vector set to [0, -1].
+     */
+    static DOWN = Object.freeze(new Vec2(0, -1));
+    /**
+     * @field
+     * @static
+     * @readonly
+     * @name pc.Vec2.RIGHT
+     * @type {pc.Vec2}
+     * @description A constant vector set to [1, 0].
+     */
+    static RIGHT = Object.freeze(new Vec2(1, 0));
+    /**
+     * @field
+     * @static
+     * @readonly
+     * @name pc.Vec2.LEFT
+     * @type {pc.Vec2}
+     * @description A constant vector set to [-1, 0].
+     */
+    static LEFT = Object.freeze(new Vec2(-1, 0));
+}
 
 export { Vec2 };

--- a/src/math/vec2.js
+++ b/src/math/vec2.js
@@ -37,13 +37,13 @@
  * vec.y = 0;
  */
 class Vec2 {
-    constructor(x, y) {
+    constructor(x = 0, y = 0) {
         if (x && x.length === 2) {
             this.x = x[0];
             this.y = x[1];
         } else {
-            this.x = x || 0;
-            this.y = y || 0;
+            this.x = x;
+            this.y = y;
         }
     }
 
@@ -104,7 +104,7 @@ class Vec2 {
      * console.log("The result of the cloning is: " + vclone.toString());
      */
     clone() {
-        return new Vec2().copy(this);
+        return new Vec2(this.x, this.y);
     }
 
     /**

--- a/src/math/vec2.js
+++ b/src/math/vec2.js
@@ -420,6 +420,7 @@ class Vec2 {
      * @description A constant vector set to [0, 0].
      */
     static ZERO = Object.freeze(new Vec2(0, 0));
+
     /**
      * @field
      * @static
@@ -429,6 +430,7 @@ class Vec2 {
      * @description A constant vector set to [1, 1].
      */
     static ONE = Object.freeze(new Vec2(1, 1));
+
     /**
      * @field
      * @static
@@ -438,6 +440,7 @@ class Vec2 {
      * @description A constant vector set to [0, 1].
      */
     static UP = Object.freeze(new Vec2(0, 1));
+
     /**
      * @field
      * @static
@@ -447,6 +450,7 @@ class Vec2 {
      * @description A constant vector set to [0, -1].
      */
     static DOWN = Object.freeze(new Vec2(0, -1));
+
     /**
      * @field
      * @static
@@ -456,6 +460,7 @@ class Vec2 {
      * @description A constant vector set to [1, 0].
      */
     static RIGHT = Object.freeze(new Vec2(1, 0));
+
     /**
      * @field
      * @static

--- a/src/math/vec2.js
+++ b/src/math/vec2.js
@@ -38,7 +38,7 @@
  */
 class Vec2 {
     constructor(x = 0, y = 0) {
-        if (x && x.length === 2) {
+        if (x.length === 2) {
             this.x = x[0];
             this.y = x[1];
         } else {

--- a/src/math/vec3.js
+++ b/src/math/vec3.js
@@ -9,451 +9,6 @@
  * @example
  * var v = new pc.Vec3(1, 2, 3);
  */
-function Vec3(x, y, z) {
-    if (x && x.length === 3) {
-        this.x = x[0];
-        this.y = x[1];
-        this.z = x[2];
-    } else {
-        this.x = x || 0;
-        this.y = y || 0;
-        this.z = z || 0;
-    }
-}
-
-Object.assign(Vec3.prototype, {
-    /**
-     * @function
-     * @name pc.Vec3#add
-     * @description Adds a 3-dimensional vector to another in place.
-     * @param {pc.Vec3} rhs - The vector to add to the specified vector.
-     * @returns {pc.Vec3} Self for chaining.
-     * @example
-     * var a = new pc.Vec3(10, 10, 10);
-     * var b = new pc.Vec3(20, 20, 20);
-     *
-     * a.add(b);
-     *
-     * // Should output [30, 30, 30]
-     * console.log("The result of the addition is: " + a.toString());
-     */
-    add: function (rhs) {
-        this.x += rhs.x;
-        this.y += rhs.y;
-        this.z += rhs.z;
-
-        return this;
-    },
-
-    /**
-     * @function
-     * @name pc.Vec3#add2
-     * @description Adds two 3-dimensional vectors together and returns the result.
-     * @param {pc.Vec3} lhs - The first vector operand for the addition.
-     * @param {pc.Vec3} rhs - The second vector operand for the addition.
-     * @returns {pc.Vec3} Self for chaining.
-     * @example
-     * var a = new pc.Vec3(10, 10, 10);
-     * var b = new pc.Vec3(20, 20, 20);
-     * var r = new pc.Vec3();
-     *
-     * r.add2(a, b);
-     * // Should output [30, 30, 30]
-     *
-     * console.log("The result of the addition is: " + r.toString());
-     */
-    add2: function (lhs, rhs) {
-        this.x = lhs.x + rhs.x;
-        this.y = lhs.y + rhs.y;
-        this.z = lhs.z + rhs.z;
-
-        return this;
-    },
-
-    /**
-     * @function
-     * @name pc.Vec3#clone
-     * @description Returns an identical copy of the specified 3-dimensional vector.
-     * @returns {pc.Vec3} A 3-dimensional vector containing the result of the cloning.
-     * @example
-     * var v = new pc.Vec3(10, 20, 30);
-     * var vclone = v.clone();
-     * console.log("The result of the cloning is: " + vclone.toString());
-     */
-    clone: function () {
-        return new Vec3().copy(this);
-    },
-
-    /**
-     * @function
-     * @name pc.Vec3#copy
-     * @description Copied the contents of a source 3-dimensional vector to a destination 3-dimensional vector.
-     * @param {pc.Vec3} rhs - A vector to copy to the specified vector.
-     * @returns {pc.Vec3} Self for chaining.
-     * @example
-     * var src = new pc.Vec3(10, 20, 30);
-     * var dst = new pc.Vec3();
-     *
-     * dst.copy(src);
-     *
-     * console.log("The two vectors are " + (dst.equals(src) ? "equal" : "different"));
-     */
-    copy: function (rhs) {
-        this.x = rhs.x;
-        this.y = rhs.y;
-        this.z = rhs.z;
-
-        return this;
-    },
-
-    /**
-     * @function
-     * @name pc.Vec3#cross
-     * @description Returns the result of a cross product operation performed on the two specified 3-dimensional vectors.
-     * @param {pc.Vec3} lhs - The first 3-dimensional vector operand of the cross product.
-     * @param {pc.Vec3} rhs - The second 3-dimensional vector operand of the cross product.
-     * @returns {pc.Vec3} Self for chaining.
-     * @example
-     * var back = new pc.Vec3().cross(pc.Vec3.RIGHT, pc.Vec3.UP);
-     *
-     * // Should print the Z axis (i.e. [0, 0, 1])
-     * console.log("The result of the cross product is: " + back.toString());
-     */
-    cross: function (lhs, rhs) {
-        // Create temporary variables in case lhs or rhs are 'this'
-        var lx = lhs.x;
-        var ly = lhs.y;
-        var lz = lhs.z;
-        var rx = rhs.x;
-        var ry = rhs.y;
-        var rz = rhs.z;
-
-        this.x = ly * rz - ry * lz;
-        this.y = lz * rx - rz * lx;
-        this.z = lx * ry - rx * ly;
-
-        return this;
-    },
-
-    /**
-     * @function
-     * @name pc.Vec3#distance
-     * @description Returns the distance between the two specified 3-dimensional vectors.
-     * @param {pc.Vec3} rhs - The second 3-dimensional vector to test.
-     * @returns {number} The distance between the two vectors.
-     * @example
-     * var v1 = new pc.Vec3(5, 10, 20);
-     * var v2 = new pc.Vec3(10, 20, 40);
-     * var d = v1.distance(v2);
-     * console.log("The between v1 and v2 is: " + d);
-     */
-    distance: function (rhs) {
-        var x = this.x - rhs.x;
-        var y = this.y - rhs.y;
-        var z = this.z - rhs.z;
-        return Math.sqrt(x * x + y * y + z * z);
-    },
-
-    /**
-     * @function
-     * @name pc.Vec3#dot
-     * @description Returns the result of a dot product operation performed on the two specified 3-dimensional vectors.
-     * @param {pc.Vec3} rhs - The second 3-dimensional vector operand of the dot product.
-     * @returns {number} The result of the dot product operation.
-     * @example
-     * var v1 = new pc.Vec3(5, 10, 20);
-     * var v2 = new pc.Vec3(10, 20, 40);
-     * var v1dotv2 = v1.dot(v2);
-     * console.log("The result of the dot product is: " + v1dotv2);
-     */
-    dot: function (rhs) {
-        return this.x * rhs.x + this.y * rhs.y + this.z * rhs.z;
-    },
-
-    /**
-     * @function
-     * @name pc.Vec3#equals
-     * @description Reports whether two vectors are equal.
-     * @param {pc.Vec3} rhs - The vector to compare to the specified vector.
-     * @returns {boolean} True if the vectors are equal and false otherwise.
-     * @example
-     * var a = new pc.Vec3(1, 2, 3);
-     * var b = new pc.Vec3(4, 5, 6);
-     * console.log("The two vectors are " + (a.equals(b) ? "equal" : "different"));
-     */
-    equals: function (rhs) {
-        return this.x === rhs.x && this.y === rhs.y && this.z === rhs.z;
-    },
-
-    /**
-     * @function
-     * @name pc.Vec3#length
-     * @description Returns the magnitude of the specified 3-dimensional vector.
-     * @returns {number} The magnitude of the specified 3-dimensional vector.
-     * @example
-     * var vec = new pc.Vec3(3, 4, 0);
-     * var len = vec.length();
-     * // Should output 5
-     * console.log("The length of the vector is: " + len);
-     */
-    length: function () {
-        return Math.sqrt(this.x * this.x + this.y * this.y + this.z * this.z);
-    },
-
-    /**
-     * @function
-     * @name pc.Vec3#lengthSq
-     * @description Returns the magnitude squared of the specified 3-dimensional vector.
-     * @returns {number} The magnitude of the specified 3-dimensional vector.
-     * @example
-     * var vec = new pc.Vec3(3, 4, 0);
-     * var len = vec.lengthSq();
-     * // Should output 25
-     * console.log("The length squared of the vector is: " + len);
-     */
-    lengthSq: function () {
-        return this.x * this.x + this.y * this.y + this.z * this.z;
-    },
-
-    /**
-     * @function
-     * @name pc.Vec3#lerp
-     * @description Returns the result of a linear interpolation between two specified 3-dimensional vectors.
-     * @param {pc.Vec3} lhs - The 3-dimensional to interpolate from.
-     * @param {pc.Vec3} rhs - The 3-dimensional to interpolate to.
-     * @param {number} alpha - The value controlling the point of interpolation. Between 0 and 1, the linear interpolant
-     * will occur on a straight line between lhs and rhs. Outside of this range, the linear interpolant will occur on
-     * a ray extrapolated from this line.
-     * @returns {pc.Vec3} Self for chaining.
-     * @example
-     * var a = new pc.Vec3(0, 0, 0);
-     * var b = new pc.Vec3(10, 10, 10);
-     * var r = new pc.Vec3();
-     *
-     * r.lerp(a, b, 0);   // r is equal to a
-     * r.lerp(a, b, 0.5); // r is 5, 5, 5
-     * r.lerp(a, b, 1);   // r is equal to b
-     */
-    lerp: function (lhs, rhs, alpha) {
-        this.x = lhs.x + alpha * (rhs.x - lhs.x);
-        this.y = lhs.y + alpha * (rhs.y - lhs.y);
-        this.z = lhs.z + alpha * (rhs.z - lhs.z);
-
-        return this;
-    },
-
-    /**
-     * @function
-     * @name pc.Vec3#mul
-     * @description Multiplies a 3-dimensional vector to another in place.
-     * @param {pc.Vec3} rhs - The 3-dimensional vector used as the second multiplicand of the operation.
-     * @returns {pc.Vec3} Self for chaining.
-     * @example
-     * var a = new pc.Vec3(2, 3, 4);
-     * var b = new pc.Vec3(4, 5, 6);
-     *
-     * a.mul(b);
-     *
-     * // Should output 8, 15, 24
-     * console.log("The result of the multiplication is: " + a.toString());
-     */
-    mul: function (rhs) {
-        this.x *= rhs.x;
-        this.y *= rhs.y;
-        this.z *= rhs.z;
-
-        return this;
-    },
-
-    /**
-     * @function
-     * @name pc.Vec3#mul2
-     * @description Returns the result of multiplying the specified 3-dimensional vectors together.
-     * @param {pc.Vec3} lhs - The 3-dimensional vector used as the first multiplicand of the operation.
-     * @param {pc.Vec3} rhs - The 3-dimensional vector used as the second multiplicand of the operation.
-     * @returns {pc.Vec3} Self for chaining.
-     * @example
-     * var a = new pc.Vec3(2, 3, 4);
-     * var b = new pc.Vec3(4, 5, 6);
-     * var r = new pc.Vec3();
-     *
-     * r.mul2(a, b);
-     *
-     * // Should output 8, 15, 24
-     * console.log("The result of the multiplication is: " + r.toString());
-     */
-    mul2: function (lhs, rhs) {
-        this.x = lhs.x * rhs.x;
-        this.y = lhs.y * rhs.y;
-        this.z = lhs.z * rhs.z;
-
-        return this;
-    },
-
-    /**
-     * @function
-     * @name pc.Vec3#normalize
-     * @description Returns this 3-dimensional vector converted to a unit vector in place.
-     * If the vector has a length of zero, the vector's elements will be set to zero.
-     * @returns {pc.Vec3} Self for chaining.
-     * @example
-     * var v = new pc.Vec3(25, 0, 0);
-     *
-     * v.normalize();
-     *
-     * // Should output 1, 0, 0
-     * console.log("The result of the vector normalization is: " + v.toString());
-     */
-    normalize: function () {
-        var lengthSq = this.x * this.x + this.y * this.y + this.z * this.z;
-        if (lengthSq > 0) {
-            var invLength = 1 / Math.sqrt(lengthSq);
-            this.x *= invLength;
-            this.y *= invLength;
-            this.z *= invLength;
-        }
-
-        return this;
-    },
-
-    /**
-     * @function
-     * @name  pc.Vec3#project
-     * @description Projects this 3-dimensional vector onto the specified vector.
-     * @param {pc.Vec3} rhs - The vector onto which the original vector will be projected on.
-     * @returns {pc.Vec3} Self for chaining.
-     * @example
-     * var v = new pc.Vec3(5, 5, 5);
-     * var normal = new pc.Vec3(1, 0, 0);
-     *
-     * v.project(normal);
-     *
-     * // Should output 5, 0, 0
-     * console.log("The result of the vector projection is: " + v.toString());
-     */
-    project: function (rhs) {
-        var a_dot_b = this.x * rhs.x + this.y * rhs.y + this.z * rhs.z;
-        var b_dot_b = rhs.x * rhs.x + rhs.y * rhs.y + rhs.z * rhs.z;
-        var s = a_dot_b / b_dot_b;
-        this.x = rhs.x * s;
-        this.y = rhs.y * s;
-        this.z = rhs.z * s;
-        return this;
-    },
-
-    /**
-     * @function
-     * @name pc.Vec3#scale
-     * @description Scales each dimension of the specified 3-dimensional vector by the supplied
-     * scalar value.
-     * @param {number} scalar - The value by which each vector component is multiplied.
-     * @returns {pc.Vec3} Self for chaining.
-     * @example
-     * var v = new pc.Vec3(2, 4, 8);
-     *
-     * // Multiply by 2
-     * v.scale(2);
-     *
-     * // Negate
-     * v.scale(-1);
-     *
-     * // Divide by 2
-     * v.scale(0.5);
-     */
-    scale: function (scalar) {
-        this.x *= scalar;
-        this.y *= scalar;
-        this.z *= scalar;
-
-        return this;
-    },
-
-    /**
-     * @function
-     * @name pc.Vec3#set
-     * @description Sets the specified 3-dimensional vector to the supplied numerical values.
-     * @param {number} x - The value to set on the first component of the vector.
-     * @param {number} y - The value to set on the second component of the vector.
-     * @param {number} z - The value to set on the third component of the vector.
-     * @returns {pc.Vec3} Self for chaining.
-     * @example
-     * var v = new pc.Vec3();
-     * v.set(5, 10, 20);
-     *
-     * // Should output 5, 10, 20
-     * console.log("The result of the vector set is: " + v.toString());
-     */
-    set: function (x, y, z) {
-        this.x = x;
-        this.y = y;
-        this.z = z;
-
-        return this;
-    },
-
-    /**
-     * @function
-     * @name pc.Vec3#sub
-     * @description Subtracts a 3-dimensional vector from another in place.
-     * @param {pc.Vec3} rhs - The vector to add to the specified vector.
-     * @returns {pc.Vec3} Self for chaining.
-     * @example
-     * var a = new pc.Vec3(10, 10, 10);
-     * var b = new pc.Vec3(20, 20, 20);
-     *
-     * a.sub(b);
-     *
-     * // Should output [-10, -10, -10]
-     * console.log("The result of the subtraction is: " + a.toString());
-     */
-    sub: function (rhs) {
-        this.x -= rhs.x;
-        this.y -= rhs.y;
-        this.z -= rhs.z;
-
-        return this;
-    },
-
-    /**
-     * @function
-     * @name pc.Vec3#sub2
-     * @description Subtracts two 3-dimensional vectors from one another and returns the result.
-     * @param {pc.Vec3} lhs - The first vector operand for the addition.
-     * @param {pc.Vec3} rhs - The second vector operand for the addition.
-     * @returns {pc.Vec3} Self for chaining.
-     * @example
-     * var a = new pc.Vec3(10, 10, 10);
-     * var b = new pc.Vec3(20, 20, 20);
-     * var r = new pc.Vec3();
-     *
-     * r.sub2(a, b);
-     *
-     * // Should output [-10, -10, -10]
-     * console.log("The result of the subtraction is: " + r.toString());
-     */
-    sub2: function (lhs, rhs) {
-        this.x = lhs.x - rhs.x;
-        this.y = lhs.y - rhs.y;
-        this.z = lhs.z - rhs.z;
-
-        return this;
-    },
-
-    /**
-     * @function
-     * @name pc.Vec3#toString
-     * @description Converts the vector to string form.
-     * @returns {string} The vector in string form.
-     * @example
-     * var v = new pc.Vec3(20, 10, 5);
-     * // Should output '[20, 10, 5]'
-     * console.log(v.toString());
-     */
-    toString: function () {
-        return '[' + this.x + ', ' + this.y + ', ' + this.z + ']';
-    }
-});
-
 /**
  * @name pc.Vec3#x
  * @type {number}
@@ -493,94 +48,522 @@ Object.assign(Vec3.prototype, {
  * // Set z
  * vec.z = 0;
  */
+class Vec3 {
+    constructor(x, y, z) {
+        if (x && x.length === 3) {
+            this.x = x[0];
+            this.y = x[1];
+            this.z = x[2];
+        } else {
+            this.x = x || 0;
+            this.y = y || 0;
+            this.z = z || 0;
+        }
+    }
 
-/**
- * @static
- * @readonly
- * @name pc.Vec3.BACK
- * @type {pc.Vec3}
- * @description A constant vector set to [0, 0, 1].
- */
+    /**
+     * @function
+     * @name pc.Vec3#add
+     * @description Adds a 3-dimensional vector to another in place.
+     * @param {pc.Vec3} rhs - The vector to add to the specified vector.
+     * @returns {pc.Vec3} Self for chaining.
+     * @example
+     * var a = new pc.Vec3(10, 10, 10);
+     * var b = new pc.Vec3(20, 20, 20);
+     *
+     * a.add(b);
+     *
+     * // Should output [30, 30, 30]
+     * console.log("The result of the addition is: " + a.toString());
+     */
+    add(rhs) {
+        this.x += rhs.x;
+        this.y += rhs.y;
+        this.z += rhs.z;
 
-/**
- * @static
- * @readonly
- * @name pc.Vec3.DOWN
- * @type {pc.Vec3}
- * @description A constant vector set to [0, -1, 0].
- */
+        return this;
+    }
 
-/**
- * @static
- * @readonly
- * @name pc.Vec3.FORWARD
- * @type {pc.Vec3}
- * @description A constant vector set to [0, 0, -1].
- */
+    /**
+     * @function
+     * @name pc.Vec3#add2
+     * @description Adds two 3-dimensional vectors together and returns the result.
+     * @param {pc.Vec3} lhs - The first vector operand for the addition.
+     * @param {pc.Vec3} rhs - The second vector operand for the addition.
+     * @returns {pc.Vec3} Self for chaining.
+     * @example
+     * var a = new pc.Vec3(10, 10, 10);
+     * var b = new pc.Vec3(20, 20, 20);
+     * var r = new pc.Vec3();
+     *
+     * r.add2(a, b);
+     * // Should output [30, 30, 30]
+     *
+     * console.log("The result of the addition is: " + r.toString());
+     */
+    add2(lhs, rhs) {
+        this.x = lhs.x + rhs.x;
+        this.y = lhs.y + rhs.y;
+        this.z = lhs.z + rhs.z;
 
-/**
- * @field
- * @static
- * @readonly
- * @name pc.Vec3.LEFT
- * @type {pc.Vec3}
- * @description A constant vector set to [-1, 0, 0].
- */
+        return this;
+    }
 
-/**
- * @field
- * @static
- * @readonly
- * @name pc.Vec3.ONE
- * @type {pc.Vec3}
- * @description A constant vector set to [1, 1, 1].
- */
+    /**
+     * @function
+     * @name pc.Vec3#clone
+     * @description Returns an identical copy of the specified 3-dimensional vector.
+     * @returns {pc.Vec3} A 3-dimensional vector containing the result of the cloning.
+     * @example
+     * var v = new pc.Vec3(10, 20, 30);
+     * var vclone = v.clone();
+     * console.log("The result of the cloning is: " + vclone.toString());
+     */
+    clone() {
+        return new Vec3().copy(this);
+    }
 
-/**
- * @field
- * @static
- * @readonly
- * @name pc.Vec3.RIGHT
- * @type {pc.Vec3}
- * @description A constant vector set to [1, 0, 0].
- */
+    /**
+     * @function
+     * @name pc.Vec3#copy
+     * @description Copied the contents of a source 3-dimensional vector to a destination 3-dimensional vector.
+     * @param {pc.Vec3} rhs - A vector to copy to the specified vector.
+     * @returns {pc.Vec3} Self for chaining.
+     * @example
+     * var src = new pc.Vec3(10, 20, 30);
+     * var dst = new pc.Vec3();
+     *
+     * dst.copy(src);
+     *
+     * console.log("The two vectors are " + (dst.equals(src) ? "equal" : "different"));
+     */
+    copy(rhs) {
+        this.x = rhs.x;
+        this.y = rhs.y;
+        this.z = rhs.z;
 
-/**
- * @field
- * @static
- * @readonly
- * @name pc.Vec3.UP
- * @type {pc.Vec3}
- * @description A constant vector set to [0, 1, 0].
- */
+        return this;
+    }
 
-/**
- * @field
- * @static
- * @readonly
- * @name pc.Vec3.ZERO
- * @type {pc.Vec3}
- * @description A constant vector set to [0, 0, 0].
- */
+    /**
+     * @function
+     * @name pc.Vec3#cross
+     * @description Returns the result of a cross product operation performed on the two specified 3-dimensional vectors.
+     * @param {pc.Vec3} lhs - The first 3-dimensional vector operand of the cross product.
+     * @param {pc.Vec3} rhs - The second 3-dimensional vector operand of the cross product.
+     * @returns {pc.Vec3} Self for chaining.
+     * @example
+     * var back = new pc.Vec3().cross(pc.Vec3.RIGHT, pc.Vec3.UP);
+     *
+     * // Should print the Z axis (i.e. [0, 0, 1])
+     * console.log("The result of the cross product is: " + back.toString());
+     */
+    cross(lhs, rhs) {
+        // Create temporary variables in case lhs or rhs are 'this'
+        var lx = lhs.x;
+        var ly = lhs.y;
+        var lz = lhs.z;
+        var rx = rhs.x;
+        var ry = rhs.y;
+        var rz = rhs.z;
 
-Object.defineProperties(Vec3, {
-    ZERO: { value: new Vec3(0, 0, 0) },
-    ONE: { value: new Vec3(1, 1, 1) },
-    UP: { value: new Vec3(0, 1, 0) },
-    DOWN: { value: new Vec3(0, -1, 0) },
-    RIGHT: { value: new Vec3(1, 0, 0) },
-    LEFT: { value: new Vec3(-1, 0, 0) },
-    FORWARD: { value: new Vec3(0, 0, -1) },
-    BACK: { value: new Vec3(0, 0, 1) }
-});
+        this.x = ly * rz - ry * lz;
+        this.y = lz * rx - rz * lx;
+        this.z = lx * ry - rx * ly;
 
-Object.freeze(Vec3.ZERO);
-Object.freeze(Vec3.ONE);
-Object.freeze(Vec3.UP);
-Object.freeze(Vec3.DOWN);
-Object.freeze(Vec3.RIGHT);
-Object.freeze(Vec3.LEFT);
-Object.freeze(Vec3.FORWARD);
-Object.freeze(Vec3.BACK);
+        return this;
+    }
+
+    /**
+     * @function
+     * @name pc.Vec3#distance
+     * @description Returns the distance between the two specified 3-dimensional vectors.
+     * @param {pc.Vec3} rhs - The second 3-dimensional vector to test.
+     * @returns {number} The distance between the two vectors.
+     * @example
+     * var v1 = new pc.Vec3(5, 10, 20);
+     * var v2 = new pc.Vec3(10, 20, 40);
+     * var d = v1.distance(v2);
+     * console.log("The between v1 and v2 is: " + d);
+     */
+    distance(rhs) {
+        var x = this.x - rhs.x;
+        var y = this.y - rhs.y;
+        var z = this.z - rhs.z;
+        return Math.sqrt(x * x + y * y + z * z);
+    }
+
+    /**
+     * @function
+     * @name pc.Vec3#dot
+     * @description Returns the result of a dot product operation performed on the two specified 3-dimensional vectors.
+     * @param {pc.Vec3} rhs - The second 3-dimensional vector operand of the dot product.
+     * @returns {number} The result of the dot product operation.
+     * @example
+     * var v1 = new pc.Vec3(5, 10, 20);
+     * var v2 = new pc.Vec3(10, 20, 40);
+     * var v1dotv2 = v1.dot(v2);
+     * console.log("The result of the dot product is: " + v1dotv2);
+     */
+    dot(rhs) {
+        return this.x * rhs.x + this.y * rhs.y + this.z * rhs.z;
+    }
+
+    /**
+     * @function
+     * @name pc.Vec3#equals
+     * @description Reports whether two vectors are equal.
+     * @param {pc.Vec3} rhs - The vector to compare to the specified vector.
+     * @returns {boolean} True if the vectors are equal and false otherwise.
+     * @example
+     * var a = new pc.Vec3(1, 2, 3);
+     * var b = new pc.Vec3(4, 5, 6);
+     * console.log("The two vectors are " + (a.equals(b) ? "equal" : "different"));
+     */
+    equals(rhs) {
+        return this.x === rhs.x && this.y === rhs.y && this.z === rhs.z;
+    }
+
+    /**
+     * @function
+     * @name pc.Vec3#length
+     * @description Returns the magnitude of the specified 3-dimensional vector.
+     * @returns {number} The magnitude of the specified 3-dimensional vector.
+     * @example
+     * var vec = new pc.Vec3(3, 4, 0);
+     * var len = vec.length();
+     * // Should output 5
+     * console.log("The length of the vector is: " + len);
+     */
+    length() {
+        return Math.sqrt(this.x * this.x + this.y * this.y + this.z * this.z);
+    }
+
+    /**
+     * @function
+     * @name pc.Vec3#lengthSq
+     * @description Returns the magnitude squared of the specified 3-dimensional vector.
+     * @returns {number} The magnitude of the specified 3-dimensional vector.
+     * @example
+     * var vec = new pc.Vec3(3, 4, 0);
+     * var len = vec.lengthSq();
+     * // Should output 25
+     * console.log("The length squared of the vector is: " + len);
+     */
+    lengthSq() {
+        return this.x * this.x + this.y * this.y + this.z * this.z;
+    }
+
+    /**
+     * @function
+     * @name pc.Vec3#lerp
+     * @description Returns the result of a linear interpolation between two specified 3-dimensional vectors.
+     * @param {pc.Vec3} lhs - The 3-dimensional to interpolate from.
+     * @param {pc.Vec3} rhs - The 3-dimensional to interpolate to.
+     * @param {number} alpha - The value controlling the point of interpolation. Between 0 and 1, the linear interpolant
+     * will occur on a straight line between lhs and rhs. Outside of this range, the linear interpolant will occur on
+     * a ray extrapolated from this line.
+     * @returns {pc.Vec3} Self for chaining.
+     * @example
+     * var a = new pc.Vec3(0, 0, 0);
+     * var b = new pc.Vec3(10, 10, 10);
+     * var r = new pc.Vec3();
+     *
+     * r.lerp(a, b, 0);   // r is equal to a
+     * r.lerp(a, b, 0.5); // r is 5, 5, 5
+     * r.lerp(a, b, 1);   // r is equal to b
+     */
+    lerp(lhs, rhs, alpha) {
+        this.x = lhs.x + alpha * (rhs.x - lhs.x);
+        this.y = lhs.y + alpha * (rhs.y - lhs.y);
+        this.z = lhs.z + alpha * (rhs.z - lhs.z);
+
+        return this;
+    }
+
+    /**
+     * @function
+     * @name pc.Vec3#mul
+     * @description Multiplies a 3-dimensional vector to another in place.
+     * @param {pc.Vec3} rhs - The 3-dimensional vector used as the second multiplicand of the operation.
+     * @returns {pc.Vec3} Self for chaining.
+     * @example
+     * var a = new pc.Vec3(2, 3, 4);
+     * var b = new pc.Vec3(4, 5, 6);
+     *
+     * a.mul(b);
+     *
+     * // Should output 8, 15, 24
+     * console.log("The result of the multiplication is: " + a.toString());
+     */
+    mul(rhs) {
+        this.x *= rhs.x;
+        this.y *= rhs.y;
+        this.z *= rhs.z;
+
+        return this;
+    }
+
+    /**
+     * @function
+     * @name pc.Vec3#mul2
+     * @description Returns the result of multiplying the specified 3-dimensional vectors together.
+     * @param {pc.Vec3} lhs - The 3-dimensional vector used as the first multiplicand of the operation.
+     * @param {pc.Vec3} rhs - The 3-dimensional vector used as the second multiplicand of the operation.
+     * @returns {pc.Vec3} Self for chaining.
+     * @example
+     * var a = new pc.Vec3(2, 3, 4);
+     * var b = new pc.Vec3(4, 5, 6);
+     * var r = new pc.Vec3();
+     *
+     * r.mul2(a, b);
+     *
+     * // Should output 8, 15, 24
+     * console.log("The result of the multiplication is: " + r.toString());
+     */
+    mul2(lhs, rhs) {
+        this.x = lhs.x * rhs.x;
+        this.y = lhs.y * rhs.y;
+        this.z = lhs.z * rhs.z;
+
+        return this;
+    }
+
+    /**
+     * @function
+     * @name pc.Vec3#normalize
+     * @description Returns this 3-dimensional vector converted to a unit vector in place.
+     * If the vector has a length of zero, the vector's elements will be set to zero.
+     * @returns {pc.Vec3} Self for chaining.
+     * @example
+     * var v = new pc.Vec3(25, 0, 0);
+     *
+     * v.normalize();
+     *
+     * // Should output 1, 0, 0
+     * console.log("The result of the vector normalization is: " + v.toString());
+     */
+    normalize() {
+        var lengthSq = this.x * this.x + this.y * this.y + this.z * this.z;
+        if (lengthSq > 0) {
+            var invLength = 1 / Math.sqrt(lengthSq);
+            this.x *= invLength;
+            this.y *= invLength;
+            this.z *= invLength;
+        }
+
+        return this;
+    }
+
+    /**
+     * @function
+     * @name  pc.Vec3#project
+     * @description Projects this 3-dimensional vector onto the specified vector.
+     * @param {pc.Vec3} rhs - The vector onto which the original vector will be projected on.
+     * @returns {pc.Vec3} Self for chaining.
+     * @example
+     * var v = new pc.Vec3(5, 5, 5);
+     * var normal = new pc.Vec3(1, 0, 0);
+     *
+     * v.project(normal);
+     *
+     * // Should output 5, 0, 0
+     * console.log("The result of the vector projection is: " + v.toString());
+     */
+    project(rhs) {
+        var a_dot_b = this.x * rhs.x + this.y * rhs.y + this.z * rhs.z;
+        var b_dot_b = rhs.x * rhs.x + rhs.y * rhs.y + rhs.z * rhs.z;
+        var s = a_dot_b / b_dot_b;
+        this.x = rhs.x * s;
+        this.y = rhs.y * s;
+        this.z = rhs.z * s;
+        return this;
+    }
+
+    /**
+     * @function
+     * @name pc.Vec3#scale
+     * @description Scales each dimension of the specified 3-dimensional vector by the supplied
+     * scalar value.
+     * @param {number} scalar - The value by which each vector component is multiplied.
+     * @returns {pc.Vec3} Self for chaining.
+     * @example
+     * var v = new pc.Vec3(2, 4, 8);
+     *
+     * // Multiply by 2
+     * v.scale(2);
+     *
+     * // Negate
+     * v.scale(-1);
+     *
+     * // Divide by 2
+     * v.scale(0.5);
+     */
+    scale(scalar) {
+        this.x *= scalar;
+        this.y *= scalar;
+        this.z *= scalar;
+
+        return this;
+    }
+
+    /**
+     * @function
+     * @name pc.Vec3#set
+     * @description Sets the specified 3-dimensional vector to the supplied numerical values.
+     * @param {number} x - The value to set on the first component of the vector.
+     * @param {number} y - The value to set on the second component of the vector.
+     * @param {number} z - The value to set on the third component of the vector.
+     * @returns {pc.Vec3} Self for chaining.
+     * @example
+     * var v = new pc.Vec3();
+     * v.set(5, 10, 20);
+     *
+     * // Should output 5, 10, 20
+     * console.log("The result of the vector set is: " + v.toString());
+     */
+    set(x, y, z) {
+        this.x = x;
+        this.y = y;
+        this.z = z;
+
+        return this;
+    }
+
+    /**
+     * @function
+     * @name pc.Vec3#sub
+     * @description Subtracts a 3-dimensional vector from another in place.
+     * @param {pc.Vec3} rhs - The vector to add to the specified vector.
+     * @returns {pc.Vec3} Self for chaining.
+     * @example
+     * var a = new pc.Vec3(10, 10, 10);
+     * var b = new pc.Vec3(20, 20, 20);
+     *
+     * a.sub(b);
+     *
+     * // Should output [-10, -10, -10]
+     * console.log("The result of the subtraction is: " + a.toString());
+     */
+    sub(rhs) {
+        this.x -= rhs.x;
+        this.y -= rhs.y;
+        this.z -= rhs.z;
+
+        return this;
+    }
+
+    /**
+     * @function
+     * @name pc.Vec3#sub2
+     * @description Subtracts two 3-dimensional vectors from one another and returns the result.
+     * @param {pc.Vec3} lhs - The first vector operand for the addition.
+     * @param {pc.Vec3} rhs - The second vector operand for the addition.
+     * @returns {pc.Vec3} Self for chaining.
+     * @example
+     * var a = new pc.Vec3(10, 10, 10);
+     * var b = new pc.Vec3(20, 20, 20);
+     * var r = new pc.Vec3();
+     *
+     * r.sub2(a, b);
+     *
+     * // Should output [-10, -10, -10]
+     * console.log("The result of the subtraction is: " + r.toString());
+     */
+    sub2(lhs, rhs) {
+        this.x = lhs.x - rhs.x;
+        this.y = lhs.y - rhs.y;
+        this.z = lhs.z - rhs.z;
+
+        return this;
+    }
+
+    /**
+     * @function
+     * @name pc.Vec3#toString
+     * @description Converts the vector to string form.
+     * @returns {string} The vector in string form.
+     * @example
+     * var v = new pc.Vec3(20, 10, 5);
+     * // Should output '[20, 10, 5]'
+     * console.log(v.toString());
+     */
+    toString() {
+        return '[' + this.x + ', ' + this.y + ', ' + this.z + ']';
+    }
+
+    /**
+     * @field
+     * @static
+     * @readonly
+     * @name pc.Vec3.ZERO
+     * @type {pc.Vec3}
+     * @description A constant vector set to [0, 0, 0].
+     */
+    static ZERO = Object.freeze(new Vec3(0, 0, 0));
+    /**
+     * @field
+     * @static
+     * @readonly
+     * @name pc.Vec3.ONE
+     * @type {pc.Vec3}
+     * @description A constant vector set to [1, 1, 1].
+     */
+    static ONE = Object.freeze(new Vec3(1, 1, 1));
+    /**
+     * @field
+     * @static
+     * @readonly
+     * @name pc.Vec3.UP
+     * @type {pc.Vec3}
+     * @description A constant vector set to [0, 1, 0].
+     */
+    static UP = Object.freeze(new Vec3(0, 1, 0));
+    /**
+     * @field
+     * @static
+     * @readonly
+     * @name pc.Vec3.DOWN
+     * @type {pc.Vec3}
+     * @description A constant vector set to [0, -1, 0].
+     */
+    static DOWN = Object.freeze(new Vec3(0, -1, 0));
+    /**
+     * @field
+     * @static
+     * @readonly
+     * @name pc.Vec3.RIGHT
+     * @type {pc.Vec3}
+     * @description A constant vector set to [1, 0, 0].
+     */
+    static RIGHT = Object.freeze(new Vec3(1, 0, 0));
+    /**
+     * @field
+     * @static
+     * @readonly
+     * @name pc.Vec3.LEFT
+     * @type {pc.Vec3}
+     * @description A constant vector set to [-1, 0, 0].
+     */
+    static LEFT = Object.freeze(new Vec3(-1, 0, 0));
+    /**
+     * @field
+     * @static
+     * @readonly
+     * @name pc.Vec3.FORWARD
+     * @type {pc.Vec3}
+     * @description A constant vector set to [0, 0, -1].
+     */
+    static FORWARD = Object.freeze(new Vec3(0, 0, -1));
+    /**
+     * @field
+     * @static
+     * @readonly
+     * @name pc.Vec3.BACK
+     * @type {pc.Vec3}
+     * @description A constant vector set to [0, 0, 1].
+     */
+    static BACK = Object.freeze(new Vec3(0, 0, 1));
+}
 
 export { Vec3 };

--- a/src/math/vec3.js
+++ b/src/math/vec3.js
@@ -49,15 +49,15 @@
  * vec.z = 0;
  */
 class Vec3 {
-    constructor(x, y, z) {
+    constructor(x = 0, y = 0, z = 0) {
         if (x && x.length === 3) {
             this.x = x[0];
             this.y = x[1];
             this.z = x[2];
         } else {
-            this.x = x || 0;
-            this.y = y || 0;
-            this.z = z || 0;
+            this.x = x;
+            this.y = y;
+            this.z = z;
         }
     }
 
@@ -120,7 +120,7 @@ class Vec3 {
      * console.log("The result of the cloning is: " + vclone.toString());
      */
     clone() {
-        return new Vec3().copy(this);
+        return new Vec3(this.x, this.y, this.z);
     }
 
     /**

--- a/src/math/vec3.js
+++ b/src/math/vec3.js
@@ -50,7 +50,7 @@
  */
 class Vec3 {
     constructor(x = 0, y = 0, z = 0) {
-        if (x && x.length === 3) {
+        if (x.length === 3) {
             this.x = x[0];
             this.y = x[1];
             this.z = x[2];

--- a/src/math/vec3.js
+++ b/src/math/vec3.js
@@ -501,6 +501,7 @@ class Vec3 {
      * @description A constant vector set to [0, 0, 0].
      */
     static ZERO = Object.freeze(new Vec3(0, 0, 0));
+
     /**
      * @field
      * @static
@@ -510,6 +511,7 @@ class Vec3 {
      * @description A constant vector set to [1, 1, 1].
      */
     static ONE = Object.freeze(new Vec3(1, 1, 1));
+
     /**
      * @field
      * @static
@@ -519,6 +521,7 @@ class Vec3 {
      * @description A constant vector set to [0, 1, 0].
      */
     static UP = Object.freeze(new Vec3(0, 1, 0));
+
     /**
      * @field
      * @static
@@ -528,6 +531,7 @@ class Vec3 {
      * @description A constant vector set to [0, -1, 0].
      */
     static DOWN = Object.freeze(new Vec3(0, -1, 0));
+
     /**
      * @field
      * @static
@@ -537,6 +541,7 @@ class Vec3 {
      * @description A constant vector set to [1, 0, 0].
      */
     static RIGHT = Object.freeze(new Vec3(1, 0, 0));
+
     /**
      * @field
      * @static
@@ -546,6 +551,7 @@ class Vec3 {
      * @description A constant vector set to [-1, 0, 0].
      */
     static LEFT = Object.freeze(new Vec3(-1, 0, 0));
+
     /**
      * @field
      * @static
@@ -555,6 +561,7 @@ class Vec3 {
      * @description A constant vector set to [0, 0, -1].
      */
     static FORWARD = Object.freeze(new Vec3(0, 0, -1));
+
     /**
      * @field
      * @static

--- a/src/math/vec4.js
+++ b/src/math/vec4.js
@@ -460,6 +460,7 @@ class Vec4 {
      * @description A constant vector set to [0, 0, 0, 0].
      */
     static ZERO = Object.freeze(new Vec4(0, 0, 0, 0));
+
     /**
      * @field
      * @static

--- a/src/math/vec4.js
+++ b/src/math/vec4.js
@@ -68,7 +68,7 @@
  */
 class Vec4 {
     constructor(x = 0, y = 0, z = 0, w = 0) {
-        if (x && x.length === 4) {
+        if (x.length === 4) {
             this.x = x[0];
             this.y = x[1];
             this.z = x[2];

--- a/src/math/vec4.js
+++ b/src/math/vec4.js
@@ -67,17 +67,17 @@
  * vec.w = 0;
  */
 class Vec4 {
-    constructor(x, y, z, w) {
+    constructor(x = 0, y = 0, z = 0, w = 0) {
         if (x && x.length === 4) {
             this.x = x[0];
             this.y = x[1];
             this.z = x[2];
             this.w = x[3];
         } else {
-            this.x = x || 0;
-            this.y = y || 0;
-            this.z = z || 0;
-            this.w = w || 0;
+            this.x = x;
+            this.y = y;
+            this.z = z;
+            this.w = w;
         }
     }
 
@@ -142,7 +142,7 @@ class Vec4 {
      * console.log("The result of the cloning is: " + vclone.toString());
      */
     clone() {
-        return new Vec4().copy(this);
+        return new Vec4(this.x, this.y, this.z, this.w);
     }
 
     /**

--- a/src/math/vec4.js
+++ b/src/math/vec4.js
@@ -10,392 +10,6 @@
  * @example
  * var v = new pc.Vec4(1, 2, 3, 4);
  */
-function Vec4(x, y, z, w) {
-    if (x && x.length === 4) {
-        this.x = x[0];
-        this.y = x[1];
-        this.z = x[2];
-        this.w = x[3];
-    } else {
-        this.x = x || 0;
-        this.y = y || 0;
-        this.z = z || 0;
-        this.w = w || 0;
-    }
-}
-
-Object.assign(Vec4.prototype, {
-    /**
-     * @function
-     * @name pc.Vec4#add
-     * @description Adds a 4-dimensional vector to another in place.
-     * @param {pc.Vec4} rhs - The vector to add to the specified vector.
-     * @returns {pc.Vec4} Self for chaining.
-     * @example
-     * var a = new pc.Vec4(10, 10, 10, 10);
-     * var b = new pc.Vec4(20, 20, 20, 20);
-     *
-     * a.add(b);
-     *
-     * // Should output [30, 30, 30]
-     * console.log("The result of the addition is: " + a.toString());
-     */
-    add: function (rhs) {
-        this.x += rhs.x;
-        this.y += rhs.y;
-        this.z += rhs.z;
-        this.w += rhs.w;
-
-        return this;
-    },
-
-    /**
-     * @function
-     * @name pc.Vec4#add2
-     * @description Adds two 4-dimensional vectors together and returns the result.
-     * @param {pc.Vec4} lhs - The first vector operand for the addition.
-     * @param {pc.Vec4} rhs - The second vector operand for the addition.
-     * @returns {pc.Vec4} Self for chaining.
-     * @example
-     * var a = new pc.Vec4(10, 10, 10, 10);
-     * var b = new pc.Vec4(20, 20, 20, 20);
-     * var r = new pc.Vec4();
-     *
-     * r.add2(a, b);
-     * // Should output [30, 30, 30]
-     *
-     * console.log("The result of the addition is: " + r.toString());
-     */
-    add2: function (lhs, rhs) {
-        this.x = lhs.x + rhs.x;
-        this.y = lhs.y + rhs.y;
-        this.z = lhs.z + rhs.z;
-        this.w = lhs.w + rhs.w;
-
-        return this;
-    },
-
-    /**
-     * @function
-     * @name pc.Vec4#clone
-     * @description Returns an identical copy of the specified 4-dimensional vector.
-     * @returns {pc.Vec4} A 4-dimensional vector containing the result of the cloning.
-     * @example
-     * var v = new pc.Vec4(10, 20, 30, 40);
-     * var vclone = v.clone();
-     * console.log("The result of the cloning is: " + vclone.toString());
-     */
-    clone: function () {
-        return new Vec4().copy(this);
-    },
-
-    /**
-     * @function
-     * @name pc.Vec4#copy
-     * @description Copied the contents of a source 4-dimensional vector to a destination 4-dimensional vector.
-     * @param {pc.Vec4} rhs - A vector to copy to the specified vector.
-     * @returns {pc.Vec4} Self for chaining.
-     * @example
-     * var src = new pc.Vec4(10, 20, 30, 40);
-     * var dst = new pc.Vec4();
-     *
-     * dst.copy(src);
-     *
-     * console.log("The two vectors are " + (dst.equals(src) ? "equal" : "different"));
-     */
-    copy: function (rhs) {
-        this.x = rhs.x;
-        this.y = rhs.y;
-        this.z = rhs.z;
-        this.w = rhs.w;
-
-        return this;
-    },
-
-    /**
-     * @function
-     * @name pc.Vec4#dot
-     * @description Returns the result of a dot product operation performed on the two specified 4-dimensional vectors.
-     * @param {pc.Vec4} rhs - The second 4-dimensional vector operand of the dot product.
-     * @returns {number} The result of the dot product operation.
-     * @example
-     * var v1 = new pc.Vec4(5, 10, 20, 40);
-     * var v2 = new pc.Vec4(10, 20, 40, 80);
-     * var v1dotv2 = v1.dot(v2);
-     * console.log("The result of the dot product is: " + v1dotv2);
-     */
-    dot: function (rhs) {
-        return this.x * rhs.x + this.y * rhs.y + this.z * rhs.z + this.w * rhs.w;
-    },
-
-    /**
-     * @function
-     * @name pc.Vec4#equals
-     * @description Reports whether two vectors are equal.
-     * @param {pc.Vec4} rhs - The vector to compare to the specified vector.
-     * @returns {boolean} True if the vectors are equal and false otherwise.
-     * @example
-     * var a = new pc.Vec4(1, 2, 3, 4);
-     * var b = new pc.Vec4(5, 6, 7, 8);
-     * console.log("The two vectors are " + (a.equals(b) ? "equal" : "different"));
-     */
-    equals: function (rhs) {
-        return this.x === rhs.x && this.y === rhs.y && this.z === rhs.z && this.w === rhs.w;
-    },
-
-    /**
-     * @function
-     * @name pc.Vec4#length
-     * @description Returns the magnitude of the specified 4-dimensional vector.
-     * @returns {number} The magnitude of the specified 4-dimensional vector.
-     * @example
-     * var vec = new pc.Vec4(3, 4, 0, 0);
-     * var len = vec.length();
-     * // Should output 5
-     * console.log("The length of the vector is: " + len);
-     */
-    length: function () {
-        return Math.sqrt(this.x * this.x + this.y * this.y + this.z * this.z + this.w * this.w);
-    },
-
-    /**
-     * @function
-     * @name pc.Vec4#lengthSq
-     * @description Returns the magnitude squared of the specified 4-dimensional vector.
-     * @returns {number} The magnitude of the specified 4-dimensional vector.
-     * @example
-     * var vec = new pc.Vec4(3, 4, 0);
-     * var len = vec.lengthSq();
-     * // Should output 25
-     * console.log("The length squared of the vector is: " + len);
-     */
-    lengthSq: function () {
-        return this.x * this.x + this.y * this.y + this.z * this.z + this.w * this.w;
-    },
-
-    /**
-     * @function
-     * @name pc.Vec4#lerp
-     * @description Returns the result of a linear interpolation between two specified 4-dimensional vectors.
-     * @param {pc.Vec4} lhs - The 4-dimensional to interpolate from.
-     * @param {pc.Vec4} rhs - The 4-dimensional to interpolate to.
-     * @param {number} alpha - The value controlling the point of interpolation. Between 0 and 1, the linear interpolant
-     * will occur on a straight line between lhs and rhs. Outside of this range, the linear interpolant will occur on
-     * a ray extrapolated from this line.
-     * @returns {pc.Vec4} Self for chaining.
-     * @example
-     * var a = new pc.Vec4(0, 0, 0, 0);
-     * var b = new pc.Vec4(10, 10, 10, 10);
-     * var r = new pc.Vec4();
-     *
-     * r.lerp(a, b, 0);   // r is equal to a
-     * r.lerp(a, b, 0.5); // r is 5, 5, 5, 5
-     * r.lerp(a, b, 1);   // r is equal to b
-     */
-    lerp: function (lhs, rhs, alpha) {
-        this.x = lhs.x + alpha * (rhs.x - lhs.x);
-        this.y = lhs.y + alpha * (rhs.y - lhs.y);
-        this.z = lhs.z + alpha * (rhs.z - lhs.z);
-        this.w = lhs.w + alpha * (rhs.w - lhs.w);
-
-        return this;
-    },
-
-    /**
-     * @function
-     * @name pc.Vec4#mul
-     * @description Multiplies a 4-dimensional vector to another in place.
-     * @param {pc.Vec4} rhs - The 4-dimensional vector used as the second multiplicand of the operation.
-     * @returns {pc.Vec4} Self for chaining.
-     * @example
-     * var a = new pc.Vec4(2, 3, 4, 5);
-     * var b = new pc.Vec4(4, 5, 6, 7);
-     *
-     * a.mul(b);
-     *
-     * // Should output 8, 15, 24, 35
-     * console.log("The result of the multiplication is: " + a.toString());
-     */
-    mul: function (rhs) {
-        this.x *= rhs.x;
-        this.y *= rhs.y;
-        this.z *= rhs.z;
-        this.w *= rhs.w;
-
-        return this;
-    },
-
-    /**
-     * @function
-     * @name pc.Vec4#mul2
-     * @description Returns the result of multiplying the specified 4-dimensional vectors together.
-     * @param {pc.Vec4} lhs - The 4-dimensional vector used as the first multiplicand of the operation.
-     * @param {pc.Vec4} rhs - The 4-dimensional vector used as the second multiplicand of the operation.
-     * @returns {pc.Vec4} Self for chaining.
-     * @example
-     * var a = new pc.Vec4(2, 3, 4, 5);
-     * var b = new pc.Vec4(4, 5, 6, 7);
-     * var r = new pc.Vec4();
-     *
-     * r.mul2(a, b);
-     *
-     * // Should output 8, 15, 24, 35
-     * console.log("The result of the multiplication is: " + r.toString());
-     */
-    mul2: function (lhs, rhs) {
-        this.x = lhs.x * rhs.x;
-        this.y = lhs.y * rhs.y;
-        this.z = lhs.z * rhs.z;
-        this.w = lhs.w * rhs.w;
-
-        return this;
-    },
-
-    /**
-     * @function
-     * @name pc.Vec4#normalize
-     * @description Returns this 4-dimensional vector converted to a unit vector in place.
-     * If the vector has a length of zero, the vector's elements will be set to zero.
-     * @returns {pc.Vec4} Self for chaining.
-     * @example
-     * var v = new pc.Vec4(25, 0, 0, 0);
-     *
-     * v.normalize();
-     *
-     * // Should output 1, 0, 0, 0
-     * console.log("The result of the vector normalization is: " + v.toString());
-     */
-    normalize: function () {
-        var lengthSq = this.x * this.x + this.y * this.y + this.z * this.z + this.w * this.w;
-        if (lengthSq > 0) {
-            var invLength = 1 / Math.sqrt(lengthSq);
-            this.x *= invLength;
-            this.y *= invLength;
-            this.z *= invLength;
-            this.w *= invLength;
-        }
-
-        return this;
-    },
-
-    /**
-     * @function
-     * @name pc.Vec4#scale
-     * @description Scales each dimension of the specified 4-dimensional vector by the supplied
-     * scalar value.
-     * @param {number} scalar - The value by which each vector component is multiplied.
-     * @returns {pc.Vec4} Self for chaining.
-     * @example
-     * var v = new pc.Vec4(2, 4, 8, 16);
-     *
-     * // Multiply by 2
-     * v.scale(2);
-     *
-     * // Negate
-     * v.scale(-1);
-     *
-     * // Divide by 2
-     * v.scale(0.5);
-     */
-    scale: function (scalar) {
-        this.x *= scalar;
-        this.y *= scalar;
-        this.z *= scalar;
-        this.w *= scalar;
-
-        return this;
-    },
-
-    /**
-     * @function
-     * @name pc.Vec4#set
-     * @description Sets the specified 4-dimensional vector to the supplied numerical values.
-     * @param {number} x - The value to set on the first component of the vector.
-     * @param {number} y - The value to set on the second component of the vector.
-     * @param {number} z - The value to set on the third component of the vector.
-     * @param {number} w - The value to set on the fourth component of the vector.
-     * @returns {pc.Vec4} Self for chaining.
-     * @example
-     * var v = new pc.Vec4();
-     * v.set(5, 10, 20, 40);
-     *
-     * // Should output 5, 10, 20, 40
-     * console.log("The result of the vector set is: " + v.toString());
-     */
-    set: function (x, y, z, w) {
-        this.x = x;
-        this.y = y;
-        this.z = z;
-        this.w = w;
-
-        return this;
-    },
-
-    /**
-     * @function
-     * @name pc.Vec4#sub
-     * @description Subtracts a 4-dimensional vector from another in place.
-     * @param {pc.Vec4} rhs - The vector to add to the specified vector.
-     * @returns {pc.Vec4} Self for chaining.
-     * @example
-     * var a = new pc.Vec4(10, 10, 10, 10);
-     * var b = new pc.Vec4(20, 20, 20, 20);
-     *
-     * a.sub(b);
-     *
-     * // Should output [-10, -10, -10, -10]
-     * console.log("The result of the subtraction is: " + a.toString());
-     */
-    sub: function (rhs) {
-        this.x -= rhs.x;
-        this.y -= rhs.y;
-        this.z -= rhs.z;
-        this.w -= rhs.w;
-
-        return this;
-    },
-
-    /**
-     * @function
-     * @name pc.Vec4#sub2
-     * @description Subtracts two 4-dimensional vectors from one another and returns the result.
-     * @param {pc.Vec4} lhs - The first vector operand for the subtraction.
-     * @param {pc.Vec4} rhs - The second vector operand for the subtraction.
-     * @returns {pc.Vec4} Self for chaining.
-     * @example
-     * var a = new pc.Vec4(10, 10, 10, 10);
-     * var b = new pc.Vec4(20, 20, 20, 20);
-     * var r = new pc.Vec4();
-     *
-     * r.sub2(a, b);
-     *
-     * // Should output [-10, -10, -10, -10]
-     * console.log("The result of the subtraction is: " + r.toString());
-     */
-    sub2: function (lhs, rhs) {
-        this.x = lhs.x - rhs.x;
-        this.y = lhs.y - rhs.y;
-        this.z = lhs.z - rhs.z;
-        this.w = lhs.w - rhs.w;
-
-        return this;
-    },
-
-    /**
-     * @function
-     * @name pc.Vec4#toString
-     * @description Converts the vector to string form.
-     * @returns {string} The vector in string form.
-     * @example
-     * var v = new pc.Vec4(20, 10, 5, 0);
-     * // Should output '[20, 10, 5, 0]'
-     * console.log(v.toString());
-     */
-    toString: function () {
-        return '[' + this.x + ', ' + this.y + ', ' + this.z + ', ' + this.w + ']';
-    }
-});
-
 /**
  * @field
  * @name pc.Vec4#x
@@ -452,31 +66,409 @@ Object.assign(Vec4.prototype, {
  * // Set w
  * vec.w = 0;
  */
+class Vec4 {
+    constructor(x, y, z, w) {
+        if (x && x.length === 4) {
+            this.x = x[0];
+            this.y = x[1];
+            this.z = x[2];
+            this.w = x[3];
+        } else {
+            this.x = x || 0;
+            this.y = y || 0;
+            this.z = z || 0;
+            this.w = w || 0;
+        }
+    }
 
-/**
- * @field
- * @static
- * @readonly
- * @name pc.Vec4.ONE
- * @type {pc.Vec4}
- * @description A constant vector set to [1, 1, 1, 1].
- */
+    /**
+     * @function
+     * @name pc.Vec4#add
+     * @description Adds a 4-dimensional vector to another in place.
+     * @param {pc.Vec4} rhs - The vector to add to the specified vector.
+     * @returns {pc.Vec4} Self for chaining.
+     * @example
+     * var a = new pc.Vec4(10, 10, 10, 10);
+     * var b = new pc.Vec4(20, 20, 20, 20);
+     *
+     * a.add(b);
+     *
+     * // Should output [30, 30, 30]
+     * console.log("The result of the addition is: " + a.toString());
+     */
+    add(rhs) {
+        this.x += rhs.x;
+        this.y += rhs.y;
+        this.z += rhs.z;
+        this.w += rhs.w;
 
-/**
- * @field
- * @static
- * @readonly
- * @name pc.Vec4.ZERO
- * @type {pc.Vec4}
- * @description A constant vector set to [0, 0, 0, 0].
- */
+        return this;
+    }
 
-Object.defineProperties(Vec4, {
-    ZERO: { value: new Vec4(0, 0, 0, 0) },
-    ONE: { value: new Vec4(1, 1, 1, 1) }
-});
+    /**
+     * @function
+     * @name pc.Vec4#add2
+     * @description Adds two 4-dimensional vectors together and returns the result.
+     * @param {pc.Vec4} lhs - The first vector operand for the addition.
+     * @param {pc.Vec4} rhs - The second vector operand for the addition.
+     * @returns {pc.Vec4} Self for chaining.
+     * @example
+     * var a = new pc.Vec4(10, 10, 10, 10);
+     * var b = new pc.Vec4(20, 20, 20, 20);
+     * var r = new pc.Vec4();
+     *
+     * r.add2(a, b);
+     * // Should output [30, 30, 30]
+     *
+     * console.log("The result of the addition is: " + r.toString());
+     */
+    add2(lhs, rhs) {
+        this.x = lhs.x + rhs.x;
+        this.y = lhs.y + rhs.y;
+        this.z = lhs.z + rhs.z;
+        this.w = lhs.w + rhs.w;
 
-Object.freeze(Vec4.ZERO);
-Object.freeze(Vec4.ONE);
+        return this;
+    }
+
+    /**
+     * @function
+     * @name pc.Vec4#clone
+     * @description Returns an identical copy of the specified 4-dimensional vector.
+     * @returns {pc.Vec4} A 4-dimensional vector containing the result of the cloning.
+     * @example
+     * var v = new pc.Vec4(10, 20, 30, 40);
+     * var vclone = v.clone();
+     * console.log("The result of the cloning is: " + vclone.toString());
+     */
+    clone() {
+        return new Vec4().copy(this);
+    }
+
+    /**
+     * @function
+     * @name pc.Vec4#copy
+     * @description Copied the contents of a source 4-dimensional vector to a destination 4-dimensional vector.
+     * @param {pc.Vec4} rhs - A vector to copy to the specified vector.
+     * @returns {pc.Vec4} Self for chaining.
+     * @example
+     * var src = new pc.Vec4(10, 20, 30, 40);
+     * var dst = new pc.Vec4();
+     *
+     * dst.copy(src);
+     *
+     * console.log("The two vectors are " + (dst.equals(src) ? "equal" : "different"));
+     */
+    copy(rhs) {
+        this.x = rhs.x;
+        this.y = rhs.y;
+        this.z = rhs.z;
+        this.w = rhs.w;
+
+        return this;
+    }
+
+    /**
+     * @function
+     * @name pc.Vec4#dot
+     * @description Returns the result of a dot product operation performed on the two specified 4-dimensional vectors.
+     * @param {pc.Vec4} rhs - The second 4-dimensional vector operand of the dot product.
+     * @returns {number} The result of the dot product operation.
+     * @example
+     * var v1 = new pc.Vec4(5, 10, 20, 40);
+     * var v2 = new pc.Vec4(10, 20, 40, 80);
+     * var v1dotv2 = v1.dot(v2);
+     * console.log("The result of the dot product is: " + v1dotv2);
+     */
+    dot(rhs) {
+        return this.x * rhs.x + this.y * rhs.y + this.z * rhs.z + this.w * rhs.w;
+    }
+
+    /**
+     * @function
+     * @name pc.Vec4#equals
+     * @description Reports whether two vectors are equal.
+     * @param {pc.Vec4} rhs - The vector to compare to the specified vector.
+     * @returns {boolean} True if the vectors are equal and false otherwise.
+     * @example
+     * var a = new pc.Vec4(1, 2, 3, 4);
+     * var b = new pc.Vec4(5, 6, 7, 8);
+     * console.log("The two vectors are " + (a.equals(b) ? "equal" : "different"));
+     */
+    equals(rhs) {
+        return this.x === rhs.x && this.y === rhs.y && this.z === rhs.z && this.w === rhs.w;
+    }
+
+    /**
+     * @function
+     * @name pc.Vec4#length
+     * @description Returns the magnitude of the specified 4-dimensional vector.
+     * @returns {number} The magnitude of the specified 4-dimensional vector.
+     * @example
+     * var vec = new pc.Vec4(3, 4, 0, 0);
+     * var len = vec.length();
+     * // Should output 5
+     * console.log("The length of the vector is: " + len);
+     */
+    length() {
+        return Math.sqrt(this.x * this.x + this.y * this.y + this.z * this.z + this.w * this.w);
+    }
+
+    /**
+     * @function
+     * @name pc.Vec4#lengthSq
+     * @description Returns the magnitude squared of the specified 4-dimensional vector.
+     * @returns {number} The magnitude of the specified 4-dimensional vector.
+     * @example
+     * var vec = new pc.Vec4(3, 4, 0);
+     * var len = vec.lengthSq();
+     * // Should output 25
+     * console.log("The length squared of the vector is: " + len);
+     */
+    lengthSq() {
+        return this.x * this.x + this.y * this.y + this.z * this.z + this.w * this.w;
+    }
+
+    /**
+     * @function
+     * @name pc.Vec4#lerp
+     * @description Returns the result of a linear interpolation between two specified 4-dimensional vectors.
+     * @param {pc.Vec4} lhs - The 4-dimensional to interpolate from.
+     * @param {pc.Vec4} rhs - The 4-dimensional to interpolate to.
+     * @param {number} alpha - The value controlling the point of interpolation. Between 0 and 1, the linear interpolant
+     * will occur on a straight line between lhs and rhs. Outside of this range, the linear interpolant will occur on
+     * a ray extrapolated from this line.
+     * @returns {pc.Vec4} Self for chaining.
+     * @example
+     * var a = new pc.Vec4(0, 0, 0, 0);
+     * var b = new pc.Vec4(10, 10, 10, 10);
+     * var r = new pc.Vec4();
+     *
+     * r.lerp(a, b, 0);   // r is equal to a
+     * r.lerp(a, b, 0.5); // r is 5, 5, 5, 5
+     * r.lerp(a, b, 1);   // r is equal to b
+     */
+    lerp(lhs, rhs, alpha) {
+        this.x = lhs.x + alpha * (rhs.x - lhs.x);
+        this.y = lhs.y + alpha * (rhs.y - lhs.y);
+        this.z = lhs.z + alpha * (rhs.z - lhs.z);
+        this.w = lhs.w + alpha * (rhs.w - lhs.w);
+
+        return this;
+    }
+
+    /**
+     * @function
+     * @name pc.Vec4#mul
+     * @description Multiplies a 4-dimensional vector to another in place.
+     * @param {pc.Vec4} rhs - The 4-dimensional vector used as the second multiplicand of the operation.
+     * @returns {pc.Vec4} Self for chaining.
+     * @example
+     * var a = new pc.Vec4(2, 3, 4, 5);
+     * var b = new pc.Vec4(4, 5, 6, 7);
+     *
+     * a.mul(b);
+     *
+     * // Should output 8, 15, 24, 35
+     * console.log("The result of the multiplication is: " + a.toString());
+     */
+    mul(rhs) {
+        this.x *= rhs.x;
+        this.y *= rhs.y;
+        this.z *= rhs.z;
+        this.w *= rhs.w;
+
+        return this;
+    }
+
+    /**
+     * @function
+     * @name pc.Vec4#mul2
+     * @description Returns the result of multiplying the specified 4-dimensional vectors together.
+     * @param {pc.Vec4} lhs - The 4-dimensional vector used as the first multiplicand of the operation.
+     * @param {pc.Vec4} rhs - The 4-dimensional vector used as the second multiplicand of the operation.
+     * @returns {pc.Vec4} Self for chaining.
+     * @example
+     * var a = new pc.Vec4(2, 3, 4, 5);
+     * var b = new pc.Vec4(4, 5, 6, 7);
+     * var r = new pc.Vec4();
+     *
+     * r.mul2(a, b);
+     *
+     * // Should output 8, 15, 24, 35
+     * console.log("The result of the multiplication is: " + r.toString());
+     */
+    mul2(lhs, rhs) {
+        this.x = lhs.x * rhs.x;
+        this.y = lhs.y * rhs.y;
+        this.z = lhs.z * rhs.z;
+        this.w = lhs.w * rhs.w;
+
+        return this;
+    }
+
+    /**
+     * @function
+     * @name pc.Vec4#normalize
+     * @description Returns this 4-dimensional vector converted to a unit vector in place.
+     * If the vector has a length of zero, the vector's elements will be set to zero.
+     * @returns {pc.Vec4} Self for chaining.
+     * @example
+     * var v = new pc.Vec4(25, 0, 0, 0);
+     *
+     * v.normalize();
+     *
+     * // Should output 1, 0, 0, 0
+     * console.log("The result of the vector normalization is: " + v.toString());
+     */
+    normalize() {
+        var lengthSq = this.x * this.x + this.y * this.y + this.z * this.z + this.w * this.w;
+        if (lengthSq > 0) {
+            var invLength = 1 / Math.sqrt(lengthSq);
+            this.x *= invLength;
+            this.y *= invLength;
+            this.z *= invLength;
+            this.w *= invLength;
+        }
+
+        return this;
+    }
+
+    /**
+     * @function
+     * @name pc.Vec4#scale
+     * @description Scales each dimension of the specified 4-dimensional vector by the supplied
+     * scalar value.
+     * @param {number} scalar - The value by which each vector component is multiplied.
+     * @returns {pc.Vec4} Self for chaining.
+     * @example
+     * var v = new pc.Vec4(2, 4, 8, 16);
+     *
+     * // Multiply by 2
+     * v.scale(2);
+     *
+     * // Negate
+     * v.scale(-1);
+     *
+     * // Divide by 2
+     * v.scale(0.5);
+     */
+    scale(scalar) {
+        this.x *= scalar;
+        this.y *= scalar;
+        this.z *= scalar;
+        this.w *= scalar;
+
+        return this;
+    }
+
+    /**
+     * @function
+     * @name pc.Vec4#set
+     * @description Sets the specified 4-dimensional vector to the supplied numerical values.
+     * @param {number} x - The value to set on the first component of the vector.
+     * @param {number} y - The value to set on the second component of the vector.
+     * @param {number} z - The value to set on the third component of the vector.
+     * @param {number} w - The value to set on the fourth component of the vector.
+     * @returns {pc.Vec4} Self for chaining.
+     * @example
+     * var v = new pc.Vec4();
+     * v.set(5, 10, 20, 40);
+     *
+     * // Should output 5, 10, 20, 40
+     * console.log("The result of the vector set is: " + v.toString());
+     */
+    set(x, y, z, w) {
+        this.x = x;
+        this.y = y;
+        this.z = z;
+        this.w = w;
+
+        return this;
+    }
+
+    /**
+     * @function
+     * @name pc.Vec4#sub
+     * @description Subtracts a 4-dimensional vector from another in place.
+     * @param {pc.Vec4} rhs - The vector to add to the specified vector.
+     * @returns {pc.Vec4} Self for chaining.
+     * @example
+     * var a = new pc.Vec4(10, 10, 10, 10);
+     * var b = new pc.Vec4(20, 20, 20, 20);
+     *
+     * a.sub(b);
+     *
+     * // Should output [-10, -10, -10, -10]
+     * console.log("The result of the subtraction is: " + a.toString());
+     */
+    sub(rhs) {
+        this.x -= rhs.x;
+        this.y -= rhs.y;
+        this.z -= rhs.z;
+        this.w -= rhs.w;
+
+        return this;
+    }
+
+    /**
+     * @function
+     * @name pc.Vec4#sub2
+     * @description Subtracts two 4-dimensional vectors from one another and returns the result.
+     * @param {pc.Vec4} lhs - The first vector operand for the subtraction.
+     * @param {pc.Vec4} rhs - The second vector operand for the subtraction.
+     * @returns {pc.Vec4} Self for chaining.
+     * @example
+     * var a = new pc.Vec4(10, 10, 10, 10);
+     * var b = new pc.Vec4(20, 20, 20, 20);
+     * var r = new pc.Vec4();
+     *
+     * r.sub2(a, b);
+     *
+     * // Should output [-10, -10, -10, -10]
+     * console.log("The result of the subtraction is: " + r.toString());
+     */
+    sub2(lhs, rhs) {
+        this.x = lhs.x - rhs.x;
+        this.y = lhs.y - rhs.y;
+        this.z = lhs.z - rhs.z;
+        this.w = lhs.w - rhs.w;
+
+        return this;
+    }
+
+    /**
+     * @function
+     * @name pc.Vec4#toString
+     * @description Converts the vector to string form.
+     * @returns {string} The vector in string form.
+     * @example
+     * var v = new pc.Vec4(20, 10, 5, 0);
+     * // Should output '[20, 10, 5, 0]'
+     * console.log(v.toString());
+     */
+    toString() {
+        return '[' + this.x + ', ' + this.y + ', ' + this.z + ', ' + this.w + ']';
+    }
+
+    /**
+     * @field
+     * @static
+     * @readonly
+     * @name pc.Vec4.ZERO
+     * @type {pc.Vec4}
+     * @description A constant vector set to [0, 0, 0, 0].
+     */
+    static ZERO = Object.freeze(new Vec4(0, 0, 0, 0));
+    /**
+     * @field
+     * @static
+     * @readonly
+     * @name pc.Vec4.ONE
+     * @type {pc.Vec4}
+     * @description A constant vector set to [1, 1, 1, 1].
+     */
+    static ONE = Object.freeze(new Vec4(1, 1, 1, 1));
+}
 
 export { Vec4 };

--- a/src/resources/anim-clip.js
+++ b/src/resources/anim-clip.js
@@ -9,12 +9,12 @@ import { AnimCurve, AnimData, AnimTrack } from '../anim/anim.js';
  * @implements {pc.ResourceHandler}
  * @classdesc Resource handler used for loading {@link pc.AnimClip} resources.
  */
-function AnimClipHandler() {
-    this.maxRetries = 0;
-}
+class AnimClipHandler {
+    constructor() {
+        this.maxRetries = 0;
+    }
 
-Object.assign(AnimClipHandler.prototype, {
-    load: function (url, callback) {
+    load(url, callback) {
         if (typeof url === 'string') {
             url = {
                 load: url,
@@ -39,9 +39,9 @@ Object.assign(AnimClipHandler.prototype, {
                 callback(null, response);
             }
         });
-    },
+    }
 
-    open: function (url, data) {
+    open(url, data) {
         var name = data.name;
         var duration = data.duration;
         var inputs = data.inputs.map(function (input) {
@@ -66,6 +66,6 @@ Object.assign(AnimClipHandler.prototype, {
             curves
         );
     }
-});
+}
 
 export { AnimClipHandler };

--- a/src/resources/anim-state-graph.js
+++ b/src/resources/anim-state-graph.js
@@ -9,12 +9,12 @@ import { AnimStateGraph } from '../framework/components/anim/state-graph.js';
  * @implements {pc.ResourceHandler}
  * @classdesc Resource handler used for loading {@link pc.AnimStateGraph} resources.
  */
-function AnimStateGraphHandler() {
-    this.maxRetries = 0;
-}
+class AnimStateGraphHandler {
+    constructor() {
+        this.maxRetries = 0;
+    }
 
-Object.assign(AnimStateGraphHandler.prototype, {
-    load: function (url, callback) {
+    load(url, callback) {
         if (typeof url === 'string') {
             url = {
                 load: url,
@@ -39,11 +39,11 @@ Object.assign(AnimStateGraphHandler.prototype, {
                 callback(null, response);
             }
         });
-    },
+    }
 
-    open: function (url, data) {
+    open(url, data) {
         return new AnimStateGraph(data);
     }
-});
+}
 
 export { AnimStateGraphHandler };

--- a/src/resources/animation.js
+++ b/src/resources/animation.js
@@ -15,12 +15,12 @@ import { GlbParser } from '../resources/parser/glb-parser.js';
  * @implements {pc.ResourceHandler}
  * @classdesc Resource handler used for loading {@link pc.Animation} resources.
  */
-function AnimationHandler() {
-    this.maxRetries = 0;
-}
+class AnimationHandler {
+    constructor() {
+        this.maxRetries = 0;
+    }
 
-Object.assign(AnimationHandler.prototype, {
-    load: function (url, callback) {
+    load(url, callback) {
         if (typeof url === 'string') {
             url = {
                 load: url,
@@ -49,9 +49,9 @@ Object.assign(AnimationHandler.prototype, {
                 callback(null, response);
             }
         });
-    },
+    }
 
-    open: function (url, data) {
+    open(url, data) {
         if (path.getExtension(url).toLowerCase() === '.glb') {
             var glb = GlbParser.parse("filename.glb", data, null);
             if (!glb) {
@@ -60,9 +60,9 @@ Object.assign(AnimationHandler.prototype, {
             return glb.animations;
         }
         return this["_parseAnimationV" + data.animation.version](data);
-    },
+    }
 
-    _parseAnimationV3: function (data) {
+    _parseAnimationV3(data) {
         var animData = data.animation;
 
         var anim = new Animation();
@@ -95,9 +95,9 @@ Object.assign(AnimationHandler.prototype, {
         }
 
         return anim;
-    },
+    }
 
-    _parseAnimationV4: function (data) {
+    _parseAnimationV4(data) {
         var animData = data.animation;
 
         var anim = new Animation();
@@ -135,6 +135,6 @@ Object.assign(AnimationHandler.prototype, {
 
         return anim;
     }
-});
+}
 
 export { AnimationHandler };

--- a/src/resources/binary.js
+++ b/src/resources/binary.js
@@ -1,11 +1,11 @@
 import { http, Http } from '../net/http.js';
 
-function BinaryHandler() {
-    this.maxRetries = 0;
-}
+class BinaryHandler {
+    constructor() {
+        this.maxRetries = 0;
+    }
 
-Object.assign(BinaryHandler.prototype, {
-    load: function (url, callback) {
+    load(url, callback) {
         if (typeof url === 'string') {
             url = {
                 load: url,
@@ -24,14 +24,14 @@ Object.assign(BinaryHandler.prototype, {
                 callback("Error loading binary resource: " + url.original + " [" + err + "]");
             }
         });
-    },
-
-    open: function (url, data) {
-        return data;
-    },
-
-    patch: function (asset, assets) {
     }
-});
+
+    open(url, data) {
+        return data;
+    }
+
+    patch(asset, assets) {
+    }
+}
 
 export { BinaryHandler };

--- a/src/resources/bundle.js
+++ b/src/resources/bundle.js
@@ -14,14 +14,14 @@ import { Untar, UntarWorker } from './untar.js';
  * @param {pc.AssetRegistry} assets - The asset registry.
  * @classdesc Loads Bundle Assets.
  */
-function BundleHandler(assets) {
-    this._assets = assets;
-    this._worker = null;
-    this.maxRetries = 0;
-}
+class BundleHandler {
+    constructor(assets) {
+        this._assets = assets;
+        this._worker = null;
+        this.maxRetries = 0;
+    }
 
-Object.assign(BundleHandler.prototype, {
-    load: function (url, callback) {
+    load(url, callback) {
         if (typeof url === 'string') {
             url = {
                 load: url,
@@ -46,9 +46,9 @@ Object.assign(BundleHandler.prototype, {
                 callback("Error loading bundle resource " + url.original + ": " + err);
             }
         });
-    },
+    }
 
-    _untar: function (response, callback) {
+    _untar(response, callback) {
         var self = this;
 
         // use web workers if available otherwise
@@ -74,14 +74,14 @@ Object.assign(BundleHandler.prototype, {
             var files = archive.untar(self._assets.prefix);
             callback(null, files);
         }
-    },
-
-    open: function (url, data) {
-        return new Bundle(data);
-    },
-
-    patch: function (asset, assets) {
     }
-});
+
+    open(url, data) {
+        return new Bundle(data);
+    }
+
+    patch(asset, assets) {
+    }
+}
 
 export { BundleHandler };

--- a/src/resources/container.js
+++ b/src/resources/container.js
@@ -18,27 +18,24 @@ import { SkinInstance } from '../scene/skin-instance.js';
  * @property {pc.Asset[]} textures - Array of assets of textures in the GLB container.
  * @property {pc.Asset[]} materials - Array of assets of materials in the GLB container.
  */
-function ContainerResource(data) {
-    this.data = data;
-    this.model = null;
-    this.renders = [];
-    this.materials = [];
-    this.textures = [];
-    this.animations = [];
-    this.registry = null;
-}
+class ContainerResource {
+    constructor(data) {
+        this.data = data;
+        this.model = null;
+        this.renders = [];
+        this.materials = [];
+        this.textures = [];
+        this.animations = [];
+        this.registry = null;
+    }
 
-Object.assign(ContainerResource.prototype, {
-
-    instantiateModelEntity: function (options) {
-
+    instantiateModelEntity(options) {
         var entity = new pc.Entity();
         entity.addComponent("model", Object.assign( { type: "asset", asset: this.model }, options));
         return entity;
-    },
+    }
 
-    instantiateRenderEntity: function (options) {
-
+    instantiateRenderEntity(options) {
         // helper function to recursively clone a hierarchy while converting ModelComponent to RenderComponents
         var cloneToEntity = function (skinInstances, model, node) {
 
@@ -120,10 +117,9 @@ Object.assign(ContainerResource.prototype, {
         }
 
         return entity;
-    },
+    }
 
-    destroy: function () {
-
+    destroy() {
         var registry = this.registry;
 
         var destroyAsset = function (asset) {
@@ -161,7 +157,7 @@ Object.assign(ContainerResource.prototype, {
         this.data = null;
         this.assets = null;
     }
-});
+}
 
 /**
  * @class
@@ -190,25 +186,25 @@ Object.assign(ContainerResource.prototype, {
  * ```javascript
  * var containerAsset = new pc.Asset(filename, 'container', { url: url, filename: filename }, null, {
  *     texture: {
- *         preprocess: function (gltfTexture) { console.log("texture preprocess"); }
+ *         preprocess(gltfTexture) { console.log("texture preprocess"); }
  *     },
  * });
  * ```
  * @param {pc.GraphicsDevice} device - The graphics device that will be rendering.
  * @param {pc.StandardMaterial} defaultMaterial - The shared default material that is used in any place that a material is not specified.
  */
-function ContainerHandler(device, defaultMaterial) {
-    this._device = device;
-    this._defaultMaterial = defaultMaterial;
-    this.maxRetries = 0;
-}
+class ContainerHandler {
+    constructor(device, defaultMaterial) {
+        this._device = device;
+        this._defaultMaterial = defaultMaterial;
+        this.maxRetries = 0;
+    }
 
-Object.assign(ContainerHandler.prototype, {
-    _getUrlWithoutParams: function (url) {
+    _getUrlWithoutParams(url) {
         return url.indexOf('?') >= 0 ? url.split('?')[0] : url;
-    },
+    }
 
-    load: function (url, callback, asset) {
+    load(url, callback, asset) {
         if (typeof url === 'string') {
             url = {
                 load: url,
@@ -258,14 +254,14 @@ Object.assign(ContainerHandler.prototype, {
                 }
             });
         }
-    },
+    }
 
-    open: function (url, data, asset) {
+    open(url, data, asset) {
         return data;
-    },
+    }
 
     // Create assets to wrap the loaded engine resources - model, materials, textures and animations.
-    patch: function (asset, assets) {
+    patch(asset, assets) {
         var container = asset.resource;
         var data = container && container.data;
 
@@ -312,6 +308,6 @@ Object.assign(ContainerHandler.prototype, {
             container.registry = assets;
         }
     }
-});
+}
 
 export { ContainerHandler, ContainerResource };

--- a/src/resources/css.js
+++ b/src/resources/css.js
@@ -1,11 +1,11 @@
 import { http } from '../net/http.js';
 
-function CssHandler() {
-    this.maxRetries = 0;
-}
+class CssHandler {
+    constructor() {
+        this.maxRetries = 0;
+    }
 
-Object.assign(CssHandler.prototype, {
-    load: function (url, callback) {
+    load(url, callback) {
         if (typeof url === 'string') {
             url = {
                 load: url,
@@ -23,15 +23,15 @@ Object.assign(CssHandler.prototype, {
                 callback("Error loading css resource: " + url.original + " [" + err + "]");
             }
         });
-    },
-
-    open: function (url, data) {
-        return data;
-    },
-
-    patch: function (asset, assets) {
     }
-});
+
+    open(url, data) {
+        return data;
+    }
+
+    patch(asset, assets) {
+    }
+}
 
 /**
  * @function

--- a/src/resources/cubemap.js
+++ b/src/resources/cubemap.js
@@ -15,24 +15,24 @@ import { Texture } from '../graphics/texture.js';
  * @param {pc.AssetRegistry} assets - The asset registry.
  * @param {pc.ResourceLoader} loader - The resource loader.
  */
-function CubemapHandler(device, assets, loader) {
-    this._device = device;
-    this._registry = assets;
-    this._loader = loader;
-}
+class CubemapHandler {
+    constructor(device, assets, loader) {
+        this._device = device;
+        this._registry = assets;
+        this._loader = loader;
+    }
 
-Object.assign(CubemapHandler.prototype, {
-    load: function (url, callback, asset) {
+    load(url, callback, asset) {
         this.loadAssets(asset, callback);
-    },
+    }
 
-    open: function (url, data, asset) {
+    open(url, data, asset) {
         // caller will set our return value to asset.resources[0]. We've already set resources[0],
         // but we must return it again here so it doesn't get overwritten.
         return asset ? asset.resource : null;
-    },
+    }
 
-    patch: function (asset, registry) {
+    patch(asset, registry) {
         this.loadAssets(asset, function (err, result) {
             if (err) {
                 // fire error event if patch failed
@@ -43,10 +43,10 @@ Object.assign(CubemapHandler.prototype, {
             // nothing to do since asset:change would have been raised if
             // resources were changed.
         });
-    },
+    }
 
     // get the list of dependent asset ids for the cubemap
-    getAssetIds: function (cubemapAsset) {
+    getAssetIds(cubemapAsset) {
         var result = [];
 
         // prefiltered cubemap is stored at index 0
@@ -62,10 +62,10 @@ Object.assign(CubemapHandler.prototype, {
         }
 
         return result;
-    },
+    }
 
     // test whether two assets ids are the same
-    compareAssetIds: function (assetIdA, assetIdB) {
+    compareAssetIds(assetIdA, assetIdB) {
         if (assetIdA && assetIdB) {
             if (parseInt(assetIdA, 10) === assetIdA || typeof assetIdA === "string") {
                 return assetIdA === assetIdB;           // id or url
@@ -75,10 +75,10 @@ Object.assign(CubemapHandler.prototype, {
         }
         // else {
         return (assetIdA !== null) === (assetIdB !== null);
-    },
+    }
 
     // update the cubemap resources given a newly loaded set of assets with their corresponding ids
-    update: function (cubemapAsset, assetIds, assets) {
+    update(cubemapAsset, assetIds, assets) {
         var assetData = cubemapAsset.data || {};
         var oldAssets = cubemapAsset._handlerState.assets;
         var oldResources = cubemapAsset._resources;
@@ -199,9 +199,9 @@ Object.assign(CubemapHandler.prototype, {
                 oldAssets[i].unload();
             }
         }
-    },
+    }
 
-    cmpArrays: function (arr1, arr2) {
+    cmpArrays(arr1, arr2) {
         if (arr1.length !== arr2.length) {
             return false;
         }
@@ -211,15 +211,15 @@ Object.assign(CubemapHandler.prototype, {
             }
         }
         return true;
-    },
+    }
 
     // convert string id to int
-    resolveId: function (value) {
+    resolveId(value) {
         var valueInt = parseInt(value, 10);
         return ((valueInt === value) || (valueInt.toString() === value)) ? valueInt : value;
-    },
+    }
 
-    loadAssets: function (cubemapAsset, callback) {
+    loadAssets(cubemapAsset, callback) {
         // initialize asset structures for tracking load requests
         if (!cubemapAsset.hasOwnProperty('_handlerState')) {
             cubemapAsset._handlerState = {
@@ -336,6 +336,6 @@ Object.assign(CubemapHandler.prototype, {
             }
         }
     }
-});
+}
 
 export { CubemapHandler };

--- a/src/resources/folder.js
+++ b/src/resources/folder.js
@@ -1,13 +1,13 @@
-function FolderHandler() {}
+class FolderHandler {
+    constructor() {}
 
-Object.assign(FolderHandler.prototype, {
-    load: function (url, callback) {
+    load(url, callback) {
         callback(null, null);
-    },
+    }
 
-    open: function (url, data) {
+    open(url, data) {
         return data;
     }
-});
+}
 
 export { FolderHandler };

--- a/src/resources/font.js
+++ b/src/resources/font.js
@@ -36,13 +36,13 @@ function upgradeDataSchema(data) {
  * @classdesc Resource handler used for loading {@link pc.Font} resources.
  * @param {pc.ResourceLoader} loader - The resource loader.
  */
-function FontHandler(loader) {
-    this._loader = loader;
-    this.maxRetries = 0;
-}
+class FontHandler {
+    constructor(loader) {
+        this._loader = loader;
+        this.maxRetries = 0;
+    }
 
-Object.assign(FontHandler.prototype, {
-    load: function (url, callback, asset) {
+    load(url, callback, asset) {
         if (typeof url === 'string') {
             url = {
                 load: url,
@@ -80,9 +80,9 @@ Object.assign(FontHandler.prototype, {
             }
             this._loadTextures(url.load, asset && asset.data, callback);
         }
-    },
+    }
 
-    _loadTextures: function (url, data, callback) {
+    _loadTextures(url, data, callback) {
         var numTextures = data.info.maps.length;
         var numLoaded = 0;
         var error = null;
@@ -116,9 +116,9 @@ Object.assign(FontHandler.prototype, {
 
         for (var i = 0; i < numTextures; i++)
             loadTexture(i);
-    },
+    }
 
-    open: function (url, data, asset) {
+    open(url, data, asset) {
         var font;
         if (data.textures) {
             // both data and textures exist
@@ -128,9 +128,9 @@ Object.assign(FontHandler.prototype, {
             font = new Font(data, null);
         }
         return font;
-    },
+    }
 
-    patch: function (asset, assets) {
+    patch(asset, assets) {
         // if not already set, get font data block from asset
         // and assign to font resource
         var font = asset.resource;
@@ -146,6 +146,6 @@ Object.assign(FontHandler.prototype, {
             asset.data = upgradeDataSchema(asset.data);
         }
     }
-});
+}
 
 export { FontHandler };

--- a/src/resources/handler.js
+++ b/src/resources/handler.js
@@ -3,9 +3,8 @@
  * @name pc.ResourceHandler
  * @description Interface for ResourceHandlers used by {@link pc.ResourceLoader}.
  */
-function ResourceHandler() {}
-
-Object.assign(ResourceHandler.prototype, {
+class ResourceHandler {
+    constructor() {}
 
     /**
      * @function
@@ -20,9 +19,9 @@ Object.assign(ResourceHandler.prototype, {
      * @param {pc.callbacks.ResourceHandler} callback - The callback used when the resource is loaded or an error occurs.
      * @param {pc.Asset} [asset] - Optional asset that is passed by ResourceLoader.
      */
-    load: function (url, callback, asset) {
+    load(url, callback, asset) {
         throw new Error('not implemented');
-    },
+    }
 
     /**
      * @function
@@ -34,9 +33,9 @@ Object.assign(ResourceHandler.prototype, {
      * @returns {*} The parsed resource data.
      */
     /* eslint-disable jsdoc/require-returns-check */
-    open: function (url, data, asset) {
+    open(url, data, asset) {
         throw new Error('not implemented');
-    },
+    }
     /* eslint-enable jsdoc/require-returns-check */
 
     /**
@@ -47,9 +46,9 @@ Object.assign(ResourceHandler.prototype, {
      * @param {pc.Asset} asset - The asset to patch.
      * @param {pc.AssetRegistry} assets - The asset registry.
      */
-    patch: function (asset, assets) {
+    patch(asset, assets) {
         // optional function
     }
-});
+}
 
 export { ResourceHandler };

--- a/src/resources/hierarchy.js
+++ b/src/resources/hierarchy.js
@@ -4,13 +4,13 @@ import { SceneParser } from './parser/scene.js';
 
 import { TemplateUtils } from '../templates/template-utils.js';
 
-function HierarchyHandler(app) {
-    this._app = app;
-    this.maxRetries = 0;
-}
+class HierarchyHandler {
+    constructor(app) {
+        this._app = app;
+        this.maxRetries = 0;
+    }
 
-Object.assign(HierarchyHandler.prototype, {
-    load: function (url, callback) {
+    load(url, callback) {
         if (typeof url === 'string') {
             url = {
                 load: url,
@@ -43,9 +43,9 @@ Object.assign(HierarchyHandler.prototype, {
                 callback(errMsg);
             }
         });
-    },
+    }
 
-    open: function (url, data) {
+    open(url, data) {
         // prevent script initialization until entire scene is open
         this._app.systems.script.preloading = true;
 
@@ -57,6 +57,6 @@ Object.assign(HierarchyHandler.prototype, {
 
         return parent;
     }
-});
+}
 
 export { HierarchyHandler };

--- a/src/resources/html.js
+++ b/src/resources/html.js
@@ -1,11 +1,11 @@
 import { http } from '../net/http.js';
 
-function HtmlHandler() {
-    this.maxRetries = 0;
-}
+class HtmlHandler {
+    constructor() {
+        this.maxRetries = 0;
+    }
 
-Object.assign(HtmlHandler.prototype, {
-    load: function (url, callback) {
+    load(url, callback) {
         if (typeof url === 'string') {
             url = {
                 load: url,
@@ -23,14 +23,14 @@ Object.assign(HtmlHandler.prototype, {
                 callback("Error loading html resource: " + url.original + " [" + err + "]");
             }
         });
-    },
-
-    open: function (url, data) {
-        return data;
-    },
-
-    patch: function (asset, assets) {
     }
-});
+
+    open(url, data) {
+        return data;
+    }
+
+    patch(asset, assets) {
+    }
+}
 
 export { HtmlHandler };

--- a/src/resources/json.js
+++ b/src/resources/json.js
@@ -1,11 +1,11 @@
 import { http, Http } from '../net/http.js';
 
-function JsonHandler() {
-    this.maxRetries = 0;
-}
+class JsonHandler {
+    constructor() {
+        this.maxRetries = 0;
+    }
 
-Object.assign(JsonHandler.prototype, {
-    load: function (url, callback) {
+    load(url, callback) {
         if (typeof url === 'string') {
             url = {
                 load: url,
@@ -30,14 +30,14 @@ Object.assign(JsonHandler.prototype, {
                 callback("Error loading JSON resource: " + url.original + " [" + err + "]");
             }
         });
-    },
-
-    open: function (url, data) {
-        return data;
-    },
-
-    patch: function (asset, assets) {
     }
-});
+
+    open(url, data) {
+        return data;
+    }
+
+    patch(asset, assets) {
+    }
+}
 
 export { JsonHandler };

--- a/src/resources/loader.js
+++ b/src/resources/loader.js
@@ -5,14 +5,14 @@
  * @classdesc Load resource data, potentially from remote sources. Caches resource on load to prevent
  * multiple requests. Add ResourceHandlers to handle different types of resources.
  */
-function ResourceLoader(app) {
-    this._handlers = {};
-    this._requests = {};
-    this._cache = {};
-    this._app = app;
-}
+class ResourceLoader {
+    constructor(app) {
+        this._handlers = {};
+        this._requests = {};
+        this._cache = {};
+        this._app = app;
+    }
 
-Object.assign(ResourceLoader.prototype, {
     /**
      * @function
      * @name pc.ResourceLoader#addHandler
@@ -40,10 +40,10 @@ Object.assign(ResourceLoader.prototype, {
      * var loader = new ResourceLoader();
      * loader.addHandler("json", new pc.JsonHandler());
      */
-    addHandler: function (type, handler) {
+    addHandler(type, handler) {
         this._handlers[type] = handler;
         handler._loader = this;
-    },
+    }
 
     /**
      * @function
@@ -51,9 +51,9 @@ Object.assign(ResourceLoader.prototype, {
      * @description Remove a {@link pc.ResourceHandler} for a resource type.
      * @param {string} type - The name of the type that the handler will be removed.
      */
-    removeHandler: function (type) {
+    removeHandler(type) {
         delete this._handlers[type];
-    },
+    }
 
     /**
      * @function
@@ -62,9 +62,9 @@ Object.assign(ResourceLoader.prototype, {
      * @param {string} type - The name of the resource type that the handler is registered with.
      * @returns {pc.ResourceHandler} The registered handler.
      */
-    getHandler: function (type) {
+    getHandler(type) {
         return this._handlers[type];
-    },
+    }
 
     /**
      * @function
@@ -82,7 +82,7 @@ Object.assign(ResourceLoader.prototype, {
      *     // use texture here
      * });
      */
-    load: function (url, type, callback, asset) {
+    load(url, type, callback, asset) {
         var handler = this._handlers[type];
         if (!handler) {
             var err = "No handler for asset type: " + type;
@@ -156,10 +156,10 @@ Object.assign(ResourceLoader.prototype, {
                 });
             }
         }
-    },
+    }
 
     // load an asset with no url, skipping bundles and caching
-    _loadNull: function (handler, callback, asset) {
+    _loadNull(handler, callback, asset) {
         var onLoad = function (err, data, extra) {
             if (err) {
                 callback(err);
@@ -172,17 +172,17 @@ Object.assign(ResourceLoader.prototype, {
             }
         };
         handler.load(null, onLoad, asset);
-    },
+    }
 
-    _onSuccess: function (key, result, extra) {
+    _onSuccess(key, result, extra) {
         this._cache[key] = result;
         for (var i = 0; i < this._requests[key].length; i++) {
             this._requests[key][i](null, result, extra);
         }
         delete this._requests[key];
-    },
+    }
 
-    _onFailure: function (key, err) {
+    _onFailure(key, err) {
         console.error(err);
         if (this._requests[key]) {
             for (var i = 0; i < this._requests[key].length; i++) {
@@ -190,7 +190,7 @@ Object.assign(ResourceLoader.prototype, {
             }
             delete this._requests[key];
         }
-    },
+    }
 
     /**
      * @function
@@ -200,7 +200,7 @@ Object.assign(ResourceLoader.prototype, {
      * @param {*} data - The raw resource data.
      * @returns {*} The parsed resource data.
      */
-    open: function (type, data) {
+    open(type, data) {
         var handler = this._handlers[type];
         if (!handler) {
             console.warn("No resource handler found for: " + type);
@@ -209,7 +209,7 @@ Object.assign(ResourceLoader.prototype, {
 
         return handler.open(null, data);
 
-    },
+    }
 
     /**
      * @function
@@ -219,7 +219,7 @@ Object.assign(ResourceLoader.prototype, {
      * @param {pc.Asset} asset - The asset to patch.
      * @param {pc.AssetRegistry} assets - The asset registry.
      */
-    patch: function (asset, assets) {
+    patch(asset, assets) {
         var handler = this._handlers[asset.type];
         if (!handler)  {
             console.warn("No resource handler found for: " + asset.type);
@@ -229,7 +229,7 @@ Object.assign(ResourceLoader.prototype, {
         if (handler.patch) {
             handler.patch(asset, assets);
         }
-    },
+    }
 
     /**
      * @function
@@ -238,9 +238,9 @@ Object.assign(ResourceLoader.prototype, {
      * @param {string} url - The URL of the resource.
      * @param {string} type - The type of resource.
      */
-    clearCache: function (url, type) {
+    clearCache(url, type) {
         delete this._cache[url + type];
-    },
+    }
 
     /**
      * @function
@@ -250,11 +250,11 @@ Object.assign(ResourceLoader.prototype, {
      * @param {string} type - The type of the resource.
      * @returns {*} The resource loaded from the cache.
      */
-    getFromCache: function (url, type) {
+    getFromCache(url, type) {
         if (this._cache[url + type]) {
             return this._cache[url + type];
         }
-    },
+    }
 
     /**
      * @private
@@ -263,17 +263,13 @@ Object.assign(ResourceLoader.prototype, {
      * @param {number} maxRetries - The maximum number of times to retry loading an asset. Defaults to 5.
      * @description Enables retrying of failed requests when loading assets.
      */
-    enableRetry: function (maxRetries) {
-        if (maxRetries === undefined) {
-            maxRetries = 5;
-        }
-
+    enableRetry(maxRetries = 5) {
         maxRetries = Math.max(0, maxRetries) || 0;
 
         for (var key in this._handlers) {
             this._handlers[key].maxRetries = maxRetries;
         }
-    },
+    }
 
     /**
      * @private
@@ -281,22 +277,22 @@ Object.assign(ResourceLoader.prototype, {
      * @name pc.ResourceLoader#disableRetry
      * @description Disables retrying of failed requests when loading assets.
      */
-    disableRetry: function () {
+    disableRetry() {
         for (var key in this._handlers) {
             this._handlers[key].maxRetries = 0;
         }
-    },
+    }
 
     /**
      * @function
      * @name pc.ResourceLoader#destroy
      * @description Destroys the resource loader.
      */
-    destroy: function () {
+    destroy() {
         this._handlers = {};
         this._requests = {};
         this._cache = {};
     }
-});
+}
 
 export { ResourceLoader };

--- a/src/resources/material.js
+++ b/src/resources/material.js
@@ -31,18 +31,18 @@ var PLACEHOLDER_MAP = {
  * @classdesc Resource handler used for loading {@link pc.Material} resources.
  * @param {pc.Application} app - The running {@link pc.Application}.
  */
-function MaterialHandler(app) {
-    this._assets = app.assets;
-    this._device = app.graphicsDevice;
+class MaterialHandler {
+    constructor(app) {
+        this._assets = app.assets;
+        this._device = app.graphicsDevice;
 
-    this._placeholderTextures = null;
+        this._placeholderTextures = null;
 
-    this._parser = new JsonStandardMaterialParser();
-    this.maxRetries = 0;
-}
+        this._parser = new JsonStandardMaterialParser();
+        this.maxRetries = 0;
+    }
 
-Object.assign(MaterialHandler.prototype, {
-    load: function (url, callback) {
+    load(url, callback) {
         if (typeof url === 'string') {
             url = {
                 load: url,
@@ -66,9 +66,9 @@ Object.assign(MaterialHandler.prototype, {
                 }
             }
         });
-    },
+    }
 
-    open: function (url, data) {
+    open(url, data) {
         var material = this._parser.parse(data);
 
         // temp storage for engine-only as we need this during patching
@@ -78,11 +78,11 @@ Object.assign(MaterialHandler.prototype, {
         }
 
         return material;
-    },
+    }
 
     // creates placeholders for textures
     // that are used while texture is loading
-    _createPlaceholders: function () {
+    _createPlaceholders() {
         this._placeholderTextures = {};
 
         var textures = {
@@ -113,9 +113,9 @@ Object.assign(MaterialHandler.prototype, {
             }
             this._placeholderTextures[key].unlock();
         }
-    },
+    }
 
-    patch: function (asset, assets) {
+    patch(asset, assets) {
         // in an engine-only environment we manually copy the source data into the asset
         if (asset.resource._data) {
             asset._data = asset.resource._data; // use _data to avoid firing events
@@ -130,24 +130,24 @@ Object.assign(MaterialHandler.prototype, {
 
         asset.off('unload', this._onAssetUnload, this);
         asset.on('unload', this._onAssetUnload, this);
-    },
+    }
 
-    _onAssetUnload: function (asset) {
+    _onAssetUnload(asset) {
         // remove the parameter block we created which includes texture references
         delete asset.data.parameters;
         delete asset.data.chunks;
         delete asset.data.name;
-    },
+    }
 
-    _assignTexture: function (parameterName, materialAsset, texture) {
+    _assignTexture(parameterName, materialAsset, texture) {
         materialAsset.data[parameterName] = texture;
         materialAsset.resource[parameterName] = texture;
-    },
+    }
 
     // assign a placeholder texture while waiting for one to load
     // placeholder textures do not replace the data[parameterName] value
     // in the asset.data thus preserving the final asset id until it is loaded
-    _assignPlaceholderTexture: function (parameterName, materialAsset) {
+    _assignPlaceholderTexture(parameterName, materialAsset) {
         // create placeholder textures on-demand
         if (!this._placeholderTextures) {
             this._createPlaceholders();
@@ -157,18 +157,18 @@ Object.assign(MaterialHandler.prototype, {
         var texture = this._placeholderTextures[placeholder];
 
         materialAsset.resource[parameterName] = texture;
-    },
+    }
 
-    _onTextureLoad: function (parameterName, materialAsset, textureAsset) {
+    _onTextureLoad(parameterName, materialAsset, textureAsset) {
         this._assignTexture(parameterName, materialAsset, textureAsset.resource);
         materialAsset.resource.update();
-    },
+    }
 
-    _onTextureAdd: function (parameterName, materialAsset, textureAsset) {
+    _onTextureAdd(parameterName, materialAsset, textureAsset) {
         this._assets.load(textureAsset);
-    },
+    }
 
-    _onTextureRemove: function (parameterName, materialAsset, textureAsset) {
+    _onTextureRemove(parameterName, materialAsset, textureAsset) {
         var material = materialAsset.resource;
         if (material) {
             if (material[parameterName] === textureAsset.resource) {
@@ -176,9 +176,9 @@ Object.assign(MaterialHandler.prototype, {
                 material.update();
             }
         }
-    },
+    }
 
-    _assignCubemap: function (parameterName, materialAsset, textures) {
+    _assignCubemap(parameterName, materialAsset, textures) {
         materialAsset.data[parameterName] = textures[0]; // the primary cubemap texture
         if (textures.length === 7) {
             // the prefiltered textures
@@ -189,32 +189,32 @@ Object.assign(MaterialHandler.prototype, {
             materialAsset.data.prefilteredCubeMap8 = textures[5];
             materialAsset.data.prefilteredCubeMap4 = textures[6];
         }
-    },
+    }
 
-    _onCubemapLoad: function (parameterName, materialAsset, cubemapAsset) {
+    _onCubemapLoad(parameterName, materialAsset, cubemapAsset) {
         this._assignCubemap(parameterName, materialAsset, cubemapAsset.resources);
         this._parser.initialize(materialAsset.resource, materialAsset.data);
-    },
+    }
 
-    _onCubemapAdd: function (parameterName, materialAsset, cubemapAsset) {
+    _onCubemapAdd(parameterName, materialAsset, cubemapAsset) {
         // phong based - so ensure we load individual faces
         if (materialAsset.data.shadingModel === SPECULAR_PHONG) {
             materialAsset.loadFaces = true;
         }
 
         this._assets.load(cubemapAsset);
-    },
+    }
 
-    _onCubemapRemove: function (parameterName, materialAsset, cubemapAsset) {
+    _onCubemapRemove(parameterName, materialAsset, cubemapAsset) {
         var material = materialAsset.resource;
 
         if (material[parameterName] === cubemapAsset.resource) {
             this._assignCubemap(parameterName, materialAsset, [null, null, null, null, null, null, null]);
             material.update();
         }
-    },
+    }
 
-    _bindAndAssignAssets: function (materialAsset, assets) {
+    _bindAndAssignAssets(materialAsset, assets) {
         // always migrate before updating material from asset data
         var data = this._parser.migrate(materialAsset.data);
 
@@ -317,6 +317,6 @@ Object.assign(MaterialHandler.prototype, {
         // call to re-initialize material after all textures assigned
         this._parser.initialize(material, data);
     }
-});
+}
 
 export { MaterialHandler };

--- a/src/resources/model.js
+++ b/src/resources/model.js
@@ -13,22 +13,22 @@ import { JsonModelParser } from './parser/json-model.js';
  * @param {pc.GraphicsDevice} device - The graphics device that will be rendering.
  * @param {pc.StandardMaterial} defaultMaterial - The shared default material that is used in any place that a material is not specified.
  */
-function ModelHandler(device, defaultMaterial) {
-    this._device = device;
-    this._parsers = [];
-    this._defaultMaterial = defaultMaterial;
-    this.maxRetries = 0;
+class ModelHandler {
+    constructor(device, defaultMaterial) {
+        this._device = device;
+        this._parsers = [];
+        this._defaultMaterial = defaultMaterial;
+        this.maxRetries = 0;
 
-    this.addParser(new JsonModelParser(this._device), function (url, data) {
-        return (path.getExtension(url) === '.json');
-    });
-    this.addParser(new GlbModelParser(this._device), function (url, data) {
-        return (path.getExtension(url) === '.glb');
-    });
-}
+        this.addParser(new JsonModelParser(this._device), function (url, data) {
+            return (path.getExtension(url) === '.json');
+        });
+        this.addParser(new GlbModelParser(this._device), function (url, data) {
+            return (path.getExtension(url) === '.glb');
+        });
+    }
 
-Object.assign(ModelHandler.prototype, {
-    load: function (url, callback) {
+    load(url, callback) {
         if (typeof url === 'string') {
             url = {
                 load: url,
@@ -60,9 +60,9 @@ Object.assign(ModelHandler.prototype, {
                 callback("Error loading model: " + url.original + " [" + err + "]");
             }
         });
-    },
+    }
 
-    open: function (url, data) {
+    open(url, data) {
         for (var i = 0; i < this._parsers.length; i++) {
             var p = this._parsers[i];
 
@@ -74,9 +74,9 @@ Object.assign(ModelHandler.prototype, {
         console.warn("pc.ModelHandler#open: No model parser found for: " + url);
         // #endif
         return null;
-    },
+    }
 
-    patch: function (asset, assets) {
+    patch(asset, assets) {
         if (!asset.resource)
             return;
 
@@ -133,7 +133,7 @@ Object.assign(ModelHandler.prototype, {
                 }
             }
         });
-    },
+    }
 
     /**
      * @function
@@ -145,12 +145,12 @@ Object.assign(ModelHandler.prototype, {
      * Function should take (url, data) arguments and return true if this parser should be used to parse the data into a {@link pc.Model}.
      * The first parser to return true is used.
      */
-    addParser: function (parser, decider) {
+    addParser(parser, decider) {
         this._parsers.push({
             parser: parser,
             decider: decider
         });
     }
-});
+}
 
 export { ModelHandler };

--- a/src/resources/parser/glb-model.js
+++ b/src/resources/parser/glb-model.js
@@ -2,19 +2,19 @@ import { getDefaultMaterial } from '../../scene/materials/default-material.js';
 
 import { GlbParser } from './glb-parser.js';
 
-function GlbModelParser(device) {
-    this._device = device;
-    this._defaultMaterial = getDefaultMaterial();
-}
+class GlbModelParser {
+    constructor(device) {
+        this._device = device;
+        this._defaultMaterial = getDefaultMaterial();
+    }
 
-Object.assign(GlbModelParser.prototype, {
-    parse: function (data) {
+    parse(data) {
         var glb = GlbParser.parse("filename.glb", data, this._device);
         if (!glb) {
             return null;
         }
         return GlbParser.createModel(glb, this._defaultMaterial);
     }
-});
+}
 
 export { GlbModelParser };

--- a/src/resources/parser/json-model.js
+++ b/src/resources/parser/json-model.js
@@ -48,13 +48,13 @@ var JSON_VERTEX_ELEMENT_TYPE = {
 };
 
 // Take PlayCanvas JSON model data and create pc.Model
-function JsonModelParser(device) {
-    this._device = device;
-    this._defaultMaterial = getDefaultMaterial();
-}
+class JsonModelParser {
+    constructor(device) {
+        this._device = device;
+        this._defaultMaterial = getDefaultMaterial();
+    }
 
-Object.assign(JsonModelParser.prototype, {
-    parse: function (data) {
+    parse(data) {
         var modelData = data.model;
         if (!modelData) {
             return null;
@@ -96,9 +96,9 @@ Object.assign(JsonModelParser.prototype, {
         model.getGraph().syncHierarchy();
 
         return model;
-    },
+    }
 
-    _parseNodes: function (data) {
+    _parseNodes(data) {
         var modelData = data.model;
         var nodes = [];
         var i;
@@ -120,9 +120,9 @@ Object.assign(JsonModelParser.prototype, {
         }
 
         return nodes;
-    },
+    }
 
-    _parseSkins: function (data, nodes) {
+    _parseSkins(data, nodes) {
         var modelData = data.model;
         var skins = [];
         var skinInstances = [];
@@ -161,10 +161,10 @@ Object.assign(JsonModelParser.prototype, {
             skins: skins,
             instances: skinInstances
         };
-    },
+    }
 
     // find number of vertices used by a mesh that is using morph target with index morphIndex
-    _getMorphVertexCount: function (modelData, morphIndex, vertexBuffers) {
+    _getMorphVertexCount(modelData, morphIndex, vertexBuffers) {
         for (var i = 0; i < modelData.meshes.length; i++) {
             var meshData = modelData.meshes[i];
 
@@ -174,9 +174,9 @@ Object.assign(JsonModelParser.prototype, {
             }
         }
         return undefined;
-    },
+    }
 
-    _parseMorphs: function (data, nodes, vertexBuffers) {
+    _parseMorphs(data, nodes, vertexBuffers) {
         var modelData = data.model;
         var morphs = [];
         var morphInstances = [];
@@ -244,9 +244,9 @@ Object.assign(JsonModelParser.prototype, {
             morphs: morphs,
             instances: morphInstances
         };
-    },
+    }
 
-    _parseVertexBuffers: function (data) {
+    _parseVertexBuffers(data) {
         var modelData = data.model;
         var vertexBuffers = [];
         var attribute, attributeName;
@@ -316,9 +316,9 @@ Object.assign(JsonModelParser.prototype, {
         }
 
         return vertexBuffers;
-    },
+    }
 
-    _parseIndexBuffers: function (data, vertexBuffers) {
+    _parseIndexBuffers(data, vertexBuffers) {
         var modelData = data.model;
         var indexBuffer = null;
         var indexData = null;
@@ -352,9 +352,9 @@ Object.assign(JsonModelParser.prototype, {
             buffer: indexBuffer,
             data: indexData
         };
-    },
+    }
 
-    _parseMeshes: function (data, skins, morphs, vertexBuffers, indexBuffer, indexData) {
+    _parseMeshes(data, skins, morphs, vertexBuffers, indexBuffer, indexData) {
         var modelData = data.model;
 
         var meshes = [];
@@ -398,9 +398,9 @@ Object.assign(JsonModelParser.prototype, {
         }
 
         return meshes;
-    },
+    }
 
-    _parseMeshInstances: function (data, nodes, meshes, skins, skinInstances, morphs, morphInstances) {
+    _parseMeshInstances(data, nodes, meshes, skins, skinInstances, morphs, morphInstances) {
         var modelData = data.model;
         var meshInstances = [];
         var i;
@@ -438,6 +438,6 @@ Object.assign(JsonModelParser.prototype, {
 
         return meshInstances;
     }
-});
+}
 
 export { JsonModelParser };

--- a/src/resources/parser/material/json-standard-material.js
+++ b/src/resources/parser/material/json-standard-material.js
@@ -18,161 +18,162 @@ import { standardMaterialParameterTypes } from '../../../scene/materials/standar
  * @name pc.JsonStandardMaterialParser
  * @description Convert incoming JSON data into a {@link pc.StandardMaterial}.
  */
-function JsonStandardMaterialParser() {
-    this._validator = null;
-}
+class JsonStandardMaterialParser {
+    constructor() {
+        this._validator = null;
+    }
 
-JsonStandardMaterialParser.prototype.parse = function (input) {
-    var migrated = this.migrate(input);
-    var validated = this._validate(migrated);
+    parse(input) {
+        var migrated = this.migrate(input);
+        var validated = this._validate(migrated);
 
-    var material = new StandardMaterial();
-    this.initialize(material, validated);
+        var material = new StandardMaterial();
+        this.initialize(material, validated);
 
-    return material;
-};
+        return material;
+    }
 
-/**
- * @private
- * @function
- * @name pc.JsonStandardMaterialParser#initialize
- * @description  Initialize material properties from the material data block e.g. Loading from server.
- * @param {pc.StandardMaterial} material - The material to be initialized.
- * @param {object} data - The data block that is used to initialize.
- */
-JsonStandardMaterialParser.prototype.initialize = function (material, data) {
-    // usual flow is that data is validated in resource loader
-    // but if not, validate here.
-    if (!data.validated) {
+    /**
+     * @private
+     * @function
+     * @name pc.JsonStandardMaterialParser#initialize
+     * @description  Initialize material properties from the material data block e.g. Loading from server.
+     * @param {pc.StandardMaterial} material - The material to be initialized.
+     * @param {object} data - The data block that is used to initialize.
+     */
+    initialize(material, data) {
+        // usual flow is that data is validated in resource loader
+        // but if not, validate here.
+        if (!data.validated) {
+            if (!this._validator) {
+                this._validator = new StandardMaterialValidator();
+            }
+            this._validator.validate(data);
+        }
+
+        if (data.chunks) {
+            material.chunks.copy(data.chunks);
+        }
+
+        // initialize material values from the input data
+        for (var key in data) {
+            var type = standardMaterialParameterTypes[key];
+            var value = data[key];
+
+            if (type === 'vec2') {
+                material[key] = new Vec2(value[0], value[1]);
+            } else if (type === 'rgb') {
+                material[key] = new Color(value[0], value[1], value[2]);
+            } else if (type === 'texture') {
+                if (value instanceof Texture) {
+                    material[key] = value;
+                } else if (material[key] instanceof Texture && typeof(value) === 'number' && value > 0) {
+                    // material already has a texture assigned, but data contains a valid asset id (which means the asset isn't yet loaded)
+                    // leave current texture (probably a placeholder) until the asset is loaded
+                } else {
+                    material[key] = null;
+                }
+            } else if (type === 'cubemap') {
+                if (value instanceof Texture) {
+                    material[key] = value;
+                } else if (material[key] instanceof Texture && typeof(value) === 'number' && value > 0) {
+                    // material already has a texture assigned, but data contains a valid asset id (which means the asset isn't yet loaded)
+                    // leave current texture (probably a placeholder) until the asset is loaded
+                } else {
+                    material[key] = null;
+                }
+            } else if (type === 'boundingbox') {
+                var center = new Vec3(value.center[0], value.center[1], value.center[2]);
+                var halfExtents = new Vec3(value.halfExtents[0], value.halfExtents[1], value.halfExtents[2]);
+                material[key] = new BoundingBox(center, halfExtents);
+            } else {
+                // number, boolean and enum types don't require type creation
+                material[key] = data[key];
+            }
+        }
+
+        material.update();
+    }
+
+    // convert any properties that are out of date
+    // or from old versions into current version
+    migrate(data) {
+        // replace old shader property with new shadingModel property
+        if (data.shadingModel === undefined) {
+            if (data.shader === 'blinn') {
+                data.shadingModel = SPECULAR_BLINN;
+            } else {
+                data.shadingModel = SPECULAR_PHONG;
+            }
+        }
+        if (data.shader) delete data.shader;
+
+        // make JS style
+        if (data.mapping_format) {
+            data.mappingFormat = data.mapping_format;
+            delete data.mapping_format;
+        }
+
+        var i;
+        // list of properties that have been renamed in StandardMaterial
+        // but may still exists in data in old format
+        var RENAMED_PROPERTIES = [
+            ["bumpMapFactor", "bumpiness"],
+
+            ["aoUvSet", "aoMapUv"],
+
+            ["aoMapVertexColor", "aoVertexColor"],
+            ["diffuseMapVertexColor", "diffuseVertexColor"],
+            ["emissiveMapVertexColor", "emissiveVertexColor"],
+            ["specularMapVertexColor", "specularVertexColor"],
+            ["metalnessMapVertexColor", "metalnessVertexColor"],
+            ["opacityMapVertexColor", "opacityVertexColor"],
+            ["glossMapVertexColor", "glossVertexColor"],
+            ["lightMapVertexColor", "lightVertexColor"],
+
+            ["diffuseMapTint", "diffuseTint"],
+            ["specularMapTint", "specularTint"],
+            ["emissiveMapTint", "emissiveTint"],
+            ["metalnessMapTint", "metalnessTint"]
+        ];
+
+        // if an old property name exists without a new one,
+        // move property into new name and delete old one.
+        for (i = 0; i < RENAMED_PROPERTIES.length; i++) {
+            var _old = RENAMED_PROPERTIES[i][0];
+            var _new = RENAMED_PROPERTIES[i][1];
+
+            if (data[_old] !== undefined && !(data[_new] !== undefined)) {
+                data[_new] = data[_old];
+                delete data[_old];
+            }
+        }
+
+        // Properties that may exist in input data, but are now ignored
+        var DEPRECATED_PROPERTIES = [
+            'fresnelFactor',
+            'shadowSampleType'
+        ];
+
+        for (i = 0; i < DEPRECATED_PROPERTIES.length; i++) {
+            var name = DEPRECATED_PROPERTIES[i];
+            if (data.hasOwnProperty(name)) {
+                delete data[name];
+            }
+        }
+
+        return data;
+    }
+
+    // check for invalid properties
+    _validate(data) {
         if (!this._validator) {
             this._validator = new StandardMaterialValidator();
         }
         this._validator.validate(data);
+
+        return data;
     }
-
-    if (data.chunks) {
-        material.chunks.copy(data.chunks);
-    }
-
-    // initialize material values from the input data
-    for (var key in data) {
-        var type = standardMaterialParameterTypes[key];
-        var value = data[key];
-
-        if (type === 'vec2') {
-            material[key] = new Vec2(value[0], value[1]);
-        } else if (type === 'rgb') {
-            material[key] = new Color(value[0], value[1], value[2]);
-        } else if (type === 'texture') {
-            if (value instanceof Texture) {
-                material[key] = value;
-            } else if (material[key] instanceof Texture && typeof(value) === 'number' && value > 0) {
-                // material already has a texture assigned, but data contains a valid asset id (which means the asset isn't yet loaded)
-                // leave current texture (probably a placeholder) until the asset is loaded
-            } else {
-                material[key] = null;
-            }
-        } else if (type === 'cubemap') {
-            if (value instanceof Texture) {
-                material[key] = value;
-            } else if (material[key] instanceof Texture && typeof(value) === 'number' && value > 0) {
-                // material already has a texture assigned, but data contains a valid asset id (which means the asset isn't yet loaded)
-                // leave current texture (probably a placeholder) until the asset is loaded
-            } else {
-                material[key] = null;
-            }
-        } else if (type === 'boundingbox') {
-            var center = new Vec3(value.center[0], value.center[1], value.center[2]);
-            var halfExtents = new Vec3(value.halfExtents[0], value.halfExtents[1], value.halfExtents[2]);
-            material[key] = new BoundingBox(center, halfExtents);
-        } else {
-            // number, boolean and enum types don't require type creation
-            material[key] = data[key];
-        }
-    }
-
-    material.update();
-};
-
-// convert any properties that are out of date
-// or from old versions into current version
-JsonStandardMaterialParser.prototype.migrate = function (data) {
-    // replace old shader property with new shadingModel property
-    if (data.shadingModel === undefined) {
-        if (data.shader === 'blinn') {
-            data.shadingModel = SPECULAR_BLINN;
-        } else {
-            data.shadingModel = SPECULAR_PHONG;
-        }
-    }
-    if (data.shader) delete data.shader;
-
-
-    // make JS style
-    if (data.mapping_format) {
-        data.mappingFormat = data.mapping_format;
-        delete data.mapping_format;
-    }
-
-    var i;
-    // list of properties that have been renamed in StandardMaterial
-    // but may still exists in data in old format
-    var RENAMED_PROPERTIES = [
-        ["bumpMapFactor", "bumpiness"],
-
-        ["aoUvSet", "aoMapUv"],
-
-        ["aoMapVertexColor", "aoVertexColor"],
-        ["diffuseMapVertexColor", "diffuseVertexColor"],
-        ["emissiveMapVertexColor", "emissiveVertexColor"],
-        ["specularMapVertexColor", "specularVertexColor"],
-        ["metalnessMapVertexColor", "metalnessVertexColor"],
-        ["opacityMapVertexColor", "opacityVertexColor"],
-        ["glossMapVertexColor", "glossVertexColor"],
-        ["lightMapVertexColor", "lightVertexColor"],
-
-        ["diffuseMapTint", "diffuseTint"],
-        ["specularMapTint", "specularTint"],
-        ["emissiveMapTint", "emissiveTint"],
-        ["metalnessMapTint", "metalnessTint"]
-    ];
-
-    // if an old property name exists without a new one,
-    // move property into new name and delete old one.
-    for (i = 0; i < RENAMED_PROPERTIES.length; i++) {
-        var _old = RENAMED_PROPERTIES[i][0];
-        var _new = RENAMED_PROPERTIES[i][1];
-
-        if (data[_old] !== undefined && !(data[_new] !== undefined)) {
-            data[_new] = data[_old];
-            delete data[_old];
-        }
-    }
-
-    // Properties that may exist in input data, but are now ignored
-    var DEPRECATED_PROPERTIES = [
-        'fresnelFactor',
-        'shadowSampleType'
-    ];
-
-    for (i = 0; i < DEPRECATED_PROPERTIES.length; i++) {
-        var name = DEPRECATED_PROPERTIES[i];
-        if (data.hasOwnProperty(name)) {
-            delete data[name];
-        }
-    }
-
-    return data;
-};
-
-// check for invalid properties
-JsonStandardMaterialParser.prototype._validate = function (data) {
-    if (!this._validator) {
-        this._validator = new StandardMaterialValidator();
-    }
-    this._validator.validate(data);
-
-    return data;
-};
+}
 
 export { JsonStandardMaterialParser };

--- a/src/resources/parser/scene.js
+++ b/src/resources/parser/scene.js
@@ -4,14 +4,14 @@ import { TemplateUtils } from '../../templates/template-utils.js';
 import { CompressUtils } from '../../compress/compress-utils';
 import { Decompress } from '../../compress/decompress';
 
-function SceneParser(app, isTemplate) {
-    this._app = app;
+class SceneParser {
+    constructor(app, isTemplate) {
+        this._app = app;
 
-    this._isTemplate = isTemplate;
-}
+        this._isTemplate = isTemplate;
+    }
 
-Object.assign(SceneParser.prototype, {
-    parse: function (data) {
+    parse(data) {
         var entities = {};
         var id, i, curEnt;
         var parent = null;
@@ -53,9 +53,9 @@ Object.assign(SceneParser.prototype, {
         delete data.compressedFormat;
 
         return parent;
-    },
+    }
 
-    _createEntity: function (data, compressed) {
+    _createEntity(data, compressed) {
         var entity = new Entity();
 
         entity.name = data.name;
@@ -84,9 +84,9 @@ Object.assign(SceneParser.prototype, {
         }
 
         return entity;
-    },
+    }
 
-    _setPosRotScale: function (entity, data, compressed) {
+    _setPosRotScale(entity, data, compressed) {
         if (compressed) {
             CompressUtils.setCompressedPRS(entity, data, compressed);
 
@@ -99,9 +99,9 @@ Object.assign(SceneParser.prototype, {
             entity.setLocalEulerAngles(r[0], r[1], r[2]);
             entity.setLocalScale(s[0], s[1], s[2]);
         }
-    },
+    }
 
-    _openComponentData: function (entity, entities) {
+    _openComponentData(entity, entities) {
         // Create components in order
         var systemsList = this._app.systems.list;
 
@@ -123,9 +123,9 @@ Object.assign(SceneParser.prototype, {
         }
 
         return entity;
-    },
+    }
 
-    _addCollapsedToEntities: function (app, data) {
+    _addCollapsedToEntities(app, data) {
         data.collapsedInstances.forEach(function (h) {
             var expanded = TemplateUtils.expandTemplateEntities(
                 app, h.instanceEntities);
@@ -133,6 +133,6 @@ Object.assign(SceneParser.prototype, {
             Object.assign(data.entities, expanded);
         });
     }
-});
+}
 
 export { SceneParser };

--- a/src/resources/parser/texture/basis.js
+++ b/src/resources/parser/texture/basis.js
@@ -11,12 +11,12 @@ import { basisTargetFormat, basisTranscode } from '../../basis.js';
  * @implements {pc.TextureParser}
  * @classdesc Parser for basis files.
  */
-function BasisParser(registry) {
-    this.maxRetries = 0;
-}
+class BasisParser {
+    constructor(registry) {
+        this.maxRetries = 0;
+    }
 
-Object.assign(BasisParser.prototype, {
-    load: function (url, callback, asset) {
+    load(url, callback, asset) {
         var options = {
             cache: true,
             responseType: "arraybuffer",
@@ -46,10 +46,10 @@ Object.assign(BasisParser.prototype, {
                 }
             }
         );
-    },
+    }
 
     // our async transcode call provides the neat structure we need to create the texture instance
-    open: function (url, data, device) {
+    open(url, data, device) {
         var texture = new Texture(device, {
             name: url,
             // #ifdef PROFILER
@@ -68,6 +68,6 @@ Object.assign(BasisParser.prototype, {
 
         return texture;
     }
-});
+}
 
 export { BasisParser };

--- a/src/resources/parser/texture/dds.js
+++ b/src/resources/parser/texture/dds.js
@@ -33,9 +33,9 @@ var DDSCAPS2_CUBEMAP_POSITIVEZ = 0x4000;
 var DDSCAPS2_CUBEMAP_NEGATIVEZ = 0x8000;
 
 var DDS_CUBEMAP_ALLFACES = DDSCAPS2_CUBEMAP |
-    DDSCAPS2_CUBEMAP_POSITIVEX | DDSCAPS2_CUBEMAP_NEGATIVEX |
-    DDSCAPS2_CUBEMAP_POSITIVEY | DDSCAPS2_CUBEMAP_NEGATIVEY |
-    DDSCAPS2_CUBEMAP_POSITIVEZ | DDSCAPS2_CUBEMAP_NEGATIVEZ;
+      DDSCAPS2_CUBEMAP_POSITIVEX | DDSCAPS2_CUBEMAP_NEGATIVEX |
+      DDSCAPS2_CUBEMAP_POSITIVEY | DDSCAPS2_CUBEMAP_NEGATIVEY |
+      DDSCAPS2_CUBEMAP_POSITIVEZ | DDSCAPS2_CUBEMAP_NEGATIVEZ;
 
 // Defined here:
 // https://docs.microsoft.com/en-us/windows/desktop/direct3ddds/dds-pixelformat
@@ -49,12 +49,12 @@ var DDPF_LUMINANCE = 0x20000;
 /* eslint-enable no-unused-vars */
 
 // FourCC construction
-var makeFourCC = function (str) {
+function makeFourCC(str) {
     return str.charCodeAt(0) +
            (str.charCodeAt(1) << 8) +
            (str.charCodeAt(2) << 16) +
            (str.charCodeAt(3) << 24);
-};
+}
 
 var DDS_MAGIC = makeFourCC('DDS ');
 
@@ -87,13 +87,12 @@ fccToFormat[FCC_PVRTC_4BPP_RGBA_1] = PIXELFORMAT_PVRTC_4BPP_RGBA_1;
  * @implements {pc.TextureParser}
  * @classdesc Texture parser for dds files.
  */
-function DdsParser(registry) {
-    this.maxRetries = 0;
-}
+class DdsParser {
+    constructor(registry) {
+        this.maxRetries = 0;
+    }
 
-Object.assign(DdsParser.prototype, {
-
-    load: function (url, callback, asset) {
+    load(url, callback, asset) {
         var options = {
             cache: true,
             responseType: "arraybuffer",
@@ -101,9 +100,9 @@ Object.assign(DdsParser.prototype, {
             maxRetries: this.maxRetries
         };
         http.get(url.load, options, callback);
-    },
+    }
 
-    open: function (url, data, device) {
+    open(url, data, device) {
         var textureData = this.parse(data);
 
         if (!textureData) {
@@ -127,9 +126,9 @@ Object.assign(DdsParser.prototype, {
         texture.upload();
 
         return texture;
-    },
+    }
 
-    parse: function (data) {
+    parse(data) {
         var arrayBuffer = data;
 
         var headerU32 = new Uint32Array(arrayBuffer, 0, 32);
@@ -252,6 +251,6 @@ Object.assign(DdsParser.prototype, {
             cubemap: isCubeMap
         };
     }
-});
+}
 
 export { DdsParser };

--- a/src/resources/parser/texture/img.js
+++ b/src/resources/parser/texture/img.js
@@ -12,16 +12,16 @@ import { ABSOLUTE_URL } from '../../../asset/constants.js';
  * @implements {pc.TextureParser}
  * @classdesc Parser for browser-supported image formats.
  */
-function ImgParser(registry) {
-    // by default don't try cross-origin, because some browsers send different cookies (e.g. safari) if this is set.
-    this.crossOrigin = registry.prefix ? 'anonymous' : null;
-    this.maxRetries = 0;
-    // disable ImageBitmap
-    this.useImageBitmap = false && typeof ImageBitmap !== 'undefined' && /Firefox/.test( navigator.userAgent ) === false;
-}
+class ImgParser {
+    constructor(registry) {
+        // by default don't try cross-origin, because some browsers send different cookies (e.g. safari) if this is set.
+        this.crossOrigin = registry.prefix ? 'anonymous' : null;
+        this.maxRetries = 0;
+        // disable ImageBitmap
+        this.useImageBitmap = false && typeof ImageBitmap !== 'undefined' && /Firefox/.test( navigator.userAgent ) === false;
+    }
 
-Object.assign(ImgParser.prototype, {
-    load: function (url, callback, asset) {
+    load(url, callback, asset) {
         var crossOrigin;
         if (asset && asset.options && asset.options.hasOwnProperty('crossOrigin')) {
             crossOrigin = asset.options.crossOrigin;
@@ -33,9 +33,9 @@ Object.assign(ImgParser.prototype, {
         } else {
             this._loadImage(url.load, url.original, crossOrigin, callback);
         }
-    },
+    }
 
-    open: function (url, data, device) {
+    open(url, data, device) {
         var ext = path.getExtension(url).toLowerCase();
         var format = (ext === ".jpg" || ext === ".jpeg") ? PIXELFORMAT_R8_G8_B8 : PIXELFORMAT_R8_G8_B8_A8;
         var texture = new Texture(device, {
@@ -49,9 +49,9 @@ Object.assign(ImgParser.prototype, {
         });
         texture.setSource(data);
         return texture;
-    },
+    }
 
-    _loadImage: function (url, originalUrl, crossOrigin, callback) {
+    _loadImage(url, originalUrl, crossOrigin, callback) {
         var image = new Image();
         if (crossOrigin) {
             image.crossOrigin = crossOrigin;
@@ -90,9 +90,9 @@ Object.assign(ImgParser.prototype, {
         };
 
         image.src = url;
-    },
+    }
 
-    _loadImageBitmap: function (url, originalUrl, crossOrigin, callback) {
+    _loadImageBitmap(url, originalUrl, crossOrigin, callback) {
         var options = {
             cache: true,
             responseType: "blob",
@@ -116,6 +116,6 @@ Object.assign(ImgParser.prototype, {
             }
         });
     }
-});
+}
 
 export { ImgParser };

--- a/src/resources/parser/texture/ktx.js
+++ b/src/resources/parser/texture/ktx.js
@@ -10,8 +10,8 @@ import {
 import { Texture } from '../../../graphics/texture.js';
 
 // Defined here: https://www.khronos.org/opengles/sdk/tools/KTX/file_format_spec/
-var IDENTIFIER = [0x58544BAB, 0xBB313120, 0x0A1A0A0D]; // «KTX 11»\r\n\x1A\n
-var KNOWN_FORMATS = {
+const IDENTIFIER = [0x58544BAB, 0xBB313120, 0x0A1A0A0D]; // «KTX 11»\r\n\x1A\n
+const KNOWN_FORMATS = {
     0x83F0: PIXELFORMAT_DXT1,
     0x83F2: PIXELFORMAT_DXT3,
     0x83F3: PIXELFORMAT_DXT5,
@@ -30,13 +30,12 @@ var KNOWN_FORMATS = {
  * @implements {pc.TextureParser}
  * @classdesc Texture parser for ktx files.
  */
-function KtxParser(registry) {
-    this.maxRetries = 0;
-}
+class KtxParser {
+    constructor(registry) {
+        this.maxRetries = 0;
+    }
 
-Object.assign(KtxParser.prototype, {
-
-    load: function (url, callback, asset) {
+    load(url, callback, asset) {
         var options = {
             cache: true,
             responseType: "arraybuffer",
@@ -44,9 +43,9 @@ Object.assign(KtxParser.prototype, {
             maxRetries: this.maxRetries
         };
         http.get(url.load, options, callback);
-    },
+    }
 
-    open: function (url, data, device) {
+    open(url, data, device) {
         var textureData = this.parse(data);
 
         if (!textureData) {
@@ -70,9 +69,9 @@ Object.assign(KtxParser.prototype, {
         texture.upload();
 
         return texture;
-    },
+    }
 
-    parse: function (data) {
+    parse(data) {
         var headerU32 = new Uint32Array(data, 0, 16);
 
         if (IDENTIFIER[0] !== headerU32[0] || IDENTIFIER[1] !== headerU32[1] || IDENTIFIER[2] !== headerU32[2]) {
@@ -168,6 +167,6 @@ Object.assign(KtxParser.prototype, {
             cubemap: isCubeMap
         };
     }
-});
+}
 
 export { KtxParser };

--- a/src/resources/parser/texture/legacy-dds.js
+++ b/src/resources/parser/texture/legacy-dds.js
@@ -17,12 +17,12 @@ import { Texture } from '../../../graphics/texture.js';
  * @implements {pc.TextureParser}
  * @classdesc Legacy texture parser for dds files.
  */
-function LegacyDdsParser(registry) {
-    this.maxRetries = 0;
-}
+class LegacyDdsParser {
+    constructor(registry) {
+        this.maxRetries = 0;
+    }
 
-Object.assign(LegacyDdsParser.prototype, {
-    load: function (url, callback, asset) {
+    load(url, callback, asset) {
         var options = {
             cache: true,
             responseType: "arraybuffer",
@@ -30,9 +30,9 @@ Object.assign(LegacyDdsParser.prototype, {
             maxRetries: this.maxRetries
         };
         http.get(url.load, options, callback);
-    },
+    }
 
-    open: function (url, data, device) {
+    open(url, data, device) {
         var header = new Uint32Array(data, 0, 128 / 4);
 
         var width = header[4];
@@ -163,6 +163,6 @@ Object.assign(LegacyDdsParser.prototype, {
 
         return texture;
     }
-});
+}
 
 export { LegacyDdsParser };

--- a/src/resources/render.js
+++ b/src/resources/render.js
@@ -1,17 +1,5 @@
 import { Render } from '../scene/render.js';
 
-/**
- * @class
- * @name pc.RenderHandler
- * @implements {pc.ResourceHandler}
- * @classdesc Resource handler used for loading {@link pc.Render} resources.
- * @param {pc.GraphicsDevice} device - The graphics device that will be rendering.
- * @param {pc.StandardMaterial} defaultMaterial - The shared default material that is used in any place that a material is not specified.
- */
-function RenderHandler(assets) {
-    this._registry = assets;
-}
-
 // The scope of this function is the render asset
 function onContainerAssetLoaded(containerAsset) {
     var renderAsset = this;
@@ -51,15 +39,27 @@ function onContainerAssetRemoved(containerAsset) {
     }
 }
 
-Object.assign(RenderHandler.prototype, {
-    load: function (url, callback, asset) {
-    },
+/**
+ * @class
+ * @name pc.RenderHandler
+ * @implements {pc.ResourceHandler}
+ * @classdesc Resource handler used for loading {@link pc.Render} resources.
+ * @param {pc.GraphicsDevice} device - The graphics device that will be rendering.
+ * @param {pc.StandardMaterial} defaultMaterial - The shared default material that is used in any place that a material is not specified.
+ */
+class RenderHandler {
+    constructor(assets) {
+        this._registry = assets;
+    }
 
-    open: function (url, data) {
+    load(url, callback, asset) {
+    }
+
+    open(url, data) {
         return new Render();
-    },
+    }
 
-    patch: function (asset, registry) {
+    patch(asset, registry) {
         if (!asset.data.containerAsset)
             return;
 
@@ -71,6 +71,6 @@ Object.assign(RenderHandler.prototype, {
 
         onContainerAssetAdded.call(asset, containerAsset);
     }
-});
+}
 
 export { RenderHandler };

--- a/src/resources/scene-settings.js
+++ b/src/resources/scene-settings.js
@@ -1,12 +1,12 @@
 import { http } from '../net/http.js';
 
-function SceneSettingsHandler(app) {
-    this._app = app;
-    this.maxRetries = 0;
-}
+class SceneSettingsHandler {
+    constructor(app) {
+        this._app = app;
+        this.maxRetries = 0;
+    }
 
-Object.assign(SceneSettingsHandler.prototype, {
-    load: function (url, callback) {
+    load(url, callback) {
         if (typeof url === 'string') {
             url = {
                 load: url,
@@ -34,11 +34,11 @@ Object.assign(SceneSettingsHandler.prototype, {
                 callback(errMsg);
             }
         });
-    },
+    }
 
-    open: function (url, data) {
+    open(url, data) {
         return data.settings;
     }
-});
+}
 
 export { SceneSettingsHandler };

--- a/src/resources/scene.js
+++ b/src/resources/scene.js
@@ -11,13 +11,13 @@ import { TemplateUtils } from '../templates/template-utils.js';
  * @classdesc Resource handler used for loading {@link pc.Scene} resources.
  * @param {pc.Application} app - The running {@link pc.Application}.
  */
-function SceneHandler(app) {
-    this._app = app;
-    this.maxRetries = 0;
-}
+class SceneHandler {
+    constructor(app) {
+        this._app = app;
+        this.maxRetries = 0;
+    }
 
-Object.assign(SceneHandler.prototype, {
-    load: function (url, callback) {
+    load(url, callback) {
         if (typeof url === 'string') {
             url = {
                 load: url,
@@ -50,9 +50,9 @@ Object.assign(SceneHandler.prototype, {
                 callback(errMsg);
             }
         });
-    },
+    }
 
-    open: function (url, data) {
+    open(url, data) {
         // prevent script initialization until entire scene is open
         this._app.systems.script.preloading = true;
 
@@ -69,10 +69,10 @@ Object.assign(SceneHandler.prototype, {
         this._app.systems.script.preloading = false;
 
         return scene;
-    },
-
-    patch: function (asset, assets) {
     }
-});
+
+    patch(asset, assets) {
+    }
+}
 
 export { SceneHandler };

--- a/src/resources/script.js
+++ b/src/resources/script.js
@@ -9,23 +9,24 @@ import { script } from '../framework/script.js';
  * or regular JavaScript files, such as third-party libraries.
  * @param {pc.Application} app - The running {@link pc.Application}.
  */
-function ScriptHandler(app) {
-    this._app = app;
-    this._scripts = { };
-    this._cache = { };
-}
-
-ScriptHandler._types = [];
-ScriptHandler._push = function (Type) {
-    if (script.legacy && ScriptHandler._types.length > 0) {
-        console.assert("Script Ordering Error. Contact support@playcanvas.com");
-    } else {
-        ScriptHandler._types.push(Type);
+class ScriptHandler {
+    constructor(app) {
+        this._app = app;
+        this._scripts = { };
+        this._cache = { };
     }
-};
 
-Object.assign(ScriptHandler.prototype, {
-    load: function (url, callback) {
+    static _types = [];
+
+    static _push(Type) {
+        if (script.legacy && ScriptHandler._types.length > 0) {
+            console.assert("Script Ordering Error. Contact support@playcanvas.com");
+        } else {
+            ScriptHandler._types.push(Type);
+        }
+    }
+
+    load(url, callback) {
         // Scripts don't support bundling since we concatenate them. Below is for consistency.
         if (typeof url === 'string') {
             url = {
@@ -72,15 +73,15 @@ Object.assign(ScriptHandler.prototype, {
                 callback(err);
             }
         }.bind(this));
-    },
+    }
 
-    open: function (url, data) {
+    open(url, data) {
         return data;
-    },
+    }
 
-    patch: function (asset, assets) { },
+    patch(asset, assets) { }
 
-    _loadScript: function (url, callback) {
+    _loadScript(url, callback) {
         var head = document.head;
         var element = document.createElement('script');
         this._cache[url] = element;
@@ -104,6 +105,6 @@ Object.assign(ScriptHandler.prototype, {
 
         head.appendChild(element);
     }
-});
+}
 
 export { ScriptHandler };

--- a/src/resources/shader.js
+++ b/src/resources/shader.js
@@ -1,11 +1,11 @@
 import { http } from '../net/http.js';
 
-function ShaderHandler() {
-    this.maxRetries = 0;
-}
+class ShaderHandler {
+    constructor() {
+        this.maxRetries = 0;
+    }
 
-Object.assign(ShaderHandler.prototype, {
-    load: function (url, callback) {
+    load(url, callback) {
         if (typeof url === 'string') {
             url = {
                 load: url,
@@ -23,14 +23,14 @@ Object.assign(ShaderHandler.prototype, {
                 callback("Error loading shader resource: " + url.original + " [" + err + "]");
             }
         });
-    },
-
-    open: function (url, data) {
-        return data;
-    },
-
-    patch: function (asset, assets) {
     }
-});
+
+    open(url, data) {
+        return data;
+    }
+
+    patch(asset, assets) {
+    }
+}
 
 export { ShaderHandler };

--- a/src/resources/sprite.js
+++ b/src/resources/sprite.js
@@ -4,20 +4,6 @@ import { http } from '../net/http.js';
 
 import { Sprite } from '../scene/sprite.js';
 
-/**
- * @class
- * @name pc.SpriteHandler
- * @implements {pc.ResourceHandler}
- * @classdesc Resource handler used for loading {@link pc.Sprite} resources.
- * @param {pc.AssetRegistry} assets - The asset registry.
- * @param {pc.GraphicsDevice} device - The graphics device.
- */
-function SpriteHandler(assets, device) {
-    this._assets = assets;
-    this._device = device;
-    this.maxRetries = 0;
-}
-
 // The scope of this function is the sprite asset
 function onTextureAtlasLoaded(atlasAsset) {
     var spriteAsset = this;
@@ -32,8 +18,22 @@ function onTextureAtlasAdded(atlasAsset) {
     spriteAsset.registry.load(atlasAsset);
 }
 
-Object.assign(SpriteHandler.prototype, {
-    load: function (url, callback) {
+/**
+ * @class
+ * @name pc.SpriteHandler
+ * @implements {pc.ResourceHandler}
+ * @classdesc Resource handler used for loading {@link pc.Sprite} resources.
+ * @param {pc.AssetRegistry} assets - The asset registry.
+ * @param {pc.GraphicsDevice} device - The graphics device.
+ */
+class SpriteHandler {
+    constructor(assets, device) {
+        this._assets = assets;
+        this._device = device;
+        this.maxRetries = 0;
+    }
+
+    load(url, callback) {
         if (typeof url === 'string') {
             url = {
                 load: url,
@@ -54,10 +54,10 @@ Object.assign(SpriteHandler.prototype, {
                 }
             });
         }
-    },
+    }
 
     // Create sprite resource
-    open: function (url, data) {
+    open(url, data) {
         var sprite = new Sprite(this._device);
         if (url) {
             // if url field is present json data is being loaded from file
@@ -66,10 +66,10 @@ Object.assign(SpriteHandler.prototype, {
         }
 
         return sprite;
-    },
+    }
 
     // Set sprite data
-    patch: function (asset, assets) {
+    patch(asset, assets) {
         var sprite = asset.resource;
         if (sprite.__data) {
             // loading from a json file we have asset data store temporarily on the sprite resource
@@ -101,10 +101,10 @@ Object.assign(SpriteHandler.prototype, {
 
         asset.off('change', this._onAssetChange, this);
         asset.on('change', this._onAssetChange, this);
-    },
+    }
 
     // Load atlas
-    _updateAtlas: function (asset) {
+    _updateAtlas(asset) {
         var sprite = asset.resource;
         if (!asset.data.textureAtlasAsset) {
             sprite.atlas = null;
@@ -125,9 +125,9 @@ Object.assign(SpriteHandler.prototype, {
                 this._assets.load(atlasAsset);
             }
         }
-    },
+    }
 
-    _onAssetChange: function (asset, attribute, value, oldValue) {
+    _onAssetChange(asset, attribute, value, oldValue) {
         if (attribute === 'data') {
             // if the texture atlas changed, clear events for old atlas asset
             if (value && value.textureAtlasAsset && oldValue && value.textureAtlasAsset !== oldValue.textureAtlasAsset) {
@@ -136,6 +136,6 @@ Object.assign(SpriteHandler.prototype, {
             }
         }
     }
-});
+}
 
 export { SpriteHandler };

--- a/src/resources/template.js
+++ b/src/resources/template.js
@@ -3,12 +3,12 @@ import { http } from '../net/http.js';
 import { Template } from '../templates/template.js';
 import { TemplateUtils } from '../templates/template-utils.js';
 
-function TemplateHandler(app) {
-    this._app = app;
-}
+class TemplateHandler {
+    constructor(app) {
+        this._app = app;
+    }
 
-Object.assign(TemplateHandler.prototype, {
-    load: function (url, callback) {
+    load(url, callback) {
         if (typeof url === 'string') {
             url = {
                 load: url,
@@ -29,11 +29,11 @@ Object.assign(TemplateHandler.prototype, {
                     response);
             }
         });
-    },
+    }
 
-    open: function (url, data) {
+    open(url, data) {
         return new Template(this._app, data);
     }
-});
+}
 
 export { TemplateHandler };

--- a/src/resources/text.js
+++ b/src/resources/text.js
@@ -1,11 +1,11 @@
 import { http } from '../net/http.js';
 
-function TextHandler() {
-    this.maxRetries = 0;
-}
+class TextHandler {
+    constructor() {
+        this.maxRetries = 0;
+    }
 
-Object.assign(TextHandler.prototype, {
-    load: function (url, callback) {
+    load(url, callback) {
         if (typeof url === 'string') {
             url = {
                 load: url,
@@ -23,14 +23,14 @@ Object.assign(TextHandler.prototype, {
                 callback("Error loading text resource: " + url.original + " [" + err + "]");
             }
         });
-    },
-
-    open: function (url, data) {
-        return data;
-    },
-
-    patch: function (asset, assets) {
     }
-});
+
+    open(url, data) {
+        return data;
+    }
+
+    patch(asset, assets) {
+    }
+}
 
 export { TextHandler };

--- a/src/resources/texture-atlas.js
+++ b/src/resources/texture-atlas.js
@@ -37,14 +37,14 @@ var regexFrame = /^data\.frames\.(\d+)$/;
  * @classdesc Resource handler used for loading {@link pc.TextureAtlas} resources.
  * @param {pc.ResourceLoader} loader - The resource loader.
  */
-function TextureAtlasHandler(loader) {
-    this._loader = loader;
-    this.maxRetries = 0;
-}
+class TextureAtlasHandler {
+    constructor(loader) {
+        this._loader = loader;
+        this.maxRetries = 0;
+    }
 
-Object.assign(TextureAtlasHandler.prototype, {
     // Load the texture atlas texture using the texture resource loader
-    load: function (url, callback) {
+    load(url, callback) {
         if (typeof url === 'string') {
             url = {
                 load: url,
@@ -82,10 +82,10 @@ Object.assign(TextureAtlasHandler.prototype, {
         } else {
             return handler.load(url, callback);
         }
-    },
+    }
 
     // Create texture atlas resource using the texture from the texture loader
-    open: function (url, data) {
+    open(url, data) {
         var resource = new TextureAtlas();
         if (data.texture && data.data) {
             resource.texture = data.texture;
@@ -97,9 +97,9 @@ Object.assign(TextureAtlasHandler.prototype, {
             resource.texture = texture;
         }
         return resource;
-    },
+    }
 
-    patch: function (asset, assets) {
+    patch(asset, assets) {
         if (asset.resource.__data) {
             // engine-only, so copy temporary asset data from texture atlas into asset and delete temp property
             if (asset.resource.__data.minfilter !== undefined) asset.data.minfilter = asset.resource.__data.minfilter;
@@ -162,9 +162,9 @@ Object.assign(TextureAtlasHandler.prototype, {
 
         asset.off('change', this._onAssetChange, this);
         asset.on('change', this._onAssetChange, this);
-    },
+    }
 
-    _onAssetChange: function (asset, attribute, value) {
+    _onAssetChange(asset, attribute, value) {
         var frame;
 
         if (attribute === 'data' || attribute === 'data.frames') {
@@ -212,6 +212,6 @@ Object.assign(TextureAtlasHandler.prototype, {
             }
         }
     }
-});
+}
 
 export { TextureAtlasHandler };

--- a/src/resources/texture.js
+++ b/src/resources/texture.js
@@ -41,9 +41,9 @@ var JSON_TEXTURE_TYPE = {
  * @description Interface to a texture parser. Implementations of this interface handle the loading
  * and opening of texture assets.
  */
-function TextureParser() {}
+class TextureParser {
+    constructor() {}
 
-Object.assign(TextureParser.prototype, {
     /**
      * @function
      * @name pc.TextureParser#load
@@ -56,9 +56,9 @@ Object.assign(TextureParser.prototype, {
      * @param {pc.Asset} [asset] - Optional asset that is passed by ResourceLoader.
      */
     /* eslint-disable jsdoc/require-returns-check */
-    load: function (url, callback, asset) {
+    load(url, callback, asset) {
         throw new Error('not implemented');
-    },
+    }
     /* eslint-enable jsdoc/require-returns-check */
 
     /**
@@ -72,11 +72,11 @@ Object.assign(TextureParser.prototype, {
      * @returns {pc.Texture} The parsed resource data.
      */
     /* eslint-disable jsdoc/require-returns-check */
-    open: function (url, data, device) {
+    open(url, data, device) {
         throw new Error('not implemented');
     }
     /* eslint-enable jsdoc/require-returns-check */
-});
+}
 
 // In the case where a texture has more than 1 level of mip data specified, but not the full
 // mip chain, we generate the missing levels here.
@@ -157,58 +157,54 @@ var _completePartialMipmapChain = function (texture) {
  * @param {pc.AssetRegistry} assets - The asset registry.
  * @param {pc.ResourceLoader} loader - The resource loader.
  */
-function TextureHandler(device, assets, loader) {
-    this._device = device;
-    this._assets = assets;
-    this._loader = loader;
+class TextureHandler {
+    constructor(device, assets, loader) {
+        this._device = device;
+        this._assets = assets;
+        this._loader = loader;
 
-    // img parser handles all broswer-supported image formats, this
-    // parser will be used when other more specific parsers are not found.
-    this.imgParser = new ImgParser(assets);
+        // img parser handles all broswer-supported image formats, this
+        // parser will be used when other more specific parsers are not found.
+        this.imgParser = new ImgParser(assets);
 
-    this.parsers = {
-        dds: new LegacyDdsParser(assets),
-        ktx: new KtxParser(assets),
-        basis: new BasisParser(assets)
-    };
-}
+        this.parsers = {
+            dds: new LegacyDdsParser(assets),
+            ktx: new KtxParser(assets),
+            basis: new BasisParser(assets)
+        };
+    }
 
-Object.defineProperties(TextureHandler.prototype, {
-    crossOrigin: {
-        get: function () {
-            return this.imgParser.crossOrigin;
-        },
-        set: function (value) {
-            this.imgParser.crossOrigin = value;
-        }
-    },
+    get crossOrigin() {
+        return this.imgParser.crossOrigin;
+    }
 
-    maxRetries: {
-        get: function () {
-            return this.imgParser.maxRetries;
-        },
-        set: function (value) {
-            this.imgParser.maxRetries = value;
-            for (var parser in this.parsers) {
-                if (this.parsers.hasOwnProperty(parser)) {
-                    this.parsers[parser].maxRetries = value;
-                }
+    set crossOrigin(value) {
+        this.imgParser.crossOrigin = value;
+    }
+
+    get maxRetries() {
+        return this.imgParser.maxRetries;
+    }
+
+    set maxRetries(value) {
+        this.imgParser.maxRetries = value;
+        for (var parser in this.parsers) {
+            if (this.parsers.hasOwnProperty(parser)) {
+                this.parsers[parser].maxRetries = value;
             }
         }
     }
-});
 
-Object.assign(TextureHandler.prototype, {
-    _getUrlWithoutParams: function (url) {
+    _getUrlWithoutParams(url) {
         return url.indexOf('?') >= 0 ? url.split('?')[0] : url;
-    },
+    }
 
-    _getParser: function (url) {
+    _getParser(url) {
         var ext = path.getExtension(this._getUrlWithoutParams(url)).toLowerCase().replace('.', '');
         return this.parsers[ext] || this.imgParser;
-    },
+    }
 
-    load: function (url, callback, asset) {
+    load(url, callback, asset) {
         if (typeof url === 'string') {
             url = {
                 load: url,
@@ -217,9 +213,9 @@ Object.assign(TextureHandler.prototype, {
         }
 
         this._getParser(url.original).load(url, callback, asset);
-    },
+    }
 
-    open: function (url, data, asset) {
+    open(url, data, asset) {
         if (!url)
             return;
 
@@ -238,9 +234,9 @@ Object.assign(TextureHandler.prototype, {
         }
 
         return texture;
-    },
+    }
 
-    patch: function (asset, assets) {
+    patch(asset, assets) {
         var texture = asset.resource;
         if (!texture) {
             return;
@@ -297,6 +293,6 @@ Object.assign(TextureHandler.prototype, {
             }
         }
     }
-});
+}
 
 export { TextureHandler, TextureParser };

--- a/src/shape/bounding-box.js
+++ b/src/shape/bounding-box.js
@@ -16,14 +16,13 @@ var tmpVecE = new Vec3();
  * @property {pc.Vec3} center Center of box.
  * @property {pc.Vec3} halfExtents Half the distance across the box in each axis.
  */
-function BoundingBox(center, halfExtents) {
-    this.center = center || new Vec3(0, 0, 0);
-    this.halfExtents = halfExtents || new Vec3(0.5, 0.5, 0.5);
-    this._min = new Vec3();
-    this._max = new Vec3();
-}
-
-Object.assign(BoundingBox.prototype, {
+class BoundingBox {
+    constructor(center, halfExtents) {
+        this.center = center || new Vec3(0, 0, 0);
+        this.halfExtents = halfExtents || new Vec3(0.5, 0.5, 0.5);
+        this._min = new Vec3();
+        this._max = new Vec3();
+    }
 
     /**
      * @function
@@ -31,7 +30,7 @@ Object.assign(BoundingBox.prototype, {
      * @description Combines two bounding boxes into one, enclosing both.
      * @param {pc.BoundingBox} other - Bounding box to add.
      */
-    add: function (other) {
+    add(other) {
         var tc = this.center;
         var tcx = tc.x;
         var tcy = tc.y;
@@ -75,7 +74,7 @@ Object.assign(BoundingBox.prototype, {
         th.x = (tmaxx - tminx) * 0.5;
         th.y = (tmaxy - tminy) * 0.5;
         th.z = (tmaxz - tminz) * 0.5;
-    },
+    }
 
     /**
      * @function
@@ -83,11 +82,11 @@ Object.assign(BoundingBox.prototype, {
      * @description Copies the contents of a source AABB.
      * @param {pc.BoundingBox} src - The AABB to copy from.
      */
-    copy: function (src) {
+    copy(src) {
         this.center.copy(src.center);
         this.halfExtents.copy(src.halfExtents);
         this.type = src.type;
-    },
+    }
 
     /**
      * @function
@@ -95,9 +94,9 @@ Object.assign(BoundingBox.prototype, {
      * @description Returns a clone of the AABB
      * @returns {pc.BoundingBox} A duplicate AABB.
      */
-    clone: function () {
+    clone() {
         return new BoundingBox(this.center.clone(), this.halfExtents.clone());
-    },
+    }
 
     /**
      * @function
@@ -106,7 +105,7 @@ Object.assign(BoundingBox.prototype, {
      * @param {pc.BoundingBox} other - Bounding box to test against.
      * @returns {boolean} True if there is an intersection.
      */
-    intersects: function (other) {
+    intersects(other) {
         var aMax = this.getMax();
         var aMin = this.getMin();
         var bMax = other.getMax();
@@ -115,9 +114,9 @@ Object.assign(BoundingBox.prototype, {
         return (aMin.x <= bMax.x) && (aMax.x >= bMin.x) &&
                (aMin.y <= bMax.y) && (aMax.y >= bMin.y) &&
                (aMin.z <= bMax.z) && (aMax.z >= bMin.z);
-    },
+    }
 
-    _intersectsRay: function (ray, point) {
+    _intersectsRay(ray, point) {
         var tMin = tmpVecA.copy(this.getMin()).sub(ray.origin);
         var tMax = tmpVecB.copy(this.getMax()).sub(ray.origin);
         var dir = ray.direction;
@@ -157,9 +156,9 @@ Object.assign(BoundingBox.prototype, {
             point.copy(ray.direction).scale(maxMin).add(ray.origin);
 
         return intersects;
-    },
+    }
 
-    _fastIntersectsRay: function (ray) {
+    _fastIntersectsRay(ray) {
         var diff = tmpVecA;
         var cross = tmpVecB;
         var prod = tmpVecC;
@@ -195,7 +194,7 @@ Object.assign(BoundingBox.prototype, {
             return false;
 
         return true;
-    },
+    }
 
     /**
      * @function
@@ -205,13 +204,13 @@ Object.assign(BoundingBox.prototype, {
      * @param {pc.Vec3} [point] - If there is an intersection, the intersection point will be copied into here.
      * @returns {boolean} True if there is an intersection.
      */
-    intersectsRay: function (ray, point) {
+    intersectsRay(ray, point) {
         if (point) {
             return this._intersectsRay(ray, point);
         }
 
         return this._fastIntersectsRay(ray);
-    },
+    }
 
     /**
      * @function
@@ -221,10 +220,10 @@ Object.assign(BoundingBox.prototype, {
      * @param {pc.Vec3} min - The minimum corner of the AABB.
      * @param {pc.Vec3} max - The maximum corner of the AABB.
      */
-    setMinMax: function (min, max) {
+    setMinMax(min, max) {
         this.center.add2(max, min).scale(0.5);
         this.halfExtents.sub2(max, min).scale(0.5);
-    },
+    }
 
     /**
      * @function
@@ -232,9 +231,9 @@ Object.assign(BoundingBox.prototype, {
      * @description Return the minimum corner of the AABB.
      * @returns {pc.Vec3} Minimum corner.
      */
-    getMin: function () {
+    getMin() {
         return this._min.copy(this.center).sub(this.halfExtents);
-    },
+    }
 
     /**
      * @function
@@ -242,9 +241,9 @@ Object.assign(BoundingBox.prototype, {
      * @description Return the maximum corner of the AABB.
      * @returns {pc.Vec3} Maximum corner.
      */
-    getMax: function () {
+    getMax() {
         return this._max.copy(this.center).add(this.halfExtents);
-    },
+    }
 
     /**
      * @function
@@ -253,7 +252,7 @@ Object.assign(BoundingBox.prototype, {
      * @param {pc.Vec3} point - Point to test.
      * @returns {boolean} True if the point is inside the AABB and false otherwise.
      */
-    containsPoint: function (point) {
+    containsPoint(point) {
         var min = this.getMin();
         var max = this.getMax();
 
@@ -264,7 +263,7 @@ Object.assign(BoundingBox.prototype, {
         }
 
         return true;
-    },
+    }
 
     /**
      * @function
@@ -274,7 +273,7 @@ Object.assign(BoundingBox.prototype, {
      * @param {pc.BoundingBox} aabb - Box to transform and enclose.
      * @param {pc.Mat4} m - Transformation matrix to apply to source AABB.
      */
-    setFromTransformedAabb: function (aabb, m) {
+    setFromTransformedAabb(aabb, m) {
         var ac = aabb.center;
         var ar = aabb.halfExtents;
 
@@ -300,7 +299,7 @@ Object.assign(BoundingBox.prototype, {
             Math.abs(my0) * ar.x + Math.abs(my1) * ar.y + Math.abs(my2) * ar.z,
             Math.abs(mz0) * ar.x + Math.abs(mz1) * ar.y + Math.abs(mz2) * ar.z
         );
-    },
+    }
 
     /**
      * @function
@@ -309,7 +308,7 @@ Object.assign(BoundingBox.prototype, {
      * @param {number[]|Float32Array} vertices - The vertices used to compute the new size for the AABB.
      * @param {number} [numVerts] - Number of vertices to use from the beginning of vertices array. All vertices are used if not specified.
      */
-    compute: function (vertices, numVerts) {
+    compute(vertices, numVerts) {
         numVerts = numVerts === undefined ? vertices.length / 3 : numVerts;
         if (numVerts > 0) {
             var min = tmpVecA.set(vertices[0], vertices[1], vertices[2]);
@@ -329,7 +328,7 @@ Object.assign(BoundingBox.prototype, {
 
             this.setMinMax(min, max);
         }
-    },
+    }
 
     /**
      * @function
@@ -338,16 +337,16 @@ Object.assign(BoundingBox.prototype, {
      * @param {pc.BoundingSphere} sphere - Bounding Sphere to test.
      * @returns {boolean} True if the Bounding Sphere is overlapping, enveloping, or inside the AABB and false otherwise.
      */
-    intersectsBoundingSphere: function (sphere) {
+    intersectsBoundingSphere(sphere) {
         var sq = this._distanceToBoundingSphereSq(sphere);
         if (sq <= sphere.radius * sphere.radius) {
             return true;
         }
 
         return false;
-    },
+    }
 
-    _distanceToBoundingSphereSq: function (sphere) {
+    _distanceToBoundingSphereSq(sphere) {
         var boxMin = this.getMin();
         var boxMax = this.getMax();
 
@@ -375,13 +374,13 @@ Object.assign(BoundingBox.prototype, {
         }
 
         return sq;
-    },
+    }
 
-    _expand: function (expandMin, expandMax) {
+    _expand(expandMin, expandMax) {
         tmpVecA.add2(this.getMin(), expandMin);
         tmpVecB.add2(this.getMax(), expandMax);
         this.setMinMax(tmpVecA, tmpVecB);
     }
-});
+}
 
 export { BoundingBox };

--- a/src/shape/bounding-box.js
+++ b/src/shape/bounding-box.js
@@ -17,9 +17,9 @@ var tmpVecE = new Vec3();
  * @property {pc.Vec3} halfExtents Half the distance across the box in each axis.
  */
 class BoundingBox {
-    constructor(center, halfExtents) {
-        this.center = center || new Vec3(0, 0, 0);
-        this.halfExtents = halfExtents || new Vec3(0.5, 0.5, 0.5);
+    constructor(center = new Vec3(), halfExtents = new Vec3(0.5, 0.5, 0.5)) {
+        this.center = center;
+        this.halfExtents = halfExtents;
         this._min = new Vec3();
         this._max = new Vec3();
     }

--- a/src/shape/bounding-box.js
+++ b/src/shape/bounding-box.js
@@ -85,7 +85,6 @@ class BoundingBox {
     copy(src) {
         this.center.copy(src.center);
         this.halfExtents.copy(src.halfExtents);
-        this.type = src.type;
     }
 
     /**

--- a/src/shape/bounding-sphere.js
+++ b/src/shape/bounding-sphere.js
@@ -17,9 +17,9 @@ var tmpVecD = new Vec3();
  * @param {number} [radius] - The radius of the bounding sphere. Defaults to 0.5.
  */
 class BoundingSphere {
-    constructor(center, radius) {
-        this.center = center || new Vec3(0, 0, 0);
-        this.radius = radius === undefined ? 0.5 : radius;
+    constructor(center = new Vec3(), radius = 0.5) {
+        this.center = center;
+        this.radius = radius;
     }
 
     containsPoint(point) {

--- a/src/shape/bounding-sphere.js
+++ b/src/shape/bounding-sphere.js
@@ -16,19 +16,19 @@ var tmpVecD = new Vec3();
  * @param {pc.Vec3} [center] - The world space coordinate marking the center of the sphere. The constructor takes a reference of this parameter.
  * @param {number} [radius] - The radius of the bounding sphere. Defaults to 0.5.
  */
-function BoundingSphere(center, radius) {
-    this.center = center || new Vec3(0, 0, 0);
-    this.radius = radius === undefined ? 0.5 : radius;
-}
+class BoundingSphere {
+    constructor(center, radius) {
+        this.center = center || new Vec3(0, 0, 0);
+        this.radius = radius === undefined ? 0.5 : radius;
+    }
 
-Object.assign(BoundingSphere.prototype, {
-    containsPoint: function (point) {
+    containsPoint(point) {
         var lenSq = tmpVecA.sub2(point, this.center).lengthSq();
         var r = this.radius;
         return lenSq < r * r;
-    },
+    }
 
-    compute: function (vertices) {
+    compute(vertices) {
         var i;
         var numVerts = vertices.length / 3;
 
@@ -69,7 +69,7 @@ Object.assign(BoundingSphere.prototype, {
         }
 
         this.radius = Math.sqrt(maxDistSq);
-    },
+    }
 
     /**
      * @function
@@ -79,7 +79,7 @@ Object.assign(BoundingSphere.prototype, {
      * @param {pc.Vec3} [point] - If there is an intersection, the intersection point will be copied into here.
      * @returns {boolean} True if there is an intersection.
      */
-    intersectsRay: function (ray, point) {
+    intersectsRay(ray, point) {
         var m = tmpVecA.copy(ray.origin).sub(this.center);
         var b = m.dot(tmpVecB.copy(ray.direction).normalize());
         var c = m.dot(m) - this.radius * this.radius;
@@ -101,7 +101,7 @@ Object.assign(BoundingSphere.prototype, {
             point.copy(ray.direction).scale(t).add(ray.origin);
 
         return true;
-    },
+    }
 
     /**
      * @function
@@ -110,7 +110,7 @@ Object.assign(BoundingSphere.prototype, {
      * @param {pc.BoundingSphere} sphere - Bounding Sphere to test.
      * @returns {boolean} True if the Bounding Sphere is overlapping, enveloping, or inside this Bounding Sphere and false otherwise.
      */
-    intersectsBoundingSphere: function (sphere) {
+    intersectsBoundingSphere(sphere) {
         tmpVecA.sub2(sphere.center, this.center);
         var totalRadius = sphere.radius + this.radius;
         if (tmpVecA.lengthSq() <= totalRadius * totalRadius) {
@@ -119,6 +119,6 @@ Object.assign(BoundingSphere.prototype, {
 
         return false;
     }
-});
+}
 
 export { BoundingSphere };

--- a/src/shape/frustum.js
+++ b/src/shape/frustum.js
@@ -8,13 +8,13 @@
  * @example
  * var frustum = new pc.Frustum();
  */
-function Frustum() {
-    this.planes = [];
-    for (var i = 0; i < 6; i++)
-        this.planes[i] = [];
-}
+class Frustum {
+    constructor() {
+        this.planes = [];
+        for (var i = 0; i < 6; i++)
+            this.planes[i] = [];
+    }
 
-Object.assign(Frustum.prototype, {
     /**
      * @function
      * @name pc.Frustum#setFromMat4
@@ -29,7 +29,7 @@ Object.assign(Frustum.prototype, {
      * var frustum = new pc.Frustum();
      * frustum.setFromMat4(projMat);
      */
-    setFromMat4: function (matrix) {
+    setFromMat4(matrix) {
         var vpm = matrix.data;
 
         var plane;
@@ -112,7 +112,7 @@ Object.assign(Frustum.prototype, {
         plane[1] /= t;
         plane[2] /= t;
         plane[3] /= t;
-    },
+    }
 
     /**
      * @function
@@ -122,7 +122,7 @@ Object.assign(Frustum.prototype, {
      * @param {pc.Vec3} point - The point to test.
      * @returns {boolean} True if the point is inside the frustum, false otherwise.
      */
-    containsPoint: function (point) {
+    containsPoint(point) {
         var p, plane;
         for (p = 0; p < 6; p++) {
             plane = this.planes[p];
@@ -131,7 +131,7 @@ Object.assign(Frustum.prototype, {
             }
         }
         return true;
-    },
+    }
 
     /**
      * @function
@@ -144,7 +144,7 @@ Object.assign(Frustum.prototype, {
      * @returns {number} 0 if the bounding sphere is outside the frustum, 1 if it intersects the frustum and 2 if
      * it is contained by the frustum.
      */
-    containsSphere: function (sphere) {
+    containsSphere(sphere) {
         var c = 0;
         var d;
         var p;
@@ -168,6 +168,6 @@ Object.assign(Frustum.prototype, {
 
         return (c === 6) ? 2 : 1;
     }
-});
+}
 
 export { Frustum };

--- a/src/shape/oriented-box.js
+++ b/src/shape/oriented-box.js
@@ -19,17 +19,17 @@ var tmpMat4 = new Mat4();
  * @param {pc.Mat4} [worldTransform] - Transform that has the orientation and position of the box. Scale is assumed to be one.
  * @param {pc.Vec3} [halfExtents] - Half the distance across the box in each local axis. The constructor takes a reference of this parameter.
  */
-function OrientedBox(worldTransform, halfExtents) {
-    this.halfExtents = halfExtents || new Vec3(0.5, 0.5, 0.5);
+class OrientedBox {
+    constructor(worldTransform, halfExtents) {
+        this.halfExtents = halfExtents || new Vec3(0.5, 0.5, 0.5);
 
-    worldTransform = worldTransform || tmpMat4.setIdentity();
-    this._modelTransform = worldTransform.clone().invert();
+        worldTransform = worldTransform || tmpMat4.setIdentity();
+        this._modelTransform = worldTransform.clone().invert();
 
-    this._worldTransform = worldTransform.clone(); // temp - currently only used in the worldTransform accessor, see future PR for more use
-    this._aabb = new BoundingBox(new Vec3(), this.halfExtents);
-}
+        this._worldTransform = worldTransform.clone(); // temp - currently only used in the worldTransform accessor, see future PR for more use
+        this._aabb = new BoundingBox(new Vec3(), this.halfExtents);
+    }
 
-Object.assign(OrientedBox.prototype, {
     /**
      * @function
      * @name pc.OrientedBox#intersectsRay
@@ -38,7 +38,7 @@ Object.assign(OrientedBox.prototype, {
      * @param {pc.Vec3} [point] - If there is an intersection, the intersection point will be copied into here.
      * @returns {boolean} True if there is an intersection.
      */
-    intersectsRay: function (ray, point) {
+    intersectsRay(ray, point) {
         this._modelTransform.transformPoint(ray.origin, tmpRay.origin);
         this._modelTransform.transformVector(ray.direction, tmpRay.direction);
 
@@ -49,7 +49,7 @@ Object.assign(OrientedBox.prototype, {
         }
 
         return this._aabb._fastIntersectsRay(tmpRay);
-    },
+    }
 
     /**
      * @function
@@ -58,10 +58,10 @@ Object.assign(OrientedBox.prototype, {
      * @param {pc.Vec3} point - Point to test.
      * @returns {boolean} True if the point is inside the OBB and false otherwise.
      */
-    containsPoint: function (point) {
+    containsPoint(point) {
         this._modelTransform.transformPoint(point, tmpVec3);
         return this._aabb.containsPoint(tmpVec3);
-    },
+    }
 
     /**
      * @function
@@ -70,7 +70,7 @@ Object.assign(OrientedBox.prototype, {
      * @param {pc.BoundingSphere} sphere - Bounding Sphere to test.
      * @returns {boolean} True if the Bounding Sphere is overlapping, enveloping or inside this OBB and false otherwise.
      */
-    intersectsBoundingSphere: function (sphere) {
+    intersectsBoundingSphere(sphere) {
         this._modelTransform.transformPoint(sphere.center, tmpSphere.center);
         tmpSphere.radius = sphere.radius;
 
@@ -80,16 +80,15 @@ Object.assign(OrientedBox.prototype, {
 
         return false;
     }
-});
 
-Object.defineProperty(OrientedBox.prototype, 'worldTransform', {
-    get: function () {
+    get worldTransform() {
         return this._worldTransform;
-    },
-    set: function (value) {
+    }
+
+    set worldTransform(value) {
         this._worldTransform.copy(value);
         this._modelTransform.copy(value).invert();
     }
-});
+}
 
 export { OrientedBox };

--- a/src/shape/oriented-box.js
+++ b/src/shape/oriented-box.js
@@ -25,7 +25,7 @@ class OrientedBox {
 
         this._modelTransform = worldTransform.clone().invert();
 
-        this._worldTransform = worldTransform.clone(); // temp - currently only used in the worldTransform accessor, see future PR for more use
+        this._worldTransform = worldTransform.clone();
         this._aabb = new BoundingBox(new Vec3(), this.halfExtents);
     }
 

--- a/src/shape/oriented-box.js
+++ b/src/shape/oriented-box.js
@@ -20,10 +20,9 @@ var tmpMat4 = new Mat4();
  * @param {pc.Vec3} [halfExtents] - Half the distance across the box in each local axis. The constructor takes a reference of this parameter.
  */
 class OrientedBox {
-    constructor(worldTransform, halfExtents) {
-        this.halfExtents = halfExtents || new Vec3(0.5, 0.5, 0.5);
+    constructor(worldTransform = new Mat4(), halfExtents = new Vec3(0.5, 0.5, 0.5)) {
+        this.halfExtents = halfExtents;
 
-        worldTransform = worldTransform || tmpMat4.setIdentity();
         this._modelTransform = worldTransform.clone().invert();
 
         this._worldTransform = worldTransform.clone(); // temp - currently only used in the worldTransform accessor, see future PR for more use

--- a/src/shape/plane.js
+++ b/src/shape/plane.js
@@ -12,9 +12,9 @@ var tmpVecA = new Vec3();
  * @param {pc.Vec3} [normal] - Normal of the plane. The constructor takes a reference of this parameter.
  */
 class Plane {
-    constructor(point, normal) {
-        this.normal = normal || new Vec3(0, 0, 1);
-        this.point = point || new Vec3(0, 0, 0);
+    constructor(point = new Vec3(), normal = new Vec3(0, 0, 1)) {
+        this.normal = normal;
+        this.point = point;
     }
 
     /**

--- a/src/shape/plane.js
+++ b/src/shape/plane.js
@@ -11,12 +11,12 @@ var tmpVecA = new Vec3();
  * @param {pc.Vec3} [point] - Point position on the plane. The constructor takes a reference of this parameter.
  * @param {pc.Vec3} [normal] - Normal of the plane. The constructor takes a reference of this parameter.
  */
-function Plane(point, normal) {
-    this.normal = normal || new Vec3(0, 0, 1);
-    this.point = point || new Vec3(0, 0, 0);
-}
+class Plane {
+    constructor(point, normal) {
+        this.normal = normal || new Vec3(0, 0, 1);
+        this.point = point || new Vec3(0, 0, 0);
+    }
 
-Object.assign(Plane.prototype, {
     /**
      * @private
      * @function
@@ -27,7 +27,7 @@ Object.assign(Plane.prototype, {
      * @param {pc.Vec3} [point] - If there is an intersection, the intersection point will be copied into here.
      * @returns {boolean} True if there is an intersection.
      */
-    intersectsLine: function (start, end, point) {
+    intersectsLine(start, end, point) {
         var d = -this.normal.dot(this.point);
         var d0 = this.normal.dot(start) + d;
         var d1 = this.normal.dot(end) + d;
@@ -38,7 +38,7 @@ Object.assign(Plane.prototype, {
             point.lerp(start, end, t);
 
         return intersects;
-    },
+    }
 
     /**
      * @private
@@ -49,7 +49,7 @@ Object.assign(Plane.prototype, {
      * @param {pc.Vec3} [point] - If there is an intersection, the intersection point will be copied into here.
      * @returns {boolean} True if there is an intersection.
      */
-    intersectsRay: function (ray, point) {
+    intersectsRay(ray, point) {
         var pointToOrigin = tmpVecA.sub2(this.point, ray.origin);
         var t = this.normal.dot(pointToOrigin) / this.normal.dot(ray.direction);
         var intersects = t >= 0;
@@ -59,6 +59,6 @@ Object.assign(Plane.prototype, {
 
         return intersects;
     }
-});
+}
 
 export { Plane };

--- a/src/shape/ray.js
+++ b/src/shape/ray.js
@@ -17,9 +17,9 @@ import { Vec3 } from '../math/vec3.js';
  * @property {pc.Vec3} direction The direction of the ray.
  */
 class Ray {
-    constructor(origin, direction) {
-        this.origin = origin || new Vec3(0, 0, 0);
-        this.direction = direction || new Vec3(0, 0, -1);
+    constructor(origin = new Vec3(), direction = new Vec3(0, 0, -1)) {
+        this.origin = origin;
+        this.direction = direction;
     }
 
     /**

--- a/src/shape/ray.js
+++ b/src/shape/ray.js
@@ -16,23 +16,25 @@ import { Vec3 } from '../math/vec3.js';
  * @property {pc.Vec3} origin The starting point of the ray.
  * @property {pc.Vec3} direction The direction of the ray.
  */
-function Ray(origin, direction) {
-    this.origin = origin || new Vec3(0, 0, 0);
-    this.direction = direction || new Vec3(0, 0, -1);
-}
+class Ray {
+    constructor(origin, direction) {
+        this.origin = origin || new Vec3(0, 0, 0);
+        this.direction = direction || new Vec3(0, 0, -1);
+    }
 
-/**
- * @function
- * @name pc.Ray#set
- * @description Sets origin and direction to the supplied vector values.
- * @param {pc.Vec3} origin - The starting point of the ray.
- * @param {pc.Vec3} direction - The direction of the ray.
- * @returns {pc.Ray} Self for chaining.
- */
-Ray.prototype.set = function (origin, direction) {
-    this.origin.copy(origin);
-    this.direction.copy(direction);
-    return this;
-};
+    /**
+     * @function
+     * @name pc.Ray#set
+     * @description Sets origin and direction to the supplied vector values.
+     * @param {pc.Vec3} origin - The starting point of the ray.
+     * @param {pc.Vec3} direction - The direction of the ray.
+     * @returns {pc.Ray} Self for chaining.
+     */
+    set(origin, direction) {
+        this.origin.copy(origin);
+        this.direction.copy(direction);
+        return this;
+    }
+}
 
 export { Ray };

--- a/src/templates/template.js
+++ b/src/templates/template.js
@@ -8,33 +8,35 @@ import { SceneParser } from '../resources/parser/scene.js';
  * @param {pc.Application} app - The application.
  * @param {object} data - Asset data from the database.
  */
-function Template(app, data) {
-    this._app = app;
+class Template {
+    constructor(app, data) {
+        this._app = app;
 
-    this._data = data;
+        this._data = data;
 
-    this._templateRoot = null;
-}
-
-/**
- * @private
- * @function
- * @name pc.Template#instantiate
- * @description Create an instance of this template.
- * @returns {pc.Entity} The root entity of the created instance.
- */
-Template.prototype.instantiate = function () {
-    if (!this._templateRoot) { // at first use, after scripts are loaded
-        this._parseTemplate();
+        this._templateRoot = null;
     }
 
-    return this._templateRoot.clone();
-};
+    /**
+     * @private
+     * @function
+     * @name pc.Template#instantiate
+     * @description Create an instance of this template.
+     * @returns {pc.Entity} The root entity of the created instance.
+     */
+    instantiate() {
+        if (!this._templateRoot) { // at first use, after scripts are loaded
+            this._parseTemplate();
+        }
 
-Template.prototype._parseTemplate = function () {
-    var parser = new SceneParser(this._app, true);
+        return this._templateRoot.clone();
+    }
 
-    this._templateRoot = parser.parse(this._data);
-};
+    _parseTemplate() {
+        var parser = new SceneParser(this._app, true);
+
+        this._templateRoot = parser.parse(this._data);
+    }
+}
 
 export { Template };


### PR DESCRIPTION
Inspired by [this talk](https://www.youtube.com/watch?v=cLxNdLK--yI&feature=youtu.be) from Chrome Dev Summit.

This PR migrates a portion of the PlayCanvas codebase from strict ES5 to support the very latest JS language features. Initially, the code has been updated to leverage:

* Classes
* Static class properties
* Default parameters
* `const` (sparingly for now)

Code updated so far is:

* `bundle`
* Most of `core`
* `math`
* `resources`
* `shape`
* `template`
* `extras` (MiniStats)

This is all made possible by adding Babel to the engine's rollup build process.

The rollup configuration has also been updated to generate `playcanvas.mjs`, an ES Module build of the engine. So now we have:

* Raw codebase: ES2021
* `playcanvas.mjs`: Transpiled to ES6 (ECMAScript 2015)
* `playcanvas.js`: Transpiled to ES5 (ECMAScript 2009)

This PR follows up on the [previous unmerged PR](https://github.com/playcanvas/engine/pull/2577) that migrated the engine codebase to Typescript. There was much debate about the overall benefit of adopting Typescript. Typescript provides two main benefits:

1. static type checking
2. ability to adopt the latest JS language features

But we can achieve 2 with Babel. Therefore, it is probably easier to migrate to TS-like JS (ES6 classes in particular), and then revisit the benefits of Typescript. *If* Typescript is adopted at some point, this will be a stepping stone almost directly in that direction.

Let's look at output in terms of `pc.Vec2` for example. Previously, it was:

```javascript
	function Vec2(x, y) {
		if (x && x.length === 2) {
			this.x = x[0];
			this.y = x[1];
		} else {
			this.x = x || 0;
			this.y = y || 0;
		}
	}
	Object.assign(Vec2.prototype, {
		add: function (rhs) {
			this.x += rhs.x;
			this.y += rhs.y;
			return this;
		},
```

Now it's:

```javascript
	var Vec2 = function () {
		function Vec2(x, y) {
			if (x && x.length === 2) {
				this.x = x[0];
				this.y = x[1];
			} else {
				this.x = x || 0;
				this.y = y || 0;
			}
		}

		var _proto = Vec2.prototype;

		_proto.add = function add(rhs) {
			this.x += rhs.x;
			this.y += rhs.y;
			return this;
		};
```

So essentially, a closure is introduced and `Object.assign` is removed. Still just as easy to debug. 

Feedback most definitely welcome!

Closes #2642

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
