### PR TITLE
[AnimComponent] Relative path resolution

### DIFF
--- a/src/anim/binder/default-anim-binder.js
+++ b/src/anim/binder/default-anim-binder.js
@@ -127,7 +127,7 @@ class DefaultAnimBinder {
     resolve(path) {
         var propertyLocation = AnimBinder.decode(path);
 
-        var node = this.graph.root.findByPath(`${this.graph.path}/${propertyLocation.entityPath[0] || ""}`);
+        var node = this.graph.findByPath(propertyLocation.entityPath[0]);
         if (!node) {
             var entityPath = AnimBinder.splitPath(propertyLocation.entityPath[0], '/');
             node = this.nodes[entityPath[entityPath.length - 1] || ""];

--- a/src/framework/components/anim/component-binder.js
+++ b/src/framework/components/anim/component-binder.js
@@ -82,7 +82,7 @@ class AnimComponentBinder extends DefaultAnimBinder {
                 break;
             case 'graph':
                 if (entity.model && entity.model.model && entity.model.model.graph) {
-                    propertyComponent = pc.app.root.findByPath(`${entity.model.model.graph.path}/${propertyLocation.entityPath[0]}`);
+                    propertyComponent = entity.model.model.graph.findByPath(propertyLocation.entityPath[0]);
                 }
                 if (!propertyComponent) {
                     var entityPath = AnimBinder.splitPath(propertyLocation.entityPath[0], '/');


### PR DESCRIPTION
Use relative paths from the anim components entity when resolving animation curve paths. This ensure sibling entities with the same name in the scene will not interfere with each others animation binding.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
