### PR TITLE
Fix recent change in Oculus Browser regarding Hands

### DIFF
--- a/src/xr/xr-hand.js
+++ b/src/xr/xr-hand.js
@@ -101,7 +101,11 @@ class XrHand extends EventHandler {
             const joint = this._joints[j];
             const jointSpace = xrInputSource.hand.get(joint._id);
             if (jointSpace) {
-                const pose = frame.getJointPose(jointSpace, this._manager._referenceSpace);
+                let pose;
+
+                if (frame.session.visibilityState !== 'hidden')
+                    pose = frame.getJointPose(jointSpace, this._manager._referenceSpace);
+
                 if (pose) {
                     joint.update(pose);
 


### PR DESCRIPTION
Where exiting session still triggers one frame update but with `hidden` session state, which throws an exception in that case.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
