### PR TITLE
[AnimComponent] Transition exit time fix

### DIFF
--- a/src/anim/binder/default-anim-binder.js
+++ b/src/anim/binder/default-anim-binder.js
@@ -56,7 +56,7 @@ class DefaultAnimBinder {
             'localPosition': function (node) {
                 var object = node.localPosition;
                 var func = function (value) {
-                    object.set.apply(object, value);
+                    object.set(...value);
                 };
                 return DefaultAnimBinder.createAnimTarget(func, 'vector', 3, node, 'localPosition');
             },
@@ -64,7 +64,7 @@ class DefaultAnimBinder {
             'localRotation': function (node) {
                 var object = node.localRotation;
                 var func = function (value) {
-                    object.set.apply(object, value);
+                    object.set(...value);
                 };
                 return DefaultAnimBinder.createAnimTarget(func, 'quaternion', 4, node, 'localRotation');
             },
@@ -72,7 +72,7 @@ class DefaultAnimBinder {
             'localScale': function (node) {
                 var object = node.localScale;
                 var func = function (value) {
-                    object.set.apply(object, value);
+                    object.set(...value);
                 };
                 return DefaultAnimBinder.createAnimTarget(func, 'vector', 3, node, 'localScale');
             },

--- a/src/anim/controller/anim-controller.js
+++ b/src/anim/controller/anim-controller.js
@@ -266,7 +266,7 @@ class AnimController {
                 var progressBefore = this._getActiveStateProgressForTime(this._timeInStateBefore);
                 var progress = this._getActiveStateProgressForTime(this._timeInState);
                 // when the exit time is smaller than 1 and the state is looping, we should check for an exit each loop
-                if (transition.exitTime < 1.0 && this.activeState.looping) {
+                if (transition.exitTime < 1.0 && this.activeState.loop) {
                     progressBefore -= Math.floor(progressBefore);
                     progress -= Math.floor(progress);
                 }


### PR DESCRIPTION
Transitions with an exit time were not always activating if the current animation looped more than once. This was due to the anim controller using an incorrect loop property in one of its conditions. This PR uses the user set loop property of a state for this condition.

Fixes https://github.com/playcanvas/editor/issues/395

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
