### PR TITLE
Remove all redundant constructors

### DIFF
--- a/src/anim/binder/anim-binder.js
+++ b/src/anim/binder/anim-binder.js
@@ -6,8 +6,6 @@
  * into instances of {@link AnimTarget}.
  */
 class AnimBinder {
-    constructor() {}
-
     // join a list of path segments into a path string using the full stop character. If another character is supplied,
     // it will join using that character instead
     static joinPath(pathSegments, character) {

--- a/src/framework/components/anim/component.js
+++ b/src/framework/components/anim/component.js
@@ -26,10 +26,6 @@ import { AnimStateGraph } from '../../../anim/state-graph/anim-state-graph.js';
  * @property {boolean} playing Plays or pauses all animations in the component.
  */
 class AnimComponent extends Component {
-    constructor(system, entity) {
-        super(system, entity);
-    }
-
     /**
      * @function
      * @name AnimComponent#loadStateGraph

--- a/src/framework/components/audio-listener/component.js
+++ b/src/framework/components/audio-listener/component.js
@@ -11,10 +11,6 @@ import { Component } from '../component.js';
  * @param {Entity} entity - The Entity that this Component is attached to.
  */
 class AudioListenerComponent extends Component {
-    constructor(system, entity) {
-        super(system, entity);
-    }
-
     setCurrentListener() {
         if (this.enabled && this.entity.audiolistener && this.entity.enabled) {
             this.system.current = this.entity;

--- a/src/framework/components/collision/system.js
+++ b/src/framework/components/collision/system.js
@@ -204,10 +204,6 @@ class CollisionSystemImpl {
 
 // Box Collision System
 class CollisionBoxSystemImpl extends CollisionSystemImpl {
-    constructor(system) {
-        super(system);
-    }
-
     createPhysicalShape(entity, data) {
         if (typeof Ammo !== 'undefined') {
             var he = data.halfExtents;
@@ -222,10 +218,6 @@ class CollisionBoxSystemImpl extends CollisionSystemImpl {
 
 // Sphere Collision System
 class CollisionSphereSystemImpl extends CollisionSystemImpl {
-    constructor(system) {
-        super(system);
-    }
-
     createPhysicalShape(entity, data) {
         if (typeof Ammo !== 'undefined') {
             return new Ammo.btSphereShape(data.radius);
@@ -236,10 +228,6 @@ class CollisionSphereSystemImpl extends CollisionSystemImpl {
 
 // Capsule Collision System
 class CollisionCapsuleSystemImpl extends CollisionSystemImpl {
-    constructor(system) {
-        super(system);
-    }
-
     createPhysicalShape(entity, data) {
         var shape = null;
         var axis = (data.axis !== undefined) ? data.axis : 1;
@@ -265,10 +253,6 @@ class CollisionCapsuleSystemImpl extends CollisionSystemImpl {
 
 // Cylinder Collision System
 class CollisionCylinderSystemImpl extends CollisionSystemImpl {
-    constructor(system) {
-        super(system);
-    }
-
     createPhysicalShape(entity, data) {
         var halfExtents = null;
         var shape = null;
@@ -302,10 +286,6 @@ class CollisionCylinderSystemImpl extends CollisionSystemImpl {
 
 // Cone Collision System
 class CollisionConeSystemImpl extends CollisionSystemImpl {
-    constructor(system) {
-        super(system);
-    }
-
     createPhysicalShape(entity, data) {
         var shape = null;
         var axis = (data.axis !== undefined) ? data.axis : 1;
@@ -331,10 +311,6 @@ class CollisionConeSystemImpl extends CollisionSystemImpl {
 
 // Mesh Collision System
 class CollisionMeshSystemImpl extends CollisionSystemImpl {
-    constructor(system) {
-        super(system);
-    }
-
     // override for the mesh implementation because the asset model needs
     // special handling
     beforeInitialize(component, data) {}
@@ -520,10 +496,6 @@ class CollisionMeshSystemImpl extends CollisionSystemImpl {
 
 // Compound Collision System
 class CollisionCompoundSystemImpl extends CollisionSystemImpl {
-    constructor(system) {
-        super(system);
-    }
-
     createPhysicalShape(entity, data) {
         if (typeof Ammo !== 'undefined') {
             return new Ammo.btCompoundShape();

--- a/src/framework/components/element/markup.js
+++ b/src/framework/components/element/markup.js
@@ -504,8 +504,6 @@ function evaluateMarkup(symbols) {
 }
 
 class Markup {
-    constructor() {}
-
     static evaluate(symbols) {
         return evaluateMarkup(symbols);
     }

--- a/src/framework/components/layout-group/layout-calculator.js
+++ b/src/framework/components/layout-group/layout-calculator.js
@@ -655,8 +655,6 @@ CALCULATE_FNS[ORIENTATION_VERTICAL] = createCalculator(ORIENTATION_VERTICAL);
  * @classdesc Used to manage layout calculations for {@link LayoutGroupComponent}s.
  */
 class LayoutCalculator {
-    constructor() {}
-
     calculateLayout(elements, options) {
         var calculateFn = CALCULATE_FNS[options.orientation];
 

--- a/src/i18n/i18n-parser.js
+++ b/src/i18n/i18n-parser.js
@@ -1,6 +1,4 @@
 class I18nParser {
-    constructor() {}
-
     _validate(data) {
         if (!data.header) {
             throw new Error('pc.I18n#addData: Missing "header" field');

--- a/src/net/http.js
+++ b/src/net/http.js
@@ -13,8 +13,6 @@ import { math } from '../math/math.js';
  * object at `http`.
  */
 class Http {
-    constructor() {}
-
     static ContentType = {
         FORM_URLENCODED: "application/x-www-form-urlencoded",
         GIF: "image/gif",

--- a/src/resources/folder.js
+++ b/src/resources/folder.js
@@ -1,6 +1,4 @@
 class FolderHandler {
-    constructor() {}
-
     load(url, callback) {
         callback(null, null);
     }

--- a/src/resources/handler.js
+++ b/src/resources/handler.js
@@ -4,8 +4,6 @@
  * @description Interface for ResourceHandlers used by {@link ResourceLoader}.
  */
 class ResourceHandler {
-    constructor() {}
-
     /**
      * @function
      * @name ResourceHandler#load

--- a/src/resources/parser/glb-parser.js
+++ b/src/resources/parser/glb-parser.js
@@ -1956,8 +1956,6 @@ var parseBufferViewsAsync = function (gltf, buffers, options, callback) {
 
 // -- GlbParser
 class GlbParser {
-    constructor() {}
-
     // parse the gltf or glb data asynchronously, loading external resources
     static parseAsync(filename, urlBase, data, device, registry, options, callback) {
         // parse the data

--- a/src/resources/texture.js
+++ b/src/resources/texture.js
@@ -43,8 +43,6 @@ var JSON_TEXTURE_TYPE = {
  * and opening of texture assets.
  */
 class TextureParser {
-    constructor() {}
-
     /**
      * @function
      * @name TextureParser#load

--- a/src/scene/materials/depth-material.js
+++ b/src/scene/materials/depth-material.js
@@ -7,10 +7,6 @@ import { Material } from './material.js';
  * @classdesc A Depth material is for rendering linear depth values to a render target.
  */
 class DepthMaterial extends Material {
-    constructor() {
-        super();
-    }
-
     /**
      * @private
      * @function


### PR DESCRIPTION
ES2015 provides a default class constructor if one is not specified. As such, it is unnecessary to provide an empty constructor or one that simply delegates into its parent class.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
