### PR TITLE
asset.load should only be true if there was no network error

### DIFF
--- a/src/asset/asset-registry.js
+++ b/src/asset/asset-registry.js
@@ -362,7 +362,6 @@ class AssetRegistry extends EventHandler {
 
         // load has completed on the resource
         var _loaded = function (err, resource, extra) {
-            asset.loaded = true;
             asset.loading = false;
 
             if (err) {
@@ -370,6 +369,8 @@ class AssetRegistry extends EventHandler {
                 self.fire("error:" + asset.id, err, asset);
                 asset.fire("error", err, asset);
             } else {
+                asset.loaded = true;
+
                 if (!script.legacy && asset.type === 'script') {
                     var handler = self._loader.getHandler('script');
                     if (handler._cache[asset.id] && handler._cache[asset.id].parentNode === document.head) {


### PR DESCRIPTION
Bug: If there was a network error when loading an asset, `asset.loaded` is set to true. This seems odd as there is no resource so is it truly loaded?

I'm a bit worried about this change affecting existing projects but looking at the engine, there are a lot of assumptions that if `loaded` is true, then there is also a `resource`.

For example, here if `loaded` is true, it prevents the user from loading the asset again:

https://github.com/playcanvas/engine/blob/master/src/asset/asset-registry.js#L338

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
