### PR TITLE
Make components on Entity class visible to TS Compiler

### DIFF
--- a/src/framework/components/camera/component.js
+++ b/src/framework/components/camera/component.js
@@ -8,6 +8,8 @@ import { PostEffectQueue } from './post-effect-queue.js';
 /** @typedef {import('../../../graphics/render-target.js').RenderTarget} RenderTarget */
 /** @typedef {import('../../../math/mat4.js').Mat4} Mat4 */
 /** @typedef {import('../../../math/vec3.js').Vec3} Vec3 */
+/** @typedef {import('../../../math/vec4.js').Vec4} Vec4 */
+/** @typedef {import('../../../shape/frustum.js').Frustum} Frustum */
 /** @typedef {import('../../../xr/xr-manager.js').xrErrorCallback} xrErrorCallback */
 /** @typedef {import('../../entity.js').Entity} Entity */
 /** @typedef {import('./system.js').CameraComponentSystem} CameraComponentSystem */
@@ -23,15 +25,12 @@ const properties = [
     { name: 'farClip', readonly: false },
     { name: 'flipFaces', readonly: false },
     { name: 'fov', readonly: false },
-    { name: 'frustum', readonly: true },
     { name: 'frustumCulling', readonly: false },
     { name: 'horizontalFov', readonly: false },
     { name: 'nearClip', readonly: false },
     { name: 'orthoHeight', readonly: false },
     { name: 'projection', readonly: false },
-    { name: 'projectionMatrix', readonly: true },
     { name: 'scissorRect', readonly: false },
-    { name: 'viewMatrix', readonly: true },
     { name: 'vrDisplay', readonly: false }
 ];
 
