### PR TITLE
Basis texture load should error if the Basis module isn't present

### DIFF
--- a/src/asset/asset.js
+++ b/src/asset/asset.js
@@ -8,7 +8,6 @@ import { findAvailableLocale } from '../i18n/utils.js';
 import { ABSOLUTE_URL } from './constants.js';
 import { AssetVariants } from './asset-variants.js';
 import { getApplication } from '../framework/globals.js';
-import { isBasisAvailable } from '../resources/basis.js';
 
 // auto incrementing number for asset ids
 var assetIdCounter = -1;
@@ -202,10 +201,9 @@ class Asset extends EventHandler {
                     // if the device supports the variant
                     if (! device[VARIANT_SUPPORT[variant]]) continue;
 
-                    var variantFile = this.file.variants[variant];
                     // if the variant exists in the asset then just return it
-                    if (variantFile && (path.getExtension(variantFile.url) !== '.basis' || isBasisAvailable())) {
-                        return variantFile;
+                    if (this.file.variants[variant]) {
+                        return this.file.variants[variant];
                     }
 
                     // if the variant does not exist but the asset is in a bundle

--- a/src/asset/asset.js
+++ b/src/asset/asset.js
@@ -8,6 +8,7 @@ import { findAvailableLocale } from '../i18n/utils.js';
 import { ABSOLUTE_URL } from './constants.js';
 import { AssetVariants } from './asset-variants.js';
 import { getApplication } from '../framework/globals.js';
+import { isBasisAvailable } from '../resources/basis.js';
 
 // auto incrementing number for asset ids
 var assetIdCounter = -1;
@@ -201,9 +202,10 @@ class Asset extends EventHandler {
                     // if the device supports the variant
                     if (! device[VARIANT_SUPPORT[variant]]) continue;
 
+                    var variantFile = this.file.variants[variant];
                     // if the variant exists in the asset then just return it
-                    if (this.file.variants[variant]) {
-                        return this.file.variants[variant];
+                    if (variantFile && (path.getExtension(variantFile.url) !== '.basis' || isBasisAvailable())) {
+                        return variantFile;
                     }
 
                     // if the variant does not exist but the asset is in a bundle

--- a/src/resources/basis.js
+++ b/src/resources/basis.js
@@ -482,8 +482,8 @@ function basisDownloadFromConfig(callback) {
             // #endif
             return false;
         }
-        return true;
     }
+    return true;
 }
 
 // render thread worker manager

--- a/src/resources/basis.js
+++ b/src/resources/basis.js
@@ -456,6 +456,7 @@ function basisSetDownloadConfig(glueUrl, wasmUrl, fallbackUrl) {
 }
 
 // search for wasm module in the global config and initialize basis
+// returns true if it can find the module
 function basisDownloadFromConfig(callback) {
     if (downloadConfig) {
         // config was user-specified
@@ -475,10 +476,13 @@ function basisDownloadFromConfig(callback) {
                           urlBase + wasmModule.wasmUrl,
                           urlBase + wasmModule.fallbackUrl,
                           callback);
+
+            return true;
         } else {
             // #ifdef DEBUG
             console.warn("WARNING: unable to load basis wasm module - no config was specified");
             // #endif
+            return false;
         }
     }
 }
@@ -488,31 +492,20 @@ function basisDownloadFromConfig(callback) {
 //   unswizzleGGGR - convert the two-component GGGR normal data to RGB
 //                   and pack into 565 format. this is used to overcome
 //                   quality issues on apple devices.
+// returns true if a transcode module is found
 function basisTranscode(url, data, callback, options) {
     if (!worker) {
         // store transcode job if no worker exists
         transcodeQueue.push({ url: url, data: data, callback: callback, options: options });
         // if the basis module download has not yet been initiated, do so now
         if (!downloadInitiated) {
-            basisDownloadFromConfig();
+            return basisDownloadFromConfig();
         }
     } else {
         transcode(url, data, callback, options);
     }
-}
 
-function isBasisAvailable() {
-    if (downloadConfig) {
-        return true;
-    } else {
-        // get config from global PC config structure
-        var modules = (window.config ? window.config.wasmModules : window.PRELOAD_MODULES) || [];
-        var wasmModule = modules.find(function (m) {
-            return m.moduleName === 'BASIS';
-        });
-
-        return !!wasmModule;
-    }
+    return true;
 }
 
 export {
@@ -521,6 +514,5 @@ export {
     basisDownloadFromConfig,
     basisInitialize,
     basisTargetFormat,
-    basisTranscode,
-    isBasisAvailable
+    basisTranscode
 };

--- a/src/resources/basis.js
+++ b/src/resources/basis.js
@@ -478,12 +478,13 @@ function basisDownloadFromConfig(callback) {
                           callback);
 
             return true;
-        } else {
-            // #ifdef DEBUG
-            console.warn("WARNING: unable to load basis wasm module - no config was specified");
-            // #endif
-            return false;
         }
+
+        // #ifdef DEBUG
+        console.warn("WARNING: unable to load basis wasm module - no config was specified");
+        // #endif
+
+        return false;
     }
 }
 

