### PR TITLE
Fix for cloned anim and render components

### DIFF
--- a/src/framework/components/anim/component.js
+++ b/src/framework/components/anim/component.js
@@ -672,6 +672,14 @@ class AnimComponent extends Component {
         });
         this._consumedTriggers.clear();
     }
+
+    resolveDuplicatedEntityReferenceProperties(oldAnim, duplicatedIdsMap) {
+        if (oldAnim.rootBone && duplicatedIdsMap[oldAnim.rootBone.getGuid()]) {
+            this.rootBone = duplicatedIdsMap[oldAnim.rootBone.getGuid()];
+        } else {
+            this.rebind();
+        }
+    }
 }
 
 export { AnimComponent };

--- a/src/framework/components/render/component.js
+++ b/src/framework/components/render/component.js
@@ -112,7 +112,9 @@ class RenderComponent extends Component {
     _onRootBoneChanged() {
         // remove existing skin instances and create new ones, connected to new root bone
         this._clearSkinInstances();
-        this._cloneSkinInstances();
+        if (this.enabled && this.entity.enabled) {
+            this._cloneSkinInstances();
+        }
     }
 
     destroyMeshInstances() {
@@ -199,12 +201,9 @@ class RenderComponent extends Component {
         var app = this.system.app;
         var scene = app.scene;
 
-        if (this._initialRootBone) {
-            this.rootBone = this._initialRootBone;
-            this._initialRootBone = null;
-        }
-
         this._rootBone.onParentComponentEnable();
+
+        this._cloneSkinInstances();
 
         scene.on("set:layers", this.onLayersChanged, this);
         if (scene.layers) {
@@ -757,9 +756,8 @@ class RenderComponent extends Component {
     }
 
     resolveDuplicatedEntityReferenceProperties(oldRender, duplicatedIdsMap) {
-        const oldRootBoneId = oldRender.rootBone || (oldRender.initialRootBone && oldRender.initialRootBone.getGuid());
-        if (oldRootBoneId && duplicatedIdsMap[oldRootBoneId]) {
-            this.rootBone = duplicatedIdsMap[oldRootBoneId];
+        if (oldRender.rootBone && duplicatedIdsMap[oldRender.rootBone]) {
+            this.rootBone = duplicatedIdsMap[oldRender.rootBone];
         }
     }
 }

--- a/src/framework/components/render/component.js
+++ b/src/framework/components/render/component.js
@@ -75,7 +75,6 @@ class RenderComponent extends Component {
         this._area = null;
 
         // the entity that represents the root bone if this render component has skinned meshes
-        this._initialRootBone = null;
         this._rootBone = new EntityReference(this, 'rootBone');
         this._rootBone.on('set:entity', this._onSetRootBone, this);
 
@@ -751,6 +750,7 @@ class RenderComponent extends Component {
         if (oldRender.rootBone && duplicatedIdsMap[oldRender.rootBone]) {
             this.rootBone = duplicatedIdsMap[oldRender.rootBone];
         }
+        this._clearSkinInstances();
     }
 }
 

--- a/src/framework/components/render/component.js
+++ b/src/framework/components/render/component.js
@@ -75,6 +75,7 @@ class RenderComponent extends Component {
         this._area = null;
 
         // the entity that represents the root bone if this render component has skinned meshes
+        this._initialRootBone = null;
         this._rootBone = new EntityReference(this, 'rootBone');
         this._rootBone.on('set:entity', this._onSetRootBone, this);
 
@@ -197,6 +198,11 @@ class RenderComponent extends Component {
     onEnable() {
         var app = this.system.app;
         var scene = app.scene;
+
+        if (this._initialRootBone) {
+            this.rootBone = this._initialRootBone;
+            this._initialRootBone = null;
+        }
 
         this._rootBone.onParentComponentEnable();
 
@@ -739,6 +745,21 @@ class RenderComponent extends Component {
 
         if (this._assetReference.asset) {
             this._onRenderAssetAdded();
+        }
+    }
+
+    get initialRootBone() {
+        return this._initialRootBone;
+    }
+
+    set initialRootBone(value) {
+        this._initialRootBone = value;
+    }
+
+    resolveDuplicatedEntityReferenceProperties(oldRender, duplicatedIdsMap) {
+        const oldRootBoneId = oldRender.rootBone || (oldRender.initialRootBone && oldRender.initialRootBone.getGuid());
+        if (oldRootBoneId && duplicatedIdsMap[oldRootBoneId]) {
+            this.rootBone = duplicatedIdsMap[oldRootBoneId];
         }
     }
 }

--- a/src/framework/components/render/component.js
+++ b/src/framework/components/render/component.js
@@ -747,14 +747,6 @@ class RenderComponent extends Component {
         }
     }
 
-    get initialRootBone() {
-        return this._initialRootBone;
-    }
-
-    set initialRootBone(value) {
-        this._initialRootBone = value;
-    }
-
     resolveDuplicatedEntityReferenceProperties(oldRender, duplicatedIdsMap) {
         if (oldRender.rootBone && duplicatedIdsMap[oldRender.rootBone]) {
             this.rootBone = duplicatedIdsMap[oldRender.rootBone];

--- a/src/framework/components/render/system.js
+++ b/src/framework/components/render/system.js
@@ -73,10 +73,10 @@ class RenderComponentSystem extends ComponentSystem {
             component.customAabb = new BoundingBox(new Vec3(_data.aabbCenter), new Vec3(_data.aabbHalfExtents));
         }
 
-        component.initialRootBone = _data.rootBone;
-        if (component.initialRootBone) {
-            delete _data.rootBone;
-        }
+        // component.initialRootBone = _data.rootBone;
+        // if (component.initialRootBone) {
+        //     delete _data.rootBone;
+        // }
 
         super.initializeComponentData(component, _data, _schema);
     }

--- a/src/framework/components/render/system.js
+++ b/src/framework/components/render/system.js
@@ -73,11 +73,6 @@ class RenderComponentSystem extends ComponentSystem {
             component.customAabb = new BoundingBox(new Vec3(_data.aabbCenter), new Vec3(_data.aabbHalfExtents));
         }
 
-        // component.initialRootBone = _data.rootBone;
-        // if (component.initialRootBone) {
-        //     delete _data.rootBone;
-        // }
-
         super.initializeComponentData(component, _data, _schema);
     }
 

--- a/src/framework/components/render/system.js
+++ b/src/framework/components/render/system.js
@@ -73,6 +73,11 @@ class RenderComponentSystem extends ComponentSystem {
             component.customAabb = new BoundingBox(new Vec3(_data.aabbCenter), new Vec3(_data.aabbHalfExtents));
         }
 
+        component.initialRootBone = _data.rootBone;
+        if (component.initialRootBone) {
+            delete _data.rootBone;
+        }
+
         super.initializeComponentData(component, _data, _schema);
     }
 

--- a/src/framework/entity.js
+++ b/src/framework/entity.js
@@ -477,6 +477,16 @@ function resolveDuplicatedEntityReferenceProperties(oldSubtreeRoot, oldEntity, n
             newEntity.script.resolveDuplicatedEntityReferenceProperties(components.script, duplicatedIdsMap);
         }
 
+        // Handle entity render attributes
+        if (components.render) {
+            newEntity.render.resolveDuplicatedEntityReferenceProperties(components.render, duplicatedIdsMap);
+        }
+
+        // Handle entity anim attributes
+        if (components.anim) {
+            newEntity.anim.resolveDuplicatedEntityReferenceProperties(components.anim, duplicatedIdsMap);
+        }
+
         // Recurse into children. Note that we continue to pass in the same `oldSubtreeRoot`,
         // in order to correctly handle cases where a child has an entity reference
         // field that points to a parent or other ancestor that is still within the

--- a/src/resources/container.js
+++ b/src/resources/container.js
@@ -175,7 +175,8 @@ class ContainerResource {
             if (attachedMi) {
                 entity.addComponent("render", Object.assign({
                     type: "asset",
-                    meshInstances: attachedMi
+                    meshInstances: attachedMi,
+                    rootBone: root
                 }, options));
             }
 


### PR DESCRIPTION
Both the render and anim component contain a rootBone property. When either of these components were cloned, the rootBone entity wasn't being updated with the cloned rootBone entity in the new cloned hierarchy. This fixes both issues by implementing the `resolveDuplicatedEntityReferenceProperties` method in both the anim and render components, much like the current script component method.

Fixes #3426 
Fixes #3393

Test project for the fix: https://playcanvas.com/project/808975/

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
