### PR TITLE
[Fix] Updated handling of ovrride clear settings on the layer

### DIFF
--- a/src/scene/forward-renderer.js
+++ b/src/scene/forward-renderer.js
@@ -3066,8 +3066,8 @@ class ForwardRenderer {
 
             if (camera) {
 
-                // Each camera must only clear each render target once
-                if (renderAction.firstCameraUse) {
+                // clear buffers
+                if (renderAction.clearColor || renderAction.clearDepth || renderAction.clearStencil) {
 
                     // TODO: refactor clearView to accept flags from renderAction directly as well
                     const backupColor = camera.camera._clearColorBuffer;

--- a/src/scene/layer-composition.js
+++ b/src/scene/layer-composition.js
@@ -349,6 +349,11 @@ class LayerComposition extends EventHandler {
             let clearDepth = cameraFirstRenderAction ? camera.clearDepthBuffer : false;
             let clearStencil = cameraFirstRenderAction ? camera.clearStencilBuffer : false;
 
+            // clear buffers if requested by the layer
+            clearColor |= layer.clearColorBuffer;
+            clearDepth |= layer.clearDepthBuffer;
+            clearStencil |= layer.clearStencilBuffer;
+
             // for cameras with post processing enabled, on layers after post processing has been applied already (so UI and similar),
             // don't render them to render target anymore
             if (postProcessMarked && camera.postEffectsEnabled) {

--- a/src/scene/layer.js
+++ b/src/scene/layer.js
@@ -1,9 +1,5 @@
 import { hashCode } from '../core/hash.js';
 
-import { Color } from '../math/color.js';
-
-import { CLEARFLAG_COLOR, CLEARFLAG_DEPTH, CLEARFLAG_STENCIL } from '../graphics/constants.js';
-
 import {
     BLEND_NONE,
     LAYER_FX,

--- a/src/scene/layer.js
+++ b/src/scene/layer.js
@@ -117,12 +117,9 @@ class InstanceList {
  * Defaults to {@link SHADER_FORWARD}.
  * @property {boolean} passThrough Tells that this layer is simple and needs to just render a bunch of mesh instances without lighting, skinning and morphing (faster).
  *
- * @property {boolean} overrideClear Defines if layer should use camera clear parameters (true) or ignore them and use {@link Layer#clearColor}, {@link Layer#clearColorBuffer},
- * {@link Layer#clearDepthBuffer} and {@link Layer#clearStencilBuffer}.
- * @property {Color} clearColor The color used to clear the canvas to before each camera starts to render.
- * @property {boolean} clearColorBuffer If true cameras will clear the color buffer to the color set in clearColor.
- * @property {boolean} clearDepthBuffer If true cameras will clear the depth buffer.
- * @property {boolean} clearStencilBuffer If true cameras will clear the stencil buffer.
+ * @property {boolean} clearColorBuffer If true the camera will clear the color buffer when it renders this layer.
+ * @property {boolean} clearDepthBuffer If true the camera will clear the depth buffer when it renders this layer.
+ * @property {boolean} clearStencilBuffer If true the camera will clear the stencil buffer when it renders this layer.
  *
  * @property {Layer} layerReference Make this layer render the same mesh instances that another layer does instead of having its own mesh instance list.
  * Both layers must share cameras. Frustum culling is only performed for one layer. Useful for rendering multiple passes using different shaders.
@@ -193,20 +190,10 @@ class Layer {
         // true if the layer is just pass-through meshInstance drawing - used for UI and Gizmo layers. The layers doesn't have lights, shadows, culling ..
         this.passThrough = options.passThrough === undefined ? false : options.passThrough;
 
-        this.overrideClear = options.overrideClear === undefined ? false : options.overrideClear;
-        this._clearColor = new Color(0, 0, 0, 1);
-        if (options.clearColor) {
-            this._clearColor.copy(options.clearColor);
-        }
-        this._clearColorBuffer = options.clearColorBuffer === undefined ? false : options.clearColorBuffer;
-        this._clearDepthBuffer = options.clearDepthBuffer === undefined ? false : options.clearDepthBuffer;
-        this._clearStencilBuffer = options.clearStencilBuffer === undefined ? false : options.clearStencilBuffer;
-        this._clearOptions = {
-            color: [this._clearColor.r, this._clearColor.g, this._clearColor.b, this._clearColor.a],
-            depth: 1,
-            stencil: 0,
-            flags: (this._clearColorBuffer ? CLEARFLAG_COLOR : 0) | (this._clearDepthBuffer ? CLEARFLAG_DEPTH : 0) | (this._clearStencilBuffer ? CLEARFLAG_STENCIL : 0)
-        };
+        // clear flags
+        this._clearColorBuffer = options.clearColorBuffer ? options.clearColorBuffer : false;
+        this._clearDepthBuffer = options.clearDepthBuffer ? options.clearDepthBuffer : false;
+        this._clearStencilBuffer = options.clearStencilBuffer ? options.clearStencilBuffer : false;
 
         this.onPreCull = options.onPreCull;
         this.onPreRender = options.onPreRender;
@@ -304,28 +291,13 @@ class Layer {
         this._clearColor.copy(val);
     }
 
-    _updateClearFlags() {
-        var flags = 0;
-
-        if (this._clearColorBuffer)
-            flags |= CLEARFLAG_COLOR;
-
-        if (this._clearDepthBuffer)
-            flags |= CLEARFLAG_DEPTH;
-
-        if (this._clearStencilBuffer)
-            flags |= CLEARFLAG_STENCIL;
-
-        this._clearOptions.flags = flags;
-    }
-
     get clearColorBuffer() {
         return this._clearColorBuffer;
     }
 
     set clearColorBuffer(val) {
         this._clearColorBuffer = val;
-        this._updateClearFlags();
+        this._dirtyCameras = true;
     }
 
     get clearDepthBuffer() {
@@ -334,7 +306,7 @@ class Layer {
 
     set clearDepthBuffer(val) {
         this._clearDepthBuffer = val;
-        this._updateClearFlags();
+        this._dirtyCameras = true;
     }
 
     get clearStencilBuffer() {
@@ -343,7 +315,7 @@ class Layer {
 
     set clearStencilBuffer(val) {
         this._clearStencilBuffer = val;
-        this._updateClearFlags();
+        this._dirtyCameras = true;
     }
 
     /**

--- a/src/scene/layer.js
+++ b/src/scene/layer.js
@@ -113,9 +113,9 @@ class InstanceList {
  * Defaults to {@link SHADER_FORWARD}.
  * @property {boolean} passThrough Tells that this layer is simple and needs to just render a bunch of mesh instances without lighting, skinning and morphing (faster).
  *
- * @property {boolean} clearColorBuffer If true the camera will clear the color buffer when it renders this layer.
- * @property {boolean} clearDepthBuffer If true the camera will clear the depth buffer when it renders this layer.
- * @property {boolean} clearStencilBuffer If true the camera will clear the stencil buffer when it renders this layer.
+ * @property {boolean} clearColorBuffer If true, the camera will clear the color buffer when it renders this layer.
+ * @property {boolean} clearDepthBuffer If true, the camera will clear the depth buffer when it renders this layer.
+ * @property {boolean} clearStencilBuffer If true, the camera will clear the stencil buffer when it renders this layer.
  *
  * @property {Layer} layerReference Make this layer render the same mesh instances that another layer does instead of having its own mesh instance list.
  * Both layers must share cameras. Frustum culling is only performed for one layer. Useful for rendering multiple passes using different shaders.

--- a/src/scene/picker.js
+++ b/src/scene/picker.js
@@ -254,14 +254,14 @@ class Picker {
             var layer;
             var layerCamId, transparent;
             for (i = 0; i < layers.length; i++) {
-                if (layers[i].overrideClear && layers[i]._clearDepthBuffer) layers[i]._pickerCleared = false;
+                if (layers[i]._clearDepthBuffer) layers[i]._pickerCleared = false;
             }
             for (i = 0; i < layers.length; i++) {
                 layer = layers[i];
                 if (layer.renderTarget !== sourceRt || !layer.enabled || !subLayerEnabled[i]) continue;
                 layerCamId = layer.cameras.indexOf(camera);
                 if (layerCamId < 0) continue;
-                if (layer.overrideClear && layer._clearDepthBuffer && !layer._pickerCleared) {
+                if (layer._clearDepthBuffer && !layer._pickerCleared) {
                     this.meshInstances.push(this.clearDepthCommand);
                     layer._pickerCleared = true;
                 }


### PR DESCRIPTION
Fixed changes in https://github.com/playcanvas/engine/pull/2882
This fixes the gizmos rendering correctly in Editor (depth buffer was not cleared and so gizmos were depth tested instead of sitting on top)

- Layer. overrideClear and Layer.clearColor are removed as unused, confusing and very unlikely useful
- LayerComposition honors clear flags set on layer in addition to camera
