### PR TITLE
Example list file

### DIFF
--- a/examples/example-directory.js
+++ b/examples/example-directory.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 
+let categoriesList = [];
 let categoriesString = '';
 let categoriesCounter = 0;
 let examplesCounter = 0;
@@ -14,20 +15,24 @@ fs.readdir(`${__dirname}/src/examples/`, function (err, categories) {
             fs.mkdirSync(dir);
         }
         fs.readdir(`${__dirname}/src/examples/${category}`, (err, examples) => {
+            examples = examples.map((example) => example.replace('.tsx', ''));
+            categoriesList.push({
+                name: category,
+                examples
+            });
             if (err) {
                 return console.log('Unable to scan directory: ' + err);
             }
             categoriesString += `<h2>${category}</h2>`;
             examplesCounter += examples.length;
-            examples.forEach((e) => {
-                const example = e.replace('.tsx', '');
+            examples.forEach((example) => {
                 categoriesString += `<li><a href='/#/iframe/${category}/${example}'>${example}</a></li>`;
                 examplesCounter--;
                 if (examplesCounter === 0) {
-                    // categoriesString += '</ul>';
                     categoriesCounter--;
                     if (categoriesCounter === 0) {
                         createIframeDirectory();
+                        createCategoriesListFile();
                     }
                 }
                 const content = `
@@ -78,6 +83,17 @@ function createIframeDirectory() {
         fs.mkdirSync(dir);
     }
     fs.writeFile(`dist/iframes/index.html`, iframeDirectoryHtml, (err) => {
+        if (err) {
+            console.error(err);
+            return null;
+        }
+    });
+}
+
+function createCategoriesListFile() {
+    const text = `/* eslint-disable no-unused-vars */
+var categories = ${JSON.stringify(categoriesList)};`;
+    fs.writeFile(`dist/examples.js`, text, (err) => {
         if (err) {
             console.error(err);
             return null;


### PR DESCRIPTION
This PR reintroduces the `examples.js` file to the examples browser. This file is now automatically generated as part of the `examples-directory.js` script with the same format as before:
```javascript
/* eslint-disable no-unused-vars */
var categories = [
       {
            "name":  "<category>",
            "examples": [
                   "<example>"
            ]
       }
];
```

This file is generated in the `dist` folder.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
