### PR TITLE
[FIX] Render handles ref counting of meshes

### DIFF
--- a/src/resources/parser/glb-parser.js
+++ b/src/resources/parser/glb-parser.js
@@ -767,6 +767,8 @@ const createMesh = function (device, gltfMesh, accessors, bufferViews, callback,
                 mesh.primitive[0].count = vertexBuffer.numVertices;
             }
 
+            // TODO: Refactor, we should not store temporary data on the mesh.
+            // The container should store some mapping table instead.
             mesh.materialIndex = primitive.material;
 
             let accessor = accessors[primitive.attributes.POSITION];

--- a/src/resources/render.js
+++ b/src/resources/render.js
@@ -35,7 +35,7 @@ function onContainerAssetRemoved(containerAsset) {
     renderAsset.registry.off('load:' + containerAsset.id, onContainerAssetLoaded, renderAsset);
 
     if (renderAsset.resource) {
-        renderAsset.resource.meshes = null;
+        renderAsset.resource.destroy();
     }
 }
 

--- a/src/scene/render.js
+++ b/src/scene/render.js
@@ -20,7 +20,43 @@ import { EventHandler } from '../core/event-handler.js';
 class Render extends EventHandler {
     constructor() {
         super();
+
+        // meshes are reference counted, and this class owns the references and is responsible
+        // for releasing the meshes when they are no longer referenced
         this._meshes = null;
+    }
+
+    destroy() {
+        this.meshes = null;
+    }
+
+    // decrement references to meshes, destroy the ones with zero references
+    decRefMeshes() {
+        if (this._meshes) {
+            const count = this._meshes.length;
+            for (let i = 0; i < count; i++) {
+                const mesh = this._meshes[i];
+                if (mesh) {
+                    mesh.decRefCount();
+                    if (mesh.getRefCount() < 1) {
+                        mesh.destroy();
+                        this._meshes[i] = null;
+                    }
+                }
+            }
+        }
+    }
+
+    // increments ref count on all meshes
+    incRefMeshes() {
+        if (this._meshes) {
+            const count = this._meshes.length;
+            for (let i = 0; i < count; i++) {
+                if (this._meshes[i]) {
+                    this._meshes[i].incRefCount();
+                }
+            }
+        }
     }
 
     get meshes() {
@@ -28,7 +64,14 @@ class Render extends EventHandler {
     }
 
     set meshes(value) {
+
+        // decrement references on the existing meshes
+        this.decRefMeshes();
+
+        // assign new meshes
         this._meshes = value;
+        this.incRefMeshes();
+
         this.fire('set:meshes', value);
     }
 }


### PR DESCRIPTION
This fixes exceptions when importing and using render components due to meshes or vertex buffers being undefined.
Easy repro: import fbx from this project: https://forum.playcanvas.com/t/bug-with-hierarchical-import/21052

- the problem was introduced recently (https://github.com/playcanvas/engine/pull/3253), when the Container stopped creating a Model instance. Model instance created MeshInstances which were holding references to meshes from the glb, keeping them alive.
- Now that the Model is not created, those meshes didn't have any persistent owner (with a ref count), and so were being deleted while still being used, for example by thumbnail renderer.
- This implementation makes a Render class own the meshes it references - it handles increment and decrement of their ref count and the release of them