### PR TITLE
[AnimComponent] AnimStateGraph asset change fix

### DIFF
--- a/src/framework/components/anim/component-layer.js
+++ b/src/framework/components/anim/component-layer.js
@@ -20,6 +20,7 @@ class AnimComponentLayer {
         this._component = component;
         this._weight = weight;
         this._blendType = blendType;
+        this._mask = null;
     }
 
     /**
@@ -82,6 +83,11 @@ class AnimComponentLayer {
         if (this._controller.assignMask(mask)) {
             this._component.rebind();
         }
+        this._mask = mask;
+    }
+
+    get mask() {
+        return this._mask;
     }
 
     /**

--- a/src/framework/components/anim/component.js
+++ b/src/framework/components/anim/component.js
@@ -96,8 +96,20 @@ class AnimComponent extends Component {
     }
 
     _onStateGraphAssetChangeEvent(asset) {
+        // both animationAssets and layer masks should be maintained when switching AnimStateGraph assets
+        const prevAnimationAssets = this.animationAssets;
+        const prevMasks = this.layers.map((layer) => layer.mask);
+        // clear the previous state graph
+        this.removeStateGraph();
+        // load the new state graph
         this._stateGraph = new AnimStateGraph(asset._data);
         this.loadStateGraph(this._stateGraph);
+        // assign the previous animation assets
+        this.animationAssets = prevAnimationAssets;
+        this.loadAnimationAssets();
+        // assign the previous layer masks then rebind all anim targets
+        this.layers.forEach((layer, i) => layer.assignMask(prevMasks[i]));
+        this.rebind();
     }
 
     get animationAssets() {

--- a/src/framework/components/anim/component.js
+++ b/src/framework/components/anim/component.js
@@ -98,7 +98,7 @@ class AnimComponent extends Component {
     _onStateGraphAssetChangeEvent(asset) {
         // both animationAssets and layer masks should be maintained when switching AnimStateGraph assets
         const prevAnimationAssets = this.animationAssets;
-        const prevMasks = this.layers.map((layer) => layer.mask);
+        const prevMasks = this.layers.map(layer => layer.mask);
         // clear the previous state graph
         this.removeStateGraph();
         // load the new state graph


### PR DESCRIPTION
Currently when an AnimStateGraph asset is modified, any anim components which reference that asset are not correctly reinitialised. Changes in this PR ensure those anim components preserve any previous properties which are unrelated to the changing state graph asset and rebinds all animation targets.

This PR fixes the editor issue: https://github.com/playcanvas/editor/issues/599

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
