### PR TITLE
Enable type-checking in VS Code

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,9 @@
+{
+    "compilerOptions": {
+        "baseUrl": ".",
+        "checkJs": true,
+        "module": "es6",
+        "target": "es6"
+    },
+    "include": ["src/**/*"]
+}


### PR DESCRIPTION
This PR introduces a `jsconfig.json`. It enables static type-checking in VS Code:

![image](https://user-images.githubusercontent.com/697563/108768732-f0568400-754f-11eb-92ef-6f3d6ce03586.png)

See [this](https://code.visualstudio.com/docs/nodejs/working-with-javascript) page for more details.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
