### PR TITLE
[Fix] Forward renderer uses Mat3 instead of Mat4 in VR mode

### DIFF
--- a/src/scene/forward-renderer.js
+++ b/src/scene/forward-renderer.js
@@ -93,8 +93,8 @@ var viewR = new Mat4();
 var viewPosL = new Vec3();
 var viewPosR = new Vec3();
 var projL, projR;
-var viewMat3L = new Mat4();
-var viewMat3R = new Mat4();
+var viewMat3L = new Mat3();
+var viewMat3R = new Mat3();
 var viewProjMatL = new Mat4();
 var viewProjMatR = new Mat4();
 


### PR DESCRIPTION
fixes bug introduced in the last release, where Mat4to3 function was extracted from two files and unified.

Related to forum post: https://forum.playcanvas.com/t/webvr-polyfill-error-after-update/16933/11