### PR TITLE
Use mouse scroll wheel events to navigate content in scroll-view UI component.

### DIFF
--- a/examples/src/examples/user-interface/scroll-view.tsx
+++ b/examples/src/examples/user-interface/scroll-view.tsx
@@ -192,6 +192,8 @@ class ScrollViewExample extends Example {
             bounceAmount: 0.1,
             contentEntity: content,
             friction: 0.05,
+            useMouseWheel: true,
+            mouseWheelSensitivity: new pc.Vec2(1, 1),
             horizontal: true,
             horizontalScrollbarEntity: horizontalScrollbar,
             horizontalScrollbarVisibility: pc.SCROLLBAR_VISIBILITY_SHOW_WHEN_REQUIRED,

--- a/examples/src/examples/user-interface/scroll-view.tsx
+++ b/examples/src/examples/user-interface/scroll-view.tsx
@@ -192,8 +192,6 @@ class ScrollViewExample extends Example {
             bounceAmount: 0.1,
             contentEntity: content,
             friction: 0.05,
-            useMouseWheel: true,
-            mouseWheelSensitivity: new pc.Vec2(1, 1),
             horizontal: true,
             horizontalScrollbarEntity: horizontalScrollbar,
             horizontalScrollbarVisibility: pc.SCROLLBAR_VISIBILITY_SHOW_WHEN_REQUIRED,

--- a/examples/src/examples/user-interface/scroll-view.tsx
+++ b/examples/src/examples/user-interface/scroll-view.tsx
@@ -130,8 +130,9 @@ class ScrollViewExample extends Example {
             lineHeight: 36,
             pivot: new pc.Vec2(0, 1),
             text: "This is a scroll view control. You can scroll the content by dragging the vertical " +
-                    "or horizontal scroll bars or by dragging the content itself. Notice the elastic " +
-                    "bounce if you drag the content beyond the limits of the scroll view.",
+                    "or horizontal scroll bars, by dragging the content itself, by using the mouse wheel, or " +
+                    "by using a trackpad. Notice the elastic bounce if you drag the content beyond the " +
+                    "limits of the scroll view.",
             type: pc.ELEMENTTYPE_TEXT,
             width: 400,
             wrapLines: true
@@ -191,6 +192,8 @@ class ScrollViewExample extends Example {
             bounceAmount: 0.1,
             contentEntity: content,
             friction: 0.05,
+            useMouseWheel: true,
+            mouseWheelSensitivity: new pc.Vec2(1, 1),
             horizontal: true,
             horizontalScrollbarEntity: horizontalScrollbar,
             horizontalScrollbarVisibility: pc.SCROLLBAR_VISIBILITY_SHOW_WHEN_REQUIRED,

--- a/examples/src/examples/user-interface/scroll-view.tsx
+++ b/examples/src/examples/user-interface/scroll-view.tsx
@@ -193,7 +193,7 @@ class ScrollViewExample extends Example {
             contentEntity: content,
             friction: 0.05,
             useMouseWheel: true,
-            mouseWheelSensitivity: new pc.Vec2(1, 1),
+            mouseWheelSensitivity: pc.Vec2.ONE,
             horizontal: true,
             horizontalScrollbarEntity: horizontalScrollbar,
             horizontalScrollbarVisibility: pc.SCROLLBAR_VISIBILITY_SHOW_WHEN_REQUIRED,

--- a/src/framework/components/scroll-view/component.js
+++ b/src/framework/components/scroll-view/component.js
@@ -10,6 +10,7 @@ import { ElementDragHelper } from '../element/element-drag-helper.js';
 
 import { SCROLL_MODE_BOUNCE, SCROLL_MODE_CLAMP, SCROLL_MODE_INFINITE, SCROLLBAR_VISIBILITY_SHOW_ALWAYS, SCROLLBAR_VISIBILITY_SHOW_WHEN_REQUIRED } from './constants.js';
 import { Component } from '../component.js';
+import { EVENT_MOUSEWHEEL } from '../../../input/constants.js';
 
 var _tempScrollValue = new Vec2();
 
@@ -32,6 +33,8 @@ var _tempScrollValue = new Vec2();
  *
  * @property {number} bounceAmount Controls how far the content should move before bouncing back.
  * @property {number} friction Controls how freely the content should move if thrown, i.e. By flicking on a phone or by flinging the scroll wheel on a mouse. A value of 1 means that content will stop immediately; 0 means that content will continue moving forever (or until the bounds of the content are reached, depending on the scrollMode).
+ * @property {boolean} useMouseWheel Whether to use mouse wheel for scrolling (horizontally and vertically) when mouse is within bounds.
+ * @property {vec2} mouseWheelSensitivity Mouse wheel horizontal and vertical sensitivity. Only used if useMouseWheel is set.
  * @property {number} horizontalScrollbarVisibility Controls whether the horizontal scrollbar should be visible all the time, or only visible when the content exceeds the size of the viewport.
  * @property {number} verticalScrollbarVisibility Controls whether the vertical scrollbar should be visible all the time, or only visible when the content exceeds the size of the viewport.
  * @property {Entity} viewportEntity The entity to be used as the masked viewport area, within which the content will scroll. This entity must have an ElementGroup component.
@@ -69,6 +72,7 @@ class ScrollViewComponent extends Component {
         this._prevContentSizes[ORIENTATION_HORIZONTAL] = null;
         this._prevContentSizes[ORIENTATION_VERTICAL] = null;
 
+        this._isHovering = false;
         this._scroll = new Vec2();
         this._velocity = new Vec3();
 
@@ -86,8 +90,6 @@ class ScrollViewComponent extends Component {
 
         system.app.systems.element[onOrOff]('add', this._onElementComponentAdd, this);
         system.app.systems.element[onOrOff]('beforeremove', this._onElementComponentRemove, this);
-
-        // TODO Handle scrollwheel events
     }
 
     _toggleElementListeners(onOrOff) {
@@ -97,6 +99,9 @@ class ScrollViewComponent extends Component {
             }
 
             this.entity.element[onOrOff]('resize', this._onSetContentOrViewportSize, this);
+            this.entity.element[onOrOff]('mouseenter', this._onMouseEnter, this);
+            this.entity.element[onOrOff]('mouseleave', this._onMouseLeave, this);
+            this.entity.element[onOrOff](EVENT_MOUSEWHEEL, this._onMouseWheel, this);
 
             this._hasElementListeners = (onOrOff === 'on');
         }
@@ -471,9 +476,6 @@ class ScrollViewComponent extends Component {
                 }
             }
 
-            this._velocity.x *= (1 - this.friction);
-            this._velocity.y *= (1 - this.friction);
-
             if (Math.abs(this._velocity.x) > 1e-4 || Math.abs(this._velocity.y) > 1e-4) {
                 var position = this._contentReference.entity.getLocalPosition();
                 position.x += this._velocity.x;
@@ -482,6 +484,9 @@ class ScrollViewComponent extends Component {
 
                 this._setScrollFromContentPosition(position);
             }
+
+            this._velocity.x *= (1 - this.friction);
+            this._velocity.y *= (1 - this.friction);
         }
     }
 
@@ -577,6 +582,30 @@ class ScrollViewComponent extends Component {
     _setContentDraggingEnabled(enabled) {
         if (this._contentDragHelper) {
             this._contentDragHelper.enabled = enabled;
+        }
+    }
+
+    _onMouseEnter(event) {
+        this._isHovering = true;
+    }
+
+    _onMouseLeave(event) {
+        this._isHovering = false;
+    }
+
+    _onMouseWheel(event) {
+        if (this._isHovering && this.useMouseWheel) {
+            const wheelEvent = event.event;
+
+            // wheelEvent's delta variables are screen space, so they need to be normalized first
+            const normalizedDeltaX = (wheelEvent.deltaX / this._contentReference.entity.element.calculatedWidth) * this.mouseWheelSensitivity.x;
+            const normalizedDeltaY = (wheelEvent.deltaY / this._contentReference.entity.element.calculatedHeight) * this.mouseWheelSensitivity.y;
+
+            // update scroll positions, clamping to [0, maxScrollValue] to always prevent over-shooting
+            var scrollX = math.clamp(this._scroll.x + normalizedDeltaX, 0, this._getMaxScrollValue(ORIENTATION_HORIZONTAL));
+            var scrollY = math.clamp(this._scroll.y + normalizedDeltaY, 0, this._getMaxScrollValue(ORIENTATION_VERTICAL));
+
+            this.scroll = new Vec2(scrollX, scrollY);
         }
     }
 

--- a/src/framework/components/scroll-view/component.js
+++ b/src/framework/components/scroll-view/component.js
@@ -34,7 +34,7 @@ var _tempScrollValue = new Vec2();
  * @property {number} bounceAmount Controls how far the content should move before bouncing back.
  * @property {number} friction Controls how freely the content should move if thrown, i.e. By flicking on a phone or by flinging the scroll wheel on a mouse. A value of 1 means that content will stop immediately; 0 means that content will continue moving forever (or until the bounds of the content are reached, depending on the scrollMode).
  * @property {boolean} useMouseWheel Whether to use mouse wheel for scrolling (horizontally and vertically) when mouse is within bounds.
- * @property {vec2} mouseWheelSensitivity Mouse wheel horizontal and vertical sensitivity. Only used if useMouseWheel is set.
+ * @property {Vec2} mouseWheelSensitivity Mouse wheel horizontal and vertical sensitivity. Only used if useMouseWheel is set.
  * @property {number} horizontalScrollbarVisibility Controls whether the horizontal scrollbar should be visible all the time, or only visible when the content exceeds the size of the viewport.
  * @property {number} verticalScrollbarVisibility Controls whether the vertical scrollbar should be visible all the time, or only visible when the content exceeds the size of the viewport.
  * @property {Entity} viewportEntity The entity to be used as the masked viewport area, within which the content will scroll. This entity must have an ElementGroup component.

--- a/src/framework/components/scroll-view/component.js
+++ b/src/framework/components/scroll-view/component.js
@@ -591,8 +591,8 @@ class ScrollViewComponent extends Component {
             const normalizedDeltaY = (wheelEvent.deltaY / this._contentReference.entity.element.calculatedHeight) * this.mouseWheelSensitivity.y;
 
             // update scroll positions, clamping to [0, maxScrollValue] to always prevent over-shooting
-            var scrollX = math.clamp(this._scroll.x + normalizedDeltaX, 0, this._getMaxScrollValue(ORIENTATION_HORIZONTAL));
-            var scrollY = math.clamp(this._scroll.y + normalizedDeltaY, 0, this._getMaxScrollValue(ORIENTATION_VERTICAL));
+            const scrollX = math.clamp(this._scroll.x + normalizedDeltaX, 0, this._getMaxScrollValue(ORIENTATION_HORIZONTAL));
+            const scrollY = math.clamp(this._scroll.y + normalizedDeltaY, 0, this._getMaxScrollValue(ORIENTATION_VERTICAL));
 
             this.scroll = new Vec2(scrollX, scrollY);
         }

--- a/src/framework/components/scroll-view/component.js
+++ b/src/framework/components/scroll-view/component.js
@@ -33,7 +33,7 @@ var _tempScrollValue = new Vec2();
  *
  * @property {number} bounceAmount Controls how far the content should move before bouncing back.
  * @property {number} friction Controls how freely the content should move if thrown, i.e. By flicking on a phone or by flinging the scroll wheel on a mouse. A value of 1 means that content will stop immediately; 0 means that content will continue moving forever (or until the bounds of the content are reached, depending on the scrollMode).
- * @property {boolean} useMouseWheel Whether to use mouse wheel for scrolling (horizontally and vertically) when mouse is within bounds.
+ * @property {boolean} useMouseWheel Whether to use mouse wheel for scrolling (horizontally and vertically).
  * @property {Vec2} mouseWheelSensitivity Mouse wheel horizontal and vertical sensitivity. Only used if useMouseWheel is set.
  * @property {number} horizontalScrollbarVisibility Controls whether the horizontal scrollbar should be visible all the time, or only visible when the content exceeds the size of the viewport.
  * @property {number} verticalScrollbarVisibility Controls whether the vertical scrollbar should be visible all the time, or only visible when the content exceeds the size of the viewport.
@@ -72,7 +72,6 @@ class ScrollViewComponent extends Component {
         this._prevContentSizes[ORIENTATION_HORIZONTAL] = null;
         this._prevContentSizes[ORIENTATION_VERTICAL] = null;
 
-        this._isHovering = false;
         this._scroll = new Vec2();
         this._velocity = new Vec3();
 
@@ -99,8 +98,6 @@ class ScrollViewComponent extends Component {
             }
 
             this.entity.element[onOrOff]('resize', this._onSetContentOrViewportSize, this);
-            this.entity.element[onOrOff]('mouseenter', this._onMouseEnter, this);
-            this.entity.element[onOrOff]('mouseleave', this._onMouseLeave, this);
             this.entity.element[onOrOff](EVENT_MOUSEWHEEL, this._onMouseWheel, this);
 
             this._hasElementListeners = (onOrOff === 'on');
@@ -585,16 +582,8 @@ class ScrollViewComponent extends Component {
         }
     }
 
-    _onMouseEnter(event) {
-        this._isHovering = true;
-    }
-
-    _onMouseLeave(event) {
-        this._isHovering = false;
-    }
-
     _onMouseWheel(event) {
-        if (this._isHovering && this.useMouseWheel) {
+        if (this.useMouseWheel) {
             const wheelEvent = event.event;
 
             // wheelEvent's delta variables are screen space, so they need to be normalized first

--- a/src/framework/components/scroll-view/component.js
+++ b/src/framework/components/scroll-view/component.js
@@ -34,7 +34,7 @@ var _tempScrollValue = new Vec2();
  * @property {number} bounceAmount Controls how far the content should move before bouncing back.
  * @property {number} friction Controls how freely the content should move if thrown, i.e. By flicking on a phone or by flinging the scroll wheel on a mouse. A value of 1 means that content will stop immediately; 0 means that content will continue moving forever (or until the bounds of the content are reached, depending on the scrollMode).
  * @property {boolean} useMouseWheel Whether to use mouse wheel for scrolling (horizontally and vertically).
- * @property {Vec2} mouseWheelSensitivity Mouse wheel horizontal and vertical sensitivity. Only used if useMouseWheel is set.
+ * @property {Vec2} mouseWheelSensitivity Mouse wheel horizontal and vertical sensitivity. Only used if useMouseWheel is set. Setting a direction to 0 will disable mouse wheel scrolling in that direction. 1 is a default sensitivity that is considered to feel good. The values can be set higher or lower than 1 to tune the sensitivity. Defaults to [1, 1].
  * @property {number} horizontalScrollbarVisibility Controls whether the horizontal scrollbar should be visible all the time, or only visible when the content exceeds the size of the viewport.
  * @property {number} verticalScrollbarVisibility Controls whether the vertical scrollbar should be visible all the time, or only visible when the content exceeds the size of the viewport.
  * @property {Entity} viewportEntity The entity to be used as the masked viewport area, within which the content will scroll. This entity must have an ElementGroup component.

--- a/src/framework/components/scroll-view/data.js
+++ b/src/framework/components/scroll-view/data.js
@@ -1,10 +1,6 @@
-import { Vec2 } from '../../../math/vec2.js';
-
 class ScrollViewComponentData {
     constructor() {
         this.enabled = true;
-        this.useMouseWheel = true;
-        this.mouseWheelSensitivity = new Vec2(1, 1);
     }
 }
 

--- a/src/framework/components/scroll-view/data.js
+++ b/src/framework/components/scroll-view/data.js
@@ -1,6 +1,10 @@
+import { Vec2 } from '../../../math/vec2.js';
+
 class ScrollViewComponentData {
     constructor() {
         this.enabled = true;
+        this.useMouseWheel = true;
+        this.mouseWheelSensitivity = new Vec2(1, 1);
     }
 }
 

--- a/src/framework/components/scroll-view/system.js
+++ b/src/framework/components/scroll-view/system.js
@@ -4,6 +4,8 @@ import { ComponentSystem } from '../system.js';
 import { ScrollViewComponent } from './component.js';
 import { ScrollViewComponentData } from './data.js';
 
+import { Vec2 } from '../../../math/vec2.js';
+
 const _schema = [
     { name: 'enabled', type: 'boolean' },
     { name: 'horizontal', type: 'boolean' },
@@ -23,6 +25,7 @@ const _schema = [
 ];
 
 const DEFAULT_DRAG_THRESHOLD = 10;
+const SCROLLBAR_MOUSE_WHEEL_SENSITIVITY = Vec2.ONE;
 
 /**
  * @class
@@ -51,6 +54,12 @@ class ScrollViewComponentSystem extends ComponentSystem {
     initializeComponentData(component, data, properties) {
         if (data.dragThreshold === undefined) {
             data.dragThreshold = DEFAULT_DRAG_THRESHOLD;
+        }
+        if (data.useMouseWheel === undefined) {
+            data.useMouseWheel = true;
+        }
+        if (data.mouseWheelSensitivity === undefined) {
+            data.mouseWheelSensitivity = SCROLLBAR_MOUSE_WHEEL_SENSITIVITY;
         }
 
         super.initializeComponentData(component, data, _schema);

--- a/src/framework/components/scroll-view/system.js
+++ b/src/framework/components/scroll-view/system.js
@@ -25,7 +25,6 @@ const _schema = [
 ];
 
 const DEFAULT_DRAG_THRESHOLD = 10;
-const DEFAULT_SCROLLBAR_MOUSE_WHEEL_SENSITIVITY = Object.freeze(Vec2.ONE.clone());
 
 /**
  * @class
@@ -59,7 +58,7 @@ class ScrollViewComponentSystem extends ComponentSystem {
             data.useMouseWheel = true;
         }
         if (data.mouseWheelSensitivity === undefined) {
-            data.mouseWheelSensitivity = DEFAULT_SCROLLBAR_MOUSE_WHEEL_SENSITIVITY;
+            data.mouseWheelSensitivity = new Vec2(1, 1);
         }
 
         super.initializeComponentData(component, data, _schema);

--- a/src/framework/components/scroll-view/system.js
+++ b/src/framework/components/scroll-view/system.js
@@ -25,7 +25,7 @@ const _schema = [
 ];
 
 const DEFAULT_DRAG_THRESHOLD = 10;
-const SCROLLBAR_MOUSE_WHEEL_SENSITIVITY = Vec2.ONE;
+const DEFAULT_SCROLLBAR_MOUSE_WHEEL_SENSITIVITY = Object.freeze(Vec2.ONE.clone());
 
 /**
  * @class
@@ -59,7 +59,7 @@ class ScrollViewComponentSystem extends ComponentSystem {
             data.useMouseWheel = true;
         }
         if (data.mouseWheelSensitivity === undefined) {
-            data.mouseWheelSensitivity = SCROLLBAR_MOUSE_WHEEL_SENSITIVITY;
+            data.mouseWheelSensitivity = DEFAULT_SCROLLBAR_MOUSE_WHEEL_SENSITIVITY;
         }
 
         super.initializeComponentData(component, data, _schema);

--- a/src/framework/components/scroll-view/system.js
+++ b/src/framework/components/scroll-view/system.js
@@ -12,6 +12,8 @@ const _schema = [
     { name: 'bounceAmount', type: 'number' },
     { name: 'friction', type: 'number' },
     { name: 'dragThreshold', type: 'number' },
+    { name: 'useMouseWheel', type: 'boolean' },
+    { name: 'mouseWheelSensitivity', type: 'vec2' },
     { name: 'horizontalScrollbarVisibility', type: 'number' },
     { name: 'verticalScrollbarVisibility', type: 'number' },
     { name: 'viewportEntity', type: 'entity' },


### PR DESCRIPTION
Fixes https://github.com/playcanvas/engine/issues/2581.

This PR adds a listener to the scroll view UI component for mouse wheel events (both X and Y directions), and updates the scroll value accordingly. Also adds additional properties to control whether this feature is enabled at all, and the sensitivity.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
