### PR TITLE
Shadow rendering fixes

### DIFF
--- a/src/graphics/program-lib/programs/standard.js
+++ b/src/graphics/program-lib/programs/standard.js
@@ -1062,9 +1062,11 @@ var standard = {
                 code += "uniform mat4 light" + i + "_shadowMatrix;\n";
 
                 // directional (cascaded) shadows
-                code += "uniform mat4 light" + i + "_shadowMatrixPalette[4];\n";
-                code += "uniform float light" + i + "_shadowCascadeDistances[4];\n";
-                code += "uniform float light" + i + "_shadowCascadeCount;\n";
+                if (lightType === LIGHTTYPE_DIRECTIONAL) {
+                    code += "uniform mat4 light" + i + "_shadowMatrixPalette[4];\n";
+                    code += "uniform float light" + i + "_shadowCascadeDistances[4];\n";
+                    code += "uniform float light" + i + "_shadowCascadeCount;\n";
+                }
 
                 if (lightType !== LIGHTTYPE_DIRECTIONAL) {
                     code += "uniform vec4 light" + i + "_shadowParams;\n"; // Width, height, bias, radius

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -914,6 +914,14 @@ class ForwardRenderer {
                     light.getBoundingSphere(tempSphere);
                     if (camera.frustum.containsSphere(tempSphere)) {
                         light.visibleThisFrame = true;
+                    } else {
+                        // if shadow casting light does not have shadow map allocated, mark it visible to allocate shadow map
+                        // Note: This won't be needed when clustered shadows are used, but at the moment even culled out lights
+                        // are used for rendering, and need shadow map to be allocated
+                        // TODO: delete this code when clusteredLightingEnabled is being removed and is on by default.
+                        if (light.castShadows && !light.shadowMap) {
+                            light.visibleThisFrame = true;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
- Fix for missing shadow map when light is not in the frustum, introduced by shadow code refactoring
- only include cascaded shadow uniforms for directional lights, as including it for all lights, even when not used, generates 'too many uniforms' when compiling shaders on some platforms (android at least)