### PR TITLE
[Fix] Area light compatibility

### DIFF
--- a/examples/graphics/area-lights.html
+++ b/examples/graphics/area-lights.html
@@ -47,6 +47,10 @@
                 material.normalMap = assetManifest[1].asset.resource;
                 material.glossMap = assetManifest[2].asset.resource;
                 material.metalness = 0.7;
+
+                material.diffuseMapTiling.set(7, 7);
+                material.normalMapTiling.set(7, 7);
+                material.glossMapTiling.set(7, 7);
             }
 
             material.update();

--- a/src/graphics/device.js
+++ b/src/graphics/device.js
@@ -684,9 +684,13 @@ class GraphicsDevice extends EventHandler {
         this._destroyedTextures = new Set();    // list of textures that have already been reported as destroyed
         // #endif
 
-        // area light LUT format
-        this._areaLightLutFormat = (this.extTextureFloat) ? PIXELFORMAT_RGBA32F : (this.extTextureHalfFloat && this.textureHalfFloatUpdatable) ? PIXELFORMAT_RGBA16F : PIXELFORMAT_R8_G8_B8_A8;
-
+        // area light LUT format - order of preference: half, float, 8bit
+        this._areaLightLutFormat = PIXELFORMAT_R8_G8_B8_A8;
+        if (this.extTextureHalfFloat && this.textureHalfFloatUpdatable) {
+            this._areaLightLutFormat = PIXELFORMAT_RGBA16F;
+        } else if (this.extTextureFloat) {
+            this._areaLightLutFormat = PIXELFORMAT_RGBA32F;
+        }
     }
 
     // #ifdef DEBUG


### PR DESCRIPTION
- LUT tables for area lights prefer formats in this order for improved compatibility: half, float, 8bit
- adjusted repeat on floor textures in area lights demo to give them higher resolution look

<img width="1716" alt="Screen Shot 2021-01-15 at 11 44 42 AM" src="https://user-images.githubusercontent.com/59932779/104723366-143fd200-5727-11eb-9011-baf28edf0247.png">
