### PR TITLE
Enable NPM dependency auto-update via Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  # Enable version updates for npm
+  - package-ecosystem: "npm"
+    # Look for `package.json` and `lock` files in the `root` directory
+    directory: "/"
+    # Check the npm registry for updates every day (weekdays)
+    schedule:
+      interval: "daily"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,6 @@ updates:
 
   - package-ecosystem: "github-actions"
     directory: "/"
+    # Look for `package.json` and `lock` files in the `root` directory
     schedule:
-      # Check for updates to GitHub Actions every weekday
       interval: "daily"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,14 @@
 version: 2
 updates:
-  # Enable version updates for npm
   - package-ecosystem: "npm"
     # Look for `package.json` and `lock` files in the `root` directory
     directory: "/"
     # Check the npm registry for updates every day (weekdays)
     schedule:
+      interval: "daily"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every weekday
       interval: "daily"


### PR DESCRIPTION
We currently manually update NPM dependencies listed in `package.json`. This PR switches to daily check + auto-update of NPM dependencies courtesy of Dependabot. See [here](https://docs.github.com/en/github/administering-a-repository/keeping-your-dependencies-updated-automatically) for more information.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
