### PR TITLE
Optimize collision component load time

### DIFF
--- a/src/framework/components/collision/component.js
+++ b/src/framework/components/collision/component.js
@@ -315,6 +315,9 @@ class CollisionComponent extends Component {
             if (asset && (!asset.resource || !this.data.shape)) {
                 this.system.recreatePhysicalShapes(this);
                 return;
+            } else if (! this.data.initialized && ! this.data.shape) {
+                this.system.recreatePhysicalShapes(this);
+                return;
             }
         }
 

--- a/src/framework/components/collision/component.js
+++ b/src/framework/components/collision/component.js
@@ -322,7 +322,7 @@ class CollisionComponent extends Component {
 
         if (_recreatePhysicalShapes) {
             this.system.recreatePhysicalShapes(this);
-            return;            
+            return;
         }
 
         if (this.entity.rigidbody) {

--- a/src/framework/components/collision/component.js
+++ b/src/framework/components/collision/component.js
@@ -308,17 +308,21 @@ class CollisionComponent extends Component {
     }
 
     onEnable() {
+        let _recreatePhysicalShapes = false;
         if (this.data.type === 'mesh' && (this.data.asset || this.data.renderAsset) && this.data.initialized) {
             var asset = this.system.app.assets.get(this.data.asset || this.data.renderAsset);
             // recreate the collision shape if the model asset is not loaded
             // or the shape does not exist
             if (asset && (!asset.resource || !this.data.shape)) {
-                this.system.recreatePhysicalShapes(this);
-                return;
-            } else if (! this.data.initialized && ! this.data.shape) {
-                this.system.recreatePhysicalShapes(this);
-                return;
+                _recreatePhysicalShapes = true;
             }
+        } else if (! this.data.initialized && ! this.data.shape) {
+            _recreatePhysicalShapes = true;
+        }
+
+        if (_recreatePhysicalShapes) {
+            this.system.recreatePhysicalShapes(this);
+            return;            
         }
 
         if (this.entity.rigidbody) {

--- a/src/framework/components/collision/system.js
+++ b/src/framework/components/collision/system.js
@@ -49,8 +49,12 @@ class CollisionSystemImpl {
 
     // Called after the call to system.super.initializeComponentData is made
     afterInitialize(component, data) {
-        this.recreatePhysicalShapes(component);
-        component.data.initialized = true;
+        const entity = component.entity;
+
+        if (entity.enabled && component.enabled) {
+            this.recreatePhysicalShapes(component);
+            component.data.initialized = true;
+        }
     }
 
     // Called when a collision component changes type in order to recreate debug and physical shapes

--- a/src/framework/components/collision/system.js
+++ b/src/framework/components/collision/system.js
@@ -49,9 +49,7 @@ class CollisionSystemImpl {
 
     // Called after the call to system.super.initializeComponentData is made
     afterInitialize(component, data) {
-        const entity = component.entity;
-
-        if (entity.enabled && component.enabled) {
+        if (component.entity.enabled && component.enabled) {
             this.recreatePhysicalShapes(component);
             component.data.initialized = true;
         }

--- a/src/resources/parser/scene.js
+++ b/src/resources/parser/scene.js
@@ -103,7 +103,7 @@ class SceneParser {
         for (let i = 0; i < len; i++) {
             const system = systemsList[i];
             const componentData = entityData.components[system.id];
-            if (componentData) {
+            if (componentData && componentData.enabled) {
                 system.addComponent(entity, componentData);
             }
         }


### PR DESCRIPTION
Optimizes application load time, when there are many disabled entities in a scene with a collision component.

Before (200 disabled entities):

![New Project (14)](https://user-images.githubusercontent.com/5677782/132882827-e476ee3d-70d4-4ddc-971f-1ccb5e837b39.png)

After:

![New Project (17)](https://user-images.githubusercontent.com/5677782/132888715-fc1003c6-0aaf-49e1-bb2c-b020114a8911.png)



Tested with See More and a local physics test bed.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
