### PR TITLE
[AnimComponent] First frame bug fix

### DIFF
--- a/src/anim/controller/anim-controller.js
+++ b/src/anim/controller/anim-controller.js
@@ -521,7 +521,7 @@ class AnimController {
         if (this._isTransitioning) {
             this._currTransitionTime += dt;
             if (this._currTransitionTime <= this._totalTransitionTime) {
-                const interpolatedTime = this._totalTransitionTime ? this._currTransitionTime / this._totalTransitionTime : 1;
+                const interpolatedTime = this._totalTransitionTime === 0 ? this._currTransitionTime / this._totalTransitionTime : 1;
                 // while transitioning, set all previous state animations to be weighted by (1.0 - interpolationTime).
                 for (let i = 0; i < this._transitionPreviousStates.length; i++) {
                     state = this._findState(this._transitionPreviousStates[i].name);

--- a/src/anim/controller/anim-controller.js
+++ b/src/anim/controller/anim-controller.js
@@ -512,7 +512,6 @@ class AnimController {
         let clip;
         this._timeInStateBefore = this._timeInState;
         this._timeInState += dt;
-        console.log('here');
 
         // transition between states if a transition is available from the active state
         const transition = this._findTransition(this._activeStateName);

--- a/src/anim/controller/anim-controller.js
+++ b/src/anim/controller/anim-controller.js
@@ -512,6 +512,7 @@ class AnimController {
         let clip;
         this._timeInStateBefore = this._timeInState;
         this._timeInState += dt;
+        console.log('here');
 
         // transition between states if a transition is available from the active state
         const transition = this._findTransition(this._activeStateName);
@@ -521,7 +522,7 @@ class AnimController {
         if (this._isTransitioning) {
             this._currTransitionTime += dt;
             if (this._currTransitionTime <= this._totalTransitionTime) {
-                const interpolatedTime = this._currTransitionTime / this._totalTransitionTime;
+                const interpolatedTime = this._totalTransitionTime ? this._currTransitionTime / this._totalTransitionTime : 1;
                 // while transitioning, set all previous state animations to be weighted by (1.0 - interpolationTime).
                 for (let i = 0; i < this._transitionPreviousStates.length; i++) {
                     state = this._findState(this._transitionPreviousStates[i].name);

--- a/src/framework/components/anim/component.js
+++ b/src/framework/components/anim/component.js
@@ -344,6 +344,7 @@ class AnimComponent extends Component {
             this._addLayer.bind(this)({ ...layer });
         }
         this.setupAnimationAssets();
+        console.log('here');
     }
 
     setupAnimationAssets() {

--- a/src/framework/components/anim/component.js
+++ b/src/framework/components/anim/component.js
@@ -344,7 +344,6 @@ class AnimComponent extends Component {
             this._addLayer.bind(this)({ ...layer });
         }
         this.setupAnimationAssets();
-        console.log('here');
     }
 
     setupAnimationAssets() {


### PR DESCRIPTION
The first update of the anim component created a divide by 0 error, which caused the output values of all animations during the initial frame to contain incorrect values.

Fixes #3533 

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
