### PR TITLE
Fix spelling of AnimComponent#layerIndices

### DIFF
--- a/src/framework/components/anim/component.js
+++ b/src/framework/components/anim/component.js
@@ -184,12 +184,12 @@ class AnimComponent extends Component {
         this._layers = value;
     }
 
-    get layerIndicies() {
-        return this._layerIndicies;
+    get layerIndices() {
+        return this._layerIndices;
     }
 
-    set layerIndicies(value) {
-        this._layerIndicies = value;
+    set layerIndices(value) {
+        this._layerIndices = value;
     }
 
     get parameters() {


### PR DESCRIPTION
`layerIndicies` -> `layerIndices`

However, I don't see where else this is used. @ellthompson - does the Editor or Viewer use this property at all? Anywhere else that might need updating?

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
