### PR TITLE
Re-added entity references init event

### DIFF
--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -1103,6 +1103,7 @@ class Application extends EventHandler {
         this.fire('initialize');
 
         this.systems.fire('postInitialize', this.root);
+        this.systems.fire('initializeEntityReferences', this.root);
         this.fire('postinitialize');
 
         this.tick();

--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -1103,7 +1103,7 @@ class Application extends EventHandler {
         this.fire('initialize');
 
         this.systems.fire('postInitialize', this.root);
-        this.systems.fire('initializeEntityReferences', this.root);
+        this.systems.fire('postPostInitialize', this.root);
         this.fire('postinitialize');
 
         this.tick();

--- a/src/framework/scene-registry.js
+++ b/src/framework/scene-registry.js
@@ -269,6 +269,7 @@ class SceneRegistry {
                 // initialize components
                 self._app.systems.fire('initialize', entity);
                 self._app.systems.fire('postInitialize', entity);
+                self._app.systems.fire('initializeEntityReferences', entity);
 
                 if (callback) callback(err, entity);
             };

--- a/src/framework/scene-registry.js
+++ b/src/framework/scene-registry.js
@@ -269,7 +269,7 @@ class SceneRegistry {
                 // initialize components
                 self._app.systems.fire('initialize', entity);
                 self._app.systems.fire('postInitialize', entity);
-                self._app.systems.fire('initializeEntityReferences', entity);
+                self._app.systems.fire('postPostInitialize', entity);
 
                 if (callback) callback(err, entity);
             };

--- a/src/framework/utils/entity-reference.js
+++ b/src/framework/utils/entity-reference.js
@@ -176,7 +176,7 @@ class EntityReference extends EventHandler {
         this._parentComponent[onOrOff]('set_' + this._entityPropertyName, this._onSetEntity, this);
         this._parentComponent.system[onOrOff]('beforeremove', this._onParentComponentRemove, this);
 
-        this._app.systems[onOrOff]('initializeEntityReferences', this._onInitialize, this);
+        this._app.systems[onOrOff]('postPostInitialize', this._updateEntityReference, this);
         this._app[onOrOff]('tools:sceneloaded', this._onSceneLoaded, this);
 
         // For any event listeners that relate to the gain/loss of a component, register
@@ -221,10 +221,6 @@ class EntityReference extends EventHandler {
                 this._updateEntityReference();
             }
         }
-    }
-
-    _onInitialize() {
-        this._updateEntityReference();
     }
 
     /**

--- a/src/framework/utils/entity-reference.js
+++ b/src/framework/utils/entity-reference.js
@@ -176,7 +176,7 @@ class EntityReference extends EventHandler {
         this._parentComponent[onOrOff]('set_' + this._entityPropertyName, this._onSetEntity, this);
         this._parentComponent.system[onOrOff]('beforeremove', this._onParentComponentRemove, this);
 
-        this._app[onOrOff]('postinitialize', this._onPostInitialize, this);
+        this._app.systems[onOrOff]('initializeEntityReferences', this._onInitialize, this);
         this._app[onOrOff]('tools:sceneloaded', this._onSceneLoaded, this);
 
         // For any event listeners that relate to the gain/loss of a component, register
@@ -223,7 +223,7 @@ class EntityReference extends EventHandler {
         }
     }
 
-    _onPostInitialize() {
+    _onInitialize() {
         this._updateEntityReference();
     }
 


### PR DESCRIPTION
Fixes #3678

In the PR #3557, there was an event fired in the ComponentSystem.postInitialize function that fired `postinitialize` on itself (note the lowercase `i`)

Event being fired: https://github.com/playcanvas/engine/pull/3557/files#diff-db3ec5f0a5ac5e79ff9192096e8673e0a195e05d91f965608ef630065760e86aL42

Event being registered: https://github.com/playcanvas/engine/pull/3557/files#diff-146cc76c99359e108357b24fb2494cffbaa3b187b07bb83c23f12d6b726fd474L180

This PR adds an event that needs to be called after `postInitialize` event on the systems object in the application.

The event name is a bit long but open to suggestions

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
