### PR TITLE
[Fix] Fix to sphere area light specular reflection

### DIFF
--- a/src/graphics/program-lib/chunks/ltc.frag
+++ b/src/graphics/program-lib/chunks/ltc.frag
@@ -3,108 +3,108 @@
 // code: https://github.com/selfshadow/ltc_code/
 
 mat3 transposeMat3( const in mat3 m ) {
-	mat3 tmp;
-	tmp[ 0 ] = vec3( m[ 0 ].x, m[ 1 ].x, m[ 2 ].x );
-	tmp[ 1 ] = vec3( m[ 0 ].y, m[ 1 ].y, m[ 2 ].y );
-	tmp[ 2 ] = vec3( m[ 0 ].z, m[ 1 ].z, m[ 2 ].z );
-	return tmp;
+    mat3 tmp;
+    tmp[ 0 ] = vec3( m[ 0 ].x, m[ 1 ].x, m[ 2 ].x );
+    tmp[ 1 ] = vec3( m[ 0 ].y, m[ 1 ].y, m[ 2 ].y );
+    tmp[ 2 ] = vec3( m[ 0 ].z, m[ 1 ].z, m[ 2 ].z );
+    return tmp;
 }
 
 vec2 LTC_Uv( const in vec3 N, const in vec3 V, const in float roughness ) {
-	const float LUT_SIZE = 64.0;
-	const float LUT_SCALE = ( LUT_SIZE - 1.0 ) / LUT_SIZE;
-	const float LUT_BIAS = 0.5 / LUT_SIZE;
-	float dotNV = saturate( dot( N, V ) );
-	// texture parameterized by sqrt( GGX alpha ) and sqrt( 1 - cos( theta ) )
-	vec2 uv = vec2( roughness, sqrt( 1.0 - dotNV ) );
-	uv = uv * LUT_SCALE + LUT_BIAS;
-	return uv;
+    const float LUT_SIZE = 64.0;
+    const float LUT_SCALE = ( LUT_SIZE - 1.0 ) / LUT_SIZE;
+    const float LUT_BIAS = 0.5 / LUT_SIZE;
+    float dotNV = saturate( dot( N, V ) );
+    // texture parameterized by sqrt( GGX alpha ) and sqrt( 1 - cos( theta ) )
+    vec2 uv = vec2( roughness, sqrt( 1.0 - dotNV ) );
+    uv = uv * LUT_SCALE + LUT_BIAS;
+    return uv;
 }
 
 float LTC_ClippedSphereFormFactor( const in vec3 f ) {
-	// Real-Time Area Lighting: a Journey from Research to Production (p.102)
-	// An approximation of the form factor of a horizon-clipped rectangle.
-	float l = length( f );
-	return max( ( l * l + f.z ) / ( l + 1.0 ), 0.0 );
+    // Real-Time Area Lighting: a Journey from Research to Production (p.102)
+    // An approximation of the form factor of a horizon-clipped rectangle.
+    float l = length( f );
+    return max( ( l * l + f.z ) / ( l + 1.0 ), 0.0 );
 }
 
 vec3 LTC_EdgeVectorFormFactor( const in vec3 v1, const in vec3 v2 ) {
-	float x = dot( v1, v2 );
-	float y = abs( x );
-	// rational polynomial approximation to theta / sin( theta ) / 2PI
-	float a = 0.8543985 + ( 0.4965155 + 0.0145206 * y ) * y;
-	float b = 3.4175940 + ( 4.1616724 + y ) * y;
-	float v = a / b;
-	float theta_sintheta = ( x > 0.0 ) ? v : 0.5 * inversesqrt( max( 1.0 - x * x, 1e-7 ) ) - v;
-	return cross( v1, v2 ) * theta_sintheta;
+    float x = dot( v1, v2 );
+    float y = abs( x );
+    // rational polynomial approximation to theta / sin( theta ) / 2PI
+    float a = 0.8543985 + ( 0.4965155 + 0.0145206 * y ) * y;
+    float b = 3.4175940 + ( 4.1616724 + y ) * y;
+    float v = a / b;
+    float theta_sintheta = ( x > 0.0 ) ? v : 0.5 * inversesqrt( max( 1.0 - x * x, 1e-7 ) ) - v;
+    return cross( v1, v2 ) * theta_sintheta;
 }
 
 struct Coords {
-	vec3 coord0;
-	vec3 coord1;
-	vec3 coord2;
-	vec3 coord3;
+    vec3 coord0;
+    vec3 coord1;
+    vec3 coord2;
+    vec3 coord3;
 };
 
 float LTC_EvaluateRect( const in vec3 N, const in vec3 V, const in vec3 P, const in mat3 mInv, const in Coords rectCoords) {
-	// bail if point is on back side of plane of light
-	// assumes ccw winding order of light vertices
-	vec3 v1 = rectCoords.coord1 - rectCoords.coord0;
-	vec3 v2 = rectCoords.coord3 - rectCoords.coord0;
-	
-	vec3 lightNormal = cross( v1, v2 );
-	// if( dot( lightNormal, P - rectCoords.coord0 ) < 0.0 ) return 0.0;	
-	float factor = sign(-dot( lightNormal, P - rectCoords.coord0 ));
+    // bail if point is on back side of plane of light
+    // assumes ccw winding order of light vertices
+    vec3 v1 = rectCoords.coord1 - rectCoords.coord0;
+    vec3 v2 = rectCoords.coord3 - rectCoords.coord0;
+    
+    vec3 lightNormal = cross( v1, v2 );
+    // if( dot( lightNormal, P - rectCoords.coord0 ) < 0.0 ) return 0.0;	
+    float factor = sign(-dot( lightNormal, P - rectCoords.coord0 ));
 
-	// construct orthonormal basis around N
-	vec3 T1, T2;
-	T1 = normalize( V - N * dot( V, N ) );
-	T2 =  factor * cross( N, T1 ); // negated from paper; possibly due to a different handedness of world coordinate system
-	// compute transform
-	mat3 mat = mInv * transposeMat3( mat3( T1, T2, N ) );
-	// transform rect
-	vec3 coords[ 4 ];
-	coords[ 0 ] = mat * ( rectCoords.coord0 - P );
-	coords[ 1 ] = mat * ( rectCoords.coord1 - P );
-	coords[ 2 ] = mat * ( rectCoords.coord2 - P );
-	coords[ 3 ] = mat * ( rectCoords.coord3 - P );
-	// project rect onto sphere
-	coords[ 0 ] = normalize( coords[ 0 ] );
-	coords[ 1 ] = normalize( coords[ 1 ] );
-	coords[ 2 ] = normalize( coords[ 2 ] );
-	coords[ 3 ] = normalize( coords[ 3 ] );
-	// calculate vector form factor
-	vec3 vectorFormFactor = vec3( 0.0 );
-	vectorFormFactor += LTC_EdgeVectorFormFactor( coords[ 0 ], coords[ 1 ] );
-	vectorFormFactor += LTC_EdgeVectorFormFactor( coords[ 1 ], coords[ 2 ] );
-	vectorFormFactor += LTC_EdgeVectorFormFactor( coords[ 2 ], coords[ 3 ] );
-	vectorFormFactor += LTC_EdgeVectorFormFactor( coords[ 3 ], coords[ 0 ] );
-	// adjust for horizon clipping
-	float result = LTC_ClippedSphereFormFactor( vectorFormFactor );
+    // construct orthonormal basis around N
+    vec3 T1, T2;
+    T1 = normalize( V - N * dot( V, N ) );
+    T2 =  factor * cross( N, T1 ); // negated from paper; possibly due to a different handedness of world coordinate system
+    // compute transform
+    mat3 mat = mInv * transposeMat3( mat3( T1, T2, N ) );
+    // transform rect
+    vec3 coords[ 4 ];
+    coords[ 0 ] = mat * ( rectCoords.coord0 - P );
+    coords[ 1 ] = mat * ( rectCoords.coord1 - P );
+    coords[ 2 ] = mat * ( rectCoords.coord2 - P );
+    coords[ 3 ] = mat * ( rectCoords.coord3 - P );
+    // project rect onto sphere
+    coords[ 0 ] = normalize( coords[ 0 ] );
+    coords[ 1 ] = normalize( coords[ 1 ] );
+    coords[ 2 ] = normalize( coords[ 2 ] );
+    coords[ 3 ] = normalize( coords[ 3 ] );
+    // calculate vector form factor
+    vec3 vectorFormFactor = vec3( 0.0 );
+    vectorFormFactor += LTC_EdgeVectorFormFactor( coords[ 0 ], coords[ 1 ] );
+    vectorFormFactor += LTC_EdgeVectorFormFactor( coords[ 1 ], coords[ 2 ] );
+    vectorFormFactor += LTC_EdgeVectorFormFactor( coords[ 2 ], coords[ 3 ] );
+    vectorFormFactor += LTC_EdgeVectorFormFactor( coords[ 3 ], coords[ 0 ] );
+    // adjust for horizon clipping
+    float result = LTC_ClippedSphereFormFactor( vectorFormFactor );
 
-	return result;
+    return result;
 }
 
 Coords dLTCCoords;
 Coords getLTCLightCoords(vec3 lightPos, vec3 halfWidth, vec3 halfHeight){
-	Coords coords;
-	coords.coord0 = lightPos + halfWidth - halfHeight;
-	coords.coord1 = lightPos - halfWidth - halfHeight;
-	coords.coord2 = lightPos - halfWidth + halfHeight;
-	coords.coord3 = lightPos + halfWidth + halfHeight;
-	return coords;
+    Coords coords;
+    coords.coord0 = lightPos + halfWidth - halfHeight;
+    coords.coord1 = lightPos - halfWidth - halfHeight;
+    coords.coord2 = lightPos - halfWidth + halfHeight;
+    coords.coord3 = lightPos + halfWidth + halfHeight;
+    return coords;
 }
 
 float dSphereRadius;
 Coords getSphereLightCoords(vec3 lightPos, vec3 halfWidth, vec3 halfHeight){
     // used for simple sphere light falloff
     // also, the code only handles a spherical light, it cannot be non-uniformly scaled in world space, and so we enforce it here
-	dSphereRadius = max(length(halfWidth), length(halfHeight));
+    dSphereRadius = max(length(halfWidth), length(halfHeight));
 
     // Billboard the 2d light quad to reflection vector, as it's used for specular. This allows us to use disk math for the sphere.
     vec3 f = reflect(normalize(lightPos - view_position), vNormalW);
-	vec3 w = normalize(cross(f, halfHeight));
-	vec3 h = normalize(cross(f, w));
+    vec3 w = normalize(cross(f, halfHeight));
+    vec3 h = normalize(cross(f, w));
 
     return getLTCLightCoords(lightPos, w * dSphereRadius, h * dSphereRadius);
 }
