### PR TITLE
Remove unused component JSDoc tags

### DIFF
--- a/src/framework/components/anim/component.js
+++ b/src/framework/components/anim/component.js
@@ -26,7 +26,6 @@ import { Entity } from "../../entity.js";
  * loaded.
  * @property {boolean} playing Plays or pauses all animations in the component.
  * @augments Component
- * @component
  */
 class AnimComponent extends Component {
     /**

--- a/src/framework/components/animation/component.js
+++ b/src/framework/components/animation/component.js
@@ -26,7 +26,6 @@ import { Component } from '../component.js';
  * @property {Skeleton|null} skeleton Get the skeleton for the current model; unless model is from glTF/glb, then skeleton is null. [read only]
  * @property {object<string, Animation>} animations Get or Set dictionary of animations by name.
  * @augments Component
- * @component
  */
 class AnimationComponent extends Component {
     /**

--- a/src/framework/components/audio-listener/component.js
+++ b/src/framework/components/audio-listener/component.js
@@ -8,7 +8,6 @@ import { Component } from '../component.js';
  * correctly.
  *
  * @augments Component
- * @component
  */
 class AudioListenerComponent extends Component {
     /**

--- a/src/framework/components/audio-source/component.js
+++ b/src/framework/components/audio-source/component.js
@@ -31,7 +31,6 @@ import { Component } from '../component.js';
  * anymore.
  * @property {number} rollOffFactor The factor used in the falloff equation.
  * @augments Component
- * @component
  * @private
  */
 class AudioSourceComponent extends Component {

--- a/src/framework/components/button/component.js
+++ b/src/framework/components/button/component.js
@@ -57,7 +57,6 @@ STATES_TO_SPRITE_FRAME_NAMES[VisualState.INACTIVE] = 'inactiveSpriteFrame';
  * @property {Asset} inactiveSpriteAsset Sprite to be used as the button image when the button is not interactive.
  * @property {number} inactiveSpriteFrame Frame to be used from the inactive sprite.
  * @augments Component
- * @component
  */
 class ButtonComponent extends Component {
     /**

--- a/src/framework/components/camera/component.js
+++ b/src/framework/components/camera/component.js
@@ -152,7 +152,6 @@ const properties = [
  * @property {Function} onPreRender Custom function that is called before the camera renders the scene.
  * @property {Function} onPostRender Custom function that is called after the camera renders the scene.
  * @augments Component
- * @component
  */
 class CameraComponent extends Component {
     /**

--- a/src/framework/components/collision/component.js
+++ b/src/framework/components/collision/component.js
@@ -49,7 +49,6 @@ import { Component } from '../component.js';
  * @property {Model} model The model that is added to the scene graph for the mesh collision
  * volume.
  * @augments Component
- * @component
  */
 class CollisionComponent extends Component {
     /**

--- a/src/framework/components/element/component.js
+++ b/src/framework/components/element/component.js
@@ -232,7 +232,6 @@ const matD = new Mat4();
  * @property {boolean} mask Switch Image Element into a mask. Masks do not render into the scene,
  * but instead limit child elements to only be rendered where this element is rendered.
  * @augments Component
- * @component
  */
 class ElementComponent extends Component {
     /**

--- a/src/framework/components/joint/component.js
+++ b/src/framework/components/joint/component.js
@@ -29,7 +29,6 @@ const properties = [
  * The JointComponent adds a physics joint constraint linking two rigid bodies.
  *
  * @augments Component
- * @component
  * @private
  */
 class JointComponent extends Component {

--- a/src/framework/components/layout-child/component.js
+++ b/src/framework/components/layout-child/component.js
@@ -20,7 +20,6 @@ import { Component } from '../component.js';
  * @property {boolean} excludeFromLayout If set to true, the child will be excluded from all layout
  * calculations.
  * @augments Component
- * @component
  */
 class LayoutChildComponent extends Component {
     /**

--- a/src/framework/components/layout-group/component.js
+++ b/src/framework/components/layout-group/component.js
@@ -74,7 +74,6 @@ function isEnabledAndHasEnabledElement(entity) {
  * {@link LayoutGroupComponent#heightFitting} mode of {@link FITTING_BOTH} will be coerced to
  * {@link FITTING_STRETCH}.
  * @augments Component
- * @component
  */
 class LayoutGroupComponent extends Component {
     /**

--- a/src/framework/components/light/component.js
+++ b/src/framework/components/light/component.js
@@ -151,7 +151,6 @@ const _lightPropsDefault = [];
  * belong. Don't push/pop/splice or modify this array, if you want to change it - set a new one
  * instead.
  * @augments Component
- * @component
  */
 class LightComponent extends Component {
     /**

--- a/src/framework/components/model/component.js
+++ b/src/framework/components/model/component.js
@@ -59,7 +59,6 @@ import { Component } from '../component.js';
  * belong. Don't push/pop/splice or modify this array, if you want to change it - set a new one
  * instead.
  * @augments Component
- * @component
  */
 class ModelComponent extends Component {
     /**

--- a/src/framework/components/particle-system/component.js
+++ b/src/framework/components/particle-system/component.js
@@ -253,7 +253,6 @@ let depthLayer;
  * system should belong. Don't push/pop/splice or modify this array, if you want to change it - set
  * a new one instead.
  * @augments Component
- * @component
  */
 class ParticleSystemComponent extends Component {
     /**

--- a/src/framework/components/render/component.js
+++ b/src/framework/components/render/component.js
@@ -65,7 +65,6 @@ import { EntityReference } from '../../utils/entity-reference.js';
  *
  * Defaults to {@link RENDERSTYLE_SOLID}.
  * @augments Component
- * @component
  */
 class RenderComponent extends Component {
     /**

--- a/src/framework/components/rigid-body/component.js
+++ b/src/framework/components/rigid-body/component.js
@@ -54,7 +54,6 @@ let ammoVec1, ammoVec2, ammoQuat, ammoOrigin;
  * - [Vehicle physics](http://playcanvas.github.io/#physics/vehicle.html)
  *
  * @augments Component
- * @component
  */
 class RigidBodyComponent extends Component {
     /**

--- a/src/framework/components/screen/component.js
+++ b/src/framework/components/screen/component.js
@@ -34,7 +34,6 @@ const _transform = new Mat4();
  * {@link SCALEMODE_BLEND}. If the actual resolution is different then the ScreenComponent will be
  * scaled according to the scaleBlend value.
  * @augments Component
- * @component
  */
 class ScreenComponent extends Component {
     /**

--- a/src/framework/components/script/component.js
+++ b/src/framework/components/script/component.js
@@ -16,7 +16,6 @@ import { ScriptType } from '../../../script/script-type.js';
  * details on scripting see [Scripting](https://developer.playcanvas.com/user-manual/scripting/).
  *
  * @augments Component
- * @component
  */
 class ScriptComponent extends Component {
     /**

--- a/src/framework/components/scroll-view/component.js
+++ b/src/framework/components/scroll-view/component.js
@@ -55,7 +55,6 @@ const _tempScrollValue = new Vec2();
  * @property {Entity} verticalScrollbarEntity The entity to be used as the vertical scrollbar. This
  * entity must have a Scrollbar component.
  * @augments Component
- * @component
  */
 class ScrollViewComponent extends Component {
     /**

--- a/src/framework/components/scrollbar/component.js
+++ b/src/framework/components/scrollbar/component.js
@@ -29,7 +29,6 @@ import { EntityReference } from '../../utils/entity-reference.js';
  * @property {Entity} handleEntity The entity to be used as the scrollbar handle. This entity must
  * have a Scrollbar component.
  * @augments Component
- * @component
  */
 class ScrollbarComponent extends Component {
     /**

--- a/src/framework/components/sound/component.js
+++ b/src/framework/components/sound/component.js
@@ -37,7 +37,6 @@ import { SoundSlot } from './slot.js';
  * @property {object} slots A dictionary that contains the {@link SoundSlot}s managed by this
  * SoundComponent.
  * @augments Component
- * @component
  */
 class SoundComponent extends Component {
     /**

--- a/src/framework/components/sprite/component.js
+++ b/src/framework/components/sprite/component.js
@@ -65,7 +65,6 @@ const PARAM_ATLAS_RECT = 'atlasRect';
  * component will be rendered on top of other components in the same layer. This is not used unless
  * the layer's sort order is set to {@link SORTMODE_MANUAL}.
  * @augments Component
- * @component
  */
 class SpriteComponent extends Component {
     /**

--- a/src/framework/components/zone/component.js
+++ b/src/framework/components/zone/component.js
@@ -11,7 +11,6 @@ import { Component } from '../component.js';
  *
  * @property {Vec3} size The size of the axis-aligned box of this ZoneComponent.
  * @augments Component
- * @component
  * @private
  */
 class ZoneComponent extends Component {


### PR DESCRIPTION
Long ago, the custom `@component` tag was added to the Engine's JSDocs to identify the various components available in the entity component system. At one time, the JSDoc template used to list components separately. But now, the `@component` tag is unused. So this PR removes the tag completely.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
