### PR TITLE
Migrate most of graphics src to ES6

### DIFF
--- a/src/graphics/graphics.js
+++ b/src/graphics/graphics.js
@@ -4,14 +4,14 @@
  * @type {number}
  * @description Ignores the integer part of texture coordinates, using only the fractional part.
  */
-export var ADDRESS_REPEAT = 0;
+export const ADDRESS_REPEAT = 0;
 /**
  * @constant
  * @name pc.ADDRESS_CLAMP_TO_EDGE
  * @type {number}
  * @description Clamps texture coordinate to the range 0 to 1.
  */
-export var ADDRESS_CLAMP_TO_EDGE = 1;
+export const ADDRESS_CLAMP_TO_EDGE = 1;
 /**
  * @constant
  * @name pc.ADDRESS_MIRRORED_REPEAT
@@ -19,7 +19,7 @@ export var ADDRESS_CLAMP_TO_EDGE = 1;
  * @description Texture coordinate to be set to the fractional part if the integer part is even. If the integer part is odd,
  * then the texture coordinate is set to 1 minus the fractional part.
  */
-export var ADDRESS_MIRRORED_REPEAT = 2;
+export const ADDRESS_MIRRORED_REPEAT = 2;
 
 /**
  * @constant
@@ -27,77 +27,77 @@ export var ADDRESS_MIRRORED_REPEAT = 2;
  * @type {number}
  * @description Multiply all fragment components by zero.
  */
-export var BLENDMODE_ZERO = 0;
+export const BLENDMODE_ZERO = 0;
 /**
  * @constant
  * @name pc.BLENDMODE_ONE
  * @type {number}
  * @description Multiply all fragment components by one.
  */
-export var BLENDMODE_ONE = 1;
+export const BLENDMODE_ONE = 1;
 /**
  * @constant
  * @name pc.BLENDMODE_SRC_COLOR
  * @type {number}
  * @description Multiply all fragment components by the components of the source fragment.
  */
-export var BLENDMODE_SRC_COLOR = 2;
+export const BLENDMODE_SRC_COLOR = 2;
 /**
  * @constant
  * @name pc.BLENDMODE_ONE_MINUS_SRC_COLOR
  * @type {number}
  * @description Multiply all fragment components by one minus the components of the source fragment.
  */
-export var BLENDMODE_ONE_MINUS_SRC_COLOR = 3;
+export const BLENDMODE_ONE_MINUS_SRC_COLOR = 3;
 /**
  * @constant
  * @name pc.BLENDMODE_DST_COLOR
  * @type {number}
  * @description Multiply all fragment components by the components of the destination fragment.
  */
-export var BLENDMODE_DST_COLOR = 4;
+export const BLENDMODE_DST_COLOR = 4;
 /**
  * @constant
  * @name pc.BLENDMODE_ONE_MINUS_DST_COLOR
  * @type {number}
  * @description Multiply all fragment components by one minus the components of the destination fragment.
  */
-export var BLENDMODE_ONE_MINUS_DST_COLOR = 5;
+export const BLENDMODE_ONE_MINUS_DST_COLOR = 5;
 /**
  * @constant
  * @name pc.BLENDMODE_SRC_ALPHA
  * @type {number}
  * @description Multiply all fragment components by the alpha value of the source fragment.
  */
-export var BLENDMODE_SRC_ALPHA = 6;
+export const BLENDMODE_SRC_ALPHA = 6;
 /**
  * @constant
  * @name pc.BLENDMODE_SRC_ALPHA_SATURATE
  * @type {number}
  * @description Multiply all fragment components by the alpha value of the source fragment.
  */
-export var BLENDMODE_SRC_ALPHA_SATURATE = 7;
+export const BLENDMODE_SRC_ALPHA_SATURATE = 7;
 /**
  * @constant
  * @name pc.BLENDMODE_ONE_MINUS_SRC_ALPHA
  * @type {number}
  * @description Multiply all fragment components by one minus the alpha value of the source fragment.
  */
-export var BLENDMODE_ONE_MINUS_SRC_ALPHA = 8;
+export const BLENDMODE_ONE_MINUS_SRC_ALPHA = 8;
 /**
  * @constant
  * @name pc.BLENDMODE_DST_ALPHA
  * @type {number}
  * @description Multiply all fragment components by the alpha value of the destination fragment.
  */
-export var BLENDMODE_DST_ALPHA = 9;
+export const BLENDMODE_DST_ALPHA = 9;
 /**
  * @constant
  * @name pc.BLENDMODE_ONE_MINUS_DST_ALPHA
  * @type {number}
  * @description Multiply all fragment components by one minus the alpha value of the destination fragment.
  */
-export var BLENDMODE_ONE_MINUS_DST_ALPHA = 10;
+export const BLENDMODE_ONE_MINUS_DST_ALPHA = 10;
 
 /**
  * @constant
@@ -105,21 +105,21 @@ export var BLENDMODE_ONE_MINUS_DST_ALPHA = 10;
  * @type {number}
  * @description Add the results of the source and destination fragment multiplies.
  */
-export var BLENDEQUATION_ADD = 0;
+export const BLENDEQUATION_ADD = 0;
 /**
  * @constant
  * @name pc.BLENDEQUATION_SUBTRACT
  * @type {number}
  * @description Subtract the results of the source and destination fragment multiplies.
  */
-export var BLENDEQUATION_SUBTRACT = 1;
+export const BLENDEQUATION_SUBTRACT = 1;
 /**
  * @constant
  * @name pc.BLENDEQUATION_REVERSE_SUBTRACT
  * @type {number}
  * @description Reverse and subtract the results of the source and destination fragment multiplies.
  */
-export var BLENDEQUATION_REVERSE_SUBTRACT = 2;
+export const BLENDEQUATION_REVERSE_SUBTRACT = 2;
 
 /**
  * @constant
@@ -127,14 +127,14 @@ export var BLENDEQUATION_REVERSE_SUBTRACT = 2;
  * @type {number}
  * @description Use the smallest value. Check app.graphicsDevice.extBlendMinmax for support.
  */
-export var BLENDEQUATION_MIN = 3;
+export const BLENDEQUATION_MIN = 3;
 /**
  * @constant
  * @name pc.BLENDEQUATION_MAX
  * @type {number}
  * @description Use the largest value. Check app.graphicsDevice.extBlendMinmax for support.
  */
-export var BLENDEQUATION_MAX = 4;
+export const BLENDEQUATION_MAX = 4;
 
 /**
  * @constant
@@ -142,28 +142,28 @@ export var BLENDEQUATION_MAX = 4;
  * @type {number}
  * @description The data store contents will be modified once and used many times.
  */
-export var BUFFER_STATIC = 0;
+export const BUFFER_STATIC = 0;
 /**
  * @constant
  * @name pc.BUFFER_DYNAMIC
  * @type {number}
  * @description The data store contents will be modified repeatedly and used many times.
  */
-export var BUFFER_DYNAMIC = 1;
+export const BUFFER_DYNAMIC = 1;
 /**
  * @constant
  * @name pc.BUFFER_STREAM
  * @type {number}
  * @description The data store contents will be modified once and used at most a few times.
  */
-export var BUFFER_STREAM = 2;
+export const BUFFER_STREAM = 2;
 /**
  * @constant
  * @name pc.BUFFER_GPUDYNAMIC
  * @type {number}
  * @description The data store contents will be modified repeatedly on the GPU and used many times. Optimal for transform feedback usage (WebGL2 only).
  */
-export var BUFFER_GPUDYNAMIC = 3;
+export const BUFFER_GPUDYNAMIC = 3;
 
 /**
  * @constant
@@ -171,21 +171,21 @@ export var BUFFER_GPUDYNAMIC = 3;
  * @type {number}
  * @description Clear the color buffer.
  */
-export var CLEARFLAG_COLOR = 1;
+export const CLEARFLAG_COLOR = 1;
 /**
  * @constant
  * @name pc.CLEARFLAG_DEPTH
  * @type {number}
  * @description Clear the depth buffer.
  */
-export var CLEARFLAG_DEPTH = 2;
+export const CLEARFLAG_DEPTH = 2;
 /**
  * @constant
  * @name pc.CLEARFLAG_STENCIL
  * @type {number}
  * @description Clear the stencil buffer.
  */
-export var CLEARFLAG_STENCIL = 4;
+export const CLEARFLAG_STENCIL = 4;
 
 /**
  * @constant
@@ -193,42 +193,42 @@ export var CLEARFLAG_STENCIL = 4;
  * @type {number}
  * @description The positive X face of a cubemap.
  */
-export var CUBEFACE_POSX = 0;
+export const CUBEFACE_POSX = 0;
 /**
  * @constant
  * @name pc.CUBEFACE_NEGX
  * @type {number}
  * @description The negative X face of a cubemap.
  */
-export var CUBEFACE_NEGX = 1;
+export const CUBEFACE_NEGX = 1;
 /**
  * @constant
  * @name pc.CUBEFACE_POSY
  * @type {number}
  * @description The positive Y face of a cubemap.
  */
-export var CUBEFACE_POSY = 2;
+export const CUBEFACE_POSY = 2;
 /**
  * @constant
  * @name pc.CUBEFACE_NEGY
  * @type {number}
  * @description The negative Y face of a cubemap.
  */
-export var CUBEFACE_NEGY = 3;
+export const CUBEFACE_NEGY = 3;
 /**
  * @constant
  * @name pc.CUBEFACE_POSZ
  * @type {number}
  * @description The positive Z face of a cubemap.
  */
-export var CUBEFACE_POSZ = 4;
+export const CUBEFACE_POSZ = 4;
 /**
  * @constant
  * @name pc.CUBEFACE_NEGZ
  * @type {number}
  * @description The negative Z face of a cubemap.
  */
-export var CUBEFACE_NEGZ = 5;
+export const CUBEFACE_NEGZ = 5;
 
 /**
  * @constant
@@ -236,21 +236,21 @@ export var CUBEFACE_NEGZ = 5;
  * @type {number}
  * @description No triangles are culled.
  */
-export var CULLFACE_NONE = 0;
+export const CULLFACE_NONE = 0;
 /**
  * @constant
  * @name pc.CULLFACE_BACK
  * @type {number}
  * @description Triangles facing away from the view direction are culled.
  */
-export var CULLFACE_BACK = 1;
+export const CULLFACE_BACK = 1;
 /**
  * @constant
  * @name pc.CULLFACE_FRONT
  * @type {number}
  * @description Triangles facing the view direction are culled.
  */
-export var CULLFACE_FRONT = 2;
+export const CULLFACE_FRONT = 2;
 /**
  * @constant
  * @name pc.CULLFACE_FRONTANDBACK
@@ -258,7 +258,7 @@ export var CULLFACE_FRONT = 2;
  * @description Triangles are culled regardless of their orientation with respect to the view
  * direction. Note that point or line primitives are unaffected by this render state.
  */
-export var CULLFACE_FRONTANDBACK = 3;
+export const CULLFACE_FRONTANDBACK = 3;
 
 /**
  * @constant
@@ -266,42 +266,42 @@ export var CULLFACE_FRONTANDBACK = 3;
  * @type {number}
  * @description Point sample filtering.
  */
-export var FILTER_NEAREST = 0;
+export const FILTER_NEAREST = 0;
 /**
  * @constant
  * @name pc.FILTER_LINEAR
  * @type {number}
  * @description Bilinear filtering.
  */
-export var FILTER_LINEAR = 1;
+export const FILTER_LINEAR = 1;
 /**
  * @constant
  * @name pc.FILTER_NEAREST_MIPMAP_NEAREST
  * @type {number}
  * @description Use the nearest neighbor in the nearest mipmap level.
  */
-export var FILTER_NEAREST_MIPMAP_NEAREST = 2;
+export const FILTER_NEAREST_MIPMAP_NEAREST = 2;
 /**
  * @constant
  * @name pc.FILTER_NEAREST_MIPMAP_LINEAR
  * @type {number}
  * @description Linearly interpolate in the nearest mipmap level.
  */
-export var FILTER_NEAREST_MIPMAP_LINEAR = 3;
+export const FILTER_NEAREST_MIPMAP_LINEAR = 3;
 /**
  * @constant
  * @name pc.FILTER_LINEAR_MIPMAP_NEAREST
  * @type {number}
  * @description Use the nearest neighbor after linearly interpolating between mipmap levels.
  */
-export var FILTER_LINEAR_MIPMAP_NEAREST = 4;
+export const FILTER_LINEAR_MIPMAP_NEAREST = 4;
 /**
  * @constant
  * @name pc.FILTER_LINEAR_MIPMAP_LINEAR
  * @type {number}
  * @description Linearly interpolate both the mipmap levels and between texels.
  */
-export var FILTER_LINEAR_MIPMAP_LINEAR = 5;
+export const FILTER_LINEAR_MIPMAP_LINEAR = 5;
 
 /**
  * @constant
@@ -309,56 +309,56 @@ export var FILTER_LINEAR_MIPMAP_LINEAR = 5;
  * @type {number}
  * @description Never pass.
  */
-export var FUNC_NEVER = 0;
+export const FUNC_NEVER = 0;
 /**
  * @constant
  * @name pc.FUNC_LESS
  * @type {number}
  * @description Pass if (ref & mask) < (stencil & mask).
  */
-export var FUNC_LESS = 1;
+export const FUNC_LESS = 1;
 /**
  * @constant
  * @name pc.FUNC_EQUAL
  * @type {number}
  * @description Pass if (ref & mask) == (stencil & mask).
  */
-export var FUNC_EQUAL = 2;
+export const FUNC_EQUAL = 2;
 /**
  * @constant
  * @name pc.FUNC_LESSEQUAL
  * @type {number}
  * @description Pass if (ref & mask) <= (stencil & mask).
  */
-export var FUNC_LESSEQUAL = 3;
+export const FUNC_LESSEQUAL = 3;
 /**
  * @constant
  * @name pc.FUNC_GREATER
  * @type {number}
  * @description Pass if (ref & mask) > (stencil & mask).
  */
-export var FUNC_GREATER = 4;
+export const FUNC_GREATER = 4;
 /**
  * @constant
  * @name pc.FUNC_NOTEQUAL
  * @type {number}
  * @description Pass if (ref & mask) != (stencil & mask).
  */
-export var FUNC_NOTEQUAL = 5;
+export const FUNC_NOTEQUAL = 5;
 /**
  * @constant
  * @name pc.FUNC_GREATEREQUAL
  * @type {number}
  * @description Pass if (ref & mask) >= (stencil & mask).
  */
-export var FUNC_GREATEREQUAL = 6;
+export const FUNC_GREATEREQUAL = 6;
 /**
  * @constant
  * @name pc.FUNC_ALWAYS
  * @type {number}
  * @description Always pass.
  */
-export var FUNC_ALWAYS = 7;
+export const FUNC_ALWAYS = 7;
 
 /**
  * @constant
@@ -366,21 +366,21 @@ export var FUNC_ALWAYS = 7;
  * @type {number}
  * @description 8-bit unsigned vertex indices (0 to 255).
  */
-export var INDEXFORMAT_UINT8 = 0;
+export const INDEXFORMAT_UINT8 = 0;
 /**
  * @constant
  * @name pc.INDEXFORMAT_UINT16
  * @type {number}
  * @description 16-bit unsigned vertex indices (0 to 65,535).
  */
-export var INDEXFORMAT_UINT16 = 1;
+export const INDEXFORMAT_UINT16 = 1;
 /**
  * @constant
  * @name pc.INDEXFORMAT_UINT32
  * @type {number}
  * @description 32-bit unsigned vertex indices (0 to 4,294,967,295).
  */
-export var INDEXFORMAT_UINT32 = 2;
+export const INDEXFORMAT_UINT32 = 2;
 
 /**
  * @constant
@@ -388,105 +388,105 @@ export var INDEXFORMAT_UINT32 = 2;
  * @type {number}
  * @description 8-bit alpha.
  */
-export var PIXELFORMAT_A8 = 0;
+export const PIXELFORMAT_A8 = 0;
 /**
  * @constant
  * @name pc.PIXELFORMAT_L8
  * @type {number}
  * @description 8-bit luminance.
  */
-export var PIXELFORMAT_L8 = 1;
+export const PIXELFORMAT_L8 = 1;
 /**
  * @constant
  * @name pc.PIXELFORMAT_L8_A8
  * @type {number}
  * @description 8-bit luminance with 8-bit alpha.
  */
-export var PIXELFORMAT_L8_A8 = 2;
+export const PIXELFORMAT_L8_A8 = 2;
 /**
  * @constant
  * @name pc.PIXELFORMAT_R5_G6_B5
  * @type {number}
  * @description 16-bit RGB (5-bits for red channel, 6 for green and 5 for blue).
  */
