### PR TITLE
Revert "Prevent shapes creation on disabled entities (#3432)"

### DIFF
--- a/src/framework/components/collision/system.js
+++ b/src/framework/components/collision/system.js
@@ -64,7 +64,7 @@ class CollisionSystemImpl {
         var entity = component.entity;
         var data = component.data;
 
-        if (typeof Ammo !== 'undefined' && entity.enabled && component.enabled) {
+        if (typeof Ammo !== 'undefined') {
             if (entity.trigger) {
                 entity.trigger.destroy();
                 delete entity.trigger;


### PR DESCRIPTION
This reverts commit 4b0760b3db5af9f635d28e4d8c8781fefd896b62.

Sorry @LeXXik this change breaks the Seemore demo https://playcanvas.com/project/612100/overview/seemore-2019 so reverting for this engine release.

Will be good to try get this optimisation in without altering behavior.