### PR TITLE
Remove circular dependencies created by handling of deprecated constructors

### DIFF
--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -401,6 +401,9 @@ class Application extends EventHandler {
     constructor(canvas, options = {}) {
         super();
 
+        // this allows us to detect if an instance is an application without having to import the class
+        this.isApplication = true;
+
         // #if _DEBUG
         console.log(`Powered by PlayCanvas ${version} ${revision}`);
         // #endif

--- a/src/framework/entity.js
+++ b/src/framework/entity.js
@@ -3,7 +3,7 @@ import { guid } from '../core/guid.js';
 
 import { GraphNode } from '../scene/graph-node.js';
 
-import { Application } from './application.js';
+import { getApplication } from './globals.js';
 
 /**
  * @class
@@ -71,13 +71,16 @@ class Entity extends GraphNode {
     constructor(name, app) {
         super(name);
 
-        if (name instanceof Application) app = name;
+        // handle old constructor where first parameter was the application
+        if (name?.isApplication) {
+            app = name;
+        }
         this._batchHandle = null; // The handle for a RequestBatch, set this if you want to Component's to load their resources using a pre-existing RequestBatch.
         this.c = {}; // Component storage
 
         this._app = app; // store app
         if (!app) {
-            this._app = Application.getApplication(); // get the current application
+            this._app = getApplication(); // get the current application
             if (!this._app) {
                 throw new Error("Couldn't find current application");
             }

--- a/src/graphics/graphics-device.js
+++ b/src/graphics/graphics-device.js
@@ -250,6 +250,9 @@ class GraphicsDevice extends EventHandler {
     constructor(canvas, options = {}) {
         super();
 
+        // this allows us to detect if an instance is a device without having to import the class
+        this.isGraphicsDevice = true;
+
         this.canvas = canvas;
         this._enableAutoInstancing = false;
         this.autoInstancingMaxObjects = 16384;

--- a/src/graphics/render-target.js
+++ b/src/graphics/render-target.js
@@ -1,8 +1,6 @@
 import { Debug } from '../core/debug.js';
 import { PIXELFORMAT_DEPTH, PIXELFORMAT_DEPTHSTENCIL } from './constants.js';
 
-import { GraphicsDevice } from './graphics-device.js';
-
 const defaultOptions = {
     depth: true,
     face: 0
@@ -62,7 +60,7 @@ class RenderTarget {
         const _arg2 = arguments[1];
         const _arg3 = arguments[2];
 
-        if (options instanceof GraphicsDevice) {
+        if (options?.isGraphicsDevice) {
             // old constructor
             this._colorBuffer = _arg2;
             options = _arg3;

--- a/src/graphics/reproject-texture.js
+++ b/src/graphics/reproject-texture.js
@@ -11,7 +11,6 @@ import { createShaderFromCode } from './program-lib/utils.js';
 import { drawQuadWithShader } from './simple-post-effect.js';
 import { shaderChunks } from './program-lib/chunks/chunks.js';
 import { RenderTarget } from './render-target.js';
-import { GraphicsDevice } from './graphics-device.js';
 import { Texture } from './texture.js';
 
 // get a coding string for texture based on its type and pixel format.
@@ -384,7 +383,7 @@ void main(void) {
 function reprojectTexture(source, target, options = {}) {
     // maintain backwards compatibility with previous function signature
     // reprojectTexture(device, source, target, specularPower = 1, numSamples = 1024)
-    if (source instanceof GraphicsDevice) {
+    if (source.isGraphicsDevice) {
         source = arguments[1];
         target = arguments[2];
         options = { };


### PR DESCRIPTION
added member functions to GraphicsDevice and Application that allow us to detect if the class is an instance of those. This avoids having to do 'instanceof Application'