### PR TITLE
[Fix] Disable skybox from picker

### DIFF
--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -436,6 +436,9 @@ class Scene extends EventHandler {
                 meshInstance.cull = false;
                 meshInstance._noDepthDrawGl1 = true;
 
+                // disable picker, the material has custom update shader and does not handle picker variant
+                meshInstance.pick = false;
+
                 var model = new Model();
                 model.graph = node;
                 model.meshInstances = [meshInstance];


### PR DESCRIPTION
The picker no longer renders Skybox meshInstance - as it does not implement pick shader variant and was writing color values into pick buffer.

There's no change to the API behaviour, as skybox picking didn't work before, but we won't get random objects getting picked up based on skydome's colors.