### PR TITLE
AnimComponent transition updates

### DIFF
--- a/src/anim/controller/anim-controller.js
+++ b/src/anim/controller/anim-controller.js
@@ -20,13 +20,16 @@ import {
  * @param {object[]} transitions - The list of transitions used to form the controller state graph.
  * @param {object[]} parameters - The anim components parameters.
  * @param {boolean} activate - Determines whether the anim controller should automatically play once all {@link AnimNodes} are assigned animations.
+ * @param {EventHandler} eventHandler - The event handler which should be notified with anim events
+ * @param {Function} resetTrigger - Used to set a trigger back to it's default state after it has been consumed by a transition
  */
 class AnimController {
-    constructor(animEvaluator, states, transitions, parameters, activate, eventHandler) {
+    constructor(animEvaluator, states, transitions, parameters, activate, eventHandler, resetTrigger) {
         this._animEvaluator = animEvaluator;
         this._states = {};
         this._stateNames = [];
         this._eventHandler = eventHandler;
+        this._resetTrigger = resetTrigger;
         for (let i = 0; i < states.length; i++) {
             this._states[states[i].name] = new AnimState(
                 this,
@@ -279,10 +282,6 @@ class AnimController {
 
         // filter out transitions that don't have their conditions met
         transitions = transitions.filter(function (transition) {
-            // if the transition is moving to the already active state, ignore it
-            if (transition.to === this.activeStateName) {
-                return false;
-            }
             // when an exit time is present, we should only exit if it falls within the current frame delta time
             if (transition.hasExitTime) {
                 let progressBefore = this._getActiveStateProgressForTime(this._timeInStateBefore);
@@ -325,7 +324,7 @@ class AnimController {
             const condition = transition.conditions[i];
             const parameter = this.findParameter(condition.parameterName);
             if (parameter.type === ANIM_PARAMETER_TRIGGER) {
-                parameter.value = false;
+                this._resetTrigger(condition.parameterName);
             }
         }
 

--- a/src/anim/controller/anim-controller.js
+++ b/src/anim/controller/anim-controller.js
@@ -21,15 +21,15 @@ import {
  * @param {object[]} parameters - The anim components parameters.
  * @param {boolean} activate - Determines whether the anim controller should automatically play once all {@link AnimNodes} are assigned animations.
  * @param {EventHandler} eventHandler - The event handler which should be notified with anim events
- * @param {Function} resetTrigger - Used to set a trigger back to it's default state after it has been consumed by a transition
+ * @param {Set} consumedTriggers - Used to set triggers back to their default state after they have been consumed by a transition
  */
 class AnimController {
-    constructor(animEvaluator, states, transitions, parameters, activate, eventHandler, resetTrigger) {
+    constructor(animEvaluator, states, transitions, parameters, activate, eventHandler, consumedTriggers) {
         this._animEvaluator = animEvaluator;
         this._states = {};
         this._stateNames = [];
         this._eventHandler = eventHandler;
-        this._resetTrigger = resetTrigger;
+        this._consumedTriggers = consumedTriggers;
         for (let i = 0; i < states.length; i++) {
             this._states[states[i].name] = new AnimState(
                 this,
@@ -324,7 +324,7 @@ class AnimController {
             const condition = transition.conditions[i];
             const parameter = this.findParameter(condition.parameterName);
             if (parameter.type === ANIM_PARAMETER_TRIGGER) {
-                this._resetTrigger(condition.parameterName);
+                this._consumedTriggers.add(condition.parameterName);
             }
         }
 

--- a/src/framework/components/anim/component.js
+++ b/src/framework/components/anim/component.js
@@ -647,7 +647,6 @@ class AnimComponent extends Component {
      * @description Sets the value of a trigger parameter that was defined in the animation components state graph to true.
      * @param {string} name - The name of the parameter to set.
      * @param {boolean} [singleFrame] - If true, this trigger will be set back to false at the end of the animation update. Defaults to false.
-
      */
     setTrigger(name, singleFrame = false) {
         this.setParameterValue(name, ANIM_PARAMETER_TRIGGER, true);

--- a/src/framework/components/anim/component.js
+++ b/src/framework/components/anim/component.js
@@ -646,9 +646,13 @@ class AnimComponent extends Component {
      * @name AnimComponent#setTrigger
      * @description Sets the value of a trigger parameter that was defined in the animation components state graph to true.
      * @param {string} name - The name of the parameter to set.
+     * @param {boolean} singleFrame - If true, this trigger will be set back to false at the end of the animation update. Defaults to false.
      */
-    setTrigger(name) {
+    setTrigger(name, singleFrame = false) {
         this.setParameterValue(name, ANIM_PARAMETER_TRIGGER, true);
+        if (singleFrame) {
+            this._consumedTriggers[name] = true;
+        }
     }
 
     /**

--- a/src/framework/components/anim/component.js
+++ b/src/framework/components/anim/component.js
@@ -646,7 +646,8 @@ class AnimComponent extends Component {
      * @name AnimComponent#setTrigger
      * @description Sets the value of a trigger parameter that was defined in the animation components state graph to true.
      * @param {string} name - The name of the parameter to set.
-     * @param {boolean} singleFrame - If true, this trigger will be set back to false at the end of the animation update. Defaults to false.
+     * @param {boolean} [singleFrame] - If true, this trigger will be set back to false at the end of the animation update. Defaults to false.
+
      */
     setTrigger(name, singleFrame = false) {
         this.setParameterValue(name, ANIM_PARAMETER_TRIGGER, true);

--- a/src/framework/components/anim/component.js
+++ b/src/framework/components/anim/component.js
@@ -40,6 +40,7 @@ class AnimComponent extends Component {
         this._layers = [];
         this._layerIndices = {};
         this._parameters = {};
+        this._consumedTriggers = {};
     }
 
     get stateGraphAsset() {
@@ -213,6 +214,14 @@ class AnimComponent extends Component {
         return null;
     }
 
+    get consumedTriggers() {
+        return this._consumedTriggers;
+    }
+
+    set consumedTriggers(value) {
+        this._consumedTriggers = value;
+    }
+
     _addLayer(name, states, transitions, order) {
         let graph;
         if (this.rootBone) {
@@ -228,7 +237,8 @@ class AnimComponent extends Component {
             transitions,
             this._parameters,
             this._activate,
-            this
+            this,
+            this._resetTrigger.bind(this)
         );
         this._layers.push(new AnimComponentLayer(name, controller, this));
         this._layerIndices[name] = order;
@@ -649,6 +659,10 @@ class AnimComponent extends Component {
      */
     resetTrigger(name) {
         this.setParameterValue(name, ANIM_PARAMETER_TRIGGER, false);
+    }
+
+    _resetTrigger(name) {
+        this._consumedTriggers[name] = true;
     }
 
     onBeforeRemove() {

--- a/src/framework/components/anim/system.js
+++ b/src/framework/components/anim/system.js
@@ -66,14 +66,7 @@ class AnimComponentSystem extends ComponentSystem {
                 const componentData = component.data;
 
                 if (componentData.enabled && component.entity.enabled && component.playing) {
-                    for (let i = 0; i < component.layers.length; i++) {
-                        component.layers[i].update(dt * component.speed);
-                    }
-                    const keys = Object.keys(component.consumedTriggers);
-                    for (let i = 0; i < keys.length; i++) {
-                        component.parameters[keys[i]].value = false;
-                        component.consumedTriggers = {};
-                    }
+                    component.update(dt);
                 }
             }
         }

--- a/src/framework/components/anim/system.js
+++ b/src/framework/components/anim/system.js
@@ -58,16 +58,20 @@ class AnimComponentSystem extends ComponentSystem {
     }
 
     onAnimationUpdate(dt) {
-        var components = this.store;
+        const components = this.store;
 
-        for (var id in components) {
+        for (const id in components) {
             if (components.hasOwnProperty(id)) {
-                var component = components[id].entity.anim;
-                var componentData = component.data;
+                const component = components[id].entity.anim;
+                const componentData = component.data;
 
                 if (componentData.enabled && component.entity.enabled && component.playing) {
-                    for (var i = 0; i < component.layers.length; i++) {
+                    for (let i = 0; i < component.layers.length; i++) {
                         component.layers[i].update(dt * component.speed);
+                    }
+                    for (let i = 0; i < Object.keys(component.consumedTriggers).length; i++) {
+                        component.parameters[Object.keys(component.consumedTriggers)[i]].value = false;
+                        component.consumedTriggers = {};
                     }
                 }
             }

--- a/src/framework/components/anim/system.js
+++ b/src/framework/components/anim/system.js
@@ -69,8 +69,9 @@ class AnimComponentSystem extends ComponentSystem {
                     for (let i = 0; i < component.layers.length; i++) {
                         component.layers[i].update(dt * component.speed);
                     }
-                    for (let i = 0; i < Object.keys(component.consumedTriggers).length; i++) {
-                        component.parameters[Object.keys(component.consumedTriggers)[i]].value = false;
+                    const keys = Object.keys(component.consumedTriggers);
+                    for (let i = 0; i < keys.length; i++) {
+                        component.parameters[keys[i]].value = false;
                         component.consumedTriggers = {};
                     }
                 }


### PR DESCRIPTION
This PR addresses a few requests that had been made in relation to anim component transitions.

- Transitions can now be made from the active state to itself (or from the any state to the active state). #3313
- Trigger parameters are now reset at the end of the animation update rather than when they're consumed by a transition. This allows multiple layers to use a single trigger before it is reset. #3268
- Updates the `AnimComponent#setTrigger` to support a `singleFrame` boolean parameter. If set to true the set trigger will be reset at the end of the next animation update. #3270


I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
