### PR TITLE
[Examples Browser] Controls for the post effects / lights examples

### DIFF
--- a/examples/src/app/control-panel.tsx
+++ b/examples/src/app/control-panel.tsx
@@ -9,7 +9,7 @@ const ControlPanel = (props: any) => {
     const [state, setState] = useState({
         showParameters: !!props.controls,
         showCode: !props.controls,
-        collapsed: document.body.offsetWidth < 601
+        collapsed: window.top.innerWidth < 601
     });
     const beforeMount = (monaco: any) => {
         monaco.languages.typescript.typescriptDefaults.addExtraLib(
@@ -48,8 +48,8 @@ const ControlPanel = (props: any) => {
         controls.ui.hidden = !controls.ui.hidden;
     };
 
-    return <Panel id='controlPanel' class={[window.top.innerWidth > 600 && !props.controls ? 'empty' : 'null', window.top.innerWidth < 601 ? 'mobile' : null]} resizable='top' headerText={window.top.innerWidth < 601 && props.controls ? 'CONTROLS & CODE' : 'CODE'} collapsible={true} collapsed={state.collapsed}>
-        { props.controls && <Container id= 'controlPanel-tabs' class='tabs-container'>
+    return <Panel id='controlPanel' class={[window.top.innerWidth > 600 && !props.controls ? 'empty' : 'null', window.top.innerWidth < 601 ? 'mobile' : null]} resizable='top' headerText={window.top.innerWidth < 601 ? (props.controls ? 'CONTROLS & CODE' : 'CODE') : 'CONTROLS'} collapsible={true} collapsed={state.collapsed}>
+        { window.top.innerWidth < 601 && props.controls && <Container id= 'controlPanel-tabs' class='tabs-container'>
             <Button text='PARAMETERS' class={state.showParameters ? 'selected' : null} id='paramButton' onClick={onClickParametersTab} />
             <Button text='CODE' id='codeButton' class={state.showCode ? 'selected' : null} onClick={onClickCodeTab}/>
         </Container>
@@ -57,7 +57,7 @@ const ControlPanel = (props: any) => {
         <Container id='controlPanel-controls'>
             { props.controls }
         </Container>
-        { document.body.offsetWidth < 601 && state.showCode && <MonacoEditor
+        { window.top.innerWidth < 601 && state.showCode && <MonacoEditor
             options={{
                 readOnly: true
             }}

--- a/examples/src/app/styles.css
+++ b/examples/src/app/styles.css
@@ -321,6 +321,7 @@ body {
     overflow: auto;
     transition: opacity 500ms;
     opacity: 1;
+    max-height: calc(100% - 16px);
 }
 
 /* @media only screen and (min-width: 601px) { */
@@ -336,6 +337,7 @@ body {
     width: calc(100% - 16px);
     top: inherit;
     background-color: rgba(54, 67, 70, 1);
+    max-height: calc(100% - 112px);
 }
 
 #controlPanel.mobile > .pcui-panel-content {
@@ -355,6 +357,19 @@ body {
 
 #controlPanel.mobile .pcui-slider .pcui-numeric-input {
     min-width: 47px;
+}
+
+#controlPanel-controls > .pcui-panel:first-child {
+    border-top: 1px solid #20292B;
+}
+
+#controlPanel-controls  .pcui-label-group > .pcui-label {
+    font-size: 14px;
+    max-width: 35%;
+}
+
+#controlPanel-controls  .pcui-label-group > .pcui-slider > .pcui-numeric-input {
+    min-width: 46px;
 }
 
 .filter-input {

--- a/examples/src/examples/graphics/lights.tsx
+++ b/examples/src/examples/graphics/lights.tsx
@@ -21,7 +21,7 @@ class LightsExample extends Example {
     // @ts-ignore: override class function
     controls(data: Observer) {
         return <>
-            <Panel headerText='OMNI LIGHT'>
+            <Panel headerText='OMNI LIGHT [KEY_1]'>
                 <LabelGroup text='enabled'>
                     <BooleanInput type='toggle' binding={new BindingTwoWay()} link={{ observer: data, path: 'lights.omni.enabled' }}/>
                 </LabelGroup>
@@ -29,7 +29,7 @@ class LightsExample extends Example {
                     <SliderInput binding={new BindingTwoWay()} link={{ observer: data, path: 'lights.omni.intensity' }}/>
                 </LabelGroup>
             </Panel>
-            <Panel headerText='SPOT LIGHT'>
+            <Panel headerText='SPOT LIGHT [KEY_2]'>
                 <LabelGroup text='enabled'>
                     <BooleanInput type='toggle' binding={new BindingTwoWay()} link={{ observer: data, path: 'lights.spot.enabled' }}/>
                 </LabelGroup>
@@ -37,7 +37,7 @@ class LightsExample extends Example {
                     <SliderInput binding={new BindingTwoWay()} link={{ observer: data, path: 'lights.spot.intensity' }}/>
                 </LabelGroup>
             </Panel>
-            <Panel headerText='DIRECTIONAL LIGHT'>
+            <Panel headerText='DIRECTIONAL LIGHT [KEY_3]'>
                 <LabelGroup text='enabled'>
                     <BooleanInput type='toggle' binding={new BindingTwoWay()} link={{ observer: data, path: 'lights.directional.enabled' }}/>
                 </LabelGroup>
@@ -182,6 +182,23 @@ class LightsExample extends Example {
             ...data.get('lights.directional')
         });
         app.root.addChild(lights.directional);
+
+        // Allow user to toggle individual lights
+        app.keyboard.on("keydown", function (e) {
+            // if the user is editing an input field, ignore key presses
+            if (e.element.constructor.name === 'HTMLInputElement') return;
+            switch (e.key) {
+                case pc.KEY_1:
+                    data.set('lights.omni.enabled', !data.get('lights.omni.enabled'));
+                    break;
+                case pc.KEY_2:
+                    data.set('lights.spot.enabled', !data.get('lights.spot.enabled'));
+                    break;
+                case pc.KEY_3:
+                    data.set('lights.directional.enabled', !data.get('lights.directional.enabled'));
+                    break;
+            }
+        }, this);
 
         // Simple update loop to rotate the light
         let angleRad = 1;

--- a/examples/src/examples/graphics/lights.tsx
+++ b/examples/src/examples/graphics/lights.tsx
@@ -2,6 +2,10 @@ import React from 'react';
 import * as pc from 'playcanvas/build/playcanvas.js';
 import Example from '../../app/example';
 import { AssetLoader } from '../../app/helpers/loader';
+// @ts-ignore: library file import
+import { Panel, SliderInput, LabelGroup, BooleanInput } from '@playcanvas/pcui/pcui-react';
+// @ts-ignore: library file import
+import { BindingTwoWay, Observer } from '@playcanvas/pcui/pcui-binding';
 
 class LightsExample extends Example {
     static CATEGORY = 'Graphics';
@@ -10,13 +14,42 @@ class LightsExample extends Example {
     load() {
         return <>
             <AssetLoader name='statue' type='container' url='static/assets/models/statue.glb' />
-            <AssetLoader name='font' type='font' url='static/assets/fonts/arial.json' />
             <AssetLoader name="heart" type="texture" url="static/assets/textures/heart.png" />
         </>;
     }
 
+    // @ts-ignore: override class function
+    controls(data: Observer) {
+        return <>
+            <Panel headerText='OMNI LIGHT'>
+                <LabelGroup text='enabled'>
+                    <BooleanInput type='toggle' binding={new BindingTwoWay()} link={{ observer: data, path: 'lights.omni.enabled' }}/>
+                </LabelGroup>
+                <LabelGroup text='intensity'>
+                    <SliderInput binding={new BindingTwoWay()} link={{ observer: data, path: 'lights.omni.intensity' }}/>
+                </LabelGroup>
+            </Panel>
+            <Panel headerText='SPOT LIGHT'>
+                <LabelGroup text='enabled'>
+                    <BooleanInput type='toggle' binding={new BindingTwoWay()} link={{ observer: data, path: 'lights.spot.enabled' }}/>
+                </LabelGroup>
+                <LabelGroup text='intensity'>
+                    <SliderInput binding={new BindingTwoWay()} link={{ observer: data, path: 'lights.spot.intensity' }}/>
+                </LabelGroup>
+            </Panel>
+            <Panel headerText='DIRECTIONAL LIGHT'>
+                <LabelGroup text='enabled'>
+                    <BooleanInput type='toggle' binding={new BindingTwoWay()} link={{ observer: data, path: 'lights.directional.enabled' }}/>
+                </LabelGroup>
+                <LabelGroup text='intensity'>
+                    <SliderInput binding={new BindingTwoWay()} link={{ observer: data, path: 'lights.directional.intensity' }}/>
+                </LabelGroup>
+            </Panel>
+        </>;
+    }
+
     // @ts-ignore: override class function$
-    example(canvas: HTMLCanvasElement, assets: any): void {
+    example(canvas: HTMLCanvasElement, assets: any, data:any): void {
         function createMaterial(colors: any) {
             const material: any = new pc.StandardMaterial();
             for (const param in colors) {
@@ -68,24 +101,44 @@ class LightsExample extends Example {
         ground.setLocalPosition(0, -0.5, 0);
         app.root.addChild(ground);
 
-        // Create an spot light
-        const spotlight = new pc.Entity();
-        spotlight.addComponent("light", {
-            type: "spot",
-            color: pc.Color.WHITE,
-            innerConeAngle: 30,
-            outerConeAngle: 31,
-            range: 100,
-            intensity: 0.6,
-            castShadows: true,
-            shadowBias: 0.05,
-            normalOffsetBias: 0.03,
-            shadowResolution: 2048,
+        // setup light data
 
-            // heart texture's alpha channel as a cookie texture
-            cookie: assets.heart.resource,
-            // cookie: assets.heart.asset.resource,
-            cookieChannel: "a"
+        data.set('lights', {
+            spot: {
+                enabled: true,
+                intensity: 0.6
+            },
+            omni: {
+                enabled: true,
+                intensity: 0.6
+            },
+            directional: {
+                enabled: true,
+                intensity: 0.6
+            }
+        });
+
+        const lights: {[key: string]: pc.Entity } = {};
+
+        // Create an spot light
+        lights.spot = new pc.Entity();
+        lights.spot.addComponent("light", {
+            ...{
+                type: "spot",
+                color: pc.Color.WHITE,
+                innerConeAngle: 30,
+                outerConeAngle: 31,
+                range: 100,
+                castShadows: true,
+                shadowBias: 0.05,
+                normalOffsetBias: 0.03,
+                shadowResolution: 2048,
+                // heart texture's alpha channel as a cookie texture
+                cookie: assets.heart.resource,
+                // cookie: assets.heart.asset.resource,
+                cookieChannel: "a"
+            },
+            ...data.get('lights.spot')
         });
 
         const cone = new pc.Entity();
@@ -94,77 +147,41 @@ class LightsExample extends Example {
             castShadows: false,
             material: createMaterial({ emissive: pc.Color.WHITE })
         });
-        spotlight.addChild(cone);
-        app.root.addChild(spotlight);
+        lights.spot.addChild(cone);
+        app.root.addChild(lights.spot);
 
         // Create a omni light
-        const omnilight = new pc.Entity();
-        omnilight.addComponent("light", {
-            type: "omni",
-            color: pc.Color.YELLOW,
-            range: 100,
-            castShadows: true,
-            intensity: 0.6
+        lights.omni = new pc.Entity();
+        lights.omni.addComponent("light", {
+            ...{
+                type: "omni",
+                color: pc.Color.YELLOW,
+                castShadows: true,
+                range: 100
+            },
+            ...data.get('lights.omni')
         });
-        omnilight.addComponent("render", {
+        lights.omni.addComponent("render", {
             type: "sphere",
             castShadows: false,
             material: createMaterial({ diffuse: pc.Color.BLACK, emissive: pc.Color.YELLOW })
         });
-        app.root.addChild(omnilight);
+        app.root.addChild(lights.omni);
 
         // Create a directional light
-        const directionallight = new pc.Entity();
-        directionallight.addComponent("light", {
-            type: "directional",
-            color: pc.Color.CYAN,
-            range: 100,
-            castShadows: true,
-            shadowBias: 0.1,
-            normalOffsetBias: 0.2,
-            intensity: 0.6
+        lights.directional = new pc.Entity();
+        lights.directional.addComponent("light", {
+            ...{
+                type: "directional",
+                color: pc.Color.CYAN,
+                range: 100,
+                castShadows: true,
+                shadowBias: 0.1,
+                normalOffsetBias: 0.2
+            },
+            ...data.get('lights.directional')
         });
-        app.root.addChild(directionallight);
-
-
-        // Create a 2D screen for text rendering
-        const screen = new pc.Entity();
-        screen.addComponent("screen", {
-            referenceResolution: new pc.Vec2(1280, 720),
-            scaleBlend: 0.5,
-            scaleMode: pc.SCALEMODE_BLEND,
-            screenSpace: true
-        });
-        app.root.addChild(screen);
-
-        // Load a font
-
-        // Create a basic text element
-        const text = new pc.Entity();
-        text.addComponent("element", {
-            anchor: new pc.Vec4(0.1, 0.1, 0.5, 0.5),
-            fontAsset: assets.font,
-            fontSize: 28,
-            pivot: new pc.Vec2(0.5, 0.1),
-            type: pc.ELEMENTTYPE_TEXT,
-            alignment: pc.Vec2.ZERO
-        });
-        screen.addChild(text);
-
-        // Allow user to toggle individual lights
-        app.keyboard.on("keydown", function (e) {
-            switch (e.key) {
-                case pc.KEY_1:
-                    omnilight.enabled = !omnilight.enabled;
-                    break;
-                case pc.KEY_2:
-                    spotlight.enabled = !spotlight.enabled;
-                    break;
-                case pc.KEY_3:
-                    directionallight.enabled = !directionallight.enabled;
-                    break;
-            }
-        }, this);
+        app.root.addChild(lights.directional);
 
         // Simple update loop to rotate the light
         let angleRad = 1;
@@ -172,21 +189,23 @@ class LightsExample extends Example {
             angleRad += 0.3 * dt;
             if (entity) {
 
-                spotlight.lookAt(new pc.Vec3(0, -5, 0));
-                spotlight.rotateLocal(90, 0, 0);
-                spotlight.setLocalPosition(15 * Math.sin(angleRad), 25, 15 * Math.cos(angleRad));
+                lights.spot.lookAt(new pc.Vec3(0, -5, 0));
+                lights.spot.rotateLocal(90, 0, 0);
+                lights.spot.setLocalPosition(15 * Math.sin(angleRad), 25, 15 * Math.cos(angleRad));
 
-                omnilight.setLocalPosition(5 * Math.sin(-2 * angleRad), 10, 5 * Math.cos(-2 * angleRad));
+                lights.omni.setLocalPosition(5 * Math.sin(-2 * angleRad), 10, 5 * Math.cos(-2 * angleRad));
 
-                directionallight.setLocalEulerAngles(45, -60 * angleRad, 0);
+                lights.directional.setLocalEulerAngles(45, -60 * angleRad, 0);
             }
+        });
 
-            // update text showing which lights are enabled
-            if (text) {
-                text.element.text =
-                    "[Key 1] Omni light: " + omnilight.enabled +
-                    "\n[Key 2] Spot light: " + spotlight.enabled +
-                    "\n[Key 3] Directional light: " + directionallight.enabled;
+        data.on('*:set', (path: string, value: any) => {
+            const pathArray = path.split('.');
+            if (pathArray[2] === 'enabled') {
+                lights[pathArray[1]].enabled = value;
+            } else {
+                // @ts-ignore
+                lights[pathArray[1]][pathArray[2]] = value;
             }
         });
     }

--- a/examples/src/examples/graphics/post-effects.tsx
+++ b/examples/src/examples/graphics/post-effects.tsx
@@ -2,6 +2,10 @@ import React from 'react';
 import * as pc from 'playcanvas/build/playcanvas.js';
 import { AssetLoader } from '../../app/helpers/loader';
 import Example from '../../app/example';
+// @ts-ignore: library file import
+import { Panel, SliderInput, LabelGroup, BooleanInput } from '@playcanvas/pcui/pcui-react';
+// @ts-ignore: library file import
+import { BindingTwoWay, Observer } from '@playcanvas/pcui/pcui-binding';
 
 class PostEffectsExample extends Example {
     static CATEGORY = 'Graphics';
@@ -20,7 +24,76 @@ class PostEffectsExample extends Example {
     }
 
     // @ts-ignore: override class function
-    example(canvas: HTMLCanvasElement, assets: any): void {
+    controls(data: Observer) {
+        return <>
+            <Panel headerText='BLOOM'>
+                <LabelGroup text='enabled'>
+                    <BooleanInput type='toggle' binding={new BindingTwoWay()} link={{ observer: data, path: 'scripts.bloom.enabled' }}/>
+                </LabelGroup>
+                <LabelGroup text='intensity'>
+                    <SliderInput binding={new BindingTwoWay()} link={{ observer: data, path: 'scripts.bloom.bloomIntensity' }}/>
+                </LabelGroup>
+                <LabelGroup text='threshold'>
+                    <SliderInput binding={new BindingTwoWay()} link={{ observer: data, path: 'scripts.bloom.bloomThreshold' }}/>
+                </LabelGroup>
+                <LabelGroup text='blur amount'>
+                    <SliderInput binding={new BindingTwoWay()} link={{ observer: data, path: 'scripts.bloom.blurAmount' }} min={1} max={30}/>
+                </LabelGroup>
+            </Panel>
+            <Panel headerText='SEPIA'>
+                <LabelGroup text='enabled'>
+                    <BooleanInput type='toggle' binding={new BindingTwoWay()} link={{ observer: data, path: 'scripts.sepia.enabled' }}/>
+                </LabelGroup>
+                <LabelGroup text='amount'>
+                    <SliderInput binding={new BindingTwoWay()} link={{ observer: data, path: 'scripts.sepia.amount' }}/>
+                </LabelGroup>
+            </Panel>
+            <Panel headerText='VIGNETTE'>
+                <LabelGroup text='enabled'>
+                    <BooleanInput type='toggle' binding={new BindingTwoWay()} link={{ observer: data, path: 'scripts.vignette.enabled' }}/>
+                </LabelGroup>
+                <LabelGroup text='darkness'>
+                    <SliderInput binding={new BindingTwoWay()} link={{ observer: data, path: 'scripts.vignette.darkness' }}/>
+                </LabelGroup>
+                <LabelGroup text='offset'>
+                    <SliderInput binding={new BindingTwoWay()} link={{ observer: data, path: 'scripts.vignette.offset' }} max={2}/>
+                </LabelGroup>
+            </Panel>
+            <Panel headerText='BOKEH'>
+                <LabelGroup text='enabled'>
+                    <BooleanInput type='toggle' binding={new BindingTwoWay()} link={{ observer: data, path: 'scripts.bokeh.enabled' }}/>
+                </LabelGroup>
+                <LabelGroup text='aperture'>
+                    <SliderInput binding={new BindingTwoWay()} link={{ observer: data, path: 'scripts.bokeh.aperture' }} max={0.2}/>
+                </LabelGroup>
+                <LabelGroup text='max blur'>
+                    <SliderInput binding={new BindingTwoWay()} link={{ observer: data, path: 'scripts.bokeh.maxBlur' }} max={0.1}/>
+                </LabelGroup>
+            </Panel>
+            <Panel headerText='SSAO'>
+                <LabelGroup text='enabled'>
+                    <BooleanInput type='toggle' binding={new BindingTwoWay()} link={{ observer: data, path: 'scripts.ssao.enabled' }}/>
+                </LabelGroup>
+                <LabelGroup text='radius'>
+                    <SliderInput binding={new BindingTwoWay()} link={{ observer: data, path: 'scripts.ssao.radius' }} max={10}/>
+                </LabelGroup>
+                <LabelGroup text='samples'>
+                    <SliderInput binding={new BindingTwoWay()} link={{ observer: data, path: 'scripts.ssao.samples' }} max={32}/>
+                </LabelGroup>
+                <LabelGroup text='brightness'>
+                    <SliderInput binding={new BindingTwoWay()} link={{ observer: data, path: 'scripts.ssao.brightness' }}/>
+                </LabelGroup>
+            </Panel>
+            <Panel headerText='POST-PROCESS UI'>
+                <LabelGroup text='enabled'>
+                    <BooleanInput type='toggle' binding={new BindingTwoWay()} link={{ observer: data, path: 'data.postProcessUI.enabled' }}/>
+                </LabelGroup>
+            </Panel>
+        </>;
+    }
+
+    // @ts-ignore: override class function
+    example(canvas: HTMLCanvasElement, assets: any, data: any): void {
         const app = new pc.Application(canvas, {
             keyboard: new pc.Keyboard(window)
         });
@@ -106,71 +179,45 @@ class PostEffectsExample extends Example {
             farClip: 500
         });
         camera.addComponent("script");
-        camera.script.create("ssao", {
-            attributes: {
+        data.set('scripts', {
+            ssao: {
+                enabled: true,
                 radius: 5,
                 samples: 16,
                 brightness: 0
-            }
-        });
-        camera.script.create("bloom", {
-            attributes: {
+            },
+            bloom: {
+                enabled: true,
                 bloomIntensity: 0.8,
                 bloomThreshold: 0.8,
                 blurAmount: 15
-            }
-        });
-        camera.script.create("sepia", {
-            attributes: {
+            },
+            sepia: {
+                enabled: true,
                 amount: 0.4
-            }
-        });
-        camera.script.create("vignette", {
-            attributes: {
+            },
+            vignette: {
+                enabled: true,
                 darkness: 1,
                 offset: 1.2
-            }
-        });
-        camera.script.create("bokeh", {
-            attributes: {
+            },
+            bokeh: {
+                enabled: true,
                 aperture: 0.1,
                 maxBlur: 0.01
             }
+        });
+
+        Object.keys(data.get('scripts')).forEach((key) => {
+            camera.script.create(key, {
+                attributes: data.get(`scripts.${key}`)
+            });
         });
 
         // position the camera in the world
         camera.setLocalPosition(0, 30, -60);
         camera.lookAt(0, 0, 100);
         app.root.addChild(camera);
-
-        // Allow user to toggle individual post effects
-        app.keyboard.on("keydown", function (e) {
-            switch (e.key) {
-                case pc.KEY_1:
-                    // @ts-ignore engine-tsd
-                    camera.script.bloom.enabled = !camera.script.bloom.enabled;
-                    break;
-                case pc.KEY_2:
-                    // @ts-ignore engine-tsd
-                    camera.script.sepia.enabled = !camera.script.sepia.enabled;
-                    break;
-                case pc.KEY_3:
-                    // @ts-ignore engine-tsd
-                    camera.script.vignette.enabled = !camera.script.vignette.enabled;
-                    break;
-                case pc.KEY_4:
-                    // @ts-ignore engine-tsd
-                    camera.script.bokeh.enabled = !camera.script.bokeh.enabled;
-                    break;
-                case pc.KEY_5:
-                    // @ts-ignore engine-tsd
-                    camera.script.ssao.enabled = !camera.script.ssao.enabled;
-                    break;
-                case pc.KEY_6:
-                    camera.camera.disablePostEffectsLayer = camera.camera.disablePostEffectsLayer === pc.LAYERID_UI ? undefined : pc.LAYERID_UI;
-                    break;
-            }
-        }, this);
 
         // Create a 2D screen to place UI on
         const screen = new pc.Entity();
@@ -194,6 +241,9 @@ class PostEffectsExample extends Example {
         });
         screen.addChild(text);
 
+        // Display some UI text which the post processing can be tested against
+        text.element.text = 'Test UI Text';
+
         // update things every frame
         let angle = 0;
         app.on("update", function (dt) {
@@ -210,19 +260,19 @@ class PostEffectsExample extends Example {
             // - it's a negative distance between the camera and the focus sphere
             camera.script.bokeh.focus = -focusPosition.sub(camera.getPosition()).length();
 
-            // update text showing which post effects are enabled
-            text.element.text =
-                `[Key 1] Bloom: ${camera.script.bloom.enabled}\n` +
-                `[Key 2] Sepia: ${camera.script.sepia.enabled}\n` +
-                `[Key 3] Vignette: ${camera.script.vignette.enabled}\n` +
-                `[Key 4] Bokeh: ${camera.script.bokeh.enabled}\n` +
-                `[Key 5] SSAO: ${camera.script.ssao.enabled}\n` +
-                `[Key 6] Post-process UI: ${camera.camera.disablePostEffectsLayer !== pc.LAYERID_UI}\n`;
-
             // display the depth textur if bokeh is enabled
             if (camera.script.bokeh.enabled) {
                 // @ts-ignore engine-tsd
                 app.renderDepthTexture(0.7, -0.7, 0.5, 0.5);
+            }
+        });
+
+        data.on('*:set', (path: string, value: any) => {
+            const pathArray = path.split('.');
+            if (pathArray[0] === 'scripts') {
+                camera.script[pathArray[1]][pathArray[2]] = value;
+            } else {
+                camera.camera.disablePostEffectsLayer = camera.camera.disablePostEffectsLayer === pc.LAYERID_UI ? undefined : pc.LAYERID_UI
             }
         });
     }

--- a/examples/src/examples/graphics/post-effects.tsx
+++ b/examples/src/examples/graphics/post-effects.tsx
@@ -26,7 +26,7 @@ class PostEffectsExample extends Example {
     // @ts-ignore: override class function
     controls(data: Observer) {
         return <>
-            <Panel headerText='BLOOM'>
+            <Panel headerText='BLOOM [KEY_1]'>
                 <LabelGroup text='enabled'>
                     <BooleanInput type='toggle' binding={new BindingTwoWay()} link={{ observer: data, path: 'scripts.bloom.enabled' }}/>
                 </LabelGroup>
@@ -40,7 +40,7 @@ class PostEffectsExample extends Example {
                     <SliderInput binding={new BindingTwoWay()} link={{ observer: data, path: 'scripts.bloom.blurAmount' }} min={1} max={30}/>
                 </LabelGroup>
             </Panel>
-            <Panel headerText='SEPIA'>
+            <Panel headerText='SEPIA [KEY_2]'>
                 <LabelGroup text='enabled'>
                     <BooleanInput type='toggle' binding={new BindingTwoWay()} link={{ observer: data, path: 'scripts.sepia.enabled' }}/>
                 </LabelGroup>
@@ -48,7 +48,7 @@ class PostEffectsExample extends Example {
                     <SliderInput binding={new BindingTwoWay()} link={{ observer: data, path: 'scripts.sepia.amount' }}/>
                 </LabelGroup>
             </Panel>
-            <Panel headerText='VIGNETTE'>
+            <Panel headerText='VIGNETTE [KEY_3]'>
                 <LabelGroup text='enabled'>
                     <BooleanInput type='toggle' binding={new BindingTwoWay()} link={{ observer: data, path: 'scripts.vignette.enabled' }}/>
                 </LabelGroup>
@@ -59,7 +59,7 @@ class PostEffectsExample extends Example {
                     <SliderInput binding={new BindingTwoWay()} link={{ observer: data, path: 'scripts.vignette.offset' }} max={2}/>
                 </LabelGroup>
             </Panel>
-            <Panel headerText='BOKEH'>
+            <Panel headerText='BOKEH [KEY_4]'>
                 <LabelGroup text='enabled'>
                     <BooleanInput type='toggle' binding={new BindingTwoWay()} link={{ observer: data, path: 'scripts.bokeh.enabled' }}/>
                 </LabelGroup>
@@ -70,7 +70,7 @@ class PostEffectsExample extends Example {
                     <SliderInput binding={new BindingTwoWay()} link={{ observer: data, path: 'scripts.bokeh.maxBlur' }} max={0.1}/>
                 </LabelGroup>
             </Panel>
-            <Panel headerText='SSAO'>
+            <Panel headerText='SSAO [KEY_5]'>
                 <LabelGroup text='enabled'>
                     <BooleanInput type='toggle' binding={new BindingTwoWay()} link={{ observer: data, path: 'scripts.ssao.enabled' }}/>
                 </LabelGroup>
@@ -84,7 +84,7 @@ class PostEffectsExample extends Example {
                     <SliderInput binding={new BindingTwoWay()} link={{ observer: data, path: 'scripts.ssao.brightness' }}/>
                 </LabelGroup>
             </Panel>
-            <Panel headerText='POST-PROCESS UI'>
+            <Panel headerText='POST-PROCESS UI [KEY_6]'>
                 <LabelGroup text='enabled'>
                     <BooleanInput type='toggle' binding={new BindingTwoWay()} link={{ observer: data, path: 'data.postProcessUI.enabled' }}/>
                 </LabelGroup>
@@ -218,6 +218,32 @@ class PostEffectsExample extends Example {
         camera.setLocalPosition(0, 30, -60);
         camera.lookAt(0, 0, 100);
         app.root.addChild(camera);
+
+        // Allow user to toggle individual post effects
+        app.keyboard.on("keydown", function (e) {
+            // if the user is editing an input field, ignore key presses
+            if (e.element.constructor.name === 'HTMLInputElement') return;
+            switch (e.key) {
+                case pc.KEY_1:
+                    data.set('scripts.bloom.enabled', !data.get('scripts.bloom.enabled'));
+                    break;
+                case pc.KEY_2:
+                    data.set('scripts.sepia.enabled', !data.get('scripts.sepia.enabled'));
+                    break;
+                case pc.KEY_3:
+                    data.set('scripts.vignette.enabled', !data.get('scripts.vignette.enabled'));
+                    break;
+                case pc.KEY_4:
+                    data.set('scripts.bokeh.enabled', !data.get('scripts.bokeh.enabled'));
+                    break;
+                case pc.KEY_5:
+                    data.set('scripts.ssao.enabled', !data.get('scripts.ssao.enabled'));
+                    break;
+                case pc.KEY_6:
+                    data.set('data.postProcessUI.enabled', !data.get('data.postProcessUI.enabled'));
+                    break;
+            }
+        }, this);
 
         // Create a 2D screen to place UI on
         const screen = new pc.Entity();


### PR DESCRIPTION
This PR moves control of the post effects and lights examples from the keyboard to the control panel. The control panel has been updated to support scrolling and will no longer extend past 100% of the screen. Also made a few other minor visual tweaks to the control panel.

![image](https://user-images.githubusercontent.com/1721533/125800147-59c6c73d-fd2a-40cd-a847-74477ae29a07.png)

![image](https://user-images.githubusercontent.com/1721533/125800081-a12feb8b-8cd7-4234-bc4a-c38a8370835e.png)

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
