### PR TITLE
[AnimComponent] Update the assignAnimation function signature and documentation with blend tree support

### DIFF
--- a/src/framework/components/anim/component-layer.js
+++ b/src/framework/components/anim/component-layer.js
@@ -94,7 +94,7 @@ class AnimComponentLayer {
      * @function
      * @name AnimComponentLayer#assignAnimation
      * @description Assigns an animation track to a state or blend tree node in the current graph. If a state for the given nodePath doesn't exist, it will be created. If all states nodes are linked and the {@link AnimComponent#activate} value was set to true then the component will begin playing.
-     * @param {string} nodePath - Either the state name or the path to a blend tree node that this animation should be associated with. Each section of a blend tree path is split using a punctuation mark therefore state names should not include this character (e.g "MyStateName" or "MyStateName.BlendTreeNode").
+     * @param {string} nodePath - Either the state name or the path to a blend tree node that this animation should be associated with. Each section of a blend tree path is split using a period (`.`) therefore state names should not include this character (e.g "MyStateName" or "MyStateName.BlendTreeNode").
      * @param {object} animTrack - The animation track that will be assigned to this state and played whenever this state is active.
      * @param {number} [speed] - Update the speed of the state you are assigning an animation to. Defaults to 1.
      * @param {boolean} [loop] - Update the loop property of the state you are assigning an animation to. Defaults to true.

--- a/src/framework/components/anim/component-layer.js
+++ b/src/framework/components/anim/component-layer.js
@@ -93,24 +93,24 @@ class AnimComponentLayer {
     /**
      * @function
      * @name AnimComponentLayer#assignAnimation
-     * @description Assigns an animation track to a state in the current graph. If a state for the given nodeName doesn't exist, it will be created. If all states nodes are linked and the {@link AnimComponent#activate} value was set to true then the component will begin playing.
-     * @param {string} nodeName - The name of the node that this animation should be associated with.
+     * @description Assigns an animation track to a state or blend tree node in the current graph. If a state for the given nodePath doesn't exist, it will be created. If all states nodes are linked and the {@link AnimComponent#activate} value was set to true then the component will begin playing.
+     * @param {string} nodePath - Either the state name or the path to a blend tree node that this animation should be associated with. Each section of a blend tree path is split using a punctuation mark therefore state names should not include this character (e.g "MyStateName" or "MyStateName.BlendTreeNode").
      * @param {object} animTrack - The animation track that will be assigned to this state and played whenever this state is active.
      * @param {number} [speed] - Update the speed of the state you are assigning an animation to. Defaults to 1.
      * @param {boolean} [loop] - Update the loop property of the state you are assigning an animation to. Defaults to true.
      */
-    assignAnimation(nodeName, animTrack, speed, loop) {
+    assignAnimation(nodePath, animTrack, speed, loop) {
         if (animTrack.constructor !== AnimTrack) {
             // #if _DEBUG
             console.error('assignAnimation: animTrack supplied to function was not of type AnimTrack');
             // #endif
             return;
         }
-        this._controller.assignAnimation(nodeName, animTrack, speed, loop);
+        this._controller.assignAnimation(nodePath, animTrack, speed, loop);
         if (this._controller._transitions.length === 0) {
             this._controller._transitions.push(new AnimTransition({
                 from: 'START',
-                to: nodeName
+                to: nodePath
             }));
         }
         if (this._component.activate && this._component.playable) {

--- a/src/framework/components/anim/component.js
+++ b/src/framework/components/anim/component.js
@@ -507,16 +507,16 @@ class AnimComponent extends Component {
     /**
      * @function
      * @name AnimComponent#assignAnimation
-     * @description Associates an animation with a state in the loaded state graph. If all states are linked and the {@link AnimComponent#activate} value was set to true then the component will begin playing.
-     * If no state graph is loaded, a default state graph will be created with a single state based on the provided nodeName parameter.
-     * @param {string} nodeName - The name of the state node that this animation should be associated with.
+     * @description Associates an animation with a state or blend tree node in the loaded state graph. If all states are linked and the {@link AnimComponent#activate} value was set to true then the component will begin playing.
+     * If no state graph is loaded, a default state graph will be created with a single state based on the provided nodePath parameter.
+     * @param {string} nodePath - Either the state name or the path to a blend tree node that this animation should be associated with. Each section of a blend tree path is split using a punctuation mark therefore state names should not include this character (e.g "MyStateName" or "MyStateName.BlendTreeNode").
      * @param {object} animTrack - The animation track that will be assigned to this state and played whenever this state is active.
      * @param {string} [layerName] - The name of the anim component layer to update. If omitted the default layer is used. If no state graph has been previously loaded this parameter is ignored.
      * @param {number} [speed] - Update the speed of the state you are assigning an animation to. Defaults to 1.
      * @param {boolean} [loop] - Update the loop property of the state you are assigning an animation to. Defaults to true.
      */
-    assignAnimation(nodeName, animTrack, layerName, speed = 1, loop = true) {
-        if (!this._stateGraph) {
+    assignAnimation(nodePath, animTrack, layerName, speed = 1, loop = true) {
+        if (!this._stateGraph && nodePath.indexOf('.') !== -1) {
             this.loadStateGraph(new AnimStateGraph({
                 "layers": [
                     {
@@ -527,7 +527,7 @@ class AnimComponent extends Component {
                                 "speed": 1
                             },
                             {
-                                "name": nodeName,
+                                "name": nodePath,
                                 "speed": speed,
                                 "loop": loop,
                                 "defaultState": true
@@ -536,14 +536,14 @@ class AnimComponent extends Component {
                         "transitions": [
                             {
                                 "from": 'START',
-                                "to": nodeName
+                                "to": nodePath
                             }
                         ]
                     }
                 ],
                 "parameters": {}
             }));
-            this.baseLayer.assignAnimation(nodeName, animTrack);
+            this.baseLayer.assignAnimation(nodePath, animTrack);
             return;
         }
         const layer = layerName ? this.findAnimationLayer(layerName) : this.baseLayer;
@@ -553,7 +553,7 @@ class AnimComponent extends Component {
             // #endif
             return;
         }
-        layer.assignAnimation(nodeName, animTrack, speed, loop);
+        layer.assignAnimation(nodePath, animTrack, speed, loop);
     }
 
     /**

--- a/src/framework/components/anim/component.js
+++ b/src/framework/components/anim/component.js
@@ -509,7 +509,7 @@ class AnimComponent extends Component {
      * @name AnimComponent#assignAnimation
      * @description Associates an animation with a state or blend tree node in the loaded state graph. If all states are linked and the {@link AnimComponent#activate} value was set to true then the component will begin playing.
      * If no state graph is loaded, a default state graph will be created with a single state based on the provided nodePath parameter.
-     * @param {string} nodePath - Either the state name or the path to a blend tree node that this animation should be associated with. Each section of a blend tree path is split using a punctuation mark therefore state names should not include this character (e.g "MyStateName" or "MyStateName.BlendTreeNode").
+     * @param {string} nodePath - Either the state name or the path to a blend tree node that this animation should be associated with. Each section of a blend tree path is split using a period (`.`) therefore state names should not include this character (e.g "MyStateName" or "MyStateName.BlendTreeNode").
      * @param {object} animTrack - The animation track that will be assigned to this state and played whenever this state is active.
      * @param {string} [layerName] - The name of the anim component layer to update. If omitted the default layer is used. If no state graph has been previously loaded this parameter is ignored.
      * @param {number} [speed] - Update the speed of the state you are assigning an animation to. Defaults to 1.


### PR DESCRIPTION
The assignAnimation functions in the anim component and anim component layer support both states and blend tree nodes. The function signature and docs should reflect this.

Fixes #3586 

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
