### PR TITLE
Support for EXT_color_buffer_half_float - texture morph targets on iOS WebGl2

### DIFF
--- a/src/graphics/graphics-device.js
+++ b/src/graphics/graphics-device.js
@@ -652,11 +652,9 @@ class GraphicsDevice extends EventHandler {
         }
 
         // two extensions allow us to render to half float buffers
-        this.textureHalfFloatRenderable = false;
         if (this.extColorBufferHalfFloat) {
             this.textureHalfFloatRenderable = !!this.extColorBufferHalfFloat;
-        }
-        if (!this.textureHalfFloatRenderable && this.extTextureHalfFloat) {
+        } else if (this.extTextureHalfFloat) {
             if (this.webgl2) {
                 // EXT_color_buffer_float should affect both float and halffloat formats
                 this.textureHalfFloatRenderable = !!this.extColorBufferFloat;
@@ -664,6 +662,8 @@ class GraphicsDevice extends EventHandler {
                 // Manual render check for half float
                 this.textureHalfFloatRenderable = testRenderable(gl, this.extTextureHalfFloat.HALF_FLOAT_OES);
             }
+        } else {
+            this.textureHalfFloatRenderable = false;
         }
 
         this.supportsMorphTargetTexturesCore = (this.maxPrecision === "highp" && this.maxVertexTextures >= 2);

--- a/src/graphics/graphics-device.js
+++ b/src/graphics/graphics-device.js
@@ -650,7 +650,13 @@ class GraphicsDevice extends EventHandler {
         } else {
             this.textureFloatRenderable = false;
         }
-        if (this.extTextureHalfFloat) {
+
+        // two extensions allow us to render to half float buffers
+        this.textureHalfFloatRenderable = false;
+        if (this.extColorBufferHalfFloat) {
+            this.textureHalfFloatRenderable = !!this.extColorBufferHalfFloat;
+        }
+        if (!this.textureHalfFloatRenderable && this.extTextureHalfFloat) {
             if (this.webgl2) {
                 // EXT_color_buffer_float should affect both float and halffloat formats
                 this.textureHalfFloatRenderable = !!this.extColorBufferFloat;
@@ -658,8 +664,6 @@ class GraphicsDevice extends EventHandler {
                 // Manual render check for half float
                 this.textureHalfFloatRenderable = testRenderable(gl, this.extTextureHalfFloat.HALF_FLOAT_OES);
             }
-        } else {
-            this.textureHalfFloatRenderable = false;
         }
 
         this.supportsMorphTargetTexturesCore = (this.maxPrecision === "highp" && this.maxVertexTextures >= 2);
@@ -828,6 +832,9 @@ class GraphicsDevice extends EventHandler {
         this.extCompressedTextureATC = getExtension('WEBGL_compressed_texture_atc');
         this.extCompressedTextureASTC = getExtension('WEBGL_compressed_texture_astc');
         this.extParallelShaderCompile = getExtension('KHR_parallel_shader_compile');
+
+        // iOS exposes this for half precision render targets on both Webgl1 and 2 from iOS v 14.5beta
+        this.extColorBufferHalfFloat = getExtension("EXT_color_buffer_half_float");
 
         this.supportsInstancing = !!this.extInstancing;
     }


### PR DESCRIPTION
Fixes https://github.com/playcanvas/engine/issues/2393