### PR TITLE
When entity is reparented, whole child hierarchy is notified

### DIFF
--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -1099,6 +1099,17 @@ class GraphNode extends EventHandler {
     }
     // #endif
 
+    // fires an event on all children of the node
+    _fireOnHierarchy(name) {
+        if (this.fire) {
+            this.fire(name, this);
+        }
+
+        for (let i = 0; i < this._children.length; i++) {
+            this._children[i]._fireOnHierarchy(name);
+        }
+    }
+
     _onInsertChild(node) {
         node._parent = this;
 
@@ -1124,8 +1135,8 @@ class GraphNode extends EventHandler {
         if (this._frozen)
             node._unfreezeParentToRoot();
 
-        // alert an entity that it has been inserted
-        if (node.fire) node.fire('insert', this);
+        // alert an entity hierarchy that it has been inserted
+        node._fireOnHierarchy('insert');
 
         // alert the parent that it has had a child inserted
         if (this.fire) this.fire('childinsert', node);
@@ -1164,8 +1175,8 @@ class GraphNode extends EventHandler {
                 // Clear parent
                 child._parent = null;
 
-                // alert child that it has been removed
-                if (child.fire) child.fire('remove', this);
+                // alert children that they has been removed
+                child._fireOnHierarchy('remove');
 
                 // alert the parent that it has had a child removed
                 if (this.fire) this.fire('childremove', child);

--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -1101,10 +1101,7 @@ class GraphNode extends EventHandler {
 
     // fires an event on all children of the node
     _fireOnHierarchy(name) {
-        if (this.fire) {
-            this.fire(name);
-        }
-
+        this.fire(name);
         for (let i = 0; i < this._children.length; i++) {
             this._children[i]._fireOnHierarchy(name);
         }

--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -1102,7 +1102,7 @@ class GraphNode extends EventHandler {
     // fires an event on all children of the node
     _fireOnHierarchy(name) {
         if (this.fire) {
-            this.fire(name, this);
+            this.fire(name);
         }
 
         for (let i = 0; i < this._children.length; i++) {


### PR DESCRIPTION
When a hierarchy of entities was parented to an entity, only the root node of the hierarchy was notified about this, using 'insert' or 'remove' event. 
This PR changes this to notify all children of reparented hierarchy.

This allows model and render components that are part of the reparented hierarchy to correctly add or remove their MeshInstances from layers.

Fixes https://github.com/playcanvas/engine/issues/3421