### PR TITLE
hide area light example for now

### DIFF
--- a/examples/examples.js
+++ b/examples/examples.js
@@ -16,7 +16,6 @@ var categories = [
     }, {
         name: "graphics",
         examples: [
-            "area-lights",
             "area-picker",
             "batching-dynamic",
             "grab-pass",


### PR DESCRIPTION
should be easy to unhide when area lights are public.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
