### PR TITLE
Simplified loading of multiple assets in engine examples

### DIFF
--- a/examples/animation/tweening.html
+++ b/examples/animation/tweening.html
@@ -7,6 +7,7 @@
     <link rel="icon" type="image/png" href="../playcanvas-favicon.png" />
     <script src="../../build/playcanvas.js"></script>
     <script src="../../build/playcanvas-extras.js"></script>
+    <script src="../assets/scripts/asset-loader.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/tween.js/18.6.4/tween.umd.js"></script>
     <style>
         body { 
@@ -55,29 +56,20 @@
         };
 
         // A list of assets that need to be loaded
-        var assetManifest = [
-            {
+        var assetManifest = {
+            font: {
                 type: "font",
                 url: "../assets/fonts/arial.json"
             },
-            {
+            script: {
                 type: "script",
                 url: "../../scripts/animation/tween.js"
             }
-        ];
+        };
 
         // Load all assets and then run the example
-        var assetsToLoad = assetManifest.length;
-        assetManifest.forEach(function (entry) {
-            app.assets.loadFromUrl(entry.url, entry.type, function (err, asset) {
-                if (!err && asset) {
-                    assetsToLoad--;
-                    entry.asset = asset;
-                    if (assetsToLoad === 0) {
-                        run();
-                    }
-                }
-            });
+        loadManifestAssets(app, assetManifest, function () {
+            run();
         });
 
         function run() {
@@ -135,7 +127,7 @@
                 colors.push(pc.Color.WHITE, pc.Color.WHITE);
 
                 // Create a text label for the sphere
-                createText(assetManifest[0].asset, easingFunctions[i], -0.5, -i, 0, 0);
+                createText(assetManifest["font"].asset, easingFunctions[i], -0.5, -i, 0, 0);
             }
 
             // Create an entity with a directional light component

--- a/examples/assets/scripts/asset-loader.js
+++ b/examples/assets/scripts/asset-loader.js
@@ -1,0 +1,28 @@
+// asset loader function allowing to load multiple assets
+function loadManifestAssets(app, manifest, onLoaded) {
+    // count of assets to load
+    var count = 0;
+    var key;
+    for (key in manifest) {
+        if (manifest.hasOwnProperty(key)) {
+            count++;
+        }
+    }
+    // load them all
+    Object.keys(manifest).forEach(function (key) {
+        if (manifest.hasOwnProperty(key)) {
+            var entry = manifest[key];
+            app.assets.loadFromUrl(entry.url, entry.type, function (err, asset) {
+                if (!err && asset) {
+                    count--;
+                    entry.asset = asset;
+                    if (count === 0) {
+                        if (onLoaded) {
+                            onLoaded();
+                        }
+                    }
+                }
+            });
+        }
+    });
+}

--- a/examples/camera/first-person.html
+++ b/examples/camera/first-person.html
@@ -7,6 +7,7 @@
     <link rel="icon" type="image/png" href="../playcanvas-favicon.png" />
     <script src="../../build/playcanvas.js"></script>
     <script src="../../build/playcanvas-extras.js"></script>
+    <script src="../assets/scripts/asset-loader.js"></script>
     <script src="../wasm-loader.js"></script>
     <style>
         body { 
@@ -49,30 +50,21 @@
             var miniStats = new pcx.MiniStats(app);
 
             // A list of assets that need to be loaded
-            var assetManifest = [
-                {
+            var assetManifest = {
+                statue: {
                     type: "container",
                     url: "../assets/models/statue.glb"
                 },
-                {
+                script: {
                     type: "script",
                     url: "../../scripts/camera/first-person-camera.js"
                 }
-            ];
+            };
 
             // Load all assets and then run the example
-            var assetsToLoad = assetManifest.length;
-            assetManifest.forEach(function (entry) {
-                app.assets.loadFromUrl(entry.url, entry.type, function (err, asset) {
-                    if (!err && asset) {
-                        assetsToLoad--;
-                        entry.asset = asset;
-                        if (assetsToLoad === 0) {
-                            run();
-                        }
-                    }
-                });
-            });
+            loadManifestAssets(app, assetManifest, function () {
+            run();
+        });
 
             function run() {
                 app.start();
@@ -102,11 +94,11 @@
                 var model = new pc.Entity();
                 model.addComponent("collision", {
                     type: "mesh",
-                    asset: assetManifest[0].asset.resource.model
+                    asset: assetManifest["statue"].asset.resource.model
                 });
                 model.addComponent("model", {
                     type: "asset",
-                    asset: assetManifest[0].asset.resource.model
+                    asset: assetManifest["statue"].asset.resource.model
                 });
                 model.addComponent("rigidbody", {
                     type: "static",

--- a/examples/camera/orbit.html
+++ b/examples/camera/orbit.html
@@ -7,6 +7,7 @@
     <link rel="icon" type="image/png" href="../playcanvas-favicon.png" />
     <script src="../../build/playcanvas.js"></script>
     <script src="../../build/playcanvas-extras.js"></script>
+    <script src="../assets/scripts/asset-loader.js"></script>
     <style>
         body { 
             margin: 0;
@@ -40,29 +41,20 @@
         var miniStats = new pcx.MiniStats(app);
 
         // A list of assets that need to be loaded
-        var assetManifest = [
-            {
+        var assetManifest = {
+            statue: {
                 type: "container",
                 url: "../assets/models/statue.glb"
             },
-            {
+            script: {
                 type: "script",
                 url: "../../scripts/camera/orbit-camera.js"
             }
-        ];
+        };
 
         // Load all assets and then run the example
-        var assetsToLoad = assetManifest.length;
-        assetManifest.forEach(function (entry) {
-            app.assets.loadFromUrl(entry.url, entry.type, function (err, asset) {
-                if (!err && asset) {
-                    assetsToLoad--;
-                    entry.asset = asset;
-                    if (assetsToLoad === 0) {
-                        run();
-                    }
-                }
-            });
+        loadManifestAssets(app, assetManifest, function () {
+            run();
         });
 
         function run() {
@@ -70,7 +62,7 @@
             var model = new pc.Entity();
             model.addComponent("model", {
                 type: "asset",
-                asset: assetManifest[0].asset.resource.model
+                asset: assetManifest["statue"].asset.resource.model
             });
             app.root.addChild(model);
 

--- a/examples/graphics/area-lights.html
+++ b/examples/graphics/area-lights.html
@@ -7,6 +7,7 @@
     <link rel="icon" type="image/png" href="../playcanvas-favicon.png" />
     <script src="../../build/playcanvas.js"></script>
     <script src="../../build/playcanvas-extras.js"></script>
+    <script src="../assets/scripts/asset-loader.js"></script>
     <style>
         body { 
             margin: 0;
@@ -36,9 +37,9 @@
             material.useMetalness = true;
 
             if (assetManifest) {
-                material.diffuseMap = assetManifest[0].asset.resource;
-                material.normalMap = assetManifest[1].asset.resource;
-                material.glossMap = assetManifest[2].asset.resource;
+                material.diffuseMap = assetManifest["color"].asset.resource;
+                material.normalMap = assetManifest["normal"].asset.resource;
+                material.glossMap = assetManifest["gloss"].asset.resource;
                 material.metalness = 0.7;
 
                 material.diffuseMapTiling.set(7, 7);
@@ -128,41 +129,32 @@
         }
 
         // A list of assets that need to be loaded
-        var assetManifest = [
-            {
+        var assetManifest = {
+            color: {
                 type: "texture",
                 url: "../assets/textures/seaside-rocks01-color.jpg"
             },
-            {
+            normal: {
                 type: "texture",
                 url: "../assets/textures/seaside-rocks01-normal.jpg"
             },
-            {
+            gloss: {
                 type: "texture",
                 url: "../assets/textures/seaside-rocks01-gloss.jpg"
             },
-            {
+            statue: {
                 type: "container",
                 url: "../assets/models/statue.glb"
             },
-            {
+            luts: {
                 type: "binary",
                 url: "../assets/binary/area-light-luts.bin"
-            },            
-        ];
+            }
+        };
 
         // Load all assets and then run the example
-        var assetsToLoad = assetManifest.length;
-        assetManifest.forEach(function (entry) {
-            app.assets.loadFromUrl(entry.url, entry.type, function (err, asset) {
-                if (!err && asset) {
-                    assetsToLoad--;
-                    entry.asset = asset;
-                    if (assetsToLoad === 0) {
-                        run();
-                    }
-                }
-            });
+        loadManifestAssets(app, assetManifest, function () {
+            run();
         });
         
         var camera;
@@ -184,7 +176,7 @@
             var miniStats = new pcx.MiniStats(app);
 
             // set the loaded area light LUT data
-            app.setAreaLightLuts(assetManifest[4].asset);
+            app.setAreaLightLuts(assetManifest["luts"].asset);
 
             // set up some general scene rendering properties
             app.scene.gammaCorrection = pc.GAMMA_SRGB;
@@ -213,7 +205,7 @@
              var statue = new pc.Entity();
              statue.addComponent("model", {
                 type: "asset",
-                asset: assetManifest[3].asset.resource.model
+                asset: assetManifest["statue"].asset.resource.model
             });
             statue.setLocalScale(0.4, 0.4, 0.4);
             app.root.addChild(statue);

--- a/examples/graphics/post-effects.html
+++ b/examples/graphics/post-effects.html
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
     <link rel="icon" type="image/png" href="../playcanvas-favicon.png" />
     <script src="../../build/playcanvas.js"></script>
+    <script src="../assets/scripts/asset-loader.js"></script>
     <script src="../../build/playcanvas-extras.js"></script>
     <style>
         body { 
@@ -37,41 +38,32 @@
         var miniStats = new pcx.MiniStats(app);
 
         // A list of assets that need to be loaded
-        var assetManifest = [
-            {
+        var assetManifest = {
+            statue: {
                 type: "container",
                 url: "../assets/models/statue.glb"
             },
-            {
+            bloom: {
                 type: "script",
                 url: "../../scripts/posteffects/posteffect-bloom.js"
             },
-            {
+            bokeh: {
                 type: "script",
                 url: "../../scripts/posteffects/posteffect-bokeh.js"
             },
-            {
+            sepia: {
                 type: "script",
                 url: "../../scripts/posteffects/posteffect-sepia.js"
             },
-            {
+            vignette: {
                 type: "script",
                 url: "../../scripts/posteffects/posteffect-vignette.js"
             }
-        ];
+        };
 
         // Load all assets and then run the example
-        var assetsToLoad = assetManifest.length;
-        assetManifest.forEach(function (entry) {
-            app.assets.loadFromUrl(entry.url, entry.type, function (err, asset) {
-                if (!err && asset) {
-                    assetsToLoad--;
-                    entry.asset = asset;
-                    if (assetsToLoad === 0) {
-                        run();
-                    }
-                }
-            });
+        loadManifestAssets(app, assetManifest, function () {
+            run();
         });
 
         function createMaterial(colors) {
@@ -102,7 +94,7 @@
             var entity = new pc.Entity();
             entity.addComponent("model", {
                 type: "asset",
-                asset: assetManifest[0].asset.resource.model,
+                asset: assetManifest["statue"].asset.resource.model,
                 castShadows: true
             });
             app.root.addChild(entity);

--- a/examples/physics/vehicle.html
+++ b/examples/physics/vehicle.html
@@ -7,6 +7,7 @@
     <link rel="icon" type="image/png" href="../playcanvas-favicon.png" />
     <script src="../../build/playcanvas.js"></script>
     <script src="../../build/playcanvas-extras.js"></script>
+    <script src="../assets/scripts/asset-loader.js"></script>
     <script src="../wasm-loader.js"></script>
     <style>
         body { 
@@ -48,37 +49,28 @@
         var miniStats = new pcx.MiniStats(app);
 
         // A list of assets that need to be loaded
-        var assetManifest = [
-            {
+        var assetManifest = {
+            script1: {
                 type: "script",
                 url: "../../scripts/camera/tracking-camera.js"
             },
-            {
+            script2: {
                 type: "script",
                 url: "../../scripts/physics/render-physics.js"
             },
-            {
+            script3: {
                 type: "script",
                 url: "../../scripts/physics/action-physics-reset.js"
             },
-            {
+            script4: {
                 type: "script",
                 url: "../../scripts/physics/vehicle.js"
             }
-        ];
+        };
 
         // Load all assets and then run the example
-        var assetsToLoad = assetManifest.length;
-        assetManifest.forEach(function (entry) {
-            app.assets.loadFromUrl(entry.url, entry.type, function (err, asset) {
-                if (!err && asset) {
-                    assetsToLoad--;
-                    entry.asset = asset;
-                    if (assetsToLoad === 0) {
-                        run();
-                    }
-                }
-            });
+        loadManifestAssets(app, assetManifest, function () {
+            run();
         });
 
         function run() {

--- a/examples/xr/vr-controllers.html
+++ b/examples/xr/vr-controllers.html
@@ -6,6 +6,7 @@
         <meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
         <link rel="icon" type="image/png" href="../playcanvas-favicon.png" />
         <script src="../../build/playcanvas.js"></script>
+        <script src="../assets/scripts/asset-loader.js"></script>
         <style>
             body {
                 margin: 0;
@@ -54,26 +55,17 @@
             app.graphicsDevice.maxPixelRatio = window.devicePixelRatio;
 
             // A list of assets that need to be loaded
-            var assetManifest = [
-                {
+            var assetManifest = {
+                glb: {
                     type: "container",
                     url: "../assets/models/vr-controller.glb"
                 }
-            ];
+            };
 
             // Load all assets and then run the example
-            var assetsToLoad = assetManifest.length;
-            assetManifest.forEach(function (entry) {
-                app.assets.loadFromUrl(entry.url, entry.type, function (err, asset) {
-                    if (!err && asset) {
-                        assetsToLoad--;
-                        entry.asset = asset;
-                        if (assetsToLoad === 0) {
-                            run();
-                        }
-                    }
-                });
-            });
+            loadManifestAssets(app, assetManifest, function () {
+            run();
+        });
 
             function run() {
                 app.start();
@@ -112,7 +104,7 @@
                     var entity = new pc.Entity();
                     entity.addComponent('model', {
                         type: 'asset',
-                        asset: assetManifest[0].asset.resource.model,
+                        asset: assetManifest["glb"].asset.resource.model,
                         castShadows: true
                     });
                     app.root.addChild(entity);


### PR DESCRIPTION
- few examples use shared asset-loader.js script
- asset are referenced using name instead of array index

Thanks to @ellthompson for help on this.