### PR TITLE
Remove dependency of Light on Application

### DIFF
--- a/src/anim/binder/default-anim-binder.js
+++ b/src/anim/binder/default-anim-binder.js
@@ -1,5 +1,3 @@
-import { Entity } from '../../framework/entity.js';
-
 import { AnimBinder } from './anim-binder.js';
 import { AnimTarget } from '../evaluator/anim-target.js';
 
@@ -36,7 +34,7 @@ class DefaultAnimBinder {
 
             // walk up to the first parent node of entity type (skips internal nodes of Model)
             var object = node;
-            while (object && !(object instanceof Entity)) {
+            while (object && object.prototype.name !== 'Entity') {
                 object = object.parent;
             }
 

--- a/src/framework/components/light/system.js
+++ b/src/framework/components/light/system.js
@@ -73,7 +73,7 @@ class LightComponentSystem extends ComponentSystem {
             data.shape = LIGHTSHAPE_PUNCTUAL;
         }
 
-        var light = new Light();
+        var light = new Light(this.app.graphicsDevice);
         light.type = lightTypes[data.type];
         light._node = component.entity;
         light._scene = this.app.scene;

--- a/src/graphics/graphics-device.js
+++ b/src/graphics/graphics-device.js
@@ -697,6 +697,11 @@ class GraphicsDevice extends EventHandler {
         }
     }
 
+    // don't stringify GraphicsDevice to JSON by JSON.stringify
+    toJSON(key) {
+        return undefined;
+    }
+
     // #if _DEBUG
     updateMarker() {
         this._spectorCurrentMarker = this._spectorMarkers.join(" | ") + " # ";

--- a/src/scene/light.js
+++ b/src/scene/light.js
@@ -14,8 +14,6 @@ import {
     LIGHTSHAPE_PUNCTUAL
 } from './constants.js';
 
-import { Application } from '../framework/application.js';
-
 var spotCenter = new Vec3();
 var spotEndPoint = new Vec3();
 var tmpVec = new Vec3();
@@ -63,7 +61,9 @@ class LightRenderData {
  * @classdesc A light.
  */
 class Light {
-    constructor() {
+    constructor(graphicsDevice) {
+        this.device = graphicsDevice;
+
         // Light properties (defaults)
         this._type = LIGHTTYPE_DIRECTIONAL;
         this._color = new Color(0.8, 0.8, 0.8);
@@ -170,7 +170,7 @@ class Light {
      * @returns {Light} A cloned Light.
      */
     clone() {
-        var clone = new Light();
+        var clone = new Light(this.device);
 
         // Clone Light properties
         clone.type = this._type;
@@ -438,7 +438,7 @@ class Light {
         if (this._shadowType === value)
             return;
 
-        var device = Application.getApplication().graphicsDevice;
+        var device = this.device;
 
         if (this._type === LIGHTTYPE_OMNI)
             value = SHADOW_PCF3; // VSM or HW PCF for omni lights is not supported yet
@@ -492,11 +492,10 @@ class Light {
         if (this._shadowResolution === value)
             return;
 
-        var device = Application.getApplication().graphicsDevice;
         if (this._type === LIGHTTYPE_OMNI) {
-            value = Math.min(value, device.maxCubeMapSize);
+            value = Math.min(value, this.device.maxCubeMapSize);
         } else {
-            value = Math.min(value, device.maxTextureSize);
+            value = Math.min(value, this.device.maxTextureSize);
         }
         this._shadowResolution = value;
     }


### PR DESCRIPTION
- Light gets device in constructor and stores it locally to avoid dependency on the Application class
- as program library stringifies options that contain array of lights, which now stores device, device class implement toJSON to disable serialization
- these changes caused DefaultAnimBinder to fail type checks, and so it's dependency on Entity was removed as well, which removed 2 circular dependencies