### PR TITLE
[FIX] Remove access to Vec4#data which is no longer API

### DIFF
--- a/src/graphics/paraboloid.js
+++ b/src/graphics/paraboloid.js
@@ -17,7 +17,7 @@ function paraboloidFromCubemap(device, sourceCubemap, fixSeamsAmount, dontFlipX)
                                       "genParaboloid");
     var constantTexSource = device.scope.resolve("source");
     var constantParams = device.scope.resolve("params");
-    var params = new Vec4();
+    var params = new Float32Array(4);
     var size = sourceCubemap.width;
     var format = sourceCubemap.format;
 
@@ -36,10 +36,10 @@ function paraboloidFromCubemap(device, sourceCubemap, fixSeamsAmount, dontFlipX)
         depth: false
     });
 
-    params.x = fixSeamsAmount;
-    params.y = dontFlipX ? -1.0 : 1.0;
+    params[0] = fixSeamsAmount;
+    params[1] = dontFlipX ? -1.0 : 1.0;
     constantTexSource.setValue(sourceCubemap);
-    constantParams.setValue(params.data);
+    constantParams.setValue(params);
     drawQuadWithShader(device, targ, shader);
 
     return tex;
@@ -62,7 +62,7 @@ function getDpAtlasRect(rect, mip) {
 function generateDpAtlas(device, sixCubemaps, dontFlipX) {
     var dp;
     var rect = new Vec4();
-    var params = new Vec4();
+    var params = new Float32Array(4);
     var size = sixCubemaps[0].width * 2 * dpMult;
 
     var shader = createShaderFromCode(device,
@@ -92,11 +92,11 @@ function generateDpAtlas(device, sixCubemaps, dontFlipX) {
         dp = paraboloidFromCubemap(device, sixCubemaps[i], i, dontFlipX);
         constantTexSource.setValue(dp);
         scaleAmount = getDpAtlasRect(rect, i);
-        params.x = scaleAmount * scaleFactor;
-        params.y = params.x * 2;
-        params.x += 1;
-        params.y += 1;
-        constantParams.setValue(params.data);
+        params[0] = scaleAmount * scaleFactor;
+        params[1] = params[0] * 2;
+        params[0] += 1;
+        params[1] += 1;
+        constantParams.setValue(params);
         rect.x *= size;
         rect.y *= size;
         rect.z *= size;

--- a/src/graphics/prefilter-cubemap.js
+++ b/src/graphics/prefilter-cubemap.js
@@ -60,7 +60,7 @@ function prefilterCubemap(options) {
                                        "outputCubemap");
     var constantTexSource = device.scope.resolve("source");
     var constantParams = device.scope.resolve("params");
-    var params = new Vec4();
+    var params = new Float32Array(4);
     var size = sourceCubemap.width;
     var format = sourceCubemap.format;
 
@@ -94,10 +94,10 @@ function prefilterCubemap(options) {
                 face: face,
                 depth: false
             });
-            params.x = face;
-            params.y = 0;
+            params[0] = face;
+            params[1] = 0;
             constantTexSource.setValue(sourceCubemap);
-            constantParams.setValue(params.data);
+            constantParams.setValue(params);
 
             drawQuadWithShader(device, targ, shader2);
             syncToCpu(device, targ, face);
@@ -127,12 +127,12 @@ function prefilterCubemap(options) {
                     face: face,
                     depth: false
                 });
-                params.x = face;
-                params.y = sampleGloss;
-                params.z = size;
-                params.w = rgbmSource ? 3 : 0;
+                params[0] = face;
+                params[1] = sampleGloss;
+                params[2] = size;
+                params[3] = rgbmSource ? 3 : 0;
                 constantTexSource.setValue(sourceCubemap);
-                constantParams.setValue(params.data);
+                constantParams.setValue(params);
 
                 drawQuadWithShader(device, targ, shader2);
                 if (i === steps - 1 && cpuSync) {
@@ -160,10 +160,10 @@ function prefilterCubemap(options) {
                 face: face,
                 depth: false
             });
-            params.x = face;
-            params.w = 2;
+            params[0] = face;
+            params[3] = 2;
             constantTexSource.setValue(sourceCubemap);
-            constantParams.setValue(params.data);
+            constantParams.setValue(params);
 
             drawQuadWithShader(device, targ, shader2);
             syncToCpu(device, targ, face);
@@ -212,13 +212,13 @@ function prefilterCubemap(options) {
                         face: face,
                         depth: false
                     });
-                    params.x = face;
-                    params.y = pass < 0 ? unblurredGloss : gloss[i];
-                    params.z = mipSize[i];
-                    params.w = rgbmSource ? 3 : pass;
+                    params[0] = face;
+                    params[1] = pass < 0 ? unblurredGloss : gloss[i];
+                    params[2] = mipSize[i];
+                    params[3] = rgbmSource ? 3 : pass;
                     constantTexSource.setValue(i === 0 ? sourceCubemap :
                         method === 0 ? cmapsList[0][i - 1] : cmapsList[-1][i - 1]);
-                    constantParams.setValue(params.data);
+                    constantParams.setValue(params);
 
                     drawQuadWithShader(device, targ, shader);
                     if (cpuSync) syncToCpu(device, targ, face);


### PR DESCRIPTION
Long ago, you could access a `Float32Array` property `data` on a vector instance to access its elements. This was removed from the API. But some parts of the codebase still assume its existence (it's there but in the `deprecated.js` module). This PR removes several uses of the `data` property.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
