### PR TITLE
fix bad merge - from area light branch

### DIFF
--- a/src/graphics/program-lib/programs/standard.js
+++ b/src/graphics/program-lib/programs/standard.js
@@ -1515,10 +1515,6 @@ var standard = {
                 code += "   addReflection();\n";
             }
 
-            if (options.dirLightMap) {
-                code += "   addDirLightMap();\n";
-            }
-
             if (hasAreaLights){
                 // specular has to be accumulated differently if we want area lights to look correct
                 code += "   ccReflection.rgb *= ccSpecularity;\n";


### PR DESCRIPTION
Fixes shader compile error when using directional light maps

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
