### PR TITLE
[Examples Browser] UI updates

### DIFF
--- a/examples/src/app/code-editor.tsx
+++ b/examples/src/app/code-editor.tsx
@@ -23,7 +23,11 @@ interface CodeEditorProps {
     files: Array<File>,
     setFiles: (value: Array<File>) => void,
     setLintErrors: (value: boolean) => void,
-    useTypescript: boolean
+    useTypescript: boolean,
+    hasEditedFiles: boolean,
+    lintErrors: boolean,
+    languageButtonRef: React.RefObject<unknown>,
+    playButtonRef: React.RefObject<unknown>
 }
 
 const CodeEditor = (props: CodeEditorProps) => {
@@ -71,11 +75,7 @@ const CodeEditor = (props: CodeEditorProps) => {
 
     useEffect(() => {
         const codePane = document.getElementById('codePane');
-        if (files.length > 2) {
-            codePane.classList.add('multiple-files');
-        } else {
-            codePane.classList.remove('multiple-files');
-        }
+        codePane.classList.add('multiple-files');
         if (!files[selectedFile]) setSelectedFile(props.useTypescript ? 1 : 0);
         if (props.useTypescript && selectedFile === 0) {
             selectFile(1);
@@ -92,15 +92,24 @@ const CodeEditor = (props: CodeEditorProps) => {
         (window as any).toggleEvent = true;
     });
 
-    return <Panel headerText='CODE' id='codePane' class={localStorage.getItem('codePaneCollapsed') !== 'false' ? 'collapsed' : null}>
+    return <Panel headerText='CODE' id='codePane' class={localStorage.getItem('codePaneCollapsed') !== 'false' ? 'collapsed' : null} resizable='left' resizeMax={2000}>
         <div className='panel-toggle' id='codePane-panel-toggle'/>
-        { props.files && props.files.length > 2 && <Container class='tabs-container'>
-            {props.files.map((file: File, index: number) => {
-                const hidden = (props.useTypescript && index === 0 || !props.useTypescript && index === 1);
-                return <Button key={index} id={`code-editor-file-tab-${index}`} hidden={hidden} text={file.name.indexOf('.') === -1 ? `${file.name}.${file.type}` : file.name} class={index === selectedFile ? 'selected' : ''} onClick={() => selectFile(index)}/>;
-            })}
+        <Container class='tabs-wrapper'>
+            <Container class='code-editor-menu-container'>
+                <Button id='play-button' enabled={!props.lintErrors && props.hasEditedFiles} icon='E304' text='' ref={props.playButtonRef} />
+                <Button id='language-button' text={props.useTypescript ? 'JS' : 'TS'} ref={props.languageButtonRef} />
+                <Button icon='E259' text='' onClick={() => {
+                    const examplePath = location.hash === '#/' ? 'misc/hello-world' : location.hash.replace('#/', '');
+                    window.open(`https://github.com/playcanvas/engine/blob/dev/examples/src/examples/${examplePath}.tsx`);
+                }}/>
+            </Container>
+            <Container class='tabs-container'>
+                {props.files.map((file: File, index: number) => {
+                    const hidden = (props.useTypescript && index === 0 || !props.useTypescript && index === 1);
+                    return <Button key={index} id={`code-editor-file-tab-${index}`} hidden={hidden} text={file.name.indexOf('.') === -1 ? `${file.name}.${file.type}` : file.name} class={index === selectedFile ? 'selected' : ''} onClick={() => selectFile(index)}/>;
+                })}
+            </Container>
         </Container>
-        }
         <MonacoEditor
             language={FILE_TYPE_LANGUAGES[files[selectedFile]?.type]}
             value={files[selectedFile]?.text}

--- a/examples/src/app/code-editor.tsx
+++ b/examples/src/app/code-editor.tsx
@@ -82,6 +82,14 @@ const CodeEditor = (props: CodeEditorProps) => {
         } else if (!props.useTypescript && selectedFile === 1) {
             selectFile(0);
         }
+        // @ts-ignore
+        codePane.ui.on('resize', () => {
+            localStorage.setItem('codePaneStyle', codePane.getAttribute('style'));
+        });
+        const codePaneStyle = localStorage.getItem('codePaneStyle');
+        if (codePaneStyle) {
+            codePane.setAttribute('style', codePaneStyle);
+        }
         if ((window as any).toggleEvent) return;
         // set up the code panel toggle button
         const panelToggleDiv = codePane.querySelector('.panel-toggle');
@@ -92,7 +100,7 @@ const CodeEditor = (props: CodeEditorProps) => {
         (window as any).toggleEvent = true;
     });
 
-    return <Panel headerText='CODE' id='codePane' class={localStorage.getItem('codePaneCollapsed') !== 'false' ? 'collapsed' : null} resizable='left' resizeMax={2000}>
+    return <Panel headerText='CODE' id='codePane' class={localStorage.getItem('codePaneCollapsed') === 'true' ? 'collapsed' : null} resizable='left' resizeMax={2000}>
         <div className='panel-toggle' id='codePane-panel-toggle'/>
         <Container class='tabs-wrapper'>
             <Container class='code-editor-menu-container'>

--- a/examples/src/app/control-panel.tsx
+++ b/examples/src/app/control-panel.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 // @ts-ignore: library file import
 import { playcanvasTypeDefs } from './helpers/raw-file-loading';
 import MonacoEditor from "@monaco-editor/react";
@@ -11,8 +11,8 @@ import Button from '@playcanvas/pcui/Button/component';
 
 const ControlPanel = (props: any) => {
     const [state, setState] = useState({
-        showParameters: !!props.controls,
-        showCode: !props.controls,
+        showParameters: false,
+        showCode: true,
         collapsed: window.top.innerWidth < 601
     });
     const beforeMount = (monaco: any) => {
@@ -34,7 +34,7 @@ const ControlPanel = (props: any) => {
         document.getElementById('codeButton').classList.toggle('selected');
         const controls = document.getElementById('controlPanel-controls');
         // @ts-ignore
-        controls.ui.hidden = !controls.ui.hidden;
+        controls.classList.remove('pcui-hidden');
     };
     const onClickCodeTab = () => {
         if (document.getElementById('codeButton').classList.contains('selected')) {
@@ -49,13 +49,21 @@ const ControlPanel = (props: any) => {
         document.getElementById('codeButton').classList.toggle('selected');
         const controls = document.getElementById('controlPanel-controls');
         // @ts-ignore
-        controls.ui.hidden = !controls.ui.hidden;
+        controls.classList.add('pcui-hidden');
     };
 
-    return <Panel id='controlPanel' class={[window.top.innerWidth > 600 && !props.controls ? 'empty' : 'null', window.top.innerWidth < 601 ? 'mobile' : null]} resizable='top' headerText={window.top.innerWidth < 601 ? (props.controls ? 'CONTROLS & CODE' : 'CODE') : 'CONTROLS'} collapsible={true} collapsed={state.collapsed}>
+    useEffect(() => {
+        if (window.top.innerWidth < 601) {
+            const controls = document.getElementById('controlPanel-controls');
+            // @ts-ignore
+            controls.ui.hidden = true;
+        }
+    });
+
+    return <Panel id='controlPanel' class={[window.top.innerWidth > 600 && !props.controls ? 'empty' : 'null', window.top.innerWidth < 601 ? 'mobile' : null]} resizable='top' headerText={window.top.innerWidth < 601 ? (props.controls ? 'CODE & CONTROLS' : 'CODE') : 'CONTROLS'} collapsible={true} collapsed={state.collapsed}>
         { window.top.innerWidth < 601 && props.controls && <Container id= 'controlPanel-tabs' class='tabs-container'>
-            <Button text='PARAMETERS' class={state.showParameters ? 'selected' : null} id='paramButton' onClick={onClickParametersTab} />
             <Button text='CODE' id='codeButton' class={state.showCode ? 'selected' : null} onClick={onClickCodeTab}/>
+            <Button text='PARAMETERS' class={state.showParameters ? 'selected' : null} id='paramButton' onClick={onClickParametersTab} />
         </Container>
         }
         <Container id='controlPanel-controls'>

--- a/examples/src/app/index.tsx
+++ b/examples/src/app/index.tsx
@@ -88,7 +88,7 @@ const MainLayout = () => {
         }
     });
 
-    const updateExample = (newExampleDefaultFiles: Array<File>) => {
+    const updateExample = (newExampleDefaultFiles: any) => {
         setDefaultFiles(newExampleDefaultFiles);
         setEditedFiles(emptyFiles);
         setExampleFiles(emptyFiles);

--- a/examples/src/app/index.tsx
+++ b/examples/src/app/index.tsx
@@ -95,9 +95,6 @@ const MainLayout = () => {
     };
 
     const hasEditedFiles = () => {
-        if (exampleFiles[0].text.length === 0) {
-            return filesHaveChanged(defaultFiles, editedFiles);
-        }
         return filesHaveChanged(editedFiles, exampleFiles);
     };
 
@@ -123,10 +120,19 @@ const MainLayout = () => {
                     <Route key='main' path='/'>
                         <SideBar categories={examples.categories}/>
                         <Container id='main-view-wrapper'>
-                            <Menu lintErrors={lintErrors} hasEditedFiles={hasEditedFiles()} useTypescript={useTypescript} playButtonRef={playButtonRef} languageButtonRef={languageButtonRef} setShowMiniStats={updateShowMiniStats} />
+                            <Menu useTypescript={useTypescript} setShowMiniStats={updateShowMiniStats} />
                             <Container id='main-view'>
+                                <CodeEditor
+                                    lintErrors={lintErrors}
+                                    setLintErrors={setLintErrors}
+                                    hasEditedFiles={hasEditedFiles()}
+                                    playButtonRef={playButtonRef}
+                                    languageButtonRef={languageButtonRef}
+                                    useTypescript={useTypescript}
+                                    files={editedFiles[0].text.length > 0 ? editedFiles : defaultFiles}
+                                    setFiles={setEditedFiles.bind(this)}
+                                />
                                 <ExampleRoutes files={exampleFiles} setDefaultFiles={updateExample.bind(this)} />
-                                <CodeEditor useTypescript={useTypescript} files={editedFiles[0].text.length > 0 ? editedFiles : defaultFiles} setFiles={setEditedFiles.bind(this)} setLintErrors={setLintErrors} />
                             </Container>
                         </Container>
                     </Route>

--- a/examples/src/app/menu.tsx
+++ b/examples/src/app/menu.tsx
@@ -1,27 +1,18 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 
 // @ts-ignore: library file import
 import Container from '@playcanvas/pcui/Container/component';
 // @ts-ignore: library file import
 import Button from '@playcanvas/pcui/Button/component';
-// @ts-ignore: library file import
-import Label from '@playcanvas/pcui/Label/component';
-// @ts-ignore: library file import
-import TextAreaInput from '@playcanvas/pcui/TextAreaInput/component';
 
 interface MenuProps {
-    lintErrors: boolean,
-    hasEditedFiles: boolean,
     useTypescript: boolean,
-    languageButtonRef: any,
-    playButtonRef: any,
     setShowMiniStats: (value: boolean) => void
 }
 const Menu = (props: MenuProps) => {
 
     let mouseTimeout: any = null;
     let clickFullscreenListener: EventListener = null;
-    const [showEmbedContainer, setShowEmbedContainer] = useState(false);
 
     const toggleFullscreen = () => {
         if (clickFullscreenListener) {
@@ -57,42 +48,19 @@ const Menu = (props: MenuProps) => {
 
     return <Container id='menu'>
         <Container id='menu-buttons'>
-            <img src='https://playcanvas.com/viewer/static/playcanvas-logo.png' />
+            <img id='playcanvas-icon' src='https://playcanvas.com/viewer/static/playcanvas-logo.png' onClick={() => {
+                window.open("https://github.com/playcanvas/engine");
+            }}/>
             <Button icon='E256' text='' onClick={() => {
                 const tweetText = encodeURI(`Check out this @playcanvas engine example! ${location.href.replace('#/', '')}`);
                 window.open(`https://twitter.com/intent/tweet?text=${tweetText}`);
             }}/>
-            <Button icon='E236' text='' id='embed-button' onClick={() => {
-                setShowEmbedContainer(!document.getElementById('menu-embed-container'));
-                document.getElementById('embed-button').classList.toggle('selected');
-            }}/>
-            <Button icon='E259' text='' onClick={() => {
-                window.open("https://github.com/playcanvas/engine");
-            }}/>
-            <Button icon='E127' text='' id='fullscreen-button' onClick={toggleFullscreen}/>
             <Button icon='E149' id='showMiniStatsButton' text='' onClick={() => {
                 document.getElementById('showMiniStatsButton').classList.toggle('selected');
                 props.setShowMiniStats(document.getElementById('showMiniStatsButton').classList.contains('selected'));
             }}/>
-            <Button id='language-button' text={props.useTypescript ? 'JS' : 'TS'} ref={props.languageButtonRef} />
-            <Button id='play-button' enabled={!props.lintErrors && props.hasEditedFiles} icon='E131' text='' ref={props.playButtonRef} />
+            <Button icon='E127' text='' id='fullscreen-button' onClick={toggleFullscreen}/>
         </Container>
-        { showEmbedContainer && <Container id='menu-embed-container'>
-            <Label text='Copy this iframe to embed the current example in your webpage:' />
-            <TextAreaInput id='embed-text-area' enabled={false} value={`<iframe src="${location.href.replace('#/', '#/iframe/')}" frameborder="0"></iframe>`}/>
-            <Button id='copy-embed-button' text='Copy to clipboard' onClick={() => {
-                // @ts-ignore
-                const embedTextArea = document.getElementById('embed-text-area').ui;
-                // @ts-ignore
-                const embedCopyButton = document.getElementById('copy-embed-button').ui;
-                navigator.clipboard.writeText(embedTextArea.value);
-                embedTextArea.flash();
-                embedCopyButton.text = 'Copied!';
-                setTimeout(() => {
-                    embedCopyButton.text = 'Copy to clipboard';
-                }, 1000);
-            }}/>
-        </Container> }
     </Container>;
 };
 

--- a/examples/src/app/sidebar.tsx
+++ b/examples/src/app/sidebar.tsx
@@ -22,6 +22,11 @@ interface SideBarProps {
     categories: any
 }
 
+const toggleSideBar = () => {
+    const sideBar = document.getElementById('sideBar');
+    sideBar.classList.toggle('collapsed');
+};
+
 const SideBar = (props: SideBarProps) => {
     const defaultCategories = props.categories;
     const [filteredCategories, setFilteredCategories] = useState(null);
@@ -30,10 +35,9 @@ const SideBar = (props: SideBarProps) => {
     useEffect(() => {
         // set up the control panel toggle button
         const sideBar = document.getElementById('sideBar');
-        const panelToggleDiv = sideBar.querySelector('.panel-toggle');
-        panelToggleDiv.addEventListener('click', function () {
-            sideBar.classList.toggle('collapsed');
-        });
+        const panelToggleDiv = document.querySelector('.sideBar-panel-toggle');
+        panelToggleDiv.removeEventListener('click', toggleSideBar);
+        panelToggleDiv.addEventListener('click', toggleSideBar);
 
         window.addEventListener('hashchange', () => {
             setHash(location.hash);
@@ -53,10 +57,9 @@ const SideBar = (props: SideBarProps) => {
             topNavItem.scrollIntoView();
         });
 
-        const sideBarPanel = document.getElementById('sideBar-panel');
         if (!filteredCategories && document.body.offsetWidth < 601) {
             // @ts-ignore
-            sideBarPanel.ui.collapsed = true;
+            sideBar.ui.collapsed = true;
         }
         sideBar.classList.add('visible');
 
@@ -70,9 +73,8 @@ const SideBar = (props: SideBarProps) => {
 
     const categories = filteredCategories || defaultCategories;
     return (
-        <Container id='sideBar' class='small-thumbnails'>
-            <div className='panel-toggle' />
-            <Panel headerText="EXAMPLES" collapsible={document.body.offsetWidth < 601} id='sideBar-panel'>
+        <>
+            <Panel headerText="EXAMPLES" collapsible={document.body.offsetWidth < 601} collapsed={true} id='sideBar' class='small-thumbnails'>
                 <TextInput class='filter-input' keyChange placeholder="Filter..." onChange={(filter: string) => {
                     const reg = (filter && filter.length > 0) ? new RegExp(filter, 'i') : null;
                     if (!reg) {
@@ -101,23 +103,23 @@ const SideBar = (props: SideBarProps) => {
                         });
                     });
                     setFilteredCategories(updatedCategories);
-                }}/>
+                }} />
                 <LabelGroup text='Large thumbnails:'>
-                    <BooleanInput type='toggle'  binding={new BindingTwoWay()} link={{ observer, path: 'largeThumbnails' }} />
+                    <BooleanInput type='toggle' binding={new BindingTwoWay()} link={{ observer, path: 'largeThumbnails' }} />
                 </LabelGroup>
                 <Container id='sideBar-contents'>
                     {
-                        Object.keys(categories).sort((a: string, b:string) => (a > b ? 1 : -1)).map((category: string) => {
+                        Object.keys(categories).sort((a: string, b: string) => (a > b ? 1 : -1)).map((category: string) => {
                             return <Panel key={category} class="categoryPanel" headerText={categories[category].name} collapsible={true} collapsed={false}>
                                 <ul className="category-nav">
                                     {
-                                        Object.keys(categories[category].examples).sort((a: string, b:string) => (a > b ? 1 : -1)).map((example: string) => {
+                                        Object.keys(categories[category].examples).sort((a: string, b: string) => (a > b ? 1 : -1)).map((example: string) => {
                                             const isSelected = new RegExp(`/${category}/${example}$`).test(hash);
                                             const className = `nav-item ${isSelected ? 'selected' : ''}`;
                                             return <Link key={example} to={`/${category}/${example}`} onClick={() => {
-                                                const sideBarPanel = document.getElementById('sideBar-panel');
+                                                const sideBar = document.getElementById('sideBar');
                                                 // @ts-ignore
-                                                sideBarPanel.ui.collapsed = true;
+                                                sideBar.ui.collapsed = true;
                                             }}>
                                                 <div className={className} id={`link-${category}-${example}`}>
                                                     <img src={`./thumbnails/${category}_${example}.png`} />
@@ -131,11 +133,12 @@ const SideBar = (props: SideBarProps) => {
                         })
                     }
                     {
-                        Object.keys(categories).length === 0 && <Label text='No results'/>
+                        Object.keys(categories).length === 0 && <Label text='No results' />
                     }
                 </Container>
             </Panel>
-        </Container>
+            <div className='panel-toggle sideBar-panel-toggle' />
+        </>
     );
 };
 

--- a/examples/src/app/styles.css
+++ b/examples/src/app/styles.css
@@ -34,12 +34,16 @@ body {
     width: 100%;
 }
 
+#main-view {
+    flex-direction: row-reverse;
+}
+
 #codePane {
     display: flex;
     margin: 8px;
     border-radius: 6px;
     overflow: hidden;
-    min-width: 50%;
+    min-width: 30%;
 }
 
 @media only screen and (max-width: 600px) {
@@ -69,7 +73,7 @@ body {
         margin: 8px;
         position: fixed;
         z-index: 99999;
-        max-height: calc(100% - 16px);
+        max-height: calc(100% - 70px);
         min-width: calc(100% - 16px);
     }
 
@@ -97,48 +101,65 @@ body {
     margin-top: 8px;
 }
 
+.sideBar-panel-toggle {
+    left: 256px;
+    top: 8px !important;
+}
+
 @media only screen and (max-width: 600px) {
-    #sideBar > .pcui-panel > .pcui-panel-content {
-        width: calc(100% - 16px);
+    .sideBar-panel-toggle {
+        display: none;
+    }
+}
+    
+
+#sideBar.collapsed ~ .sideBar-panel-toggle {
+    left: 8px;
+        transform: rotateZ(90deg);
+}
+
+@media only screen and (max-width: 600px) {
+    #sideBar > .pcui-panel-content {
         z-index: -1;
         height: calc(100% - 48px);
-        border-radius: 6px;
         background-color: rgba(54, 67, 70, 1);
         margin-top: 0px;
-        padding-top: 32px;
     }
-    #sideBar > .pcui-panel {
+    #sideBar {
         background-color: rgba(1,1,1,0);
     }
-    #sideBar > .pcui-panel > .pcui-panel-header {
+    #sideBar > .pcui-panel-header {
         border-top-left-radius: 6px !important;
         border-top-right-radius: 6px !important;
-        /* border-radius: 6px !important; */
     }
 
-    #sideBar > .pcui-panel.pcui-collapsed > .pcui-panel-header {
+    #sideBar.pcui-collapsed > .pcui-panel-header {
         border-radius: 6px !important;
     }
 
     #sideBar-contents {
-        height: calc(100% - 108px);
-        overflow: auto;
-        margin-top: 8px;
-    }
-
-    #sideBar-panel .pcui-panel-content {
-        overflow: hidden;
+        height: calc(100% - 80px);
+        overflow-y: scroll;
+        margin-top: 0px;
+        position: absolute;
+        width: 100%;
+        max-height: 100%;
     }
 
     #sideBar {
-        opacity: 0;
+        bottom: 0px;
+        min-height: calc(100% - 70px);
+    }
+
+    #sideBar.pcui-collapsed {
+        min-height: 0;
     }
 
     #sideBar.visible {
         opacity: 1;
     }
 
-    #sideBar-panel.pcui-collapsed > .pcui-panel-content {
+    #sideBar.pcui-collapsed > .pcui-panel-content {
         display: none;
     }
 }
@@ -184,10 +205,6 @@ body {
 
 #sideBar a {
     text-decoration: none;
-}
-
-#sideBar .pcui-panel-header {
-    border-radius: 2px;
 }
 
 #sideBar .categoryPanel {
@@ -246,6 +263,11 @@ body {
     border-radius: 6px;
     overflow: hidden;
     flex-grow: 1;
+}
+@media only screen and (min-width: 601px) {
+    #canvas-container {
+        min-width: 445px;
+    }
 }
 
 #canvas-container iframe {
@@ -332,22 +354,25 @@ body {
 
 /* @media only screen and (max-width: 600px) { */
 #controlPanel.mobile {
-    bottom: 64px;
+    bottom: 48px;
     left: 8px;
     width: calc(100% - 16px);
     top: inherit;
     background-color: rgba(54, 67, 70, 1);
-    max-height: calc(100% - 112px);
+    min-height: calc(100% - 112px);
+}
+
+#controlPanel.mobile.pcui-collapsed {
+    min-height: 0;
 }
 
 #controlPanel.mobile > .pcui-panel-content {
-    min-height: 250px;
+    min-height: 100%;
 }
 #controlPanel.mobile > .pcui-panel-content > section {
-    height: calc(400px - 52px) !important;
-    width: calc(100% - 16px) !important;
-    margin: 8px;
     border-radius: 6px;
+    height: calc(100% - 32px) !important;
+    position: fixed !important;
 }
 /* } */
 
@@ -438,7 +463,7 @@ body {
     padding-top: 24px;
 }
 
-#codePane.collapsed .tabs-container {
+#codePane.collapsed .tabs-container, #codePane.collapsed .code-editor-menu-container {
     display: none;
 }
 
@@ -448,10 +473,18 @@ body {
     position: absolute;
     transform: rotate(90deg);
     margin-top: 52px;
-    margin-left: -28px;
-    padding-top: 6px;
+    margin-left: -21px;
+    padding-top: 20px;
     width: 83px;
     height: 15px !important;
+}
+
+#codePane.collapsed .pcui-panel-header {
+    left: 5px;
+}
+
+#codePane.pcui-resizable-resizing ~ #canvas-container {
+    pointer-events: none;
 }
 
 #codePane-panel-toggle {
