### PR TITLE
Add custom bounding box properties to model / render components

### DIFF
--- a/src/deprecated.js
+++ b/src/deprecated.js
@@ -99,6 +99,7 @@ import { ComponentSystem } from './framework/components/system.js';
 import { Entity } from './framework/entity.js';
 import { LightComponent } from './framework/components/light/component.js';
 import { ModelComponent } from './framework/components/model/component.js';
+import { RenderComponent } from './framework/components/render/component.js';
 import {
     BODYFLAG_KINEMATIC_OBJECT, BODYFLAG_NORESPONSE_OBJECT, BODYFLAG_STATIC_OBJECT,
     BODYSTATE_ACTIVE_TAG, BODYSTATE_DISABLE_DEACTIVATION, BODYSTATE_DISABLE_SIMULATION, BODYSTATE_ISLAND_SLEEPING, BODYSTATE_WANTS_DEACTIVATION,
@@ -995,6 +996,34 @@ ModelComponent.prototype.setVisible = function (visible) {
     // #endif
     this.enabled = visible;
 };
+
+Object.defineProperty(ModelComponent.prototype, "aabb", {
+    get: function () {
+        // #if _DEBUG
+        console.error('DEPRECATED: pc.ModelComponent#aabb is deprecated. Use pc.ModelComponent#customAabb instead - which expects local space AABB instead of a world space AABB.');
+        // #endif
+        return null;
+    },
+    set: function (type) {
+        // #if _DEBUG
+        console.error('DEPRECATED: pc.ModelComponent#aabb is deprecated. Use pc.ModelComponent#customAabb instead - which expects local space AABB instead of a world space AABB.');
+        // #endif
+    }
+});
+
+Object.defineProperty(RenderComponent.prototype, "aabb", {
+    get: function () {
+        // #if _DEBUG
+        console.error('DEPRECATED: pc.RenderComponent#aabb is deprecated. Use pc.RenderComponent#customAabb instead - which expects local space AABB instead of a world space AABB.');
+        // #endif
+        return null;
+    },
+    set: function (type) {
+        // #if _DEBUG
+        console.error('DEPRECATED: pc.RenderComponent#aabb is deprecated. Use pc.RenderComponent#customAabb instead - which expects local space AABB instead of a world space AABB.');
+        // #endif
+    }
+});
 
 Object.defineProperty(RigidBodyComponent.prototype, "bodyType", {
     get: function () {

--- a/src/framework/components/model/component.js
+++ b/src/framework/components/model/component.js
@@ -494,10 +494,12 @@ class ModelComponent extends Component {
         this._aabb = value;
 
         // set it on meshInstances
-        var mi = this._model.meshInstances;
-        if (mi) {
-            for (var i = 0; i < mi.length; i++) {
-                mi[i].setOverrideAabb(this._aabb);
+        if (this._model) {
+            var mi = this._model.meshInstances;
+            if (mi) {
+                for (var i = 0; i < mi.length; i++) {
+                    mi[i].setOverrideAabb(this._aabb);
+                }
             }
         }
     }

--- a/src/framework/components/model/component.js
+++ b/src/framework/components/model/component.js
@@ -41,7 +41,7 @@ import { Component } from '../component.js';
  * @property {boolean} lightmapped If true, this model will be lightmapped after using lightmapper.bake().
  * @property {number} lightmapSizeMultiplier Lightmap resolution multiplier.
  * @property {boolean} isStatic Mark model as non-movable (optimization).
- * @property {BoundingBox} aabb If set, the bounding box is used as a bounding box for visibility culling of attached mesh instances. This is an optimization,
+ * @property {BoundingBox} aabb If set, the object space bounding box is used as a bounding box for visibility culling of attached mesh instances. This is an optimization,
  * allowing oversized bounding box to be specified for skinned characters in order to avoid per frame bounding box computations based on bone positions.
  * @property {MeshInstance[]} meshInstances An array of meshInstances contained in the component's model. If model is not set or loaded for component it will return null.
  * @property {number} batchGroupId Assign model to a specific batch group (see {@link BatchGroup}). Default value is -1 (no group).

--- a/src/framework/components/model/component.js
+++ b/src/framework/components/model/component.js
@@ -41,7 +41,7 @@ import { Component } from '../component.js';
  * @property {boolean} lightmapped If true, this model will be lightmapped after using lightmapper.bake().
  * @property {number} lightmapSizeMultiplier Lightmap resolution multiplier.
  * @property {boolean} isStatic Mark model as non-movable (optimization).
- * @property {BoundingBox} aabb If set, the object space bounding box is used as a bounding box for visibility culling of attached mesh instances. This is an optimization,
+ * @property {BoundingBox} customAabb If set, the object space bounding box is used as a bounding box for visibility culling of attached mesh instances. This is an optimization,
  * allowing oversized bounding box to be specified for skinned characters in order to avoid per frame bounding box computations based on bone positions.
  * @property {MeshInstance[]} meshInstances An array of meshInstances contained in the component's model. If model is not set or loaded for component it will return null.
  * @property {number} batchGroupId Assign model to a specific batch group (see {@link BatchGroup}). Default value is -1 (no group).
@@ -76,7 +76,7 @@ class ModelComponent extends Component {
         this._batchGroupId = -1;
 
         // bounding box which can be set to override bounding box based on mesh
-        this._aabb = null;
+        this._customAabb = null;
 
         this._area = null;
 
@@ -486,19 +486,19 @@ class ModelComponent extends Component {
         this._model.meshInstances = value;
     }
 
-    get aabb() {
-        return this._aabb;
+    get customAabb() {
+        return this._customAabb;
     }
 
-    set aabb(value) {
-        this._aabb = value;
+    set customAabb(value) {
+        this._customAabb = value;
 
         // set it on meshInstances
         if (this._model) {
             var mi = this._model.meshInstances;
             if (mi) {
                 for (var i = 0; i < mi.length; i++) {
-                    mi[i].setOverrideAabb(this._aabb);
+                    mi[i].setCustomAabb(this._customAabb);
                 }
             }
         }
@@ -620,7 +620,7 @@ class ModelComponent extends Component {
                 meshInstances[i].castShadow = this._castShadows;
                 meshInstances[i].receiveShadow = this._receiveShadows;
                 meshInstances[i].isStatic = this._isStatic;
-                meshInstances[i].setOverrideAabb(this._aabb);
+                meshInstances[i].setCustomAabb(this._customAabb);
             }
 
             this.lightmapped = this._lightmapped; // update meshInstances

--- a/src/framework/components/model/system.js
+++ b/src/framework/components/model/system.js
@@ -135,7 +135,7 @@ class ModelComponentSystem extends ComponentSystem {
         }
 
         if (entity.model.aabb) {
-            component.model.aabb = entity.model.aabb.clone();
+            component.aabb = entity.model.aabb.clone();
         }
     }
 

--- a/src/framework/components/model/system.js
+++ b/src/framework/components/model/system.js
@@ -8,6 +8,9 @@ import { ComponentSystem } from '../system.js';
 import { ModelComponent } from './component.js';
 import { ModelComponentData } from './data.js';
 
+import { BoundingBox } from '../../../shape/bounding-box';
+import { Vec3 } from '../../../math/vec3';
+
 const _schema = ['enabled'];
 
 /**
@@ -65,6 +68,10 @@ class ModelComponentSystem extends ComponentSystem {
             if (_data.hasOwnProperty(properties[i])) {
                 component[properties[i]] = _data[properties[i]];
             }
+        }
+
+        if (_data.aabbCenter && _data.aabbHalfExtents) {
+            component.aabb = new BoundingBox(new Vec3(_data.aabbCenter), new Vec3(_data.aabbHalfExtents));
         }
 
         super.initializeComponentData(component, _data, ['enabled']);
@@ -125,6 +132,10 @@ class ModelComponentSystem extends ComponentSystem {
                 meshInstancesClone[i].layer = meshInstances[i].layer;
                 meshInstancesClone[i].receiveShadow = meshInstances[i].receiveShadow;
             }
+        }
+
+        if (entity.model.aabb) {
+            component.model.aabb = entity.model.aabb.clone();
         }
     }
 

--- a/src/framework/components/model/system.js
+++ b/src/framework/components/model/system.js
@@ -71,7 +71,7 @@ class ModelComponentSystem extends ComponentSystem {
         }
 
         if (_data.aabbCenter && _data.aabbHalfExtents) {
-            component.aabb = new BoundingBox(new Vec3(_data.aabbCenter), new Vec3(_data.aabbHalfExtents));
+            component.customAabb = new BoundingBox(new Vec3(_data.aabbCenter), new Vec3(_data.aabbHalfExtents));
         }
 
         super.initializeComponentData(component, _data, ['enabled']);
@@ -134,8 +134,8 @@ class ModelComponentSystem extends ComponentSystem {
             }
         }
 
-        if (entity.model.aabb) {
-            component.aabb = entity.model.aabb.clone();
+        if (entity.model.customAabb) {
+            component.customAabb = entity.model.aabb.clone();
         }
     }
 

--- a/src/framework/components/render/component.js
+++ b/src/framework/components/render/component.js
@@ -50,7 +50,7 @@ class SkinInstanceCachedObject extends RefCountedObject {
  * @property {boolean} lightmapped If true, the meshes will be lightmapped after using lightmapper.bake().
  * @property {number} lightmapSizeMultiplier Lightmap resolution multiplier.
  * @property {boolean} isStatic Mark meshes as non-movable (optimization).
- * @property {BoundingBox} aabb If set, the object space bounding box is used as a bounding box for visibility culling of attached mesh instances. This is an optimization,
+ * @property {BoundingBox} customAabb If set, the object space bounding box is used as a bounding box for visibility culling of attached mesh instances. This is an optimization,
  * allowing oversized bounding box to be specified for skinned characters in order to avoid per frame bounding box computations based on bone positions.
  * @property {MeshInstance[]} meshInstances An array of meshInstances contained in the component. If meshes are not set or loaded for component it will return null.
  * @property {number} batchGroupId Assign meshes to a specific batch group (see {@link BatchGroup}). Default value is -1 (no group).
@@ -80,7 +80,7 @@ class RenderComponent extends Component {
         this._renderStyle = RENDERSTYLE_SOLID;
 
         // bounding box which can be set to override bounding box based on mesh
-        this._aabb = null;
+        this._customAabb = null;
 
         // area - used by lightmapper
         this._area = null;
@@ -556,18 +556,18 @@ class RenderComponent extends Component {
         }
     }
 
-    get aabb() {
-        return this._aabb;
+    get customAabb() {
+        return this._customAabb;
     }
 
-    set aabb(value) {
-        this._aabb = value;
+    set customAabb(value) {
+        this._customAabb = value;
 
         // set it on meshInstances
         var mi = this._meshInstances;
         if (mi) {
             for (var i = 0; i < mi.length; i++) {
-                mi[i].setOverrideAabb(this._aabb);
+                mi[i].setCustomAabb(this._customAabb);
             }
         }
     }
@@ -624,7 +624,7 @@ class RenderComponent extends Component {
                 mi[i].isStatic = this._isStatic;
                 mi[i].renderStyle = this._renderStyle;
                 mi[i].setLightmapped(this._lightmapped);
-                mi[i].setOverrideAabb(this._aabb);
+                mi[i].setCustomAabb(this._customAabb);
             }
 
             if (this.enabled && this.entity.enabled) {

--- a/src/framework/components/render/component.js
+++ b/src/framework/components/render/component.js
@@ -50,7 +50,7 @@ class SkinInstanceCachedObject extends RefCountedObject {
  * @property {boolean} lightmapped If true, the meshes will be lightmapped after using lightmapper.bake().
  * @property {number} lightmapSizeMultiplier Lightmap resolution multiplier.
  * @property {boolean} isStatic Mark meshes as non-movable (optimization).
- * @property {BoundingBox} aabb If set, the bounding box is used as a bounding box for visibility culling of attached mesh instances. This is an optimization,
+ * @property {BoundingBox} aabb If set, the object space bounding box is used as a bounding box for visibility culling of attached mesh instances. This is an optimization,
  * allowing oversized bounding box to be specified for skinned characters in order to avoid per frame bounding box computations based on bone positions.
  * @property {MeshInstance[]} meshInstances An array of meshInstances contained in the component. If meshes are not set or loaded for component it will return null.
  * @property {number} batchGroupId Assign meshes to a specific batch group (see {@link BatchGroup}). Default value is -1 (no group).

--- a/src/framework/components/render/system.js
+++ b/src/framework/components/render/system.js
@@ -70,7 +70,7 @@ class RenderComponentSystem extends ComponentSystem {
         }
 
         if (_data.aabbCenter && _data.aabbHalfExtents) {
-            component.aabb = new BoundingBox(new Vec3(_data.aabbCenter), new Vec3(_data.aabbHalfExtents));
+            component.customAabb = new BoundingBox(new Vec3(_data.aabbCenter), new Vec3(_data.aabbHalfExtents));
         }
 
         super.initializeComponentData(component, _data, _schema);
@@ -100,8 +100,8 @@ class RenderComponentSystem extends ComponentSystem {
             component.meshInstances[m].material = srcMeshInstances[m].material;
         }
 
-        if (entity.render.aabb) {
-            component.aabb = entity.render.aabb.clone();
+        if (entity.render.customAabb) {
+            component.customAabb = entity.render.customAabb.clone();
         }
     }
 

--- a/src/framework/components/rigid-body/component.js
+++ b/src/framework/components/rigid-body/component.js
@@ -466,7 +466,7 @@ class RigidBodyComponent extends Component {
                 }
 
                 if (entity.collision.type === 'compound') {
-                    this.system._compounds.push(this.entity.collision);
+                    this.system._compounds.push(entity.collision);
                 }
 
                 body.activate();

--- a/src/scene/mesh-instance.js
+++ b/src/scene/mesh-instance.js
@@ -148,7 +148,7 @@ class MeshInstance {
         this.instancingData = null;
 
         // override local space AABB
-        this._overrideAabb = null;
+        this._customAabb = null;
 
         // World space AABB
         this.aabb = new BoundingBox();
@@ -248,7 +248,7 @@ class MeshInstance {
         }
 
         // use local space override aabb if specified
-        let localAabb = this._overrideAabb;
+        let localAabb = this._customAabb;
         let toWorldSpace = !!localAabb;
 
         // otherwise evaluate local aabb
@@ -682,18 +682,18 @@ class MeshInstance {
         }
     }
 
-    setOverrideAabb(aabb) {
+    setCustomAabb(aabb) {
 
         if (aabb) {
             // store the override aabb
-            if (this._overrideAabb) {
-                this._overrideAabb.copy(aabb);
+            if (this._customAabb) {
+                this._customAabb.copy(aabb);
             } else {
-                this._overrideAabb = aabb.clone();
+                this._customAabb = aabb.clone();
             }
         } else {
             // no override, force refresh the actual one
-            this._overrideAabb = null;
+            this._customAabb = null;
             this._aabbVer = -1;
         }
 
@@ -704,7 +704,7 @@ class MeshInstance {
 
         // set if bones need to be updated before culling
         if (this._skinInstance) {
-            this._skinInstance._updateBeforeCull = !this._overrideAabb;
+            this._skinInstance._updateBeforeCull = !this._customAabb;
         }
     }
 }


### PR DESCRIPTION
**API CHANGE**
- **aabb** property of RenderComponent and ModelComponent has been renamed to **customAabb**, to allow aabb property to be used for different purpose in the future.
- This also fixes the issue with this customAabb property usage. Before this PR, it was incorrectly handled as if specified in world space. This is correctly being handled as in local space now. 

This PR improves / fixes functionality introduced here: https://github.com/playcanvas/engine/pull/2435

This PR also adds support to specify custom AABB in addComponent for model and render component. This is to allow customAabb to be exposed in the Editor by separate PR.