### PR TITLE
[FIX] npm package not working with Node.js

### DIFF
--- a/src/polyfill/OESVertexArrayObject.js
+++ b/src/polyfill/OESVertexArrayObject.js
@@ -277,6 +277,7 @@ OESVertexArrayObject.prototype.bindVertexArrayOES = function bindVertexArrayOES(
 };
 
 // You MUST call this BEFORE adding event listeners for 'webglcontextrestored'
+if(typeof window !== 'undefined'){
 window.setupVertexArrayObject = function(gl) {
     // Ignore if already installed (or the browser provides the extension)
     // FIXME: when all stable browsers support getSupportedExtensions
@@ -292,6 +293,7 @@ window.setupVertexArrayObject = function(gl) {
             return;
         }
     }
+}
 
     if (gl.getSupportedExtensions) {
         var original_getSupportedExtensions = gl.getSupportedExtensions;

--- a/src/xr/xr-hand.js
+++ b/src/xr/xr-hand.js
@@ -13,7 +13,7 @@ var vecA = new Vec3();
 var vecB = new Vec3();
 var vecC = new Vec3();
 
-if (window.XRHand) {
+if (typeof window !== 'undefined' && window.XRHand) {
     fingerJointIds = [
         [XRHand.THUMB_METACARPAL, XRHand.THUMB_PHALANX_PROXIMAL, XRHand.THUMB_PHALANX_DISTAL, XRHand.THUMB_PHALANX_TIP],
         [XRHand.INDEX_METACARPAL, XRHand.INDEX_PHALANX_PROXIMAL, XRHand.INDEX_PHALANX_INTERMEDIATE, XRHand.INDEX_PHALANX_DISTAL, XRHand.INDEX_PHALANX_TIP],

--- a/src/xr/xr-joint.js
+++ b/src/xr/xr-joint.js
@@ -2,7 +2,7 @@ import { Mat4 } from '../math/mat4.js';
 import { Quat } from '../math/quat.js';
 import { Vec3 } from '../math/vec3.js';
 
-var tipJointIds = window.XRHand ? [
+var tipJointIds = typeof window !== 'undefined' && window.XRHand ? [
     XRHand.THUMB_PHALANX_TIP,
     XRHand.INDEX_PHALANX_TIP,
     XRHand.MIDDLE_PHALANX_TIP,


### PR DESCRIPTION
#### Fixed this issue. 
ReferenceError: window is not defined #2372

This pull request fixes a problem with Node.js that was not working.
Added environment detection when window is used.

#### Versions
- Node.js : v14.15.0
- playcanvas: v1.38.4
- macOS Catalina 10.15.5

##### Before
An error occurs when I try to use PlayCanvas with Node.js.

![1](https://user-images.githubusercontent.com/39250588/105790220-3955ff80-5fc7-11eb-98fa-ba6ace102d23.png)

##### After
![2](https://user-images.githubusercontent.com/39250588/105790217-38bd6900-5fc7-11eb-99f9-446352f08734.png)


I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
