### PR TITLE
Reorganize font source

### DIFF
--- a/src/font/canvas-font.js
+++ b/src/font/canvas-font.js
@@ -1,13 +1,13 @@
-import { string } from '../../../core/string.js';
-import { Color } from '../../../core/color.js';
-import { EventHandler } from '../../../core/event-handler.js';
+import { string } from '../core/string.js';
+import { Color } from '../core/color.js';
+import { EventHandler } from '../core/event-handler.js';
 
 import {
     ADDRESS_CLAMP_TO_EDGE,
     FILTER_LINEAR, FILTER_LINEAR_MIPMAP_LINEAR,
     PIXELFORMAT_R8_G8_B8_A8
-} from '../../../graphics/graphics.js';
-import { Texture } from '../../../graphics/texture.js';
+} from '../graphics/graphics.js';
+import { Texture } from '../graphics/texture.js';
 
 var MAX_TEXTURE_SIZE = 4096;
 var DEFAULT_TEXTURE_SIZE = 512;

--- a/src/font/constants.js
+++ b/src/font/constants.js
@@ -1,0 +1,2 @@
+export const FONT_MSDF = 'msdf';
+export const FONT_BITMAP = 'bitmap';

--- a/src/font/font.js
+++ b/src/font/font.js
@@ -1,5 +1,4 @@
-var FONT_MSDF = 'msdf';
-var FONT_BITMAP = 'bitmap';
+import { FONT_MSDF } from './constants.js';
 
 /**
  * @class
@@ -10,28 +9,28 @@ var FONT_BITMAP = 'bitmap';
  * @property {number} intensity The font intensity.
  * @property {pc.Texture[]} textures The font textures.
  */
-function Font(textures, data) {
-    this.type = data ? data.type || FONT_MSDF : FONT_MSDF;
+class Font {
+    constructor(textures, data) {
+        this.type = data ? data.type || FONT_MSDF : FONT_MSDF;
 
-    this.em = 1;
+        this.em = 1;
 
-    // atlas texture
-    this.textures = textures;
+        // atlas texture
+        this.textures = textures;
 
-    // intensity
-    this.intensity = 0.0;
+        // intensity
+        this.intensity = 0.0;
 
-    // json data
-    this._data = null;
-    this.data = data;
-}
+        // json data
+        this._data = null;
+        this.data = data;
+    }
 
-Object.defineProperty(Font.prototype, "data", {
-    get: function () {
+    get data() {
         return this._data;
-    },
+    }
 
-    set: function (value){
+    set data(value){
         this._data = value;
         if (!value)
             return;
@@ -57,6 +56,6 @@ Object.defineProperty(Font.prototype, "data", {
             }
         }
     }
-});
+}
 
-export { FONT_BITMAP, FONT_MSDF, Font };
+export { Font };

--- a/src/framework/components/element/text-element.js
+++ b/src/framework/components/element/text-element.js
@@ -16,7 +16,7 @@ import { Model } from '../../../scene/model.js';
 
 import { LocalizedAsset } from '../../../asset/asset-localized.js';
 
-import { FONT_BITMAP, FONT_MSDF } from '../text/font.js';
+import { FONT_BITMAP, FONT_MSDF } from '../../../font/constants.js';
 
 import { Markup } from './markup.js';
 

--- a/src/index.js
+++ b/src/index.js
@@ -117,6 +117,11 @@ export { AnimTarget } from './anim/anim-target.js';
 export { AnimTrack } from './anim/anim-track.js';
 export { DefaultAnimBinder } from './anim/default-anim-binder.js';
 
+// FONT
+export * from './font/constants.js';
+export { Font } from './font/font.js';
+export { CanvasFont } from './font/canvas-font.js';
+
 // SOUND
 export * from './audio/constants.js';
 
@@ -213,7 +218,6 @@ export { ButtonComponent } from './framework/components/button/component.js';
 export { ButtonComponentSystem } from './framework/components/button/system.js';
 export { CameraComponent } from './framework/components/camera/component.js';
 export { CameraComponentSystem } from './framework/components/camera/system.js';
-export { CanvasFont } from './framework/components/text/canvas-font.js';
 export { CollisionComponent } from './framework/components/collision/component.js';
 export { CollisionComponentSystem } from './framework/components/collision/system.js';
 export { Component } from './framework/components/component.js';
@@ -226,7 +230,6 @@ export { ElementComponentSystem } from './framework/components/element/system.js
 export { ElementDragHelper } from './framework/components/element/element-drag-helper.js';
 export { Entity } from './framework/entity.js';
 export { EntityReference } from './framework/utils/entity-reference.js';
-export { Font, FONT_BITMAP, FONT_MSDF } from './framework/components/text/font.js';
 export { ImageElement } from './framework/components/element/image-element.js';
 export { LayoutCalculator } from './framework/components/layout-group/layout-calculator.js';
 export { LayoutChildComponent } from './framework/components/layout-child/component.js';

--- a/src/resources/font.js
+++ b/src/resources/font.js
@@ -3,7 +3,7 @@ import { string } from '../core/string.js';
 
 import { http } from '../net/http.js';
 
-import { Font } from '../framework/components/text/font.js';
+import { Font } from '../font/font.js';
 
 function upgradeDataSchema(data) {
     // convert v1 and v2 to v3 font data schema


### PR DESCRIPTION
* Move `src\framework\components\text\*` to `src\font\*` (`text` is **not** a component!)
* Migrate `pc.Font` to ES6 class
* Move constants to their own module (in line with other subsystems)

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
