### PR TITLE
Improve WebGL context creation

### DIFF
--- a/src/graphics/graphics-device.js
+++ b/src/graphics/graphics-device.js
@@ -609,7 +609,7 @@ class GraphicsDevice extends EventHandler {
         this._drawCallsPerFrame = 0;
         this._shaderSwitchesPerFrame = 0;
         this._primsPerFrame = [];
-        for (i = PRIMITIVE_POINTS; i <= PRIMITIVE_TRIFAN; i++) {
+        for (let i = PRIMITIVE_POINTS; i <= PRIMITIVE_TRIFAN; i++) {
             this._primsPerFrame[i] = 0;
         }
         this._renderTargetCreationTime = 0;

--- a/src/graphics/graphics-device.js
+++ b/src/graphics/graphics-device.js
@@ -246,7 +246,6 @@ class GraphicsDevice extends EventHandler {
     constructor(canvas, options) {
         super();
 
-        var i;
         this.canvas = canvas;
         this._enableAutoInstancing = false;
         this.autoInstancingMaxObjects = 16384;
@@ -290,18 +289,15 @@ class GraphicsDevice extends EventHandler {
         // Retrieve the WebGL context
         var preferWebGl2 = (options && options.preferWebGl2 !== undefined) ? options.preferWebGl2 : true;
 
-        var names = preferWebGl2 ? ["webgl2", "experimental-webgl2", "webgl", "experimental-webgl"] :
-            ["webgl", "experimental-webgl"];
+        var names = preferWebGl2 ? ["webgl2", "webgl", "experimental-webgl"] : ["webgl", "experimental-webgl"];
         var gl = null;
         options = options || {};
         options.stencil = true;
-        for (i = 0; i < names.length; i++) {
-            try {
-                gl = canvas.getContext(names[i], options);
-            } catch (e) { }
+        for (let i = 0; i < names.length; i++) {
+            gl = canvas.getContext(names[i], options);
 
             if (gl) {
-                this.webgl2 = preferWebGl2 && i < 2;
+                this.webgl2 = (names[i] === 'webgl2');
                 break;
             }
         }


### PR DESCRIPTION
There are a couple of problems with PlayCanvas' current WebGL context creation code:

1. There was never a experimental-webgl2 so it should not be passed to `getContext`. Reference: https://webgl2fundamentals.org/webgl/lessons/webgl1-to-webgl2.html
2. `getContext` does not throw an exception. You just need to check return type for null. Reference: https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/getContext#return_value

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
