### PR TITLE
Refactor of debug rendering private API

### DIFF
--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -6,6 +6,7 @@ import { EventHandler } from '../core/event-handler.js';
 import { math } from '../math/math.js';
 import { Color } from '../math/color.js';
 import { Vec3 } from '../math/vec3.js';
+import { Mat4 } from '../math/mat4.js';
 
 import { http } from '../net/http.js';
 
@@ -14,17 +15,12 @@ import {
     CLEARFLAG_COLOR, CLEARFLAG_DEPTH,
     FILTER_NEAREST,
     PIXELFORMAT_DEPTHSTENCIL, PIXELFORMAT_R8_G8_B8_A8,
-    PRIMITIVE_TRIANGLES, PRIMITIVE_TRIFAN, PRIMITIVE_TRISTRIP,
-    SEMANTIC_POSITION,
-    TYPE_FLOAT32
+    PRIMITIVE_TRIANGLES, PRIMITIVE_TRIFAN, PRIMITIVE_TRISTRIP
 } from '../graphics/constants.js';
 import { destroyPostEffectQuad } from '../graphics/simple-post-effect.js';
 import { GraphicsDevice } from '../graphics/graphics-device.js';
 import { RenderTarget } from '../graphics/render-target.js';
 import { Texture } from '../graphics/texture.js';
