### PR TITLE
[FIX] Missing extension on some imports

### DIFF
--- a/src/resources/hierarchy.js
+++ b/src/resources/hierarchy.js
@@ -1,5 +1,5 @@
 import { SceneParser } from './parser/scene.js';
-import { SceneUtils } from "./scene-utils";
+import { SceneUtils } from "./scene-utils.js";
 
 class HierarchyHandler {
     constructor(app) {

--- a/src/resources/scene-settings.js
+++ b/src/resources/scene-settings.js
@@ -1,4 +1,4 @@
-import { SceneUtils } from "./scene-utils";
+import { SceneUtils } from "./scene-utils.js";
 
 class SceneSettingsHandler {
     constructor(app) {

--- a/src/resources/scene-utils.js
+++ b/src/resources/scene-utils.js
@@ -1,9 +1,11 @@
-import { http } from '../net/http';
+import { http } from '../net/http.js';
+
 var SceneUtils = {
     /**
      * @private
      * @function
-     * @name pc.SceneUtils#load
+     * @static
+     * @name SceneUtils.load
      * @description Loads the scene JSON file from a URL
      * @param {string} url - URL to scene JSON.
      * @param {Function} callback - The callback to the JSON file is loaded.

--- a/src/resources/scene.js
+++ b/src/resources/scene.js
@@ -1,5 +1,5 @@
 import { SceneParser } from './parser/scene.js';
-import { SceneUtils } from "./scene-utils";
+import { SceneUtils } from "./scene-utils.js";
 
 /**
  * @class


### PR DESCRIPTION
Adds some missing `.js` extensions to some imports in the `resources` folder. Also fixes up some JSDoc for `SceneUtils.load`.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
