### PR TITLE
fix dead link to models page of userguide in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ PlayCanvas uses of Karma for unit testing. There are two ways of running the tes
 
 ## How to get models?
 
-To convert any models created using a 3D modelling package see [this page](https://developer.playcanvas.com/en/engine/) in the developer documentation.
+To convert any models created using a 3D modelling package see [this page](https://developer.playcanvas.com/en/user-manual/assets/models/) in the developer documentation.
 
 ## Useful Links
 


### PR DESCRIPTION
Fixes #

No fix number, just a dead link in the readme. Changed it to reflect the new link.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