--- a/src/resources/basis.js
+++ b/src/resources/basis.js
@@ -501,11 +501,26 @@ function basisTranscode(url, data, callback, options) {
     }
 }
 
+function isBasisAvailable() {
+    if (downloadConfig) {
+        return true;
+    } else {
+        // get config from global PC config structure
+        var modules = (window.config ? window.config.wasmModules : window.PRELOAD_MODULES) || [];
+        var wasmModule = modules.find(function (m) {
+            return m.moduleName === 'BASIS';
+        });
+
+        return !!wasmModule;
+    }
+}
+
 export {
     basisDownload,
     basisSetDownloadConfig,
     basisDownloadFromConfig,
     basisInitialize,
     basisTargetFormat,
-    basisTranscode
+    basisTranscode,
+    isBasisAvailable
 };

--- a/src/resources/basis.js
+++ b/src/resources/basis.js
@@ -476,15 +476,13 @@ function basisDownloadFromConfig(callback) {
                           urlBase + wasmModule.wasmUrl,
                           urlBase + wasmModule.fallbackUrl,
                           callback);
-
-            return true;
+        } else {
+            // #ifdef DEBUG
+            console.warn("WARNING: unable to load basis wasm module - no config was specified");
+            // #endif
+            return false;
         }
-
-        // #ifdef DEBUG
-        console.warn("WARNING: unable to load basis wasm module - no config was specified");
-        // #endif
-
-        return false;
+        return true;
     }
 }
 

--- a/src/resources/parser/texture/basis.js
+++ b/src/resources/parser/texture/basis.js
@@ -45,7 +45,7 @@ class BasisParser {
                     var basisModuleFound = basisTranscode(url.load, result, callback, { unswizzleGGGR: unswizzleGGGR });
 
                     if (!basisModuleFound) {
-                        callback('WARNING: Basis module not found. ' + asset.name + ' texture will not be loaded');
+                        callback('Basis module not found. Asset "' + asset.name + '" basis texture variant will not be loaded.');
                     }
                 }
             }

--- a/src/resources/parser/texture/basis.js
+++ b/src/resources/parser/texture/basis.js
@@ -42,7 +42,11 @@ class BasisParser {
                         // remove the swizzled flag from the asset
                         asset.file.variants.basis.opt &= ~8;
                     }
-                    basisTranscode(url.load, result, callback, { unswizzleGGGR: unswizzleGGGR });
+                    var basisModuleFound = basisTranscode(url.load, result, callback, { unswizzleGGGR: unswizzleGGGR });
+
+                    if (!basisModuleFound) {
+                        callback('WARNING: Basis module not found. ' + asset.name + ' texture will not be loaded');
+                    }
                 }
             }
         );


### PR DESCRIPTION
Edit: Tue 2 Mar 2021

PR updated after discussion with @slimbuck and @mvaligursky.

The Basis texture loader should error out the load if Basis module is not found/loaded. This allows the asset loader to progress rather than waiting on a basis transcode that won't call the callback.

The app will then able to progress pass the preloading screen, just with missing textures.

![image](https://user-images.githubusercontent.com/16639049/109694065-46e04580-7b82-11eb-9c6b-d30b5f4b3c37.png)

---

Draft PR to discuss implementation:

The check here is inefficient and also adds a dependency on basis to the asset which I'm not too keen on. Especially if we are thinking of doing tree shaking/specialised builds.

Ideally, I would like to do the logic in `isBasisAvailable` once on pc.Application creation and store it as a flag there instead. Also not keen on getting the extension each time and wonder if that should be cached in the asset/file object?


I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
