### PR TITLE
Invoke equals on internal property

### DIFF
--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -709,7 +709,7 @@ const defineProp = (prop) => {
         },
         set: function (value) {
             const oldValue = this[internalName];
-            if (!funcs.equals(value, oldValue)) {
+            if (!funcs.equals(oldValue, value)) {
                 if (!this._dirtyShader) {
                     this._dirtyShader = dirtyShaderFunc ? dirtyShaderFunc(oldValue, value) : true;
                 }


### PR DESCRIPTION
Due to changes in #3391 a forum user encountered the following:

https://forum.playcanvas.com/t/error-on-previously-working-material-offset-tiling-manipulation/21521

That call should have worked and this PR addresses the issue by calling the `.equals` function on the internal object instead of the one passed in.