### PR TITLE
Updated reprojectTexture

### DIFF
--- a/examples/graphics/render-to-cubemap.html
+++ b/examples/graphics/render-to-cubemap.html
@@ -252,22 +252,30 @@
             var srcCube = shinyBall.script.cubemapRenderer.cubeMap;
 
             // cube -> equi1
-            pc.reprojectTexture(device, srcCube, textureEqui, undefined, 1);
+            pc.reprojectTexture(srcCube, textureEqui, {
+                numSamples: 1
+            });
             app.renderTexture(-0.6, 0.7, 0.6, 0.3, textureEqui);
 
             // cube -> octa1
-            pc.reprojectTexture(device, srcCube, textureOcta, undefined, 1);
+            pc.reprojectTexture(srcCube, textureOcta, {
+                numSamples: 1
+            });
             app.renderTexture(0.7, 0.7, 0.4, 0.4, textureOcta);
 
             // equi1 -> octa2
-            pc.reprojectTexture(device, textureEqui, textureOcta2, 32, 1024);
+            pc.reprojectTexture(textureEqui, textureOcta2, {
+                specularPower: 32,
+                numSamples: 1024
+            });
             app.renderTexture(-0.7, -0.7, 0.4, 0.4, textureOcta2);
 
             // octa1 -> equi2
-            pc.reprojectTexture(device, textureOcta, textureEqui2, 16, 512);
+            pc.reprojectTexture(textureOcta, textureEqui2, {
+                specularPower: 16,
+                numSamples: 512
+            });
             app.renderTexture(0.6, -0.7, 0.6, 0.3, textureEqui2);
-
-
         });
     </script>
 </body>

--- a/src/graphics/reproject-texture.js
+++ b/src/graphics/reproject-texture.js
@@ -62,7 +62,7 @@ function getProjectionName(projection) {
 function reprojectTexture(source, target, options = {}) {
     // maintain backwards compatibility with previous function signature
     // reprojectTexture(device, source, target, specularPower = 1, numSamples = 1024)
-    if (source.constructor === GraphicsDevice) {
+    if (source instanceof GraphicsDevice) {
         source = arguments[1];
         target = arguments[2];
         options = {

--- a/src/graphics/reproject-texture.js
+++ b/src/graphics/reproject-texture.js
@@ -52,7 +52,6 @@ function getProjectionName(projection) {
  * @param {Texture} source - The source texture.
  * @param {Texture} target - The target texture.
  * @param {object} [options] - The options object.
- * @param {GraphicsDevice} [options.device] - Optional graphics device (default is the source texture device).
  * @param {number} [options.specularPower] - Optional specular power. When specular power is specified,
  * the source is convolved by a phong-weighted kernel raised to the specified power. Otherwise
  * the function performs a standard resample.

--- a/src/graphics/reproject-texture.js
+++ b/src/graphics/reproject-texture.js
@@ -7,6 +7,7 @@ import { createShaderFromCode } from './program-lib/utils.js';
 import { drawQuadWithShader } from './simple-post-effect.js';
 import { shaderChunks } from './program-lib/chunks/chunks.js';
 import { RenderTarget } from './render-target.js';
+import { GraphicsDevice } from './graphics-device.js';
 
 // get a coding string for texture based on its type and pixel format.
 function getCoding(texture) {
@@ -59,6 +60,21 @@ function getProjectionName(projection) {
  * @param {number} [options.face] - Optional cubemap face to update (default is update all faces).
  */
 function reprojectTexture(source, target, options = {}) {
+    // maintain backwards compatibility with previous function signature
+    // reprojectTexture(device, source, target, specularPower = 1, numSamples = 1024)
+    if (source.constructor === GraphicsDevice) {
+        source = arguments[1];
+        target = arguments[2];
+        options = {
+            device: arguments[0],
+            specularPower: arguments[3] === undefined ? 1 : arguments[3],
+            numSamples: arguments[4] === undefined ? 1024 : arguments[4]
+        };
+        // #if _DEBUG
+        console.warn('DEPRECATED: please use the updated pc.reprojectTexture API.');
+        // #endif
+    }
+
     // extract options
     const device = options.device || source.device;
     const specularPower = options.hasOwnProperty('specularPower') ? options.specularPower : 1;

--- a/src/graphics/reproject-texture.js
+++ b/src/graphics/reproject-texture.js
@@ -66,7 +66,6 @@ function reprojectTexture(source, target, options = {}) {
         source = arguments[1];
         target = arguments[2];
         options = {
-            device: arguments[0],
             specularPower: arguments[3] === undefined ? 1 : arguments[3],
             numSamples: arguments[4] === undefined ? 1024 : arguments[4]
         };
@@ -76,7 +75,7 @@ function reprojectTexture(source, target, options = {}) {
     }
 
     // extract options
-    const device = options.device || source.device;
+    const device = source.device;
     const specularPower = options.hasOwnProperty('specularPower') ? options.specularPower : 1;
     const numSamples = options.hasOwnProperty('numSamples') ? options.numSamples : 1024;
     const face = options.hasOwnProperty('face') ? options.face : null;


### PR DESCRIPTION
Added the option of limiting reprojectTexture to a single face of a cubemap.

Also moved the options into an option argument as follows. 

The function now has the following signature:
``` javascript
pc.reprojectTexture(source, target, options = { });
```

Which replaces the old style:
```javascript
pc.reprojectTexture(device, source, target, specularPower = 1, numSamples = 1024);
```

