### PR TITLE
Create skybox layer enabled

### DIFF
--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -473,7 +473,7 @@ class Application extends EventHandler {
         this.defaultLayerDepth = this.sceneDepth.layer;
 
         this.defaultLayerSkybox = new Layer({
-            enabled: false,
+            enabled: true,
             name: "Skybox",
             id: LAYERID_SKYBOX,
             opaqueSortMode: SORTMODE_NONE

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -114,7 +114,6 @@ class Scene extends EventHandler {
 
         this._skyboxPrefiltered = [null, null, null, null, null, null];
 
-        this._firstUpdateSkybox = true;
         this._skyboxCubeMap = null;
         this.skyboxModel = null;
 
@@ -444,12 +443,6 @@ class Scene extends EventHandler {
 
                 skyLayer.addMeshInstances(model.meshInstances);
                 this.skyLayer = skyLayer;
-
-                // enable the layer on first skybox update (the skybox layer is created disabled)
-                if (this._firstUpdateSkybox) {
-                    skyLayer.enabled = true;
-                    this._firstUpdateSkybox = false;
-                }
 
                 this.fire("set:skybox", usedTex);
             }


### PR DESCRIPTION
This PR enables the skybox layer at construction time and removes a previously introduced workaround, see #1838.

The skybox layer is currently constructed disabled and is then enabled by the scene during the first invocation of `_updateSkybox`.

This can result in the user attempting to disable the skybox layer only to have it re-enabled on first render.

@guycalledfrank @Maksims: can you remember why create the layer disabled in the first place?