### PR TITLE
Support for KHR_lights_punctual extension

### DIFF
--- a/examples/src/examples/graphics/model-asset.tsx
+++ b/examples/src/examples/graphics/model-asset.tsx
@@ -28,7 +28,7 @@ class ModelAssetExample extends Example {
         app.start();
 
         // create an entity with render assets
-        const entity = assets.statue.resource.instantiateRenderEntity({
+        const entity = assets.statue.resource.instantiateModelEntity({
             castShadows: true
         });
 

--- a/src/framework/components/render/component.js
+++ b/src/framework/components/render/component.js
@@ -1,12 +1,10 @@
-import { RefCountedObject } from '../../../core/ref-counted-object.js';
-
 import { LAYERID_WORLD, RENDERSTYLE_SOLID } from '../../../scene/constants.js';
 import { BatchGroup } from '../../../scene/batching/batch-group.js';
 import { MeshInstance } from '../../../scene/mesh-instance.js';
-import { SkinInstance } from '../../../scene/skin-instance.js';
 import { MorphInstance } from '../../../scene/morph-instance.js';
 import { getShapePrimitive } from '../../../scene/procedural.js';
 import { GraphNode } from '../../../scene/graph-node.js';
+import { SkinInstanceCache } from '../../../scene/skin-instance-cache.js';
 
 import { Asset } from '../../../asset/asset.js';
 import { AssetReference } from '../../../asset/asset-reference.js';
@@ -14,15 +12,6 @@ import { AssetReference } from '../../../asset/asset-reference.js';
 import { Component } from '../component.js';
 
 import { EntityReference } from '../../utils/entity-reference.js';
-
-// Class used as an entry in the ref-counted skin instance cache
-class SkinInstanceCachedObject extends RefCountedObject {
-    constructor(skin, skinInstance) {
-        super();
-        this.skin = skin;
-        this.skinInstance = skinInstance;
-    }
-}
 
 /**
  * @component
@@ -111,106 +100,6 @@ class RenderComponent extends Component {
 
         entity.on('remove', this.onRemoveChild, this);
         entity.on('insert', this.onInsertChild, this);
-    }
-
-    // map of SkinInstances allowing those to be shared between render components
-    // (specifically a single glb with multiple render components)
-    // maps rootBone to an array of SkinInstanceCachedObject
-    // this allows to find if a skin instance already exists for a rootbone, and a specific skin
-    static _skinInstanceCache = new Map();
-
-    // #if _DEBUG
-    // function that logs out the state of the skin instances cache
-    static logCachedSkinInstances() {
-        console.log("CachedSkinInstances");
-        RenderComponent._skinInstanceCache.forEach(function (array, rootBone) {
-            console.log(rootBone.name + ': Array(' + array.length + ")");
-            for (let i = 0; i < array.length; i++) {
-                console.log("  " + i + ": RefCount " + array[i].getRefCount());
-            }
-        });
-    }
-    // #endif
-
-    // returns already created skin instance from skin, for use on the rootBone
-    // ref count of existing skinInstance is increased
-    static getCachedSkinInstance(skin, rootBone) {
-
-        let skinInstance = null;
-
-        // get an array of cached object for the rootBone
-        const cachedObjArray = RenderComponent._skinInstanceCache.get(rootBone);
-        if (cachedObjArray) {
-
-            // find matching skin
-            const cachedObj = cachedObjArray.find((element) => element.skin === skin);
-            if (cachedObj) {
-                cachedObj.incRefCount();
-                skinInstance = cachedObj.skinInstance;
-            }
-        }
-
-        return skinInstance;
-    }
-
-    // adds skin instance to the cache, and increases ref count on it
-    static addCachedSkinInstance(skin, rootBone, skinInstance) {
-
-        // get an array for the rootBone
-        let cachedObjArray = RenderComponent._skinInstanceCache.get(rootBone);
-        if (!cachedObjArray) {
-            cachedObjArray = [];
-            RenderComponent._skinInstanceCache.set(rootBone, cachedObjArray);
-        }
-
-        // find entry for the skin
-        let cachedObj = cachedObjArray.find((element) => element.skin === skin);
-        if (!cachedObj) {
-            cachedObj = new SkinInstanceCachedObject(skin, skinInstance);
-            cachedObjArray.push(cachedObj);
-        }
-
-        cachedObj.incRefCount();
-    }
-
-    // removes skin instance from the cache. This decreases ref count, and when that reaches 0 it gets destroyed
-    static removeCachedSkinInstance(skinInstance) {
-
-        if (skinInstance) {
-            const rootBone = skinInstance.rootBone;
-            if (rootBone) {
-
-                // an array for boot bone
-                const cachedObjArray = RenderComponent._skinInstanceCache.get(rootBone);
-                if (cachedObjArray) {
-
-                    // actual skin instance
-                    const cachedObjIndex = cachedObjArray.findIndex((element) => element.skinInstance === skinInstance);
-                    if (cachedObjIndex >= 0) {
-
-                        // dec ref on the object
-                        const cachedObj = cachedObjArray[cachedObjIndex];
-                        cachedObj.decRefCount();
-
-                        // last reference, needs to be destroyed
-                        if (cachedObj.getRefCount() === 0) {
-                            cachedObjArray.splice(cachedObjIndex, 1);
-
-                            // if the array is empty
-                            if (!cachedObjArray.length) {
-                                RenderComponent._skinInstanceCache.delete(rootBone);
-                            }
-
-                            // destroy the skin instance
-                            if (skinInstance) {
-                                skinInstance.destroy();
-                                cachedObj.skinInstance = null;
-                            }
-                        }
-                    }
-                }
-            }
-        }
     }
 
     _onSetRootBone(entity) {
@@ -418,7 +307,7 @@ class RenderComponent extends Component {
             const meshInstance = this._meshInstances[i];
 
             // remove it from the cache
-            RenderComponent.removeCachedSkinInstance(meshInstance.skinInstance);
+            SkinInstanceCache.removeCachedSkinInstance(meshInstance.skinInstance);
             meshInstance.skinInstance = null;
         }
     }
@@ -427,47 +316,13 @@ class RenderComponent extends Component {
 
         if (this._meshInstances.length && this._rootBone.entity instanceof GraphNode) {
 
-            var j, skin, skinInst;
-
-            for (var i = 0; i < this._meshInstances.length; i++) {
-                var meshInstance = this._meshInstances[i];
-                var mesh = meshInstance.mesh;
+            for (let i = 0; i < this._meshInstances.length; i++) {
+                const meshInstance = this._meshInstances[i];
+                const mesh = meshInstance.mesh;
 
                 // if skinned but does not have instance created yet
                 if (mesh.skin && !mesh.skinInstance) {
-
-                    skin = mesh.skin;
-                    const rootBone = this._rootBone.entity;
-
-                    // try and get skin instance from the cache
-                    skinInst = RenderComponent.getCachedSkinInstance(skin, rootBone);
-
-                    // don't have skin instance for this skin
-                    if (!skinInst) {
-
-                        skinInst = new SkinInstance(skin);
-                        skinInst.rootBone = rootBone;
-
-                        // add it to the cache
-                        RenderComponent.addCachedSkinInstance(skin, rootBone, skinInst);
-
-                        // Resolve bone IDs to actual graph nodes
-                        var bones = [];
-                        for (j = 0; j < skin.boneNames.length; j++) {
-                            var boneName = skin.boneNames[j];
-                            var bone = this._rootBone.entity.findByName(boneName);
-
-                            if (!bone) {
-                                console.error("Failed to find bone [" + boneName + "] in the entity hierarchy, RenderComponent on " + this.entity.name + ", rootBone: " + this._rootBone.entity.name);
-                                bone = this.entity;
-                            }
-
-                            bones.push(bone);
-                        }
-                        skinInst.bones = bones;
-                    }
-
-                    meshInstance.skinInstance = skinInst;
+                    meshInstance.skinInstance = SkinInstanceCache.createCachedSkinedInstance(mesh.skin, this._rootBone.entity, this.entity);
                 }
             }
         }

--- a/src/resources/parser/glb-model.js
+++ b/src/resources/parser/glb-model.js
@@ -1,4 +1,5 @@
 import { Material } from '../../scene/materials/material.js';
+import { ContainerResource } from '../container.js';
 import { GlbParser } from './glb-parser.js';
 
 class GlbModelParser {
@@ -11,7 +12,7 @@ class GlbModelParser {
         if (!glb) {
             return null;
         }
-        return GlbParser.createModel(glb, Material.defaultMaterial);
+        return ContainerResource.createModel(glb, Material.defaultMaterial);
     }
 }
 

--- a/src/resources/parser/glb-parser.js
+++ b/src/resources/parser/glb-parser.js
@@ -1377,7 +1377,7 @@ const createLight = function (gltfLight, node) {
         type: gltfLight.type === "point" ? "omni" : gltfLight.type,
         color: gltfLight.hasOwnProperty('color') ? new Color(gltfLight.color) : Color.WHITE,
         range: gltfLight.hasOwnProperty('range') ? gltfLight.range : Number.MAX_VALUE,
-        falloffMode: LIGHTFALLOFF_INVERSESQUARED,
+        falloffMode: LIGHTFALLOFF_INVERSESQUARED
     };
 
     // TODO: (engine issue #3252) Set intensity to match glTF specification, which uses physically based values:

--- a/src/resources/parser/glb-parser.js
+++ b/src/resources/parser/glb-parser.js
@@ -1772,7 +1772,7 @@ const loadTexturesAsync = function (gltf, bufferViews, urlBase, registry, option
                     applySampler(textureAsset.resource, (gltf.samplers || [])[gltf.textures[textureIndex].sampler]);
                     result[textureIndex] = textureAsset;
                     if (postprocess) {
-                        postprocess(gltf.textures[index], textureAsset);
+                        postprocess(gltf.textures[textureIndex], textureAsset);
                     }
                 });
             });

--- a/src/resources/parser/glb-parser.js
+++ b/src/resources/parser/glb-parser.js
@@ -1377,16 +1377,14 @@ const createLight = function (gltfLight, node) {
         type: gltfLight.type === "point" ? "omni" : gltfLight.type,
         color: gltfLight.hasOwnProperty('color') ? new Color(gltfLight.color) : Color.WHITE,
         range: gltfLight.hasOwnProperty('range') ? gltfLight.range : Number.MAX_VALUE,
-        falloffMode: LIGHTFALLOFF_INVERSESQUARED
-    };
+        falloffMode: LIGHTFALLOFF_INVERSESQUARED,
 
-    // TODO: (engine issue #3252) Set intensity to match glTF specification, which uses physically based values:
-    // - Omni and spot lights use luminous intensity in candela (lm/sr)
-    // - Directional lights use illuminance in lux (lm/m2).
-    lightProps.intensity = 1;
-    if (gltfLight.hasOwnProperty('intensity')) {
-        lightProps.intensity = gltfLight.intensity > 0 ? 1 : 0;
-    }
+        // TODO: (engine issue #3252) Set intensity to match glTF specification, which uses physically based values:
+        // - Omni and spot lights use luminous intensity in candela (lm/sr)
+        // - Directional lights use illuminance in lux (lm/m2).
+        // Current implementation: clapms specified intensity to 0..2 range
+        intensity: gltfLight.hasOwnProperty('intensity') ? math.clamp(gltfLight.intensity, 0, 2) : 1
+    };
 
     if (gltfLight.hasOwnProperty('spot')) {
         lightProps.innerConeAngle = gltfLight.spot.hasOwnProperty('innerConeAngle') ? gltfLight.spot.innerConeAngle * math.RAD_TO_DEG : 0;

--- a/src/resources/parser/glb-parser.js
+++ b/src/resources/parser/glb-parser.js
@@ -2,9 +2,11 @@ import { path } from '../../core/path.js';
 
 import { http } from '../../net/http.js';
 
+import { math } from '../../math/math.js';
 import { Mat4 } from '../../math/mat4.js';
 import { Vec2 } from '../../math/vec2.js';
 import { Vec3 } from '../../math/vec3.js';
+import { Color } from '../../math/color.js';
 
 import { BoundingBox } from '../../shape/bounding-box.js';
 
@@ -25,20 +27,18 @@ import { VertexBuffer } from '../../graphics/vertex-buffer.js';
 import { VertexFormat } from '../../graphics/vertex-format.js';
 
 import {
-    BLEND_NONE, BLEND_NORMAL
+    BLEND_NONE, BLEND_NORMAL, LIGHTFALLOFF_INVERSESQUARED
 } from '../../scene/constants.js';
 import { calculateNormals } from '../../scene/procedural.js';
 import { GraphNode } from '../../scene/graph-node.js';
 import { Mesh } from '../../scene/mesh.js';
-import { MeshInstance } from '../../scene/mesh-instance.js';
-import { Model } from '../../scene/model.js';
 import { Morph } from '../../scene/morph.js';
-import { MorphInstance } from '../../scene/morph-instance.js';
 import { MorphTarget } from '../../scene/morph-target.js';
 import { Skin } from '../../scene/skin.js';
-import { SkinInstance } from '../../scene/skin-instance.js';
 import { StandardMaterial } from '../../scene/materials/standard-material.js';
 import { Render } from '../../scene/render.js';
+
+import { Entity } from '../../framework/entity.js';
 
 import { AnimCurve } from '../../anim/evaluator/anim-curve.js';
 import { AnimData } from '../../anim/evaluator/anim-data.js';
@@ -1370,6 +1370,40 @@ const createNode = function (gltfNode, nodeIndex) {
     return entity;
 };
 
+// creates light component, adds it to the node and returns the created light component
+const createLight = function (gltfLight, node) {
+
+    const lightProps = {
+        type: gltfLight.type === "point" ? "omni" : gltfLight.type,
+        color: gltfLight.hasOwnProperty('color') ? new Color(gltfLight.color) : Color.WHITE,
+        range: gltfLight.hasOwnProperty('range') ? gltfLight.range : Number.MAX_VALUE,
+        falloffMode: LIGHTFALLOFF_INVERSESQUARED,
+    };
+
+    // TODO: (engine issue #3252) Set intensity to match glTF specification, which uses physically based values:
+    // - Omni and spot lights use luminous intensity in candela (lm/sr)
+    // - Directional lights use illuminance in lux (lm/m2).
+    lightProps.intensity = 1;
+    if (gltfLight.hasOwnProperty('intensity')) {
+        lightProps.intensity = gltfLight.intensity > 0 ? 1 : 0;
+    }
+
+    if (gltfLight.hasOwnProperty('spot')) {
+        lightProps.innerConeAngle = gltfLight.spot.hasOwnProperty('innerConeAngle') ? gltfLight.spot.innerConeAngle * math.RAD_TO_DEG : 0;
+        lightProps.outerConeAngle = gltfLight.spot.hasOwnProperty('outerConeAngle') ? gltfLight.spot.outerConeAngle * math.RAD_TO_DEG : Math.PI / 4;
+    }
+
+    // Rotate to match light orientation in glTF specification
+    // Note that this adds a new entity node into the hierarchy that does not exist in the gltf hierarchy
+    var lightNode = new Entity(node.name);
+    lightNode.rotateLocal(90, 0, 0);
+
+    // add component
+    lightNode.addComponent("light", lightProps);
+
+    return lightNode;
+};
+
 const createSkins = function (device, gltf, nodes, bufferViews) {
     if (!gltf.hasOwnProperty('skins') || gltf.skins.length === 0) {
         return [];
@@ -1503,6 +1537,51 @@ const createScenes = function (gltf, nodes) {
     return scenes;
 };
 
+const createLights = function (gltf, nodes, options) {
+
+    let lights = null;
+
+    if (gltf.hasOwnProperty('nodes') && gltf.hasOwnProperty('extensions') &&
+        gltf.extensions.hasOwnProperty('KHR_lights_punctual') && gltf.extensions.KHR_lights_punctual.hasOwnProperty('lights')) {
+
+        const gltfLights = gltf.extensions.KHR_lights_punctual.lights;
+        if (gltfLights.length) {
+
+            const preprocess = options && options.light && options.light.preprocess;
+            const process = options && options.light && options.light.process || createLight;
+            const postprocess = options && options.light && options.light.postprocess;
+
+            // handle nodes with lights
+            gltf.nodes.forEach(function (gltfNode, nodeIndex) {
+                if (gltfNode.hasOwnProperty('extensions') &&
+                    gltfNode.extensions.hasOwnProperty('KHR_lights_punctual') &&
+                    gltfNode.extensions.KHR_lights_punctual.hasOwnProperty('light')) {
+
+                    const lightIndex = gltfNode.extensions.KHR_lights_punctual.light;
+                    const gltfLight = gltfLights[lightIndex];
+                    if (gltfLight) {
+                        if (preprocess) {
+                            preprocess(gltfLight);
+                        }
+                        const light = process(gltfLight, nodes[nodeIndex]);
+                        if (postprocess) {
+                            postprocess(gltfLight, light);
+                        }
+
+                        // add the light to node->light map
+                        if (light) {
+                            if (!lights) lights = new Map();
+                            lights.set(gltfNode, light);
+                        }
+                    }
+                }
+            });
+        }
+    }
+
+    return lights;
+};
+
 // create engine resources from the downloaded GLB data
 const createResources = function (device, gltf, bufferViews, textureAssets, options, callback) {
     const preprocess = options && options.global && options.global.preprocess;
@@ -1519,6 +1598,7 @@ const createResources = function (device, gltf, bufferViews, textureAssets, opti
 
     const nodes = createNodes(gltf, options);
     const scenes = createScenes(gltf, nodes);
+    const lights = createLights(gltf, nodes, options);
     const animations = createAnimations(gltf, nodes, bufferViews, options);
     const materials = createMaterials(gltf, textureAssets.map(function (textureAsset) {
         return textureAsset.resource;
@@ -1541,7 +1621,8 @@ const createResources = function (device, gltf, bufferViews, textureAssets, opti
         'textures': textureAssets,
         'materials': materials,
         'renders': renders,
-        'skins': skins
+        'skins': skins,
+        'lights': lights
     };
 
     if (postprocess) {
@@ -2048,80 +2129,6 @@ class GlbParser {
         });
 
         return result;
-    }
-
-    // create a pc.Model from the parsed GLB data structures
-    static createModel(glb, defaultMaterial) {
-
-        const createMeshInstance = function (model, mesh, skins, skinInstances, materials, node, gltfNode) {
-            const material = (mesh.materialIndex === undefined) ? defaultMaterial : materials[mesh.materialIndex];
-            const meshInstance = new MeshInstance(mesh, material, node);
-
-            if (mesh.morph) {
-                const morphInstance = new MorphInstance(mesh.morph);
-                if (mesh.weights) {
-                    for (let wi = 0; wi < mesh.weights.length; wi++) {
-                        morphInstance.setWeight(wi, mesh.weights[wi]);
-                    }
-                }
-
-                meshInstance.morphInstance = morphInstance;
-                model.morphInstances.push(morphInstance);
-            }
-
-            if (gltfNode.hasOwnProperty('skin')) {
-                const skinIndex = gltfNode.skin;
-                const skin = skins[skinIndex];
-                mesh.skin = skin;
-
-                const skinInstance = skinInstances[skinIndex];
-                meshInstance.skinInstance = skinInstance;
-                model.skinInstances.push(skinInstance);
-            }
-
-            model.meshInstances.push(meshInstance);
-        };
-
-        const model = new Model();
-
-        // create skinInstance for each skin
-        const skinInstances = [];
-        for (const skin of glb.skins) {
-            const skinInstance = new SkinInstance(skin);
-            skinInstance.bones = skin.bones;
-            skinInstances.push(skinInstance);
-        }
-
-        // node hierarchy for the model
-        if (glb.scenes.length === 1) {
-            // use scene if only one
-            model.graph = glb.scenes[0];
-        } else {
-            // create group node for all scenes
-            model.graph = new GraphNode('SceneGroup');
-            for (const scene of glb.scenes) {
-                model.graph.addChild(scene);
-            }
-        }
-
-        // create mesh instance for meshes on nodes that are part of hierarchy
-        for (let i = 0; i < glb.nodes.length; i++) {
-            const node = glb.nodes[i];
-            if (node.root === model.graph) {
-                const gltfNode = glb.gltf.nodes[i];
-                if (gltfNode.hasOwnProperty('mesh')) {
-                    const meshGroup = glb.renders[gltfNode.mesh].meshes;
-                    for (var mi = 0; mi < meshGroup.length; mi++) {
-                        const mesh = meshGroup[mi];
-                        if (mesh) {
-                            createMeshInstance(model, mesh, glb.skins, skinInstances, glb.materials, node, gltfNode);
-                        }
-                    }
-                }
-            }
-        }
-
-        return model;
     }
 }
 

--- a/src/scene/skin-instance-cache.js
+++ b/src/scene/skin-instance-cache.js
@@ -25,7 +25,7 @@ class SkinInstanceCache {
         SkinInstanceCache._skinInstanceCache.forEach(function (array, rootBone) {
             console.log(rootBone.name + ': Array(' + array.length + ")");
             for (let i = 0; i < array.length; i++) {
-                console.log("  " + i + ": RefCount " + array[i].getRefCount());
+                console.log(`  ${i}: RefCount ${array[i].getRefCount()}`);
             }
         });
     }

--- a/src/scene/skin-instance-cache.js
+++ b/src/scene/skin-instance-cache.js
@@ -1,0 +1,136 @@
+import { RefCountedObject } from '../core/ref-counted-object.js';
+import { SkinInstance } from './skin-instance.js';
+
+// Class used as an entry in the ref-counted skin instance cache
+class SkinInstanceCachedObject extends RefCountedObject {
+    constructor(skin, skinInstance) {
+        super();
+        this.skin = skin;
+        this.skinInstance = skinInstance;
+    }
+}
+
+// Pure static class, implementing the cache of skin instances used by render component.
+class SkinInstanceCache {
+    // map of SkinInstances allowing those to be shared between
+    // (specifically a single glb with multiple render components)
+    // It maps a rootBone to an array of SkinInstanceCachedObject
+    // this allows us to find if a skin instance already exists for a rootbone, and a specific skin
+    static _skinInstanceCache = new Map();
+
+    // #if _DEBUG
+    // function that logs out the state of the skin instances cache
+    static logCachedSkinInstances() {
+        console.log("CachedSkinInstances");
+        SkinInstanceCache._skinInstanceCache.forEach(function (array, rootBone) {
+            console.log(rootBone.name + ': Array(' + array.length + ")");
+            for (let i = 0; i < array.length; i++) {
+                console.log("  " + i + ": RefCount " + array[i].getRefCount());
+            }
+        });
+    }
+    // #endif
+
+    // returns cached or creates a skin instance for the skin and a rootBone, to be used by render component
+    // on the specified entity
+    static createCachedSkinedInstance(skin, rootBone, entity) {
+
+        // try and get skin instance from the cache
+        let skinInst = SkinInstanceCache.getCachedSkinInstance(skin, rootBone);
+
+        // don't have skin instance for this skin
+        if (!skinInst) {
+
+            skinInst = new SkinInstance(skin);
+            skinInst.resolve(rootBone, entity);
+
+            // add it to the cache
+            SkinInstanceCache.addCachedSkinInstance(skin, rootBone, skinInst);
+        }
+
+        return skinInst;
+    }
+
+    // returns already created skin instance from skin, for use on the rootBone
+    // ref count of existing skinInstance is increased
+    static getCachedSkinInstance(skin, rootBone) {
+
+        let skinInstance = null;
+
+        // get an array of cached object for the rootBone
+        const cachedObjArray = SkinInstanceCache._skinInstanceCache.get(rootBone);
+        if (cachedObjArray) {
+
+            // find matching skin
+            const cachedObj = cachedObjArray.find((element) => element.skin === skin);
+            if (cachedObj) {
+                cachedObj.incRefCount();
+                skinInstance = cachedObj.skinInstance;
+            }
+        }
+
+        return skinInstance;
+    }
+
+    // adds skin instance to the cache, and increases ref count on it
+    static addCachedSkinInstance(skin, rootBone, skinInstance) {
+
+        // get an array for the rootBone
+        let cachedObjArray = SkinInstanceCache._skinInstanceCache.get(rootBone);
+        if (!cachedObjArray) {
+            cachedObjArray = [];
+            SkinInstanceCache._skinInstanceCache.set(rootBone, cachedObjArray);
+        }
+
+        // find entry for the skin
+        let cachedObj = cachedObjArray.find((element) => element.skin === skin);
+        if (!cachedObj) {
+            cachedObj = new SkinInstanceCachedObject(skin, skinInstance);
+            cachedObjArray.push(cachedObj);
+        }
+
+        cachedObj.incRefCount();
+    }
+
+    // removes skin instance from the cache. This decreases ref count, and when that reaches 0 it gets destroyed
+    static removeCachedSkinInstance(skinInstance) {
+
+        if (skinInstance) {
+            const rootBone = skinInstance.rootBone;
+            if (rootBone) {
+
+                // an array for boot bone
+                const cachedObjArray = SkinInstanceCache._skinInstanceCache.get(rootBone);
+                if (cachedObjArray) {
+
+                    // actual skin instance
+                    const cachedObjIndex = cachedObjArray.findIndex((element) => element.skinInstance === skinInstance);
+                    if (cachedObjIndex >= 0) {
+
+                        // dec ref on the object
+                        const cachedObj = cachedObjArray[cachedObjIndex];
+                        cachedObj.decRefCount();
+
+                        // last reference, needs to be destroyed
+                        if (cachedObj.getRefCount() === 0) {
+                            cachedObjArray.splice(cachedObjIndex, 1);
+
+                            // if the array is empty
+                            if (!cachedObjArray.length) {
+                                SkinInstanceCache._skinInstanceCache.delete(rootBone);
+                            }
+
+                            // destroy the skin instance
+                            if (skinInstance) {
+                                skinInstance.destroy();
+                                cachedObj.skinInstance = null;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+export { SkinInstanceCache };

--- a/src/scene/skin-instance-cache.js
+++ b/src/scene/skin-instance-cache.js
@@ -23,7 +23,7 @@ class SkinInstanceCache {
     static logCachedSkinInstances() {
         console.log("CachedSkinInstances");
         SkinInstanceCache._skinInstanceCache.forEach(function (array, rootBone) {
-            console.log(rootBone.name + ': Array(' + array.length + ")");
+            console.log(`${rootBone.name}: Array(${array.length})`);
             for (let i = 0; i < array.length; i++) {
                 console.log(`  ${i}: RefCount ${array[i].getRefCount()}`);
             }

--- a/src/scene/skin-instance.js
+++ b/src/scene/skin-instance.js
@@ -90,7 +90,9 @@ class SkinInstance {
             var bone = rootBone.findByName(boneName);
 
             if (!bone) {
-                console.error("Failed to find bone [" + boneName + "] in the entity hierarchy, RenderComponent on " + entity.name + ", rootBone: " + rootBone.entity.name);
+                // #if _DEBUG
+                console.error(`Failed to find bone [${boneName}] in the entity hierarchy, RenderComponent on ${entity.name}, rootBone: ${rootBone.entity.name}`);
+                // #endif
                 bone = entity;
             }
 

--- a/src/scene/skin-instance.js
+++ b/src/scene/skin-instance.js
@@ -77,7 +77,7 @@ class SkinInstance {
     }
 
     // resolved skin bones to a hierarchy with the rootBone at its root.
-    // entity parameter specifies the entity used if the bone match is not found in the hierarhy - usually the entity the render component is attached to
+    // entity parameter specifies the entity used if the bone match is not found in the hierarchy - usually the entity the render component is attached to
     resolve(rootBone, entity) {
 
         this.rootBone = rootBone;

--- a/src/scene/skin-instance.js
+++ b/src/scene/skin-instance.js
@@ -76,6 +76,29 @@ class SkinInstance {
         this._rootBone = rootBone;
     }
 
+    // resolved skin bones to a hierarchy with the rootBone at its root.
+    // entity parameter specifies the entity used if the bone match is not found in the hierarhy - usually the entity the render component is attached to
+    resolve(rootBone, entity) {
+
+        this.rootBone = rootBone;
+
+        // Resolve bone IDs to actual graph nodes of the hierarchy
+        const skin = this.skin;
+        const  bones = [];
+        for (let j = 0; j < skin.boneNames.length; j++) {
+            var boneName = skin.boneNames[j];
+            var bone = rootBone.findByName(boneName);
+
+            if (!bone) {
+                console.error("Failed to find bone [" + boneName + "] in the entity hierarchy, RenderComponent on " + entity.name + ", rootBone: " + rootBone.entity.name);
+                bone = entity;
+            }
+
+            bones.push(bone);
+        }
+        this.bones = bones;
+    }
+
     initSkin(skin) {
 
         this.skin = skin;


### PR DESCRIPTION
- Added support for KHR_lights_punctual extension https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Khronos/KHR_lights_punctual
- Note of the limitation: https://github.com/playcanvas/engine/issues/3252 causing light intensities to be clamped to 0..1 range
- Note that lights are supported only when creating hierarchy with render components using **instantiateRenderEntity**, but not when using model components using **instantiateModelEntity**
- The instance of the model is no longer created when a glb file is loaded, and is created and cached on the fly only when needed
- render component hierarchy is being created from parsed glb file directly with no dependency on the Model being created (and so if user uses Renders, the Model does not get created at all)
- moved SkinInstanceCache to separate file to share it between render component and glb creating one.
- moved GlbParser.CreateModel to ContainerResource.

Fixes https://github.com/playcanvas/engine/issues/2061

**Example** on how to create lights from loaded glb container (the same as creating hierarchy with renders):
`const lightsEntity = assets.lights.resource.instantiateRenderEntity();`

lights can be processed this way:
```
const lights = lightsEntity.findComponents("light");
lights.forEach((light) => {
    light.enabled = false;
});
```

Thanks to @godiagonal for initial implementation here: https://github.com/playcanvas/engine/pull/2385