### PR TITLE
Clustered lighting uses textureLod to sample data textures to improve dynamic branching

### DIFF
--- a/src/graphics/program-lib/chunks/clusteredLight.frag
+++ b/src/graphics/program-lib/chunks/clusteredLight.frag
@@ -116,12 +116,19 @@ vec4 decodeClusterLowRange4Vec4(vec4 d0, vec4 d1, vec4 d2, vec4 d3) {
     );
 }
 
+// use LOD sampling if supported to sample data textures as it has better chance of getting skipped inside dynamic branches
+#ifdef SUPPORTS_TEXLOD
+    #define textureData(texture, uv) texture2DLodEXT(texture, uv, 0.0)
+#else
+    #define textureData(texture, uv) texture2D(texture, uv)
+#endif
+
 vec4 sampleLightsTexture8(const ClusterLightData clusterLightData, float index) {
-    return texture2D(lightsTexture8, vec2(index * lightsTextureInvSize.z, clusterLightData.lightV));
+    return textureData(lightsTexture8, vec2(index * lightsTextureInvSize.z, clusterLightData.lightV));
 }
 
 vec4 sampleLightTextureF(const ClusterLightData clusterLightData, float index) {
-    return texture2D(lightsTextureFloat, vec2(index * lightsTextureInvSize.x, clusterLightData.lightV));
+    return textureData(lightsTextureFloat, vec2(index * lightsTextureInvSize.x, clusterLightData.lightV));
 }
 
 void decodeClusterLightCore(inout ClusterLightData clusterLightData, float lightIndex) {
@@ -537,7 +544,7 @@ void addClusteredLights() {
         const float maxLightCells = 256.0 / 4.0;  // 8 bit index, each stores 4 lights
         for (float lightCellIndex = 0.5; lightCellIndex < maxLightCells; lightCellIndex++) {
 
-            vec4 lightIndices = texture2D(clusterWorldTexture, vec2(clusterTextureSize.y * (clusterU + lightCellIndex), clusterV));
+            vec4 lightIndices = textureData(clusterWorldTexture, vec2(clusterTextureSize.y * (clusterU + lightCellIndex), clusterV));
             vec4 indices = lightIndices * 255.0;
 
             // evaluate up to 4 lights. This is written using a loop instead of manually unrolling to keep shader compile time smaller

--- a/src/graphics/program-lib/chunks/gles3.frag
+++ b/src/graphics/program-lib/chunks/gles3.frag
@@ -11,3 +11,4 @@ out highp vec4 pc_fragColor;
 #define texture2DProjGradEXT textureProjGrad
 #define textureCubeGradEXT textureGrad
 #define GL2
+#define SUPPORTS_TEXLOD

--- a/src/graphics/program-lib/programs/standard.js
+++ b/src/graphics/program-lib/programs/standard.js
@@ -788,6 +788,7 @@ const standard = {
             }
             if (device.extTextureLod) {
                 code += "#extension GL_EXT_shader_texture_lod : enable\n";
+                code += "#define SUPPORTS_TEXLOD\n";
             }
         }
         if (chunks.extensionPS) {


### PR DESCRIPTION
On some platforms, shader performance can improve, if texture sampling inside dynamic branches uses textureLOD instruction when available. This allows the GPU to skip texture samples, which otherwise might not be possible due to non-LOD sampling requiring ddx/ddy 