### PR TITLE
Trigger events on world UI elements in the correct order.

### DIFF
--- a/src/input/element-input.js
+++ b/src/input/element-input.js
@@ -1026,8 +1026,9 @@ class ElementInput {
     _checkElement(ray, element, screen) {
         // ensure click is contained by any mask first
         if (element.maskedBy) {
-            var result = this._checkElement(ray, element.maskedBy.element, screen);
-            if (result < 0) return -1;
+            if (this._checkElement(ray, element.maskedBy.element, screen) < 0) {
+                return -1;
+            }
         }
 
         var scale;

--- a/src/input/element-input.js
+++ b/src/input/element-input.js
@@ -848,7 +848,6 @@ class ElementInput {
         for (var i = 0, len = this._elements.length; i < len; i++) {
             var element = this._elements[i];
             var screen = false;
-            var ray;
 
             // cache rays
             if (element.screen && element.screen.screen.screenSpace) {
@@ -859,14 +858,15 @@ class ElementInput {
                         rayScreen = null;
                     }
                 }
-                ray = rayScreen;
                 screen = true;
 
-                // break on the first element that hit
-                const hit = this._checkElement(ray, element, screen) > 0;
-                if (ray && hit === true) {
-                    result = element;
-                    break;
+                if (rayScreen) {
+                    // break on the first element that hit
+                    const hit = this._checkElement(rayScreen, element, screen) >= 0;
+                    if (hit === true) {
+                        result = element;
+                        break;
+                    }
                 }
             } else {
                 // 3d
@@ -876,13 +876,14 @@ class ElementInput {
                         ray3d = null;
                     }
                 }
-                ray = ray3d;
 
-                // continue looking through all elements, only storing the closest one
-                const currentDistance = this._checkElement(ray, element, screen);
-                if (ray && currentDistance > 0 && currentDistance < closestDistance3d) {
-                    result = element;
-                    closestDistance3d = currentDistance;
+                if (ray3d) {
+                    // continue looking through all elements, only storing the closest one
+                    const currentDistance = this._checkElement(ray3d, element, screen);
+                    if (currentDistance >= 0 && currentDistance < closestDistance3d) {
+                        result = element;
+                        closestDistance3d = currentDistance;
+                    }
                 }
             }
         }
@@ -904,7 +905,7 @@ class ElementInput {
             var element = this._elements[i];
 
             if (! element.screen || ! element.screen.screen.screenSpace) {
-                if (this._checkElement(rayA, element, false) > 0) {
+                if (this._checkElement(rayA, element, false) >= 0) {
                     result = element;
                     break;
                 }

--- a/src/input/element-input.js
+++ b/src/input/element-input.js
@@ -50,7 +50,7 @@ function scalarTriple(p1, p2, p3) {
     return _sct.cross(p1, p2).dot(p3);
 }
 
-// Given line pq and ccw corners of a quad, return the distance to the intersection point.
+// Given line pq and ccw corners of a quad, return the square distance to the intersection point.
 // If the line and quad do not intersect, return -1. (from Real-Time Collision Detection book)
 function intersectLineQuad(p, q, corners) {
     _pq.sub2(q, p);
@@ -838,7 +838,7 @@ class ElementInput {
 
     _getTargetElement(camera, x, y) {
         var result = null;
-        var closestDistance = Infinity;
+        let closestDistance3d = Infinity;
 
         // sort elements
         this._elements.sort(this._sortHandler);
@@ -861,6 +861,13 @@ class ElementInput {
                 }
                 ray = rayScreen;
                 screen = true;
+
+                // break on the first element that hit
+                const hit = this._checkElement(ray, element, screen) > 0;
+                if (ray && hit === true) {
+                    result = element;
+                    break;
+                }
             } else {
                 // 3d
                 if (ray3d === undefined) {
@@ -870,12 +877,13 @@ class ElementInput {
                     }
                 }
                 ray = ray3d;
-            }
 
-            var d = this._checkElement(ray, element, screen);
-            if (ray && d > 0 && d < closestDistance) {
-                result = element;
-                closestDistance = d;
+                // continue looking through all elements, only storing the closest one
+                const currentDistance = this._checkElement(ray, element, screen);
+                if (ray && currentDistance > 0 && currentDistance < closestDistance3d) {
+                    result = element;
+                    closestDistance3d = currentDistance;
+                }
             }
         }
 

--- a/src/input/element-input.js
+++ b/src/input/element-input.js
@@ -1034,7 +1034,7 @@ class ElementInput {
         // ensure click is contained by any mask first
         if (element.maskedBy) {
             var result = this._checkElement(ray, element.maskedBy.element, screen);
-            if (!result) return -1;
+            if (result < 0) return -1;
         }
 
         var scale;

--- a/src/input/element-input.js
+++ b/src/input/element-input.js
@@ -28,12 +28,11 @@ var _pb = new Vec3();
 var _pc = new Vec3();
 var _pd = new Vec3();
 var _m = new Vec3();
+var _au = new Vec3();
+var _bv = new Vec3();
+var _cw = new Vec3();
+var _ir = new Vec3();
 var _sct = new Vec3();
-var _sdpr1 = new Vec3();
-var _sdpr2 = new Vec3();
-var _sdprQ = new Vec3();
-var _sdprD = new Vec3();
-var _sdprTemp = new Vec3();
 var _accumulatedScale = new Vec2();
 var _paddingTop = new Vec3();
 var _paddingBottom = new Vec3();
@@ -51,42 +50,8 @@ function scalarTriple(p1, p2, p3) {
     return _sct.cross(p1, p2).dot(p3);
 }
 
-// calculates the distance from a point to a 3D rectangle defined by its corners
-// corners is assumed to be an array [BottomLeft, BottomRight, TopRight, TopLeft]
-// algorithm from from Real-Time Collision Detection book
-function calculateSqrDistancePointTo3dRect(p, corners) {
-    _sdpr1.sub2(corners[2], corners[3]); // vector across rect
-    _sdpr2.sub2(corners[0], corners[3]); // vector down rect
-    _sdprD.sub2(p, corners[0]);
-
-    // Start result at top-left corner of rect; make steps from there
-    _sdprQ.set(corners[3].x, corners[3].y, corners[3].z);
-
-    // Clamp p’ (projection of p to plane of r) to rectangle in the across direction
-    var dist = _sdprD.dot(_sdpr1);
-    var maxDist = _sdpr1.dot(_sdpr1);
-    if (dist >= maxDist) {
-        _sdprQ.add(_sdpr1);
-    } else if (dist > 0.0) {
-        _sdprTemp.copy(_sdpr1).mulScalar(dist / maxDist);
-        _sdprQ.add(_sdprTemp);
-    }
-
-    // Clamp p’ (projection of p to plane of r) to rectangle in the down direction
-    dist = _sdprD.dot(_sdpr2);
-    maxDist = _sdpr2.dot(_sdpr2);
-    if (dist >= maxDist) {
-        _sdprQ.add(_sdpr2);
-    } else if (dist > 0.0) {
-        _sdprTemp.copy(_sdpr2).mulScalar(dist / maxDist);
-        _sdprQ.add(_sdprTemp);
-    }
-
-    return _sdprQ.sub(p).lengthSq();
-}
-
-// Given line pq and ccw corners of a quad, return whether the line
-// intersects it. (from Real-Time Collision Detection book)
+// Given line pq and ccw corners of a quad, return the distance to the intersection point.
+// If the line and quad do not intersect, return -1. (from Real-Time Collision Detection book)
 function intersectLineQuad(p, q, corners) {
     _pq.sub2(q, p);
     _pa.sub2(corners[0], p);
@@ -95,30 +60,53 @@ function intersectLineQuad(p, q, corners) {
 
     // Determine which triangle to test against by testing against diagonal first
     _m.cross(_pc, _pq);
-    var v = _pa.dot(_m);
+    let v = _pa.dot(_m);
+    let u;
+    let w;
+
     if (v >= 0) {
         // Test intersection against triangle abc
-        if (-_pb.dot(_m) < 0)
-            return false;
+        u = -_pb.dot(_m);
+        if (u < 0)
+            return -1;
 
-        if (scalarTriple(_pq, _pb, _pa) < 0)
-            return false;
+        w = scalarTriple(_pq, _pb, _pa);
+        if (w < 0)
+            return -1;
+
+        const denom = 1.0 / (u + v + w);
+
+        _au.copy(corners[0]).mulScalar(u * denom);
+        _bv.copy(corners[1]).mulScalar(v * denom);
+        _cw.copy(corners[2]).mulScalar(w * denom);
+        _ir.copy(_au).add(_bv).add(_cw);
     } else {
         // Test intersection against triangle dac
         _pd.sub2(corners[3], p);
-        if (_pd.dot(_m) < 0)
-            return false;
+        u = _pd.dot(_m);
+        if (u < 0)
+            return -1;
 
-        if (scalarTriple(_pq, _pa, _pd) < 0)
-            return false;
+        w = scalarTriple(_pq, _pa, _pd);
+        if (w < 0)
+            return -1;
+
+        v = -v;
+
+        const denom = 1.0 / (u + v + w);
+
+        _au.copy(corners[0]).mulScalar(u * denom);
+        _bv.copy(corners[3]).mulScalar(v * denom);
+        _cw.copy(corners[2]).mulScalar(w * denom);
+        _ir.copy(_au).add(_bv).add(_cw);
     }
 
     // The algorithm above doesn't work if all the corners are the same
     // So do that test here by checking if the diagonals are 0 (since these are rectangles we're checking against)
-    if (_pq.sub2(corners[0], corners[2]).lengthSq() < 0.0001 * 0.0001) return false;
-    if (_pq.sub2(corners[1], corners[3]).lengthSq() < 0.0001 * 0.0001) return false;
+    if (_pq.sub2(corners[0], corners[2]).lengthSq() < 0.0001 * 0.0001) return -1;
+    if (_pq.sub2(corners[1], corners[3]).lengthSq() < 0.0001 * 0.0001) return -1;
 
-    return true;
+    return _ir.sub(p).lengthSq();
 }
 
 /**
@@ -884,7 +872,7 @@ class ElementInput {
                 ray = ray3d;
             }
 
-            var d = this._checkElementSqrDistanceToBounds(ray, element, screen);
+            var d = this._checkElement(ray, element, screen);
             if (ray && d > 0 && d < closestDistance) {
                 result = element;
                 closestDistance = d;
@@ -908,7 +896,7 @@ class ElementInput {
             var element = this._elements[i];
 
             if (! element.screen || ! element.screen.screen.screenSpace) {
-                if (this._checkElement(rayA, element, false)) {
+                if (this._checkElement(rayA, element, false) > 0) {
                     result = element;
                     break;
                 }
@@ -1034,33 +1022,11 @@ class ElementInput {
         return false;
     }
 
-    _checkElementSqrDistanceToBounds(ray, element, screen) {
-        // ensure click is contained by any mask first
-        if (element.maskedBy) {
-            return this._checkElementSqrDistanceToBounds(ray, element.maskedBy.element, screen);
-        }
-
-        let scale;
-
-        if (screen) {
-            scale = this._calculateScaleToScreen(element);
-        } else {
-            scale = element.entity.getWorldTransform().getScale();
-        }
-
-        const corners = this._buildHitCorners(element, screen ? element.screenCorners : element.worldCorners, scale.x, scale.y);
-
-        if (intersectLineQuad(ray.origin, ray.end, corners))
-            return calculateSqrDistancePointTo3dRect(ray.origin, corners);
-
-        return -1;
-    }
-
     _checkElement(ray, element, screen) {
         // ensure click is contained by any mask first
         if (element.maskedBy) {
             var result = this._checkElement(ray, element.maskedBy.element, screen);
-            if (!result) return false;
+            if (!result) return -1;
         }
 
         var scale;
@@ -1073,10 +1039,7 @@ class ElementInput {
 
         var corners = this._buildHitCorners(element, screen ? element.screenCorners : element.worldCorners, scale.x, scale.y);
 
-        if (intersectLineQuad(ray.origin, ray.end, corners))
-            return true;
-
-        return false;
+        return intersectLineQuad(ray.origin, ray.end, corners);
     }
 
     get enabled() {

--- a/src/input/element-input.js
+++ b/src/input/element-input.js
@@ -55,12 +55,12 @@ function scalarTriple(p1, p2, p3) {
 // corners is assumed to be an array [BottomLeft, BottomRight, TopRight, TopLeft]
 // algorithm from from Real-Time Collision Detection book
 function calculateSqrDistancePointTo3dRect(p, corners) {
-    _sdpr1.sub2(corners[1], corners[0]); // vector across rect
-    _sdpr2.sub2(corners[3], corners[0]); // vector down rect
+    _sdpr1.sub2(corners[2], corners[3]); // vector across rect
+    _sdpr2.sub2(corners[0], corners[3]); // vector down rect
     _sdprD.sub2(p, corners[0]);
 
     // Start result at top-left corner of rect; make steps from there
-    _sdprQ.set(corners[0].x, corners[0].y, corners[0].z);
+    _sdprQ.set(corners[3].x, corners[3].y, corners[3].z);
 
     // Clamp p’ (projection of p to plane of r) to rectangle in the across direction
     var dist = _sdprD.dot(_sdpr1);
@@ -1040,7 +1040,7 @@ class ElementInput {
             return this._checkElementSqrDistanceToBounds(ray, element.maskedBy.element, screen);
         }
 
-        var scale;
+        let scale;
 
         if (screen) {
             scale = this._calculateScaleToScreen(element);
@@ -1048,7 +1048,7 @@ class ElementInput {
             scale = element.entity.getWorldTransform().getScale();
         }
 
-        var corners = this._buildHitCorners(element, screen ? element.screenCorners : element.worldCorners, scale.x, scale.y);
+        const corners = this._buildHitCorners(element, screen ? element.screenCorners : element.worldCorners, scale.x, scale.y);
 
         if (intersectLineQuad(ray.origin, ray.end, corners))
             return calculateSqrDistancePointTo3dRect(ray.origin, corners);

--- a/src/input/element-input.js
+++ b/src/input/element-input.js
@@ -847,22 +847,17 @@ class ElementInput {
 
         for (var i = 0, len = this._elements.length; i < len; i++) {
             var element = this._elements[i];
-            var screen = false;
 
             // cache rays
             if (element.screen && element.screen.screen.screenSpace) {
                 // 2D screen
                 if (rayScreen === undefined) {
-                    rayScreen = rayA;
-                    if (this._calculateRayScreen(x, y, camera, rayScreen) === false) {
-                        rayScreen = null;
-                    }
+                    rayScreen = this._calculateRayScreen(x, y, camera, rayA) ? rayA : null;
                 }
-                screen = true;
 
                 if (rayScreen) {
                     // break on the first element that hit
-                    const hit = this._checkElement(rayScreen, element, screen) >= 0;
+                    const hit = this._checkElement(rayScreen, element, true) >= 0;
                     if (hit === true) {
                         result = element;
                         break;
@@ -871,15 +866,12 @@ class ElementInput {
             } else {
                 // 3d
                 if (ray3d === undefined) {
-                    ray3d = rayB;
-                    if (this._calculateRay3d(x, y, camera, ray3d) === false) {
-                        ray3d = null;
-                    }
+                    ray3d = this._calculateRay3d(x, y, camera, rayB) ? rayB : null;
                 }
 
                 if (ray3d) {
                     // continue looking through all elements, only storing the closest one
-                    const currentDistance = this._checkElement(ray3d, element, screen);
+                    const currentDistance = this._checkElement(ray3d, element, false);
                     if (currentDistance >= 0 && currentDistance < closestDistance3d) {
                         result = element;
                         closestDistance3d = currentDistance;


### PR DESCRIPTION
Fixes https://github.com/playcanvas/engine/issues/3427

This PR extends the algorithm `intersectLineQuad` as per the Real-Time Collision Detection book by Christer Ericson (`5.3.5 Intersecting Line Against Quadrilateral`, page 189) to instead of just returning if the line intersected with a quad, return the square distance to the intersection point or -1 if there's no intersection. The algorithm uses square distance (rather than distance) because the 'exact' distance doesn't really matter: the value is only used to 'sort' the elements. This saves computation by avoiding an extra `sqrt`.

Then, for 3D elements, instead of immediately returning the first element that intersected with the ray, return the one that was closest to the ray's origin. For 2D elements, the logic is unchanged: return the first one (after layer and hierarchy sorting) that hit.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
