### PR TITLE
Modify src/scene/scene.js to verify if `this.defaultMaterial` is valid before destroying

### DIFF
--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -152,8 +152,10 @@ Scene.prototype.constructor = Scene;
 
 Scene.prototype.destroy = function () {
     this.root = null;
-    this.defaultMaterial.destroy();
-    this.defaultMaterial = null;
+    if (this.defaultMaterial){
+        this.defaultMaterial.destroy();
+        this.defaultMaterial = null;
+    }
     this.off();
 };
 


### PR DESCRIPTION
modify src/scene/scene.js to verify if `this.defaultMaterial` is valid before destroying (to solve the problem that deleting the last app in multiple apps will cause an exception)

Fixes #

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
