### PR TITLE
Clustered lighting does not use lights with intensity of zero

### DIFF
--- a/src/scene/world-clusters.js
+++ b/src/scene/world-clusters.js
@@ -485,7 +485,7 @@ class WorldClusters {
 
             // use enabled and visible lights
             const light = lights[i];
-            if (light.enabled && light.type !== LIGHTTYPE_DIRECTIONAL && light.visibleThisFrame) {
+            if (light.enabled && light.type !== LIGHTTYPE_DIRECTIONAL && light.visibleThisFrame && light.intensity > 0) {
 
                 // within light limit
                 if (lightIndex < this.maxLights) {


### PR DESCRIPTION
- small optimization to avoid having to enable / disable light which has higher cost. Intensity can instead be set to 0.