### PR TITLE
examples browser fixes

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -26,6 +26,9 @@ To create the side bar thumbnails run the following script:
 npm run thumbnails
 ```
 
+### Local engine development
+By default, the local build uses whichever version of PlayCanvas is listed in the package.json file. If you'd like to use the locally built version of PlayCanvas in the engines build directory you can replace the `npm run build:watch` script above with `npm run local` or `npm run local:dbg` for the debug version.
+
 ## Creating an example
 
 The available examples are written as classes in TypeScript under the paths `./src/examples/\<categoryName\>/\<exampleName>.tsx.

--- a/examples/src/app/menu.tsx
+++ b/examples/src/app/menu.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 // @ts-ignore: library file import
 import { Container, Button, Label, TextAreaInput } from '@playcanvas/pcui/pcui-react';
@@ -16,6 +16,37 @@ const Menu = (props: MenuProps) => {
     let clickFullscreenListener: EventListener = null;
     const [showEmbedContainer, setShowEmbedContainer] = useState(false);
 
+    const toggleFullscreen = () => {
+        if (clickFullscreenListener) {
+            document.querySelector('iframe').contentDocument.removeEventListener('mousemove', clickFullscreenListener);
+        }
+        document.querySelector('#canvas-container').classList.toggle('fullscreen');
+        const app = document.querySelector('#appInner');
+        app.classList.toggle('fullscreen');
+        if (app.classList.contains('fullscreen')) {
+            clickFullscreenListener = () => {
+                app.classList.add('active');
+                if (mouseTimeout) {
+                    window.clearTimeout(mouseTimeout);
+                }
+                mouseTimeout = setTimeout(() => {
+                    app.classList.remove('active');
+                }, 2000);
+            };
+            document.querySelector('iframe').contentDocument.addEventListener('mousemove', clickFullscreenListener);
+        }
+    }
+
+    useEffect(() => {
+        const escapeKeyEvent = (e: any) => {
+            if (e.keyCode === 27 && document.querySelector('#canvas-container').classList.contains('fullscreen')) {
+                toggleFullscreen();
+            }
+        };
+        document.querySelector('iframe').contentDocument.addEventListener('keydown', escapeKeyEvent);
+        document.addEventListener('keydown', escapeKeyEvent);
+    })
+
     return <Container id='menu'>
         <Container id='menu-buttons'>
             <img src='https://playcanvas.com/viewer/static/playcanvas-logo.png' />
@@ -30,28 +61,7 @@ const Menu = (props: MenuProps) => {
             <Button icon='E259' text='' onClick={() => {
                 window.open("https://github.com/playcanvas/engine");
             }}/>
-            <Button icon='E127' text='' id='fullscreen-button' onClick={() => {
-                if (clickFullscreenListener) {
-                    document.querySelector('iframe').contentDocument.removeEventListener('mousemove', clickFullscreenListener);
-                }
-                document.querySelector('#canvas-container').classList.toggle('fullscreen');
-                const app = document.querySelector('#appInner');
-                app.classList.toggle('fullscreen');
-                if (app.classList.contains('fullscreen')) {
-                    clickFullscreenListener = () => {
-                        console.log('here');
-                        app.classList.add('active');
-                        if (mouseTimeout) {
-                            window.clearTimeout(mouseTimeout);
-                        }
-                        mouseTimeout = setTimeout(() => {
-                            app.classList.remove('active');
-                        }, 2000);
-                    };
-                    console.log(clickFullscreenListener);
-                    document.querySelector('iframe').contentDocument.addEventListener('mousemove', clickFullscreenListener);
-                }
-            }}/>
+            <Button icon='E127' text='' id='fullscreen-button' onClick={toggleFullscreen}/>
             <Button icon='E149' id='showMiniStatsButton' text='' onClick={() => {
                 document.getElementById('showMiniStatsButton').classList.toggle('selected');
                 props.setShowMiniStats(document.getElementById('showMiniStatsButton').classList.contains('selected'));
@@ -60,7 +70,19 @@ const Menu = (props: MenuProps) => {
         </Container>
         { showEmbedContainer && <Container id='menu-embed-container'>
             <Label text='Copy this iframe to embed the current example in your webpage:' />
-            <TextAreaInput enabled={false} value={`<iframe src="${location.href.replace('#/', '#/iframe/')}" frameborder="0"></iframe>`}/>
+            <TextAreaInput id='embed-text-area' enabled={false} value={`<iframe src="${location.href.replace('#/', '#/iframe/')}" frameborder="0"></iframe>`}/>
+            <Button id='copy-embed-button' text='Copy to clipboard' onClick={() => {
+                // @ts-ignore
+                const embedTextArea = document.getElementById('embed-text-area').ui;
+                // @ts-ignore
+                const embedCopyButton = document.getElementById('copy-embed-button').ui;
+                navigator.clipboard.writeText(embedTextArea.value);
+                embedTextArea.flash();
+                embedCopyButton.text = 'Copied!'
+                setTimeout(() => {
+                    embedCopyButton.text = 'Copy to clipboard'
+                }, 1000);
+            }}/>
         </Container> }
     </Container>;
 };

--- a/examples/src/app/styles.css
+++ b/examples/src/app/styles.css
@@ -516,13 +516,17 @@ body {
     white-space: normal;
 }
 
+#menu #menu-embed-container .pcui-button {
+    width: calc(100% - 12px);
+}
+
 #menu #menu-embed-container textarea {
     font-size: 10px;
 }
 
 @media only screen and (min-width: 601px) {
 #menu #menu-embed-container {
-    max-width: 232px;
+    max-width: 272px;
 }
 }
 

--- a/examples/thumbnails.js
+++ b/examples/thumbnails.js
@@ -38,7 +38,7 @@ async function takeScreenshots() {
     for (let i = 0; i < pathData.length; i++) {
         const { example, category } = pathData[i];
 
-        if (fs.existsSync(`dist/thumbnails/${category}/${example}.png`)) {
+        if (fs.existsSync(`dist/thumbnails/${category}_${example}.png`)) {
             console.log('skipped: ', `http://localhost:5000/#/iframe/${category}/${example}?fullscreen=true`)
             continue;
         }

--- a/examples/webpack.config.js
+++ b/examples/webpack.config.js
@@ -114,7 +114,7 @@ const config = {
 if (process.env.ENGINE_PATH) {
     config.plugins.push(
         new webpack.NormalModuleReplacementPlugin(
-            /^playcanvas$/,
+            /^playcanvas\/build\/playcanvas\.js$/,
             path.resolve(__dirname, process.env.ENGINE_PATH)
         )
     );


### PR DESCRIPTION
- Add a 'copy to clipboard' button to the embed example menu item
- Support closing fullscreen mode with the esc key
- Subsequent runs of `npm run thumbnails` correctly skips thumbnails that have already been captured
- Fix the `npm run local` and `npm run local:dbg` scripts
- Add a readme section for the local engine scripts

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
