### PR TITLE
Optimize Element / Screen Events

### DIFF
--- a/src/framework/components/element/component.js
+++ b/src/framework/components/element/component.js
@@ -465,19 +465,11 @@ class ElementComponent extends Component {
     }
 
     _bindScreen(screen) {
-        screen.on('set:resolution', this._onScreenResize, this);
-        screen.on('set:referenceresolution', this._onScreenResize, this);
-        screen.on('set:scaleblend', this._onScreenResize, this);
-        screen.on('set:screenspace', this._onScreenSpaceChange, this);
-        screen.on('remove', this._onScreenRemove, this);
+        screen._bindElement(this);
     }
 
     _unbindScreen(screen) {
-        screen.off('set:resolution', this._onScreenResize, this);
-        screen.off('set:referenceresolution', this._onScreenResize, this);
-        screen.off('set:scaleblend', this._onScreenResize, this);
-        screen.off('set:screenspace', this._onScreenSpaceChange, this);
-        screen.off('remove', this._onScreenRemove, this);
+        screen._unbindElement(this);
     }
 
     _updateScreen(screen) {

--- a/src/framework/components/element/component.js
+++ b/src/framework/components/element/component.js
@@ -465,6 +465,13 @@ class ElementComponent extends Component {
     }
 
     _bindScreen(screen) {
+        // bind the Element to the Screen
+        // We used to subscribe to Screen events here however
+        // that was very slow when there are thousands of Elements.
+        // When the time comes to unbind the Element from the Screen
+        // finding the event callbacks to remove takes a considerable amount of 
+        // time. So instead the Screen stores the Element component and calls
+        // its functions directly.
         screen._bindElement(this);
     }
 

--- a/src/framework/components/element/component.js
+++ b/src/framework/components/element/component.js
@@ -469,7 +469,7 @@ class ElementComponent extends Component {
         // We used to subscribe to Screen events here however
         // that was very slow when there are thousands of Elements.
         // When the time comes to unbind the Element from the Screen
-        // finding the event callbacks to remove takes a considerable amount of 
+        // finding the event callbacks to remove takes a considerable amount of
         // time. So instead the Screen stores the Element component and calls
         // its functions directly.
         screen._bindElement(this);

--- a/src/framework/components/element/component.js
+++ b/src/framework/components/element/component.js
@@ -465,13 +465,11 @@ class ElementComponent extends Component {
     }
 
     _bindScreen(screen) {
-        // bind the Element to the Screen
-        // We used to subscribe to Screen events here however
-        // that was very slow when there are thousands of Elements.
-        // When the time comes to unbind the Element from the Screen
-        // finding the event callbacks to remove takes a considerable amount of
-        // time. So instead the Screen stores the Element component and calls
-        // its functions directly.
+        // Bind the Element to the Screen. We used to subscribe to Screen events here. However,
+        // that was very slow when there are thousands of Elements. When the time comes to unbind
+        // the Element from the Screen, finding the event callbacks to remove takes a considerable
+        // amount of time. So instead, the Screen stores the Element component and calls its
+        // functions directly.
         screen._bindElement(this);
     }
 

--- a/src/framework/components/screen/component.js
+++ b/src/framework/components/screen/component.js
@@ -42,6 +42,8 @@ class ScreenComponent extends Component {
         this.cull = this._screenSpace;
         this._screenMatrix = new Mat4();
 
+        this._elements = [];
+
         system.app.graphicsDevice.on("resizecanvas", this._onResize, this);
     }
 
@@ -136,12 +138,29 @@ class ScreenComponent extends Component {
         }
     }
 
+    _bindElement(element) {
+        this._elements.push(element);
+    }
+
+    _unbindElement(element) {
+        const index = this._elements.indexOf(element);
+        if (index !== -1) {
+            this._elements.splice(index, 1);
+        }
+    }
+
     onRemove() {
         this.system.app.graphicsDevice.off("resizecanvas", this._onResize, this);
         this.fire('remove');
 
-        // remove all events used by elements
+        for (let i = 0; i < this._elements.length; i++) {
+            this._elements[i]._onScreenRemove();
+        }
+        this._elements.length = 0;
+
+        // remove all events
         this.off();
+
     }
 
     set resolution(value) {
@@ -160,6 +179,9 @@ class ScreenComponent extends Component {
             this.entity._dirtifyLocal();
 
         this.fire("set:resolution", this._resolution);
+        for (let i = 0; i < this._elements.length; i++) {
+            this._elements[i]._onScreenResize(this._resolution);
+        }
     }
 
     get resolution() {
@@ -175,6 +197,9 @@ class ScreenComponent extends Component {
             this.entity._dirtifyLocal();
 
         this.fire("set:referenceresolution", this._resolution);
+        for (let i = 0; i < this._elements.length; i++) {
+            this._elements[i]._onScreenResize(this._resolution);
+        }
     }
 
     get referenceResolution() {
@@ -196,6 +221,10 @@ class ScreenComponent extends Component {
             this.entity._dirtifyLocal();
 
         this.fire('set:screenspace', this._screenSpace);
+
+        for (let i = 0; i < this._elements.length; i++) {
+            this._elements[i]._onScreenSpaceChange();
+        }
     }
 
     get screenSpace() {
@@ -230,6 +259,10 @@ class ScreenComponent extends Component {
             this.entity._dirtifyLocal();
 
         this.fire("set:scaleblend", this._scaleBlend);
+
+        for (let i = 0; i < this._elements.length; i++) {
+            this._elements[i]._onScreenResize(this._resolution);
+        }
     }
 
     get scaleBlend() {

--- a/src/framework/components/screen/component.js
+++ b/src/framework/components/screen/component.js
@@ -42,7 +42,7 @@ class ScreenComponent extends Component {
         this.cull = this._screenSpace;
         this._screenMatrix = new Mat4();
 
-        this._elements = [];
+        this._elements = new Set();
 
         system.app.graphicsDevice.on("resizecanvas", this._onResize, this);
     }
@@ -139,24 +139,19 @@ class ScreenComponent extends Component {
     }
 
     _bindElement(element) {
-        this._elements.push(element);
+        this._elements.add(element);
     }
 
     _unbindElement(element) {
-        const index = this._elements.indexOf(element);
-        if (index !== -1) {
-            this._elements.splice(index, 1);
-        }
+        this._elements.delete(element);
     }
 
     onRemove() {
         this.system.app.graphicsDevice.off("resizecanvas", this._onResize, this);
         this.fire('remove');
 
-        for (let i = 0; i < this._elements.length; i++) {
-            this._elements[i]._onScreenRemove();
-        }
-        this._elements.length = 0;
+        this._elements.forEach(element => element._onScreenRemove());
+        this._elements.clear();
 
         // remove all events
         this.off();
@@ -179,9 +174,7 @@ class ScreenComponent extends Component {
             this.entity._dirtifyLocal();
 
         this.fire("set:resolution", this._resolution);
-        for (let i = 0; i < this._elements.length; i++) {
-            this._elements[i]._onScreenResize(this._resolution);
-        }
+        this._elements.forEach(element => element._onScreenResize(this._resolution));
     }
 
     get resolution() {
@@ -197,9 +190,7 @@ class ScreenComponent extends Component {
             this.entity._dirtifyLocal();
 
         this.fire("set:referenceresolution", this._resolution);
-        for (let i = 0; i < this._elements.length; i++) {
-            this._elements[i]._onScreenResize(this._resolution);
-        }
+        this._elements.forEach(element => element._onScreenResize(this._resolution));
     }
 
     get referenceResolution() {
@@ -222,9 +213,7 @@ class ScreenComponent extends Component {
 
         this.fire('set:screenspace', this._screenSpace);
 
-        for (let i = 0; i < this._elements.length; i++) {
-            this._elements[i]._onScreenSpaceChange();
-        }
+        this._elements.forEach(element => element._onScreenSpaceChange());
     }
 
     get screenSpace() {
@@ -260,9 +249,7 @@ class ScreenComponent extends Component {
 
         this.fire("set:scaleblend", this._scaleBlend);
 
-        for (let i = 0; i < this._elements.length; i++) {
-            this._elements[i]._onScreenResize(this._resolution);
-        }
+        this._elements.forEach(element => element._onScreenResize(this._resolution));
     }
 
     get scaleBlend() {

--- a/tests/framework/components/element/test_element.js
+++ b/tests/framework/components/element/test_element.js
@@ -119,19 +119,11 @@ describe("pc.ElementComponent", function() {
 
         screen.addChild(e);
 
-        expect(screen.screen.hasEvent('set:resolution')).to.be.true;
-        expect(screen.screen.hasEvent('set:referenceresolution')).to.be.true;
-        expect(screen.screen.hasEvent('set:scaleblend')).to.be.true;
-        expect(screen.screen.hasEvent('set:screenspace')).to.be.true;
-        expect(screen.screen.hasEvent('remove')).to.be.true;
+        expect(screen.screen._elements).to.include(e.element);
 
         e.reparent(app.root);
 
-        expect(screen.screen.hasEvent('set:resolution')).to.be.false;
-        expect(screen.screen.hasEvent('set:referenceresolution')).to.be.false;
-        expect(screen.screen.hasEvent('set:scaleblend')).to.be.false;
-        expect(screen.screen.hasEvent('set:screenspace')).to.be.false;
-        expect(screen.screen.hasEvent('remove')).to.be.false;
+        expect(screen.screen._elements).to.not.include(e.element);
     });
 
     it('screen component unbound on destroy', function () {
@@ -144,18 +136,10 @@ describe("pc.ElementComponent", function() {
 
         screen.addChild(e);
 
-        expect(screen.screen.hasEvent('set:resolution')).to.be.true;
-        expect(screen.screen.hasEvent('set:referenceresolution')).to.be.true;
-        expect(screen.screen.hasEvent('set:scaleblend')).to.be.true;
-        expect(screen.screen.hasEvent('set:screenspace')).to.be.true;
-        expect(screen.screen.hasEvent('remove')).to.be.true;
+        expect(screen.screen._elements).to.include(e.element);
 
         e.destroy();
 
-        expect(screen.screen.hasEvent('set:resolution')).to.be.false;
-        expect(screen.screen.hasEvent('set:referenceresolution')).to.be.false;
-        expect(screen.screen.hasEvent('set:scaleblend')).to.be.false;
-        expect(screen.screen.hasEvent('set:screenspace')).to.be.false;
-        expect(screen.screen.hasEvent('remove')).to.be.false;
+        expect(screen.screen._elements).to.not.include(e.element);
     });
 });


### PR DESCRIPTION
Fixes https://github.com/playcanvas/engine/issues/2705.

This PR changes the Element component to no longer subscribe to Screen events for various Screen property changes. Instead each Element component is stored in an internal set in the Screen component, and the Screen component calls the Element functions directly.

This is a lot faster and uses less memory in the expense of using some private Element functions from the Screen component.