### PR TITLE
WebXR Input Source: linear velocity

### DIFF
--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -2298,7 +2298,7 @@ var makeTick = function (_app) {
         application.fire("frameupdate", ms);
 
         if (frame) {
-            application.xr.update(frame);
+            application.xr.update(frame, dt);
             application.graphicsDevice.defaultFramebuffer = frame.session.renderState.baseLayer.framebuffer;
         } else {
             application.graphicsDevice.defaultFramebuffer = null;

--- a/src/xr/xr-input-source.js
+++ b/src/xr/xr-input-source.js
@@ -311,6 +311,12 @@ class XrInputSource extends EventHandler {
         return this._localRotation;
     }
 
+    /**
+     * @function
+     * @name XrInputSource#getLinearVelocity
+     * @description Get the linear velocity (units per second) of input source if it is handheld ({@link XrInputSource#grip} is true). Otherwise it will return null.
+     * @returns {Vec3|null} The world space linear velocity of handheld input source.
+     */
     getLinearVelocity() {
         if (! this._velocitiesAvailable)
             return null;

--- a/src/xr/xr-input.js
+++ b/src/xr/xr-input.js
@@ -20,6 +20,7 @@ class XrInput extends EventHandler {
         this.manager = manager;
         this._session = null;
         this._inputSources = [];
+        this.velocitiesSupported = (window.XRPose && XRPose.prototype.hasOwnProperty('linearVelocity')) || false;
 
         this._onInputSourcesChangeEvt = function (evt) {
             self._onInputSourcesChange(evt);
@@ -233,9 +234,9 @@ class XrInput extends EventHandler {
         }
     }
 
-    update(frame) {
+    update(frame, dt) {
         for (var i = 0; i < this._inputSources.length; i++) {
-            this._inputSources[i].update(frame);
+            this._inputSources[i].update(frame, dt);
         }
     }
 

--- a/src/xr/xr-manager.js
+++ b/src/xr/xr-manager.js
@@ -426,7 +426,7 @@ class XrManager extends EventHandler {
         });
     }
 
-    update(frame) {
+    update(frame, dt) {
         if (! this._session) return;
 
         var i, view, viewRaw, layer, viewport;
@@ -502,7 +502,7 @@ class XrManager extends EventHandler {
         this._camera.camera._node.setLocalPosition(this._localPosition);
         this._camera.camera._node.setLocalRotation(this._localRotation);
 
-        this.input.update(frame);
+        this.input.update(frame, dt);
 
         if (this._type === XRTYPE_AR) {
             if (this.hitTest.supported)


### PR DESCRIPTION
Linear Velocity has been added for handheld devices in WebXR specs: https://pr-preview.s3.amazonaws.com/cabanier/webxr/pull/1182.html#dom-xrpose-linearvelocity

This also been implemented in the latest Oculus Browser: https://twitter.com/rcabanier/status/1377459759876505606

This PR implements input source linear velocity and also emulates it with the same logic if it is not available/supported.
So if the input source has a grip space - we guarantee to provide linear velocity.

### New APIs:
```javascript
// pc.XrInputSource
inputSource.getLinearVelocity() // Vec3 with world space linear velosity in units per second, or null if input source is not handheld
```

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
