### PR TITLE
Explicitly include files in the NPM package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,9 +1,0 @@
-.*
-/examples
-/extras
-/src
-/tests
-/conf-api.json
-/conf-tsd.json
-/externs.js
-/rollup.config.js

--- a/package.json
+++ b/package.json
@@ -35,6 +35,20 @@
     "examples/lib/*", 
     "src/polyfill/*"
   ], 
+  "files": [
+    "build/playcanvas.js",
+    "build/playcanvas.min.js",
+    "build/playcanvas.mjs",
+    "build/playcanvas.dbg.js",
+    "build/playcanvas.prf.js",
+    "build/playcanvas.d.ts",
+    "build/playcanvas-extras.js",
+    "index.d.ts",
+    "LICENSE",
+    "package.json",
+    "README.md",
+    "README-zh.md"
+  ],
   "devDependencies": {
     "@babel/core": "7.12.13", 
     "@babel/plugin-proposal-class-properties": "7.12.13", 


### PR DESCRIPTION
Until now, we've relied on the `.npmignore` file to exclude unwanted files from our NPM module when doing `npm publish`. However, if you accidentally have superfluous files/folders in your local clone of the repo, they can end up being included.

This PR removes the `.npmignore` and explicitly lists the only files that should be included in the module. This will help avoid mistakes in the future.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
