### PR TITLE
Remove a no longer needed temporary function

### DIFF
--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -2009,9 +2009,6 @@ class ForwardRenderer {
             // #endif
         }
     }
-
-    prepareStaticMeshes(meshInstances, lights) {
-    }
 }
 
 export { ForwardRenderer };


### PR DESCRIPTION
reverses PR https://github.com/playcanvas/engine/pull/3504 which was required temporarily before the Editor is released with a fix.

This should be merged after next Editor release.