### PR TITLE
[FIX] Suppress warning from rollup-plugin-replace

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -140,8 +140,11 @@ const target_release_es5 = {
         }),
         shaderChunks(true),
         replace({
-            __REVISION__: revision,
-            __CURRENT_SDK_VERSION__: version
+            values: {
+                __REVISION__: revision,
+                __CURRENT_SDK_VERSION__: version
+            },
+            preventAssignment: true
         }),
         babel(es5Options),
         spacesToTabs()
@@ -163,8 +166,11 @@ const target_release_es5min = {
         }),
         shaderChunks(true),
         replace({
-            __REVISION__: revision,
-            __CURRENT_SDK_VERSION__: version
+            values: {
+                __REVISION__: revision,
+                __CURRENT_SDK_VERSION__: version
+            },
+            preventAssignment: true
         }),
         babel(es5Options),
         terser()
@@ -186,8 +192,11 @@ const target_release_es6 = {
         }),
         shaderChunks(true),
         replace({
-            __REVISION__: revision,
-            __CURRENT_SDK_VERSION__: version
+            values: {
+                __REVISION__: revision,
+                __CURRENT_SDK_VERSION__: version
+            },
+            preventAssignment: true
         }),
         babel(moduleOptions),
         spacesToTabs()
@@ -212,8 +221,11 @@ const target_debug = {
         }),
         shaderChunks(false),
         replace({
-            __REVISION__: revision,
-            __CURRENT_SDK_VERSION__: version
+            values: {
+                __REVISION__: revision,
+                __CURRENT_SDK_VERSION__: version
+            },
+            preventAssignment: true
         }),
         babel(es5Options),
         spacesToTabs()
@@ -237,8 +249,11 @@ const target_profiler = {
         }),
         shaderChunks(false),
         replace({
-            __REVISION__: revision,
-            __CURRENT_SDK_VERSION__: version
+            values: {
+                __REVISION__: revision,
+                __CURRENT_SDK_VERSION__: version
+            },
+            preventAssignment: true
         }),
         babel(es5Options),
         spacesToTabs()


### PR DESCRIPTION
Currently, the build process prints the following warning:

> (!) Plugin replace: @rollup/plugin-replace: 'preventAssignment' currently defaults to false. It is recommended to set this option to `true`, as the next major version will default this option to `true`.

This PR sets `preventAssignment` to true as suggested.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
