### PR TITLE
[Animation] Binding updates and bug fixes

### DIFF
--- a/src/anim/binder/anim-binder.js
+++ b/src/anim/binder/anim-binder.js
@@ -51,41 +51,22 @@ class AnimBinder {
      * @private
      * @static
      * @function
-     * @name pc.AnimPropertyLocator#encode
+     * @name pc.AnimBinder#encode
      * @description Converts a locator array into its string version
-     * @param {Array} locator - The property location in the scene defined as an array
+     * @param {string|Array} entityPath - The entity location in the scene defined as an array or string path
+     * @param {string} component - The component of the entity the property is located under
+     * @param {string|Array} propertyPath - The property location in the entity defined as an array or string path
      * @returns {string} The locator encoded as a string
      * @example
      * // returns 'spotLight/light/color.r'
      * encode({ entityPath: ['spotLight'], component: 'light', propertyPath: ['color', 'r'] });
      */
-    static encode(locator) {
-        return AnimBinder.joinPath([
-            AnimBinder.joinPath(Array.isArray(locator.entityPath) ? locator.entityPath : [locator.entityPath]),
-            locator.component,
-            AnimBinder.joinPath(Array.isArray(locator.propertyPath) ? locator.propertyPath : [locator.propertyPath])
-        ], '/');
-    }
-
-    /**
-     * @private
-     * @static
-     * @function
-     * @name pc.AnimPropertyLocator#decode
-     * @description Converts a locator string into its array version
-     * @param {Array} locator - The property location in the scene defined as a string
-     * @returns {Array} - The locator decoded into an array
-     * @example
-     * // returns { entityPath: ['spotLight'], component: 'light', propertyPath: ['color', 'r'] }
-     * decode('spotLight/light/color.r');
-     */
-    static decode(locator) {
-        var locatorSections = AnimBinder.splitPath(locator, '/');
-        return {
-            entityPath: AnimBinder.splitPath(locatorSections[0]),
-            component: locatorSections[1],
-            propertyPath: AnimBinder.splitPath(locatorSections[2])
-        };
+    static encode(entityPath, component, propertyPath) {
+        return `${
+            Array.isArray(entityPath) ? AnimBinder.joinPath(entityPath) : entityPath
+        }/${component}/${
+            Array.isArray(propertyPath) ? AnimBinder.joinPath(propertyPath) : propertyPath
+        }`;
     }
 
     /**

--- a/src/anim/binder/anim-binder.js
+++ b/src/anim/binder/anim-binder.js
@@ -59,13 +59,13 @@ class AnimBinder {
      * @returns {string} The locator encoded as a string
      * @example
      * // returns 'spotLight/light/color.r'
-     * encode({ entityPath: ['spotLight'], component: 'light', propertyPath: ['color', 'r'] });
+     * encode(['spotLight'], 'light', ['color', 'r']);
      */
     static encode(entityPath, component, propertyPath) {
         return `${
-            Array.isArray(entityPath) ? AnimBinder.joinPath(entityPath) : entityPath
+            Array.isArray(entityPath) ? entityPath.join('/') : entityPath
         }/${component}/${
-            Array.isArray(propertyPath) ? AnimBinder.joinPath(propertyPath) : propertyPath
+            Array.isArray(propertyPath) ? propertyPath.join('/') : propertyPath
         }`;
     }
 

--- a/src/anim/binder/default-anim-binder.js
+++ b/src/anim/binder/default-anim-binder.js
@@ -128,8 +128,11 @@ class DefaultAnimBinder {
         };
     }
 
-    findNode(graph, path) {
-        var node = graph.findByPath(path.entityPath);
+    findNode(path) {
+        var node;
+        if (this.graph) {
+            node = this.graph.findByPath(path.entityPath);
+        }
         if (!node) {
             node = this.nodes[path.entityPath[path.entityPath.length - 1] || ""];
 
@@ -154,7 +157,7 @@ class DefaultAnimBinder {
         var target = this.targetCache[encodedPath];
         if (target) return target;
 
-        var node = this.findNode(this.graph, path);
+        var node = this.findNode(path);
         if (!node) {
             return null;
         }

--- a/src/anim/binder/default-anim-binder.js
+++ b/src/anim/binder/default-anim-binder.js
@@ -184,8 +184,7 @@ class DefaultAnimBinder {
         if (path.component !== 'graph')
             return;
 
-        var entityPathArr = AnimBinder.splitPath(path.entityPath, '/');
-        var node = this.nodes[entityPathArr[entityPathArr.length - 1] || ""];
+        var node = this.nodes[path.entityPath[path.entityPath.length - 1] || ""];
 
         this.nodeCounts[node.path]--;
         if (this.nodeCounts[node.path] === 0) {

--- a/src/anim/binder/default-anim-binder.js
+++ b/src/anim/binder/default-anim-binder.js
@@ -56,7 +56,12 @@ class DefaultAnimBinder {
                 var func = function (value) {
                     object.set.apply(object, value);
                 };
-                return new AnimTarget(func, 'vector', 3);
+                var targetIdentifier = AnimBinder.encode({
+                    entityPath: node.path,
+                    component: 'entity',
+                    propertyPath: 'localPosition'
+                });
+                return new AnimTarget(func, 'vector', 3, targetIdentifier);
             },
 
             'localRotation': function (node) {
@@ -64,7 +69,12 @@ class DefaultAnimBinder {
                 var func = function (value) {
                     object.set.apply(object, value);
                 };
-                return new AnimTarget(func, 'quaternion', 4);
+                var targetIdentifier = AnimBinder.encode({
+                    entityPath: node.path,
+                    component: 'entity',
+                    propertyPath: 'localRotation'
+                });
+                return new AnimTarget(func, 'quaternion', 4, targetIdentifier);
             },
 
             'localScale': function (node) {
@@ -72,7 +82,12 @@ class DefaultAnimBinder {
                 var func = function (value) {
                     object.set.apply(object, value);
                 };
-                return new AnimTarget(func, 'vector', 3);
+                var targetIdentifier = AnimBinder.encode({
+                    entityPath: node.path,
+                    component: 'entity',
+                    propertyPath: 'localScale'
+                });
+                return new AnimTarget(func, 'vector', 3, targetIdentifier);
             },
 
             'weights': function (node) {
@@ -91,7 +106,12 @@ class DefaultAnimBinder {
                                 morphInstance.setWeight(i, value[i]);
                             }
                         };
-                        return new AnimTarget(func, 'vector', morphInstance.morph._targets.length);
+                        var targetIdentifier = AnimBinder.encode({
+                            entityPath: node.path,
+                            component: 'entity',
+                            propertyPath: 'weights'
+                        });
+                        return new AnimTarget(func, 'vector', morphInstance.morph._targets.length, targetIdentifier);
                     }
                 }
 
@@ -115,7 +135,12 @@ class DefaultAnimBinder {
                                 meshInstance.material.update();
                             }
                         }.bind(this);
-                        return new AnimTarget(func, 'vector', 1);
+                        var targetIdentifier = AnimBinder.encode({
+                            entityPath: node.path,
+                            component: 'material',
+                            propertyPath: 'materialTexture'
+                        });
+                        return new AnimTarget(func, 'vector', 1, targetIdentifier);
                     }
                 }
 

--- a/src/anim/binder/default-anim-binder.js
+++ b/src/anim/binder/default-anim-binder.js
@@ -129,7 +129,7 @@ class DefaultAnimBinder {
     }
 
     findNode(graph, path) {
-        var node = graph.findByPath(path.entityPath.join('/'));
+        var node = graph.findByPath(path.entityPath);
         if (!node) {
             node = this.nodes[path.entityPath[path.entityPath.length - 1] || ""];
 
@@ -150,7 +150,8 @@ class DefaultAnimBinder {
     }
 
     resolve(path) {
-        var target = this.targetCache[AnimBinder.encode(path.entityPath, path.component, path.propertyPath)];
+        var encodedPath = AnimBinder.encode(path.entityPath, path.component, path.propertyPath);
+        var target = this.targetCache[encodedPath];
         if (target) return target;
 
         var node = this.findNode(this.graph, path);
@@ -168,7 +169,7 @@ class DefaultAnimBinder {
             return null;
         }
 
-        this.targetCache[AnimBinder.encode(path.entityPath, path.component, path.propertyPath)] = target;
+        this.targetCache[encodedPath] = target;
 
         if (!this.nodeCounts[node.path]) {
             this.activeNodes.push(node);

--- a/src/anim/controller/anim-controller.js
+++ b/src/anim/controller/anim-controller.js
@@ -130,7 +130,9 @@ class AnimController {
         var maxDuration = 0.0;
         for (var i = 0; i < this.activeStateAnimations.length; i++) {
             var activeClip = this._animEvaluator.findClip(this.activeStateAnimations[i].name);
-            maxDuration = Math.max(maxDuration, activeClip.track.duration);
+            if (activeClip) {
+                maxDuration = Math.max(maxDuration, activeClip.track.duration);
+            }
         }
         return maxDuration;
     }
@@ -388,10 +390,6 @@ class AnimController {
     }
 
     _transitionToState(newStateName) {
-        if (newStateName === this._activeStateName) {
-            return;
-        }
-
         if (!this._findState(newStateName)) {
             return;
         }

--- a/src/anim/controller/anim-controller.js
+++ b/src/anim/controller/anim-controller.js
@@ -456,6 +456,10 @@ class AnimController {
         this._animEvaluator.removeClips();
     }
 
+    rebind() {
+        this._animEvaluator.rebind();
+    }
+
     update(dt) {
         if (!this._playing) {
             return;

--- a/src/anim/controller/anim-state.js
+++ b/src/anim/controller/anim-state.js
@@ -41,8 +41,9 @@ class AnimState {
     }
 
     addAnimation(path, animTrack) {
+        var pathString = path.join('.');
         var indexOfAnimation = this._animationList.findIndex(function (animation) {
-            return animation.path === path;
+            return animation.path === pathString;
         });
         if (indexOfAnimation >= 0) {
             this._animationList[indexOfAnimation].animTrack = animTrack;

--- a/src/anim/evaluator/anim-evaluator.js
+++ b/src/anim/evaluator/anim-evaluator.js
@@ -132,25 +132,23 @@ class AnimEvaluator {
             var paths = curve.paths;
             for (var j = 0; j < paths.length; ++j) {
                 var path = paths[j];
-                var target = targets[path];
+                var resolved = this._binder.resolve(path);
+                var target = targets[resolved && resolved.targetIdentifier || null];
 
                 // create new target if it doesn't exist yet
-                if (!target) {
-                    var resolved = this._binder.resolve(path);
-                    if (resolved) {
-                        target = {
-                            target: resolved,           // resolved target instance
-                            value: [],                  // storage for calculated value
-                            curves: 0,                  // number of curves driving this target
-                            blendCounter: 0             // per-frame number of blends (used to identify first blend)
-                        };
+                if (!target && resolved) {
+                    target = {
+                        target: resolved,           // resolved target instance
+                        value: [],                  // storage for calculated value
+                        curves: 0,                  // number of curves driving this target
+                        blendCounter: 0             // per-frame number of blends (used to identify first blend)
+                    };
 
-                        for (var k = 0; k < target.target.components; ++k) {
-                            target.value.push(0);
-                        }
-
-                        targets[path] = target;
+                    for (var k = 0; k < target.target.components; ++k) {
+                        target.value.push(0);
                     }
+
+                    targets[resolved.targetIdentifier] = target;
                 }
 
                 // binding may have failed
@@ -190,13 +188,13 @@ class AnimEvaluator {
             for (var j = 0; j < paths.length; ++j) {
                 var path = paths[j];
 
-                var target = targets[path];
+                var target = this._binder.resolve(path);
 
                 if (target) {
                     target.curves--;
                     if (target.curves === 0) {
                         this._binder.unresolve(path);
-                        delete targets[path];
+                        delete targets[target.targetIdentifier];
                     }
                 }
             }
@@ -236,6 +234,16 @@ class AnimEvaluator {
             }
         }
         return null;
+    }
+
+    rebind() {
+        this._binder.rebind();
+        this._targets = {};
+        var clips = [...this.clips];
+        this.removeClips();
+        clips.forEach(clip => {
+            this.addClip(clip);
+        });
     }
 
     /**

--- a/src/anim/evaluator/anim-evaluator.js
+++ b/src/anim/evaluator/anim-evaluator.js
@@ -133,7 +133,7 @@ class AnimEvaluator {
             for (var j = 0; j < paths.length; ++j) {
                 var path = paths[j];
                 var resolved = this._binder.resolve(path);
-                var target = targets[resolved && resolved.targetIdentifier || null];
+                var target = targets[resolved && resolved.targetPath || null];
 
                 // create new target if it doesn't exist yet
                 if (!target && resolved) {
@@ -148,7 +148,7 @@ class AnimEvaluator {
                         target.value.push(0);
                     }
 
-                    targets[resolved.targetIdentifier] = target;
+                    targets[resolved.targetPath] = target;
                 }
 
                 // binding may have failed
@@ -194,7 +194,7 @@ class AnimEvaluator {
                     target.curves--;
                     if (target.curves === 0) {
                         this._binder.unresolve(path);
-                        delete targets[target.targetIdentifier];
+                        delete targets[target.targetPath];
                     }
                 }
             }

--- a/src/anim/evaluator/anim-target.js
+++ b/src/anim/evaluator/anim-target.js
@@ -19,11 +19,11 @@
  * of components found on all attached animation curves).
  */
 class AnimTarget {
-    constructor(func, type, components, targetIdentifier) {
+    constructor(func, type, components, targetPath) {
         this._func = func;
         this._type = type;
         this._components = components;
-        this._targetIdentifier = targetIdentifier;
+        this._targetPath = targetPath;
     }
 
     get func() {
@@ -38,8 +38,8 @@ class AnimTarget {
         return this._components;
     }
 
-    get targetIdentifier() {
-        return this._targetIdentifier;
+    get targetPath() {
+        return this._targetPath;
     }
 }
 

--- a/src/anim/evaluator/anim-target.js
+++ b/src/anim/evaluator/anim-target.js
@@ -19,10 +19,11 @@
  * of components found on all attached animation curves).
  */
 class AnimTarget {
-    constructor(func, type, components) {
+    constructor(func, type, components, targetIdentifier) {
         this._func = func;
         this._type = type;
         this._components = components;
+        this._targetIdentifier = targetIdentifier;
     }
 
     get func() {
@@ -35,6 +36,10 @@ class AnimTarget {
 
     get components() {
         return this._components;
+    }
+
+    get targetIdentifier() {
+        return this._targetIdentifier;
     }
 }
 

--- a/src/framework/components/anim/component-binder.js
+++ b/src/framework/components/anim/component-binder.js
@@ -67,7 +67,8 @@ class AnimComponentBinder extends DefaultAnimBinder {
     }
 
     resolve(path) {
-        var target = this.targetCache[AnimBinder.encode(path.entityPath, path.component, path.propertyPath)];
+        var encodedPath = AnimBinder.encode(path.entityPath, path.component, path.propertyPath);
+        var target = this.targetCache[encodedPath];
         if (target) return target;
 
         var entity;
@@ -109,7 +110,7 @@ class AnimComponentBinder extends DefaultAnimBinder {
         }
 
         target = this._createAnimTargetForProperty(propertyComponent, path.propertyPath, targetPath);
-        this.targetCache[AnimBinder.encode(path.entityPath, path.component, path.propertyPath)] = target;
+        this.targetCache[encodedPath] = target;
         return target;
     }
 
@@ -133,7 +134,7 @@ class AnimComponentBinder extends DefaultAnimBinder {
         if (entityHierarchy.length === 1) {
             return currEntity;
         }
-        return currEntity._parent.findByPath(Array.isArray(entityHierarchy) ? entityHierarchy.join('/') : entityHierarchy);
+        return currEntity._parent.findByPath(entityHierarchy);
     }
 
     // resolve an object path

--- a/src/framework/components/anim/component-binder.js
+++ b/src/framework/components/anim/component-binder.js
@@ -86,9 +86,7 @@ class AnimComponentBinder extends DefaultAnimBinder {
                 propertyComponent = entity;
                 break;
             case 'graph':
-                entity = this.animComponent.entity;
-                var graph = entity.model && entity.model.model && entity.model.model.graph;
-                propertyComponent = this.findNode(graph, path);
+                propertyComponent = this.findNode(path);
                 if (!propertyComponent) return null;
                 targetPath = AnimBinder.encode(
                     propertyComponent.path,
@@ -266,10 +264,11 @@ class AnimComponentBinder extends DefaultAnimBinder {
         // #ifdef DEBUG
         this.visitedFallbackGraphPaths = {};
         // #endif
-        var entity = this.animComponent && this.animComponent.entity;
-        var graph = entity.model && entity.model.model && entity.model.model.graph;
-        if (!graph) return;
-        this.graph = graph;
+
+        if (this.animComponent.entity.model?.model?.graph) {
+            this.graph = this.animComponent.entity.model?.model?.graph;
+        }
+
         var nodes = { };
         // cache node names so we can quickly resolve animation paths
         var flatten = function (node) {

--- a/src/framework/components/anim/component-layer.js
+++ b/src/framework/components/anim/component-layer.js
@@ -48,6 +48,16 @@ class AnimComponentLayer {
         this._controller.reset();
     }
 
+    /**
+     * @private
+     * @function
+     * @name pc.AnimComponentLayer#rebind
+     * @description Rebind any animations in the layer to the currently present components and model of the anim components entity.
+     */
+    rebind() {
+        this._controller.rebind();
+    }
+
     update(dt) {
         this._controller.update(dt);
     }

--- a/src/framework/components/anim/component.js
+++ b/src/framework/components/anim/component.js
@@ -53,11 +53,8 @@ class AnimComponent extends Component {
         data.layers = [];
 
         var graph;
-        if (this.entity.model) {
-            var m = this.entity.model.model;
-            if (m) {
-                graph = m.getGraph();
-            }
+        if (this.entity.model?.model?.graph) {
+            graph = this.entity.model?.model?.graph;
         } else {
             // animating hierarchy without model
             graph = this.entity;

--- a/src/framework/components/anim/component.js
+++ b/src/framework/components/anim/component.js
@@ -175,6 +175,18 @@ class AnimComponent extends Component {
     /**
      * @private
      * @function
+     * @name pc.AnimComponent#rebind
+     * @description Rebind all of the components layers
+     */
+    rebind() {
+        for (var i = 0; i < this.data.layers.length; i++) {
+            this.data.layers[i].rebind();
+        }
+    }
+
+    /**
+     * @private
+     * @function
      * @name pc.AnimComponent#findAnimationLayer
      * @description Finds a pc.AnimComponentLayer in this component.
      * @param {string} layerName - The name of the anim component layer to find

--- a/src/framework/components/anim/component.js
+++ b/src/framework/components/anim/component.js
@@ -226,9 +226,9 @@ class AnimComponent extends Component {
     /**
      * @private
      * @function
-     * @name pc.AnimComponent#removeStateAnimations
-     * @description Removes animations from a state in the loaded state graph.
-     * @param {string} nodeName - The name of the state node that should have its animation tracks removed.
+     * @name pc.AnimComponent#removeNodeAnimations
+     * @description Removes animations from a node in the loaded state graph.
+     * @param {string} nodeName - The name of the node that should have its animation tracks removed.
      * @param {string?} layerName - The name of the anim component layer to update. If omitted the default layer is used.
      */
     removeNodeAnimations(nodeName, layerName) {

--- a/src/framework/components/model/component.js
+++ b/src/framework/components/model/component.js
@@ -642,7 +642,11 @@ class ModelComponent extends Component {
 
             // Update any animation component
             if (this.entity.anim) {
-                this.entity.anim.resetStateGraph();
+                if (this.entity.anim.playing) {
+                    this.entity.anim.rebind();
+                } else {
+                    this.entity.anim.resetStateGraph();
+                }
             }
             // trigger event handler to load mapping
             // for new model

--- a/src/resources/parser/glb-parser.js
+++ b/src/resources/parser/glb-parser.js
@@ -1253,11 +1253,11 @@ var createAnimation = function (gltfAnimation, animationIndex, gltfAccessors, bu
         var target = channel.target;
         var curve = curves[channel.sampler];
 
-        curve._paths.push(AnimBinder.encode({
-            entityPath: [nodes[target.node].path],
+        curve._paths.push({
+            entityPath: AnimBinder.splitPath(nodes[target.node].path, '/'),
             component: 'graph',
             propertyPath: [transformSchema[target.path]]
-        }));
+        });
 
         // if this target is a set of quaternion keys, make note of its index so we can perform
         // quaternion-specific processing on it.

--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -474,7 +474,13 @@ class GraphNode extends EventHandler {
      */
     findByPath(path) {
         // if the path isn't an array, split the path in parts. Each part represents a deeper hierarchy level
-        var parts = Array.isArray(path) ? path : path.split('/');
+        var parts;
+        if (Array.isArray(path)) {
+            if (path.length === 0) return null;
+            parts = path;
+        } else {
+            parts = path.split('/');
+        }
         var currentParent = this;
         var result = null;
 

--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -467,14 +467,14 @@ class GraphNode extends EventHandler {
      * @name pc.GraphNode#findByPath
      * @description Get the first node found in the graph by its full path in the graph.
      * The full path has this form 'parent/child/sub-child'. The search is depth first.
-     * @param {string} path - The full path of the pc.GraphNode.
+     * @param {string|Array} path - The full path of the pc.GraphNode as either a string or array of pc.GraphNode names
      * @returns {pc.GraphNode} The first node to be found matching the supplied path.
      * @example
      * var path = this.entity.findByPath('child/another_child');
      */
     findByPath(path) {
-        // split the paths in parts. Each part represents a deeper hierarchy level
-        var parts = path.split('/');
+        // if the path isn't an array, split the path in parts. Each part represents a deeper hierarchy level
+        var parts = Array.isArray(path) ? path : path.split('/');
         var currentParent = this;
         var result = null;
 

--- a/tests/anim/test_anim.js
+++ b/tests/anim/test_anim.js
@@ -14,12 +14,11 @@ describe("pc.AnimEvaluator", function () {
         // create curve
         var keys = new pc.AnimData(1, [0, 1, 2]);
         var translations = new pc.AnimData(3, [0, 0, 0, 1, 0, 0, 1, 0, 1]);
-        var curvePath = pc.AnimBinder.encode({
-            entityPath: 'child1',
+        var curvePath = {
+            entityPath: ['child1'],
             component: 'graph',
-            propertyPath: 'localPosition'
-        });
-        console.log(curvePath);
+            propertyPath: ['localPosition']
+        };
         var curve = new pc.AnimCurve([curvePath], 0, 0, pc.INTERPOLATION_LINEAR);
 
         // construct the animation track


### PR DESCRIPTION
- Adds the rebind function to the anim component and component layers to allow for any currently playing animations to rebind using current entity properties.
- Uses absolute scene paths when storing AnimTargets in the AnimEvaluator to ensure the correct blending and assignment of animations even when animation curve paths mismatch the scene structure.
- Fixes jsdocs for the AnimComponent
- Fixes the AnimState.addAnimation function to overwrite existing animations when the same path is used


**New API:**
```javascript
// Rebind any animations in the layer to the currently present components and model of the anim components entity
pc.AnimComponentLayer#rebind: function ();
// Rebind all of the components layers
pc.AnimComponent#rebind: function ();
```

Fixes #2771 
Fixes #2751
Fixes #2788
Fixes #2786

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
