### PR TITLE
[FIX] Type for TEXTUREPROJECTION constants is string, not number

### DIFF
--- a/src/graphics/constants.js
+++ b/src/graphics/constants.js
@@ -1003,7 +1003,7 @@ export const TEXHINT_LIGHTMAP = 3;
 /**
  * @constant
  * @name TEXTUREPROJECTION_NONE
- * @type {number}
+ * @type {string}
  * @description Texture data is not stored a specific projection format.
  */
 export const TEXTUREPROJECTION_NONE = "none";
@@ -1011,7 +1011,7 @@ export const TEXTUREPROJECTION_NONE = "none";
 /**
  * @constant
  * @name TEXTUREPROJECTION_CUBE
- * @type {number}
+ * @type {string}
  * @description Texture data is stored in cubemap projection format.
  */
 export const TEXTUREPROJECTION_CUBE = "cube";
@@ -1019,7 +1019,7 @@ export const TEXTUREPROJECTION_CUBE = "cube";
 /**
  * @constant
  * @name TEXTUREPROJECTION_EQUIRECT
- * @type {number}
+ * @type {string}
  * @description Texture data is stored in equirectangular projection format.
  */
 export const TEXTUREPROJECTION_EQUIRECT = "equirect";
@@ -1027,7 +1027,7 @@ export const TEXTUREPROJECTION_EQUIRECT = "equirect";
 /**
  * @constant
  * @name TEXTUREPROJECTION_OCTAHEDRAL
- * @type {number}
+ * @type {string}
  * @description Texture data is stored in octahedral projection format.
  */
 export const TEXTUREPROJECTION_OCTAHEDRAL = "octahedral";


### PR DESCRIPTION
TEXTUREPROJECTION constants were previously defined with the incorrect type. Possibly a copy and paste error.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
