### PR TITLE
Removed PlayCanvas version logging

### DIFF
--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -1,4 +1,3 @@
-import { version, revision } from '../core/core.js';
 import { platform } from '../core/platform.js';
 import { now } from '../core/time.js';
 import { path } from '../core/path.js';

--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -400,8 +400,6 @@ class Application extends EventHandler {
     constructor(canvas, options = {}) {
         super();
 
-        console.log("Powered by PlayCanvas " + version + " " + revision);
-
         // Store application instance
         Application._applications[canvas.id] = this;
         setApplication(this);


### PR DESCRIPTION
The version and revision are already exported as pc.version and pc.revision in core.js

We have decided to remove the logging completely rather than have an option. If users/developers want to add it to the console, they will have to do so explicitly in the app as:

```
console.log("Powered by PlayCanvas " + pc.version + " " + pc.revision);
```

Fixes #3456

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
