### PR TITLE
Handle material offset correctly with reoriented textures

### DIFF
--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -408,7 +408,7 @@ class StandardMaterial extends Material {
         }
 
         transform = transform || new Vec4();
-        transform.set(tiling.x, tiling.y, offset.x, offset.y);
+        transform.set(tiling.x, tiling.y, offset.x, 1.0 - tiling.y - offset.y);
         return transform;
     }
 


### PR DESCRIPTION
Related to #3335

Material map offset + tiling need to be tweaked for backwards compatibility given engine's texture origin change.
