### PR TITLE
Picker refactoring

### DIFF
--- a/examples/graphics/area-picker.html
+++ b/examples/graphics/area-picker.html
@@ -5,7 +5,8 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
     <link rel="icon" type="image/png" href="../playcanvas-favicon.png" />
-    <script src="../../build/playcanvas.js"></script>
+    <script src="../../build/playcanvas.dbg.js"></script>
+    <script src="../assets/scripts/asset-loader.js"></script>
     <script src="../../build/playcanvas-extras.js"></script>
     <style>
         body { 
@@ -30,6 +31,7 @@
         // Set the canvas to fill the window and automatically change resolution to be the same as the canvas size
         app.setCanvasFillMode(pc.FILLMODE_FILL_WINDOW);
         app.setCanvasResolution(pc.RESOLUTION_AUTO);
+        app.scene.ambientLight = new pc.Color(0.2, 0.2, 0.2);
 
         window.addEventListener("resize", function () {
             app.resizeCanvas(canvas.width, canvas.height);
@@ -37,7 +39,33 @@
 
         var miniStats = new pcx.MiniStats(app);
 
-        app.scene.ambientLight = new pc.Color(0.2, 0.2, 0.2);
+        // setup skydome
+        app.scene.skyboxMip = 2;
+
+        // Load a cubemap asset. This DDS file was 'prefiltered' in the PlayCanvas Editor and then downloaded.
+        var cubemapAsset = new pc.Asset('helipad.dds', 'cubemap', {
+            url: "../assets/cubemaps/helipad.dds"
+        }, {
+            type: pc.TEXTURETYPE_RGBM
+        });
+        app.assets.add(cubemapAsset);
+        app.assets.load(cubemapAsset);
+        cubemapAsset.ready(function () {
+            app.scene.setSkybox(cubemapAsset.resources);
+        });
+
+        // A list of assets that need to be loaded
+        var assetManifest = {
+            bloom: {
+                type: "script",
+                url: "../../scripts/posteffects/posteffect-bloom.js"
+            }
+        };
+
+        // Load all assets and then run the example
+        loadManifestAssets(app, assetManifest, function () {
+            run();
+        });
 
         // helper function to create a primitive with shape type, position, scale
         function createPrimitive(primitiveType, position, scale) {
@@ -45,6 +73,9 @@
             // create material of random color
             var material = new pc.StandardMaterial();
             material.diffuse = new pc.Color(Math.random(), Math.random(), Math.random());
+            material.shininess = 60;
+            material.metalness = 0.4;
+            material.useMetalness = true;
             material.update();
 
             // create primitive
@@ -61,36 +92,10 @@
             return primitive;
         }
 
-        // generate a box area with specified size of random primitives
-        var size = 30;
-        var halfSize = size * 0.5;
-        for (var i = 0; i < 300; i++) {
-            var shape = Math.random() < 0.5 ? "box" : "sphere";
-            var position = new pc.Vec3(Math.random() * size - halfSize, Math.random() * size - halfSize, Math.random() * size - halfSize);
-            var scale = 1 + Math.random();
-            var entity = createPrimitive(shape, position, new pc.Vec3(scale, scale, scale));
-            app.root.addChild(entity);
-        }
-
-        // Create main camera
-        var camera = new pc.Entity();
-        camera.addComponent("camera", {
-            clearColor: new pc.Color(0.1, 0.1, 0.1)
-        });
-        app.root.addChild(camera);
-
-        // Create an Entity with a omni light component
-        var light1 = new pc.Entity();
-        light1.addComponent("light", {
-            type: "omni",
-            color: new pc.Color(0.7, 0.7, 0.7),
-            range: 150
-        });
-        light1.translate(70, 60, 50);
-        app.root.addChild(light1);
-
         // function to draw a 2D rectangle in the screen space coordinates
         function drawRectangle(x, y, w, h) {
+
+            var pink = new pc.Color(1, 0.02, 0.58);
 
             // transform 4 2D screen points into world space
             var pt0 = camera.camera.screenToWorld(x, y, 1);
@@ -100,8 +105,9 @@
 
             // and connect them using white lines
             var points = [pt0, pt1,  pt1, pt2,  pt2, pt3,  pt3, pt0];
-            var colors = [pc.Color.WHITE, pc.Color.WHITE,  pc.Color.WHITE, pc.Color.WHITE,  
-                pc.Color.WHITE, pc.Color.WHITE,  pc.Color.WHITE, pc.Color.WHITE
+            var colors = [pink, pink, pink, pink, pink, pink, pink, pink
+                // var colors = [pc.Color.WHITE, pc.Color.WHITE,  pc.Color.WHITE, pc.Color.WHITE,  
+                // pc.Color.WHITE, pc.Color.WHITE,  pc.Color.WHITE, pc.Color.WHITE
             ];
             app.renderLines(points, colors);
         }
@@ -112,17 +118,52 @@
             material.update();
         }
 
-        // handle mouse move event and store current mouse position to use as a position to pick from the scene        
-        var mouseX = 0, mouseY = 0;
-        new pc.Mouse(document.body).on(pc.EVENT_MOUSEMOVE, function (event) {
-            mouseX = event.x;
-            mouseY = event.y;
-        }, this);
-
-        // Create an instance of the picker class
-        // Lets use quarter of the resolution to improve performance - this will miss very small objects, but it's ok in our case
+        // use a quarter resolution for picker render target (faster but less precise - can miss small objects)
         var pickerScale = 0.25;
-        var picker = new pc.Picker(app, canvas.clientWidth * pickerScale, canvas.clientHeight * pickerScale);
+        var picker;
+        var camera;
+        var mouseX = 0, mouseY = 0;
+
+        function run() {
+
+            // generate a box area with specified size of random primitives
+            var size = 30;
+            var halfSize = size * 0.5;
+            for (var i = 0; i < 300; i++) {
+                var shape = Math.random() < 0.5 ? "cylinder" : "sphere";
+                var position = new pc.Vec3(Math.random() * size - halfSize, Math.random() * size - halfSize, Math.random() * size - halfSize);
+                var scale = 1 + Math.random();
+                var entity = createPrimitive(shape, position, new pc.Vec3(scale, scale, scale));
+                app.root.addChild(entity);
+            }
+
+            // Create main camera
+            camera = new pc.Entity();
+            camera.addComponent("camera", {
+                clearColor: new pc.Color(0.1, 0.1, 0.1)
+            });
+
+            // add bloom postprocessing (this is ignored by the picker)
+            camera.addComponent("script");
+            camera.script.create("bloom", {
+                attributes: {
+                    bloomIntensity: 1,
+                    bloomThreshold: 0.7,
+                    blurAmount: 4
+                }
+            });
+            app.root.addChild(camera);
+
+            // handle mouse move event and store current mouse position to use as a position to pick from the scene        
+            new pc.Mouse(document.body).on(pc.EVENT_MOUSEMOVE, function (event) {
+                mouseX = event.x;
+                mouseY = event.y;
+            }, this);
+
+            // Create an instance of the picker class
+            // Lets use quarter of the resolution to improve performance - this will miss very small objects, but it's ok in our case
+            picker = new pc.Picker(app, canvas.clientWidth * pickerScale, canvas.clientHeight * pickerScale);
+        }
 
         // array of highlighted materials
         var highlights = [];
@@ -131,8 +172,13 @@
         var time = 0;
         app.on("update", function (dt) {
 
-            // orbit the camera around
             time += dt * 0.1;
+
+            // orbit the camera around
+            if (!camera) {
+                return;
+            }
+
             camera.setLocalPosition(40 * Math.sin(time), 0, 40 * Math.cos(time));
             camera.lookAt(pc.Vec3.ZERO);
 
@@ -143,8 +189,10 @@
             highlights.length = 0;
 
             // Make sure the picker is the right size, and prepare it, which renders meshes into its render target
-            picker.resize(canvas.clientWidth * pickerScale, canvas.clientHeight * pickerScale);
-            picker.prepare(camera.camera, app.scene);
+            if (picker) {
+                picker.resize(canvas.clientWidth * pickerScale, canvas.clientHeight * pickerScale);
+                picker.prepare(camera.camera, app.scene);
+            }
 
             // areas we want to sample - two larger rectangles, one small square, and one pixel at a mouse position
             // assign them different highlight colors as well
@@ -153,8 +201,7 @@
                     pos: new pc.Vec2(canvas.clientWidth * 0.3, canvas.clientHeight * 0.3),
                     size: new pc.Vec2(100, 200),
                     color: pc.Color.YELLOW
-                }
-                ,
+                },
                 { 
                     pos: new pc.Vec2(canvas.clientWidth * 0.6, canvas.clientHeight * 0.7),
                     size: new pc.Vec2(200, 20),

--- a/examples/graphics/area-picker.html
+++ b/examples/graphics/area-picker.html
@@ -5,7 +5,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
     <link rel="icon" type="image/png" href="../playcanvas-favicon.png" />
-    <script src="../../build/playcanvas.dbg.js"></script>
+    <script src="../../build/playcanvas.js"></script>
     <script src="../assets/scripts/asset-loader.js"></script>
     <script src="../../build/playcanvas-extras.js"></script>
     <style>

--- a/src/framework/components/camera/component.js
+++ b/src/framework/components/camera/component.js
@@ -5,6 +5,29 @@ import { Component } from '../component.js';
 
 import { PostEffectQueue } from './post-effect-queue.js';
 
+const properties = [
+    { name: 'aspectRatio', readonly: false },
+    { name: 'aspectRatioMode', readonly: false },
+    { name: 'calculateProjection', readonly: false },
+    { name: 'calculateTransform', readonly: false },
+    { name: 'clearColor', readonly: false },
+    { name: 'cullFaces', readonly: false },
+    { name: 'farClip', readonly: false },
+    { name: 'flipFaces', readonly: false },
+    { name: 'fov', readonly: false },
+    { name: 'frustum', readonly: true },
+    { name: 'frustumCulling', readonly: false },
+    { name: 'horizontalFov', readonly: false },
+    { name: 'nearClip', readonly: false },
+    { name: 'orthoHeight', readonly: false },
+    { name: 'projection', readonly: false },
+    { name: 'projectionMatrix', readonly: true },
+    { name: 'rect', readonly: false },
+    { name: 'scissorRect', readonly: false },
+    { name: 'viewMatrix', readonly: true },
+    { name: 'vrDisplay', readonly: false }
+];
+
 /**
  * @component
  * @class
@@ -603,31 +626,33 @@ class CameraComponent extends Component {
 
         this._camera.xr.end(callback);
     }
+
+    // function to copy properties from the source CameraComponent.
+    // properties not copied: postEffects
+    // inherited properties not copied (all): system, entity, enabled)
+    copy(source) {
+
+        // copy data driven properties
+        properties.forEach((property) => {
+            if (!property.readonly) {
+                const name = property.name;
+                this[name] = source[name];
+            }
+        });
+
+        // other properties
+        this.clearColorBuffer = source.clearColorBuffer;
+        this.clearDepthBuffer = source.clearDepthBuffer;
+        this.clearStencilBuffer = source.clearStencilBuffer;
+        this.disablePostEffectsLayer = source.disablePostEffectsLayer;
+        this.layers = source.layers;
+        this.priority = source.priority;
+        this.renderTarget = source.renderTarget;
+    }
 }
 
 // for common properties, create getters and setters which use this._camera as a storage for their values
-[
-    { name: 'aspectRatio', readonly: false },
-    { name: 'aspectRatioMode', readonly: false },
-    { name: 'calculateProjection', readonly: false },
-    { name: 'calculateTransform', readonly: false },
-    { name: 'clearColor', readonly: false },
-    { name: 'cullFaces', readonly: false },
-    { name: 'farClip', readonly: false },
-    { name: 'flipFaces', readonly: false },
-    { name: 'fov', readonly: false },
-    { name: 'frustum', readonly: true },
-    { name: 'frustumCulling', readonly: false },
-    { name: 'horizontalFov', readonly: false },
-    { name: 'nearClip', readonly: false },
-    { name: 'orthoHeight', readonly: false },
-    { name: 'projection', readonly: false },
-    { name: 'projectionMatrix', readonly: true },
-    { name: 'rect', readonly: false },
-    { name: 'scissorRect', readonly: false },
-    { name: 'viewMatrix', readonly: true },
-    { name: 'vrDisplay', readonly: false }
-].forEach(function (property) {
+properties.forEach(function (property) {
     var name = property.name;
     var options = {};
 

--- a/src/math/vec2.js
+++ b/src/math/vec2.js
@@ -131,7 +131,7 @@ class Vec2 {
     /**
      * @function
      * @name Vec2#copy
-     * @description Copied the contents of a source 2-dimensional vector to a destination 2-dimensional vector.
+     * @description Copies the contents of a source 2-dimensional vector to a destination 2-dimensional vector.
      * @param {Vec2} rhs - A vector to copy to the specified vector.
      * @returns {Vec2} Self for chaining.
      * @example

--- a/src/math/vec3.js
+++ b/src/math/vec3.js
@@ -148,7 +148,7 @@ class Vec3 {
     /**
      * @function
      * @name Vec3#copy
-     * @description Copied the contents of a source 3-dimensional vector to a destination 3-dimensional vector.
+     * @description Copies the contents of a source 3-dimensional vector to a destination 3-dimensional vector.
      * @param {Vec3} rhs - A vector to copy to the specified vector.
      * @returns {Vec3} Self for chaining.
      * @example

--- a/src/math/vec4.js
+++ b/src/math/vec4.js
@@ -171,7 +171,7 @@ class Vec4 {
     /**
      * @function
      * @name Vec4#copy
-     * @description Copied the contents of a source 4-dimensional vector to a destination 4-dimensional vector.
+     * @description Copies the contents of a source 4-dimensional vector to a destination 4-dimensional vector.
      * @param {Vec4} rhs - A vector to copy to the specified vector.
      * @returns {Vec4} Self for chaining.
      * @example

--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -240,6 +240,7 @@ class GraphNode extends EventHandler {
         clone.name = this.name;
 
         var tags = this.tags._list;
+        clone.tags.clear();
         for (var i = 0; i < tags.length; i++)
             clone.tags.add(tags[i]);
 
@@ -274,6 +275,12 @@ class GraphNode extends EventHandler {
         var clone = new GraphNode();
         this._cloneInternal(clone);
         return clone;
+    }
+
+    // copies properties from source to this
+    copy(source) {
+        source._cloneInternal(this);
+        return this;
     }
 
     /**

--- a/src/scene/layer-composition.js
+++ b/src/scene/layer-composition.js
@@ -238,7 +238,6 @@ class LayerComposition extends EventHandler {
                 }
 
                 layer._dirty = false;
-                layer._version++;
             }
 
             this._dirty = false;

--- a/src/scene/layer.js
+++ b/src/scene/layer.js
@@ -271,7 +271,6 @@ class Layer {
         // #endif
 
         this._shaderVersion = -1;
-        this._version = 0;
         this._lightCube = null;
     }
 

--- a/src/scene/picker.js
+++ b/src/scene/picker.js
@@ -232,7 +232,7 @@ class Picker {
      * in any way, {@link Picker#prepare} does not need to be called again.
      * @param {CameraComponent} camera - The camera component used to render the scene.
      * @param {Scene} scene - The scene containing the pickable mesh instances.
-     * @param {[]Layer} [layers] - Layers from which objects will be picked. If not supplied, all layers the provided camera renders will be used.
+     * @param {Layer[]} [layers] - Layers from which objects will be picked. If not supplied, all layers the provided camera renders will be used.
      */
     prepare(camera, scene, layers) {
 

--- a/src/scene/picker.js
+++ b/src/scene/picker.js
@@ -232,7 +232,7 @@ class Picker {
      * in any way, {@link Picker#prepare} does not need to be called again.
      * @param {CameraComponent} camera - The camera component used to render the scene.
      * @param {Scene} scene - The scene containing the pickable mesh instances.
-     * @param {Layer[]} [layers] - Layers from which objects will be picked. If not supplied, all layers the provided camera renders will be used.
+     * @param {Layer[]} [layers] - Layers from which objects will be picked. If not supplied, all layers of the specified camera will be used.
      */
     prepare(camera, scene, layers) {
 

--- a/src/scene/picker.js
+++ b/src/scene/picker.js
@@ -1,19 +1,28 @@
-import { ADDRESS_CLAMP_TO_EDGE, CLEARFLAG_COLOR, CLEARFLAG_DEPTH, FILTER_NEAREST, PIXELFORMAT_R8_G8_B8_A8 } from '../graphics/constants.js';
+import { Color } from "../math/color.js";
+
+import { ADDRESS_CLAMP_TO_EDGE, CLEARFLAG_DEPTH, FILTER_NEAREST, PIXELFORMAT_R8_G8_B8_A8 } from '../graphics/constants.js';
 import { GraphicsDevice } from '../graphics/graphics-device.js';
 import { RenderTarget } from '../graphics/render-target.js';
 import { Texture } from '../graphics/texture.js';
 
-import { ASPECT_MANUAL, SHADER_PICK, SORTMODE_NONE } from './constants.js';
+import { SHADER_PICK, SORTMODE_NONE } from './constants.js';
 import { Camera } from './camera.js';
 import { Command } from './mesh-instance.js';
 import { Layer } from './layer.js';
 import { LayerComposition } from './layer-composition.js';
 
 import { getApplication } from '../framework/globals.js';
+import { Entity } from '../framework/entity.js';
 
-var _deviceDeprecationWarning = false;
-var _getSelectionDeprecationWarning = false;
-var _prepareDeprecationWarning = false;
+let _deviceDeprecationWarning = false;
+let _getSelectionDeprecationWarning = false;
+let _prepareDeprecationWarning = false;
+const tempSet = new Set();
+
+const clearDepthOptions = {
+    depth: 1.0,
+    flags: CLEARFLAG_DEPTH
+};
 
 /**
  * @class
@@ -41,37 +50,32 @@ class Picker {
 
         this.app = app;
         this.device = app.graphicsDevice;
-        var device = this.device;
 
+        // uniform for the mesh index encoded into rgba
         this.pickColor = new Float32Array(4);
         this.pickColor[3] = 1;
 
         // mapping table from ids to meshInstances
         this.mapping = [];
 
-        this.scene = null;
-        this.drawCalls = [];
+        // create layer composition with the layer and camera
+        this.cameraEntity = null;
         this.layer = null;
         this.layerComp = null;
+        this.initLayerComposition();
 
-        this.clearOptions = {
-            color: [1, 1, 1, 1],
-            depth: 1,
-            flags: CLEARFLAG_COLOR | CLEARFLAG_DEPTH
-        };
+        // internal render target
+        this._renderTarget = null;
 
-        var self = this;
-        this._clearDepthOptions = {
-            depth: 1.0,
-            flags: CLEARFLAG_DEPTH
-        };
+        // clear command user to simulate layer clearing, required due to storing meshes from multiple layers on a singe layer
+        const device = this.device;
         this.clearDepthCommand = new Command(0, 0, function () {
-            device.clear(self._clearDepthOptions);
+            device.clear(clearDepthOptions);
         });
 
+        this.width = 0;
+        this.height = 0;
         this.resize(width, height);
-
-        this._ignoreOpacityFor = null; // meshInstance
     }
 
     /**
@@ -92,7 +96,7 @@ class Picker {
      * var selection = picker.getSelection(10, 20, 10, 20);
      */
     getSelection(x, y, width, height) {
-        var device = this.device;
+        const device = this.device;
 
         if (typeof x === 'object') {
             // #if _DEBUG
@@ -102,13 +106,13 @@ class Picker {
             }
             // #endif
 
-            var rect = x;
+            const rect = x;
             x = rect.x;
             y = rect.y;
             width = rect.width;
             height = rect.height;
         } else {
-            y = this.layer.renderTarget.height - (y + (height || 1));
+            y = this.renderTarget.height - (y + (height || 1));
         }
 
         // make sure we have nice numbers to work with
@@ -117,41 +121,106 @@ class Picker {
         width = Math.floor(Math.max(width || 1, 1));
         height = Math.floor(Math.max(height || 1, 1));
 
-        // Cache active render target
-        var prevRenderTarget = device.renderTarget;
+        // backup active render target
+        const origRenderTarget = device.renderTarget;
 
         // Ready the device for rendering to the pick buffer
-        device.setRenderTarget(this.layer.renderTarget);
+        device.setRenderTarget(this.renderTarget);
         device.updateBegin();
 
-        var pixels = new Uint8Array(4 * width * height);
+        const pixels = new Uint8Array(4 * width * height);
         device.readPixels(x, y, width, height, pixels);
 
         device.updateEnd();
 
         // Restore render target
-        device.setRenderTarget(prevRenderTarget);
+        device.setRenderTarget(origRenderTarget);
 
-        var selection = [];
-        var mapping = this.mapping;
+        const mapping = this.mapping;
+        for (let i = 0; i < width * height; i++) {
+            const r = pixels[4 * i + 0];
+            const g = pixels[4 * i + 1];
+            const b = pixels[4 * i + 2];
+            const index = r << 16 | g << 8 | b;
 
-        var r, g, b, index;
-        for (var i = 0; i < width * height; i++) {
-            r = pixels[4 * i + 0];
-            g = pixels[4 * i + 1];
-            b = pixels[4 * i + 2];
-            index = r << 16 | g << 8 | b;
             // White is 'no selection'
             if (index !== 0xffffff) {
-                // TODO: optimize search using set instead of array
-                var selectedMeshInstance = mapping[index];
-                if (selection.indexOf(selectedMeshInstance) === -1) {
-                    selection.push(selectedMeshInstance);
-                }
+                tempSet.add(mapping[index]);
             }
         }
 
+        // return the content of the set as an array
+        const selection = [];
+        tempSet.forEach((meshInstance) => selection.push(meshInstance));
+        tempSet.clear();
+
         return selection;
+    }
+
+    allocateRenderTarget() {
+
+        const colorBuffer = new Texture(this.device, {
+            format: PIXELFORMAT_R8_G8_B8_A8,
+            width: this.width,
+            height: this.height,
+            mipmaps: false,
+            minFilter: FILTER_NEAREST,
+            magFilter: FILTER_NEAREST,
+            addressU: ADDRESS_CLAMP_TO_EDGE,
+            addressV: ADDRESS_CLAMP_TO_EDGE
+        });
+        colorBuffer.name = 'pick';
+
+        this.renderTarget = new RenderTarget(this.device, colorBuffer, {
+            depth: true
+        });
+    }
+
+    releaseRenderTarget() {
+
+        // unset it from the camera
+        this.cameraEntity.camera.renderTarget = null;
+
+        if (this._renderTarget) {
+            this._renderTarget._colorBuffer.destroy();
+            this._renderTarget.destroy();
+            this._renderTarget = null;
+        }
+    }
+
+    initLayerComposition() {
+
+        const device = this.device;
+        const self = this;
+        const pickColorId = device.scope.resolve('uColor');
+
+        // camera
+        this.cameraEntity = new Entity();
+        this.cameraEntity.addComponent("camera");
+
+        // layer all meshes rendered for picking at added to
+        this.layer = new Layer({
+            name: "Picker",
+            shaderPass: SHADER_PICK,
+            opaqueSortMode: SORTMODE_NONE,
+
+            // executes just before the mesh is rendered. And index encoded in rgb is assigned to it
+            onDrawCall: function (meshInstance, index) {
+                self.pickColor[0] = ((index >> 16) & 0xff) / 255;
+                self.pickColor[1] = ((index >> 8) & 0xff) / 255;
+                self.pickColor[2] = (index & 0xff) / 255;
+                pickColorId.setValue(self.pickColor);
+                device.setBlending(false);
+
+                // keep the index -> meshInstance index mapping
+                self.mapping[index] = meshInstance;
+            }
+        });
+        this.layer.addCamera(this.cameraEntity.camera);
+
+        // composition
+        this.layerComp = new LayerComposition("picker");
+        this.layerComp.pushOpaque(this.layer);
     }
 
     /**
@@ -163,14 +232,11 @@ class Picker {
      * in any way, {@link Picker#prepare} does not need to be called again.
      * @param {CameraComponent} camera - The camera component used to render the scene.
      * @param {Scene} scene - The scene containing the pickable mesh instances.
-     * @param {Layer|RenderTarget} [arg] - Layer or RenderTarget from which objects will be picked.
-     * If not supplied, all layers rendering to backbuffer before this layer will be used.
+     * @param {[]Layer} [layers] - Layers from which objects will be picked. If not supplied, all layers the provided camera renders will be used.
      */
-    prepare(camera, scene, arg) {
-        var device = this.device;
-        var i, j;
-        var self = this;
+    prepare(camera, scene, layers) {
 
+        // handle deprecated arguments
         if (camera instanceof Camera) {
             // #if _DEBUG
             if (!_getSelectionDeprecationWarning) {
@@ -183,176 +249,89 @@ class Picker {
             camera = camera.node.camera;
         }
 
-        this.scene = scene;
-        var sourceLayer = null;
-        var sourceRt = null;
-
-        if (arg instanceof Layer) {
-            sourceLayer = arg;
-        } else {
-            sourceRt = arg;
+        if (layers instanceof Layer) {
+            layers = [layers];
         }
 
-        // Setup picker rendering once
-        if (!this.layer) {
-            var pickColorId = device.scope.resolve('uColor');
+        // populate the layer with meshes and depth clear commands
+        this.layer.clearMeshInstances();
+        const destMeshInstances = this.layer.opaqueMeshInstances;
 
-            this.layer = new Layer({
-                name: "Picker",
-                shaderPass: SHADER_PICK,
-                opaqueSortMode: SORTMODE_NONE,
+        // source mesh instances
+        const srcLayers = scene.layers.layerList;
+        const subLayerEnabled = scene.layers.subLayerEnabled;
+        const isTransparent = scene.layers.subLayerList;
 
-                onEnable: function () {
-                    if (this.renderTarget) return;
-                    var colorBuffer = new Texture(device, {
-                        format: PIXELFORMAT_R8_G8_B8_A8,
-                        width: self.width,
-                        height: self.height,
-                        mipmaps: false
-                    });
-                    colorBuffer.name = 'pick';
-                    colorBuffer.minFilter = FILTER_NEAREST;
-                    colorBuffer.magFilter = FILTER_NEAREST;
-                    colorBuffer.addressU = ADDRESS_CLAMP_TO_EDGE;
-                    colorBuffer.addressV = ADDRESS_CLAMP_TO_EDGE;
-                    this.renderTarget = new RenderTarget(device, colorBuffer, {
-                        depth: true
-                    });
-                },
+        for (let i = 0; i < srcLayers.length; i++) {
+            const srcLayer = srcLayers[i];
 
-                onDisable: function () {
-                    if (!this.renderTarget) return;
-                    this.renderTarget._colorBuffer.destroy();
-                    this.renderTarget.destroy();
-                    this.renderTarget = null;
-                },
-
-                onDrawCall: function (meshInstance, index) {
-                    self.pickColor[0] = ((index >> 16) & 0xff) / 255;
-                    self.pickColor[1] = ((index >> 8) & 0xff) / 255;
-                    self.pickColor[2] = (index & 0xff) / 255;
-                    pickColorId.setValue(self.pickColor);
-                    device.setBlending(false);
-                    self.mapping[index] = meshInstance;
-                }
-            });
-
-            this.layerComp = new LayerComposition(device, "picker");
-            this.layerComp.pushOpaque(this.layer);
-
-            this.meshInstances = this.layer.opaqueMeshInstances;
-            this._instancesVersion = -1;
-        }
-
-        // Collect pickable mesh instances
-        var instanceList, instanceListLength, drawCall;
-        if (!sourceLayer) {
-            this.layer.clearMeshInstances();
-            var layers = scene.layers.layerList;
-            var subLayerEnabled = scene.layers.subLayerEnabled;
-            var isTransparent = scene.layers.subLayerList;
-            var layer;
-            var layerCamId, transparent;
-            for (i = 0; i < layers.length; i++) {
-                if (layers[i]._clearDepthBuffer) layers[i]._pickerCleared = false;
+            // skip the layer if it does not match the provided ones
+            if (layers && layers.indexOf(srcLayer) < 0) {
+                continue;
             }
-            for (i = 0; i < layers.length; i++) {
-                layer = layers[i];
-                if (layer.renderTarget !== sourceRt || !layer.enabled || !subLayerEnabled[i]) continue;
-                layerCamId = layer.cameras.indexOf(camera);
-                if (layerCamId < 0) continue;
-                if (layer._clearDepthBuffer && !layer._pickerCleared) {
-                    this.meshInstances.push(this.clearDepthCommand);
-                    layer._pickerCleared = true;
-                }
-                transparent = isTransparent[i];
-                instanceList = transparent ? layer.instances.transparentMeshInstances : layer.instances.opaqueMeshInstances;
-                instanceListLength = instanceList.length;
-                for (j = 0; j < instanceListLength; j++) {
-                    drawCall = instanceList[j];
-                    if (drawCall.pick) {
-                        this.meshInstances.push(drawCall);
+
+            if (srcLayer.enabled && subLayerEnabled[i]) {
+
+                // if the layer is rendered by the camera
+                const layerCamId = srcLayer.cameras.indexOf(camera);
+                if (layerCamId >= 0) {
+
+                    // if the layer clears the depth, add command to clear it
+                    if (srcLayer._clearDepthBuffer) {
+                        destMeshInstances.push(this.clearDepthCommand);
+                    }
+
+                    // copy all pickable mesh instances
+                    const meshInstances = isTransparent[i] ? srcLayer.instances.transparentMeshInstances : srcLayer.instances.opaqueMeshInstances;
+                    for (let j = 0; j < meshInstances.length; j++) {
+                        const meshInstance = meshInstances[j];
+                        if (meshInstance.pick) {
+                            destMeshInstances.push(meshInstance);
+                        }
                     }
                 }
             }
-        } else {
-            if (this._instancesVersion !== sourceLayer._version) {
-                this.layer.clearMeshInstances();
-                instanceList = sourceLayer.instances.opaqueMeshInstances;
-                instanceListLength = instanceList.length;
-                for (j = 0; j < instanceListLength; j++) {
-                    drawCall = instanceList[j];
-                    if (drawCall.pick) {
-                        this.meshInstances.push(drawCall);
-                    }
-                }
-                instanceList = sourceLayer.instances.transparentMeshInstances;
-                instanceListLength = instanceList.length;
-                for (j = 0; j < instanceListLength; j++) {
-                    drawCall = instanceList[j];
-                    if (drawCall.pick) {
-                        this.meshInstances.push(drawCall);
-                    }
-                }
-                this._instancesVersion = sourceLayer._version;
-            }
         }
 
-        // Setup picker camera if changed
-        if (this.layer.cameras[0] !== camera) {
-            this.layer.clearCameras();
-            this.layer.addCamera(camera);
+        // make the render target the right size
+        if (!this.renderTarget || (this.width !== this.renderTarget.width || this.height !== this.renderTarget.height)) {
+            this.releaseRenderTarget();
+            this.allocateRenderTarget();
         }
 
-        // save old camera state
-        const originalLayers = this.onLayerPreRender(this.layer, sourceLayer, sourceRt, camera);
+        // prepare the rendering camera
+        this.updateCamera(camera);
 
-        // clear registered meshes, rendering will register them again
-        self.mapping.length = 0;
+        // clear registered meshes mapping
+        this.mapping.length = 0;
 
-        // Render
+        // render
         this.app.renderer.renderComposition(this.layerComp);
-
-        // restore old camera state
-        this.onLayerPostRender(this.layer, camera, originalLayers);
     }
 
-    onLayerPreRender(layer, sourceLayer, sourceRt, camera) {
-        if (this.width !== layer.renderTarget.width || this.height !== layer.renderTarget.height) {
-            layer.onDisable();
-            layer.onEnable();
-        }
+    updateCamera(srcCamera) {
 
-        // back up original settings
-        layer.oldClear = layer.cameras[0].camera._clearOptions;
-        layer.oldAspectMode = layer.cameras[0].aspectRatioMode;
-        layer.oldAspect = layer.cameras[0].aspectRatio;
+        // copy transform
+        this.cameraEntity.copy(srcCamera.entity);
+        this.cameraEntity.name = "PickerCamera";
 
-        // set up new settings
-        layer.cameras[0].camera._clearOptions = this.clearOptions;
-        layer.cameras[0].aspectRatioMode = ASPECT_MANUAL;
-        var rt = sourceRt ? sourceRt : (sourceLayer ? sourceLayer.renderTarget : null);
-        layer.cameras[0].aspectRatio = layer.cameras[0].calculateAspectRatio(rt);
-        this.app.renderer.updateCameraFrustum(layer.cameras[0].camera);
+        // copy camera component properties - which overwrites few properties we change to what is needed later
+        const destCamera = this.cameraEntity.camera;
+        destCamera.copy(srcCamera);
 
-        // add layer to be rendered by the camera
-        const originalLayers = camera.layers.slice();
-        const cameraLayers = camera.layers;
-        cameraLayers.push(this.layer.id);
-        camera.layers = cameraLayers;
+        // set up clears
+        destCamera.clearColorBuffer = true;
+        destCamera.clearDepthBuffer = true;
+        destCamera.clearStencilBuffer = true;
+        destCamera.clearColor = Color.WHITE;
 
-        return originalLayers;
-    }
+        // render target
+        destCamera.renderTarget = this.renderTarget;
 
-    onLayerPostRender(layer, camera, originalLayers) {
-
-        // restore original settings
-        layer.cameras[0].camera._clearOptions = layer.oldClear;
-        layer.cameras[0].aspectRatioMode = layer.oldAspectMode;
-        layer.cameras[0].aspectRatio = layer.oldAspect;
-
-        // restore camera layers to original condition
-        camera.layers = originalLayers;
+        // layers
+        this.layer.clearCameras();
+        this.layer.addCamera(destCamera);
+        destCamera.layers = [this.layer.id];
     }
 
     /**
@@ -367,12 +346,8 @@ class Picker {
      * @param {number} height - The height of the pick buffer in pixels.
      */
     resize(width, height) {
-        this.width = width;
-        this.height = height;
-    }
-
-    get renderTarget() {
-        return this.layer.renderTarget;
+        this.width = Math.floor(width);
+        this.height = Math.floor(height);
     }
 }
 


### PR DESCRIPTION
Refactored picker class, with these larger changes:
- ignores post effects, Fixes https://github.com/playcanvas/engine/issues/3093
- engine example - uses bloom and skydome for additional visual quality and functional testing
- refactored to reflect the fact the camera stores render target instead of layer now
 
**API change**:
- **Picker.prepare** 
    - does not support passing render target as a way to filter layers
    - allows passing in an array of layers (and also handles a single layer as before)

![Screen Shot 2021-04-23 at 10 48 46 AM](https://user-images.githubusercontent.com/59932779/115855060-c374ff00-a422-11eb-8fa8-bcaef08c487f.png)
