### PR TITLE
[Fix] Lightmapper no longer leaks shadow map GPU memory

### DIFF
--- a/src/framework/components/anim/component.js
+++ b/src/framework/components/anim/component.js
@@ -94,8 +94,7 @@ class AnimComponent extends Component {
     _onStateGraphAssetChangeEvent = (asset) => {
         this._stateGraph = new AnimStateGraph(asset._data);
         this.loadStateGraph(this._stateGraph);
-    }
-
+    };
 
     get animationAssets() {
         return this._animationAssets;

--- a/src/scene/lightmapper/bake-light.js
+++ b/src/scene/lightmapper/bake-light.js
@@ -54,17 +54,19 @@ class BakeLight {
 
     startBake() {
         this.light.enabled = true;
-        this.light._cacheShadowMap = true;
+
+        // destroy shadow map the light might have
+        this.light._destroyShadowMap();
     }
 
-    endBake() {
+    endBake(shadowMapCache) {
         const light = this.light;
         light.enabled = false;
 
-        // release light shadowmap
-        light._cacheShadowMap = false;
-        if (light._isCachedShadowMap) {
-            light._destroyShadowMap();
+        // return shadow map to the cache
+        if (light.shadowMap && light.shadowMap.cached) {
+            shadowMapCache.add(light, light.shadowMap);
+            light.shadowMap = null;
         }
     }
 }

--- a/src/scene/lightmapper/lightmapper.js
+++ b/src/scene/lightmapper/lightmapper.js
@@ -818,7 +818,9 @@ class Lightmapper {
         if (!shadowMapRendered && light.castShadows) {
 
             // allocate shadow map from the cache to avoid per light allocation
-            light.shadowMap = this.shadowMapCache.get(this.device, light);
+            if (!light.shadowMap) {
+                light.shadowMap = this.shadowMapCache.get(this.device, light);
+            }
 
             if (light.type === LIGHTTYPE_DIRECTIONAL) {
                 this.renderer._shadowRenderer.cullDirectional(light, casters, this.camera);
@@ -1078,7 +1080,7 @@ class Lightmapper {
                     this.restoreMaterials(rcv);
                 }
 
-                bakeLight.endBake();
+                bakeLight.endBake(this.shadowMapCache);
 
                 // #if _DEBUG
                 device.popMarker();
@@ -1095,6 +1097,10 @@ class Lightmapper {
 
         this.restoreLights(allLights);
         this.restoreScene();
+
+        // empty cache to minimize persistent memory use .. if some cached textures are needed,
+        // they will be allocated again as needed
+        this.shadowMapCache.clear();
     }
 }
 


### PR DESCRIPTION
Fixes https://github.com/playcanvas/engine/issues/3623

- lightmapper no longer leaks shadow maps, but returns them to cache for reuse
- shadow map cache is emptied at the end of the bake
- reuse of shadow maps instead of allocating new per pass sped up AO baking engine example, bake time is down from around 400ms to 50ms.