### PR TITLE
Directional Blend Trees speed fix

### DIFF
--- a/src/anim/controller/anim-blend-tree-2d-directional.js
+++ b/src/anim/controller/anim-blend-tree-2d-directional.js
@@ -58,7 +58,7 @@ class AnimBlendTreeDirectional2D extends AnimBlendTree {
             const child = this._children[i];
             child.weight = child._weight / weightSum;
             if (this._syncAnimations) {
-                child.weightedSpeed = child.animTrack.duration / child.absoluteSpeed / weightedDurationSum;
+                child.weightedSpeed = child.animTrack.duration / child.absoluteSpeed / weightedDurationSum * weightSum;
             }
         }
     }

--- a/src/anim/controller/anim-blend-tree-2d-directional.js
+++ b/src/anim/controller/anim-blend-tree-2d-directional.js
@@ -51,14 +51,14 @@ class AnimBlendTreeDirectional2D extends AnimBlendTree {
             child.weight = minj;
             weightSum += minj;
             if (this._syncAnimations) {
-                weightedDurationSum += child.animTrack.duration / child.absoluteSpeed * child.weight;
+                weightedDurationSum += (child.animTrack.duration / child.absoluteSpeed) * child.weight;
             }
         }
         for (i = 0; i < this._children.length; i++) {
             const child = this._children[i];
             child.weight = child._weight / weightSum;
             if (this._syncAnimations) {
-                const weightedChildDuration = child.animTrack.duration / weightedDurationSum * weightSum;
+                const weightedChildDuration = (child.animTrack.duration / weightedDurationSum) * weightSum;
                 child.weightedSpeed =  child.absoluteSpeed * weightedChildDuration;
             }
         }

--- a/src/anim/controller/anim-blend-tree-2d-directional.js
+++ b/src/anim/controller/anim-blend-tree-2d-directional.js
@@ -58,7 +58,8 @@ class AnimBlendTreeDirectional2D extends AnimBlendTree {
             const child = this._children[i];
             child.weight = child._weight / weightSum;
             if (this._syncAnimations) {
-                child.weightedSpeed = child.animTrack.duration / child.absoluteSpeed / weightedDurationSum * weightSum;
+                const weightedChildDuration = child.animTrack.duration / weightedDurationSum * weightSum;
+                child.weightedSpeed =  child.absoluteSpeed * weightedChildDuration;
             }
         }
     }


### PR DESCRIPTION
When using a directional blend tree with synchronised animation durations, the blend weight of each animation clip's speed should be normalised using the total weight of all clips.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
