### PR TITLE
Better shader compilation error reporting

### DIFF
--- a/src/graphics/graphics-device.js
+++ b/src/graphics/graphics-device.js
@@ -3406,13 +3406,13 @@ class GraphicsDevice extends EventHandler {
         // Check for errors
         if (!gl.getShaderParameter(glVertexShader, gl.COMPILE_STATUS)) {
             const infoLog = gl.getShaderInfoLog(glVertexShader);
-            const errorCode = this._addLineNumbers(definition.vshader, infoLog));
+            const errorCode = this._addLineNumbers(definition.vshader, infoLog);
             console.error(`Failed to compile vertex shader:\n\n${infoLog}\n${errorCode}`);
             return false;
         }
         if (!gl.getShaderParameter(glFragmentShader, gl.COMPILE_STATUS)) {
             const infoLog = gl.getShaderInfoLog(glFragmentShader);
-            const errorCode = this._addLineNumbers(definition.fshader, infoLog));
+            const errorCode = this._addLineNumbers(definition.fshader, infoLog);
             console.error(`Failed to compile fragment shader:\n\n${infoLog}\n${errorCode}`);
             return false;
         }

--- a/src/graphics/graphics-device.js
+++ b/src/graphics/graphics-device.js
@@ -3412,7 +3412,8 @@ class GraphicsDevice extends EventHandler {
         }
         if (!gl.getShaderParameter(glFragmentShader, gl.COMPILE_STATUS)) {
             const infoLog = gl.getShaderInfoLog(glFragmentShader);
-            console.error("Failed to compile fragment shader:\n\n" + infoLog + "\n" + this._addLineNumbers(definition.fshader, infoLog));
+            const errorCode = this._addLineNumbers(definition.fshader, infoLog));
+            console.error(`Failed to compile fragment shader:\n\n${infoLog}\n${errorCode}`);
             return false;
         }
         if (!gl.getProgramParameter(glProgram, gl.LINK_STATUS)) {

--- a/src/graphics/graphics-device.js
+++ b/src/graphics/graphics-device.js
@@ -3406,7 +3406,8 @@ class GraphicsDevice extends EventHandler {
         // Check for errors
         if (!gl.getShaderParameter(glVertexShader, gl.COMPILE_STATUS)) {
             const infoLog = gl.getShaderInfoLog(glVertexShader);
-            console.error("Failed to compile vertex shader:\n\n" + infoLog + "\n" + this._addLineNumbers(definition.vshader, infoLog));
+            const errorCode = this._addLineNumbers(definition.vshader, infoLog));
+            console.error(`Failed to compile vertex shader:\n\n${infoLog}\n${errorCode}`);
             return false;
         }
         if (!gl.getShaderParameter(glFragmentShader, gl.COMPILE_STATUS)) {


### PR DESCRIPTION
Instead of printing the whole shader and error at the end, now it prints error first, and then 6 lines before, error line, and 6 lines of code after, that way it does not take the whole console with huge shader logs.

Fixes #3280 

Screenshot:
![image](https://user-images.githubusercontent.com/636263/134928638-d3d66c8a-8921-4179-ac27-7f853aa64bfb.png)

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
