### PR TITLE
MorphTarget - exposed name and defaultWeight as a public property

### DIFF
--- a/src/resources/parser/glb-parser.js
+++ b/src/resources/parser/glb-parser.js
@@ -795,24 +795,23 @@ var createMesh = function (device, gltfMesh, accessors, bufferViews, callback, d
                         options.deltaNormalsType = getComponentType(accessor.componentType);
                     }
 
+                    // name if specified
                     if (gltfMesh.hasOwnProperty('extras') &&
                         gltfMesh.extras.hasOwnProperty('targetNames')) {
                         options.name = gltfMesh.extras.targetNames[index];
                     } else {
-                        options.name = targets.length.toString(10);
+                        options.name = index.toString(10);
+                    }
+
+                    // default weight if specified
+                    if (gltfMesh.hasOwnProperty('weights')) {
+                        options.defaultWeight = gltfMesh.weights[index];
                     }
 
                     targets.push(new MorphTarget(options));
                 });
 
                 mesh.morph = new Morph(targets, device);
-
-                // set default morph target weights if they're specified
-                if (gltfMesh.hasOwnProperty('weights')) {
-                    for (var i = 0; i < gltfMesh.weights.length; ++i) {
-                        targets[i].defaultWeight = gltfMesh.weights[i];
-                    }
-                }
             }
         }
 

--- a/src/scene/morph-target.js
+++ b/src/scene/morph-target.js
@@ -29,8 +29,8 @@ class MorphTarget {
         }
 
         this.options = options;
-        this.name = options.name;
-        this.defaultWeight = options.defaultWeight || 0;
+        this._name = options.name;
+        this._defaultWeight = options.defaultWeight || 0;
 
         // bounds
         this.aabb = options.aabb;
@@ -42,6 +42,26 @@ class MorphTarget {
 
         // store delta positions, used by aabb evaluation
         this.deltaPositions = options.deltaPositions;
+    }
+
+    /**
+     * @name MorphTarget#name
+     * @type {string}
+     * @readonly
+     * @description The name of the morph target.
+     */
+    get name() {
+        return this._name;
+    }
+
+    /**
+     * @name MorphTarget#defaultWeight
+     * @type {number}
+     * @readonly
+     * @description The default weight of the morph target.
+     */
+    get defaultWeight() {
+        return this._defaultWeight;
     }
 
     get morphPositions() {


### PR DESCRIPTION
- exposed properties
- modified parser to not use the setter on the weights, but pass it using options to constructor