### PR TITLE
Fixed jsdoc datatype on excludeFromLayout

### DIFF
--- a/src/framework/components/layout-child/component.js
+++ b/src/framework/components/layout-child/component.js
@@ -15,7 +15,7 @@ import { Component } from '../component.js';
  * @property {number} maxHeight The maximum height the element should be rendered at.
  * @property {number} fitWidthProportion The amount of additional horizontal space that the element should take up, if necessary to satisfy a Stretch/Shrink fitting calculation. This is specified as a proportion, taking into account the proportion values of other siblings.
  * @property {number} fitHeightProportion The amount of additional vertical space that the element should take up, if necessary to satisfy a Stretch/Shrink fitting calculation. This is specified as a proportion, taking into account the proportion values of other siblings.
- * @property {number} excludeFromLayout If set to true, the child will be excluded from all layout calculations.
+ * @property {boolean} excludeFromLayout If set to true, the child will be excluded from all layout calculations.
  */
 class LayoutChildComponent extends Component {
     constructor(system, entity) {


### PR DESCRIPTION
Was incorrectly declared as a number instead of boolean

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
