### PR TITLE
Assign animations events when animation asset is loaded

### DIFF
--- a/src/framework/components/anim/component.js
+++ b/src/framework/components/anim/component.js
@@ -381,11 +381,11 @@ class AnimComponent extends Component {
                 // check whether assigned animation asset still exists
                 if (asset) {
                     if (asset.resource) {
-                        this.onAnimAssetLoaded(layer.name, stateName, asset);
+                        this.onAnimationAssetLoaded(layer.name, stateName, asset);
                     } else {
                         asset.once('load', function (layerName, stateName) {
                             return function (asset) {
-                                this.onAnimAssetLoaded(layerName, stateName, asset);
+                                this.onAnimationAssetLoaded(layerName, stateName, asset);
                             }.bind(this);
                         }.bind(this)(layer.name, stateName));
                         this.system.app.assets.load(asset);
@@ -395,7 +395,7 @@ class AnimComponent extends Component {
         }
     }
 
-    onAnimAssetLoaded(layerName, stateName, asset) {
+    onAnimationAssetLoaded(layerName, stateName, asset) {
         const animTrack = asset.resource;
         if (asset.data.events) {
             animTrack.events = new AnimEvents(Object.values(asset.data.events));

--- a/src/framework/components/anim/component.js
+++ b/src/framework/components/anim/component.js
@@ -381,15 +381,11 @@ class AnimComponent extends Component {
                 // check whether assigned animation asset still exists
                 if (asset) {
                     if (asset.resource) {
-                        const animTrack = asset.resource;
-                        if (asset.data.events) {
-                            animTrack.events = new AnimEvents(Object.values(asset.data.events));
-                        }
-                        this.findAnimationLayer(layer.name).assignAnimation(stateName, animTrack);
+                        this.onAnimAssetLoaded(layer.name, stateName, asset);
                     } else {
                         asset.once('load', function (layerName, stateName) {
                             return function (asset) {
-                                this.findAnimationLayer(layerName).assignAnimation(stateName, asset.resource);
+                                this.onAnimAssetLoaded(layerName, stateName, asset);
                             }.bind(this);
                         }.bind(this)(layer.name, stateName));
                         this.system.app.assets.load(asset);
@@ -397,6 +393,14 @@ class AnimComponent extends Component {
                 }
             }
         }
+    }
+
+    onAnimAssetLoaded(layerName, stateName, asset) {
+        const animTrack = asset.resource;
+        if (asset.data.events) {
+            animTrack.events = new AnimEvents(Object.values(asset.data.events));
+        }
+        this.findAnimationLayer(layerName).assignAnimation(stateName, asset.resource);
     }
 
     /**


### PR DESCRIPTION
Fixes https://github.com/playcanvas/engine/issues/3765

Note: merging to branch release 1.50.0

If the animation asset is not loaded when the anim component needs it, it component starts a load on the asset but doesn't assign the anim events of the asset to the track.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
