### PR TITLE
[Fix] Enforce lighting chunks used by clustered lighting are included

### DIFF
--- a/src/graphics/program-lib/programs/standard.js
+++ b/src/graphics/program-lib/programs/standard.js
@@ -463,6 +463,10 @@ var standard = {
             lighting = true;
         }
 
+        if (LayerComposition.clusteredLightingEnabled) {
+            lighting = true;
+        }
+
         if (options.shadingModel === SPECULAR_PHONG) {
             options.fresnelModel = 0;
             options.specularAntialias = false;
@@ -1406,9 +1410,11 @@ var standard = {
         if (LayerComposition.clusteredLightingEnabled) {
 
             usesSpot = true;
+            hasPointLights = true;
+            usesLinearFalloff = true;
 
             const clusterTextureFormat = WorldClusters.lightTextureFormat === WorldClusters.FORMAT_FLOAT ? "FLOAT" : "8BIT";
-            code += `#define CLUSTER_TEXTURE_${clusterTextureFormat}\n`;
+            code += `\n#define CLUSTER_TEXTURE_${clusterTextureFormat}\n`;
             code += chunks.clusteredLightPS;
         }
 


### PR DESCRIPTION
fixes to issues with clustered lighting mentioned here:
https://forum.playcanvas.com/t/clusteredlights-shader-crash/20083/4
https://forum.playcanvas.com/t/avoiding-spikes-on-enabling-groups-of-entities/20092/16
