### PR TITLE
Animation curve path fix

### DIFF
--- a/src/resources/parser/glb-parser.js
+++ b/src/resources/parser/glb-parser.js
@@ -1253,8 +1253,9 @@ var createAnimation = function (gltfAnimation, animationIndex, gltfAccessors, bu
         var target = channel.target;
         var curve = curves[channel.sampler];
 
+        var entityPath = nodes[target.node].path.length > 0 ? AnimBinder.splitPath(nodes[target.node].path, '/') : [nodes[target.node].name];
         curve._paths.push({
-            entityPath: AnimBinder.splitPath(nodes[target.node].path, '/'),
+            entityPath: entityPath,
             component: 'graph',
             propertyPath: [transformSchema[target.path]]
         });

--- a/src/resources/parser/glb-parser.js
+++ b/src/resources/parser/glb-parser.js
@@ -1253,7 +1253,8 @@ var createAnimation = function (gltfAnimation, animationIndex, gltfAccessors, bu
         var target = channel.target;
         var curve = curves[channel.sampler];
 
-        var entityPath = nodes[target.node].path.length > 0 ? AnimBinder.splitPath(nodes[target.node].path, '/') : [nodes[target.node].name];
+        var node = nodes[target.node];
+        var entityPath = node.path.length > 0 ? AnimBinder.splitPath(node.path, '/') : [node.name];
         curve._paths.push({
             entityPath: entityPath,
             component: 'graph',


### PR DESCRIPTION
Currently if an animation curves target node contains an empty path, the animation won't resolve. This PR will resolve those animations to the node using it's name as an identifier.

Fixes: https://forum.playcanvas.com/t/is-it-possible-to-animate-morphs/17501/7


I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
