### PR TITLE
[Fix] Fixes skining using render component meshes imported using hierarchy in Editor

### DIFF
--- a/src/resources/container.js
+++ b/src/resources/container.js
@@ -116,7 +116,6 @@ class ContainerResource {
             if (gltfNode.hasOwnProperty('skin')) {
                 skinedMeshInstances.push({
                     meshInstance: meshInstance,
-                    skin: skins[gltfNode.skin],
                     rootBone: root,
                     entity: entity
                 });
@@ -194,8 +193,7 @@ class ContainerResource {
 
         // now that the hierarchy is created, create skin instances and resolve bones using the hierarchy
         skinedMeshInstances.forEach((data) => {
-            data.meshInstance.mesh.skin = data.skin;
-            data.meshInstance.skinInstance = SkinInstanceCache.createCachedSkinedInstance(data.skin, data.rootBone, data.entity);
+            data.meshInstance.skinInstance = SkinInstanceCache.createCachedSkinedInstance(data.meshInstance.mesh.skin, data.rootBone, data.entity);
         });
 
         // return the scene hierarachy created from scene clones

--- a/src/resources/parser/glb-parser.js
+++ b/src/resources/parser/glb-parser.js
@@ -1608,6 +1608,18 @@ const createLights = function (gltf, nodes, options) {
     return lights;
 };
 
+// link skins to the meshes
+const linkSkins = function (gltf, renders, skins) {
+    gltf.nodes.forEach((gltfNode) => {
+        if (gltfNode.hasOwnProperty('mesh') && gltfNode.hasOwnProperty('skin')) {
+            const meshGroup = renders[gltfNode.mesh].meshes;
+            meshGroup.forEach((mesh) => {
+                mesh.skin = skins[gltfNode.skin];
+            });
+        }
+    });
+};
+
 // create engine resources from the downloaded GLB data
 const createResources = function (device, gltf, bufferViews, textureAssets, options, callback) {
     const preprocess = options && options.global && options.global.preprocess;
@@ -1638,6 +1650,9 @@ const createResources = function (device, gltf, bufferViews, textureAssets, opti
         renders[i] = new Render();
         renders[i].meshes = meshes[i];
     }
+
+    // link skins to meshes
+    linkSkins(gltf, renders, skins);
 
     const result = new GlbResources(gltf);
     result.nodes = nodes;


### PR DESCRIPTION
The reasons for this fix:
- in https://github.com/playcanvas/engine/pull/3253 a change was made where the model is no longer being automatically created when a glb is loaded
- during the creation of the model before this change, skins were assigned to meshes
- now the skins are assigned to meshes when glb loads

Fixes issue mentioned here: https://forum.playcanvas.com/t/importing-models-with-hierarchy-is-now-in-soft-launch/20304/14