### PR TITLE
[AnimComponent] fix a bug with the assignAnimation function

### DIFF
--- a/src/framework/components/anim/component.js
+++ b/src/framework/components/anim/component.js
@@ -516,7 +516,7 @@ class AnimComponent extends Component {
      * @param {boolean} [loop] - Update the loop property of the state you are assigning an animation to. Defaults to true.
      */
     assignAnimation(nodePath, animTrack, layerName, speed = 1, loop = true) {
-        if (!this._stateGraph && nodePath.indexOf('.') !== -1) {
+        if (!this._stateGraph && nodePath.indexOf('.') === -1) {
             this.loadStateGraph(new AnimStateGraph({
                 "layers": [
                     {


### PR DESCRIPTION
The assignAnimation function was not creating a state graph when assigning the first animation to a state due to a bug in the check for a BlendTree path in the first parameter.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
