### PR TITLE
[Examples Browser] Debug build

### DIFF
--- a/examples/debug/index.js
+++ b/examples/debug/index.js
@@ -1,0 +1,86 @@
+const fs = require("fs");
+const Babel = require("@babel/standalone");
+const Handlebars = require("handlebars");
+
+const MAIN_DIR = `${__dirname}/../`;
+
+const EXAMPLE_CONSTS = [
+    "vshader",
+    "fshader",
+    "fshaderFeedback",
+    "fshaderCloud",
+    "vshaderFeedback",
+    "vshaderCloud"
+];
+
+function retrieveConstString(data, name) {
+    var start = data.indexOf(`const ${name} = `);
+    if (start < 1) return;
+    var end = data.indexOf("`;", start);
+    return data.substring(start + name.length + 10, end);
+}
+
+function loadHtmlTemplate(data) {
+    const html = fs.readFileSync(`${MAIN_DIR}/debug/index.mustache`, "utf8");
+    const template = Handlebars.compile(html);
+    return template(data);
+}
+
+function formatExampleString(exampleString) {
+    exampleString = exampleString
+        .substring(exampleString.indexOf("extends Example {"))
+        .replace("extends Example {", "class Example {");
+    exampleString = exampleString.substring(0, exampleString.indexOf("export default") - 1);
+    exampleString = exampleString.replace(/AssetLoader/g, "div");
+    exampleString = exampleString.replace(/ScriptLoader/g, "div");
+    exampleString = Babel.transform(exampleString, {
+        retainLines: true,
+        filename: `transformedScript.tsx`,
+        presets: ["react", "typescript", "env"]
+    }).code;
+    exampleString = exampleString.replace("example(canvas", "example(app, canvas");
+    exampleString = exampleString.replace("wasmSupported(", "window.wasmSupported(");
+    exampleString = exampleString.replace("loadWasmModuleAsync(", "window.loadWasmModuleAsync(");
+    exampleString = exampleString.replace(/static\//g, '../../static/');
+
+    const indexOfAppCallStart = exampleString.indexOf("var app");
+    const indexOfAppCallEnd =
+        indexOfAppCallStart +
+        exampleString.substring(indexOfAppCallStart, exampleString.length - 1).indexOf(";");
+    const appCall = exampleString.substring(indexOfAppCallStart, indexOfAppCallEnd + 1);
+    exampleString = exampleString.replace(appCall, "");
+    return exampleString;
+}
+
+function buildExample(category, filename) {
+    const exampleString = fs.readFileSync(
+        `${MAIN_DIR}/src/examples/${category}/${filename}`,
+        "utf8"
+    );
+    const exampleConstValues = [];
+    EXAMPLE_CONSTS.forEach((key) => {
+        const value = retrieveConstString(exampleString, key);
+        if (!value) return;
+        exampleConstValues.push({ k: key, v: value });
+    });
+    const formattedExampleString = formatExampleString(exampleString);
+    if (!fs.existsSync(`${MAIN_DIR}/dist/debug/${category}/`)) {
+        fs.mkdirSync(`${MAIN_DIR}/dist/debug/${category}/`);
+    }
+    fs.writeFileSync(`${MAIN_DIR}/dist/debug/${category}/${filename.replace(".tsx", "")}.html`, loadHtmlTemplate({
+        exampleClass: formattedExampleString,
+        exampleConstValues: JSON.stringify(exampleConstValues),
+        enginePath: process.env.ENGINE_PATH || '../../build/playcanvas.dbg.js'
+    }));
+}
+
+if (!fs.existsSync(`${MAIN_DIR}/dist/debug/`)) {
+    fs.mkdirSync(`${MAIN_DIR}/dist/debug/`);
+}
+const categories = fs.readdirSync(`${MAIN_DIR}/src/examples/`);
+categories.forEach(function (category) {
+    const examples = fs.readdirSync(`${MAIN_DIR}/src/examples/${category}`);
+    examples.forEach((example) => {
+        buildExample(category, example);
+    });
+});

--- a/examples/debug/index.js
+++ b/examples/debug/index.js
@@ -14,9 +14,9 @@ const EXAMPLE_CONSTS = [
 ];
 
 function retrieveConstString(data, name) {
-    var start = data.indexOf(`const ${name} = `);
+    const start = data.indexOf(`const ${name} = `);
     if (start < 1) return;
-    var end = data.indexOf("`;", start);
+    const end = data.indexOf("`;", start);
     return data.substring(start + name.length + 10, end);
 }
 

--- a/examples/debug/index.mustache
+++ b/examples/debug/index.mustache
@@ -1,0 +1,139 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <script crossorigin src="https://unpkg.com/react@17/umd/react.development.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@17/umd/react-dom.development.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/regenerator-runtime@0.13.9/runtime.min.js"> </script>
+    <script src="{{{enginePath}}}"></script>
+    <script src="../../build/playcanvas-extras.js"></script>
+    <script src="../../build/playcanvas-observer.js"></script>
+    <script src="../../build/wasm-loader.js"></script>
+    <style>
+        body {
+            margin: 0;
+            overflow-y: hidden;
+        }
+        #app-canvas {
+            width: 100%;
+            height: 100%;
+        }
+    </style>
+</head>
+
+<body>
+    <canvas id='app-canvas'></canvas>
+    <script>
+        {{{ exampleConstValues }}}.forEach(function(s) {
+            window[s.k] = s.v;
+        });
+
+        function loadExample(exampleFunction, loadFunction, controlsFunction) {
+            var data = new observer.Observer({});
+
+            var app = new pc.Application(canvas, {
+                mouse: new pc.Mouse(document.body),
+                touch: new pc.TouchDevice(document.body),
+                elementInput: new pc.ElementInput(canvas),
+                gamepads: new pc.GamePads(),
+                keyboard: new pc.Keyboard(window),
+                graphicsDeviceOptions: {
+                    alpha: true
+                }
+            });
+
+            new pcx.MiniStats(app);
+
+            var assets;
+            if (!loadFunction) {
+                assets = [];
+            } else {
+                assets = loadFunction().props.children;
+                if (!Array.isArray(assets)) {
+                    assets = [assets];
+                }
+            }
+
+            assets = assets.map(function (c) {
+                var props = {
+                    ...c.props
+                };
+                return props;
+            });
+
+            var manifest = {};
+
+            // count of assets to load
+            var count = assets.length;
+
+            function onLoadedResource(key, asset) {
+                count--;
+                if (key) {
+                    manifest[key] = asset;
+                }
+                if (count <= 0) {
+                    exampleFunction(app, canvas, manifest, data);
+                }
+            }
+
+            if (assets.length === 0) {
+                onLoadedResource();
+            }
+
+            assets.forEach(function (resource) {
+                if (!resource.type) {
+                    fetch(resource.url)
+                        .then((response) => response.text())
+                        .then((data) => {
+                            const module = {
+                                exports: {}
+                            };
+                            window[resource.name] = (Function('module', 'exports', data).call(module, module, module.exports), module).exports;
+                            onLoadedResource();
+                        });
+                    return;
+                }
+                if (resource.data) {
+                    var asset = new pc.Asset(
+                        resource.name,
+                        resource.type,
+                        resource.type === "cubemap" ? {
+                            url: resource.url
+                        } : null,
+                        resource.data
+                    );
+                    asset.on("load", function (asset) {
+                        onLoadedResource(resource.name, asset);
+                    });
+                    app.assets.add(asset);
+                    app.assets.load(asset);
+                } else {
+                    app.assets.loadFromUrl(resource.url, resource.type, function (
+                        err,
+                        asset
+                    ) {
+                        if (!err && asset) {
+                            onLoadedResource(resource.name, asset);
+                        }
+                    });
+                }
+            });
+        }
+
+        var canvas = document.getElementById('app-canvas');
+        canvas.setAttribute('width', window.innerWidth + 'px');
+        canvas.setAttribute('height', window.innerHeight + 'px');
+
+        {{{ exampleClass }}}
+
+        pc.basisInitialize({
+            glueUrl: '../../static/lib/basis/basis.wasm.js',
+            wasmUrl: '../../static/lib/basis/basis.wasm.wasm',
+            fallbackUrl: '../../static/lib/basis/basis.js'
+        });
+
+        var e = new Example();
+        loadExample.bind(this)(e.example, e.load, e.controls);
+    </script>
+</body>
+
+</html>

