### PR TITLE
Added Base64 and blob check in Asset#getAbsoluteUrl

### DIFF
--- a/src/asset/asset.js
+++ b/src/asset/asset.js
@@ -236,7 +236,6 @@ class Asset extends EventHandler {
      * @returns {string} Resulting URL of the asset.
      */
     getAbsoluteUrl(relativePath) {
-        // Support for Base64 paths
         if (relativePath.startsWith('blob:') || relativePath.startsWith('data:')) {
             return relativePath;
         }

--- a/src/asset/asset.js
+++ b/src/asset/asset.js
@@ -230,11 +230,17 @@ class Asset extends EventHandler {
      * @private
      * @function
      * @name Asset#getAbsoluteUrl
-     * @description Construct an asset URL from this asset's location and a relative path.
+     * @description Construct an asset URL from this asset's location and a relative path. If the relativePath is a
+     * blob or Base64 URI, then return that instead.
      * @param {string} relativePath - The relative path to be concatenated to this asset's base url.
      * @returns {string} Resulting URL of the asset.
      */
     getAbsoluteUrl(relativePath) {
+        // Support for Base64 paths
+        if (relativePath.startsWith('blob:') || relativePath.startsWith('data:')) {
+            return relativePath;
+        }
+
         var base = path.getDirectory(this.file.url);
         return path.join(base, relativePath);
     }


### PR DESCRIPTION
Fixes https://forum.playcanvas.com/t/can-i-use-dataurl-for-instead-of-map-image/20105/2

This stops path prefixes being added to data: or blob: URIs

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
