### PR TITLE
Remove circular dependency from shFromCubemap

### DIFF
--- a/src/graphics/prefilter-cubemap.js
+++ b/src/graphics/prefilter-cubemap.js
@@ -12,8 +12,6 @@ import { shaderChunks } from './program-lib/chunks/chunks.js';
 import { RenderTarget } from './render-target.js';
 import { Texture } from './texture.js';
 
-import { Application } from '../framework/application.js';
-
 function syncToCpu(device, targ, face) {
     var tex = targ._colorBuffer;
     if (tex.format != PIXELFORMAT_R8_G8_B8_A8) return;
@@ -41,7 +39,9 @@ function prefilterCubemap(options) {
     var cpuSync = options.cpuSync;
 
     if (cpuSync && !sourceCubemap._levels[0]) {
+        // #ifdef DEBUG
         console.error("ERROR: prefilter: cubemap must have _levels");
+        // #endif
         return;
     }
 
@@ -306,24 +306,27 @@ function texelCoordSolidAngle(u, v, size) {
     return solidAngle;
 }
 
-function shFromCubemap(source, dontFlipX) {
+function shFromCubemap(device, source, dontFlipX) {
     var face;
     var cubeSize = source.width;
     var x, y;
 
-    if (source.format != PIXELFORMAT_R8_G8_B8_A8) {
+    if (source.format !== PIXELFORMAT_R8_G8_B8_A8) {
+        // #ifdef DEBUG
         console.error("ERROR: SH: cubemap must be RGBA8");
+        // #endif
         return;
     }
     if (!source._levels[0]) {
+        // #ifdef DEBUG
         console.error("ERROR: SH: cubemap must be synced to CPU");
+        // #endif
         return;
     }
     if (!source._levels[0][0].length) {
         // Cubemap is not composed of arrays
         if (source._levels[0][0] instanceof HTMLImageElement) {
             // Cubemap is made of imgs - convert to arrays
-            var device = Application.getApplication().graphicsDevice;
             var gl = device.gl;
             var shader = createShaderFromCode(device,
                                               shaderChunks.fullscreenQuadVS,
@@ -368,7 +371,9 @@ function shFromCubemap(source, dontFlipX) {
                 source._levels[0][face] = pixels;
             }
         } else {
+            // #ifdef DEBUG
             console.error("ERROR: SH: cubemap must be composed of arrays or images");
+            // #endif
             return;
         }
     }

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -981,7 +981,7 @@ Object.assign(StandardMaterial.prototype, {
                     var atlas = [prefilteredCubeMap128, prefilteredCubeMap64, prefilteredCubeMap32,
                         prefilteredCubeMap16, prefilteredCubeMap8, prefilteredCubeMap4];
                     prefilteredCubeMap128.dpAtlas = generateDpAtlas(device, atlas);
-                    prefilteredCubeMap128.sh = shFromCubemap(prefilteredCubeMap16);
+                    prefilteredCubeMap128.sh = shFromCubemap(device, prefilteredCubeMap16);
                 }
                 this.dpAtlas = prefilteredCubeMap128.dpAtlas;
                 this.ambientSH = prefilteredCubeMap128.sh;


### PR DESCRIPTION
Currently, `prefilter-cubemap.js` imports `Application` from the framework. This PR refactors the code to no longer require this, thereby removing a circular dependency in the imports.

As an aside, this PR also relegates some console logging to the DEBUG build.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
