### PR TITLE
Fix lighting basis during RTT

### DIFF
--- a/src/graphics/program-lib/chunks/TBNderivative.frag
+++ b/src/graphics/program-lib/chunks/TBNderivative.frag
@@ -1,3 +1,5 @@
+uniform float tbnBasis;
+
 // http://www.thetenthplanet.de/archives/1180
 void getTBN() {
     vec2 uv = $UV;
@@ -16,6 +18,6 @@ void getTBN() {
 
     // construct a scale-invariant frame
     float denom = max( dot(T,T), dot(B,B) );
-    float invmax = (denom == 0.0) ? 0.0 : 1.0 / sqrt( denom );
-    dTBN = mat3( T * invmax, -B * invmax, dVertexNormalW );
+    float invmax = (denom == 0.0) ? 0.0 : tbnBasis / sqrt( denom );
+    dTBN = mat3(T * invmax, -B * invmax, dVertexNormalW );
 }

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -446,11 +446,9 @@ class ForwardRenderer {
 
                 this.viewProjId.setValue(flippedViewProjMat.data);
                 this.projSkyboxId.setValue(flippedSkyboxProjMat.data);
-                this.tbnBasis.setValue(-1);
             } else {
                 this.viewProjId.setValue(viewProjMat.data);
                 this.projSkyboxId.setValue(camera.getProjectionMatrixSkybox().data);
-                this.tbnBasis.setValue(1);
             }
 
             // View Position (world space)
@@ -458,6 +456,8 @@ class ForwardRenderer {
 
             camera.frustum.setFromMat4(viewProjMat);
         }
+
+        this.tbnBasis.setValue(target && target.flipY ? -1 : 1);
 
         // Near and far clip values
         this.nearClipId.setValue(camera._nearClip);

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -130,6 +130,7 @@ class ForwardRenderer {
         this.nearClipId = scope.resolve('camera_near');
         this.farClipId = scope.resolve('camera_far');
         this.cameraParamsId = scope.resolve('camera_params');
+        this.tbnBasis = scope.resolve('tbnBasis');
 
         this.fogColorId = scope.resolve('fog_color');
         this.fogStartId = scope.resolve('fog_start');
@@ -445,9 +446,11 @@ class ForwardRenderer {
 
                 this.viewProjId.setValue(flippedViewProjMat.data);
                 this.projSkyboxId.setValue(flippedSkyboxProjMat.data);
+                this.tbnBasis.setValue(-1);
             } else {
                 this.viewProjId.setValue(viewProjMat.data);
                 this.projSkyboxId.setValue(camera.getProjectionMatrixSkybox().data);
+                this.tbnBasis.setValue(1);
             }
 
             // View Position (world space)


### PR DESCRIPTION
As a consequence of #3335 the lighting basis was inverted when rendering of offscreen targets, see [here](https://forum.playcanvas.com/t/normal-maps-flipped-when-layer-is-rendered-into-a-texture/21515/3).

This PR:
- adds a `tbnBasis` fragment shader uniform and sets the value based on flipY
- uses this when calculating the lighting basis from UV derivatives

Before:
![Camera0 (21)](https://user-images.githubusercontent.com/11276292/130630881-06c6de54-f223-46de-aa52-64f88f6afbd2.png)

After:
![Camera0 (22)](https://user-images.githubusercontent.com/11276292/130630900-a0576ab7-7e79-4519-95a5-e9b3832358a7.png)