### PR TITLE
Remove index.d.ts file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,0 @@
-/// <reference path="build/playcanvas.d.ts" />
-
-export = pc;

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "license": "MIT", 
   "main": "build/playcanvas.js", 
   "module": "build/playcanvas.mjs", 
-  "types": "index.d.ts", 
+  "types": "build/playcanvas.d.ts", 
   "bugs": {
     "url": "https://github.com/playcanvas/engine/issues"
   }, 


### PR DESCRIPTION
This PR removes the `index.d.ts` file. It should now be unnecessary because the `playcanvas.d.ts` file now exports the `pc` namespace:

```typescript
export as namespace pc;
```

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
