### PR TITLE
AnimComponent layer mask path fix

### DIFF
--- a/src/framework/components/anim/component-layer.js
+++ b/src/framework/components/anim/component-layer.js
@@ -67,7 +67,7 @@ class AnimComponentLayer {
      * @function
      * @name AnimComponentLayer#assignMask
      * @description Add a mask to this layer.
-     * @param {object} [mask] - The mask to assign to the layer. If not provided the current mask in the layer will be removed.
+     * @param {object} [mask] - The mask to assign to the layer. If not provided the current mask in the layer will be removed. Any special characters in mask paths will be unescaped.
      * @example
      * entity.anim.baseLayer.assignMask({
      *     // include the spine of the current model and all of its children
@@ -79,7 +79,14 @@ class AnimComponentLayer {
      * });
      */
     assignMask(mask) {
-        if (this._controller.assignMask(mask)) {
+        let layerMask;
+        if (typeof mask === 'object') {
+            layerMask = {};
+            Object.keys(mask).forEach((maskKey) => {
+                layerMask[unescape(maskKey)] = mask[maskKey];
+            });
+        }
+        if (this._controller.assignMask(layerMask)) {
             this._component.rebind();
         }
     }

--- a/src/framework/components/anim/component-layer.js
+++ b/src/framework/components/anim/component-layer.js
@@ -67,7 +67,7 @@ class AnimComponentLayer {
      * @function
      * @name AnimComponentLayer#assignMask
      * @description Add a mask to this layer.
-     * @param {object} [mask] - The mask to assign to the layer. If not provided the current mask in the layer will be removed. Any special characters in mask paths will be unescaped.
+     * @param {object} [mask] - The mask to assign to the layer. If not provided the current mask in the layer will be removed.
      * @example
      * entity.anim.baseLayer.assignMask({
      *     // include the spine of the current model and all of its children
@@ -83,7 +83,7 @@ class AnimComponentLayer {
         if (typeof mask === 'object') {
             layerMask = {};
             Object.keys(mask).forEach((maskKey) => {
-                layerMask[unescape(maskKey)] = mask[maskKey];
+                layerMask[decodeURI(maskKey)] = mask[maskKey];
             });
         }
         if (this._controller.assignMask(layerMask)) {

--- a/src/framework/components/anim/component-layer.js
+++ b/src/framework/components/anim/component-layer.js
@@ -79,14 +79,7 @@ class AnimComponentLayer {
      * });
      */
     assignMask(mask) {
-        let layerMask;
-        if (typeof mask === 'object') {
-            layerMask = {};
-            Object.keys(mask).forEach((maskKey) => {
-                layerMask[decodeURI(maskKey)] = mask[maskKey];
-            });
-        }
-        if (this._controller.assignMask(layerMask)) {
+        if (this._controller.assignMask(mask)) {
             this._component.rebind();
         }
     }

--- a/src/framework/components/anim/system.js
+++ b/src/framework/components/anim/system.js
@@ -59,9 +59,10 @@ class AnimComponentSystem extends ComponentSystem {
         if (data.masks) {
             Object.keys(data.masks).forEach((key) => {
                 if (component.layers[key]) {
+                    const maskData = data.masks[key].mask;
                     const mask = {};
-                    Object.keys(data.masks[key].mask).forEach((maskKey) => {
-                        mask[decodeURI(maskKey)] = data.masks[key].mask[maskKey];
+                    Object.keys(maskData).forEach((maskKey) => {
+                        mask[decodeURI(maskKey)] = maskData[maskKey];
                     });
                     component.layers[key].assignMask(mask);
                 }

--- a/src/framework/components/anim/system.js
+++ b/src/framework/components/anim/system.js
@@ -59,7 +59,12 @@ class AnimComponentSystem extends ComponentSystem {
         if (data.masks) {
             Object.keys(data.masks).forEach((key) => {
                 if (component.layers[key]) {
-                    component.layers[key].assignMask(data.masks[key].mask);
+                    const mask = data.masks[key].mask;
+                    Object.keys(mask).forEach((maskKey) => {
+                        mask[decodeURI(maskKey)] = mask[maskKey];
+                        delete mask[maskKey];
+                    });
+                    component.layers[key].assignMask(mask);
                 }
             });
         }

--- a/src/framework/components/anim/system.js
+++ b/src/framework/components/anim/system.js
@@ -59,10 +59,9 @@ class AnimComponentSystem extends ComponentSystem {
         if (data.masks) {
             Object.keys(data.masks).forEach((key) => {
                 if (component.layers[key]) {
-                    const mask = data.masks[key].mask;
-                    Object.keys(mask).forEach((maskKey) => {
-                        mask[decodeURI(maskKey)] = mask[maskKey];
-                        delete mask[maskKey];
+                    const mask = {};
+                    Object.keys(data.masks[key].mask).forEach((maskKey) => {
+                        mask[decodeURI(maskKey)] = data.masks[key].mask[maskKey];
                     });
                     component.layers[key].assignMask(mask);
                 }


### PR DESCRIPTION
AnimComponent mask paths that come from the editor will need to sometimes contain encoded characters. When loading a mask into an AnimComponent from data, these characters should be decoded.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
