### PR TITLE
Make area lights public

### DIFF
--- a/examples/camera/fly.html
+++ b/examples/camera/fly.html
@@ -93,7 +93,7 @@
         // make our scene prettier by adding a directional light
         var light = new pc.Entity();
         light.addComponent("light", {
-            type: "point",
+            type: "omni",
             color: new pc.Color(1, 1, 1),
             range: 100
         });

--- a/examples/examples.js
+++ b/examples/examples.js
@@ -16,6 +16,7 @@ var categories = [
     }, {
         name: "graphics",
         examples: [
+            "area-lights",
             "area-picker",
             "batching-dynamic",
             "grab-pass",

--- a/examples/graphics/area-picker.html
+++ b/examples/graphics/area-picker.html
@@ -79,10 +79,10 @@
         });
         app.root.addChild(camera);
 
-        // Create an Entity with a point light component
+        // Create an Entity with a omni light component
         var light1 = new pc.Entity();
         light1.addComponent("light", {
-            type: "point",
+            type: "omni",
             color: new pc.Color(0.7, 0.7, 0.7),
             range: 150
         });

--- a/examples/graphics/grab-pass.html
+++ b/examples/graphics/grab-pass.html
@@ -134,10 +134,10 @@
         camera.setLocalPosition(0, 10, 20);
         camera.lookAt(pc.Vec3.ZERO);
 
