### PR TITLE
Make unary op spacing consistent

### DIFF
--- a/src/asset/asset-registry.js
+++ b/src/asset/asset-registry.js
@@ -559,7 +559,7 @@ class AssetRegistry extends EventHandler {
         const texParams = standardMaterialTextureParameters;
         for (let i = 0; i < texParams.length; i++) {
             const path = data[texParams[i]];
-            if (path && typeof(path) === 'string') {
+            if (path && typeof path === 'string') {
                 count++;
                 const url = materialAsset.getAbsoluteUrl(path);
                 this.loadFromUrl(url, "texture", onTextureLoaded);

--- a/src/bundles/bundle-registry.js
+++ b/src/bundles/bundle-registry.js
@@ -55,7 +55,7 @@ class BundleRegistry {
     // Index the specified asset id and its file URLs so that
     // the registry knows that the asset is in that bundle
     _indexAssetInBundle(assetId, bundleAsset) {
-        if (! this._assetsInBundles[assetId]) {
+        if (!this._assetsInBundles[assetId]) {
             this._assetsInBundles[assetId] = [bundleAsset];
         } else {
             const bundles = this._assetsInBundles[assetId];
@@ -74,7 +74,7 @@ class BundleRegistry {
     // Index the file URLs of the specified asset
     _indexAssetFileUrls(asset) {
         const urls = this._getAssetFileUrls(asset);
-        if (! urls) return;
+        if (!urls) return;
 
         for (let i = 0, len = urls.length; i < len; i++) {
             const url = urls[i];
@@ -90,7 +90,7 @@ class BundleRegistry {
     // Get all the possible URLs of an asset
     _getAssetFileUrls(asset) {
         let url = asset.getFileUrl();
-        if (! url) return null;
+        if (!url) return null;
 
         url = this._normalizeUrl(url);
         const urls = [url];
@@ -127,7 +127,7 @@ class BundleRegistry {
                 const idx = array.indexOf(asset);
                 if (idx !== -1) {
                     array.splice(idx, 1);
-                    if (! array.length) {
+                    if (!array.length) {
                         delete this._assetsInBundles[id];
 
                         // make sure we do not leave that array in
@@ -162,7 +162,7 @@ class BundleRegistry {
     _onBundleLoaded(bundleAsset) {
         // this can happen if the bundleAsset failed
         // to create its resource
-        if (! bundleAsset.resource) {
+        if (!bundleAsset.resource) {
             this._onBundleError(`Bundle ${bundleAsset.id} failed to load`, bundleAsset);
             return;
         }
@@ -208,7 +208,7 @@ class BundleRegistry {
     _onBundleError(err, bundleAsset) {
         for (const url in this._fileRequests) {
             const bundle = this._findLoadedOrLoadingBundleForUrl(url);
-            if (! bundle) {
+            if (!bundle) {
                 const requests = this._fileRequests[url];
                 for (let i = 0, len = requests.length; i < len; i++) {
                     requests[i](err);
@@ -224,7 +224,7 @@ class BundleRegistry {
     // only returns the bundle if it's either loaded or being loaded
     _findLoadedOrLoadingBundleForUrl(url) {
         const bundles = this._urlsInBundles[url];
-        if (! bundles) return null;
+        if (!bundles) return null;
 
         // look for loaded bundle first...
         const len = bundles.length;
@@ -315,7 +315,7 @@ class BundleRegistry {
      */
     loadUrl(url, callback) {
         const bundle = this._findLoadedOrLoadingBundleForUrl(url);
-        if (! bundle) {
+        if (!bundle) {
             callback(`URL ${url} not found in any bundles`);
             return;
         }

--- a/src/core/platform.js
+++ b/src/core/platform.js
@@ -38,7 +38,7 @@ if (typeof navigator !== 'undefined') {
 
     gamepads = 'getGamepads' in navigator;
 
-    workers = (typeof(Worker) !== 'undefined');
+    workers = (typeof Worker !== 'undefined');
 
     try {
         const opts = Object.defineProperty({}, 'passive', {

--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -433,7 +433,7 @@ class Application extends EventHandler {
         // for compatibility
         this.context = this;
 
-        if (! options.graphicsDeviceOptions)
+        if (!options.graphicsDeviceOptions)
             options.graphicsDeviceOptions = { };
 
         if (platform.browser && !!navigator.xr) {

--- a/src/framework/components/collision/component.js
+++ b/src/framework/components/collision/component.js
@@ -264,7 +264,7 @@ class CollisionComponent extends Component {
 
         if (this._compoundParent) {
             this.system.recreatePhysicalShapes(this);
-        } else if (! this.entity.rigidbody) {
+        } else if (!this.entity.rigidbody) {
             let ancestor = this.entity.parent;
             while (ancestor) {
                 if (ancestor.collision && ancestor.collision.type === 'compound') {
@@ -340,7 +340,7 @@ class CollisionComponent extends Component {
         if (this.entity.rigidbody) {
             this.entity.rigidbody.disableSimulation();
         } else if (this._compoundParent && this !== this._compoundParent) {
-            if (! this._compoundParent.entity._destroying) {
+            if (!this._compoundParent.entity._destroying) {
                 this.system._removeCompoundChild(this._compoundParent, this.data.shape);
 
                 if (this._compoundParent.entity.rigidbody)

--- a/src/framework/components/collision/system.js
+++ b/src/framework/components/collision/system.js
@@ -84,9 +84,9 @@ class CollisionSystemImpl {
 
             data.shape = this.createPhysicalShape(component.entity, data);
 
-            const firstCompoundChild = ! component._compoundParent;
+            const firstCompoundChild = !component._compoundParent;
 
-            if (data.type === 'compound' && (! component._compoundParent || component === component._compoundParent)) {
+            if (data.type === 'compound' && (!component._compoundParent || component === component._compoundParent)) {
                 component._compoundParent = component;
 
                 entity.forEach(this._addEachDescendant, component);
@@ -95,7 +95,7 @@ class CollisionSystemImpl {
                     entity.forEach(this.system.implementations.compound._updateEachDescendant, component);
                 }
 
-                if (! component.rigidbody) {
+                if (!component.rigidbody) {
                     component._compoundParent = null;
                     let parent = entity.parent;
                     while (parent) {
@@ -128,8 +128,8 @@ class CollisionSystemImpl {
                 if (entity.enabled && entity.rigidbody.enabled) {
                     entity.rigidbody.enableSimulation();
                 }
-            } else if (! component._compoundParent) {
-                if (! entity.trigger) {
+            } else if (!component._compoundParent) {
+                if (!entity.trigger) {
                     entity.trigger = new Trigger(this.system.app, component, data);
                 } else {
                     entity.trigger.initialize(data);
@@ -153,7 +153,7 @@ class CollisionSystemImpl {
 
     beforeRemove(entity, component) {
         if (component.data.shape) {
-            if (component._compoundParent && ! component._compoundParent.entity._destroying) {
+            if (component._compoundParent && !component._compoundParent.entity._destroying) {
                 this.system._removeCompoundChild(component._compoundParent, component.data.shape);
 
                 if (component._compoundParent.entity.rigidbody)
@@ -528,7 +528,7 @@ class CollisionCompoundSystemImpl extends CollisionSystemImpl {
     }
 
     _addEachDescendant(entity) {
-        if (! entity.collision || entity.rigidbody)
+        if (!entity.collision || entity.rigidbody)
             return;
 
         entity.collision._compoundParent = this;
@@ -539,7 +539,7 @@ class CollisionCompoundSystemImpl extends CollisionSystemImpl {
     }
 
     _updateEachDescendant(entity) {
-        if (! entity.collision)
+        if (!entity.collision)
             return;
 
         if (entity.collision._compoundParent !== this)
@@ -547,13 +547,13 @@ class CollisionCompoundSystemImpl extends CollisionSystemImpl {
 
         entity.collision._compoundParent = null;
 
-        if (entity !== this.entity && ! entity.rigidbody) {
+        if (entity !== this.entity && !entity.rigidbody) {
             entity.collision.system.recreatePhysicalShapes(entity.collision);
         }
     }
 
     _updateEachDescendantTransform(entity) {
-        if (! entity.collision || entity.collision._compoundParent !== this.collision._compoundParent)
+        if (!entity.collision || entity.collision._compoundParent !== this.collision._compoundParent)
             return;
 
         this.collision.system.updateCompoundChildTransform(entity);

--- a/src/framework/components/collision/trigger.js
+++ b/src/framework/components/collision/trigger.js
@@ -18,7 +18,7 @@ class Trigger {
         this.component = component;
         this.app = app;
 
-        if (typeof Ammo !== 'undefined' && ! ammoVec1) {
+        if (typeof Ammo !== 'undefined' && !ammoVec1) {
             ammoVec1 = new Ammo.btVector3();
             ammoQuat = new Ammo.btQuaternion();
             ammoTransform = new Ammo.btTransform();

--- a/src/framework/components/element/image-element.js
+++ b/src/framework/components/element/image-element.js
@@ -598,7 +598,7 @@ class ImageElement {
         this.mesh = nineSlice ? mesh : this._defaultMesh;
 
         if (this.mesh) {
-            if (! this._element._beingInitialized) {
+            if (!this._element._beingInitialized) {
                 this._updateMesh(this.mesh);
             } else {
                 this._meshDirty = true;
@@ -952,7 +952,7 @@ class ImageElement {
         this._rect.set(x, y, z, w);
 
         if (this._renderable.mesh) {
-            if (! this._element._beingInitialized) {
+            if (!this._element._beingInitialized) {
                 this._updateMesh(this._renderable.mesh);
             } else {
                 this._meshDirty = true;

--- a/src/framework/components/element/system.js
+++ b/src/framework/components/element/system.js
@@ -183,7 +183,7 @@ class ElementComponentSystem extends ComponentSystem {
             }
             if (data.color !== undefined) {
                 color = data.color;
-                if (! (color instanceof Color)) {
+                if (!(color instanceof Color)) {
                     color = new Color(data.color[0], data.color[1], data.color[2]);
                 }
                 component.color = color;
@@ -214,7 +214,7 @@ class ElementComponentSystem extends ComponentSystem {
             }
             if (data.color !== undefined) {
                 color = data.color;
-                if (! (color instanceof Color)) {
+                if (!(color instanceof Color)) {
                     color = new Color(color[0], color[1], color[2]);
                 }
                 component.color = color;

--- a/src/framework/components/element/text-element.js
+++ b/src/framework/components/element/text-element.js
@@ -1596,9 +1596,9 @@ class TextElement {
         if (this._aabbDirty) {
             let initialized = false;
             for (let i = 0; i < this._meshInfo.length; i++) {
-                if (! this._meshInfo[i].meshInstance) continue;
+                if (!this._meshInfo[i].meshInstance) continue;
 
-                if (! initialized) {
+                if (!initialized) {
                     this._aabb.copy(this._meshInfo[i].meshInstance.aabb);
                     initialized = true;
                 } else {

--- a/src/framework/components/rigid-body/system.js
+++ b/src/framework/components/rigid-body/system.js
@@ -619,7 +619,7 @@ class RigidBodyComponentSystem extends ComponentSystem {
 
                     // fire triggerenter events for rigidbodies
                     if (e0BodyEvents) {
-                        if (! newCollision) {
+                        if (!newCollision) {
                             newCollision = this._storeCollision(e1, e0);
                         }
 
@@ -629,7 +629,7 @@ class RigidBodyComponentSystem extends ComponentSystem {
                     }
 
                     if (e1BodyEvents) {
-                        if (! newCollision) {
+                        if (!newCollision) {
                             newCollision = this._storeCollision(e0, e1);
                         }
 

--- a/src/framework/components/script/component.js
+++ b/src/framework/components/script/component.js
@@ -457,7 +457,7 @@ class ScriptComponent extends Component {
         if (attribute.array) {
             // handle entity array attribute
             const len = oldValue.length;
-            if (! len) {
+            if (!len) {
                 return;
             }
 
@@ -783,13 +783,13 @@ class ScriptComponent extends Component {
         for (const scriptName in oldScriptComponent._scriptsIndex) {
             // get the script type from the script registry
             const scriptType = this.system.app.scripts.get(scriptName);
-            if (! scriptType) {
+            if (!scriptType) {
                 continue;
             }
 
             // get the script from the component's index
             const script = oldScriptComponent._scriptsIndex[scriptName];
-            if (! script || ! script.instance) {
+            if (!script || !script.instance) {
                 continue;
             }
 
@@ -800,7 +800,7 @@ class ScriptComponent extends Component {
             // and put it in the new attributes
             const newAttributesRaw = newScriptComponent[scriptName].__attributesRaw;
             const newAttributes = newScriptComponent[scriptName].__attributes;
-            if (! newAttributesRaw && ! newAttributes) {
+            if (!newAttributesRaw && !newAttributes) {
                 continue;
             }
 
@@ -810,7 +810,7 @@ class ScriptComponent extends Component {
             // get the old script attributes from the instance
             const oldAttributes = script.instance.__attributes;
             for (const attributeName in oldAttributes) {
-                if (! oldAttributes[attributeName]) {
+                if (!oldAttributes[attributeName]) {
                     continue;
                 }
 

--- a/src/framework/entity.js
+++ b/src/framework/entity.js
@@ -465,7 +465,7 @@ function resolveDuplicatedEntityReferenceProperties(oldSubtreeRoot, oldEntity, n
         }
 
         // Handle entity script attributes
-        if (components.script && ! newEntity._app.useLegacyScriptAttributeCloning) {
+        if (components.script && !newEntity._app.useLegacyScriptAttributeCloning) {
             newEntity.script.resolveDuplicatedEntityReferenceProperties(components.script, duplicatedIdsMap);
         }
 

--- a/src/graphics/graphics-device.js
+++ b/src/graphics/graphics-device.js
@@ -3422,10 +3422,10 @@ class GraphicsDevice extends EventHandler {
         // #endif
 
         // Check for compilation errors
-        if (! this._isShaderCompiled(shader, shader._glVertexShader, definition.vshader, "vertex"))
+        if (!this._isShaderCompiled(shader, shader._glVertexShader, definition.vshader, "vertex"))
             return false;
 
-        if (! this._isShaderCompiled(shader, shader._glFragmentShader, definition.fshader, "fragment"))
+        if (!this._isShaderCompiled(shader, shader._glFragmentShader, definition.fshader, "fragment"))
             return false;
 
         if (!gl.getProgramParameter(glProgram, gl.LINK_STATUS)) {

--- a/src/input/element-input.js
+++ b/src/input/element-input.js
@@ -336,8 +336,8 @@ class ElementInput {
     }
 
     attachSelectEvents() {
-        if (! this._selectEventsAttached && this._useXr && this.app && this.app.xr && this.app.xr.supported) {
-            if (! this._clickedEntities)
+        if (!this._selectEventsAttached && this._useXr && this.app && this.app.xr && this.app.xr.supported) {
+            if (!this._clickedEntities)
                 this._clickedEntities = {};
 
             this._selectEventsAttached = true;
@@ -693,12 +693,12 @@ class ElementInput {
     }
 
     _onSelectStart(inputSource, event) {
-        if (! this._enabled) return;
+        if (!this._enabled) return;
         this._onElementSelectEvent('selectstart', inputSource, event);
     }
 
     _onSelectEnd(inputSource, event) {
-        if (! this._enabled) return;
+        if (!this._enabled) return;
         this._onElementSelectEvent('selectend', inputSource, event);
     }
 
@@ -743,7 +743,7 @@ class ElementInput {
         }
 
         const pressed = this._selectedPressedElements[inputSource.id];
-        if (! inputSource.elementInput && pressed) {
+        if (!inputSource.elementInput && pressed) {
             delete this._selectedPressedElements[inputSource.id];
             if (hoveredBefore) this._fireEvent('selectend', new ElementSelectEvent(event, hoveredBefore, camera, inputSource));
         }
@@ -898,7 +898,7 @@ class ElementInput {
         for (let i = 0, len = this._elements.length; i < len; i++) {
             const element = this._elements[i];
 
-            if (! element.screen || ! element.screen.screen.screenSpace) {
+            if (!element.screen || !element.screen.screen.screenSpace) {
                 if (this._checkElement(rayA, element, false) >= 0) {
                     result = element;
                     break;

--- a/src/resources/bundle.js
+++ b/src/resources/bundle.js
@@ -36,7 +36,7 @@ class BundleHandler {
             retry: this.maxRetries > 0,
             maxRetries: this.maxRetries
         }, function (err, response) {
-            if (! err) {
+            if (!err) {
                 try {
                     self._untar(response, callback);
                 } catch (ex) {
@@ -64,7 +64,7 @@ class BundleHandler {
 
                 // if we have no more requests for this worker then
                 // destroy it
-                if (! self._worker.hasPendingRequests()) {
+                if (!self._worker.hasPendingRequests()) {
                     self._worker.destroy();
                     self._worker = null;
                 }

--- a/src/resources/parser/material/json-standard-material.js
+++ b/src/resources/parser/material/json-standard-material.js
@@ -63,7 +63,7 @@ class JsonStandardMaterialParser {
             } else if (type === 'texture') {
                 if (value instanceof Texture) {
                     material[key] = value;
-                } else if (!(material[key] instanceof Texture && typeof(value) === 'number' && value > 0)) {
+                } else if (!(material[key] instanceof Texture && typeof value === 'number' && value > 0)) {
                     material[key] = null;
                 }
                 // OTHERWISE: material already has a texture assigned, but data contains a valid asset id (which means the asset isn't yet loaded)
@@ -71,7 +71,7 @@ class JsonStandardMaterialParser {
             } else if (type === 'cubemap') {
                 if (value instanceof Texture) {
                     material[key] = value;
-                } else if (!(material[key] instanceof Texture && typeof(value) === 'number' && value > 0)) {
+                } else if (!(material[key] instanceof Texture && typeof value === 'number' && value > 0)) {
                     material[key] = null;
                 }
                 // OTHERWISE: material already has a texture assigned, but data contains a valid asset id (which means the asset isn't yet loaded)

--- a/src/resources/untar.js
+++ b/src/resources/untar.js
@@ -96,7 +96,7 @@ function UntarScope(isWorker) {
         this._bytesRead = 0;
     }
 
-    if (! isWorker) {
+    if (!isWorker) {
         Untar = UntarInternal;
     }
 
@@ -166,7 +166,7 @@ function UntarScope(isWorker) {
             this._bytesRead += (512 - remainder);
         }
 
-        if (! normalFile) {
+        if (!normalFile) {
             return null;
         }
 
@@ -206,7 +206,7 @@ function UntarScope(isWorker) {
      * @returns {object[]} An array of files in this format {name, start, size, url}.
      */
     UntarInternal.prototype.untar = function (filenamePrefix) {
-        if (! utfDecoder) {
+        if (!utfDecoder) {
             console.error('Cannot untar because TextDecoder interface is not available for this platform.');
             return [];
         }
@@ -214,7 +214,7 @@ function UntarScope(isWorker) {
         const files = [];
         while (this._hasNext()) {
             const file = this._readNextFile();
-            if (! file) continue;
+            if (!file) continue;
             if (filenamePrefix && file.name) {
                 file.name = filenamePrefix + file.name;
             }
@@ -286,7 +286,7 @@ class UntarWorker {
 
     _onMessage(e) {
         const id = e.data.id;
-        if (! this._pendingRequests[id]) return;
+        if (!this._pendingRequests[id]) return;
 
         const callback = this._pendingRequests[id];
 

--- a/src/scene/materials/standard-material-validator.js
+++ b/src/scene/materials/standard-material-validator.js
@@ -90,15 +90,15 @@ class StandardMaterialValidator {
                 }
 
             } else if (type === 'number') {
-                if (typeof(data[key]) !== 'number') {
+                if (typeof data[key] !== 'number') {
                     this.setInvalid(key, data);
                 }
             } else if (type === 'boolean') {
-                if (typeof(data[key]) !== 'boolean') {
+                if (typeof data[key] !== 'boolean') {
                     this.setInvalid(key, data);
                 }
             } else if (type === 'string') {
-                if (typeof(data[key]) !== 'string') {
+                if (typeof data[key] !== 'string') {
                     this.setInvalid(key, data);
                 }
             } else if (type === 'vec2') {
@@ -111,7 +111,7 @@ class StandardMaterialValidator {
                 }
             } else if (type === 'texture') {
                 if (!pathMapping) {
-                    if (!(typeof(data[key]) === 'number' || data[key] === null)) {
+                    if (!(typeof data[key] === 'number' || data[key] === null)) {
                         if (!(data[key] instanceof Texture)) {
                             this.setInvalid(key, data);
                         }
@@ -120,7 +120,7 @@ class StandardMaterialValidator {
                     // this counts as a valid input
                     // null texture reference is also valid
                 } else {
-                    if (!(typeof(data[key]) === 'string' || data[key === null])) {
+                    if (!(typeof data[key] === 'string' || data[key === null])) {
                         if (!(data[key] instanceof Texture)) {
                             this.setInvalid(key, data);
                         }
@@ -135,7 +135,7 @@ class StandardMaterialValidator {
                     this.setInvalid(key, data);
                 }
             } else if (type === 'cubemap') {
-                if (!(typeof(data[key]) === 'number' || data[key] === null || data[key] === undefined)) {
+                if (!(typeof data[key] === 'number' || data[key] === null || data[key] === undefined)) {
 
                     if (!(data[key] instanceof Texture && data[key].cubemap)) {
                         this.setInvalid(key, data);
@@ -147,7 +147,7 @@ class StandardMaterialValidator {
             } else if (type === 'chunks') {
                 const chunkNames = Object.keys(data[key]);
                 for (let i = 0; i < chunkNames.length; i++) {
-                    if (typeof(data[key][chunkNames[i]]) !== 'string') {
+                    if (typeof data[key][chunkNames[i]] !== 'string') {
                         this.setInvalid(chunkNames[i], data[key]);
                     }
                 }

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -1337,7 +1337,7 @@ class ForwardRenderer {
 
                 if (newMaterial) {
 
-                    if (! drawCall._shader[pass].failed && ! device.setShader(drawCall._shader[pass])) {
+                    if (!drawCall._shader[pass].failed && !device.setShader(drawCall._shader[pass])) {
                         // #if _DEBUG
                         console.error(`Error in material "${material.name}" with flags ${objDefs}`);
                         // #endif

--- a/src/xr/xr-depth-sensing.js
+++ b/src/xr/xr-depth-sensing.js
@@ -191,7 +191,7 @@ class XrDepthSensing extends EventHandler {
     }
 
     update(frame, view) {
-        if (! this._usage)
+        if (!this._usage)
             return;
 
         let depthInfoCpu = null;
@@ -202,7 +202,7 @@ class XrDepthSensing extends EventHandler {
             depthInfoGpu = frame.getDepthInformation(view);
         }
 
-        if ((this._depthInfoCpu && ! depthInfoCpu) || (! this._depthInfoCpu && depthInfoCpu) || (this.depthInfoGpu && ! depthInfoGpu) || (! this._depthInfoGpu && depthInfoGpu)) {
+        if ((this._depthInfoCpu && !depthInfoCpu) || (!this._depthInfoCpu && depthInfoCpu) || (this.depthInfoGpu && !depthInfoGpu) || (!this._depthInfoGpu && depthInfoGpu)) {
             this._matrixDirty = true;
         }
         this._depthInfoCpu = depthInfoCpu;
@@ -222,10 +222,10 @@ class XrDepthSensing extends EventHandler {
             }
         }
 
-        if ((this._depthInfoCpu || this._depthInfoGpu) && ! this._available) {
+        if ((this._depthInfoCpu || this._depthInfoGpu) && !this._available) {
             this._available = true;
             this.fire('available');
-        } else if (! this._depthInfoCpu && ! this._depthInfoGpu && this._available) {
+        } else if (!this._depthInfoCpu && !this._depthInfoGpu && this._available) {
             this._available = false;
             this.fire('unavailable');
         }
@@ -248,7 +248,7 @@ class XrDepthSensing extends EventHandler {
         // TODO
         // GPU usage
 
-        if (! this._depthInfoCpu)
+        if (!this._depthInfoCpu)
             return null;
 
         return this._depthInfoCpu.getDepthInMeters(u, v);

--- a/src/xr/xr-dom-overlay.js
+++ b/src/xr/xr-dom-overlay.js
@@ -41,7 +41,7 @@ class XrDomOverlay {
     }
 
     get state() {
-        if (! this._supported || ! this._manager.active || ! this._manager._session.domOverlayState)
+        if (!this._supported || !this._manager.active || !this._manager._session.domOverlayState)
             return null;
 
         return this._manager._session.domOverlayState.type;
@@ -56,7 +56,7 @@ class XrDomOverlay {
      * app.xr.start(camera, pc.XRTYPE_AR, pc.XRSPACE_LOCALFLOOR);
      */
     set root(value) {
-        if (! this._supported || this._manager.active)
+        if (!this._supported || this._manager.active)
             return;
 
         this._root = value;

--- a/src/xr/xr-hand.js
+++ b/src/xr/xr-hand.js
@@ -67,7 +67,7 @@ class XrHand extends EventHandler {
 
             for (let j = 0; j < fingerJointIds[f].length; j++) {
                 const jointId = fingerJointIds[f][j];
-                if (! xrHand.get(jointId)) continue;
+                if (!xrHand.get(jointId)) continue;
 
                 const joint = new XrJoint(j, jointId, this, finger);
 
@@ -111,7 +111,7 @@ class XrHand extends EventHandler {
                 if (pose) {
                     joint.update(pose);
 
-                    if (joint.wrist && ! this._tracking) {
+                    if (joint.wrist && !this._tracking) {
                         this._tracking = true;
                         this.fire('tracking');
                     }
@@ -170,7 +170,7 @@ class XrHand extends EventHandler {
         const squeezing = this._fingerIsClosed(1) && this._fingerIsClosed(2) && this._fingerIsClosed(3) && this._fingerIsClosed(4);
 
         if (squeezing) {
-            if (! this._inputSource._squeezing) {
+            if (!this._inputSource._squeezing) {
                 this._inputSource._squeezing = true;
                 this._inputSource.fire('squeezestart');
                 this._manager.input.fire('squeezestart', this._inputSource);

--- a/src/xr/xr-hit-test-source.js
+++ b/src/xr/xr-hit-test-source.js
@@ -60,7 +60,7 @@ class XrHitTestSource extends EventHandler {
      * @description Stop and remove hit test source.
      */
     remove() {
-        if (! this._xrHitTestSource)
+        if (!this._xrHitTestSource)
             return;
 
         const sources = this.manager.hitTest.sources;
@@ -100,11 +100,11 @@ class XrHitTestSource extends EventHandler {
             const pose = results[i].getPose(this.manager._referenceSpace);
 
             let position = poolVec3.pop();
-            if (! position) position = new Vec3();
+            if (!position) position = new Vec3();
             position.copy(pose.transform.position);
 
             let rotation = poolQuat.pop();
-            if (! rotation) rotation = new Quat();
+            if (!rotation) rotation = new Quat();
             rotation.copy(pose.transform.orientation);
 
             this.fire('result', position, rotation, inputSource);

--- a/src/xr/xr-hit-test.js
+++ b/src/xr/xr-hit-test.js
@@ -84,7 +84,7 @@ class XrHitTest extends EventHandler {
     }
 
     _onSessionEnd() {
-        if (! this._session)
+        if (!this._session)
             return;
 
         this._session = null;
@@ -98,10 +98,10 @@ class XrHitTest extends EventHandler {
     isAvailable(callback, fireError) {
         let err;
 
-        if (! this._supported)
+        if (!this._supported)
             err = new Error('XR HitTest is not supported');
 
-        if (! this._session)
+        if (!this._session)
             err = new Error('XR Session is not started (1)');
 
         if (this.manager.type !== XRTYPE_AR)
@@ -174,10 +174,10 @@ class XrHitTest extends EventHandler {
     start(options) {
         options = options || { };
 
-        if (! this.isAvailable(options.callback, this))
+        if (!this.isAvailable(options.callback, this))
             return;
 
-        if (! options.profile && ! options.spaceType)
+        if (!options.profile && !options.spaceType)
             options.spaceType = XRSPACE_VIEWER;
 
         let xrRay;
@@ -188,7 +188,7 @@ class XrHitTest extends EventHandler {
 
         if (options.spaceType) {
             this._session.requestReferenceSpace(options.spaceType).then((referenceSpace) => {
-                if (! this._session) {
+                if (!this._session) {
                     const err = new Error('XR Session is not started (2)');
                     if (callback) callback(err);
                     this.fire('error', err);
@@ -224,7 +224,7 @@ class XrHitTest extends EventHandler {
     }
 
     _onHitTestSource(xrHitTestSource, transient, callback) {
-        if (! this._session) {
+        if (!this._session) {
             xrHitTestSource.cancel();
             const err = new Error('XR Session is not started (3)');
             if (callback) callback(err);

--- a/src/xr/xr-image-tracking.js
+++ b/src/xr/xr-image-tracking.js
@@ -48,7 +48,7 @@ class XrImageTracking extends EventHandler {
      * app.xr.imageTracking.add(bookCoverImg, 0.2);
      */
     add(image, width) {
-        if (! this._supported || this._manager.active) return null;
+        if (!this._supported || this._manager.active) return null;
 
         const trackedImage = new XrTrackedImage(image, width);
         this._images.push(trackedImage);
@@ -113,7 +113,7 @@ class XrImageTracking extends EventHandler {
     }
 
     update(frame) {
-        if (! this._available) return;
+        if (!this._available) return;
 
         const results = frame.getImageTrackingResults();
         const index = { };
@@ -129,10 +129,10 @@ class XrImageTracking extends EventHandler {
         }
 
         for (let i = 0; i < this._images.length; i++) {
-            if (this._images[i]._tracking && ! index[i]) {
+            if (this._images[i]._tracking && !index[i]) {
                 this._images[i]._tracking = false;
                 this._images[i].fire('untracked');
-            } else if (! this._images[i]._tracking && index[i]) {
+            } else if (!this._images[i]._tracking && index[i]) {
                 this._images[i]._tracking = true;
                 this._images[i].fire('tracked');
             }

--- a/src/xr/xr-input-source.js
+++ b/src/xr/xr-input-source.js
@@ -189,7 +189,7 @@ class XrInputSource extends EventHandler {
             if (this._xrInputSource.gripSpace) {
                 const gripPose = frame.getPose(this._xrInputSource.gripSpace, this._manager._referenceSpace);
                 if (gripPose) {
-                    if (! this._grip) {
+                    if (!this._grip) {
                         this._grip = true;
 
                         this._localTransform = new Mat4();
@@ -257,7 +257,7 @@ class XrInputSource extends EventHandler {
      * @returns {Vec3|null} The world space position of handheld input source.
      */
     getPosition() {
-        if (! this._position) return null;
+        if (!this._position) return null;
 
         this._updateTransforms();
         this._worldTransform.getTranslation(this._position);
@@ -282,7 +282,7 @@ class XrInputSource extends EventHandler {
      * @returns {Quat|null} The world space rotation of handheld input source.
      */
     getRotation() {
-        if (! this._rotation) return null;
+        if (!this._rotation) return null;
 
         this._updateTransforms();
         this._rotation.setFromMat4(this._worldTransform);
@@ -438,7 +438,7 @@ class XrInputSource extends EventHandler {
 
         this._elementInput = value;
 
-        if (! this._elementInput)
+        if (!this._elementInput)
             this._elementEntity = null;
     }
 

--- a/src/xr/xr-joint.js
+++ b/src/xr/xr-joint.js
@@ -42,7 +42,7 @@ class XrJoint {
         this._hand = hand;
         this._finger = finger;
         this._wrist = id === 'wrist';
-        this._tip = this._finger && !! tipJointIdsIndex[id];
+        this._tip = this._finger && !!tipJointIdsIndex[id];
 
         this._radius = null;
 

--- a/src/xr/xr-light-estimation.js
+++ b/src/xr/xr-light-estimation.js
@@ -68,8 +68,8 @@ class XrLightEstimation extends EventHandler {
      */
 
     _onSessionStart() {
-        const supported = !! this._manager.session.requestLightProbe;
-        if (! supported) return;
+        const supported = !!this._manager.session.requestLightProbe;
+        if (!supported) return;
         this._supported = true;
     }
 
@@ -97,16 +97,16 @@ class XrLightEstimation extends EventHandler {
     start() {
         let err;
 
-        if (! this._manager.session)
+        if (!this._manager.session)
             err = new Error('XR session is not running');
 
-        if (! err && this._manager.type !== XRTYPE_AR)
+        if (!err && this._manager.type !== XRTYPE_AR)
             err = new Error('XR session type is not AR');
 
-        if (! err && ! this._supported)
+        if (!err && !this._supported)
             err = new Error('light-estimation is not supported');
 
-        if (! err && this._lightProbe || this._lightProbeRequested)
+        if (!err && this._lightProbe || this._lightProbeRequested)
             err = new Error('light estimation is already requested');
 
         if (err) {
@@ -146,12 +146,12 @@ class XrLightEstimation extends EventHandler {
     }
 
     update(frame) {
-        if (! this._lightProbe) return;
+        if (!this._lightProbe) return;
 
         const lightEstimate = frame.getLightEstimate(this._lightProbe);
-        if (! lightEstimate) return;
+        if (!lightEstimate) return;
 
-        if (! this._available) {
+        if (!this._available) {
             this._available = true;
             this.fire('available');
         }

--- a/src/xr/xr-manager.js
+++ b/src/xr/xr-manager.js
@@ -41,7 +41,7 @@ class XrManager extends EventHandler {
 
         this.app = app;
 
-        this._supported = platform.browser && !! navigator.xr;
+        this._supported = platform.browser && !!navigator.xr;
 
         this._available = { };
 
@@ -195,10 +195,10 @@ class XrManager extends EventHandler {
     start(camera, type, spaceType, options) {
         let callback = options;
 
-        if (typeof(options) === 'object')
+        if (typeof options === 'object')
             callback = options.callback;
 
-        if (! this._available[type]) {
+        if (!this._available[type]) {
             if (callback) callback(new Error('XR is not available'));
             return;
         }
@@ -320,7 +320,7 @@ class XrManager extends EventHandler {
      * @param {callbacks.XrError} [callback] - Optional callback function called once session is started. The callback has one argument Error - it is null if successfully started XR session.
      */
     end(callback) {
-        if (! this._session) {
+        if (!this._session) {
             if (callback) callback(new Error('XR Session is not initialized'));
             return;
         }
@@ -403,7 +403,7 @@ class XrManager extends EventHandler {
             session.removeEventListener('end', onEnd);
             session.removeEventListener('visibilitychange', onVisibilityChange);
 
-            if (! failed) this.fire('end');
+            if (!failed) this.fire('end');
 
             // old requestAnimationFrame will never be triggered,
             // so queue up new tick
@@ -449,7 +449,7 @@ class XrManager extends EventHandler {
         this._depthNear = near;
         this._depthFar = far;
 
-        if (! this._session)
+        if (!this._session)
             return;
 
         // if session is available,
@@ -461,7 +461,7 @@ class XrManager extends EventHandler {
     }
 
     update(frame) {
-        if (! this._session) return;
+        if (!this._session) return;
 
         // canvas resolution should be set on first frame availability or resolution changes
         const width = frame.session.renderState.baseLayer.framebufferWidth;
@@ -479,7 +479,7 @@ class XrManager extends EventHandler {
             // add new views into list
             for (let i = 0; i <= (lengthNew - this.views.length); i++) {
                 let view = this.viewsPool.pop();
-                if (! view) {
+                if (!view) {
                     view = {
                         viewport: new Vec4(),
                         projMat: new Mat4(),
@@ -560,7 +560,7 @@ class XrManager extends EventHandler {
     }
 
     get active() {
-        return !! this._session;
+        return !!this._session;
     }
 
     get type() {
@@ -576,7 +576,7 @@ class XrManager extends EventHandler {
     }
 
     get visibilityState() {
-        if (! this._session)
+        if (!this._session)
             return null;
 
         return this._session.visibilityState;

--- a/src/xr/xr-plane-detection.js
+++ b/src/xr/xr-plane-detection.js
@@ -94,7 +94,7 @@ class XrPlaneDetection extends EventHandler {
     update(frame) {
         let detectedPlanes;
 
-        if (! this._available) {
+        if (!this._available) {
             try {
                 detectedPlanes = frame.detectedPlanes;
                 this._planes = [];
@@ -124,7 +124,7 @@ class XrPlaneDetection extends EventHandler {
         for (const xrPlane of detectedPlanes) {
             let plane = this._planesIndex.get(xrPlane);
 
-            if (! plane) {
+            if (!plane) {
                 // detected plane is not indexed
                 // then create new XrPlane
                 plane = new XrPlane(this, xrPlane);


### PR DESCRIPTION
Enable the ESLint rule [`space-unary-ops`](https://eslint.org/docs/rules/space-unary-ops#require-or-disallow-spaces-beforeafter-unary-operators-space-unary-ops).

Rule setting:

```
    "space-unary-ops": [
      "error", {
        "words": true,
        "nonwords": false,
        "overrides": {
        }
    }],
```

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
