### PR TITLE
Improvements to internal implementation of debug line / mesh rendering

### DIFF
--- a/examples/src/examples/graphics/render-cubemap.tsx
+++ b/examples/src/examples/graphics/render-cubemap.tsx
@@ -197,7 +197,6 @@ class RenderCubemapExample extends Example {
 
         // update things each frame
         let time = 0;
-        const device = app.graphicsDevice;
         app.on("update", function (dt) {
             time += dt;
 

--- a/src/deprecated/deprecated.js
+++ b/src/deprecated/deprecated.js
@@ -912,13 +912,13 @@ Application.prototype.loadSceneSettings = function (url, callback) {
 
 Application.prototype.renderMeshInstance = function (meshInstance, options) {
     Debug.deprecated("pc.Application.renderMeshInstance is deprecated. Use pc.Application.drawMeshInstance.");
-    const layer = options?.layer ? options.layer : this.scene.getDefaultDrawLayer();
+    const layer = options?.layer ? options.layer : this.scene.defaultDrawLayer;
     this.scene.immediate.drawMesh(null, null, null, meshInstance, layer);
 };
 
 Application.prototype.renderMesh = function (mesh, material, matrix, options) {
     Debug.deprecated("pc.Application.renderMesh is deprecated. Use pc.Application.drawMesh.");
-    const layer = options?.layer ? options.layer : this.scene.getDefaultDrawLayer();
+    const layer = options?.layer ? options.layer : this.scene.defaultDrawLayer;
     this.scene.immediate.drawMesh(material, matrix, mesh, null, layer);
 };
 

--- a/src/deprecated/deprecated.js
+++ b/src/deprecated/deprecated.js
@@ -912,21 +912,21 @@ Application.prototype.loadSceneSettings = function (url, callback) {
 
 Application.prototype.renderMeshInstance = function (meshInstance, options) {
     Debug.deprecated("pc.Application.renderMeshInstance is deprecated. Use pc.Application.drawMeshInstance.");
-    const layer = options?.layer ? options.layer : this._getDefaultDrawLayer();
-    this._immediate.drawMesh(null, null, null, meshInstance, layer);
+    const layer = options?.layer ? options.layer : this.scene.getDefaultDrawLayer();
+    this.scene.immediate.drawMesh(null, null, null, meshInstance, layer);
 };
 
 Application.prototype.renderMesh = function (mesh, material, matrix, options) {
     Debug.deprecated("pc.Application.renderMesh is deprecated. Use pc.Application.drawMesh.");
-    const layer = options?.layer ? options.layer : this._getDefaultDrawLayer();
-    this._immediate.drawMesh(material, matrix, mesh, null, layer);
+    const layer = options?.layer ? options.layer : this.scene.getDefaultDrawLayer();
+    this.scene.immediate.drawMesh(material, matrix, mesh, null, layer);
 };
 
 Application.prototype._addLines = function (positions, colors, options) {
     const layer = (options && options.layer) ? options.layer : this.scene.layers.getLayerById(LAYERID_IMMEDIATE);
     const depthTest = (options && options.depthTest !== undefined) ? options.depthTest : true;
 
-    const batch = this._immediate.getBatch(layer, depthTest);
+    const batch = this.scene.immediate.getBatch(layer, depthTest);
     batch.addLines(positions, colors);
 };
 

--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -1716,7 +1716,7 @@ class Application extends EventHandler {
      * ];
      * app.drawLines(points, colors);
      */
-    drawLines(positions, colors, depthTest = true, layer = this.scene.getDefaultDrawLayer()) {
+    drawLines(positions, colors, depthTest = true, layer = this.scene.defaultDrawLayer) {
         this.scene.drawLines(positions, colors, depthTest, layer);
     }
 
@@ -1750,7 +1750,7 @@ class Application extends EventHandler {
      * ];
      * app.drawLineArrays(points, colors);
      */
-    drawLineArrays(positions, colors, depthTest = true, layer = this.scene.getDefaultDrawLayer()) {
+    drawLineArrays(positions, colors, depthTest = true, layer = this.scene.defaultDrawLayer) {
         this.scene.drawLineArrays(positions, colors, depthTest, layer);
     }
 
@@ -1770,7 +1770,7 @@ class Application extends EventHandler {
      * var center = new pc.Vec3(0, 0, 0);
      * app.drawWireSphere(center, 1.0, pc.Color.RED);
      */
-    drawWireSphere(center, radius, color = Color.WHITE, segments = 20, depthTest = true, layer = this.scene.getDefaultDrawLayer()) {
+    drawWireSphere(center, radius, color = Color.WHITE, segments = 20, depthTest = true, layer = this.scene.defaultDrawLayer) {
         this.scene.immediate.drawWireSphere(center, radius, color, segments, depthTest, layer);
     }
 
@@ -1790,28 +1790,28 @@ class Application extends EventHandler {
      * var max = new pc.Vec3(1, 1, 1);
      * app.drawWireAlignedBox(min, max, pc.Color.RED);
      */
-    drawWireAlignedBox(minPoint, maxPoint, color = Color.WHITE, depthTest = true, layer = this.scene.getDefaultDrawLayer()) {
+    drawWireAlignedBox(minPoint, maxPoint, color = Color.WHITE, depthTest = true, layer = this.scene.defaultDrawLayer) {
         this.scene.immediate.drawWireAlignedBox(minPoint, maxPoint, color, depthTest, layer);
     }
 
     // Draw meshInstance at this frame
-    drawMeshInstance(meshInstance, layer = this.scene.getDefaultDrawLayer()) {
+    drawMeshInstance(meshInstance, layer = this.scene.defaultDrawLayer) {
         this.scene.immediate.drawMesh(null, null, null, meshInstance, layer);
     }
 
     // Draw mesh at this frame
-    drawMesh(mesh, material, matrix, layer = this.scene.getDefaultDrawLayer()) {
+    drawMesh(mesh, material, matrix, layer = this.scene.defaultDrawLayer) {
         this.scene.immediate.drawMesh(material, matrix, mesh, null, layer);
     }
 
     // Draw quad of size [-0.5, 0.5] at this frame
-    drawQuad(matrix, material, layer = this.scene.getDefaultDrawLayer()) {
+    drawQuad(matrix, material, layer = this.scene.defaultDrawLayer) {
         this.scene.immediate.drawMesh(material, matrix, this.scene.immediate.getQuadMesh(), null, layer);
     }
 
     // draws a texture on [x,y] position on screen, with size [width, height].
     // Coordinates / sizes are in projected space (-1 .. 1)
-    drawTexture(x, y, width, height, texture, material, layer = this.scene.getDefaultDrawLayer()) {
+    drawTexture(x, y, width, height, texture, material, layer = this.scene.defaultDrawLayer) {
 
         // TODO: if this is used for anything other than debug texture display, we should optimize this to avoid allocations
         const matrix = new Mat4();
@@ -1829,7 +1829,7 @@ class Application extends EventHandler {
 
     // draws a depth texture on [x,y] position on screen, with size [width, height].
     // Coordinates / sizes are in projected space (-1 .. 1)
-    drawDepthTexture(x, y, width, height, layer = this.scene.getDefaultDrawLayer()) {
+    drawDepthTexture(x, y, width, height, layer = this.scene.defaultDrawLayer) {
         const material = new Material();
         material.shader = this.scene.immediate.getDepthTextureShader();
         material.update();

--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -2003,7 +2003,6 @@ class Application extends EventHandler {
     }
 
     _registerSceneImmediate(scene) {
-        this.on('prerender', scene.immediate.onPreRender, scene.immediate);
         this.on('postrender', scene.immediate.onPostRender, scene.immediate);
     }
 }

--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -28,7 +28,6 @@ import {
 } from '../scene/constants.js';
 import { BatchManager } from '../scene/batching/batch-manager.js';
 import { ForwardRenderer } from '../scene/renderer/forward-renderer.js';
-import { Immediate } from '../scene/immediate/immediate.js';
 import { AreaLightLuts } from '../scene/area-light-luts.js';
 import { Layer } from '../scene/layer.js';
 import { LayerComposition } from '../scene/composition/layer-composition.js';
@@ -266,7 +265,9 @@ class Application extends EventHandler {
         this._entityIndex = {};
 
         this.scene = new Scene(this.graphicsDevice);
-        this.root = new Entity(this);
+        this._registerSceneImmediate(this.scene);
+
+        this.root = new Entity();
         this.root._enabledInHierarchy = true;
         this._enableList = [];
         this._enableList.size = 0;
@@ -453,9 +454,6 @@ class Application extends EventHandler {
                 document.addEventListener('webkitvisibilitychange', this._visibilityChangeHandler, false);
             }
         }
-
-        // immediate rendering
-        this._immediate = new Immediate(this.graphicsDevice, this);
 
         // bind tick function to current scope
         /* eslint-disable-next-line no-use-before-define */
@@ -1650,11 +1648,6 @@ class Application extends EventHandler {
         return timestamp;
     }
 
-    // returns the default layer used by the line drawing functions
-    _getDefaultDrawLayer() {
-        return this.scene.layers.getLayerById(LAYERID_IMMEDIATE);
-    }
-
     /**
      * @function
      * @name Application#drawLine
@@ -1682,9 +1675,8 @@ class Application extends EventHandler {
      * var worldLayer = app.scene.layers.getLayerById(pc.LAYERID_WORLD);
      * app.drawLine(start, end, pc.Color.WHITE, true, worldLayer);
      */
-    drawLine(start, end, color = Color.WHITE, depthTest = true, layer = this._getDefaultDrawLayer()) {
-        const batch = this._immediate.getBatch(layer, depthTest);
-        batch.addLines([start, end], [color, color]);
+    drawLine(start, end, color, depthTest, layer) {
+        this.scene.drawLine(start, end, color, depthTest, layer);
     }
 
     /**
@@ -1724,9 +1716,8 @@ class Application extends EventHandler {
      * ];
      * app.drawLines(points, colors);
      */
-    drawLines(positions, colors, depthTest = true, layer = this._getDefaultDrawLayer()) {
-        const batch = this._immediate.getBatch(layer, depthTest);
-        batch.addLines(positions, colors);
+    drawLines(positions, colors, depthTest = true, layer = this.scene.getDefaultDrawLayer()) {
+        this.scene.drawLines(positions, colors, depthTest, layer);
     }
 
     /**
@@ -1759,9 +1750,8 @@ class Application extends EventHandler {
      * ];
      * app.drawLineArrays(points, colors);
      */
-    drawLineArrays(positions, colors, depthTest = true, layer = this._getDefaultDrawLayer()) {
-        const batch = this._immediate.getBatch(layer, depthTest);
-        batch.addLinesArrays(positions, colors);
+    drawLineArrays(positions, colors, depthTest = true, layer = this.scene.getDefaultDrawLayer()) {
+        this.scene.drawLineArrays(positions, colors, depthTest, layer);
     }
 
     /**
@@ -1780,8 +1770,8 @@ class Application extends EventHandler {
      * var center = new pc.Vec3(0, 0, 0);
      * app.drawWireSphere(center, 1.0, pc.Color.RED);
      */
-    drawWireSphere(center, radius, color = Color.WHITE, segments = 20, depthTest = true, layer = this._getDefaultDrawLayer()) {
-        this._immediate.drawWireSphere(center, radius, color, segments, depthTest, layer);
+    drawWireSphere(center, radius, color = Color.WHITE, segments = 20, depthTest = true, layer = this.scene.getDefaultDrawLayer()) {
+        this.scene.immediate.drawWireSphere(center, radius, color, segments, depthTest, layer);
     }
 
     /**
@@ -1800,28 +1790,28 @@ class Application extends EventHandler {
      * var max = new pc.Vec3(1, 1, 1);
      * app.drawWireAlignedBox(min, max, pc.Color.RED);
      */
-    drawWireAlignedBox(minPoint, maxPoint, color = Color.WHITE, depthTest = true, layer = this._getDefaultDrawLayer()) {
-        this._immediate.drawWireAlignedBox(minPoint, maxPoint, color, depthTest, layer);
+    drawWireAlignedBox(minPoint, maxPoint, color = Color.WHITE, depthTest = true, layer = this.scene.getDefaultDrawLayer()) {
+        this.scene.immediate.drawWireAlignedBox(minPoint, maxPoint, color, depthTest, layer);
     }
 
     // Draw meshInstance at this frame
-    drawMeshInstance(meshInstance, layer = this._getDefaultDrawLayer()) {
-        this._immediate.drawMesh(null, null, null, meshInstance, layer);
+    drawMeshInstance(meshInstance, layer = this.scene.getDefaultDrawLayer()) {
+        this.scene.immediate.drawMesh(null, null, null, meshInstance, layer);
     }
 
     // Draw mesh at this frame
-    drawMesh(mesh, material, matrix, layer = this._getDefaultDrawLayer()) {
-        this._immediate.drawMesh(material, matrix, mesh, null, layer);
+    drawMesh(mesh, material, matrix, layer = this.scene.getDefaultDrawLayer()) {
+        this.scene.immediate.drawMesh(material, matrix, mesh, null, layer);
     }
 
     // Draw quad of size [-0.5, 0.5] at this frame
-    drawQuad(matrix, material, layer = this._getDefaultDrawLayer()) {
-        this._immediate.drawMesh(material, matrix, this._immediate.getQuadMesh(), null, layer);
+    drawQuad(matrix, material, layer = this.scene.getDefaultDrawLayer()) {
+        this.scene.immediate.drawMesh(material, matrix, this.scene.immediate.getQuadMesh(), null, layer);
     }
 
     // draws a texture on [x,y] position on screen, with size [width, height].
     // Coordinates / sizes are in projected space (-1 .. 1)
-    drawTexture(x, y, width, height, texture, material, layer = this._getDefaultDrawLayer()) {
+    drawTexture(x, y, width, height, texture, material, layer = this.scene.getDefaultDrawLayer()) {
 
         // TODO: if this is used for anything other than debug texture display, we should optimize this to avoid allocations
         const matrix = new Mat4();
@@ -1830,7 +1820,7 @@ class Application extends EventHandler {
         if (!material) {
             material = new Material();
             material.setParameter("colorMap", texture);
-            material.shader = this._immediate.getTextureShader();
+            material.shader = this.scene.immediate.getTextureShader();
             material.update();
         }
 
@@ -1839,9 +1829,9 @@ class Application extends EventHandler {
 
     // draws a depth texture on [x,y] position on screen, with size [width, height].
     // Coordinates / sizes are in projected space (-1 .. 1)
-    drawDepthTexture(x, y, width, height, layer = this._getDefaultDrawLayer()) {
+    drawDepthTexture(x, y, width, height, layer = this.scene.getDefaultDrawLayer()) {
         const material = new Material();
-        material.shader = this._immediate.getDepthTextureShader();
+        material.shader = this.scene.immediate.getDepthTextureShader();
         material.update();
 
         this.drawTexture(x, y, width, height, null, material, layer);
@@ -2010,6 +2000,11 @@ class Application extends EventHandler {
      */
     getEntityFromIndex(guid) {
         return this._entityIndex[guid];
+    }
+
+    _registerSceneImmediate(scene) {
+        this.on('prerender', scene.immediate.onPreRender, scene.immediate);
+        this.on('postrender', scene.immediate.onPostRender, scene.immediate);
     }
 }
 

--- a/src/scene/composition/layer-composition.js
+++ b/src/scene/composition/layer-composition.js
@@ -217,10 +217,8 @@ class LayerComposition extends EventHandler {
         // function moves transparent or opaque meshes based on moveTransparent from src to dest array
         function moveByBlendType(dest, src, moveTransparent) {
             for (let s = 0; s < src.length;) {
-                const material = src[s].material;
-                const isTransparent = material && material.blendType !== BLEND_NONE;
 
-                if (isTransparent === moveTransparent) {
+                if (src[s].material.transparent === moveTransparent) {
 
                     // add it to dest
                     dest.push(src[s]);

--- a/src/scene/composition/layer-composition.js
+++ b/src/scene/composition/layer-composition.js
@@ -4,7 +4,6 @@ import { set } from '../../core/set-utils.js';
 
 import {
     LAYERID_DEPTH,
-    BLEND_NONE,
     COMPUPDATED_BLEND, COMPUPDATED_CAMERAS, COMPUPDATED_INSTANCES, COMPUPDATED_LIGHTS,
     LIGHTTYPE_DIRECTIONAL, LIGHTTYPE_OMNI, LIGHTTYPE_SPOT
 } from '../constants.js';

--- a/src/scene/immediate/immediate-batches.js
+++ b/src/scene/immediate/immediate-batches.js
@@ -18,15 +18,9 @@ class ImmediateBatches {
         return batch;
     }
 
-    onPreRender() {
+    onPreRender(visibleList, transparent) {
         this.map.forEach((batch) => {
-            batch.onPreRender();
-        });
-    }
-
-    onPostRender() {
-        this.map.forEach((batch) => {
-            batch.onPostRender();
+            batch.onPreRender(visibleList, transparent);
         });
     }
 }

--- a/src/scene/immediate/immediate.js
+++ b/src/scene/immediate/immediate.js
@@ -16,7 +16,7 @@ import { ImmediateBatches } from '../immediate/immediate-batches.js';
 const tempPoints = [];
 
 class Immediate {
-    constructor(device, app) {
+    constructor(device) {
         this.device = device;
         this.quadMesh = null;
         this.textureShader = null;
@@ -39,10 +39,6 @@ class Immediate {
 
         // map of meshes instances added to a layer. The key is layer, the value is an array of mesh instances
         this.layerMeshInstances = new Map();
-
-        // connect to rendering
-        app.on('prerender', this.onPreRender, this);
-        app.on('postrender', this.onPostRender, this);
     }
 
     // creates material for line rendering

--- a/src/scene/immediate/immediate.js
+++ b/src/scene/immediate/immediate.js
@@ -24,14 +24,14 @@ class Immediate {
         this.cubeLocalPos = null;
         this.cubeWorldPos = null;
 
-        this.usedGraphNodes = [];
-        this.freeGraphNodes = [];
-
         // map of Layer to ImmediateBatches, storing line batches for a layer
         this.batchesMap = new Map();
 
         // set of all batches that were used in the frame
         this.allBatches = new Set();
+
+        // set of all layers updated during this frame
+        this.updatedLayers = new Set();
 
         // line materials
         this._materialDepth = null;
@@ -171,7 +171,6 @@ class Immediate {
         if (!meshInstance) {
             const graphNode = this.getGraphNode(matrix);
             meshInstance = new MeshInstance(mesh, material, graphNode);
-            meshInstance.cull = false;
         }
 
         // add the mesh instance to an array per layer, they get added to layers before rendering
@@ -230,57 +229,47 @@ class Immediate {
     }
 
     getGraphNode(matrix) {
-        let graphNode = null;
-        if (this.freeGraphNodes.length > 0) {
-            graphNode = this.freeGraphNodes.pop();
-        } else {
-            graphNode = new GraphNode();
-        }
-        this.usedGraphNodes.push(graphNode);
-
+        const graphNode = new GraphNode();
         graphNode.worldTransform = matrix;
         graphNode._dirtyWorld = graphNode._dirtyNormal = false;
 
         return graphNode;
     }
 
-    // called before the frame is rendered, prepares data for rendering
-    onPreRender() {
+    // called before the layer is getting rendered, this updates debug rendering for the layer
+    // This is called just before the layer is rendered to allow lines to be added from inside
+    // the frame getting rendered
+    onPreRenderLayer(layer, visibleList, transparent) {
 
-        // update line batches
-        this.allBatches.forEach((batches) => {
-            batches.onPreRender();
+        // update line batches for the specified sub-layer
+        this.batchesMap.forEach((batches, batchLayer) => {
+            if (batchLayer === layer) {
+                batches.onPreRender(visibleList, transparent);
+            }
         });
 
-        // add mesh instances to layers for rendering
-        // TODO: the way meshes are rendered (not lines) is by adding mesh instances to the layers each frame,
-        // which forces partial update of layer composition which is slow. If this was released as a proper API to submit meshes
-        // to be rendered for a singe frame only,  mesh instances should probably be injected into the final visible list during
-        // culling to avoid the cost.
-        this.layerMeshInstances.forEach((meshInstances, layer) => {
-            layer.addMeshInstances(meshInstances, true);
-        });
+        // only update meshes once for each layer (they're not per sub-layer at the moment)
+        if (!this.updatedLayers.has(layer)) {
+            this.updatedLayers.add(layer);
+
+            // add mesh instances for specified layer to visible list
+            const meshInstances = this.layerMeshInstances.get(layer);
+            if (meshInstances) {
+                visibleList.list.push(...meshInstances);
+                visibleList.length += meshInstances.length;
+                meshInstances.length = 0;
+            }
+        }
     }
 
     // called after the frame was rendered, clears data
     onPostRender() {
 
         // clean up line batches
-        this.allBatches.forEach((batches) => {
-            batches.onPostRender();
-        });
         this.allBatches.clear();
 
-        // remove mesh instances from layers
-        this.layerMeshInstances.forEach((meshInstances, layer) => {
-            layer.removeMeshInstances(meshInstances, true);
-            meshInstances.length = 0;
-        });
-
-        // reuse graph nodes
-        const temp = this.freeGraphNodes;
-        this.freeGraphNodes = this.usedGraphNodes;
-        this.usedGraphNodes = temp;
+        // all batches need updating next frame
+        this.updatedLayers.clear();
     }
 }
 

--- a/src/scene/immediate/immediate.js
+++ b/src/scene/immediate/immediate.js
@@ -236,8 +236,7 @@ class Immediate {
         return graphNode;
     }
 
-    // called before the layer is getting rendered, this updates debug rendering for the layer
-    // This is called just before the layer is rendered to allow lines to be added from inside
+    // This is called just before the layer is rendered to allow lines for the layer to be added from inside
     // the frame getting rendered
     onPreRenderLayer(layer, visibleList, transparent) {
 

--- a/src/scene/materials/material.js
+++ b/src/scene/materials/material.js
@@ -156,11 +156,13 @@ class Material {
         this._shader = shader;
     }
 
+    // returns boolean depending on material being transparent
+    get transparent() {
+        return this.blend || this.blendSrc !== BLENDMODE_ONE || this.blendDst !== BLENDMODE_ZERO || this.blendEquation !== BLENDEQUATION_ADD;
+    }
+
     get blendType() {
-        if ((!this.blend) &&
-            (this.blendSrc === BLENDMODE_ONE) &&
-            (this.blendDst === BLENDMODE_ZERO) &&
-            (this.blendEquation === BLENDEQUATION_ADD)) {
+        if (!this.transparent) {
             return BLEND_NONE;
         } else if ((this.blend) &&
                    (this.blendSrc === BLENDMODE_SRC_ALPHA) &&

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -36,7 +36,6 @@ import { ShadowRenderer } from './shadow-renderer.js';
 import { StaticMeshes } from './static-meshes.js';
 import { CookieRenderer } from './cookie-renderer.js';
 import { LightCamera } from './light-camera.js';
-import { WorldClustersDebug } from '../lighting/world-clusters-debug.js';
 
 /** @typedef {import('../../graphics/graphics-device.js').GraphicsDevice} GraphicsDevice */
 

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -36,6 +36,7 @@ import { ShadowRenderer } from './shadow-renderer.js';
 import { StaticMeshes } from './static-meshes.js';
 import { CookieRenderer } from './cookie-renderer.js';
 import { LightCamera } from './light-camera.js';
+import { WorldClustersDebug } from '../lighting/world-clusters-debug.js';
 
 /** @typedef {import('../../graphics/graphics-device.js').GraphicsDevice} GraphicsDevice */
 
@@ -1951,6 +1952,9 @@ class ForwardRenderer {
 
                 const objects = layer.instances;
                 const visible = transparent ? objects.visibleTransparent[cameraPass] : objects.visibleOpaque[cameraPass];
+
+                // add debug mesh instances to visible list
+                this.scene.immediate.onPreRenderLayer(layer, visible, transparent);
 
                 // Set the not very clever global variable which is only useful when there's just one camera
                 this.scene._activeCamera = camera.camera;

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -237,21 +237,21 @@ class Scene extends EventHandler {
     }
 
     // returns the default layer used by the immediate drawing functions
-    getDefaultDrawLayer() {
+    get defaultDrawLayer() {
         return this.layers.getLayerById(LAYERID_IMMEDIATE);
     }
 
-    drawLine(start, end, color = Color.WHITE, depthTest = true, layer = this.getDefaultDrawLayer()) {
+    drawLine(start, end, color = Color.WHITE, depthTest = true, layer = this.defaultDrawLayer) {
         const batch = this.immediate.getBatch(layer, depthTest);
         batch.addLines([start, end], [color, color]);
     }
 
-    drawLines(positions, colors, depthTest = true, layer = this.getDefaultDrawLayer()) {
+    drawLines(positions, colors, depthTest = true, layer = this.defaultDrawLayer) {
         const batch = this.immediate.getBatch(layer, depthTest);
         batch.addLines(positions, colors);
     }
 
-    drawLineArrays(positions, colors, depthTest = true, layer = this.getDefaultDrawLayer()) {
+    drawLineArrays(positions, colors, depthTest = true, layer = this.defaultDrawLayer) {
         const batch = this.immediate.getBatch(layer, depthTest);
         batch.addLinesArrays(positions, colors);
     }

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -9,13 +9,15 @@ import { math } from '../math/math.js';
 
 import { CULLFACE_FRONT, PIXELFORMAT_RGBA32F, TEXTURETYPE_RGBM } from '../graphics/constants.js';
 
-import { BAKE_COLORDIR, FOG_NONE, GAMMA_NONE, GAMMA_SRGBHDR, LAYERID_SKYBOX, LAYERID_WORLD, SHADER_FORWARDHDR, TONEMAP_LINEAR } from './constants.js';
+import { BAKE_COLORDIR, FOG_NONE, GAMMA_NONE, GAMMA_SRGBHDR, LAYERID_IMMEDIATE, LAYERID_SKYBOX, LAYERID_WORLD, SHADER_FORWARDHDR, TONEMAP_LINEAR } from './constants.js';
 import { createBox } from './procedural.js';
 import { GraphNode } from './graph-node.js';
 import { Material } from './materials/material.js';
 import { MeshInstance } from './mesh-instance.js';
 import { Model } from './model.js';
 import { LightingParams } from './lighting/lighting-params.js';
+import { Immediate } from './immediate/immediate.js';
+
 import { EnvLighting } from '../graphics/env-lighting.js';
 import { getApplication } from '../framework/globals.js';
 
@@ -223,12 +225,35 @@ class Scene extends EventHandler {
 
         // backwards compatibility only
         this._models = [];
+
+        // immediate rendering
+        this.immediate = new Immediate(this.device);
     }
 
     destroy() {
         this._resetSkyboxModel();
         this.root = null;
         this.off();
+    }
+
+    // returns the default layer used by the immediate drawing functions
+    getDefaultDrawLayer() {
+        return this.layers.getLayerById(LAYERID_IMMEDIATE);
+    }
+
+    drawLine(start, end, color = Color.WHITE, depthTest = true, layer = this.getDefaultDrawLayer()) {
+        const batch = this.immediate.getBatch(layer, depthTest);
+        batch.addLines([start, end], [color, color]);
+    }
+
+    drawLines(positions, colors, depthTest = true, layer = this.getDefaultDrawLayer()) {
+        const batch = this.immediate.getBatch(layer, depthTest);
+        batch.addLines(positions, colors);
+    }
+
+    drawLineArrays(positions, colors, depthTest = true, layer = this.getDefaultDrawLayer()) {
+        const batch = this.immediate.getBatch(layer, depthTest);
+        batch.addLinesArrays(positions, colors);
     }
 
     /**


### PR DESCRIPTION
- ownership of the instance of Immediate has been moved from the Application to the Scene - which allows debug rendering functionality to be used internally by the engine on the Scene level, not only on the Framework level.
- this does not change any functionality nor public API
- changed the internal implementation if debug rendering - it no longer adds mesh instances (for both debug lines and debug meshes) to layers, which triggers layer composition update, but directly injects them to a visible lists after the culling. This also allows those to be submitted for rendering from inside the frame, after the culling.
- new private Material.transparent property to speed up layercomposition update (it only needs true / false, instead of a blend mode)