### PR TITLE
Fix: Compressed SceneItem cannot be reloaded

### DIFF
--- a/src/resources/parser/scene.js
+++ b/src/resources/parser/scene.js
@@ -15,7 +15,8 @@ class SceneParser {
         let parent = null;
 
         const compressed = data.compressedFormat;
-        if (compressed) {
+        if (compressed && !data.entDecompressed) {
+            data.entDecompressed = true;
             data.entities = new Decompress(data.entities, compressed).run();
         }
 
@@ -43,8 +44,6 @@ class SceneParser {
         }
 
         this._openComponentData(parent, data.entities);
-
-        delete data.compressedFormat;
 
         return parent;
     }


### PR DESCRIPTION
Fixes #3186

When scene compression is enabled, position, rotation and scale are stored outside of json entity data objects to exploit repetition and save space and time. We avoid creating a lot of in-memory array objects which would slow down parsing json. Position, rotation and scale stay outside of data.entities even after the line  ``data.entities = new Decompress(data.entities, compressed).run(); `` is executed. To be able to create run-time Entity objects multiple times, we need to keep compression metadata (data.compressedFormat) available for future _createEntity calls, and use a flag (data.entDecompressed) to avoid calling Decompress multiple times.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
