### PR TITLE
Add SHADOWPASS #define to shader

### DIFF
--- a/src/graphics/program-lib/programs/standard.js
+++ b/src/graphics/program-lib/programs/standard.js
@@ -414,6 +414,17 @@ const standard = {
         }
     },
 
+    _getPassDefineString: function (pass) {
+        if (pass === SHADER_PICK) {
+            return '#define PICK_PASS\n';
+        } else if (pass === SHADER_DEPTH) {
+            return '#define DEPTH_PASS\n';
+        } else if (pass >= SHADER_SHADOW && pass <= 17) {
+            return '#define SHADOW_PASS\n';
+        }
+        return '';
+    },
+
     _vsAddTransformCode: function (code, device, chunks, options) {
         code += chunks.transformVS;
 
@@ -655,13 +666,7 @@ const standard = {
             chunks = customChunks;
         }
 
-        if (options.pass === SHADER_PICK) {
-            code += '#define PICKPASS\n';
-        } else if (options.pass === SHADER_DEPTH) {
-            code += '#define DEPTHPASS\n';
-        } else if (shadowPass) {
-            code += '#define SHADOWPASS\n';
-        }
+        code += this._getPassDefineString(options.pass);
 
         // code += chunks.baseVS;
         code = this._vsAddBaseCode(code, device, chunks, options);
@@ -937,9 +942,10 @@ const standard = {
 
         code += options.forceFragmentPrecision ? "precision " + options.forceFragmentPrecision + " float;\n\n" : precisionCode(device);
 
+        code += this._getPassDefineString(options.pass);
+
         if (options.pass === SHADER_PICK) {
             // ##### PICK PASS #####
-            code += '#define PICKPASS\n';
             code += "uniform vec4 uColor;\n";
             code += varyings;
             if (options.alphaTest) {
@@ -962,7 +968,6 @@ const standard = {
 
         } else if (options.pass === SHADER_DEPTH) {
             // ##### SCREEN DEPTH PASS #####
-            code += '#define DEPTHPASS\n';
             code += 'varying float vDepth;\n';
             code += varyings;
             code += chunks.packDepthPS;
@@ -986,7 +991,6 @@ const standard = {
 
         } else if (shadowPass) {
             // ##### SHADOW PASS #####
-            code += '#define SHADOWPASS\n';
             return {
                 attributes: attributes,
                 vshader: vshader,

--- a/src/graphics/program-lib/programs/standard.js
+++ b/src/graphics/program-lib/programs/standard.js
@@ -674,6 +674,10 @@ const standard = {
             codeBody += "    vDepth = -(matrix_view * vec4(vPositionW,1.0)).z * camera_params.x;\n";
         }
 
+        if (shadowPass) {
+            code += '#define SHADOWPASS\n';
+        }
+
         if (options.useInstancing) {
             attributes.instance_line1 = SEMANTIC_ATTR12;
             attributes.instance_line2 = SEMANTIC_ATTR13;

--- a/src/graphics/program-lib/programs/standard.js
+++ b/src/graphics/program-lib/programs/standard.js
@@ -655,6 +655,13 @@ const standard = {
             chunks = customChunks;
         }
 
+        if (options.pass === SHADER_PICK) {
+            code += '#define PICKPASS\n';
+        } else if (options.pass === SHADER_DEPTH) {
+            code += '#define DEPTHPASS\n';
+        } else if (shadowPass) {
+            code += '#define SHADOWPASS\n';
+        }
 
         // code += chunks.baseVS;
         code = this._vsAddBaseCode(code, device, chunks, options);
@@ -672,10 +679,6 @@ const standard = {
             code += 'uniform vec4 camera_params;\n\n';
             code += '#endif\n';
             codeBody += "    vDepth = -(matrix_view * vec4(vPositionW,1.0)).z * camera_params.x;\n";
-        }
-
-        if (shadowPass) {
-            code += '#define SHADOWPASS\n';
         }
 
         if (options.useInstancing) {
@@ -936,6 +939,7 @@ const standard = {
 
         if (options.pass === SHADER_PICK) {
             // ##### PICK PASS #####
+            code += '#define PICKPASS\n';
             code += "uniform vec4 uColor;\n";
             code += varyings;
             if (options.alphaTest) {
@@ -958,6 +962,7 @@ const standard = {
 
         } else if (options.pass === SHADER_DEPTH) {
             // ##### SCREEN DEPTH PASS #####
+            code += '#define DEPTHPASS\n';
             code += 'varying float vDepth;\n';
             code += varyings;
             code += chunks.packDepthPS;
@@ -981,6 +986,7 @@ const standard = {
 
         } else if (shadowPass) {
             // ##### SHADOW PASS #####
+            code += '#define SHADOWPASS\n';
             return {
                 attributes: attributes,
                 vshader: vshader,


### PR DESCRIPTION
Similar to https://github.com/playcanvas/engine/pull/2454
This PR adds `#define SHADOWPASS` to the vertex shader, so it can be used for branching logic when writing custom shader chunks. So the developer has the ability to avoid some unwanted shader code in the shadow pass shader variant.

Usage example: Seethrough effect, when you want to offset geometry when it obstructs visibility of a character, but don't want to lose original shadows.

This change has no effect on the existing project.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
