### PR TITLE
[Fix] Update to handling of LightComponent.shadowUpdateMode

### DIFF
--- a/src/framework/components/light/component.js
+++ b/src/framework/components/light/component.js
@@ -449,7 +449,7 @@ function _defineProps() {
     }, true);
     _defineProperty("shadowUpdateMode", SHADOWUPDATE_REALTIME, function (newValue, oldValue) {
         this.light.shadowUpdateMode = newValue;
-    });
+    }, true);
     _defineProperty("mask", 1, function (newValue, oldValue) {
         this.light.mask = newValue;
     });


### PR DESCRIPTION
LightComponent stores shadowUpdateMode on the Light, but ShadowRenderer modifies it during shadow rendering on the light directly, making those going out of sync. The observed issue is that the shadow cannot be forced to re-render by setting shadowUpdateMode to update on a specific frame.
This fixes the behaviour by always passing the value to the light without testing for change, making the shadow correctly re-render as requested.