### PR TITLE
Calculate compressed mipmap sizes correctly

### DIFF
--- a/src/graphics/graphics-device.js
+++ b/src/graphics/graphics-device.js
@@ -1942,8 +1942,8 @@ class GraphicsDevice extends EventHandler {
                             gl.TEXTURE_2D,
                             mipLevel,
                             texture._glInternalFormat,
-                            Math.max(texture._width * resMult, 1),
-                            Math.max(texture._height * resMult, 1),
+                            Math.max((Math.floor((texture._width * resMult)) + 3) & ~3, 1),
+                            Math.max((Math.floor((texture._height * resMult)) + 3) & ~3, 1),
                             0,
                             mipObject
                         );

--- a/src/resources/basis-worker.js
+++ b/src/resources/basis-worker.js
@@ -95,12 +95,6 @@ function BasisWorker() {
         return data;
     };
 
-    const isCompressedFormat = (basisFormat) => {
-        return basisFormat !== BASIS_FORMAT.cTFRGBA32 &&
-               basisFormat !== BASIS_FORMAT.cTFRGB565 &&
-               basisFormat !== BASIS_FORMAT.cTFRGBA4444;
-    };
-
     // pack rgba8888 data into rgb565
     const pack565 = (data) => {
         const result = new Uint16Array(data.length / 4);
@@ -236,8 +230,6 @@ function BasisWorker() {
             }
         }
 
-        const compressedFormat = isCompressedFormat(basisFormat);
-
         return {
             format: basisToEngineMapping(basisFormat, options.deviceDetails),
             width: width,
@@ -326,8 +318,6 @@ function BasisWorker() {
                 levelData[i] = pack565(unswizzleGGGR(levelData[i]));
             }
         }
-
-        const compressedFormat = isCompressedFormat(basisFormat);
 
         return {
             format: basisToEngineMapping(basisFormat, options.deviceDetails),

--- a/src/resources/basis-worker.js
+++ b/src/resources/basis-worker.js
@@ -240,8 +240,8 @@ function BasisWorker() {
 
         return {
             format: basisToEngineMapping(basisFormat, options.deviceDetails),
-            width: compressedFormat ? ((width + 3) & ~3) : width,
-            height: compressedFormat ? ((height + 3) & ~3) : height,
+            width: width,
+            height: height,
             levels: levelData,
             cubemap: false,
             transcodeTime: performanceNow() - funcStart,
@@ -331,8 +331,8 @@ function BasisWorker() {
 
         return {
             format: basisToEngineMapping(basisFormat, options.deviceDetails),
-            width: compressedFormat ? ((width + 3) & ~3) : width,
-            height: compressedFormat ? ((height + 3) & ~3) : height,
+            width: width,
+            height: height,
             levels: levelData,
             cubemap: false,
             transcodeTime: performanceNow() - funcStart,


### PR DESCRIPTION
While investigating https://forum.playcanvas.com/t/problem-concerning-none-pot-textures/22862/7 I noticed the engine specifies mipmap sizes incorrectly for the deep mipmaps of some odd-sized textures.

With this PR we fix that, however the resulting odd-sized textures are still not renderable. (Presumably because DXT compression doesn't support the odd size anyway, but still investigating).