### PR TITLE
Used instanceof to check against Entity type directly in Anim rootBone assignment

### DIFF
--- a/src/framework/components/anim/component.js
+++ b/src/framework/components/anim/component.js
@@ -12,7 +12,7 @@ import { AnimComponentBinder } from './component-binder.js';
 import { AnimComponentLayer } from './component-layer.js';
 import { AnimStateGraph } from '../../../anim/state-graph/anim-state-graph.js';
 import { AnimEvents } from '../../../anim/evaluator/anim-events.js';
-import { Entity } from "../../entity";
+import { Entity } from "../../entity.js";
 
 /**
  * @component


### PR DESCRIPTION
Fixes https://github.com/playcanvas/engine/issues/3618

@ellthompson Please give this once over :) 

`constructor.name` is not `Entity` in the minified build as the constructor/class name is minified to be smaller so it will `t` or similar.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
