### PR TITLE
Revert recent material chunk changes

### DIFF
--- a/examples/graphics/material-anisotropic.html
+++ b/examples/graphics/material-anisotropic.html
@@ -76,7 +76,6 @@
 
         var createSphere = function (x, y, z) {
             var material = new pc.StandardMaterial();
-            material.diffuse = new pc.Color(1, 1, 1);
             material.metalness = 1.0;
             material.shininess = (z) / (NUM_SPHERES_Z - 1) * 100;
             material.useMetalness = true;

--- a/src/graphics/program-lib/chunks/chunks.js
+++ b/src/graphics/program-lib/chunks/chunks.js
@@ -41,8 +41,6 @@ import dpAtlasQuadPS from './dpAtlasQuad.frag';
 import emissivePS from './emissive.frag';
 import endPS from './end.frag';
 import endVS from './end.vert';
-import envBrdfNonePS from './envBrdfNone.frag';
-import envBrdfApproxPS from './envBrdfApprox.frag';
 import envConstPS from './envConst.frag';
 import envMultiplyPS from './envMultiply.frag';
 import extensionPS from './extension.frag';
@@ -249,8 +247,6 @@ var shaderChunks = {
     emissivePS: emissivePS,
     endPS: endPS,
     endVS: endVS,
-    envBrdfApproxPS: envBrdfApproxPS,
-    envBrdfNonePS: envBrdfNonePS,
     envConstPS: envConstPS,
     envMultiplyPS: envMultiplyPS,
     extensionPS: extensionPS,

--- a/src/graphics/program-lib/chunks/combineClearCoat.frag
+++ b/src/graphics/program-lib/chunks/combineClearCoat.frag
@@ -1,3 +1,3 @@
 vec3 combineColorCC() {
-    return combineColor() + (ccSpecularLight + ccReflection.rgb * ccReflection.a);
+    return combineColor() + (ccSpecularLight * ccSpecularity + ccReflection.rgb * ccReflection.a);
 }

--- a/src/graphics/program-lib/chunks/combineClearCoat.frag
+++ b/src/graphics/program-lib/chunks/combineClearCoat.frag
@@ -1,3 +1,3 @@
 vec3 combineColorCC() {
-    return combineColor() + (ccSpecularLight * ccSpecularity + ccReflection.rgb * ccReflection.a);
+    return combineColor()+(ccSpecularLight*ccSpecularity+ccReflection.rgb*ccSpecularity*ccReflection.a);
 }

--- a/src/graphics/program-lib/chunks/combineDiffuseSpecular.frag
+++ b/src/graphics/program-lib/chunks/combineDiffuseSpecular.frag
@@ -1,4 +1,3 @@
 vec3 combineColor() {
-    // NB energy conservation has changed with half-angle fresnel  
-    return dAlbedo * dDiffuseLight + dSpecularLight + dReflection.rgb * dReflection.a;
+    return mix(dAlbedo * dDiffuseLight, dSpecularLight, dSpecularity) + dReflection.rgb * dReflection.a;
 }

--- a/src/graphics/program-lib/chunks/combineDiffuseSpecular.frag
+++ b/src/graphics/program-lib/chunks/combineDiffuseSpecular.frag
@@ -1,3 +1,3 @@
 vec3 combineColor() {
-    return mix(dAlbedo * dDiffuseLight, dSpecularLight, dSpecularity) + dReflection.rgb * dReflection.a;
+    return mix(dAlbedo * dDiffuseLight, dSpecularLight + dReflection.rgb * dReflection.a, dSpecularity);
 }

--- a/src/graphics/program-lib/chunks/combineDiffuseSpecularNoConserve.frag
+++ b/src/graphics/program-lib/chunks/combineDiffuseSpecularNoConserve.frag
@@ -1,3 +1,3 @@
 vec3 combineColor() {
-    return dAlbedo * dDiffuseLight + (dSpecularLight * dSpecularity) + dReflection.rgb * dReflection.a;
+    return dAlbedo * dDiffuseLight + (dSpecularLight + dReflection.rgb * dReflection.a) * dSpecularity;
 }

--- a/src/graphics/program-lib/chunks/combineDiffuseSpecularNoConserve.frag
+++ b/src/graphics/program-lib/chunks/combineDiffuseSpecularNoConserve.frag
@@ -1,3 +1,3 @@
 vec3 combineColor() {
-    return dAlbedo * dDiffuseLight + dSpecularLight + dReflection.rgb * dReflection.a;
+    return dAlbedo * dDiffuseLight + (dSpecularLight * dSpecularity) + dReflection.rgb * dReflection.a;
 }

--- a/src/graphics/program-lib/chunks/combineDiffuseSpecularNoRefl.frag
+++ b/src/graphics/program-lib/chunks/combineDiffuseSpecularNoRefl.frag
@@ -1,3 +1,3 @@
 vec3 combineColor() {
-    return dAlbedo * dDiffuseLight + dSpecularLight;
+    return dAlbedo * dDiffuseLight + dSpecularLight * dSpecularity;
 }

--- a/src/graphics/program-lib/chunks/combineDiffuseSpecularNoReflSeparateAmbient.frag
+++ b/src/graphics/program-lib/chunks/combineDiffuseSpecularNoReflSeparateAmbient.frag
@@ -1,5 +1,5 @@
 uniform vec3 material_ambient;
 
 vec3 combineColor() {
-    return (dDiffuseLight - light_globalAmbient) * dAlbedo + dSpecularLight + material_ambient * light_globalAmbient;
+    return (dDiffuseLight - light_globalAmbient) * dAlbedo + dSpecularLight * dSpecularity + material_ambient * light_globalAmbient;
 }

--- a/src/graphics/program-lib/chunks/combineDiffuseSpecularOld.frag
+++ b/src/graphics/program-lib/chunks/combineDiffuseSpecularOld.frag
@@ -1,3 +1,3 @@
 vec3 combineColor() {
-    return mix(dAlbedo * dDiffuseLight + dSpecularLight, dReflection.rgb, dReflection.a);
+    return mix(dAlbedo * dDiffuseLight + dSpecularLight * dSpecularity, dReflection.rgb, dReflection.a);
 }

--- a/src/graphics/program-lib/chunks/envBrdfApprox.frag
+++ b/src/graphics/program-lib/chunks/envBrdfApprox.frag
@@ -1,9 +1,0 @@
-// Adapted from https://www.unrealengine.com/en-US/blog/physically-based-shading-on-mobile
-vec3 envBrdf(vec3 f0, float glossiness, vec3 normal) {
-    const vec4 c0 = vec4(-1, -0.0275, -0.572, 0.022);
-    const vec4 c1 = vec4(1, 0.0425, 1.04, -0.04);
-    vec4 r = (1.0 - glossiness) * (1.0 - glossiness) * c0 + c1;
-    float a004 = min(r.x * r.x, exp2(-9.28 * dot(normal, dViewDirW))) * r.x + r.y;
-    vec2 AB = vec2(-1.04, 1.04) * a004 + r.zw;
-    return f0 * AB.x + AB.y;
-}

--- a/src/graphics/program-lib/chunks/envBrdfNone.frag
+++ b/src/graphics/program-lib/chunks/envBrdfNone.frag
@@ -1,3 +1,0 @@
-vec3 envBrdf(vec3 f0, float glossiness, vec3 normal) {
-    return f0;
-}

--- a/src/graphics/program-lib/chunks/fresnelSchlick.frag
+++ b/src/graphics/program-lib/chunks/fresnelSchlick.frag
@@ -1,15 +1,18 @@
 // Schlick's approximation
+uniform float material_fresnelFactor; // unused
 
-vec3 calcFresnel(float cosTheta, vec3 F0)
-{
-    return F0 + (1.0 - F0) * pow(max(1.0 - cosTheta, 0.0), 5.0);
-}
-
-vec3 calcFresnel(float cosTheta, vec3 F0, float glossiness)
-{
-    float fresnel = 1.0 - cosTheta;
+void getFresnel() {
+    float fresnel = 1.0 - max(dot(dNormalW, dViewDirW), 0.0);
     float fresnel2 = fresnel * fresnel;
     fresnel *= fresnel2 * fresnel2;
-    fresnel *= glossiness * glossiness;
-    return F0 + (1.0 - F0) * fresnel;
+    fresnel *= dGlossiness * dGlossiness;
+    dSpecularity = dSpecularity + (1.0 - dSpecularity) * fresnel;
+
+    #ifdef CLEARCOAT
+    fresnel = 1.0 - max(dot(ccNormalW, dViewDirW), 0.0);
+    fresnel2 = fresnel * fresnel;
+    fresnel *= fresnel2 * fresnel2;
+    fresnel *= ccGlossiness * ccGlossiness;
+    ccSpecularity = ccSpecularity + (1.0 - ccSpecularity) * fresnel;
+    #endif
 }

--- a/src/graphics/program-lib/chunks/lightSpecularAnisoGGX.frag
+++ b/src/graphics/program-lib/chunks/lightSpecularAnisoGGX.frag
@@ -1,6 +1,5 @@
 // Anisotropic GGX
-
-vec3 calcLightSpecular(float tGlossiness, vec3 tNormalW, vec3 F0, out vec3 tFresnel) {
+float calcLightSpecular(float tGlossiness, vec3 tNormalW) {
     float PI = 3.141592653589793;
     float roughness = max((1.0 - tGlossiness) * (1.0 - tGlossiness), 0.001);
     float anisotropy = material_anisotropy * roughness;
@@ -31,18 +30,13 @@ vec3 calcLightSpecular(float tGlossiness, vec3 tNormalW, vec3 F0, out vec3 tFres
     float lambdaL = NoV * length(vec3(at * ToL, ab * BoL, NoL));
     float G = 0.5 / (lambdaV + lambdaL);
 
-    vec3 F = calcFresnel(NoH, F0);
-
-    tFresnel = F;
-
-    return D * G * F;
+    return D * G;
 }
 
-vec3 getLightSpecular() {
-    return calcLightSpecular(dGlossiness, dNormalW, dSpecularity, dLightFresnel);
+float getLightSpecular() {
+    return calcLightSpecular(dGlossiness, dNormalW);
 }
 
-vec3 getLightSpecularCC() {
-
-    return calcLightSpecular(ccGlossiness, ccNormalW, vec3(ccSpecularity), ccLightFresnel);
+float getLightSpecularCC() {
+    return calcLightSpecular(ccGlossiness, ccNormalW);
 }

--- a/src/graphics/program-lib/chunks/lightSpecularBlinn.frag
+++ b/src/graphics/program-lib/chunks/lightSpecularBlinn.frag
@@ -1,5 +1,5 @@
 // Energy-conserving (hopefully) Blinn-Phong
-vec3 calcLightSpecular(float tGlossiness, vec3 tNormalW, vec3 F0, out vec3 tFresnel) {
+float calcLightSpecular(float tGlossiness, vec3 tNormalW) {
     vec3 h = normalize( -dLightDirNormW + dViewDirW );
     float nh = max( dot( h, tNormalW ), 0.0 );
 
@@ -9,17 +9,13 @@ vec3 calcLightSpecular(float tGlossiness, vec3 tNormalW, vec3 F0, out vec3 tFres
     // Hack: On Mac OS X, calling pow with zero for the exponent generates hideous artifacts so bias up a little
     specPow = max(specPow, 0.0001);
 
-    vec3 F = calcFresnel(nh, F0);
-
-    tFresnel = F;
-
-    return F * pow(nh, specPow) * (specPow + 2.0) / 8.0;
+    return pow(nh, specPow) * (specPow + 2.0) / 8.0;
 }
 
-vec3 getLightSpecular() {
-    return calcLightSpecular(dGlossiness, dNormalW, dSpecularity, dLightFresnel);
+float getLightSpecular() {
+    return calcLightSpecular(dGlossiness, dNormalW);
 }
 
-vec3 getLightSpecularCC() {
-    return calcLightSpecular(ccGlossiness, ccNormalW, vec3(ccSpecularity), ccLightFresnel);
+float getLightSpecularCC() {
+    return calcLightSpecular(ccGlossiness, ccNormalW);
 }

--- a/src/graphics/program-lib/chunks/lightSpecularPhong.frag
+++ b/src/graphics/program-lib/chunks/lightSpecularPhong.frag
@@ -1,20 +1,16 @@
-vec3 calcLightSpecular(float tGlossiness, vec3 tReflDirW, vec3 F0, out vec3 tFresnel) {
+float calcLightSpecular(float tGlossiness, vec3 tReflDirW) {
     float specPow = tGlossiness;
 
     specPow = antiAliasGlossiness(specPow);
 
-    float rl = max(dot(tReflDirW, -dLightDirNormW), 0.0);
-
-    vec3 F = calcFresnel(rl, F0);
-
     // Hack: On Mac OS X, calling pow with zero for the exponent generates hideous artifacts so bias up a little
-    return F * pow(rl, specPow + 0.0001);
+    return pow(max(dot(tReflDirW, -dLightDirNormW), 0.0), specPow + 0.0001);
 }
 
-vec3 getLightSpecular() {
-    return calcLightSpecular(dGlossiness, dNormalW, dSpecularity, dLightFresnel);
+float getLightSpecular() {
+    return calcLightSpecular(dGlossiness, dReflDirW);
 }
 
-vec3 getLightSpecularCC() {
-    return calcLightSpecular(ccGlossiness, ccNormalW, vec3(ccSpecularity), ccLightFresnel);
+float getLightSpecularCC() {
+    return calcLightSpecular(ccGlossiness, ccReflDirW);
 }

--- a/src/graphics/program-lib/chunks/lightSpecularPhong.frag
+++ b/src/graphics/program-lib/chunks/lightSpecularPhong.frag
@@ -5,8 +5,10 @@ vec3 calcLightSpecular(float tGlossiness, vec3 tReflDirW, vec3 F0, out vec3 tFre
 
     float rl = max(dot(tReflDirW, -dLightDirNormW), 0.0);
 
+    vec3 F = calcFresnel(rl, F0);
+
     // Hack: On Mac OS X, calling pow with zero for the exponent generates hideous artifacts so bias up a little
-    return vec3(pow(rl, specPow + 0.0001));
+    return F * pow(rl, specPow + 0.0001);
 }
 
 vec3 getLightSpecular() {

--- a/src/graphics/program-lib/chunks/ltc.frag
+++ b/src/graphics/program-lib/chunks/ltc.frag
@@ -407,12 +407,12 @@ float calcRectLightSpecular(vec3 tNormalW, vec2 uv) {
 	return LTC_EvaluateRect( tNormalW, dViewDirW, vPositionW, mInv, dLTCCoords );
 }
 
-vec3 getRectLightSpecular() {
+float getRectLightSpecular() {
     return dLightFresnel * calcRectLightSpecular(dNormalW, dLTCUV);
 }
 
 #ifdef CLEARCOAT
-vec3 getRectLightSpecularCC() {
+float getRectLightSpecularCC() {
     return ccLightFresnel * calcRectLightSpecular(ccNormalW, ccLTCUV);
 }
 #endif
@@ -422,22 +422,22 @@ float calcDiskLightSpecular(vec3 tNormalW, vec2 uv) {
 	return LTC_EvaluateDisk( tNormalW, dViewDirW, vPositionW, mInv, dLTCCoords );
 }
 
-vec3 getDiskLightSpecular() {
+float getDiskLightSpecular() {
     return dLightFresnel * calcDiskLightSpecular(dNormalW, dLTCUV);
 }
 
 #ifdef CLEARCOAT
-vec3 getDiskLightSpecularCC() {
+float getDiskLightSpecularCC() {
     return ccLightFresnel * calcDiskLightSpecular(ccNormalW, ccLTCUV);
 }
 #endif
 
-vec3 getSphereLightSpecular() {
+float getSphereLightSpecular() {
     return dLightFresnel * calcDiskLightSpecular(dNormalW, dLTCUV);
 }
 
 #ifdef CLEARCOAT
-vec3 getSphereLightSpecularCC() {
+float getSphereLightSpecularCC() {
     return ccLightFresnel * calcDiskLightSpecular(ccNormalW, ccLTCUV);
 }
 #endif

--- a/src/graphics/program-lib/chunks/ltc.frag
+++ b/src/graphics/program-lib/chunks/ltc.frag
@@ -125,6 +125,11 @@ vec2 getLTCLightUV(float tGlossiness, vec3 tNormalW)
 	return LTC_Uv( tNormalW, dViewDirW, roughness );
 }
 
+//used for energy conservation and to modulate specular
+vec3 dLTCSpecFres;
+#ifdef CLEARCOAT
+vec3 ccLTCSpecFres;
+#endif
 vec3 getLTCLightSpecFres(vec2 uv, vec3 tSpecularity)
 {
 	vec4 t2 = texture2D( areaLightsLutTex2, uv );
@@ -140,11 +145,11 @@ vec3 getLTCLightSpecFres(vec2 uv, vec3 tSpecularity)
 void calcLTCLightValues()
 {
 	dLTCUV = getLTCLightUV(dGlossiness, dNormalW);
-	dLightFresnel = getLTCLightSpecFres(dLTCUV, dSpecularity); 
+	dLTCSpecFres = getLTCLightSpecFres(dLTCUV, dSpecularityNoFres); 
 
 #ifdef CLEARCOAT
 	ccLTCUV = getLTCLightUV(ccGlossiness, ccNormalW);
-	ccLightFresnel = getLTCLightSpecFres(ccLTCUV, vec3(ccSpecularity));
+	ccLTCSpecFres = getLTCLightSpecFres(ccLTCUV, vec3(ccSpecularityNoFres));
 #endif
 }
 
@@ -408,12 +413,12 @@ float calcRectLightSpecular(vec3 tNormalW, vec2 uv) {
 }
 
 float getRectLightSpecular() {
-    return dLightFresnel * calcRectLightSpecular(dNormalW, dLTCUV);
+    return calcRectLightSpecular(dNormalW, dLTCUV);
 }
 
 #ifdef CLEARCOAT
 float getRectLightSpecularCC() {
-    return ccLightFresnel * calcRectLightSpecular(ccNormalW, ccLTCUV);
+    return calcRectLightSpecular(ccNormalW, ccLTCUV);
 }
 #endif
 
@@ -423,21 +428,21 @@ float calcDiskLightSpecular(vec3 tNormalW, vec2 uv) {
 }
 
 float getDiskLightSpecular() {
-    return dLightFresnel * calcDiskLightSpecular(dNormalW, dLTCUV);
+    return calcDiskLightSpecular(dNormalW, dLTCUV);
 }
 
 #ifdef CLEARCOAT
 float getDiskLightSpecularCC() {
-    return ccLightFresnel * calcDiskLightSpecular(ccNormalW, ccLTCUV);
+    return calcDiskLightSpecular(ccNormalW, ccLTCUV);
 }
 #endif
 
 float getSphereLightSpecular() {
-    return dLightFresnel * calcDiskLightSpecular(dNormalW, dLTCUV);
+    return calcDiskLightSpecular(dNormalW, dLTCUV);
 }
 
 #ifdef CLEARCOAT
 float getSphereLightSpecularCC() {
-    return ccLightFresnel * calcDiskLightSpecular(ccNormalW, ccLTCUV);
+    return calcDiskLightSpecular(ccNormalW, ccLTCUV);
 }
 #endif

--- a/src/graphics/program-lib/chunks/reflectionCC.frag
+++ b/src/graphics/program-lib/chunks/reflectionCC.frag
@@ -2,6 +2,6 @@
 uniform float material_clearCoatReflectivity;
 
 void addReflectionCC() {
-    ccReflection += vec4(envBrdf(vec3(ccSpecularity), ccGlossiness, ccNormalW) * calcReflection(ccReflDirW, ccGlossiness), material_clearCoatReflectivity);
+    ccReflection += vec4(calcReflection(ccReflDirW, ccGlossiness), material_clearCoatReflectivity);
 }
 #endif

--- a/src/graphics/program-lib/chunks/reflectionCube.frag
+++ b/src/graphics/program-lib/chunks/reflectionCube.frag
@@ -10,5 +10,5 @@ vec3 calcReflection(vec3 tReflDirW, float tGlossiness) {
 }
 
 void addReflection() {   
-    dReflection += vec4(envBrdf(dSpecularity, dGlossiness, dNormalW) * calcReflection(dReflDirW, dGlossiness), material_reflectivity);
+    dReflection += vec4(calcReflection(dReflDirW, dGlossiness), material_reflectivity);
 }

--- a/src/graphics/program-lib/chunks/reflectionDpAtlas.frag
+++ b/src/graphics/program-lib/chunks/reflectionDpAtlas.frag
@@ -53,5 +53,5 @@ vec3 calcReflection(vec3 tReflDirW, float tGlossiness) {
 }
 
 void addReflection() {   
-    dReflection += vec4(envBrdf(dSpecularity, dGlossiness, dNormalW) * calcReflection(dReflDirW, dGlossiness), material_reflectivity);
+    dReflection += vec4(calcReflection(dReflDirW, dGlossiness), material_reflectivity);
 }

--- a/src/graphics/program-lib/chunks/reflectionPrefilteredCube.frag
+++ b/src/graphics/program-lib/chunks/reflectionPrefilteredCube.frag
@@ -50,6 +50,6 @@ vec3 calcReflection(vec3 tReflDirW, float tGlossiness) {
     return processEnvironment($DECODE(cubeFinal).rgb);
 }
 
-void addReflection() {
-    dReflection += vec4(envBrdf(dSpecularity, dGlossiness, dNormalW) * calcReflection(dReflDirW, dGlossiness), material_reflectivity);
+void addReflection() {   
+    dReflection += vec4(calcReflection(dReflDirW, dGlossiness), material_reflectivity);
 }

--- a/src/graphics/program-lib/chunks/reflectionPrefilteredCubeLod.frag
+++ b/src/graphics/program-lib/chunks/reflectionPrefilteredCubeLod.frag
@@ -19,5 +19,5 @@ vec3 calcReflection(vec3 tReflDirW, float tGlossiness) {
 }
 
 void addReflection() {   
-    dReflection += vec4(envBrdf(dSpecularity, dGlossiness, dNormalW) * calcReflection(dReflDirW, dGlossiness), material_reflectivity);
+    dReflection += vec4(calcReflection(dReflDirW, dGlossiness), material_reflectivity);
 }

--- a/src/graphics/program-lib/chunks/reflectionSphere.frag
+++ b/src/graphics/program-lib/chunks/reflectionSphere.frag
@@ -15,5 +15,5 @@ vec3 calcReflection(vec3 tReflDirW, float tGlossiness) {
 }
 
 void addReflection() {   
-    dReflection += vec4(envBrdf(dSpecularity, dGlossiness, dNormalW) * calcReflection(dReflDirW, dGlossiness), material_reflectivity);
+    dReflection += vec4(calcReflection(dReflDirW, dGlossiness), material_reflectivity);
 }

--- a/src/graphics/program-lib/chunks/reflectionSphereLow.frag
+++ b/src/graphics/program-lib/chunks/reflectionSphereLow.frag
@@ -9,5 +9,5 @@ vec3 calcReflection(vec3 tReflDirW, float tGlossiness) {
 }
 
 void addReflection() {   
-    dReflection += vec4(envBrdf(dSpecularity, dGlossiness, dNormalW) * calcReflection(dReflDirW, dGlossiness), material_reflectivity);
+    dReflection += vec4(calcReflection(dReflDirW, dGlossiness), material_reflectivity);
 }

--- a/src/graphics/program-lib/chunks/reproject.frag
+++ b/src/graphics/program-lib/chunks/reproject.frag
@@ -231,17 +231,6 @@ vec3 hemisphereSamplePhong(vec2 uv, float specPow) {
     return vec3(cos(phi) * sinTheta, sin(phi) * sinTheta, cosTheta);
 }
 
-vec3 hemisphereSampleGGX(vec2 uv, float specPow) {
-    float roughness = 1.0 - (log2(specPow) / 11.0);
-    float a = roughness * roughness;
-	
-    float phi = 2.0 * PI * uv.y;
-    float cosTheta = sqrt((1.0 - uv.x) / (1.0 + (a * a - 1.0) * uv.x));
-    float sinTheta = sqrt(1.0 - cosTheta * cosTheta);
-	
-    return vec3(cos(phi) * sinTheta, sin(phi) * sinTheta, cosTheta);
-}  
-
 vec4 reproject() {
     if (NUM_SAMPLES <= 1) {
         // single sample
@@ -274,7 +263,7 @@ vec4 prefilter() {
     vec3 result = vec3(0.0);
     for (int i=0; i<NUM_SAMPLES; ++i) {
         vec2 uv = vec2(float(i) / float(NUM_SAMPLES), rnd(i));
-        vec3 dir = vecSpace * hemisphereSampleGGX(uv, specularPower()); // NB now lines up with environmental BRDF
+        vec3 dir = vecSpace * hemisphereSamplePhong(uv, specularPower());
         result += DECODE_FUNC(SOURCE_FUNC(dir));
     }
 

--- a/src/graphics/program-lib/programs/standard.js
+++ b/src/graphics/program-lib/programs/standard.js
@@ -1279,16 +1279,15 @@ var standard = {
 
         if (lighting) {
             code += chunks.lightDiffuseLambertPS;
-
-            // used for energy conservation and to modulate specular with half-angle fresnel
-            code += "vec3 dLightFresnel;\n";
-            code += "vec3 ccLightFresnel;\n\n";
-
             if (hasAreaLights) code += chunks.ltc;
         }
         var useOldAmbient = false;
         if (options.useSpecular) {
             if (lighting) {
+                // used for energy conservation and to modulate specular with half-angle fresnel
+                code += "vec3 dLightFresnel;\n";
+                code += "vec3 ccLightFresnel;\n\n";
+
                 code += options.shadingModel === SPECULAR_PHONG ? chunks.lightSpecularPhongPS : (options.enableGGXSpecular) ? chunks.lightSpecularAnisoGGXPS : chunks.lightSpecularBlinnPS;
             }
             if (options.sphereMap || cubemapReflection || options.dpAtlas || (options.fresnelModel > 0)) {

--- a/src/graphics/program-lib/programs/standard.js
+++ b/src/graphics/program-lib/programs/standard.js
@@ -1283,19 +1283,14 @@ var standard = {
         }
         var useOldAmbient = false;
         if (options.useSpecular) {
-            if (lighting) {
-                // used for energy conservation and to modulate specular with half-angle fresnel
-                code += "vec3 dLightFresnel;\n";
-                code += "vec3 ccLightFresnel;\n\n";
-
-                code += options.shadingModel === SPECULAR_PHONG ? chunks.lightSpecularPhongPS : (options.enableGGXSpecular) ? chunks.lightSpecularAnisoGGXPS : chunks.lightSpecularBlinnPS;
-            }
+            if (lighting) code += options.shadingModel === SPECULAR_PHONG ? chunks.lightSpecularPhongPS : (options.enableGGXSpecular) ? chunks.lightSpecularAnisoGGXPS : chunks.lightSpecularBlinnPS;
             if (options.sphereMap || cubemapReflection || options.dpAtlas || (options.fresnelModel > 0)) {
                 if (options.fresnelModel > 0) {
-                    if (options.conserveEnergy && !options.useMetalness) {
-                        code += chunks.combineDiffuseSpecularPS; // post half-angle fresnel, this one is for spec-gloss path
+                    if (options.conserveEnergy && !hasAreaLights) {
+                        // NB if there are area lights, energy conservation is done differently
+                        code += chunks.combineDiffuseSpecularPS; // this one is correct, others are old stuff
                     } else {
-                        code += chunks.combineDiffuseSpecularNoConservePS; // post half-angle fresnel, this one is for metalness-gloss path
+                        code += chunks.combineDiffuseSpecularNoConservePS; // if you don't use environment cubemaps, you may consider this
                     }
                 } else {
                     code += chunks.combineDiffuseSpecularOldPS;
@@ -1464,7 +1459,17 @@ var standard = {
             code += "   getSpecularity();\n";
             if (!getGlossinessCalled) code += "   getGlossiness();\n";
 
-            // NB switched to more correct half-angle fresnel
+            // this is needed to allow custom area light fresnel calculations
+            if (hasAreaLights) {
+                code += "   #ifdef AREA_LIGHTS\n";
+                code += "   dSpecularityNoFres = dSpecularity;\n";
+                code += "   #ifdef CLEARCOAT\n";
+                code += "   ccSpecularityNoFres = ccSpecularity;\n";
+                code += "   #endif\n";
+                code += "   #endif\n";
+            }
+
+            if (!options.useMetalness && options.fresnelModel > 0) code += "   getFresnel();\n";
         }
 
         if (addAmbient) {
@@ -1488,9 +1493,14 @@ var standard = {
                 code += "   addReflection();\n";
             }
 
-            // NB switched to more correct half-angle fresnel
+            if (options.useSpecular && options.useMetalness && options.fresnelModel > 0) code += "   getFresnel();\n";
 
             if (hasAreaLights) {
+                // specular has to be accumulated differently if we want area lights to look correct
+                code += "   ccReflection.rgb *= ccSpecularity;\n";
+                code += "   dReflection.rgb *= dSpecularity;\n";
+                code += "   dSpecularLight *= dSpecularity;\n";
+
                 code += "   float roughness = max((1.0 - dGlossiness) * (1.0 - dGlossiness), 0.001);\n";
             }
 
@@ -1640,25 +1650,34 @@ var standard = {
                     }
                 }
 
-                // NB specular lighting moved here for legacy energy conservation
-                if (options.clearCoat > 0) code += "       ccSpecularLight += get" + shapeString + "LightSpecularCC() * dAtten * light" + i + "_color" + (usesCookieNow ? " * dAtten3" : "") + ";\n";
-                if (options.useSpecular) code += "       dSpecularLight += get" + shapeString + "LightSpecular() * dAtten * light" + i + "_color" + (usesCookieNow ? " * dAtten3" : "") + ";\n";
-
                 // non-punctual lights do not mix diffuse lighting into specular attenuation
                 if (lightShape !== LIGHTSHAPE_PUNCTUAL) {
-                    if (options.conserveEnergy && options.useSpecular && !options.useMetalness) {
-                        code += "       dDiffuseLight += mix((dAttenD * dAtten) * light" + i + "_color" + (usesCookieNow ? " * dAtten3" : "") + ", vec3(0), dLightFresnel * dSpecularity);\n";
+                    if (options.conserveEnergy && options.useSpecular) {
+                        code += "       dDiffuseLight += mix((dAttenD * dAtten) * light" + i + "_color" + (usesCookieNow ? " * dAtten3" : "") + ", vec3(0), dLTCSpecFres);\n";
                     } else {
                         code += "       dDiffuseLight += (dAttenD * dAtten) * light" + i + "_color" + (usesCookieNow ? " * dAtten3" : "") + ";\n";
                     }
                 } else {
-                    if (options.conserveEnergy && options.useSpecular && !options.useMetalness) {
-                        code += "       dDiffuseLight += mix(dAtten * light" + i + "_color" + (usesCookieNow ? " * dAtten3" : "") + ", vec3(0), dLightFresnel * dSpecularity);\n";
+                    if (hasAreaLights && options.conserveEnergy && options.useSpecular) {
+                        code += "       dDiffuseLight += mix(dAtten * light" + i + "_color" + (usesCookieNow ? " * dAtten3" : "") + ", vec3(0), dSpecularity);\n";
                     } else {
                         code += "       dDiffuseLight += dAtten * light" + i + "_color" + (usesCookieNow ? " * dAtten3" : "") + ";\n";
                     }
                 }
 
+                if (lightShape !== LIGHTSHAPE_PUNCTUAL) {
+                    if (options.clearCoat > 0) code += "       ccSpecularLight += ccLTCSpecFres * get" + shapeString + "LightSpecularCC() * dAtten * light" + i + "_color" + (usesCookieNow ? " * dAtten3" : "") + ";\n";
+                    if (options.useSpecular) code += "       dSpecularLight += dLTCSpecFres * get" + shapeString + "LightSpecular() * dAtten * light" + i + "_color" + (usesCookieNow ? " * dAtten3" : "") + ";\n";
+                } else {
+                    if (hasAreaLights) {
+                        // if LTC lights are present, specular must be accumulated with specularity (specularity is pre multiplied by punctual light fresnel)
+                        if (options.clearCoat > 0) code += "       ccSpecularLight += ccSpecularity * getLightSpecularCC() * dAtten * light" + i + "_color" + (usesCookieNow ? " * dAtten3" : "") + ";\n";
+                        if (options.useSpecular) code += "       dSpecularLight += dSpecularity * getLightSpecular() * dAtten * light" + i + "_color" + (usesCookieNow ? " * dAtten3" : "") + ";\n";
+                    } else {
+                        if (options.clearCoat > 0) code += "       ccSpecularLight += getLightSpecularCC() * dAtten * light" + i + "_color" + (usesCookieNow ? " * dAtten3" : "") + ";\n";
+                        if (options.useSpecular) code += "       dSpecularLight += getLightSpecular() * dAtten * light" + i + "_color" + (usesCookieNow ? " * dAtten3" : "") + ";\n";
+                    }
+                }
 
                 if (lightType !== LIGHTTYPE_DIRECTIONAL) {
                     code += "   }\n"; // BRANCH END
@@ -1667,7 +1686,15 @@ var standard = {
                 code += "\n";
             }
 
-            // NB using half-angle fresnel accumulates specular consistenetly accross all punctual, area and image-based lights
+            if (hasAreaLights) {
+                // specular has to be accumulated differently if we want area lights to look correct
+                if (options.clearCoat > 0) {
+                    code += "   ccSpecularity = 1.0;\n";
+                }
+                if (options.useSpecular) {
+                    code += "   dSpecularity = vec3(1);\n";
+                }
+            }
 
             if ((cubemapReflection || options.sphereMap || options.dpAtlas) && options.refraction) {
                 code += "   addRefraction();\n";
@@ -1743,6 +1770,7 @@ var standard = {
         if (code.includes("dShadowCoord")) structCode += "vec3 dShadowCoord;\n";
         if (code.includes("dNormalMap")) structCode += "vec3 dNormalMap;\n";
         if (code.includes("dSpecularity")) structCode += "vec3 dSpecularity;\n";
+        if (code.includes("dSpecularityNoFres")) structCode += "vec3 dSpecularityNoFres;\n";
         if (code.includes("dUvOffset")) structCode += "vec2 dUvOffset;\n";
         if (code.includes("dGlossiness")) structCode += "float dGlossiness;\n";
         if (code.includes("dAlpha")) structCode += "float dAlpha;\n";
@@ -1756,6 +1784,7 @@ var standard = {
         if (code.includes("ccReflDirW")) structCode += "vec3 ccReflDirW;\n";
         if (code.includes("ccSpecularLight")) structCode += "vec3 ccSpecularLight;\n";
         if (code.includes("ccSpecularity")) structCode += "float ccSpecularity;\n";
+        if (code.includes("ccSpecularityNoFres")) structCode += "float ccSpecularityNoFres;\n";
         if (code.includes("ccGlossiness")) structCode += "float ccGlossiness;\n";
 
         code = codeBegin + structCode + code;

--- a/src/graphics/program-lib/programs/standard.js
+++ b/src/graphics/program-lib/programs/standard.js
@@ -1687,8 +1687,8 @@ var standard = {
 
         if (options.opacityFadesSpecular === false) {
             if (options.blendType === BLEND_NORMAL || options.blendType === BLEND_PREMULTIPLIED) {
-                code += "float specLum = dot((dSpecularLight + dReflection.rgb * dReflection.a), vec3( 0.2126, 0.7152, 0.0722 ));\n";
-                code += "#ifdef CLEARCOAT\n specLum += dot(ccSpecularLight + ccReflection.rgb * ccReflection.a, vec3( 0.2126, 0.7152, 0.0722 ));\n#endif\n";
+                code += "float specLum = dot((dSpecularLight + dReflection.rgb * dReflection.a) * dSpecularity, vec3( 0.2126, 0.7152, 0.0722 ));\n";
+                code += "#ifdef CLEARCOAT\n specLum += dot(ccSpecularLight * ccSpecularity + ccReflection.rgb * ccReflection.a * ccSpecularity, vec3( 0.2126, 0.7152, 0.0722 ));\n#endif\n";
                 code += "dAlpha = clamp(dAlpha + gammaCorrectInput(specLum), 0.0, 1.0);\n";
             }
             code += "dAlpha *= material_alphaFade;\n";


### PR DESCRIPTION
This PR reverts recently merged changes to the material chunks:
- new, more accurate brdf function
- half angle fresnel
- use ggx instead of phong falloff when generating prefiltered lighting data

This is a temporary revert till the last issues have been dealt with.