### PR TITLE
Anim binder debug fix

### DIFF
--- a/src/anim/binder/default-anim-binder.js
+++ b/src/anim/binder/default-anim-binder.js
@@ -139,7 +139,7 @@ class DefaultAnimBinder {
             // #ifdef DEBUG
             var fallbackGraphPath = AnimBinder.encode(path.entityPath[path.entityPath.length - 1] || "", 'graph', path.propertyPath);
             if (this.visitedFallbackGraphPaths[fallbackGraphPath]) {
-                console.warn('Multiple nodes with the path ' + fallbackGraphPath + ' are present in the ' + entity.name + ' entity\'s graph which may result in the incorrect binding of animations');
+                console.warn('Anim Binder: Multiple animation curves with the path ' + fallbackGraphPath + ' are present in the ' + this.graph.path + ' graph which may result in the incorrect binding of animations');
             }
             this.visitedFallbackGraphPaths[fallbackGraphPath] = true;
             // #endif


### PR DESCRIPTION
Fixes the anim binder debug message which is logged when the anim binder finds two nodes of the same name in the graph hierarchy.


I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
