### PR TITLE
Remove gl canvas dependency resize

### DIFF
--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -2317,12 +2317,12 @@ var makeTick = function (_app) {
             if (application._resolutionMode === RESOLUTION_AUTO) {
                 // Check if the canvas DOM has changed size
                 const canvas = application.graphicsDevice.canvas;
-                const pixelRatio = application.graphicsDevice.maxPixelRatio;
+                const pixelRatio = Math.min(application.graphicsDevice.maxPixelRatio, window.devicePixelRatio);
 
                 const clientWidth = canvas.clientWidth;
                 const clientHeight = canvas.clientHeight;
 
-                if (canvas.width !== (clientWidth * pixelRatio) || canvas.height !== (clientHeight * pixelRatio)) {
+                if (canvas.width !== Math.floor(clientWidth * pixelRatio) || canvas.height !== Math.floor(clientHeight * pixelRatio)) {
                     application.graphicsDevice.resizeCanvas(clientWidth, clientHeight);
                 }
             }

--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -421,8 +421,6 @@ class Application extends EventHandler {
         this.autoRender = true;
         this.renderNextFrame = false;
 
-        this.timeBetweenCanvasSizeCheck = 0.2;
-
         // enable if you want entity type script attributes
         // to not be re-mapped when an entity is cloned
         this.useLegacyScriptAttributeCloning = script.legacy;
@@ -2260,7 +2258,6 @@ var _frameEndData = {};
 var makeTick = function (_app) {
     var application = _app;
     var frameRequest;
-    var timeToNextCanvasSizeCheck = 0;
 
     return function (timestamp, frame) {
         if (!application.graphicsDevice)
@@ -2278,11 +2275,9 @@ var makeTick = function (_app) {
 
         var currentTime = application._processTimestamp(timestamp) || now();
         var ms = currentTime - (application._time || currentTime);
-        var realDt = ms / 1000.0;
-
-        var scaledDt = realDt;
-        scaledDt = math.clamp(scaledDt, 0, application.maxDeltaTime);
-        scaledDt *= application.timeScale;
+        var dt = ms / 1000.0;
+        dt = math.clamp(dt, 0, application.maxDeltaTime);
+        dt *= application.timeScale;
 
         application._time = currentTime;
 
@@ -2298,7 +2293,7 @@ var makeTick = function (_app) {
         if (application.graphicsDevice.contextLost)
             return;
 
-        application._fillFrameStatsBasic(currentTime, scaledDt, ms);
+        application._fillFrameStatsBasic(currentTime, dt, ms);
 
         // #if _PROFILER
         application._fillFrameStats();
@@ -2313,30 +2308,23 @@ var makeTick = function (_app) {
             application.graphicsDevice.defaultFramebuffer = null;
         }
 
-        application.update(scaledDt);
+        application.update(dt);
 
         application.fire("framerender");
 
         if (application.autoRender || application.renderNextFrame) {
             // In AUTO mode the resolution is changed to match the canvas size
             if (application._resolutionMode === RESOLUTION_AUTO) {
-                timeToNextCanvasSizeCheck -= realDt;
-                if (timeToNextCanvasSizeCheck <= 0) {
-                    // Check if the canvas DOM has changed size
-                    const canvas = application.graphicsDevice.canvas;
-                    const pixelRatio = application.graphicsDevice.maxPixelRatio;
+                // Check if the canvas DOM has changed size
+                const canvas = application.graphicsDevice.canvas;
+                const pixelRatio = application.graphicsDevice.maxPixelRatio;
 
-                    const clientWidth = canvas.clientWidth;
-                    const clientHeight = canvas.clientHeight;
+                const clientWidth = canvas.clientWidth;
+                const clientHeight = canvas.clientHeight;
 
-                    if (canvas.width !== (clientWidth * pixelRatio) || canvas.height !== (clientHeight * pixelRatio)) {
-                        application.graphicsDevice.resizeCanvas(clientWidth, clientHeight);
-                    }
-
-                    timeToNextCanvasSizeCheck = application.timeBetweenCanvasSizeCheck;
+                if (canvas.width !== (clientWidth * pixelRatio) || canvas.height !== (clientHeight * pixelRatio)) {
+                    application.graphicsDevice.resizeCanvas(clientWidth, clientHeight);
                 }
-            } else {
-                timeToNextCanvasSizeCheck = 0;
             }
 
             application.render();

--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -2317,8 +2317,13 @@ var makeTick = function (_app) {
             if (application._resolutionMode === RESOLUTION_AUTO) {
                 // Check if the canvas DOM has changed size
                 const canvas = application.graphicsDevice.canvas;
-                if (canvas.width !== canvas.clientWidth || canvas.height !== canvas.clientHeight) {
-                    application.graphicsDevice.resizeCanvas(canvas.clientWidth, canvas.clientHeight);
+                const pixelRatio = application.graphicsDevice.maxPixelRatio;
+
+                const clientWidth = canvas.clientWidth;
+                const clientHeight = canvas.clientHeight;
+
+                if (canvas.width !== (clientWidth * pixelRatio) || canvas.height !== (clientHeight * pixelRatio)) {
+                    application.graphicsDevice.resizeCanvas(clientWidth, clientHeight);
                 }
             }
 

--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -1562,11 +1562,6 @@ class Application extends EventHandler {
         this.graphicsDevice.canvas.style.width = width + 'px';
         this.graphicsDevice.canvas.style.height = height + 'px';
 
-        // In AUTO mode the resolution is changed to match the canvas size
-        if (this._resolutionMode === RESOLUTION_AUTO) {
-            this.setCanvasResolution(RESOLUTION_AUTO);
-        }
-
         // return the final values calculated for width and height
         return {
             width: width,
@@ -2318,6 +2313,15 @@ var makeTick = function (_app) {
         application.fire("framerender");
 
         if (application.autoRender || application.renderNextFrame) {
+            // In AUTO mode the resolution is changed to match the canvas size
+            if (application._resolutionMode === RESOLUTION_AUTO) {
+                // Check if the canvas DOM has changed size
+                const canvas = application.graphicsDevice.canvas;
+                if (canvas.width !== canvas.clientWidth || canvas.height !== canvas.clientHeight) {
+                    application.graphicsDevice.resizeCanvas(canvas.clientWidth, canvas.clientHeight);
+                }
+            }
+
             application.render();
             application.renderNextFrame = false;
         }

--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -2317,14 +2317,7 @@ var makeTick = function (_app) {
             if (application._resolutionMode === RESOLUTION_AUTO) {
                 // Check if the canvas DOM has changed size
                 const canvas = application.graphicsDevice.canvas;
-                const pixelRatio = Math.min(application.graphicsDevice.maxPixelRatio, window.devicePixelRatio);
-
-                const clientWidth = canvas.clientWidth;
-                const clientHeight = canvas.clientHeight;
-
-                if (canvas.width !== Math.floor(clientWidth * pixelRatio) || canvas.height !== Math.floor(clientHeight * pixelRatio)) {
-                    application.graphicsDevice.resizeCanvas(clientWidth, clientHeight);
-                }
+                application.graphicsDevice.resizeCanvas(canvas.clientWidth, canvas.clientHeight);
             }
 
             application.render();

--- a/src/graphics/graphics-device.js
+++ b/src/graphics/graphics-device.js
@@ -3480,6 +3480,7 @@ class GraphicsDevice extends EventHandler {
     }
 
     /**
+     * @private
      * @function
      * @name GraphicsDevice#resizeCanvas
      * @description Sets the width and height of the canvas, then fires the 'resizecanvas' event.

--- a/src/graphics/graphics-device.js
+++ b/src/graphics/graphics-device.js
@@ -3495,8 +3495,8 @@ class GraphicsDevice extends EventHandler {
         this._height = height;
 
         var ratio = Math.min(this._maxPixelRatio, window.devicePixelRatio);
-        width *= ratio;
-        height *= ratio;
+        width = Math.floor(width * ratio);
+        height = Math.floor(height * ratio);
 
         if (this.canvas.width === width && this.canvas.height === height)
             return;


### PR DESCRIPTION
Fixes #3114 

First step in making the engine more flexible to use in different page layouts where the canvas DOM changes size. It also means that the canvas rendering resolution is no longer dependent on calling resizeCanvas manually from window resize events.

There was a comment in the ticket about doing the check every 200ms instead of every frame. I've measured performance on an older Samsung S7 and compared stable to my branch and the difference doesn't show up on the profiler.

Ideally, I would like to keep it every frame as it looks lot better when the Canvas DOM is being resized and doesn't suffer from a stutter delay due to only being updated every Xms

For comparison, Babylon JS does this too every frame: https://github.com/BabylonJS/Babylon.js/blob/5e6321d887637877d8b28b417410abbbeb651c6e/src/Engines/Extensions/engine.views.ts#L145

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
