### PR TITLE
Migrate all ComponentData classes to ES6

### DIFF
--- a/src/framework/components/anim/data.js
+++ b/src/framework/components/anim/data.js
@@ -1,17 +1,19 @@
-function AnimComponentData() {
-    // Serialized
-    this.stateGraphAsset = null;
-    this.animationAssets = {};
-    this.speed = 1.0;
-    this.activate = true;
-    this.enabled = true;
-    this.playing = false;
+class AnimComponentData {
+    constructor() {
+        // Serialized
+        this.stateGraphAsset = null;
+        this.animationAssets = {};
+        this.speed = 1.0;
+        this.activate = true;
+        this.enabled = true;
+        this.playing = false;
 
-    // Non-serialized
-    this.stateGraph = null;
-    this.layers = [];
-    this.layerIndices = {};
-    this.parameters = {};
+        // Non-serialized
+        this.stateGraph = null;
+        this.layers = [];
+        this.layerIndices = {};
+        this.parameters = {};
+    }
 }
 
 export { AnimComponentData };

--- a/src/framework/components/animation/data.js
+++ b/src/framework/components/animation/data.js
@@ -1,28 +1,30 @@
-function AnimationComponentData() {
-    // Serialized
-    this.assets = [];
-    this.speed = 1.0;
-    this.loop = true;
-    this.activate = true;
-    this.enabled = true;
+class AnimationComponentData {
+    constructor() {
+        // Serialized
+        this.assets = [];
+        this.speed = 1.0;
+        this.loop = true;
+        this.activate = true;
+        this.enabled = true;
 
-    // Non-serialized
-    this.animations = { };
-    this.model = null;
-    this.prevAnim = null;
-    this.currAnim = null;
-    this.blending = false;
-    this.blend = 0;
-    this.blendSpeed = 0;
-    this.playing = false;
+        // Non-serialized
+        this.animations = { };
+        this.model = null;
+        this.prevAnim = null;
+        this.currAnim = null;
+        this.blending = false;
+        this.blend = 0;
+        this.blendSpeed = 0;
+        this.playing = false;
 
-    // json animation skeleton
-    this.skeleton = null;
-    this.fromSkel = null;
-    this.toSkel = null;
+        // json animation skeleton
+        this.skeleton = null;
+        this.fromSkel = null;
+        this.toSkel = null;
 
-    // glb animation controller
-    this.animEvaluator = null;
+        // glb animation controller
+        this.animEvaluator = null;
+    }
 }
 
 export { AnimationComponentData };

--- a/src/framework/components/audio-listener/data.js
+++ b/src/framework/components/audio-listener/data.js
@@ -1,6 +1,8 @@
-function AudioListenerComponentData() {
-    // Serialized
-    this.enabled = true;
+class AudioListenerComponentData {
+    constructor() {
+        // Serialized
+        this.enabled = true;
+    }
 }
 
 export { AudioListenerComponentData };

--- a/src/framework/components/audio-source/data.js
+++ b/src/framework/components/audio-source/data.js
@@ -1,26 +1,28 @@
 import { DISTANCE_INVERSE } from '../../../audio/constants.js';
 
-function AudioSourceComponentData() {
-    // serialized
-    this.enabled = true;
-    this.assets = [];
-    this.activate = true;
-    this.volume = 1;
-    this.pitch = 1;
-    this.loop = false;
-    this['3d'] = true;
+class AudioSourceComponentData {
+    constructor() {
+        // serialized
+        this.enabled = true;
+        this.assets = [];
+        this.activate = true;
+        this.volume = 1;
+        this.pitch = 1;
+        this.loop = false;
+        this['3d'] = true;
 
-    this.minDistance = 1;
-    this.maxDistance = 10000;
-    this.rollOffFactor = 1;
-    this.distanceModel = DISTANCE_INVERSE;
+        this.minDistance = 1;
+        this.maxDistance = 10000;
+        this.rollOffFactor = 1;
+        this.distanceModel = DISTANCE_INVERSE;
 
-    // not serialized
-    this.paused = true;
+        // not serialized
+        this.paused = true;
 
-    this.sources = {};
-    this.currentSource = null;
-    this.channel = null;
+        this.sources = {};
+        this.currentSource = null;
+        this.channel = null;
+    }
 }
 
 export { AudioSourceComponentData };

--- a/src/framework/components/button/data.js
+++ b/src/framework/components/button/data.js
@@ -4,23 +4,25 @@ import { Vec4 } from '../../../math/vec4.js';
 
 import { BUTTON_TRANSITION_MODE_TINT } from './constants.js';
 
-function ButtonComponentData() {
-    this.enabled = true;
+class ButtonComponentData {
+    constructor() {
+        this.enabled = true;
 
-    this.active = true;
-    this.imageEntity = null;
-    this.hitPadding = new Vec4();
-    this.transitionMode = BUTTON_TRANSITION_MODE_TINT;
-    this.hoverTint = new Color(0.75, 0.75, 0.75);
-    this.pressedTint = new Color(0.5, 0.5, 0.5);
-    this.inactiveTint = new Color(0.25, 0.25, 0.25);
-    this.fadeDuration = 0;
-    this.hoverSpriteAsset = null;
-    this.hoverSpriteFrame = 0;
-    this.pressedSpriteAsset = null;
-    this.pressedSpriteFrame = 0;
-    this.inactiveSpriteAsset = null;
-    this.inactiveSpriteFrame = 0;
+        this.active = true;
+        this.imageEntity = null;
+        this.hitPadding = new Vec4();
+        this.transitionMode = BUTTON_TRANSITION_MODE_TINT;
+        this.hoverTint = new Color(0.75, 0.75, 0.75);
+        this.pressedTint = new Color(0.5, 0.5, 0.5);
+        this.inactiveTint = new Color(0.25, 0.25, 0.25);
+        this.fadeDuration = 0;
+        this.hoverSpriteAsset = null;
+        this.hoverSpriteFrame = 0;
+        this.pressedSpriteAsset = null;
+        this.pressedSpriteFrame = 0;
+        this.inactiveSpriteAsset = null;
+        this.inactiveSpriteFrame = 0;
+    }
 }
 
 export { ButtonComponentData };

--- a/src/framework/components/camera/data.js
+++ b/src/framework/components/camera/data.js
@@ -1,5 +1,7 @@
-function CameraComponentData() {
-    this.enabled = true;
+class CameraComponentData {
+    constructor() {
+        this.enabled = true;
+    }
 }
 
 export { CameraComponentData };

--- a/src/framework/components/collision/data.js
+++ b/src/framework/components/collision/data.js
@@ -1,18 +1,20 @@
 import { Vec3 } from '../../../math/vec3.js';
 
-function CollisionComponentData() {
-    this.enabled = true;
-    this.type = 'box';
-    this.halfExtents = new Vec3(0.5, 0.5, 0.5);
-    this.radius = 0.5;
-    this.axis = 1;
-    this.height = 2;
-    this.asset = null;
+class CollisionComponentData {
+    constructor() {
+        this.enabled = true;
+        this.type = 'box';
+        this.halfExtents = new Vec3(0.5, 0.5, 0.5);
+        this.radius = 0.5;
+        this.axis = 1;
+        this.height = 2;
+        this.asset = null;
 
-    // Non-serialized properties
-    this.shape = null;
-    this.model = null;
-    this.initialized = false;
+        // Non-serialized properties
+        this.shape = null;
+        this.model = null;
+        this.initialized = false;
+    }
 }
 
 export { CollisionComponentData };

--- a/src/framework/components/data.js
+++ b/src/framework/components/data.js
@@ -4,6 +4,8 @@
  * @name pc.ComponentData
  * @classdesc Base class for Component data storage.
  */
-function ComponentData() {}
+class ComponentData {
+    constructor() {}
+}
 
 export { ComponentData };

--- a/src/framework/components/element/data.js
+++ b/src/framework/components/element/data.js
@@ -1,5 +1,7 @@
-function ElementComponentData() {
-    this.enabled = true;
+class ElementComponentData {
+    constructor() {
+        this.enabled = true;
+    }
 }
 
 export { ElementComponentData };

--- a/src/framework/components/layout-child/data.js
+++ b/src/framework/components/layout-child/data.js
@@ -1,5 +1,7 @@
-function LayoutChildComponentData() {
-    this.enabled = true;
+class LayoutChildComponentData {
+    constructor() {
+        this.enabled = true;
+    }
 }
 
 export { LayoutChildComponentData };

--- a/src/framework/components/layout-group/data.js
+++ b/src/framework/components/layout-group/data.js
@@ -1,5 +1,7 @@
-function LayoutGroupComponentData() {
-    this.enabled = true;
+class LayoutGroupComponentData {
+    constructor() {
+        this.enabled = true;
+    }
 }
 
 export { LayoutGroupComponentData };

--- a/src/framework/components/light/data.js
+++ b/src/framework/components/light/data.js
@@ -1,15 +1,17 @@
 import { _lightProps, _lightPropsDefault } from './component.js';
 
-function LightComponentData() {
-    var _props = _lightProps;
-    var _propsDefault = _lightPropsDefault;
-    var value;
-    for (var i = 0; i < _props.length; i++) {
-        value = _propsDefault[i];
-        if (value && value.clone) {
-            this[_props[i]] = value.clone();
-        } else {
-            this[_props[i]] = value;
+class LightComponentData {
+    constructor() {
+        var _props = _lightProps;
+        var _propsDefault = _lightPropsDefault;
+        var value;
+        for (var i = 0; i < _props.length; i++) {
+            value = _propsDefault[i];
+            if (value && value.clone) {
+                this[_props[i]] = value.clone();
+            } else {
+                this[_props[i]] = value;
+            }
         }
     }
 }

--- a/src/framework/components/model/data.js
+++ b/src/framework/components/model/data.js
@@ -1,5 +1,7 @@
-function ModelComponentData() {
-    this.enabled = true;
+class ModelComponentData {
+    constructor() {
+        this.enabled = true;
+    }
 }
 
 export { ModelComponentData };

--- a/src/framework/components/particle-system/data.js
+++ b/src/framework/components/particle-system/data.js
@@ -2,89 +2,91 @@ import { Vec3 } from '../../../math/vec3.js';
 
 import { BLEND_NORMAL, EMITTERSHAPE_BOX, LAYERID_WORLD, PARTICLEMODE_GPU, PARTICLEORIENTATION_SCREEN } from '../../../scene/constants.js';
 
-function ParticleSystemComponentData() {
-    this.numParticles = 1;                  // Amount of particles allocated (max particles = max GL texture width at this moment)
-    this.rate = 1;                          // Emission rate
-    this.rate2 = null;
-    this.startAngle = 0;
-    this.startAngle2 = null;
-    this.lifetime = 50;                     // Particle lifetime
-    this.emitterExtents = new Vec3();       // Spawn point divergence
-    this.emitterExtentsInner = new Vec3();
-    this.emitterRadius = 0;
-    this.emitterRadiusInner = 0;
-    this.emitterShape = EMITTERSHAPE_BOX;
-    this.initialVelocity = 0;
-    this.wrapBounds = new Vec3();
-    this.localSpace = false;
-    this.screenSpace = false;
-    this.colorMap = null;
-    this.colorMapAsset = null;
-    this.normalMap = null;
-    this.normalMapAsset = null;
-    this.loop = true;
-    this.preWarm = false;
-    this.sort = 0;                          // Sorting mode: 0 = none, 1 = by distance, 2 = by life, 3 = by -life;   Forces CPU mode if not 0
-    this.mode = PARTICLEMODE_GPU;
-    this.scene = null;
-    this.lighting = false;
-    this.halfLambert = false;            // Uses half-lambert lighting instead of Lambert
-    this.intensity = 1;
-    this.stretch = 0.0;
-    this.alignToMotion = false;
-    this.depthSoftening = 0;
-    this.meshAsset = null;
-    this.mesh = null;                       // Mesh to be used as particle. Vertex buffer is supposed to hold vertex position in first 3 floats of each vertex
-                                            // Leave undefined to use simple quads
-    this.depthWrite = false;
-    this.noFog = false;
+class ParticleSystemComponentData {
+    constructor() {
+        this.numParticles = 1;                  // Amount of particles allocated (max particles = max GL texture width at this moment)
+        this.rate = 1;                          // Emission rate
+        this.rate2 = null;
+        this.startAngle = 0;
+        this.startAngle2 = null;
+        this.lifetime = 50;                     // Particle lifetime
+        this.emitterExtents = new Vec3();       // Spawn point divergence
+        this.emitterExtentsInner = new Vec3();
+        this.emitterRadius = 0;
+        this.emitterRadiusInner = 0;
+        this.emitterShape = EMITTERSHAPE_BOX;
+        this.initialVelocity = 0;
+        this.wrapBounds = new Vec3();
+        this.localSpace = false;
+        this.screenSpace = false;
+        this.colorMap = null;
+        this.colorMapAsset = null;
+        this.normalMap = null;
+        this.normalMapAsset = null;
+        this.loop = true;
+        this.preWarm = false;
+        this.sort = 0;                          // Sorting mode: 0 = none, 1 = by distance, 2 = by life, 3 = by -life;   Forces CPU mode if not 0
+        this.mode = PARTICLEMODE_GPU;
+        this.scene = null;
+        this.lighting = false;
+        this.halfLambert = false;            // Uses half-lambert lighting instead of Lambert
+        this.intensity = 1;
+        this.stretch = 0.0;
+        this.alignToMotion = false;
+        this.depthSoftening = 0;
+        this.meshAsset = null;
+        this.mesh = null;                       // Mesh to be used as particle. Vertex buffer is supposed to hold vertex position in first 3 floats of each vertex
+                                                // Leave undefined to use simple quads
+        this.depthWrite = false;
+        this.noFog = false;
 
-    this.orientation = PARTICLEORIENTATION_SCREEN;
-    this.particleNormal = new Vec3(0, 1, 0);
+        this.orientation = PARTICLEORIENTATION_SCREEN;
+        this.particleNormal = new Vec3(0, 1, 0);
 
-    this.animTilesX = 1;
-    this.animTilesY = 1;
-    this.animStartFrame = 0;
-    this.animNumFrames = 1;
-    this.animNumAnimations = 1;
-    this.animIndex = 0;
-    this.randomizeAnimIndex = false;
-    this.animSpeed = 1;
-    this.animLoop = true;
+        this.animTilesX = 1;
+        this.animTilesY = 1;
+        this.animStartFrame = 0;
+        this.animNumFrames = 1;
+        this.animNumAnimations = 1;
+        this.animIndex = 0;
+        this.randomizeAnimIndex = false;
+        this.animSpeed = 1;
+        this.animLoop = true;
 
-    // Time-dependent parameters
-    this.scaleGraph = null;
-    this.scaleGraph2 = null;
+        // Time-dependent parameters
+        this.scaleGraph = null;
+        this.scaleGraph2 = null;
 
-    this.colorGraph = null;
-    this.colorGraph2 = null;
+        this.colorGraph = null;
+        this.colorGraph2 = null;
 
-    this.alphaGraph = null;
-    this.alphaGraph2 = null;
+        this.alphaGraph = null;
+        this.alphaGraph2 = null;
 
-    this.localVelocityGraph = null;
-    this.localVelocityGraph2 = null;
+        this.localVelocityGraph = null;
+        this.localVelocityGraph2 = null;
 
-    this.velocityGraph = null;
-    this.velocityGraph2 = null;
+        this.velocityGraph = null;
+        this.velocityGraph2 = null;
 
-    this.rotationSpeedGraph = null;
-    this.rotationSpeedGraph2 = null;
+        this.rotationSpeedGraph = null;
+        this.rotationSpeedGraph2 = null;
 
-    this.radialSpeedGraph = null;
-    this.radialSpeedGraph2 = null;
+        this.radialSpeedGraph = null;
+        this.radialSpeedGraph2 = null;
 
-    this.blendType = BLEND_NORMAL;
+        this.blendType = BLEND_NORMAL;
 
-    this.model = null;
+        this.model = null;
 
-    this.enabled = true;
+        this.enabled = true;
 
-    this.paused = false;
+        this.paused = false;
 
-    this.autoPlay = true;
+        this.autoPlay = true;
 
-    this.layers = [LAYERID_WORLD]; // assign to the default world layer
+        this.layers = [LAYERID_WORLD]; // assign to the default world layer
+    }
 }
 
 export { ParticleSystemComponentData };

--- a/src/framework/components/render/data.js
+++ b/src/framework/components/render/data.js
@@ -1,6 +1,8 @@
-function RenderComponentData() {
-    this.enabled = true;
-    this.rootBone = null;
+class RenderComponentData {
+    constructor() {
+        this.enabled = true;
+        this.rootBone = null;
+    }
 }
 
 export { RenderComponentData };

--- a/src/framework/components/rigid-body/data.js
+++ b/src/framework/components/rigid-body/data.js
@@ -10,25 +10,27 @@ import { BODYGROUP_STATIC, BODYMASK_NOT_STATIC, BODYTYPE_STATIC } from './consta
  * @classdesc Contains data for the RigidBodyComponent.
  * @description Create a new data structure for a RigidBodyComponent.
  */
-function RigidBodyComponentData() {
-    this.enabled = true;
-    this.mass = 1;
-    this.linearDamping = 0;
-    this.angularDamping = 0;
-    this.linearFactor = new Vec3(1, 1, 1);
-    this.angularFactor = new Vec3(1, 1, 1);
+class RigidBodyComponentData {
+    constructor() {
+        this.enabled = true;
+        this.mass = 1;
+        this.linearDamping = 0;
+        this.angularDamping = 0;
+        this.linearFactor = new Vec3(1, 1, 1);
+        this.angularFactor = new Vec3(1, 1, 1);
 
-    this.friction = 0.5;
-    this.restitution = 0;
+        this.friction = 0.5;
+        this.restitution = 0;
 
-    this.type = BODYTYPE_STATIC;
+        this.type = BODYTYPE_STATIC;
 
-    this.group = BODYGROUP_STATIC;
-    this.mask = BODYMASK_NOT_STATIC;
+        this.group = BODYGROUP_STATIC;
+        this.mask = BODYMASK_NOT_STATIC;
 
-    // Non-serialized properties
-    this.body = null;
-    this.simulationEnabled = false;
+        // Non-serialized properties
+        this.body = null;
+        this.simulationEnabled = false;
+    }
 }
 
 export { RigidBodyComponentData };

--- a/src/framework/components/screen/data.js
+++ b/src/framework/components/screen/data.js
@@ -1,5 +1,7 @@
-function ScreenComponentData() {
-    this.enabled = true;
+class ScreenComponentData {
+    constructor() {
+        this.enabled = true;
+    }
 }
 
 export { ScreenComponentData };

--- a/src/framework/components/script-legacy/data.js
+++ b/src/framework/components/script-legacy/data.js
@@ -1,16 +1,18 @@
-function ScriptLegacyComponentData() {
-    // serialized
-    this.scripts = [];
-    this.enabled = true;
+class ScriptLegacyComponentData {
+    constructor() {
+        // serialized
+        this.scripts = [];
+        this.enabled = true;
 
-    // not serialized
-    this.instances = {};
-    this._instances = {};
-    this.runInTools = false;
-    this.attributes = {};
-    this.initialized = false;
-    this.postInitialized = false;
-    this.areScriptsLoaded = false;
+        // not serialized
+        this.instances = {};
+        this._instances = {};
+        this.runInTools = false;
+        this.attributes = {};
+        this.initialized = false;
+        this.postInitialized = false;
+        this.areScriptsLoaded = false;
+    }
 }
 
 export { ScriptLegacyComponentData };

--- a/src/framework/components/script/data.js
+++ b/src/framework/components/script/data.js
@@ -1,5 +1,7 @@
-function ScriptComponentData() {
-    this.enabled = true;
+class ScriptComponentData {
+    constructor() {
+        this.enabled = true;
+    }
 }
 
 export { ScriptComponentData };

--- a/src/framework/components/scroll-view/data.js
+++ b/src/framework/components/scroll-view/data.js
@@ -1,5 +1,7 @@
-function ScrollViewComponentData() {
-    this.enabled = true;
+class ScrollViewComponentData {
+    constructor() {
+        this.enabled = true;
+    }
 }
 
 export { ScrollViewComponentData };

--- a/src/framework/components/scrollbar/data.js
+++ b/src/framework/components/scrollbar/data.js
@@ -1,5 +1,7 @@
-function ScrollbarComponentData() {
-    this.enabled = true;
+class ScrollbarComponentData {
+    constructor() {
+        this.enabled = true;
+    }
 }
 
 export { ScrollbarComponentData };

--- a/src/framework/components/sound/data.js
+++ b/src/framework/components/sound/data.js
@@ -1,5 +1,7 @@
-function SoundComponentData() {
-    this.enabled = true;
+class SoundComponentData {
+    constructor() {
+        this.enabled = true;
+    }
 }
 
 export { SoundComponentData };

--- a/src/framework/components/sprite/data.js
+++ b/src/framework/components/sprite/data.js
@@ -1,5 +1,7 @@
-function SpriteComponentData() {
-    this.enabled = true;
+class SpriteComponentData {
+    constructor() {
+        this.enabled = true;
+    }
 }
 
 export { SpriteComponentData };

--- a/src/framework/components/zone/data.js
+++ b/src/framework/components/zone/data.js
@@ -1,5 +1,7 @@
-function ZoneComponentData() {
-    this.enabled = true;
+class ZoneComponentData {
+    constructor() {
+        this.enabled = true;
+    }
 }
 
 export { ZoneComponentData };


### PR DESCRIPTION
Migrate all `ComponentData` based classes to ES6. `Components` and `ComponentSystems` are subclasses from `EventHandler` so they are not included in this PR.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
