### PR TITLE
Toaster fix

### DIFF
--- a/src/graphics/program-lib/chunks/chunks.js
+++ b/src/graphics/program-lib/chunks/chunks.js
@@ -43,6 +43,7 @@ import endPS from './end.frag';
 import endVS from './end.vert';
 import envBrdfNonePS from './envBrdfNone.frag';
 import envBrdfApproxPS from './envBrdfApprox.frag';
+import envBrdfOldPS from './envBrdfOld.frag';
 import envConstPS from './envConst.frag';
 import envMultiplyPS from './envMultiply.frag';
 import extensionPS from './extension.frag';
@@ -249,6 +250,7 @@ var shaderChunks = {
     emissivePS: emissivePS,
     endPS: endPS,
     endVS: endVS,
+    envBrdfOldPS: envBrdfOldPS,
     envBrdfApproxPS: envBrdfApproxPS,
     envBrdfNonePS: envBrdfNonePS,
     envConstPS: envConstPS,

--- a/src/graphics/program-lib/chunks/envBrdfNone.frag
+++ b/src/graphics/program-lib/chunks/envBrdfNone.frag
@@ -1,3 +1,3 @@
 vec3 envBrdf(vec3 f0, float glossiness, vec3 normal) {
-    return f0;
+    return vec3(1);
 }

--- a/src/graphics/program-lib/chunks/envBrdfOld.frag
+++ b/src/graphics/program-lib/chunks/envBrdfOld.frag
@@ -1,0 +1,3 @@
+vec3 envBrdf(vec3 f0, float glossiness, vec3 normal) {
+    return f0; 
+}

--- a/src/graphics/program-lib/chunks/lightSpecularPhong.frag
+++ b/src/graphics/program-lib/chunks/lightSpecularPhong.frag
@@ -5,6 +5,8 @@ vec3 calcLightSpecular(float tGlossiness, vec3 tReflDirW, vec3 F0, out vec3 tFre
 
     float rl = max(dot(tReflDirW, -dLightDirNormW), 0.0);
 
+    tFresnel = vec3(1);
+
     // Hack: On Mac OS X, calling pow with zero for the exponent generates hideous artifacts so bias up a little
     return vec3(pow(rl, specPow + 0.0001));
 }

--- a/src/graphics/program-lib/programs/standard.js
+++ b/src/graphics/program-lib/programs/standard.js
@@ -1213,7 +1213,7 @@ var standard = {
             if (options.useMetalness) {
                 code += chunks.envBrdfApproxPS;
             } else {
-                code += chunks.envBrdfNonePS;
+                code += options.shadingModel === SPECULAR_PHONG ? chunks.envBrdfNonePS : chunks.envBrdfOldPS;
             }
 
             var reflectionDecode = options.rgbmReflection ? "decodeRGBM" : (options.hdrReflection ? "" : "gammaCorrectInput");

--- a/src/graphics/program-lib/programs/standard.js
+++ b/src/graphics/program-lib/programs/standard.js
@@ -1281,8 +1281,8 @@ var standard = {
             code += chunks.lightDiffuseLambertPS;
 
             // used for energy conservation and to modulate specular with half-angle fresnel
-            code += "vec3 dLightFresnel;\n";
-            code += "vec3 ccLightFresnel;\n\n";
+            code += "vec3 dLightFresnel = vec3(0);\n";
+            code += "vec3 ccLightFresnel = vec3(0);\n\n";
 
             if (hasAreaLights) code += chunks.ltc;
         }


### PR DESCRIPTION
This PR:
- fixes the phong lighting path used by the shiny flying toasters in Safari.
- adds a new envBRDF chunk for non-metalness specular code path

Tested locally with the toaster project in Safari.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
