### PR TITLE
Fixes gamepad crash with wasReleased

### DIFF
--- a/src/input/game-pads.js
+++ b/src/input/game-pads.js
@@ -195,7 +195,10 @@ class GamePads {
 
         var key = this.current[index].map.buttons[button];
         var i = pc[key];
-        return this.current[index].pad.buttons[i].pressed && !this.previous[index][i];
+
+        // Previous pad buttons may not have been populated yet
+        // If this is the first time frame a pad has been detected
+        return this.current[index].pad.buttons[i].pressed && !(this.previous[index] && this.previous[index][i]);
     }
 
     /**


### PR DESCRIPTION
If wasReleased was used against the first button pressed in a session, it would crash as this.previous[gamepadIndex] would be empty

Test project: https://playcanvas.com/editor/scene/742878 (press button 1 on a gamepad)

Fixes https://forum.playcanvas.com/t/how-to-use-wasreleased-with-gamepads/18579/7

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
