### PR TITLE
Migrate SceneRegistryItem to ES6 class

### DIFF
--- a/src/framework/scene-registry-item.js
+++ b/src/framework/scene-registry-item.js
@@ -8,24 +8,22 @@
  * @property {string} url - The url of the scene file.
  * @property {boolean} loaded - Returns true if the scene data is still being loaded
  */
-function SceneRegistryItem(name, url) {
-    this.name = name;
-    this.url = url;
-    this.data = null;
-    this._loading = false;
-    this._onLoadedCallbacks = [];
-}
+class SceneRegistryItem {
+    constructor(name, url) {
+        this.name = name;
+        this.url = url;
+        this.data = null;
+        this._loading = false;
+        this._onLoadedCallbacks = [];
+    }
 
-Object.defineProperty(SceneRegistryItem.prototype, "loaded", {
-    get: function () {
+    get loaded() {
         return !!this.data;
     }
-});
 
-Object.defineProperty(SceneRegistryItem.prototype, "loading", {
-    get: function () {
+    get loading() {
         return this._loading;
     }
-});
+}
 
 export { SceneRegistryItem };


### PR DESCRIPTION
When the engine was migrated to ES6 classes, it seems `SceneRegistryItem` was missed. This PR rectifies that.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
