### PR TITLE
Update all calls of vector scale to mulScalar

### DIFF
--- a/src/framework/components/element/component.js
+++ b/src/framework/components/element/component.js
@@ -1350,7 +1350,7 @@ Object.defineProperty(ElementComponent.prototype, 'screenCorners', {
         for (var i = 0; i < 4; i++) {
             this._screenTransform.transformPoint(this._screenCorners[i], this._screenCorners[i]);
             if (screenSpace)
-                this._screenCorners[i].scale(this.screen.screen.scale);
+                this._screenCorners[i].mulScalar(this.screen.screen.scale);
 
             if (parentBottomLeft) {
                 this._screenCorners[i].add(parentBottomLeft);

--- a/src/framework/components/element/element-drag-helper.js
+++ b/src/framework/components/element/element-drag-helper.js
@@ -122,7 +122,7 @@ class ElementDragHelper extends EventHandler {
         this._chooseRayOriginAndDirection();
 
         _planeOrigin.copy(this._element.entity.getPosition());
-        _planeNormal.copy(this._element.entity.forward).scale(-1);
+        _planeNormal.copy(this._element.entity.forward).mulScalar(-1);
 
         var denominator = _planeNormal.dot(_rayDirection);
 
@@ -130,7 +130,7 @@ class ElementDragHelper extends EventHandler {
         if (Math.abs(denominator) > 0) {
             var rayOriginToPlaneOrigin = _planeOrigin.sub(_rayOrigin);
             var collisionDistance = rayOriginToPlaneOrigin.dot(_planeNormal) / denominator;
-            var position = _rayOrigin.add(_rayDirection.scale(collisionDistance));
+            var position = _rayOrigin.add(_rayDirection.mulScalar(collisionDistance));
 
             _entityRotation.copy(this._element.entity.getRotation()).invert().transformVector(position, position);
 

--- a/src/framework/components/rigid-body/component.js
+++ b/src/framework/components/rigid-body/component.js
@@ -338,14 +338,14 @@ class RigidBodyComponent extends Component {
      * @example
      * // Apply a force at the body's center
      * // Calculate a force vector pointing in the world space direction of the entity
-     * var force = this.entity.forward.clone().scale(100);
+     * var force = this.entity.forward.clone().mulScalar(100);
      *
      * // Apply the force
      * this.entity.rigidbody.applyForce(force);
      * @example
      * // Apply a force at some relative offset from the body's center
      * // Calculate a force vector pointing in the world space direction of the entity
-     * var force = this.entity.forward.clone().scale(100);
+     * var force = this.entity.forward.clone().mulScalar(100);
      *
      * // Calculate the world space relative offset
      * var relativePos = new pc.Vec3();

--- a/src/input/element-input.js
+++ b/src/input/element-input.js
@@ -858,7 +858,7 @@ class ElementInput {
 
         rayA.origin.copy(ray.origin);
         rayA.direction.copy(ray.direction);
-        rayA.end.copy(rayA.direction).scale(camera.farClip * 2).add(rayA.origin);
+        rayA.end.copy(rayA.direction).mulScalar(camera.farClip * 2).add(rayA.origin);
 
         // sort elements
         this._elements.sort(this._sortHandler);
@@ -889,14 +889,14 @@ class ElementInput {
             var hitPadding = element.entity.button.hitPadding || ZERO_VEC4;
 
             _paddingTop.copy(element.entity.up);
-            _paddingBottom.copy(_paddingTop).scale(-1);
+            _paddingBottom.copy(_paddingTop).mulScalar(-1);
             _paddingRight.copy(element.entity.right);
-            _paddingLeft.copy(_paddingRight).scale(-1);
+            _paddingLeft.copy(_paddingRight).mulScalar(-1);
 
-            _paddingTop.scale(hitPadding.w * scaleY);
-            _paddingBottom.scale(hitPadding.y * scaleY);
-            _paddingRight.scale(hitPadding.z * scaleX);
-            _paddingLeft.scale(hitPadding.x * scaleX);
+            _paddingTop.mulScalar(hitPadding.w * scaleY);
+            _paddingBottom.mulScalar(hitPadding.y * scaleY);
+            _paddingRight.mulScalar(hitPadding.z * scaleX);
+            _paddingLeft.mulScalar(hitPadding.x * scaleX);
 
             _cornerBottomLeft.copy(hitCorners[0]).add(_paddingBottom).add(_paddingLeft);
             _cornerBottomRight.copy(hitCorners[1]).add(_paddingBottom).add(_paddingRight);
@@ -950,7 +950,7 @@ class ElementInput {
 
             ray.origin.set(_x, _y, 1);
             ray.direction.set(0, 0, -1);
-            ray.end.copy(ray.direction).scale(2).add(ray.origin);
+            ray.end.copy(ray.direction).mulScalar(2).add(ray.origin);
 
             return true;
         }

--- a/src/math/mat4.js
+++ b/src/math/mat4.js
@@ -1132,9 +1132,6 @@ class Mat4 {
      * @param {Vec3} [scale] - Vector to receive the scale.
      * @returns {Vec3} The scale in X, Y and Z of the specified 4x4 matrix.
      * @example
-     * // Create a 4x4 scale matrix
-     * var m = new pc.Mat4().scale(2, 3, 4);
-     *
      * // Query the scale component
      * var scale = m.getScale();
      */
@@ -1248,7 +1245,7 @@ class Mat4 {
             x = Math.atan2(m[4] / sy, m[5] / sy);
         }
 
-        return eulers.set(x, y, z).scale(math.RAD_TO_DEG);
+        return eulers.set(x, y, z).mulScalar(math.RAD_TO_DEG);
     }
 
     /**

--- a/src/math/quat.js
+++ b/src/math/quat.js
@@ -215,7 +215,7 @@ class Quat {
             z = Math.atan2(2 * (qw * qz + qx * qy), 1 - 2 * (qy * qy + qz * qz));
         }
 
-        return eulers.set(x, y, z).scale(math.RAD_TO_DEG);
+        return eulers.set(x, y, z).mulScalar(math.RAD_TO_DEG);
     }
 
     /**

--- a/src/scene/camera.js
+++ b/src/scene/camera.js
@@ -415,7 +415,7 @@ class Camera {
         // Calculate the screen click as a point on the far plane of the normalized device coordinate 'box' (z=1)
         var range = this._farClip - this._nearClip;
         _deviceCoord.set(x / cw, (ch - y) / ch, z / range);
-        _deviceCoord.scale(2);
+        _deviceCoord.mulScalar(2);
         _deviceCoord.sub(Vec3.ONE);
 
         if (this._projection === PROJECTION_PERSPECTIVE) {
@@ -436,7 +436,7 @@ class Camera {
             var cameraPos = this._node.getPosition();
             worldCoord.sub2(_point, cameraPos);
             worldCoord.normalize();
-            worldCoord.scale(z);
+            worldCoord.mulScalar(z);
             worldCoord.add(cameraPos);
 
         } else {

--- a/src/scene/forward-renderer.js
+++ b/src/scene/forward-renderer.js
@@ -1044,7 +1044,7 @@ class ForwardRenderer {
             this.lightColorId[cnt].setValue(scene.gammaCorrection ? directional._linearFinalColor : directional._finalColor);
 
             // Directionals shine down the negative Y axis
-            wtm.getY(directional._direction).scale(-1);
+            wtm.getY(directional._direction).mulScalar(-1);
             directional._direction.normalize();
             this.lightDir[cnt][0] = directional._direction.x;
             this.lightDir[cnt][1] = directional._direction.y;
@@ -1172,7 +1172,7 @@ class ForwardRenderer {
         }
 
         // Spots shine down the negative Y axis
-        wtm.getY(spot._direction).scale(-1);
+        wtm.getY(spot._direction).mulScalar(-1);
         spot._direction.normalize();
         this.lightDir[cnt][0] = spot._direction.x;
         this.lightDir[cnt][1] = spot._direction.y;

--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -117,7 +117,7 @@ class GraphNode extends EventHandler {
         if (!this._forward) {
             this._forward = new Vec3();
         }
-        return this.getWorldTransform().getZ(this._forward).normalize().scale(-1);
+        return this.getWorldTransform().getZ(this._forward).normalize().mulScalar(-1);
     }
 
     /**

--- a/src/scene/light.js
+++ b/src/scene/light.js
@@ -237,15 +237,15 @@ class Light {
             var node = this._node;
 
             spotCenter.copy(node.up);
-            spotCenter.scale(-range * 0.5 * f);
+            spotCenter.mulScalar(-range * 0.5 * f);
             spotCenter.add(node.getPosition());
             sphere.center = spotCenter;
 
             spotEndPoint.copy(node.up);
-            spotEndPoint.scale(-range);
+            spotEndPoint.mulScalar(-range);
 
             tmpVec.copy(node.right);
-            tmpVec.scale(Math.sin(angle * math.DEG_TO_RAD) * range);
+            tmpVec.mulScalar(Math.sin(angle * math.DEG_TO_RAD) * range);
             spotEndPoint.add(tmpVec);
 
             sphere.radius = spotEndPoint.length() * 0.5;

--- a/src/scene/particle-system/cpu-updater.js
+++ b/src/scene/particle-system/cpu-updater.js
@@ -105,9 +105,9 @@ class ParticleCPUUpdater {
             var spawnBoundsSphereInnerRatio = (emitter.emitterRadius === 0) ? 0 : emitter.emitterRadiusInner / emitter.emitterRadius;
             var r = rW * (1.0 - spawnBoundsSphereInnerRatio) + spawnBoundsSphereInnerRatio;
             if (!emitter.localSpace)
-                randomPosTformed.copy(emitterPos).add( randomPos.scale(r * emitter.emitterRadius) );
+                randomPosTformed.copy(emitterPos).add( randomPos.mulScalar(r * emitter.emitterRadius) );
             else
-                randomPosTformed.copy( randomPos.scale(r * emitter.emitterRadius) );
+                randomPosTformed.copy( randomPos.mulScalar(r * emitter.emitterRadius) );
         }
 
         var particleRate, startSpawnTime;
@@ -263,7 +263,7 @@ class ParticleCPUUpdater {
                     radialVelocityVec.copy(particlePosPrev).sub(emitterPos);
                 else
                     radialVelocityVec.copy(particlePosPrev);
-                radialVelocityVec.normalize().scale(radialSpeed);
+                radialVelocityVec.normalize().mulScalar(radialSpeed);
 
                 cf *= 3;
                 cc *= 3;
@@ -318,10 +318,10 @@ class ParticleCPUUpdater {
 
                 if (emitter.initialVelocity > 0) {
                     if (emitter.emitterShape === EMITTERSHAPE_SPHERE) {
-                        randomPos.copy(rndFactor3Vec).scale(2).sub(Vec3.ONE).normalize();
-                        localVelocityVec.add(randomPos.scale(emitter.initialVelocity));
+                        randomPos.copy(rndFactor3Vec).mulScalar(2).sub(Vec3.ONE).normalize();
+                        localVelocityVec.add(randomPos.mulScalar(emitter.initialVelocity));
                     } else {
-                        localVelocityVec.add(Vec3.FORWARD.scale(emitter.initialVelocity));
+                        localVelocityVec.add(Vec3.FORWARD.mulScalar(emitter.initialVelocity));
                     }
                 }
 
@@ -353,7 +353,7 @@ class ParticleCPUUpdater {
 
                 moveDirVec.copy(localVelocityVec);
 
-                particlePos.copy(particlePosPrev).add(localVelocityVec.scale(delta));
+                particlePos.copy(particlePosPrev).add(localVelocityVec.mulScalar(delta));
                 particleFinalPos.copy(particlePos);
 
                 particleTex[id * particleTexChannels] =      particleFinalPos.x;

--- a/src/scene/particle-system/particle-emitter.js
+++ b/src/scene/particle-system/particle-emitter.js
@@ -415,7 +415,7 @@ class ParticleEmitter {
         this.worldBoundsMul.y = 1.0 / this.worldBoundsSize.y;
         this.worldBoundsMul.z = 1.0 / this.worldBoundsSize.z;
 
-        this.worldBoundsAdd.copy(this.worldBounds.center).mul(this.worldBoundsMul).scale(-1);
+        this.worldBoundsAdd.copy(this.worldBounds.center).mul(this.worldBoundsMul).mulScalar(-1);
         this.worldBoundsAdd.x += 0.5;
         this.worldBoundsAdd.y += 0.5;
         this.worldBoundsAdd.z += 0.5;
@@ -459,7 +459,7 @@ class ParticleEmitter {
 
         this.worldBounds.copy(this.worldBoundsTrail[0]);
 
-        this.worldBoundsSize.copy(this.worldBounds.halfExtents).scale(2);
+        this.worldBoundsSize.copy(this.worldBounds.halfExtents).mulScalar(2);
 
         if (this.localSpace) {
             this.meshInstance.aabb.setFromTransformedAabb(this.worldBounds, nodeWT);
@@ -483,7 +483,7 @@ class ParticleEmitter {
         this.worldBoundsTrail[1].copy(this.worldBoundsNoTrail);
 
         this.worldBounds.copy(this.worldBoundsTrail[0]);
-        this.worldBoundsSize.copy(this.worldBounds.halfExtents).scale(2);
+        this.worldBoundsSize.copy(this.worldBounds.halfExtents).mulScalar(2);
 
         this.prevWorldBoundsSize.copy(this.worldBoundsSize);
         this.prevWorldBoundsCenter.copy(this.worldBounds.center);
@@ -607,7 +607,7 @@ class ParticleEmitter {
             this.worldBoundsTrail[0].copy(this.worldBounds);
             this.worldBoundsTrail[1].copy(this.worldBounds);
 
-            this.worldBoundsSize.copy(this.worldBounds.halfExtents).scale(2);
+            this.worldBoundsSize.copy(this.worldBounds.halfExtents).mulScalar(2);
             this.prevWorldBoundsSize.copy(this.worldBoundsSize);
             this.prevWorldBoundsCenter.copy(this.worldBounds.center);
             if (this.pack8) this.calculateBoundsMad();

--- a/src/scene/procedural.js
+++ b/src/scene/procedural.js
@@ -196,7 +196,7 @@ function calculateTangents(positions, normals, uvs, indices) {
 
         // Gram-Schmidt orthogonalize
         var ndott = n.dot(t1);
-        temp.copy(n).scale(ndott);
+        temp.copy(n).mulScalar(ndott);
         temp.sub2(t1, temp).normalize();
 
         tangents[i * 4]     = temp.x;

--- a/src/shape/bounding-box.js
+++ b/src/shape/bounding-box.js
@@ -152,7 +152,7 @@ class BoundingBox {
         var intersects = minMax >= maxMin && maxMin >= 0;
 
         if (intersects)
-            point.copy(ray.direction).scale(maxMin).add(ray.origin);
+            point.copy(ray.direction).mulScalar(maxMin).add(ray.origin);
 
         return intersects;
     }
@@ -220,8 +220,8 @@ class BoundingBox {
      * @param {Vec3} max - The maximum corner of the AABB.
      */
     setMinMax(min, max) {
-        this.center.add2(max, min).scale(0.5);
-        this.halfExtents.sub2(max, min).scale(0.5);
+        this.center.add2(max, min).mulScalar(0.5);
+        this.halfExtents.sub2(max, min).mulScalar(0.5);
     }
 
     /**

--- a/src/shape/bounding-sphere.js
+++ b/src/shape/bounding-sphere.js
@@ -53,7 +53,7 @@ class BoundingSphere {
 
         // if t is negative, ray started inside sphere so clamp t to zero
         if (point)
-            point.copy(ray.direction).scale(t).add(ray.origin);
+            point.copy(ray.direction).mulScalar(t).add(ray.origin);
 
         return true;
     }

--- a/src/shape/plane.js
+++ b/src/shape/plane.js
@@ -55,7 +55,7 @@ class Plane {
         var intersects = t >= 0;
 
         if (intersects && point)
-            point.copy(ray.direction).scale(t).add(ray.origin);
+            point.copy(ray.direction).mulScalar(t).add(ray.origin);
 
         return intersects;
     }

--- a/src/xr/xr-light-estimation.js
+++ b/src/xr/xr-light-estimation.js
@@ -161,7 +161,7 @@ class XrLightEstimation extends EventHandler {
         this._intensity = Math.max(1.0, Math.max(pli.x, Math.max(pli.y, pli.z)));
 
         // color
-        vec3A.copy(pli).scale(1 / this._intensity);
+        vec3A.copy(pli).mulScalar(1 / this._intensity);
         this._color.set(vec3A.x, vec3A.y, vec3A.z);
 
         // rotation


### PR DESCRIPTION
This PR updates all calls to `Vec2/3/4#scale` to `Vec2/3/4#mulScalar`. This is in response to a recent update to the math API.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
