### PR TITLE
Make import statements consistent

### DIFF
--- a/src/anim/evaluator/anim-evaluator.js
+++ b/src/anim/evaluator/anim-evaluator.js
@@ -1,4 +1,4 @@
-import { AnimTargetValue } from './anim-target-value';
+import { AnimTargetValue } from './anim-target-value.js';
 
 /**
  * @private

--- a/src/anim/evaluator/anim-track.js
+++ b/src/anim/evaluator/anim-track.js
@@ -1,4 +1,4 @@
-import { AnimEvents } from "./anim-events";
+import { AnimEvents } from './anim-events.js';
 
 /**
  * @private

--- a/src/deprecated/deprecated.js
+++ b/src/deprecated/deprecated.js
@@ -1,6 +1,6 @@
 import { revision, version } from '../core/core.js';
 import { string } from '../core/string.js';
-import { Timer, now } from "../core/time";
+import { Timer, now } from '../core/time.js';
 
 import { math } from '../math/math.js';
 import { Color } from '../math/color.js';

--- a/src/resources/hierarchy.js
+++ b/src/resources/hierarchy.js
@@ -1,5 +1,5 @@
 import { SceneParser } from './parser/scene.js';
-import { SceneUtils } from "./scene-utils.js";
+import { SceneUtils } from './scene-utils.js';
 
 class HierarchyHandler {
     constructor(app) {

--- a/src/resources/scene-settings.js
+++ b/src/resources/scene-settings.js
@@ -1,4 +1,4 @@
-import { SceneUtils } from "./scene-utils.js";
+import { SceneUtils } from './scene-utils.js';
 
 class SceneSettingsHandler {
     constructor(app) {

--- a/src/resources/scene.js
+++ b/src/resources/scene.js
@@ -1,5 +1,5 @@
 import { SceneParser } from './parser/scene.js';
-import { SceneUtils } from "./scene-utils.js";
+import { SceneUtils } from './scene-utils.js';
 
 /**
  * @class

--- a/src/scene/immediate/immediate-batches.js
+++ b/src/scene/immediate/immediate-batches.js
@@ -1,4 +1,4 @@
-import { ImmediateBatch } from "./immediate-batch";
+import { ImmediateBatch } from './immediate-batch.js';
 
 // helper class storing line batches for a single layer
 class ImmediateBatches {

--- a/src/scene/lightmapper/bake-light.js
+++ b/src/scene/lightmapper/bake-light.js
@@ -1,6 +1,6 @@
 import { BoundingBox } from '../../shape/bounding-box.js';
 import { BoundingSphere } from '../../shape/bounding-sphere.js';
-import { LIGHTTYPE_DIRECTIONAL } from "../constants";
+import { LIGHTTYPE_DIRECTIONAL } from '../constants.js';
 
 const tempSphere = new BoundingSphere();
 

--- a/src/scene/picker.js
+++ b/src/scene/picker.js
@@ -1,4 +1,4 @@
-import { Color } from "../math/color.js";
+import { Color } from '../math/color.js';
 
 import { ADDRESS_CLAMP_TO_EDGE, CLEARFLAG_DEPTH, FILTER_NEAREST, PIXELFORMAT_R8_G8_B8_A8 } from '../graphics/constants.js';
 import { GraphicsDevice } from '../graphics/graphics-device.js';

--- a/src/scene/renderer/cookie-renderer.js
+++ b/src/scene/renderer/cookie-renderer.js
@@ -2,7 +2,7 @@ import { Vec4 } from '../../math/vec4.js';
 import { Mat4 } from '../../math/mat4.js';
 
 import { ADDRESS_CLAMP_TO_EDGE, FILTER_NEAREST, PIXELFORMAT_R8_G8_B8_A8 } from '../../graphics/constants.js';
-import { Texture } from "../../graphics/texture.js";
+import { Texture } from '../../graphics/texture.js';
 import { createShaderFromCode } from '../../graphics/program-lib/utils.js';
 import { drawQuadWithShader } from '../../graphics/simple-post-effect.js';
 

--- a/src/shape/frustum.js
+++ b/src/shape/frustum.js
@@ -1,5 +1,5 @@
-import { Vec3 } from "../math/vec3";
-import { PROJECTION_PERSPECTIVE } from "../scene/constants";
+import { Vec3 } from '../math/vec3.js';
+import { PROJECTION_PERSPECTIVE } from '../scene/constants.js';
 
 const _frustumPoints = [new Vec3(), new Vec3(), new Vec3(), new Vec3(), new Vec3(), new Vec3(), new Vec3(), new Vec3()];
 

--- a/src/xr/xr-dom-overlay.js
+++ b/src/xr/xr-dom-overlay.js
@@ -1,4 +1,4 @@
-import { platform } from "../core/platform.js";
+import { platform } from '../core/platform.js';
 
 /**
  * @class

--- a/src/xr/xr-hand.js
+++ b/src/xr/xr-hand.js
@@ -1,4 +1,4 @@
-import { platform } from "../core/platform.js";
+import { platform } from '../core/platform.js';
 import { EventHandler } from '../core/event-handler.js';
 
 import { XRHAND_LEFT } from './constants.js';

--- a/src/xr/xr-hit-test.js
+++ b/src/xr/xr-hit-test.js
@@ -1,4 +1,4 @@
-import { platform } from "../core/platform.js";
+import { platform } from '../core/platform.js';
 import { EventHandler } from '../core/event-handler.js';
 
 import { XRSPACE_VIEWER, XRTYPE_AR } from './constants.js';

--- a/src/xr/xr-image-tracking.js
+++ b/src/xr/xr-image-tracking.js
@@ -1,4 +1,4 @@
-import { platform } from "../core/platform.js";
+import { platform } from '../core/platform.js';
 import { EventHandler } from '../core/event-handler.js';
 import { XrTrackedImage } from './xr-tracked-image.js';
 

--- a/src/xr/xr-joint.js
+++ b/src/xr/xr-joint.js
@@ -1,4 +1,4 @@
-import { platform } from "../core/platform.js";
+import { platform } from '../core/platform.js';
 import { Mat4 } from '../math/mat4.js';
 import { Quat } from '../math/quat.js';
 import { Vec3 } from '../math/vec3.js';

--- a/src/xr/xr-plane-detection.js
+++ b/src/xr/xr-plane-detection.js
@@ -1,4 +1,4 @@
-import { platform } from "../core/platform.js";
+import { platform } from '../core/platform.js';
 import { EventHandler } from '../core/event-handler.js';
 import { XrPlane } from './xr-plane.js';
 


### PR DESCRIPTION
This PR is all about consistency. A few `import` statements were using double quotes instead of single. And some missed the `.js` extension from the end of imported modules. Now they're all consistent.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
