### PR TITLE
Simplify README.md

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -3,6 +3,7 @@
 <img width="200" src="https://s3-eu-west-1.amazonaws.com/static.playcanvas.com/platform/images/logo/playcanvas-logo-medium.png"/>
 
 # PlayCanvas WebGL 游戏引擎
+[开发者站点](https://developer.playcanvas.com) | [例子](https://playcanvas.github.io) | [论坛](https://forum.playcanvas.com) | [博客](https://blog.playcanvas.com)
 
 PlayCanvas 是一款使用 HTML5 和 WebGL 技术运行游戏以及其他 3D 内容的开源游戏引擎，PlayCanvas 以其独特的性能实现了在任何手机移动端和桌面浏览器端均可以流畅运行。
 
@@ -162,22 +163,6 @@ PlayCanvas 使用 Karma 进行单元测试。您可以使用如下两种方式�
 | -------------------- | ------------------------------------------------------------------------------------ |
 | `npm run test`       | Runs unit tests on a built `playcanvas.js`                                           |
 | `npm run test:watch` | Re-runs unit tests when changes are detected - open http://localhost:9876/debug.html |
-
-## 模型
-
-请移步至 [开发手册](https://developer.playcanvas.com/en/engine/) 查看如何通过 3D 模型组件换任意模型。
-
-## 相关链接
-
-- [论坛](https://forum.playcanvas.com)
-- [开发者站点](https://developer.playcanvas.com)
-- [博客](https://blog.playcanvas.com)
-
-## 贡献
-
-想要和我们一起开发最棒的网页 3D 引擎？
-
-您可以先从查看 [CONTRIBUTING.md](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) 开始。然后，在 Issues 中查找一个您拿手的 ["good first PR"](https://github.com/playcanvas/engine/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+PR%22) 进行处理。
 
 ## PlayCanvas 平台
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 <img width="200" src="https://s3-eu-west-1.amazonaws.com/static.playcanvas.com/platform/images/logo/playcanvas-logo-medium.png"/>
 
 # PlayCanvas WebGL Game Engine
+[Docs](https://developer.playcanvas.com) | [Examples](https://playcanvas.github.io) | [Forum](https://forum.playcanvas.com) | [Blog](https://blog.playcanvas.com)
 
 PlayCanvas is an open-source game engine. It uses HTML5 and WebGL to run games and other interactive 3D content in any mobile or desktop browser.
 
@@ -162,22 +163,6 @@ PlayCanvas uses of Karma for unit testing. There are two ways of running the tes
 | `npm run test`         | Runs unit tests on a built `playcanvas.js`                                            |
 | `npm run test:watch`   | Re-runs unit tests when changes are detected - open http://localhost:9876/debug.html  |
 
-## How to get models?
-
-To convert any models created using a 3D modelling package see [this page](https://developer.playcanvas.com/en/user-manual/assets/models/) in the developer documentation.
-
-## Useful Links
-
-* [Forum](https://forum.playcanvas.com)
-* [Developer Site](https://developer.playcanvas.com)
-* [Blog](https://blog.playcanvas.com)
-
-## Contributing
-
-Want to help us make the best 3D engine on the web? Great!
-Check out [CONTRIBUTING.md](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) that will get you started.
-And look for ["good first PR"](https://github.com/playcanvas/engine/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+PR%22)  label in Issues.
-
 ## PlayCanvas Editor
 
 The PlayCanvas Engine is an open source engine which you can use to create HTML5 apps/games. In addition to the engine, we also make the [PlayCanvas Editor](https://playcanvas.com/):
@@ -185,10 +170,6 @@ The PlayCanvas Engine is an open source engine which you can use to create HTML5
 [![Editor](https://github.com/playcanvas/editor/blob/master/images/editor.png?raw=true)](https://github.com/playcanvas/editor)
 
 For Editor related bugs and issues, please refer to the [Editor's repo](https://github.com/playcanvas/editor).
-
-## License
-
-The PlayCanvas Engine is released under the [MIT](https://opensource.org/licenses/MIT) license. See LICENSE file.
 
 [npm-badge]: https://img.shields.io/npm/v/playcanvas
 [npm-url]: https://www.npmjs.com/package/playcanvas


### PR DESCRIPTION
Cull some sections in the README:

* Contributing - there's a standard CONTRIBUTING.md that anyone can find
* License - there's a LICENSE file plus a license type in the sidebar
* Finding models - it's not for the README to go into such specifics
* Useful links - added a single line list of links nearer the top

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
