### PR TITLE
Change to the ownership of defaultMaterial to allow easier access to it

### DIFF
--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -23,7 +23,7 @@ import { GraphicsDevice } from '../graphics/graphics-device.js';
 
 import {
     LAYERID_DEPTH, LAYERID_IMMEDIATE, LAYERID_SKYBOX, LAYERID_UI, LAYERID_WORLD,
-    SORTMODE_NONE, SORTMODE_MANUAL
+    SORTMODE_NONE, SORTMODE_MANUAL, SPECULAR_BLINN
 } from '../scene/constants.js';
 import { BatchManager } from '../scene/batching/batch-manager.js';
 import { ForwardRenderer } from '../scene/renderer/forward-renderer.js';
@@ -118,6 +118,7 @@ import {
     getApplication,
     setApplication
 } from './globals.js';
+import { StandardMaterial } from '../scene/materials/standard-material.js';
 
 // Mini-object used to measure progress of loading sets
 class Progress {
@@ -448,11 +449,16 @@ class Application extends EventHandler {
         this.loader = new ResourceLoader(this);
         LightsBuffer.init(this.graphicsDevice);
 
+        // default material used in case no other material is available
+        this.graphicsDevice.defaultMaterial = new StandardMaterial();
+        this.graphicsDevice.defaultMaterial.name = "Default Material";
+        this.graphicsDevice.defaultMaterial.shadingModel = SPECULAR_BLINN;
+
         // stores all entities that have been created
         // for this app by guid
         this._entityIndex = {};
 
-        this.scene = new Scene();
+        this.scene = new Scene(this.graphicsDevice);
         this.root = new Entity(this);
         this.root._enabledInHierarchy = true;
         this._enableList = [];
@@ -1951,6 +1957,9 @@ class Application extends EventHandler {
 
         this.renderer.destroy();
         this.renderer = null;
+
+        this.defaultMaterial.destroy();
+        this.defaultMaterial = null;
 
         this.graphicsDevice.destroy();
         this.graphicsDevice = null;

--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -119,6 +119,7 @@ import {
     setApplication
 } from './globals.js';
 import { StandardMaterial } from '../scene/materials/standard-material.js';
+import { DefaultMaterial } from '../scene/materials/default-material.js';
 
 // Mini-object used to measure progress of loading sets
 class Progress {
@@ -448,11 +449,6 @@ class Application extends EventHandler {
         this._soundManager = new SoundManager(options);
         this.loader = new ResourceLoader(this);
         LightsBuffer.init(this.graphicsDevice);
-
-        // default material used in case no other material is available
-        this.graphicsDevice.defaultMaterial = new StandardMaterial();
-        this.graphicsDevice.defaultMaterial.name = "Default Material";
-        this.graphicsDevice.defaultMaterial.shadingModel = SPECULAR_BLINN;
 
         // stores all entities that have been created
         // for this app by guid
@@ -1958,8 +1954,7 @@ class Application extends EventHandler {
         this.renderer.destroy();
         this.renderer = null;
 
-        this.defaultMaterial.destroy();
-        this.defaultMaterial = null;
+        DefaultMaterial.release(this.graphicsDevice);
 
         this.graphicsDevice.destroy();
         this.graphicsDevice = null;

--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -23,7 +23,7 @@ import { GraphicsDevice } from '../graphics/graphics-device.js';
 
 import {
     LAYERID_DEPTH, LAYERID_IMMEDIATE, LAYERID_SKYBOX, LAYERID_UI, LAYERID_WORLD,
-    SORTMODE_NONE, SORTMODE_MANUAL, SPECULAR_BLINN
+    SORTMODE_NONE, SORTMODE_MANUAL
 } from '../scene/constants.js';
 import { BatchManager } from '../scene/batching/batch-manager.js';
 import { ForwardRenderer } from '../scene/renderer/forward-renderer.js';
@@ -118,7 +118,6 @@ import {
     getApplication,
     setApplication
 } from './globals.js';
-import { StandardMaterial } from '../scene/materials/standard-material.js';
 import { DefaultMaterial } from '../scene/materials/default-material.js';
 
 // Mini-object used to measure progress of loading sets

--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -453,7 +453,7 @@ class Application extends EventHandler {
         // for this app by guid
         this._entityIndex = {};
 
-        this.scene = new Scene(this.graphicsDevice);
+        this.scene = new Scene();
         this.root = new Entity(this);
         this.root._enabledInHierarchy = true;
         this._enableList = [];

--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -1953,7 +1953,7 @@ class Application extends EventHandler {
         this.renderer.destroy();
         this.renderer = null;
 
-        DefaultMaterial.release(this.graphicsDevice);
+        DefaultMaterial.remove(this.graphicsDevice);
 
         this.graphicsDevice.destroy();
         this.graphicsDevice = null;

--- a/src/graphics/graphics-device.js
+++ b/src/graphics/graphics-device.js
@@ -685,9 +685,6 @@ class GraphicsDevice extends EventHandler {
         this.grabPass = new GrabPass(this, options.alpha);
         this.grabPass.create();
 
-        // default material used in case no other material is available - assigned and owned by the application
-        this.defaultMaterial = null;
-
         VertexFormat.init(this);
 
         // #if _DEBUG
@@ -724,7 +721,6 @@ class GraphicsDevice extends EventHandler {
         this.scope = null;
         this.canvas = null;
         this.gl = null;
-        this.defaultMaterial = null;
     }
 
     // don't stringify GraphicsDevice to JSON by JSON.stringify

--- a/src/graphics/graphics-device.js
+++ b/src/graphics/graphics-device.js
@@ -685,6 +685,9 @@ class GraphicsDevice extends EventHandler {
         this.grabPass = new GrabPass(this, options.alpha);
         this.grabPass.create();
 
+        // default material used in case no other material is available - assigned and owned by the application
+        this.defaultMaterial = null;
+
         VertexFormat.init(this);
 
         // #if _DEBUG
@@ -721,6 +724,7 @@ class GraphicsDevice extends EventHandler {
         this.scope = null;
         this.canvas = null;
         this.gl = null;
+        this.defaultMaterial = null;
     }
 
     // don't stringify GraphicsDevice to JSON by JSON.stringify

--- a/src/scene/materials/default-material.js
+++ b/src/scene/materials/default-material.js
@@ -21,7 +21,7 @@ class DefaultMaterial {
     }
 
     // releases a default material for the device (when device is getting destroyed)
-    static release(device) {
+    static remove(device) {
         this.cache.delete(device);
     }
 }

--- a/src/scene/materials/default-material.js
+++ b/src/scene/materials/default-material.js
@@ -1,0 +1,29 @@
+import { SPECULAR_BLINN } from "../constants.js";
+import { StandardMaterial } from "./standard-material.js";
+
+// Default material used in case no other material is available.
+// There is one instance of it per device (application) stored in the cache in this class.
+class DefaultMaterial {
+    // dictionary of Device -> default material
+    static cache = new Map();
+
+    // returns a default material for the device
+    static get(device) {
+        let material = this.cache.get(device);
+        if (!material) {
+            material = new StandardMaterial();
+            material.name = "Default Material";
+            material.shadingModel = SPECULAR_BLINN;
+
+            this.cache.set(device, material);
+        }
+        return material;
+    }
+
+    // releases a default material for the device (when device is getting destroyed)
+    static release(device) {
+        this.cache.delete(device);
+    }
+}
+
+export { DefaultMaterial };

--- a/src/scene/materials/material.js
+++ b/src/scene/materials/material.js
@@ -12,7 +12,6 @@ import {
     BLEND_MULTIPLICATIVE, BLEND_ADDITIVEALPHA, BLEND_MULTIPLICATIVE2X, BLEND_SCREEN,
     BLEND_MIN, BLEND_MAX
 } from '../constants.js';
-import { StandardMaterial } from './standard-material.js';
 
 let id = 0;
 

--- a/src/scene/materials/material.js
+++ b/src/scene/materials/material.js
@@ -12,6 +12,7 @@ import {
     BLEND_MULTIPLICATIVE, BLEND_ADDITIVEALPHA, BLEND_MULTIPLICATIVE2X, BLEND_SCREEN,
     BLEND_MIN, BLEND_MAX
 } from '../constants.js';
+import { StandardMaterial } from './standard-material.js';
 
 let id = 0;
 
@@ -431,6 +432,11 @@ class Material {
                 meshInstance._shader[j] = null;
             }
             meshInstance._material = null;
+
+            const defaultMaterial = meshInstance.mesh.device.defaultMaterial;
+            if (this !== defaultMaterial) {
+                meshInstance.material = defaultMaterial;
+            }
         }
     }
 

--- a/src/scene/materials/material.js
+++ b/src/scene/materials/material.js
@@ -12,6 +12,7 @@ import {
     BLEND_MULTIPLICATIVE, BLEND_ADDITIVEALPHA, BLEND_MULTIPLICATIVE2X, BLEND_SCREEN,
     BLEND_MIN, BLEND_MAX
 } from '../constants.js';
+import { DefaultMaterial } from './default-material.js';
 
 let id = 0;
 
@@ -432,7 +433,7 @@ class Material {
             }
             meshInstance._material = null;
 
-            const defaultMaterial = meshInstance.mesh.device.defaultMaterial;
+            const defaultMaterial = DefaultMaterial.get(meshInstance.mesh.device);
             if (this !== defaultMaterial) {
                 meshInstance.material = defaultMaterial;
             }

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -9,13 +9,14 @@ import { math } from '../math/math.js';
 
 import { CULLFACE_FRONT, PIXELFORMAT_RGBA32F, TEXTURETYPE_RGBM } from '../graphics/constants.js';
 
-import { BAKE_COLORDIR, FOG_NONE, GAMMA_NONE, GAMMA_SRGBHDR, LAYERID_SKYBOX, LAYERID_WORLD, SHADER_FORWARDHDR, SPECULAR_BLINN, TONEMAP_LINEAR } from './constants.js';
+import { BAKE_COLORDIR, FOG_NONE, GAMMA_NONE, GAMMA_SRGBHDR, LAYERID_SKYBOX, LAYERID_WORLD, SHADER_FORWARDHDR, TONEMAP_LINEAR } from './constants.js';
 import { createBox } from './procedural.js';
 import { GraphNode } from './graph-node.js';
 import { Material } from './materials/material.js';
 import { MeshInstance } from './mesh-instance.js';
 import { Model } from './model.js';
-import { StandardMaterial } from './materials/standard-material.js';
+
+import { getApplication } from '../framework/globals.js';
 
 /**
  * @class
@@ -24,6 +25,7 @@ import { StandardMaterial } from './materials/standard-material.js';
  * @classdesc A scene is graphical representation of an environment. It manages the
  * scene hierarchy, all graphical objects, lights, and scene-wide properties.
  * @description Creates a new Scene.
+ * @param {GraphicsDevice} [graphicsDevice] - The graphics device used to manage this scene. If it is not provided, a device is obtained from the {@link Application}.
  * @property {Color} ambientLight The color of the scene's ambient light. Defaults
  * to black (0, 0, 0).
  * @property {string} fog The type of fog used by the scene. Can be:
@@ -103,8 +105,10 @@ import { StandardMaterial } from './materials/standard-material.js';
  * child to the Application root entity.
  */
 class Scene extends EventHandler {
-    constructor() {
+    constructor(graphicsDevice) {
         super();
+
+        this.device = graphicsDevice || getApplication().graphicsDevice;
 
         this.root = null;
 
@@ -173,19 +177,16 @@ class Scene extends EventHandler {
 
         // backwards compatibility only
         this._models = [];
-
-        // default material used in case no other material is available
-        this.defaultMaterial = new StandardMaterial();
-        this.defaultMaterial.name = "Default Material";
-        this.defaultMaterial.shadingModel = SPECULAR_BLINN;
     }
 
     destroy() {
         this._resetSkyboxModel();
         this.root = null;
-        this.defaultMaterial.destroy();
-        this.defaultMaterial = null;
         this.off();
+    }
+
+    get defaultMaterial() {
+        return this.device.defaultMaterial;
     }
 
     get fog() {

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -26,7 +26,6 @@ import { getApplication } from '../framework/globals.js';
  * @classdesc A scene is graphical representation of an environment. It manages the
  * scene hierarchy, all graphical objects, lights, and scene-wide properties.
  * @description Creates a new Scene.
- * @param {GraphicsDevice} [graphicsDevice] - The graphics device used to manage this scene. If it is not provided, a device is obtained from the {@link Application}.
  * @property {Color} ambientLight The color of the scene's ambient light. Defaults
  * to black (0, 0, 0).
  * @property {string} fog The type of fog used by the scene. Can be:
@@ -106,10 +105,8 @@ import { getApplication } from '../framework/globals.js';
  * child to the Application root entity.
  */
 class Scene extends EventHandler {
-    constructor(graphicsDevice) {
+    constructor() {
         super();
-
-        this.device = graphicsDevice || getApplication().graphicsDevice;
 
         this.root = null;
 
@@ -187,7 +184,7 @@ class Scene extends EventHandler {
     }
 
     get defaultMaterial() {
-        return DefaultMaterial.get(this.device);
+        return DefaultMaterial.get(getApplication().graphicsDevice);
     }
 
     get fog() {

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -13,6 +13,7 @@ import { BAKE_COLORDIR, FOG_NONE, GAMMA_NONE, GAMMA_SRGBHDR, LAYERID_SKYBOX, LAY
 import { createBox } from './procedural.js';
 import { GraphNode } from './graph-node.js';
 import { Material } from './materials/material.js';
+import { DefaultMaterial } from './materials/default-material.js';
 import { MeshInstance } from './mesh-instance.js';
 import { Model } from './model.js';
 
@@ -186,7 +187,7 @@ class Scene extends EventHandler {
     }
 
     get defaultMaterial() {
-        return this.device.defaultMaterial;
+        return DefaultMaterial.get(this.device);
     }
 
     get fog() {


### PR DESCRIPTION
Fixes https://github.com/playcanvas/engine/issues/3683

Change:
- defaultMaterial is created and owned DefaultMaterial class, instead of by the Scene. DefaultMaterial stores one defaultMaterial instance per device. This gets us closer to allow multiple Scenes, while still sharing single defaultMaterial, which some behaviours depend on
- this fixes the issue where upon Material getting destroyed, some mesh instances would have null materials. Now they find a defaultMaterial from the device and assign it to the meshInstance.
