### PR TITLE
Fix for crash: unbind (texture) asset references when material is destroyed

### DIFF
--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -738,7 +738,7 @@ class StandardMaterial extends Material {
         for (const asset in this._assetReferences) {
             this._assetReferences[asset]._unbind();
         }
-        this._assetReferences = {};
+        this._assetReferences = null;
         this._validator = null;
 
         super.destroy();

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -738,7 +738,7 @@ class StandardMaterial extends Material {
         for (const asset in this._assetReferences) {
             this._assetReferences[asset]._unbind();
         }
-        this._assetReferences = null;
+        this._assetReferences = {};
         this._validator = null;
 
         super.destroy();

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -727,6 +727,22 @@ class StandardMaterial extends Material {
 
         this.dirtyShader = false;
     }
+
+    /**
+     * @function
+     * @name StandardMaterial#destroy
+     * @description Removes this material from the scene and possibly frees up memory from its shaders (if there are no other materials using it).
+     */
+    destroy() {
+        // unbind (texture) asset references
+        for (const asset in this._assetReferences) {
+            this._assetReferences[asset]._unbind();
+        }
+        this._assetReferences = null;
+        this._validator = null;
+
+        super.destroy();
+    }
 }
 
 function _defineTex2D(obj, name, uv, channels, defChannel, vertexColor, detailMode) {


### PR DESCRIPTION
Fixes #2982

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
