### PR TITLE
Clustered lighting honors MeshInstance.noShadow

### DIFF
--- a/src/graphics/program-lib/programs/standard.js
+++ b/src/graphics/program-lib/programs/standard.js
@@ -1447,7 +1447,7 @@ const standard = {
 
             if (options.clusteredLightingCookiesEnabled)
                 code += "\n#define CLUSTER_COOKIES";
-            if (options.clusteredLightingShadowsEnabled)
+            if (options.clusteredLightingShadowsEnabled && !options.noShadow)
                 code += "\n#define CLUSTER_SHADOWS";
             if (options.clusteredLightingAreaLightsEnabled)
                 code += "\n#define CLUSTER_AREALIGHTS";


### PR DESCRIPTION
- receiveShadows property on Render and Model components is used by clustered lighting