### PR TITLE
Migrate core, math and shape source to use let and const

### DIFF
--- a/src/core/core.js
+++ b/src/core/core.js
@@ -10,22 +10,22 @@
  * @name _typeLookup
  * @description Create look up table for types.
  */
-var _typeLookup = function () {
-    var result = { };
-    var names = ["Array", "Object", "Function", "Date", "RegExp", "Float32Array"];
+const _typeLookup = function () {
+    const result = { };
+    const names = ["Array", "Object", "Function", "Date", "RegExp", "Float32Array"];
 
-    for (var i = 0; i < names.length; i++)
+    for (let i = 0; i < names.length; i++)
         result["[object " + names[i] + "]"] = names[i].toLowerCase();
 
     return result;
 }();
 
-var version = "__CURRENT_SDK_VERSION__";
-var revision = "__REVISION__";
-var config = { };
-var common = { };
-var apps = { }; // Storage for the applications using the PlayCanvas Engine
-var data = { }; // Storage for exported entity data
+const version = "__CURRENT_SDK_VERSION__";
+const revision = "__REVISION__";
+const config = { };
+const common = { };
+const apps = { }; // Storage for the applications using the PlayCanvas Engine
+const data = { }; // Storage for exported entity data
 
 /**
  * @private
@@ -40,7 +40,7 @@ function type(obj) {
         return "null";
     }
 
-    var type = typeof obj;
+    const type = typeof obj;
 
     if (type === "undefined" || type === "number" || type === "string" || type === "boolean") {
         return type;
@@ -76,14 +76,12 @@ function type(obj) {
  * // logs "b"
  */
 function extend(target, ex) {
-    var prop,
-        copy;
+    for (const prop in ex) {
+        const copy = ex[prop];
 
-    for (prop in ex) {
-        copy = ex[prop];
-        if (type(copy) == "object") {
+        if (type(copy) === "object") {
             target[prop] = extend({}, copy);
-        } else if (type(copy) == "array") {
+        } else if (type(copy) === "array") {
             target[prop] = extend([], copy);
         } else {
             target[prop] = copy;
@@ -102,7 +100,7 @@ function extend(target, ex) {
  * @returns {boolean} True if the Object is not undefined.
  */
 function isDefined(o) {
-    var a;
+    let a;
     return (o !== a);
 }
 

--- a/src/core/debug.js
+++ b/src/core/debug.js
@@ -1,56 +1,54 @@
+let table = null;
+let row = null;
+let title = null;
+let field = null;
+
+function init() {
+    table = document.createElement('table');
+    row = document.createElement('tr');
+    title = document.createElement('td');
+    field = document.createElement('td');
+
+    table.style.cssText = 'position:absolute;font-family:sans-serif;font-size:12px;color:#cccccc';
+    table.style.top = '0px';
+    table.style.left = '0px';
+    table.style.border = 'thin solid #cccccc';
+
+    document.body.appendChild(table);
+}
+
 /**
- * @name debug
  * @private
+ * @name debug
  * @namespace
  */
-var debug = (function () {
-    var table = null;
-    var row = null;
-    var title = null;
-    var field = null;
-
-    return {
-        /**
-         * @private
-         * @function
-         * @name debug.display
-         * @description Display an object and its data in a table on the page.
-         * @param {object} data - The object to display.
-         */
-        display: function (data) {
-            function init() {
-                table = document.createElement('table');
-                row = document.createElement('tr');
-                title = document.createElement('td');
-                field = document.createElement('td');
-
-                table.style.cssText = 'position:absolute;font-family:sans-serif;font-size:12px;color:#cccccc';
-                table.style.top = '0px';
-                table.style.left = '0px';
-                table.style.border = 'thin solid #cccccc';
-
-                document.body.appendChild(table);
-            }
-
-            if (!table) {
-                init();
-            }
-
-            table.innerHTML = '';
-            for (var key in data) {
-                var r = row.cloneNode();
-                var t = title.cloneNode();
-                var f = field.cloneNode();
-
-                t.textContent = key;
-                f.textContent = data[key];
-
-                r.appendChild(t);
-                r.appendChild(f);
-                table.appendChild(r);
-            }
+const debug = {
+    /**
+     * @private
+     * @function
+     * @name debug.display
+     * @description Display an object and its data in a table on the page.
+     * @param {object} data - The object to display.
+     */
+    display: function (data) {
+        if (!table) {
+            init();
         }
-    };
-}());
+
+        table.innerHTML = '';
+        for (const key in data) {
+            const r = row.cloneNode();
+            const t = title.cloneNode();
+            const f = field.cloneNode();
+
+            t.textContent = key;
+            f.textContent = data[key];
+
+            r.appendChild(t);
+            r.appendChild(f);
+            table.appendChild(r);
+        }
+    }
+};
 
 export { debug };

--- a/src/core/event-handler.js
+++ b/src/core/event-handler.js
@@ -85,7 +85,7 @@ class EventHandler {
             if (this._callbackActive[name] && this._callbackActive[name] === this._callbacks[name])
                 this._callbackActive[name] = this._callbackActive[name].slice();
         } else {
-            for (var key in this._callbackActive) {
+            for (const key in this._callbackActive) {
                 if (!this._callbacks[key])
                     continue;
 
@@ -102,13 +102,13 @@ class EventHandler {
             if (this._callbacks[name])
                 this._callbacks[name] = [];
         } else {
-            var events = this._callbacks[name];
+            const events = this._callbacks[name];
             if (!events)
                 return this;
 
-            var count = events.length;
+            let count = events.length;
 
-            for (var i = 0; i < count; i++) {
+            for (let i = 0; i < count; i++) {
                 if (events[i].callback !== callback)
                     continue;
 
@@ -148,7 +148,7 @@ class EventHandler {
         if (!name || !this._callbacks[name])
             return this;
 
-        var callbacks;
+        let callbacks;
 
         if (!this._callbackActive[name]) {
             this._callbackActive[name] = this._callbacks[name];
@@ -163,12 +163,12 @@ class EventHandler {
         // In particular this condition check looks wrong: (i < (callbacks || this._callbackActive[name]).length)
         // Because callbacks is not an integer
         // eslint-disable-next-line no-unmodified-loop-condition
-        for (var i = 0; (callbacks || this._callbackActive[name]) && (i < (callbacks || this._callbackActive[name]).length); i++) {
-            var evt = (callbacks || this._callbackActive[name])[i];
+        for (let i = 0; (callbacks || this._callbackActive[name]) && (i < (callbacks || this._callbackActive[name]).length); i++) {
+            const evt = (callbacks || this._callbackActive[name])[i];
             evt.callback.call(evt.scope, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
 
             if (evt.once) {
-                var ind = this._callbacks[name].indexOf(evt);
+                const ind = this._callbacks[name].indexOf(evt);
                 if (ind !== -1) {
                     if (this._callbackActive[name] === this._callbacks[name])
                         this._callbackActive[name] = this._callbackActive[name].slice();

--- a/src/core/events.js
+++ b/src/core/events.js
@@ -1,6 +1,6 @@
 import { EventHandler } from './event-handler.js';
 
-var events = {
+const events = {
     /**
      * @private
      * @function
@@ -14,7 +14,7 @@ var events = {
      * pc.events.attach(obj);
      */
     attach: function (target) {
-        var ev = events;
+        const ev = events;
         target._addCallback = ev._addCallback;
         target.on = ev.on;
         target.off = ev.off;

--- a/src/core/guid.js
+++ b/src/core/guid.js
@@ -4,7 +4,7 @@
  * @description Basically a very large random number (128-bit) which means the probability of creating two that clash is vanishingly small.
  * GUIDs are used as the unique identifiers for Entities.
  */
-export var guid = {
+const guid = {
     /**
      * @function
      * @name guid.create
@@ -13,9 +13,11 @@ export var guid = {
      */
     create: function () {
         return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
-            var r = Math.random() * 16 | 0,
-                v = (c == 'x') ? r : (r & 0x3 | 0x8);
+            const r = Math.random() * 16 | 0;
+            const v = (c === 'x') ? r : (r & 0x3 | 0x8);
             return v.toString(16);
         });
     }
 };
+
+export { guid };

--- a/src/core/indexed-list.js
+++ b/src/core/indexed-list.js
@@ -22,7 +22,7 @@ class IndexedList {
         if (this._index[key]) {
             throw Error("Key already in index " + key);
         }
-        var location = this._list.push(item) - 1;
+        const location = this._list.push(item) - 1;
         this._index[key] = location;
     }
 
@@ -47,7 +47,7 @@ class IndexedList {
      * @returns {object} The item stored at key.
      */
     get(key) {
-        var location = this._index[key];
+        const location = this._index[key];
         if (location !== undefined) {
             return this._list[location];
         }
@@ -63,14 +63,14 @@ class IndexedList {
      * @returns {boolean} Returns true if the key exists and an item was removed, returns false if no item was removed.
      */
     remove(key) {
-        var location = this._index[key];
+        const location = this._index[key];
         if (location !== undefined) {
             this._list.splice(location, 1);
             delete this._index[key];
 
             // update index
             for (key in this._index) {
-                var idx = this._index[key];
+                const idx = this._index[key];
                 if (idx > location) {
                     this._index[key] = idx - 1;
                 }
@@ -101,7 +101,7 @@ class IndexedList {
     clear() {
         this._list.length = 0;
 
-        for (var prop in this._index) {
+        for (const prop in this._index) {
             delete this._index[prop];
         }
     }

--- a/src/core/object-pool.js
+++ b/src/core/object-pool.js
@@ -9,7 +9,7 @@ class ObjectPool {
 
     _resize(size) {
         if (size > this._pool.length) {
-            for (var i = this._pool.length; i < size; i++) {
+            for (let i = this._pool.length; i < size; i++) {
                 this._pool[i] = new this._constructor();
             }
         }

--- a/src/core/path.js
+++ b/src/core/path.js
@@ -4,7 +4,7 @@ import { isDefined } from './core.js';
  * @namespace path
  * @description File path API.
  */
-var path = {
+const path = {
     /**
      * @constant
      * @type {string}
@@ -29,13 +29,12 @@ var path = {
      * console.log(path); // Prints 'alpha/beta/gamma'
      */
     join: function () {
-        var index;
-        var num = arguments.length;
-        var result = arguments[0];
+        const num = arguments.length;
+        let result = arguments[0];
 
-        for (index = 0; index < num - 1; ++index) {
-            var one = arguments[index];
-            var two = arguments[index + 1];
+        for (let index = 0; index < num - 1; ++index) {
+            const one = arguments[index];
+            const two = arguments[index + 1];
             if (!isDefined(one) || !isDefined(two)) {
                 throw new Error("undefined argument to pc.path.join");
             }
@@ -62,16 +61,16 @@ var path = {
      * @returns {string} The normalized path.
      */
     normalize: function (pathname) {
-        var lead = pathname.startsWith(path.delimiter);
-        var trail = pathname.endsWith(path.delimiter);
+        const lead = pathname.startsWith(path.delimiter);
+        const trail = pathname.endsWith(path.delimiter);
 
-        var parts = pathname.split('/');
+        const parts = pathname.split('/');
 
-        var result = '';
+        let result = '';
 
-        var cleaned = [];
+        let cleaned = [];
 
-        for (var i = 0; i < parts.length; i++) {
+        for (let i = 0; i < parts.length; i++) {
             if (parts[i] === '') continue;
             if (parts[i] === '.') continue;
             if (parts[i] === '..' && cleaned.length > 0) {
@@ -105,9 +104,9 @@ var path = {
      * @returns {string[]} The split path which is an array of two strings, the path and the filename.
      */
     split: function (pathname) {
-        var parts = pathname.split(path.delimiter);
-        var tail = parts.slice(parts.length - 1)[0];
-        var head = parts.slice(0, parts.length - 1).join(path.delimiter);
+        const parts = pathname.split(path.delimiter);
+        const tail = parts.slice(parts.length - 1)[0];
+        const head = parts.slice(0, parts.length - 1).join(path.delimiter);
         return [head, tail];
     },
 
@@ -134,7 +133,7 @@ var path = {
      * @returns {string} The directory part of the path.
      */
     getDirectory: function (pathname) {
-        var parts = pathname.split(path.delimiter);
+        const parts = pathname.split(path.delimiter);
         return parts.slice(0, parts.length - 1).join(path.delimiter);
     },
     /**
@@ -149,7 +148,7 @@ var path = {
      * pc.path.getExtension("/path/to/file.txt?function=getExtension"); // returns ".txt"
      */
     getExtension: function (pathname) {
-        var ext = pathname.split('?')[0].split('.').pop();
+        const ext = pathname.split('?')[0].split('.').pop();
         if (ext !== pathname) {
             return "." + ext;
         }
@@ -187,9 +186,9 @@ var path = {
      * pc.path.extractPath("/path/to/file.txt");   // returns "/path/to"
      */
     extractPath: function (pathname) {
-        var result = "";
-        var parts = pathname.split("/");
-        var i = 0;
+        let result = "";
+        const parts = pathname.split("/");
+        let i = 0;
 
         if (parts.length > 1) {
             if (path.isRelativePath(pathname)) {

--- a/src/core/platform.js
+++ b/src/core/platform.js
@@ -1,3 +1,54 @@
+let desktop = false;
+let mobile = false;
+let windows = false;
+let xbox = false;
+let android = false;
+let ios = false;
+let touch = false;
+let gamepads = false;
+let workers = false;
+let passiveEvents = false;
+
+if (typeof navigator !== 'undefined') {
+    const ua = navigator.userAgent;
+
+    if (/(windows|mac os|linux|cros)/i.test(ua))
+        desktop = true;
+
+    if (/xbox/i.test(ua))
+        xbox = true;
+
+    if (/(windows phone|iemobile|wpdesktop)/i.test(ua)) {
+        mobile = true;
+        windows = true;
+    } else if (/android/i.test(ua)) {
+        mobile = true;
+        android = true;
+    } else if (/ip([ao]d|hone)/i.test(ua)) {
+        mobile = true;
+        ios = true;
+    }
+
+    if (typeof window !== 'undefined') {
+        touch = 'ontouchstart' in window || ('maxTouchPoints' in navigator && navigator.maxTouchPoints > 0);
+    }
+
+    gamepads = 'getGamepads' in navigator;
+
+    workers = (typeof(Worker) !== 'undefined');
+
+    try {
+        const opts = Object.defineProperty({}, 'passive', {
+            get: function () {
+                passiveEvents = true;
+                return false;
+            }
+        });
+        window.addEventListener("testpassive", null, opts);
+        window.removeEventListener("testpassive", null, opts);
+    } catch (e) {}
+}
+
 /**
  * @namespace
  * @name platform
@@ -15,7 +66,7 @@ const platform = {
      * @name platform.desktop
      * @description Is it a desktop or laptop device.
      */
-    desktop: false,
+    desktop: desktop,
 
     /**
      * @static
@@ -24,7 +75,7 @@ const platform = {
      * @name platform.mobile
      * @description Is it a mobile or tablet device.
      */
-    mobile: false,
+    mobile: mobile,
 
     /**
      * @static
@@ -33,7 +84,7 @@ const platform = {
      * @name platform.ios
      * @description If it is iOS.
      */
-    ios: false,
+    ios: ios,
 
     /**
      * @static
@@ -42,7 +93,7 @@ const platform = {
      * @name platform.android
      * @description If it is Android.
      */
-    android: false,
+    android: android,
 
     /**
      * @static
@@ -51,7 +102,7 @@ const platform = {
      * @name platform.windows
      * @description If it is Windows.
      */
-    windows: false,
+    windows: windows,
 
     /**
      * @static
@@ -60,7 +111,7 @@ const platform = {
      * @name platform.xbox
      * @description If it is Xbox.
      */
-    xbox: false,
+    xbox: xbox,
 
     /**
      * @static
@@ -69,7 +120,7 @@ const platform = {
      * @name platform.gamepads
      * @description If platform supports gamepads.
      */
-    gamepads: false,
+    gamepads: gamepads,
 
     /**
      * @static
@@ -78,7 +129,7 @@ const platform = {
      * @name platform.touch
      * @description If platform supports touch input.
      */
-    touch: false,
+    touch: touch,
 
     /**
      * @static
@@ -87,7 +138,7 @@ const platform = {
      * @name platform.workers
      * @description If the platform supports Web Workers.
      */
-    workers: false,
+    workers: workers,
 
     /**
      * @private
@@ -98,50 +149,7 @@ const platform = {
      * @description If the platform supports an options object as the third parameter
      * to `EventTarget.addEventListener()` and the passive property is supported.
      */
-    passiveEvents: false
+    passiveEvents: passiveEvents
 };
-
-if (typeof navigator !== 'undefined') {
-    const ua = navigator.userAgent;
-
-    if (/(windows|mac os|linux|cros)/i.test(ua))
-        platform.desktop = true;
-
-    if (/xbox/i.test(ua))
-        platform.xbox = true;
-
-    if (/(windows phone|iemobile|wpdesktop)/i.test(ua)) {
-        platform.desktop = false;
-        platform.mobile = true;
-        platform.windows = true;
-    } else if (/android/i.test(ua)) {
-        platform.desktop = false;
-        platform.mobile = true;
-        platform.android = true;
-    } else if (/ip([ao]d|hone)/i.test(ua)) {
-        platform.desktop = false;
-        platform.mobile = true;
-        platform.ios = true;
-    }
-
-    if (typeof window !== 'undefined') {
-        platform.touch = 'ontouchstart' in window || ('maxTouchPoints' in navigator && navigator.maxTouchPoints > 0);
-    }
-
-    platform.gamepads = 'getGamepads' in navigator;
-
-    platform.workers = (typeof(Worker) !== 'undefined');
-
-    try {
-        const opts = Object.defineProperty({}, 'passive', {
-            get: function () {
-                platform.passiveEvents = true;
-                return false;
-            }
-        });
-        window.addEventListener("testpassive", null, opts);
-        window.removeEventListener("testpassive", null, opts);
-    } catch (e) {}
-}
 
 export { platform };

--- a/src/core/platform.js
+++ b/src/core/platform.js
@@ -7,7 +7,7 @@
  *     // touch is supported
  * }
  */
-var platform = {
+const platform = {
     /**
      * @static
      * @readonly
@@ -102,7 +102,7 @@ var platform = {
 };
 
 if (typeof navigator !== 'undefined') {
-    var ua = navigator.userAgent;
+    const ua = navigator.userAgent;
 
     if (/(windows|mac os|linux|cros)/i.test(ua))
         platform.desktop = true;
@@ -133,7 +133,7 @@ if (typeof navigator !== 'undefined') {
     platform.workers = (typeof(Worker) !== 'undefined');
 
     try {
-        var opts = Object.defineProperty({}, 'passive', {
+        const opts = Object.defineProperty({}, 'passive', {
             get: function () {
                 platform.passiveEvents = true;
                 return false;

--- a/src/core/sorted-loop-array.js
+++ b/src/core/sorted-loop-array.js
@@ -39,12 +39,12 @@ class SortedLoopArray {
      * @returns {number} The index where to insert the item.
      */
     _binarySearch(item) {
-        var left = 0;
-        var right = this.items.length - 1;
-        var search = item[this._sortBy];
+        let left = 0;
+        let right = this.items.length - 1;
+        const search = item[this._sortBy];
 
-        var middle;
-        var current;
+        let middle;
+        let current;
         while (left <= right) {
             middle = Math.floor((left + right) / 2);
             current = this.items[middle][this._sortBy];
@@ -59,7 +59,7 @@ class SortedLoopArray {
     }
 
     _doSort(a, b) {
-        var sortBy = this._sortBy;
+        const sortBy = this._sortBy;
         return a[sortBy] - b[sortBy];
     }
 
@@ -73,7 +73,7 @@ class SortedLoopArray {
      * @param {object} item - The item to insert.
      */
     insert(item) {
-        var index = this._binarySearch(item);
+        const index = this._binarySearch(item);
         this.items.splice(index, 0, item);
         this.length++;
         if (this.loopIndex >= index) {
@@ -103,7 +103,7 @@ class SortedLoopArray {
      * @param {object} item - The item to remove.
      */
     remove(item) {
-        var idx = this.items.indexOf(item);
+        const idx = this.items.indexOf(item);
         if (idx < 0) return;
 
         this.items.splice(idx, 1);
@@ -126,7 +126,7 @@ class SortedLoopArray {
      */
     sort() {
         // get current item pointed to by loopIndex
-        var current = (this.loopIndex >= 0 ? this.items[this.loopIndex] : null);
+        const current = (this.loopIndex >= 0 ? this.items[this.loopIndex] : null);
         // sort
         this.items.sort(this._sortHandler);
         // find new loopIndex

--- a/src/core/string.js
+++ b/src/core/string.js
@@ -1,54 +1,60 @@
-var ASCII_LOWERCASE = "abcdefghijklmnopqrstuvwxyz";
-var ASCII_UPPERCASE = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
-var ASCII_LETTERS = ASCII_LOWERCASE + ASCII_UPPERCASE;
+const ASCII_LOWERCASE = "abcdefghijklmnopqrstuvwxyz";
+const ASCII_UPPERCASE = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+const ASCII_LETTERS = ASCII_LOWERCASE + ASCII_UPPERCASE;
 
-var HIGH_SURROGATE_BEGIN = 0xD800;
-var HIGH_SURROGATE_END = 0xDBFF;
-var LOW_SURROGATE_BEGIN = 0xDC00;
-var LOW_SURROGATE_END = 0xDFFF;
-var ZERO_WIDTH_JOINER = 0x200D;
+const HIGH_SURROGATE_BEGIN = 0xD800;
+const HIGH_SURROGATE_END = 0xDBFF;
+const LOW_SURROGATE_BEGIN = 0xDC00;
+const LOW_SURROGATE_END = 0xDFFF;
+const ZERO_WIDTH_JOINER = 0x200D;
 
 // Flag emoji
-var REGIONAL_INDICATOR_BEGIN = 0x1F1E6;
-var REGIONAL_INDICATOR_END = 0x1F1FF;
+const REGIONAL_INDICATOR_BEGIN = 0x1F1E6;
+const REGIONAL_INDICATOR_END = 0x1F1FF;
 
 // Skin color modifications to emoji
-var FITZPATRICK_MODIFIER_BEGIN = 0x1F3FB;
-var FITZPATRICK_MODIFIER_END = 0x1F3FF;
+const FITZPATRICK_MODIFIER_BEGIN = 0x1F3FB;
+const FITZPATRICK_MODIFIER_END = 0x1F3FF;
 
 // Accent characters
-var DIACRITICAL_MARKS_BEGIN = 0x20D0;
-var DIACRITICAL_MARKS_END = 0x20FF;
+const DIACRITICAL_MARKS_BEGIN = 0x20D0;
+const DIACRITICAL_MARKS_END = 0x20FF;
 
 // Special emoji joins
-var VARIATION_MODIFIER_BEGIN = 0xFE00;
-var VARIATION_MODIFIER_END = 0xFE0F;
+const VARIATION_MODIFIER_BEGIN = 0xFE00;
+const VARIATION_MODIFIER_END = 0xFE0F;
 
-function getCodePointData(string, i) {
-    var size = string.length;
-    i = i || 0;
+function getCodePointData(string, i = 0) {
+    const size = string.length;
+
     // Account for out-of-bounds indices:
     if (i < 0 || i >= size) {
         return null;
     }
-    var first = string.charCodeAt(i);
-    var second;
+    const first = string.charCodeAt(i);
     if (size > 1 && first >= HIGH_SURROGATE_BEGIN && first <= HIGH_SURROGATE_END) {
-        second = string.charCodeAt(i + 1);
+        const second = string.charCodeAt(i + 1);
         if (second >= LOW_SURROGATE_BEGIN && second <= LOW_SURROGATE_END) {
             // https://mathiasbynens.be/notes/javascript-encoding#surrogate-formulae
-            return { code: (first - HIGH_SURROGATE_BEGIN) * 0x400 + second - LOW_SURROGATE_BEGIN + 0x10000, long: true };
+            return {
+                code: (first - HIGH_SURROGATE_BEGIN) * 0x400 + second - LOW_SURROGATE_BEGIN + 0x10000,
+                long: true
+            };
         }
     }
-    return { code: first, long: false };
+
+    return {
+        code: first,
+        long: false
+    };
 }
 
 function isCodeBetween(string, begin, end) {
     if (!string)
         return false;
-    var codeData = getCodePointData(string);
+    const codeData = getCodePointData(string);
     if (codeData) {
-        var code = codeData.code;
+        const code = codeData.code;
         return code >= begin && code <= end;
     }
     return false;
@@ -60,8 +66,8 @@ function numCharsToTakeForNextSymbol(string, index) {
         return 1;
     }
     if (isCodeBetween(string[index], HIGH_SURROGATE_BEGIN, HIGH_SURROGATE_END)) {
-        var first = string.substring(index, index + 2);
-        var second = string.substring(index + 2, index + 4);
+        const first = string.substring(index, index + 2);
+        const second = string.substring(index + 2, index + 4);
 
         // check if second character is fitzpatrick (color) modifier
         // or if this is a pair of regional indicators (a flag)
@@ -95,7 +101,7 @@ function numCharsToTakeForNextSymbol(string, index) {
  * @name string
  * @description Extended String API.
  */
-var string = {
+const string = {
     /**
      * @constant
      * @type {string}
@@ -130,7 +136,7 @@ var string = {
      * console.log(s); // Prints "Hello world"
      */
     format: function (s) {
-        for (var i = 1; i < arguments.length; i++) {
+        for (let i = 1; i < arguments.length; i++) {
             s = s.replace('{' + (i - 1) + '}', arguments[i]);
         }
         return s;
@@ -146,7 +152,7 @@ var string = {
      * @param {boolean} [strict] - In strict mode an Exception is thrown if s is not an accepted string value. Defaults to false.
      * @returns {boolean} The converted value.
      */
-    toBool: function (s, strict) {
+    toBool: function (s, strict = false) {
         if (s === 'true') {
             return true;
         }
@@ -172,7 +178,7 @@ var string = {
      * @returns {number} The code point value for the character in the string.
      */
     getCodePoint: function (string, i) {
-        var codePointData = getCodePointData(string, i);
+        const codePointData = getCodePointData(string, i);
         return codePointData && codePointData.code;
     },
 
@@ -187,9 +193,9 @@ var string = {
         if (typeof string !== 'string') {
             throw new TypeError('Not a string');
         }
-        var i = 0;
-        var arr = [];
-        var codePoint;
+        let i = 0;
+        const arr = [];
+        let codePoint;
         while (!!(codePoint = getCodePointData(string, i))) {
             arr.push(codePoint.code);
             i += codePoint.long ? 2 : 1;
@@ -210,11 +216,11 @@ var string = {
         if (typeof string !== 'string') {
             throw new TypeError('Not a string');
         }
-        var index = 0;
-        var length = string.length;
-        var output = [];
-        var take = 0;
-        var ch;
+        let index = 0;
+        const length = string.length;
+        const output = [];
+        let take = 0;
+        let ch;
         while (index < length) {
             take += numCharsToTakeForNextSymbol(string, index + take);
             ch = string[index + take];
@@ -230,7 +236,7 @@ var string = {
                 // Not a complete char yet
                 continue;
             }
-            var char = string.substring(index, index + take);
+            const char = string.substring(index, index + take);
             output.push(char);
             index += take;
             take = 0;
@@ -247,11 +253,11 @@ var string = {
      * @returns {string} The converted string.
      */
     fromCodePoint: function (/* ...args */) {
-        var chars = [];
-        var current;
-        var codePoint;
-        var units;
-        for (var i = 0; i < arguments.length; ++i) {
+        const chars = [];
+        let current;
+        let codePoint;
+        let units;
+        for (let i = 0; i < arguments.length; ++i) {
             current = Number(arguments[i]);
             codePoint = current - 0x10000;
             units = current > 0xFFFF ? [(codePoint >> 10) + 0xD800, (codePoint % 0x400) + 0xDC00] : [current];

--- a/src/core/tags-cache.js
+++ b/src/core/tags-cache.js
@@ -5,17 +5,17 @@ class TagsCache {
     }
 
     addItem(item) {
-        var tags = item.tags._list;
+        const tags = item.tags._list;
 
-        for (var i = 0; i < tags.length; i++)
-            this.add(tags[i], item);
+        for (const tag of tags)
+            this.add(tag, item);
     }
 
     removeItem(item) {
-        var tags = item.tags._list;
+        const tags = item.tags._list;
 
-        for (var i = 0; i < tags.length; i++)
-            this.remove(tags[i], item);
+        for (const tag of tags)
+            this.remove(tag, item);
     }
 
     add(tag, item) {
@@ -54,7 +54,7 @@ class TagsCache {
         }
 
         // by position in list
-        var ind = this._index[tag].list.indexOf(item);
+        const ind = this._index[tag].list.indexOf(item);
         if (ind === -1)
             return;
 
@@ -71,17 +71,15 @@ class TagsCache {
     }
 
     find(args) {
-        var self = this;
-        var index = { };
-        var items = [];
-        var i, n, t;
-        var item, tag, tags, tagsRest, missingIndex;
+        const index = { };
+        const items = [];
+        let item, tag, tags, tagsRest, missingIndex;
 
-        var sort = (a, b) => {
-            return self._index[a].list.length - self._index[b].list.length;
+        const sort = (a, b) => {
+            return this._index[a].list.length - this._index[b].list.length;
         };
 
-        for (i = 0; i < args.length; i++) {
+        for (let i = 0; i < args.length; i++) {
             tag = args[i];
 
             if (tag instanceof Array) {
@@ -93,7 +91,7 @@ class TagsCache {
                 } else {
                     // check if all indexes are in present
                     missingIndex = false;
-                    for (t = 0; t < tag.length; t++) {
+                    for (let t = 0; t < tag.length; t++) {
                         if (!this._index[tag[t]]) {
                             missingIndex = true;
                             break;
@@ -110,7 +108,7 @@ class TagsCache {
                     if (tagsRest.length === 1)
                         tagsRest = tagsRest[0];
 
-                    for (n = 0; n < this._index[tags[0]].list.length; n++) {
+                    for (let n = 0; n < this._index[tags[0]].list.length; n++) {
                         item = this._index[tags[0]].list[n];
                         if ((this._key ? !index[item[this._key]] : (items.indexOf(item) === -1)) && item.tags.has(tagsRest)) {
                             if (this._key)
@@ -124,7 +122,7 @@ class TagsCache {
             }
 
             if (tag && typeof tag === 'string' && this._index[tag]) {
-                for (n = 0; n < this._index[tag].list.length; n++) {
+                for (let n = 0; n < this._index[tag].list.length; n++) {
                     item = this._index[tag].list[n];
 
                     if (this._key) {

--- a/src/core/tags.js
+++ b/src/core/tags.js
@@ -32,13 +32,13 @@ class Tags extends EventHandler {
      * tags.add(['level-2', 'mob']);
      */
     add() {
-        var changed = false;
-        var tags = this._processArguments(arguments, true);
+        let changed = false;
+        const tags = this._processArguments(arguments, true);
 
         if (!tags.length)
             return changed;
 
-        for (var i = 0; i < tags.length; i++) {
+        for (let i = 0; i < tags.length; i++) {
             if (this._index[tags[i]])
                 continue;
 
@@ -70,17 +70,17 @@ class Tags extends EventHandler {
      * tags.remove(['level-2', 'mob']);
      */
     remove() {
-        var changed = false;
+        let changed = false;
 
         if (!this._list.length)
             return changed;
 
-        var tags = this._processArguments(arguments, true);
+        const tags = this._processArguments(arguments, true);
 
         if (!tags.length)
             return changed;
 
-        for (var i = 0; i < tags.length; i++) {
+        for (let i = 0; i < tags.length; i++) {
             if (!this._index[tags[i]])
                 continue;
 
@@ -109,11 +109,11 @@ class Tags extends EventHandler {
         if (!this._list.length)
             return;
 
-        var tags = this._list.slice(0);
+        const tags = this._list.slice(0);
         this._list = [];
         this._index = { };
 
-        for (var i = 0; i < tags.length; i++)
+        for (let i = 0; i < tags.length; i++)
             this.fire('remove', tags[i], this._parent);
 
         this.fire('change', this._parent);
@@ -150,16 +150,16 @@ class Tags extends EventHandler {
         if (!this._list.length || !tags.length)
             return false;
 
-        for (var i = 0; i < tags.length; i++) {
+        for (let i = 0; i < tags.length; i++) {
             if (tags[i].length === 1) {
                 // single occurance
                 if (this._index[tags[i][0]])
                     return true;
             } else {
                 // combined occurance
-                var multiple = true;
+                let multiple = true;
 
-                for (var t = 0; t < tags[i].length; t++) {
+                for (let t = 0; t < tags[i].length; t++) {
                     if (this._index[tags[i][t]])
                         continue;
 
@@ -186,18 +186,18 @@ class Tags extends EventHandler {
     }
 
     _processArguments(args, flat) {
-        var tags = [];
-        var tmp = [];
+        const tags = [];
+        let tmp = [];
 
         if (!args || !args.length)
             return tags;
 
-        for (var i = 0; i < args.length; i++) {
+        for (let i = 0; i < args.length; i++) {
             if (args[i] instanceof Array) {
                 if (!flat)
                     tmp = [];
 
-                for (var t = 0; t < args[i].length; t++) {
+                for (let t = 0; t < args[i].length; t++) {
                     if (typeof args[i][t] !== 'string')
                         continue;
 

--- a/src/core/time.js
+++ b/src/core/time.js
@@ -5,7 +5,7 @@
  * @description Get current time in milliseconds. Use it to measure time difference. Reference time may differ on different platforms.
  * @returns {number} The time in milliseconds.
  */
-var now = (typeof window !== 'undefined') && window.performance && window.performance.now && window.performance.timing ? function () {
+const now = (typeof window !== 'undefined') && window.performance && window.performance.now && window.performance.timing ? function () {
     return window.performance.now();
 } : Date.now;
 

--- a/src/core/uri.js
+++ b/src/core/uri.js
@@ -74,7 +74,7 @@ class URI {
      * @property {string} fragment The fragment, the section after a #.
      */
     constructor(uri) {
-        let result = uri.match(re);
+        const result = uri.match(re);
 
         this.scheme = result[2];
         this.authority = result[4];
@@ -134,7 +134,7 @@ class URI {
         if (this.query) {
             const queryParams = decodeURIComponent(this.query).split("&");
             for (const queryParam of queryParams) {
-                let pair = queryParam.split("=");
+                const pair = queryParam.split("=");
                 result[pair[0]] = pair[1];
             }
         }

--- a/src/math/color.js
+++ b/src/math/color.js
@@ -16,7 +16,7 @@ import { math } from '../math/math.js';
  */
 class Color {
     constructor(r = 0, g = 0, b = 0, a = 1) {
-        var length = r.length;
+        const length = r.length;
         if (length === 3 || length === 4) {
             this.r = r[0];
             this.g = r[1];
@@ -134,8 +134,8 @@ class Color {
      * @returns {Color} Self for chaining.
      */
     fromString(hex) {
-        var i = parseInt(hex.replace('#', '0x'), 16);
-        var bytes;
+        const i = parseInt(hex.replace('#', '0x'), 16);
+        let bytes;
         if (hex.length > 7) {
             bytes = math.intToBytes32(i);
         } else {
@@ -162,9 +162,9 @@ class Color {
      * console.log(c.toString());
      */
     toString(alpha) {
-        var s = "#" + ((1 << 24) + (Math.round(this.r * 255) << 16) + (Math.round(this.g * 255) << 8) + Math.round(this.b * 255)).toString(16).slice(1);
+        let s = "#" + ((1 << 24) + (Math.round(this.r * 255) << 16) + (Math.round(this.g * 255) << 8) + Math.round(this.b * 255)).toString(16).slice(1);
         if (alpha === true) {
-            var a = Math.round(this.a * 255).toString(16);
+            const a = Math.round(this.a * 255).toString(16);
             if (this.a < 16 / 255) {
                 s += '0' + a;
             } else {

--- a/src/math/curve-evaluator.js
+++ b/src/math/curve-evaluator.js
@@ -21,15 +21,15 @@ class CurveEvaluator {
             this._reset(time);
         }
 
-        var result;
+        let result;
 
-        var type = this._curve.type;
+        const type = this._curve.type;
         if (type === CURVE_STEP) {
             // step
             result = this._p0;
         } else {
             // calculate normalized t
-            var t = (this._recip === 0) ? 0 : (time - this._left) * this._recip;
+            const t = (this._recip === 0) ? 0 : (time - this._left) * this._recip;
 
             if (type === CURVE_LINEAR) {
                 // linear
@@ -47,8 +47,8 @@ class CurveEvaluator {
 
     // Calculate weights for the curve interval at the given time
     _reset(time) {
-        var keys = this._curve.keys;
-        var len = keys.length;
+        const keys = this._curve.keys;
+        const len = keys.length;
 
         if (!len) {
             // curve is empty
@@ -77,13 +77,13 @@ class CurveEvaluator {
                 // (TODO: for cases where the curve has more than 'n' keys it will
                 // be more efficient to perform a binary search here instead. Which is
                 // straight forward thanks to the sorted list of knots).
-                var index = 0;
+                let index = 0;
                 while (time >= keys[index + 1][0]) {
                     index++;
                 }
                 this._left = keys[index][0];
                 this._right = keys[index + 1][0];
-                var diff = 1.0 / (this._right - this._left);
+                const diff = 1.0 / (this._right - this._left);
                 this._recip = (isFinite(diff) ? diff : 0);
                 this._p0 = keys[index][1];
                 this._p1 = keys[index + 1][1];
@@ -103,10 +103,10 @@ class CurveEvaluator {
 
     // calculate tangents for the hermite curve
     _calcTangents(keys, index) {
-        var a;
-        var b = keys[index];
-        var c = keys[index + 1];
-        var d;
+        let a;
+        const b = keys[index];
+        const c = keys[index + 1];
+        let d;
 
         if (index === 0) {
             a = [keys[0][0] + (keys[0][0] - keys[1][0]),
@@ -124,20 +124,20 @@ class CurveEvaluator {
 
         if (this._curve.type === CURVE_SPLINE) {
             // calculate tangent scale (due to non-uniform knot spacing)
-            var s1_ = 2 * (c[0] - b[0]) / (c[0] - a[0]);
-            var s2_ = 2 * (c[0] - b[0]) / (d[0] - b[0]);
+            const s1_ = 2 * (c[0] - b[0]) / (c[0] - a[0]);
+            const s2_ = 2 * (c[0] - b[0]) / (d[0] - b[0]);
 
             this._m0 = this._curve.tension * (isFinite(s1_) ? s1_ : 0) * (c[1] - a[1]);
             this._m1 = this._curve.tension * (isFinite(s2_) ? s2_ : 0) * (d[1] - b[1]);
         } else {
             // original tangent scale calc
-            var s1 = (c[0] - b[0]) / (b[0] - a[0]);
-            var s2 = (c[0] - b[0]) / (d[0] - c[0]);
+            const s1 = (c[0] - b[0]) / (b[0] - a[0]);
+            const s2 = (c[0] - b[0]) / (d[0] - c[0]);
 
-            var a_ = b[1] + (a[1] - b[1]) * (isFinite(s1) ? s1 : 0);
-            var d_ = c[1] + (d[1] - c[1]) * (isFinite(s2) ? s2 : 0);
+            const a_ = b[1] + (a[1] - b[1]) * (isFinite(s1) ? s1 : 0);
+            const d_ = c[1] + (d[1] - c[1]) * (isFinite(s2) ? s2 : 0);
 
-            var tension = (this._curve.type === CURVE_CATMULL) ? 0.5 : this._curve.tension;
+            const tension = (this._curve.type === CURVE_CATMULL) ? 0.5 : this._curve.tension;
 
             this._m0 = tension * (c[1] - a_);
             this._m1 = tension * (d_ - b[1]);
@@ -145,10 +145,10 @@ class CurveEvaluator {
     }
 
     _evaluateHermite(p0, p1, m0, m1, t) {
-        var t2 = t * t;
-        var twot = t + t;
-        var omt = 1 - t;
-        var omt2 = omt * omt;
+        const t2 = t * t;
+        const twot = t + t;
+        const omt = 1 - t;
+        const omt2 = omt * omt;
         return p0 * ((1 + twot) * omt2) +
                m0 * (t * omt2) +
                p1 * (t2 * (3 - twot)) +

--- a/src/math/curve-set.js
+++ b/src/math/curve-set.js
@@ -27,26 +27,24 @@ import { CurveEvaluator } from './curve-evaluator.js';
  */
 class CurveSet {
     constructor() {
-        var i;
-
         this.curves = [];
         this._type = CURVE_SMOOTHSTEP;
 
         if (arguments.length > 1) {
-            for (i = 0; i < arguments.length; i++) {
+            for (let i = 0; i < arguments.length; i++) {
                 this.curves.push(new Curve(arguments[i]));
             }
         } else {
             if (arguments.length === 0) {
                 this.curves.push(new Curve());
             } else {
-                var arg = arguments[0];
+                const arg = arguments[0];
                 if (typeof arg === 'number') {
-                    for (i = 0; i < arg; i++) {
+                    for (let i = 0; i < arg; i++) {
                         this.curves.push(new Curve());
                     }
                 } else {
-                    for (i = 0; i < arg.length; i++) {
+                    for (let i = 0; i < arg.length; i++) {
                         this.curves.push(new Curve(arg[i]));
                     }
                 }
@@ -77,10 +75,10 @@ class CurveSet {
      * @returns {number[]} The interpolated curve values at the specified time.
      */
     value(time, result = []) {
-        var length = this.curves.length;
+        const length = this.curves.length;
         result.length = length;
 
-        for (var i = 0; i < length; i++) {
+        for (let i = 0; i < length; i++) {
             result[i] = this.curves[i].value(time);
         }
 
@@ -94,10 +92,10 @@ class CurveSet {
      * @returns {CurveSet} A clone of the specified curve set.
      */
     clone() {
-        var result = new CurveSet();
+        const result = new CurveSet();
 
         result.curves = [];
-        for (var i = 0; i < this.curves.length; i++) {
+        for (let i = 0; i < this.curves.length; i++) {
             result.curves.push(this.curves[i].clone());
         }
 
@@ -109,13 +107,13 @@ class CurveSet {
     quantize(precision) {
         precision = Math.max(precision, 2);
 
-        var numCurves = this.curves.length;
-        var values = new Float32Array(precision * numCurves);
-        var step = 1.0 / (precision - 1);
+        const numCurves = this.curves.length;
+        const values = new Float32Array(precision * numCurves);
+        const step = 1.0 / (precision - 1);
 
-        for (var c = 0; c < numCurves; c++) {
-            var ev = new CurveEvaluator(this.curves[c]);
-            for (var i = 0; i < precision; i++) { // quantize graph to table of interpolated values
+        for (let c = 0; c < numCurves; c++) {
+            const ev = new CurveEvaluator(this.curves[c]);
+            for (let i = 0; i < precision; i++) { // quantize graph to table of interpolated values
                 values[i * numCurves + c] = ev.evaluate(step * i);
             }
         }
@@ -135,8 +133,8 @@ class CurveSet {
      * @returns {Float32Array} The set of quantized values.
      */
     quantizeClamped(precision, min, max) {
-        var result = this.quantize(precision);
-        for (var i = 0; i < result.length; ++i) {
+        const result = this.quantize(precision);
+        for (let i = 0; i < result.length; ++i) {
             result[i] = Math.min(max, Math.max(min, result[i]));
         }
         return result;
@@ -170,7 +168,7 @@ class CurveSet {
 
     set type(value) {
         this._type = value;
-        for (var i = 0; i < this.curves.length; i++) {
+        for (let i = 0; i < this.curves.length; i++) {
             this.curves[i].type = value;
         }
     }

--- a/src/math/curve.js
+++ b/src/math/curve.js
@@ -40,7 +40,7 @@ class Curve {
         this._eval = new CurveEvaluator(this);
 
         if (data) {
-            for (var i = 0; i < data.length - 1; i += 2) {
+            for (let i = 0; i < data.length - 1; i += 2) {
                 this.keys.push([data[i], data[i + 1]]);
             }
         }
@@ -57,9 +57,9 @@ class Curve {
      * @returns {number[]} [time, value] pair.
      */
     add(time, value) {
-        var keys = this.keys;
-        var len = keys.length;
-        var i = 0;
+        const keys = this.keys;
+        const len = keys.length;
+        let i = 0;
 
         for (; i < len; i++) {
             if (keys[i][0] > time) {
@@ -67,7 +67,7 @@ class Curve {
             }
         }
 
-        var key = [time, value];
+        const key = [time, value];
         this.keys.splice(i, 0, key);
         return key;
     }
@@ -108,13 +108,13 @@ class Curve {
     }
 
     closest(time) {
-        var keys = this.keys;
-        var length = keys.length;
-        var min = 2;
-        var result = null;
+        const keys = this.keys;
+        const length = keys.length;
+        let min = 2;
+        let result = null;
 
-        for (var i = 0; i < length; i++) {
-            var diff = Math.abs(time - keys[i][0]);
+        for (let i = 0; i < length; i++) {
+            const diff = Math.abs(time - keys[i][0]);
             if (min >= diff) {
                 min = diff;
                 result = keys[i];
@@ -133,7 +133,7 @@ class Curve {
      * @returns {Curve} A clone of the specified curve.
      */
     clone() {
-        var result = new Curve();
+        const result = new Curve();
         result.keys = extend(result.keys, this.keys);
         result.type = this.type;
         result.tension = this.tension;
@@ -151,12 +151,12 @@ class Curve {
     quantize(precision) {
         precision = Math.max(precision, 2);
 
-        var values = new Float32Array(precision);
-        var step = 1.0 / (precision - 1);
+        const values = new Float32Array(precision);
+        const step = 1.0 / (precision - 1);
 
         // quantize graph to table of interpolated values
         values[0] = this._eval.evaluate(0, true);
-        for (var i = 1; i < precision; i++) {
+        for (let i = 1; i < precision; i++) {
             values[i] = this._eval.evaluate(step * i);
         }
 
@@ -175,8 +175,8 @@ class Curve {
      * @returns {Float32Array} The set of quantized values.
      */
     quantizeClamped(precision, min, max) {
-        var result = this.quantize(precision);
-        for (var i = 0; i < result.length; ++i) {
+        const result = this.quantize(precision);
+        for (let i = 0; i < result.length; ++i) {
             result[i] = Math.min(max, Math.max(min, result[i]));
         }
         return result;

--- a/src/math/mat3.js
+++ b/src/math/mat3.js
@@ -9,10 +9,9 @@ import { Vec3 } from './vec3.js';
  */
 class Mat3 {
     constructor() {
-        var data;
         // Create an identity matrix. Note that a new Float32Array has all elements set
         // to zero by default, so we only need to set the relevant elements to one.
-        data = new Float32Array(9);
+        const data = new Float32Array(9);
         data[0] = data[4] = data[8] = 1;
         this.data = data;
     }
@@ -44,8 +43,8 @@ class Mat3 {
      * console.log("The two matrices are " + (src.equals(dst) ? "equal" : "different"));
      */
     copy(rhs) {
-        var src = rhs.data;
-        var dst = this.data;
+        const src = rhs.data;
+        const dst = this.data;
 
         dst[0] = src[0];
         dst[1] = src[1];
@@ -71,7 +70,7 @@ class Mat3 {
      * dst.set([0, 1, 2, 3, 4, 5, 6, 7, 8]);
      */
     set(src) {
-        var dst = this.data;
+        const dst = this.data;
 
         dst[0] = src[0];
         dst[1] = src[1];
@@ -98,8 +97,8 @@ class Mat3 {
      * console.log("The two matrices are " + (a.equals(b) ? "equal" : "different"));
      */
     equals(rhs) {
-        var l = this.data;
-        var r = rhs.data;
+        const l = this.data;
+        const r = rhs.data;
 
         return ((l[0] === r[0]) &&
                 (l[1] === r[1]) &&
@@ -122,7 +121,7 @@ class Mat3 {
      * console.log("The matrix is " + (m.isIdentity() ? "identity" : "not identity"));
      */
     isIdentity() {
-        var m = this.data;
+        const m = this.data;
         return ((m[0] === 1) &&
                 (m[1] === 0) &&
                 (m[2] === 0) &&
@@ -144,7 +143,7 @@ class Mat3 {
      * console.log("The matrix is " + (m.isIdentity() ? "identity" : "not identity"));
      */
     setIdentity() {
-        var m = this.data;
+        const m = this.data;
         m[0] = 1;
         m[1] = 0;
         m[2] = 0;
@@ -171,8 +170,8 @@ class Mat3 {
      * console.log(m.toString());
      */
     toString() {
-        var t = '[';
-        for (var i = 0; i < 9; i++) {
+        let t = '[';
+        for (let i = 0; i < 9; i++) {
             t += this.data[i];
             t += (i !== 8) ? ', ' : '';
         }
@@ -192,9 +191,9 @@ class Mat3 {
      * m.transpose();
      */
     transpose() {
-        var m = this.data;
+        const m = this.data;
 
-        var tmp;
+        let tmp;
         tmp = m[1]; m[1] = m[3]; m[3] = tmp;
         tmp = m[2]; m[2] = m[6]; m[6] = tmp;
         tmp = m[5]; m[5] = m[7]; m[7] = tmp;
@@ -210,8 +209,8 @@ class Mat3 {
      * @returns {Mat3} Self for chaining.
      */
     setFromMat4(m) {
-        var src = m.data;
-        var dst = this.data;
+        const src = m.data;
+        const dst = this.data;
 
         dst[0] = src[0];
         dst[1] = src[1];
@@ -237,13 +236,11 @@ class Mat3 {
      * @returns {Vec3} The input vector v transformed by the current instance.
      */
     transformVector(vec, res = new Vec3()) {
-        var x, y, z, m;
+        const m = this.data;
 
-        m = this.data;
-
-        x = vec.x;
-        y = vec.y;
-        z = vec.z;
+        const x = vec.x;
+        const y = vec.y;
+        const z = vec.z;
 
         res.x = x * m[0] + y * m[3] + z * m[6];
         res.y = x * m[1] + y * m[4] + z * m[7];

--- a/src/math/mat4.js
+++ b/src/math/mat4.js
@@ -3,11 +3,11 @@ import { Vec2 } from './vec2.js';
 import { Vec3 } from './vec3.js';
 import { Vec4 } from './vec4.js';
 
-var _halfSize = new Vec2();
-var x = new Vec3();
-var y = new Vec3();
-var z = new Vec3();
-var scale = new Vec3();
+const _halfSize = new Vec2();
+const x = new Vec3();
+const y = new Vec3();
+const z = new Vec3();
+const scale = new Vec3();
 
 
 /**
@@ -19,9 +19,9 @@ var scale = new Vec3();
  */
 class Mat4 {
     constructor() {
-        var data = new Float32Array(16);
         // Create an identity matrix. Note that a new Float32Array has all elements set
         // to zero by default, so we only need to set the relevant elements to one.
+        const data = new Float32Array(16);
         data[0] = data[5] = data[10] = data[15] = 1;
         this.data = data;
     }
@@ -53,7 +53,7 @@ class Mat4 {
      * console.log("The result of the addition is: " + m.toString());
      */
     add2(lhs, rhs) {
-        var a = lhs.data,
+        const a = lhs.data,
             b = rhs.data,
             r = this.data;
 
@@ -121,7 +121,7 @@ class Mat4 {
      * console.log("The two matrices are " + (src.equals(dst) ? "equal" : "different"));
      */
     copy(rhs) {
-        var src = rhs.data,
+        const src = rhs.data,
             dst = this.data;
 
         dst[0] = src[0];
@@ -156,7 +156,7 @@ class Mat4 {
      * console.log("The two matrices are " + (a.equals(b) ? "equal" : "different"));
      */
     equals(rhs) {
-        var l = this.data,
+        const l = this.data,
             r = rhs.data;
 
         return ((l[0] === r[0]) &&
@@ -187,7 +187,7 @@ class Mat4 {
      * console.log("The matrix is " + (m.isIdentity() ? "identity" : "not identity"));
      */
     isIdentity() {
-        var m = this.data;
+        const m = this.data;
 
         return ((m[0] === 1) &&
                 (m[1] === 0) &&
@@ -226,31 +226,28 @@ class Mat4 {
      * console.log("The result of the multiplication is: " + r.toString());
      */
     mul2(lhs, rhs) {
-        var a00, a01, a02, a03,
-            a10, a11, a12, a13,
-            a20, a21, a22, a23,
-            a30, a31, a32, a33,
-            b0, b1, b2, b3,
-            a = lhs.data,
-            b = rhs.data,
-            r = this.data;
+        const a = lhs.data;
+        const b = rhs.data;
+        const r = this.data;
 
-        a00 = a[0];
-        a01 = a[1];
-        a02 = a[2];
-        a03 = a[3];
-        a10 = a[4];
-        a11 = a[5];
-        a12 = a[6];
-        a13 = a[7];
-        a20 = a[8];
-        a21 = a[9];
-        a22 = a[10];
-        a23 = a[11];
-        a30 = a[12];
-        a31 = a[13];
-        a32 = a[14];
-        a33 = a[15];
+        const a00 = a[0];
+        const a01 = a[1];
+        const a02 = a[2];
+        const a03 = a[3];
+        const a10 = a[4];
+        const a11 = a[5];
+        const a12 = a[6];
+        const a13 = a[7];
+        const a20 = a[8];
+        const a21 = a[9];
+        const a22 = a[10];
+        const a23 = a[11];
+        const a30 = a[12];
+        const a31 = a[13];
+        const a32 = a[14];
+        const a33 = a[15];
+
+        let b0, b1, b2, b3;
 
         b0 = b[0];
         b1 = b[1];
@@ -303,27 +300,24 @@ class Mat4 {
      * @returns {Mat4} Self for chaining.
      */
     mulAffine2(lhs, rhs) {
-        var a00, a01, a02,
-            a10, a11, a12,
-            a20, a21, a22,
-            a30, a31, a32,
-            b0, b1, b2,
-            a = lhs.data,
-            b = rhs.data,
-            r = this.data;
+        const a = lhs.data;
+        const b = rhs.data;
+        const r = this.data;
 
-        a00 = a[0];
-        a01 = a[1];
-        a02 = a[2];
-        a10 = a[4];
-        a11 = a[5];
-        a12 = a[6];
-        a20 = a[8];
-        a21 = a[9];
-        a22 = a[10];
-        a30 = a[12];
-        a31 = a[13];
-        a32 = a[14];
+        const a00 = a[0];
+        const a01 = a[1];
+        const a02 = a[2];
+        const a10 = a[4];
+        const a11 = a[5];
+        const a12 = a[6];
+        const a20 = a[8];
+        const a21 = a[9];
+        const a22 = a[10];
+        const a30 = a[12];
+        const a31 = a[13];
+        const a32 = a[14];
+
+        let b0, b1, b2;
 
         b0 = b[0];
         b1 = b[1];
@@ -396,13 +390,11 @@ class Mat4 {
      * var tv = m.transformPoint(v);
      */
     transformPoint(vec, res = new Vec3()) {
-        var x, y, z, m;
+        const m = this.data;
 
-        m = this.data;
-
-        x = vec.x;
-        y = vec.y;
-        z = vec.z;
+        const x = vec.x;
+        const y = vec.y;
+        const z = vec.z;
 
         res.x = x * m[0] + y * m[4] + z * m[8] + m[12];
         res.y = x * m[1] + y * m[5] + z * m[9] + m[13];
@@ -428,13 +420,11 @@ class Mat4 {
      * var tv = m.transformVector(v);
      */
     transformVector(vec, res = new Vec3()) {
-        var x, y, z, m;
+        const m = this.data;
 
-        m = this.data;
-
-        x = vec.x;
-        y = vec.y;
-        z = vec.z;
+        const x = vec.x;
+        const y = vec.y;
+        const z = vec.z;
 
         res.x = x * m[0] + y * m[4] + z * m[8];
         res.y = x * m[1] + y * m[5] + z * m[9];
@@ -463,14 +453,12 @@ class Mat4 {
      * m.transformVec4(v, result);
      */
     transformVec4(vec, res = new Vec4()) {
-        var x, y, z, w, m;
+        const m = this.data;
 
-        m = this.data;
-
-        x = vec.x;
-        y = vec.y;
-        z = vec.z;
-        w = vec.w;
+        const x = vec.x;
+        const y = vec.y;
+        const z = vec.z;
+        const w = vec.w;
 
         res.x = x * m[0] + y * m[4] + z * m[8] + w * m[12];
         res.y = x * m[1] + y * m[5] + z * m[9] + w * m[13];
@@ -505,7 +493,7 @@ class Mat4 {
         x.cross(y, z).normalize();
         y.cross(z, x);
 
-        var r = this.data;
+        const r = this.data;
 
         r[0]  = x.x;
         r[1]  = x.y;
@@ -545,14 +533,12 @@ class Mat4 {
      * var f = pc.Mat4().setFrustum(-2, 2, -1, 1, 1, 1000);
      */
     setFrustum(left, right, bottom, top, znear, zfar) {
-        var temp1, temp2, temp3, temp4, r;
+        const temp1 = 2 * znear;
+        const temp2 = right - left;
+        const temp3 = top - bottom;
+        const temp4 = zfar - znear;
 
-        temp1 = 2 * znear;
-        temp2 = right - left;
-        temp3 = top - bottom;
-        temp4 = zfar - znear;
-
-        r = this.data;
+        const r = this.data;
         r[0] = temp1 / temp2;
         r[1] = 0;
         r[2] = 0;
@@ -613,7 +599,7 @@ class Mat4 {
      * var ortho = pc.Mat4().ortho(-2, 2, -2, 2, 1, 1000);
      */
     setOrtho(left, right, bottom, top, near, far) {
-        var r = this.data;
+        const r = this.data;
 
         r[0] = 2 / (right - left);
         r[1] = 0;
@@ -648,19 +634,17 @@ class Mat4 {
      * var rm = new pc.Mat4().setFromAxisAngle(pc.Vec3.UP, 90);
      */
     setFromAxisAngle(axis, angle) {
-        var x, y, z, c, s, t, tx, ty, m;
-
         angle *= math.DEG_TO_RAD;
 
-        x = axis.x;
-        y = axis.y;
-        z = axis.z;
-        c = Math.cos(angle);
-        s = Math.sin(angle);
-        t = 1 - c;
-        tx = t * x;
-        ty = t * y;
-        m = this.data;
+        const x = axis.x;
+        const y = axis.y;
+        const z = axis.z;
+        const c = Math.cos(angle);
+        const s = Math.sin(angle);
+        const t = 1 - c;
+        const tx = t * x;
+        const ty = t * y;
+        const m = this.data;
 
         m[0] = tx * x + c;
         m[1] = tx * y + s * z;
@@ -696,7 +680,7 @@ class Mat4 {
      * var tm = new pc.Mat4().setTranslate(10, 10, 10);
      */
     setTranslate(x, y, z) {
-        var m = this.data;
+        const m = this.data;
 
         m[0] = 1;
         m[1] = 0;
@@ -732,7 +716,7 @@ class Mat4 {
      * var sm = new pc.Mat4().setScale(10, 10, 10);
      */
     setScale(x, y, z) {
-        var m = this.data;
+        const m = this.data;
 
         m[0] = x;
         m[1] = 0;
@@ -767,51 +751,43 @@ class Mat4 {
      * rot.invert();
      */
     invert() {
-        var a00, a01, a02, a03,
-            a10, a11, a12, a13,
-            a20, a21, a22, a23,
-            a30, a31, a32, a33,
-            b00, b01, b02, b03,
-            b04, b05, b06, b07,
-            b08, b09, b10, b11,
-            det, invDet, m;
+        const m = this.data;
 
-        m = this.data;
-        a00 = m[0];
-        a01 = m[1];
-        a02 = m[2];
-        a03 = m[3];
-        a10 = m[4];
-        a11 = m[5];
-        a12 = m[6];
-        a13 = m[7];
-        a20 = m[8];
-        a21 = m[9];
-        a22 = m[10];
-        a23 = m[11];
-        a30 = m[12];
-        a31 = m[13];
-        a32 = m[14];
-        a33 = m[15];
+        const a00 = m[0];
+        const a01 = m[1];
+        const a02 = m[2];
+        const a03 = m[3];
+        const a10 = m[4];
+        const a11 = m[5];
+        const a12 = m[6];
+        const a13 = m[7];
+        const a20 = m[8];
+        const a21 = m[9];
+        const a22 = m[10];
+        const a23 = m[11];
+        const a30 = m[12];
+        const a31 = m[13];
+        const a32 = m[14];
+        const a33 = m[15];
 
-        b00 = a00 * a11 - a01 * a10;
-        b01 = a00 * a12 - a02 * a10;
-        b02 = a00 * a13 - a03 * a10;
-        b03 = a01 * a12 - a02 * a11;
-        b04 = a01 * a13 - a03 * a11;
-        b05 = a02 * a13 - a03 * a12;
-        b06 = a20 * a31 - a21 * a30;
-        b07 = a20 * a32 - a22 * a30;
-        b08 = a20 * a33 - a23 * a30;
-        b09 = a21 * a32 - a22 * a31;
-        b10 = a21 * a33 - a23 * a31;
-        b11 = a22 * a33 - a23 * a32;
+        const b00 = a00 * a11 - a01 * a10;
+        const b01 = a00 * a12 - a02 * a10;
+        const b02 = a00 * a13 - a03 * a10;
+        const b03 = a01 * a12 - a02 * a11;
+        const b04 = a01 * a13 - a03 * a11;
+        const b05 = a02 * a13 - a03 * a12;
+        const b06 = a20 * a31 - a21 * a30;
+        const b07 = a20 * a32 - a22 * a30;
+        const b08 = a20 * a33 - a23 * a30;
+        const b09 = a21 * a32 - a22 * a31;
+        const b10 = a21 * a33 - a23 * a31;
+        const b11 = a22 * a33 - a23 * a32;
 
-        det = (b00 * b11 - b01 * b10 + b02 * b09 + b03 * b08 - b04 * b07 + b05 * b06);
+        const det = (b00 * b11 - b01 * b10 + b02 * b09 + b03 * b08 - b04 * b07 + b05 * b06);
         if (det === 0) {
             this.setIdentity();
         } else {
-            invDet = 1 / det;
+            const invDet = 1 / det;
 
             m[0] = (a11 * b11 - a12 * b10 + a13 * b09) * invDet;
             m[1] = (-a01 * b11 + a02 * b10 - a03 * b09) * invDet;
@@ -831,7 +807,6 @@ class Mat4 {
             m[15] = (a20 * b03 - a21 * b01 + a22 * b00) * invDet;
         }
 
-
         return this;
     }
 
@@ -843,7 +818,8 @@ class Mat4 {
      * @returns {Mat4} Self for chaining.
      */
     set(src) {
-        var dst = this.data;
+        const dst = this.data;
+
         dst[0] = src[0];
         dst[1] = src[1];
         dst[2] = src[2];
@@ -874,7 +850,8 @@ class Mat4 {
      * console.log("The matrix is " + (m.isIdentity() ? "identity" : "not identity"));
      */
     setIdentity() {
-        var m = this.data;
+        const m = this.data;
+
         m[0] = 1;
         m[1] = 0;
         m[2] = 0;
@@ -913,32 +890,29 @@ class Mat4 {
      * m.setTRS(t, r, s);
      */
     setTRS(t, r, s) {
-        var qx, qy, qz, qw, sx, sy, sz,
-            x2, y2, z2, xx, xy, xz, yy, yz, zz, wx, wy, wz, m;
+        const qx = r.x;
+        const qy = r.y;
+        const qz = r.z;
+        const qw = r.w;
 
-        qx = r.x;
-        qy = r.y;
-        qz = r.z;
-        qw = r.w;
+        const sx = s.x;
+        const sy = s.y;
+        const sz = s.z;
 
-        sx = s.x;
-        sy = s.y;
-        sz = s.z;
+        const x2 = qx + qx;
+        const y2 = qy + qy;
+        const z2 = qz + qz;
+        const xx = qx * x2;
+        const xy = qx * y2;
+        const xz = qx * z2;
+        const yy = qy * y2;
+        const yz = qy * z2;
+        const zz = qz * z2;
+        const wx = qw * x2;
+        const wy = qw * y2;
+        const wz = qw * z2;
 
-        x2 = qx + qx;
-        y2 = qy + qy;
-        z2 = qz + qz;
-        xx = qx * x2;
-        xy = qx * y2;
-        xz = qx * z2;
-        yy = qy * y2;
-        yz = qy * z2;
-        zz = qz * z2;
-        wx = qw * x2;
-        wy = qw * y2;
-        wz = qw * z2;
-
-        m = this.data;
+        const m = this.data;
 
         m[0] = (1 - (yy + zz)) * sx;
         m[1] = (xy + wz) * sx;
@@ -975,7 +949,8 @@ class Mat4 {
      * m.transpose();
      */
     transpose() {
-        var tmp, m = this.data;
+        let tmp;
+        const m = this.data;
 
         tmp = m[1];
         m[1] = m[4];
@@ -1005,40 +980,37 @@ class Mat4 {
     }
 
     invertTo3x3(res) {
-        var a11, a21, a31, a12, a22, a32, a13, a23, a33,
-            m, r, det, idet;
+        const m = this.data;
+        const r = res.data;
 
-        m = this.data;
-        r = res.data;
+        const m0 = m[0];
+        const m1 = m[1];
+        const m2 = m[2];
 
-        var m0 = m[0];
-        var m1 = m[1];
-        var m2 = m[2];
+        const m4 = m[4];
+        const m5 = m[5];
+        const m6 = m[6];
 
-        var m4 = m[4];
-        var m5 = m[5];
-        var m6 = m[6];
+        const m8 = m[8];
+        const m9 = m[9];
+        const m10 = m[10];
 
-        var m8 = m[8];
-        var m9 = m[9];
-        var m10 = m[10];
+        const a11 =  m10 * m5 - m6 * m9;
+        const a21 = -m10 * m1 + m2 * m9;
+        const a31 =  m6  * m1 - m2 * m5;
+        const a12 = -m10 * m4 + m6 * m8;
+        const a22 =  m10 * m0 - m2 * m8;
+        const a32 = -m6  * m0 + m2 * m4;
+        const a13 =  m9  * m4 - m5 * m8;
+        const a23 = -m9  * m0 + m1 * m8;
+        const a33 =  m5  * m0 - m1 * m4;
 
-        a11 =  m10 * m5 - m6 * m9;
-        a21 = -m10 * m1 + m2 * m9;
-        a31 =  m6  * m1 - m2 * m5;
-        a12 = -m10 * m4 + m6 * m8;
-        a22 =  m10 * m0 - m2 * m8;
-        a32 = -m6  * m0 + m2 * m4;
-        a13 =  m9  * m4 - m5 * m8;
-        a23 = -m9  * m0 + m1 * m8;
-        a33 =  m5  * m0 - m1 * m4;
-
-        det =  m0 * a11 + m1 * a12 + m2 * a13;
+        const det =  m0 * a11 + m1 * a12 + m2 * a13;
         if (det === 0) { // no inverse
             return this;
         }
 
-        idet = 1 / det;
+        const idet = 1 / det;
 
         r[0] = idet * a11;
         r[1] = idet * a21;
@@ -1164,21 +1136,19 @@ class Mat4 {
     // The 3D space is right-handed, so the rotation around each axis will be counterclockwise
     // for an observer placed so that the axis goes in his or her direction (Right-hand rule).
     setFromEulerAngles(ex, ey, ez) {
-        var s1, c1, s2, c2, s3, c3, m;
-
         ex *= math.DEG_TO_RAD;
         ey *= math.DEG_TO_RAD;
         ez *= math.DEG_TO_RAD;
 
         // Solution taken from http://en.wikipedia.org/wiki/Euler_angles#Matrix_orientation
-        s1 = Math.sin(-ex);
-        c1 = Math.cos(-ex);
-        s2 = Math.sin(-ey);
-        c2 = Math.cos(-ey);
-        s3 = Math.sin(-ez);
-        c3 = Math.cos(-ez);
+        const s1 = Math.sin(-ex);
+        const c1 = Math.cos(-ex);
+        const s2 = Math.sin(-ey);
+        const c2 = Math.cos(-ey);
+        const s3 = Math.sin(-ez);
+        const c3 = Math.cos(-ez);
 
-        m = this.data;
+        const m = this.data;
 
         // Set rotation elements
         m[0] = c2 * c3;
@@ -1218,20 +1188,20 @@ class Mat4 {
      * var eulers = m.getEulerAngles();
      */
     getEulerAngles(eulers = new Vec3()) {
-        var x, y, z, sx, sy, sz, m, halfPi;
-
         this.getScale(scale);
-        sx = scale.x;
-        sy = scale.y;
-        sz = scale.z;
+        const sx = scale.x;
+        const sy = scale.y;
+        const sz = scale.z;
 
         if (sx === 0 || sy === 0 || sz === 0)
             return eulers.set(0, 0, 0);
 
-        m = this.data;
+        const m = this.data;
 
-        y = Math.asin(-m[2] / sx);
-        halfPi = Math.PI * 0.5;
+        const y = Math.asin(-m[2] / sx);
+        const halfPi = Math.PI * 0.5;
+
+        let x, z;
 
         if (y < halfPi) {
             if (y > -halfPi) {
@@ -1248,7 +1218,7 @@ class Mat4 {
             x = Math.atan2(m[4] / sy, m[5] / sy);
         }
 
-        return eulers.set(x, y, z).scale(math.RAD_TO_DEG);
+        return eulers.set(x, y, z).mulScalar(math.RAD_TO_DEG);
     }
 
     /**
@@ -1262,10 +1232,8 @@ class Mat4 {
      * console.log(m.toString());
      */
     toString() {
-        var i, t;
-
-        t = '[';
-        for (i = 0; i < 16; i += 1) {
+        let t = '[';
+        for (let i = 0; i < 16; i += 1) {
             t += this.data[i];
             t += (i !== 15) ? ', ' : '';
         }

--- a/src/math/math.js
+++ b/src/math/math.js
@@ -3,7 +3,7 @@
  * @namespace
  * @description Math API.
  */
-var math = {
+const math = {
     /**
      * @constant
      * @type {number}
@@ -52,11 +52,9 @@ var math = {
      * var bytes = pc.math.intToBytes24(0x112233);
      */
     intToBytes24: function (i) {
-        var r, g, b;
-
-        r = (i >> 16) & 0xff;
-        g = (i >> 8) & 0xff;
-        b = (i) & 0xff;
+        const r = (i >> 16) & 0xff;
+        const g = (i >> 8) & 0xff;
+        const b = (i) & 0xff;
 
         return [r, g, b];
     },
@@ -72,12 +70,10 @@ var math = {
      * var bytes = pc.math.intToBytes32(0x11223344);
      */
     intToBytes32: function (i) {
-        var r, g, b, a;
-
-        r = (i >> 24) & 0xff;
-        g = (i >> 16) & 0xff;
-        b = (i >> 8) & 0xff;
-        a = (i) & 0xff;
+        const r = (i >> 24) & 0xff;
+        const g = (i >> 16) & 0xff;
+        const b = (i >> 8) & 0xff;
+        const a = (i) & 0xff;
 
         return [r, g, b, a];
     },
@@ -212,7 +208,7 @@ var math = {
      * @returns {number} Pseudo-random number between the supplied range.
      */
     random: function (min, max) {
-        var diff = max - min;
+        const diff = max - min;
         return Math.random() * diff + min;
     },
 
@@ -284,8 +280,8 @@ var math = {
     float2Half: (function () {
 
         // based on based on https://esdiscuss.org/topic/float16array
-        var floatView = new Float32Array(1);
-        var int32View = new Int32Array(floatView.buffer);
+        const floatView = new Float32Array(1);
+        const int32View = new Int32Array(floatView.buffer);
 
         // This method is faster than the OpenEXR implementation (very often
         // used, eg. in Ogre), with the additional benefit of rounding, inspired
@@ -293,11 +289,11 @@ var math = {
         return function (val) {
 
             floatView[0] = val;
-            var x = int32View[0];
+            const x = int32View[0];
 
-            var bits = (x >> 16) & 0x8000; // Get the sign
-            var m = (x >> 12) & 0x07ff; // Keep one extra bit for rounding
-            var e = (x >> 23) & 0xff; // Using int is faster here
+            let bits = (x >> 16) & 0x8000; // Get the sign
+            let m = (x >> 12) & 0x07ff; // Keep one extra bit for rounding
+            const e = (x >> 23) & 0xff; // Using int is faster here
 
             // If zero, or denormal, or exponent underflows too much for a denormal half, return signed zero.
             if (e < 103) {
@@ -344,7 +340,7 @@ var math = {
      * @param {boolean} inclusive - If true, a num param which is equal to a or b will return true.
      */
     between: function (num, a, b, inclusive) {
-        var min = Math.min(a, b),
+        const min = Math.min(a, b),
             max = Math.max(a, b);
         return inclusive ? num >= min && num <= max : num > min && num < max;
     }

--- a/src/math/quat.js
+++ b/src/math/quat.js
@@ -162,8 +162,8 @@ class Quat {
      * console.log(v.toString());
      */
     getAxisAngle(axis) {
-        var rad = Math.acos(this.w) * 2;
-        var s = Math.sin(rad / 2);
+        let rad = Math.acos(this.w) * 2;
+        const s = Math.sin(rad / 2);
         if (s !== 0) {
             axis.x = this.x / s;
             axis.y = this.y / s;
@@ -193,14 +193,15 @@ class Quat {
      * correspond to the supplied quaternion.
      */
     getEulerAngles(eulers = new Vec3()) {
-        var x, y, z, qx, qy, qz, qw, a2;
+        let x, y, z;
 
-        qx = this.x;
-        qy = this.y;
-        qz = this.z;
-        qw = this.w;
+        const qx = this.x;
+        const qy = this.y;
+        const qz = this.z;
+        const qw = this.w;
 
-        a2 = 2 * (qw * qy - qx * qz);
+        const a2 = 2 * (qw * qy - qx * qz);
+
         if (a2 <= -0.99999) {
             x = 2 * Math.atan2(qx, qw);
             y = -Math.PI / 2;
@@ -281,17 +282,15 @@ class Quat {
      * console.log("The result of the multiplication is: " + a.toString());
      */
     mul(rhs) {
-        var q1x, q1y, q1z, q1w, q2x, q2y, q2z, q2w;
+        const q1x = this.x;
+        const q1y = this.y;
+        const q1z = this.z;
+        const q1w = this.w;
 
-        q1x = this.x;
-        q1y = this.y;
-        q1z = this.z;
-        q1w = this.w;
-
-        q2x = rhs.x;
-        q2y = rhs.y;
-        q2z = rhs.z;
-        q2w = rhs.w;
+        const q2x = rhs.x;
+        const q2y = rhs.y;
+        const q2z = rhs.z;
+        const q2w = rhs.w;
 
         this.x = q1w * q2x + q1x * q2w + q1y * q2z - q1z * q2y;
         this.y = q1w * q2y + q1y * q2w + q1z * q2x - q1x * q2z;
@@ -320,17 +319,15 @@ class Quat {
      * console.log("The result of the multiplication is: " + r.toString());
      */
     mul2(lhs, rhs) {
-        var q1x, q1y, q1z, q1w, q2x, q2y, q2z, q2w;
+        const q1x = lhs.x;
+        const q1y = lhs.y;
+        const q1z = lhs.z;
+        const q1w = lhs.w;
 
-        q1x = lhs.x;
-        q1y = lhs.y;
-        q1z = lhs.z;
-        q1w = lhs.w;
-
-        q2x = rhs.x;
-        q2y = rhs.y;
-        q2z = rhs.z;
-        q2w = rhs.w;
+        const q2x = rhs.x;
+        const q2y = rhs.y;
+        const q2z = rhs.z;
+        const q2w = rhs.w;
 
         this.x = q1w * q2x + q1x * q2w + q1y * q2z - q1z * q2y;
         this.y = q1w * q2y + q1y * q2w + q1z * q2x - q1x * q2z;
@@ -354,7 +351,7 @@ class Quat {
      * console.log("The result of the vector normalization is: " + v.toString());
      */
     normalize() {
-        var len = this.length();
+        let len = this.length();
         if (len === 0) {
             this.x = this.y = this.z = 0;
             this.w = 1;
@@ -406,12 +403,10 @@ class Quat {
      * q.setFromAxisAngle(pc.Vec3.UP, 90);
      */
     setFromAxisAngle(axis, angle) {
-        var sa, ca;
-
         angle *= 0.5 * math.DEG_TO_RAD;
 
-        sa = Math.sin(angle);
-        ca = Math.cos(angle);
+        const sa = Math.sin(angle);
+        const ca = Math.cos(angle);
 
         this.x = sa * axis.x;
         this.y = sa * axis.y;
@@ -434,19 +429,17 @@ class Quat {
      * q.setFromEulerAngles(45, 90, 180);
      */
     setFromEulerAngles(ex, ey, ez) {
-        var sx, cx, sy, cy, sz, cz, halfToRad;
-
-        halfToRad = 0.5 * math.DEG_TO_RAD;
+        const halfToRad = 0.5 * math.DEG_TO_RAD;
         ex *= halfToRad;
         ey *= halfToRad;
         ez *= halfToRad;
 
-        sx = Math.sin(ex);
-        cx = Math.cos(ex);
-        sy = Math.sin(ey);
-        cy = Math.cos(ey);
-        sz = Math.sin(ez);
-        cz = Math.cos(ez);
+        const sx = Math.sin(ex);
+        const cx = Math.cos(ex);
+        const sy = Math.sin(ey);
+        const cy = Math.cos(ey);
+        const sz = Math.sin(ez);
+        const cz = Math.cos(ez);
 
         this.x = sx * cy * cz - cx * sy * sz;
         this.y = cx * sy * cz + sx * cy * sz;
@@ -472,8 +465,8 @@ class Quat {
      * var q = new pc.Quat().setFromMat4(rot);
      */
     setFromMat4(m) {
-        var m00, m01, m02, m10, m11, m12, m20, m21, m22,
-            tr, s, rs, lx, ly, lz;
+        let m00, m01, m02, m10, m11, m12, m20, m21, m22,
+            s, rs, lx, ly, lz;
 
         m = m.data;
 
@@ -514,7 +507,7 @@ class Quat {
 
         // http://www.cs.ucr.edu/~vbz/resources/quatut.pdf
 
-        tr = m00 + m11 + m22;
+        const tr = m00 + m11 + m22;
         if (tr >= 0) {
             s = Math.sqrt(tr + 1);
             this.w = s * 0.5;
@@ -594,18 +587,17 @@ class Quat {
     slerp(lhs, rhs, alpha) {
         // Algorithm sourced from:
         // http://www.euclideanspace.com/maths/algebra/realNormedAlgebra/quaternions/slerp/
-        var lx, ly, lz, lw, rx, ry, rz, rw;
-        lx = lhs.x;
-        ly = lhs.y;
-        lz = lhs.z;
-        lw = lhs.w;
-        rx = rhs.x;
-        ry = rhs.y;
-        rz = rhs.z;
-        rw = rhs.w;
+        const lx = lhs.x;
+        const ly = lhs.y;
+        const lz = lhs.z;
+        const lw = lhs.w;
+        let rx = rhs.x;
+        let ry = rhs.y;
+        let rz = rhs.z;
+        let rw = rhs.w;
 
         // Calculate angle between them.
-        var cosHalfTheta = lw * rw + lx * rx + ly * ry + lz * rz;
+        let cosHalfTheta = lw * rw + lx * rx + ly * ry + lz * rz;
 
         if (cosHalfTheta < 0) {
             rw = -rw;
@@ -625,8 +617,8 @@ class Quat {
         }
 
         // Calculate temporary values.
-        var halfTheta = Math.acos(cosHalfTheta);
-        var sinHalfTheta = Math.sqrt(1 - cosHalfTheta * cosHalfTheta);
+        const halfTheta = Math.acos(cosHalfTheta);
+        const sinHalfTheta = Math.sqrt(1 - cosHalfTheta * cosHalfTheta);
 
         // If theta = 180 degrees then result is not fully defined
         // we could rotate around any axis normal to qa or qb
@@ -638,8 +630,8 @@ class Quat {
             return this;
         }
 
-        var ratioA = Math.sin((1 - alpha) * halfTheta) / sinHalfTheta;
-        var ratioB = Math.sin(alpha * halfTheta) / sinHalfTheta;
+        const ratioA = Math.sin((1 - alpha) * halfTheta) / sinHalfTheta;
+        const ratioB = Math.sin(alpha * halfTheta) / sinHalfTheta;
 
         // Calculate Quaternion.
         this.w = (lw * ratioA + rw * ratioB);
@@ -666,14 +658,14 @@ class Quat {
      * var tv = q.transformVector(v);
      */
     transformVector(vec, res = new Vec3()) {
-        var x = vec.x, y = vec.y, z = vec.z;
-        var qx = this.x, qy = this.y, qz = this.z, qw = this.w;
+        const x = vec.x, y = vec.y, z = vec.z;
+        const qx = this.x, qy = this.y, qz = this.z, qw = this.w;
 
         // calculate quat * vec
-        var ix = qw * x + qy * z - qz * y;
-        var iy = qw * y + qz * x - qx * z;
-        var iz = qw * z + qx * y - qy * x;
-        var iw = -qx * x - qy * y - qz * z;
+        const ix = qw * x + qy * z - qz * y;
+        const iy = qw * y + qz * x - qx * z;
+        const iz = qw * z + qx * y - qy * x;
+        const iw = -qx * x - qy * y - qz * z;
 
         // calculate result * inverse quat
         res.x = ix * qw + iw * -qx + iy * -qz - iz * -qy;

--- a/src/math/vec2.js
+++ b/src/math/vec2.js
@@ -180,8 +180,8 @@ class Vec2 {
      * console.log("The between v1 and v2 is: " + d);
      */
     distance(rhs) {
-        var x = this.x - rhs.x;
-        var y = this.y - rhs.y;
+        const x = this.x - rhs.x;
+        const y = this.y - rhs.y;
         return Math.sqrt(x * x + y * y);
     }
 
@@ -422,9 +422,9 @@ class Vec2 {
      * console.log("The result of the vector normalization is: " + v.toString());
      */
     normalize() {
-        var lengthSq = this.x * this.x + this.y * this.y;
+        const lengthSq = this.x * this.x + this.y * this.y;
         if (lengthSq > 0) {
-            var invLength = 1 / Math.sqrt(lengthSq);
+            const invLength = 1 / Math.sqrt(lengthSq);
             this.x *= invLength;
             this.y *= invLength;
         }

--- a/src/math/vec3.js
+++ b/src/math/vec3.js
@@ -182,12 +182,12 @@ class Vec3 {
      */
     cross(lhs, rhs) {
         // Create temporary variables in case lhs or rhs are 'this'
-        var lx = lhs.x;
-        var ly = lhs.y;
-        var lz = lhs.z;
-        var rx = rhs.x;
-        var ry = rhs.y;
-        var rz = rhs.z;
+        const lx = lhs.x;
+        const ly = lhs.y;
+        const lz = lhs.z;
+        const rx = rhs.x;
+        const ry = rhs.y;
+        const rz = rhs.z;
 
         this.x = ly * rz - ry * lz;
         this.y = lz * rx - rz * lx;
@@ -209,9 +209,9 @@ class Vec3 {
      * console.log("The between v1 and v2 is: " + d);
      */
     distance(rhs) {
-        var x = this.x - rhs.x;
-        var y = this.y - rhs.y;
-        var z = this.z - rhs.z;
+        const x = this.x - rhs.x;
+        const y = this.y - rhs.y;
+        const z = this.z - rhs.z;
         return Math.sqrt(x * x + y * y + z * z);
     }
 
@@ -459,9 +459,9 @@ class Vec3 {
      * console.log("The result of the vector normalization is: " + v.toString());
      */
     normalize() {
-        var lengthSq = this.x * this.x + this.y * this.y + this.z * this.z;
+        const lengthSq = this.x * this.x + this.y * this.y + this.z * this.z;
         if (lengthSq > 0) {
-            var invLength = 1 / Math.sqrt(lengthSq);
+            const invLength = 1 / Math.sqrt(lengthSq);
             this.x *= invLength;
             this.y *= invLength;
             this.z *= invLength;
@@ -486,9 +486,9 @@ class Vec3 {
      * console.log("The result of the vector projection is: " + v.toString());
      */
     project(rhs) {
-        var a_dot_b = this.x * rhs.x + this.y * rhs.y + this.z * rhs.z;
-        var b_dot_b = rhs.x * rhs.x + rhs.y * rhs.y + rhs.z * rhs.z;
-        var s = a_dot_b / b_dot_b;
+        const a_dot_b = this.x * rhs.x + this.y * rhs.y + this.z * rhs.z;
+        const b_dot_b = rhs.x * rhs.x + rhs.y * rhs.y + rhs.z * rhs.z;
+        const s = a_dot_b / b_dot_b;
         this.x = rhs.x * s;
         this.y = rhs.y * s;
         this.z = rhs.z * s;

--- a/src/math/vec4.js
+++ b/src/math/vec4.js
@@ -442,9 +442,9 @@ class Vec4 {
      * console.log("The result of the vector normalization is: " + v.toString());
      */
     normalize() {
-        var lengthSq = this.x * this.x + this.y * this.y + this.z * this.z + this.w * this.w;
+        const lengthSq = this.x * this.x + this.y * this.y + this.z * this.z + this.w * this.w;
         if (lengthSq > 0) {
-            var invLength = 1 / Math.sqrt(lengthSq);
+            const invLength = 1 / Math.sqrt(lengthSq);
             this.x *= invLength;
             this.y *= invLength;
             this.z *= invLength;

--- a/src/shape/bounding-box.js
+++ b/src/shape/bounding-box.js
@@ -1,10 +1,10 @@
 import { Vec3 } from '../math/vec3.js';
 
-var tmpVecA = new Vec3();
-var tmpVecB = new Vec3();
-var tmpVecC = new Vec3();
-var tmpVecD = new Vec3();
-var tmpVecE = new Vec3();
+const tmpVecA = new Vec3();
+const tmpVecB = new Vec3();
+const tmpVecC = new Vec3();
+const tmpVecD = new Vec3();
+const tmpVecE = new Vec3();
 
 /**
  * @class
@@ -31,35 +31,35 @@ class BoundingBox {
      * @param {BoundingBox} other - Bounding box to add.
      */
     add(other) {
-        var tc = this.center;
-        var tcx = tc.x;
-        var tcy = tc.y;
-        var tcz = tc.z;
-        var th = this.halfExtents;
-        var thx = th.x;
-        var thy = th.y;
-        var thz = th.z;
-        var tminx = tcx - thx;
-        var tmaxx = tcx + thx;
-        var tminy = tcy - thy;
-        var tmaxy = tcy + thy;
-        var tminz = tcz - thz;
-        var tmaxz = tcz + thz;
+        const tc = this.center;
+        const tcx = tc.x;
+        const tcy = tc.y;
+        const tcz = tc.z;
+        const th = this.halfExtents;
+        const thx = th.x;
+        const thy = th.y;
+        const thz = th.z;
+        let tminx = tcx - thx;
+        let tmaxx = tcx + thx;
+        let tminy = tcy - thy;
+        let tmaxy = tcy + thy;
+        let tminz = tcz - thz;
+        let tmaxz = tcz + thz;
 
-        var oc = other.center;
-        var ocx = oc.x;
-        var ocy = oc.y;
-        var ocz = oc.z;
-        var oh = other.halfExtents;
-        var ohx = oh.x;
-        var ohy = oh.y;
-        var ohz = oh.z;
-        var ominx = ocx - ohx;
-        var omaxx = ocx + ohx;
-        var ominy = ocy - ohy;
-        var omaxy = ocy + ohy;
-        var ominz = ocz - ohz;
-        var omaxz = ocz + ohz;
+        const oc = other.center;
+        const ocx = oc.x;
+        const ocy = oc.y;
+        const ocz = oc.z;
+        const oh = other.halfExtents;
+        const ohx = oh.x;
+        const ohy = oh.y;
+        const ohz = oh.z;
+        const ominx = ocx - ohx;
+        const omaxx = ocx + ohx;
+        const ominy = ocy - ohy;
+        const omaxy = ocy + ohy;
+        const ominz = ocz - ohz;
+        const omaxz = ocz + ohz;
 
         if (ominx < tminx) tminx = ominx;
         if (omaxx > tmaxx) tmaxx = omaxx;
@@ -105,10 +105,10 @@ class BoundingBox {
      * @returns {boolean} True if there is an intersection.
      */
     intersects(other) {
-        var aMax = this.getMax();
-        var aMin = this.getMin();
-        var bMax = other.getMax();
-        var bMin = other.getMin();
+        const aMax = this.getMax();
+        const aMin = this.getMin();
+        const bMax = other.getMax();
+        const bMin = other.getMin();
 
         return (aMin.x <= bMax.x) && (aMax.x >= bMin.x) &&
                (aMin.y <= bMax.y) && (aMax.y >= bMin.y) &&
@@ -116,9 +116,9 @@ class BoundingBox {
     }
 
     _intersectsRay(ray, point) {
-        var tMin = tmpVecA.copy(this.getMin()).sub(ray.origin);
-        var tMax = tmpVecB.copy(this.getMax()).sub(ray.origin);
-        var dir = ray.direction;
+        const tMin = tmpVecA.copy(this.getMin()).sub(ray.origin);
+        const tMax = tmpVecB.copy(this.getMax()).sub(ray.origin);
+        const dir = ray.direction;
 
         // Ensure that we are not dividing it by zero
         if (dir.x === 0) {
@@ -143,13 +143,13 @@ class BoundingBox {
             tMax.z /= dir.z;
         }
 
-        var realMin = tmpVecC.set(Math.min(tMin.x, tMax.x), Math.min(tMin.y, tMax.y), Math.min(tMin.z, tMax.z));
-        var realMax = tmpVecD.set(Math.max(tMin.x, tMax.x), Math.max(tMin.y, tMax.y), Math.max(tMin.z, tMax.z));
+        const realMin = tmpVecC.set(Math.min(tMin.x, tMax.x), Math.min(tMin.y, tMax.y), Math.min(tMin.z, tMax.z));
+        const realMax = tmpVecD.set(Math.max(tMin.x, tMax.x), Math.max(tMin.y, tMax.y), Math.max(tMin.z, tMax.z));
 
-        var minMax = Math.min(Math.min(realMax.x, realMax.y), realMax.z);
-        var maxMin = Math.max(Math.max(realMin.x, realMin.y), realMin.z);
+        const minMax = Math.min(Math.min(realMax.x, realMax.y), realMax.z);
+        const maxMin = Math.max(Math.max(realMin.x, realMin.y), realMin.z);
 
-        var intersects = minMax >= maxMin && maxMin >= 0;
+        const intersects = minMax >= maxMin && maxMin >= 0;
 
         if (intersects)
             point.copy(ray.direction).scale(maxMin).add(ray.origin);
@@ -158,12 +158,12 @@ class BoundingBox {
     }
 
     _fastIntersectsRay(ray) {
-        var diff = tmpVecA;
-        var cross = tmpVecB;
-        var prod = tmpVecC;
-        var absDiff = tmpVecD;
-        var absDir = tmpVecE;
-        var rayDir = ray.direction;
+        const diff = tmpVecA;
+        const cross = tmpVecB;
+        const prod = tmpVecC;
+        const absDiff = tmpVecD;
+        const absDir = tmpVecE;
+        const rayDir = ray.direction;
 
         diff.sub2(ray.origin, this.center);
         absDiff.set(Math.abs(diff.x), Math.abs(diff.y), Math.abs(diff.z));
@@ -252,8 +252,8 @@ class BoundingBox {
      * @returns {boolean} True if the point is inside the AABB and false otherwise.
      */
     containsPoint(point) {
-        var min = this.getMin();
-        var max = this.getMax();
+        const min = this.getMin();
+        const max = this.getMax();
 
         if (point.x < min.x || point.x > max.x ||
             point.y < min.y || point.y > max.y ||
@@ -273,19 +273,19 @@ class BoundingBox {
      * @param {Mat4} m - Transformation matrix to apply to source AABB.
      */
     setFromTransformedAabb(aabb, m) {
-        var ac = aabb.center;
-        var ar = aabb.halfExtents;
+        const ac = aabb.center;
+        const ar = aabb.halfExtents;
 
-        var d = m.data;
-        var mx0 = d[0];
-        var mx1 = d[4];
-        var mx2 = d[8];
-        var my0 = d[1];
-        var my1 = d[5];
-        var my2 = d[9];
-        var mz0 = d[2];
-        var mz1 = d[6];
-        var mz2 = d[10];
+        const d = m.data;
+        const mx0 = d[0];
+        const mx1 = d[4];
+        const mx2 = d[8];
+        const my0 = d[1];
+        const my1 = d[5];
+        const my2 = d[9];
+        const mz0 = d[2];
+        const mz1 = d[6];
+        const mz2 = d[10];
 
         this.center.set(
             d[12] + mx0 * ac.x + mx1 * ac.y + mx2 * ac.z,
@@ -310,13 +310,13 @@ class BoundingBox {
     compute(vertices, numVerts) {
         numVerts = numVerts === undefined ? vertices.length / 3 : numVerts;
         if (numVerts > 0) {
-            var min = tmpVecA.set(vertices[0], vertices[1], vertices[2]);
-            var max = tmpVecB.set(vertices[0], vertices[1], vertices[2]);
+            const min = tmpVecA.set(vertices[0], vertices[1], vertices[2]);
+            const max = tmpVecB.set(vertices[0], vertices[1], vertices[2]);
 
-            for (var i = 1; i < numVerts; i++) {
-                var x = vertices[i * 3 + 0];
-                var y = vertices[i * 3 + 1];
-                var z = vertices[i * 3 + 2];
+            for (let i = 1; i < numVerts; i++) {
+                const x = vertices[i * 3 + 0];
+                const y = vertices[i * 3 + 1];
+                const z = vertices[i * 3 + 2];
                 if (x < min.x) min.x = x;
                 if (y < min.y) min.y = y;
                 if (z < min.z) min.z = z;
@@ -337,7 +337,7 @@ class BoundingBox {
      * @returns {boolean} True if the Bounding Sphere is overlapping, enveloping, or inside the AABB and false otherwise.
      */
     intersectsBoundingSphere(sphere) {
-        var sq = this._distanceToBoundingSphereSq(sphere);
+        const sq = this._distanceToBoundingSphereSq(sphere);
         if (sq <= sphere.radius * sphere.radius) {
             return true;
         }
@@ -346,18 +346,18 @@ class BoundingBox {
     }
 
     _distanceToBoundingSphereSq(sphere) {
-        var boxMin = this.getMin();
-        var boxMax = this.getMax();
+        const boxMin = this.getMin();
+        const boxMax = this.getMax();
 
-        var sq = 0;
-        var axis = ['x', 'y', 'z'];
+        let sq = 0;
+        const axis = ['x', 'y', 'z'];
 
-        for (var i = 0; i < 3; ++i) {
-            var out = 0;
-            var pn = sphere.center[axis[i]];
-            var bMin = boxMin[axis[i]];
-            var bMax = boxMax[axis[i]];
-            var val = 0;
+        for (let i = 0; i < 3; ++i) {
+            let out = 0;
+            const pn = sphere.center[axis[i]];
+            const bMin = boxMin[axis[i]];
+            const bMax = boxMax[axis[i]];
+            let val = 0;
 
             if (pn < bMin) {
                 val = (bMin - pn);

--- a/src/shape/bounding-sphere.js
+++ b/src/shape/bounding-sphere.js
@@ -1,7 +1,7 @@
 import { Vec3 } from '../math/vec3.js';
 
-var tmpVecA = new Vec3();
-var tmpVecB = new Vec3();
+const tmpVecA = new Vec3();
+const tmpVecB = new Vec3();
 
 /**
  * @class
@@ -21,8 +21,8 @@ class BoundingSphere {
     }
 
     containsPoint(point) {
-        var lenSq = tmpVecA.sub2(point, this.center).lengthSq();
-        var r = this.radius;
+        const lenSq = tmpVecA.sub2(point, this.center).lengthSq();
+        const r = this.radius;
         return lenSq < r * r;
     }
 
@@ -35,21 +35,21 @@ class BoundingSphere {
      * @returns {boolean} True if there is an intersection.
      */
     intersectsRay(ray, point) {
-        var m = tmpVecA.copy(ray.origin).sub(this.center);
-        var b = m.dot(tmpVecB.copy(ray.direction).normalize());
-        var c = m.dot(m) - this.radius * this.radius;
+        const m = tmpVecA.copy(ray.origin).sub(this.center);
+        const b = m.dot(tmpVecB.copy(ray.direction).normalize());
+        const c = m.dot(m) - this.radius * this.radius;
 
         // exit if ray's origin outside of sphere (c > 0) and ray pointing away from s (b > 0)
         if (c > 0 && b > 0)
             return null;
 
-        var discr = b * b - c;
+        const discr = b * b - c;
         // a negative discriminant corresponds to ray missing sphere
         if (discr < 0)
             return false;
 
         // ray intersects sphere, compute smallest t value of intersection
-        var t = Math.abs(-b - Math.sqrt(discr));
+        const t = Math.abs(-b - Math.sqrt(discr));
 
         // if t is negative, ray started inside sphere so clamp t to zero
         if (point)
@@ -67,7 +67,7 @@ class BoundingSphere {
      */
     intersectsBoundingSphere(sphere) {
         tmpVecA.sub2(sphere.center, this.center);
-        var totalRadius = sphere.radius + this.radius;
+        const totalRadius = sphere.radius + this.radius;
         if (tmpVecA.lengthSq() <= totalRadius * totalRadius) {
             return true;
         }

--- a/src/shape/frustum.js
+++ b/src/shape/frustum.js
@@ -11,7 +11,7 @@
 class Frustum {
     constructor() {
         this.planes = [];
-        for (var i = 0; i < 6; i++)
+        for (let i = 0; i < 6; i++)
             this.planes[i] = [];
     }
 
@@ -30,10 +30,10 @@ class Frustum {
      * frustum.setFromMat4(projMat);
      */
     setFromMat4(matrix) {
-        var vpm = matrix.data;
+        const vpm = matrix.data;
 
-        var plane;
-        var planes = this.planes;
+        let plane;
+        const planes = this.planes;
 
         // Extract the numbers for the RIGHT plane
         plane = planes[0];
@@ -42,7 +42,7 @@ class Frustum {
         plane[2] = vpm[11] - vpm[8];
         plane[3] = vpm[15] - vpm[12];
         // Normalize the result
-        var t = Math.sqrt(plane[0] * plane[0] + plane[1] * plane[1] + plane[2] * plane[2]);
+        let t = Math.sqrt(plane[0] * plane[0] + plane[1] * plane[1] + plane[2] * plane[2]);
         plane[0] /= t;
         plane[1] /= t;
         plane[2] /= t;
@@ -123,7 +123,7 @@ class Frustum {
      * @returns {boolean} True if the point is inside the frustum, false otherwise.
      */
     containsPoint(point) {
-        var p, plane;
+        let p, plane;
         for (p = 0; p < 6; p++) {
             plane = this.planes[p];
             if (plane[0] * point.x + plane[1] * point.y + plane[2] * point.z + plane[3] <= 0) {
@@ -145,17 +145,17 @@ class Frustum {
      * it is contained by the frustum.
      */
     containsSphere(sphere) {
-        var c = 0;
-        var d;
-        var p;
+        let c = 0;
+        let d;
+        let p;
 
-        var sr = sphere.radius;
-        var sc = sphere.center;
-        var scx = sc.x;
-        var scy = sc.y;
-        var scz = sc.z;
-        var planes = this.planes;
-        var plane;
+        const sr = sphere.radius;
+        const sc = sphere.center;
+        const scx = sc.x;
+        const scy = sc.y;
+        const scz = sc.z;
+        const planes = this.planes;
+        let plane;
 
         for (p = 0; p < 6; p++) {
             plane = planes[p];

--- a/src/shape/oriented-box.js
+++ b/src/shape/oriented-box.js
@@ -5,10 +5,10 @@ import { BoundingBox } from './bounding-box.js';
 import { BoundingSphere } from './bounding-sphere.js';
 import { Ray } from './ray.js';
 
-var tmpRay = new Ray();
-var tmpVec3 = new Vec3();
-var tmpSphere = new BoundingSphere();
-var tmpMat4 = new Mat4();
+const tmpRay = new Ray();
+const tmpVec3 = new Vec3();
+const tmpSphere = new BoundingSphere();
+const tmpMat4 = new Mat4();
 
 /**
  * @class
@@ -42,7 +42,7 @@ class OrientedBox {
         this._modelTransform.transformVector(ray.direction, tmpRay.direction);
 
         if (point) {
-            var result = this._aabb._intersectsRay(tmpRay, point);
+            const result = this._aabb._intersectsRay(tmpRay, point);
             tmpMat4.copy(this._modelTransform).invert().transformPoint(point, point);
             return result;
         }

--- a/src/shape/plane.js
+++ b/src/shape/plane.js
@@ -1,6 +1,6 @@
 import { Vec3 } from '../math/vec3.js';
 
-var tmpVecA = new Vec3();
+const tmpVecA = new Vec3();
 
 /**
  * @private
@@ -28,12 +28,12 @@ class Plane {
      * @returns {boolean} True if there is an intersection.
      */
     intersectsLine(start, end, point) {
-        var d = -this.normal.dot(this.point);
-        var d0 = this.normal.dot(start) + d;
-        var d1 = this.normal.dot(end) + d;
+        const d = -this.normal.dot(this.point);
+        const d0 = this.normal.dot(start) + d;
+        const d1 = this.normal.dot(end) + d;
 
-        var t = d0 / (d0 - d1);
-        var intersects = t >= 0 && t <= 1;
+        const t = d0 / (d0 - d1);
+        const intersects = t >= 0 && t <= 1;
         if (intersects && point)
             point.lerp(start, end, t);
 
@@ -50,9 +50,9 @@ class Plane {
      * @returns {boolean} True if there is an intersection.
      */
     intersectsRay(ray, point) {
-        var pointToOrigin = tmpVecA.sub2(this.point, ray.origin);
-        var t = this.normal.dot(pointToOrigin) / this.normal.dot(ray.direction);
-        var intersects = t >= 0;
+        const pointToOrigin = tmpVecA.sub2(this.point, ray.origin);
+        const t = this.normal.dot(pointToOrigin) / this.normal.dot(ray.direction);
+        const intersects = t >= 0;
 
         if (intersects && point)
             point.copy(ray.direction).scale(t).add(ray.origin);


### PR DESCRIPTION
Migrates entire core, math and shape codebase from `var` to use `let` and `const`. Note that, for now, API ref docs still use `var`.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
