### PR TITLE
Deprecated functionality improvements

### DIFF
--- a/src/deprecated.js
+++ b/src/deprecated.js
@@ -111,8 +111,10 @@ import { RigidBodyComponent } from './framework/components/rigid-body/component.
 import { RigidBodyComponentSystem } from './framework/components/rigid-body/system.js';
 import { basisInitialize } from './resources/basis.js';
 
+// #if _DEBUG
 // function responsible for logging each unique deprecated message one time
 const _loggedDeprecatedMessages = new Set();
+// #endif
 
 function deprecatedWarn(message) {
     // #if _DEBUG


### PR DESCRIPTION
- deprecated functions log warning only one time per function to avoid spamming the log
- added deprecated implementations of app.renderMesh and app.renderMeshInstance - it was not public, but Editor uses these.