### PR TITLE
Fixed circular dependency for image element 'set:color' and 'set:opacity' events

### DIFF
--- a/src/framework/components/button/component.js
+++ b/src/framework/components/button/component.js
@@ -431,53 +431,32 @@ class ButtonComponent extends Component {
         }
     }
 
+    _applyTint(tintColor) {
+        this._cancelTween();
+
+        if (this.fadeDuration === 0) {
+            this._applyTintImmediately(tintColor);
+        } else {
+            this._applyTintWithTween(tintColor);
+        }
+    }
+
+    _applyTint(tintColor) {
+        this._cancelTween();
+
+        if (this.fadeDuration === 0) {
+            this._applyTintImmediately(tintColor);
+        } else {
+            this._applyTintWithTween(tintColor);
+        }
+    }
+
     _applyTintImmediately(tintColor) {
-        if (!tintColor || !this._imageReference.hasComponent('element'))
-            return;
-
-        const color3 = toColor3(tintColor);
-
-        this._isApplyingTint = true;
-
-        if (!color3.equals(this._imageReference.entity.element.color))
-            this._imageReference.entity.element.color = color3;
-
-        if (this._imageReference.entity.element.opacity != tintColor.a)
-            this._imageReference.entity.element.opacity = tintColor.a;
-
-        this._isApplyingTint = false;
-    }
-
-    _applyTintWithTween(tintColor) {
-        if (!tintColor || !this._imageReference.hasComponent('element'))
-            return;
-
-        const color3 = toColor3(tintColor);
-        const color = this._imageReference.entity.element.color;
-        const opacity = this._imageReference.entity.element.opacity;
-
-        if (color3.equals(color) && tintColor.a == opacity)
-            return;
-
-        this._tweenInfo = {
-            startTime: now(),
-            from: new Color(color.r, color.g, color.b, opacity),
-            to: tintColor.clone(),
-            lerpColor: new Color()
-        };
-    }
-
-    _applyTintWithTween(tintColor) {
         if (this._imageReference.hasComponent('element') && tintColor) {
-            const color = this._imageReference.entity.element.color;
-            const opacity = this._imageReference.entity.element.opacity;
-
-            this._tweenInfo = {
-                startTime: now(),
-                from: new Color(color.r, color.g, color.b, opacity),
-                to: tintColor.clone(),
-                lerpColor: new Color()
-            };
+            this._isApplyingTint = true;
+            this._imageReference.entity.element.color = toColor3(tintColor);
+            this._imageReference.entity.element.opacity = tintColor.a;
+            this._isApplyingTint = false;
         }
     }
 

--- a/src/framework/components/button/component.js
+++ b/src/framework/components/button/component.js
@@ -431,23 +431,40 @@ class ButtonComponent extends Component {
         }
     }
 
-    _applyTint(tintColor) {
-        this._cancelTween();
+    _applyTintImmediately(tintColor) {
+        if (!tintColor || !this._imageReference.hasComponent('element'))
+            return;
 
-        if (this.fadeDuration === 0) {
-            this._applyTintImmediately(tintColor);
-        } else {
-            this._applyTintWithTween(tintColor);
-        }
+        const color3 = toColor3(tintColor);
+
+        this._isApplyingTint = true;
+
+        if (!color3.equals(this._imageReference.entity.element.color))
+            this._imageReference.entity.element.color = color3;
+
+        if (this._imageReference.entity.element.opacity != tintColor.a)
+            this._imageReference.entity.element.opacity = tintColor.a;
+
+        this._isApplyingTint = false;
     }
 
-    _applyTintImmediately(tintColor) {
-        if (this._imageReference.hasComponent('element') && tintColor) {
-            this._isApplyingTint = true;
-            this._imageReference.entity.element.color = toColor3(tintColor);
-            this._imageReference.entity.element.opacity = tintColor.a;
-            this._isApplyingTint = false;
-        }
+    _applyTintWithTween(tintColor) {
+        if (!tintColor || !this._imageReference.hasComponent('element'))
+            return;
+
+        const color3 = toColor3(tintColor);
+        const color = this._imageReference.entity.element.color;
+        const opacity = this._imageReference.entity.element.opacity;
+
+        if (color3.equals(color) && tintColor.a == opacity)
+            return;
+
+        this._tweenInfo = {
+            startTime: now(),
+            from: new Color(color.r, color.g, color.b, opacity),
+            to: tintColor.clone(),
+            lerpColor: new Color()
+        };
     }
 
     _applyTintWithTween(tintColor) {


### PR DESCRIPTION
Fixed circular dependency for image element 'set:color' and 'set:opacity' events

Fixes #3814 

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
