### PR TITLE
Implementation of utility function instance.of

### DIFF
--- a/src/core/instance-utils.js
+++ b/src/core/instance-utils.js
@@ -1,0 +1,43 @@
+const regex = new RegExp(/^\s*function\s*(\S*)\s*\(/);
+
+const instance = {
+
+    // helper function to get a class name of the object
+    name: function (object) {
+
+        // modern browsers have name property
+        if (object.constructor.name) {
+            return object.constructor.name;
+        }
+
+        // IE11 fallback
+        return object.constructor.toString().match(regex)[1];
+    },
+
+    // helper function to find out if the specified object is an instance of the specified class name
+    // example use: const isInstance = instance.of(app, "Application");
+    of: function (object, className) {
+
+        // make sure object is an object and not null of a number of similar
+        if (typeof object === 'object' && object !== null) {
+
+            let proto = Object.getPrototypeOf(object);
+            for (;;) {
+                if (proto === null) {
+                    return false;
+                }
+
+                if (this.name(proto) === className) {
+                    return true;
+                }
+
+                // trace up the chain
+                proto = Object.getPrototypeOf(proto);
+            }
+        }
+
+        return false;
+    }
+};
+
+export { instance };

--- a/src/framework/components/anim/component.js
+++ b/src/framework/components/anim/component.js
@@ -1,4 +1,5 @@
 import { Asset } from '../../../asset/asset.js';
+import { instance } from '../../../core/instance-utils.js';
 
 import { AnimEvaluator } from '../../../anim/evaluator/anim-evaluator.js';
 import { AnimController } from '../../../anim/controller/anim-controller.js';
@@ -370,7 +371,7 @@ class AnimComponent extends Component {
                 console.warn(`rootBone entity for supplied guid:${value} cannot be found in the scene`);
             }
             // #endif
-        } else if (value?.constructor.name === 'Entity') {
+        } else if (instance.of(value, 'Entity')) {
             this.data.rootBone = value;
         } else {
             this.data.rootBone = null;

--- a/src/framework/components/camera/post-effect-queue.js
+++ b/src/framework/components/camera/post-effect-queue.js
@@ -1,4 +1,5 @@
 import { now } from '../../../core/time.js';
+import { instance } from '../../../core/instance-utils.js';
 
 import { ADDRESS_CLAMP_TO_EDGE, FILTER_NEAREST, PIXELFORMAT_R8_G8_B8_A8 } from '../../../graphics/constants.js';
 import { RenderTarget } from '../../../graphics/render-target.js';
@@ -13,7 +14,7 @@ class PostEffect {
         this.effect = effect;
         this.inputTarget = inputTarget;
         this.outputTarget = null;
-        this.name = effect.constructor.name;
+        this.name = instance.name(effect);
     }
 }
 

--- a/src/graphics/render-target.js
+++ b/src/graphics/render-target.js
@@ -1,6 +1,6 @@
-import { PIXELFORMAT_DEPTH, PIXELFORMAT_DEPTHSTENCIL } from './constants.js';
+import { instance} from '../core/instance-utils.js';
 
-import { GraphicsDevice } from './graphics-device.js';
+import { PIXELFORMAT_DEPTH, PIXELFORMAT_DEPTHSTENCIL } from './constants.js';
 
 var defaultOptions = {
     depth: true,
@@ -53,7 +53,7 @@ class RenderTarget {
         var _arg2 = arguments[1];
         var _arg3 = arguments[2];
 
-        if (options instanceof GraphicsDevice) {
+        if (instance.of(options, "GraphicsDevice")) {
             // old constructor
             this._colorBuffer = _arg2;
             options = _arg3;

--- a/src/graphics/render-target.js
+++ b/src/graphics/render-target.js
@@ -1,4 +1,4 @@
-import { instance} from '../core/instance-utils.js';
+import { instance } from '../core/instance-utils.js';
 
 import { PIXELFORMAT_DEPTH, PIXELFORMAT_DEPTHSTENCIL } from './constants.js';
 


### PR DESCRIPTION
A replacement of 'instanceof' functionality which does not require the type of the object to be imported, avoiding (circular) dependencies.

Note: this is not mean to be a generic replacement for `instanceof`, even though it can be completely used as a replacement. The main reason is to allow some backwards compatibility code which imports modules otherwise not needed to be fixed, in order to remove circular dependency.

Instead of currently often used code:

```
import { GraphicsDevice } from './graphics-device.js';
if (options instanceof GraphicsDevice) {
}
```
this can be used to remove import of the GraphicsDevice.
```
import { instance } from '../core/instance-utils.js';
if (instance.of(options, "GraphicsDevice")) {
}
```

Other changes:
- applied this functionality to Render Target
- replaced some calls to constructor.name by calls to instance.name which handles IE11 fallback.

Test code (passes on IE11 as well)
```
        var dm = new pc.DepthMaterial();
        console.log("DepthMat: " + pc.instance.of(dm, "DepthMaterial"));
        console.log("Mat: " + pc.instance.of(dm, "Material"));

        console.log("app: " + pc.instance.of(app, "Application"));

        var x = 5;
        console.log("x: " + pc.instance.of(x, "Application"));
        console.log("null: " + pc.instance.of(null, "Application"));
        console.log("undefined: " + pc.instance.of(undefined, "Application"));

```

output:
![Screen Shot 2021-04-23 at 12 50 55 PM](https://user-images.githubusercontent.com/59932779/115868614-9e898780-a434-11eb-9006-a669f922e0aa.png)

When this is approved, multiple dependencies will be removed in following PR.