### PR TITLE
[FIX] Restore properties to support profiler

### DIFF
--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -1355,9 +1355,13 @@ class Application extends EventHandler {
         // #endif
 
         this.fire("prerender");
+
         this.root.syncHierarchy();
         this.batcher.updateAll();
+
+        ForwardRenderer._skipRenderCounter = 0;
         this.renderer.renderComposition(this.scene.layers);
+
         this.fire("postrender");
 
         // #if _PROFILER

--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -1359,7 +1359,9 @@ class Application extends EventHandler {
         this.root.syncHierarchy();
         this.batcher.updateAll();
 
+        // #if _PROFILER
         ForwardRenderer._skipRenderCounter = 0;
+        // #endif
         this.renderer.renderComposition(this.scene.layers);
 
         this.fire("postrender");

--- a/src/scene/forward-renderer.js
+++ b/src/scene/forward-renderer.js
@@ -513,6 +513,7 @@ class ForwardRenderer {
         this._createAreaLightPlaceholderLuts();
     }
 
+    // Static properties used by the Profiler in the Editor's Launch Page
     static skipRenderCamera = null;
 
     static _skipRenderCounter = 0;

--- a/src/scene/forward-renderer.js
+++ b/src/scene/forward-renderer.js
@@ -114,9 +114,6 @@ const maxBlurSize = 25;
 var keyA, keyB;
 
 var _autoInstanceBuffer = null;
-var skipRenderCamera = null;
-var _skipRenderCounter = 0;
-var skipRenderAfter = 0;
 
 var _skinUpdateIndex = 0;
 
@@ -515,6 +512,12 @@ class ForwardRenderer {
         // placeholder texture for area light LUTs
         this._createAreaLightPlaceholderLuts();
     }
+
+    static skipRenderCamera = null;
+
+    static _skipRenderCounter = 0;
+
+    static skipRenderAfter = 0;
 
     sortCompare(drawCallA, drawCallB) {
         if (drawCallA.layer === drawCallB.layer) {
@@ -1916,9 +1919,9 @@ class ForwardRenderer {
             } else {
 
                 // #if _PROFILER
-                if (camera === skipRenderCamera) {
-                    if (_skipRenderCounter >= skipRenderAfter) continue;
-                    _skipRenderCounter++;
+                if (camera === ForwardRenderer.skipRenderCamera) {
+                    if (ForwardRenderer._skipRenderCounter >= ForwardRenderer.skipRenderAfter) continue;
+                    ForwardRenderer._skipRenderCounter++;
                 }
                 if (layer) {
                     if (layer._skipRenderCounter >= layer.skipRenderAfter) continue;

--- a/src/scene/forward-renderer.js
+++ b/src/scene/forward-renderer.js
@@ -513,12 +513,14 @@ class ForwardRenderer {
         this._createAreaLightPlaceholderLuts();
     }
 
+    // #if _PROFILER
     // Static properties used by the Profiler in the Editor's Launch Page
     static skipRenderCamera = null;
 
     static _skipRenderCounter = 0;
 
     static skipRenderAfter = 0;
+    // #endif
 
     sortCompare(drawCallA, drawCallB) {
         if (drawCallA.layer === drawCallB.layer) {


### PR DESCRIPTION
Restores external access to properties that the launch page's Profiler relies upon to limit draw call rendering. This bug was introduced back in June 2020 by [this PR](https://github.com/playcanvas/engine/pull/2166).

Partial fix for https://github.com/playcanvas/editor/issues/103

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
