### PR TITLE
Fixes for loading quantized glTF data

### DIFF
--- a/src/resources/parser/glb-parser.js
+++ b/src/resources/parser/glb-parser.js
@@ -1279,7 +1279,6 @@ const createAnimation = function (gltfAnimation, animationIndex, gltfAccessors, 
 
     // create animation data block for the accessor
     const createAnimData = function (gltfAccessor) {
-        // TODO: this assumes data is tightly packed, handle the case data is interleaved
         return new AnimData(getNumComponents(gltfAccessor.type), getAccessorDataFloat32(gltfAccessor, bufferViews));
     };
 


### PR DESCRIPTION
Fixes #2636 #2630 #2802 (though not able to verify this one)

The glTF parser was not always handling bufferview `byteStride` correctly, especially for quantized animation data and quantized morph target data.

In summary, this PR:
- unpacks strided bufferView data except when handling interleaved vertex buffer data
- dequantizes data for animation curves and morph target normals