### PR TITLE
Create examples for the proper use of world-space screens and world to screen coordinates.

### DIFF
--- a/examples/src/examples/user-interface/custom-shader.tsx
+++ b/examples/src/examples/user-interface/custom-shader.tsx
@@ -68,7 +68,7 @@ void main(void)
 
 class UserInterfaceCustomShaderExample extends Example {
     static CATEGORY = 'User Interface';
-    static NAME = 'Custom Shaders';
+    static NAME = 'Custom Shader';
 
     load() {
         return <>

--- a/examples/src/examples/user-interface/world-ui.tsx
+++ b/examples/src/examples/user-interface/world-ui.tsx
@@ -1,0 +1,144 @@
+import React from 'react';
+import * as pc from 'playcanvas/build/playcanvas.js';
+import { AssetLoader } from '../../app/helpers/loader';
+import Example from '../../app/example';
+
+class WorldScreenExample extends Example {
+    static CATEGORY = 'User Interface';
+    static NAME = 'World UI';
+
+    load() {
+        return <>
+            <AssetLoader name="checkboard" type="texture" url="static/assets/textures/checkboard.png" />
+            <AssetLoader name='font' type='font' url='static/assets/fonts/courier.json' />
+            <AssetLoader name='script' type='script' url='static/scripts/camera/orbit-camera.js' />
+        </>;
+    }
+
+    example(canvas: HTMLCanvasElement, assets: { checkboard: pc.Asset, font: pc.Asset, script: pc.Asset }): void {
+
+        // Create the application with input and start the update loop
+        const app = new pc.Application(canvas, {
+            mouse: new pc.Mouse(document.body),
+            touch: new pc.TouchDevice(document.body),
+            elementInput: new pc.ElementInput(canvas)
+        });
+        app.start();
+
+        // Create an Entity with a camera component and simple orbiter script
+        const camera = new pc.Entity();
+        camera.addComponent("camera", {
+            clearColor: new pc.Color(30 / 255, 30 / 255, 30 / 255)
+        });
+        camera.rotateLocal(-30, 0, 0);
+        camera.translateLocal(0, 0, 7);
+        camera.addComponent("script");
+        camera.script.create("orbitCamera", {
+            attributes: {
+                inertiaFactor: 0.2 // Override default of 0 (no inertia)
+            }
+        });
+        camera.script.create("orbitCameraInputMouse");
+        camera.script.create("orbitCameraInputTouch");
+        app.root.addChild(camera);
+
+        // Create an Entity for the ground
+        const material = new pc.StandardMaterial();
+        material.diffuse = pc.Color.WHITE;
+        material.diffuseMap = assets.checkboard.resource;
+        material.diffuseMapTiling = new pc.Vec2(50, 50);
+        material.update();
+
+        const ground = new pc.Entity();
+        ground.addComponent("render", {
+            type: "box",
+            material: material
+        });
+        ground.setLocalScale(50, 1, 50);
+        ground.setLocalPosition(0, -0.5, 0);
+        app.root.addChild(ground);
+
+        // Create an entity with a light component
+        const light = new pc.Entity();
+        light.addComponent("light", {
+            type: "directional",
+            color: new pc.Color(1, 1, 1),
+            castShadows: true,
+            intensity: 1,
+            shadowBias: 0.2,
+            shadowDistance: 16,
+            normalOffsetBias: 0.05,
+            shadowResolution: 2048
+        });
+        light.setLocalEulerAngles(45, 30, 0);
+        app.root.addChild(light);
+
+        // Create a 3D world screen, which is basically a `screen` with `screenSpace` set to false
+        const screen = new pc.Entity();
+        screen.setLocalScale(0.01, 0.01, 0.01);
+        screen.setPosition(0, 0.01, 0); // place UI slightly above the ground
+        screen.setLocalRotation(new pc.Quat().setFromEulerAngles(-90, 0, 0));
+        screen.addComponent("screen", {
+            referenceResolution: new pc.Vec2(1280, 720),
+            screenSpace: false
+        });
+        app.root.addChild(screen);
+
+        // Text
+        const text = new pc.Entity();
+        text.setLocalPosition(0, 25, 0);
+        text.addComponent("element", {
+            pivot: new pc.Vec2(0.5, 0.5),
+            anchor: new pc.Vec4(0.5, 0.5, 0.5, 0.5),
+            fontAsset: assets.font.id,
+            fontSize: 18,
+            text: "this is a UI screen placed in the 3D world",
+            width: 200,
+            height: 100,
+            autoWidth: false,
+            autoHeight: false,
+            wrapLines: true,
+            enableMarkup: true,
+            type: pc.ELEMENTTYPE_TEXT
+        });
+        screen.addChild(text);
+
+        // Button
+        const button = new pc.Entity();
+        button.setLocalPosition(0, -25, 0);
+        button.addComponent("button", {
+            imageEntity: button
+        });
+        button.addComponent("element", {
+            anchor: [0.5, 0.5, 0.5, 0.5],
+            width: 100,
+            height: 25,
+            pivot: [0.5, 0.5],
+            type: pc.ELEMENTTYPE_IMAGE,
+            useInput: true
+        });
+        screen.addChild(button);
+
+        // Create a label for the button
+        const buttonText = new pc.Entity();
+        buttonText.addComponent("element", {
+            pivot: new pc.Vec2(0.5, 0.5),
+            anchor: new pc.Vec4(0, 0, 1, 1),
+            margin: new pc.Vec4(0, 0, 0, 0),
+            color: new pc.Color(0, 0, 0),
+            fontAsset: assets.font.id,
+            fontSize: 12,
+            text: "and this is a button",
+            type: pc.ELEMENTTYPE_TEXT,
+            wrapLines: true
+        });
+        button.addChild(buttonText);
+
+        // Change the background color every time the button is clicked
+        button.button.on('click', function (e) {
+            camera.camera.clearColor = new pc.Color(Math.random(), Math.random(), Math.random());
+        });
+    }
+}
+
+export default WorldScreenExample;


### PR DESCRIPTION
This PR changes the UI examples related to world-space by making sure it showcases the intended usage of the world-space screens, and creates a new example showing how to convert world-space to screen-space coordinates.

### World to screen

This example shows how to convert world position to screen position. The UI elements in this example are in a regular 2d screen.

<img width="1440" alt="Screenshot 2021-12-03 at 14 36 28" src="https://user-images.githubusercontent.com/6392953/144620320-d32e3bb3-0be8-4b38-9f91-eb20b26591bc.png">


### World UI

This example shows how to setup a UI screen that exists in the 3D world.

<img width="1454" alt="Screenshot 2021-12-03 at 14 37 12" src="https://user-images.githubusercontent.com/6392953/144620417-25ee34d0-3261-44fc-80f2-6ae9a077d2d5.png">



I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
