### PR TITLE
New interface for RenderComponent to handle wireframe and point render style

### DIFF
--- a/src/framework/components/render/component.js
+++ b/src/framework/components/render/component.js
@@ -1,4 +1,3 @@
-import { LAYERID_WORLD, RENDERSTYLE_WIREFRAME } from '../../../scene/constants.js';
 import { BatchGroup } from '../../../scene/batching/batch-group.js';
 import { MeshInstance } from '../../../scene/mesh-instance.js';
 import { SkinInstance } from '../../../scene/skin-instance.js';
@@ -425,33 +424,16 @@ class RenderComponent extends Component {
     /**
      * @private
      * @function
-     * @name pc.RenderComponent#generateWireframe
-     * @description Generates the necessary internal data for this component to be
-     * renderable as wireframe. Once this function has been called, any mesh
-     * instance can have its renderStyle property set to pc.RENDERSTYLE_WIREFRAME.
-     * @example
-     * render.generateWireframe();
-     * for (var i = 0; i < render.meshInstances.length; i++) {
-     *     render.meshInstances[i].renderStyle = pc.RENDERSTYLE_WIREFRAME;
-     * }
+     * @name pc.RenderComponent#setRenderStyle
+     * @description Set rendering of all {@link pc.MeshInstance}s to the specified render style.
+     * @param {number} renderStyle - The render style. Can be:
+     *
+     * * {@link pc.RENDERSTYLE_SOLID}
+     * * {@link pc.RENDERSTYLE_WIREFRAME}
+     * * {@link pc.RENDERSTYLE_POINTS}
      */
-    generateWireframe() {
-
-        // Build an array of unique meshes
-        var i, mesh, meshes = [];
-        for (i = 0; i < this._meshInstances.length; i++) {
-            mesh = this._meshInstances[i].mesh;
-            if (meshes.indexOf(mesh) === -1) {
-                meshes.push(mesh);
-            }
-        }
-
-        for (i = 0; i < meshes.length; ++i) {
-            mesh = meshes[i];
-            if (!mesh.primitive[RENDERSTYLE_WIREFRAME]) {
-                mesh.generateWireframe();
-            }
-        }
+    setRenderStyle(renderStyle) {
+        MeshInstance._prepareRenderStyleForArray(this._meshInstances, renderStyle);
     }
 
     get aabb() {

--- a/src/framework/components/render/component.js
+++ b/src/framework/components/render/component.js
@@ -1,3 +1,4 @@
+import { LAYERID_WORLD, RENDERSTYLE_SOLID } from '../../../scene/constants.js';
 import { BatchGroup } from '../../../scene/batching/batch-group.js';
 import { MeshInstance } from '../../../scene/mesh-instance.js';
 import { SkinInstance } from '../../../scene/skin-instance.js';
@@ -46,6 +47,10 @@ import { EntityReference } from '../../utils/entity-reference.js';
  * @property {number[]} layers An array of layer IDs ({@link pc.Layer#id}) to which the meshes should belong.
  * Don't push/pop/splice or modify this array, if you want to change it - set a new one instead.
  * @property {pc.Entity} rootBone A reference to the entity to be used as the root bone for any skinned meshes that are rendered by this component.
+ * @property {number} renderStyle Set rendering of all {@link pc.MeshInstance}s to the specified render style. Can be one of the following:
+ * * {@link pc.RENDERSTYLE_SOLID}
+ * * {@link pc.RENDERSTYLE_WIREFRAME}
+ * * {@link pc.RENDERSTYLE_POINTS}
  */
 class RenderComponent extends Component {
     constructor(system, entity)   {
@@ -62,6 +67,7 @@ class RenderComponent extends Component {
 
         this._meshInstances = [];
         this._layers = [LAYERID_WORLD]; // assign to the default world layer
+        this._renderStyle = RENDERSTYLE_SOLID;
 
         // bounding box which can be set to override bounding box based on mesh
         this._aabb = null;
@@ -421,19 +427,15 @@ class RenderComponent extends Component {
         }
     }
 
-    /**
-     * @private
-     * @function
-     * @name pc.RenderComponent#setRenderStyle
-     * @description Set rendering of all {@link pc.MeshInstance}s to the specified render style.
-     * @param {number} renderStyle - The render style. Can be:
-     *
-     * * {@link pc.RENDERSTYLE_SOLID}
-     * * {@link pc.RENDERSTYLE_WIREFRAME}
-     * * {@link pc.RENDERSTYLE_POINTS}
-     */
-    setRenderStyle(renderStyle) {
-        MeshInstance._prepareRenderStyleForArray(this._meshInstances, renderStyle);
+    get renderStyle() {
+        return this._renderStyle;
+    }
+
+    set renderStyle(renderStyle) {
+        if (this._renderStyle !== renderStyle) {
+            this._renderStyle = renderStyle;
+            MeshInstance._prepareRenderStyleForArray(this._meshInstances, renderStyle);
+        }
     }
 
     get aabb() {

--- a/src/scene/mesh-instance.js
+++ b/src/scene/mesh-instance.js
@@ -151,6 +151,27 @@ class MeshInstance {
         this.flipFaces = false;
     }
 
+    static _meshSet = new Set();
+
+    // generates wireframes for an array of mesh instances
+    static _prepareRenderStyleForArray(meshInstances, renderStyle) {
+
+        for (let i = 0; i < meshInstances.length; i++) {
+
+            // switch mesh instance to the requested style
+            meshInstances[i].renderStyle = renderStyle;
+
+            // process all unique meshes
+            let mesh = meshInstances[i].mesh;
+            if (!MeshInstance._meshSet.has(mesh)) {
+                MeshInstance._meshSet.add(mesh);
+                mesh.prepareRenderState(renderStyle);
+            }
+        }
+
+        MeshInstance._meshSet.clear();
+    }
+
     get mesh() {
         return this._mesh;
     }

--- a/src/scene/mesh-instance.js
+++ b/src/scene/mesh-instance.js
@@ -15,6 +15,8 @@ import {
 var _tmpAabb = new BoundingBox();
 var _tempBoneAabb = new BoundingBox();
 var _tempSphere = new BoundingSphere();
+var _meshSet = new Set();
+
 
 // internal data structure used to store data used by hardware instancing
 class InstancingData {
@@ -151,8 +153,6 @@ class MeshInstance {
         this.flipFaces = false;
     }
 
-    static _meshSet = new Set();
-
     // generates wireframes for an array of mesh instances
     static _prepareRenderStyleForArray(meshInstances, renderStyle) {
 
@@ -163,13 +163,13 @@ class MeshInstance {
 
             // process all unique meshes
             let mesh = meshInstances[i].mesh;
-            if (!MeshInstance._meshSet.has(mesh)) {
-                MeshInstance._meshSet.add(mesh);
+            if (!_meshSet.has(mesh)) {
+                _meshSet.add(mesh);
                 mesh.prepareRenderState(renderStyle);
             }
         }
 
-        MeshInstance._meshSet.clear();
+        _meshSet.clear();
     }
 
     get mesh() {

--- a/src/scene/mesh.js
+++ b/src/scene/mesh.js
@@ -710,6 +710,9 @@ class Mesh extends RefCountedObject {
             this._geometryData.vertexStreamsUpdated = false;
             this._geometryData.indexStreamUpdated = false;
             this._geometryData.recreate = false;
+
+            // update other render states
+            this.updateRenderStates();
         }
     }
 
@@ -788,6 +791,18 @@ class Mesh extends RefCountedObject {
                 count: this.vertexBuffer ? this.vertexBuffer.numVertices : 0,
                 indexed: false
             };
+        }
+    }
+
+    // updates existing render states with changes to solid render state
+    updateRenderStates() {
+
+        if (this.primitive[RENDERSTYLE_POINTS]) {
+            this.prepareRenderState(RENDERSTYLE_POINTS);
+        }
+
+        if (this.primitive[RENDERSTYLE_WIREFRAME]) {
+            this.prepareRenderState(RENDERSTYLE_WIREFRAME);
         }
     }
 

--- a/src/scene/mesh.js
+++ b/src/scene/mesh.js
@@ -5,17 +5,18 @@ import { BoundingBox } from '../shape/bounding-box.js';
 
 import {
     BUFFER_DYNAMIC, BUFFER_STATIC,
-    INDEXFORMAT_UINT8, INDEXFORMAT_UINT16, INDEXFORMAT_UINT32,
-    PRIMITIVE_LINES, PRIMITIVE_TRIANGLES,
+    INDEXFORMAT_UINT16, INDEXFORMAT_UINT32,
+    PRIMITIVE_LINES, PRIMITIVE_TRIANGLES, PRIMITIVE_POINTS,
     SEMANTIC_BLENDINDICES, SEMANTIC_BLENDWEIGHT, SEMANTIC_COLOR, SEMANTIC_NORMAL, SEMANTIC_POSITION, SEMANTIC_TEXCOORD,
-    TYPE_FLOAT32, TYPE_UINT8
+    TYPE_FLOAT32, TYPE_UINT8,
+    typedArrayIndexFormats
 } from '../graphics/constants.js';
 import { IndexBuffer } from '../graphics/index-buffer.js';
 import { VertexBuffer } from '../graphics/vertex-buffer.js';
 import { VertexFormat } from '../graphics/vertex-format.js';
 import { VertexIterator } from '../graphics/vertex-iterator.js';
 
-import { RENDERSTYLE_SOLID, RENDERSTYLE_WIREFRAME } from './constants.js';
+import { RENDERSTYLE_SOLID, RENDERSTYLE_WIREFRAME, RENDERSTYLE_POINTS } from './constants.js';
 
 import { Application } from '../framework/application.js';
 
@@ -220,15 +221,19 @@ class Mesh extends RefCountedObject {
             this.vertexBuffer = null;
         }
 
-        var j, ib;
-        for (j = 0; j < this.indexBuffer.length; j++) {
-            ib = this.indexBuffer[j];
-            if (ib)
-                ib.destroy();
+        for (let j = 0; j < this.indexBuffer.length; j++) {
+            this._destroyIndexBuffer(j);
         }
 
         this.indexBuffer.length = 0;
         this._geometryData = null;
+    }
+
+    _destroyIndexBuffer(index) {
+        if (this.indexBuffer[index]) {
+            this.indexBuffer[index].destroy();
+            this.indexBuffer[index] = null;
+        }
     }
 
     // initializes local bounding boxes for each bone based on vertices affected by the bone
@@ -772,19 +777,24 @@ class Mesh extends RefCountedObject {
         }
     }
 
+    // prepares the mesh to be rendered with specific render style
+    prepareRenderState(renderStyle) {
+        if (renderStyle === RENDERSTYLE_WIREFRAME) {
+            this.generateWireframe();
+        } else if (renderStyle === RENDERSTYLE_POINTS) {
+            this.primitive[RENDERSTYLE_POINTS] = {
+                type: PRIMITIVE_POINTS,
+                base: 0,
+                count: this.vertexBuffer ? this.vertexBuffer.numVertices : 0,
+                indexed: false
+            };
+        }
+    }
+
     generateWireframe() {
-        var typedArray = function (indexBuffer) {
-            switch (indexBuffer.format) {
-                case INDEXFORMAT_UINT8:
-                    return new Uint8Array(indexBuffer.storage);
-                case INDEXFORMAT_UINT16:
-                    return new Uint16Array(indexBuffer.storage);
-                case INDEXFORMAT_UINT32:
-                    return new Uint32Array(indexBuffer.storage);
-                default:
-                    return null;
-            }
-        };
+
+        // release existing IB
+        this._destroyIndexBuffer(RENDERSTYLE_WIREFRAME);
 
         var lines = [];
         var format;
@@ -794,7 +804,7 @@ class Mesh extends RefCountedObject {
             var base = this.primitive[RENDERSTYLE_SOLID].base;
             var count = this.primitive[RENDERSTYLE_SOLID].count;
             var indexBuffer = this.indexBuffer[RENDERSTYLE_SOLID];
-            var srcIndices = typedArray(indexBuffer);
+            var srcIndices = new typedArrayIndexFormats[indexBuffer.format](indexBuffer.storage);
 
             var uniqueLineIndices = {};
 
@@ -818,7 +828,7 @@ class Mesh extends RefCountedObject {
         }
 
         var wireBuffer = new IndexBuffer(this.vertexBuffer.device, format, lines.length);
-        var dstIndices = typedArray(wireBuffer);
+        var dstIndices = new typedArrayIndexFormats[wireBuffer.format](wireBuffer.storage);
         dstIndices.set(lines);
         wireBuffer.unlock();
 

--- a/src/scene/model.js
+++ b/src/scene/model.js
@@ -188,24 +188,7 @@ class Model {
      * }
      */
     generateWireframe() {
-        var i;
-        var mesh;
-
-        // Build an array of unique meshes in this model
-        var meshes = [];
-        for (i = 0; i < this.meshInstances.length; i++) {
-            mesh = this.meshInstances[i].mesh;
-            if (meshes.indexOf(mesh) === -1) {
-                meshes.push(mesh);
-            }
-        }
-
-        for (i = 0; i < meshes.length; ++i) {
-            mesh = meshes[i];
-            if (!mesh.primitive[RENDERSTYLE_WIREFRAME]) {
-                mesh.generateWireframe();
-            }
-        }
+        MeshInstance._prepareRenderStyleForArray(this.meshInstances, RENDERSTYLE_WIREFRAME);
     }
 }
 


### PR DESCRIPTION
API changes:

```javascript
RenderComponent#generateWireframe // removed this private interface
RenderComponent#renderStyle       // new property accepting RENDERSTYLE_XXX constants.
```

When different render styles exist on the Mesh, they get automatically updated when mesh updates - so that procedurally updated geometry can render in wireless without user having to manually update it.

addresses part of https://github.com/playcanvas/engine/issues/2753


https://user-images.githubusercontent.com/59932779/105339697-e51cdb00-5bd4-11eb-98db-f5c0163870af.mov

![Screen Shot 2021-01-20 at 6 35 14 PM](https://user-images.githubusercontent.com/59932779/105219896-e4d9fc80-5b4e-11eb-9b20-c2d9044d111c.png)

![Screen Shot 2021-01-20 at 6 34 49 PM](https://user-images.githubusercontent.com/59932779/105219906-e73c5680-5b4e-11eb-8ab1-ba7eeda2a10b.png)
