### PR TITLE
Added version logging in debug only

### DIFF
--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -1,3 +1,7 @@
+// #if _DEBUG
+import { version, revision } from '../core/core.js';
+// #endif
+
 import { platform } from '../core/platform.js';
 import { now } from '../core/time.js';
 import { path } from '../core/path.js';
@@ -395,6 +399,10 @@ let app = null;
 class Application extends EventHandler {
     constructor(canvas, options = {}) {
         super();
+
+        // #if _DEBUG
+        console.log("Powered by PlayCanvas " + version + " " + revision);
+        // #endif
 
         // Store application instance
         Application._applications[canvas.id] = this;


### PR DESCRIPTION
Re-added version logging in debug builds.

I can see this being useful for end users on playcanvas.com to report issues/notice releases and is easier to get to compared to looking at the playcanvas engine source file in devtools for the average user.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
