### PR TITLE
[FIX] Allow Application#destroy to work under Node.js

### DIFF
--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -1972,12 +1972,14 @@ class Application extends EventHandler {
         var canvasId = this.graphicsDevice.canvas.id;
 
         this.off('librariesloaded');
-        document.removeEventListener('visibilitychange', this._visibilityChangeHandler, false);
-        document.removeEventListener('mozvisibilitychange', this._visibilityChangeHandler, false);
-        document.removeEventListener('msvisibilitychange', this._visibilityChangeHandler, false);
-        document.removeEventListener('webkitvisibilitychange', this._visibilityChangeHandler, false);
+
+        if (typeof document !== 'undefined') {
+            document.removeEventListener('visibilitychange', this._visibilityChangeHandler, false);
+            document.removeEventListener('mozvisibilitychange', this._visibilityChangeHandler, false);
+            document.removeEventListener('msvisibilitychange', this._visibilityChangeHandler, false);
+            document.removeEventListener('webkitvisibilitychange', this._visibilityChangeHandler, false);
+        }
         this._visibilityChangeHandler = null;
-        this.onVisibilityChange = null;
 
         this.root.destroy();
         this.root = null;


### PR DESCRIPTION
Currently, `Application#destroy` will throw an exception under Node.js because `document` is not defined.

Note that the original code was also setting the function `Application#onVisibilityChange` to `null` for some unknown reason, so I've also removed that.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
