### PR TITLE
EnvAtlas lighting fix

### DIFF
--- a/src/graphics/program-lib/chunks/decode.frag
+++ b/src/graphics/program-lib/chunks/decode.frag
@@ -22,7 +22,7 @@ vec3 decodeRGBE(vec4 raw) {
 const float PI = 3.141592653589793;
 
 vec2 toSpherical(vec3 dir) {
-    return vec2(atan(dir.x, dir.z), asin(dir.y));
+    return vec2(dir.xz == vec2(0.0) ? 0.0 : atan(dir.x, dir.z), asin(dir.y));
 }
 
 vec2 toSphericalUv(vec3 dir) {

--- a/src/graphics/program-lib/chunks/reproject.frag
+++ b/src/graphics/program-lib/chunks/reproject.frag
@@ -115,7 +115,7 @@ vec3 modifySeams(vec3 dir, float scale) {
 }
 
 vec2 toSpherical(vec3 dir) {
-    return vec2(atan(dir.x, dir.z), asin(dir.y));
+    return vec2(dir.xz == vec2(0.0) ? 0.0 : atan(dir.x, dir.z), asin(dir.y));
 }
 
 vec3 fromSpherical(vec2 uv) {

--- a/src/scene/materials/standard-material-options-builder.js
+++ b/src/scene/materials/standard-material-options-builder.js
@@ -30,6 +30,14 @@ const arraysEqual = (a, b) => {
     return true;
 };
 
+const notWhite = (color) => {
+    return color.r !== 1 || color.g !== 1 || color.b !== 1;
+};
+
+const notBlack = (color) => {
+    return color.r !== 0 || color.g !== 0 || color.b !== 0;
+};
+
 class StandardMaterialOptionsBuilder {
     constructor() {
         this._mapXForms = null;
@@ -97,15 +105,11 @@ class StandardMaterialOptionsBuilder {
     }
 
     _updateMaterialOptions(options, stdMat) {
-        const notWhite = (color) => {
-            return color.r !== 1 || color.g !== 1 || color.b !== 1;
-        };
-
         const diffuseTint = (stdMat.diffuseTint || (!stdMat.diffuseMap && !stdMat.diffuseVertexColor)) &&
                             notWhite(stdMat.diffuse);
 
         const useSpecular = !!(stdMat.useMetalness || stdMat.specularMap || stdMat.sphereMap || stdMat.cubeMap ||
-                            notWhite(stdMat.specular) ||
+                            notBlack(stdMat.specular) ||
                             stdMat.enableGGXSpecular ||
                             (stdMat.clearCoat > 0));
 


### PR DESCRIPTION
Handle vertical normals when converting to spherical coordinates.

And fix specular color comparison in the standard material options builder.