### PR TITLE
Asset unload event moved to public API

### DIFF
--- a/src/asset/asset.js
+++ b/src/asset/asset.js
@@ -112,6 +112,13 @@ class Asset extends EventHandler {
 
     /**
      * @event
+     * @name Asset#unload
+     * @description Fired just before the asset unloads the resource.
+     * @param {Asset} asset - The asset that is due to be unloaded.
+     */
+
+    /**
+     * @event
      * @name Asset#remove
      * @description Fired when the asset is removed from the asset registry.
      * @param {Asset} asset - The asset that was removed.

--- a/src/asset/asset.js
+++ b/src/asset/asset.js
@@ -113,7 +113,7 @@ class Asset extends EventHandler {
     /**
      * @event
      * @name Asset#unload
-     * @description Fired just before the asset unloads the resource.
+     * @description Fired just before the asset unloads the resource. This allows for the opportunity to prepare for an asset that will be unloaded. E.g. Changing the texture of a model to a default before the one it was using is unloaded.
      * @param {Asset} asset - The asset that is due to be unloaded.
      */
 


### PR DESCRIPTION
Proposal to move the event to public API

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
