### PR TITLE
AnimComponentLayer - fix the pause function description

### DIFF
--- a/src/framework/components/anim/component-layer.js
+++ b/src/framework/components/anim/component-layer.js
@@ -35,7 +35,7 @@ class AnimComponentLayer {
     /**
      * @function
      * @name AnimComponentLayer#pause
-     * @description Start playing the animation in the current state.
+     * @description Pause the animation in the current state.
      */
     pause() {
         this._controller.pause();


### PR DESCRIPTION
The pause description was incorrectly copied from the play function's description. The PR corrects the description.
Fixes #3617

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
