### PR TITLE
Add vector div and scalar ops

### DIFF
--- a/src/deprecated.js
+++ b/src/deprecated.js
@@ -263,6 +263,8 @@ Object.defineProperty(Vec2.prototype, "data", {
     }
 });
 
+Vec2.prototype.scale = Vec2.prototype.mulScalar;
+
 Object.defineProperty(Vec3.prototype, "data", {
     get: function () {
         // #ifdef DEBUG
@@ -277,6 +279,8 @@ Object.defineProperty(Vec3.prototype, "data", {
         return this._data;
     }
 });
+
+Vec3.prototype.scale = Vec3.prototype.mulScalar;
 
 Object.defineProperty(Vec4.prototype, "data", {
     get: function () {
@@ -293,6 +297,8 @@ Object.defineProperty(Vec4.prototype, "data", {
         return this._data;
     }
 });
+
+Vec4.prototype.scale = Vec4.prototype.mulScalar;
 
 // SHAPE
 

--- a/src/math/color.js
+++ b/src/math/color.js
@@ -158,7 +158,7 @@ class Color {
      * @returns {string} The color in string form.
      * @example
      * var c = new pc.Color(1, 1, 1);
-     * // Should output '#ffffffff'
+     * // Outputs '#ffffffff'
      * console.log(c.toString());
      */
     toString(alpha) {

--- a/src/math/color.js
+++ b/src/math/color.js
@@ -158,7 +158,7 @@ class Color {
      * @returns {string} The color in string form.
      * @example
      * var c = new pc.Color(1, 1, 1);
-     * // Outputs '#ffffffff'
+     * // Outputs #ffffffff
      * console.log(c.toString());
      */
     toString(alpha) {

--- a/src/math/mat3.js
+++ b/src/math/mat3.js
@@ -167,7 +167,7 @@ class Mat3 {
      * @returns {string} The matrix in string form.
      * @example
      * var m = new pc.Mat3();
-     * // Outputs '[1, 0, 0, 0, 1, 0, 0, 0, 1]'
+     * // Outputs [1, 0, 0, 0, 1, 0, 0, 0, 1]
      * console.log(m.toString());
      */
     toString() {

--- a/src/math/mat3.js
+++ b/src/math/mat3.js
@@ -167,7 +167,7 @@ class Mat3 {
      * @returns {string} The matrix in string form.
      * @example
      * var m = new pc.Mat3();
-     * // Should output '[1, 0, 0, 0, 1, 0, 0, 0, 1]'
+     * // Outputs '[1, 0, 0, 0, 1, 0, 0, 0, 1]'
      * console.log(m.toString());
      */
     toString() {

--- a/src/math/mat4.js
+++ b/src/math/mat4.js
@@ -1255,7 +1255,7 @@ class Mat4 {
      * @returns {string} The matrix in string form.
      * @example
      * var m = new pc.Mat4();
-     * // Should output '[1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]'
+     * // Outputs '[1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]'
      * console.log(m.toString());
      */
     toString() {

--- a/src/math/mat4.js
+++ b/src/math/mat4.js
@@ -1255,7 +1255,7 @@ class Mat4 {
      * @returns {string} The matrix in string form.
      * @example
      * var m = new pc.Mat4();
-     * // Outputs '[1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]'
+     * // Outputs [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]
      * console.log(m.toString());
      */
     toString() {

--- a/src/math/quat.js
+++ b/src/math/quat.js
@@ -156,9 +156,9 @@ class Quat {
      * q.setFromAxisAngle(new pc.Vec3(0, 1, 0), 90);
      * var v = new pc.Vec3();
      * var angle = q.getAxisAngle(v);
-     * // Should output 90
+     * // Outputs 90
      * console.log(angle);
-     * // Should output [0, 1, 0]
+     * // Outputs [0, 1, 0]
      * console.log(v.toString());
      */
     getAxisAngle(axis) {
@@ -242,7 +242,7 @@ class Quat {
      * @example
      * var q = new pc.Quat(0, 0, 0, 5);
      * var len = q.length();
-     * // Should output 5
+     * // Outputs 5
      * console.log("The length of the quaternion is: " + len);
      */
     length() {
@@ -257,7 +257,7 @@ class Quat {
      * @example
      * var q = new pc.Quat(3, 4, 0);
      * var lenSq = q.lengthSq();
-     * // Should output 25
+     * // Outputs 25
      * console.log("The length squared of the quaternion is: " + lenSq);
      */
     lengthSq() {
@@ -350,7 +350,7 @@ class Quat {
      *
      * v.normalize();
      *
-     * // Should output 0, 0, 0, 1
+     * // Outputs 0, 0, 0, 1
      * console.log("The result of the vector normalization is: " + v.toString());
      */
     normalize() {
@@ -382,7 +382,7 @@ class Quat {
      * var q = new pc.Quat();
      * q.set(1, 0, 0, 0);
      *
-     * // Should output 1, 0, 0, 0
+     * // Outputs 1, 0, 0, 0
      * console.log("The result of the vector set is: " + q.toString());
      */
     set(x, y, z, w) {
@@ -690,7 +690,7 @@ class Quat {
      * @returns {string} The quaternion in string form.
      * @example
      * var v = new pc.Quat(0, 0, 0, 1);
-     * // Should output '[0, 0, 0, 1]'
+     * // Outputs '[0, 0, 0, 1]'
      * console.log(v.toString());
      */
     toString() {

--- a/src/math/quat.js
+++ b/src/math/quat.js
@@ -690,7 +690,7 @@ class Quat {
      * @returns {string} The quaternion in string form.
      * @example
      * var v = new pc.Quat(0, 0, 0, 1);
-     * // Outputs '[0, 0, 0, 1]'
+     * // Outputs [0, 0, 0, 1]
      * console.log(v.toString());
      */
     toString() {

--- a/src/math/vec2.js
+++ b/src/math/vec2.js
@@ -527,7 +527,7 @@ class Vec2 {
      * @returns {string} The vector in string form.
      * @example
      * var v = new pc.Vec2(20, 10);
-     * // Outputs '[20, 10]'
+     * // Outputs [20, 10]
      * console.log(v.toString());
      */
     toString() {

--- a/src/math/vec2.js
+++ b/src/math/vec2.js
@@ -220,7 +220,7 @@ class Vec2 {
      * var b = new pc.Vec2(2, 3);
      * var r = new pc.Vec2();
      *
-     * r.add2(a, b);
+     * r.div2(a, b);
      * // Outputs [2, 3]
      *
      * console.log("The result of the division is: " + r.toString());

--- a/src/math/vec2.js
+++ b/src/math/vec2.js
@@ -59,7 +59,7 @@ class Vec2 {
      *
      * a.add(b);
      *
-     * // Should output [30, 30]
+     * // Outputs [30, 30]
      * console.log("The result of the addition is: " + a.toString());
      */
     add(rhs) {
@@ -82,7 +82,7 @@ class Vec2 {
      * var r = new pc.Vec2();
      *
      * r.add2(a, b);
-     * // Should output [30, 30]
+     * // Outputs [30, 30]
      *
      * console.log("The result of the addition is: " + r.toString());
      */
@@ -104,7 +104,7 @@ class Vec2 {
      *
      * vec.addScalar(2);
      *
-     * // Should output [5, 6]
+     * // Outputs [5, 6]
      * console.log("The result of the addition is: " + a.toString());
      */
     addScalar(scalar) {
@@ -197,7 +197,7 @@ class Vec2 {
      *
      * a.div(b);
      *
-     * // Should output [2, 3]
+     * // Outputs [2, 3]
      * console.log("The result of the division is: " + a.toString());
      */
     div(rhs) {
@@ -221,7 +221,7 @@ class Vec2 {
      * var r = new pc.Vec2();
      *
      * r.add2(a, b);
-     * // Should output [2, 3]
+     * // Outputs [2, 3]
      *
      * console.log("The result of the division is: " + r.toString());
      */
@@ -243,7 +243,7 @@ class Vec2 {
      *
      * vec.divScalar(3);
      *
-     * // Should output [1, 2]
+     * // Outputs [1, 2]
      * console.log("The result of the division is: " + a.toString());
      */
     divScalar(scalar) {
@@ -292,7 +292,7 @@ class Vec2 {
      * @example
      * var vec = new pc.Vec2(3, 4);
      * var len = vec.length();
-     * // Should output 5
+     * // Outputs 5
      * console.log("The length of the vector is: " + len);
      */
     length() {
@@ -307,7 +307,7 @@ class Vec2 {
      * @example
      * var vec = new pc.Vec2(3, 4);
      * var len = vec.lengthSq();
-     * // Should output 25
+     * // Outputs 25
      * console.log("The length squared of the vector is: " + len);
      */
     lengthSq() {
@@ -352,7 +352,7 @@ class Vec2 {
      *
      * a.mul(b);
      *
-     * // Should output 8, 15
+     * // Outputs 8, 15
      * console.log("The result of the multiplication is: " + a.toString());
      */
     mul(rhs) {
@@ -376,7 +376,7 @@ class Vec2 {
      *
      * r.mul2(a, b);
      *
-     * // Should output 8, 15
+     * // Outputs 8, 15
      * console.log("The result of the multiplication is: " + r.toString());
      */
     mul2(lhs, rhs) {
@@ -397,7 +397,7 @@ class Vec2 {
      *
      * vec.divScalar(3);
      *
-     * // Should output [9, 18]
+     * // Outputs [9, 18]
      * console.log("The result of the multiplication is: " + a.toString());
      */
     mulScalar(scalar) {
@@ -418,7 +418,7 @@ class Vec2 {
      *
      * v.normalize();
      *
-     * // Should output 1, 0
+     * // Outputs 1, 0
      * console.log("The result of the vector normalization is: " + v.toString());
      */
     normalize() {
@@ -443,7 +443,7 @@ class Vec2 {
      * var v = new pc.Vec2();
      * v.set(5, 10);
      *
-     * // Should output 5, 10
+     * // Outputs 5, 10
      * console.log("The result of the vector set is: " + v.toString());
      */
     set(x, y) {
@@ -465,7 +465,7 @@ class Vec2 {
      *
      * a.sub(b);
      *
-     * // Should output [-10, -10]
+     * // Outputs [-10, -10]
      * console.log("The result of the subtraction is: " + a.toString());
      */
     sub(rhs) {
@@ -489,7 +489,7 @@ class Vec2 {
      *
      * r.sub2(a, b);
      *
-     * // Should output [-10, -10]
+     * // Outputs [-10, -10]
      * console.log("The result of the subtraction is: " + r.toString());
      */
     sub2(lhs, rhs) {
@@ -510,7 +510,7 @@ class Vec2 {
      *
      * vec.subScalar(2);
      *
-     * // Should output [1, 2]
+     * // Outputs [1, 2]
      * console.log("The result of the subtraction is: " + a.toString());
      */
     subScalar(scalar) {
@@ -527,7 +527,7 @@ class Vec2 {
      * @returns {string} The vector in string form.
      * @example
      * var v = new pc.Vec2(20, 10);
-     * // Should output '[20, 10]'
+     * // Outputs '[20, 10]'
      * console.log(v.toString());
      */
     toString() {

--- a/src/math/vec2.js
+++ b/src/math/vec2.js
@@ -95,6 +95,27 @@ class Vec2 {
 
     /**
      * @function
+     * @name Vec2#addScalar
+     * @description Adds a number to each element of a vector.
+     * @param {number} scalar - The number to add.
+     * @returns {Vec2} Self for chaining.
+     * @example
+     * var vec = new pc.Vec2(3, 4);
+     *
+     * vec.addScalar(2);
+     *
+     * // Should output [5, 6]
+     * console.log("The result of the addition is: " + a.toString());
+     */
+    addScalar(scalar) {
+        this.x += scalar;
+        this.y += scalar;
+
+        return this;
+    }
+
+    /**
+     * @function
      * @name Vec2#clone
      * @description Returns an identical copy of the specified 2-dimensional vector.
      * @returns {Vec2} A 2-dimensional vector containing the result of the cloning.
@@ -162,6 +183,74 @@ class Vec2 {
         var x = this.x - rhs.x;
         var y = this.y - rhs.y;
         return Math.sqrt(x * x + y * y);
+    }
+
+    /**
+     * @function
+     * @name Vec2#div
+     * @description Divides a 2-dimensional vector by another in place.
+     * @param {Vec2} rhs - The vector to divide the specified vector by.
+     * @returns {Vec2} Self for chaining.
+     * @example
+     * var a = new pc.Vec2(4, 9);
+     * var b = new pc.Vec2(2, 3);
+     *
+     * a.div(b);
+     *
+     * // Should output [2, 3]
+     * console.log("The result of the division is: " + a.toString());
+     */
+    div(rhs) {
+        this.x /= rhs.x;
+        this.y /= rhs.y;
+
+        return this;
+    }
+
+    /**
+     * @function
+     * @name Vec2#div2
+     * @description Divides one 2-dimensional vector by another and writes the result to
+     * the specified vector.
+     * @param {Vec2} lhs - The dividend vector (the vector being divided).
+     * @param {Vec2} rhs - The divisor vector (the vector dividing the dividend).
+     * @returns {Vec2} Self for chaining.
+     * @example
+     * var a = new pc.Vec2(4, 9);
+     * var b = new pc.Vec2(2, 3);
+     * var r = new pc.Vec2();
+     *
+     * r.add2(a, b);
+     * // Should output [2, 3]
+     *
+     * console.log("The result of the division is: " + r.toString());
+     */
+    div2(lhs, rhs) {
+        this.x = lhs.x / rhs.x;
+        this.y = lhs.y / rhs.y;
+
+        return this;
+    }
+
+    /**
+     * @function
+     * @name Vec2#divScalar
+     * @description Divides each element of a vector by a number.
+     * @param {number} scalar - The number to divide by.
+     * @returns {Vec2} Self for chaining.
+     * @example
+     * var vec = new pc.Vec2(3, 6);
+     *
+     * vec.divScalar(3);
+     *
+     * // Should output [1, 2]
+     * console.log("The result of the division is: " + a.toString());
+     */
+    divScalar(scalar) {
+        this.x /= scalar;
+        this.y /= scalar;
+
+        return this;
     }
 
     /**
@@ -299,6 +388,27 @@ class Vec2 {
 
     /**
      * @function
+     * @name Vec2#mulScalar
+     * @description Multiplies each element of a vector by a number.
+     * @param {number} scalar - The number to multiply by.
+     * @returns {Vec2} Self for chaining.
+     * @example
+     * var vec = new pc.Vec2(3, 6);
+     *
+     * vec.divScalar(3);
+     *
+     * // Should output [9, 18]
+     * console.log("The result of the multiplication is: " + a.toString());
+     */
+    mulScalar(scalar) {
+        this.x *= scalar;
+        this.y *= scalar;
+
+        return this;
+    }
+
+    /**
+     * @function
      * @name Vec2#normalize
      * @description Returns this 2-dimensional vector converted to a unit vector in place.
      * If the vector has a length of zero, the vector's elements will be set to zero.
@@ -318,32 +428,6 @@ class Vec2 {
             this.x *= invLength;
             this.y *= invLength;
         }
-
-        return this;
-    }
-
-    /**
-     * @function
-     * @name Vec2#scale
-     * @description Scales each component of the specified 2-dimensional vector by the supplied
-     * scalar value.
-     * @param {number} scalar - The value by which each vector component is multiplied.
-     * @returns {Vec2} Self for chaining.
-     * @example
-     * var v = new pc.Vec2(2, 4);
-     *
-     * // Multiply by 2
-     * v.scale(2);
-     *
-     * // Negate
-     * v.scale(-1);
-     *
-     * // Divide by 2
-     * v.scale(0.5);
-     */
-    scale(scalar) {
-        this.x *= scalar;
-        this.y *= scalar;
 
         return this;
     }
@@ -411,6 +495,27 @@ class Vec2 {
     sub2(lhs, rhs) {
         this.x = lhs.x - rhs.x;
         this.y = lhs.y - rhs.y;
+
+        return this;
+    }
+
+    /**
+     * @function
+     * @name Vec2#subScalar
+     * @description Subtracts a number from each element of a vector.
+     * @param {number} scalar - The number to subtract.
+     * @returns {Vec2} Self for chaining.
+     * @example
+     * var vec = new pc.Vec2(3, 4);
+     *
+     * vec.subScalar(2);
+     *
+     * // Should output [1, 2]
+     * console.log("The result of the subtraction is: " + a.toString());
+     */
+    subScalar(scalar) {
+        this.x -= scalar;
+        this.y -= scalar;
 
         return this;
     }

--- a/src/math/vec2.js
+++ b/src/math/vec2.js
@@ -105,7 +105,7 @@ class Vec2 {
      * vec.addScalar(2);
      *
      * // Outputs [5, 6]
-     * console.log("The result of the addition is: " + a.toString());
+     * console.log("The result of the addition is: " + vec.toString());
      */
     addScalar(scalar) {
         this.x += scalar;
@@ -160,7 +160,7 @@ class Vec2 {
      * var up = new pc.Vec2(0, 1);
      * var crossProduct = right.cross(up);
      *
-     * // Should print 1
+     * // Prints 1
      * console.log("The result of the cross product is: " + crossProduct);
      */
     cross(rhs) {
@@ -244,7 +244,7 @@ class Vec2 {
      * vec.divScalar(3);
      *
      * // Outputs [1, 2]
-     * console.log("The result of the division is: " + a.toString());
+     * console.log("The result of the division is: " + vec.toString());
      */
     divScalar(scalar) {
         this.x /= scalar;
@@ -398,7 +398,7 @@ class Vec2 {
      * vec.divScalar(3);
      *
      * // Outputs [9, 18]
-     * console.log("The result of the multiplication is: " + a.toString());
+     * console.log("The result of the multiplication is: " + vec.toString());
      */
     mulScalar(scalar) {
         this.x *= scalar;
@@ -511,7 +511,7 @@ class Vec2 {
      * vec.subScalar(2);
      *
      * // Outputs [1, 2]
-     * console.log("The result of the subtraction is: " + a.toString());
+     * console.log("The result of the subtraction is: " + vec.toString());
      */
     subScalar(scalar) {
         this.x -= scalar;

--- a/src/math/vec2.js
+++ b/src/math/vec2.js
@@ -395,7 +395,7 @@ class Vec2 {
      * @example
      * var vec = new pc.Vec2(3, 6);
      *
-     * vec.divScalar(3);
+     * vec.mulScalar(3);
      *
      * // Outputs [9, 18]
      * console.log("The result of the multiplication is: " + vec.toString());

--- a/src/math/vec3.js
+++ b/src/math/vec3.js
@@ -595,7 +595,7 @@ class Vec3 {
      * @returns {string} The vector in string form.
      * @example
      * var v = new pc.Vec3(20, 10, 5);
-     * // Outputs '[20, 10, 5]'
+     * // Outputs [20, 10, 5]
      * console.log(v.toString());
      */
     toString() {

--- a/src/math/vec3.js
+++ b/src/math/vec3.js
@@ -111,6 +111,28 @@ class Vec3 {
 
     /**
      * @function
+     * @name Vec3#addScalar
+     * @description Adds a number to each element of a vector.
+     * @param {number} scalar - The number to add.
+     * @returns {Vec3} Self for chaining.
+     * @example
+     * var vec = new pc.Vec3(3, 4, 5);
+     *
+     * vec.addScalar(2);
+     *
+     * // Should output [5, 6, 7]
+     * console.log("The result of the addition is: " + a.toString());
+     */
+    addScalar(scalar) {
+        this.x += scalar;
+        this.y += scalar;
+        this.z += scalar;
+
+        return this;
+    }
+
+    /**
+     * @function
      * @name Vec3#clone
      * @description Returns an identical copy of the specified 3-dimensional vector.
      * @returns {Vec3} A 3-dimensional vector containing the result of the cloning.
@@ -191,6 +213,77 @@ class Vec3 {
         var y = this.y - rhs.y;
         var z = this.z - rhs.z;
         return Math.sqrt(x * x + y * y + z * z);
+    }
+
+    /**
+     * @function
+     * @name Vec3#div
+     * @description Divides a 3-dimensional vector by another in place.
+     * @param {Vec3} rhs - The vector to divide the specified vector by.
+     * @returns {Vec3} Self for chaining.
+     * @example
+     * var a = new pc.Vec3(4, 9, 16);
+     * var b = new pc.Vec3(2, 3, 4);
+     *
+     * a.div(b);
+     *
+     * // Should output [2, 3, 4]
+     * console.log("The result of the division is: " + a.toString());
+     */
+    div(rhs) {
+        this.x /= rhs.x;
+        this.y /= rhs.y;
+        this.z /= rhs.z;
+
+        return this;
+    }
+
+    /**
+     * @function
+     * @name Vec3#div2
+     * @description Divides one 3-dimensional vector by another and writes the result to
+     * the specified vector.
+     * @param {Vec3} lhs - The dividend vector (the vector being divided).
+     * @param {Vec3} rhs - The divisor vector (the vector dividing the dividend).
+     * @returns {Vec3} Self for chaining.
+     * @example
+     * var a = new pc.Vec3(4, 9, 16);
+     * var b = new pc.Vec3(2, 3, 4);
+     * var r = new pc.Vec3();
+     *
+     * r.add2(a, b);
+     * // Should output [2, 3, 4]
+     *
+     * console.log("The result of the division is: " + r.toString());
+     */
+    div2(lhs, rhs) {
+        this.x = lhs.x / rhs.x;
+        this.y = lhs.y / rhs.y;
+        this.z = lhs.z / rhs.z;
+
+        return this;
+    }
+
+    /**
+     * @function
+     * @name Vec3#divScalar
+     * @description Divides each element of a vector by a number.
+     * @param {number} scalar - The number to divide by.
+     * @returns {Vec3} Self for chaining.
+     * @example
+     * var vec = new pc.Vec3(3, 6, 9);
+     *
+     * vec.divScalar(3);
+     *
+     * // Should output [1, 2, 3]
+     * console.log("The result of the division is: " + a.toString());
+     */
+    divScalar(scalar) {
+        this.x /= scalar;
+        this.y /= scalar;
+        this.z /= scalar;
+
+        return this;
     }
 
     /**
@@ -331,6 +424,28 @@ class Vec3 {
 
     /**
      * @function
+     * @name Vec3#mulScalar
+     * @description Multiplies each element of a vector by a number.
+     * @param {number} scalar - The number to multiply by.
+     * @returns {Vec3} Self for chaining.
+     * @example
+     * var vec = new pc.Vec3(3, 6, 9);
+     *
+     * vec.divScalar(3);
+     *
+     * // Should output [9, 18, 27]
+     * console.log("The result of the multiplication is: " + a.toString());
+     */
+    mulScalar(scalar) {
+        this.x *= scalar;
+        this.y *= scalar;
+        this.z *= scalar;
+
+        return this;
+    }
+
+    /**
+     * @function
      * @name Vec3#normalize
      * @description Returns this 3-dimensional vector converted to a unit vector in place.
      * If the vector has a length of zero, the vector's elements will be set to zero.
@@ -377,33 +492,6 @@ class Vec3 {
         this.x = rhs.x * s;
         this.y = rhs.y * s;
         this.z = rhs.z * s;
-        return this;
-    }
-
-    /**
-     * @function
-     * @name Vec3#scale
-     * @description Scales each dimension of the specified 3-dimensional vector by the supplied
-     * scalar value.
-     * @param {number} scalar - The value by which each vector component is multiplied.
-     * @returns {Vec3} Self for chaining.
-     * @example
-     * var v = new pc.Vec3(2, 4, 8);
-     *
-     * // Multiply by 2
-     * v.scale(2);
-     *
-     * // Negate
-     * v.scale(-1);
-     *
-     * // Divide by 2
-     * v.scale(0.5);
-     */
-    scale(scalar) {
-        this.x *= scalar;
-        this.y *= scalar;
-        this.z *= scalar;
-
         return this;
     }
 
@@ -474,6 +562,28 @@ class Vec3 {
         this.x = lhs.x - rhs.x;
         this.y = lhs.y - rhs.y;
         this.z = lhs.z - rhs.z;
+
+        return this;
+    }
+
+    /**
+     * @function
+     * @name Vec3#subScalar
+     * @description Subtracts a number from each element of a vector.
+     * @param {number} scalar - The number to subtract.
+     * @returns {Vec3} Self for chaining.
+     * @example
+     * var vec = new pc.Vec3(3, 4, 5);
+     *
+     * vec.subScalar(2);
+     *
+     * // Should output [1, 2, 3]
+     * console.log("The result of the subtraction is: " + a.toString());
+     */
+    subScalar(scalar) {
+        this.x -= scalar;
+        this.y -= scalar;
+        this.z -= scalar;
 
         return this;
     }

--- a/src/math/vec3.js
+++ b/src/math/vec3.js
@@ -73,7 +73,7 @@ class Vec3 {
      *
      * a.add(b);
      *
-     * // Should output [30, 30, 30]
+     * // Outputs [30, 30, 30]
      * console.log("The result of the addition is: " + a.toString());
      */
     add(rhs) {
@@ -97,7 +97,7 @@ class Vec3 {
      * var r = new pc.Vec3();
      *
      * r.add2(a, b);
-     * // Should output [30, 30, 30]
+     * // Outputs [30, 30, 30]
      *
      * console.log("The result of the addition is: " + r.toString());
      */
@@ -120,7 +120,7 @@ class Vec3 {
      *
      * vec.addScalar(2);
      *
-     * // Should output [5, 6, 7]
+     * // Outputs [5, 6, 7]
      * console.log("The result of the addition is: " + a.toString());
      */
     addScalar(scalar) {
@@ -227,7 +227,7 @@ class Vec3 {
      *
      * a.div(b);
      *
-     * // Should output [2, 3, 4]
+     * // Outputs [2, 3, 4]
      * console.log("The result of the division is: " + a.toString());
      */
     div(rhs) {
@@ -252,7 +252,7 @@ class Vec3 {
      * var r = new pc.Vec3();
      *
      * r.add2(a, b);
-     * // Should output [2, 3, 4]
+     * // Outputs [2, 3, 4]
      *
      * console.log("The result of the division is: " + r.toString());
      */
@@ -275,7 +275,7 @@ class Vec3 {
      *
      * vec.divScalar(3);
      *
-     * // Should output [1, 2, 3]
+     * // Outputs [1, 2, 3]
      * console.log("The result of the division is: " + a.toString());
      */
     divScalar(scalar) {
@@ -325,7 +325,7 @@ class Vec3 {
      * @example
      * var vec = new pc.Vec3(3, 4, 0);
      * var len = vec.length();
-     * // Should output 5
+     * // Outputs 5
      * console.log("The length of the vector is: " + len);
      */
     length() {
@@ -340,7 +340,7 @@ class Vec3 {
      * @example
      * var vec = new pc.Vec3(3, 4, 0);
      * var len = vec.lengthSq();
-     * // Should output 25
+     * // Outputs 25
      * console.log("The length squared of the vector is: " + len);
      */
     lengthSq() {
@@ -386,7 +386,7 @@ class Vec3 {
      *
      * a.mul(b);
      *
-     * // Should output 8, 15, 24
+     * // Outputs 8, 15, 24
      * console.log("The result of the multiplication is: " + a.toString());
      */
     mul(rhs) {
@@ -411,7 +411,7 @@ class Vec3 {
      *
      * r.mul2(a, b);
      *
-     * // Should output 8, 15, 24
+     * // Outputs 8, 15, 24
      * console.log("The result of the multiplication is: " + r.toString());
      */
     mul2(lhs, rhs) {
@@ -433,7 +433,7 @@ class Vec3 {
      *
      * vec.divScalar(3);
      *
-     * // Should output [9, 18, 27]
+     * // Outputs [9, 18, 27]
      * console.log("The result of the multiplication is: " + a.toString());
      */
     mulScalar(scalar) {
@@ -455,7 +455,7 @@ class Vec3 {
      *
      * v.normalize();
      *
-     * // Should output 1, 0, 0
+     * // Outputs 1, 0, 0
      * console.log("The result of the vector normalization is: " + v.toString());
      */
     normalize() {
@@ -482,7 +482,7 @@ class Vec3 {
      *
      * v.project(normal);
      *
-     * // Should output 5, 0, 0
+     * // Outputs 5, 0, 0
      * console.log("The result of the vector projection is: " + v.toString());
      */
     project(rhs) {
@@ -507,7 +507,7 @@ class Vec3 {
      * var v = new pc.Vec3();
      * v.set(5, 10, 20);
      *
-     * // Should output 5, 10, 20
+     * // Outputs 5, 10, 20
      * console.log("The result of the vector set is: " + v.toString());
      */
     set(x, y, z) {
@@ -530,7 +530,7 @@ class Vec3 {
      *
      * a.sub(b);
      *
-     * // Should output [-10, -10, -10]
+     * // Outputs [-10, -10, -10]
      * console.log("The result of the subtraction is: " + a.toString());
      */
     sub(rhs) {
@@ -555,7 +555,7 @@ class Vec3 {
      *
      * r.sub2(a, b);
      *
-     * // Should output [-10, -10, -10]
+     * // Outputs [-10, -10, -10]
      * console.log("The result of the subtraction is: " + r.toString());
      */
     sub2(lhs, rhs) {
@@ -577,7 +577,7 @@ class Vec3 {
      *
      * vec.subScalar(2);
      *
-     * // Should output [1, 2, 3]
+     * // Outputs [1, 2, 3]
      * console.log("The result of the subtraction is: " + a.toString());
      */
     subScalar(scalar) {
@@ -595,7 +595,7 @@ class Vec3 {
      * @returns {string} The vector in string form.
      * @example
      * var v = new pc.Vec3(20, 10, 5);
-     * // Should output '[20, 10, 5]'
+     * // Outputs '[20, 10, 5]'
      * console.log(v.toString());
      */
     toString() {

--- a/src/math/vec3.js
+++ b/src/math/vec3.js
@@ -431,7 +431,7 @@ class Vec3 {
      * @example
      * var vec = new pc.Vec3(3, 6, 9);
      *
-     * vec.divScalar(3);
+     * vec.mulScalar(3);
      *
      * // Outputs [9, 18, 27]
      * console.log("The result of the multiplication is: " + vec.toString());

--- a/src/math/vec3.js
+++ b/src/math/vec3.js
@@ -251,7 +251,7 @@ class Vec3 {
      * var b = new pc.Vec3(2, 3, 4);
      * var r = new pc.Vec3();
      *
-     * r.add2(a, b);
+     * r.div2(a, b);
      * // Outputs [2, 3, 4]
      *
      * console.log("The result of the division is: " + r.toString());

--- a/src/math/vec3.js
+++ b/src/math/vec3.js
@@ -121,7 +121,7 @@ class Vec3 {
      * vec.addScalar(2);
      *
      * // Outputs [5, 6, 7]
-     * console.log("The result of the addition is: " + a.toString());
+     * console.log("The result of the addition is: " + vec.toString());
      */
     addScalar(scalar) {
         this.x += scalar;
@@ -177,7 +177,7 @@ class Vec3 {
      * @example
      * var back = new pc.Vec3().cross(pc.Vec3.RIGHT, pc.Vec3.UP);
      *
-     * // Should print the Z axis (i.e. [0, 0, 1])
+     * // Prints the Z axis (i.e. [0, 0, 1])
      * console.log("The result of the cross product is: " + back.toString());
      */
     cross(lhs, rhs) {
@@ -276,7 +276,7 @@ class Vec3 {
      * vec.divScalar(3);
      *
      * // Outputs [1, 2, 3]
-     * console.log("The result of the division is: " + a.toString());
+     * console.log("The result of the division is: " + vec.toString());
      */
     divScalar(scalar) {
         this.x /= scalar;
@@ -434,7 +434,7 @@ class Vec3 {
      * vec.divScalar(3);
      *
      * // Outputs [9, 18, 27]
-     * console.log("The result of the multiplication is: " + a.toString());
+     * console.log("The result of the multiplication is: " + vec.toString());
      */
     mulScalar(scalar) {
         this.x *= scalar;
@@ -578,7 +578,7 @@ class Vec3 {
      * vec.subScalar(2);
      *
      * // Outputs [1, 2, 3]
-     * console.log("The result of the subtraction is: " + a.toString());
+     * console.log("The result of the subtraction is: " + vec.toString());
      */
     subScalar(scalar) {
         this.x -= scalar;

--- a/src/math/vec4.js
+++ b/src/math/vec4.js
@@ -133,12 +133,12 @@ class Vec4 {
 
     /**
      * @function
-     * @name Vec3#addScalar
+     * @name Vec4#addScalar
      * @description Adds a number to each element of a vector.
      * @param {number} scalar - The number to add.
      * @returns {Vec4} Self for chaining.
      * @example
-     * var vec = new pc.Vec3(3, 4, 5, 6);
+     * var vec = new pc.Vec4(3, 4, 5, 6);
      *
      * vec.addScalar(2);
      *
@@ -193,7 +193,7 @@ class Vec4 {
 
     /**
      * @function
-     * @name Vec3#div
+     * @name Vec4#div
      * @description Divides a 4-dimensional vector by another in place.
      * @param {Vec4} rhs - The vector to divide the specified vector by.
      * @returns {Vec4} Self for chaining.
@@ -224,9 +224,9 @@ class Vec4 {
      * @param {Vec4} rhs - The divisor vector (the vector dividing the dividend).
      * @returns {Vec4} Self for chaining.
      * @example
-     * var a = new pc.Vec3(4, 9, 16, 25);
-     * var b = new pc.Vec3(2, 3, 4, 5);
-     * var r = new pc.Vec3();
+     * var a = new pc.Vec4(4, 9, 16, 25);
+     * var b = new pc.Vec4(2, 3, 4, 5);
+     * var r = new pc.Vec4();
      *
      * r.add2(a, b);
      * // Should output [2, 3, 4, 5]
@@ -411,7 +411,7 @@ class Vec4 {
      * @param {number} scalar - The number to multiply by.
      * @returns {Vec4} Self for chaining.
      * @example
-     * var vec = new pc.Vec3(3, 6, 9, 12);
+     * var vec = new pc.Vec4(3, 6, 9, 12);
      *
      * vec.divScalar(3);
      *

--- a/src/math/vec4.js
+++ b/src/math/vec4.js
@@ -143,7 +143,7 @@ class Vec4 {
      * vec.addScalar(2);
      *
      * // Outputs [5, 6, 7, 8]
-     * console.log("The result of the addition is: " + a.toString());
+     * console.log("The result of the addition is: " + vec.toString());
      */
     addScalar(scalar) {
         this.x += scalar;
@@ -254,7 +254,7 @@ class Vec4 {
      * vec.divScalar(3);
      *
      * // Outputs [1, 2, 3, 4]
-     * console.log("The result of the division is: " + a.toString());
+     * console.log("The result of the division is: " + vec.toString());
      */
     divScalar(scalar) {
         this.x /= scalar;
@@ -416,7 +416,7 @@ class Vec4 {
      * vec.divScalar(3);
      *
      * // Outputs [9, 18, 27, 36]
-     * console.log("The result of the multiplication is: " + a.toString());
+     * console.log("The result of the multiplication is: " + vec.toString());
      */
     mulScalar(scalar) {
         this.x *= scalar;
@@ -541,7 +541,7 @@ class Vec4 {
      * vec.subScalar(2);
      *
      * // Outputs [1, 2, 3, 4]
-     * console.log("The result of the subtraction is: " + a.toString());
+     * console.log("The result of the subtraction is: " + vec.toString());
      */
     subScalar(scalar) {
         this.x -= scalar;

--- a/src/math/vec4.js
+++ b/src/math/vec4.js
@@ -559,7 +559,7 @@ class Vec4 {
      * @returns {string} The vector in string form.
      * @example
      * var v = new pc.Vec4(20, 10, 5, 0);
-     * // Outputs '[20, 10, 5, 0]'
+     * // Outputs [20, 10, 5, 0]
      * console.log(v.toString());
      */
     toString() {

--- a/src/math/vec4.js
+++ b/src/math/vec4.js
@@ -413,7 +413,7 @@ class Vec4 {
      * @example
      * var vec = new pc.Vec4(3, 6, 9, 12);
      *
-     * vec.divScalar(3);
+     * vec.mulScalar(3);
      *
      * // Outputs [9, 18, 27, 36]
      * console.log("The result of the multiplication is: " + vec.toString());

--- a/src/math/vec4.js
+++ b/src/math/vec4.js
@@ -133,6 +133,29 @@ class Vec4 {
 
     /**
      * @function
+     * @name Vec3#addScalar
+     * @description Adds a number to each element of a vector.
+     * @param {number} scalar - The number to add.
+     * @returns {Vec4} Self for chaining.
+     * @example
+     * var vec = new pc.Vec3(3, 4, 5, 6);
+     *
+     * vec.addScalar(2);
+     *
+     * // Should output [5, 6, 7, 8]
+     * console.log("The result of the addition is: " + a.toString());
+     */
+    addScalar(scalar) {
+        this.x += scalar;
+        this.y += scalar;
+        this.z += scalar;
+        this.w += scalar;
+
+        return this;
+    }
+
+    /**
+     * @function
      * @name Vec4#clone
      * @description Returns an identical copy of the specified 4-dimensional vector.
      * @returns {Vec4} A 4-dimensional vector containing the result of the cloning.
@@ -164,6 +187,80 @@ class Vec4 {
         this.y = rhs.y;
         this.z = rhs.z;
         this.w = rhs.w;
+
+        return this;
+    }
+
+    /**
+     * @function
+     * @name Vec3#div
+     * @description Divides a 4-dimensional vector by another in place.
+     * @param {Vec4} rhs - The vector to divide the specified vector by.
+     * @returns {Vec4} Self for chaining.
+     * @example
+     * var a = new pc.Vec4(4, 9, 16, 25);
+     * var b = new pc.Vec4(2, 3, 4, 5);
+     *
+     * a.div(b);
+     *
+     * // Should output [2, 3, 4, 5]
+     * console.log("The result of the division is: " + a.toString());
+     */
+    div(rhs) {
+        this.x /= rhs.x;
+        this.y /= rhs.y;
+        this.z /= rhs.z;
+        this.w /= rhs.w;
+
+        return this;
+    }
+
+    /**
+     * @function
+     * @name Vec4#div2
+     * @description Divides one 4-dimensional vector by another and writes the result to
+     * the specified vector.
+     * @param {Vec4} lhs - The dividend vector (the vector being divided).
+     * @param {Vec4} rhs - The divisor vector (the vector dividing the dividend).
+     * @returns {Vec4} Self for chaining.
+     * @example
+     * var a = new pc.Vec3(4, 9, 16, 25);
+     * var b = new pc.Vec3(2, 3, 4, 5);
+     * var r = new pc.Vec3();
+     *
+     * r.add2(a, b);
+     * // Should output [2, 3, 4, 5]
+     *
+     * console.log("The result of the division is: " + r.toString());
+     */
+    div2(lhs, rhs) {
+        this.x = lhs.x / rhs.x;
+        this.y = lhs.y / rhs.y;
+        this.z = lhs.z / rhs.z;
+        this.w = lhs.w / rhs.w;
+
+        return this;
+    }
+
+    /**
+     * @function
+     * @name Vec4#divScalar
+     * @description Divides each element of a vector by a number.
+     * @param {number} scalar - The number to divide by.
+     * @returns {Vec4} Self for chaining.
+     * @example
+     * var vec = new pc.Vec4(3, 6, 9, 12);
+     *
+     * vec.divScalar(3);
+     *
+     * // Should output [1, 2, 3, 4]
+     * console.log("The result of the division is: " + a.toString());
+     */
+    divScalar(scalar) {
+        this.x /= scalar;
+        this.y /= scalar;
+        this.z /= scalar;
+        this.w /= scalar;
 
         return this;
     }
@@ -309,6 +406,29 @@ class Vec4 {
 
     /**
      * @function
+     * @name Vec4#mulScalar
+     * @description Multiplies each element of a vector by a number.
+     * @param {number} scalar - The number to multiply by.
+     * @returns {Vec4} Self for chaining.
+     * @example
+     * var vec = new pc.Vec3(3, 6, 9, 12);
+     *
+     * vec.divScalar(3);
+     *
+     * // Should output [9, 18, 27, 36]
+     * console.log("The result of the multiplication is: " + a.toString());
+     */
+    mulScalar(scalar) {
+        this.x *= scalar;
+        this.y *= scalar;
+        this.z *= scalar;
+        this.w *= scalar;
+
+        return this;
+    }
+
+    /**
+     * @function
      * @name Vec4#normalize
      * @description Returns this 4-dimensional vector converted to a unit vector in place.
      * If the vector has a length of zero, the vector's elements will be set to zero.
@@ -330,34 +450,6 @@ class Vec4 {
             this.z *= invLength;
             this.w *= invLength;
         }
-
-        return this;
-    }
-
-    /**
-     * @function
-     * @name Vec4#scale
-     * @description Scales each dimension of the specified 4-dimensional vector by the supplied
-     * scalar value.
-     * @param {number} scalar - The value by which each vector component is multiplied.
-     * @returns {Vec4} Self for chaining.
-     * @example
-     * var v = new pc.Vec4(2, 4, 8, 16);
-     *
-     * // Multiply by 2
-     * v.scale(2);
-     *
-     * // Negate
-     * v.scale(-1);
-     *
-     * // Divide by 2
-     * v.scale(0.5);
-     */
-    scale(scalar) {
-        this.x *= scalar;
-        this.y *= scalar;
-        this.z *= scalar;
-        this.w *= scalar;
 
         return this;
     }
@@ -433,6 +525,29 @@ class Vec4 {
         this.y = lhs.y - rhs.y;
         this.z = lhs.z - rhs.z;
         this.w = lhs.w - rhs.w;
+
+        return this;
+    }
+
+    /**
+     * @function
+     * @name Vec4#subScalar
+     * @description Subtracts a number from each element of a vector.
+     * @param {number} scalar - The number to subtract.
+     * @returns {Vec4} Self for chaining.
+     * @example
+     * var vec = new pc.Vec4(3, 4, 5, 6);
+     *
+     * vec.subScalar(2);
+     *
+     * // Should output [1, 2, 3, 4]
+     * console.log("The result of the subtraction is: " + a.toString());
+     */
+    subScalar(scalar) {
+        this.x -= scalar;
+        this.y -= scalar;
+        this.z -= scalar;
+        this.w -= scalar;
 
         return this;
     }

--- a/src/math/vec4.js
+++ b/src/math/vec4.js
@@ -93,7 +93,7 @@ class Vec4 {
      *
      * a.add(b);
      *
-     * // Should output [30, 30, 30]
+     * // Outputs [30, 30, 30]
      * console.log("The result of the addition is: " + a.toString());
      */
     add(rhs) {
@@ -118,7 +118,7 @@ class Vec4 {
      * var r = new pc.Vec4();
      *
      * r.add2(a, b);
-     * // Should output [30, 30, 30]
+     * // Outputs [30, 30, 30]
      *
      * console.log("The result of the addition is: " + r.toString());
      */
@@ -142,7 +142,7 @@ class Vec4 {
      *
      * vec.addScalar(2);
      *
-     * // Should output [5, 6, 7, 8]
+     * // Outputs [5, 6, 7, 8]
      * console.log("The result of the addition is: " + a.toString());
      */
     addScalar(scalar) {
@@ -203,7 +203,7 @@ class Vec4 {
      *
      * a.div(b);
      *
-     * // Should output [2, 3, 4, 5]
+     * // Outputs [2, 3, 4, 5]
      * console.log("The result of the division is: " + a.toString());
      */
     div(rhs) {
@@ -229,7 +229,7 @@ class Vec4 {
      * var r = new pc.Vec4();
      *
      * r.add2(a, b);
-     * // Should output [2, 3, 4, 5]
+     * // Outputs [2, 3, 4, 5]
      *
      * console.log("The result of the division is: " + r.toString());
      */
@@ -253,7 +253,7 @@ class Vec4 {
      *
      * vec.divScalar(3);
      *
-     * // Should output [1, 2, 3, 4]
+     * // Outputs [1, 2, 3, 4]
      * console.log("The result of the division is: " + a.toString());
      */
     divScalar(scalar) {
@@ -304,7 +304,7 @@ class Vec4 {
      * @example
      * var vec = new pc.Vec4(3, 4, 0, 0);
      * var len = vec.length();
-     * // Should output 5
+     * // Outputs 5
      * console.log("The length of the vector is: " + len);
      */
     length() {
@@ -319,7 +319,7 @@ class Vec4 {
      * @example
      * var vec = new pc.Vec4(3, 4, 0);
      * var len = vec.lengthSq();
-     * // Should output 25
+     * // Outputs 25
      * console.log("The length squared of the vector is: " + len);
      */
     lengthSq() {
@@ -366,7 +366,7 @@ class Vec4 {
      *
      * a.mul(b);
      *
-     * // Should output 8, 15, 24, 35
+     * // Outputs 8, 15, 24, 35
      * console.log("The result of the multiplication is: " + a.toString());
      */
     mul(rhs) {
@@ -392,7 +392,7 @@ class Vec4 {
      *
      * r.mul2(a, b);
      *
-     * // Should output 8, 15, 24, 35
+     * // Outputs 8, 15, 24, 35
      * console.log("The result of the multiplication is: " + r.toString());
      */
     mul2(lhs, rhs) {
@@ -415,7 +415,7 @@ class Vec4 {
      *
      * vec.divScalar(3);
      *
-     * // Should output [9, 18, 27, 36]
+     * // Outputs [9, 18, 27, 36]
      * console.log("The result of the multiplication is: " + a.toString());
      */
     mulScalar(scalar) {
@@ -438,7 +438,7 @@ class Vec4 {
      *
      * v.normalize();
      *
-     * // Should output 1, 0, 0, 0
+     * // Outputs 1, 0, 0, 0
      * console.log("The result of the vector normalization is: " + v.toString());
      */
     normalize() {
@@ -467,7 +467,7 @@ class Vec4 {
      * var v = new pc.Vec4();
      * v.set(5, 10, 20, 40);
      *
-     * // Should output 5, 10, 20, 40
+     * // Outputs 5, 10, 20, 40
      * console.log("The result of the vector set is: " + v.toString());
      */
     set(x, y, z, w) {
@@ -491,7 +491,7 @@ class Vec4 {
      *
      * a.sub(b);
      *
-     * // Should output [-10, -10, -10, -10]
+     * // Outputs [-10, -10, -10, -10]
      * console.log("The result of the subtraction is: " + a.toString());
      */
     sub(rhs) {
@@ -517,7 +517,7 @@ class Vec4 {
      *
      * r.sub2(a, b);
      *
-     * // Should output [-10, -10, -10, -10]
+     * // Outputs [-10, -10, -10, -10]
      * console.log("The result of the subtraction is: " + r.toString());
      */
     sub2(lhs, rhs) {
@@ -540,7 +540,7 @@ class Vec4 {
      *
      * vec.subScalar(2);
      *
-     * // Should output [1, 2, 3, 4]
+     * // Outputs [1, 2, 3, 4]
      * console.log("The result of the subtraction is: " + a.toString());
      */
     subScalar(scalar) {
@@ -559,7 +559,7 @@ class Vec4 {
      * @returns {string} The vector in string form.
      * @example
      * var v = new pc.Vec4(20, 10, 5, 0);
-     * // Should output '[20, 10, 5, 0]'
+     * // Outputs '[20, 10, 5, 0]'
      * console.log(v.toString());
      */
     toString() {

--- a/src/math/vec4.js
+++ b/src/math/vec4.js
@@ -228,7 +228,7 @@ class Vec4 {
      * var b = new pc.Vec4(2, 3, 4, 5);
      * var r = new pc.Vec4();
      *
-     * r.add2(a, b);
+     * r.div2(a, b);
      * // Outputs [2, 3, 4, 5]
      *
      * console.log("The result of the division is: " + r.toString());

--- a/tests/math/test_vec2.js
+++ b/tests/math/test_vec2.js
@@ -242,7 +242,7 @@ describe("pc.Vec2", function () {
     });
 
     it("subScalar", function() {
-        var v = new pc.Vec2(2, 4, 6);
+        var v = new pc.Vec2(2, 4);
 
         v.subScalar(2);
 
@@ -259,4 +259,3 @@ describe("pc.Vec2", function () {
     });
 
 });
-

--- a/tests/math/test_vec2.js
+++ b/tests/math/test_vec2.js
@@ -9,6 +9,16 @@ describe("pc.Vec2", function () {
         equal(4, v1.y);
     });
 
+    it("add", function() {
+        var v1 = new pc.Vec2(2, 4);
+        var v2 = new pc.Vec2(1, 2);
+
+        v1.add(v2);
+
+        equal(3, v1.x);
+        equal(6, v1.y);
+    });
+
     it("add2", function() {
         var v1 = new pc.Vec2(2, 4);
         var v2 = new pc.Vec2(1, 2);
@@ -18,6 +28,15 @@ describe("pc.Vec2", function () {
 
         equal(3, r.x);
         equal(6, r.y);
+    });
+
+    it("addScalar", function() {
+        var v = new pc.Vec2(2, 4);
+
+        v.addScalar(2);
+
+        equal(4, v.x);
+        equal(6, v.y);
     });
 
     it("clone", function () {
@@ -50,6 +69,33 @@ describe("pc.Vec2", function () {
 
     it("constructor: args", function() {
         var v = new pc.Vec2(1, 2);
+
+        equal(1, v.x);
+        equal(2, v.y);
+    });
+
+    it("div", function() {
+        var v1 = new pc.Vec2(9, 16);
+        var v2 = new pc.Vec2(3, 4);
+        v1.div(v2);
+
+        equal(3, v1.x);
+        equal(4, v1.y);
+    });
+
+    it("div2", function() {
+        var v1 = new pc.Vec2(9, 16);
+        var v2 = new pc.Vec2(3, 4);
+        var r = new pc.Vec2();
+        r.div2(v1, v2);
+
+        equal(3, r.x);
+        equal(4, r.y);
+    });
+
+    it("divScalar", function() {
+        var v = new pc.Vec2(3, 6);
+        v.divScalar(3);
 
         equal(1, v.x);
         equal(2, v.y);
@@ -144,6 +190,14 @@ describe("pc.Vec2", function () {
         equal(8, r.y);
     });
 
+    it("mulScalar", function() {
+        var v = new pc.Vec2(1, 2);
+        v.mulScalar(2);
+
+        equal(2, v.x);
+        equal(4, v.y);
+    });
+
     it("normalize", function(){
         var x = new pc.Vec2(10, 0);
         var y = new pc.Vec2(0, 10);
@@ -155,14 +209,6 @@ describe("pc.Vec2", function () {
         y.normalize()
         equal(0, y.x);
         equal(1, y.y);
-    });
-
-    it("scale", function() {
-        var v = new pc.Vec2(1, 2);
-        v.scale(2);
-
-        equal(2, v.x);
-        equal(4, v.y);
     });
 
     it("set", function() {
@@ -193,6 +239,15 @@ describe("pc.Vec2", function () {
 
         equal(1, r.x);
         equal(2, r.y);
+    });
+
+    it("subScalar", function() {
+        var v = new pc.Vec2(2, 4, 6);
+
+        v.subScalar(2);
+
+        equal(0, v.x);
+        equal(2, v.y);
     });
 
     it("toString", function() {

--- a/tests/math/test_vec3.js
+++ b/tests/math/test_vec3.js
@@ -14,6 +14,17 @@ describe("pc.Vec3", function () {
         equal(6, v1.z);
     });
 
+    it("add", function() {
+        var v1 = new pc.Vec3(2, 4, 6);
+        var v2 = new pc.Vec3(1, 2, 3);
+
+        v1.add(v2);
+
+        equal(3, v1.x);
+        equal(6, v1.y);
+        equal(9, v1.z);
+    });
+
     it("add2", function() {
         var v1 = new pc.Vec3(2, 4, 6);
         var v2 = new pc.Vec3(1, 2, 3);
@@ -24,6 +35,16 @@ describe("pc.Vec3", function () {
         equal(3, r.x);
         equal(6, r.y);
         equal(9, r.z);
+    });
+
+    it("addScalar", function() {
+        var v = new pc.Vec3(2, 4, 6);
+
+        v.addScalar(2);
+
+        equal(4, v.x);
+        equal(6, v.y);
+        equal(8, v.z);
     });
 
     it("clone", function () {
@@ -97,6 +118,36 @@ describe("pc.Vec3", function () {
         equal(0, r.x);
         equal(0, r.y);
         equal(1, r.z);
+    });
+
+    it("div", function() {
+        var v1 = new pc.Vec3(9, 16, 25);
+        var v2 = new pc.Vec3(3, 4, 5);
+        v1.div(v2);
+
+        equal(3, v1.x);
+        equal(4, v1.y);
+        equal(5, v1.z);
+    });
+
+    it("div2", function() {
+        var v1 = new pc.Vec3(9, 16, 25);
+        var v2 = new pc.Vec3(3, 4, 5);
+        var r = new pc.Vec3();
+        r.div2(v1, v2);
+
+        equal(3, r.x);
+        equal(4, r.y);
+        equal(5, r.z);
+    });
+
+    it("divScalar", function() {
+        var v = new pc.Vec3(3, 6, 9);
+        v.divScalar(3);
+
+        equal(1, v.x);
+        equal(2, v.y);
+        equal(3, v.z);
     });
 
     it("dot", function() {
@@ -188,6 +239,15 @@ describe("pc.Vec3", function () {
         equal(9, r.z);
     });
 
+    it("mulScalar", function() {
+        var v = new pc.Vec3(1, 2, 3);
+        v.mulScalar(2);
+
+        equal(2, v.x);
+        equal(4, v.y);
+        equal(6, v.z);
+    });
+
     it("normalize", function(){
         var x = new pc.Vec3(10, 0, 0);
         var y = new pc.Vec3(0, 10, 0);
@@ -227,15 +287,6 @@ describe("pc.Vec3", function () {
         equal(p.z, 0);
     });
 
-    it("scale", function() {
-        var v = new pc.Vec3(1, 2, 3);
-        v.scale(2);
-
-        equal(2, v.x);
-        equal(4, v.y);
-        equal(6, v.z);
-    });
-
     it("set", function() {
         var v1 = new pc.Vec3();
 
@@ -269,6 +320,16 @@ describe("pc.Vec3", function () {
         equal(3, r.z);
     });
 
+    it("subScalar", function() {
+        var v = new pc.Vec3(2, 4, 6);
+
+        v.subScalar(2);
+
+        equal(0, v.x);
+        equal(2, v.y);
+        equal(4, v.z);
+    });
+
     it("toString", function() {
         var v1 = new pc.Vec3(2, 4, 6);
 
@@ -276,6 +337,5 @@ describe("pc.Vec3", function () {
 
         equal(s, '[2, 4, 6]');
     });
-
 });
 

--- a/tests/math/test_vec4.js
+++ b/tests/math/test_vec4.js
@@ -19,6 +19,18 @@ describe("pc.Vec4", function () {
         equal(8, v1.w);
     });
 
+    it("add", function() {
+        var v1 = new pc.Vec4(2, 4, 6, 8);
+        var v2 = new pc.Vec4(1, 2, 3, 4);
+
+        v1.add(v2);
+
+        equal(3, v1.x);
+        equal(6, v1.y);
+        equal(9, v1.z);
+        equal(12, v1.w);
+    });
+
     it("add2", function() {
         var v1 = new pc.Vec4(2, 4, 6, 8);
         var v2 = new pc.Vec4(1, 2, 3, 4);
@@ -30,6 +42,17 @@ describe("pc.Vec4", function () {
         equal(6, r.y);
         equal(9, r.z);
         equal(12, r.w);
+    });
+
+    it("addScalar", function() {
+        var v = new pc.Vec4(2, 4, 6, 8);
+
+        v.addScalar(2);
+
+        equal(4, v.x);
+        equal(6, v.y);
+        equal(8, v.z);
+        equal(10, v.w);
     });
 
     it("clone", function () {
@@ -68,6 +91,39 @@ describe("pc.Vec4", function () {
 
     it("constructor: args", function() {
         var v = new pc.Vec4(1, 2, 3, 4);
+
+        equal(1, v.x);
+        equal(2, v.y);
+        equal(3, v.z);
+        equal(4, v.w);
+    });
+
+    it("div", function() {
+        var v1 = new pc.Vec4(9, 16, 25, 36);
+        var v2 = new pc.Vec4(3, 4, 5, 6);
+        v1.div(v2);
+
+        equal(3, v1.x);
+        equal(4, v1.y);
+        equal(5, v1.z);
+        equal(6, v1.w);
+    });
+
+    it("div2", function() {
+        var v1 = new pc.Vec4(9, 16, 25, 36);
+        var v2 = new pc.Vec4(3, 4, 5, 6);
+        var r = new pc.Vec4();
+        r.div2(v1, v2);
+
+        equal(3, r.x);
+        equal(4, r.y);
+        equal(5, r.z);
+        equal(6, r.w);
+    });
+
+    it("divScalar", function() {
+        var v = new pc.Vec4(3, 6, 9, 12);
+        v.divScalar(3);
 
         equal(1, v.x);
         equal(2, v.y);
@@ -152,6 +208,16 @@ describe("pc.Vec4", function () {
         equal(32, r.w);
     });
 
+    it("mulScalar", function() {
+        var v = new pc.Vec4(1, 2, 3, 4);
+        v.mulScalar(2);
+
+        equal(2, v.x);
+        equal(4, v.y);
+        equal(6, v.z);
+        equal(8, v.w);
+    });
+
     it("normalize", function(){
         var x = new pc.Vec4(10, 0, 0, 0);
         var y = new pc.Vec4(0, 10, 0, 0);
@@ -181,16 +247,6 @@ describe("pc.Vec4", function () {
         equal(0, w.y);
         equal(0, w.z);
         equal(1, w.w);
-    });
-
-    it("scale", function() {
-        var v = new pc.Vec4(1, 2, 3, 4);
-        v.scale(2);
-
-        equal(2, v.x);
-        equal(4, v.y);
-        equal(6, v.z);
-        equal(8, v.w);
     });
 
     it("set", function() {
@@ -227,6 +283,17 @@ describe("pc.Vec4", function () {
         equal(-4, r.y);
         equal(-4, r.z);
         equal(-4, r.w);
+    });
+
+    it("subScalar", function() {
+        var v = new pc.Vec4(2, 4, 6, 8);
+
+        v.subScalar(2);
+
+        equal(0, v.x);
+        equal(2, v.y);
+        equal(4, v.z);
+        equal(6, v.w);
     });
 
     it("toString", function() {


### PR DESCRIPTION
Adds the following API:

```typescript
Vec2.addScalar(scalar: number) : Vec2
Vec2.div(v: Vec2) : Vec2
Vec2.div2(v1: Vec2, v2: Vec2) : Vec2
Vec2.divScalar(scalar: number) : Vec2
Vec2.mulScalar(scalar: number) : Vec2
Vec2.subScalar(scalar: number) : Vec2

Vec3.addScalar(scalar: number) : Vec3
Vec3.div(v: Vec3) : Vec3
Vec3.div2(v1: Vec3, v2: Vec3) : Vec3
Vec3.divScalar(scalar: number) : Vec3
Vec3.mulScalar(scalar: number) : Vec3
Vec3.subScalar(scalar: number) : Vec3

Vec4.addScalar(scalar: number) : Vec4
Vec4.div(v: Vec4) : Vec4
Vec4.div2(v1: Vec4, v2: Vec4) : Vec4
Vec4.divScalar(scalar: number) : Vec4
Vec4.mulScalar(scalar: number) : Vec4
Vec4.subScalar(scalar: number) : Vec4
```

Deprecates the following API:

```typescript
Vec2.scale(scale: number) : Vec2
Vec3.scale(scale: number) : Vec3
Vec4.scale(scale: number) : Vec4
```

Adds unit tests for all new API.

Fixes #2942 

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
