### PR TITLE
Fixed null exception when button component is used with element group

### DIFF
--- a/src/framework/components/button/component.js
+++ b/src/framework/components/button/component.js
@@ -8,6 +8,7 @@ import { EntityReference } from '../../utils/entity-reference.js';
 import { Component } from '../component.js';
 
 import { BUTTON_TRANSITION_MODE_SPRITE_CHANGE, BUTTON_TRANSITION_MODE_TINT } from './constants.js';
+import { ELEMENTTYPE_GROUP } from "../element/constants";
 
 const VisualState = {
     DEFAULT: 'DEFAULT',
@@ -170,11 +171,15 @@ class ButtonComponent extends Component {
     }
 
     _storeDefaultVisualState() {
+        // If the element is of group type, all it's visual properties are null
         if (this._imageReference.hasComponent('element')) {
-            this._storeDefaultColor(this._imageReference.entity.element.color);
-            this._storeDefaultOpacity(this._imageReference.entity.element.opacity);
-            this._storeDefaultSpriteAsset(this._imageReference.entity.element.spriteAsset);
-            this._storeDefaultSpriteFrame(this._imageReference.entity.element.spriteFrame);
+            const element = this._imageReference.entity.element;
+            if (element.type !== ELEMENTTYPE_GROUP) {
+                this._storeDefaultColor(element.color);
+                this._storeDefaultOpacity(element.opacity);
+                this._storeDefaultSpriteAsset(element.spriteAsset);
+                this._storeDefaultSpriteFrame(element.spriteFrame);
+            }
         }
     }
 


### PR DESCRIPTION
Repro project: https://playcanvas.com/editor/scene/1272519

If a button component is used with the element group, it tries to copy the colour property on the element but as it's a group type, it's colour property is null causing an exception.

Exception:
```
launch.js:15178 TypeError: Cannot read properties of null (reading 'r')
    at ButtonComponent._storeDefaultColor (playcanvas.dbg.js:49264)
    at ButtonComponent._storeDefaultVisualState (playcanvas.dbg.js:49253)
    at ButtonComponent._onImageElementGain (playcanvas.dbg.js:49221)
    at EntityReference._callGainOrLoseListener (playcanvas.dbg.js:49024)
    at EntityReference._callAllGainOrLoseListeners (playcanvas.dbg.js:49017)
    at EntityReference._onAfterEntityChange (playcanvas.dbg.js:48992)
    at EntityReference._updateEntityReference (playcanvas.dbg.js:48976)
    at ComponentSystemRegistry.fire (playcanvas.dbg.js:796)
    at Application.start (playcanvas.dbg.js:71297)
    at launch.js:14548
```

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
