### PR TITLE
Anim events fix

### DIFF
--- a/src/anim/evaluator/anim-clip.js
+++ b/src/anim/evaluator/anim-clip.js
@@ -129,7 +129,7 @@ class AnimClip {
             var loop = this._loop;
 
             // check for events that should fire during this frame
-            this.activeEventsForFrame(time, time + speed * deltaTime);
+            this._track.events.length > 0 && duration > 0 && this.activeEventsForFrame(time, time + speed * deltaTime);
 
             // update time
             time += speed * deltaTime;

--- a/src/anim/evaluator/anim-clip.js
+++ b/src/anim/evaluator/anim-clip.js
@@ -129,7 +129,9 @@ class AnimClip {
             var loop = this._loop;
 
             // check for events that should fire during this frame
-            this._track.events.length > 0 && duration > 0 && this.activeEventsForFrame(time, time + speed * deltaTime);
+            if (this._track.events.length > 0 && duration > 0) {
+                this.activeEventsForFrame(time, time + speed * deltaTime);
+            }
 
             // update time
             time += speed * deltaTime;


### PR DESCRIPTION
Resolves this forum bug report: https://forum.playcanvas.com/t/bug-animevents-causing-errors-in-engine-v1-43-0/20751/8

Anim clips should only check for events if it's track contains events and the clip has a non zero duration.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
