### PR TITLE
Make arrow function parentheses consistent

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -55,7 +55,7 @@ function shaderChunks(removeComments) {
                 code = code.replace(/\/\*[\s\S]*?\*\/|\/\/.*/g, '');
 
                 // Trim all whitespace from line endings
-                code = code.split('\n').map(line => line.trimEnd()).join('\n');
+                code = code.split('\n').map((line) => line.trimEnd()).join('\n');
 
                 // Restore final new line
                 code += '\n';

--- a/scripts/textmesh/text-mesh.js
+++ b/scripts/textmesh/text-mesh.js
@@ -32,7 +32,7 @@ class Polygon {
 
     close() {
         let cur = this.points[this.points.length - 1];
-        this.points.forEach(next => {
+        this.points.forEach((next) => {
             this.area += 0.5 * cur.cross(next);
             cur = next;
         });
@@ -82,7 +82,7 @@ class Polygon {
 
     inside(p) {
         let count = 0, cur = this.points[this.points.length - 1];
-        this.points.forEach(next => {
+        this.points.forEach((next) => {
             const p0 = (cur.y < next.y ? cur : next);
             const p1 = (cur.y < next.y ? next : cur);
             if (p0.y < p.y + EPSILON && p1.y > p.y + EPSILON) {
@@ -253,7 +253,7 @@ TextMesh.prototype.parseCommands = function (commands) {
         const coords = [];
         const holes = [];
         poly.points.forEach(({ x, y }) => coords.push(x, y));
-        poly.children.forEach(child => {
+        poly.children.forEach((child) => {
             // Children's children are new, separate shapes
             child.children.forEach(process);
 
@@ -265,7 +265,7 @@ TextMesh.prototype.parseCommands = function (commands) {
         vertexData.set(coords, vertexCount * 2);
 
         // Add index data
-        earcut(coords, holes).forEach(i => indices.push(i + vertexCount));
+        earcut(coords, holes).forEach((i) => indices.push(i + vertexCount));
         vertexCount += coords.length / 2;
     }
 
@@ -291,7 +291,7 @@ TextMesh.prototype.parseCommands = function (commands) {
     }
 
     // Generate sides
-    polygons.forEach(poly => {
+    polygons.forEach((poly) => {
         for (let i = 0; i < poly.points.length - 1; i++) {
             const base = vertices.length / 3;
             const p1 = poly.points[i];

--- a/src/anim/evaluator/anim-evaluator.js
+++ b/src/anim/evaluator/anim-evaluator.js
@@ -241,7 +241,7 @@ class AnimEvaluator {
         this._targets = {};
         var clips = [...this.clips];
         this.removeClips();
-        clips.forEach(clip => {
+        clips.forEach((clip) => {
             this.addClip(clip);
         });
     }

--- a/src/framework/components/joint/component.js
+++ b/src/framework/components/joint/component.js
@@ -483,9 +483,9 @@ const functionMap = {
 };
 
 // Define additional properties for each degree of freedom
-['linear', 'angular'].forEach(type => {
-    ['Damping', 'Equilibrium', 'Spring', 'Stiffness'].forEach(name => {
-        ['X', 'Y', 'Z'].forEach(axis => {
+['linear', 'angular'].forEach((type) => {
+    ['Damping', 'Equilibrium', 'Spring', 'Stiffness'].forEach((name) => {
+        ['X', 'Y', 'Z'].forEach((axis) => {
             const prop = type + name + axis;
             const propInternal = '_' + prop;
 

--- a/src/framework/components/render/component.js
+++ b/src/framework/components/render/component.js
@@ -143,7 +143,7 @@ class RenderComponent extends Component {
         if (cachedObjArray) {
 
             // find matching skin
-            const cachedObj = cachedObjArray.find(element => element.skin === skin);
+            const cachedObj = cachedObjArray.find((element) => element.skin === skin);
             if (cachedObj) {
                 cachedObj.incRefCount();
                 skinInstance = cachedObj.skinInstance;
@@ -164,7 +164,7 @@ class RenderComponent extends Component {
         }
 
         // find entry for the skin
-        let cachedObj = cachedObjArray.find(element => element.skin === skin);
+        let cachedObj = cachedObjArray.find((element) => element.skin === skin);
         if (!cachedObj) {
             cachedObj = new SkinInstanceCachedObject(skin, skinInstance);
             cachedObjArray.push(cachedObj);
@@ -185,7 +185,7 @@ class RenderComponent extends Component {
                 if (cachedObjArray) {
 
                     // actual skin instance
-                    const cachedObjIndex = cachedObjArray.findIndex(element => element.skinInstance === skinInstance);
+                    const cachedObjIndex = cachedObjArray.findIndex((element) => element.skinInstance === skinInstance);
                     if (cachedObjIndex >= 0) {
 
                         // dec ref on the object

--- a/src/framework/components/render/system.js
+++ b/src/framework/components/render/system.js
@@ -85,7 +85,7 @@ class RenderComponentSystem extends ComponentSystem {
 
         // clone mesh instances
         const srcMeshInstances = entity.render.meshInstances;
-        const meshes = srcMeshInstances.map(mi => mi.mesh);
+        const meshes = srcMeshInstances.map((mi) => mi.mesh);
         component._onSetMeshes(meshes);
 
         // assign materials

--- a/src/framework/components/screen/component.js
+++ b/src/framework/components/screen/component.js
@@ -150,7 +150,7 @@ class ScreenComponent extends Component {
         this.system.app.graphicsDevice.off("resizecanvas", this._onResize, this);
         this.fire('remove');
 
-        this._elements.forEach(element => element._onScreenRemove());
+        this._elements.forEach((element) => element._onScreenRemove());
         this._elements.clear();
 
         // remove all events
@@ -174,7 +174,7 @@ class ScreenComponent extends Component {
             this.entity._dirtifyLocal();
 
         this.fire("set:resolution", this._resolution);
-        this._elements.forEach(element => element._onScreenResize(this._resolution));
+        this._elements.forEach((element) => element._onScreenResize(this._resolution));
     }
 
     get resolution() {
@@ -190,7 +190,7 @@ class ScreenComponent extends Component {
             this.entity._dirtifyLocal();
 
         this.fire("set:referenceresolution", this._resolution);
-        this._elements.forEach(element => element._onScreenResize(this._resolution));
+        this._elements.forEach((element) => element._onScreenResize(this._resolution));
     }
 
     get referenceResolution() {
@@ -213,7 +213,7 @@ class ScreenComponent extends Component {
 
         this.fire('set:screenspace', this._screenSpace);
 
-        this._elements.forEach(element => element._onScreenSpaceChange());
+        this._elements.forEach((element) => element._onScreenSpaceChange());
     }
 
     get screenSpace() {
@@ -249,7 +249,7 @@ class ScreenComponent extends Component {
 
         this.fire("set:scaleblend", this._scaleBlend);
 
-        this._elements.forEach(element => element._onScreenResize(this._resolution));
+        this._elements.forEach((element) => element._onScreenResize(this._resolution));
     }
 
     get scaleBlend() {

--- a/src/graphics/graphics-device.js
+++ b/src/graphics/graphics-device.js
@@ -268,7 +268,7 @@ class GraphicsDevice extends EventHandler {
         // Add handlers for when the WebGL context is lost or restored
         this.contextLost = false;
 
-        this._contextLostHandler = event => {
+        this._contextLostHandler = (event) => {
             event.preventDefault();
             this.contextLost = true;
             this.loseContext();


### PR DESCRIPTION
Arrow functions can optionally omit parentheses when they have exactly one parameter. In all other cases the parameter(s) must be wrapped in parentheses. This rule enforces the consistent use of parentheses in arrow functions.

Here, we ensure parentheses are used everywhere.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
