### PR TITLE
eulers fix

### DIFF
--- a/src/math/mat4.js
+++ b/src/math/mat4.js
@@ -1225,6 +1225,9 @@ class Mat4 {
         sy = scale.y;
         sz = scale.z;
 
+        if (sx === 0 || sy === 0)
+            return eulers.set(0, 0, 0);
+
         m = this.data;
 
         y = Math.asin(-m[2] / sx);

--- a/src/math/mat4.js
+++ b/src/math/mat4.js
@@ -1225,7 +1225,7 @@ class Mat4 {
         sy = scale.y;
         sz = scale.z;
 
-        if (sx === 0 || sy === 0)
+        if (sx === 0 || sy === 0 || sz === 0)
             return eulers.set(0, 0, 0);
 
         m = this.data;


### PR DESCRIPTION
Fixes #2911 

If an entity scale is 0, the `getEulerAngles()` returns a vector with invalid (NaN) components. This change adds a check and sets eulers to 0 if scale is 0 on X or Y axis.

```js
entity.setLocalScale(0, 0, 0);
entity.setEulerAngles(10, 10, 10);
    
console.log(entity.getEulerAngles()); // Vec3 { x: NaN, y: NaN, z: 0 }
```

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
