### PR TITLE
[FIX] Image element crash on assigning new layer composition to scene

### DIFF
--- a/src/framework/components/element/component.js
+++ b/src/framework/components/element/component.js
@@ -716,7 +716,7 @@ class ElementComponent extends Component {
     }
 
     onLayersChanged(oldComp, newComp) {
-        this.addModelToLayers(this._image ? this._image._model : this._text._model);
+        this.addModelToLayers(this._image ? this._image._renderable.model : this._text._model);
         oldComp.off("add", this.onLayerAdded, this);
         oldComp.off("remove", this.onLayerRemoved, this);
         newComp.on("add", this.onLayerAdded, this);
@@ -727,7 +727,7 @@ class ElementComponent extends Component {
         var index = this.layers.indexOf(layer.id);
         if (index < 0) return;
         if (this._image) {
-            layer.addMeshInstances(this._image._model.meshInstances);
+            layer.addMeshInstances(this._image._renderable.model.meshInstances);
         } else if (this._text) {
             layer.addMeshInstances(this._text._model.meshInstances);
         }
@@ -737,7 +737,7 @@ class ElementComponent extends Component {
         var index = this.layers.indexOf(layer.id);
         if (index < 0) return;
         if (this._image) {
-            layer.removeMeshInstances(this._image._model.meshInstances);
+            layer.removeMeshInstances(this._image._renderable.model.meshInstances);
         } else if (this._text) {
             layer.removeMeshInstances(this._text._model.meshInstances);
         }


### PR DESCRIPTION
When the Editor disconnects and then reconnects, I suspect that the scene's layer composition is reassigned (maybe in `Application#_parseApplicationProperties`). This triggers the `onLayersChanged` handler for an image element in the scene. The code tries to access the model incorrectly. This PR specifies the correct property for the model.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