--- a/examples/lib/wasm-loader.js
+++ b/examples/lib/wasm-loader.js
@@ -1,0 +1,43 @@
+/* eslint-disable no-unused-vars */
+
+// check for wasm module support
+function wasmSupported() {
+    try {
+        if (typeof WebAssembly === "object" && typeof WebAssembly.instantiate === "function") {
+            const module = new WebAssembly.Module(Uint8Array.of(0x0, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00));
+            if (module instanceof WebAssembly.Module)
+                return new WebAssembly.Instance(module) instanceof WebAssembly.Instance;
+        }
+    } catch (e) { }
+    return false;
+}
+
+// load a script
+function loadScriptAsync(url, doneCallback) {
+    var tag = document.createElement('script');
+    tag.onload = function () {
+        doneCallback();
+    };
+    tag.onerror = function () {
+        throw new Error('failed to load ' + url);
+    };
+    tag.async = true;
+    tag.src = url;
+    document.head.appendChild(tag);
+}
+
+// load and initialize a wasm module
+function loadWasmModuleAsync(moduleName, jsUrl, binaryUrl, doneCallback) {
+    loadScriptAsync(jsUrl, function () {
+        var lib = window[moduleName];
+        window[moduleName + 'Lib'] = lib;
+        lib({
+            locateFile: function () {
+                return binaryUrl;
+            }
+        }).then(function (instance) {
+            window[moduleName] = instance;
+            doneCallback();
+        });
+    });
+}

--- a/examples/package-lock.json
+++ b/examples/package-lock.json
@@ -4225,6 +4225,15 @@
         "original": "^1.0.0"
       }
     },
+    "exec-sh": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.2.tgz",
+      "integrity": "sha512-FIUCJz1RbuS0FKTdaAafAByGS0CPvU3R0MeHxgtl+djzCc//F8HakL8GzmVNZanasTbTAY/3DRFA0KpVqj/eAw==",
+      "dev": true,
+      "requires": {
+        "merge": "^1.2.0"
+      }
+    },
     "execa": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
@@ -6140,6 +6149,12 @@
         "errno": "^0.1.3",
         "readable-stream": "^2.0.1"
       }
