### PR TITLE
do not warn if missing char is a break char

### DIFF
--- a/src/framework/components/element/text-element.js
+++ b/src/framework/components/element/text-element.js
@@ -745,7 +745,7 @@ class TextElement {
                             json.missingChars = new Set();
                         }
 
-                        if (!json.missingChars.has(char)) {
+                        if (!json.missingChars.has(char) && !LINE_BREAK_CHAR.test(char)) {
                             console.warn("Character '" + char + "' is missing from the font " + json.info.face);
                             json.missingChars.add(char);
                         }


### PR DESCRIPTION
Fixes #

do not console.warn if missing character is a break char character

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
