### PR TITLE
Making RenderComponent related API public

### DIFF
--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -260,6 +260,7 @@ var _deprecationWarning = false;
  * * model ({@link ModelComponentSystem})
  * * particlesystem ({@link ParticleSystemComponentSystem})
  * * rigidbody ({@link RigidBodyComponentSystem})
+ * * render ({@link RenderComponentSystem})
  * * screen ({@link ScreenComponentSystem})
  * * script ({@link ScriptComponentSystem})
  * * scrollbar ({@link ScrollbarComponentSystem})

--- a/src/framework/components/render/component.js
+++ b/src/framework/components/render/component.js
@@ -14,7 +14,6 @@ import { Component } from '../component.js';
 import { EntityReference } from '../../utils/entity-reference.js';
 
 /**
- * @private
  * @component
  * @class
  * @name RenderComponent
@@ -241,7 +240,6 @@ class RenderComponent extends Component {
     }
 
     /**
-     * @private
      * @function
      * @name RenderComponent#hide
      * @description Stop rendering {@link MeshInstance}s without removing them from the scene hierarchy.
@@ -258,7 +256,6 @@ class RenderComponent extends Component {
     }
 
     /**
-     * @private
      * @function
      * @name RenderComponent#show
      * @description Enable rendering of the render {@link MeshInstance}s if hidden using {@link RenderComponent#hide}.

--- a/src/framework/components/render/system.js
+++ b/src/framework/components/render/system.js
@@ -28,7 +28,6 @@ const _properties = [
 ];
 
 /**
- * @private
  * @class
  * @name RenderComponentSystem
  * @augments ComponentSystem

--- a/src/framework/entity.js
+++ b/src/framework/entity.js
@@ -30,6 +30,7 @@ import { Application } from './application.js';
  * @property {LightComponent} [light] Gets the {@link LightComponent} attached to this entity. [read only]
  * @property {ModelComponent} [model] Gets the {@link ModelComponent} attached to this entity. [read only]
  * @property {ParticleSystemComponent} [particlesystem] Gets the {@link ParticleSystemComponent} attached to this entity. [read only]
+ * @property {RenderComponent} [render] Gets the {@link RenderComponent} attached to this entity. [read only]
  * @property {RigidBodyComponent} [rigidbody] Gets the {@link RigidBodyComponent} attached to this entity. [read only]
  * @property {ScreenComponent} [screen] Gets the {@link ScreenComponent} attached to this entity. [read only]
  * @property {ScriptComponent} [script] Gets the {@link ScriptComponent} attached to this entity. [read only]
@@ -107,6 +108,7 @@ class Entity extends GraphNode {
      * * "light" - see {@link LightComponent}
      * * "model" - see {@link ModelComponent}
      * * "particlesystem" - see {@link ParticleSystemComponent}
+     * * "render" - see {@link RenderComponent}
      * * "rigidbody" - see {@link RigidBodyComponent}
      * * "screen" - see {@link ScreenComponent}
      * * "script" - see {@link ScriptComponent}

--- a/src/index.js
+++ b/src/index.js
@@ -249,6 +249,8 @@ export { ParticleSystemComponent } from './framework/components/particle-system/
 export { ParticleSystemComponentSystem } from './framework/components/particle-system/system.js';
 export { PostEffectQueue } from './framework/components/camera/post-effect-queue.js';
 export * from './framework/components/rigid-body/constants.js';
+export { RenderComponent } from './framework/components/render/component.js';
+export { RenderComponentSystem } from './framework/components/render/system.js';
 export { RigidBodyComponent } from './framework/components/rigid-body/component.js';
 export { RigidBodyComponentSystem, ContactPoint, ContactResult, RaycastResult, SingleContactResult } from './framework/components/rigid-body/system.js';
 export { SceneRegistry } from './framework/scene-registry.js';

--- a/src/resources/container.js
+++ b/src/resources/container.js
@@ -53,7 +53,7 @@ class ContainerResource {
     /**
      * @function
      * @name ContainerResource#instantiateRenderEntity
-     * @description Instantiates an entity with a render components.
+     * @description Instantiates an entity with a render component.
      * @param {object} [options] - The initialization data for the render component type {@link RenderComponent}.
      * @returns {Entity} A hierarachy of entities with render components on entities containing renderable geometry.
      * @example

--- a/src/resources/container.js
+++ b/src/resources/container.js
@@ -29,12 +29,42 @@ class ContainerResource {
         this.registry = null;
     }
 
+    /**
+     * @function
+     * @name ContainerResource#instantiateModelEntity
+     * @description Instantiates an entity with a model component.
+     * @param {object} [options] - The initialization data for the model component type {@link ModelComponent}.
+     * @returns {Entity} A single entity with a model component. Model component internally contains a hierarchy based on {@link GraphNode}.
+     * @example
+     * // load a glb file and instantiate an entity with a model component based on it
+     * app.assets.loadFromUrl("statue.glb", "container", function (err, asset) {
+     *     var entity = asset.resource.instantiateModelEntity({
+     *         castShadows: true
+     *     });
+     *     app.root.addChild(entity);
+     * });
+     */
     instantiateModelEntity(options) {
         var entity = new Entity();
         entity.addComponent("model", Object.assign( { type: "asset", asset: this.model }, options));
         return entity;
     }
 
+    /**
+     * @function
+     * @name ContainerResource#instantiateRenderEntity
+     * @description Instantiates an entity with a render components.
+     * @param {object} [options] - The initialization data for the render component type {@link RenderComponent}.
+     * @returns {Entity} A hierarachy of entities with render components on entities containing renderable geometry.
+     * @example
+     * // load a glb file and instantiate an entity with a model component based on it
+     * app.assets.loadFromUrl("statue.glb", "container", function (err, asset) {
+     *     var entity = asset.resource.instantiateRenderEntity({
+     *         castShadows: true
+     *     });
+     *     app.root.addChild(entity);
+     * });
+     */
     instantiateRenderEntity(options) {
         // helper function to recursively clone a hierarchy while converting ModelComponent to RenderComponents
         var cloneToEntity = function (skinInstances, model, node) {


### PR DESCRIPTION
RenderComponent API that is different to ModelComponent:
- **ModelComponent.mapping** - not exposed on RenderComponent, override materials are stored directly in MeshInstances
- **ModelComponent.model** - not exposed on RenderComponent, as there is no model and only MeshInstances
- **RenderComponent.renderStyle** - new API to change solid / line / point rendering
- **RenderComponent.rootBone** - new API to expose animation root bone, as render component can be on any child of the hierarchy

new API in the screenshots:

<img width="826" alt="Screen Shot 2021-03-05 at 11 42 07 AM" src="https://user-images.githubusercontent.com/59932779/110111234-eb8f9c80-7da7-11eb-8939-1996175ea3f9.png">

<img width="836" alt="Screen Shot 2021-03-05 at 11 42 36 AM" src="https://user-images.githubusercontent.com/59932779/110111241-edf1f680-7da7-11eb-8f36-487429134620.png">

![Screen Shot 2021-03-05 at 11 55 18 AM](https://user-images.githubusercontent.com/59932779/110112487-b97f3a00-7da9-11eb-80bc-7c1bda4c1a6d.png)

original PR adding RenderComponent: https://github.com/playcanvas/engine/pull/2488