### PR TITLE
Forward renderer - cleanup, separated static-meshes functionality

### DIFF
--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -534,6 +534,7 @@ class Application extends EventHandler {
         AreaLightLuts.createPlaceholder(this.graphicsDevice);
 
         this.renderer = new ForwardRenderer(this.graphicsDevice, this.scene);
+        this.renderer.scene = this.scene;
         this.lightmapper = new Lightmapper(this.graphicsDevice, this.root, this.scene, this.renderer, this.assets);
         this.once('prerender', this._firstBake, this);
         this.batcher = new BatchManager(this.graphicsDevice, this.root, this.scene);

--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -1658,10 +1658,6 @@ class Application extends EventHandler {
     }
 
     _firstBatch() {
-        if (this.scene._needsStaticPrepare) {
-            this.renderer.prepareStaticMeshes(this.graphicsDevice, this.scene);
-            this.scene._needsStaticPrepare = false;
-        }
         this.batcher.generate();
     }
 

--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -533,7 +533,7 @@ class Application extends EventHandler {
         // placeholder texture for area light LUTs
         AreaLightLuts.createPlaceholder(this.graphicsDevice);
 
-        this.renderer = new ForwardRenderer(this.graphicsDevice, this.scene);
+        this.renderer = new ForwardRenderer(this.graphicsDevice);
         this.renderer.scene = this.scene;
         this.lightmapper = new Lightmapper(this.graphicsDevice, this.root, this.scene, this.renderer, this.assets);
         this.once('prerender', this._firstBake, this);

--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -533,8 +533,7 @@ class Application extends EventHandler {
         // placeholder texture for area light LUTs
         AreaLightLuts.createPlaceholder(this.graphicsDevice);
 
-        this.renderer = new ForwardRenderer(this.graphicsDevice);
-        this.renderer.scene = this.scene;
+        this.renderer = new ForwardRenderer(this.graphicsDevice, this.scene);
         this.lightmapper = new Lightmapper(this.graphicsDevice, this.root, this.scene, this.renderer, this.assets);
         this.once('prerender', this._firstBake, this);
         this.batcher = new BatchManager(this.graphicsDevice, this.root, this.scene);

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -87,9 +87,8 @@ const _tempMaterialSet = new Set();
  * @param {Scene} A - scene for the rendering.
  */
 class ForwardRenderer {
-    constructor(graphicsDevice, scene) {
+    constructor(graphicsDevice) {
         this.device = graphicsDevice;
-        this.scene = scene;
 
         this._shadowDrawCalls = 0;
         this._forwardDrawCalls = 0;

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -39,46 +39,46 @@ import { ShadowRenderer } from './shadow-renderer.js';
 import { Camera } from '../camera.js';
 import { GraphNode } from '../graph-node.js';
 
-var shadowCamView = new Mat4();
-var shadowCamViewProj = new Mat4();
+const shadowCamView = new Mat4();
+const shadowCamViewProj = new Mat4();
 
-var viewInvMat = new Mat4();
-var viewMat = new Mat4();
-var viewMat3 = new Mat3();
-var viewProjMat = new Mat4();
-var projMat;
+const viewInvMat = new Mat4();
+const viewMat = new Mat4();
+const viewMat3 = new Mat3();
+const viewProjMat = new Mat4();
+let projMat;
 
-var flipYMat = new Mat4().setScale(1, -1, 1);
-var flippedViewProjMat = new Mat4();
-var flippedSkyboxProjMat = new Mat4();
+const flipYMat = new Mat4().setScale(1, -1, 1);
+const flippedViewProjMat = new Mat4();
+const flippedSkyboxProjMat = new Mat4();
 
-var viewInvL = new Mat4();
-var viewInvR = new Mat4();
-var viewL = new Mat4();
-var viewR = new Mat4();
-var viewPosL = new Vec3();
-var viewPosR = new Vec3();
-var projL, projR;
-var viewMat3L = new Mat3();
-var viewMat3R = new Mat3();
-var viewProjMatL = new Mat4();
-var viewProjMatR = new Mat4();
+const viewInvL = new Mat4();
+const viewInvR = new Mat4();
+const viewL = new Mat4();
+const viewR = new Mat4();
+const viewPosL = new Vec3();
+const viewPosR = new Vec3();
+let projL, projR;
+const viewMat3L = new Mat3();
+const viewMat3R = new Mat3();
+const viewProjMatL = new Mat4();
+const viewProjMatR = new Mat4();
 
-var worldMatX = new Vec3();
-var worldMatY = new Vec3();
-var worldMatZ = new Vec3();
+const worldMatX = new Vec3();
+const worldMatY = new Vec3();
+const worldMatZ = new Vec3();
 
-var tempSphere = new BoundingSphere();
-var boneTextureSize = [0, 0, 0, 0];
-var boneTexture, instancingData, modelMatrix, normalMatrix;
+const tempSphere = new BoundingSphere();
+const boneTextureSize = [0, 0, 0, 0];
+let boneTexture, instancingData, modelMatrix, normalMatrix;
 
-var keyA, keyB;
+let keyA, keyB;
 
-var _autoInstanceBuffer = null;
+let _autoInstanceBuffer = null;
 
-var _skinUpdateIndex = 0;
+let _skinUpdateIndex = 0;
 
-var _tempMaterialSet = new Set();
+const _tempMaterialSet = new Set();
 
 /**
  * @class
@@ -90,7 +90,7 @@ var _tempMaterialSet = new Set();
 class ForwardRenderer {
     constructor(graphicsDevice) {
         this.device = graphicsDevice;
-        var device = this.device;
+        const device = this.device;
 
         this._shadowDrawCalls = 0;
         this._forwardDrawCalls = 0;
@@ -111,14 +111,14 @@ class ForwardRenderer {
         this._lightClusters = 0;
 
         // Shaders
-        var library = device.getProgramLibrary();
+        const library = device.getProgramLibrary();
         this.library = library;
 
         // shadows
         this._shadowRenderer = new ShadowRenderer(this);
 
         // Uniforms
-        var scope = device.scope;
+        const scope = device.scope;
         this.projId = scope.resolve('matrix_projection');
         this.projSkyboxId = scope.resolve('matrix_projectionSkybox');
         this.viewId = scope.resolve('matrix_view');
@@ -274,7 +274,7 @@ class ForwardRenderer {
     updateCameraFrustum(camera) {
         if (camera.vrDisplay && camera.vrDisplay.presenting) {
             projMat = camera.vrDisplay.combinedProj;
-            var parent = camera._node.parent;
+            const parent = camera._node.parent;
             if (parent) {
                 viewMat.copy(parent.getWorldTransform()).mul(camera.vrDisplay.combinedViewInv).invert();
             } else {
@@ -286,7 +286,7 @@ class ForwardRenderer {
             camera.frustum.setFromMat4(viewProjMat);
         } else if (camera.xr && camera.xr.views.length) {
             // calculate frustum based on XR view
-            var view = camera.xr.views[0];
+            const view = camera.xr.views[0];
             viewProjMat.mul2(view.projMat, view.viewOffMat);
             camera.frustum.setFromMat4(viewProjMat);
             return;
@@ -300,8 +300,8 @@ class ForwardRenderer {
         if (camera.calculateTransform) {
             camera.calculateTransform(viewInvMat, VIEW_CENTER);
         } else {
-            var pos = camera._node.getPosition();
-            var rot = camera._node.getRotation();
+            const pos = camera._node.getPosition();
+            const rot = camera._node.getRotation();
             viewInvMat.setTRS(pos, rot, Vec3.ONE);
             this.viewInvId.setValue(viewInvMat.data);
         }
@@ -313,8 +313,8 @@ class ForwardRenderer {
 
     // make sure colorWrite is set to true to all channels, if you want to fully clear the target
     setCamera(camera, target, clear, cullBorder) {
-        var vrDisplay = camera.vrDisplay;
-        var parent, transform;
+        const vrDisplay = camera.vrDisplay;
+        let transform;
 
         if (vrDisplay && vrDisplay.presenting) {
             // Projection LR
@@ -335,7 +335,7 @@ class ForwardRenderer {
                 viewR.copy(viewInvR).invert();
                 viewMat.copy(viewInvMat).invert();
             } else {
-                parent = camera._node.parent;
+                const parent = camera._node.parent;
                 if (parent) {
                     transform = parent.getWorldTransform();
 
@@ -383,13 +383,12 @@ class ForwardRenderer {
             viewProjMat.mul2(projMat, viewMat);
             camera.frustum.setFromMat4(viewProjMat);
         } else if (camera.xr && camera.xr.session) {
-            parent = camera._node.parent;
+            const parent = camera._node.parent;
             if (parent) transform = parent.getWorldTransform();
 
-            var views = camera.xr.views;
-
-            for (var v = 0; v < views.length; v++) {
-                var view = views[v];
+            const views = camera.xr.views;
+            for (let v = 0; v < views.length; v++) {
+                const view = views[v];
 
                 if (parent) {
                     view.viewInvOffMat.mul2(transform, view.viewInvMat);
@@ -423,8 +422,8 @@ class ForwardRenderer {
             if (camera.calculateTransform) {
                 camera.calculateTransform(viewInvMat, VIEW_CENTER);
             } else {
-                var pos = camera._node.getPosition();
-                var rot = camera._node.getRotation();
+                const pos = camera._node.getPosition();
+                const rot = camera._node.getRotation();
                 viewInvMat.setTRS(pos, rot, Vec3.ONE);
             }
             this.viewInvId.setValue(viewInvMat.data);
@@ -463,8 +462,8 @@ class ForwardRenderer {
         this.nearClipId.setValue(camera._nearClip);
         this.farClipId.setValue(camera._farClip);
 
-        var n = camera._nearClip;
-        var f = camera._farClip;
+        const n = camera._nearClip;
+        const f = camera._farClip;
         this.cameraParams[0] = 1 / f;
         this.cameraParams[1] = f;
         this.cameraParams[2] = (1 - f / n) * 0.5;
@@ -473,22 +472,22 @@ class ForwardRenderer {
 
         this.clearView(camera, target, clear, false);
 
-        var device = this.device;
-        var pixelWidth = target ? target.width : device.width;
-        var pixelHeight = target ? target.height : device.height;
+        const device = this.device;
+        const pixelWidth = target ? target.width : device.width;
+        const pixelHeight = target ? target.height : device.height;
 
-        var scissorRect = camera.scissorRect;
-        var x = Math.floor(scissorRect.x * pixelWidth);
-        var y = Math.floor(scissorRect.y * pixelHeight);
-        var w = Math.floor(scissorRect.z * pixelWidth);
-        var h = Math.floor(scissorRect.w * pixelHeight);
+        const scissorRect = camera.scissorRect;
+        const x = Math.floor(scissorRect.x * pixelWidth);
+        const y = Math.floor(scissorRect.y * pixelHeight);
+        const w = Math.floor(scissorRect.z * pixelWidth);
+        const h = Math.floor(scissorRect.w * pixelHeight);
         device.setScissor(x, y, w, h);
 
         if (cullBorder) device.setScissor(1, 1, pixelWidth - 2, pixelHeight - 2); // optionally clip borders when rendering
     }
 
     clearView(camera, target, clear, forceWrite, options) {
-        var device = this.device;
+        const device = this.device;
         device.setRenderTarget(target);
         device.updateBegin();
 
@@ -497,13 +496,13 @@ class ForwardRenderer {
             device.setDepthWrite(true);
         }
 
-        var rect = camera.rect;
-        var pixelWidth = target ? target.width : device.width;
-        var pixelHeight = target ? target.height : device.height;
-        var x = Math.floor(rect.x * pixelWidth);
-        var y = Math.floor(rect.y * pixelHeight);
-        var w = Math.floor(rect.z * pixelWidth);
-        var h = Math.floor(rect.w * pixelHeight);
+        const rect = camera.rect;
+        const pixelWidth = target ? target.width : device.width;
+        const pixelHeight = target ? target.height : device.height;
+        const x = Math.floor(rect.x * pixelWidth);
+        const y = Math.floor(rect.y * pixelHeight);
+        const w = Math.floor(rect.z * pixelWidth);
+        const h = Math.floor(rect.w * pixelHeight);
         device.setViewport(x, y, w, h);
         device.setScissor(x, y, w, h);
 
@@ -571,13 +570,13 @@ class ForwardRenderer {
         this.lightPos[cnt][2] = campos.z - dir.z * far;
         this.lightPosId[cnt].setValue(this.lightPos[cnt]);
 
-        var hWidth = wtm.transformVector(new Vec3(-0.5, 0, 0));
+        const hWidth = wtm.transformVector(new Vec3(-0.5, 0, 0));
         this.lightWidth[cnt][0] = hWidth.x * far;
         this.lightWidth[cnt][1] = hWidth.y * far;
         this.lightWidth[cnt][2] = hWidth.z * far;
         this.lightWidthId[cnt].setValue(this.lightWidth[cnt]);
 
-        var hHeight = wtm.transformVector(new Vec3(0, 0, 0.5));
+        const hHeight = wtm.transformVector(new Vec3(0, 0, 0.5));
         this.lightHeight[cnt][0] = hHeight.x * far;
         this.lightHeight[cnt][1] = hHeight.y * far;
         this.lightHeight[cnt][2] = hHeight.z * far;
@@ -585,18 +584,15 @@ class ForwardRenderer {
     }
 
     dispatchDirectLights(dirs, scene, mask, camera) {
-        var numDirs = dirs.length;
-        var i;
-        var directional, wtm;
-        var cnt = 0;
+        let cnt = 0;
 
-        var scope = this.device.scope;
+        const scope = this.device.scope;
 
-        for (i = 0; i < numDirs; i++) {
+        for (let i = 0; i < dirs.length; i++) {
             if (!(dirs[i].mask & mask)) continue;
 
-            directional = dirs[i];
-            wtm = directional._node.getWorldTransform();
+            const directional = dirs[i];
+            const wtm = directional._node.getWorldTransform();
 
             if (!this.lightColorId[cnt]) {
                 this._resolveLight(scope, cnt);
@@ -633,7 +629,7 @@ class ForwardRenderer {
                         bias *= -100;
                     }
                 }
-                var normalBias = directional._isVsm ?
+                const normalBias = directional._isVsm ?
                     directional.vsmBias / (farClip / 7.0) :
                     directional._normalOffsetBias;
 
@@ -644,7 +640,7 @@ class ForwardRenderer {
                 this.shadowCascadeDistancesId[cnt].setValue(directional._shadowCascadeDistances);
                 this.shadowCascadeCountId[cnt].setValue(directional.numCascades);
 
-                var params = directional._shadowRenderParams;
+                const params = directional._shadowRenderParams;
                 params.length = 3;
                 params[0] = directional._shadowResolution;  // Note: this needs to change for non-square shadow maps (2 cascades). Currently square is used
                 params[1] = normalBias;
@@ -657,13 +653,13 @@ class ForwardRenderer {
     }
 
     setLTCPositionalLight(wtm, cnt) {
-        var hWidth = wtm.transformVector(new Vec3(-0.5, 0, 0));
+        const hWidth = wtm.transformVector(new Vec3(-0.5, 0, 0));
         this.lightWidth[cnt][0] = hWidth.x;
         this.lightWidth[cnt][1] = hWidth.y;
         this.lightWidth[cnt][2] = hWidth.z;
         this.lightWidthId[cnt].setValue(this.lightWidth[cnt]);
 
-        var hHeight = wtm.transformVector(new Vec3(0, 0, 0.5));
+        const hHeight = wtm.transformVector(new Vec3(0, 0, 0.5));
         this.lightHeight[cnt][0] = hHeight.x;
         this.lightHeight[cnt][1] = hHeight.y;
         this.lightHeight[cnt][2] = hHeight.z;
@@ -671,7 +667,7 @@ class ForwardRenderer {
     }
 
     dispatchOmniLight(scene, scope, omni, cnt) {
-        var wtm = omni._node.getWorldTransform();
+        const wtm = omni._node.getWorldTransform();
 
         if (!this.lightColorId[cnt]) {
             this._resolveLight(scope, cnt);
@@ -696,7 +692,7 @@ class ForwardRenderer {
             const lightRenderData = omni.getRenderData(null, 0);
             this.lightShadowMapId[cnt].setValue(lightRenderData.shadowBuffer);
 
-            var params = omni._shadowRenderParams;
+            const params = omni._shadowRenderParams;
             params.length = 4;
             params[0] = omni._shadowResolution;
             params[1] = omni._normalOffsetBias;
@@ -712,7 +708,7 @@ class ForwardRenderer {
     }
 
     dispatchSpotLight(scene, scope, spot, cnt) {
-        var wtm = spot._node.getWorldTransform();
+        const wtm = spot._node.getWorldTransform();
 
         if (!this.lightColorId[cnt]) {
             this._resolveLight(scope, cnt);
@@ -743,14 +739,14 @@ class ForwardRenderer {
 
         let cookieMatrix;
         if (spot.castShadows) {
-            var bias;
+            let bias;
             if (spot._isVsm) {
                 bias = -0.00001 * 20;
             } else {
                 bias = spot.shadowBias * 20; // approx remap from old bias values
                 if (!this.device.webgl2 && this.device.extStandardDerivatives) bias *= -100;
             }
-            var normalBias = spot._isVsm ?
+            const normalBias = spot._isVsm ?
                 spot.vsmBias / (spot.attenuationEnd / 7.0) :
                 spot._normalOffsetBias;
 
@@ -759,7 +755,7 @@ class ForwardRenderer {
             this.lightShadowMapId[cnt].setValue(lightRenderData.shadowBuffer);
 
             this.lightShadowMatrixId[cnt].setValue(lightRenderData.shadowMatrix.data);
-            var params = spot._shadowRenderParams;
+            const params = spot._shadowRenderParams;
             params.length = 4;
             params[0] = spot._shadowResolution;
             params[1] = normalBias;
@@ -803,30 +799,23 @@ class ForwardRenderer {
     }
 
     dispatchLocalLights(sortedLights, scene, mask, usedDirLights, staticLightList) {
-        var i;
-        var omni, spot;
 
-        var omnis = sortedLights[LIGHTTYPE_OMNI];
-        var spts = sortedLights[LIGHTTYPE_SPOT];
+        let cnt = usedDirLights;
+        const scope = this.device.scope;
 
-        var numDirs = usedDirLights;
-        var numOmnis = omnis.length;
-        var numSpts = spts.length;
-        var cnt = numDirs;
-
-        var scope = this.device.scope;
-
-        for (i = 0; i < numOmnis; i++) {
-            omni = omnis[i];
+        const omnis = sortedLights[LIGHTTYPE_OMNI];
+        const numOmnis = omnis.length;
+        for (let i = 0; i < numOmnis; i++) {
+            const omni = omnis[i];
             if (!(omni.mask & mask)) continue;
             if (omni.isStatic) continue;
             this.dispatchOmniLight(scene, scope, omni, cnt);
             cnt++;
         }
 
-        var staticId = 0;
+        let staticId = 0;
         if (staticLightList) {
-            omni = staticLightList[staticId];
+            let omni = staticLightList[staticId];
             while (omni && omni._type === LIGHTTYPE_OMNI) {
                 this.dispatchOmniLight(scene, scope, omni, cnt);
                 cnt++;
@@ -835,8 +824,10 @@ class ForwardRenderer {
             }
         }
 
-        for (i = 0; i < numSpts; i++) {
-            spot = spts[i];
+        const spts = sortedLights[LIGHTTYPE_SPOT];
+        const numSpts = spts.length;
+        for (let i = 0; i < numSpts; i++) {
+            const spot = spts[i];
             if (!(spot.mask & mask)) continue;
             if (spot.isStatic) continue;
             this.dispatchSpotLight(scene, scope, spot, cnt);
@@ -844,7 +835,7 @@ class ForwardRenderer {
         }
 
         if (staticLightList) {
-            spot = staticLightList[staticId];
+            let spot = staticLightList[staticId];
             while (spot && spot._type === LIGHTTYPE_SPOT) {
                 this.dispatchSpotLight(scene, scope, spot, cnt);
                 cnt++;
@@ -856,20 +847,19 @@ class ForwardRenderer {
 
     cull(camera, drawCalls, visibleList) {
         // #if _PROFILER
-        var cullTime = now();
-        var numDrawCallsCulled = 0;
+        const cullTime = now();
+        let numDrawCallsCulled = 0;
         // #endif
 
-        var visibleLength = 0;
-        var i, drawCall, visible;
-        var drawCallsCount = drawCalls.length;
+        let visibleLength = 0;
+        const drawCallsCount = drawCalls.length;
 
-        var cullingMask = camera.cullingMask || 0xFFFFFFFF; // if missing assume camera's default value
+        const cullingMask = camera.cullingMask || 0xFFFFFFFF; // if missing assume camera's default value
 
         if (!camera.frustumCulling) {
-            for (i = 0; i < drawCallsCount; i++) {
+            for (let i = 0; i < drawCallsCount; i++) {
                 // need to copy array anyway because sorting will happen and it'll break original draw call order assumption
-                drawCall = drawCalls[i];
+                const drawCall = drawCalls[i];
                 if (!drawCall.visible && !drawCall.command) continue;
 
                 // if the object's mask AND the camera's cullingMask is zero then the game object will be invisible from the camera
@@ -882,11 +872,11 @@ class ForwardRenderer {
             return visibleLength;
         }
 
-        for (i = 0; i < drawCallsCount; i++) {
-            drawCall = drawCalls[i];
+        for (let i = 0; i < drawCallsCount; i++) {
+            const drawCall = drawCalls[i];
             if (!drawCall.command) {
                 if (!drawCall.visible) continue; // use visible property to quickly hide/show meshInstances
-                visible = true;
+                let visible = true;
 
                 // if the object's mask AND the camera's cullingMask is zero then the game object will be invisible from the camera
                 if (drawCall.mask && (drawCall.mask & cullingMask) === 0) continue;
@@ -949,16 +939,15 @@ class ForwardRenderer {
 
         _skinUpdateIndex++;
 
-        var drawCallsCount = drawCalls.length;
+        const drawCallsCount = drawCalls.length;
         if (drawCallsCount === 0) return;
 
         // #if _PROFILER
-        var skinTime = now();
+        const skinTime = now();
         // #endif
 
-        var i, si;
-        for (i = 0; i < drawCallsCount; i++) {
-            si = drawCalls[i].skinInstance;
+        for (let i = 0; i < drawCallsCount; i++) {
+            const si = drawCalls[i].skinInstance;
             if (si) {
                 si.updateMatrices(drawCalls[i].node, _skinUpdateIndex);
                 si._dirty = true;
@@ -972,14 +961,13 @@ class ForwardRenderer {
 
     updateGpuSkinMatrices(drawCalls) {
         // #if _PROFILER
-        var skinTime = now();
+        const skinTime = now();
         // #endif
 
-        var i, skin;
-        var drawCallsCount = drawCalls.length;
-        for (i = 0; i < drawCallsCount; i++) {
+        const drawCallsCount = drawCalls.length;
+        for (let i = 0; i < drawCallsCount; i++) {
             if (!drawCalls[i].visibleThisFrame) continue;
-            skin = drawCalls[i].skinInstance;
+            const skin = drawCalls[i].skinInstance;
             if (skin) {
                 if (skin._dirty) {
                     skin.updateMatrixPalette(drawCalls[i].node, _skinUpdateIndex);
@@ -995,13 +983,12 @@ class ForwardRenderer {
 
     updateMorphing(drawCalls) {
         // #if _PROFILER
-        var morphTime = now();
+        const morphTime = now();
         // #endif
 
-        var i, morphInst;
-        var drawCallsCount = drawCalls.length;
-        for (i = 0; i < drawCallsCount; i++) {
-            morphInst = drawCalls[i].morphInstance;
+        const drawCallsCount = drawCalls.length;
+        for (let i = 0; i < drawCallsCount; i++) {
+            const morphInst = drawCalls[i].morphInstance;
             if (morphInst && morphInst._dirty && drawCalls[i].visibleThisFrame) {
                 morphInst.update();
             }
@@ -1113,11 +1100,11 @@ class ForwardRenderer {
 
     renderShadows(lights, camera) {
 
-        var device = this.device;
+        const device = this.device;
         device.grabPassAvailable = false;
 
         // #if _PROFILER
-        var shadowMapStartTime = now();
+        const shadowMapStartTime = now();
         // #endif
 
         for (let i = 0; i < lights.length; i++) {
@@ -1152,10 +1139,10 @@ class ForwardRenderer {
     }
 
     setCullMode(cullFaces, flip, drawCall) {
-        var material = drawCall.material;
-        var mode = CULLFACE_NONE;
+        const material = drawCall.material;
+        let mode = CULLFACE_NONE;
         if (cullFaces) {
-            var flipFaces = 1;
+            let flipFaces = 1;
 
             if (material.cull > CULLFACE_NONE && material.cull < CULLFACE_FRONTANDBACK) {
                 if (drawCall.flipFaces)
@@ -1164,7 +1151,7 @@ class ForwardRenderer {
                 if (flip)
                     flipFaces *= -1;
 
-                var wt = drawCall.node.worldTransform;
+                const wt = drawCall.node.worldTransform;
                 wt.getX(worldMatX);
                 wt.getY(worldMatY);
                 wt.getZ(worldMatZ);
@@ -1183,7 +1170,7 @@ class ForwardRenderer {
         this.device.setCullMode(mode);
 
         if (mode === CULLFACE_NONE && material.cull === CULLFACE_NONE) {
-            var wt2 = drawCall.node.worldTransform;
+            const wt2 = drawCall.node.worldTransform;
             wt2.getX(worldMatX);
             wt2.getY(worldMatY);
             wt2.getZ(worldMatZ);
@@ -1220,14 +1207,13 @@ class ForwardRenderer {
 
             } else {    // vertex attributes based morphing
 
-                var vb, semantic;
-                for (var t = 0; t < morphInstance._activeVertexBuffers.length; t++) {
+                for (let t = 0; t < morphInstance._activeVertexBuffers.length; t++) {
 
-                    vb = morphInstance._activeVertexBuffers[t];
+                    const vb = morphInstance._activeVertexBuffers[t];
                     if (vb) {
 
                         // patch semantic for the buffer to current ATTR slot (using ATTR8 - ATTR15 range)
-                        semantic = SEMANTIC_ATTR + (t + 8);
+                        const semantic = SEMANTIC_ATTR + (t + 8);
                         vb.format.elements[0].name = semantic;
                         vb.format.elements[0].scopeId = device.scope.resolve(semantic);
                         vb.format.update();
@@ -1253,27 +1239,24 @@ class ForwardRenderer {
     }
 
     renderForward(camera, drawCalls, drawCallsCount, sortedLights, pass, cullingMask, drawCallback, layer, flipFaces) {
-        var device = this.device;
-        var scene = this.scene;
-        var vrDisplay = camera.vrDisplay;
-        var lightHash = layer ? layer._lightHash : 0;
-
-        var passFlag = 1 << pass;
+        const device = this.device;
+        const scene = this.scene;
+        const vrDisplay = camera.vrDisplay;
+        const lightHash = layer ? layer._lightHash : 0;
+        const passFlag = 1 << pass;
 
         // #if _PROFILER
-        var forwardStartTime = now();
+        const forwardStartTime = now();
         // #endif
 
-        var i, drawCall, mesh, material, objDefs, variantKey, lightMask, style, usedDirLights;
-        var prevMaterial = null, prevObjDefs, prevLightMask, prevStatic;
-        var stencilFront, stencilBack;
+        let prevMaterial = null, prevObjDefs, prevLightMask, prevStatic;
 
-        var halfWidth = device.width * 0.5;
+        const halfWidth = device.width * 0.5;
 
         // Render the scene
-        for (i = 0; i < drawCallsCount; i++) {
+        for (let i = 0; i < drawCallsCount; i++) {
 
-            drawCall = drawCalls[i];
+            const drawCall = drawCalls[i];
             if (cullingMask && drawCall.mask && !(cullingMask & drawCall.mask)) continue; // apply visibility override
 
             if (drawCall.command) {
@@ -1293,10 +1276,10 @@ class ForwardRenderer {
                 // #endif
 
                 // We have a mesh instance
-                mesh = drawCall.mesh;
-                material = drawCall.material;
-                objDefs = drawCall._shaderDefs;
-                lightMask = drawCall.mask;
+                const mesh = drawCall.mesh;
+                const material = drawCall.material;
+                const objDefs = drawCall._shaderDefs;
+                const lightMask = drawCall.mask;
 
                 this.setSkinning(device, drawCall, material);
 
@@ -1318,7 +1301,7 @@ class ForwardRenderer {
 
                     if (!drawCall._shader[pass] || drawCall._shaderDefs !== objDefs || drawCall._lightHash !== lightHash) {
                         if (!drawCall.isStatic) {
-                            variantKey = pass + "_" + objDefs + "_" + lightHash;
+                            const variantKey = pass + "_" + objDefs + "_" + lightHash;
                             drawCall._shader[pass] = material.variants[variantKey];
                             if (!drawCall._shader[pass]) {
                                 this.updateShader(drawCall, objDefs, null, pass, sortedLights);
@@ -1342,7 +1325,7 @@ class ForwardRenderer {
                     material.setParameters(device);
 
                     if (!prevMaterial || lightMask !== prevLightMask) {
-                        usedDirLights = this.dispatchDirectLights(sortedLights[LIGHTTYPE_DIRECTIONAL], scene, lightMask, camera);
+                        const usedDirLights = this.dispatchDirectLights(sortedLights[LIGHTTYPE_DIRECTIONAL], scene, lightMask, camera);
                         this.dispatchLocalLights(sortedLights, scene, lightMask, usedDirLights, drawCall._staticLightList);
                     }
 
@@ -1382,8 +1365,8 @@ class ForwardRenderer {
 
                 this.setCullMode(camera._cullFaces, flipFaces, drawCall);
 
-                stencilFront = drawCall.stencilFront || material.stencilFront;
-                stencilBack = drawCall.stencilBack || material.stencilBack;
+                const stencilFront = drawCall.stencilFront || material.stencilFront;
+                const stencilBack = drawCall.stencilBack || material.stencilBack;
 
                 if (stencilFront || stencilBack) {
                     device.setStencilTest(true);
@@ -1422,7 +1405,7 @@ class ForwardRenderer {
                 this.setVertexBuffers(device, mesh);
                 this.setMorphing(device, drawCall.morphInstance);
 
-                style = drawCall.renderStyle;
+                const style = drawCall.renderStyle;
                 device.setIndexBuffer(mesh.indexBuffer[style]);
 
                 if (drawCallback) {
@@ -1456,10 +1439,10 @@ class ForwardRenderer {
                     i += this.drawInstance2(device, drawCall, mesh, style);
                     this._forwardDrawCalls++;
                 } else if (camera.xr && camera.xr.session && camera.xr.views.length) {
-                    var views = camera.xr.views;
+                    const views = camera.xr.views;
 
-                    for (var v = 0; v < views.length; v++) {
-                        var view = views[v];
+                    for (let v = 0; v < views.length; v++) {
+                        const view = views[v];
 
                         device.setViewport(view.viewport.x, view.viewport.y, view.viewport.z, view.viewport.w);
 
@@ -1511,15 +1494,13 @@ class ForwardRenderer {
     }
 
     revertStaticMeshes(meshInstances) {
-        var i;
-        var drawCalls = meshInstances;
-        var drawCallsCount = drawCalls.length;
-        var drawCall;
-        var newDrawCalls = [];
+        const drawCalls = meshInstances;
+        const drawCallsCount = drawCalls.length;
+        const newDrawCalls = [];
 
-        var prevStaticSource;
-        for (i = 0; i < drawCallsCount; i++) {
-            drawCall = drawCalls[i];
+        let prevStaticSource;
+        for (let i = 0; i < drawCallsCount; i++) {
+            const drawCall = drawCalls[i];
             if (drawCall._staticSource) {
                 if (drawCall._staticSource !== prevStaticSource) {
                     newDrawCalls.push(drawCall._staticSource);
@@ -1532,7 +1513,7 @@ class ForwardRenderer {
 
         // Set array to new
         meshInstances.length = newDrawCalls.length;
-        for (i = 0; i < newDrawCalls.length; i++) {
+        for (let i = 0; i < newDrawCalls.length; i++) {
             meshInstances[i] = newDrawCalls[i];
         }
     }
@@ -1834,9 +1815,9 @@ class ForwardRenderer {
     }
 
     updateShaders(drawCalls) {
-        var mat, count = drawCalls.length;
-        for (var i = 0; i < count; i++) {
-            mat = drawCalls[i].material;
+        const count = drawCalls.length;
+        for (let i = 0; i < count; i++) {
+            const mat = drawCalls[i].material;
             if (mat) {
                 // material not processed yet
                 if (!_tempMaterialSet.has(mat)) {
@@ -1855,9 +1836,9 @@ class ForwardRenderer {
     }
 
     updateLitShaders(drawCalls) {
-        var mat, count = drawCalls.length;
-        for (var i = 0; i < count; i++) {
-            mat = drawCalls[i].material;
+        const count = drawCalls.length;
+        for (let i = 0; i < count; i++) {
+            const mat = drawCalls[i].material;
             if (mat) {
                 // material not processed yet
                 if (!_tempMaterialSet.has(mat)) {
@@ -1880,9 +1861,9 @@ class ForwardRenderer {
     }
 
     beginFrame(comp) {
-        var scene = this.scene;
-        var meshInstances = comp._meshInstances;
-        var lights = comp._lights;
+        const scene = this.scene;
+        const meshInstances = comp._meshInstances;
+        const lights = comp._lights;
 
         // Update shaders if needed
         // all mesh instances (TODO: ideally can update less if only lighting changed)
@@ -1900,31 +1881,29 @@ class ForwardRenderer {
         // Update all skin matrices to properly cull skinned objects (but don't update rendering data yet)
         this.updateCpuSkinMatrices(meshInstances);
 
-        var i;
-        var len = meshInstances.length;
-        for (i = 0; i < len; i++) {
+        const miCount = meshInstances.length;
+        for (let i = 0; i < miCount; i++) {
             meshInstances[i].visibleThisFrame = false;
         }
 
         // clear light visibility
-        len = lights.length;
-        for (i = 0; i < len; i++) {
+        const lightCount = lights.length;
+        for (let i = 0; i < lightCount; i++) {
             lights[i].visibleThisFrame = lights[i]._type === LIGHTTYPE_DIRECTIONAL;
         }
     }
 
     beginLayers(comp) {
-        var scene = this.scene;
-        var len = comp.layerList.length;
-        var layer;
-        var i, j;
-        var shaderVersion = this.scene._shaderVersion;
-        for (i = 0; i < len; i++) {
+
+        const len = comp.layerList.length;
+        for (let i = 0; i < len; i++) {
             comp.layerList[i]._postRenderCounter = 0;
         }
-        var transparent;
-        for (i = 0; i < len; i++) {
-            layer = comp.layerList[i];
+
+        const scene = this.scene;
+        const shaderVersion = scene._shaderVersion;
+        for (let i = 0; i < len; i++) {
+            const layer = comp.layerList[i];
             layer._shaderVersion = shaderVersion;
             // #if _PROFILER
             layer._skipRenderCounter = 0;
@@ -1935,7 +1914,7 @@ class ForwardRenderer {
 
             layer._preRenderCalledForCameras = 0;
             layer._postRenderCalledForCameras = 0;
-            transparent = comp.subLayerList[i];
+            const transparent = comp.subLayerList[i];
             if (transparent) {
                 layer._postRenderCounter |= 2;
             } else {
@@ -1944,7 +1923,7 @@ class ForwardRenderer {
             layer._postRenderCounterMax = layer._postRenderCounter;
 
             // prepare layer for culling with the camera
-            for (j = 0; j < layer.cameras.length; j++) {
+            for (let j = 0; j < layer.cameras.length; j++) {
                 layer.instances.prepare(j);
             }
 
@@ -1972,9 +1951,7 @@ class ForwardRenderer {
     }
 
     setSceneConstants() {
-        var i;
-        var device = this.device;
-        var scene = this.scene;
+        const scene = this.scene;
 
         // Set up ambient/exposure
         this.dispatchGlobalLights(scene);
@@ -1985,7 +1962,7 @@ class ForwardRenderer {
             this.fogColor[1] = scene.fogColor.g;
             this.fogColor[2] = scene.fogColor.b;
             if (scene.gammaCorrection) {
-                for (i = 0; i < 3; i++) {
+                for (const i = 0; i < 3; i++) {
                     this.fogColor[i] = Math.pow(this.fogColor[i], 2.2);
                 }
             }
@@ -1999,6 +1976,7 @@ class ForwardRenderer {
         }
 
         // Set up screen size // should be RT size?
+        const device = this.device;
         this._screenSize[0] = device.width;
         this._screenSize[1] = device.height;
         this._screenSize[2] = 1 / device.width;
@@ -2009,14 +1987,15 @@ class ForwardRenderer {
     updateLightStats(comp, compUpdatedFlags) {
 
         // #if _PROFILER
-        if (compUpdatedFlags & COMPUPDATED_LIGHTS || !this.scene._statsUpdated) {
-            var stats = this.scene._stats;
+        const scene = this.scene;
+        if (compUpdatedFlags & COMPUPDATED_LIGHTS || !scene._statsUpdated) {
+            const stats = scene._stats;
             stats.lights = comp._lights.length;
             stats.dynamicLights = 0;
             stats.bakedLights = 0;
-            var l;
-            for (var i = 0; i < stats.lights; i++) {
-                l = comp._lights[i];
+
+            for (let i = 0; i < stats.lights; i++) {
+                const l = comp._lights[i];
                 if (l.enabled) {
                     if ((l.mask & MASK_DYNAMIC) || (l.mask & MASK_BAKED)) { // if affects dynamic or baked objects in real-time
                         stats.dynamicLights++;
@@ -2028,11 +2007,11 @@ class ForwardRenderer {
             }
         }
 
-        if (compUpdatedFlags & COMPUPDATED_INSTANCES || !this.scene._statsUpdated) {
-            this.scene._stats.meshInstances = comp._meshInstances.length;
+        if (compUpdatedFlags & COMPUPDATED_INSTANCES || !scene._statsUpdated) {
+            scene._stats.meshInstances = comp._meshInstances.length;
         }
 
-        this.scene._statsUpdated = true;
+        scene._statsUpdated = true;
         // #endif
     }
 
@@ -2155,10 +2134,7 @@ class ForwardRenderer {
     }
 
     renderComposition(comp) {
-        var device = this.device;
-        var camera;
-        var renderAction, renderActions = comp._renderActions;
-        var i, layer, layerIndex, transparent;
+        const device = this.device;
 
         // update the skybox, since this might change _meshInstances
         if (this.scene.updateSkybox) {
@@ -2169,11 +2145,11 @@ class ForwardRenderer {
         this.beginLayers(comp);
 
         // #if _PROFILER
-        var layerCompositionUpdateTime = now();
+        const layerCompositionUpdateTime = now();
         // #endif
 
         // Update static layer data, if something's changed
-        var updated = comp._update();
+        const updated = comp._update();
         if (updated & COMPUPDATED_LIGHTS) {
             this.scene.updateLitShaders = true;
         }
@@ -2207,16 +2183,17 @@ class ForwardRenderer {
 
         // Rendering
         let sortTime, drawTime;
-        for (i = 0; i < renderActions.length; i++) {
-            renderAction = renderActions[i];
+        const renderActions = comp._renderActions;
+        for (let i = 0; i < renderActions.length; i++) {
+            const renderAction = renderActions[i];
 
             // layer
-            layerIndex = renderAction.layerIndex;
-            layer = comp.layerList[layerIndex];
-            transparent = comp.subLayerList[layerIndex];
+            const layerIndex = renderAction.layerIndex;
+            const layer = comp.layerList[layerIndex];
+            const transparent = comp.subLayerList[layerIndex];
 
             const cameraPass = renderAction.cameraIndex;
-            camera = layer.cameras[cameraPass];
+            const camera = layer.cameras[cameraPass];
 
             // render directional shadow maps for this camera - these get re-rendered for each camera
             if (renderAction.directionalLights.length > 0) {

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -82,16 +82,20 @@ const _tempMaterialSet = new Set();
  * @name ForwardRenderer
  * @classdesc The forward renderer render scene objects.
  * @description Creates a new forward renderer object.
+ * @hideconstructor
  * @param {GraphicsDevice} graphicsDevice - The graphics device used by the renderer.
+ * @param {Scene} A - scene for the rendering.
  */
 class ForwardRenderer {
-    constructor(graphicsDevice) {
+    constructor(graphicsDevice, scene) {
         this.device = graphicsDevice;
-        const device = this.device;
+        this.scene = scene;
 
         this._shadowDrawCalls = 0;
         this._forwardDrawCalls = 0;
         this._skinDrawCalls = 0;
+        this._numDrawCallsCulled = 0;
+        this._instancedDrawCalls = 0;
         this._camerasRendered = 0;
         this._materialSwitches = 0;
         this._shadowMapUpdates = 0;
@@ -103,11 +107,13 @@ class ForwardRenderer {
         this._skinTime = 0;
         this._morphTime = 0;
         this._instancingTime = 0;
+        this._removedByInstancing = 0;
         this._layerCompositionUpdateTime = 0;
         this._lightClustersTime = 0;
         this._lightClusters = 0;
 
         // Shaders
+        const device = this.device;
         const library = device.getProgramLibrary();
         this.library = library;
 
@@ -1634,7 +1640,7 @@ class ForwardRenderer {
             this.fogColor[1] = scene.fogColor.g;
             this.fogColor[2] = scene.fogColor.b;
             if (scene.gammaCorrection) {
-                for (const i = 0; i < 3; i++) {
+                for (let i = 0; i < 3; i++) {
                     this.fogColor[i] = Math.pow(this.fogColor[i], 2.2);
                 }
             }

--- a/src/scene/renderer/static-meshes.js
+++ b/src/scene/renderer/static-meshes.js
@@ -1,0 +1,342 @@
+import { now } from  '../../core/time.js';
+import { Vec3 } from '../../math/vec3.js';
+import { Mat4 } from '../../math/mat4.js';
+
+import { BoundingBox } from '../../shape/bounding-box.js';
+import { BoundingSphere } from '../../shape/bounding-sphere.js';
+
+import { PRIMITIVE_TRIANGLES, SEMANTIC_POSITION } from '../../graphics/constants.js';
+import { IndexBuffer } from '../../graphics/index-buffer.js';
+
+import { LIGHTTYPE_OMNI, LIGHTTYPE_SPOT } from '../constants.js';
+import { Mesh } from '../mesh.js';
+import { MeshInstance } from '../mesh-instance.js';
+
+const tempSphere = new BoundingSphere();
+
+class StaticMeshes {
+    static lightCompare(lightA, lightB) {
+        return lightA.key - lightB.key;
+    }
+
+    static prepare(device, scene, meshInstances, lights) {
+        // #if _PROFILER
+        var prepareTime = now();
+        var searchTime = 0;
+        var subSearchTime = 0;
+        var triAabbTime = 0;
+        var subTriAabbTime = 0;
+        var writeMeshTime = 0;
+        var subWriteMeshTime = 0;
+        var combineTime = 0;
+        var subCombineTime = 0;
+        // #endif
+
+        var i, j, k, v, s, index;
+
+        var drawCalls = meshInstances;
+        var drawCallsCount = drawCalls.length;
+        var drawCall, light;
+
+        var newDrawCalls = [];
+        var mesh;
+        var indices, verts, numTris, elems, vertSize, offsetP, baseIndex;
+        var _x, _y, _z;
+        var minx, miny, minz, maxx, maxy, maxz;
+        var minv, maxv;
+        var minVec = new Vec3();
+        var maxVec = new Vec3();
+        var localLightBounds = new BoundingBox();
+        var invMatrix = new Mat4();
+        var triLightComb = [];
+        var triLightCombUsed;
+        var indexBuffer, vertexBuffer;
+        var combIndices, combIbName, combIb;
+        var lightTypePass;
+        var lightAabb = [];
+        var aabb;
+        var triBounds = [];
+        var staticLights = [];
+        var bit;
+        var lht;
+        for (i = 0; i < drawCallsCount; i++) {
+            drawCall = drawCalls[i];
+            if (!drawCall.isStatic) {
+                newDrawCalls.push(drawCall);
+            } else {
+                aabb = drawCall.aabb;
+                staticLights.length = 0;
+                for (lightTypePass = LIGHTTYPE_OMNI; lightTypePass <= LIGHTTYPE_SPOT; lightTypePass++) {
+                    for (j = 0; j < lights.length; j++) {
+                        light = lights[j];
+                        if (light._type !== lightTypePass) continue;
+                        if (light.enabled) {
+                            if (light.mask & drawCall.mask) {
+                                if (light.isStatic) {
+                                    if (!lightAabb[j]) {
+                                        lightAabb[j] = new BoundingBox();
+                                        // light.getBoundingBox(lightAabb[j]); // box from sphere seems to give better granularity
+                                        light._node.getWorldTransform();
+                                        light.getBoundingSphere(tempSphere);
+                                        lightAabb[j].center.copy(tempSphere.center);
+                                        lightAabb[j].halfExtents.x = tempSphere.radius;
+                                        lightAabb[j].halfExtents.y = tempSphere.radius;
+                                        lightAabb[j].halfExtents.z = tempSphere.radius;
+                                    }
+                                    if (!lightAabb[j].intersects(aabb)) continue;
+                                    staticLights.push(j);
+                                }
+                            }
+                        }
+                    }
+                }
+
+                if (staticLights.length === 0) {
+                    newDrawCalls.push(drawCall);
+                    continue;
+                }
+
+                mesh = drawCall.mesh;
+                vertexBuffer = mesh.vertexBuffer;
+                indexBuffer = mesh.indexBuffer[drawCall.renderStyle];
+                indices = indexBuffer.bytesPerIndex === 2 ? new Uint16Array(indexBuffer.lock()) : new Uint32Array(indexBuffer.lock());
+                numTris = mesh.primitive[drawCall.renderStyle].count / 3;
+                baseIndex = mesh.primitive[drawCall.renderStyle].base;
+                elems = vertexBuffer.format.elements;
+                vertSize = vertexBuffer.format.size / 4; // / 4 because float
+                verts = new Float32Array(vertexBuffer.storage);
+
+                for (k = 0; k < elems.length; k++) {
+                    if (elems[k].name === SEMANTIC_POSITION) {
+                        offsetP = elems[k].offset / 4; // / 4 because float
+                    }
+                }
+
+                // #if _PROFILER
+                subTriAabbTime = now();
+                // #endif
+
+                triLightComb.length = numTris;
+                for (k = 0; k < numTris; k++) {
+                    // triLightComb[k] = ""; // uncomment to remove 32 lights limit
+                    triLightComb[k] = 0; // comment to remove 32 lights limit
+                }
+                triLightCombUsed = false;
+
+                triBounds.length = numTris * 6;
+                for (k = 0; k < numTris; k++) {
+                    minx = Number.MAX_VALUE;
+                    miny = Number.MAX_VALUE;
+                    minz = Number.MAX_VALUE;
+                    maxx = -Number.MAX_VALUE;
+                    maxy = -Number.MAX_VALUE;
+                    maxz = -Number.MAX_VALUE;
+                    for (v = 0; v < 3; v++) {
+                        index = indices[k * 3 + v + baseIndex];
+                        index = index * vertSize + offsetP;
+                        _x = verts[index];
+                        _y = verts[index + 1];
+                        _z = verts[index + 2];
+                        if (_x < minx) minx = _x;
+                        if (_y < miny) miny = _y;
+                        if (_z < minz) minz = _z;
+                        if (_x > maxx) maxx = _x;
+                        if (_y > maxy) maxy = _y;
+                        if (_z > maxz) maxz = _z;
+                    }
+                    index = k * 6;
+                    triBounds[index] = minx;
+                    triBounds[index + 1] = miny;
+                    triBounds[index + 2] = minz;
+                    triBounds[index + 3] = maxx;
+                    triBounds[index + 4] = maxy;
+                    triBounds[index + 5] = maxz;
+                }
+                // #if _PROFILER
+                triAabbTime += now() - subTriAabbTime;
+                // #endif
+
+                // #if _PROFILER
+                subSearchTime = now();
+                // #endif
+                for (s = 0; s < staticLights.length; s++) {
+                    j = staticLights[s];
+                    light = lights[j];
+
+                    invMatrix.copy(drawCall.node.worldTransform).invert();
+                    localLightBounds.setFromTransformedAabb(lightAabb[j], invMatrix);
+                    minv = localLightBounds.getMin();
+                    maxv = localLightBounds.getMax();
+                    bit = 1 << s;
+
+                    for (k = 0; k < numTris; k++) {
+                        index = k * 6;
+                        if ((triBounds[index] <= maxv.x) && (triBounds[index + 3] >= minv.x) &&
+                            (triBounds[index + 1] <= maxv.y) && (triBounds[index + 4] >= minv.y) &&
+                            (triBounds[index + 2] <= maxv.z) && (triBounds[index + 5] >= minv.z)) {
+
+                            // triLightComb[k] += j + "_";  // uncomment to remove 32 lights limit
+                            triLightComb[k] |= bit; // comment to remove 32 lights limit
+                            triLightCombUsed = true;
+                        }
+                    }
+                }
+                // #if _PROFILER
+                searchTime += now() - subSearchTime;
+                // #endif
+
+                if (triLightCombUsed) {
+
+                    // #if _PROFILER
+                    subCombineTime = now();
+                    // #endif
+
+                    combIndices = {};
+                    for (k = 0; k < numTris; k++) {
+                        j = k * 3 + baseIndex; // can go beyond 0xFFFF if base was non-zero?
+                        combIbName = triLightComb[k];
+                        if (!combIndices[combIbName]) combIndices[combIbName] = [];
+                        combIb = combIndices[combIbName];
+                        combIb.push(indices[j]);
+                        combIb.push(indices[j + 1]);
+                        combIb.push(indices[j + 2]);
+                    }
+
+                    // #if _PROFILER
+                    combineTime += now() - subCombineTime;
+                    // #endif
+
+                    // #if _PROFILER
+                    subWriteMeshTime = now();
+                    // #endif
+
+                    for (combIbName in combIndices) {
+                        combIb = combIndices[combIbName];
+                        var ib = new IndexBuffer(device, indexBuffer.format, combIb.length, indexBuffer.usage);
+                        var ib2 = ib.bytesPerIndex === 2 ? new Uint16Array(ib.lock()) : new Uint32Array(ib.lock());
+                        ib2.set(combIb);
+                        ib.unlock();
+
+                        minx = Number.MAX_VALUE;
+                        miny = Number.MAX_VALUE;
+                        minz = Number.MAX_VALUE;
+                        maxx = -Number.MAX_VALUE;
+                        maxy = -Number.MAX_VALUE;
+                        maxz = -Number.MAX_VALUE;
+                        for (k = 0; k < combIb.length; k++) {
+                            index = combIb[k];
+                            _x = verts[index * vertSize + offsetP];
+                            _y = verts[index * vertSize + offsetP + 1];
+                            _z = verts[index * vertSize + offsetP + 2];
+                            if (_x < minx) minx = _x;
+                            if (_y < miny) miny = _y;
+                            if (_z < minz) minz = _z;
+                            if (_x > maxx) maxx = _x;
+                            if (_y > maxy) maxy = _y;
+                            if (_z > maxz) maxz = _z;
+                        }
+                        minVec.set(minx, miny, minz);
+                        maxVec.set(maxx, maxy, maxz);
+                        var chunkAabb = new BoundingBox();
+                        chunkAabb.setMinMax(minVec, maxVec);
+
+                        var mesh2 = new Mesh(device);
+                        mesh2.vertexBuffer = vertexBuffer;
+                        mesh2.indexBuffer[0] = ib;
+                        mesh2.primitive[0].type = PRIMITIVE_TRIANGLES;
+                        mesh2.primitive[0].base = 0;
+                        mesh2.primitive[0].count = combIb.length;
+                        mesh2.primitive[0].indexed = true;
+                        mesh2.aabb = chunkAabb;
+
+                        var instance = new MeshInstance(mesh2, drawCall.material, drawCall.node);
+                        instance.isStatic = drawCall.isStatic;
+                        instance.visible = drawCall.visible;
+                        instance.layer = drawCall.layer;
+                        instance.castShadow = drawCall.castShadow;
+                        instance._receiveShadow = drawCall._receiveShadow;
+                        instance.cull = drawCall.cull;
+                        instance.pick = drawCall.pick;
+                        instance.mask = drawCall.mask;
+                        instance.parameters = drawCall.parameters;
+                        instance._shaderDefs = drawCall._shaderDefs;
+                        instance._staticSource = drawCall;
+
+                        if (drawCall._staticLightList) {
+                            instance._staticLightList = drawCall._staticLightList; // add forced assigned lights
+                        } else {
+                            instance._staticLightList = [];
+                        }
+
+                        // uncomment to remove 32 lights limit
+                        // var lnames = combIbName.split("_");
+                        // lnames.length = lnames.length - 1;
+                        // for(k = 0; k < lnames.length; k++) {
+                        //     instance._staticLightList[k] = lights[parseInt(lnames[k])];
+                        // }
+
+                        // comment to remove 32 lights limit
+                        for (k = 0; k < staticLights.length; k++) {
+                            bit = 1 << k;
+                            if (combIbName & bit) {
+                                lht = lights[staticLights[k]];
+                                if (instance._staticLightList.indexOf(lht) < 0) {
+                                    instance._staticLightList.push(lht);
+                                }
+                            }
+                        }
+
+                        instance._staticLightList.sort(StaticMeshes.lightCompare);
+
+                        newDrawCalls.push(instance);
+                    }
+
+                    // #if _PROFILER
+                    writeMeshTime += now() - subWriteMeshTime;
+                    // #endif
+                } else {
+                    newDrawCalls.push(drawCall);
+                }
+            }
+        }
+        // Set array to new
+        meshInstances.length = newDrawCalls.length;
+        for (i = 0; i < newDrawCalls.length; i++) {
+            meshInstances[i] = newDrawCalls[i];
+        }
+        // #if _PROFILER
+        scene._stats.lastStaticPrepareFullTime = now() - prepareTime;
+        scene._stats.lastStaticPrepareSearchTime = searchTime;
+        scene._stats.lastStaticPrepareWriteTime = writeMeshTime;
+        scene._stats.lastStaticPrepareTriAabbTime = triAabbTime;
+        scene._stats.lastStaticPrepareCombineTime = combineTime;
+        // #endif
+    }
+
+    static revert(meshInstances) {
+        const drawCalls = meshInstances;
+        const drawCallsCount = drawCalls.length;
+        const newDrawCalls = [];
+
+        let prevStaticSource;
+        for (let i = 0; i < drawCallsCount; i++) {
+            const drawCall = drawCalls[i];
+            if (drawCall._staticSource) {
+                if (drawCall._staticSource !== prevStaticSource) {
+                    newDrawCalls.push(drawCall._staticSource);
+                    prevStaticSource = drawCall._staticSource;
+                }
+            } else {
+                newDrawCalls.push(drawCall);
+            }
+        }
+
+        // Set array to new
+        meshInstances.length = newDrawCalls.length;
+        for (let i = 0; i < newDrawCalls.length; i++) {
+            meshInstances[i] = newDrawCalls[i];
+        }
+    }
+}
+
+export { StaticMeshes };


### PR DESCRIPTION
- separated functionality dealing with static meshes getting split up by lights into separate file (static-meshes)
- removed invalid/obsolete call to prepareStaticMeshes by the Application (completely incorrect parameters resulting to no-op)
- hiding ForwardRenderer's constructor from jsdocs
- initialized few missing members in ForwardRenderer to avoid Visual Studio giving us errors
- converted var to let/const (apart from static-meshes.js)