### PR TITLE
Remove and repair some eslint directives

### DIFF
--- a/src/framework/components/script/component.js
+++ b/src/framework/components/script/component.js
@@ -15,8 +15,6 @@ import { ScriptType } from '../../../script/script-type.js';
  * Script Types defined in JavaScript files to be executed with access to the Entity. For more
  * details on scripting see [Scripting](https://developer.playcanvas.com/user-manual/scripting/).
  *
- * @property {ScriptType[]} scripts An array of all script instances attached to an entity. This
- * array is read-only and should not be modified by developer.
  * @augments Component
  * @component
  */
@@ -394,13 +392,14 @@ class ScriptComponent extends Component {
     }
 
     /**
-     * @private
-     * @function
-     * @description Inserts script instance into the scripts array at the specified index. Also inserts the script
-     * into the update list if it has an update method and the post update list if it has a postUpdate method.
+     * Inserts script instance into the scripts array at the specified index. Also inserts the
+     * script into the update list if it has an update method and the post update list if it has a
+     * postUpdate method.
+     *
      * @param {object} scriptInstance - The script instance.
-     * @param {number} index - The index where to insert the script at. If -1 then append it at the end.
+     * @param {number} index - The index where to insert the script at. If -1, append it at the end.
      * @param {number} scriptsLength - The length of the scripts array.
+     * @private
      */
     _insertScriptInstance(scriptInstance, index, scriptsLength) {
         if (index === -1) {
@@ -494,11 +493,9 @@ class ScriptComponent extends Component {
         }
     }
 
-    /* eslint-disable jsdoc/no-undefined-types */
     /**
-     * @function
-     * @name ScriptComponent#has
-     * @description Detect if script is attached to an entity.
+     * Detect if script is attached to an entity.
+     *
      * @param {string|Class<ScriptType>} nameOrType - The name or type of {@link ScriptType}.
      * @returns {boolean} If script is attached to an entity.
      * @example
@@ -506,7 +503,6 @@ class ScriptComponent extends Component {
      *     // entity has script
      * }
      */
-    /* eslint-enable jsdoc/no-undefined-types */
     has(nameOrType) {
         if (typeof nameOrType === 'string') {
             return !!this._scriptsIndex[nameOrType];
@@ -520,17 +516,15 @@ class ScriptComponent extends Component {
         return scriptInstance instanceof scriptType; // will return false if scriptInstance undefined
     }
 
-    /* eslint-disable jsdoc/no-undefined-types */
     /**
-     * @function
-     * @name ScriptComponent#get
-     * @description Get a script instance (if attached).
+     * Get a script instance (if attached).
+     *
      * @param {string|Class<ScriptType>} nameOrType - The name or type of {@link ScriptType}.
-     * @returns {ScriptType|null} If script is attached, the instance is returned. Otherwise null is returned.
+     * @returns {ScriptType|null} If script is attached, the instance is returned. Otherwise null
+     * is returned.
      * @example
      * var controller = entity.script.get('playerController');
      */
-    /* eslint-enable jsdoc/no-undefined-types */
     get(nameOrType) {
         if (typeof nameOrType === 'string') {
             const data = this._scriptsIndex[nameOrType];
@@ -545,19 +539,21 @@ class ScriptComponent extends Component {
         return scriptInstance instanceof scriptType ? scriptInstance : null;
     }
 
-    /* eslint-disable jsdoc/no-undefined-types */
     /**
-     * @function
-     * @name ScriptComponent#create
-     * @description Create a script instance and attach to an entity script component.
+     * Create a script instance and attach to an entity script component.
+     *
      * @param {string|Class<ScriptType>} nameOrType - The name or type of {@link ScriptType}.
      * @param {object} [args] - Object with arguments for a script.
-     * @param {boolean} [args.enabled] - If script instance is enabled after creation. Defaults to true.
-     * @param {object} [args.attributes] - Object with values for attributes (if any), where key is name of an attribute.
-     * @param {boolean} [args.preloading] - If script instance is created during preload. If true, script and attributes must be initialized manually. Defaults to false.
-     * @param {number} [args.ind] - The index where to insert the script instance at. Defaults to -1, which means append it at the end.
-     * @returns {ScriptType} Returns an instance of a {@link ScriptType} if successfully attached to an entity,
-     * or null if it failed because a script with a same name has already been added
+     * @param {boolean} [args.enabled] - If script instance is enabled after creation. Defaults to
+     * true.
+     * @param {object} [args.attributes] - Object with values for attributes (if any), where key is
+     * name of an attribute.
+     * @param {boolean} [args.preloading] - If script instance is created during preload. If true,
+     * script and attributes must be initialized manually. Defaults to false.
+     * @param {number} [args.ind] - The index where to insert the script instance at. Defaults to
+     * -1, which means append it at the end.
+     * @returns {ScriptType} Returns an instance of a {@link ScriptType} if successfully attached
+     * to an entity, or null if it failed because a script with a same name has already been added
      * or if the {@link ScriptType} cannot be found by name in the {@link ScriptRegistry}.
      * @example
      * entity.script.create('playerController', {
@@ -566,7 +562,6 @@ class ScriptComponent extends Component {
      *     }
      * });
      */
-    /* eslint-enable jsdoc/no-undefined-types */
     create(nameOrType, args = {}) {
         const self = this;
 
@@ -647,17 +642,14 @@ class ScriptComponent extends Component {
         return null;
     }
 
-    /* eslint-disable jsdoc/no-undefined-types */
     /**
-     * @function
-     * @name ScriptComponent#destroy
-     * @description Destroy the script instance that is attached to an entity.
+     * Destroy the script instance that is attached to an entity.
+     *
      * @param {string|Class<ScriptType>} nameOrType - The name or type of {@link ScriptType}.
      * @returns {boolean} If it was successfully destroyed.
      * @example
      * entity.script.destroy('playerController');
      */
-    /* eslint-enable jsdoc/no-undefined-types */
     destroy(nameOrType) {
         let scriptName = nameOrType;
         let scriptType = nameOrType;
@@ -706,16 +698,13 @@ class ScriptComponent extends Component {
         return true;
     }
 
-    /* eslint-disable jsdoc/no-undefined-types */
     /**
-     * @private
-     * @function
-     * @name ScriptComponent#swap
-     * @description Swap the script instance.
+     * Swap the script instance.
+     *
      * @param {string|Class<ScriptType>} nameOrType - The name or type of {@link ScriptType}.
      * @returns {boolean} If it was successfully swapped.
+     * @private
      */
-    /* eslint-enable jsdoc/no-undefined-types */
     swap(nameOrType) {
         let scriptName = nameOrType;
         let scriptType = nameOrType;
@@ -776,15 +765,16 @@ class ScriptComponent extends Component {
     }
 
     /**
-     * @function
+     * When an entity is cloned and it has entity script attributes that point to other entities in
+     * the same subtree that is cloned, then we want the new script attributes to point at the
+     * cloned entities. This method remaps the script attributes for this entity and it assumes
+     * that this entity is the result of the clone operation.
+     *
+     * @param {ScriptComponent} oldScriptComponent - The source script component that belongs to
+     * the entity that was being cloned.
+     * @param {object} duplicatedIdsMap - A dictionary with guid-entity values that contains the
+     * entities that were cloned.
      * @private
-     * @name ScriptComponent#resolveDuplicatedEntityReferenceProperties
-     * @description When an entity is cloned and it has entity script attributes that point
-     * to other entities in the same subtree that is cloned, then we want the new script attributes to point
-     * at the cloned entities. This method remaps the script attributes for this entity and it assumes that this
-     * entity is the result of the clone operation.
-     * @param {ScriptComponent} oldScriptComponent - The source script component that belongs to the entity that was being cloned.
-     * @param {object} duplicatedIdsMap - A dictionary with guid-entity values that contains the entities that were cloned.
      */
     resolveDuplicatedEntityReferenceProperties(oldScriptComponent, duplicatedIdsMap) {
         const newScriptComponent = this.entity.script;
@@ -878,19 +868,15 @@ class ScriptComponent extends Component {
         }
     }
 
-
-    /* eslint-disable jsdoc/no-undefined-types */
     /**
-     * @function
-     * @name ScriptComponent#move
-     * @description Move script instance to different position to alter update order of scripts within entity.
+     * Move script instance to different position to alter update order of scripts within entity.
+     *
      * @param {string|Class<ScriptType>} nameOrType - The name or type of {@link ScriptType}.
      * @param {number} ind - New position index.
      * @returns {boolean} If it was successfully moved.
      * @example
      * entity.script.move('playerController', 0);
      */
-    /* eslint-enable jsdoc/no-undefined-types */
     move(nameOrType, ind) {
         const len = this._scripts.length;
         if (ind >= len || ind < 0)
@@ -942,6 +928,12 @@ class ScriptComponent extends Component {
         this.fire('set', 'enabled', oldValue, value);
     }
 
+    /**
+     * An array of all script instances attached to an entity. This array is read-only and should
+     * not be modified by developer.
+     *
+     * @type {ScriptType[]}
+     */
     get scripts() {
         return this._scripts;
     }

--- a/src/resources/handler.js
+++ b/src/resources/handler.js
@@ -32,6 +32,7 @@ class ResourceHandler {
         throw new Error('not implemented');
     }
 
+    /* eslint-disable jsdoc/require-returns-check */
     /**
      * @function
      * @name ResourceHandler#open
@@ -41,7 +42,6 @@ class ResourceHandler {
      * @param {Asset} [asset] - Optional asset that is passed by ResourceLoader.
      * @returns {*} The parsed resource data.
      */
-    /* eslint-disable jsdoc/require-returns-check */
     open(url, data, asset) {
         throw new Error('not implemented');
     }

--- a/src/resources/texture.js
+++ b/src/resources/texture.js
@@ -51,6 +51,7 @@ const JSON_TEXTURE_TYPE = {
  * and opening of texture assets.
  */
 class TextureParser {
+    /* eslint-disable jsdoc/require-returns-check */
     /**
      * @function
      * @name TextureParser#load
@@ -62,11 +63,9 @@ class TextureParser {
      * @param {resourceHandlerCallback} callback - The callback used when the resource is loaded or an error occurs.
      * @param {Asset} [asset] - Optional asset that is passed by ResourceLoader.
      */
-    /* eslint-disable jsdoc/require-returns-check */
     load(url, callback, asset) {
         throw new Error('not implemented');
     }
-    /* eslint-enable jsdoc/require-returns-check */
 
     /**
      * @function
@@ -78,7 +77,6 @@ class TextureParser {
      * @param {GraphicsDevice} device - The graphics device.
      * @returns {Texture} The parsed resource data.
      */
-    /* eslint-disable jsdoc/require-returns-check */
     open(url, data, device) {
         throw new Error('not implemented');
     }

--- a/src/script/script-attributes.js
+++ b/src/script/script-attributes.js
@@ -158,7 +158,6 @@ function rawToValue(app, args, value, old) {
  * created automatically by each {@link ScriptType}.
  */
 class ScriptAttributes {
-    /* eslint-disable jsdoc/no-undefined-types */
     /**
      * Create a new ScriptAttributes instance.
      *
@@ -168,7 +167,6 @@ class ScriptAttributes {
         this.scriptType = scriptType;
         this.index = {};
     }
-    /* eslint-enable jsdoc/no-undefined-types */
 
     static reservedNames = new Set([
         'app', 'entity', 'enabled', '_enabled', '_enabledOld', '_destroyed',

--- a/src/script/script-registry.js
+++ b/src/script/script-registry.js
@@ -31,7 +31,6 @@ class ScriptRegistry extends EventHandler {
         this.off();
     }
 
-    /* eslint-disable jsdoc/no-undefined-types */
     /**
      * Add {@link ScriptType} to registry. Note: when {@link createScript} is called, it will add
      * the {@link ScriptType} to the registry automatically. If a script already exists in
@@ -216,7 +215,6 @@ class ScriptRegistry extends EventHandler {
     list() {
         return this._list;
     }
-    /* eslint-enable jsdoc/no-undefined-types */
 }
 
 export { ScriptRegistry };

--- a/src/script/script.js
+++ b/src/script/script.js
@@ -19,8 +19,6 @@ const reservedScriptNames = new Set([
     '_callbacks', 'has', 'get', 'on', 'off', 'fire', 'once', 'hasEvent'
 ]);
 
-/* eslint-disable jsdoc/no-undefined-types */
-
 /**
  * Create and register a new {@link ScriptType}. It returns new class type (constructor function),
  * which is auto-registered to {@link ScriptRegistry} using its name. This is the main interface to
@@ -84,9 +82,7 @@ ScriptAttributes.reservedNames.forEach((value, value2, set) => {
 });
 createScript.reservedAttributes = reservedAttributes;
 
-
 /* eslint-disable jsdoc/check-examples */
-
 /**
  * Register a existing class type as a Script Type to {@link ScriptRegistry}. Useful when defining
  * a ES6 script class that extends {@link ScriptType} (see example).
@@ -149,8 +145,6 @@ function registerScript(script, name, app) {
 
     ScriptHandler._push(script);
 }
-
 /* eslint-enable jsdoc/check-examples */
-/* eslint-enable jsdoc/no-undefined-types */
 
 export { createScript, registerScript };

--- a/src/xr/xr-depth-sensing.js
+++ b/src/xr/xr-depth-sensing.js
@@ -349,10 +349,10 @@ class XrDepthSensing extends EventHandler {
      *     gl_FragColor = vec4(depth, depth, depth, 1.0);
      * }
      */
-    /* eslint-enable jsdoc/check-examples */
     get texture() {
         return this._texture;
     }
+    /* eslint-enable jsdoc/check-examples */
 
     /**
      * 4x4 matrix that should be used to transform depth texture UVs to normalized UVs in a shader.


### PR DESCRIPTION
Fixes all cases where ESLint directive comment would sit between a JSDoc block and a function/property definition. This can break the Typescript declarations since the compiler is unable to match the comment to the code.

Also migrates the script component to the ES6 JSDoc format.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
