### PR TITLE
Fix to culling of non-moving skinned objects

### DIFF
--- a/src/scene/batching/batch.js
+++ b/src/scene/batching/batch.js
@@ -54,7 +54,6 @@ class Batch {
             this._aabb.add(this.origMeshInstances[i].aabb);
         }
         this.meshInstance.aabb = this._aabb;
-        this._aabb._radiusVer = -1;
         this.meshInstance._aabbVer = 0;
     }
 }

--- a/src/scene/mesh-instance.js
+++ b/src/scene/mesh-instance.js
@@ -521,14 +521,8 @@ class MeshInstance {
                 return this.isVisibleFunc(camera);
             }
 
-            var pos = this.aabb.center;
-            if (this._aabb._radiusVer !== this._aabbVer) {
-                this._aabb._radius = this._aabb.halfExtents.length();
-                this._aabb._radiusVer = this._aabbVer;
-            }
-
-            _tempSphere.radius = this._aabb._radius;
-            _tempSphere.center = pos;
+            _tempSphere.center = this.aabb.center;  // this line evaluates aabb
+            _tempSphere.radius = this._aabb.halfExtents.length();
 
             return camera.frustum.containsSphere(_tempSphere);
         }


### PR DESCRIPTION
Mesh instance had optimization to avoid radius of the bounding sphere to be evaluated from bounding box. This has few problems:
- it didn't work for skinned object that were not moving (world transform wasn't being updated)
- it was adding two members to BoundingBox instances at runtime, which is not good for performance.

I've decided to remove it and simply evaluate the radius each frame, which is a small cost.

Fixes this issue: https://forum.playcanvas.com/t/frustrum-culling-a-little-too-eager/21064/3