### PR TITLE
Shadow culling and rendering refactor

### DIFF
--- a/examples/graphics/lights.html
+++ b/examples/graphics/lights.html
@@ -35,7 +35,9 @@
         var canvas = document.getElementById("application-canvas");
 
         // Create the application and start the update loop
-        var app = new pc.Application(canvas);
+        var app = new pc.Application(canvas, {
+            keyboard: new pc.Keyboard(window)
+        });
         app.start();
 
         // Set the canvas to fill the window and automatically change resolution to be the same as the canvas size
@@ -71,6 +73,7 @@
         });
         camera.translate(0, 7, 24);
         camera.rotate(0, 0, 0);
+        app.root.addChild(camera);
 
         // Create an Entity for the ground
         var ground = new pc.Entity();
@@ -81,20 +84,21 @@
         ground.setLocalPosition(0, -0.5, 0);
 
         var material = createMaterial({
-            ambient: new pc.Color(0.1, 0.4, 0.1),
-            diffuse: new pc.Color(0.1, 0.4, 0.1)
+            ambient: pc.Color.GRAY,
+            diffuse: pc.Color.GRAY
         });
         ground.model.material = material;
+        app.root.addChild(ground);
 
         // Create an spot light
-        var light = new pc.Entity();
-        light.addComponent("light", {
+        var spotlight = new pc.Entity();
+        spotlight.addComponent("light", {
             type: "spot",
-            color: new pc.Color(1, 1, 1),
+            color: pc.Color.WHITE,
             outerConeAngle: 60,
             innerConeAngle: 40,
             range: 100,
-            intensity: 1,
+            intensity: 0.6,
             castShadows: true,
             shadowBias: 0.005,
             normalOffsetBias: 0.01,
@@ -105,48 +109,110 @@
         cone.addComponent("model", {
             type: "cone"
         });
-        cone.model.material = createMaterial({ emissive: new pc.Color(1, 1, 1) });
-        light.addChild(cone);
+        cone.model.material = createMaterial({ emissive: pc.Color.WHITE });
+        spotlight.addChild(cone);
+        app.root.addChild(spotlight);
 
         // Create a point light
         var pointlight = new pc.Entity();
         pointlight.addComponent("light", {
             type: "point",
-            color: new pc.Color(0, 0, 1),
+            color: pc.Color.YELLOW,
             range: 100,
-            intensity: 1
+            castShadows: true,
+            intensity: 0.6
         });
         pointlight.addComponent("model", {
             type: "sphere"
         });
-        pointlight.model.material = createMaterial({ diffuse: new pc.Color(0, 0, 0), emissive: new pc.Color(0, 0, 1) });
-
-        // Add Entities into the scene hierarchy
-        app.root.addChild(camera);
-        app.root.addChild(light);
+        pointlight.model.material = createMaterial({ diffuse: new pc.Color(0, 0, 0), emissive: pc.Color.YELLOW });
         app.root.addChild(pointlight);
-        app.root.addChild(ground);
+
+        // Create a directional light
+        var directionallight = new pc.Entity();
+        directionallight.addComponent("light", {
+            type: "directional",
+            color: pc.Color.CYAN,
+            range: 100,
+            castShadows: true,
+            shadowBias: 0.05,
+            normalOffsetBias: 0.1,
+            intensity: 0.6
+        });
+        app.root.addChild(directionallight);
+
+
+        // Create a 2D screen for text rendering
+        var screen = new pc.Entity();
+        screen.addComponent("screen", {
+            referenceResolution: new pc.Vec2(1280, 720),
+            scaleBlend: 0.5,
+            scaleMode: pc.SCALEMODE_BLEND,
+            screenSpace: true
+        });
+        app.root.addChild(screen);
+
+        // Load a font
+        var fontAsset = new pc.Asset('arial.json', "font", {
+            url: "../assets/fonts/arial.json"
+        });
+        fontAsset.on('load', onFontLoaded);
+        app.assets.add(fontAsset);
+        app.assets.load(fontAsset);
+
+        // When the font is loaded, create text to show which lights are enabled
+        var text;
+        function onFontLoaded() {
+            // Create a basic text element
+            text = new pc.Entity();
+            text.addComponent("element", {
+                anchor: new pc.Vec4(0.1, 0.1, 0.5, 0.5),
+                fontAsset: fontAsset,
+                fontSize: 28,
+                pivot: new pc.Vec2(0.5, 0.1),
+                type: pc.ELEMENTTYPE_TEXT,
+                alignment: pc.Vec2.ZERO
+            });
+            screen.addChild(text);
+        }
+
+        // Allow user to toggle individual lights
+        app.keyboard.on("keydown", function (e) {
+            switch (e.key) {
+                case pc.KEY_1:
+                    pointlight.enabled = !pointlight.enabled
+                    break;
+                case pc.KEY_2:
+                    spotlight.enabled = !spotlight.enabled;
+                    break;
+                case pc.KEY_3:
+                    directionallight.enabled = !directionallight.enabled;
+                    break;
+            }
+        }, this);
 
         // Simple update loop to rotate the light
-        var radius = 20;
-        var height = 5;
-        var angle = 0;
-
-        var pointRadius = 5;
-        var pointHeight = 10;
+        var angleRad = 0;
         app.on("update", function (dt) {
-            angle += 20 * dt;
-            if (angle > 360) {
-                angle -= 360;
-            }
+            angleRad += 0.3 * dt;
             if (entity) {
-                light.lookAt(entity.getPosition());
-                light.rotateLocal(90, 0, 0);
-                light.setLocalPosition(radius * Math.sin(angle * pc.math.DEG_TO_RAD), height, radius * Math.cos(angle * pc.math.DEG_TO_RAD));
 
-                pointlight.setLocalPosition(pointRadius * Math.sin(-2 * angle * pc.math.DEG_TO_RAD), pointHeight, pointRadius * Math.cos(-2 * angle * pc.math.DEG_TO_RAD));
+                spotlight.lookAt(entity.getPosition());
+                spotlight.rotateLocal(90, 0, 0);
+                spotlight.setLocalPosition(20 * Math.sin(angleRad), 5, 20 * Math.cos(angleRad));
+
+                pointlight.setLocalPosition(5 * Math.sin(-2 * angleRad), 10, 5 * Math.cos(-2 * angleRad));
+
+                directionallight.setLocalEulerAngles(45, 60 * angleRad, 0);
             }
 
+            // update text showing which lights are enabled
+            if (text) {
+                text.element.text = 
+                    "[Key 1] Point light: " + pointlight.enabled +
+                    "\n[Key 2] Spot light: " + spotlight.enabled +
+                    "\n[Key 3] Directional light: " + directionallight.enabled;
+            }
         });
     </script>
 </body>

--- a/src/framework/components/light/component.js
+++ b/src/framework/components/light/component.js
@@ -125,8 +125,9 @@ class LightComponent extends Component {
         var layer;
         for (var i = 0; i < this.layers.length; i++) {
             layer = this.system.app.scene.layers.getLayerById(this.layers[i]);
-            if (!layer) continue;
-            layer.addLight(this);
+            if (layer) {
+                layer.addLight(this);
+            }
         }
     }
 
@@ -134,8 +135,9 @@ class LightComponent extends Component {
         var layer;
         for (var i = 0; i < this.layers.length; i++) {
             layer = this.system.app.scene.layers.getLayerById(this.layers[i]);
-            if (!layer) continue;
-            layer.removeLight(this);
+            if (layer) {
+                layer.removeLight(this);
+            }
         }
     }
 
@@ -151,16 +153,16 @@ class LightComponent extends Component {
 
     onLayerAdded(layer) {
         var index = this.layers.indexOf(layer.id);
-        if (index < 0) return;
-        if (this.enabled && this.entity.enabled) {
+        if (index >= 0 && this.enabled && this.entity.enabled) {
             layer.addLight(this);
         }
     }
 
     onLayerRemoved(layer) {
         var index = this.layers.indexOf(layer.id);
-        if (index < 0) return;
-        layer.removeLight(this);
+        if (index >= 0) {
+            layer.removeLight(this);
+        }
     }
 
     refreshProperties() {

--- a/src/scene/forward-renderer.js
+++ b/src/scene/forward-renderer.js
@@ -1527,7 +1527,7 @@ class ForwardRenderer {
         var shadowMapStartTime = now();
         // #endif
 
-        var i, j, light, shadowShader, type, shadowCam, shadowCamNode, pass, passes, shadowType, smode;
+        var i, j, light, shadowShader, type, shadowCam, shadowCamNode, passes, shadowType, smode;
         var meshInstance, mesh, material;
         var style;
         var passFlag = 1 << SHADER_SHADOW;

--- a/src/scene/forward-renderer.js
+++ b/src/scene/forward-renderer.js
@@ -2887,12 +2887,12 @@ class ForwardRenderer {
         let globalLightCounter = -1;
         for (let i = 0; i < comp._lights.length; i++) {
             let light = comp._lights[i];
+            const casters = comp._lightShadowCasters[i];
 
             if (light._type === LIGHTTYPE_DIRECTIONAL) {
                 // directional light
                 globalLightCounter++;
                 if (light.castShadows && light.enabled && light.shadowUpdateMode !== SHADOWUPDATE_NONE) {
-                    const casters = comp._lightShadowCasters[i];
                     let cameras = comp._globalLightCameras[globalLightCounter];
                     for (let j = 0; j < cameras.length; j++) {
                         this.cullDirectionalShadowmap(light, casters, cameras[j].camera, comp._globalLightCameraIds[globalLightCounter][j]);
@@ -2901,7 +2901,6 @@ class ForwardRenderer {
             } else {
                 // local light - omni or spot
                 if (light.visibleThisFrame && light.castShadows && light.enabled && light.shadowUpdateMode !== SHADOWUPDATE_NONE) {
-                    const casters = comp._lightShadowCasters[i];
                     this.cullLocalShadowmap(light, casters);
                 }
             }

--- a/src/scene/forward-renderer.js
+++ b/src/scene/forward-renderer.js
@@ -2636,7 +2636,7 @@ class ForwardRenderer {
 
             this.updateCameraFrustum(shadowCam);
 
-            // render data are shared between cameras for locl lights, so pass null for camera
+            // render data are shared between cameras for local lights, so pass null for camera
             const lightRenderData = light.getRenderData(null, pass);
             const visibleCasters = lightRenderData.visibleCasters;
             let count = 0;

--- a/src/scene/forward-renderer.js
+++ b/src/scene/forward-renderer.js
@@ -2580,22 +2580,9 @@ class ForwardRenderer {
             }
             layer._postRenderCounterMax = layer._postRenderCounter;
 
+            // prepare layer for culling with the camera
             for (j = 0; j < layer.cameras.length; j++) {
-                // Create visible arrays for every camera inside each layer if not present
-                if (!layer.instances.visibleOpaque[j]) layer.instances.visibleOpaque[j] = new VisibleInstanceList();
-                if (!layer.instances.visibleTransparent[j]) layer.instances.visibleTransparent[j] = new VisibleInstanceList();
-                // Mark visible arrays as not processed yet
-                layer.instances.visibleOpaque[j].done = false;
-                layer.instances.visibleTransparent[j].done = false;
-            }
-
-            // remove visible lists if cameras have been removed, remove one per frame
-            if (layer.cameras.length < layer.instances.visibleOpaque.length) {
-                layer.instances.visibleOpaque.splice(layer.cameras.length, 1);
-            }
-
-            if (layer.cameras.length < layer.instances.visibleTransparent.length) {
-                layer.instances.visibleTransparent.splice(layer.cameras.length, 1);
+                layer.instances.prepare(j);
             }
 
             // Generate static lighting for meshes in this layer if needed

--- a/src/scene/layer-composition.js
+++ b/src/scene/layer-composition.js
@@ -88,7 +88,7 @@ class LayerComposition extends EventHandler {
     }
 
     _update() {
-        var i, j, k, l;
+        var i, j;
         var layer;
         var len = this.layerList.length;
         var result = 0;

--- a/src/scene/layer-composition.js
+++ b/src/scene/layer-composition.js
@@ -356,18 +356,11 @@ class LayerComposition extends EventHandler {
                     // find its index in global light list, and get shadow casters for it
                     const lightIndex = this._lightsMap.get(lights[j]);
                     const casters = this._lightShadowCasters[lightIndex];
-                    const castersSet = casters.set;
-                    const castersList = casters.list;
 
                     // add unique meshes from the layer to casters
                     const meshInstances = layer.shadowCasters;
                     for (let k = 0; k < meshInstances.length; k++) {
-                        const meshInstance = meshInstances[k];
-
-                        if (!castersSet.has(meshInstance)) {
-                            castersSet.add(meshInstance);
-                            castersList.push(meshInstance);
-                        }
+                        casters.add(meshInstances[k]);
                     }
                 }
             }

--- a/src/scene/layer-composition.js
+++ b/src/scene/layer-composition.js
@@ -33,7 +33,7 @@ class LayerComposition extends EventHandler {
         this.name = name;
 
         // enable logging
-        this.logRenderActions = true;
+        this.logRenderActions = false;
 
         // all layers added into the composition
         this.layerList = [];

--- a/src/scene/layer-composition.js
+++ b/src/scene/layer-composition.js
@@ -8,6 +8,7 @@ import {
 } from './constants.js';
 
 import { RenderAction } from './render-action.js';
+import { ShadowCasters } from './shadow-casters.js';
 
 /**
  * @class
@@ -32,7 +33,7 @@ class LayerComposition extends EventHandler {
         this.name = name;
 
         // enable logging
-        this.logRenderActions = false;
+        this.logRenderActions = true;
 
         // all layers added into the composition
         this.layerList = [];
@@ -51,25 +52,20 @@ class LayerComposition extends EventHandler {
         this._meshInstances = [];
         this._meshInstancesSet = new Set();
 
-        // all unique lights from all layers, stored both as an array, and also map for fast search (key is light, values is its index in _lights array)
+        // an array of all unique lights from all layers
         this._lights = [];
+
+        // a map of Light to index in _lights for fast lookup
         this._lightsMap = new Map();
 
-        // each light in _lights has entry here at the same index, storing an array and also a set of shadow casters for it
+        // each entry in _lights has entry of type ShadowCasters here at the same index, storing shadow casters for the light
         this._lightShadowCasters = [];
-        this._lightShadowCastersSets = [];
 
         // _lights split into arrays per type of light, indexed by LIGHTTYPE_*** constants
         this._splitLights = [[], [], []];
 
-        // for each directional light (in _splitLights[LIGHTTYPE_DIRECTIONAL]), this stores array of unique cameras that are on the same layer as the light
-        this._globalLightCameras = [];
-
         // array of unique cameras from all layers (CameraComponent type)
         this.cameras = [];
-
-
-        this._globalLightCameraIds = []; // array mapping _globalLights to camera ids in composition
 
         // the actual rendering sequence, generated based on layers and cameras
         this._renderActions = [];
@@ -202,180 +198,20 @@ class LayerComposition extends EventHandler {
             this._dirtyBlend = false;
         }
 
-        var light, lights;
         if (this._dirtyLights) {
             result |= COMPUPDATED_LIGHTS;
-
-            // build a list and map of all unique lights from all layers
-            this._lights.length = 0;
-            this._lightsMap.clear();
-
-            // create a list of all unique lights from all layers
-            for (i = 0; i < len; i++) {
-                layer = this.layerList[i];
-                lights = layer._lights;
-                for (j = 0; j < lights.length; j++) {
-                    light = lights[j];
-
-                    // add new light
-                    if (!this._lightsMap.has(light)) {
-
-                        this._lightsMap.set(light, this._lights.length);
-                        this._lights.push(light);
-                    }
-                }
-            }
-
-            // adjust _lightShadowCasters to the right size, matching number of lights, and clean it up (minimize allocations)
-            var lightCount = this._lights.length;
-            this._lightShadowCasters.length = lightCount;
-            this._lightShadowCastersSets.length = lightCount;
-            for (i = 0; i < lightCount; i++) {
-
-                // clear array
-                if (this._lightShadowCasters[i]) {
-                    this._lightShadowCasters[i].length = 0;
-                } else {
-                    this._lightShadowCasters[i] = [];
-                }
-
-                // clear set
-                if (this._lightShadowCastersSets[i]) {
-                    this._lightShadowCastersSets[i].clear();
-                } else {
-                    this._lightShadowCastersSets[i] = new Set();
-                }
-            }
-
-            // split global lights list by type
-            this._splitLightsArray(this);
             this._dirtyLights = false;
 
-            // split layer lights lists by type
-            for (i = 0; i < len; i++) {
-                layer = this.layerList[i];
-                this._splitLightsArray(layer);
-                layer._dirtyLights = false;
-            }
+            this.updateLights();
         }
 
         // if meshes OR lights changed, rebuild shadow casters
-        var casters, castersSet;
-        var meshInstances, meshInstance;
-        var lightIndex;
         if (result) {
-
-            // start with empty shadow casters
-            for (i = 0; i < this._lightShadowCasters.length; i++) {
-                this._lightShadowCasters[i].length = 0;
-                this._lightShadowCastersSets[i].clear();
-            }
-
-            // for each layer
-            for (i = 0; i < len; i++) {
-                layer = this.layerList[i];
-                lights = layer._lights;
-
-                // for each light of a layer
-                for (j = 0; j < lights.length; j++) {
-
-                    // find its index in global light list, and get shadow casters for it
-                    lightIndex = this._lightsMap.get(lights[j]);
-                    casters = this._lightShadowCasters[lightIndex];
-                    castersSet = this._lightShadowCastersSets[lightIndex];
-
-                    // add unique meshes from the layer to casters
-                    meshInstances = layer.shadowCasters;
-                    for (k = 0; k < meshInstances.length; k++) {
-
-                        meshInstance = meshInstances[k];
-
-                        if (!castersSet.has(meshInstance)) {
-                            castersSet.add(meshInstance);
-                            casters.push(meshInstance);
-                        }
-                    }
-                }
-            }
-        }
-
-        // rebuild _globalLightCameras - list of cameras for each directional light
-        if ((result & COMPUPDATED_LIGHTS) || this._dirtyCameras) {
-
-            // TODO: make dirty when changing layer.enabled on/off
-            this._globalLightCameras.length = 0;
-            var globalLights = this._splitLights[LIGHTTYPE_DIRECTIONAL];
-
-            for (l = 0; l < globalLights.length; l++) {
-                light = globalLights[l];
-                this._globalLightCameras[l] = [];
-
-                for (i = 0; i < len; i++) {
-                    layer = this.layerList[i];
-                    if (layer._splitLights[LIGHTTYPE_DIRECTIONAL].indexOf(light) >= 0) {
-
-                        for (k = 0; k < layer.cameras.length; k++) {
-                            if (this._globalLightCameras[l].indexOf(layer.cameras[k]) < 0) {
-                                this._globalLightCameras[l].push(layer.cameras[k]);
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        // function adds new render action to a list, while trying to limit allocation and reuse already allocated objects
-        var renderActionCount = 0;
-        var renderActions = this._renderActions;
-        function addRenderAction(layer, layerIndex, cameraIndex, cameraFirstRenderAction, postProcessMarked) {
-
-            // try and reuse object, otherwise allocate new
-            var renderAction = renderActions[renderActionCount];
-            if (!renderAction) {
-                renderAction = renderActions[renderActionCount] = new RenderAction();
-            }
-
-            // render target from the camera takes precedence over the render target from the layer
-            var rt = layer.renderTarget;
-            var camera = layer.cameras[cameraIndex];
-            if (camera && camera.renderTarget) {
-                if (layer.id !== LAYERID_DEPTH) {   // ignore depth layer
-                    rt = camera.renderTarget;
-                }
-            }
-
-            // clear flags - use camera clear flags in the first render action for each camera, other render actions don't clear
-            let clearColor = cameraFirstRenderAction ? camera.clearColorBuffer : false;
-            let clearDepth = cameraFirstRenderAction ? camera.clearDepthBuffer : false;
-            let clearStencil = cameraFirstRenderAction ? camera.clearStencilBuffer : false;
-
-            // clear buffers if requested by the layer
-            clearColor |= layer.clearColorBuffer;
-            clearDepth |= layer.clearDepthBuffer;
-            clearStencil |= layer.clearStencilBuffer;
-
-            // for cameras with post processing enabled, on layers after post processing has been applied already (so UI and similar),
-            // don't render them to render target anymore
-            if (postProcessMarked && camera.postEffectsEnabled) {
-                rt = null;
-            }
-
-            // store the properties - write all as we reuse previously allocated class instances
-            renderAction.triggerPostprocess = false;
-            renderAction.layerIndex = layerIndex;
-            renderAction.cameraIndex = cameraIndex;
-            renderAction.renderTarget = rt;
-            renderAction.clearColor = clearColor;
-            renderAction.clearDepth = clearDepth;
-            renderAction.clearStencil = clearStencil;
-            renderAction.firstCameraUse = cameraFirstRenderAction;
-            renderActionCount++;
-
-            return renderAction;
+            this.updateShadowCasters();
         }
 
         var camera, index, cameraIndex;
-        if (this._dirtyCameras) {
+        if (this._dirtyCameras || (result & COMPUPDATED_LIGHTS)) {
 
             this._dirtyCameras = false;
             result |= COMPUPDATED_CAMERAS;
@@ -401,9 +237,14 @@ class LayerComposition extends EventHandler {
                 this.cameras.sort((a, b) => a.priority - b.priority);
             }
 
+            // collect a list of layers this camera renders
+            let cameraLayers = [];
+
             // render in order of cameras sorted by priority
+            var renderActionCount = 0;
             for (i = 0; i < this.cameras.length; i++) {
                 camera = this.cameras[i];
+                cameraLayers.length = 0;
 
                 // first render action for this camera
                 let cameraFirstRenderAction = true;
@@ -428,6 +269,8 @@ class LayerComposition extends EventHandler {
                             // if the camera renders this layer
                             if (camera.layers.indexOf(layer.id) >= 0) {
 
+                                cameraLayers.push(layer);
+
                                 // if this layer is the stop layer for postprocessing
                                 if (layer.id === camera.disablePostEffectsLayer) {
                                     postProcessMarked = true;
@@ -445,12 +288,20 @@ class LayerComposition extends EventHandler {
                                 if (cameraIndex >= 0) {
 
                                     // add render action to describe rendering step
-                                    lastRenderAction = addRenderAction(layer, j, cameraIndex, cameraFirstRenderAction, postProcessMarked);
+                                    lastRenderAction = this.addRenderAction(this._renderActions, renderActionCount, layer, j, cameraIndex,
+                                                                            cameraFirstRenderAction, postProcessMarked);
+                                    renderActionCount++;
                                     cameraFirstRenderAction = false;
                                 }
                             }
                         }
                     }
+                }
+
+                // based on all layers this camera renders, prepare a list of directional lights the camera needs to render shadow for
+                // and set these up on the first render action for the camera. Only do it if camera renders any layers.
+                if (cameraFirstRenderActionIndex < renderActionCount) {
+                    this._renderActions[cameraFirstRenderActionIndex].collectDirectionalLights(cameraLayers, this._splitLights[LIGHTTYPE_DIRECTIONAL], this._lights);
                 }
 
                 // if no render action for this camera was marked for end of posprocessing, mark last one
@@ -466,31 +317,139 @@ class LayerComposition extends EventHandler {
             }
 
             this._renderActions.length = renderActionCount;
+        }
 
+        if ((result & COMPUPDATED_LIGHTS) || (result & COMPUPDATED_CAMERAS)) {
             this._logRenderActions();
         }
 
-        var arr;
-        if ((result & COMPUPDATED_LIGHTS) || (result & COMPUPDATED_CAMERAS)) {
-            // cameras/lights changed
-            this._globalLightCameraIds.length = 0;
-            for (l = 0; l < this._globalLightCameras.length; l++) {
-                arr = [];
-                for (i = 0; i < this._globalLightCameras[l].length; i++) {
-                    index = this.cameras.indexOf( this._globalLightCameras[l][i] );
-                    if (index < 0) {
-                        // #ifdef DEBUG
-                        console.warn("Can't find _globalLightCameras[l][i] in cameras");
-                        // #endif
-                        continue;
-                    }
-                    arr.push(index);
-                }
-                this._globalLightCameraIds.push(arr);
+        return result;
+    }
+
+    updateShadowCasters() {
+
+        // adjust _lightShadowCasters to the right size, matching number of lights, and clean it up
+        const lightCount = this._lights.length;
+        this._lightShadowCasters.length = lightCount;
+        for (let i = 0; i < lightCount; i++) {
+
+            let casters = this._lightShadowCasters[i];
+            if (casters) {
+                casters.clear();
+            } else {
+                this._lightShadowCasters[i] = new ShadowCasters();
             }
         }
 
-        return result;
+        // for each layer
+        const len = this.layerList.length;
+        for (let i = 0; i < len; i++) {
+            const layer = this.layerList[i];
+            const lights = layer._lights;
+
+            // for each light of a layer
+            for (let j = 0; j < lights.length; j++) {
+
+                // only need casters when casting shadows
+                if (lights[j].castShadows) {
+
+                    // find its index in global light list, and get shadow casters for it
+                    const lightIndex = this._lightsMap.get(lights[j]);
+                    const casters = this._lightShadowCasters[lightIndex];
+                    const castersSet = casters.set;
+                    const castersList = casters.list;
+
+                    // add unique meshes from the layer to casters
+                    const meshInstances = layer.shadowCasters;
+                    for (let k = 0; k < meshInstances.length; k++) {
+                        const meshInstance = meshInstances[k];
+
+                        if (!castersSet.has(meshInstance)) {
+                            castersSet.add(meshInstance);
+                            castersList.push(meshInstance);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    updateLights() {
+
+        // build a list and map of all unique lights from all layers
+        this._lights.length = 0;
+        this._lightsMap.clear();
+
+        const count = this.layerList.length;
+        for (let i = 0; i < count; i++) {
+            const layer = this.layerList[i];
+            const lights = layer._lights;
+
+            for (let j = 0; j < lights.length; j++) {
+                const light = lights[j];
+
+                // add new light
+                if (!this._lightsMap.has(light)) {
+                    this._lightsMap.set(light, this._lights.length);
+                    this._lights.push(light);
+                }
+            }
+
+            // split layer lights lists by type
+            this._splitLightsArray(layer);
+            layer._dirtyLights = false;
+        }
+
+        // split light list by type
+        this._splitLightsArray(this);
+    }
+
+    // function adds new render action to a list, while trying to limit allocation and reuse already allocated objects
+    addRenderAction(renderActions, renderActionIndex, layer, layerIndex, cameraIndex, cameraFirstRenderAction, postProcessMarked) {
+
+        // try and reuse object, otherwise allocate new
+        var renderAction = renderActions[renderActionIndex];
+        if (!renderAction) {
+            renderAction = renderActions[renderActionIndex] = new RenderAction();
+        }
+
+        // render target from the camera takes precedence over the render target from the layer
+        var rt = layer.renderTarget;
+        var camera = layer.cameras[cameraIndex];
+        if (camera && camera.renderTarget) {
+            if (layer.id !== LAYERID_DEPTH) {   // ignore depth layer
+                rt = camera.renderTarget;
+            }
+        }
+
+        // clear flags - use camera clear flags in the first render action for each camera, other render actions don't clear
+        let clearColor = cameraFirstRenderAction ? camera.clearColorBuffer : false;
+        let clearDepth = cameraFirstRenderAction ? camera.clearDepthBuffer : false;
+        let clearStencil = cameraFirstRenderAction ? camera.clearStencilBuffer : false;
+
+        // clear buffers if requested by the layer
+        clearColor |= layer.clearColorBuffer;
+        clearDepth |= layer.clearDepthBuffer;
+        clearStencil |= layer.clearStencilBuffer;
+
+        // for cameras with post processing enabled, on layers after post processing has been applied already (so UI and similar),
+        // don't render them to render target anymore
+        if (postProcessMarked && camera.postEffectsEnabled) {
+            rt = null;
+        }
+
+        // store the properties - write all as we reuse previously allocated class instances
+        renderAction.triggerPostprocess = false;
+        renderAction.layerIndex = layerIndex;
+        renderAction.cameraIndex = cameraIndex;
+        renderAction.camera = camera;
+        renderAction.renderTarget = rt;
+        renderAction.clearColor = clearColor;
+        renderAction.clearDepth = clearDepth;
+        renderAction.clearStencil = clearStencil;
+        renderAction.firstCameraUse = cameraFirstRenderAction;
+
+        return renderAction;
     }
 
     // executes when post-processing camera's render actions were created to propage rendering to
@@ -530,6 +489,7 @@ class LayerComposition extends EventHandler {
                 const enabled = layer.enabled && this.subLayerEnabled[layerIndex];
                 const transparent = this.subLayerList[layerIndex];
                 const camera = layer.cameras[ra.cameraIndex];
+                const dirLightCount = ra.directionalLights.length;
                 const clear = (ra.clearColor ? "Color " : "..... ") + (ra.clearDepth ? "Depth " : "..... ") + (ra.clearStencil ? "Stencil" : ".......");
 
                 console.log(i +
@@ -541,7 +501,9 @@ class LayerComposition extends EventHandler {
                     (" RT: " + (ra.renderTarget ? ra.renderTarget.name : "-")).padEnd(30, " ") +
                     " Clear: " + clear +
                     (ra.firstCameraUse ? " CAM-FIRST" : "") +
-                    (ra.triggerPostprocess ? " POSTPROCESS" : ""));
+                    (ra.triggerPostprocess ? " POSTPROCESS" : "") +
+                    (dirLightCount ? (" DirLights: " + dirLightCount) : "")
+                );
             }
         }
         // #endif

--- a/src/scene/layer.js
+++ b/src/scene/layer.js
@@ -238,7 +238,6 @@ class Layer {
         this.customSortCallback = null;
         this.customCalculateSortValues = null;
 
-        this._lightComponents = [];
         this._lights = [];
         this._splitLights = [[], [], []];
 
@@ -495,11 +494,11 @@ class Layer {
      * @param {LightComponent} light - A {@link LightComponent}.
      */
     addLight(light) {
-        if (this._lightComponents.indexOf(light) >= 0) return;
-        this._lightComponents.push(light);
-        this._lights.push(light.light);
-        this._dirtyLights = true;
-        this._generateLightHash();
+        if (this._lights.indexOf(light.light) < 0) {
+            this._lights.push(light.light);
+            this._dirtyLights = true;
+            this._generateLightHash();
+        }
     }
 
     /**
@@ -509,15 +508,13 @@ class Layer {
      * @param {LightComponent} light - A {@link LightComponent}.
      */
     removeLight(light) {
-        var id = this._lightComponents.indexOf(light);
-        if (id < 0) return;
-        this._lightComponents.splice(id, 1);
+        const id = this._lights.indexOf(light.light);
+        if (id >= 0) {
+            this._lights.splice(id, 1);
 
-        id = this._lights.indexOf(light.light);
-        this._lights.splice(id, 1);
-
-        this._dirtyLights = true;
-        this._generateLightHash();
+            this._dirtyLights = true;
+            this._generateLightHash();
+        }
     }
 
     /**
@@ -526,7 +523,6 @@ class Layer {
      * @description Removes all lights from this layer.
      */
     clearLights() {
-        this._lightComponents.length = 0;
         this._lights.length = 0;
         this._dirtyLights = true;
     }

--- a/src/scene/layer.js
+++ b/src/scene/layer.js
@@ -259,7 +259,7 @@ class Layer {
 
         this._renderTime = 0;
         this._forwardDrawCalls = 0;
-        this._shadowDrawCalls = 0;
+        this._shadowDrawCalls = 0;  // deprecated, not useful on a layer anymore, could be moved to camera
         // #endif
 
         this._shaderVersion = -1;

--- a/src/scene/light.js
+++ b/src/scene/light.js
@@ -22,6 +22,14 @@ var tmpVec = new Vec3();
 
 var chanId = { r: 0, g: 1, b: 2, a: 3 };
 
+// viewport in shadows map for cascades for directional light
+const directionalCascades = [
+    [new Vec4(0, 0, 1, 1)],
+    [new Vec4(0, 0, 0.5, 0.5), new Vec4(0, 0.5, 0.5, 0.5)],
+    [new Vec4(0, 0, 0.5, 0.5), new Vec4(0, 0.5, 0.5, 0.5), new Vec4(0.5, 0, 0.5, 0.5)],
+    [new Vec4(0, 0, 0.5, 0.5), new Vec4(0, 0.5, 0.5, 0.5), new Vec4(0.5, 0, 0.5, 0.5), new Vec4(0.5, 0.5, 0.5, 0.5)]
+];
+
 // Class storing rendering related private information
 class LightRenderData {
     constructor(camera, face, lightType) {
@@ -89,6 +97,9 @@ class Light {
         // Spot properties
         this._innerConeAngle = 40;
         this._outerConeAngle = 45;
+
+        // Directional properties
+        this.numCascades = 1;
 
         // Light source shape properties
         this._shape = LIGHTSHAPE_PUNCTUAL;
@@ -182,6 +193,9 @@ class Light {
         clone.innerConeAngle = this._innerConeAngle;
         clone.outerConeAngle = this._outerConeAngle;
 
+        // Directional properties
+        clone.numCascades = this.numCascades;
+
         // shape properties
         clone.shape = this._shape;
 
@@ -200,6 +214,14 @@ class Light {
         // clone.cookieOffset = this._cookieOffset;
 
         return clone;
+    }
+
+    get numCascades() {
+        return this.cascades.length;
+    }
+
+    set numCascades(value) {
+        this.cascades = directionalCascades[value - 1];
     }
 
     getColor() {

--- a/src/scene/light.js
+++ b/src/scene/light.js
@@ -100,6 +100,7 @@ class Light {
 
         // Directional properties
         this.numCascades = 1;
+        this.cascades = null;   // an array of Vec4 viewports per cascade
 
         // Light source shape properties
         this._shape = LIGHTSHAPE_PUNCTUAL;

--- a/src/scene/light.js
+++ b/src/scene/light.js
@@ -8,7 +8,7 @@ import { Vec4 } from '../math/vec4.js';
 import {
     BLUR_GAUSSIAN,
     LIGHTTYPE_DIRECTIONAL, LIGHTTYPE_OMNI, LIGHTTYPE_SPOT,
-    MASK_LIGHTMAP,
+    MASK_LIGHTMAP, MASK_DYNAMIC,
     SHADOW_PCF3, SHADOW_PCF5, SHADOW_VSM8, SHADOW_VSM16, SHADOW_VSM32,
     SHADOWUPDATE_NONE, SHADOWUPDATE_REALTIME, SHADOWUPDATE_THISFRAME,
     LIGHTSHAPE_PUNCTUAL
@@ -21,6 +21,32 @@ var spotEndPoint = new Vec3();
 var tmpVec = new Vec3();
 
 var chanId = { r: 0, g: 1, b: 2, a: 3 };
+
+// Class storing rendering related private information
+class LightRenderData {
+    constructor(camera, face, lightType) {
+
+        // camera this applies to. Only used by directional light, as directional shadow map
+        // is culled and rendered for each camera. Local lights' shadow is culled and rendered one time
+        // and shared between cameras (even though it's not strictly correct and we can get shadows
+        // from a mesh that is not visible by the camera)
+        this.camera = camera;
+
+        // face index, value is based on light type:
+        // - spot: always 0
+        // - omni: cubemap face, 0..5
+        // - directional: 0 for simple shadows, cascade index for cascaded shadow map
+        this.face = face;
+
+        // shadow camera settings, only used by directional lights
+        this.position = lightType === LIGHTTYPE_DIRECTIONAL ? new Vec3() : null;
+        this.orthoHeight = 0;
+        this.farClip = 0;
+
+        // visible shadow casters
+        this.visibleCasters = [];
+    }
+}
 
 /**
  * @private
@@ -35,8 +61,8 @@ class Light {
         this._color = new Color(0.8, 0.8, 0.8);
         this._intensity = 1;
         this._castShadows = false;
-        this.enabled = false;
-        this.mask = 1;
+        this._enabled = false;
+        this.mask = MASK_DYNAMIC;
         this.isStatic = false;
         this.key = 0;
         this.bakeDir = true;
@@ -95,13 +121,32 @@ class Light {
         this._cacheShadowMap = false;
         this._isCachedShadowMap = false;
 
-        this._visibleLength = [0]; // lengths of passes in culledList
-        this._visibleList = [[]]; // culled mesh instances per pass (1 for spot, 6 for omni, cameraCount for directional)
-        this._visibleCameraSettings = []; // camera settings used in each directional light pass
+        // private rendering data
+        this._renderData = [];
+
+        // true if the light is visible by any camera within a frame
+        this.visibleThisFrame = false;
     }
 
     destroy() {
         this._destroyShadowMap();
+    }
+
+    // returns LightRenderData with matching camera and face
+    getRenderData(camera, face) {
+
+        // returns existing
+        for (let i = 0; i < this._renderData.length; i++) {
+            let current = this._renderData[i];
+            if (current.camera === camera && current.face === face) {
+                return current;
+            }
+        }
+
+        // create new one
+        const rd = new LightRenderData(camera, face, this._type);
+        this._renderData.push(rd);
+        return rd;
     }
 
     /**
@@ -119,7 +164,7 @@ class Light {
         clone.setColor(this._color);
         clone.intensity = this._intensity;
         clone.castShadows = this.castShadows;
-        clone.enabled = this.enabled;
+        clone._enabled = this._enabled;
 
         // Omni and spot properties
         clone.attenuationStart = this.attenuationStart;
@@ -319,6 +364,8 @@ class Light {
         }
 
         if (key !== this.key && this._scene !== null) {
+            // TODO: most of changes to the key should not invalidate composition,
+            // probably only _type and _castShadows
             this.layersDirty();
         }
 
@@ -388,6 +435,17 @@ class Light {
         this._shadowType = value;
         this._destroyShadowMap();
         this.updateKey();
+    }
+
+    get enabled() {
+        return this._enabled;
+    }
+
+    set enabled(value) {
+        if (this._enabled !== value) {
+            this._enabled = value;
+            this.layersDirty();
+        }
     }
 
     get castShadows() {
@@ -574,4 +632,4 @@ class Light {
     }
 }
 
-export { Light };
+export { Light, LightRenderData };

--- a/src/scene/light.js
+++ b/src/scene/light.js
@@ -387,7 +387,7 @@ class Light {
         }
 
         if (key !== this.key && this._scene !== null) {
-            // TODO: most of changes to the key should not invalidate composition,
+// TODO: most of the changes to the key should not invalidate the composition,
             // probably only _type and _castShadows
             this.layersDirty();
         }

--- a/src/scene/light.js
+++ b/src/scene/light.js
@@ -130,6 +130,7 @@ class Light {
 
     destroy() {
         this._destroyShadowMap();
+        this._renderData = null;
     }
 
     // returns LightRenderData with matching camera and face

--- a/src/scene/light.js
+++ b/src/scene/light.js
@@ -655,4 +655,4 @@ class Light {
     }
 }
 
-export { Light, LightRenderData };
+export { Light };

--- a/src/scene/lightmapper.js
+++ b/src/scene/lightmapper.js
@@ -793,14 +793,12 @@ class Lightmapper {
         if (!shadowMapRendered && light.castShadows) {
 
             if (light.type === LIGHTTYPE_DIRECTIONAL) {
-                this.renderer.cullDirectionalShadowmap(light, casters, this.camera, 0);
-            } else  if (light.type === LIGHTTYPE_OMNI) {
-                this.renderer.cullLocalShadowmap(light, casters);
+                this.renderer.cullDirectionalShadowmap(light, casters, this.camera);
             } else {
                 this.renderer.cullLocalShadowmap(light, casters);
             }
 
-            this.renderer.renderShadows(lightArray[light.type], 0);
+            this.renderer.renderShadows(lightArray[light.type], this.camera);
         }
 
         return true;

--- a/src/scene/render-action.js
+++ b/src/scene/render-action.js
@@ -1,3 +1,7 @@
+import {
+    LIGHTTYPE_DIRECTIONAL
+} from './constants.js';
+
 // class representing an entry in the final order of rendering of cameras and layers in the engine
 // this is populated at runtime based on LayerComposition
 class RenderAction {
@@ -8,6 +12,9 @@ class RenderAction {
 
         // index into a camera array of the layer, stored in Layer.cameras
         this.cameraIndex = 0;
+
+        // camera of type CameraComponent
+        this.camera = null;
 
         // render target this render action renders to (taken from either camera or layer)
         this.renderTarget = null;
@@ -22,6 +29,42 @@ class RenderAction {
 
         // true if this is first render action using this camera
         this.firstCameraUse = false;
+
+        // directional lights that needs to update their shadows for this render action, stored as a set
+        this.directionalLightsSet = new Set();
+
+        // and also store them as an array
+        this.directionalLights = [];
+
+        // and also the same directional lights, stored as indicies into LayerComposition._lights
+        this.directionalLightsIndices = [];
+    }
+
+    // store directional lights that are needed for this camera based on layers it renders
+    collectDirectionalLights(cameraLayers, dirLights, allLights) {
+
+        this.directionalLightsSet.clear();
+        this.directionalLights.length = 0;
+        this.directionalLightsIndices.length = 0;
+
+        for (let i = 0; i < dirLights.length; i++) {
+            let light = dirLights[i];
+            for (let l = 0; l < cameraLayers.length; l++) {
+
+                // if layer has the light
+                if (cameraLayers[l]._splitLights[LIGHTTYPE_DIRECTIONAL].indexOf(light) >= 0) {
+                    if (!this.directionalLightsSet.has(light)) {
+                        this.directionalLightsSet.add(light);
+
+                        this.directionalLights.push(light);
+
+                        // store index into all lights
+                        const lightIndex = allLights.indexOf(light);
+                        this.directionalLightsIndices.push(lightIndex);
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/src/scene/shadow-casters.js
+++ b/src/scene/shadow-casters.js
@@ -12,6 +12,13 @@ class ShadowCasters {
         this.set.clear();
         this.list.length = 0;
     }
+
+    add(item) {
+        if (!this.set.has(item)) {
+            this.set.add(item);
+            this.list.push(item);
+        }
+    }
 }
 
 export { ShadowCasters };

--- a/src/scene/shadow-casters.js
+++ b/src/scene/shadow-casters.js
@@ -1,0 +1,17 @@
+// Storage of shadow casters for a single light
+class ShadowCasters {
+    constructor() {
+        // stored in a set for fast de-duplication
+        this.set = new Set();
+
+        // stored in an array for fast iteration
+        this.list = [];
+    }
+
+    clear() {
+        this.set.clear();
+        this.list.length = 0;
+    }
+}
+
+export { ShadowCasters };


### PR DESCRIPTION
Shadow culling and rendering refactoring in order to simplify the data / code and fix existing issues with directional shadow map rendering and prepare for cascaded shadow map and shadow atlases.

- directional shadow maps render before the camera that needs it, not after the camera's render target was set active and cleared, to avoid expensive resolve to memory on tiled architectures.
- changes to lights engine example to include all 3 lights types with their shadows, key toggles per light type
- partial support for cascaded shadow maps (culling & rendering to shadow map, but not frustum distribution / shadow map use)
- new private API for cascades: **Light.numCascades**

![Screen Shot 2021-03-04 at 3 45 47 PM](https://user-images.githubusercontent.com/59932779/109994918-b0d52800-7d05-11eb-8c4e-aa2d2f41db22.png)

![Screen Shot 2021-03-04 at 6 08 38 PM](https://user-images.githubusercontent.com/59932779/110009250-aa01e180-7d14-11eb-9aff-38a0adff2a14.png)

Fixes https://github.com/playcanvas/engine/issues/2518