### PR TITLE
Lazily create AudioContext

### DIFF
--- a/src/audio/capabilities.js
+++ b/src/audio/capabilities.js
@@ -1,17 +1,6 @@
 /**
  * @private
  * @function
- * @name pc.SoundManager.hasAudio
- * @description Reports whether this device supports the HTML5 Audio tag API.
- * @returns {boolean} True if HTML5 Audio tag API is supported and false otherwise.
- */
-function hasAudio() {
-    return (typeof Audio !== 'undefined');
-}
-
-/**
- * @private
- * @function
  * @name pc.SoundManager.hasAudioContext
  * @description Reports whether this device supports the Web Audio API.
  * @returns {boolean} True if Web Audio is supported and false otherwise.
@@ -20,4 +9,4 @@ function hasAudioContext() {
     return !!(typeof AudioContext !== 'undefined' || typeof webkitAudioContext !== 'undefined');
 }
 
-export { hasAudio, hasAudioContext };
+export { hasAudioContext };

--- a/src/audio/channel.js
+++ b/src/audio/channel.js
@@ -1,6 +1,6 @@
 import { math } from '../math/math.js';
 
-import { hasAudio, hasAudioContext } from './capabilities.js';
+import { hasAudioContext } from './capabilities.js';
 
 /**
  * @private
@@ -36,12 +36,10 @@ class Channel {
 
             const context = manager.context;
             this.gain = context.createGain();
-        } else if (hasAudio()) {
+        } else if (sound.audio) {
             // handle the case where sound was
-            if (sound.audio) {
-                this.source = sound.audio.cloneNode(false);
-                this.source.pause(); // not initially playing
-            }
+            this.source = sound.audio.cloneNode(false);
+            this.source.pause(); // not initially playing
         }
     }
 
@@ -274,7 +272,7 @@ if (hasAudioContext()) {
             }
         }
     });
-} else if (hasAudio()) {
+} else {
     Object.assign(Channel.prototype, {
         play: function () {
             if (this.source) {

--- a/src/resources/audio.js
+++ b/src/resources/audio.js
@@ -2,7 +2,7 @@ import { path } from '../core/path.js';
 
 import { http, Http } from '../net/http.js';
 
-import { hasAudio, hasAudioContext } from '../audio/capabilities.js';
+import { hasAudioContext } from '../audio/capabilities.js';
 
 import { Sound } from '../sound/sound.js';
 
@@ -136,7 +136,7 @@ class AudioHandler {
 
                 manager.context.decodeAudioData(response, success, error);
             });
-        } else if (hasAudio()) {
+        } else {
             var audio = null;
 
             try {

--- a/src/sound/listener.js
+++ b/src/sound/listener.js
@@ -1,8 +1,6 @@
 import { Vec3 } from '../math/vec3.js';
 import { Mat4 } from '../math/mat4.js';
 
-import { hasAudioContext } from '../audio/capabilities.js';
-
 /**
  * @private
  * @class
@@ -12,13 +10,11 @@ import { hasAudioContext } from '../audio/capabilities.js';
  */
 class Listener {
     constructor(manager) {
+        this._manager = manager;
+
         this.position = new Vec3();
         this.velocity = new Vec3();
         this.orientation = new Mat4();
-
-        if (hasAudioContext()) {
-            this.listener = manager.context.listener;
-        }
     }
 
     getPosition() {
@@ -27,8 +23,9 @@ class Listener {
 
     setPosition(position) {
         this.position.copy(position);
-        if (this.listener) {
-            this.listener.setPosition(position.x, position.y, position.z);
+        const listener = this.listener;
+        if (listener) {
+            listener.setPosition(position.x, position.y, position.z);
         }
     }
 
@@ -38,21 +35,28 @@ class Listener {
 
     setVelocity(velocity) {
         this.velocity.copy(velocity);
-        if (this.listener) {
-            this.listener.setPosition(velocity.x, velocity.y, velocity.z);
+        const listener = this.listener;
+        if (listener) {
+            listener.setPosition(velocity.x, velocity.y, velocity.z);
         }
     }
 
     setOrientation(orientation) {
         this.orientation.copy(orientation);
-        if (this.listener) {
-            this.listener.setOrientation(-orientation.data[8], -orientation.data[9], -orientation.data[10],
-                                         orientation.data[4], orientation.data[5], orientation.data[6]);
+        const listener = this.listener;
+        if (listener) {
+            listener.setOrientation(-orientation.data[8], -orientation.data[9], -orientation.data[10],
+                                     orientation.data[4], orientation.data[5], orientation.data[6]);
         }
     }
 
     getOrientation() {
         return this.orientation;
+    }
+
+    get listener() {
+        const context = this._manager.context;
+        return context ? context.listener : null;
     }
 }
 

--- a/src/sound/listener.js
+++ b/src/sound/listener.js
@@ -46,7 +46,7 @@ class Listener {
         const listener = this.listener;
         if (listener) {
             listener.setOrientation(-orientation.data[8], -orientation.data[9], -orientation.data[10],
-                                     orientation.data[4], orientation.data[5], orientation.data[6]);
+                                    orientation.data[4], orientation.data[5], orientation.data[6]);
         }
     }
 

--- a/src/sound/manager.js
+++ b/src/sound/manager.js
@@ -3,7 +3,7 @@ import { EventHandler } from '../core/event-handler.js';
 
 import { math } from '../math/math.js';
 
-import { hasAudio, hasAudioContext } from '../audio/capabilities.js';
+import { hasAudioContext } from '../audio/capabilities.js';
 import { Channel } from '../audio/channel.js';
 import { Channel3d } from '../audio/channel3d.js';
 
@@ -68,9 +68,6 @@ class SoundManager extends EventHandler {
         } else {
             console.warn('No support for 3D audio found');
         }
-
-        if (!hasAudio())
-            console.warn('No support for 2D audio found');
 
         this.listener = new Listener(this);
 


### PR DESCRIPTION
Related to https://github.com/playcanvas/engine/issues/2678

This PR will lazily create the AudioContext if there are no audio assets or audio related components in the scene. This will prevent a relevant Chrome warning to show up.
