### PR TITLE
collision system fix

### DIFF
--- a/src/framework/components/collision/system.js
+++ b/src/framework/components/collision/system.js
@@ -169,7 +169,6 @@ class CollisionSystemImpl {
     remove(entity, data) {
         var app = this.system.app;
         if (entity.rigidbody && entity.rigidbody.body) {
-            app.systems.rigidbody.removeBody(entity.rigidbody.body);
             entity.rigidbody.disableSimulation();
         }
 


### PR DESCRIPTION
Currently the collision component system implementation removes a rigidbody from the dynamics world:
![image](https://user-images.githubusercontent.com/5677782/109653909-3d4ae380-7b6a-11eb-884d-24c2b1e73fa6.png)

It does so by calling `removeBody()` method of the rigidbody component system directly. It then calls `disableSimulation()` on the component, which again calls `removeBody()` inside of it (if simulation is enabled), which makes it a double request to the dynamics world to remove the same body.

I removed the first call to the `removeBody()`, assuming that if during the next call of `disableSimulation()` the simulation is disabled, then the body is not in the world. If I understand correctly, the only way currently to disable a simulation is by also removing the body from the world. As such, if the simulation is disabled, we can assume the body is not there and does not need to be removed.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
