### PR TITLE
Fix undefined positions bug

### DIFF
--- a/src/framework/components/layout-group/layout-calculator.js
+++ b/src/framework/components/layout-group/layout-calculator.js
@@ -396,7 +396,8 @@ function createCalculator(orientation) {
             const line = lines[lineIndex];
 
             if (line.length === 0) {
-                break;
+                positionsAllLines.push([]);
+                continue;
             }
 
             const positionsThisLine = [];

--- a/src/framework/components/layout-group/layout-calculator.js
+++ b/src/framework/components/layout-group/layout-calculator.js
@@ -396,7 +396,7 @@ function createCalculator(orientation) {
             const line = lines[lineIndex];
 
             if (line.length === 0) {
-                return;
+                break;
             }
 
             const positionsThisLine = [];


### PR DESCRIPTION
Was running into this error:
`TypeError: Cannot read properties of undefined (reading '0')`

Took a look at the code and pretty sure that this `return` on line 399 is incorrect. Not sure if it should be a `break` or a `return []`, but returning `undefined` seems like an error.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
