### PR TITLE
Don't allow clustered area lights if less than 8 texture units

### DIFF
--- a/src/graphics/graphics-device.js
+++ b/src/graphics/graphics-device.js
@@ -913,9 +913,13 @@ class GraphicsDevice extends EventHandler {
         this.samples = gl.getParameter(gl.SAMPLES);
         this.maxSamples = this.webgl2 ? gl.getParameter(gl.MAX_SAMPLES) : 1;
 
-        // Don't allow area lights on old android devices, they often fail to compile the shader,
-        // run it incorrectly or are very slow.
+        // Don't allow area lights on old android devices, they often fail to compile the shader, run it incorrectly or are very slow.
         this.supportsAreaLights = this.webgl2 || !platform.android;
+
+        // Also do not allow them when we only have small number of texture units
+        if (this.maxTextures <= 8) {
+            this.supportsAreaLights = false;
+        }
     }
 
     initializeRenderState() {

--- a/src/scene/composition/layer-composition.js
+++ b/src/scene/composition/layer-composition.js
@@ -161,6 +161,11 @@ class LayerComposition extends EventHandler {
     }
 
     set clusteredLightingAreaLightsEnabled(value) {
+
+        if (!this.device.supportsAreaLights) {
+            value = false;
+        }
+
         if (this._clusteredLightingAreaLightsEnabled !== value) {
             this._clusteredLightingAreaLightsEnabled = value;
 

--- a/src/scene/materials/standard-material-options-builder.js
+++ b/src/scene/materials/standard-material-options-builder.js
@@ -211,7 +211,7 @@ class StandardMaterialOptionsBuilder {
         if (LayerComposition.clusteredLightingEnabled && scene.layers) {
             options.clusteredLightingCookiesEnabled = scene.layers.clusteredLightingCookiesEnabled;
             options.clusteredLightingShadowsEnabled = scene.layers.clusteredLightingShadowsEnabled;
-            options.clusteredLightingAreaLightsEnabled = scene.layers.clusteredLightingAreaLightsEnabled && device.supportsAreaLights;
+            options.clusteredLightingAreaLightsEnabled = scene.layers.clusteredLightingAreaLightsEnabled;
         }
     }
 


### PR DESCRIPTION
- this targets older devices (iPhone XR and also iPhone 11) running iOS < 15, so WebGL1 only - only 8 texture units are allowed.