### PR TITLE
Fix recent crash for Safari 15 on MacOS

### DIFF
--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -435,7 +435,9 @@ class Application extends EventHandler {
         if (! options.graphicsDeviceOptions)
             options.graphicsDeviceOptions = { };
 
-        options.graphicsDeviceOptions.xrCompatible = true;
+        if (platform.browser && !!navigator.xr) {
+            options.graphicsDeviceOptions.xrCompatible = true;
+        }
 
         options.graphicsDeviceOptions.alpha = options.graphicsDeviceOptions.alpha || false;
 


### PR DESCRIPTION
The recent update of Safari 15 brought the crash for MacOS.
This, unfortunately, affects all published projects out there.

Fixes: https://github.com/playcanvas/engine/issues/3500

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
