### PR TITLE
Added same sprite check in Button component to break circular dependency

### DIFF
--- a/src/framework/components/button/component.js
+++ b/src/framework/components/button/component.js
@@ -449,39 +449,26 @@ class ButtonComponent extends Component {
     }
 
     _applyTintImmediately(tintColor) {
-        if (!tintColor || !this._imageReference.hasComponent('element'))
-            return;
-
-        const color3 = toColor3(tintColor);
-
-        this._isApplyingTint = true;
-
-        if (!color3.equals(this._imageReference.entity.element.color))
-            this._imageReference.entity.element.color = color3;
-
-        if (this._imageReference.entity.element.opacity !== tintColor.a)
+        if (this._imageReference.hasComponent('element') && tintColor) {
+            this._isApplyingTint = true;
+            this._imageReference.entity.element.color = toColor3(tintColor);
             this._imageReference.entity.element.opacity = tintColor.a;
-
-        this._isApplyingTint = false;
+            this._isApplyingTint = false;
+        }
     }
 
     _applyTintWithTween(tintColor) {
-        if (!tintColor || !this._imageReference.hasComponent('element'))
-            return;
+        if (this._imageReference.hasComponent('element') && tintColor) {
+            const color = this._imageReference.entity.element.color;
+            const opacity = this._imageReference.entity.element.opacity;
 
-        const color3 = toColor3(tintColor);
-        const color = this._imageReference.entity.element.color;
-        const opacity = this._imageReference.entity.element.opacity;
-
-        if (color3.equals(color) && tintColor.a === opacity)
-            return;
-
-        this._tweenInfo = {
-            startTime: now(),
-            from: new Color(color.r, color.g, color.b, opacity),
-            to: tintColor.clone(),
-            lerpColor: new Color()
-        };
+            this._tweenInfo = {
+                startTime: now(),
+                from: new Color(color.r, color.g, color.b, opacity),
+                to: tintColor.clone(),
+                lerpColor: new Color()
+            };
+        }
     }
 
     _updateTintTween() {

--- a/src/framework/components/button/component.js
+++ b/src/framework/components/button/component.js
@@ -425,8 +425,15 @@ class ButtonComponent extends Component {
 
         if (this._imageReference.hasComponent('element')) {
             this._isApplyingSprite = true;
-            this._imageReference.entity.element.spriteAsset = spriteAsset;
-            this._imageReference.entity.element.spriteFrame = spriteFrame;
+
+            if (this._imageReference.entity.element.spriteAsset !== spriteAsset) {
+                this._imageReference.entity.element.spriteAsset = spriteAsset;
+            }
+
+            if (this._imageReference.entity.element.spriteFrame !== spriteFrame) {
+                this._imageReference.entity.element.spriteFrame = spriteFrame;
+            }
+
             this._isApplyingSprite = false;
         }
     }
@@ -442,26 +449,39 @@ class ButtonComponent extends Component {
     }
 
     _applyTintImmediately(tintColor) {
-        if (this._imageReference.hasComponent('element') && tintColor) {
-            this._isApplyingTint = true;
-            this._imageReference.entity.element.color = toColor3(tintColor);
+        if (!tintColor || !this._imageReference.hasComponent('element'))
+            return;
+
+        const color3 = toColor3(tintColor);
+
+        this._isApplyingTint = true;
+
+        if (!color3.equals(this._imageReference.entity.element.color))
+            this._imageReference.entity.element.color = color3;
+
+        if (this._imageReference.entity.element.opacity !== tintColor.a)
             this._imageReference.entity.element.opacity = tintColor.a;
-            this._isApplyingTint = false;
-        }
+
+        this._isApplyingTint = false;
     }
 
     _applyTintWithTween(tintColor) {
-        if (this._imageReference.hasComponent('element') && tintColor) {
-            const color = this._imageReference.entity.element.color;
-            const opacity = this._imageReference.entity.element.opacity;
+        if (!tintColor || !this._imageReference.hasComponent('element'))
+            return;
 
-            this._tweenInfo = {
-                startTime: now(),
-                from: new Color(color.r, color.g, color.b, opacity),
-                to: tintColor.clone(),
-                lerpColor: new Color()
-            };
-        }
+        const color3 = toColor3(tintColor);
+        const color = this._imageReference.entity.element.color;
+        const opacity = this._imageReference.entity.element.opacity;
+
+        if (color3.equals(color) && tintColor.a === opacity)
+            return;
+
+        this._tweenInfo = {
+            startTime: now(),
+            from: new Color(color.r, color.g, color.b, opacity),
+            to: tintColor.clone(),
+            lerpColor: new Color()
+        };
     }
 
     _updateTintTween() {


### PR DESCRIPTION
Fixes #3814

Breaks cyclic call when there are multiple button components referring to the same image component

Between this PR and #3761, the check on whether the same sprite/color is being set on the element component has moved from the element component to the button component. The button component is now responsible for breaking the cyclic call.

Thank you @Sarletor for the fix on the color in PR #3817

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
