### PR TITLE
[Fix] Fixed looping over Set to be compatible with old browsers

### DIFF
--- a/src/scene/composition/layer-composition.js
+++ b/src/scene/composition/layer-composition.js
@@ -112,7 +112,9 @@ class LayerComposition extends EventHandler {
         }
 
         // all other clusters
-        this._worldClusters.forEach((cluster) => cluster.destroy());
+        this._worldClusters.forEach((cluster) => {
+            cluster.destroy();
+        });
         this._worldClusters = null;
     }
 
@@ -612,7 +614,9 @@ class LayerComposition extends EventHandler {
         }
 
         // delete leftovers
-        tempClusterArray.forEach((item) => item.destroy());
+        tempClusterArray.forEach((item) => {
+            item.destroy();
+        });
         tempClusterArray.length = 0;
     }
 

--- a/src/scene/composition/layer-composition.js
+++ b/src/scene/composition/layer-composition.js
@@ -112,7 +112,7 @@ class LayerComposition extends EventHandler {
         }
 
         // all other clusters
-        this._worldClusters.forEach(cluster => cluster.destroy());
+        this._worldClusters.forEach((cluster) => cluster.destroy());
         this._worldClusters = null;
     }
 
@@ -612,7 +612,7 @@ class LayerComposition extends EventHandler {
         }
 
         // delete leftovers
-        tempClusterArray.forEach(item => item.destroy());
+        tempClusterArray.forEach((item) => item.destroy());
         tempClusterArray.length = 0;
     }
 

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -415,11 +415,11 @@ class StandardMaterial extends Material {
 
     _processParameters(paramsName) {
         const prevParams = this[paramsName];
-        for (const param of prevParams) {
+        prevParams.forEach((param) => {
             if (!_params.has(param)) {
                 delete this.parameters[param];
             }
-        }
+        });
 
         this[paramsName] = _params;
         _params = prevParams;


### PR DESCRIPTION
Uses Set.foreach to loop over it, instead of less supported for .. in

- Fixes https://github.com/playcanvas/engine/issues/3658
- also removes 2 lint warnings