### PR TITLE
Added note about drawOrder only working if layer is set to manual sorting

### DIFF
--- a/src/framework/components/sprite/component.js
+++ b/src/framework/components/sprite/component.js
@@ -53,7 +53,7 @@ const PARAM_ATLAS_RECT = 'atlasRect';
  * @property {number} batchGroupId Assign sprite to a specific batch group (see {@link pc.BatchGroup}). Default value is -1 (no group).
  * @property {string} autoPlayClip The name of the clip to play automatically when the component is enabled and the clip exists.
  * @property {number[]} layers An array of layer IDs ({@link pc.Layer#id}) to which this sprite should belong.
- * @property {number} drawOrder The draw order of the component. A higher value means that the component will be rendered on top of other components in the same layer. For this to work, the layer must have {@link pc.SORTMODE_MANUAL} sort order.
+ * @property {number} drawOrder The draw order of the component. A higher value means that the component will be rendered on top of other components in the same layer. This is not used unless the layer's sort order is set to {@link pc.SORTMODE_MANUAL}.
  */
 class SpriteComponent extends Component {
     constructor(system, entity) {

--- a/src/framework/components/sprite/component.js
+++ b/src/framework/components/sprite/component.js
@@ -53,7 +53,7 @@ const PARAM_ATLAS_RECT = 'atlasRect';
  * @property {number} batchGroupId Assign sprite to a specific batch group (see {@link pc.BatchGroup}). Default value is -1 (no group).
  * @property {string} autoPlayClip The name of the clip to play automatically when the component is enabled and the clip exists.
  * @property {number[]} layers An array of layer IDs ({@link pc.Layer#id}) to which this sprite should belong.
- * @property {number} drawOrder The draw order of the component. A higher value means that the component will be rendered on top of other components in the same layer.
+ * @property {number} drawOrder The draw order of the component. A higher value means that the component will be rendered on top of other components in the same layer. For this to work, the layer must have {@link pc.SORTMODE_MANUAL} sort order.
  */
 class SpriteComponent extends Component {
     constructor(system, entity) {


### PR DESCRIPTION
Added note about the layer's sort order needing to be manual.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
