### PR TITLE
[FIX] Fix I18n#destroy

### DIFF
--- a/src/i18n/i18n.js
+++ b/src/i18n/i18n.js
@@ -264,7 +264,7 @@ class I18n extends EventHandler {
      * @name I18n#destroy
      * @description Frees up memory.
      */
-    destroy = function () {
+    destroy() {
         this._translations = null;
         this._availableLangs = null;
         this._assets = null;


### PR DESCRIPTION
Fix incorrectly defined `I18n#destroy` function. This bug has been present since the migration to ES6 classes.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
