### PR TITLE
Fix embedded ktx2 loading

### DIFF
--- a/src/resources/parser/glb-parser.js
+++ b/src/resources/parser/glb-parser.js
@@ -1884,6 +1884,7 @@ const loadImageAsync = function (gltfImage, index, bufferViews, urlBase, registr
         'image/jpeg': 'jpg',
         'image/basis': 'basis',
         'image/ktx': 'ktx',
+        'image/ktx2': 'ktx2',
         'image/vnd-ms.dds': 'dds'
     };
 
@@ -1895,7 +1896,7 @@ const loadImageAsync = function (gltfImage, index, bufferViews, urlBase, registr
             url: url || name
         };
         if (bufferView) {
-            file.contents = bufferView;
+            file.contents = bufferView.slice(0).buffer;
         }
         if (mimeType) {
             const extension = mimeTypeFileExtensions[mimeType];


### PR DESCRIPTION
Fixes #3811

PR:
- include ktx2 in supported/recognised mime formats
- also slice the array buffer (because it will be transferred to web worker for processing)