### PR TITLE
Fix blend tree URLs from the examples browser

### DIFF
--- a/examples/examples.js
+++ b/examples/examples.js
@@ -4,8 +4,8 @@ var categories = [
         name: "animation",
         examples: [
             "blend",
-            "blend-trees-1D",
-            "blend-trees-2D-cartesian",
+            "blend-trees-1d",
+            "blend-trees-2d-cartesian",
             "blend-trees-directional",
             "component-properties",
             "locomotion",


### PR DESCRIPTION
Capitalization mismatch in blend tree example URLs when selected in the examples browser.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
