### PR TITLE
print a console error if a char is missing in the font

### DIFF
--- a/src/framework/components/element/text-element.js
+++ b/src/framework/components/element/text-element.js
@@ -733,6 +733,17 @@ class TextElement {
                                 break;
                             }
                         }
+
+                        // #ifdef DEBUG
+                        if (!json.missingChars) {
+                            json.missingChars = new Set();
+                        }
+
+                        if (!json.missingChars.has(char)) {
+                            console.warn("Character '" + char + "' is missing from the font " + json.info.face);
+                            json.missingChars.add(char);
+                        }
+                        // #endif
                     }
                 }
 


### PR DESCRIPTION
this PR prints a message about missing char in a debug mode

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).

![image](https://user-images.githubusercontent.com/7876371/111675634-42b85700-8815-11eb-8510-89aa6b0ba9b9.png)
