### PR TITLE
Examples browser iOS 11 fix

### DIFF
--- a/examples/src/app/control-panel.tsx
+++ b/examples/src/app/control-panel.tsx
@@ -54,9 +54,12 @@ const ControlPanel = (props: any) => {
 
     useEffect(() => {
         if (window.top.innerWidth < 601) {
-            const controls = document.getElementById('controlPanel-controls');
             // @ts-ignore
-            controls.ui.hidden = true;
+            document.getElementById('controlPanel-controls').ui.hidden = true;
+        }
+        if (window.top.location.hash.indexOf('#/iframe') === 0) {
+            // @ts-ignore
+            document.getElementById('controlPanel').ui.hidden = true;
         }
     });
 

--- a/examples/src/app/example-iframe.tsx
+++ b/examples/src/app/example-iframe.tsx
@@ -14,6 +14,8 @@ import * as pcx from 'playcanvas/build/playcanvas-extras.js';
 // @ts-ignore: library file import
 import * as Babel from '@babel/standalone';
 // @ts-ignore: library file import
+import ResizeObserver from 'resize-observer-polyfill/dist/ResizeObserver.global.js';
+// @ts-ignore: library file import
 import { Observer } from '@playcanvas/observer';
 import * as javascriptErrorOverlay from '../../lib/javascriptErrorOverlay';
 import { File } from './helpers/types';

--- a/examples/src/app/helpers/raw-file-loading.ts
+++ b/examples/src/app/helpers/raw-file-loading.ts
@@ -100,16 +100,18 @@ export const examples = (() => {
                 })
                 .join('');
 
-            functionText = Babel.transform(functionText, { retainLines: true, filename: `transformedScript.tsx`, presets: ["typescript"] }).code;
-            functionText = format(functionText, { parser: parse, tabWidth: 4 });
+            if (!/Mobi/.test(navigator.userAgent)) {
+                functionText = Babel.transform(functionText, { retainLines: true, filename: `transformedScript.tsx`, presets: ["typescript"] }).code;
+                functionText = format(functionText, { parser: parse, tabWidth: 4 });
+                files.unshift(
+                    {
+                        name: 'example.js',
+                        text: functionText,
+                        type: 'javascript'
+                    }
+                );
+            }
 
-            files.unshift(
-                {
-                    name: 'example.js',
-                    text: functionText,
-                    type: 'javascript'
-                }
-            );
             // @ts-ignore
             if (example.load) {
                 // @ts-ignore

--- a/examples/src/app/styles.css
+++ b/examples/src/app/styles.css
@@ -371,8 +371,7 @@ body {
 }
 #controlPanel.mobile > .pcui-panel-content > section {
     border-radius: 6px;
-    height: calc(100% - 32px) !important;
-    position: fixed !important;
+    position: absolute !important;
 }
 /* } */
 

--- a/examples/src/examples/graphics/grab-pass.tsx
+++ b/examples/src/examples/graphics/grab-pass.tsx
@@ -161,7 +161,7 @@ class GrabPassExample extends Example {
         glass.render.castShadows = false;
         glass.render.receiveShadows = false;
 
-        // create shader using vertex and fragment shaders
+        // @ts-ignore create shader using vertex and fragment shaders
         const webgl2def = (app.graphicsDevice.webgl2) ? "#define GL2\n" : "";
         const shaderDefinition = {
             attributes: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3923,6 +3923,12 @@
         "lodash": "^4.17.14"
       }
     },
+    "resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==",
+      "dev": true
+    },
     "resolve": {
       "version": "1.20.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "karma-mocha": "2.0.1",
     "karma-spec-reporter": "0.0.32",
     "mocha": "^9.1.3",
+    "resize-observer-polyfill": "^1.5.1",
     "rollup": "^2.59.0",
     "rollup-plugin-jscc": "2.0.0",
     "rollup-plugin-terser": "7.0.2",


### PR DESCRIPTION
The examples browser wasn't loading on iOS 11 due to ResizeObserver not being available. This PR includes a polyfill for it and makes some further adjustments to improve the mobile experience:
- Disables code formatting on mobile devices as this is unused and can cause breakages on older devices.
- Hides the code panel in fullscreen iframe mode on mobile.
- Fixes the code viewer styling on mobile to ensure text doesn't flow off screen.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
