### PR TITLE
Exposed additional public functions for mesh morphing

### DIFF
--- a/src/deprecated.js
+++ b/src/deprecated.js
@@ -507,7 +507,7 @@ export var scene = {
 };
 
 Morph.prototype.getTarget = function (index) {
-    return this._targets[index];
+    return this.targets[index];
 };
 
 GraphNode.prototype._dirtify = function (local) {

--- a/src/deprecated.js
+++ b/src/deprecated.js
@@ -507,6 +507,10 @@ export var scene = {
 };
 
 Morph.prototype.getTarget = function (index) {
+    // #if _DEBUG
+    console.warn('DEPRECATED: pc.Morph#getTarget is deprecated. Use pc.Morph#targets instead.');
+    // #endif
+
     return this.targets[index];
 };
 

--- a/src/deprecated.js
+++ b/src/deprecated.js
@@ -59,6 +59,7 @@ import { ForwardRenderer } from './scene/renderer/forward-renderer.js';
 import { GraphNode } from './scene/graph-node.js';
 import { Material } from './scene/materials/material.js';
 import { Mesh } from './scene/mesh.js';
+import { Morph } from './scene/morph.js';
 import { MeshInstance, Command } from './scene/mesh-instance.js';
 import { Model } from './scene/model.js';
 import { ParticleEmitter } from './scene/particle-system/particle-emitter.js';
@@ -503,6 +504,10 @@ export var scene = {
     Scene: Scene,
     Skin: Skin,
     SkinInstance: SkinInstance
+};
+
+Morph.prototype.getTarget = function (index) {
+    return this._targets[index];
 };
 
 GraphNode.prototype._dirtify = function (local) {

--- a/src/scene/mesh-instance.js
+++ b/src/scene/mesh-instance.js
@@ -55,6 +55,7 @@ class Command {
  * @param {Material} material - The material used to render this instance.
  * @param {GraphNode} [node] - The graph node defining the transform for this instance. This parameter is optional when used with {@link RenderComponent} and will use the node the component is attached to.
  * @property {BoundingBox} aabb The world space axis-aligned bounding box for this mesh instance.
+ * @property {MorphInstance} morphInstance The morph instance managing morphing of this mesh instance, or null if morphing is not used.
  * @property {boolean} visible Enable rendering for this mesh instance. Use visible property to enable/disable rendering without overhead of removing from scene.
  * But note that the mesh instance is still in the hierarchy and still in the draw call list.
  * @property {GraphNode} node The graph node defining the transform for this instance.

--- a/src/scene/morph-instance.js
+++ b/src/scene/morph-instance.js
@@ -19,6 +19,8 @@ var textureMorphVertexShader =
  * @name MorphInstance
  * @classdesc An instance of {@link Morph}. Contains weights to assign to every {@link MorphTarget}, manages selection of active morph targets.
  * @param {Morph} morph - The {@link Morph} to instance.
+ * @property {MeshInstance} meshInstance The mesh instance this morph instance controls the morphing of.
+ * @property {Morph} morph The morph with its targets, which is being instanced.
  */
 class MorphInstance {
     constructor(morph) {

--- a/src/scene/morph.js
+++ b/src/scene/morph.js
@@ -222,6 +222,12 @@ class Morph extends RefCountedObject {
         this._targets.length = 0;
     }
 
+    /**
+     * @readonly
+     * @name Morph#targets
+     * @type {MorphTarget[]}
+     * @description The array of morph targets.
+     */
     get targets() {
         return this._targets;
     }

--- a/src/scene/morph.js
+++ b/src/scene/morph.js
@@ -222,6 +222,16 @@ class Morph extends RefCountedObject {
     }
 
     /**
+     * @readonly
+     * @name Morph#numTargets
+     * @type {number}
+     * @description Read-only property that returns number of targets of this morph. Access targets using {@link Morph#getTarget}.
+     */
+    get numTargets() {
+        return this._targets ? this._targets.length : 0;
+    }
+
+    /**
      * @function
      * @name Morph#getTarget
      * @description Gets the morph target by index.

--- a/src/scene/morph.js
+++ b/src/scene/morph.js
@@ -16,6 +16,7 @@ import { BUFFER_STATIC, TYPE_FLOAT32, SEMANTIC_ATTR15, ADDRESS_CLAMP_TO_EDGE, FI
  * @param {MorphTarget[]} targets - A list of morph targets.
  * @param {GraphicsDevice} graphicsDevice - The graphics device used to manage this morph target. If it is not provided, a device is obtained
  * from the {@link Application}.
+ * @property {MorphTarget} targets Gets an array of morph targets.
  */
 class Morph extends RefCountedObject {
     constructor(targets, graphicsDevice) {
@@ -221,25 +222,8 @@ class Morph extends RefCountedObject {
         this._targets.length = 0;
     }
 
-    /**
-     * @readonly
-     * @name Morph#numTargets
-     * @type {number}
-     * @description Read-only property that returns number of targets of this morph. Access targets using {@link Morph#getTarget}.
-     */
-    get numTargets() {
-        return this._targets ? this._targets.length : 0;
-    }
-
-    /**
-     * @function
-     * @name Morph#getTarget
-     * @description Gets the morph target by index.
-     * @param {number} index - An index of morph target.
-     * @returns {MorphTarget} A morph target object.
-     */
-    getTarget(index) {
-        return this._targets[index];
+    get targets() {
+        return this._targets;
     }
 
     _updateMorphFlags() {

--- a/src/scene/morph.js
+++ b/src/scene/morph.js
@@ -16,7 +16,6 @@ import { BUFFER_STATIC, TYPE_FLOAT32, SEMANTIC_ATTR15, ADDRESS_CLAMP_TO_EDGE, FI
  * @param {MorphTarget[]} targets - A list of morph targets.
  * @param {GraphicsDevice} graphicsDevice - The graphics device used to manage this morph target. If it is not provided, a device is obtained
  * from the {@link Application}.
- * @property {MorphTarget} targets Gets an array of morph targets.
  */
 class Morph extends RefCountedObject {
     constructor(targets, graphicsDevice) {


### PR DESCRIPTION
- viewer uses these functions, and they are useful in general when accessing for example morph target names on a loaded glb.

**new public API**:
- MeshInstance.morphInstance
- MorphInstance.meshInstance
- MorphInstance.morph
- Morph.targets

**deprecated API**:
- Morph.getTarget(index) - this is replaced by new Morph.targets.