### PR TITLE
Add/use init methods for ScriptType and EventHandler

### DIFF
--- a/src/core/event-handler.js
+++ b/src/core/event-handler.js
@@ -16,6 +16,10 @@
  */
 class EventHandler {
     constructor() {
+        this.initEventHandler();
+    }
+
+    initEventHandler() {
         this._callbacks = { };
         this._callbackActive = { };
     }

--- a/src/script/script-type.js
+++ b/src/script/script-type.js
@@ -48,7 +48,10 @@ var funcNameRegex = new RegExp('^\\s*function(?:\\s|\\s*\\/\\*.*\\*\\/\\s*)+([^\
 class ScriptType extends EventHandler {
     constructor(args) {
         super();
+        this.initScriptType(args);
+    }
 
+    initScriptType(args) {
         var script = this.constructor; // get script type, i.e. function (class)
 
         // #ifdef DEBUG

--- a/src/script/script.js
+++ b/src/script/script.js
@@ -1,3 +1,5 @@
+import { EventHandler } from '../core/event-handler.js';
+
 import { ScriptHandler } from '../resources/script.js';
 
 import { script } from '../framework/script.js';
@@ -5,7 +7,6 @@ import { Application } from '../framework/application.js';
 
 import { ScriptAttributes } from './script-attributes.js';
 import { ScriptType } from './script-type.js';
-import { EventHandler } from '../core/event-handler.js';
 
 const reservedScriptNames = new Set([
     'system', 'entity', 'create', 'destroy', 'swap', 'move',

--- a/src/script/script.js
+++ b/src/script/script.js
@@ -5,6 +5,7 @@ import { Application } from '../framework/application.js';
 
 import { ScriptAttributes } from './script-attributes.js';
 import { ScriptType } from './script-type.js';
+import { EventHandler } from '../core/event-handler.js';
 
 const reservedScriptNames = new Set([
     'system', 'entity', 'create', 'destroy', 'swap', 'move',
@@ -61,7 +62,8 @@ function createScript(name, app) {
         throw new Error('script name: \'' + name + '\' is reserved, please change script name');
 
     var scriptType = function (args) {
-        ScriptType.call(this, args);
+        EventHandler.prototype.initEventHandler.call(this);
+        ScriptType.prototype.initScriptType.call(this, args);
     };
 
     scriptType.prototype = Object.create(ScriptType.prototype);


### PR DESCRIPTION
Fixes https://github.com/playcanvas/engine/issues/2871

@willeastcott PR: https://github.com/playcanvas/engine/pull/2872

Tested ES5 and ES6 scripts with `playcanvas.js` and `playcanvas.mjs`

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
