### PR TITLE
Follow camera lerp function is framerate independent

### DIFF
--- a/scripts/camera/follow-camera.js
+++ b/scripts/camera/follow-camera.js
@@ -15,7 +15,7 @@ FollowCamera.attributes.add('lerpAmount', {
     type: 'number',
     min: 0,
     max: 1,
-    default: 0.1,
+    default: 0.99,
     title: 'Lerp Amount',
     description: 'The amount to lerp the camera towards its desired position every frame based on a 60fps frame rate. Lerping is frame rate independent though and will be correct for other frame rates.'
 });
@@ -57,7 +57,8 @@ FollowCamera.prototype.postUpdate = function (dt) {
 
         // Lerp the current camera position to where we want it to be
         // Note that the lerping is framerate independent
-        this.currentPos.lerp(this.currentPos, this.targetPos, this.lerpAmount * dt * 60);
+        // From: https://www.rorydriscoll.com/2016/03/07/frame-rate-independent-damping-using-lerp/
+        this.currentPos.lerp(this.currentPos, this.targetPos, 1 - Math.pow(1 - this.lerpAmount, dt));
 
         // Set the camera's position
         this.entity.setPosition(this.currentPos);


### PR DESCRIPTION
The old code was effectively doing:

x * dt * 60

Where dt is commonly 1/60 which results to x

However, if the frame rate lower than 60, it starts scaling the lerpAmount to go beyond 1 and cause issues.

Fixes https://forum.playcanvas.com/t/camera-shake-problem/22801

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
