### PR TITLE
cubemap resources set directly in material handler

### DIFF
--- a/src/resources/material.js
+++ b/src/resources/material.js
@@ -183,15 +183,16 @@ class MaterialHandler {
     }
 
     _assignCubemap(parameterName, materialAsset, textures) {
-        // NB removed swapping out asset id for resource here
+        // NB we now set resource directly (like textures)
+        materialAsset.resource[parameterName] = textures[0]; // the primary cubemap texture
         if (textures.length === 7) {
             // the prefiltered textures
-            materialAsset.data.prefilteredCubeMap128 = textures[1];
-            materialAsset.data.prefilteredCubeMap64 = textures[2];
-            materialAsset.data.prefilteredCubeMap32 = textures[3];
-            materialAsset.data.prefilteredCubeMap16 = textures[4];
-            materialAsset.data.prefilteredCubeMap8 = textures[5];
-            materialAsset.data.prefilteredCubeMap4 = textures[6];
+            materialAsset.resource.prefilteredCubeMap128 = textures[1];
+            materialAsset.resource.prefilteredCubeMap64 = textures[2];
+            materialAsset.resource.prefilteredCubeMap32 = textures[3];
+            materialAsset.resource.prefilteredCubeMap16 = textures[4];
+            materialAsset.resource.prefilteredCubeMap8 = textures[5];
+            materialAsset.resource.prefilteredCubeMap4 = textures[6];
         }
     }
 


### PR DESCRIPTION
I believe this fixes potential webGL errors introduced in https://github.com/playcanvas/engine/pull/3074

cubemap properties are now being set directly in the material asset resource - this is consistent with textures.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
