### PR TITLE
Build single targets via `npm run build:es5` etc.

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,10 @@
   },
   "scripts": {
     "build": "rollup -c",
+    "build:es5": "rollup -c --environment target:es5",
+    "build:es6": "rollup -c --environment target:es6",
+    "build:debug": "rollup -c --environment target:debug",
+    "build:profiler": "rollup -c --environment target:profiler",
     "build:all": "npm run build && npm run closure",
     "closure": "google-closure-compiler --compilation_level=SIMPLE --warning_level=VERBOSE --jscomp_off=nonStandardJsDocs --jscomp_off=checkTypes --externs externs.js --language_in=ECMASCRIPT5_STRICT --js build/playcanvas.js --js_output_file build/playcanvas.min.js",
     "docs": "jsdoc -c conf-api.json",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -140,7 +140,7 @@ const moduleOptions = {
     ]
 };
 
-export default [{
+const target_release_es5 = {
     input: 'src/index.js',
     output: {
         banner: getBanner(''),
@@ -163,7 +163,9 @@ export default [{
         babel(es5Options),
         spacesToTabs()
     ]
-}, {
+};
+
+const target_release_es6 = {
     input: 'src/index.js',
     output: {
         banner: getBanner(''),
@@ -186,7 +188,9 @@ export default [{
         babel(moduleOptions),
         spacesToTabs()
     ]
-}, {
+};
+
+const target_debug = {
     input: 'src/index.js',
     output: {
         banner: getBanner(' (DEBUG PROFILER)'),
@@ -209,7 +213,9 @@ export default [{
         babel(es5Options),
         spacesToTabs()
     ]
-}, {
+};
+
+const target_profiler = {
     input: 'src/index.js',
     output: {
         banner: getBanner(' (PROFILER)'),
@@ -232,7 +238,9 @@ export default [{
         babel(es5Options),
         spacesToTabs()
     ]
-}, {
+};
+
+const target_extras = {
     input: 'extras/index.js',
     output: {
         banner: getBanner(''),
@@ -245,4 +253,24 @@ export default [{
         babel(es5Options),
         spacesToTabs()
     ]
-}];
+};
+
+let targets = [
+    target_release_es5,
+    target_release_es6,
+    target_debug,
+    target_profiler,
+    target_extras
+];
+
+// Build all targets by default, unless a specific target is chosen
+if (process.env.target) {
+    switch (process.env.target.toLowerCase()) {
+        case "es5"     : targets = [target_release_es5, target_extras]; break;
+        case "es6"     : targets = [target_release_es6, target_extras]; break;
+        case "debug"   : targets = [target_debug      , target_extras]; break;
+        case "profiler": targets = [target_profiler   , target_extras]; break;
+    }
+}
+
+export default targets;

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -266,10 +266,10 @@ let targets = [
 // Build all targets by default, unless a specific target is chosen
 if (process.env.target) {
     switch (process.env.target.toLowerCase()) {
-        case "es5"     : targets = [target_release_es5, target_extras]; break;
-        case "es6"     : targets = [target_release_es6, target_extras]; break;
-        case "debug"   : targets = [target_debug      , target_extras]; break;
-        case "profiler": targets = [target_profiler   , target_extras]; break;
+        case "es5":      targets = [target_release_es5, target_extras]; break;
+        case "es6":      targets = [target_release_es6, target_extras]; break;
+        case "debug":    targets = [target_debug,       target_extras]; break;
+        case "profiler": targets = [target_profiler,    target_extras]; break;
     }
 }
 


### PR DESCRIPTION
`npm run build` is building everything at once, which takes like half a minute on my machine and it would be nice to only build whatever is needed.

For example, in order to test code changes in the example browser, this is enough: `npm run build:es5`

This would also make it easier for me to merge master for the AssemblyScript PR, since I am adding even more targets (32bit, 64bit, ASJS) and the `export default [{...}, {...}, ...];` map became pretty long.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
