### PR TITLE
RTT texture flip flag

### DIFF
--- a/examples/src/examples/graphics/render-to-texture.tsx
+++ b/examples/src/examples/graphics/render-to-texture.tsx
@@ -69,7 +69,9 @@ class RenderToTextureExample extends Example {
         });
         const renderTarget = new pc.RenderTarget({
             colorBuffer: texture,
-            depth: true
+            depth: true,
+            // @ts-ignore
+            flipY: true
         });
 
         // create a layer for object that do not render into texture
@@ -130,7 +132,7 @@ class RenderToTextureExample extends Example {
         // create a plane called tv which we use to display rendered texture
         // this is only added to excluded Layer, so it does not render into texture
         const tv = createPrimitive("plane", new pc.Vec3(6, 8, -5), new pc.Vec3(20, 10, 10), pc.Color.BLACK, [excludedLayer.id]);
-        tv.setLocalEulerAngles(90, 0, 180);
+        tv.setLocalEulerAngles(90, 0, 0);
         tv.render.castShadows = false;
         tv.render.receiveShadows = false;
         // @ts-ignore engine-tsd

--- a/src/graphics/render-target.js
+++ b/src/graphics/render-target.js
@@ -32,6 +32,8 @@ const defaultOptions = {
  * * {@link CUBEFACE_POSZ}
  * * {@link CUBEFACE_NEGZ}
  *
+ * @param {boolean} [options.flipY] - Render the image flipped in Y, useful when the render target will be used as a texture in UI rendering.
+ *
  * Defaults to {@link CUBEFACE_POSX}.
  * @example
  * // Create a 512x512x24-bit render target with a depth buffer
@@ -126,6 +128,9 @@ class RenderTarget {
         if (!this.name) {
             this.name = "Untitled";
         }
+
+        // render image flipped in Y
+        this.flipY = !!options.flipY;
     }
 
     /**

--- a/src/graphics/render-target.js
+++ b/src/graphics/render-target.js
@@ -32,7 +32,7 @@ const defaultOptions = {
  * * {@link CUBEFACE_POSZ}
  * * {@link CUBEFACE_NEGZ}
  *
- * @param {boolean} [options.flipY] - Render the image flipped in Y, useful when the render target will be used as a texture in UI rendering.
+ * @param {boolean} [options.flipY] - When set to true the image will be flipped in Y. Default is false.
  *
  * Defaults to {@link CUBEFACE_POSX}.
  * @example

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -48,8 +48,7 @@ var viewMat3 = new Mat3();
 var viewProjMat = new Mat4();
 var projMat;
 
-var flipYMat = new Mat4();
-flipYMat.setScale(1, -1, 1);
+var flipYMat = new Mat4().setScale(1, -1, 1);
 var flippedViewProjMat = new Mat4();
 var flippedSkyboxProjMat = new Mat4();
 

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -1377,6 +1377,8 @@ class ForwardRenderer {
                     }
                 }
 
+                // enable cull inversion if either the camera has flipFaces enabled or the render target
+                // has flipY enabled (but disable inversion if both are true or false).
                 this.setCullMode(camera._cullFaces, !!(camera._flipFaces ^ rtFlipY), drawCall);
 
                 stencilFront = drawCall.stencilFront || material.stencilFront;
@@ -2306,7 +2308,7 @@ class ForwardRenderer {
                                    layer.cullingMask,
                                    layer.onDrawCall,
                                    layer,
-                                   !!(renderAction.renderTarget && renderAction.renderTarget.flipY));
+                                   !!(renderAction?.renderTarget?.flipY));
                 layer._forwardDrawCalls += this._forwardDrawCalls - draws;
 
                 // Revert temp frame stuff

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -48,6 +48,11 @@ var viewMat3 = new Mat3();
 var viewProjMat = new Mat4();
 var projMat;
 
+var flipYMat = new Mat4();
+flipYMat.setScale(1, -1, 1);
+var flippedViewProjMat = new Mat4();
+var flippedSkyboxProjMat = new Mat4();
+
 var viewInvL = new Mat4();
 var viewInvR = new Mat4();
 var viewL = new Mat4();
@@ -434,7 +439,17 @@ class ForwardRenderer {
 
             // ViewProjection Matrix
             viewProjMat.mul2(projMat, viewMat);
-            this.viewProjId.setValue(viewProjMat.data);
+
+            if (target && target.flipY) {
+                flippedViewProjMat.mul2(flipYMat, viewProjMat);
+                flippedSkyboxProjMat.mul2(flipYMat, camera.getProjectionMatrixSkybox());
+
+                this.viewProjId.setValue(flippedViewProjMat.data);
+                this.projSkyboxId.setValue(flippedSkyboxProjMat.data);
+            } else {
+                this.viewProjId.setValue(viewProjMat.data);
+                this.projSkyboxId.setValue(camera.getProjectionMatrixSkybox().data);
+            }
 
             // View Position (world space)
             this.dispatchViewPos(camera._node.getPosition());
@@ -1235,7 +1250,7 @@ class ForwardRenderer {
         this.viewPosId.setValue(vp);
     }
 
-    renderForward(camera, drawCalls, drawCallsCount, sortedLights, pass, cullingMask, drawCallback, layer) {
+    renderForward(camera, drawCalls, drawCallsCount, sortedLights, pass, cullingMask, drawCallback, layer, rtFlipY) {
         var device = this.device;
         var scene = this.scene;
         var vrDisplay = camera.vrDisplay;
@@ -1363,7 +1378,7 @@ class ForwardRenderer {
                     }
                 }
 
-                this.setCullMode(camera._cullFaces, camera._flipFaces, drawCall);
+                this.setCullMode(camera._cullFaces, !!(camera._flipFaces ^ rtFlipY), drawCall);
 
                 stencilFront = drawCall.stencilFront || material.stencilFront;
                 stencilBack = drawCall.stencilBack || material.stencilBack;
@@ -2291,7 +2306,8 @@ class ForwardRenderer {
                                    layer.shaderPass,
                                    layer.cullingMask,
                                    layer.onDrawCall,
-                                   layer);
+                                   layer,
+                                   !!(renderAction.renderTarget && renderAction.renderTarget.flipY));
                 layer._forwardDrawCalls += this._forwardDrawCalls - draws;
 
                 // Revert temp frame stuff

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -1249,7 +1249,7 @@ class ForwardRenderer {
         this.viewPosId.setValue(vp);
     }
 
-    renderForward(camera, drawCalls, drawCallsCount, sortedLights, pass, cullingMask, drawCallback, layer, rtFlipY) {
+    renderForward(camera, drawCalls, drawCallsCount, sortedLights, pass, cullingMask, drawCallback, layer, flipFaces) {
         var device = this.device;
         var scene = this.scene;
         var vrDisplay = camera.vrDisplay;
@@ -1377,9 +1377,7 @@ class ForwardRenderer {
                     }
                 }
 
-                // enable cull inversion if either the camera has flipFaces enabled or the render target
-                // has flipY enabled (but disable inversion if both are true or false).
-                this.setCullMode(camera._cullFaces, !!(camera._flipFaces ^ rtFlipY), drawCall);
+                this.setCullMode(camera._cullFaces, flipFaces, drawCall);
 
                 stencilFront = drawCall.stencilFront || material.stencilFront;
                 stencilBack = drawCall.stencilBack || material.stencilBack;
@@ -2299,6 +2297,10 @@ class ForwardRenderer {
                     renderAction.lightClusters.activate();
                 }
 
+                // enable flip faces if either the camera has _flipFaces enabled or the render target
+                // has flipY enabled
+                const flipFaces = !!(camera._flipFaces ^ renderAction?.renderTarget?.flipY);
+
                 const draws = this._forwardDrawCalls;
                 this.renderForward(camera.camera,
                                    visible.list,
@@ -2308,7 +2310,7 @@ class ForwardRenderer {
                                    layer.cullingMask,
                                    layer.onDrawCall,
                                    layer,
-                                   !!(renderAction?.renderTarget?.flipY));
+                                   flipFaces);
                 layer._forwardDrawCalls += this._forwardDrawCalls - draws;
 
                 // Revert temp frame stuff


### PR DESCRIPTION
In #3335 we inverted V coordinates of 2d elements and built-in primitives to compensate for -not- flipping images at load time.

This change caused dynamically-rendered (RTT) textures to appear upside down.

This PR adds a flag to a render target `flipY` which will cause it to be rendered upside down. Enabling this flag on render targets destined for UI rendering will result in images correctly orientated.
