### PR TITLE
Prefer triple to double equals

### DIFF
--- a/scripts/camera/orbit-camera.js
+++ b/scripts/camera/orbit-camera.js
@@ -547,10 +547,10 @@ OrbitCameraInputTouch.prototype.onTouchStartEndCancel = function (event) {
     // We only care about the first touch for camera rotation. As the user touches the screen,
     // we stored the current touch position
     var touches = event.touches;
-    if (touches.length == 1) {
+    if (touches.length === 1) {
         this.lastTouchPoint.set(touches[0].x, touches[0].y);
 
-    } else if (touches.length == 2) {
+    } else if (touches.length === 2) {
         // If there are 2 touches on the screen, then set the pinch distance
         this.lastPinchDistance = this.getPinchDistance(touches[0], touches[1]);
         this.calcMidPoint(touches[0], touches[1], this.lastPinchMidPoint);
@@ -590,7 +590,7 @@ OrbitCameraInputTouch.prototype.onTouchMove = function (event) {
     // We only care about the first touch for camera rotation. Work out the difference moved since the last event
     // and use that to update the camera target position
     var touches = event.touches;
-    if (touches.length == 1) {
+    if (touches.length === 1) {
         var touch = touches[0];
 
         this.orbitCamera.pitch -= (touch.y - this.lastTouchPoint.y) * this.orbitSensitivity;
@@ -598,7 +598,7 @@ OrbitCameraInputTouch.prototype.onTouchMove = function (event) {
 
         this.lastTouchPoint.set(touch.x, touch.y);
 
-    } else if (touches.length == 2) {
+    } else if (touches.length === 2) {
         // Calculate the difference in pinch distance since the last event
         var currentPinchDistance = this.getPinchDistance(touches[0], touches[1]);
         var diffInPinchDistance = currentPinchDistance - this.lastPinchDistance;

--- a/scripts/utils/download-texture.js
+++ b/scripts/utils/download-texture.js
@@ -39,7 +39,7 @@ function constructPngUrl(data, width, height) {
             var block = data.slice(i, i + 65535);
             var len = block.length;
             compressed += String.fromCharCode(
-                ((i += block.length) == data.length) << 0,
+                ((i += block.length) === data.length) << 0,
                 len & 255, len >>> 8, ~len & 255, (~len >>> 8) & 255);
             compressed += block;
         } while (i < data.length);
@@ -49,7 +49,7 @@ function constructPngUrl(data, width, height) {
     var crc32 = function (data) {
         var c = ~0;
         for (var i = 0; i < data.length; i++)
-            for (var b = data.charCodeAt(i) | 0x100; b != 1; b >>>= 1)
+            for (var b = data.charCodeAt(i) | 0x100; b !== 1; b >>>= 1)
                 c = (c >>> 1) ^ ((c ^ b) & 1 ? 0xedb88320 : 0);
         return ~c;
     };

--- a/src/anim/evaluator/anim-clip.js
+++ b/src/anim/evaluator/anim-clip.js
@@ -119,7 +119,7 @@ class AnimClip {
         }
 
         // update snapshot if time has changed
-        if (this._time != this._snapshot._time) {
+        if (this._time !== this._snapshot._time) {
             this._track.eval(this._time, this._snapshot);
         }
     }

--- a/src/framework/components/audio-source/component.js
+++ b/src/framework/components/audio-source/component.js
@@ -198,7 +198,7 @@ class AudioSourceComponent extends Component {
     }
 
     onSetLoop(name, oldValue, newValue) {
-        if (oldValue != newValue) {
+        if (oldValue !== newValue) {
             if (this.channel) {
                 this.channel.setLoop(newValue);
             }
@@ -206,7 +206,7 @@ class AudioSourceComponent extends Component {
     }
 
     onSetVolume(name, oldValue, newValue) {
-        if (oldValue != newValue) {
+        if (oldValue !== newValue) {
             if (this.channel) {
                 this.channel.setVolume(newValue);
             }
@@ -214,7 +214,7 @@ class AudioSourceComponent extends Component {
     }
 
     onSetPitch(name, oldValue, newValue) {
-        if (oldValue != newValue) {
+        if (oldValue !== newValue) {
             if (this.channel) {
                 this.channel.setPitch(newValue);
             }
@@ -222,7 +222,7 @@ class AudioSourceComponent extends Component {
     }
 
     onSetMaxDistance(name, oldValue, newValue) {
-        if (oldValue != newValue) {
+        if (oldValue !== newValue) {
             if (this.channel instanceof Channel3d) {
                 this.channel.setMaxDistance(newValue);
             }
@@ -230,7 +230,7 @@ class AudioSourceComponent extends Component {
     }
 
     onSetMinDistance(name, oldValue, newValue) {
-        if (oldValue != newValue) {
+        if (oldValue !== newValue) {
             if (this.channel instanceof Channel3d) {
                 this.channel.setMinDistance(newValue);
             }
@@ -238,7 +238,7 @@ class AudioSourceComponent extends Component {
     }
 
     onSetRollOffFactor(name, oldValue, newValue) {
-        if (oldValue != newValue) {
+        if (oldValue !== newValue) {
             if (this.channel instanceof Channel3d) {
                 this.channel.setRollOffFactor(newValue);
             }

--- a/src/framework/components/screen/component.js
+++ b/src/framework/components/screen/component.js
@@ -67,7 +67,7 @@ class ScreenComponent extends Component {
             var prevDrawOrder = e.element.drawOrder;
             e.element.drawOrder = i++;
 
-            if (e.element._batchGroupId >= 0 && prevDrawOrder != e.element.drawOrder) {
+            if (e.element._batchGroupId >= 0 && prevDrawOrder !== e.element.drawOrder) {
                 this.system.app.batcher.markGroupDirty(e.element._batchGroupId);
             }
         }

--- a/src/graphics/prefilter-cubemap.js
+++ b/src/graphics/prefilter-cubemap.js
@@ -13,7 +13,7 @@ import { Texture } from './texture.js';
 
 function syncToCpu(device, targ, face) {
     var tex = targ._colorBuffer;
-    if (tex.format != PIXELFORMAT_R8_G8_B8_A8) return;
+    if (tex.format !== PIXELFORMAT_R8_G8_B8_A8) return;
     var pixels = new Uint8Array(tex.width * tex.height * 4);
     var gl = device.gl;
     device.setFramebuffer(targ._glFrameBuffer);
@@ -425,23 +425,23 @@ function shFromCubemap(device, source, dontFlipX) {
                     dx = dir.z;
                     dy = -dir.y;
                     dz = -dir.x;
-                } else if (face == px) {
+                } else if (face === px) {
                     dx = -dir.z;
                     dy = -dir.y;
                     dz = dir.x;
-                } else if (face == ny) {
+                } else if (face === ny) {
                     dx = dir.x;
                     dy = dir.z;
                     dz = dir.y;
-                } else if (face == py) {
+                } else if (face === py) {
                     dx = dir.x;
                     dy = -dir.z;
                     dz = -dir.y;
-                } else if (face == nz) {
+                } else if (face === nz) {
                     dx = dir.x;
                     dy = -dir.y;
                     dz = dir.z;
-                } else if (face == pz) {
+                } else if (face === pz) {
                     dx = -dir.x;
                     dy = -dir.y;
                     dz = -dir.z;

--- a/src/graphics/program-lib/programs/particle.js
+++ b/src/graphics/program-lib/programs/particle.js
@@ -39,8 +39,8 @@ var particle = {
         if (options.animTex) vshader += "\nuniform vec2 animTexTilesParams;\n";
         if (options.animTex) vshader += "\nuniform vec4 animTexParams;\n";
         if (options.animTex) vshader += "\nuniform vec2 animTexIndexParams;\n";
-        if (options.normal == 2) vshader += "\nvarying mat3 ParticleMat;\n";
-        if (options.normal == 1) vshader += "\nvarying vec3 Normal;\n";
+        if (options.normal === 2) vshader += "\nvarying mat3 ParticleMat;\n";
+        if (options.normal === 1) vshader += "\nvarying vec3 Normal;\n";
         if (options.soft) vshader += "\nvarying float vDepth;\n";
 
         var faceVS = options.customFace ? shaderChunks.particle_customFaceVS : shaderChunks.particle_billboardVS;
@@ -55,8 +55,8 @@ var particle = {
             if (options.wrap) vshader += shaderChunks.particle_wrapVS;
             if (options.alignToMotion) vshader += shaderChunks.particle_pointAlongVS;
             vshader += options.mesh ? shaderChunks.particle_meshVS : faceVS;
-            if (options.normal == 1) vshader += shaderChunks.particle_normalVS;
-            if (options.normal == 2) vshader += shaderChunks.particle_TBNVS;
+            if (options.normal === 1) vshader += shaderChunks.particle_normalVS;
+            if (options.normal === 2) vshader += shaderChunks.particle_TBNVS;
             if (options.stretch > 0.0) vshader += shaderChunks.particle_stretchVS;
             vshader += shaderChunks.particle_endVS;
             if (options.soft > 0) vshader += shaderChunks.particle_softVS;
@@ -68,8 +68,8 @@ var particle = {
             // if (options.wrap) vshader += shaderChunks.particle_wrapVS;
             if (options.alignToMotion) vshader += shaderChunks.particle_pointAlongVS;
             vshader += options.mesh ? shaderChunks.particle_meshVS : faceVS;
-            if (options.normal == 1) vshader += shaderChunks.particle_normalVS;
-            if (options.normal == 2) vshader += shaderChunks.particle_TBNVS;
+            if (options.normal === 1) vshader += shaderChunks.particle_normalVS;
+            if (options.normal === 2) vshader += shaderChunks.particle_TBNVS;
             if (options.stretch > 0.0) vshader += shaderChunks.particle_stretchVS;
             vshader += shaderChunks.particle_cpu_endVS;
             if (options.soft > 0) vshader += shaderChunks.particle_softVS;
@@ -77,9 +77,9 @@ var particle = {
         vshader += "}\n";
 
         if (options.normal > 0) {
-            if (options.normal == 1) {
+            if (options.normal === 1) {
                 fshader += "\nvarying vec3 Normal;\n";
-            } else if (options.normal == 2) {
+            } else if (options.normal === 2) {
                 fshader += "\nvarying mat3 ParticleMat;\n";
             }
             fshader += "\nuniform vec3 lightCube[6];\n";
@@ -100,19 +100,19 @@ var particle = {
             fshader += shaderChunks.fogNonePS;
         }
 
-        if (options.normal == 2) fshader += "\nuniform sampler2D normalMap;\n";
+        if (options.normal === 2) fshader += "\nuniform sampler2D normalMap;\n";
         if (options.soft > 0) fshader += shaderChunks.screenDepthPS;
         fshader += shaderChunks.particlePS;
         if (options.soft > 0) fshader += shaderChunks.particle_softPS;
-        if (options.normal == 1) fshader += "\nvec3 normal = Normal;\n";
-        if (options.normal == 2) fshader += shaderChunks.particle_normalMapPS;
+        if (options.normal === 1) fshader += "\nvec3 normal = Normal;\n";
+        if (options.normal === 2) fshader += shaderChunks.particle_normalMapPS;
         if (options.normal > 0) fshader += options.halflambert ? shaderChunks.particle_halflambertPS : shaderChunks.particle_lambertPS;
         if (options.normal > 0) fshader += shaderChunks.particle_lightingPS;
-        if (options.blend == BLEND_NORMAL) {
+        if (options.blend === BLEND_NORMAL) {
             fshader += shaderChunks.particle_blendNormalPS;
-        } else if (options.blend == BLEND_ADDITIVE) {
+        } else if (options.blend === BLEND_ADDITIVE) {
             fshader += shaderChunks.particle_blendAddPS;
-        } else if (options.blend == BLEND_MULTIPLICATIVE) {
+        } else if (options.blend === BLEND_MULTIPLICATIVE) {
             fshader += shaderChunks.particle_blendMultiplyPS;
         }
         fshader += shaderChunks.particle_endPS;

--- a/src/graphics/program-lib/programs/standard.js
+++ b/src/graphics/program-lib/programs/standard.js
@@ -817,7 +817,7 @@ var standard = {
         }
 
         // GENERATE FRAGMENT SHADER
-        if (options.forceFragmentPrecision && options.forceFragmentPrecision != "highp" &&
+        if (options.forceFragmentPrecision && options.forceFragmentPrecision !== "highp" &&
             options.forceFragmentPrecision !== "mediump" && options.forceFragmentPrecision !== "lowp")
             options.forceFragmentPrecision = null;
 

--- a/src/math/curve-evaluator.js
+++ b/src/math/curve-evaluator.js
@@ -115,7 +115,7 @@ class CurveEvaluator {
             a = keys[index - 1];
         }
 
-        if (index == keys.length - 2) {
+        if (index === keys.length - 2) {
             d = [keys[index + 1][0] + (keys[index + 1][0] - keys[index][0]),
                 keys[index + 1][1] + (keys[index + 1][1] - keys[index][1])];
         } else {

--- a/src/math/math.js
+++ b/src/math/math.js
@@ -306,7 +306,7 @@ const math = {
 
                 // If exponent was 0xff and one mantissa bit was set, it means NaN,
                 // not Inf, so make sure we set one mantissa bit too.
-                bits |= ((e == 255) ? 0 : 1) && (x & 0x007fffff);
+                bits |= ((e === 255) ? 0 : 1) && (x & 0x007fffff);
                 return bits;
             }
 

--- a/src/resources/parser/glb-parser.js
+++ b/src/resources/parser/glb-parser.js
@@ -677,7 +677,7 @@ var createMesh = function (device, gltfMesh, accessors, bufferViews, callback, d
 
                         // indices
                         var numFaces = outputGeometry.num_faces();
-                        if (geometryType == decoderModule.TRIANGULAR_MESH) {
+                        if (geometryType === decoderModule.TRIANGULAR_MESH) {
                             var bit32 = outputGeometry.num_points() > 65535;
                             numIndices = numFaces * 3;
                             var dataSize = numIndices * (bit32 ? 4 : 2);
@@ -971,7 +971,7 @@ var createMaterial = function (gltfMaterial, textures, disableFlipV) {
             color = specData.diffuseFactor;
             // Convert from linear space to sRGB space
             material.diffuse.set(Math.pow(color[0], 1 / 2.2), Math.pow(color[1], 1 / 2.2), Math.pow(color[2], 1 / 2.2));
-            material.opacity = (color[3] != null) ? color[3] : 1;
+            material.opacity = color[3];
         } else {
             material.diffuse.set(1, 1, 1);
             material.opacity = 1;

--- a/src/resources/parser/texture/hdr.js
+++ b/src/resources/parser/texture/hdr.js
@@ -136,7 +136,7 @@ class HdrParser {
 
         // read the resolution specifier
         var resolution = reader.readLine().split(' ');
-        if (resolution.length != 4) {
+        if (resolution.length !== 4) {
             this._error("radiance header has invalid resolution");
             return null;
         }
@@ -167,7 +167,7 @@ class HdrParser {
 
         // check first scanline width to determine whether the file is RLE
         reader.peekUint8s(rgbe);
-        if ((rgbe[0] != 2 || rgbe[1] != 2 || (rgbe[2] & 0x80) != 0)) {
+        if ((rgbe[0] !== 2 || rgbe[1] !== 2 || (rgbe[2] & 0x80) !== 0)) {
             // not RLE
             return this._readPixelsFlat(reader, width, height);
         }
@@ -183,7 +183,7 @@ class HdrParser {
             reader.readUint8s(rgbe);
 
             // sanity check it
-            if ((rgbe[2] << 8) + rgbe[3] != width) {
+            if ((rgbe[2] << 8) + rgbe[3] !== width) {
                 this._error("radiance has invalid scanline width");
                 return null;
             }

--- a/src/resources/script.js
+++ b/src/resources/script.js
@@ -95,7 +95,7 @@ class ScriptHandler {
 
         var done = false;
         element.onload = element.onreadystatechange = function () {
-            if (!done && (!this.readyState || (this.readyState == "loaded" || this.readyState == "complete"))) {
+            if (!done && (!this.readyState || (this.readyState === "loaded" || this.readyState === "complete"))) {
                 done = true; // prevent double event firing
                 callback(null, url, element);
             }

--- a/src/resources/untar.js
+++ b/src/resources/untar.js
@@ -29,7 +29,7 @@ function UntarScope(isWorker) {
         while (bytesRead < length) {
             var spaceIndex;
             for (spaceIndex = bytesRead; spaceIndex < length; spaceIndex++) {
-                if (paxArray[spaceIndex] == 0x20)
+                if (paxArray[spaceIndex] === 0x20)
                     break;
             }
 

--- a/src/scene/batching/batch-manager.js
+++ b/src/scene/batching/batch-manager.js
@@ -582,13 +582,13 @@ class BatchManager {
                 }
                 // Split stencil mask (UI elements), both front and back expected to be the same
                 if (stencil) {
-                    if (!(sf = mi.stencilFront) || stencil.func != sf.func || stencil.zpass != sf.zpass) {
+                    if (!(sf = mi.stencilFront) || stencil.func !== sf.func || stencil.zpass !== sf.zpass) {
                         skipMesh(mi);
                         continue;
                     }
                 }
                 // Split by negative scale
-                if (scaleSign != getScaleSign(mi)) {
+                if (scaleSign !== getScaleSign(mi)) {
                     skipMesh(mi);
                     continue;
                 }
@@ -670,7 +670,7 @@ class BatchManager {
 
                 // index counts (handles special case of TRI-FAN-type non-indexed primitive used by UI)
                 batchNumIndices += mesh.primitive[0].indexed ? mesh.primitive[0].count :
-                    (mesh.primitive[0].type == PRIMITIVE_TRIFAN && mesh.primitive[0].count === 4 ? 6 : 0);
+                    (mesh.primitive[0].type === PRIMITIVE_TRIFAN && mesh.primitive[0].count === 4 ? 6 : 0);
 
                 // if first mesh
                 if (!streams) {
@@ -792,7 +792,7 @@ class BatchManager {
                     // source index buffer data mapped to its format
                     var srcFormat = mesh.indexBuffer[0].getFormat();
                     indexData = new typedArrayIndexFormats[srcFormat](mesh.indexBuffer[0].storage);
-                } else if (mesh.primitive[0].type == PRIMITIVE_TRIFAN && mesh.primitive[0].count === 4) {
+                } else if (mesh.primitive[0].type === PRIMITIVE_TRIFAN && mesh.primitive[0].count === 4) {
                     // Special case for UI image elements
                     indexBase = 0;
                     numIndices = 6;

--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -492,7 +492,7 @@ class GraphNode extends EventHandler {
             // check all the children
             var children = currentParent._children;
             for (var j = 0, jmax = children.length; j < jmax; j++) {
-                if (children[j].name == part) {
+                if (children[j].name === part) {
                     result = children[j];
                     break;
                 }

--- a/src/scene/materials/standard-material-options-builder.js
+++ b/src/scene/materials/standard-material-options-builder.js
@@ -315,19 +315,19 @@ StandardMaterialOptionsBuilder.prototype._getMapTransformID = function (xform, u
     var i, same;
     for (i = 0; i < this._mapXForms[uv].length; i++) {
         same = true;
-        if (this._mapXForms[uv][i][0] != xform.x) {
+        if (this._mapXForms[uv][i][0] !== xform.x) {
             same = false;
             break;
         }
-        if (this._mapXForms[uv][i][1] != xform.y) {
+        if (this._mapXForms[uv][i][1] !== xform.y) {
             same = false;
             break;
         }
-        if (this._mapXForms[uv][i][2] != xform.z) {
+        if (this._mapXForms[uv][i][2] !== xform.z) {
             same = false;
             break;
         }
-        if (this._mapXForms[uv][i][3] != xform.w) {
+        if (this._mapXForms[uv][i][3] !== xform.w) {
             same = false;
             break;
         }

--- a/src/scene/mesh.js
+++ b/src/scene/mesh.js
@@ -644,7 +644,7 @@ class Mesh extends RefCountedObject {
                 // find vec3 position stream
                 var stream = this._geometryData.vertexStreamDictionary[SEMANTIC_POSITION];
                 if (stream) {
-                    if (stream.componentCount == 3) {
+                    if (stream.componentCount === 3) {
                         this._aabb.compute(stream.data, this._geometryData.vertexCount);
                     }
                 }

--- a/src/scene/particle-system/cpu-updater.js
+++ b/src/scene/particle-system/cpu-updater.js
@@ -92,9 +92,9 @@ class ParticleCPUUpdater {
             var edgeX = max + (0.5 - max) * extentsInnerRatioUniform[0];
             var edgeY = max + (0.5 - max) * extentsInnerRatioUniform[1];
             var edgeZ = max + (0.5 - max) * extentsInnerRatioUniform[2];
-            randomPos.x = edgeX * (max == Math.abs(randomPos.x) ? Math.sign(randomPos.x) : 2 * randomPos.x);
-            randomPos.y = edgeY * (max == Math.abs(randomPos.y) ? Math.sign(randomPos.y) : 2 * randomPos.y);
-            randomPos.z = edgeZ * (max == Math.abs(randomPos.z) ? Math.sign(randomPos.z) : 2 * randomPos.z);
+            randomPos.x = edgeX * (max === Math.abs(randomPos.x) ? Math.sign(randomPos.x) : 2 * randomPos.x);
+            randomPos.y = edgeY * (max === Math.abs(randomPos.y) ? Math.sign(randomPos.y) : 2 * randomPos.y);
+            randomPos.z = edgeZ * (max === Math.abs(randomPos.z) ? Math.sign(randomPos.z) : 2 * randomPos.z);
 
             if (!emitter.localSpace)
                 randomPosTformed.copy(emitterPos).add(spawnMatrix.transformPoint(randomPos));

--- a/src/scene/particle-system/particle-emitter.js
+++ b/src/scene/particle-system/particle-emitter.js
@@ -628,9 +628,9 @@ class ParticleEmitter {
             } else {
                 spawnMatrix.setTRS(Vec3.ZERO, this.node.getRotation(), tmpVec3.copy(this.spawnBounds).mul(this.node.localScale));
             }
-            extentsInnerRatioUniform[0] = this.emitterExtents.x != 0 ? this.emitterExtentsInner.x / this.emitterExtents.x : 0;
-            extentsInnerRatioUniform[1] = this.emitterExtents.y != 0 ? this.emitterExtentsInner.y / this.emitterExtents.y : 0;
-            extentsInnerRatioUniform[2] = this.emitterExtents.z != 0 ? this.emitterExtentsInner.z / this.emitterExtents.z : 0;
+            extentsInnerRatioUniform[0] = this.emitterExtents.x !== 0 ? this.emitterExtentsInner.x / this.emitterExtents.x : 0;
+            extentsInnerRatioUniform[1] = this.emitterExtents.y !== 0 ? this.emitterExtentsInner.y / this.emitterExtents.y : 0;
+            extentsInnerRatioUniform[2] = this.emitterExtents.z !== 0 ? this.emitterExtentsInner.z / this.emitterExtents.z : 0;
         }
         for (i = 0; i < this.numParticles; i++) {
             this._cpuUpdater.calcSpawnPosition(this.particleTex, spawnMatrix, extentsInnerRatioUniform, emitterPos, i);
@@ -842,7 +842,7 @@ class ParticleEmitter {
             // so wrong shader is being compiled.
             // To fix it, we need to check activeCamera!=emitter.camera in shader init too
             if (this.emitter.scene) {
-                if (this.emitter.camera != this.emitter.scene._activeCamera) {
+                if (this.emitter.camera !== this.emitter.scene._activeCamera) {
                     this.emitter.camera = this.emitter.scene._activeCamera;
                     this.emitter.onChangeCamera();
                 }
@@ -872,7 +872,7 @@ class ParticleEmitter {
                 animTex: this.emitter._isAnimated(),
                 animTexLoop: this.emitter.animLoop,
                 pack8: this.emitter.pack8,
-                customFace: this.emitter.orientation != PARTICLEORIENTATION_SCREEN
+                customFace: this.emitter.orientation !== PARTICLEORIENTATION_SCREEN
             });
             this.shader = shader;
         };
@@ -943,12 +943,12 @@ class ParticleEmitter {
 
     _compParticleFaceParams() {
         var tangent, binormal;
-        if (this.orientation == PARTICLEORIENTATION_SCREEN) {
+        if (this.orientation === PARTICLEORIENTATION_SCREEN) {
             tangent = new Float32Array([1, 0, 0]);
             binormal = new Float32Array([0, 0, 1]);
         } else {
             var n;
-            if (this.orientation == PARTICLEORIENTATION_WORLD) {
+            if (this.orientation === PARTICLEORIENTATION_WORLD) {
                 n = this.particleNormal.normalize();
             } else {
                 var emitterMat = this.node === null ?
@@ -956,7 +956,7 @@ class ParticleEmitter {
                 n = emitterMat.transformVector(this.particleNormal).normalize();
             }
             var t = new Vec3(1, 0, 0);
-            if (Math.abs(t.dot(n)) == 1)
+            if (Math.abs(t.dot(n)) === 1)
                 t.set(0, 0, 1);
             var b = new Vec3().cross(n, t).normalize();
             t.cross(b, n).normalize();
@@ -1157,16 +1157,16 @@ class ParticleEmitter {
         }
 
         if (this.scene) {
-            if (this.camera != this.scene._activeCamera) {
+            if (this.camera !== this.scene._activeCamera) {
                 this.camera = this.scene._activeCamera;
                 this.onChangeCamera();
             }
         }
 
         if (this.emitterShape === EMITTERSHAPE_BOX) {
-            extentsInnerRatioUniform[0] = this.emitterExtents.x != 0 ? this.emitterExtentsInner.x / this.emitterExtents.x : 0;
-            extentsInnerRatioUniform[1] = this.emitterExtents.y != 0 ? this.emitterExtentsInner.y / this.emitterExtents.y : 0;
-            extentsInnerRatioUniform[2] = this.emitterExtents.z != 0 ? this.emitterExtentsInner.z / this.emitterExtents.z : 0;
+            extentsInnerRatioUniform[0] = this.emitterExtents.x !== 0 ? this.emitterExtentsInner.x / this.emitterExtents.x : 0;
+            extentsInnerRatioUniform[1] = this.emitterExtents.y !== 0 ? this.emitterExtentsInner.y / this.emitterExtents.y : 0;
+            extentsInnerRatioUniform[2] = this.emitterExtents.z !== 0 ? this.emitterExtentsInner.z / this.emitterExtents.z : 0;
             if (this.meshInstance.node === null) {
                 spawnMatrix.setTRS(Vec3.ZERO, Quat.IDENTITY, this.emitterExtents);
             } else {

--- a/src/scene/procedural.js
+++ b/src/scene/procedural.js
@@ -148,8 +148,8 @@ function calculateTangents(positions, normals, uvs, indices) {
 
         area = s1 * t2 - s2 * t1;
 
-        // Area can 0.0 for degenerate triangles or bad uv coordinates
-        if (area == 0.0) {
+        // Area can be 0 for degenerate triangles or bad uv coordinates
+        if (area === 0) {
             // Fallback to default values
             sdir.set(0.0, 1.0, 0.0);
             tdir.set(1.0, 0.0, 0.0);

--- a/src/scene/skin-partition.js
+++ b/src/scene/skin-partition.js
@@ -63,7 +63,7 @@ class SkinPartition {
                     var boneIndex = vertexArray.blendIndices.data[idx * 4 + influence];
                     var needToAdd = true;
                     for (j = 0; j < bonesToAddCount; j++) {
-                        if (bonesToAdd[j] == boneIndex) {
+                        if (bonesToAdd[j] === boneIndex) {
                             needToAdd = false;
                             break;
                         }


### PR DESCRIPTION
According to [ESLint](https://eslint.org/docs/rules/eqeqeq):

> It is considered good practice to use the type-safe equality operators === and !== instead of their regular counterparts == and !=.
>
> The reason for this is that == and != do type coercion which follows the rather obscure Abstract Equality Comparison Algorithm. For instance, the following statements are all considered true:
>
> [] == false
> [] == ![]
> 3 == "03"
>
>If one of those occurs in an innocent-looking statement such as a == b the actual problem is very difficult to spot.

This PR does not apply this principle to all occurrences of `==` and `!=`. It leaves those testing against `null`, where sometimes the use was intentional. I still believe those should be reworked, but for now, this PR just deals with the 'safe' instances.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
