### PR TITLE
Remove Babel class properties plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
   "devDependencies": {
     "@babel/core": "^7.15.0",
     "@babel/eslint-parser": "^7.15.0",
-    "@babel/plugin-proposal-class-properties": "^7.14.5",
     "@babel/preset-env": "^7.15.0",
     "@playcanvas/eslint-config": "1.0.8",
     "@playcanvas/jsdoc-template": "1.0.19",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -93,13 +93,6 @@ const es5Options = {
                 }
             }
         ]
-    ],
-    plugins: [
-        [
-            '@babel/plugin-proposal-class-properties', {
-                loose: true
-            }
-        ]
     ]
 };
 
@@ -118,13 +111,6 @@ const moduleOptions = {
                 targets: {
                     esmodules: true
                 }
-            }
-        ]
-    ],
-    plugins: [
-        [
-            '@babel/plugin-proposal-class-properties', {
-                loose: true
             }
         ]
     ]


### PR DESCRIPTION
The Babel plugin `@babel/plugin-proposal-class-properties` has now been folded into `@babel/preset-env`. On [this page](https://babeljs.io/docs/en/babel-plugin-proposal-class-properties) it says:

> NOTE: This plugin is included in `@babel/preset-env`

So it is now safe to remove it from `package.json` and the Rollup config.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
