### PR TITLE
Refactor some single iteration loops

### DIFF
--- a/src/framework/components/animation/component.js
+++ b/src/framework/components/animation/component.js
@@ -356,8 +356,10 @@ class AnimationComponent extends Component {
 
         if (!data.currAnim && data.activate && data.enabled && this.entity.enabled) {
             // Set the first loaded animation as the current
-            const animName = Object.keys(data.animations)[0];
-            this.play(animName);
+            const animations = Object.keys(data.animations);
+            if (animations.length > 0) {
+                this.play(animations[0]);
+            }
         }
     }
 
@@ -442,8 +444,10 @@ class AnimationComponent extends Component {
         }
 
         if (data.activate && !data.currAnim) {
-            const animName = Object.keys(data.animations)[0];
-            this.play(animName);
+            const animations = Object.keys(data.animations);
+            if (animations.length > 0) {
+                this.play(animations[0]);
+            }
         }
     }
 

--- a/src/framework/components/animation/component.js
+++ b/src/framework/components/animation/component.js
@@ -356,9 +356,9 @@ class AnimationComponent extends Component {
 
         if (!data.currAnim && data.activate && data.enabled && this.entity.enabled) {
             // Set the first loaded animation as the current
-            const animations = Object.keys(data.animations);
-            if (animations.length > 0) {
-                this.play(animations[0]);
+            const animationNames = Object.keys(data.animations);
+            if (animationNames.length > 0) {
+                this.play(animationNames[0]);
             }
         }
     }
@@ -444,9 +444,9 @@ class AnimationComponent extends Component {
         }
 
         if (data.activate && !data.currAnim) {
-            const animations = Object.keys(data.animations);
-            if (animations.length > 0) {
-                this.play(animations[0]);
+            const animationNames = Object.keys(data.animations);
+            if (animationNames.length > 0) {
+                this.play(animationNames[0]);
             }
         }
     }

--- a/src/framework/components/animation/component.js
+++ b/src/framework/components/animation/component.js
@@ -49,7 +49,7 @@ class AnimationComponent extends Component {
      * @param {number} [blendTime] - The time in seconds to blend from the current
      * animation state to the start of the animation being set.
      */
-    play(name, blendTime) {
+    play(name, blendTime = 0) {
         if (!this.enabled || !this.entity.enabled) {
             return;
         }
@@ -62,8 +62,6 @@ class AnimationComponent extends Component {
             // #endif
             return;
         }
-
-        blendTime = blendTime || 0;
 
         data.prevAnim = data.currAnim;
         data.currAnim = name;
@@ -189,42 +187,40 @@ class AnimationComponent extends Component {
         if (!ids || !ids.length)
             return;
 
-        const self = this;
         const assets = this.system.app.assets;
-        const l = ids.length;
 
-        const onAssetReady = function (asset) {
+        const onAssetReady = (asset) => {
             if (asset.resources.length > 1) {
                 for (let i = 0; i < asset.resources.length; i++) {
-                    self.animations[asset.resources[i].name] = asset.resources[i];
-                    self.animationsIndex[asset.id] = asset.resources[i].name;
+                    this.animations[asset.resources[i].name] = asset.resources[i];
+                    this.animationsIndex[asset.id] = asset.resources[i].name;
                 }
             } else {
-                self.animations[asset.name] = asset.resource;
-                self.animationsIndex[asset.id] = asset.name;
+                this.animations[asset.name] = asset.resource;
+                this.animationsIndex[asset.id] = asset.name;
             }
             /* eslint-disable no-self-assign */
-            self.animations = self.animations; // assigning ensures set_animations event is fired
+            this.animations = this.animations; // assigning ensures set_animations event is fired
             /* eslint-enable no-self-assign */
         };
 
-        const onAssetAdd = function (asset) {
-            asset.off('change', self.onAssetChanged, self);
-            asset.on('change', self.onAssetChanged, self);
+        const onAssetAdd = (asset) => {
+            asset.off('change', this.onAssetChanged, this);
+            asset.on('change', this.onAssetChanged, this);
 
-            asset.off('remove', self.onAssetRemoved, self);
-            asset.on('remove', self.onAssetRemoved, self);
+            asset.off('remove', this.onAssetRemoved, this);
+            asset.on('remove', this.onAssetRemoved, this);
 
             if (asset.resource) {
                 onAssetReady(asset);
             } else {
-                asset.once('load', onAssetReady, self);
-                if (self.enabled && self.entity.enabled)
+                asset.once('load', onAssetReady, this);
+                if (this.enabled && this.entity.enabled)
                     assets.load(asset);
             }
         };
 
-        for (let i = 0; i < l; i++) {
+        for (let i = 0, l = ids.length; i < l; i++) {
             const asset = assets.get(ids[i]);
             if (asset) {
                 onAssetAdd(asset);
@@ -261,7 +257,7 @@ class AnimationComponent extends Component {
                             // restart animation
                             if (this.data.playing && this.data.enabled && this.entity.enabled) {
                                 restarted = true;
-                                this.play(newValue[i].name, 0);
+                                this.play(newValue[i].name);
                             }
                         }
                     }
@@ -282,7 +278,7 @@ class AnimationComponent extends Component {
                         // restart animation
                         if (this.data.playing && this.data.enabled && this.entity.enabled) {
                             restarted = true;
-                            this.play(asset.name, 0);
+                            this.play(asset.name);
                         }
                     }
                     if (!restarted) {
@@ -359,11 +355,9 @@ class AnimationComponent extends Component {
         }
 
         if (!data.currAnim && data.activate && data.enabled && this.entity.enabled) {
-            for (const animName in data.animations) {
-                // Set the first loaded animation as the current
-                this.play(animName, 0);
-                break;
-            }
+            // Set the first loaded animation as the current
+            const animName = Object.keys(data.animations)[0];
+            this.play(animName);
         }
     }
 
@@ -389,7 +383,7 @@ class AnimationComponent extends Component {
             }
         }
 
-        const ids = newValue.map(function (value) {
+        const ids = newValue.map((value) => {
             return (value instanceof Asset) ? value.id : value;
         });
 
@@ -448,10 +442,8 @@ class AnimationComponent extends Component {
         }
 
         if (data.activate && !data.currAnim) {
-            for (const animName in data.animations) {
-                this.play(animName, 0);
-                break;
-            }
+            const animName = Object.keys(data.animations)[0];
+            this.play(animName);
         }
     }
 

--- a/src/framework/components/animation/component.js
+++ b/src/framework/components/animation/component.js
@@ -47,7 +47,7 @@ class AnimationComponent extends Component {
      * @description Start playing an animation.
      * @param {string} name - The name of the animation asset to begin playing.
      * @param {number} [blendTime] - The time in seconds to blend from the current
-     * animation state to the start of the animation being set.
+     * animation state to the start of the animation being set. Defaults to 0.
      */
     play(name, blendTime = 0) {
         if (!this.enabled || !this.entity.enabled) {

--- a/src/framework/components/element/markup.js
+++ b/src/framework/components/element/markup.js
@@ -111,37 +111,35 @@ class Scanner {
 
     // read tag block
     _tag() {
-        while (true) {
-            switch (this._cur) {
-                case null:
-                    this._error = "unexpected end of input reading tag";
+        switch (this._cur) {
+            case null:
+                this._error = "unexpected end of input reading tag";
+                return ERROR_TOKEN;
+            case "[":
+                this._store();
+                return OPEN_BRACKET_TOKEN;
+            case "]":
+                this._store();
+                this._mode = "text";
+                return CLOSE_BRACKET_TOKEN;
+            case "=":
+                this._store();
+                return EQUALS_TOKEN;
+            case " ":
+            case "\t":
+            case "\n":
+            case "\r":
+            case "\v":
+            case "\f":
+                return this._whitespace();
+            case "\"":
+                return this._string();
+            default:
+                if (!this._isIdentifierSymbol(this._cur)) {
+                    this._error = "unrecognized character";
                     return ERROR_TOKEN;
-                case "[":
-                    this._store();
-                    return OPEN_BRACKET_TOKEN;
-                case "]":
-                    this._store();
-                    this._mode = "text";
-                    return CLOSE_BRACKET_TOKEN;
-                case "=":
-                    this._store();
-                    return EQUALS_TOKEN;
-                case " ":
-                case "\t":
-                case "\n":
-                case "\r":
-                case "\v":
-                case "\f":
-                    return this._whitespace();
-                case "\"":
-                    return this._string();
-                default:
-                    if (!this._isIdentifierSymbol(this._cur)) {
-                        this._error = "unrecognized character";
-                        return ERROR_TOKEN;
-                    }
-                    return this._identifier();
-            }
+                }
+                return this._identifier();
         }
     }
 

--- a/src/framework/components/element/text-element.js
+++ b/src/framework/components/element/text-element.js
@@ -769,6 +769,7 @@ class TextElement {
                         if (json.chars[' ']) {
                             data = json.chars[' '];
                         } else {
+                            // eslint-disable-next-line no-unreachable-loop
                             for (const key in json.chars) {
                                 data = json.chars[key];
                                 break;

--- a/src/i18n/i18n.js
+++ b/src/i18n/i18n.js
@@ -269,13 +269,7 @@ class I18n extends EventHandler {
 
             // if no more entries for that locale then
             // delete the locale
-            let hasAny = false;
-            for (const key in translations) { // eslint-disable-line no-unused-vars
-                hasAny = true;
-                break;
-            }
-
-            if (!hasAny) {
+            if (Object.keys(translations).length === 0) {
                 delete this._translations[locale];
                 delete this._availableLangs[getLang(locale)];
             }

--- a/src/resources/untar.js
+++ b/src/resources/untar.js
@@ -342,11 +342,7 @@ class UntarWorker {
      * @returns {boolean} Returns true of false.
      */
     hasPendingRequests() {
-        for (const key in this._pendingRequests) {
-            return true;
-        }
-
-        return false;
+        return Object.keys(this._pendingRequests).length > 0;
     }
 
     /**


### PR DESCRIPTION
Address all errors from ESLint's [`no-unreachable-loop`](https://eslint.org/docs/rules/no-unreachable-loop) rule. Using `Object.keys` is, in principle, slower than using a `for..in` loop, but it's more concise and easier to read, plus the instances refactored here are in non-performance critical code.

This PR also uses more ES6 features in the now legacy `AnimationComponent` (arrow functions and defaults arguments).

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
