### PR TITLE
Normalize test

### DIFF
--- a/src/framework/components/element/text-element.js
+++ b/src/framework/components/element/text-element.js
@@ -287,7 +287,13 @@ class TextElement {
         if (text === undefined) text = this._text;
 
         // get the list of symbols
-        this._symbols = string.getSymbols(text.normalize('NFC'));
+        if (text.normalize) {
+            // NOTE: we must normalize text here in order to be consistent with the number of
+            // symbols returned from the bidi algorithm. If we don't, then it's possible bidi
+            // will return a different number of RTL codes to what we expect.
+            // NOTE: IE doesn't support string.normalize(), so we must check for its existence.
+            this._symbols = string.getSymbols(text.normalize ? text.normalize('NFC') : text);
+        }
 
         // handle null string
         if (this._symbols.length === 0) {

--- a/src/framework/components/element/text-element.js
+++ b/src/framework/components/element/text-element.js
@@ -287,13 +287,12 @@ class TextElement {
         if (text === undefined) text = this._text;
 
         // get the list of symbols
-        if (text.normalize) {
-            // NOTE: we must normalize text here in order to be consistent with the number of
-            // symbols returned from the bidi algorithm. If we don't, then it's possible bidi
-            // will return a different number of RTL codes to what we expect.
-            // NOTE: IE doesn't support string.normalize(), so we must check for its existence.
-            this._symbols = string.getSymbols(text.normalize ? text.normalize('NFC') : text);
-        }
+        // NOTE: we must normalize text here in order to be consistent with the number of
+        // symbols returned from the bidi algorithm. If we don't, then in some cases bidi
+        // returns a different number of RTL codes to what we expect.
+        // NOTE: IE doesn't support string.normalize(), so we must check for its existence
+        // before invoking.
+        this._symbols = string.getSymbols(text.normalize ? text.normalize('NFC') : text);
 
         // handle null string
         if (this._symbols.length === 0) {


### PR DESCRIPTION
TextElement normalises text in order to remain consistent with bidi results (introduced in https://github.com/playcanvas/engine/pull/2979), but unfortunately IE doesn't support string.normalize().

So test for presence of string.normalize() before invoking.