### PR TITLE
Basis lazyInit

### DIFF
--- a/src/deprecated.js
+++ b/src/deprecated.js
@@ -108,6 +108,7 @@ import {
 } from './framework/components/rigid-body/constants.js';
 import { RigidBodyComponent } from './framework/components/rigid-body/component.js';
 import { RigidBodyComponentSystem } from './framework/components/rigid-body/system.js';
+import { basisInitialize } from './resources/basis.js';
 
 // CORE
 
@@ -1067,3 +1068,14 @@ RigidBodyComponentSystem.prototype.setGravity = function () {
         this.gravity.set(arguments[0], arguments[1], arguments[2]);
     }
 };
+
+export function basisSetDownloadConfig(glueUrl, wasmUrl, fallbackUrl) {
+    // #if _DEBUG
+    console.warn('DEPRECATED: pc.basisSetDownloadConfig is deprecated. Use pc.basisInitialize instead.');
+    // #endif
+    basisInitialize({
+        glueUrl: glueUrl,
+        wasmUrl: wasmUrl,
+        fallbackUrl: fallbackUrl
+    });
+}

--- a/src/deprecated.js
+++ b/src/deprecated.js
@@ -1076,6 +1076,7 @@ export function basisSetDownloadConfig(glueUrl, wasmUrl, fallbackUrl) {
     basisInitialize({
         glueUrl: glueUrl,
         wasmUrl: wasmUrl,
-        fallbackUrl: fallbackUrl
+        fallbackUrl: fallbackUrl,
+        lazyInit: true
     });
 }

--- a/src/resources/basis.js
+++ b/src/resources/basis.js
@@ -228,8 +228,8 @@ let initializing = false;
  * @param {string} [config.glueUrl] - URL of glue script.
  * @param {string} [config.wasmUrl] - URL of the wasm module.
  * @param {string} [config.fallbackUrl] - URL of the fallback script to use when wasm modules aren't supported.
- * @param {boolean} [config.lazyInit] - Wait for first transcode request before initializing basis
- * (default is false). Otherwise initialize basis immediately.
+ * @param {boolean} [config.lazyInit] - Wait for first transcode request before initializing Basis
+ * (default is false). Otherwise initialize Basis immediately.
  * @param {number} [config.numWorkers] - Number of workers to use for transcoding (default is 1). While it is
  * possible to improve transcode performance using multiple workers, this will likely depend on the runtime
  * platform. For example, desktop will likely benefit from more workers compared to mobile. Also


### PR DESCRIPTION
This PR follows on from #3277. It introduces the following changes:
- add lazyInit flag to `basisInitialize` config
- add the deprecated `basisSetDownloadConfig` function

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
