### PR TITLE
fix: type argument for attributes had regressed from a union of strings to plain string

### DIFF
--- a/src/script/script-attributes.js
+++ b/src/script/script-attributes.js
@@ -175,7 +175,7 @@ class ScriptAttributes {
      * @description Add Attribute.
      * @param {string} name - Name of an attribute.
      * @param {object} args - Object with Arguments for an attribute.
-     * @param {string} args.type - Type of an attribute value. Can be one of "boolean", "number", "string", "json", "asset", "entity", "rgb", "rgba", "vec2", "vec3", "vec4" or "curve".
+     * @param {("boolean"|"number"|"string"|"json"|"asset"|"entity"|"rgb"|"rgba"|"vec2"|"vec3"|"vec4"|"curve")} args.type - Type of an attribute value.  Can be one of "boolean", "number", "string", "json", "asset", "entity", "rgb", "rgba", "vec2", "vec3", "vec4" or "curve".
      * @param {*} [args.default] - Default attribute value.
      * @param {string} [args.title] - Title for Editor's for field UI.
      * @param {string} [args.description] - Description for Editor's for field UI.


### PR DESCRIPTION
We noticed the type of `ScriptAttributes.add` parameter `args.type` regressed from a union type to a plain string, hence losing the nicer type-checking. Found the original and merged back here.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
