### PR TITLE
Export default for ES6 build

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -91,14 +91,14 @@ function exportDefault() {
     return {
         /**
          * @param {string} code - Input code.
-         * @param {RenderedChunk} chunk - See https://github.com/rollup/rollup/blob/master/src/rollup/types.d.ts
+         * @param {import('./node_modules/rollup/dist/rollup').RenderedChunk} chunk - See https://github.com/rollup/rollup/blob/master/src/rollup/types.d.ts
          * @returns {string} Output code.
          */
         renderChunk(code, chunk) {
             return `${code}\n\nexport default { ${chunk.exports.join(', ')} };\n`;
         }
     };
-};
+}
 
 const es5Options = {
     babelHelpers: 'bundled',

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -87,6 +87,19 @@ function shaderChunks(removeComments) {
     };
 }
 
+function exportDefault() {
+    return {
+        /**
+         * @param {string} code - Input code.
+         * @param {RenderedChunk} chunk - See https://github.com/rollup/rollup/blob/master/src/rollup/types.d.ts
+         * @returns {string} Output code.
+         */
+        renderChunk(code, chunk) {
+            return `${code}\n\nexport default { ${chunk.exports.join(', ')} };\n`;
+        }
+    };
+};
+
 const es5Options = {
     babelHelpers: 'bundled',
     babelrc: false,
@@ -186,7 +199,8 @@ const target_release_es6 = {
             __CURRENT_SDK_VERSION__: version
         }),
         babel(moduleOptions),
-        spacesToTabs()
+        spacesToTabs(),
+        exportDefault()
     ]
 };
 


### PR DESCRIPTION
Currently only this works:

```js
import * as pc from "./playcanvas.mjs";
```

But usually people expect this to work:

```js
import pc from "./playcanvas.mjs";
```

This is adding all export statements again, but as `export default`:

![image](https://user-images.githubusercontent.com/5236548/103477770-22563000-4dc2-11eb-88ab-9924e4067dbc.png)

So the file size grows, but a HTTP server with gzip is compressing/zipping that all away (because it is equal to the previous string)

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
