### PR TITLE
Small tweaks to clusered lighting to improve compatibility and performance

### DIFF
--- a/examples/src/examples/graphics/clustered-omni-shadows.tsx
+++ b/examples/src/examples/graphics/clustered-omni-shadows.tsx
@@ -47,7 +47,7 @@ class ClusteredShadowsOmniExample extends Example {
         // @ts-ignore engine-tsd
         app.scene.layers.clusteredLightingShadowsEnabled = true;
 
-        // enable clustered cookies (it's enabled by default as well)
+        // enable clustered cookies
         // @ts-ignore engine-tsd
         app.scene.layers.clusteredLightingCookiesEnabled = true;
 

--- a/examples/src/examples/graphics/clustered-spot-shadows.tsx
+++ b/examples/src/examples/graphics/clustered-spot-shadows.tsx
@@ -35,6 +35,10 @@ class ClusteredSpotShadowsExample extends Example {
         // @ts-ignore engine-tsd
         app.scene.layers.clusteredLightingMaxLights = 80;
 
+        // enable clustered cookies
+        // @ts-ignore engine-tsd
+        app.scene.layers.clusteredLightingCookiesEnabled = true;
+
         // Set the canvas to fill the window and automatically change resolution to be the same as the canvas size
         app.setCanvasFillMode(pc.FILLMODE_FILL_WINDOW);
         app.setCanvasResolution(pc.RESOLUTION_AUTO);

--- a/src/graphics/graphics-device.js
+++ b/src/graphics/graphics-device.js
@@ -912,6 +912,10 @@ class GraphicsDevice extends EventHandler {
 
         this.samples = gl.getParameter(gl.SAMPLES);
         this.maxSamples = this.webgl2 ? gl.getParameter(gl.MAX_SAMPLES) : 1;
+
+        // Don't allow area lights on old android devices, they often fail to compile the shader,
+        // run it incorrectly or are very slow.
+        this.supportsAreaLights = this.webgl2 || !platform.android;
     }
 
     initializeRenderState() {

--- a/src/graphics/program-lib/chunks/clusteredLight.frag
+++ b/src/graphics/program-lib/chunks/clusteredLight.frag
@@ -491,13 +491,6 @@ void evaluateClusterLight(float lightIndex) {
     evaluateLight(clusterLightData);
 }
 
-const vec4 channelSelector[4] = vec4[4] (
-    vec4(1., 0., 0., 0.),
-    vec4(0., 1., 0., 0.),
-    vec4(0., 0., 1., 0.),
-    vec4(0., 0., 0., 1.)
-);
-
 void addClusteredLights() {
     // world space position to 3d integer cell cordinates in the cluster structure
     vec3 cellCoords = floor((vPositionW - clusterBoundsMin) * clusterCellsCountByBoundsSize);
@@ -522,7 +515,12 @@ void addClusteredLights() {
 
             // evaluate up to 4 lights. This is written using a loop instead of manually unrolling to keep shader compile time smaller
             for (int i = 0; i < 4; i++) {
-                float index = dot(channelSelector[i], indices);
+                
+                float index = indices.x;
+                if (i == 1) index = indices.y;
+                else if (i == 2) index = indices.z;
+                else if (i == 3) index = indices.w;
+
                 if (index <= 0.0)
                     return;
 

--- a/src/scene/composition/layer-composition.js
+++ b/src/scene/composition/layer-composition.js
@@ -100,9 +100,9 @@ class LayerComposition extends EventHandler {
         // clustered lighting parameters
         this._clusteredLightingCells = new Vec3(10, 3, 10);
         this._clusteredLightingMaxLights = 64;
-        this._clusteredLightingCookiesEnabled = true;
+        this._clusteredLightingCookiesEnabled = false;
         this._clusteredLightingShadowsEnabled = true;
-        this._clusteredLightingAreaLightsEnabled = true;
+        this._clusteredLightingAreaLightsEnabled = false;
     }
 
     destroy() {

--- a/src/scene/materials/standard-material-options-builder.js
+++ b/src/scene/materials/standard-material-options-builder.js
@@ -44,7 +44,7 @@ class StandardMaterialOptionsBuilder {
     updateRef(options, device, scene, stdMat, objDefs, staticLightList, pass, sortedLights, prefilteredCubeMap128) {
         this._updateSharedOptions(options, stdMat, objDefs, pass);
         options.useTexCubeLod = device.useTexCubeLod;
-        this._updateEnvOptions(options, stdMat, scene, prefilteredCubeMap128);
+        this._updateEnvOptions(options, device, stdMat, scene, prefilteredCubeMap128);
         this._updateMaterialOptions(options, stdMat);
         if (pass === SHADER_FORWARDHDR) {
             if (options.gamma) options.gamma = GAMMA_SRGBHDR;
@@ -167,7 +167,7 @@ class StandardMaterialOptionsBuilder {
         options.clearCoatGlossTint = (stdMat.clearCoatGlossiness !== 1.0) ? 1 : 0;
     }
 
-    _updateEnvOptions(options, stdMat, scene, prefilteredCubeMap128) {
+    _updateEnvOptions(options, device, stdMat, scene, prefilteredCubeMap128) {
         const rgbmAmbient = (prefilteredCubeMap128 && prefilteredCubeMap128.type === TEXTURETYPE_RGBM) ||
             (stdMat.cubeMap && stdMat.cubeMap.type === TEXTURETYPE_RGBM) ||
             (stdMat.dpAtlas && stdMat.dpAtlas.type === TEXTURETYPE_RGBM);
@@ -211,7 +211,7 @@ class StandardMaterialOptionsBuilder {
         if (LayerComposition.clusteredLightingEnabled && scene.layers) {
             options.clusteredLightingCookiesEnabled = scene.layers.clusteredLightingCookiesEnabled;
             options.clusteredLightingShadowsEnabled = scene.layers.clusteredLightingShadowsEnabled;
-            options.clusteredLightingAreaLightsEnabled = scene.layers.clusteredLightingAreaLightsEnabled;
+            options.clusteredLightingAreaLightsEnabled = scene.layers.clusteredLightingAreaLightsEnabled && device.supportsAreaLights;
         }
     }
 


### PR DESCRIPTION
- updating cluster fragment code to GL ES 2.0 to compile on all devices (no const arrays)
- defaulting clustered area lights and cookies to false to improve compile and runtime cost across devices
- disabling clustered area lights on webgl1 android devices due to their poor performance / ability to compile and run at all