### PR TITLE
Fix enabled flag on camea and light component

### DIFF
--- a/src/framework/components/camera/system.js
+++ b/src/framework/components/camera/system.js
@@ -107,6 +107,7 @@ class CameraComponentSystem extends ComponentSystem {
             clearDepthBuffer: c.clearDepthBuffer,
             clearStencilBuffer: c.clearStencilBuffer,
             cullFaces: c.cullFaces,
+            enabled: c.enabled,
             farClip: c.farClip,
             flipFaces: c.flipFaces,
             fov: c.fov,

--- a/src/resources/parser/glb-parser.js
+++ b/src/resources/parser/glb-parser.js
@@ -1434,6 +1434,7 @@ const createCamera = function (gltfCamera, node) {
 const createLight = function (gltfLight, node) {
 
     const lightProps = {
+        enabled: false,
         type: gltfLight.type === "point" ? "omni" : gltfLight.type,
         color: gltfLight.hasOwnProperty('color') ? new Color(gltfLight.color) : Color.WHITE,
         range: gltfLight.hasOwnProperty('range') ? gltfLight.range : Number.MAX_VALUE,


### PR DESCRIPTION
This PR:
- propagates the enabled flag on the camera component when cloning
- set the disabled flag on lights created during gltf load