-export var PIXELFORMAT_R5_G6_B5 = 3;
+export const PIXELFORMAT_R5_G6_B5 = 3;
 /**
  * @constant
  * @name pc.PIXELFORMAT_R5_G5_B5_A1
  * @type {number}
  * @description 16-bit RGBA (5-bits for red channel, 5 for green, 5 for blue with 1-bit alpha).
  */
-export var PIXELFORMAT_R5_G5_B5_A1 = 4;
+export const PIXELFORMAT_R5_G5_B5_A1 = 4;
 /**
  * @constant
  * @name pc.PIXELFORMAT_R4_G4_B4_A4
  * @type {number}
  * @description 16-bit RGBA (4-bits for red channel, 4 for green, 4 for blue with 4-bit alpha).
  */
-export var PIXELFORMAT_R4_G4_B4_A4 = 5;
+export const PIXELFORMAT_R4_G4_B4_A4 = 5;
 /**
  * @constant
  * @name pc.PIXELFORMAT_R8_G8_B8
  * @type {number}
  * @description 24-bit RGB (8-bits for red channel, 8 for green and 8 for blue).
  */
-export var PIXELFORMAT_R8_G8_B8 = 6;
+export const PIXELFORMAT_R8_G8_B8 = 6;
 /**
  * @constant
  * @name pc.PIXELFORMAT_R8_G8_B8_A8
  * @type {number}
  * @description 32-bit RGBA (8-bits for red channel, 8 for green, 8 for blue with 8-bit alpha).
  */
-export var PIXELFORMAT_R8_G8_B8_A8 = 7;
+export const PIXELFORMAT_R8_G8_B8_A8 = 7;
 /**
  * @constant
  * @name pc.PIXELFORMAT_DXT1
  * @type {number}
  * @description Block compressed format storing 16 input pixels in 64 bits of output, consisting of two 16-bit RGB 5:6:5 color values and a 4x4 two bit lookup table.
  */
-export var PIXELFORMAT_DXT1 = 8;
+export const PIXELFORMAT_DXT1 = 8;
 /**
  * @constant
  * @name pc.PIXELFORMAT_DXT3
  * @type {number}
  * @description Block compressed format storing 16 input pixels (corresponding to a 4x4 pixel block) into 128 bits of output, consisting of 64 bits of alpha channel data (4 bits for each pixel) followed by 64 bits of color data; encoded the same way as DXT1.
  */
-export var PIXELFORMAT_DXT3 = 9;
+export const PIXELFORMAT_DXT3 = 9;
 /**
  * @constant
  * @name pc.PIXELFORMAT_DXT5
  * @type {number}
  * @description Block compressed format storing 16 input pixels into 128 bits of output, consisting of 64 bits of alpha channel data (two 8 bit alpha values and a 4x4 3 bit lookup table) followed by 64 bits of color data (encoded the same way as DXT1).
  */
-export var PIXELFORMAT_DXT5 = 10;
+export const PIXELFORMAT_DXT5 = 10;
 /**
  * @constant
  * @name pc.PIXELFORMAT_RGB16F
  * @type {number}
  * @description 16-bit floating point RGB (16-bit float for each red, green and blue channels).
  */
-export var PIXELFORMAT_RGB16F = 11;
+export const PIXELFORMAT_RGB16F = 11;
 /**
  * @constant
  * @name pc.PIXELFORMAT_RGBA16F
  * @type {number}
  * @description 16-bit floating point RGBA (16-bit float for each red, green, blue and alpha channels).
  */
-export var PIXELFORMAT_RGBA16F = 12;
+export const PIXELFORMAT_RGBA16F = 12;
 /**
  * @constant
  * @name pc.PIXELFORMAT_RGB32F
  * @type {number}
  * @description 32-bit floating point RGB (32-bit float for each red, green and blue channels).
  */
-export var PIXELFORMAT_RGB32F = 13;
+export const PIXELFORMAT_RGB32F = 13;
 /**
  * @constant
  * @name pc.PIXELFORMAT_RGBA32F
  * @type {number}
  * @description 32-bit floating point RGBA (32-bit float for each red, green, blue and alpha channels).
  */
-export var PIXELFORMAT_RGBA32F = 14;
+export const PIXELFORMAT_RGBA32F = 14;
 
 /**
  * @constant
@@ -494,7 +494,7 @@ export var PIXELFORMAT_RGBA32F = 14;
  * @type {number}
  * @description 32-bit floating point single channel format (WebGL2 only).
  */
-export var PIXELFORMAT_R32F = 15;
+export const PIXELFORMAT_R32F = 15;
 
 /**
  * @constant
@@ -502,7 +502,7 @@ export var PIXELFORMAT_R32F = 15;
  * @type {number}
  * @description A readable depth buffer format.
  */
-export var PIXELFORMAT_DEPTH = 16;
+export const PIXELFORMAT_DEPTH = 16;
 
 /**
  * @constant
@@ -510,7 +510,7 @@ export var PIXELFORMAT_DEPTH = 16;
  * @type {number}
  * @description A readable depth/stencil buffer format (WebGL2 only).
  */
-export var PIXELFORMAT_DEPTHSTENCIL = 17;
+export const PIXELFORMAT_DEPTHSTENCIL = 17;
 
 /**
  * @constant
@@ -518,7 +518,7 @@ export var PIXELFORMAT_DEPTHSTENCIL = 17;
  * @type {number}
  * @description A floating-point color-only format with 11 bits for red and green channels and 10 bits for the blue channel (WebGL2 only).
  */
-export var PIXELFORMAT_111110F = 18;
+export const PIXELFORMAT_111110F = 18;
 
 /**
  * @constant
@@ -526,7 +526,7 @@ export var PIXELFORMAT_111110F = 18;
  * @type {number}
  * @description Color-only sRGB format (WebGL2 only).
  */
-export var PIXELFORMAT_SRGB = 19;
+export const PIXELFORMAT_SRGB = 19;
 
 /**
  * @constant
@@ -534,7 +534,7 @@ export var PIXELFORMAT_SRGB = 19;
  * @type {number}
  * @description Color sRGB format with additional alpha channel (WebGL2 only).
  */
-export var PIXELFORMAT_SRGBA = 20;
+export const PIXELFORMAT_SRGBA = 20;
 
 /**
  * @constant
@@ -542,7 +542,7 @@ export var PIXELFORMAT_SRGBA = 20;
  * @type {number}
  * @description ETC1 compressed format.
  */
-export var PIXELFORMAT_ETC1 = 21;
+export const PIXELFORMAT_ETC1 = 21;
 
 /**
  * @constant
@@ -550,7 +550,7 @@ export var PIXELFORMAT_ETC1 = 21;
  * @type {number}
  * @description ETC2 (RGB) compressed format.
  */
-export var PIXELFORMAT_ETC2_RGB = 22;
+export const PIXELFORMAT_ETC2_RGB = 22;
 
 /**
  * @constant
@@ -558,7 +558,7 @@ export var PIXELFORMAT_ETC2_RGB = 22;
  * @type {number}
  * @description ETC2 (RGBA) compressed format.
  */
-export var PIXELFORMAT_ETC2_RGBA = 23;
+export const PIXELFORMAT_ETC2_RGBA = 23;
 
 /**
  * @constant
@@ -566,7 +566,7 @@ export var PIXELFORMAT_ETC2_RGBA = 23;
  * @type {number}
  * @description PVRTC (2BPP RGB) compressed format.
  */
-export var PIXELFORMAT_PVRTC_2BPP_RGB_1 = 24;
+export const PIXELFORMAT_PVRTC_2BPP_RGB_1 = 24;
 
 /**
  * @constant
@@ -574,7 +574,7 @@ export var PIXELFORMAT_PVRTC_2BPP_RGB_1 = 24;
  * @type {number}
  * @description PVRTC (2BPP RGBA) compressed format.
  */
-export var PIXELFORMAT_PVRTC_2BPP_RGBA_1 = 25;
+export const PIXELFORMAT_PVRTC_2BPP_RGBA_1 = 25;
 
 /**
  * @constant
@@ -582,7 +582,7 @@ export var PIXELFORMAT_PVRTC_2BPP_RGBA_1 = 25;
  * @type {number}
  * @description PVRTC (4BPP RGB) compressed format.
  */
-export var PIXELFORMAT_PVRTC_4BPP_RGB_1 = 26;
+export const PIXELFORMAT_PVRTC_4BPP_RGB_1 = 26;
 
 /**
  * @constant
@@ -590,7 +590,7 @@ export var PIXELFORMAT_PVRTC_4BPP_RGB_1 = 26;
  * @type {number}
  * @description PVRTC (4BPP RGBA) compressed format.
  */
-export var PIXELFORMAT_PVRTC_4BPP_RGBA_1 = 27;
+export const PIXELFORMAT_PVRTC_4BPP_RGBA_1 = 27;
 
 /**
  * @constant
@@ -598,7 +598,7 @@ export var PIXELFORMAT_PVRTC_4BPP_RGBA_1 = 27;
  * @type {number}
  * @description ATC compressed format with alpha channel in blocks of 4x4.
  */
-export var PIXELFORMAT_ASTC_4x4 = 28;
+export const PIXELFORMAT_ASTC_4x4 = 28;
 
 /**
  * @constant
@@ -606,7 +606,7 @@ export var PIXELFORMAT_ASTC_4x4 = 28;
  * @type {number}
  * @description ATC compressed format with no alpha channel.
  */
-export var PIXELFORMAT_ATC_RGB = 29;
+export const PIXELFORMAT_ATC_RGB = 29;
 
 /**
  * @constant
@@ -614,7 +614,7 @@ export var PIXELFORMAT_ATC_RGB = 29;
  * @type {number}
  * @description ATC compressed format with alpha channel.
  */
-export var PIXELFORMAT_ATC_RGBA = 30;
+export const PIXELFORMAT_ATC_RGBA = 30;
 
 // only add compressed formats next
 
@@ -624,49 +624,49 @@ export var PIXELFORMAT_ATC_RGBA = 30;
  * @type {number}
  * @description List of distinct points.
  */
-export var PRIMITIVE_POINTS = 0;
+export const PRIMITIVE_POINTS = 0;
 /**
  * @constant
  * @name pc.PRIMITIVE_LINES
  * @type {number}
  * @description Discrete list of line segments.
  */
-export var PRIMITIVE_LINES = 1;
+export const PRIMITIVE_LINES = 1;
 /**
  * @constant
  * @name pc.PRIMITIVE_LINELOOP
  * @type {number}
  * @description List of points that are linked sequentially by line segments, with a closing line segment between the last and first points.
  */
-export var PRIMITIVE_LINELOOP = 2;
+export const PRIMITIVE_LINELOOP = 2;
 /**
  * @constant
  * @name pc.PRIMITIVE_LINESTRIP
  * @type {number}
  * @description List of points that are linked sequentially by line segments.
  */
-export var PRIMITIVE_LINESTRIP = 3;
+export const PRIMITIVE_LINESTRIP = 3;
 /**
  * @constant
  * @name pc.PRIMITIVE_TRIANGLES
  * @type {number}
  * @description Discrete list of triangles.
  */
-export var PRIMITIVE_TRIANGLES = 4;
+export const PRIMITIVE_TRIANGLES = 4;
 /**
  * @constant
  * @name pc.PRIMITIVE_TRISTRIP
  * @type {number}
  * @description Connected strip of triangles where a specified vertex forms a triangle using the previous two.
  */
-export var PRIMITIVE_TRISTRIP = 5;
+export const PRIMITIVE_TRISTRIP = 5;
 /**
  * @constant
  * @name pc.PRIMITIVE_TRIFAN
  * @type {number}
  * @description Connected fan of triangles where the first vertex forms triangles with the following pairs of vertices.
  */
-export var PRIMITIVE_TRIFAN = 6;
+export const PRIMITIVE_TRIFAN = 6;
 
 /**
  * @constant
@@ -674,45 +674,45 @@ export var PRIMITIVE_TRIFAN = 6;
  * @type {string}
  * @description Vertex attribute to be treated as a position.
  */
-export var SEMANTIC_POSITION = "POSITION";
+export const SEMANTIC_POSITION = "POSITION";
 /**
  * @constant
  * @name pc.SEMANTIC_NORMAL
  * @type {string}
  * @description Vertex attribute to be treated as a normal.
  */
-export var SEMANTIC_NORMAL = "NORMAL";
+export const SEMANTIC_NORMAL = "NORMAL";
 /**
  * @constant
  * @name pc.SEMANTIC_TANGENT
  * @type {string}
  * @description Vertex attribute to be treated as a tangent.
  */
-export var SEMANTIC_TANGENT = "TANGENT";
+export const SEMANTIC_TANGENT = "TANGENT";
 /**
  * @constant
  * @name pc.SEMANTIC_BLENDWEIGHT
  * @type {string}
  * @description Vertex attribute to be treated as skin blend weights.
  */
-export var SEMANTIC_BLENDWEIGHT = "BLENDWEIGHT";
+export const SEMANTIC_BLENDWEIGHT = "BLENDWEIGHT";
 /**
  * @constant
  * @name pc.SEMANTIC_BLENDINDICES
  * @type {string}
  * @description Vertex attribute to be treated as skin blend indices.
  */
-export var SEMANTIC_BLENDINDICES = "BLENDINDICES";
+export const SEMANTIC_BLENDINDICES = "BLENDINDICES";
 /**
  * @constant
  * @name pc.SEMANTIC_COLOR
  * @type {string}
  * @description Vertex attribute to be treated as a color.
  */
-export var SEMANTIC_COLOR = "COLOR";
+export const SEMANTIC_COLOR = "COLOR";
 
 // private semantic used for programatic construction of individual texcoord semantics
-export var SEMANTIC_TEXCOORD = "TEXCOORD";
+export const SEMANTIC_TEXCOORD = "TEXCOORD";
 
 /**
  * @constant
@@ -720,59 +720,59 @@ export var SEMANTIC_TEXCOORD = "TEXCOORD";
  * @type {string}
  * @description Vertex attribute to be treated as a texture coordinate (set 0).
  */
-export var SEMANTIC_TEXCOORD0 = "TEXCOORD0";
+export const SEMANTIC_TEXCOORD0 = "TEXCOORD0";
 /**
  * @constant
  * @name pc.SEMANTIC_TEXCOORD1
  * @type {string}
  * @description Vertex attribute to be treated as a texture coordinate (set 1).
  */
-export var SEMANTIC_TEXCOORD1 = "TEXCOORD1";
+export const SEMANTIC_TEXCOORD1 = "TEXCOORD1";
 /**
  * @constant
  * @name pc.SEMANTIC_TEXCOORD2
  * @type {string}
  * @description Vertex attribute to be treated as a texture coordinate (set 2).
  */
-export var SEMANTIC_TEXCOORD2 = "TEXCOORD2";
+export const SEMANTIC_TEXCOORD2 = "TEXCOORD2";
 /**
  * @constant
  * @name pc.SEMANTIC_TEXCOORD3
  * @type {string}
  * @description Vertex attribute to be treated as a texture coordinate (set 3).
  */
-export var SEMANTIC_TEXCOORD3 = "TEXCOORD3";
+export const SEMANTIC_TEXCOORD3 = "TEXCOORD3";
 /**
  * @constant
  * @name pc.SEMANTIC_TEXCOORD4
  * @type {string}
  * @description Vertex attribute to be treated as a texture coordinate (set 4).
  */
-export var SEMANTIC_TEXCOORD4 = "TEXCOORD4";
+export const SEMANTIC_TEXCOORD4 = "TEXCOORD4";
 /**
  * @constant
  * @name pc.SEMANTIC_TEXCOORD5
  * @type {string}
  * @description Vertex attribute to be treated as a texture coordinate (set 5).
  */
-export var SEMANTIC_TEXCOORD5 = "TEXCOORD5";
+export const SEMANTIC_TEXCOORD5 = "TEXCOORD5";
 /**
  * @constant
  * @name pc.SEMANTIC_TEXCOORD6
  * @type {string}
  * @description Vertex attribute to be treated as a texture coordinate (set 6).
  */
-export var SEMANTIC_TEXCOORD6 = "TEXCOORD6";
+export const SEMANTIC_TEXCOORD6 = "TEXCOORD6";
 /**
  * @constant
  * @name pc.SEMANTIC_TEXCOORD7
  * @type {string}
  * @description Vertex attribute to be treated as a texture coordinate (set 7).
  */
-export var SEMANTIC_TEXCOORD7 = "TEXCOORD7";
+export const SEMANTIC_TEXCOORD7 = "TEXCOORD7";
 
 // private semantic used for programatic construction of individual attr semantics
-export var SEMANTIC_ATTR = "ATTR";
+export const SEMANTIC_ATTR = "ATTR";
 
 /**
  * @constant
@@ -780,114 +780,114 @@ export var SEMANTIC_ATTR = "ATTR";
  * @type {string}
  * @description Vertex attribute with a user defined semantic.
  */
