### PR TITLE
[FIX] Several fixes reported by checkJs

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,8 +74,8 @@
     "test": "karma start tests/karma.conf.js -- --single-run --release",
     "test:watch": "karma start tests/karma.conf.js",
     "test:debug": "karma start tests/karma.conf.js -- --single-run=false",
-    "test:tsd": "npm run tsd && tsc --pretty false build/playcanvas.d.ts;",
-    "tsd": "jsdoc -c conf-tsd.json; node tsd.js;",
+    "test:tsd": "npm run tsd && tsc --pretty false build/playcanvas.d.ts",
+    "tsd": "jsdoc -c conf-tsd.json && node tsd.js",
     "unzipbundle": "gzip -x tests/assets/bundle.gz"
   }
 }

--- a/src/anim/controller/anim-blend-tree.js
+++ b/src/anim/controller/anim-blend-tree.js
@@ -1,3 +1,5 @@
+import { Vec2 } from '../../math/vec2.js';
+
 import { AnimNode } from './anim-node.js';
 import {
     ANIM_BLEND_1D, ANIM_BLEND_2D_DIRECTIONAL, ANIM_BLEND_2D_CARTESIAN, ANIM_BLEND_DIRECT
@@ -115,7 +117,7 @@ class AnimBlendTree extends AnimNode {
                     return;
                 }
                 this._parameterValues = parameterValues;
-                p = new pc.Vec2(this._parameterValues);
+                p = new Vec2(this._parameterValues);
 
                 weightSum = 0.0;
                 for (i = 0; i < this._children.length; i++) {
@@ -145,7 +147,7 @@ class AnimBlendTree extends AnimNode {
                     return;
                 }
                 this._parameterValues = parameterValues;
-                p = new pc.Vec2(this._parameterValues);
+                p = new Vec2(this._parameterValues);
 
 
                 weightSum = 0.0;
@@ -157,8 +159,8 @@ class AnimBlendTree extends AnimNode {
                         pj = this._children[j].point.clone();
                         var pipAngle = getAngleRad(pi, p);
                         var pipjAngle = getAngleRad(pi, pj);
-                        pipj = new pc.Vec2((pj.length() - pi.length()) / ((pj.length() + pi.length()) / 2), pipjAngle * 2.0);
-                        pip = new pc.Vec2((p.length() - pi.length()) / ((pj.length() + pi.length()) / 2), pipAngle * 2.0);
+                        pipj = new Vec2((pj.length() - pi.length()) / ((pj.length() + pi.length()) / 2), pipjAngle * 2.0);
+                        pip = new Vec2((p.length() - pi.length()) / ((pj.length() + pi.length()) / 2), pipAngle * 2.0);
                         result = clamp(1.0 - Math.abs((pip.clone().dot(pipj) / pipj.lengthSq())), 0.0, 1.0);
                         if (result < minj) minj = result;
                     }

--- a/src/anim/controller/anim-controller.js
+++ b/src/anim/controller/anim-controller.js
@@ -15,7 +15,7 @@ import {
  * @name AnimController
  * @classdesc The AnimController manages the animations for it's entity, based on the provided state graph and parameters. It's update method determines which state the controller should be in based on the current time, parameters and available states / transitions. It also ensures the AnimEvaluator is supplied with the correct animations, based on the currently active state.
  * @description Create a new AnimController.
- * @param {animEvaluator} animEvaluator - The animation evaluator used to blend all current playing animation keyframes and update the entities properties based on the current animation values.
+ * @param {AnimEvaluator} animEvaluator - The animation evaluator used to blend all current playing animation keyframes and update the entities properties based on the current animation values.
  * @param {object[]} states - The list of states used to form the controller state graph.
  * @param {object[]} transitions - The list of transitions used to form the controller state graph.
  * @param {object[]} parameters - The anim components parameters.

--- a/src/anim/controller/anim-node.js
+++ b/src/anim/controller/anim-node.js
@@ -1,3 +1,5 @@
+import { Vec2 } from '../../math/vec2.js';
+
 /**
  * @private
  * @class
@@ -15,7 +17,7 @@ class AnimNode {
         this._state = state;
         this._parent = parent;
         this._name = name;
-        this._point = Array.isArray(point) ? new pc.Vec2(point) : point;
+        this._point = Array.isArray(point) ? new Vec2(point[0], point[1]) : point;
         this._speed = speed;
         this._weight = 1.0;
         this._animTrack = null;

--- a/src/anim/evaluator/anim-evaluator.js
+++ b/src/anim/evaluator/anim-evaluator.js
@@ -104,8 +104,8 @@ class AnimEvaluator {
 
     /**
      * @private
-     * @name AnimEvaluator
-     * @type {number}
+     * @name AnimEvaluator#clips
+     * @type {AnimClip[]}
      * @description The number of clips.
      */
     get clips() {

--- a/src/core/string.js
+++ b/src/core/string.js
@@ -201,10 +201,10 @@ var string = {
      * @function
      * @name string.getSymbols
      * @description Gets an array of all grapheme clusters (visible symbols) in a string. This is needed because
-     * some symbols (such as emoji or accented characters) are actually made up of multiple character codes.
+     * some symbols (such as emoji or accented characters) are actually made up of multiple character codes. See
+     * {@link https://mathiasbynens.be/notes/javascript-unicode here} for more info.
      * @param {string} string - The string to break into symbols.
      * @returns {string[]} The symbols in the string.
-     * @see {@link https://mathiasbynens.be/notes/javascript-unicode Unicode strings in JavaScript}
      */
     getSymbols: function (string) {
         if (typeof string !== 'string') {

--- a/src/graphics/graphics-device.js
+++ b/src/graphics/graphics-device.js
@@ -268,7 +268,7 @@ class GraphicsDevice extends EventHandler {
         // Add handlers for when the WebGL context is lost or restored
         this.contextLost = false;
 
-        this._contextLostHandler = function (event) {
+        this._contextLostHandler = event => {
             event.preventDefault();
             this.contextLost = true;
             this.loseContext();
@@ -276,16 +276,16 @@ class GraphicsDevice extends EventHandler {
             console.log('pc.GraphicsDevice: WebGL context lost.');
             // #endif
             this.fire('devicelost');
-        }.bind(this);
+        };
 
-        this._contextRestoredHandler = function () {
+        this._contextRestoredHandler = () => {
             // #ifdef DEBUG
             console.log('pc.GraphicsDevice: WebGL context restored.');
             // #endif
             this.restoreContext();
             this.contextLost = false;
             this.fire('devicerestored');
-        }.bind(this);
+        };
 
         // Retrieve the WebGL context
         var preferWebGl2 = (options && options.preferWebGl2 !== undefined) ? options.preferWebGl2 : true;
@@ -2484,6 +2484,7 @@ class GraphicsDevice extends EventHandler {
      * * {@link CLEARFLAG_COLOR}
      * * {@link CLEARFLAG_DEPTH}
      * * {@link CLEARFLAG_STENCIL}
+     * @param {number} options.stencil - The stencil value to clear the stencil buffer to. Defaults to 0.
      * @example
      * // Clear color buffer to black and depth buffer to 1.0
      * device.clear();
@@ -3616,11 +3617,11 @@ class GraphicsDevice extends EventHandler {
         this._enableAutoInstancing = value && this.extInstancing;
     }
 
-/**
- * @name GraphicsDevice#maxPixelRatio
- * @type {number}
- * @description Maximum pixel ratio.
- */
+    /**
+     * @name GraphicsDevice#maxPixelRatio
+     * @type {number}
+     * @description Maximum pixel ratio.
+     */
     get maxPixelRatio() {
         return this._maxPixelRatio;
     }
@@ -3633,7 +3634,7 @@ class GraphicsDevice extends EventHandler {
     /**
      * @readonly
      * @name GraphicsDevice#textureFloatHighPrecision
-     * @type {number}
+     * @type {boolean}
      * @description Check if high precision floating-point textures are supported.
      */
     get textureFloatHighPrecision() {
@@ -3646,7 +3647,7 @@ class GraphicsDevice extends EventHandler {
     /**
      * @readonly
      * @name GraphicsDevice#textureHalfFloatUpdatable
-     * @type {number}
+     * @type {boolean}
      * @description Check if texture with half float format can be updated with data.
      */
     get textureHalfFloatUpdatable() {

--- a/src/graphics/prefilter-cubemap.js
+++ b/src/graphics/prefilter-cubemap.js
@@ -247,7 +247,6 @@ function prefilterCubemap(options) {
             cubemap._levels[i] = mips[i]._levels[0];
 
         cubemap.upload();
-        cubemap._prefilteredMips = true;
         options.singleFilteredFixed = cubemap;
     }
 
@@ -268,7 +267,6 @@ function prefilterCubemap(options) {
             cubemap._levels[i] = mips[i]._levels[0];
         }
         cubemap.upload();
-        cubemap._prefilteredMips = true;
         options.singleFilteredFixedRgbm = cubemap;
     }
 }

--- a/src/graphics/texture.js
+++ b/src/graphics/texture.js
@@ -607,7 +607,7 @@ class Texture {
 
                 if (format === PIXELFORMAT_PVRTC_2BPP_RGB_1 ||
                     format === PIXELFORMAT_PVRTC_2BPP_RGBA_1) {
-                    blockWidth = Math.floor(blockWidth / 2, 1);
+                    blockWidth = Math.floor(blockWidth / 2);
                 }
 
                 result += blockWidth * blockHeight * blockDepth * blockSize;
@@ -656,6 +656,10 @@ class Texture {
      * @param {object} [options] - Optional options object. Valid properties are as follows:
      * @param {number} [options.level] - The mip level to lock with 0 being the top level. Defaults to 0.
      * @param {number} [options.face] - If the texture is a cubemap, this is the index of the face to lock.
+     * @param {number} [options.mode] - The lock mode. Can be:
+     * * {@link TEXTURELOCK_READ}
+     * * {@link TEXTURELOCK_WRITE}
+     * Defaults to {@link TEXTURELOCK_WRITE}.
      * @returns {Uint8Array|Uint16Array|Float32Array} A typed array containing the pixel data of the locked mip level.
      */
     lock(options = {}) {

--- a/src/graphics/texture.js
+++ b/src/graphics/texture.js
@@ -607,7 +607,7 @@ class Texture {
 
                 if (format === PIXELFORMAT_PVRTC_2BPP_RGB_1 ||
                     format === PIXELFORMAT_PVRTC_2BPP_RGBA_1) {
-                    blockWidth = Math.floor(blockWidth / 2);
+                    blockWidth = Math.max(Math.floor(blockWidth / 2), 1);
                 }
 
                 result += blockWidth * blockHeight * blockDepth * blockSize;

--- a/src/math/curve-set.js
+++ b/src/math/curve-set.js
@@ -132,7 +132,7 @@ class CurveSet {
      * @param {number} precision - The number of samples to return.
      * @param {number} min - The minimum output value.
      * @param {number} max - The maximum output value.
-     * @returns {number[]} The set of quantized values.
+     * @returns {Float32Array} The set of quantized values.
      */
     quantizeClamped(precision, min, max) {
         var result = this.quantize(precision);

--- a/src/math/mat3.js
+++ b/src/math/mat3.js
@@ -1,3 +1,5 @@
+import { Vec3 } from './vec3.js';
+
 /**
  * @class
  * @name Mat3

--- a/src/resources/parser/glb-parser.js
+++ b/src/resources/parser/glb-parser.js
@@ -20,6 +20,7 @@ import {
     TYPE_INT8, TYPE_UINT8, TYPE_INT16, TYPE_UINT16, TYPE_INT32, TYPE_UINT32, TYPE_FLOAT32
 } from '../../graphics/constants.js';
 import { IndexBuffer } from '../../graphics/index-buffer.js';
+import { Texture } from '../../graphics/texture.js';
 import { VertexBuffer } from '../../graphics/vertex-buffer.js';
 import { VertexFormat } from '../../graphics/vertex-format.js';
 
@@ -315,18 +316,18 @@ var cloneTexture = function (texture) {
         return result;
     };
 
-    var result = new pc.Texture(texture.device, texture);   // duplicate texture
+    var result = new Texture(texture.device, texture);   // duplicate texture
     result._levels = shallowCopyLevels(texture);            // shallow copy the levels structure
     return result;
 };
 
 // given a texture asset, clone it
 var cloneTextureAsset = function (src) {
-    var result = new pc.Asset(src.name + '_clone',
-                              src.type,
-                              src.file,
-                              src.data,
-                              src.options);
+    var result = new Asset(src.name + '_clone',
+                           src.type,
+                           src.file,
+                           src.data,
+                           src.options);
     result.loaded = true;
     result.resource = cloneTexture(src.resource);
     src.registry.add(result);

--- a/src/resources/template.js
+++ b/src/resources/template.js
@@ -18,7 +18,7 @@ class TemplateHandler {
 
         var assets = this._app.assets;
 
-        http.get(url.load, function (err, response) {
+        http.get(url.load, {}, function (err, response) {
             if (err) {
                 callback("Error requesting template: " + url.original);
             } else {

--- a/src/scene/camera.js
+++ b/src/scene/camera.js
@@ -320,9 +320,17 @@ class Camera {
      * @returns {Camera} A cloned Camera.
      */
     clone() {
-        return new this.constructor().copy(this);
+        return new Camera().copy(this);
     }
 
+    /**
+     * @private
+     * @function
+     * @name Camera#copy
+     * @param {Camera} other - Camera to copy.
+     * @description Copies one camera to another.
+     * @returns {Camera} Self for chaining.
+     */
     copy(other) {
         this.aspectRatio = other.aspectRatio;
         this.aspectRatioMode = other.aspectRatioMode;
@@ -349,6 +357,7 @@ class Camera {
         this.renderTarget = other.renderTarget;
         this.scissorRect = other.scissorRect;
         this.vrDisplay = other.vrDisplay;
+        return this;
     }
 
     _updateViewProjMat() {

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -420,7 +420,7 @@ class Scene extends EventHandler {
             if (!this.skyboxRotation.equals(Quat.IDENTITY)) {
                 if (!this._skyboxRotationMat4) this._skyboxRotationMat4 = new Mat4();
                 if (!this._skyboxRotationMat3) this._skyboxRotationMat3 = new Mat3();
-                this._skyboxRotationMat4.setTRS(pc.Vec3.ZERO, this._skyboxRotation, pc.Vec3.ONE);
+                this._skyboxRotationMat4.setTRS(Vec3.ZERO, this._skyboxRotation, Vec3.ONE);
                 this._skyboxRotationMat4.invertTo3x3(this._skyboxRotationMat3);
                 material.setParameter("cubeMapRotationMatrix", this._skyboxRotationMat3.data);
             }

--- a/src/scene/skin-partition.js
+++ b/src/scene/skin-partition.js
@@ -24,6 +24,8 @@ class SkinPartition {
         // to this particular partition. speeds up checking for duplicate vertices so we don't
         // add the same vertex more than once.
         this.indexMap = {};
+
+        this.originalMesh = null;
     }
 
     addVertex(vertex, idx, vertexArray) {

--- a/src/shape/bounding-sphere.js
+++ b/src/shape/bounding-sphere.js
@@ -2,8 +2,6 @@ import { Vec3 } from '../math/vec3.js';
 
 var tmpVecA = new Vec3();
 var tmpVecB = new Vec3();
-var tmpVecC = new Vec3();
-var tmpVecD = new Vec3();
 
 /**
  * @class
@@ -26,49 +24,6 @@ class BoundingSphere {
         var lenSq = tmpVecA.sub2(point, this.center).lengthSq();
         var r = this.radius;
         return lenSq < r * r;
-    }
-
-    compute(vertices) {
-        var i;
-        var numVerts = vertices.length / 3;
-
-        var vertex = tmpVecA;
-        var avgVertex = tmpVecB;
-        var sum = tmpVecC;
-
-        // FIRST PASS:
-        // Find the "average vertex", which is the sphere's center...
-
-        for (i = 0; i < numVerts; i++) {
-            vertex.set(vertices[i * 3], vertices[i * 3 + 1], vertices[i * 3 + 2]);
-            sum.addSelf(vertex);
-
-            // apply a part-result to avoid float-overflows
-            if (i % 100 === 0) {
-                sum.scale(1 / numVerts);
-                avgVertex.add(sum);
-                sum.set(0, 0, 0);
-            }
-        }
-
-        sum.scale(1 / numVerts);
-        avgVertex.add(sum);
-
-        this.center.copy(avgVertex);
-
-        // SECOND PASS:
-        // Find the maximum (squared) distance of all vertices to the center...
-        var maxDistSq = 0;
-        var centerToVert = tmpVecD;
-
-        for (i = 0; i < numVerts; i++) {
-            vertex.set(vertices[i * 3], vertices[i * 3 + 1], vertices[i * 3 + 2]);
-
-            centerToVert.sub2(vertex, this.center);
-            maxDistSq = Math.max(centerToVert.lengthSq(), maxDistSq);
-        }
-
-        this.radius = Math.sqrt(maxDistSq);
     }
 
     /**

--- a/src/xr/xr-input-source.js
+++ b/src/xr/xr-input-source.js
@@ -278,7 +278,7 @@ class XrInputSource extends EventHandler {
      * @function
      * @name XrInputSource#getRotation
      * @description Get the world space rotation of input source if it is handheld ({@link XrInputSource#grip} is true). Otherwise it will return null.
-     * @returns {Vec3|null} The world space rotation of handheld input source.
+     * @returns {Quat|null} The world space rotation of handheld input source.
      */
     getRotation() {
         if (! this._rotation) return null;


### PR DESCRIPTION
After enabling `checkJs` in VS Code, the following were fixed:

* Removed several uses of `pc.` in the codebase.
* Various missing tags, typos and type errors in JSDocs.
* Incorrect number of args for `Math.floor`.
* Removed `BoundingSphere#compute` which has been completely broken (and private) for years.
* Removed occurrences of non-existent and unused property `Texture#_prefilteredMips`.
* Switched context lost/restore handlers to arrow functions.
* Add missing imports.
* Fixes `npm run tsd` on Windows. You can't insert semi-colons in `package.json` scripts. You need to use `&&` instead.

Note that this is only a small fraction of errors/warnings reported by `checkJs`. Hopefully, this is already a testament to the value of the work to enable it.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
