### PR TITLE
Improvements to RenderComponent API

### DIFF
--- a/examples/graphics/mesh-decals.html
+++ b/examples/graphics/mesh-decals.html
@@ -170,7 +170,7 @@
 
         // Create the mesh instance
         var node = new pc.GraphNode();
-        var meshInstance = new pc.MeshInstance(node, this.mesh, this.material);
+        var meshInstance = new pc.MeshInstance(this.mesh, this.material, node);
 
         // Create a model and add the mesh instance to it
         var model = new pc.Model();

--- a/examples/graphics/mesh-generation.html
+++ b/examples/graphics/mesh-generation.html
@@ -56,7 +56,7 @@
             material.update();
 
             // add sphere at the position of light
-            light.addComponent("model", {
+            light.addComponent("render", {
                 type: "sphere",
                 material: material
             });
@@ -140,25 +140,20 @@
         this.mesh.clear(true, false);
         updateMesh(this.mesh, true);
 
-        // Create the mesh instance
-        var node = new pc.GraphNode();
-        var material = new pc.StandardMaterial();
-        var meshInstance = new pc.MeshInstance(node, this.mesh, material);
-
-        // Create a model and add the mesh instance to it
-        var model = new pc.Model();
-        model.graph = node;
-        model.meshInstances = [meshInstance];
-
         // Create Entity and add it to the scene
         this.entity = new pc.Entity();
-        app.root.addChild(this.entity);
 
-        // Add a model compoonent
-        app.systems.model.addComponent(this.entity, {
-            type: 'asset'
+        // Create the mesh instance
+        var material = new pc.StandardMaterial();
+        var meshInstance = new pc.MeshInstance(this.mesh, material);
+
+
+
+        // Create the entity with render component using meshInstances
+        this.entity.addComponent("render", {
+            meshInstances: [ meshInstance ]
         });
-        this.entity.model.model = model;
+        app.root.addChild(this.entity);
 
         // load a texture, create material and apply it to our MeshInstance
         app.assets.loadFromUrl("../assets/textures/playcanvas-grey.png", "texture", function (err, asset) {
@@ -166,7 +161,7 @@
             material.diffuseMap = asset.resource;
             material.update();
 
-            self.entity.model.model.meshInstances[0].material = material;
+            self.entity.render.meshInstances[0].material = material;
 
             // start application update loop when texture is loaded
             app.start();

--- a/examples/graphics/mesh-morph-many.html
+++ b/examples/graphics/mesh-morph-many.html
@@ -132,7 +132,7 @@
         // Create the mesh instance
         var node = new pc.GraphNode();
         var material = new pc.StandardMaterial();
-        this.meshInstance = new pc.MeshInstance(node, mesh, material);
+        this.meshInstance = new pc.MeshInstance(mesh, material, node);
 
         // Create a model and add the mesh instance to it
         var model = new pc.Model();

--- a/examples/graphics/mesh-morph.html
+++ b/examples/graphics/mesh-morph.html
@@ -119,7 +119,7 @@
             // Create the mesh instance
             var node = new pc.GraphNode();
             var material = new pc.StandardMaterial();
-            var meshInstance = new pc.MeshInstance(node, mesh, material);
+            var meshInstance = new pc.MeshInstance(mesh, material, node);
 
             // Create a model and add the mesh instance to it
             var model = new pc.Model();

--- a/examples/graphics/point-cloud-simulation.html
+++ b/examples/graphics/point-cloud-simulation.html
@@ -141,7 +141,7 @@
 
         // Create the mesh instance
         var node = new pc.GraphNode();
-        var meshInstance = new pc.MeshInstance(node, this.mesh, material);
+        var meshInstance = new pc.MeshInstance(this.mesh, material, node);
 
         // Create a model and add the mesh instance to it
         var model = new pc.Model();

--- a/examples/graphics/render-to-cubemap.html
+++ b/examples/graphics/render-to-cubemap.html
@@ -76,7 +76,7 @@
 
             // Create the mesh instance
             var node = new pc.GraphNode();
-            this.meshInstance = new pc.MeshInstance(node, mesh, material);
+            this.meshInstance = new pc.MeshInstance(mesh, material, node);
 
             // Create a model and add the mesh instance to it
             var model = new pc.Model();

--- a/examples/graphics/transform-feedback.html
+++ b/examples/graphics/transform-feedback.html
@@ -213,7 +213,7 @@
 
             // Create the mesh instance
             var node = new pc.GraphNode();
-            var meshInstance = new pc.MeshInstance(node, this.mesh, material);
+            var meshInstance = new pc.MeshInstance(this.mesh, material, node);
 
             // Create a model and add the mesh instance to it
             var model = new pc.Model();

--- a/scripts/parsers/obj-model.js
+++ b/scripts/parsers/obj-model.js
@@ -108,7 +108,7 @@ Object.assign(ObjModelParser.prototype, {
                 normals: currentGroup.normals,
                 uvs: currentGroup.uvs
             });
-            var mi = new pc.MeshInstance(new pc.GraphNode(), mesh, this._defaultMaterial);
+            var mi = new pc.MeshInstance(mesh, this._defaultMaterial, new pc.GraphNode());
             model.meshInstances.push(mi);
             root.addChild(mi.node);
         }

--- a/scripts/physics/render-physics.js
+++ b/scripts/physics/render-physics.js
@@ -61,7 +61,7 @@ RenderPhysics.prototype.initialize = function () {
 
 RenderPhysics.prototype.createModel = function (mesh, material) {
     var node = new pc.GraphNode();
-    var meshInstance = new pc.MeshInstance(node, mesh, material);
+    var meshInstance = new pc.MeshInstance(mesh, material, node);
     var model = new pc.Model();
     model.graph = node;
     model.meshInstances = [meshInstance];

--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -2122,7 +2122,7 @@ class Application extends EventHandler {
         tempGraphNode.worldTransform = matrix;
         tempGraphNode._dirtyWorld = tempGraphNode._dirtyNormal = false;
 
-        var instance = new MeshInstance(tempGraphNode, mesh, material);
+        var instance = new MeshInstance(mesh, material, tempGraphNode);
         instance.cull = false;
 
         if (options.mask) instance.mask = options.mask;
@@ -2169,7 +2169,7 @@ class Application extends EventHandler {
         tempGraphNode.worldTransform = matrix;
         tempGraphNode._dirtyWorld = tempGraphNode._dirtyNormal = false;
 
-        var quad = new MeshInstance(tempGraphNode, this._immediateData.quadMesh, material);
+        var quad = new MeshInstance(this._immediateData.quadMesh, material, tempGraphNode);
         quad.cull = false;
         this.meshInstanceArray[0] = quad;
 

--- a/src/framework/components/element/image-element.js
+++ b/src/framework/components/element/image-element.js
@@ -41,7 +41,7 @@ class ImageRenderable {
         this.model.graph = this.node;
 
         this.mesh = mesh;
-        this.meshInstance = new MeshInstance(this.node, this.mesh, material);
+        this.meshInstance = new MeshInstance(this.mesh, material, this.node);
         this.meshInstance.name = 'ImageElement: ' + entity.name;
         this.meshInstance.castShadow = false;
         this.meshInstance.receiveShadow = false;
@@ -86,7 +86,7 @@ class ImageRenderable {
         if (!this.meshInstance) return;
 
         if (mask) {
-            this.unmaskMeshInstance = new MeshInstance(this.node, this.mesh, this.meshInstance.material);
+            this.unmaskMeshInstance = new MeshInstance(this.mesh, this.meshInstance.material, this.node);
             this.unmaskMeshInstance.name = 'Unmask: ' + this._entity.name;
             this.unmaskMeshInstance.castShadow = false;
             this.unmaskMeshInstance.receiveShadow = false;

--- a/src/framework/components/element/text-element.js
+++ b/src/framework/components/element/text-element.js
@@ -456,7 +456,7 @@ class TextElement {
                                           indices: meshInfo.indices
                                       });
 
-                var mi = new MeshInstance(this._node, mesh, this._material);
+                var mi = new MeshInstance(mesh, this._material, this._node);
                 mi.name = "Text Element: " + this._entity.name;
                 mi.castShadow = false;
                 mi.receiveShadow = false;

--- a/src/framework/components/model/component.js
+++ b/src/framework/components/model/component.js
@@ -531,7 +531,7 @@ class ModelComponent extends Component {
             var model = new Model();
             model.graph = node;
 
-            model.meshInstances = [new MeshInstance(node, mesh, this._material)];
+            model.meshInstances = [new MeshInstance(mesh, this._material, node)];
 
             this.model = model;
             this._asset = null;

--- a/src/framework/components/render/component.js
+++ b/src/framework/components/render/component.js
@@ -493,8 +493,14 @@ class RenderComponent extends Component {
 
         if (this._meshInstances) {
 
-            var mi = this._meshInstances;
+            let mi = this._meshInstances;
             for (var i = 0; i < mi.length; i++) {
+
+                // if mesh instance was created without a node, assign it here
+                if (!mi[i].node) {
+                    mi[i].node = this.entity;
+                }
+
                 mi[i].castShadow = this._castShadows;
                 mi[i].receiveShadow = this._receiveShadows;
                 mi[i].isStatic = this._isStatic;

--- a/src/framework/components/render/component.js
+++ b/src/framework/components/render/component.js
@@ -367,7 +367,7 @@ class RenderComponent extends Component {
                 // mesh instance
                 var mesh = meshes[i];
                 var material = this._materialReferences[i] && this._materialReferences[i].asset && this._materialReferences[i].asset.resource;
-                var meshInst = new MeshInstance(this.entity, mesh, material || this.system.defaultMaterial);
+                var meshInst = new MeshInstance(mesh, material || this.system.defaultMaterial, this.entity);
                 meshInstances.push(meshInst);
 
                 // morph instance
@@ -476,7 +476,7 @@ class RenderComponent extends Component {
 
                 var primData = getShapePrimitive(this.system.app.graphicsDevice, value);
                 this._area = primData.area;
-                this.meshInstances = [new MeshInstance(this.entity, primData.mesh, material || this.system.defaultMaterial)];
+                this.meshInstances = [new MeshInstance(primData.mesh, material || this.system.defaultMaterial, this.entity)];
             }
         }
     }

--- a/src/framework/components/render/component.js
+++ b/src/framework/components/render/component.js
@@ -504,6 +504,7 @@ class RenderComponent extends Component {
                 mi[i].castShadow = this._castShadows;
                 mi[i].receiveShadow = this._receiveShadows;
                 mi[i].isStatic = this._isStatic;
+                mi[i].renderStyle = this._renderStyle;
                 mi[i].setLightmapped(this._lightmapped);
                 mi[i].setOverrideAabb(this._aabb);
             }

--- a/src/framework/components/render/system.js
+++ b/src/framework/components/render/system.js
@@ -12,6 +12,7 @@ const _schema = [
 // order matters here
 const _properties = [
     'material',
+    'meshInstances',
     'asset',
     'materialAssets',
     'castShadows',
@@ -75,6 +76,9 @@ class RenderComponentSystem extends ComponentSystem {
         for (i = 0; i < _properties.length; i++) {
             data[_properties[i]] = entity.render[_properties[i]];
         }
+
+        // we cannot copy mesh instances, delete them and component recreates them properly
+        delete data.meshInstances;
 
         var component = this.addComponent(clone, data);
 

--- a/src/framework/components/render/system.js
+++ b/src/framework/components/render/system.js
@@ -20,6 +20,7 @@ const _properties = [
     'castShadowsLightmap',
     'lightmapped',
     'lightmapSizeMultiplier',
+    'renderStyle',
     'type',
     'layers',
     'isStatic',

--- a/src/framework/components/sprite/component.js
+++ b/src/framework/components/sprite/component.js
@@ -241,7 +241,7 @@ class SpriteComponent extends Component {
 
         // create mesh instance if it doesn't exist yet
         if (!this._meshInstance) {
-            this._meshInstance = new MeshInstance(this._node, mesh, this._material);
+            this._meshInstance = new MeshInstance(mesh, this._material, this._node);
             this._meshInstance.castShadow = false;
             this._meshInstance.receiveShadow = false;
             this._meshInstance.drawOrder = this._drawOrder;

--- a/src/graphics/transform-feedback.js
+++ b/src/graphics/transform-feedback.js
@@ -58,7 +58,7 @@ import { VertexBuffer } from './vertex-buffer.js';
  *     var device = this.app.graphicsDevice;
  *     var mesh = pc.createTorus(device, { tubeRadius: 0.01, ringRadius: 3 });
  *     var node = new pc.GraphNode();
- *     var meshInstance = new pc.MeshInstance(node, mesh, this.material.resource);
+ *     var meshInstance = new pc.MeshInstance(mesh, this.material.resource, node);
  *     var model = new pc.Model();
  *     model.graph = node;
  *     model.meshInstances = [ meshInstance ];

--- a/src/resources/container.js
+++ b/src/resources/container.js
@@ -50,7 +50,7 @@ class ContainerResource {
                     if (mi.node === node) {
 
                         // clone mesh instance
-                        var cloneMi = new MeshInstance(entity, mi.mesh, mi.material);
+                        var cloneMi = new MeshInstance(mi.mesh, mi.material, entity);
 
                         // clone morph instance
                         if (mi.morphInstance) {

--- a/src/resources/parser/glb-parser.js
+++ b/src/resources/parser/glb-parser.js
@@ -2040,7 +2040,7 @@ class GlbParser {
 
         var createMeshInstance = function (model, mesh, skins, skinInstances, materials, node, gltfNode) {
             var material = (mesh.materialIndex === undefined) ? defaultMaterial : materials[mesh.materialIndex];
-            var meshInstance = new MeshInstance(node, mesh, material);
+            var meshInstance = new MeshInstance(mesh, material, node);
 
             if (mesh.morph) {
                 var morphInstance = new MorphInstance(mesh.morph);

--- a/src/resources/parser/json-model.js
+++ b/src/resources/parser/json-model.js
@@ -411,7 +411,7 @@ class JsonModelParser {
             var node = nodes[meshInstanceData.node];
             var mesh = meshes[meshInstanceData.mesh];
 
-            var meshInstance = new MeshInstance(node, mesh, Material.defaultMaterial);
+            var meshInstance = new MeshInstance(mesh, Material.defaultMaterial, node);
 
             if (mesh.skin) {
                 var skinIndex = skins.indexOf(mesh.skin);

--- a/src/scene/batching/batch-manager.js
+++ b/src/scene/batching/batch-manager.js
@@ -819,7 +819,7 @@ class BatchManager {
             }
 
             // Create meshInstance
-            var meshInstance = new MeshInstance(this.rootNode, mesh, material);
+            var meshInstance = new MeshInstance(mesh, material, this.rootNode);
             meshInstance.castShadow = batch.origMeshInstances[0].castShadow;
             meshInstance.parameters = batch.origMeshInstances[0].parameters;
             meshInstance.isStatic = batch.origMeshInstances[0].isStatic;
@@ -927,7 +927,7 @@ class BatchManager {
             nodes.push(clonedMeshInstances[i].node);
         }
 
-        batch2.meshInstance = new MeshInstance(batch.meshInstance.node, batch.meshInstance.mesh, batch.meshInstance.material);
+        batch2.meshInstance = new MeshInstance(batch.meshInstance.mesh, batch.meshInstance.material, batch.meshInstance.node);
         batch2.meshInstance._updateAabb = false;
         batch2.meshInstance.parameters = clonedMeshInstances[0].parameters;
         batch2.meshInstance.isStatic = clonedMeshInstances[0].isStatic;

--- a/src/scene/forward-renderer.js
+++ b/src/scene/forward-renderer.js
@@ -2408,7 +2408,7 @@ class ForwardRenderer {
                         mesh2.primitive[0].indexed = true;
                         mesh2.aabb = chunkAabb;
 
-                        var instance = new MeshInstance(drawCall.node, mesh2, drawCall.material);
+                        var instance = new MeshInstance(mesh2, drawCall.material, drawCall.node);
                         instance.isStatic = drawCall.isStatic;
                         instance.visible = drawCall.visible;
                         instance.layer = drawCall.layer;

--- a/src/scene/immediate.js
+++ b/src/scene/immediate.js
@@ -93,7 +93,7 @@ class LineBatch {
             if (!this.meshInstance) {
                 identityGraphNode.worldTransform = Mat4.IDENTITY;
                 identityGraphNode._dirtyWorld = identityGraphNode._dirtyNormal = false;
-                this.meshInstance = new MeshInstance(identityGraphNode, this.mesh, this.material);
+                this.meshInstance = new MeshInstance(this.mesh, this.material, identityGraphNode);
                 this.meshInstance.cull = false;
             }
         }

--- a/src/scene/mesh-instance.js
+++ b/src/scene/mesh-instance.js
@@ -166,20 +166,22 @@ class MeshInstance {
     // generates wireframes for an array of mesh instances
     static _prepareRenderStyleForArray(meshInstances, renderStyle) {
 
-        for (let i = 0; i < meshInstances.length; i++) {
+        if (meshInstances) {
+            for (let i = 0; i < meshInstances.length; i++) {
 
-            // switch mesh instance to the requested style
-            meshInstances[i].renderStyle = renderStyle;
+                // switch mesh instance to the requested style
+                meshInstances[i].renderStyle = renderStyle;
 
-            // process all unique meshes
-            let mesh = meshInstances[i].mesh;
-            if (!_meshSet.has(mesh)) {
-                _meshSet.add(mesh);
-                mesh.prepareRenderState(renderStyle);
+                // process all unique meshes
+                let mesh = meshInstances[i].mesh;
+                if (!_meshSet.has(mesh)) {
+                    _meshSet.add(mesh);
+                    mesh.prepareRenderState(renderStyle);
+                }
             }
-        }
 
-        _meshSet.clear();
+            _meshSet.clear();
+        }
     }
 
     get mesh() {

--- a/src/scene/mesh-instance.js
+++ b/src/scene/mesh-instance.js
@@ -12,7 +12,7 @@ import {
     SORTKEY_FORWARD
 } from './constants.js';
 
-import { Mesh } from './mesh.js';
+import { GraphNode } from './graph-node.js';
 
 var _tmpAabb = new BoundingBox();
 var _tempBoneAabb = new BoundingBox();
@@ -50,9 +50,9 @@ class Command {
  * @classdesc An instance of a {@link pc.Mesh}. A single mesh can be referenced by many
  * mesh instances that can have different transforms and materials.
  * @description Create a new mesh instance.
- * @param {pc.GraphNode} [node] - The graph node defining the transform for this instance. This parameter is optional when used with {@link pc.RenderComponent} and will use the node the component is attached to.
  * @param {pc.Mesh} mesh - The graphics mesh being instanced.
  * @param {pc.Material} material - The material used to render this instance.
+ * @param {pc.GraphNode} [node] - The graph node defining the transform for this instance. This parameter is optional when used with {@link pc.RenderComponent} and will use the node the component is attached to.
  * @property {pc.BoundingBox} aabb The world space axis-aligned bounding box for this mesh instance.
  * @property {boolean} visible Enable rendering for this mesh instance. Use visible property to enable/disable rendering without overhead of removing from scene.
  * But note that the mesh instance is still in the hierarchy and still in the draw call list.
@@ -78,7 +78,7 @@ class Command {
  * var mesh = pc.createBox(graphicsDevice);
  * var material = new pc.StandardMaterial();
  * var node = new pc.GraphNode();
- * var meshInstance = new pc.MeshInstance(node, mesh, material);
+ * var meshInstance = new pc.MeshInstance(mesh, material, node);
  *
  * @example
  * // A script you can attach on an entity to test if it is visible on a Layer
@@ -92,13 +92,14 @@ class Command {
  * };
  */
 class MeshInstance {
-    constructor(node, mesh, material) {
+    constructor(mesh, material, node = null) {
 
-        // optional node parameter was skipped, shift parameters by one
-        if (node instanceof Mesh) {
-            material = mesh;
-            mesh = node;
-            node = null;
+        // if first parameter is of GraphNode type, handle previous constructor signature: (node, mesh, material)
+        if (mesh instanceof GraphNode) {
+            const temp = mesh;
+            mesh = material;
+            material = node;
+            node = temp;
         }
 
         this._key = [0, 0];

--- a/src/scene/mesh-instance.js
+++ b/src/scene/mesh-instance.js
@@ -12,6 +12,8 @@ import {
     SORTKEY_FORWARD
 } from './constants.js';
 
+import { Mesh } from './mesh.js';
+
 var _tmpAabb = new BoundingBox();
 var _tempBoneAabb = new BoundingBox();
 var _tempSphere = new BoundingSphere();
@@ -48,7 +50,7 @@ class Command {
  * @classdesc An instance of a {@link pc.Mesh}. A single mesh can be referenced by many
  * mesh instances that can have different transforms and materials.
  * @description Create a new mesh instance.
- * @param {pc.GraphNode} node - The graph node defining the transform for this instance.
+ * @param {pc.GraphNode} [node] - The graph node defining the transform for this instance. This parameter is optional when used with {@link pc.RenderComponent} and will use the node the component is attached to.
  * @param {pc.Mesh} mesh - The graphics mesh being instanced.
  * @param {pc.Material} material - The material used to render this instance.
  * @property {pc.BoundingBox} aabb The world space axis-aligned bounding box for this mesh instance.
@@ -91,6 +93,14 @@ class Command {
  */
 class MeshInstance {
     constructor(node, mesh, material) {
+
+        // optional node parameter was skipped, shift parameters by one
+        if (node instanceof Mesh) {
+            material = mesh;
+            mesh = node;
+            node = null;
+        }
+
         this._key = [0, 0];
         this._shader = [null, null, null];
 

--- a/src/scene/mesh-instance.js
+++ b/src/scene/mesh-instance.js
@@ -124,7 +124,7 @@ class MeshInstance {
         // Render options
         this.visible = true;
         this.layer = LAYER_WORLD; // legacy
-        this.renderStyle = RENDERSTYLE_SOLID;
+        this._renderStyle = RENDERSTYLE_SOLID;
         this.castShadow = false;
         this._receiveShadow = true;
         this._screenSpace = false;
@@ -163,6 +163,15 @@ class MeshInstance {
         this.flipFaces = false;
     }
 
+    get renderStyle() {
+        return this._renderStyle;
+    }
+
+    set renderStyle(renderStyle) {
+        this._renderStyle = renderStyle;
+        this.mesh.prepareRenderState(renderStyle);
+    }
+
     // generates wireframes for an array of mesh instances
     static _prepareRenderStyleForArray(meshInstances, renderStyle) {
 
@@ -170,7 +179,7 @@ class MeshInstance {
             for (let i = 0; i < meshInstances.length; i++) {
 
                 // switch mesh instance to the requested style
-                meshInstances[i].renderStyle = renderStyle;
+                meshInstances[i]._renderStyle = renderStyle;
 
                 // process all unique meshes
                 let mesh = meshInstances[i].mesh;

--- a/src/scene/model.js
+++ b/src/scene/model.js
@@ -132,7 +132,7 @@ class Model {
         for (i = 0; i < this.meshInstances.length; i++) {
             var meshInstance = this.meshInstances[i];
             var nodeIndex = srcNodes.indexOf(meshInstance.node);
-            var cloneMeshInstance = new MeshInstance(cloneNodes[nodeIndex], meshInstance.mesh, meshInstance.material);
+            var cloneMeshInstance = new MeshInstance(meshInstance.mesh, meshInstance.material, cloneNodes[nodeIndex]);
 
             if (meshInstance.skinInstance) {
                 var skinInstanceIndex = this.skinInstances.indexOf(meshInstance.skinInstance);

--- a/src/scene/particle-system/particle-emitter.js
+++ b/src/scene/particle-system/particle-emitter.js
@@ -702,7 +702,7 @@ class ParticleEmitter {
         this.resetMaterial();
 
         var wasVisible = this.meshInstance ? this.meshInstance.visible : true;
-        this.meshInstance = new MeshInstance(this.node, mesh, this.material);
+        this.meshInstance = new MeshInstance(mesh, this.material, this.node);
         this.meshInstance.pick = false;
         this.meshInstance.updateKey(); // shouldn't be here?
         this.meshInstance.cull = true;

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -432,7 +432,7 @@ class Scene extends EventHandler {
             if (skyLayer) {
                 var node = new GraphNode();
                 var mesh = createBox(device);
-                var meshInstance = new MeshInstance(node, mesh, material);
+                var meshInstance = new MeshInstance(mesh, material, node);
                 meshInstance.cull = false;
                 meshInstance._noDepthDrawGl1 = true;
 


### PR DESCRIPTION
Fixes https://github.com/playcanvas/engine/issues/2753

1. API change. Constructor of MeshInstance has changed from `constructor(node, mesh, material)` to `constructor(mesh, material, node = null)` - node is optional for when used with a RenderComponent. Note that this change does not break compatibility and the constructor handles previous case as well.
2. MeshInstances can be supplied to RenderComponent using initializer.
3. MeshInstance.renderStyle works now