### PR TITLE
Fix clearcoat normals shader gen

### DIFF
--- a/src/graphics/program-lib/programs/standard.js
+++ b/src/graphics/program-lib/programs/standard.js
@@ -1022,16 +1022,16 @@ const standard = {
         }
 
         if (needsNormal) {
-             // if normalMap is disabled, then so is normalDetailMap
+            // if normalMap is disabled, then so is normalDetailMap
             if (options.normalMap || options.clearCoatNormalMap) {
-                // TODO: let each normalmap input (normalMap, normalDetailMap, clearCoatNormalMap) indenpendently decide which unpackNormal to use.
+                // TODO: let each normalmap input (normalMap, normalDetailMap, clearCoatNormalMap) independently decide which unpackNormal to use.
                 code += options.packedNormal ? chunks.normalXYPS : chunks.normalXYZPS;
 
                 if (!options.hasTangents) {
-                    // TODO: generalize to support each normalmap input (normalMap, normalDetailMap, clearCoatNormalMap) indenpendently
-                    const transformPropName = options.normalMap ? "normalMapTransform" : "clearCoatNormalMapTransform";
-                    const normalMapUv = this._getUvSourceExpression(transformPropName, "normalMapUv", options);
-                    tbn = tbn.replace(/\$UV/g, normalMapUv);
+                    // TODO: generalize to support each normalmap input (normalMap, normalDetailMap, clearCoatNormalMap) independently
+                    const baseName = options.normalMap ? "normalMap" : "clearCoatNormalMap";
+                    const uv = this._getUvSourceExpression(`${baseName}Transform`, `${baseName}Uv`, options);
+                    tbn = tbn.replace(/\$UV/g, uv);
                 }
                 code += tbn;
             } else if (options.enableGGXSpecular && !options.heightMap) {


### PR DESCRIPTION
This PR fixes an invalid shader generation for [this](https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0/TextureTransformMultiTest) gltf test model.

The shader code for calculating tangent basis for material "ClearcoatNormalTest1Mat" was accessing an incorrect set of uvs.