### PR TITLE
Ignore maxlines in linebreak logic on text elements

### DIFF
--- a/src/framework/components/element/text-element.js
+++ b/src/framework/components/element/text-element.js
@@ -751,7 +751,8 @@ class TextElement {
                 const isLineBreak = LINE_BREAK_CHAR.test(char);
                 if (isLineBreak) {
                     numBreaksThisLine++;
-                    if (this._maxLines < 0 || lines < this._maxLines) {
+                    // If we are not line wrapping then we should be ignoring maxlines
+                    if (!this._wrapLines || this._maxLines < 0 || lines < this._maxLines) {
                         breakLine(this._symbols, i, _xMinusTrailingWhitespace);
                         wordStartIndex = i + 1;
                         lineStartIndex = i + 1;


### PR DESCRIPTION
Fixes https://github.com/playcanvas/engine/issues/3250

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
