### PR TITLE
[Fix] when no projection is set for 2d texture, equirect is assumed

### DIFF
--- a/src/graphics/reproject-texture.js
+++ b/src/graphics/reproject-texture.js
@@ -30,7 +30,7 @@ function getCoding(texture) {
 
 function getProjectionName(projection) {
     // default to equirect if not specified
-    if (!projection || projection === TEXTUREPROJECTION_NONE) {
+    if (projection === TEXTUREPROJECTION_NONE) {
         projection = TEXTUREPROJECTION_EQUIRECT;
     }
     switch (projection) {

--- a/src/graphics/reproject-texture.js
+++ b/src/graphics/reproject-texture.js
@@ -30,7 +30,7 @@ function getCoding(texture) {
 
 function getProjectionName(projection) {
     // default to equirect if not specified
-    if (projection === TEXTUREPROJECTION_NONE) {
+    if (!projection || projection === TEXTUREPROJECTION_NONE) {
         projection = TEXTUREPROJECTION_EQUIRECT;
     }
     switch (projection) {

--- a/src/graphics/texture.js
+++ b/src/graphics/texture.js
@@ -185,7 +185,7 @@ class Texture {
 
             if (this._cubemap) {
                 this.projection = TEXTUREPROJECTION_CUBE;
-            } else if (options.projection !== TEXTUREPROJECTION_CUBE) {
+            } else if (options.projection && options.projection !== TEXTUREPROJECTION_CUBE) {
                 this.projection = options.projection;
             }
 


### PR DESCRIPTION
Fixes viewer loading equirect envmaps