### PR TITLE
[FIX] Support for glTF extension KHR_mesh_quantization

### DIFF
--- a/src/resources/parser/glb-parser.js
+++ b/src/resources/parser/glb-parser.js
@@ -446,7 +446,7 @@ const createVertexBufferInternal = function (device, sourceDesc, disableFlipV) {
             sourceStride = source.stride / 4;
             // ensure we don't go beyond the end of the arraybuffer when dealing with
             // interlaced vertex formats
-            sourceArray = new Uint32Array(source.buffer, source.offset, (source.count - 1) * sourceStride + source.size / 4);
+            sourceArray = new Uint32Array(source.buffer, source.offset, (source.count - 1) * sourceStride + (source.size + 3) / 4);
 
             let src = 0;
             let dst = target.offset / 4;


### PR DESCRIPTION
Fixes a wayward vertex on quantised duck.

Before and after:
<img width="824" alt="Screenshot 2021-08-09 at 14 45 42" src="https://user-images.githubusercontent.com/11276292/128716414-fe26e1aa-df23-40f4-9513-88cade6e2e67.png">
<img width="824" alt="Screenshot 2021-08-09 at 14 44 29" src="https://user-images.githubusercontent.com/11276292/128716421-4aaf9c9c-de94-42bb-a453-964628265b17.png">
