### PR TITLE
findAvailableLocale refactor - Removed the static function from the API and added a member function

### DIFF
--- a/src/i18n/i18n.js
+++ b/src/i18n/i18n.js
@@ -42,17 +42,37 @@ class I18n extends EventHandler {
     }
 
     /**
+     * @private
      * @static
      * @function
      * @name I18n.findAvailableLocale
      * @description Returns the first available locale based on the desired locale specified. First
      * tries to find the desired locale and then tries to find an alternative locale based on the language.
-     * @param {string} desiredLocale - The desired locale e.g. En-US.
+     * @param {string} desiredLocale - The desired locale e.g. en-US.
      * @param {object} availableLocales - A dictionary where each key is an available locale.
      * @returns {string} The locale found or if no locale is available returns the default en-US locale.
+     * @example
+     * // With a defined dictionary of locales
+     * var availableLocales = { en: 'en-US', fr: 'fr-FR' };
+     * var locale = pc.I18n.getText('en-US', availableLocales);
+     * // returns 'en'
      */
     static findAvailableLocale(desiredLocale, availableLocales) {
         return findAvailableLocale(desiredLocale, availableLocales);
+    }
+
+    /**
+     * @function
+     * @name I18n#findAvailableLocale
+     * @description Returns the first available locale based on the desired locale specified. First
+     * tries to find the desired locale and then tries to find an alternative locale based on the language.
+     * @param {string} desiredLocale - The desired locale e.g. en-US.
+     * @returns {string} The locale found or if no locale is available returns the default en-US locale.
+     * @example
+     * var locale = this.app.i18n.getText('en-US');
+     */
+    findAvailableLocale(desiredLocale) {
+        return findAvailableLocale(desiredLocale, this._translations);
     }
 
     /**

--- a/src/i18n/i18n.js
+++ b/src/i18n/i18n.js
@@ -65,7 +65,8 @@ class I18n extends EventHandler {
      * @function
      * @name I18n#findAvailableLocale
      * @description Returns the first available locale based on the desired locale specified. First
-     * tries to find the desired locale and then tries to find an alternative locale based on the language.
+     * tries to find the desired locale in the loaded translations and then tries to find an alternative
+     * locale based on the language.
      * @param {string} desiredLocale - The desired locale e.g. en-US.
      * @returns {string} The locale found or if no locale is available returns the default en-US locale.
      * @example

--- a/src/i18n/i18n.js
+++ b/src/i18n/i18n.js
@@ -73,7 +73,12 @@ class I18n extends EventHandler {
      * var locale = this.app.i18n.getText('en-US');
      */
     findAvailableLocale(desiredLocale) {
-        return findAvailableLocale(desiredLocale, this._translations);
+        if (this._translations[desiredLocale]) {
+            return desiredLocale;
+        }
+
+        const lang = getLang(desiredLocale);
+        return this._findFallbackLocale(desiredLocale, lang);
     }
 
     /**

--- a/tests/i18n/test_i18n.js
+++ b/tests/i18n/test_i18n.js
@@ -772,4 +772,24 @@ describe('I18n tests', function () {
 
         expect(asset.getLocalizedAssetId('zh-SG')).to.equal(2);
     });
+
+    it('findAvailableLocale() should find locale if translations have been provided for it', function () {
+        addText('no-IT', 'key', 'norwegian');
+        expect(app.i18n.findAvailableLocale('no-IT')).to.equal('no-IT');
+    });
+
+    it('findAvailableLocale() should fallback to en-US if translations have not been provide for the desired locale', function () {
+        addText('no-IT', 'key', 'norwegian');
+        expect(app.i18n.findAvailableLocale('de-DE')).to.equal('en-US');
+    });
+
+    it('findAvailableLocale() should fallback to zh-CN if translations are provided and zh-SG is the desired locale', function () {
+        addText('zh-CN', 'key', 'Chinese');
+        expect(app.i18n.findAvailableLocale('zh-SG')).to.equal('zh-CN');
+    });
+
+    it('findAvailableLocale() should fallback to en-GB if translations are provided and en-US is the desired locale', function () {
+        addText('en-GB', 'key', 'British');
+        expect(app.i18n.findAvailableLocale('en-US')).to.equal('en-GB');
+    });
 });


### PR DESCRIPTION
Fixes https://forum.playcanvas.com/t/playcanvas-api-function-not-working/20738

I can't think why this was public as static function as the only way to use it would be to access private member properties on i18n.

Added a member version of the function that checks against loaded translations.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
