### PR TITLE
[FIX] Handle inf on windows correctly

### DIFF
--- a/src/graphics/program-lib/chunks/TBNderivative.frag
+++ b/src/graphics/program-lib/chunks/TBNderivative.frag
@@ -15,6 +15,7 @@ void getTBN() {
     vec3 B = dp2perp * duv1.y + dp1perp * duv2.y;
 
     // construct a scale-invariant frame
-    float invmax = 1.0 / sqrt( max( dot(T,T), dot(B,B) ) );
+    float denom = max( dot(T,T), dot(B,B) );
+    float invmax = (denom == 0.0) ? 0.0 : 1.0 / sqrt( denom );
     dTBN = mat3( T * invmax, B * invmax, dVertexNormalW );
 }


### PR DESCRIPTION
Fixes an issue where reflective materials were rendering incorrectly on windows and linux.

The cause was a difference in the result of a shader multiplication when one of the operands are infinity. On mac and mobile `0.0 * inf == 0`, but on windows and linux not (presumably infinity propagates or result is nan).

The fix is to test for this case upfront.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
