### PR TITLE
Expose rolling friction as RigidBodyComponent#rollingFriction

### DIFF
--- a/src/framework/components/rigid-body/component.js
+++ b/src/framework/components/rigid-body/component.js
@@ -40,7 +40,7 @@ var ammoVec1, ammoVec2, ammoQuat, ammoOrigin;
  * valid for rigid bodies of type pc.BODYTYPE_DYNAMIC. Defaults to 1 in all axes.
  * @property {number} friction The friction value used when contacts occur between two bodies. A higher
  * value indicates more friction. Should be set in the range 0 to 1. Defaults to 0.5.
- * @property {number} rollingFriction Sets a torsional friction orthogonal to the contact point. Defaults 
+ * @property {number} rollingFriction Sets a torsional friction orthogonal to the contact point. Defaults
  * to 0.
  * @property {number} restitution Influences the amount of energy lost when two rigid bodies collide. The
  * calculation multiplies the restitution values for both colliding bodies. A multiplied value of 0 means

--- a/src/framework/components/rigid-body/component.js
+++ b/src/framework/components/rigid-body/component.js
@@ -40,6 +40,8 @@ var ammoVec1, ammoVec2, ammoQuat, ammoOrigin;
  * valid for rigid bodies of type pc.BODYTYPE_DYNAMIC. Defaults to 1 in all axes.
  * @property {number} friction The friction value used when contacts occur between two bodies. A higher
  * value indicates more friction. Should be set in the range 0 to 1. Defaults to 0.5.
+ * @property {number} rollingFriction Sets a torsional friction orthogonal to the contact point. Defaults 
+ * to 0.
  * @property {number} restitution Influences the amount of energy lost when two rigid bodies collide. The
  * calculation multiplies the restitution values for both colliding bodies. A multiplied value of 0 means
  * that all energy is lost in the collision while a value of 1 means that no energy is lost. Should be
@@ -76,6 +78,7 @@ class RigidBodyComponent extends Component {
         this.on('set_linearFactor', this.onSetLinearFactor, this);
         this.on('set_angularFactor', this.onSetAngularFactor, this);
         this.on('set_friction', this.onSetFriction, this);
+        this.on('set_rollingFriction', this.onSetRollingFriction, this);
         this.on('set_restitution', this.onSetRestitution, this);
         this.on('set_type', this.onSetType, this);
         this.on('set_group', this.onSetGroupOrMask, this);
@@ -198,6 +201,7 @@ class RigidBodyComponent extends Component {
 
             body.setRestitution(this.restitution);
             body.setFriction(this.friction);
+            body.setRollingFriction(this.rollingFriction);
             body.setDamping(this.linearDamping, this.angularDamping);
 
             if (this.type === BODYTYPE_DYNAMIC) {
@@ -800,6 +804,13 @@ class RigidBodyComponent extends Component {
         var body = this.data.body;
         if (body) {
             body.setFriction(newValue);
+        }
+    }
+
+    onSetRollingFriction(name, oldValue, newValue) {
+        var body = this.data.body;
+        if (body) {
+            body.setRollingFriction(newValue);
         }
     }
 

--- a/src/framework/components/rigid-body/data.js
+++ b/src/framework/components/rigid-body/data.js
@@ -20,6 +20,7 @@ class RigidBodyComponentData {
         this.angularFactor = new Vec3(1, 1, 1);
 
         this.friction = 0.5;
+        this.rollingFriction = 0;
         this.restitution = 0;
 
         this.type = BODYTYPE_STATIC;

--- a/src/framework/components/rigid-body/system.js
+++ b/src/framework/components/rigid-body/system.js
@@ -141,6 +141,7 @@ const _schema = [
     'linearFactor',
     'angularFactor',
     'friction',
+    'rollingFriction',
     'restitution',
     'group',
     'mask',
@@ -224,7 +225,7 @@ class RigidBodyComponentSystem extends ComponentSystem {
     }
 
     initializeComponentData(component, _data, properties) {
-        properties = ['enabled', 'mass', 'linearDamping', 'angularDamping', 'linearFactor', 'angularFactor', 'friction', 'restitution', 'type', 'group', 'mask'];
+        properties = ['enabled', 'mass', 'linearDamping', 'angularDamping', 'linearFactor', 'angularFactor', 'friction', 'rollingFriction', 'restitution', 'type', 'group', 'mask'];
 
         // duplicate the input data because we are modifying it
         var data = {};
@@ -261,6 +262,7 @@ class RigidBodyComponentSystem extends ComponentSystem {
             linearFactor: [entity.rigidbody.linearFactor.x, entity.rigidbody.linearFactor.y, entity.rigidbody.linearFactor.z],
             angularFactor: [entity.rigidbody.angularFactor.x, entity.rigidbody.angularFactor.y, entity.rigidbody.angularFactor.z],
             friction: entity.rigidbody.friction,
+            rollingFriction: entity.rigidbody.rollingFriction,
             restitution: entity.rigidbody.restitution,
             type: entity.rigidbody.type,
             group: entity.rigidbody.group,


### PR DESCRIPTION
Ammo allows to set a rolling friction on rigid bodies. The Bullet Physics version that Ammo uses defaults it to 0. A rolling friction is a torsional friction orthogonal to the contact normal. In general cases it should have a zero or a near-zero value.

This commit exposes a `rollingFriction` property of an Ammo rigidbody to the Editor. The Editor needs to add a new field to rigidbody component to support it. Prefer a number range limit [0-1], defaulting at 0, precision 4.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
