### PR TITLE
Normalize text to work correctly with bidi

### DIFF
--- a/src/framework/components/element/text-element.js
+++ b/src/framework/components/element/text-element.js
@@ -286,7 +286,7 @@ class TextElement {
         if (text === undefined) text = this._text;
 
         // get the list of symbols
-        this._symbols = string.getSymbols(text);
+        this._symbols = string.getSymbols(text.normalize('NFC'));
 
         // handle null string
         if (this._symbols.length === 0) {


### PR DESCRIPTION
Running the bidi algorithm on text resulted sometimes in more levels than codepoints. This caused our remapping logic to break.

Turns out this is because bbc bidi algorithm normalises codepoints (see https://github.com/bbc/unicode-bidirectional/blob/master/src/main.js#L15).

This PR fixes the issue by normalising our text using the same function.