### PR TITLE
[Fix] Model parser releases meshes correctly

### DIFF
--- a/src/resources/animation.js
+++ b/src/resources/animation.js
@@ -53,11 +53,13 @@ class AnimationHandler {
 
     open(url, data) {
         if (path.getExtension(url).toLowerCase() === '.glb') {
-            const glb = GlbParser.parse("filename.glb", data, null);
-            if (!glb) {
-                return null;
+            const glbResources = GlbParser.parse("filename.glb", data, null);
+            if (glbResources) {
+                const animations = glbResources.animations;
+                glbResources.destroy();
+                return animations;
             }
-            return glb.animations;
+            return null;
         }
         return this["_parseAnimationV" + data.animation.version](data);
     }

--- a/src/resources/container.js
+++ b/src/resources/container.js
@@ -26,7 +26,9 @@ import { Model } from '../scene/model.js';
  */
 class ContainerResource {
     constructor(data) {
+        // glb content, of type GlbResources
         this.data = data;
+
         this._model = null;
         this.renders = [];
         this.materials = [];

--- a/src/resources/parser/glb-model.js
+++ b/src/resources/parser/glb-model.js
@@ -8,11 +8,13 @@ class GlbModelParser {
     }
 
     parse(data) {
-        const glb = GlbParser.parse("filename.glb", data, this._device);
-        if (!glb) {
-            return null;
+        const glbResources = GlbParser.parse("filename.glb", data, this._device);
+        if (glbResources) {
+            const model = ContainerResource.createModel(glbResources, Material.defaultMaterial);
+            glbResources.destroy();
+            return model;
         }
-        return ContainerResource.createModel(glb, Material.defaultMaterial);
+        return null;
     }
 }
 

--- a/src/resources/parser/glb-parser.js
+++ b/src/resources/parser/glb-parser.js
@@ -49,6 +49,30 @@ import { INTERPOLATION_CUBIC, INTERPOLATION_LINEAR, INTERPOLATION_STEP } from '.
 
 import { Asset } from '../../asset/asset.js';
 
+// resources loaded from GLB file that the parser returns
+class GlbResources {
+    constructor(gltf) {
+        this.gltf = gltf;
+        this.nodes = null;
+        this.scenes = null;
+        this.animations = null;
+        this.textures = null;
+        this.materials = null;
+        this.renders = null;
+        this.skins = null;
+        this.lights = null;
+    }
+
+    destroy() {
+        // render needs to dec ref meshes
+        if (this.renders) {
+            this.renders.forEach((render) => {
+                render.meshes = null;
+            });
+        }
+    }
+}
+
 const isDataURI = function (uri) {
     return /^data:.*,.*$/i.test(uri);
 };
@@ -1615,17 +1639,15 @@ const createResources = function (device, gltf, bufferViews, textureAssets, opti
         renders[i].meshes = meshes[i];
     }
 
-    const result = {
-        'gltf': gltf,
-        'nodes': nodes,
-        'scenes': scenes,
-        'animations': animations,
-        'textures': textureAssets,
-        'materials': materials,
-        'renders': renders,
-        'skins': skins,
-        'lights': lights
-    };
+    const result = new GlbResources(gltf);
+    result.nodes = nodes;
+    result.scenes = scenes;
+    result.animations = animations;
+    result.textures = textureAssets;
+    result.materials = materials;
+    result.renders = renders;
+    result.skins = skins;
+    result.lights = lights;
 
     if (postprocess) {
         postprocess(gltf, result);


### PR DESCRIPTION
Fixes an issue mentioned here: https://forum.playcanvas.com/t/unload-model-doesnt-release-vram-vertex-buffers/21131

Fixes a problem where data loaded from glb are not released correctly when a model parses uses them.