### PR TITLE
Update PCUI URL in examples to use https

### DIFF
--- a/examples/animation/blend-trees-1d.html
+++ b/examples/animation/blend-trees-1d.html
@@ -8,7 +8,7 @@
     <script src="../../build/playcanvas.js"></script>
     <script src="../../build/playcanvas-extras.js"></script>
     <script src="../assets/scripts/asset-loader.js"></script>
-    <script src="http://code.playcanvas.com/pcui/pcui-v1.1.5.js"></script>
+    <script src="https://code.playcanvas.com/pcui/pcui-v1.1.5.js"></script>
     <style>
         body { 
             margin: 0;

--- a/examples/animation/blend-trees-2d-cartesian.html
+++ b/examples/animation/blend-trees-2d-cartesian.html
@@ -8,7 +8,7 @@
     <script src="../../build/playcanvas.js"></script>
     <script src="../../build/playcanvas-extras.js"></script>
     <script src="../assets/scripts/asset-loader.js"></script>
-    <script src="http://code.playcanvas.com/pcui/pcui-v1.1.5.js"></script>
+    <script src="https://code.playcanvas.com/pcui/pcui-v1.1.5.js"></script>
     <style>
         body { 
             margin: 0;

--- a/examples/animation/blend-trees-directional.html
+++ b/examples/animation/blend-trees-directional.html
@@ -8,7 +8,7 @@
     <script src="../../build/playcanvas.js"></script>
     <script src="../../build/playcanvas-extras.js"></script>
     <script src="../assets/scripts/asset-loader.js"></script>
-    <script src="http://code.playcanvas.com/pcui/pcui-v1.1.5.js"></script>
+    <script src="https://code.playcanvas.com/pcui/pcui-v1.1.5.js"></script>
     <style>
         body { 
             margin: 0;

--- a/examples/animation/component-properties.html
+++ b/examples/animation/component-properties.html
@@ -8,7 +8,7 @@
     <script src="../../build/playcanvas.js"></script>
     <script src="../../build/playcanvas-extras.js"></script>
     <script src="../assets/scripts/asset-loader.js"></script>
-    <script src="http://code.playcanvas.com/pcui/pcui-v1.1.5.js"></script>
+    <script src="https://code.playcanvas.com/pcui/pcui-v1.1.5.js"></script>
     <style>
         body { 
             margin: 0;

--- a/examples/animation/locomotion.html
+++ b/examples/animation/locomotion.html
@@ -9,7 +9,7 @@
     <script src="../../build/playcanvas-extras.js"></script>
     <script src="../assets/scripts/asset-loader.js"></script>
     <script src="../wasm-loader.js"></script>
-    <script src="http://code.playcanvas.com/pcui/pcui-v1.1.5.js"></script>
+    <script src="https://code.playcanvas.com/pcui/pcui-v1.1.5.js"></script>
     <style>
         body { 
             margin: 0;


### PR DESCRIPTION
This was preventing the animation examples from loading on https://playcanvas.github.io

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
