### PR TITLE
Track active StandardMaterial parameters correctly

### DIFF
--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -417,7 +417,7 @@ class StandardMaterial extends Material {
         if (prevParams) {
             Object.keys(prevParams).forEach((param) => {
                 if (!activeParams.hasOwnProperty(param)) {
-                    delete this.parameters[name];
+                    delete this.parameters[param];
                 }
             });
         }

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -452,12 +452,10 @@ class StandardMaterial extends Material {
     }
 
     updateUniforms(device, scene) {
-
         const getUniform = (name) => {
             return this.getUniform(name, device, scene);
         };
 
-        // gather params as we set them into this object
         this._setParameter('material_ambient', getUniform('ambient'));
 
         if (!this.diffuseMap || this.diffuseTint) {


### PR DESCRIPTION
Fixes #3452

This PR updates the method of tracking active parameters in `StandardMaterial` as the previous method was just plain wrong.

Lighting-specific parameters are now tracked and cleared separately from the rest (since they get updated at different times).

