### PR TITLE
Fix 9-slice tiling not rendering as expected

### DIFF
--- a/src/graphics/program-lib/chunks/startNineSlicedTiled.frag
+++ b/src/graphics/program-lib/chunks/startNineSlicedTiled.frag
@@ -1,4 +1,6 @@
     vec2 tileMask = step(vMask, vec2(0.99999));
-    vec2 clampedUv = mix(innerOffset.xy*0.5, vec2(1.0) - innerOffset.zw*0.5, fract(vTiledUv));
+    vec2 tileSize = 0.5 * (innerOffset.xy + innerOffset.zw);
+    vec2 tileScale = vec2(1.0) / (vec2(1.0) - tileSize);
+    vec2 clampedUv = mix(innerOffset.xy * 0.5, vec2(1.0) - innerOffset.zw * 0.5, fract((vTiledUv - tileSize) * tileScale));
     clampedUv = clampedUv * atlasRect.zw + atlasRect.xy;
     nineSlicedUv = vUv0 * tileMask + clampedUv * (vec2(1.0) - tileMask);


### PR DESCRIPTION
Fixes #1526 

Though it might be better to declare tileSize and tileScale as uniforms and compute them only when needed

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
