### PR TITLE
fix chunk naming

### DIFF
--- a/src/graphics/program-lib/programs/skybox.js
+++ b/src/graphics/program-lib/programs/skybox.js
@@ -38,7 +38,7 @@ const skybox = {
             fshader += gammaCode(options.gamma);
             fshader += tonemapCode(options.toneMapping);
             fshader += shaderChunks.decodePS;
-            fshader += shaderChunks.skyboxEnvAtlasPS.replace(/\$DECODE/g, decodeTable[options.encoding] || "decodeGamma");
+            fshader += shaderChunks.skyboxEnvPS.replace(/\$DECODE/g, decodeTable[options.encoding] || "decodeGamma");
         }
 
         return {


### PR DESCRIPTION
First fix for https://github.com/playcanvas/engine/pull/3783.

A last minute chunk rename wasn't correctly applied to skybox.