### PR TITLE
Update to msdf font rendering shader to lower the smoothing

### DIFF
--- a/src/graphics/program-lib/chunks/msdf.frag
+++ b/src/graphics/program-lib/chunks/msdf.frag
@@ -34,16 +34,20 @@ vec4 applyMsdf(vec4 color) {
     float sigDist = median(tsample.r, tsample.g, tsample.b);
     float sigDistShdw = median(ssample.r, ssample.g, ssample.b);
 
+    // smoothing limit - smaller value makes for sharper but more aliased text, especially on angles
+    // too large value (0.5) creates a dark glow around the letters
+    float smoothingMax = 0.2;
+
     #ifdef USE_FWIDTH
     // smoothing depends on size of texture on screen
     vec2 w = fwidth(vUv0);
-    float smoothing = clamp(w.x * font_textureWidth / font_pxrange, 0.0, 0.5);
+    float smoothing = clamp(w.x * font_textureWidth / font_pxrange, 0.0, smoothingMax);
     #else
     float font_size = 16.0; // TODO fix this
     // smoothing gets smaller as the font size gets bigger
     // don't have fwidth we can approximate from font size, this doesn't account for scaling
     // so a big font scaled down will be wrong...
-    float smoothing = clamp(font_pxrange / font_size, 0.0, 0.5);
+    float smoothing = clamp(font_pxrange / font_size, 0.0, smoothingMax);
     #endif
 
     float mapMin = 0.05;


### PR DESCRIPTION
Fixes https://github.com/playcanvas/engine/issues/3087
Fixes https://github.com/playcanvas/engine/issues/3477

The lowering of the smoothing has an effect of slightly sharper / more aliased text, but removes the dark blur around the edges in the distance / at sharp angles.

Images after:
![Screenshot 2021-11-16 at 13 02 50](https://user-images.githubusercontent.com/59932779/141997306-6fabac5a-d676-498a-8706-98bb55bc0926.png)
![Screenshot 2021-11-16 at 13 02 33](https://user-images.githubusercontent.com/59932779/141997311-812016e8-8e38-462c-9626-f1fec52e5838.png)
![Screenshot 2021-11-16 at 13 58 10](https://user-images.githubusercontent.com/59932779/141998752-76bf1ab1-7f3c-486a-9cec-7cf3d3c596dd.png)

Note that this does not improve / change the readability of the text when very small .. this is disadvantage of msdf technology. 
