### PR TITLE
Make UI elements on screens take proper precedence when determining the input target.

### DIFF
--- a/src/input/element-input.js
+++ b/src/input/element-input.js
@@ -854,9 +854,9 @@ class ElementInput {
                 }
                 if (!rayScreen) continue;
 
-                // 2d screen elements take precedence
-                const hit = this._checkElement(rayScreen, element, true) >= 0;
-                if (hit === true) {
+                // 2d screen elements take precedence - if hit, immediately return
+                const currentDistance = this._checkElement(rayScreen, element, true);
+                if (currentDistance >= 0) {
                     result = element;
                     break;
                 }


### PR DESCRIPTION
Fixes https://forum.playcanvas.com/t/3d-screen-button-acting-strangely/22390.

This PR makes it so UI elements that are within a screen (either 2D or 3D) take the proper precedence over other elements. The issue with the previous code was mostly on 3D screens with multiple overlapping elements, causing the code to not be consistent in which element to choose.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
