### PR TITLE
Properly resume AudioContext on iOS platform.

### DIFF
--- a/src/sound/manager.js
+++ b/src/sound/manager.js
@@ -81,8 +81,15 @@ class SoundManager extends EventHandler {
     }
 
     resume() {
-        this.suspended = false;
-        this.fire('resume');
+        const resumeFunction = function () {
+            this.suspended = false;
+            this.fire('resume');
+        }.bind(this);
+
+        if (platform.ios && (hasAudioContext() || this._forceWebAudioApi))
+            this.context.resume().then(resumeFunction);
+        else
+            resumeFunction();
     }
 
     destroy() {

--- a/src/sound/manager.js
+++ b/src/sound/manager.js
@@ -81,14 +81,18 @@ class SoundManager extends EventHandler {
     }
 
     resume() {
-        const resumeFunction = function () {
+        const resumeFunction = () => {
             this.suspended = false;
             this.fire('resume');
-        }.bind(this);
+        };
 
-        if (platform.ios && (hasAudioContext() || this._forceWebAudioApi))
+        // On iOS safari, switching tab or minimizing the browser will set the AudioContext state as 'interrupted'.
+        // On other browsers, AudioContext state will be set to 'suspended'.
+        // In those situations, the .resume() API must be called explicitly
+        if ((hasAudioContext() || this._forceWebAudioApi) &&
+            (this.context.state === 'interrupted' || this.context.state === 'suspended')) {
             this.context.resume().then(resumeFunction);
-        else
+        } else
             resumeFunction();
     }
 


### PR DESCRIPTION
Fixes https://github.com/playcanvas/engine/issues/3212

This PR makes sure that the `AudioContext` is properly resumed on the iOS platform when context is switched by using the [AudioContext#resume API](https://developer.mozilla.org/en-US/docs/Web/API/AudioContext/resume). It returns a future, so the callback is only triggered once `AudioContext` is actually resumed. For other platforms, or if `AudioContext` is not being used, the logic is unchanged.

According to https://developer.mozilla.org/en-US/docs/Web/API/BaseAudioContext/state , iOS Safari sets the state to `interrupted`.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
