### PR TITLE
Always fire element set:color and set:opacity event when color and opacity is set

### DIFF
--- a/src/framework/components/element/image-element.js
+++ b/src/framework/components/element/image-element.js
@@ -1139,10 +1139,10 @@ class ImageElement {
             } else {
                 this.sprite = null;
             }
+        }
 
-            if (this._element) {
-                this._element.fire('set:spriteAsset', _id);
-            }
+        if (this._element) {
+            this._element.fire('set:spriteAsset', _id);
         }
     }
 
@@ -1207,9 +1207,9 @@ class ImageElement {
             this._spriteFrame = value;
         }
 
-        if (this._spriteFrame === oldValue) return;
-
-        this._updateSprite();
+        if (this._spriteFrame !== oldValue) {
+            this._updateSprite();
+        }
 
         if (this._element) {
             this._element.fire('set:spriteFrame', value);

--- a/src/framework/components/element/image-element.js
+++ b/src/framework/components/element/image-element.js
@@ -883,18 +883,16 @@ class ImageElement {
         }
         // #endif
 
-        if (this._color.r === r && this._color.g === g && this._color.b === b) {
-            return;
+        if (this._color.r !== r || this._color.g !== g || this._color.b !== b) {
+            this._color.r = r;
+            this._color.g = g;
+            this._color.b = b;
+
+            this._colorUniform[0] = r;
+            this._colorUniform[1] = g;
+            this._colorUniform[2] = b;
+            this._renderable.setParameter('material_emissive', this._colorUniform);
         }
-
-        this._color.r = r;
-        this._color.g = g;
-        this._color.b = b;
-
-        this._colorUniform[0] = r;
-        this._colorUniform[1] = g;
-        this._colorUniform[2] = b;
-        this._renderable.setParameter('material_emissive', this._colorUniform);
 
         if (this._element) {
             this._element.fire('set:color', this._color);
@@ -906,11 +904,10 @@ class ImageElement {
     }
 
     set opacity(value) {
-        if (value === this._color.a) return;
-
-        this._color.a = value;
-
-        this._renderable.setParameter('material_opacity', value);
+        if (value !== this._color.a) {
+            this._color.a = value;
+            this._renderable.setParameter('material_opacity', value);
+        }
 
         if (this._element) {
             this._element.fire('set:opacity', value);


### PR DESCRIPTION
Fixes #3760

PR to branch "release 1.50.0" as I would like to get this out in the next patch

(Also remember to merge release to dev)

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
