### PR TITLE
Added typing information for `pc.Asset`'s `type` property

### DIFF
--- a/src/asset/asset.js
+++ b/src/asset/asset.js
@@ -37,7 +37,7 @@ const VARIANT_DEFAULT_PRIORITY = ['pvr', 'dxt', 'etc2', 'etc1', 'basis'];
  * See the {@link AssetRegistry} for details on loading resources from assets.
  * @description Create a new Asset record. Generally, Assets are created in the loading process and you won't need to create them by hand.
  * @param {string} name - A non-unique but human-readable name which can be later used to retrieve the asset.
- * @param {string} type - Type of asset. One of ["animation", "audio", "binary", "cubemap", "css", "font", "json", "html", "material", "model", "script", "shader", "text", "texture"]
+ * @param {("animation"|"audio"|"binary"|"cubemap"|"css"|"font"|"json"|"html"|"material"|"model"|"script"|"shader"|"template"|"text"|"texture")} type - Type of asset. One of ["animation", "audio", "binary", "cubemap", "css", "font", "json", "html", "material", "model", "script", "shader", "template", "text", "texture"]
  * @param {object} [file] - Details about the file the asset is made from. At the least must contain the 'url' field. For assets that don't contain file data use null.
  * @example
  * var file = {
@@ -53,7 +53,7 @@ const VARIANT_DEFAULT_PRIORITY = ['pvr', 'dxt', 'etc2', 'etc1', 'basis'];
  * });
  * @property {string} name The name of the asset
  * @property {number} id The asset id
- * @property {string} type The type of the asset. One of ["animation", "audio", "binary", "cubemap", "css", "font", "json", "html", "material", "model", "script", "shader", "text", "texture"]
+ * @property {("animation"|"audio"|"binary"|"cubemap"|"css"|"font"|"json"|"html"|"material"|"model"|"script"|"shader"|"template"|"text"|"texture")} type The type of the asset. One of ["animation", "audio", "binary", "cubemap", "css", "font", "json", "html", "material", "model", "script", "shader", "template", "text", "texture"]
  * @property {Tags} tags Interface for tagging. Allows to find assets by tags using {@link AssetRegistry#findByTag} method.
  * @property {object} file The file details or null if no file
  * @property {string} [file.url] The URL of the resource file that contains the asset data

--- a/src/asset/asset.js
+++ b/src/asset/asset.js
@@ -37,7 +37,7 @@ const VARIANT_DEFAULT_PRIORITY = ['pvr', 'dxt', 'etc2', 'etc1', 'basis'];
  * See the {@link AssetRegistry} for details on loading resources from assets.
  * @description Create a new Asset record. Generally, Assets are created in the loading process and you won't need to create them by hand.
  * @param {string} name - A non-unique but human-readable name which can be later used to retrieve the asset.
- * @param {("animation"|"audio"|"binary"|"cubemap"|"css"|"font"|"json"|"html"|"material"|"model"|"script"|"shader"|"template"|"text"|"texture")} type - Type of asset. One of ["animation", "audio", "binary", "cubemap", "css", "font", "json", "html", "material", "model", "script", "shader", "template", "text", "texture"]
+ * @param {("animation"|"audio"|"binary"|"container"|"cubemap"|"css"|"font"|"json"|"html"|"material"|"model"|"script"|"shader"|"sprite"|"template"|"text"|"texture")} type - Type of asset. One of ["animation", "audio", "binary", "container", "cubemap", "css", "font", "json", "html", "material", "model", "script", "shader", "sprite", "template", "text", "texture"]
  * @param {object} [file] - Details about the file the asset is made from. At the least must contain the 'url' field. For assets that don't contain file data use null.
  * @example
  * var file = {
@@ -53,7 +53,7 @@ const VARIANT_DEFAULT_PRIORITY = ['pvr', 'dxt', 'etc2', 'etc1', 'basis'];
  * });
  * @property {string} name The name of the asset
  * @property {number} id The asset id
- * @property {("animation"|"audio"|"binary"|"cubemap"|"css"|"font"|"json"|"html"|"material"|"model"|"script"|"shader"|"template"|"text"|"texture")} type The type of the asset. One of ["animation", "audio", "binary", "cubemap", "css", "font", "json", "html", "material", "model", "script", "shader", "template", "text", "texture"]
+ * @property {("animation"|"audio"|"binary"|"container"|"cubemap"|"css"|"font"|"json"|"html"|"material"|"model"|"script"|"shader"|"sprite"|"template"|"text"|"texture")} type The type of the asset. One of ["animation", "audio", "binary", "container", "cubemap", "css", "font", "json", "html", "material", "model", "script", "shader", "sprite", "template", "text", "texture"]
  * @property {Tags} tags Interface for tagging. Allows to find assets by tags using {@link AssetRegistry#findByTag} method.
  * @property {object} file The file details or null if no file
  * @property {string} [file.url] The URL of the resource file that contains the asset data


### PR DESCRIPTION
Enhancement: Add typing info for the `type` of `pc.Asset`s

In addition to the documented types, 'template' is now a valid string too from what I see when looking at a template asset's `type` value.

---

Update - possibly this is a bit more nuanced than I first thought; there were a few types (sprite, template, container) that were not documented in the text. Poking a bit into the editor revealed a longer list than I realised:
```
0: "animation"
1: "animstategraph"
2: "audio"
3: "bundle"
4: "binary"
5: "container"
6: "cubemap"
7: "css"
8: "font"
9: "folder"
10: "json"
11: "html"
12: "material"
13: "model"
14: "render"
15: "scene"
16: "script"
17: "shader"
18: "sprite"
19: "template"
20: "text"
21: "texture"
22: "textureAtlas"
23: "wasm"
```
I'm not sure which of these Playcanvas would deem internal/undocumented though. So this PR contains ones we've been using in code when the type was just a `string`. Perhaps you would prefer to have this as a plain string, though it is useful for type-safety to know we're using the right values...?

---

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
