### PR TITLE
Omni shadows for clustered lights

### DIFF
--- a/examples/src/examples/graphics/clustered-omni-shadows.tsx
+++ b/examples/src/examples/graphics/clustered-omni-shadows.tsx
@@ -1,0 +1,141 @@
+import React from 'react';
+import * as pc from 'playcanvas/build/playcanvas.js';
+import { AssetLoader } from '../../app/helpers/loader';
+import Example from '../../app/example';
+
+class ClusteredShadowsOmniExample extends Example {
+    static CATEGORY = 'Graphics';
+    static NAME = 'Clustered Omni Shadows';
+
+    load() {
+        return <>
+            <AssetLoader name='script' type='script' url='static/scripts/camera/orbit-camera.js' />
+        </>;
+    }
+
+    // @ts-ignore: override class function
+    example(canvas: HTMLCanvasElement): void {
+
+        // Create the application and start the update loop
+        const app = new pc.Application(canvas, {});
+        app.start();
+
+        // Set the canvas to fill the window and automatically change resolution to be the same as the canvas size
+        app.setCanvasFillMode(pc.FILLMODE_FILL_WINDOW);
+        app.setCanvasResolution(pc.RESOLUTION_AUTO);
+
+        // enabled clustered lighting. This is a temporary API and will change in the future
+        // @ts-ignore engine-tsd
+        pc.LayerComposition.clusteredLightingEnabled = true;
+
+        // adjust default clusterered lighting parameters to handle many lights:
+        // 1) subdivide space with lights into this many cells:
+        // @ts-ignore engine-tsd
+        app.scene.layers.clusteredLightingCells = new pc.Vec3(16, 12, 16);
+
+        // 2) and allow this many lights per cell:
+        // @ts-ignore engine-tsd
+        app.scene.layers.clusteredLightingMaxLights = 80;
+
+
+
+
+        // helper function to create a 3d primitive including its material
+        function createPrimitive(primitiveType: string, position: pc.Vec3, scale: pc.Vec3) {
+
+            // create a material
+            const material = new pc.StandardMaterial();
+            material.diffuse = new pc.Color(0.7, 0.7, 0.7);
+            material.update();
+
+            // create the primitive using the material
+            const primitive = new pc.Entity();
+            primitive.addComponent('render', {
+                type: primitiveType,
+                material: material
+            });
+
+            // set position and scale and add it to scene
+            primitive.setLocalPosition(position);
+            primitive.setLocalScale(scale);
+            app.root.addChild(primitive);
+
+            return primitive;
+        }
+
+        // create the ground plane from the boxes
+        createPrimitive("box", new pc.Vec3(0, -5, 0), new pc.Vec3(800, 2, 800));
+
+        // create the towers from the boxes
+        let scale = 16;
+        for (let y = 0; y <= 7; y++) {
+            for (let x = -1; x <= 1; x += 2) {
+                for (let z = -5; z <= 5; z += 2) {
+                    const prim = createPrimitive("box", new pc.Vec3(x * 70, 2 + y * 10, z * 40), new pc.Vec3(scale, scale, scale));
+                    prim.setLocalEulerAngles(Math.random() * 360, Math.random() * 360, Math.random() * 360);
+                }
+            }
+            scale -= 1.5;
+        }
+
+
+
+        const lightOmni = new pc.Entity("Omni");
+        lightOmni.addComponent("light", {
+            type: "omni",
+            color: pc.Color.WHITE,
+            range: 600,
+            castShadows: true,
+            shadowBias: 0.4,
+            normalOffsetBias: 0.1
+        });
+
+        // attach a render component with a small sphere to it
+        const material = new pc.StandardMaterial();
+        material.emissive = pc.Color.WHITE;
+        material.update();
+
+        lightOmni.addComponent('render', {
+            type: "sphere",
+            material: material,
+            castShadows: false
+        });
+        lightOmni.setPosition(0, 120, 0);
+        lightOmni.setLocalScale(5, 5, 5);
+        app.root.addChild(lightOmni);
+
+
+
+        // create an Entity with a camera component
+        const camera = new pc.Entity();
+        camera.addComponent("camera", {
+            clearColor: new pc.Color(0.9, 0.9, 0.9),
+            farClip: 1500
+        });
+
+        // and position it in the world
+        camera.setLocalPosition(300, 60, 25);
+
+        // add orbit camera script with a mouse and a touch support
+        camera.addComponent("script");
+        camera.script.create("orbitCamera", {
+            attributes: {
+                inertiaFactor: 0.2,
+                focusEntity: app.root,
+                distanceMax: 600
+            }
+        });
+        camera.script.create("orbitCameraInputMouse");
+        camera.script.create("orbitCameraInputTouch");
+        app.root.addChild(camera);
+
+        // Set an update function on the app's update event
+        app.on("update", function (dt: number) {
+
+            // display shadow texture (debug feature, only works when depth is stored as color, which is webgl1)
+            app.renderTexture(-0.7, 0.7, 0.4, 0.4, app.renderer.lightTextureAtlas.shadowMap.texture);
+        });
+    }
+}
+
+export default ClusteredShadowsOmniExample;

