### PR TITLE
Upgrade RigidBodyComponent to current component structure

### DIFF
--- a/scripts/physics/render-physics.js
+++ b/scripts/physics/render-physics.js
@@ -185,7 +185,7 @@ RenderPhysics.prototype.postUpdate = function (dt) {
 
                 // Use the rigid body position if we have it
                 if (collision.entity.rigidbody) {
-                    var body = collision.entity.rigidbody.data.body;
+                    var body = collision.entity.rigidbody.body;
                     if (body) {
                         var t = body.getWorldTransform();
 

--- a/scripts/physics/render-physics.js
+++ b/scripts/physics/render-physics.js
@@ -89,7 +89,7 @@ RenderPhysics.prototype.postUpdate = function (dt) {
                     } else {
                         switch (collision.type) {
                             case 'box':
-                                if (!collision._debugShape._halfExents.equals(collision.halfExtents)) {
+                                if (!collision._debugShape._halfExtents.equals(collision.halfExtents)) {
                                     deleteShape = true;
                                 }
                                 break;
@@ -130,7 +130,7 @@ RenderPhysics.prototype.postUpdate = function (dt) {
                             mesh = pc.createBox(this.app.graphicsDevice, {
                                 halfExtents: collision.halfExtents
                             });
-                            debugShape._halfExents = collision.halfExtents.clone();
+                            debugShape._halfExtents = collision.halfExtents.clone();
                             break;
                         case 'cone':
                             mesh = pc.createCone(this.app.graphicsDevice, {

--- a/src/framework/components/rigid-body/component.js
+++ b/src/framework/components/rigid-body/component.js
@@ -20,9 +20,36 @@ var ammoVec1, ammoVec2, ammoQuat, ammoOrigin;
  * @name RigidBodyComponent
  * @augments Component
  * @classdesc The rigidbody component, when combined with a {@link CollisionComponent}, allows your
- * entities to be simulated using realistic physics.
- * A rigidbody component will fall under gravity and collide with other rigid bodies. Using scripts, you
- * can apply forces and impulses to rigid bodies.
+ * entities to be simulated using realistic physics. A rigidbody component will fall under gravity and
+ * collide with other rigid bodies. Using scripts, you can apply forces and impulses to rigid bodies.
+ *
+ * You should never need to use the RigidBodyComponent constructor. To add an RigidBodyComponent to a
+ * {@link Entity}, use {@link Entity#addComponent}:
+ *
+ * ~~~javascript
+ * // Create a static 1x1x1 box-shaped rigid body
+ * const entity = pc.Entity();
+ * entity.addComponent("rigidbody"); // With no options specified, this defaults to a 'static' body
+ * entity.addComponent("collision"); // With no options specified, this defaults to a 1x1x1 box shape
+ * ~~~
+ *
+ * To create a dynamic sphere with mass of 10, do:
+ *
+ * ~~~javascript
+ * const entity = pc.Entity();
+ * entity.addComponent("rigidbody", {
+ *     type: pc.BODYTYPE_DYNAMIC,
+ *     mass: 10
+ * });
+ * entity.addComponent("collision", {
+ *     type: "sphere"
+ * });
+ * ~~~
+ *
+ * Relevant 'Engine-only' examples:
+ * * [Falling shapes](http://playcanvas.github.io/#physics/falling-shapes.html)
+ * * [Vehicle physics](http://playcanvas.github.io/#physics/vehicle.html)
+ *
  * @description Create a new RigidBodyComponent.
  * @param {RigidBodyComponentSystem} system - The ComponentSystem that created this component.
  * @param {Entity} entity - The entity this component is attached to.
@@ -35,9 +62,11 @@ var ammoVec1, ammoVec2, ammoQuat, ammoOrigin;
  * @property {number} angularDamping Controls the rate at which a body loses angular velocity over time.
  * Defaults to 0.
  * @property {Vec3} linearFactor Scaling factor for linear movement of the body in each axis. Only
- * valid for rigid bodies of type {@link BODYTYPE_DYNAMIC}. Defaults to 1 in all axes.
+ * valid for rigid bodies of type {@link BODYTYPE_DYNAMIC}. Defaults to 1 in all axes (body can freely
+ * move).
  * @property {Vec3} angularFactor Scaling factor for angular movement of the body in each axis. Only
- * valid for rigid bodies of type {@link BODYTYPE_DYNAMIC}. Defaults to 1 in all axes.
+ * valid for rigid bodies of type {@link BODYTYPE_DYNAMIC}. Defaults to 1 in all axes (body can freely
+ * rotate).
  * @property {number} friction The friction value used when contacts occur between two bodies. A higher
  * value indicates more friction. Should be set in the range 0 to 1. Defaults to 0.5.
  * @property {number} rollingFriction Sets a torsional friction orthogonal to the contact point. Defaults

--- a/src/framework/components/rigid-body/component.js
+++ b/src/framework/components/rigid-body/component.js
@@ -72,99 +72,263 @@ class RigidBodyComponent extends Component {
             ammoOrigin = new Ammo.btVector3(0, 0, 0);
         }
 
-        this.on('set_mass', this.onSetMass, this);
-        this.on('set_linearDamping', this.onSetLinearDamping, this);
-        this.on('set_angularDamping', this.onSetAngularDamping, this);
-        this.on('set_linearFactor', this.onSetLinearFactor, this);
-        this.on('set_angularFactor', this.onSetAngularFactor, this);
-        this.on('set_friction', this.onSetFriction, this);
-        this.on('set_rollingFriction', this.onSetRollingFriction, this);
-        this.on('set_restitution', this.onSetRestitution, this);
-        this.on('set_type', this.onSetType, this);
-        this.on('set_group', this.onSetGroupOrMask, this);
-        this.on('set_mask', this.onSetGroupOrMask, this);
-
-        this.on('set_body', this.onSetBody, this);
-
-        this._linearVelocity = new Vec3(0, 0, 0);
-        this._angularVelocity = new Vec3(0, 0, 0);
+        this._angularDamping = 0;
+        this._angularFactor = new Vec3(1, 1, 1);
+        this._angularVelocity = new Vec3();
+        this._body = null;
+        this._friction = 0.5;
+        this._group = BODYGROUP_STATIC;
+        this._linearDamping = 0;
+        this._linearFactor = new Vec3(1, 1, 1);
+        this._linearVelocity = new Vec3();
+        this._mask = BODYMASK_NOT_STATIC;
+        this._mass = 1;
+        this._restitution = 0;
+        this._rollingFriction = 0;
+        this._simulationEnabled = false;
+        this._type = BODYTYPE_STATIC;
     }
 
-    // Events Documentation
-    /**
-     * @event
-     * @name RigidBodyComponent#contact
-     * @description The 'contact' event is fired when a contact occurs between two rigid bodies.
-     * @param {ContactResult} result - Details of the contact between the two rigid bodies.
-     */
+    get angularDamping() {
+        return this._angularDamping;
+    }
 
-    /**
-     * @event
-     * @name RigidBodyComponent#collisionstart
-     * @description The 'collisionstart' event is fired when two rigid bodies start touching.
-     * @param {ContactResult} result - Details of the contact between the two rigid bodies.
-     */
+    set angularDamping(damping) {
+        if (this._angularDamping !== damping) {
+            this._angularDamping = damping;
 
-    /**
-     * @event
-     * @name RigidBodyComponent#collisionend
-     * @description The 'collisionend' event is fired two rigid-bodies stop touching.
-     * @param {Entity} other - The {@link Entity} that stopped touching this rigid body.
-     */
-
-    /**
-     * @event
-     * @name RigidBodyComponent#triggerenter
-     * @description The 'triggerenter' event is fired when a rigid body enters a trigger volume.
-     * @param {Entity} other - The {@link Entity} with trigger volume that this rigidbody entered.
-     */
-
-    /**
-     * @event
-     * @name RigidBodyComponent#triggerleave
-     * @description The 'triggerleave' event is fired when a rigid body exits a trigger volume.
-     * @param {Entity} other - The {@link Entity} with trigger volume that this rigidbody exited.
-     */
-
-    get linearVelocity() {
-        var body = this.body;
-        if (body && this.type === BODYTYPE_DYNAMIC) {
-            var vel = body.getLinearVelocity();
-            this._linearVelocity.set(vel.x(), vel.y(), vel.z());
+            if (this._body) {
+                this._body.setDamping(this._linearDamping, damping);
+            }
         }
-        return this._linearVelocity;
     }
 
-    set linearVelocity(lv) {
-        var body = this.body;
-        if (body && this.type === BODYTYPE_DYNAMIC) {
-            body.activate();
+    get angularFactor() {
+        return this._angularFactor;
+    }
 
-            ammoVec1.setValue(lv.x, lv.y, lv.z);
-            body.setLinearVelocity(ammoVec1);
+    set angularFactor(factor) {
+        if (!this._angularFactor.equals(factor)) {
+            this._angularFactor.copy(factor);
 
-            this._linearVelocity.copy(lv);
+            if (this._body && this._type === BODYTYPE_DYNAMIC) {
+                ammoVec1.setValue(factor.x, factor.y, factor.z);
+                this._body.setAngularFactor(ammoVec1);
+            }
         }
     }
 
     get angularVelocity() {
-        var body = this.body;
-        if (body && this.type === BODYTYPE_DYNAMIC) {
-            var vel = body.getAngularVelocity();
-            this._angularVelocity.set(vel.x(), vel.y(), vel.z());
+        if (this._body && this._type === BODYTYPE_DYNAMIC) {
+            const velocity = this._body.getAngularVelocity();
+            this._angularVelocity.set(velocity.x(), velocity.y(), velocity.z());
         }
         return this._angularVelocity;
     }
 
-    set angularVelocity(av) {
-        var body = this.body;
-        if (body && this.type === BODYTYPE_DYNAMIC) {
-            body.activate();
+    set angularVelocity(velocity) {
+        if (this._body && this._type === BODYTYPE_DYNAMIC) {
+            this._body.activate();
 
-            ammoVec1.setValue(av.x, av.y, av.z);
-            body.setAngularVelocity(ammoVec1);
+            ammoVec1.setValue(velocity.x, velocity.y, velocity.z);
+            this._body.setAngularVelocity(ammoVec1);
 
-            this._angularVelocity.copy(av);
+            this._angularVelocity.copy(velocity);
+        }
+    }
+
+    get body() {
+        return this._body;
+    }
+
+    set body(body) {
+        if (this._body !== body) {
+            this._body = body;
+
+            if (body && this._simulationEnabled) {
+                body.activate();
+            }
+        }
+    }
+
+    get friction() {
+        return this._friction;
+    }
+
+    set friction(friction) {
+        if (this._friction !== friction) {
+            this._friction = friction;
+
+            if (this._body) {
+                this._body.setFriction(friction);
+            }
+        }
+    }
+
+    get group() {
+        return this._group;
+    }
+
+    set group(group) {
+        if (this._group !== group) {
+            this._group = group;
+
+            // re-enabling simulation adds rigidbody back into world with new masks
+            if (this.enabled && this.entity.enabled) {
+                this.disableSimulation();
+                this.enableSimulation();
+            }
+        }
+    }
+
+    get linearDamping() {
+        return this._linearDamping;
+    }
+
+    set linearDamping(damping) {
+        if (this._linearDamping !== damping) {
+            this._linearDamping = damping;
+
+            if (this._body) {
+                this._body.setDamping(damping, this._angularDamping);
+            }
+        }
+    }
+
+    get linearFactor() {
+        return this._linearFactor;
+    }
+
+    set linearFactor(factor) {
+        if (!this._linearFactor.equals(factor)) {
+            this._linearFactor.copy(factor);
+
+            if (this._body && this._type === BODYTYPE_DYNAMIC) {
+                ammoVec1.setValue(factor.x, factor.y, factor.z);
+                this._body.setLinearFactor(ammoVec1);
+            }
+        }
+    }
+
+    get linearVelocity() {
+        if (this._body && this._type === BODYTYPE_DYNAMIC) {
+            const velocity = this._body.getLinearVelocity();
+            this._linearVelocity.set(velocity.x(), velocity.y(), velocity.z());
+        }
+        return this._linearVelocity;
+    }
+
+    set linearVelocity(velocity) {
+        if (this._body && this._type === BODYTYPE_DYNAMIC) {
+            this._body.activate();
+
+            ammoVec1.setValue(velocity.x, velocity.y, velocity.z);
+            this._body.setLinearVelocity(ammoVec1);
+
+            this._linearVelocity.copy(velocity);
+        }
+    }
+
+    get mask() {
+        return this._mask;
+    }
+
+    set mask(mask) {
+        if (this._mask !== mask) {
+            this._mask = mask;
+
+            // re-enabling simulation adds rigidbody back into world with new masks
+            if (this.enabled && this.entity.enabled) {
+                this.disableSimulation();
+                this.enableSimulation();
+            }
+        }
+    }
+
+    get mass() {
+        return this._mass;
+    }
+
+    set mass(mass) {
+  //      if (this._mass !== mass) {
+            this._mass = mass;
+
+            if (this._body && this._type === BODYTYPE_DYNAMIC) {
+                const enabled = this.enabled && this.entity.enabled;
+                if (enabled) {
+                    this.disableSimulation();
+                }
+
+                // calculateLocalInertia writes local inertia to ammoVec1 here...
+                this._body.getCollisionShape().calculateLocalInertia(mass, ammoVec1);
+                // ...and then writes the calculated local inertia to the body
+                this._body.setMassProps(mass, ammoVec1);
+                this._body.updateInertiaTensor();
+
+                if (enabled) {
+                    this.enableSimulation();
+                }
+            }
+//        }
+    }
+
+    get restitution() {
+        return this._restitution;
+    }
+
+    set restitution(restitution) {
+        if (this._restitution !== restitution) {
+            this._restitution = restitution;
+
+            if (this._body) {
+                this._body.setRestitution(restitution);
+            }
+        }
+    }
+
+    get rollingFriction() {
+        return this._rollingFriction;
+    }
+
+    set rollingFriction(friction) {
+        if (this._rollingFriction !== friction) {
+            this._rollingFriction = friction;
+
+            if (this._body) {
+                this._body.setRollingFriction(friction);
+            }
+        }
+    }
+
+    get type() {
+        return this._type;
+    }
+
+    set type(type) {
+        if (this._type !== type) {
+            this._type = type;
+
+            this.disableSimulation();
+
+            // set group and mask to defaults for type
+            switch (type) {
+                case BODYTYPE_DYNAMIC:
+                    this._group = BODYGROUP_DYNAMIC;
+                    this._mask = BODYMASK_ALL;
+                    break;
+                case BODYTYPE_KINEMATIC:
+                    this._group = BODYGROUP_KINEMATIC;
+                    this._mask = BODYMASK_ALL;
+                    break;
+                case BODYTYPE_STATIC:
+                default:
+                    this._group = BODYGROUP_STATIC;
+                    this._mask = BODYMASK_NOT_STATIC;
+                    break;
+            }
+
+            // Create a new body
+            this.createBody();
         }
     }
 
@@ -175,8 +339,8 @@ class RigidBodyComponent extends Component {
      * @description If the Entity has a Collision shape attached then create a rigid body using this shape. This method destroys the existing body.
      */
     createBody() {
-        var entity = this.entity;
-        var shape;
+        const entity = this.entity;
+        let shape;
 
         if (entity.collision) {
             shape = entity.collision.shape;
@@ -190,38 +354,38 @@ class RigidBodyComponent extends Component {
         }
 
         if (shape) {
-            if (this.body)
-                this.system.onRemove(this.entity, this);
+            if (this._body)
+                this.system.onRemove(entity, this);
 
-            var mass = this.type === BODYTYPE_DYNAMIC ? this.mass : 0;
+            const mass = this._type === BODYTYPE_DYNAMIC ? this._mass : 0;
 
             this._getEntityTransform(ammoTransform);
 
-            var body = this.system.createBody(mass, shape, ammoTransform);
+            const body = this.system.createBody(mass, shape, ammoTransform);
 
-            body.setRestitution(this.restitution);
-            body.setFriction(this.friction);
-            body.setRollingFriction(this.rollingFriction);
-            body.setDamping(this.linearDamping, this.angularDamping);
+            body.setRestitution(this._restitution);
+            body.setFriction(this._friction);
+            body.setRollingFriction(this._rollingFriction);
+            body.setDamping(this._linearDamping, this._angularDamping);
 
-            if (this.type === BODYTYPE_DYNAMIC) {
-                var linearFactor = this.linearFactor;
+            if (this._type === BODYTYPE_DYNAMIC) {
+                const linearFactor = this._linearFactor;
                 ammoVec1.setValue(linearFactor.x, linearFactor.y, linearFactor.z);
                 body.setLinearFactor(ammoVec1);
 
-                var angularFactor = this.angularFactor;
+                const angularFactor = this._angularFactor;
                 ammoVec1.setValue(angularFactor.x, angularFactor.y, angularFactor.z);
                 body.setAngularFactor(ammoVec1);
-            } else if (this.type === BODYTYPE_KINEMATIC) {
+            } else if (this._type === BODYTYPE_KINEMATIC) {
                 body.setCollisionFlags(body.getCollisionFlags() | BODYFLAG_KINEMATIC_OBJECT);
                 body.setActivationState(BODYSTATE_DISABLE_DEACTIVATION);
             }
 
             body.entity = entity;
 
-            entity.rigidbody.body = body;
+            this.body = body;
 
-            if (this.enabled && this.entity.enabled) {
+            if (this.enabled && entity.enabled) {
                 this.enableSimulation();
             }
         }
@@ -234,8 +398,7 @@ class RigidBodyComponent extends Component {
      * @returns {boolean} True if the body is active.
      */
     isActive() {
-        var body = this.body;
-        return body ? body.isActive() : false;
+        return this._body ? this._body.isActive() : false;
     }
 
     /**
@@ -245,19 +408,19 @@ class RigidBodyComponent extends Component {
      * type {@link BODYTYPE_DYNAMIC}.
      */
     activate() {
-        var body = this.body;
-        if (body) {
-            body.activate();
+        if (this._body) {
+            this._body.activate();
         }
     }
 
     enableSimulation() {
-        if (this.entity.collision && this.entity.collision.enabled && !this.data.simulationEnabled) {
-            var body = this.body;
+        const entity = this.entity;
+        if (entity.collision && entity.collision.enabled && !this._simulationEnabled) {
+            const body = this._body;
             if (body) {
-                this.system.addBody(body, this.group, this.mask);
+                this.system.addBody(body, this._group, this._mask);
 
-                switch (this.type) {
+                switch (this._type) {
                     case BODYTYPE_DYNAMIC:
                         this.system._dynamic.push(this);
                         body.forceActivationState(BODYSTATE_ACTIVE_TAG);
@@ -273,44 +436,44 @@ class RigidBodyComponent extends Component {
                         break;
                 }
 
-                if (this.entity.collision.type === 'compound') {
+                if (entity.collision.type === 'compound') {
                     this.system._compounds.push(this.entity.collision);
                 }
 
                 body.activate();
 
-                this.data.simulationEnabled = true;
+                this._simulationEnabled = true;
             }
         }
     }
 
     disableSimulation() {
-        var body = this.body;
-        if (body && this.data.simulationEnabled) {
-            var idx;
+        const body = this._body;
+        if (body && this._simulationEnabled) {
+            const system = this.system;
 
-            idx = this.system._compounds.indexOf(this.entity.collision);
+            let idx = system._compounds.indexOf(this.entity.collision);
             if (idx > -1) {
-                this.system._compounds.splice(idx, 1);
+                system._compounds.splice(idx, 1);
             }
 
-            idx = this.system._dynamic.indexOf(this);
+            idx = system._dynamic.indexOf(this);
             if (idx > -1) {
-                this.system._dynamic.splice(idx, 1);
+                system._dynamic.splice(idx, 1);
             }
 
-            idx = this.system._kinematic.indexOf(this);
+            idx = system._kinematic.indexOf(this);
             if (idx > -1) {
-                this.system._kinematic.splice(idx, 1);
+                system._kinematic.splice(idx, 1);
             }
 
-            this.system.removeBody(body);
+            system.removeBody(body);
 
             // set activation state to disable simulation to avoid body.isActive() to return
             // true even if it's not in the dynamics world
             body.forceActivationState(BODYSTATE_DISABLE_SIMULATION);
 
-            this.data.simulationEnabled = false;
+            this._simulationEnabled = false;
         }
     }
 
@@ -356,8 +519,8 @@ class RigidBodyComponent extends Component {
      * this.entity.rigidbody.applyForce(force, relativePos);
      */
     applyForce() {
-        var x, y, z;
-        var px, py, pz;
+        let x, y, z;
+        let px, py, pz;
         switch (arguments.length) {
             case 1:
                 x = arguments[0].x;
@@ -386,7 +549,7 @@ class RigidBodyComponent extends Component {
                 pz = arguments[5];
                 break;
         }
-        var body = this.body;
+        const body = this._body;
         if (body) {
             body.activate();
             ammoVec1.setValue(x, y, z);
@@ -396,7 +559,6 @@ class RigidBodyComponent extends Component {
             } else {
                 body.applyForce(ammoVec1, ammoOrigin);
             }
-
         }
     }
 
@@ -418,7 +580,7 @@ class RigidBodyComponent extends Component {
      * entity.rigidbody.applyTorque(0, 10, 0);
      */
     applyTorque() {
-        var x, y, z;
+        let x, y, z;
         switch (arguments.length) {
             case 1:
                 x = arguments[0].x;
@@ -436,7 +598,7 @@ class RigidBodyComponent extends Component {
                 // #endif
                 return;
         }
-        var body = this.body;
+        const body = this._body;
         if (body) {
             body.activate();
             ammoVec1.setValue(x, y, z);
@@ -478,8 +640,8 @@ class RigidBodyComponent extends Component {
      * entity.rigidbody.applyImpulse(0, 10, 0, 0, 0, 1);
      */
     applyImpulse() {
-        var x, y, z;
-        var px, py, pz;
+        let x, y, z;
+        let px, py, pz;
         switch (arguments.length) {
             case 1:
                 x = arguments[0].x;
@@ -513,7 +675,7 @@ class RigidBodyComponent extends Component {
                 // #endif
                 return;
         }
-        var body = this.body;
+        const body = this._body;
         if (body) {
             body.activate();
             ammoVec1.setValue(x, y, z);
@@ -545,7 +707,7 @@ class RigidBodyComponent extends Component {
      * entity.rigidbody.applyTorqueImpulse(0, 10, 0);
      */
     applyTorqueImpulse() {
-        var x, y, z;
+        let x, y, z;
         switch (arguments.length) {
             case 1:
                 x = arguments[0].x;
@@ -563,7 +725,7 @@ class RigidBodyComponent extends Component {
                 // #endif
                 return;
         }
-        var body = this.body;
+        const body = this._body;
         if (body) {
             body.activate();
             ammoVec1.setValue(x, y, z);
@@ -578,7 +740,7 @@ class RigidBodyComponent extends Component {
      * @returns {boolean} True if static.
      */
     isStatic() {
-        return (this.type === BODYTYPE_STATIC);
+        return (this._type === BODYTYPE_STATIC);
     }
 
     /**
@@ -588,7 +750,7 @@ class RigidBodyComponent extends Component {
      * @returns {boolean} True if static or kinematic.
      */
     isStaticOrKinematic() {
-        return (this.type === BODYTYPE_STATIC || this.type === BODYTYPE_KINEMATIC);
+        return (this._type === BODYTYPE_STATIC || this._type === BODYTYPE_KINEMATIC);
     }
 
     /**
@@ -598,7 +760,7 @@ class RigidBodyComponent extends Component {
      * @returns {boolean} True if kinematic.
      */
     isKinematic() {
-        return (this.type === BODYTYPE_KINEMATIC);
+        return (this._type === BODYTYPE_KINEMATIC);
     }
 
     /**
@@ -609,8 +771,9 @@ class RigidBodyComponent extends Component {
      * @param {object} transform - The ammo transform to write the entity transform to.
      */
     _getEntityTransform(transform) {
-        var pos = this.entity.getPosition();
-        var rot = this.entity.getRotation();
+        const entity = this.entity;
+        const pos = entity.getPosition();
+        const rot = entity.getRotation();
 
         ammoVec1.setValue(pos.x, pos.y, pos.z);
         ammoQuat.setValue(rot.x, rot.y, rot.z, rot.w);
@@ -628,14 +791,14 @@ class RigidBodyComponent extends Component {
      * in order to update the rigid body to match the Entity.
      */
     syncEntityToBody() {
-        var body = this.data.body;
+        const body = this._body;
         if (body) {
             this._getEntityTransform(ammoTransform);
 
             body.setWorldTransform(ammoTransform);
 
-            if (this.type === BODYTYPE_KINEMATIC) {
-                var motionState = body.getMotionState();
+            if (this._type === BODYTYPE_KINEMATIC) {
+                const motionState = body.getMotionState();
                 if (motionState) {
                     motionState.setWorldTransform(ammoTransform);
                 }
@@ -652,19 +815,19 @@ class RigidBodyComponent extends Component {
      * matrix of a dynamic rigid body's motion state.
      */
     _updateDynamic() {
-        var body = this.data.body;
+        const body = this._body;
 
         // If a dynamic body is frozen, we can assume its motion state transform is
         // the same is the entity world transform
         if (body.isActive()) {
             // Update the motion state. Note that the test for the presence of the motion
             // state is technically redundant since the engine creates one for all bodies.
-            var motionState = body.getMotionState();
+            const motionState = body.getMotionState();
             if (motionState) {
                 motionState.getWorldTransform(ammoTransform);
 
-                var p = ammoTransform.getOrigin();
-                var q = ammoTransform.getRotation();
+                const p = ammoTransform.getOrigin();
+                const q = ammoTransform.getRotation();
                 this.entity.setPosition(p.x(), p.y(), p.z());
                 this.entity.setRotation(q.x(), q.y(), q.z(), q.w());
             }
@@ -679,8 +842,7 @@ class RigidBodyComponent extends Component {
      * of a kinematic body.
      */
     _updateKinematic() {
-        var body = this.data.body;
-        var motionState = body.getMotionState();
+        const motionState = this._body.getMotionState();
         if (motionState) {
             this._getEntityTransform(ammoTransform);
             motionState.setWorldTransform(ammoTransform);
@@ -739,7 +901,7 @@ class RigidBodyComponent extends Component {
     }
 
     onEnable() {
-        if (!this.body) {
+        if (!this._body) {
             this.createBody();
         }
 
@@ -749,115 +911,42 @@ class RigidBodyComponent extends Component {
     onDisable() {
         this.disableSimulation();
     }
-
-    onSetMass(name, oldValue, newValue) {
-        var body = this.data.body;
-        if (body && this.type === BODYTYPE_DYNAMIC) {
-            var enabled = this.enabled && this.entity.enabled;
-            if (enabled) {
-                this.disableSimulation();
-            }
-
-            // calculateLocalInertia writes local inertia to ammoVec1 here...
-            body.getCollisionShape().calculateLocalInertia(newValue, ammoVec1);
-            // ...and then writes the calculated local inertia to the body
-            body.setMassProps(newValue, ammoVec1);
-            body.updateInertiaTensor();
-
-            if (enabled) {
-                this.enableSimulation();
-            }
-        }
-    }
-
-    onSetLinearDamping(name, oldValue, newValue) {
-        var body = this.data.body;
-        if (body) {
-            body.setDamping(newValue, this.data.angularDamping);
-        }
-    }
-
-    onSetAngularDamping(name, oldValue, newValue) {
-        var body = this.data.body;
-        if (body) {
-            body.setDamping(this.data.linearDamping, newValue);
-        }
-    }
-
-    onSetLinearFactor(name, oldValue, newValue) {
-        var body = this.data.body;
-        if (body && this.type === BODYTYPE_DYNAMIC) {
-            ammoVec1.setValue(newValue.x, newValue.y, newValue.z);
-            body.setLinearFactor(ammoVec1);
-        }
-    }
-
-    onSetAngularFactor(name, oldValue, newValue) {
-        var body = this.data.body;
-        if (body && this.type === BODYTYPE_DYNAMIC) {
-            ammoVec1.setValue(newValue.x, newValue.y, newValue.z);
-            body.setAngularFactor(ammoVec1);
-        }
-    }
-
-    onSetFriction(name, oldValue, newValue) {
-        var body = this.data.body;
-        if (body) {
-            body.setFriction(newValue);
-        }
-    }
-
-    onSetRollingFriction(name, oldValue, newValue) {
-        var body = this.data.body;
-        if (body) {
-            body.setRollingFriction(newValue);
-        }
-    }
-
-    onSetRestitution(name, oldValue, newValue) {
-        var body = this.data.body;
-        if (body) {
-            body.setRestitution(newValue);
-        }
-    }
-
-    onSetType(name, oldValue, newValue) {
-        if (newValue !== oldValue) {
-            this.disableSimulation();
-
-            // set group and mask to defaults for type
-            if (newValue === BODYTYPE_DYNAMIC) {
-                this.data.group = BODYGROUP_DYNAMIC;
-                this.data.mask = BODYMASK_ALL;
-            } else if (newValue === BODYTYPE_KINEMATIC) {
-                this.data.group = BODYGROUP_KINEMATIC;
-                this.data.mask = BODYMASK_ALL;
-            } else {
-                this.data.group = BODYGROUP_STATIC;
-                this.data.mask = BODYMASK_NOT_STATIC;
-            }
-
-            // Create a new body
-            this.createBody();
-        }
-    }
-
-    onSetGroupOrMask(name, oldValue, newValue) {
-        if (newValue !== oldValue) {
-            // re-enabling simulation adds rigidbody back into world with new masks
-            var isEnabled = this.enabled && this.entity.enabled;
-            if (isEnabled) {
-                this.disableSimulation();
-                this.enableSimulation();
-            }
-        }
-    }
-
-    onSetBody(name, oldValue, newValue) {
-        if (this.body && this.data.simulationEnabled) {
-            this.body.activate();
-        }
-    }
 }
+
+// Events Documentation
+/**
+ * @event
+ * @name RigidBodyComponent#contact
+ * @description The 'contact' event is fired when a contact occurs between two rigid bodies.
+ * @param {ContactResult} result - Details of the contact between the two rigid bodies.
+ */
+
+/**
+ * @event
+ * @name RigidBodyComponent#collisionstart
+ * @description The 'collisionstart' event is fired when two rigid bodies start touching.
+ * @param {ContactResult} result - Details of the contact between the two rigid bodies.
+ */
+
+/**
+ * @event
+ * @name RigidBodyComponent#collisionend
+ * @description The 'collisionend' event is fired two rigid-bodies stop touching.
+ * @param {Entity} other - The {@link Entity} that stopped touching this rigid body.
+ */
+
+/**
+ * @event
+ * @name RigidBodyComponent#triggerenter
+ * @description The 'triggerenter' event is fired when a rigid body enters a trigger volume.
+ * @param {Entity} other - The {@link Entity} with trigger volume that this rigidbody entered.
+ */
+
+/**
+ * @event
+ * @name RigidBodyComponent#triggerleave
+ * @description The 'triggerleave' event is fired when a rigid body exits a trigger volume.
+ * @param {Entity} other - The {@link Entity} with trigger volume that this rigidbody exited.
+ */
 
 export { RigidBodyComponent };

--- a/src/framework/components/rigid-body/component.js
+++ b/src/framework/components/rigid-body/component.js
@@ -250,7 +250,7 @@ class RigidBodyComponent extends Component {
     }
 
     set mass(mass) {
-  //      if (this._mass !== mass) {
+        if (this._mass !== mass) {
             this._mass = mass;
 
             if (this._body && this._type === BODYTYPE_DYNAMIC) {
@@ -269,7 +269,7 @@ class RigidBodyComponent extends Component {
                     this.enableSimulation();
                 }
             }
-//        }
+        }
     }
 
     get restitution() {

--- a/src/framework/components/rigid-body/data.js
+++ b/src/framework/components/rigid-body/data.js
@@ -1,7 +1,3 @@
-import { Vec3 } from '../../../math/vec3.js';
-
-import { BODYGROUP_STATIC, BODYMASK_NOT_STATIC, BODYTYPE_STATIC } from './constants.js';
-
 /**
  * @private
  * @class
@@ -12,24 +8,6 @@ import { BODYGROUP_STATIC, BODYMASK_NOT_STATIC, BODYTYPE_STATIC } from './consta
 class RigidBodyComponentData {
     constructor() {
         this.enabled = true;
-        this.mass = 1;
-        this.linearDamping = 0;
-        this.angularDamping = 0;
-        this.linearFactor = new Vec3(1, 1, 1);
-        this.angularFactor = new Vec3(1, 1, 1);
-
-        this.friction = 0.5;
-        this.rollingFriction = 0;
-        this.restitution = 0;
-
-        this.type = BODYTYPE_STATIC;
-
-        this.group = BODYGROUP_STATIC;
-        this.mask = BODYMASK_NOT_STATIC;
-
-        // Non-serialized properties
-        this.body = null;
-        this.simulationEnabled = false;
     }
 }
 

--- a/src/framework/components/rigid-body/system.js
+++ b/src/framework/components/rigid-body/system.js
@@ -179,7 +179,7 @@ class RigidBodyComponentSystem extends ComponentSystem {
             this.dynamicsWorld = new Ammo.btDiscreteDynamicsWorld(this.dispatcher, this.overlappingPairCache, this.solver, this.collisionConfiguration);
 
             if (this.dynamicsWorld.setInternalTickCallback) {
-                var checkForCollisionsPointer = Ammo.addFunction(this._checkForCollisions.bind(this), 'vif');
+                const checkForCollisionsPointer = Ammo.addFunction(this._checkForCollisions.bind(this), 'vif');
                 this.dynamicsWorld.setInternalTickCallback(checkForCollisionsPointer);
             } else {
                 // #if _DEBUG
@@ -233,19 +233,20 @@ class RigidBodyComponentSystem extends ComponentSystem {
 
     cloneComponent(entity, clone) {
         // create new data block for clone
+        const rigidbody = entity.rigidbody;
         const data = {
-            enabled: entity.rigidbody.enabled,
-            mass: entity.rigidbody.mass,
-            linearDamping: entity.rigidbody.linearDamping,
-            angularDamping: entity.rigidbody.angularDamping,
-            linearFactor: [entity.rigidbody.linearFactor.x, entity.rigidbody.linearFactor.y, entity.rigidbody.linearFactor.z],
-            angularFactor: [entity.rigidbody.angularFactor.x, entity.rigidbody.angularFactor.y, entity.rigidbody.angularFactor.z],
-            friction: entity.rigidbody.friction,
-            rollingFriction: entity.rigidbody.rollingFriction,
-            restitution: entity.rigidbody.restitution,
-            type: entity.rigidbody.type,
-            group: entity.rigidbody.group,
-            mask: entity.rigidbody.mask
+            enabled: rigidbody.enabled,
+            mass: rigidbody.mass,
+            linearDamping: rigidbody.linearDamping,
+            angularDamping: rigidbody.angularDamping,
+            linearFactor: [rigidbody.linearFactor.x, rigidbody.linearFactor.y, rigidbody.linearFactor.z],
+            angularFactor: [rigidbody.angularFactor.x, rigidbody.angularFactor.y, rigidbody.angularFactor.z],
+            friction: rigidbody.friction,
+            rollingFriction: rigidbody.rollingFriction,
+            restitution: rigidbody.restitution,
+            type: rigidbody.type,
+            group: rigidbody.group,
+            mask: rigidbody.mask
         };
 
         this.addComponent(clone, data);
@@ -498,7 +499,7 @@ class RigidBodyComponentSystem extends ComponentSystem {
                 const length = others.length;
                 let i = length;
                 while (i--) {
-                    var other = others[i];
+                    const other = others[i];
                     // if the contact does not exist in the current frame collisions then fire event
                     if (!frameCollision || frameCollision.others.indexOf(other) < 0) {
                         // remove from others list
@@ -590,15 +591,15 @@ class RigidBodyComponentSystem extends ComponentSystem {
             const numContacts = manifold.getNumContacts();
             const forwardContacts = [];
             const reverseContacts = [];
-            var newCollision, e0Events, e1Events;
+            let newCollision;
 
             if (numContacts > 0) {
                 // don't fire contact events for triggers
                 if ((flags0 & BODYFLAG_NORESPONSE_OBJECT) ||
                     (flags1 & BODYFLAG_NORESPONSE_OBJECT)) {
 
-                    e0Events = e0.collision && (e0.collision.hasEvent("triggerenter") || e0.collision.hasEvent("triggerleave"));
-                    e1Events = e1.collision && (e1.collision.hasEvent("triggerenter") || e1.collision.hasEvent("triggerleave"));
+                    const e0Events = e0.collision && (e0.collision.hasEvent("triggerenter") || e0.collision.hasEvent("triggerleave"));
+                    const e1Events = e1.collision && (e1.collision.hasEvent("triggerenter") || e1.collision.hasEvent("triggerleave"));
                     const e0BodyEvents = e0.rigidbody && (e0.rigidbody.hasEvent("triggerenter") || e0.rigidbody.hasEvent("triggerleave"));
                     const e1BodyEvents = e1.rigidbody && (e1.rigidbody.hasEvent("triggerenter") || e1.rigidbody.hasEvent("triggerleave"));
 
@@ -638,8 +639,8 @@ class RigidBodyComponentSystem extends ComponentSystem {
                         }
                     }
                 } else {
-                    e0Events = this._hasContactEvent(e0);
-                    e1Events = this._hasContactEvent(e1);
+                    const e0Events = this._hasContactEvent(e0);
+                    const e1Events = this._hasContactEvent(e1);
                     const globalEvents = this.hasEvent("contact");
 
                     if (globalEvents || e0Events || e1Events) {

--- a/src/framework/components/rigid-body/system.js
+++ b/src/framework/components/rigid-body/system.js
@@ -78,11 +78,11 @@ class SingleContactResult {
  * @name ContactPoint
  * @classdesc Object holding the result of a contact between two Entities.
  * @description Create a new ContactPoint.
- * @param {Vec3} localPoint - The point on the entity where the contact occurred, relative to the entity.
- * @param {Vec3} localPointOther - The point on the other entity where the contact occurred, relative to the other entity.
- * @param {Vec3} point - The point on the entity where the contact occurred, in world space.
- * @param {Vec3} pointOther - The point on the other entity where the contact occurred, in world space.
- * @param {Vec3} normal - The normal vector of the contact on the other entity, in world space.
+ * @param {Vec3} [localPoint] - The point on the entity where the contact occurred, relative to the entity.
+ * @param {Vec3} [localPointOther] - The point on the other entity where the contact occurred, relative to the other entity.
+ * @param {Vec3} [point] - The point on the entity where the contact occurred, in world space.
+ * @param {Vec3} [pointOther] - The point on the other entity where the contact occurred, in world space.
+ * @param {Vec3} [normal] - The normal vector of the contact on the other entity, in world space.
  * @property {Vec3} localPoint The point on the entity where the contact occurred, relative to the entity.
  * @property {Vec3} localPointOther The point on the other entity where the contact occurred, relative to the other entity.
  * @property {Vec3} point The point on the entity where the contact occurred, in world space.
@@ -90,20 +90,12 @@ class SingleContactResult {
  * @property {Vec3} normal The normal vector of the contact on the other entity, in world space.
  */
 class ContactPoint {
-    constructor(localPoint, localPointOther, point, pointOther, normal) {
-        if (arguments.length === 0) {
-            this.localPoint = new Vec3();
-            this.localPointOther = new Vec3();
-            this.point = new Vec3();
-            this.pointOther = new Vec3();
-            this.normal = new Vec3();
-        } else {
-            this.localPoint = localPoint;
-            this.localPointOther = localPointOther;
-            this.point = point;
-            this.pointOther = pointOther;
-            this.normal = normal;
-        }
+    constructor(localPoint = new Vec3(), localPointOther = new Vec3(), point = new Vec3(), pointOther = new Vec3(), normal = new Vec3()) {
+        this.localPoint = localPoint;
+        this.localPointOther = localPointOther;
+        this.point = point;
+        this.pointOther = pointOther;
+        this.normal = normal;
     }
 }
 
@@ -132,21 +124,7 @@ class ContactResult {
  * @param {SingleContactResult} result - Details of the contact between the two bodies.
  */
 
-const _schema = [
-    'enabled',
-    'type',
-    'mass',
-    'linearDamping',
-    'angularDamping',
-    'linearFactor',
-    'angularFactor',
-    'friction',
-    'rollingFriction',
-    'restitution',
-    'group',
-    'mask',
-    'body'
-];
+const _schema = ['enabled'];
 
 /**
  * @class
@@ -224,37 +202,38 @@ class RigidBodyComponentSystem extends ComponentSystem {
         }
     }
 
-    initializeComponentData(component, _data, properties) {
-        properties = ['enabled', 'mass', 'linearDamping', 'angularDamping', 'linearFactor', 'angularFactor', 'friction', 'rollingFriction', 'restitution', 'type', 'group', 'mask'];
+    initializeComponentData(component, data, properties) {
+        const props = [
+            'mass',
+            'linearDamping',
+            'angularDamping',
+            'linearFactor',
+            'angularFactor',
+            'friction',
+            'rollingFriction',
+            'restitution',
+            'type',
+            'group',
+            'mask'
+        ];
 
-        // duplicate the input data because we are modifying it
-        var data = {};
-        for (var i = 0, len = properties.length; i < len; i++) {
-            var property = properties[i];
-            data[property] = _data[property];
+        for (const property of props) {
+            if (data.hasOwnProperty(property)) {
+                const value = data[property];
+                if (Array.isArray(value)) {
+                    component[property] = new Vec3(value[0], value[1], value[2]);
+                } else {
+                    component[property] = value;
+                }
+            }
         }
 
-        // backwards compatibility
-        if (_data.bodyType) {
-            data.type = _data.bodyType;
-            // #if _DEBUG
-            console.warn('DEPRECATED: pc.RigidBodyComponent#bodyType is deprecated. Use pc.RigidBodyComponent#type instead.');
-            // #endif
-        }
-
-        if (data.linearFactor && Array.isArray(data.linearFactor)) {
-            data.linearFactor = new Vec3(data.linearFactor[0], data.linearFactor[1], data.linearFactor[2]);
-        }
-        if (data.angularFactor && Array.isArray(data.angularFactor)) {
-            data.angularFactor = new Vec3(data.angularFactor[0], data.angularFactor[1], data.angularFactor[2]);
-        }
-
-        super.initializeComponentData(component, data, properties);
+        super.initializeComponentData(component, data, ['enabled']);
     }
 
     cloneComponent(entity, clone) {
         // create new data block for clone
-        var data = {
+        const data = {
             enabled: entity.rigidbody.enabled,
             mass: entity.rigidbody.mass,
             linearDamping: entity.rigidbody.linearDamping,
@@ -278,13 +257,13 @@ class RigidBodyComponentSystem extends ComponentSystem {
         }
     }
 
-    onRemove(entity, data) {
-        var body = data.body;
+    onRemove(entity, component) {
+        const body = component.body;
         if (body) {
             this.removeBody(body);
             this.destroyBody(body);
 
-            data.body = null;
+            component.body = null;
         }
     }
 
@@ -301,14 +280,14 @@ class RigidBodyComponentSystem extends ComponentSystem {
     }
 
     createBody(mass, shape, transform) {
-        var localInertia = new Ammo.btVector3(0, 0, 0);
+        const localInertia = new Ammo.btVector3(0, 0, 0);
         if (mass !== 0) {
             shape.calculateLocalInertia(mass, localInertia);
         }
 
-        var motionState = new Ammo.btDefaultMotionState(transform);
-        var bodyInfo = new Ammo.btRigidBodyConstructionInfo(mass, motionState, shape, localInertia);
-        var body = new Ammo.btRigidBody(bodyInfo);
+        const motionState = new Ammo.btDefaultMotionState(transform);
+        const bodyInfo = new Ammo.btRigidBodyConstructionInfo(mass, motionState, shape, localInertia);
+        const body = new Ammo.btRigidBody(bodyInfo);
         Ammo.destroy(bodyInfo);
         Ammo.destroy(localInertia);
 
@@ -317,7 +296,7 @@ class RigidBodyComponentSystem extends ComponentSystem {
 
     destroyBody(body) {
         // The motion state needs to be destroyed explicitly (if present)
-        var motionState = body.getMotionState();
+        const motionState = body.getMotionState();
         if (motionState) {
             Ammo.destroy(motionState);
         }
@@ -334,19 +313,19 @@ class RigidBodyComponentSystem extends ComponentSystem {
      * @returns {RaycastResult} The result of the raycasting or null if there was no hit.
      */
     raycastFirst(start, end) {
-        var result = null;
+        let result = null;
 
         ammoRayStart.setValue(start.x, start.y, start.z);
         ammoRayEnd.setValue(end.x, end.y, end.z);
-        var rayCallback = new Ammo.ClosestRayResultCallback(ammoRayStart, ammoRayEnd);
+        const rayCallback = new Ammo.ClosestRayResultCallback(ammoRayStart, ammoRayEnd);
 
         this.dynamicsWorld.rayTest(ammoRayStart, ammoRayEnd, rayCallback);
         if (rayCallback.hasHit()) {
-            var collisionObj = rayCallback.get_m_collisionObject();
-            var body = Ammo.castObject(collisionObj, Ammo.btRigidBody);
+            const collisionObj = rayCallback.get_m_collisionObject();
+            const body = Ammo.castObject(collisionObj, Ammo.btRigidBody);
             if (body) {
-                var point = rayCallback.get_m_hitPointWorld();
-                var normal = rayCallback.get_m_hitNormalWorld();
+                const point = rayCallback.get_m_hitPointWorld();
+                const normal = rayCallback.get_m_hitNormalWorld();
 
                 result = new RaycastResult(
                     body.entity,
@@ -360,7 +339,7 @@ class RigidBodyComponentSystem extends ComponentSystem {
                     console.warn('DEPRECATED: pc.RigidBodyComponentSystem#rayCastFirst no longer requires a callback. The result of the raycast is returned by the function instead.');
                     // #endif
 
-                    var callback = arguments[2];
+                    const callback = arguments[2];
                     callback(result);
                 }
             }
@@ -388,25 +367,25 @@ class RigidBodyComponentSystem extends ComponentSystem {
         }
         // #endif
 
-        var results = [];
+        const results = [];
 
         ammoRayStart.setValue(start.x, start.y, start.z);
         ammoRayEnd.setValue(end.x, end.y, end.z);
-        var rayCallback = new Ammo.AllHitsRayResultCallback(ammoRayStart, ammoRayEnd);
+        const rayCallback = new Ammo.AllHitsRayResultCallback(ammoRayStart, ammoRayEnd);
 
         this.dynamicsWorld.rayTest(ammoRayStart, ammoRayEnd, rayCallback);
         if (rayCallback.hasHit()) {
-            var collisionObjs = rayCallback.get_m_collisionObjects();
-            var points = rayCallback.get_m_hitPointWorld();
-            var normals = rayCallback.get_m_hitNormalWorld();
+            const collisionObjs = rayCallback.get_m_collisionObjects();
+            const points = rayCallback.get_m_hitPointWorld();
+            const normals = rayCallback.get_m_hitNormalWorld();
 
-            var numHits = collisionObjs.size();
-            for (var i = 0; i < numHits; i++) {
-                var body = Ammo.castObject(collisionObjs.at(i), Ammo.btRigidBody);
+            const numHits = collisionObjs.size();
+            for (let i = 0; i < numHits; i++) {
+                const body = Ammo.castObject(collisionObjs.at(i), Ammo.btRigidBody);
                 if (body) {
-                    var point = points.at(i);
-                    var normal = normals.at(i);
-                    var result = new RaycastResult(
+                    const point = points.at(i);
+                    const normal = normals.at(i);
+                    const result = new RaycastResult(
                         body.entity,
                         new Vec3(point.x(), point.y(), point.z()),
                         new Vec3(normal.x(), normal.y(), normal.z())
@@ -431,8 +410,8 @@ class RigidBodyComponentSystem extends ComponentSystem {
      * @returns {boolean} True if this is a new collision, false otherwise.
      */
     _storeCollision(entity, other) {
-        var isNewCollision = false;
-        var guid = entity.getGuid();
+        let isNewCollision = false;
+        const guid = entity.getGuid();
 
         collisions[guid] = collisions[guid] || { others: [], entity: entity };
 
@@ -448,13 +427,13 @@ class RigidBodyComponentSystem extends ComponentSystem {
     }
 
     _createContactPointFromAmmo(contactPoint) {
-        var localPointA = contactPoint.get_m_localPointA();
-        var localPointB = contactPoint.get_m_localPointB();
-        var positionWorldOnA = contactPoint.getPositionWorldOnA();
-        var positionWorldOnB = contactPoint.getPositionWorldOnB();
-        var normalWorldOnB = contactPoint.get_m_normalWorldOnB();
+        const localPointA = contactPoint.get_m_localPointA();
+        const localPointB = contactPoint.get_m_localPointB();
+        const positionWorldOnA = contactPoint.getPositionWorldOnA();
+        const positionWorldOnB = contactPoint.getPositionWorldOnB();
+        const normalWorldOnB = contactPoint.get_m_normalWorldOnB();
 
-        var contact = this.contactPointPool.allocate();
+        const contact = this.contactPointPool.allocate();
         contact.localPoint.set(localPointA.x(), localPointA.y(), localPointA.z());
         contact.localPointOther.set(localPointB.x(), localPointB.y(), localPointB.z());
         contact.point.set(positionWorldOnA.x(), positionWorldOnA.y(), positionWorldOnA.z());
@@ -464,13 +443,13 @@ class RigidBodyComponentSystem extends ComponentSystem {
     }
 
     _createReverseContactPointFromAmmo(contactPoint) {
-        var localPointA = contactPoint.get_m_localPointA();
-        var localPointB = contactPoint.get_m_localPointB();
-        var positionWorldOnA = contactPoint.getPositionWorldOnA();
-        var positionWorldOnB = contactPoint.getPositionWorldOnB();
-        var normalWorldOnB = contactPoint.get_m_normalWorldOnB();
+        const localPointA = contactPoint.get_m_localPointA();
+        const localPointB = contactPoint.get_m_localPointB();
+        const positionWorldOnA = contactPoint.getPositionWorldOnA();
+        const positionWorldOnB = contactPoint.getPositionWorldOnB();
+        const normalWorldOnB = contactPoint.get_m_normalWorldOnB();
 
-        var contact = this.contactPointPool.allocate();
+        const contact = this.contactPointPool.allocate();
         contact.localPointOther.set(localPointA.x(), localPointA.y(), localPointA.z());
         contact.localPoint.set(localPointB.x(), localPointB.y(), localPointB.z());
         contact.pointOther.set(positionWorldOnA.x(), positionWorldOnA.y(), positionWorldOnA.z());
@@ -480,7 +459,7 @@ class RigidBodyComponentSystem extends ComponentSystem {
     }
 
     _createSingleContactResult(a, b, contactPoint) {
-        var result = this.singleContactResultPool.allocate();
+        const result = this.singleContactResultPool.allocate();
 
         result.a = a;
         result.b = b;
@@ -494,7 +473,7 @@ class RigidBodyComponentSystem extends ComponentSystem {
     }
 
     _createContactResult(other, contacts) {
-        var result = this.contactResultPool.allocate();
+        const result = this.contactResultPool.allocate();
         result.other = other;
         result.contacts = contacts;
         return result;
@@ -508,16 +487,16 @@ class RigidBodyComponentSystem extends ComponentSystem {
      * related entities.
      */
     _cleanOldCollisions() {
-        for (var guid in collisions) {
+        for (const guid in collisions) {
             if (collisions.hasOwnProperty(guid)) {
-                var frameCollision = frameCollisions[guid];
-                var collision = collisions[guid];
-                var entity = collision.entity;
-                var entityCollision = entity.collision;
-                var entityRigidbody = entity.rigidbody;
-                var others = collision.others;
-                var length = others.length;
-                var i = length;
+                const frameCollision = frameCollisions[guid];
+                const collision = collisions[guid];
+                const entity = collision.entity;
+                const entityCollision = entity.collision;
+                const entityRigidbody = entity.rigidbody;
+                const others = collision.others;
+                const length = others.length;
+                let i = length;
                 while (i--) {
                     var other = others[i];
                     // if the contact does not exist in the current frame collisions then fire event
@@ -561,12 +540,12 @@ class RigidBodyComponentSystem extends ComponentSystem {
      * @returns {boolean} True if the entity has a contact and false otherwise.
      */
     _hasContactEvent(entity) {
-        var c = entity.collision;
+        const c = entity.collision;
         if (c && (c.hasEvent("collisionstart") || c.hasEvent("collisionend") || c.hasEvent("contact"))) {
             return true;
         }
 
-        var r = entity.rigidbody;
+        const r = entity.rigidbody;
         return r && (r.hasEvent("collisionstart") || r.hasEvent("collisionend") || r.hasEvent("contact"));
     }
 
@@ -579,39 +558,39 @@ class RigidBodyComponentSystem extends ComponentSystem {
      * @param {number} timeStep - The amount of simulation time processed in the last simulation tick.
      */
     _checkForCollisions(world, timeStep) {
-        var dynamicsWorld = Ammo.wrapPointer(world, Ammo.btDynamicsWorld);
+        const dynamicsWorld = Ammo.wrapPointer(world, Ammo.btDynamicsWorld);
 
         // Check for collisions and fire callbacks
-        var dispatcher = dynamicsWorld.getDispatcher();
-        var numManifolds = dispatcher.getNumManifolds();
+        const dispatcher = dynamicsWorld.getDispatcher();
+        const numManifolds = dispatcher.getNumManifolds();
 
         frameCollisions = {};
 
         // loop through the all contacts and fire events
-        for (var i = 0; i < numManifolds; i++) {
-            var manifold = dispatcher.getManifoldByIndexInternal(i);
+        for (let i = 0; i < numManifolds; i++) {
+            const manifold = dispatcher.getManifoldByIndexInternal(i);
 
-            var body0 = manifold.getBody0();
-            var body1 = manifold.getBody1();
+            const body0 = manifold.getBody0();
+            const body1 = manifold.getBody1();
 
-            var wb0 = Ammo.castObject(body0, Ammo.btRigidBody);
-            var wb1 = Ammo.castObject(body1, Ammo.btRigidBody);
+            const wb0 = Ammo.castObject(body0, Ammo.btRigidBody);
+            const wb1 = Ammo.castObject(body1, Ammo.btRigidBody);
 
-            var e0 = wb0.entity;
-            var e1 = wb1.entity;
+            const e0 = wb0.entity;
+            const e1 = wb1.entity;
 
             // check if entity is null - TODO: investigate when this happens
             if (!e0 || !e1) {
                 continue;
             }
 
-            var flags0 = wb0.getCollisionFlags();
-            var flags1 = wb1.getCollisionFlags();
+            const flags0 = wb0.getCollisionFlags();
+            const flags1 = wb1.getCollisionFlags();
 
-            var numContacts = manifold.getNumContacts();
-            var forwardContacts = [];
-            var reverseContacts = [];
-            var newCollision, e0Events, e1Events, e0BodyEvents, e1BodyEvents;
+            const numContacts = manifold.getNumContacts();
+            const forwardContacts = [];
+            const reverseContacts = [];
+            var newCollision, e0Events, e1Events;
 
             if (numContacts > 0) {
                 // don't fire contact events for triggers
@@ -620,8 +599,8 @@ class RigidBodyComponentSystem extends ComponentSystem {
 
                     e0Events = e0.collision && (e0.collision.hasEvent("triggerenter") || e0.collision.hasEvent("triggerleave"));
                     e1Events = e1.collision && (e1.collision.hasEvent("triggerenter") || e1.collision.hasEvent("triggerleave"));
-                    e0BodyEvents = e0.rigidbody && (e0.rigidbody.hasEvent("triggerenter") || e0.rigidbody.hasEvent("triggerleave"));
-                    e1BodyEvents = e1.rigidbody && (e1.rigidbody.hasEvent("triggerenter") || e1.rigidbody.hasEvent("triggerleave"));
+                    const e0BodyEvents = e0.rigidbody && (e0.rigidbody.hasEvent("triggerenter") || e0.rigidbody.hasEvent("triggerleave"));
+                    const e1BodyEvents = e1.rigidbody && (e1.rigidbody.hasEvent("triggerenter") || e1.rigidbody.hasEvent("triggerleave"));
 
                     // fire triggerenter events for triggers
                     if (e0Events) {
@@ -661,29 +640,28 @@ class RigidBodyComponentSystem extends ComponentSystem {
                 } else {
                     e0Events = this._hasContactEvent(e0);
                     e1Events = this._hasContactEvent(e1);
-                    var globalEvents = this.hasEvent("contact");
+                    const globalEvents = this.hasEvent("contact");
 
                     if (globalEvents || e0Events || e1Events) {
-                        for (var j = 0; j < numContacts; j++) {
-                            var btContactPoint = manifold.getContactPoint(j);
+                        for (let j = 0; j < numContacts; j++) {
+                            const btContactPoint = manifold.getContactPoint(j);
+                            const contactPoint = this._createContactPointFromAmmo(btContactPoint);
 
-                            var contactPoint = this._createContactPointFromAmmo(btContactPoint);
-                            var reverseContactPoint = null;
                             if (e0Events || e1Events) {
-                                reverseContactPoint = this._createReverseContactPointFromAmmo(btContactPoint);
                                 forwardContacts.push(contactPoint);
+                                const reverseContactPoint = this._createReverseContactPointFromAmmo(btContactPoint);
                                 reverseContacts.push(reverseContactPoint);
                             }
 
                             if (globalEvents) {
                                 // fire global contact event for every contact
-                                var result = this._createSingleContactResult(e0, e1, contactPoint);
+                                const result = this._createSingleContactResult(e0, e1, contactPoint);
                                 this.fire("contact", result);
                             }
                         }
 
                         if (e0Events) {
-                            var forwardResult = this._createContactResult(e1, forwardContacts);
+                            const forwardResult = this._createContactResult(e1, forwardContacts);
                             newCollision = this._storeCollision(e0, e1);
 
                             if (e0.collision) {
@@ -702,7 +680,7 @@ class RigidBodyComponentSystem extends ComponentSystem {
                         }
 
                         if (e1Events) {
-                            var reverseResult = this._createContactResult(e0, reverseContacts);
+                            const reverseResult = this._createContactResult(e0, reverseContacts);
                             newCollision = this._storeCollision(e1, e0);
 
                             if (e1.collision) {
@@ -734,31 +712,31 @@ class RigidBodyComponentSystem extends ComponentSystem {
     }
 
     onUpdate(dt) {
-        var i, len;
+        let i, len;
 
         // #if _PROFILER
         this._stats.physicsStart = now();
         // #endif
 
         // Check to see whether we need to update gravity on the dynamics world
-        var gravity = this.dynamicsWorld.getGravity();
+        const gravity = this.dynamicsWorld.getGravity();
         if (gravity.x() !== this.gravity.x || gravity.y() !== this.gravity.y || gravity.z() !== this.gravity.z) {
             gravity.setValue(this.gravity.x, this.gravity.y, this.gravity.z);
             this.dynamicsWorld.setGravity(gravity);
         }
 
-        var triggers = this._triggers;
+        const triggers = this._triggers;
         for (i = 0, len = triggers.length; i < len; i++) {
             triggers[i].updateTransform();
         }
 
-        var compounds = this._compounds;
+        const compounds = this._compounds;
         for (i = 0, len = compounds.length; i < len; i++) {
             compounds[i]._updateCompound();
         }
 
         // Update all kinematic bodies based on their current entity transform
-        var kinematic = this._kinematic;
+        const kinematic = this._kinematic;
         for (i = 0, len = kinematic.length; i < len; i++) {
             kinematic[i]._updateKinematic();
         }
@@ -767,7 +745,7 @@ class RigidBodyComponentSystem extends ComponentSystem {
         this.dynamicsWorld.stepSimulation(dt, this.maxSubSteps, this.fixedTimeStep);
 
         // Update the transforms of all entities referencing a dynamic body
-        var dynamic = this._dynamic;
+        const dynamic = this._dynamic;
         for (i = 0, len = dynamic.length; i < len; i++) {
             dynamic[i]._updateDynamic();
         }


### PR DESCRIPTION
Upgrades the `RigidBodyComponent` to the current recommended component format. This moves component data properties into the core `RigidBodyComponent`. This makes property access faster and the code easier to read/debug.

This PR also upgrades the code to ES6 (mainly `var` to `let` and `const`...and default parameters).

The physics render script was (naughtily) accessing the non-API `RigidBodyComponent#data` property so that's been fixed too.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
