### PR TITLE
fix diffuse only materials and working with directional light map

### DIFF
--- a/src/graphics/program-lib/programs/standard.js
+++ b/src/graphics/program-lib/programs/standard.js
@@ -458,7 +458,6 @@ var standard = {
 
         if (options.dirLightMap) {
             lighting = true;
-            options.useSpecular = true;
         }
 
         if (options.shadingModel === SPECULAR_PHONG) {
@@ -1348,7 +1347,7 @@ var standard = {
 
         var addAmbient = true;
         if (options.lightMap || options.lightVertexColor) {
-            var lightmapChunkPropName = options.dirLightMap ? 'lightmapDirPS' : 'lightmapSinglePS';
+            var lightmapChunkPropName = (options.dirLightMap && options.useSpecular) ? 'lightmapDirPS' : 'lightmapSinglePS';
             code += this._addMap("light", lightmapChunkPropName, options, chunks, options.lightMapFormat);
             addAmbient = options.lightMapWithoutAmbient;
         }


### PR DESCRIPTION
Fixes #2769

Handle the case of diffuse only materials and directional light map correctly in the standard material generator - which results in correct rendering.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
