### PR TITLE
Migrate WebXR Hands to new Specs

### DIFF
--- a/src/xr/xr-hand.js
+++ b/src/xr/xr-hand.js
@@ -179,7 +179,7 @@ class XrHand extends EventHandler {
      * @function
      * @name XrHand#getJointById
      * @description Returns joint by XRHand id from list in specs: https://immersive-web.github.io/webxr-hand-input/
-     * @param {number} id - id of a joint based on specs ID's in XRHand: https://immersive-web.github.io/webxr-hand-input/
+     * @param {string} id - id of a joint based on specs ID's in XRHand: https://immersive-web.github.io/webxr-hand-input/
      * @returns {XrJoint|null} Joint or null if not available
      */
     getJointById(id) {

--- a/src/xr/xr-hand.js
+++ b/src/xr/xr-hand.js
@@ -15,11 +15,11 @@ var vecC = new Vec3();
 
 if (window.XRHand) {
     fingerJointIds = [
-        [XRHand.THUMB_METACARPAL, XRHand.THUMB_PHALANX_PROXIMAL, XRHand.THUMB_PHALANX_DISTAL, XRHand.THUMB_PHALANX_TIP],
-        [XRHand.INDEX_METACARPAL, XRHand.INDEX_PHALANX_PROXIMAL, XRHand.INDEX_PHALANX_INTERMEDIATE, XRHand.INDEX_PHALANX_DISTAL, XRHand.INDEX_PHALANX_TIP],
-        [XRHand.MIDDLE_METACARPAL, XRHand.MIDDLE_PHALANX_PROXIMAL, XRHand.MIDDLE_PHALANX_INTERMEDIATE, XRHand.MIDDLE_PHALANX_DISTAL, XRHand.MIDDLE_PHALANX_TIP],
-        [XRHand.RING_METACARPAL, XRHand.RING_PHALANX_PROXIMAL, XRHand.RING_PHALANX_INTERMEDIATE, XRHand.RING_PHALANX_DISTAL, XRHand.RING_PHALANX_TIP],
-        [XRHand.LITTLE_METACARPAL, XRHand.LITTLE_PHALANX_PROXIMAL, XRHand.LITTLE_PHALANX_INTERMEDIATE, XRHand.LITTLE_PHALANX_DISTAL, XRHand.LITTLE_PHALANX_TIP]
+        ['thumb-metacarpal', 'thumb-phalanx-proximal', 'thumb-phalanx-distal', 'thumb-tip'],
+        ['index-finger-metacarpal', 'index-finger-phalanx-proximal', 'index-finger-phalanx-intermediate', 'index-finger-phalanx-distal', 'index-finger-tip'],
+        ['middle-finger-metacarpal', 'middle-finger-phalanx-proximal', 'middle-finger-phalanx-intermediate', 'middle-finger-phalanx-distal', 'middle-finger-tip'],
+        ['ring-finger-metacarpal', 'ring-finger-phalanx-proximal', 'ring-finger-phalanx-intermediate', 'ring-finger-phalanx-distal', 'ring-finger-tip'],
+        ['pinky-finger-metacarpal', 'pinky-finger-phalanx-proximal', 'pinky-finger-phalanx-intermediate', 'pinky-finger-phalanx-distal', 'pinky-finger-tip']
     ];
 }
 
@@ -53,15 +53,15 @@ class XrHand extends EventHandler {
 
         this._wrist = null;
 
-        if (xrHand[XRHand.WRIST])
-            this._wrist = new XrJoint(0, XRHand.WRIST, this, null);
+        if (xrHand.get('wrist'))
+            this._wrist = new XrJoint(0, 'wrist', this, null);
 
         for (var f = 0; f < fingerJointIds.length; f++) {
             var finger = new XrFinger(f, this);
 
             for (var j = 0; j < fingerJointIds[f].length; j++) {
                 var jointId = fingerJointIds[f][j];
-                if (! xrHand[jointId]) continue;
+                if (! xrHand.get(jointId)) continue;
                 new XrJoint(j, jointId, this, finger);
             }
         }
@@ -85,7 +85,7 @@ class XrHand extends EventHandler {
         // joints
         for (var j = 0; j < this._joints.length; j++) {
             var joint = this._joints[j];
-            var jointSpace = xrInputSource.hand[joint._id];
+            var jointSpace = xrInputSource.hand.get(joint._id);
             if (jointSpace) {
                 var pose = frame.getJointPose(jointSpace, this._manager._referenceSpace);
                 if (pose) {
@@ -107,12 +107,12 @@ class XrHand extends EventHandler {
             }
         }
 
-        var j1 = this._jointsById[XRHand.THUMB_METACARPAL];
-        var j4 = this._jointsById[XRHand.THUMB_PHALANX_TIP];
-        var j6 = this._jointsById[XRHand.INDEX_PHALANX_PROXIMAL];
-        var j9 = this._jointsById[XRHand.INDEX_PHALANX_TIP];
-        var j16 = this._jointsById[XRHand.RING_PHALANX_PROXIMAL];
-        var j21 = this._jointsById[XRHand.LITTLE_PHALANX_PROXIMAL];
+        var j1 = this._jointsById['thumb-metacarpal'];
+        var j4 = this._jointsById['thumb-tip'];
+        var j6 = this._jointsById['index-finger-phalanx-proximal'];
+        var j9 = this._jointsById['index-finger-tip'];
+        var j16 = this._jointsById['ring-finger-phalanx-proximal'];
+        var j21 = this._jointsById['pinky-finger-phalanx-proximal'];
 
         // ray
         if (j1 && j4 && j6 && j9 && j16 && j21) {

--- a/src/xr/xr-joint.js
+++ b/src/xr/xr-joint.js
@@ -22,7 +22,7 @@ for (var i = 0; i < tipJointIds.length; i++) {
  * @classdesc Represents joint of a finger
  * @description Represents joint of a finger
  * @param {number} index - Index of a joint within a finger
- * @param {number} id - Id of a joint based on XRHand specs
+ * @param {string} id - Id of a joint based on WebXR Hand Input Specs
  * @param {XrHand} hand - Hand that joint relates to
  * @param {XrFinger} [finger] - Finger that joint is related to, can be null in case of wrist joint
  * @property {number} index Index of a joint within a finger, starting from 0 (root of a finger) all the way to tip of the finger

--- a/src/xr/xr-joint.js
+++ b/src/xr/xr-joint.js
@@ -3,11 +3,11 @@ import { Quat } from '../math/quat.js';
 import { Vec3 } from '../math/vec3.js';
 
 var tipJointIds = window.XRHand ? [
-    XRHand.THUMB_PHALANX_TIP,
-    XRHand.INDEX_PHALANX_TIP,
-    XRHand.MIDDLE_PHALANX_TIP,
-    XRHand.RING_PHALANX_TIP,
-    XRHand.LITTLE_PHALANX_TIP
+    'thumb-tip',
+    'index-finger-tip',
+    'middle-finger-tip',
+    'ring-finger-tip',
+    'pinky-finger-tip'
 ] : [];
 
 var tipJointIdsIndex = {};
@@ -44,7 +44,7 @@ class XrJoint {
         this._finger = finger;
         if (this._finger) this._finger._joints.push(this);
 
-        this._wrist = id === XRHand.WRIST;
+        this._wrist = id === 'wrist';
         if (this._wrist) this._hand._wrist = this;
 
         this._tip = this._finger && !! tipJointIdsIndex[id];


### PR DESCRIPTION
[WebXR Hand Input Module Level 1](https://immersive-web.github.io/webxr-hand-input/) has been updated, with changes the way joints are accessed from XRHand instance, now it is more Map like, with string IDs instead of numeric IDs.

This changes been deployed to Oculus Browser version 14.

PR has very minimal engine API change, that can affect few users:
```javascript
inputSource.hand.getJointById(id);
```
This now uses string ID, if developer used to provide hard coded ID's, then this will return `null`, and updating to string ID will be required by developer.

**Otherwise there is no code changes required by developer.**

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