@@ -116,8 +116,8 @@ vec2 ccLTCUV;
 #endif
 vec2 getLTCLightUV(float tGlossiness, vec3 tNormalW)
 {
-	float roughness = max((1.0 - tGlossiness) * (1.0 - tGlossiness), 0.001);
-	return LTC_Uv( tNormalW, dViewDirW, roughness );
+    float roughness = max((1.0 - tGlossiness) * (1.0 - tGlossiness), 0.001);
+    return LTC_Uv( tNormalW, dViewDirW, roughness );
 }
 
 //used for energy conservation and to modulate specular
@@ -127,38 +127,38 @@ vec3 ccLTCSpecFres;
 #endif
 vec3 getLTCLightSpecFres(vec2 uv, vec3 tSpecularity)
 {
-	vec4 t2 = texture2D( areaLightsLutTex2, uv );
+    vec4 t2 = texture2D( areaLightsLutTex2, uv );
 
-	#ifdef AREA_R8_G8_B8_A8_LUTS
-	t2 *= vec4(0.693103,1,1,1);
-	t2 += vec4(0.306897,0,0,0);
-	#endif
+    #ifdef AREA_R8_G8_B8_A8_LUTS
+    t2 *= vec4(0.693103,1,1,1);
+    t2 += vec4(0.306897,0,0,0);
+    #endif
 
-	return tSpecularity * t2.x + ( vec3( 1.0 ) - tSpecularity) * t2.y;
+    return tSpecularity * t2.x + ( vec3( 1.0 ) - tSpecularity) * t2.y;
 }
 
 void calcLTCLightValues()
 {
-	dLTCUV = getLTCLightUV(dGlossiness, dNormalW);
-	dLTCSpecFres = getLTCLightSpecFres(dLTCUV, dSpecularityNoFres); 
+    dLTCUV = getLTCLightUV(dGlossiness, dNormalW);
+    dLTCSpecFres = getLTCLightSpecFres(dLTCUV, dSpecularityNoFres); 
 
 #ifdef CLEARCOAT
-	ccLTCUV = getLTCLightUV(ccGlossiness, ccNormalW);
-	ccLTCSpecFres = getLTCLightSpecFres(ccLTCUV, vec3(ccSpecularityNoFres));
+    ccLTCUV = getLTCLightUV(ccGlossiness, ccNormalW);
+    ccLTCSpecFres = getLTCLightSpecFres(ccLTCUV, vec3(ccSpecularityNoFres));
 #endif
 }
 
 void calcRectLightValues(vec3 lightPos, vec3 halfWidth, vec3 halfHeight)
 {
-	dLTCCoords = getLTCLightCoords(lightPos, halfWidth, halfHeight);
+    dLTCCoords = getLTCLightCoords(lightPos, halfWidth, halfHeight);
 }
 void calcDiskLightValues(vec3 lightPos, vec3 halfWidth, vec3 halfHeight)
 {
-	calcRectLightValues(lightPos, halfWidth, halfHeight);
+    calcRectLightValues(lightPos, halfWidth, halfHeight);
 }
 void calcSphereLightValues(vec3 lightPos, vec3 halfWidth, vec3 halfHeight)
 {
-	dLTCCoords = getSphereLightCoords(lightPos, halfWidth, halfHeight);
+    dLTCCoords = getSphereLightCoords(lightPos, halfWidth, halfHeight);
 }
 
 // An extended version of the implementation from