-        // Create an Entity with a point light component
+        // Create an Entity with a omni light component
         var light = new pc.Entity();
         light.addComponent("light", {
-            type: "point",
+            type: "omni",
             color: new pc.Color(1, 1, 1),
             range: 100,
             castShadows: true

--- a/examples/graphics/hardware-instancing.html
+++ b/examples/graphics/hardware-instancing.html
@@ -39,10 +39,10 @@
 
         app.scene.ambientLight = new pc.Color(0.1, 0.1, 0.1);
 
-        // Create an Entity with a point light component, which is casting shadows (using rendering to cubemap)
+        // Create an Entity with a omni light component, which is casting shadows (using rendering to cubemap)
         var light = new pc.Entity();
         light.addComponent("light", {
-            type: "point",
+            type: "omni",
             color: new pc.Color(2, 3, 1),
             radius: 10,
             castShadows: true

--- a/examples/graphics/hierarchy.html
+++ b/examples/graphics/hierarchy.html
@@ -105,10 +105,10 @@
         camera.lookAt(new pc.Vec3(0, 5, 0));
         app.root.addChild(camera);
 
-        // Create an Entity with a point light component
+        // Create an Entity with a omni light component
         var light = new pc.Entity();
         light.addComponent("light", {
-            type: "point",
+            type: "omni",
             color: new pc.Color(1, 1, 1),
             range: 150
         });

--- a/examples/graphics/layers.html
+++ b/examples/graphics/layers.html
@@ -63,11 +63,11 @@
         camera.translate(0, 0, 24);
         app.root.addChild(camera);
 
-        // Create an Entity with a point light component
+        // Create an Entity with a omni light component
         // Make sure it lights both World and Front Layer
         var light = new pc.Entity();
         light.addComponent("light", {
-            type: "point",
+            type: "omni",
             color: new pc.Color(1, 1, 1),
             range: 100,
             layers: [worldLayer.id, layer.id]

--- a/examples/graphics/lights-baked-ao.html
+++ b/examples/graphics/lights-baked-ao.html
@@ -126,7 +126,7 @@
             light.setLocalEulerAngles(Math.random() * p - (p * 0.5), 10, Math.random() * p - (p * 0.5));
         }
 
-        // Create an entity with a point light component that is configured as a baked light
+        // Create an entity with a omni light component that is configured as a baked light
         var lightPoint = new pc.Entity("Point");
         lightPoint.addComponent("light", {
             affectDynamic: false,
@@ -140,7 +140,7 @@
             shadowType: pc.SHADOW_PCF3,
             color: pc.Color.RED,
             range: 10,
-            type: "point"
+            type: "omni"
         });
         lightPoint.setLocalPosition(-6, 5, 0);
         app.root.addChild(lightPoint);

--- a/examples/graphics/lights.html
+++ b/examples/graphics/lights.html
@@ -113,20 +113,20 @@
         spotlight.addChild(cone);
         app.root.addChild(spotlight);
 
-        // Create a point light
-        var pointlight = new pc.Entity();
-        pointlight.addComponent("light", {
-            type: "point",
+        // Create a omni light
+        var omnilight = new pc.Entity();
+        omnilight.addComponent("light", {
+            type: "omni",
             color: pc.Color.YELLOW,
             range: 100,
             castShadows: true,
             intensity: 0.6
         });
-        pointlight.addComponent("model", {
+        omnilight.addComponent("model", {
             type: "sphere"
         });
-        pointlight.model.material = createMaterial({ diffuse: new pc.Color(0, 0, 0), emissive: pc.Color.YELLOW });
-        app.root.addChild(pointlight);
+        omnilight.model.material = createMaterial({ diffuse: new pc.Color(0, 0, 0), emissive: pc.Color.YELLOW });
+        app.root.addChild(omnilight);
 
         // Create a directional light
         var directionallight = new pc.Entity();
@@ -180,7 +180,7 @@
         app.keyboard.on("keydown", function (e) {
             switch (e.key) {
                 case pc.KEY_1:
-                    pointlight.enabled = !pointlight.enabled
+                    omnilight.enabled = !omnilight.enabled
                     break;
                 case pc.KEY_2:
                     spotlight.enabled = !spotlight.enabled;
@@ -201,7 +201,7 @@
                 spotlight.rotateLocal(90, 0, 0);
                 spotlight.setLocalPosition(20 * Math.sin(angleRad), 5, 20 * Math.cos(angleRad));
 
-                pointlight.setLocalPosition(5 * Math.sin(-2 * angleRad), 10, 5 * Math.cos(-2 * angleRad));
+                omnilight.setLocalPosition(5 * Math.sin(-2 * angleRad), 10, 5 * Math.cos(-2 * angleRad));
 
                 directionallight.setLocalEulerAngles(45, 60 * angleRad, 0);
             }
@@ -209,7 +209,7 @@
             // update text showing which lights are enabled
             if (text) {
                 text.element.text = 
-                    "[Key 1] Point light: " + pointlight.enabled +
+                    "[Key 1] Omni light: " + omnilight.enabled +
                     "\n[Key 2] Spot light: " + spotlight.enabled +
                     "\n[Key 3] Directional light: " + directionallight.enabled;
             }

--- a/examples/graphics/mesh-decals.html
+++ b/examples/graphics/mesh-decals.html
@@ -49,10 +49,10 @@
         primitive.setLocalPosition(new pc.Vec3(0, -0.01, 0));
         app.root.addChild(primitive);
 
-        // Create an Entity with a point light component
+        // Create an Entity with a omni light component
         var light = new pc.Entity();
         light.addComponent("light", {
-            type: "point",
+            type: "omni",
             color: new pc.Color(0.2, 0.2, 0.2),
             range: 30,
             castShadows: true

--- a/examples/graphics/mesh-deformation.html
+++ b/examples/graphics/mesh-deformation.html
@@ -46,10 +46,10 @@
         camera.translate(0, 7, 24);
         app.root.addChild(camera);
 
-        // Create an Entity with a point light component
+        // Create an Entity with a omni light component
         var light = new pc.Entity();
         light.addComponent("light", {
-            type: "point",
+            type: "omni",
             color: new pc.Color(1, 1, 1),
             range: 100,
             castShadows: true

--- a/examples/graphics/mesh-generation.html
+++ b/examples/graphics/mesh-generation.html
@@ -41,10 +41,10 @@
         // helper function to create a light
         function createLight(color, scale) {
 
-            // Create an Entity with a point light component, which is casting shadows (using rendering to cubemap)
+            // Create an Entity with a omni light component, which is casting shadows (using rendering to cubemap)
             var light = new pc.Entity();
             light.addComponent("light", {
-                type: "point",
+                type: "omni",
                 color: color,
                 radius: 10,
                 castShadows: false

--- a/examples/graphics/model-asset.html
+++ b/examples/graphics/model-asset.html
@@ -61,10 +61,10 @@
             camera.translate(0, 7, 24);
             app.root.addChild(camera);
 
-            // Create an Entity with a point light component
+            // Create an Entity with a omni light component
             var light = new pc.Entity();
             light.addComponent("light", {
-                type: "point",
+                type: "omni",
                 color: new pc.Color(1, 1, 1),
                 range: 100,
                 castShadows: true

--- a/examples/graphics/model-box.html
+++ b/examples/graphics/model-box.html
@@ -45,10 +45,10 @@
             type: "box"
         });
 
-        // Create an Entity with a point light component and a sphere model component.
+        // Create an Entity with a omni light component and a sphere model component.
         var light = new pc.Entity();
         light.addComponent("light", {
-            type: "point",
+            type: "omni",
             color: new pc.Color(1, 0, 0),
             radius: 10
         });

--- a/examples/graphics/model-outline.html
+++ b/examples/graphics/model-outline.html
@@ -112,10 +112,10 @@
 
         app.root.addChild(camera);
 
-        // Create an Entity with a point light component and add it to both layers
+        // Create an Entity with a omni light component and add it to both layers
         var light = new pc.Entity();
         light.addComponent("light", {
-            type: "point",
+            type: "omni",
             color: new pc.Color(1, 1, 1),
             range: 200,
             castShadows: true,

--- a/examples/graphics/model-textured-box.html
+++ b/examples/graphics/model-textured-box.html
@@ -45,10 +45,10 @@
             type: "box"
         });
 
-        // Create an Entity with a point light component and a sphere model component.
+        // Create an Entity with a omni light component and a sphere model component.
         var light = new pc.Entity();
         light.addComponent("light", {
-            type: "point",
+            type: "omni",
             color: new pc.Color(1, 0, 0),
             radius: 10
         });

--- a/examples/graphics/render-to-texture.html
+++ b/examples/graphics/render-to-texture.html
@@ -126,10 +126,10 @@
         });
         app.root.addChild(textureCamera);
 
-        // Create an Entity with a point light component and add it to world layer (and so used by both cameras)
+        // Create an Entity with a omni light component and add it to world layer (and so used by both cameras)
         var light = new pc.Entity();
         light.addComponent("light", {
-            type: "point",
+            type: "omni",
             color: pc.Color.WHITE,
             range: 200,
             castShadows: true,

--- a/examples/graphics/shader-burn.html
+++ b/examples/graphics/shader-burn.html
@@ -89,10 +89,10 @@
         camera.rotate(0, 0, 0);
         camera.translateLocal(0, 7, 24);
 
-        // Create an Entity with a point light component and a sphere model component.
+        // Create an Entity with a omni light component and a sphere model component.
         light = new pc.Entity();
         light.addComponent("light", {
-            type: "point",
+            type: "omni",
             color: new pc.Color(1, 1, 1),
             radius: 10
         });

--- a/examples/graphics/shader-toon.html
+++ b/examples/graphics/shader-toon.html
@@ -106,10 +106,10 @@
         });
         camera.translate(0, 7, 24);
 
-        // Create an Entity with a point light component and a sphere model component.
+        // Create an Entity with a omni light component and a sphere model component.
         light = new pc.Entity();
         light.addComponent("light", {
-            type: "point",
+            type: "omni",
             color: new pc.Color(1, 1, 1),
             radius: 10
         });

--- a/examples/graphics/shader-wobble.html
+++ b/examples/graphics/shader-wobble.html
@@ -82,10 +82,10 @@
         });
         camera.translate(0, 7, 25);
 
-        // Create an Entity with a point light component and a sphere model component.
+        // Create an Entity with a omni light component and a sphere model component.
         light = new pc.Entity();
         light.addComponent("light", {
-            type: "point",
+            type: "omni",
             color: new pc.Color(1, 1, 1),
             radius: 10
         });

--- a/examples/graphics/video-texture.html
+++ b/examples/graphics/video-texture.html
@@ -53,10 +53,10 @@
         });
         camera.translate(0, 0, 15);
 
-        // Create an Entity with a point light component and a sphere model component.
+        // Create an Entity with a omni light component and a sphere model component.
         var light = new pc.Entity();
         light.addComponent("light", {
-            type: "point",
+            type: "omni",
             color: new pc.Color(1, 1, 1),
             range: 30
         });

--- a/examples/input/gamepad.html
+++ b/examples/input/gamepad.html
@@ -48,10 +48,10 @@
         });
         camera.translate(0, 7, 24);
 
-        // Create an Entity with a point light component and a sphere model component.
+        // Create an Entity with a omni light component and a sphere model component.
         var light = new pc.Entity();
         light.addComponent("light", {
-            type: "point",
+            type: "omni",
             color: new pc.Color(1, 1, 1),
             range: 100
         });

--- a/examples/input/keyboard.html
+++ b/examples/input/keyboard.html
@@ -48,10 +48,10 @@
         });
         camera.translate(0, 7, 24);
 
-        // Create an Entity with a point light component and a sphere model component.
+        // Create an Entity with a omni light component and a sphere model component.
         var light = new pc.Entity();
         light.addComponent("light", {
-            type: "point",
+            type: "omni",
             color: new pc.Color(1, 1, 1),
             range: 100
         });

--- a/examples/input/mouse.html
+++ b/examples/input/mouse.html
@@ -48,10 +48,10 @@
         });
         camera.translate(0, 7, 25);
 
-        // Create an Entity with a point light component and a sphere model component.
+        // Create an Entity with a omni light component and a sphere model component.
         var light = new pc.Entity();
         light.addComponent("light", {
-            type: "point",
+            type: "omni",
             color: new pc.Color(1, 1, 1),
             range: 100
         });

--- a/examples/loaders/loader-glb.html
+++ b/examples/loaders/loader-glb.html
@@ -56,10 +56,10 @@
             camera.translate(0, 0, 3);
             app.root.addChild(camera);
 
-            // Create an entity with a directional light component
+            // Create an entity with a omni light component
             var light = new pc.Entity();
             light.addComponent("light", {
-                type: "point"
+                type: "omni"
             });
             light.setLocalPosition(1, 1, 5);
             app.root.addChild(light);

--- a/examples/loaders/loader-obj.html
+++ b/examples/loaders/loader-obj.html
@@ -75,10 +75,10 @@
         camera.translate(0, 0, 5);
         app.root.addChild(camera);
 
-        // Create an Entity with a point light component
+        // Create an Entity with a omni light component
         var light = new pc.Entity();
         light.addComponent("light", {
-            type: "point",
+            type: "omni",
             color: new pc.Color(1, 1, 1),
             range: 100
         });

--- a/examples/misc/multi-application.html
+++ b/examples/misc/multi-application.html
@@ -55,10 +55,10 @@
         camera.translate(0, 0, 4);
         app1.root.addChild(camera);
 
-        // Create an Entity with a point light component
+        // Create an Entity with a omni light component
         var light = new pc.Entity(app1);
         light.addComponent("light", {
-            type: "point",
+            type: "omni",
             color: new pc.Color(1, 1, 1),
             range: 100
         });
@@ -98,10 +98,10 @@
         camera.translate(0, 0, 4);
         app2.root.addChild(camera);
 
-        // Create an Entity with a point light component
+        // Create an Entity with a omni light component
         var light = new pc.Entity(app2);
         light.addComponent("light", {
-            type: "point",
+            type: "omni",
             color: new pc.Color(1, 1, 1),
             range: 100
         });

--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -1674,10 +1674,9 @@ class Application extends EventHandler {
 
     /**
      * @function
-     * @private
      * @name Application#setAreaLightLuts
      * @description Sets the area light LUT asset for this app.
-     * @param {Asset} asset - Asset of type `binary` to be set.
+     * @param {Asset} asset - LUT asset of type `binary` to be set.
      */
     setAreaLightLuts(asset) {
         if (asset) {

--- a/src/framework/components/light/component.js
+++ b/src/framework/components/light/component.js
@@ -49,12 +49,19 @@ var _lightPropsDefault = [];
  * entity.light.range = 20;
  * @property {string} type The type of light. Can be:
  * * "directional": A light that is infinitely far away and lights the entire scene from one direction.
- * * "point": A light that illuminates in all directions from a point.
- * * "spot": A light that illuminates in all directions from a point and is bounded by a cone.
+ * * "omni": A omni-directional light that illuminates in all directions from the light source.
+ * * "point": A omni-directional light but light source shape is {@link pc.LIGHTSHAPE_PUNCTUAL}.
+ * * "spot": A omni-directional light but is bounded by a cone.
  * Defaults to "directional".
  * @property {Color} color The Color of the light. The alpha component of the color is
  * ignored. Defaults to white (1, 1, 1).
  * @property {number} intensity The brightness of the light. Defaults to 1.
+ * @property {number} shape The light source shape. Can be:
+ * * {@link pc.LIGHTSHAPE_PUNCTUAL}: Infinitesimally small point.
+ * * {@link pc.LIGHTSHAPE_RECT}: Rectangle shape.
+ * * {@link pc.LIGHTSHAPE_DISK}: Disk shape.
+ * * {@link pc.LIGHTSHAPE_SPHERE}: Sphere shape.
+ * Affects spot lights only. Defaults to pc.LIGHTSHAPE_PUNCTUAL.
  * @property {boolean} castShadows If enabled the light will cast shadows. Defaults to false.
  * @property {number} shadowDistance The distance from the viewpoint beyond which shadows
  * are no longer rendered. Affects directional lights only. Defaults to 40.

--- a/src/framework/components/light/component.js
+++ b/src/framework/components/light/component.js
@@ -37,7 +37,7 @@ var _lightPropsDefault = [];
  * // Add a pc.LightComponent to an entity
  * var entity = new pc.Entity();
  * entity.addComponent('light', {
- *     type: "point",
+ *     type: "omni",
  *     color: new pc.Color(1, 0, 0),
  *     range: 10
  * });

--- a/src/framework/components/light/component.js
+++ b/src/framework/components/light/component.js
@@ -50,7 +50,6 @@ var _lightPropsDefault = [];
  * @property {string} type The type of light. Can be:
  * * "directional": A light that is infinitely far away and lights the entire scene from one direction.
  * * "omni": A omni-directional light that illuminates in all directions from the light source.
- * * "point": A omni-directional light but light source shape is {@link pc.LIGHTSHAPE_PUNCTUAL}.
  * * "spot": A omni-directional light but is bounded by a cone.
  * Defaults to "directional".
  * @property {Color} color The Color of the light. The alpha component of the color is
@@ -61,7 +60,7 @@ var _lightPropsDefault = [];
  * * {@link pc.LIGHTSHAPE_RECT}: Rectangle shape.
  * * {@link pc.LIGHTSHAPE_DISK}: Disk shape.
  * * {@link pc.LIGHTSHAPE_SPHERE}: Sphere shape.
- * Affects spot lights only. Defaults to pc.LIGHTSHAPE_PUNCTUAL.
+ * Defaults to pc.LIGHTSHAPE_PUNCTUAL.
  * @property {boolean} castShadows If enabled the light will cast shadows. Defaults to false.
  * @property {number} shadowDistance The distance from the viewpoint beyond which shadows
  * are no longer rendered. Affects directional lights only. Defaults to 40.

--- a/src/framework/components/light/component.js
+++ b/src/framework/components/light/component.js
@@ -49,8 +49,8 @@ var _lightPropsDefault = [];
  * entity.light.range = 20;
  * @property {string} type The type of light. Can be:
  * * "directional": A light that is infinitely far away and lights the entire scene from one direction.
- * * "omni": A omni-directional light that illuminates in all directions from the light source.
- * * "spot": A omni-directional light but is bounded by a cone.
+ * * "omni": An omni-directional light that illuminates in all directions from the light source.
+ * * "spot": An omni-directional light but is bounded by a cone.
  * Defaults to "directional".
  * @property {Color} color The Color of the light. The alpha component of the color is
  * ignored. Defaults to white (1, 1, 1).

--- a/src/scene/constants.js
+++ b/src/scene/constants.js
@@ -206,7 +206,6 @@ export const LIGHTTYPE_SPOT = 2;
 
 /**
  * @constant
- * @private
  * @name LIGHTSHAPE_PUNCTUAL
  * @type {number}
  * @description Infinitesimally small point light source shape.
@@ -215,7 +214,6 @@ export const LIGHTSHAPE_PUNCTUAL = 0;
 
 /**
  * @constant
- * @private
  * @name LIGHTSHAPE_RECT
  * @type {number}
  * @description Rectangle shape of light source.
@@ -224,7 +222,6 @@ export const LIGHTSHAPE_RECT = 1;
 
 /**
  * @constant
- * @private
  * @name LIGHTSHAPE_DISK
  * @type {number}
  * @description Disk shape of light source.
@@ -233,7 +230,6 @@ export const LIGHTSHAPE_DISK = 2;
 
 /**
  * @constant
- * @private
  * @name LIGHTSHAPE_SPHERE
  * @type {number}
  * @description Sphere shape of light source.


### PR DESCRIPTION
this PR
- removes `@private` from some JSDocs
- adds `area-lights` example to examples list
- removes `point` light type from JSDocs and changes all examples to use `omni` light type

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
