### PR TITLE
Simplify path and root

### DIFF
--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -164,7 +164,7 @@ class GraphNode extends EventHandler {
         let result = this.name;
         let node = this._parent;
         while (node && node._parent) {
-            result = `node.name/${result}`;
+            result = `${node.name}/${result}`;
             node = node._parent;
         }
         return result;

--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -161,10 +161,10 @@ class GraphNode extends EventHandler {
      * the root of the hierarchy.
      */
     get path() {
-        let result = '';
+        let result = this.name;
         let node = this._parent;
-        while (node) {
-            result = node.name + (result.length > 0 ? `/${result}` : '');
+        while (node && node._parent) {
+            result = `node.name/${result}`;
             node = node._parent;
         }
         return result;

--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -161,18 +161,13 @@ class GraphNode extends EventHandler {
      * the root of the hierarchy.
      */
     get path() {
-        let parent = this._parent;
-        if (parent) {
-            let path = this.name;
-
-            while (parent && parent._parent) {
-                path = parent.name + "/" + path;
-                parent = parent._parent;
-            }
-
-            return path;
+        let result = '';
+        let node = this._parent;
+        while (node) {
+            result = `${node.name}/${result}`;
+            node = node._parent;
         }
-        return '';
+        return result;
     }
 
     /**
@@ -182,14 +177,11 @@ class GraphNode extends EventHandler {
      * @description A read-only property to get highest graph node from current node.
      */
     get root() {
-        let parent = this._parent;
-        if (!parent)
-            return this;
-
-        while (parent._parent)
-            parent = parent._parent;
-
-        return parent;
+        let result = this;
+        while (result._parent) {
+            result = result._parent;
+        }
+        return result;
     }
 
     /**

--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -161,8 +161,12 @@ class GraphNode extends EventHandler {
      * the root of the hierarchy.
      */
     get path() {
-        let result = this.name;
         let node = this._parent;
+        if (!node) {
+            return '';
+        }
+
+        let result = this.name;
         while (node && node._parent) {
             result = `${node.name}/${result}`;
             node = node._parent;

--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -164,7 +164,7 @@ class GraphNode extends EventHandler {
         let result = '';
         let node = this._parent;
         while (node) {
-            result = `${node.name}/${result}`;
+            result = node.name + (result.length > 0 ? `/${result}` : '');
             node = node._parent;
         }
         return result;


### PR DESCRIPTION
GraphNode root and path implementations are overly complex.

This PR just neatens them a little, but doesn't change behavior.