### PR TITLE
AnimComponent fixes

### DIFF
--- a/src/anim/default-anim-binder.js
+++ b/src/anim/default-anim-binder.js
@@ -13,6 +13,10 @@ import { AnimTarget } from './anim-target.js';
  */
 class DefaultAnimBinder {
     constructor(graph) {
+        this.propertyLocator = new AnimPropertyLocator();
+
+        if (!graph) return;
+
         var nodes = { };
 
         // cache node names so we can quickly resolve animation paths
@@ -121,8 +125,6 @@ class DefaultAnimBinder {
                 return null;
             }.bind(this)
         };
-
-        this.propertyLocator = new AnimPropertyLocator();
     }
 
     resolve(path) {

--- a/src/framework/components/anim/binder.js
+++ b/src/framework/components/anim/binder.js
@@ -18,13 +18,8 @@ const q  = new Quat();
 
 class AnimComponentBinder extends DefaultAnimBinder {
     constructor(animComponent, graph) {
+        super(graph);
         this.animComponent = animComponent;
-
-        if (graph) {
-            super(graph);
-        } else {
-            this.propertyLocator = new AnimPropertyLocator();
-        }
     }
 
     static _packFloat(values) {

--- a/src/framework/components/anim/binder.js
+++ b/src/framework/components/anim/binder.js
@@ -8,8 +8,6 @@ import { Vec2 } from '../../../math/vec2.js';
 import { Vec3 } from '../../../math/vec3.js';
 import { Vec4 } from '../../../math/vec4.js';
 
-import { AnimPropertyLocator } from './property-locator.js';
-
 const v2 = new Vec2();
 const v3 = new Vec3();
 const v4 = new Vec4();

--- a/src/framework/components/anim/component.js
+++ b/src/framework/components/anim/component.js
@@ -115,15 +115,18 @@ class AnimComponent extends Component {
                 }
                 var assetId = animationAsset.asset;
                 var asset = this.system.app.assets.get(assetId);
-                if (asset.resource) {
-                    this.assignAnimation(stateName, asset.resource, layer.name);
-                } else {
-                    asset.once('load', function (layerName, stateName) {
-                        return function (asset) {
-                            this.assignAnimation(stateName, asset.resource, layerName);
-                        }.bind(this);
-                    }.bind(this)(layer.name, stateName));
-                    this.system.app.assets.load(asset);
+                // check whether assigned animation asset still exists
+                if (asset) {
+                    if (asset.resource) {
+                        this.assignAnimation(stateName, asset.resource, layer.name);
+                    } else {
+                        asset.once('load', function (layerName, stateName) {
+                            return function (asset) {
+                                this.assignAnimation(stateName, asset.resource, layerName);
+                            }.bind(this);
+                        }.bind(this)(layer.name, stateName));
+                        this.system.app.assets.load(asset);
+                    }
                 }
             }
         }


### PR DESCRIPTION
- Fixes an issue where this is called before super in the `AnimComponentBinder`
- Ensures the `AnimComponent` doesn't crash on load if it's been assigned a now deleted animation asset. When this occurs the component will now stay as 'unplayable' until a new animation asset is assigned.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
