### PR TITLE
[Examples Browser] Updates & fixes

### DIFF
--- a/examples/package-lock.json
+++ b/examples/package-lock.json
@@ -7108,9 +7108,9 @@
       }
     },
     "playcanvas": {
-      "version": "1.43.1",
-      "resolved": "https://registry.npmjs.org/playcanvas/-/playcanvas-1.43.1.tgz",
-      "integrity": "sha512-x7muwlT8XiEyXffaltKeisuyRlWBztSskteNok9MfiXnw7dvaRGjGDoao1pS56lXcEI6CiUm+ddbHJpxiTw/Rw==",
+      "version": "1.44.2",
+      "resolved": "https://registry.npmjs.org/playcanvas/-/playcanvas-1.44.2.tgz",
+      "integrity": "sha512-UlUxHyd/O/p6q/ZQ8soLBa6hECQswoV34iMHwznCYw5U9HawlD3H5KLIFZ+aw13T7xAFb0HZr4Nwj58dZYWxvg==",
       "dev": true
     },
     "portfinder": {

--- a/examples/package.json
+++ b/examples/package.json
@@ -62,7 +62,7 @@
     "html-webpack-plugin": "^5.3.2",
     "monaco-editor": "^0.25.2",
     "monaco-editor-webpack-plugin": "^4.0.0",
-    "playcanvas": "^1.43.1",
+    "playcanvas": "^1.44.2",
     "prop-types": "^15.7.2",
     "puppeteer": "^10.1.0",
     "raw-loader": "^4.0.2",

--- a/examples/src/app/code-editor.tsx
+++ b/examples/src/app/code-editor.tsx
@@ -43,7 +43,8 @@ const CodeEditor = (props: CodeEditorProps) => {
     };
 
     const onValidate = (markers: Array<any>) => {
-        if (markers.length === 0) {
+        // filter out markers which are warnings
+        if (markers.filter((m) => m.severity > 1).length === 0) {
             props.setFiles(files);
             props.setLintErrors(false);
         } else {

--- a/examples/src/app/control-panel.tsx
+++ b/examples/src/app/control-panel.tsx
@@ -48,11 +48,12 @@ const ControlPanel = (props: any) => {
         controls.ui.hidden = !controls.ui.hidden;
     };
 
-    return <Panel id='controlPanel' class={[!props.controls ? 'empty' : 'null', window.top.innerWidth < 601 ? 'mobile' : null]} resizable='top' headerText='CONTROLS' collapsible={true} collapsed={state.collapsed}>
-        <Container id= 'controlPanel-tabs' class='tabs-container'>
-            {props.controls && <Button text='PARAMETERS' class={state.showParameters ? 'selected' : null} id='paramButton' onClick={onClickParametersTab} /> }
+    return <Panel id='controlPanel' class={[window.top.innerWidth > 600 && !props.controls ? 'empty' : 'null', window.top.innerWidth < 601 ? 'mobile' : null]} resizable='top' headerText={window.top.innerWidth < 601 && props.controls ? 'CONTROLS & CODE' : 'CODE'} collapsible={true} collapsed={state.collapsed}>
+        { props.controls && <Container id= 'controlPanel-tabs' class='tabs-container'>
+            <Button text='PARAMETERS' class={state.showParameters ? 'selected' : null} id='paramButton' onClick={onClickParametersTab} />
             <Button text='CODE' id='codeButton' class={state.showCode ? 'selected' : null} onClick={onClickCodeTab}/>
         </Container>
+        }
         <Container id='controlPanel-controls'>
             { props.controls }
         </Container>

--- a/examples/src/app/example-iframe.tsx
+++ b/examples/src/app/example-iframe.tsx
@@ -6,6 +6,8 @@ import * as playcanvas from 'playcanvas/build/playcanvas.js';
 // @ts-ignore: library file import
 import * as playcanvasDebug from 'playcanvas/build/playcanvas.dbg.js';
 // @ts-ignore: library file import
+import * as playcanvasPerformance from 'playcanvas/build/playcanvas.prf.js';
+// @ts-ignore: library file import
 import * as pcx from 'playcanvas/build/playcanvas-extras.js';
 // @ts-ignore: library file import
 import * as Babel from '@babel/standalone';

--- a/examples/src/app/example-iframe.tsx
+++ b/examples/src/app/example-iframe.tsx
@@ -56,13 +56,6 @@ const ExampleIframe = (props: ExampleIframeProps) => {
     } catch (e) {
         files = props.files;
     }
-    let showMiniStats = false;
-    // Try to retrieve a set of B64 encoded files from the URL's query params.
-    // If not present then use the default files passed in the props
-    try {
-        showMiniStats = location.hash.split('showMiniStats=')[1].split('&')[0] === 'true';
-    } catch (e) {
-    }
 
     const fullscreen = location.hash.includes('fullscreen=true');
 
@@ -140,9 +133,10 @@ const ExampleIframe = (props: ExampleIframeProps) => {
             graphicsDeviceOptions: { alpha: true }
         });
 
-        if (showMiniStats) {
-            const miniStats = new pcx.MiniStats(app);
-        }
+        const miniStats: any = new pcx.MiniStats(app);
+        app.on('update', () => {
+            miniStats.enabled = (window?.parent as any)?._showMiniStats;
+        });
 
         (window as any).app = app;
 

--- a/examples/src/app/example-iframe.tsx
+++ b/examples/src/app/example-iframe.tsx
@@ -27,14 +27,18 @@ interface ExampleIframeProps {
     controls: any,
     assets: any,
     files: Array<File>,
-    debug?: boolean,
+    engine: string,
     debugExample?: any
 }
 
 const ExampleIframe = (props: ExampleIframeProps) => {
-    let pc = playcanvas;
-    if (props.debug) {
+    let pc: any;
+    if (props.engine === 'DEBUG') {
         pc = playcanvasDebug;
+    } else if (props.engine === 'PERFORMANCE') {
+        pc = playcanvasPerformance;
+    } else {
+        pc = playcanvas;
     }
     // expose PlayCanvas as a global in the iframe
     (window as any).pc = pc;

--- a/examples/src/app/example.tsx
+++ b/examples/src/app/example.tsx
@@ -10,8 +10,7 @@ interface ExampleProps {
     files: Array<File>,
     defaultFiles: Array<File>,
     setDefaultFiles: (value: Array<File>) => void,
-    path: string,
-    showMiniStats: boolean
+    path: string
 }
 
 interface ExampleState {
@@ -57,7 +56,7 @@ class Example extends Component <ExampleProps, ExampleState> {
     }
 
     get iframePath() {
-        return `/#/iframe${this.props.path}?showMiniStats=${this.props.showMiniStats}&files=${btoa(encodeURIComponent(JSON.stringify(this.files)))}`;
+        return `/#/iframe${this.props.path}?files=${btoa(encodeURIComponent(JSON.stringify(this.files)))}`;
     }
 
     addAssets(app: pc.Application, assets?: any) {

--- a/examples/src/app/helpers/raw-file-loading.ts
+++ b/examples/src/app/helpers/raw-file-loading.ts
@@ -71,7 +71,7 @@ export const examples = (() => {
             functionText = functionText.split('\n')
                 .map((line: string, index: number) => {
                     if (index === 0) return line;
-                    if (line.substring(0, 4).includes('//')) {
+                    if (line.substring(0, 4).split('').filter((a) => a !== ' ').length > 0) {
                         return line;
                     }
                     return line.substring(4);

--- a/examples/src/app/helpers/raw-file-loading.ts
+++ b/examples/src/app/helpers/raw-file-loading.ts
@@ -62,11 +62,13 @@ export const examples = (() => {
             };
 
             const transformedCode = require(`!raw-loader!../../examples/${categorySlug}/${nameSlug}.tsx`).default;
-            const functionSignatureString = '): void {';
-            const indexOfAppCallStart = transformedCode.indexOf(functionSignatureString);
-            const indexOfAppCallEnd = findClosingBracketMatchIndex(transformedCode, indexOfAppCallStart + functionSignatureString.length - 1);
-            let functionCall = 'function ' + transformedCode.substring(transformedCode.indexOf('example('), indexOfAppCallEnd + 1);
-            functionCall = functionCall.split('\n')
+            const functionSignatureStartString = 'example(canvas: HTMLCanvasElement';
+            const indexOfFunctionSignatureStart = transformedCode.indexOf(functionSignatureStartString);
+            const functionSignatureEndString = '): void ';
+            const indexOfFunctionSignatureEnd = indexOfFunctionSignatureStart + transformedCode.substring(indexOfFunctionSignatureStart).indexOf(functionSignatureEndString) + functionSignatureEndString.length;
+            const indexOfFunctionEnd = findClosingBracketMatchIndex(transformedCode, indexOfFunctionSignatureEnd) + 1;
+            let functionText = 'function ' + transformedCode.substring(indexOfFunctionSignatureStart, indexOfFunctionEnd);
+            functionText = functionText.split('\n')
                 .map((line: string, index: number) => {
                     if (index === 0) return line;
                     return line.substring(4);
@@ -76,7 +78,7 @@ export const examples = (() => {
             const files: Array<File> = [
                 {
                     name: 'example.ts',
-                    text: functionCall
+                    text: functionText
                 }
             ];
             // @ts-ignore

--- a/examples/src/app/helpers/raw-file-loading.ts
+++ b/examples/src/app/helpers/raw-file-loading.ts
@@ -71,6 +71,9 @@ export const examples = (() => {
             functionText = functionText.split('\n')
                 .map((line: string, index: number) => {
                     if (index === 0) return line;
+                    if (line.substring(0, 4).includes('//')) {
+                        return line;
+                    }
                     return line.substring(4);
                 })
                 .join('\n');

--- a/examples/src/app/helpers/raw-file-loading.ts
+++ b/examples/src/app/helpers/raw-file-loading.ts
@@ -21,7 +21,7 @@ export const examples = (() => {
     importAll(require.context('../../examples/', true, /\.tsx$/));
 
     const categories: any = {};
-    const paths: Array<{ path: string, example: any, files: Array<File> }> = [];
+    const paths: {[key: string]: { path: string, example: any, files: Array<File> }} = {};
 
     Object.keys(exampleFiles).forEach((key: string) => {
         if (key.indexOf('./') === 0) {
@@ -105,11 +105,11 @@ export const examples = (() => {
                 });
             }
 
-            paths.push({
+            paths[`/${categorySlug}/${nameSlug}`] = {
                 path: `/${categorySlug}/${nameSlug}`,
                 example: exampleFiles[key].default,
                 files: files
-            });
+            };
         }
     });
 

--- a/examples/src/app/index.tsx
+++ b/examples/src/app/index.tsx
@@ -98,10 +98,10 @@ const MainLayout = () => {
                             const controls = e.controls;
                             return [
                                 <Route key={`/iframe${p.path}`} path={[`/iframe${p.path}`]}>
-                                    <ExampleIframe controls={controls} assets={assetsLoader ? assetsLoader().props.children : null} files={p.files} debug={p.path.includes('mini-stats')}/>
+                                    <ExampleIframe controls={controls} assets={assetsLoader ? assetsLoader().props.children : null} engine={e.constructor.ENGINE} files={p.files} />
                                 </Route>,
                                 <Route key={`/debug${p.path}`} path={[`/debug${p.path}`]}>
-                                    <ExampleIframe controls={controls} assets={assetsLoader ? assetsLoader().props.children : null} files={p.files} debug={p.path.includes('mini-stats')} debugExample={e}/>
+                                    <ExampleIframe controls={controls} assets={assetsLoader ? assetsLoader().props.children : null}  engine={e.constructor.ENGINE} files={p.files} debugExample={e}/>
                                 </Route>
                             ];
                         })

--- a/examples/src/app/index.tsx
+++ b/examples/src/app/index.tsx
@@ -3,7 +3,7 @@ import ReactDOM from 'react-dom';
 // @ts-ignore: library file import
 import { Container } from '@playcanvas/pcui/pcui-react';
 // @ts-ignore: library file import
-import { HashRouter as Router, Switch, Route, Redirect } from "react-router-dom";
+import { HashRouter as Router, Switch, Route } from "react-router-dom";
 import SideBar from './sidebar';
 import CodeEditor from './code-editor';
 import ExampleIframe from './example-iframe';
@@ -17,15 +17,19 @@ interface ExampleRoutesProps {
     setDefaultFiles: (files: Array<File>) => void
 }
 const ExampleRoutes = (props: ExampleRoutesProps) => {
+    const defaultExample = examples.paths['/misc/hello-world'];
     return (
         <Switch>
             {
-                examples.paths.map((p) => {
+                Object.values(examples.paths).map((p) => {
                     return <Route key={p.path} path={[p.path, `${p.path}.html`]}>
                         <p.example path={p.path} defaultFiles={p.files} files={props.files} setDefaultFiles={props.setDefaultFiles} />
                     </Route>;
                 })
             }
+            <Route path='/'>
+                <defaultExample.example path={defaultExample.path} defaultFiles={defaultExample.files} files={props.files} setDefaultFiles={props.setDefaultFiles} />
+            </Route>
         </Switch>
     );
 };
@@ -90,11 +94,8 @@ const MainLayout = () => {
         <div id='appInner'>
             <Router>
                 <Switch>
-                    <Route exact path="/">
-                        <Redirect to="/misc/hello-world" />
-                    </Route>
                     {
-                        examples.paths.map((p) => {
+                        Object.values(examples.paths).map((p) => {
                             const e = new p.example();
                             const assetsLoader = e.load;
                             const controls = e.controls;
@@ -108,7 +109,7 @@ const MainLayout = () => {
                             ];
                         })
                     }
-                    <Route key='main' path={`/`}>
+                    <Route key='main' path='/'>
                         <SideBar categories={examples.categories}/>
                         <Container id='main-view-wrapper'>
                             <Menu lintErrors={lintErrors} hasEditedFiles={hasEditedFiles()} playButtonRef={playButtonRef} setShowMiniStats={updateShowMiniStats} />

--- a/examples/src/app/index.tsx
+++ b/examples/src/app/index.tsx
@@ -14,8 +14,7 @@ import './styles.css';
 
 interface ExampleRoutesProps {
     files: Array<File>,
-    setDefaultFiles: (files: Array<File>) => void,
-    showMiniStats: boolean
+    setDefaultFiles: (files: Array<File>) => void
 }
 const ExampleRoutes = (props: ExampleRoutesProps) => {
     return (
@@ -23,7 +22,7 @@ const ExampleRoutes = (props: ExampleRoutesProps) => {
             {
                 examples.paths.map((p) => {
                     return <Route key={p.path} path={[p.path, `${p.path}.html`]}>
-                        <p.example path={p.path} defaultFiles={p.files} files={props.files} setDefaultFiles={props.setDefaultFiles} showMiniStats={props.showMiniStats} />
+                        <p.example path={p.path} defaultFiles={p.files} files={props.files} setDefaultFiles={props.setDefaultFiles} />
                     </Route>;
                 })
             }
@@ -57,7 +56,10 @@ const MainLayout = () => {
     // The example files are the files that should be loaded and executed by the example. Upon hitting the play button, the currently set edited files are set to the example files
     const [exampleFiles, setExampleFiles] = useState(emptyFiles);
     const [lintErrors, setLintErrors] = useState(false);
-    const [showMiniStats, setShowMiniStats] = useState(false);
+
+    const updateShowMiniStats = (value: boolean) => {
+        (window as any)._showMiniStats = value;
+    };
 
     const playButtonRef = createRef();
     useEffect(() => {
@@ -109,9 +111,9 @@ const MainLayout = () => {
                     <Route key='main' path={`/`}>
                         <SideBar categories={examples.categories}/>
                         <Container id='main-view-wrapper'>
-                            <Menu lintErrors={lintErrors} hasEditedFiles={hasEditedFiles()} playButtonRef={playButtonRef} showMiniStats={showMiniStats} setShowMiniStats={setShowMiniStats} />
+                            <Menu lintErrors={lintErrors} hasEditedFiles={hasEditedFiles()} playButtonRef={playButtonRef} setShowMiniStats={updateShowMiniStats} />
                             <Container id='main-view'>
-                                <ExampleRoutes files={exampleFiles} setDefaultFiles={updateExample.bind(this)} showMiniStats={showMiniStats} />
+                                <ExampleRoutes files={exampleFiles} setDefaultFiles={updateExample.bind(this)} />
                                 <CodeEditor files={editedFiles[0].text.length > 0 ? editedFiles : defaultFiles} setFiles={setEditedFiles.bind(this)} setLintErrors={setLintErrors} />
                             </Container>
                         </Container>

--- a/examples/src/app/menu.tsx
+++ b/examples/src/app/menu.tsx
@@ -7,7 +7,6 @@ interface MenuProps {
     lintErrors: boolean,
     hasEditedFiles: boolean,
     playButtonRef: any,
-    showMiniStats: boolean,
     setShowMiniStats: (value: boolean) => void
 }
 const Menu = (props: MenuProps) => {

--- a/examples/src/app/menu.tsx
+++ b/examples/src/app/menu.tsx
@@ -22,6 +22,7 @@ const Menu = (props: MenuProps) => {
         document.querySelector('#canvas-container').classList.toggle('fullscreen');
         const app = document.querySelector('#appInner');
         app.classList.toggle('fullscreen');
+        document.querySelector('iframe').contentDocument.getElementById('appInner').classList.toggle('fullscreen');
         if (app.classList.contains('fullscreen')) {
             clickFullscreenListener = () => {
                 app.classList.add('active');

--- a/examples/src/app/sidebar.tsx
+++ b/examples/src/app/sidebar.tsx
@@ -28,7 +28,17 @@ const SideBar = (props: SideBarProps) => {
         });
 
         observer.on('largeThumbnails:set', () => {
+            let topNavItem: HTMLElement;
+            let minTopNavItemDistance = Number.MAX_VALUE;
+            document.querySelectorAll('.nav-item').forEach((nav: HTMLElement) => {
+                const navItemDistance = Math.abs(120 - nav.getBoundingClientRect().top);
+                if (navItemDistance < minTopNavItemDistance) {
+                    minTopNavItemDistance = navItemDistance;
+                    topNavItem = nav;
+                }
+            });
             sideBar.classList.toggle('small-thumbnails');
+            topNavItem.scrollIntoView();
         });
     });
 

--- a/examples/src/app/sidebar.tsx
+++ b/examples/src/app/sidebar.tsx
@@ -40,6 +40,12 @@ const SideBar = (props: SideBarProps) => {
             sideBar.classList.toggle('small-thumbnails');
             topNavItem.scrollIntoView();
         });
+        // when first opening the examples browser via a specific example, scroll it into view
+        if (!(window as any)._scrolledToExample) {
+            const examplePath = location.hash.split('/');
+            document.getElementById(`link-${examplePath[1]}-${examplePath[2]}`)?.scrollIntoView();
+            (window as any)._scrolledToExample = true;
+        }
     });
 
     return (
@@ -87,8 +93,7 @@ const SideBar = (props: SideBarProps) => {
                                         Object.keys(filteredCategories[category].examples).sort((a: string, b:string) => (a > b ? 1 : -1)).map((example: string) => {
                                             const isSelected = new RegExp(`/${category}/${example}$`).test(hash);
                                             const className = `nav-item ${isSelected ? 'selected' : ''}`;
-                                            return <Link key={example} to={`/${category}/${example}`}>
-                                                <div className={className}>
+                                                <div className={className} id={`link-${category}-${example}`}>
                                                     <img src={`./thumbnails/${category}_${example}.png`} />
                                                     <div className='nav-item-text'>{filteredCategories[category].examples[example].constructor.NAME.toUpperCase()}</div>
                                                 </div>

--- a/examples/src/app/sidebar.tsx
+++ b/examples/src/app/sidebar.tsx
@@ -11,8 +11,8 @@ interface SideBarProps {
 }
 
 const SideBar = (props: SideBarProps) => {
-    const categories = props.categories;
-    const [filteredCategories, setFilteredCategories] = useState(categories);
+    const defaultCategories = props.categories;
+    const [filteredCategories, setFilteredCategories] = useState(null);
     const [hash, setHash] = useState(location.hash);
     const observer = new Observer({ largeThumbnails: false });
     useEffect(() => {
@@ -40,6 +40,14 @@ const SideBar = (props: SideBarProps) => {
             sideBar.classList.toggle('small-thumbnails');
             topNavItem.scrollIntoView();
         });
+
+        const sideBarPanel = document.getElementById('sideBar-panel');
+        if (!filteredCategories && document.body.offsetWidth < 601) {
+            // @ts-ignore
+            sideBarPanel.ui.collapsed = true;
+        }
+        sideBar.classList.add('visible');
+
         // when first opening the examples browser via a specific example, scroll it into view
         if (!(window as any)._scrolledToExample) {
             const examplePath = location.hash.split('/');
@@ -48,33 +56,34 @@ const SideBar = (props: SideBarProps) => {
         }
     });
 
+    const categories = filteredCategories || defaultCategories;
     return (
         <Container id='sideBar' class='small-thumbnails'>
             <div className='panel-toggle' />
-            <Panel headerText="EXAMPLES" collapsible={document.body.offsetWidth < 601} id='sideBar-panel' collapsed={document.body.offsetWidth < 601}>
+            <Panel headerText="EXAMPLES" collapsible={document.body.offsetWidth < 601} id='sideBar-panel'>
                 <TextInput class='filter-input' keyChange placeholder="Filter..." onChange={(filter: string) => {
                     const reg = (filter && filter.length > 0) ? new RegExp(filter, 'i') : null;
                     if (!reg) {
-                        setFilteredCategories(categories);
+                        setFilteredCategories(defaultCategories);
                         return;
                     }
                     const updatedCategories: any = {};
-                    Object.keys(categories).forEach((category: string) => {
-                        if (categories[category].name.search(reg) !== -1) {
-                            updatedCategories[category] = categories[category];
+                    Object.keys(defaultCategories).forEach((category: string) => {
+                        if (defaultCategories[category].name.search(reg) !== -1) {
+                            updatedCategories[category] = defaultCategories[category];
                             return null;
                         }
-                        Object.keys(categories[category].examples).forEach((example: string) => {
-                            if (categories[category].examples[example].constructor.NAME.search(reg) !== -1) {
+                        Object.keys(defaultCategories[category].examples).forEach((example: string) => {
+                            if (defaultCategories[category].examples[example].constructor.NAME.search(reg) !== -1) {
                                 if (!updatedCategories[category]) {
                                     updatedCategories[category] = {
-                                        name: categories[category].name,
+                                        name: defaultCategories[category].name,
                                         examples: {
-                                            [example]: categories[category].examples[example]
+                                            [example]: defaultCategories[category].examples[example]
                                         }
                                     };
                                 } else {
-                                    updatedCategories[category].examples[example] = categories[category].examples[example];
+                                    updatedCategories[category].examples[example] = defaultCategories[category].examples[example];
                                 }
                             }
                         });
@@ -84,18 +93,23 @@ const SideBar = (props: SideBarProps) => {
                 <LabelGroup text='Large thumbnails:'>
                     <BooleanInput type='toggle'  binding={new BindingTwoWay()} link={{ observer, path: 'largeThumbnails' }} />
                 </LabelGroup>
-                <Container class='sideBar-contents'>
+                <Container id='sideBar-contents'>
                     {
-                        Object.keys(filteredCategories).sort((a: string, b:string) => (a > b ? 1 : -1)).map((category: string) => {
-                            return <Panel key={category} class="categoryPanel" headerText={filteredCategories[category].name} collapsible={true} collapsed={false}>
+                        Object.keys(categories).sort((a: string, b:string) => (a > b ? 1 : -1)).map((category: string) => {
+                            return <Panel key={category} class="categoryPanel" headerText={categories[category].name} collapsible={true} collapsed={false}>
                                 <ul className="category-nav">
                                     {
-                                        Object.keys(filteredCategories[category].examples).sort((a: string, b:string) => (a > b ? 1 : -1)).map((example: string) => {
+                                        Object.keys(categories[category].examples).sort((a: string, b:string) => (a > b ? 1 : -1)).map((example: string) => {
                                             const isSelected = new RegExp(`/${category}/${example}$`).test(hash);
                                             const className = `nav-item ${isSelected ? 'selected' : ''}`;
+                                            return <Link key={example} to={`/${category}/${example}`} onClick={() => {
+                                                const sideBarPanel = document.getElementById('sideBar-panel');
+                                                // @ts-ignore
+                                                sideBarPanel.ui.collapsed = true;
+                                            }}>
                                                 <div className={className} id={`link-${category}-${example}`}>
                                                     <img src={`./thumbnails/${category}_${example}.png`} />
-                                                    <div className='nav-item-text'>{filteredCategories[category].examples[example].constructor.NAME.toUpperCase()}</div>
+                                                    <div className='nav-item-text'>{categories[category].examples[example].constructor.NAME.toUpperCase()}</div>
                                                 </div>
                                             </Link>;
                                         })
@@ -105,7 +119,7 @@ const SideBar = (props: SideBarProps) => {
                         })
                     }
                     {
-                        Object.keys(filteredCategories).length === 0 && <Label text='No results'/>
+                        Object.keys(categories).length === 0 && <Label text='No results'/>
                     }
                 </Container>
             </Panel>

--- a/examples/src/app/styles.css
+++ b/examples/src/app/styles.css
@@ -91,7 +91,7 @@ body {
     margin-top: 32px;
 }
 
-.sideBar-contents {
+#sideBar-contents {
     height: calc(100% - 88px);
     overflow: auto;
     margin-top: 8px;
@@ -120,7 +120,7 @@ body {
         border-radius: 6px !important;
     }
 
-    .sideBar-contents {
+    #sideBar-contents {
         height: calc(100% - 108px);
         overflow: auto;
         margin-top: 8px;
@@ -128,6 +128,18 @@ body {
 
     #sideBar-panel .pcui-panel-content {
         overflow: hidden;
+    }
+
+    #sideBar {
+        opacity: 0;
+    }
+
+    #sideBar.visible {
+        opacity: 1;
+    }
+
+    #sideBar-panel.pcui-collapsed > .pcui-panel-content {
+        display: none;
     }
 }
 
@@ -399,7 +411,7 @@ body {
     min-width: 32px;
 }
 
-#sideBar.collapsed .sideBar-contents, #sideBar.collapsed .pcui-panel-content, #codePane.collapsed section {
+#sideBar.collapsed #sideBar-contents, #sideBar.collapsed .pcui-panel-content, #codePane.collapsed section {
     display: none !important;
 }
 

--- a/examples/src/app/styles.css
+++ b/examples/src/app/styles.css
@@ -596,14 +596,19 @@ body {
 #appInner.fullscreen #menu {
     opacity: 0;
 }
-#appInner.fullscreen.active #menu, #appInner.fullscreen #menu:hover {
+#appInner.fullscreen.active #menu {
     opacity: 1;
 }
 
 @media only screen and (min-width: 601px) {
-    #appInner.fullscreen #menu {
-        top: 8px;
+    #appInner.fullscreen #menu:hover {
+        opacity: 1;
     }
+}
+
+#appInner.fullscreen #menu {
+    top: 8px;
+    bottom: inherit;
 }
 
 #appInner.fullscreen #controlPanel, #appInner.fullscreen #sideBar {

--- a/examples/src/examples/graphics/clustered-lighting.tsx
+++ b/examples/src/examples/graphics/clustered-lighting.tsx
@@ -189,7 +189,7 @@ class ClusteredLightingExample extends Example {
 
         // Set an update function on the app's update event
         let time = 0;
-        app.on("update", function (dt) {
+        app.on("update", function (dt: number) {
             time += dt;
 
             // move lights along sin based waves around the cylinder

--- a/examples/src/examples/graphics/clustered-lighting.tsx
+++ b/examples/src/examples/graphics/clustered-lighting.tsx
@@ -1,11 +1,15 @@
 import React from 'react';
-import * as pc from 'playcanvas/build/playcanvas.js';
+// @ts-ignore: library file import
+import * as pc from 'playcanvas/build/playcanvas.prf.js';
+// @ts-ignore: library file import
+import * as pcx from 'playcanvas/build/playcanvas-extras.js';
 import Example from '../../app/example';
 import { AssetLoader } from '../../app/helpers/loader';
 
 class ClusteredLightingExample extends Example {
     static CATEGORY = 'Graphics';
     static NAME = 'Clustered Lighting';
+    static ENGINE = 'PERFORMANCE';
 
     load() {
         return <>
@@ -47,24 +51,27 @@ class ClusteredLightingExample extends Example {
         });
 
         // set up options for mini-stats, start with the default options and add clusted lighting stats
-        // const options = pcx.MiniStats.getDefaultOptions();
-        // options.stats.push(
-        //     {
-        //         // CPU time it takes to process the clusters each frame
-        //         name: "Clusters",
-        //         stats: ["frame.lightClustersTime"],
-        //         decimalPlaces: 2,
-        //         unitsName: "ms",
-        //         watermark: 3
-        //     },
-        //     {
-        //         // number of clusters used internally
-        //         // should be one if all lights are on the same set of layers
-        //         name: "Num Clusters",
-        //         stats: ["frame.lightClusters"],
-        //         watermark: 3
-        //     }
-        // );
+        const options = pcx.MiniStats.getDefaultOptions();
+        options.stats.push(
+            {
+                // CPU time it takes to process the clusters each frame
+                name: "Clusters",
+                stats: ["frame.lightClustersTime"],
+                decimalPlaces: 2,
+                unitsName: "ms",
+                watermark: 3
+            },
+            {
+                // number of clusters used internally
+                // should be one if all lights are on the same set of layers
+                name: "Num Clusters",
+                stats: ["frame.lightClusters"],
+                watermark: 3
+            }
+        );
+
+        // create mini-stats system
+        const miniStats = new pcx.MiniStats(app, options);
 
         // material with tiled normal map
         let material = new pc.StandardMaterial();

--- a/examples/src/examples/misc/mini-stats.tsx
+++ b/examples/src/examples/misc/mini-stats.tsx
@@ -7,6 +7,7 @@ import Example from '../../app/example';
 class MiniStatsExample extends Example {
     static CATEGORY = 'Misc';
     static NAME = 'Mini Stats';
+    static ENGINE = 'DEBUG';
 
     // @ts-ignore: override class function
     example(canvas: HTMLCanvasElement, pcx: any): void {


### PR DESCRIPTION
This PR contains a bunch of tweaks and fixes to the examples browser project. There were too many small changes to justify individual PR's so i've grouped them here.

### Updates
- Bump playcanvas dependancy to 1.44.2 playcanvas/engine@32b7a1c
- Support performance and debug builds of playcanvas in examples (defined using the static ENGINE property). This enables the mini stats in the clustered lighting example playcanvas/engine@2a61f07 (#3254)
- Show mini stats toggle no longer requires an example rebuild to switch playcanvas/engine@6b1b3ac (#3297)
- All non example paths now direct to the hello world example playcanvas/engine@70179a1 (#3303)
- When switching thumbnail sizes in the side bar, the position of the top most nav item is maintained playcanvas/engine@5c5a94d
- Opening the examples browser using a specific path to an example will scroll that example's nav item into view in the side bar playcanvas/engine@fd6f7b4


### Fixes
- Filter out code editor warnings when validating browser edits of examples. Warnings were previously blocking rebuilds. playcanvas/engine@1f593a1
- Fixes an issue where including extra functions in an Example class could break the example build playcanvas/engine@4ebe5e1 (#3310)
- Fixes an issue where comments in an example that start at line position 0 break the build playcanvas/engine@e87521d (#3310)
- The code view panel was hidden on mobile for examples without controls. Fixed in: playcanvas/engine@1eb6fe8
- The input of text in the filter text input no longer closes the side bar on mobile playcanvas/engine@c1b4904 (#3287)

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
