### PR TITLE
Destroy all lightmaps when the Application is destroyed

### DIFF
--- a/src/core/ref-counted-cache.js
+++ b/src/core/ref-counted-cache.js
@@ -8,6 +8,15 @@ class RefCountedCache {
         this.cache = new Map();
     }
 
+    // destroy all stored objects
+    destroy() {
+        console.log("RefCountedCache destroy");
+        this.cache.forEach((refCount, lightmap) => {
+            lightmap.destroy();
+        });
+        this.cache.clear();
+    }
+
     // add object reference to the cache
     incRef(object) {
         const refCount = (this.cache.get(object) || 0) + 1;

--- a/src/core/ref-counted-cache.js
+++ b/src/core/ref-counted-cache.js
@@ -10,9 +10,8 @@ class RefCountedCache {
 
     // destroy all stored objects
     destroy() {
-        console.log("RefCountedCache destroy");
-        this.cache.forEach((refCount, lightmap) => {
-            lightmap.destroy();
+        this.cache.forEach((refCount, object) => {
+            object.destroy();
         });
         this.cache.clear();
     }

--- a/src/scene/lightmapper.js
+++ b/src/scene/lightmapper.js
@@ -155,6 +155,9 @@ class Lightmapper {
         MeshInstance.decRefLightmap(this.blackTex);
         this.blackTex = null;
 
+        // destroy all lightmaps
+        MeshInstance.destroyLightmapCache();
+
         this.device = null;
         this.root = null;
         this.scene = null;

--- a/src/scene/mesh-instance.js
+++ b/src/scene/mesh-instance.js
@@ -186,6 +186,11 @@ class MeshInstance {
         this._lightmapCache.decRef(texture);
     }
 
+    static destroyLightmapCache() {
+        this._lightmapCache.destroy();
+        this._lightmapCache = null;
+    }
+
     get renderStyle() {
         return this._renderStyle;
     }

--- a/src/scene/mesh-instance.js
+++ b/src/scene/mesh-instance.js
@@ -188,7 +188,6 @@ class MeshInstance {
 
     static destroyLightmapCache() {
         this._lightmapCache.destroy();
-        this._lightmapCache = null;
     }
 
     get renderStyle() {


### PR DESCRIPTION
Fixes https://github.com/playcanvas/engine/pull/1645

When the application is destroyed, it destroys all lightmaps stored in the cache. This should not make any difference, but it's nice to destroy internally allocated engine resources.

Note that the issue mentions shadow maps not getting released - this has been addressed about a month ago when refactoring shadow rendering.