### PR TITLE
Resolve animation nodes correctly and uniquify sibling node names

### DIFF
--- a/src/anim/binder/default-anim-binder.js
+++ b/src/anim/binder/default-anim-binder.js
@@ -159,7 +159,34 @@ class DefaultAnimBinder {
 
         let node;
         if (this.graph) {
-            node = this.graph.findByPath(path.entityPath);
+            const entityPath = path.entityPath;
+
+            if (this.graph.name === entityPath[0]) {
+                // handle fully specified path
+                const findChild = (node, name) => {
+                    const children = node.children;
+                    for (let i = 0; i < children.length; ++i) {
+                        const child = children[i];
+                        if (child.name === name) {
+                            return child;
+                        }
+                    }
+                    return null;
+                };
+
+                node = this.graph;
+                for (let i = 1; i < entityPath.length; ++i) {
+                    node = findChild(node, entityPath[i]);
+                    if (!node) {
+                        break;
+                    }
+                }
+            }
+
+            // fall back to old method if node wasn't found
+            if (!node) {
+                node = this.graph.findByPath(path.entityPath);
+            }
         }
         if (!node) {
             node = this.nodes[path.entityPath[path.entityPath.length - 1] || ""];

--- a/src/resources/parser/glb-parser.js
+++ b/src/resources/parser/glb-parser.js
@@ -1356,6 +1356,15 @@ const createAnimation = function (gltfAnimation, animationIndex, gltfAccessors, 
         'weights': 'weights'
     };
 
+    const constructNodePath = (node) => {
+        const path = [];
+        while (node) {
+            path.splice(0, 0, node.name);
+            node = node.parent;
+        }
+        return path;
+    };
+
     // convert anim channels
     for (i = 0; i < gltfAnimation.channels.length; ++i) {
         const channel = gltfAnimation.channels[i];
@@ -1363,7 +1372,7 @@ const createAnimation = function (gltfAnimation, animationIndex, gltfAccessors, 
         const curve = curves[channel.sampler];
 
         const node = nodes[target.node];
-        const entityPath = [nodes[0].name, ...AnimBinder.splitPath(node.path, '/')];
+        const entityPath = constructNodePath(node);
         curve._paths.push({
             entityPath: entityPath,
             component: 'graph',
@@ -1632,10 +1641,16 @@ const createNodes = function (gltf, options) {
     for (let i = 0; i < gltf.nodes.length; ++i) {
         const gltfNode = gltf.nodes[i];
         if (gltfNode.hasOwnProperty('children')) {
+            const parent = nodes[i];
+            const uniqueNames = { };
             for (let j = 0; j < gltfNode.children.length; ++j) {
-                const parent = nodes[i];
                 const child = nodes[gltfNode.children[j]];
                 if (!child.parent) {
+                    if (uniqueNames.hasOwnProperty(child.name)) {
+                        child.name += uniqueNames[child.name]++;
+                    } else {
+                        uniqueNames[child.name] = 1;
+                    }
                     parent.addChild(child);
                 }
             }


### PR DESCRIPTION
Fixes #https://github.com/playcanvas/playcanvas-viewer/issues/135

We've had a bug in the gltf loader which prepends the name of the first node in the file to the animation path. This results in totally incorrect animation paths when the root node is not first in the list.

We are also unable to resolve paths in the tree when sibling nodes have the same name.

This PR does the following:
- directly build the path from the node, including root name
- uniquify sibling node names
- attempt tree traversal to resolve node names, otherwise fall back to previous methods.

This PR appears to resolve a number of existing problem gltf files.