### PR TITLE
[Fix] Fixes an issue with cloning a model component with customAabb

### DIFF
--- a/examples/src/examples/graphics/model-asset.tsx
+++ b/examples/src/examples/graphics/model-asset.tsx
@@ -34,6 +34,12 @@ class ModelAssetExample extends Example {
 
         app.root.addChild(entity);
 
+        // clone a small version of the entity
+        const clone = entity.clone();
+        clone.setLocalScale(0.2, 0.2, 0.2);
+        clone.setLocalPosition(-4, 12, 0);
+        app.root.addChild(clone);
+
         // Create an Entity with a camera component
         const camera = new pc.Entity();
         camera.addComponent("camera", {

--- a/src/framework/components/model/system.js
+++ b/src/framework/components/model/system.js
@@ -135,7 +135,7 @@ class ModelComponentSystem extends ComponentSystem {
         }
 
         if (entity.model.customAabb) {
-            component.customAabb = entity.model.aabb.clone();
+            component.customAabb = entity.model.customAabb.clone();
         }
     }
 


### PR DESCRIPTION
- it was using incorrect property name after a rename was done.
- added clone test to model to potentially catch some errors (render component examples does cloning as well)