### PR TITLE
Fix curve evaluator crash

### DIFF
--- a/src/math/curve-evaluator.js
+++ b/src/math/curve-evaluator.js
@@ -78,7 +78,7 @@ class CurveEvaluator {
                 // be more efficient to perform a binary search here instead. Which is
                 // straight forward thanks to the sorted list of knots).
                 let index = 0;
-                while (time >= keys[index + 1][0]) {
+                while (keys[index + 1] && time >= keys[index + 1][0]) {
                     index++;
                 }
                 this._left = keys[index][0];


### PR DESCRIPTION
When the `while` loop reaches the end of the array, the application crashes, trying to evaluate property 0 of an element that does not exist:
`TypeError: Cannot read property '0' of undefined`

The fix adds a check that the element exists, before accessing its property 0.

Fixes #

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
