### PR TITLE
Refactor JSDoc comments for ES6 classes

### DIFF
--- a/src/core/core.js
+++ b/src/core/core.js
@@ -1,14 +1,15 @@
 /**
+ * Root namespace for the PlayCanvas Engine.
+ *
  * @name pc
  * @namespace
- * @description Root namespace for the PlayCanvas Engine.
  */
 
 /**
+ * Create look up table for types.
+ *
+ * @returns {object} The type lookup table.
  * @private
- * @function
- * @name _typeLookup
- * @description Create look up table for types.
  */
 const _typeLookup = function () {
     const result = { };
@@ -28,12 +29,12 @@ const apps = { }; // Storage for the applications using the PlayCanvas Engine
 const data = { }; // Storage for exported entity data
 
 /**
- * @private
- * @function
- * @name type
- * @description Extended typeof() function, returns the type of the object.
+ * Extended typeof() function, returns the type of the object.
+ *
  * @param {object} obj - The object to get the type of.
- * @returns {string} The type string: "null", "undefined", "number", "string", "boolean", "array", "object", "function", "date", "regexp" or "float32array".
+ * @returns {string} The type string: "null", "undefined", "number", "string", "boolean", "array",
+ * "object", "function", "date", "regexp" or "float32array".
+ * @private
  */
 function type(obj) {
     if (obj === null) {
@@ -50,10 +51,8 @@ function type(obj) {
 }
 
 /**
- * @private
- * @function
- * @name extend
- * @description Merge the contents of two objects into a single object.
+ * Merge the contents of two objects into a single object.
+ *
  * @param {object} target - The target object of the merge.
  * @param {object} ex - The object that is merged with target.
  * @returns {object} The target object.
@@ -74,6 +73,7 @@ function type(obj) {
  * // logs "a"
  * A.b();
  * // logs "b"
+ * @private
  */
 function extend(target, ex) {
     for (const prop in ex) {
@@ -92,12 +92,11 @@ function extend(target, ex) {
 }
 
 /**
- * @private
- * @function
- * @name isDefined
- * @description Return true if the Object is not undefined.
+ * Return true if the Object is not undefined.
+ *
  * @param {object} o - The Object to test.
  * @returns {boolean} True if the Object is not undefined.
+ * @private
  */
 function isDefined(o) {
     let a;

--- a/src/core/debug.js
+++ b/src/core/debug.js
@@ -18,17 +18,17 @@ function init() {
 }
 
 /**
- * @private
- * @name debug
+ * Debugging functionality
+ *
  * @namespace
+ * @private
  */
 const debug = {
     /**
-     * @private
-     * @function
-     * @name debug.display
-     * @description Display an object and its data in a table on the page.
+     * Display an object and its data in a table on the page.
+     *
      * @param {object} data - The object to display.
+     * @private
      */
     display: function (data) {
         if (!table) {

--- a/src/core/event-handler.js
+++ b/src/core/event-handler.js
@@ -1,20 +1,21 @@
 /**
- * @class
- * @name EventHandler
- * @classdesc Abstract base class that implements functionality for event handling.
- * @description Create a new event handler.
- * @example
- * var obj = new EventHandlerSubclass();
- *
- * // subscribe to an event
- * obj.on('hello', function (str) {
- *     console.log('event hello is fired', str);
- * });
- *
- * // fire event
- * obj.fire('hello', 'world');
+ * Abstract base class that implements functionality for event handling.
  */
 class EventHandler {
+    /**
+     * Create a new event handler.
+     *
+     * @example
+     * var obj = new EventHandlerSubclass();
+     *
+     * // subscribe to an event
+     * obj.on('hello', function (str) {
+     *     console.log('event hello is fired', str);
+     * });
+     *
+     * // fire event
+     * obj.fire('hello', 'world');
+     */
     constructor() {
         this.initEventHandler();
     }
@@ -42,12 +43,13 @@ class EventHandler {
     }
 
     /**
-     * @function
-     * @name EventHandler#on
-     * @description Attach an event handler to an event.
+     * Attach an event handler to an event.
+     *
      * @param {string} name - Name of the event to bind the callback to.
-     * @param {callbacks.HandleEvent} callback - Function that is called when event is fired. Note the callback is limited to 8 arguments.
-     * @param {object} [scope] - Object to use as 'this' when the event is fired, defaults to current this.
+     * @param {callbacks.HandleEvent} callback - Function that is called when event is fired. Note
+     * the callback is limited to 8 arguments.
+     * @param {object} [scope] - Object to use as 'this' when the event is fired, defaults to
+     * current this.
      * @returns {EventHandler} Self for chaining.
      * @example
      * obj.on('test', function (a, b) {
@@ -62,10 +64,10 @@ class EventHandler {
     }
 
     /**
-     * @function
-     * @name EventHandler#off
-     * @description Detach an event handler from an event. If callback is not provided then all callbacks are unbound from the event,
-     * if scope is not provided then all events with the callback will be unbound.
+     * Detach an event handler from an event. If callback is not provided then all callbacks are
+     * unbound from the event, if scope is not provided then all events with the callback will be
+     * unbound.
+     *
      * @param {string} [name] - Name of the event to unbind.
      * @param {callbacks.HandleEvent} [callback] - Function to be unbound.
      * @param {object} [scope] - Scope that was used as the this when the event is fired.
@@ -78,7 +80,7 @@ class EventHandler {
      * obj.off(); // Removes all events
      * obj.off('test'); // Removes all events called 'test'
      * obj.off('test', handler); // Removes all handler functions, called 'test'
-     * obj.off('test', handler, this); // Removes all hander functions, called 'test' with scope this
+     * obj.off('test', handler, this); // Removes all handler functions, called 'test' with scope this
      */
     off(name, callback, scope) {
         if (name) {
@@ -123,13 +125,9 @@ class EventHandler {
         return this;
     }
 
-    // ESLint rule disabled here as documenting arg1, arg2...argN as [...] rest
-    // arguments is preferable to documenting each one individually.
-    /* eslint-disable valid-jsdoc */
     /**
-     * @function
-     * @name EventHandler#fire
-     * @description Fire an event, all additional arguments are passed on to the event listener.
+     * Fire an event, all additional arguments are passed on to the event listener.
+     *
      * @param {object} name - Name of event to fire.
      * @param {*} [arg1] - First argument that is passed to the event handler.
      * @param {*} [arg2] - Second argument that is passed to the event handler.
@@ -143,7 +141,6 @@ class EventHandler {
      * @example
      * obj.fire('test', 'This is the message');
      */
-    /* eslint-enable valid-jsdoc */
     fire(name, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) {
         if (!name || !this._callbacks[name])
             return this;
@@ -189,12 +186,13 @@ class EventHandler {
     }
 
     /**
-     * @function
-     * @name EventHandler#once
-     * @description Attach an event handler to an event. This handler will be removed after being fired once.
+     * Attach an event handler to an event. This handler will be removed after being fired once.
+     *
      * @param {string} name - Name of the event to bind the callback to.
-     * @param {callbacks.HandleEvent} callback - Function that is called when event is fired. Note the callback is limited to 8 arguments.
-     * @param {object} [scope] - Object to use as 'this' when the event is fired, defaults to current this.
+     * @param {callbacks.HandleEvent} callback - Function that is called when event is fired. Note
+     * the callback is limited to 8 arguments.
+     * @param {object} [scope] - Object to use as 'this' when the event is fired, defaults to
+     * current this.
      * @returns {EventHandler} Self for chaining.
      * @example
      * obj.once('test', function (a, b) {
@@ -209,9 +207,8 @@ class EventHandler {
     }
 
     /**
-     * @function
-     * @name EventHandler#hasEvent
-     * @description Test if there are any handlers bound to an event name.
+     * Test if there are any handlers bound to an event name.
+     *
      * @param {string} name - The name of the event to test.
      * @returns {boolean} True if the object has handlers bound to the specified event name.
      * @example

--- a/src/core/events.js
+++ b/src/core/events.js
@@ -1,17 +1,21 @@
 import { EventHandler } from './event-handler.js';
 
+/**
+ * Event functionality.
+ *
+ * @namespace
+ * @private
+ */
 const events = {
     /**
-     * @private
-     * @function
-     * @name events.attach
-     * @description Attach event methods 'on', 'off', 'fire', 'once' and 'hasEvent' to the
-     * target object.
+     * Attach event methods 'on', 'off', 'fire', 'once' and 'hasEvent' to the target object.
+     *
      * @param {object} target - The object to add events to.
      * @returns {object} The target object.
      * @example
      * var obj = { };
      * pc.events.attach(obj);
+     * @private
      */
     attach: function (target) {
         const ev = events;

--- a/src/core/guid.js
+++ b/src/core/guid.js
@@ -1,14 +1,14 @@
 /**
- * @name guid
+ * GUIDs are essentially a very large random number (128-bit) which means the probability of
+ * creating two that clash is vanishingly small. GUIDs are used as the unique identifiers for
+ * Entities.
+ *
  * @namespace
- * @description Basically a very large random number (128-bit) which means the probability of creating two that clash is vanishingly small.
- * GUIDs are used as the unique identifiers for Entities.
  */
 const guid = {
     /**
-     * @function
-     * @name guid.create
-     * @description Create an RFC4122 version 4 compliant GUID.
+     * Create an RFC4122 version 4 compliant GUID.
+     *
      * @returns {string} A new GUID.
      */
     create: function () {

--- a/src/core/hash.js
+++ b/src/core/hash.js
@@ -1,10 +1,9 @@
 /**
- * @private
- * @function
- * @name hashCode
- * @description Calculates simple hash value of a string. Designed for performance, not perfect.
+ * Calculates simple hash value of a string. Designed for performance, not perfect.
+ *
  * @param {string} str - String.
  * @returns {number} Hash value.
+ * @private
  */
 function hashCode(str) {
     let hash = 0;

--- a/src/core/indexed-list.js
+++ b/src/core/indexed-list.js
@@ -1,22 +1,26 @@
 /**
+ * A ordered list-type data structure that can provide item look up by key, but also return return
+ * a list.
+ *
  * @private
- * @class
- * @name IndexedList
- * @classdesc A ordered list-type data structure that can provide item look up by key, but also return return a list.\.
  */
 class IndexedList {
+    /**
+     * Create a new IndexedList.
+     *
+     * @private
+     */
     constructor() {
         this._list = [];
         this._index = {};
     }
 
     /**
-     * @private
-     * @function
-     * @name IndexedList#push
-     * @description Add a new item into the list with a index key.
+     * Add a new item into the list with a index key.
+     *
      * @param {string} key -  Key used to look up item in index.
      * @param {object} item - Item to be stored.
+     * @private
      */
     push(key, item) {
         if (this._index[key]) {
@@ -27,24 +31,22 @@ class IndexedList {
     }
 
     /**
-     * @private
-     * @function
-     * @name IndexedList#has
-     * @description Test whether a key has been added to the index.
+     * Test whether a key has been added to the index.
+     *
      * @param {string} key - The key to test.
      * @returns {boolean} Returns true if key is in the index, false if not.
+     * @private
      */
     has(key) {
         return this._index[key] !== undefined;
     }
 
     /**
-     * @private
-     * @function
-     * @name IndexedList#get
-     * @description Return the item indexed by a key.
+     * Return the item indexed by a key.
+     *
      * @param {string} key - The key of the item to retrieve.
      * @returns {object} The item stored at key.
+     * @private
      */
     get(key) {
         const location = this._index[key];
@@ -55,12 +57,11 @@ class IndexedList {
     }
 
     /**
-     * @private
-     * @function
-     * @name IndexedList#remove
-     * @description Remove the item indexed by key from the list.
+     * Remove the item indexed by key from the list.
+     *
      * @param {string} key - The key at which to remove the item.
      * @returns {boolean} Returns true if the key exists and an item was removed, returns false if no item was removed.
+     * @private
      */
     remove(key) {
         const location = this._index[key];
@@ -82,21 +83,19 @@ class IndexedList {
     }
 
     /**
-     * @private
-     * @function
-     * @name IndexedList#list
-     * @description Returns the list of items.
+     * Returns the list of items.
+     *
      * @returns {object[]} The list of items.
+     * @private
      */
     list() {
         return this._list;
     }
 
     /**
+     * Remove all items from the list.
+     *
      * @private
-     * @function
-     * @name IndexedList#clear
-     * @description Remove all items from the list.
      */
     clear() {
         this._list.length = 0;

--- a/src/core/path.js
+++ b/src/core/path.js
@@ -1,23 +1,22 @@
 import { isDefined } from './core.js';
 
 /**
- * @namespace path
- * @description File path API.
+ * File path API.
+ *
+ * @namespace
  */
 const path = {
     /**
-     * @constant
+     * The character that separates path segments.
+     *
      * @type {string}
-     * @name path.delimiter
-     * @description The character that separates path segments.
+     * @constant
      */
     delimiter: "/",
 
     /**
-     * @function
-     * @name path.join
-     * @description Join two or more sections of file path together, inserting a
-     * delimiter if needed.
+     * Join two or more sections of file path together, inserting a delimiter if needed.
+     *
      * @param {...string} section - Section of path to join. 2 or more can be
      * provided as parameters.
      * @returns {string} The joined file path.
@@ -54,9 +53,8 @@ const path = {
     },
 
     /**
-     * @function
-     * @name path.normalize
-     * @description Normalize the path by removing '.' and '..' instances.
+     * Normalize the path by removing '.' and '..' instances.
+     *
      * @param {string} pathname - The path to normalize.
      * @returns {string} The normalized path.
      */
@@ -96,12 +94,13 @@ const path = {
     },
 
     /**
-     * @function
-     * @name path.split
-     * @description Split the pathname path into a pair [head, tail] where tail is the final part of the path
-     * after the last delimiter and head is everything leading up to that. tail will never contain a slash.
+     * Split the pathname path into a pair [head, tail] where tail is the final part of the path
+     * after the last delimiter and head is everything leading up to that. tail will never contain
+     * a slash.
+     *
      * @param {string} pathname - The path to split.
-     * @returns {string[]} The split path which is an array of two strings, the path and the filename.
+     * @returns {string[]} The split path which is an array of two strings, the path and the
+     * filename.
      */
     split: function (pathname) {
         const parts = pathname.split(path.delimiter);
@@ -111,10 +110,9 @@ const path = {
     },
 
     /**
-     * @function
-     * @name path.getBasename
-     * @description Return the basename of the path. That is the second element of the pair returned by
-     * passing path into {@link path.split}.
+     * Return the basename of the path. That is the second element of the pair returned by passing
+     * path into {@link path.split}.
+     *
      * @param {string} pathname - The path to process.
      * @returns {string} The basename.
      * @example
@@ -126,9 +124,9 @@ const path = {
     },
 
     /**
-     * @function
-     * @name path.getDirectory
-     * @description Get the directory name from the path. This is everything up to the final instance of {@link path.delimiter}.
+     * Get the directory name from the path. This is everything up to the final instance of
+     * {@link path.delimiter}.
+     *
      * @param {string} pathname - The path to get the directory from.
      * @returns {string} The directory part of the path.
      */
@@ -136,10 +134,11 @@ const path = {
         const parts = pathname.split(path.delimiter);
         return parts.slice(0, parts.length - 1).join(path.delimiter);
     },
+
     /**
-     * @function
-     * @name path.getExtension
-     * @description Return the extension of the path. Pop the last value of a list after path is split by question mark and comma.
+     * Return the extension of the path. Pop the last value of a list after path is split by
+     * question mark and comma.
+     *
      * @param {string} pathname - The path to process.
      * @returns {string} The extension.
      * @example
@@ -156,11 +155,11 @@ const path = {
     },
 
     /**
-     * @function
-     * @name path.isRelativePath
-     * @description Check if a string s is relative path.
+     * Check if a string s is relative path.
+     *
      * @param {string} pathname - The path to process.
-     * @returns {boolean} True if s doesn't start with slash and doesn't include colon and double slash.
+     * @returns {boolean} True if s doesn't start with slash and doesn't include colon and double
+     * slash.
      * @example
      * pc.path.isRelativePath("file.txt"); // returns true
      * pc.path.isRelativePath("path/to/file.txt"); // returns true
@@ -174,9 +173,8 @@ const path = {
     },
 
     /**
-     * @function
-     * @name path.extractPath
-     * @description Return the path without file name. If path is relative path, start with period.
+     * Return the path without file name. If path is relative path, start with period.
+     *
      * @param {string} pathname - The full path to process.
      * @returns {string} The path without a last element from list split by slash.
      * @example

--- a/src/core/platform.js
+++ b/src/core/platform.js
@@ -56,9 +56,9 @@ if (typeof navigator !== 'undefined') {
 const environment = (typeof window !== 'undefined') ? 'browser' : 'node';
 
 /**
+ * Global namespace that stores flags regarding platform environment and features support.
+ *
  * @namespace
- * @name platform
- * @description Global namespace that stores flags regarding platform environment and features support.
  * @example
  * if (pc.platform.touch) {
  *     // touch is supported
@@ -66,122 +66,109 @@ const environment = (typeof window !== 'undefined') ? 'browser' : 'node';
  */
 const platform = {
     /**
-     * @static
-     * @readonly
+     * String identifying the current runtime environment. Either 'browser' or 'node'.
+     *
      * @type {string}
-     * @name platform.environment
-     * @description String identifying the current runtime environment. Either 'browser' or 'node'.
+     * @readonly
      */
     environment: environment,
 
     /**
-     * @static
-     * @readonly
+     * The global object. This will be the window object when running in a browser and the global
+     * object when running in nodejs.
+     *
      * @type {object}
-     * @name platform.global
-     * @description The global object. This will be the window object when running in a browser and
-     * the global object when running in nodejs.
+     * @readonly
      */
     global: (environment === 'browser') ? window : global,
 
     /**
-     * @static
-     * @readonly
+     * Convenience boolean indicating whether we're running in the browser.
+     *
      * @type {boolean}
-     * @name platform.isBrowser
-     * @description Convenience boolean indicating whether we're running in the browser.
+     * @readonly
      */
     browser: environment === 'browser',
 
     /**
-     * @static
-     * @readonly
+     * Is it a desktop or laptop device.
+     *
      * @type {boolean}
-     * @name platform.desktop
-     * @description Is it a desktop or laptop device.
+     * @readonly
      */
     desktop: desktop,
 
     /**
-     * @static
-     * @readonly
+     * Is it a mobile or tablet device.
+     *
      * @type {boolean}
-     * @name platform.mobile
-     * @description Is it a mobile or tablet device.
+     * @readonly
      */
     mobile: mobile,
 
     /**
-     * @static
-     * @readonly
+     * If it is iOS.
+     *
      * @type {boolean}
-     * @name platform.ios
-     * @description If it is iOS.
+     * @readonly
      */
     ios: ios,
 
     /**
-     * @static
-     * @readonly
+     * If it is Android.
+     *
      * @type {boolean}
-     * @name platform.android
-     * @description If it is Android.
+     * @readonly
      */
     android: android,
 
     /**
-     * @static
-     * @readonly
+     * If it is Windows.
+     *
      * @type {boolean}
-     * @name platform.windows
-     * @description If it is Windows.
+     * @readonly
      */
     windows: windows,
 
     /**
-     * @static
-     * @readonly
+     * If it is Xbox.
+     *
      * @type {boolean}
-     * @name platform.xbox
-     * @description If it is Xbox.
+     * @readonly
      */
     xbox: xbox,
 
     /**
-     * @static
-     * @readonly
+     * If platform supports gamepads.
+     *
      * @type {boolean}
-     * @name platform.gamepads
-     * @description If platform supports gamepads.
+     * @readonly
      */
     gamepads: gamepads,
 
     /**
-     * @static
-     * @readonly
+     * If platform supports touch input.
+     *
      * @type {boolean}
-     * @name platform.touch
-     * @description If platform supports touch input.
+     * @readonly
      */
     touch: touch,
 
     /**
-     * @static
-     * @readonly
+     * If the platform supports Web Workers.
+     *
      * @type {boolean}
-     * @name platform.workers
-     * @description If the platform supports Web Workers.
+     * @readonly
      */
     workers: workers,
 
     /**
-     * @private
-     * @static
-     * @readonly
+     * If the platform supports an options object as the third parameter to
+     * `EventTarget.addEventListener()` and the passive property is supported.
+     *
      * @type {boolean}
-     * @name platform.passiveEvents
-     * @description If the platform supports an options object as the third parameter
-     * to `EventTarget.addEventListener()` and the passive property is supported.
+     * @readonly
+     * @private
      */
     passiveEvents: passiveEvents
 };

--- a/src/core/read-stream.js
+++ b/src/core/read-stream.js
@@ -1,8 +1,7 @@
 /**
+ * Helper class for organized reading of memory.
+ *
  * @private
- * @class
- * @name ReadStream
- * @classdesc Helper class for organized reading of memory.
  */
 class ReadStream {
     constructor(arraybuffer) {

--- a/src/core/ref-counted-object.js
+++ b/src/core/ref-counted-object.js
@@ -5,7 +5,7 @@ class RefCountedObject {
         this._refCount = 0;
     }
 
-    // inrements the counter
+    // increments the counter
     incRefCount() {
         this._refCount++;
     }

--- a/src/core/sorted-loop-array.js
+++ b/src/core/sorted-loop-array.js
@@ -1,42 +1,64 @@
 /**
+ * Helper class used to hold an array of items in a specific order. This array is safe to modify
+ * while we loop through it. The class assumes that it holds objects that need to be sorted based
+ * on one of their fields.
+ *
  * @private
- * @class
- * @name SortedLoopArray
- * @classdesc Helper class used to hold an array of items in a specific order. This array is safe to modify
- * while we loop through it. The class assumes that it holds objects that need to be sorted based on
- * one of their fields.
- * @param {object} args - Arguments.
- * @param {string} args.sortBy - The name of the field that each element in the array is going to be sorted by.
- * @property {number} loopIndex The current index used to loop through the array. This gets modified if we
- * add or remove elements from the array while looping. See the example to see how to loop through this array.
- * @property {number} length The number of elements in the array.
- * @property {object[]} items The internal array that holds the actual array elements.
- * @example
- * var array = new pc.SortedLoopArray({ sortBy: 'priority' });
- * array.insert(item); // adds item to the right slot based on item.priority
- * array.append(item); // adds item to the end of the array
- * array.remove(item); // removes item from array
- * for (array.loopIndex = 0; array.loopIndex < array.length; array.loopIndex++) {
- *   // do things with array elements
- *   // safe to remove and add elements into the array while looping
- * }
  */
 class SortedLoopArray {
+    /**
+     * The current index used to loop through the array. This gets modified if we add or remove
+     * elements from the array while looping. See the example to see how to loop through this array.
+     *
+     * @type {number}
+     * @private
+     */
+    loopIndex = -1;
+
+    /**
+     * The number of elements in the array.
+     *
+     * @type {number}
+     * @private
+     */
+    length = 0;
+
+    /**
+     * The internal array that holds the actual array elements.
+     *
+     * @type {object[]}
+     * @private
+     */
+    items = [];
+
+    /**
+     * Create a new SortedLoopArray.
+     *
+     * @param {object} args - Arguments.
+     * @param {string} args.sortBy - The name of the field that each element in the array is going
+     * to be sorted by.
+     * @example
+     * var array = new pc.SortedLoopArray({ sortBy: 'priority' });
+     * array.insert(item); // adds item to the right slot based on item.priority
+     * array.append(item); // adds item to the end of the array
+     * array.remove(item); // removes item from array
+     * for (array.loopIndex = 0; array.loopIndex < array.length; array.loopIndex++) {
+     *   // do things with array elements
+     *   // safe to remove and add elements into the array while looping
+     * }
+     * @private
+     */
     constructor(args) {
         this._sortBy = args.sortBy;
-        this.items = [];
-        this.length = 0;
-        this.loopIndex = -1;
         this._sortHandler = this._doSort.bind(this);
     }
 
     /**
-     * @private
-     * @function
-     * @name SortedLoopArray#_binarySearch
-     * @description Searches for the right spot to insert the specified item.
+     * Searches for the right spot to insert the specified item.
+     *
      * @param {object} item - The item.
      * @returns {number} The index where to insert the item.
+     * @private
      */
     _binarySearch(item) {
         let left = 0;
@@ -64,13 +86,11 @@ class SortedLoopArray {
     }
 
     /**
-     * @private
-     * @function
-     * @name SortedLoopArray#insert
-     * @description Inserts the specified item into the array at the right
-     * index based on the 'sortBy' field passed into the constructor. This
-     * also adjusts the loopIndex accordingly.
+     * Inserts the specified item into the array at the right index based on the 'sortBy' field
+     * passed into the constructor. This also adjusts the loopIndex accordingly.
+     *
      * @param {object} item - The item to insert.
+     * @private
      */
     insert(item) {
         const index = this._binarySearch(item);
@@ -82,13 +102,11 @@ class SortedLoopArray {
     }
 
     /**
-     * @private
-     * @function
-     * @name SortedLoopArray#append
-     * @description Appends the specified item to the end of the array. Faster than insert()
-     * as it does not binary search for the right index. This also adjusts
-     * the loopIndex accordingly.
+     * Appends the specified item to the end of the array. Faster than insert() as it does not
+     * binary search for the right index. This also adjusts the loopIndex accordingly.
+     *
      * @param {object} item - The item to append.
+     * @private
      */
     append(item) {
         this.items.push(item);
@@ -96,11 +114,10 @@ class SortedLoopArray {
     }
 
     /**
-     * @private
-     * @function
-     * @name SortedLoopArray#remove
-     * @description Removes the specified item from the array.
+     * Removes the specified item from the array.
+     *
      * @param {object} item - The item to remove.
+     * @private
      */
     remove(item) {
         const idx = this.items.indexOf(item);
@@ -114,15 +131,13 @@ class SortedLoopArray {
     }
 
     /**
+     * Sorts elements in the array based on the 'sortBy' field passed into the constructor. This
+     * also updates the loopIndex if we are currently looping. WARNING: Be careful if you are
+     * sorting while iterating because if after sorting the array element that you are currently
+     * processing is moved behind other elements then you might end up iterating over elements
+     * more than once!
+     *
      * @private
-     * @function
-     * @name SortedLoopArray#sort
-     * @description Sorts elements in the array based on the 'sortBy' field
-     * passed into the constructor. This also updates the loopIndex
-     * if we are currently looping.
-     * WARNING: Be careful if you are sorting while iterating because if after
-     * sorting the array element that you are currently processing is moved
-     * behind other elements then you might end up iterating over elements more than once!
      */
     sort() {
         // get current item pointed to by loopIndex

--- a/src/core/string.js
+++ b/src/core/string.js
@@ -97,37 +97,38 @@ function numCharsToTakeForNextSymbol(string, index) {
 }
 
 /**
+ * Extended String API.
+ *
  * @namespace
- * @name string
- * @description Extended String API.
  */
 const string = {
     /**
-     * @constant
+     * All lowercase letters.
+     *
      * @type {string}
-     * @name string.ASCII_LOWERCASE
-     * @description All lowercase letters.
+     * @constant
      */
     ASCII_LOWERCASE: ASCII_LOWERCASE,
+
     /**
-     * @constant
+     * All uppercase letters.
+     *
      * @type {string}
-     * @name string.ASCII_UPPERCASE
-     * @description All uppercase letters.
+     * @constant
      */
+
     ASCII_UPPERCASE: ASCII_UPPERCASE,
     /**
-     * @constant
+     * All ASCII letters.
+     *
      * @type {string}
-     * @name string.ASCII_LETTERS
-     * @description All ASCII letters.
+     * @constant
      */
     ASCII_LETTERS: ASCII_LETTERS,
 
     /**
-     * @function
-     * @name string.format
-     * @description Return a string with {n} replaced with the n-th argument.
+     * Return a string with {n} replaced with the n-th argument.
+     *
      * @param {string} s - The string to format.
      * @param {object} [arguments] - All other arguments are substituted into the string.
      * @returns {string} The formatted string.
@@ -143,13 +144,13 @@ const string = {
     },
 
     /**
-     * @function
-     * @name string.toBool
-     * @description Convert a string value to a boolean. In non-strict mode (the default), 'true' is converted to true, all other values
-     * are converted to false. In strict mode, 'true' is converted to true, 'false' is converted to false, all other values will throw
-     * an Exception.
+     * Convert a string value to a boolean. In non-strict mode (the default), 'true' is converted
+     * to true, all other values are converted to false. In strict mode, 'true' is converted to
+     * true, 'false' is converted to false, all other values will throw an Exception.
+     *
      * @param {string} s - The string to convert.
-     * @param {boolean} [strict] - In strict mode an Exception is thrown if s is not an accepted string value. Defaults to false.
+     * @param {boolean} [strict] - In strict mode an Exception is thrown if s is not an accepted
+     * string value. Defaults to false.
      * @returns {boolean} The converted value.
      */
     toBool: function (s, strict = false) {
@@ -169,10 +170,9 @@ const string = {
     },
 
     /**
-     * @function
-     * @name string.getCodePoint
-     * @description Get the code point number for a character in a string. Polyfill for
+     * Get the code point number for a character in a string. Polyfill for
      * [`codePointAt`]{@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/codePointAt}.
+     *
      * @param {string} string - The string to get the code point from.
      * @param {number} [i] - The index in the string.
      * @returns {number} The code point value for the character in the string.
@@ -183,9 +183,8 @@ const string = {
     },
 
     /**
-     * @function
-     * @name string.getCodePoints
-     * @description Gets an array of all code points in a string.
+     * Gets an array of all code points in a string.
+     *
      * @param {string} string - The string to get code points from.
      * @returns {number[]} The code points in the string.
      */
@@ -204,11 +203,11 @@ const string = {
     },
 
     /**
-     * @function
-     * @name string.getSymbols
-     * @description Gets an array of all grapheme clusters (visible symbols) in a string. This is needed because
-     * some symbols (such as emoji or accented characters) are actually made up of multiple character codes. See
-     * {@link https://mathiasbynens.be/notes/javascript-unicode here} for more info.
+     * Gets an array of all grapheme clusters (visible symbols) in a string. This is needed because
+     * some symbols (such as emoji or accented characters) are actually made up of multiple
+     * character codes. See {@link https://mathiasbynens.be/notes/javascript-unicode here} for more
+     * info.
+     *
      * @param {string} string - The string to break into symbols.
      * @returns {string[]} The symbols in the string.
      */
@@ -245,10 +244,9 @@ const string = {
     },
 
     /**
-     * @function
-     * @name string.fromCodePoint
-     * @description Get the string for a given code point or set of code points. Polyfill for
+     * Get the string for a given code point or set of code points. Polyfill for
      * [`fromCodePoint`]{@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/fromCodePoint}.
+     *
      * @param {...number} args - The code points to convert to a string.
      * @returns {string} The converted string.
      */

--- a/src/core/tags-cache.js
+++ b/src/core/tags-cache.js
@@ -61,7 +61,7 @@ class TagsCache {
         // remove item from index list
         this._index[tag].list.splice(ind, 1);
 
-        // rmeove item from index keys
+        // remove item from index keys
         if (this._key)
             delete this._index[tag].keys[item[this._key]];
 

--- a/src/core/tags.js
+++ b/src/core/tags.js
@@ -1,15 +1,17 @@
 import { EventHandler } from './event-handler.js';
 
 /**
- * @class
- * @name Tags
+ * Set of tag names. Tags are automatically available on {@link Entity} and {@link Asset}
+ * instances via a `tags` property.
+ *
  * @augments EventHandler
- * @classdesc Set of tag names.
- * @description Create an instance of a Tags.
- * @param {object} [parent] - Parent object who tags belong to.
- * Note: Tags are automatically available on {@link Entity} and {@link Asset} as `tags` field.
  */
 class Tags extends EventHandler {
+    /**
+     * Create an instance of a Tags.
+     *
+     * @param {object} [parent] - Parent object who tags belong to.
+     */
     constructor(parent) {
         super();
 
@@ -19,9 +21,9 @@ class Tags extends EventHandler {
     }
 
     /**
-     * @function
-     * @name Tags#add
-     * @description Add a tag, duplicates are ignored. Can be array or comma separated arguments for multiple tags.
+     * Add a tag, duplicates are ignored. Can be array or comma separated arguments for multiple
+     * tags.
+     *
      * @param {...*} name - Name of a tag, or array of tags.
      * @returns {boolean} True if any tag were added.
      * @example
@@ -57,9 +59,8 @@ class Tags extends EventHandler {
     }
 
     /**
-     * @function
-     * @name Tags#remove
-     * @description Remove tag.
+     * Remove tag.
+     *
      * @param {...*} name - Name of a tag or array of tags.
      * @returns {boolean} True if any tag were removed.
      * @example
@@ -99,9 +100,8 @@ class Tags extends EventHandler {
     }
 
     /**
-     * @function
-     * @name Tags#clear
-     * @description Remove all tags.
+     * Remove all tags.
+     *
      * @example
      * tags.clear();
      */
@@ -120,13 +120,11 @@ class Tags extends EventHandler {
     }
 
     /**
-     * @function
-     * @name Tags#has
-     * @description Check if tags satisfy filters.
-     * Filters can be provided by simple name of tag, as well as by array of tags.
-     * When an array is provided it will check if tags contain each tag within the array.
-     * If any of comma separated argument is satisfied, then it will return true.
-     * Any number of combinations are valid, and order is irrelevant.
+     * Check if tags satisfy filters. Filters can be provided by simple name of tag, as well as by
+     * array of tags. When an array is provided it will check if tags contain each tag within the
+     * array. If any of comma separated argument is satisfied, then it will return true. Any number
+     * of combinations are valid, and order is irrelevant.
+     *
      * @param {...*} query - Name of a tag or array of tags.
      * @returns {boolean} True if filters are satisfied.
      * @example
@@ -152,11 +150,11 @@ class Tags extends EventHandler {
 
         for (let i = 0; i < tags.length; i++) {
             if (tags[i].length === 1) {
-                // single occurance
+                // single occurrence
                 if (this._index[tags[i][0]])
                     return true;
             } else {
-                // combined occurance
+                // combined occurrence
                 let multiple = true;
 
                 for (let t = 0; t < tags[i].length; t++) {
@@ -176,9 +174,8 @@ class Tags extends EventHandler {
     }
 
     /**
-     * @function
-     * @name Tags#list
-     * @description Returns immutable array of tags.
+     * Returns immutable array of tags.
+     *
      * @returns {string[]} Copy of tags array.
      */
     list() {
@@ -223,11 +220,10 @@ class Tags extends EventHandler {
     }
 
     /**
-     * @field
-     * @readonly
-     * @name Tags#size
+     * Number of tags in set.
+     *
      * @type {number}
-     * @description Number of tags in set.
+     * @readonly
      */
     get size() {
         return this._list.length;

--- a/src/core/time.js
+++ b/src/core/time.js
@@ -1,22 +1,25 @@
 /**
- * @private
- * @function
- * @name now
- * @description Get current time in milliseconds. Use it to measure time difference. Reference time may differ on different platforms.
+ * Get current time in milliseconds. Use it to measure time difference. Reference time may differ
+ * on different platforms.
+ *
  * @returns {number} The time in milliseconds.
+ * @private
  */
 const now = (typeof window !== 'undefined') && window.performance && window.performance.now && window.performance.timing ? function () {
     return window.performance.now();
 } : Date.now;
 
 /**
+ * A Timer counts milliseconds from when start() is called until when stop() is called.
+ *
  * @private
- * @class
- * @name Timer
- * @description Create a new Timer instance.
- * @classdesc A Timer counts milliseconds from when start() is called until when stop() is called.
  */
 class Timer {
+    /**
+     * Create a new Timer instance.
+     *
+     * @private
+     */
     constructor() {
         this._isRunning = false;
         this._a = 0;
@@ -24,10 +27,9 @@ class Timer {
     }
 
     /**
+     * Start the timer.
+     *
      * @private
-     * @function
-     * @name Timer#start
-     * @description Start the timer.
      */
     start() {
         this._isRunning = true;
@@ -35,10 +37,9 @@ class Timer {
     }
 
     /**
+     * Stop the timer.
+     *
      * @private
-     * @function
-     * @name Timer#stop
-     * @description Stop the timer.
      */
     stop() {
         this._isRunning = false;
@@ -46,11 +47,10 @@ class Timer {
     }
 
     /**
-     * @private
-     * @function
-     * @name Timer#getMilliseconds
-     * @description Get the number of milliseconds that passed between start() and stop() being called.
+     * Get the number of milliseconds that passed between start() and stop() being called.
+     *
      * @returns {number} The elapsed milliseconds.
+     * @private
      */
     getMilliseconds() {
         return this._b - this._a;

--- a/src/core/uri.js
+++ b/src/core/uri.js
@@ -1,8 +1,6 @@
 /**
- * @private
- * @function
- * @name createURI
- * @description Create a URI object from constituent parts.
+ * Create a URI object from constituent parts.
+ *
  * @param {object} options - Parts of the URI to build.
  * @param {string} [options.scheme] - The URI scheme (e.g. http).
  * @param {string} [options.authority] - The URI authority (e.g. `www.example.com`).
@@ -12,6 +10,7 @@
  * @param {string} [options.query] - The query section, after the ?(e.g. `http://example.com?**key=value&another=123**`).
  * @param {string} [options.fragment] - The fragment section, after the # (e.g. `http://example.com#**fragment/data**`).
  * @returns {string} A URI string.
+ * @private
  */
 function createURI(options) {
     let s = "";
@@ -59,19 +58,22 @@ function createURI(options) {
 // See http://tools.ietf.org/html/rfc2396#appendix-B for details of RegExp
 const re = /^(([^:\/?#]+):)?(\/\/([^\/?#]*))?([^?#]*)(\?([^#]*))?(#(.*))?/;
 
+/**
+ * A URI object.
+ *
+ * @private
+ */
 class URI {
     /**
-     * @private
-     * @class
-     * @name URI
-     * @description Create a new URI object.
-     * @classdesc A URI object.
+     * Create a new URI object.
+     *
      * @param {string} uri - URI string.
      * @property {string} scheme The scheme. (e.g. http).
      * @property {string} authority The authority. (e.g. `www.example.com`).
      * @property {string} path The path. (e.g. /users/example).
      * @property {string} query The query, the section after a ?. (e.g. search=value).
      * @property {string} fragment The fragment, the section after a #.
+     * @private
      */
     constructor(uri) {
         const result = uri.match(re);
@@ -84,11 +86,10 @@ class URI {
     }
 
     /**
-     * @private
-     * @function
-     * @name URI#toString
-     * @description Convert URI back to string.
+     * Convert URI back to string.
+     *
      * @returns {string} The URI as a string.
+     * @private
      */
     toString() {
         let s = "";
@@ -115,10 +116,8 @@ class URI {
     }
 
     /**
-     * @private
-     * @function
-     * @name URI#getQuery
-     * @description Returns the query parameters as an Object.
+     * Returns the query parameters as an Object.
+     *
      * @returns {object} The URI's query parameters converted to an Object.
      * @example
      * var s = "http://example.com?a=1&b=2&c=3";
@@ -127,6 +126,7 @@ class URI {
      * console.log(q.a); // logs "1"
      * console.log(q.b); // logs "2"
      * console.log(q.c); // logs "3"
+     * @private
      */
     getQuery() {
         const result = {};
@@ -143,10 +143,8 @@ class URI {
     }
 
     /**
-     * @private
-     * @function
-     * @name URI#setQuery
-     * @description Set the query section of the URI from a Object.
+     * Set the query section of the URI from a Object.
+     *
      * @param {object} params - Key-Value pairs to encode into the query string.
      * @example
      * var s = "http://example.com";
@@ -156,6 +154,7 @@ class URI {
      *     "b": 2
      * });
      * console.log(uri.toString()); // logs "http://example.com?a=1&b=2
+     * @private
      */
     setQuery(params) {
         let q = "";

--- a/src/math/color.js
+++ b/src/math/color.js
@@ -1,20 +1,46 @@
 import { math } from '../math/math.js';
 
 /**
- * @class
- * @name Color
- * @classdesc Representation of an RGBA color.
- * @description Create a new Color object.
- * @param {number|number[]} [r] - The value of the red component (0-1). If r is an array of length 3 or 4, the array will be used to populate all components.
- * @param {number} [g] - The value of the green component (0-1).
- * @param {number} [b] - The value of the blue component (0-1).
- * @param {number} [a] - The value of the alpha component (0-1).
- * @property {number} r The red component of the color.
- * @property {number} g The green component of the color.
- * @property {number} b The blue component of the color.
- * @property {number} a The alpha component of the color.
+ * Representation of an RGBA color.
  */
 class Color {
+    /**
+     * The red component of the color.
+     *
+     * @type {number}
+     */
+    r;
+
+    /**
+     * The green component of the color.
+     *
+     * @type {number}
+     */
+    g;
+
+    /**
+     * The blue component of the color.
+     *
+     * @type {number}
+     */
+    b;
+
+    /**
+     * The alpha component of the color.
+     *
+     * @type {number}
+     */
+    a;
+
+    /**
+     * Create a new Color object.
+     *
+     * @param {number|number[]} [r] - The value of the red component (0-1). If r is an array of
+     * length 3 or 4, the array will be used to populate all components.
+     * @param {number} [g] - The value of the green component (0-1).
+     * @param {number} [b] - The value of the blue component (0-1).
+     * @param {number} [a] - The value of the alpha component (0-1).
+     */
     constructor(r = 0, g = 0, b = 0, a = 1) {
         const length = r.length;
         if (length === 3 || length === 4) {
@@ -31,9 +57,8 @@ class Color {
     }
 
     /**
-     * @function
-     * @name Color#clone
-     * @description Returns a clone of the specified color.
+     * Returns a clone of the specified color.
+     *
      * @returns {Color} A duplicate color object.
      */
     clone() {
@@ -41,9 +66,8 @@ class Color {
     }
 
     /**
-     * @function
-     * @name Color#copy
-     * @description Copies the contents of a source color to a destination color.
+     * Copies the contents of a source color to a destination color.
+     *
      * @param {Color} rhs - A color to copy to the specified color.
      * @returns {Color} Self for chaining.
      * @example
@@ -64,9 +88,8 @@ class Color {
     }
 
     /**
-     * @function
-     * @name Color#equals
-     * @description Reports whether two colors are equal.
+     * Reports whether two colors are equal.
+     *
      * @param {Color} rhs - The color to compare to the specified color.
      * @returns {boolean} True if the colors are equal and false otherwise.
      * @example
@@ -79,9 +102,8 @@ class Color {
     }
 
     /**
-     * @function
-     * @name Color#set
-     * @description Assign values to the color components, including alpha.
+     * Assign values to the color components, including alpha.
+     *
      * @param {number} r - The value for red (0-1).
      * @param {number} g - The value for blue (0-1).
      * @param {number} b - The value for green (0-1).
@@ -98,14 +120,13 @@ class Color {
     }
 
     /**
-     * @function
-     * @name Color#lerp
-     * @description Returns the result of a linear interpolation between two specified colors.
+     * Returns the result of a linear interpolation between two specified colors.
+     *
      * @param {Color} lhs - The color to interpolate from.
      * @param {Color} rhs - The color to interpolate to.
-     * @param {number} alpha - The value controlling the point of interpolation. Between 0 and 1, the linear interpolant
-     * will occur on a straight line between lhs and rhs. Outside of this range, the linear interpolant will occur on
-     * a ray extrapolated from this line.
+     * @param {number} alpha - The value controlling the point of interpolation. Between 0 and 1,
+     * the linear interpolant will occur on a straight line between lhs and rhs. Outside of this
+     * range, the linear interpolant will occur on a ray extrapolated from this line.
      * @returns {Color} Self for chaining.
      * @example
      * var a = new pc.Color(0, 0, 0);
@@ -126,11 +147,11 @@ class Color {
     }
 
     /**
-     * @function
-     * @name Color#fromString
-     * @description Set the values of the color from a string representation '#11223344' or '#112233'.
-     * @param {string} hex - A string representation in the format '#RRGGBBAA' or '#RRGGBB'. Where RR, GG, BB, AA are red, green, blue and alpha values.
-     * This is the same format used in HTML/CSS.
+     * Set the values of the color from a string representation '#11223344' or '#112233'.
+     *
+     * @param {string} hex - A string representation in the format '#RRGGBBAA' or '#RRGGBB' where
+     * RR, GG, BB, AA are red, green, blue and alpha values. This is the same format used in
+     * HTML/CSS.
      * @returns {Color} Self for chaining.
      */
     fromString(hex) {
@@ -149,11 +170,10 @@ class Color {
     }
 
     /**
-     * @function
-     * @name Color#toString
-     * @description Converts the color to string form. The format is '#RRGGBBAA', where
-     * RR, GG, BB, AA are the red, green, blue and alpha values. When the alpha value is not
-     * included (the default), this is the same format as used in HTML/CSS.
+     * Converts the color to string form. The format is '#RRGGBBAA', where RR, GG, BB, AA are the
+     * red, green, blue and alpha values. When the alpha value is not included (the default), this
+     * is the same format as used in HTML/CSS.
+     *
      * @param {boolean} alpha - If true, the output string will include the alpha value.
      * @returns {string} The color in string form.
      * @example
@@ -177,92 +197,83 @@ class Color {
     }
 
     /**
-     * @field
-     * @static
-     * @readonly
+     * A constant color set to black [0, 0, 0, 1].
+     *
      * @name Color.BLACK
      * @type {Color}
-     * @description A constant color set to black [0, 0, 0, 1].
+     * @readonly
      */
     static BLACK = Object.freeze(new Color(0, 0, 0, 1));
 
     /**
-     * @field
-     * @static
-     * @readonly
+     * A constant color set to blue [0, 0, 1, 1].
+     *
      * @name Color.BLUE
      * @type {Color}
-     * @description A constant color set to blue [0, 0, 1, 1].
+     * @readonly
      */
     static BLUE = Object.freeze(new Color(0, 0, 1, 1));
 
     /**
-     * @field
-     * @static
-     * @readonly
+     * A constant color set to cyan [0, 1, 1, 1].
+     *
      * @name Color.CYAN
      * @type {Color}
-     * @description A constant color set to cyan [0, 1, 1, 1].
+     * @readonly
      */
     static CYAN = Object.freeze(new Color(0, 1, 1, 1));
 
     /**
-     * @field
-     * @static
-     * @readonly
+     * A constant color set to gray [0.5, 0.5, 0.5, 1].
+     *
      * @name Color.GRAY
      * @type {Color}
-     * @description A constant color set to gray [0.5, 0.5, 0.5, 1].
+     * @readonly
      */
     static GRAY = Object.freeze(new Color(0.5, 0.5, 0.5, 1));
 
     /**
-     * @field
-     * @static
-     * @readonly
+     * A constant color set to green [0, 1, 0, 1].
+     *
      * @name Color.GREEN
      * @type {Color}
-     * @description A constant color set to green [0, 1, 0, 1].
+     * @readonly
      */
     static GREEN = Object.freeze(new Color(0, 1, 0, 1));
 
     /**
-     * @field
-     * @static
-     * @readonly
+     * A constant color set to magenta [1, 0, 1, 1].
+     *
      * @name Color.MAGENTA
      * @type {Color}
-     * @description A constant color set to magenta [1, 0, 1, 1].
+     * @readonly
      */
     static MAGENTA = Object.freeze(new Color(1, 0, 1, 1));
 
     /**
-     * @field
-     * @static
-     * @readonly
+     * A constant color set to red [1, 0, 0, 1].
+     *
      * @name Color.RED
      * @type {Color}
-     * @description A constant color set to red [1, 0, 0, 1].
+     * @readonly
      */
     static RED = Object.freeze(new Color(1, 0, 0, 1));
 
     /**
-     * @field
-     * @static
-     * @readonly
+     * A constant color set to white [1, 1, 1, 1].
+     *
      * @name Color.WHITE
      * @type {Color}
-     * @description A constant color set to white [1, 1, 1, 1].
+     * @readonly
      */
     static WHITE = Object.freeze(new Color(1, 1, 1, 1));
 
     /**
-     * @field
-     * @static
-     * @readonly
+     * A constant color set to yellow [1, 1, 0, 1].
+     *
      * @name Color.YELLOW
      * @type {Color}
-     * @description A constant color set to yellow [1, 1, 0, 1].
+     * @readonly
      */
     static YELLOW = Object.freeze(new Color(1, 1, 0, 1));
 }

--- a/src/math/constants.js
+++ b/src/math/constants.js
@@ -1,44 +1,45 @@
 /**
- * @constant
+ * A linear interpolation scheme.
+ *
  * @type {number}
- * @name CURVE_LINEAR
- * @description A linear interpolation scheme.
  */
 export const CURVE_LINEAR = 0;
+
 /**
- * @constant
+ * A smooth step interpolation scheme.
+ *
  * @type {number}
- * @name CURVE_SMOOTHSTEP
- * @description A smooth step interpolation scheme.
  */
 export const CURVE_SMOOTHSTEP = 1;
+
 /**
- * @deprecated
- * @constant
+ * A Catmull-Rom spline interpolation scheme. This interpolation scheme is deprecated. Use
+ * CURVE_SPLINE instead.
+ *
  * @type {number}
- * @name CURVE_CATMULL
- * @description A Catmull-Rom spline interpolation scheme. This interpolation scheme is deprecated. Use CURVE_SPLINE instead.
+ * @deprecated
  */
 export const CURVE_CATMULL = 2;
+
 /**
- * @deprecated
- * @constant
+ * A cardinal spline interpolation scheme. This interpolation scheme is deprecated. Use
+ * CURVE_SPLINE instead.
+ *
  * @type {number}
- * @name CURVE_CARDINAL
- * @description A cardinal spline interpolation scheme. This interpolation scheme is deprecated. Use CURVE_SPLINE instead.
+ * @deprecated
  */
 export const CURVE_CARDINAL = 3;
+
 /**
- * @constant
+ * Cardinal spline interpolation scheme. For Catmull-Rom, specify curve tension 0.5.
+ *
  * @type {number}
- * @name CURVE_SPLINE
- * @description Cardinal spline interpolation scheme. For Catmull-Rom, specify curve tension 0.5.
  */
 export const CURVE_SPLINE = 4;
+
 /**
- * @constant
+ * A stepped interpolator, free from the shackles of blending.
+ *
  * @type {number}
- * @name CURVE_STEP
- * @description A stepped interpolator, free from the shackles of blending.
  */
 export const CURVE_STEP = 5;

--- a/src/math/curve-set.js
+++ b/src/math/curve-set.js
@@ -3,29 +3,30 @@ import { Curve } from './curve.js';
 import { CurveEvaluator } from './curve-evaluator.js';
 
 /**
- * @class
- * @name CurveSet
- * @classdesc A curve set is a collection of curves.
- * @description Creates a new curve set.
- * @param {Array<number[]>} curveKeys - An array of arrays of keys (pairs of numbers with
- * the time first and value second).
- * @example
- * var curveSet = new pc.CurveSet([
- *     [
- *         0, 0,        // At 0 time, value of 0
- *         0.33, 2,     // At 0.33 time, value of 2
- *         0.66, 2.6,   // At 0.66 time, value of 2.6
- *         1, 3         // At 1 time, value of 3
- *     ],
- *     [
- *         0, 34,
- *         0.33, 35,
- *         0.66, 36,
- *         1, 37
- *     ]
- * ]);
+ * A curve set is a collection of curves.
  */
 class CurveSet {
+    /**
+     * Creates a new curve set.
+     *
+     * @param {Array<number[]>} curveKeys - An array of arrays of keys (pairs of numbers with
+     * the time first and value second).
+     * @example
+     * var curveSet = new pc.CurveSet([
+     *     [
+     *         0, 0,        // At 0 time, value of 0
+     *         0.33, 2,     // At 0.33 time, value of 2
+     *         0.66, 2.6,   // At 0.66 time, value of 2.6
+     *         1, 3         // At 1 time, value of 3
+     *     ],
+     *     [
+     *         0, 34,
+     *         0.33, 35,
+     *         0.66, 36,
+     *         1, 37
+     *     ]
+     * ]);
+     */
     constructor() {
         this.curves = [];
         this._type = CURVE_SMOOTHSTEP;
@@ -53,9 +54,8 @@ class CurveSet {
     }
 
     /**
-     * @function
-     * @name CurveSet#get
-     * @description Return a specific curve in the curve set.
+     * Return a specific curve in the curve set.
+     *
      * @param {number} index - The index of the curve to return.
      * @returns {Curve} The curve at the specified index.
      */
@@ -64,14 +64,12 @@ class CurveSet {
     }
 
     /**
-     * @function
-     * @name CurveSet#value
-     * @description Returns the interpolated value of all curves in the curve
-     * set at the specified time.
+     * Returns the interpolated value of all curves in the curve set at the specified time.
+     *
      * @param {number} time - The time at which to calculate the value.
-     * @param {number[]} [result] - The interpolated curve values at the specified time.
-     * If this parameter is not supplied, the function allocates a new array internally
-     * to return the result.
+     * @param {number[]} [result] - The interpolated curve values at the specified time. If this
+     * parameter is not supplied, the function allocates a new array internally to return the
+     * result.
      * @returns {number[]} The interpolated curve values at the specified time.
      */
     value(time, result = []) {
@@ -86,9 +84,8 @@ class CurveSet {
     }
 
     /**
-     * @function
-     * @name CurveSet#clone
-     * @description Returns a clone of the specified curve set object.
+     * Returns a clone of the specified curve set object.
+     *
      * @returns {CurveSet} A clone of the specified curve set.
      */
     clone() {
@@ -122,15 +119,14 @@ class CurveSet {
     }
 
     /**
-     * @private
-     * @function
-     * @name CurveSet#quantizeClamped
-     * @description This function will sample the curveset at regular intervals
-     * over the range [0..1] and clamp the result to min and max.
+     * This function will sample the curveset at regular intervals over the range [0..1] and clamp
+     * the result to min and max.
+     *
      * @param {number} precision - The number of samples to return.
      * @param {number} min - The minimum output value.
      * @param {number} max - The maximum output value.
      * @returns {Float32Array} The set of quantized values.
+     * @private
      */
     quantizeClamped(precision, min, max) {
         const result = this.quantize(precision);
@@ -141,19 +137,17 @@ class CurveSet {
     }
 
     /**
-     * @readonly
-     * @name CurveSet#length
+     * The number of curves in the curve set.
+     *
      * @type {number}
-     * @description The number of curves in the curve set.
+     * @readonly
      */
     get length() {
         return this.curves.length;
     }
 
     /**
-     * @name CurveSet#type
-     * @type {number}
-     * @description The interpolation scheme applied to all curves in the curve set. Can be:
+     * The interpolation scheme applied to all curves in the curve set. Can be:
      *
      * - {@link CURVE_LINEAR}
      * - {@link CURVE_SMOOTHSTEP}
@@ -161,6 +155,8 @@ class CurveSet {
      * - {@link CURVE_STEP}
      *
      * Defaults to {@link CURVE_SMOOTHSTEP}.
+     *
+     * @type {number}
      */
     get type() {
         return this._type;

--- a/src/math/curve.js
+++ b/src/math/curve.js
@@ -4,39 +4,48 @@ import { CURVE_SMOOTHSTEP } from './constants.js';
 import { CurveEvaluator } from './curve-evaluator.js';
 
 /**
- * @class
- * @name Curve
- * @classdesc A curve is a collection of keys (time/value pairs). The shape of the
- * curve is defined by its type that specifies an interpolation scheme for the keys.
- * @description Creates a new curve.
- * @param {number[]} [data] - An array of keys (pairs of numbers with the time first and
- * value second).
- * @property {number} length The number of keys in the curve. [read only].
- * @property {number} type The curve interpolation scheme. Can be:
- *
- * - {@link CURVE_LINEAR}
- * - {@link CURVE_SMOOTHSTEP}
- * - {@link CURVE_SPLINE}
- * - {@link CURVE_STEP}
- *
- * Defaults to {@link CURVE_SMOOTHSTEP}.
- * @property {number} tension Controls how {@link CURVE_SPLINE} tangents are calculated.
- * Valid range is between 0 and 1 where 0 results in a non-smooth curve (equivalent to linear
- * interpolation) and 1 results in a very smooth curve. Use 0.5 for a Catmull-rom spline.
- *
- * @example
- * var curve = new pc.Curve([
- *     0, 0,        // At 0 time, value of 0
- *     0.33, 2,     // At 0.33 time, value of 2
- *     0.66, 2.6,   // At 0.66 time, value of 2.6
- *     1, 3         // At 1 time, value of 3
- * ]);
+ * A curve is a collection of keys (time/value pairs). The shape of the curve is defined by its
+ * type that specifies an interpolation scheme for the keys.
  */
 class Curve {
+    /**
+     * Controls how {@link CURVE_SPLINE} tangents are calculated. Valid range is between 0 and 1
+     * where 0 results in a non-smooth curve (equivalent to linear interpolation) and 1 results in
+     * a very smooth curve. Use 0.5 for a Catmull-rom spline.
+     *
+     * @type {number}
+     */
+    tension = 0.5;
+
+    /**
+     * The curve interpolation scheme. Can be:
+     *
+     * - {@link CURVE_LINEAR}
+     * - {@link CURVE_SMOOTHSTEP}
+     * - {@link CURVE_SPLINE}
+     * - {@link CURVE_STEP}
+     *
+     * Defaults to {@link CURVE_SMOOTHSTEP}.
+     *
+     * @type {number}
+     */
+    type = CURVE_SMOOTHSTEP;
+
+    /**
+     * Creates a new curve.
+     *
+     * @param {number[]} [data] - An array of keys (pairs of numbers with the time first and
+     * value second).
+     * @example
+     * var curve = new pc.Curve([
+     *     0, 0,        // At 0 time, value of 0
+     *     0.33, 2,     // At 0.33 time, value of 2
+     *     0.66, 2.6,   // At 0.66 time, value of 2.6
+     *     1, 3         // At 1 time, value of 3
+     * ]);
+     */
     constructor(data) {
         this.keys = [];
-        this.type = CURVE_SMOOTHSTEP;
-        this.tension = 0.5;                     // used for CURVE_SPLINE
         this._eval = new CurveEvaluator(this);
 
         if (data) {
@@ -49,9 +58,8 @@ class Curve {
     }
 
     /**
-     * @function
-     * @name Curve#add
-     * @description Add a new key to the curve.
+     * Add a new key to the curve.
+     *
      * @param {number} time - Time to add new key.
      * @param {number} value - Value of new key.
      * @returns {number[]} [time, value] pair.
@@ -73,9 +81,8 @@ class Curve {
     }
 
     /**
-     * @function
-     * @name Curve#get
-     * @description Return a specific key.
+     * Return a specific key.
+     *
      * @param {number} index - The index of the key to return.
      * @returns {number[]} The key at the specified index.
      */
@@ -84,9 +91,7 @@ class Curve {
     }
 
     /**
-     * @function
-     * @name Curve#sort
-     * @description Sort keys by time.
+     * Sort keys by time.
      */
     sort() {
         this.keys.sort(function (a, b) {
@@ -95,9 +100,8 @@ class Curve {
     }
 
     /**
-     * @function
-     * @name Curve#value
-     * @description Returns the interpolated value of the curve at specified time.
+     * Returns the interpolated value of the curve at specified time.
+     *
      * @param {number} time - The time at which to calculate the value.
      * @returns {number} The interpolated value.
      */
@@ -127,9 +131,8 @@ class Curve {
     }
 
     /**
-     * @function
-     * @name Curve#clone
-     * @description Returns a clone of the specified curve object.
+     * Returns a clone of the specified curve object.
+     *
      * @returns {Curve} A clone of the specified curve.
      */
     clone() {
@@ -141,12 +144,11 @@ class Curve {
     }
 
     /**
-     * @private
-     * @function
-     * @name Curve#quantize
-     * @description Sample the curve at regular intervals over the range [0..1].
+     * Sample the curve at regular intervals over the range [0..1].
+     *
      * @param {number} precision - The number of samples to return.
      * @returns {Float32Array} The set of quantized values.
+     * @private
      */
     quantize(precision) {
         precision = Math.max(precision, 2);
@@ -164,15 +166,14 @@ class Curve {
     }
 
     /**
-     * @private
-     * @function
-     * @name Curve#quantizeClamped
-     * @description Sample the curve at regular intervals over the range [0..1]
-     * and clamp the resulting samples to [min..max].
+     * Sample the curve at regular intervals over the range [0..1] and clamp the resulting samples
+     * to [min..max].
+     *
      * @param {number} precision - The number of samples to return.
      * @param {number} min - The minimum output value.
      * @param {number} max - The maximum output value.
      * @returns {Float32Array} The set of quantized values.
+     * @private
      */
     quantizeClamped(precision, min, max) {
         const result = this.quantize(precision);
@@ -182,6 +183,12 @@ class Curve {
         return result;
     }
 
+    /**
+     * The number of keys in the curve.
+     *
+     * @type {number}
+     * @readonly
+     */
     get length() {
         return this.keys.length;
     }

--- a/src/math/mat3.js
+++ b/src/math/mat3.js
@@ -1,13 +1,19 @@
 import { Vec3 } from './vec3.js';
 
 /**
- * @class
- * @name Mat3
- * @classdesc A 3x3 matrix.
- * @description Creates a new identity Mat3 object.
- * @property {Float32Array} data Matrix elements in the form of a flat array.
+ * A 3x3 matrix.
  */
 class Mat3 {
+    /**
+     * Matrix elements in the form of a flat array.
+     *
+     * @type {Float32Array}
+     */
+    data;
+
+    /**
+     * Creates a new identity Mat3 object.
+     */
     constructor() {
         // Create an identity matrix. Note that a new Float32Array has all elements set
         // to zero by default, so we only need to set the relevant elements to one.
@@ -17,9 +23,8 @@ class Mat3 {
     }
 
     /**
-     * @function
-     * @name Mat3#clone
-     * @description Creates a duplicate of the specified matrix.
+     * Creates a duplicate of the specified matrix.
+     *
      * @returns {Mat3} A duplicate matrix.
      * @example
      * var src = new pc.Mat3().translate(10, 20, 30);
@@ -31,9 +36,8 @@ class Mat3 {
     }
 
     /**
-     * @function
-     * @name Mat3#copy
-     * @description Copies the contents of a source 3x3 matrix to a destination 3x3 matrix.
+     * Copies the contents of a source 3x3 matrix to a destination 3x3 matrix.
+     *
      * @param {Mat3} rhs - A 3x3 matrix to be copied.
      * @returns {Mat3} Self for chaining.
      * @example
@@ -60,9 +64,8 @@ class Mat3 {
     }
 
     /**
-     * @function
-     * @name Mat3#set
-     * @description Copies the contents of a source array[9] to a destination 3x3 matrix.
+     * Copies the contents of a source array[9] to a destination 3x3 matrix.
+     *
      * @param {number[]} src - An array[9] to be copied.
      * @returns {Mat3} Self for chaining.
      * @example
@@ -86,10 +89,9 @@ class Mat3 {
     }
 
     /**
-     * @function
-     * @name Mat3#equals
+     * Reports whether two matrices are equal.
+     *
      * @param {Mat3} rhs - The other matrix.
-     * @description Reports whether two matrices are equal.
      * @returns {boolean} True if the matrices are equal and false otherwise.
      * @example
      * var a = new pc.Mat3().translate(10, 20, 30);
@@ -112,9 +114,8 @@ class Mat3 {
     }
 
     /**
-     * @function
-     * @name Mat3#isIdentity
-     * @description Reports whether the specified matrix is the identity matrix.
+     * Reports whether the specified matrix is the identity matrix.
+     *
      * @returns {boolean} True if the matrix is identity and false otherwise.
      * @example
      * var m = new pc.Mat3();
@@ -134,9 +135,8 @@ class Mat3 {
     }
 
     /**
-     * @function
-     * @name Mat3#setIdentity
-     * @description Sets the matrix to the identity matrix.
+     * Sets the matrix to the identity matrix.
+     *
      * @returns {Mat3} Self for chaining.
      * @example
      * m.setIdentity();
@@ -160,9 +160,8 @@ class Mat3 {
     }
 
     /**
-     * @function
-     * @name Mat3#toString
-     * @description Converts the matrix to string form.
+     * Converts the matrix to string form.
+     *
      * @returns {string} The matrix in string form.
      * @example
      * var m = new pc.Mat3();
@@ -180,9 +179,8 @@ class Mat3 {
     }
 
     /**
-     * @function
-     * @name Mat3#transpose
-     * @description Generates the transpose of the specified 3x3 matrix.
+     * Generates the transpose of the specified 3x3 matrix.
+     *
      * @returns {Mat3} Self for chaining.
      * @example
      * var m = new pc.Mat3();
@@ -202,9 +200,8 @@ class Mat3 {
     }
 
     /**
-     * @function
-     * @name Mat3#setFromMat4
-     * @description Converts the specified 4x4 matrix to a Mat3.
+     * Converts the specified 4x4 matrix to a Mat3.
+     *
      * @param {Mat4} m - The 4x4 matrix to convert.
      * @returns {Mat3} Self for chaining.
      */
@@ -228,11 +225,11 @@ class Mat3 {
     }
 
     /**
-     * @function
-     * @name Mat3#transformVector
-     * @description Transforms a 3-dimensional vector by a 3x3 matrix.
+     * Transforms a 3-dimensional vector by a 3x3 matrix.
+     *
      * @param {Vec3} vec - The 3-dimensional vector to be transformed.
-     * @param {Vec3} [res] - An optional 3-dimensional vector to receive the result of the transformation.
+     * @param {Vec3} [res] - An optional 3-dimensional vector to receive the result of the
+     * transformation.
      * @returns {Vec3} The input vector v transformed by the current instance.
      */
     transformVector(vec, res = new Vec3()) {
@@ -251,22 +248,20 @@ class Mat3 {
 
 
     /**
-     * @field
-     * @static
-     * @readonly
+     * A constant matrix set to the identity.
+     *
      * @name Mat3.IDENTITY
      * @type {Mat3}
-     * @description A constant matrix set to the identity.
+     * @readonly
      */
     static IDENTITY = Object.freeze(new Mat3());
 
     /**
-     * @field
-     * @static
-     * @readonly
+     * A constant matrix with all elements set to 0.
+     *
      * @name Mat3.ZERO
      * @type {Mat3}
-     * @description A constant matrix with all elements set to 0.
+     * @readonly
      */
     static ZERO = Object.freeze(new Mat3().set([0, 0, 0, 0, 0, 0, 0, 0, 0]));
 }

--- a/src/math/mat4.js
+++ b/src/math/mat4.js
@@ -11,13 +11,19 @@ const scale = new Vec3();
 
 
 /**
- * @class
- * @name Mat4
- * @classdesc A 4x4 matrix.
- * @description Creates a new identity Mat4 object.
- * @property {Float32Array} data Matrix elements in the form of a flat array.
+ * A 4x4 matrix.
  */
 class Mat4 {
+    /**
+     * Matrix elements in the form of a flat array.
+     *
+     * @type {Float32Array}
+     */
+    data;
+
+    /**
+     * Creates a new identity Mat4 object.
+     */
     constructor() {
         // Create an identity matrix. Note that a new Float32Array has all elements set
         // to zero by default, so we only need to set the relevant elements to one.
@@ -38,10 +44,8 @@ class Mat4 {
     }
 
     /**
-     * @function
-     * @name Mat4#add2
-     * @description Adds the specified 4x4 matrices together and stores the result in
-     * the current instance.
+     * Adds the specified 4x4 matrices together and stores the result in the current instance.
+     *
      * @param {Mat4} lhs - The 4x4 matrix used as the first operand of the addition.
      * @param {Mat4} rhs - The 4x4 matrix used as the second operand of the addition.
      * @returns {Mat4} Self for chaining.
@@ -78,9 +82,8 @@ class Mat4 {
     }
 
     /**
-     * @function
-     * @name Mat4#add
-     * @description Adds the specified 4x4 matrix to the current instance.
+     * Adds the specified 4x4 matrix to the current instance.
+     *
      * @param {Mat4} rhs - The 4x4 matrix used as the second operand of the addition.
      * @returns {Mat4} Self for chaining.
      * @example
@@ -95,9 +98,8 @@ class Mat4 {
     }
 
     /**
-     * @function
-     * @name Mat4#clone
-     * @description Creates a duplicate of the specified matrix.
+     * Creates a duplicate of the specified matrix.
+     *
      * @returns {Mat4} A duplicate matrix.
      * @example
      * var src = new pc.Mat4().setFromEulerAngles(10, 20, 30);
@@ -109,9 +111,8 @@ class Mat4 {
     }
 
     /**
-     * @function
-     * @name Mat4#copy
-     * @description Copies the contents of a source 4x4 matrix to a destination 4x4 matrix.
+     * Copies the contents of a source 4x4 matrix to a destination 4x4 matrix.
+     *
      * @param {Mat4} rhs - A 4x4 matrix to be copied.
      * @returns {Mat4} Self for chaining.
      * @example
@@ -145,9 +146,8 @@ class Mat4 {
     }
 
     /**
-     * @function
-     * @name Mat4#equals
-     * @description Reports whether two matrices are equal.
+     * Reports whether two matrices are equal.
+     *
      * @param {Mat4} rhs - The other matrix.
      * @returns {boolean} True if the matrices are equal and false otherwise.
      * @example
@@ -178,9 +178,8 @@ class Mat4 {
     }
 
     /**
-     * @function
-     * @name Mat4#isIdentity
-     * @description Reports whether the specified matrix is the identity matrix.
+     * Reports whether the specified matrix is the identity matrix.
+     *
      * @returns {boolean} True if the matrix is identity and false otherwise.
      * @example
      * var m = new pc.Mat4();
@@ -208,10 +207,9 @@ class Mat4 {
     }
 
     /**
-     * @function
-     * @name Mat4#mul2
-     * @description Multiplies the specified 4x4 matrices together and stores the result in
-     * the current instance.
+     * Multiplies the specified 4x4 matrices together and stores the result in the current
+     * instance.
+     *
      * @param {Mat4} lhs - The 4x4 matrix used as the first multiplicand of the operation.
      * @param {Mat4} rhs - The 4x4 matrix used as the second multiplicand of the operation.
      * @returns {Mat4} Self for chaining.
@@ -289,14 +287,17 @@ class Mat4 {
     }
 
     /**
-     * @function
-     * @name Mat4#mulAffine2
-     * @description Multiplies the specified 4x4 matrices together and stores the result in
-     * the current instance. This function assumes the matrices are affine transformation matrices, where the upper left 3x3 elements
-     * are a rotation matrix, and the bottom left 3 elements are translation. The rightmost column is assumed to be [0, 0, 0, 1]. The parameters
-     * are not verified to be in the expected format. This function is faster than general {@link Mat4#mul2}.
-     * @param {Mat4} lhs - The affine transformation 4x4 matrix used as the first multiplicand of the operation.
-     * @param {Mat4} rhs - The affine transformation 4x4 matrix used as the second multiplicand of the operation.
+     * Multiplies the specified 4x4 matrices together and stores the result in the current
+     * instance. This function assumes the matrices are affine transformation matrices, where the
+     * upper left 3x3 elements are a rotation matrix, and the bottom left 3 elements are
+     * translation. The rightmost column is assumed to be [0, 0, 0, 1]. The parameters are not
+     * verified to be in the expected format. This function is faster than general
+     * {@link Mat4#mul2}.
+     *
+     * @param {Mat4} lhs - The affine transformation 4x4 matrix used as the first multiplicand of
+     * the operation.
+     * @param {Mat4} rhs - The affine transformation 4x4 matrix used as the second multiplicand of
+     * the operation.
      * @returns {Mat4} Self for chaining.
      */
     mulAffine2(lhs, rhs) {
@@ -355,9 +356,8 @@ class Mat4 {
     }
 
     /**
-     * @function
-     * @name Mat4#mul
-     * @description Multiplies the current instance by the specified 4x4 matrix.
+     * Multiplies the current instance by the specified 4x4 matrix.
+     *
      * @param {Mat4} rhs - The 4x4 matrix used as the second multiplicand of the operation.
      * @returns {Mat4} Self for chaining.
      * @example
@@ -374,9 +374,8 @@ class Mat4 {
     }
 
     /**
-     * @function
-     * @name Mat4#transformPoint
-     * @description Transforms a 3-dimensional point by a 4x4 matrix.
+     * Transforms a 3-dimensional point by a 4x4 matrix.
+     *
      * @param {Vec3} vec - The 3-dimensional point to be transformed.
      * @param {Vec3} [res] - An optional 3-dimensional point to receive the result of the transformation.
      * @returns {Vec3} The input point v transformed by the current instance.
@@ -404,9 +403,8 @@ class Mat4 {
     }
 
     /**
-     * @function
-     * @name Mat4#transformVector
-     * @description Transforms a 3-dimensional vector by a 4x4 matrix.
+     * Transforms a 3-dimensional vector by a 4x4 matrix.
+     *
      * @param {Vec3} vec - The 3-dimensional vector to be transformed.
      * @param {Vec3} [res] - An optional 3-dimensional vector to receive the result of the transformation.
      * @returns {Vec3} The input vector v transformed by the current instance.
@@ -434,9 +432,8 @@ class Mat4 {
     }
 
     /**
-     * @function
-     * @name Mat4#transformVec4
-     * @description Transforms a 4-dimensional vector by a 4x4 matrix.
+     * Transforms a 4-dimensional vector by a 4x4 matrix.
+     *
      * @param {Vec4} vec - The 4-dimensional vector to be transformed.
      * @param {Vec4} [res] - An optional 4-dimensional vector to receive the result of the transformation.
      * @returns {Vec4} The input vector v transformed by the current instance.
@@ -469,14 +466,14 @@ class Mat4 {
     }
 
     /**
-     * @function
-     * @name Mat4#setLookAt
-     * @description Sets the specified matrix to a viewing matrix derived from an eye point, a target point
-     * and an up vector. The matrix maps the target point to the negative z-axis and the eye point to the
-     * origin, so that when you use a typical projection matrix, the center of the scene maps to the center
-     * of the viewport. Similarly, the direction described by the up vector projected onto the viewing plane
-     * is mapped to the positive y-axis so that it points upward in the viewport. The up vector must not be
-     * parallel to the line of sight from the eye to the reference point.
+     * Sets the specified matrix to a viewing matrix derived from an eye point, a target point and
+     * an up vector. The matrix maps the target point to the negative z-axis and the eye point to
+     * the origin, so that when you use a typical projection matrix, the center of the scene maps
+     * to the center of the viewport. Similarly, the direction described by the up vector projected
+     * onto the viewing plane is mapped to the positive y-axis so that it points upward in the
+     * viewport. The up vector must not be parallel to the line of sight from the eye to the
+     * reference point.
+     *
      * @param {Vec3} position - 3-d vector holding view position.
      * @param {Vec3} target - 3-d vector holding reference point.
      * @param {Vec3} up - 3-d vector holding the up direction.
@@ -516,21 +513,24 @@ class Mat4 {
     }
 
     /**
-     * @private
-     * @function
-     * @name Mat4#setFrustum
-     * @description Sets the specified matrix to a perspective projection matrix. The function's parameters define
-     * the shape of a frustum.
-     * @param {number} left - The x-coordinate for the left edge of the camera's projection plane in eye space.
-     * @param {number} right - The x-coordinate for the right edge of the camera's projection plane in eye space.
-     * @param {number} bottom - The y-coordinate for the bottom edge of the camera's projection plane in eye space.
-     * @param {number} top - The y-coordinate for the top edge of the camera's projection plane in eye space.
+     * Sets the specified matrix to a perspective projection matrix. The function's parameters
+     * define the shape of a frustum.
+     *
+     * @param {number} left - The x-coordinate for the left edge of the camera's projection plane
+     * in eye space.
+     * @param {number} right - The x-coordinate for the right edge of the camera's projection plane
+     * in eye space.
+     * @param {number} bottom - The y-coordinate for the bottom edge of the camera's projection
+     * plane in eye space.
+     * @param {number} top - The y-coordinate for the top edge of the camera's projection plane in
+     * eye space.
      * @param {number} znear - The near clip plane in eye coordinates.
      * @param {number} zfar - The far clip plane in eye coordinates.
      * @returns {Mat4} Self for chaining.
      * @example
      * // Create a 4x4 perspective projection matrix
      * var f = pc.Mat4().setFrustum(-2, 2, -1, 1, 1, 1000);
+     * @private
      */
     setFrustum(left, right, bottom, top, znear, zfar) {
         const temp1 = 2 * znear;
@@ -560,18 +560,17 @@ class Mat4 {
     }
 
     /**
-     * @function
-     * @name Mat4#setPerspective
-     * @description Sets the specified matrix to a perspective projection matrix. The function's
-     * parameters define the shape of a frustum.
+     * Sets the specified matrix to a perspective projection matrix. The function's parameters
+     * define the shape of a frustum.
+     *
      * @param {number} fov - The frustum's field of view in degrees. The fovIsHorizontal parameter
      * controls whether this is a vertical or horizontal field of view. By default, it's a vertical
      * field of view.
      * @param {number} aspect - The aspect ratio of the frustum's projection plane (width / height).
      * @param {number} znear - The near clip plane in eye coordinates.
      * @param {number} zfar - The far clip plane in eye coordinates.
-     * @param {boolean} [fovIsHorizontal=false] - Set to true to treat the fov as horizontal (x-axis)
-     * and false for vertical (y-axis). Defaults to false.
+     * @param {boolean} [fovIsHorizontal=false] - Set to true to treat the fov as horizontal
+     * (x-axis) and false for vertical (y-axis). Defaults to false.
      * @returns {Mat4} Self for chaining.
      * @example
      * // Create a 4x4 perspective projection matrix
@@ -583,14 +582,17 @@ class Mat4 {
     }
 
     /**
-     * @function
-     * @name Mat4#setOrtho
-     * @description Sets the specified matrix to an orthographic projection matrix. The function's parameters
+     * Sets the specified matrix to an orthographic projection matrix. The function's parameters
      * define the shape of a cuboid-shaped frustum.
-     * @param {number} left - The x-coordinate for the left edge of the camera's projection plane in eye space.
-     * @param {number} right - The x-coordinate for the right edge of the camera's projection plane in eye space.
-     * @param {number} bottom - The y-coordinate for the bottom edge of the camera's projection plane in eye space.
-     * @param {number} top - The y-coordinate for the top edge of the camera's projection plane in eye space.
+     *
+     * @param {number} left - The x-coordinate for the left edge of the camera's projection plane
+     * in eye space.
+     * @param {number} right - The x-coordinate for the right edge of the camera's projection plane
+     * in eye space.
+     * @param {number} bottom - The y-coordinate for the bottom edge of the camera's projection
+     * plane in eye space.
+     * @param {number} top - The y-coordinate for the top edge of the camera's projection plane in
+     * eye space.
      * @param {number} near - The near clip plane in eye coordinates.
      * @param {number} far - The far clip plane in eye coordinates.
      * @returns {Mat4} Self for chaining.
@@ -622,10 +624,9 @@ class Mat4 {
     }
 
     /**
-     * @function
-     * @name Mat4#setFromAxisAngle
-     * @description Sets the specified matrix to a rotation matrix equivalent to a rotation around
-     * an axis. The axis must be normalized (unit length) and the angle must be specified in degrees.
+     * Sets the specified matrix to a rotation matrix equivalent to a rotation around an axis. The
+     * axis must be normalized (unit length) and the angle must be specified in degrees.
+     *
      * @param {Vec3} axis - The normalized axis vector around which to rotate.
      * @param {number} angle - The angle of rotation in degrees.
      * @returns {Mat4} Self for chaining.
@@ -667,10 +668,8 @@ class Mat4 {
     }
 
     /**
-     * @private
-     * @function
-     * @name Mat4#setTranslate
-     * @description Sets the specified matrix to a translation matrix.
+     * Sets the specified matrix to a translation matrix.
+     *
      * @param {number} x - The x-component of the translation.
      * @param {number} y - The y-component of the translation.
      * @param {number} z - The z-component of the translation.
@@ -678,6 +677,7 @@ class Mat4 {
      * @example
      * // Create a 4x4 translation matrix
      * var tm = new pc.Mat4().setTranslate(10, 10, 10);
+     * @private
      */
     setTranslate(x, y, z) {
         const m = this.data;
@@ -703,10 +703,8 @@ class Mat4 {
     }
 
     /**
-     * @private
-     * @function
-     * @name Mat4#setScale
-     * @description Sets the specified matrix to a scale matrix.
+     * Sets the specified matrix to a scale matrix.
+     *
      * @param {number} x - The x-component of the scale.
      * @param {number} y - The y-component of the scale.
      * @param {number} z - The z-component of the scale.
@@ -714,6 +712,7 @@ class Mat4 {
      * @example
      * // Create a 4x4 scale matrix
      * var sm = new pc.Mat4().setScale(10, 10, 10);
+     * @private
      */
     setScale(x, y, z) {
         const m = this.data;
@@ -739,12 +738,10 @@ class Mat4 {
     }
 
     /**
-     * @private
-     * @function
-     * @name Mat4#setViewport
-     * @description Sets the specified matrix to a matrix transforming a normalized view volume (in range of -1 .. 1)
-     * to their position inside a viewport (in range of 0 .. 1). This encapsulates a scaling to the size of the viewport
-     * and a translation to the position of the viewport.
+     * Sets the specified matrix to a matrix transforming a normalized view volume (in range of
+     * -1 .. 1) to their position inside a viewport (in range of 0 .. 1). This encapsulates a
+     * scaling to the size of the viewport and a translation to the position of the viewport.
+     *
      * @param {number} x - The x-component of the position of the viewport (in 0..1 range).
      * @param {number} y - The y-component of the position of the viewport (in 0..1 range).
      * @param {number} width - The width of the viewport (in 0..1 range).
@@ -753,6 +750,7 @@ class Mat4 {
      * @example
      * // Create a 4x4 viewport matrix which scales normalized view volume to full texture viewport.
      * var vm = new pc.Mat4().setViewport(0, 0, 1, 1);
+     * @private
      */
     setViewport(x, y, width, height) {
         const m = this.data;
@@ -778,9 +776,8 @@ class Mat4 {
     }
 
     /**
-     * @function
-     * @name Mat4#invert
-     * @description Sets the specified matrix to its inverse.
+     * Sets the specified matrix to its inverse.
+     *
      * @returns {Mat4} Self for chaining.
      * @example
      * // Create a 4x4 rotation matrix of 180 degrees around the y-axis
@@ -850,9 +847,8 @@ class Mat4 {
     }
 
     /**
-     * @function
-     * @name Mat4#set
-     * @description Sets matrix data from an array.
+     * Sets matrix data from an array.
+     *
      * @param {number[]} src - Source array. Must have 16 values.
      * @returns {Mat4} Self for chaining.
      */
@@ -880,9 +876,8 @@ class Mat4 {
     }
 
     /**
-     * @function
-     * @name Mat4#setIdentity
-     * @description Sets the specified matrix to the identity matrix.
+     * Sets the specified matrix to the identity matrix.
+     *
      * @returns {Mat4} Self for chaining.
      * @example
      * m.setIdentity();
@@ -912,10 +907,9 @@ class Mat4 {
     }
 
     /**
-     * @function
-     * @name Mat4#setTRS
-     * @description Sets the specified matrix to the concatenation of a translation, a
-     * quaternion rotation and a scale.
+     * Sets the specified matrix to the concatenation of a translation, a quaternion rotation and a
+     * scale.
+     *
      * @param {Vec3} t - A 3-d vector translation.
      * @param {Quat} r - A quaternion rotation.
      * @param {Vec3} s - A 3-d vector scale.
@@ -977,9 +971,8 @@ class Mat4 {
     }
 
     /**
-     * @function
-     * @name Mat4#transpose
-     * @description Sets the specified matrix to its transpose.
+     * Sets the specified matrix to its transpose.
+     *
      * @returns {Mat4} Self for chaining.
      * @example
      * var m = new pc.Mat4();
@@ -1065,9 +1058,8 @@ class Mat4 {
     }
 
     /**
-     * @function
-     * @name Mat4#getTranslation
-     * @description Extracts the translational component from the specified 4x4 matrix.
+     * Extracts the translational component from the specified 4x4 matrix.
+     *
      * @param {Vec3} [t] - The vector to receive the translation of the matrix.
      * @returns {Vec3} The translation of the specified 4x4 matrix.
      * @example
@@ -1083,9 +1075,8 @@ class Mat4 {
     }
 
     /**
-     * @function
-     * @name Mat4#getX
-     * @description Extracts the x-axis from the specified 4x4 matrix.
+     * Extracts the x-axis from the specified 4x4 matrix.
+     *
      * @param {Vec3} [x] - The vector to receive the x axis of the matrix.
      * @returns {Vec3} The x-axis of the specified 4x4 matrix.
      * @example
@@ -1101,9 +1092,8 @@ class Mat4 {
     }
 
     /**
-     * @function
-     * @name Mat4#getY
-     * @description Extracts the y-axis from the specified 4x4 matrix.
+     * Extracts the y-axis from the specified 4x4 matrix.
+     *
      * @param {Vec3} [y] - The vector to receive the y axis of the matrix.
      * @returns {Vec3} The y-axis of the specified 4x4 matrix.
      * @example
@@ -1119,9 +1109,8 @@ class Mat4 {
     }
 
     /**
-     * @function
-     * @name Mat4#getZ
-     * @description Extracts the z-axis from the specified 4x4 matrix.
+     * Extracts the z-axis from the specified 4x4 matrix.
+     *
      * @param {Vec3} [z] - The vector to receive the z axis of the matrix.
      * @returns {Vec3} The z-axis of the specified 4x4 matrix.
      * @example
@@ -1137,9 +1126,8 @@ class Mat4 {
     }
 
     /**
-     * @function
-     * @name Mat4#getScale
-     * @description Extracts the scale component from the specified 4x4 matrix.
+     * Extracts the scale component from the specified 4x4 matrix.
+     *
      * @param {Vec3} [scale] - Vector to receive the scale.
      * @returns {Vec3} The scale in X, Y and Z of the specified 4x4 matrix.
      * @example
@@ -1156,10 +1144,9 @@ class Mat4 {
     }
 
     /**
-     * @function
-     * @name Mat4#setFromEulerAngles
-     * @description Sets the specified matrix to a rotation matrix defined by
-     * Euler angles. The Euler angles are specified in XYZ order and in degrees.
+     * Sets the specified matrix to a rotation matrix defined by Euler angles. The Euler angles are
+     * specified in XYZ order and in degrees.
+     *
      * @param {number} ex - Angle to rotate around X axis in degrees.
      * @param {number} ey - Angle to rotate around Y axis in degrees.
      * @param {number} ez - Angle to rotate around Z axis in degrees.
@@ -1168,10 +1155,10 @@ class Mat4 {
      * var m = new pc.Mat4();
      * m.setFromEulerAngles(45, 90, 180);
      */
-    // http://en.wikipedia.org/wiki/Rotation_matrix#Conversion_from_and_to_axis-angle
-    // The 3D space is right-handed, so the rotation around each axis will be counterclockwise
-    // for an observer placed so that the axis goes in his or her direction (Right-hand rule).
     setFromEulerAngles(ex, ey, ez) {
+        // http://en.wikipedia.org/wiki/Rotation_matrix#Conversion_from_and_to_axis-angle
+        // The 3D space is right-handed, so the rotation around each axis will be counterclockwise
+        // for an observer placed so that the axis goes in his or her direction (Right-hand rule).
         ex *= math.DEG_TO_RAD;
         ey *= math.DEG_TO_RAD;
         ez *= math.DEG_TO_RAD;
@@ -1211,10 +1198,9 @@ class Mat4 {
     }
 
     /**
-     * @function
-     * @name Mat4#getEulerAngles
-     * @description Extracts the Euler angles equivalent to the rotational portion
-     * of the specified matrix. The returned Euler angles are in XYZ order an in degrees.
+     * Extracts the Euler angles equivalent to the rotational portion of the specified matrix. The
+     * returned Euler angles are in XYZ order an in degrees.
+     *
      * @param {Vec3} [eulers] - A 3-d vector to receive the Euler angles.
      * @returns {Vec3} A 3-d vector containing the Euler angles.
      * @example
@@ -1258,9 +1244,8 @@ class Mat4 {
     }
 
     /**
-     * @function
-     * @name Mat4#toString
-     * @description Converts the specified matrix to string form.
+     * Converts the specified matrix to string form.
+     *
      * @returns {string} The matrix in string form.
      * @example
      * var m = new pc.Mat4();
@@ -1278,22 +1263,20 @@ class Mat4 {
     }
 
     /**
-     * @field
-     * @static
-     * @readonly
+     * A constant matrix set to the identity.
+     *
      * @name Mat4.IDENTITY
-     * @type {Mat4}
-     * @description A constant matrix set to the identity.
+     * @type {Readonly<Mat4>}
+     * @readonly
      */
     static IDENTITY = Object.freeze(new Mat4());
 
     /**
-     * @field
-     * @static
-     * @readonly
+     * A constant matrix with all elements set to 0.
+     *
      * @name Mat4.ZERO
-     * @type {Mat4}
-     * @description A constant matrix with all elements set to 0.
+     * @type {Readonly<Mat4>}
+     * @readonly
      */
     static ZERO = Object.freeze(new Mat4().set([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]));
 }

--- a/src/math/math.js
+++ b/src/math/math.js
@@ -36,7 +36,7 @@ const math = {
      * @returns {boolean} true if between or false otherwise.
      * @private
      */
-     between: function (num, a, b, inclusive) {
+    between: function (num, a, b, inclusive) {
         const min = Math.min(a, b);
         const max = Math.max(a, b);
         return inclusive ? num >= min && num <= max : num > min && num < max;
@@ -184,7 +184,7 @@ const math = {
      * @param {number} val - The value for which to calculate the next power of 2.
      * @returns {number} The next power of 2.
      */
-     nextPowerOfTwo: function (val) {
+    nextPowerOfTwo: function (val) {
         val--;
         val |= (val >> 1);
         val |= (val >> 2);
@@ -230,7 +230,7 @@ const math = {
             return numToRound;
         return Math.ceil(numToRound / multiple) * multiple;
     },
-    
+
     /**
      * The function interpolates smoothly between two input values based on a third one that should
      * be between the first two. The returned value is clamped between 0 and 1.

--- a/src/math/math.js
+++ b/src/math/math.js
@@ -1,14 +1,14 @@
 /**
- * @name math
+ * Math API.
+ *
  * @namespace
- * @description Math API.
  */
 const math = {
     /**
-     * @constant
+     * Conversion factor between degrees and radians.
+     *
      * @type {number}
-     * @name math.DEG_TO_RAD
-     * @description Conversion factor between degrees and radians.
+     * @constant
      * @example
      * // Convert 180 degrees to pi radians
      * var rad = 180 * pc.math.DEG_TO_RAD;
@@ -16,10 +16,10 @@ const math = {
     DEG_TO_RAD: Math.PI / 180,
 
     /**
-     * @constant
+     * Conversion factor between degrees and radians.
+     *
      * @type {number}
-     * @name math.RAD_TO_DEG
-     * @description Conversion factor between degrees and radians.
+     * @constant
      * @example
      * // Convert pi radians to 180 degrees
      * var deg = Math.PI * pc.math.RAD_TO_DEG;
@@ -27,9 +27,24 @@ const math = {
     RAD_TO_DEG: 180 / Math.PI,
 
     /**
-     * @function
-     * @name math.clamp
-     * @description Clamp a number between min and max inclusive.
+     * Checks whether a given number resides between two other given numbers.
+     *
+     * @param {number} num - The number to check the position of.
+     * @param {number} a - The first upper or lower threshold to check between.
+     * @param {number} b - The second upper or lower threshold to check between.
+     * @param {boolean} inclusive - If true, a num param which is equal to a or b will return true.
+     * @returns {boolean} true if between or false otherwise.
+     * @private
+     */
+     between: function (num, a, b, inclusive) {
+        const min = Math.min(a, b);
+        const max = Math.max(a, b);
+        return inclusive ? num >= min && num <= max : num > min && num < max;
+    },
+
+    /**
+     * Clamp a number between min and max inclusive.
+     *
      * @param {number} value - Number to clamp.
      * @param {number} min - Min value.
      * @param {number} max - Max value.
@@ -42,9 +57,8 @@ const math = {
     },
 
     /**
-     * @function
-     * @name math.intToBytes24
-     * @description Convert an 24 bit integer into an array of 3 bytes.
+     * Convert an 24 bit integer into an array of 3 bytes.
+     *
      * @param {number} i - Number holding an integer value.
      * @returns {number[]} An array of 3 bytes.
      * @example
@@ -60,11 +74,10 @@ const math = {
     },
 
     /**
-     * @function
-     * @name math.intToBytes32
-     * @description Convert an 32 bit integer into an array of 4 bytes.
-     * @returns {number[]} An array of 4 bytes.
+     * Convert an 32 bit integer into an array of 4 bytes.
+     *
      * @param {number} i - Number holding an integer value.
+     * @returns {number[]} An array of 4 bytes.
      * @example
      * // Set bytes to [0x11, 0x22, 0x33, 0x44]
      * var bytes = pc.math.intToBytes32(0x11223344);
@@ -79,19 +92,18 @@ const math = {
     },
 
     /**
-     * @function
-     * @name math.bytesToInt24
-     * @description Convert 3 8 bit Numbers into a single unsigned 24 bit Number.
+     * Convert 3 8 bit Numbers into a single unsigned 24 bit Number.
+     *
+     * @param {number} r - A single byte (0-255).
+     * @param {number} g - A single byte (0-255).
+     * @param {number} b - A single byte (0-255).
+     * @returns {number} A single unsigned 24 bit Number.
      * @example
      * // Set result1 to 0x112233 from an array of 3 values
      * var result1 = pc.math.bytesToInt24([0x11, 0x22, 0x33]);
      *
      * // Set result2 to 0x112233 from 3 discrete values
      * var result2 = pc.math.bytesToInt24(0x11, 0x22, 0x33);
-     * @param {number} r - A single byte (0-255).
-     * @param {number} g - A single byte (0-255).
-     * @param {number} b - A single byte (0-255).
-     * @returns {number} A single unsigned 24 bit Number.
      */
     bytesToInt24: function (r, g, b) {
         if (r.length) {
@@ -103,9 +115,12 @@ const math = {
     },
 
     /**
-     * @function
-     * @name math.bytesToInt32
-     * @description Convert 4 1-byte Numbers into a single unsigned 32bit Number.
+     * Convert 4 1-byte Numbers into a single unsigned 32bit Number.
+     *
+     * @param {number} r - A single byte (0-255).
+     * @param {number} g - A single byte (0-255).
+     * @param {number} b - A single byte (0-255).
+     * @param {number} a - A single byte (0-255).
      * @returns {number} A single unsigned 32bit Number.
      * @example
      * // Set result1 to 0x11223344 from an array of 4 values
@@ -113,10 +128,6 @@ const math = {
      *
      * // Set result2 to 0x11223344 from 4 discrete values
      * var result2 = pc.math.bytesToInt32(0x11, 0x22, 0x33, 0x44);
-     * @param {number} r - A single byte (0-255).
-     * @param {number} g - A single byte (0-255).
-     * @param {number} b - A single byte (0-255).
-     * @param {number} a - A single byte (0-255).
      */
     bytesToInt32: function (r, g, b, a) {
         if (r.length) {
@@ -133,31 +144,29 @@ const math = {
     },
 
     /**
-     * @function
-     * @name math.lerp
-     * @returns {number} The linear interpolation of two numbers.
-     * @description Calculates the linear interpolation of two numbers.
+     * Calculates the linear interpolation of two numbers.
+     *
      * @param {number} a - Number to linearly interpolate from.
      * @param {number} b - Number to linearly interpolate to.
      * @param {number} alpha - The value controlling the result of interpolation. When alpha is 0,
-     * a is returned. When alpha is 1, b is returned. Between 0 and 1, a linear interpolation between
-     * a and b is returned. alpha is clamped between 0 and 1.
+     * a is returned. When alpha is 1, b is returned. Between 0 and 1, a linear interpolation
+     * between a and b is returned. alpha is clamped between 0 and 1.
+     * @returns {number} The linear interpolation of two numbers.
      */
     lerp: function (a, b, alpha) {
         return a + (b - a) * math.clamp(alpha, 0, 1);
     },
 
     /**
-     * @function
-     * @name math.lerpAngle
-     * @description Calculates the linear interpolation of two angles ensuring that interpolation
-     * is correctly performed across the 360 to 0 degree boundary. Angles are supplied in degrees.
-     * @returns {number} The linear interpolation of two angles.
+     * Calculates the linear interpolation of two angles ensuring that interpolation is correctly
+     * performed across the 360 to 0 degree boundary. Angles are supplied in degrees.
+     *
      * @param {number} a - Angle (in degrees) to linearly interpolate from.
      * @param {number} b - Angle (in degrees) to linearly interpolate to.
      * @param {number} alpha - The value controlling the result of interpolation. When alpha is 0,
-     * a is returned. When alpha is 1, b is returned. Between 0 and 1, a linear interpolation between
-     * a and b is returned. alpha is clamped between 0 and 1.
+     * a is returned. When alpha is 1, b is returned. Between 0 and 1, a linear interpolation
+     * between a and b is returned. alpha is clamped between 0 and 1.
+     * @returns {number} The linear interpolation of two angles.
      */
     lerpAngle: function (a, b, alpha) {
         if (b - a > 180) {
@@ -170,24 +179,12 @@ const math = {
     },
 
     /**
-     * @function
-     * @name math.powerOfTwo
-     * @description Returns true if argument is a power-of-two and false otherwise.
-     * @param {number} x - Number to check for power-of-two property.
-     * @returns {boolean} true if power-of-two and false otherwise.
-     */
-    powerOfTwo: function (x) {
-        return ((x !== 0) && !(x & (x - 1)));
-    },
-
-    /**
-     * @function
-     * @name math.nextPowerOfTwo
-     * @description Returns the next power of 2 for the specified value.
+     * Returns the next power of 2 for the specified value.
+     *
      * @param {number} val - The value for which to calculate the next power of 2.
      * @returns {number} The next power of 2.
      */
-    nextPowerOfTwo: function (val) {
+     nextPowerOfTwo: function (val) {
         val--;
         val |= (val >> 1);
         val |= (val >> 2);
@@ -199,10 +196,19 @@ const math = {
     },
 
     /**
-     * @function
-     * @name math.random
-     * @description Return a pseudo-random number between min and max.
-     * The number generated is in the range [min, max), that is inclusive of the minimum but exclusive of the maximum.
+     * Returns true if argument is a power-of-two and false otherwise.
+     *
+     * @param {number} x - Number to check for power-of-two property.
+     * @returns {boolean} true if power-of-two and false otherwise.
+     */
+    powerOfTwo: function (x) {
+        return ((x !== 0) && !(x & (x - 1)));
+    },
+
+    /**
+     * Return a pseudo-random number between min and max. The number generated is in the range
+     * [min, max), that is inclusive of the minimum but exclusive of the maximum.
+     *
      * @param {number} min - Lower bound for range.
      * @param {number} max - Upper bound for range.
      * @returns {number} Pseudo-random number between the supplied range.
@@ -213,15 +219,26 @@ const math = {
     },
 
     /**
-     * @function
-     * @name math.smoothstep
-     * @description The function interpolates smoothly between two input values based on
-     * a third one that should be between the first two. The returned value is clamped
-     * between 0 and 1.
+     * Rounds a number up to nearest multiple.
+     *
+     * @param {number} numToRound - The number to round up.
+     * @param {number} multiple - The multiple to round up to.
+     * @returns {number} A number rounded up to nearest multiple.
+     */
+    roundUp: function (numToRound, multiple) {
+        if (multiple === 0)
+            return numToRound;
+        return Math.ceil(numToRound / multiple) * multiple;
+    },
+    
+    /**
+     * The function interpolates smoothly between two input values based on a third one that should
+     * be between the first two. The returned value is clamped between 0 and 1.
      * <br/>The slope (i.e. derivative) of the smoothstep function starts at 0 and ends at 0.
      * This makes it easy to create a sequence of transitions using smoothstep to interpolate
      * each segment rather than using a more sophisticated or expensive interpolation technique.
      * <br/>See http://en.wikipedia.org/wiki/Smoothstep for more details.
+     *
      * @param {number} min - The lower bound of the interpolation range.
      * @param {number} max - The upper bound of the interpolation range.
      * @param {number} x - The value to interpolate.
@@ -237,11 +254,10 @@ const math = {
     },
 
     /**
-     * @function
-     * @name math.smootherstep
-     * @description An improved version of the {@link math.smoothstep} function which has zero
-     * 1st and 2nd order derivatives at t=0 and t=1.
+     * An improved version of the {@link math.smoothstep} function which has zero 1st and 2nd order
+     * derivatives at t=0 and t=1.
      * <br/>See http://en.wikipedia.org/wiki/Smoothstep for more details.
+     *
      * @param {number} min - The lower bound of the interpolation range.
      * @param {number} max - The upper bound of the interpolation range.
      * @param {number} x - The value to interpolate.
@@ -254,37 +270,6 @@ const math = {
         x = (x - min) / (max - min);
 
         return x * x * x * (x * (x * 6 - 15) + 10);
-    },
-
-    /**
-     * @function
-     * @name math.roundUp
-     * @description Rounds a number up to nearest multiple.
-     * @param {number} numToRound - The number to round up.
-     * @param {number} multiple - The multiple to round up to.
-     * @returns {number} A number rounded up to nearest multiple.
-     */
-    roundUp: function (numToRound, multiple) {
-        if (multiple === 0)
-            return numToRound;
-        return Math.ceil(numToRound / multiple) * multiple;
-    },
-
-    /**
-     * @function
-     * @private
-     * @name math.between
-     * @description Checks whether a given number resides between two other given numbers.
-     * @param {number} num - The number to check the position of.
-     * @param {number} a - The first upper or lower threshold to check between.
-     * @param {number} b - The second upper or lower threshold to check between.
-     * @param {boolean} inclusive - If true, a num param which is equal to a or b will return true.
-     * @returns {boolean} true if between or false otherwise.
-     */
-    between: function (num, a, b, inclusive) {
-        const min = Math.min(a, b);
-        const max = Math.max(a, b);
-        return inclusive ? num >= min && num <= max : num > min && num < max;
     }
 };
 

--- a/src/math/quat.js
+++ b/src/math/quat.js
@@ -2,72 +2,80 @@ import { math } from './math.js';
 import { Vec3 } from './vec3.js';
 
 /**
- * @class
- * @name Quat
- * @classdesc A quaternion.
- * @description Create a new Quat object.
- * @param {number|number[]} [x] - The quaternion's x component. Default value 0. If x is an array of length 4, the array will be used to populate all components.
- * @param {number} [y] - The quaternion's y component. Default value 0.
- * @param {number} [z] - The quaternion's z component. Default value 0.
- * @param {number} [w] - The quaternion's w component. Default value 1.
- */
-/**
- * @field
- * @name Quat#x
- * @type {number}
- * @description The x component of the quaternion.
- * @example
- * var quat = new pc.Quat();
- *
- * // Get x
- * var x = quat.x;
- *
- * // Set x
- * quat.x = 0;
- */
-/**
- * @field
- * @name Quat#y
- * @type {number}
- * @description The y component of the quaternion.
- * @example
- * var quat = new pc.Quat();
- *
- * // Get y
- * var y = quat.y;
- *
- * // Set y
- * quat.y = 0;
- */
-/**
- * @field
- * @name Quat#z
- * @type {number}
- * @description The z component of the quaternion.
- * @example
- * var quat = new pc.Quat();
- *
- * // Get z
- * var z = quat.z;
- *
- * // Set z
- * quat.z = 0;
- */
-/**
- * @field
- * @name Quat#w
- * @type {number}
- * @description The w component of the quaternion.
- * @example
- * var quat = new pc.Quat();
- *
- * // Get w
- * var w = quat.w;
- *
- * // Set w
- * quat.w = 0;
+ * Quaternions are used to represent rotations. Quaternions consist of 4 values: x, y, z, and w,
+ * where w is the real part and x, y, and z are the imaginary parts. Typically, you will rarely
+ * manipulate a quaternion's properties directly, but instead use the methods on the Quat class.
  */
 class Quat {
+    /**
+     * The x component of the quaternion.
+     *
+     * @type {number}
+     * @example
+     * var quat = new pc.Quat();
+     *
+     * // Get x
+     * var x = quat.x;
+     *
+     * // Set x
+     * quat.x = 0;
+     */
+    x;
+
+    /**
+     * The y component of the quaternion.
+     *
+     * @type {number}
+     * @example
+     * var quat = new pc.Quat();
+     *
+     * // Get y
+     * var y = quat.y;
+     *
+     * // Set y
+     * quat.y = 0;
+     */
+    y;
+
+    /**
+     * The z component of the quaternion.
+     *
+     * @type {number}
+     * @example
+     * var quat = new pc.Quat();
+     *
+     * // Get z
+     * var z = quat.z;
+     *
+     * // Set z
+     * quat.z = 0;
+     */
+    z;
+
+    /**
+     * The w component of the quaternion.
+     *
+     * @type {number}
+     * @example
+     * var quat = new pc.Quat();
+     *
+     * // Get w
+     * var w = quat.w;
+     *
+     * // Set w
+     * quat.w = 0;
+     */
+    w;
+
+    /**
+     * Creates a new Quat object. If no arguments are supplied, the identity quaternion is created.
+     *
+     * @param {number|number[]} [x] - The quaternion's x component. Default value 0. If x is an
+     * array of length 4, the array will be used to populate all components.
+     * @param {number} [y] - The quaternion's y component. Default value 0.
+     * @param {number} [z] - The quaternion's z component. Default value 0.
+     * @param {number} [w] - The quaternion's w component. Default value 1.
+     */
     constructor(x = 0, y = 0, z = 0, w = 1) {
         if (x.length === 4) {
             this.x = x[0];
@@ -83,9 +91,8 @@ class Quat {
     }
 
     /**
-     * @function
-     * @name Quat#clone
-     * @description Returns an identical copy of the specified quaternion.
+     * Returns an identical copy of the specified quaternion.
+     *
      * @returns {Quat} A quaternion containing the result of the cloning.
      * @example
      * var q = new pc.Quat(-0.11, -0.15, -0.46, 0.87);
@@ -106,9 +113,8 @@ class Quat {
     }
 
     /**
-     * @function
-     * @name Quat#copy
-     * @description Copies the contents of a source quaternion to a destination quaternion.
+     * Copies the contents of a source quaternion to a destination quaternion.
+     *
      * @param {Quat} rhs - The quaternion to be copied.
      * @returns {Quat} Self for chaining.
      * @example
@@ -127,9 +133,8 @@ class Quat {
     }
 
     /**
-     * @function
-     * @name Quat#equals
-     * @description Reports whether two quaternions are equal.
+     * Reports whether two quaternions are equal.
+     *
      * @param {Quat} rhs - The quaternion to be compared against.
      * @returns {boolean} True if the quaternions are equal and false otherwise.
      * @example
@@ -142,13 +147,10 @@ class Quat {
     }
 
     /**
-     * @function
-     * @name Quat#getAxisAngle
-     * @description Gets the rotation axis and angle for a given
-     *  quaternion. If a quaternion is created with
-     *  setFromAxisAngle, this method will return the same
-     *  values as provided in the original parameter list
-     *  OR functionally equivalent values.
+     * Gets the rotation axis and angle for a given quaternion. If a quaternion is created with
+     * setFromAxisAngle, this method will return the same values as provided in the original
+     * parameter list OR functionally equivalent values.
+     *
      * @param {Vec3} axis - The 3-dimensional vector to receive the axis of rotation.
      * @returns {number} Angle, in degrees, of the rotation.
      * @example
@@ -185,12 +187,11 @@ class Quat {
     }
 
     /**
-     * @function
-     * @name Quat#getEulerAngles
-     * @description Converts the supplied quaternion to Euler angles.
+     * Converts the supplied quaternion to Euler angles.
+     *
      * @param {Vec3} [eulers] - The 3-dimensional vector to receive the Euler angles.
-     * @returns {Vec3} The 3-dimensional vector holding the Euler angles that
-     * correspond to the supplied quaternion.
+     * @returns {Vec3} The 3-dimensional vector holding the Euler angles that correspond to the
+     * supplied quaternion.
      */
     getEulerAngles(eulers = new Vec3()) {
         let x, y, z;
@@ -220,9 +221,8 @@ class Quat {
     }
 
     /**
-     * @function
-     * @name Quat#invert
-     * @description Generates the inverse of the specified quaternion.
+     * Generates the inverse of the specified quaternion.
+     *
      * @returns {Quat} Self for chaining.
      * @example
      * // Create a quaternion rotated 180 degrees around the y-axis
@@ -236,9 +236,8 @@ class Quat {
     }
 
     /**
-     * @function
-     * @name Quat#length
-     * @description Returns the magnitude of the specified quaternion.
+     * Returns the magnitude of the specified quaternion.
+     *
      * @returns {number} The magnitude of the specified quaternion.
      * @example
      * var q = new pc.Quat(0, 0, 0, 5);
@@ -251,9 +250,8 @@ class Quat {
     }
 
     /**
-     * @function
-     * @name Quat#lengthSq
-     * @description Returns the magnitude squared of the specified quaternion.
+     * Returns the magnitude squared of the specified quaternion.
+     *
      * @returns {number} The magnitude of the specified quaternion.
      * @example
      * var q = new pc.Quat(3, 4, 0);
@@ -266,9 +264,8 @@ class Quat {
     }
 
     /**
-     * @function
-     * @name Quat#mul
-     * @description Returns the result of multiplying the specified quaternions together.
+     * Returns the result of multiplying the specified quaternions together.
+     *
      * @param {Quat} rhs - The quaternion used as the second multiplicand of the operation.
      * @returns {Quat} Self for chaining.
      * @example
@@ -301,9 +298,8 @@ class Quat {
     }
 
     /**
-     * @function
-     * @name Quat#mul2
-     * @description Returns the result of multiplying the specified quaternions together.
+     * Returns the result of multiplying the specified quaternions together.
+     *
      * @param {Quat} lhs - The quaternion used as the first multiplicand of the operation.
      * @param {Quat} rhs - The quaternion used as the second multiplicand of the operation.
      * @returns {Quat} Self for chaining.
@@ -338,9 +334,8 @@ class Quat {
     }
 
     /**
-     * @function
-     * @name Quat#normalize
-     * @description Returns the specified quaternion converted in place to a unit quaternion.
+     * Returns the specified quaternion converted in place to a unit quaternion.
+     *
      * @returns {Quat} The result of the normalization.
      * @example
      * var v = new pc.Quat(0, 0, 0, 5);
@@ -367,9 +362,8 @@ class Quat {
     }
 
     /**
-     * @function
-     * @name Quat#set
-     * @description Sets the specified quaternion to the supplied numerical values.
+     * Sets the specified quaternion to the supplied numerical values.
+     *
      * @param {number} x - The x component of the quaternion.
      * @param {number} y - The y component of the quaternion.
      * @param {number} z - The z component of the quaternion.
@@ -392,9 +386,8 @@ class Quat {
     }
 
     /**
-     * @function
-     * @name Quat#setFromAxisAngle
-     * @description Sets a quaternion from an angular rotation around an axis.
+     * Sets a quaternion from an angular rotation around an axis.
+     *
      * @param {Vec3} axis - World space axis around which to rotate.
      * @param {number} angle - Angle to rotate around the given axis in degrees.
      * @returns {Quat} Self for chaining.
@@ -417,9 +410,8 @@ class Quat {
     }
 
     /**
-     * @function
-     * @name Quat#setFromEulerAngles
-     * @description Sets a quaternion from Euler angles specified in XYZ order.
+     * Sets a quaternion from Euler angles specified in XYZ order.
+     *
      * @param {number} ex - Angle to rotate around X axis in degrees.
      * @param {number} ey - Angle to rotate around Y axis in degrees.
      * @param {number} ez - Angle to rotate around Z axis in degrees.
@@ -450,11 +442,9 @@ class Quat {
     }
 
     /**
-     * @function
-     * @name Quat#setFromMat4
-     * @description Converts the specified 4x4 matrix to a quaternion. Note that since
-     * a quaternion is purely a representation for orientation, only the translational part
-     * of the matrix is lost.
+     * Converts the specified 4x4 matrix to a quaternion. Note that since a quaternion is purely a
+     * representation for orientation, only the translational part of the matrix is lost.
+     *
      * @param {Mat4} m - The 4x4 matrix to convert.
      * @returns {Quat} Self for chaining.
      * @example
@@ -565,10 +555,9 @@ class Quat {
     }
 
     /**
-     * @function
-     * @name Quat#slerp
-     * @description Performs a spherical interpolation between two quaternions. The result of
-     * the interpolation is written to the quaternion calling the function.
+     * Performs a spherical interpolation between two quaternions. The result of the interpolation
+     * is written to the quaternion calling the function.
+     *
      * @param {Quat} lhs - The quaternion to interpolate from.
      * @param {Quat} rhs - The quaternion to interpolate to.
      * @param {number} alpha - The value controlling the interpolation in relation to the two input
@@ -642,11 +631,11 @@ class Quat {
     }
 
     /**
-     * @function
-     * @name Quat#transformVector
-     * @description Transforms a 3-dimensional vector by the specified quaternion.
+     * Transforms a 3-dimensional vector by the specified quaternion.
+     *
      * @param {Vec3} vec - The 3-dimensional vector to be transformed.
-     * @param {Vec3} [res] - An optional 3-dimensional vector to receive the result of the transformation.
+     * @param {Vec3} [res] - An optional 3-dimensional vector to receive the result of the
+     * transformation.
      * @returns {Vec3} The input vector v transformed by the current instance.
      * @example
      * // Create a 3-dimensional vector
@@ -676,9 +665,8 @@ class Quat {
     }
 
     /**
-     * @function
-     * @name Quat#toString
-     * @description Converts the quaternion to string form.
+     * Converts the quaternion to string form.
+     *
      * @returns {string} The quaternion in string form.
      * @example
      * var v = new pc.Quat(0, 0, 0, 1);
@@ -690,22 +678,20 @@ class Quat {
     }
 
     /**
-     * @field
-     * @static
-     * @readonly
+     * A constant quaternion set to [0, 0, 0, 1] (the identity).
+     *
      * @name Quat.IDENTITY
      * @type {Quat}
-     * @description A constant quaternion set to [0, 0, 0, 1] (the identity).
+     * @readonly
      */
     static IDENTITY = Object.freeze(new Quat(0, 0, 0, 1));
 
     /**
-     * @field
-     * @static
-     * @readonly
+     * A constant quaternion set to [0, 0, 0, 0].
+     *
      * @name Quat.ZERO
      * @type {Quat}
-     * @description A constant quaternion set to [0, 0, 0, 0].
+     * @readonly
      */
     static ZERO = Object.freeze(new Quat(0, 0, 0, 0));
 }

--- a/src/math/random.js
+++ b/src/math/random.js
@@ -4,18 +4,18 @@ import { math } from './math.js';
 const _goldenAngle = 2.399963229728653;
 
 /**
- * @name random
+ * Random API.
+ *
  * @namespace
- * @description Random API.
+ * @private
  */
 const random = {
 
     /**
-     * @function
-     * @private
-     * @name random.circlePoint
-     * @description Return a pseudo-random 2D point inside a unit circle with uniform distribution.
+     * Return a pseudo-random 2D point inside a unit circle with uniform distribution.
+     *
      * @param {Vec2} point - the returned generated point.
+     * @private
      */
     circlePoint: function (point) {
         const r = Math.sqrt(Math.random());
@@ -25,13 +25,13 @@ const random = {
     },
 
     /**
-     * @function
-     * @private
-     * @name random.circlePointDeterministic
-     * @description Generates evenly distributed deterministic points inside a unit circle using Fermat's spiral and Vogel's method.
+     * Generates evenly distributed deterministic points inside a unit circle using Fermat's spiral
+     * and Vogel's method.
+     *
      * @param {Vec2} point - the returned generated point.
-     * @param {number} index - index of the point to generate, in the range from 0 to numPoints - 1.
+     * @param {number} index - index of the point to generate in the range 0 to numPoints - 1.
      * @param {number} numPoints - the total number of points of the set.
+     * @private
      */
     circlePointDeterministic: function (point, index, numPoints) {
         const theta = index * _goldenAngle;
@@ -42,22 +42,25 @@ const random = {
     },
 
     /**
-     * @function
-     * @private
-     * @name random.spherePointDeterministic
-     * @description Generates evenly distributed deterministic points on a unit sphere using Fibonacci sphere algorithm. It also allows
-     * the points to cover only part of the sphere by specifying start and end parameters, representing value from 0 (top of the sphere) and
-     * 1 (bottom of the sphere). For example by specifying 0.4 and 0.6 and start and end, a band around the equator would be generated.
+     * Generates evenly distributed deterministic points on a unit sphere using Fibonacci sphere
+     * algorithm. It also allows the points to cover only part of the sphere by specifying start
+     * and end parameters, representing value from 0 (top of the sphere) and 1 (bottom of the
+     * sphere). For example by specifying 0.4 and 0.6 and start and end, a band around the equator
+     * would be generated.
+     *
      * @param {Vec3} point - the returned generated point.
-     * @param {number} index - index of the point to generate, in the range from 0 to numPoints - 1.
+     * @param {number} index - index of the point to generate in the range 0 to numPoints - 1.
      * @param {number} numPoints - the total number of points of the set.
-     * @param {number} [start] - Part on the sphere along y axis to start the points, in the range of 0 and 1. Defaults to 0.
-     * @param {number} [end] - Part on the sphere along y axis to stop the points, in the range of 0 and 1. Defaults to 1.
+     * @param {number} [start] - Part on the sphere along y axis to start the points, in the range
+     * of 0 and 1. Defaults to 0.
+     * @param {number} [end] - Part on the sphere along y axis to stop the points, in the range of
+     * 0 and 1. Defaults to 1.
+     * @private
      */
     spherePointDeterministic: function (point, index, numPoints, start = 0, end = 1) {
 
         // y coordinate needs to go from -1 (top) to 1 (bottom) for the full sphere
-        // evaluate its vaue for this point and specified start and end
+        // evaluate its value for this point and specified start and end
         start = 1 - 2 * start;
         end = 1 - 2 * end;
         const y = math.lerp(start, end, index / numPoints);

--- a/src/math/vec2.js
+++ b/src/math/vec2.js
@@ -1,42 +1,45 @@
 /**
- * @class
- * @name Vec2
- * @classdesc A 2-dimensional vector.
- * @description Creates a new Vec2 object.
- * @param {number|number[]} [x] - The x value. If x is an array of length 2, the array will be used to populate all components.
- * @param {number} [y] - The y value.
- * @example
- * var v = new pc.Vec2(1, 2);
- */
-/**
- * @field
- * @name Vec2#x
- * @type {number}
- * @description The first element of the vector.
- * @example
- * var vec = new pc.Vec2(10, 20);
- *
- * // Get x
- * var x = vec.x;
- *
- * // Set x
- * vec.x = 0;
- */
-/**
- * @field
- * @name Vec2#y
- * @type {number}
- * @description The second element of the vector.
- * @example
- * var vec = new pc.Vec2(10, 20);
- *
- * // Get y
- * var y = vec.y;
- *
- * // Set y
- * vec.y = 0;
+ * A 2-dimensional vector.
  */
 class Vec2 {
+    /**
+     * The first element of the vector.
+     *
+     * @type {number}
+     * @example
+     * var vec = new pc.Vec2(10, 20);
+     *
+     * // Get x
+     * var x = vec.x;
+     *
+     * // Set x
+     * vec.x = 0;
+     */
+    x;
+
+    /**
+     * The second element of the vector.
+     *
+     * @type {number}
+     * @example
+     * var vec = new pc.Vec2(10, 20);
+     *
+     * // Get y
+     * var y = vec.y;
+     *
+     * // Set y
+     * vec.y = 0;
+     */
+    y;
+
+    /**
+     * Creates a new Vec2 object.
+     *
+     * @param {number|number[]} [x] - The x value. If x is an array of length 2, the array will be used to populate all components.
+     * @param {number} [y] - The y value.
+     * @example
+     * var v = new pc.Vec2(1, 2);
+     */
     constructor(x = 0, y = 0) {
         if (x.length === 2) {
             this.x = x[0];
@@ -48,9 +51,8 @@ class Vec2 {
     }
 
     /**
-     * @function
-     * @name Vec2#add
-     * @description Adds a 2-dimensional vector to another in place.
+     * Adds a 2-dimensional vector to another in place.
+     *
      * @param {Vec2} rhs - The vector to add to the specified vector.
      * @returns {Vec2} Self for chaining.
      * @example
@@ -70,9 +72,8 @@ class Vec2 {
     }
 
     /**
-     * @function
-     * @name Vec2#add2
-     * @description Adds two 2-dimensional vectors together and returns the result.
+     * Adds two 2-dimensional vectors together and returns the result.
+     *
      * @param {Vec2} lhs - The first vector operand for the addition.
      * @param {Vec2} rhs - The second vector operand for the addition.
      * @returns {Vec2} Self for chaining.
@@ -94,9 +95,8 @@ class Vec2 {
     }
 
     /**
-     * @function
-     * @name Vec2#addScalar
-     * @description Adds a number to each element of a vector.
+     * Adds a number to each element of a vector.
+     *
      * @param {number} scalar - The number to add.
      * @returns {Vec2} Self for chaining.
      * @example
@@ -115,9 +115,8 @@ class Vec2 {
     }
 
     /**
-     * @function
-     * @name Vec2#clone
-     * @description Returns an identical copy of the specified 2-dimensional vector.
+     * Returns an identical copy of the specified 2-dimensional vector.
+     *
      * @returns {Vec2} A 2-dimensional vector containing the result of the cloning.
      * @example
      * var v = new pc.Vec2(10, 20);
@@ -129,9 +128,8 @@ class Vec2 {
     }
 
     /**
-     * @function
-     * @name Vec2#copy
-     * @description Copies the contents of a source 2-dimensional vector to a destination 2-dimensional vector.
+     * Copies the contents of a source 2-dimensional vector to a destination 2-dimensional vector.
+     *
      * @param {Vec2} rhs - A vector to copy to the specified vector.
      * @returns {Vec2} Self for chaining.
      * @example
@@ -150,9 +148,9 @@ class Vec2 {
     }
 
     /**
-     * @function
-     * @name Vec2#cross
-     * @description Returns the result of a cross product operation performed on the two specified 2-dimensional vectors.
+     * Returns the result of a cross product operation performed on the two specified 2-dimensional
+     * vectors.
+     *
      * @param {Vec2} rhs - The second 2-dimensional vector operand of the cross product.
      * @returns {number} The cross product of the two vectors.
      * @example
@@ -168,9 +166,8 @@ class Vec2 {
     }
 
     /**
-     * @function
-     * @name Vec2#distance
-     * @description Returns the distance between the two specified 2-dimensional vectors.
+     * Returns the distance between the two specified 2-dimensional vectors.
+     *
      * @param {Vec2} rhs - The second 2-dimensional vector to test.
      * @returns {number} The distance between the two vectors.
      * @example
@@ -186,9 +183,8 @@ class Vec2 {
     }
 
     /**
-     * @function
-     * @name Vec2#div
-     * @description Divides a 2-dimensional vector by another in place.
+     * Divides a 2-dimensional vector by another in place.
+     *
      * @param {Vec2} rhs - The vector to divide the specified vector by.
      * @returns {Vec2} Self for chaining.
      * @example
@@ -208,10 +204,8 @@ class Vec2 {
     }
 
     /**
-     * @function
-     * @name Vec2#div2
-     * @description Divides one 2-dimensional vector by another and writes the result to
-     * the specified vector.
+     * Divides one 2-dimensional vector by another and writes the result to the specified vector.
+     *
      * @param {Vec2} lhs - The dividend vector (the vector being divided).
      * @param {Vec2} rhs - The divisor vector (the vector dividing the dividend).
      * @returns {Vec2} Self for chaining.
@@ -233,9 +227,8 @@ class Vec2 {
     }
 
     /**
-     * @function
-     * @name Vec2#divScalar
-     * @description Divides each element of a vector by a number.
+     * Divides each element of a vector by a number.
+     *
      * @param {number} scalar - The number to divide by.
      * @returns {Vec2} Self for chaining.
      * @example
@@ -254,9 +247,9 @@ class Vec2 {
     }
 
     /**
-     * @function
-     * @name Vec2#dot
-     * @description Returns the result of a dot product operation performed on the two specified 2-dimensional vectors.
+     * Returns the result of a dot product operation performed on the two specified 2-dimensional
+     * vectors.
+     *
      * @param {Vec2} rhs - The second 2-dimensional vector operand of the dot product.
      * @returns {number} The result of the dot product operation.
      * @example
@@ -270,9 +263,8 @@ class Vec2 {
     }
 
     /**
-     * @function
-     * @name Vec2#equals
-     * @description Reports whether two vectors are equal.
+     * Reports whether two vectors are equal.
+     *
      * @param {Vec2} rhs - The vector to compare to the specified vector.
      * @returns {boolean} True if the vectors are equal and false otherwise.
      * @example
@@ -285,9 +277,8 @@ class Vec2 {
     }
 
     /**
-     * @function
-     * @name Vec2#length
-     * @description Returns the magnitude of the specified 2-dimensional vector.
+     * Returns the magnitude of the specified 2-dimensional vector.
+     *
      * @returns {number} The magnitude of the specified 2-dimensional vector.
      * @example
      * var vec = new pc.Vec2(3, 4);
@@ -300,9 +291,8 @@ class Vec2 {
     }
 
     /**
-     * @function
-     * @name Vec2#lengthSq
-     * @description Returns the magnitude squared of the specified 2-dimensional vector.
+     * Returns the magnitude squared of the specified 2-dimensional vector.
+     *
      * @returns {number} The magnitude of the specified 2-dimensional vector.
      * @example
      * var vec = new pc.Vec2(3, 4);
@@ -315,14 +305,13 @@ class Vec2 {
     }
 
     /**
-     * @function
-     * @name Vec2#lerp
-     * @description Returns the result of a linear interpolation between two specified 2-dimensional vectors.
+     * Returns the result of a linear interpolation between two specified 2-dimensional vectors.
+     *
      * @param {Vec2} lhs - The 2-dimensional to interpolate from.
      * @param {Vec2} rhs - The 2-dimensional to interpolate to.
-     * @param {number} alpha - The value controlling the point of interpolation. Between 0 and 1, the linear interpolant
-     * will occur on a straight line between lhs and rhs. Outside of this range, the linear interpolant will occur on
-     * a ray extrapolated from this line.
+     * @param {number} alpha - The value controlling the point of interpolation. Between 0 and 1,
+     * the linear interpolant will occur on a straight line between lhs and rhs. Outside of this
+     * range, the linear interpolant will occur on a ray extrapolated from this line.
      * @returns {Vec2} Self for chaining.
      * @example
      * var a = new pc.Vec2(0, 0);
@@ -341,9 +330,8 @@ class Vec2 {
     }
 
     /**
-     * @function
-     * @name Vec2#mul
-     * @description Multiplies a 2-dimensional vector to another in place.
+     * Multiplies a 2-dimensional vector to another in place.
+     *
      * @param {Vec2} rhs - The 2-dimensional vector used as the second multiplicand of the operation.
      * @returns {Vec2} Self for chaining.
      * @example
@@ -363,11 +351,12 @@ class Vec2 {
     }
 
     /**
-     * @function
-     * @name Vec2#mul2
-     * @description Returns the result of multiplying the specified 2-dimensional vectors together.
-     * @param {Vec2} lhs - The 2-dimensional vector used as the first multiplicand of the operation.
-     * @param {Vec2} rhs - The 2-dimensional vector used as the second multiplicand of the operation.
+     * Returns the result of multiplying the specified 2-dimensional vectors together.
+     *
+     * @param {Vec2} lhs - The 2-dimensional vector used as the first multiplicand of the
+     * operation.
+     * @param {Vec2} rhs - The 2-dimensional vector used as the second multiplicand of the
+     * operation.
      * @returns {Vec2} Self for chaining.
      * @example
      * var a = new pc.Vec2(2, 3);
@@ -387,9 +376,8 @@ class Vec2 {
     }
 
     /**
-     * @function
-     * @name Vec2#mulScalar
-     * @description Multiplies each element of a vector by a number.
+     * Multiplies each element of a vector by a number.
+     *
      * @param {number} scalar - The number to multiply by.
      * @returns {Vec2} Self for chaining.
      * @example
@@ -408,10 +396,9 @@ class Vec2 {
     }
 
     /**
-     * @function
-     * @name Vec2#normalize
-     * @description Returns this 2-dimensional vector converted to a unit vector in place.
-     * If the vector has a length of zero, the vector's elements will be set to zero.
+     * Returns this 2-dimensional vector converted to a unit vector in place. If the vector has a
+     * length of zero, the vector's elements will be set to zero.
+     *
      * @returns {Vec2} Self for chaining.
      * @example
      * var v = new pc.Vec2(25, 0);
@@ -433,9 +420,8 @@ class Vec2 {
     }
 
     /**
-     * @function
-     * @name Vec2#floor
-     * @description Each element is set to the largest integer less than or equal to its value.
+     * Each element is set to the largest integer less than or equal to its value.
+     *
      * @returns {Vec2} Self for chaining.
      */
     floor() {
@@ -445,9 +431,8 @@ class Vec2 {
     }
 
     /**
-     * @function
-     * @name Vec2#ceil
-     * @description Each element is rounded up to the next largest integer.
+     * Each element is rounded up to the next largest integer.
+     *
      * @returns {Vec2} Self for chaining.
      */
     ceil() {
@@ -457,9 +442,8 @@ class Vec2 {
     }
 
     /**
-     * @function
-     * @name Vec2#round
-     * @description Each element is rounded up or down to the nearest integer.
+     * Each element is rounded up or down to the nearest integer.
+     *
      * @returns {Vec2} Self for chaining.
      */
     round() {
@@ -469,9 +453,8 @@ class Vec2 {
     }
 
     /**
-     * @function
-     * @name Vec2#min
-     * @description Each element is assigned a value from rhs parameter if it is smaller.
+     * Each element is assigned a value from rhs parameter if it is smaller.
+     *
      * @param {Vec2} rhs - The 2-dimensional vector used as the source of elements to compare to.
      * @returns {Vec2} Self for chaining.
      */
@@ -482,9 +465,8 @@ class Vec2 {
     }
 
     /**
-     * @function
-     * @name Vec2#max
-     * @description Each element is assigned a value from rhs parameter if it is larger.
+     * Each element is assigned a value from rhs parameter if it is larger.
+     *
      * @param {Vec2} rhs - The 2-dimensional vector used as the source of elements to compare to.
      * @returns {Vec2} Self for chaining.
      */
@@ -495,9 +477,8 @@ class Vec2 {
     }
 
     /**
-     * @function
-     * @name Vec2#set
-     * @description Sets the specified 2-dimensional vector to the supplied numerical values.
+     * Sets the specified 2-dimensional vector to the supplied numerical values.
+     *
      * @param {number} x - The value to set on the first component of the vector.
      * @param {number} y - The value to set on the second component of the vector.
      * @returns {Vec2} Self for chaining.
@@ -516,9 +497,8 @@ class Vec2 {
     }
 
     /**
-     * @function
-     * @name Vec2#sub
-     * @description Subtracts a 2-dimensional vector from another in place.
+     * Subtracts a 2-dimensional vector from another in place.
+     *
      * @param {Vec2} rhs - The vector to add to the specified vector.
      * @returns {Vec2} Self for chaining.
      * @example
@@ -538,9 +518,8 @@ class Vec2 {
     }
 
     /**
-     * @function
-     * @name Vec2#sub2
-     * @description Subtracts two 2-dimensional vectors from one another and returns the result.
+     * Subtracts two 2-dimensional vectors from one another and returns the result.
+     *
      * @param {Vec2} lhs - The first vector operand for the addition.
      * @param {Vec2} rhs - The second vector operand for the addition.
      * @returns {Vec2} Self for chaining.
@@ -562,9 +541,8 @@ class Vec2 {
     }
 
     /**
-     * @function
-     * @name Vec2#subScalar
-     * @description Subtracts a number from each element of a vector.
+     * Subtracts a number from each element of a vector.
+     *
      * @param {number} scalar - The number to subtract.
      * @returns {Vec2} Self for chaining.
      * @example
@@ -583,9 +561,8 @@ class Vec2 {
     }
 
     /**
-     * @function
-     * @name Vec2#toString
-     * @description Converts the vector to string form.
+     * Converts the vector to string form.
+     *
      * @returns {string} The vector in string form.
      * @example
      * var v = new pc.Vec2(20, 10);
@@ -597,75 +574,68 @@ class Vec2 {
     }
 
     /**
-     * @function
-     * @private
-     * @name Vec2#angleRad
-     * @description Calculates the angle between two Vec2's in radians.
+     * Calculates the angle between two Vec2's in radians.
+     *
      * @param {Vec2} lhs - The first vector operand for the calculation.
      * @param {Vec2} rhs - The second vector operand for the calculation.
      * @returns {number} The calculated angle in radians.
+     * @private
      */
     static angleRad(lhs, rhs) {
         return Math.atan2(lhs.x * rhs.y - lhs.y * rhs.x, lhs.x * rhs.x + lhs.y * rhs.y);
     }
 
     /**
-     * @field
-     * @static
-     * @readonly
+     * A constant vector set to [0, 0].
+     *
      * @name Vec2.ZERO
      * @type {Vec2}
-     * @description A constant vector set to [0, 0].
+     * @readonly
      */
     static ZERO = Object.freeze(new Vec2(0, 0));
 
     /**
-     * @field
-     * @static
-     * @readonly
+     * A constant vector set to [1, 1].
+     *
      * @name Vec2.ONE
      * @type {Vec2}
-     * @description A constant vector set to [1, 1].
+     * @readonly
      */
     static ONE = Object.freeze(new Vec2(1, 1));
 
     /**
-     * @field
-     * @static
-     * @readonly
+     * A constant vector set to [0, 1].
+     *
      * @name Vec2.UP
      * @type {Vec2}
-     * @description A constant vector set to [0, 1].
+     * @readonly
      */
     static UP = Object.freeze(new Vec2(0, 1));
 
     /**
-     * @field
-     * @static
-     * @readonly
+     * A constant vector set to [0, -1].
+     *
      * @name Vec2.DOWN
      * @type {Vec2}
-     * @description A constant vector set to [0, -1].
+     * @readonly
      */
     static DOWN = Object.freeze(new Vec2(0, -1));
 
     /**
-     * @field
-     * @static
-     * @readonly
+     * A constant vector set to [1, 0].
+     *
      * @name Vec2.RIGHT
      * @type {Vec2}
-     * @description A constant vector set to [1, 0].
+     * @readonly
      */
     static RIGHT = Object.freeze(new Vec2(1, 0));
 
     /**
-     * @field
-     * @static
-     * @readonly
+     * A constant vector set to [-1, 0].
+     *
      * @name Vec2.LEFT
      * @type {Vec2}
-     * @description A constant vector set to [-1, 0].
+     * @readonly
      */
     static LEFT = Object.freeze(new Vec2(-1, 0));
 }

--- a/src/math/vec3.js
+++ b/src/math/vec3.js
@@ -1,54 +1,62 @@
 /**
- * @class
- * @name Vec3
- * @classdesc A 3-dimensional vector.
- * @description Creates a new Vec3 object.
- * @param {number|number[]} [x] - The x value. If x is an array of length 3, the array will be used to populate all components.
- * @param {number} [y] - The y value.
- * @param {number} [z] - The z value.
- * @example
- * var v = new pc.Vec3(1, 2, 3);
- */
-/**
- * @name Vec3#x
- * @type {number}
- * @description The first component of the vector.
- * @example
- * var vec = new pc.Vec3(10, 20, 30);
- *
- * // Get x
- * var x = vec.x;
- *
- * // Set x
- * vec.x = 0;
- */
-/**
- * @name Vec3#y
- * @type {number}
- * @description The second component of the vector.
- * @example
- * var vec = new pc.Vec3(10, 20, 30);
- *
- * // Get y
- * var y = vec.y;
- *
- * // Set y
- * vec.y = 0;
- */
-/**
- * @name Vec3#z
- * @type {number}
- * @description The third component of the vector.
- * @example
- * var vec = new pc.Vec3(10, 20, 30);
- *
- * // Get z
- * var z = vec.z;
- *
- * // Set z
- * vec.z = 0;
+ * A 3-dimensional vector.
  */
 class Vec3 {
+    /**
+     * The first component of the vector.
+     *
+     * @type {number}
+     * @example
+     * var vec = new pc.Vec3(10, 20, 30);
+     *
+     * // Get x
+     * var x = vec.x;
+     *
+     * // Set x
+     * vec.x = 0;
+     */
+    x;
+
+    /**
+     * The second component of the vector.
+     *
+     * @type {number}
+     * @example
+     * var vec = new pc.Vec3(10, 20, 30);
+     *
+     * // Get y
+     * var y = vec.y;
+     *
+     * // Set y
+     * vec.y = 0;
+     */
+    y;
+
+    /**
+     * The third component of the vector.
+     *
+     * @type {number}
+     * @example
+     * var vec = new pc.Vec3(10, 20, 30);
+     *
+     * // Get z
+     * var z = vec.z;
+     *
+     * // Set z
+     * vec.z = 0;
+     */
+    z;
+
+    /**
+     * Creates a new Vec3 object.
+     *
+     * @param {number|number[]} [x] - The x value. If x is an array of length 3, the array will be
+     * used to populate all components.
+     * @param {number} [y] - The y value.
+     * @param {number} [z] - The z value.
+     * @example
+     * var v = new pc.Vec3(1, 2, 3);
+     */
     constructor(x = 0, y = 0, z = 0) {
         if (x.length === 3) {
             this.x = x[0];
@@ -62,9 +70,8 @@ class Vec3 {
     }
 
     /**
-     * @function
-     * @name Vec3#add
-     * @description Adds a 3-dimensional vector to another in place.
+     * Adds a 3-dimensional vector to another in place.
+     *
      * @param {Vec3} rhs - The vector to add to the specified vector.
      * @returns {Vec3} Self for chaining.
      * @example
@@ -85,9 +92,8 @@ class Vec3 {
     }
 
     /**
-     * @function
-     * @name Vec3#add2
-     * @description Adds two 3-dimensional vectors together and returns the result.
+     * Adds two 3-dimensional vectors together and returns the result.
+     *
      * @param {Vec3} lhs - The first vector operand for the addition.
      * @param {Vec3} rhs - The second vector operand for the addition.
      * @returns {Vec3} Self for chaining.
@@ -110,9 +116,8 @@ class Vec3 {
     }
 
     /**
-     * @function
-     * @name Vec3#addScalar
-     * @description Adds a number to each element of a vector.
+     * Adds a number to each element of a vector.
+     *
      * @param {number} scalar - The number to add.
      * @returns {Vec3} Self for chaining.
      * @example
@@ -132,9 +137,8 @@ class Vec3 {
     }
 
     /**
-     * @function
-     * @name Vec3#clone
-     * @description Returns an identical copy of the specified 3-dimensional vector.
+     * Returns an identical copy of the specified 3-dimensional vector.
+     *
      * @returns {Vec3} A 3-dimensional vector containing the result of the cloning.
      * @example
      * var v = new pc.Vec3(10, 20, 30);
@@ -146,9 +150,8 @@ class Vec3 {
     }
 
     /**
-     * @function
-     * @name Vec3#copy
-     * @description Copies the contents of a source 3-dimensional vector to a destination 3-dimensional vector.
+     * Copies the contents of a source 3-dimensional vector to a destination 3-dimensional vector.
+     *
      * @param {Vec3} rhs - A vector to copy to the specified vector.
      * @returns {Vec3} Self for chaining.
      * @example
@@ -168,9 +171,9 @@ class Vec3 {
     }
 
     /**
-     * @function
-     * @name Vec3#cross
-     * @description Returns the result of a cross product operation performed on the two specified 3-dimensional vectors.
+     * Returns the result of a cross product operation performed on the two specified 3-dimensional
+     * vectors.
+     *
      * @param {Vec3} lhs - The first 3-dimensional vector operand of the cross product.
      * @param {Vec3} rhs - The second 3-dimensional vector operand of the cross product.
      * @returns {Vec3} Self for chaining.
@@ -197,9 +200,8 @@ class Vec3 {
     }
 
     /**
-     * @function
-     * @name Vec3#distance
-     * @description Returns the distance between the two specified 3-dimensional vectors.
+     * Returns the distance between the two specified 3-dimensional vectors.
+     *
      * @param {Vec3} rhs - The second 3-dimensional vector to test.
      * @returns {number} The distance between the two vectors.
      * @example
@@ -216,9 +218,8 @@ class Vec3 {
     }
 
     /**
-     * @function
-     * @name Vec3#div
-     * @description Divides a 3-dimensional vector by another in place.
+     * Divides a 3-dimensional vector by another in place.
+     *
      * @param {Vec3} rhs - The vector to divide the specified vector by.
      * @returns {Vec3} Self for chaining.
      * @example
@@ -239,10 +240,8 @@ class Vec3 {
     }
 
     /**
-     * @function
-     * @name Vec3#div2
-     * @description Divides one 3-dimensional vector by another and writes the result to
-     * the specified vector.
+     * Divides one 3-dimensional vector by another and writes the result to the specified vector.
+     *
      * @param {Vec3} lhs - The dividend vector (the vector being divided).
      * @param {Vec3} rhs - The divisor vector (the vector dividing the dividend).
      * @returns {Vec3} Self for chaining.
@@ -265,9 +264,8 @@ class Vec3 {
     }
 
     /**
-     * @function
-     * @name Vec3#divScalar
-     * @description Divides each element of a vector by a number.
+     * Divides each element of a vector by a number.
+     *
      * @param {number} scalar - The number to divide by.
      * @returns {Vec3} Self for chaining.
      * @example
@@ -287,9 +285,9 @@ class Vec3 {
     }
 
     /**
-     * @function
-     * @name Vec3#dot
-     * @description Returns the result of a dot product operation performed on the two specified 3-dimensional vectors.
+     * Returns the result of a dot product operation performed on the two specified 3-dimensional
+     * vectors.
+     *
      * @param {Vec3} rhs - The second 3-dimensional vector operand of the dot product.
      * @returns {number} The result of the dot product operation.
      * @example
@@ -303,9 +301,8 @@ class Vec3 {
     }
 
     /**
-     * @function
-     * @name Vec3#equals
-     * @description Reports whether two vectors are equal.
+     * Reports whether two vectors are equal.
+     *
      * @param {Vec3} rhs - The vector to compare to the specified vector.
      * @returns {boolean} True if the vectors are equal and false otherwise.
      * @example
@@ -318,9 +315,8 @@ class Vec3 {
     }
 
     /**
-     * @function
-     * @name Vec3#length
-     * @description Returns the magnitude of the specified 3-dimensional vector.
+     * Returns the magnitude of the specified 3-dimensional vector.
+     *
      * @returns {number} The magnitude of the specified 3-dimensional vector.
      * @example
      * var vec = new pc.Vec3(3, 4, 0);
@@ -333,9 +329,8 @@ class Vec3 {
     }
 
     /**
-     * @function
-     * @name Vec3#lengthSq
-     * @description Returns the magnitude squared of the specified 3-dimensional vector.
+     * Returns the magnitude squared of the specified 3-dimensional vector.
+     *
      * @returns {number} The magnitude of the specified 3-dimensional vector.
      * @example
      * var vec = new pc.Vec3(3, 4, 0);
@@ -348,14 +343,13 @@ class Vec3 {
     }
 
     /**
-     * @function
-     * @name Vec3#lerp
-     * @description Returns the result of a linear interpolation between two specified 3-dimensional vectors.
+     * Returns the result of a linear interpolation between two specified 3-dimensional vectors.
+     *
      * @param {Vec3} lhs - The 3-dimensional to interpolate from.
      * @param {Vec3} rhs - The 3-dimensional to interpolate to.
-     * @param {number} alpha - The value controlling the point of interpolation. Between 0 and 1, the linear interpolant
-     * will occur on a straight line between lhs and rhs. Outside of this range, the linear interpolant will occur on
-     * a ray extrapolated from this line.
+     * @param {number} alpha - The value controlling the point of interpolation. Between 0 and 1,
+     * the linear interpolant will occur on a straight line between lhs and rhs. Outside of this
+     * range, the linear interpolant will occur on a ray extrapolated from this line.
      * @returns {Vec3} Self for chaining.
      * @example
      * var a = new pc.Vec3(0, 0, 0);
@@ -375,10 +369,10 @@ class Vec3 {
     }
 
     /**
-     * @function
-     * @name Vec3#mul
-     * @description Multiplies a 3-dimensional vector to another in place.
-     * @param {Vec3} rhs - The 3-dimensional vector used as the second multiplicand of the operation.
+     * Multiplies a 3-dimensional vector to another in place.
+     *
+     * @param {Vec3} rhs - The 3-dimensional vector used as the second multiplicand of the
+     * operation.
      * @returns {Vec3} Self for chaining.
      * @example
      * var a = new pc.Vec3(2, 3, 4);
@@ -398,11 +392,12 @@ class Vec3 {
     }
 
     /**
-     * @function
-     * @name Vec3#mul2
-     * @description Returns the result of multiplying the specified 3-dimensional vectors together.
-     * @param {Vec3} lhs - The 3-dimensional vector used as the first multiplicand of the operation.
-     * @param {Vec3} rhs - The 3-dimensional vector used as the second multiplicand of the operation.
+     * Returns the result of multiplying the specified 3-dimensional vectors together.
+     *
+     * @param {Vec3} lhs - The 3-dimensional vector used as the first multiplicand of the
+     * operation.
+     * @param {Vec3} rhs - The 3-dimensional vector used as the second multiplicand of the
+     * operation.
      * @returns {Vec3} Self for chaining.
      * @example
      * var a = new pc.Vec3(2, 3, 4);
@@ -423,9 +418,8 @@ class Vec3 {
     }
 
     /**
-     * @function
-     * @name Vec3#mulScalar
-     * @description Multiplies each element of a vector by a number.
+     * Multiplies each element of a vector by a number.
+     *
      * @param {number} scalar - The number to multiply by.
      * @returns {Vec3} Self for chaining.
      * @example
@@ -445,10 +439,9 @@ class Vec3 {
     }
 
     /**
-     * @function
-     * @name Vec3#normalize
-     * @description Returns this 3-dimensional vector converted to a unit vector in place.
-     * If the vector has a length of zero, the vector's elements will be set to zero.
+     * Returns this 3-dimensional vector converted to a unit vector in place. If the vector has a
+     * length of zero, the vector's elements will be set to zero.
+     *
      * @returns {Vec3} Self for chaining.
      * @example
      * var v = new pc.Vec3(25, 0, 0);
@@ -471,9 +464,8 @@ class Vec3 {
     }
 
     /**
-     * @function
-     * @name Vec3#floor
-     * @description Each element is set to the largest integer less than or equal to its value.
+     * Each element is set to the largest integer less than or equal to its value.
+     *
      * @returns {Vec3} Self for chaining.
      */
     floor() {
@@ -484,9 +476,8 @@ class Vec3 {
     }
 
     /**
-     * @function
-     * @name Vec3#ceil
-     * @description Each element is rounded up to the next largest integer.
+     * Each element is rounded up to the next largest integer.
+     *
      * @returns {Vec3} Self for chaining.
      */
     ceil() {
@@ -497,9 +488,8 @@ class Vec3 {
     }
 
     /**
-     * @function
-     * @name Vec3#round
-     * @description Each element is rounded up or down to the nearest integer.
+     * Each element is rounded up or down to the nearest integer.
+     *
      * @returns {Vec3} Self for chaining.
      */
     round() {
@@ -510,9 +500,8 @@ class Vec3 {
     }
 
     /**
-     * @function
-     * @name Vec3#min
-     * @description Each element is assigned a value from rhs parameter if it is smaller.
+     * Each element is assigned a value from rhs parameter if it is smaller.
+     *
      * @param {Vec3} rhs - The 3-dimensional vector used as the source of elements to compare to.
      * @returns {Vec3} Self for chaining.
      */
@@ -524,9 +513,8 @@ class Vec3 {
     }
 
     /**
-     * @function
-     * @name Vec3#max
-     * @description Each element is assigned a value from rhs parameter if it is larger.
+     * Each element is assigned a value from rhs parameter if it is larger.
+     *
      * @param {Vec3} rhs - The 3-dimensional vector used as the source of elements to compare to.
      * @returns {Vec3} Self for chaining.
      */
@@ -538,9 +526,8 @@ class Vec3 {
     }
 
     /**
-     * @function
-     * @name Vec3#project
-     * @description Projects this 3-dimensional vector onto the specified vector.
+     * Projects this 3-dimensional vector onto the specified vector.
+     *
      * @param {Vec3} rhs - The vector onto which the original vector will be projected on.
      * @returns {Vec3} Self for chaining.
      * @example
@@ -563,9 +550,8 @@ class Vec3 {
     }
 
     /**
-     * @function
-     * @name Vec3#set
-     * @description Sets the specified 3-dimensional vector to the supplied numerical values.
+     * Sets the specified 3-dimensional vector to the supplied numerical values.
+     *
      * @param {number} x - The value to set on the first component of the vector.
      * @param {number} y - The value to set on the second component of the vector.
      * @param {number} z - The value to set on the third component of the vector.
@@ -586,9 +572,8 @@ class Vec3 {
     }
 
     /**
-     * @function
-     * @name Vec3#sub
-     * @description Subtracts a 3-dimensional vector from another in place.
+     * Subtracts a 3-dimensional vector from another in place.
+     *
      * @param {Vec3} rhs - The vector to add to the specified vector.
      * @returns {Vec3} Self for chaining.
      * @example
@@ -609,9 +594,8 @@ class Vec3 {
     }
 
     /**
-     * @function
-     * @name Vec3#sub2
-     * @description Subtracts two 3-dimensional vectors from one another and returns the result.
+     * Subtracts two 3-dimensional vectors from one another and returns the result.
+     *
      * @param {Vec3} lhs - The first vector operand for the addition.
      * @param {Vec3} rhs - The second vector operand for the addition.
      * @returns {Vec3} Self for chaining.
@@ -634,9 +618,8 @@ class Vec3 {
     }
 
     /**
-     * @function
-     * @name Vec3#subScalar
-     * @description Subtracts a number from each element of a vector.
+     * Subtracts a number from each element of a vector.
+     *
      * @param {number} scalar - The number to subtract.
      * @returns {Vec3} Self for chaining.
      * @example
@@ -656,9 +639,8 @@ class Vec3 {
     }
 
     /**
-     * @function
-     * @name Vec3#toString
-     * @description Converts the vector to string form.
+     * Converts the vector to string form.
+     *
      * @returns {string} The vector in string form.
      * @example
      * var v = new pc.Vec3(20, 10, 5);
@@ -670,82 +652,74 @@ class Vec3 {
     }
 
     /**
-     * @field
-     * @static
-     * @readonly
+     * A constant vector set to [0, 0, 0].
+     *
      * @name Vec3.ZERO
      * @type {Vec3}
-     * @description A constant vector set to [0, 0, 0].
+     * @readonly
      */
     static ZERO = Object.freeze(new Vec3(0, 0, 0));
 
     /**
-     * @field
-     * @static
-     * @readonly
+     * A constant vector set to [1, 1, 1].
+     *
      * @name Vec3.ONE
      * @type {Vec3}
-     * @description A constant vector set to [1, 1, 1].
+     * @readonly
      */
     static ONE = Object.freeze(new Vec3(1, 1, 1));
 
     /**
-     * @field
-     * @static
-     * @readonly
+     * A constant vector set to [0, 1, 0].
+     *
      * @name Vec3.UP
      * @type {Vec3}
-     * @description A constant vector set to [0, 1, 0].
+     * @readonly
      */
     static UP = Object.freeze(new Vec3(0, 1, 0));
 
     /**
-     * @field
-     * @static
-     * @readonly
+     * A constant vector set to [0, -1, 0].
+     *
      * @name Vec3.DOWN
      * @type {Vec3}
-     * @description A constant vector set to [0, -1, 0].
+     * @readonly
      */
     static DOWN = Object.freeze(new Vec3(0, -1, 0));
 
     /**
-     * @field
-     * @static
-     * @readonly
+     * A constant vector set to [1, 0, 0].
+     *
      * @name Vec3.RIGHT
      * @type {Vec3}
-     * @description A constant vector set to [1, 0, 0].
+     * @readonly
      */
     static RIGHT = Object.freeze(new Vec3(1, 0, 0));
 
     /**
-     * @field
-     * @static
-     * @readonly
+     * A constant vector set to [-1, 0, 0].
+     *
      * @name Vec3.LEFT
      * @type {Vec3}
-     * @description A constant vector set to [-1, 0, 0].
+     * @readonly
      */
     static LEFT = Object.freeze(new Vec3(-1, 0, 0));
 
     /**
-     * @field
-     * @static
-     * @readonly
+     * A constant vector set to [0, 0, -1].
+     *
      * @name Vec3.FORWARD
      * @type {Vec3}
-     * @description A constant vector set to [0, 0, -1].
+     * @readonly
      */
     static FORWARD = Object.freeze(new Vec3(0, 0, -1));
 
     /**
-     * @field
-     * @static
-     * @readonly
+     * A constant vector set to [0, 0, 1].
+     *
      * @name Vec3.BACK
      * @type {Vec3}
-     * @description A constant vector set to [0, 0, 1].
+     * @readonly
      */
     static BACK = Object.freeze(new Vec3(0, 0, 1));
 }

--- a/src/math/vec4.js
+++ b/src/math/vec4.js
@@ -1,72 +1,79 @@
 /**
- * @class
- * @name Vec4
- * @classdesc A 4-dimensional vector.
- * @description Creates a new Vec4 object.
- * @param {number|number[]} [x] - The x value. If x is an array of length 4, the array will be used to populate all components.
- * @param {number} [y] - The y value.
- * @param {number} [z] - The z value.
- * @param {number} [w] - The w value.
- * @example
- * var v = new pc.Vec4(1, 2, 3, 4);
- */
-/**
- * @field
- * @name Vec4#x
- * @type {number}
- * @description The first component of the vector.
- * @example
- * var vec = new pc.Vec4(10, 20, 30, 40);
- *
- * // Get x
- * var x = vec.x;
- *
- * // Set x
- * vec.x = 0;
- */
-/**
- * @field
- * @name Vec4#y
- * @type {number}
- * @description The second component of the vector.
- * @example
- * var vec = new pc.Vec4(10, 20, 30, 40);
- *
- * // Get y
- * var y = vec.y;
- *
- * // Set y
- * vec.y = 0;
- */
-/**
- * @field
- * @name Vec4#z
- * @type {number}
- * @description The third component of the vector.
- * @example
- * var vec = new pc.Vec4(10, 20, 30, 40);
- *
- * // Get z
- * var z = vec.z;
- *
- * // Set z
- * vec.z = 0;
- */
-/**
- * @field
- * @name Vec4#w
- * @type {number}
- * @description The fourth component of the vector.
- * @example
- * var vec = new pc.Vec4(10, 20, 30, 40);
- *
- * // Get w
- * var w = vec.w;
- *
- * // Set w
- * vec.w = 0;
+ * A 4-dimensional vector.
  */
 class Vec4 {
+    /**
+     * The first component of the vector.
+     *
+     * @type {number}
+     * @example
+     * var vec = new pc.Vec4(10, 20, 30, 40);
+     *
+     * // Get x
+     * var x = vec.x;
+     *
+     * // Set x
+     * vec.x = 0;
+     */
+    x;
+
+    /**
+     * The second component of the vector.
+     *
+     * @type {number}
+     * @example
+     * var vec = new pc.Vec4(10, 20, 30, 40);
+     *
+     * // Get y
+     * var y = vec.y;
+     *
+     * // Set y
+     * vec.y = 0;
+     */
+    y;
+
+    /**
+     * The third component of the vector.
+     *
+     * @type {number}
+     * @example
+     * var vec = new pc.Vec4(10, 20, 30, 40);
+     *
+     * // Get z
+     * var z = vec.z;
+     *
+     * // Set z
+     * vec.z = 0;
+     */
+    z;
+
+    /**
+     * The fourth component of the vector.
+     *
+     * @type {number}
+     * @example
+     * var vec = new pc.Vec4(10, 20, 30, 40);
+     *
+     * // Get w
+     * var w = vec.w;
+     *
+     * // Set w
+     * vec.w = 0;
+     */
+    w;
+
+    /**
+     * Creates a new Vec4 object.
+     *
+     * @param {number|number[]} [x] - The x value. If x is an array of length 4, the array will be
+     * used to populate all components.
+     * @param {number} [y] - The y value.
+     * @param {number} [z] - The z value.
+     * @param {number} [w] - The w value.
+     * @example
+     * var v = new pc.Vec4(1, 2, 3, 4);
+     */
+
     constructor(x = 0, y = 0, z = 0, w = 0) {
         if (x.length === 4) {
             this.x = x[0];
@@ -82,9 +89,8 @@ class Vec4 {
     }
 
     /**
-     * @function
-     * @name Vec4#add
-     * @description Adds a 4-dimensional vector to another in place.
+     * Adds a 4-dimensional vector to another in place.
+     *
      * @param {Vec4} rhs - The vector to add to the specified vector.
      * @returns {Vec4} Self for chaining.
      * @example
@@ -106,9 +112,8 @@ class Vec4 {
     }
 
     /**
-     * @function
-     * @name Vec4#add2
-     * @description Adds two 4-dimensional vectors together and returns the result.
+     * Adds two 4-dimensional vectors together and returns the result.
+     *
      * @param {Vec4} lhs - The first vector operand for the addition.
      * @param {Vec4} rhs - The second vector operand for the addition.
      * @returns {Vec4} Self for chaining.
@@ -132,9 +137,8 @@ class Vec4 {
     }
 
     /**
-     * @function
-     * @name Vec4#addScalar
-     * @description Adds a number to each element of a vector.
+     * Adds a number to each element of a vector.
+     *
      * @param {number} scalar - The number to add.
      * @returns {Vec4} Self for chaining.
      * @example
@@ -155,9 +159,8 @@ class Vec4 {
     }
 
     /**
-     * @function
-     * @name Vec4#clone
-     * @description Returns an identical copy of the specified 4-dimensional vector.
+     * Returns an identical copy of the specified 4-dimensional vector.
+     *
      * @returns {Vec4} A 4-dimensional vector containing the result of the cloning.
      * @example
      * var v = new pc.Vec4(10, 20, 30, 40);
@@ -169,9 +172,8 @@ class Vec4 {
     }
 
     /**
-     * @function
-     * @name Vec4#copy
-     * @description Copies the contents of a source 4-dimensional vector to a destination 4-dimensional vector.
+     * Copies the contents of a source 4-dimensional vector to a destination 4-dimensional vector.
+     *
      * @param {Vec4} rhs - A vector to copy to the specified vector.
      * @returns {Vec4} Self for chaining.
      * @example
@@ -192,9 +194,8 @@ class Vec4 {
     }
 
     /**
-     * @function
-     * @name Vec4#div
-     * @description Divides a 4-dimensional vector by another in place.
+     * Divides a 4-dimensional vector by another in place.
+     *
      * @param {Vec4} rhs - The vector to divide the specified vector by.
      * @returns {Vec4} Self for chaining.
      * @example
@@ -216,10 +217,8 @@ class Vec4 {
     }
 
     /**
-     * @function
-     * @name Vec4#div2
-     * @description Divides one 4-dimensional vector by another and writes the result to
-     * the specified vector.
+     * Divides one 4-dimensional vector by another and writes the result to the specified vector.
+     *
      * @param {Vec4} lhs - The dividend vector (the vector being divided).
      * @param {Vec4} rhs - The divisor vector (the vector dividing the dividend).
      * @returns {Vec4} Self for chaining.
@@ -243,9 +242,8 @@ class Vec4 {
     }
 
     /**
-     * @function
-     * @name Vec4#divScalar
-     * @description Divides each element of a vector by a number.
+     * Divides each element of a vector by a number.
+     *
      * @param {number} scalar - The number to divide by.
      * @returns {Vec4} Self for chaining.
      * @example
@@ -266,9 +264,9 @@ class Vec4 {
     }
 
     /**
-     * @function
-     * @name Vec4#dot
-     * @description Returns the result of a dot product operation performed on the two specified 4-dimensional vectors.
+     * Returns the result of a dot product operation performed on the two specified 4-dimensional
+     * vectors.
+     *
      * @param {Vec4} rhs - The second 4-dimensional vector operand of the dot product.
      * @returns {number} The result of the dot product operation.
      * @example
@@ -282,9 +280,8 @@ class Vec4 {
     }
 
     /**
-     * @function
-     * @name Vec4#equals
-     * @description Reports whether two vectors are equal.
+     * Reports whether two vectors are equal.
+     *
      * @param {Vec4} rhs - The vector to compare to the specified vector.
      * @returns {boolean} True if the vectors are equal and false otherwise.
      * @example
@@ -297,9 +294,8 @@ class Vec4 {
     }
 
     /**
-     * @function
-     * @name Vec4#length
-     * @description Returns the magnitude of the specified 4-dimensional vector.
+     * Returns the magnitude of the specified 4-dimensional vector.
+     *
      * @returns {number} The magnitude of the specified 4-dimensional vector.
      * @example
      * var vec = new pc.Vec4(3, 4, 0, 0);
@@ -312,9 +308,8 @@ class Vec4 {
     }
 
     /**
-     * @function
-     * @name Vec4#lengthSq
-     * @description Returns the magnitude squared of the specified 4-dimensional vector.
+     * Returns the magnitude squared of the specified 4-dimensional vector.
+     *
      * @returns {number} The magnitude of the specified 4-dimensional vector.
      * @example
      * var vec = new pc.Vec4(3, 4, 0);
@@ -327,14 +322,13 @@ class Vec4 {
     }
 
     /**
-     * @function
-     * @name Vec4#lerp
-     * @description Returns the result of a linear interpolation between two specified 4-dimensional vectors.
+     * Returns the result of a linear interpolation between two specified 4-dimensional vectors.
+     *
      * @param {Vec4} lhs - The 4-dimensional to interpolate from.
      * @param {Vec4} rhs - The 4-dimensional to interpolate to.
-     * @param {number} alpha - The value controlling the point of interpolation. Between 0 and 1, the linear interpolant
-     * will occur on a straight line between lhs and rhs. Outside of this range, the linear interpolant will occur on
-     * a ray extrapolated from this line.
+     * @param {number} alpha - The value controlling the point of interpolation. Between 0 and 1,
+     * the linear interpolant will occur on a straight line between lhs and rhs. Outside of this
+     * range, the linear interpolant will occur on a ray extrapolated from this line.
      * @returns {Vec4} Self for chaining.
      * @example
      * var a = new pc.Vec4(0, 0, 0, 0);
@@ -355,10 +349,10 @@ class Vec4 {
     }
 
     /**
-     * @function
-     * @name Vec4#mul
-     * @description Multiplies a 4-dimensional vector to another in place.
-     * @param {Vec4} rhs - The 4-dimensional vector used as the second multiplicand of the operation.
+     * Multiplies a 4-dimensional vector to another in place.
+     *
+     * @param {Vec4} rhs - The 4-dimensional vector used as the second multiplicand of the
+     * operation.
      * @returns {Vec4} Self for chaining.
      * @example
      * var a = new pc.Vec4(2, 3, 4, 5);
@@ -379,11 +373,12 @@ class Vec4 {
     }
 
     /**
-     * @function
-     * @name Vec4#mul2
-     * @description Returns the result of multiplying the specified 4-dimensional vectors together.
-     * @param {Vec4} lhs - The 4-dimensional vector used as the first multiplicand of the operation.
-     * @param {Vec4} rhs - The 4-dimensional vector used as the second multiplicand of the operation.
+     * Returns the result of multiplying the specified 4-dimensional vectors together.
+     *
+     * @param {Vec4} lhs - The 4-dimensional vector used as the first multiplicand of the
+     * operation.
+     * @param {Vec4} rhs - The 4-dimensional vector used as the second multiplicand of the
+     * operation.
      * @returns {Vec4} Self for chaining.
      * @example
      * var a = new pc.Vec4(2, 3, 4, 5);
@@ -405,9 +400,8 @@ class Vec4 {
     }
 
     /**
-     * @function
-     * @name Vec4#mulScalar
-     * @description Multiplies each element of a vector by a number.
+     * Multiplies each element of a vector by a number.
+     *
      * @param {number} scalar - The number to multiply by.
      * @returns {Vec4} Self for chaining.
      * @example
@@ -428,10 +422,9 @@ class Vec4 {
     }
 
     /**
-     * @function
-     * @name Vec4#normalize
-     * @description Returns this 4-dimensional vector converted to a unit vector in place.
-     * If the vector has a length of zero, the vector's elements will be set to zero.
+     * Returns this 4-dimensional vector converted to a unit vector in place. If the vector has a
+     * length of zero, the vector's elements will be set to zero.
+     *
      * @returns {Vec4} Self for chaining.
      * @example
      * var v = new pc.Vec4(25, 0, 0, 0);
@@ -455,9 +448,8 @@ class Vec4 {
     }
 
     /**
-     * @function
-     * @name Vec4#floor
-     * @description Each element is set to the largest integer less than or equal to its value.
+     * Each element is set to the largest integer less than or equal to its value.
+     *
      * @returns {Vec4} Self for chaining.
      */
     floor() {
@@ -469,9 +461,8 @@ class Vec4 {
     }
 
     /**
-     * @function
-     * @name Vec4#ceil
-     * @description Each element is rounded up to the next largest integer.
+     * Each element is rounded up to the next largest integer.
+     *
      * @returns {Vec4} Self for chaining.
      */
     ceil() {
@@ -483,9 +474,8 @@ class Vec4 {
     }
 
     /**
-     * @function
-     * @name Vec4#round
-     * @description Each element is rounded up or down to the nearest integer.
+     * Each element is rounded up or down to the nearest integer.
+     *
      * @returns {Vec4} Self for chaining.
      */
     round() {
@@ -497,9 +487,8 @@ class Vec4 {
     }
 
     /**
-     * @function
-     * @name Vec4#min
-     * @description Each element is assigned a value from rhs parameter if it is smaller.
+     * Each element is assigned a value from rhs parameter if it is smaller.
+     *
      * @param {Vec4} rhs - The 4-dimensional vector used as the source of elements to compare to.
      * @returns {Vec4} Self for chaining.
      */
@@ -512,9 +501,8 @@ class Vec4 {
     }
 
     /**
-     * @function
-     * @name Vec4#max
-     * @description Each element is assigned a value from rhs parameter if it is larger.
+     * Each element is assigned a value from rhs parameter if it is larger.
+     *
      * @param {Vec4} rhs - The 4-dimensional vector used as the source of elements to compare to.
      * @returns {Vec4} Self for chaining.
      */
@@ -527,9 +515,8 @@ class Vec4 {
     }
 
     /**
-     * @function
-     * @name Vec4#set
-     * @description Sets the specified 4-dimensional vector to the supplied numerical values.
+     * Sets the specified 4-dimensional vector to the supplied numerical values.
+     *
      * @param {number} x - The value to set on the first component of the vector.
      * @param {number} y - The value to set on the second component of the vector.
      * @param {number} z - The value to set on the third component of the vector.
@@ -552,9 +539,8 @@ class Vec4 {
     }
 
     /**
-     * @function
-     * @name Vec4#sub
-     * @description Subtracts a 4-dimensional vector from another in place.
+     * Subtracts a 4-dimensional vector from another in place.
+     *
      * @param {Vec4} rhs - The vector to add to the specified vector.
      * @returns {Vec4} Self for chaining.
      * @example
@@ -576,9 +562,8 @@ class Vec4 {
     }
 
     /**
-     * @function
-     * @name Vec4#sub2
-     * @description Subtracts two 4-dimensional vectors from one another and returns the result.
+     * Subtracts two 4-dimensional vectors from one another and returns the result.
+     *
      * @param {Vec4} lhs - The first vector operand for the subtraction.
      * @param {Vec4} rhs - The second vector operand for the subtraction.
      * @returns {Vec4} Self for chaining.
@@ -602,9 +587,8 @@ class Vec4 {
     }
 
     /**
-     * @function
-     * @name Vec4#subScalar
-     * @description Subtracts a number from each element of a vector.
+     * Subtracts a number from each element of a vector.
+     *
      * @param {number} scalar - The number to subtract.
      * @returns {Vec4} Self for chaining.
      * @example
@@ -625,9 +609,8 @@ class Vec4 {
     }
 
     /**
-     * @function
-     * @name Vec4#toString
-     * @description Converts the vector to string form.
+     * Converts the vector to string form.
+     *
      * @returns {string} The vector in string form.
      * @example
      * var v = new pc.Vec4(20, 10, 5, 0);
@@ -639,22 +622,20 @@ class Vec4 {
     }
 
     /**
-     * @field
-     * @static
-     * @readonly
+     * A constant vector set to [0, 0, 0, 0].
+     *
      * @name Vec4.ZERO
      * @type {Vec4}
-     * @description A constant vector set to [0, 0, 0, 0].
+     * @readonly
      */
     static ZERO = Object.freeze(new Vec4(0, 0, 0, 0));
 
     /**
-     * @field
-     * @static
-     * @readonly
+     * A constant vector set to [1, 1, 1, 1].
+     *
      * @name Vec4.ONE
      * @type {Vec4}
-     * @description A constant vector set to [1, 1, 1, 1].
+     * @readonly
      */
     static ONE = Object.freeze(new Vec4(1, 1, 1, 1));
 }

--- a/src/shape/bounding-box.js
+++ b/src/shape/bounding-box.js
@@ -7,16 +7,29 @@ const tmpVecD = new Vec3();
 const tmpVecE = new Vec3();
 
 /**
- * @class
- * @name BoundingBox
- * @description Create a new axis-aligned bounding box.
- * @classdesc Axis-Aligned Bounding Box.
- * @param {Vec3} [center] - Center of box. The constructor takes a reference of this parameter.
- * @param {Vec3} [halfExtents] - Half the distance across the box in each axis. The constructor takes a reference of this parameter. Defaults to 0.5 on each axis.
- * @property {Vec3} center Center of box.
- * @property {Vec3} halfExtents Half the distance across the box in each axis.
+ * Axis-Aligned Bounding Box.
  */
 class BoundingBox {
+    /**
+     * Center of box.
+     *
+     * @type {Vec3}
+     */
+    center;
+
+    /**
+     * Half the distance across the box in each axis.
+     *
+     * @type {Vec3}
+     */
+    halfExtents;
+
+    /**
+     * Create a new axis-aligned bounding box.
+     *
+     * @param {Vec3} [center] - Center of box. The constructor takes a reference of this parameter.
+     * @param {Vec3} [halfExtents] - Half the distance across the box in each axis. The constructor takes a reference of this parameter. Defaults to 0.5 on each axis.
+     */
     constructor(center = new Vec3(), halfExtents = new Vec3(0.5, 0.5, 0.5)) {
         this.center = center;
         this.halfExtents = halfExtents;
@@ -25,9 +38,8 @@ class BoundingBox {
     }
 
     /**
-     * @function
-     * @name BoundingBox#add
-     * @description Combines two bounding boxes into one, enclosing both.
+     * Combines two bounding boxes into one, enclosing both.
+     *
      * @param {BoundingBox} other - Bounding box to add.
      */
     add(other) {
@@ -77,9 +89,8 @@ class BoundingBox {
     }
 
     /**
-     * @function
-     * @name BoundingBox#copy
-     * @description Copies the contents of a source AABB.
+     * Copies the contents of a source AABB.
+     *
      * @param {BoundingBox} src - The AABB to copy from.
      */
     copy(src) {
@@ -88,9 +99,8 @@ class BoundingBox {
     }
 
     /**
-     * @function
-     * @name BoundingBox#clone
-     * @description Returns a clone of the AABB.
+     * Returns a clone of the AABB.
+     *
      * @returns {BoundingBox} A duplicate AABB.
      */
     clone() {
@@ -98,9 +108,8 @@ class BoundingBox {
     }
 
     /**
-     * @function
-     * @name BoundingBox#intersects
-     * @description Test whether two axis-aligned bounding boxes intersect.
+     * Test whether two axis-aligned bounding boxes intersect.
+     *
      * @param {BoundingBox} other - Bounding box to test against.
      * @returns {boolean} True if there is an intersection.
      */
@@ -196,11 +205,11 @@ class BoundingBox {
     }
 
     /**
-     * @function
-     * @name BoundingBox#intersectsRay
-     * @description Test if a ray intersects with the AABB.
+     * Test if a ray intersects with the AABB.
+     *
      * @param {Ray} ray - Ray to test against (direction must be normalized).
-     * @param {Vec3} [point] - If there is an intersection, the intersection point will be copied into here.
+     * @param {Vec3} [point] - If there is an intersection, the intersection point will be copied
+     * into here.
      * @returns {boolean} True if there is an intersection.
      */
     intersectsRay(ray, point) {
@@ -212,10 +221,9 @@ class BoundingBox {
     }
 
     /**
-     * @function
-     * @name BoundingBox#setMinMax
-     * @description Sets the minimum and maximum corner of the AABB.
-     * Using this function is faster than assigning min and max separately.
+     * Sets the minimum and maximum corner of the AABB. Using this function is faster than
+     * assigning min and max separately.
+     *
      * @param {Vec3} min - The minimum corner of the AABB.
      * @param {Vec3} max - The maximum corner of the AABB.
      */
@@ -225,9 +233,8 @@ class BoundingBox {
     }
 
     /**
-     * @function
-     * @name BoundingBox#getMin
-     * @description Return the minimum corner of the AABB.
+     * Return the minimum corner of the AABB.
+     *
      * @returns {Vec3} Minimum corner.
      */
     getMin() {
@@ -235,9 +242,8 @@ class BoundingBox {
     }
 
     /**
-     * @function
-     * @name BoundingBox#getMax
-     * @description Return the maximum corner of the AABB.
+     * Return the maximum corner of the AABB.
+     *
      * @returns {Vec3} Maximum corner.
      */
     getMax() {
@@ -245,9 +251,8 @@ class BoundingBox {
     }
 
     /**
-     * @function
-     * @name BoundingBox#containsPoint
-     * @description Test if a point is inside a AABB.
+     * Test if a point is inside a AABB.
+     *
      * @param {Vec3} point - Point to test.
      * @returns {boolean} True if the point is inside the AABB and false otherwise.
      */
@@ -265,10 +270,9 @@ class BoundingBox {
     }
 
     /**
-     * @function
-     * @name BoundingBox#setFromTransformedAabb
-     * @description Set an AABB to enclose the specified AABB if it were to be
-     * transformed by the specified 4x4 matrix.
+     * Set an AABB to enclose the specified AABB if it were to be transformed by the specified 4x4
+     * matrix.
+     *
      * @param {BoundingBox} aabb - Box to transform and enclose.
      * @param {Mat4} m - Transformation matrix to apply to source AABB.
      */
@@ -301,11 +305,12 @@ class BoundingBox {
     }
 
     /**
-     * @function
-     * @name BoundingBox#compute
-     * @description Compute the size of the AABB to encapsulate all specified vertices.
-     * @param {number[]|Float32Array} vertices - The vertices used to compute the new size for the AABB.
-     * @param {number} [numVerts] - Number of vertices to use from the beginning of vertices array. All vertices are used if not specified.
+     * Compute the size of the AABB to encapsulate all specified vertices.
+     *
+     * @param {number[]|Float32Array} vertices - The vertices used to compute the new size for the
+     * AABB.
+     * @param {number} [numVerts] - Number of vertices to use from the beginning of vertices array.
+     * All vertices are used if not specified.
      */
     compute(vertices, numVerts) {
         numVerts = numVerts === undefined ? vertices.length / 3 : numVerts;
@@ -330,11 +335,11 @@ class BoundingBox {
     }
 
     /**
-     * @function
-     * @name BoundingBox#intersectsBoundingSphere
-     * @description Test if a Bounding Sphere is overlapping, enveloping, or inside this AABB.
+     * Test if a Bounding Sphere is overlapping, enveloping, or inside this AABB.
+     *
      * @param {BoundingSphere} sphere - Bounding Sphere to test.
-     * @returns {boolean} True if the Bounding Sphere is overlapping, enveloping, or inside the AABB and false otherwise.
+     * @returns {boolean} True if the Bounding Sphere is overlapping, enveloping, or inside the
+     * AABB and false otherwise.
      */
     intersectsBoundingSphere(sphere) {
         const sq = this._distanceToBoundingSphereSq(sphere);

--- a/src/shape/bounding-box.js
+++ b/src/shape/bounding-box.js
@@ -28,7 +28,8 @@ class BoundingBox {
      * Create a new axis-aligned bounding box.
      *
      * @param {Vec3} [center] - Center of box. The constructor takes a reference of this parameter.
-     * @param {Vec3} [halfExtents] - Half the distance across the box in each axis. The constructor takes a reference of this parameter. Defaults to 0.5 on each axis.
+     * @param {Vec3} [halfExtents] - Half the distance across the box in each axis. The constructor
+     * takes a reference of this parameter. Defaults to 0.5 on each axis.
      */
     constructor(center = new Vec3(), halfExtents = new Vec3(0.5, 0.5, 0.5)) {
         this.center = center;

--- a/src/shape/bounding-sphere.js
+++ b/src/shape/bounding-sphere.js
@@ -4,19 +4,33 @@ const tmpVecA = new Vec3();
 const tmpVecB = new Vec3();
 
 /**
- * @class
- * @name BoundingSphere
- * @classdesc A bounding sphere is a volume for facilitating fast intersection testing.
- * @description Creates a new bounding sphere.
- * @example
- * // Create a new bounding sphere centered on the origin with a radius of 0.5
- * var sphere = new pc.BoundingSphere();
- * @param {Vec3} [center] - The world space coordinate marking the center of the sphere. The constructor takes a reference of this parameter.
- * @param {number} [radius] - The radius of the bounding sphere. Defaults to 0.5.
- * @property {Vec3} center Center of sphere.
- * @property {number} radius The radius of the bounding sphere.
+ * A bounding sphere is a volume for facilitating fast intersection testing.
  */
 class BoundingSphere {
+    /**
+     * Center of sphere.
+     *
+     * @type {Vec3}
+     */
+    center;
+
+    /**
+     * The radius of the bounding sphere.
+     *
+     * @type {number}
+     */
+    radius;
+
+    /**
+     * Creates a new bounding sphere.
+     *
+     * @param {Vec3} [center] - The world space coordinate marking the center of the sphere. The
+     * constructor takes a reference of this parameter.
+     * @param {number} [radius] - The radius of the bounding sphere. Defaults to 0.5.
+     * @example
+     * // Create a new bounding sphere centered on the origin with a radius of 0.5
+     * var sphere = new pc.BoundingSphere();
+     */
     constructor(center = new Vec3(), radius = 0.5) {
         this.center = center;
         this.radius = radius;
@@ -29,11 +43,11 @@ class BoundingSphere {
     }
 
     /**
-     * @function
-     * @name BoundingSphere#intersectsRay
-     * @description Test if a ray intersects with the sphere.
+     * Test if a ray intersects with the sphere.
+     *
      * @param {Ray} ray - Ray to test against (direction must be normalized).
-     * @param {Vec3} [point] - If there is an intersection, the intersection point will be copied into here.
+     * @param {Vec3} [point] - If there is an intersection, the intersection point will be copied
+     * into here.
      * @returns {boolean} True if there is an intersection.
      */
     intersectsRay(ray, point) {
@@ -61,9 +75,8 @@ class BoundingSphere {
     }
 
     /**
-     * @function
-     * @name BoundingSphere#intersectsBoundingSphere
-     * @description Test if a Bounding Sphere is overlapping, enveloping, or inside this Bounding Sphere.
+     * Test if a Bounding Sphere is overlapping, enveloping, or inside this Bounding Sphere.
+     *
      * @param {BoundingSphere} sphere - Bounding Sphere to test.
      * @returns {boolean} True if the Bounding Sphere is overlapping, enveloping, or inside this Bounding Sphere and false otherwise.
      */

--- a/src/shape/frustum.js
+++ b/src/shape/frustum.js
@@ -4,16 +4,17 @@ import { PROJECTION_PERSPECTIVE } from '../scene/constants.js';
 const _frustumPoints = [new Vec3(), new Vec3(), new Vec3(), new Vec3(), new Vec3(), new Vec3(), new Vec3(), new Vec3()];
 
 /**
- * @class
- * @name Frustum
- * @classdesc A frustum is a shape that defines the viewing space of a camera. It can be
- * used to determine visibility of points and bounding spheres. Typically, you would not
- * create a Frustum shape directly, but instead query {@link CameraComponent#frustum}.
- * @description Creates a new frustum shape.
- * @example
- * var frustum = new pc.Frustum();
+ * A frustum is a shape that defines the viewing space of a camera. It can be used to determine
+ * visibility of points and bounding spheres. Typically, you would not create a Frustum shape
+ * directly, but instead query {@link CameraComponent#frustum}.
  */
 class Frustum {
+    /**
+     * Creates a new frustum shape.
+     *
+     * @example
+     * var frustum = new pc.Frustum();
+     */
     constructor() {
         this.planes = [];
         for (let i = 0; i < 6; i++)
@@ -21,9 +22,8 @@ class Frustum {
     }
 
     /**
-     * @function
-     * @name Frustum#setFromMat4
-     * @description Updates the frustum shape based on the supplied 4x4 matrix.
+     * Updates the frustum shape based on the supplied 4x4 matrix.
+     *
      * @param {Mat4} matrix - The matrix describing the shape of the frustum.
      * @example
      * // Create a perspective projection matrix
@@ -120,10 +120,9 @@ class Frustum {
     }
 
     /**
-     * @function
-     * @name Frustum#containsPoint
-     * @description Tests whether a point is inside the frustum. Note that points lying in a frustum plane are
+     * Tests whether a point is inside the frustum. Note that points lying in a frustum plane are
      * considered to be outside the frustum.
+     *
      * @param {Vec3} point - The point to test.
      * @returns {boolean} True if the point is inside the frustum, false otherwise.
      */
@@ -139,15 +138,14 @@ class Frustum {
     }
 
     /**
-     * @function
-     * @name Frustum#containsSphere
-     * @description Tests whether a bounding sphere intersects the frustum. If the sphere is outside the frustum,
-     * zero is returned. If the sphere intersects the frustum, 1 is returned. If the sphere is completely inside
-     * the frustum, 2 is returned. Note that a sphere touching a frustum plane from the outside is considered to
-     * be outside the frustum.
+     * Tests whether a bounding sphere intersects the frustum. If the sphere is outside the
+     * frustum, zero is returned. If the sphere intersects the frustum, 1 is returned. If the
+     * sphere is completely inside the frustum, 2 is returned. Note that a sphere touching a
+     * frustum plane from the outside is considered to be outside the frustum.
+     *
      * @param {BoundingSphere} sphere - The sphere to test.
-     * @returns {number} 0 if the bounding sphere is outside the frustum, 1 if it intersects the frustum and 2 if
-     * it is contained by the frustum.
+     * @returns {number} 0 if the bounding sphere is outside the frustum, 1 if it intersects the
+     * frustum and 2 if it is contained by the frustum.
      */
     containsSphere(sphere) {
         let c = 0;

--- a/src/shape/oriented-box.js
+++ b/src/shape/oriented-box.js
@@ -11,15 +11,17 @@ const tmpSphere = new BoundingSphere();
 const tmpMat4 = new Mat4();
 
 /**
- * @class
- * @name OrientedBox
- * @description Create a new oriented box.
- * @classdesc Oriented Box.
- * @property {Mat4} [worldTransform] The world transform of the OBB.
- * @param {Mat4} [worldTransform] - Transform that has the orientation and position of the box. Scale is assumed to be one.
- * @param {Vec3} [halfExtents] - Half the distance across the box in each local axis. The constructor takes a reference of this parameter.
+ * Oriented Box.
  */
 class OrientedBox {
+    /**
+     * Create a new oriented box.
+     *
+     * @param {Mat4} [worldTransform] - Transform that has the orientation and position of the box.
+     * Scale is assumed to be one.
+     * @param {Vec3} [halfExtents] - Half the distance across the box in each local axis. The
+     * constructor takes a reference of this parameter.
+     */
     constructor(worldTransform = new Mat4(), halfExtents = new Vec3(0.5, 0.5, 0.5)) {
         this.halfExtents = halfExtents;
 
@@ -30,11 +32,11 @@ class OrientedBox {
     }
 
     /**
-     * @function
-     * @name OrientedBox#intersectsRay
-     * @description Test if a ray intersects with the OBB.
+     * Test if a ray intersects with the OBB.
+     *
      * @param {Ray} ray - Ray to test against (direction must be normalized).
-     * @param {Vec3} [point] - If there is an intersection, the intersection point will be copied into here.
+     * @param {Vec3} [point] - If there is an intersection, the intersection point will be copied
+     * into here.
      * @returns {boolean} True if there is an intersection.
      */
     intersectsRay(ray, point) {
@@ -51,9 +53,8 @@ class OrientedBox {
     }
 
     /**
-     * @function
-     * @name OrientedBox#containsPoint
-     * @description Test if a point is inside a OBB.
+     * Test if a point is inside a OBB.
+     *
      * @param {Vec3} point - Point to test.
      * @returns {boolean} True if the point is inside the OBB and false otherwise.
      */
@@ -63,11 +64,11 @@ class OrientedBox {
     }
 
     /**
-     * @function
-     * @name OrientedBox#intersectsBoundingSphere
-     * @description Test if a Bounding Sphere is overlapping, enveloping, or inside this OBB.
+     * Test if a Bounding Sphere is overlapping, enveloping, or inside this OBB.
+     *
      * @param {BoundingSphere} sphere - Bounding Sphere to test.
-     * @returns {boolean} True if the Bounding Sphere is overlapping, enveloping or inside this OBB and false otherwise.
+     * @returns {boolean} True if the Bounding Sphere is overlapping, enveloping or inside this OBB
+     * and false otherwise.
      */
     intersectsBoundingSphere(sphere) {
         this._modelTransform.transformPoint(sphere.center, tmpSphere.center);
@@ -80,6 +81,11 @@ class OrientedBox {
         return false;
     }
 
+    /**
+     * The world transform of the OBB.
+     *
+     * @type {Mat4}
+     */
     get worldTransform() {
         return this._worldTransform;
     }

--- a/src/shape/plane.js
+++ b/src/shape/plane.js
@@ -3,29 +3,34 @@ import { Vec3 } from '../math/vec3.js';
 const tmpVecA = new Vec3();
 
 /**
+ * An infinite plane.
+ *
  * @private
- * @class
- * @name Plane
- * @classdesc An infinite plane.
- * @description Create an infinite plane.
- * @param {Vec3} [point] - Point position on the plane. The constructor takes a reference of this parameter.
- * @param {Vec3} [normal] - Normal of the plane. The constructor takes a reference of this parameter.
  */
 class Plane {
+    /**
+     * Create an infinite plane.
+     *
+     * @param {Vec3} [point] - Point position on the plane. The constructor takes a reference of
+     * this parameter.
+     * @param {Vec3} [normal] - Normal of the plane. The constructor takes a reference of this
+     * parameter.
+     * @private
+     */
     constructor(point = new Vec3(), normal = new Vec3(0, 0, 1)) {
         this.normal = normal;
         this.point = point;
     }
 
     /**
-     * @private
-     * @function
-     * @name Plane#intersectsLine
-     * @description Test if the plane intersects between two points.
+     * Test if the plane intersects between two points.
+     *
      * @param {Vec3} start - Start position of line.
      * @param {Vec3} end - End position of line.
-     * @param {Vec3} [point] - If there is an intersection, the intersection point will be copied into here.
+     * @param {Vec3} [point] - If there is an intersection, the intersection point will be copied
+     * into here.
      * @returns {boolean} True if there is an intersection.
+     * @private
      */
     intersectsLine(start, end, point) {
         const d = -this.normal.dot(this.point);
@@ -41,13 +46,13 @@ class Plane {
     }
 
     /**
-     * @private
-     * @function
-     * @name Plane#intersectsRay
-     * @description Test if a ray intersects with the infinite plane.
+     * Test if a ray intersects with the infinite plane.
+     *
      * @param {Ray} ray - Ray to test against (direction must be normalized).
-     * @param {Vec3} [point] - If there is an intersection, the intersection point will be copied into here.
+     * @param {Vec3} [point] - If there is an intersection, the intersection point will be copied
+     * into here.
      * @returns {boolean} True if there is an intersection.
+     * @private
      */
     intersectsRay(ray, point) {
         const pointToOrigin = tmpVecA.sub2(this.point, ray.origin);

--- a/src/shape/ray.js
+++ b/src/shape/ray.js
@@ -1,31 +1,43 @@
 import { Vec3 } from '../math/vec3.js';
 
 /**
- * @class
- * @name Ray
- * @classdesc An infinite ray.
- * @description Creates a new infinite ray starting at a given origin and pointing in a given direction.
- * @example
- * // Create a new ray starting at the position of this entity and pointing down
- * // the entity's negative Z axis
- * var ray = new pc.Ray(this.entity.getPosition(), this.entity.forward);
- * @param {Vec3} [origin] - The starting point of the ray. The constructor takes a reference of this parameter.
- * Defaults to the origin (0, 0, 0).
- * @param {Vec3} [direction] - The direction of the ray. The constructor takes a reference of this parameter.
- * Defaults to a direction down the world negative Z axis (0, 0, -1).
- * @property {Vec3} origin The starting point of the ray.
- * @property {Vec3} direction The direction of the ray.
+ * An infinite ray.
  */
 class Ray {
+    /**
+     * The starting point of the ray.
+     *
+     * @type {Vec3}
+     */
+    origin;
+
+    /**
+     * The direction of the ray.
+     *
+     * @type {Vec3}
+     */
+    direction;
+
+    /**
+     * Creates a new infinite ray starting at a given origin and pointing in a given direction.
+     *
+     * @param {Vec3} [origin] - The starting point of the ray. The constructor takes a reference of
+     * this parameter. Defaults to the origin (0, 0, 0).
+     * @param {Vec3} [direction] - The direction of the ray. The constructor takes a reference of
+     * this parameter. Defaults to a direction down the world negative Z axis (0, 0, -1).
+     * @example
+     * // Create a new ray starting at the position of this entity and pointing down
+     * // the entity's negative Z axis
+     * var ray = new pc.Ray(this.entity.getPosition(), this.entity.forward);
+     */
     constructor(origin = new Vec3(), direction = new Vec3(0, 0, -1)) {
         this.origin = origin;
         this.direction = direction;
     }
 
     /**
-     * @function
-     * @name Ray#set
-     * @description Sets origin and direction to the supplied vector values.
+     * Sets origin and direction to the supplied vector values.
+     *
      * @param {Vec3} origin - The starting point of the ray.
      * @param {Vec3} direction - The direction of the ray.
      * @returns {Ray} Self for chaining.


### PR DESCRIPTION
When the engine's JSDoc comments were originally written, the code was 100% ES5. Now we have migrated to ES6 classes. JSDoc makes recommendations for documenting ES6 classes:

https://jsdoc.app/howto-es2015-classes.html

This PR updates the core, math and shape APIs to this format. JSDoc is smart enough to deduce many tags from the code without having to specify them explicitly in the JSDoc comment blocks. For example: `name`, `function` and `static`. You also do not have to explicitly include the `description` and `classdesc` tags. You mainly just need the type information, which can be used to generate the Typescript definitions and helps VS Code point out code errors.

Each ES6 class now has a JSDoc comment before it which is interpreted as the `classdesc` (class description/overview). We can now more easily expand on these overview sections and write more useful docs.

The only code change introduced here is the use of field declarations:

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes#field_declarations

For example, see `Color#r` etc.

One final thing: I have limited columns in all updated source to 100. I think this makes the docs (and code) more readable.

I have verified that both the generated API reference manual and the Typescript definitions are still valid/unchanged.

Once this update is agreed upon, we can roll it out to the rest of the sourcebase.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