@@ -497,9 +530,13 @@ body {
     font-size: 20px;
 }
 
+#menu #playcanvas-icon {
+    cursor: pointer;
+}
+
 #menu #language-button {
     font-weight: 900;
-    width: 34px;
+    width: 36px;
 }
 
 @media only screen and (max-width: 600px) {
@@ -513,23 +550,12 @@ body {
 
 @media only screen and (max-width: 600px) {
     #menu {
-        bottom: 8px;
-        top: inherit;
-        width: calc(100% - 32px);
+        top: 8px;
         background-color: rgba(54, 67, 70, 1);
     }
 
     #menu img {
         min-width: 32px;
-    }
-
-    #menu .pcui-button {
-        width: 100%;
-    }
-
-    #menu .pcui-button[data-icon]:before {
-        left: 50%;
-        transform: translateX(-50%);
     }
 }
 
@@ -568,7 +594,11 @@ body {
     background-color: #F60;
 }
 
-.tabs-container {
+.tabs-wrapper {
+    display: flex;
+}
+
+.tabs-container, .code-editor-menu-container {
     padding: 4px;
     margin: 8px;
     display: flex;
@@ -576,13 +606,33 @@ body {
     background-color: rgba(32, 41, 43, 1);
 }
 
-.tabs-container > .pcui-button {
+.code-editor-menu-container {
+    width: 110px;
+    min-width: 110px;
+    margin-right: 0px;
+}
+
+.tabs-container {
+    flex-grow: 1;
+}
+
+.tabs-container > .pcui-button, .code-editor-menu-container > .pcui-button {
     width: 100%;
     margin: 0px;
     border-radius: 4px;
     background-color: rgba(32, 41, 43, 1);
     outline: none;
     box-shadow: none !important;
+}
+
+.code-editor-menu-container > .pcui-button {
+    color: #fff;
+    background-color: #2c393c;
+    margin-right: 4px;
+}
+
+.code-editor-menu-container > .pcui-button:last-child {
+    margin-right: 0px;
 }
 
 .tabs-container > .pcui-button.selected {

--- a/examples/src/examples/animation/blend-trees-2d-cartesian.tsx
+++ b/examples/src/examples/animation/blend-trees-2d-cartesian.tsx
@@ -138,17 +138,26 @@ class BlendTrees2DCartesianExample extends Example {
             };
             drawPosition(ctx);
             const mouseEvent = (e: any) => {
-                if (e.buttons) {
-                    // @ts-ignore engine-tsd
-                    position = new pc.Vec2(e.offsetX, e.offsetY).scale(1 / (width / 2)).sub(new pc.Vec2(1.0, 1.0));
-                    position.y *= -1.0;
-                    modelEntity.anim.setFloat('posX', position.x);
-                    modelEntity.anim.setFloat('posY', position.y);
-                    drawPosition(ctx);
+                // @ts-ignore engine-tsd
+                if (e.targetTouches) {
+                    const offset = canvas.getBoundingClientRect();
+                    position = new pc.Vec2(e.targetTouches[0].clientX - offset.x, e.targetTouches[0].clientY - offset.y).scale(1 / (width / 2)).sub(new pc.Vec2(1.0, 1.0));
+                } else {
+                    if (e.buttons) {
+                        position = new pc.Vec2(e.offsetX, e.offsetY).scale(1 / (width / 2)).sub(new pc.Vec2(1.0, 1.0));
+                    } else {
+                        return;
+                    }
                 }
+                position.y *= -1.0;
+                modelEntity.anim.setFloat('posX', position.x);
+                modelEntity.anim.setFloat('posY', position.y);
+                drawPosition(ctx);
             };
             canvas.addEventListener('mousemove', mouseEvent);
             canvas.addEventListener('mousedown', mouseEvent);
+            canvas.addEventListener('touchmove', mouseEvent);
+            canvas.addEventListener('touchstart', mouseEvent);
         });
         return <>
             <canvas id='2d-blend-control' ref={canvasRef as React.RefObject<HTMLCanvasElement>} />

--- a/examples/src/examples/animation/blend-trees-2d-cartesian.tsx
+++ b/examples/src/examples/animation/blend-trees-2d-cartesian.tsx
@@ -138,12 +138,13 @@ class BlendTrees2DCartesianExample extends Example {
             };
             drawPosition(ctx);
             const mouseEvent = (e: any) => {
-                // @ts-ignore engine-tsd
                 if (e.targetTouches) {
                     const offset = canvas.getBoundingClientRect();
+                    // @ts-ignore engine-tsd
                     position = new pc.Vec2(e.targetTouches[0].clientX - offset.x, e.targetTouches[0].clientY - offset.y).scale(1 / (width / 2)).sub(new pc.Vec2(1.0, 1.0));
                 } else {
                     if (e.buttons) {
+                        // @ts-ignore engine-tsd
                         position = new pc.Vec2(e.offsetX, e.offsetY).scale(1 / (width / 2)).sub(new pc.Vec2(1.0, 1.0));
                     } else {
                         return;


### PR DESCRIPTION
Includes enhancements and fixes for the examples browser application.

![image](https://user-images.githubusercontent.com/1721533/139668701-8b75273b-a685-4ed1-b79f-7a402401c468.png)

- The code editor pane is now resizable, starts opened and at 30% width. #3602
- The code editor pane now includes buttons to reload the example, switch the code language and view the examples source code. #3601
- The PlayCanvas icon now opens the PlayCanvas github page on click
- Fixes an issue where the examples list would not close #3603 

- Updated mobile UI:
![image](https://user-images.githubusercontent.com/1721533/139667181-4ffb0b96-bdc3-4416-a395-7b3b2daebc0b.png)


I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
