### PR TITLE
[FIX] Crash when compound kinematic body enters trigger

### DIFF
--- a/src/framework/components/rigid-body/system.js
+++ b/src/framework/components/rigid-body/system.js
@@ -731,15 +731,15 @@ class RigidBodyComponentSystem extends ComponentSystem {
             triggers[i].updateTransform();
         }
 
-        const compounds = this._compounds;
-        for (i = 0, len = compounds.length; i < len; i++) {
-            compounds[i]._updateCompound();
-        }
-
         // Update all kinematic bodies based on their current entity transform
         const kinematic = this._kinematic;
         for (i = 0, len = kinematic.length; i < len; i++) {
             kinematic[i]._updateKinematic();
+        }
+
+        const compounds = this._compounds;
+        for (i = 0, len = compounds.length; i < len; i++) {
+            compounds[i]._updateCompound();
         }
 
         // Step the physics simulation


### PR DESCRIPTION
I can't say why but if I update compounds *after* kinematics, the crash goes away.

Fixes #3127 

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
