### PR TITLE
Keep gamepad getAxis return type consistent

### DIFF
--- a/src/input/game-pads.js
+++ b/src/input/game-pads.js
@@ -211,7 +211,7 @@ Object.assign(GamePads.prototype, {
      */
     getAxis: function (index, axes) {
         if (!this.current[index]) {
-            return false;
+            return 0;
         }
 
         var key = this.current[index].map.axes[axes];


### PR DESCRIPTION
Fixes #2665

Example project: https://playcanvas.com/editor/scene/742878

This will crash when treating the return type as a number.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
