### PR TITLE
Improved DefaultMaterial to avoid circular dependency

### DIFF
--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -24,7 +24,7 @@ import { GraphicsDevice } from '../graphics/graphics-device.js';
 
 import {
     LAYERID_DEPTH, LAYERID_IMMEDIATE, LAYERID_SKYBOX, LAYERID_UI, LAYERID_WORLD,
-    SORTMODE_NONE, SORTMODE_MANUAL
+    SORTMODE_NONE, SORTMODE_MANUAL, SPECULAR_BLINN
 } from '../scene/constants.js';
 import { BatchManager } from '../scene/batching/batch-manager.js';
 import { ForwardRenderer } from '../scene/renderer/forward-renderer.js';
@@ -38,6 +38,7 @@ import { Scene } from '../scene/scene.js';
 import { Material } from '../scene/materials/material.js';
 import { LightsBuffer } from '../scene/lighting/lights-buffer.js';
 import { DefaultMaterial } from '../scene/materials/default-material.js';
+import { StandardMaterial } from '../scene/materials/standard-material.js';
 
 import { SoundManager } from '../sound/manager.js';
 
@@ -445,6 +446,7 @@ class Application extends EventHandler {
         options.graphicsDeviceOptions.alpha = options.graphicsDeviceOptions.alpha || false;
 
         this.graphicsDevice = new GraphicsDevice(canvas, options.graphicsDeviceOptions);
+        this._initDefaultMaterial();
         this.stats = new ApplicationStats(this.graphicsDevice);
         this._soundManager = new SoundManager(options);
         this.loader = new ResourceLoader(this);
@@ -668,6 +670,13 @@ class Application extends EventHandler {
      */
     static getApplication(id) {
         return id ? Application._applications[id] : getApplication();
+    }
+
+    _initDefaultMaterial() {
+        const material = new StandardMaterial();
+        material.name = "Default Material";
+        material.shadingModel = SPECULAR_BLINN;
+        DefaultMaterial.add(this.graphicsDevice, material);
     }
 
     /**

--- a/src/scene/materials/default-material.js
+++ b/src/scene/materials/default-material.js
@@ -1,5 +1,4 @@
-import { SPECULAR_BLINN } from "../constants.js";
-import { StandardMaterial } from "./standard-material.js";
+import { Debug } from "../../core/debug.js";
 
 // Default material used in case no other material is available.
 // There is one instance of it per device (application) stored in the cache in this class.
@@ -9,19 +8,19 @@ class DefaultMaterial {
 
     // returns a default material for the device
     static get(device) {
-        let material = this.cache.get(device);
-        if (!material) {
-            material = new StandardMaterial();
-            material.name = "Default Material";
-            material.shadingModel = SPECULAR_BLINN;
-
-            this.cache.set(device, material);
-        }
+        const material = this.cache.get(device);
+        Debug.assert(material);
         return material;
+    }
+
+    static add(device, material) {
+        Debug.assert(!this.cache.has(device));
+        this.cache.set(device, material);
     }
 
     // releases a default material for the device (when device is getting destroyed)
     static remove(device) {
+        Debug.assert(this.cache.has(device));
         this.cache.delete(device);
     }
 }


### PR DESCRIPTION
moved creation of default material to the application, to break circular depenency: 
`src/scene/materials/standard-material.js -> src/scene/materials/material.js -> src/scene/materials/default-material.js -> src/scene/materials/standard-material.js`