-export var SEMANTIC_ATTR0 = "ATTR0";
+export const SEMANTIC_ATTR0 = "ATTR0";
 /**
  * @constant
  * @name pc.SEMANTIC_ATTR1
  * @type {string}
  * @description Vertex attribute with a user defined semantic.
  */
-export var SEMANTIC_ATTR1 = "ATTR1";
+export const SEMANTIC_ATTR1 = "ATTR1";
 /**
  * @constant
  * @name pc.SEMANTIC_ATTR2
  * @type {string}
  * @description Vertex attribute with a user defined semantic.
  */
-export var SEMANTIC_ATTR2 = "ATTR2";
+export const SEMANTIC_ATTR2 = "ATTR2";
 /**
  * @constant
  * @name pc.SEMANTIC_ATTR3
  * @type {string}
  * @description Vertex attribute with a user defined semantic.
  */
-export var SEMANTIC_ATTR3 = "ATTR3";
+export const SEMANTIC_ATTR3 = "ATTR3";
 /**
  * @constant
  * @name pc.SEMANTIC_ATTR4
  * @type {string}
  * @description Vertex attribute with a user defined semantic.
  */
-export var SEMANTIC_ATTR4 = "ATTR4";
+export const SEMANTIC_ATTR4 = "ATTR4";
 /**
  * @constant
  * @name pc.SEMANTIC_ATTR5
  * @type {string}
  * @description Vertex attribute with a user defined semantic.
  */
-export var SEMANTIC_ATTR5 = "ATTR5";
+export const SEMANTIC_ATTR5 = "ATTR5";
 /**
  * @constant
  * @name pc.SEMANTIC_ATTR6
  * @type {string}
  * @description Vertex attribute with a user defined semantic.
  */
-export var SEMANTIC_ATTR6 = "ATTR6";
+export const SEMANTIC_ATTR6 = "ATTR6";
 /**
  * @constant
  * @name pc.SEMANTIC_ATTR7
  * @type {string}
  * @description Vertex attribute with a user defined semantic.
  */
-export var SEMANTIC_ATTR7 = "ATTR7";
+export const SEMANTIC_ATTR7 = "ATTR7";
 /**
  * @constant
  * @name pc.SEMANTIC_ATTR8
  * @type {string}
  * @description Vertex attribute with a user defined semantic.
  */
-export var SEMANTIC_ATTR8 = "ATTR8";
+export const SEMANTIC_ATTR8 = "ATTR8";
 /**
  * @constant
  * @name pc.SEMANTIC_ATTR9
  * @type {string}
  * @description Vertex attribute with a user defined semantic.
  */
-export var SEMANTIC_ATTR9 = "ATTR9";
+export const SEMANTIC_ATTR9 = "ATTR9";
 /**
  * @constant
  * @name pc.SEMANTIC_ATTR10
  * @type {string}
  * @description Vertex attribute with a user defined semantic.
  */
-export var SEMANTIC_ATTR10 = "ATTR10";
+export const SEMANTIC_ATTR10 = "ATTR10";
 /**
  * @constant
  * @name pc.SEMANTIC_ATTR11
  * @type {string}
  * @description Vertex attribute with a user defined semantic.
  */
-export var SEMANTIC_ATTR11 = "ATTR11";
+export const SEMANTIC_ATTR11 = "ATTR11";
 /**
  * @constant
  * @name pc.SEMANTIC_ATTR12
  * @type {string}
  * @description Vertex attribute with a user defined semantic.
  */
-export var SEMANTIC_ATTR12 = "ATTR12";
+export const SEMANTIC_ATTR12 = "ATTR12";
 /**
  * @constant
  * @name pc.SEMANTIC_ATTR13
  * @type {string}
  * @description Vertex attribute with a user defined semantic.
  */
-export var SEMANTIC_ATTR13 = "ATTR13";
+export const SEMANTIC_ATTR13 = "ATTR13";
 /**
  * @constant
  * @name pc.SEMANTIC_ATTR14
  * @type {string}
  * @description Vertex attribute with a user defined semantic.
  */
-export var SEMANTIC_ATTR14 = "ATTR14";
+export const SEMANTIC_ATTR14 = "ATTR14";
 /**
  * @constant
  * @name pc.SEMANTIC_ATTR15
  * @type {string}
  * @description Vertex attribute with a user defined semantic.
  */
-export var SEMANTIC_ATTR15 = "ATTR15";
+export const SEMANTIC_ATTR15 = "ATTR15";
 
-export var SHADERTAG_MATERIAL = 1;
+export const SHADERTAG_MATERIAL = 1;
 
 /**
  * @constant
@@ -895,56 +895,56 @@ export var SHADERTAG_MATERIAL = 1;
  * @type {number}
  * @description Don't change the stencil buffer value.
  */
-export var STENCILOP_KEEP = 0;
+export const STENCILOP_KEEP = 0;
 /**
  * @constant
  * @name pc.STENCILOP_ZERO
  * @type {number}
  * @description Set value to zero.
  */
-export var STENCILOP_ZERO = 1;
+export const STENCILOP_ZERO = 1;
 /**
  * @constant
  * @name pc.STENCILOP_REPLACE
  * @type {number}
  * @description Replace value with the reference value (see {@link pc.GraphicsDevice#setStencilFunc}).
  */
-export var STENCILOP_REPLACE = 2;
+export const STENCILOP_REPLACE = 2;
 /**
  * @constant
  * @name pc.STENCILOP_INCREMENT
  * @type {number}
  * @description Increment the value.
  */
-export var STENCILOP_INCREMENT = 3;
+export const STENCILOP_INCREMENT = 3;
 /**
  * @constant
  * @name pc.STENCILOP_INCREMENTWRAP
  * @type {number}
  * @description Increment the value but wrap it to zero when it's larger than a maximum representable value.
  */
-export var STENCILOP_INCREMENTWRAP = 4;
+export const STENCILOP_INCREMENTWRAP = 4;
 /**
  * @constant
  * @name pc.STENCILOP_DECREMENT
  * @type {number}
  * @description Decrement the value.
  */
-export var STENCILOP_DECREMENT = 5;
+export const STENCILOP_DECREMENT = 5;
 /**
  * @constant
  * @name pc.STENCILOP_DECREMENTWRAP
  * @type {number}
  * @description Decrement the value but wrap it to a maximum representable value if the current value is 0.
  */
-export var STENCILOP_DECREMENTWRAP = 6;
+export const STENCILOP_DECREMENTWRAP = 6;
 /**
  * @constant
  * @name pc.STENCILOP_INVERT
  * @type {number}
  * @description Invert the value bitwise.
  */
-export var STENCILOP_INVERT = 7;
+export const STENCILOP_INVERT = 7;
 
 /**
  * @constant
@@ -952,14 +952,14 @@ export var STENCILOP_INVERT = 7;
  * @type {number}
  * @description Read only. Any changes to the locked mip level's pixels will not update the texture.
  */
-export var TEXTURELOCK_READ = 1;
+export const TEXTURELOCK_READ = 1;
 /**
  * @constant
  * @name pc.TEXTURELOCK_WRITE
  * @type {number}
  * @description Write only. The contents of the specified mip level will be entirely replaced.
  */
-export var TEXTURELOCK_WRITE = 2;
+export const TEXTURELOCK_WRITE = 2;
 
 /**
  * @constant
@@ -967,7 +967,7 @@ export var TEXTURELOCK_WRITE = 2;
  * @type {string}
  * @description Texture is a default type.
  */
-export var TEXTURETYPE_DEFAULT = 'default';
+export const TEXTURETYPE_DEFAULT = 'default';
 
 /**
  * @constant
@@ -975,7 +975,7 @@ export var TEXTURETYPE_DEFAULT = 'default';
  * @type {string}
  * @description Texture stores high dynamic range data in RGBM format
  */
-export var TEXTURETYPE_RGBM = 'rgbm';
+export const TEXTURETYPE_RGBM = 'rgbm';
 
 /**
  * @constant
@@ -983,7 +983,7 @@ export var TEXTURETYPE_RGBM = 'rgbm';
  * @type {string}
  * @description Texture stores high dynamic range data in RGBE format
  */
-export var TEXTURETYPE_RGBE = 'rgbe';
+export const TEXTURETYPE_RGBE = 'rgbe';
 
 /**
  * @constant
@@ -993,12 +993,12 @@ export var TEXTURETYPE_RGBE = 'rgbe';
  * maps. The R component is stored in alpha and G is stored in RGB. This packing can result in higher quality
  * when the texture data is compressed.
  */
-export var TEXTURETYPE_SWIZZLEGGGR = 'swizzleGGGR';
+export const TEXTURETYPE_SWIZZLEGGGR = 'swizzleGGGR';
 
-export var TEXHINT_NONE = 0;
-export var TEXHINT_SHADOWMAP = 1;
-export var TEXHINT_ASSET = 2;
-export var TEXHINT_LIGHTMAP = 3;
+export const TEXHINT_NONE = 0;
+export const TEXHINT_SHADOWMAP = 1;
+export const TEXHINT_ASSET = 2;
+export const TEXHINT_LIGHTMAP = 3;
 
 /**
  * @constant
@@ -1006,81 +1006,81 @@ export var TEXHINT_LIGHTMAP = 3;
  * @type {number}
  * @description Signed byte vertex element type.
  */
-export var TYPE_INT8 = 0;
+export const TYPE_INT8 = 0;
 /**
  * @constant
  * @name pc.TYPE_UINT8
  * @type {number}
  * @description Unsigned byte vertex element type.
  */
-export var TYPE_UINT8 = 1;
+export const TYPE_UINT8 = 1;
 /**
  * @constant
  * @name pc.TYPE_INT16
  * @type {number}
  * @description Signed short vertex element type.
  */
-export var TYPE_INT16 = 2;
+export const TYPE_INT16 = 2;
 /**
  * @constant
  * @name pc.TYPE_UINT16
  * @type {number}
  * @description Unsigned short vertex element type.
  */
-export var TYPE_UINT16 = 3;
+export const TYPE_UINT16 = 3;
 /**
  * @constant
  * @name pc.TYPE_INT32
  * @type {number}
  * @description Signed integer vertex element type.
  */
-export var TYPE_INT32 = 4;
+export const TYPE_INT32 = 4;
 /**
  * @constant
  * @name pc.TYPE_UINT32
  * @type {number}
  * @description Unsigned integer vertex element type.
  */
-export var TYPE_UINT32 = 5;
+export const TYPE_UINT32 = 5;
 /**
  * @constant
  * @name pc.TYPE_FLOAT32
  * @type {number}
  * @description Floating point vertex element type.
  */
-export var TYPE_FLOAT32 = 6;
+export const TYPE_FLOAT32 = 6;
 
-export var UNIFORMTYPE_BOOL = 0;
-export var UNIFORMTYPE_INT = 1;
-export var UNIFORMTYPE_FLOAT = 2;
-export var UNIFORMTYPE_VEC2 = 3;
-export var UNIFORMTYPE_VEC3 = 4;
-export var UNIFORMTYPE_VEC4 = 5;
-export var UNIFORMTYPE_IVEC2 = 6;
-export var UNIFORMTYPE_IVEC3 = 7;
-export var UNIFORMTYPE_IVEC4 = 8;
-export var UNIFORMTYPE_BVEC2 = 9;
-export var UNIFORMTYPE_BVEC3 = 10;
-export var UNIFORMTYPE_BVEC4 = 11;
-export var UNIFORMTYPE_MAT2 = 12;
-export var UNIFORMTYPE_MAT3 = 13;
-export var UNIFORMTYPE_MAT4 = 14;
-export var UNIFORMTYPE_TEXTURE2D = 15;
-export var UNIFORMTYPE_TEXTURECUBE = 16;
-export var UNIFORMTYPE_FLOATARRAY = 17;
-export var UNIFORMTYPE_TEXTURE2D_SHADOW = 18;
-export var UNIFORMTYPE_TEXTURECUBE_SHADOW = 19;
-export var UNIFORMTYPE_TEXTURE3D = 20;
-export var UNIFORMTYPE_VEC2ARRAY = 21;
-export var UNIFORMTYPE_VEC3ARRAY = 22;
-export var UNIFORMTYPE_VEC4ARRAY = 23;
+export const UNIFORMTYPE_BOOL = 0;
+export const UNIFORMTYPE_INT = 1;
+export const UNIFORMTYPE_FLOAT = 2;
+export const UNIFORMTYPE_VEC2 = 3;
+export const UNIFORMTYPE_VEC3 = 4;
+export const UNIFORMTYPE_VEC4 = 5;
+export const UNIFORMTYPE_IVEC2 = 6;
+export const UNIFORMTYPE_IVEC3 = 7;
+export const UNIFORMTYPE_IVEC4 = 8;
+export const UNIFORMTYPE_BVEC2 = 9;
+export const UNIFORMTYPE_BVEC3 = 10;
+export const UNIFORMTYPE_BVEC4 = 11;
+export const UNIFORMTYPE_MAT2 = 12;
+export const UNIFORMTYPE_MAT3 = 13;
+export const UNIFORMTYPE_MAT4 = 14;
+export const UNIFORMTYPE_TEXTURE2D = 15;
+export const UNIFORMTYPE_TEXTURECUBE = 16;
+export const UNIFORMTYPE_FLOATARRAY = 17;
+export const UNIFORMTYPE_TEXTURE2D_SHADOW = 18;
+export const UNIFORMTYPE_TEXTURECUBE_SHADOW = 19;
+export const UNIFORMTYPE_TEXTURE3D = 20;
+export const UNIFORMTYPE_VEC2ARRAY = 21;
+export const UNIFORMTYPE_VEC3ARRAY = 22;
+export const UNIFORMTYPE_VEC4ARRAY = 23;
 
 // map of engine pc.TYPE_*** enums to their corresponding typed array constructors and byte sizes
-export var typedArrayTypes = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array, Float32Array];
-export var typedArrayTypesByteSize = [1, 1, 2, 2, 4, 4, 4];
+export const typedArrayTypes = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array, Float32Array];
+export const typedArrayTypesByteSize = [1, 1, 2, 2, 4, 4, 4];
 
 // map of typed array to engine pc.TYPE_***
