### PR TITLE
Bind assets to material fix - Fixes an issue that shows in Editor when changing textures

### DIFF
--- a/src/resources/material.js
+++ b/src/resources/material.js
@@ -238,7 +238,14 @@ class MaterialHandler {
 
             // data[name] contains an asset id for a texture
             // if we have an asset id and nothing is assigned to the texture resource or the placeholder texture is assigned
-            if (data[name] && (!materialAsset.resource[name] || materialAsset.resource[name] === this._getPlaceholderTexture(name, materialAsset))) {
+            // or the data has changed
+            const dataAssetId = data[name];
+
+            const materialTexture = material[name];
+            const dataValidated = data.validated;
+            const isPlaceHolderTexture = materialTexture === this._getPlaceholderTexture(name, materialAsset);
+
+            if (dataAssetId && (!materialTexture || !dataValidated || isPlaceHolderTexture)) {
                 if (!assetReference) {
                     assetReference = new AssetReference(name, materialAsset, assets, {
                         load: this._onTextureLoad,
@@ -252,9 +259,9 @@ class MaterialHandler {
 
                 if (pathMapping) {
                     // texture paths are measured from the material directory
-                    assetReference.url = materialAsset.getAbsoluteUrl(data[name]);
+                    assetReference.url = materialAsset.getAbsoluteUrl(dataAssetId);
                 } else {
-                    assetReference.id = data[name];
+                    assetReference.id = dataAssetId;
                 }
 
                 if (assetReference.asset) {

--- a/src/resources/material.js
+++ b/src/resources/material.js
@@ -242,8 +242,8 @@ class MaterialHandler {
             const dataAssetId = data[name];
 
             const materialTexture = material[name];
-            const dataValidated = data.validated;
             const isPlaceHolderTexture = materialTexture === this._getPlaceholderTexture(name, materialAsset);
+            const dataValidated = data.validated;
 
             if (dataAssetId && (!materialTexture || !dataValidated || isPlaceHolderTexture)) {
                 if (!assetReference) {


### PR DESCRIPTION
Fixes https://github.com/playcanvas/engine/issues/3294

Context of fix: https://github.com/playcanvas/engine/issues/3294#issuecomment-874154144

Tested against the original issue that the commit fixed: https://github.com/playcanvas/engine/issues/3061

As far as I can tell, the data is not validated the first time `_bindAndAssignAssets` is called with new data (such as those coming from the Editor) so we can use this flag to know if this is the first time we have binded this data.

Part of me is not keen on using this flag as if we change the order of this function to validate the data first, this issue will reappear.

@vkalpias Can you see any issues/edge cases with this?

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
