### PR TITLE
Update SSAO code to Use New RenderTarget API

### DIFF
--- a/scripts/posteffects/posteffect-ssao.js
+++ b/scripts/posteffects/posteffect-ssao.js
@@ -377,7 +377,10 @@ function SSAOEffect(graphicsDevice, ssaoScript) {
         mipmaps: false
     });
     colorBuffer.name = 'ssao';
-    this.target = new pc.RenderTarget(graphicsDevice, colorBuffer, { depth: false });
+    this.target = new pc.RenderTarget({
+      colorBuffer: colorBuffer,
+      depth: false,
+    });
 
     // Uniforms
     this.radius = 4;

--- a/scripts/posteffects/posteffect-ssao.js
+++ b/scripts/posteffects/posteffect-ssao.js
@@ -378,8 +378,8 @@ function SSAOEffect(graphicsDevice, ssaoScript) {
     });
     colorBuffer.name = 'ssao';
     this.target = new pc.RenderTarget({
-      colorBuffer: colorBuffer,
-      depth: false,
+        colorBuffer: colorBuffer,
+        depth: false
     });
 
     // Uniforms


### PR DESCRIPTION
The SSAO post-effect uses the deprecated RenderTarget API, updated to use new API.

RenderTarget API: https://developer.playcanvas.com/en/api/pc.RenderTarget.html
