### PR TITLE
Small miscellaneous fixes

### DIFF
--- a/src/graphics/graphics-device.js
+++ b/src/graphics/graphics-device.js
@@ -2197,12 +2197,10 @@ class GraphicsDevice extends EventHandler {
                 // grab framebuffer to be used as a texture - this returns false when not supported for current render pass
                 // (for example when rendering to shadow map), in which case previous content is used
                 this.updateGrabPass();
-            } else {
-                if (texture._needsUpload || texture._needsMipmapsUpload) {
-                    this.uploadTexture(texture);
-                    texture._needsUpload = false;
-                    texture._needsMipmapsUpload = false;
-                }
+            } else if (texture._needsUpload || texture._needsMipmapsUpload) {
+                this.uploadTexture(texture);
+                texture._needsUpload = false;
+                texture._needsMipmapsUpload = false;
             }
         } else {
             // Ensure the texture is currently bound to the correct target on the specified texture unit.

--- a/src/graphics/graphics-device.js
+++ b/src/graphics/graphics-device.js
@@ -2193,11 +2193,11 @@ class GraphicsDevice extends EventHandler {
                 texture._parameterFlags = 0;
             }
 
-            if (texture === this.grabPassTexture) {
-                // grab framebuffer to be used as a texture - this returns false when not supported for current render pass
-                // (for example when rendering to shadow map), in which case previous content is used
-                this.updateGrabPass();
-            } else if (texture._needsUpload || texture._needsMipmapsUpload) {
+            // grab framebuffer to be used as a texture - this returns false when not supported for current render pass
+            // (for example when rendering to shadow map), in which case previous content is used
+            var processed = (texture === this.grabPassTexture) && this.updateGrabPass();
+
+            if (!processed && (texture._needsUpload || texture._needsMipmapsUpload)) {
                 this.uploadTexture(texture);
                 texture._needsUpload = false;
                 texture._needsMipmapsUpload = false;

--- a/src/graphics/program-lib/chunks/reflectionPrefilteredCubeLod.frag
+++ b/src/graphics/program-lib/chunks/reflectionPrefilteredCubeLod.frag
@@ -1,6 +1,8 @@
 #ifndef PMREM4
 #define PMREM4
+#ifndef GL2
 #extension GL_EXT_shader_texture_lod : enable
+#endif
 uniform samplerCube texture_prefilteredCubeMap128;
 #endif
 uniform float material_reflectivity;

--- a/src/graphics/reproject-texture.js
+++ b/src/graphics/reproject-texture.js
@@ -97,7 +97,7 @@ function reprojectTexture(device, source, target, specularPower = 1, numSamples 
     params[3] = 1.0 - (target.fixCubemapSeams ? 1.0 / target.width : 0.0);       // target seam scale
 
     for (let face = 0; face < (target.cubemap ? 6 : 1); face++) {
-        const targ = new RenderTarget({
+        const renderTarget = new RenderTarget({
             colorBuffer: target,
             face: face,
             depth: false
@@ -105,7 +105,9 @@ function reprojectTexture(device, source, target, specularPower = 1, numSamples 
         params[0] = face;
         constantParams.setValue(params);
 
-        drawQuadWithShader(device, targ, shader);
+        drawQuadWithShader(device, renderTarget, shader);
+
+        renderTarget.destroy();
     }
 
     // #if _DEBUG


### PR DESCRIPTION
This PR combines the following changes:
- destroy render target when prefiltering
- support single cubemap PMREM case on webgl 2.0 devices
- small texture code cleanup
- add note on incorrect mipmap generation behaviour for cubemaps