### PR TITLE
[Fix] Fix to ParticleSystem crash caused by recent refactor

### DIFF
--- a/src/framework/components/particle-system/system.js
+++ b/src/framework/components/particle-system/system.js
@@ -217,6 +217,7 @@ class ParticleSystemComponentSystem extends ComponentSystem {
                     // TODO: don't do for every emitter
                     if (emitter.lighting) {
                         const layers = data.layers;
+                        let lightCube;
                         for (let i = 0; i < layers.length; i++) {
                             const layer = this.app.scene.layers.getLayerById(layers[i]);
                             if (!layer) continue;
@@ -224,7 +225,7 @@ class ParticleSystemComponentSystem extends ComponentSystem {
                             if (!layer._lightCube) {
                                 layer._lightCube = new Float32Array(6 * 3);
                             }
-                            const lightCube = layer._lightCube;
+                            lightCube = layer._lightCube;
                             for (let j = 0; j < 6; j++) {
                                 lightCube[j * 3] = this.app.scene.ambientLight.r;
                                 lightCube[j * 3 + 1] = this.app.scene.ambientLight.g;


### PR DESCRIPTION
Fixes an issue introduced here
https://github.com/playcanvas/engine/pull/3576

the Edit (how did that code ever worked with the two loops using index i?

<img width="1606" alt="Screenshot 2021-10-21 at 09 56 24" src="https://user-images.githubusercontent.com/59932779/138245510-bac4cd1a-cbd4-4416-ae6f-5e520c1df9bc.png">


forum post: https://forum.playcanvas.com/t/solved-error-in-start-published-build/22508