### PR TITLE
[Fix] Fixed standard shader generation when GGX is enabled but there are no lights

### DIFF
--- a/src/graphics/program-lib/programs/standard.js
+++ b/src/graphics/program-lib/programs/standard.js
@@ -1379,7 +1379,7 @@ const standard = {
 
             code += "   getNormal();\n";
             if (options.useSpecular) {
-                if (options.enableGGXSpecular) {
+                if (lighting && options.enableGGXSpecular) {
                     code += "   getGlossiness();\n";
                     getGlossinessCalled = true;
                 }


### PR DESCRIPTION
Fixes https://github.com/playcanvas/engine/issues/3762