@@ -166,7 +166,7 @@ void calcSphereLightValues(vec3 lightPos, vec3 halfWidth, vec3 halfHeight)
 // http://momentsingraphics.de/?p=105
 vec3 SolveCubic(vec4 Coefficient)
 {
-	float pi = 3.14159;
+    float pi = 3.14159;
     // Normalize the polynomial
     Coefficient.xyz /= Coefficient.w;
     // Divide middle coefficients by three
@@ -257,12 +257,12 @@ float LTC_EvaluateDisk(vec3 N, vec3 V, vec3 P, mat3 Minv, Coords points)
 
     // rotate area light in (T1, T2, N) basis
     //mat3 R = transpose(mat3(T1, T2, N));
-	mat3 R = transposeMat3( mat3( T1, T2, N ) );
+    mat3 R = transposeMat3( mat3( T1, T2, N ) );
     // polygon (allocate 5 vertices for clipping)	
-	vec3 L_[ 3 ];
-	L_[ 0 ] = R * ( points.coord0 - P );
-	L_[ 1 ] = R * ( points.coord1 - P );
-	L_[ 2 ] = R * ( points.coord2 - P );
+    vec3 L_[ 3 ];
+    L_[ 0 ] = R * ( points.coord0 - P );
+    L_[ 1 ] = R * ( points.coord1 - P );
+    L_[ 2 ] = R * ( points.coord2 - P );
 
     vec3 Lo_i = vec3(0);
 
@@ -356,53 +356,53 @@ float LTC_EvaluateDisk(vec3 N, vec3 V, vec3 P, mat3 Minv, Coords points)
     float L2 = sqrt(-e2 / e1);
 
     float formFactor = L1 * L2 * inversesqrt((1.0 + L1 * L1) * (1.0 + L2 * L2));
-	
-	const float LUT_SIZE = 64.0;
-	const float LUT_SCALE = ( LUT_SIZE - 1.0 ) / LUT_SIZE;
-	const float LUT_BIAS = 0.5 / LUT_SIZE;
+    
+    const float LUT_SIZE = 64.0;
+    const float LUT_SCALE = ( LUT_SIZE - 1.0 ) / LUT_SIZE;
+    const float LUT_BIAS = 0.5 / LUT_SIZE;
 
     // use tabulated horizon-clipped sphere
     vec2 uv = vec2(avgDir.z * 0.5 + 0.5, formFactor);
     uv = uv*LUT_SCALE + LUT_BIAS;
 
-	float scale = texture2D( areaLightsLutTex2, uv ).w;
+    float scale = texture2D( areaLightsLutTex2, uv ).w;
 
     return formFactor*scale;
 }
 
 float getRectLightDiffuse() {
-	return LTC_EvaluateRect( dNormalW, dViewDirW, vPositionW, mat3( 1.0 ), dLTCCoords );
+    return LTC_EvaluateRect( dNormalW, dViewDirW, vPositionW, mat3( 1.0 ), dLTCCoords );
 }
 
 float getDiskLightDiffuse() {	
-	return LTC_EvaluateDisk( dNormalW, dViewDirW, vPositionW, mat3( 1.0 ), dLTCCoords );
+    return LTC_EvaluateDisk( dNormalW, dViewDirW, vPositionW, mat3( 1.0 ), dLTCCoords );
 }
 
 float getSphereLightDiffuse() {
-	// NB: this could be improved further with distance based wrap lighting
-	float falloff = dSphereRadius / (dot(dLightDirW, dLightDirW) + dSphereRadius);
-	return getLightDiffuse()*falloff;
+    // NB: this could be improved further with distance based wrap lighting
+    float falloff = dSphereRadius / (dot(dLightDirW, dLightDirW) + dSphereRadius);
+    return getLightDiffuse()*falloff;
 }
 
 mat3 getLTCLightInvMat(vec2 uv)
 {
-	vec4 t1 = texture2D( areaLightsLutTex1, uv );
+    vec4 t1 = texture2D( areaLightsLutTex1, uv );
 
-	#ifdef AREA_R8_G8_B8_A8_LUTS
-	t1 *= vec4(1.001, 0.3239, 0.60437568, 1.0);
-	t1 += vec4(0.0, -0.2976, -0.01381, 0.0);
-	#endif
+    #ifdef AREA_R8_G8_B8_A8_LUTS
+    t1 *= vec4(1.001, 0.3239, 0.60437568, 1.0);
+    t1 += vec4(0.0, -0.2976, -0.01381, 0.0);
+    #endif
 
-	return mat3(
-		vec3( t1.x, 0, t1.y ),
-		vec3(    0, 1,    0 ),
-		vec3( t1.z, 0, t1.w )
-	);
+    return mat3(
+        vec3( t1.x, 0, t1.y ),
+        vec3(    0, 1,    0 ),
+        vec3( t1.z, 0, t1.w )
+    );
 }
 
 float calcRectLightSpecular(vec3 tNormalW, vec2 uv) {
-	mat3 mInv = getLTCLightInvMat(uv);
-	return LTC_EvaluateRect( tNormalW, dViewDirW, vPositionW, mInv, dLTCCoords );
+    mat3 mInv = getLTCLightInvMat(uv);
+    return LTC_EvaluateRect( tNormalW, dViewDirW, vPositionW, mInv, dLTCCoords );
 }
 
 float getRectLightSpecular() {
@@ -416,8 +416,8 @@ float getRectLightSpecularCC() {
 #endif
 
 float calcDiskLightSpecular(vec3 tNormalW, vec2 uv) {
-	mat3 mInv = getLTCLightInvMat(uv);
-	return LTC_EvaluateDisk( tNormalW, dViewDirW, vPositionW, mInv, dLTCCoords );
+    mat3 mInv = getLTCLightInvMat(uv);
+    return LTC_EvaluateDisk( tNormalW, dViewDirW, vPositionW, mInv, dLTCCoords );
 }
 
 float getDiskLightSpecular() {

--- a/src/graphics/program-lib/chunks/ltc.frag
+++ b/src/graphics/program-lib/chunks/ltc.frag
@@ -94,24 +94,19 @@ Coords getLTCLightCoords(vec3 lightPos, vec3 halfWidth, vec3 halfHeight){
 	coords.coord3 = lightPos + halfWidth + halfHeight;
 	return coords;
 }
-//used for simple sphere light falloff
+
 float dSphereRadius;
 Coords getSphereLightCoords(vec3 lightPos, vec3 halfWidth, vec3 halfHeight){
-	Coords coords;
-	float radius = max(length(halfWidth), length(halfWidth));
+    // used for simple sphere light falloff
+    // also, the code only handles a spherical light, it cannot be non-uniformly scaled in world space, and so we enforce it here
+	dSphereRadius = max(length(halfWidth), length(halfHeight));
 
-	dSphereRadius = radius;
-
-	vec3 f = normalize(lightPos-view_position);
+    // Billboard the 2d light quad to reflection vector, as it's used for specular. This allows us to use disk math for the sphere.
+    vec3 f = reflect(normalize(lightPos - view_position), vNormalW);
 	vec3 w = normalize(cross(f, halfHeight));
 	vec3 h = normalize(cross(f, w));
 
-	coords.coord0 = lightPos + w * radius - h * radius;
-	coords.coord1 = lightPos - w * radius - h * radius;
-	coords.coord2 = lightPos - w * radius + h * radius;
-	coords.coord3 = lightPos + w * radius + h * radius;
-    
-	return coords;
+    return getLTCLightCoords(lightPos, w * dSphereRadius, h * dSphereRadius);
 }
 
 // used for LTC LUT texture lookup


### PR DESCRIPTION
Fixes https://github.com/playcanvas/engine/issues/3462

The implementation of the sphere specular reflection was done by billboarding the disk's specular reflection to the camera view vector. This was incorrect and needs to be billboarded to the reflection vector instead.