-import { VertexBuffer } from '../graphics/vertex-buffer.js';
-import { VertexFormat } from '../graphics/vertex-format.js';
-import { VertexIterator } from '../graphics/vertex-iterator.js';
 
 import {
     LAYERID_DEPTH, LAYERID_IMMEDIATE, LAYERID_SKYBOX, LAYERID_UI, LAYERID_WORLD,
@@ -34,13 +30,10 @@ import {
 } from '../scene/constants.js';
 import { BatchManager } from '../scene/batching/batch-manager.js';
 import { ForwardRenderer } from '../scene/forward-renderer.js';
-import { GraphNode } from '../scene/graph-node.js';
-import { ImmediateData, LineBatch } from '../scene/immediate.js';
+import { ImmediateData } from '../scene/immediate.js';
 import { Layer } from '../scene/layer.js';
 import { LayerComposition } from '../scene/layer-composition.js';
 import { Lightmapper } from '../scene/lightmapper.js';
-import { Mesh } from '../scene/mesh.js';
-import { MeshInstance } from '../scene/mesh-instance.js';
 import { ParticleEmitter } from '../scene/particle-system/particle-emitter.js';
 import { Scene } from '../scene/scene.js';
 
@@ -143,7 +136,6 @@ class Progress {
 }
 
 var _deprecationWarning = false;
-var tempGraphNode = new GraphNode();
 
 /**
  * @class
@@ -808,8 +800,6 @@ class Application extends EventHandler {
                 document.addEventListener('webkitvisibilitychange', this._visibilityChangeHandler, false);
             }
         }
-
-        this.meshInstanceArray = [];
 
         // bind tick function to current scope
 
@@ -1813,19 +1803,11 @@ class Application extends EventHandler {
 
     // IMMEDIATE MODE API
     _preRenderImmediate() {
-        for (var i = 0; i < this._immediateData.lineBatches.length; i++) {
-            if (this._immediateData.lineBatches[i]) {
-                this._immediateData.lineBatches[i].finalize(this.meshInstanceArray);
-            }
-        }
+        this._immediateData.finalize();
     }
 
     _postRenderImmediate() {
-        for (var i = 0; i < this._immediateData.layers.length; i++) {
-            this._immediateData.layers[i].clearMeshInstances(true);
-        }
-
-        this._immediateData.layers.length = 0;
+        this._immediateData.clear();
     }
 
     _initImmediate() {
@@ -1844,27 +1826,10 @@ class Application extends EventHandler {
         var mask = (options && options.mask) ? options.mask : undefined;
 
         this._initImmediate();
+        let lineBatch = this._immediateData.prepareLineBatch(layer, depthTest, mask, position.length / 2);
 
-        this._immediateData.addLayer(layer);
-
-        var idx = this._immediateData.getLayerIdx(layer);
-        if (idx === undefined) {
-            // Init used batch once
-            var batch = new LineBatch();
-            batch.init(this.graphicsDevice, this._immediateData.lineVertexFormat, layer, position.length / 2);
-            batch.material.depthTest = depthTest;
-            if (mask) batch.meshInstance.mask = mask;
-
-            idx = this._immediateData.lineBatches.push(batch) - 1; // push into list and get index
-            this._immediateData.addLayerIdx(idx, layer);
-        } else {
-            // Possibly reallocate buffer if it's small
-            this._immediateData.lineBatches[idx].init(this.graphicsDevice, this._immediateData.lineVertexFormat, layer, position.length / 2);
-            this._immediateData.lineBatches[idx].material.depthTest = depthTest;
-            if (mask) this._immediateData.lineBatches[idx].meshInstance.mask = mask;
-        }
         // Append
-        this._immediateData.lineBatches[idx].addLines(position, color);
+        lineBatch.addLines(position, color);
     }
 
     /**
@@ -2094,88 +2059,45 @@ class Application extends EventHandler {
         ], color, options);
     }
 
+    _getDefaultImmediateOptions() {
+        return {
+            layer: this.scene.layers.getLayerById(LAYERID_IMMEDIATE)
+        };
+    }
+
     // Draw meshInstance at this frame
-    renderMeshInstance(meshInstance, options) {
-        if (!options) {
-            options = {
-                layer: this.scene.layers.getLayerById(LAYERID_IMMEDIATE)
-            };
-        }
-
+    renderMeshInstance(meshInstance, options = this._getDefaultImmediateOptions()) {
         this._initImmediate();
-
-        this._immediateData.addLayer(options.layer);
-
-        this.meshInstanceArray[0] = meshInstance;
-        options.layer.addMeshInstances(this.meshInstanceArray, true);
+        this._immediateData.renderMesh(null, null, null, meshInstance, options);
     }
 
     // Draw mesh at this frame
-    renderMesh(mesh, material, matrix, options) {
-        if (!options) {
-            options = {
-                layer: this.scene.layers.getLayerById(LAYERID_IMMEDIATE)
-            };
-        }
-
+    renderMesh(mesh, material, matrix, options = this._getDefaultImmediateOptions()) {
         this._initImmediate();
-        tempGraphNode.worldTransform = matrix;
-        tempGraphNode._dirtyWorld = tempGraphNode._dirtyNormal = false;
-
-        var instance = new MeshInstance(mesh, material, tempGraphNode);
-        instance.cull = false;
-
-        if (options.mask) instance.mask = options.mask;
-        this._immediateData.addLayer(options.layer);
-
-        this.meshInstanceArray[0] = instance;
-        options.layer.addMeshInstances(this.meshInstanceArray, true);
+        this._immediateData.renderMesh(material, matrix, mesh, null, options);
     }
 
     // Draw quad of size [-0.5, 0.5] at this frame
-    renderQuad(matrix, material, options) {
-        if (!options) {
-            options = {
-                layer: this.scene.layers.getLayerById(LAYERID_IMMEDIATE)
-            };
-        }
+    renderQuad(matrix, material, options = this._getDefaultImmediateOptions()) {
+        this._initImmediate();
+        this._immediateData.renderMesh(material, matrix, this._immediateData.getQuadMesh(), null, options);
+    }
 
+    // draws a texture on [x,y] position on screen, with size [width, height].
+    // Coordinates / sizes are in projected space (-1 .. 1)
+    renderTexture(x, y, width, height, texture, options) {
         this._initImmediate();
 
-        // Init quad data once
-        if (!this._immediateData.quadMesh) {
-            var format = new VertexFormat(this.graphicsDevice, [
-                { semantic: SEMANTIC_POSITION, components: 3, type: TYPE_FLOAT32 }
-            ]);
-            var quadVb = new VertexBuffer(this.graphicsDevice, format, 4);
-            var iterator = new VertexIterator(quadVb);
-            iterator.element[SEMANTIC_POSITION].set(-0.5, -0.5, 0);
-            iterator.next();
-            iterator.element[SEMANTIC_POSITION].set(0.5, -0.5, 0);
-            iterator.next();
-            iterator.element[SEMANTIC_POSITION].set(-0.5, 0.5, 0);
-            iterator.next();
-            iterator.element[SEMANTIC_POSITION].set(0.5, 0.5, 0);
-            iterator.end();
-            this._immediateData.quadMesh = new Mesh(this.graphicsDevice);
-            this._immediateData.quadMesh.vertexBuffer = quadVb;
-            this._immediateData.quadMesh.primitive[0].type = PRIMITIVE_TRISTRIP;
-            this._immediateData.quadMesh.primitive[0].base = 0;
-            this._immediateData.quadMesh.primitive[0].count = 4;
-            this._immediateData.quadMesh.primitive[0].indexed = false;
-        }
+        // TODO: if this is used for anything other than debug texture display, we should optimize this to avoid allocations
+        let matrix = new Mat4();
+        matrix.setTRS(new Vec3(x, y, 0.0), pc.Quat.IDENTITY, new Vec3(width, height, 0.0));
 
-        // Issue quad drawcall
-        tempGraphNode.worldTransform = matrix;
-        tempGraphNode._dirtyWorld = tempGraphNode._dirtyNormal = false;
+        let material = new pc.Material();
+        material.setParameter("colorMap", texture);
+        material.shader = this._immediateData.getTextureShader();
+        material.update();
 
-        var quad = new MeshInstance(this._immediateData.quadMesh, material, tempGraphNode);
-        quad.cull = false;
-        this.meshInstanceArray[0] = quad;
-
-        this._immediateData.addLayer(options.layer);
-
-        options.layer.addMeshInstances(this.meshInstanceArray, true);
+        this.renderQuad(matrix, material, options);
     }
 
     /**

--- a/src/scene/immediate.js
+++ b/src/scene/immediate.js
@@ -1,8 +1,13 @@
 import { Mat4 } from '../math/mat4.js';
 
-import { BUFFER_DYNAMIC, PRIMITIVE_LINES, SEMANTIC_POSITION, SEMANTIC_COLOR, TYPE_FLOAT32, TYPE_UINT8 } from '../graphics/constants.js';
+import {
+    BUFFER_DYNAMIC, PRIMITIVE_LINES, SEMANTIC_POSITION, SEMANTIC_COLOR, TYPE_FLOAT32, TYPE_UINT8,
+    PRIMITIVE_TRISTRIP
+} from '../graphics/constants.js';
+
 import { VertexBuffer } from '../graphics/vertex-buffer.js';
 import { VertexFormat } from '../graphics/vertex-format.js';
+import { VertexIterator } from '../graphics/vertex-iterator.js';
 
 import { BLEND_NORMAL } from '../scene/constants.js';
 import { BasicMaterial } from '../scene/materials/basic-material.js';
@@ -11,35 +16,6 @@ import { Mesh } from '../scene/mesh.js';
 import { MeshInstance } from '../scene/mesh-instance.js';
 
 var identityGraphNode = new GraphNode();
-
-class ImmediateData {
-    constructor(device) {
-        this.lineVertexFormat = new VertexFormat(device, [
-            { semantic: SEMANTIC_POSITION, components: 3, type: TYPE_FLOAT32 },
-            { semantic: SEMANTIC_COLOR, components: 4, type: TYPE_UINT8, normalize: true }
-        ]);
-        this.lineBatches = [];
-        this.layers = [];
-        this.layerToBatch = {};
-        this.quadMesh = null;
-        this.cubeLocalPos = null;
-        this.cubeWorldPos = null;
-    }
-
-    addLayer(layer) {
-        if (this.layers.indexOf(layer) < 0) {
-            this.layers.push(layer);
-        }
-    }
-
-    getLayerIdx(layer) {
-        return this.layerToBatch[layer.id];
-    }
-
-    addLayerIdx(idx, layer) {
-        this.layerToBatch[layer.id] = idx;
-    }
-}
 
 class LineBatch {
     constructor() {
@@ -52,6 +28,7 @@ class LineBatch {
         this.linesUsed = 0;
         this.material = null;
         this.meshInstance = null;
+        this.meshInstanceArray = [];
 
         this.layer = null;
     }
@@ -129,4 +106,183 @@ class LineBatch {
     }
 }
 
-export { ImmediateData, LineBatch };
+class ImmediateData {
+    constructor(device) {
+        this.lineVertexFormat = new VertexFormat(device, [
+            { semantic: SEMANTIC_POSITION, components: 3, type: TYPE_FLOAT32 },
+            { semantic: SEMANTIC_COLOR, components: 4, type: TYPE_UINT8, normalize: true }
+        ]);
+        this.device = device;
+        this.lineBatches = [];
+        this.layers = [];
+        this.layerToBatch = {};
+        this.quadMesh = null;
+        this.textureShader = null;
+        this.cubeLocalPos = null;
+        this.cubeWorldPos = null;
+        this.meshInstanceArray = [];
+
+        this.usedGraphNodes = [];
+        this.freeGraphNodes = [];
+    }
+
+    // shader used to display texture
+    getTextureShader() {
+
+        if (!this.textureShader) {
+            const shaderDefinition = {
+                attributes: {
+                    aPosition: pc.SEMANTIC_POSITION
+                },
+                vshader: `
+                    attribute vec2 aPosition;
+                    uniform mat4 matrix_model;
+                    varying vec2 uv0;
+                    void main(void) {
+                        gl_Position = matrix_model * vec4(aPosition, 0, 1);
+                        uv0 = aPosition.xy * 0.5 + 0.5;
+                    }
+                `,
+                fshader: `
+                    precision lowp float;
+                    varying vec2 uv0;
+                    uniform sampler2D colorMap;
+                    void main (void) {
+                        gl_FragColor = vec4(texture2D(colorMap, uv0).xyz, 1);
+                    }
+                `
+            };
+            this.textureShader = new pc.Shader(app.graphicsDevice, shaderDefinition);
+        }
+
+        return this.textureShader;
+    }
+
+    getQuadMesh() {
+        if (!this.quadMesh) {
+            // Init quad data once
+            var format = new VertexFormat(this.graphicsDevice, [
+                { semantic: SEMANTIC_POSITION, components: 3, type: TYPE_FLOAT32 }
+            ]);
+            var quadVb = new VertexBuffer(this.device, format, 4);
+            var iterator = new VertexIterator(quadVb);
+            iterator.element[SEMANTIC_POSITION].set(-0.5, -0.5, 0);
+            iterator.next();
+            iterator.element[SEMANTIC_POSITION].set(0.5, -0.5, 0);
+            iterator.next();
+            iterator.element[SEMANTIC_POSITION].set(-0.5, 0.5, 0);
+            iterator.next();
+            iterator.element[SEMANTIC_POSITION].set(0.5, 0.5, 0);
+            iterator.end();
+            this.quadMesh = new Mesh(this.graphicsDevice);
+            this.quadMesh.vertexBuffer = quadVb;
+            this.quadMesh.primitive[0].type = PRIMITIVE_TRISTRIP;
+            this.quadMesh.primitive[0].base = 0;
+            this.quadMesh.primitive[0].count = 4;
+            this.quadMesh.primitive[0].indexed = false;
+        }
+        return this.quadMesh;
+    }
+
+    // Draw mesh at this frame
+    renderMesh(material, matrix, mesh, meshInstance, options) {
+
+        if (!meshInstance) {
+            var graphNode = this.getGraphNode(matrix);
+            meshInstance = new MeshInstance(mesh, material, graphNode);
+            meshInstance.cull = false;
+        }
+
+        this.addLayer(options.layer);
+        if (options.mask) {
+            meshInstance.mask = options.mask;
+        }
+
+        this.meshInstanceArray[0] = meshInstance;
+        options.layer.addMeshInstances(this.meshInstanceArray, true);
+    }
+
+    getGraphNode(matrix) {
+        let graphNode = null;
+        if (this.freeGraphNodes.length > 0) {
+            graphNode = this.freeGraphNodes.pop();
+        } else {
+            graphNode = new GraphNode();
+        }
+        this.usedGraphNodes.push(graphNode);
+
+        graphNode.worldTransform = matrix;
+        graphNode._dirtyWorld = graphNode._dirtyNormal = false;
+
+        return graphNode;
+    }
+
+    addLayer(layer) {
+        if (this.layers.indexOf(layer) < 0) {
+            this.layers.push(layer);
+        }
+    }
+
+    getLayerIdx(layer) {
+        return this.layerToBatch[layer.id];
+    }
+
+    addLayerIdx(idx, layer) {
+        this.layerToBatch[layer.id] = idx;
+    }
+
+    // called before the frame is rendered, preparas data for rendering
+    finalize() {
+        for (var i = 0; i < this.lineBatches.length; i++) {
+            if (this.lineBatches[i]) {
+                this.lineBatches[i].finalize(this.meshInstanceArray);
+            }
+        }
+    }
+
+    // called after the frame was rendered, clears data
+    clear() {
+        for (var i = 0; i < this.layers.length; i++) {
+            this.layers[i].clearMeshInstances(true);
+        }
+
+        // reuse graph nodes
+        const temp = this.freeGraphNodes;
+        this.freeGraphNodes = this.usedGraphNodes;
+        this.usedGraphNodes = temp;
+
+        this.layers.length = 0;
+    }
+
+    prepareLineBatch(layer, depthTest, mask, numLines) {
+        this.addLayer(layer);
+
+        var idx = this.getLayerIdx(layer);
+        if (idx === undefined) {
+
+            // Init used batch once
+            var batch = new LineBatch();
+            batch.init(this.device, this.lineVertexFormat, layer, numLines);
+            batch.material.depthTest = depthTest;
+            if (mask) {
+                batch.meshInstance.mask = mask;
+            }
+
+            // push into list and get index
+            idx = this.lineBatches.push(batch) - 1;
+            this.addLayerIdx(idx, layer);
+
+        } else {
+            // Possibly reallocate buffer if it's small
+            this.lineBatches[idx].init(this.device, this.lineVertexFormat, layer, numLines);
+            this.lineBatches[idx].material.depthTest = depthTest;
+            if (mask) {
+                this.lineBatches[idx].meshInstance.mask = mask;
+            }
+        }
+
+        return this.lineBatches[idx];
+    }
+}
+
+export { ImmediateData };

--- a/src/scene/immediate.js
+++ b/src/scene/immediate.js
@@ -140,7 +140,7 @@ class ImmediateData {
                     varying vec2 uv0;
                     void main(void) {
                         gl_Position = matrix_model * vec4(aPosition, 0, 1);
-                        uv0 = aPosition.xy * 0.5 + 0.5;
+                        uv0 = aPosition.xy + 0.5;
                     }
                 `,
                 fshader: `


### PR DESCRIPTION
- refactor of private part of debug rendering of meshes / meshInstances in app - moved most of the code to immediate.js to separate it and remove imports to the Application
- new private API: Application.renderTexture(x, y, w, h, texture) - debug renders the texture on screen, useful for rendering to texture debugging

screenshot: top view of the scene is display of render target texture, added by 
`            app.renderTexture(0.3, 0.7, 0.8, 0.5, texture);`

![Screen Shot 2021-02-09 at 3 52 00 PM](https://user-images.githubusercontent.com/59932779/107389652-e0ba5280-6aee-11eb-89ba-40d7fd89ca2c.png)
