### PR TITLE
Correctly enable textureLod extension on webgl1

### DIFF
--- a/src/graphics/program-lib/chunks/ambientPrefilteredCubeLod.frag
+++ b/src/graphics/program-lib/chunks/ambientPrefilteredCubeLod.frag
@@ -1,6 +1,5 @@
-#ifndef PMREM4
-#define PMREM4
-#extension GL_EXT_shader_texture_lod : enable
+#ifndef PMREM128
+#define PMREM128
 uniform samplerCube texture_prefilteredCubeMap128;
 #endif
 

--- a/src/graphics/program-lib/chunks/fixCubemapSeamsStretch.frag
+++ b/src/graphics/program-lib/chunks/fixCubemapSeamsStretch.frag
@@ -1,27 +1,30 @@
 vec3 fixSeams(vec3 vec, float mipmapIndex) {
+    vec3 avec = abs(vec);
     float scale = 1.0 - exp2(mipmapIndex) / 128.0;
-    float M = max(max(abs(vec.x), abs(vec.y)), abs(vec.z));
-    if (abs(vec.x) != M) vec.x *= scale;
-    if (abs(vec.y) != M) vec.y *= scale;
-    if (abs(vec.z) != M) vec.z *= scale;
+    float M = max(max(avec.x, avec.y), avec.z);
+    if (avec.x != M) vec.x *= scale;
+    if (avec.y != M) vec.y *= scale;
+    if (avec.z != M) vec.z *= scale;
     return vec;
 }
 
 vec3 fixSeams(vec3 vec) {
+    vec3 avec = abs(vec);
     float scale = 1.0 - 1.0 / 128.0;
-    float M = max(max(abs(vec.x), abs(vec.y)), abs(vec.z));
-    if (abs(vec.x) != M) vec.x *= scale;
-    if (abs(vec.y) != M) vec.y *= scale;
-    if (abs(vec.z) != M) vec.z *= scale;
+    float M = max(max(avec.x, avec.y), avec.z);
+    if (avec.x != M) vec.x *= scale;
+    if (avec.y != M) vec.y *= scale;
+    if (avec.z != M) vec.z *= scale;
     return vec;
 }
 
 vec3 fixSeamsStatic(vec3 vec, float invRecMipSize) {
+    vec3 avec = abs(vec);
     float scale = invRecMipSize;
-    float M = max(max(abs(vec.x), abs(vec.y)), abs(vec.z));
-    if (abs(vec.x) != M) vec.x *= scale;
-    if (abs(vec.y) != M) vec.y *= scale;
-    if (abs(vec.z) != M) vec.z *= scale;
+    float M = max(max(avec.x, avec.y), avec.z);
+    if (avec.x != M) vec.x *= scale;
+    if (avec.y != M) vec.y *= scale;
+    if (avec.z != M) vec.z *= scale;
     return vec;
 }
 

--- a/src/graphics/program-lib/chunks/reflectionPrefilteredCubeLod.frag
+++ b/src/graphics/program-lib/chunks/reflectionPrefilteredCubeLod.frag
@@ -1,8 +1,5 @@
-#ifndef PMREM4
-#define PMREM4
-#ifndef GL2
-#extension GL_EXT_shader_texture_lod : enable
-#endif
+#ifndef PMREM128
+#define PMREM128
 uniform samplerCube texture_prefilteredCubeMap128;
 #endif
 uniform float material_reflectivity;

--- a/src/graphics/program-lib/programs/standard.js
+++ b/src/graphics/program-lib/programs/standard.js
@@ -912,8 +912,13 @@ const standard = {
             code += versionCode(device);
         }
 
-        if (device.extStandardDerivatives && !device.webgl2) {
-            code += "#extension GL_OES_standard_derivatives : enable\n\n";
+        if (!device.webgl2) {
+            if (device.extStandardDerivatives) {
+                code += "#extension GL_OES_standard_derivatives : enable\n";
+            }
+            if (device.extTextureLod) {
+                code += "#extension GL_EXT_shader_texture_lod : enable\n";
+            }
         }
         if (chunks.extensionPS) {
             code += chunks.extensionPS + "\n";


### PR DESCRIPTION
WebGL 1 expects #extension declarations to come first in the GLSL source.

The old method seems to have worked on some devices, but it will fails on others.

This PR:
- moves textureLod extension declaration to the top of the source file (along with GL_OES_standard_derivatives)
- update seam calculation to invoke abs once instead of 6 times