### PR TITLE
Area light optimization - shared functionality is executed one time for all lights

### DIFF
--- a/src/graphics/program-lib/chunks/clusteredLight.frag
+++ b/src/graphics/program-lib/chunks/clusteredLight.frag
@@ -26,6 +26,9 @@ uniform vec3 clusterCellsMax;
 uniform vec2 clusterCompressionLimit0;
 uniform vec2 shadowAtlasParams;
 
+// global variable to limit shared area light values to be evaluated only one time
+float LTCLightValuesEvaluated = 0.0;
+
 // structure storing light properties of a clustered light
 struct ClusterLightData {
 
@@ -269,6 +272,12 @@ void evaluateLight(ClusterLightData light) {
 
         // area lights
         decodeClusterLightAreaData(light);
+
+        // evaluate material based area lights data, shared by all area lights
+        if (LTCLightValuesEvaluated < 0.5) {
+            LTCLightValuesEvaluated = 1.0;
+            calcLTCLightValues();
+        }
 
         // handle light shape
         if (isClusteredLightRect(light)) {

--- a/src/graphics/program-lib/chunks/ltc.frag
+++ b/src/graphics/program-lib/chunks/ltc.frag
@@ -156,7 +156,6 @@ void calcLTCLightValues()
 void calcRectLightValues(vec3 lightPos, vec3 halfWidth, vec3 halfHeight)
 {
 	dLTCCoords = getLTCLightCoords(lightPos, halfWidth, halfHeight);
-	calcLTCLightValues();
 }
 void calcDiskLightValues(vec3 lightPos, vec3 halfWidth, vec3 halfHeight)
 {
@@ -165,7 +164,6 @@ void calcDiskLightValues(vec3 lightPos, vec3 halfWidth, vec3 halfHeight)
 void calcSphereLightValues(vec3 lightPos, vec3 halfWidth, vec3 halfHeight)
 {
 	dLTCCoords = getSphereLightCoords(lightPos, halfWidth, halfHeight);
-	calcLTCLightValues();
 }
 
 // An extended version of the implementation from

--- a/src/graphics/program-lib/programs/standard.js
+++ b/src/graphics/program-lib/programs/standard.js
@@ -1591,6 +1591,9 @@ const standard = {
                 code += "   dSpecularLight *= dSpecularity;\n";
 
                 code += "   float roughness = max((1.0 - dGlossiness) * (1.0 - dGlossiness), 0.001);\n";
+
+                // evaluate material based area lights data, shared by all area lights
+                code += "   calcLTCLightValues();\n";
             }
 
             // light source shape support


### PR DESCRIPTION
Fixes https://github.com/playcanvas/engine/issues/2957 - the remaining issue

- done for both clustered and normal lights