### PR TITLE
Camera onPreRender and onPostRender callbacks

### DIFF
--- a/src/framework/components/camera/component.js
+++ b/src/framework/components/camera/component.js
@@ -135,7 +135,7 @@ const properties = [
  * any following layers for the camera. Set to undefined for post-processing to be applied to all layers of the camera.
  * @property {Function} onPreRender Custom function that is called before the camera renders the scene.
  * @property {Function} onPostRender Custom function that is called after the camera renders the scene.
-*/
+ */
 class CameraComponent extends Component {
     constructor(system, entity) {
         super(system, entity);

--- a/src/framework/components/camera/component.js
+++ b/src/framework/components/camera/component.js
@@ -133,7 +133,9 @@ const properties = [
  * @property {number} disablePostEffectsLayer Layer ID of a layer on which the postprocessing of the camera stops being applied to.
  * Defaults to LAYERID_UI, which causes post processing to not be applied to UI layer and
  * any following layers for the camera. Set to undefined for post-processing to be applied to all layers of the camera.
- */
+ * @property {Function} onPreRender Custom function that is called before the camera renders the scene.
+ * @property {Function} onPostRender Custom function that is called after the camera renders the scene.
+*/
 class CameraComponent extends Component {
     constructor(system, entity) {
         super(system, entity);
@@ -145,6 +147,10 @@ class CameraComponent extends Component {
 
         // event called when postprocessing should execute
         this.onPostprocessing = null;
+
+        // events called during the frame before and after the camera renders
+        this.onPreRender = null;
+        this.onPostRender = null;
 
         // layer id at which the postprocessing stops for the camera
         this._disablePostEffectsLayer = LAYERID_UI;

--- a/src/framework/components/camera/post-effect-queue.js
+++ b/src/framework/components/camera/post-effect-queue.js
@@ -277,7 +277,7 @@ class PostEffectQueue {
             this.camera.renderTarget = this.effects[0].inputTarget;
 
             // callback when postprocessing takes place
-            this.camera.onPostprocessing = (camera) => {
+            this.camera.onPostprocessing = () => {
 
                 if (this.enabled) {
                     let rect = null;

--- a/src/scene/composition/layer-composition.js
+++ b/src/scene/composition/layer-composition.js
@@ -343,10 +343,14 @@ class LayerComposition extends EventHandler {
                     }
                 }
 
-                // based on all layers this camera renders, prepare a list of directional lights the camera needs to render shadow for
-                // and set these up on the first render action for the camera. Only do it if camera renders any layers.
+                // if the camera renders any layers.
                 if (cameraFirstRenderActionIndex < renderActionCount) {
+                    // based on all layers this camera renders, prepare a list of directional lights the camera needs to render shadow for
+                    // and set these up on the first render action for the camera.
                     this._renderActions[cameraFirstRenderActionIndex].collectDirectionalLights(cameraLayers, this._splitLights[LIGHTTYPE_DIRECTIONAL], this._lights);
+
+                    // mark the last render action as last one using the camera
+                    lastRenderAction.lastCameraUse = true;
                 }
 
                 // if no render action for this camera was marked for end of postprocessing, mark last one
@@ -603,6 +607,7 @@ class LayerComposition extends EventHandler {
         renderAction.clearDepth = clearDepth;
         renderAction.clearStencil = clearStencil;
         renderAction.firstCameraUse = cameraFirstRenderAction;
+        renderAction.lastCameraUse = false;
 
         return renderAction;
     }
@@ -667,6 +672,7 @@ class LayerComposition extends EventHandler {
                     " Lights: (" + layer._clusteredLightsSet.size + "/" + layer._lightsSet.size + ")" +
                     " " + (ra.lightClusters !== this._emptyWorldClusters ? (ra.lightClusters.name) : "").padEnd(10, " ") +
                     (ra.firstCameraUse ? " CAM-FIRST" : "") +
+                    (ra.lastCameraUse ? " CAM-LAST" : "") +
                     (ra.triggerPostprocess ? " POSTPROCESS" : "") +
                     (dirLightCount ? (" DirLights: " + dirLightCount) : "")
                 );

--- a/src/scene/composition/render-action.js
+++ b/src/scene/composition/render-action.js
@@ -33,6 +33,9 @@ class RenderAction {
         // true if this is first render action using this camera
         this.firstCameraUse = false;
 
+        // true if this is the last render action using this camera
+        this.lastCameraUse = false;
+
         // directional lights that needs to update their shadows for this render action, stored as a set
         this.directionalLightsSet = new Set();
 

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -1895,6 +1895,11 @@ class ForwardRenderer {
 
             if (camera) {
                 camera.frameBegin(renderAction.renderTarget);
+
+                // callback on the camera component before rendering with this camera for the first time during the frame
+                if (renderAction.firstCameraUse && camera.onPreRender) {
+                    camera.onPreRender();
+                }
             }
 
             // Call prerender callback if there's one
@@ -1981,13 +1986,18 @@ class ForwardRenderer {
 
                 camera.frameEnd();
 
+                // callback on the camera component when we're done rendering all layers with this camera
+                if (renderAction.lastCameraUse && camera.onPostRender) {
+                    camera.onPostRender();
+                }
+
                 // trigger postprocessing for camera
                 if (renderAction.triggerPostprocess && camera.onPostprocessing) {
-                    camera.onPostprocessing(camera);
+                    camera.onPostprocessing();
                 }
             }
 
-            // Call postrender callback if there's one
+            // Call layer's postrender callback if there's one
             if (!transparent && layer.onPostRenderOpaque) {
                 layer.onPostRenderOpaque(cameraPass);
             } else if (transparent && layer.onPostRenderTransparent) {


### PR DESCRIPTION
**New public API:**
Now that we are more camera driven rendering than layer driven, these  are useful to have:
- `CameraComponent.onPreRender` Custom function that is called before the camera renders the scene.
- `CameraComponent.onPostRender` Custom function that is called after the camera renders the scene.

**Other updates**
- removed camera parameter from internal callback: `CameraComponent.OnPostprocessing`