### PR TITLE
Don't add post effects to the pc namespace

### DIFF
--- a/examples/assets/scripts/posteffects/posteffect-blend.js
+++ b/examples/assets/scripts/posteffects/posteffect-blend.js
@@ -71,7 +71,7 @@ var Blend = pc.createScript('blend');
 
 Blend.attributes.add('mixRatio', {
     type: 'number',
-    default: 1,
+    default: 0.5,
     min: 0,
     max: 1,
     title: 'Mix Ratio'
@@ -86,7 +86,9 @@ Blend.attributes.add('blendMap', {
 Blend.prototype.initialize = function () {
     this.effect = new BlendEffect(this.app.graphicsDevice);
     this.effect.mixRatio = this.mixRatio;
-    this.effect.blendMap = this.blendMap.resource;
+    if (this.blendMap) {
+        this.effect.blendMap = this.blendMap.resource;
+    }
 
     var queue = this.entity.camera.postEffects;
 

--- a/examples/assets/scripts/posteffects/posteffect-blend.js
+++ b/examples/assets/scripts/posteffects/posteffect-blend.js
@@ -1,77 +1,70 @@
 // --------------- POST EFFECT DEFINITION --------------- //
-Object.assign(pc, function () {
+/**
+ * @class
+ * @name BlendEffect
+ * @classdesc Blends the input render target with another texture.
+ * @description Creates new instance of the post effect.
+ * @augments pc.PostEffect
+ * @param {pc.GraphicsDevice} graphicsDevice - The graphics device of the application.
+ * @property {pc.Texture} blendMap The texture with which to blend the input render target with.
+ * @property {number} mixRatio The amount of blending between the input and the blendMap. Ranges from 0 to 1.
+ */
+function BlendEffect(graphicsDevice) {
+    pc.PostEffect.call(this, graphicsDevice);
 
-    /**
-     * @class
-     * @name pc.BlendEffect
-     * @classdesc Blends the input render target with another texture.
-     * @description Creates new instance of the post effect.
-     * @augments pc.PostEffect
-     * @param {pc.GraphicsDevice} graphicsDevice - The graphics device of the application.
-     * @property {pc.Texture} blendMap The texture with which to blend the input render target with.
-     * @property {number} mixRatio The amount of blending between the input and the blendMap. Ranges from 0 to 1.
-     */
-    var BlendEffect = function (graphicsDevice) {
-        pc.PostEffect.call(this, graphicsDevice);
-
-        this.shader = new pc.Shader(graphicsDevice, {
-            attributes: {
-                aPosition: pc.SEMANTIC_POSITION
-            },
-            vshader: [
-                "attribute vec2 aPosition;",
-                "",
-                "varying vec2 vUv0;",
-                "",
-                "void main(void)",
-                "{",
-                "    gl_Position = vec4(aPosition, 0.0, 1.0);",
-                "    vUv0 = (aPosition.xy + 1.0) * 0.5;",
-                "}"
-            ].join("\n"),
-            fshader: [
-                "precision " + graphicsDevice.precision + " float;",
-                "",
-                "uniform float uMixRatio;",
-                "uniform sampler2D uColorBuffer;",
-                "uniform sampler2D uBlendMap;",
-                "",
-                "varying vec2 vUv0;",
-                "",
-                "void main(void)",
-                "{",
-                "    vec4 texel1 = texture2D(uColorBuffer, vUv0);",
-                "    vec4 texel2 = texture2D(uBlendMap, vUv0);",
-                "    gl_FragColor = mix(texel1, texel2, uMixRatio);",
-                "}"
-            ].join("\n")
-        });
-
-        // Uniforms
-        this.mixRatio = 0.5;
-        this.blendMap = new pc.Texture(graphicsDevice);
-        this.blendMap.name = 'pe-blend';
-    };
-
-    BlendEffect.prototype = Object.create(pc.PostEffect.prototype);
-    BlendEffect.prototype.constructor = BlendEffect;
-
-    Object.assign(BlendEffect.prototype, {
-        render: function (inputTarget, outputTarget, rect) {
-            var device = this.device;
-            var scope = device.scope;
-
-            scope.resolve("uMixRatio").setValue(this.mixRatio);
-            scope.resolve("uColorBuffer").setValue(inputTarget.colorBuffer);
-            scope.resolve("uBlendMap").setValue(this.blendMap);
-            pc.drawFullscreenQuad(device, outputTarget, this.vertexBuffer, this.shader, rect);
-        }
+    this.shader = new pc.Shader(graphicsDevice, {
+        attributes: {
+            aPosition: pc.SEMANTIC_POSITION
+        },
+        vshader: [
+            "attribute vec2 aPosition;",
+            "",
+            "varying vec2 vUv0;",
+            "",
+            "void main(void)",
+            "{",
+            "    gl_Position = vec4(aPosition, 0.0, 1.0);",
+            "    vUv0 = (aPosition.xy + 1.0) * 0.5;",
+            "}"
+        ].join("\n"),
+        fshader: [
+            "precision " + graphicsDevice.precision + " float;",
+            "",
+            "uniform float uMixRatio;",
+            "uniform sampler2D uColorBuffer;",
+            "uniform sampler2D uBlendMap;",
+            "",
+            "varying vec2 vUv0;",
+            "",
+            "void main(void)",
+            "{",
+            "    vec4 texel1 = texture2D(uColorBuffer, vUv0);",
+            "    vec4 texel2 = texture2D(uBlendMap, vUv0);",
+            "    gl_FragColor = mix(texel1, texel2, uMixRatio);",
+            "}"
+        ].join("\n")
     });
 
-    return {
-        BlendEffect: BlendEffect
-    };
-}());
+    // Uniforms
+    this.mixRatio = 0.5;
+    this.blendMap = new pc.Texture(graphicsDevice);
+    this.blendMap.name = 'pe-blend';
+}
+
+BlendEffect.prototype = Object.create(pc.PostEffect.prototype);
+BlendEffect.prototype.constructor = BlendEffect;
+
+Object.assign(BlendEffect.prototype, {
+    render: function (inputTarget, outputTarget, rect) {
+        var device = this.device;
+        var scope = device.scope;
+
+        scope.resolve("uMixRatio").setValue(this.mixRatio);
+        scope.resolve("uColorBuffer").setValue(inputTarget.colorBuffer);
+        scope.resolve("uBlendMap").setValue(this.blendMap);
+        pc.drawFullscreenQuad(device, outputTarget, this.vertexBuffer, this.shader, rect);
+    }
+});
 
 // ----------------- SCRIPT DEFINITION ------------------ //
 var Blend = pc.createScript('blend');
@@ -81,7 +74,6 @@ Blend.attributes.add('mixRatio', {
     default: 1,
     min: 0,
     max: 1,
-    precision: 5,
     title: 'Mix Ratio'
 });
 
@@ -92,7 +84,7 @@ Blend.attributes.add('blendMap', {
 });
 
 Blend.prototype.initialize = function () {
-    this.effect = new pc.BlendEffect(this.app.graphicsDevice);
+    this.effect = new BlendEffect(this.app.graphicsDevice);
     this.effect.mixRatio = this.mixRatio;
     this.effect.blendMap = this.blendMap.resource;
 

--- a/examples/assets/scripts/posteffects/posteffect-bloom.js
+++ b/examples/assets/scripts/posteffects/posteffect-bloom.js
@@ -1,251 +1,245 @@
 // --------------- POST EFFECT DEFINITION --------------- //
-Object.assign(pc, function () {
-    var SAMPLE_COUNT = 15;
+var SAMPLE_COUNT = 15;
 
-    function computeGaussian(n, theta) {
-        return ((1.0 / Math.sqrt(2 * Math.PI * theta)) * Math.exp(-(n * n) / (2 * theta * theta)));
+function computeGaussian(n, theta) {
+    return ((1.0 / Math.sqrt(2 * Math.PI * theta)) * Math.exp(-(n * n) / (2 * theta * theta)));
+}
+
+function calculateBlurValues(sampleWeights, sampleOffsets, dx, dy, blurAmount) {
+    // Look up how many samples our gaussian blur effect supports.
+
+    // Create temporary arrays for computing our filter settings.
+    // The first sample always has a zero offset.
+    sampleWeights[0] = computeGaussian(0, blurAmount);
+    sampleOffsets[0] = 0;
+    sampleOffsets[1] = 0;
+
+    // Maintain a sum of all the weighting values.
+    var totalWeights = sampleWeights[0];
+
+    // Add pairs of additional sample taps, positioned
+    // along a line in both directions from the center.
+    var i, len;
+    for (i = 0, len = Math.floor(SAMPLE_COUNT / 2); i < len; i++) {
+        // Store weights for the positive and negative taps.
+        var weight = computeGaussian(i + 1, blurAmount);
+        sampleWeights[i * 2] = weight;
+        sampleWeights[i * 2 + 1] = weight;
+        totalWeights += weight * 2;
+
+        // To get the maximum amount of blurring from a limited number of
+        // pixel shader samples, we take advantage of the bilinear filtering
+        // hardware inside the texture fetch unit. If we position our texture
+        // coordinates exactly halfway between two texels, the filtering unit
+        // will average them for us, giving two samples for the price of one.
+        // This allows us to step in units of two texels per sample, rather
+        // than just one at a time. The 1.5 offset kicks things off by
+        // positioning us nicely in between two texels.
+        var sampleOffset = i * 2 + 1.5;
+
+        // Store texture coordinate offsets for the positive and negative taps.
+        sampleOffsets[i * 4] = dx * sampleOffset;
+        sampleOffsets[i * 4 + 1] = dy * sampleOffset;
+        sampleOffsets[i * 4 + 2] = -dx * sampleOffset;
+        sampleOffsets[i * 4 + 3] = -dy * sampleOffset;
     }
 
-    function calculateBlurValues(sampleWeights, sampleOffsets, dx, dy, blurAmount) {
-        // Look up how many samples our gaussian blur effect supports.
-
-        // Create temporary arrays for computing our filter settings.
-        // The first sample always has a zero offset.
-        sampleWeights[0] = computeGaussian(0, blurAmount);
-        sampleOffsets[0] = 0;
-        sampleOffsets[1] = 0;
-
-        // Maintain a sum of all the weighting values.
-        var totalWeights = sampleWeights[0];
-
-        // Add pairs of additional sample taps, positioned
-        // along a line in both directions from the center.
-        var i, len;
-        for (i = 0, len = Math.floor(SAMPLE_COUNT / 2); i < len; i++) {
-            // Store weights for the positive and negative taps.
-            var weight = computeGaussian(i + 1, blurAmount);
-            sampleWeights[i * 2] = weight;
-            sampleWeights[i * 2 + 1] = weight;
-            totalWeights += weight * 2;
-
-            // To get the maximum amount of blurring from a limited number of
-            // pixel shader samples, we take advantage of the bilinear filtering
-            // hardware inside the texture fetch unit. If we position our texture
-            // coordinates exactly halfway between two texels, the filtering unit
-            // will average them for us, giving two samples for the price of one.
-            // This allows us to step in units of two texels per sample, rather
-            // than just one at a time. The 1.5 offset kicks things off by
-            // positioning us nicely in between two texels.
-            var sampleOffset = i * 2 + 1.5;
-
-            // Store texture coordinate offsets for the positive and negative taps.
-            sampleOffsets[i * 4] = dx * sampleOffset;
-            sampleOffsets[i * 4 + 1] = dy * sampleOffset;
-            sampleOffsets[i * 4 + 2] = -dx * sampleOffset;
-            sampleOffsets[i * 4 + 3] = -dy * sampleOffset;
-        }
-
-        // Normalize the list of sample weightings, so they will always sum to one.
-        for (i = 0, len = sampleWeights.length; i < len; i++) {
-            sampleWeights[i] /= totalWeights;
-        }
+    // Normalize the list of sample weightings, so they will always sum to one.
+    for (i = 0, len = sampleWeights.length; i < len; i++) {
+        sampleWeights[i] /= totalWeights;
     }
+}
 
-    /**
-     * @class
-     * @name pc.BloomEffect
-     * @classdesc Implements the BloomEffect post processing effect.
-     * @description Creates new instance of the post effect.
-     * @augments pc.PostEffect
-     * @param {pc.GraphicsDevice} graphicsDevice - The graphics device of the application.
-     * @property {number} bloomThreshold Only pixels brighter then this threshold will be processed. Ranges from 0 to 1.
-     * @property {number} blurAmount Controls the amount of blurring.
-     * @property {number} bloomIntensity The intensity of the effect.
-     */
-    var BloomEffect = function (graphicsDevice) {
-        pc.PostEffect.call(this, graphicsDevice);
+/**
+ * @class
+ * @name BloomEffect
+ * @classdesc Implements the BloomEffect post processing effect.
+ * @description Creates new instance of the post effect.
+ * @augments pc.PostEffect
+ * @param {pc.GraphicsDevice} graphicsDevice - The graphics device of the application.
+ * @property {number} bloomThreshold Only pixels brighter then this threshold will be processed. Ranges from 0 to 1.
+ * @property {number} blurAmount Controls the amount of blurring.
+ * @property {number} bloomIntensity The intensity of the effect.
+ */
+function BloomEffect(graphicsDevice) {
+    pc.PostEffect.call(this, graphicsDevice);
 
-        // Shaders
-        var attributes = {
-            aPosition: pc.SEMANTIC_POSITION
-        };
-
-        var passThroughVert = [
-            "attribute vec2 aPosition;",
-            "",
-            "varying vec2 vUv0;",
-            "",
-            "void main(void)",
-            "{",
-            "    gl_Position = vec4(aPosition, 0.0, 1.0);",
-            "    vUv0 = (aPosition + 1.0) * 0.5;",
-            "}"
-        ].join("\n");
-
-        // Pixel shader extracts the brighter areas of an image.
-        // This is the first step in applying a bloom postprocess.
-        var bloomExtractFrag = [
-            "precision " + graphicsDevice.precision + " float;",
-            "",
-            "varying vec2 vUv0;",
-            "",
-            "uniform sampler2D uBaseTexture;",
-            "uniform float uBloomThreshold;",
-            "",
-            "void main(void)",
-            "{",
-                 // Look up the original image color.
-            "    vec4 color = texture2D(uBaseTexture, vUv0);",
-            "",
-                 // Adjust it to keep only values brighter than the specified threshold.
-            "    gl_FragColor = clamp((color - uBloomThreshold) / (1.0 - uBloomThreshold), 0.0, 1.0);",
-            "}"
-        ].join("\n");
-
-        // Pixel shader applies a one dimensional gaussian blur filter.
-        // This is used twice by the bloom postprocess, first to
-        // blur horizontally, and then again to blur vertically.
-        var gaussianBlurFrag = [
-            "precision " + graphicsDevice.precision + " float;",
-            "",
-            "#define SAMPLE_COUNT " + SAMPLE_COUNT,
-            "",
-            "varying vec2 vUv0;",
-            "",
-            "uniform sampler2D uBloomTexture;",
-            "uniform vec2 uBlurOffsets[SAMPLE_COUNT];",
-            "uniform float uBlurWeights[SAMPLE_COUNT];",
-            "",
-            "void main(void)",
-            "{",
-            "    vec4 color = vec4(0.0);",
-                 // Combine a number of weighted image filter taps.
-            "    for (int i = 0; i < SAMPLE_COUNT; i++)",
-            "    {",
-            "        color += texture2D(uBloomTexture, vUv0 + uBlurOffsets[i]) * uBlurWeights[i];",
-            "    }",
-            "",
-            "    gl_FragColor = color;",
-            "}"
-        ].join("\n");
-
-        // Pixel shader combines the bloom image with the original
-        // scene, using tweakable intensity levels.
-        // This is the final step in applying a bloom postprocess.
-        var bloomCombineFrag = [
-            "precision " + graphicsDevice.precision + " float;",
-            "",
-            "varying vec2 vUv0;",
-            "",
-            "uniform float uBloomEffectIntensity;",
-            "uniform sampler2D uBaseTexture;",
-            "uniform sampler2D uBloomTexture;",
-            "",
-            "void main(void)",
-            "{",
-                 // Look up the bloom and original base image colors.
-            "    vec4 bloom = texture2D(uBloomTexture, vUv0) * uBloomEffectIntensity;",
-            "    vec4 base = texture2D(uBaseTexture, vUv0);",
-            "",
-                 // Darken down the base image in areas where there is a lot of bloom,
-                 // to prevent things looking excessively burned-out.
-            "    base *= (1.0 - clamp(bloom, 0.0, 1.0));",
-            "",
-                 // Combine the two images.
-            "    gl_FragColor = base + bloom;",
-            "}"
-        ].join("\n");
-
-        this.extractShader = new pc.Shader(graphicsDevice, {
-            attributes: attributes,
-            vshader: passThroughVert,
-            fshader: bloomExtractFrag
-        });
-        this.blurShader = new pc.Shader(graphicsDevice, {
-            attributes: attributes,
-            vshader: passThroughVert,
-            fshader: gaussianBlurFrag
-        });
-        this.combineShader = new pc.Shader(graphicsDevice, {
-            attributes: attributes,
-            vshader: passThroughVert,
-            fshader: bloomCombineFrag
-        });
-
-        // Render targets
-        var width = graphicsDevice.width;
-        var height = graphicsDevice.height;
-        this.targets = [];
-        for (var i = 0; i < 2; i++) {
-            var colorBuffer = new pc.Texture(graphicsDevice, {
-                format: pc.PIXELFORMAT_R8_G8_B8_A8,
-                width: width >> 1,
-                height: height >> 1
-            });
-            colorBuffer.minFilter = pc.FILTER_LINEAR;
-            colorBuffer.magFilter = pc.FILTER_LINEAR;
-            colorBuffer.addressU = pc.ADDRESS_CLAMP_TO_EDGE;
-            colorBuffer.addressV = pc.ADDRESS_CLAMP_TO_EDGE;
-            colorBuffer.name = 'pe-bloom';
-            var target = new pc.RenderTarget(graphicsDevice, colorBuffer, { depth: false });
-
-            this.targets.push(target);
-        }
-
-        // Effect defaults
-        this.bloomThreshold = 0.25;
-        this.blurAmount = 4;
-        this.bloomIntensity = 1.25;
-
-        // Uniforms
-        this.sampleWeights = new Float32Array(SAMPLE_COUNT);
-        this.sampleOffsets = new Float32Array(SAMPLE_COUNT * 2);
+    // Shaders
+    var attributes = {
+        aPosition: pc.SEMANTIC_POSITION
     };
 
-    BloomEffect.prototype = Object.create(pc.PostEffect.prototype);
-    BloomEffect.prototype.constructor = BloomEffect;
+    var passThroughVert = [
+        "attribute vec2 aPosition;",
+        "",
+        "varying vec2 vUv0;",
+        "",
+        "void main(void)",
+        "{",
+        "    gl_Position = vec4(aPosition, 0.0, 1.0);",
+        "    vUv0 = (aPosition + 1.0) * 0.5;",
+        "}"
+    ].join("\n");
 
-    Object.assign(BloomEffect.prototype, {
-        render: function (inputTarget, outputTarget, rect) {
-            var device = this.device;
-            var scope = device.scope;
+    // Pixel shader extracts the brighter areas of an image.
+    // This is the first step in applying a bloom postprocess.
+    var bloomExtractFrag = [
+        "precision " + graphicsDevice.precision + " float;",
+        "",
+        "varying vec2 vUv0;",
+        "",
+        "uniform sampler2D uBaseTexture;",
+        "uniform float uBloomThreshold;",
+        "",
+        "void main(void)",
+        "{",
+                // Look up the original image color.
+        "    vec4 color = texture2D(uBaseTexture, vUv0);",
+        "",
+                // Adjust it to keep only values brighter than the specified threshold.
+        "    gl_FragColor = clamp((color - uBloomThreshold) / (1.0 - uBloomThreshold), 0.0, 1.0);",
+        "}"
+    ].join("\n");
 
-            // Pass 1: draw the scene into rendertarget 1, using a
-            // shader that extracts only the brightest parts of the image.
-            scope.resolve("uBloomThreshold").setValue(this.bloomThreshold);
-            scope.resolve("uBaseTexture").setValue(inputTarget.colorBuffer);
-            pc.drawFullscreenQuad(device, this.targets[0], this.vertexBuffer, this.extractShader);
+    // Pixel shader applies a one dimensional gaussian blur filter.
+    // This is used twice by the bloom postprocess, first to
+    // blur horizontally, and then again to blur vertically.
+    var gaussianBlurFrag = [
+        "precision " + graphicsDevice.precision + " float;",
+        "",
+        "#define SAMPLE_COUNT " + SAMPLE_COUNT,
+        "",
+        "varying vec2 vUv0;",
+        "",
+        "uniform sampler2D uBloomTexture;",
+        "uniform vec2 uBlurOffsets[SAMPLE_COUNT];",
+        "uniform float uBlurWeights[SAMPLE_COUNT];",
+        "",
+        "void main(void)",
+        "{",
+        "    vec4 color = vec4(0.0);",
+                // Combine a number of weighted image filter taps.
+        "    for (int i = 0; i < SAMPLE_COUNT; i++)",
+        "    {",
+        "        color += texture2D(uBloomTexture, vUv0 + uBlurOffsets[i]) * uBlurWeights[i];",
+        "    }",
+        "",
+        "    gl_FragColor = color;",
+        "}"
+    ].join("\n");
 
-            // Pass 2: draw from rendertarget 1 into rendertarget 2,
-            // using a shader to apply a horizontal gaussian blur filter.
-            calculateBlurValues(this.sampleWeights, this.sampleOffsets, 1.0 / this.targets[1].width, 0, this.blurAmount);
-            scope.resolve("uBlurWeights[0]").setValue(this.sampleWeights);
-            scope.resolve("uBlurOffsets[0]").setValue(this.sampleOffsets);
-            scope.resolve("uBloomTexture").setValue(this.targets[0].colorBuffer);
-            pc.drawFullscreenQuad(device, this.targets[1], this.vertexBuffer, this.blurShader);
+    // Pixel shader combines the bloom image with the original
+    // scene, using tweakable intensity levels.
+    // This is the final step in applying a bloom postprocess.
+    var bloomCombineFrag = [
+        "precision " + graphicsDevice.precision + " float;",
+        "",
+        "varying vec2 vUv0;",
+        "",
+        "uniform float uBloomEffectIntensity;",
+        "uniform sampler2D uBaseTexture;",
+        "uniform sampler2D uBloomTexture;",
+        "",
+        "void main(void)",
+        "{",
+                // Look up the bloom and original base image colors.
+        "    vec4 bloom = texture2D(uBloomTexture, vUv0) * uBloomEffectIntensity;",
+        "    vec4 base = texture2D(uBaseTexture, vUv0);",
+        "",
+                // Darken down the base image in areas where there is a lot of bloom,
+                // to prevent things looking excessively burned-out.
+        "    base *= (1.0 - clamp(bloom, 0.0, 1.0));",
+        "",
+                // Combine the two images.
+        "    gl_FragColor = base + bloom;",
+        "}"
+    ].join("\n");
 
-            // Pass 3: draw from rendertarget 2 back into rendertarget 1,
-            // using a shader to apply a vertical gaussian blur filter.
-            calculateBlurValues(this.sampleWeights, this.sampleOffsets, 0, 1.0 / this.targets[0].height, this.blurAmount);
-            scope.resolve("uBlurWeights[0]").setValue(this.sampleWeights);
-            scope.resolve("uBlurOffsets[0]").setValue(this.sampleOffsets);
-            scope.resolve("uBloomTexture").setValue(this.targets[1].colorBuffer);
-            pc.drawFullscreenQuad(device, this.targets[0], this.vertexBuffer, this.blurShader);
-
-            // Pass 4: draw both rendertarget 1 and the original scene
-            // image back into the main backbuffer, using a shader that
-            // combines them to produce the final bloomed result.
-            scope.resolve("uBloomEffectIntensity").setValue(this.bloomIntensity);
-            scope.resolve("uBloomTexture").setValue(this.targets[0].colorBuffer);
-            scope.resolve("uBaseTexture").setValue(inputTarget.colorBuffer);
-            pc.drawFullscreenQuad(device, outputTarget, this.vertexBuffer, this.combineShader, rect);
-        }
+    this.extractShader = new pc.Shader(graphicsDevice, {
+        attributes: attributes,
+        vshader: passThroughVert,
+        fshader: bloomExtractFrag
+    });
+    this.blurShader = new pc.Shader(graphicsDevice, {
+        attributes: attributes,
+        vshader: passThroughVert,
+        fshader: gaussianBlurFrag
+    });
+    this.combineShader = new pc.Shader(graphicsDevice, {
+        attributes: attributes,
+        vshader: passThroughVert,
+        fshader: bloomCombineFrag
     });
 
-    return {
-        BloomEffect: BloomEffect
-    };
-}());
+    // Render targets
+    var width = graphicsDevice.width;
+    var height = graphicsDevice.height;
+    this.targets = [];
+    for (var i = 0; i < 2; i++) {
+        var colorBuffer = new pc.Texture(graphicsDevice, {
+            format: pc.PIXELFORMAT_R8_G8_B8_A8,
+            width: width >> 1,
+            height: height >> 1
+        });
+        colorBuffer.minFilter = pc.FILTER_LINEAR;
+        colorBuffer.magFilter = pc.FILTER_LINEAR;
+        colorBuffer.addressU = pc.ADDRESS_CLAMP_TO_EDGE;
+        colorBuffer.addressV = pc.ADDRESS_CLAMP_TO_EDGE;
+        colorBuffer.name = 'pe-bloom';
+        var target = new pc.RenderTarget(graphicsDevice, colorBuffer, { depth: false });
+
+        this.targets.push(target);
+    }
+
+    // Effect defaults
+    this.bloomThreshold = 0.25;
+    this.blurAmount = 4;
+    this.bloomIntensity = 1.25;
+
+    // Uniforms
+    this.sampleWeights = new Float32Array(SAMPLE_COUNT);
+    this.sampleOffsets = new Float32Array(SAMPLE_COUNT * 2);
+}
+
+BloomEffect.prototype = Object.create(pc.PostEffect.prototype);
+BloomEffect.prototype.constructor = BloomEffect;
+
+Object.assign(BloomEffect.prototype, {
+    render: function (inputTarget, outputTarget, rect) {
+        var device = this.device;
+        var scope = device.scope;
+
+        // Pass 1: draw the scene into rendertarget 1, using a
+        // shader that extracts only the brightest parts of the image.
+        scope.resolve("uBloomThreshold").setValue(this.bloomThreshold);
+        scope.resolve("uBaseTexture").setValue(inputTarget.colorBuffer);
+        pc.drawFullscreenQuad(device, this.targets[0], this.vertexBuffer, this.extractShader);
+
+        // Pass 2: draw from rendertarget 1 into rendertarget 2,
+        // using a shader to apply a horizontal gaussian blur filter.
+        calculateBlurValues(this.sampleWeights, this.sampleOffsets, 1.0 / this.targets[1].width, 0, this.blurAmount);
+        scope.resolve("uBlurWeights[0]").setValue(this.sampleWeights);
+        scope.resolve("uBlurOffsets[0]").setValue(this.sampleOffsets);
+        scope.resolve("uBloomTexture").setValue(this.targets[0].colorBuffer);
+        pc.drawFullscreenQuad(device, this.targets[1], this.vertexBuffer, this.blurShader);
+
+        // Pass 3: draw from rendertarget 2 back into rendertarget 1,
+        // using a shader to apply a vertical gaussian blur filter.
+        calculateBlurValues(this.sampleWeights, this.sampleOffsets, 0, 1.0 / this.targets[0].height, this.blurAmount);
+        scope.resolve("uBlurWeights[0]").setValue(this.sampleWeights);
+        scope.resolve("uBlurOffsets[0]").setValue(this.sampleOffsets);
+        scope.resolve("uBloomTexture").setValue(this.targets[1].colorBuffer);
+        pc.drawFullscreenQuad(device, this.targets[0], this.vertexBuffer, this.blurShader);
+
+        // Pass 4: draw both rendertarget 1 and the original scene
+        // image back into the main backbuffer, using a shader that
+        // combines them to produce the final bloomed result.
+        scope.resolve("uBloomEffectIntensity").setValue(this.bloomIntensity);
+        scope.resolve("uBloomTexture").setValue(this.targets[0].colorBuffer);
+        scope.resolve("uBaseTexture").setValue(inputTarget.colorBuffer);
+        pc.drawFullscreenQuad(device, outputTarget, this.vertexBuffer, this.combineShader, rect);
+    }
+});
 
 // ----------------- SCRIPT DEFINITION ------------------ //
 var Bloom = pc.createScript('bloom');
@@ -262,7 +256,6 @@ Bloom.attributes.add('bloomThreshold', {
     default: 0.25,
     min: 0,
     max: 1,
-    precision: 2,
     title: 'Threshold'
 });
 
@@ -274,7 +267,7 @@ Bloom.attributes.add('blurAmount', {
 });
 
 Bloom.prototype.initialize = function () {
-    this.effect = new pc.BloomEffect(this.app.graphicsDevice);
+    this.effect = new BloomEffect(this.app.graphicsDevice);
 
     this.effect.bloomThreshold = this.bloomThreshold;
     this.effect.blurAmount = this.blurAmount;

--- a/examples/assets/scripts/posteffects/posteffect-bokeh.js
+++ b/examples/assets/scripts/posteffects/posteffect-bokeh.js
@@ -1,151 +1,144 @@
 // --------------- POST EFFECT DEFINITION --------------- //
-Object.assign(pc, function () {
+/**
+ * @class
+ * @name BokehEffect
+ * @classdesc Implements the BokehEffect post processing effect.
+ * @description Creates new instance of the post effect.
+ * @augments pc.PostEffect
+ * @param {pc.GraphicsDevice} graphicsDevice - The graphics device of the application.
+ * @property {number} maxBlur The maximum amount of blurring. Ranges from 0 to 1.
+ * @property {number} aperture Bigger values create a shallower depth of field.
+ * @property {number} focus Controls the focus of the effect.
+ * @property {number} aspect Controls the blurring effect.
+ */
+function BokehEffect(graphicsDevice) {
+    pc.PostEffect.call(this, graphicsDevice);
 
-    /**
-     * @class
-     * @name pc.BokehEffect
-     * @classdesc Implements the BokehEffect post processing effect.
-     * @description Creates new instance of the post effect.
-     * @augments pc.PostEffect
-     * @param {pc.GraphicsDevice} graphicsDevice - The graphics device of the application.
-     * @property {number} maxBlur The maximum amount of blurring. Ranges from 0 to 1.
-     * @property {number} aperture Bigger values create a shallower depth of field.
-     * @property {number} focus Controls the focus of the effect.
-     * @property {number} aspect Controls the blurring effect.
-     */
-    var BokehEffect = function (graphicsDevice) {
-        pc.PostEffect.call(this, graphicsDevice);
+    this.needsDepthBuffer = true;
 
-        this.needsDepthBuffer = true;
-
-        // Shader author: alteredq / http://alteredqualia.com/
-        // Depth-of-field shader with bokeh
-        // ported from GLSL shader by Martins Upitis
-        // http://artmartinsh.blogspot.com/2010/02/glsl-lens-blur-filter-with-bokeh.html
-        this.shader = new pc.Shader(graphicsDevice, {
-            attributes: {
-                aPosition: pc.SEMANTIC_POSITION
-            },
-            vshader: [
-                "attribute vec2 aPosition;",
-                "",
-                "varying vec2 vUv0;",
-                "",
-                "void main(void)",
-                "{",
-                "    gl_Position = vec4(aPosition, 0.0, 1.0);",
-                "    vUv0 = (aPosition.xy + 1.0) * 0.5;",
-                "}"
-            ].join("\n"),
-            fshader: [
-                "precision " + graphicsDevice.precision + " float;",
-                (graphicsDevice.webgl2) ? "#define GL2" : "",
-                pc.shaderChunks.screenDepthPS,
-                "",
-                "varying vec2 vUv0;",
-                "",
-                "uniform sampler2D uColorBuffer;",
-                "",
-                "uniform float uMaxBlur;",  // max blur amount
-                "uniform float uAperture;", // uAperture - bigger values for shallower depth of field
-                "",
-                "uniform float uFocus;",
-                "uniform float uAspect;",
-                "",
-                "void main()",
-                "{",
-                "    vec2 aspectCorrect = vec2( 1.0, uAspect );",
-                "",
-                "    float factor = ((getLinearScreenDepth(vUv0) * -1.0) - uFocus) / camera_params.y;",
-                "",
-                "    vec2 dofblur = vec2 ( clamp( factor * uAperture, -uMaxBlur, uMaxBlur ) );",
-                "",
-                "    vec2 dofblur9 = dofblur * 0.9;",
-                "    vec2 dofblur7 = dofblur * 0.7;",
-                "    vec2 dofblur4 = dofblur * 0.4;",
-                "",
-                "    vec4 col;",
-                "",
-                "    col  = texture2D( uColorBuffer, vUv0 );",
-                "    col += texture2D( uColorBuffer, vUv0 + ( vec2(  0.0,   0.4  ) * aspectCorrect ) * dofblur );",
-                "    col += texture2D( uColorBuffer, vUv0 + ( vec2(  0.15,  0.37 ) * aspectCorrect ) * dofblur );",
-                "    col += texture2D( uColorBuffer, vUv0 + ( vec2(  0.29,  0.29 ) * aspectCorrect ) * dofblur );",
-                "    col += texture2D( uColorBuffer, vUv0 + ( vec2( -0.37,  0.15 ) * aspectCorrect ) * dofblur );",
-                "    col += texture2D( uColorBuffer, vUv0 + ( vec2(  0.40,  0.0  ) * aspectCorrect ) * dofblur );",
-                "    col += texture2D( uColorBuffer, vUv0 + ( vec2(  0.37, -0.15 ) * aspectCorrect ) * dofblur );",
-                "    col += texture2D( uColorBuffer, vUv0 + ( vec2(  0.29, -0.29 ) * aspectCorrect ) * dofblur );",
-                "    col += texture2D( uColorBuffer, vUv0 + ( vec2( -0.15, -0.37 ) * aspectCorrect ) * dofblur );",
-                "    col += texture2D( uColorBuffer, vUv0 + ( vec2(  0.0,  -0.4  ) * aspectCorrect ) * dofblur );",
-                "    col += texture2D( uColorBuffer, vUv0 + ( vec2( -0.15,  0.37 ) * aspectCorrect ) * dofblur );",
-                "    col += texture2D( uColorBuffer, vUv0 + ( vec2( -0.29,  0.29 ) * aspectCorrect ) * dofblur );",
-                "    col += texture2D( uColorBuffer, vUv0 + ( vec2(  0.37,  0.15 ) * aspectCorrect ) * dofblur );",
-                "    col += texture2D( uColorBuffer, vUv0 + ( vec2( -0.4,   0.0  ) * aspectCorrect ) * dofblur );",
-                "    col += texture2D( uColorBuffer, vUv0 + ( vec2( -0.37, -0.15 ) * aspectCorrect ) * dofblur );",
-                "    col += texture2D( uColorBuffer, vUv0 + ( vec2( -0.29, -0.29 ) * aspectCorrect ) * dofblur );",
-                "    col += texture2D( uColorBuffer, vUv0 + ( vec2(  0.15, -0.37 ) * aspectCorrect ) * dofblur );",
-                "",
-                "    col += texture2D( uColorBuffer, vUv0 + ( vec2(  0.15,  0.37 ) * aspectCorrect ) * dofblur9 );",
-                "    col += texture2D( uColorBuffer, vUv0 + ( vec2( -0.37,  0.15 ) * aspectCorrect ) * dofblur9 );",
-                "    col += texture2D( uColorBuffer, vUv0 + ( vec2(  0.37, -0.15 ) * aspectCorrect ) * dofblur9 );",
-                "    col += texture2D( uColorBuffer, vUv0 + ( vec2( -0.15, -0.37 ) * aspectCorrect ) * dofblur9 );",
-                "    col += texture2D( uColorBuffer, vUv0 + ( vec2( -0.15,  0.37 ) * aspectCorrect ) * dofblur9 );",
-                "    col += texture2D( uColorBuffer, vUv0 + ( vec2(  0.37,  0.15 ) * aspectCorrect ) * dofblur9 );",
-                "    col += texture2D( uColorBuffer, vUv0 + ( vec2( -0.37, -0.15 ) * aspectCorrect ) * dofblur9 );",
-                "    col += texture2D( uColorBuffer, vUv0 + ( vec2(  0.15, -0.37 ) * aspectCorrect ) * dofblur9 );",
-                "",
-                "    col += texture2D( uColorBuffer, vUv0 + ( vec2(  0.29,  0.29 ) * aspectCorrect ) * dofblur7 );",
-                "    col += texture2D( uColorBuffer, vUv0 + ( vec2(  0.40,  0.0  ) * aspectCorrect ) * dofblur7 );",
-                "    col += texture2D( uColorBuffer, vUv0 + ( vec2(  0.29, -0.29 ) * aspectCorrect ) * dofblur7 );",
-                "    col += texture2D( uColorBuffer, vUv0 + ( vec2(  0.0,  -0.4  ) * aspectCorrect ) * dofblur7 );",
-                "    col += texture2D( uColorBuffer, vUv0 + ( vec2( -0.29,  0.29 ) * aspectCorrect ) * dofblur7 );",
-                "    col += texture2D( uColorBuffer, vUv0 + ( vec2( -0.4,   0.0  ) * aspectCorrect ) * dofblur7 );",
-                "    col += texture2D( uColorBuffer, vUv0 + ( vec2( -0.29, -0.29 ) * aspectCorrect ) * dofblur7 );",
-                "    col += texture2D( uColorBuffer, vUv0 + ( vec2(  0.0,   0.4  ) * aspectCorrect ) * dofblur7 );",
-                "",
-                "    col += texture2D( uColorBuffer, vUv0 + ( vec2(  0.29,  0.29 ) * aspectCorrect ) * dofblur4 );",
-                "    col += texture2D( uColorBuffer, vUv0 + ( vec2(  0.4,   0.0  ) * aspectCorrect ) * dofblur4 );",
-                "    col += texture2D( uColorBuffer, vUv0 + ( vec2(  0.29, -0.29 ) * aspectCorrect ) * dofblur4 );",
-                "    col += texture2D( uColorBuffer, vUv0 + ( vec2(  0.0,  -0.4  ) * aspectCorrect ) * dofblur4 );",
-                "    col += texture2D( uColorBuffer, vUv0 + ( vec2( -0.29,  0.29 ) * aspectCorrect ) * dofblur4 );",
-                "    col += texture2D( uColorBuffer, vUv0 + ( vec2( -0.4,   0.0  ) * aspectCorrect ) * dofblur4 );",
-                "    col += texture2D( uColorBuffer, vUv0 + ( vec2( -0.29, -0.29 ) * aspectCorrect ) * dofblur4 );",
-                "    col += texture2D( uColorBuffer, vUv0 + ( vec2(  0.0,   0.4  ) * aspectCorrect ) * dofblur4 );",
-                "",
-                "    gl_FragColor = col / 41.0;",
-                "    gl_FragColor.a = 1.0;",
-                "}"
-            ].join("\n")
-        });
-
-        // Uniforms
-        this.maxBlur = 0.02;
-        this.aperture = 1;
-        this.focus = 1;
-        this.aspect = graphicsDevice.width / graphicsDevice.height;
-    };
-
-    BokehEffect.prototype = Object.create(pc.PostEffect.prototype);
-    BokehEffect.prototype.constructor = BokehEffect;
-
-    Object.assign(BokehEffect.prototype, {
-        render: function (inputTarget, outputTarget, rect) {
-            var device = this.device;
-            var scope = device.scope;
-
-            scope.resolve("uMaxBlur").setValue(this.maxBlur);
-            scope.resolve("uAperture").setValue(this.aperture);
-            scope.resolve("uFocus").setValue(this.focus);
-            scope.resolve("uAspect").setValue(this.aspect);
-            scope.resolve("uColorBuffer").setValue(inputTarget.colorBuffer);
-
-            pc.drawFullscreenQuad(device, outputTarget, this.vertexBuffer, this.shader, rect);
-        }
+    // Shader author: alteredq / http://alteredqualia.com/
+    // Depth-of-field shader with bokeh
+    // ported from GLSL shader by Martins Upitis
+    // http://artmartinsh.blogspot.com/2010/02/glsl-lens-blur-filter-with-bokeh.html
+    this.shader = new pc.Shader(graphicsDevice, {
+        attributes: {
+            aPosition: pc.SEMANTIC_POSITION
+        },
+        vshader: [
+            "attribute vec2 aPosition;",
+            "",
+            "varying vec2 vUv0;",
+            "",
+            "void main(void)",
+            "{",
+            "    gl_Position = vec4(aPosition, 0.0, 1.0);",
+            "    vUv0 = (aPosition.xy + 1.0) * 0.5;",
+            "}"
+        ].join("\n"),
+        fshader: [
+            "precision " + graphicsDevice.precision + " float;",
+            (graphicsDevice.webgl2) ? "#define GL2" : "",
+            pc.shaderChunks.screenDepthPS,
+            "",
+            "varying vec2 vUv0;",
+            "",
+            "uniform sampler2D uColorBuffer;",
+            "",
+            "uniform float uMaxBlur;",  // max blur amount
+            "uniform float uAperture;", // uAperture - bigger values for shallower depth of field
+            "",
+            "uniform float uFocus;",
+            "uniform float uAspect;",
+            "",
+            "void main()",
+            "{",
+            "    vec2 aspectCorrect = vec2( 1.0, uAspect );",
+            "",
+            "    float factor = ((getLinearScreenDepth(vUv0) * -1.0) - uFocus) / camera_params.y;",
+            "",
+            "    vec2 dofblur = vec2 ( clamp( factor * uAperture, -uMaxBlur, uMaxBlur ) );",
+            "",
+            "    vec2 dofblur9 = dofblur * 0.9;",
+            "    vec2 dofblur7 = dofblur * 0.7;",
+            "    vec2 dofblur4 = dofblur * 0.4;",
+            "",
+            "    vec4 col;",
+            "",
+            "    col  = texture2D( uColorBuffer, vUv0 );",
+            "    col += texture2D( uColorBuffer, vUv0 + ( vec2(  0.0,   0.4  ) * aspectCorrect ) * dofblur );",
+            "    col += texture2D( uColorBuffer, vUv0 + ( vec2(  0.15,  0.37 ) * aspectCorrect ) * dofblur );",
+            "    col += texture2D( uColorBuffer, vUv0 + ( vec2(  0.29,  0.29 ) * aspectCorrect ) * dofblur );",
+            "    col += texture2D( uColorBuffer, vUv0 + ( vec2( -0.37,  0.15 ) * aspectCorrect ) * dofblur );",
+            "    col += texture2D( uColorBuffer, vUv0 + ( vec2(  0.40,  0.0  ) * aspectCorrect ) * dofblur );",
+            "    col += texture2D( uColorBuffer, vUv0 + ( vec2(  0.37, -0.15 ) * aspectCorrect ) * dofblur );",
+            "    col += texture2D( uColorBuffer, vUv0 + ( vec2(  0.29, -0.29 ) * aspectCorrect ) * dofblur );",
+            "    col += texture2D( uColorBuffer, vUv0 + ( vec2( -0.15, -0.37 ) * aspectCorrect ) * dofblur );",
+            "    col += texture2D( uColorBuffer, vUv0 + ( vec2(  0.0,  -0.4  ) * aspectCorrect ) * dofblur );",
+            "    col += texture2D( uColorBuffer, vUv0 + ( vec2( -0.15,  0.37 ) * aspectCorrect ) * dofblur );",
+            "    col += texture2D( uColorBuffer, vUv0 + ( vec2( -0.29,  0.29 ) * aspectCorrect ) * dofblur );",
+            "    col += texture2D( uColorBuffer, vUv0 + ( vec2(  0.37,  0.15 ) * aspectCorrect ) * dofblur );",
+            "    col += texture2D( uColorBuffer, vUv0 + ( vec2( -0.4,   0.0  ) * aspectCorrect ) * dofblur );",
+            "    col += texture2D( uColorBuffer, vUv0 + ( vec2( -0.37, -0.15 ) * aspectCorrect ) * dofblur );",
+            "    col += texture2D( uColorBuffer, vUv0 + ( vec2( -0.29, -0.29 ) * aspectCorrect ) * dofblur );",
+            "    col += texture2D( uColorBuffer, vUv0 + ( vec2(  0.15, -0.37 ) * aspectCorrect ) * dofblur );",
+            "",
+            "    col += texture2D( uColorBuffer, vUv0 + ( vec2(  0.15,  0.37 ) * aspectCorrect ) * dofblur9 );",
+            "    col += texture2D( uColorBuffer, vUv0 + ( vec2( -0.37,  0.15 ) * aspectCorrect ) * dofblur9 );",
+            "    col += texture2D( uColorBuffer, vUv0 + ( vec2(  0.37, -0.15 ) * aspectCorrect ) * dofblur9 );",
+            "    col += texture2D( uColorBuffer, vUv0 + ( vec2( -0.15, -0.37 ) * aspectCorrect ) * dofblur9 );",
+            "    col += texture2D( uColorBuffer, vUv0 + ( vec2( -0.15,  0.37 ) * aspectCorrect ) * dofblur9 );",
+            "    col += texture2D( uColorBuffer, vUv0 + ( vec2(  0.37,  0.15 ) * aspectCorrect ) * dofblur9 );",
+            "    col += texture2D( uColorBuffer, vUv0 + ( vec2( -0.37, -0.15 ) * aspectCorrect ) * dofblur9 );",
+            "    col += texture2D( uColorBuffer, vUv0 + ( vec2(  0.15, -0.37 ) * aspectCorrect ) * dofblur9 );",
+            "",
+            "    col += texture2D( uColorBuffer, vUv0 + ( vec2(  0.29,  0.29 ) * aspectCorrect ) * dofblur7 );",
+            "    col += texture2D( uColorBuffer, vUv0 + ( vec2(  0.40,  0.0  ) * aspectCorrect ) * dofblur7 );",
+            "    col += texture2D( uColorBuffer, vUv0 + ( vec2(  0.29, -0.29 ) * aspectCorrect ) * dofblur7 );",
+            "    col += texture2D( uColorBuffer, vUv0 + ( vec2(  0.0,  -0.4  ) * aspectCorrect ) * dofblur7 );",
+            "    col += texture2D( uColorBuffer, vUv0 + ( vec2( -0.29,  0.29 ) * aspectCorrect ) * dofblur7 );",
+            "    col += texture2D( uColorBuffer, vUv0 + ( vec2( -0.4,   0.0  ) * aspectCorrect ) * dofblur7 );",
+            "    col += texture2D( uColorBuffer, vUv0 + ( vec2( -0.29, -0.29 ) * aspectCorrect ) * dofblur7 );",
+            "    col += texture2D( uColorBuffer, vUv0 + ( vec2(  0.0,   0.4  ) * aspectCorrect ) * dofblur7 );",
+            "",
+            "    col += texture2D( uColorBuffer, vUv0 + ( vec2(  0.29,  0.29 ) * aspectCorrect ) * dofblur4 );",
+            "    col += texture2D( uColorBuffer, vUv0 + ( vec2(  0.4,   0.0  ) * aspectCorrect ) * dofblur4 );",
+            "    col += texture2D( uColorBuffer, vUv0 + ( vec2(  0.29, -0.29 ) * aspectCorrect ) * dofblur4 );",
+            "    col += texture2D( uColorBuffer, vUv0 + ( vec2(  0.0,  -0.4  ) * aspectCorrect ) * dofblur4 );",
+            "    col += texture2D( uColorBuffer, vUv0 + ( vec2( -0.29,  0.29 ) * aspectCorrect ) * dofblur4 );",
+            "    col += texture2D( uColorBuffer, vUv0 + ( vec2( -0.4,   0.0  ) * aspectCorrect ) * dofblur4 );",
+            "    col += texture2D( uColorBuffer, vUv0 + ( vec2( -0.29, -0.29 ) * aspectCorrect ) * dofblur4 );",
+            "    col += texture2D( uColorBuffer, vUv0 + ( vec2(  0.0,   0.4  ) * aspectCorrect ) * dofblur4 );",
+            "",
+            "    gl_FragColor = col / 41.0;",
+            "    gl_FragColor.a = 1.0;",
+            "}"
+        ].join("\n")
     });
 
-    return {
-        BokehEffect: BokehEffect
-    };
-}());
+    // Uniforms
+    this.maxBlur = 0.02;
+    this.aperture = 1;
+    this.focus = 1;
+    this.aspect = graphicsDevice.width / graphicsDevice.height;
+}
+
+BokehEffect.prototype = Object.create(pc.PostEffect.prototype);
+BokehEffect.prototype.constructor = BokehEffect;
+
+Object.assign(BokehEffect.prototype, {
+    render: function (inputTarget, outputTarget, rect) {
+        var device = this.device;
+        var scope = device.scope;
+
+        scope.resolve("uMaxBlur").setValue(this.maxBlur);
+        scope.resolve("uAperture").setValue(this.aperture);
+        scope.resolve("uFocus").setValue(this.focus);
+        scope.resolve("uAspect").setValue(this.aspect);
+        scope.resolve("uColorBuffer").setValue(inputTarget.colorBuffer);
+
+        pc.drawFullscreenQuad(device, outputTarget, this.vertexBuffer, this.shader, rect);
+    }
+});
 
 // ----------------- SCRIPT DEFINITION ------------------ //
 var Bokeh = pc.createScript('bokeh');
@@ -155,7 +148,6 @@ Bokeh.attributes.add('maxBlur', {
     default: 1,
     min: 0,
     max: 1,
-    precision: 5,
     title: 'Max Blur'
 });
 
@@ -164,7 +156,6 @@ Bokeh.attributes.add('aperture', {
     default: 0.025,
     min: 0,
     max: 1,
-    precision: 5,
     title: 'Aperture'
 });
 
@@ -181,7 +172,7 @@ Bokeh.attributes.add('aspect', {
 });
 
 Bokeh.prototype.initialize = function () {
-    this.effect = new pc.BokehEffect(this.app.graphicsDevice);
+    this.effect = new BokehEffect(this.app.graphicsDevice);
     this.effect.maxBlur = this.maxBlur;
     this.effect.aperture = this.aperture;
     this.effect.focus = this.focus;

--- a/examples/assets/scripts/posteffects/posteffect-bokeh.js
+++ b/examples/assets/scripts/posteffects/posteffect-bokeh.js
@@ -9,7 +9,6 @@
  * @property {number} maxBlur The maximum amount of blurring. Ranges from 0 to 1.
  * @property {number} aperture Bigger values create a shallower depth of field.
  * @property {number} focus Controls the focus of the effect.
- * @property {number} aspect Controls the blurring effect.
  */
 function BokehEffect(graphicsDevice) {
     pc.PostEffect.call(this, graphicsDevice);
@@ -119,7 +118,6 @@ function BokehEffect(graphicsDevice) {
     this.maxBlur = 0.02;
     this.aperture = 1;
     this.focus = 1;
-    this.aspect = graphicsDevice.width / graphicsDevice.height;
 }
 
 BokehEffect.prototype = Object.create(pc.PostEffect.prototype);
@@ -133,7 +131,7 @@ Object.assign(BokehEffect.prototype, {
         scope.resolve("uMaxBlur").setValue(this.maxBlur);
         scope.resolve("uAperture").setValue(this.aperture);
         scope.resolve("uFocus").setValue(this.focus);
-        scope.resolve("uAspect").setValue(this.aspect);
+        scope.resolve("uAspect").setValue(device.width / device.height);
         scope.resolve("uColorBuffer").setValue(inputTarget.colorBuffer);
 
         pc.drawFullscreenQuad(device, outputTarget, this.vertexBuffer, this.shader, rect);
@@ -145,7 +143,7 @@ var Bokeh = pc.createScript('bokeh');
 
 Bokeh.attributes.add('maxBlur', {
     type: 'number',
-    default: 1,
+    default: 0.02,
     min: 0,
     max: 1,
     title: 'Max Blur'
@@ -153,7 +151,7 @@ Bokeh.attributes.add('maxBlur', {
 
 Bokeh.attributes.add('aperture', {
     type: 'number',
-    default: 0.025,
+    default: 1,
     min: 0,
     max: 1,
     title: 'Aperture'
@@ -165,18 +163,11 @@ Bokeh.attributes.add('focus', {
     title: 'Focus'
 });
 
-Bokeh.attributes.add('aspect', {
-    type: 'number',
-    default: 1,
-    title: 'Aspect'
-});
-
 Bokeh.prototype.initialize = function () {
     this.effect = new BokehEffect(this.app.graphicsDevice);
     this.effect.maxBlur = this.maxBlur;
     this.effect.aperture = this.aperture;
     this.effect.focus = this.focus;
-    this.effect.aspect = this.aspect;
 
     this.on('attr', function (name, value) {
         this.effect[name] = value;

--- a/examples/assets/scripts/posteffects/posteffect-brightnesscontrast.js
+++ b/examples/assets/scripts/posteffects/posteffect-brightnesscontrast.js
@@ -1,81 +1,74 @@
 // --------------- POST EFFECT DEFINITION --------------- //
-Object.assign(pc, function () {
+/**
+ * @class
+ * @name BrightnessContrastEffect
+ * @classdesc Changes the brightness and contrast of the input render target.
+ * @description Creates new instance of the post effect.
+ * @augments pc.PostEffect
+ * @param {pc.GraphicsDevice} graphicsDevice - The graphics device of the application.
+ * @property {number} brightness Controls the brightness of the render target. Ranges from -1 to 1 (-1 is solid black, 0 no change, 1 solid white).
+ * @property {number} contrast Controls the contrast of the render target. Ranges from -1 to 1 (-1 is solid gray, 0 no change, 1 maximum contrast).
+ */
+function BrightnessContrastEffect(graphicsDevice) {
+    pc.PostEffect.call(this, graphicsDevice);
 
-    /**
-     * @class
-     * @name pc.BrightnessContrastEffect
-     * @classdesc Changes the brightness and contrast of the input render target.
-     * @description Creates new instance of the post effect.
-     * @augments pc.PostEffect
-     * @param {pc.GraphicsDevice} graphicsDevice - The graphics device of the application.
-     * @property {number} brightness Controls the brightness of the render target. Ranges from -1 to 1 (-1 is solid black, 0 no change, 1 solid white).
-     * @property {number} contrast Controls the contrast of the render target. Ranges from -1 to 1 (-1 is solid gray, 0 no change, 1 maximum contrast).
-     */
-    var BrightnessContrastEffect = function (graphicsDevice) {
-        pc.PostEffect.call(this, graphicsDevice);
-
-        // Shader author: tapio / http://tapio.github.com/
-        this.shader = new pc.Shader(graphicsDevice, {
-            attributes: {
-                aPosition: pc.SEMANTIC_POSITION
-            },
-            vshader: [
-                "attribute vec2 aPosition;",
-                "",
-                "varying vec2 vUv0;",
-                "",
-                "void main(void)",
-                "{",
-                "    gl_Position = vec4(aPosition, 0.0, 1.0);",
-                "    vUv0 = (aPosition.xy + 1.0) * 0.5;",
-                "}"
-            ].join("\n"),
-            fshader: [
-                "precision " + graphicsDevice.precision + " float;",
-                "",
-                "uniform sampler2D uColorBuffer;",
-                "uniform float uBrightness;",
-                "uniform float uContrast;",
-                "",
-                "varying vec2 vUv0;",
-                "",
-                "void main() {",
-                "    gl_FragColor = texture2D( uColorBuffer, vUv0 );",
-                "    gl_FragColor.rgb += uBrightness;",
-                "",
-                "    if (uContrast > 0.0) {",
-                "        gl_FragColor.rgb = (gl_FragColor.rgb - 0.5) / (1.0 - uContrast) + 0.5;",
-                "    } else {",
-                "        gl_FragColor.rgb = (gl_FragColor.rgb - 0.5) * (1.0 + uContrast) + 0.5;",
-                "    }",
-                "}"
-            ].join("\n")
-        });
-
-        // Uniforms
-        this.brightness = 0;
-        this.contrast = 0;
-    };
-
-    BrightnessContrastEffect.prototype = Object.create(pc.PostEffect.prototype);
-    BrightnessContrastEffect.prototype.constructor = BrightnessContrastEffect;
-
-    Object.assign(BrightnessContrastEffect.prototype, {
-        render: function (inputTarget, outputTarget, rect) {
-            var device = this.device;
-            var scope = device.scope;
-
-            scope.resolve("uBrightness").setValue(this.brightness);
-            scope.resolve("uContrast").setValue(this.contrast);
-            scope.resolve("uColorBuffer").setValue(inputTarget.colorBuffer);
-            pc.drawFullscreenQuad(device, outputTarget, this.vertexBuffer, this.shader, rect);
-        }
+    // Shader author: tapio / http://tapio.github.com/
+    this.shader = new pc.Shader(graphicsDevice, {
+        attributes: {
+            aPosition: pc.SEMANTIC_POSITION
+        },
+        vshader: [
+            "attribute vec2 aPosition;",
+            "",
+            "varying vec2 vUv0;",
+            "",
+            "void main(void)",
+            "{",
+            "    gl_Position = vec4(aPosition, 0.0, 1.0);",
+            "    vUv0 = (aPosition.xy + 1.0) * 0.5;",
+            "}"
+        ].join("\n"),
+        fshader: [
+            "precision " + graphicsDevice.precision + " float;",
+            "",
+            "uniform sampler2D uColorBuffer;",
+            "uniform float uBrightness;",
+            "uniform float uContrast;",
+            "",
+            "varying vec2 vUv0;",
+            "",
+            "void main() {",
+            "    gl_FragColor = texture2D( uColorBuffer, vUv0 );",
+            "    gl_FragColor.rgb += uBrightness;",
+            "",
+            "    if (uContrast > 0.0) {",
+            "        gl_FragColor.rgb = (gl_FragColor.rgb - 0.5) / (1.0 - uContrast) + 0.5;",
+            "    } else {",
+            "        gl_FragColor.rgb = (gl_FragColor.rgb - 0.5) * (1.0 + uContrast) + 0.5;",
+            "    }",
+            "}"
+        ].join("\n")
     });
 
-    return {
-        BrightnessContrastEffect: BrightnessContrastEffect
-    };
-}());
+    // Uniforms
+    this.brightness = 0;
+    this.contrast = 0;
+}
+
+BrightnessContrastEffect.prototype = Object.create(pc.PostEffect.prototype);
+BrightnessContrastEffect.prototype.constructor = BrightnessContrastEffect;
+
+Object.assign(BrightnessContrastEffect.prototype, {
+    render: function (inputTarget, outputTarget, rect) {
+        var device = this.device;
+        var scope = device.scope;
+
+        scope.resolve("uBrightness").setValue(this.brightness);
+        scope.resolve("uContrast").setValue(this.contrast);
+        scope.resolve("uColorBuffer").setValue(inputTarget.colorBuffer);
+        pc.drawFullscreenQuad(device, outputTarget, this.vertexBuffer, this.shader, rect);
+    }
+});
 
 // ----------------- SCRIPT DEFINITION ------------------ //
 var BrightnessContrast = pc.createScript('brightnessContrast');
@@ -85,7 +78,6 @@ BrightnessContrast.attributes.add('brightness', {
     default: 0,
     min: -1,
     max: 1,
-    precision: 5,
     title: 'Brightness'
 });
 
@@ -94,12 +86,11 @@ BrightnessContrast.attributes.add('contrast', {
     default: 0,
     min: -1,
     max: 1,
-    precision: 5,
     title: 'Contrast'
 });
 
 BrightnessContrast.prototype.initialize = function () {
-    this.effect = new pc.BrightnessContrastEffect(this.app.graphicsDevice);
+    this.effect = new BrightnessContrastEffect(this.app.graphicsDevice);
     this.effect.brightness = this.brightness;
     this.effect.contrast = this.contrast;
 

--- a/examples/assets/scripts/posteffects/posteffect-edgedetect.js
+++ b/examples/assets/scripts/posteffects/posteffect-edgedetect.js
@@ -1,105 +1,98 @@
 // --------------- POST EFFECT DEFINITION --------------- //
-Object.assign(pc, function () {
+/**
+ * @class
+ * @name EdgeDetectEffect
+ * @classdesc Edge Detection post effect using Sobel filter.
+ * @description Creates new instance of the post effect.
+ * @augments pc.PostEffect
+ * @param {pc.GraphicsDevice} graphicsDevice - The graphics device of the application.
+ */
+function EdgeDetectEffect(graphicsDevice) {
+    pc.PostEffect.call(this, graphicsDevice);
 
-    /**
-     * @class
-     * @name pc.EdgeDetectEffect
-     * @classdesc Edge Detection post effect using Sobel filter.
-     * @description Creates new instance of the post effect.
-     * @augments pc.PostEffect
-     * @param {pc.GraphicsDevice} graphicsDevice - The graphics device of the application.
-     */
-    var EdgeDetectEffect = function (graphicsDevice) {
-        pc.PostEffect.call(this, graphicsDevice);
-
-        this.shader = new pc.Shader(graphicsDevice, {
-            attributes: {
-                aPosition: pc.SEMANTIC_POSITION
-            },
-            vshader: [
-                "attribute vec2 aPosition;",
-                "",
-                "varying vec2 vUv0;",
-                "",
-                "void main(void)",
-                "{",
-                "    gl_Position = vec4(aPosition, 0.0, 1.0);",
-                "    vUv0 = (aPosition.xy + 1.0) * 0.5;",
-                "}"
-            ].join("\n"),
-            fshader: [
-                "precision " + graphicsDevice.precision + " float;",
-                "",
-                "uniform sampler2D uColorBuffer;",
-                "varying vec2 vUv0;",
-                "uniform vec2 uResolution;",
-                "uniform float uIntensity;",
-                "uniform vec4 uColor;",
-                "",
-                "mat3 G[2];",
-                "",
-                "const mat3 g0 = mat3( 1.0, 2.0, 1.0, 0.0, 0.0, 0.0, -1.0, -2.0, -1.0 );",
-                "const mat3 g1 = mat3( 1.0, 0.0, -1.0, 2.0, 0.0, -2.0, 1.0, 0.0, -1.0 );",
-                "",
-                "void main(void)",
-                "{",
-                "    mat3 I;",
-                "    float cnv[2];",
-                "    vec3 sample;",
-                "",
-                "    G[0] = g0;",
-                "    G[1] = g1;",
-                "",
-                     /* Fetch the 3x3 neighbourhood and use the RGB vector's length as intensity value */
-                "    for (float i = 0.0; i < 3.0; i++)",
-                "    {",
-                "        for (float j = 0.0; j < 3.0; j++)",
-                "        {",
-                "            sample = texture2D(uColorBuffer, vUv0 + uResolution * vec2(i - 1.0, j - 1.0)).rgb;",
-                "            I[int(i)][int(j)] = length(sample);",
-                "         }",
-                "    }",
-                "",
-                     /* Calculate the convolution values for all the masks */
-                "    for (int i=0; i<2; i++)",
-                "    {",
-                "        float dp3 = dot(G[i][0], I[0]) + dot(G[i][1], I[1]) + dot(G[i][2], I[2]);",
-                "        cnv[i] = dp3 * dp3; ",
-                "    }",
-                "",
-                "    gl_FragColor = uIntensity * uColor * vec4(sqrt(cnv[0]*cnv[0]+cnv[1]*cnv[1]));",
-                "}"
-            ].join("\n")
-        });
-
-        // Uniforms
-        this.resolution = new Float32Array(2);
-        this.intensity = 1.0;
-        this.color = new pc.Color(1, 1, 1, 1);
-    };
-
-    EdgeDetectEffect.prototype = Object.create(pc.PostEffect.prototype);
-    EdgeDetectEffect.prototype.constructor = EdgeDetectEffect;
-
-    Object.assign(EdgeDetectEffect.prototype, {
-        render: function (inputTarget, outputTarget, rect) {
-            var device = this.device;
-            var scope = device.scope;
-
-            this.resolution[0] = 1 / inputTarget.width;
-            this.resolution[1] = 1 / inputTarget.height;
-            scope.resolve("uResolution").setValue(this.resolution);
-            scope.resolve("uColorBuffer").setValue(inputTarget.colorBuffer);
-            scope.resolve("uColor").setValue(this.color.data);
-            scope.resolve("uIntensity").setValue(this.intensity);
-            pc.drawFullscreenQuad(device, outputTarget, this.vertexBuffer, this.shader, rect);
-        }
+    this.shader = new pc.Shader(graphicsDevice, {
+        attributes: {
+            aPosition: pc.SEMANTIC_POSITION
+        },
+        vshader: [
+            "attribute vec2 aPosition;",
+            "",
+            "varying vec2 vUv0;",
+            "",
+            "void main(void)",
+            "{",
+            "    gl_Position = vec4(aPosition, 0.0, 1.0);",
+            "    vUv0 = (aPosition.xy + 1.0) * 0.5;",
+            "}"
+        ].join("\n"),
+        fshader: [
+            "precision " + graphicsDevice.precision + " float;",
+            "",
+            "uniform sampler2D uColorBuffer;",
+            "varying vec2 vUv0;",
+            "uniform vec2 uResolution;",
+            "uniform float uIntensity;",
+            "uniform vec4 uColor;",
+            "",
+            "mat3 G[2];",
+            "",
+            "const mat3 g0 = mat3( 1.0, 2.0, 1.0, 0.0, 0.0, 0.0, -1.0, -2.0, -1.0 );",
+            "const mat3 g1 = mat3( 1.0, 0.0, -1.0, 2.0, 0.0, -2.0, 1.0, 0.0, -1.0 );",
+            "",
+            "void main(void)",
+            "{",
+            "    mat3 I;",
+            "    float cnv[2];",
+            "    vec3 sample;",
+            "",
+            "    G[0] = g0;",
+            "    G[1] = g1;",
+            "",
+                    /* Fetch the 3x3 neighbourhood and use the RGB vector's length as intensity value */
+            "    for (float i = 0.0; i < 3.0; i++)",
+            "    {",
+            "        for (float j = 0.0; j < 3.0; j++)",
+            "        {",
+            "            sample = texture2D(uColorBuffer, vUv0 + uResolution * vec2(i - 1.0, j - 1.0)).rgb;",
+            "            I[int(i)][int(j)] = length(sample);",
+            "         }",
+            "    }",
+            "",
+                    /* Calculate the convolution values for all the masks */
+            "    for (int i=0; i<2; i++)",
+            "    {",
+            "        float dp3 = dot(G[i][0], I[0]) + dot(G[i][1], I[1]) + dot(G[i][2], I[2]);",
+            "        cnv[i] = dp3 * dp3; ",
+            "    }",
+            "",
+            "    gl_FragColor = uIntensity * uColor * vec4(sqrt(cnv[0]*cnv[0]+cnv[1]*cnv[1]));",
+            "}"
+        ].join("\n")
     });
 
-    return {
-        EdgeDetectEffect: EdgeDetectEffect
-    };
-}());
+    // Uniforms
+    this.resolution = new Float32Array(2);
+    this.intensity = 1.0;
+    this.color = new pc.Color(1, 1, 1, 1);
+}
+
+EdgeDetectEffect.prototype = Object.create(pc.PostEffect.prototype);
+EdgeDetectEffect.prototype.constructor = EdgeDetectEffect;
+
+Object.assign(EdgeDetectEffect.prototype, {
+    render: function (inputTarget, outputTarget, rect) {
+        var device = this.device;
+        var scope = device.scope;
+
+        this.resolution[0] = 1 / inputTarget.width;
+        this.resolution[1] = 1 / inputTarget.height;
+        scope.resolve("uResolution").setValue(this.resolution);
+        scope.resolve("uColorBuffer").setValue(inputTarget.colorBuffer);
+        scope.resolve("uColor").setValue(this.color.data);
+        scope.resolve("uIntensity").setValue(this.intensity);
+        pc.drawFullscreenQuad(device, outputTarget, this.vertexBuffer, this.shader, rect);
+    }
+});
 
 // ----------------- SCRIPT DEFINITION ------------------ //
 var EdgeDetect = pc.createScript('edgeDetect');
@@ -120,7 +113,7 @@ EdgeDetect.attributes.add('color', {
 
 // initialize code called once per entity
 EdgeDetect.prototype.initialize = function () {
-    this.effect = new pc.EdgeDetectEffect(this.app.graphicsDevice);
+    this.effect = new EdgeDetectEffect(this.app.graphicsDevice);
     this.effect.intensity = this.intensity;
     this.effect.color = this.color;
 

--- a/examples/assets/scripts/posteffects/posteffect-fxaa.js
+++ b/examples/assets/scripts/posteffects/posteffect-fxaa.js
@@ -1,128 +1,121 @@
 // --------------- POST EFFECT DEFINITION --------------- //
-Object.assign(pc, function () {
+/**
+ * @class
+ * @name FxaaEffect
+ * @classdesc Implements the FXAA post effect by NVIDIA.
+ * @description Creates new instance of the post effect.
+ * @augments pc.PostEffect
+ * @param {pc.GraphicsDevice} graphicsDevice - The graphics device of the application.
+ */
+function FxaaEffect(graphicsDevice) {
+    pc.PostEffect.call(this, graphicsDevice);
 
-    /**
-     * @class
-     * @name pc.FxaaEffect
-     * @classdesc Implements the FXAA post effect by NVIDIA.
-     * @description Creates new instance of the post effect.
-     * @augments pc.PostEffect
-     * @param {pc.GraphicsDevice} graphicsDevice - The graphics device of the application.
-     */
-    var FxaaEffect = function (graphicsDevice) {
-        pc.PostEffect.call(this, graphicsDevice);
-
-        // Shaders
-        var attributes = {
-            aPosition: pc.SEMANTIC_POSITION
-        };
-
-        var passThroughVert = [
-            "attribute vec2 aPosition;",
-            "",
-            "void main(void)",
-            "{",
-            "    gl_Position = vec4(aPosition, 0.0, 1.0);",
-            "}"
-        ].join("\n");
-
-        var fxaaFrag = [
-            "precision " + graphicsDevice.precision + " float;",
-            "",
-            "uniform sampler2D uColorBuffer;",
-            "uniform vec2 uResolution;",
-            "",
-            "#define FXAA_REDUCE_MIN   (1.0/128.0)",
-            "#define FXAA_REDUCE_MUL   (1.0/8.0)",
-            "#define FXAA_SPAN_MAX     8.0",
-            "",
-            "void main()",
-            "{",
-            "    vec3 rgbNW = texture2D( uColorBuffer, ( gl_FragCoord.xy + vec2( -1.0, -1.0 ) ) * uResolution ).xyz;",
-            "    vec3 rgbNE = texture2D( uColorBuffer, ( gl_FragCoord.xy + vec2( 1.0, -1.0 ) ) * uResolution ).xyz;",
-            "    vec3 rgbSW = texture2D( uColorBuffer, ( gl_FragCoord.xy + vec2( -1.0, 1.0 ) ) * uResolution ).xyz;",
-            "    vec3 rgbSE = texture2D( uColorBuffer, ( gl_FragCoord.xy + vec2( 1.0, 1.0 ) ) * uResolution ).xyz;",
-            "    vec4 rgbaM  = texture2D( uColorBuffer,  gl_FragCoord.xy  * uResolution );",
-            "    vec3 rgbM  = rgbaM.xyz;",
-            "    float opacity  = rgbaM.w;",
-            "",
-            "    vec3 luma = vec3( 0.299, 0.587, 0.114 );",
-            "",
-            "    float lumaNW = dot( rgbNW, luma );",
-            "    float lumaNE = dot( rgbNE, luma );",
-            "    float lumaSW = dot( rgbSW, luma );",
-            "    float lumaSE = dot( rgbSE, luma );",
-            "    float lumaM  = dot( rgbM,  luma );",
-            "    float lumaMin = min( lumaM, min( min( lumaNW, lumaNE ), min( lumaSW, lumaSE ) ) );",
-            "    float lumaMax = max( lumaM, max( max( lumaNW, lumaNE) , max( lumaSW, lumaSE ) ) );",
-            "",
-            "    vec2 dir;",
-            "    dir.x = -((lumaNW + lumaNE) - (lumaSW + lumaSE));",
-            "    dir.y =  ((lumaNW + lumaSW) - (lumaNE + lumaSE));",
-            "",
-            "    float dirReduce = max( ( lumaNW + lumaNE + lumaSW + lumaSE ) * ( 0.25 * FXAA_REDUCE_MUL ), FXAA_REDUCE_MIN );",
-            "",
-            "    float rcpDirMin = 1.0 / ( min( abs( dir.x ), abs( dir.y ) ) + dirReduce );",
-            "    dir = min( vec2( FXAA_SPAN_MAX, FXAA_SPAN_MAX), max( vec2(-FXAA_SPAN_MAX, -FXAA_SPAN_MAX), dir * rcpDirMin)) * uResolution;",
-            "",
-            "    vec3 rgbA = 0.5 * (",
-            "        texture2D( uColorBuffer, gl_FragCoord.xy  * uResolution + dir * ( 1.0 / 3.0 - 0.5 ) ).xyz +",
-            "        texture2D( uColorBuffer, gl_FragCoord.xy  * uResolution + dir * ( 2.0 / 3.0 - 0.5 ) ).xyz );",
-            "",
-            "    vec3 rgbB = rgbA * 0.5 + 0.25 * (",
-            "        texture2D( uColorBuffer, gl_FragCoord.xy  * uResolution + dir * -0.5 ).xyz +",
-            "        texture2D( uColorBuffer, gl_FragCoord.xy  * uResolution + dir * 0.5 ).xyz );",
-            "",
-            "    float lumaB = dot( rgbB, luma );",
-            "",
-            "    if ( ( lumaB < lumaMin ) || ( lumaB > lumaMax ) )",
-            "    {",
-            "        gl_FragColor = vec4( rgbA, opacity );",
-            "    }",
-            "    else",
-            "    {",
-            "        gl_FragColor = vec4( rgbB, opacity );",
-            "    }",
-            "}"
-        ].join("\n");
-
-        this.fxaaShader = new pc.Shader(graphicsDevice, {
-            attributes: attributes,
-            vshader: passThroughVert,
-            fshader: fxaaFrag
-        });
-
-        // Uniforms
-        this.resolution = new Float32Array(2);
+    // Shaders
+    var attributes = {
+        aPosition: pc.SEMANTIC_POSITION
     };
 
-    FxaaEffect.prototype = Object.create(pc.PostEffect.prototype);
-    FxaaEffect.prototype.constructor = FxaaEffect;
+    var passThroughVert = [
+        "attribute vec2 aPosition;",
+        "",
+        "void main(void)",
+        "{",
+        "    gl_Position = vec4(aPosition, 0.0, 1.0);",
+        "}"
+    ].join("\n");
 
-    Object.assign(FxaaEffect.prototype, {
-        render: function (inputTarget, outputTarget, rect) {
-            var device = this.device;
-            var scope = device.scope;
+    var fxaaFrag = [
+        "precision " + graphicsDevice.precision + " float;",
+        "",
+        "uniform sampler2D uColorBuffer;",
+        "uniform vec2 uResolution;",
+        "",
+        "#define FXAA_REDUCE_MIN   (1.0/128.0)",
+        "#define FXAA_REDUCE_MUL   (1.0/8.0)",
+        "#define FXAA_SPAN_MAX     8.0",
+        "",
+        "void main()",
+        "{",
+        "    vec3 rgbNW = texture2D( uColorBuffer, ( gl_FragCoord.xy + vec2( -1.0, -1.0 ) ) * uResolution ).xyz;",
+        "    vec3 rgbNE = texture2D( uColorBuffer, ( gl_FragCoord.xy + vec2( 1.0, -1.0 ) ) * uResolution ).xyz;",
+        "    vec3 rgbSW = texture2D( uColorBuffer, ( gl_FragCoord.xy + vec2( -1.0, 1.0 ) ) * uResolution ).xyz;",
+        "    vec3 rgbSE = texture2D( uColorBuffer, ( gl_FragCoord.xy + vec2( 1.0, 1.0 ) ) * uResolution ).xyz;",
+        "    vec4 rgbaM  = texture2D( uColorBuffer,  gl_FragCoord.xy  * uResolution );",
+        "    vec3 rgbM  = rgbaM.xyz;",
+        "    float opacity  = rgbaM.w;",
+        "",
+        "    vec3 luma = vec3( 0.299, 0.587, 0.114 );",
+        "",
+        "    float lumaNW = dot( rgbNW, luma );",
+        "    float lumaNE = dot( rgbNE, luma );",
+        "    float lumaSW = dot( rgbSW, luma );",
+        "    float lumaSE = dot( rgbSE, luma );",
+        "    float lumaM  = dot( rgbM,  luma );",
+        "    float lumaMin = min( lumaM, min( min( lumaNW, lumaNE ), min( lumaSW, lumaSE ) ) );",
+        "    float lumaMax = max( lumaM, max( max( lumaNW, lumaNE) , max( lumaSW, lumaSE ) ) );",
+        "",
+        "    vec2 dir;",
+        "    dir.x = -((lumaNW + lumaNE) - (lumaSW + lumaSE));",
+        "    dir.y =  ((lumaNW + lumaSW) - (lumaNE + lumaSE));",
+        "",
+        "    float dirReduce = max( ( lumaNW + lumaNE + lumaSW + lumaSE ) * ( 0.25 * FXAA_REDUCE_MUL ), FXAA_REDUCE_MIN );",
+        "",
+        "    float rcpDirMin = 1.0 / ( min( abs( dir.x ), abs( dir.y ) ) + dirReduce );",
+        "    dir = min( vec2( FXAA_SPAN_MAX, FXAA_SPAN_MAX), max( vec2(-FXAA_SPAN_MAX, -FXAA_SPAN_MAX), dir * rcpDirMin)) * uResolution;",
+        "",
+        "    vec3 rgbA = 0.5 * (",
+        "        texture2D( uColorBuffer, gl_FragCoord.xy  * uResolution + dir * ( 1.0 / 3.0 - 0.5 ) ).xyz +",
+        "        texture2D( uColorBuffer, gl_FragCoord.xy  * uResolution + dir * ( 2.0 / 3.0 - 0.5 ) ).xyz );",
+        "",
+        "    vec3 rgbB = rgbA * 0.5 + 0.25 * (",
+        "        texture2D( uColorBuffer, gl_FragCoord.xy  * uResolution + dir * -0.5 ).xyz +",
+        "        texture2D( uColorBuffer, gl_FragCoord.xy  * uResolution + dir * 0.5 ).xyz );",
+        "",
+        "    float lumaB = dot( rgbB, luma );",
+        "",
+        "    if ( ( lumaB < lumaMin ) || ( lumaB > lumaMax ) )",
+        "    {",
+        "        gl_FragColor = vec4( rgbA, opacity );",
+        "    }",
+        "    else",
+        "    {",
+        "        gl_FragColor = vec4( rgbB, opacity );",
+        "    }",
+        "}"
+    ].join("\n");
 
-            this.resolution[0] = 1 / inputTarget.width;
-            this.resolution[1] = 1 / inputTarget.height;
-            scope.resolve("uResolution").setValue(this.resolution);
-            scope.resolve("uColorBuffer").setValue(inputTarget.colorBuffer);
-            pc.drawFullscreenQuad(device, outputTarget, this.vertexBuffer, this.fxaaShader, rect);
-        }
+    this.fxaaShader = new pc.Shader(graphicsDevice, {
+        attributes: attributes,
+        vshader: passThroughVert,
+        fshader: fxaaFrag
     });
 
-    return {
-        FxaaEffect: FxaaEffect
-    };
-}());
+    // Uniforms
+    this.resolution = new Float32Array(2);
+}
+
+FxaaEffect.prototype = Object.create(pc.PostEffect.prototype);
+FxaaEffect.prototype.constructor = FxaaEffect;
+
+Object.assign(FxaaEffect.prototype, {
+    render: function (inputTarget, outputTarget, rect) {
+        var device = this.device;
+        var scope = device.scope;
+
+        this.resolution[0] = 1 / inputTarget.width;
+        this.resolution[1] = 1 / inputTarget.height;
+        scope.resolve("uResolution").setValue(this.resolution);
+        scope.resolve("uColorBuffer").setValue(inputTarget.colorBuffer);
+        pc.drawFullscreenQuad(device, outputTarget, this.vertexBuffer, this.fxaaShader, rect);
+    }
+});
 
 // ----------------- SCRIPT DEFINITION ------------------ //
 var Fxaa = pc.createScript('fxaa');
 
 // initialize code called once per entity
 Fxaa.prototype.initialize = function () {
-    this.effect = new pc.FxaaEffect(this.app.graphicsDevice);
+    this.effect = new FxaaEffect(this.app.graphicsDevice);
 
     var queue = this.entity.camera.postEffects;
     queue.addEffect(this.effect);

--- a/examples/assets/scripts/posteffects/posteffect-horizontaltiltshift.js
+++ b/examples/assets/scripts/posteffects/posteffect-horizontaltiltshift.js
@@ -1,85 +1,78 @@
 // --------------- POST EFFECT DEFINITION --------------- //
-Object.assign(pc, function () {
+/**
+ * @class
+ * @name HorizontalTiltShiftEffect
+ * @classdesc Simple fake tilt-shift effect, modulating two pass Gaussian blur by horizontal position.
+ * @description Creates new instance of the post effect.
+ * @augments pc.PostEffect
+ * @param {pc.GraphicsDevice} graphicsDevice - The graphics device of the application.
+ * @property {number} focus Controls where the "focused" vertical line lies.
+ */
+function HorizontalTiltShiftEffect(graphicsDevice) {
+    pc.PostEffect.call(this, graphicsDevice);
 
-    /**
-     * @class
-     * @name pc.HorizontalTiltShiftEffect
-     * @classdesc Simple fake tilt-shift effect, modulating two pass Gaussian blur by horizontal position.
-     * @description Creates new instance of the post effect.
-     * @augments pc.PostEffect
-     * @param {pc.GraphicsDevice} graphicsDevice - The graphics device of the application.
-     * @property {number} focus Controls where the "focused" vertical line lies.
-     */
-    var HorizontalTiltShiftEffect = function (graphicsDevice) {
-        pc.PostEffect.call(this, graphicsDevice);
-
-        // Shader author: alteredq / http://alteredqualia.com/
-        this.shader = new pc.Shader(graphicsDevice, {
-            attributes: {
-                aPosition: pc.SEMANTIC_POSITION
-            },
-            vshader: [
-                "attribute vec2 aPosition;",
-                "",
-                "varying vec2 vUv0;",
-                "",
-                "void main(void)",
-                "{",
-                "    gl_Position = vec4(aPosition, 0.0, 1.0);",
-                "    vUv0 = (aPosition.xy + 1.0) * 0.5;",
-                "}"
-            ].join("\n"),
-            fshader: [
-                "precision " + graphicsDevice.precision + " float;",
-                "",
-                "uniform sampler2D uColorBuffer;",
-                "uniform float uH;",
-                "uniform float uR;",
-                "",
-                "varying vec2 vUv0;",
-                "",
-                "void main() {",
-                "    vec4 sum = vec4( 0.0 );",
-                "    float hh = uH * abs( uR - vUv0.x );",
-                "",
-                "    sum += texture2D( uColorBuffer, vec2( vUv0.x - 4.0 * hh, vUv0.y ) ) * 0.051;",
-                "    sum += texture2D( uColorBuffer, vec2( vUv0.x - 3.0 * hh, vUv0.y ) ) * 0.0918;",
-                "    sum += texture2D( uColorBuffer, vec2( vUv0.x - 2.0 * hh, vUv0.y ) ) * 0.12245;",
-                "    sum += texture2D( uColorBuffer, vec2( vUv0.x - 1.0 * hh, vUv0.y ) ) * 0.1531;",
-                "    sum += texture2D( uColorBuffer, vec2( vUv0.x, vUv0.y ) ) * 0.1633;",
-                "    sum += texture2D( uColorBuffer, vec2( vUv0.x + 1.0 * hh, vUv0.y ) ) * 0.1531;",
-                "    sum += texture2D( uColorBuffer, vec2( vUv0.x + 2.0 * hh, vUv0.y ) ) * 0.12245;",
-                "    sum += texture2D( uColorBuffer, vec2( vUv0.x + 3.0 * hh, vUv0.y ) ) * 0.0918;",
-                "    sum += texture2D( uColorBuffer, vec2( vUv0.x + 4.0 * hh, vUv0.y ) ) * 0.051;",
-                "",
-                "    gl_FragColor = sum;",
-                "}"
-            ].join("\n")
-        });
-
-        // uniforms
-        this.focus = 0.35;
-    };
-
-    HorizontalTiltShiftEffect.prototype = Object.create(pc.PostEffect.prototype);
-    HorizontalTiltShiftEffect.prototype.constructor = HorizontalTiltShiftEffect;
-
-    Object.assign(HorizontalTiltShiftEffect.prototype, {
-        render: function (inputTarget, outputTarget, rect) {
-            var device = this.device;
-            var scope = device.scope;
-
-            scope.resolve("uH").setValue(1 / inputTarget.width);
-            scope.resolve("uR").setValue(this.focus);
-            scope.resolve("uColorBuffer").setValue(inputTarget.colorBuffer);
-            pc.drawFullscreenQuad(device, outputTarget, this.vertexBuffer, this.shader, rect);
-        }
+    // Shader author: alteredq / http://alteredqualia.com/
+    this.shader = new pc.Shader(graphicsDevice, {
+        attributes: {
+            aPosition: pc.SEMANTIC_POSITION
+        },
+        vshader: [
+            "attribute vec2 aPosition;",
+            "",
+            "varying vec2 vUv0;",
+            "",
+            "void main(void)",
+            "{",
+            "    gl_Position = vec4(aPosition, 0.0, 1.0);",
+            "    vUv0 = (aPosition.xy + 1.0) * 0.5;",
+            "}"
+        ].join("\n"),
+        fshader: [
+            "precision " + graphicsDevice.precision + " float;",
+            "",
+            "uniform sampler2D uColorBuffer;",
+            "uniform float uH;",
+            "uniform float uR;",
+            "",
+            "varying vec2 vUv0;",
+            "",
+            "void main() {",
+            "    vec4 sum = vec4( 0.0 );",
+            "    float hh = uH * abs( uR - vUv0.x );",
+            "",
+            "    sum += texture2D( uColorBuffer, vec2( vUv0.x - 4.0 * hh, vUv0.y ) ) * 0.051;",
+            "    sum += texture2D( uColorBuffer, vec2( vUv0.x - 3.0 * hh, vUv0.y ) ) * 0.0918;",
+            "    sum += texture2D( uColorBuffer, vec2( vUv0.x - 2.0 * hh, vUv0.y ) ) * 0.12245;",
+            "    sum += texture2D( uColorBuffer, vec2( vUv0.x - 1.0 * hh, vUv0.y ) ) * 0.1531;",
+            "    sum += texture2D( uColorBuffer, vec2( vUv0.x, vUv0.y ) ) * 0.1633;",
+            "    sum += texture2D( uColorBuffer, vec2( vUv0.x + 1.0 * hh, vUv0.y ) ) * 0.1531;",
+            "    sum += texture2D( uColorBuffer, vec2( vUv0.x + 2.0 * hh, vUv0.y ) ) * 0.12245;",
+            "    sum += texture2D( uColorBuffer, vec2( vUv0.x + 3.0 * hh, vUv0.y ) ) * 0.0918;",
+            "    sum += texture2D( uColorBuffer, vec2( vUv0.x + 4.0 * hh, vUv0.y ) ) * 0.051;",
+            "",
+            "    gl_FragColor = sum;",
+            "}"
+        ].join("\n")
     });
 
-    return {
-        HorizontalTiltShiftEffect: HorizontalTiltShiftEffect
-    };
-}());
+    // uniforms
+    this.focus = 0.35;
+}
+
+HorizontalTiltShiftEffect.prototype = Object.create(pc.PostEffect.prototype);
+HorizontalTiltShiftEffect.prototype.constructor = HorizontalTiltShiftEffect;
+
+Object.assign(HorizontalTiltShiftEffect.prototype, {
+    render: function (inputTarget, outputTarget, rect) {
+        var device = this.device;
+        var scope = device.scope;
+
+        scope.resolve("uH").setValue(1 / inputTarget.width);
+        scope.resolve("uR").setValue(this.focus);
+        scope.resolve("uColorBuffer").setValue(inputTarget.colorBuffer);
+        pc.drawFullscreenQuad(device, outputTarget, this.vertexBuffer, this.shader, rect);
+    }
+});
 
 // ----------------- SCRIPT DEFINITION ------------------ //
 var HorizontalTiltShift = pc.createScript('horizontalTiltShift');
@@ -89,13 +82,12 @@ HorizontalTiltShift.attributes.add('focus', {
     default: 0.35,
     min: 0,
     max: 1,
-    precision: 5,
     title: 'Focus'
 });
 
 // initialize code called once per entity
 HorizontalTiltShift.prototype.initialize = function () {
-    this.effect = new pc.HorizontalTiltShiftEffect(this.app.graphicsDevice);
+    this.effect = new HorizontalTiltShiftEffect(this.app.graphicsDevice);
     this.effect.focus = this.focus;
 
     this.on('attr:focus', function (value) {

--- a/examples/assets/scripts/posteffects/posteffect-huesaturation.js
+++ b/examples/assets/scripts/posteffects/posteffect-huesaturation.js
@@ -1,93 +1,86 @@
 // --------------- POST EFFECT DEFINITION --------------- //
-Object.assign(pc, function () {
+/**
+ * @class
+ * @name HueSaturationEffect
+ * @classdesc Allows hue and saturation adjustment of the input render target.
+ * @description Creates new instance of the post effect.
+ * @augments pc.PostEffect
+ * @param {pc.GraphicsDevice} graphicsDevice - The graphics device of the application.
+ * @property {number} hue Controls the hue. Ranges from -1 to 1 (-1 is 180 degrees in the negative direction, 0 no change, 1 is 180 degrees in the postitive direction).
+ * @property {number} saturation Controls the saturation. Ranges from -1 to 1 (-1 is solid gray, 0 no change, 1 maximum saturation).
+ */
+function HueSaturationEffect(graphicsDevice) {
+    pc.PostEffect.call(this, graphicsDevice);
 
-    /**
-     * @class
-     * @name pc.HueSaturationEffect
-     * @classdesc Allows hue and saturation adjustment of the input render target.
-     * @description Creates new instance of the post effect.
-     * @augments pc.PostEffect
-     * @param {pc.GraphicsDevice} graphicsDevice - The graphics device of the application.
-     * @property {number} hue Controls the hue. Ranges from -1 to 1 (-1 is 180 degrees in the negative direction, 0 no change, 1 is 180 degrees in the postitive direction).
-     * @property {number} saturation Controls the saturation. Ranges from -1 to 1 (-1 is solid gray, 0 no change, 1 maximum saturation).
-     */
-    var HueSaturationEffect = function (graphicsDevice) {
-        pc.PostEffect.call(this, graphicsDevice);
-
-        // Shader author: tapio / http://tapio.github.com/
-        this.shader = new pc.Shader(graphicsDevice, {
-            attributes: {
-                aPosition: pc.SEMANTIC_POSITION
-            },
-            vshader: [
-                "attribute vec2 aPosition;",
-                "",
-                "varying vec2 vUv0;",
-                "",
-                "void main(void)",
-                "{",
-                "    gl_Position = vec4(aPosition, 0.0, 1.0);",
-                "    vUv0 = (aPosition.xy + 1.0) * 0.5;",
-                "}"
-            ].join("\n"),
-            fshader: [
-                "precision " + graphicsDevice.precision + " float;",
-                "",
-                "uniform sampler2D uColorBuffer;",
-                "uniform float uHue;",
-                "uniform float uSaturation;",
-                "",
-                "varying vec2 vUv0;",
-                "",
-                "void main() {",
-                "    gl_FragColor = texture2D( uColorBuffer, vUv0 );",
-                "",
-                // uHue
-                "    float angle = uHue * 3.14159265;",
-                "    float s = sin(angle), c = cos(angle);",
-                "    vec3 weights = (vec3(2.0 * c, -sqrt(3.0) * s - c, sqrt(3.0) * s - c) + 1.0) / 3.0;",
-                "    float len = length(gl_FragColor.rgb);",
-                "    gl_FragColor.rgb = vec3(",
-                "        dot(gl_FragColor.rgb, weights.xyz),",
-                "        dot(gl_FragColor.rgb, weights.zxy),",
-                "        dot(gl_FragColor.rgb, weights.yzx)",
-                "    );",
-                "",
-                // uSaturation
-                "    float average = (gl_FragColor.r + gl_FragColor.g + gl_FragColor.b) / 3.0;",
-                "    if (uSaturation > 0.0) {",
-                "        gl_FragColor.rgb += (average - gl_FragColor.rgb) * (1.0 - 1.0 / (1.001 - uSaturation));",
-                "    } else {",
-                "        gl_FragColor.rgb += (average - gl_FragColor.rgb) * (-uSaturation);",
-                "    }",
-                "}"
-            ].join("\n")
-        });
-
-        // uniforms
-        this.hue = 0;
-        this.saturation = 0;
-    };
-
-    HueSaturationEffect.prototype = Object.create(pc.PostEffect.prototype);
-    HueSaturationEffect.prototype.constructor = HueSaturationEffect;
-
-    Object.assign(HueSaturationEffect.prototype, {
-        render: function (inputTarget, outputTarget, rect) {
-            var device = this.device;
-            var scope = device.scope;
-
-            scope.resolve("uHue").setValue(this.hue);
-            scope.resolve("uSaturation").setValue(this.saturation);
-            scope.resolve("uColorBuffer").setValue(inputTarget.colorBuffer);
-            pc.drawFullscreenQuad(device, outputTarget, this.vertexBuffer, this.shader, rect);
-        }
+    // Shader author: tapio / http://tapio.github.com/
+    this.shader = new pc.Shader(graphicsDevice, {
+        attributes: {
+            aPosition: pc.SEMANTIC_POSITION
+        },
+        vshader: [
+            "attribute vec2 aPosition;",
+            "",
+            "varying vec2 vUv0;",
+            "",
+            "void main(void)",
+            "{",
+            "    gl_Position = vec4(aPosition, 0.0, 1.0);",
+            "    vUv0 = (aPosition.xy + 1.0) * 0.5;",
+            "}"
+        ].join("\n"),
+        fshader: [
+            "precision " + graphicsDevice.precision + " float;",
+            "",
+            "uniform sampler2D uColorBuffer;",
+            "uniform float uHue;",
+            "uniform float uSaturation;",
+            "",
+            "varying vec2 vUv0;",
+            "",
+            "void main() {",
+            "    gl_FragColor = texture2D( uColorBuffer, vUv0 );",
+            "",
+            // uHue
+            "    float angle = uHue * 3.14159265;",
+            "    float s = sin(angle), c = cos(angle);",
+            "    vec3 weights = (vec3(2.0 * c, -sqrt(3.0) * s - c, sqrt(3.0) * s - c) + 1.0) / 3.0;",
+            "    float len = length(gl_FragColor.rgb);",
+            "    gl_FragColor.rgb = vec3(",
+            "        dot(gl_FragColor.rgb, weights.xyz),",
+            "        dot(gl_FragColor.rgb, weights.zxy),",
+            "        dot(gl_FragColor.rgb, weights.yzx)",
+            "    );",
+            "",
+            // uSaturation
+            "    float average = (gl_FragColor.r + gl_FragColor.g + gl_FragColor.b) / 3.0;",
+            "    if (uSaturation > 0.0) {",
+            "        gl_FragColor.rgb += (average - gl_FragColor.rgb) * (1.0 - 1.0 / (1.001 - uSaturation));",
+            "    } else {",
+            "        gl_FragColor.rgb += (average - gl_FragColor.rgb) * (-uSaturation);",
+            "    }",
+            "}"
+        ].join("\n")
     });
 
-    return {
-        HueSaturationEffect: HueSaturationEffect
-    };
-}());
+    // uniforms
+    this.hue = 0;
+    this.saturation = 0;
+}
+
+HueSaturationEffect.prototype = Object.create(pc.PostEffect.prototype);
+HueSaturationEffect.prototype.constructor = HueSaturationEffect;
+
+Object.assign(HueSaturationEffect.prototype, {
+    render: function (inputTarget, outputTarget, rect) {
+        var device = this.device;
+        var scope = device.scope;
+
+        scope.resolve("uHue").setValue(this.hue);
+        scope.resolve("uSaturation").setValue(this.saturation);
+        scope.resolve("uColorBuffer").setValue(inputTarget.colorBuffer);
+        pc.drawFullscreenQuad(device, outputTarget, this.vertexBuffer, this.shader, rect);
+    }
+});
 
 // ----------------- SCRIPT DEFINITION ------------------ //
 var HueSaturation = pc.createScript('hueSaturation');
@@ -97,7 +90,6 @@ HueSaturation.attributes.add('hue', {
     default: 0,
     min: -1,
     max: 1,
-    precision: 5,
     title: 'Hue'
 });
 
@@ -106,12 +98,11 @@ HueSaturation.attributes.add('saturation', {
     default: 0,
     min: -1,
     max: 1,
-    precision: 5,
     title: 'Saturation'
 });
 
 HueSaturation.prototype.initialize = function () {
-    this.effect = new pc.HueSaturationEffect(this.app.graphicsDevice);
+    this.effect = new HueSaturationEffect(this.app.graphicsDevice);
     this.effect.hue = this.hue;
     this.effect.saturation = this.saturation;
 

--- a/examples/assets/scripts/posteffects/posteffect-luminosity.js
+++ b/examples/assets/scripts/posteffects/posteffect-luminosity.js
@@ -1,73 +1,66 @@
 // --------------- POST EFFECT DEFINITION --------------- //
-Object.assign(pc, function () {
+/**
+ * @class
+ * @name LuminosityEffect
+ * @classdesc Outputs the luminosity of the input render target.
+ * @description Creates new instance of the post effect.
+ * @augments pc.PostEffect
+ * @param {pc.GraphicsDevice} graphicsDevice - The graphics device of the application.
+ */
+function LuminosityEffect(graphicsDevice) {
+    pc.PostEffect.call(this, graphicsDevice);
 
-    /**
-     * @class
-     * @name pc.LuminosityEffect
-     * @classdesc Outputs the luminosity of the input render target.
-     * @description Creates new instance of the post effect.
-     * @augments pc.PostEffect
-     * @param {pc.GraphicsDevice} graphicsDevice - The graphics device of the application.
-     */
-    var LuminosityEffect = function (graphicsDevice) {
-        pc.PostEffect.call(this, graphicsDevice);
-
-        this.shader = new pc.Shader(graphicsDevice, {
-            attributes: {
-                aPosition: pc.SEMANTIC_POSITION
-            },
-            vshader: [
-                "attribute vec2 aPosition;",
-                "",
-                "varying vec2 vUv0;",
-                "",
-                "void main(void)",
-                "{",
-                "    gl_Position = vec4(aPosition, 0.0, 1.0);",
-                "    vUv0 = (aPosition.xy + 1.0) * 0.5;",
-                "}"
-            ].join("\n"),
-            fshader: [
-                "precision " + graphicsDevice.precision + " float;",
-                "",
-                "uniform sampler2D uColorBuffer;",
-                "",
-                "varying vec2 vUv0;",
-                "",
-                "void main() {",
-                "    vec4 texel = texture2D(uColorBuffer, vUv0);",
-                "    vec3 luma = vec3(0.299, 0.587, 0.114);",
-                "    float v = dot(texel.xyz, luma);",
-                "    gl_FragColor = vec4(v, v, v, texel.w);",
-                "}"
-            ].join("\n")
-        });
-    };
-
-    LuminosityEffect.prototype = Object.create(pc.PostEffect.prototype);
-    LuminosityEffect.prototype.constructor = LuminosityEffect;
-
-    Object.assign(LuminosityEffect.prototype, {
-        render: function (inputTarget, outputTarget, rect) {
-            var device = this.device;
-            var scope = device.scope;
-
-            scope.resolve("uColorBuffer").setValue(inputTarget.colorBuffer);
-            pc.drawFullscreenQuad(device, outputTarget, this.vertexBuffer, this.shader, rect);
-        }
+    this.shader = new pc.Shader(graphicsDevice, {
+        attributes: {
+            aPosition: pc.SEMANTIC_POSITION
+        },
+        vshader: [
+            "attribute vec2 aPosition;",
+            "",
+            "varying vec2 vUv0;",
+            "",
+            "void main(void)",
+            "{",
+            "    gl_Position = vec4(aPosition, 0.0, 1.0);",
+            "    vUv0 = (aPosition.xy + 1.0) * 0.5;",
+            "}"
+        ].join("\n"),
+        fshader: [
+            "precision " + graphicsDevice.precision + " float;",
+            "",
+            "uniform sampler2D uColorBuffer;",
+            "",
+            "varying vec2 vUv0;",
+            "",
+            "void main() {",
+            "    vec4 texel = texture2D(uColorBuffer, vUv0);",
+            "    vec3 luma = vec3(0.299, 0.587, 0.114);",
+            "    float v = dot(texel.xyz, luma);",
+            "    gl_FragColor = vec4(v, v, v, texel.w);",
+            "}"
+        ].join("\n")
     });
+}
 
-    return {
-        LuminosityEffect: LuminosityEffect
-    };
-}());
+LuminosityEffect.prototype = Object.create(pc.PostEffect.prototype);
+LuminosityEffect.prototype.constructor = LuminosityEffect;
+
+Object.assign(LuminosityEffect.prototype, {
+    render: function (inputTarget, outputTarget, rect) {
+        var device = this.device;
+        var scope = device.scope;
+
+        scope.resolve("uColorBuffer").setValue(inputTarget.colorBuffer);
+        pc.drawFullscreenQuad(device, outputTarget, this.vertexBuffer, this.shader, rect);
+    }
+});
 
 // ----------------- SCRIPT DEFINITION ------------------ //
 var Luminosity = pc.createScript('luminosity');
 
 // initialize code called once per entity
 Luminosity.prototype.initialize = function () {
-    this.effect = new pc.LuminosityEffect(this.app.graphicsDevice);
+    this.effect = new LuminosityEffect(this.app.graphicsDevice);
 
     var queue = this.entity.camera.postEffects;
     queue.addEffect(this.effect);

--- a/examples/assets/scripts/posteffects/posteffect-outline.js
+++ b/examples/assets/scripts/posteffects/posteffect-outline.js
@@ -1,105 +1,98 @@
 // --------------- POST EFFECT DEFINITION --------------- //
-Object.assign(pc, function () {
+/**
+ * @class
+ * @name OutlineEffect
+ * @classdesc Applies an outline effect on input render target
+ * @description Creates new instance of the post effect.
+ * @augments pc.PostEffect
+ * @param {pc.GraphicsDevice} graphicsDevice - The graphics device of the application.
+ * @param {number} thickness - The thickness for the outline effect passed here to be used as a constant in shader.
+ * @property {pc.Texture} texture The outline texture to use.
+ * @property {pc.Color} color The outline color.
+ */
+function OutlineEffect(graphicsDevice, thickness) {
+    pc.PostEffect.call(this, graphicsDevice);
 
-    /**
-     * @class
-     * @name pc.OutlineEffect
-     * @classdesc Applies an outline effect on input render target
-     * @description Creates new instance of the post effect.
-     * @augments pc.PostEffect
-     * @param {pc.GraphicsDevice} graphicsDevice - The graphics device of the application.
-     * @param {number} thickness - The thickness for the outline effect passed here to be used as a constant in shader.
-     * @property {pc.Texture} texture The outline texture to use.
-     * @property {pc.Color} color The outline color.
-     */
-    var OutlineEffect = function (graphicsDevice, thickness) {
-        pc.PostEffect.call(this, graphicsDevice);
-
-        this.shader = new pc.Shader(graphicsDevice, {
-            attributes: {
-                aPosition: pc.SEMANTIC_POSITION
-            },
-            vshader: [
-                "attribute vec2 aPosition;",
-                "",
-                "varying vec2 vUv0;",
-                "",
-                "void main(void)",
-                "{",
-                "    gl_Position = vec4(aPosition, 0.0, 1.0);",
-                "    vUv0 = (aPosition.xy + 1.0) * 0.5;",
-                "}"
-            ].join("\n"),
-            fshader: [
-                "precision " + graphicsDevice.precision + " float;",
-                "",
-                "#define THICKNESS " + (thickness ? thickness.toFixed(0) : 1),
-                "uniform float uWidth;",
-                "uniform float uHeight;",
-                "uniform vec4 uOutlineCol;",
-                "uniform sampler2D uColorBuffer;",
-                "uniform sampler2D uOutlineTex;",
-                "",
-                "varying vec2 vUv0;",
-                "",
-                "void main(void)",
-                "{",
-                "    vec4 texel1 = texture2D(uColorBuffer, vUv0);",
-                "    float sample0 = texture2D(uOutlineTex, vUv0).a;",
-                "    float outline = 0.0;",
-                "    if (sample0==0.0)",
-                "    {",
-                "        for (int x=-THICKNESS;x<=THICKNESS;x++)",
-                "        {",
-                "            for (int y=-THICKNESS;y<=THICKNESS;y++)",
-                "            {    ",
-                "                float sample=texture2D(uOutlineTex, vUv0+vec2(float(x)/uWidth, float(y)/uHeight)).a;",
-                "                if (sample>0.0)",
-                "                {",
-                "                    outline=1.0;",
-                "                }",
-                "            }",
-                "        } ",
-                "    }",
-                "    gl_FragColor = mix(texel1, uOutlineCol, outline * uOutlineCol.a);",
-                "}"
-            ].join("\n")
-        });
-
-        // Uniforms
-        this.color = new pc.Color(1, 1, 1, 1);
-        this.texture = new pc.Texture(graphicsDevice);
-        this.texture.name = 'pe-outline';
-    };
-
-    OutlineEffect.prototype = Object.create(pc.PostEffect.prototype);
-    OutlineEffect.prototype.constructor = OutlineEffect;
-
-    Object.assign(OutlineEffect.prototype, {
-        render: function (inputTarget, outputTarget, rect) {
-            var device = this.device;
-            var scope = device.scope;
-
-            scope.resolve("uWidth").setValue(inputTarget.width);
-            scope.resolve("uHeight").setValue(inputTarget.height);
-            scope.resolve("uOutlineCol").setValue(this.color.data);
-            scope.resolve("uColorBuffer").setValue(inputTarget.colorBuffer);
-            scope.resolve("uOutlineTex").setValue(this.texture);
-            pc.drawFullscreenQuad(device, outputTarget, this.vertexBuffer, this.shader, rect);
-        }
+    this.shader = new pc.Shader(graphicsDevice, {
+        attributes: {
+            aPosition: pc.SEMANTIC_POSITION
+        },
+        vshader: [
+            "attribute vec2 aPosition;",
+            "",
+            "varying vec2 vUv0;",
+            "",
+            "void main(void)",
+            "{",
+            "    gl_Position = vec4(aPosition, 0.0, 1.0);",
+            "    vUv0 = (aPosition.xy + 1.0) * 0.5;",
+            "}"
+        ].join("\n"),
+        fshader: [
+            "precision " + graphicsDevice.precision + " float;",
+            "",
+            "#define THICKNESS " + (thickness ? thickness.toFixed(0) : 1),
+            "uniform float uWidth;",
+            "uniform float uHeight;",
+            "uniform vec4 uOutlineCol;",
+            "uniform sampler2D uColorBuffer;",
+            "uniform sampler2D uOutlineTex;",
+            "",
+            "varying vec2 vUv0;",
+            "",
+            "void main(void)",
+            "{",
+            "    vec4 texel1 = texture2D(uColorBuffer, vUv0);",
+            "    float sample0 = texture2D(uOutlineTex, vUv0).a;",
+            "    float outline = 0.0;",
+            "    if (sample0==0.0)",
+            "    {",
+            "        for (int x=-THICKNESS;x<=THICKNESS;x++)",
+            "        {",
+            "            for (int y=-THICKNESS;y<=THICKNESS;y++)",
+            "            {    ",
+            "                float sample=texture2D(uOutlineTex, vUv0+vec2(float(x)/uWidth, float(y)/uHeight)).a;",
+            "                if (sample>0.0)",
+            "                {",
+            "                    outline=1.0;",
+            "                }",
+            "            }",
+            "        } ",
+            "    }",
+            "    gl_FragColor = mix(texel1, uOutlineCol, outline * uOutlineCol.a);",
+            "}"
+        ].join("\n")
     });
 
-    return {
-        OutlineEffect: OutlineEffect
-    };
-}());
+    // Uniforms
+    this.color = new pc.Color(1, 1, 1, 1);
+    this.texture = new pc.Texture(graphicsDevice);
+    this.texture.name = 'pe-outline';
+}
+
+OutlineEffect.prototype = Object.create(pc.PostEffect.prototype);
+OutlineEffect.prototype.constructor = OutlineEffect;
+
+Object.assign(OutlineEffect.prototype, {
+    render: function (inputTarget, outputTarget, rect) {
+        var device = this.device;
+        var scope = device.scope;
+
+        scope.resolve("uWidth").setValue(inputTarget.width);
+        scope.resolve("uHeight").setValue(inputTarget.height);
+        scope.resolve("uOutlineCol").setValue(this.color.data);
+        scope.resolve("uColorBuffer").setValue(inputTarget.colorBuffer);
+        scope.resolve("uOutlineTex").setValue(this.texture);
+        pc.drawFullscreenQuad(device, outputTarget, this.vertexBuffer, this.shader, rect);
+    }
+});
 
 // ----------------- SCRIPT DEFINITION ------------------ //
 var Outline = pc.createScript('outline');
 
 Outline.attributes.add('color', {
     type: 'rgb',
-    default: [0.5, 0.5, 0.5, 1],
+    default: [0.5, 0.5, 0.5],
     title: 'Color'
 });
 
@@ -120,7 +113,7 @@ Outline.attributes.add('texture', {
 });
 
 Outline.prototype.initialize = function () {
-    this.effect = new pc.OutlineEffect(this.app.graphicsDevice, this.thickness);
+    this.effect = new OutlineEffect(this.app.graphicsDevice, this.thickness);
     this.effect.color = this.color;
     this.effect.texture = this.texture.resource;
 

--- a/examples/assets/scripts/posteffects/posteffect-sepia.js
+++ b/examples/assets/scripts/posteffects/posteffect-sepia.js
@@ -1,76 +1,69 @@
 // --------------- POST EFFECT DEFINITION --------------- //
-Object.assign(pc, function () {
+/**
+ * @class
+ * @name SepiaEffect
+ * @classdesc Implements the SepiaEffect color filter.
+ * @description Creates new instance of the post effect.
+ * @augments pc.PostEffect
+ * @param {pc.GraphicsDevice} graphicsDevice - The graphics device of the application.
+ * @property {number} amount Controls the intensity of the effect. Ranges from 0 to 1.
+ */
+function SepiaEffect(graphicsDevice) {
+    pc.PostEffect.call(this, graphicsDevice);
 
-    /**
-     * @class
-     * @name pc.SepiaEffect
-     * @classdesc Implements the SepiaEffect color filter.
-     * @description Creates new instance of the post effect.
-     * @augments pc.PostEffect
-     * @param {pc.GraphicsDevice} graphicsDevice - The graphics device of the application.
-     * @property {number} amount Controls the intensity of the effect. Ranges from 0 to 1.
-     */
-    var SepiaEffect = function (graphicsDevice) {
-        pc.PostEffect.call(this, graphicsDevice);
-
-        this.shader = new pc.Shader(graphicsDevice, {
-            attributes: {
-                aPosition: pc.SEMANTIC_POSITION
-            },
-            vshader: [
-                "attribute vec2 aPosition;",
-                "",
-                "varying vec2 vUv0;",
-                "",
-                "void main(void)",
-                "{",
-                "    gl_Position = vec4(aPosition, 0.0, 1.0);",
-                "    vUv0 = (aPosition.xy + 1.0) * 0.5;",
-                "}"
-            ].join("\n"),
-            fshader: [
-                "precision " + graphicsDevice.precision + " float;",
-                "",
-                "uniform float uAmount;",
-                "uniform sampler2D uColorBuffer;",
-                "",
-                "varying vec2 vUv0;",
-                "",
-                "void main() {",
-                "    vec4 color = texture2D(uColorBuffer, vUv0);",
-                "    vec3 c = color.rgb;",
-                "",
-                "    color.r = dot(c, vec3(1.0 - 0.607 * uAmount, 0.769 * uAmount, 0.189 * uAmount));",
-                "    color.g = dot(c, vec3(0.349 * uAmount, 1.0 - 0.314 * uAmount, 0.168 * uAmount));",
-                "    color.b = dot(c, vec3(0.272 * uAmount, 0.534 * uAmount, 1.0 - 0.869 * uAmount));",
-                "",
-                "    gl_FragColor = vec4(min(vec3(1.0), color.rgb), color.a);",
-                "}"
-            ].join("\n")
-        });
-
-        // Uniforms
-        this.amount = 1;
-    };
-
-    SepiaEffect.prototype = Object.create(pc.PostEffect.prototype);
-    SepiaEffect.prototype.constructor = SepiaEffect;
-
-    Object.assign(SepiaEffect.prototype, {
-        render: function (inputTarget, outputTarget, rect) {
-            var device = this.device;
-            var scope = device.scope;
-
-            scope.resolve("uAmount").setValue(this.amount);
-            scope.resolve("uColorBuffer").setValue(inputTarget.colorBuffer);
-            pc.drawFullscreenQuad(device, outputTarget, this.vertexBuffer, this.shader, rect);
-        }
+    this.shader = new pc.Shader(graphicsDevice, {
+        attributes: {
+            aPosition: pc.SEMANTIC_POSITION
+        },
+        vshader: [
+            "attribute vec2 aPosition;",
+            "",
+            "varying vec2 vUv0;",
+            "",
+            "void main(void)",
+            "{",
+            "    gl_Position = vec4(aPosition, 0.0, 1.0);",
+            "    vUv0 = (aPosition.xy + 1.0) * 0.5;",
+            "}"
+        ].join("\n"),
+        fshader: [
+            "precision " + graphicsDevice.precision + " float;",
+            "",
+            "uniform float uAmount;",
+            "uniform sampler2D uColorBuffer;",
+            "",
+            "varying vec2 vUv0;",
+            "",
+            "void main() {",
+            "    vec4 color = texture2D(uColorBuffer, vUv0);",
+            "    vec3 c = color.rgb;",
+            "",
+            "    color.r = dot(c, vec3(1.0 - 0.607 * uAmount, 0.769 * uAmount, 0.189 * uAmount));",
+            "    color.g = dot(c, vec3(0.349 * uAmount, 1.0 - 0.314 * uAmount, 0.168 * uAmount));",
+            "    color.b = dot(c, vec3(0.272 * uAmount, 0.534 * uAmount, 1.0 - 0.869 * uAmount));",
+            "",
+            "    gl_FragColor = vec4(min(vec3(1.0), color.rgb), color.a);",
+            "}"
+        ].join("\n")
     });
 
-    return {
-        SepiaEffect: SepiaEffect
-    };
-}());
+    // Uniforms
+    this.amount = 1;
+}
+
+SepiaEffect.prototype = Object.create(pc.PostEffect.prototype);
+SepiaEffect.prototype.constructor = SepiaEffect;
+
+Object.assign(SepiaEffect.prototype, {
+    render: function (inputTarget, outputTarget, rect) {
+        var device = this.device;
+        var scope = device.scope;
+
+        scope.resolve("uAmount").setValue(this.amount);
+        scope.resolve("uColorBuffer").setValue(inputTarget.colorBuffer);
+        pc.drawFullscreenQuad(device, outputTarget, this.vertexBuffer, this.shader, rect);
+    }
+});
 
 // ----------------- SCRIPT DEFINITION ------------------ //
 var Sepia = pc.createScript('sepia');
@@ -85,7 +78,7 @@ Sepia.attributes.add('amount', {
 
 // initialize code called once per entity
 Sepia.prototype.initialize = function () {
-    this.effect = new pc.SepiaEffect(this.app.graphicsDevice);
+    this.effect = new SepiaEffect(this.app.graphicsDevice);
     this.effect.amount = this.amount;
 
     this.on('attr:amount', function (value) {

--- a/examples/assets/scripts/posteffects/posteffect-verticaltiltshift.js
+++ b/examples/assets/scripts/posteffects/posteffect-verticaltiltshift.js
@@ -1,85 +1,78 @@
 // --------------- POST EFFECT DEFINITION --------------- //
-Object.assign(pc, function () {
+/**
+ * @class
+ * @name VerticalTiltShiftEffect
+ * @classdesc Simple fake tilt-shift effect, modulating two pass Gaussian blur by vertical position.
+ * @description Creates new instance of the post effect.
+ * @augments pc.PostEffect
+ * @param {pc.GraphicsDevice} graphicsDevice - The graphics device of the application.
+ * @property {number} focus Controls where the "focused" horizontal line lies.
+ */
+function VerticalTiltShiftEffect(graphicsDevice) {
+    pc.PostEffect.call(this, graphicsDevice);
 
-    /**
-     * @class
-     * @name pc.VerticalTiltShiftEffect
-     * @classdesc Simple fake tilt-shift effect, modulating two pass Gaussian blur by vertical position.
-     * @description Creates new instance of the post effect.
-     * @augments pc.PostEffect
-     * @param {pc.GraphicsDevice} graphicsDevice - The graphics device of the application.
-     * @property {number} focus Controls where the "focused" horizontal line lies.
-     */
-    var VerticalTiltShiftEffect = function (graphicsDevice) {
-        pc.PostEffect.call(this, graphicsDevice);
-
-        // Shader author: alteredq / http://alteredqualia.com/
-        this.shader = new pc.Shader(graphicsDevice, {
-            attributes: {
-                aPosition: pc.SEMANTIC_POSITION
-            },
-            vshader: [
-                "attribute vec2 aPosition;",
-                "",
-                "varying vec2 vUv0;",
-                "",
-                "void main(void)",
-                "{",
-                "    gl_Position = vec4(aPosition, 0.0, 1.0);",
-                "    vUv0 = (aPosition.xy + 1.0) * 0.5;",
-                "}"
-            ].join("\n"),
-            fshader: [
-                "precision " + graphicsDevice.precision + " float;",
-                "",
-                "uniform sampler2D uColorBuffer;",
-                "uniform float uV;",
-                "uniform float uR;",
-                "",
-                "varying vec2 vUv0;",
-                "",
-                "void main() {",
-                "    vec4 sum = vec4( 0.0 );",
-                "    float vv = uV * abs( uR - vUv0.y );",
-                "",
-                "    sum += texture2D( uColorBuffer, vec2( vUv0.x, vUv0.y - 4.0 * vv ) ) * 0.051;",
-                "    sum += texture2D( uColorBuffer, vec2( vUv0.x, vUv0.y - 3.0 * vv ) ) * 0.0918;",
-                "    sum += texture2D( uColorBuffer, vec2( vUv0.x, vUv0.y - 2.0 * vv ) ) * 0.12245;",
-                "    sum += texture2D( uColorBuffer, vec2( vUv0.x, vUv0.y - 1.0 * vv ) ) * 0.1531;",
-                "    sum += texture2D( uColorBuffer, vec2( vUv0.x, vUv0.y ) ) * 0.1633;",
-                "    sum += texture2D( uColorBuffer, vec2( vUv0.x, vUv0.y + 1.0 * vv ) ) * 0.1531;",
-                "    sum += texture2D( uColorBuffer, vec2( vUv0.x, vUv0.y + 2.0 * vv ) ) * 0.12245;",
-                "    sum += texture2D( uColorBuffer, vec2( vUv0.x, vUv0.y + 3.0 * vv ) ) * 0.0918;",
-                "    sum += texture2D( uColorBuffer, vec2( vUv0.x, vUv0.y + 4.0 * vv ) ) * 0.051;",
-                "",
-                "    gl_FragColor = sum;",
-                "}"
-            ].join("\n")
-        });
-
-        // uniforms
-        this.focus = 0.35;
-    };
-
-    VerticalTiltShiftEffect.prototype = Object.create(pc.PostEffect.prototype);
-    VerticalTiltShiftEffect.prototype.constructor = VerticalTiltShiftEffect;
-
-    Object.assign(VerticalTiltShiftEffect.prototype, {
-        render: function (inputTarget, outputTarget, rect) {
-            var device = this.device;
-            var scope = device.scope;
-
-            scope.resolve("uV").setValue(1 / inputTarget.height);
-            scope.resolve("uR").setValue(this.focus);
-            scope.resolve("uColorBuffer").setValue(inputTarget.colorBuffer);
-            pc.drawFullscreenQuad(device, outputTarget, this.vertexBuffer, this.shader, rect);
-        }
+    // Shader author: alteredq / http://alteredqualia.com/
+    this.shader = new pc.Shader(graphicsDevice, {
+        attributes: {
+            aPosition: pc.SEMANTIC_POSITION
+        },
+        vshader: [
+            "attribute vec2 aPosition;",
+            "",
+            "varying vec2 vUv0;",
+            "",
+            "void main(void)",
+            "{",
+            "    gl_Position = vec4(aPosition, 0.0, 1.0);",
+            "    vUv0 = (aPosition.xy + 1.0) * 0.5;",
+            "}"
+        ].join("\n"),
+        fshader: [
+            "precision " + graphicsDevice.precision + " float;",
+            "",
+            "uniform sampler2D uColorBuffer;",
+            "uniform float uV;",
+            "uniform float uR;",
+            "",
+            "varying vec2 vUv0;",
+            "",
+            "void main() {",
+            "    vec4 sum = vec4( 0.0 );",
+            "    float vv = uV * abs( uR - vUv0.y );",
+            "",
+            "    sum += texture2D( uColorBuffer, vec2( vUv0.x, vUv0.y - 4.0 * vv ) ) * 0.051;",
+            "    sum += texture2D( uColorBuffer, vec2( vUv0.x, vUv0.y - 3.0 * vv ) ) * 0.0918;",
+            "    sum += texture2D( uColorBuffer, vec2( vUv0.x, vUv0.y - 2.0 * vv ) ) * 0.12245;",
+            "    sum += texture2D( uColorBuffer, vec2( vUv0.x, vUv0.y - 1.0 * vv ) ) * 0.1531;",
+            "    sum += texture2D( uColorBuffer, vec2( vUv0.x, vUv0.y ) ) * 0.1633;",
+            "    sum += texture2D( uColorBuffer, vec2( vUv0.x, vUv0.y + 1.0 * vv ) ) * 0.1531;",
+            "    sum += texture2D( uColorBuffer, vec2( vUv0.x, vUv0.y + 2.0 * vv ) ) * 0.12245;",
+            "    sum += texture2D( uColorBuffer, vec2( vUv0.x, vUv0.y + 3.0 * vv ) ) * 0.0918;",
+            "    sum += texture2D( uColorBuffer, vec2( vUv0.x, vUv0.y + 4.0 * vv ) ) * 0.051;",
+            "",
+            "    gl_FragColor = sum;",
+            "}"
+        ].join("\n")
     });
 
-    return {
-        VerticalTiltShiftEffect: VerticalTiltShiftEffect
-    };
-}());
+    // uniforms
+    this.focus = 0.35;
+}
+
+VerticalTiltShiftEffect.prototype = Object.create(pc.PostEffect.prototype);
+VerticalTiltShiftEffect.prototype.constructor = VerticalTiltShiftEffect;
+
+Object.assign(VerticalTiltShiftEffect.prototype, {
+    render: function (inputTarget, outputTarget, rect) {
+        var device = this.device;
+        var scope = device.scope;
+
+        scope.resolve("uV").setValue(1 / inputTarget.height);
+        scope.resolve("uR").setValue(this.focus);
+        scope.resolve("uColorBuffer").setValue(inputTarget.colorBuffer);
+        pc.drawFullscreenQuad(device, outputTarget, this.vertexBuffer, this.shader, rect);
+    }
+});
 
 // ----------------- SCRIPT DEFINITION ------------------ //
 var VerticalTiltShift = pc.createScript('verticalTiltShift');
@@ -89,13 +82,12 @@ VerticalTiltShift.attributes.add('focus', {
     default: 0.35,
     min: 0,
     max: 1,
-    precision: 5,
     title: 'Focus'
 });
 
 // initialize code called once per entity
 VerticalTiltShift.prototype.initialize = function () {
-    this.effect = new pc.VerticalTiltShiftEffect(this.app.graphicsDevice);
+    this.effect = new VerticalTiltShiftEffect(this.app.graphicsDevice);
     this.effect.focus = this.focus;
 
     this.on('attr:focus', function (value) {

--- a/examples/assets/scripts/posteffects/posteffect-vignette.js
+++ b/examples/assets/scripts/posteffects/posteffect-vignette.js
@@ -1,81 +1,74 @@
 // --------------- POST EFFECT DEFINITION --------------- //
-Object.assign(pc, function () {
+/**
+ * @class
+ * @name VignetteEffect
+ * @classdesc Implements the VignetteEffect post processing effect.
+ * @description Creates new instance of the post effect.
+ * @augments pc.PostEffect
+ * @param {pc.GraphicsDevice} graphicsDevice - The graphics device of the application.
+ * @property {number} offset Controls the offset of the effect.
+ * @property {number} darkness Controls the darkness of the effect.
+ */
+function VignetteEffect(graphicsDevice) {
+    pc.PostEffect.call(this, graphicsDevice);
 
-    /**
-     * @class
-     * @name pc.VignetteEffect
-     * @classdesc Implements the VignetteEffect post processing effect.
-     * @description Creates new instance of the post effect.
-     * @augments pc.PostEffect
-     * @param {pc.GraphicsDevice} graphicsDevice - The graphics device of the application.
-     * @property {number} offset Controls the offset of the effect.
-     * @property {number} darkness Controls the darkness of the effect.
-     */
-    var VignetteEffect = function (graphicsDevice) {
-        pc.PostEffect.call(this, graphicsDevice);
-
-        // Shaders
-        var attributes = {
-            aPosition: pc.SEMANTIC_POSITION
-        };
-
-        var passThroughVert = [
-            "attribute vec2 aPosition;",
-            "",
-            "varying vec2 vUv0;",
-            "",
-            "void main(void)",
-            "{",
-            "    gl_Position = vec4(aPosition, 0.0, 1.0);",
-            "    vUv0 = (aPosition.xy + 1.0) * 0.5;",
-            "}"
-        ].join("\n");
-
-        var luminosityFrag = [
-            "precision " + graphicsDevice.precision + " float;",
-            "",
-            "uniform sampler2D uColorBuffer;",
-            "uniform float uDarkness;",
-            "uniform float uOffset;",
-            "",
-            "varying vec2 vUv0;",
-            "",
-            "void main() {",
-            "    vec4 texel = texture2D(uColorBuffer, vUv0);",
-            "    vec2 uv = (vUv0 - vec2(0.5)) * vec2(uOffset);",
-            "    gl_FragColor = vec4(mix(texel.rgb, vec3(1.0 - uDarkness), dot(uv, uv)), texel.a);",
-            "}"
-        ].join("\n");
-
-        this.vignetteShader = new pc.Shader(graphicsDevice, {
-            attributes: attributes,
-            vshader: passThroughVert,
-            fshader: luminosityFrag
-        });
-
-        this.offset = 1;
-        this.darkness = 1;
+    // Shaders
+    var attributes = {
+        aPosition: pc.SEMANTIC_POSITION
     };
 
-    VignetteEffect.prototype = Object.create(pc.PostEffect.prototype);
-    VignetteEffect.prototype.constructor = VignetteEffect;
+    var passThroughVert = [
+        "attribute vec2 aPosition;",
+        "",
+        "varying vec2 vUv0;",
+        "",
+        "void main(void)",
+        "{",
+        "    gl_Position = vec4(aPosition, 0.0, 1.0);",
+        "    vUv0 = (aPosition.xy + 1.0) * 0.5;",
+        "}"
+    ].join("\n");
 
-    Object.assign(VignetteEffect.prototype, {
-        render: function (inputTarget, outputTarget, rect) {
-            var device = this.device;
-            var scope = device.scope;
+    var luminosityFrag = [
+        "precision " + graphicsDevice.precision + " float;",
+        "",
+        "uniform sampler2D uColorBuffer;",
+        "uniform float uDarkness;",
+        "uniform float uOffset;",
+        "",
+        "varying vec2 vUv0;",
+        "",
+        "void main() {",
+        "    vec4 texel = texture2D(uColorBuffer, vUv0);",
+        "    vec2 uv = (vUv0 - vec2(0.5)) * vec2(uOffset);",
+        "    gl_FragColor = vec4(mix(texel.rgb, vec3(1.0 - uDarkness), dot(uv, uv)), texel.a);",
+        "}"
+    ].join("\n");
 
-            scope.resolve("uColorBuffer").setValue(inputTarget.colorBuffer);
-            scope.resolve("uOffset").setValue(this.offset);
-            scope.resolve("uDarkness").setValue(this.darkness);
-            pc.drawFullscreenQuad(device, outputTarget, this.vertexBuffer, this.vignetteShader, rect);
-        }
+    this.vignetteShader = new pc.Shader(graphicsDevice, {
+        attributes: attributes,
+        vshader: passThroughVert,
+        fshader: luminosityFrag
     });
 
-    return {
-        VignetteEffect: VignetteEffect
-    };
-}());
+    this.offset = 1;
+    this.darkness = 1;
+}
+
+VignetteEffect.prototype = Object.create(pc.PostEffect.prototype);
+VignetteEffect.prototype.constructor = VignetteEffect;
+
+Object.assign(VignetteEffect.prototype, {
+    render: function (inputTarget, outputTarget, rect) {
+        var device = this.device;
+        var scope = device.scope;
+
+        scope.resolve("uColorBuffer").setValue(inputTarget.colorBuffer);
+        scope.resolve("uOffset").setValue(this.offset);
+        scope.resolve("uDarkness").setValue(this.darkness);
+        pc.drawFullscreenQuad(device, outputTarget, this.vertexBuffer, this.vignetteShader, rect);
+    }
+});
 
 // ----------------- SCRIPT DEFINITION ------------------ //
 var Vignette = pc.createScript('vignette');
@@ -84,20 +77,18 @@ Vignette.attributes.add('offset', {
     type: 'number',
     default: 1,
     min: 0,
-    precision: 5,
     title: 'Offset'
 });
 
 Vignette.attributes.add('darkness', {
     type: 'number',
     default: 1,
-    precision: 5,
     title: 'Darkness'
 });
 
 // initialize code called once per entity
 Vignette.prototype.initialize = function () {
-    this.effect = new pc.VignetteEffect(this.app.graphicsDevice);
+    this.effect = new VignetteEffect(this.app.graphicsDevice);
     this.effect.offset = this.offset;
     this.effect.darkness = this.darkness;
 

--- a/examples/graphics/post-effects.html
+++ b/examples/graphics/post-effects.html
@@ -20,22 +20,12 @@
     <canvas id="application-canvas"></canvas>
 
     <script>
-        // create the application
         var canvas = document.getElementById("application-canvas");
         var app = new pc.Application(canvas, {
             keyboard: new pc.Keyboard(window)
         });
-    </script>
-
-    <!-- Include some post effects -->
-    <script src="../assets/scripts/posteffects/posteffect-bloom.js"></script>
-    <script src="../assets/scripts/posteffects/posteffect-sepia.js"></script>
-    <script src="../assets/scripts/posteffects/posteffect-vignette.js"></script>
-    <script src="../assets/scripts/posteffects/posteffect-bokeh.js"></script>
-    <!-- The script -->
-    <script>
-        // Start the update loop
         app.start();
+
         // Set the canvas to fill the window and automatically change resolution to be the same as the canvas size
         app.setCanvasFillMode(pc.FILLMODE_FILL_WINDOW);
         app.setCanvasResolution(pc.RESOLUTION_AUTO);
@@ -46,7 +36,43 @@
 
         var miniStats = new pcx.MiniStats(app);
 
-        app.scene.ambientLight = new pc.Color(0.4, 0.4, 0.4);
+        // A list of assets that need to be loaded
+        var assetManifest = [
+            {
+                type: "container",
+                url: "../assets/models/statue.glb"
+            },
+            {
+                type: "script",
+                url: "../assets/scripts/posteffects/posteffect-bloom.js"
+            },
+            {
+                type: "script",
+                url: "../assets/scripts/posteffects/posteffect-bokeh.js"
+            },
+            {
+                type: "script",
+                url: "../assets/scripts/posteffects/posteffect-sepia.js"
+            },
+            {
+                type: "script",
+                url: "../assets/scripts/posteffects/posteffect-vignette.js"
+            }
+        ];
+
+        // Load all assets and then run the example
+        var assetsToLoad = assetManifest.length;
+        assetManifest.forEach(function (entry) {
+            app.assets.loadFromUrl(entry.url, entry.type, function (err, asset) {
+                if (!err && asset) {
+                    assetsToLoad--;
+                    entry.asset = asset;
+                    if (assetsToLoad === 0) {
+                        run();
+                    }
+                }
+            });
+        });
 
         function createMaterial(colors) {
             var material = new pc.StandardMaterial();
@@ -57,152 +83,155 @@
             return material;
         }
 
-        // Generate some materials to assign to scene objects
-        var gray = createMaterial({
-            ambient: new pc.Color(0.1, 0.1, 0.1),
-            diffuse: new pc.Color(0.5, 0.5, 0.5)
-        });
-        var white = createMaterial({
-            emissive: new pc.Color(1, 1, 1)
-        });
-        var blue = createMaterial({
-            diffuse: new pc.Color(0, 0, 0),
-            emissive: new pc.Color(0, 0, 1)
-        });
+        function run() {
+            app.scene.ambientLight = new pc.Color(0.4, 0.4, 0.4);
 
-        var entity, light, camera;
+            // Generate some materials to assign to scene objects
+            var gray = createMaterial({
+                ambient: new pc.Color(0.1, 0.1, 0.1),
+                diffuse: new pc.Color(0.5, 0.5, 0.5)
+            });
+            var white = createMaterial({
+                emissive: new pc.Color(1, 1, 1)
+            });
+            var blue = createMaterial({
+                diffuse: new pc.Color(0, 0, 0),
+                emissive: new pc.Color(0, 0, 1)
+            });
 
-        // Load a model file and create a Entity with a model component
-        var url = "../assets/models/statue.glb";
-        app.assets.loadFromUrl(url, "container", function (err, asset) {
-            entity = new pc.Entity();
+            var entity = new pc.Entity();
             entity.addComponent("model", {
                 type: "asset",
-                asset: asset.resource.model,
+                asset: assetManifest[0].asset.resource.model,
                 castShadows: true
             });
             app.root.addChild(entity);
-        });
 
-        // Create an Entity with a camera component
-        var camera = new pc.Entity();
-        camera.addComponent("camera", {
-            clearColor: new pc.Color(0.4, 0.45, 0.5)
-        });
-        camera.addComponent("script");
-        camera.script.create("bloom", {
-            attributes: {
-                bloomIntensity: 1,
-                bloomThreshold: 0.1,
-                blurAmount: 4
-            }
-        });
-        camera.script.create("sepia", {
-            attributes: {
-                amount: 0.7
-            }
-        });
-        camera.script.create("vignette", {
-            attributes: {
-                darkness: 2,
-                offset: 1
-            }
-        });
-        camera.script.create("bokeh");
-        camera.translate(0, 7, 24);
-        camera.rotate(0, 0, 0);
+            // Create an Entity with a camera component
+            var camera = new pc.Entity();
+            camera.addComponent("camera", {
+                clearColor: new pc.Color(0.4, 0.45, 0.5)
+            });
+            camera.addComponent("script");
+            camera.script.create("bloom", {
+                attributes: {
+                    bloomIntensity: 1,
+                    bloomThreshold: 0.1,
+                    blurAmount: 4
+                }
+            });
+            camera.script.create("sepia", {
+                attributes: {
+                    amount: 0.7
+                }
+            });
+            camera.script.create("vignette", {
+                attributes: {
+                    darkness: 2,
+                    offset: 1
+                }
+            });
+            camera.script.create("bokeh", {
+                attributes: {
+                    aperture: 1,
+                    maxBlur: 0.02
+                }
+            });
+            camera.translate(0, 7, 24);
+            camera.rotate(0, 0, 0);
 
-        // Create an Entity for the ground
-        var ground = new pc.Entity();
-        ground.addComponent("model", {
-            type: "box"
-        });
-        ground.setLocalScale(50, 1, 50);
-        ground.setLocalPosition(0, -0.5, 0);
-        ground.model.material = gray;
+            // Create an Entity for the ground
+            var ground = new pc.Entity();
+            ground.addComponent("model", {
+                type: "box"
+            });
+            ground.setLocalScale(50, 1, 50);
+            ground.setLocalPosition(0, -0.5, 0);
+            ground.model.material = gray;
 
-        // Create an spot light
-        var light = new pc.Entity();
-        light.addComponent("light", {
-            type: "spot",
-            color: new pc.Color(1, 1, 1),
-            outerConeAngle: 60,
-            innerConeAngle: 40,
-            range: 100,
-            intensity: 1,
-            castShadows: true,
-            shadowBias: 0.005,
-            normalOffsetBias: 0.01,
-            shadowResolution: 2048
-        });
+            // Create an spot light
+            var light = new pc.Entity();
+            light.addComponent("light", {
+                type: "spot",
+                color: new pc.Color(1, 1, 1),
+                outerConeAngle: 60,
+                innerConeAngle: 40,
+                range: 100,
+                intensity: 1,
+                castShadows: true,
+                shadowBias: 0.005,
+                normalOffsetBias: 0.01,
+                shadowResolution: 2048
+            });
 
-        var cone = new pc.Entity();
-        cone.addComponent("model", {
-            type: "cone"
-        });
-        cone.model.material = white;
-        light.addChild(cone);
+            var cone = new pc.Entity();
+            cone.addComponent("model", {
+                type: "cone"
+            });
+            cone.model.material = white;
+            light.addChild(cone);
 
-        // Create a point light
-        var pointlight = new pc.Entity();
-        pointlight.addComponent("light", {
-            type: "point",
-            color: new pc.Color(0, 0, 1),
-            range: 100,
-            intensity: 1
-        });
-        pointlight.addComponent("model", {
-            type: "sphere"
-        });
-        pointlight.model.material = blue;
+            // Create a point light
+            var pointlight = new pc.Entity();
+            pointlight.addComponent("light", {
+                type: "point",
+                color: new pc.Color(0, 0, 1),
+                range: 100,
+                intensity: 1
+            });
+            pointlight.addComponent("model", {
+                type: "sphere"
+            });
+            pointlight.model.material = blue;
 
-        // Add Entities into the scene hierarchy
-        app.root.addChild(camera);
-        app.root.addChild(light);
-        app.root.addChild(pointlight);
-        app.root.addChild(ground);
+            // Add Entities into the scene hierarchy
+            app.root.addChild(camera);
+            app.root.addChild(light);
+            app.root.addChild(pointlight);
+            app.root.addChild(ground);
 
-        // Simple update loop to rotate the light
-        var radius = 20;
-        var height = 5;
-        var angle = 0;
+            // Allow user to toggle individual post effects
+            app.keyboard.on("keydown", function (e) {
+                switch (e.key) {
+                    case pc.KEY_1:
+                        camera.script.bloom.enabled = !camera.script.bloom.enabled;
+                        break;
+                    case pc.KEY_2:
+                        camera.script.sepia.enabled = !camera.script.sepia.enabled;
+                        break;
+                    case pc.KEY_3:
+                        camera.script.vignette.enabled = !camera.script.vignette.enabled;
+                        break;
+                    case pc.KEY_4:
+                        camera.script.bokeh.enabled = !camera.script.bokeh.enabled;
+                        break;
+                }
+            }, this);
 
-        var pointRadius = 5;
-        var pointHeight = 10;
+            // Simple update loop to rotate the light
+            var radius = 20;
+            var height = 5;
+            var angle = 0;
 
-        function onKeyDown(e) {
-            switch (e.key) {
-                case pc.KEY_1:
-                    camera.script.bloom.enabled = !camera.script.bloom.enabled;
-                    break;
-                case pc.KEY_2:
-                    camera.script.sepia.enabled = !camera.script.sepia.enabled;
-                    break;
-                case pc.KEY_3:
-                    camera.script.vignette.enabled = !camera.script.vignette.enabled;
-                    break;
-                case pc.KEY_4:
-                    camera.script.bokeh.enabled = !camera.script.bokeh.enabled;
-                    break;
-            }
-        };
-        app.keyboard.on("keydown", onKeyDown, this);
+            var pointRadius = 5;
+            var pointHeight = 10;
 
-        app.on("update", function (dt) {
-            angle += 20 * dt;
-            if (angle > 360) {
-                angle -= 360;
-            }
-            if (entity) {
-                light.lookAt(entity.getPosition());
-                light.rotateLocal(90, 0, 0);
-                light.setLocalPosition(radius * Math.sin(angle * pc.math.DEG_TO_RAD), height, radius * Math.cos(angle * pc.math.DEG_TO_RAD));
-                
-                pointlight.setLocalPosition(pointRadius * Math.sin(-2 * angle * pc.math.DEG_TO_RAD), pointHeight, pointRadius * Math.cos(-2 * angle * pc.math.DEG_TO_RAD));
+            app.on("update", function (dt) {
+                angle += 20 * dt;
+                if (angle > 360) {
+                    angle -= 360;
+                }
+                if (entity) {
+                    light.lookAt(entity.getPosition());
+                    light.rotateLocal(90, 0, 0);
+                    light.setLocalPosition(radius * Math.sin(angle * pc.math.DEG_TO_RAD), height, radius * Math.cos(angle * pc.math.DEG_TO_RAD));
+                    
+                    pointlight.setLocalPosition(pointRadius * Math.sin(-2 * angle * pc.math.DEG_TO_RAD), pointHeight, pointRadius * Math.cos(-2 * angle * pc.math.DEG_TO_RAD));
 
-                camera.script.bokeh.focus = light.getLocalPosition().z - camera.getLocalPosition().z;
-            }
-        });
+                    camera.script.bokeh.focus = light.getLocalPosition().z - camera.getLocalPosition().z;
+                }
+            });
+        }
     </script>
 </body>
 </html>

--- a/examples/graphics/post-effects.html
+++ b/examples/graphics/post-effects.html
@@ -20,18 +20,11 @@
     <canvas id="application-canvas"></canvas>
 
     <script>
-        function createMaterial(colors) {
-            var material = new pc.StandardMaterial();
-            for (var param in colors) {
-                material[param] = colors[param];
-            }
-            material.update();
-            return material;
-        }
-
         // create the application
         var canvas = document.getElementById("application-canvas");
-        var app = new pc.Application(canvas);
+        var app = new pc.Application(canvas, {
+            keyboard: new pc.Keyboard(window)
+        });
     </script>
 
     <!-- Include some post effects -->
@@ -55,7 +48,16 @@
 
         app.scene.ambientLight = new pc.Color(0.4, 0.4, 0.4);
 
-        // Generate some materials to assigm to scene objects
+        function createMaterial(colors) {
+            var material = new pc.StandardMaterial();
+            for (var param in colors) {
+                material[param] = colors[param];
+            }
+            material.update();
+            return material;
+        }
+
+        // Generate some materials to assign to scene objects
         var gray = createMaterial({
             ambient: new pc.Color(0.1, 0.1, 0.1),
             diffuse: new pc.Color(0.5, 0.5, 0.5)
@@ -87,6 +89,26 @@
         camera.addComponent("camera", {
             clearColor: new pc.Color(0.4, 0.45, 0.5)
         });
+        camera.addComponent("script");
+        camera.script.create("bloom", {
+            attributes: {
+                bloomIntensity: 1,
+                bloomThreshold: 0.1,
+                blurAmount: 4
+            }
+        });
+        camera.script.create("sepia", {
+            attributes: {
+                amount: 0.7
+            }
+        });
+        camera.script.create("vignette", {
+            attributes: {
+                darkness: 2,
+                offset: 1
+            }
+        });
+        camera.script.create("bokeh");
         camera.translate(0, 7, 24);
         camera.rotate(0, 0, 0);
 
@@ -134,22 +156,6 @@
         });
         pointlight.model.material = blue;
 
-        // create some post effects
-        var bloom = new pc.BloomEffect(app.graphicsDevice);
-        bloom.bloomThreshold = 0.1;
-        camera.camera.postEffects.addEffect(bloom);
-
-        var sepia = new pc.SepiaEffect(app.graphicsDevice);
-        sepia.amount = 0.7;
-        camera.camera.postEffects.addEffect(sepia);
-
-        var vignette = new pc.VignetteEffect(app.graphicsDevice);
-        vignette.darkness = 2;
-        camera.camera.postEffects.addEffect(vignette);
-
-        var bokeh = new pc.BokehEffect(app.graphicsDevice);
-        bokeh.focus = 0.0 - camera.getLocalPosition().z;
-        camera.camera.postEffects.addEffect(bokeh);
         // Add Entities into the scene hierarchy
         app.root.addChild(camera);
         app.root.addChild(light);
@@ -164,24 +170,23 @@
         var pointRadius = 5;
         var pointHeight = 10;
 
-        var hasEffects = true;
-        var onKeyDown = function (e) {
-            if (e.key === pc.KEY_SPACE) {
-                if (hasEffects) {
-                    camera.camera.postEffects.removeEffect(bokeh);
-                    camera.camera.postEffects.removeEffect(sepia);
-                    camera.camera.postEffects.removeEffect(vignette);
-                } else {
-                    camera.camera.postEffects.addEffect(sepia);
-                    camera.camera.postEffects.addEffect(vignette);
-                    camera.camera.postEffects.addEffect(bokeh);
-                }
-                hasEffects = !hasEffects;
+        function onKeyDown(e) {
+            switch (e.key) {
+                case pc.KEY_1:
+                    camera.script.bloom.enabled = !camera.script.bloom.enabled;
+                    break;
+                case pc.KEY_2:
+                    camera.script.sepia.enabled = !camera.script.sepia.enabled;
+                    break;
+                case pc.KEY_3:
+                    camera.script.vignette.enabled = !camera.script.vignette.enabled;
+                    break;
+                case pc.KEY_4:
+                    camera.script.bokeh.enabled = !camera.script.bokeh.enabled;
+                    break;
             }
-            e.event.preventDefault(); // Use original browser event to prevent browser action.
         };
-        var keyboard = new pc.Keyboard(document.body);
-        keyboard.on("keydown", onKeyDown, this);
+        app.keyboard.on("keydown", onKeyDown, this);
 
         app.on("update", function (dt) {
             angle += 20 * dt;
@@ -195,9 +200,8 @@
                 
                 pointlight.setLocalPosition(pointRadius * Math.sin(-2 * angle * pc.math.DEG_TO_RAD), pointHeight, pointRadius * Math.cos(-2 * angle * pc.math.DEG_TO_RAD));
 
-                bokeh.focus = light.getLocalPosition().z-camera.getLocalPosition().z;
+                camera.script.bokeh.focus = light.getLocalPosition().z - camera.getLocalPosition().z;
             }
-
         });
     </script>
 </body>


### PR DESCRIPTION
* There is no reason for the post effects to be added to the `pc` namespace.
* Removed `precision` property from attributes (default script attribute has been increased since the effects were written).
* Outline post effect wasn't parsing correctly in the Editor (because of malformed attribute specification)
* Gracefully handle no blend map being set on the `BlendEffect`

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
