### PR TITLE
Remove SceneUtils from global export

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -164,7 +164,6 @@ export { ResourceLoader } from './resources/loader.js';
 export { ScriptHandler } from './resources/script.js';
 export { SceneHandler } from './resources/scene.js';
 export { SceneSettingsHandler } from './resources/scene-settings.js';
-export { SceneUtils } from './resources/scene-utils';
 export { ShaderHandler } from './resources/shader.js';
 export { SpriteHandler } from './resources/sprite.js';
 export { TemplateHandler } from './resources/template.js';


### PR DESCRIPTION
[This PR](https://github.com/playcanvas/engine/pull/2623) added the global export of the `SceneUtils` object to the `pc` namespace. However, I don't see any reason why this should be public (and it adds no public API via JSDoc comments). So this PR removes it again.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
