### PR TITLE
Improve environment reflection filtering quality

### DIFF
--- a/src/graphics/program-lib/chunks/ambientEnv.frag
+++ b/src/graphics/program-lib/chunks/ambientEnv.frag
@@ -5,7 +5,7 @@ uniform sampler2D texture_envAtlas;
 
 void addAmbient() {
     vec3 dir = cubeMapRotate(dNormalW) * vec3(-1.0, 1.0, 1.0);
-    vec2 uv = mapUv(toSphericalUv(dir), vec4(256.0, 256.0, 64.0, 32.0) / 512.0);
+    vec2 uv = mapUv(toSphericalUv(dir), vec4(128.0, 256.0 + 128.0, 64.0, 32.0) / atlasSize);
 
     vec4 raw = texture2D(texture_envAtlas, uv);
     vec3 linear = $DECODE(raw);

--- a/src/graphics/program-lib/chunks/decode.frag
+++ b/src/graphics/program-lib/chunks/decode.frag
@@ -33,7 +33,8 @@ vec2 toSphericalUv(vec3 dir) {
 // equirectangular helper functions
 
 // envAtlas is fixed at 512 pixels. every equirect is generated with 1 pixel boundary.
-const float seamSize = 1.0 / 512.0;
+const float atlasSize = 512.0;
+const float seamSize = 1.0 / atlasSize;
 
 // map a normalized equirect UV to the given rectangle (taking 1 pixel seam into account).
 vec2 mapUv(vec2 uv, vec4 rect) {
@@ -45,4 +46,10 @@ vec2 mapUv(vec2 uv, vec4 rect) {
 vec2 mapRoughnessUv(vec2 uv, float level) {
     float t = 1.0 / exp2(level);
     return mapUv(uv, vec4(0, 1.0 - t, t, t * 0.5));
+}
+
+// 
+vec2 mapMip(vec2 uv, float level) {
+    float t = 1.0 / exp2(level);
+    return mapUv(uv, vec4(1.0 - t, 1.0 - t, t, t * 0.5));
 }

--- a/src/graphics/program-lib/chunks/gles3.frag
+++ b/src/graphics/program-lib/chunks/gles3.frag
@@ -12,3 +12,4 @@ out highp vec4 pc_fragColor;
 #define textureCubeGradEXT textureGrad
 #define GL2
 #define SUPPORTS_TEXLOD
+#define SUPPORTS_STD_DERIVATIVES

--- a/src/graphics/program-lib/chunks/gles3.frag
+++ b/src/graphics/program-lib/chunks/gles3.frag
@@ -12,4 +12,3 @@ out highp vec4 pc_fragColor;
 #define textureCubeGradEXT textureGrad
 #define GL2
 #define SUPPORTS_TEXLOD
-#define SUPPORTS_STD_DERIVATIVES

--- a/src/graphics/program-lib/chunks/reflectionEnv.frag
+++ b/src/graphics/program-lib/chunks/reflectionEnv.frag
@@ -4,14 +4,17 @@ uniform sampler2D texture_envAtlas;
 #endif
 uniform float material_reflectivity;
 
-float mipLevel(vec2 uv) {
+// calculate mip level for shiny reflection given equirect coords uv.
+float shinyMipLevel(vec2 uv) {
     vec2 dx = dFdx(uv);
     vec2 dy = dFdy(uv);
 
+    // calculate second dF at 180 degrees
     vec2 uv2 = vec2(fract(uv.x + 0.5), uv.y);
     vec2 dx2 = dFdx(uv2);
     vec2 dy2 = dFdy(uv2);
 
+    // calculate min of both sets of dF to handle discontinuity at the azim edge
     float maxd = min(max(dot(dx, dx), dot(dy, dy)), max(dot(dx2, dx2), dot(dy2, dy2)));
 
     return clamp(0.5 * log2(maxd), 0.0, 10.0);
@@ -26,7 +29,7 @@ vec3 calcReflection(vec3 tReflDirW, float tGlossiness) {
 
     vec3 linear0;
     if (ilevel == 0.0) {
-        float level2 = mipLevel(uv * atlasSize);
+        float level2 = shinyMipLevel(uv * atlasSize);
         float ilevel2 = floor(level2);
         vec3 linearA = $DECODE(texture2D(texture_envAtlas, mapMip(uv, ilevel2)));
         vec3 linearB = $DECODE(texture2D(texture_envAtlas, mapMip(uv, ilevel2 + 1.0)));

--- a/src/graphics/program-lib/chunks/reflectionEnv.frag
+++ b/src/graphics/program-lib/chunks/reflectionEnv.frag
@@ -29,6 +29,7 @@ vec3 calcReflection(vec3 tReflDirW, float tGlossiness) {
 
     vec3 linear0;
     if (ilevel == 0.0) {
+        // we're accessing the top level reflection - perform manual mipmap
         float level2 = shinyMipLevel(uv * atlasSize);
         float ilevel2 = floor(level2);
         vec3 linearA = $DECODE(texture2D(texture_envAtlas, mapMip(uv, ilevel2)));

--- a/src/graphics/program-lib/chunks/reflectionEnv.frag
+++ b/src/graphics/program-lib/chunks/reflectionEnv.frag
@@ -7,7 +7,14 @@ uniform float material_reflectivity;
 float mipLevel(vec2 uv) {
     vec2 dx = dFdx(uv);
     vec2 dy = dFdy(uv);
-    return clamp(0.5 * log2(max(dot(dx, dx), dot(dy, dy))), 0.0, 10.0);
+
+    vec2 uv2 = vec2(fract(uv.x + 0.5), uv.y);
+    vec2 dx2 = dFdx(uv2);
+    vec2 dy2 = dFdy(uv2);
+
+    float maxd = min(max(dot(dx, dx), dot(dy, dy)), max(dot(dx2, dx2), dot(dy2, dy2)));
+
+    return clamp(0.5 * log2(maxd), 0.0, 10.0);
 }
 
 vec3 calcReflection(vec3 tReflDirW, float tGlossiness) {

--- a/src/graphics/program-lib/programs/standard.js
+++ b/src/graphics/program-lib/programs/standard.js
@@ -785,7 +785,6 @@ const standard = {
         if (!device.webgl2) {
             if (device.extStandardDerivatives) {
                 code += "#extension GL_OES_standard_derivatives : enable\n";
-                code += "#define SUPPORTS_STD_DERIVATIVES\n";
             }
             if (device.extTextureLod) {
                 code += "#extension GL_EXT_shader_texture_lod : enable\n";

--- a/src/graphics/program-lib/programs/standard.js
+++ b/src/graphics/program-lib/programs/standard.js
@@ -785,6 +785,7 @@ const standard = {
         if (!device.webgl2) {
             if (device.extStandardDerivatives) {
                 code += "#extension GL_OES_standard_derivatives : enable\n";
+                code += "#define SUPPORTS_STD_DERIVATIVES\n";
             }
             if (device.extTextureLod) {
                 code += "#extension GL_EXT_shader_texture_lod : enable\n";
@@ -1204,6 +1205,9 @@ const standard = {
             code += chunks.lightDiffuseLambertPS;
             if (hasAreaLights || options.clusteredLightingEnabled) code += chunks.ltc;
         }
+
+        code += '\n';
+
         let useOldAmbient = false;
         if (options.useSpecular) {
 

--- a/src/resources/cubemap.js
+++ b/src/resources/cubemap.js
@@ -116,7 +116,8 @@ class CubemapHandler {
                         fixCubemapSeams: true,
                         addressU: ADDRESS_CLAMP_TO_EDGE,
                         addressV: ADDRESS_CLAMP_TO_EDGE,
-                        mipmaps: false
+                        // generate cubemaps on the top level only
+                        mipmaps: i === 0
                     });
                 }
             }


### PR DESCRIPTION
This PR is a followup to https://github.com/playcanvas/engine/pull/3783.

We improve filtering on shiny environment reflections to nearly (but not quite) match the quality of the previous 6-cubemap approach.

This PR adds higher quality filtering as follows:
- generate a mipmap pyramid of the shiny reflections along with the blurry reflections pyramid (this is fast - single sample)
- at runtime, perform manual mipmapping when sampling from the top level shiny reflection

An updated atlas showing the blurry reflections to the left and shiny mipmaps to the right:
![envAtlas4](https://user-images.githubusercontent.com/11276292/145835999-e0bc0f92-b74f-43db-a878-eb6c757e276a.png)

This approach means we spend a little more GPU effort filtering just the parts of env reflections prone to aliasing.