### PR TITLE
Improve CJK character line breaking

### DIFF
--- a/src/framework/components/element/text-element.js
+++ b/src/framework/components/element/text-element.js
@@ -56,6 +56,7 @@ const ALPHANUMERIC_CHAR = /^[a-z0-9]$/i;
 // AC00—D7AF Hangul Syllables
 // D7B0—D7FF Hangul Jamo Extended-B
 const CJK_CHAR = /^[\u1100-\u11ff]|[\u3000-\u9fff]|[\ua960-\ua97f]|[\uac00-\ud7ff]$/;
+const NO_LINE_BREAK_CJK_CHAR = /^[〕〉》」』】〙〗〟ヽヾーァィゥェォッャュョヮヵヶぁぃぅぇぉっゃゅょゎゕゖㇰㇱㇲㇳㇴㇵㇶㇷㇸㇹㇺㇻㇼㇽㇾㇿ々〻]$/;
 
 // unicode bidi control characters https://en.wikipedia.org/wiki/Unicode_control_characters
 const CONTROL_CHARS = [
@@ -911,14 +912,9 @@ class TextElement {
                     _xMinusTrailingWhitespace = _x;
                 }
 
-                // char is space, tab, or dash
-                const isWordBoundary = WORD_BOUNDARY_CHAR.test(char);
-                // char is CJK character boundary
-                const isCJKBoundary = CJK_CHAR.test(char) && ((nextchar !== null) && (WORD_BOUNDARY_CHAR.test(nextchar) || ALPHANUMERIC_CHAR.test(nextchar)));
-                // next character is CJK character
-                const isNextCJK = (nextchar !== null) && CJK_CHAR.test(nextchar);
-
-                if (isWordBoundary || isCJKBoundary || isNextCJK) {
+                if ((WORD_BOUNDARY_CHAR.test(char)) || // char is space, tab, or dash
+                    (CJK_CHAR.test(char) && ((nextchar !== null) && !NO_LINE_BREAK_CJK_CHAR.test(nextchar) && (WORD_BOUNDARY_CHAR.test(nextchar) || ALPHANUMERIC_CHAR.test(nextchar)))) || // char is a CJK character and next character is a CJK boundary
+                    ((nextchar !== null) && CJK_CHAR.test(nextchar) && !NO_LINE_BREAK_CJK_CHAR.test(nextchar))) { // next character is a CJK character that can be a whole word
                     numWordsThisLine++;
                     wordStartX = _xMinusTrailingWhitespace;
                     wordStartIndex = i + 1;

--- a/src/framework/components/element/text-element.js
+++ b/src/framework/components/element/text-element.js
@@ -43,25 +43,23 @@ class MeshInfo {
     }
 }
 
+const LINE_BREAK_CHAR = /^[\r\n]$/;
+const WHITESPACE_CHAR = /^[ \t]$/;
+const WORD_BOUNDARY_CHAR = /^[ \t\-]|[\u200b]$/; // NB \u200b is zero width space
+const ALPHANUMERIC_CHAR = /^[a-z0-9]$/i;
+
 // 1100—11FF Hangul Jamo
-// 3130—318F Hangul Compatibility Jamo
+// 3000—303F CJK Symbols and Punctuation \
+// 3130—318F Hangul Compatibility Jamo    -- grouped
+// 4E00—9FFF CJK Unified Ideographs      /
 // A960—A97F Hangul Jamo Extended-A
 // AC00—D7AF Hangul Syllables
 // D7B0—D7FF Hangul Jamo Extended-B
-// 3000—303F CJK Symbols and Punctuation
-// 4E00—9FFF CJK Unified Ideographs
-
-const LINE_BREAK_CHAR = /^[\r\n]$/;
-const WHITESPACE_CHAR = /^[ \t]$/;
-const WORD_BOUNDARY_CHAR = /^[ \t\-]|[\u200b]$/; // NB \u200b zero width space
-//const CJK_CHAR = /^[\uac00-\ud7ff]$/; //|[\u1100-\u11ff]|[\u3130-\u318f]|[\ua960-\ua97f]|[\ud7b0-\ud7ff]|[\u3040-\u9FFF]$/; // NB \u3041 Japanese \u3131 Korean
 const CJK_CHAR = /^[\u1100-\u11ff]|[\u3000-\u9fff]|[\ua960-\ua97f]|[\uac00-\ud7ff]$/;
-
-const ALPHANUMERIC_CHAR = /^[a-z0-9]$/i;
 
 // unicode bidi control characters https://en.wikipedia.org/wiki/Unicode_control_characters
 const CONTROL_CHARS = [
-    '\u200B', //zero width space
+    '\u200B', // zero width space
     '\u061C',
     '\u200E',
     '\u200F',

--- a/src/framework/components/element/text-element.js
+++ b/src/framework/components/element/text-element.js
@@ -914,7 +914,7 @@ class TextElement {
                 // char is space, tab, or dash
                 const isWordBoundary = WORD_BOUNDARY_CHAR.test(char);
                 // char is CJK character boundary
-                const isCJKBoundary = CJK_CHAR.test(char) && (((nextchar !== null) && (WORD_BOUNDARY_CHAR.test(nextchar)) || ALPHANUMERIC_CHAR.test(nextchar)));
+                const isCJKBoundary = CJK_CHAR.test(char) && ((nextchar !== null) && (WORD_BOUNDARY_CHAR.test(nextchar) || ALPHANUMERIC_CHAR.test(nextchar)));
                 // next character is CJK character
                 const isNextCJK = (nextchar !== null) && CJK_CHAR.test(nextchar);
 

--- a/src/framework/components/element/text-element.js
+++ b/src/framework/components/element/text-element.js
@@ -902,9 +902,9 @@ class TextElement {
                     _xMinusTrailingWhitespace = _x;
                 }
 
-                const isWordBoundary = WORD_BOUNDARY_CHAR.test(char); // char is space, tab, or dash 
+                const isWordBoundary = WORD_BOUNDARY_CHAR.test(char); // char is space, tab, or dash
                 const isCJKBoundary = CJK_CHAR.test(char) && (WORD_BOUNDARY_CHAR.test(nextchar) || ALPHANUMERIC_CHAR.test(nextchar)); // char is CJK character boundary
-                const isNextCJK = (nextchar !== null) && CJK_CHAR.test(nextchar); // next character is CJK character 
+                const isNextCJK = (nextchar !== null) && CJK_CHAR.test(nextchar); // next character is CJK character
                 if (isWordBoundary || isCJKBoundary || isNextCJK) {
                     numWordsThisLine++;
                     wordStartX = _xMinusTrailingWhitespace;

--- a/src/framework/components/element/text-element.js
+++ b/src/framework/components/element/text-element.js
@@ -902,10 +902,10 @@ class TextElement {
                     _xMinusTrailingWhitespace = _x;
                 }
 
-                var isWordBoundary = WORD_BOUNDARY_CHAR.test(char);
-                var isCJK = CJK_CHAR.test(char);
-                const isNextCJK = (nextchar !== null) && CJK_CHAR.test(nextchar);
-                if (isWordBoundary || isNextCJK || (isCJK && (WORD_BOUNDARY_CHAR.test(nextchar) || ALPHANUMERIC_CHAR.test(nextchar)))) { // char is space, tab, or dash OR CJK character
+                const isWordBoundary = WORD_BOUNDARY_CHAR.test(char); // char is space, tab, or dash 
+                const isCJKBoundary = CJK_CHAR.test(char) && (WORD_BOUNDARY_CHAR.test(nextchar) || ALPHANUMERIC_CHAR.test(nextchar)); // char is CJK character boundary
+                const isNextCJK = (nextchar !== null) && CJK_CHAR.test(nextchar); // next character is CJK character 
+                if (isWordBoundary || isCJKBoundary || isNextCJK) {
                     numWordsThisLine++;
                     wordStartX = _xMinusTrailingWhitespace;
                     wordStartIndex = i + 1;

--- a/src/framework/components/element/text-element.js
+++ b/src/framework/components/element/text-element.js
@@ -675,6 +675,25 @@ class TextElement {
             lineStartIndex = lineBreakIndex;
         }
 
+        // char is space, tab, or dash
+        const isWordBoundary = () => {
+            return WORD_BOUNDARY_CHAR.test(char);
+        };
+
+        const isValidNextChar = () => {
+            return (nextchar !== null) && !NO_LINE_BREAK_CJK_CHAR.test(nextchar);
+        };
+
+        // char is a CJK character and next character is a CJK boundary
+        const isNextCJKBoundary = () => {
+            return CJK_CHAR.test(char) && (WORD_BOUNDARY_CHAR.test(nextchar) || ALPHANUMERIC_CHAR.test(nextchar));
+        };
+
+        // next character is a CJK character that can be a whole word
+        const isNextCJKWholeWord = () => {
+            return CJK_CHAR.test(nextchar);
+        };
+
         var retryUpdateMeshes = true;
         while (retryUpdateMeshes) {
             retryUpdateMeshes = false;
@@ -912,26 +931,7 @@ class TextElement {
                     _xMinusTrailingWhitespace = _x;
                 }
 
-            // char is space, tab, or dash
-            const isWordBoundary = () => {
-                return WORD_BOUNDARY_CHAR.test(char);
-            };
-
-            const isValidNextChar = () => {
-                return (nextchar !== null) && !NO_LINE_BREAK_CJK_CHAR.test(nextchar);
-            };
-
-            // char is a CJK character and next character is a CJK boundary
-            const isNextCJKBoundary = () => {
-                return CJK_CHAR.test(char) && (WORD_BOUNDARY_CHAR.test(nextchar) || ALPHANUMERIC_CHAR.test(nextchar));
-            };
-
-            // next character is a CJK character that can be a whole word
-            const isNextCJKWholeWord = () => {
-                return CJK_CHAR.test(nextchar);
-            };
-
-            if (isWordBoundary() || (isValidNextChar() && (isNextCJKBoundary() || isNextCJKWholeWord()))) {
+                if (isWordBoundary() || (isValidNextChar() && (isNextCJKBoundary() || isNextCJKWholeWord()))) {
                     numWordsThisLine++;
                     wordStartX = _xMinusTrailingWhitespace;
                     wordStartIndex = i + 1;

--- a/src/framework/components/element/text-element.js
+++ b/src/framework/components/element/text-element.js
@@ -904,7 +904,7 @@ class TextElement {
 
                 var isWordBoundary = WORD_BOUNDARY_CHAR.test(char);
                 var isCJK = CJK_CHAR.test(char);
-                var isNextCJK = (nextchar !== null) ? CJK_CHAR.test(nextchar) : false;
+                const isNextCJK = (nextchar !== null) && CJK_CHAR.test(nextchar);
                 if (isWordBoundary || isNextCJK || (isCJK && (WORD_BOUNDARY_CHAR.test(nextchar) || ALPHANUMERIC_CHAR.test(nextchar)))) { // char is space, tab, or dash OR CJK character
                     numWordsThisLine++;
                     wordStartX = _xMinusTrailingWhitespace;

--- a/src/framework/components/element/text-element.js
+++ b/src/framework/components/element/text-element.js
@@ -47,6 +47,7 @@ const LINE_BREAK_CHAR = /^[\r\n]$/;
 const WHITESPACE_CHAR = /^[ \t]$/;
 const WORD_BOUNDARY_CHAR = /^[ \t\-]$/;
 const CJK_CHAR = /^[\u4E00-\u9FFF]$/;
+const ALPHANUMERIC_CHAR = /^[a-z0-9]$/i;
 
 // unicode bidi control characters https://en.wikipedia.org/wiki/Unicode_control_characters
 const CONTROL_CHARS = [
@@ -626,7 +627,7 @@ class TextElement {
         var fontMaxY = 0;
         var scale = 1;
 
-        var char, data, i, j, quad;
+        var char, data, i, j, quad, nextchar;
 
         function breakLine(symbols, lineBreakIndex, lineBreakX) {
             self._lineWidths.push(Math.abs(lineBreakX));
@@ -715,6 +716,7 @@ class TextElement {
             // in order to wrap lines in the correct order
             for (i = 0; i < l; i++) {
                 char = this._symbols[i];
+                nextchar = ((i + 1) >= l) ? null : this._symbols[i + 1];
 
                 // handle line break
                 const isLineBreak = LINE_BREAK_CHAR.test(char);
@@ -902,7 +904,8 @@ class TextElement {
 
                 var isWordBoundary = WORD_BOUNDARY_CHAR.test(char);
                 var isCJK = CJK_CHAR.test(char);
-                if (isWordBoundary || isCJK) { // char is space, tab, or dash OR CJK
+                var isNextCJK = nextchar ? CJK_CHAR.test(nextchar) : false;
+                if (isWordBoundary || isNextCJK || (isCJK && (WORD_BOUNDARY_CHAR.test(nextchar) || ALPHANUMERIC_CHAR.test(nextchar)))) { // char is space, tab, or dash OR CJK and next character isn't a space, tab or dash
                     numWordsThisLine++;
                     wordStartX = _xMinusTrailingWhitespace;
                     wordStartIndex = i + 1;

--- a/src/framework/components/element/text-element.js
+++ b/src/framework/components/element/text-element.js
@@ -600,6 +600,25 @@ class TextElement {
         }
     }
 
+    // char is space, tab, or dash
+    _isWordBoundary(char) {
+        return WORD_BOUNDARY_CHAR.test(char);
+    }
+
+    _isValidNextChar(nextchar) {
+        return (nextchar !== null) && !NO_LINE_BREAK_CJK_CHAR.test(nextchar);
+    }
+
+    // char is a CJK character and next character is a CJK boundary
+    _isNextCJKBoundary(char, nextchar) {
+        return CJK_CHAR.test(char) && (WORD_BOUNDARY_CHAR.test(nextchar) || ALPHANUMERIC_CHAR.test(nextchar));
+    }
+
+    // next character is a CJK character that can be a whole word
+    _isNextCJKWholeWord(nextchar) {
+        return CJK_CHAR.test(nextchar);
+    }
+
     _updateMeshes() {
         var json = this._font.data;
         var self = this;
@@ -674,25 +693,6 @@ class TextElement {
             wordStartX = 0;
             lineStartIndex = lineBreakIndex;
         }
-
-        // char is space, tab, or dash
-        const isWordBoundary = () => {
-            return WORD_BOUNDARY_CHAR.test(char);
-        };
-
-        const isValidNextChar = () => {
-            return (nextchar !== null) && !NO_LINE_BREAK_CJK_CHAR.test(nextchar);
-        };
-
-        // char is a CJK character and next character is a CJK boundary
-        const isNextCJKBoundary = () => {
-            return CJK_CHAR.test(char) && (WORD_BOUNDARY_CHAR.test(nextchar) || ALPHANUMERIC_CHAR.test(nextchar));
-        };
-
-        // next character is a CJK character that can be a whole word
-        const isNextCJKWholeWord = () => {
-            return CJK_CHAR.test(nextchar);
-        };
 
         var retryUpdateMeshes = true;
         while (retryUpdateMeshes) {
@@ -931,7 +931,7 @@ class TextElement {
                     _xMinusTrailingWhitespace = _x;
                 }
 
-                if (isWordBoundary() || (isValidNextChar() && (isNextCJKBoundary() || isNextCJKWholeWord()))) {
+                if (this._isWordBoundary(char) || (this._isValidNextChar(nextchar) && (this._isNextCJKBoundary(char, nextchar) || this._isNextCJKWholeWord(nextchar)))) {
                     numWordsThisLine++;
                     wordStartX = _xMinusTrailingWhitespace;
                     wordStartIndex = i + 1;

--- a/src/framework/components/element/text-element.js
+++ b/src/framework/components/element/text-element.js
@@ -904,8 +904,8 @@ class TextElement {
 
                 var isWordBoundary = WORD_BOUNDARY_CHAR.test(char);
                 var isCJK = CJK_CHAR.test(char);
-                var isNextCJK = nextchar ? CJK_CHAR.test(nextchar) : false;
-                if (isWordBoundary || isNextCJK || (isCJK && (WORD_BOUNDARY_CHAR.test(nextchar) || ALPHANUMERIC_CHAR.test(nextchar)))) { // char is space, tab, or dash OR CJK and next character isn't a space, tab or dash
+                var isNextCJK = (nextchar !== null) ? CJK_CHAR.test(nextchar) : false;
+                if (isWordBoundary || isNextCJK || (isCJK && (WORD_BOUNDARY_CHAR.test(nextchar) || ALPHANUMERIC_CHAR.test(nextchar)))) { // char is space, tab, or dash OR CJK character
                     numWordsThisLine++;
                     wordStartX = _xMinusTrailingWhitespace;
                     wordStartIndex = i + 1;

--- a/src/framework/components/element/text-element.js
+++ b/src/framework/components/element/text-element.js
@@ -43,14 +43,25 @@ class MeshInfo {
     }
 }
 
+// 1100—11FF Hangul Jamo
+// 3130—318F Hangul Compatibility Jamo
+// A960—A97F Hangul Jamo Extended-A
+// AC00—D7AF Hangul Syllables
+// D7B0—D7FF Hangul Jamo Extended-B
+// 3000—303F CJK Symbols and Punctuation
+// 4E00—9FFF CJK Unified Ideographs
+
 const LINE_BREAK_CHAR = /^[\r\n]$/;
 const WHITESPACE_CHAR = /^[ \t]$/;
-const WORD_BOUNDARY_CHAR = /^[ \t\-]$/; // NB \u200b zero width space
-const CJK_CHAR = /^[\u3040-\u9FFF]$/; // NB \u3041 Japanese \u3131 Korean
+const WORD_BOUNDARY_CHAR = /^[ \t\-]|[\u200b]$/; // NB \u200b zero width space
+//const CJK_CHAR = /^[\uac00-\ud7ff]$/; //|[\u1100-\u11ff]|[\u3130-\u318f]|[\ua960-\ua97f]|[\ud7b0-\ud7ff]|[\u3040-\u9FFF]$/; // NB \u3041 Japanese \u3131 Korean
+const CJK_CHAR = /^[\u1100-\u11ff]|[\u3000-\u9fff]|[\ua960-\ua97f]|[\uac00-\ud7ff]$/;
+
 const ALPHANUMERIC_CHAR = /^[a-z0-9]$/i;
 
 // unicode bidi control characters https://en.wikipedia.org/wiki/Unicode_control_characters
 const CONTROL_CHARS = [
+    '\u200B', //zero width space
     '\u061C',
     '\u200E',
     '\u200F',

--- a/src/framework/components/element/text-element.js
+++ b/src/framework/components/element/text-element.js
@@ -912,9 +912,26 @@ class TextElement {
                     _xMinusTrailingWhitespace = _x;
                 }
 
-                if ((WORD_BOUNDARY_CHAR.test(char)) || // char is space, tab, or dash
-                    (CJK_CHAR.test(char) && ((nextchar !== null) && !NO_LINE_BREAK_CJK_CHAR.test(nextchar) && (WORD_BOUNDARY_CHAR.test(nextchar) || ALPHANUMERIC_CHAR.test(nextchar)))) || // char is a CJK character and next character is a CJK boundary
-                    ((nextchar !== null) && CJK_CHAR.test(nextchar) && !NO_LINE_BREAK_CJK_CHAR.test(nextchar))) { // next character is a CJK character that can be a whole word
+            // char is space, tab, or dash
+            const isWordBoundary = () => {
+                return WORD_BOUNDARY_CHAR.test(char);
+            };
+
+            const isValidNextChar = () => {
+                return (nextchar !== null) && !NO_LINE_BREAK_CJK_CHAR.test(nextchar);
+            };
+
+            // char is a CJK character and next character is a CJK boundary
+            const isNextCJKBoundary = () => {
+                return CJK_CHAR.test(char) && (WORD_BOUNDARY_CHAR.test(nextchar) || ALPHANUMERIC_CHAR.test(nextchar));
+            };
+
+            // next character is a CJK character that can be a whole word
+            const isNextCJKWholeWord = () => {
+                return CJK_CHAR.test(nextchar);
+            };
+
+            if (isWordBoundary() || (isValidNextChar() && (isNextCJKBoundary() || isNextCJKWholeWord()))) {
                     numWordsThisLine++;
                     wordStartX = _xMinusTrailingWhitespace;
                     wordStartIndex = i + 1;

--- a/src/framework/components/element/text-element.js
+++ b/src/framework/components/element/text-element.js
@@ -45,8 +45,8 @@ class MeshInfo {
 
 const LINE_BREAK_CHAR = /^[\r\n]$/;
 const WHITESPACE_CHAR = /^[ \t]$/;
-const WORD_BOUNDARY_CHAR = /^[ \t\-]$/;
-const CJK_CHAR = /^[\u4E00-\u9FFF]$/;
+const WORD_BOUNDARY_CHAR = /^[ \t\-]$/; // NB \u200b zero width space
+const CJK_CHAR = /^[\u3040-\u9FFF]$/; // NB \u3041 Japanese \u3131 Korean
 const ALPHANUMERIC_CHAR = /^[a-z0-9]$/i;
 
 // unicode bidi control characters https://en.wikipedia.org/wiki/Unicode_control_characters
@@ -902,9 +902,13 @@ class TextElement {
                     _xMinusTrailingWhitespace = _x;
                 }
 
-                const isWordBoundary = WORD_BOUNDARY_CHAR.test(char); // char is space, tab, or dash
-                const isCJKBoundary = CJK_CHAR.test(char) && (WORD_BOUNDARY_CHAR.test(nextchar) || ALPHANUMERIC_CHAR.test(nextchar)); // char is CJK character boundary
-                const isNextCJK = (nextchar !== null) && CJK_CHAR.test(nextchar); // next character is CJK character
+                // char is space, tab, or dash
+                const isWordBoundary = WORD_BOUNDARY_CHAR.test(char);
+                // char is CJK character boundary
+                const isCJKBoundary = CJK_CHAR.test(char) && (((nextchar !== null) && (WORD_BOUNDARY_CHAR.test(nextchar)) || ALPHANUMERIC_CHAR.test(nextchar)));
+                // next character is CJK character
+                const isNextCJK = (nextchar !== null) && CJK_CHAR.test(nextchar);
+
                 if (isWordBoundary || isCJKBoundary || isNextCJK) {
                     numWordsThisLine++;
                     wordStartX = _xMinusTrailingWhitespace;


### PR DESCRIPTION
- now deals with non-alphanumeric characters like punctuation.
- supports Korean and Japanese unicode ranges
- supports zero width space for Thai
- added some small kana and CJK punctuation characters that do not allow line break

Fixes #2963

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
