### PR TITLE
remove fresnel calculation from Phong specular lighting chunk

### DIFF
--- a/src/graphics/program-lib/chunks/lightSpecularPhong.frag
+++ b/src/graphics/program-lib/chunks/lightSpecularPhong.frag
@@ -5,10 +5,8 @@ vec3 calcLightSpecular(float tGlossiness, vec3 tReflDirW, vec3 F0, out vec3 tFre
 
     float rl = max(dot(tReflDirW, -dLightDirNormW), 0.0);
 
-    vec3 F = calcFresnel(rl, F0);
-
     // Hack: On Mac OS X, calling pow with zero for the exponent generates hideous artifacts so bias up a little
-    return F * pow(rl, specPow + 0.0001);
+    return vec3(pow(rl, specPow + 0.0001));
 }
 
 vec3 getLightSpecular() {


### PR DESCRIPTION
This PR:
- fixes the the phong specular model by removing the fresnel calculations

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
