### PR TITLE
Fix for animation loading in editor projects

### DIFF
--- a/src/framework/components/anim/component.js
+++ b/src/framework/components/anim/component.js
@@ -345,11 +345,11 @@ class AnimComponent extends Component {
                         if (asset.data.events) {
                             animTrack.events = new AnimEvents(Object.values(asset.data.events));
                         }
-                        this.assignAnimation(stateName, animTrack, layer.name);
+                        this.findAnimationLayer(layer.name).assignAnimation(stateName, animTrack);
                     } else {
                         asset.once('load', function (layerName, stateName) {
                             return function (asset) {
-                                this.assignAnimation(stateName, asset.resource, layerName);
+                                this.findAnimationLayer(layerName).assignAnimation(stateName, asset.resource);
                             }.bind(this);
                         }.bind(this)(layer.name, stateName));
                         this.system.app.assets.load(asset);


### PR DESCRIPTION
Animations that are loaded via the loadAnimationAssets function (used by the editor) currently do not have their loop properties respected. This is due to the anim component's assignAnimation function now containing default parameter values which will in turn overwrite any loop properties set via the initial state graph. The loadAnimationAssets function has been modified to user the layers own assignAnimation function which will not set default properties.

Fixes #3324 

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
