### PR TITLE
[Examples Browser] Code editor horizontal scrollbar fix

### DIFF
--- a/examples/src/app/code-editor.tsx
+++ b/examples/src/app/code-editor.tsx
@@ -64,10 +64,15 @@ const CodeEditor = (props: CodeEditorProps) => {
     };
 
     useEffect(() => {
+        const codePane = document.getElementById('codePane');
+        if (files.length > 1) {
+            codePane.classList.add('multiple-files');
+        } else {
+            codePane.classList.remove('multiple-files');
+        }
         if (!files[selectedFile]) setSelectedFile(0);
         if ((window as any).toggleEvent) return;
         // set up the code panel toggle button
-        const codePane = document.getElementById('codePane');
         const panelToggleDiv = codePane.querySelector('.panel-toggle');
         panelToggleDiv.addEventListener('click', function () {
             codePane.classList.toggle('collapsed');
@@ -91,6 +96,11 @@ const CodeEditor = (props: CodeEditorProps) => {
             onMount={editorDidMount}
             onChange={onChange}
             onValidate={onValidate}
+            options={{
+                scrollbar: {
+                    horizontal: 'visible'
+                }
+            }}
         />
     </Panel>;
 };

--- a/examples/src/app/styles.css
+++ b/examples/src/app/styles.css
@@ -48,6 +48,10 @@ body {
     }
 }
 
+#codePane.multiple-files > .pcui-panel-content > section {
+    height: calc(100% - 52px) !important;
+}
+
 #sideBar {
     background-color: #324447;
     min-width: 280px;


### PR DESCRIPTION
The examples browser's code editor now correctly displays the horizontal scroll bar when multiple files are present.

Fixes #3240 

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
