### PR TITLE
Specular & Clear-coat support for clusterted lights

### DIFF
--- a/examples/src/examples/graphics/clustered-lighting.tsx
+++ b/examples/src/examples/graphics/clustered-lighting.tsx
@@ -1,15 +1,12 @@
 import React from 'react';
 // @ts-ignore: library file import
 import * as pc from 'playcanvas/build/playcanvas.prf.js';
-// @ts-ignore: library file import
-import * as pcx from 'playcanvas/build/playcanvas-extras.js';
 import Example from '../../app/example';
 import { AssetLoader } from '../../app/helpers/loader';
 
 class ClusteredLightingExample extends Example {
     static CATEGORY = 'Graphics';
     static NAME = 'Clustered Lighting';
-    static ENGINE = 'PERFORMANCE';
 
     load() {
         return <>
@@ -49,34 +46,17 @@ class ClusteredLightingExample extends Example {
             app.resizeCanvas(canvas.width, canvas.height);
         });
 
-        // set up options for mini-stats, start with the default options and add clusted lighting stats
-        const options = pcx.MiniStats.getDefaultOptions();
-        options.stats.push(
-            {
-                // CPU time it takes to process the clusters each frame
-                name: "Clusters",
-                stats: ["frame.lightClustersTime"],
-                decimalPlaces: 2,
-                unitsName: "ms",
-                watermark: 3
-            },
-            {
-                // number of clusters used internally
-                // should be one if all lights are on the same set of layers
-                name: "Num Clusters",
-                stats: ["frame.lightClusters"],
-                watermark: 3
-            }
-        );
-
-        // create mini-stats system
-        const miniStats = new pcx.MiniStats(app, options);
-
         // material with tiled normal map
         let material = new pc.StandardMaterial();
         material.normalMap = assets.normal.resource;
         material.normalMapTiling.set(5, 5);
-        material.bumpiness = 2;
+        material.bumpiness = 1;
+
+        // enable specular
+        material.shininess = 50;
+        material.metalness = 0.3;
+        material.useMetalness = true;
+
         material.update();
 
         // ground plane

--- a/examples/src/examples/graphics/clustered-omni-shadows.tsx
+++ b/examples/src/examples/graphics/clustered-omni-shadows.tsx
@@ -10,6 +10,7 @@ class ClusteredShadowsOmniExample extends Example {
     load() {
         return <>
             <AssetLoader name='script' type='script' url='static/scripts/camera/orbit-camera.js' />
+            <AssetLoader name='normal' type='texture' url='static/assets/textures/normal-map.png' />
             <AssetLoader name="xmas_negx" type="texture" url="static/assets/cubemaps/xmas_faces/xmas_negx.png" />
             <AssetLoader name="xmas_negy" type="texture" url="static/assets/cubemaps/xmas_faces/xmas_negy.png" />
             <AssetLoader name="xmas_negz" type="texture" url="static/assets/cubemaps/xmas_faces/xmas_negz.png" />
@@ -57,6 +58,17 @@ class ClusteredShadowsOmniExample extends Example {
             // create a material
             const material = new pc.StandardMaterial();
             material.diffuse = new pc.Color(0.7, 0.7, 0.7);
+
+            // normal map
+            material.normalMap = assets.normal.resource;
+            material.normalMapTiling.set(5, 5);
+            material.bumpiness = 0.7;
+
+            // enable specular
+            material.shininess = 40;
+            material.metalness = 0.3;
+            material.useMetalness = true;
+
             material.update();
 
             // create the primitive using the material

--- a/src/graphics/program-lib/chunks/clusteredLight.frag
+++ b/src/graphics/program-lib/chunks/clusteredLight.frag
@@ -269,6 +269,7 @@ void evaluateLight(ClusterLightData light) {
                 }
 
                 #endif
+
                 #ifdef CLUSTER_SHADOWS
 
                 // shadow
@@ -298,6 +299,16 @@ void evaluateLight(ClusterLightData light) {
         #endif
 
         dDiffuseLight += dAtten * light.color * dAtten3;
+
+        // specular and clear coat are material settings and get included by a define based on the material
+        #ifdef CLUSTER_SPECULAR
+            dSpecularLight += getLightSpecular() * dAtten * light.color;
+
+            #ifdef CLUSTER_CLEAR_COAT
+                ccSpecularLight += getLightSpecularCC() * dAtten * light.color  * dAtten3;
+            #endif
+
+        #endif
     }
 }
 

--- a/src/graphics/program-lib/programs/standard.js
+++ b/src/graphics/program-lib/programs/standard.js
@@ -1338,6 +1338,10 @@ const standard = {
         }
         let useOldAmbient = false;
         if (options.useSpecular) {
+
+            // enable specular path in clustered chunk
+            code += "#define CLUSTER_SPECULAR\n";
+
             if (lighting) code += options.shadingModel === SPECULAR_PHONG ? chunks.lightSpecularPhongPS : (options.enableGGXSpecular) ? chunks.lightSpecularAnisoGGXPS : chunks.lightSpecularBlinnPS;
             if (options.sphereMap || cubemapReflection || options.dpAtlas || (options.fresnelModel > 0)) {
                 if (options.fresnelModel > 0) {
@@ -1363,6 +1367,10 @@ const standard = {
         }
 
         if (options.clearCoat > 0) {
+
+            // enable clear-coast path in clustered chunk
+            code += "#define CLUSTER_CLEAR_COAT\n";
+
             code += chunks.combineClearCoatPS;
         }
 
@@ -1580,7 +1588,7 @@ const standard = {
 
                 usesLinearFalloff = true;
                 hasPointLights = true;
-                code += '   addClusteredLights();';
+                code += '   addClusteredLights();\n';
             }
 
             for (let i = 0; i < options.lights.length; i++) {


### PR DESCRIPTION
- implements specular and clear-coat support
- updated clustered lighting examples to use release engine version
- updated clustered lighting examples to have normal map and use specular

![Screenshot 2021-11-05 at 11 18 50](https://user-images.githubusercontent.com/59932779/140505330-84980b1d-a427-4a11-b462-a75e7271484e.png)
![Screenshot 2021-11-05 at 11 11 58](https://user-images.githubusercontent.com/59932779/140505343-cb1eb29d-4254-4b5e-b5e8-cc1a8502f80c.png)
<img width="2169" alt="Screenshot 2021-11-05 at 11 05 43" src="https://user-images.githubusercontent.com/59932779/140505345-9c7e53c2-4489-4dc8-a548-687727207746.png">
