### PR TITLE
fix material asset unload and reload

### DIFF
--- a/src/resources/parser/material/json-standard-material.js
+++ b/src/resources/parser/material/json-standard-material.js
@@ -44,10 +44,7 @@ class JsonStandardMaterialParser {
         // usual flow is that data is validated in resource loader
         // but if not, validate here.
         if (!data.validated) {
-            if (!this._validator) {
-                this._validator = new StandardMaterialValidator();
-            }
-            this._validator.validate(data);
+            data = this._validate(data);
         }
 
         if (data.chunks) {
@@ -164,10 +161,10 @@ class JsonStandardMaterialParser {
 
     // check for invalid properties
     _validate(data) {
-        if (!this._validator) {
-            this._validator = new StandardMaterialValidator();
-        }
         if (!data.validated) {
+            if (!this._validator) {
+                this._validator = new StandardMaterialValidator();
+            }
             this._validator.validate(data);
         }
         return data;

--- a/src/resources/parser/material/json-standard-material.js
+++ b/src/resources/parser/material/json-standard-material.js
@@ -167,8 +167,9 @@ class JsonStandardMaterialParser {
         if (!this._validator) {
             this._validator = new StandardMaterialValidator();
         }
-        this._validator.validate(data);
-
+        if (!data.validated) {
+            this._validator.validate(data);
+        }
         return data;
     }
 }


### PR DESCRIPTION
Fixes #3061

This PR:
- adds a texture and cubemap `unload` event callback to clean up texture references when a texture is unloaded
- removes a not-so-robust setting of asset id to loaded resource - which was causing problems if a texture asset is unloaded and reloaded
- fixes and tidies up a calls to `_validate()` in the material json parser.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
