### PR TITLE
Refactor script reserved name code

### DIFF
--- a/src/framework/components/script/component.js
+++ b/src/framework/components/script/component.js
@@ -1,4 +1,4 @@
-import { createScript } from '../../../script/script.js';
+import { reservedAttributes } from '../../../script/script-attributes.js';
 
 import { Component } from '../component.js';
 import { Entity } from '../../entity.js';
@@ -970,7 +970,7 @@ Object.defineProperty(ScriptComponent.prototype, 'scripts', {
                 // attributes
                 if (typeof value[key].attributes === 'object') {
                     for (var attr in value[key].attributes) {
-                        if (createScript.reservedAttributes[attr])
+                        if (reservedAttributes[attr])
                             continue;
 
                         if (!script.__attributes.hasOwnProperty(attr)) {

--- a/src/framework/components/script/component.js
+++ b/src/framework/components/script/component.js
@@ -1,4 +1,4 @@
-import { reservedAttributes } from '../../../script/script-attributes.js';
+import { ScriptAttributes } from '../../../script/script-attributes.js';
 
 import { Component } from '../component.js';
 import { Entity } from '../../entity.js';
@@ -970,7 +970,7 @@ Object.defineProperty(ScriptComponent.prototype, 'scripts', {
                 // attributes
                 if (typeof value[key].attributes === 'object') {
                     for (var attr in value[key].attributes) {
-                        if (reservedAttributes[attr])
+                        if (ScriptAttributes.reservedNames[attr])
                             continue;
 
                         if (!script.__attributes.hasOwnProperty(attr)) {

--- a/src/framework/components/script/component.js
+++ b/src/framework/components/script/component.js
@@ -970,7 +970,7 @@ Object.defineProperty(ScriptComponent.prototype, 'scripts', {
                 // attributes
                 if (typeof value[key].attributes === 'object') {
                     for (var attr in value[key].attributes) {
-                        if (ScriptAttributes.reservedNames[attr])
+                        if (ScriptAttributes.reservedNames.has(attr))
                             continue;
 
                         if (!script.__attributes.hasOwnProperty(attr)) {

--- a/src/script/script-attributes.js
+++ b/src/script/script-attributes.js
@@ -164,11 +164,11 @@ function ScriptAttributes(scriptType) {
     this.index = { };
 }
 
-ScriptAttributes.reservedNames = [
+ScriptAttributes.reservedNames = new Set([
     'app', 'entity', 'enabled', '_enabled', '_enabledOld', '_destroyed',
     '__attributes', '__attributesRaw', '__scriptType', '__executionOrder',
     '_callbacks', 'has', 'get', 'on', 'off', 'fire', 'once', 'hasEvent'
-].reduce((acc, curr) => (acc[curr] = 1, acc), {});
+]);
 
 /**
  * @function
@@ -243,7 +243,7 @@ ScriptAttributes.prototype.add = function (name, args) {
         console.warn('attribute \'' + name + '\' is already defined for script type \'' + this.scriptType.name + '\'');
         // #endif
         return;
-    } else if (ScripAttributes.reservedNames[name]) {
+    } else if (ScripAttributes.reservedNames.has(name)) {
         // #ifdef DEBUG
         console.warn('attribute \'' + name + '\' is a reserved attribute name');
         // #endif

--- a/src/script/script-attributes.js
+++ b/src/script/script-attributes.js
@@ -243,7 +243,7 @@ ScriptAttributes.prototype.add = function (name, args) {
         console.warn('attribute \'' + name + '\' is already defined for script type \'' + this.scriptType.name + '\'');
         // #endif
         return;
-    } else if (ScripAttributes.reservedNames.has(name)) {
+    } else if (ScriptAttributes.reservedNames.has(name)) {
         // #ifdef DEBUG
         console.warn('attribute \'' + name + '\' is a reserved attribute name');
         // #endif

--- a/src/script/script-attributes.js
+++ b/src/script/script-attributes.js
@@ -10,8 +10,6 @@ import { GraphNode } from '../scene/graph-node.js';
 
 import { Asset } from '../asset/asset.js';
 
-import { createScript } from './script.js';
-
 var components = ['x', 'y', 'z', 'w'];
 var vecLookup = [undefined, undefined, Vec2, Vec3, Vec4];
 
@@ -166,6 +164,12 @@ function ScriptAttributes(scriptType) {
     this.index = { };
 }
 
+ScriptAttributes.reservedNames = [
+    'app', 'entity', 'enabled', '_enabled', '_enabledOld', '_destroyed',
+    '__attributes', '__attributesRaw', '__scriptType', '__executionOrder',
+    '_callbacks', 'has', 'get', 'on', 'off', 'fire', 'once', 'hasEvent'
+].reduce((acc, curr) => (acc[curr] = 1, acc), {});
+
 /**
  * @function
  * @name pc.ScriptAttributes#add
@@ -239,7 +243,7 @@ ScriptAttributes.prototype.add = function (name, args) {
         console.warn('attribute \'' + name + '\' is already defined for script type \'' + this.scriptType.name + '\'');
         // #endif
         return;
-    } else if (createScript.reservedAttributes[name]) {
+    } else if (ScripAttributes.reservedNames[name]) {
         // #ifdef DEBUG
         console.warn('attribute \'' + name + '\' is a reserved attribute name');
         // #endif

--- a/src/script/script.js
+++ b/src/script/script.js
@@ -6,6 +6,16 @@ import { Application } from '../framework/application.js';
 import { ScriptAttributes } from './script-attributes.js';
 import { ScriptType } from './script-type.js';
 
+var reservedScriptNames = [
+    'system', 'entity', 'create', 'destroy', 'swap', 'move',
+    'scripts', '_scripts', '_scriptsIndex', '_scriptsData',
+    'enabled', '_oldState', 'onEnable', 'onDisable', 'onPostStateChange',
+    '_onSetEnabled', '_checkState', '_onBeforeRemove',
+    '_onInitializeAttributes', '_onInitialize', '_onPostInitialize',
+    '_onUpdate', '_onPostUpdate',
+    '_callbacks', 'has', 'get', 'on', 'off', 'fire', 'once', 'hasEvent'
+].reduce((acc, curr) => (acc[curr] = 1, acc), {});
+
 /* eslint-disable jsdoc/no-undefined-types */
 /**
  * @static
@@ -47,7 +57,7 @@ function createScript(name, app) {
         return null;
     }
 
-    if (createScript.reservedScripts[name])
+    if (reservedScriptNames[name])
         throw new Error('script name: \'' + name + '\' is reserved, please change script name');
 
     var scriptType = function (args) {
@@ -63,6 +73,10 @@ function createScript(name, app) {
     registerScript(scriptType, name, app);
     return scriptType;
 }
+
+// Editor uses this - migrate to ScriptAttributes.reservedNames and delete this
+createScript.reservedAttributes = ScriptAttributes.reservedNames;
+
 
 /* eslint-disable jsdoc/no-undefined-types */
 /* eslint-disable jsdoc/check-examples */
@@ -119,7 +133,7 @@ function registerScript(script, name, app) {
 
     name = name || script.__name || ScriptType.__getScriptName(script);
 
-    if (createScript.reservedScripts[name])
+    if (reservedScriptNames[name])
         throw new Error('script name: \'' + name + '\' is reserved, please change script name');
 
     script.__name = name;
@@ -130,33 +144,5 @@ function registerScript(script, name, app) {
 
     ScriptHandler._push(script);
 }
-
-// reserved scripts
-createScript.reservedScripts = [
-    'system', 'entity', 'create', 'destroy', 'swap', 'move',
-    'scripts', '_scripts', '_scriptsIndex', '_scriptsData',
-    'enabled', '_oldState', 'onEnable', 'onDisable', 'onPostStateChange',
-    '_onSetEnabled', '_checkState', '_onBeforeRemove',
-    '_onInitializeAttributes', '_onInitialize', '_onPostInitialize',
-    '_onUpdate', '_onPostUpdate',
-    '_callbacks', 'has', 'get', 'on', 'off', 'fire', 'once', 'hasEvent'
-];
-var reservedScripts = { };
-var i;
-for (i = 0; i < createScript.reservedScripts.length; i++)
-    reservedScripts[createScript.reservedScripts[i]] = 1;
-createScript.reservedScripts = reservedScripts;
-
-
-// reserved script attribute names
-createScript.reservedAttributes = [
-    'app', 'entity', 'enabled', '_enabled', '_enabledOld', '_destroyed',
-    '__attributes', '__attributesRaw', '__scriptType', '__executionOrder',
-    '_callbacks', 'has', 'get', 'on', 'off', 'fire', 'once', 'hasEvent'
-];
-var reservedAttributes = { };
-for (i = 0; i < createScript.reservedAttributes.length; i++)
-    reservedAttributes[createScript.reservedAttributes[i]] = 1;
-createScript.reservedAttributes = reservedAttributes;
 
 export { createScript, registerScript };

--- a/src/script/script.js
+++ b/src/script/script.js
@@ -6,7 +6,7 @@ import { Application } from '../framework/application.js';
 import { ScriptAttributes } from './script-attributes.js';
 import { ScriptType } from './script-type.js';
 
-var reservedScriptNames = [
+const reservedScriptNames = new Set([
     'system', 'entity', 'create', 'destroy', 'swap', 'move',
     'scripts', '_scripts', '_scriptsIndex', '_scriptsData',
     'enabled', '_oldState', 'onEnable', 'onDisable', 'onPostStateChange',
@@ -14,7 +14,7 @@ var reservedScriptNames = [
     '_onInitializeAttributes', '_onInitialize', '_onPostInitialize',
     '_onUpdate', '_onPostUpdate',
     '_callbacks', 'has', 'get', 'on', 'off', 'fire', 'once', 'hasEvent'
-].reduce((acc, curr) => (acc[curr] = 1, acc), {});
+]);
 
 /* eslint-disable jsdoc/no-undefined-types */
 /**
@@ -57,7 +57,7 @@ function createScript(name, app) {
         return null;
     }
 
-    if (reservedScriptNames[name])
+    if (reservedScriptNames.has(name))
         throw new Error('script name: \'' + name + '\' is reserved, please change script name');
 
     var scriptType = function (args) {
@@ -75,7 +75,11 @@ function createScript(name, app) {
 }
 
 // Editor uses this - migrate to ScriptAttributes.reservedNames and delete this
-createScript.reservedAttributes = ScriptAttributes.reservedNames;
+var reservedAttributes = {};
+ScriptAttributes.reservedNames.forEach((value, value2, set) => {
+    reservedAttributes[value] = 1;
+});
+createScript.reservedAttributes = reservedAttributes;
 
 
 /* eslint-disable jsdoc/no-undefined-types */
@@ -133,7 +137,7 @@ function registerScript(script, name, app) {
 
     name = name || script.__name || ScriptType.__getScriptName(script);
 
-    if (reservedScriptNames[name])
+    if (reservedScriptNames.has(name))
         throw new Error('script name: \'' + name + '\' is reserved, please change script name');
 
     script.__name = name;


### PR DESCRIPTION
This PR removes circular dependencies from the script code. Currently, the engine stores two additional properties on the `createScript` function which looks pretty horrible. I've made one private to `script.js` and the other has been made a static class property of `ScriptAttributes`.

It also simplifies the code to generates the look-up objects for the reserved names by leveraging the `Set` object.

Since the Editor relies on the previous code, I've added support for backwards compatibility, but that can be removed some time after the Editor codebase has been updated.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