--- a/src/graphics/program-lib/chunks/cookie.frag
+++ b/src/graphics/program-lib/chunks/cookie.frag
@@ -37,5 +37,5 @@ vec3 getCookie2DClustered(sampler2D tex, mat4 transform, float intensity, bool i
     vec4 projPos = transform * vec4(vPositionW, 1.0);
     projPos.xy /= projPos.w;
     vec4 pixel = mix(vec4(1.0), texture2D(tex, projPos.xy), intensity);
-    return isRgb ? pixel.rgb : vec3(dot(pixel, cookieChannel));
+    return isRgb == true ? pixel.rgb : vec3(dot(pixel, cookieChannel));
 }

--- a/src/graphics/program-lib/chunks/shadowStandard.frag
+++ b/src/graphics/program-lib/chunks/shadowStandard.frag
@@ -113,7 +113,7 @@ float getShadowSpotPCF3x3(sampler2D shadowMap, vec4 shadowParams) {
 #endif
 
 
-// ----- Point Sampling -----
+// ----- Omni Sampling -----
 
 float _getShadowPoint(samplerCube shadowMap, vec4 shadowParams, vec3 dir) {
 

--- a/src/graphics/program-lib/chunks/shadowStandard.frag
+++ b/src/graphics/program-lib/chunks/shadowStandard.frag
@@ -183,7 +183,7 @@ float getShadowPointPCF3x3(samplerCube shadowMap, vec4 shadowParams) {
 
 // ----- Clustered Omni Sampling using atlas -----
 
-// Converts unnormaized direction vector to a cubemap face index [0..5] and uv coordinates within the face in [0..1] range.
+// Converts unnormalized direction vector to a cubemap face index [0..5] and uv coordinates within the face in [0..1] range.
 // Additionally offset to a tile in atlas within 3x3 subdivision is provided
 vec2 getCubemapFaceCoordinates(const vec3 dir, out float faceIndex, out vec2 tileOffset)
 {

--- a/src/graphics/program-lib/chunks/shadowStandard.frag
+++ b/src/graphics/program-lib/chunks/shadowStandard.frag
@@ -187,38 +187,38 @@ float getShadowPointPCF3x3(samplerCube shadowMap, vec4 shadowParams) {
 // Additionally offset to a tile in atlas within 3x3 subdivision is provided
 vec2 getCubemapFaceCoordinates(const vec3 dir, out float faceIndex, out vec2 tileOffset)
 {
-	vec3 vAbs = abs(dir);
-	float ma;
-	vec2 uv;
-	if (vAbs.z >= vAbs.x && vAbs.z >= vAbs.y) {   // front / back
+    vec3 vAbs = abs(dir);
+    float ma;
+    vec2 uv;
+    if (vAbs.z >= vAbs.x && vAbs.z >= vAbs.y) {   // front / back
 
-		faceIndex = dir.z < 0.0 ? 5.0 : 4.0;
-		ma = 0.5 / vAbs.z;
-		uv = vec2(dir.z < 0.0 ? -dir.x : dir.x, -dir.y);
+        faceIndex = dir.z < 0.0 ? 5.0 : 4.0;
+        ma = 0.5 / vAbs.z;
+        uv = vec2(dir.z < 0.0 ? -dir.x : dir.x, -dir.y);
 
         tileOffset.x = 2.0;
         tileOffset.y = dir.z < 0.0 ? 1.0 : 0.0;
 
-	} else if(vAbs.y >= vAbs.x) {  // top index 2, bottom index 3
+    } else if(vAbs.y >= vAbs.x) {  // top index 2, bottom index 3
 
-		faceIndex = dir.y < 0.0 ? 3.0 : 2.0;
-		ma = 0.5 / vAbs.y;
-		uv = vec2(dir.x, dir.y < 0.0 ? -dir.z : dir.z);
+        faceIndex = dir.y < 0.0 ? 3.0 : 2.0;
+        ma = 0.5 / vAbs.y;
+        uv = vec2(dir.x, dir.y < 0.0 ? -dir.z : dir.z);
 
         tileOffset.x = 1.0;
         tileOffset.y = dir.y < 0.0 ? 1.0 : 0.0;
 
-	} else {    // left / right
+    } else {    // left / right
 
-		faceIndex = dir.x < 0.0 ? 1.0 : 0.0;
-		ma = 0.5 / vAbs.x;
-		uv = vec2(dir.x < 0.0 ? dir.z : -dir.z, -dir.y);
+        faceIndex = dir.x < 0.0 ? 1.0 : 0.0;
+        ma = 0.5 / vAbs.x;
+        uv = vec2(dir.x < 0.0 ? dir.z : -dir.z, -dir.y);
 
         tileOffset.x = 0.0;
         tileOffset.y = dir.x < 0.0 ? 1.0 : 0.0;
 
-	}
-	return uv * ma + 0.5;
+    }
+    return uv * ma + 0.5;
 }
 
 // converts unnormalized direction vector to a texture coordinate for a cubemap face stored within texture atlas described by the viewport

--- a/src/graphics/program-lib/chunks/shadowStandard.frag
+++ b/src/graphics/program-lib/chunks/shadowStandard.frag
@@ -180,3 +180,116 @@ float _getShadowPoint(samplerCube shadowMap, vec4 shadowParams, vec3 dir) {
 float getShadowPointPCF3x3(samplerCube shadowMap, vec4 shadowParams) {
     return _getShadowPoint(shadowMap, shadowParams, dLightDirW);
 }
+
+// ----- Clustered Omni Sampling using atlas -----
+
+// Converts unnormaized direction vector to a cubemap face index [0..5] and uv coordinates within the face in [0..1] range.
+// Additionally offset to a tile in atlas within 3x3 subdivision is provided
+vec2 getCubemapFaceCoordinates(const vec3 dir, out float faceIndex, out vec2 tileOffset)
+{
+	vec3 vAbs = abs(dir);
+	float ma;
+	vec2 uv;
+	if (vAbs.z >= vAbs.x && vAbs.z >= vAbs.y) {   // front / back
+
+		faceIndex = dir.z < 0.0 ? 5.0 : 4.0;
+		ma = 0.5 / vAbs.z;
+		uv = vec2(dir.z < 0.0 ? -dir.x : dir.x, -dir.y);
+
+        tileOffset.x = 2.0;
+        tileOffset.y = dir.z < 0.0 ? 1.0 : 0.0;
+
+	} else if(vAbs.y >= vAbs.x) {  // top index 2, bottom index 3
+
+		faceIndex = dir.y < 0.0 ? 3.0 : 2.0;
+		ma = 0.5 / vAbs.y;
+		uv = vec2(dir.x, dir.y < 0.0 ? -dir.z : dir.z);
+
+        tileOffset.x = 1.0;
+        tileOffset.y = dir.y < 0.0 ? 1.0 : 0.0;
+
+	} else {    // left / right
+
+		faceIndex = dir.x < 0.0 ? 1.0 : 0.0;
+		ma = 0.5 / vAbs.x;
+		uv = vec2(dir.x < 0.0 ? dir.z : -dir.z, -dir.y);
+
+        tileOffset.x = 0.0;
+        tileOffset.y = dir.x < 0.0 ? 1.0 : 0.0;
+
+	}
+	return uv * ma + 0.5;
+}
+
+// converts unnormaized direction vector to a texture coordinate for a cubemap face stored within texture atlas described by the viewport
+vec2 getCubemapAtlasCoordinates(const vec3 omniAtlasViewport, float shadowEdgePixels, float shadowTextureResolution, const vec3 dir) {
+
+    float faceIndex;
+    vec2 tileOffset;
+    vec2 uv = getCubemapFaceCoordinates(dir, faceIndex, tileOffset);
+
+    // move uv coordinates inwards inside to compensate for larger fov when rendering shadow into atlas
+    float atlasFaceSize = omniAtlasViewport.z;
+    float tileSize = shadowTextureResolution * atlasFaceSize;
+    float offset = shadowEdgePixels / tileSize;
+    uv = uv * vec2(1.0 - offset * 2.0) + vec2(offset * 1.0);
+
+    // scale uv coordinates to cube face area within the viewport
+    uv *= atlasFaceSize;
+
+    // offset into face of the atlas (3x3 grid)
+    uv += tileOffset * atlasFaceSize;
+
+    // offset into the atlas viewport
+    uv += omniAtlasViewport.xy;
+
+    return uv;
+}
+
+#ifdef GL2
+
+float getShadowOmniClusteredSingleSample(sampler2DShadow shadowMap, vec4 shadowParams, vec3 omniAtlasViewport, float shadowEdgePixels, vec3 dir) {
+
+    float shadowTextureResolution = shadowParams.x;
+    vec2 uv = getCubemapAtlasCoordinates(omniAtlasViewport, shadowEdgePixels, shadowTextureResolution, dir);
+
+    float shadowZ = length(dir) * shadowParams.w + shadowParams.z;
+    return texture(shadowMap, vec3(uv, shadowZ));
+}
+
+
+float getShadowOmniClusteredPCF3x3(sampler2DShadow shadowMap, vec4 shadowParams, vec3 omniAtlasViewport, float shadowEdgePixels, vec3 dir) {
+
+    float shadowTextureResolution = shadowParams.x;
+    vec2 uv = getCubemapAtlasCoordinates(omniAtlasViewport, shadowEdgePixels, shadowTextureResolution, dir);
+
+    float shadowZ = length(dir) * shadowParams.w + shadowParams.z;
+    dShadowCoord = vec3(uv, shadowZ);
+    return getShadowPCF3x3(shadowMap, shadowParams.xyz);
+}
+
+#else
+
+float getShadowOmniClusteredSingleSample(sampler2D shadowMap, vec4 shadowParams, vec3 omniAtlasViewport, float shadowEdgePixels, vec3 dir) {
+
+    float shadowTextureResolution = shadowParams.x;
+    vec2 uv = getCubemapAtlasCoordinates(omniAtlasViewport, shadowEdgePixels, shadowTextureResolution, dir);
+
+    // no filter shadow sampling
+    float depth = unpackFloat(texture2D(shadowMap, uv));
+    float shadowZ = length(dir) * shadowParams.w + shadowParams.z;
+    return depth > shadowZ ? 1.0 : 0.0;
+}
+
+float getShadowOmniClusteredPCF3x3(sampler2D shadowMap, vec4 shadowParams, vec3 omniAtlasViewport, float shadowEdgePixels, vec3 dir) {
+
+    float shadowTextureResolution = shadowParams.x;
+    vec2 uv = getCubemapAtlasCoordinates(omniAtlasViewport, shadowEdgePixels, shadowTextureResolution, dir);
+
+    // pcf3
+    float shadowZ = length(dir) * shadowParams.w + shadowParams.z;
+    dShadowCoord = vec3(uv, shadowZ);
+    return getShadowPCF3x3(shadowMap, shadowParams.xyz);
+}
+
+#endif

--- a/src/graphics/program-lib/chunks/shadowStandard.frag
+++ b/src/graphics/program-lib/chunks/shadowStandard.frag
@@ -221,7 +221,7 @@ vec2 getCubemapFaceCoordinates(const vec3 dir, out float faceIndex, out vec2 til
 	return uv * ma + 0.5;
 }
 
-// converts unnormaized direction vector to a texture coordinate for a cubemap face stored within texture atlas described by the viewport
+// converts unnormalized direction vector to a texture coordinate for a cubemap face stored within texture atlas described by the viewport
 vec2 getCubemapAtlasCoordinates(const vec3 omniAtlasViewport, float shadowEdgePixels, float shadowTextureResolution, const vec3 dir) {
 
     float faceIndex;

--- a/src/graphics/program-lib/programs/standard.js
+++ b/src/graphics/program-lib/programs/standard.js
@@ -548,7 +548,7 @@ var standard = {
         } else if (shadowType === SHADOW_PCF3 || shadowType === SHADOW_PCF5) {
             code += "   gl_FragColor = vec4(1.0);\n"; // just the simpliest code, color is not written anyway
 
-            // clustered omni light is using shadow sampler and neesd to write custom depth
+            // clustered omni light is using shadow sampler and needs to write custom depth
             if (isClustered && lightType === LIGHTTYPE_OMNI && device.webgl2) {
                 code += "   gl_FragDepth = depth;\n";
             }

--- a/src/graphics/program-lib/programs/standard.js
+++ b/src/graphics/program-lib/programs/standard.js
@@ -477,6 +477,92 @@ var standard = {
         return code;
     },
 
+    _buildShadowPassFragmentCode: function (code, device, chunks, options, varyings) {
+
+        const isClustered = LayerComposition.clusteredLightingEnabled;
+        const smode = options.pass - SHADER_SHADOW;
+        const numShadowModes = SHADOW_COUNT;
+        const lightType = Math.floor(smode / numShadowModes);
+        const shadowType = smode - lightType * numShadowModes;
+
+        if (device.extStandardDerivatives && !device.webgl2) {
+            code += 'uniform vec2 polygonOffset;\n';
+        }
+
+        if (shadowType === SHADOW_VSM32) {
+            if (device.textureFloatHighPrecision) {
+                code += '#define VSM_EXPONENT 15.0\n\n';
+            } else {
+                code += '#define VSM_EXPONENT 5.54\n\n';
+            }
+        } else if (shadowType === SHADOW_VSM16) {
+            code += '#define VSM_EXPONENT 5.54\n\n';
+        }
+
+        if (lightType !== LIGHTTYPE_DIRECTIONAL) {
+            code += 'uniform vec3 view_position;\n';
+            code += 'uniform float light_radius;\n';
+        }
+
+        code += varyings;
+        if (options.alphaTest) {
+            code += "float dAlpha;\n";
+            code += this._addMap("opacity", "opacityPS", options, chunks);
+            code += chunks.alphaTestPS;
+        }
+
+        if (shadowType === SHADOW_PCF3 && (!device.webgl2 || lightType === LIGHTTYPE_OMNI)) {
+            code += chunks.packDepthPS;
+        } else if (shadowType === SHADOW_VSM8) {
+            code += "vec2 encodeFloatRG( float v ) {\n";
+            code += "    vec2 enc = vec2(1.0, 255.0) * v;\n";
+            code += "    enc = fract(enc);\n";
+            code += "    enc -= enc.yy * vec2(1.0/255.0, 1.0/255.0);\n";
+            code += "    return enc;\n";
+            code += "}\n\n";
+        }
+
+        code += begin();
+
+        if (options.alphaTest) {
+            code += "   getOpacity();\n";
+            code += "   alphaTest(dAlpha);\n";
+        }
+
+        const isVsm = shadowType === SHADOW_VSM8 || shadowType === SHADOW_VSM16 || shadowType === SHADOW_VSM32;
+
+        if (lightType === LIGHTTYPE_OMNI || (isVsm && lightType !== LIGHTTYPE_DIRECTIONAL)) {
+            code += "   float depth = min(distance(view_position, vPositionW) / light_radius, 0.99999);\n";
+        } else {
+            code += "   float depth = gl_FragCoord.z;\n";
+        }
+
+        if (shadowType === SHADOW_PCF3 && (!device.webgl2 || (lightType === LIGHTTYPE_OMNI && !isClustered))) {
+            if (device.extStandardDerivatives && !device.webgl2) {
+                code += "   float minValue = 2.3374370500153186e-10; //(1.0 / 255.0) / (256.0 * 256.0 * 256.0);\n";
+                code += "   depth += polygonOffset.x * max(abs(dFdx(depth)), abs(dFdy(depth))) + minValue * polygonOffset.y;\n";
+                code += "   gl_FragColor = packFloat(depth);\n";
+            } else {
+                code += "   gl_FragColor = packFloat(depth);\n";
+            }
+        } else if (shadowType === SHADOW_PCF3 || shadowType === SHADOW_PCF5) {
+            code += "   gl_FragColor = vec4(1.0);\n"; // just the simpliest code, color is not written anyway
+
+            // clustered omni light is using shadow sampler and neesd to write custom depth
+            if (isClustered && lightType === LIGHTTYPE_OMNI && device.webgl2) {
+                code += "   gl_FragDepth = depth;\n";
+            }
+        } else if (shadowType === SHADOW_VSM8) {
+            code += "   gl_FragColor = vec4(encodeFloatRG(depth), encodeFloatRG(depth*depth));\n";
+        } else {
+            code += chunks.storeEVSMPS;
+        }
+
+        code += end();
+
+        return code;
+    },
+
     createShaderDefinition: function (device, options) {
         var i, p;
         var lighting = options.lights.length > 0;
@@ -890,85 +976,10 @@ var standard = {
 
         } else if (shadowPass) {
             // ##### SHADOW PASS #####
-            const smode = options.pass - SHADER_SHADOW;
-            const numShadowModes = SHADOW_COUNT;
-            lightType = Math.floor(smode / numShadowModes);
-            var shadowType = smode - lightType * numShadowModes;
-
-            if (device.extStandardDerivatives && !device.webgl2) {
-                code += 'uniform vec2 polygonOffset;\n';
-            }
-
-            if (shadowType === SHADOW_VSM32) {
-                if (device.textureFloatHighPrecision) {
-                    code += '#define VSM_EXPONENT 15.0\n\n';
-                } else {
-                    code += '#define VSM_EXPONENT 5.54\n\n';
-                }
-            } else if (shadowType === SHADOW_VSM16) {
-                code += '#define VSM_EXPONENT 5.54\n\n';
-            }
-
-            if (lightType !== LIGHTTYPE_DIRECTIONAL) {
-                code += 'uniform vec3 view_position;\n';
-                code += 'uniform float light_radius;\n';
-            }
-
-            code += varyings;
-            if (options.alphaTest) {
-                code += "float dAlpha;\n";
-                code += this._addMap("opacity", "opacityPS", options, chunks);
-                code += chunks.alphaTestPS;
-            }
-
-            if (shadowType === SHADOW_PCF3 && (!device.webgl2 || lightType === LIGHTTYPE_OMNI)) {
-                code += chunks.packDepthPS;
-            } else if (shadowType === SHADOW_VSM8) {
-                code += "vec2 encodeFloatRG( float v ) {\n";
-                code += "    vec2 enc = vec2(1.0, 255.0) * v;\n";
-                code += "    enc = fract(enc);\n";
-                code += "    enc -= enc.yy * vec2(1.0/255.0, 1.0/255.0);\n";
-                code += "    return enc;\n";
-                code += "}\n\n";
-            }
-
-            code += begin();
-
-            if (options.alphaTest) {
-                code += "   getOpacity();\n";
-                code += "   alphaTest(dAlpha);\n";
-            }
-
-            var isVsm = shadowType === SHADOW_VSM8 || shadowType === SHADOW_VSM16 || shadowType === SHADOW_VSM32;
-
-            if (lightType === LIGHTTYPE_OMNI || (isVsm && lightType !== LIGHTTYPE_DIRECTIONAL)) {
-                code += "   float depth = min(distance(view_position, vPositionW) / light_radius, 0.99999);\n";
-            } else {
-                code += "   float depth = gl_FragCoord.z;\n";
-            }
-
-            if (shadowType === SHADOW_PCF3 && (!device.webgl2 || lightType === LIGHTTYPE_OMNI)) {
-                if (device.extStandardDerivatives && !device.webgl2) {
-                    code += "   float minValue = 2.3374370500153186e-10; //(1.0 / 255.0) / (256.0 * 256.0 * 256.0);\n";
-                    code += "   depth += polygonOffset.x * max(abs(dFdx(depth)), abs(dFdy(depth))) + minValue * polygonOffset.y;\n";
-                    code += "   gl_FragColor = packFloat(depth);\n";
-                } else {
-                    code += "   gl_FragColor = packFloat(depth);\n";
-                }
-            } else if (shadowType === SHADOW_PCF3 || shadowType === SHADOW_PCF5) {
-                code += "   gl_FragColor = vec4(1.0);\n"; // just the simpliest code, color is not written anyway
-            } else if (shadowType === SHADOW_VSM8) {
-                code += "   gl_FragColor = vec4(encodeFloatRG(depth), encodeFloatRG(depth*depth));\n";
-            } else {
-                code += chunks.storeEVSMPS;
-            }
-
-            code += end();
-
             return {
                 attributes: attributes,
                 vshader: vshader,
-                fshader: code
+                fshader: this._buildShadowPassFragmentCode(code, device, chunks, options, varyings)
             };
         }
 

--- a/src/scene/constants.js
+++ b/src/scene/constants.js
@@ -288,7 +288,7 @@ export const SHADOW_VSM32 = 3;
  */
 export const SHADOW_PCF5 = 4;
 
-// non-public number of supported depth shadow modes
+// non-public: number of supported depth shadow modes
 export const SHADOW_COUNT = 5;
 
 /**

--- a/src/scene/light.js
+++ b/src/scene/light.js
@@ -166,8 +166,8 @@ class Light {
         // cookie matrix (used in case the shadow mapping is disabled and so the shadow matrix cannot be used)
         this._cookieMatrix = null;
 
-        // viewport of the cookie texture in the atlas
-        this._cookieViewport = null;
+        // viewport of the cookie texture / shadow in the atlas
+        this._atlasViewport = null;
 
         this._scene = null;
         this._node = null;
@@ -677,11 +677,11 @@ class Light {
         return this._cookieMatrix;
     }
 
-    get cookieViewport() {
-        if (!this._cookieViewport) {
-            this._cookieViewport = new Vec4(0, 0, 1, 1);
+    get atlasViewport() {
+        if (!this._atlasViewport) {
+            this._atlasViewport = new Vec4(0, 0, 1, 1);
         }
-        return this._cookieViewport;
+        return this._atlasViewport;
     }
 
     get cookie() {

--- a/src/scene/renderer/cookie-renderer.js
+++ b/src/scene/renderer/cookie-renderer.js
@@ -96,7 +96,7 @@ class CookieRenderer {
 
         const cookieMatrix = light.cookieMatrix;
 
-        const rectViewport = light.cookieViewport;
+        const rectViewport = light.atlasViewport;
         _viewportMatrix.setViewport(rectViewport.x, rectViewport.y, rectViewport.z, rectViewport.w);
         cookieMatrix.mul2(_viewportMatrix, _viewProjMat);
 
@@ -121,7 +121,7 @@ class CookieRenderer {
                 this.blitTextureId.setValue(light.cookie);
 
                 // render it to a viewport of the target
-                _viewport.copy(light.cookieViewport).mulScalar(renderTarget.colorBuffer.width);
+                _viewport.copy(light.atlasViewport).mulScalar(renderTarget.colorBuffer.width);
                 drawQuadWithShader(device, renderTarget, shader, _viewport);
             }
 

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -114,14 +114,14 @@ class ForwardRenderer {
         const library = device.getProgramLibrary();
         this.library = library;
 
+        // texture atlas managing shadow map / cookie texture atlassing for omni and spot lights
+        this.lightTextureAtlas = new LightTextureAtlas(device);
+
         // shadows
-        this._shadowRenderer = new ShadowRenderer(this);
+        this._shadowRenderer = new ShadowRenderer(this, this.lightTextureAtlas);
 
         // cookies
         this._cookieRenderer = new CookieRenderer(device);
-
-        // texture atlas managing shadow map / cookie texture atlassing for omni and spot lights
-        this.lightTextureAtlas = new LightTextureAtlas(device);
 
         // Uniforms
         const scope = device.scope;


### PR DESCRIPTION
Clustered omni lights now support shadows by rendering them to the shadow atlas (shared with the spot lights)
- webgl1 encodes depth in color buffer and does manual PCF comparison
- webgl2 uses depth shadows sampler and writes custom depth to the shadow map, and uses HW PCF
- it uses PCF3x3 (the same as spot lights), but single sample version is implemented as well and will be exposed at a later stage.
- omni light uses few pixel larger FOV than 90deg to avoid doing PCF filtering across multiple faces.
- new example to demonstrate: clustered-omni-shadows.tsx

![Screenshot 2021-10-05 at 12 15 47](https://user-images.githubusercontent.com/59932779/136013108-210c8ce1-5222-4a48-94dc-8c03cd9f78a4.png)