### PR TITLE
[Fix] Fix to insert and remove events when reparenting

### DIFF
--- a/src/framework/components/model/component.js
+++ b/src/framework/components/model/component.js
@@ -91,8 +91,11 @@ class ModelComponent extends Component {
         this._batchGroup = null;
         // #endif
 
+        // handle events when the entity is directly (or indirectly as a child of sub-hierarchy) added or removed from the parent
         entity.on('remove', this.onRemoveChild, this);
+        entity.on('removehierarchy', this.onRemoveChild, this);
         entity.on('insert', this.onInsertChild, this);
+        entity.on('inserthierarchy', this.onInsertChild, this);
     }
 
     addModelToLayers() {

--- a/src/framework/components/render/component.js
+++ b/src/framework/components/render/component.js
@@ -98,8 +98,11 @@ class RenderComponent extends Component {
         // material asset references
         this._materialReferences = [];
 
+        // handle events when the entity is directly (or indirectly as a child of sub-hierarchy) added or removed from the parent
         entity.on('remove', this.onRemoveChild, this);
+        entity.on('removehierarchy', this.onRemoveChild, this);
         entity.on('insert', this.onInsertChild, this);
+        entity.on('inserthierarchy', this.onInsertChild, this);
     }
 
     _onSetRootBone(entity) {

--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -1100,10 +1100,12 @@ class GraphNode extends EventHandler {
     // #endif
 
     // fires an event on all children of the node
-    _fireOnHierarchy(name) {
-        this.fire(name);
+    // the event name is fired on the first (root) node only
+    // the event nameHierarchy is fired for all children
+    _fireOnHierarchy(name, nameHierarchy, parent) {
+        this.fire(name, parent);
         for (let i = 0; i < this._children.length; i++) {
-            this._children[i]._fireOnHierarchy(name);
+            this._children[i]._fireOnHierarchy(nameHierarchy, nameHierarchy, parent);
         }
     }
 
@@ -1133,7 +1135,7 @@ class GraphNode extends EventHandler {
             node._unfreezeParentToRoot();
 
         // alert an entity hierarchy that it has been inserted
-        node._fireOnHierarchy('insert');
+        node._fireOnHierarchy('insert', 'inserthierarchy', this);
 
         // alert the parent that it has had a child inserted
         if (this.fire) this.fire('childinsert', node);
@@ -1173,7 +1175,7 @@ class GraphNode extends EventHandler {
                 child._parent = null;
 
                 // alert children that they has been removed
-                child._fireOnHierarchy('remove');
+                child._fireOnHierarchy('remove', 'removehierarchy', this);
 
                 // alert the parent that it has had a child removed
                 if (this.fire) this.fire('childremove', child);


### PR DESCRIPTION
PR https://github.com/playcanvas/engine/pull/3436 introduced a change where 'insert' and 'remove' events were called on all children (direct and indirect) of the hierarchy when reparenting.

This has caused different behavior for components not handling it: https://github.com/playcanvas/engine/issues/3469

This PR reverts back to the original behavior, where 'insert' and 'remove' events are only called on a single child node being reparented. Also new events 'inserthierarchy' and 'removehierarchy' events are added and triggered for all children of the node being reparented. Render and Model components handle this event now to fix the original issue https://github.com/playcanvas/engine/issues/3421

Fixes https://github.com/playcanvas/engine/issues/3469