### PR TITLE
[Fix] Setting up render target for lights with SHADOWUPDATE_NONE correctly

### DIFF
--- a/src/scene/renderer/shadow-renderer.js
+++ b/src/scene/renderer/shadow-renderer.js
@@ -271,6 +271,12 @@ class ShadowRenderer {
             const lightRenderData = light.getRenderData(camera, cascade);
             const shadowCam = lightRenderData.shadowCamera;
 
+            // assign render target
+            // Note: this is done during rendering for all shadow maps, but do it here for the case shadow rendering for the directional light
+            // is disabled - we need shadow map to be assigned for rendering to work even in this case. This needs further refactoring - as when
+            // shadow rendering is set to SHADOWUPDATE_NONE, we should not even execute shadow map culling
+            shadowCam.renderTarget = light._shadowMap.renderTargets[0];
+
             // viewport
             lightRenderData.shadowViewport.copy(light.cascades[cascade]);
             lightRenderData.shadowScissor.copy(light.cascades[cascade]);


### PR DESCRIPTION
Fixing issue introduced here: https://github.com/playcanvas/engine/pull/3235

If shadow map rendering for directional light is set up to be SHADOWUPDATE_NONE, than the shadow map is not set up on the light and rendering using the light fails as the shader requires shadow map.

This fixes it by setting up the shadow map even when not rendering to it.