-export var typedArrayToType = {
+export const typedArrayToType = {
     "Int8Array": TYPE_INT8,
     "Uint8Array": TYPE_UINT8,
     "Int16Array": TYPE_INT16,
@@ -1091,13 +1091,13 @@ export var typedArrayToType = {
 };
 
 // map of engine pc.INDEXFORMAT_*** to their corresponding typed array constructors and byte sizes
-export var typedArrayIndexFormats = [Uint8Array, Uint16Array, Uint32Array];
-export var typedArrayIndexFormatsByteSize = [1, 2, 4];
+export const typedArrayIndexFormats = [Uint8Array, Uint16Array, Uint32Array];
+export const typedArrayIndexFormatsByteSize = [1, 2, 4];
 
 // map of engine semantics into location on device in range 0..15 (note - semantics mapping to
 // the same location cannot be used at the same time)
 // organized in a way that ATTR0-ATTR7 do not overlap with common important semantics
-export var semanticToLocation = {};
+export const semanticToLocation = {};
 semanticToLocation[SEMANTIC_POSITION] = 0;
 semanticToLocation[SEMANTIC_NORMAL] = 1;
 semanticToLocation[SEMANTIC_BLENDWEIGHT] = 2;

--- a/src/graphics/index-buffer.js
+++ b/src/graphics/index-buffer.js
@@ -41,50 +41,49 @@ import {
  * @param {ArrayBuffer} [initialData] - Initial data. If left unspecified, the
  * index buffer will be initialized to zeros.
  */
-function IndexBuffer(graphicsDevice, format, numIndices, usage, initialData) {
-    // By default, index buffers are static (better for performance since buffer
-    // data can be cached in VRAM)
-    this.usage = usage || BUFFER_STATIC;
-    this.format = format;
-    this.numIndices = numIndices;
-    this.device = graphicsDevice;
+class IndexBuffer {
+    constructor(graphicsDevice, format, numIndices, usage = BUFFER_STATIC, initialData) {
+        // By default, index buffers are static (better for performance since buffer data can be cached in VRAM)
+        this.device = graphicsDevice;
+        this.format = format;
+        this.numIndices = numIndices;
+        this.usage = usage;
 
-    var gl = this.device.gl;
+        var gl = this.device.gl;
 
-    // Allocate the storage
-    var bytesPerIndex;
-    if (format === INDEXFORMAT_UINT8) {
-        bytesPerIndex = 1;
-        this.glFormat = gl.UNSIGNED_BYTE;
-    } else if (format === INDEXFORMAT_UINT16) {
-        bytesPerIndex = 2;
-        this.glFormat = gl.UNSIGNED_SHORT;
-    } else if (format === INDEXFORMAT_UINT32) {
-        bytesPerIndex = 4;
-        this.glFormat = gl.UNSIGNED_INT;
+        // Allocate the storage
+        var bytesPerIndex;
+        if (format === INDEXFORMAT_UINT8) {
+            bytesPerIndex = 1;
+            this.glFormat = gl.UNSIGNED_BYTE;
+        } else if (format === INDEXFORMAT_UINT16) {
+            bytesPerIndex = 2;
+            this.glFormat = gl.UNSIGNED_SHORT;
+        } else if (format === INDEXFORMAT_UINT32) {
+            bytesPerIndex = 4;
+            this.glFormat = gl.UNSIGNED_INT;
+        }
+        this.bytesPerIndex = bytesPerIndex;
+
+        this.numBytes = this.numIndices * bytesPerIndex;
+
+        if (initialData) {
+            this.setData(initialData);
+        } else {
+            this.storage = new ArrayBuffer(this.numBytes);
+        }
+
+        graphicsDevice._vram.ib += this.numBytes;
+
+        this.device.buffers.push(this);
     }
-    this.bytesPerIndex = bytesPerIndex;
 
-    this.numBytes = this.numIndices * bytesPerIndex;
-
-    if (initialData) {
-        this.setData(initialData);
-    } else {
-        this.storage = new ArrayBuffer(this.numBytes);
-    }
-
-    graphicsDevice._vram.ib += this.numBytes;
-
-    this.device.buffers.push(this);
-}
-
-Object.assign(IndexBuffer.prototype, {
     /**
      * @function
      * @name pc.IndexBuffer#destroy
      * @description Frees resources associated with this index buffer.
      */
-    destroy: function () {
+    destroy() {
         var device = this.device;
         var idx = device.buffers.indexOf(this);
         if (idx !== -1) {
@@ -101,12 +100,12 @@ Object.assign(IndexBuffer.prototype, {
                 this.device.indexBuffer = null;
             }
         }
-    },
+    }
 
     // called when context was lost, function releases all context related resources
-    loseContext: function () {
+    loseContext() {
         this.bufferId = undefined;
-    },
+    }
 
     /**
      * @function
@@ -118,9 +117,9 @@ Object.assign(IndexBuffer.prototype, {
      * * {@link pc.INDEXFORMAT_UINT16}
      * * {@link pc.INDEXFORMAT_UINT32}
      */
-    getFormat: function () {
+    getFormat() {
         return this.format;
-    },
+    }
 
     /**
      * @function
@@ -128,9 +127,9 @@ Object.assign(IndexBuffer.prototype, {
      * @description Returns the number of indices stored in the specified index buffer.
      * @returns {number} The number of indices stored in the specified index buffer.
      */
-    getNumIndices: function () {
+    getNumIndices() {
         return this.numIndices;
-    },
+    }
 
     /**
      * @function
@@ -138,9 +137,9 @@ Object.assign(IndexBuffer.prototype, {
      * @description Gives access to the block of memory that stores the buffer's indices.
      * @returns {ArrayBuffer} A contiguous block of memory where index data can be written to.
      */
-    lock: function () {
+    lock() {
         return this.storage;
-    },
+    }
 
     /**
      * @function
@@ -149,7 +148,7 @@ Object.assign(IndexBuffer.prototype, {
      * ready to be given to the graphics hardware. Only unlocked index buffers can be set on the
      * currently active device.
      */
-    unlock: function () {
+    unlock() {
         // Upload the new index data
         var gl = this.device.gl;
 
@@ -179,9 +178,9 @@ Object.assign(IndexBuffer.prototype, {
 
         gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, this.bufferId);
         gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, this.storage, glUsage);
-    },
+    }
 
-    setData: function (data) {
+    setData(data) {
         if (data.byteLength !== this.numBytes) {
             // #ifdef DEBUG
             console.error("IndexBuffer: wrong initial data size: expected " + this.numBytes + ", got " + data.byteLength);
@@ -192,20 +191,18 @@ Object.assign(IndexBuffer.prototype, {
         this.storage = data;
         this.unlock();
         return true;
-    },
+    }
 
-    _lockTypedArray: function () {
-
+    _lockTypedArray() {
         var lock = this.lock();
         var indices = this.format === INDEXFORMAT_UINT32 ? new Uint32Array(lock) :
             (this.format === INDEXFORMAT_UINT16 ? new Uint16Array(lock) : new Uint8Array(lock) );
         return indices;
-    },
+    }
 
     // Copies count elements from data into index buffer.
     // optimized for performance from both typed array as well as array
-    writeData: function (data, count) {
-
+    writeData(data, count) {
         var indices = this._lockTypedArray();
 
         // if data contains more indices than needed, copy from its subarray
@@ -227,11 +224,10 @@ Object.assign(IndexBuffer.prototype, {
         }
 
         this.unlock();
-    },
+    }
 
     // copies index data from index buffer into provided data array
-    readData: function (data) {
-
+    readData(data) {
         // note: there is no need to unlock this buffer, as we are only reading from it
         var indices = this._lockTypedArray();
         var count = this.numIndices;
@@ -249,6 +245,6 @@ Object.assign(IndexBuffer.prototype, {
 
         return count;
     }
-});
+}
 
 export { IndexBuffer };

--- a/src/graphics/paraboloid.js
+++ b/src/graphics/paraboloid.js
@@ -60,8 +60,8 @@ function getDpAtlasRect(rect, mip) {
 }
 
 function generateDpAtlas(device, sixCubemaps, dontFlipX) {
-    var dp, rect;
-    rect = new Vec4();
+    var dp;
+    var rect = new Vec4();
     var params = new Vec4();
     var size = sixCubemaps[0].width * 2 * dpMult;
 

--- a/src/graphics/render-target.js
+++ b/src/graphics/render-target.js
@@ -164,14 +164,12 @@ class RenderTarget {
         if (!this._device.webgl2) return;
 
         var gl = this._device.gl;
-
         gl.bindFramebuffer(gl.READ_FRAMEBUFFER, this._glFrameBuffer);
         gl.bindFramebuffer(gl.DRAW_FRAMEBUFFER, this._glResolveFrameBuffer);
         gl.blitFramebuffer( 0, 0, this.width, this.height,
                             0, 0, this.width, this.height,
                             (color ? gl.COLOR_BUFFER_BIT : 0) | (depth ? gl.DEPTH_BUFFER_BIT : 0),
                             gl.NEAREST);
-
         gl.bindFramebuffer(gl.FRAMEBUFFER, this._glFrameBuffer);
     }
 

--- a/src/graphics/render-target.js
+++ b/src/graphics/render-target.js
@@ -47,61 +47,61 @@ var defaultOptions = {
  * // Set the render target on a layer
  * layer.renderTarget = renderTarget;
  */
-var RenderTarget = function (options) {
-    var _arg2 = arguments[1];
-    var _arg3 = arguments[2];
+class RenderTarget {
+    constructor(options) {
+        var _arg2 = arguments[1];
+        var _arg3 = arguments[2];
 
-    if (options instanceof GraphicsDevice) {
-        // old constructor
-        this._colorBuffer = _arg2;
-        options = _arg3;
-    } else {
-        // new constructor
-        this._colorBuffer = options.colorBuffer;
-    }
-
-    this._glFrameBuffer = null;
-    this._glDepthBuffer = null;
-
-    // Process optional arguments
-    options = (options !== undefined) ? options : defaultOptions;
-    this._depthBuffer = options.depthBuffer;
-    this._face = (options.face !== undefined) ? options.face : 0;
-
-    if (this._depthBuffer) {
-        var format = this._depthBuffer._format;
-        if (format === PIXELFORMAT_DEPTH) {
-            this._depth = true;
-            this._stencil = false;
-        } else if (format === PIXELFORMAT_DEPTHSTENCIL) {
-            this._depth = true;
-            this._stencil = true;
+        if (options instanceof GraphicsDevice) {
+            // old constructor
+            this._colorBuffer = _arg2;
+            options = _arg3;
         } else {
-            // #ifdef DEBUG
-            console.warn('Incorrect depthBuffer format. Must be pc.PIXELFORMAT_DEPTH or pc.PIXELFORMAT_DEPTHSTENCIL');
-            // #endif
-            this._depth = false;
-            this._stencil = false;
+            // new constructor
+            this._colorBuffer = options.colorBuffer;
         }
-    } else {
-        this._depth = (options.depth !== undefined) ? options.depth : true;
-        this._stencil = (options.stencil !== undefined) ? options.stencil : false;
+
+        this._glFrameBuffer = null;
+        this._glDepthBuffer = null;
+
+        // Process optional arguments
+        options = (options !== undefined) ? options : defaultOptions;
+        this._depthBuffer = options.depthBuffer;
+        this._face = (options.face !== undefined) ? options.face : 0;
+
+        if (this._depthBuffer) {
+            var format = this._depthBuffer._format;
+            if (format === PIXELFORMAT_DEPTH) {
+                this._depth = true;
+                this._stencil = false;
+            } else if (format === PIXELFORMAT_DEPTHSTENCIL) {
+                this._depth = true;
+                this._stencil = true;
+            } else {
+                // #ifdef DEBUG
+                console.warn('Incorrect depthBuffer format. Must be pc.PIXELFORMAT_DEPTH or pc.PIXELFORMAT_DEPTHSTENCIL');
+                // #endif
+                this._depth = false;
+                this._stencil = false;
+            }
+        } else {
+            this._depth = (options.depth !== undefined) ? options.depth : true;
+            this._stencil = (options.stencil !== undefined) ? options.stencil : false;
+        }
+
+        this._samples = (options.samples !== undefined) ? options.samples : 1;
+        this.autoResolve = (options.autoResolve !== undefined) ? options.autoResolve : true;
+        this._glResolveFrameBuffer = null;
+        this._glMsaaColorBuffer = null;
+        this._glMsaaDepthBuffer = null;
     }
 
-    this._samples = (options.samples !== undefined) ? options.samples : 1;
-    this.autoResolve = (options.autoResolve !== undefined) ? options.autoResolve : true;
-    this._glResolveFrameBuffer = null;
-    this._glMsaaColorBuffer = null;
-    this._glMsaaDepthBuffer = null;
-};
-
-Object.assign(RenderTarget.prototype, {
     /**
      * @function
      * @name pc.RenderTarget#destroy
      * @description Frees resources associated with this render target.
      */
-    destroy: function () {
+    destroy() {
         if (!this._device) return;
 
         var device = this._device;
@@ -135,16 +135,16 @@ Object.assign(RenderTarget.prototype, {
             gl.deleteRenderbuffer(this._glMsaaDepthBuffer);
             this._glMsaaDepthBuffer = null;
         }
-    },
+    }
 
     // called when context was lost, function releases all context related resources
-    loseContext: function () {
+    loseContext() {
         this._glFrameBuffer = undefined;
         this._glDepthBuffer = undefined;
         this._glResolveFrameBuffer = undefined;
         this._glMsaaColorBuffer = undefined;
         this._glMsaaDepthBuffer = undefined;
-    },
+    }
 
     /**
      * @function
@@ -156,16 +156,14 @@ Object.assign(RenderTarget.prototype, {
      * This function performs this averaging and updates the colorBuffer and the depthBuffer.
      * If autoResolve is set to true, the resolve will happen after every rendering to this render target, otherwise you can do it manually,
      * during the app update or inside a pc.Command.
-     * @param {boolean} color - Resolve color buffer.
-     * @param {boolean} depth - Resolve depth buffer.
+     * @param {boolean} [color] - Resolve color buffer. Defaults to true.
+     * @param {boolean} [depth] - Resolve depth buffer. Defaults to true if the render target has a depth buffer.
      */
-    resolve: function (color, depth) {
+    resolve(color = true, depth = !!this._depthBuffer) {
         if (!this._device) return;
         if (!this._device.webgl2) return;
-        var gl = this._device.gl;
 
-        if (color === undefined) color = true;
-        if (depth === undefined && this._depthBuffer) depth = true;
+        var gl = this._device.gl;
 
         gl.bindFramebuffer(gl.READ_FRAMEBUFFER, this._glFrameBuffer);
         gl.bindFramebuffer(gl.DRAW_FRAMEBUFFER, this._glResolveFrameBuffer);
@@ -175,7 +173,7 @@ Object.assign(RenderTarget.prototype, {
                             gl.NEAREST);
 
         gl.bindFramebuffer(gl.FRAMEBUFFER, this._glFrameBuffer);
-    },
+    }
 
     /**
      * @function
@@ -187,7 +185,7 @@ Object.assign(RenderTarget.prototype, {
      * @param {boolean} [depth] - If true will copy the depth buffer. Defaults to false.
      * @returns {boolean} True if the copy was successful, false otherwise.
      */
-    copy: function (source, color, depth) {
+    copy(source, color, depth) {
         if (!this._device) {
             if (source._device) {
                 this._device = source._device;
@@ -200,75 +198,65 @@ Object.assign(RenderTarget.prototype, {
         }
         return this._device.copyRenderTarget(source, this, color, depth);
     }
-});
 
-/**
- * @readonly
- * @name pc.RenderTarget#colorBuffer
- * @type {pc.Texture}
- * @description Color buffer set up on the render target.
- */
-Object.defineProperty(RenderTarget.prototype, 'colorBuffer', {
-    get: function () {
+    /**
+     * @readonly
+     * @name pc.RenderTarget#colorBuffer
+     * @type {pc.Texture}
+     * @description Color buffer set up on the render target.
+     */
+    get colorBuffer() {
         return this._colorBuffer;
     }
-});
 
-/**
- * @readonly
- * @name pc.RenderTarget#depthBuffer
- * @type {pc.Texture}
- * @description Depth buffer set up on the render target. Only available, if depthBuffer was set in constructor.
- * Not available, if depth property was used instead.
- */
-Object.defineProperty(RenderTarget.prototype, 'depthBuffer', {
-    get: function () {
+    /**
+     * @readonly
+     * @name pc.RenderTarget#depthBuffer
+     * @type {pc.Texture}
+     * @description Depth buffer set up on the render target. Only available, if depthBuffer was set in constructor.
+     * Not available, if depth property was used instead.
+     */
+    get depthBuffer() {
         return this._depthBuffer;
     }
-});
 
-/**
- * @readonly
- * @name pc.RenderTarget#face
- * @type {number}
- * @description If the render target is bound to a cubemap, this property
- * specifies which face of the cubemap is rendered to. Can be:
- *
- * * {@link pc.CUBEFACE_POSX}
- * * {@link pc.CUBEFACE_NEGX}
- * * {@link pc.CUBEFACE_POSY}
- * * {@link pc.CUBEFACE_NEGY}
- * * {@link pc.CUBEFACE_POSZ}
- * * {@link pc.CUBEFACE_NEGZ}
- */
-Object.defineProperty(RenderTarget.prototype, 'face', {
-    get: function () {
+    /**
+     * @readonly
+     * @name pc.RenderTarget#face
+     * @type {number}
+     * @description If the render target is bound to a cubemap, this property
+     * specifies which face of the cubemap is rendered to. Can be:
+     *
+     * * {@link pc.CUBEFACE_POSX}
+     * * {@link pc.CUBEFACE_NEGX}
+     * * {@link pc.CUBEFACE_POSY}
+     * * {@link pc.CUBEFACE_NEGY}
+     * * {@link pc.CUBEFACE_POSZ}
+     * * {@link pc.CUBEFACE_NEGZ}
+     */
+    get face() {
         return this._face;
     }
-});
 
-/**
- * @readonly
- * @name pc.RenderTarget#width
- * @type {number}
- * @description Width of the render target in pixels.
- */
-Object.defineProperty(RenderTarget.prototype, 'width', {
-    get: function () {
+    /**
+     * @readonly
+     * @name pc.RenderTarget#width
+     * @type {number}
+     * @description Width of the render target in pixels.
+     */
+    get width() {
         return this._colorBuffer ? this._colorBuffer.width : this._depthBuffer.width;
     }
-});
 
-/**
- * @readonly
- * @name pc.RenderTarget#height
- * @type {number}
- * @description Height of the render target in pixels.
- */
-Object.defineProperty(RenderTarget.prototype, 'height', {
-    get: function () {
+    /**
+     * @readonly
+     * @name pc.RenderTarget#height
+     * @type {number}
+     * @description Height of the render target in pixels.
+     */
+    get height() {
         return this._colorBuffer ? this._colorBuffer.height : this._depthBuffer.height;
     }
-});
+}
 
 export { RenderTarget };

--- a/src/graphics/scope-id.js
+++ b/src/graphics/scope-id.js
@@ -7,31 +7,31 @@ import { VersionedObject } from './versioned-object.js';
  * @param {string} name - The variable name.
  * @property {string} name The variable name.
  */
-function ScopeId(name) {
-    // Set the name
-    this.name = name;
+class ScopeId {
+    constructor(name) {
+        // Set the name
+        this.name = name;
 
-    // Set the default value
-    this.value = null;
+        // Set the default value
+        this.value = null;
 
-    // Create the version object
-    this.versionObject = new VersionedObject();
-}
+        // Create the version object
+        this.versionObject = new VersionedObject();
+    }
 
-Object.assign(ScopeId.prototype, {
     /**
      * @function
      * @name pc.ScopeId#setValue
      * @description Set variable value.
      * @param {*} value - The value.
      */
-    setValue: function (value) {
+    setValue(value) {
         // Set the new value
         this.value = value;
 
         // Increment the revision
         this.versionObject.increment();
-    },
+    }
 
     /**
      * @function
@@ -39,9 +39,9 @@ Object.assign(ScopeId.prototype, {
      * @description Get variable value.
      * @returns {*} The value.
      */
-    getValue: function () {
+    getValue() {
         return this.value;
     }
-});
+}
 
 export { ScopeId };

--- a/src/graphics/scope-space.js
+++ b/src/graphics/scope-space.js
@@ -7,16 +7,16 @@ import { ScopeId } from './scope-id.js';
  * @param {string} name - The scope name.
  * @property {string} name The scope name.
  */
-function ScopeSpace(name) {
-    // Store the name
-    this.name = name;
+class ScopeSpace {
+    constructor(name) {
+        // Store the name
+        this.name = name;
 
-    // Create the empty tables
-    this.variables = {};
-    this.namespaces = {};
-}
+        // Create the empty tables
+        this.variables = {};
+        this.namespaces = {};
+    }
 
-Object.assign(ScopeSpace.prototype, {
     /**
      * @function
      * @name pc.ScopeSpace#resolve
@@ -24,7 +24,7 @@ Object.assign(ScopeSpace.prototype, {
      * @param {string} name - The variable name.
      * @returns {pc.ScopeId} The variable instance.
      */
-    resolve: function (name) {
+    resolve(name) {
         // Check if the ScopeId already exists
         if (!this.variables.hasOwnProperty(name)) {
             // Create and add to the table
@@ -33,7 +33,7 @@ Object.assign(ScopeSpace.prototype, {
 
         // Now return the ScopeId instance
         return this.variables[name];
-    },
+    }
 
     /**
      * @function
@@ -42,7 +42,7 @@ Object.assign(ScopeSpace.prototype, {
      * @param {string} name - The subspace name.
      * @returns {pc.ScopeSpace} The subspace instance.
      */
-    getSubSpace: function (name) {
+    getSubSpace(name) {
         // Check if the nested namespace already exists
         if (!this.namespaces.hasOwnProperty(name)) {
             // Create and add to the table
@@ -52,6 +52,6 @@ Object.assign(ScopeSpace.prototype, {
         // Now return the ScopeNamespace instance
         return this.namespaces[name];
     }
-});
+}
 
 export { ScopeSpace };

--- a/src/graphics/shader-input.js
+++ b/src/graphics/shader-input.js
@@ -2,33 +2,35 @@ import { UNIFORMTYPE_FLOAT, UNIFORMTYPE_FLOATARRAY, UNIFORMTYPE_VEC2, UNIFORMTYP
     UNIFORMTYPE_VEC2ARRAY, UNIFORMTYPE_VEC3ARRAY, UNIFORMTYPE_VEC4ARRAY } from './graphics.js';
 import { Version } from './version.js';
 
-function ShaderInput(graphicsDevice, name, type, locationId) {
-    // Set the shader attribute location
-    this.locationId = locationId;
+class ShaderInput {
+    constructor(graphicsDevice, name, type, locationId) {
+        // Set the shader attribute location
+        this.locationId = locationId;
 
-    // Resolve the ScopeId for the attribute name
-    this.scopeId = graphicsDevice.scope.resolve(name);
+        // Resolve the ScopeId for the attribute name
+        this.scopeId = graphicsDevice.scope.resolve(name);
 
-    // Create the version
-    this.version = new Version();
+        // Create the version
+        this.version = new Version();
 
-    // custom data type for arrays
-    if (name.substr(name.length - 3) === "[0]") {
-        switch (type) {
-            case UNIFORMTYPE_FLOAT: type = UNIFORMTYPE_FLOATARRAY; break;
-            case UNIFORMTYPE_VEC2: type = UNIFORMTYPE_VEC2ARRAY; break;
-            case UNIFORMTYPE_VEC3: type = UNIFORMTYPE_VEC3ARRAY; break;
-            case UNIFORMTYPE_VEC4: type = UNIFORMTYPE_VEC4ARRAY; break;
+        // custom data type for arrays
+        if (name.substr(name.length - 3) === "[0]") {
+            switch (type) {
+                case UNIFORMTYPE_FLOAT: type = UNIFORMTYPE_FLOATARRAY; break;
+                case UNIFORMTYPE_VEC2: type = UNIFORMTYPE_VEC2ARRAY; break;
+                case UNIFORMTYPE_VEC3: type = UNIFORMTYPE_VEC3ARRAY; break;
+                case UNIFORMTYPE_VEC4: type = UNIFORMTYPE_VEC4ARRAY; break;
+            }
         }
+
+        // Set the data dataType
+        this.dataType = type;
+
+        this.value = [null, null, null, null];
+
+        // Array to hold texture unit ids
+        this.array = [];
     }
-
-    // Set the data dataType
-    this.dataType = type;
-
-    this.value = [null, null, null, null];
-
-    // Array to hold texture unit ids
-    this.array = [];
 }
 
 export { ShaderInput };

--- a/src/graphics/shader.js
+++ b/src/graphics/shader.js
@@ -42,39 +42,38 @@
  *
  * var shader = new pc.Shader(graphicsDevice, shaderDefinition);
  */
-function Shader(graphicsDevice, definition) {
-    this.device = graphicsDevice;
-    this.definition = definition;
+class Shader {
+    constructor(graphicsDevice, definition) {
+        this.device = graphicsDevice;
+        this.definition = definition;
 
-    this.init();
+        this.init();
 
-    this.device.createShader(this);
-}
+        this.device.createShader(this);
+    }
 
-Object.assign(Shader.prototype, {
-
-    init: function () {
+    init() {
         this.attributes = [];
         this.uniforms = [];
         this.samplers = [];
 
         this.ready = false;
         this.failed = false;
-    },
+    }
 
     /**
      * @function
      * @name pc.Shader#destroy
      * @description Frees resources associated with this shader.
      */
-    destroy: function () {
+    destroy() {
         this.device.destroyShader(this);
-    },
+    }
 
     // called when context was lost, function releases all context related resources
-    loseContext: function () {
+    loseContext() {
         this.init();
     }
-});
+}
 
 export { Shader };

--- a/src/graphics/simple-post-effect.js
+++ b/src/graphics/simple-post-effect.js
@@ -23,7 +23,7 @@ var _postEffectQuadDraw = {
  * @param {pc.Vec4} [scissorRect] - The scissor rectangle of the quad, in pixels. Defaults to fullscreen (`0, 0, target.width, target.height`).
  * @param {boolean} [useBlend] - True to enable blending. Defaults to false, disabling blending.
  */
-function drawQuadWithShader(device, target, shader, rect, scissorRect, useBlend) {
+function drawQuadWithShader(device, target, shader, rect, scissorRect, useBlend = false) {
     if (_postEffectQuadVB === null) {
         var vertexFormat = new VertexFormat(device, [{
             semantic: SEMANTIC_POSITION,
@@ -135,7 +135,7 @@ function destroyPostEffectQuad() {
  * @param {pc.Vec4} [scissorRect] - The scissor rectangle to use for the texture, in pixels. Defaults to fullscreen (`0, 0, target.width, target.height`).
  * @param {boolean} [useBlend] - True to enable blending. Defaults to false, disabling blending.
  */
-function drawTexture(device, texture, target, shader, rect, scissorRect, useBlend) {
+function drawTexture(device, texture, target, shader, rect, scissorRect, useBlend = false) {
     shader = shader || device.getCopyShader();
     device.constantTexSource.setValue(texture);
     drawQuadWithShader(device, target, shader, rect, scissorRect, useBlend);

--- a/src/graphics/texture.js
+++ b/src/graphics/texture.js
@@ -15,6 +15,9 @@ import {
     TEXTURETYPE_DEFAULT, TEXTURETYPE_RGBM, TEXTURETYPE_SWIZZLEGGGR
 } from './graphics.js';
 
+var _pixelSizeTable = null;
+var _blockSizeTable = null;
+
 /**
  * @class
  * @name pc.Texture
@@ -102,116 +105,116 @@ import {
  * texture.unlock();
  * @property {string} name The name of the texture. Defaults to null.
  */
-function Texture(graphicsDevice, options) {
-    this.device = graphicsDevice;
+class Texture {
+    constructor(graphicsDevice, options) {
+        this.device = graphicsDevice;
 
-    this.name = null;
-    this._width = 4;
-    this._height = 4;
-    this._depth = 1;
+        this.name = null;
+        this._width = 4;
+        this._height = 4;
+        this._depth = 1;
 
-    this._format = PIXELFORMAT_R8_G8_B8_A8;
-    this.type = TEXTURETYPE_DEFAULT;
+        this._format = PIXELFORMAT_R8_G8_B8_A8;
+        this.type = TEXTURETYPE_DEFAULT;
 
-    this._cubemap = false;
-    this._volume = false;
-    this.fixCubemapSeams = false;
-    this._flipY = true;
-    this._premultiplyAlpha = false;
+        this._cubemap = false;
+        this._volume = false;
+        this.fixCubemapSeams = false;
+        this._flipY = true;
+        this._premultiplyAlpha = false;
 
-    this._isRenderTarget = false;
+        this._isRenderTarget = false;
 
-    this._mipmaps = true;
+        this._mipmaps = true;
 
-    this._minFilter = FILTER_LINEAR_MIPMAP_LINEAR;
-    this._magFilter = FILTER_LINEAR;
-    this._anisotropy = 1;
-    this._addressU = ADDRESS_REPEAT;
-    this._addressV = ADDRESS_REPEAT;
-    this._addressW = ADDRESS_REPEAT;
+        this._minFilter = FILTER_LINEAR_MIPMAP_LINEAR;
+        this._magFilter = FILTER_LINEAR;
+        this._anisotropy = 1;
+        this._addressU = ADDRESS_REPEAT;
+        this._addressV = ADDRESS_REPEAT;
+        this._addressW = ADDRESS_REPEAT;
 
-    this._compareOnRead = false;
-    this._compareFunc = FUNC_LESS;
-
-    // #ifdef PROFILER
-    this.profilerHint = 0;
-    // #endif
-
-    if (options !== undefined) {
-        if (options.name !== undefined) {
-            this.name = options.name;
-        }
-        this._width = (options.width !== undefined) ? options.width : this._width;
-        this._height = (options.height !== undefined) ? options.height : this._height;
-
-        this._format = (options.format !== undefined) ? options.format : this._format;
-
-        if (options.hasOwnProperty('type')) {
-            this.type = options.type;
-        } else if (options.hasOwnProperty('rgbm')) {
-            // #ifdef DEBUG
-            console.warn("DEPRECATED: options.rgbm is deprecated. Use options.type instead.");
-            // #endif
-            this.type = options.rgbm ? TEXTURETYPE_RGBM : TEXTURETYPE_DEFAULT;
-        } else if (options.hasOwnProperty('swizzleGGGR')) {
-            // #ifdef DEBUG
-            console.warn("DEPRECATED: options.swizzleGGGR is deprecated. Use options.type instead.");
-            // #endif
-            this.type = options.swizzleGGGR ? TEXTURETYPE_SWIZZLEGGGR : TEXTURETYPE_DEFAULT;
-        }
-
-        if (options.mipmaps !== undefined) {
-            this._mipmaps = options.mipmaps;
-        } else {
-            this._mipmaps = (options.autoMipmap !== undefined) ? options.autoMipmap : this._mipmaps;
-        }
-
-        this._levels = options.levels;
-
-        this._cubemap = (options.cubemap !== undefined) ? options.cubemap : this._cubemap;
-        this.fixCubemapSeams = (options.fixCubemapSeams !== undefined) ? options.fixCubemapSeams : this.fixCubemapSeams;
-
-        this._minFilter = (options.minFilter !== undefined) ? options.minFilter : this._minFilter;
-        this._magFilter = (options.magFilter !== undefined) ? options.magFilter : this._magFilter;
-        this._anisotropy = (options.anisotropy !== undefined) ? options.anisotropy : this._anisotropy;
-        this._addressU = (options.addressU !== undefined) ? options.addressU : this._addressU;
-        this._addressV = (options.addressV !== undefined) ? options.addressV : this._addressV;
-
-        this._compareOnRead = (options.compareOnRead !== undefined) ? options.compareOnRead : this._compareOnRead;
-        this._compareFunc = (options._compareFunc !== undefined) ? options._compareFunc : this._compareFunc;
-
-        this._flipY = (options.flipY !== undefined) ? options.flipY : this._flipY;
-        this._premultiplyAlpha = (options.premultiplyAlpha !== undefined) ? options.premultiplyAlpha : this._premultiplyAlpha;
-
-        if (graphicsDevice.webgl2) {
-            this._depth = (options.depth !== undefined) ? options.depth : this._depth;
-            this._volume = (options.volume !== undefined) ? options.volume : this._volume;
-            this._addressW = (options.addressW !== undefined) ? options.addressW : this._addressW;
-        }
+        this._compareOnRead = false;
+        this._compareFunc = FUNC_LESS;
 
         // #ifdef PROFILER
-        this.profilerHint = (options.profilerHint !== undefined) ? options.profilerHint : this.profilerHint;
+        this.profilerHint = 0;
         // #endif
+
+        if (options !== undefined) {
+            if (options.name !== undefined) {
+                this.name = options.name;
+            }
+            this._width = (options.width !== undefined) ? options.width : this._width;
+            this._height = (options.height !== undefined) ? options.height : this._height;
+
+            this._format = (options.format !== undefined) ? options.format : this._format;
+
+            if (options.hasOwnProperty('type')) {
+                this.type = options.type;
+            } else if (options.hasOwnProperty('rgbm')) {
+                // #ifdef DEBUG
+                console.warn("DEPRECATED: options.rgbm is deprecated. Use options.type instead.");
+                // #endif
+                this.type = options.rgbm ? TEXTURETYPE_RGBM : TEXTURETYPE_DEFAULT;
+            } else if (options.hasOwnProperty('swizzleGGGR')) {
+                // #ifdef DEBUG
+                console.warn("DEPRECATED: options.swizzleGGGR is deprecated. Use options.type instead.");
+                // #endif
+                this.type = options.swizzleGGGR ? TEXTURETYPE_SWIZZLEGGGR : TEXTURETYPE_DEFAULT;
+            }
+
+            if (options.mipmaps !== undefined) {
+                this._mipmaps = options.mipmaps;
+            } else {
+                this._mipmaps = (options.autoMipmap !== undefined) ? options.autoMipmap : this._mipmaps;
+            }
+
+            this._levels = options.levels;
+
+            this._cubemap = (options.cubemap !== undefined) ? options.cubemap : this._cubemap;
+            this.fixCubemapSeams = (options.fixCubemapSeams !== undefined) ? options.fixCubemapSeams : this.fixCubemapSeams;
+
+            this._minFilter = (options.minFilter !== undefined) ? options.minFilter : this._minFilter;
+            this._magFilter = (options.magFilter !== undefined) ? options.magFilter : this._magFilter;
+            this._anisotropy = (options.anisotropy !== undefined) ? options.anisotropy : this._anisotropy;
+            this._addressU = (options.addressU !== undefined) ? options.addressU : this._addressU;
+            this._addressV = (options.addressV !== undefined) ? options.addressV : this._addressV;
+
+            this._compareOnRead = (options.compareOnRead !== undefined) ? options.compareOnRead : this._compareOnRead;
+            this._compareFunc = (options._compareFunc !== undefined) ? options._compareFunc : this._compareFunc;
+
+            this._flipY = (options.flipY !== undefined) ? options.flipY : this._flipY;
+            this._premultiplyAlpha = (options.premultiplyAlpha !== undefined) ? options.premultiplyAlpha : this._premultiplyAlpha;
+
+            if (graphicsDevice.webgl2) {
+                this._depth = (options.depth !== undefined) ? options.depth : this._depth;
+                this._volume = (options.volume !== undefined) ? options.volume : this._volume;
+                this._addressW = (options.addressW !== undefined) ? options.addressW : this._addressW;
+            }
+
+            // #ifdef PROFILER
+            this.profilerHint = (options.profilerHint !== undefined) ? options.profilerHint : this.profilerHint;
+            // #endif
+        }
+
+        this._compressed = (this._format === PIXELFORMAT_DXT1 ||
+                            this._format === PIXELFORMAT_DXT3 ||
+                            this._format === PIXELFORMAT_DXT5 ||
+                            this._format >= PIXELFORMAT_ETC1);
+
+        // Mip levels
+        this._invalid = false;
+        this._lockedLevel = -1;
+        if (!this._levels) {
+            this._levels = this._cubemap ? [[null, null, null, null, null, null]] : [null];
+        }
+
+        this.dirtyAll();
+
+        this._gpuSize = 0;
     }
 
-    this._compressed = (this._format === PIXELFORMAT_DXT1 ||
-                        this._format === PIXELFORMAT_DXT3 ||
-                        this._format === PIXELFORMAT_DXT5 ||
-                        this._format >= PIXELFORMAT_ETC1);
-
-    // Mip levels
-    this._invalid = false;
-    this._lockedLevel = -1;
-    if (!this._levels) {
-        this._levels = this._cubemap ? [[null, null, null, null, null, null]] : [null];
-    }
-
-    this.dirtyAll();
-
-    this._gpuSize = 0;
-}
-
-Object.defineProperties(Texture.prototype, {
     /**
      * @name pc.Texture#minFilter
      * @type {number}
@@ -223,17 +226,16 @@ Object.defineProperties(Texture.prototype, {
      * * {@link pc.FILTER_LINEAR_MIPMAP_NEAREST}
      * * {@link pc.FILTER_LINEAR_MIPMAP_LINEAR}
      */
-    minFilter: {
-        get: function () {
-            return this._minFilter;
-        },
-        set: function (v) {
-            if (this._minFilter !== v) {
-                this._minFilter = v;
-                this._parameterFlags |= 1;
-            }
+    get minFilter() {
+        return this._minFilter;
+    }
+
+    set minFilter(v) {
+        if (this._minFilter !== v) {
+            this._minFilter = v;
+            this._parameterFlags |= 1;
         }
-    },
+    }
 
     /**
      * @name pc.Texture#magFilter
@@ -242,17 +244,16 @@ Object.defineProperties(Texture.prototype, {
      * * {@link pc.FILTER_NEAREST}
      * * {@link pc.FILTER_LINEAR}
      */
-    magFilter: {
-        get: function () {
-            return this._magFilter;
-        },
-        set: function (v) {
-            if (this._magFilter !== v) {
-                this._magFilter = v;
-                this._parameterFlags |= 2;
-            }
+    get magFilter() {
+        return this._magFilter;
+    }
+
+    set magFilter(v) {
+        if (this._magFilter !== v) {
+            this._magFilter = v;
+            this._parameterFlags |= 2;
         }
-    },
+    }
 
     /**
      * @name pc.Texture#addressU
@@ -262,17 +263,16 @@ Object.defineProperties(Texture.prototype, {
      * * {@link pc.ADDRESS_CLAMP_TO_EDGE}
      * * {@link pc.ADDRESS_MIRRORED_REPEAT}
      */
-    addressU: {
-        get: function () {
-            return this._addressU;
-        },
-        set: function (v) {
-            if (this._addressU !== v) {
-                this._addressU = v;
-                this._parameterFlags |= 4;
-            }
+    get addressU() {
+        return this._addressU;
+    }
+
+    set addressU(v) {
+        if (this._addressU !== v) {
+            this._addressU = v;
+            this._parameterFlags |= 4;
         }
-    },
+    }
 
     /**
      * @name pc.Texture#addressV
@@ -282,17 +282,16 @@ Object.defineProperties(Texture.prototype, {
      * * {@link pc.ADDRESS_CLAMP_TO_EDGE}
      * * {@link pc.ADDRESS_MIRRORED_REPEAT}
      */
-    addressV: {
-        get: function () {
-            return this._addressV;
-        },
-        set: function (v) {
-            if (this._addressV !== v) {
-                this._addressV = v;
-                this._parameterFlags |= 8;
-            }
+    get addressV() {
+        return this._addressV;
+    }
+
+    set addressV(v) {
+        if (this._addressV !== v) {
+            this._addressV = v;
+            this._parameterFlags |= 8;
         }
-    },
+    }
 
     /**
      * @name pc.Texture#addressW
@@ -302,24 +301,23 @@ Object.defineProperties(Texture.prototype, {
      * * {@link pc.ADDRESS_CLAMP_TO_EDGE}
      * * {@link pc.ADDRESS_MIRRORED_REPEAT}
      */
-    addressW: {
-        get: function () {
-            return this._addressW;
-        },
-        set: function (addressW) {
-            if (!this.device.webgl2) return;
-            if (!this._volume) {
-                // #ifdef DEBUG
-                console.warn("pc.Texture#addressW: Can't set W addressing mode for a non-3D texture.");
-                // #endif
-                return;
-            }
-            if (addressW !== this._addressW) {
-                this._addressW = addressW;
-                this._parameterFlags |= 16;
-            }
+    get addressW() {
+        return this._addressW;
+    }
+
+    set addressW(addressW) {
+        if (!this.device.webgl2) return;
+        if (!this._volume) {
+            // #ifdef DEBUG
+            console.warn("pc.Texture#addressW: Can't set W addressing mode for a non-3D texture.");
+            // #endif
+            return;
         }
-    },
+        if (addressW !== this._addressW) {
+            this._addressW = addressW;
+            this._parameterFlags |= 16;
+        }
+    }
 
     /**
      * @name pc.Texture#compareOnRead
@@ -327,17 +325,16 @@ Object.defineProperties(Texture.prototype, {
      * @description When enabled, and if texture format is pc.PIXELFORMAT_DEPTH or pc.PIXELFORMAT_DEPTHSTENCIL,
      * hardware PCF is enabled for this texture, and you can get filtered results of comparison using texture() in your shader (WebGL2 only).
      */
-    compareOnRead: {
-        get: function () {
-            return this._compareOnRead;
-        },
-        set: function (v) {
-            if (this._compareOnRead !== v) {
-                this._compareOnRead = v;
-                this._parameterFlags |= 32;
-            }
+    get compareOnRead() {
+        return this._compareOnRead;
+    }
+
+    set compareOnRead(v) {
+        if (this._compareOnRead !== v) {
+            this._compareOnRead = v;
+            this._parameterFlags |= 32;
         }
-    },
+    }
 
     /**
      * @name pc.Texture#compareFunc
@@ -351,17 +348,16 @@ Object.defineProperties(Texture.prototype, {
      * * {@link pc.FUNC_EQUAL}
      * * {@link pc.FUNC_NOTEQUAL}
      */
-    compareFunc: {
-        get: function () {
-            return this._compareFunc;
-        },
-        set: function (v) {
-            if (this._compareFunc !== v) {
-                this._compareFunc = v;
-                this._parameterFlags |= 64;
-            }
+    get compareFunc() {
+        return this._compareFunc;
+    }
+
+    set compareFunc(v) {
+        if (this._compareFunc !== v) {
+            this._compareFunc = v;
+            this._parameterFlags |= 64;
         }
-    },
+    }
 
     /**
      * @name pc.Texture#anisotropy
@@ -369,17 +365,16 @@ Object.defineProperties(Texture.prototype, {
      * @description Integer value specifying the level of anisotropic to apply to the texture
      * ranging from 1 (no anisotropic filtering) to the {@link pc.GraphicsDevice} property maxAnisotropy.
      */
-    anisotropy: {
-        get: function () {
-            return this._anisotropy;
-        },
-        set: function (v) {
-            if (this._anisotropy !== v) {
-                this._anisotropy = v;
-                this._parameterFlags |= 128;
-            }
+    get anisotropy() {
+        return this._anisotropy;
+    }
+
+    set anisotropy(v) {
+        if (this._anisotropy !== v) {
+            this._anisotropy = v;
+            this._parameterFlags |= 128;
         }
-    },
+    }
 
     /**
      * @private
@@ -388,33 +383,31 @@ Object.defineProperties(Texture.prototype, {
      * @type {boolean}
      * @description Toggles automatic mipmap generation. Can't be used on non power of two textures.
      */
-    autoMipmap: {
-        get: function () {
-            return this._mipmaps;
-        },
-        set: function (v) {
-            this._mipmaps = v;
-        }
-    },
+    get autoMipmap() {
+        return this._mipmaps;
+    }
+
+    set autoMipmap(v) {
+        this._mipmaps = v;
+    }
 
     /**
      * @name pc.Texture#mipmaps
      * @type {boolean}
      * @description Defines if texture should generate/upload mipmaps if possible.
      */
-    mipmaps: {
-        get: function () {
-            return this._mipmaps;
-        },
-        set: function (v) {
-            if (this._mipmaps !== v) {
-                this._mipmaps = v;
-                this._minFilterDirty = true;
+    get mipmaps() {
+        return this._mipmaps;
+    }
 
-                if (v) this._needsMipmapsUpload = true;
-            }
+    set mipmaps(v) {
+        if (this._mipmaps !== v) {
+            this._mipmaps = v;
+            this._minFilterDirty = true;
+
+            if (v) this._needsMipmapsUpload = true;
         }
-    },
+    }
 
     /**
      * @readonly
@@ -422,11 +415,9 @@ Object.defineProperties(Texture.prototype, {
      * @type {number}
      * @description The width of the texture in pixels.
      */
-    width: {
-        get: function () {
-            return this._width;
-        }
-    },
+    get width() {
+        return this._width;
+    }
 
     /**
      * @readonly
@@ -434,11 +425,9 @@ Object.defineProperties(Texture.prototype, {
      * @type {number}
      * @description The height of the texture in pixels.
      */
-    height: {
-        get: function () {
-            return this._height;
-        }
-    },
+    get height() {
+        return this._height;
+    }
 
     /**
      * @readonly
@@ -446,11 +435,9 @@ Object.defineProperties(Texture.prototype, {
      * @type {number}
      * @description The number of depth slices in a 3D texture (WebGL2 only).
      */
-    depth: {
-        get: function () {
-            return this._depth;
-        }
-    },
+    get depth() {
+        return this._depth;
+    }
 
     /**
      * @readonly
@@ -482,11 +469,9 @@ Object.defineProperties(Texture.prototype, {
      * * {@link pc.PIXELFORMAT_ATC_RGB}
      * * {@link pc.PIXELFORMAT_ATC_RGBA}
      */
-    format: {
-        get: function () {
-            return this._format;
-        }
-    },
+    get format() {
+        return this._format;
+    }
 
     /**
      * @readonly
@@ -494,18 +479,14 @@ Object.defineProperties(Texture.prototype, {
      * @type {boolean}
      * @description Returns true if this texture is a cube map and false otherwise.
      */
-    cubemap: {
-        get: function () {
-            return this._cubemap;
-        }
-    },
+    get cubemap() {
+        return this._cubemap;
+    }
 
-    gpuSize: {
-        get: function () {
-            var mips = this.pot && this._mipmaps && !(this._compressed && this._levels.length === 1);
-            return Texture.calcGpuSize(this._width, this._height, this._depth, this._format, mips, this._cubemap);
-        }
-    },
+    get gpuSize() {
+        var mips = this.pot && this._mipmaps && !(this._compressed && this._levels.length === 1);
+        return Texture.calcGpuSize(this._width, this._height, this._depth, this._format, mips, this._cubemap);
+    }
 
     /**
      * @readonly
@@ -513,11 +494,9 @@ Object.defineProperties(Texture.prototype, {
      * @type {boolean}
      * @description Returns true if this texture is a 3D volume and false otherwise.
      */
-    volume: {
-        get: function () {
-            return this._volume;
-        }
-    },
+    get volume() {
+        return this._volume;
+    }
 
     /**
      * @name pc.Texture#flipY
@@ -526,29 +505,27 @@ Object.defineProperties(Texture.prototype, {
      * with a source that is an image, canvas or video element. Does not affect cubemaps, compressed textures
      * or textures set from raw pixel data. Defaults to true.
      */
-    flipY: {
-        get: function () {
-            return this._flipY;
-        },
-        set: function (flipY) {
-            if (this._flipY !== flipY) {
-                this._flipY = flipY;
-                this._needsUpload = true;
-            }
-        }
-    },
+    get flipY() {
+        return this._flipY;
+    }
 
-    premultiplyAlpha: {
-        get: function () {
-            return this._premultiplyAlpha;
-        },
-        set: function (premultiplyAlpha) {
-            if (this._premultiplyAlpha !== premultiplyAlpha) {
-                this._premultiplyAlpha = premultiplyAlpha;
-                this._needsUpload = true;
-            }
+    set flipY(flipY) {
+        if (this._flipY !== flipY) {
+            this._flipY = flipY;
+            this._needsUpload = true;
         }
-    },
+    }
+
+    get premultiplyAlpha() {
+        return this._premultiplyAlpha;
+    }
+
+    set premultiplyAlpha(premultiplyAlpha) {
+        if (this._premultiplyAlpha !== premultiplyAlpha) {
+            this._premultiplyAlpha = premultiplyAlpha;
+            this._needsUpload = true;
+        }
+    }
 
     /**
      * @readonly
@@ -556,18 +533,11 @@ Object.defineProperties(Texture.prototype, {
      * @type {boolean}
      * @description Returns true if all dimensions of the texture are power of two, and false otherwise.
      */
-    pot: {
-        get: function () {
-            return math.powerOfTwo(this._width) && math.powerOfTwo(this._height);
-        }
+    get pot() {
+        return math.powerOfTwo(this._width) && math.powerOfTwo(this._height);
     }
-});
 
-var _pixelSizeTable = null;
-var _blockSizeTable = null;
-
-// static functions
-Object.assign(Texture, {
+    // static functions
     /**
      * @private
      * @function
@@ -581,7 +551,7 @@ Object.assign(Texture, {
      * @param {boolean} [cubemap] - True is the texture is a cubemap, false otherwise.
      * @returns {number} The amount of GPU memory required for the texture, in bytes.
      */
-    calcGpuSize: function (width, height, depth, format, mipmaps, cubemap) {
+    static calcGpuSize(width, height, depth, format, mipmaps, cubemap) {
         if (!_pixelSizeTable) {
             _pixelSizeTable = [];
             _pixelSizeTable[PIXELFORMAT_A8] = 1;
@@ -653,25 +623,23 @@ Object.assign(Texture, {
 
         return result * (cubemap ? 6 : 1);
     }
-});
 
-// Public methods
-Object.assign(Texture.prototype, {
+    // Public methods
     /**
      * @function
      * @name pc.Texture#destroy
      * @description Forcibly free up the underlying WebGL resource owned by the texture.
      */
-    destroy: function () {
+    destroy() {
         if (this.device) {
             this.device.destroyTexture(this);
         }
         this.device = null;
         this._levels = this._cubemap ? [[null, null, null, null, null, null]] : [null];
-    },
+    }
 
     // Force a full resubmission of the texture to WebGL (used on a context restore event)
-    dirtyAll: function () {
+    dirtyAll() {
         this._levelsUpdated = this._cubemap ? [[true, true, true, true, true, true]] : [true];
 
         this._needsUpload = true;
@@ -679,7 +647,7 @@ Object.assign(Texture.prototype, {
         this._mipmapsUploaded = false;
 
         this._parameterFlags = 255; // 1 | 2 | 4 | 8 | 16 | 32 | 64 | 128
-    },
+    }
 
     /**
      * @function
@@ -690,9 +658,8 @@ Object.assign(Texture.prototype, {
      * @param {number} [options.face] - If the texture is a cubemap, this is the index of the face to lock.
      * @returns {Uint8Array|Uint16Array|Float32Array} A typed array containing the pixel data of the locked mip level.
      */
-    lock: function (options) {
+    lock(options = {}) {
         // Initialize options to some sensible defaults
-        options = options || { level: 0, face: 0, mode: TEXTURELOCK_WRITE };
         if (options.level === undefined) {
             options.level = 0;
         }
@@ -748,7 +715,7 @@ Object.assign(Texture.prototype, {
         }
 
         return this._levels[options.level];
-    },
+    }
 
     /**
      * @function
@@ -760,12 +727,10 @@ Object.assign(Texture.prototype, {
      * @param {number} [mipLevel] - A non-negative integer specifying the image level of detail. Defaults to 0, which represents the base image source.
      * A level value of N, that is greater than 0, represents the image source for the Nth mipmap reduction level.
      */
-    setSource: function (source, mipLevel) {
+    setSource(source, mipLevel = 0) {
         var i;
         var invalid = false;
         var width, height;
-
-        mipLevel = mipLevel || 0;
 
         if (this._cubemap) {
             if (source[0]) {
@@ -845,7 +810,7 @@ Object.assign(Texture.prototype, {
             // reupload
             this.upload();
         }
-    },
+    }
 
     /**
      * @function
@@ -856,17 +821,16 @@ Object.assign(Texture.prototype, {
      * A level value of N, that is greater than 0, represents the image source for the Nth mipmap reduction level.
      * @returns {HTMLImageElement} The source image of this texture. Can be null if source not assigned for specific image level.
      */
-    getSource: function (mipLevel) {
-        mipLevel = mipLevel || 0;
+    getSource(mipLevel = 0) {
         return this._levels[mipLevel];
-    },
+    }
 
     /**
      * @function
      * @name pc.Texture#unlock
      * @description Unlocks the currently locked mip level and uploads it to VRAM.
      */
-    unlock: function () {
+    unlock() {
         // #ifdef DEBUG
         if (this._lockedLevel === -1) {
             console.log("pc.Texture#unlock: Attempting to unlock a texture that is not locked.");
@@ -876,7 +840,7 @@ Object.assign(Texture.prototype, {
         // Upload the new pixel data
         this.upload();
         this._lockedLevel = -1;
-    },
+    }
 
     /**
      * @function
@@ -886,14 +850,16 @@ Object.assign(Texture.prototype, {
      * be called explicitly in the case where an HTMLVideoElement is set as the source of the texture.  Normally,
      * this is done once every frame before video textured geometry is rendered.
      */
-    upload: function () {
+    upload() {
         this._needsUpload = true;
         this._needsMipmapsUpload = this._mipmaps;
-    },
+    }
 
-    getDds: function () {
+    getDds() {
+        // #ifdef DEBUG
         if (this.format !== PIXELFORMAT_R8_G8_B8_A8)
             console.error("This format is not implemented yet");
+        // #endif
 
         var fsize = 128;
         var i = 0;
@@ -904,19 +870,25 @@ Object.assign(Texture.prototype, {
             if (!this.cubemap) {
                 mipSize = this._levels[i].length;
                 if (!mipSize) {
+                    // #ifdef DEBUG
                     console.error("No byte array for mip " + i);
+                    // #endif
                     return;
                 }
                 fsize += mipSize;
             } else {
                 for (face = 0; face < 6; face++) {
                     if (!this._levels[i][face]) {
+                        // #ifdef DEBUG
                         console.error('No level data for mip ' + i + ', face ' + face);
+                        // #endif
                         return;
                     }
                     mipSize = this._levels[i][face].length;
                     if (!mipSize) {
+                        // #ifdef DEBUG
                         console.error("No byte array for mip " + i + ", face " + face);
+                        // #endif
                         return;
                     }
                     fsize += mipSize;
@@ -994,6 +966,6 @@ Object.assign(Texture.prototype, {
 
         return buff;
     }
-});
+}
 
 export { Texture };

--- a/src/graphics/transform-feedback.js
+++ b/src/graphics/transform-feedback.js
@@ -77,49 +77,48 @@ import { VertexBuffer } from './vertex-buffer.js';
  * };
  */
 /* eslint-enable jsdoc/check-examples */
-function TransformFeedback(inputBuffer, usage) {
-    usage = usage || BUFFER_GPUDYNAMIC;
-    this.device = inputBuffer.device;
-    var gl = this.device.gl;
+class TransformFeedback {
+    constructor(inputBuffer, usage = BUFFER_GPUDYNAMIC) {
+        this.device = inputBuffer.device;
+        var gl = this.device.gl;
 
-    // #ifdef DEBUG
-    if (!inputBuffer.format.interleaved && inputBuffer.format.elements.length > 1) {
-        console.error("Vertex buffer used by TransformFeedback needs to be interleaved.");
+        // #ifdef DEBUG
+        if (!inputBuffer.format.interleaved && inputBuffer.format.elements.length > 1) {
+            console.error("Vertex buffer used by TransformFeedback needs to be interleaved.");
+        }
+        // #endif
+
+        this._inputBuffer = inputBuffer;
+        if (usage === BUFFER_GPUDYNAMIC && inputBuffer.usage !== usage) {
+            // have to recreate input buffer with other usage
+            gl.bindBuffer(gl.ARRAY_BUFFER, inputBuffer.bufferId);
+            gl.bufferData(gl.ARRAY_BUFFER, inputBuffer.storage, gl.DYNAMIC_COPY);
+        }
+
+        this._outputBuffer = new VertexBuffer(inputBuffer.device, inputBuffer.format, inputBuffer.numVertices, usage, inputBuffer.storage);
     }
-    // #endif
 
-    this._inputBuffer = inputBuffer;
-    if (usage === BUFFER_GPUDYNAMIC && inputBuffer.usage !== usage) {
-        // have to recreate input buffer with other usage
-        gl.bindBuffer(gl.ARRAY_BUFFER, inputBuffer.bufferId);
-        gl.bufferData(gl.ARRAY_BUFFER, inputBuffer.storage, gl.DYNAMIC_COPY);
+    /**
+     * @function
+     * @name pc.TransformFeedback.createShader
+     * @description Creates a transform feedback ready vertex shader from code.
+     * @param {pc.GraphicsDevice} graphicsDevice - The graphics device used by the renderer.
+     * @param {string} vsCode - Vertex shader code. Should contain output variables starting with "out_".
+     * @param {string} name - Unique name for caching the shader.
+     * @returns {pc.Shader} A shader to use in the process() function.
+     */
+    static createShader(graphicsDevice, vsCode, name) {
+        return createShaderFromCode(graphicsDevice, vsCode, null, name, true);
     }
 
-    this._outputBuffer = new VertexBuffer(inputBuffer.device, inputBuffer.format, inputBuffer.numVertices, usage, inputBuffer.storage);
-}
-
-/**
- * @function
- * @name pc.TransformFeedback#createShader
- * @description Creates a transform feedback ready vertex shader from code.
- * @param {pc.GraphicsDevice} graphicsDevice - The graphics device used by the renderer.
- * @param {string} vsCode - Vertex shader code. Should contain output variables starting with "out_".
- * @param {string} name - Unique name for caching the shader.
- * @returns {pc.Shader} A shader to use in the process() function.
- */
-TransformFeedback.createShader = function (graphicsDevice, vsCode, name) {
-    return createShaderFromCode(graphicsDevice, vsCode, null, name, true);
-};
-
-Object.assign(TransformFeedback.prototype, {
     /**
      * @function
      * @name pc.TransformFeedback#destroy
      * @description Destroys the transform feedback helper object.
      */
-    destroy: function () {
+    destroy() {
         this._outputBuffer.destroy();
-    },
+    }
 
     /**
      * @function
@@ -128,9 +127,7 @@ Object.assign(TransformFeedback.prototype, {
      * @param {pc.Shader} shader - A vertex shader to run. Should be created with pc.TransformFeedback.createShader.
      * @param {boolean} [swap] - Swap input/output buffer data. Useful for continuous buffer processing. Default is true.
      */
-    process: function (shader, swap) {
-        if (swap === undefined) swap = true;
-
+    process(shader, swap = true) {
         var device = this.device;
 
         // #ifdef DEBUG
@@ -169,30 +166,26 @@ Object.assign(TransformFeedback.prototype, {
             this._outputBuffer._vao = tmp;
         }
     }
-});
 
-/**
- * @readonly
- * @name pc.TransformFeedback#inputBuffer
- * @type {pc.VertexBuffer}
- * @description The current input buffer.
- */
-Object.defineProperty(TransformFeedback.prototype, 'inputBuffer', {
-    get: function () {
+    /**
+     * @readonly
+     * @name pc.TransformFeedback#inputBuffer
+     * @type {pc.VertexBuffer}
+     * @description The current input buffer.
+     */
+    get inputBuffer() {
         return this._inputBuffer;
     }
-});
 
-/**
- * @readonly
- * @name pc.TransformFeedback#outputBuffer
- * @type {pc.VertexBuffer}
- * @description The current output buffer.
- */
-Object.defineProperty(TransformFeedback.prototype, 'outputBuffer', {
-    get: function () {
+    /**
+     * @readonly
+     * @name pc.TransformFeedback#outputBuffer
+     * @type {pc.VertexBuffer}
+     * @description The current output buffer.
+     */
+    get outputBuffer() {
         return this._outputBuffer;
     }
-});
+}
 
 export { TransformFeedback };

--- a/src/graphics/version.js
+++ b/src/graphics/version.js
@@ -1,29 +1,29 @@
-function Version() {
-    // Set the variables
-    this.globalId = 0;
-    this.revision = 0;
-}
-
-Object.assign(Version.prototype, {
-    equals: function (other) {
-        return this.globalId === other.globalId &&
-               this.revision === other.revision;
-    },
-
-    notequals: function (other) {
-        return this.globalId !== other.globalId ||
-               this.revision !== other.revision;
-    },
-
-    copy: function (other) {
-        this.globalId = other.globalId;
-        this.revision = other.revision;
-    },
-
-    reset: function () {
+class Version {
+    constructor() {
+        // Set the variables
         this.globalId = 0;
         this.revision = 0;
     }
-});
+
+    equals(other) {
+        return this.globalId === other.globalId &&
+               this.revision === other.revision;
+    }
+
+    notequals(other) {
+        return this.globalId !== other.globalId ||
+               this.revision !== other.revision;
+    }
+
+    copy(other) {
+        this.globalId = other.globalId;
+        this.revision = other.revision;
+    }
+
+    reset() {
+        this.globalId = 0;
+        this.revision = 0;
+    }
+}
 
 export { Version };

--- a/src/graphics/versioned-object.js
+++ b/src/graphics/versioned-object.js
@@ -1,23 +1,23 @@
 import { Version } from './version.js';
 
-var idCounter = 0;
+let idCounter = 0;
 
-function VersionedObject() {
-    // Increment the global object ID counter
-    idCounter++;
+class VersionedObject {
+    constructor() {
+        // Increment the global object ID counter
+        idCounter++;
 
-    // Create a version for this object
-    this.version = new Version();
+        // Create a version for this object
+        this.version = new Version();
 
-    // Set the unique object ID
-    this.version.globalId = idCounter;
-}
+        // Set the unique object ID
+        this.version.globalId = idCounter;
+    }
 
-Object.assign(VersionedObject.prototype, {
-    increment: function () {
+    increment() {
         // Increment the revision number
         this.version.revision++;
     }
-});
+}
 
 export { VersionedObject };

--- a/src/graphics/vertex-buffer.js
+++ b/src/graphics/vertex-buffer.js
@@ -1,6 +1,6 @@
 import { BUFFER_DYNAMIC, BUFFER_GPUDYNAMIC, BUFFER_STATIC, BUFFER_STREAM } from './graphics.js';
 
-var id = 0;
+let id = 0;
 
 /**
  * @class
@@ -14,40 +14,39 @@ var id = 0;
  * @param {number} [usage] - The usage type of the vertex buffer (see pc.BUFFER_*).
  * @param {ArrayBuffer} [initialData] - Initial data.
  */
-function VertexBuffer(graphicsDevice, format, numVertices, usage, initialData) {
-    // By default, vertex buffers are static (better for performance since buffer data can be cached in VRAM)
-    this.usage = usage || BUFFER_STATIC;
-    this.format = format;
-    this.numVertices = numVertices;
-    this.id = id++;
+class VertexBuffer{
+    constructor(graphicsDevice, format, numVertices, usage = BUFFER_STATIC, initialData) {
+        // By default, vertex buffers are static (better for performance since buffer data can be cached in VRAM)
+        this.device = graphicsDevice;
+        this.format = format;
+        this.numVertices = numVertices;
+        this.usage = usage;
 
-    // vertex array object
-    this._vao = null;
+        this.id = id++;
 
-    // Calculate the size. If format contains verticesByteSize (non-interleaved format), use it
-    this.numBytes = format.verticesByteSize ? format.verticesByteSize : format.size * numVertices;
-    graphicsDevice._vram.vb += this.numBytes;
+        // vertex array object
+        this._vao = null;
 
-    // Create the WebGL vertex buffer object
-    this.device = graphicsDevice;
+        // Calculate the size. If format contains verticesByteSize (non-interleaved format), use it
+        this.numBytes = format.verticesByteSize ? format.verticesByteSize : format.size * numVertices;
+        graphicsDevice._vram.vb += this.numBytes;
 
-    // Allocate the storage
-    if (initialData) {
-        this.setData(initialData);
-    } else {
-        this.storage = new ArrayBuffer(this.numBytes);
+        // Allocate the storage
+        if (initialData) {
+            this.setData(initialData);
+        } else {
+            this.storage = new ArrayBuffer(this.numBytes);
+        }
+
+        this.device.buffers.push(this);
     }
 
-    this.device.buffers.push(this);
-}
-
-Object.assign(VertexBuffer.prototype, {
     /**
      * @function
      * @name pc.VertexBuffer#destroy
      * @description Frees resources associated with this vertex buffer.
      */
-    destroy: function () {
+    destroy() {
         var device = this.device;
         var idx = device.buffers.indexOf(this);
         if (idx !== -1) {
@@ -66,13 +65,13 @@ Object.assign(VertexBuffer.prototype, {
             device._vram.vb -= this.storage.byteLength;
             this.bufferId = null;
         }
-    },
+    }
 
     // called when context was lost, function releases all context related resources
-    loseContext: function () {
+    loseContext() {
         this.bufferId = undefined;
         this._vao = null;
-    },
+    }
 
     /**
      * @function
@@ -80,9 +79,9 @@ Object.assign(VertexBuffer.prototype, {
      * @description Returns the data format of the specified vertex buffer.
      * @returns {pc.VertexFormat} The data format of the specified vertex buffer.
      */
-    getFormat: function () {
+    getFormat() {
         return this.format;
-    },
+    }
 
     /**
      * @function
@@ -93,9 +92,9 @@ Object.assign(VertexBuffer.prototype, {
      * and used at most a few times (pc.BUFFER_STREAM).
      * @returns {number} The usage type of the vertex buffer (see pc.BUFFER_*).
      */
-    getUsage: function () {
+    getUsage() {
         return this.usage;
-    },
+    }
 
     /**
      * @function
@@ -103,9 +102,9 @@ Object.assign(VertexBuffer.prototype, {
      * @description Returns the number of vertices stored in the specified vertex buffer.
      * @returns {number} The number of vertices stored in the vertex buffer.
      */
-    getNumVertices: function () {
+    getNumVertices() {
         return this.numVertices;
-    },
+    }
 
     /**
      * @function
@@ -113,9 +112,9 @@ Object.assign(VertexBuffer.prototype, {
      * @description Returns a mapped memory block representing the content of the vertex buffer.
      * @returns {ArrayBuffer} An array containing the byte data stored in the vertex buffer.
      */
-    lock: function () {
+    lock() {
         return this.storage;
-    },
+    }
 
     /**
      * @function
@@ -123,7 +122,7 @@ Object.assign(VertexBuffer.prototype, {
      * @description Notifies the graphics engine that the client side copy of the vertex buffer's
      * memory can be returned to the control of the graphics driver.
      */
-    unlock: function () {
+    unlock() {
         // Upload the new vertex data
         var gl = this.device.gl;
 
@@ -153,7 +152,7 @@ Object.assign(VertexBuffer.prototype, {
 
         gl.bindBuffer(gl.ARRAY_BUFFER, this.bufferId);
         gl.bufferData(gl.ARRAY_BUFFER, this.storage, glUsage);
-    },
+    }
 
     /**
      * @function
@@ -162,7 +161,7 @@ Object.assign(VertexBuffer.prototype, {
      * @param {ArrayBuffer} [data] - Source data to copy.
      * @returns {boolean} True if function finished successfuly, false otherwise.
      */
-    setData: function (data) {
+    setData(data) {
         if (data.byteLength !== this.numBytes) {
             console.error("VertexBuffer: wrong initial data size: expected " + this.numBytes + ", got " + data.byteLength);
             return false;
@@ -171,6 +170,6 @@ Object.assign(VertexBuffer.prototype, {
         this.unlock();
         return true;
     }
-});
+}
 
 export { VertexBuffer };

--- a/src/graphics/vertex-iterator.js
+++ b/src/graphics/vertex-iterator.js
@@ -1,5 +1,71 @@
 import { typedArrayTypes } from './graphics.js';
 
+function set1(a) {
+    this.array[this.index] = a;
+}
+
+function set2(a, b) {
+    this.array[this.index] = a;
+    this.array[this.index + 1] = b;
+}
+
+function set3(a, b, c) {
+    this.array[this.index] = a;
+    this.array[this.index + 1] = b;
+    this.array[this.index + 2] = c;
+}
+
+function set4(a, b, c, d) {
+    this.array[this.index] = a;
+    this.array[this.index + 1] = b;
+    this.array[this.index + 2] = c;
+    this.array[this.index + 3] = d;
+}
+
+function arraySet1(index, inputArray, inputIndex) {
+    this.array[index] = inputArray[inputIndex];
+}
+
+function arraySet2(index, inputArray, inputIndex) {
+    this.array[index] = inputArray[inputIndex];
+    this.array[index + 1] = inputArray[inputIndex + 1];
+}
+
+function arraySet3(index, inputArray, inputIndex) {
+    this.array[index] = inputArray[inputIndex];
+    this.array[index + 1] = inputArray[inputIndex + 1];
+    this.array[index + 2] = inputArray[inputIndex + 2];
+}
+
+function arraySet4(index, inputArray, inputIndex) {
+    this.array[index] = inputArray[inputIndex];
+    this.array[index + 1] = inputArray[inputIndex + 1];
+    this.array[index + 2] = inputArray[inputIndex + 2];
+    this.array[index + 3] = inputArray[inputIndex + 3];
+}
+
+function arrayGet1(offset, outputArray, outputIndex) {
+    outputArray[outputIndex] = this.array[offset];
+}
+
+function arrayGet2(offset, outputArray, outputIndex) {
+    outputArray[outputIndex] = this.array[offset];
+    outputArray[outputIndex + 1] = this.array[offset + 1];
+}
+
+function arrayGet3(offset, outputArray, outputIndex) {
+    outputArray[outputIndex] = this.array[offset];
+    outputArray[outputIndex + 1] = this.array[offset + 1];
+    outputArray[outputIndex + 2] = this.array[offset + 2];
+}
+
+function arrayGet4(offset, outputArray, outputIndex) {
+    outputArray[outputIndex] = this.array[offset];
+    outputArray[outputIndex + 1] = this.array[offset + 1];
+    outputArray[outputIndex + 2] = this.array[offset + 2];
+    outputArray[outputIndex + 3] = this.array[offset + 3];
+}
+
 /**
  * @class
  * @name pc.VertexIteratorAccessor
@@ -47,160 +113,96 @@ import { typedArrayTypes } from './graphics.js';
  * @param {number} vertexElement.size - The size of the attribute in bytes.
  * @param {pc.VertexFormat} vertexFormat - A vertex format that defines the layout of vertex data inside the buffer.
  */
-function VertexIteratorAccessor(buffer, vertexElement, vertexFormat) {
-    this.index = 0;
-    this.numComponents = vertexElement.numComponents;
+class VertexIteratorAccessor {
+    constructor(buffer, vertexElement, vertexFormat) {
+        this.index = 0;
+        this.numComponents = vertexElement.numComponents;
 
-    // create the typed array based on the element data type
-    if (vertexFormat.interleaved) {
-        this.array = new typedArrayTypes[vertexElement.dataType](buffer, vertexElement.offset);
-    } else {
-        this.array = new typedArrayTypes[vertexElement.dataType](buffer, vertexElement.offset, vertexFormat.vertexCount * vertexElement.numComponents);
+        // create the typed array based on the element data type
+        if (vertexFormat.interleaved) {
+            this.array = new typedArrayTypes[vertexElement.dataType](buffer, vertexElement.offset);
+        } else {
+            this.array = new typedArrayTypes[vertexElement.dataType](buffer, vertexElement.offset, vertexFormat.vertexCount * vertexElement.numComponents);
+        }
+
+        // BYTES_PER_ELEMENT is on the instance and constructor for Chrome, Safari and Firefox, but just the constructor for Opera
+        this.stride = vertexElement.stride / this.array.constructor.BYTES_PER_ELEMENT;
+
+        // Methods
+        switch (vertexElement.numComponents) {
+            case 1:
+                this.set = set1;
+                this.getToArray = arrayGet1;
+                this.setFromArray = arraySet1;
+                break;
+
+            case 2:
+                this.set = set2;
+                this.getToArray = arrayGet2;
+                this.setFromArray = arraySet2;
+                break;
+
+            case 3:
+                this.set = set3;
+                this.getToArray = arrayGet3;
+                this.setFromArray = arraySet3;
+                break;
+
+            case 4:
+                this.set = set4;
+                this.getToArray = arrayGet4;
+                this.setFromArray = arraySet4;
+                break;
+        }
     }
 
-    // BYTES_PER_ELEMENT is on the instance and constructor for Chrome, Safari and Firefox, but just the constructor for Opera
-    this.stride = vertexElement.stride / this.array.constructor.BYTES_PER_ELEMENT;
-
-    // Methods
-    switch (vertexElement.numComponents) {
-        case 1:
-            this.set = VertexIteratorAccessor_set1;
-            this.getToArray = VertexIteratorAccessor_arrayGet1;
-            this.setFromArray = VertexIteratorAccessor_arraySet1;
-            break;
-
-        case 2:
-            this.set = VertexIteratorAccessor_set2;
-            this.getToArray = VertexIteratorAccessor_arrayGet2;
-            this.setFromArray = VertexIteratorAccessor_arraySet2;
-            break;
-
-        case 3:
-            this.set = VertexIteratorAccessor_set3;
-            this.getToArray = VertexIteratorAccessor_arrayGet3;
-            this.setFromArray = VertexIteratorAccessor_arraySet3;
-            break;
-
-        case 4:
-            this.set = VertexIteratorAccessor_set4;
-            this.getToArray = VertexIteratorAccessor_arrayGet4;
-            this.setFromArray = VertexIteratorAccessor_arraySet4;
-            break;
+    /**
+     * @function
+     * @name pc.VertexIteratorAccessor#get
+     * @description Get a attribute component at the iterator's current index.
+     * @param {number} offset - The component offset. Should be either 0, 1, 2, or 3.
+     * @returns {number} The value of a attribute component.
+     */
+    get(offset) {
+        return this.array[this.index + offset];
     }
-}
 
-/**
- * @function
- * @name pc.VertexIteratorAccessor#get
- * @description Get a attribute component at the iterator's current index.
- * @param {number} offset - The component offset. Should be either 0, 1, 2, or 3.
- * @returns {number} The value of a attribute component.
- */
-VertexIteratorAccessor.prototype.get = function (offset) {
-    return this.array[this.index + offset];
-};
+    /**
+     * @function
+     * @name pc.VertexIteratorAccessor#set
+     * @description Set all the attribute components at the iterator's current index.
+     * @param {number} a - The first component value.
+     * @param {number} [b] - The second component value (if applicable).
+     * @param {number} [c] - The third component value (if applicable).
+     * @param {number} [d] - The fourth component value (if applicable).
+     */
+    set(a, b, c, d) {
+        // Will be replaced with specialized implementation based on number of components
+    }
 
-/**
- * @function
- * @name pc.VertexIteratorAccessor#set
- * @description Set all the attribute components at the iterator's current index.
- * @param {number} a - The first component value.
- * @param {number} [b] - The second component value (if applicable).
- * @param {number} [c] - The third component value (if applicable).
- * @param {number} [d] - The fourth component value (if applicable).
- */
-VertexIteratorAccessor.prototype.set = function (a, b, c, d) {
-    // Will be replaced with specialized implementation based on number of components
-};
+    /**
+     * @function
+     * @name pc.VertexIteratorAccessor#getToArray
+     * @description Read attribute components to an output array.
+     * @param {number} offset - The component offset at which to read data from the buffer. Will be used instead of the iterator's current index.
+     * @param {number[]|Int8Array|Uint8Array|Uint8ClampedArray|Int16Array|Uint16Array|Int32Array|Uint32Array|Float32Array} outputArray - The output array to write data into.
+     * @param {number} outputIndex - The output index at which to write into the output array.
+     */
+    getToArray(offset, outputArray, outputIndex) {
+        // Will be replaced with specialized implementation based on number of components
+    }
 
-function VertexIteratorAccessor_set1(a) {
-    this.array[this.index] = a;
-}
-
-function VertexIteratorAccessor_set2(a, b) {
-    this.array[this.index] = a;
-    this.array[this.index + 1] = b;
-}
-
-function VertexIteratorAccessor_set3(a, b, c) {
-    this.array[this.index] = a;
-    this.array[this.index + 1] = b;
-    this.array[this.index + 2] = c;
-}
-
-function VertexIteratorAccessor_set4(a, b, c, d) {
-    this.array[this.index] = a;
-    this.array[this.index + 1] = b;
-    this.array[this.index + 2] = c;
-    this.array[this.index + 3] = d;
-}
-
-/**
- * @function
- * @name pc.VertexIteratorAccessor#setFromArray
- * @description Write attribute components from an input array.
- * @param {number} index - The starting index at which to write data into the buffer. Will be used instead of the iterator's current index.
- * @param {number[]|Int8Array|Uint8Array|Uint8ClampedArray|Int16Array|Uint16Array|Int32Array|Uint32Array|Float32Array} inputArray - The input array to read data from.
- * @param {number} inputIndex - The input index at which to read from the input array.
- */
-VertexIteratorAccessor.prototype.setFromArray = function (index, inputArray, inputIndex) {
-    // Will be replaced with specialized implementation based on number of components
-};
-
-function VertexIteratorAccessor_arraySet1(index, inputArray, inputIndex) {
-    this.array[index] = inputArray[inputIndex];
-}
-
-function VertexIteratorAccessor_arraySet2(index, inputArray, inputIndex) {
-    this.array[index] = inputArray[inputIndex];
-    this.array[index + 1] = inputArray[inputIndex + 1];
-}
-
-function VertexIteratorAccessor_arraySet3(index, inputArray, inputIndex) {
-    this.array[index] = inputArray[inputIndex];
-    this.array[index + 1] = inputArray[inputIndex + 1];
-    this.array[index + 2] = inputArray[inputIndex + 2];
-}
-
-function VertexIteratorAccessor_arraySet4(index, inputArray, inputIndex) {
-    this.array[index] = inputArray[inputIndex];
-    this.array[index + 1] = inputArray[inputIndex + 1];
-    this.array[index + 2] = inputArray[inputIndex + 2];
-    this.array[index + 3] = inputArray[inputIndex + 3];
-}
-
-/**
- * @function
- * @name pc.VertexIteratorAccessor#getToArray
- * @description Read attribute components to an output array.
- * @param {number} offset - The component offset at which to read data from the buffer. Will be used instead of the iterator's current index.
- * @param {number[]|Int8Array|Uint8Array|Uint8ClampedArray|Int16Array|Uint16Array|Int32Array|Uint32Array|Float32Array} outputArray - The output array to write data into.
- * @param {number} outputIndex - The output index at which to write into the output array.
- */
-VertexIteratorAccessor.prototype.getToArray = function (offset, outputArray, outputIndex) {
-    // Will be replaced with specialized implementation based on number of components
-};
-
-function VertexIteratorAccessor_arrayGet1(offset, outputArray, outputIndex) {
-    outputArray[outputIndex] = this.array[offset];
-}
-
-function VertexIteratorAccessor_arrayGet2(offset, outputArray, outputIndex) {
-    outputArray[outputIndex] = this.array[offset];
-    outputArray[outputIndex + 1] = this.array[offset + 1];
-}
-
-function VertexIteratorAccessor_arrayGet3(offset, outputArray, outputIndex) {
-    outputArray[outputIndex] = this.array[offset];
-    outputArray[outputIndex + 1] = this.array[offset + 1];
-    outputArray[outputIndex + 2] = this.array[offset + 2];
-}
-
-function VertexIteratorAccessor_arrayGet4(offset, outputArray, outputIndex) {
-    outputArray[outputIndex] = this.array[offset];
-    outputArray[outputIndex + 1] = this.array[offset + 1];
-    outputArray[outputIndex + 2] = this.array[offset + 2];
-    outputArray[outputIndex + 3] = this.array[offset + 3];
+    /**
+     * @function
+     * @name pc.VertexIteratorAccessor#setFromArray
+     * @description Write attribute components from an input array.
+     * @param {number} index - The starting index at which to write data into the buffer. Will be used instead of the iterator's current index.
+     * @param {number[]|Int8Array|Uint8Array|Uint8ClampedArray|Int16Array|Uint16Array|Int32Array|Uint32Array|Float32Array} inputArray - The input array to read data from.
+     * @param {number} inputIndex - The input index at which to read from the input array.
+     */
+    setFromArray(index, inputArray, inputIndex) {
+        // Will be replaced with specialized implementation based on number of components
+    }
 }
 
 /**
@@ -211,33 +213,33 @@ function VertexIteratorAccessor_arrayGet4(offset, outputArray, outputIndex) {
  * @param {pc.VertexBuffer} vertexBuffer - The vertex buffer to be iterated.
  * @property {object<string, pc.VertexIteratorAccessor>} element The vertex buffer elements.
  */
-function VertexIterator(vertexBuffer) {
-    // Store the vertex buffer
-    this.vertexBuffer = vertexBuffer;
-    this.vertexFormatSize = vertexBuffer.getFormat().size;
+class VertexIterator {
+    constructor(vertexBuffer) {
+        // Store the vertex buffer
+        this.vertexBuffer = vertexBuffer;
+        this.vertexFormatSize = vertexBuffer.getFormat().size;
 
-    // Lock the vertex buffer
-    this.buffer = this.vertexBuffer.lock();
+        // Lock the vertex buffer
+        this.buffer = this.vertexBuffer.lock();
 
-    // Create an empty list
-    this.accessors = [];
-    this.element = {};
+        // Create an empty list
+        this.accessors = [];
+        this.element = {};
 
-    // Add a new 'setter' function for each element
-    var vertexFormat = this.vertexBuffer.getFormat();
-    for (var i = 0; i < vertexFormat.elements.length; i++) {
-        var vertexElement = vertexFormat.elements[i];
-        this.accessors[i] = new VertexIteratorAccessor(this.buffer, vertexElement, vertexFormat);
-        this.element[vertexElement.name] = this.accessors[i];
+        // Add a new 'setter' function for each element
+        var vertexFormat = this.vertexBuffer.getFormat();
+        for (var i = 0; i < vertexFormat.elements.length; i++) {
+            var vertexElement = vertexFormat.elements[i];
+            this.accessors[i] = new VertexIteratorAccessor(this.buffer, vertexElement, vertexFormat);
+            this.element[vertexElement.name] = this.accessors[i];
+        }
     }
-}
 
-Object.assign(VertexIterator.prototype, {
     /**
      * @function
      * @name pc.VertexIterator#next
      * @description Moves the vertex iterator on to the next vertex.
-     * @param {number} [count] - Optional number of steps to move on when calling next, defaults to 1.
+     * @param {number} [count] - Optional number of steps to move on when calling next. Defaults to 1.
      * @example
      * var iterator = new pc.VertexIterator(vertexBuffer);
      * iterator.element[pc.SEMANTIC_POSTIION].set(-0.9, -0.9, 0.0);
@@ -250,9 +252,7 @@ Object.assign(VertexIterator.prototype, {
      * iterator.element[pc.SEMANTIC_COLOR].set(0, 0, 255, 255);
      * iterator.end();
      */
-    next: function (count) {
-        if (count === undefined) count = 1;
-
+    next(count = 1) {
         var i = 0;
         var accessors = this.accessors;
         var numAccessors = this.accessors.length;
@@ -260,7 +260,7 @@ Object.assign(VertexIterator.prototype, {
             var accessor = accessors[i++];
             accessor.index += count * accessor.stride;
         }
-    },
+    }
 
     /**
      * @function
@@ -279,14 +279,14 @@ Object.assign(VertexIterator.prototype, {
      * iterator.element[pc.SEMANTIC_COLOR].set(0, 0, 255, 255);
      * iterator.end();
      */
-    end: function () {
+    end() {
         // Unlock the vertex buffer
         this.vertexBuffer.unlock();
-    },
+    }
 
     // Copies data for specified semantic into vertex buffer.
     // Works with both interleaved (slower) and non-interleaved (fast) vertex buffer
-    writeData: function (semantic, data, numVertices) {
+    writeData(semantic, data, numVertices) {
         var element = this.element[semantic];
         if (element) {
 
@@ -329,13 +329,13 @@ Object.assign(VertexIterator.prototype, {
                 }
             }
         }
-    },
+    }
 
     // Function to extract elements of a specified semantic from vertex buffer into flat array (data).
     // Works with both interleaved (slower) and non-interleaved (fast) vertex buffer
     // returns number of verticies
     // Note: when data is typed array and is smaller than needed, only part of data gets copied out (typed arrays ignore read/write out of range)
-    readData: function (semantic, data) {
+    readData(semantic, data) {
         var element = this.element[semantic];
         var count = 0;
         if (element) {
@@ -370,6 +370,6 @@ Object.assign(VertexIterator.prototype, {
 
         return count;
     }
-});
+}
 
 export { VertexIterator, VertexIteratorAccessor };


### PR DESCRIPTION
Migrate the majority of the `src/graphics` to ES6 (mainly classes).

Left out from this PR are:

* `GraphicsDevice` - because it inherits from `EventHandler`
* `VertexFormat` - `VertexFormat.defaultInstancingFormat` might need to be refactored
* `PostEffect` - we should check that a prototype-based post effect subclassed from `pc.PostEffect` still works with an ES6 class base class.
* `program-lib` folder - to avoid creating conflicts in yet to be merged PRs

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
