### PR TITLE
Update JSDoc examples to use ES6

### DIFF
--- a/src/asset/asset-reference.js
+++ b/src/asset/asset-reference.js
@@ -15,8 +15,7 @@
  * @property {number} id Get or set the asset id which this references. One of either id or url must be set to initialize an asset reference.
  * @property {string} url Get or set the asset url which this references. One of either id or url must be called to initialize an asset reference.
  * @example
- *
- * var reference = new pc.AssetReference('textureAsset', this, this.app.assets, {
+ * const reference = new pc.AssetReference('textureAsset', this, this.app.assets, {
  *     load: this.onTextureAssetLoad,
  *     add: this.onTextureAssetAdd,
  *     remove: this.onTextureAssetRemove

--- a/src/asset/asset-registry.js
+++ b/src/asset/asset-registry.js
@@ -39,7 +39,7 @@ class AssetRegistry extends EventHandler {
      * @description Fired when an asset completes loading.
      * @param {Asset} asset - The asset that has just loaded.
      * @example
-     * app.assets.on("load", function (asset) {
+     * app.assets.on("load", (asset) => {
      *     console.log("asset loaded: " + asset.name);
      * });
      */
@@ -50,9 +50,9 @@ class AssetRegistry extends EventHandler {
      * @description Fired when an asset completes loading.
      * @param {Asset} asset - The asset that has just loaded.
      * @example
-     * var id = 123456;
-     * var asset = app.assets.get(id);
-     * app.assets.on("load:" + id, function (asset) {
+     * const id = 123456;
+     * const asset = app.assets.get(id);
+     * app.assets.on("load:" + id, (asset) => {
      *     console.log("asset loaded: " + asset.name);
      * });
      * app.assets.load(asset);
@@ -64,9 +64,9 @@ class AssetRegistry extends EventHandler {
      * @description Fired when an asset completes loading.
      * @param {Asset} asset - The asset that has just loaded.
      * @example
-     * var id = 123456;
-     * var asset = app.assets.get(id);
-     * app.assets.on("load:url:" + asset.file.url, function (asset) {
+     * const id = 123456;
+     * const asset = app.assets.get(id);
+     * app.assets.on("load:url:" + asset.file.url, (asset) => {
      *     console.log("asset loaded: " + asset.name);
      * });
      * app.assets.load(asset);
@@ -78,7 +78,7 @@ class AssetRegistry extends EventHandler {
      * @description Fired when an asset is added to the registry.
      * @param {Asset} asset - The asset that was added.
      * @example
-     * app.assets.on("add", function (asset) {
+     * app.assets.on("add", (asset) => {
      *     console.log("New asset added: " + asset.name);
      * });
      */
@@ -89,8 +89,8 @@ class AssetRegistry extends EventHandler {
      * @description Fired when an asset is added to the registry.
      * @param {Asset} asset - The asset that was added.
      * @example
-     * var id = 123456;
-     * app.assets.on("add:" + id, function (asset) {
+     * const id = 123456;
+     * app.assets.on("add:" + id, (asset) => {
      *     console.log("Asset 123456 loaded");
      * });
      */
@@ -108,7 +108,7 @@ class AssetRegistry extends EventHandler {
      * @description Fired when an asset is removed from the registry.
      * @param {Asset} asset - The asset that was removed.
      * @example
-     * app.assets.on("remove", function (aseet) {
+     * app.assets.on("remove", (asset) => {
      *     console.log("Asset removed: " + asset.name);
      * });
      */
@@ -119,8 +119,8 @@ class AssetRegistry extends EventHandler {
      * @description Fired when an asset is removed from the registry.
      * @param {Asset} asset - The asset that was removed.
      * @example
-     * var id = 123456;
-     * app.assets.on("remove:" + id, function (asset) {
+     * const id = 123456;
+     * app.assets.on("remove:" + id, (asset) => {
      *     console.log("Asset removed: " + asset.name);
      * });
      */
@@ -139,9 +139,9 @@ class AssetRegistry extends EventHandler {
      * @param {string} err - The error message.
      * @param {Asset} asset - The asset that generated the error.
      * @example
-     * var id = 123456;
-     * var asset = app.assets.get(id);
-     * app.assets.on("error", function (err, asset) {
+     * const id = 123456;
+     * const asset = app.assets.get(id);
+     * app.assets.on("error", (err, asset) => {
      *     console.error(err);
      * });
      * app.assets.load(asset);
@@ -153,9 +153,9 @@ class AssetRegistry extends EventHandler {
      * @description Fired when an error occurs during asset loading.
      * @param {Asset} asset - The asset that generated the error.
      * @example
-     * var id = 123456;
-     * var asset = app.assets.get(id);
-     * app.assets.on("error:" + id, function (err, asset) {
+     * const id = 123456;
+     * const asset = app.assets.get(id);
+     * app.assets.on("error:" + id, (err, asset) => {
      *     console.error(err);
      * });
      * app.assets.load(asset);
@@ -185,7 +185,7 @@ class AssetRegistry extends EventHandler {
      * @description Add an asset to the registry.
      * @param {Asset} asset - The asset to add.
      * @example
-     * var asset = new pc.Asset("My Asset", "texture", {
+     * const asset = new pc.Asset("My Asset", "texture", {
      *     url: "../path/to/image.jpg"
      * });
      * app.assets.add(asset);
@@ -228,7 +228,7 @@ class AssetRegistry extends EventHandler {
      * @param {Asset} asset - The asset to remove.
      * @returns {boolean} True if the asset was successfully removed and false otherwise.
      * @example
-     * var asset = app.assets.get(100);
+     * const asset = app.assets.get(100);
      * app.assets.remove(asset);
      */
     remove(asset) {
@@ -288,7 +288,7 @@ class AssetRegistry extends EventHandler {
      * @param {number} id - The id of the asset to get.
      * @returns {Asset} The asset.
      * @example
-     * var asset = app.assets.get(100);
+     * const asset = app.assets.get(100);
      */
     get(id) {
         const idx = this._cache[id];
@@ -302,7 +302,7 @@ class AssetRegistry extends EventHandler {
      * @param {string} url - The url of the asset to get.
      * @returns {Asset} The asset.
      * @example
-     * var asset = app.assets.getByUrl("../path/to/image.jpg");
+     * const asset = app.assets.getByUrl("../path/to/image.jpg");
      */
     getByUrl(url) {
         const idx = this._urls[url];
@@ -316,13 +316,13 @@ class AssetRegistry extends EventHandler {
      * @param {Asset} asset - The asset to load.
      * @example
      * // load some assets
-     * var assetsToLoad = [
+     * const assetsToLoad = [
      *     app.assets.find("My Asset"),
      *     app.assets.find("Another Asset")
      * ];
-     * var count = 0;
-     * assetsToLoad.forEach(function (assetToLoad) {
-     *     assetToLoad.ready(function (asset) {
+     * let count = 0;
+     * assetsToLoad.forEach((assetToLoad) => {
+     *     assetToLoad.ready((asset) => {
      *         count++;
      *         if (count === assetsToLoad.length) {
      *             // done
@@ -406,8 +406,8 @@ class AssetRegistry extends EventHandler {
      * @param {string} type - The type of asset to load.
      * @param {callbacks.LoadAsset} callback - Function called when asset is loaded, passed (err, asset), where err is null if no errors were encountered.
      * @example
-     * app.assets.loadFromUrl("../path/to/texture.jpg", "texture", function (err, asset) {
-     *     var texture = asset.resource;
+     * app.assets.loadFromUrl("../path/to/texture.jpg", "texture", (err, asset) => {
+     *     const texture = asset.resource;
      * });
      */
     loadFromUrl(url, type, callback) {
@@ -424,9 +424,9 @@ class AssetRegistry extends EventHandler {
      * @param {string} type - The type of asset to load.
      * @param {callbacks.LoadAsset} callback - Function called when asset is loaded, passed (err, asset), where err is null if no errors were encountered.
      * @example
-     * var file = magicallyAttainAFile();
-     * app.assets.loadFromUrlAndFilename(URL.createObjectURL(file), "texture.png", "texture", function (err, asset) {
-     *     var texture = asset.resource;
+     * const file = magicallyAttainAFile();
+     * app.assets.loadFromUrlAndFilename(URL.createObjectURL(file), "texture.png", "texture", (err, asset) => {
+     *     const texture = asset.resource;
      * });
      */
     loadFromUrlAndFilename(url, filename, type, callback) {
@@ -579,7 +579,7 @@ class AssetRegistry extends EventHandler {
      * @param {string} [type] - The type of the Assets to find.
      * @returns {Asset[]} A list of all Assets found.
      * @example
-     * var assets = app.assets.findAll("myTextureAsset", "texture");
+     * const assets = app.assets.findAll("myTextureAsset", "texture");
      * console.log("Found " + assets.length + " assets called " + name);
      */
     findAll(name, type) {
@@ -619,16 +619,16 @@ class AssetRegistry extends EventHandler {
      * @param {...*} query - Name of a tag or array of tags.
      * @returns {Asset[]} A list of all Assets matched query.
      * @example
-     * var assets = app.assets.findByTag("level-1");
+     * const assets = app.assets.findByTag("level-1");
      * // returns all assets that tagged by `level-1`
      * @example
-     * var assets = app.assets.findByTag("level-1", "level-2");
+     * const assets = app.assets.findByTag("level-1", "level-2");
      * // returns all assets that tagged by `level-1` OR `level-2`
      * @example
-     * var assets = app.assets.findByTag(["level-1", "monster"]);
+     * const assets = app.assets.findByTag(["level-1", "monster"]);
      * // returns all assets that tagged by `level-1` AND `monster`
      * @example
-     * var assets = app.assets.findByTag(["level-1", "monster"], ["level-2", "monster"]);
+     * const assets = app.assets.findByTag(["level-1", "monster"], ["level-2", "monster"]);
      * // returns all assets that tagged by (`level-1` AND `monster`) OR (`level-2` AND `monster`)
      */
     findByTag() {
@@ -643,7 +643,7 @@ class AssetRegistry extends EventHandler {
      * Return `true` to include an asset in the returned array.
      * @returns {Asset[]} A list of all Assets found.
      * @example
-     * var assets = app.assets.filter(function (asset) {
+     * const assets = app.assets.filter((asset) => {
      *     return asset.name.indexOf('monster') !== -1;
      * });
      * console.log("Found " + assets.length + " assets, where names contains 'monster'");
@@ -660,7 +660,7 @@ class AssetRegistry extends EventHandler {
      * @param {string} [type] - The type of the Asset to find.
      * @returns {Asset} A single Asset or null if no Asset is found.
      * @example
-     * var asset = app.assets.find("myTextureAsset", "texture");
+     * const asset = app.assets.find("myTextureAsset", "texture");
      */
     find(name, type) {
         // findAll returns an empty array the if the asset cannot be found so `asset` is

--- a/src/asset/asset.js
+++ b/src/asset/asset.js
@@ -39,17 +39,13 @@ const VARIANT_DEFAULT_PRIORITY = ['pvr', 'dxt', 'etc2', 'etc1', 'basis'];
  * @description Create a new Asset record. Generally, Assets are created in the loading process and you won't need to create them by hand.
  * @param {string} name - A non-unique but human-readable name which can be later used to retrieve the asset.
  * @param {string} type - Type of asset. One of ["animation", "audio", "binary", "container", cubemap", "css", "font", "json", "html", "material", "model", "script", "shader", "sprite", "template", text", "texture"]
- * @param {object} [file] - Details about the file the asset is made from. At the least must contain the 'url' field. For assets that don't contain file data use null.
- * @example
- * var file = {
- *     filename: "filename.txt",
- *     url: "/example/filename.txt"
- * };
+ * @param {object} [file] - Details about the file the asset is made from. For assets that don't contain file data, specify null.
+ * @param {string} [file.url] - URL of the file to load. This property is required if the asset is loaded from a file.
  * @param {object} [data] - JSON object with additional data about the asset. (e.g. for texture and model assets) or contains the asset data itself (e.g. in the case of materials)
  * @param {object} [options] - The asset handler options. For container options see {@link ContainerHandler}
  * @param {boolean} [options.crossOrigin] - For use with texture resources. For browser-supported image formats only, enable cross origin.
  * @example
- * var asset = new pc.Asset("a texture", "texture", {
+ * const asset = new pc.Asset("a texture", "texture", {
  *     url: "http://example.com/my/assets/here/texture.png"
  * });
  * @property {string} name The name of the asset
@@ -164,8 +160,8 @@ class Asset extends EventHandler {
      * @description Return the URL required to fetch the file for this asset.
      * @returns {string} The URL.
      * @example
-     * var assets = app.assets.find("My Image", "texture");
-     * var img = "&lt;img src='" + assets[0].getFileUrl() + "'&gt;";
+     * const assets = app.assets.find("My Image", "texture");
+     * const img = "&lt;img src='" + assets[0].getFileUrl() + "'&gt;";
      */
     getFileUrl() {
         const file = this.file;
@@ -255,8 +251,8 @@ class Asset extends EventHandler {
      * @param {callbacks.AssetReady} callback - The function called when the asset is ready. Passed the (asset) arguments.
      * @param {object} [scope] - Scope object to use when calling the callback.
      * @example
-     * var asset = app.assets.find("My Asset");
-     * asset.ready(function (asset) {
+     * const asset = app.assets.find("My Asset");
+     * asset.ready((asset) => {
      *   // asset loaded
      * });
      * app.assets.load(asset);
@@ -286,7 +282,7 @@ class Asset extends EventHandler {
      * @name Asset#unload
      * @description Destroys the associated resource and marks asset as unloaded.
      * @example
-     * var asset = app.assets.find("My Asset");
+     * const asset = app.assets.find("My Asset");
      * asset.unload();
      * // asset.resource is null
      */

--- a/src/bundles/bundle-registry.js
+++ b/src/bundles/bundle-registry.js
@@ -308,8 +308,8 @@ class BundleRegistry {
      * @param {Function} callback - The callback is called when the file has been loaded or if an error occurs. The callback
      * expects the first argument to be the error message (if any) and the second argument is the file blob URL.
      * @example
-     * var url = asset.getFileUrl().split('?')[0]; // get normalized asset URL
-     * this.app.bundles.loadFile(url, function (err, blobUrl) {
+     * const url = asset.getFileUrl().split('?')[0]; // get normalized asset URL
+     * this.app.bundles.loadFile(url, (err, blobUrl) => {
      *     // do something with the blob URL
      * });
      */

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -58,12 +58,12 @@ function type(obj) {
  * @param {object} ex - The object that is merged with target.
  * @returns {object} The target object.
  * @example
- * var A = {
+ * const A = {
  *     a: function () {
  *         console.log(this.a);
  *     }
  * };
- * var B = {
+ * const B = {
  *     b: function () {
  *         console.log(this.b);
  *     }

--- a/src/core/event-handler.js
+++ b/src/core/event-handler.js
@@ -4,10 +4,10 @@
  * @classdesc Abstract base class that implements functionality for event handling.
  * @description Create a new event handler.
  * @example
- * var obj = new EventHandlerSubclass();
+ * const obj = new EventHandlerSubclass();
  *
  * // subscribe to an event
- * obj.on('hello', function (str) {
+ * obj.on('hello', (str) => {
  *     console.log('event hello is fired', str);
  * });
  *
@@ -50,7 +50,7 @@ class EventHandler {
      * @param {object} [scope] - Object to use as 'this' when the event is fired, defaults to current this.
      * @returns {EventHandler} Self for chaining.
      * @example
-     * obj.on('test', function (a, b) {
+     * obj.on('test', (a, b) => {
      *     console.log(a + b);
      * });
      * obj.fire('test', 1, 2); // prints 3 to the console
@@ -71,14 +71,14 @@ class EventHandler {
      * @param {object} [scope] - Scope that was used as the this when the event is fired.
      * @returns {EventHandler} Self for chaining.
      * @example
-     * var handler = function () {
+     * const handler = () => {
      * };
      * obj.on('test', handler);
      *
      * obj.off(); // Removes all events
      * obj.off('test'); // Removes all events called 'test'
      * obj.off('test', handler); // Removes all handler functions, called 'test'
-     * obj.off('test', handler, this); // Removes all hander functions, called 'test' with scope this
+     * obj.off('test', handler, this); // Removes all handler functions, called 'test' with scope this
      */
     off(name, callback, scope) {
         if (name) {
@@ -197,7 +197,7 @@ class EventHandler {
      * @param {object} [scope] - Object to use as 'this' when the event is fired, defaults to current this.
      * @returns {EventHandler} Self for chaining.
      * @example
-     * obj.once('test', function (a, b) {
+     * obj.once('test', (a, b) => {
      *     console.log(a + b);
      * });
      * obj.fire('test', 1, 2); // prints 3 to the console
@@ -215,7 +215,10 @@ class EventHandler {
      * @param {string} name - The name of the event to test.
      * @returns {boolean} True if the object has handlers bound to the specified event name.
      * @example
-     * obj.on('test', function () { }); // bind an event to 'test'
+     * // bind an event to 'test'
+     * obj.on('test', () => {
+     *     // insert handler coder here...
+     * });
      * obj.hasEvent('test'); // returns true
      * obj.hasEvent('hello'); // returns false
      */

--- a/src/core/events.js
+++ b/src/core/events.js
@@ -10,7 +10,7 @@ const events = {
      * @param {object} target - The object to add events to.
      * @returns {object} The target object.
      * @example
-     * var obj = { };
+     * const obj = { };
      * pc.events.attach(obj);
      */
     attach: function (target) {

--- a/src/core/path.js
+++ b/src/core/path.js
@@ -22,10 +22,10 @@ const path = {
      * provided as parameters.
      * @returns {string} The joined file path.
      * @example
-     * var path = pc.path.join('foo', 'bar');
+     * const path = pc.path.join('foo', 'bar');
      * console.log(path); // Prints 'foo/bar'
      * @example
-     * var path = pc.path.join('alpha', 'beta', 'gamma');
+     * const path = pc.path.join('alpha', 'beta', 'gamma');
      * console.log(path); // Prints 'alpha/beta/gamma'
      */
     join: function () {

--- a/src/core/sorted-loop-array.js
+++ b/src/core/sorted-loop-array.js
@@ -12,7 +12,7 @@
  * @property {number} length The number of elements in the array.
  * @property {object[]} items The internal array that holds the actual array elements.
  * @example
- * var array = new pc.SortedLoopArray({ sortBy: 'priority' });
+ * const array = new pc.SortedLoopArray({ sortBy: 'priority' });
  * array.insert(item); // adds item to the right slot based on item.priority
  * array.append(item); // adds item to the end of the array
  * array.remove(item); // removes item from array

--- a/src/core/string.js
+++ b/src/core/string.js
@@ -132,7 +132,7 @@ const string = {
      * @param {object} [arguments] - All other arguments are substituted into the string.
      * @returns {string} The formatted string.
      * @example
-     * var s = pc.string.format("Hello {0}", "world");
+     * const s = pc.string.format("Hello {0}", "world");
      * console.log(s); // Prints "Hello world"
      */
     format: function (s) {

--- a/src/core/uri.js
+++ b/src/core/uri.js
@@ -121,9 +121,9 @@ class URI {
      * @description Returns the query parameters as an Object.
      * @returns {object} The URI's query parameters converted to an Object.
      * @example
-     * var s = "http://example.com?a=1&b=2&c=3";
-     * var uri = new pc.URI(s);
-     * var q = uri.getQuery();
+     * const s = "http://example.com?a=1&b=2&c=3";
+     * const uri = new pc.URI(s);
+     * const q = uri.getQuery();
      * console.log(q.a); // logs "1"
      * console.log(q.b); // logs "2"
      * console.log(q.c); // logs "3"
@@ -149,8 +149,8 @@ class URI {
      * @description Set the query section of the URI from a Object.
      * @param {object} params - Key-Value pairs to encode into the query string.
      * @example
-     * var s = "http://example.com";
-     * var uri = new pc.URI(s);
+     * const s = "http://example.com";
+     * const uri = new pc.URI(s);
      * uri.setQuery({
      *     "a": 1,
      *     "b": 2

--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -176,7 +176,7 @@ class Progress {
  * @param {string[]} [options.scriptsOrder] - Scripts in order of loading first.
  * @example
  * // Engine-only example: create the application manually
- * var app = new pc.Application(canvas, options);
+ * const app = new pc.Application(canvas, options);
  *
  * // Start the application's main loop
  * app.start();
@@ -219,7 +219,7 @@ class Progress {
  * @description The scene registry managed by the application.
  * @example
  * // Search the scene registry for a item with the name 'racetrack1'
- * var sceneItem = this.app.scenes.find('racetrack1');
+ * const sceneItem = this.app.scenes.find('racetrack1');
  *
  * // Load the scene using the item's url
  * this.app.scenes.loadScene(sceneItem.url);
@@ -231,7 +231,7 @@ class Progress {
  * @description The asset registry managed by the application.
  * @example
  * // Search the asset registry for all assets with the tag 'vehicle'
- * var vehicleAssets = this.app.assets.findByTag('vehicle');
+ * const vehicleAssets = this.app.assets.findByTag('vehicle');
  */
 
 /**
@@ -304,7 +304,7 @@ class Progress {
  * @description The root entity of the application.
  * @example
  * // Return the first entity called 'Camera' in a depth-first search of the scene hierarchy
- * var camera = this.app.root.findByName('Camera');
+ * const camera = this.app.root.findByName('Camera');
  */
 
 /**
@@ -662,7 +662,7 @@ class Application extends EventHandler {
      * @param {string} [id] - If defined, the returned application should use the canvas which has this id. Otherwise current application will be returned.
      * @returns {Application|undefined} The running application, if any.
      * @example
-     * var app = pc.Application.getApplication();
+     * const app = pc.Application.getApplication();
      */
     static getApplication(id) {
         return id ? Application._applications[id] : getApplication();
@@ -1473,8 +1473,7 @@ class Application extends EventHandler {
      *
      * Only lights with bakeDir=true will be used for generating the dominant light direction.
      * @example
-     *
-     * var settings = {
+     * const settings = {
      *     physics: {
      *         gravity: [0, -9.8, 0]
      *     },
@@ -1662,23 +1661,23 @@ class Application extends EventHandler {
      * @param {Vec3} start - The start world-space coordinate of the line.
      * @param {Vec3} end - The end world-space coordinate of the line.
      * @param {Color} [color] - The color of the line. It defaults to white if not specified.
-     * @param {boolean} [depthTest] - Specifies if the line is depth tested againts the depth buffer. Defaults to true.
+     * @param {boolean} [depthTest] - Specifies if the line is depth tested against the depth buffer. Defaults to true.
      * @param {Layer} [layer] - The layer to render the line into. Defaults to {@link LAYERID_IMMEDIATE}.
      * @example
      * // Render a 1-unit long white line
-     * var start = new pc.Vec3(0, 0, 0);
-     * var end = new pc.Vec3(1, 0, 0);
+     * const start = new pc.Vec3(0, 0, 0);
+     * const end = new pc.Vec3(1, 0, 0);
      * app.drawLine(start, end);
      * @example
      * // Render a 1-unit long red line which is not depth tested and renders on top of other geometry
-     * var start = new pc.Vec3(0, 0, 0);
-     * var end = new pc.Vec3(1, 0, 0);
+     * const start = new pc.Vec3(0, 0, 0);
+     * const end = new pc.Vec3(1, 0, 0);
      * app.drawLine(start, end, pc.Color.RED, false);
      * @example
      * // Render a 1-unit long white line into the world layer
-     * var start = new pc.Vec3(0, 0, 0);
-     * var end = new pc.Vec3(1, 0, 0);
-     * var worldLayer = app.scene.layers.getLayerById(pc.LAYERID_WORLD);
+     * const start = new pc.Vec3(0, 0, 0);
+     * const end = new pc.Vec3(1, 0, 0);
+     * const worldLayer = app.scene.layers.getLayerById(pc.LAYERID_WORLD);
      * app.drawLine(start, end, pc.Color.WHITE, true, worldLayer);
      */
     drawLine(start, end, color = Color.WHITE, depthTest = true, layer = this._getDefaultDrawLayer()) {
@@ -1696,16 +1695,16 @@ class Application extends EventHandler {
      * @param {Vec3[]} positions - An array of points to draw lines between. The length of the array must be a multiple of 2.
      * @param {Color[]} colors - An array of colors to color the lines. This must be the same length as the position array.
      * The length of the array must also be a multiple of 2.
-     * @param {boolean} [depthTest] - Specifies if the lines are depth tested againts the depth buffer. Defaults to true.
+     * @param {boolean} [depthTest] - Specifies if the lines are depth tested against the depth buffer. Defaults to true.
      * @param {Layer} [layer] - The layer to render the lines into. Defaults to {@link LAYERID_IMMEDIATE}.
      * @example
      * // Render a single line, with unique colors for each point
-     * var start = new pc.Vec3(0, 0, 0);
-     * var end = new pc.Vec3(1, 0, 0);
+     * const start = new pc.Vec3(0, 0, 0);
+     * const end = new pc.Vec3(1, 0, 0);
      * app.drawLines([start, end], [pc.Color.RED, pc.Color.WHITE]);
      * @example
      * // Render 2 discrete line segments
-     * var points = [
+     * const points = [
      *     // Line 1
      *     new pc.Vec3(0, 0, 0),
      *     new pc.Vec3(1, 0, 0),
@@ -1713,7 +1712,7 @@ class Application extends EventHandler {
      *     new pc.Vec3(1, 1, 0),
      *     new pc.Vec3(1, 1, 1)
      * ];
-     * var colors = [
+     * const colors = [
      *     // Line 1
      *     pc.Color.RED,
      *     pc.Color.YELLOW,
@@ -1736,11 +1735,11 @@ class Application extends EventHandler {
      * @param {number[]} positions - An array of points to draw lines between. Each point is represented by 3 numbers - x, y and z coordinate.
      * @param {number[]} colors - An array of colors to color the lines. This must be the same length as the position array.
      * The length of the array must also be a multiple of 2.
-     * @param {boolean} [depthTest] - Specifies if the lines are depth tested againts the depth buffer. Defaults to true.
+     * @param {boolean} [depthTest] - Specifies if the lines are depth tested against the depth buffer. Defaults to true.
      * @param {Layer} [layer] - The layer to render the lines into. Defaults to {@link LAYERID_IMMEDIATE}.
      * @example
      * // Render 2 discrete line segments
-     * var points = [
+     * const points = [
      *     // Line 1
      *     0, 0, 0,
      *     1, 0, 0,
@@ -1748,7 +1747,7 @@ class Application extends EventHandler {
      *     1, 1, 0,
      *     1, 1, 1
      * ];
-     * var colors = [
+     * const colors = [
      *     // Line 1
      *     1, 0, 0, 1,  // red
      *     0, 1, 0, 1,  // green
@@ -1776,7 +1775,7 @@ class Application extends EventHandler {
      * @param {Layer} [layer] - The layer to render the sphere into. Defaults to {@link LAYERID_IMMEDIATE}.
      * @example
      * // Render a red wire sphere with radius of 1
-     * var center = new pc.Vec3(0, 0, 0);
+     * const center = new pc.Vec3(0, 0, 0);
      * app.drawWireSphere(center, 1.0, pc.Color.RED);
      */
     drawWireSphere(center, radius, color = Color.WHITE, segments = 20, depthTest = true, layer = this._getDefaultDrawLayer()) {
@@ -1795,8 +1794,8 @@ class Application extends EventHandler {
      * @param {Layer} [layer] - The layer to render the sphere into. Defaults to {@link LAYERID_IMMEDIATE}.
      * @example
      * // Render a red wire aligned box
-     * var min = new pc.Vec3(-1, -1, -1);
-     * var max = new pc.Vec3(1, 1, 1);
+     * const min = new pc.Vec3(-1, -1, -1);
+     * const max = new pc.Vec3(1, 1, 1);
      * app.drawWireAlignedBox(min, max, pc.Color.RED);
      */
     drawWireAlignedBox(minPoint, maxPoint, color = Color.WHITE, depthTest = true, layer = this._getDefaultDrawLayer()) {

--- a/src/framework/components/camera/component.js
+++ b/src/framework/components/camera/component.js
@@ -43,7 +43,7 @@ const properties = [
  * @param {Entity} entity - The Entity that this Component is attached to.
  * @example
  * // Add a pc.CameraComponent to an entity
- * var entity = new pc.Entity();
+ * const entity = new pc.Entity();
  * entity.addComponent('camera', {
  *     nearClip: 1,
  *     farClip: 100,
@@ -51,7 +51,7 @@ const properties = [
  * });
  * @example
  * // Get the pc.CameraComponent on an entity
- * var cameraComponent = entity.camera;
+ * const cameraComponent = entity.camera;
  * @example
  * // Update a property on a camera component
  * entity.camera.nearClip = 2;
@@ -287,8 +287,8 @@ class CameraComponent extends Component {
      * @param {Vec3} [worldCoord] - 3D vector to receive world coordinate result.
      * @example
      * // Get the start and end points of a 3D ray fired from a screen click position
-     * var start = entity.camera.screenToWorld(clickX, clickY, entity.camera.nearClip);
-     * var end = entity.camera.screenToWorld(clickX, clickY, entity.camera.farClip);
+     * const start = entity.camera.screenToWorld(clickX, clickY, entity.camera.nearClip);
+     * const end = entity.camera.screenToWorld(clickX, clickY, entity.camera.farClip);
      *
      * // Use the ray coordinates to perform a raycast
      * app.systems.rigidbody.raycastFirst(start, end, function (result) {

--- a/src/framework/components/light/component.js
+++ b/src/framework/components/light/component.js
@@ -35,7 +35,7 @@ const _lightPropsDefault = [];
  * @param {Entity} entity - The Entity that this Component is attached to.
  * @example
  * // Add a pc.LightComponent to an entity
- * var entity = new pc.Entity();
+ * const entity = new pc.Entity();
  * entity.addComponent('light', {
  *     type: "omni",
  *     color: new pc.Color(1, 0, 0),
@@ -43,7 +43,7 @@ const _lightPropsDefault = [];
  * });
  * @example
  * // Get the pc.LightComponent on an entity
- * var lightComponent = entity.light;
+ * const lightComponent = entity.light;
  * @example
  * // Update a property on a light component
  * entity.light.range = 20;

--- a/src/framework/components/rigid-body/component.js
+++ b/src/framework/components/rigid-body/component.js
@@ -530,18 +530,18 @@ class RigidBodyComponent extends Component {
      * @example
      * // Apply a force at the body's center
      * // Calculate a force vector pointing in the world space direction of the entity
-     * var force = this.entity.forward.clone().mulScalar(100);
+     * const force = this.entity.forward.clone().mulScalar(100);
      *
      * // Apply the force
      * this.entity.rigidbody.applyForce(force);
      * @example
      * // Apply a force at some relative offset from the body's center
      * // Calculate a force vector pointing in the world space direction of the entity
-     * var force = this.entity.forward.clone().mulScalar(100);
+     * const force = this.entity.forward.clone().mulScalar(100);
      *
      * // Calculate the world space relative offset
-     * var relativePos = new pc.Vec3();
-     * var childEntity = this.entity.findByName('Engine');
+     * const relativePos = new pc.Vec3();
+     * const childEntity = this.entity.findByName('Engine');
      * relativePos.sub2(childEntity.getPosition(), this.entity.getPosition());
      *
      * // Apply the force
@@ -602,7 +602,7 @@ class RigidBodyComponent extends Component {
      * @param {number} [z] - The z-component of the torque force in world-space.
      * @example
      * // Apply via vector
-     * var torque = new pc.Vec3(0, 10, 0);
+     * const torque = new pc.Vec3(0, 10, 0);
      * entity.rigidbody.applyTorque(torque);
      * @example
      * // Apply via numbers
@@ -652,13 +652,13 @@ class RigidBodyComponent extends Component {
      * @param {number} [pz=0] - The z-component of the point at which to apply the impulse in the local-space of the entity.
      * @example
      * // Apply an impulse along the world-space positive y-axis at the entity's position.
-     * var impulse = new pc.Vec3(0, 10, 0);
+     * const impulse = new pc.Vec3(0, 10, 0);
      * entity.rigidbody.applyImpulse(impulse);
      * @example
      * // Apply an impulse along the world-space positive y-axis at 1 unit down the positive
      * // z-axis of the entity's local-space.
-     * var impulse = new pc.Vec3(0, 10, 0);
-     * var relativePoint = new pc.Vec3(0, 0, 1);
+     * const impulse = new pc.Vec3(0, 10, 0);
+     * const relativePoint = new pc.Vec3(0, 0, 1);
      * entity.rigidbody.applyImpulse(impulse, relativePoint);
      * @example
      * // Apply an impulse along the world-space positive y-axis at the entity's position.
@@ -729,7 +729,7 @@ class RigidBodyComponent extends Component {
      * @param {number} [z] - The z-component of the torque impulse in world-space.
      * @example
      * // Apply via vector
-     * var torque = new pc.Vec3(0, 10, 0);
+     * const torque = new pc.Vec3(0, 10, 0);
      * entity.rigidbody.applyTorqueImpulse(torque);
      * @example
      * // Apply via numbers
@@ -901,7 +901,7 @@ class RigidBodyComponent extends Component {
      * entity.rigidbody.teleport(0, 0, 0);
      * @example
      * // Teleport the entity to world-space coordinate [1, 2, 3] and reset orientation
-     * var position = new pc.Vec3(1, 2, 3);
+     * const position = new pc.Vec3(1, 2, 3);
      * entity.rigidbody.teleport(position, pc.Vec3.ZERO);
      * @example
      * // Teleport the entity to world-space coordinate [1, 2, 3] and reset orientation

--- a/src/framework/components/script/component.js
+++ b/src/framework/components/script/component.js
@@ -518,7 +518,7 @@ class ScriptComponent extends Component {
      * @param {string|Class<ScriptType>} nameOrType - The name or type of {@link ScriptType}.
      * @returns {ScriptType|null} If script is attached, the instance is returned. Otherwise null is returned.
      * @example
-     * var controller = entity.script.get('playerController');
+     * const controller = entity.script.get('playerController');
      */
     /* eslint-enable jsdoc/no-undefined-types */
     get(nameOrType) {

--- a/src/framework/components/sound/component.js
+++ b/src/framework/components/sound/component.js
@@ -189,7 +189,7 @@ class SoundComponent extends Component {
      * @returns {SoundSlot} The new slot.
      * @example
      * // get an asset by id
-     * var asset = app.assets.get(10);
+     * const asset = app.assets.get(10);
      * // add a slot
      * this.entity.sound.addSlot('beep', {
      *     asset: asset
@@ -255,7 +255,7 @@ class SoundComponent extends Component {
      * @param {string} name - The name of the {@link SoundSlot} to play.
      * @example
      * // get asset by id
-     * var asset = app.assets.get(10);
+     * const asset = app.assets.get(10);
      * // create a slot and play it
      * this.entity.sound.addSlot('beep', {
      *     asset: asset

--- a/src/framework/components/sound/slot.js
+++ b/src/framework/components/sound/slot.js
@@ -242,10 +242,10 @@ class SoundSlot extends EventHandler {
      * @param {AudioNode} [lastNode] - The last node that will be connected to the destination of the AudioContext.
      * If unspecified then the firstNode will be connected to the destination instead.
      * @example
-     * var context = app.systems.sound.context;
-     * var analyzer = context.createAnalyzer();
-     * var distortion = context.createWaveShaper();
-     * var filter = context.createBiquadFilter();
+     * const context = app.systems.sound.context;
+     * const analyzer = context.createAnalyzer();
+     * const distortion = context.createWaveShaper();
+     * const filter = context.createBiquadFilter();
      * analyzer.connect(distortion);
      * distortion.connect(filter);
      * slot.setExternalNodes(analyzer, filter);

--- a/src/framework/components/system.js
+++ b/src/framework/components/system.js
@@ -34,7 +34,7 @@ class ComponentSystem extends EventHandler {
      * @param {object} [data] - The source data with which to create the component.
      * @returns {Component} Returns a Component of type defined by the component system.
      * @example
-     * var entity = new pc.Entity(app);
+     * const entity = new pc.Entity(app);
      * app.systems.model.addComponent(entity, { type: 'box' });
      * // entity.model is now set to a pc.ModelComponent
      */

--- a/src/framework/components/zone/component.js
+++ b/src/framework/components/zone/component.js
@@ -32,7 +32,7 @@ class ZoneComponent extends Component {
      * @description Fired when Component becomes enabled
      * Note: this event does not take in account entity or any of its parent enabled state.
      * @example
-     * entity.zone.on('enable', function () {
+     * entity.zone.on('enable', () => {
      *     // component is enabled
      * });
      */
@@ -44,7 +44,7 @@ class ZoneComponent extends Component {
      * @description Fired when Component becomes disabled
      * Note: this event does not take in account entity or any of its parent enabled state.
      * @example
-     * entity.zone.on('disable', function () {
+     * entity.zone.on('disable', () => {
      *     // component is disabled
      * });
      */
@@ -57,7 +57,7 @@ class ZoneComponent extends Component {
      * Note: this event does not take in account entity or any of its parent enabled state.
      * @param {boolean} enabled - True if now enabled, False if disabled.
      * @example
-     * entity.zone.on('state', function (enabled) {
+     * entity.zone.on('state', (enabled) => {
      *     // component changed state
      * });
      */
@@ -68,7 +68,7 @@ class ZoneComponent extends Component {
      * @name ZoneComponent#remove
      * @description Fired when a zone is removed from an entity.
      * @example
-     * entity.zone.on('remove', function () {
+     * entity.zone.on('remove', () => {
      *     // zone has been removed from an entity
      * });
      */

--- a/src/framework/entity.js
+++ b/src/framework/entity.js
@@ -39,7 +39,7 @@ import { Application } from './application.js';
  * @property {SoundComponent} [sound] Gets the {@link SoundComponent} attached to this entity. [read only]
  * @property {SpriteComponent} [sprite] Gets the {@link SpriteComponent} attached to this entity. [read only]
  * @example
- * var entity = new pc.Entity();
+ * const entity = new pc.Entity();
  *
  * // Add a Component to the Entity
  * entity.addComponent("camera", {
@@ -55,11 +55,11 @@ import { Application } from './application.js';
  * entity.translate(10, 0, 0);
  *
  * // Or translate it by setting it's position directly
- * var p = entity.getPosition();
+ * const p = entity.getPosition();
  * entity.setPosition(p.x + 10, p.y, p.z);
  *
  * // Change the entity's rotation in local space
- * var e = entity.getLocalEulerAngles();
+ * const e = entity.getLocalEulerAngles();
  * entity.setLocalEulerAngles(e.x, e.y + 90, e.z);
  *
  * // Or use rotateLocal
@@ -123,7 +123,7 @@ class Entity extends GraphNode {
      * @returns {Component} The new Component that was attached to the entity or null if there
      * was an error.
      * @example
-     * var entity = new pc.Entity();
+     * const entity = new pc.Entity();
      *
      * // Add a light component with default properties
      * entity.addComponent("light");
@@ -157,7 +157,7 @@ class Entity extends GraphNode {
      * @description Remove a component from the Entity.
      * @param {string} type - The name of the Component type.
      * @example
-     * var entity = new pc.Entity();
+     * const entity = new pc.Entity();
      * entity.addComponent("light"); // add new light component
      *
      * entity.removeComponent("light"); // remove light component
@@ -188,7 +188,7 @@ class Entity extends GraphNode {
      * one. Returns undefined otherwise.
      * @example
      * // Get the first found light component in the hierarchy tree that starts with this entity
-     * var light = entity.findComponent("light");
+     * const light = entity.findComponent("light");
      */
     findComponent(type) {
         const entity = this.findOne(function (node) {
@@ -206,7 +206,7 @@ class Entity extends GraphNode {
      * Returns empty array if none found.
      * @example
      * // Get all light components in the hierarchy tree that starts with this entity
-     * var lights = entity.findComponents("light");
+     * const lights = entity.findComponents("light");
      */
     findComponents(type) {
         const entities = this.find(function (node) {
@@ -335,7 +335,7 @@ class Entity extends GraphNode {
      * @name Entity#destroy
      * @description Remove all components from the Entity and detach it from the Entity hierarchy. Then recursively destroy all ancestor Entities.
      * @example
-     * var firstChild = this.entity.children[0];
+     * const firstChild = this.entity.children[0];
      * firstChild.destroy(); // delete child, all components and remove from hierarchy
      */
     destroy() {
@@ -391,7 +391,7 @@ class Entity extends GraphNode {
      * Note, this Entity is not in the hierarchy and must be added manually.
      * @returns {Entity} A new Entity which is a deep copy of the original.
      * @example
-     * var e = this.entity.clone();
+     * const e = this.entity.clone();
      *
      * // Add clone as a sibling to the original
      * this.entity.parent.addChild(e);
@@ -502,7 +502,7 @@ function resolveDuplicatedEntityReferenceProperties(oldSubtreeRoot, oldEntity, n
  * @description Fired after the entity is destroyed.
  * @param {Entity} entity - The entity that was destroyed.
  * @example
- * entity.on("destroy", function (e) {
+ * entity.on("destroy", (e) => {
  *     console.log('entity ' + e.name + ' has been destroyed');
  * });
  */

--- a/src/framework/scene-registry.js
+++ b/src/framework/scene-registry.js
@@ -189,9 +189,8 @@ class SceneRegistry {
      * @param {callbacks.LoadSceneData} callback - The function to call after loading,
      * passed (err, sceneItem) where err is null if no errors occurred.
      * @example
-     *
-     * var sceneItem = app.scenes.find("Scene Name");
-     * app.scenes.loadSceneData(sceneItem, function (err, sceneItem) {
+     * const sceneItem = app.scenes.find("Scene Name");
+     * app.scenes.loadSceneData(sceneItem, (err, sceneItem) => {
      *     if (err) {
      *         // error
      *     }
@@ -207,8 +206,7 @@ class SceneRegistry {
      * @description Unloads scene data that has been loaded previously using {@link SceneRegistry#loadSceneData}.
      * @param {SceneRegistryItem | string} sceneItem - The scene item (which can be found with {@link SceneRegistry#find} or URL of the scene file. Usually this will be "scene_id.json".
      * @example
-     *
-     * var sceneItem = app.scenes.find("Scene Name");
+     * const sceneItem = app.scenes.find("Scene Name");
      * app.scenes.unloadSceneData(sceneItem);
      */
     unloadSceneData(sceneItem) {
@@ -230,11 +228,10 @@ class SceneRegistry {
      * @param {callbacks.LoadHierarchy} callback - The function to call after loading,
      * passed (err, entity) where err is null if no errors occurred.
      * @example
-     *
-     * var sceneItem = app.scenes.find("Scene Name");
-     * app.scenes.loadSceneHierarchy(sceneItem, function (err, entity) {
+     * const sceneItem = app.scenes.find("Scene Name");
+     * app.scenes.loadSceneHierarchy(sceneItem, (err, entity) => {
      *     if (!err) {
-     *         var e = app.root.find("My New Entity");
+     *         const e = app.root.find("My New Entity");
      *     } else {
      *         // error
      *     }
@@ -289,11 +286,10 @@ class SceneRegistry {
      * @param {callbacks.LoadSettings} callback - The function called after the settings
      * are applied. Passed (err) where err is null if no error occurred.
      * @example
-     *
-     * var sceneItem = app.scenes.find("Scene Name");
-     * app.scenes.loadSceneHierarchy(sceneItem, function (err, entity) {
+     * const sceneItem = app.scenes.find("Scene Name");
+     * app.scenes.loadSceneHierarchy(sceneItem, (err, entity) => {
      *     if (!err) {
-     *         var e = app.root.find("My New Entity");
+     *         const e = app.root.find("My New Entity");
      *     } else {
      *         // error
      *     }

--- a/src/graphics/graphics-device.js
+++ b/src/graphics/graphics-device.js
@@ -2635,7 +2635,7 @@ class GraphicsDevice extends EventHandler {
      * @returns {RenderTarget} The current render target.
      * @example
      * // Get the current render target
-     * var renderTarget = device.getRenderTarget();
+     * const renderTarget = device.getRenderTarget();
      */
     getRenderTarget() {
         return this.renderTarget;
@@ -2647,7 +2647,7 @@ class GraphicsDevice extends EventHandler {
      * @description Queries whether depth testing is enabled.
      * @returns {boolean} True if depth testing is enabled and false otherwise.
      * @example
-     * var depthTest = device.getDepthTest();
+     * const depthTest = device.getDepthTest();
      * console.log('Depth testing is ' + depthTest ? 'enabled' : 'disabled');
      */
     getDepthTest() {
@@ -2701,7 +2701,7 @@ class GraphicsDevice extends EventHandler {
      * @description Queries whether writes to the depth buffer are enabled.
      * @returns {boolean} True if depth writing is enabled and false otherwise.
      * @example
-     * var depthWrite = device.getDepthWrite();
+     * const depthWrite = device.getDepthWrite();
      * console.log('Depth writing is ' + depthWrite ? 'enabled' : 'disabled');
      */
     getDepthWrite() {

--- a/src/graphics/index-buffer.js
+++ b/src/graphics/index-buffer.js
@@ -12,15 +12,6 @@ import {
  *
  * Typically, index buffers are set on {@link Mesh} objects.
  * @description Creates a new index buffer.
- * @example
- * // Create an index buffer holding 3 16-bit indices. The buffer is marked as
- * // static, hinting that the buffer will never be modified.
- * var indices = new UInt16Array([0, 1, 2]);
- * var indexBuffer = new pc.IndexBuffer(graphicsDevice,
- *                                      pc.INDEXFORMAT_UINT16,
- *                                      3,
- *                                      pc.BUFFER_STATIC,
- *                                      indices);
  * @param {GraphicsDevice} graphicsDevice - The graphics device used to
  * manage this index buffer.
  * @param {number} format - The type of each index to be stored in the index
@@ -40,6 +31,11 @@ import {
  * Defaults to {@link BUFFER_STATIC}.
  * @param {ArrayBuffer} [initialData] - Initial data. If left unspecified, the
  * index buffer will be initialized to zeros.
+ * @example
+ * // Create an index buffer holding 3 16-bit indices. The buffer is marked as
+ * // static, hinting that the buffer will never be modified.
+ * const indices = new UInt16Array([0, 1, 2]);
+ * const indexBuffer = new pc.IndexBuffer(graphicsDevice, pc.INDEXFORMAT_UINT16, 3, pc.BUFFER_STATIC, indices);
  */
 class IndexBuffer {
     constructor(graphicsDevice, format, numIndices, usage = BUFFER_STATIC, initialData) {
@@ -183,7 +179,7 @@ class IndexBuffer {
     setData(data) {
         if (data.byteLength !== this.numBytes) {
             // #if _DEBUG
-            console.error("IndexBuffer: wrong initial data size: expected " + this.numBytes + ", got " + data.byteLength);
+            console.error(`IndexBuffer: wrong initial data size: expected ${this.numBytes}, got ${data.byteLength}`);
             // #endif
             return false;
         }

--- a/src/graphics/render-target.js
+++ b/src/graphics/render-target.js
@@ -38,12 +38,12 @@ const defaultOptions = {
  * Defaults to {@link CUBEFACE_POSX}.
  * @example
  * // Create a 512x512x24-bit render target with a depth buffer
- * var colorBuffer = new pc.Texture(graphicsDevice, {
+ * const colorBuffer = new pc.Texture(graphicsDevice, {
  *     width: 512,
  *     height: 512,
  *     format: pc.PIXELFORMAT_R8_G8_B8
  * });
- * var renderTarget = new pc.RenderTarget({
+ * const renderTarget = new pc.RenderTarget({
  *     colorBuffer: colorBuffer,
  *     depth: true
  * });

--- a/src/graphics/shader.js
+++ b/src/graphics/shader.js
@@ -18,7 +18,7 @@
  * @param {boolean} [definition.useTransformFeedback] - Specifies that this shader outputs post-VS data to a buffer.
  * @example
  * // Create a shader that renders primitives with a solid red color
- * var shaderDefinition = {
+ * const shaderDefinition = {
  *     attributes: {
  *         aPosition: pc.SEMANTIC_POSITION
  *     },
@@ -40,7 +40,7 @@
  *     ].join("\n")
  * };
  *
- * var shader = new pc.Shader(graphicsDevice, shaderDefinition);
+ * const shader = new pc.Shader(graphicsDevice, shaderDefinition);
  */
 class Shader {
     constructor(graphicsDevice, definition) {

--- a/src/graphics/texture.js
+++ b/src/graphics/texture.js
@@ -93,17 +93,17 @@ let _blockSizeTable = null;
  * * {@link FUNC_NOTEQUAL}
  * @example
  * // Create a 8x8x24-bit texture
- * var texture = new pc.Texture(graphicsDevice, {
+ * const texture = new pc.Texture(graphicsDevice, {
  *     width: 8,
  *     height: 8,
  *     format: pc.PIXELFORMAT_R8_G8_B8
  * });
  *
  * // Fill the texture with a gradient
- * var pixels = texture.lock();
- * var count = 0;
- * for (var i = 0; i < 8; i++) {
- *     for (var j = 0; j < 8; j++) {
+ * const pixels = texture.lock();
+ * let count = 0;
+ * for (let i = 0; i < 8; i++) {
+ *     for (let j = 0; j < 8; j++) {
  *         pixels[count++] = i * 32;
  *         pixels[count++] = j * 32;
  *         pixels[count++] = 255;

--- a/src/graphics/vertex-format.js
+++ b/src/graphics/vertex-format.js
@@ -94,12 +94,12 @@ import {
  * @property {number} elements[].size The size of the attribute in bytes.
  * @example
  * // Specify 3-component positions (x, y, z)
- * var vertexFormat = new pc.VertexFormat(graphicsDevice, [
+ * const vertexFormat = new pc.VertexFormat(graphicsDevice, [
  *     { semantic: pc.SEMANTIC_POSITION, components: 3, type: pc.TYPE_FLOAT32 }
  * ]);
  * @example
  * // Specify 2-component positions (x, y), a texture coordinate (u, v) and a vertex color (r, g, b, a)
- * var vertexFormat = new pc.VertexFormat(graphicsDevice, [
+ * const vertexFormat = new pc.VertexFormat(graphicsDevice, [
  *     { semantic: pc.SEMANTIC_POSITION, components: 2, type: pc.TYPE_FLOAT32 },
  *     { semantic: pc.SEMANTIC_TEXCOORD0, components: 2, type: pc.TYPE_FLOAT32 },
  *     { semantic: pc.SEMANTIC_COLOR, components: 4, type: pc.TYPE_UINT8, normalize: true }

--- a/src/graphics/vertex-iterator.js
+++ b/src/graphics/vertex-iterator.js
@@ -241,7 +241,7 @@ class VertexIterator {
      * @description Moves the vertex iterator on to the next vertex.
      * @param {number} [count] - Optional number of steps to move on when calling next. Defaults to 1.
      * @example
-     * var iterator = new pc.VertexIterator(vertexBuffer);
+     * const iterator = new pc.VertexIterator(vertexBuffer);
      * iterator.element[pc.SEMANTIC_POSTIION].set(-0.9, -0.9, 0.0);
      * iterator.element[pc.SEMANTIC_COLOR].set(255, 0, 0, 255);
      * iterator.next();
@@ -268,7 +268,7 @@ class VertexIterator {
      * @description Notifies the vertex buffer being iterated that writes are complete. Internally
      * the vertex buffer is unlocked and vertex data is uploaded to video memory.
      * @example
-     * var iterator = new pc.VertexIterator(vertexBuffer);
+     * const iterator = new pc.VertexIterator(vertexBuffer);
      * iterator.element[pc.SEMANTIC_POSTIION].set(-0.9, -0.9, 0.0);
      * iterator.element[pc.SEMANTIC_COLOR].set(255, 0, 0, 255);
      * iterator.next();

--- a/src/i18n/i18n.js
+++ b/src/i18n/i18n.js
@@ -53,8 +53,8 @@ class I18n extends EventHandler {
      * @returns {string} The locale found or if no locale is available returns the default en-US locale.
      * @example
      * // With a defined dictionary of locales
-     * var availableLocales = { en: 'en-US', fr: 'fr-FR' };
-     * var locale = pc.I18n.getText('en-US', availableLocales);
+     * const availableLocales = { en: 'en-US', fr: 'fr-FR' };
+     * const locale = pc.I18n.getText('en-US', availableLocales);
      * // returns 'en'
      */
     static findAvailableLocale(desiredLocale, availableLocales) {
@@ -70,7 +70,7 @@ class I18n extends EventHandler {
      * @param {string} desiredLocale - The desired locale e.g. en-US.
      * @returns {string} The locale found or if no locale is available returns the default en-US locale.
      * @example
-     * var locale = this.app.i18n.getText('en-US');
+     * const locale = this.app.i18n.getText('en-US');
      */
     findAvailableLocale(desiredLocale) {
         if (this._translations[desiredLocale]) {
@@ -91,8 +91,8 @@ class I18n extends EventHandler {
      * @returns {string} The translated text. If no translations are found at all for the locale then it will return
      * the en-US translation. If no translation exists for that key then it will return the localization key.
      * @example
-     * var localized = this.app.i18n.getText('localization-key');
-     * var localizedFrench = this.app.i18n.getText('localization-key', 'fr-FR');
+     * const localized = this.app.i18n.getText('localization-key');
+     * const localizedFrench = this.app.i18n.getText('localization-key', 'fr-FR');
      */
     getText(key, locale) {
         // default translation is the key
@@ -143,7 +143,7 @@ class I18n extends EventHandler {
      * the en-US translation. If no translation exists for that key then it will return the localization key.
      * @example
      * // manually replace {number} in the resulting translation with our number
-     * var localized = this.app.i18n.getPluralText('{number} apples', number).replace("{number}", number);
+     * const localized = this.app.i18n.getPluralText('{number} apples', number).replace("{number}", number);
      */
     getPluralText(key, n, locale) {
         // default translation is the key

--- a/src/input/controller.js
+++ b/src/input/controller.js
@@ -22,7 +22,7 @@ import { Mouse } from './mouse.js';
  * @param {Mouse} [options.mouse] - A Mouse object to use.
  * @param {GamePads} [options.gamepads] - A Gamepads object to use.
  * @example
- * var c = new pc.Controller(document);
+ * const c = new pc.Controller(document);
  *
  * // Register the "fire" action and assign it to both the Enter key and the Spacebar.
  * c.registerKeys("fire", [pc.KEY_ENTER, pc.KEY_SPACE]);

--- a/src/input/game-pads.js
+++ b/src/input/game-pads.js
@@ -127,8 +127,8 @@ class GamePads {
      * returned by this function.
      * @returns {object[]} An array of gamepads and mappings for the model of gamepad that is attached.
      * @example
-     * var gamepads = new pc.GamePads();
-     * var pads = gamepads.poll();
+     * const gamepads = new pc.GamePads();
+     * const pads = gamepads.poll();
      */
     poll(pads = []) {
         if (pads.length > 0) {

--- a/src/input/keyboard-event.js
+++ b/src/input/keyboard-event.js
@@ -9,7 +9,7 @@
  * @property {Element} element The element that fired the keyboard event.
  * @property {KeyboardEvent} event The original browser event which was fired.
  * @example
- * var onKeyDown = function (e) {
+ * const onKeyDown = (e) => {
  *     if (e.key === pc.KEY_SPACE) {
  *         // space key pressed
  *     }

--- a/src/input/keyboard.js
+++ b/src/input/keyboard.js
@@ -51,7 +51,7 @@ const _keyCodeToKeyIdentifier = {
  * @description Event fired when a key is pressed.
  * @param {KeyboardEvent} event - The Keyboard event object. Note, this event is only valid for the current callback.
  * @example
- * var onKeyDown = function (e) {
+ * const onKeyDown = (e) => {
  *     if (e.key === pc.KEY_SPACE) {
  *         // space key pressed
  *     }
@@ -66,7 +66,7 @@ const _keyCodeToKeyIdentifier = {
  * @description Event fired when a key is released.
  * @param {KeyboardEvent} event - The Keyboard event object. Note, this event is only valid for the current callback.
  * @example
- * var onKeyUp = function (e) {
+ * const onKeyUp = (e) => {
  *     if (e.key === pc.KEY_SPACE) {
  *         // space key released
  *     }
@@ -88,7 +88,7 @@ const _keyCodeToKeyIdentifier = {
  * @param {boolean} [options.preventDefault] - Call preventDefault() in key event handlers. This stops the default action of the event occurring. e.g. Ctrl+T will not open a new browser tab
  * @param {boolean} [options.stopPropagation] - Call stopPropagation() in key event handlers. This stops the event bubbling up the DOM so no parent handlers will be notified of the event
  * @example
- * var keyboard = new pc.Keyboard(window); // attach keyboard listeners to the window
+ * const keyboard = new pc.Keyboard(window); // attach keyboard listeners to the window
  */
 class Keyboard extends EventHandler {
     constructor(element, options = {}) {

--- a/src/math/color.js
+++ b/src/math/color.js
@@ -47,8 +47,8 @@ class Color {
      * @param {Color} rhs - A color to copy to the specified color.
      * @returns {Color} Self for chaining.
      * @example
-     * var src = new pc.Color(1, 0, 0, 1);
-     * var dst = new pc.Color();
+     * const src = new pc.Color(1, 0, 0, 1);
+     * const dst = new pc.Color();
      *
      * dst.copy(src);
      *
@@ -70,8 +70,8 @@ class Color {
      * @param {Color} rhs - The color to compare to the specified color.
      * @returns {boolean} True if the colors are equal and false otherwise.
      * @example
-     * var a = new pc.Color(1, 0, 0, 1);
-     * var b = new pc.Color(1, 1, 0, 1);
+     * const a = new pc.Color(1, 0, 0, 1);
+     * const b = new pc.Color(1, 1, 0, 1);
      * console.log("The two colors are " + (a.equals(b) ? "equal" : "different"));
      */
     equals(rhs) {
@@ -108,9 +108,9 @@ class Color {
      * a ray extrapolated from this line.
      * @returns {Color} Self for chaining.
      * @example
-     * var a = new pc.Color(0, 0, 0);
-     * var b = new pc.Color(1, 1, 0.5);
-     * var r = new pc.Color();
+     * const a = new pc.Color(0, 0, 0);
+     * const b = new pc.Color(1, 1, 0.5);
+     * const r = new pc.Color();
      *
      * r.lerp(a, b, 0);   // r is equal to a
      * r.lerp(a, b, 0.5); // r is 0.5, 0.5, 0.25
@@ -157,7 +157,7 @@ class Color {
      * @param {boolean} alpha - If true, the output string will include the alpha value.
      * @returns {string} The color in string form.
      * @example
-     * var c = new pc.Color(1, 1, 1);
+     * const c = new pc.Color(1, 1, 1);
      * // Outputs #ffffffff
      * console.log(c.toString());
      */

--- a/src/math/curve-set.js
+++ b/src/math/curve-set.js
@@ -10,7 +10,7 @@ import { CurveEvaluator } from './curve-evaluator.js';
  * @param {Array<number[]>} curveKeys - An array of arrays of keys (pairs of numbers with
  * the time first and value second).
  * @example
- * var curveSet = new pc.CurveSet([
+ * const curveSet = new pc.CurveSet([
  *     [
  *         0, 0,        // At 0 time, value of 0
  *         0.33, 2,     // At 0.33 time, value of 2

--- a/src/math/curve.js
+++ b/src/math/curve.js
@@ -25,7 +25,7 @@ import { CurveEvaluator } from './curve-evaluator.js';
  * interpolation) and 1 results in a very smooth curve. Use 0.5 for a Catmull-rom spline.
  *
  * @example
- * var curve = new pc.Curve([
+ * const curve = new pc.Curve([
  *     0, 0,        // At 0 time, value of 0
  *     0.33, 2,     // At 0.33 time, value of 2
  *     0.66, 2.6,   // At 0.66 time, value of 2.6

--- a/src/math/mat3.js
+++ b/src/math/mat3.js
@@ -22,8 +22,8 @@ class Mat3 {
      * @description Creates a duplicate of the specified matrix.
      * @returns {Mat3} A duplicate matrix.
      * @example
-     * var src = new pc.Mat3().translate(10, 20, 30);
-     * var dst = src.clone();
+     * const src = new pc.Mat3().translate(10, 20, 30);
+     * const dst = src.clone();
      * console.log("The two matrices are " + (src.equals(dst) ? "equal" : "different"));
      */
     clone() {
@@ -37,8 +37,8 @@ class Mat3 {
      * @param {Mat3} rhs - A 3x3 matrix to be copied.
      * @returns {Mat3} Self for chaining.
      * @example
-     * var src = new pc.Mat3().translate(10, 20, 30);
-     * var dst = new pc.Mat3();
+     * const src = new pc.Mat3().translate(10, 20, 30);
+     * const dst = new pc.Mat3();
      * dst.copy(src);
      * console.log("The two matrices are " + (src.equals(dst) ? "equal" : "different"));
      */
@@ -66,7 +66,7 @@ class Mat3 {
      * @param {number[]} src - An array[9] to be copied.
      * @returns {Mat3} Self for chaining.
      * @example
-     * var dst = new pc.Mat3();
+     * const dst = new pc.Mat3();
      * dst.set([0, 1, 2, 3, 4, 5, 6, 7, 8]);
      */
     set(src) {
@@ -92,8 +92,8 @@ class Mat3 {
      * @description Reports whether two matrices are equal.
      * @returns {boolean} True if the matrices are equal and false otherwise.
      * @example
-     * var a = new pc.Mat3().translate(10, 20, 30);
-     * var b = new pc.Mat3();
+     * const a = new pc.Mat3().translate(10, 20, 30);
+     * const b = new pc.Mat3();
      * console.log("The two matrices are " + (a.equals(b) ? "equal" : "different"));
      */
     equals(rhs) {
@@ -117,7 +117,7 @@ class Mat3 {
      * @description Reports whether the specified matrix is the identity matrix.
      * @returns {boolean} True if the matrix is identity and false otherwise.
      * @example
-     * var m = new pc.Mat3();
+     * const m = new pc.Mat3();
      * console.log("The matrix is " + (m.isIdentity() ? "identity" : "not identity"));
      */
     isIdentity() {
@@ -165,7 +165,7 @@ class Mat3 {
      * @description Converts the matrix to string form.
      * @returns {string} The matrix in string form.
      * @example
-     * var m = new pc.Mat3();
+     * const m = new pc.Mat3();
      * // Outputs [1, 0, 0, 0, 1, 0, 0, 0, 1]
      * console.log(m.toString());
      */
@@ -185,7 +185,7 @@ class Mat3 {
      * @description Generates the transpose of the specified 3x3 matrix.
      * @returns {Mat3} Self for chaining.
      * @example
-     * var m = new pc.Mat3();
+     * const m = new pc.Mat3();
      *
      * // Transpose in place
      * m.transpose();

--- a/src/math/mat4.js
+++ b/src/math/mat4.js
@@ -46,7 +46,7 @@ class Mat4 {
      * @param {Mat4} rhs - The 4x4 matrix used as the second operand of the addition.
      * @returns {Mat4} Self for chaining.
      * @example
-     * var m = new pc.Mat4();
+     * const m = new pc.Mat4();
      *
      * m.add2(pc.Mat4.IDENTITY, pc.Mat4.ONE);
      *
@@ -84,7 +84,7 @@ class Mat4 {
      * @param {Mat4} rhs - The 4x4 matrix used as the second operand of the addition.
      * @returns {Mat4} Self for chaining.
      * @example
-     * var m = new pc.Mat4();
+     * const m = new pc.Mat4();
      *
      * m.add(pc.Mat4.ONE);
      *
@@ -100,8 +100,8 @@ class Mat4 {
      * @description Creates a duplicate of the specified matrix.
      * @returns {Mat4} A duplicate matrix.
      * @example
-     * var src = new pc.Mat4().setFromEulerAngles(10, 20, 30);
-     * var dst = src.clone();
+     * const src = new pc.Mat4().setFromEulerAngles(10, 20, 30);
+     * const dst = src.clone();
      * console.log("The two matrices are " + (src.equals(dst) ? "equal" : "different"));
      */
     clone() {
@@ -115,8 +115,8 @@ class Mat4 {
      * @param {Mat4} rhs - A 4x4 matrix to be copied.
      * @returns {Mat4} Self for chaining.
      * @example
-     * var src = new pc.Mat4().setFromEulerAngles(10, 20, 30);
-     * var dst = new pc.Mat4();
+     * const src = new pc.Mat4().setFromEulerAngles(10, 20, 30);
+     * const dst = new pc.Mat4();
      * dst.copy(src);
      * console.log("The two matrices are " + (src.equals(dst) ? "equal" : "different"));
      */
@@ -151,8 +151,8 @@ class Mat4 {
      * @param {Mat4} rhs - The other matrix.
      * @returns {boolean} True if the matrices are equal and false otherwise.
      * @example
-     * var a = new pc.Mat4().setFromEulerAngles(10, 20, 30);
-     * var b = new pc.Mat4();
+     * const a = new pc.Mat4().setFromEulerAngles(10, 20, 30);
+     * const b = new pc.Mat4();
      * console.log("The two matrices are " + (a.equals(b) ? "equal" : "different"));
      */
     equals(rhs) {
@@ -183,7 +183,7 @@ class Mat4 {
      * @description Reports whether the specified matrix is the identity matrix.
      * @returns {boolean} True if the matrix is identity and false otherwise.
      * @example
-     * var m = new pc.Mat4();
+     * const m = new pc.Mat4();
      * console.log("The matrix is " + (m.isIdentity() ? "identity" : "not identity"));
      */
     isIdentity() {
@@ -216,9 +216,9 @@ class Mat4 {
      * @param {Mat4} rhs - The 4x4 matrix used as the second multiplicand of the operation.
      * @returns {Mat4} Self for chaining.
      * @example
-     * var a = new pc.Mat4().setFromEulerAngles(10, 20, 30);
-     * var b = new pc.Mat4().setFromAxisAngle(pc.Vec3.UP, 180);
-     * var r = new pc.Mat4();
+     * const a = new pc.Mat4().setFromEulerAngles(10, 20, 30);
+     * const b = new pc.Mat4().setFromAxisAngle(pc.Vec3.UP, 180);
+     * const r = new pc.Mat4();
      *
      * // r = a * b
      * r.mul2(a, b);
@@ -361,8 +361,8 @@ class Mat4 {
      * @param {Mat4} rhs - The 4x4 matrix used as the second multiplicand of the operation.
      * @returns {Mat4} Self for chaining.
      * @example
-     * var a = new pc.Mat4().setFromEulerAngles(10, 20, 30);
-     * var b = new pc.Mat4().setFromAxisAngle(pc.Vec3.UP, 180);
+     * const a = new pc.Mat4().setFromEulerAngles(10, 20, 30);
+     * const b = new pc.Mat4().setFromAxisAngle(pc.Vec3.UP, 180);
      *
      * // a = a * b
      * a.mul(b);
@@ -382,12 +382,12 @@ class Mat4 {
      * @returns {Vec3} The input point v transformed by the current instance.
      * @example
      * // Create a 3-dimensional point
-     * var v = new pc.Vec3(1, 2, 3);
+     * const v = new pc.Vec3(1, 2, 3);
      *
      * // Create a 4x4 rotation matrix
-     * var m = new pc.Mat4().setFromEulerAngles(10, 20, 30);
+     * const m = new pc.Mat4().setFromEulerAngles(10, 20, 30);
      *
-     * var tv = m.transformPoint(v);
+     * const tv = m.transformPoint(v);
      */
     transformPoint(vec, res = new Vec3()) {
         const m = this.data;
@@ -412,12 +412,12 @@ class Mat4 {
      * @returns {Vec3} The input vector v transformed by the current instance.
      * @example
      * // Create a 3-dimensional vector
-     * var v = new pc.Vec3(1, 2, 3);
+     * const v = new pc.Vec3(1, 2, 3);
      *
      * // Create a 4x4 rotation matrix
-     * var m = new pc.Mat4().setFromEulerAngles(10, 20, 30);
+     * const m = new pc.Mat4().setFromEulerAngles(10, 20, 30);
      *
-     * var tv = m.transformVector(v);
+     * const tv = m.transformVector(v);
      */
     transformVector(vec, res = new Vec3()) {
         const m = this.data;
@@ -442,13 +442,13 @@ class Mat4 {
      * @returns {Vec4} The input vector v transformed by the current instance.
      * @example
      * // Create an input 4-dimensional vector
-     * var v = new pc.Vec4(1, 2, 3, 4);
+     * const v = new pc.Vec4(1, 2, 3, 4);
      *
      * // Create an output 4-dimensional vector
-     * var result = new pc.Vec4();
+     * const result = new pc.Vec4();
      *
      * // Create a 4x4 rotation matrix
-     * var m = new pc.Mat4().setFromEulerAngles(10, 20, 30);
+     * const m = new pc.Mat4().setFromEulerAngles(10, 20, 30);
      *
      * m.transformVec4(v, result);
      */
@@ -482,10 +482,10 @@ class Mat4 {
      * @param {Vec3} up - 3-d vector holding the up direction.
      * @returns {Mat4} Self for chaining.
      * @example
-     * var position = new pc.Vec3(10, 10, 10);
-     * var target = new pc.Vec3(0, 0, 0);
-     * var up = new pc.Vec3(0, 1, 0);
-     * var m = new pc.Mat4().setLookAt(position, target, up);
+     * const position = new pc.Vec3(10, 10, 10);
+     * const target = new pc.Vec3(0, 0, 0);
+     * const up = new pc.Vec3(0, 1, 0);
+     * const m = new pc.Mat4().setLookAt(position, target, up);
      */
     setLookAt(position, target, up) {
         z.sub2(position, target).normalize();
@@ -530,7 +530,7 @@ class Mat4 {
      * @returns {Mat4} Self for chaining.
      * @example
      * // Create a 4x4 perspective projection matrix
-     * var f = pc.Mat4().setFrustum(-2, 2, -1, 1, 1, 1000);
+     * const f = pc.Mat4().setFrustum(-2, 2, -1, 1, 1, 1000);
      */
     setFrustum(left, right, bottom, top, znear, zfar) {
         const temp1 = 2 * znear;
@@ -575,7 +575,7 @@ class Mat4 {
      * @returns {Mat4} Self for chaining.
      * @example
      * // Create a 4x4 perspective projection matrix
-     * var persp = pc.Mat4().setPerspective(45, 16 / 9, 1, 1000);
+     * const persp = pc.Mat4().setPerspective(45, 16 / 9, 1, 1000);
      */
     setPerspective(fov, aspect, znear, zfar, fovIsHorizontal) {
         Mat4._getPerspectiveHalfSize(_halfSize, fov, aspect, znear, fovIsHorizontal);
@@ -596,7 +596,7 @@ class Mat4 {
      * @returns {Mat4} Self for chaining.
      * @example
      * // Create a 4x4 orthographic projection matrix
-     * var ortho = pc.Mat4().ortho(-2, 2, -2, 2, 1, 1000);
+     * const ortho = pc.Mat4().ortho(-2, 2, -2, 2, 1, 1000);
      */
     setOrtho(left, right, bottom, top, near, far) {
         const r = this.data;
@@ -631,7 +631,7 @@ class Mat4 {
      * @returns {Mat4} Self for chaining.
      * @example
      * // Create a 4x4 rotation matrix
-     * var rm = new pc.Mat4().setFromAxisAngle(pc.Vec3.UP, 90);
+     * const rm = new pc.Mat4().setFromAxisAngle(pc.Vec3.UP, 90);
      */
     setFromAxisAngle(axis, angle) {
         angle *= math.DEG_TO_RAD;
@@ -677,7 +677,7 @@ class Mat4 {
      * @returns {Mat4} Self for chaining.
      * @example
      * // Create a 4x4 translation matrix
-     * var tm = new pc.Mat4().setTranslate(10, 10, 10);
+     * const tm = new pc.Mat4().setTranslate(10, 10, 10);
      */
     setTranslate(x, y, z) {
         const m = this.data;
@@ -713,7 +713,7 @@ class Mat4 {
      * @returns {Mat4} Self for chaining.
      * @example
      * // Create a 4x4 scale matrix
-     * var sm = new pc.Mat4().setScale(10, 10, 10);
+     * const sm = new pc.Mat4().setScale(10, 10, 10);
      */
     setScale(x, y, z) {
         const m = this.data;
@@ -752,7 +752,7 @@ class Mat4 {
      * @returns {Mat4} Self for chaining.
      * @example
      * // Create a 4x4 viewport matrix which scales normalized view volume to full texture viewport.
-     * var vm = new pc.Mat4().setViewport(0, 0, 1, 1);
+     * const vm = new pc.Mat4().setViewport(0, 0, 1, 1);
      */
     setViewport(x, y, width, height) {
         const m = this.data;
@@ -784,7 +784,7 @@ class Mat4 {
      * @returns {Mat4} Self for chaining.
      * @example
      * // Create a 4x4 rotation matrix of 180 degrees around the y-axis
-     * var rot = new pc.Mat4().setFromAxisAngle(pc.Vec3.UP, 180);
+     * const rot = new pc.Mat4().setFromAxisAngle(pc.Vec3.UP, 180);
      *
      * // Invert in place
      * rot.invert();
@@ -921,11 +921,11 @@ class Mat4 {
      * @param {Vec3} s - A 3-d vector scale.
      * @returns {Mat4} Self for chaining.
      * @example
-     * var t = new pc.Vec3(10, 20, 30);
-     * var r = new pc.Quat();
-     * var s = new pc.Vec3(2, 2, 2);
+     * const t = new pc.Vec3(10, 20, 30);
+     * const r = new pc.Quat();
+     * const s = new pc.Vec3(2, 2, 2);
      *
-     * var m = new pc.Mat4();
+     * const m = new pc.Mat4();
      * m.setTRS(t, r, s);
      */
     setTRS(t, r, s) {
@@ -982,7 +982,7 @@ class Mat4 {
      * @description Sets the specified matrix to its transpose.
      * @returns {Mat4} Self for chaining.
      * @example
-     * var m = new pc.Mat4();
+     * const m = new pc.Mat4();
      *
      * // Transpose in place
      * m.transpose();
@@ -1072,10 +1072,10 @@ class Mat4 {
      * @returns {Vec3} The translation of the specified 4x4 matrix.
      * @example
      * // Create a 4x4 matrix
-     * var m = new pc.Mat4();
+     * const m = new pc.Mat4();
      *
      * // Query the z-axis component
-     * var t = new pc.Vec3();
+     * const t = new pc.Vec3();
      * m.getTranslation(t);
      */
     getTranslation(t = new Vec3()) {
@@ -1090,10 +1090,10 @@ class Mat4 {
      * @returns {Vec3} The x-axis of the specified 4x4 matrix.
      * @example
      * // Create a 4x4 matrix
-     * var m = new pc.Mat4();
+     * const m = new pc.Mat4();
      *
      * // Query the z-axis component
-     * var x = new pc.Vec3();
+     * const x = new pc.Vec3();
      * m.getX(x);
      */
     getX(x = new Vec3()) {
@@ -1108,10 +1108,10 @@ class Mat4 {
      * @returns {Vec3} The y-axis of the specified 4x4 matrix.
      * @example
      * // Create a 4x4 matrix
-     * var m = new pc.Mat4();
+     * const m = new pc.Mat4();
      *
      * // Query the z-axis component
-     * var y = new pc.Vec3();
+     * const y = new pc.Vec3();
      * m.getY(y);
      */
     getY(y = new Vec3()) {
@@ -1126,10 +1126,10 @@ class Mat4 {
      * @returns {Vec3} The z-axis of the specified 4x4 matrix.
      * @example
      * // Create a 4x4 matrix
-     * var m = new pc.Mat4();
+     * const m = new pc.Mat4();
      *
      * // Query the z-axis component
-     * var z = new pc.Vec3();
+     * const z = new pc.Vec3();
      * m.getZ(z);
      */
     getZ(z = new Vec3()) {
@@ -1144,7 +1144,7 @@ class Mat4 {
      * @returns {Vec3} The scale in X, Y and Z of the specified 4x4 matrix.
      * @example
      * // Query the scale component
-     * var scale = m.getScale();
+     * const scale = m.getScale();
      */
     getScale(scale = new Vec3()) {
         this.getX(x);
@@ -1165,7 +1165,7 @@ class Mat4 {
      * @param {number} ez - Angle to rotate around Z axis in degrees.
      * @returns {Mat4} Self for chaining.
      * @example
-     * var m = new pc.Mat4();
+     * const m = new pc.Mat4();
      * m.setFromEulerAngles(45, 90, 180);
      */
     // http://en.wikipedia.org/wiki/Rotation_matrix#Conversion_from_and_to_axis-angle
@@ -1219,9 +1219,9 @@ class Mat4 {
      * @returns {Vec3} A 3-d vector containing the Euler angles.
      * @example
      * // Create a 4x4 rotation matrix of 45 degrees around the y-axis
-     * var m = new pc.Mat4().setFromAxisAngle(pc.Vec3.UP, 45);
+     * const m = new pc.Mat4().setFromAxisAngle(pc.Vec3.UP, 45);
      *
-     * var eulers = m.getEulerAngles();
+     * const eulers = m.getEulerAngles();
      */
     getEulerAngles(eulers = new Vec3()) {
         this.getScale(scale);
@@ -1263,7 +1263,7 @@ class Mat4 {
      * @description Converts the specified matrix to string form.
      * @returns {string} The matrix in string form.
      * @example
-     * var m = new pc.Mat4();
+     * const m = new pc.Mat4();
      * // Outputs [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]
      * console.log(m.toString());
      */

--- a/src/math/math.js
+++ b/src/math/math.js
@@ -11,7 +11,7 @@ const math = {
      * @description Conversion factor between degrees and radians.
      * @example
      * // Convert 180 degrees to pi radians
-     * var rad = 180 * pc.math.DEG_TO_RAD;
+     * const rad = 180 * pc.math.DEG_TO_RAD;
      */
     DEG_TO_RAD: Math.PI / 180,
 
@@ -22,7 +22,7 @@ const math = {
      * @description Conversion factor between degrees and radians.
      * @example
      * // Convert pi radians to 180 degrees
-     * var deg = Math.PI * pc.math.RAD_TO_DEG;
+     * const deg = Math.PI * pc.math.RAD_TO_DEG;
      */
     RAD_TO_DEG: 180 / Math.PI,
 
@@ -49,7 +49,7 @@ const math = {
      * @returns {number[]} An array of 3 bytes.
      * @example
      * // Set bytes to [0x11, 0x22, 0x33]
-     * var bytes = pc.math.intToBytes24(0x112233);
+     * const bytes = pc.math.intToBytes24(0x112233);
      */
     intToBytes24: function (i) {
         const r = (i >> 16) & 0xff;
@@ -67,7 +67,7 @@ const math = {
      * @param {number} i - Number holding an integer value.
      * @example
      * // Set bytes to [0x11, 0x22, 0x33, 0x44]
-     * var bytes = pc.math.intToBytes32(0x11223344);
+     * const bytes = pc.math.intToBytes32(0x11223344);
      */
     intToBytes32: function (i) {
         const r = (i >> 24) & 0xff;
@@ -84,10 +84,10 @@ const math = {
      * @description Convert 3 8 bit Numbers into a single unsigned 24 bit Number.
      * @example
      * // Set result1 to 0x112233 from an array of 3 values
-     * var result1 = pc.math.bytesToInt24([0x11, 0x22, 0x33]);
+     * const result1 = pc.math.bytesToInt24([0x11, 0x22, 0x33]);
      *
      * // Set result2 to 0x112233 from 3 discrete values
-     * var result2 = pc.math.bytesToInt24(0x11, 0x22, 0x33);
+     * const result2 = pc.math.bytesToInt24(0x11, 0x22, 0x33);
      * @param {number} r - A single byte (0-255).
      * @param {number} g - A single byte (0-255).
      * @param {number} b - A single byte (0-255).
@@ -109,10 +109,10 @@ const math = {
      * @returns {number} A single unsigned 32bit Number.
      * @example
      * // Set result1 to 0x11223344 from an array of 4 values
-     * var result1 = pc.math.bytesToInt32([0x11, 0x22, 0x33, 0x44]);
+     * const result1 = pc.math.bytesToInt32([0x11, 0x22, 0x33, 0x44]);
      *
      * // Set result2 to 0x11223344 from 4 discrete values
-     * var result2 = pc.math.bytesToInt32(0x11, 0x22, 0x33, 0x44);
+     * const result2 = pc.math.bytesToInt32(0x11, 0x22, 0x33, 0x44);
      * @param {number} r - A single byte (0-255).
      * @param {number} g - A single byte (0-255).
      * @param {number} b - A single byte (0-255).

--- a/src/math/quat.js
+++ b/src/math/quat.js
@@ -17,10 +17,10 @@ import { Vec3 } from './vec3.js';
  * @type {number}
  * @description The x component of the quaternion.
  * @example
- * var quat = new pc.Quat();
+ * const quat = new pc.Quat();
  *
  * // Get x
- * var x = quat.x;
+ * const x = quat.x;
  *
  * // Set x
  * quat.x = 0;
@@ -31,10 +31,10 @@ import { Vec3 } from './vec3.js';
  * @type {number}
  * @description The y component of the quaternion.
  * @example
- * var quat = new pc.Quat();
+ * const quat = new pc.Quat();
  *
  * // Get y
- * var y = quat.y;
+ * const y = quat.y;
  *
  * // Set y
  * quat.y = 0;
@@ -45,10 +45,10 @@ import { Vec3 } from './vec3.js';
  * @type {number}
  * @description The z component of the quaternion.
  * @example
- * var quat = new pc.Quat();
+ * const quat = new pc.Quat();
  *
  * // Get z
- * var z = quat.z;
+ * const z = quat.z;
  *
  * // Set z
  * quat.z = 0;
@@ -59,10 +59,10 @@ import { Vec3 } from './vec3.js';
  * @type {number}
  * @description The w component of the quaternion.
  * @example
- * var quat = new pc.Quat();
+ * const quat = new pc.Quat();
  *
  * // Get w
- * var w = quat.w;
+ * const w = quat.w;
  *
  * // Set w
  * quat.w = 0;
@@ -88,8 +88,8 @@ class Quat {
      * @description Returns an identical copy of the specified quaternion.
      * @returns {Quat} A quaternion containing the result of the cloning.
      * @example
-     * var q = new pc.Quat(-0.11, -0.15, -0.46, 0.87);
-     * var qclone = q.clone();
+     * const q = new pc.Quat(-0.11, -0.15, -0.46, 0.87);
+     * const qclone = q.clone();
      *
      * console.log("The result of the cloning is: " + q.toString());
      */
@@ -112,8 +112,8 @@ class Quat {
      * @param {Quat} rhs - The quaternion to be copied.
      * @returns {Quat} Self for chaining.
      * @example
-     * var src = new pc.Quat();
-     * var dst = new pc.Quat();
+     * const src = new pc.Quat();
+     * const dst = new pc.Quat();
      * dst.copy(src, src);
      * console.log("The two quaternions are " + (src.equals(dst) ? "equal" : "different"));
      */
@@ -133,8 +133,8 @@ class Quat {
      * @param {Quat} rhs - The quaternion to be compared against.
      * @returns {boolean} True if the quaternions are equal and false otherwise.
      * @example
-     * var a = new pc.Quat();
-     * var b = new pc.Quat();
+     * const a = new pc.Quat();
+     * const b = new pc.Quat();
      * console.log("The two quaternions are " + (a.equals(b) ? "equal" : "different"));
      */
     equals(rhs) {
@@ -152,10 +152,10 @@ class Quat {
      * @param {Vec3} axis - The 3-dimensional vector to receive the axis of rotation.
      * @returns {number} Angle, in degrees, of the rotation.
      * @example
-     * var q = new pc.Quat();
+     * const q = new pc.Quat();
      * q.setFromAxisAngle(new pc.Vec3(0, 1, 0), 90);
-     * var v = new pc.Vec3();
-     * var angle = q.getAxisAngle(v);
+     * const v = new pc.Vec3();
+     * const angle = q.getAxisAngle(v);
      * // Outputs 90
      * console.log(angle);
      * // Outputs [0, 1, 0]
@@ -226,7 +226,7 @@ class Quat {
      * @returns {Quat} Self for chaining.
      * @example
      * // Create a quaternion rotated 180 degrees around the y-axis
-     * var rot = new pc.Quat().setFromEulerAngles(0, 180, 0);
+     * const rot = new pc.Quat().setFromEulerAngles(0, 180, 0);
      *
      * // Invert in place
      * rot.invert();
@@ -241,8 +241,8 @@ class Quat {
      * @description Returns the magnitude of the specified quaternion.
      * @returns {number} The magnitude of the specified quaternion.
      * @example
-     * var q = new pc.Quat(0, 0, 0, 5);
-     * var len = q.length();
+     * const q = new pc.Quat(0, 0, 0, 5);
+     * const len = q.length();
      * // Outputs 5
      * console.log("The length of the quaternion is: " + len);
      */
@@ -256,8 +256,8 @@ class Quat {
      * @description Returns the magnitude squared of the specified quaternion.
      * @returns {number} The magnitude of the specified quaternion.
      * @example
-     * var q = new pc.Quat(3, 4, 0);
-     * var lenSq = q.lengthSq();
+     * const q = new pc.Quat(3, 4, 0);
+     * const lenSq = q.lengthSq();
      * // Outputs 25
      * console.log("The length squared of the quaternion is: " + lenSq);
      */
@@ -272,8 +272,8 @@ class Quat {
      * @param {Quat} rhs - The quaternion used as the second multiplicand of the operation.
      * @returns {Quat} Self for chaining.
      * @example
-     * var a = new pc.Quat().setFromEulerAngles(0, 30, 0);
-     * var b = new pc.Quat().setFromEulerAngles(0, 60, 0);
+     * const a = new pc.Quat().setFromEulerAngles(0, 30, 0);
+     * const b = new pc.Quat().setFromEulerAngles(0, 60, 0);
      *
      * // a becomes a 90 degree rotation around the Y axis
      * // In other words, a = a * b
@@ -308,9 +308,9 @@ class Quat {
      * @param {Quat} rhs - The quaternion used as the second multiplicand of the operation.
      * @returns {Quat} Self for chaining.
      * @example
-     * var a = new pc.Quat().setFromEulerAngles(0, 30, 0);
-     * var b = new pc.Quat().setFromEulerAngles(0, 60, 0);
-     * var r = new pc.Quat();
+     * const a = new pc.Quat().setFromEulerAngles(0, 30, 0);
+     * const b = new pc.Quat().setFromEulerAngles(0, 60, 0);
+     * const r = new pc.Quat();
      *
      * // r is set to a 90 degree rotation around the Y axis
      * // In other words, r = a * b
@@ -343,7 +343,7 @@ class Quat {
      * @description Returns the specified quaternion converted in place to a unit quaternion.
      * @returns {Quat} The result of the normalization.
      * @example
-     * var v = new pc.Quat(0, 0, 0, 5);
+     * const v = new pc.Quat(0, 0, 0, 5);
      *
      * v.normalize();
      *
@@ -376,7 +376,7 @@ class Quat {
      * @param {number} w - The w component of the quaternion.
      * @returns {Quat} Self for chaining.
      * @example
-     * var q = new pc.Quat();
+     * const q = new pc.Quat();
      * q.set(1, 0, 0, 0);
      *
      * // Outputs 1, 0, 0, 0
@@ -399,7 +399,7 @@ class Quat {
      * @param {number} angle - Angle to rotate around the given axis in degrees.
      * @returns {Quat} Self for chaining.
      * @example
-     * var q = new pc.Quat();
+     * const q = new pc.Quat();
      * q.setFromAxisAngle(pc.Vec3.UP, 90);
      */
     setFromAxisAngle(axis, angle) {
@@ -425,7 +425,7 @@ class Quat {
      * @param {number} ez - Angle to rotate around Z axis in degrees.
      * @returns {Quat} Self for chaining.
      * @example
-     * var q = new pc.Quat();
+     * const q = new pc.Quat();
      * q.setFromEulerAngles(45, 90, 180);
      */
     setFromEulerAngles(ex, ey, ez) {
@@ -459,10 +459,10 @@ class Quat {
      * @returns {Quat} Self for chaining.
      * @example
      * // Create a 4x4 rotation matrix of 180 degrees around the y-axis
-     * var rot = new pc.Mat4().setFromAxisAngle(pc.Vec3.UP, 180);
+     * const rot = new pc.Mat4().setFromAxisAngle(pc.Vec3.UP, 180);
      *
      * // Convert to a quaternion
-     * var q = new pc.Quat().setFromMat4(rot);
+     * const q = new pc.Quat().setFromMat4(rot);
      */
     setFromMat4(m) {
         let m00, m01, m02, m10, m11, m12, m20, m21, m22,
@@ -576,10 +576,10 @@ class Quat {
      * in between generating a spherical interpolation between the two.
      * @returns {Quat} Self for chaining.
      * @example
-     * var q1 = new pc.Quat(-0.11, -0.15, -0.46, 0.87);
-     * var q2 = new pc.Quat(-0.21, -0.21, -0.67, 0.68);
+     * const q1 = new pc.Quat(-0.11, -0.15, -0.46, 0.87);
+     * const q2 = new pc.Quat(-0.21, -0.21, -0.67, 0.68);
      *
-     * var result;
+     * let result;
      * result = new pc.Quat().slerp(q1, q2, 0);   // Return q1
      * result = new pc.Quat().slerp(q1, q2, 0.5); // Return the midpoint interpolant
      * result = new pc.Quat().slerp(q1, q2, 1);   // Return q2
@@ -650,12 +650,12 @@ class Quat {
      * @returns {Vec3} The input vector v transformed by the current instance.
      * @example
      * // Create a 3-dimensional vector
-     * var v = new pc.Vec3(1, 2, 3);
+     * const v = new pc.Vec3(1, 2, 3);
      *
      * // Create a 4x4 rotation matrix
-     * var q = new pc.Quat().setFromEulerAngles(10, 20, 30);
+     * const q = new pc.Quat().setFromEulerAngles(10, 20, 30);
      *
-     * var tv = q.transformVector(v);
+     * const tv = q.transformVector(v);
      */
     transformVector(vec, res = new Vec3()) {
         const x = vec.x, y = vec.y, z = vec.z;
@@ -681,7 +681,7 @@ class Quat {
      * @description Converts the quaternion to string form.
      * @returns {string} The quaternion in string form.
      * @example
-     * var v = new pc.Quat(0, 0, 0, 1);
+     * const v = new pc.Quat(0, 0, 0, 1);
      * // Outputs [0, 0, 0, 1]
      * console.log(v.toString());
      */

--- a/src/math/vec2.js
+++ b/src/math/vec2.js
@@ -6,7 +6,7 @@
  * @param {number|number[]} [x] - The x value. If x is an array of length 2, the array will be used to populate all components.
  * @param {number} [y] - The y value.
  * @example
- * var v = new pc.Vec2(1, 2);
+ * const v = new pc.Vec2(1, 2);
  */
 /**
  * @field
@@ -14,10 +14,10 @@
  * @type {number}
  * @description The first element of the vector.
  * @example
- * var vec = new pc.Vec2(10, 20);
+ * const vec = new pc.Vec2(10, 20);
  *
  * // Get x
- * var x = vec.x;
+ * const x = vec.x;
  *
  * // Set x
  * vec.x = 0;
@@ -28,10 +28,10 @@
  * @type {number}
  * @description The second element of the vector.
  * @example
- * var vec = new pc.Vec2(10, 20);
+ * const vec = new pc.Vec2(10, 20);
  *
  * // Get y
- * var y = vec.y;
+ * const y = vec.y;
  *
  * // Set y
  * vec.y = 0;
@@ -54,8 +54,8 @@ class Vec2 {
      * @param {Vec2} rhs - The vector to add to the specified vector.
      * @returns {Vec2} Self for chaining.
      * @example
-     * var a = new pc.Vec2(10, 10);
-     * var b = new pc.Vec2(20, 20);
+     * const a = new pc.Vec2(10, 10);
+     * const b = new pc.Vec2(20, 20);
      *
      * a.add(b);
      *
@@ -77,9 +77,9 @@ class Vec2 {
      * @param {Vec2} rhs - The second vector operand for the addition.
      * @returns {Vec2} Self for chaining.
      * @example
-     * var a = new pc.Vec2(10, 10);
-     * var b = new pc.Vec2(20, 20);
-     * var r = new pc.Vec2();
+     * const a = new pc.Vec2(10, 10);
+     * const b = new pc.Vec2(20, 20);
+     * const r = new pc.Vec2();
      *
      * r.add2(a, b);
      * // Outputs [30, 30]
@@ -100,7 +100,7 @@ class Vec2 {
      * @param {number} scalar - The number to add.
      * @returns {Vec2} Self for chaining.
      * @example
-     * var vec = new pc.Vec2(3, 4);
+     * const vec = new pc.Vec2(3, 4);
      *
      * vec.addScalar(2);
      *
@@ -120,8 +120,8 @@ class Vec2 {
      * @description Returns an identical copy of the specified 2-dimensional vector.
      * @returns {Vec2} A 2-dimensional vector containing the result of the cloning.
      * @example
-     * var v = new pc.Vec2(10, 20);
-     * var vclone = v.clone();
+     * const v = new pc.Vec2(10, 20);
+     * const vclone = v.clone();
      * console.log("The result of the cloning is: " + vclone.toString());
      */
     clone() {
@@ -135,8 +135,8 @@ class Vec2 {
      * @param {Vec2} rhs - A vector to copy to the specified vector.
      * @returns {Vec2} Self for chaining.
      * @example
-     * var src = new pc.Vec2(10, 20);
-     * var dst = new pc.Vec2();
+     * const src = new pc.Vec2(10, 20);
+     * const dst = new pc.Vec2();
      *
      * dst.copy(src);
      *
@@ -156,9 +156,9 @@ class Vec2 {
      * @param {Vec2} rhs - The second 2-dimensional vector operand of the cross product.
      * @returns {number} The cross product of the two vectors.
      * @example
-     * var right = new pc.Vec2(1, 0);
-     * var up = new pc.Vec2(0, 1);
-     * var crossProduct = right.cross(up);
+     * const right = new pc.Vec2(1, 0);
+     * const up = new pc.Vec2(0, 1);
+     * const crossProduct = right.cross(up);
      *
      * // Prints 1
      * console.log("The result of the cross product is: " + crossProduct);
@@ -174,9 +174,9 @@ class Vec2 {
      * @param {Vec2} rhs - The second 2-dimensional vector to test.
      * @returns {number} The distance between the two vectors.
      * @example
-     * var v1 = new pc.Vec2(5, 10);
-     * var v2 = new pc.Vec2(10, 20);
-     * var d = v1.distance(v2);
+     * const v1 = new pc.Vec2(5, 10);
+     * const v2 = new pc.Vec2(10, 20);
+     * const d = v1.distance(v2);
      * console.log("The between v1 and v2 is: " + d);
      */
     distance(rhs) {
@@ -192,8 +192,8 @@ class Vec2 {
      * @param {Vec2} rhs - The vector to divide the specified vector by.
      * @returns {Vec2} Self for chaining.
      * @example
-     * var a = new pc.Vec2(4, 9);
-     * var b = new pc.Vec2(2, 3);
+     * const a = new pc.Vec2(4, 9);
+     * const b = new pc.Vec2(2, 3);
      *
      * a.div(b);
      *
@@ -216,9 +216,9 @@ class Vec2 {
      * @param {Vec2} rhs - The divisor vector (the vector dividing the dividend).
      * @returns {Vec2} Self for chaining.
      * @example
-     * var a = new pc.Vec2(4, 9);
-     * var b = new pc.Vec2(2, 3);
-     * var r = new pc.Vec2();
+     * const a = new pc.Vec2(4, 9);
+     * const b = new pc.Vec2(2, 3);
+     * const r = new pc.Vec2();
      *
      * r.div2(a, b);
      * // Outputs [2, 3]
@@ -239,7 +239,7 @@ class Vec2 {
      * @param {number} scalar - The number to divide by.
      * @returns {Vec2} Self for chaining.
      * @example
-     * var vec = new pc.Vec2(3, 6);
+     * const vec = new pc.Vec2(3, 6);
      *
      * vec.divScalar(3);
      *
@@ -260,9 +260,9 @@ class Vec2 {
      * @param {Vec2} rhs - The second 2-dimensional vector operand of the dot product.
      * @returns {number} The result of the dot product operation.
      * @example
-     * var v1 = new pc.Vec2(5, 10);
-     * var v2 = new pc.Vec2(10, 20);
-     * var v1dotv2 = v1.dot(v2);
+     * const v1 = new pc.Vec2(5, 10);
+     * const v2 = new pc.Vec2(10, 20);
+     * const v1dotv2 = v1.dot(v2);
      * console.log("The result of the dot product is: " + v1dotv2);
      */
     dot(rhs) {
@@ -276,8 +276,8 @@ class Vec2 {
      * @param {Vec2} rhs - The vector to compare to the specified vector.
      * @returns {boolean} True if the vectors are equal and false otherwise.
      * @example
-     * var a = new pc.Vec2(1, 2);
-     * var b = new pc.Vec2(4, 5);
+     * const a = new pc.Vec2(1, 2);
+     * const b = new pc.Vec2(4, 5);
      * console.log("The two vectors are " + (a.equals(b) ? "equal" : "different"));
      */
     equals(rhs) {
@@ -290,8 +290,8 @@ class Vec2 {
      * @description Returns the magnitude of the specified 2-dimensional vector.
      * @returns {number} The magnitude of the specified 2-dimensional vector.
      * @example
-     * var vec = new pc.Vec2(3, 4);
-     * var len = vec.length();
+     * const vec = new pc.Vec2(3, 4);
+     * const len = vec.length();
      * // Outputs 5
      * console.log("The length of the vector is: " + len);
      */
@@ -305,8 +305,8 @@ class Vec2 {
      * @description Returns the magnitude squared of the specified 2-dimensional vector.
      * @returns {number} The magnitude of the specified 2-dimensional vector.
      * @example
-     * var vec = new pc.Vec2(3, 4);
-     * var len = vec.lengthSq();
+     * const vec = new pc.Vec2(3, 4);
+     * const len = vec.lengthSq();
      * // Outputs 25
      * console.log("The length squared of the vector is: " + len);
      */
@@ -325,9 +325,9 @@ class Vec2 {
      * a ray extrapolated from this line.
      * @returns {Vec2} Self for chaining.
      * @example
-     * var a = new pc.Vec2(0, 0);
-     * var b = new pc.Vec2(10, 10);
-     * var r = new pc.Vec2();
+     * const a = new pc.Vec2(0, 0);
+     * const b = new pc.Vec2(10, 10);
+     * const r = new pc.Vec2();
      *
      * r.lerp(a, b, 0);   // r is equal to a
      * r.lerp(a, b, 0.5); // r is 5, 5
@@ -347,8 +347,8 @@ class Vec2 {
      * @param {Vec2} rhs - The 2-dimensional vector used as the second multiplicand of the operation.
      * @returns {Vec2} Self for chaining.
      * @example
-     * var a = new pc.Vec2(2, 3);
-     * var b = new pc.Vec2(4, 5);
+     * const a = new pc.Vec2(2, 3);
+     * const b = new pc.Vec2(4, 5);
      *
      * a.mul(b);
      *
@@ -370,9 +370,9 @@ class Vec2 {
      * @param {Vec2} rhs - The 2-dimensional vector used as the second multiplicand of the operation.
      * @returns {Vec2} Self for chaining.
      * @example
-     * var a = new pc.Vec2(2, 3);
-     * var b = new pc.Vec2(4, 5);
-     * var r = new pc.Vec2();
+     * const a = new pc.Vec2(2, 3);
+     * const b = new pc.Vec2(4, 5);
+     * const r = new pc.Vec2();
      *
      * r.mul2(a, b);
      *
@@ -393,7 +393,7 @@ class Vec2 {
      * @param {number} scalar - The number to multiply by.
      * @returns {Vec2} Self for chaining.
      * @example
-     * var vec = new pc.Vec2(3, 6);
+     * const vec = new pc.Vec2(3, 6);
      *
      * vec.mulScalar(3);
      *
@@ -414,7 +414,7 @@ class Vec2 {
      * If the vector has a length of zero, the vector's elements will be set to zero.
      * @returns {Vec2} Self for chaining.
      * @example
-     * var v = new pc.Vec2(25, 0);
+     * const v = new pc.Vec2(25, 0);
      *
      * v.normalize();
      *
@@ -502,7 +502,7 @@ class Vec2 {
      * @param {number} y - The value to set on the second component of the vector.
      * @returns {Vec2} Self for chaining.
      * @example
-     * var v = new pc.Vec2();
+     * const v = new pc.Vec2();
      * v.set(5, 10);
      *
      * // Outputs 5, 10
@@ -522,8 +522,8 @@ class Vec2 {
      * @param {Vec2} rhs - The vector to add to the specified vector.
      * @returns {Vec2} Self for chaining.
      * @example
-     * var a = new pc.Vec2(10, 10);
-     * var b = new pc.Vec2(20, 20);
+     * const a = new pc.Vec2(10, 10);
+     * const b = new pc.Vec2(20, 20);
      *
      * a.sub(b);
      *
@@ -545,9 +545,9 @@ class Vec2 {
      * @param {Vec2} rhs - The second vector operand for the addition.
      * @returns {Vec2} Self for chaining.
      * @example
-     * var a = new pc.Vec2(10, 10);
-     * var b = new pc.Vec2(20, 20);
-     * var r = new pc.Vec2();
+     * const a = new pc.Vec2(10, 10);
+     * const b = new pc.Vec2(20, 20);
+     * const r = new pc.Vec2();
      *
      * r.sub2(a, b);
      *
@@ -568,7 +568,7 @@ class Vec2 {
      * @param {number} scalar - The number to subtract.
      * @returns {Vec2} Self for chaining.
      * @example
-     * var vec = new pc.Vec2(3, 4);
+     * const vec = new pc.Vec2(3, 4);
      *
      * vec.subScalar(2);
      *
@@ -588,7 +588,7 @@ class Vec2 {
      * @description Converts the vector to string form.
      * @returns {string} The vector in string form.
      * @example
-     * var v = new pc.Vec2(20, 10);
+     * const v = new pc.Vec2(20, 10);
      * // Outputs [20, 10]
      * console.log(v.toString());
      */

--- a/src/math/vec3.js
+++ b/src/math/vec3.js
@@ -7,17 +7,17 @@
  * @param {number} [y] - The y value.
  * @param {number} [z] - The z value.
  * @example
- * var v = new pc.Vec3(1, 2, 3);
+ * const v = new pc.Vec3(1, 2, 3);
  */
 /**
  * @name Vec3#x
  * @type {number}
  * @description The first component of the vector.
  * @example
- * var vec = new pc.Vec3(10, 20, 30);
+ * const vec = new pc.Vec3(10, 20, 30);
  *
  * // Get x
- * var x = vec.x;
+ * const x = vec.x;
  *
  * // Set x
  * vec.x = 0;
@@ -27,10 +27,10 @@
  * @type {number}
  * @description The second component of the vector.
  * @example
- * var vec = new pc.Vec3(10, 20, 30);
+ * const vec = new pc.Vec3(10, 20, 30);
  *
  * // Get y
- * var y = vec.y;
+ * const y = vec.y;
  *
  * // Set y
  * vec.y = 0;
@@ -40,10 +40,10 @@
  * @type {number}
  * @description The third component of the vector.
  * @example
- * var vec = new pc.Vec3(10, 20, 30);
+ * const vec = new pc.Vec3(10, 20, 30);
  *
  * // Get z
- * var z = vec.z;
+ * const z = vec.z;
  *
  * // Set z
  * vec.z = 0;
@@ -68,8 +68,8 @@ class Vec3 {
      * @param {Vec3} rhs - The vector to add to the specified vector.
      * @returns {Vec3} Self for chaining.
      * @example
-     * var a = new pc.Vec3(10, 10, 10);
-     * var b = new pc.Vec3(20, 20, 20);
+     * const a = new pc.Vec3(10, 10, 10);
+     * const b = new pc.Vec3(20, 20, 20);
      *
      * a.add(b);
      *
@@ -92,9 +92,9 @@ class Vec3 {
      * @param {Vec3} rhs - The second vector operand for the addition.
      * @returns {Vec3} Self for chaining.
      * @example
-     * var a = new pc.Vec3(10, 10, 10);
-     * var b = new pc.Vec3(20, 20, 20);
-     * var r = new pc.Vec3();
+     * const a = new pc.Vec3(10, 10, 10);
+     * const b = new pc.Vec3(20, 20, 20);
+     * const r = new pc.Vec3();
      *
      * r.add2(a, b);
      * // Outputs [30, 30, 30]
@@ -116,7 +116,7 @@ class Vec3 {
      * @param {number} scalar - The number to add.
      * @returns {Vec3} Self for chaining.
      * @example
-     * var vec = new pc.Vec3(3, 4, 5);
+     * const vec = new pc.Vec3(3, 4, 5);
      *
      * vec.addScalar(2);
      *
@@ -137,8 +137,8 @@ class Vec3 {
      * @description Returns an identical copy of the specified 3-dimensional vector.
      * @returns {Vec3} A 3-dimensional vector containing the result of the cloning.
      * @example
-     * var v = new pc.Vec3(10, 20, 30);
-     * var vclone = v.clone();
+     * const v = new pc.Vec3(10, 20, 30);
+     * const vclone = v.clone();
      * console.log("The result of the cloning is: " + vclone.toString());
      */
     clone() {
@@ -152,8 +152,8 @@ class Vec3 {
      * @param {Vec3} rhs - A vector to copy to the specified vector.
      * @returns {Vec3} Self for chaining.
      * @example
-     * var src = new pc.Vec3(10, 20, 30);
-     * var dst = new pc.Vec3();
+     * const src = new pc.Vec3(10, 20, 30);
+     * const dst = new pc.Vec3();
      *
      * dst.copy(src);
      *
@@ -175,7 +175,7 @@ class Vec3 {
      * @param {Vec3} rhs - The second 3-dimensional vector operand of the cross product.
      * @returns {Vec3} Self for chaining.
      * @example
-     * var back = new pc.Vec3().cross(pc.Vec3.RIGHT, pc.Vec3.UP);
+     * const back = new pc.Vec3().cross(pc.Vec3.RIGHT, pc.Vec3.UP);
      *
      * // Prints the Z axis (i.e. [0, 0, 1])
      * console.log("The result of the cross product is: " + back.toString());
@@ -203,9 +203,9 @@ class Vec3 {
      * @param {Vec3} rhs - The second 3-dimensional vector to test.
      * @returns {number} The distance between the two vectors.
      * @example
-     * var v1 = new pc.Vec3(5, 10, 20);
-     * var v2 = new pc.Vec3(10, 20, 40);
-     * var d = v1.distance(v2);
+     * const v1 = new pc.Vec3(5, 10, 20);
+     * const v2 = new pc.Vec3(10, 20, 40);
+     * const d = v1.distance(v2);
      * console.log("The between v1 and v2 is: " + d);
      */
     distance(rhs) {
@@ -222,8 +222,8 @@ class Vec3 {
      * @param {Vec3} rhs - The vector to divide the specified vector by.
      * @returns {Vec3} Self for chaining.
      * @example
-     * var a = new pc.Vec3(4, 9, 16);
-     * var b = new pc.Vec3(2, 3, 4);
+     * const a = new pc.Vec3(4, 9, 16);
+     * const b = new pc.Vec3(2, 3, 4);
      *
      * a.div(b);
      *
@@ -247,9 +247,9 @@ class Vec3 {
      * @param {Vec3} rhs - The divisor vector (the vector dividing the dividend).
      * @returns {Vec3} Self for chaining.
      * @example
-     * var a = new pc.Vec3(4, 9, 16);
-     * var b = new pc.Vec3(2, 3, 4);
-     * var r = new pc.Vec3();
+     * const a = new pc.Vec3(4, 9, 16);
+     * const b = new pc.Vec3(2, 3, 4);
+     * const r = new pc.Vec3();
      *
      * r.div2(a, b);
      * // Outputs [2, 3, 4]
@@ -271,7 +271,7 @@ class Vec3 {
      * @param {number} scalar - The number to divide by.
      * @returns {Vec3} Self for chaining.
      * @example
-     * var vec = new pc.Vec3(3, 6, 9);
+     * const vec = new pc.Vec3(3, 6, 9);
      *
      * vec.divScalar(3);
      *
@@ -293,9 +293,9 @@ class Vec3 {
      * @param {Vec3} rhs - The second 3-dimensional vector operand of the dot product.
      * @returns {number} The result of the dot product operation.
      * @example
-     * var v1 = new pc.Vec3(5, 10, 20);
-     * var v2 = new pc.Vec3(10, 20, 40);
-     * var v1dotv2 = v1.dot(v2);
+     * const v1 = new pc.Vec3(5, 10, 20);
+     * const v2 = new pc.Vec3(10, 20, 40);
+     * const v1dotv2 = v1.dot(v2);
      * console.log("The result of the dot product is: " + v1dotv2);
      */
     dot(rhs) {
@@ -309,8 +309,8 @@ class Vec3 {
      * @param {Vec3} rhs - The vector to compare to the specified vector.
      * @returns {boolean} True if the vectors are equal and false otherwise.
      * @example
-     * var a = new pc.Vec3(1, 2, 3);
-     * var b = new pc.Vec3(4, 5, 6);
+     * const a = new pc.Vec3(1, 2, 3);
+     * const b = new pc.Vec3(4, 5, 6);
      * console.log("The two vectors are " + (a.equals(b) ? "equal" : "different"));
      */
     equals(rhs) {
@@ -323,8 +323,8 @@ class Vec3 {
      * @description Returns the magnitude of the specified 3-dimensional vector.
      * @returns {number} The magnitude of the specified 3-dimensional vector.
      * @example
-     * var vec = new pc.Vec3(3, 4, 0);
-     * var len = vec.length();
+     * const vec = new pc.Vec3(3, 4, 0);
+     * const len = vec.length();
      * // Outputs 5
      * console.log("The length of the vector is: " + len);
      */
@@ -338,8 +338,8 @@ class Vec3 {
      * @description Returns the magnitude squared of the specified 3-dimensional vector.
      * @returns {number} The magnitude of the specified 3-dimensional vector.
      * @example
-     * var vec = new pc.Vec3(3, 4, 0);
-     * var len = vec.lengthSq();
+     * const vec = new pc.Vec3(3, 4, 0);
+     * const len = vec.lengthSq();
      * // Outputs 25
      * console.log("The length squared of the vector is: " + len);
      */
@@ -358,9 +358,9 @@ class Vec3 {
      * a ray extrapolated from this line.
      * @returns {Vec3} Self for chaining.
      * @example
-     * var a = new pc.Vec3(0, 0, 0);
-     * var b = new pc.Vec3(10, 10, 10);
-     * var r = new pc.Vec3();
+     * const a = new pc.Vec3(0, 0, 0);
+     * const b = new pc.Vec3(10, 10, 10);
+     * const r = new pc.Vec3();
      *
      * r.lerp(a, b, 0);   // r is equal to a
      * r.lerp(a, b, 0.5); // r is 5, 5, 5
@@ -381,8 +381,8 @@ class Vec3 {
      * @param {Vec3} rhs - The 3-dimensional vector used as the second multiplicand of the operation.
      * @returns {Vec3} Self for chaining.
      * @example
-     * var a = new pc.Vec3(2, 3, 4);
-     * var b = new pc.Vec3(4, 5, 6);
+     * const a = new pc.Vec3(2, 3, 4);
+     * const b = new pc.Vec3(4, 5, 6);
      *
      * a.mul(b);
      *
@@ -405,9 +405,9 @@ class Vec3 {
      * @param {Vec3} rhs - The 3-dimensional vector used as the second multiplicand of the operation.
      * @returns {Vec3} Self for chaining.
      * @example
-     * var a = new pc.Vec3(2, 3, 4);
-     * var b = new pc.Vec3(4, 5, 6);
-     * var r = new pc.Vec3();
+     * const a = new pc.Vec3(2, 3, 4);
+     * const b = new pc.Vec3(4, 5, 6);
+     * const r = new pc.Vec3();
      *
      * r.mul2(a, b);
      *
@@ -429,7 +429,7 @@ class Vec3 {
      * @param {number} scalar - The number to multiply by.
      * @returns {Vec3} Self for chaining.
      * @example
-     * var vec = new pc.Vec3(3, 6, 9);
+     * const vec = new pc.Vec3(3, 6, 9);
      *
      * vec.mulScalar(3);
      *
@@ -451,7 +451,7 @@ class Vec3 {
      * If the vector has a length of zero, the vector's elements will be set to zero.
      * @returns {Vec3} Self for chaining.
      * @example
-     * var v = new pc.Vec3(25, 0, 0);
+     * const v = new pc.Vec3(25, 0, 0);
      *
      * v.normalize();
      *
@@ -544,8 +544,8 @@ class Vec3 {
      * @param {Vec3} rhs - The vector onto which the original vector will be projected on.
      * @returns {Vec3} Self for chaining.
      * @example
-     * var v = new pc.Vec3(5, 5, 5);
-     * var normal = new pc.Vec3(1, 0, 0);
+     * const v = new pc.Vec3(5, 5, 5);
+     * const normal = new pc.Vec3(1, 0, 0);
      *
      * v.project(normal);
      *
@@ -571,7 +571,7 @@ class Vec3 {
      * @param {number} z - The value to set on the third component of the vector.
      * @returns {Vec3} Self for chaining.
      * @example
-     * var v = new pc.Vec3();
+     * const v = new pc.Vec3();
      * v.set(5, 10, 20);
      *
      * // Outputs 5, 10, 20
@@ -592,8 +592,8 @@ class Vec3 {
      * @param {Vec3} rhs - The vector to add to the specified vector.
      * @returns {Vec3} Self for chaining.
      * @example
-     * var a = new pc.Vec3(10, 10, 10);
-     * var b = new pc.Vec3(20, 20, 20);
+     * const a = new pc.Vec3(10, 10, 10);
+     * const b = new pc.Vec3(20, 20, 20);
      *
      * a.sub(b);
      *
@@ -616,9 +616,9 @@ class Vec3 {
      * @param {Vec3} rhs - The second vector operand for the addition.
      * @returns {Vec3} Self for chaining.
      * @example
-     * var a = new pc.Vec3(10, 10, 10);
-     * var b = new pc.Vec3(20, 20, 20);
-     * var r = new pc.Vec3();
+     * const a = new pc.Vec3(10, 10, 10);
+     * const b = new pc.Vec3(20, 20, 20);
+     * const r = new pc.Vec3();
      *
      * r.sub2(a, b);
      *
@@ -640,7 +640,7 @@ class Vec3 {
      * @param {number} scalar - The number to subtract.
      * @returns {Vec3} Self for chaining.
      * @example
-     * var vec = new pc.Vec3(3, 4, 5);
+     * const vec = new pc.Vec3(3, 4, 5);
      *
      * vec.subScalar(2);
      *
@@ -661,7 +661,7 @@ class Vec3 {
      * @description Converts the vector to string form.
      * @returns {string} The vector in string form.
      * @example
-     * var v = new pc.Vec3(20, 10, 5);
+     * const v = new pc.Vec3(20, 10, 5);
      * // Outputs [20, 10, 5]
      * console.log(v.toString());
      */

--- a/src/math/vec4.js
+++ b/src/math/vec4.js
@@ -8,7 +8,7 @@
  * @param {number} [z] - The z value.
  * @param {number} [w] - The w value.
  * @example
- * var v = new pc.Vec4(1, 2, 3, 4);
+ * const v = new pc.Vec4(1, 2, 3, 4);
  */
 /**
  * @field
@@ -16,10 +16,10 @@
  * @type {number}
  * @description The first component of the vector.
  * @example
- * var vec = new pc.Vec4(10, 20, 30, 40);
+ * const vec = new pc.Vec4(10, 20, 30, 40);
  *
  * // Get x
- * var x = vec.x;
+ * const x = vec.x;
  *
  * // Set x
  * vec.x = 0;
@@ -30,10 +30,10 @@
  * @type {number}
  * @description The second component of the vector.
  * @example
- * var vec = new pc.Vec4(10, 20, 30, 40);
+ * const vec = new pc.Vec4(10, 20, 30, 40);
  *
  * // Get y
- * var y = vec.y;
+ * const y = vec.y;
  *
  * // Set y
  * vec.y = 0;
@@ -44,10 +44,10 @@
  * @type {number}
  * @description The third component of the vector.
  * @example
- * var vec = new pc.Vec4(10, 20, 30, 40);
+ * const vec = new pc.Vec4(10, 20, 30, 40);
  *
  * // Get z
- * var z = vec.z;
+ * const z = vec.z;
  *
  * // Set z
  * vec.z = 0;
@@ -58,10 +58,10 @@
  * @type {number}
  * @description The fourth component of the vector.
  * @example
- * var vec = new pc.Vec4(10, 20, 30, 40);
+ * const vec = new pc.Vec4(10, 20, 30, 40);
  *
  * // Get w
- * var w = vec.w;
+ * const w = vec.w;
  *
  * // Set w
  * vec.w = 0;
@@ -88,8 +88,8 @@ class Vec4 {
      * @param {Vec4} rhs - The vector to add to the specified vector.
      * @returns {Vec4} Self for chaining.
      * @example
-     * var a = new pc.Vec4(10, 10, 10, 10);
-     * var b = new pc.Vec4(20, 20, 20, 20);
+     * const a = new pc.Vec4(10, 10, 10, 10);
+     * const b = new pc.Vec4(20, 20, 20, 20);
      *
      * a.add(b);
      *
@@ -113,9 +113,9 @@ class Vec4 {
      * @param {Vec4} rhs - The second vector operand for the addition.
      * @returns {Vec4} Self for chaining.
      * @example
-     * var a = new pc.Vec4(10, 10, 10, 10);
-     * var b = new pc.Vec4(20, 20, 20, 20);
-     * var r = new pc.Vec4();
+     * const a = new pc.Vec4(10, 10, 10, 10);
+     * const b = new pc.Vec4(20, 20, 20, 20);
+     * const r = new pc.Vec4();
      *
      * r.add2(a, b);
      * // Outputs [30, 30, 30]
@@ -138,7 +138,7 @@ class Vec4 {
      * @param {number} scalar - The number to add.
      * @returns {Vec4} Self for chaining.
      * @example
-     * var vec = new pc.Vec4(3, 4, 5, 6);
+     * const vec = new pc.Vec4(3, 4, 5, 6);
      *
      * vec.addScalar(2);
      *
@@ -160,8 +160,8 @@ class Vec4 {
      * @description Returns an identical copy of the specified 4-dimensional vector.
      * @returns {Vec4} A 4-dimensional vector containing the result of the cloning.
      * @example
-     * var v = new pc.Vec4(10, 20, 30, 40);
-     * var vclone = v.clone();
+     * const v = new pc.Vec4(10, 20, 30, 40);
+     * const vclone = v.clone();
      * console.log("The result of the cloning is: " + vclone.toString());
      */
     clone() {
@@ -175,8 +175,8 @@ class Vec4 {
      * @param {Vec4} rhs - A vector to copy to the specified vector.
      * @returns {Vec4} Self for chaining.
      * @example
-     * var src = new pc.Vec4(10, 20, 30, 40);
-     * var dst = new pc.Vec4();
+     * const src = new pc.Vec4(10, 20, 30, 40);
+     * const dst = new pc.Vec4();
      *
      * dst.copy(src);
      *
@@ -198,8 +198,8 @@ class Vec4 {
      * @param {Vec4} rhs - The vector to divide the specified vector by.
      * @returns {Vec4} Self for chaining.
      * @example
-     * var a = new pc.Vec4(4, 9, 16, 25);
-     * var b = new pc.Vec4(2, 3, 4, 5);
+     * const a = new pc.Vec4(4, 9, 16, 25);
+     * const b = new pc.Vec4(2, 3, 4, 5);
      *
      * a.div(b);
      *
@@ -224,9 +224,9 @@ class Vec4 {
      * @param {Vec4} rhs - The divisor vector (the vector dividing the dividend).
      * @returns {Vec4} Self for chaining.
      * @example
-     * var a = new pc.Vec4(4, 9, 16, 25);
-     * var b = new pc.Vec4(2, 3, 4, 5);
-     * var r = new pc.Vec4();
+     * const a = new pc.Vec4(4, 9, 16, 25);
+     * const b = new pc.Vec4(2, 3, 4, 5);
+     * const r = new pc.Vec4();
      *
      * r.div2(a, b);
      * // Outputs [2, 3, 4, 5]
@@ -249,7 +249,7 @@ class Vec4 {
      * @param {number} scalar - The number to divide by.
      * @returns {Vec4} Self for chaining.
      * @example
-     * var vec = new pc.Vec4(3, 6, 9, 12);
+     * const vec = new pc.Vec4(3, 6, 9, 12);
      *
      * vec.divScalar(3);
      *
@@ -272,9 +272,9 @@ class Vec4 {
      * @param {Vec4} rhs - The second 4-dimensional vector operand of the dot product.
      * @returns {number} The result of the dot product operation.
      * @example
-     * var v1 = new pc.Vec4(5, 10, 20, 40);
-     * var v2 = new pc.Vec4(10, 20, 40, 80);
-     * var v1dotv2 = v1.dot(v2);
+     * const v1 = new pc.Vec4(5, 10, 20, 40);
+     * const v2 = new pc.Vec4(10, 20, 40, 80);
+     * const v1dotv2 = v1.dot(v2);
      * console.log("The result of the dot product is: " + v1dotv2);
      */
     dot(rhs) {
@@ -288,8 +288,8 @@ class Vec4 {
      * @param {Vec4} rhs - The vector to compare to the specified vector.
      * @returns {boolean} True if the vectors are equal and false otherwise.
      * @example
-     * var a = new pc.Vec4(1, 2, 3, 4);
-     * var b = new pc.Vec4(5, 6, 7, 8);
+     * const a = new pc.Vec4(1, 2, 3, 4);
+     * const b = new pc.Vec4(5, 6, 7, 8);
      * console.log("The two vectors are " + (a.equals(b) ? "equal" : "different"));
      */
     equals(rhs) {
@@ -302,8 +302,8 @@ class Vec4 {
      * @description Returns the magnitude of the specified 4-dimensional vector.
      * @returns {number} The magnitude of the specified 4-dimensional vector.
      * @example
-     * var vec = new pc.Vec4(3, 4, 0, 0);
-     * var len = vec.length();
+     * const vec = new pc.Vec4(3, 4, 0, 0);
+     * const len = vec.length();
      * // Outputs 5
      * console.log("The length of the vector is: " + len);
      */
@@ -317,8 +317,8 @@ class Vec4 {
      * @description Returns the magnitude squared of the specified 4-dimensional vector.
      * @returns {number} The magnitude of the specified 4-dimensional vector.
      * @example
-     * var vec = new pc.Vec4(3, 4, 0);
-     * var len = vec.lengthSq();
+     * const vec = new pc.Vec4(3, 4, 0);
+     * const len = vec.lengthSq();
      * // Outputs 25
      * console.log("The length squared of the vector is: " + len);
      */
@@ -337,9 +337,9 @@ class Vec4 {
      * a ray extrapolated from this line.
      * @returns {Vec4} Self for chaining.
      * @example
-     * var a = new pc.Vec4(0, 0, 0, 0);
-     * var b = new pc.Vec4(10, 10, 10, 10);
-     * var r = new pc.Vec4();
+     * const a = new pc.Vec4(0, 0, 0, 0);
+     * const b = new pc.Vec4(10, 10, 10, 10);
+     * const r = new pc.Vec4();
      *
      * r.lerp(a, b, 0);   // r is equal to a
      * r.lerp(a, b, 0.5); // r is 5, 5, 5, 5
@@ -361,8 +361,8 @@ class Vec4 {
      * @param {Vec4} rhs - The 4-dimensional vector used as the second multiplicand of the operation.
      * @returns {Vec4} Self for chaining.
      * @example
-     * var a = new pc.Vec4(2, 3, 4, 5);
-     * var b = new pc.Vec4(4, 5, 6, 7);
+     * const a = new pc.Vec4(2, 3, 4, 5);
+     * const b = new pc.Vec4(4, 5, 6, 7);
      *
      * a.mul(b);
      *
@@ -386,9 +386,9 @@ class Vec4 {
      * @param {Vec4} rhs - The 4-dimensional vector used as the second multiplicand of the operation.
      * @returns {Vec4} Self for chaining.
      * @example
-     * var a = new pc.Vec4(2, 3, 4, 5);
-     * var b = new pc.Vec4(4, 5, 6, 7);
-     * var r = new pc.Vec4();
+     * const a = new pc.Vec4(2, 3, 4, 5);
+     * const b = new pc.Vec4(4, 5, 6, 7);
+     * const r = new pc.Vec4();
      *
      * r.mul2(a, b);
      *
@@ -411,7 +411,7 @@ class Vec4 {
      * @param {number} scalar - The number to multiply by.
      * @returns {Vec4} Self for chaining.
      * @example
-     * var vec = new pc.Vec4(3, 6, 9, 12);
+     * const vec = new pc.Vec4(3, 6, 9, 12);
      *
      * vec.mulScalar(3);
      *
@@ -434,7 +434,7 @@ class Vec4 {
      * If the vector has a length of zero, the vector's elements will be set to zero.
      * @returns {Vec4} Self for chaining.
      * @example
-     * var v = new pc.Vec4(25, 0, 0, 0);
+     * const v = new pc.Vec4(25, 0, 0, 0);
      *
      * v.normalize();
      *
@@ -536,7 +536,7 @@ class Vec4 {
      * @param {number} w - The value to set on the fourth component of the vector.
      * @returns {Vec4} Self for chaining.
      * @example
-     * var v = new pc.Vec4();
+     * const v = new pc.Vec4();
      * v.set(5, 10, 20, 40);
      *
      * // Outputs 5, 10, 20, 40
@@ -558,8 +558,8 @@ class Vec4 {
      * @param {Vec4} rhs - The vector to add to the specified vector.
      * @returns {Vec4} Self for chaining.
      * @example
-     * var a = new pc.Vec4(10, 10, 10, 10);
-     * var b = new pc.Vec4(20, 20, 20, 20);
+     * const a = new pc.Vec4(10, 10, 10, 10);
+     * const b = new pc.Vec4(20, 20, 20, 20);
      *
      * a.sub(b);
      *
@@ -583,9 +583,9 @@ class Vec4 {
      * @param {Vec4} rhs - The second vector operand for the subtraction.
      * @returns {Vec4} Self for chaining.
      * @example
-     * var a = new pc.Vec4(10, 10, 10, 10);
-     * var b = new pc.Vec4(20, 20, 20, 20);
-     * var r = new pc.Vec4();
+     * const a = new pc.Vec4(10, 10, 10, 10);
+     * const b = new pc.Vec4(20, 20, 20, 20);
+     * const r = new pc.Vec4();
      *
      * r.sub2(a, b);
      *
@@ -608,7 +608,7 @@ class Vec4 {
      * @param {number} scalar - The number to subtract.
      * @returns {Vec4} Self for chaining.
      * @example
-     * var vec = new pc.Vec4(3, 4, 5, 6);
+     * const vec = new pc.Vec4(3, 4, 5, 6);
      *
      * vec.subScalar(2);
      *
@@ -630,7 +630,7 @@ class Vec4 {
      * @description Converts the vector to string form.
      * @returns {string} The vector in string form.
      * @example
-     * var v = new pc.Vec4(20, 10, 5, 0);
+     * const v = new pc.Vec4(20, 10, 5, 0);
      * // Outputs [20, 10, 5, 0]
      * console.log(v.toString());
      */

--- a/src/resources/container.js
+++ b/src/resources/container.js
@@ -62,8 +62,8 @@ class ContainerResource {
      * @returns {Entity} A single entity with a model component. Model component internally contains a hierarchy based on {@link GraphNode}.
      * @example
      * // load a glb file and instantiate an entity with a model component based on it
-     * app.assets.loadFromUrl("statue.glb", "container", function (err, asset) {
-     *     var entity = asset.resource.instantiateModelEntity({
+     * app.assets.loadFromUrl("statue.glb", "container", (err, asset) => {
+     *     const entity = asset.resource.instantiateModelEntity({
      *         castShadows: true
      *     });
      *     app.root.addChild(entity);
@@ -83,16 +83,16 @@ class ContainerResource {
      * @returns {Entity} A hierarchy of entities with render components on entities containing renderable geometry.
      * @example
      * // load a glb file and instantiate an entity with a render component based on it
-     * app.assets.loadFromUrl("statue.glb", "container", function (err, asset) {
-     *     var entity = asset.resource.instantiateRenderEntity({
+     * app.assets.loadFromUrl("statue.glb", "container", (err, asset) => {
+     *     const entity = asset.resource.instantiateRenderEntity({
      *         castShadows: true
      *     });
      *     app.root.addChild(entity);
      *
      *     // find all render components containing mesh instances, and change blend mode on their materials
-     *     var renders = entity.findComponents("render");
-     *     renders.forEach(function (render) {
-     *         render.meshInstances.forEach(function (meshInstance) {
+     *     const renders = entity.findComponents("render");
+     *     renders.forEach((render) => {
+     *         render.meshInstances.forEach((meshInstance) => {
      *             meshInstance.material.blendType = pc.BLEND_MULTIPLICATIVE;
      *             meshInstance.material.update();
      *         });
@@ -364,7 +364,7 @@ class ContainerResource {
  * ```
  * For example, to receive a texture preprocess callback:
  * ```javascript
- * var containerAsset = new pc.Asset(filename, 'container', { url: url, filename: filename }, null, {
+ * const containerAsset = new pc.Asset(filename, 'container', { url: url, filename: filename }, null, {
  *     texture: {
  *         preprocess(gltfTexture) { console.log("texture preprocess"); }
  *     },

--- a/src/resources/css.js
+++ b/src/resources/css.js
@@ -39,8 +39,8 @@ class CssHandler {
  * @description Creates a &lt;style&gt; DOM element from a string that contains CSS.
  * @param {string} cssString - A string that contains valid CSS.
  * @example
- * var css = 'body {height: 100;}';
- * var style = pc.createStyle(css);
+ * const css = 'body {height: 100;}';
+ * const style = pc.createStyle(css);
  * document.head.appendChild(style);
  * @returns {Element} The style DOM element.
  */

--- a/src/resources/loader.js
+++ b/src/resources/loader.js
@@ -16,7 +16,7 @@ class ResourceLoader {
     /**
      * @function
      * @name ResourceLoader#addHandler
-     * @description Add a {@link ResourceHandler} for a resource type. Handler should support atleast load() and open().
+     * @description Add a {@link ResourceHandler} for a resource type. Handler should support at least load() and open().
      * Handlers can optionally support patch(asset, assets) to handle dependencies on other assets.
      * @param {string} type - The name of the resource type that the handler will be registered with. Can be:
      *
@@ -35,9 +35,9 @@ class ResourceLoader {
      * * {@link ASSET_SCRIPT}
      * * {@link ASSET_CONTAINER}
      *
-     * @param {ResourceHandler} handler - An instance of a resource handler supporting atleast load() and open().
+     * @param {ResourceHandler} handler - An instance of a resource handler supporting at least load() and open().
      * @example
-     * var loader = new ResourceLoader();
+     * const loader = new ResourceLoader();
      * loader.addHandler("json", new pc.JsonHandler());
      */
     addHandler(type, handler) {

--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -298,12 +298,12 @@ class GraphNode extends EventHandler {
      * @returns {GraphNode[]} The array of graph nodes that match the search criteria.
      * @example
      * // Finds all nodes that have a model component and have `door` in their lower-cased name
-     * var doors = house.find(function (node) {
+     * const doors = house.find((node) => {
      *     return node.model && node.name.toLowerCase().indexOf('door') !== -1;
      * });
      * @example
      * // Finds all nodes that have the name property set to 'Test'
-     * var entities = parent.find('name', 'Test');
+     * const entities = parent.find('name', 'Test');
      */
     find(attr, value) {
         let result, results = [];
@@ -359,12 +359,12 @@ class GraphNode extends EventHandler {
      * @returns {GraphNode} A graph node that match the search criteria.
      * @example
      * // Find the first node that is called `head` and has a model component
-     * var head = player.findOne(function (node) {
+     * const head = player.findOne((node) => {
      *     return node.model && node.name === 'head';
      * });
      * @example
      * // Finds the first node that has the name property set to 'Test'
-     * var node = parent.findOne('name', 'Test');
+     * const node = parent.findOne('name', 'Test');
      */
     findOne(attr, value) {
         const len = this._children.length;
@@ -416,16 +416,16 @@ class GraphNode extends EventHandler {
      * @returns {GraphNode[]} A list of all graph nodes that match the query.
      * @example
      * // Return all graph nodes that tagged by `animal`
-     * var animals = node.findByTag("animal");
+     * const animals = node.findByTag("animal");
      * @example
      * // Return all graph nodes that tagged by `bird` OR `mammal`
-     * var birdsAndMammals = node.findByTag("bird", "mammal");
+     * const birdsAndMammals = node.findByTag("bird", "mammal");
      * @example
      * // Return all assets that tagged by `carnivore` AND `mammal`
-     * var meatEatingMammals = node.findByTag(["carnivore", "mammal"]);
+     * const meatEatingMammals = node.findByTag(["carnivore", "mammal"]);
      * @example
      * // Return all assets that tagged by (`carnivore` AND `mammal`) OR (`carnivore` AND `reptile`)
-     * var meatEatingMammalsAndReptiles = node.findByTag(["carnivore", "mammal"], ["carnivore", "reptile"]);
+     * const meatEatingMammalsAndReptiles = node.findByTag(["carnivore", "mammal"], ["carnivore", "reptile"]);
      */
     findByTag() {
         const tags = this.tags._processArguments(arguments);
@@ -474,7 +474,7 @@ class GraphNode extends EventHandler {
      * @param {string|Array} path - The full path of the {@link GraphNode} as either a string or array of {@link GraphNode} names.
      * @returns {GraphNode} The first node to be found matching the supplied path.
      * @example
-     * var path = this.entity.findByPath('child/another_child');
+     * const path = this.entity.findByPath('child/another_child');
      */
     findByPath(path) {
         // if the path isn't an array, split the path in parts. Each part represents a deeper hierarchy level
@@ -517,7 +517,7 @@ class GraphNode extends EventHandler {
      * @param {object} [thisArg] - Optional value to use as this when executing callback function.
      * @example
      * // Log the path and name of each node in descendant tree starting with "parent"
-     * parent.forEach(function (node) {
+     * parent.forEach((node) => {
      *     console.log(node.path + "/" + node.name);
      * });
      */
@@ -576,7 +576,7 @@ class GraphNode extends EventHandler {
      * node, use {@link GraphNode#setEulerAngles}.
      * @returns {Vec3} The world space rotation of the graph node in Euler angle form.
      * @example
-     * var angles = this.entity.getEulerAngles();
+     * const angles = this.entity.getEulerAngles();
      * angles.y = 180; // rotate the entity around Y by 180 degrees
      * this.entity.setEulerAngles(angles);
      */
@@ -594,7 +594,7 @@ class GraphNode extends EventHandler {
      * {@link GraphNode#setLocalEulerAngles}.
      * @returns {Vec3} The local space rotation of the graph node as euler angles in XYZ order.
      * @example
-     * var angles = this.entity.getLocalEulerAngles();
+     * const angles = this.entity.getLocalEulerAngles();
      * angles.y = 180;
      * this.entity.setLocalEulerAngles(angles);
      */
@@ -611,7 +611,7 @@ class GraphNode extends EventHandler {
      * To update the local position, use {@link GraphNode#setLocalPosition}.
      * @returns {Vec3} The local space position of the graph node.
      * @example
-     * var position = this.entity.getLocalPosition();
+     * const position = this.entity.getLocalPosition();
      * position.x += 1; // move the entity 1 unit along x.
      * this.entity.setLocalPosition(position);
      */
@@ -627,7 +627,7 @@ class GraphNode extends EventHandler {
      * To update the local rotation, use {@link GraphNode#setLocalRotation}.
      * @returns {Quat} The local space rotation of the graph node as a quaternion.
      * @example
-     * var rotation = this.entity.getLocalRotation();
+     * const rotation = this.entity.getLocalRotation();
      */
     getLocalRotation() {
         return this.localRotation;
@@ -641,7 +641,7 @@ class GraphNode extends EventHandler {
      * To update the local scale, use {@link GraphNode#setLocalScale}.
      * @returns {Vec3} The local space scale of the graph node.
      * @example
-     * var scale = this.entity.getLocalScale();
+     * const scale = this.entity.getLocalScale();
      * scale.x = 100;
      * this.entity.setLocalScale(scale);
      */
@@ -656,7 +656,7 @@ class GraphNode extends EventHandler {
      * is the transform relative to the node's parent's world transformation matrix.
      * @returns {Mat4} The node's local transformation matrix.
      * @example
-     * var transform = this.entity.getLocalTransform();
+     * const transform = this.entity.getLocalTransform();
      */
     getLocalTransform() {
         if (this._dirtyLocal) {
@@ -674,7 +674,7 @@ class GraphNode extends EventHandler {
      * In order to set the world-space position of the graph node, use {@link GraphNode#setPosition}.
      * @returns {Vec3} The world space position of the graph node.
      * @example
-     * var position = this.entity.getPosition();
+     * const position = this.entity.getPosition();
      * position.x = 10;
      * this.entity.setPosition(position);
      */
@@ -691,7 +691,7 @@ class GraphNode extends EventHandler {
      * to set the world-space rotation of the graph node, use {@link GraphNode#setRotation}.
      * @returns {Quat} The world space rotation of the graph node as a quaternion.
      * @example
-     * var rotation = this.entity.getRotation();
+     * const rotation = this.entity.getRotation();
      */
     getRotation() {
         this.rotation.setFromMat4(this.getWorldTransform());
@@ -710,7 +710,7 @@ class GraphNode extends EventHandler {
      * that it is not possible to set the world space scale of a graph node directly.
      * @returns {Vec3} The world space scale of the graph node.
      * @example
-     * var scale = this.entity.getScale();
+     * const scale = this.entity.getScale();
      */
     getScale() {
         if (!this._scale) {
@@ -725,7 +725,7 @@ class GraphNode extends EventHandler {
      * @description Get the world transformation matrix for this graph node.
      * @returns {Mat4} The node's world transformation matrix.
      * @example
-     * var transform = this.entity.getWorldTransform();
+     * const transform = this.entity.getWorldTransform();
      */
     getWorldTransform() {
         if (!this._dirtyLocal && !this._dirtyWorld)
@@ -777,7 +777,7 @@ class GraphNode extends EventHandler {
      * this.entity.setLocalEulerAngles(0, 90, 0);
      * @example
      * // Set rotation of 90 degrees around y-axis via a vector
-     * var angles = new pc.Vec3(0, 90, 0);
+     * const angles = new pc.Vec3(0, 90, 0);
      * this.entity.setLocalEulerAngles(angles);
      */
     setLocalEulerAngles(x, y, z) {
@@ -806,7 +806,7 @@ class GraphNode extends EventHandler {
      * this.entity.setLocalPosition(0, 10, 0);
      * @example
      * // Set via vector
-     * var pos = new pc.Vec3(0, 10, 0);
+     * const pos = new pc.Vec3(0, 10, 0);
      * this.entity.setLocalPosition(pos);
      */
     setLocalPosition(x, y, z) {
@@ -836,7 +836,7 @@ class GraphNode extends EventHandler {
      * this.entity.setLocalRotation(0, 0, 0, 1);
      * @example
      * // Set via quaternion
-     * var q = pc.Quat();
+     * const q = pc.Quat();
      * this.entity.setLocalRotation(q);
      */
     setLocalRotation(x, y, z, w) {
@@ -865,7 +865,7 @@ class GraphNode extends EventHandler {
      * this.entity.setLocalScale(10, 10, 10);
      * @example
      * // Set via vector
-     * var scale = new pc.Vec3(10, 10, 10);
+     * const scale = new pc.Vec3(10, 10, 10);
      * this.entity.setLocalScale(scale);
      */
     setLocalScale(x, y, z) {
@@ -929,7 +929,7 @@ class GraphNode extends EventHandler {
      * this.entity.setPosition(0, 10, 0);
      * @example
      * // Set via vector
-     * var position = new pc.Vec3(0, 10, 0);
+     * const position = new pc.Vec3(0, 10, 0);
      * this.entity.setPosition(position);
      */
     setPosition(x, y, z) {
@@ -966,7 +966,7 @@ class GraphNode extends EventHandler {
      * this.entity.setRotation(0, 0, 0, 1);
      * @example
      * // Set via quaternion
-     * var q = pc.Quat();
+     * const q = pc.Quat();
      * this.entity.setRotation(q);
      */
     setRotation(x, y, z, w) {
@@ -1004,7 +1004,7 @@ class GraphNode extends EventHandler {
      * this.entity.setEulerAngles(0, 90, 0);
      * @example
      * // Set rotation of 90 degrees around world-space y-axis via a vector
-     * var angles = new pc.Vec3(0, 90, 0);
+     * const angles = new pc.Vec3(0, 90, 0);
      * this.entity.setEulerAngles(angles);
      */
     setEulerAngles(x, y, z) {
@@ -1030,7 +1030,7 @@ class GraphNode extends EventHandler {
      * @description Add a new child to the child list and update the parent value of the child node.
      * @param {GraphNode} node - The new child to add.
      * @example
-     * var e = new pc.Entity(app);
+     * const e = new pc.Entity(app);
      * this.entity.addChild(e);
      */
     addChild(node) {
@@ -1071,7 +1071,7 @@ class GraphNode extends EventHandler {
      * @param {GraphNode} node - The new child to insert.
      * @param {number} index - The index in the child list of the parent where the new node will be inserted.
      * @example
-     * var e = new pc.Entity(app);
+     * const e = new pc.Entity(app);
      * this.entity.insertChild(e, 1);
      */
     insertChild(node, index) {
@@ -1156,7 +1156,7 @@ class GraphNode extends EventHandler {
      * @description Remove the node from the child list and update the parent value of the child.
      * @param {GraphNode} child - The node to remove.
      * @example
-     * var child = this.entity.children[0];
+     * const child = this.entity.children[0];
      * this.entity.removeChild(child);
      */
     removeChild(child) {
@@ -1280,11 +1280,11 @@ class GraphNode extends EventHandler {
      * @param {number} [uz=0] - Z-component of the up vector for the look at transform.
      * @example
      * // Look at another entity, using the (default) positive y-axis for up
-     * var position = otherEntity.getPosition();
+     * const position = otherEntity.getPosition();
      * this.entity.lookAt(position);
      * @example
      * // Look at another entity, using the negative world y-axis for up
-     * var position = otherEntity.getPosition();
+     * const position = otherEntity.getPosition();
      * this.entity.lookAt(position, pc.Vec3.DOWN);
      * @example
      * // Look at the world space origin, using the (default) positive y-axis for up
@@ -1329,7 +1329,7 @@ class GraphNode extends EventHandler {
      * this.entity.translate(10, 0, 0);
      * @example
      * // Translate via vector
-     * var t = new pc.Vec3(10, 0, 0);
+     * const t = new pc.Vec3(10, 0, 0);
      * this.entity.translate(t);
      */
     translate(x, y, z) {
@@ -1358,7 +1358,7 @@ class GraphNode extends EventHandler {
      * this.entity.translateLocal(10, 0, 0);
      * @example
      * // Translate via vector
-     * var t = new pc.Vec3(10, 0, 0);
+     * const t = new pc.Vec3(10, 0, 0);
      * this.entity.translateLocal(t);
      */
     translateLocal(x, y, z) {
@@ -1390,7 +1390,7 @@ class GraphNode extends EventHandler {
      * this.entity.rotate(0, 90, 0);
      * @example
      * // Rotate via vector
-     * var r = new pc.Vec3(0, 90, 0);
+     * const r = new pc.Vec3(0, 90, 0);
      * this.entity.rotate(r);
      */
     rotate(x, y, z) {
@@ -1430,7 +1430,7 @@ class GraphNode extends EventHandler {
      * this.entity.rotateLocal(0, 90, 0);
      * @example
      * // Rotate via vector
-     * var r = new pc.Vec3(0, 90, 0);
+     * const r = new pc.Vec3(0, 90, 0);
      * this.entity.rotateLocal(r);
      */
     rotateLocal(x, y, z) {

--- a/src/scene/materials/basic-material.js
+++ b/src/scene/materials/basic-material.js
@@ -17,7 +17,7 @@ import { Material } from './material.js';
  * modulated by the color property.
  * @example
  * // Create a new Basic material
- * var material = new pc.BasicMaterial();
+ * const material = new pc.BasicMaterial();
  *
  * // Set the material to have a texture map that is multiplied by a red color
  * material.color.set(1, 0, 0);

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -322,7 +322,7 @@ let _params = new Set();
  * * useMorphNormal: if morphing code should be generated to morph normals.
  * @example
  * // Create a new Standard material
- * var material = new pc.StandardMaterial();
+ * const material = new pc.StandardMaterial();
  *
  * // Update the material's diffuse and specular properties
  * material.diffuse.set(1, 0, 0);
@@ -332,7 +332,7 @@ let _params = new Set();
  * material.update();
  * @example
  * // Create a new Standard material
- * var material = new pc.StandardMaterial();
+ * const material = new pc.StandardMaterial();
  *
  * // Assign a texture to the diffuse slot
  * material.diffuseMap = texture;

--- a/src/scene/mesh-instance.js
+++ b/src/scene/mesh-instance.js
@@ -78,18 +78,17 @@ class Command {
  * @property {boolean} visibleThisFrame Read this value in {@link Layer#onPostCull} to determine if the object is actually going to be rendered.
  * @example
  * // Create a mesh instance pointing to a 1x1x1 'cube' mesh
- * var mesh = pc.createBox(graphicsDevice);
- * var material = new pc.StandardMaterial();
- * var node = new pc.GraphNode();
- * var meshInstance = new pc.MeshInstance(mesh, material, node);
- *
+ * const mesh = pc.createBox(graphicsDevice);
+ * const material = new pc.StandardMaterial();
+ * const node = new pc.GraphNode();
+ * const meshInstance = new pc.MeshInstance(mesh, material, node);
  * @example
  * // A script you can attach on an entity to test if it is visible on a Layer
- * var MeshVisScript = pc.createScript('meshVisScript');
+ * const MeshVisScript = pc.createScript('meshVisScript');
+ *
  * MeshVisScript.prototype.initialize = function () {
- *     var _this = this;
- *     this.app.scene.layers.getLayerByName("World").onPostCull = function (cameraIndex) {
- *         var meshInstance = _this.entity.model.model.meshInstances[0];
+ *     this.app.scene.layers.getLayerByName("World").onPostCull = (cameraIndex) => {
+ *         const meshInstance = this.entity.model.meshInstances[0];
  *         console.log("visible: " + meshInstance.visibleThisFrame);
  *     };
  * };

--- a/src/scene/mesh.js
+++ b/src/scene/mesh.js
@@ -113,8 +113,8 @@ class GeometryVertexStream {
  * A simple example which creates a Mesh with 3 vertices, containing position coordinates only, to form a single triangle.
  *
  * ~~~javascript
- * var mesh = new pc.Mesh(device);
- * var positions = [
+ * const mesh = new pc.Mesh(device);
+ * const positions = [
  *     0, 0, 0, // pos 0
  *     1, 0, 0, // pos 1
  *     1, 1, 0  // pos 2
@@ -127,20 +127,20 @@ class GeometryVertexStream {
  * Float32Array is used for positions and uvs.
  *
  * ~~~javascript
- * var mesh = new pc.Mesh(device);
- * var positions = new Float32Array([
+ * const mesh = new pc.Mesh(device);
+ * const positions = new Float32Array([
  *     0, 0, 0, // pos 0
  *     1, 0, 0, // pos 1
  *     1, 1, 0, // pos 2
  *     0, 1, 0  // pos 3
  * ]);
- * var uvs = new Float32Array([
+ * const uvs = new Float32Array([
  *     0, 0, // uv 0
  *     1, 0, // uv 1
  *     1, 1, // uv 2
  *     0, 1  // uv 3
  * ]);
- * var indices = [
+ * const indices = [
  *     0, 1, 2, // triangle 0
  *     0, 2, 3  // triangle 1
  * ];

--- a/src/scene/model.js
+++ b/src/scene/model.js
@@ -11,7 +11,7 @@ import { SkinInstance } from './skin-instance.js';
  * @description Creates a new model.
  * @example
  * // Create a new model
- * var model = new pc.Model();
+ * const model = new pc.Model();
  * @property {GraphNode} graph The root node of the model's graph node hierarchy.
  * @property {MeshInstance[]} meshInstances An array of MeshInstances contained in this model.
  * @property {SkinInstance[]} skinInstances An array of SkinInstances contained in this model.
@@ -76,7 +76,7 @@ class Model {
      * model.
      * @returns {Model} A clone of the specified model.
      * @example
-     * var clonedModel = model.clone();
+     * const clonedModel = model.clone();
      */
     clone() {
 
@@ -181,7 +181,7 @@ class Model {
      * {@link RENDERSTYLE_WIREFRAME}.
      * @example
      * model.generateWireframe();
-     * for (var i = 0; i < model.meshInstances.length; i++) {
+     * for (let i = 0; i < model.meshInstances.length; i++) {
      *     model.meshInstances[i].renderStyle = pc.RENDERSTYLE_WIREFRAME;
      * }
      */

--- a/src/scene/picker.js
+++ b/src/scene/picker.js
@@ -90,10 +90,10 @@ class Picker {
      * @returns {MeshInstance[]} An array of mesh instances that are in the selection.
      * @example
      * // Get the selection at the point (10,20)
-     * var selection = picker.getSelection(10, 20);
+     * const selection = picker.getSelection(10, 20);
      * @example
      * // Get all models in rectangle with corners at (10,20) and (20,40)
-     * var selection = picker.getSelection(10, 20, 10, 20);
+     * const selection = picker.getSelection(10, 20, 10, 20);
      */
     getSelection(x, y, width, height) {
         const device = this.device;

--- a/src/scene/procedural.js
+++ b/src/scene/procedural.js
@@ -24,9 +24,9 @@ const shapePrimitives = [];
  * @param {number[]} indices - An array of triangle indices.
  * @returns {number[]} An array of 3-dimensional vertex normals.
  * @example
- * var normals = pc.calculateNormals(positions, indices);
- * var tangents = pc.calculateTangents(positions, normals, uvs, indices);
- * var mesh = pc.createMesh(positions, normals, tangents, uvs, indices);
+ * const normals = pc.calculateNormals(positions, indices);
+ * const tangents = pc.calculateTangents(positions, normals, uvs, indices);
+ * const mesh = pc.createMesh(positions, normals, tangents, uvs, indices);
  */
 function calculateNormals(positions, indices) {
     const triangleCount = indices.length / 3;
@@ -95,8 +95,8 @@ function calculateNormals(positions, indices) {
  * @param {number[]} indices - An array of triangle indices.
  * @returns {number[]} An array of 3-dimensional vertex tangents.
  * @example
- * var tangents = pc.calculateTangents(positions, normals, uvs, indices);
- * var mesh = pc.createMesh(positions, normals, tangents, uvs, indices);
+ * const tangents = pc.calculateTangents(positions, normals, uvs, indices);
+ * const mesh = pc.createMesh(positions, normals, tangents, uvs, indices);
  */
 function calculateTangents(positions, normals, uvs, indices) {
     // Lengyel’s Method
@@ -227,7 +227,7 @@ function calculateTangents(positions, normals, uvs, indices) {
  * @returns {Mesh} A new Mesh constructed from the supplied vertex and triangle data.
  * @example
  * // Create a simple, indexed triangle (with texture coordinates and vertex normals)
- * var mesh = pc.createMesh(graphicsDevice, [0, 0, 0, 1, 0, 0, 0, 1, 0], {
+ * const mesh = pc.createMesh(graphicsDevice, [0, 0, 0, 1, 0, 0, 0, 1, 0], {
  *     normals: [0, 0, 1, 0, 0, 1, 0, 0, 1],
  *     uvs: [0, 0, 1, 0, 0, 1],
  *     indices: [0, 1, 2]

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -611,11 +611,10 @@ class Scene extends EventHandler {
      * @param {LayerComposition} oldComp - Previously used {@link LayerComposition}.
      * @param {LayerComposition} newComp - Newly set {@link LayerComposition}.
      * @example
-     * this.app.scene.on('set:layers', function (oldComp, newComp) {
-     *     var list = newComp.layerList;
-     *     var layer;
-     *     for (var i = 0; i < list.length; i++) {
-     *         layer = list[i];
+     * this.app.scene.on('set:layers', (oldComp, newComp) => {
+     *     const list = newComp.layerList;
+     *     for (let i = 0; i < list.length; i++) {
+     *         const layer = list[i];
      *         switch (layer.name) {
      *             case 'MyLayer':
      *                 layer.onEnable = myOnEnableFunction;

--- a/src/scene/texture-atlas.js
+++ b/src/scene/texture-atlas.js
@@ -9,7 +9,7 @@ import { EventHandler } from '../core/event-handler.js';
  * @property {Texture} texture The texture atlas.
  * @property {object} frames Contains frames which define portions of the texture atlas.
  * @example
- * var atlas = new pc.TextureAtlas();
+ * const atlas = new pc.TextureAtlas();
  * atlas.frames = {
  *     '0': {
  *         // rect has u, v, width and height in pixels

--- a/src/shape/bounding-sphere.js
+++ b/src/shape/bounding-sphere.js
@@ -10,7 +10,7 @@ const tmpVecB = new Vec3();
  * @description Creates a new bounding sphere.
  * @example
  * // Create a new bounding sphere centered on the origin with a radius of 0.5
- * var sphere = new pc.BoundingSphere();
+ * const sphere = new pc.BoundingSphere();
  * @param {Vec3} [center] - The world space coordinate marking the center of the sphere. The constructor takes a reference of this parameter.
  * @param {number} [radius] - The radius of the bounding sphere. Defaults to 0.5.
  * @property {Vec3} center Center of sphere.

--- a/src/shape/frustum.js
+++ b/src/shape/frustum.js
@@ -11,7 +11,7 @@ const _frustumPoints = [new Vec3(), new Vec3(), new Vec3(), new Vec3(), new Vec3
  * create a Frustum shape directly, but instead query {@link CameraComponent#frustum}.
  * @description Creates a new frustum shape.
  * @example
- * var frustum = new pc.Frustum();
+ * const frustum = new pc.Frustum();
  */
 class Frustum {
     constructor() {
@@ -27,11 +27,11 @@ class Frustum {
      * @param {Mat4} matrix - The matrix describing the shape of the frustum.
      * @example
      * // Create a perspective projection matrix
-     * var projMat = pc.Mat4();
+     * const projMat = pc.Mat4();
      * projMat.setPerspective(45, 16 / 9, 1, 1000);
      *
      * // Create a frustum shape that is represented by the matrix
-     * var frustum = new pc.Frustum();
+     * const frustum = new pc.Frustum();
      * frustum.setFromMat4(projMat);
      */
     setFromMat4(matrix) {

--- a/src/shape/ray.js
+++ b/src/shape/ray.js
@@ -8,7 +8,7 @@ import { Vec3 } from '../math/vec3.js';
  * @example
  * // Create a new ray starting at the position of this entity and pointing down
  * // the entity's negative Z axis
- * var ray = new pc.Ray(this.entity.getPosition(), this.entity.forward);
+ * const ray = new pc.Ray(this.entity.getPosition(), this.entity.forward);
  * @param {Vec3} [origin] - The starting point of the ray. The constructor takes a reference of this parameter.
  * Defaults to the origin (0, 0, 0).
  * @param {Vec3} [direction] - The direction of the ray. The constructor takes a reference of this parameter.

--- a/src/sound/instance.js
+++ b/src/sound/instance.js
@@ -480,10 +480,10 @@ if (hasAudioContext()) {
          * @param {AudioNode} [lastNode] - The last node that will be connected to the destination of the AudioContext.
          * If unspecified then the firstNode will be connected to the destination instead.
          * @example
-         * var context = app.systems.sound.context;
-         * var analyzer = context.createAnalyzer();
-         * var distortion = context.createWaveShaper();
-         * var filter = context.createBiquadFilter();
+         * const context = app.systems.sound.context;
+         * const analyzer = context.createAnalyzer();
+         * const distortion = context.createWaveShaper();
+         * const filter = context.createBiquadFilter();
          * analyzer.connect(distortion);
          * distortion.connect(filter);
          * instance.setExternalNodes(analyzer, filter);

--- a/src/xr/xr-depth-sensing.js
+++ b/src/xr/xr-depth-sensing.js
@@ -19,10 +19,10 @@ import { XRDEPTHSENSINGUSAGE_CPU, XRDEPTHSENSINGUSAGE_GPU } from './constants.js
  * @property {number} height Height of depth texture or 0 if not available.
  * @example
  * // CPU path
- * var depthSensing = app.xr.depthSensing;
+ * const depthSensing = app.xr.depthSensing;
  * if (depthSensing.available) {
  *     // get depth in the middle of the screen, value is in meters
- *     var depth = depthSensing.getDepth(depthSensing.width / 2, depthSensing.height / 2);
+ *     const depth = depthSensing.getDepth(depthSensing.width / 2, depthSensing.height / 2);
  * }
  * @example
  * // GPU path, attaching texture to material
@@ -238,7 +238,7 @@ class XrDepthSensing extends EventHandler {
      * @param {number} v - V coordinate of pixel in depth texture, which is in range from 0.0 to 1.0 (top to bottom).
      * @description Get depth value from depth information in meters. UV is in range of 0..1, with origin in top-left corner of a texture.
      * @example
-     * var depth = app.xr.depthSensing.getDepth(u, v);
+     * const depth = app.xr.depthSensing.getDepth(u, v);
      * if (depth !== null) {
      *     // depth in meters
      * }
@@ -264,7 +264,7 @@ class XrDepthSensing extends EventHandler {
      * @description True if depth sensing information is available.
      * @example
      * if (app.xr.depthSensing.available) {
-     *     var depth = app.xr.depthSensing.getDepth(x, y);
+     *     const depth = app.xr.depthSensing.getDepth(x, y);
      * }
      */
     get available() {

--- a/src/xr/xr-hit-test.js
+++ b/src/xr/xr-hit-test.js
@@ -38,7 +38,7 @@ class XrHitTest extends EventHandler {
      * @description Fired when new {@link XrHitTestSource} is added to the list.
      * @param {XrHitTestSource} hitTestSource - Hit test source that has been added.
      * @example
-     * app.xr.hitTest.on('add', function (hitTestSource) {
+     * app.xr.hitTest.on('add', (hitTestSource) => {
      *     // new hit test source is added
      * });
      */
@@ -49,7 +49,7 @@ class XrHitTest extends EventHandler {
      * @description Fired when {@link XrHitTestSource} is removed to the list.
      * @param {XrHitTestSource} hitTestSource - Hit test source that has been removed.
      * @example
-     * app.xr.hitTest.on('remove', function (hitTestSource) {
+     * app.xr.hitTest.on('remove', (hitTestSource) => {
      *     // hit test source is removed
      * });
      */
@@ -63,7 +63,7 @@ class XrHitTest extends EventHandler {
      * @param {Quat} rotation - Rotation of hit test.
      * @param {XrInputSource|null} inputSource - If is transient hit test source, then it will provide related input source.
      * @example
-     * app.xr.hitTest.on('result', function (hitTestSource, position, rotation, inputSource) {
+     * app.xr.hitTest.on('result', (hitTestSource, position, rotation, inputSource) => {
      *     target.setPosition(position);
      *     target.setRotation(rotation);
      * });
@@ -141,20 +141,20 @@ class XrHitTest extends EventHandler {
      * @example
      * app.xr.hitTest.start({
      *     spaceType: pc.XRSPACE_VIEWER,
-     *     callback: function (err, hitTestSource) {
+     *     callback: (err, hitTestSource) => {
      *         if (err) return;
-     *         hitTestSource.on('result', function (position, rotation) {
+     *         hitTestSource.on('result', (position, rotation) => {
      *             // position and rotation of hit test result
      *             // based on Ray facing forward from the Viewer reference space
      *         });
      *     }
      * });
      * @example
-     * var ray = new pc.Ray(new pc.Vec3(0, 0, 0), new pc.Vec3(0, -1, 0));
+     * const ray = new pc.Ray(new pc.Vec3(0, 0, 0), new pc.Vec3(0, -1, 0));
      * app.xr.hitTest.start({
      *     spaceType: pc.XRSPACE_LOCAL,
      *     offsetRay: ray,
-     *     callback: function (err, hitTestSource) {
+     *     callback: (err, hitTestSource) => {
      *         // hit test source that will sample real world geometry straight down
      *         // from the position where AR session started
      *     }
@@ -162,9 +162,9 @@ class XrHitTest extends EventHandler {
      * @example
      * app.xr.hitTest.start({
      *     profile: 'generic-touchscreen',
-     *     callback: function (err, hitTestSource) {
+     *     callback: (err, hitTestSource) => {
      *         if (err) return;
-     *         hitTestSource.on('result', function (position, rotation, inputSource) {
+     *         hitTestSource.on('result', (position, rotation, inputSource) => {
      *             // position and rotation of hit test result
      *             // that will be created from touch on mobile devices
      *         });

--- a/src/xr/xr-input-source.js
+++ b/src/xr/xr-input-source.js
@@ -34,7 +34,7 @@ let ids = 0;
  * * {@link XRHAND_LEFT}: Left - indicates that input source is meant to be held in left hand.
  * * {@link XRHAND_RIGHT}: Right - indicates that input source is meant to be held in right hand.
  *
- * @property {string[]} profiles List of input profile names indicating both the prefered visual representation and behavior of the input source.
+ * @property {string[]} profiles List of input profile names indicating both the preferred visual representation and behavior of the input source.
  * @property {boolean} grip If input source can be held, then it will have node with its world transformation, that can be used to position and rotate virtual joystics based on it.
  * @property {XrHand|null} hand If input source is a tracked hand, then it will point to {@link XrHand} otherwise it is null.
  * @property {Gamepad|null} gamepad If input source has buttons, triggers, thumbstick or touchpad, then this object provides access to its states.
@@ -83,7 +83,7 @@ class XrInputSource extends EventHandler {
      * @name XrInputSource#remove
      * @description Fired when {@link XrInputSource} is removed.
      * @example
-     * inputSource.once('remove', function () {
+     * inputSource.once('remove', () => {
      *     // input source is not available anymore
      * });
      */
@@ -94,8 +94,8 @@ class XrInputSource extends EventHandler {
      * @description Fired when input source has triggered primary action. This could be pressing a trigger button, or touching a screen.
      * @param {object} evt - XRInputSourceEvent event data from WebXR API.
      * @example
-     * var ray = new pc.Ray();
-     * inputSource.on('select', function (evt) {
+     * const ray = new pc.Ray();
+     * inputSource.on('select', (evt) => {
      *     ray.set(inputSource.getOrigin(), inputSource.getDirection());
      *     if (obj.intersectsRay(ray)) {
      *         // selected an object with input source
@@ -113,7 +113,7 @@ class XrInputSource extends EventHandler {
     /**
      * @event
      * @name XrInputSource#selectend
-     * @description Fired when input source has ended triggerring primary action.
+     * @description Fired when input source has ended triggering primary action.
      * @param {object} evt - XRInputSourceEvent event data from WebXR API.
      */
 
@@ -127,10 +127,10 @@ class XrInputSource extends EventHandler {
     /**
      * @event
      * @name XrInputSource#squeezestart
-     * @description Fired when input source has started to trigger sqeeze action.
+     * @description Fired when input source has started to trigger squeeze action.
      * @param {object} evt - XRInputSourceEvent event data from WebXR API.
      * @example
-     * inputSource.on('squeezestart', function (evt) {
+     * inputSource.on('squeezestart', (evt) => {
      *     if (obj.containsPoint(inputSource.getPosition())) {
      *         // grabbed an object
      *     }
@@ -140,7 +140,7 @@ class XrInputSource extends EventHandler {
     /**
      * @event
      * @name XrInputSource#squeezeend
-     * @description Fired when input source has ended triggerring sqeeze action.
+     * @description Fired when input source has ended triggering squeeze action.
      * @param {object} evt - XRInputSourceEvent event data from WebXR API.
      */
 
@@ -150,7 +150,7 @@ class XrInputSource extends EventHandler {
      * @description Fired when new {@link XrHitTestSource} is added to the input source.
      * @param {XrHitTestSource} hitTestSource - Hit test source that has been added.
      * @example
-     * inputSource.on('hittest:add', function (hitTestSource) {
+     * inputSource.on('hittest:add', (hitTestSource) => {
      *     // new hit test source is added
      * });
      */
@@ -161,7 +161,7 @@ class XrInputSource extends EventHandler {
      * @description Fired when {@link XrHitTestSource} is removed to the the input source.
      * @param {XrHitTestSource} hitTestSource - Hit test source that has been removed.
      * @example
-     * inputSource.on('remove', function (hitTestSource) {
+     * inputSource.on('remove', (hitTestSource) => {
      *     // hit test source is removed
      * });
      */
@@ -174,7 +174,7 @@ class XrInputSource extends EventHandler {
      * @param {Vec3} position - Position of hit test.
      * @param {Quat} rotation - Rotation of hit test.
      * @example
-     * inputSource.on('hittest:result', function (hitTestSource, position, rotation) {
+     * inputSource.on('hittest:result', (hitTestSource, position, rotation) => {
      *     target.setPosition(position);
      *     target.setRotation(rotation);
      * });
@@ -342,11 +342,11 @@ class XrInputSource extends EventHandler {
      * @param {callbacks.XrHitTestStart} [options.callback] - Optional callback function
      * called once hit test source is created or failed.
      * @example
-     * app.xr.input.on('add', function (inputSource) {
+     * app.xr.input.on('add', (inputSource) => {
      *     inputSource.hitTestStart({
-     *         callback: function (err, hitTestSource) {
+     *         callback: (err, hitTestSource) => {
      *             if (err) return;
-     *             hitTestSource.on('result', function (position, rotation) {
+     *             hitTestSource.on('result', (position, rotation) => {
      *                 // position and rotation of hit test result
      *                 // that will be created from touch on mobile devices
      *             });

--- a/src/xr/xr-input.js
+++ b/src/xr/xr-input.js
@@ -34,7 +34,7 @@ class XrInput extends EventHandler {
      * @description Fired when new {@link XrInputSource} is added to the list.
      * @param {XrInputSource} inputSource - Input source that has been added.
      * @example
-     * app.xr.input.on('add', function (inputSource) {
+     * app.xr.input.on('add', (inputSource) => {
      *     // new input source is added
      * });
      */
@@ -45,7 +45,7 @@ class XrInput extends EventHandler {
      * @description Fired when {@link XrInputSource} is removed to the list.
      * @param {XrInputSource} inputSource - Input source that has been removed.
      * @example
-     * app.xr.input.on('remove', function (inputSource) {
+     * app.xr.input.on('remove', (inputSource) => {
      *     // input source is removed
      * });
      */
@@ -57,8 +57,8 @@ class XrInput extends EventHandler {
      * @param {XrInputSource} inputSource - Input source that triggered select event.
      * @param {object} evt - XRInputSourceEvent event data from WebXR API.
      * @example
-     * var ray = new pc.Ray();
-     * app.xr.input.on('select', function (inputSource, evt) {
+     * const ray = new pc.Ray();
+     * app.xr.input.on('select', (inputSource, evt) => {
      *     ray.set(inputSource.getOrigin(), inputSource.getDirection());
      *     if (obj.intersectsRay(ray)) {
      *         // selected an object with input source
@@ -77,7 +77,7 @@ class XrInput extends EventHandler {
     /**
      * @event
      * @name XrInput#selectend
-     * @description Fired when {@link XrInputSource} has ended triggerring primary action.
+     * @description Fired when {@link XrInputSource} has ended triggering primary action.
      * @param {XrInputSource} inputSource - Input source that triggered selectend event.
      * @param {object} evt - XRInputSourceEvent event data from WebXR API.
      */
@@ -93,11 +93,11 @@ class XrInput extends EventHandler {
     /**
      * @event
      * @name XrInput#squeezestart
-     * @description Fired when {@link XrInputSource} has started to trigger sqeeze action.
+     * @description Fired when {@link XrInputSource} has started to trigger squeeze action.
      * @param {XrInputSource} inputSource - Input source that triggered squeezestart event.
      * @param {object} evt - XRInputSourceEvent event data from WebXR API.
      * @example
-     * app.xr.input.on('squeezestart', function (inputSource, evt) {
+     * app.xr.input.on('squeezestart', (inputSource, evt) => {
      *     if (obj.containsPoint(inputSource.getPosition())) {
      *         // grabbed an object
      *     }
@@ -107,7 +107,7 @@ class XrInput extends EventHandler {
     /**
      * @event
      * @name XrInput#squeezeend
-     * @description Fired when {@link XrInputSource} has ended triggerring sqeeze action.
+     * @description Fired when {@link XrInputSource} has ended triggering squeeze action.
      * @param {XrInputSource} inputSource - Input source that triggered squeezeend event.
      * @param {object} evt - XRInputSourceEvent event data from WebXR API.
      */

--- a/src/xr/xr-light-estimation.js
+++ b/src/xr/xr-light-estimation.js
@@ -62,7 +62,7 @@ class XrLightEstimation extends EventHandler {
      * @param {Error} error - Error object related to failure of light estimation start.
      * @description Fired when light estimation has failed to start.
      * @example
-     * app.xr.lightEstimation.on('error', function (ex) {
+     * app.xr.lightEstimation.on('error', (ex) => {
      *     // has failed to start
      * });
      */
@@ -84,11 +84,11 @@ class XrLightEstimation extends EventHandler {
     /**
      * @function
      * @name XrLightEstimation#start
-     * @description Start estimation of illimunation data.
+     * @description Start estimation of illumination data.
      * Availability of such data will come later and an `available` event will be fired.
      * If it failed to start estimation, an `error` event will be fired.
      * @example
-     * app.xr.on('start', function () {
+     * app.xr.on('start', () => {
      *     if (app.xr.lightEstimation.supported) {
      *         app.xr.lightEstimation.start();
      *     }
@@ -168,7 +168,7 @@ class XrLightEstimation extends EventHandler {
         vec3A.set(0, 0, 0);
         vec3B.copy(lightEstimate.primaryLightDirection);
         mat4A.setLookAt(vec3B, vec3A, Vec3.UP);
-        mat4B.setFromAxisAngle(Vec3.RIGHT, 90); // direcitonal light is looking down
+        mat4B.setFromAxisAngle(Vec3.RIGHT, 90); // directional light is looking down
         mat4A.mul(mat4B);
         this._rotation.setFromMat4(mat4A);
 

--- a/src/xr/xr-manager.js
+++ b/src/xr/xr-manager.js
@@ -96,7 +96,7 @@ class XrManager extends EventHandler {
      * @param {string} type - The session type that has changed availability.
      * @param {boolean} available - True if specified session type is now available.
      * @example
-     * app.xr.on('available', function (type, available) {
+     * app.xr.on('available', (type, available) => {
      *     console.log('"' + type + '" XR session is now ' + (available ? 'available' : 'unavailable'));
      * });
      */
@@ -107,7 +107,7 @@ class XrManager extends EventHandler {
      * @description Fired when availability of specific XR type is changed.
      * @param {boolean} available - True if specified session type is now available.
      * @example
-     * app.xr.on('available:' + pc.XRTYPE_VR, function (available) {
+     * app.xr.on('available:' + pc.XRTYPE_VR, (available) => {
      *     console.log('Immersive VR session is now ' + (available ? 'available' : 'unavailable'));
      * });
      */
@@ -117,7 +117,7 @@ class XrManager extends EventHandler {
      * @name XrManager#start
      * @description Fired when XR session is started.
      * @example
-     * app.xr.on('start', function () {
+     * app.xr.on('start', () => {
      *     // XR session has started
      * });
      */
@@ -127,7 +127,7 @@ class XrManager extends EventHandler {
      * @name XrManager#end
      * @description Fired when XR session is ended.
      * @example
-     * app.xr.on('end', function () {
+     * app.xr.on('end', () => {
      *     // XR session has ended
      * });
      */
@@ -138,7 +138,7 @@ class XrManager extends EventHandler {
      * @param {object} frame - [XRFrame](https://developer.mozilla.org/en-US/docs/Web/API/XRFrame) object that can be used for interfacing directly with WebXR APIs.
      * @description Fired when XR session is updated, providing relevant XRFrame object.
      * @example
-     * app.xr.on('update', function (frame) {
+     * app.xr.on('update', (frame) => {
      *
      * });
      */
@@ -149,7 +149,7 @@ class XrManager extends EventHandler {
      * @param {Error} error - Error object related to failure of session start or check of session type support.
      * @description Fired when XR session is failed to start or failed to check for session type support.
      * @example
-     * app.xr.on('error', function (ex) {
+     * app.xr.on('error', (ex) => {
      *     // XR session has failed to start, or failed to check for session type support
      * });
      */
@@ -174,11 +174,11 @@ class XrManager extends EventHandler {
      * * {@link XRSPACE_UNBOUNDED}: Unbounded - represents a tracking space where the user is expected to move freely around their environment, potentially long distances from their starting point.
      *
      * @example
-     * button.on('click', function () {
+     * button.on('click', () => {
      *     app.xr.start(camera, pc.XRTYPE_VR, pc.XRSPACE_LOCALFLOOR);
      * });
      * @example
-     * button.on('click', function () {
+     * button.on('click', () => {
      *     app.xr.start(camera, pc.XRTYPE_AR, pc.XRSPACE_LOCALFLOOR, {
      *         depthSensing: { }
      *     });
@@ -312,7 +312,7 @@ class XrManager extends EventHandler {
      * @name XrManager#end
      * @description Attempts to end XR session and optionally fires callback when session is ended or failed to end.
      * @example
-     * app.keyboard.on('keydown', function (evt) {
+     * app.keyboard.on('keydown', (evt) => {
      *     if (evt.key === pc.KEY_ESCAPE && app.xr.active) {
      *         app.xr.end();
      *     }

--- a/src/xr/xr-plane.js
+++ b/src/xr/xr-plane.js
@@ -37,7 +37,7 @@ class XrPlane extends EventHandler {
      * @name XrPlane#remove
      * @description Fired when {@link XrPlane} is removed.
      * @example
-     * plane.once('remove', function () {
+     * plane.once('remove', () => {
      *     // plane is not available anymore
      * });
      */
@@ -47,7 +47,7 @@ class XrPlane extends EventHandler {
      * @name XrPlane#change
      * @description Fired when {@link XrPlane} attributes such as: orientation and/or points have been changed. Position and rotation can change at any time without triggering a `change` event.
      * @example
-     * plane.on('change', function () {
+     * plane.on('change', () => {
      *     // plane has been changed
      * });
      */
@@ -106,15 +106,15 @@ class XrPlane extends EventHandler {
      * @description Array of DOMPointReadOnly objects. DOMPointReadOnly is an object with `x y z` properties that defines a local point of a plane's polygon.
      * @example
      * // prepare reusable objects
-     * var vecA = new pc.Vec3();
-     * var vecB = new pc.Vec3();
-     * var color = new pc.Color(1, 1, 1);
+     * const vecA = new pc.Vec3();
+     * const vecB = new pc.Vec3();
+     * const color = new pc.Color(1, 1, 1);
      *
      * // update Mat4 to plane position and rotation
      * transform.setTRS(plane.getPosition(), plane.getRotation(), pc.Vec3.ONE);
      *
      * // draw lines between points
-     * for (var i = 0; i < plane.points.length; i++) {
+     * for (let i = 0; i < plane.points.length; i++) {
      *     vecA.copy(plane.points[i]);
      *     vecB.copy(plane.points[(i + 1) % plane.points.length]);
      *


### PR DESCRIPTION
This PR updates the JSDoc example code to use:

* `let` and `const` instead of `var`
* Arrow functions

Note that this does mean that some example code will be incompatible with IE11. According to [StatCounter](https://gs.statcounter.com/browser-market-share), IE (all versions, not just IE11) accounts for 0.57% of the browser market now.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
