### PR TITLE
Also store max msaa samples on device

### DIFF
--- a/src/graphics/graphics-device.js
+++ b/src/graphics/graphics-device.js
@@ -877,6 +877,7 @@ class GraphicsDevice extends EventHandler {
         this.maxAnisotropy = ext ? gl.getParameter(ext.MAX_TEXTURE_MAX_ANISOTROPY_EXT) : 1;
 
         this.samples = gl.getParameter(gl.SAMPLES);
+        this.maxSamples = gl.getParameter(gl.MAX_SAMPLES);
     }
 
     initializeRenderState() {


### PR DESCRIPTION
Seems helpful for device to also store maximum number of MSAA samples supported (not just the backbuffer number MSAA samples).