### PR TITLE
Migrate namespaces to ES6 JSDoc comments

### DIFF
--- a/src/asset/asset-registry.js
+++ b/src/asset/asset-registry.js
@@ -130,7 +130,7 @@ class AssetRegistry extends EventHandler {
      * @description Fired when an asset is removed from the registry.
      * @param {Asset} asset - The asset that was removed.
      * @example
-     * app.assets.on("remove", function (aseet) {
+     * app.assets.on("remove", function (asset) {
      *     console.log("Asset removed: " + asset.name);
      * });
      */

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -4,12 +4,14 @@
  * @description Root namespace for the PlayCanvas Engine.
  */
 
-/**
- * @private
- * @function
- * @name _typeLookup
- * @description Create look up table for types.
- */
+const version = "__CURRENT_SDK_VERSION__";
+const revision = "__REVISION__";
+const config = { };
+const common = { };
+const apps = { }; // Storage for the applications using the PlayCanvas Engine
+const data = { }; // Storage for exported entity data
+
+// Create look up table for types.
 const _typeLookup = function () {
     const result = { };
     const names = ["Array", "Object", "Function", "Date", "RegExp", "Float32Array"];
@@ -20,20 +22,12 @@ const _typeLookup = function () {
     return result;
 }();
 
-const version = "__CURRENT_SDK_VERSION__";
-const revision = "__REVISION__";
-const config = { };
-const common = { };
-const apps = { }; // Storage for the applications using the PlayCanvas Engine
-const data = { }; // Storage for exported entity data
-
 /**
- * @private
- * @function
- * @name type
- * @description Extended typeof() function, returns the type of the object.
+ * Extended typeof() function, returns the type of the object.
+ *
  * @param {object} obj - The object to get the type of.
  * @returns {string} The type string: "null", "undefined", "number", "string", "boolean", "array", "object", "function", "date", "regexp" or "float32array".
+ * @private
  */
 function type(obj) {
     if (obj === null) {
@@ -50,10 +44,8 @@ function type(obj) {
 }
 
 /**
- * @private
- * @function
- * @name extend
- * @description Merge the contents of two objects into a single object.
+ * Merge the contents of two objects into a single object.
+ *
  * @param {object} target - The target object of the merge.
  * @param {object} ex - The object that is merged with target.
  * @returns {object} The target object.
@@ -74,6 +66,7 @@ function type(obj) {
  * // logs "a"
  * A.b();
  * // logs "b"
+ * @private
  */
 function extend(target, ex) {
     for (const prop in ex) {
@@ -92,12 +85,11 @@ function extend(target, ex) {
 }
 
 /**
- * @private
- * @function
- * @name isDefined
- * @description Return true if the Object is not undefined.
+ * Return true if the Object is not undefined.
+ *
  * @param {object} o - The Object to test.
  * @returns {boolean} True if the Object is not undefined.
+ * @private
  */
 function isDefined(o) {
     let a;

--- a/src/core/event-handler.js
+++ b/src/core/event-handler.js
@@ -1,6 +1,7 @@
 /**
+ * Callback used by {@link EventHandler} functions. Note the callback is limited to 8 arguments.
+ *
  * @callback handleEventCallback
- * @description Callback used by {@link EventHandler} functions. Note the callback is limited to 8 arguments.
  * @param {*} [arg1] - First argument that is passed from caller.
  * @param {*} [arg2] - Second argument that is passed from caller.
  * @param {*} [arg3] - Third argument that is passed from caller.
@@ -93,7 +94,7 @@ class EventHandler {
      * obj.off(); // Removes all events
      * obj.off('test'); // Removes all events called 'test'
      * obj.off('test', handler); // Removes all handler functions, called 'test'
-     * obj.off('test', handler, this); // Removes all hander functions, called 'test' with scope this
+     * obj.off('test', handler, this); // Removes all handler functions, called 'test' with scope this
      */
     off(name, callback, scope) {
         if (name) {
@@ -138,13 +139,10 @@ class EventHandler {
         return this;
     }
 
-    // ESLint rule disabled here as documenting arg1, arg2...argN as [...] rest
-    // arguments is preferable to documenting each one individually.
-    /* eslint-disable valid-jsdoc */
     /**
      * Fire an event, all additional arguments are passed on to the event listener.
      *
-     * @param {object} name - Name of event to fire.
+     * @param {string} name - Name of event to fire.
      * @param {*} [arg1] - First argument that is passed to the event handler.
      * @param {*} [arg2] - Second argument that is passed to the event handler.
      * @param {*} [arg3] - Third argument that is passed to the event handler.
@@ -157,7 +155,6 @@ class EventHandler {
      * @example
      * obj.fire('test', 'This is the message');
      */
-    /* eslint-enable valid-jsdoc */
     fire(name, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) {
         if (!name || !this._callbacks[name])
             return this;

--- a/src/core/guid.js
+++ b/src/core/guid.js
@@ -1,14 +1,13 @@
 /**
- * @name guid
+ * Basically a very large random number (128-bit) which means the probability of creating two that
+ * clash is vanishingly small. GUIDs are used as the unique identifiers for Entities.
+ *
  * @namespace
- * @description Basically a very large random number (128-bit) which means the probability of creating two that clash is vanishingly small.
- * GUIDs are used as the unique identifiers for Entities.
  */
 const guid = {
     /**
-     * @function
-     * @name guid.create
-     * @description Create an RFC4122 version 4 compliant GUID.
+     * Create an RFC4122 version 4 compliant GUID.
+     *
      * @returns {string} A new GUID.
      */
     create: function () {

--- a/src/core/indexed-list.js
+++ b/src/core/indexed-list.js
@@ -1,5 +1,6 @@
 /**
- * A ordered list-type data structure that can provide item look up by key, but also return return a list.
+ * A ordered list-type data structure that can provide item look up by key, but also return return
+ * a list.
  *
  * @private
  */

--- a/src/core/path.js
+++ b/src/core/path.js
@@ -1,25 +1,22 @@
 import { isDefined } from './core.js';
 
 /**
- * @namespace path
- * @description File path API.
+ * File path API.
+ *
+ * @namespace
  */
 const path = {
     /**
-     * @constant
+     * The character that separates path segments.
+     *
      * @type {string}
-     * @name path.delimiter
-     * @description The character that separates path segments.
      */
     delimiter: "/",
 
     /**
-     * @function
-     * @name path.join
-     * @description Join two or more sections of file path together, inserting a
-     * delimiter if needed.
-     * @param {...string} section - Section of path to join. 2 or more can be
-     * provided as parameters.
+     * Join two or more sections of file path together, inserting a delimiter if needed.
+     *
+     * @param {...string} section - Section of path to join. 2 or more can be provided as parameters.
      * @returns {string} The joined file path.
      * @example
      * var path = pc.path.join('foo', 'bar');
@@ -54,9 +51,8 @@ const path = {
     },
 
     /**
-     * @function
-     * @name path.normalize
-     * @description Normalize the path by removing '.' and '..' instances.
+     * Normalize the path by removing '.' and '..' instances.
+     *
      * @param {string} pathname - The path to normalize.
      * @returns {string} The normalized path.
      */
@@ -96,12 +92,13 @@ const path = {
     },
 
     /**
-     * @function
-     * @name path.split
-     * @description Split the pathname path into a pair [head, tail] where tail is the final part of the path
-     * after the last delimiter and head is everything leading up to that. tail will never contain a slash.
+     * Split the pathname path into a pair [head, tail] where tail is the final part of the path
+     * after the last delimiter and head is everything leading up to that. tail will never contain
+     * a slash.
+     *
      * @param {string} pathname - The path to split.
-     * @returns {string[]} The split path which is an array of two strings, the path and the filename.
+     * @returns {string[]} The split path which is an array of two strings, the path and the
+     * filename.
      */
     split: function (pathname) {
         const parts = pathname.split(path.delimiter);
@@ -111,10 +108,9 @@ const path = {
     },
 
     /**
-     * @function
-     * @name path.getBasename
-     * @description Return the basename of the path. That is the second element of the pair returned by
-     * passing path into {@link path.split}.
+     * Return the basename of the path. That is the second element of the pair returned by passing
+     * path into {@link path.split}.
+     *
      * @param {string} pathname - The path to process.
      * @returns {string} The basename.
      * @example
@@ -126,9 +122,9 @@ const path = {
     },
 
     /**
-     * @function
-     * @name path.getDirectory
-     * @description Get the directory name from the path. This is everything up to the final instance of {@link path.delimiter}.
+     * Get the directory name from the path. This is everything up to the final instance of
+     * {@link path.delimiter}.
+     *
      * @param {string} pathname - The path to get the directory from.
      * @returns {string} The directory part of the path.
      */
@@ -136,10 +132,11 @@ const path = {
         const parts = pathname.split(path.delimiter);
         return parts.slice(0, parts.length - 1).join(path.delimiter);
     },
+
     /**
-     * @function
-     * @name path.getExtension
-     * @description Return the extension of the path. Pop the last value of a list after path is split by question mark and comma.
+     * Return the extension of the path. Pop the last value of a list after path is split by
+     * question mark and comma.
+     *
      * @param {string} pathname - The path to process.
      * @returns {string} The extension.
      * @example
@@ -156,11 +153,12 @@ const path = {
     },
 
     /**
-     * @function
-     * @name path.isRelativePath
-     * @description Check if a string s is relative path.
+     * Check if a string s is relative path.
+     *
      * @param {string} pathname - The path to process.
-     * @returns {boolean} True if s doesn't start with slash and doesn't include colon and double slash.
+     * @returns {boolean} True if s doesn't start with slash and doesn't include colon and double
+     * slash.
+     *
      * @example
      * pc.path.isRelativePath("file.txt"); // returns true
      * pc.path.isRelativePath("path/to/file.txt"); // returns true
@@ -174,9 +172,8 @@ const path = {
     },
 
     /**
-     * @function
-     * @name path.extractPath
-     * @description Return the path without file name. If path is relative path, start with period.
+     * Return the path without file name. If path is relative path, start with period.
+     *
      * @param {string} pathname - The full path to process.
      * @returns {string} The path without a last element from list split by slash.
      * @example

--- a/src/core/platform.js
+++ b/src/core/platform.js
@@ -56,9 +56,9 @@ if (typeof navigator !== 'undefined') {
 const environment = (typeof window !== 'undefined') ? 'browser' : 'node';
 
 /**
+ * Global namespace that stores flags regarding platform environment and features support.
+ *
  * @namespace
- * @name platform
- * @description Global namespace that stores flags regarding platform environment and features support.
  * @example
  * if (pc.platform.touch) {
  *     // touch is supported
@@ -66,122 +66,96 @@ const environment = (typeof window !== 'undefined') ? 'browser' : 'node';
  */
 const platform = {
     /**
-     * @static
-     * @readonly
+     * String identifying the current runtime environment. Either 'browser' or 'node'.
+     *
      * @type {string}
-     * @name platform.environment
-     * @description String identifying the current runtime environment. Either 'browser' or 'node'.
      */
     environment: environment,
 
     /**
-     * @static
-     * @readonly
+     * The global object. This will be the window object when running in a browser and the global
+     * object when running in nodejs.
+     *
      * @type {object}
-     * @name platform.global
-     * @description The global object. This will be the window object when running in a browser and
-     * the global object when running in nodejs.
      */
     global: (environment === 'browser') ? window : global,
 
     /**
-     * @static
-     * @readonly
+     * Convenience boolean indicating whether we're running in the browser.
+     *
      * @type {boolean}
-     * @name platform.isBrowser
-     * @description Convenience boolean indicating whether we're running in the browser.
      */
     browser: environment === 'browser',
 
     /**
-     * @static
-     * @readonly
+     * Is it a desktop or laptop device.
+     *
      * @type {boolean}
-     * @name platform.desktop
-     * @description Is it a desktop or laptop device.
      */
     desktop: desktop,
 
     /**
-     * @static
-     * @readonly
+     * Is it a mobile or tablet device.
+     *
      * @type {boolean}
-     * @name platform.mobile
-     * @description Is it a mobile or tablet device.
      */
     mobile: mobile,
 
     /**
-     * @static
-     * @readonly
+     * If it is iOS.
+     *
      * @type {boolean}
-     * @name platform.ios
-     * @description If it is iOS.
      */
     ios: ios,
 
     /**
-     * @static
-     * @readonly
+     * If it is Android.
+     *
      * @type {boolean}
-     * @name platform.android
-     * @description If it is Android.
      */
     android: android,
 
     /**
-     * @static
-     * @readonly
+     * If it is Windows.
+     *
      * @type {boolean}
-     * @name platform.windows
-     * @description If it is Windows.
      */
     windows: windows,
 
     /**
-     * @static
-     * @readonly
+     * If it is Xbox.
+     *
      * @type {boolean}
-     * @name platform.xbox
-     * @description If it is Xbox.
      */
     xbox: xbox,
 
     /**
-     * @static
-     * @readonly
+     * If platform supports gamepads.
+     *
      * @type {boolean}
-     * @name platform.gamepads
-     * @description If platform supports gamepads.
      */
     gamepads: gamepads,
 
     /**
-     * @static
-     * @readonly
+     * If platform supports touch input.
+     *
      * @type {boolean}
-     * @name platform.touch
-     * @description If platform supports touch input.
      */
     touch: touch,
 
     /**
-     * @static
-     * @readonly
+     * If the platform supports Web Workers.
+     *
      * @type {boolean}
-     * @name platform.workers
-     * @description If the platform supports Web Workers.
      */
     workers: workers,
 
     /**
-     * @private
-     * @static
-     * @readonly
+     * If the platform supports an options object as the third parameter to
+     * `EventTarget.addEventListener()` and the passive property is supported.
+     *
      * @type {boolean}
-     * @name platform.passiveEvents
-     * @description If the platform supports an options object as the third parameter
-     * to `EventTarget.addEventListener()` and the passive property is supported.
+     * @private
      */
     passiveEvents: passiveEvents
 };

--- a/src/core/string.js
+++ b/src/core/string.js
@@ -97,37 +97,35 @@ function numCharsToTakeForNextSymbol(string, index) {
 }
 
 /**
+ * Extended String API.
+ *
  * @namespace
- * @name string
- * @description Extended String API.
  */
 const string = {
     /**
-     * @constant
+     * All lowercase letters.
+     *
      * @type {string}
-     * @name string.ASCII_LOWERCASE
-     * @description All lowercase letters.
      */
     ASCII_LOWERCASE: ASCII_LOWERCASE,
+
     /**
-     * @constant
+     * All uppercase letters.
+     *
      * @type {string}
-     * @name string.ASCII_UPPERCASE
-     * @description All uppercase letters.
      */
     ASCII_UPPERCASE: ASCII_UPPERCASE,
+
     /**
-     * @constant
+     * All ASCII letters.
+     *
      * @type {string}
-     * @name string.ASCII_LETTERS
-     * @description All ASCII letters.
      */
     ASCII_LETTERS: ASCII_LETTERS,
 
     /**
-     * @function
-     * @name string.format
-     * @description Return a string with {n} replaced with the n-th argument.
+     * Return a string with {n} replaced with the n-th argument.
+     *
      * @param {string} s - The string to format.
      * @param {object} [arguments] - All other arguments are substituted into the string.
      * @returns {string} The formatted string.
@@ -143,13 +141,13 @@ const string = {
     },
 
     /**
-     * @function
-     * @name string.toBool
-     * @description Convert a string value to a boolean. In non-strict mode (the default), 'true' is converted to true, all other values
-     * are converted to false. In strict mode, 'true' is converted to true, 'false' is converted to false, all other values will throw
-     * an Exception.
+     * Convert a string value to a boolean. In non-strict mode (the default), 'true' is converted
+     * to true, all other values are converted to false. In strict mode, 'true' is converted to
+     * true, 'false' is converted to false, all other values will throw an Exception.
+     *
      * @param {string} s - The string to convert.
-     * @param {boolean} [strict] - In strict mode an Exception is thrown if s is not an accepted string value. Defaults to false.
+     * @param {boolean} [strict] - In strict mode an Exception is thrown if s is not an accepted
+     * string value. Defaults to false.
      * @returns {boolean} The converted value.
      */
     toBool: function (s, strict = false) {
@@ -169,10 +167,9 @@ const string = {
     },
 
     /**
-     * @function
-     * @name string.getCodePoint
-     * @description Get the code point number for a character in a string. Polyfill for
+     * Get the code point number for a character in a string. Polyfill for
      * [`codePointAt`]{@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/codePointAt}.
+     *
      * @param {string} string - The string to get the code point from.
      * @param {number} [i] - The index in the string.
      * @returns {number} The code point value for the character in the string.
@@ -183,9 +180,8 @@ const string = {
     },
 
     /**
-     * @function
-     * @name string.getCodePoints
-     * @description Gets an array of all code points in a string.
+     * Gets an array of all code points in a string.
+     *
      * @param {string} string - The string to get code points from.
      * @returns {number[]} The code points in the string.
      */
@@ -204,11 +200,11 @@ const string = {
     },
 
     /**
-     * @function
-     * @name string.getSymbols
-     * @description Gets an array of all grapheme clusters (visible symbols) in a string. This is needed because
-     * some symbols (such as emoji or accented characters) are actually made up of multiple character codes. See
-     * {@link https://mathiasbynens.be/notes/javascript-unicode here} for more info.
+     * Gets an array of all grapheme clusters (visible symbols) in a string. This is needed because
+     * some symbols (such as emoji or accented characters) are actually made up of multiple
+     * character codes. See {@link https://mathiasbynens.be/notes/javascript-unicode here} for more
+     * info.
+     *
      * @param {string} string - The string to break into symbols.
      * @returns {string[]} The symbols in the string.
      */
@@ -245,10 +241,9 @@ const string = {
     },
 
     /**
-     * @function
-     * @name string.fromCodePoint
-     * @description Get the string for a given code point or set of code points. Polyfill for
+     * Get the string for a given code point or set of code points. Polyfill for
      * [`fromCodePoint`]{@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/fromCodePoint}.
+     *
      * @param {...number} args - The code points to convert to a string.
      * @returns {string} The converted string.
      */

--- a/src/framework/entity.js
+++ b/src/framework/entity.js
@@ -127,8 +127,8 @@ class Entity extends GraphNode {
      * - "sound" - see {@link SoundComponent}
      * - "sprite" - see {@link SpriteComponent}
      *
-     * @param {object} [data] - The initialization data for the specific component type. Refer to each
-     * specific component's API reference page for details on valid values for this parameter.
+     * @param {object} [data] - The initialization data for the specific component type. Refer to
+     * each specific component's API reference page for details on valid values for this parameter.
      * @returns {Component} The new Component that was attached to the entity or null if there
      * was an error.
      * @example

--- a/src/framework/script.js
+++ b/src/framework/script.js
@@ -7,13 +7,6 @@ import { getApplication } from './globals.js';
 /** @typedef {import('./application.js').Application} Application */
 
 /**
- * @name script
- * @namespace
- * @description The script namespace holds the createLoadingScreen function that
- * is used to override the default PlayCanvas loading screen.
- */
-
-/**
  * Callback used by {@link script.createLoadingScreen}.
  *
  * @callback createScreenCallback
@@ -35,20 +28,25 @@ let _legacy = false;
 // loading screen scripts are reloaded
 let _createdLoadingScreen = false;
 
+/**
+ * The script namespace holds the createLoadingScreen function that is used to override the default
+ * PlayCanvas loading screen.
+ *
+ * @namespace
+ */
 const script = {
     // set during script load to be used for initializing script
     app: null,
 
     /**
-     * @private
-     * @function
-     * @name script.create
-     * @description Create a script resource object. A script file should contain a single call to {@link script.create} and the callback should return a script object which will be
+     * Create a script resource object. A script file should contain a single call to
+     * {@link script.create} and the callback should return a script object which will be
      * instantiated when attached to Entities.
+     *
      * @param {string} name - The name of the script object.
-     * @param {createScriptCallback} callback - The callback function which is passed an {@link Application} object,
-     * which is used to access Entities and Components, and should return the Type of the script resource
-     * to be instanced for each Entity.
+     * @param {createScriptCallback} callback - The callback function which is passed an
+     * {@link Application} object, which is used to access Entities and Components, and should
+     * return the Type of the script resource to be instanced for each Entity.
      * @example
      * pc.script.create(function (app) {
      *     var Scriptable = function (entity) {
@@ -63,6 +61,7 @@ const script = {
      *
      *     return Scriptable;
      * });
+     * @private
      */
     create: function (name, callback) {
         if (!_legacy)
@@ -81,23 +80,28 @@ const script = {
     },
 
     /**
-     * @private
-     * @function
-     * @name script.attribute
-     * @description Creates a script attribute for the current script. The script attribute can be accessed
-     * inside the script instance like so 'this.attributeName' or outside a script instance like so 'entity.script.attributeName'.
-     * Script attributes can be edited from the Attribute Editor of the PlayCanvas Editor like normal Components.
+     * Creates a script attribute for the current script. The script attribute can be accessed
+     * inside the script instance like so 'this.attributeName' or outside a script instance like so
+     * 'entity.script.attributeName'. Script attributes can be edited from the Attribute Editor of
+     * the PlayCanvas Editor like normal Components.
+     *
      * @param {string} name - The name of the attribute.
-     * @param {string} type - The type of the attribute. Can be: 'number', 'string', 'boolean', 'asset', 'entity', 'rgb', 'rgba', 'vector', 'enumeration', 'curve', 'colorcurve'.
+     * @param {string} type - The type of the attribute. Can be: 'number', 'string', 'boolean',
+     * 'asset', 'entity', 'rgb', 'rgba', 'vector', 'enumeration', 'curve', 'colorcurve'.
      * @param {object} defaultValue - The default value of the attribute.
      * @param {object} options - Optional parameters for the attribute.
      * @param {number} options.min - The minimum value of the attribute.
      * @param {number} options.max - The maximum value of the attribute.
-     * @param {number} options.step - The step that will be used when changing the attribute value in the PlayCanvas Editor.
-     * @param {number} options.decimalPrecision - A number that specifies the number of decimal digits allowed for the value.
-     * @param {object[]} options.enumerations - An array of name, value pairs from which the user can select one if the attribute type is an enumeration.
-     * @param {string[]} options.curves - (For 'curve' attributes only) An array of strings that define the names of each curve in the curve editor.
-     * @param {boolean} options.color - (For 'curve' attributes only) If true then the curve attribute will be a color curve.
+     * @param {number} options.step - The step that will be used when changing the attribute value
+     * in the PlayCanvas Editor.
+     * @param {number} options.decimalPrecision - A number that specifies the number of decimal
+     * digits allowed for the value.
+     * @param {object[]} options.enumerations - An array of name, value pairs from which the user
+     * can select one if the attribute type is an enumeration.
+     * @param {string[]} options.curves - (For 'curve' attributes only) An array of strings that
+     * define the names of each curve in the curve editor.
+     * @param {boolean} options.color - (For 'curve' attributes only) If true then the curve
+     * attribute will be a color curve.
      * @example
      * pc.script.attribute('speed', 'number', 5);
      * pc.script.attribute('message', 'string', "My message");
@@ -128,18 +132,20 @@ const script = {
      *
      *     return Scriptable;
      * });
+     * @private
      */
     attribute: function (name, type, defaultValue, options) {
         // only works when parsing the script...
     },
 
     /**
-     * @function
-     * @name script.createLoadingScreen
-     * @description Handles the creation of the loading screen of the application. A script can subscribe to
-     * the events of a {@link Application} to show a loading screen, progress bar etc. In order for this to work
-     * you need to set the project's loading screen script to the script that calls this method.
-     * @param {createScreenCallback} callback - A function which can set up and tear down a customized loading screen.
+     * Handles the creation of the loading screen of the application. A script can subscribe to the
+     * events of a {@link Application} to show a loading screen, progress bar etc. In order for
+     * this to work you need to set the project's loading screen script to the script that calls
+     * this method.
+     *
+     * @param {createScreenCallback} callback - A function which can set up and tear down a
+     * customized loading screen.
      * @example
      * pc.script.createLoadingScreen(function (app) {
      *     var showSplashScreen = function () {};

--- a/src/math/math.js
+++ b/src/math/math.js
@@ -1,35 +1,26 @@
 /**
- * @name math
+ * Math API.
+ *
  * @namespace
- * @description Math API.
  */
 const math = {
     /**
-     * @constant
+     * Conversion factor between degrees and radians.
+     *
      * @type {number}
-     * @name math.DEG_TO_RAD
-     * @description Conversion factor between degrees and radians.
-     * @example
-     * // Convert 180 degrees to pi radians
-     * var rad = 180 * pc.math.DEG_TO_RAD;
      */
     DEG_TO_RAD: Math.PI / 180,
 
     /**
-     * @constant
+     * Conversion factor between degrees and radians.
+     *
      * @type {number}
-     * @name math.RAD_TO_DEG
-     * @description Conversion factor between degrees and radians.
-     * @example
-     * // Convert pi radians to 180 degrees
-     * var deg = Math.PI * pc.math.RAD_TO_DEG;
      */
     RAD_TO_DEG: 180 / Math.PI,
 
     /**
-     * @function
-     * @name math.clamp
-     * @description Clamp a number between min and max inclusive.
+     * Clamp a number between min and max inclusive.
+     *
      * @param {number} value - Number to clamp.
      * @param {number} min - Min value.
      * @param {number} max - Max value.
@@ -42,9 +33,8 @@ const math = {
     },
 
     /**
-     * @function
-     * @name math.intToBytes24
-     * @description Convert an 24 bit integer into an array of 3 bytes.
+     * Convert an 24 bit integer into an array of 3 bytes.
+     *
      * @param {number} i - Number holding an integer value.
      * @returns {number[]} An array of 3 bytes.
      * @example
@@ -60,11 +50,10 @@ const math = {
     },
 
     /**
-     * @function
-     * @name math.intToBytes32
-     * @description Convert an 32 bit integer into an array of 4 bytes.
-     * @returns {number[]} An array of 4 bytes.
+     * Convert an 32 bit integer into an array of 4 bytes.
+     *
      * @param {number} i - Number holding an integer value.
+     * @returns {number[]} An array of 4 bytes.
      * @example
      * // Set bytes to [0x11, 0x22, 0x33, 0x44]
      * var bytes = pc.math.intToBytes32(0x11223344);
@@ -79,19 +68,18 @@ const math = {
     },
 
     /**
-     * @function
-     * @name math.bytesToInt24
-     * @description Convert 3 8 bit Numbers into a single unsigned 24 bit Number.
+     * Convert 3 8 bit Numbers into a single unsigned 24 bit Number.
+     *
+     * @param {number} r - A single byte (0-255).
+     * @param {number} g - A single byte (0-255).
+     * @param {number} b - A single byte (0-255).
+     * @returns {number} A single unsigned 24 bit Number.
      * @example
      * // Set result1 to 0x112233 from an array of 3 values
      * var result1 = pc.math.bytesToInt24([0x11, 0x22, 0x33]);
      *
      * // Set result2 to 0x112233 from 3 discrete values
      * var result2 = pc.math.bytesToInt24(0x11, 0x22, 0x33);
-     * @param {number} r - A single byte (0-255).
-     * @param {number} g - A single byte (0-255).
-     * @param {number} b - A single byte (0-255).
-     * @returns {number} A single unsigned 24 bit Number.
      */
     bytesToInt24: function (r, g, b) {
         if (r.length) {
@@ -103,9 +91,12 @@ const math = {
     },
 
     /**
-     * @function
-     * @name math.bytesToInt32
-     * @description Convert 4 1-byte Numbers into a single unsigned 32bit Number.
+     * Convert 4 1-byte Numbers into a single unsigned 32bit Number.
+     *
+     * @param {number} r - A single byte (0-255).
+     * @param {number} g - A single byte (0-255).
+     * @param {number} b - A single byte (0-255).
+     * @param {number} a - A single byte (0-255).
      * @returns {number} A single unsigned 32bit Number.
      * @example
      * // Set result1 to 0x11223344 from an array of 4 values
@@ -113,10 +104,6 @@ const math = {
      *
      * // Set result2 to 0x11223344 from 4 discrete values
      * var result2 = pc.math.bytesToInt32(0x11, 0x22, 0x33, 0x44);
-     * @param {number} r - A single byte (0-255).
-     * @param {number} g - A single byte (0-255).
-     * @param {number} b - A single byte (0-255).
-     * @param {number} a - A single byte (0-255).
      */
     bytesToInt32: function (r, g, b, a) {
         if (r.length) {
@@ -133,31 +120,29 @@ const math = {
     },
 
     /**
-     * @function
-     * @name math.lerp
-     * @returns {number} The linear interpolation of two numbers.
-     * @description Calculates the linear interpolation of two numbers.
+     * Calculates the linear interpolation of two numbers.
+     *
      * @param {number} a - Number to linearly interpolate from.
      * @param {number} b - Number to linearly interpolate to.
      * @param {number} alpha - The value controlling the result of interpolation. When alpha is 0,
-     * a is returned. When alpha is 1, b is returned. Between 0 and 1, a linear interpolation between
-     * a and b is returned. alpha is clamped between 0 and 1.
+     * a is returned. When alpha is 1, b is returned. Between 0 and 1, a linear interpolation
+     * between a and b is returned. alpha is clamped between 0 and 1.
+     * @returns {number} The linear interpolation of two numbers.
      */
     lerp: function (a, b, alpha) {
         return a + (b - a) * math.clamp(alpha, 0, 1);
     },
 
     /**
-     * @function
-     * @name math.lerpAngle
-     * @description Calculates the linear interpolation of two angles ensuring that interpolation
-     * is correctly performed across the 360 to 0 degree boundary. Angles are supplied in degrees.
-     * @returns {number} The linear interpolation of two angles.
+     * Calculates the linear interpolation of two angles ensuring that interpolation is correctly
+     * performed across the 360 to 0 degree boundary. Angles are supplied in degrees.
+     *
      * @param {number} a - Angle (in degrees) to linearly interpolate from.
      * @param {number} b - Angle (in degrees) to linearly interpolate to.
      * @param {number} alpha - The value controlling the result of interpolation. When alpha is 0,
-     * a is returned. When alpha is 1, b is returned. Between 0 and 1, a linear interpolation between
-     * a and b is returned. alpha is clamped between 0 and 1.
+     * a is returned. When alpha is 1, b is returned. Between 0 and 1, a linear interpolation
+     * between a and b is returned. alpha is clamped between 0 and 1.
+     * @returns {number} The linear interpolation of two angles.
      */
     lerpAngle: function (a, b, alpha) {
         if (b - a > 180) {
@@ -170,9 +155,8 @@ const math = {
     },
 
     /**
-     * @function
-     * @name math.powerOfTwo
-     * @description Returns true if argument is a power-of-two and false otherwise.
+     * Returns true if argument is a power-of-two and false otherwise.
+     *
      * @param {number} x - Number to check for power-of-two property.
      * @returns {boolean} true if power-of-two and false otherwise.
      */
@@ -181,9 +165,8 @@ const math = {
     },
 
     /**
-     * @function
-     * @name math.nextPowerOfTwo
-     * @description Returns the next power of 2 for the specified value.
+     * Returns the next power of 2 for the specified value.
+     *
      * @param {number} val - The value for which to calculate the next power of 2.
      * @returns {number} The next power of 2.
      */
@@ -199,10 +182,9 @@ const math = {
     },
 
     /**
-     * @function
-     * @name math.random
-     * @description Return a pseudo-random number between min and max.
-     * The number generated is in the range [min, max), that is inclusive of the minimum but exclusive of the maximum.
+     * Return a pseudo-random number between min and max. The number generated is in the range
+     * [min, max), that is inclusive of the minimum but exclusive of the maximum.
+     *
      * @param {number} min - Lower bound for range.
      * @param {number} max - Upper bound for range.
      * @returns {number} Pseudo-random number between the supplied range.
@@ -213,15 +195,15 @@ const math = {
     },
 
     /**
-     * @function
-     * @name math.smoothstep
-     * @description The function interpolates smoothly between two input values based on
-     * a third one that should be between the first two. The returned value is clamped
-     * between 0 and 1.
-     * <br/>The slope (i.e. derivative) of the smoothstep function starts at 0 and ends at 0.
-     * This makes it easy to create a sequence of transitions using smoothstep to interpolate
-     * each segment rather than using a more sophisticated or expensive interpolation technique.
-     * <br/>See http://en.wikipedia.org/wiki/Smoothstep for more details.
+     * The function interpolates smoothly between two input values based on a third one that should
+     * be between the first two. The returned value is clamped between 0 and 1.
+     *
+     * The slope (i.e. derivative) of the smoothstep function starts at 0 and ends at 0. This makes
+     * it easy to create a sequence of transitions using smoothstep to interpolate each segment
+     * rather than using a more sophisticated or expensive interpolation technique.
+     *
+     * See http://en.wikipedia.org/wiki/Smoothstep for more details.
+     *
      * @param {number} min - The lower bound of the interpolation range.
      * @param {number} max - The upper bound of the interpolation range.
      * @param {number} x - The value to interpolate.
@@ -237,11 +219,11 @@ const math = {
     },
 
     /**
-     * @function
-     * @name math.smootherstep
-     * @description An improved version of the {@link math.smoothstep} function which has zero
-     * 1st and 2nd order derivatives at t=0 and t=1.
-     * <br/>See http://en.wikipedia.org/wiki/Smoothstep for more details.
+     * An improved version of the {@link math.smoothstep} function which has zero 1st and 2nd order
+     * derivatives at t=0 and t=1.
+     *
+     * See http://en.wikipedia.org/wiki/Smoothstep for more details.
+     *
      * @param {number} min - The lower bound of the interpolation range.
      * @param {number} max - The upper bound of the interpolation range.
      * @param {number} x - The value to interpolate.
@@ -257,9 +239,8 @@ const math = {
     },
 
     /**
-     * @function
-     * @name math.roundUp
-     * @description Rounds a number up to nearest multiple.
+     * Rounds a number up to nearest multiple.
+     *
      * @param {number} numToRound - The number to round up.
      * @param {number} multiple - The multiple to round up to.
      * @returns {number} A number rounded up to nearest multiple.
@@ -271,15 +252,14 @@ const math = {
     },
 
     /**
-     * @function
-     * @private
-     * @name math.between
-     * @description Checks whether a given number resides between two other given numbers.
+     * Checks whether a given number resides between two other given numbers.
+     *
      * @param {number} num - The number to check the position of.
      * @param {number} a - The first upper or lower threshold to check between.
      * @param {number} b - The second upper or lower threshold to check between.
      * @param {boolean} inclusive - If true, a num param which is equal to a or b will return true.
      * @returns {boolean} true if between or false otherwise.
+     * @private
      */
     between: function (num, a, b, inclusive) {
         const min = Math.min(a, b);

--- a/src/math/random.js
+++ b/src/math/random.js
@@ -4,18 +4,17 @@ import { math } from './math.js';
 const _goldenAngle = 2.399963229728653;
 
 /**
- * @name random
+ * Random API.
+ *
  * @namespace
- * @description Random API.
+ * @private
  */
 const random = {
-
     /**
-     * @function
+     * Return a pseudo-random 2D point inside a unit circle with uniform distribution.
+     *
+     * @param {Vec2} point - The returned generated point.
      * @private
-     * @name random.circlePoint
-     * @description Return a pseudo-random 2D point inside a unit circle with uniform distribution.
-     * @param {Vec2} point - the returned generated point.
      */
     circlePoint: function (point) {
         const r = Math.sqrt(Math.random());
@@ -25,13 +24,13 @@ const random = {
     },
 
     /**
-     * @function
+     * Generates evenly distributed deterministic points inside a unit circle using Fermat's spiral
+     * and Vogel's method.
+     *
+     * @param {Vec2} point - The returned generated point.
+     * @param {number} index - Index of the point to generate, in the range from 0 to numPoints - 1.
+     * @param {number} numPoints - The total number of points of the set.
      * @private
-     * @name random.circlePointDeterministic
-     * @description Generates evenly distributed deterministic points inside a unit circle using Fermat's spiral and Vogel's method.
-     * @param {Vec2} point - the returned generated point.
-     * @param {number} index - index of the point to generate, in the range from 0 to numPoints - 1.
-     * @param {number} numPoints - the total number of points of the set.
      */
     circlePointDeterministic: function (point, index, numPoints) {
         const theta = index * _goldenAngle;
@@ -42,22 +41,25 @@ const random = {
     },
 
     /**
-     * @function
+     * Generates evenly distributed deterministic points on a unit sphere using Fibonacci sphere
+     * algorithm. It also allows the points to cover only part of the sphere by specifying start
+     * and end parameters, representing value from 0 (top of the sphere) and 1 (bottom of the
+     * sphere). For example by specifying 0.4 and 0.6 and start and end, a band around the equator
+     * would be generated.
+     *
+     * @param {Vec3} point - The returned generated point.
+     * @param {number} index - Index of the point to generate, in the range from 0 to numPoints - 1.
+     * @param {number} numPoints - The total number of points of the set.
+     * @param {number} [start] - Part on the sphere along y axis to start the points, in the range
+     * of 0 and 1. Defaults to 0.
+     * @param {number} [end] - Part on the sphere along y axis to stop the points, in the range of
+     * 0 and 1. Defaults to 1.
      * @private
-     * @name random.spherePointDeterministic
-     * @description Generates evenly distributed deterministic points on a unit sphere using Fibonacci sphere algorithm. It also allows
-     * the points to cover only part of the sphere by specifying start and end parameters, representing value from 0 (top of the sphere) and
-     * 1 (bottom of the sphere). For example by specifying 0.4 and 0.6 and start and end, a band around the equator would be generated.
-     * @param {Vec3} point - the returned generated point.
-     * @param {number} index - index of the point to generate, in the range from 0 to numPoints - 1.
-     * @param {number} numPoints - the total number of points of the set.
-     * @param {number} [start] - Part on the sphere along y axis to start the points, in the range of 0 and 1. Defaults to 0.
-     * @param {number} [end] - Part on the sphere along y axis to stop the points, in the range of 0 and 1. Defaults to 1.
      */
     spherePointDeterministic: function (point, index, numPoints, start = 0, end = 1) {
 
         // y coordinate needs to go from -1 (top) to 1 (bottom) for the full sphere
-        // evaluate its vaue for this point and specified start and end
+        // evaluate its value for this point and specified start and end
         start = 1 - 2 * start;
         end = 1 - 2 * end;
         const y = math.lerp(start, end, index / numPoints);
@@ -74,13 +76,12 @@ const random = {
     },
 
     /**
-     * @function
-     * @private
-     * @name random.radicalInverse
-     * @description Generate a repeatable pseudo-random sequence using radical inverse.
-     * Based on http://holger.dammertz.org/stuff/notes_HammersleyOnHemisphere.html
-     * @param {number} [i] - The index in the sequence to return.
+     * Generate a repeatable pseudo-random sequence using radical inverse. Based on
+     * http://holger.dammertz.org/stuff/notes_HammersleyOnHemisphere.html
+     *
+     * @param {number} i - The index in the sequence to return.
      * @returns {number} The pseudo-random value.
+     * @private
      */
     radicalInverse: function (i) {
         let bits = ((i << 16) | (i >>> 16)) >>> 0;

--- a/src/xr/constants.js
+++ b/src/xr/constants.js
@@ -35,7 +35,7 @@ export const XRSPACE_VIEWER = 'viewer';
  * underlying platform. When using this reference space the user is not expected to move beyond
  * their initial position much, if at all, and tracking is optimized for that purpose. For devices
  * with 6DoF tracking, local reference spaces should emphasize keeping the origin stable relative
- * to the user’s environment.
+ * to the user's environment.
  *
  * @type string
  */
@@ -48,7 +48,7 @@ export const XRSPACE_LOCAL = 'local';
  * might be estimated by the underlying platform. When using this reference space, the user is not
  * expected to move beyond their initial position much, if at all, and tracking is optimized for
  * that purpose. For devices with 6DoF tracking, local-floor reference spaces should emphasize
- * keeping the origin stable relative to the user’s environment.
+ * keeping the origin stable relative to the user's environment.
  *
  * @type string
  */
@@ -58,7 +58,7 @@ export const XRSPACE_LOCALFLOOR = 'local-floor';
  * Bounded Floor - represents a tracking space with its native origin at the floor, where the user
  * is expected to move within a pre-established boundary. Tracking in a bounded-floor reference
  * space is optimized for keeping the native origin and bounds geometry stable relative to the
- * user’s environment.
+ * user's environment.
  *
  * @type string
  */
@@ -67,7 +67,7 @@ export const XRSPACE_BOUNDEDFLOOR = 'bounded-floor';
 /**
  * Unbounded - represents a tracking space where the user is expected to move freely around their
  * environment, potentially even long distances from their starting point. Tracking in an unbounded
- * reference space is optimized for stability around the user’s current position, and as such the
+ * reference space is optimized for stability around the user's current position, and as such the
  * native origin may drift over time.
  *
  * @type string
@@ -85,7 +85,7 @@ export const XRTARGETRAY_GAZE = 'gaze';
 
 /**
  * Screen - indicates that the input source was an interaction with the canvas element associated
- * with an inline session’s output context, such as a mouse click or touch event.
+ * with an inline session's output context, such as a mouse click or touch event.
  *
  * @type string
  */


### PR DESCRIPTION
Migrates more of the JSDoc comments to ES6 format, mainly focusing on namespaces (`math`, `string`, etc).

Fixes #3827

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
