### PR TITLE
Issue error when attempting to load a KTX2 file without transcoder support

### DIFF
--- a/src/resources/basis-worker.js
+++ b/src/resources/basis-worker.js
@@ -158,6 +158,10 @@ function BasisWorker() {
     };
 
     const transcodeKTX2 = (url, data, options) => {
+        if (!basis.KTX2File) {
+            throw new Error('Basis transcoder module does not include support for KTX2.');
+        }
+
         const funcStart = performanceNow();
         const basisFile = new basis.KTX2File(new Uint8Array(data));
 


### PR DESCRIPTION
Basis transcoders may not include support for KTX2. Either because it is an old version of the module or because it was compiled without KTX2 support.

Fixes #3490