### PR TITLE
Use the same prefiltered lighting data for options parsing as before

### DIFF
--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -625,7 +625,7 @@ class StandardMaterial extends Material {
     updateShader(device, scene, objDefs, staticLightList, pass, sortedLights) {
         // update prefiltered lighting data
         this.updateLightingUniforms(device, scene);
-        const prefilteredCubeMap128 = this.parameters.texture_prefilteredCubeMap128?.data;
+        const prefilteredCubeMap128 = this.prefilteredCubeMap128 || (this.useSkybox && scene._skyboxPrefiltered[0]);
 
         // Minimal options for Depth and Shadow passes
         const minimalOptions = pass > SHADER_FORWARDHDR && pass <= SHADER_PICK;


### PR DESCRIPTION
In https://github.com/playcanvas/engine/pull/3391/files#diff-3d28fa0b12934d0b6f4314eb2637fca0e13c4f2e191ddce393fc8d473c27a06eR606 the texture used for prefiltered lighting data was changed to mirror the actual texture set on the material.

However if dual paraboloid lighting is chosen, this texture is null and the material options generator fails to set skyboxIntensity.

This PR reverts the source of texture to the way it was before.