### PR TITLE
Examples browser updates

### DIFF
--- a/examples/example-directory.js
+++ b/examples/example-directory.js
@@ -35,6 +35,12 @@ fs.readdir(`${__dirname}/src/examples/`, function (err, categories) {
 <html>
   <head>
     <meta http-equiv="refresh" content="0; url='/#/${category}/${example}'" />
+    <meta name="twitter:card" content="photo" />
+    <meta name="twitter:site" content="@playcanvas" />
+    <meta name="twitter:title" content="${example.split('-').join(' ')}" />
+    <meta name="twitter:description" content="A PlayCanvas engine example" />
+    <meta name="twitter:image" content="https://playcanvas.github.io/thumbnails/${category}_${example}.png" />
+    <meta name="twitter:url" content="https://playcanvas.github.io/${category}/${example}" />
   </head>
   <body>
     <p>Please follow <a href="/#/${category}/${example}">this link</a>.</p>

--- a/examples/src/app/code-editor.tsx
+++ b/examples/src/app/code-editor.tsx
@@ -64,7 +64,6 @@ const CodeEditor = (props: CodeEditorProps) => {
     };
 
     useEffect(() => {
-        monacoEditor?.setScrollPosition({ scrollTop: 0 });
         if (!files[selectedFile]) setSelectedFile(0);
         if ((window as any).toggleEvent) return;
         // set up the code panel toggle button
@@ -72,11 +71,12 @@ const CodeEditor = (props: CodeEditorProps) => {
         const panelToggleDiv = codePane.querySelector('.panel-toggle');
         panelToggleDiv.addEventListener('click', function () {
             codePane.classList.toggle('collapsed');
+            localStorage.setItem('codePaneCollapsed', codePane.classList.contains('collapsed') ? 'true' : 'false');
         });
         (window as any).toggleEvent = true;
     });
 
-    return <Panel headerText='CODE' id='codePane'>
+    return <Panel headerText='CODE' id='codePane' class={localStorage.getItem('codePaneCollapsed') !== 'false' ? 'collapsed' : null}>
         <div className='panel-toggle' id='codePane-panel-toggle'/>
         { props.files && props.files.length > 1 && <Container class='tabs-container'>
             {props.files.map((file: File, index: number) => {

--- a/examples/src/app/example-iframe.tsx
+++ b/examples/src/app/example-iframe.tsx
@@ -2,7 +2,9 @@ import React, { useEffect, useState } from 'react';
 import ControlPanel from './control-panel';
 // @ts-ignore: library file import
 import { Container, Spinner } from '@playcanvas/pcui/pcui-react';
-import * as pc from 'playcanvas/build/playcanvas.js';
+import * as playcanvas from 'playcanvas/build/playcanvas.js';
+// @ts-ignore: library file import
+import * as playcanvasDebug from 'playcanvas/build/playcanvas.dbg.js';
 // @ts-ignore: library file import
 import * as pcx from 'playcanvas/build/playcanvas-extras.js';
 // @ts-ignore: library file import
@@ -24,10 +26,15 @@ const APP_STATE = {
 interface ExampleIframeProps {
     controls: any,
     assets: any,
-    files: Array<File>
+    files: Array<File>,
+    debug?: boolean
 }
 
 const ExampleIframe = (props: ExampleIframeProps) => {
+    let pc = playcanvas;
+    if (props.debug) {
+        pc = playcanvasDebug;
+    }
     // expose PlayCanvas as a global in the iframe
     (window as any).pc = pc;
 

--- a/examples/src/app/index.tsx
+++ b/examples/src/app/index.tsx
@@ -22,7 +22,7 @@ const ExampleRoutes = (props: ExampleRoutesProps) => {
         <Switch>
             {
                 examples.paths.map((p) => {
-                    return <Route key={p.path} path={p.path}>
+                    return <Route key={p.path} path={[p.path, `${p.path}.html`]}>
                         <p.example path={p.path} defaultFiles={p.files} files={props.files} setDefaultFiles={props.setDefaultFiles} showMiniStats={props.showMiniStats} />
                     </Route>;
                 })
@@ -96,8 +96,8 @@ const MainLayout = () => {
                             const e = new p.example();
                             const assetsLoader = e.load;
                             const controls = e.controls;
-                            return <Route key={`/iframe${p.path}`} path={[`/iframe${p.path}`, `${p.path}.html`]}>
-                                <ExampleIframe controls={controls} assets={assetsLoader ? assetsLoader().props.children : null} files={p.files}/>
+                            return <Route key={`/iframe${p.path}`} path={[`/iframe${p.path}`]}>
+                                <ExampleIframe controls={controls} assets={assetsLoader ? assetsLoader().props.children : null} files={p.files} debug={p.path.includes('mini-stats')} />
                             </Route>;
                         })
                     }

--- a/examples/src/app/styles.css
+++ b/examples/src/app/styles.css
@@ -157,12 +157,6 @@ body {
     height: 100%;
 }
 
-
-#sideBar .pcui-text-input[placeholder]:after {
-    left: 0;
-    right: inherit;
-}
-
 #sideBar .pcui-label-group {
     margin: 12px;
 }


### PR DESCRIPTION
Updates for the examples browser based on feedback:

- Mini-stats example now uses the debug build of the engine and therefore correctly shows all graphs
- Editing long files no longer causes the code viewport to scroll to the top
- example links of the format `http://playcanvas.github.io/#/animation/blend.html` now link to the full examples browser so users who click these links can view the examples source.
- The code panel now starts in the closed state. This state is stored in local storage.
- Included twitter meta data on the twitter link pages which should allow twitter to show the thumbnails of each example in tweets.
- The filter examples input placeholder no longer obscures text that users enter in the input.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
