### PR TITLE
[Fix] When render target is changed on layer, LayerComp needs to update RenderActions

### DIFF
--- a/src/scene/layer.js
+++ b/src/scene/layer.js
@@ -274,6 +274,15 @@ class Layer {
         this._lightCube = null;
     }
 
+    get renderTarget() {
+        return this._renderTarget;
+    }
+
+    set renderTarget(rt) {
+        this._renderTarget = rt;
+        this._dirtyCameras = true;
+    }
+
     get enabled() {
         return this._enabled;
     }


### PR DESCRIPTION
fixes an issue introduced in https://github.com/playcanvas/engine/pull/2681

When renderTarget is changed on a Layer, LayerComposition needs to update RenderActions to use this new target.