### PR TITLE
[Fix] Fix to generated UV1 coordinates of Primitives

### DIFF
--- a/src/scene/procedural.js
+++ b/src/scene/procedural.js
@@ -406,9 +406,9 @@ function _createConeData(baseRadius, peakRadius, height, heightSegments, capSegm
                 var _v = v;
                 v = u;
                 u = _v;
-                u /= 3;
                 u = u * primitiveUv1PaddingScale + primitiveUv1Padding;
                 v = v * primitiveUv1PaddingScale + primitiveUv1Padding;
+                u /= 3;
                 uvs1.push(u, 1.0 - v);
 
                 if ((i < heightSegments) && (j < capSegments)) {
@@ -453,10 +453,10 @@ function _createConeData(baseRadius, peakRadius, height, heightSegments, capSegm
                 uvs.push(u, 1.0 - v);
 
                 // Pack UV1 to 2nd third
-                u /= 3;
-                v /= 3;
                 u = u * primitiveUv1PaddingScale + primitiveUv1Padding;
                 v = v * primitiveUv1PaddingScale + primitiveUv1Padding;
+                u /= 3;
+                v /= 3;
                 u += 1.0 / 3;
                 uvs1.push(u, 1.0 - v);
             }
@@ -496,10 +496,10 @@ function _createConeData(baseRadius, peakRadius, height, heightSegments, capSegm
                 uvs.push(u, 1.0 - v);
 
                 // Pack UV1 to 3rd third
-                u /= 3;
-                v /= 3;
                 u = u * primitiveUv1PaddingScale + primitiveUv1Padding;
                 v = v * primitiveUv1PaddingScale + primitiveUv1Padding;
+                u /= 3;
+                v /= 3;
                 u += 2.0 / 3;
                 uvs1.push(u, 1.0 - v);
             }
@@ -532,10 +532,10 @@ function _createConeData(baseRadius, peakRadius, height, heightSegments, capSegm
                 uvs.push(u, 1.0 - v);
 
                 // Pack UV1 to 2nd third
-                u /= 3;
-                v /= 3;
                 u = u * primitiveUv1PaddingScale + primitiveUv1Padding;
                 v = v * primitiveUv1PaddingScale + primitiveUv1Padding;
+                u /= 3;
+                v /= 3;
                 u += 1.0 / 3;
                 uvs1.push(u, 1.0 - v);
 
@@ -561,10 +561,10 @@ function _createConeData(baseRadius, peakRadius, height, heightSegments, capSegm
                 uvs.push(u, 1.0 - v);
 
                 // Pack UV1 to 3rd third
-                u /= 3;
-                v /= 3;
                 u = u * primitiveUv1PaddingScale + primitiveUv1Padding;
                 v = v * primitiveUv1PaddingScale + primitiveUv1Padding;
+                u /= 3;
+                v /= 3;
                 u += 2.0 / 3;
                 uvs1.push(u, 1.0 - v);
 
@@ -965,13 +965,13 @@ function createBox(device, opts) {
                 positions.push(r.x, r.y, r.z);
                 normals.push(faceNormals[side][0], faceNormals[side][1], faceNormals[side][2]);
                 uvs.push(u, 1.0 - v);
-                // pack as 3x2
-                // 1/3 will be empty, but it's either that or stretched pixels
+                // pack as 3x2. 1/3 will be empty, but it's either that or stretched pixels
                 // TODO: generate non-rectangular lightMaps, so we could use space without stretching
-                u /= 3;
-                v /= 3;
                 u = u * primitiveUv1PaddingScale + primitiveUv1Padding;
                 v = v * primitiveUv1PaddingScale + primitiveUv1Padding;
+                u /= 3;
+                v /= 3;
+
                 u += (side % 3) / 3;
                 v += Math.floor(side / 3) / 3;
                 uvs1.push(u, 1.0 - v);


### PR DESCRIPTION
scaling and offset didn't have 1/3 multiplication applied to it, and so was too large and uv space went outside of 0..1 range for box, cylinder, cone and capsule.

example incorrect:

<img width="307" alt="Screenshot 2021-08-27 at 11 33 19" src="https://user-images.githubusercontent.com/59932779/131128349-a5833226-eead-431b-a7ae-330f5e736870.png">
<img width="230" alt="Screenshot 2021-08-27 at 11 45 39" src="https://user-images.githubusercontent.com/59932779/131128350-77d2bbcc-f8d2-47d7-9be5-cd1378fcd647.png">

fixed:

<img width="269" alt="Screenshot 2021-08-27 at 13 21 42" src="https://user-images.githubusercontent.com/59932779/131128374-ba7961b2-35d4-49f8-bb01-d110555beeb6.png">
<img width="274" alt="Screenshot 2021-08-27 at 13 22 26" src="https://user-images.githubusercontent.com/59932779/131128379-ac7ba0b1-969a-41f8-8dbc-c81338297140.png">
