### PR TITLE
Migrate resources codebase to let and const

### DIFF
--- a/src/resources/anim-clip.js
+++ b/src/resources/anim-clip.js
@@ -25,7 +25,7 @@ class AnimClipHandler {
         }
 
         // we need to specify JSON for blob URLs
-        var options = {
+        const options = {
             retry: this.maxRetries > 0,
             maxRetries: this.maxRetries
         };
@@ -44,15 +44,15 @@ class AnimClipHandler {
     }
 
     open(url, data) {
-        var name = data.name;
-        var duration = data.duration;
-        var inputs = data.inputs.map(function (input) {
+        const name = data.name;
+        const duration = data.duration;
+        const inputs = data.inputs.map(function (input) {
             return new AnimData(1, input);
         });
-        var outputs = data.outputs.map(function (output) {
+        const outputs = data.outputs.map(function (output) {
             return new AnimData(output.components, output.data);
         });
-        var curves = data.curves.map(function (curve) {
+        const curves = data.curves.map(function (curve) {
             return new AnimCurve(
                 [curve.path],
                 curve.inputIndex,

--- a/src/resources/anim-state-graph.js
+++ b/src/resources/anim-state-graph.js
@@ -22,7 +22,7 @@ class AnimStateGraphHandler {
         }
 
         // we need to specify JSON for blob URLs
-        var options = {
+        const options = {
             retry: this.maxRetries > 0,
             maxRetries: this.maxRetries
         };

--- a/src/resources/animation.js
+++ b/src/resources/animation.js
@@ -29,7 +29,7 @@ class AnimationHandler {
         }
 
         // we need to specify JSON for blob URLs
-        var options = {
+        const options = {
             retry: this.maxRetries > 0,
             maxRetries: this.maxRetries
         };
@@ -53,7 +53,7 @@ class AnimationHandler {
 
     open(url, data) {
         if (path.getExtension(url).toLowerCase() === '.glb') {
-            var glb = GlbParser.parse("filename.glb", data, null);
+            const glb = GlbParser.parse("filename.glb", data, null);
             if (!glb) {
                 return null;
             }
@@ -63,30 +63,30 @@ class AnimationHandler {
     }
 
     _parseAnimationV3(data) {
-        var animData = data.animation;
+        const animData = data.animation;
 
-        var anim = new Animation();
+        const anim = new Animation();
         anim.name = animData.name;
         anim.duration = animData.duration;
 
-        for (var i = 0; i < animData.nodes.length; i++) {
-            var node = new Node();
+        for (let i = 0; i < animData.nodes.length; i++) {
+            const node = new Node();
 
-            var n = animData.nodes[i];
+            const n = animData.nodes[i];
             node._name = n.name;
 
-            for (var j = 0; j < n.keys.length; j++) {
-                var k = n.keys[j];
+            for (let j = 0; j < n.keys.length; j++) {
+                const k = n.keys[j];
 
-                var t = k.time;
-                var p = k.pos;
-                var r = k.rot;
-                var s = k.scale;
-                var pos = new Vec3(p[0], p[1], p[2]);
-                var rot = new Quat().setFromEulerAngles(r[0], r[1], r[2]);
-                var scl = new Vec3(s[0], s[1], s[2]);
+                const t = k.time;
+                const p = k.pos;
+                const r = k.rot;
+                const s = k.scale;
+                const pos = new Vec3(p[0], p[1], p[2]);
+                const rot = new Quat().setFromEulerAngles(r[0], r[1], r[2]);
+                const scl = new Vec3(s[0], s[1], s[2]);
 
-                var key = new Key(t, pos, rot, scl);
+                const key = new Key(t, pos, rot, scl);
 
                 node._keys.push(key);
             }
@@ -98,34 +98,34 @@ class AnimationHandler {
     }
 
     _parseAnimationV4(data) {
-        var animData = data.animation;
+        const animData = data.animation;
 
-        var anim = new Animation();
+        const anim = new Animation();
         anim.name = animData.name;
         anim.duration = animData.duration;
 
-        for (var i = 0; i < animData.nodes.length; i++) {
-            var node = new Node();
+        for (let i = 0; i < animData.nodes.length; i++) {
+            const node = new Node();
 
-            var n = animData.nodes[i];
+            const n = animData.nodes[i];
             node._name = n.name;
 
-            var defPos = n.defaults.p;
-            var defRot = n.defaults.r;
-            var defScl = n.defaults.s;
+            const defPos = n.defaults.p;
+            const defRot = n.defaults.r;
+            const defScl = n.defaults.s;
 
-            for (var j = 0; j < n.keys.length; j++) {
-                var k = n.keys[j];
+            for (let j = 0; j < n.keys.length; j++) {
+                const k = n.keys[j];
 
-                var t = k.t;
-                var p = defPos ? defPos : k.p;
-                var r = defRot ? defRot : k.r;
-                var s = defScl ? defScl : k.s;
-                var pos = new Vec3(p[0], p[1], p[2]);
-                var rot = new Quat().setFromEulerAngles(r[0], r[1], r[2]);
-                var scl = new Vec3(s[0], s[1], s[2]);
+                const t = k.t;
+                const p = defPos ? defPos : k.p;
+                const r = defRot ? defRot : k.r;
+                const s = defScl ? defScl : k.s;
+                const pos = new Vec3(p[0], p[1], p[2]);
+                const rot = new Quat().setFromEulerAngles(r[0], r[1], r[2]);
+                const scl = new Vec3(s[0], s[1], s[2]);
 
-                var key = new Key(t, pos, rot, scl);
+                const key = new Key(t, pos, rot, scl);
 
                 node._keys.push(key);
             }

--- a/src/resources/audio.js
+++ b/src/resources/audio.js
@@ -7,23 +7,23 @@ import { hasAudioContext } from '../audio/capabilities.js';
 import { Sound } from '../sound/sound.js';
 
 // checks if user is running IE
-var ie = (function () {
+const ie = (function () {
     if (typeof window === 'undefined') {
         // Node.js => return false
         return false;
     }
-    var ua = window.navigator.userAgent;
+    const ua = window.navigator.userAgent;
 
-    var msie = ua.indexOf('MSIE ');
+    const msie = ua.indexOf('MSIE ');
     if (msie > 0) {
         // IE 10 or older => return version number
         return parseInt(ua.substring(msie + 5, ua.indexOf('.', msie)), 10);
     }
 
-    var trident = ua.indexOf('Trident/');
+    const trident = ua.indexOf('Trident/');
     if (trident > 0) {
         // IE 11 => return version number
-        var rv = ua.indexOf('rv:');
+        const rv = ua.indexOf('rv:');
         return parseInt(ua.substring(rv + 3, ua.indexOf('.', rv)), 10);
     }
 
@@ -54,7 +54,7 @@ class AudioHandler {
     }
 
     _isSupported(url) {
-        var ext = path.getExtension(url);
+        const ext = path.getExtension(url);
 
         if (toMIME[ext]) {
             return true;
@@ -70,12 +70,12 @@ class AudioHandler {
             };
         }
 
-        var success = function (resource) {
+        const success = function (resource) {
             callback(null, new Sound(resource));
         };
 
-        var error = function (err) {
-            var msg = 'Error loading audio url: ' + url.original;
+        const error = function (err) {
+            let msg = 'Error loading audio url: ' + url.original;
             if (err) {
                 msg += ': ' + (err.message || err);
             }
@@ -111,7 +111,7 @@ class AudioHandler {
      */
     _createSound(url, success, error) {
         if (hasAudioContext()) {
-            var manager = this.manager;
+            const manager = this.manager;
 
             if (!manager.context) {
                 error('Audio manager has no audio context');
@@ -119,7 +119,7 @@ class AudioHandler {
             }
 
             // if this is a blob URL we need to set the response type to arraybuffer
-            var options = {
+            const options = {
                 retry: this.maxRetries > 0,
                 maxRetries: this.maxRetries
             };
@@ -137,7 +137,7 @@ class AudioHandler {
                 manager.context.decodeAudioData(response, success, error);
             });
         } else {
-            var audio = null;
+            let audio = null;
 
             try {
                 audio = new Audio();
@@ -153,7 +153,7 @@ class AudioHandler {
                 document.body.appendChild(audio);
             }
 
-            var onReady = function () {
+            const onReady = function () {
                 audio.removeEventListener('canplaythrough', onReady);
 
                 // remove from DOM no longer necessary

--- a/src/resources/basis.js
+++ b/src/resources/basis.js
@@ -9,7 +9,7 @@ function BasisWorker() {
 
     // Basis compression format enums
     // Note: these must match definitions in the BASIS module
-    var BASIS_FORMAT = {
+    const BASIS_FORMAT = {
         cTFETC1: 0,                         // etc1
         cTFETC2: 1,                         // etc2
         cTFBC1: 2,                          // dxt1
@@ -26,7 +26,7 @@ function BasisWorker() {
     };
 
     // Map GPU to basis format for textures without alpha
-    var opaqueMapping = {
+    const opaqueMapping = {
         astc: BASIS_FORMAT.cTFASTC_4x4,
         dxt: BASIS_FORMAT.cTFBC1,
         etc2: BASIS_FORMAT.cTFETC1,
@@ -37,7 +37,7 @@ function BasisWorker() {
     };
 
     // Map GPU to basis format for textures with alpha
-    var alphaMapping = {
+    const alphaMapping = {
         astc: BASIS_FORMAT.cTFASTC_4x4,
         dxt: BASIS_FORMAT.cTFBC3,
         etc2: BASIS_FORMAT.cTFETC2,
@@ -48,7 +48,7 @@ function BasisWorker() {
     };
 
     // Map basis format to engine pixel format
-    var basisToEngineMapping = { };
+    const basisToEngineMapping = { };
     // Note that we don't specify the enum constants directly because they're not
     // available in the worker. And if they are specified in the worker code string,
     // they unfortunately get mangled by Terser on minification. So let's write in
@@ -66,21 +66,21 @@ function BasisWorker() {
     basisToEngineMapping[BASIS_FORMAT.cTFRGB565]        = 3;  // PIXELFORMAT_R5_G6_B5
     basisToEngineMapping[BASIS_FORMAT.cTFRGBA4444]      = 5;  // PIXELFORMAT_R4_G4_B4_A4
 
-    var hasPerformance = typeof performance !== 'undefined';
+    const hasPerformance = typeof performance !== 'undefined';
 
     // unswizzle two-component gggr8888 normal data into rgba8888
-    var unswizzleGGGR = function (data) {
+    const unswizzleGGGR = function (data) {
         // given R and G generate B
-        var genB = function (R, G) {
-            var r = R * (2.0 / 255.0) - 1.0;
-            var g = G * (2.0 / 255.0) - 1.0;
-            var b = Math.sqrt(1.0 - Math.min(1.0, r * r + g * g));
+        const genB = function (R, G) {
+            const r = R * (2.0 / 255.0) - 1.0;
+            const g = G * (2.0 / 255.0) - 1.0;
+            const b = Math.sqrt(1.0 - Math.min(1.0, r * r + g * g));
             return Math.max(0, Math.min(255, Math.floor(((b + 1.0) * 0.5) * 255.0)));
         };
 
-        for (var offset = 0; offset < data.length; offset += 4) {
-            var R = data[offset + 3];
-            var G = data[offset + 1];
+        for (let offset = 0; offset < data.length; offset += 4) {
+            const R = data[offset + 3];
+            const G = data[offset + 1];
             data[offset + 0] = R;
             data[offset + 2] = genB(R, G);
             data[offset + 3] = 255;
@@ -90,13 +90,13 @@ function BasisWorker() {
     };
 
     // pack rgba8888 data into rgb565
-    var pack565 = function (data) {
-        var result = new Uint16Array(data.length / 4);
+    const pack565 = function (data) {
+        const result = new Uint16Array(data.length / 4);
 
-        for (var offset = 0; offset < data.length; offset += 4) {
-            var R = data[offset + 0];
-            var G = data[offset + 1];
-            var B = data[offset + 2];
+        for (let offset = 0; offset < data.length; offset += 4) {
+            const R = data[offset + 0];
+            const G = data[offset + 1];
+            const B = data[offset + 2];
             result[offset / 4] = ((R & 0xf8) << 8) |  // 5
                                  ((G & 0xfc) << 3) |  // 6
                                  ((B >> 3));          // 5
@@ -106,15 +106,15 @@ function BasisWorker() {
     };
 
     // transcode the basis super-compressed data into one of the runtime gpu native formats
-    var transcode = function (basis, url, format, data, options) {
-        var funcStart = hasPerformance ? performance.now() : 0;
-        var basisFile = new basis.BasisFile(new Uint8Array(data));
+    const transcode = function (basis, url, format, data, options) {
+        const funcStart = hasPerformance ? performance.now() : 0;
+        const basisFile = new basis.BasisFile(new Uint8Array(data));
 
-        var width = basisFile.getImageWidth(0, 0);
-        var height = basisFile.getImageHeight(0, 0);
-        var images = basisFile.getNumImages();
-        var levels = basisFile.getNumLevels(0);
-        var hasAlpha = !!basisFile.getHasAlpha();
+        const width = basisFile.getImageWidth(0, 0);
+        const height = basisFile.getImageHeight(0, 0);
+        const images = basisFile.getNumImages();
+        const levels = basisFile.getNumLevels(0);
+        const hasAlpha = !!basisFile.getHasAlpha();
 
         if (!width || !height || !images || !levels) {
             basisFile.close();
@@ -123,7 +123,7 @@ function BasisWorker() {
         }
 
         // select format based on supported formats
-        var basisFormat = hasAlpha ? alphaMapping[format] : opaqueMapping[format];
+        let basisFormat = hasAlpha ? alphaMapping[format] : opaqueMapping[format];
 
         // PVR does not support non-square or non-pot textures. In these cases we
         // transcode to an uncompressed format.
@@ -147,12 +147,12 @@ function BasisWorker() {
             throw new Error('Failed to start transcoding url=' + url);
         }
 
-        var i;
+        let i;
 
-        var levelData = [];
-        for (var mip = 0; mip < levels; ++mip) {
-            var dstSize = basisFile.getImageTranscodedSizeInBytes(0, mip, basisFormat);
-            var dst = new Uint8Array(dstSize);
+        const levelData = [];
+        for (let mip = 0; mip < levels; ++mip) {
+            const dstSize = basisFile.getImageTranscodedSizeInBytes(0, mip, basisFormat);
+            let dst = new Uint8Array(dstSize);
 
             if (!basisFile.transcodeImage(dst, 0, mip, basisFormat, 1, 0)) {
                 basisFile.close();
@@ -162,7 +162,7 @@ function BasisWorker() {
 
             if (basisFormat === BASIS_FORMAT.cTFRGB565 || basisFormat === BASIS_FORMAT.cTFRGBA4444) {
                 // 16 bit formats require Uint16 typed array
-                var dst16 = new Uint16Array(dstSize / 2);
+                const dst16 = new Uint16Array(dstSize / 2);
                 for (i = 0; i < dstSize / 2; ++i) {
                     dst16[i] = dst[i * 2] + dst[i * 2 + 1] * 256;
                 }
@@ -195,15 +195,15 @@ function BasisWorker() {
         };
     };
 
-    var basis = null;
-    var queue = [];
+    let basis = null;
+    let queue = [];
 
     // download and transcode the file given the basis module and
     // file url
-    var workerTranscode = function (url, format, data, options) {
+    const workerTranscode = function (url, format, data, options) {
         try {
             // texture data has been provided
-            var result = transcode(basis, url, format, data, options);
+            const result = transcode(basis, url, format, data, options);
             result.levels = result.levels.map(function (v) {
                 return v.buffer;
             });
@@ -215,8 +215,8 @@ function BasisWorker() {
 
     // Initialize the web worker's BASIS interface.
     // basisModule is the optional wasm binary.
-    var workerInit = function (basisModule) {
-        var instantiateWasmFunc = function (imports, successCallback) {
+    const workerInit = function (basisModule) {
+        const instantiateWasmFunc = function (imports, successCallback) {
             WebAssembly.instantiate(basisModule, imports)
                 .then(function (result) {
                     successCallback(result);
@@ -227,7 +227,7 @@ function BasisWorker() {
         self.BASIS(basisModule ? { instantiateWasm: instantiateWasmFunc } : null).then(function (instance) {
             basis = instance;
             basis.initializeBasis();
-            for (var i = 0; i < queue.length; ++i) {
+            for (let i = 0; i < queue.length; ++i) {
                 workerTranscode(queue[i].url, queue[i].format, queue[i].data, queue[i].options);
             }
             queue = [];
@@ -236,7 +236,7 @@ function BasisWorker() {
 
     // handle incoming worker requests
     self.onmessage = function (message) {
-        var data = message.data;
+        const data = message.data;
         switch (data.type) {
             case 'init':
                 workerInit(data.module);
@@ -253,10 +253,10 @@ function BasisWorker() {
 }
 
 // check for wasm module support
-var wasmSupported = (function () {
+const wasmSupported = (function () {
     try {
         if (typeof WebAssembly === "object" && typeof WebAssembly.instantiate === "function") {
-            var module = new WebAssembly.Module(Uint8Array.of(0x0, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00));
+            const module = new WebAssembly.Module(Uint8Array.of(0x0, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00));
             if (module instanceof WebAssembly.Module)
                 return new WebAssembly.Instance(module) instanceof WebAssembly.Instance;
         }
@@ -283,12 +283,13 @@ function chooseTargetFormat(device) {
 }
 
 // global state
-var downloadInitiated = false;
-var worker = null;
-var callbacks = { };
-var format = null;
-var transcodeQueue = [];
-var downloadConfig = null;
+let downloadInitiated = false;
+let downloadConfig = null;
+let worker = null;
+let format = null;
+
+const callbacks = { };
+const transcodeQueue = [];
 
 function basisTargetFormat() {
     if (!format) {
@@ -298,17 +299,17 @@ function basisTargetFormat() {
 }
 
 function handleWorkerResponse(message) {
-    var url = message.data.url;
-    var err = message.data.err;
-    var data = message.data.data;
-    var callback = callbacks[url];
+    const url = message.data.url;
+    const err = message.data.err;
+    const data = message.data.data;
+    const callback = callbacks[url];
 
     if (!callback) {
         console.error('internal logical error encountered in basis transcoder');
         return;
     }
 
-    var i;
+    let i;
     if (err) {
         for (i = 0; i < callback.length; ++i) {
             (callback[i])(err);
@@ -353,15 +354,15 @@ function transcode(url, data, callback, options) {
 // initialize the basis worker given the basis module script (glue or fallback)
 // and the optional accompanying wasm binary.
 function basisInitialize(basisCode, basisModule, callback) {
-    var code = [
+    const code = [
         "/* basis.js */",
         basisCode,
         "",
         "/* worker */",
         '(' + BasisWorker.toString() + ')()\n\n'
     ].join('\n');
-    var blob = new Blob([code], { type: 'application/javascript' });
-    var url = URL.createObjectURL(blob);
+    const blob = new Blob([code], { type: 'application/javascript' });
+    const url = URL.createObjectURL(blob);
     worker = new Worker(url);
     worker.addEventListener('message', handleWorkerResponse);
     worker.postMessage({ type: 'init', module: basisModule });
@@ -369,8 +370,8 @@ function basisInitialize(basisCode, basisModule, callback) {
         callback();
     }
     // module is initialized, initiate queued jobs
-    for (var i = 0; i < transcodeQueue.length; ++i) {
-        var entry = transcodeQueue[i];
+    for (let i = 0; i < transcodeQueue.length; ++i) {
+        const entry = transcodeQueue[i];
         transcode(entry.url, entry.data, entry.callback, entry.options);
     }
 }
@@ -382,10 +383,10 @@ function basisDownload(glueUrl, wasmUrl, fallbackUrl, callback) {
     }
     downloadInitiated = true;
     if (wasmSupported) {
-        var glueCode = null;
-        var compiledModule = null;
+        let glueCode = null;
+        let compiledModule = null;
 
-        var downloadCompleted = function () {
+        const downloadCompleted = function () {
             if (glueCode && compiledModule) {
                 basisInitialize(glueCode, compiledModule, callback);
             }
@@ -393,7 +394,7 @@ function basisDownload(glueUrl, wasmUrl, fallbackUrl, callback) {
 
         // perform the fallback http download if compileStreaming isn't
         // available or fails
-        var performHttpDownload = function () {
+        const performHttpDownload = function () {
             http.get(
                 wasmUrl,
                 { cache: true, responseType: "arraybuffer", retry: false },
@@ -466,12 +467,12 @@ function basisDownloadFromConfig(callback) {
                       callback);
     } else {
         // get config from global PC config structure
-        var modules = (window.config ? window.config.wasmModules : window.PRELOAD_MODULES) || [];
-        var wasmModule = modules.find(function (m) {
+        const modules = (window.config ? window.config.wasmModules : window.PRELOAD_MODULES) || [];
+        const wasmModule = modules.find(function (m) {
             return m.moduleName === 'BASIS';
         });
         if (wasmModule) {
-            var urlBase = window.ASSET_PREFIX ? window.ASSET_PREFIX : "";
+            const urlBase = window.ASSET_PREFIX ? window.ASSET_PREFIX : "";
             basisDownload(urlBase + wasmModule.glueUrl,
                           urlBase + wasmModule.wasmUrl,
                           urlBase + wasmModule.fallbackUrl,

--- a/src/resources/bundle.js
+++ b/src/resources/bundle.js
@@ -29,7 +29,7 @@ class BundleHandler {
             };
         }
 
-        var self = this;
+        const self = this;
 
         http.get(url.load, {
             responseType: Http.ResponseType.ARRAY_BUFFER,
@@ -49,7 +49,7 @@ class BundleHandler {
     }
 
     _untar(response, callback) {
-        var self = this;
+        const self = this;
 
         // use web workers if available otherwise
         // fallback to untar'ing in the main thread
@@ -70,8 +70,8 @@ class BundleHandler {
                 }
             });
         } else {
-            var archive = new Untar(response);
-            var files = archive.untar(self._assets.prefix);
+            const archive = new Untar(response);
+            const files = archive.untar(self._assets.prefix);
             callback(null, files);
         }
     }

--- a/src/resources/container.js
+++ b/src/resources/container.js
@@ -45,7 +45,7 @@ class ContainerResource {
      * });
      */
     instantiateModelEntity(options) {
-        var entity = new Entity();
+        const entity = new Entity();
         entity.addComponent("model", Object.assign({ type: "asset", asset: this.model }, options));
         return entity;
     }
@@ -67,20 +67,20 @@ class ContainerResource {
      */
     instantiateRenderEntity(options) {
         // helper function to recursively clone a hierarchy while converting ModelComponent to RenderComponents
-        var cloneToEntity = function (skinInstances, model, node) {
+        const cloneToEntity = function (skinInstances, model, node) {
 
             if (node) {
-                var entity = new Entity();
+                const entity = new Entity();
                 node._cloneInternal(entity);
 
                 // find all mesh instances attached to this node
-                var attachedMi = null;
-                for (var m = 0; m < model.meshInstances.length; m++) {
-                    var mi = model.meshInstances[m];
+                let attachedMi = null;
+                for (let m = 0; m < model.meshInstances.length; m++) {
+                    const mi = model.meshInstances[m];
                     if (mi.node === node) {
 
                         // clone mesh instance
-                        var cloneMi = new MeshInstance(mi.mesh, mi.material, entity);
+                        const cloneMi = new MeshInstance(mi.mesh, mi.material, entity);
 
                         // clone morph instance
                         if (mi.morphInstance) {
@@ -110,9 +110,9 @@ class ContainerResource {
                 }
 
                 // recursivelly clone children
-                var children = node.children;
-                for (var i = 0; i < children.length; i++) {
-                    var childClone = cloneToEntity(skinInstances, model, children[i]);
+                const children = node.children;
+                for (let i = 0; i < children.length; i++) {
+                    const childClone = cloneToEntity(skinInstances, model, children[i]);
                     entity.addChild(childClone);
                 }
 
@@ -123,22 +123,22 @@ class ContainerResource {
         };
 
         // clone GraphNode hierarchy from model to Entity hierarchy
-        var skinInstances = [];
-        var entity = cloneToEntity(skinInstances, this.model.resource, this.model.resource.graph);
+        const skinInstances = [];
+        const entity = cloneToEntity(skinInstances, this.model.resource, this.model.resource.graph);
 
         // clone skin instances - now that all entities (bones) are created
-        for (var i = 0; i < skinInstances.length; i++) {
-            var srcSkinInstance = skinInstances[i].src;
-            var dstMeshInstance = skinInstances[i].dst;
+        for (let i = 0; i < skinInstances.length; i++) {
+            const srcSkinInstance = skinInstances[i].src;
+            const dstMeshInstance = skinInstances[i].dst;
 
-            var skin = srcSkinInstance.skin;
-            var cloneSkinInstance = new SkinInstance(skin);
+            const skin = srcSkinInstance.skin;
+            const cloneSkinInstance = new SkinInstance(skin);
 
             // Resolve bone IDs to cloned entities
-            var bones = [];
-            for (var j = 0; j < skin.boneNames.length; j++) {
-                var boneName = skin.boneNames[j];
-                var bone = entity.findByName(boneName);
+            const bones = [];
+            for (let j = 0; j < skin.boneNames.length; j++) {
+                const boneName = skin.boneNames[j];
+                const bone = entity.findByName(boneName);
                 bones.push(bone);
             }
 
@@ -150,14 +150,14 @@ class ContainerResource {
     }
 
     destroy() {
-        var registry = this.registry;
+        const registry = this.registry;
 
-        var destroyAsset = function (asset) {
+        const destroyAsset = function (asset) {
             registry.remove(asset);
             asset.unload();
         };
 
-        var destroyAssets = function (assets) {
+        const destroyAssets = function (assets) {
             assets.forEach(function (asset) {
                 destroyAsset(asset);
             });
@@ -247,16 +247,16 @@ class ContainerHandler {
             };
         }
 
-        var options = {
+        const options = {
             responseType: Http.ResponseType.ARRAY_BUFFER,
             retry: this.maxRetries > 0,
             maxRetries: this.maxRetries
         };
 
-        var self = this;
+        const self = this;
 
         // parse downloaded file data
-        var parseData = function (arrayBuffer) {
+        const parseData = function (arrayBuffer) {
             GlbParser.parseAsync(self._getUrlWithoutParams(url.original),
                                  path.extractPath(url.load),
                                  arrayBuffer,
@@ -297,12 +297,12 @@ class ContainerHandler {
 
     // Create assets to wrap the loaded engine resources - model, materials, textures and animations.
     patch(asset, assets) {
-        var container = asset.resource;
-        var data = container && container.data;
+        const container = asset.resource;
+        const data = container && container.data;
 
         if (data) {
-            var createAsset = function (type, resource, index) {
-                var subAsset = new Asset(asset.name + '/' + type + '/' + index, type, {
+            const createAsset = function (type, resource, index) {
+                const subAsset = new Asset(asset.name + '/' + type + '/' + index, type, {
                     url: ''
                 });
                 subAsset.resource = resource;
@@ -311,25 +311,25 @@ class ContainerHandler {
                 return subAsset;
             };
 
-            var i;
+            let i;
 
             // create model asset
-            var model = createAsset('model', GlbParser.createModel(data, this._defaultMaterial), 0);
+            const model = createAsset('model', GlbParser.createModel(data, this._defaultMaterial), 0);
 
             // render assets
-            var renders = [];
+            const renders = [];
             for (i = 0; i < data.meshes.length; ++i) {
                 renders.push(createAsset('render', data.meshes[i], i));
             }
 
             // create material assets
-            var materials = [];
+            const materials = [];
             for (i = 0; i < data.materials.length; ++i) {
                 materials.push(createAsset('material', data.materials[i], i));
             }
 
             // create animation assets
-            var animations = [];
+            const animations = [];
             for (i = 0; i < data.animations.length; ++i) {
                 animations.push(createAsset('animation', data.animations[i], i));
             }

--- a/src/resources/css.js
+++ b/src/resources/css.js
@@ -45,7 +45,7 @@ class CssHandler {
  * @returns {Element} The style DOM element.
  */
 function createStyle(cssString) {
-    var result = document.createElement('style');
+    const result = document.createElement('style');
     result.type = 'text/css';
     if (result.styleSheet) {
         result.styleSheet.cssText = cssString;

--- a/src/resources/cubemap.js
+++ b/src/resources/cubemap.js
@@ -47,14 +47,14 @@ class CubemapHandler {
 
     // get the list of dependent asset ids for the cubemap
     getAssetIds(cubemapAsset) {
-        var result = [];
+        const result = [];
 
         // prefiltered cubemap is stored at index 0
         result[0] = cubemapAsset.file;
 
         // faces are stored at index 1..6
         if ((cubemapAsset.loadFaces || !cubemapAsset.file) && cubemapAsset.data && cubemapAsset.data.textures) {
-            for (var i = 0; i < 6; ++i) {
+            for (let i = 0; i < 6; ++i) {
                 result[i + 1] = cubemapAsset.data.textures[i];
             }
         } else {
@@ -79,17 +79,17 @@ class CubemapHandler {
 
     // update the cubemap resources given a newly loaded set of assets with their corresponding ids
     update(cubemapAsset, assetIds, assets) {
-        var assetData = cubemapAsset.data || {};
-        var oldAssets = cubemapAsset._handlerState.assets;
-        var oldResources = cubemapAsset._resources;
-        var tex, mip, i;
+        const assetData = cubemapAsset.data || {};
+        const oldAssets = cubemapAsset._handlerState.assets;
+        const oldResources = cubemapAsset._resources;
+        let tex, mip, i;
 
         // faces, prelit cubemap 128, 64, 32, 16, 8, 4
-        var resources = [null, null, null, null, null, null, null];
+        const resources = [null, null, null, null, null, null, null];
 
         // texture type used for faces and prelit cubemaps are both taken from
         // cubemap.data.rgbm
-        var getType = function () {
+        const getType = function () {
             if (assetData.hasOwnProperty('type')) {
                 return assetData.type;
             }
@@ -105,7 +105,7 @@ class CubemapHandler {
             if (assets[0]) {
                 tex = assets[0].resource;
                 for (i = 0; i < 6; ++i) {
-                    var prelitLevels = [tex._levels[i]];
+                    const prelitLevels = [tex._levels[i]];
 
                     // construct full prem chain on highest prefilter cubemap on ios
                     if (i === 0 && this._device.useTexCubeLod) {
@@ -114,7 +114,7 @@ class CubemapHandler {
                         }
                     }
 
-                    var prelit = new Texture(this._device, {
+                    const prelit = new Texture(this._device, {
                         name: cubemapAsset.name + '_prelitCubemap' + (tex.width >> i),
                         cubemap: true,
                         type: getType() || tex.type,
@@ -140,22 +140,22 @@ class CubemapHandler {
             resources[6] = oldResources[6] || null;
         }
 
-        var faceAssets = assets.slice(1);
+        const faceAssets = assets.slice(1);
         if (!cubemapAsset.loaded || !this.cmpArrays(faceAssets, oldAssets.slice(1))) {
             // face assets have changed
             if (faceAssets.indexOf(null) === -1) {
                 // extract cubemap level data from face textures
-                var faceTextures = faceAssets.map(function (asset) {
+                const faceTextures = faceAssets.map(function (asset) {
                     return asset.resource;
                 });
-                var faceLevels = [];
+                const faceLevels = [];
                 for (mip = 0; mip < faceTextures[0]._levels.length; ++mip) {
                     faceLevels.push(faceTextures.map(function (faceTexture) {  // eslint-disable-line no-loop-func
                         return faceTexture._levels[mip];
                     }));
                 }
 
-                var faces = new Texture(this._device, {
+                const faces = new Texture(this._device, {
                     name: cubemapAsset.name + '_faces',
                     cubemap: true,
                     type: getType() || faceTextures[0].type,
@@ -205,7 +205,7 @@ class CubemapHandler {
         if (arr1.length !== arr2.length) {
             return false;
         }
-        for (var i = 0; i < arr1.length; ++i) {
+        for (let i = 0; i < arr1.length; ++i) {
             if (arr1[i] !== arr2[i]) {
                 return false;
             }
@@ -215,7 +215,7 @@ class CubemapHandler {
 
     // convert string id to int
     resolveId(value) {
-        var valueInt = parseInt(value, 10);
+        const valueInt = parseInt(value, 10);
         return ((valueInt === value) || (valueInt.toString() === value)) ? valueInt : value;
     }
 
@@ -230,16 +230,16 @@ class CubemapHandler {
             };
         }
 
-        var self = this;
-        var assetIds = self.getAssetIds(cubemapAsset);
-        var assets = [null, null, null, null, null, null, null];
-        var loadedAssetIds = cubemapAsset._handlerState.assetIds;
-        var loadedAssets = cubemapAsset._handlerState.assets;
-        var registry = self._registry;
+        const self = this;
+        const assetIds = self.getAssetIds(cubemapAsset);
+        const assets = [null, null, null, null, null, null, null];
+        const loadedAssetIds = cubemapAsset._handlerState.assetIds;
+        const loadedAssets = cubemapAsset._handlerState.assets;
+        const registry = self._registry;
 
         // one of the dependent assets has finished loading
-        var awaiting = 7;
-        var onReady = function (index, asset) {
+        let awaiting = 7;
+        const onReady = function (index, asset) {
             assets[index] = asset;
             awaiting--;
 
@@ -253,8 +253,8 @@ class CubemapHandler {
         // handle a texture asset finished loading.
         // the engine is unable to flip ImageBitmaps (to orient them correctly for cubemaps)
         // so we do that here.
-        var onLoad = function (index, asset) {
-            var level0 = asset && asset.resource && asset.resource._levels[0];
+        const onLoad = function (index, asset) {
+            const level0 = asset && asset.resource && asset.resource._levels[0];
             if (level0 && typeof ImageBitmap !== 'undefined' && level0 instanceof ImageBitmap) {
                 createImageBitmap(level0, {
                     premultiplyAlpha: 'none',
@@ -273,12 +273,12 @@ class CubemapHandler {
         };
 
         // handle an asset load failure
-        var onError = function (index, err, asset) {
+        const onError = function (index, err, asset) {
             callback(err);
         };
 
         // process the texture asset
-        var processTexAsset = function (index, texAsset) {
+        const processTexAsset = function (index, texAsset) {
             if (texAsset.loaded) {
                 // asset already exists
                 onLoad(index, texAsset);
@@ -293,9 +293,9 @@ class CubemapHandler {
             }
         };
 
-        var texAsset;
-        for (var i = 0; i < 7; ++i) {
-            var assetId = this.resolveId(assetIds[i]);
+        let texAsset;
+        for (let i = 0; i < 7; ++i) {
+            const assetId = this.resolveId(assetIds[i]);
 
             if (!assetId) {
                 // no asset
@@ -314,7 +314,7 @@ class CubemapHandler {
                     // a chance to add the dependent scene texture to registry before we attempt
                     // to get the asset again.
                     setTimeout(function (index, assetId_) {
-                        var texAsset = registry.get(assetId_);
+                        const texAsset = registry.get(assetId_);
                         if (texAsset) {
                             processTexAsset(index, texAsset);
                         } else {
@@ -324,7 +324,7 @@ class CubemapHandler {
                 }
             } else {
                 // assetId is a url or file object and we're responsible for creating it
-                var file = (typeof assetId === "string") ? {
+                const file = (typeof assetId === "string") ? {
                     url: assetId,
                     filename: assetId
                 } : assetId;

--- a/src/resources/font.js
+++ b/src/resources/font.js
@@ -15,9 +15,9 @@ function upgradeDataSchema(data) {
             }];
         }
         data.chars = Object.keys(data.chars || {}).reduce(function (newChars, key) {
-            var existing = data.chars[key];
+            const existing = data.chars[key];
             // key by letter instead of char code
-            var newKey = existing.letter !== undefined ? existing.letter : string.fromCodePoint(key);
+            const newKey = existing.letter !== undefined ? existing.letter : string.fromCodePoint(key);
             if (data.version < 2) {
                 existing.map = existing.map || 0;
             }
@@ -50,7 +50,7 @@ class FontHandler {
             };
         }
 
-        var self = this;
+        const self = this;
         if (path.getExtension(url.original) === '.json') {
             // load json data then load texture of same name
             http.get(url.load, {
@@ -59,7 +59,7 @@ class FontHandler {
             }, function (err, response) {
                 // update asset data
                 if (!err) {
-                    var data = upgradeDataSchema(response);
+                    const data = upgradeDataSchema(response);
                     self._loadTextures(url.load.replace('.json', '.png'), data, function (err, textures) {
                         if (err) return callback(err);
 
@@ -83,15 +83,15 @@ class FontHandler {
     }
 
     _loadTextures(url, data, callback) {
-        var numTextures = data.info.maps.length;
-        var numLoaded = 0;
-        var error = null;
+        const numTextures = data.info.maps.length;
+        let numLoaded = 0;
+        let error = null;
 
-        var textures = new Array(numTextures);
-        var loader = this._loader;
+        const textures = new Array(numTextures);
+        const loader = this._loader;
 
-        var loadTexture = function (index) {
-            var onLoaded = function (err, texture) {
+        const loadTexture = function (index) {
+            const onLoaded = function (err, texture) {
                 if (error) return;
 
                 if (err) {
@@ -114,12 +114,12 @@ class FontHandler {
             }
         };
 
-        for (var i = 0; i < numTextures; i++)
+        for (let i = 0; i < numTextures; i++)
             loadTexture(i);
     }
 
     open(url, data, asset) {
-        var font;
+        let font;
         if (data.textures) {
             // both data and textures exist
             font = new Font(data.textures, data.data);
@@ -133,7 +133,7 @@ class FontHandler {
     patch(asset, assets) {
         // if not already set, get font data block from asset
         // and assign to font resource
-        var font = asset.resource;
+        const font = asset.resource;
         if (!font.data && asset.data) {
             // font data present in asset but not in font
             font.data = asset.data;

--- a/src/resources/hierarchy.js
+++ b/src/resources/hierarchy.js
@@ -15,8 +15,8 @@ class HierarchyHandler {
         // prevent script initialization until entire scene is open
         this._app.systems.script.preloading = true;
 
-        var parser = new SceneParser(this._app, false);
-        var parent = parser.parse(data);
+        const parser = new SceneParser(this._app, false);
+        const parent = parser.parse(data);
 
         // re-enable script initialization
         this._app.systems.script.preloading = false;

--- a/src/resources/json.js
+++ b/src/resources/json.js
@@ -14,7 +14,7 @@ class JsonHandler {
         }
 
         // if this a blob URL we need to set the response type as json
-        var options = {
+        const options = {
             retry: this.maxRetries > 0,
             maxRetries: this.maxRetries
         };

--- a/src/resources/loader.js
+++ b/src/resources/loader.js
@@ -83,9 +83,9 @@ class ResourceLoader {
      * });
      */
     load(url, type, callback, asset) {
-        var handler = this._handlers[type];
+        const handler = this._handlers[type];
         if (!handler) {
-            var err = "No handler for asset type: " + type;
+            const err = "No handler for asset type: " + type;
             callback(err);
             return;
         }
@@ -96,7 +96,7 @@ class ResourceLoader {
             return;
         }
 
-        var key = url + type;
+        const key = url + type;
 
         if (this._cache[key] !== undefined) {
             // in cache
@@ -108,9 +108,9 @@ class ResourceLoader {
             // new request
             this._requests[key] = [callback];
 
-            var self = this;
+            const self = this;
 
-            var handleLoad = function (err, urlObj) {
+            const handleLoad = function (err, urlObj) {
                 if (err) {
                     self._onFailure(key, err);
                     return;
@@ -136,7 +136,7 @@ class ResourceLoader {
                 }, asset);
             };
 
-            var normalizedUrl = url.split('?')[0];
+            const normalizedUrl = url.split('?')[0];
             if (this._app.enableBundles && this._app.bundles.hasUrl(normalizedUrl)) {
                 if (!this._app.bundles.canLoadUrl(normalizedUrl)) {
                     handleLoad('Bundle for ' + url + ' not loaded yet');
@@ -160,7 +160,7 @@ class ResourceLoader {
 
     // load an asset with no url, skipping bundles and caching
     _loadNull(handler, callback, asset) {
-        var onLoad = function (err, data, extra) {
+        const onLoad = function (err, data, extra) {
             if (err) {
                 callback(err);
             } else {
@@ -176,7 +176,7 @@ class ResourceLoader {
 
     _onSuccess(key, result, extra) {
         this._cache[key] = result;
-        for (var i = 0; i < this._requests[key].length; i++) {
+        for (let i = 0; i < this._requests[key].length; i++) {
             this._requests[key][i](null, result, extra);
         }
         delete this._requests[key];
@@ -185,7 +185,7 @@ class ResourceLoader {
     _onFailure(key, err) {
         console.error(err);
         if (this._requests[key]) {
-            for (var i = 0; i < this._requests[key].length; i++) {
+            for (let i = 0; i < this._requests[key].length; i++) {
                 this._requests[key][i](err);
             }
             delete this._requests[key];
@@ -201,7 +201,7 @@ class ResourceLoader {
      * @returns {*} The parsed resource data.
      */
     open(type, data) {
-        var handler = this._handlers[type];
+        const handler = this._handlers[type];
         if (!handler) {
             console.warn("No resource handler found for: " + type);
             return data;
@@ -220,7 +220,7 @@ class ResourceLoader {
      * @param {AssetRegistry} assets - The asset registry.
      */
     patch(asset, assets) {
-        var handler = this._handlers[asset.type];
+        const handler = this._handlers[asset.type];
         if (!handler)  {
             console.warn("No resource handler found for: " + asset.type);
             return;
@@ -266,7 +266,7 @@ class ResourceLoader {
     enableRetry(maxRetries = 5) {
         maxRetries = Math.max(0, maxRetries) || 0;
 
-        for (var key in this._handlers) {
+        for (const key in this._handlers) {
             this._handlers[key].maxRetries = maxRetries;
         }
     }
@@ -278,7 +278,7 @@ class ResourceLoader {
      * @description Disables retrying of failed requests when loading assets.
      */
     disableRetry() {
-        for (var key in this._handlers) {
+        for (const key in this._handlers) {
             this._handlers[key].maxRetries = 0;
         }
     }

--- a/src/resources/material.js
+++ b/src/resources/material.js
@@ -10,7 +10,7 @@ import { AssetReference } from '../asset/asset-reference.js';
 
 import { JsonStandardMaterialParser } from './parser/material/json-standard-material.js';
 
-var PLACEHOLDER_MAP = {
+const PLACEHOLDER_MAP = {
     aoMap: 'white',
     diffuseMap: 'gray',
     specularMap: 'gray',
@@ -69,7 +69,7 @@ class MaterialHandler {
     }
 
     open(url, data) {
-        var material = this._parser.parse(data);
+        const material = this._parser.parse(data);
 
         // temp storage for engine-only as we need this during patching
         if (data._engine) {
@@ -85,14 +85,14 @@ class MaterialHandler {
     _createPlaceholders() {
         this._placeholderTextures = {};
 
-        var textures = {
+        const textures = {
             white: [255, 255, 255, 255],
             gray: [128, 128, 128, 255],
             black: [0, 0, 0, 255],
             normal: [128, 128, 255, 255]
         };
 
-        for (var key in textures) {
+        for (const key in textures) {
             if (!textures.hasOwnProperty(key))
                 continue;
 
@@ -105,9 +105,9 @@ class MaterialHandler {
             this._placeholderTextures[key].name = 'placeholder';
 
             // fill pixels with color
-            var pixels = this._placeholderTextures[key].lock();
-            for (var i = 0; i < 4; i++) {
-                for (var c = 0; c < 4; c++) {
+            const pixels = this._placeholderTextures[key].lock();
+            for (let i = 0; i < 4; i++) {
+                for (let c = 0; c < 4; c++) {
                     pixels[i * 4 + c] = textures[key][c];
                 }
             }
@@ -153,8 +153,8 @@ class MaterialHandler {
             this._createPlaceholders();
         }
 
-        var placeholder = PLACEHOLDER_MAP[parameterName];
-        var texture = this._placeholderTextures[placeholder];
+        const placeholder = PLACEHOLDER_MAP[parameterName];
+        const texture = this._placeholderTextures[placeholder];
 
         materialAsset.resource[parameterName] = texture;
     }
@@ -169,7 +169,7 @@ class MaterialHandler {
     }
 
     _onTextureRemove(parameterName, materialAsset, textureAsset) {
-        var material = materialAsset.resource;
+        const material = materialAsset.resource;
         if (material) {
             if (material[parameterName] === textureAsset.resource) {
                 this._assignTexture(parameterName, materialAsset, null);
@@ -206,7 +206,7 @@ class MaterialHandler {
     }
 
     _onCubemapRemove(parameterName, materialAsset, cubemapAsset) {
-        var material = materialAsset.resource;
+        const material = materialAsset.resource;
 
         if (material[parameterName] === cubemapAsset.resource) {
             this._assignCubemap(parameterName, materialAsset, [null, null, null, null, null, null, null]);
@@ -216,15 +216,15 @@ class MaterialHandler {
 
     _bindAndAssignAssets(materialAsset, assets) {
         // always migrate before updating material from asset data
-        var data = this._parser.migrate(materialAsset.data);
+        const data = this._parser.migrate(materialAsset.data);
 
-        var material = materialAsset.resource;
+        const material = materialAsset.resource;
 
-        var pathMapping = (data.mappingFormat === "path");
+        const pathMapping = (data.mappingFormat === "path");
 
-        var TEXTURES = standardMaterialTextureParameters;
+        const TEXTURES = standardMaterialTextureParameters;
 
-        var i, name, assetReference;
+        let i, name, assetReference;
         // iterate through all texture parameters
         for (i = 0; i < TEXTURES.length; i++) {
             name = TEXTURES[i];
@@ -275,7 +275,7 @@ class MaterialHandler {
             }
         }
 
-        var CUBEMAPS = standardMaterialCubemapParameters;
+        const CUBEMAPS = standardMaterialCubemapParameters;
 
         // iterate through all cubemap parameters
         for (i = 0; i < CUBEMAPS.length; i++) {

--- a/src/resources/model.js
+++ b/src/resources/model.js
@@ -37,7 +37,7 @@ class ModelHandler {
         }
 
         // we need to specify JSON for blob URLs
-        var options = {
+        const options = {
             retry: this.maxRetries > 0,
             maxRetries: this.maxRetries
         };
@@ -63,8 +63,8 @@ class ModelHandler {
     }
 
     open(url, data) {
-        for (var i = 0; i < this._parsers.length; i++) {
-            var p = this._parsers[i];
+        for (let i = 0; i < this._parsers.length; i++) {
+            const p = this._parsers[i];
 
             if (p.decider(url, data)) {
                 return p.parser.parse(data);
@@ -80,12 +80,12 @@ class ModelHandler {
         if (!asset.resource)
             return;
 
-        var data = asset.data;
+        const data = asset.data;
 
-        var self = this;
+        const self = this;
         asset.resource.meshInstances.forEach(function (meshInstance, i) {
             if (data.mapping) {
-                var handleMaterial = function (asset) {
+                const handleMaterial = function (asset) {
                     if (asset.resource) {
                         meshInstance.material = asset.resource;
                     } else {
@@ -105,9 +105,9 @@ class ModelHandler {
                     return;
                 }
 
-                var id = data.mapping[i].material;
-                var url = data.mapping[i].path;
-                var material;
+                const id = data.mapping[i].material;
+                const url = data.mapping[i].path;
+                let material;
 
                 if (id !== undefined) { // id mapping
                     if (!id) {
@@ -122,7 +122,7 @@ class ModelHandler {
                     }
                 } else if (url) {
                     // url mapping
-                    var path = asset.getAbsoluteUrl(data.mapping[i].path);
+                    const path = asset.getAbsoluteUrl(data.mapping[i].path);
                     material = assets.getByUrl(path);
 
                     if (material) {

--- a/src/resources/parser/glb-model.js
+++ b/src/resources/parser/glb-model.js
@@ -7,7 +7,7 @@ class GlbModelParser {
     }
 
     parse(data) {
-        var glb = GlbParser.parse("filename.glb", data, this._device);
+        const glb = GlbParser.parse("filename.glb", data, this._device);
         if (!glb) {
             return null;
         }

--- a/src/resources/parser/glb-parser.js
+++ b/src/resources/parser/glb-parser.js
@@ -48,15 +48,15 @@ import { INTERPOLATION_CUBIC, INTERPOLATION_LINEAR, INTERPOLATION_STEP } from '.
 
 import { Asset } from '../../asset/asset.js';
 
-var isDataURI = function (uri) {
+const isDataURI = function (uri) {
     return /^data:.*,.*$/i.test(uri);
 };
 
-var getDataURIMimeType = function (uri) {
+const getDataURIMimeType = function (uri) {
     return uri.substring(uri.indexOf(":") + 1, uri.indexOf(";"));
 };
 
-var getNumComponents = function (accessorType) {
+const getNumComponents = function (accessorType) {
     switch (accessorType) {
         case 'SCALAR': return 1;
         case 'VEC2': return 2;
@@ -69,7 +69,7 @@ var getNumComponents = function (accessorType) {
     }
 };
 
-var getComponentType = function (componentType) {
+const getComponentType = function (componentType) {
     switch (componentType) {
         case 5120: return TYPE_INT8;
         case 5121: return TYPE_UINT8;
@@ -82,7 +82,7 @@ var getComponentType = function (componentType) {
     }
 };
 
-var getComponentSizeInBytes = function (componentType) {
+const getComponentSizeInBytes = function (componentType) {
     switch (componentType) {
         case 5120: return 1;    // int8
         case 5121: return 1;    // uint8
@@ -95,7 +95,7 @@ var getComponentSizeInBytes = function (componentType) {
     }
 };
 
-var getComponentDataType = function (componentType) {
+const getComponentDataType = function (componentType) {
     switch (componentType) {
         case 5120: return Int8Array;
         case 5121: return Uint8Array;
@@ -108,7 +108,7 @@ var getComponentDataType = function (componentType) {
     }
 };
 
-var gltfToEngineSemanticMap = {
+const gltfToEngineSemanticMap = {
     'POSITION': SEMANTIC_POSITION,
     'NORMAL': SEMANTIC_NORMAL,
     'TANGENT': SEMANTIC_TANGENT,
@@ -120,36 +120,36 @@ var gltfToEngineSemanticMap = {
 };
 
 // get accessor data, making a copy and patching in the case of a sparse accessor
-var getAccessorData = function (gltfAccessor, bufferViews) {
-    var numComponents = getNumComponents(gltfAccessor.type);
-    var dataType = getComponentDataType(gltfAccessor.componentType);
+const getAccessorData = function (gltfAccessor, bufferViews) {
+    const numComponents = getNumComponents(gltfAccessor.type);
+    const dataType = getComponentDataType(gltfAccessor.componentType);
     if (!dataType) {
         return null;
     }
-    var result;
+    let result;
 
     if (gltfAccessor.sparse) {
         // handle sparse data
-        var sparse = gltfAccessor.sparse;
+        const sparse = gltfAccessor.sparse;
 
         // get indices data
-        var indicesAccessor = {
+        const indicesAccessor = {
             count: sparse.count,
             type: "SCALAR"
         };
-        var indices = getAccessorData(Object.assign(indicesAccessor, sparse.indices), bufferViews);
+        const indices = getAccessorData(Object.assign(indicesAccessor, sparse.indices), bufferViews);
 
         // data values data
-        var valuesAccessor = {
+        const valuesAccessor = {
             count: sparse.count,
             type: gltfAccessor.scalar,
             componentType: gltfAccessor.componentType
         };
-        var values = getAccessorData(Object.assign(valuesAccessor, sparse.values), bufferViews);
+        const values = getAccessorData(Object.assign(valuesAccessor, sparse.values), bufferViews);
 
         // get base data
         if (gltfAccessor.hasOwnProperty('bufferView')) {
-            var baseAccessor = {
+            const baseAccessor = {
                 bufferView: gltfAccessor.bufferView,
                 byteOffset: gltfAccessor.byteOffset,
                 componentType: gltfAccessor.componentType,
@@ -163,14 +163,14 @@ var getAccessorData = function (gltfAccessor, bufferViews) {
             result = new dataType(gltfAccessor.count * numComponents);
         }
 
-        for (var i = 0; i < sparse.count; ++i) {
-            var targetIndex = indices[i];
-            for (var j = 0; j < numComponents; ++j) {
+        for (let i = 0; i < sparse.count; ++i) {
+            const targetIndex = indices[i];
+            for (let j = 0; j < numComponents; ++j) {
                 result[targetIndex * numComponents + j] = values[i * numComponents + j];
             }
         }
     } else {
-        var bufferView = bufferViews[gltfAccessor.bufferView];
+        const bufferView = bufferViews[gltfAccessor.bufferView];
         result = new dataType(bufferView.buffer,
                               bufferView.byteOffset + (gltfAccessor.hasOwnProperty('byteOffset') ? gltfAccessor.byteOffset : 0),
                               gltfAccessor.count * numComponents);
@@ -179,7 +179,7 @@ var getAccessorData = function (gltfAccessor, bufferViews) {
     return result;
 };
 
-var getPrimitiveType = function (primitive) {
+const getPrimitiveType = function (primitive) {
     if (!primitive.hasOwnProperty('mode')) {
         return PRIMITIVE_TRIANGLES;
     }
@@ -196,28 +196,28 @@ var getPrimitiveType = function (primitive) {
     }
 };
 
-var generateIndices = function (numVertices) {
-    var dummyIndices = new Uint16Array(numVertices);
-    for (var i = 0; i < numVertices; i++) {
+const generateIndices = function (numVertices) {
+    const dummyIndices = new Uint16Array(numVertices);
+    for (let i = 0; i < numVertices; i++) {
         dummyIndices[i] = i;
     }
     return dummyIndices;
 };
 
-var generateNormals = function (sourceDesc, indices) {
+const generateNormals = function (sourceDesc, indices) {
     // get positions
-    var p = sourceDesc[SEMANTIC_POSITION];
+    const p = sourceDesc[SEMANTIC_POSITION];
     if (!p || p.components !== 3) {
         return;
     }
 
-    var positions;
+    let positions;
     if (p.size !== p.stride) {
         // extract positions which aren't tightly packed
-        var srcStride = p.stride / typedArrayTypesByteSize[p.type];
-        var src = new typedArrayTypes[p.type](p.buffer, p.offset, p.count * srcStride);
+        const srcStride = p.stride / typedArrayTypesByteSize[p.type];
+        const src = new typedArrayTypes[p.type](p.buffer, p.offset, p.count * srcStride);
         positions = new typedArrayTypes[p.type](p.count * 3);
-        for (var i = 0; i < p.count; ++i) {
+        for (let i = 0; i < p.count; ++i) {
             positions[i * 3 + 0] = src[i * srcStride + 0];
             positions[i * 3 + 1] = src[i * srcStride + 1];
             positions[i * 3 + 2] = src[i * srcStride + 2];
@@ -227,7 +227,7 @@ var generateNormals = function (sourceDesc, indices) {
         positions = new typedArrayTypes[p.type](p.buffer, p.offset, p.count * 3);
     }
 
-    var numVertices = p.count;
+    const numVertices = p.count;
 
     // generate indices if necessary
     if (!indices) {
@@ -235,8 +235,8 @@ var generateNormals = function (sourceDesc, indices) {
     }
 
     // generate normals
-    var normalsTemp = calculateNormals(positions, indices);
-    var normals = new Float32Array(normalsTemp.length);
+    const normalsTemp = calculateNormals(positions, indices);
+    const normals = new Float32Array(normalsTemp.length);
     normals.set(normalsTemp);
 
     sourceDesc[SEMANTIC_NORMAL] = {
@@ -250,14 +250,14 @@ var generateNormals = function (sourceDesc, indices) {
     };
 };
 
-var flipTexCoordVs = function (vertexBuffer) {
-    var i, j;
+const flipTexCoordVs = function (vertexBuffer) {
+    let i, j;
 
-    var floatOffsets = [];
-    var shortOffsets = [];
-    var byteOffsets = [];
+    const floatOffsets = [];
+    const shortOffsets = [];
+    const byteOffsets = [];
     for (i = 0; i < vertexBuffer.format.elements.length; ++i) {
-        var element = vertexBuffer.format.elements[i];
+        const element = vertexBuffer.format.elements[i];
         if (element.name === SEMANTIC_TEXCOORD0 ||
             element.name === SEMANTIC_TEXCOORD1) {
             switch (element.dataType) {
@@ -274,11 +274,11 @@ var flipTexCoordVs = function (vertexBuffer) {
         }
     }
 
-    var flip = function (offsets, type, one) {
-        var typedArray = new type(vertexBuffer.storage);
+    const flip = function (offsets, type, one) {
+        const typedArray = new type(vertexBuffer.storage);
         for (i = 0; i < offsets.length; ++i) {
-            var index = offsets[i].offset;
-            var stride = offsets[i].stride;
+            let index = offsets[i].offset;
+            const stride = offsets[i].stride;
             for (j = 0; j < vertexBuffer.numVertices; ++j) {
                 typedArray[index] = one - typedArray[index];
                 index += stride;
@@ -299,13 +299,13 @@ var flipTexCoordVs = function (vertexBuffer) {
 
 // given a texture, clone it
 // NOTE: CPU-side texture data will be shared but GPU memory will be duplicated
-var cloneTexture = function (texture) {
-    var shallowCopyLevels = function (texture) {
-        var result = [];
-        for (var mip = 0; mip < texture._levels.length; ++mip) {
-            var level = [];
+const cloneTexture = function (texture) {
+    const shallowCopyLevels = function (texture) {
+        const result = [];
+        for (let mip = 0; mip < texture._levels.length; ++mip) {
+            let level = [];
             if (texture.cubemap) {
-                for (var face = 0; face < 6; ++face) {
+                for (let face = 0; face < 6; ++face) {
                     level.push(texture._levels[mip][face]);
                 }
             } else {
@@ -316,35 +316,35 @@ var cloneTexture = function (texture) {
         return result;
     };
 
-    var result = new Texture(texture.device, texture);   // duplicate texture
+    const result = new Texture(texture.device, texture);   // duplicate texture
     result._levels = shallowCopyLevels(texture);            // shallow copy the levels structure
     return result;
 };
 
 // given a texture asset, clone it
-var cloneTextureAsset = function (src) {
-    var result = new Asset(src.name + '_clone',
-                           src.type,
-                           src.file,
-                           src.data,
-                           src.options);
+const cloneTextureAsset = function (src) {
+    const result = new Asset(src.name + '_clone',
+                             src.type,
+                             src.file,
+                             src.data,
+                             src.options);
     result.loaded = true;
     result.resource = cloneTexture(src.resource);
     src.registry.add(result);
     return result;
 };
 
-var createVertexBufferInternal = function (device, sourceDesc, disableFlipV) {
-    var positionDesc = sourceDesc[SEMANTIC_POSITION];
+const createVertexBufferInternal = function (device, sourceDesc, disableFlipV) {
+    const positionDesc = sourceDesc[SEMANTIC_POSITION];
     if (!positionDesc) {
         // ignore meshes without positions
         return null;
     }
-    var numVertices = positionDesc.count;
+    const numVertices = positionDesc.count;
 
     // generate vertexDesc elements
-    var vertexDesc = [];
-    for (var semantic in sourceDesc) {
+    const vertexDesc = [];
+    for (const semantic in sourceDesc) {
         if (sourceDesc.hasOwnProperty(semantic)) {
             vertexDesc.push({
                 semantic: semantic,
@@ -356,7 +356,7 @@ var createVertexBufferInternal = function (device, sourceDesc, disableFlipV) {
     }
 
     // order vertexDesc to match the rest of the engine
-    var elementOrder = [
+    const elementOrder = [
         SEMANTIC_POSITION,
         SEMANTIC_NORMAL,
         SEMANTIC_TANGENT,
@@ -369,18 +369,18 @@ var createVertexBufferInternal = function (device, sourceDesc, disableFlipV) {
 
     // sort vertex elements by engine-ideal order
     vertexDesc.sort(function (lhs, rhs) {
-        var lhsOrder = elementOrder.indexOf(lhs.semantic);
-        var rhsOrder = elementOrder.indexOf(rhs.semantic);
+        const lhsOrder = elementOrder.indexOf(lhs.semantic);
+        const rhsOrder = elementOrder.indexOf(rhs.semantic);
         return (lhsOrder < rhsOrder) ? -1 : (rhsOrder < lhsOrder ? 1 : 0);
     });
 
-    var i, j, k;
-    var source, target, sourceOffset;
+    let i, j, k;
+    let source, target, sourceOffset;
 
-    var vertexFormat = new VertexFormat(device, vertexDesc);
+    const vertexFormat = new VertexFormat(device, vertexDesc);
 
     // check whether source data is correctly interleaved
-    var isCorrectlyInterleaved = true;
+    let isCorrectlyInterleaved = true;
     for (i = 0; i < vertexFormat.elements.length; ++i) {
         target = vertexFormat.elements[i];
         source = sourceDesc[target.name];
@@ -395,14 +395,14 @@ var createVertexBufferInternal = function (device, sourceDesc, disableFlipV) {
     }
 
     // create vertex buffer
-    var vertexBuffer = new VertexBuffer(device,
-                                        vertexFormat,
-                                        numVertices,
-                                        BUFFER_STATIC);
+    const vertexBuffer = new VertexBuffer(device,
+                                          vertexFormat,
+                                          numVertices,
+                                          BUFFER_STATIC);
 
-    var vertexData = vertexBuffer.lock();
-    var targetArray = new Uint32Array(vertexData);
-    var sourceArray;
+    const vertexData = vertexBuffer.lock();
+    const targetArray = new Uint32Array(vertexData);
+    let sourceArray;
 
     if (isCorrectlyInterleaved) {
         // copy data
@@ -411,7 +411,7 @@ var createVertexBufferInternal = function (device, sourceDesc, disableFlipV) {
                                       numVertices * vertexBuffer.format.size / 4);
         targetArray.set(sourceArray);
     } else {
-        var targetStride, sourceStride;
+        let targetStride, sourceStride;
         // copy data and interleave
         for (i = 0; i < vertexBuffer.format.elements.length; ++i) {
             target = vertexBuffer.format.elements[i];
@@ -421,9 +421,9 @@ var createVertexBufferInternal = function (device, sourceDesc, disableFlipV) {
             sourceArray = new Uint32Array(source.buffer, source.offset, source.count * source.stride / 4);
             sourceStride = source.stride / 4;
 
-            var src = 0;
-            var dst = target.offset / 4;
-            var kend = Math.floor((source.size + 3) / 4);
+            let src = 0;
+            let dst = target.offset / 4;
+            const kend = Math.floor((source.size + 3) / 4);
             for (j = 0; j < numVertices; ++j) {
                 for (k = 0; k < kend; ++k) {
                     targetArray[dst + k] = sourceArray[src + k];
@@ -443,11 +443,13 @@ var createVertexBufferInternal = function (device, sourceDesc, disableFlipV) {
     return vertexBuffer;
 };
 
-var createVertexBuffer = function (device, attributes, indices, accessors, bufferViews, disableFlipV, vertexBufferDict) {
+const createVertexBuffer = function (device, attributes, indices, accessors, bufferViews, disableFlipV, vertexBufferDict) {
 
     // extract list of attributes to use
-    var attrib, useAttributes = {}, attribIds = [];
-    for (attrib in attributes) {
+    const useAttributes = {};
+    const attribIds = [];
+
+    for (const attrib in attributes) {
         if (attributes.hasOwnProperty(attrib) && gltfToEngineSemanticMap.hasOwnProperty(attrib)) {
             useAttributes[attrib] = attributes[attrib];
 
@@ -458,20 +460,20 @@ var createVertexBuffer = function (device, attributes, indices, accessors, buffe
 
     // sort unique ids and create unique vertex buffer ID
     attribIds.sort();
-    var vbKey = attribIds.join();
+    const vbKey = attribIds.join();
 
     // return already created vertex buffer if identical
-    var vb = vertexBufferDict[vbKey];
+    let vb = vertexBufferDict[vbKey];
     if (!vb) {
         // build vertex buffer format desc and source
-        var sourceDesc = {};
-        for (attrib in useAttributes) {
-            var accessor = accessors[attributes[attrib]];
-            var accessorData = getAccessorData(accessor, bufferViews);
-            var bufferView = bufferViews[accessor.bufferView];
-            var semantic = gltfToEngineSemanticMap[attrib];
-            var size = getNumComponents(accessor.type) * getComponentSizeInBytes(accessor.componentType);
-            var stride = bufferView.hasOwnProperty('byteStride') ? bufferView.byteStride : size;
+        const sourceDesc = {};
+        for (const attrib in useAttributes) {
+            const accessor = accessors[attributes[attrib]];
+            const accessorData = getAccessorData(accessor, bufferViews);
+            const bufferView = bufferViews[accessor.bufferView];
+            const semantic = gltfToEngineSemanticMap[attrib];
+            const size = getNumComponents(accessor.type) * getComponentSizeInBytes(accessor.componentType);
+            const stride = bufferView.hasOwnProperty('byteStride') ? bufferView.byteStride : size;
             sourceDesc[semantic] = {
                 buffer: accessorData.buffer,
                 size: size,
@@ -497,16 +499,16 @@ var createVertexBuffer = function (device, attributes, indices, accessors, buffe
     return vb;
 };
 
-var createVertexBufferDraco = function (device, outputGeometry, extDraco, decoder, decoderModule, indices, disableFlipV) {
+const createVertexBufferDraco = function (device, outputGeometry, extDraco, decoder, decoderModule, indices, disableFlipV) {
 
-    var numPoints = outputGeometry.num_points();
+    const numPoints = outputGeometry.num_points();
 
     // helper function to decode data stream with id to TypedArray of appropriate type
-    var extractDracoAttributeInfo = function (uniqueId) {
-        var attribute = decoder.GetAttributeByUniqueId(outputGeometry, uniqueId);
-        var numValues = numPoints * attribute.num_components();
-        var dracoFormat = attribute.data_type();
-        var ptr, values, componentSizeInBytes, storageType;
+    const extractDracoAttributeInfo = function (uniqueId) {
+        const attribute = decoder.GetAttributeByUniqueId(outputGeometry, uniqueId);
+        const numValues = numPoints * attribute.num_components();
+        const dracoFormat = attribute.data_type();
+        let ptr, values, componentSizeInBytes, storageType;
 
         // storage format is based on draco attribute data type
         switch (dracoFormat) {
@@ -549,15 +551,15 @@ var createVertexBufferDraco = function (device, outputGeometry, extDraco, decode
     };
 
     // build vertex buffer format desc and source
-    var sourceDesc = {};
-    var attributes = extDraco.attributes;
-    for (var attrib in attributes) {
+    const sourceDesc = {};
+    const attributes = extDraco.attributes;
+    for (const attrib in attributes) {
         if (attributes.hasOwnProperty(attrib) && gltfToEngineSemanticMap.hasOwnProperty(attrib)) {
-            var semantic = gltfToEngineSemanticMap[attrib];
-            var attributeInfo = extractDracoAttributeInfo(attributes[attrib]);
+            const semantic = gltfToEngineSemanticMap[attrib];
+            const attributeInfo = extractDracoAttributeInfo(attributes[attrib]);
 
             // store the info we'll need to copy this data into the vertex buffer
-            var size = attributeInfo.numComponents * attributeInfo.componentSizeInBytes;
+            const size = attributeInfo.numComponents * attributeInfo.componentSizeInBytes;
             sourceDesc[semantic] = {
                 values: attributeInfo.values,
                 buffer: attributeInfo.values.buffer,
@@ -580,15 +582,15 @@ var createVertexBufferDraco = function (device, outputGeometry, extDraco, decode
     return createVertexBufferInternal(device, sourceDesc, disableFlipV);
 };
 
-var createSkin = function (device, gltfSkin, accessors, bufferViews, nodes, glbSkins) {
-    var i, j, bindMatrix;
-    var joints = gltfSkin.joints;
-    var numJoints = joints.length;
-    var ibp = [];
+const createSkin = function (device, gltfSkin, accessors, bufferViews, nodes, glbSkins) {
+    let i, j, bindMatrix;
+    const joints = gltfSkin.joints;
+    const numJoints = joints.length;
+    const ibp = [];
     if (gltfSkin.hasOwnProperty('inverseBindMatrices')) {
-        var inverseBindMatrices = gltfSkin.inverseBindMatrices;
-        var ibmData = getAccessorData(accessors[inverseBindMatrices], bufferViews);
-        var ibmValues = [];
+        const inverseBindMatrices = gltfSkin.inverseBindMatrices;
+        const ibmData = getAccessorData(accessors[inverseBindMatrices], bufferViews);
+        const ibmValues = [];
 
         for (i = 0; i < numJoints; i++) {
             for (j = 0; j < 16; j++) {
@@ -605,7 +607,7 @@ var createSkin = function (device, gltfSkin, accessors, bufferViews, nodes, glbS
         }
     }
 
-    var boneNames = [];
+    const boneNames = [];
     for (i = 0; i < numJoints; i++) {
         boneNames[i] = nodes[joints[i]].name;
     }
@@ -623,36 +625,36 @@ var createSkin = function (device, gltfSkin, accessors, bufferViews, nodes, glbS
     return skin;
 };
 
-var tempMat = new Mat4();
-var tempVec = new Vec3();
+const tempMat = new Mat4();
+const tempVec = new Vec3();
 
-var createMesh = function (device, gltfMesh, accessors, bufferViews, callback, disableFlipV, vertexBufferDict) {
-    var meshes = [];
+const createMesh = function (device, gltfMesh, accessors, bufferViews, callback, disableFlipV, vertexBufferDict) {
+    const meshes = [];
 
     gltfMesh.primitives.forEach(function (primitive) {
 
-        var primitiveType, vertexBuffer, numIndices;
-        var indices = null;
-        var canUseMorph = true;
+        let primitiveType, vertexBuffer, numIndices;
+        let indices = null;
+        let canUseMorph = true;
 
         // try and get draco compressed data first
         if (primitive.hasOwnProperty('extensions')) {
-            var extensions = primitive.extensions;
+            const extensions = primitive.extensions;
             if (extensions.hasOwnProperty('KHR_draco_mesh_compression')) {
 
                 // access DracoDecoderModule
-                var decoderModule = window.DracoDecoderModule;
+                const decoderModule = window.DracoDecoderModule;
                 if (decoderModule) {
-                    var extDraco = extensions.KHR_draco_mesh_compression;
+                    const extDraco = extensions.KHR_draco_mesh_compression;
                     if (extDraco.hasOwnProperty('attributes')) {
-                        var uint8Buffer = bufferViews[extDraco.bufferView];
-                        var buffer = new decoderModule.DecoderBuffer();
+                        const uint8Buffer = bufferViews[extDraco.bufferView];
+                        const buffer = new decoderModule.DecoderBuffer();
                         buffer.Init(uint8Buffer, uint8Buffer.length);
 
-                        var decoder = new decoderModule.Decoder();
-                        var geometryType = decoder.GetEncodedGeometryType(buffer);
+                        const decoder = new decoderModule.Decoder();
+                        const geometryType = decoder.GetEncodedGeometryType(buffer);
 
-                        var outputGeometry, status;
+                        let outputGeometry, status;
                         switch (geometryType) {
                             case decoderModule.POINT_CLOUD:
                                 primitiveType = PRIMITIVE_POINTS;
@@ -676,12 +678,12 @@ var createMesh = function (device, gltfMesh, accessors, bufferViews, callback, d
                         }
 
                         // indices
-                        var numFaces = outputGeometry.num_faces();
+                        const numFaces = outputGeometry.num_faces();
                         if (geometryType == decoderModule.TRIANGULAR_MESH) {
-                            var bit32 = outputGeometry.num_points() > 65535;
+                            const bit32 = outputGeometry.num_points() > 65535;
                             numIndices = numFaces * 3;
-                            var dataSize = numIndices * (bit32 ? 4 : 2);
-                            var ptr = decoderModule._malloc(dataSize);
+                            const dataSize = numIndices * (bit32 ? 4 : 2);
+                            const ptr = decoderModule._malloc(dataSize);
 
                             if (bit32) {
                                 decoder.GetTrianglesUInt32Array(outputGeometry, dataSize, ptr);
@@ -720,7 +722,7 @@ var createMesh = function (device, gltfMesh, accessors, bufferViews, callback, d
             primitiveType = getPrimitiveType(primitive);
         }
 
-        var mesh = null;
+        let mesh = null;
         if (vertexBuffer) {
             // build the mesh
             mesh = new Mesh(device);
@@ -731,7 +733,7 @@ var createMesh = function (device, gltfMesh, accessors, bufferViews, callback, d
 
             // index buffer
             if (indices !== null) {
-                var indexFormat;
+                let indexFormat;
                 if (indices instanceof Uint8Array) {
                     indexFormat = INDEXFORMAT_UINT8;
                 } else if (indices instanceof Uint16Array) {
@@ -754,7 +756,7 @@ var createMesh = function (device, gltfMesh, accessors, bufferViews, callback, d
                     indices = new Uint16Array(indices);
                 }
 
-                var indexBuffer = new IndexBuffer(device, indexFormat, indices.length, BUFFER_STATIC, indices);
+                const indexBuffer = new IndexBuffer(device, indexFormat, indices.length, BUFFER_STATIC, indices);
                 mesh.indexBuffer[0] = indexBuffer;
                 mesh.primitive[0].count = indices.length;
             } else {
@@ -763,10 +765,10 @@ var createMesh = function (device, gltfMesh, accessors, bufferViews, callback, d
 
             mesh.materialIndex = primitive.material;
 
-            var accessor = accessors[primitive.attributes.POSITION];
-            var min = accessor.min;
-            var max = accessor.max;
-            var aabb = new BoundingBox(
+            let accessor = accessors[primitive.attributes.POSITION];
+            const min = accessor.min;
+            const max = accessor.max;
+            const aabb = new BoundingBox(
                 new Vec3((max[0] + min[0]) / 2, (max[1] + min[1]) / 2, (max[2] + min[2]) / 2),
                 new Vec3((max[0] - min[0]) / 2, (max[1] - min[1]) / 2, (max[2] - min[2]) / 2)
             );
@@ -774,10 +776,10 @@ var createMesh = function (device, gltfMesh, accessors, bufferViews, callback, d
 
             // morph targets
             if (canUseMorph && primitive.hasOwnProperty('targets')) {
-                var targets = [];
+                const targets = [];
 
                 primitive.targets.forEach(function (target, index) {
-                    var options = {};
+                    const options = {};
 
                     if (target.hasOwnProperty('POSITION')) {
                         accessor = accessors[target.POSITION];
@@ -821,9 +823,9 @@ var createMesh = function (device, gltfMesh, accessors, bufferViews, callback, d
     return meshes;
 };
 
-var createMaterial = function (gltfMaterial, textures, disableFlipV) {
+const createMaterial = function (gltfMaterial, textures, disableFlipV) {
     // TODO: integrate these shader chunks into the native engine
-    var glossChunk = [
+    const glossChunk = [
         "#ifdef MAPFLOAT",
         "uniform float material_shininess;",
         "#endif",
@@ -853,7 +855,7 @@ var createMaterial = function (gltfMaterial, textures, disableFlipV) {
         "}"
     ].join('\n');
 
-    var specularChunk = [
+    const specularChunk = [
         "#ifdef MAPCOLOR",
         "uniform vec3 material_specular;",
         "#endif",
@@ -880,7 +882,7 @@ var createMaterial = function (gltfMaterial, textures, disableFlipV) {
         "}"
     ].join('\n');
 
-    var clearCoatGlossChunk = [
+    const clearCoatGlossChunk = [
         "#ifdef MAPFLOAT",
         "uniform float material_clearCoatGlossiness;",
         "#endif",
@@ -910,25 +912,25 @@ var createMaterial = function (gltfMaterial, textures, disableFlipV) {
         "}"
     ].join('\n');
 
-    var uvONE = [1, 1];
-    var uvZERO = [0, 0];
+    const uvONE = [1, 1];
+    const uvZERO = [0, 0];
 
-    var extractTextureTransform = function (source, material, maps) {
-        var map;
+    const extractTextureTransform = function (source, material, maps) {
+        let map;
 
-        var texCoord = source.texCoord;
+        const texCoord = source.texCoord;
         if (texCoord) {
             for (map = 0; map < maps.length; ++map) {
                 material[maps[map] + 'MapUv'] = texCoord;
             }
         }
 
-        var scale = uvONE;
-        var offset = uvZERO;
+        let scale = uvONE;
+        let offset = uvZERO;
 
-        var extensions = source.extensions;
+        const extensions = source.extensions;
         if (extensions) {
-            var textureTransformData = extensions.KHR_texture_transform;
+            const textureTransformData = extensions.KHR_texture_transform;
             if (textureTransformData) {
                 if (textureTransformData.scale) {
                     scale = textureTransformData.scale;
@@ -947,7 +949,7 @@ var createMaterial = function (gltfMaterial, textures, disableFlipV) {
         }
     };
 
-    var material = new StandardMaterial();
+    const material = new StandardMaterial();
 
     // glTF dooesn't define how to occlude specular
     material.occludeSpecular = true;
@@ -962,10 +964,10 @@ var createMaterial = function (gltfMaterial, textures, disableFlipV) {
         material.name = gltfMaterial.name;
     }
 
-    var color, texture;
+    let color, texture;
     if (gltfMaterial.hasOwnProperty('extensions') &&
         gltfMaterial.extensions.hasOwnProperty('KHR_materials_pbrSpecularGlossiness')) {
-        var specData = gltfMaterial.extensions.KHR_materials_pbrSpecularGlossiness;
+        const specData = gltfMaterial.extensions.KHR_materials_pbrSpecularGlossiness;
 
         if (specData.hasOwnProperty('diffuseFactor')) {
             color = specData.diffuseFactor;
@@ -977,7 +979,7 @@ var createMaterial = function (gltfMaterial, textures, disableFlipV) {
             material.opacity = 1;
         }
         if (specData.hasOwnProperty('diffuseTexture')) {
-            var diffuseTexture = specData.diffuseTexture;
+            const diffuseTexture = specData.diffuseTexture;
             texture = textures[diffuseTexture.index];
 
             material.diffuseMap = texture;
@@ -1001,7 +1003,7 @@ var createMaterial = function (gltfMaterial, textures, disableFlipV) {
             material.shininess = 100;
         }
         if (specData.hasOwnProperty('specularGlossinessTexture')) {
-            var specularGlossinessTexture = specData.specularGlossinessTexture;
+            const specularGlossinessTexture = specData.specularGlossinessTexture;
             material.specularMap = material.glossMap = textures[specularGlossinessTexture.index];
             material.specularMapChannel = 'rgb';
             material.glossMapChannel = 'a';
@@ -1012,7 +1014,7 @@ var createMaterial = function (gltfMaterial, textures, disableFlipV) {
         material.chunks.specularPS = specularChunk;
 
     } else if (gltfMaterial.hasOwnProperty('pbrMetallicRoughness')) {
-        var pbrData = gltfMaterial.pbrMetallicRoughness;
+        const pbrData = gltfMaterial.pbrMetallicRoughness;
 
         if (pbrData.hasOwnProperty('baseColorFactor')) {
             color = pbrData.baseColorFactor;
@@ -1024,7 +1026,7 @@ var createMaterial = function (gltfMaterial, textures, disableFlipV) {
             material.opacity = 1;
         }
         if (pbrData.hasOwnProperty('baseColorTexture')) {
-            var baseColorTexture = pbrData.baseColorTexture;
+            const baseColorTexture = pbrData.baseColorTexture;
             texture = textures[baseColorTexture.index];
 
             material.diffuseMap = texture;
@@ -1046,7 +1048,7 @@ var createMaterial = function (gltfMaterial, textures, disableFlipV) {
             material.shininess = 100;
         }
         if (pbrData.hasOwnProperty('metallicRoughnessTexture')) {
-            var metallicRoughnessTexture = pbrData.metallicRoughnessTexture;
+            const metallicRoughnessTexture = pbrData.metallicRoughnessTexture;
             material.metalnessMap = material.glossMap = textures[metallicRoughnessTexture.index];
             material.metalnessMapChannel = 'b';
             material.glossMapChannel = 'g';
@@ -1058,7 +1060,7 @@ var createMaterial = function (gltfMaterial, textures, disableFlipV) {
     }
 
     if (gltfMaterial.hasOwnProperty('normalTexture')) {
-        var normalTexture = gltfMaterial.normalTexture;
+        const normalTexture = gltfMaterial.normalTexture;
         material.normalMap = textures[normalTexture.index];
 
         extractTextureTransform(normalTexture, material, ['normal']);
@@ -1068,7 +1070,7 @@ var createMaterial = function (gltfMaterial, textures, disableFlipV) {
         }
     }
     if (gltfMaterial.hasOwnProperty('occlusionTexture')) {
-        var occlusionTexture = gltfMaterial.occlusionTexture;
+        const occlusionTexture = gltfMaterial.occlusionTexture;
         material.aoMap = textures[occlusionTexture.index];
         material.aoMapChannel = 'r';
 
@@ -1085,7 +1087,7 @@ var createMaterial = function (gltfMaterial, textures, disableFlipV) {
         material.emissiveTint = false;
     }
     if (gltfMaterial.hasOwnProperty('emissiveTexture')) {
-        var emissiveTexture = gltfMaterial.emissiveTexture;
+        const emissiveTexture = gltfMaterial.emissiveTexture;
         material.emissiveMap = textures[emissiveTexture.index];
 
         extractTextureTransform(emissiveTexture, material, ['emissive']);
@@ -1121,7 +1123,7 @@ var createMaterial = function (gltfMaterial, textures, disableFlipV) {
 
     if (gltfMaterial.hasOwnProperty('extensions') &&
         gltfMaterial.extensions.hasOwnProperty('KHR_materials_clearcoat')) {
-        var ccData = gltfMaterial.extensions.KHR_materials_clearcoat;
+        const ccData = gltfMaterial.extensions.KHR_materials_clearcoat;
 
         if (ccData.hasOwnProperty('clearcoatFactor')) {
             material.clearCoat = ccData.clearcoatFactor * 0.25; // TODO: remove temporary workaround for replicating glTF clear-coat visuals
@@ -1129,7 +1131,7 @@ var createMaterial = function (gltfMaterial, textures, disableFlipV) {
             material.clearCoat = 0;
         }
         if (ccData.hasOwnProperty('clearcoatTexture')) {
-            var clearcoatTexture = ccData.clearcoatTexture;
+            const clearcoatTexture = ccData.clearcoatTexture;
             material.clearCoatMap = textures[clearcoatTexture.index];
             material.clearCoatMapChannel = 'r';
 
@@ -1141,14 +1143,14 @@ var createMaterial = function (gltfMaterial, textures, disableFlipV) {
             material.clearCoatGlossiness = 0;
         }
         if (ccData.hasOwnProperty('clearcoatRoughnessTexture')) {
-            var clearcoatRoughnessTexture = ccData.clearcoatRoughnessTexture;
+            const clearcoatRoughnessTexture = ccData.clearcoatRoughnessTexture;
             material.clearCoatGlossMap = textures[clearcoatRoughnessTexture.index];
             material.clearCoatGlossMapChannel = 'g';
 
             extractTextureTransform(clearcoatRoughnessTexture, material, ['clearCoatGloss']);
         }
         if (ccData.hasOwnProperty('clearcoatNormalTexture')) {
-            var clearcoatNormalTexture = ccData.clearcoatNormalTexture;
+            const clearcoatNormalTexture = ccData.clearcoatNormalTexture;
             material.clearCoatNormalMap = textures[clearcoatNormalTexture.index];
 
             extractTextureTransform(clearcoatNormalTexture, material, ['clearCoatNormal']);
@@ -1191,34 +1193,34 @@ var createMaterial = function (gltfMaterial, textures, disableFlipV) {
 };
 
 // create the anim structure
-var createAnimation = function (gltfAnimation, animationIndex, gltfAccessors, bufferViews, nodes) {
+const createAnimation = function (gltfAnimation, animationIndex, gltfAccessors, bufferViews, nodes) {
 
     // create animation data block for the accessor
-    var createAnimData = function (gltfAccessor) {
-        var data = getAccessorData(gltfAccessor, bufferViews);
+    const createAnimData = function (gltfAccessor) {
+        const data = getAccessorData(gltfAccessor, bufferViews);
         // TODO: this assumes data is tightly packed, handle the case data is interleaved
         return new AnimData(getNumComponents(gltfAccessor.type), new data.constructor(data));
     };
 
-    var interpMap = {
+    const interpMap = {
         "STEP": INTERPOLATION_STEP,
         "LINEAR": INTERPOLATION_LINEAR,
         "CUBICSPLINE": INTERPOLATION_CUBIC
     };
 
-    var inputMap = { };
-    var inputs = [];
+    const inputMap = { };
+    const inputs = [];
 
-    var outputMap = { };
-    var outputs = [];
+    const outputMap = { };
+    const outputs = [];
 
-    var curves = [];
+    const curves = [];
 
-    var i;
+    let i;
 
     // convert samplers
     for (i = 0; i < gltfAnimation.samplers.length; ++i) {
-        var sampler = gltfAnimation.samplers[i];
+        const sampler = gltfAnimation.samplers[i];
 
         // get input data
         if (!inputMap.hasOwnProperty(sampler.input)) {
@@ -1232,7 +1234,7 @@ var createAnimation = function (gltfAnimation, animationIndex, gltfAccessors, bu
             outputs.push(createAnimData(gltfAccessors[sampler.output]));
         }
 
-        var interpolation =
+        const interpolation =
             sampler.hasOwnProperty('interpolation') &&
             interpMap.hasOwnProperty(sampler.interpolation) ?
                 interpMap[sampler.interpolation] : INTERPOLATION_LINEAR;
@@ -1245,9 +1247,9 @@ var createAnimation = function (gltfAnimation, animationIndex, gltfAccessors, bu
             interpolation));
     }
 
-    var quatArrays = [];
+    const quatArrays = [];
 
-    var transformSchema = {
+    const transformSchema = {
         'translation': 'localPosition',
         'rotation': 'localRotation',
         'scale': 'localScale',
@@ -1256,12 +1258,12 @@ var createAnimation = function (gltfAnimation, animationIndex, gltfAccessors, bu
 
     // convert anim channels
     for (i = 0; i < gltfAnimation.channels.length; ++i) {
-        var channel = gltfAnimation.channels[i];
-        var target = channel.target;
-        var curve = curves[channel.sampler];
+        const channel = gltfAnimation.channels[i];
+        const target = channel.target;
+        const curve = curves[channel.sampler];
 
-        var node = nodes[target.node];
-        var entityPath = [nodes[0].name, ...AnimBinder.splitPath(node.path, '/')];
+        const node = nodes[target.node];
+        const entityPath = [nodes[0].name, ...AnimBinder.splitPath(node.path, '/')];
         curve._paths.push({
             entityPath: entityPath,
             component: 'graph',
@@ -1285,18 +1287,18 @@ var createAnimation = function (gltfAnimation, animationIndex, gltfAccessors, bu
 
     // run through the quaternion data arrays flipping quaternion keys
     // that don't fall in the same winding order.
-    var prevIndex = null;
-    var data;
+    let prevIndex = null;
+    let data;
     for (i = 0; i < quatArrays.length; ++i) {
-        var index = quatArrays[i];
+        const index = quatArrays[i];
         // skip over duplicate array indices
         if (i === 0 || index !== prevIndex) {
             data = outputs[index];
             if (data.components === 4) {
-                var d = data.data;
-                var len = d.length - 4;
-                for (var j = 0; j < len; j += 4) {
-                    var dp = d[j + 0] * d[j + 4] +
+                const d = data.data;
+                const len = d.length - 4;
+                for (let j = 0; j < len; j += 4) {
+                    const dp = d[j + 0] * d[j + 4] +
                              d[j + 1] * d[j + 5] +
                              d[j + 2] * d[j + 6] +
                              d[j + 3] * d[j + 7];
@@ -1314,7 +1316,7 @@ var createAnimation = function (gltfAnimation, animationIndex, gltfAccessors, bu
     }
 
     // calculate duration of the animation as maximum time value
-    var duration = 0;
+    let duration = 0;
     for (i = 0; i < inputs.length; i++) {
         data  = inputs[i]._data;
         duration = Math.max(duration, data.length === 0 ? 0 : data[data.length - 1]);
@@ -1328,8 +1330,8 @@ var createAnimation = function (gltfAnimation, animationIndex, gltfAccessors, bu
         curves);
 };
 
-var createNode = function (gltfNode, nodeIndex) {
-    var entity = new GraphNode();
+const createNode = function (gltfNode, nodeIndex) {
+    const entity = new GraphNode();
 
     if (gltfNode.hasOwnProperty('name') && gltfNode.name.length > 0) {
         entity.name = gltfNode.name;
@@ -1349,37 +1351,37 @@ var createNode = function (gltfNode, nodeIndex) {
     }
 
     if (gltfNode.hasOwnProperty('rotation')) {
-        var r = gltfNode.rotation;
+        const r = gltfNode.rotation;
         entity.setLocalRotation(r[0], r[1], r[2], r[3]);
     }
 
     if (gltfNode.hasOwnProperty('translation')) {
-        var t = gltfNode.translation;
+        const t = gltfNode.translation;
         entity.setLocalPosition(t[0], t[1], t[2]);
     }
 
     if (gltfNode.hasOwnProperty('scale')) {
-        var s = gltfNode.scale;
+        const s = gltfNode.scale;
         entity.setLocalScale(s[0], s[1], s[2]);
     }
 
     return entity;
 };
 
-var createSkins = function (device, gltf, nodes, bufferViews) {
+const createSkins = function (device, gltf, nodes, bufferViews) {
     if (!gltf.hasOwnProperty('skins') || gltf.skins.length === 0) {
         return [];
     }
 
     // cache for skins to filter out duplicates
-    var glbSkins = new Map();
+    const glbSkins = new Map();
 
     return gltf.skins.map(function (gltfSkin) {
         return createSkin(device, gltfSkin, gltf.accessors, bufferViews, nodes, glbSkins);
     });
 };
 
-var createMeshes = function (device, gltf, bufferViews, callback, disableFlipV) {
+const createMeshes = function (device, gltf, bufferViews, callback, disableFlipV) {
     if (!gltf.hasOwnProperty('meshes') || gltf.meshes.length === 0 ||
         !gltf.hasOwnProperty('accessors') || gltf.accessors.length === 0 ||
         !gltf.hasOwnProperty('bufferViews') || gltf.bufferViews.length === 0) {
@@ -1387,27 +1389,27 @@ var createMeshes = function (device, gltf, bufferViews, callback, disableFlipV) 
     }
 
     // dictionary of vertex buffers to avoid duplicates
-    var vertexBufferDict = {};
+    const vertexBufferDict = {};
 
     return gltf.meshes.map(function (gltfMesh) {
         return createMesh(device, gltfMesh, gltf.accessors, bufferViews, callback, disableFlipV, vertexBufferDict);
     });
 };
 
-var createMaterials = function (gltf, textures, options, disableFlipV) {
+const createMaterials = function (gltf, textures, options, disableFlipV) {
     if (!gltf.hasOwnProperty('materials') || gltf.materials.length === 0) {
         return [];
     }
 
-    var preprocess = options && options.material && options.material.preprocess;
-    var process = options && options.material && options.material.process || createMaterial;
-    var postprocess = options && options.material && options.material.postprocess;
+    const preprocess = options && options.material && options.material.preprocess;
+    const process = options && options.material && options.material.process || createMaterial;
+    const postprocess = options && options.material && options.material.postprocess;
 
     return gltf.materials.map(function (gltfMaterial) {
         if (preprocess) {
             preprocess(gltfMaterial);
         }
-        var material = process(gltfMaterial, textures, disableFlipV);
+        const material = process(gltfMaterial, textures, disableFlipV);
         if (postprocess) {
             postprocess(gltfMaterial, material);
         }
@@ -1415,19 +1417,19 @@ var createMaterials = function (gltf, textures, options, disableFlipV) {
     });
 };
 
-var createAnimations = function (gltf, nodes, bufferViews, options) {
+const createAnimations = function (gltf, nodes, bufferViews, options) {
     if (!gltf.hasOwnProperty('animations') || gltf.animations.length === 0) {
         return [];
     }
 
-    var preprocess = options && options.animation && options.animation.preprocess;
-    var postprocess = options && options.animation && options.animation.postprocess;
+    const preprocess = options && options.animation && options.animation.preprocess;
+    const postprocess = options && options.animation && options.animation.postprocess;
 
     return gltf.animations.map(function (gltfAnimation, index) {
         if (preprocess) {
             preprocess(gltfAnimation);
         }
-        var animation = createAnimation(gltfAnimation, index, gltf.accessors, bufferViews, nodes);
+        const animation = createAnimation(gltfAnimation, index, gltf.accessors, bufferViews, nodes);
         if (postprocess) {
             postprocess(gltfAnimation, animation);
         }
@@ -1435,20 +1437,20 @@ var createAnimations = function (gltf, nodes, bufferViews, options) {
     });
 };
 
-var createNodes = function (gltf, options) {
+const createNodes = function (gltf, options) {
     if (!gltf.hasOwnProperty('nodes') || gltf.nodes.length === 0) {
         return [];
     }
 
-    var preprocess = options && options.node && options.node.preprocess;
-    var process = options && options.node && options.node.process || createNode;
-    var postprocess = options && options.node && options.node.postprocess;
+    const preprocess = options && options.node && options.node.preprocess;
+    const process = options && options.node && options.node.process || createNode;
+    const postprocess = options && options.node && options.node.postprocess;
 
-    var nodes = gltf.nodes.map(function (gltfNode, index) {
+    const nodes = gltf.nodes.map(function (gltfNode, index) {
         if (preprocess) {
             preprocess(gltfNode);
         }
-        var node = process(gltfNode, index);
+        const node = process(gltfNode, index);
         if (postprocess) {
             postprocess(gltfNode, node);
         }
@@ -1456,12 +1458,12 @@ var createNodes = function (gltf, options) {
     });
 
     // build node hierarchy
-    for (var i = 0; i < gltf.nodes.length; ++i) {
-        var gltfNode = gltf.nodes[i];
+    for (let i = 0; i < gltf.nodes.length; ++i) {
+        const gltfNode = gltf.nodes[i];
         if (gltfNode.hasOwnProperty('children')) {
-            for (var j = 0; j < gltfNode.children.length; ++j) {
-                var parent = nodes[i];
-                var child = nodes[gltfNode.children[j]];
+            for (let j = 0; j < gltfNode.children.length; ++j) {
+                const parent = nodes[i];
+                const child = nodes[gltfNode.children[j]];
                 if (!child.parent) {
                     parent.addChild(child);
                 }
@@ -1472,23 +1474,23 @@ var createNodes = function (gltf, options) {
     return nodes;
 };
 
-var createScenes = function (gltf, nodes) {
-    var scenes = [];
-    var count = gltf.scenes.length;
+const createScenes = function (gltf, nodes) {
+    const scenes = [];
+    const count = gltf.scenes.length;
 
     // if there's a single scene with a single node in it, don't create wrapper nodes
     if (count === 1 && gltf.scenes[0].nodes.length === 1) {
-        var nodeIndex = gltf.scenes[0].nodes[0];
+        const nodeIndex = gltf.scenes[0].nodes[0];
         scenes.push(nodes[nodeIndex]);
     } else {
 
         // create root node per scene
-        for (var i = 0; i < count; i++) {
-            var scene = gltf.scenes[i];
-            var sceneRoot = new GraphNode(scene.name);
+        for (let i = 0; i < count; i++) {
+            const scene = gltf.scenes[i];
+            const sceneRoot = new GraphNode(scene.name);
 
-            for (var n = 0; n < scene.nodes.length; n++) {
-                var childNode = nodes[scene.nodes[n]];
+            for (let n = 0; n < scene.nodes.length; n++) {
+                const childNode = nodes[scene.nodes[n]];
                 sceneRoot.addChild(childNode);
             }
 
@@ -1500,9 +1502,9 @@ var createScenes = function (gltf, nodes) {
 };
 
 // create engine resources from the downloaded GLB data
-var createResources = function (device, gltf, bufferViews, textureAssets, options, callback) {
-    var preprocess = options && options.global && options.global.preprocess;
-    var postprocess = options && options.global && options.global.postprocess;
+const createResources = function (device, gltf, bufferViews, textureAssets, options, callback) {
+    const preprocess = options && options.global && options.global.preprocess;
+    const postprocess = options && options.global && options.global.postprocess;
 
     if (preprocess) {
         preprocess(gltf);
@@ -1511,18 +1513,18 @@ var createResources = function (device, gltf, bufferViews, textureAssets, option
     // The original version of FACT generated incorrectly flipped V texture
     // coordinates. We must compensate by -not- flipping V in this case. Once
     // all models have been re-exported we can remove this flag.
-    var disableFlipV = gltf.asset && gltf.asset.generator === 'PlayCanvas';
+    const disableFlipV = gltf.asset && gltf.asset.generator === 'PlayCanvas';
 
-    var nodes = createNodes(gltf, options);
-    var scenes = createScenes(gltf, nodes);
-    var animations = createAnimations(gltf, nodes, bufferViews, options);
-    var materials = createMaterials(gltf, textureAssets.map(function (textureAsset) {
+    const nodes = createNodes(gltf, options);
+    const scenes = createScenes(gltf, nodes);
+    const animations = createAnimations(gltf, nodes, bufferViews, options);
+    const materials = createMaterials(gltf, textureAssets.map(function (textureAsset) {
         return textureAsset.resource;
     }), options, disableFlipV);
-    var meshes = createMeshes(device, gltf, bufferViews, callback, disableFlipV);
-    var skins = createSkins(device, gltf, nodes, bufferViews);
+    const meshes = createMeshes(device, gltf, bufferViews, callback, disableFlipV);
+    const skins = createSkins(device, gltf, nodes, bufferViews);
 
-    var result = {
+    const result = {
         'gltf': gltf,
         'nodes': nodes,
         'scenes': scenes,
@@ -1540,8 +1542,8 @@ var createResources = function (device, gltf, bufferViews, textureAssets, option
     callback(null, result);
 };
 
-var applySampler = function (texture, gltfSampler) {
-    var getFilter = function (filter, defaultValue) {
+const applySampler = function (texture, gltfSampler) {
+    const getFilter = function (filter, defaultValue) {
         switch (filter) {
             case 9728: return FILTER_NEAREST;
             case 9729: return FILTER_LINEAR;
@@ -1553,7 +1555,7 @@ var applySampler = function (texture, gltfSampler) {
         }
     };
 
-    var getWrap = function (wrap, defaultValue) {
+    const getWrap = function (wrap, defaultValue) {
         switch (wrap) {
             case 33071: return ADDRESS_CLAMP_TO_EDGE;
             case 33648: return ADDRESS_MIRRORED_REPEAT;
@@ -1572,22 +1574,22 @@ var applySampler = function (texture, gltfSampler) {
 };
 
 // load an image
-var loadImageAsync = function (gltfImage, index, bufferViews, urlBase, registry, options, callback) {
-    var preprocess = options && options.image && options.image.preprocess;
-    var processAsync = (options && options.image && options.image.processAsync) || function (gltfImage, callback) {
+const loadImageAsync = function (gltfImage, index, bufferViews, urlBase, registry, options, callback) {
+    const preprocess = options && options.image && options.image.preprocess;
+    const processAsync = (options && options.image && options.image.processAsync) || function (gltfImage, callback) {
         callback(null, null);
     };
-    var postprocess = options && options.image && options.image.postprocess;
+    const postprocess = options && options.image && options.image.postprocess;
 
-    var onLoad = function (textureAsset) {
+    const onLoad = function (textureAsset) {
         if (postprocess) {
             postprocess(gltfImage, textureAsset);
         }
         callback(null, textureAsset);
     };
 
-    var loadTexture = function (url, mimeType, crossOrigin, isBlobUrl) {
-        var mimeTypeFileExtensions = {
+    const loadTexture = function (url, mimeType, crossOrigin, isBlobUrl) {
+        const mimeTypeFileExtensions = {
             'image/png': 'png',
             'image/jpeg': 'jpg',
             'image/basis': 'basis',
@@ -1596,16 +1598,16 @@ var loadImageAsync = function (gltfImage, index, bufferViews, urlBase, registry,
         };
 
         // construct the asset file
-        var file = { url: url };
+        const file = { url: url };
         if (mimeType) {
-            var extension = mimeTypeFileExtensions[mimeType];
+            const extension = mimeTypeFileExtensions[mimeType];
             if (extension) {
                 file.filename = 'glb-texture-' + index + '.' + extension;
             }
         }
 
         // create and load the asset
-        var asset = new Asset('texture_' + index, 'texture',  file, null, { crossOrigin: crossOrigin });
+        const asset = new Asset('texture_' + index, 'texture',  file, null, { crossOrigin: crossOrigin });
         asset.on('load', function () {
             if (isBlobUrl) {
                 URL.revokeObjectURL(url);
@@ -1638,7 +1640,7 @@ var loadImageAsync = function (gltfImage, index, bufferViews, urlBase, registry,
                 }
             } else if (gltfImage.hasOwnProperty('bufferView') && gltfImage.hasOwnProperty('mimeType')) {
                 // bufferview
-                var blob = new Blob([bufferViews[gltfImage.bufferView]], { type: gltfImage.mimeType });
+                const blob = new Blob([bufferViews[gltfImage.bufferView]], { type: gltfImage.mimeType });
                 loadTexture(URL.createObjectURL(blob), gltfImage.mimeType, null, true);
             } else {
                 // fail
@@ -1649,34 +1651,34 @@ var loadImageAsync = function (gltfImage, index, bufferViews, urlBase, registry,
 };
 
 // load textures using the asset system
-var loadTexturesAsync = function (gltf, bufferViews, urlBase, registry, options, callback) {
+const loadTexturesAsync = function (gltf, bufferViews, urlBase, registry, options, callback) {
     if (!gltf.hasOwnProperty('images') || gltf.images.length === 0 ||
         !gltf.hasOwnProperty('textures') || gltf.textures.length === 0) {
         callback(null, []);
         return;
     }
 
-    var preprocess = options && options.texture && options.texture.preprocess;
-    var processAsync = (options && options.texture && options.texture.processAsync) || function (gltfTexture, gltfImages, callback) {
+    const preprocess = options && options.texture && options.texture.preprocess;
+    const processAsync = (options && options.texture && options.texture.processAsync) || function (gltfTexture, gltfImages, callback) {
         callback(null, null);
     };
-    var postprocess = options && options.texture && options.texture.postprocess;
+    const postprocess = options && options.texture && options.texture.postprocess;
 
-    var assets = [];        // one per image
-    var textures = [];      // list per image
+    const assets = [];        // one per image
+    const textures = [];      // list per image
 
-    var remaining = gltf.textures.length;
-    var onLoad = function (textureIndex, imageIndex) {
+    let remaining = gltf.textures.length;
+    const onLoad = function (textureIndex, imageIndex) {
         if (!textures[imageIndex]) {
             textures[imageIndex] = [];
         }
         textures[imageIndex].push(textureIndex);
 
         if (--remaining === 0) {
-            var result = [];
+            const result = [];
             textures.forEach(function (textureList, imageIndex) {
                 textureList.forEach(function (textureIndex, index) {
-                    var textureAsset = (index === 0) ? assets[imageIndex] : cloneTextureAsset(assets[imageIndex]);
+                    const textureAsset = (index === 0) ? assets[imageIndex] : cloneTextureAsset(assets[imageIndex]);
                     applySampler(textureAsset.resource, (gltf.samplers || [])[gltf.textures[textureIndex].sampler]);
                     result[textureIndex] = textureAsset;
                     if (postprocess) {
@@ -1688,8 +1690,8 @@ var loadTexturesAsync = function (gltf, bufferViews, urlBase, registry, options,
         }
     };
 
-    for (var i = 0; i < gltf.textures.length; ++i) {
-        var gltfTexture = gltf.textures[i];
+    for (let i = 0; i < gltf.textures.length; ++i) {
+        const gltfTexture = gltf.textures[i];
 
         if (preprocess) {
             preprocess(gltfTexture);
@@ -1708,7 +1710,7 @@ var loadTexturesAsync = function (gltf, bufferViews, urlBase, registry, options,
                     onLoad(i, gltfImageIndex);
                 } else {
                     // first occcurrence, load it
-                    var gltfImage = gltf.images[gltfImageIndex];
+                    const gltfImage = gltf.images[gltfImageIndex];
                     loadImageAsync(gltfImage, i, bufferViews, urlBase, registry, options, function (err, textureAsset) {
                         if (err) {
                             callback(err);
@@ -1724,22 +1726,22 @@ var loadTexturesAsync = function (gltf, bufferViews, urlBase, registry, options,
 };
 
 // load gltf buffers asynchronously, returning them in the callback
-var loadBuffersAsync = function (gltf, binaryChunk, urlBase, options, callback) {
-    var result = [];
+const loadBuffersAsync = function (gltf, binaryChunk, urlBase, options, callback) {
+    const result = [];
 
     if (!gltf.buffers || gltf.buffers.length === 0) {
         callback(null, result);
         return;
     }
 
-    var preprocess = options && options.buffer && options.buffer.preprocess;
-    var processAsync = (options && options.buffer && options.buffer.processAsync) || function (gltfBuffer, callback) {
+    const preprocess = options && options.buffer && options.buffer.preprocess;
+    const processAsync = (options && options.buffer && options.buffer.processAsync) || function (gltfBuffer, callback) {
         callback(null, null);
     };
-    var postprocess = options && options.buffer && options.buffer.postprocess;
+    const postprocess = options && options.buffer && options.buffer.postprocess;
 
-    var remaining = gltf.buffers.length;
-    var onLoad = function (index, buffer) {
+    let remaining = gltf.buffers.length;
+    const onLoad = function (index, buffer) {
         result[index] = buffer;
         if (postprocess) {
             postprocess(gltf.buffers[index], buffer);
@@ -1749,8 +1751,8 @@ var loadBuffersAsync = function (gltf, binaryChunk, urlBase, options, callback) 
         }
     };
 
-    for (var i = 0; i < gltf.buffers.length; ++i) {
-        var gltfBuffer = gltf.buffers[i];
+    for (let i = 0; i < gltf.buffers.length; ++i) {
+        const gltfBuffer = gltf.buffers[i];
 
         if (preprocess) {
             preprocess(gltfBuffer);
@@ -1766,13 +1768,13 @@ var loadBuffersAsync = function (gltf, binaryChunk, urlBase, options, callback) 
                     if (isDataURI(gltfBuffer.uri)) {
                         // convert base64 to raw binary data held in a string
                         // doesn't handle URLEncoded DataURIs - see SO answer #6850276 for code that does this
-                        var byteString = atob(gltfBuffer.uri.split(',')[1]);
+                        const byteString = atob(gltfBuffer.uri.split(',')[1]);
 
                         // create a view into the buffer
-                        var binaryArray = new Uint8Array(byteString.length);
+                        const binaryArray = new Uint8Array(byteString.length);
 
                         // set the bytes of the buffer to the correct values
-                        for (var j = 0; j < byteString.length; j++) {
+                        for (let j = 0; j < byteString.length; j++) {
                             binaryArray[j] = byteString.charCodeAt(j);
                         }
 
@@ -1800,21 +1802,21 @@ var loadBuffersAsync = function (gltf, binaryChunk, urlBase, options, callback) 
 };
 
 // parse the gltf chunk, returns the gltf json
-var parseGltf = function (gltfChunk, callback) {
-    var decodeBinaryUtf8 = function (array) {
+const parseGltf = function (gltfChunk, callback) {
+    const decodeBinaryUtf8 = function (array) {
         if (typeof TextDecoder !== 'undefined') {
             return new TextDecoder().decode(array);
         }
 
-        var str = "";
-        for (var i = 0; i < array.length; i++) {
+        let str = "";
+        for (let i = 0; i < array.length; i++) {
             str += String.fromCharCode(array[i]);
         }
 
         return decodeURIComponent(escape(str));
     };
 
-    var gltf = JSON.parse(decodeBinaryUtf8(gltfChunk));
+    const gltf = JSON.parse(decodeBinaryUtf8(gltfChunk));
 
     // check gltf version
     if (gltf.asset && gltf.asset.version && parseFloat(gltf.asset.version) < 2) {
@@ -1826,13 +1828,13 @@ var parseGltf = function (gltfChunk, callback) {
 };
 
 // parse glb data, returns the gltf and binary chunk
-var parseGlb = function (glbData, callback) {
-    var data = new DataView(glbData);
+const parseGlb = function (glbData, callback) {
+    const data = new DataView(glbData);
 
     // read header
-    var magic = data.getUint32(0, true);
-    var version = data.getUint32(4, true);
-    var length = data.getUint32(8, true);
+    const magic = data.getUint32(0, true);
+    const version = data.getUint32(4, true);
+    const length = data.getUint32(8, true);
 
     if (magic !== 0x46546C67) {
         callback("Invalid magic number found in glb header. Expected 0x46546C67, found 0x" + magic.toString(16));
@@ -1850,15 +1852,15 @@ var parseGlb = function (glbData, callback) {
     }
 
     // read chunks
-    var chunks = [];
-    var offset = 12;
+    const chunks = [];
+    let offset = 12;
     while (offset < length) {
-        var chunkLength = data.getUint32(offset, true);
+        const chunkLength = data.getUint32(offset, true);
         if (offset + chunkLength + 8 > glbData.byteLength) {
             throw new Error("Invalid chunk length found in glb. Found " + chunkLength);
         }
-        var chunkType = data.getUint32(offset + 4, true);
-        var chunkData = new Uint8Array(glbData, offset + 8, chunkLength);
+        const chunkType = data.getUint32(offset + 4, true);
+        const chunkData = new Uint8Array(glbData, offset + 8, chunkLength);
         chunks.push({ length: chunkLength, type: chunkType, data: chunkData });
         offset += chunkLength + 8;
     }
@@ -1885,7 +1887,7 @@ var parseGlb = function (glbData, callback) {
 };
 
 // parse the chunk of data, which can be glb or gltf
-var parseChunk = function (filename, data, callback) {
+const parseChunk = function (filename, data, callback) {
     if (filename && filename.toLowerCase().endsWith('.glb')) {
         parseGlb(data, callback);
     } else {
@@ -1897,17 +1899,17 @@ var parseChunk = function (filename, data, callback) {
 };
 
 // create buffer views
-var parseBufferViewsAsync = function (gltf, buffers, options, callback) {
+const parseBufferViewsAsync = function (gltf, buffers, options, callback) {
 
-    var result = [];
+    const result = [];
 
-    var preprocess = options && options.bufferView && options.bufferView.preprocess;
-    var processAsync = (options && options.bufferView && options.bufferView.processAsync) || function (gltfBufferView, buffers, callback) {
+    const preprocess = options && options.bufferView && options.bufferView.preprocess;
+    const processAsync = (options && options.bufferView && options.bufferView.processAsync) || function (gltfBufferView, buffers, callback) {
         callback(null, null);
     };
-    var postprocess = options && options.bufferView && options.bufferView.postprocess;
+    const postprocess = options && options.bufferView && options.bufferView.postprocess;
 
-    var remaining = gltf.bufferViews ? gltf.bufferViews.length : 0;
+    let remaining = gltf.bufferViews ? gltf.bufferViews.length : 0;
 
     // handle case of no buffers
     if (!remaining) {
@@ -1915,8 +1917,8 @@ var parseBufferViewsAsync = function (gltf, buffers, options, callback) {
         return;
     }
 
-    var onLoad = function (index, bufferView) {
-        var gltfBufferView = gltf.bufferViews[index];
+    const onLoad = function (index, bufferView) {
+        const gltfBufferView = gltf.bufferViews[index];
         if (gltfBufferView.hasOwnProperty('byteStride')) {
             bufferView.byteStride = gltfBufferView.byteStride;
         }
@@ -1930,8 +1932,8 @@ var parseBufferViewsAsync = function (gltf, buffers, options, callback) {
         }
     };
 
-    for (var i = 0; i < gltf.bufferViews.length; ++i) {
-        var gltfBufferView = gltf.bufferViews[i];
+    for (let i = 0; i < gltf.bufferViews.length; ++i) {
+        const gltfBufferView = gltf.bufferViews[i];
 
         if (preprocess) {
             preprocess(gltfBufferView);
@@ -1943,10 +1945,10 @@ var parseBufferViewsAsync = function (gltf, buffers, options, callback) {
             } else if (result) {
                 onLoad(i, result);
             } else {
-                var buffer = buffers[gltfBufferView.buffer];
-                var typedArray = new Uint8Array(buffer.buffer,
-                                                buffer.byteOffset + (gltfBufferView.hasOwnProperty('byteOffset') ? gltfBufferView.byteOffset : 0),
-                                                gltfBufferView.byteLength);
+                const buffer = buffers[gltfBufferView.buffer];
+                const typedArray = new Uint8Array(buffer.buffer,
+                                                  buffer.byteOffset + (gltfBufferView.hasOwnProperty('byteOffset') ? gltfBufferView.byteOffset : 0),
+                                                  gltfBufferView.byteLength);
                 onLoad(i, typedArray);
             }
         }.bind(null, i, gltfBufferView));
@@ -2002,7 +2004,7 @@ class GlbParser {
 
     // parse the gltf or glb data synchronously. external resources (buffers and images) are ignored.
     static parse(filename, data, device, options) {
-        var result = null;
+        let result = null;
 
         options = options || { };
 
@@ -2042,14 +2044,14 @@ class GlbParser {
     // create a pc.Model from the parsed GLB data structures
     static createModel(glb, defaultMaterial) {
 
-        var createMeshInstance = function (model, mesh, skins, skinInstances, materials, node, gltfNode) {
-            var material = (mesh.materialIndex === undefined) ? defaultMaterial : materials[mesh.materialIndex];
-            var meshInstance = new MeshInstance(mesh, material, node);
+        const createMeshInstance = function (model, mesh, skins, skinInstances, materials, node, gltfNode) {
+            const material = (mesh.materialIndex === undefined) ? defaultMaterial : materials[mesh.materialIndex];
+            const meshInstance = new MeshInstance(mesh, material, node);
 
             if (mesh.morph) {
-                var morphInstance = new MorphInstance(mesh.morph);
+                const morphInstance = new MorphInstance(mesh.morph);
                 if (mesh.weights) {
-                    for (var wi = 0; wi < mesh.weights.length; wi++) {
+                    for (let wi = 0; wi < mesh.weights.length; wi++) {
                         morphInstance.setWeight(wi, mesh.weights[wi]);
                     }
                 }
@@ -2059,11 +2061,11 @@ class GlbParser {
             }
 
             if (gltfNode.hasOwnProperty('skin')) {
-                var skinIndex = gltfNode.skin;
-                var skin = skins[skinIndex];
+                const skinIndex = gltfNode.skin;
+                const skin = skins[skinIndex];
                 mesh.skin = skin;
 
-                var skinInstance = skinInstances[skinIndex];
+                const skinInstance = skinInstances[skinIndex];
                 meshInstance.skinInstance = skinInstance;
                 model.skinInstances.push(skinInstance);
             }
@@ -2071,12 +2073,12 @@ class GlbParser {
             model.meshInstances.push(meshInstance);
         };
 
-        var model = new Model();
+        const model = new Model();
 
         // create skinInstance for each skin
-        var s, skinInstances = [];
+        let s, skinInstances = [];
         for (s = 0; s < glb.skins.length; s++) {
-            var skinInstance = new SkinInstance(glb.skins[s]);
+            const skinInstance = new SkinInstance(glb.skins[s]);
             skinInstance.bones = glb.skins[s].bones;
             skinInstances.push(skinInstance);
         }
@@ -2094,13 +2096,13 @@ class GlbParser {
         }
 
         // create mesh instance for meshes on nodes that are part of hierarchy
-        for (var i = 0; i < glb.nodes.length; i++) {
-            var node = glb.nodes[i];
+        for (let i = 0; i < glb.nodes.length; i++) {
+            const node = glb.nodes[i];
             if (node.root === model.graph) {
-                var gltfNode = glb.gltf.nodes[i];
+                const gltfNode = glb.gltf.nodes[i];
                 if (gltfNode.hasOwnProperty('mesh')) {
-                    var meshGroup = glb.meshes[gltfNode.mesh];
-                    for (var mi = 0; mi < meshGroup.length; mi++) {
+                    const meshGroup = glb.meshes[gltfNode.mesh];
+                    for (let mi = 0; mi < meshGroup.length; mi++) {
                         const mesh = meshGroup[mi];
                         if (mesh) {
                             createMeshInstance(model, mesh, glb.skins, skinInstances, glb.materials, node, gltfNode);

--- a/src/resources/parser/glb-parser.js
+++ b/src/resources/parser/glb-parser.js
@@ -2076,7 +2076,6 @@ class GlbParser {
         const model = new Model();
 
         // create skinInstance for each skin
-        let s;
         const skinInstances = [];
         for (let s = 0; s < glb.skins.length; s++) {
             const skinInstance = new SkinInstance(glb.skins[s]);

--- a/src/resources/parser/glb-parser.js
+++ b/src/resources/parser/glb-parser.js
@@ -2077,9 +2077,9 @@ class GlbParser {
 
         // create skinInstance for each skin
         const skinInstances = [];
-        for (let s = 0; s < glb.skins.length; s++) {
-            const skinInstance = new SkinInstance(glb.skins[s]);
-            skinInstance.bones = glb.skins[s].bones;
+        for (const skin of glb.skins) {
+            const skinInstance = new SkinInstance(skin);
+            skinInstance.bones = skin.bones;
             skinInstances.push(skinInstance);
         }
 

--- a/src/resources/parser/glb-parser.js
+++ b/src/resources/parser/glb-parser.js
@@ -2076,8 +2076,9 @@ class GlbParser {
         const model = new Model();
 
         // create skinInstance for each skin
-        let s, skinInstances = [];
-        for (s = 0; s < glb.skins.length; s++) {
+        let s;
+        const skinInstances = [];
+        for (let s = 0; s < glb.skins.length; s++) {
             const skinInstance = new SkinInstance(glb.skins[s]);
             skinInstance.bones = glb.skins[s].bones;
             skinInstances.push(skinInstance);
@@ -2090,8 +2091,8 @@ class GlbParser {
         } else {
             // create group node for all scenes
             model.graph = new GraphNode('SceneGroup');
-            for (s = 0; s < glb.scenes.length; s++) {
-                model.graph.addChild(glb.scenes[s]);
+            for (const scene of glb.scenes) {
+                model.graph.addChild(scene);
             }
         }
 

--- a/src/resources/parser/json-model.js
+++ b/src/resources/parser/json-model.js
@@ -28,7 +28,7 @@ import { SkinInstance } from '../../scene/skin-instance.js';
 
 import { Material } from '../../scene/materials/material.js';
 
-var JSON_PRIMITIVE_TYPE = {
+const JSON_PRIMITIVE_TYPE = {
     "points": PRIMITIVE_POINTS,
     "lines": PRIMITIVE_LINES,
     "lineloop": PRIMITIVE_LINELOOP,
@@ -38,7 +38,7 @@ var JSON_PRIMITIVE_TYPE = {
     "trianglefan": PRIMITIVE_TRIFAN
 };
 
-var JSON_VERTEX_ELEMENT_TYPE = {
+const JSON_VERTEX_ELEMENT_TYPE = {
     "int8": TYPE_INT8,
     "uint8": TYPE_UINT8,
     "int16": TYPE_INT16,
@@ -55,7 +55,7 @@ class JsonModelParser {
     }
 
     parse(data) {
-        var modelData = data.model;
+        const modelData = data.model;
         if (!modelData) {
             return null;
         }
@@ -68,27 +68,27 @@ class JsonModelParser {
         }
 
         // NODE HIERARCHY
-        var nodes = this._parseNodes(data);
+        const nodes = this._parseNodes(data);
 
         // SKINS
-        var skins = this._parseSkins(data, nodes);
+        const skins = this._parseSkins(data, nodes);
 
         // VERTEX BUFFERS
-        var vertexBuffers = this._parseVertexBuffers(data);
+        const vertexBuffers = this._parseVertexBuffers(data);
 
         // INDEX BUFFER
-        var indices = this._parseIndexBuffers(data, vertexBuffers);
+        const indices = this._parseIndexBuffers(data, vertexBuffers);
 
         // MORPHS
-        var morphs = this._parseMorphs(data, nodes, vertexBuffers);
+        const morphs = this._parseMorphs(data, nodes, vertexBuffers);
 
         // MESHES
-        var meshes = this._parseMeshes(data, skins.skins, morphs.morphs, vertexBuffers, indices.buffer, indices.data);
+        const meshes = this._parseMeshes(data, skins.skins, morphs.morphs, vertexBuffers, indices.buffer, indices.data);
 
         // MESH INSTANCES
-        var meshInstances = this._parseMeshInstances(data, nodes, meshes, skins.skins, skins.instances, morphs.morphs, morphs.instances);
+        const meshInstances = this._parseMeshInstances(data, nodes, meshes, skins.skins, skins.instances, morphs.morphs, morphs.instances);
 
-        var model = new Model();
+        const model = new Model();
         model.graph = nodes[0];
         model.meshInstances = meshInstances;
         model.skinInstances = skins.instances;
@@ -99,14 +99,14 @@ class JsonModelParser {
     }
 
     _parseNodes(data) {
-        var modelData = data.model;
-        var nodes = [];
-        var i;
+        const modelData = data.model;
+        const nodes = [];
+        let i;
 
         for (i = 0; i < modelData.nodes.length; i++) {
-            var nodeData = modelData.nodes[i];
+            const nodeData = modelData.nodes[i];
 
-            var node = new GraphNode(nodeData.name);
+            const node = new GraphNode(nodeData.name);
             node.setLocalPosition(nodeData.position[0], nodeData.position[1], nodeData.position[2]);
             node.setLocalEulerAngles(nodeData.rotation[0], nodeData.rotation[1], nodeData.rotation[2]);
             node.setLocalScale(nodeData.scale[0], nodeData.scale[1], nodeData.scale[2]);
@@ -123,34 +123,34 @@ class JsonModelParser {
     }
 
     _parseSkins(data, nodes) {
-        var modelData = data.model;
-        var skins = [];
-        var skinInstances = [];
-        var i, j;
+        const modelData = data.model;
+        const skins = [];
+        const skinInstances = [];
+        let i, j;
 
         if (!this._device.supportsBoneTextures && modelData.skins.length > 0) {
-            var boneLimit = this._device.getBoneLimit();
+            const boneLimit = this._device.getBoneLimit();
             partitionSkin(modelData, null, boneLimit);
         }
 
         for (i = 0; i < modelData.skins.length; i++) {
-            var skinData = modelData.skins[i];
+            const skinData = modelData.skins[i];
 
-            var inverseBindMatrices = [];
+            const inverseBindMatrices = [];
             for (j = 0; j < skinData.inverseBindMatrices.length; j++) {
-                var ibm = skinData.inverseBindMatrices[j];
+                const ibm = skinData.inverseBindMatrices[j];
                 inverseBindMatrices[j] = new Mat4().set(ibm);
             }
 
-            var skin = new Skin(this._device, inverseBindMatrices, skinData.boneNames);
+            const skin = new Skin(this._device, inverseBindMatrices, skinData.boneNames);
             skins.push(skin);
 
-            var skinInstance = new SkinInstance(skin);
+            const skinInstance = new SkinInstance(skin);
             // Resolve bone IDs to actual graph nodes
-            var bones = [];
+            const bones = [];
             for (j = 0; j < skin.boneNames.length; j++) {
-                var boneName = skin.boneNames[j];
-                var bone = nodes[0].findByName(boneName);
+                const boneName = skin.boneNames[j];
+                const bone = nodes[0].findByName(boneName);
                 bones.push(bone);
             }
             skinInstance.bones = bones;
@@ -165,11 +165,11 @@ class JsonModelParser {
 
     // find number of vertices used by a mesh that is using morph target with index morphIndex
     _getMorphVertexCount(modelData, morphIndex, vertexBuffers) {
-        for (var i = 0; i < modelData.meshes.length; i++) {
-            var meshData = modelData.meshes[i];
+        for (let i = 0; i < modelData.meshes.length; i++) {
+            const meshData = modelData.meshes[i];
 
             if (meshData.morph === morphIndex) {
-                var vertexBuffer = vertexBuffers[meshData.vertices];
+                const vertexBuffer = vertexBuffers[meshData.vertices];
                 return vertexBuffer.numVertices;
             }
         }
@@ -177,20 +177,20 @@ class JsonModelParser {
     }
 
     _parseMorphs(data, nodes, vertexBuffers) {
-        var modelData = data.model;
-        var morphs = [];
-        var morphInstances = [];
-        var i, j, vertexCount;
+        const modelData = data.model;
+        const morphs = [];
+        const morphInstances = [];
+        let i, j, vertexCount;
 
-        var targets, morphTarget, morphTargetArray;
+        let targets, morphTarget, morphTargetArray;
 
         if (modelData.morphs) {
 
             // convert sparse morph target vertex data to full format
-            var sparseToFull = function (data, indices, totalCount) {
-                var full = new Float32Array(totalCount * 3);
-                for (var s = 0; s < indices.length; s++) {
-                    var dstIndex = indices[s] * 3;
+            const sparseToFull = function (data, indices, totalCount) {
+                const full = new Float32Array(totalCount * 3);
+                for (let s = 0; s < indices.length; s++) {
+                    const dstIndex = indices[s] * 3;
                     full[dstIndex] = data[s * 3];
                     full[dstIndex + 1] = data[s * 3 + 1];
                     full[dstIndex + 2] = data[s * 3 + 2];
@@ -206,19 +206,19 @@ class JsonModelParser {
                 vertexCount = this._getMorphVertexCount(modelData, i, vertexBuffers);
 
                 for (j = 0; j < targets.length; j++) {
-                    var targetAabb = targets[j].aabb;
+                    const targetAabb = targets[j].aabb;
 
-                    var min = targetAabb.min;
-                    var max = targetAabb.max;
-                    var aabb = new BoundingBox(
+                    const min = targetAabb.min;
+                    const max = targetAabb.max;
+                    const aabb = new BoundingBox(
                         new Vec3((max[0] + min[0]) * 0.5, (max[1] + min[1]) * 0.5, (max[2] + min[2]) * 0.5),
                         new Vec3((max[0] - min[0]) * 0.5, (max[1] - min[1]) * 0.5, (max[2] - min[2]) * 0.5)
                     );
 
                     // convert sparse to full format
-                    var indices = targets[j].indices;
-                    var deltaPositions = targets[j].deltaPositions;
-                    var deltaNormals = targets[j].deltaNormals;
+                    const indices = targets[j].indices;
+                    let deltaPositions = targets[j].deltaPositions;
+                    let deltaNormals = targets[j].deltaNormals;
                     if (indices) {
                         deltaPositions = sparseToFull(deltaPositions, indices, vertexCount);
                         deltaNormals = sparseToFull(deltaNormals, indices, vertexCount);
@@ -232,10 +232,10 @@ class JsonModelParser {
                     morphTargetArray.push(morphTarget);
                 }
 
-                var morph = new Morph(morphTargetArray, this._device);
+                const morph = new Morph(morphTargetArray, this._device);
                 morphs.push(morph);
 
-                var morphInstance = new MorphInstance(morph);
+                const morphInstance = new MorphInstance(morph);
                 morphInstances.push(morphInstance);
             }
         }
@@ -247,10 +247,10 @@ class JsonModelParser {
     }
 
     _parseVertexBuffers(data) {
-        var modelData = data.model;
-        var vertexBuffers = [];
-        var attribute, attributeName;
-        var attributeMap = {
+        const modelData = data.model;
+        const vertexBuffers = [];
+        let attribute, attributeName;
+        const attributeMap = {
             position: SEMANTIC_POSITION,
             normal: SEMANTIC_NORMAL,
             tangent: SEMANTIC_TANGENT,
@@ -267,11 +267,11 @@ class JsonModelParser {
             texCoord7: SEMANTIC_TEXCOORD7
         };
 
-        var i, j;
+        let i, j;
         for (i = 0; i < modelData.vertices.length; i++) {
-            var vertexData = modelData.vertices[i];
+            const vertexData = modelData.vertices[i];
 
-            var formatDesc = [];
+            const formatDesc = [];
             for (attributeName in vertexData) {
                 attribute = vertexData[attributeName];
 
@@ -282,13 +282,13 @@ class JsonModelParser {
                     normalize: (attributeMap[attributeName] === SEMANTIC_COLOR)
                 });
             }
-            var vertexFormat = new VertexFormat(this._device, formatDesc);
+            const vertexFormat = new VertexFormat(this._device, formatDesc);
 
             // Create the vertex buffer
-            var numVertices = vertexData.position.data.length / vertexData.position.components;
-            var vertexBuffer = new VertexBuffer(this._device, vertexFormat, numVertices);
+            const numVertices = vertexData.position.data.length / vertexData.position.components;
+            const vertexBuffer = new VertexBuffer(this._device, vertexFormat, numVertices);
 
-            var iterator = new VertexIterator(vertexBuffer);
+            const iterator = new VertexIterator(vertexBuffer);
             for (j = 0; j < numVertices; j++) {
                 for (attributeName in vertexData) {
                     attribute = vertexData[attributeName];
@@ -319,22 +319,22 @@ class JsonModelParser {
     }
 
     _parseIndexBuffers(data, vertexBuffers) {
-        var modelData = data.model;
-        var indexBuffer = null;
-        var indexData = null;
-        var i;
+        const modelData = data.model;
+        let indexBuffer = null;
+        let indexData = null;
+        let i;
 
         // Count the number of indices in the model
-        var numIndices = 0;
+        let numIndices = 0;
         for (i = 0; i < modelData.meshes.length; i++) {
-            var meshData = modelData.meshes[i];
+            const meshData = modelData.meshes[i];
             if (meshData.indices !== undefined) {
                 numIndices += meshData.indices.length;
             }
         }
 
         // Create an index buffer big enough to store all indices in the model
-        var maxVerts = 0;
+        let maxVerts = 0;
         for (i = 0; i < vertexBuffers.length; i++) {
             maxVerts = Math.max(maxVerts, vertexBuffers[i].numVertices);
         }
@@ -355,25 +355,25 @@ class JsonModelParser {
     }
 
     _parseMeshes(data, skins, morphs, vertexBuffers, indexBuffer, indexData) {
-        var modelData = data.model;
+        const modelData = data.model;
 
-        var meshes = [];
-        var indexBase = 0;
-        var i;
+        const meshes = [];
+        let indexBase = 0;
+        let i;
 
         for (i = 0; i < modelData.meshes.length; i++) {
-            var meshData = modelData.meshes[i];
+            const meshData = modelData.meshes[i];
 
-            var meshAabb = meshData.aabb;
-            var min = meshAabb.min;
-            var max = meshAabb.max;
-            var aabb = new BoundingBox(
+            const meshAabb = meshData.aabb;
+            const min = meshAabb.min;
+            const max = meshAabb.max;
+            const aabb = new BoundingBox(
                 new Vec3((max[0] + min[0]) * 0.5, (max[1] + min[1]) * 0.5, (max[2] + min[2]) * 0.5),
                 new Vec3((max[0] - min[0]) * 0.5, (max[1] - min[1]) * 0.5, (max[2] - min[2]) * 0.5)
             );
 
-            var indexed = (meshData.indices !== undefined);
-            var mesh = new Mesh(this._device);
+            const indexed = (meshData.indices !== undefined);
+            const mesh = new Mesh(this._device);
             mesh.vertexBuffer = vertexBuffers[meshData.vertices];
             mesh.indexBuffer[0] = indexed ? indexBuffer : null;
             mesh.primitive[0].type = JSON_PRIMITIVE_TYPE[meshData.type];
@@ -401,20 +401,20 @@ class JsonModelParser {
     }
 
     _parseMeshInstances(data, nodes, meshes, skins, skinInstances, morphs, morphInstances) {
-        var modelData = data.model;
-        var meshInstances = [];
-        var i;
+        const modelData = data.model;
+        const meshInstances = [];
+        let i;
 
         for (i = 0; i < modelData.meshInstances.length; i++) {
-            var meshInstanceData = modelData.meshInstances[i];
+            const meshInstanceData = modelData.meshInstances[i];
 
-            var node = nodes[meshInstanceData.node];
-            var mesh = meshes[meshInstanceData.mesh];
+            const node = nodes[meshInstanceData.node];
+            const mesh = meshes[meshInstanceData.mesh];
 
-            var meshInstance = new MeshInstance(mesh, Material.defaultMaterial, node);
+            const meshInstance = new MeshInstance(mesh, Material.defaultMaterial, node);
 
             if (mesh.skin) {
-                var skinIndex = skins.indexOf(mesh.skin);
+                const skinIndex = skins.indexOf(mesh.skin);
                 // #if _DEBUG
                 if (skinIndex === -1) {
                     throw new Error('Mesh\'s skin does not appear in skin array.');
@@ -424,7 +424,7 @@ class JsonModelParser {
             }
 
             if (mesh.morph) {
-                var morphIndex = morphs.indexOf(mesh.morph);
+                const morphIndex = morphs.indexOf(mesh.morph);
                 // #if _DEBUG
                 if (morphIndex === -1) {
                     throw new Error('Mesh\'s morph does not appear in morph array.');

--- a/src/resources/parser/json-model.js
+++ b/src/resources/parser/json-model.js
@@ -249,7 +249,6 @@ class JsonModelParser {
     _parseVertexBuffers(data) {
         const modelData = data.model;
         const vertexBuffers = [];
-        let attribute, attributeName;
         const attributeMap = {
             position: SEMANTIC_POSITION,
             normal: SEMANTIC_NORMAL,
@@ -267,13 +266,12 @@ class JsonModelParser {
             texCoord7: SEMANTIC_TEXCOORD7
         };
 
-        let i, j;
-        for (i = 0; i < modelData.vertices.length; i++) {
+        for (let i = 0; i < modelData.vertices.length; i++) {
             const vertexData = modelData.vertices[i];
 
             const formatDesc = [];
-            for (attributeName in vertexData) {
-                attribute = vertexData[attributeName];
+            for (const attributeName in vertexData) {
+                const attribute = vertexData[attributeName];
 
                 formatDesc.push({
                     semantic: attributeMap[attributeName],
@@ -289,9 +287,9 @@ class JsonModelParser {
             const vertexBuffer = new VertexBuffer(this._device, vertexFormat, numVertices);
 
             const iterator = new VertexIterator(vertexBuffer);
-            for (j = 0; j < numVertices; j++) {
-                for (attributeName in vertexData) {
-                    attribute = vertexData[attributeName];
+            for (let j = 0; j < numVertices; j++) {
+                for (const attributeName in vertexData) {
+                    const attribute = vertexData[attributeName];
 
                     switch (attribute.components) {
                         case 1:
@@ -359,9 +357,8 @@ class JsonModelParser {
 
         const meshes = [];
         let indexBase = 0;
-        let i;
 
-        for (i = 0; i < modelData.meshes.length; i++) {
+        for (let i = 0; i < modelData.meshes.length; i++) {
             const meshData = modelData.meshes[i];
 
             const meshAabb = meshData.aabb;

--- a/src/resources/parser/material/json-standard-material.js
+++ b/src/resources/parser/material/json-standard-material.js
@@ -23,10 +23,10 @@ class JsonStandardMaterialParser {
     }
 
     parse(input) {
-        var migrated = this.migrate(input);
-        var validated = this._validate(migrated);
+        const migrated = this.migrate(input);
+        const validated = this._validate(migrated);
 
-        var material = new StandardMaterial();
+        const material = new StandardMaterial();
         this.initialize(material, validated);
 
         return material;
@@ -55,9 +55,9 @@ class JsonStandardMaterialParser {
         }
 
         // initialize material values from the input data
-        for (var key in data) {
-            var type = standardMaterialParameterTypes[key];
-            var value = data[key];
+        for (const key in data) {
+            const type = standardMaterialParameterTypes[key];
+            const value = data[key];
 
             if (type === 'vec2') {
                 material[key] = new Vec2(value[0], value[1]);
@@ -80,8 +80,8 @@ class JsonStandardMaterialParser {
                 // OTHERWISE: material already has a texture assigned, but data contains a valid asset id (which means the asset isn't yet loaded)
                 // leave current texture (probably a placeholder) until the asset is loaded
             } else if (type === 'boundingbox') {
-                var center = new Vec3(value.center[0], value.center[1], value.center[2]);
-                var halfExtents = new Vec3(value.halfExtents[0], value.halfExtents[1], value.halfExtents[2]);
+                const center = new Vec3(value.center[0], value.center[1], value.center[2]);
+                const halfExtents = new Vec3(value.halfExtents[0], value.halfExtents[1], value.halfExtents[2]);
                 material[key] = new BoundingBox(center, halfExtents);
             } else {
                 // number, boolean and enum types don't require type creation
@@ -111,10 +111,10 @@ class JsonStandardMaterialParser {
             delete data.mapping_format;
         }
 
-        var i;
+        let i;
         // list of properties that have been renamed in StandardMaterial
         // but may still exists in data in old format
-        var RENAMED_PROPERTIES = [
+        const RENAMED_PROPERTIES = [
             ["bumpMapFactor", "bumpiness"],
 
             ["aoUvSet", "aoMapUv"],
@@ -137,8 +137,8 @@ class JsonStandardMaterialParser {
         // if an old property name exists without a new one,
         // move property into new name and delete old one.
         for (i = 0; i < RENAMED_PROPERTIES.length; i++) {
-            var _old = RENAMED_PROPERTIES[i][0];
-            var _new = RENAMED_PROPERTIES[i][1];
+            const _old = RENAMED_PROPERTIES[i][0];
+            const _new = RENAMED_PROPERTIES[i][1];
 
             if (data[_old] !== undefined && !(data[_new] !== undefined)) {
                 data[_new] = data[_old];
@@ -147,13 +147,13 @@ class JsonStandardMaterialParser {
         }
 
         // Properties that may exist in input data, but are now ignored
-        var DEPRECATED_PROPERTIES = [
+        const DEPRECATED_PROPERTIES = [
             'fresnelFactor',
             'shadowSampleType'
         ];
 
         for (i = 0; i < DEPRECATED_PROPERTIES.length; i++) {
-            var name = DEPRECATED_PROPERTIES[i];
+            const name = DEPRECATED_PROPERTIES[i];
             if (data.hasOwnProperty(name)) {
                 delete data[name];
             }

--- a/src/resources/parser/scene.js
+++ b/src/resources/parser/scene.js
@@ -11,18 +11,18 @@ class SceneParser {
     }
 
     parse(data) {
-        var entities = {};
-        var id, i, curEnt;
-        var parent = null;
+        const entities = {};
+        let id, i, curEnt;
+        let parent = null;
 
-        var compressed = data.compressedFormat;
+        const compressed = data.compressedFormat;
         if (compressed) {
             data.entities = new Decompress(data.entities, compressed).run();
         }
 
         // instantiate entities
         for (id in data.entities) {
-            var curData = data.entities[id];
+            const curData = data.entities[id];
             curEnt = this._createEntity(curData, compressed);
             entities[id] = curEnt;
             if (curData.parent === null) {
@@ -33,10 +33,10 @@ class SceneParser {
         // put entities into hierarchy
         for (id in data.entities) {
             curEnt = entities[id];
-            var children = data.entities[id].children;
-            var len = children.length;
+            const children = data.entities[id].children;
+            const len = children.length;
             for (i = 0; i < len; i++) {
-                var childEnt = entities[children[i]];
+                const childEnt = entities[children[i]];
                 if (childEnt) {
                     curEnt.addChild(childEnt);
                 }
@@ -51,7 +51,7 @@ class SceneParser {
     }
 
     _createEntity(data, compressed) {
-        var entity = new Entity();
+        const entity = new Entity();
 
         entity.name = data.name;
         entity.setGuid(data.resource_id);
@@ -67,7 +67,7 @@ class SceneParser {
         entity.template = data.template;
 
         if (data.tags) {
-            for (var i = 0; i < data.tags.length; i++) {
+            for (let i = 0; i < data.tags.length; i++) {
                 entity.tags.add(data.tags[i]);
             }
         }
@@ -86,9 +86,9 @@ class SceneParser {
             CompressUtils.setCompressedPRS(entity, data, compressed);
 
         } else {
-            var p = data.position;
-            var r = data.rotation;
-            var s = data.scale;
+            const p = data.position;
+            const r = data.rotation;
+            const s = data.scale;
 
             entity.setLocalPosition(p[0], p[1], p[2]);
             entity.setLocalEulerAngles(r[0], r[1], r[2]);
@@ -98,13 +98,13 @@ class SceneParser {
 
     _openComponentData(entity, entities) {
         // Create components in order
-        var systemsList = this._app.systems.list;
+        const systemsList = this._app.systems.list;
 
-        var i, len = systemsList.length;
-        var entityData = entities[entity.getGuid()];
+        let i, len = systemsList.length;
+        const entityData = entities[entity.getGuid()];
         for (i = 0; i < len; i++) {
-            var system = systemsList[i];
-            var componentData = entityData.components[system.id];
+            const system = systemsList[i];
+            const componentData = entityData.components[system.id];
             if (componentData) {
                 system.addComponent(entity, componentData);
             }
@@ -112,7 +112,7 @@ class SceneParser {
 
         // Open all children and add them to the node
         len = entityData.children.length;
-        var children = entity._children;
+        const children = entity._children;
         for (i = 0; i < len; i++) {
             children[i] = this._openComponentData(children[i], entities);
         }

--- a/src/resources/parser/scene.js
+++ b/src/resources/parser/scene.js
@@ -12,7 +12,6 @@ class SceneParser {
 
     parse(data) {
         const entities = {};
-        let id, i, curEnt;
         let parent = null;
 
         const compressed = data.compressedFormat;
@@ -21,9 +20,9 @@ class SceneParser {
         }
 
         // instantiate entities
-        for (id in data.entities) {
+        for (const id in data.entities) {
             const curData = data.entities[id];
-            curEnt = this._createEntity(curData, compressed);
+            const curEnt = this._createEntity(curData, compressed);
             entities[id] = curEnt;
             if (curData.parent === null) {
                 parent = curEnt;
@@ -31,11 +30,11 @@ class SceneParser {
         }
 
         // put entities into hierarchy
-        for (id in data.entities) {
-            curEnt = entities[id];
+        for (const id in data.entities) {
+            const curEnt = entities[id];
             const children = data.entities[id].children;
             const len = children.length;
-            for (i = 0; i < len; i++) {
+            for (let i = 0; i < len; i++) {
                 const childEnt = entities[children[i]];
                 if (childEnt) {
                     curEnt.addChild(childEnt);
@@ -100,9 +99,9 @@ class SceneParser {
         // Create components in order
         const systemsList = this._app.systems.list;
 
-        let i, len = systemsList.length;
+        let len = systemsList.length;
         const entityData = entities[entity.getGuid()];
-        for (i = 0; i < len; i++) {
+        for (let i = 0; i < len; i++) {
             const system = systemsList[i];
             const componentData = entityData.components[system.id];
             if (componentData) {
@@ -113,7 +112,7 @@ class SceneParser {
         // Open all children and add them to the node
         len = entityData.children.length;
         const children = entity._children;
-        for (i = 0; i < len; i++) {
+        for (let i = 0; i < len; i++) {
             children[i] = this._openComponentData(children[i], entities);
         }
 

--- a/src/resources/parser/texture/basis.js
+++ b/src/resources/parser/texture/basis.js
@@ -18,7 +18,7 @@ class BasisParser {
     }
 
     load(url, callback, asset) {
-        var options = {
+        const options = {
             cache: true,
             responseType: "arraybuffer",
             retry: this.maxRetries > 0,
@@ -35,7 +35,7 @@ class BasisParser {
                     // the quality of GGGR normal maps under PVR compression is still terrible
                     // so here we instruct the basis transcoder to unswizzle the normal map data
                     // and pack to 565
-                    var unswizzleGGGR = basisTargetFormat() === 'pvr' &&
+                    const unswizzleGGGR = basisTargetFormat() === 'pvr' &&
                                         asset && asset.file && asset.file.variants &&
                                         asset.file.variants.basis &&
                                         ((asset.file.variants.basis.opt & 8) !== 0);
@@ -43,7 +43,7 @@ class BasisParser {
                         // remove the swizzled flag from the asset
                         asset.file.variants.basis.opt &= ~8;
                     }
-                    var basisModuleFound = basisTranscode(url.load, result, callback, { unswizzleGGGR: unswizzleGGGR });
+                    const basisModuleFound = basisTranscode(url.load, result, callback, { unswizzleGGGR: unswizzleGGGR });
 
                     if (!basisModuleFound) {
                         callback('Basis module not found. Asset "' + asset.name + '" basis texture variant will not be loaded.');
@@ -55,7 +55,7 @@ class BasisParser {
 
     // our async transcode call provides the neat structure we need to create the texture instance
     open(url, data, device) {
-        var texture = new Texture(device, {
+        const texture = new Texture(device, {
             name: url,
             // #if _PROFILER
             profilerHint: TEXHINT_ASSET,

--- a/src/resources/parser/texture/dds.js
+++ b/src/resources/parser/texture/dds.js
@@ -15,36 +15,36 @@ import { Texture } from '../../../graphics/texture.js';
 
 // Defined here:
 // https://docs.microsoft.com/en-us/windows/desktop/direct3ddds/dds-header
-var DDSD_CAPS = 0x1;            // Required in every .dds file.
-var DDSD_HEIGHT = 0x2;          // Required in every .dds file.
-var DDSD_WIDTH = 0x4;           // Required in every .dds file.
-var DDSD_PITCH = 0x8;           // Required when pitch is provided for an uncompressed texture.
-var DDSD_PIXELFORMAT = 0x1000;  // Required in every .dds file.
-var DDSD_MIPMAPCOUNT = 0x20000; // Required in a mipmapped texture.
-var DDSD_LINEARSIZE = 0x80000;  // Required when pitch is provided for a compressed texture.
-var DDSD_DEPTH = 0x800000;      // Required in a depth texture.
+const DDSD_CAPS = 0x1;            // Required in every .dds file.
+const DDSD_HEIGHT = 0x2;          // Required in every .dds file.
+const DDSD_WIDTH = 0x4;           // Required in every .dds file.
+const DDSD_PITCH = 0x8;           // Required when pitch is provided for an uncompressed texture.
+const DDSD_PIXELFORMAT = 0x1000;  // Required in every .dds file.
+const DDSD_MIPMAPCOUNT = 0x20000; // Required in a mipmapped texture.
+const DDSD_LINEARSIZE = 0x80000;  // Required when pitch is provided for a compressed texture.
+const DDSD_DEPTH = 0x800000;      // Required in a depth texture.
 
-var DDSCAPS2_CUBEMAP = 0x200;
-var DDSCAPS2_CUBEMAP_POSITIVEX = 0x400;
-var DDSCAPS2_CUBEMAP_NEGATIVEX = 0x800;
-var DDSCAPS2_CUBEMAP_POSITIVEY = 0x1000;
-var DDSCAPS2_CUBEMAP_NEGATIVEY = 0x2000;
-var DDSCAPS2_CUBEMAP_POSITIVEZ = 0x4000;
-var DDSCAPS2_CUBEMAP_NEGATIVEZ = 0x8000;
+const DDSCAPS2_CUBEMAP = 0x200;
+const DDSCAPS2_CUBEMAP_POSITIVEX = 0x400;
+const DDSCAPS2_CUBEMAP_NEGATIVEX = 0x800;
+const DDSCAPS2_CUBEMAP_POSITIVEY = 0x1000;
+const DDSCAPS2_CUBEMAP_NEGATIVEY = 0x2000;
+const DDSCAPS2_CUBEMAP_POSITIVEZ = 0x4000;
+const DDSCAPS2_CUBEMAP_NEGATIVEZ = 0x8000;
 
-var DDS_CUBEMAP_ALLFACES = DDSCAPS2_CUBEMAP |
+const DDS_CUBEMAP_ALLFACES = DDSCAPS2_CUBEMAP |
       DDSCAPS2_CUBEMAP_POSITIVEX | DDSCAPS2_CUBEMAP_NEGATIVEX |
       DDSCAPS2_CUBEMAP_POSITIVEY | DDSCAPS2_CUBEMAP_NEGATIVEY |
       DDSCAPS2_CUBEMAP_POSITIVEZ | DDSCAPS2_CUBEMAP_NEGATIVEZ;
 
 // Defined here:
 // https://docs.microsoft.com/en-us/windows/desktop/direct3ddds/dds-pixelformat
-var DDPF_ALPHAPIXELS = 0x1;
-var DDPF_ALPHA = 0x2;
-var DDPF_FOURCC = 0x4;
-var DDPF_RGB = 0x40;
-var DDPF_YUV = 0x200;
-var DDPF_LUMINANCE = 0x20000;
+const DDPF_ALPHAPIXELS = 0x1;
+const DDPF_ALPHA = 0x2;
+const DDPF_FOURCC = 0x4;
+const DDPF_RGB = 0x40;
+const DDPF_YUV = 0x200;
+const DDPF_LUMINANCE = 0x20000;
 
 /* eslint-enable no-unused-vars */
 
@@ -56,22 +56,22 @@ function makeFourCC(str) {
            (str.charCodeAt(3) << 24);
 }
 
-var DDS_MAGIC = makeFourCC('DDS ');
+const DDS_MAGIC = makeFourCC('DDS ');
 
 // Standard
-var FCC_DXT1 = makeFourCC('DXT1');
-var FCC_DXT5 = makeFourCC('DXT5');
-var FCC_DX10 = makeFourCC('DX10');
-var FCC_FP32 = 116; // RGBA32f
+const FCC_DXT1 = makeFourCC('DXT1');
+const FCC_DXT5 = makeFourCC('DXT5');
+const FCC_DX10 = makeFourCC('DX10');
+const FCC_FP32 = 116; // RGBA32f
 
 // Non-standard
-var FCC_ETC1 = makeFourCC('ETC1');
-var FCC_PVRTC_2BPP_RGB_1 = makeFourCC('P231');
-var FCC_PVRTC_2BPP_RGBA_1 = makeFourCC('P241');
-var FCC_PVRTC_4BPP_RGB_1 = makeFourCC('P431');
-var FCC_PVRTC_4BPP_RGBA_1 = makeFourCC('P441');
+const FCC_ETC1 = makeFourCC('ETC1');
+const FCC_PVRTC_2BPP_RGB_1 = makeFourCC('P231');
+const FCC_PVRTC_2BPP_RGBA_1 = makeFourCC('P241');
+const FCC_PVRTC_4BPP_RGB_1 = makeFourCC('P431');
+const FCC_PVRTC_4BPP_RGBA_1 = makeFourCC('P441');
 
-var fccToFormat = {};
+const fccToFormat = {};
 fccToFormat[FCC_FP32] = PIXELFORMAT_RGBA32F;
 fccToFormat[FCC_DXT1] = PIXELFORMAT_DXT1;
 fccToFormat[FCC_DXT5] = PIXELFORMAT_DXT5;
@@ -94,7 +94,7 @@ class DdsParser {
     }
 
     load(url, callback, asset) {
-        var options = {
+        const options = {
             cache: true,
             responseType: "arraybuffer",
             retry: this.maxRetries > 0,
@@ -104,13 +104,13 @@ class DdsParser {
     }
 
     open(url, data, device) {
-        var textureData = this.parse(data);
+        const textureData = this.parse(data);
 
         if (!textureData) {
             return null;
         }
 
-        var texture = new Texture(device, {
+        const texture = new Texture(device, {
             name: url,
             // #if _PROFILER
             profilerHint: TEXHINT_ASSET,
@@ -130,12 +130,12 @@ class DdsParser {
     }
 
     parse(data) {
-        var arrayBuffer = data;
+        const arrayBuffer = data;
 
-        var headerU32 = new Uint32Array(arrayBuffer, 0, 32);
+        let headerU32 = new Uint32Array(arrayBuffer, 0, 32);
 
         // Check magic number
-        var magic = headerU32[0];
+        const magic = headerU32[0];
         if (magic !== DDS_MAGIC) {
             // #if _DEBUG
             console.warn("Invalid magic number found in DDS file. Expected 0x20534444. Got " + magic + ".");
@@ -143,7 +143,7 @@ class DdsParser {
             return null;
         }
 
-        var header = {
+        const header = {
             size: headerU32[1],
             flags: headerU32[2],
             height: headerU32[3],
@@ -178,14 +178,14 @@ class DdsParser {
         }
 
         // Byte offset locating the first byte of texture level data
-        var offset = 4 + header.size;
+        let offset = 4 + header.size;
 
         // If the ddspf.flags property is set to DDPF_FOURCC and ddspf.fourCc is set to
         // "DX10" an additional DDS_HEADER_DXT10 structure will be present.
         // https://docs.microsoft.com/en-us/windows/desktop/direct3ddds/dds-header-dxt10
-        // var header10; // not used
-        var isFcc = header.ddspf.flags & DDPF_FOURCC;
-        var fcc = header.ddspf.fourCc;
+        // let header10; // not used
+        const isFcc = header.ddspf.flags & DDPF_FOURCC;
+        const fcc = header.ddspf.fourCc;
         if (isFcc && (fcc === FCC_DX10)) {
             headerU32 = new Uint32Array(arrayBuffer, 128, 5);
             // header10 = {
@@ -199,24 +199,24 @@ class DdsParser {
         }
 
         // Read texture data
-        // var bpp = header.ddspf.rgbBitCount; // not used
-        var isCubeMap = header.caps2 === DDS_CUBEMAP_ALLFACES;
-        var numFaces = isCubeMap ? 6 : 1;
-        var numMips = header.flags & DDSD_MIPMAPCOUNT ? header.mipMapCount : 1;
-        var levels = [];
+        // let bpp = header.ddspf.rgbBitCount; // not used
+        const isCubeMap = header.caps2 === DDS_CUBEMAP_ALLFACES;
+        const numFaces = isCubeMap ? 6 : 1;
+        const numMips = header.flags & DDSD_MIPMAPCOUNT ? header.mipMapCount : 1;
+        const levels = [];
         if (isCubeMap) {
-            for (var mipCnt = 0; mipCnt < numMips; mipCnt++) {
+            for (let mipCnt = 0; mipCnt < numMips; mipCnt++) {
                 levels.push([]);
             }
         }
-        for (var face = 0; face < numFaces; face++) {
-            var mipWidth = header.width;
-            var mipHeight = header.height;
+        for (let face = 0; face < numFaces; face++) {
+            let mipWidth = header.width;
+            let mipHeight = header.height;
 
-            for (var mip = 0; mip < numMips; mip++) {
-                var mipSize;
+            for (let mip = 0; mip < numMips; mip++) {
+                let mipSize;
                 if ((fcc === FCC_DXT1) || (fcc === FCC_DXT5) || (fcc === FCC_ETC1)) {
-                    var bytesPerBlock = (fcc === FCC_DXT5) ? 16 : 8;
+                    const bytesPerBlock = (fcc === FCC_DXT5) ? 16 : 8;
                     mipSize = Math.floor((mipWidth + 3) / 4) * Math.floor((mipHeight + 3) / 4) * bytesPerBlock;
                 } else if ((fcc === FCC_PVRTC_2BPP_RGB_1 || fcc === FCC_PVRTC_2BPP_RGBA_1)) {
                     mipSize = Math.max(mipWidth, 16) * Math.max(mipHeight, 8) / 4;
@@ -231,7 +231,7 @@ class DdsParser {
                     return null;
                 }
 
-                var mipData = (fcc === FCC_FP32) ? new Float32Array(arrayBuffer, offset, mipSize) : new Uint8Array(arrayBuffer, offset, mipSize);
+                const mipData = (fcc === FCC_FP32) ? new Float32Array(arrayBuffer, offset, mipSize) : new Uint8Array(arrayBuffer, offset, mipSize);
                 if (isCubeMap) {
                     levels[mip][face] = mipData;
                 } else {

--- a/src/resources/parser/texture/hdr.js
+++ b/src/resources/parser/texture/hdr.js
@@ -15,14 +15,14 @@ class Reader {
     }
 
     readLine() {
-        var view = this.view;
-        var result = "";
+        const view = this.view;
+        let result = "";
         while (true) {
             if (this.offset >= view.byteLength) {
                 break;
             }
 
-            var c = String.fromCharCode(this.readUint8());
+            const c = String.fromCharCode(this.readUint8());
             if (c === '\n') {
                 break;
             }
@@ -36,15 +36,15 @@ class Reader {
     }
 
     readUint8s(result) {
-        var view = this.view;
-        for (var i = 0; i < result.length; ++i) {
+        const view = this.view;
+        for (let i = 0; i < result.length; ++i) {
             result[i] = view.getUint8(this.offset++);
         }
     }
 
     peekUint8s(result) {
-        var view = this.view;
-        for (var i = 0; i < result.length; ++i) {
+        const view = this.view;
+        for (let i = 0; i < result.length; ++i) {
             result[i] = view.getUint8(this.offset + i);
         }
     }
@@ -63,7 +63,7 @@ class HdrParser {
     }
 
     load(url, callback, asset) {
-        var options = {
+        const options = {
             cache: true,
             responseType: "arraybuffer",
             retry: this.maxRetries > 0,
@@ -73,13 +73,13 @@ class HdrParser {
     }
 
     open(url, data, device) {
-        var textureData = this.parse(data);
+        const textureData = this.parse(data);
 
         if (!textureData) {
             return null;
         }
 
-        var texture = new Texture(device, {
+        const texture = new Texture(device, {
             name: url,
             // #if _PROFILER
             profilerHint: TEXHINT_ASSET,
@@ -104,24 +104,24 @@ class HdrParser {
 
     // https://floyd.lbl.gov/radiance/refer/filefmts.pdf with help from http://www.graphics.cornell.edu/~bjw/rgbe/rgbe.c
     parse(data) {
-        var reader = new Reader(data);
+        const reader = new Reader(data);
 
         // require magic
-        var magic = reader.readLine();
+        const magic = reader.readLine();
         if (!magic.startsWith('#?RADIANCE')) {
             this._error("radiance header has invalid magic");
             return null;
         }
 
         // read header variables
-        var variables = { };
+        const variables = { };
         while (true) {
-            var line = reader.readLine();
+            const line = reader.readLine();
             if (line.length === 0) {
                 // empty line signals end of header
                 break;
             } else {
-                var parts = line.split('=');
+                const parts = line.split('=');
                 if (parts.length === 2) {
                     variables[parts[0]] = parts[1];
                 }
@@ -135,15 +135,15 @@ class HdrParser {
         }
 
         // read the resolution specifier
-        var resolution = reader.readLine().split(' ');
+        const resolution = reader.readLine().split(' ');
         if (resolution.length != 4) {
             this._error("radiance header has invalid resolution");
             return null;
         }
 
-        var height = parseInt(resolution[1], 10);
-        var width = parseInt(resolution[3], 10);
-        var pixels = this._readPixels(reader, width, height, resolution[0] === '-Y');
+        const height = parseInt(resolution[1], 10);
+        const width = parseInt(resolution[3], 10);
+        const pixels = this._readPixels(reader, width, height, resolution[0] === '-Y');
 
         if (!pixels) {
             return null;
@@ -163,7 +163,7 @@ class HdrParser {
             return this._readPixelsFlat(reader, width, height);
         }
 
-        var rgbe = [0, 0, 0, 0];
+        const rgbe = [0, 0, 0, 0];
 
         // check first scanline width to determine whether the file is RLE
         reader.peekUint8s(rgbe);
@@ -173,10 +173,10 @@ class HdrParser {
         }
 
         // allocate texture buffer
-        var buffer = new ArrayBuffer(width * height * 4);
-        var view = new Uint8Array(buffer);
-        var scanstart = flipY ? width * 4 * (height - 1) : 0;
-        var x, y, i, channel, count, value;
+        const buffer = new ArrayBuffer(width * height * 4);
+        const view = new Uint8Array(buffer);
+        let scanstart = flipY ? width * 4 * (height - 1) : 0;
+        let x, y, i, channel, count, value;
 
         for (y = 0; y < height; ++y) {
             // read scanline width specifier
@@ -224,7 +224,7 @@ class HdrParser {
     }
 
     _readPixelsFlat(reader, width, height) {
-        var filePixelBytes = reader.view.buffer.byteLength - reader.offset;
+        const filePixelBytes = reader.view.buffer.byteLength - reader.offset;
         return filePixelBytes === width * height * 4 ? new Uint8Array(reader.view.buffer, reader.offset) : null;
     }
 

--- a/src/resources/parser/texture/img.js
+++ b/src/resources/parser/texture/img.js
@@ -23,7 +23,7 @@ class ImgParser {
     }
 
     load(url, callback, asset) {
-        var crossOrigin;
+        let crossOrigin;
         if (asset && asset.options && asset.options.hasOwnProperty('crossOrigin')) {
             crossOrigin = asset.options.crossOrigin;
         } else if (ABSOLUTE_URL.test(url.load)) {
@@ -37,9 +37,9 @@ class ImgParser {
     }
 
     open(url, data, device) {
-        var ext = path.getExtension(url).toLowerCase();
-        var format = (ext === ".jpg" || ext === ".jpeg") ? PIXELFORMAT_R8_G8_B8 : PIXELFORMAT_R8_G8_B8_A8;
-        var texture = new Texture(device, {
+        const ext = path.getExtension(url).toLowerCase();
+        const format = (ext === ".jpg" || ext === ".jpeg") ? PIXELFORMAT_R8_G8_B8 : PIXELFORMAT_R8_G8_B8_A8;
+        const texture = new Texture(device, {
             name: url,
             // #if _PROFILER
             profilerHint: TEXHINT_ASSET,
@@ -53,14 +53,14 @@ class ImgParser {
     }
 
     _loadImage(url, originalUrl, crossOrigin, callback) {
-        var image = new Image();
+        const image = new Image();
         if (crossOrigin) {
             image.crossOrigin = crossOrigin;
         }
 
-        var retries = 0;
-        var maxRetries = this.maxRetries;
-        var retryTimeout;
+        let retries = 0;
+        const maxRetries = this.maxRetries;
+        let retryTimeout;
 
         // Call success callback after opening Texture
         image.onload = function () {
@@ -72,11 +72,11 @@ class ImgParser {
             if (retryTimeout) return;
 
             if (maxRetries > 0 && ++retries <= maxRetries) {
-                var retryDelay = Math.pow(2, retries) * 100;
+                const retryDelay = Math.pow(2, retries) * 100;
                 console.log("Error loading Texture from: '" + originalUrl + "' - Retrying in " + retryDelay + "ms...");
 
-                var idx = url.indexOf('?');
-                var separator = idx >= 0 ? '&' : '?';
+                const idx = url.indexOf('?');
+                const separator = idx >= 0 ? '&' : '?';
 
                 retryTimeout = setTimeout(function () {
                     // we need to add a cache busting argument if we are trying to re-load an image element
@@ -94,7 +94,7 @@ class ImgParser {
     }
 
     _loadImageBitmap(url, originalUrl, crossOrigin, callback) {
-        var options = {
+        const options = {
             cache: true,
             responseType: "blob",
             retry: this.maxRetries > 0,

--- a/src/resources/parser/texture/ktx.js
+++ b/src/resources/parser/texture/ktx.js
@@ -37,7 +37,7 @@ class KtxParser {
     }
 
     load(url, callback, asset) {
-        var options = {
+        const options = {
             cache: true,
             responseType: "arraybuffer",
             retry: this.maxRetries > 0,
@@ -47,13 +47,13 @@ class KtxParser {
     }
 
     open(url, data, device) {
-        var textureData = this.parse(data);
+        const textureData = this.parse(data);
 
         if (!textureData) {
             return null;
         }
 
-        var texture = new Texture(device, {
+        const texture = new Texture(device, {
             name: url,
             // #if _PROFILER
             profilerHint: TEXHINT_ASSET,
@@ -73,7 +73,7 @@ class KtxParser {
     }
 
     parse(data) {
-        var headerU32 = new Uint32Array(data, 0, 16);
+        const headerU32 = new Uint32Array(data, 0, 16);
 
         if (IDENTIFIER[0] !== headerU32[0] || IDENTIFIER[1] !== headerU32[1] || IDENTIFIER[2] !== headerU32[2]) {
             // #if _DEBUG
@@ -82,7 +82,7 @@ class KtxParser {
             return null;
         }
 
-        var header = {
+        const header = {
             endianness: headerU32[3], // todo: Use this information
             glType: headerU32[4],
             glTypeSize: headerU32[5],
@@ -127,25 +127,25 @@ class KtxParser {
         }
 
         // Byte offset locating the first byte of texture level data
-        var offset = (16 * 4) + header.bytesOfKeyValueData;
+        let offset = (16 * 4) + header.bytesOfKeyValueData;
 
-        var levels = [];
-        var isCubeMap = false;
-        for (var mipmapLevel = 0; mipmapLevel < (header.numberOfMipmapLevels || 1); mipmapLevel++) {
-            var imageSizeInBytes = new Uint32Array(data.slice(offset, offset + 4))[0];
+        const levels = [];
+        let isCubeMap = false;
+        for (let mipmapLevel = 0; mipmapLevel < (header.numberOfMipmapLevels || 1); mipmapLevel++) {
+            const imageSizeInBytes = new Uint32Array(data.slice(offset, offset + 4))[0];
             offset += 4;
             // Currently array textures not supported. Keeping this here for reference.
-            // for (var arrayElement = 0; arrayElement < (header.numberOfArrayElements || 1); arrayElement++) {
-            var faceSizeInBytes = imageSizeInBytes / (header.numberOfFaces || 1);
+            // for (let arrayElement = 0; arrayElement < (header.numberOfArrayElements || 1); arrayElement++) {
+            const faceSizeInBytes = imageSizeInBytes / (header.numberOfFaces || 1);
             // Create array for cubemaps
             if (header.numberOfFaces > 1) {
                 isCubeMap = true;
                 levels.push([]);
             }
-            for (var face = 0; face < header.numberOfFaces; face++) {
+            for (let face = 0; face < header.numberOfFaces; face++) {
                 // Currently more than 1 pixel depth not supported. Keeping this here for reference.
-                // for (var  zSlice = 0; zSlice < (header.pixelDepth || 1); zSlice++) {
-                var mipData = new Uint8Array(data, offset, faceSizeInBytes);
+                // for (let  zSlice = 0; zSlice < (header.pixelDepth || 1); zSlice++) {
+                const mipData = new Uint8Array(data, offset, faceSizeInBytes);
                 // Handle cubemaps
                 if (header.numberOfFaces > 1) {
                     levels[mipmapLevel].push(mipData);

--- a/src/resources/parser/texture/legacy-dds.js
+++ b/src/resources/parser/texture/legacy-dds.js
@@ -23,7 +23,7 @@ class LegacyDdsParser {
     }
 
     load(url, callback, asset) {
-        var options = {
+        const options = {
             cache: true,
             responseType: "arraybuffer",
             retry: this.maxRetries > 0,
@@ -33,35 +33,35 @@ class LegacyDdsParser {
     }
 
     open(url, data, device) {
-        var header = new Uint32Array(data, 0, 128 / 4);
+        const header = new Uint32Array(data, 0, 128 / 4);
 
-        var width = header[4];
-        var height = header[3];
-        var mips = Math.max(header[7], 1);
-        var isFourCc = header[20] === 4;
-        var fcc = header[21];
-        var bpp = header[22];
-        var isCubemap = header[28] === 65024; // TODO: check by bitflag
+        const width = header[4];
+        const height = header[3];
+        const mips = Math.max(header[7], 1);
+        const isFourCc = header[20] === 4;
+        const fcc = header[21];
+        const bpp = header[22];
+        const isCubemap = header[28] === 65024; // TODO: check by bitflag
 
-        var FCC_DXT1 = 827611204; // DXT1
-        var FCC_DXT5 = 894720068; // DXT5
-        var FCC_FP32 = 116; // RGBA32f
+        const FCC_DXT1 = 827611204; // DXT1
+        const FCC_DXT5 = 894720068; // DXT5
+        const FCC_FP32 = 116; // RGBA32f
 
         // non standard
-        var FCC_ETC1 = 826496069;
-        var FCC_PVRTC_2BPP_RGB_1 = 825438800;
-        var FCC_PVRTC_2BPP_RGBA_1 = 825504336;
-        var FCC_PVRTC_4BPP_RGB_1 = 825439312;
-        var FCC_PVRTC_4BPP_RGBA_1 = 825504848;
+        const FCC_ETC1 = 826496069;
+        const FCC_PVRTC_2BPP_RGB_1 = 825438800;
+        const FCC_PVRTC_2BPP_RGBA_1 = 825504336;
+        const FCC_PVRTC_4BPP_RGB_1 = 825439312;
+        const FCC_PVRTC_4BPP_RGBA_1 = 825504848;
 
-        var compressed = false;
-        var floating = false;
-        var etc1 = false;
-        var pvrtc2 = false;
-        var pvrtc4 = false;
-        var format = null;
+        let compressed = false;
+        let floating = false;
+        let etc1 = false;
+        let pvrtc2 = false;
+        let pvrtc4 = false;
+        let format = null;
 
-        var texture;
+        let texture;
 
         if (isFourCc) {
             if (fcc === FCC_DXT1) {
@@ -118,17 +118,17 @@ class LegacyDdsParser {
             cubemap: isCubemap
         });
 
-        var offset = 128;
-        var faces = isCubemap ? 6 : 1;
-        var mipSize;
-        var DXT_BLOCK_WIDTH = 4;
-        var DXT_BLOCK_HEIGHT = 4;
-        var blockSize = fcc === FCC_DXT1 ? 8 : 16;
-        var numBlocksAcross, numBlocksDown, numBlocks;
-        for (var face = 0; face < faces; face++) {
-            var mipWidth = width;
-            var mipHeight = height;
-            for (var i = 0; i < mips; i++) {
+        let offset = 128;
+        const faces = isCubemap ? 6 : 1;
+        let mipSize;
+        const DXT_BLOCK_WIDTH = 4;
+        const DXT_BLOCK_HEIGHT = 4;
+        const blockSize = fcc === FCC_DXT1 ? 8 : 16;
+        let numBlocksAcross, numBlocksDown, numBlocks;
+        for (let face = 0; face < faces; face++) {
+            let mipWidth = width;
+            let mipHeight = height;
+            for (let i = 0; i < mips; i++) {
                 if (compressed) {
                     if (etc1) {
                         mipSize = Math.floor((mipWidth + 3) / 4) * Math.floor((mipHeight + 3) / 4) * 8;
@@ -146,7 +146,7 @@ class LegacyDdsParser {
                     mipSize = mipWidth * mipHeight * 4;
                 }
 
-                var mipBuff = floating ? new Float32Array(data, offset, mipSize) : new Uint8Array(data, offset, mipSize);
+                const mipBuff = floating ? new Float32Array(data, offset, mipSize) : new Uint8Array(data, offset, mipSize);
                 if (!isCubemap) {
                     texture._levels[i] = mipBuff;
                 } else {

--- a/src/resources/render.js
+++ b/src/resources/render.js
@@ -2,12 +2,12 @@ import { Render } from '../scene/render.js';
 
 // The scope of this function is the render asset
 function onContainerAssetLoaded(containerAsset) {
-    var renderAsset = this;
+    const renderAsset = this;
     if (!renderAsset.resource) return;
 
-    var containerResource = containerAsset.resource;
+    const containerResource = containerAsset.resource;
 
-    var render = containerResource.renders && containerResource.renders[renderAsset.data.renderIndex];
+    const render = containerResource.renders && containerResource.renders[renderAsset.data.renderIndex];
     if (render) {
         renderAsset.resource.meshes = render.resource;
     }
@@ -15,7 +15,7 @@ function onContainerAssetLoaded(containerAsset) {
 
 // The scope of this function is the render asset
 function onContainerAssetAdded(containerAsset) {
-    var renderAsset = this;
+    const renderAsset = this;
 
     renderAsset.registry.off('load:' + containerAsset.id, onContainerAssetLoaded, renderAsset);
     renderAsset.registry.on('load:' + containerAsset.id, onContainerAssetLoaded, renderAsset);
@@ -30,7 +30,7 @@ function onContainerAssetAdded(containerAsset) {
 }
 
 function onContainerAssetRemoved(containerAsset) {
-    var renderAsset = this;
+    const renderAsset = this;
 
     renderAsset.registry.off('load:' + containerAsset.id, onContainerAssetLoaded, renderAsset);
 
@@ -63,7 +63,7 @@ class RenderHandler {
         if (!asset.data.containerAsset)
             return;
 
-        var containerAsset = registry.get(asset.data.containerAsset);
+        const containerAsset = registry.get(asset.data.containerAsset);
         if (!containerAsset) {
             registry.once('add:' + asset.data.containerAsset, onContainerAssetAdded, asset);
             return;

--- a/src/resources/scene-utils.js
+++ b/src/resources/scene-utils.js
@@ -1,6 +1,6 @@
 import { http } from '../net/http.js';
 
-var SceneUtils = {
+const SceneUtils = {
     /**
      * @private
      * @function
@@ -25,7 +25,7 @@ var SceneUtils = {
             if (!err) {
                 callback(err, response);
             } else {
-                var errMsg = 'Error while loading scene JSON ' + url.original;
+                let errMsg = 'Error while loading scene JSON ' + url.original;
                 if (err.message) {
                     errMsg += ': ' + err.message;
                     if (err.stack) {

--- a/src/resources/scene.js
+++ b/src/resources/scene.js
@@ -22,11 +22,11 @@ class SceneHandler {
         // prevent script initialization until entire scene is open
         this._app.systems.script.preloading = true;
 
-        var parser = new SceneParser(this._app, false);
-        var parent = parser.parse(data);
+        const parser = new SceneParser(this._app, false);
+        const parent = parser.parse(data);
 
         // set scene root
-        var scene = this._app.scene;
+        const scene = this._app.scene;
         scene.root = parent;
 
         this._app.applySceneSettings(data.settings);

--- a/src/resources/script.js
+++ b/src/resources/script.js
@@ -35,13 +35,13 @@ class ScriptHandler {
             };
         }
 
-        var self = this;
+        const self = this;
         script.app = this._app;
 
         this._loadScript(url.load, function (err, url, extra) {
             if (!err) {
                 if (script.legacy) {
-                    var Type = null;
+                    let Type = null;
                     // pop the type from the loading stack
                     if (ScriptHandler._types.length) {
                         Type = ScriptHandler._types.pop();
@@ -57,9 +57,9 @@ class ScriptHandler {
                     // return the resource
                     callback(null, Type, extra);
                 } else {
-                    var obj = { };
+                    const obj = { };
 
-                    for (var i = 0; i < ScriptHandler._types.length; i++)
+                    for (let i = 0; i < ScriptHandler._types.length; i++)
                         obj[ScriptHandler._types[i].name] = ScriptHandler._types[i];
 
                     ScriptHandler._types.length = 0;
@@ -82,8 +82,8 @@ class ScriptHandler {
     patch(asset, assets) { }
 
     _loadScript(url, callback) {
-        var head = document.head;
-        var element = document.createElement('script');
+        const head = document.head;
+        const element = document.createElement('script');
         this._cache[url] = element;
 
         // use async=false to force scripts to execute in order
@@ -93,7 +93,7 @@ class ScriptHandler {
             callback("Script: " + e.target.src + " failed to load");
         }, false);
 
-        var done = false;
+        let done = false;
         element.onload = element.onreadystatechange = function () {
             if (!done && (!this.readyState || (this.readyState == "loaded" || this.readyState == "complete"))) {
                 done = true; // prevent double event firing

--- a/src/resources/sprite.js
+++ b/src/resources/sprite.js
@@ -6,7 +6,7 @@ import { Sprite } from '../scene/sprite.js';
 
 // The scope of this function is the sprite asset
 function onTextureAtlasLoaded(atlasAsset) {
-    var spriteAsset = this;
+    const spriteAsset = this;
     if (spriteAsset.resource) {
         spriteAsset.resource.atlas = atlasAsset.resource;
     }
@@ -14,7 +14,7 @@ function onTextureAtlasLoaded(atlasAsset) {
 
 // The scope of this function is the sprite asset
 function onTextureAtlasAdded(atlasAsset) {
-    var spriteAsset = this;
+    const spriteAsset = this;
     spriteAsset.registry.load(atlasAsset);
 }
 
@@ -58,7 +58,7 @@ class SpriteHandler {
 
     // Create sprite resource
     open(url, data) {
-        var sprite = new Sprite(this._device);
+        const sprite = new Sprite(this._device);
         if (url) {
             // if url field is present json data is being loaded from file
             // store data on sprite object temporarily
@@ -70,7 +70,7 @@ class SpriteHandler {
 
     // Set sprite data
     patch(asset, assets) {
-        var sprite = asset.resource;
+        const sprite = asset.resource;
         if (sprite.__data) {
             // loading from a json file we have asset data store temporarily on the sprite resource
             // copy it into asset.data and delete
@@ -80,7 +80,7 @@ class SpriteHandler {
             asset.data.frameKeys = sprite.__data.frameKeys;
 
             if (sprite.__data.textureAtlasAsset) {
-                var atlas = assets.getByUrl(sprite.__data.textureAtlasAsset);
+                const atlas = assets.getByUrl(sprite.__data.textureAtlasAsset);
                 if (atlas) {
                     asset.data.textureAtlasAsset = atlas.id;
                 } else {
@@ -105,7 +105,7 @@ class SpriteHandler {
 
     // Load atlas
     _updateAtlas(asset) {
-        var sprite = asset.resource;
+        const sprite = asset.resource;
         if (!asset.data.textureAtlasAsset) {
             sprite.atlas = null;
             return;
@@ -114,7 +114,7 @@ class SpriteHandler {
         this._assets.off('load:' + asset.data.textureAtlasAsset, onTextureAtlasLoaded, asset);
         this._assets.on('load:' + asset.data.textureAtlasAsset, onTextureAtlasLoaded, asset);
 
-        var atlasAsset = this._assets.get(asset.data.textureAtlasAsset);
+        const atlasAsset = this._assets.get(asset.data.textureAtlasAsset);
         if (atlasAsset && atlasAsset.resource) {
             sprite.atlas = atlasAsset.resource;
         } else {

--- a/src/resources/texture-atlas.js
+++ b/src/resources/texture-atlas.js
@@ -13,13 +13,13 @@ import {
 
 import { TextureAtlas } from '../scene/texture-atlas.js';
 
-var JSON_ADDRESS_MODE = {
+const JSON_ADDRESS_MODE = {
     "repeat": ADDRESS_REPEAT,
     "clamp": ADDRESS_CLAMP_TO_EDGE,
     "mirror": ADDRESS_MIRRORED_REPEAT
 };
 
-var JSON_FILTER_MODE = {
+const JSON_FILTER_MODE = {
     "nearest": FILTER_NEAREST,
     "linear": FILTER_LINEAR,
     "nearest_mip_nearest": FILTER_NEAREST_MIPMAP_NEAREST,
@@ -28,7 +28,7 @@ var JSON_FILTER_MODE = {
     "linear_mip_linear": FILTER_LINEAR_MIPMAP_LINEAR
 };
 
-var regexFrame = /^data\.frames\.(\d+)$/;
+const regexFrame = /^data\.frames\.(\d+)$/;
 
 /**
  * @class
@@ -52,8 +52,8 @@ class TextureAtlasHandler {
             };
         }
 
-        var self = this;
-        var handler = this._loader.getHandler("texture");
+        const self = this;
+        const handler = this._loader.getHandler("texture");
 
         // if supplied with a json file url (probably engine-only)
         // load json data then load texture of same name
@@ -64,7 +64,7 @@ class TextureAtlasHandler {
             }, function (err, response) {
                 if (!err) {
                     // load texture
-                    var textureUrl = url.original.replace('.json', '.png');
+                    const textureUrl = url.original.replace('.json', '.png');
                     self._loader.load(textureUrl, "texture", function (err, texture) {
                         if (err) {
                             callback(err);
@@ -86,13 +86,13 @@ class TextureAtlasHandler {
 
     // Create texture atlas resource using the texture from the texture loader
     open(url, data) {
-        var resource = new TextureAtlas();
+        const resource = new TextureAtlas();
         if (data.texture && data.data) {
             resource.texture = data.texture;
             resource.__data = data.data; // store data temporarily to be copied into asset
         } else {
-            var handler = this._loader.getHandler("texture");
-            var texture = handler.open(url, data);
+            const handler = this._loader.getHandler("texture");
+            const texture = handler.open(url, data);
             if (!texture) return null;
             resource.texture = texture;
         }
@@ -116,7 +116,7 @@ class TextureAtlasHandler {
         }
 
         // pass texture data
-        var texture = asset.resource.texture;
+        const texture = asset.resource.texture;
         if (texture) {
             texture.name = asset.name;
 
@@ -139,7 +139,7 @@ class TextureAtlasHandler {
                 texture.anisotropy = asset.data.anisotropy;
 
             if (asset.data.hasOwnProperty('rgbm')) {
-                var type = asset.data.rgbm ? TEXTURETYPE_RGBM : TEXTURETYPE_DEFAULT;
+                const type = asset.data.rgbm ? TEXTURETYPE_RGBM : TEXTURETYPE_DEFAULT;
                 if (texture.type !== type) {
                     texture.type = type;
                 }
@@ -149,9 +149,9 @@ class TextureAtlasHandler {
         asset.resource.texture = texture;
 
         // set frames
-        var frames = {};
-        for (var key in asset.data.frames) {
-            var frame = asset.data.frames[key];
+        const frames = {};
+        for (const key in asset.data.frames) {
+            const frame = asset.data.frames[key];
             frames[key] = {
                 rect: new Vec4(frame.rect),
                 pivot: new Vec2(frame.pivot),
@@ -165,12 +165,12 @@ class TextureAtlasHandler {
     }
 
     _onAssetChange(asset, attribute, value) {
-        var frame;
+        let frame;
 
         if (attribute === 'data' || attribute === 'data.frames') {
             // set frames
-            var frames = {};
-            for (var key in value.frames) {
+            const frames = {};
+            for (const key in value.frames) {
                 frame = value.frames[key];
                 frames[key] = {
                     rect: new Vec4(frame.rect),
@@ -180,9 +180,9 @@ class TextureAtlasHandler {
             }
             asset.resource.frames = frames;
         } else {
-            var match = attribute.match(regexFrame);
+            const match = attribute.match(regexFrame);
             if (match) {
-                var frameKey = match[1];
+                const frameKey = match[1];
 
                 if (value) {
                     // add or update frame

--- a/src/resources/texture.js
+++ b/src/resources/texture.js
@@ -14,13 +14,13 @@ import { KtxParser } from './parser/texture/ktx.js';
 import { LegacyDdsParser } from './parser/texture/legacy-dds.js';
 import { HdrParser } from './parser/texture/hdr.js';
 
-var JSON_ADDRESS_MODE = {
+const JSON_ADDRESS_MODE = {
     "repeat": ADDRESS_REPEAT,
     "clamp": ADDRESS_CLAMP_TO_EDGE,
     "mirror": ADDRESS_MIRRORED_REPEAT
 };
 
-var JSON_FILTER_MODE = {
+const JSON_FILTER_MODE = {
     "nearest": FILTER_NEAREST,
     "linear": FILTER_LINEAR,
     "nearest_mip_nearest": FILTER_NEAREST_MIPMAP_NEAREST,
@@ -29,7 +29,7 @@ var JSON_FILTER_MODE = {
     "linear_mip_linear": FILTER_LINEAR_MIPMAP_LINEAR
 };
 
-var JSON_TEXTURE_TYPE = {
+const JSON_TEXTURE_TYPE = {
     "default": TEXTURETYPE_DEFAULT,
     "rgbm": TEXTURETYPE_RGBM,
     "rgbe": TEXTURETYPE_RGBE,
@@ -83,11 +83,11 @@ class TextureParser {
 // after invoking gl.generateMipmap on the texture (which was the previous method of ensuring
 // the texture's full mip chain was complete).
 // NOTE: this function only resamples RGBA8 and RGBAFloat32 data.
-var _completePartialMipmapChain = function (texture) {
+const _completePartialMipmapChain = function (texture) {
 
-    var requiredMipLevels = Math.log2(Math.max(texture._width, texture._height)) + 1;
+    const requiredMipLevels = Math.log2(Math.max(texture._width, texture._height)) + 1;
 
-    var isHtmlElement = function (object) {
+    const isHtmlElement = function (object) {
         return (object instanceof HTMLCanvasElement) ||
                (object instanceof HTMLImageElement) ||
                (object instanceof HTMLVideoElement);
@@ -103,21 +103,21 @@ var _completePartialMipmapChain = function (texture) {
         return;
     }
 
-    var downsample = function (width, height, data) {
-        var sampledWidth = Math.max(1, width >> 1);
-        var sampledHeight = Math.max(1, height >> 1);
-        var sampledData = new data.constructor(sampledWidth * sampledHeight * 4);
+    const downsample = function (width, height, data) {
+        const sampledWidth = Math.max(1, width >> 1);
+        const sampledHeight = Math.max(1, height >> 1);
+        const sampledData = new data.constructor(sampledWidth * sampledHeight * 4);
 
-        var xs = Math.floor(width / sampledWidth);
-        var ys = Math.floor(height / sampledHeight);
-        var xsys = xs * ys;
+        const xs = Math.floor(width / sampledWidth);
+        const ys = Math.floor(height / sampledHeight);
+        const xsys = xs * ys;
 
-        for (var y = 0; y < sampledHeight; ++y) {
-            for (var x = 0; x < sampledWidth; ++x) {
-                for (var e = 0; e < 4; ++e) {
-                    var sum = 0;
-                    for (var sy = 0; sy < ys; ++sy) {
-                        for (var sx = 0; sx < xs; ++sx) {
+        for (let y = 0; y < sampledHeight; ++y) {
+            for (let x = 0; x < sampledWidth; ++x) {
+                for (let e = 0; e < 4; ++e) {
+                    let sum = 0;
+                    for (let sy = 0; sy < ys; ++sy) {
+                        for (let sx = 0; sx < xs; ++sx) {
                             sum += data[(x * xs + sx + (y * ys + sy) * width) * 4 + e];
                         }
                     }
@@ -130,12 +130,12 @@ var _completePartialMipmapChain = function (texture) {
     };
 
     // step through levels
-    for (var level = texture._levels.length; level < requiredMipLevels; ++level) {
-        var width = Math.max(1, texture._width >> (level - 1));
-        var height = Math.max(1, texture._height >> (level - 1));
+    for (let level = texture._levels.length; level < requiredMipLevels; ++level) {
+        const width = Math.max(1, texture._width >> (level - 1));
+        const height = Math.max(1, texture._height >> (level - 1));
         if (texture._cubemap) {
-            var mips = [];
-            for (var face = 0; face < 6; ++face) {
+            const mips = [];
+            for (let face = 0; face < 6; ++face) {
                 mips.push(downsample(width, height, texture._levels[level - 1][face]));
             }
             texture._levels.push(mips);
@@ -188,7 +188,7 @@ class TextureHandler {
 
     set maxRetries(value) {
         this.imgParser.maxRetries = value;
-        for (var parser in this.parsers) {
+        for (const parser in this.parsers) {
             if (this.parsers.hasOwnProperty(parser)) {
                 this.parsers[parser].maxRetries = value;
             }
@@ -200,7 +200,7 @@ class TextureHandler {
     }
 
     _getParser(url) {
-        var ext = path.getExtension(this._getUrlWithoutParams(url)).toLowerCase().replace('.', '');
+        const ext = path.getExtension(this._getUrlWithoutParams(url)).toLowerCase().replace('.', '');
         return this.parsers[ext] || this.imgParser;
     }
 
@@ -219,7 +219,7 @@ class TextureHandler {
         if (!url)
             return;
 
-        var texture = this._getParser(url).open(url, data, this._device);
+        let texture = this._getParser(url).open(url, data, this._device);
 
         if (texture === null) {
             texture = new Texture(this._device, {
@@ -237,7 +237,7 @@ class TextureHandler {
     }
 
     patch(asset, assets) {
-        var texture = asset.resource;
+        const texture = asset.resource;
         if (!texture) {
             return;
         }
@@ -246,7 +246,7 @@ class TextureHandler {
             texture.name = asset.name;
         }
 
-        var assetData = asset.data;
+        const assetData = asset.data;
 
         if (assetData.hasOwnProperty('minfilter')) {
             texture.minFilter = JSON_FILTER_MODE[assetData.minfilter];
@@ -285,7 +285,7 @@ class TextureHandler {
             texture.type = TEXTURETYPE_RGBM;
         } else if (asset.file && asset.getPreferredFile) {
             // basis normalmaps flag the variant as swizzled
-            var preferredFile = asset.getPreferredFile();
+            const preferredFile = asset.getPreferredFile();
             if (preferredFile) {
                 if (preferredFile.opt && ((preferredFile.opt & 8) !== 0)) {
                     texture.type = TEXTURETYPE_SWIZZLEGGGR;


### PR DESCRIPTION
This PR migrates all of the code in `resources` to use `let` and `const` instead of `var`.

Note: JSDoc blocks still use `var` for now.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
