### PR TITLE
Always reset internal asset and model references on ModelComponent onRemove

### DIFF
--- a/src/framework/components/model/component.js
+++ b/src/framework/components/model/component.js
@@ -130,11 +130,8 @@ class ModelComponent extends Component {
     }
 
     onRemove() {
-        if (this.type === 'asset') {
-            this.asset = null;
-        } else {
-            this.model = null;
-        }
+        this.asset = null;
+        this.model = null;
         this.materialAsset = null;
         this._unsetMaterialEvents();
 


### PR DESCRIPTION
Fixes https://github.com/playcanvas/editor/issues/159 and https://github.com/playcanvas/editor/issues/365.

This PR fixes issues on `model` instances not being correctly "freed" when a `ModelComponent` is deleted by always calling `model` and `asset` setters to `null` when removed. Although in most cases `modelComponent.model` would never be set when `modelComponent.type` is `asset`, this is not a guarantee: for example, the two issues linked above happen because the "preview" model is created in code, but are not properly freed because the `type` is left at `asset` (default). There are actually multiple ways of fixing those particular bugs, but this fixes the most underlying issue.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
