### PR TITLE
AnimComponent syntax change

### DIFF
--- a/src/framework/components/anim/component.js
+++ b/src/framework/components/anim/component.js
@@ -57,7 +57,10 @@ class AnimComponent extends Component {
         }
 
         // remove event from previous asset
-        if (this._stateGraphAsset) this.system.app.assets.get(this._stateGraphAsset).off('change', this._onStateGraphAssetChangeEvent, this);
+        if (this._stateGraphAsset) {
+            const stateGraphAsset = this.system.app.assets.get(this._stateGraphAsset);
+            stateGraphAsset.off('change', this._onStateGraphAssetChangeEvent, this);
+        }
 
         let _id;
         let _asset;
@@ -685,7 +688,8 @@ class AnimComponent extends Component {
 
     onBeforeRemove() {
         if (Number.isFinite(this._stateGraphAsset)) {
-            this.system.app.assets.get(this._stateGraphAsset).off('change', this._onStateGraphAssetChangeEvent, this);
+            const stateGraphAsset = this.system.app.assets.get(this._stateGraphAsset);
+            stateGraphAsset.off('change', this._onStateGraphAssetChangeEvent, this);
         }
     }
 

--- a/src/framework/components/anim/component.js
+++ b/src/framework/components/anim/component.js
@@ -57,7 +57,7 @@ class AnimComponent extends Component {
         }
 
         // remove event from previous asset
-        if (this._stateGraphAsset) this.system.app.assets.get(this._stateGraphAsset).off('change', this._onStateGraphAssetChangeEvent);
+        if (this._stateGraphAsset) this.system.app.assets.get(this._stateGraphAsset).off('change', this._onStateGraphAssetChangeEvent, this);
 
         let _id;
         let _asset;
@@ -80,22 +80,22 @@ class AnimComponent extends Component {
         if (_asset.resource) {
             this._stateGraph = _asset.resource;
             this.loadStateGraph(this._stateGraph);
-            _asset.on('change', this._onStateGraphAssetChangeEvent);
+            _asset.on('change', this._onStateGraphAssetChangeEvent, this);
         } else {
             _asset.once('load', (asset) => {
                 this._stateGraph = asset.resource;
                 this.loadStateGraph(this._stateGraph);
             });
-            _asset.on('change', this._onStateGraphAssetChangeEvent);
+            _asset.on('change', this._onStateGraphAssetChangeEvent, this);
             this.system.app.assets.load(_asset);
         }
         this._stateGraphAsset = _id;
     }
 
-    _onStateGraphAssetChangeEvent = (asset) => {
+    _onStateGraphAssetChangeEvent(asset) {
         this._stateGraph = new AnimStateGraph(asset._data);
         this.loadStateGraph(this._stateGraph);
-    };
+    }
 
     get animationAssets() {
         return this._animationAssets;
@@ -685,7 +685,7 @@ class AnimComponent extends Component {
 
     onBeforeRemove() {
         if (Number.isFinite(this._stateGraphAsset)) {
-            this.system.app.assets.get(this._stateGraphAsset).off('change', this._onStateGraphAssetChangeEvent);
+            this.system.app.assets.get(this._stateGraphAsset).off('change', this._onStateGraphAssetChangeEvent, this);
         }
     }
 


### PR DESCRIPTION
The _onStateGraphAssetChangeEvent function was created as an anonymous function to give it the AnimComponent class' scope. However this is inconsistent with the rest of the repo. I've updated the AnimComponent to pass itself into the event on function call to define the correct scope.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
