### PR TITLE
Make text-element color and opacity setter consistent with image-element.

### DIFF
--- a/src/framework/components/element/text-element.js
+++ b/src/framework/components/element/text-element.js
@@ -1304,28 +1304,30 @@ class TextElement {
         }
         // #endif
 
-        if (this._color.r === r && this._color.g === g && this._color.b === b) {
-            return;
+        if (this._color.r !== r || this._color.g !== g || this._color.b !== b) {
+            this._color.r = r;
+            this._color.g = g;
+            this._color.b = b;
+
+            if (this._symbolColors) {
+                // color is baked into vertices, update text
+                if (this._font) {
+                    this._updateText();
+                }
+            } else {
+                this._colorUniform[0] = this._color.r;
+                this._colorUniform[1] = this._color.g;
+                this._colorUniform[2] = this._color.b;
+
+                for (let i = 0, len = this._model.meshInstances.length; i < len; i++) {
+                    const mi = this._model.meshInstances[i];
+                    mi.setParameter('material_emissive', this._colorUniform);
+                }
+            }
         }
 
-        this._color.r = r;
-        this._color.g = g;
-        this._color.b = b;
-
-        if (this._symbolColors) {
-            // color is baked into vertices, update text
-            if (this._font) {
-                this._updateText();
-            }
-        } else {
-            this._colorUniform[0] = this._color.r;
-            this._colorUniform[1] = this._color.g;
-            this._colorUniform[2] = this._color.b;
-
-            for (let i = 0, len = this._model.meshInstances.length; i < len; i++) {
-                const mi = this._model.meshInstances[i];
-                mi.setParameter('material_emissive', this._colorUniform);
-            }
+        if (this._element) {
+            this._element.fire('set:color', this._color);
         }
     }
 
@@ -1334,15 +1336,19 @@ class TextElement {
     }
 
     set opacity(value) {
-        if (this._color.a === value) return;
+        if (this._color.a !== value) {
+            this._color.a = value;
 
-        this._color.a = value;
-
-        if (this._model) {
-            for (let i = 0, len = this._model.meshInstances.length; i < len; i++) {
-                const mi = this._model.meshInstances[i];
-                mi.setParameter('material_opacity', value);
+            if (this._model) {
+                for (let i = 0, len = this._model.meshInstances.length; i < len; i++) {
+                    const mi = this._model.meshInstances[i];
+                    mi.setParameter('material_opacity', value);
+                }
             }
+        }
+
+        if (this._element) {
+            this._element.fire('set:opacity', value);
         }
     }
 


### PR DESCRIPTION
This PR makes the logic for setting `color` and `opacity` on `text-element` consistent with the logic for `image-element` from https://github.com/playcanvas/engine/pull/3761. This PR also adds the correct event firing for these properties.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
