### PR TITLE
feat: Support chain for `attributes.add` and `registerScript`

### DIFF
--- a/src/script/script-attributes.js
+++ b/src/script/script-attributes.js
@@ -194,6 +194,7 @@ class ScriptAttributes {
      * @param {object[]} [args.enum] - List of fixed choices for field, defined as array of objects, where key in object is a title of an option.
      * @param {object[]} [args.schema] - List of attributes for type 'json'. Each attribute description is an object with the same properties as regular script attributes
      * but with an added 'name' field to specify the name of each attribute in the JSON.
+     * @return {this}
      * @example
      * PlayerController.attributes.add('fullName', {
      *     type: 'string'
@@ -241,12 +242,12 @@ class ScriptAttributes {
             // #if _DEBUG
             console.warn('attribute \'' + name + '\' is already defined for script type \'' + this.scriptType.name + '\'');
             // #endif
-            return;
+            return this;
         } else if (ScriptAttributes.reservedNames.has(name)) {
             // #if _DEBUG
             console.warn('attribute \'' + name + '\' is a reserved attribute name');
             // #endif
-            return;
+            return this;
         }
 
         this.index[name] = args;
@@ -290,6 +291,8 @@ class ScriptAttributes {
                 this.fire(evtName, this.__attributes[name], oldCopy);
             }
         });
+
+        return this;
     }
 
     /**

--- a/src/script/script.js
+++ b/src/script/script.js
@@ -103,6 +103,7 @@ createScript.reservedAttributes = reservedAttributes;
  * system, entity, create, destroy, swap, move, scripts, onEnable, onDisable, onPostStateChange, has, on, off, fire, once, hasEvent.
  * @param {Application} [app] - Optional application handler, to choose which {@link ScriptRegistry} to register the script type to.
  * By default it will use `Application.getApplication()` to get current {@link Application}.
+ * @return {Class<ScriptType>} - Same script, can be used for chaining
  * @example
  * // define a ES6 script class
  * class PlayerController extends pc.ScriptType {
@@ -129,7 +130,7 @@ function registerScript(script, name, app) {
         // #if _DEBUG
         console.error("This project is using the legacy script system. You cannot call pc.registerScript(). See: http://developer.playcanvas.com/en/user-manual/scripting/legacy/");
         // #endif
-        return;
+        return script;
     }
 
     if (typeof script !== 'function')
@@ -150,6 +151,8 @@ function registerScript(script, name, app) {
     registry.add(script);
 
     ScriptHandler._push(script);
+
+    return script;
 }
 
 export { createScript, registerScript };


### PR DESCRIPTION
This feature allowing use chaining in script registration phase.

**What is problem:**

Current implementation of `ScriptAttributes.add` and `pc.registerScript` return `void` and this enforce use explict syntaxis:

```
class Class  extends pc.ScriptType {

}

pc.registerScript('Class', Class);

Class.attributes.add(...);
Class.attributes.add(...);
Class.attributes.add(...);
```

**What is new:**

Because `add` and `registerScript` will return `this` and `script`, we can use it for chaining.
 1. We can use anonymous class as argument:
    `const Class = pc.registerScript('Class', class extends pc.ScriptType {} ) `
 2. We can chaining attributes: 
    ` Class.attributes.add('attr1', ...).add('attr2, ....)`
 3. We can doing both it together: 
  ```
      pc
          .registerScript('Class', class extends pc.ScriptType {} )
          .attributes
          .add(...)
          .add(...)
  ```

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
