### PR TITLE
LayerComposition refactor to simplify rendering to texture

### DIFF
--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -657,7 +657,7 @@ class Application extends EventHandler {
             opaqueSortMode: SORTMODE_NONE,
             passThrough: true
         });
-        this.defaultLayerComposition = new LayerComposition();
+        this.defaultLayerComposition = new LayerComposition("default");
 
         this.defaultLayerComposition.pushOpaque(this.defaultLayerWorld);
         this.defaultLayerComposition.pushOpaque(this.defaultLayerDepth);
@@ -1041,7 +1041,7 @@ class Application extends EventHandler {
 
         // set up layers
         if (props.layers && props.layerOrder) {
-            var composition = new LayerComposition();
+            var composition = new LayerComposition("application");
 
             var layers = {};
             for (var key in props.layers) {

--- a/src/framework/components/camera/component.js
+++ b/src/framework/components/camera/component.js
@@ -73,6 +73,8 @@ import { PostEffectQueue } from './post-effect-queue.js';
  * the Y-axis). Used for {@link pc.PROJECTION_ORTHOGRAPHIC} cameras only. Defaults to 10.
  * @property {number} priority Controls the order in which cameras are rendered. Cameras
  * with smaller values for priority are rendered first. Defaults to 0.
+ * @property {pc.RenderTarget} renderTarget Render target to which rendering of the cameras
+ * is performed. If not set, it will render simply to the screen.
  * @property {pc.Vec4} rect Controls where on the screen the camera will be rendered in
  * normalized screen coordinates. Defaults to [0, 0, 1, 1].
  * @property {pc.Vec4} scissorRect Clips all pixels which are not in the rectangle.
@@ -176,12 +178,9 @@ class CameraComponent extends Component {
     set priority(newValue) {
         this._priority = newValue;
 
-        var layers = this.layers;
-        for (var i = 0; i < layers.length; i++) {
-            var layer = this.system.app.scene.layers.getLayerById(layers[i]);
-            if (!layer) continue;
-            layer._sortCameras();
-        }
+        // layer composition needs to update order
+        let layerComp = this.system.app.scene.layers;
+        layerComp._dirtyCameras = true;
     }
 
     /**
@@ -235,8 +234,9 @@ class CameraComponent extends Component {
         var layers = this.layers;
         for (var i = 0; i < layers.length; i++) {
             var layer = this.system.app.scene.layers.getLayerById(layers[i]);
-            if (!layer) continue;
-            layer.addCamera(this);
+            if (layer) {
+                layer.addCamera(this);
+            }
         }
     }
 
@@ -244,8 +244,9 @@ class CameraComponent extends Component {
         var layers = this.layers;
         for (var i = 0; i < layers.length; i++) {
             var layer = this.system.app.scene.layers.getLayerById(layers[i]);
-            if (!layer) continue;
-            layer.removeCamera(this);
+            if (layer) {
+                layer.removeCamera(this);
+            }
         }
     }
 

--- a/src/framework/components/camera/post-effect-pass.js
+++ b/src/framework/components/camera/post-effect-pass.js
@@ -233,7 +233,6 @@ class PostEffectPass {
             }
         });
 
-        this.layer._generateCameraHash(); // post effect doesn't contain actual cameras, but we need to generate cam data
         this.layer.isPostEffect = true;
         this.layer.unmodifiedUvs = options.unmodifiedUvs;
         this.layer.postEffectBilinear = options.bilinear;

--- a/src/graphics/render-target.js
+++ b/src/graphics/render-target.js
@@ -61,6 +61,11 @@ class RenderTarget {
             this._colorBuffer = options.colorBuffer;
         }
 
+        // mark color buffer texture as render target
+        if (this._colorBuffer) {
+            this._colorBuffer._isRenderTarget = true;
+        }
+
         this._glFrameBuffer = null;
         this._glDepthBuffer = null;
 

--- a/src/scene/layer-composition.js
+++ b/src/scene/layer-composition.js
@@ -15,7 +15,7 @@ import { RenderAction } from './render-action.js';
  * @classdesc Layer Composition is a collection of {@link pc.Layer} that is fed to {@link pc.Scene#layers} to define rendering order.
  * @description Create a new layer composition.
  * @param {string} [name] - Optional non-unique name of the layer composition. Defaults to "Untitled" if not specified.
-  * @property {pc.Layer[]} layerList A read-only array of {@link pc.Layer} sorted in the order they will be rendered.
+ * @property {pc.Layer[]} layerList A read-only array of {@link pc.Layer} sorted in the order they will be rendered.
  * @property {boolean[]} subLayerList A read-only array of boolean values, matching {@link pc.Layer#layerList}.
  * True means only semi-transparent objects are rendered, and false means opaque.
  * @property {boolean[]} subLayerEnabled A read-only array of boolean values, matching {@link pc.Layer#layerList}.

--- a/src/scene/layer-composition.js
+++ b/src/scene/layer-composition.js
@@ -14,7 +14,8 @@ import { RenderAction } from './render-action.js';
  * @augments pc.EventHandler
  * @classdesc Layer Composition is a collection of {@link pc.Layer} that is fed to {@link pc.Scene#layers} to define rendering order.
  * @description Create a new layer composition.
- * @property {pc.Layer[]} layerList A read-only array of {@link pc.Layer} sorted in the order they will be rendered.
+ * @param {string} [name] - Optional non-unique name of the layer composition. Defaults to "Untitled" if not specified.
+  * @property {pc.Layer[]} layerList A read-only array of {@link pc.Layer} sorted in the order they will be rendered.
  * @property {boolean[]} subLayerList A read-only array of boolean values, matching {@link pc.Layer#layerList}.
  * True means only semi-transparent objects are rendered, and false means opaque.
  * @property {boolean[]} subLayerEnabled A read-only array of boolean values, matching {@link pc.Layer#layerList}.
@@ -24,8 +25,10 @@ import { RenderAction } from './render-action.js';
  */
 // Composition can hold only 2 sublayers of each layer
 class LayerComposition extends EventHandler {
-    constructor() {
+    constructor(name = "Untitled") {
         super();
+
+        this.name = name;
 
         // all layers added into the composition
         this.layerList = [];
@@ -335,14 +338,17 @@ class LayerComposition extends EventHandler {
                 renderAction = renderActions[renderActionCount] = new RenderAction();
             }
 
+            // render target from the camera takes precedence over the render target from the layer
+            var rt = layer.renderTarget;
+            var camera = layer.cameras[cameraIndex];
+            if (camera && camera.renderTarget) {
+                rt = camera.renderTarget;
+            }
+
             // store the properties
             renderAction.layerIndex = layerIndex;
             renderAction.cameraIndex = cameraIndex;
-
-            // render target for rendering - target from the camera overrrides target from the layer
-            var camera = layer.cameras[cameraIndex];
-            var cameraTarget = camera ? camera.renderTarget : undefined;
-            renderAction.renderTarget = cameraTarget ? cameraTarget : layer.renderTarget;
+            renderAction.renderTarget = rt;
 
             renderActionCount++;
         }
@@ -353,14 +359,13 @@ class LayerComposition extends EventHandler {
             this._dirtyCameras = false;
             result |= COMPUPDATED_CAMERAS;
 
+            // walk the layers and build an array of unique cameras from all layers
             this.cameras.length = 0;
-
-            // walk the layers
             for (i = 0; i < len; i++) {
                 layer = this.layerList[i];
                 layer._dirtyCameras = false;
 
-                // build array of unique cameras from all layers
+                // for all cameras in the layer
                 for (j = 0; j < layer.cameras.length; j++) {
                     camera = layer.cameras[j];
                     index = this.cameras.indexOf(camera);
@@ -370,61 +375,40 @@ class LayerComposition extends EventHandler {
                 }
             }
 
-            var hash, groupLength;
-            var skipCount = 0;
+            // sort cameras by priority
+            if (this.cameras.length > 1) {
+                this.cameras.sort((a, b) => a.priority - b.priority);
+            }
 
-            // build render actions array which is the actual rendering sequence based on layers and cameras attached to them
-            for (i = 0; i < len; i++) {
+            // render in order of cameras sorted by priority
+            for (i = 0; i < this.cameras.length; i++) {
+                camera = this.cameras[i];
 
-                if (skipCount) {
-                    skipCount--;
-                    continue;
-                }
+                // walk all global sorted list of layers (sublayers) to check if camera renders it
+                // this adds both opaque and transparent sublayers if camera renders the layer
+                for (j = 0; j < len; j++) {
 
-                layer = this.layerList[i];
-                if (layer.cameras.length === 0 && !layer.isPostEffect) {
-                    continue;
-                }
+                    layer = this.layerList[j];
+                    if (layer) {
 
-                hash = layer._cameraHash;
+                        // if layer needs to be rendered
+                        if (layer.cameras.length > 0 || layer.isPostEffect) {
 
-                // single camera in layer
-                if (hash === 0) {
-                    addRenderAction(layer, i, 0);
+                            // if the camera renders this layer
+                            if (camera.layers.indexOf(layer.id) >= 0) {
 
-                } else { // multiple cameras in a layer
+                                // camera index in the layer array
+                                cameraIndex = layer.cameras.indexOf(camera);
+                                if (cameraIndex >= 0) {
+                                    addRenderAction(layer, j, cameraIndex);
+                                }
 
-                    // count a sequence of following sublayers with the same cameras
-                    groupLength = 1;
-                    for (j = i + 1; j < len; j++) {
-                        if (hash !== this.layerList[j]._cameraHash) {
-                            groupLength = (j - i) - 1;
-                            break;
-                        } else if (j === len - 1) {
-                            groupLength = j - i;
-                        }
-                    }
+                            } else if (layer.isPostEffect) {
 
-                    if (groupLength === 1) {
-
-                        // no sequence - render all cameras for this layer
-                        for (cameraIndex = 0; cameraIndex < layer.cameras.length; cameraIndex++) {
-                            addRenderAction(layer, i, cameraIndex);
-                        }
-
-                    } else {
-
-                        // sequence of groupLength - add a whole sequence for each camera
-                        // sequence is added by camera to minimize number of times directional shadows gets re-rendered, which is done per camera
-                        // this changes sequence: Layer1 (Camera1, Camera2), Layer2 (Camera1, Camera2) to sequence:
-                        // Camera1(Layer1, Layer2), Camera2 (Layer1, Layer2) to group layer rendering into the same camera.
-                        for (cameraIndex = 0; cameraIndex < layer.cameras.length; cameraIndex++) {
-                            for (j = 0; j <= groupLength; j++) {
-                                addRenderAction(layer, i + j, cameraIndex);
+                                // post-effect layers don't have camera
+                                addRenderAction(layer, j, -1);
                             }
                         }
-                        // skip the sequence sublayers (can't just modify i in JS)
-                        skipCount = groupLength;
                     }
                 }
             }

--- a/src/scene/layer.js
+++ b/src/scene/layer.js
@@ -37,10 +37,6 @@ function sortFrontToBack(drawCallA, drawCallB) {
 
 var sortCallbacks = [null, sortManual, sortMaterialMesh, sortBackToFront, sortFrontToBack];
 
-function sortCameras(camA, camB) {
-    return camA.priority - camB.priority;
-}
-
 function sortLights(lightA, lightB) {
     return lightB.key - lightA.key;
 }
@@ -110,7 +106,6 @@ class InstanceList {
  * * {@link pc.SORTMODE_FRONT2BACK}
  *
  * Defaults to pc.SORTMODE_BACK2FRONT.
- * @property {pc.RenderTarget} renderTarget Render target to which rendering is performed. If not set, will render simply to the screen.
  * @property {number} shaderPass A type of shader to use during rendering. Possible values are:
  *
  * * {@link pc.SHADER_FORWARD}
@@ -252,9 +247,6 @@ class Layer {
         this._dirtyLights = false;
         this._dirtyCameras = false;
 
-        // if there is single camera in a layer, this is 0, otherwise unique ID of the combination of the cameras
-        this._cameraHash = 0;
-
         this._lightHash = 0;
         this._staticLightHash = 0;
         this._needsStaticPrepare = true;
@@ -390,14 +382,6 @@ class Layer {
         }
         this._refCounter--;
     }
-
-    // SUBLAYER GROUPS
-    // If there are multiple sublayer with identical _cameraHash without anything in between, these
-    // are called a SUBLAYER GROUP instead of:
-    //     for each sublayer
-    //         for each camera
-    // we go:
-    //     for each sublayerGroup
 
     /**
      * @function
@@ -627,22 +611,6 @@ class Layer {
         }
     }
 
-    _generateCameraHash() {
-        // generate hash to check if cameras in layers are identical
-        // order of cameras shouldn't matter
-        if (this.cameras.length > 1) {
-            this.cameras.sort(sortCameras);
-            var str = "";
-            for (var i = 0; i < this.cameras.length; i++) {
-                str += this.cameras[i].entity.getGuid();
-            }
-            this._cameraHash = hashCode(str);
-        } else {
-            this._cameraHash = 0;
-        }
-        this._dirtyCameras = true;
-    }
-
     /**
      * @function
      * @name pc.Layer#addCamera
@@ -652,7 +620,7 @@ class Layer {
     addCamera(camera) {
         if (this.cameras.indexOf(camera) >= 0) return;
         this.cameras.push(camera);
-        this._generateCameraHash();
+        this._dirtyCameras = true;
     }
 
     /**
@@ -665,7 +633,7 @@ class Layer {
         var id = this.cameras.indexOf(camera);
         if (id < 0) return;
         this.cameras.splice(id, 1);
-        this._generateCameraHash();
+        this._dirtyCameras = true;
 
         // visible lists in layer are not updated after camera is removed
         // so clear out any remaining mesh instances
@@ -679,12 +647,7 @@ class Layer {
      */
     clearCameras() {
         this.cameras.length = 0;
-        this._cameraHash = 0;
         this._dirtyCameras = true;
-    }
-
-    _sortCameras() {
-        this._generateCameraHash();
     }
 
     _calculateSortDistances(drawCalls, drawCallsCount, camPos, camFwd) {

--- a/src/scene/picker.js
+++ b/src/scene/picker.js
@@ -237,7 +237,7 @@ class Picker {
                 }
             });
 
-            this.layerComp = new LayerComposition();
+            this.layerComp = new LayerComposition("picker");
             this.layerComp.pushOpaque(this.layer);
 
             this.meshInstances = this.layer.opaqueMeshInstances;
@@ -305,7 +305,7 @@ class Picker {
         }
 
         // save old camera state
-        this.onLayerPreRender(this.layer, sourceLayer, sourceRt);
+        let originalLayers = this.onLayerPreRender(this.layer, sourceLayer, sourceRt, camera);
 
         // clear registered meshes, rendering will register them again
         self.mapping.length = 0;
@@ -314,10 +314,10 @@ class Picker {
         this.app.renderer.renderComposition(this.layerComp);
 
         // restore old camera state
-        this.onLayerPostRender(this.layer);
+        this.onLayerPostRender(this.layer, camera, originalLayers);
     }
 
-    onLayerPreRender(layer, sourceLayer, sourceRt) {
+    onLayerPreRender(layer, sourceLayer, sourceRt, camera) {
         if (this.width !== layer.renderTarget.width || this.height !== layer.renderTarget.height) {
             layer.onDisable();
             layer.onEnable();
@@ -334,14 +334,25 @@ class Picker {
         var rt = sourceRt ? sourceRt : (sourceLayer ? sourceLayer.renderTarget : null);
         layer.cameras[0].aspectRatio = layer.cameras[0].calculateAspectRatio(rt);
         this.app.renderer.updateCameraFrustum(layer.cameras[0].camera);
+
+        // add layer to be rendered by the camera
+        let originalLayers = camera.layers.slice();
+        let cameraLayers = camera.layers;
+        cameraLayers.push(this.layer.id);
+        camera.layers = cameraLayers;
+
+        return originalLayers;
     }
 
-    onLayerPostRender(layer) {
+    onLayerPostRender(layer, camera, originalLayers) {
 
         // restore original settings
         layer.cameras[0].camera._clearOptions = layer.oldClear;
         layer.cameras[0].aspectRatioMode = layer.oldAspectMode;
         layer.cameras[0].aspectRatio = layer.oldAspect;
+
+        // restore camera layers to original condition
+        camera.layers = originalLayers;
     }
 
     /**


### PR DESCRIPTION
Refactoring of the way LayerComposition builds up a list of cameras / layers to be rendered:
- The overall rendering order is driven by cameras, and not layers. All cameras are sorted by priority, and each camera renders all layers assigned to it in the order specified by layer ordering. When rendering to textures, this makes the engine to switch to each render target exactly one time per frame, instead of switching between render targets when walking layers, which was costing us fill rate heavy restore and resolve operations each time.
- This simplified the way rendering to texture can be set up, as seen in PR with examples for this: https://github.com/playcanvas/engine/pull/2757

**API changes**
- Layer.renderTarget is deprecated (still supported)
- Camera.RenderTarget is made public as preferred way to set up rendering to texture
- LayerComposition constructor takes optional name parameter, useful for debugging of multiple compositions
