### PR TITLE
[AnimComponent] Fix for transitions

### DIFF
--- a/src/anim/controller/anim-controller.js
+++ b/src/anim/controller/anim-controller.js
@@ -320,7 +320,7 @@ class AnimController {
         let state;
         let animation;
         let clip;
-        // If transition.from is set, tranisition from the active state irregardless of the transition.from value (this could be the previous, active or ANY states).
+        // If transition.from is set, transition from the active state irregardless of the transition.from value (this could be the previous, active or ANY states).
         // Otherwise the previousState is cleared.
         this.previousState = transition.from ? this.activeStateName : null;
         this.activeState = transition.to;

--- a/src/anim/controller/anim-controller.js
+++ b/src/anim/controller/anim-controller.js
@@ -323,11 +323,6 @@ class AnimController {
         // If transition.from is set, tranisition from the active state irregardless of the transition.from value (this could be the previous, active or ANY states).
         // Otherwise the previousState is cleared.
         this.previousState = (transition.from ? this.activeStateName : null);
-        if (transition.from === ANIM_STATE_ANY) {
-            this.previousState = this.activeStateName;
-        } else {
-            this.previousState = transition.from;
-        }
         this.activeState = transition.to;
 
         // turn off any triggers which were required to activate this transition

--- a/src/anim/controller/anim-controller.js
+++ b/src/anim/controller/anim-controller.js
@@ -320,7 +320,13 @@ class AnimController {
         let state;
         let animation;
         let clip;
-        this.previousState = transition.from;
+        // if the transition is coming from the ANY state, use the active state as the previous state to maintain the record of currently plaing animations.
+        // Otherwise use the transitions 'from' state
+        if (transition.from === ANIM_STATE_ANY) {
+            this.previousState = this.activeStateName;
+        } else {
+            this.previousState = transition.from;
+        }
         this.activeState = transition.to;
 
         // turn off any triggers which were required to activate this transition

--- a/src/anim/controller/anim-controller.js
+++ b/src/anim/controller/anim-controller.js
@@ -322,7 +322,7 @@ class AnimController {
         let clip;
         // If transition.from is set, tranisition from the active state irregardless of the transition.from value (this could be the previous, active or ANY states).
         // Otherwise the previousState is cleared.
-        this.previousState = (transition.from ? this.activeStateName : null);
+        this.previousState = transition.from ? this.activeStateName : null;
         this.activeState = transition.to;
 
         // turn off any triggers which were required to activate this transition

--- a/src/anim/controller/anim-controller.js
+++ b/src/anim/controller/anim-controller.js
@@ -320,8 +320,9 @@ class AnimController {
         let state;
         let animation;
         let clip;
-        // if the transition is coming from the ANY state, use the active state as the previous state to maintain the record of currently plaing animations.
-        // Otherwise use the transitions 'from' state
+        // If transition.from is set, tranisition from the active state irregardless of the transition.from value (this could be the previous, active or ANY states).
+        // Otherwise the previousState is cleared.
+        this.previousState = (transition.from ? this.activeStateName : null);
         if (transition.from === ANIM_STATE_ANY) {
             this.previousState = this.activeStateName;
         } else {


### PR DESCRIPTION
The anim controller now uses the currently active state as the new previous state in all state transitions, irregardless of whether the transition was from the active state, previous state or ANY state. In the instance where the controller is forcing a new state rather than transitioning between states, the previousState is cleared.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