+    },
+    "merge": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.1.tgz",
+      "integrity": "sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==",
+      "dev": true
     },
     "merge-descriptors": {
       "version": "1.0.1",
@@ -13577,6 +13592,16 @@
       "dev": true,
       "requires": {
         "loose-envify": "^1.0.0"
+      }
+    },
+    "watch": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/watch/-/watch-1.0.2.tgz",
+      "integrity": "sha1-NApxe952Vyb6CqB9ch4BR6VR3ww=",
+      "dev": true,
+      "requires": {
+        "exec-sh": "^0.2.0",
+        "minimist": "^1.2.0"
       }
     },
     "watchpack": {

--- a/examples/package.json
+++ b/examples/package.json
@@ -13,7 +13,7 @@
     "serve": "serve dist",
     "thumbnails": "node ./thumbnails.js",
     "build:directory": "node ./example-directory.js",
-    "build:debug:directory": "cp -r ../build/ ./dist/build/ && cp ./node_modules/@playcanvas/observer/index.js ./dist/build/playcanvas-observer.js && node ./debug/index.js",
+    "build:debug:directory": "cp -r ../build/ ./dist/build/ && cp ./lib/wasm-loader.js ./dist/build && cp ./node_modules/@playcanvas/observer/index.js ./dist/build/playcanvas-observer.js && node ./debug/index.js",
     "watch:debug:directory": "watch 'npm run build:debug:directory' ./src/examples/"
   },
   "eslintConfig": {

--- a/examples/package.json
+++ b/examples/package.json
@@ -12,7 +12,9 @@
     "build:profiler": "cross-env ENGINE_PATH=../build/playcanvas.prf.js EXTRAS_PATH=../build/playcanvas-extras.js concurrently --kill-others \"npm run webpack:watch\"",
     "serve": "serve dist",
     "thumbnails": "node ./thumbnails.js",
-    "build:directory": "node ./example-directory.js"
+    "build:directory": "node ./example-directory.js",
+    "build:debug:directory": "cp -r ../build/ ./dist/build/ && cp ./node_modules/@playcanvas/observer/index.js ./dist/build/playcanvas-observer.js && node ./debug/index.js",
+    "watch:debug:directory": "watch 'npm run build:debug:directory' ./src/examples/"
   },
   "eslintConfig": {
     "root": true,
@@ -78,6 +80,7 @@
     "sharp": "^0.28.3",
     "style-loader": "^3.0.0",
     "typescript": "^4.3.5",
+    "watch": "^1.0.2",
     "webpack": "^5.42.1",
     "webpack-bundle-analyzer": "^4.4.2",
     "webpack-cli": "^4.7.2",

--- a/examples/src/examples/animation/blend-trees-1d.tsx
+++ b/examples/src/examples/animation/blend-trees-1d.tsx
@@ -11,53 +11,6 @@ import BindingTwoWay from '@playcanvas/pcui/BindingTwoWay';
 // @ts-ignore: library file import
 import { Observer } from '@playcanvas/observer';
 
-// create an anim state graph
-const animStateGraphData = {
-    "layers": [
-        {
-            "name": "characterState",
-            "states": [
-                {
-                    "name": "START"
-                },
-                {
-                    "name": "Movement",
-                    "speed": 1.0,
-                    "loop": true,
-                    "blendTree": {
-                        "type": "1D",
-                        "parameter": "blend",
-                        "children": [
-                            {
-                                "name": "Idle",
-                                "point": 0.0
-                            },
-                            {
-                                "name": "Dance",
-                                "point": 1.0,
-                                "speed": 0.85
-                            }
-                        ]
-                    }
-                }
-            ],
-            "transitions": [
-                {
-                    "from": "START",
-                    "to": "Movement"
-                }
-            ]
-        }
-    ],
-    "parameters": {
-        "blend": {
-            "name": "blend",
-            "type": "FLOAT",
-            "value": 0
-        }
-    }
-};
-
 class BlendTrees1DExample extends Example {
     static CATEGORY = 'Animation';
     static NAME = 'Blend Trees 1D';
@@ -67,7 +20,6 @@ class BlendTrees1DExample extends Example {
             <AssetLoader name='model' type='container' url='static/assets/models/bitmoji.glb' />
             <AssetLoader name='idleAnim' type='container' url='static/assets/animations/bitmoji/idle.glb' />
             <AssetLoader name='danceAnim' type='container' url='static/assets/animations/bitmoji/win-dance.glb' />
-            <AssetLoader name='animStateGraph' type='json' data={animStateGraphData} />
             <AssetLoader name='helipad.dds' type='cubemap' url='static/assets/cubemaps/helipad.dds' data={{ type: pc.TEXTURETYPE_RGBM }}/>
             <AssetLoader name='bloom' type='script' url='static/scripts/posteffects/posteffect-bloom.js' />
         </>;
@@ -136,8 +88,55 @@ class BlendTrees1DExample extends Example {
             activate: true
         });
 
+        // create an anim state graph
+        const animStateGraphData = {
+            "layers": [
+                {
+                    "name": "characterState",
+                    "states": [
+                        {
+                            "name": "START"
+                        },
+                        {
+                            "name": "Movement",
+                            "speed": 1.0,
+                            "loop": true,
+                            "blendTree": {
+                                "type": "1D",
+                                "parameter": "blend",
+                                "children": [
+                                    {
+                                        "name": "Idle",
+                                        "point": 0.0
+                                    },
+                                    {
+                                        "name": "Dance",
+                                        "point": 1.0,
+                                        "speed": 0.85
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "transitions": [
+                        {
+                            "from": "START",
+                            "to": "Movement"
+                        }
+                    ]
+                }
+            ],
+            "parameters": {
+                "blend": {
+                    "name": "blend",
+                    "type": "FLOAT",
+                    "value": 0
+                }
+            }
+        };
+
         // load the state graph into the anim component
-        modelEntity.anim.loadStateGraph(assets.animStateGraph.data);
+        modelEntity.anim.loadStateGraph(animStateGraphData);
 
         // load the state graph asset resource into the anim component
         const characterStateLayer = modelEntity.anim.baseLayer;

--- a/examples/src/examples/animation/blend-trees-2d-cartesian.tsx
+++ b/examples/src/examples/animation/blend-trees-2d-cartesian.tsx
@@ -5,65 +5,6 @@ import Example from '../../app/example';
 // @ts-ignore: library file import
 import { Observer } from '@playcanvas/observer';
 
-// create an anim state graph
-const animStateGraphData = {
-    "layers": [
-        {
-            "name": "base",
-            "states": [
-                {
-                    "name": "START"
-                },
-                {
-                    "name": "Emote",
-                    "speed": 1.0,
-                    "loop": true,
-                    "blendTree": {
-                        "type": pc.ANIM_BLEND_2D_CARTESIAN,
-                        "parameters": ["posX", "posY"],
-                        "children": [
-                            {
-                                "name": "Idle",
-                                "point": [-0.5, 0.5]
-                            },
-                            {
-                                "name": "Eager",
-                                "point": [0.5, 0.5]
-                            },
-                            {
-                                "name": "Walk",
-                                "point": [0.5, -0.5]
-                            },
-                            {
-                                "name": "Dance",
-                                "point": [-0.5, -0.5]
-                            }
-                        ]
-                    }
-                }
-            ],
-            "transitions": [
-                {
-                    "from": "START",
-                    "to": "Emote"
-                }
-            ]
-        }
-    ],
-    "parameters": {
-        "posX": {
-            "name": "posX",
-            "type": "FLOAT",
-            "value": -0.5
-        },
-        "posY": {
-            "name": "posY",
-            "type": "FLOAT",
-            "value": 0.5
-        }
-    }
-};
-
 class BlendTrees2DCartesianExample extends Example {
     static CATEGORY = 'Animation';
     static NAME = 'Blend Trees 2D Cartesian';
@@ -75,7 +16,6 @@ class BlendTrees2DCartesianExample extends Example {
             <AssetLoader name='eagerAnim' type='container' url='static/assets/animations/bitmoji/idle-eager.glb' />
             <AssetLoader name='walkAnim' type='container' url='static/assets/animations/bitmoji/walk.glb' />
             <AssetLoader name='danceAnim' type='container' url='static/assets/animations/bitmoji/win-dance.glb' />
-            <AssetLoader name='animStateGraph' type='json' data={animStateGraphData} />
             <AssetLoader name='helipad.dds' type='cubemap' url='static/assets/cubemaps/helipad.dds' data={{ type: pc.TEXTURETYPE_RGBM }}/>
             <AssetLoader name='bloom' type='script' url='static/scripts/posteffects/posteffect-bloom.js' />
         </>;
@@ -220,8 +160,67 @@ class BlendTrees2DCartesianExample extends Example {
             activate: true
         });
 
+        // create an anim state graph
+        const animStateGraphData = {
+            "layers": [
+                {
+                    "name": "base",
+                    "states": [
+                        {
+                            "name": "START"
+                        },
+                        {
+                            "name": "Emote",
+                            "speed": 1.0,
+                            "loop": true,
+                            "blendTree": {
+                                "type": pc.ANIM_BLEND_2D_CARTESIAN,
+                                "parameters": ["posX", "posY"],
+                                "children": [
+                                    {
+                                        "name": "Idle",
+                                        "point": [-0.5, 0.5]
+                                    },
+                                    {
+                                        "name": "Eager",
+                                        "point": [0.5, 0.5]
+                                    },
+                                    {
+                                        "name": "Walk",
+                                        "point": [0.5, -0.5]
+                                    },
+                                    {
+                                        "name": "Dance",
+                                        "point": [-0.5, -0.5]
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "transitions": [
+                        {
+                            "from": "START",
+                            "to": "Emote"
+                        }
+                    ]
+                }
+            ],
+            "parameters": {
+                "posX": {
+                    "name": "posX",
+                    "type": "FLOAT",
+                    "value": -0.5
+                },
+                "posY": {
+                    "name": "posY",
+                    "type": "FLOAT",
+                    "value": 0.5
+                }
+            }
+        };
+
         // load the state graph into the anim component
-        modelEntity.anim.loadStateGraph(assets.animStateGraph.data);
+        modelEntity.anim.loadStateGraph(animStateGraphData);
 
         // load the state graph asset resource into the anim component
         const characterStateLayer = modelEntity.anim.baseLayer;

--- a/examples/src/examples/animation/blend-trees-2d-directional.tsx
+++ b/examples/src/examples/animation/blend-trees-2d-directional.tsx
@@ -5,69 +5,6 @@ import Example from '../../app/example';
 // @ts-ignore: library file import
 import { Observer } from '@playcanvas/observer';
 
-// create an anim state graph
-const animStateGraphData = {
-    "layers": [
-        {
-            "name": "locomotion",
-            "states": [
-                {
-                    "name": "START"
-                },
-                {
-                    "name": "Travel",
-                    "speed": 1.0,
-                    "loop": true,
-                    "blendTree": {
-                        "type": pc.ANIM_BLEND_2D_DIRECTIONAL,
-                        "syncDurations": true,
-                        "parameters": ["posX", "posY"],
-                        "children": [
-                            {
-                                "name": "Idle",
-                                "point": [0.0, 0.0]
-                            },
-                            {
-                                "speed": -1,
-                                "name": "WalkBackwards",
-                                "point": [0.0, -0.5]
-                            },
-                            {
-                                "speed": 1,
-                                "name": "Walk",
-                                "point": [0.0, 0.5]
-                            },
-                            {
-                                "speed": 1,
-                                "name": "Jog",
-                                "point": [0.0, 1.0]
-                            }
-                        ]
-                    }
-                }
-            ],
-            "transitions": [
-                {
-                    "from": "START",
-                    "to": "Travel"
-                }
-            ]
-        }
-    ],
-    "parameters": {
-        "posX": {
-            "name": "posX",
-            "type": "FLOAT",
-            "value": 0
-        },
-        "posY": {
-            "name": "posY",
-            "type": "FLOAT",
-            "value": 0
-        }
-    }
-};
-
 class BlendTrees2DDirectionalExample extends Example {
     static CATEGORY = 'Animation';
     static NAME = 'Blend Trees 2D Directional';
@@ -78,7 +15,6 @@ class BlendTrees2DDirectionalExample extends Example {
             <AssetLoader name='idleAnim' type='container' url='static/assets/animations/bitmoji/idle.glb' />
             <AssetLoader name='walkAnim' type='container' url='static/assets/animations/bitmoji/walk.glb' />
             <AssetLoader name='jogAnim' type='container' url='static/assets/animations/bitmoji/run.glb' />
-            <AssetLoader name='animStateGraph' type='json' data={animStateGraphData} />
             <AssetLoader name='helipad.dds' type='cubemap' url='static/assets/cubemaps/helipad.dds' data={{ type: pc.TEXTURETYPE_RGBM }}/>
             <AssetLoader name='bloom' type='script' url='static/scripts/posteffects/posteffect-bloom.js' />
         </>;
@@ -213,8 +149,71 @@ class BlendTrees2DDirectionalExample extends Example {
             activate: true
         });
 
+        // create an anim state graph
+        const animStateGraphData = {
+            "layers": [
+                {
+                    "name": "locomotion",
+                    "states": [
+                        {
+                            "name": "START"
+                        },
+                        {
+                            "name": "Travel",
+                            "speed": 1.0,
+                            "loop": true,
+                            "blendTree": {
+                                "type": pc.ANIM_BLEND_2D_DIRECTIONAL,
+                                "syncDurations": true,
+                                "parameters": ["posX", "posY"],
+                                "children": [
+                                    {
+                                        "name": "Idle",
+                                        "point": [0.0, 0.0]
+                                    },
+                                    {
+                                        "speed": -1,
+                                        "name": "WalkBackwards",
+                                        "point": [0.0, -0.5]
+                                    },
+                                    {
+                                        "speed": 1,
+                                        "name": "Walk",
+                                        "point": [0.0, 0.5]
+                                    },
+                                    {
+                                        "speed": 1,
+                                        "name": "Jog",
+                                        "point": [0.0, 1.0]
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "transitions": [
+                        {
+                            "from": "START",
+                            "to": "Travel"
+                        }
+                    ]
+                }
+            ],
+            "parameters": {
+                "posX": {
+                    "name": "posX",
+                    "type": "FLOAT",
+                    "value": 0
+                },
+                "posY": {
+                    "name": "posY",
+                    "type": "FLOAT",
+                    "value": 0
+                }
+            }
+        };
+
         // load the state graph into the anim component
-        modelEntity.anim.loadStateGraph(assets.animStateGraph.data);
+        modelEntity.anim.loadStateGraph(animStateGraphData);
 
         // load the state graph asset resource into the anim component
         const locomotionLayer = modelEntity.anim.baseLayer;

--- a/examples/src/examples/animation/component-properties.tsx
+++ b/examples/src/examples/animation/component-properties.tsx
@@ -5,137 +5,6 @@ import Example from '../../app/example';
 // @ts-ignore: library file import
 import Button from '@playcanvas/pcui/Button/component';
 
-const animClipStaticLightData = {
-    "name": "staticLight",
-    "duration": 1.0,
-    // curve keyframe inputs
-    "inputs": [
-        [
-            0.0
-        ]
-    ],
-    // curve keyframe outputs
-    "outputs": [
-        // a single RGBA color keyframe value of a green light
-        {
-            "components": 4,
-            "data": [
-                0.0, 1.0, 0.0, 1.0
-            ]
-        },
-        // a single quaternion keyframe value with no rotation
-        {
-            "components": 4,
-            "data": [
-                0.0, 0.0, 0.0, 0.0
-            ]
-        }
-    ],
-    // the curves contained in the clip, each with the path to the property they animation, the index of
-    // their input and output keyframes and the method of interpolation to be used
-    "curves": [
-        {
-            "path": { entityPath: ["lights", "spotLight1"], component: "light", propertyPath: ["color"] },
-            "inputIndex": 0,
-            "outputIndex": 0,
-            "interpolation": 1
-        },
-        {
-            "path": { entityPath: ["lights", "spotLight2"], component: "light", propertyPath: ["color"] },
-            "inputIndex": 0,
-            "outputIndex": 0,
-            "interpolation": 1
-        },
-        {
-            "path": { entityPath: ["lights", "spotLight1"], component: "entity", propertyPath: ["localEulerAngles"] },
-            "inputIndex": 0,
-            "outputIndex": 1,
-            "interpolation": 1
-        },
-        {
-            "path": { entityPath: ["lights", "spotLight2"], component: "entity", propertyPath: ["localEulerAngles"] },
-            "inputIndex": 0,
-            "outputIndex": 1,
-            "interpolation": 1
-        }
-    ]
-};
-
-// create the animation data for two flashing spot lights
-const animClipFlashingLightData = {
-    "name": "flashingLight",
-    "duration": 2.0,
-    // curve keyframe inputs
-    "inputs": [
-        [
-            0.0, 0.5, 1.0, 1.5, 2.0
-        ],
-        [
-            0, 1, 2
-        ]
-    ],
-    // curve keyframe outputs
-    "outputs": [
-        //  keyframe outputs for a flashing red RGBA color
-        {
-            "components": 4,
-            "data": [
-                1.0, 0.0, 0.0, 1.0,
-                0.4, 0.0, 0.0, 1.0,
-                1.0, 0.0, 0.0, 1.0,
-                0.4, 0.0, 0.0, 1.0,
-                1.0, 0.0, 0.0, 1.0
-            ]
-        },
-        //  keyframe outputs for a quaterion rotation
-        {
-            "components": 4,
-            "data": [
-                4.0, 0.0, 0.0, 0.0,
-                4.0, 180.0, 0.0, 0.0,
-                4.0, 0.0, 0.0, 0.0
-            ]
-        },
-        //  keyframe outputs for a quaterion rotation
-        {
-            "components": 4,
-            "data": [
-                -4.0, 0.0, 0.0, 0.0,
-                -4.0, 180.0, 0.0, 0.0,
-                -4.0, 0.0, 0.0, 0.0
-            ]
-        }
-    ],
-    // the curves contained in the clip, each with the path to the property they animation, the index of
-    // their input and output keyframes and the method of interpolation to be used
-    "curves": [
-        {
-            "path": { entityPath: ["lights", "spotLight1"], component: "light", propertyPath: ["color"] },
-            "inputIndex": 0,
-            "outputIndex": 0,
-            "interpolation": 1
-        },
-        {
-            "path": { entityPath: ["lights", "spotLight2"], component: "light", propertyPath: ["color"] },
-            "inputIndex": 0,
-            "outputIndex": 0,
-            "interpolation": 1
-        },
-        {
-            "path": { entityPath: ["lights", "spotLight1"], component: "entity", propertyPath: ["localEulerAngles"] },
-            "inputIndex": 1,
-            "outputIndex": 1,
-            "interpolation": 1
-        },
-        {
-            "path": { entityPath: ["lights", "spotLight2"], component: "entity", propertyPath: ["localEulerAngles"] },
-            "inputIndex": 1,
-            "outputIndex": 2,
-            "interpolation": 1
-        }
-    ]
-};
-
 class ComponentPropertiesExample extends Example {
     static CATEGORY = 'Animation';
     static NAME = 'Component Properties';
@@ -143,8 +12,6 @@ class ComponentPropertiesExample extends Example {
     load() {
         return <>
             <AssetLoader name='playcanvasGreyTexture' type='texture' url='static/assets/textures/playcanvas-grey.png' />
-            <AssetLoader name='staticLightClip' type='json' data={animClipStaticLightData} />
-            <AssetLoader name='flashingLightClip' type='json' data={animClipFlashingLightData} />
         </>;
     }
 
@@ -159,7 +26,7 @@ class ComponentPropertiesExample extends Example {
 
 
     // @ts-ignore: abstract class function
-    example(canvas: HTMLCanvasElement, assets: { playcanvasGreyTexture: pc.Asset, staticLightClip: pc.Asset, flashingLightClip: pc.Asset }, data: any): void {
+    example(canvas: HTMLCanvasElement, assets: { playcanvasGreyTexture: pc.Asset }, data: any): void {
 
         const app = new pc.Application(canvas, {
             mouse: new pc.Mouse(document.body),
@@ -168,11 +35,141 @@ class ComponentPropertiesExample extends Example {
         });
 
         // create the animation data for two static spot lights
+        const animClipStaticLightData = {
+            "name": "staticLight",
+            "duration": 1.0,
+            // curve keyframe inputs
+            "inputs": [
+                [
+                    0.0
+                ]
+            ],
+            // curve keyframe outputs
+            "outputs": [
+                // a single RGBA color keyframe value of a green light
+                {
+                    "components": 4,
+                    "data": [
+                        0.0, 1.0, 0.0, 1.0
+                    ]
+                },
+                // a single quaternion keyframe value with no rotation
+                {
+                    "components": 4,
+                    "data": [
+                        0.0, 0.0, 0.0, 0.0
+                    ]
+                }
+            ],
+            // the curves contained in the clip, each with the path to the property they animation, the index of
+            // their input and output keyframes and the method of interpolation to be used
+            "curves": [
+                {
+                    "path": { entityPath: ["lights", "spotLight1"], component: "light", propertyPath: ["color"] },
+                    "inputIndex": 0,
+                    "outputIndex": 0,
+                    "interpolation": 1
+                },
+                {
+                    "path": { entityPath: ["lights", "spotLight2"], component: "light", propertyPath: ["color"] },
+                    "inputIndex": 0,
+                    "outputIndex": 0,
+                    "interpolation": 1
+                },
+                {
+                    "path": { entityPath: ["lights", "spotLight1"], component: "entity", propertyPath: ["localEulerAngles"] },
+                    "inputIndex": 0,
+                    "outputIndex": 1,
+                    "interpolation": 1
+                },
+                {
+                    "path": { entityPath: ["lights", "spotLight2"], component: "entity", propertyPath: ["localEulerAngles"] },
+                    "inputIndex": 0,
+                    "outputIndex": 1,
+                    "interpolation": 1
+                }
+            ]
+        };
+
+        // create the animation data for two flashing spot lights
+        const animClipFlashingLightData = {
+            "name": "flashingLight",
+            "duration": 2.0,
+            // curve keyframe inputs
+            "inputs": [
+                [
+                    0.0, 0.5, 1.0, 1.5, 2.0
+                ],
+                [
+                    0, 1, 2
+                ]
+            ],
+            // curve keyframe outputs
+            "outputs": [
+                //  keyframe outputs for a flashing red RGBA color
+                {
+                    "components": 4,
+                    "data": [
+                        1.0, 0.0, 0.0, 1.0,
+                        0.4, 0.0, 0.0, 1.0,
+                        1.0, 0.0, 0.0, 1.0,
+                        0.4, 0.0, 0.0, 1.0,
+                        1.0, 0.0, 0.0, 1.0
+                    ]
+                },
+                //  keyframe outputs for a quaterion rotation
+                {
+                    "components": 4,
+                    "data": [
+                        4.0, 0.0, 0.0, 0.0,
+                        4.0, 180.0, 0.0, 0.0,
+                        4.0, 0.0, 0.0, 0.0
+                    ]
+                },
+                //  keyframe outputs for a quaterion rotation
+                {
+                    "components": 4,
+                    "data": [
+                        -4.0, 0.0, 0.0, 0.0,
+                        -4.0, 180.0, 0.0, 0.0,
+                        -4.0, 0.0, 0.0, 0.0
+                    ]
+                }
+            ],
+            // the curves contained in the clip, each with the path to the property they animation, the index of
+            // their input and output keyframes and the method of interpolation to be used
+            "curves": [
+                {
+                    "path": { entityPath: ["lights", "spotLight1"], component: "light", propertyPath: ["color"] },
+                    "inputIndex": 0,
+                    "outputIndex": 0,
+                    "interpolation": 1
+                },
+                {
+                    "path": { entityPath: ["lights", "spotLight2"], component: "light", propertyPath: ["color"] },
+                    "inputIndex": 0,
+                    "outputIndex": 0,
+                    "interpolation": 1
+                },
+                {
+                    "path": { entityPath: ["lights", "spotLight1"], component: "entity", propertyPath: ["localEulerAngles"] },
+                    "inputIndex": 1,
+                    "outputIndex": 1,
+                    "interpolation": 1
+                },
+                {
+                    "path": { entityPath: ["lights", "spotLight2"], component: "entity", propertyPath: ["localEulerAngles"] },
+                    "inputIndex": 1,
+                    "outputIndex": 2,
+                    "interpolation": 1
+                }
+            ]
+        };
 
         // @ts-ignore
         const animClipHandler = new pc.AnimClipHandler();
-        const animClipStaticLight = animClipHandler.open(undefined, assets.staticLightClip.data);
-        const animClipFlashingLight = animClipHandler.open(undefined, assets.flashingLightClip.data);
+        const animClipStaticLight = animClipHandler.open(undefined, animClipStaticLightData);
+        const animClipFlashingLight = animClipHandler.open(undefined, animClipFlashingLightData);
 
         // Create an Entity with a camera component
         const cameraEntity = new pc.Entity();

--- a/examples/src/examples/animation/locomotion.tsx
+++ b/examples/src/examples/animation/locomotion.tsx
@@ -14,139 +14,6 @@ import BindingTwoWay from '@playcanvas/pcui/BindingTwoWay';
 import { Observer } from '@playcanvas/observer';
 import { wasmSupported, loadWasmModuleAsync } from '../../wasm-loader';
 
-// create an anim state graph
-const animStateGraphData = {
-    "layers": [
-        {
-            "name": "locomotion",
-            "states": [
-                {
-                    "name": "START"
-                },
-                {
-                    "name": "Idle",
-                    "speed": 1.0
-                },
-                {
-                    "name": "Walk",
-                    "speed": 1.0
-                },
-                {
-                    "name": "Jump",
-                    "speed": 1
-                },
-                {
-                    "name": "Jog",
-                    "speed": 1.0
-                },
-                {
-                    "name": "END"
-                }
-            ],
-            "transitions": [
-                {
-                    "from": "START",
-                    "to": "Idle",
-                    "time": 0,
-                    "priority": 0
-                },
-                {
-                    "from": "Idle",
-                    "to": "Walk",
-                    "time": 0.1,
-                    "priority": 0,
-                    "conditions": [
-                        {
-                            "parameterName": "speed",
-                            "predicate": pc.ANIM_GREATER_THAN,
-                            "value": 0
-                        }
-                    ]
-                },
-                {
-                    "from": "ANY",
-                    "to": "Jump",
-                    "time": 0.1,
-                    "priority": 0,
-                    "conditions": [
-                        {
-                            "parameterName": "jump",
-                            "predicate": pc.ANIM_EQUAL_TO,
-                            "value": true
-                        }
-                    ]
-                },
-                {
-                    "from": "Jump",
-                    "to": "Idle",
-                    "time": 0.2,
-                    "priority": 0,
-                    "exitTime": 0.8
-                },
-                {
-                    "from": "Jump",
-                    "to": "Walk",
-                    "time": 0.2,
-                    "priority": 0,
-                    "exitTime": 0.8
-                },
-                {
-                    "from": "Walk",
-                    "to": "Idle",
-                    "time": 0.1,
-                    "priority": 0,
-                    "conditions": [
-                        {
-                            "parameterName": "speed",
-                            "predicate": pc.ANIM_LESS_THAN_EQUAL_TO,
-                            "value": 0
-                        }
-                    ]
-                },
-                {
-                    "from": "Walk",
-                    "to": "Jog",
-                    "time": 0.1,
-                    "priority": 0,
-                    "conditions": [
-                        {
-                            "parameterName": "speed",
-                            "predicate": pc.ANIM_GREATER_THAN,
-                            "value": 1
-                        }
-                    ]
-                },
-                {
-                    "from": "Jog",
-                    "to": "Walk",
-                    "time": 0.1,
-                    "priority": 0,
-                    "conditions": [
-                        {
-                            "parameterName": "speed",
-                            "predicate": pc.ANIM_LESS_THAN,
-                            "value": 2
-                        }
-                    ]
-                }
-            ]
-        }
-    ],
-    "parameters": {
-        "speed": {
-            "name": "speed",
-            "type": pc.ANIM_PARAMETER_INTEGER,
-            "value": 0
-        },
-        "jump": {
-            "name": "jump",
-            "type": pc.ANIM_PARAMETER_TRIGGER,
-            "value": false
-        }
-    }
-};
-
-
 class LocomotionExample extends Example {
     static CATEGORY = 'Animation';
     static NAME = 'Locomotion';
@@ -159,7 +26,6 @@ class LocomotionExample extends Example {
             <AssetLoader name='walkAnim' type='container' url='static/assets/animations/bitmoji/walk.glb' />
             <AssetLoader name='jogAnim' type='container' url='static/assets/animations/bitmoji/run.glb' />
             <AssetLoader name='jumpAnim' type='container' url='static/assets/animations/bitmoji/jump-flip.glb' />
-            <AssetLoader name='animStateGraph' type='json' data={animStateGraphData} />
             <AssetLoader name='helipad.dds' type='cubemap' url='static/assets/cubemaps/helipad.dds' data={{ type: pc.TEXTURETYPE_RGBM }}/>
             <AssetLoader name='bloom' type='script' url='static/scripts/posteffects/posteffect-bloom.js' />
         </>;
@@ -246,8 +112,140 @@ class LocomotionExample extends Example {
                 activate: true
             });
 
+            // create an anim state graph
+            const animStateGraphData = {
+                "layers": [
+                    {
+                        "name": "locomotion",
+                        "states": [
+                            {
+                                "name": "START"
+                            },
+                            {
+                                "name": "Idle",
+                                "speed": 1.0
+                            },
+                            {
+                                "name": "Walk",
+                                "speed": 1.0
+                            },
+                            {
+                                "name": "Jump",
+                                "speed": 1
+                            },
+                            {
+                                "name": "Jog",
+                                "speed": 1.0
+                            },
+                            {
+                                "name": "END"
+                            }
+                        ],
+                        "transitions": [
+                            {
+                                "from": "START",
+                                "to": "Idle",
+                                "time": 0,
+                                "priority": 0
+                            },
+                            {
+                                "from": "Idle",
+                                "to": "Walk",
+                                "time": 0.1,
+                                "priority": 0,
+                                "conditions": [
+                                    {
+                                        "parameterName": "speed",
+                                        "predicate": pc.ANIM_GREATER_THAN,
+                                        "value": 0
+                                    }
+                                ]
+                            },
+                            {
+                                "from": "ANY",
+                                "to": "Jump",
+                                "time": 0.1,
+                                "priority": 0,
+                                "conditions": [
+                                    {
+                                        "parameterName": "jump",
+                                        "predicate": pc.ANIM_EQUAL_TO,
+                                        "value": true
+                                    }
+                                ]
+                            },
+                            {
+                                "from": "Jump",
+                                "to": "Idle",
+                                "time": 0.2,
+                                "priority": 0,
+                                "exitTime": 0.8
+                            },
+                            {
+                                "from": "Jump",
+                                "to": "Walk",
+                                "time": 0.2,
+                                "priority": 0,
+                                "exitTime": 0.8
+                            },
+                            {
+                                "from": "Walk",
+                                "to": "Idle",
+                                "time": 0.1,
+                                "priority": 0,
+                                "conditions": [
+                                    {
+                                        "parameterName": "speed",
+                                        "predicate": pc.ANIM_LESS_THAN_EQUAL_TO,
+                                        "value": 0
+                                    }
+                                ]
+                            },
+                            {
+                                "from": "Walk",
+                                "to": "Jog",
+                                "time": 0.1,
+                                "priority": 0,
+                                "conditions": [
+                                    {
+                                        "parameterName": "speed",
+                                        "predicate": pc.ANIM_GREATER_THAN,
+                                        "value": 1
+                                    }
+                                ]
+                            },
+                            {
+                                "from": "Jog",
+                                "to": "Walk",
+                                "time": 0.1,
+                                "priority": 0,
+                                "conditions": [
+                                    {
+                                        "parameterName": "speed",
+                                        "predicate": pc.ANIM_LESS_THAN,
+                                        "value": 2
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "parameters": {
+                    "speed": {
+                        "name": "speed",
+                        "type": pc.ANIM_PARAMETER_INTEGER,
+                        "value": 0
+                    },
+                    "jump": {
+                        "name": "jump",
+                        "type": pc.ANIM_PARAMETER_TRIGGER,
+                        "value": false
+                    }
+                }
+            };
+
             // load the state graph into the anim component
-            characterEntity.anim.loadStateGraph(assets.animStateGraph.resource);
+            characterEntity.anim.loadStateGraph(animStateGraphData);
 
             // assign the loaded animation assets to each of the states present in the state graph
             const locomotionLayer = characterEntity.anim.baseLayer;

--- a/examples/src/examples/graphics/particles-random-sprites.tsx
+++ b/examples/src/examples/graphics/particles-random-sprites.tsx
@@ -3,7 +3,6 @@ import * as pc from 'playcanvas/build/playcanvas.js';
 import { AssetLoader } from '../../app/helpers/loader';
 import Example from '../../app/example';
 
-// class ComponentPropertiesExample extends Example {
 class ParticlesRandomSpritesExample extends Example {
     static CATEGORY = 'Graphics';
     static NAME = 'Particles: Random Sprites';

--- a/examples/src/examples/graphics/render-cubemap.tsx
+++ b/examples/src/examples/graphics/render-cubemap.tsx
@@ -184,7 +184,7 @@ class RenderCubemapExample extends Example {
 
         // helper function to create a texture that can be used to project cubemap to
         function createReprojectionTexture(projection: string, size: number) {
-            return new pc.Texture(this.app.graphicsDevice, {
+            return new pc.Texture(app.graphicsDevice, {
                 width: size,
                 height: size,
                 format: pc.PIXELFORMAT_R8_G8_B8,


### PR DESCRIPTION
Adds scripts to build and watch a debug version of each example:
- `npm run build:debug:directory`
- `npm run watch:debug:directory` (rebuilds each time an example is edited)

Serving the examples build directory using `npm run serve` will then make the `localhost:5000/debug` directory available which contains static HTML versions of each example for debugging purposes.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
