### PR TITLE
fix light shape property causing incorrect light mapping

### DIFF
--- a/src/framework/components/light/system.js
+++ b/src/framework/components/light/system.js
@@ -72,7 +72,6 @@ class LightComponentSystem extends ComponentSystem {
 
         var light = new Light();
         light.type = lightTypes[data.type];
-        light.shape = data.shape;
         light._node = component.entity;
         light._scene = this.app.scene;
         component.data.light = light;

--- a/src/scene/light.js
+++ b/src/scene/light.js
@@ -452,25 +452,26 @@ class Light {
     }
 
     get shape() {
-        return this._shape ? this._shape : LIGHTSHAPE_PUNCTUAL;
+        return this._shape;
     }
 
     set shape(value) {
-        if (this._shape === value)
+        var sanitizedValue = value ? value : LIGHTSHAPE_PUNCTUAL;
+
+        if (this._shape === sanitizedValue)
             return;
 
-        if (value !== LIGHTSHAPE_PUNCTUAL) {
+        if (sanitizedValue !== LIGHTSHAPE_PUNCTUAL) {
             this.uploadAreaLightLUTs();
         }
 
-        this._shape = value ? value : LIGHTSHAPE_PUNCTUAL;
+        this._shape = sanitizedValue;
         this._destroyShadowMap();
         this.updateKey();
 
         var stype = this._shadowType;
         this._shadowType = null;
         this.shadowType = stype; // refresh shadow type; switching shape and back may change it
-
     }
 
     get shadowType() {

--- a/src/scene/light.js
+++ b/src/scene/light.js
@@ -455,17 +455,15 @@ class Light {
         return this._shape;
     }
 
-    set shape(value) {
-        var sanitizedValue = value ? value : LIGHTSHAPE_PUNCTUAL;
-
-        if (this._shape === sanitizedValue)
+    set shape(value = LIGHTSHAPE_PUNCTUAL) {
+        if (this._shape === value)
             return;
 
-        if (sanitizedValue !== LIGHTSHAPE_PUNCTUAL) {
+        if (value !== LIGHTSHAPE_PUNCTUAL) {
             this.uploadAreaLightLUTs();
         }
 
-        this._shape = sanitizedValue;
+        this._shape = value;
         this._destroyShadowMap();
         this.updateKey();
 

--- a/src/scene/light.js
+++ b/src/scene/light.js
@@ -452,7 +452,7 @@ class Light {
     }
 
     get shape() {
-        return this._shape;
+        return this._shape ? this._shape : LIGHTSHAPE_PUNCTUAL;
     }
 
     set shape(value) {
@@ -463,7 +463,7 @@ class Light {
             this.uploadAreaLightLUTs();
         }
 
-        this._shape = value;
+        this._shape = value ? value : LIGHTSHAPE_PUNCTUAL;
         this._destroyShadowMap();
         this.updateKey();
 


### PR DESCRIPTION
Fixes #2716

this fixes light map problems with unmigrated lights in editor

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
