### PR TITLE
[FIX] Reproject error

### DIFF
--- a/src/graphics/program-lib/chunks/reproject.frag
+++ b/src/graphics/program-lib/chunks/reproject.frag
@@ -109,13 +109,13 @@ vec3 modifySeams(vec3 dir, float amount) {
 }
 
 vec2 toSpherical(vec3 dir) {
-    return vec2(atan(dir.z, dir.x) * -1.0, asin(dir.y));
+    return vec2(atan(dir.z, dir.x), asin(dir.y));
 }
 
 vec3 fromSpherical(vec2 uv) {
-    return vec3(cos(uv.y) * cos(-uv.x),
+    return vec3(cos(uv.y) * cos(uv.x),
                 sin(uv.y),
-                cos(uv.y) * sin(-uv.x));
+                cos(uv.y) * sin(uv.x));
 }
 
 vec4 sampleEquirect(vec2 sph) {


### PR DESCRIPTION
This PR fixes a bug where equirectangular maps were being mirrored in the x/z axis.