### PR TITLE
Prevent collision data processing on disabled entities

### DIFF
--- a/src/framework/components/collision/system.js
+++ b/src/framework/components/collision/system.js
@@ -64,7 +64,7 @@ class CollisionSystemImpl {
         var entity = component.entity;
         var data = component.data;
 
-        if (typeof Ammo !== 'undefined') {
+        if (typeof Ammo !== 'undefined' && entity.enabled && component.enabled) {
             if (entity.trigger) {
                 entity.trigger.destroy();
                 delete entity.trigger;


### PR DESCRIPTION
Currently a SceneParser will initialize Collision Component and execute its `afterInitialize()` method. This in turn calls the `recreatePhysicalShapes(component)`, which destroys old collision data and generates new collision shapes in the physics world, regardless if the entity/component is enabled or not. If the entity is not enabled, the shapes are created only to be immediately destroyed afterwards. As a result, if a scene contains many entities with collision component, they all get processed on start, even if disabled.

This PR adds a check if both entity and component are enabled, before destroying old collision data and generating a new one.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
