### PR TITLE
[Fix] Corrected aabb computation for morphed meshes

### DIFF
--- a/src/scene/morph.js
+++ b/src/scene/morph.js
@@ -260,8 +260,8 @@ class Morph extends RefCountedObject {
             max.max(targetAabb.getMax());
         }
 
-        this.aabb = new BoundingBox(new Vec3(0, 0, 0), new Vec3(0, 0, 0));
-        this.aabb._expand(min, max);
+        this.aabb = new BoundingBox();
+        this.aabb.setMinMax(min, max);
     }
 
     // creates texture. Used to create both source morph target data, as well as render target used to morph these into, positions and normals

--- a/src/scene/morph.js
+++ b/src/scene/morph.js
@@ -250,7 +250,7 @@ class Morph extends RefCountedObject {
 
         // calculate min and max expansion size
         // Note: This represents average case, where most morph targets expand the mesh within the same area. It does not
-        // represents the stacked worst case scenario where all morphs could be enabled at the same time, as this can result
+        // represent the stacked worst case scenario where all morphs could be enabled at the same time, as this can result
         // in a very large aabb. In cases like this, the users should specify customAabb for Model/Render component.
         const min = new Vec3();
         const max = new Vec3();

--- a/src/scene/morph.js
+++ b/src/scene/morph.js
@@ -248,13 +248,20 @@ class Morph extends RefCountedObject {
 
     _calculateAabb() {
 
-        this.aabb = new BoundingBox(new Vec3(0, 0, 0), new Vec3(0, 0, 0));
-
-        // calc bounding box of the relative change this morph can add
+        // calculate min and max expansion size
+        // Note: This represents average case, where most morph targets expand the mesh within the same area. It does not
+        // represents the stacked worst case scenario where all morphs could be enabled at the same time, as this can result
+        // in a very large aabb. In cases like this, the users should specify customAabb for Model/Render component.
+        const min = new Vec3();
+        const max = new Vec3();
         for (let i = 0; i < this._targets.length; i++) {
-            const target = this._targets[i];
-            this.aabb._expand(target.aabb.getMin(), target.aabb.getMax());
+            const targetAabb = this._targets[i].aabb;
+            min.min(targetAabb.getMin());
+            max.max(targetAabb.getMax());
         }
+
+        this.aabb = new BoundingBox(new Vec3(0, 0, 0), new Vec3(0, 0, 0));
+        this.aabb._expand(min, max);
     }
 
     // creates texture. Used to create both source morph target data, as well as render target used to morph these into, positions and normals


### PR DESCRIPTION
Fixes https://github.com/playcanvas/engine/issues/3702

Fixes the aabb estimation for non-skinned meshes with morphing - it was incorrectly estimated, and aabb of mesh instance could be modified the way the mesh would no longer be visible as it would get culled.

This brings it to parity with skinned morphed meshes.

**Behaviour change**: This represents average case, where most morph targets expand the mesh within the same area. It does not represent the stacked worst case scenario where all morphs could be enabled at the same time, as this can result in a very large aabb. In cases like this, the users should specify customAabb for Model/Render component.