@@ -91,12 +90,6 @@ const properties = [
  * Defaults to {@link ASPECT_AUTO}.
  * @property {Color} clearColor The color used to clear the canvas to before the camera starts to
  * render. Defaults to [0.75, 0.75, 0.75, 1].
- * @property {boolean} clearColorBuffer If true the camera will clear the color buffer to the color
- * set in clearColor. Defaults to true.
- * @property {boolean} clearDepthBuffer If true the camera will clear the depth buffer. Defaults to
- * true.
- * @property {boolean} clearStencilBuffer If true the camera will clear the stencil buffer.
- * Defaults to true.
  * @property {number} farClip The distance from the camera after which no rendering will take
  * place. Defaults to 1000.
  * @property {number} fov The field of view of the camera in degrees. Usually this is the Y-axis
@@ -108,16 +101,8 @@ const properties = [
  * place. Defaults to 0.1.
  * @property {number} orthoHeight The half-height of the orthographic view window (in the Y-axis).
  * Used for {@link PROJECTION_ORTHOGRAPHIC} cameras only. Defaults to 10.
- * @property {number} priority Controls the order in which cameras are rendered. Cameras with
- * smaller values for priority are rendered first. Defaults to 0.
- * @property {RenderTarget} renderTarget Render target to which rendering of the cameras is
- * performed. If not set, it will render simply to the screen.
- * @property {Vec4} rect Controls where on the screen the camera will be rendered in normalized
- * screen coordinates. Defaults to [0, 0, 1, 1].
  * @property {Vec4} scissorRect Clips all pixels which are not in the rectangle. The order of the
  * values is [x, y, width, height]. Defaults to [0, 0, 1, 1].
- * @property {PostEffectQueue} postEffects The post effects queue for this camera. Use this to add
- * or remove post effects from the camera.
  * @property {boolean} frustumCulling Controls the culling of mesh instances against the camera
  * frustum, i.e. if objects outside of camera should be omitted from rendering. If false, all mesh
  * instances in the scene are rendered by the camera, regardless of visibility. Defaults to false.
@@ -141,19 +126,31 @@ const properties = [
  * both front and back faces will be rendered. Defaults to true.
  * @property {boolean} flipFaces If true the camera will invert front and back faces. Can be useful
  * for reflection rendering. Defaults to false.
- * @property {number[]} layers An array of layer IDs ({@link Layer#id}) to which this camera should
- * belong. Don't push/pop/splice or modify this array, if you want to change it, set a new one
- * instead. Defaults to [LAYERID_WORLD, LAYERID_DEPTH, LAYERID_SKYBOX, LAYERID_UI,
- * LAYERID_IMMEDIATE].
- * @property {number} disablePostEffectsLayer Layer ID of a layer on which the postprocessing of
- * the camera stops being applied to. Defaults to LAYERID_UI, which causes post processing to not
- * be applied to UI layer and any following layers for the camera. Set to undefined for
- * post-processing to be applied to all layers of the camera.
- * @property {Function} onPreRender Custom function that is called before the camera renders the scene.
- * @property {Function} onPostRender Custom function that is called after the camera renders the scene.
  * @augments Component
  */
 class CameraComponent extends Component {
+    /**
+     * Custom function that is called when postprocessing should execute.
+     *
+     * @type {Function}
+     * @private
+     */
+    onPostprocessing = null;
+
+    /**
+     * Custom function that is called before the camera renders the scene.
+     *
+     * @type {Function}
+     */
+    onPreRender = null;
+
+    /**
+     * Custom function that is called after the camera renders the scene.
+     *
+     * @type {Function}
+     */
+    onPostRender = null;
+
     /**
      * Create a new CameraComponent instance.
      *
@@ -168,38 +165,12 @@ class CameraComponent extends Component {
 
         this._priority = 0;
 
-        // event called when postprocessing should execute
-        this.onPostprocessing = null;
-
-        // events called during the frame before and after the camera renders
-        this.onPreRender = null;
-        this.onPostRender = null;
-
         // layer id at which the postprocessing stops for the camera
         this._disablePostEffectsLayer = LAYERID_UI;
 
         // postprocessing management
         this._postEffects = new PostEffectQueue(system.app, this);
     }
-
-    /**
-     * @readonly
-     * @name CameraComponent#frustum
-     * @type {Frustum}
-     * @description Queries the camera's frustum shape.
-     */
-    /**
-     * @readonly
-     * @name CameraComponent#projectionMatrix
-     * @type {Mat4}
-     * @description Queries the camera's projection matrix.
-     */
-    /**
-     * @readonly
-     * @name CameraComponent#viewMatrix
-     * @type {Mat4}
-     * @description Queries the camera's view matrix.
-     */
 
     /**
      * Queries the camera component's underlying Camera instance.
@@ -211,12 +182,56 @@ class CameraComponent extends Component {
         return this._camera;
     }
 
-    dirtyLayerCompositionCameras() {
-        // layer composition needs to update order
-        const layerComp = this.system.app.scene.layers;
-        layerComp._dirtyCameras = true;
+    /**
+     * If true the camera will clear the color buffer to the color set in clearColor. Defaults to true.
+     *
+     * @type {boolean}
+     */
+    get clearColorBuffer() {
+        return this._camera.clearColorBuffer;
     }
 
+    set clearColorBuffer(value) {
+        this._camera.clearColorBuffer = value;
+        this.dirtyLayerCompositionCameras();
+    }
+
+    /**
+     * If true the camera will clear the depth buffer. Defaults to true.
+     *
+     * @type {boolean}
+     */
+    get clearDepthBuffer() {
+        return this._camera.clearDepthBuffer;
+    }
+
+    set clearDepthBuffer(value) {
+        this._camera.clearDepthBuffer = value;
+        this.dirtyLayerCompositionCameras();
+    }
+
+    /**
+     * If true the camera will clear the stencil buffer. Defaults to true.
+     *
+     * @type {boolean}
+     */
+    get clearStencilBuffer() {
+        return this._camera.clearStencilBuffer;
+    }
+
+    set clearStencilBuffer(value) {
+        this._camera.clearStencilBuffer = value;
+        this.dirtyLayerCompositionCameras();
+    }
+
+    /**
+     * Layer ID of a layer on which the postprocessing of the camera stops being applied to.
+     * Defaults to LAYERID_UI, which causes post processing to not be applied to UI layer and any
+     * following layers for the camera. Set to undefined for post-processing to be applied to all
+     * layers of the camera.
+     *
+     * @type {number}
+     */
     get disablePostEffectsLayer() {
         return this._disablePostEffectsLayer;
     }
@@ -226,10 +241,22 @@ class CameraComponent extends Component {
         this.dirtyLayerCompositionCameras();
     }
 
-    get postEffectsEnabled() {
-        return this._postEffects.enabled;
+    /**
+     * Queries the camera's frustum shape.
+     *
+     * @type {Frustum}
+     */
+    get frustum() {
+        return this._camera.frustum;
     }
 
+    /**
+     * An array of layer IDs ({@link Layer#id}) to which this camera should belong. Don't push,
+     * pop, splice or modify this array, if you want to change it, set a new one instead. Defaults
+     * to [LAYERID_WORLD, LAYERID_DEPTH, LAYERID_SKYBOX, LAYERID_UI, LAYERID_IMMEDIATE].
+     *
+     * @type {number[]}
+     */
     get layers() {
         return this._camera.layers;
     }
@@ -253,10 +280,25 @@ class CameraComponent extends Component {
         }
     }
 
+    /**
+     * The post effects queue for this camera. Use this to add or remove post effects from the camera.
+     *
+     * @type {PostEffectQueue}
+     */
     get postEffects() {
         return this._postEffects;
     }
 
+    get postEffectsEnabled() {
+        return this._postEffects.enabled;
+    }
+
+    /**
+     * Controls the order in which cameras are rendered. Cameras with smaller values for priority
+     * are rendered first. Defaults to 0.
+     *
+     * @type {number}
+     */
     get priority() {
         return this._priority;
     }
@@ -266,6 +308,21 @@ class CameraComponent extends Component {
         this.dirtyLayerCompositionCameras();
     }
 
+    /**
+     * Queries the camera's projection matrix.
+     *
+     * @type {Mat4}
+     */
+    get projectionMatrix() {
+        return this._camera.projectionMatrix;
+    }
+
+    /**
+     * Controls where on the screen the camera will be rendered in normalized screen coordinates.
+     * Defaults to [0, 0, 1, 1].
+     *
+     * @type {Vec4}
+     */
     get rect() {
         return this._camera.rect;
     }
@@ -275,33 +332,12 @@ class CameraComponent extends Component {
         this.fire('set:rect', this._camera.rect);
     }
 
-    get clearColorBuffer() {
-        return this._camera.clearColorBuffer;
-    }
-
-    set clearColorBuffer(value) {
-        this._camera.clearColorBuffer = value;
-        this.dirtyLayerCompositionCameras();
-    }
-
-    get clearDepthBuffer() {
-        return this._camera.clearDepthBuffer;
-    }
-
-    set clearDepthBuffer(value) {
-        this._camera.clearDepthBuffer = value;
-        this.dirtyLayerCompositionCameras();
-    }
-
-    get clearStencilBuffer() {
-        return this._camera.clearStencilBuffer;
-    }
-
-    set clearStencilBuffer(value) {
-        this._camera.clearStencilBuffer = value;
-        this.dirtyLayerCompositionCameras();
-    }
-
+    /**
+     * Render target to which rendering of the cameras is performed. If not set, it will render
+     * simply to the screen.
+     *
+     * @type {RenderTarget}
+     */
     get renderTarget() {
         return this._camera.renderTarget;
     }
@@ -309,6 +345,21 @@ class CameraComponent extends Component {
     set renderTarget(value) {
         this._camera.renderTarget = value;
         this.dirtyLayerCompositionCameras();
+    }
+
+    /**
+     * Queries the camera's view matrix.
+     *
+     * @type {Mat4}
+     */
+    get viewMatrix() {
+        return this._camera.viewMatrix;
+    }
+
+    dirtyLayerCompositionCameras() {
+        // layer composition needs to update order
+        const layerComp = this.system.app.scene.layers;
+        layerComp._dirtyCameras = true;
     }
 
     /**

--- a/src/framework/components/system.js
+++ b/src/framework/components/system.js
@@ -74,10 +74,14 @@ class ComponentSystem extends EventHandler {
     removeComponent(entity) {
         const record = this.store[entity.getGuid()];
         const component = entity.c[this.id];
+
         this.fire('beforeremove', entity, component);
+
         delete this.store[entity.getGuid()];
-        delete entity[this.id];
+
+        entity[this.id] = undefined;
         delete entity.c[this.id];
+
         this.fire('remove', entity, record.data);
     }
 

--- a/src/framework/entity.js
+++ b/src/framework/entity.js
@@ -6,6 +6,26 @@ import { GraphNode } from '../scene/graph-node.js';
 import { Application } from './application.js';
 
 /** @typedef {import('./components/component.js').Component} Component */
+/** @typedef {import('./components/anim/component.js').AnimComponent} AnimComponent */
+/** @typedef {import('./components/animation/component.js').AnimationComponent} AnimationComponent */
+/** @typedef {import('./components/audio-listener/component.js').AudioListenerComponent} AudioListenerComponent */
+/** @typedef {import('./components/button/component.js').ButtonComponent} ButtonComponent */
+/** @typedef {import('./components/camera/component.js').CameraComponent} CameraComponent */
+/** @typedef {import('./components/collision/component.js').CollisionComponent} CollisionComponent */
+/** @typedef {import('./components/element/component.js').ElementComponent} ElementComponent */
+/** @typedef {import('./components/layout-child/component.js').LayoutChildComponent} LayoutChildComponent */
+/** @typedef {import('./components/layout-group/component.js').LayoutGroupComponent} LayoutGroupComponent */
+/** @typedef {import('./components/light/component.js').LightComponent} LightComponent */
+/** @typedef {import('./components/model/component.js').ModelComponent} ModelComponent */
+/** @typedef {import('./components/particle-system/component.js').ParticleSystemComponent} ParticleSystemComponent */
+/** @typedef {import('./components/render/component.js').RenderComponent} RenderComponent */
+/** @typedef {import('./components/rigid-body/component.js').RigidBodyComponent} RigidBodyComponent */
+/** @typedef {import('./components/screen/component.js').ScreenComponent} ScreenComponent */
+/** @typedef {import('./components/script/component.js').ScriptComponent} ScriptComponent */
+/** @typedef {import('./components/scrollbar/component.js').ScrollbarComponent} ScrollbarComponent */
+/** @typedef {import('./components/scroll-view/component.js').ScrollViewComponent} ScrollViewComponent */
+/** @typedef {import('./components/sound/component.js').SoundComponent} SoundComponent */
+/** @typedef {import('./components/sprite/component.js').SpriteComponent} SpriteComponent */
 
 /**
  * The Entity is the core primitive of a PlayCanvas game. Generally speaking an object in your game
@@ -20,29 +40,149 @@ import { Application } from './application.js';
  * Entity and are attached (e.g. `this.entity.model`) ComponentSystems allow access to all Entities
  * and Components and are attached to the {@link Application}.
  *
- * @property {AnimComponent} [anim] Gets the {@link AnimComponent} attached to this entity. [read only]
- * @property {AnimationComponent} [animation] Gets the {@link AnimationComponent} attached to this entity. [read only]
- * @property {AudioListenerComponent} [audiolistener] Gets the {@link AudioListenerComponent} attached to this entity. [read only]
- * @property {ButtonComponent} [button] Gets the {@link ButtonComponent} attached to this entity. [read only]
- * @property {CameraComponent} [camera] Gets the {@link CameraComponent} attached to this entity. [read only]
- * @property {CollisionComponent} [collision] Gets the {@link CollisionComponent} attached to this entity. [read only]
- * @property {ElementComponent} [element] Gets the {@link ElementComponent} attached to this entity. [read only]
- * @property {LayoutChildComponent} [layoutchild] Gets the {@link LayoutChildComponent} attached to this entity. [read only]
- * @property {LayoutGroupComponent} [layoutgroup] Gets the {@link LayoutGroupComponent} attached to this entity. [read only]
- * @property {LightComponent} [light] Gets the {@link LightComponent} attached to this entity. [read only]
- * @property {ModelComponent} [model] Gets the {@link ModelComponent} attached to this entity. [read only]
- * @property {ParticleSystemComponent} [particlesystem] Gets the {@link ParticleSystemComponent} attached to this entity. [read only]
- * @property {RenderComponent} [render] Gets the {@link RenderComponent} attached to this entity. [read only]
- * @property {RigidBodyComponent} [rigidbody] Gets the {@link RigidBodyComponent} attached to this entity. [read only]
- * @property {ScreenComponent} [screen] Gets the {@link ScreenComponent} attached to this entity. [read only]
- * @property {ScriptComponent} [script] Gets the {@link ScriptComponent} attached to this entity. [read only]
- * @property {ScrollbarComponent} [scrollbar] Gets the {@link ScrollbarComponent} attached to this entity. [read only]
- * @property {ScrollViewComponent} [scrollview] Gets the {@link ScrollViewComponent} attached to this entity. [read only]
- * @property {SoundComponent} [sound] Gets the {@link SoundComponent} attached to this entity. [read only]
- * @property {SpriteComponent} [sprite] Gets the {@link SpriteComponent} attached to this entity. [read only]
  * @augments GraphNode
  */
 class Entity extends GraphNode {
+    /**
+     * Gets the {@link AnimComponent} attached to this entity. [read only]
+     *
+     * @type {AnimComponent}
+     */
+    anim;
+
+    /**
+     * Gets the {@link AnimationComponent} attached to this entity. [read only]
+     *
+     * @type {AnimationComponent}
+     */
+    animation;
+
+    /**
+     * Gets the {@link AudioListenerComponent} attached to this entity. [read only]
+     *
+     * @type {AudioListenerComponent}
+     */
+    audioListener;
+
+    /**
+     * Gets the {@link ButtonComponent} attached to this entity. [read only]
+     *
+     * @type {ButtonComponent}
+     */
+    button;
+
+    /**
+     * Gets the {@link CameraComponent} attached to this entity. [read only]
+     *
+     * @type {CameraComponent}
+     */
+    camera;
+
+    /**
+     * Gets the {@link CollisionComponent} attached to this entity. [read only]
+     *
+     * @type {CollisionComponent}
+     */
+    collision;
+
+    /**
+     * Gets the {@link ElementComponent} attached to this entity. [read only]
+     *
+     * @type {ElementComponent}
+     */
+    element;
+
+    /**
+     * Gets the {@link LayoutChildComponent} attached to this entity. [read only]
+     *
+     * @type {LayoutChildComponent}
+     */
+    layoutchild;
+
+    /**
+     * Gets the {@link LayoutGroupComponent} attached to this entity. [read only]
+     *
+     * @type {LayoutGroupComponent}
+     */
+    layoutgroup;
+
+    /**
+     * Gets the {@link LightComponent} attached to this entity. [read only]
+     *
+     * @type {LightComponent}
+     */
+    light;
+
+    /**
+     * Gets the {@link ModelComponent} attached to this entity. [read only]
+     *
+     * @type {ModelComponent}
+     */
+    model;
+
+    /**
+     * Gets the {@link ParticleSystemComponent} attached to this entity. [read only]
+     *
+     * @type {ParticleSystemComponent}
+     */
+    particlesystem;
+
+    /**
+     * Gets the {@link RenderComponent} attached to this entity. [read only]
+     *
+     * @type {RenderComponent}
+     */
+    render;
+
+    /**
+     * Gets the {@link RigidBodyComponent} attached to this entity. [read only]
+     *
+     * @type {RigidBodyComponent}
+     */
+    rigidbody;
+
+    /**
+     * Gets the {@link ScreenComponent} attached to this entity. [read only]
+     *
+     * @type {ScreenComponent}
+     */
+    screen;
+
+    /**
+     * Gets the {@link ScriptComponent} attached to this entity. [read only]
+     *
+     * @type {ScriptComponent}
+     */
+    script;
+
+    /**
+     * Gets the {@link ScrollbarComponent} attached to this entity. [read only]
+     *
+     * @type {ScrollbarComponent}
+     */
+    scrollbar;
+
+    /**
+     * Gets the {@link ScrollViewComponent} attached to this entity. [read only]
+     *
+     * @type {ScrollViewComponent}
+     */
+    scrollview;
+
+    /**
+     * Gets the {@link SoundComponent} attached to this entity. [read only]
+     *
+     * @type {SoundComponent}
+     */
+    sound;
+
+    /**
+     * Gets the {@link SpriteComponent} attached to this entity. [read only]
+     *
+     * @type {SpriteComponent}
+     */
+    sprite;
+
     /**
      * Create a new Entity.
      *


### PR DESCRIPTION
At the moment, the TypeScript compiler `tsc` is unable to discern the components that can be available on an `Entity` instance. So the following generates an error in TS:

```
this.entity.camera.nearClip = 1;
```

This PR ensures the component properties are present and initialized to `undefined` so that the TS compiler takes them into account. So the main difference here is that all component properties will exist now, but will be set to `undefined` if not actually added to the entity. This should not cause any functional changes to any projects, as far as I can tell.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
