### PR TITLE
[FIX] Animation#setName to Animation#name

### DIFF
--- a/src/resources/animation.js
+++ b/src/resources/animation.js
@@ -66,7 +66,7 @@ class AnimationHandler {
         var animData = data.animation;
 
         var anim = new Animation();
-        anim.setName(animData.name);
+        anim.name = animData.name;
         anim.duration = animData.duration;
 
         for (var i = 0; i < animData.nodes.length; i++) {
@@ -101,7 +101,7 @@ class AnimationHandler {
         var animData = data.animation;
 
         var anim = new Animation();
-        anim.setName(animData.name);
+        anim.name = animData.name;
         anim.duration = animData.duration;
 
         for (var i = 0; i < animData.nodes.length; i++) {


### PR DESCRIPTION
`AnimationHandler` was using deprecated API.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
