### PR TITLE
Support KHR_texture_transform

### DIFF
--- a/src/graphics/program-lib/programs/standard.js
+++ b/src/graphics/program-lib/programs/standard.js
@@ -236,10 +236,9 @@ var standard = {
 
     _setMapTransform: function (codes, name, id, uv) {
         const varName = `texture_${name}MapTransform`;
+        const checkId = id + uv * 100;
 
         codes[0] += `uniform mat3 ${varName};\n`;
-
-        var checkId = id + uv * 100;
         if (!codes[3][checkId]) {
             codes[1] += `varying vec2 vUV${uv}_${id};\n`;
             codes[2] += `   vUV${uv}_${id} = (${varName} * vec3(uv${uv}, 1)).xy;\n`;

--- a/src/graphics/program-lib/programs/standard.js
+++ b/src/graphics/program-lib/programs/standard.js
@@ -238,10 +238,12 @@ var standard = {
         const varName = `texture_${name}MapTransform`;
         const checkId = id + uv * 100;
 
-        codes[0] += `uniform mat3 ${varName};\n`;
+        // upload a 3x2 matrix and manually perform the multiplication
+        codes[0] += `uniform vec3 ${varName}0;\n`;
+        codes[0] += `uniform vec3 ${varName}1;\n`;
         if (!codes[3][checkId]) {
             codes[1] += `varying vec2 vUV${uv}_${id};\n`;
-            codes[2] += `   vUV${uv}_${id} = (${varName} * vec3(uv${uv}, 1)).xy;\n`;
+            codes[2] += `   vUV${uv}_${id} = vec2(dot(uv${uv}, ${varName}0.xy) + ${varName}0.z, dot(uv${uv}, ${varName}1.xy) + ${varName}1.z).xy;\n`;
             codes[3][checkId] = true;
         }
         return codes;

--- a/src/graphics/program-lib/programs/standard.js
+++ b/src/graphics/program-lib/programs/standard.js
@@ -243,7 +243,7 @@ var standard = {
         codes[0] += `uniform vec3 ${varName}1;\n`;
         if (!codes[3][checkId]) {
             codes[1] += `varying vec2 vUV${uv}_${id};\n`;
-            codes[2] += `   vUV${uv}_${id} = vec2(dot(uv${uv}, ${varName}0.xy) + ${varName}0.z, dot(uv${uv}, ${varName}1.xy) + ${varName}1.z).xy;\n`;
+            codes[2] += `   vUV${uv}_${id} = vec2(dot(vec3(uv${uv}, 1), ${varName}0), dot(vec3(uv${uv}, 1), ${varName}1));\n`;
             codes[3][checkId] = true;
         }
         return codes;

--- a/src/graphics/program-lib/programs/standard.js
+++ b/src/graphics/program-lib/programs/standard.js
@@ -235,12 +235,14 @@ var standard = {
     },
 
     _setMapTransform: function (codes, name, id, uv) {
-        codes[0] += "uniform vec4 texture_" + name + "MapTransform;\n";
+        const varName = `texture_${name}MapTransform`;
+
+        codes[0] += `uniform mat3 ${varName};\n`;
 
         var checkId = id + uv * 100;
         if (!codes[3][checkId]) {
-            codes[1] += "varying vec2 vUV" + uv + "_" + id + ";\n";
-            codes[2] += "   vUV" + uv + "_" + id + " = uv" + uv + " * texture_" + name + "MapTransform.xy + texture_" + name + "MapTransform.zw;\n";
+            codes[1] += `varying vec2 vUV${uv}_${id};\n`;
+            codes[2] += `   vUV${uv}_${id} = (${varName} * vec3(uv${uv}, 1)).xy;\n`;
             codes[3][checkId] = true;
         }
         return codes;

--- a/src/math/mat3.js
+++ b/src/math/mat3.js
@@ -135,56 +135,6 @@ class Mat3 {
 
     /**
      * @function
-     * @name Mat3#mul2
-     * @description Multiplies the specified 3x3 matrices together and stores the result in
-     * the current instance.
-     * @param {Mat3} lhs - The 3x3 matrix used as the first multiplicand of the operation.
-     * @param {Mat3} rhs - The 3x3 matrix used as the second multiplicand of the operation.
-     * @returns {Mat3} Self for chaining.
-     */
-    mul2(lhs, rhs) {
-        const a = lhs.data;
-        const b = rhs.data;
-        const r = this.data;
-
-        const a00 = a[0];
-        const a01 = a[1];
-        const a02 = a[2];
-        const a10 = a[3];
-        const a11 = a[4];
-        const a12 = a[5];
-        const a20 = a[6];
-        const a21 = a[7];
-        const a22 = a[8];
-
-        let b0, b1, b2;
-
-        b0 = b[0];
-        b1 = b[1];
-        b2 = b[2];
-        r[0] = a00 * b0 + a10 * b1 + a20 * b2;
-        r[1] = a01 * b0 + a11 * b1 + a21 * b2;
-        r[2] = a02 * b0 + a12 * b1 + a22 * b2;
-
-        b0 = b[3];
-        b1 = b[4];
-        b2 = b[5];
-        r[3] = a00 * b0 + a10 * b1 + a20 * b2;
-        r[4] = a01 * b0 + a11 * b1 + a21 * b2;
-        r[5] = a02 * b0 + a12 * b1 + a22 * b2;
-
-        b0 = b[6];
-        b1 = b[7];
-        b2 = b[8];
-        r[6] = a00 * b0 + a10 * b1 + a20 * b2;
-        r[7] = a01 * b0 + a11 * b1 + a21 * b2;
-        r[8] = a02 * b0 + a12 * b1 + a22 * b2;
-
-        return this;
-    }
-
-    /**
-     * @function
      * @name Mat3#setIdentity
      * @description Sets the matrix to the identity matrix.
      * @returns {Mat3} Self for chaining.

--- a/src/math/mat3.js
+++ b/src/math/mat3.js
@@ -135,6 +135,56 @@ class Mat3 {
 
     /**
      * @function
+     * @name Mat3#mul2
+     * @description Multiplies the specified 3x3 matrices together and stores the result in
+     * the current instance.
+     * @param {Mat3} lhs - The 3x3 matrix used as the first multiplicand of the operation.
+     * @param {Mat3} rhs - The 3x3 matrix used as the second multiplicand of the operation.
+     * @returns {Mat3} Self for chaining.
+     */
+    mul2(lhs, rhs) {
+        const a = lhs.data;
+        const b = rhs.data;
+        const r = this.data;
+
+        const a00 = a[0];
+        const a01 = a[1];
+        const a02 = a[2];
+        const a10 = a[3];
+        const a11 = a[4];
+        const a12 = a[5];
+        const a20 = a[6];
+        const a21 = a[7];
+        const a22 = a[8];
+
+        let b0, b1, b2;
+
+        b0 = b[0];
+        b1 = b[1];
+        b2 = b[2];
+        r[0] = a00 * b0 + a10 * b1 + a20 * b2;
+        r[1] = a01 * b0 + a11 * b1 + a21 * b2;
+        r[2] = a02 * b0 + a12 * b1 + a22 * b2;
+
+        b0 = b[3];
+        b1 = b[4];
+        b2 = b[5];
+        r[3] = a00 * b0 + a10 * b1 + a20 * b2;
+        r[4] = a01 * b0 + a11 * b1 + a21 * b2;
+        r[5] = a02 * b0 + a12 * b1 + a22 * b2;
+
+        b0 = b[6];
+        b1 = b[7];
+        b2 = b[8];
+        r[6] = a00 * b0 + a10 * b1 + a20 * b2;
+        r[7] = a01 * b0 + a11 * b1 + a21 * b2;
+        r[8] = a02 * b0 + a12 * b1 + a22 * b2;
+
+        return this;
+    }
+
+    /**
+     * @function
      * @name Mat3#setIdentity
      * @description Sets the matrix to the identity matrix.
      * @returns {Mat3} Self for chaining.

--- a/src/resources/parser/glb-parser.js
+++ b/src/resources/parser/glb-parser.js
@@ -945,6 +945,9 @@ const createMaterial = function (gltfMaterial, textures, flipV) {
         "}"
     ].join('\n');
 
+    const zeros = [0, 0];
+    const ones = [1, 1];
+
     const extractTextureTransform = function (source, material, maps) {
         let map;
 
@@ -957,8 +960,8 @@ const createMaterial = function (gltfMaterial, textures, flipV) {
 
         const textureTransform = source.extensions?.KHR_texture_transform;
         if (textureTransform) {
-            const offset = textureTransform.offset || Vec2.ZERO;
-            const scale = textureTransform.scale || Vec2.ONE;
+            const offset = textureTransform.offset || zeros;
+            const scale = textureTransform.scale || ones;
             const rotation = textureTransform.rotation ? (-textureTransform.rotation * math.RAD_TO_DEG) : 0;
 
             const tilingVec = new Vec2(scale[0], scale[1]);

--- a/src/resources/parser/glb-parser.js
+++ b/src/resources/parser/glb-parser.js
@@ -3,8 +3,8 @@ import { path } from '../../core/path.js';
 import { http } from '../../net/http.js';
 
 import { math } from '../../math/math.js';
-import { Mat3 } from '../../math/mat3.js';
 import { Mat4 } from '../../math/mat4.js';
+import { Vec2 } from '../../math/vec2.js';
 import { Vec3 } from '../../math/vec3.js';
 import { Color } from '../../math/color.js';
 
@@ -960,14 +960,11 @@ const createMaterial = function (gltfMaterial, textures, flipV) {
             const offset = textureTransform.offset || [0, 0];
             const scale = textureTransform.scale || [1, 1];
             const rotation = -(textureTransform.rotation || 0);
-            const tmpMat = new Mat3();
-            tmpMat.set([
-                Math.cos(rotation) * scale[0], Math.sin(rotation) * scale[0], 0,
-                -Math.sin(rotation) * scale[1], Math.cos(rotation) * scale[1], 0,
-                offset[0], offset[1], 1
-            ]);
+
             for (map = 0; map < maps.length; ++map) {
-                material[maps[map] + 'MapTransform'] = tmpMat;
+                material[`${maps[map]}MapTiling`] = new Vec2(scale[0], scale[1]);
+                material[`${maps[map]}MapOffset`] = new Vec2(offset[0], 1.0 - scale[1] - offset[1]);
+                material[`${maps[map]}MapRotation`] = rotation;
             }
         }
     };

--- a/src/resources/parser/glb-parser.js
+++ b/src/resources/parser/glb-parser.js
@@ -955,7 +955,7 @@ const createMaterial = function (gltfMaterial, textures, flipV) {
             }
         }
 
-        const textureTransform = source?.extensions?.KHR_texture_transform;
+        const textureTransform = source.extensions?.KHR_texture_transform;
         if (textureTransform) {
             const offset = textureTransform.offset || [0, 0];
             const scale = textureTransform.scale || [1, 1];

--- a/src/resources/parser/glb-parser.js
+++ b/src/resources/parser/glb-parser.js
@@ -959,11 +959,14 @@ const createMaterial = function (gltfMaterial, textures, flipV) {
         if (textureTransform) {
             const offset = textureTransform.offset || [0, 0];
             const scale = textureTransform.scale || [1, 1];
-            const rotation = -(textureTransform.rotation || 0);
+            const rotation = textureTransform.rotation ? (-textureTransform.rotation * math.RAD_TO_DEG) : 0;
+
+            const tilingVec = new Vec2(scale[0], scale[1]);
+            const offsetVec = new Vec2(offset[0], 1.0 - scale[1] - offset[1]);
 
             for (map = 0; map < maps.length; ++map) {
-                material[`${maps[map]}MapTiling`] = new Vec2(scale[0], scale[1]);
-                material[`${maps[map]}MapOffset`] = new Vec2(offset[0], 1.0 - scale[1] - offset[1]);
+                material[`${maps[map]}MapTiling`] = tilingVec;
+                material[`${maps[map]}MapOffset`] = offsetVec;
                 material[`${maps[map]}MapRotation`] = rotation;
             }
         }

--- a/src/resources/parser/glb-parser.js
+++ b/src/resources/parser/glb-parser.js
@@ -957,8 +957,8 @@ const createMaterial = function (gltfMaterial, textures, flipV) {
 
         const textureTransform = source.extensions?.KHR_texture_transform;
         if (textureTransform) {
-            const offset = textureTransform.offset || [0, 0];
-            const scale = textureTransform.scale || [1, 1];
+            const offset = textureTransform.offset || Vec2.ZERO;
+            const scale = textureTransform.scale || Vec2.ONE;
             const rotation = textureTransform.rotation ? (-textureTransform.rotation * math.RAD_TO_DEG) : 0;
 
             const tilingVec = new Vec2(scale[0], scale[1]);

--- a/src/scene/materials/standard-material-options-builder.js
+++ b/src/scene/materials/standard-material-options-builder.js
@@ -330,7 +330,8 @@ StandardMaterialOptionsBuilder.prototype._getMapTransformID = function (xform, u
     }
 
     for (let i = 0; i < xforms.length; i++) {
-        if (arraysEqual(xforms[i], xform)) {
+        if (arraysEqual(xforms[i][0].value, xform[0].value) &&
+            arraysEqual(xforms[i][1].value, xform[1].value)) {
             return i + 1;
         }
     }

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -112,7 +112,7 @@ const _tmpMat1 = new Mat3();
  * @property {number} clearCoatNormalMapUv Clear coat normal map UV channel.
  * @property {Vec2} clearCoatNormalMapTiling Controls the 2D tiling of the main clear coat normal map.
  * @property {Vec2} clearCoatNormalMapOffset Controls the 2D offset of the main clear coat normal map. Each component is between 0 and 1.
- * @property {Mat3} clearCoatMapTransform Controls the 2D transform of the main clear coat map.
+ * @property {Mat3} clearCoatNormalMapTransform Controls the 2D transform of the main clear coat map.
  * @property {number} clearCoatBumpiness The bumpiness of the clear coat layer. This value scales the assigned main clear coat normal map.
  * It should be normally between 0 (no bump mapping) and 1 (full bump mapping), but can be set to e.g. 2 to give even more pronounced bump effect.
  *

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -47,7 +47,7 @@ const _propsSet = [];
  * @property {number} diffuseMapUv Main (primary) diffuse map UV channel.
  * @property {Vec2} diffuseMapTiling Controls the 2D tiling of the main (primary) diffuse map.
  * @property {Vec2} diffuseMapOffset Controls the 2D offset of the main (primary) diffuse map. Each component is between 0 and 1.
- * @property {Mat3} diffuseMapRotation Controls the 2D rotation of the main (primary) diffuse map.
+ * @property {number} diffuseMapRotation Controls the 2D rotation of the main (primary) diffuse map.
  * @property {string} diffuseMapChannel Color channels of the main (primary) diffuse map to use. Can be "r", "g", "b", "a", "rgb" or any swizzled combination.
  * @property {boolean} diffuseVertexColor Use mesh vertex colors for diffuse. If diffuseMap or are diffuseTint are set, they'll be multiplied by vertex colors.
  * @property {string} diffuseVertexColorChannel Vertex color channels to use for diffuse. Can be "r", "g", "b", "a", "rgb" or any swizzled combination.
@@ -56,7 +56,7 @@ const _propsSet = [];
  * @property {number} diffuseDetailMapUv Detail (secondary) diffuse map UV channel.
  * @property {Vec2} diffuseDetailMapTiling Controls the 2D tiling of the detail (secondary) diffuse map.
  * @property {Vec2} diffuseDetailMapOffset Controls the 2D offset of the detail (secondary) diffuse map. Each component is between 0 and 1.
- * @property {Mat3} diffuseDetailMapRotation Controls the 2D rotation of the main (secondary) diffuse map.
+ * @property {number} diffuseDetailMapRotation Controls the 2D rotation of the main (secondary) diffuse map.
  * @property {string} diffuseDetailMapChannel Color channels of the detail (secondary) diffuse map to use. Can be "r", "g", "b", "a", "rgb" or any swizzled combination.
  * @property {string} diffuseDetailMode Determines how the main (primary) and detail (secondary) diffuse maps are blended together. Can be:
  * * {@link DETAILMODE_MUL}: Multiply together the primary and secondary colors.
@@ -75,7 +75,7 @@ const _propsSet = [];
  * @property {number} specularMapUv Specular map UV channel.
  * @property {Vec2} specularMapTiling Controls the 2D tiling of the specular map.
  * @property {Vec2} specularMapOffset Controls the 2D offset of the specular map. Each component is between 0 and 1.
- * @property {Mat3} specularMapRotation Controls the 2D rotation of the specular map.
+ * @property {number} specularMapRotation Controls the 2D rotation of the specular map.
  * @property {string} specularMapChannel Color channels of the specular map to use. Can be "r", "g", "b", "a", "rgb" or any swizzled combination.
  * @property {boolean} specularVertexColor Use mesh vertex colors for specular. If specularMap or are specularTint are set, they'll be multiplied by vertex colors.
  * @property {string} specularVertexColorChannel Vertex color channels to use for specular. Can be "r", "g", "b", "a", "rgb" or any swizzled combination.
@@ -91,7 +91,7 @@ const _propsSet = [];
  * @property {number} clearCoatMapUv Clear coat intensity map UV channel.
  * @property {Vec2} clearCoatMapTiling Controls the 2D tiling of the clear coat intensity map.
  * @property {Vec2} clearCoatMapOffset Controls the 2D offset of the clear coat intensity map. Each component is between 0 and 1.
- * @property {Mat3} clearCoatMapRotation Controls the 2D rotation of the clear coat intensity map.
+ * @property {number} clearCoatMapRotation Controls the 2D rotation of the clear coat intensity map.
  * @property {string} clearCoatMapChannel Color channel of the clear coat intensity map to use. Can be "r", "g", "b" or "a".
  * @property {boolean} clearCoatVertexColor Use mesh vertex colors for clear coat intensity. If clearCoatMap is set, it'll be multiplied by vertex colors.
  * @property {string} clearCoatVertexColorChannel Vertex color channel to use for clear coat intensity. Can be "r", "g", "b" or "a".
@@ -100,7 +100,7 @@ const _propsSet = [];
  * @property {number} clearCoatGlossMapUv Clear coat gloss map UV channel.
  * @property {Vec2} clearCoatGlossMapTiling Controls the 2D tiling of the clear coat gloss map.
  * @property {Vec2} clearCoatGlossMapOffset Controls the 2D offset of the clear coat gloss map. Each component is between 0 and 1.
- * @property {Mat3} clearCoatGlossMapRotation Controls the 2D rotation of the clear coat gloss map.
+ * @property {number} clearCoatGlossMapRotation Controls the 2D rotation of the clear coat gloss map.
  * @property {string} clearCoatGlossMapChannel Color channel of the clear coat gloss map to use. Can be "r", "g", "b" or "a".
  * @property {boolean} clearCoatGlossVertexColor Use mesh vertex colors for clear coat glossiness. If clearCoatGlossMap is set, it'll be multiplied by vertex colors.
  * @property {string} clearCoatGlossVertexColorChannel Vertex color channel to use for clear coat glossiness. Can be "r", "g", "b" or "a".
@@ -108,7 +108,7 @@ const _propsSet = [];
  * @property {number} clearCoatNormalMapUv Clear coat normal map UV channel.
  * @property {Vec2} clearCoatNormalMapTiling Controls the 2D tiling of the main clear coat normal map.
  * @property {Vec2} clearCoatNormalMapOffset Controls the 2D offset of the main clear coat normal map. Each component is between 0 and 1.
- * @property {Mat3} clearCoatNormalMapRotation Controls the 2D rotation of the main clear coat map.
+ * @property {number} clearCoatNormalMapRotation Controls the 2D rotation of the main clear coat map.
  * @property {number} clearCoatBumpiness The bumpiness of the clear coat layer. This value scales the assigned main clear coat normal map.
  * It should be normally between 0 (no bump mapping) and 1 (full bump mapping), but can be set to e.g. 2 to give even more pronounced bump effect.
  *
@@ -122,7 +122,7 @@ const _propsSet = [];
  * @property {number} metalnessMapUv Metalness map UV channel.
  * @property {Vec2} metalnessMapTiling Controls the 2D tiling of the metalness map.
  * @property {Vec2} metalnessMapOffset Controls the 2D offset of the metalness map. Each component is between 0 and 1.
- * @property {Mat3} metalnessMapRotation Controls the 2D rotation of the metalness map.
+ * @property {number} metalnessMapRotation Controls the 2D rotation of the metalness map.
  * @property {string} metalnessMapChannel Color channel of the metalness map to use. Can be "r", "g", "b" or "a".
  * @property {boolean} metalnessVertexColor Use mesh vertex colors for metalness. If metalnessMap is set, it'll be multiplied by vertex colors.
  * @property {string} metalnessVertexColorChannel Vertex color channel to use for metalness. Can be "r", "g", "b" or "a".
@@ -135,7 +135,7 @@ const _propsSet = [];
  * @property {string} glossMapChannel Color channel of the gloss map to use. Can be "r", "g", "b" or "a".
  * @property {Vec2} glossMapTiling Controls the 2D tiling of the gloss map.
  * @property {Vec2} glossMapOffset Controls the 2D offset of the gloss map. Each component is between 0 and 1.
- * @property {Mat3} glossMapRotation Controls the 2D rotation of the gloss map.
+ * @property {number} glossMapRotation Controls the 2D rotation of the gloss map.
  * @property {boolean} glossVertexColor Use mesh vertex colors for glossiness. If glossMap is set, it'll be multiplied by vertex colors.
  * @property {string} glossVertexColorChannel Vertex color channel to use for glossiness. Can be "r", "g", "b" or "a".
  *
@@ -152,7 +152,7 @@ const _propsSet = [];
  * @property {number} emissiveMapUv Emissive map UV channel.
  * @property {Vec2} emissiveMapTiling Controls the 2D tiling of the emissive map.
  * @property {Vec2} emissiveMapOffset Controls the 2D offset of the emissive map. Each component is between 0 and 1.
- * @property {Mat3} emissiveMapRotation Controls the 2D rotation of the emissive map.
+ * @property {number} emissiveMapRotation Controls the 2D rotation of the emissive map.
  * @property {string} emissiveMapChannel Color channels of the emissive map to use. Can be "r", "g", "b", "a", "rgb" or any swizzled combination.
  * @property {boolean} emissiveVertexColor Use mesh vertex colors for emission. If emissiveMap or emissiveTint are set, they'll be multiplied by vertex colors.
  * @property {string} emissiveVertexColorChannel Vertex color channels to use for emission. Can be "r", "g", "b", "a", "rgb" or any swizzled combination.
@@ -166,7 +166,7 @@ const _propsSet = [];
  * @property {string} opacityMapChannel Color channel of the opacity map to use. Can be "r", "g", "b" or "a".
  * @property {Vec2} opacityMapTiling Controls the 2D tiling of the opacity map.
  * @property {Vec2} opacityMapOffset Controls the 2D offset of the opacity map. Each component is between 0 and 1.
- * @property {Mat3} opacityMapRotation Controls the 2D rotation of the opacity map.
+ * @property {number} opacityMapRotation Controls the 2D rotation of the opacity map.
  * @property {boolean} opacityVertexColor Use mesh vertex colors for opacity. If opacityMap is set, it'll be multiplied by vertex colors.
  * @property {string} opacityVertexColorChannel Vertex color channels to use for opacity. Can be "r", "g", "b" or "a".
  *
@@ -178,7 +178,7 @@ const _propsSet = [];
  * @property {number} normalMapUv Main (primary) normal map UV channel.
  * @property {Vec2} normalMapTiling Controls the 2D tiling of the main (primary) normal map.
  * @property {Vec2} normalMapOffset Controls the 2D offset of the main (primary) normal map. Each component is between 0 and 1.
- * @property {Mat3} normalMapRotation Controls the 2D rotation of the main (primary) normal map.
+ * @property {number} normalMapRotation Controls the 2D rotation of the main (primary) normal map.
  * @property {number} bumpiness The bumpiness of the material. This value scales the assigned main (primary) normal map.
  * It should be normally between 0 (no bump mapping) and 1 (full bump mapping), but can be set to e.g. 2 to give even more pronounced bump effect.
  *
@@ -186,7 +186,7 @@ const _propsSet = [];
  * @property {number} normalDetailMapUv Detail (secondary) normal map UV channel.
  * @property {Vec2} normalDetailMapTiling Controls the 2D tiling of the detail (secondary) normal map.
  * @property {Vec2} normalDetailMapOffset Controls the 2D offset of the detail (secondary) normal map. Each component is between 0 and 1.
- * @property {Mat3} normalDetailMapRotation Controls the 2D rotation of the detail (secondary) normal map.
+ * @property {number} normalDetailMapRotation Controls the 2D rotation of the detail (secondary) normal map.
  * @property {number} normalDetailMapBumpiness The bumpiness of the material. This value scales the assigned detail (secondary) normal map.
  * It should be normally between 0 (no bump mapping) and 1 (full bump mapping), but can be set to e.g. 2 to give even more pronounced bump effect.
  *
@@ -197,7 +197,7 @@ const _propsSet = [];
  * @property {string} heightMapChannel Color channel of the height map to use. Can be "r", "g", "b" or "a".
  * @property {Vec2} heightMapTiling Controls the 2D tiling of the height map.
  * @property {Vec2} heightMapOffset Controls the 2D offset of the height map. Each component is between 0 and 1.
- * @property {Mat3} heightMapRotation Controls the 2D rotation of the height map.
+ * @property {number} heightMapRotation Controls the 2D rotation of the height map.
  * @property {number} heightMapFactor Height map multiplier. Affects the strength of the parallax effect.
  *
  * @property {Texture|null} sphereMap The spherical environment map of the material (default is null). Affects reflections.
@@ -215,7 +215,7 @@ const _propsSet = [];
  * @property {string} lightMapChannel Color channels of the lightmap to use. Can be "r", "g", "b", "a", "rgb" or any swizzled combination.
  * @property {Vec2} lightMapTiling Controls the 2D tiling of the lightmap.
  * @property {Vec2} lightMapOffset Controls the 2D offset of the lightmap. Each component is between 0 and 1.
- * @property {Mat3} lightMapRotation Controls the 2D rotation of the lightmap.
+ * @property {number} lightMapRotation Controls the 2D rotation of the lightmap.
  * @property {boolean} lightVertexColor Use baked vertex lighting. If lightMap is set, it'll be multiplied by vertex colors.
  * @property {string} lightVertexColorChannel Vertex color channels to use for baked lighting. Can be "r", "g", "b", "a", "rgb" or any swizzled combination.
  *
@@ -225,7 +225,7 @@ const _propsSet = [];
  * @property {string} aoMapChannel Color channel of the AO map to use. Can be "r", "g", "b" or "a".
  * @property {Vec2} aoMapTiling Controls the 2D tiling of the AO map.
  * @property {Vec2} aoMapOffset Controls the 2D offset of the AO map. Each component is between 0 and 1.
- * @property {Mat3} aoMapRotation Controls the 2D rotation of the AO map.
+ * @property {number} aoMapRotation Controls the 2D rotation of the AO map.
  * @property {boolean} aoVertexColor Use mesh vertex colors for AO. If aoMap is set, it'll be multiplied by vertex colors.
  * @property {string} aoVertexColorChannel Vertex color channels to use for AO. Can be "r", "g", "b" or "a".
  * @property {number} occludeSpecular Uses ambient occlusion to darken specular/reflection. It's a hack, because real specular occlusion is view-dependent. However, it can be better than nothing.

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -1,6 +1,7 @@
 import { Color } from '../../math/color.js';
 import { Vec2 } from '../../math/vec2.js';
 import { Quat } from '../../math/quat.js';
+import { math } from '../../math/math.js';
 
 import { generateDpAtlas } from '../../graphics/paraboloid.js';
 import { shFromCubemap } from '../../graphics/prefilter-cubemap.js';
@@ -47,7 +48,7 @@ const _propsSet = [];
  * @property {number} diffuseMapUv Main (primary) diffuse map UV channel.
  * @property {Vec2} diffuseMapTiling Controls the 2D tiling of the main (primary) diffuse map.
  * @property {Vec2} diffuseMapOffset Controls the 2D offset of the main (primary) diffuse map. Each component is between 0 and 1.
- * @property {number} diffuseMapRotation Controls the 2D rotation of the main (primary) diffuse map.
+ * @property {number} diffuseMapRotation Controls the 2D rotation (in degrees) of the main (primary) diffuse map.
  * @property {string} diffuseMapChannel Color channels of the main (primary) diffuse map to use. Can be "r", "g", "b", "a", "rgb" or any swizzled combination.
  * @property {boolean} diffuseVertexColor Use mesh vertex colors for diffuse. If diffuseMap or are diffuseTint are set, they'll be multiplied by vertex colors.
  * @property {string} diffuseVertexColorChannel Vertex color channels to use for diffuse. Can be "r", "g", "b", "a", "rgb" or any swizzled combination.
@@ -56,7 +57,7 @@ const _propsSet = [];
  * @property {number} diffuseDetailMapUv Detail (secondary) diffuse map UV channel.
  * @property {Vec2} diffuseDetailMapTiling Controls the 2D tiling of the detail (secondary) diffuse map.
  * @property {Vec2} diffuseDetailMapOffset Controls the 2D offset of the detail (secondary) diffuse map. Each component is between 0 and 1.
- * @property {number} diffuseDetailMapRotation Controls the 2D rotation of the main (secondary) diffuse map.
+ * @property {number} diffuseDetailMapRotation Controls the 2D rotation (in degrees) of the main (secondary) diffuse map.
  * @property {string} diffuseDetailMapChannel Color channels of the detail (secondary) diffuse map to use. Can be "r", "g", "b", "a", "rgb" or any swizzled combination.
  * @property {string} diffuseDetailMode Determines how the main (primary) and detail (secondary) diffuse maps are blended together. Can be:
  * * {@link DETAILMODE_MUL}: Multiply together the primary and secondary colors.
@@ -75,7 +76,7 @@ const _propsSet = [];
  * @property {number} specularMapUv Specular map UV channel.
  * @property {Vec2} specularMapTiling Controls the 2D tiling of the specular map.
  * @property {Vec2} specularMapOffset Controls the 2D offset of the specular map. Each component is between 0 and 1.
- * @property {number} specularMapRotation Controls the 2D rotation of the specular map.
+ * @property {number} specularMapRotation Controls the 2D rotation (in degrees) of the specular map.
  * @property {string} specularMapChannel Color channels of the specular map to use. Can be "r", "g", "b", "a", "rgb" or any swizzled combination.
  * @property {boolean} specularVertexColor Use mesh vertex colors for specular. If specularMap or are specularTint are set, they'll be multiplied by vertex colors.
  * @property {string} specularVertexColorChannel Vertex color channels to use for specular. Can be "r", "g", "b", "a", "rgb" or any swizzled combination.
@@ -91,7 +92,7 @@ const _propsSet = [];
  * @property {number} clearCoatMapUv Clear coat intensity map UV channel.
  * @property {Vec2} clearCoatMapTiling Controls the 2D tiling of the clear coat intensity map.
  * @property {Vec2} clearCoatMapOffset Controls the 2D offset of the clear coat intensity map. Each component is between 0 and 1.
- * @property {number} clearCoatMapRotation Controls the 2D rotation of the clear coat intensity map.
+ * @property {number} clearCoatMapRotation Controls the 2D rotation (in degrees) of the clear coat intensity map.
  * @property {string} clearCoatMapChannel Color channel of the clear coat intensity map to use. Can be "r", "g", "b" or "a".
  * @property {boolean} clearCoatVertexColor Use mesh vertex colors for clear coat intensity. If clearCoatMap is set, it'll be multiplied by vertex colors.
  * @property {string} clearCoatVertexColorChannel Vertex color channel to use for clear coat intensity. Can be "r", "g", "b" or "a".
@@ -100,7 +101,7 @@ const _propsSet = [];
  * @property {number} clearCoatGlossMapUv Clear coat gloss map UV channel.
  * @property {Vec2} clearCoatGlossMapTiling Controls the 2D tiling of the clear coat gloss map.
  * @property {Vec2} clearCoatGlossMapOffset Controls the 2D offset of the clear coat gloss map. Each component is between 0 and 1.
- * @property {number} clearCoatGlossMapRotation Controls the 2D rotation of the clear coat gloss map.
+ * @property {number} clearCoatGlossMapRotation Controls the 2D rotation (in degrees) of the clear coat gloss map.
  * @property {string} clearCoatGlossMapChannel Color channel of the clear coat gloss map to use. Can be "r", "g", "b" or "a".
  * @property {boolean} clearCoatGlossVertexColor Use mesh vertex colors for clear coat glossiness. If clearCoatGlossMap is set, it'll be multiplied by vertex colors.
  * @property {string} clearCoatGlossVertexColorChannel Vertex color channel to use for clear coat glossiness. Can be "r", "g", "b" or "a".
@@ -108,7 +109,7 @@ const _propsSet = [];
  * @property {number} clearCoatNormalMapUv Clear coat normal map UV channel.
  * @property {Vec2} clearCoatNormalMapTiling Controls the 2D tiling of the main clear coat normal map.
  * @property {Vec2} clearCoatNormalMapOffset Controls the 2D offset of the main clear coat normal map. Each component is between 0 and 1.
- * @property {number} clearCoatNormalMapRotation Controls the 2D rotation of the main clear coat map.
+ * @property {number} clearCoatNormalMapRotation Controls the 2D rotation (in degrees) of the main clear coat map.
  * @property {number} clearCoatBumpiness The bumpiness of the clear coat layer. This value scales the assigned main clear coat normal map.
  * It should be normally between 0 (no bump mapping) and 1 (full bump mapping), but can be set to e.g. 2 to give even more pronounced bump effect.
  *
@@ -122,7 +123,7 @@ const _propsSet = [];
  * @property {number} metalnessMapUv Metalness map UV channel.
  * @property {Vec2} metalnessMapTiling Controls the 2D tiling of the metalness map.
  * @property {Vec2} metalnessMapOffset Controls the 2D offset of the metalness map. Each component is between 0 and 1.
- * @property {number} metalnessMapRotation Controls the 2D rotation of the metalness map.
+ * @property {number} metalnessMapRotation Controls the 2D rotation (in degrees) of the metalness map.
  * @property {string} metalnessMapChannel Color channel of the metalness map to use. Can be "r", "g", "b" or "a".
  * @property {boolean} metalnessVertexColor Use mesh vertex colors for metalness. If metalnessMap is set, it'll be multiplied by vertex colors.
  * @property {string} metalnessVertexColorChannel Vertex color channel to use for metalness. Can be "r", "g", "b" or "a".
@@ -135,7 +136,7 @@ const _propsSet = [];
  * @property {string} glossMapChannel Color channel of the gloss map to use. Can be "r", "g", "b" or "a".
  * @property {Vec2} glossMapTiling Controls the 2D tiling of the gloss map.
  * @property {Vec2} glossMapOffset Controls the 2D offset of the gloss map. Each component is between 0 and 1.
- * @property {number} glossMapRotation Controls the 2D rotation of the gloss map.
+ * @property {number} glossMapRotation Controls the 2D rotation (in degrees) of the gloss map.
  * @property {boolean} glossVertexColor Use mesh vertex colors for glossiness. If glossMap is set, it'll be multiplied by vertex colors.
  * @property {string} glossVertexColorChannel Vertex color channel to use for glossiness. Can be "r", "g", "b" or "a".
  *
@@ -152,7 +153,7 @@ const _propsSet = [];
  * @property {number} emissiveMapUv Emissive map UV channel.
  * @property {Vec2} emissiveMapTiling Controls the 2D tiling of the emissive map.
  * @property {Vec2} emissiveMapOffset Controls the 2D offset of the emissive map. Each component is between 0 and 1.
- * @property {number} emissiveMapRotation Controls the 2D rotation of the emissive map.
+ * @property {number} emissiveMapRotation Controls the 2D rotation (in degrees) of the emissive map.
  * @property {string} emissiveMapChannel Color channels of the emissive map to use. Can be "r", "g", "b", "a", "rgb" or any swizzled combination.
  * @property {boolean} emissiveVertexColor Use mesh vertex colors for emission. If emissiveMap or emissiveTint are set, they'll be multiplied by vertex colors.
  * @property {string} emissiveVertexColorChannel Vertex color channels to use for emission. Can be "r", "g", "b", "a", "rgb" or any swizzled combination.
@@ -166,7 +167,7 @@ const _propsSet = [];
  * @property {string} opacityMapChannel Color channel of the opacity map to use. Can be "r", "g", "b" or "a".
  * @property {Vec2} opacityMapTiling Controls the 2D tiling of the opacity map.
  * @property {Vec2} opacityMapOffset Controls the 2D offset of the opacity map. Each component is between 0 and 1.
- * @property {number} opacityMapRotation Controls the 2D rotation of the opacity map.
+ * @property {number} opacityMapRotation Controls the 2D rotation (in degrees) of the opacity map.
  * @property {boolean} opacityVertexColor Use mesh vertex colors for opacity. If opacityMap is set, it'll be multiplied by vertex colors.
  * @property {string} opacityVertexColorChannel Vertex color channels to use for opacity. Can be "r", "g", "b" or "a".
  *
@@ -178,7 +179,7 @@ const _propsSet = [];
  * @property {number} normalMapUv Main (primary) normal map UV channel.
  * @property {Vec2} normalMapTiling Controls the 2D tiling of the main (primary) normal map.
  * @property {Vec2} normalMapOffset Controls the 2D offset of the main (primary) normal map. Each component is between 0 and 1.
- * @property {number} normalMapRotation Controls the 2D rotation of the main (primary) normal map.
+ * @property {number} normalMapRotation Controls the 2D rotation (in degrees) of the main (primary) normal map.
  * @property {number} bumpiness The bumpiness of the material. This value scales the assigned main (primary) normal map.
  * It should be normally between 0 (no bump mapping) and 1 (full bump mapping), but can be set to e.g. 2 to give even more pronounced bump effect.
  *
@@ -186,7 +187,7 @@ const _propsSet = [];
  * @property {number} normalDetailMapUv Detail (secondary) normal map UV channel.
  * @property {Vec2} normalDetailMapTiling Controls the 2D tiling of the detail (secondary) normal map.
  * @property {Vec2} normalDetailMapOffset Controls the 2D offset of the detail (secondary) normal map. Each component is between 0 and 1.
- * @property {number} normalDetailMapRotation Controls the 2D rotation of the detail (secondary) normal map.
+ * @property {number} normalDetailMapRotation Controls the 2D rotation (in degrees) of the detail (secondary) normal map.
  * @property {number} normalDetailMapBumpiness The bumpiness of the material. This value scales the assigned detail (secondary) normal map.
  * It should be normally between 0 (no bump mapping) and 1 (full bump mapping), but can be set to e.g. 2 to give even more pronounced bump effect.
  *
@@ -197,7 +198,7 @@ const _propsSet = [];
  * @property {string} heightMapChannel Color channel of the height map to use. Can be "r", "g", "b" or "a".
  * @property {Vec2} heightMapTiling Controls the 2D tiling of the height map.
  * @property {Vec2} heightMapOffset Controls the 2D offset of the height map. Each component is between 0 and 1.
- * @property {number} heightMapRotation Controls the 2D rotation of the height map.
+ * @property {number} heightMapRotation Controls the 2D rotation (in degrees) of the height map.
  * @property {number} heightMapFactor Height map multiplier. Affects the strength of the parallax effect.
  *
  * @property {Texture|null} sphereMap The spherical environment map of the material (default is null). Affects reflections.
@@ -215,7 +216,7 @@ const _propsSet = [];
  * @property {string} lightMapChannel Color channels of the lightmap to use. Can be "r", "g", "b", "a", "rgb" or any swizzled combination.
  * @property {Vec2} lightMapTiling Controls the 2D tiling of the lightmap.
  * @property {Vec2} lightMapOffset Controls the 2D offset of the lightmap. Each component is between 0 and 1.
- * @property {number} lightMapRotation Controls the 2D rotation of the lightmap.
+ * @property {number} lightMapRotation Controls the 2D rotation (in degrees) of the lightmap.
  * @property {boolean} lightVertexColor Use baked vertex lighting. If lightMap is set, it'll be multiplied by vertex colors.
  * @property {string} lightVertexColorChannel Vertex color channels to use for baked lighting. Can be "r", "g", "b", "a", "rgb" or any swizzled combination.
  *
@@ -225,7 +226,7 @@ const _propsSet = [];
  * @property {string} aoMapChannel Color channel of the AO map to use. Can be "r", "g", "b" or "a".
  * @property {Vec2} aoMapTiling Controls the 2D tiling of the AO map.
  * @property {Vec2} aoMapOffset Controls the 2D offset of the AO map. Each component is between 0 and 1.
- * @property {number} aoMapRotation Controls the 2D rotation of the AO map.
+ * @property {number} aoMapRotation Controls the 2D rotation (in degrees) of the AO map.
  * @property {boolean} aoVertexColor Use mesh vertex colors for AO. If aoMap is set, it'll be multiplied by vertex colors.
  * @property {string} aoVertexColorChannel Vertex color channels to use for AO. Can be "r", "g", "b" or "a".
  * @property {number} occludeSpecular Uses ambient occlusion to darken specular/reflection. It's a hack, because real specular occlusion is view-dependent. However, it can be better than nothing.
@@ -404,6 +405,12 @@ class StandardMaterial extends Material {
         this.setParameter(name, value);
     }
 
+    _setParameters(parameters) {
+        parameters.forEach((v) => {
+            this._setParameter(v.name, v.value);
+        });
+    }
+
     _clearParameters() {
         _propsSet.forEach((p) => {
             delete this.parameters[p];
@@ -420,7 +427,7 @@ class StandardMaterial extends Material {
             const tname = mname + "Transform";
             const uniform = this.getUniform(tname);
             if (uniform) {
-                this._setParameter('texture_' + tname, uniform);
+                this._setParameters(uniform);
             }
         }
     }
@@ -801,12 +808,29 @@ function _defineTex2D(name, uv, channels, defChannel, vertexColor, detailMode) {
             return null;
         }
 
-        const uniform = material._allocUniform(mapTransform, () => new Float32Array(9));
-        uniform.set([
-            Math.cos(rotation) * tiling.x, Math.sin(rotation) * tiling.x, 0,
-            -Math.sin(rotation) * tiling.y, Math.cos(rotation) * tiling.y, 0,
-            offset.x, 1.0 - tiling.y - offset.y, 1
-        ]);
+        const uniform = material._allocUniform(mapTransform, () => {
+            return [{
+                name: `texture_${mapTransform}0`,
+                value: new Float32Array(3)
+            }, {
+                name: `texture_${mapTransform}1`,
+                value: new Float32Array(3)
+            }];
+        });
+
+        const cr = Math.cos(rotation * math.DEG_TO_RAD);
+        const sr = Math.sin(rotation * math.DEG_TO_RAD);
+
+        const uniform0 = uniform[0].value;
+        uniform0[0] = cr * tiling.x;
+        uniform0[1] = -sr * tiling.y;
+        uniform0[2] = offset.x;
+
+        const uniform1 = uniform[1].value;
+        uniform1[0] = sr * tiling.x;
+        uniform1[1] = cr * tiling.y;
+        uniform1[2] = 1.0 - tiling.y - offset.y;
+
         return uniform;
     });
 }
@@ -937,23 +961,29 @@ function _defineMaterialProps() {
     _defineObject("ambientSH");
 
     _defineObject("cubeMapProjectionBox", (material, device, scene) => {
-        const value = material.cubeMapProjectionBox;
+        const uniform = material._allocUniform('cubeMapProjectionBox', () => {
+            return [{
+                name: 'envBoxMin',
+                value: new Float32Array(3)
+            }, {
+                name: 'envBoxMax',
+                value: new Float32Array(3)
+            }];
+        });
 
-        const minUniform = material._allocUniform('cubeMapMin', () => new Float32Array(3));
-        const bboxMin = value.getMin();
-        minUniform.set([bboxMin.x, bboxMin.y, bboxMin.z]);
+        const bboxMin = material.cubeMapProjectionBox.getMin();
+        const minUniform = uniform[0].value;
+        minUniform[0] = bboxMin.x;
+        minUniform[1] = bboxMin.y;
+        minUniform[2] = bboxMin.z;
 
-        const maxUniform = material._allocUniform('cubeMapMax', () => new Float32Array(3));
-        const bboxMax = value.getMax();
-        maxUniform.set([bboxMax.x, bboxMax.y, bboxMax.z]);
+        const bboxMax = material.cubeMapProjectionBox.getMax();
+        const maxUniform = uniform[1].value;
+        maxUniform[0] = bboxMax.x;
+        maxUniform[1] = bboxMax.y;
+        maxUniform[2] = bboxMax.z;
 
-        return [{
-            name: "envBoxMin",
-            value: minUniform
-        }, {
-            name: "envBoxMax",
-            value: maxUniform
-        }];
+        return uniform;
     });
 
     _defineChunks();

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -1,7 +1,6 @@
 import { Color } from '../../math/color.js';
 import { Vec2 } from '../../math/vec2.js';
 import { Quat } from '../../math/quat.js';
-import { Mat3 } from '../../math/mat3.js';
 
 import { generateDpAtlas } from '../../graphics/paraboloid.js';
 import { shFromCubemap } from '../../graphics/prefilter-cubemap.js';
@@ -29,9 +28,6 @@ const _uniforms = {};
 // temporary helper array
 const _propsSet = [];
 
-const _tmpMat0 = new Mat3();
-const _tmpMat1 = new Mat3();
-
 /**
  * @class
  * @name StandardMaterial
@@ -51,7 +47,7 @@ const _tmpMat1 = new Mat3();
  * @property {number} diffuseMapUv Main (primary) diffuse map UV channel.
  * @property {Vec2} diffuseMapTiling Controls the 2D tiling of the main (primary) diffuse map.
  * @property {Vec2} diffuseMapOffset Controls the 2D offset of the main (primary) diffuse map. Each component is between 0 and 1.
- * @property {Mat3} diffuseMapTransform Controls the 2D transform of the main (primary) diffuse map.
+ * @property {Mat3} diffuseMapRotation Controls the 2D rotation of the main (primary) diffuse map.
  * @property {string} diffuseMapChannel Color channels of the main (primary) diffuse map to use. Can be "r", "g", "b", "a", "rgb" or any swizzled combination.
  * @property {boolean} diffuseVertexColor Use mesh vertex colors for diffuse. If diffuseMap or are diffuseTint are set, they'll be multiplied by vertex colors.
  * @property {string} diffuseVertexColorChannel Vertex color channels to use for diffuse. Can be "r", "g", "b", "a", "rgb" or any swizzled combination.
@@ -60,7 +56,7 @@ const _tmpMat1 = new Mat3();
  * @property {number} diffuseDetailMapUv Detail (secondary) diffuse map UV channel.
  * @property {Vec2} diffuseDetailMapTiling Controls the 2D tiling of the detail (secondary) diffuse map.
  * @property {Vec2} diffuseDetailMapOffset Controls the 2D offset of the detail (secondary) diffuse map. Each component is between 0 and 1.
- * @property {Mat3} diffuseDetailMapTransform Controls the 2D transform of the main (secondary) diffuse map.
+ * @property {Mat3} diffuseDetailMapRotation Controls the 2D rotation of the main (secondary) diffuse map.
  * @property {string} diffuseDetailMapChannel Color channels of the detail (secondary) diffuse map to use. Can be "r", "g", "b", "a", "rgb" or any swizzled combination.
  * @property {string} diffuseDetailMode Determines how the main (primary) and detail (secondary) diffuse maps are blended together. Can be:
  * * {@link DETAILMODE_MUL}: Multiply together the primary and secondary colors.
@@ -79,7 +75,7 @@ const _tmpMat1 = new Mat3();
  * @property {number} specularMapUv Specular map UV channel.
  * @property {Vec2} specularMapTiling Controls the 2D tiling of the specular map.
  * @property {Vec2} specularMapOffset Controls the 2D offset of the specular map. Each component is between 0 and 1.
- * @property {Mat3} specularMapTransform Controls the 2D transform of the specular map.
+ * @property {Mat3} specularMapRotation Controls the 2D rotation of the specular map.
  * @property {string} specularMapChannel Color channels of the specular map to use. Can be "r", "g", "b", "a", "rgb" or any swizzled combination.
  * @property {boolean} specularVertexColor Use mesh vertex colors for specular. If specularMap or are specularTint are set, they'll be multiplied by vertex colors.
  * @property {string} specularVertexColorChannel Vertex color channels to use for specular. Can be "r", "g", "b", "a", "rgb" or any swizzled combination.
@@ -95,7 +91,7 @@ const _tmpMat1 = new Mat3();
  * @property {number} clearCoatMapUv Clear coat intensity map UV channel.
  * @property {Vec2} clearCoatMapTiling Controls the 2D tiling of the clear coat intensity map.
  * @property {Vec2} clearCoatMapOffset Controls the 2D offset of the clear coat intensity map. Each component is between 0 and 1.
- * @property {Mat3} clearCoatMapTransform Controls the 2D transform of the clear coat intensity map.
+ * @property {Mat3} clearCoatMapRotation Controls the 2D rotation of the clear coat intensity map.
  * @property {string} clearCoatMapChannel Color channel of the clear coat intensity map to use. Can be "r", "g", "b" or "a".
  * @property {boolean} clearCoatVertexColor Use mesh vertex colors for clear coat intensity. If clearCoatMap is set, it'll be multiplied by vertex colors.
  * @property {string} clearCoatVertexColorChannel Vertex color channel to use for clear coat intensity. Can be "r", "g", "b" or "a".
@@ -104,7 +100,7 @@ const _tmpMat1 = new Mat3();
  * @property {number} clearCoatGlossMapUv Clear coat gloss map UV channel.
  * @property {Vec2} clearCoatGlossMapTiling Controls the 2D tiling of the clear coat gloss map.
  * @property {Vec2} clearCoatGlossMapOffset Controls the 2D offset of the clear coat gloss map. Each component is between 0 and 1.
- * @property {Mat3} clearCoatGlossMapTransform Controls the 2D transform of the clear coat gloss map.
+ * @property {Mat3} clearCoatGlossMapRotation Controls the 2D rotation of the clear coat gloss map.
  * @property {string} clearCoatGlossMapChannel Color channel of the clear coat gloss map to use. Can be "r", "g", "b" or "a".
  * @property {boolean} clearCoatGlossVertexColor Use mesh vertex colors for clear coat glossiness. If clearCoatGlossMap is set, it'll be multiplied by vertex colors.
  * @property {string} clearCoatGlossVertexColorChannel Vertex color channel to use for clear coat glossiness. Can be "r", "g", "b" or "a".
@@ -112,7 +108,7 @@ const _tmpMat1 = new Mat3();
  * @property {number} clearCoatNormalMapUv Clear coat normal map UV channel.
  * @property {Vec2} clearCoatNormalMapTiling Controls the 2D tiling of the main clear coat normal map.
  * @property {Vec2} clearCoatNormalMapOffset Controls the 2D offset of the main clear coat normal map. Each component is between 0 and 1.
- * @property {Mat3} clearCoatNormalMapTransform Controls the 2D transform of the main clear coat map.
+ * @property {Mat3} clearCoatNormalMapRotation Controls the 2D rotation of the main clear coat map.
  * @property {number} clearCoatBumpiness The bumpiness of the clear coat layer. This value scales the assigned main clear coat normal map.
  * It should be normally between 0 (no bump mapping) and 1 (full bump mapping), but can be set to e.g. 2 to give even more pronounced bump effect.
  *
@@ -126,7 +122,7 @@ const _tmpMat1 = new Mat3();
  * @property {number} metalnessMapUv Metalness map UV channel.
  * @property {Vec2} metalnessMapTiling Controls the 2D tiling of the metalness map.
  * @property {Vec2} metalnessMapOffset Controls the 2D offset of the metalness map. Each component is between 0 and 1.
- * @property {Mat3} metalnessMapTransform Controls the 2D transform of the metalness map.
+ * @property {Mat3} metalnessMapRotation Controls the 2D rotation of the metalness map.
  * @property {string} metalnessMapChannel Color channel of the metalness map to use. Can be "r", "g", "b" or "a".
  * @property {boolean} metalnessVertexColor Use mesh vertex colors for metalness. If metalnessMap is set, it'll be multiplied by vertex colors.
  * @property {string} metalnessVertexColorChannel Vertex color channel to use for metalness. Can be "r", "g", "b" or "a".
@@ -139,7 +135,7 @@ const _tmpMat1 = new Mat3();
  * @property {string} glossMapChannel Color channel of the gloss map to use. Can be "r", "g", "b" or "a".
  * @property {Vec2} glossMapTiling Controls the 2D tiling of the gloss map.
  * @property {Vec2} glossMapOffset Controls the 2D offset of the gloss map. Each component is between 0 and 1.
- * @property {Mat3} glossMapTransform Controls the 2D transform of the gloss map.
+ * @property {Mat3} glossMapRotation Controls the 2D rotation of the gloss map.
  * @property {boolean} glossVertexColor Use mesh vertex colors for glossiness. If glossMap is set, it'll be multiplied by vertex colors.
  * @property {string} glossVertexColorChannel Vertex color channel to use for glossiness. Can be "r", "g", "b" or "a".
  *
@@ -156,7 +152,7 @@ const _tmpMat1 = new Mat3();
  * @property {number} emissiveMapUv Emissive map UV channel.
  * @property {Vec2} emissiveMapTiling Controls the 2D tiling of the emissive map.
  * @property {Vec2} emissiveMapOffset Controls the 2D offset of the emissive map. Each component is between 0 and 1.
- * @property {Mat3} emissiveMapTransform Controls the 2D transform of the emissive map.
+ * @property {Mat3} emissiveMapRotation Controls the 2D rotation of the emissive map.
  * @property {string} emissiveMapChannel Color channels of the emissive map to use. Can be "r", "g", "b", "a", "rgb" or any swizzled combination.
  * @property {boolean} emissiveVertexColor Use mesh vertex colors for emission. If emissiveMap or emissiveTint are set, they'll be multiplied by vertex colors.
  * @property {string} emissiveVertexColorChannel Vertex color channels to use for emission. Can be "r", "g", "b", "a", "rgb" or any swizzled combination.
@@ -170,7 +166,7 @@ const _tmpMat1 = new Mat3();
  * @property {string} opacityMapChannel Color channel of the opacity map to use. Can be "r", "g", "b" or "a".
  * @property {Vec2} opacityMapTiling Controls the 2D tiling of the opacity map.
  * @property {Vec2} opacityMapOffset Controls the 2D offset of the opacity map. Each component is between 0 and 1.
- * @property {Mat3} opacityMapTransform Controls the 2D transform of the opacity map.
+ * @property {Mat3} opacityMapRotation Controls the 2D rotation of the opacity map.
  * @property {boolean} opacityVertexColor Use mesh vertex colors for opacity. If opacityMap is set, it'll be multiplied by vertex colors.
  * @property {string} opacityVertexColorChannel Vertex color channels to use for opacity. Can be "r", "g", "b" or "a".
  *
@@ -182,7 +178,7 @@ const _tmpMat1 = new Mat3();
  * @property {number} normalMapUv Main (primary) normal map UV channel.
  * @property {Vec2} normalMapTiling Controls the 2D tiling of the main (primary) normal map.
  * @property {Vec2} normalMapOffset Controls the 2D offset of the main (primary) normal map. Each component is between 0 and 1.
- * @property {Mat3} normalMapTransform Controls the 2D transform of the main (primary) normal map.
+ * @property {Mat3} normalMapRotation Controls the 2D rotation of the main (primary) normal map.
  * @property {number} bumpiness The bumpiness of the material. This value scales the assigned main (primary) normal map.
  * It should be normally between 0 (no bump mapping) and 1 (full bump mapping), but can be set to e.g. 2 to give even more pronounced bump effect.
  *
@@ -190,7 +186,7 @@ const _tmpMat1 = new Mat3();
  * @property {number} normalDetailMapUv Detail (secondary) normal map UV channel.
  * @property {Vec2} normalDetailMapTiling Controls the 2D tiling of the detail (secondary) normal map.
  * @property {Vec2} normalDetailMapOffset Controls the 2D offset of the detail (secondary) normal map. Each component is between 0 and 1.
- * @property {Mat3} normalDetailMapTransform Controls the 2D transform of the detail (secondary) normal map.
+ * @property {Mat3} normalDetailMapRotation Controls the 2D rotation of the detail (secondary) normal map.
  * @property {number} normalDetailMapBumpiness The bumpiness of the material. This value scales the assigned detail (secondary) normal map.
  * It should be normally between 0 (no bump mapping) and 1 (full bump mapping), but can be set to e.g. 2 to give even more pronounced bump effect.
  *
@@ -201,7 +197,7 @@ const _tmpMat1 = new Mat3();
  * @property {string} heightMapChannel Color channel of the height map to use. Can be "r", "g", "b" or "a".
  * @property {Vec2} heightMapTiling Controls the 2D tiling of the height map.
  * @property {Vec2} heightMapOffset Controls the 2D offset of the height map. Each component is between 0 and 1.
- * @property {Mat3} heightMapTransform Controls the 2D transform of the height map.
+ * @property {Mat3} heightMapRotation Controls the 2D rotation of the height map.
  * @property {number} heightMapFactor Height map multiplier. Affects the strength of the parallax effect.
  *
  * @property {Texture|null} sphereMap The spherical environment map of the material (default is null). Affects reflections.
@@ -219,7 +215,7 @@ const _tmpMat1 = new Mat3();
  * @property {string} lightMapChannel Color channels of the lightmap to use. Can be "r", "g", "b", "a", "rgb" or any swizzled combination.
  * @property {Vec2} lightMapTiling Controls the 2D tiling of the lightmap.
  * @property {Vec2} lightMapOffset Controls the 2D offset of the lightmap. Each component is between 0 and 1.
- * @property {Mat3} lightMapTransform Controls the 2D transform of the lightmap.
+ * @property {Mat3} lightMapRotation Controls the 2D rotation of the lightmap.
  * @property {boolean} lightVertexColor Use baked vertex lighting. If lightMap is set, it'll be multiplied by vertex colors.
  * @property {string} lightVertexColorChannel Vertex color channels to use for baked lighting. Can be "r", "g", "b", "a", "rgb" or any swizzled combination.
  *
@@ -229,7 +225,7 @@ const _tmpMat1 = new Mat3();
  * @property {string} aoMapChannel Color channel of the AO map to use. Can be "r", "g", "b" or "a".
  * @property {Vec2} aoMapTiling Controls the 2D tiling of the AO map.
  * @property {Vec2} aoMapOffset Controls the 2D offset of the AO map. Each component is between 0 and 1.
- * @property {Mat3} aoMapTransform Controls the 2D transform of the AO map.
+ * @property {Mat3} aoMapRotation Controls the 2D rotation of the AO map.
  * @property {boolean} aoVertexColor Use mesh vertex colors for AO. If aoMap is set, it'll be multiplied by vertex colors.
  * @property {string} aoVertexColorChannel Vertex color channels to use for AO. Can be "r", "g", "b" or "a".
  * @property {number} occludeSpecular Uses ambient occlusion to darken specular/reflection. It's a hack, because real specular occlusion is view-dependent. However, it can be better than nothing.
@@ -752,8 +748,8 @@ function _defineTex2D(name, uv, channels, defChannel, vertexColor, detailMode) {
     });
 
     defineProp({
-        name: `${name}MapTransform`,
-        defaultValue: new Mat3()
+        name: `${name}MapRotation`,
+        defaultValue: 0
     });
 
     defineProp({
@@ -792,43 +788,25 @@ function _defineTex2D(name, uv, channels, defChannel, vertexColor, detailMode) {
     // construct the transform uniform
     const mapTiling = `${name}MapTiling`;
     const mapOffset = `${name}MapOffset`;
+    const mapRotation = `${name}MapRotation`;
     const mapTransform = `${name}MapTransform`;
     defineUniform(mapTransform, (material, device, scene) => {
         const tiling = material[mapTiling];
         const offset = material[mapOffset];
-        const transform = material[mapTransform];
-        const tdata = transform.data;
+        const rotation = material[mapRotation];
 
-        const hasTilingOffset = tiling.x !== 1 || tiling.y !== 1 ||
-                                offset.x !== 0 || offset.y !== 0;
-
-        const hasTransform = tdata[0] !== 1 || tdata[1] !== 0 ||
-                             tdata[3] !== 0 || tdata[4] !== 1 ||
-                             tdata[6] !== 0 || tdata[7] !== 0;
-
-        if (!hasTilingOffset && !hasTransform) {
+        if (tiling.x === 1 && tiling.y === 1 &&
+            offset.x === 0 && offset.y === 0 &&
+            rotation === 0) {
             return null;
         }
 
-        let src;
-        if (hasTilingOffset) {
-            _tmpMat0[0] = tiling.x;
-            _tmpMat0[4] = tiling.y;
-            _tmpMat0[6] = offset.x;
-            _tmpMat0[7] = 1.0 - tiling.y - offset.y;
-
-            if (hasTransform) {
-                _tmpMat1.mul2(_tmpMat0, transform);
-                src = _tmpMat1.data;
-            } else {
-                src = _tmpMat0.data;
-            }
-        } else {
-            src = transform.data;
-        }
-
         const uniform = material._allocUniform(mapTransform, () => new Float32Array(9));
-        uniform.set(src);
+        uniform.set([
+            Math.cos(rotation) * tiling.x, Math.sin(rotation) * tiling.x, 0,
+            -Math.sin(rotation) * tiling.y, Math.cos(rotation) * tiling.y, 0,
+            offset.x, 1.0 - tiling.y - offset.y, 1
+        ]);
         return uniform;
     });
 }


### PR DESCRIPTION
This PR:
- adds `Mat3.mul2` function
- adds a `rotation` property to all the maps supported in `StandardMaterial`
- uses this to implement the full KHR_texture_transform gltf extension

Old:
![chrome](https://user-images.githubusercontent.com/11276292/129578687-f624500c-2187-41f8-8658-59ce713c58bb.png)

New:
![chrome](https://user-images.githubusercontent.com/11276292/129578768-90c17af3-7ecb-4d89-9351-f39d7a1f3d60.png)

Fixes https://github.com/playcanvas/engine/issues/2563