### PR TITLE
Ensure setter appears before getter

### DIFF
--- a/extras/mini-stats/mini-stats.js
+++ b/extras/mini-stats/mini-stats.js
@@ -180,32 +180,28 @@ class MiniStats {
         };
     }
 
-    get activeSizeIndex() {
-        return this._activeSizeIndex;
-    }
-
     set activeSizeIndex(value) {
         this._activeSizeIndex = value;
         this.gspacing = this.sizes[value].spacing;
         this.resize(this.sizes[value].width, this.sizes[value].height, this.sizes[value].graphs);
     }
 
-    get opacity() {
-        return this.clr[3];
+    get activeSizeIndex() {
+        return this._activeSizeIndex;
     }
 
     set opacity(value) {
         this.clr[3] = value;
     }
 
+    get opacity() {
+        return this.clr[3];
+    }
+
     get overallHeight() {
         const graphs = this.graphs;
         const spacing = this.gspacing;
         return this.height * graphs.length + spacing * (graphs.length - 1);
-    }
-
-    get enabled() {
-        return this._enabled;
     }
 
     set enabled(value) {
@@ -216,6 +212,10 @@ class MiniStats {
                 this.graphs[i].timer.enabled = value;
             }
         }
+    }
+
+    get enabled() {
+        return this._enabled;
     }
 
     initWordAtlas(device, words, maxWidth, numGraphs) {

--- a/src/anim/controller/anim-controller.js
+++ b/src/anim/controller/anim-controller.js
@@ -83,12 +83,12 @@ class AnimController {
         return this._animEvaluator;
     }
 
-    get activeState() {
-        return this._findState(this._activeStateName);
-    }
-
     set activeState(stateName) {
         this._activeStateName = stateName;
+    }
+
+    get activeState() {
+        return this._findState(this._activeStateName);
     }
 
     get activeStateName() {
@@ -99,12 +99,12 @@ class AnimController {
         return this.activeState.animations;
     }
 
-    get previousState() {
-        return this._findState(this._previousStateName);
-    }
-
     set previousState(stateName) {
         this._previousStateName = stateName;
+    }
+
+    get previousState() {
+        return this._findState(this._previousStateName);
     }
 
     get previousStateName() {
@@ -121,12 +121,12 @@ class AnimController {
         return playable;
     }
 
-    get playing() {
-        return this._playing;
-    }
-
     set playing(value) {
         this._playing = value;
+    }
+
+    get playing() {
+        return this._playing;
     }
 
     get activeStateProgress() {
@@ -147,10 +147,6 @@ class AnimController {
         return maxDuration;
     }
 
-    get activeStateCurrentTime() {
-        return this._timeInState;
-    }
-
     set activeStateCurrentTime(time) {
         this._timeInStateBefore = time;
         this._timeInState = time;
@@ -160,6 +156,10 @@ class AnimController {
                 clip.time = time;
             }
         }
+    }
+
+    get activeStateCurrentTime() {
+        return this._timeInState;
     }
 
     get transitioning() {

--- a/src/anim/controller/anim-node.js
+++ b/src/anim/controller/anim-node.js
@@ -59,12 +59,12 @@ class AnimNode {
         return this._pointLength;
     }
 
-    get weight() {
-        return this._parent ? this._parent.weight * this._weight : this._weight;
-    }
-
     set weight(value) {
         this._weight = value;
+    }
+
+    get weight() {
+        return this._parent ? this._parent.weight * this._weight : this._weight;
     }
 
     get normalizedWeight() {
@@ -81,20 +81,20 @@ class AnimNode {
         return Math.abs(this._speed);
     }
 
-    get weightedSpeed() {
-        return this._weightedSpeed;
-    }
-
     set weightedSpeed(weightedSpeed) {
         this._weightedSpeed = weightedSpeed;
     }
 
-    get animTrack() {
-        return this._animTrack;
+    get weightedSpeed() {
+        return this._weightedSpeed;
     }
 
     set animTrack(value) {
         this._animTrack = value;
+    }
+
+    get animTrack() {
+        return this._animTrack;
     }
 }
 

--- a/src/anim/controller/anim-state.js
+++ b/src/anim/controller/anim-state.js
@@ -94,28 +94,28 @@ class AnimState {
         return this._name;
     }
 
-    get animations() {
-        return this._animationList;
-    }
-
     set animations(value) {
         this._animationList = value;
     }
 
-    get speed() {
-        return this._speed;
+    get animations() {
+        return this._animationList;
     }
 
     set speed(value) {
         this._speed = value;
     }
 
-    get loop() {
-        return this._loop;
+    get speed() {
+        return this._speed;
     }
 
     set loop(value) {
         this._loop = value;
+    }
+
+    get loop() {
+        return this._loop;
     }
 
     get nodeCount() {

--- a/src/anim/controller/anim-transition.js
+++ b/src/anim/controller/anim-transition.js
@@ -48,12 +48,12 @@ class AnimTransition {
         return this._from;
     }
 
-    get to() {
-        return this._to;
-    }
-
     set to(value) {
         this._to = value;
+    }
+
+    get to() {
+        return this._to;
     }
 
     get time() {

--- a/src/anim/evaluator/anim-clip.js
+++ b/src/anim/evaluator/anim-clip.js
@@ -40,12 +40,12 @@ class AnimClip {
         }
     }
 
-    get name() {
-        return this._name;
-    }
-
     set name(name) {
         this._name = name;
+    }
+
+    get name() {
+        return this._name;
     }
 
     get track() {
@@ -56,52 +56,52 @@ class AnimClip {
         return this._snapshot;
     }
 
-    get time() {
-        return this._time;
-    }
-
     set time(time) {
         this._time = time;
     }
 
-    get speed() {
-        return this._speed;
+    get time() {
+        return this._time;
     }
 
     set speed(speed) {
         this._speed = speed;
     }
 
-    get loop() {
-        return this._loop;
+    get speed() {
+        return this._speed;
     }
 
     set loop(loop) {
         this._loop = loop;
     }
 
-    get blendWeight() {
-        return this._blendWeight;
+    get loop() {
+        return this._loop;
     }
 
     set blendWeight(blendWeight) {
         this._blendWeight = blendWeight;
     }
 
-    get blendOrder() {
-        return this._blendOrder;
+    get blendWeight() {
+        return this._blendWeight;
     }
 
     set blendOrder(blendOrder) {
         this._blendOrder = blendOrder;
     }
 
-    get eventCursor() {
-        return this._eventCursor;
+    get blendOrder() {
+        return this._blendOrder;
     }
 
     set eventCursor(value) {
         this._eventCursor = value;
+    }
+
+    get eventCursor() {
+        return this._eventCursor;
     }
 
     activeEventsForFrame(frameStartTime, frameEndTime) {

--- a/src/anim/evaluator/anim-data.js
+++ b/src/anim/evaluator/anim-data.js
@@ -1,8 +1,6 @@
 /**
  * Wraps a set of data used in animation.
  *
- * @property {number} components - The number of components that make up and element.
- * @property {Float32Array|number[]} data - The data.
  * @private
  */
 class AnimData {
@@ -20,10 +18,20 @@ class AnimData {
         this._data = data;
     }
 
+    /**
+     * The number of components that make up an element.
+     *
+     * @type {number}
+     */
     get components() {
         return this._components;
     }
 
+    /**
+     * The data.
+     *
+     * @type {Float32Array|number[]}
+     */
     get data() {
         return this._data;
     }

--- a/src/anim/evaluator/anim-evaluator.js
+++ b/src/anim/evaluator/anim-evaluator.js
@@ -5,7 +5,6 @@ import { AnimTargetValue } from './anim-target-value.js';
 /**
  * AnimEvaluator blends multiple sets of animation clips together.
  *
- * @property {AnimClip[]} clips - the list of animation clips
  * @private
  */
 class AnimEvaluator {
@@ -21,6 +20,16 @@ class AnimEvaluator {
         this._inputs = [];
         this._outputs = [];
         this._targets = {};
+    }
+
+    /**
+     * The list of animation clips.
+     *
+     * @type {AnimClip[]}
+     * @private
+     */
+    get clips() {
+        return this._clips;
     }
 
     static _dot(a, b) {
@@ -106,16 +115,6 @@ class AnimEvaluator {
                 }
             }
         }
-    }
-
-    /**
-     * @private
-     * @name AnimEvaluator#clips
-     * @type {AnimClip[]}
-     * @description The number of clips.
-     */
-    get clips() {
-        return this._clips;
     }
 
     /**

--- a/src/anim/evaluator/anim-track.js
+++ b/src/anim/evaluator/anim-track.js
@@ -49,12 +49,12 @@ class AnimTrack {
         return this._curves;
     }
 
-    get events() {
-        return this._animEvents.events;
-    }
-
     set events(animEvents) {
         this._animEvents = animEvents;
+    }
+
+    get events() {
+        return this._animEvents.events;
     }
 
     // evaluate all track curves at the specified time and store results
@@ -73,7 +73,7 @@ class AnimTrack {
             cache[i].update(time, inputs[i]._data);
         }
 
-        // evalute outputs
+        // evaluate outputs
         for (let i = 0; i < curves.length; ++i) {
             const curve = curves[i];
             const output = outputs[curve._output];

--- a/src/animation/skeleton.js
+++ b/src/animation/skeleton.js
@@ -45,6 +45,10 @@ class Skeleton {
      * @param {GraphNode} graph - The root {@link GraphNode} of the skeleton.
      */
     constructor(graph) {
+        /**
+         * @type {Animation}
+         * @private
+         */
         this._animation = null;
         this._time = 0;
 
@@ -73,13 +77,13 @@ class Skeleton {
      *
      * @type {Animation}
      */
-    get animation() {
-        return this._animation;
-    }
-
     set animation(value) {
         this._animation = value;
         this.currentTime = 0;
+    }
+
+    get animation() {
+        return this._animation;
     }
 
     /**
@@ -88,10 +92,6 @@ class Skeleton {
      *
      * @type {number}
      */
-    get currentTime() {
-        return this._time;
-    }
-
     set currentTime(value) {
         this._time = value;
         const numNodes = this._interpolatedKeys.length;
@@ -103,6 +103,10 @@ class Skeleton {
 
         this.addTime(0);
         this.updateGraph();
+    }
+
+    get currentTime() {
+        return this._time;
     }
 
     /**

--- a/src/asset/asset-localized.js
+++ b/src/asset/asset-localized.js
@@ -16,6 +16,85 @@ class LocalizedAsset extends EventHandler {
         this._localizedAsset = null;
     }
 
+    set defaultAsset(value) {
+        const id = value instanceof Asset ? value.id : value;
+
+        if (this._defaultAsset === id) return;
+
+        if (this._defaultAsset) {
+            this._unbindDefaultAsset();
+        }
+
+        this._defaultAsset = id;
+
+        if (this._defaultAsset) {
+            this._bindDefaultAsset();
+        }
+
+        // reset localized asset
+        this._onSetLocale(this._app.i18n.locale);
+    }
+
+    get defaultAsset() {
+        return this._defaultAsset;
+    }
+
+    set localizedAsset(value) {
+        const id = value instanceof Asset ? value.id : value;
+        if (this._localizedAsset === id) {
+            return;
+        }
+
+        if (this._localizedAsset) {
+            this._app.assets.off('add:' + this._localizedAsset, this._onLocalizedAssetAdd, this);
+            this._unbindLocalizedAsset();
+            this._localizedAsset = null;
+        }
+
+        this._localizedAsset = id;
+
+        if (this._localizedAsset) {
+            const asset = this._app.assets.get(this._localizedAsset);
+            if (!asset) {
+                this._app.assets.once('add:' + this._localizedAsset, this._onLocalizedAssetAdd, this);
+            } else {
+                this._bindLocalizedAsset();
+            }
+        }
+    }
+
+    get localizedAsset() {
+        return this._localizedAsset;
+    }
+
+    set autoLoad(value) {
+        if (this._autoLoad === value) return;
+
+        this._autoLoad = value;
+
+        if (this._autoLoad && this._localizedAsset) {
+            this._unbindLocalizedAsset();
+            this._bindLocalizedAsset();
+        }
+    }
+
+    get autoLoad() {
+        return this._autoLoad;
+    }
+
+    set disableLocalization(value) {
+        if (this._disableLocalization === value) return;
+
+        this._disableLocalization = value;
+
+        // reset localized asset
+        this._onSetLocale(this._app.i18n.locale);
+    }
+
+    get disableLocalization() {
+        return this._disableLocalization;
+    }
+
     _bindDefaultAsset() {
         const asset = this._app.assets.get(this._defaultAsset);
         if (!asset) {
@@ -139,85 +218,6 @@ class LocalizedAsset extends EventHandler {
         this.defaultAsset = null;
         this._app.i18n.off('set:locale', this._onSetLocale, this);
         this.off();
-    }
-
-    get defaultAsset() {
-        return this._defaultAsset;
-    }
-
-    set defaultAsset(value) {
-        const id = value instanceof Asset ? value.id : value;
-
-        if (this._defaultAsset === id) return;
-
-        if (this._defaultAsset) {
-            this._unbindDefaultAsset();
-        }
-
-        this._defaultAsset = id;
-
-        if (this._defaultAsset) {
-            this._bindDefaultAsset();
-        }
-
-        // reset localized asset
-        this._onSetLocale(this._app.i18n.locale);
-    }
-
-    get localizedAsset() {
-        return this._localizedAsset;
-    }
-
-    set localizedAsset(value) {
-        const id = value instanceof Asset ? value.id : value;
-        if (this._localizedAsset === id) {
-            return;
-        }
-
-        if (this._localizedAsset) {
-            this._app.assets.off('add:' + this._localizedAsset, this._onLocalizedAssetAdd, this);
-            this._unbindLocalizedAsset();
-            this._localizedAsset = null;
-        }
-
-        this._localizedAsset = id;
-
-        if (this._localizedAsset) {
-            const asset = this._app.assets.get(this._localizedAsset);
-            if (!asset) {
-                this._app.assets.once('add:' + this._localizedAsset, this._onLocalizedAssetAdd, this);
-            } else {
-                this._bindLocalizedAsset();
-            }
-        }
-    }
-
-    get autoLoad() {
-        return this._autoLoad;
-    }
-
-    set autoLoad(value) {
-        if (this._autoLoad === value) return;
-
-        this._autoLoad = value;
-
-        if (this._autoLoad && this._localizedAsset) {
-            this._unbindLocalizedAsset();
-            this._bindLocalizedAsset();
-        }
-    }
-
-    get disableLocalization() {
-        return this._disableLocalization;
-    }
-
-    set disableLocalization(value) {
-        if (this._disableLocalization === value) return;
-
-        this._disableLocalization = value;
-
-        // reset localized asset
-        this._onSetLocale(this._app.i18n.locale);
     }
 }
 

--- a/src/asset/asset-reference.js
+++ b/src/asset/asset-reference.js
@@ -5,11 +5,6 @@
  * An object that manages the case where an object holds a reference to an asset and needs to be
  * notified when changes occur in the asset. e.g. notifications include load, add and remove
  * events.
- *
- * @property {number} id Get or set the asset id which this references. One of either id or url
- * must be set to initialize an asset reference.
- * @property {string} url Get or set the asset url which this references. One of either id or url
- * must be called to initialize an asset reference.
  */
 class AssetReference {
     /**
@@ -54,6 +49,48 @@ class AssetReference {
         this._onAssetAdd = callbacks.add;
         this._onAssetRemove = callbacks.remove;
         this._onAssetUnload = callbacks.unload;
+    }
+
+    /**
+     * Get or set the asset id which this references. One of either id or url must be set to
+     * initialize an asset reference.
+     *
+     * @type {number}
+     */
+    set id(value) {
+        if (this.url) throw Error("Can't set id and url");
+
+        this._unbind();
+
+        this._id = value;
+        this.asset = this._registry.get(this._id);
+
+        this._bind();
+    }
+
+    get id() {
+        return this._id;
+    }
+
+    /**
+     * Get or set the asset url which this references. One of either id or url must be called to
+     * initialize an asset reference.
+     *
+     * @type {string}
+     */
+    set url(value) {
+        if (this.id) throw Error("Can't set id and url");
+
+        this._unbind();
+
+        this._url = value;
+        this.asset = this._registry.getByUrl(this._url);
+
+        this._bind();
+    }
+
+    get url() {
+        return this._url;
     }
 
     _bind() {
@@ -101,36 +138,6 @@ class AssetReference {
 
     _onUnload(asset) {
         this._onAssetUnload.call(this._scope, this.propertyName, this.parent, asset);
-    }
-
-    get id() {
-        return this._id;
-    }
-
-    set id(value) {
-        if (this.url) throw Error("Can't set id and url");
-
-        this._unbind();
-
-        this._id = value;
-        this.asset = this._registry.get(this._id);
-
-        this._bind();
-    }
-
-    get url() {
-        return this._url;
-    }
-
-    set url(value) {
-        if (this.id) throw Error("Can't set id and url");
-
-        this._unbind();
-
-        this._url = value;
-        this.asset = this._registry.getByUrl(this._url);
-
-        this._bind();
     }
 }
 

--- a/src/asset/asset-registry.js
+++ b/src/asset/asset-registry.js
@@ -32,7 +32,6 @@ import { Asset } from './asset.js';
  * Container for all assets that are available to this application. Note that PlayCanvas scripts
  * are provided with an AssetRegistry instance as `app.assets`.
  *
- * @property {string} prefix A URL prefix that will be added to all asset loading requests.
  * @augments EventHandler
  */
 class AssetRegistry extends EventHandler {
@@ -52,6 +51,11 @@ class AssetRegistry extends EventHandler {
         this._tags = new TagsCache('_id'); // index for looking up by tags
         this._urls = {}; // index for looking up assets by url
 
+        /**
+         * A URL prefix that will be added to all asset loading requests.
+         *
+         * @type {string}
+         */
         this.prefix = null;
     }
 

--- a/src/asset/asset.js
+++ b/src/asset/asset.js
@@ -60,14 +60,14 @@ class Asset extends EventHandler {
      * "template", text", "texture"]
      * @param {object} [file] - Details about the file the asset is made from. At the least must
      * contain the 'url' field. For assets that don't contain file data use null.
-     * @property {string} [file.url] The URL of the resource file that contains the asset data.
-     * @property {string} [file.filename] The filename of the resource file or null if no filename
+     * @param {string} [file.url] - The URL of the resource file that contains the asset data.
+     * @param {string} [file.filename] - The filename of the resource file or null if no filename
      * was set (e.g from using {@link AssetRegistry#loadFromUrl}).
-     * @property {number} [file.size] The size of the resource file or null if no size was set
+     * @param {number} [file.size] - The size of the resource file or null if no size was set
      * (e.g. from using {@link AssetRegistry#loadFromUrl}).
-     * @property {string} [file.hash] The MD5 hash of the resource file data and the Asset data
+     * @param {string} [file.hash] - The MD5 hash of the resource file data and the Asset data
      * field or null if hash was set (e.g from using {@link AssetRegistry#loadFromUrl}).
-     * @property {ArrayBuffer} [file.contents] Optional file contents. This is faster than wrapping
+     * @param {ArrayBuffer} [file.contents] - Optional file contents. This is faster than wrapping
      * the data in a (base64 encoded) blob. Currently only used by container assets.
      * @param {object} [data] - JSON object with additional data about the asset. (e.g. for texture
      * and model assets) or contains the asset data itself (e.g. in the case of materials).

--- a/src/asset/asset.js
+++ b/src/asset/asset.js
@@ -32,34 +32,18 @@ const VARIANT_DEFAULT_PRIORITY = ['pvr', 'dxt', 'etc2', 'etc1', 'basis'];
 
 /**
  * An asset record of a file or data resource that can be loaded by the engine. The asset contains
- * three important fields:
+ * four important fields:
  *
- * - `file`: contains the details of a file (filename, url) which contains the resource data, e.g. an image file for a texture asset.
- * - `data`: contains a JSON blob which contains either the resource data for the asset (e.g. material data) or additional data for the file (e.g. material mappings for a model).
+ * - `file`: contains the details of a file (filename, url) which contains the resource data, e.g.
+ * an image file for a texture asset.
+ * - `data`: contains a JSON blob which contains either the resource data for the asset (e.g.
+ * material data) or additional data for the file (e.g. material mappings for a model).
  * - `options`: contains a JSON blob with handler-specific load options.
- * - `resource`: contains the final resource when it is loaded. (e.g. a {@link StandardMaterial} or a {@link Texture}).
+ * - `resource`: contains the final resource when it is loaded. (e.g. a {@link StandardMaterial} or
+ * a {@link Texture}).
  *
  * See the {@link AssetRegistry} for details on loading resources from assets.
  *
- * @property {string} name The name of the asset
- * @property {number} id The asset id
- * @property {("animation"|"audio"|"binary"|"container"|"cubemap"|"css"|"font"|"json"|"html"|"material"|"model"|"script"|"shader"|"sprite"|"template"|"text"|"texture")} type The type of the asset. One of ["animation", "audio", "binary", "container", "cubemap", "css", "font", "json", "html", "material", "model", "script", "shader", "sprite", "template", "text", "texture"]
- * @property {Tags} tags Interface for tagging. Allows to find assets by tags using {@link AssetRegistry#findByTag} method.
- * @property {object} file The file details or null if no file
- * @property {string} [file.url] The URL of the resource file that contains the asset data
- * @property {string} [file.filename] The filename of the resource file or null if no filename was set (e.g from using {@link AssetRegistry#loadFromUrl})
- * @property {number} [file.size] The size of the resource file or null if no size was set (e.g from using {@link AssetRegistry#loadFromUrl})
- * @property {string} [file.hash] The MD5 hash of the resource file data and the Asset data field or null if hash was set (e.g from using {@link AssetRegistry#loadFromUrl})
- * @property {ArrayBuffer} [file.contents] Optional file contents. This is faster than wrapping the data
- * in a (base64 encoded) blob. Currently only used by container assets.
- * @property {object} [data] Optional JSON data that contains either the complete resource data. (e.g. in the case of a material) or additional data (e.g. in the case of a model it contains mappings from mesh to material)
- * @property {object} [options] - Optional JSON data that contains the asset handler options.
- * @property {object} resource A reference to the resource when the asset is loaded. e.g. a {@link Texture} or a {@link Model}
- * @property {Array} resources A reference to the resources of the asset when it's loaded. An asset can hold more runtime resources than one e.g. cubemaps
- * @property {boolean} preload If true the asset will be loaded during the preload phase of application set up.
- * @property {boolean} loaded True if the asset has finished attempting to load the resource. It is not guaranteed that the resources are available as there could have been a network error.
- * @property {boolean} loading True if the resource is currently being loaded
- * @property {AssetRegistry} registry The asset registry that this Asset belongs to
  * @augments EventHandler
  */
 class Asset extends EventHandler {
@@ -74,9 +58,21 @@ class Asset extends EventHandler {
      * "template", text", "texture"]
      * @param {object} [file] - Details about the file the asset is made from. At the least must
      * contain the 'url' field. For assets that don't contain file data use null.
-     * @param {object} [data] - JSON object with additional data about the asset. (e.g. for texture and model assets) or contains the asset data itself (e.g. in the case of materials)
-     * @param {object} [options] - The asset handler options. For container options see {@link ContainerHandler}
-     * @param {boolean} [options.crossOrigin] - For use with texture resources. For browser-supported image formats only, enable cross origin.
+     * @property {string} [file.url] The URL of the resource file that contains the asset data.
+     * @property {string} [file.filename] The filename of the resource file or null if no filename
+     * was set (e.g from using {@link AssetRegistry#loadFromUrl}).
+     * @property {number} [file.size] The size of the resource file or null if no size was set
+     * (e.g. from using {@link AssetRegistry#loadFromUrl}).
+     * @property {string} [file.hash] The MD5 hash of the resource file data and the Asset data
+     * field or null if hash was set (e.g from using {@link AssetRegistry#loadFromUrl}).
+     * @property {ArrayBuffer} [file.contents] Optional file contents. This is faster than wrapping
+     * the data in a (base64 encoded) blob. Currently only used by container assets.
+     * @param {object} [data] - JSON object with additional data about the asset. (e.g. for texture
+     * and model assets) or contains the asset data itself (e.g. in the case of materials).
+     * @param {object} [options] - The asset handler options. For container options see
+     * {@link ContainerHandler}.
+     * @param {boolean} [options.crossOrigin] - For use with texture resources. For
+     * browser-supported image formats only, enable cross origin.
      * @example
      * var asset = new pc.Asset("a texture", "texture", {
      *     url: "http://example.com/my/assets/here/texture.png"
@@ -87,13 +83,38 @@ class Asset extends EventHandler {
 
         this._id = assetIdCounter--;
 
+        /**
+         * The name of the asset.
+         *
+         * @type {string}
+         */
         this.name = name || '';
-        this.type = type;
-        this.tags = new Tags(this);
-        this._preload = false;
 
+        /**
+         * The type of the asset. One of ["animation", "audio", "binary", "container", "cubemap",
+         * "css", "font", "json", "html", "material", "model", "script", "shader", "sprite",
+         * "template", "text", "texture"]
+         *
+         * @type {("animation"|"audio"|"binary"|"container"|"cubemap"|"css"|"font"|"json"|"html"|"material"|"model"|"script"|"shader"|"sprite"|"template"|"text"|"texture")}
+         */
+        this.type = type;
+
+        /**
+         * Asset tags. Enables finding of assets by tags using the {@link AssetRegistry#findByTag} method.
+         *
+         * @type {Tags}
+         */
+        this.tags = new Tags(this);
+
+        this._preload = false;
         this._file = null;
         this._data = data || { };
+
+        /**
+         * Optional JSON data that contains the asset handler options.
+         *
+         * @type {object}
+         */
         this.options = options || { };
 
         // This is where the loaded resource(s) will be
@@ -103,13 +124,182 @@ class Asset extends EventHandler {
         // locale to asset id
         this._i18n = {};
 
-        // Is resource loaded
+        /**
+         * True if the asset has finished attempting to load the resource. It is not guaranteed
+         * that the resources are available as there could have been a network error.
+         *
+         * @type {boolean}
+         */
         this.loaded = false;
+
+        /**
+         * True if the resource is currently being loaded.
+         *
+         * @type {boolean}
+         */
         this.loading = false;
 
+        /**
+         * The asset registry that this Asset belongs to.
+         *
+         * @type {AssetRegistry}
+         */
         this.registry = null;
 
         if (file) this.file = file;
+    }
+
+    /**
+     * The asset id.
+     *
+     * @type {number}
+     */
+    set id(value) {
+        this._id = value;
+    }
+
+    get id() {
+        return this._id;
+    }
+
+    /**
+     * The file details or null if no file.
+     *
+     * @type {object}
+     */
+    set file(value) {
+        // if value contains variants, choose the correct variant first
+        if (value && value.variants && ['texture', 'textureatlas', 'bundle'].indexOf(this.type) !== -1) {
+            // search for active variant
+            const app = this.registry?._loader?._app || getApplication();
+            const device = app?.graphicsDevice;
+            if (device) {
+                for (let i = 0, len = VARIANT_DEFAULT_PRIORITY.length; i < len; i++) {
+                    const variant = VARIANT_DEFAULT_PRIORITY[i];
+                    // if the device supports the variant
+                    if (value.variants[variant] && device[VARIANT_SUPPORT[variant]]) {
+                        value = value.variants[variant];
+                        break;
+                    }
+
+                    // if the variant does not exist but the asset is in a bundle
+                    // and the bundle contain assets with this variant then return the default
+                    // file for the asset
+                    if (app.enableBundles) {
+                        const bundles = app.bundles.listBundlesForAsset(this);
+                        if (bundles && bundles.find((b) => {
+                            return b?.file?.variants[variant];
+                        })) {
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        const oldFile = this._file;
+        const newFile = value ? new AssetFile(value.url, value.filename, value.hash, value.size, value.opt, value.contents) : null;
+
+        if (!!newFile !== !!oldFile || (newFile && !newFile.equals(oldFile))) {
+            this._file = newFile;
+            this.fire('change', this, 'file', newFile, oldFile);
+            this.reload();
+        }
+    }
+
+    get file() {
+        return this._file;
+    }
+
+    /**
+     * Optional JSON data that contains either the complete resource data. (e.g. in the case of a
+     * material) or additional data (e.g. in the case of a model it contains mappings from mesh to
+     * material).
+     *
+     * @type {object}
+     */
+    set data(value) {
+        // fire change event when data changes
+        // because the asset might need reloading if that happens
+        const old = this._data;
+        this._data = value;
+        if (value !== old) {
+            this.fire('change', this, 'data', value, old);
+
+            if (this.loaded)
+                this.registry._loader.patch(this, this.registry);
+        }
+    }
+
+    get data() {
+        return this._data;
+    }
+
+    /**
+     * A reference to the resource when the asset is loaded. e.g. a {@link Texture} or a {@link Model}.
+     *
+     * @type {object}
+     */
+    set resource(value) {
+        const _old = this._resources[0];
+        this._resources[0] = value;
+        this.fire('change', this, 'resource', value, _old);
+    }
+
+    get resource() {
+        return this._resources[0];
+    }
+
+    /**
+     * A reference to the resources of the asset when it's loaded. An asset can hold more runtime
+     * resources than one e.g. cubemaps.
+     *
+     * @type {object[]}
+     */
+    set resources(value) {
+        const _old = this._resources;
+        this._resources = value;
+        this.fire('change', this, 'resources', value, _old);
+    }
+
+    get resources() {
+        return this._resources;
+    }
+
+    /**
+     * If true the asset will be loaded during the preload phase of application set up.
+     *
+     * @type {boolean}
+     */
+    set preload(value) {
+        value = !!value;
+        if (this._preload === value)
+            return;
+
+        this._preload = value;
+        if (this._preload && !this.loaded && !this.loading && this.registry)
+            this.registry.load(this);
+    }
+
+    get preload() {
+        return this._preload;
+    }
+
+    set loadFaces(value) {
+        value = !!value;
+        if (!this.hasOwnProperty('_loadFaces') || value !== this._loadFaces) {
+            this._loadFaces = value;
+
+            // the loadFaces property should be part of the asset data block
+            // because changing the flag should result in asset patch being invoked.
+            // here we must invoke it manually instead.
+            if (this.loaded)
+                this.registry._loader.patch(this, this.registry);
+        }
+    }
+
+    get loadFaces() {
+        return this._loadFaces;
     }
 
     /**
@@ -319,126 +509,6 @@ class Asset extends EventHandler {
             if (resource && resource.destroy) {
                 resource.destroy();
             }
-        }
-    }
-
-    get id() {
-        return this._id;
-    }
-
-    set id(value) {
-        this._id = value;
-    }
-
-    get file() {
-        return this._file;
-    }
-
-    set file(value) {
-        // if value contains variants, choose the correct variant first
-        if (value && value.variants && ['texture', 'textureatlas', 'bundle'].indexOf(this.type) !== -1) {
-            // search for active variant
-            const app = this.registry?._loader?._app || getApplication();
-            const device = app?.graphicsDevice;
-            if (device) {
-                for (let i = 0, len = VARIANT_DEFAULT_PRIORITY.length; i < len; i++) {
-                    const variant = VARIANT_DEFAULT_PRIORITY[i];
-                    // if the device supports the variant
-                    if (value.variants[variant] && device[VARIANT_SUPPORT[variant]]) {
-                        value = value.variants[variant];
-                        break;
-                    }
-
-                    // if the variant does not exist but the asset is in a bundle
-                    // and the bundle contain assets with this variant then return the default
-                    // file for the asset
-                    if (app.enableBundles) {
-                        const bundles = app.bundles.listBundlesForAsset(this);
-                        if (bundles && bundles.find((b) => {
-                            return b?.file?.variants[variant];
-                        })) {
-                            break;
-                        }
-                    }
-                }
-            }
-        }
-
-        const oldFile = this._file;
-        const newFile = value ? new AssetFile(value.url, value.filename, value.hash, value.size, value.opt, value.contents) : null;
-
-        if (!!newFile !== !!oldFile || (newFile && !newFile.equals(oldFile))) {
-            this._file = newFile;
-            this.fire('change', this, 'file', newFile, oldFile);
-            this.reload();
-        }
-    }
-
-    get data() {
-        return this._data;
-    }
-
-    set data(value) {
-        // fire change event when data changes
-        // because the asset might need reloading if that happens
-        const old = this._data;
-        this._data = value;
-        if (value !== old) {
-            this.fire('change', this, 'data', value, old);
-
-            if (this.loaded)
-                this.registry._loader.patch(this, this.registry);
-        }
-    }
-
-    get resource() {
-        return this._resources[0];
-    }
-
-    set resource(value) {
-        const _old = this._resources[0];
-        this._resources[0] = value;
-        this.fire('change', this, 'resource', value, _old);
-    }
-
-    get resources() {
-        return this._resources;
-    }
-
-    set resources(value) {
-        const _old = this._resources;
-        this._resources = value;
-        this.fire('change', this, 'resources', value, _old);
-    }
-
-    get preload() {
-        return this._preload;
-    }
-
-    set preload(value) {
-        value = !!value;
-        if (this._preload === value)
-            return;
-
-        this._preload = value;
-        if (this._preload && !this.loaded && !this.loading && this.registry)
-            this.registry.load(this);
-    }
-
-    get loadFaces() {
-        return this._loadFaces;
-    }
-
-    set loadFaces(value) {
-        value = !!value;
-        if (!this.hasOwnProperty('_loadFaces') || value !== this._loadFaces) {
-            this._loadFaces = value;
-
-            // the loadFaces property should be part of the asset data block
-            // because changing the flag should result in asset patch being invoked.
-            // here we must invoke it manually instead.
-            if (this.loaded)
-                this.registry._loader.patch(this, this.registry);
         }
     }
 

--- a/src/asset/asset.js
+++ b/src/asset/asset.js
@@ -10,6 +10,8 @@ import { AssetFile } from './asset-file.js';
 import { getApplication } from '../framework/globals.js';
 import { http } from '../net/http.js';
 
+/** @typedef {import('./asset-registry.js').AssetRegistry} AssetRegistry */
+
 // auto incrementing number for asset ids
 let assetIdCounter = -1;
 

--- a/src/core/event-handler.js
+++ b/src/core/event-handler.js
@@ -40,7 +40,7 @@ class EventHandler {
          * @type {object}
          * @private
          */
-         this._callbackActive = { };
+        this._callbackActive = { };
     }
 
     /**

--- a/src/core/event-handler.js
+++ b/src/core/event-handler.js
@@ -31,14 +31,39 @@ class EventHandler {
      * obj.fire('hello', 'world');
      */
     constructor() {
-        this.initEventHandler();
+        /**
+         * @type {object}
+         * @private
+         */
+        this._callbacks = { };
+        /**
+         * @type {object}
+         * @private
+         */
+         this._callbackActive = { };
     }
 
+    /**
+     * Reinitialize the event handler.
+     *
+     * @private
+     */
     initEventHandler() {
         this._callbacks = { };
         this._callbackActive = { };
     }
 
+    /**
+     * Registers a new event handler.
+     *
+     * @param {string} name - Name of the event to bind the callback to.
+     * @param {handleEventCallback} callback - Function that is called when event is fired. Note
+     * the callback is limited to 8 arguments.
+     * @param {object} [scope] - Object to use as 'this' when the event is fired, defaults to
+     * current this.
+     * @param {boolean} [once=false] - If true, the callback will be unbound after being fired once.
+     * @private
+     */
     _addCallback(name, callback, scope, once = false) {
         if (!name || typeof name !== 'string' || !callback)
             return;

--- a/src/core/sorted-loop-array.js
+++ b/src/core/sorted-loop-array.js
@@ -3,11 +3,6 @@
  * while we loop through it. The class assumes that it holds objects that need to be sorted based
  * on one of their fields.
  *
- * @property {number} loopIndex The current index used to loop through the array. This gets
- * modified if we add or remove elements from the array while looping. See the example to see how
- * to loop through this array.
- * @property {number} length The number of elements in the array.
- * @property {object[]} items The internal array that holds the actual array elements.
  * @private
  */
 class SortedLoopArray {
@@ -29,10 +24,28 @@ class SortedLoopArray {
      * @private
      */
     constructor(args) {
-        this._sortBy = args.sortBy;
+        /**
+         * The internal array that holds the actual array elements.
+         *
+         * @type {object[]}
+         */
         this.items = [];
+        /**
+         * The number of elements in the array.
+         *
+         * @type {number}
+         */
         this.length = 0;
+        /**
+         * The current index used to loop through the array. This gets modified if we add or remove
+         * elements from the array while looping. See the example to see how to loop through this
+         * array.
+         *
+         * @type {number}
+         */
         this.loopIndex = -1;
+
+        this._sortBy = args.sortBy;
         this._sortHandler = this._doSort.bind(this);
     }
 

--- a/src/core/uri.js
+++ b/src/core/uri.js
@@ -61,11 +61,6 @@ const re = /^(([^:\/?#]+):)?(\/\/([^\/?#]*))?([^?#]*)(\?([^#]*))?(#(.*))?/;
 /**
  * A URI object.
  *
- * @property {string} scheme The scheme. (e.g. http).
- * @property {string} authority The authority. (e.g. `www.example.com`).
- * @property {string} path The path. (e.g. /users/example).
- * @property {string} query The query, the section after a ?. (e.g. search=value).
- * @property {string} fragment The fragment, the section after a #.
  * @private
  */
 class URI {
@@ -78,10 +73,40 @@ class URI {
     constructor(uri) {
         const result = uri.match(re);
 
+        /**
+         * The scheme. (e.g. http).
+         *
+         * @type {string}
+         * @private
+         */
         this.scheme = result[2];
+        /**
+         * The authority. (e.g. `www.example.com`).
+         *
+         * @type {string}
+         * @private
+         */
         this.authority = result[4];
+        /**
+         * The path. (e.g. /users/example).
+         *
+         * @type {string}
+         * @private
+         */
         this.path = result[5];
+        /**
+         * The query, the section after a ?. (e.g. search=value).
+         *
+         * @type {string}
+         * @private
+         */
         this.query = result[7];
+        /**
+         * The fragment, the section after a #.
+         *
+         * @type {string}
+         * @private
+         */
         this.fragment = result[9];
     }
 

--- a/src/font/font.js
+++ b/src/font/font.js
@@ -4,9 +4,6 @@ import { FONT_MSDF } from './constants.js';
 
 /**
  * Represents the resource of a font asset.
- *
- * @property {number} intensity The font intensity.
- * @property {Texture[]} textures The font textures.
  */
 class Font {
     /**
@@ -20,19 +17,23 @@ class Font {
 
         this.em = 1;
 
-        // atlas texture
+        /**
+         * The font textures.
+         *
+         * @type {Texture[]}
+         */
         this.textures = textures;
 
-        // intensity
+        /**
+         * The font intensity.
+         *
+         * @type {number}
+         */
         this.intensity = 0.0;
 
         // json data
         this._data = null;
         this.data = data;
-    }
-
-    get data() {
-        return this._data;
     }
 
     set data(value) {
@@ -60,6 +61,10 @@ class Font {
                 }
             }
         }
+    }
+
+    get data() {
+        return this._data;
     }
 }
 

--- a/src/framework/components/anim/component-layer.js
+++ b/src/framework/components/anim/component-layer.js
@@ -28,6 +28,149 @@ class AnimComponentLayer {
     }
 
     /**
+     * Returns the name of the layer.
+     *
+     * @type {string}
+     */
+    get name() {
+        return this._name;
+    }
+
+    /**
+     * Whether this layer is currently playing.
+     *
+     * @type {string}
+     */
+    set playing(value) {
+        this._controller.playing = value;
+    }
+
+    get playing() {
+        return this._controller.playing;
+    }
+
+    /**
+     * Returns true if a state graph has been loaded and all states in the graph have been assigned
+     * animation tracks.
+     *
+     * @type {string}
+     */
+    get playable() {
+        return this._controller.playable;
+    }
+
+    /**
+     * Returns the currently active state name.
+     *
+     * @type {string}
+     */
+    get activeState() {
+        return this._controller.activeStateName;
+    }
+
+    /**
+     * Returns the previously active state name.
+     *
+     * @type {string}
+     */
+    get previousState() {
+        return this._controller.previousStateName;
+    }
+
+    /**
+     * Returns the currently active states progress as a value normalized by the states animation
+     * duration. Looped animations will return values greater than 1.
+     *
+     * @type {number}
+     */
+    get activeStateProgress() {
+        return this._controller.activeStateProgress;
+    }
+
+    /**
+     * Returns the currently active states duration.
+     *
+     * @type {number}
+     */
+    get activeStateDuration() {
+        return this._controller.activeStateDuration;
+    }
+
+    /**
+     * The active states time in seconds.
+     *
+     * @type {number}
+     */
+    set activeStateCurrentTime(time) {
+        this._controller.activeStateCurrentTime = time;
+    }
+
+    get activeStateCurrentTime() {
+        return this._controller.activeStateCurrentTime;
+    }
+
+    /**
+     * Returns whether the anim component layer is currently transitioning between states.
+     *
+     * @type {boolean}
+     */
+    get transitioning() {
+        return this._controller.transitioning;
+    }
+
+    /**
+     * If the anim component layer is currently transitioning between states, returns the progress.
+     * Otherwise returns null.
+     *
+     * @type {number}
+     */
+    get transitionProgress() {
+        if (this.transitioning) {
+            return this._controller.transitionProgress;
+        }
+        return null;
+    }
+
+    /**
+     * Lists all available states in this layers state graph.
+     *
+     * @type {string[]}
+     */
+    get states() {
+        return this._controller.states;
+    }
+
+    /**
+     * The blending weight of this layer. Used when calculating the value of properties that are
+     * animated by more than one layer.
+     *
+     * @type {number}
+     */
+    set weight(value) {
+        this._weight = value;
+        this._component.dirtifyTargets();
+    }
+
+    get weight() {
+        return this._weight;
+    }
+
+    set blendType(value) {
+        if (value !== this._blendType) {
+            this._blendType = value;
+            this._component.rebind();
+        }
+    }
+
+    get blendType() {
+        return this._blendType;
+    }
+
+    get mask() {
+        return this._mask;
+    }
+
+    /**
      * Start playing the animation in the current state.
      *
      * @param {string} [name] - If provided, will begin playing from the start of the state with
@@ -84,10 +227,6 @@ class AnimComponentLayer {
             this._component.rebind();
         }
         this._mask = mask;
-    }
-
-    get mask() {
-        return this._mask;
     }
 
     /**
@@ -152,145 +291,6 @@ class AnimComponentLayer {
             time,
             transitionOffset
         }));
-    }
-
-    /**
-     * Returns the name of the layer.
-     *
-     * @type {string}
-     */
-    get name() {
-        return this._name;
-    }
-
-    /**
-     * Whether this layer is currently playing.
-     *
-     * @type {string}
-     */
-    get playing() {
-        return this._controller.playing;
-    }
-
-    set playing(value) {
-        this._controller.playing = value;
-    }
-
-    /**
-     * Returns true if a state graph has been loaded and all states in the graph have been assigned
-     * animation tracks.
-     *
-     * @type {string}
-     */
-    get playable() {
-        return this._controller.playable;
-    }
-
-    /**
-     * Returns the currently active state name.
-     *
-     * @type {string}
-     */
-    get activeState() {
-        return this._controller.activeStateName;
-    }
-
-    /**
-     * Returns the previously active state name.
-     *
-     * @type {string}
-     */
-    get previousState() {
-        return this._controller.previousStateName;
-    }
-
-    /**
-     * Returns the currently active states progress as a value normalized by the states animation
-     * duration. Looped animations will return values greater than 1.
-     *
-     * @type {number}
-     */
-    get activeStateProgress() {
-        return this._controller.activeStateProgress;
-    }
-
-    /**
-     * Returns the currently active states duration.
-     *
-     * @type {number}
-     */
-    get activeStateDuration() {
-        return this._controller.activeStateDuration;
-    }
-
-    /**
-     * The active states time in seconds.
-     *
-     * @type {number}
-     */
-    get activeStateCurrentTime() {
-        return this._controller.activeStateCurrentTime;
-    }
-
-    set activeStateCurrentTime(time) {
-        this._controller.activeStateCurrentTime = time;
-    }
-
-    /**
-     * Returns whether the anim component layer is currently transitioning between states.
-     *
-     * @type {boolean}
-     */
-    get transitioning() {
-        return this._controller.transitioning;
-    }
-
-    /**
-     * If the anim component layer is currently transitioning between states, returns the progress.
-     * Otherwise returns null.
-     *
-     * @type {number}
-     */
-    get transitionProgress() {
-        if (this.transitioning) {
-            return this._controller.transitionProgress;
-        }
-        return null;
-    }
-
-    /**
-     * Lists all available states in this layers state graph.
-     *
-     * @type {string[]}
-     */
-    get states() {
-        return this._controller.states;
-    }
-
-    /**
-     * The blending weight of this layer. Used when calculating the value of properties that are
-     * animated by more than one layer.
-     *
-     * @type {number}
-     */
-    get weight() {
-        return this._weight;
-    }
-
-    set weight(value) {
-        this._weight = value;
-        this._component.dirtifyTargets();
-    }
-
-    get blendType() {
-        return this._blendType;
-    }
-
-    set blendType(value) {
-        if (value !== this._blendType) {
-            this._blendType = value;
-            this._component.rebind();
-        }
     }
 }
 

--- a/src/framework/components/anim/component.js
+++ b/src/framework/components/anim/component.js
@@ -20,11 +20,6 @@ import { Entity } from "../../entity.js";
 /**
  * The Anim Component allows an Entity to playback animations on models and entity properties.
  *
- * @property {number} speed Speed multiplier for animation play back speed. 1.0 is playback at
- * normal speed, 0.0 pauses the animation.
- * @property {boolean} activate If true the first animation will begin playing when the scene is
- * loaded.
- * @property {boolean} playing Plays or pauses all animations in the component.
  * @augments Component
  */
 class AnimComponent extends Component {
@@ -51,10 +46,6 @@ class AnimComponent extends Component {
         // a collection of animated property targets
         this._targets = {};
         this._consumedTriggers = new Set();
-    }
-
-    get stateGraphAsset() {
-        return this._stateGraphAsset;
     }
 
     set stateGraphAsset(value) {
@@ -102,6 +93,147 @@ class AnimComponent extends Component {
         this._stateGraphAsset = _id;
     }
 
+    get stateGraphAsset() {
+        return this._stateGraphAsset;
+    }
+
+    set animationAssets(value) {
+        this._animationAssets = value;
+        this.loadAnimationAssets();
+    }
+
+    get animationAssets() {
+        return this._animationAssets;
+    }
+
+    /**
+     * Speed multiplier for animation play back speed. 1.0 is playback at normal speed, 0.0 pauses
+     * the animation.
+     *
+     * @type {number}
+     */
+    set speed(value) {
+        this._speed = value;
+    }
+
+    get speed() {
+        return this._speed;
+    }
+
+    /**
+     * If true the first animation will begin playing when the scene is loaded.
+     *
+     * @type {boolean}
+     */
+    set activate(value) {
+        this._activate = value;
+    }
+
+    get activate() {
+        return this._activate;
+    }
+
+    /**
+     * Plays or pauses all animations in the component.
+     *
+     * @type {boolean}
+     */
+    set playing(value) {
+        this._playing = value;
+    }
+
+    get playing() {
+        return this._playing;
+    }
+
+    /**
+     * The entity that this anim component should use as the root of the animation hierarchy.
+     *
+     * @type {Entity}
+     */
+    set rootBone(value) {
+        if (typeof value === 'string') {
+            const entity = this.entity.root.findByGuid(value);
+            Debug.assert(entity, `rootBone entity for supplied guid:${value} cannot be found in the scene`);
+            this._rootBone = entity;
+        } else if (value instanceof Entity) {
+            this._rootBone = value;
+        } else {
+            this._rootBone = null;
+        }
+        this.rebind();
+    }
+
+    get rootBone() {
+        return this._rootBone;
+    }
+
+    set stateGraph(value) {
+        this._stateGraph = value;
+    }
+
+    get stateGraph() {
+        return this._stateGraph;
+    }
+
+    set layers(value) {
+        this._layers = value;
+    }
+
+    get layers() {
+        return this._layers;
+    }
+
+    set layerIndices(value) {
+        this._layerIndices = value;
+    }
+
+    get layerIndices() {
+        return this._layerIndices;
+    }
+
+    set parameters(value) {
+        this._parameters = value;
+    }
+
+    get parameters() {
+        return this._parameters;
+    }
+
+    set targets(value) {
+        this._targets = value;
+    }
+
+    get targets() {
+        return this._targets;
+    }
+
+    /**
+     * Returns whether all component layers are currently playable.
+     *
+     * @type {boolean}
+     */
+    get playable() {
+        for (let i = 0; i < this._layers.length; i++) {
+            if (!this._layers[i].playable) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Returns the base layer of the state graph.
+     *
+     * @type {AnimComponentLayer}
+     */
+    get baseLayer() {
+        if (this._layers.length > 0) {
+            return this._layers[0];
+        }
+        return null;
+    }
+
     _onStateGraphAssetChangeEvent(asset) {
         // both animationAssets and layer masks should be maintained when switching AnimStateGraph assets
         const prevAnimationAssets = this.animationAssets;
@@ -117,127 +249,6 @@ class AnimComponent extends Component {
         // assign the previous layer masks then rebind all anim targets
         this.layers.forEach((layer, i) => layer.assignMask(prevMasks[i]));
         this.rebind();
-    }
-
-    get animationAssets() {
-        return this._animationAssets;
-    }
-
-    set animationAssets(value) {
-        this._animationAssets = value;
-        this.loadAnimationAssets();
-    }
-
-    get speed() {
-        return this._speed;
-    }
-
-    set speed(value) {
-        this._speed = value;
-    }
-
-    get activate() {
-        return this._activate;
-    }
-
-    set activate(value) {
-        this._activate = value;
-    }
-
-    get playing() {
-        return this._playing;
-    }
-
-    set playing(value) {
-        this._playing = value;
-    }
-
-    /**
-     * @name AnimComponent#rootBone
-     * @type {Entity}
-     * @description The entity that this anim component should use as the root of the animation hierarchy.
-     */
-    get rootBone() {
-        return this._rootBone;
-    }
-
-    set rootBone(value) {
-        if (typeof value === 'string') {
-            const entity = this.entity.root.findByGuid(value);
-            Debug.assert(entity, `rootBone entity for supplied guid:${value} cannot be found in the scene`);
-            this._rootBone = entity;
-        } else if (value instanceof Entity) {
-            this._rootBone = value;
-        } else {
-            this._rootBone = null;
-        }
-        this.rebind();
-    }
-
-    get stateGraph() {
-        return this._stateGraph;
-    }
-
-    set stateGraph(value) {
-        this._stateGraph = value;
-    }
-
-    get layers() {
-        return this._layers;
-    }
-
-    set layers(value) {
-        this._layers = value;
-    }
-
-    get layerIndices() {
-        return this._layerIndices;
-    }
-
-    set layerIndices(value) {
-        this._layerIndices = value;
-    }
-
-    get parameters() {
-        return this._parameters;
-    }
-
-    set parameters(value) {
-        this._parameters = value;
-    }
-
-    get targets() {
-        return this._targets;
-    }
-
-    set targets(value) {
-        this._targets = value;
-    }
-
-    /**
-     * @name AnimComponent#playable
-     * @type {boolean}
-     * @description Returns whether all component layers are currently playable.
-     */
-    get playable() {
-        for (let i = 0; i < this._layers.length; i++) {
-            if (!this._layers[i].playable) {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    /**
-     * @name AnimComponent#baseLayer
-     * @type {AnimComponentLayer}
-     * @description Returns the base layer of the state graph.
-     */
-    get baseLayer() {
-        if (this._layers.length > 0) {
-            return this._layers[0];
-        }
-        return null;
     }
 
     dirtifyTargets() {

--- a/src/framework/components/camera/component.js
+++ b/src/framework/components/camera/component.js
@@ -8,6 +8,8 @@ import { PostEffectQueue } from './post-effect-queue.js';
 /** @typedef {import('../../../graphics/render-target.js').RenderTarget} RenderTarget */
 /** @typedef {import('../../../math/mat4.js').Mat4} Mat4 */
 /** @typedef {import('../../../math/vec3.js').Vec3} Vec3 */
+/** @typedef {import('../../../math/vec4.js').Vec4} Vec4 */
+/** @typedef {import('../../../shape/frustum.js').Frustum} Frustum */
 /** @typedef {import('../../../xr/xr-manager.js').xrErrorCallback} xrErrorCallback */
 /** @typedef {import('../../entity.js').Entity} Entity */
 /** @typedef {import('./system.js').CameraComponentSystem} CameraComponentSystem */
@@ -23,15 +25,12 @@ const properties = [
     { name: 'farClip', readonly: false },
     { name: 'flipFaces', readonly: false },
     { name: 'fov', readonly: false },
-    { name: 'frustum', readonly: true },
     { name: 'frustumCulling', readonly: false },
     { name: 'horizontalFov', readonly: false },
     { name: 'nearClip', readonly: false },
     { name: 'orthoHeight', readonly: false },
     { name: 'projection', readonly: false },
-    { name: 'projectionMatrix', readonly: true },
     { name: 'scissorRect', readonly: false },
-    { name: 'viewMatrix', readonly: true },
     { name: 'vrDisplay', readonly: false }
 ];
 
@@ -91,12 +90,6 @@ const properties = [
  * Defaults to {@link ASPECT_AUTO}.
  * @property {Color} clearColor The color used to clear the canvas to before the camera starts to
  * render. Defaults to [0.75, 0.75, 0.75, 1].
- * @property {boolean} clearColorBuffer If true the camera will clear the color buffer to the color
- * set in clearColor. Defaults to true.
- * @property {boolean} clearDepthBuffer If true the camera will clear the depth buffer. Defaults to
- * true.
- * @property {boolean} clearStencilBuffer If true the camera will clear the stencil buffer.
- * Defaults to true.
  * @property {number} farClip The distance from the camera after which no rendering will take
  * place. Defaults to 1000.
  * @property {number} fov The field of view of the camera in degrees. Usually this is the Y-axis
@@ -108,16 +101,8 @@ const properties = [
  * place. Defaults to 0.1.
  * @property {number} orthoHeight The half-height of the orthographic view window (in the Y-axis).
  * Used for {@link PROJECTION_ORTHOGRAPHIC} cameras only. Defaults to 10.
- * @property {number} priority Controls the order in which cameras are rendered. Cameras with
- * smaller values for priority are rendered first. Defaults to 0.
- * @property {RenderTarget} renderTarget Render target to which rendering of the cameras is
- * performed. If not set, it will render simply to the screen.
- * @property {Vec4} rect Controls where on the screen the camera will be rendered in normalized
- * screen coordinates. Defaults to [0, 0, 1, 1].
  * @property {Vec4} scissorRect Clips all pixels which are not in the rectangle. The order of the
  * values is [x, y, width, height]. Defaults to [0, 0, 1, 1].
- * @property {PostEffectQueue} postEffects The post effects queue for this camera. Use this to add
- * or remove post effects from the camera.
  * @property {boolean} frustumCulling Controls the culling of mesh instances against the camera
  * frustum, i.e. if objects outside of camera should be omitted from rendering. If false, all mesh
  * instances in the scene are rendered by the camera, regardless of visibility. Defaults to false.
@@ -141,19 +126,31 @@ const properties = [
  * both front and back faces will be rendered. Defaults to true.
  * @property {boolean} flipFaces If true the camera will invert front and back faces. Can be useful
  * for reflection rendering. Defaults to false.
- * @property {number[]} layers An array of layer IDs ({@link Layer#id}) to which this camera should
- * belong. Don't push/pop/splice or modify this array, if you want to change it, set a new one
- * instead. Defaults to [LAYERID_WORLD, LAYERID_DEPTH, LAYERID_SKYBOX, LAYERID_UI,
- * LAYERID_IMMEDIATE].
- * @property {number} disablePostEffectsLayer Layer ID of a layer on which the postprocessing of
- * the camera stops being applied to. Defaults to LAYERID_UI, which causes post processing to not
- * be applied to UI layer and any following layers for the camera. Set to undefined for
- * post-processing to be applied to all layers of the camera.
- * @property {Function} onPreRender Custom function that is called before the camera renders the scene.
- * @property {Function} onPostRender Custom function that is called after the camera renders the scene.
  * @augments Component
  */
 class CameraComponent extends Component {
+    /**
+     * Custom function that is called when postprocessing should execute.
+     *
+     * @type {Function}
+     * @private
+     */
+    onPostprocessing = null;
+
+    /**
+     * Custom function that is called before the camera renders the scene.
+     *
+     * @type {Function}
+     */
+    onPreRender = null;
+
+    /**
+     * Custom function that is called after the camera renders the scene.
+     *
+     * @type {Function}
+     */
+    onPostRender = null;
+
     /**
      * Create a new CameraComponent instance.
      *
@@ -168,38 +165,12 @@ class CameraComponent extends Component {
 
         this._priority = 0;
 
-        // event called when postprocessing should execute
-        this.onPostprocessing = null;
-
-        // events called during the frame before and after the camera renders
-        this.onPreRender = null;
-        this.onPostRender = null;
-
         // layer id at which the postprocessing stops for the camera
         this._disablePostEffectsLayer = LAYERID_UI;
 
         // postprocessing management
         this._postEffects = new PostEffectQueue(system.app, this);
     }
-
-    /**
-     * @readonly
-     * @name CameraComponent#frustum
-     * @type {Frustum}
-     * @description Queries the camera's frustum shape.
-     */
-    /**
-     * @readonly
-     * @name CameraComponent#projectionMatrix
-     * @type {Mat4}
-     * @description Queries the camera's projection matrix.
-     */
-    /**
-     * @readonly
-     * @name CameraComponent#viewMatrix
-     * @type {Mat4}
-     * @description Queries the camera's view matrix.
-     */
 
     /**
      * Queries the camera component's underlying Camera instance.
@@ -211,29 +182,81 @@ class CameraComponent extends Component {
         return this._camera;
     }
 
-    dirtyLayerCompositionCameras() {
-        // layer composition needs to update order
-        const layerComp = this.system.app.scene.layers;
-        layerComp._dirtyCameras = true;
+    /**
+     * If true the camera will clear the color buffer to the color set in clearColor. Defaults to true.
+     *
+     * @type {boolean}
+     */
+    set clearColorBuffer(value) {
+        this._camera.clearColorBuffer = value;
+        this.dirtyLayerCompositionCameras();
+    }
+
+    get clearColorBuffer() {
+        return this._camera.clearColorBuffer;
+    }
+
+    /**
+     * If true the camera will clear the depth buffer. Defaults to true.
+     *
+     * @type {boolean}
+     */
+    set clearDepthBuffer(value) {
+        this._camera.clearDepthBuffer = value;
+        this.dirtyLayerCompositionCameras();
+    }
+
+    get clearDepthBuffer() {
+        return this._camera.clearDepthBuffer;
+    }
+
+    /**
+     * If true the camera will clear the stencil buffer. Defaults to true.
+     *
+     * @type {boolean}
+     */
+    set clearStencilBuffer(value) {
+        this._camera.clearStencilBuffer = value;
+        this.dirtyLayerCompositionCameras();
+    }
+
+    get clearStencilBuffer() {
+        return this._camera.clearStencilBuffer;
+    }
+
+    /**
+     * Layer ID of a layer on which the postprocessing of the camera stops being applied to.
+     * Defaults to LAYERID_UI, which causes post processing to not be applied to UI layer and any
+     * following layers for the camera. Set to undefined for post-processing to be applied to all
+     * layers of the camera.
+     *
+     * @type {number}
+     */
+    set disablePostEffectsLayer(layer) {
+        this._disablePostEffectsLayer = layer;
+        this.dirtyLayerCompositionCameras();
     }
 
     get disablePostEffectsLayer() {
         return this._disablePostEffectsLayer;
     }
 
-    set disablePostEffectsLayer(layer) {
-        this._disablePostEffectsLayer = layer;
-        this.dirtyLayerCompositionCameras();
+    /**
+     * Queries the camera's frustum shape.
+     *
+     * @type {Frustum}
+     */
+    get frustum() {
+        return this._camera.frustum;
     }
 
-    get postEffectsEnabled() {
-        return this._postEffects.enabled;
-    }
-
-    get layers() {
-        return this._camera.layers;
-    }
-
+    /**
+     * An array of layer IDs ({@link Layer#id}) to which this camera should belong. Don't push,
+     * pop, splice or modify this array, if you want to change it, set a new one instead. Defaults
+     * to [LAYERID_WORLD, LAYERID_DEPTH, LAYERID_SKYBOX, LAYERID_UI, LAYERID_IMMEDIATE].
+     *
+     * @type {number[]}
+     */
     set layers(newValue) {
         const layers = this._camera.layers;
         for (let i = 0; i < layers.length; i++) {
@@ -253,52 +276,70 @@ class CameraComponent extends Component {
         }
     }
 
+    get layers() {
+        return this._camera.layers;
+    }
+
+    /**
+     * The post effects queue for this camera. Use this to add or remove post effects from the camera.
+     *
+     * @type {PostEffectQueue}
+     */
+    get postEffectsEnabled() {
+        return this._postEffects.enabled;
+    }
+
     get postEffects() {
         return this._postEffects;
+    }
+
+    /**
+     * Controls the order in which cameras are rendered. Cameras with smaller values for priority
+     * are rendered first. Defaults to 0.
+     *
+     * @type {number}
+     */
+    set priority(newValue) {
+        this._priority = newValue;
+        this.dirtyLayerCompositionCameras();
     }
 
     get priority() {
         return this._priority;
     }
 
-    set priority(newValue) {
-        this._priority = newValue;
-        this.dirtyLayerCompositionCameras();
+    /**
+     * Queries the camera's projection matrix.
+     *
+     * @type {Mat4}
+     */
+    get projectionMatrix() {
+        return this._camera.projectionMatrix;
+    }
+
+    /**
+     * Controls where on the screen the camera will be rendered in normalized screen coordinates.
+     * Defaults to [0, 0, 1, 1].
+     *
+     * @type {Vec4}
+     */
+    set rect(value) {
+        this._camera.rect = value;
+        this.fire('set:rect', this._camera.rect);
     }
 
     get rect() {
         return this._camera.rect;
     }
 
-    set rect(value) {
-        this._camera.rect = value;
-        this.fire('set:rect', this._camera.rect);
-    }
-
-    get clearColorBuffer() {
-        return this._camera.clearColorBuffer;
-    }
-
-    set clearColorBuffer(value) {
-        this._camera.clearColorBuffer = value;
-        this.dirtyLayerCompositionCameras();
-    }
-
-    get clearDepthBuffer() {
-        return this._camera.clearDepthBuffer;
-    }
-
-    set clearDepthBuffer(value) {
-        this._camera.clearDepthBuffer = value;
-        this.dirtyLayerCompositionCameras();
-    }
-
-    get clearStencilBuffer() {
-        return this._camera.clearStencilBuffer;
-    }
-
-    set clearStencilBuffer(value) {
-        this._camera.clearStencilBuffer = value;
+    /**
+     * Render target to which rendering of the cameras is performed. If not set, it will render
+     * simply to the screen.
+     *
+     * @type {RenderTarget}
+     */
+    set renderTarget(value) {
+        this._camera.renderTarget = value;
         this.dirtyLayerCompositionCameras();
     }
 
@@ -306,9 +347,19 @@ class CameraComponent extends Component {
         return this._camera.renderTarget;
     }
 
-    set renderTarget(value) {
-        this._camera.renderTarget = value;
-        this.dirtyLayerCompositionCameras();
+    /**
+     * Queries the camera's view matrix.
+     *
+     * @type {Mat4}
+     */
+    get viewMatrix() {
+        return this._camera.viewMatrix;
+    }
+
+    dirtyLayerCompositionCameras() {
+        // layer composition needs to update order
+        const layerComp = this.system.app.scene.layers;
+        layerComp._dirtyCameras = true;
     }
 
     /**

--- a/src/framework/components/element/component.js
+++ b/src/framework/components/element/component.js
@@ -289,12 +289,7 @@ class ElementComponent extends Component {
      *
      * @type {Vec4}
      */
-    get anchor() {
-        return this._anchor;
-    }
-
     set anchor(value) {
-
         if (value instanceof Vec4) {
             this._anchor.set(value.x, value.y, value.z, value.w);
         } else {
@@ -315,15 +310,15 @@ class ElementComponent extends Component {
         this.fire('set:anchor', this._anchor);
     }
 
+    get anchor() {
+        return this._anchor;
+    }
+
     /**
      * Assign element to a specific batch group (see {@link BatchGroup}). Default is -1 (no group).
      *
      * @type {number}
      */
-    get batchGroupId() {
-        return this._batchGroupId;
-    }
-
     set batchGroupId(value) {
         if (this._batchGroupId === value)
             return;
@@ -348,16 +343,16 @@ class ElementComponent extends Component {
         this._batchGroupId = value;
     }
 
+    get batchGroupId() {
+        return this._batchGroupId;
+    }
+
     /**
      * The distance from the bottom edge of the anchor. Can be used in combination with a split
      * anchor to make the component's top edge always be 'top' units away from the top.
      *
      * @type {number}
      */
-    get bottom() {
-        return this._margin.y;
-    }
-
     set bottom(value) {
         this._margin.y = value;
         const p = this.entity.getLocalPosition();
@@ -369,6 +364,10 @@ class ElementComponent extends Component {
         this.entity.setLocalPosition(p);
     }
 
+    get bottom() {
+        return this._margin.y;
+    }
+
     /**
      * The width at which the element will be rendered. In most cases this will be the same as
      * `width`. However, in some cases the engine may calculate a different width for the element,
@@ -378,12 +377,12 @@ class ElementComponent extends Component {
      *
      * @type {number}
      */
-    get calculatedWidth() {
-        return this._calculatedWidth;
-    }
-
     set calculatedWidth(value) {
         this._setCalculatedWidth(value, true);
+    }
+
+    get calculatedWidth() {
+        return this._calculatedWidth;
     }
 
     /**
@@ -395,12 +394,12 @@ class ElementComponent extends Component {
      *
      * @type {number}
      */
-    get calculatedHeight() {
-        return this._calculatedHeight;
-    }
-
     set calculatedHeight(value) {
         this._setCalculatedHeight(value, true);
+    }
+
+    get calculatedHeight() {
+        return this._calculatedHeight;
     }
 
     /**
@@ -435,10 +434,6 @@ class ElementComponent extends Component {
      *
      * @type {number}
      */
-    get drawOrder() {
-        return this._drawOrder;
-    }
-
     set drawOrder(value) {
         let priority = 0;
         if (this.screen) {
@@ -455,6 +450,10 @@ class ElementComponent extends Component {
         this.fire('set:draworder', this._drawOrder);
     }
 
+    get drawOrder() {
+        return this._drawOrder;
+    }
+
     /**
      * The height of the element as set in the editor. Note that in some cases this may not reflect
      * the true height at which the element is rendered, such as when the element is under the
@@ -463,10 +462,6 @@ class ElementComponent extends Component {
      *
      * @type {number}
      */
-    get height() {
-        return this._height;
-    }
-
     set height(value) {
         this._height = value;
 
@@ -477,16 +472,16 @@ class ElementComponent extends Component {
         this.fire('set:height', this._height);
     }
 
+    get height() {
+        return this._height;
+    }
+
     /**
      * An array of layer IDs ({@link Layer#id}) to which this element should belong. Don't push,
      * pop, splice or modify this array, if you want to change it - set a new one instead.
      *
      * @type {number[]}
      */
-    get layers() {
-        return this._layers;
-    }
-
     set layers(value) {
         if (this._addedModels.length) {
             for (let i = 0; i < this._layers.length; i++) {
@@ -513,16 +508,16 @@ class ElementComponent extends Component {
         }
     }
 
+    get layers() {
+        return this._layers;
+    }
+
     /**
      * The distance from the left edge of the anchor. Can be used in combination with a split
      * anchor to make the component's left edge always be 'left' units away from the left.
      *
      * @type {number}
      */
-    get left() {
-        return this._margin.x;
-    }
-
     set left(value) {
         this._margin.x = value;
         const p = this.entity.getLocalPosition();
@@ -534,6 +529,10 @@ class ElementComponent extends Component {
         this.entity.setLocalPosition(p);
     }
 
+    get left() {
+        return this._margin.x;
+    }
+
     /**
      * The distance from the left, bottom, right and top edges of the anchor. For example if we are
      * using a split anchor like [0,0,1,1] and the margin is [0,0,0,0] then the component will be
@@ -541,14 +540,14 @@ class ElementComponent extends Component {
      *
      * @type {Vec4}
      */
-    get margin() {
-        return this._margin;
-    }
-
     set margin(value) {
         this._margin.copy(value);
         this._calculateSize(true, true);
         this.fire('set:margin', this._margin);
+    }
+
+    get margin() {
+        return this._margin;
     }
 
     /**
@@ -567,10 +566,6 @@ class ElementComponent extends Component {
      *
      * @type {Vec2}
      */
-    get pivot() {
-        return this._pivot;
-    }
-
     set pivot(value) {
         const prevX = this._pivot.x;
         const prevY = this._pivot.y;
@@ -604,16 +599,16 @@ class ElementComponent extends Component {
         this.fire('set:pivot', this._pivot);
     }
 
+    get pivot() {
+        return this._pivot;
+    }
+
     /**
      * The distance from the right edge of the anchor. Can be used in combination with a split
      * anchor to make the component's right edge always be 'right' units away from the right.
      *
      * @type {number}
      */
-    get right() {
-        return this._margin.z;
-    }
-
     set right(value) {
         this._margin.z = value;
 
@@ -626,6 +621,10 @@ class ElementComponent extends Component {
         // update position
         p.x = (this._localAnchor.z - this._localAnchor.x) - value - (this._calculatedWidth * (1 - this._pivot.x));
         this.entity.setLocalPosition(p);
+    }
+
+    get right() {
+        return this._margin.z;
     }
 
     /**
@@ -690,10 +689,6 @@ class ElementComponent extends Component {
      *
      * @type {number}
      */
-    get top() {
-        return this._margin.w;
-    }
-
     set top(value) {
         this._margin.w = value;
         const p = this.entity.getLocalPosition();
@@ -703,6 +698,10 @@ class ElementComponent extends Component {
 
         p.y = (this._localAnchor.w - this._localAnchor.y) - value - this._calculatedHeight * (1 - this._pivot.y);
         this.entity.setLocalPosition(p);
+    }
+
+    get top() {
+        return this._margin.w;
     }
 
     /**
@@ -715,10 +714,6 @@ class ElementComponent extends Component {
      *
      * @type {string}
      */
-    get type() {
-        return this._type;
-    }
-
     set type(value) {
         if (value !== this._type) {
             this._type = value;
@@ -740,15 +735,15 @@ class ElementComponent extends Component {
         }
     }
 
+    get type() {
+        return this._type;
+    }
+
     /**
      * If true then the component will receive Mouse or Touch input events.
      *
      * @type {boolean}
      */
-    get useInput() {
-        return this._useInput;
-    }
-
     set useInput(value) {
         if (this._useInput === value)
             return;
@@ -772,6 +767,10 @@ class ElementComponent extends Component {
         this.fire('set:useInput', value);
     }
 
+    get useInput() {
+        return this._useInput;
+    }
+
     /**
      * The width of the element as set in the editor. Note that in some cases this may not reflect
      * the true width at which the element is rendered, such as when the element is under the
@@ -780,10 +779,6 @@ class ElementComponent extends Component {
      *
      * @type {number}
      */
-    get width() {
-        return this._width;
-    }
-
     set width(value) {
         this._width = value;
 
@@ -792,6 +787,10 @@ class ElementComponent extends Component {
         }
 
         this.fire('set:width', this._width);
+    }
+
+    get width() {
+        return this._width;
     }
 
     /**

--- a/src/framework/components/element/element-drag-helper.js
+++ b/src/framework/components/element/element-drag-helper.js
@@ -219,12 +219,12 @@ class ElementDragHelper extends EventHandler {
         this._toggleDragListeners('off');
     }
 
-    get enabled() {
-        return this._enabled;
-    }
-
     set enabled(value) {
         this._enabled = value;
+    }
+
+    get enabled() {
+        return this._enabled;
     }
 
     get isDragging() {

--- a/src/framework/components/element/image-element.js
+++ b/src/framework/components/element/image-element.js
@@ -870,10 +870,6 @@ class ImageElement {
         }
     }
 
-    get color() {
-        return this._color;
-    }
-
     set color(value) {
         const r = value.r;
         const g = value.g;
@@ -901,8 +897,8 @@ class ImageElement {
         }
     }
 
-    get opacity() {
-        return this._color.a;
+    get color() {
+        return this._color;
     }
 
     set opacity(value) {
@@ -916,8 +912,8 @@ class ImageElement {
         }
     }
 
-    get rect() {
-        return this._rect;
+    get opacity() {
+        return this._color.a;
     }
 
     set rect(value) {
@@ -959,8 +955,8 @@ class ImageElement {
         }
     }
 
-    get material() {
-        return this._material;
+    get rect() {
+        return this._rect;
     }
 
     set material(value) {
@@ -994,8 +990,8 @@ class ImageElement {
         }
     }
 
-    get materialAsset() {
-        return this._materialAsset;
+    get material() {
+        return this._material;
     }
 
     set materialAsset(value) {
@@ -1032,8 +1028,8 @@ class ImageElement {
         }
     }
 
-    get texture() {
-        return this._texture;
+    get materialAsset() {
+        return this._materialAsset;
     }
 
     set texture(value) {
@@ -1070,8 +1066,8 @@ class ImageElement {
         }
     }
 
-    get textureAsset() {
-        return this._textureAsset;
+    get texture() {
+        return this._texture;
     }
 
     set textureAsset(value) {
@@ -1108,8 +1104,8 @@ class ImageElement {
         }
     }
 
-    get spriteAsset() {
-        return this._spriteAsset;
+    get textureAsset() {
+        return this._textureAsset;
     }
 
     set spriteAsset(value) {
@@ -1148,8 +1144,8 @@ class ImageElement {
         }
     }
 
-    get sprite() {
-        return this._sprite;
+    get spriteAsset() {
+        return this._spriteAsset;
     }
 
     set sprite(value) {
@@ -1195,8 +1191,8 @@ class ImageElement {
         this._updateSprite();
     }
 
-    get spriteFrame() {
-        return this._spriteFrame;
+    get sprite() {
+        return this._sprite;
     }
 
     set spriteFrame(value) {
@@ -1218,8 +1214,8 @@ class ImageElement {
         }
     }
 
-    get mesh() {
-        return this._renderable.mesh;
+    get spriteFrame() {
+        return this._spriteFrame;
     }
 
     set mesh(value) {
@@ -1231,8 +1227,8 @@ class ImageElement {
         }
     }
 
-    get mask() {
-        return this._mask;
+    get mesh() {
+        return this._renderable.mesh;
     }
 
     set mask(value) {
@@ -1242,8 +1238,8 @@ class ImageElement {
         }
     }
 
-    get pixelsPerUnit() {
-        return this._pixelsPerUnit;
+    get mask() {
+        return this._mask;
     }
 
     set pixelsPerUnit(value) {
@@ -1254,6 +1250,10 @@ class ImageElement {
             this._updateSprite();
         }
 
+    }
+
+    get pixelsPerUnit() {
+        return this._pixelsPerUnit;
     }
 
     // private

--- a/src/framework/components/element/text-element.js
+++ b/src/framework/components/element/text-element.js
@@ -1261,18 +1261,14 @@ class TextElement {
         }
     }
 
-    get text() {
-        return this._text;
-    }
-
     set text(value) {
         this._i18nKey = null;
         const str = value != null && value.toString() || "";
         this._setText(str);
     }
 
-    get key() {
-        return this._i18nKey;
+    get text() {
+        return this._text;
     }
 
     set key(value) {
@@ -1290,8 +1286,8 @@ class TextElement {
         }
     }
 
-    get color() {
-        return this._color;
+    get key() {
+        return this._i18nKey;
     }
 
     set color(value) {
@@ -1332,8 +1328,8 @@ class TextElement {
         }
     }
 
-    get opacity() {
-        return this._color.a;
+    get color() {
+        return this._color;
     }
 
     set opacity(value) {
@@ -1353,8 +1349,8 @@ class TextElement {
         }
     }
 
-    get lineHeight() {
-        return this._lineHeight;
+    get opacity() {
+        return this._color.a;
     }
 
     set lineHeight(value) {
@@ -1366,8 +1362,8 @@ class TextElement {
         }
     }
 
-    get wrapLines() {
-        return this._wrapLines;
+    get lineHeight() {
+        return this._lineHeight;
     }
 
     set wrapLines(value) {
@@ -1378,12 +1374,12 @@ class TextElement {
         }
     }
 
-    get lines() {
-        return this._lineContents;
+    get wrapLines() {
+        return this._wrapLines;
     }
 
-    get spacing() {
-        return this._spacing;
+    get lines() {
+        return this._lineContents;
     }
 
     set spacing(value) {
@@ -1394,8 +1390,8 @@ class TextElement {
         }
     }
 
-    get fontSize() {
-        return this._fontSize;
+    get spacing() {
+        return this._spacing;
     }
 
     set fontSize(value) {
@@ -1407,9 +1403,8 @@ class TextElement {
         }
     }
 
-    get fontAsset() {
-        // getting fontAsset returns the currently used localized asset
-        return this._fontAsset.localizedAsset;
+    get fontSize() {
+        return this._fontSize;
     }
 
     set fontAsset(value) {
@@ -1418,8 +1413,9 @@ class TextElement {
         this._fontAsset.defaultAsset = value;
     }
 
-    get font() {
-        return this._font;
+    get fontAsset() {
+        // getting fontAsset returns the currently used localized asset
+        return this._fontAsset.localizedAsset;
     }
 
     set font(value) {
@@ -1504,8 +1500,8 @@ class TextElement {
         this._updateText();
     }
 
-    get alignment() {
-        return this._alignment;
+    get font() {
+        return this._font;
     }
 
     set alignment(value) {
@@ -1519,8 +1515,8 @@ class TextElement {
             this._updateText();
     }
 
-    get autoWidth() {
-        return this._autoWidth;
+    get alignment() {
+        return this._alignment;
     }
 
     set autoWidth(value) {
@@ -1545,8 +1541,8 @@ class TextElement {
         }
     }
 
-    get autoHeight() {
-        return this._autoHeight;
+    get autoWidth() {
+        return this._autoWidth;
     }
 
     set autoHeight(value) {
@@ -1571,8 +1567,8 @@ class TextElement {
         }
     }
 
-    get rtlReorder() {
-        return this._rtlReorder;
+    get autoHeight() {
+        return this._autoHeight;
     }
 
     set rtlReorder(value) {
@@ -1584,8 +1580,8 @@ class TextElement {
         }
     }
 
-    get unicodeConverter() {
-        return this._unicodeConverter;
+    get rtlReorder() {
+        return this._rtlReorder;
     }
 
     set unicodeConverter(value) {
@@ -1593,6 +1589,10 @@ class TextElement {
             this._unicodeConverter = value;
             this._setText(this._text);
         }
+    }
+
+    get unicodeConverter() {
+        return this._unicodeConverter;
     }
 
     // private
@@ -1613,10 +1613,6 @@ class TextElement {
             this._aabbDirty = false;
         }
         return this._aabb;
-    }
-
-    get outlineColor() {
-        return this._outlineColor;
     }
 
     set outlineColor(value) {
@@ -1656,8 +1652,8 @@ class TextElement {
         }
     }
 
-    get outlineThickness() {
-        return this._outlineThickness;
+    get outlineColor() {
+        return this._outlineColor;
     }
 
     set outlineThickness(value) {
@@ -1673,8 +1669,8 @@ class TextElement {
         }
     }
 
-    get shadowColor() {
-        return this._shadowColor;
+    get outlineThickness() {
+        return this._outlineThickness;
     }
 
     set shadowColor(value) {
@@ -1714,8 +1710,8 @@ class TextElement {
         }
     }
 
-    get shadowOffset() {
-        return this._shadowOffset;
+    get shadowColor() {
+        return this._shadowColor;
     }
 
     set shadowOffset(value) {
@@ -1737,8 +1733,8 @@ class TextElement {
         }
     }
 
-    get minFontSize() {
-        return this._minFontSize;
+    get shadowOffset() {
+        return this._shadowOffset;
     }
 
     set minFontSize(value) {
@@ -1750,8 +1746,8 @@ class TextElement {
         }
     }
 
-    get maxFontSize() {
-        return this._maxFontSize;
+    get minFontSize() {
+        return this._minFontSize;
     }
 
     set maxFontSize(value) {
@@ -1763,8 +1759,8 @@ class TextElement {
         }
     }
 
-    get autoFitWidth() {
-        return this._autoFitWidth;
+    get maxFontSize() {
+        return this._maxFontSize;
     }
 
     set autoFitWidth(value) {
@@ -1777,8 +1773,8 @@ class TextElement {
         }
     }
 
-    get autoFitHeight() {
-        return this._autoFitHeight;
+    get autoFitWidth() {
+        return this._autoFitWidth;
     }
 
     set autoFitHeight(value) {
@@ -1791,8 +1787,8 @@ class TextElement {
         }
     }
 
-    get maxLines() {
-        return this._maxLines;
+    get autoFitHeight() {
+        return this._autoFitHeight;
     }
 
     set maxLines(value) {
@@ -1806,8 +1802,8 @@ class TextElement {
         }
     }
 
-    get enableMarkup() {
-        return this._enableMarkup;
+    get maxLines() {
+        return this._maxLines;
     }
 
     set enableMarkup(value) {
@@ -1819,6 +1815,10 @@ class TextElement {
         if (this.font) {
             this._updateText();
         }
+    }
+
+    get enableMarkup() {
+        return this._enableMarkup;
     }
 
     get symbols() {
@@ -1838,10 +1838,6 @@ class TextElement {
         return this._rtl;
     }
 
-    get rangeStart() {
-        return this._rangeStart;
-    }
-
     set rangeStart(rangeStart) {
         rangeStart = Math.max(0, Math.min(rangeStart, this._symbols.length));
 
@@ -1851,8 +1847,8 @@ class TextElement {
         }
     }
 
-    get rangeEnd() {
-        return this._rangeEnd;
+    get rangeStart() {
+        return this._rangeStart;
     }
 
     set rangeEnd(rangeEnd) {
@@ -1862,6 +1858,10 @@ class TextElement {
             this._rangeEnd = rangeEnd;
             this._updateRenderRange();
         }
+    }
+
+    get rangeEnd() {
+        return this._rangeEnd;
     }
 }
 

--- a/src/framework/components/model/component.js
+++ b/src/framework/components/model/component.js
@@ -12,6 +12,7 @@ import { Asset } from '../../../asset/asset.js';
 
 import { Component } from '../component.js';
 
+/** @typedef {import('../../../shape/bounding-box.js').BoundingBox} BoundingBox */
 /** @typedef {import('../../entity.js').Entity} Entity */
 /** @typedef {import('./system.js').ModelComponentSystem} ModelComponentSystem */
 
@@ -19,45 +20,6 @@ import { Component } from '../component.js';
  * Enables an Entity to render a model or a primitive shape. This Component attaches additional
  * model geometry in to the scene graph below the Entity.
  *
- * @property {string} type The type of the model. Can be:
- * - "asset": The component will render a model asset
- * - "box": The component will render a box (1 unit in each dimension)
- * - "capsule": The component will render a capsule (radius 0.5, height 2)
- * - "cone": The component will render a cone (radius 0.5, height 1)
- * - "cylinder": The component will render a cylinder (radius 0.5, height 1)
- * - "plane": The component will render a plane (1 unit in each dimension)
- * - "sphere": The component will render a sphere (radius 0.5)
- * @property {Asset|number} asset The asset for the model (only applies to models of type 'asset')
- * - can also be an asset id.
- * @property {boolean} castShadows If true, this model will cast shadows for lights that have
- * shadow casting enabled.
- * @property {boolean} receiveShadows If true, shadows will be cast on this model.
- * @property {Material} material The material {@link Material} that will be used to render the
- * model (not used on models of type 'asset').
- * @property {Asset|number} materialAsset The material {@link Asset} that will be used to render
- * the model (not used on models of type 'asset').
- * @property {Model} model The model that is added to the scene graph. It can be not set or loaded,
- * so will return null.
- * @property {object} mapping A dictionary that holds material overrides for each mesh instance.
- * Only applies to model components of type 'asset'. The mapping contains pairs of mesh instance
- * index - material asset id.
- * @property {boolean} castShadowsLightmap If true, this model will cast shadows when rendering
- * lightmaps.
- * @property {boolean} lightmapped If true, this model will be lightmapped after using
- * lightmapper.bake().
- * @property {number} lightmapSizeMultiplier Lightmap resolution multiplier.
- * @property {boolean} isStatic Mark model as non-movable (optimization).
- * @property {BoundingBox} customAabb If set, the object space bounding box is used as a bounding
- * box for visibility culling of attached mesh instances. This is an optimization, allowing
- * oversized bounding box to be specified for skinned characters in order to avoid per frame
- * bounding box computations based on bone positions.
- * @property {MeshInstance[]} meshInstances An array of meshInstances contained in the component's
- * model. If model is not set or loaded for component it will return null.
- * @property {number} batchGroupId Assign model to a specific batch group (see {@link BatchGroup}).
- * Default value is -1 (no group).
- * @property {number[]} layers An array of layer IDs ({@link Layer#id}) to which this model should
- * belong. Don't push/pop/splice or modify this array, if you want to change it - set a new one
- * instead.
  * @augments Component
  */
 class ModelComponent extends Component {
@@ -70,11 +32,17 @@ class ModelComponent extends Component {
     constructor(system, entity) {
         super(system, entity);
 
-        // this.enabled = true;
         this._type = 'asset';
 
-        // model asset
+        /**
+         * @type {number}
+         * @private
+         */
         this._asset = null;
+        /**
+         * @type {Model}
+         * @private
+         */
         this._model = null;
 
         this._mapping = {};
@@ -82,6 +50,10 @@ class ModelComponent extends Component {
         this._castShadows = true;
         this._receiveShadows = true;
 
+        /**
+         * @type {Asset}
+         * @private
+         */
         this._materialAsset = null;
         this._material = system.defaultMaterial;
 
@@ -93,7 +65,10 @@ class ModelComponent extends Component {
         this._layers = [LAYERID_WORLD]; // assign to the default world layer
         this._batchGroupId = -1;
 
-        // bounding box which can be set to override bounding box based on mesh
+        /**
+         * @type {BoundingBox}
+         * @private
+         */
         this._customAabb = null;
 
         this._area = null;
@@ -114,6 +89,545 @@ class ModelComponent extends Component {
         entity.on('removehierarchy', this.onRemoveChild, this);
         entity.on('insert', this.onInsertChild, this);
         entity.on('inserthierarchy', this.onInsertChild, this);
+    }
+
+    /**
+     * An array of meshInstances contained in the component's model. If model is not set or loaded
+     * for component it will return null.
+     *
+     * @type {MeshInstance[]}
+     */
+    set meshInstances(value) {
+        if (!this._model)
+            return;
+
+        this._model.meshInstances = value;
+    }
+
+    get meshInstances() {
+        if (!this._model)
+            return null;
+
+        return this._model.meshInstances;
+    }
+
+    /**
+     * If set, the object space bounding box is used as a bounding box for visibility culling of
+     * attached mesh instances. This is an optimization, allowing oversized bounding box to be
+     * specified for skinned characters in order to avoid per frame bounding box computations based
+     * on bone positions.
+     *
+     * @type {BoundingBox}
+     */
+    set customAabb(value) {
+        this._customAabb = value;
+
+        // set it on meshInstances
+        if (this._model) {
+            const mi = this._model.meshInstances;
+            if (mi) {
+                for (let i = 0; i < mi.length; i++) {
+                    mi[i].setCustomAabb(this._customAabb);
+                }
+            }
+        }
+    }
+
+    get customAabb() {
+        return this._customAabb;
+    }
+
+    /**
+     * The type of the model. Can be:
+     *
+     * - "asset": The component will render a model asset
+     * - "box": The component will render a box (1 unit in each dimension)
+     * - "capsule": The component will render a capsule (radius 0.5, height 2)
+     * - "cone": The component will render a cone (radius 0.5, height 1)
+     * - "cylinder": The component will render a cylinder (radius 0.5, height 1)
+     * - "plane": The component will render a plane (1 unit in each dimension)
+     * - "sphere": The component will render a sphere (radius 0.5)
+     *
+     * @type {string}
+     */
+    set type(value) {
+        if (this._type === value) return;
+
+        this._area = null;
+
+        this._type = value;
+
+        if (value === 'asset') {
+            if (this._asset !== null) {
+                this._bindModelAsset(this._asset);
+            } else {
+                this.model = null;
+            }
+        } else {
+
+            // get / create mesh of type
+            const primData = getShapePrimitive(this.system.app.graphicsDevice, value);
+            this._area = primData.area;
+            const mesh = primData.mesh;
+
+            const node = new GraphNode();
+            const model = new Model();
+            model.graph = node;
+
+            model.meshInstances = [new MeshInstance(mesh, this._material, node)];
+
+            this.model = model;
+            this._asset = null;
+        }
+    }
+
+    get type() {
+        return this._type;
+    }
+
+    /**
+     * The asset for the model (only applies to models of type 'asset') can also be an asset id.
+     *
+     * @type {Asset|number}
+     */
+    set asset(value) {
+        const assets = this.system.app.assets;
+        let _id = value;
+
+        if (value instanceof Asset) {
+            _id = value.id;
+        }
+
+        if (this._asset !== _id) {
+            if (this._asset) {
+                // remove previous asset
+                assets.off('add:' + this._asset, this._onModelAssetAdded, this);
+                const _prev = assets.get(this._asset);
+                if (_prev) {
+                    this._unbindModelAsset(_prev);
+                }
+            }
+
+            this._asset = _id;
+
+            if (this._asset) {
+                const asset = assets.get(this._asset);
+                if (!asset) {
+                    this.model = null;
+                    assets.on('add:' + this._asset, this._onModelAssetAdded, this);
+                } else {
+                    this._bindModelAsset(asset);
+                }
+            } else {
+                this.model = null;
+            }
+        }
+    }
+
+    get asset() {
+        return this._asset;
+    }
+
+    /**
+     * The model that is added to the scene graph. It can be not set or loaded, so will return null.
+     *
+     * @type {Model}
+     */
+    set model(value) {
+        if (this._model === value)
+            return;
+
+        // return if the model has been flagged as immutable
+        if (value && value._immutable) {
+            Debug.error('Invalid attempt to assign a model to multiple ModelComponents');
+            return;
+        }
+
+        if (this._model) {
+            this._model._immutable = false;
+
+            this.removeModelFromLayers();
+            this.entity.removeChild(this._model.getGraph());
+            delete this._model._entity;
+
+            if (this._clonedModel) {
+                this._model.destroy();
+                this._clonedModel = false;
+            }
+        }
+
+        this._model = value;
+
+        if (this._model) {
+            // flag the model as being assigned to a component
+            this._model._immutable = true;
+
+            const meshInstances = this._model.meshInstances;
+
+            for (let i = 0; i < meshInstances.length; i++) {
+                meshInstances[i].castShadow = this._castShadows;
+                meshInstances[i].receiveShadow = this._receiveShadows;
+                meshInstances[i].isStatic = this._isStatic;
+                meshInstances[i].setCustomAabb(this._customAabb);
+            }
+
+            this.lightmapped = this._lightmapped; // update meshInstances
+
+            this.entity.addChild(this._model.graph);
+
+            if (this.enabled && this.entity.enabled) {
+                this.addModelToLayers();
+            }
+
+            // Store the entity that owns this model
+            this._model._entity = this.entity;
+
+            // Update any animation component
+            if (this.entity.animation)
+                this.entity.animation.setModel(this._model);
+
+            // Update any animation component
+            if (this.entity.anim) {
+                if (this.entity.anim.playing) {
+                    this.entity.anim.rebind();
+                } else {
+                    this.entity.anim.resetStateGraph();
+                }
+            }
+            // trigger event handler to load mapping
+            // for new model
+            if (this.type === 'asset') {
+                this.mapping = this._mapping;
+            } else {
+                this._unsetMaterialEvents();
+            }
+        }
+    }
+
+    get model() {
+        return this._model;
+    }
+
+    /**
+     * If true, this model will be lightmapped after using lightmapper.bake().
+     *
+     * @type {boolean}
+     */
+    set lightmapped(value) {
+        if (value !== this._lightmapped) {
+
+            this._lightmapped = value;
+
+            if (this._model) {
+                const mi = this._model.meshInstances;
+                for (let i = 0; i < mi.length; i++) {
+                    mi[i].setLightmapped(value);
+                }
+            }
+        }
+    }
+
+    get lightmapped() {
+        return this._lightmapped;
+    }
+
+    /**
+     * If true, this model will cast shadows for lights that have shadow casting enabled.
+     *
+     * @type {boolean}
+     */
+    set castShadows(value) {
+        if (this._castShadows === value) return;
+
+        const model = this._model;
+
+        if (model) {
+            const layers = this.layers;
+            const scene = this.system.app.scene;
+            if (this._castShadows && !value) {
+                for (let i = 0; i < layers.length; i++) {
+                    const layer = this.system.app.scene.layers.getLayerById(this.layers[i]);
+                    if (!layer) continue;
+                    layer.removeShadowCasters(model.meshInstances);
+                }
+            }
+
+            const meshInstances = model.meshInstances;
+            for (let i = 0; i < meshInstances.length; i++) {
+                meshInstances[i].castShadow = value;
+            }
+
+            if (!this._castShadows && value) {
+                for (let i = 0; i < layers.length; i++) {
+                    const layer = scene.layers.getLayerById(layers[i]);
+                    if (!layer) continue;
+                    layer.addShadowCasters(model.meshInstances);
+                }
+            }
+        }
+
+        this._castShadows = value;
+    }
+
+    get castShadows() {
+        return this._castShadows;
+    }
+
+    /**
+     * If true, shadows will be cast on this model.
+     *
+     * @type {boolean}
+     */
+    set receiveShadows(value) {
+        if (this._receiveShadows === value) return;
+
+        this._receiveShadows = value;
+
+        if (this._model) {
+            const meshInstances = this._model.meshInstances;
+            for (let i = 0, len = meshInstances.length; i < len; i++) {
+                meshInstances[i].receiveShadow = value;
+            }
+        }
+    }
+
+    get receiveShadows() {
+        return this._receiveShadows;
+    }
+
+    /**
+     * If true, this model will cast shadows when rendering lightmaps.
+     *
+     * @type {boolean}
+     */
+    set castShadowsLightmap(value) {
+        this._castShadowsLightmap = value;
+    }
+
+    get castShadowsLightmap() {
+        return this._castShadowsLightmap;
+    }
+
+    /**
+     * Lightmap resolution multiplier.
+     *
+     * @type {number}
+     */
+    set lightmapSizeMultiplier(value) {
+        this._lightmapSizeMultiplier = value;
+    }
+
+    get lightmapSizeMultiplier() {
+        return this._lightmapSizeMultiplier;
+    }
+
+    /**
+     * Mark model as non-movable (optimization).
+     *
+     * @type {boolean}
+     */
+    set isStatic(value) {
+        if (this._isStatic === value) return;
+
+        this._isStatic = value;
+
+        if (this._model) {
+            const rcv = this._model.meshInstances;
+            for (let i = 0; i < rcv.length; i++) {
+                const m = rcv[i];
+                m.isStatic = value;
+            }
+        }
+    }
+
+    get isStatic() {
+        return this._isStatic;
+    }
+
+    /**
+     * An array of layer IDs ({@link Layer#id}) to which this model should belong. Don't push, pop,
+     * splice or modify this array, if you want to change it - set a new one instead.
+     *
+     * @type {number[]}
+     */
+    set layers(value) {
+        const layers = this.system.app.scene.layers;
+
+        if (this.meshInstances) {
+            // remove all mesh instances from old layers
+            for (let i = 0; i < this._layers.length; i++) {
+                const layer = layers.getLayerById(this._layers[i]);
+                if (!layer) continue;
+                layer.removeMeshInstances(this.meshInstances);
+            }
+        }
+
+        // set the layer list
+        this._layers.length = 0;
+        for (let i = 0; i < value.length; i++) {
+            this._layers[i] = value[i];
+        }
+
+        // don't add into layers until we're enabled
+        if (!this.enabled || !this.entity.enabled || !this.meshInstances) return;
+
+        // add all mesh instances to new layers
+        for (let i = 0; i < this._layers.length; i++) {
+            const layer = layers.getLayerById(this._layers[i]);
+            if (!layer) continue;
+            layer.addMeshInstances(this.meshInstances);
+        }
+    }
+
+    get layers() {
+        return this._layers;
+    }
+
+    /**
+     * Assign model to a specific batch group (see {@link BatchGroup}). Default is -1 (no group).
+     *
+     * @type {number}
+     */
+    set batchGroupId(value) {
+        if (this._batchGroupId === value) return;
+
+        const batcher = this.system.app.batcher;
+        if (this.entity.enabled && this._batchGroupId >= 0) {
+            batcher.remove(BatchGroup.MODEL, this.batchGroupId, this.entity);
+        }
+        if (this.entity.enabled && value >= 0) {
+            batcher.insert(BatchGroup.MODEL, value, this.entity);
+        }
+
+        if (value < 0 && this._batchGroupId >= 0 && this.enabled && this.entity.enabled) {
+            // re-add model to scene, in case it was removed by batching
+            this.addModelToLayers();
+        }
+
+        this._batchGroupId = value;
+    }
+
+    get batchGroupId() {
+        return this._batchGroupId;
+    }
+
+    /**
+     * The material {@link Asset} that will be used to render the model (not used on models of type
+     * 'asset').
+     *
+     * @type {Asset|number}
+     */
+    set materialAsset(value) {
+        let _id = value;
+        if (value instanceof Asset) {
+            _id = value.id;
+        }
+
+        const assets = this.system.app.assets;
+
+        if (_id !== this._materialAsset) {
+            if (this._materialAsset) {
+                assets.off('add:' + this._materialAsset, this._onMaterialAssetAdd, this);
+                const _prev = assets.get(this._materialAsset);
+                if (_prev) {
+                    this._unbindMaterialAsset(_prev);
+                }
+            }
+
+            this._materialAsset = _id;
+
+            if (this._materialAsset) {
+                const asset = assets.get(this._materialAsset);
+                if (!asset) {
+                    this._setMaterial(this.system.defaultMaterial);
+                    assets.on('add:' + this._materialAsset, this._onMaterialAssetAdd, this);
+                } else {
+                    this._bindMaterialAsset(asset);
+                }
+            } else {
+                this._setMaterial(this.system.defaultMaterial);
+            }
+        }
+    }
+
+    get materialAsset() {
+        return this._materialAsset;
+    }
+
+    /**
+     * The material {@link Material} that will be used to render the model (not used on models of
+     * type 'asset').
+     *
+     * @type {Material}
+     */
+    set material(value) {
+        if (this._material === value)
+            return;
+
+        this.materialAsset = null;
+
+        this._setMaterial(value);
+    }
+
+    get material() {
+        return this._material;
+    }
+
+    /**
+     * A dictionary that holds material overrides for each mesh instance. Only applies to model
+     * components of type 'asset'. The mapping contains pairs of mesh instance index - material
+     * asset id.
+     *
+     * @type {object}
+     */
+    set mapping(value) {
+        if (this._type !== 'asset')
+            return;
+
+        // unsubscribe from old events
+        this._unsetMaterialEvents();
+
+        // can't have a null mapping
+        if (!value)
+            value = {};
+
+        this._mapping = value;
+
+        if (!this._model) return;
+
+        const meshInstances = this._model.meshInstances;
+        const modelAsset = this.asset ? this.system.app.assets.get(this.asset) : null;
+        const assetMapping = modelAsset ? modelAsset.data.mapping : null;
+        let asset = null;
+
+        for (let i = 0, len = meshInstances.length; i < len; i++) {
+            if (value[i] !== undefined) {
+                if (value[i]) {
+                    asset = this.system.app.assets.get(value[i]);
+                    this._loadAndSetMeshInstanceMaterial(asset, meshInstances[i], i);
+                } else {
+                    meshInstances[i].material = this.system.defaultMaterial;
+                }
+            } else if (assetMapping) {
+                if (assetMapping[i] && (assetMapping[i].material || assetMapping[i].path)) {
+                    if (assetMapping[i].material !== undefined) {
+                        asset = this.system.app.assets.get(assetMapping[i].material);
+                    } else if (assetMapping[i].path !== undefined) {
+                        const url = this._getMaterialAssetUrl(assetMapping[i].path);
+                        if (url) {
+                            asset = this.system.app.assets.getByUrl(url);
+                        }
+                    }
+                    this._loadAndSetMeshInstanceMaterial(asset, meshInstances[i], i);
+                } else {
+                    meshInstances[i].material = this.system.defaultMaterial;
+                }
+            }
+        }
+    }
+
+    get mapping() {
+        return this._mapping;
     }
 
     addModelToLayers() {
@@ -479,448 +993,6 @@ class ModelComponent extends Component {
             const meshInstances = model.meshInstances;
             for (let i = 0, len = meshInstances.length; i < len; i++) {
                 meshInstances[i].material = material;
-            }
-        }
-    }
-
-    get meshInstances() {
-        if (!this._model)
-            return null;
-
-        return this._model.meshInstances;
-    }
-
-    set meshInstances(value) {
-        if (!this._model)
-            return;
-
-        this._model.meshInstances = value;
-    }
-
-    get customAabb() {
-        return this._customAabb;
-    }
-
-    set customAabb(value) {
-        this._customAabb = value;
-
-        // set it on meshInstances
-        if (this._model) {
-            const mi = this._model.meshInstances;
-            if (mi) {
-                for (let i = 0; i < mi.length; i++) {
-                    mi[i].setCustomAabb(this._customAabb);
-                }
-            }
-        }
-    }
-
-    get type() {
-        return this._type;
-    }
-
-    set type(value) {
-        if (this._type === value) return;
-
-        this._area = null;
-
-        this._type = value;
-
-        if (value === 'asset') {
-            if (this._asset !== null) {
-                this._bindModelAsset(this._asset);
-            } else {
-                this.model = null;
-            }
-        } else {
-
-            // get / create mesh of type
-            const primData = getShapePrimitive(this.system.app.graphicsDevice, value);
-            this._area = primData.area;
-            const mesh = primData.mesh;
-
-            const node = new GraphNode();
-            const model = new Model();
-            model.graph = node;
-
-            model.meshInstances = [new MeshInstance(mesh, this._material, node)];
-
-            this.model = model;
-            this._asset = null;
-        }
-    }
-
-    get asset() {
-        return this._asset;
-    }
-
-    set asset(value) {
-        const assets = this.system.app.assets;
-        let _id = value;
-
-        if (value instanceof Asset) {
-            _id = value.id;
-        }
-
-        if (this._asset !== _id) {
-            if (this._asset) {
-                // remove previous asset
-                assets.off('add:' + this._asset, this._onModelAssetAdded, this);
-                const _prev = assets.get(this._asset);
-                if (_prev) {
-                    this._unbindModelAsset(_prev);
-                }
-            }
-
-            this._asset = _id;
-
-            if (this._asset) {
-                const asset = assets.get(this._asset);
-                if (!asset) {
-                    this.model = null;
-                    assets.on('add:' + this._asset, this._onModelAssetAdded, this);
-                } else {
-                    this._bindModelAsset(asset);
-                }
-            } else {
-                this.model = null;
-            }
-        }
-    }
-
-    get model() {
-        return this._model;
-    }
-
-    set model(value) {
-        if (this._model === value)
-            return;
-
-        // return if the model has been flagged as immutable
-        if (value && value._immutable) {
-            Debug.error('Invalid attempt to assign a model to multiple ModelComponents');
-            return;
-        }
-
-        if (this._model) {
-            this._model._immutable = false;
-
-            this.removeModelFromLayers();
-            this.entity.removeChild(this._model.getGraph());
-            delete this._model._entity;
-
-            if (this._clonedModel) {
-                this._model.destroy();
-                this._clonedModel = false;
-            }
-        }
-
-        this._model = value;
-
-        if (this._model) {
-            // flag the model as being assigned to a component
-            this._model._immutable = true;
-
-            const meshInstances = this._model.meshInstances;
-
-            for (let i = 0; i < meshInstances.length; i++) {
-                meshInstances[i].castShadow = this._castShadows;
-                meshInstances[i].receiveShadow = this._receiveShadows;
-                meshInstances[i].isStatic = this._isStatic;
-                meshInstances[i].setCustomAabb(this._customAabb);
-            }
-
-            this.lightmapped = this._lightmapped; // update meshInstances
-
-            this.entity.addChild(this._model.graph);
-
-            if (this.enabled && this.entity.enabled) {
-                this.addModelToLayers();
-            }
-
-            // Store the entity that owns this model
-            this._model._entity = this.entity;
-
-            // Update any animation component
-            if (this.entity.animation)
-                this.entity.animation.setModel(this._model);
-
-            // Update any animation component
-            if (this.entity.anim) {
-                if (this.entity.anim.playing) {
-                    this.entity.anim.rebind();
-                } else {
-                    this.entity.anim.resetStateGraph();
-                }
-            }
-            // trigger event handler to load mapping
-            // for new model
-            if (this.type === 'asset') {
-                this.mapping = this._mapping;
-            } else {
-                this._unsetMaterialEvents();
-            }
-        }
-    }
-
-    get lightmapped() {
-        return this._lightmapped;
-    }
-
-    set lightmapped(value) {
-        if (value !== this._lightmapped) {
-
-            this._lightmapped = value;
-
-            if (this._model) {
-                const mi = this._model.meshInstances;
-                for (let i = 0; i < mi.length; i++) {
-                    mi[i].setLightmapped(value);
-                }
-            }
-        }
-    }
-
-    get castShadows() {
-        return this._castShadows;
-    }
-
-    set castShadows(value) {
-        if (this._castShadows === value) return;
-
-        const model = this._model;
-
-        if (model) {
-            const layers = this.layers;
-            const scene = this.system.app.scene;
-            if (this._castShadows && !value) {
-                for (let i = 0; i < layers.length; i++) {
-                    const layer = this.system.app.scene.layers.getLayerById(this.layers[i]);
-                    if (!layer) continue;
-                    layer.removeShadowCasters(model.meshInstances);
-                }
-            }
-
-            const meshInstances = model.meshInstances;
-            for (let i = 0; i < meshInstances.length; i++) {
-                meshInstances[i].castShadow = value;
-            }
-
-            if (!this._castShadows && value) {
-                for (let i = 0; i < layers.length; i++) {
-                    const layer = scene.layers.getLayerById(layers[i]);
-                    if (!layer) continue;
-                    layer.addShadowCasters(model.meshInstances);
-                }
-            }
-        }
-
-        this._castShadows = value;
-    }
-
-    get receiveShadows() {
-        return this._receiveShadows;
-    }
-
-    set receiveShadows(value) {
-        if (this._receiveShadows === value) return;
-
-        this._receiveShadows = value;
-
-        if (this._model) {
-            const meshInstances = this._model.meshInstances;
-            for (let i = 0, len = meshInstances.length; i < len; i++) {
-                meshInstances[i].receiveShadow = value;
-            }
-        }
-    }
-
-    get castShadowsLightmap() {
-        return this._castShadowsLightmap;
-    }
-
-    set castShadowsLightmap(value) {
-        this._castShadowsLightmap = value;
-    }
-
-    get lightmapSizeMultiplier() {
-        return this._lightmapSizeMultiplier;
-    }
-
-    set lightmapSizeMultiplier(value) {
-        this._lightmapSizeMultiplier = value;
-    }
-
-    get isStatic() {
-        return this._isStatic;
-    }
-
-    set isStatic(value) {
-        if (this._isStatic === value) return;
-
-        this._isStatic = value;
-
-        if (this._model) {
-            const rcv = this._model.meshInstances;
-            for (let i = 0; i < rcv.length; i++) {
-                const m = rcv[i];
-                m.isStatic = value;
-            }
-        }
-    }
-
-    get layers() {
-        return this._layers;
-    }
-
-    set layers(value) {
-        const layers = this.system.app.scene.layers;
-
-        if (this.meshInstances) {
-            // remove all meshinstances from old layers
-            for (let i = 0; i < this._layers.length; i++) {
-                const layer = layers.getLayerById(this._layers[i]);
-                if (!layer) continue;
-                layer.removeMeshInstances(this.meshInstances);
-            }
-        }
-
-        // set the layer list
-        this._layers.length = 0;
-        for (let i = 0; i < value.length; i++) {
-            this._layers[i] = value[i];
-        }
-
-        // don't add into layers until we're enabled
-        if (!this.enabled || !this.entity.enabled || !this.meshInstances) return;
-
-        // add all mesh instances to new layers
-        for (let i = 0; i < this._layers.length; i++) {
-            const layer = layers.getLayerById(this._layers[i]);
-            if (!layer) continue;
-            layer.addMeshInstances(this.meshInstances);
-        }
-    }
-
-    get batchGroupId() {
-        return this._batchGroupId;
-    }
-
-    set batchGroupId(value) {
-        if (this._batchGroupId === value) return;
-
-        const batcher = this.system.app.batcher;
-        if (this.entity.enabled && this._batchGroupId >= 0) {
-            batcher.remove(BatchGroup.MODEL, this.batchGroupId, this.entity);
-        }
-        if (this.entity.enabled && value >= 0) {
-            batcher.insert(BatchGroup.MODEL, value, this.entity);
-        }
-
-        if (value < 0 && this._batchGroupId >= 0 && this.enabled && this.entity.enabled) {
-            // re-add model to scene, in case it was removed by batching
-            this.addModelToLayers();
-        }
-
-        this._batchGroupId = value;
-    }
-
-    get materialAsset() {
-        return this._materialAsset;
-    }
-
-    set materialAsset(value) {
-        let _id = value;
-        if (value instanceof Asset) {
-            _id = value.id;
-        }
-
-        const assets = this.system.app.assets;
-
-        if (_id !== this._materialAsset) {
-            if (this._materialAsset) {
-                assets.off('add:' + this._materialAsset, this._onMaterialAssetAdd, this);
-                const _prev = assets.get(this._materialAsset);
-                if (_prev) {
-                    this._unbindMaterialAsset(_prev);
-                }
-            }
-
-            this._materialAsset = _id;
-
-            if (this._materialAsset) {
-                const asset = assets.get(this._materialAsset);
-                if (!asset) {
-                    this._setMaterial(this.system.defaultMaterial);
-                    assets.on('add:' + this._materialAsset, this._onMaterialAssetAdd, this);
-                } else {
-                    this._bindMaterialAsset(asset);
-                }
-            } else {
-                this._setMaterial(this.system.defaultMaterial);
-            }
-        }
-    }
-
-    get material() {
-        return this._material;
-    }
-
-    set material(value) {
-        if (this._material === value)
-            return;
-
-        this.materialAsset = null;
-
-        this._setMaterial(value);
-    }
-
-    get mapping() {
-        return this._mapping;
-    }
-
-    set mapping(value) {
-        if (this._type !== 'asset')
-            return;
-
-        // unsubscribe from old events
-        this._unsetMaterialEvents();
-
-        // can't have a null mapping
-        if (!value)
-            value = {};
-
-        this._mapping = value;
-
-        if (!this._model) return;
-
-        const meshInstances = this._model.meshInstances;
-        const modelAsset = this.asset ? this.system.app.assets.get(this.asset) : null;
-        const assetMapping = modelAsset ? modelAsset.data.mapping : null;
-        let asset = null;
-
-        for (let i = 0, len = meshInstances.length; i < len; i++) {
-            if (value[i] !== undefined) {
-                if (value[i]) {
-                    asset = this.system.app.assets.get(value[i]);
-                    this._loadAndSetMeshInstanceMaterial(asset, meshInstances[i], i);
-                } else {
-                    meshInstances[i].material = this.system.defaultMaterial;
-                }
-            } else if (assetMapping) {
-                if (assetMapping[i] && (assetMapping[i].material || assetMapping[i].path)) {
-                    if (assetMapping[i].material !== undefined) {
-                        asset = this.system.app.assets.get(assetMapping[i].material);
-                    } else if (assetMapping[i].path !== undefined) {
-                        const url = this._getMaterialAssetUrl(assetMapping[i].path);
-                        if (url) {
-                            asset = this.system.app.assets.getByUrl(url);
-                        }
-                    }
-                    this._loadAndSetMeshInstanceMaterial(asset, meshInstances[i], i);
-                } else {
-                    meshInstances[i].material = this.system.defaultMaterial;
-                }
             }
         }
     }

--- a/src/framework/components/particle-system/component.js
+++ b/src/framework/components/particle-system/component.js
@@ -291,15 +291,15 @@ class ParticleSystemComponent extends Component {
         this._drawOrder = 0;
     }
 
-    get drawOrder() {
-        return this._drawOrder;
-    }
-
     set drawOrder(drawOrder) {
         this._drawOrder = drawOrder;
         if (this.emitter) {
             this.emitter.drawOrder = drawOrder;
         }
+    }
+
+    get drawOrder() {
+        return this._drawOrder;
     }
 
     addModelToLayers() {

--- a/src/framework/components/rigid-body/component.js
+++ b/src/framework/components/rigid-body/component.js
@@ -96,10 +96,6 @@ class RigidBodyComponent extends Component {
      *
      * @type {number}
      */
-    get angularDamping() {
-        return this._angularDamping;
-    }
-
     set angularDamping(damping) {
         if (this._angularDamping !== damping) {
             this._angularDamping = damping;
@@ -110,16 +106,16 @@ class RigidBodyComponent extends Component {
         }
     }
 
+    get angularDamping() {
+        return this._angularDamping;
+    }
+
     /**
      * Scaling factor for angular movement of the body in each axis. Only valid for rigid bodies of
      * type {@link BODYTYPE_DYNAMIC}. Defaults to 1 in all axes (body can freely rotate).
      *
      * @type {Vec3}
      */
-    get angularFactor() {
-        return this._angularFactor;
-    }
-
     set angularFactor(factor) {
         if (!this._angularFactor.equals(factor)) {
             this._angularFactor.copy(factor);
@@ -131,19 +127,15 @@ class RigidBodyComponent extends Component {
         }
     }
 
+    get angularFactor() {
+        return this._angularFactor;
+    }
+
     /**
      * Defines the rotational speed of the body around each world axis.
      *
      * @type {Vec3}
      */
-    get angularVelocity() {
-        if (this._body && this._type === BODYTYPE_DYNAMIC) {
-            const velocity = this._body.getAngularVelocity();
-            this._angularVelocity.set(velocity.x(), velocity.y(), velocity.z());
-        }
-        return this._angularVelocity;
-    }
-
     set angularVelocity(velocity) {
         if (this._body && this._type === BODYTYPE_DYNAMIC) {
             this._body.activate();
@@ -155,8 +147,12 @@ class RigidBodyComponent extends Component {
         }
     }
 
-    get body() {
-        return this._body;
+    get angularVelocity() {
+        if (this._body && this._type === BODYTYPE_DYNAMIC) {
+            const velocity = this._body.getAngularVelocity();
+            this._angularVelocity.set(velocity.x(), velocity.y(), velocity.z());
+        }
+        return this._angularVelocity;
     }
 
     set body(body) {
@@ -169,16 +165,16 @@ class RigidBodyComponent extends Component {
         }
     }
 
+    get body() {
+        return this._body;
+    }
+
     /**
      * The friction value used when contacts occur between two bodies. A higher value indicates
      * more friction. Should be set in the range 0 to 1. Defaults to 0.5.
      *
      * @type {number}
      */
-    get friction() {
-        return this._friction;
-    }
-
     set friction(friction) {
         if (this._friction !== friction) {
             this._friction = friction;
@@ -189,16 +185,16 @@ class RigidBodyComponent extends Component {
         }
     }
 
+    get friction() {
+        return this._friction;
+    }
+
     /**
      * The collision group this body belongs to. Combine the group and the mask to prevent bodies
      * colliding with each other. Defaults to 1.
      *
      * @type {number}
      */
-    get group() {
-        return this._group;
-    }
-
     set group(group) {
         if (this._group !== group) {
             this._group = group;
@@ -211,15 +207,15 @@ class RigidBodyComponent extends Component {
         }
     }
 
+    get group() {
+        return this._group;
+    }
+
     /**
      * Controls the rate at which a body loses linear velocity over time. Defaults to 0.
      *
      * @type {number}
      */
-    get linearDamping() {
-        return this._linearDamping;
-    }
-
     set linearDamping(damping) {
         if (this._linearDamping !== damping) {
             this._linearDamping = damping;
@@ -230,16 +226,16 @@ class RigidBodyComponent extends Component {
         }
     }
 
+    get linearDamping() {
+        return this._linearDamping;
+    }
+
     /**
      * Scaling factor for linear movement of the body in each axis. Only valid for rigid bodies of
      * type {@link BODYTYPE_DYNAMIC}. Defaults to 1 in all axes (body can freely move).
      *
      * @type {Vec3}
      */
-    get linearFactor() {
-        return this._linearFactor;
-    }
-
     set linearFactor(factor) {
         if (!this._linearFactor.equals(factor)) {
             this._linearFactor.copy(factor);
@@ -251,19 +247,15 @@ class RigidBodyComponent extends Component {
         }
     }
 
+    get linearFactor() {
+        return this._linearFactor;
+    }
+
     /**
      * Defines the speed of the body in a given direction.
      *
      * @type {Vec3}
      */
-    get linearVelocity() {
-        if (this._body && this._type === BODYTYPE_DYNAMIC) {
-            const velocity = this._body.getLinearVelocity();
-            this._linearVelocity.set(velocity.x(), velocity.y(), velocity.z());
-        }
-        return this._linearVelocity;
-    }
-
     set linearVelocity(velocity) {
         if (this._body && this._type === BODYTYPE_DYNAMIC) {
             this._body.activate();
@@ -275,16 +267,20 @@ class RigidBodyComponent extends Component {
         }
     }
 
+    get linearVelocity() {
+        if (this._body && this._type === BODYTYPE_DYNAMIC) {
+            const velocity = this._body.getLinearVelocity();
+            this._linearVelocity.set(velocity.x(), velocity.y(), velocity.z());
+        }
+        return this._linearVelocity;
+    }
+
     /**
      * The collision mask sets which groups this body collides with. It is a bitfield of 16 bits,
      * the first 8 bits are reserved for engine use. Defaults to 65535.
      *
      * @type {number}
      */
-    get mask() {
-        return this._mask;
-    }
-
     set mask(mask) {
         if (this._mask !== mask) {
             this._mask = mask;
@@ -297,16 +293,16 @@ class RigidBodyComponent extends Component {
         }
     }
 
+    get mask() {
+        return this._mask;
+    }
+
     /**
      * The mass of the body. This is only relevant for {@link BODYTYPE_DYNAMIC} bodies, other types
      * have infinite mass. Defaults to 1.
      *
      * @type {number}
      */
-    get mass() {
-        return this._mass;
-    }
-
     set mass(mass) {
         if (this._mass !== mass) {
             this._mass = mass;
@@ -330,6 +326,10 @@ class RigidBodyComponent extends Component {
         }
     }
 
+    get mass() {
+        return this._mass;
+    }
+
     /**
      * Influences the amount of energy lost when two rigid bodies collide. The calculation
      * multiplies the restitution values for both colliding bodies. A multiplied value of 0 means
@@ -338,10 +338,6 @@ class RigidBodyComponent extends Component {
      *
      * @type {number}
      */
-    get restitution() {
-        return this._restitution;
-    }
-
     set restitution(restitution) {
         if (this._restitution !== restitution) {
             this._restitution = restitution;
@@ -352,15 +348,15 @@ class RigidBodyComponent extends Component {
         }
     }
 
+    get restitution() {
+        return this._restitution;
+    }
+
     /**
      * Sets a torsional friction orthogonal to the contact point. Defaults to 0.
      *
      * @type {number}
      */
-    get rollingFriction() {
-        return this._rollingFriction;
-    }
-
     set rollingFriction(friction) {
         if (this._rollingFriction !== friction) {
             this._rollingFriction = friction;
@@ -369,6 +365,10 @@ class RigidBodyComponent extends Component {
                 this._body.setRollingFriction(friction);
             }
         }
+    }
+
+    get rollingFriction() {
+        return this._rollingFriction;
     }
 
     /**
@@ -383,10 +383,6 @@ class RigidBodyComponent extends Component {
      *
      * @type {string}
      */
-    get type() {
-        return this._type;
-    }
-
     set type(type) {
         if (this._type !== type) {
             this._type = type;
@@ -413,6 +409,10 @@ class RigidBodyComponent extends Component {
             // Create a new body
             this.createBody();
         }
+    }
+
+    get type() {
+        return this._type;
     }
 
     /**

--- a/src/framework/components/screen/component.js
+++ b/src/framework/components/screen/component.js
@@ -16,23 +16,6 @@ const _transform = new Mat4();
  * A ScreenComponent enables the Entity to render child {@link ElementComponent}s using anchors and
  * positions in the ScreenComponent's space.
  *
- * @property {boolean} screenSpace If true then the ScreenComponent will render its child
- * {@link ElementComponent}s in screen space instead of world space. Enable this to create 2D user
- * interfaces.
- * @property {boolean} cull If true then elements inside this screen will be not be rendered when
- * outside of the screen (only valid when screenSpace is true).
- * @property {string} scaleMode Can either be {@link SCALEMODE_NONE} or {@link SCALEMODE_BLEND}.
- * See the description of referenceResolution for more information.
- * @property {number} scaleBlend A value between 0 and 1 that is used when scaleMode is equal to
- * {@link SCALEMODE_BLEND}. Scales the ScreenComponent with width as a reference (when value is 0),
- * the height as a reference (when value is 1) or anything in between.
- * @property {Vec2} resolution The width and height of the ScreenComponent. When screenSpace is
- * true the resolution will always be equal to {@link GraphicsDevice#width} x
- * {@link GraphicsDevice#height}.
- * @property {Vec2} referenceResolution The resolution that the ScreenComponent is designed for.
- * This is only taken into account when screenSpace is true and scaleMode is
- * {@link SCALEMODE_BLEND}. If the actual resolution is different then the ScreenComponent will be
- * scaled according to the scaleBlend value.
  * @augments Component
  */
 class ScreenComponent extends Component {
@@ -51,11 +34,16 @@ class ScreenComponent extends Component {
         this.scale = 1;
         this._scaleBlend = 0.5;
 
-        // priority determines the order in which screens components are rendered
-        // priority is set into the top 8 bits of the drawOrder property in an element
         this._priority = 0;
 
         this._screenSpace = false;
+
+        /**
+         * If true then elements inside this screen will be not be rendered when outside of the
+         * screen (only valid when screenSpace is true).
+         *
+         * @type {boolean}
+         */
         this.cull = this._screenSpace;
         this._screenMatrix = new Mat4();
 
@@ -168,11 +156,17 @@ class ScreenComponent extends Component {
 
     }
 
+    /**
+     * The width and height of the ScreenComponent. When screenSpace is true the resolution will
+     * always be equal to {@link GraphicsDevice#width} x {@link GraphicsDevice#height}.
+     *
+     * @type {Vec2}
+     */
     set resolution(value) {
         if (!this._screenSpace) {
             this._resolution.set(value.x, value.y);
         } else {
-            // ignore input when using screenspace.
+            // ignore input when using screen space.
             this._resolution.set(this.system.app.graphicsDevice.width, this.system.app.graphicsDevice.height);
         }
 
@@ -191,6 +185,13 @@ class ScreenComponent extends Component {
         return this._resolution;
     }
 
+    /**
+     * The resolution that the ScreenComponent is designed for. This is only taken into account
+     * when screenSpace is true and scaleMode is {@link SCALEMODE_BLEND}. If the actual resolution
+     * is different then the ScreenComponent will be scaled according to the scaleBlend value.
+     *
+     * @type {Vec2}
+     */
     set referenceResolution(value) {
         this._referenceResolution.set(value.x, value.y);
         this._updateScale();
@@ -208,9 +209,14 @@ class ScreenComponent extends Component {
             return this._resolution;
         }
         return this._referenceResolution;
-
     }
 
+    /**
+     * If true then the ScreenComponent will render its child {@link ElementComponent}s in screen
+     * space instead of world space. Enable this to create 2D user interfaces.
+     *
+     * @type {boolean}
+     */
     set screenSpace(value) {
         this._screenSpace = value;
         if (this._screenSpace) {
@@ -230,6 +236,12 @@ class ScreenComponent extends Component {
         return this._screenSpace;
     }
 
+    /**
+     * Can either be {@link SCALEMODE_NONE} or {@link SCALEMODE_BLEND}. See the description of
+     * referenceResolution for more information.
+     *
+     * @type {string}
+     */
     set scaleMode(value) {
         if (value !== SCALEMODE_NONE && value !== SCALEMODE_BLEND) {
             value = SCALEMODE_NONE;
@@ -249,6 +261,13 @@ class ScreenComponent extends Component {
         return this._scaleMode;
     }
 
+    /**
+     * A value between 0 and 1 that is used when scaleMode is equal to {@link SCALEMODE_BLEND}.
+     * Scales the ScreenComponent with width as a reference (when value is 0), the height as a
+     * reference (when value is 1) or anything in between.
+     *
+     * @type {number}
+     */
     set scaleBlend(value) {
         this._scaleBlend = value;
         this._updateScale();
@@ -266,10 +285,13 @@ class ScreenComponent extends Component {
         return this._scaleBlend;
     }
 
-    get priority() {
-        return this._priority;
-    }
-
+    /**
+     * Priority determines the order in which screens components are rendered. Priority is set into
+     * the top 8 bits of the drawOrder property in an element.
+     *
+     * @type {number}
+     * @private
+     */
     set priority(value) {
         if (value > 0xFF) {
             Debug.warn(`Clamping screen priority from ${value} to 255`);
@@ -277,6 +299,10 @@ class ScreenComponent extends Component {
         }
 
         this._priority = value;
+    }
+
+    get priority() {
+        return this._priority;
     }
 }
 

--- a/src/framework/components/script/component.js
+++ b/src/framework/components/script/component.js
@@ -917,14 +917,14 @@ class ScriptComponent extends Component {
         return true;
     }
 
-    get enabled() {
-        return this._enabled;
-    }
-
     set enabled(value) {
         const oldValue = this._enabled;
         this._enabled = value;
         this.fire('set', 'enabled', oldValue, value);
+    }
+
+    get enabled() {
+        return this._enabled;
     }
 
     /**

--- a/src/framework/components/script/component.js
+++ b/src/framework/components/script/component.js
@@ -58,6 +58,66 @@ class ScriptComponent extends Component {
         this.on('set_enabled', this._onSetEnabled, this);
     }
 
+    set enabled(value) {
+        const oldValue = this._enabled;
+        this._enabled = value;
+        this.fire('set', 'enabled', oldValue, value);
+    }
+
+    get enabled() {
+        return this._enabled;
+    }
+
+    /**
+     * An array of all script instances attached to an entity. This array is read-only and should
+     * not be modified by developer.
+     *
+     * @type {ScriptType[]}
+     */
+    set scripts(value) {
+        this._scriptsData = value;
+
+        for (const key in value) {
+            if (!value.hasOwnProperty(key))
+                continue;
+
+            const script = this._scriptsIndex[key];
+            if (script) {
+                // existing script
+
+                // enabled
+                if (typeof value[key].enabled === 'boolean')
+                    script.enabled = !!value[key].enabled;
+
+                // attributes
+                if (typeof value[key].attributes === 'object') {
+                    for (const attr in value[key].attributes) {
+                        if (ScriptAttributes.reservedNames.has(attr))
+                            continue;
+
+                        if (!script.__attributes.hasOwnProperty(attr)) {
+                            // new attribute
+                            const scriptType = this.system.app.scripts.get(key);
+                            if (scriptType)
+                                scriptType.attributes.add(attr, { });
+                        }
+
+                        // update attribute
+                        script[attr] = value[key].attributes[attr];
+                    }
+                }
+            } else {
+                // TODO scripts2
+                // new script
+                console.log(this.order);
+            }
+        }
+    }
+
+    get scripts() {
+        return this._scripts;
+    }
+
     static scriptMethods = {
         initialize: 'initialize',
         postInitialize: 'postInitialize',
@@ -915,66 +975,6 @@ class ScriptComponent extends Component {
         this.fire('move:' + scriptName, scriptInstance, ind, indOld);
 
         return true;
-    }
-
-    set enabled(value) {
-        const oldValue = this._enabled;
-        this._enabled = value;
-        this.fire('set', 'enabled', oldValue, value);
-    }
-
-    get enabled() {
-        return this._enabled;
-    }
-
-    /**
-     * An array of all script instances attached to an entity. This array is read-only and should
-     * not be modified by developer.
-     *
-     * @type {ScriptType[]}
-     */
-    get scripts() {
-        return this._scripts;
-    }
-
-    set scripts(value) {
-        this._scriptsData = value;
-
-        for (const key in value) {
-            if (!value.hasOwnProperty(key))
-                continue;
-
-            const script = this._scriptsIndex[key];
-            if (script) {
-                // existing script
-
-                // enabled
-                if (typeof value[key].enabled === 'boolean')
-                    script.enabled = !!value[key].enabled;
-
-                // attributes
-                if (typeof value[key].attributes === 'object') {
-                    for (const attr in value[key].attributes) {
-                        if (ScriptAttributes.reservedNames.has(attr))
-                            continue;
-
-                        if (!script.__attributes.hasOwnProperty(attr)) {
-                            // new attribute
-                            const scriptType = this.system.app.scripts.get(key);
-                            if (scriptType)
-                                scriptType.attributes.add(attr, { });
-                        }
-
-                        // update attribute
-                        script[attr] = value[key].attributes[attr];
-                    }
-                }
-            } else {
-                // TODO scripts2
-                // new script
-                console.log(this.order);
-            }
-        }
     }
 }
 

--- a/src/framework/components/scroll-view/component.js
+++ b/src/framework/components/scroll-view/component.js
@@ -676,12 +676,12 @@ class ScrollViewComponent extends Component {
         this._destroyDragHelper();
     }
 
-    get scroll() {
-        return this._scroll;
-    }
-
     set scroll(value) {
         this._onSetScroll(value.x, value.y);
+    }
+
+    get scroll() {
+        return this._scroll;
     }
 
     /**

--- a/src/framework/components/sound/component.js
+++ b/src/framework/components/sound/component.js
@@ -17,9 +17,6 @@ import { SoundSlot } from './slot.js';
  * 1.
  * @property {number} pitch The pitch modifier to play the audio with. Must be larger than 0.01.
  * Defaults to 1.
- * @property {boolean} positional If true the audio will play back at the location of the Entity in
- * space, so the audio will be affected by the position of the {@link AudioListenerComponent}.
- * Defaults to true.
  * @property {string} distanceModel Determines which algorithm to use to reduce the volume of the
  * sound as it moves away from the listener. Can be:
  *
@@ -34,8 +31,6 @@ import { SoundSlot } from './slot.js';
  * stops. Note the volume of the audio is not 0 after this distance, but just doesn't fall off
  * anymore. Defaults to 10000.
  * @property {number} rollOffFactor The factor used in the falloff equation. Defaults to 1.
- * @property {object} slots A dictionary that contains the {@link SoundSlot}s managed by this
- * SoundComponent.
  * @augments Component
  */
 class SoundComponent extends Component {
@@ -55,15 +50,24 @@ class SoundComponent extends Component {
         this._maxDistance = 10000;
         this._rollOffFactor = 1;
         this._distanceModel = DISTANCE_LINEAR;
+
+        /* eslint-disable jsdoc/check-types */
+        /**
+         * @type {Object.<string, SoundSlot>}
+         * @private
+         */
         this._slots = {};
+        /* eslint-enable jsdoc/check-types */
 
         this._playingBeforeDisable = {};
     }
 
-    get positional() {
-        return this._positional;
-    }
-
+    /**
+     * If true the audio will play back at the location of the Entity in space, so the audio will
+     * be affected by the position of the {@link AudioListenerComponent}. Defaults to true.
+     *
+     * @type {boolean}
+     */
     set positional(newValue) {
         this._positional = newValue;
 
@@ -96,10 +100,16 @@ class SoundComponent extends Component {
         }
     }
 
-    get slots() {
-        return this._slots;
+    get positional() {
+        return this._positional;
     }
 
+    /* eslint-disable jsdoc/check-types */
+    /**
+     * A dictionary that contains the {@link SoundSlot}s managed by this SoundComponent.
+     *
+     * @type {Object.<string, SoundSlot>}
+     */
     set slots(newValue) {
         const oldValue = this._slots;
 
@@ -129,6 +139,11 @@ class SoundComponent extends Component {
         if (this.enabled && this.entity.enabled)
             this.onEnable();
     }
+
+    get slots() {
+        return this._slots;
+    }
+    /* eslint-enable jsdoc/check-types */
 
     onEnable() {
         // do not run if running in Editor

--- a/src/framework/components/sound/slot.js
+++ b/src/framework/components/sound/slot.js
@@ -446,10 +446,6 @@ class SoundSlot extends EventHandler {
      *
      * @type {number|null}
      */
-    get asset() {
-        return this._asset;
-    }
-
     set asset(value) {
         const old = this._asset;
 
@@ -472,17 +468,21 @@ class SoundSlot extends EventHandler {
         }
     }
 
+    get asset() {
+        return this._asset;
+    }
+
     /**
      * If true the slot will begin playing as soon as it is loaded.
      *
      * @type {boolean}
      */
-    get autoPlay() {
-        return this._autoPlay;
-    }
-
     set autoPlay(value) {
         this._autoPlay = !!value;
+    }
+
+    get autoPlay() {
+        return this._autoPlay;
     }
 
     /**
@@ -490,6 +490,18 @@ class SoundSlot extends EventHandler {
      *
      * @type {number}
      */
+    set duration(value) {
+        this._duration = Math.max(0, Number(value) || 0) || null;
+
+        // update instances if non overlapping
+        if (!this._overlap) {
+            const instances = this.instances;
+            for (let i = 0, len = instances.length; i < len; i++) {
+                instances[i].duration = this._duration;
+            }
+        }
+    }
+
     get duration() {
         let assetDuration = 0;
         if (this._hasAsset()) {
@@ -502,18 +514,6 @@ class SoundSlot extends EventHandler {
             return this._duration % (assetDuration || 1);
         }
         return assetDuration;
-    }
-
-    set duration(value) {
-        this._duration = Math.max(0, Number(value) || 0) || null;
-
-        // update instances if non overlapping
-        if (!this._overlap) {
-            const instances = this.instances;
-            for (let i = 0, len = instances.length; i < len; i++) {
-                instances[i].duration = this._duration;
-            }
-        }
     }
 
     /**
@@ -586,10 +586,6 @@ class SoundSlot extends EventHandler {
      *
      * @type {boolean}
      */
-    get loop() {
-        return this._loop;
-    }
-
     set loop(value) {
         this._loop = !!value;
 
@@ -600,18 +596,22 @@ class SoundSlot extends EventHandler {
         }
     }
 
+    get loop() {
+        return this._loop;
+    }
+
     /**
      * If true then sounds played from slot will be played independently of each other. Otherwise
      * the slot will first stop the current sound before starting the new one.
      *
      * @type {boolean}
      */
-    get overlap() {
-        return this._overlap;
-    }
-
     set overlap(value) {
         this._overlap = !!value;
+    }
+
+    get overlap() {
+        return this._overlap;
     }
 
     /**
@@ -619,10 +619,6 @@ class SoundSlot extends EventHandler {
      *
      * @type {number}
      */
-    get pitch() {
-        return this._pitch;
-    }
-
     set pitch(value) {
         this._pitch = Math.max(Number(value) || 0, 0.01);
 
@@ -635,15 +631,15 @@ class SoundSlot extends EventHandler {
         }
     }
 
+    get pitch() {
+        return this._pitch;
+    }
+
     /**
      * The start time from which the sound will start playing.
      *
      * @type {number}
      */
-    get startTime() {
-        return this._startTime;
-    }
-
     set startTime(value) {
         this._startTime = Math.max(0, Number(value) || 0);
 
@@ -656,15 +652,15 @@ class SoundSlot extends EventHandler {
         }
     }
 
+    get startTime() {
+        return this._startTime;
+    }
+
     /**
      * The volume modifier to play the sound with. In range 0-1.
      *
      * @type {number}
      */
-    get volume() {
-        return this._volume;
-    }
-
     set volume(value) {
         this._volume = math.clamp(Number(value) || 0, 0, 1);
 
@@ -675,6 +671,10 @@ class SoundSlot extends EventHandler {
                 instances[i].volume = this._volume * this._component.volume;
             }
         }
+    }
+
+    get volume() {
+        return this._volume;
     }
 
     // Events Documentation

--- a/src/framework/components/sound/system.js
+++ b/src/framework/components/sound/system.js
@@ -16,11 +16,6 @@ const _schema = ['enabled'];
 /**
  * Manages creation of {@link SoundComponent}s.
  *
- * @property {number} volume Sets / gets the volume for the entire Sound system. All sounds will
- * have their volume multiplied by this value. Valid between [0, 1].
- * @property {AudioContext} context Gets the AudioContext currently used by the sound manager.
- * Requires Web Audio API support.
- * @property {SoundManager} manager Gets / sets the sound manager.
  * @augments ComponentSystem
  */
 class SoundComponentSystem extends ComponentSystem {
@@ -40,11 +35,44 @@ class SoundComponentSystem extends ComponentSystem {
 
         this.schema = _schema;
 
+        /**
+         * Gets / sets the sound manager.
+         *
+         * @type {SoundManager}
+         */
         this.manager = manager;
 
         this.app.systems.on('update', this.onUpdate, this);
 
         this.on('beforeremove', this.onBeforeRemove, this);
+    }
+
+    /**
+     * Sets / gets the volume for the entire Sound system. All sounds will have their volume
+     * multiplied by this value. Valid between [0, 1].
+     *
+     * @type {number}
+     */
+    set volume(volume) {
+        this.manager.volume = volume;
+    }
+
+    get volume() {
+        return this.manager.volume;
+    }
+
+    /**
+     * Gets the AudioContext currently used by the sound manager. Requires Web Audio API support.
+     *
+     * @type {AudioContext}
+     */
+    get context() {
+        if (!hasAudioContext()) {
+            Debug.warn('WARNING: Audio context is not supported on this browser');
+            return null;
+        }
+
+        return this.manager.context;
     }
 
     initializeComponentData(component, data, properties) {
@@ -146,23 +174,6 @@ class SoundComponentSystem extends ComponentSystem {
         super.destroy();
 
         this.app.systems.off('update', this.onUpdate, this);
-    }
-
-    get volume() {
-        return this.manager.volume;
-    }
-
-    set volume(volume) {
-        this.manager.volume = volume;
-    }
-
-    get context() {
-        if (!hasAudioContext()) {
-            Debug.warn('WARNING: Audio context is not supported on this browser');
-            return null;
-        }
-
-        return this.manager.context;
     }
 }
 

--- a/src/framework/components/sprite/sprite-animation-clip.js
+++ b/src/framework/components/sprite/sprite-animation-clip.js
@@ -50,7 +50,7 @@ class SpriteAnimationClip extends EventHandler {
      *
      * @type {number}
      */
-     get duration() {
+    get duration() {
         if (this._sprite) {
             const fps = this.fps || Number.MIN_VALUE;
             return this._sprite.frameKeys.length / Math.abs(fps);

--- a/src/framework/components/sprite/sprite-animation-clip.js
+++ b/src/framework/components/sprite/sprite-animation-clip.js
@@ -45,6 +45,191 @@ class SpriteAnimationClip extends EventHandler {
         this._time = 0;
     }
 
+    /**
+     * The total duration of the animation in seconds.
+     *
+     * @type {number}
+     */
+     get duration() {
+        if (this._sprite) {
+            const fps = this.fps || Number.MIN_VALUE;
+            return this._sprite.frameKeys.length / Math.abs(fps);
+        }
+        return 0;
+    }
+
+    /**
+     * The index of the frame of the {@link Sprite} currently being rendered.
+     *
+     * @type {number}
+     */
+    set frame(value) {
+        this._setFrame(value);
+
+        // update time to start of frame
+        const fps = this.fps || Number.MIN_VALUE;
+        this._setTime(this._frame / fps);
+    }
+
+    get frame() {
+        return this._frame;
+    }
+
+    /**
+     * Whether the animation is currently paused.
+     *
+     * @type {boolean}
+     */
+    get isPaused() {
+        return this._paused;
+    }
+
+    /**
+     * Whether the animation is currently playing.
+     *
+     * @type {boolean}
+     */
+    get isPlaying() {
+        return this._playing;
+    }
+
+    /**
+     * The current sprite used to play the animation.
+     *
+     * @type {Sprite}
+     */
+    set sprite(value) {
+        if (this._sprite) {
+            this._sprite.off('set:meshes', this._onSpriteMeshesChange, this);
+            this._sprite.off('set:pixelsPerUnit', this._onSpritePpuChanged, this);
+            this._sprite.off('set:atlas', this._onSpriteMeshesChange, this);
+            if (this._sprite.atlas) {
+                this._sprite.atlas.off('set:texture', this._onSpriteMeshesChange, this);
+            }
+        }
+
+        this._sprite = value;
+
+        if (this._sprite) {
+            this._sprite.on('set:meshes', this._onSpriteMeshesChange, this);
+            this._sprite.on('set:pixelsPerUnit', this._onSpritePpuChanged, this);
+            this._sprite.on('set:atlas', this._onSpriteMeshesChange, this);
+
+            if (this._sprite.atlas) {
+                this._sprite.atlas.on('set:texture', this._onSpriteMeshesChange, this);
+            }
+        }
+
+        if (this._component.currentClip === this) {
+            let mi;
+
+            // if we are clearing the sprite clear old mesh instance parameters
+            if (!value || !value.atlas) {
+                mi = this._component._meshInstance;
+                if (mi) {
+                    mi.deleteParameter('texture_emissiveMap');
+                    mi.deleteParameter('texture_opacityMap');
+                }
+
+                this._component._hideModel();
+            } else {
+                // otherwise show sprite
+
+                // update texture
+                if (value.atlas.texture) {
+                    mi = this._component._meshInstance;
+                    if (mi) {
+                        mi.setParameter('texture_emissiveMap', value.atlas.texture);
+                        mi.setParameter('texture_opacityMap', value.atlas.texture);
+                    }
+
+                    if (this._component.enabled && this._component.entity.enabled) {
+                        this._component._showModel();
+                    }
+                }
+
+                // if we have a time then force update
+                // frame based on the time (check if fps is not 0 otherwise time will be Infinity)
+
+                /* eslint-disable no-self-assign */
+                if (this.time && this.fps) {
+                    this.time = this.time;
+                } else {
+                    // if we don't have a time
+                    // then force update frame counter
+                    this.frame = this.frame;
+                }
+                /* eslint-enable no-self-assign */
+            }
+        }
+    }
+
+    get sprite() {
+        return this._sprite;
+    }
+
+    /**
+     * The id of the sprite asset used to play the animation.
+     *
+     * @type {number}
+     */
+    set spriteAsset(value) {
+        const assets = this._component.system.app.assets;
+        let id = value;
+
+        if (value instanceof Asset) {
+            id = value.id;
+        }
+
+        if (this._spriteAsset !== id) {
+            if (this._spriteAsset) {
+                // clean old event listeners
+                const prev = assets.get(this._spriteAsset);
+                if (prev) {
+                    this._unbindSpriteAsset(prev);
+                }
+            }
+
+            this._spriteAsset = id;
+
+            // bind sprite asset
+            if (this._spriteAsset) {
+                const asset = assets.get(this._spriteAsset);
+                if (!asset) {
+                    this.sprite = null;
+                    assets.on('add:' + this._spriteAsset, this._onSpriteAssetAdded, this);
+                } else {
+                    this._bindSpriteAsset(asset);
+                }
+            } else {
+                this.sprite = null;
+            }
+        }
+    }
+
+    get spriteAsset() {
+        return this._spriteAsset;
+    }
+
+    /**
+     * The current time of the animation in seconds.
+     *
+     * @type {number}
+     */
+    set time(value) {
+        this._setTime(value);
+
+        if (this._sprite) {
+            this.frame = Math.min(this._sprite.frameKeys.length - 1, Math.floor(this._time * Math.abs(this.fps)));
+        } else {
+            this.frame = 0;
+        }
+    }
+
+    get time() {
+        return this._time;
+    }
+
     // When sprite asset is added bind it
     _onSpriteAssetAdded(asset) {
         this._component.system.app.assets.off('add:' + asset.id, this._onSpriteAssetAdded, this);
@@ -259,191 +444,6 @@ class SpriteAnimationClip extends EventHandler {
 
         this.fire('stop');
         this._component.fire('stop', this);
-    }
-
-    /**
-     * The total duration of the animation in seconds.
-     *
-     * @type {number}
-     */
-    get duration() {
-        if (this._sprite) {
-            const fps = this.fps || Number.MIN_VALUE;
-            return this._sprite.frameKeys.length / Math.abs(fps);
-        }
-        return 0;
-    }
-
-    /**
-     * The index of the frame of the {@link Sprite} currently being rendered.
-     *
-     * @type {number}
-     */
-    get frame() {
-        return this._frame;
-    }
-
-    set frame(value) {
-        this._setFrame(value);
-
-        // update time to start of frame
-        const fps = this.fps || Number.MIN_VALUE;
-        this._setTime(this._frame / fps);
-    }
-
-    /**
-     * Whether the animation is currently paused.
-     *
-     * @type {boolean}
-     */
-    get isPaused() {
-        return this._paused;
-    }
-
-    /**
-     * Whether the animation is currently playing.
-     *
-     * @type {boolean}
-     */
-    get isPlaying() {
-        return this._playing;
-    }
-
-    /**
-     * The current sprite used to play the animation.
-     *
-     * @type {Sprite}
-     */
-    get sprite() {
-        return this._sprite;
-    }
-
-    set sprite(value) {
-        if (this._sprite) {
-            this._sprite.off('set:meshes', this._onSpriteMeshesChange, this);
-            this._sprite.off('set:pixelsPerUnit', this._onSpritePpuChanged, this);
-            this._sprite.off('set:atlas', this._onSpriteMeshesChange, this);
-            if (this._sprite.atlas) {
-                this._sprite.atlas.off('set:texture', this._onSpriteMeshesChange, this);
-            }
-        }
-
-        this._sprite = value;
-
-        if (this._sprite) {
-            this._sprite.on('set:meshes', this._onSpriteMeshesChange, this);
-            this._sprite.on('set:pixelsPerUnit', this._onSpritePpuChanged, this);
-            this._sprite.on('set:atlas', this._onSpriteMeshesChange, this);
-
-            if (this._sprite.atlas) {
-                this._sprite.atlas.on('set:texture', this._onSpriteMeshesChange, this);
-            }
-        }
-
-        if (this._component.currentClip === this) {
-            let mi;
-
-            // if we are clearing the sprite clear old mesh instance parameters
-            if (!value || !value.atlas) {
-                mi = this._component._meshInstance;
-                if (mi) {
-                    mi.deleteParameter('texture_emissiveMap');
-                    mi.deleteParameter('texture_opacityMap');
-                }
-
-                this._component._hideModel();
-            } else {
-                // otherwise show sprite
-
-                // update texture
-                if (value.atlas.texture) {
-                    mi = this._component._meshInstance;
-                    if (mi) {
-                        mi.setParameter('texture_emissiveMap', value.atlas.texture);
-                        mi.setParameter('texture_opacityMap', value.atlas.texture);
-                    }
-
-                    if (this._component.enabled && this._component.entity.enabled) {
-                        this._component._showModel();
-                    }
-                }
-
-                // if we have a time then force update
-                // frame based on the time (check if fps is not 0 otherwise time will be Infinity)
-
-                /* eslint-disable no-self-assign */
-                if (this.time && this.fps) {
-                    this.time = this.time;
-                } else {
-                    // if we don't have a time
-                    // then force update frame counter
-                    this.frame = this.frame;
-                }
-                /* eslint-enable no-self-assign */
-            }
-        }
-    }
-
-    /**
-     * The id of the sprite asset used to play the animation.
-     *
-     * @type {number}
-     */
-    get spriteAsset() {
-        return this._spriteAsset;
-    }
-
-    set spriteAsset(value) {
-        const assets = this._component.system.app.assets;
-        let id = value;
-
-        if (value instanceof Asset) {
-            id = value.id;
-        }
-
-        if (this._spriteAsset !== id) {
-            if (this._spriteAsset) {
-                // clean old event listeners
-                const prev = assets.get(this._spriteAsset);
-                if (prev) {
-                    this._unbindSpriteAsset(prev);
-                }
-            }
-
-            this._spriteAsset = id;
-
-            // bind sprite asset
-            if (this._spriteAsset) {
-                const asset = assets.get(this._spriteAsset);
-                if (!asset) {
-                    this.sprite = null;
-                    assets.on('add:' + this._spriteAsset, this._onSpriteAssetAdded, this);
-                } else {
-                    this._bindSpriteAsset(asset);
-                }
-            } else {
-                this.sprite = null;
-            }
-        }
-    }
-
-    /**
-     * The current time of the animation in seconds.
-     *
-     * @type {number}
-     */
-    get time() {
-        return this._time;
-    }
-
-    set time(value) {
-        this._setTime(value);
-
-        if (this._sprite) {
-            this.frame = Math.min(this._sprite.frameKeys.length - 1, Math.floor(this._time * Math.abs(this.fps)));
-        } else {
-            this.frame = 0;
-        }
     }
 
     // Events Documentation

--- a/src/framework/components/sprite/system.js
+++ b/src/framework/components/sprite/system.js
@@ -56,6 +56,10 @@ class SpriteComponentSystem extends ComponentSystem {
         this.on('beforeremove', this.onBeforeRemove, this);
     }
 
+    set defaultMaterial(material) {
+        this._defaultMaterial = material;
+    }
+
     get defaultMaterial() {
         if (!this._defaultMaterial) {
             const texture = new Texture(this.app.graphicsDevice, {
@@ -93,8 +97,8 @@ class SpriteComponentSystem extends ComponentSystem {
         return this._defaultMaterial;
     }
 
-    set defaultMaterial(material) {
-        this._defaultMaterial = material;
+    set default9SlicedMaterialSlicedMode(material) {
+        this._default9SlicedMaterialSlicedMode = material;
     }
 
     get default9SlicedMaterialSlicedMode() {
@@ -108,8 +112,8 @@ class SpriteComponentSystem extends ComponentSystem {
         return this._default9SlicedMaterialSlicedMode;
     }
 
-    set default9SlicedMaterialSlicedMode(material) {
-        this._default9SlicedMaterialSlicedMode = material;
+    set default9SlicedMaterialTiledMode(material) {
+        this._default9SlicedMaterialTiledMode = material;
     }
 
     get default9SlicedMaterialTiledMode() {
@@ -121,10 +125,6 @@ class SpriteComponentSystem extends ComponentSystem {
             this._default9SlicedMaterialTiledMode = material;
         }
         return this._default9SlicedMaterialTiledMode;
-    }
-
-    set default9SlicedMaterialTiledMode(material) {
-        this._default9SlicedMaterialTiledMode = material;
     }
 
     destroy() {

--- a/src/framework/components/zone/component.js
+++ b/src/framework/components/zone/component.js
@@ -9,7 +9,6 @@ import { Component } from '../component.js';
  * performance reasons. And many other possible options. Zones are building blocks and meant to be
  * used in many different ways.
  *
- * @property {Vec3} size The size of the axis-aligned box of this ZoneComponent.
  * @augments Component
  * @private
  */
@@ -27,6 +26,51 @@ class ZoneComponent extends Component {
         this._oldState = true;
         this._size = new Vec3();
         this.on('set_enabled', this._onSetEnabled, this);
+    }
+
+    /**
+     * The size of the axis-aligned box of this ZoneComponent.
+     *
+     * @type {Vec3}
+     * @private
+     */
+    set size(data) {
+        if (data instanceof Vec3) {
+            this._size.copy(data);
+        } else if (data instanceof Array && data.length >= 3) {
+            this.size.set(data[0], data[1], data[2]);
+        }
+    }
+
+    get size() {
+        return this._size;
+    }
+
+    onEnable() {
+        this._checkState();
+    }
+
+    onDisable() {
+        this._checkState();
+    }
+
+    _onSetEnabled(prop, old, value) {
+        this._checkState();
+    }
+
+    _checkState() {
+        const state = this.enabled && this.entity.enabled;
+        if (state === this._oldState)
+            return;
+
+        this._oldState = state;
+
+        this.fire('enable');
+        this.fire('state', this.enabled);
+    }
+
+    _onBeforeRemove() {
+        this.fire('remove');
     }
 
     /**
@@ -76,45 +120,6 @@ class ZoneComponent extends Component {
      *     // zone has been removed from an entity
      * });
      */
-
-    onEnable() {
-        this._checkState();
-    }
-
-    onDisable() {
-        this._checkState();
-    }
-
-    _onSetEnabled(prop, old, value) {
-        this._checkState();
-    }
-
-    _checkState() {
-        const state = this.enabled && this.entity.enabled;
-        if (state === this._oldState)
-            return;
-
-        this._oldState = state;
-
-        this.fire('enable');
-        this.fire('state', this.enabled);
-    }
-
-    _onBeforeRemove() {
-        this.fire('remove');
-    }
-
-    set size(data) {
-        if (data instanceof Vec3) {
-            this._size.copy(data);
-        } else if (data instanceof Array && data.length >= 3) {
-            this.size.set(data[0], data[1], data[2]);
-        }
-    }
-
-    get size() {
-        return this._size;
-    }
 }
 
 export { ZoneComponent };

--- a/src/framework/scene-registry-item.js
+++ b/src/framework/scene-registry-item.js
@@ -1,9 +1,5 @@
 /**
  * Item to be stored in the {@link SceneRegistry}.
- *
- * @property {string} name - The name of the scene.
- * @property {string} url - The url of the scene file.
- * @property {boolean} loaded - Returns true if the scene data is still being loaded.
  */
 class SceneRegistryItem {
     /**
@@ -13,18 +9,38 @@ class SceneRegistryItem {
      * @param {string} url - The url of the scene file.
      */
     constructor(name, url) {
+        /**
+         * The name of the scene.
+         *
+         * @type {string}
+         */
         this.name = name;
+        /**
+         * The url of the scene file.
+         *
+         * @type {string}
+         */
         this.url = url;
         this.data = null;
         this._loading = false;
         this._onLoadedCallbacks = [];
     }
 
+    /**
+     * Returns true if the scene data has loaded.
+     *
+     * @type {boolean}
+     */
     get loaded() {
         return !!this.data;
     }
 
-    get loading() {
+    /**
+     * Returns true if the scene data is still being loaded.
+     *
+     * @type {boolean}
+     */
+     get loading() {
         return this._loading;
     }
 }

--- a/src/framework/scene-registry-item.js
+++ b/src/framework/scene-registry-item.js
@@ -40,7 +40,7 @@ class SceneRegistryItem {
      *
      * @type {boolean}
      */
-     get loading() {
+    get loading() {
         return this._loading;
     }
 }

--- a/src/graphics/graphics-device.js
+++ b/src/graphics/graphics-device.js
@@ -204,16 +204,16 @@ function testTextureFloatHighPrecision(device) {
  * specific canvas HTML element. It is valid to have more than one canvas element per page and
  * create a new graphics device against each.
  *
- * @property {HTMLCanvasElement} canvas The canvas DOM element that provides the underlying WebGL
- * context used by the graphics device.
- * @property {boolean} textureFloatRenderable Determines if 32-bit floating-point textures can be
- * used as frame buffer. [read only].
- * @property {boolean} textureHalfFloatRenderable Determines if 16-bit floating-point textures can
- * be used as frame buffer. [read only].
- * @property {ScopeSpace} scope The scope namespace for shader attributes and variables. [read only].
  * @augments EventHandler
  */
 class GraphicsDevice extends EventHandler {
+    /**
+     * The canvas DOM element that provides the underlying WebGL context used by the graphics device.
+     *
+     * @type {HTMLCanvasElement}
+     */
+    canvas;
+
     /**
      * The highest shader precision supported by this graphics device. Can be 'hiphp', 'mediump' or
      * 'lowp'.
@@ -251,11 +251,32 @@ class GraphicsDevice extends EventHandler {
     maxAnisotropy;
 
     /**
+     * The scope namespace for shader attributes and variables.
+     *
+     * @type {ScopeSpace}
+     */
+    scope;
+
+    /**
      * True if hardware instancing is supported.
      *
      * @type {boolean}
      */
     supportsInstancing;
+
+    /**
+     * True if 32-bit floating-point textures can be used as a frame buffer.
+     *
+     * @type {boolean}
+     */
+    textureFloatRenderable;
+
+    /**
+     * True if 16-bit floating-point textures can be used as a frame buffer.
+     *
+     * @type {boolean}
+     */
+    textureHalfFloatRenderable;
 
     /**
      * Creates a new GraphicsDevice instance.
@@ -795,13 +816,18 @@ class GraphicsDevice extends EventHandler {
     }
     // #endif
 
+    /**
+     * Query the precision supported by ints and floats in vertex and fragment shaders. Note that
+     * getShaderPrecisionFormat is not guaranteed to be present (such as some instances of the
+     * default Android browser). In this case, assume highp is available.
+     *
+     * @returns {string} "highp", "mediump" or "lowp"
+     * @private
+     */
     getPrecision() {
         const gl = this.gl;
         let precision = "highp";
 
-        // Query the precision supported by ints and floats in vertex and fragment shaders.
-        // Note that getShaderPrecisionFormat is not guaranteed to be present (such as some
-        // instances of the default Android browser). In this case, assume highp is available.
         if (gl.getShaderPrecisionFormat) {
             const vertexShaderPrecisionHighpFloat = gl.getShaderPrecisionFormat(gl.VERTEX_SHADER, gl.HIGH_FLOAT);
             const vertexShaderPrecisionMediumpFloat = gl.getShaderPrecisionFormat(gl.VERTEX_SHADER, gl.MEDIUM_FLOAT);

--- a/src/graphics/graphics-device.js
+++ b/src/graphics/graphics-device.js
@@ -3560,10 +3560,6 @@ class GraphicsDevice extends EventHandler {
      *
      * @type {boolean}
      */
-    get fullscreen() {
-        return !!document.fullscreenElement;
-    }
-
     set fullscreen(fullscreen) {
         if (fullscreen) {
             const canvas = this.gl.canvas;
@@ -3573,18 +3569,22 @@ class GraphicsDevice extends EventHandler {
         }
     }
 
+    get fullscreen() {
+        return !!document.fullscreenElement;
+    }
+
     /**
      * Automatic instancing.
      *
      * @type {boolean}
      * @private
      */
-    get enableAutoInstancing() {
-        return this._enableAutoInstancing;
-    }
-
     set enableAutoInstancing(value) {
         this._enableAutoInstancing = value && this.extInstancing;
+    }
+
+    get enableAutoInstancing() {
+        return this._enableAutoInstancing;
     }
 
     /**
@@ -3592,13 +3592,13 @@ class GraphicsDevice extends EventHandler {
      *
      * @type {number}
      */
-    get maxPixelRatio() {
-        return this._maxPixelRatio;
-    }
-
     set maxPixelRatio(ratio) {
         this._maxPixelRatio = ratio;
         this.resizeCanvas(this._width, this._height);
+    }
+
+    get maxPixelRatio() {
+        return this._maxPixelRatio;
     }
 
     /**

--- a/src/graphics/texture.js
+++ b/src/graphics/texture.js
@@ -267,15 +267,15 @@ class Texture {
      *
      * @type {number}
      */
-    get minFilter() {
-        return this._minFilter;
-    }
-
     set minFilter(v) {
         if (this._minFilter !== v) {
             this._minFilter = v;
             this._parameterFlags |= 1;
         }
+    }
+
+    get minFilter() {
+        return this._minFilter;
     }
 
     /**
@@ -286,15 +286,15 @@ class Texture {
      *
      * @type {number}
      */
-    get magFilter() {
-        return this._magFilter;
-    }
-
     set magFilter(v) {
         if (this._magFilter !== v) {
             this._magFilter = v;
             this._parameterFlags |= 2;
         }
+    }
+
+    get magFilter() {
+        return this._magFilter;
     }
 
     /**
@@ -306,15 +306,15 @@ class Texture {
      *
      * @type {number}
      */
-    get addressU() {
-        return this._addressU;
-    }
-
     set addressU(v) {
         if (this._addressU !== v) {
             this._addressU = v;
             this._parameterFlags |= 4;
         }
+    }
+
+    get addressU() {
+        return this._addressU;
     }
 
     /**
@@ -326,15 +326,15 @@ class Texture {
      *
      * @type {number}
      */
-    get addressV() {
-        return this._addressV;
-    }
-
     set addressV(v) {
         if (this._addressV !== v) {
             this._addressV = v;
             this._parameterFlags |= 8;
         }
+    }
+
+    get addressV() {
+        return this._addressV;
     }
 
     /**
@@ -346,10 +346,6 @@ class Texture {
      *
      * @type {number}
      */
-    get addressW() {
-        return this._addressW;
-    }
-
     set addressW(addressW) {
         if (!this.device.webgl2) return;
         if (!this._volume) {
@@ -362,6 +358,10 @@ class Texture {
         }
     }
 
+    get addressW() {
+        return this._addressW;
+    }
+
     /**
      * When enabled, and if texture format is {@link PIXELFORMAT_DEPTH} or
      * {@link PIXELFORMAT_DEPTHSTENCIL}, hardware PCF is enabled for this texture, and you can get
@@ -369,15 +369,15 @@ class Texture {
      *
      * @type {boolean}
      */
-    get compareOnRead() {
-        return this._compareOnRead;
-    }
-
     set compareOnRead(v) {
         if (this._compareOnRead !== v) {
             this._compareOnRead = v;
             this._parameterFlags |= 32;
         }
+    }
+
+    get compareOnRead() {
+        return this._compareOnRead;
     }
 
     /**
@@ -392,15 +392,15 @@ class Texture {
      *
      * @type {number}
      */
-    get compareFunc() {
-        return this._compareFunc;
-    }
-
     set compareFunc(v) {
         if (this._compareFunc !== v) {
             this._compareFunc = v;
             this._parameterFlags |= 64;
         }
+    }
+
+    get compareFunc() {
+        return this._compareFunc;
     }
 
     /**
@@ -409,15 +409,15 @@ class Texture {
      *
      * @type {number}
      */
-    get anisotropy() {
-        return this._anisotropy;
-    }
-
     set anisotropy(v) {
         if (this._anisotropy !== v) {
             this._anisotropy = v;
             this._parameterFlags |= 128;
         }
+    }
+
+    get anisotropy() {
+        return this._anisotropy;
     }
 
     /**
@@ -427,12 +427,12 @@ class Texture {
      * @private
      * @deprecated
      */
-    get autoMipmap() {
-        return this._mipmaps;
-    }
-
     set autoMipmap(v) {
         this._mipmaps = v;
+    }
+
+    get autoMipmap() {
+        return this._mipmaps;
     }
 
     /**
@@ -440,15 +440,15 @@ class Texture {
      *
      * @type {boolean}
      */
-    get mipmaps() {
-        return this._mipmaps;
-    }
-
     set mipmaps(v) {
         if (this._mipmaps !== v) {
             this._mipmaps = v;
             if (v) this._needsMipmapsUpload = true;
         }
+    }
+
+    get mipmaps() {
+        return this._mipmaps;
     }
 
     /**
@@ -542,10 +542,6 @@ class Texture {
      *
      * @type {boolean}
      */
-    get flipY() {
-        return this._flipY;
-    }
-
     set flipY(flipY) {
         if (this._flipY !== flipY) {
             this._flipY = flipY;
@@ -553,8 +549,8 @@ class Texture {
         }
     }
 
-    get premultiplyAlpha() {
-        return this._premultiplyAlpha;
+    get flipY() {
+        return this._flipY;
     }
 
     set premultiplyAlpha(premultiplyAlpha) {
@@ -564,6 +560,10 @@ class Texture {
         }
     }
 
+    get premultiplyAlpha() {
+        return this._premultiplyAlpha;
+    }
+
     /**
      * Returns true if all dimensions of the texture are power of two, and false otherwise.
      *
@@ -571,6 +571,23 @@ class Texture {
      */
     get pot() {
         return math.powerOfTwo(this._width) && math.powerOfTwo(this._height);
+    }
+
+    // get the texture's encoding type
+    get encoding() {
+        if (this.type === TEXTURETYPE_RGBM) {
+            return 'rgbm';
+        }
+
+        if (this.type === TEXTURETYPE_RGBE) {
+            return 'rgbe';
+        }
+
+        if (this.format === PIXELFORMAT_RGBA16F || this.format === PIXELFORMAT_RGBA32F) {
+            return 'linear';
+        }
+
+        return 'srgb';
     }
 
     // static functions
@@ -993,23 +1010,6 @@ class Texture {
         }
 
         return buff;
-    }
-
-    // get the texture's encoding type
-    get encoding() {
-        if (this.type === TEXTURETYPE_RGBM) {
-            return 'rgbm';
-        }
-
-        if (this.type === TEXTURETYPE_RGBE) {
-            return 'rgbe';
-        }
-
-        if (this.format === PIXELFORMAT_RGBA16F || this.format === PIXELFORMAT_RGBA32F) {
-            return 'linear';
-        }
-
-        return 'srgb';
     }
 }
 

--- a/src/i18n/i18n.js
+++ b/src/i18n/i18n.js
@@ -49,7 +49,7 @@ class I18n extends EventHandler {
      *
      * @type {number[]|Asset[]}
      */
-     set assets(value) {
+    set assets(value) {
         const index = {};
 
         // convert array to dict

--- a/src/input/element-input.js
+++ b/src/input/element-input.js
@@ -168,14 +168,6 @@ class ElementInputEvent {
 /**
  * Represents a Mouse event fired on a {@link ElementComponent}.
  *
- * @property {boolean} ctrlKey Whether the ctrl key was pressed.
- * @property {boolean} altKey Whether the alt key was pressed.
- * @property {boolean} shiftKey Whether the shift key was pressed.
- * @property {boolean} metaKey Whether the meta key was pressed.
- * @property {number} button The mouse button.
- * @property {number} dx The amount of horizontal movement of the cursor.
- * @property {number} dy The amount of vertical movement of the cursor.
- * @property {number} wheelDelta The amount of the wheel movement.
  * @augments ElementInputEvent
  */
 class ElementMouseEvent extends ElementInputEvent {
@@ -198,24 +190,65 @@ class ElementMouseEvent extends ElementInputEvent {
         this.x = x;
         this.y = y;
 
+        /**
+         * Whether the ctrl key was pressed.
+         *
+         * @type {boolean}
+         */
         this.ctrlKey = event.ctrlKey || false;
+        /**
+         * Whether the alt key was pressed.
+         *
+         * @type {boolean}
+         */
         this.altKey = event.altKey || false;
+        /**
+         * Whether the shift key was pressed.
+         *
+         * @type {boolean}
+         */
         this.shiftKey = event.shiftKey || false;
+        /**
+         * Whether the meta key was pressed.
+         *
+         * @type {boolean}
+         */
         this.metaKey = event.metaKey || false;
 
+        /**
+         * The mouse button.
+         *
+         * @type {number}
+         */
         this.button = event.button;
 
         if (Mouse.isPointerLocked()) {
+            /**
+             * The amount of horizontal movement of the cursor.
+             *
+             * @type {number}
+             */
             this.dx = event.movementX || event.webkitMovementX || event.mozMovementX || 0;
+            /**
+             * The amount of vertical movement of the cursor.
+             *
+             * @type {number}
+             */
             this.dy = event.movementY || event.webkitMovementY || event.mozMovementY || 0;
         } else {
             this.dx = x - lastX;
             this.dy = y - lastY;
         }
 
+        /**
+         * The amount of the wheel movement.
+         *
+         * @type {number}
+         */
+        this.wheelDelta = 0;
+
         // deltaY is in a different range across different browsers. The only thing
         // that is consistent is the sign of the value so snap to -1/+1.
-        this.wheelDelta = 0;
         if (event.type === 'wheel') {
             if (event.deltaY > 0) {
                 this.wheelDelta = 1;
@@ -229,11 +262,6 @@ class ElementMouseEvent extends ElementInputEvent {
 /**
  * Represents a TouchEvent fired on a {@link ElementComponent}.
  *
- * @property {Touch[]} touches The Touch objects representing all current points of contact with
- * the surface, regardless of target or changed status.
- * @property {Touch[]} changedTouches The Touch objects representing individual points of contact
- * whose states changed between the previous touch event and this one.
- * @property {Touch} touch The touch object that triggered the event.
  * @augments ElementInputEvent
  */
 class ElementTouchEvent extends ElementInputEvent {
@@ -252,10 +280,27 @@ class ElementTouchEvent extends ElementInputEvent {
     constructor(event, element, camera, x, y, touch) {
         super(event, element, camera);
 
+        /**
+         * The Touch objects representing all current points of contact with the surface,
+         * regardless of target or changed status.
+         *
+         * @type {Touch[]}
+         */
         this.touches = event.touches;
+        /**
+         * The Touch objects representing individual points of contact whose states changed between
+         * the previous touch event and this one.
+         *
+         * @type {Touch[]}
+         */
         this.changedTouches = event.changedTouches;
         this.x = x;
         this.y = y;
+        /**
+         * The touch object that triggered the event.
+         *
+         * @type {Touch}
+         */
         this.touch = touch;
     }
 }

--- a/src/input/element-input.js
+++ b/src/input/element-input.js
@@ -343,6 +343,22 @@ class ElementInput {
         this.attach(domElement);
     }
 
+    set enabled(value) {
+        this._enabled = value;
+    }
+
+    get enabled() {
+        return this._enabled;
+    }
+
+    set app(value) {
+        this._app = value;
+    }
+
+    get app() {
+        return this._app || getApplication();
+    }
+
     /**
      * Attach mouse and touch events to a DOM element.
      *
@@ -1127,22 +1143,6 @@ class ElementInput {
         const corners = this._buildHitCorners(element, screen ? element.screenCorners : element.worldCorners, scale.x, scale.y, scale.z);
 
         return intersectLineQuad(ray.origin, ray.end, corners);
-    }
-
-    get enabled() {
-        return this._enabled;
-    }
-
-    set enabled(value) {
-        this._enabled = value;
-    }
-
-    get app() {
-        return this._app || getApplication();
-    }
-
-    set app(value) {
-        this._app = value;
     }
 }
 

--- a/src/math/color.js
+++ b/src/math/color.js
@@ -2,11 +2,6 @@ import { math } from '../math/math.js';
 
 /**
  * Representation of an RGBA color.
- *
- * @property {number} r The red component of the color.
- * @property {number} g The green component of the color.
- * @property {number} b The blue component of the color.
- * @property {number} a The alpha component of the color.
  */
 class Color {
     /**
@@ -21,9 +16,29 @@ class Color {
     constructor(r = 0, g = 0, b = 0, a = 1) {
         const length = r.length;
         if (length === 3 || length === 4) {
+            /**
+             * The red component of the color.
+             *
+             * @type {number}
+             */
             this.r = r[0];
+            /**
+             * The green component of the color.
+             *
+             * @type {number}
+             */
             this.g = r[1];
+            /**
+             * The blue component of the color.
+             *
+             * @type {number}
+             */
             this.b = r[2];
+            /**
+             * The alpha component of the color.
+             *
+             * @type {number}
+             */
             this.a = r[3] !== undefined ? r[3] : 1;
         } else {
             this.r = r;

--- a/src/math/curve-set.js
+++ b/src/math/curve-set.js
@@ -54,6 +54,38 @@ class CurveSet {
     }
 
     /**
+     * The number of curves in the curve set.
+     *
+     * @type {number}
+     */
+     get length() {
+        return this.curves.length;
+    }
+
+    /**
+     * The interpolation scheme applied to all curves in the curve set. Can be:
+     *
+     * - {@link CURVE_LINEAR}
+     * - {@link CURVE_SMOOTHSTEP}
+     * - {@link CURVE_SPLINE}
+     * - {@link CURVE_STEP}
+     *
+     * Defaults to {@link CURVE_SMOOTHSTEP}.
+     *
+     * @type {number}
+     */
+    set type(value) {
+        this._type = value;
+        for (let i = 0; i < this.curves.length; i++) {
+            this.curves[i].type = value;
+        }
+    }
+
+    get type() {
+        return this._type;
+    }
+
+    /**
      * Return a specific curve in the curve set.
      *
      * @param {number} index - The index of the curve to return.
@@ -134,38 +166,6 @@ class CurveSet {
             result[i] = Math.min(max, Math.max(min, result[i]));
         }
         return result;
-    }
-
-    /**
-     * The number of curves in the curve set.
-     *
-     * @type {number}
-     */
-    get length() {
-        return this.curves.length;
-    }
-
-    /**
-     * The interpolation scheme applied to all curves in the curve set. Can be:
-     *
-     * - {@link CURVE_LINEAR}
-     * - {@link CURVE_SMOOTHSTEP}
-     * - {@link CURVE_SPLINE}
-     * - {@link CURVE_STEP}
-     *
-     * Defaults to {@link CURVE_SMOOTHSTEP}.
-     *
-     * @type {number}
-     */
-    get type() {
-        return this._type;
-    }
-
-    set type(value) {
-        this._type = value;
-        for (let i = 0; i < this.curves.length; i++) {
-            this.curves[i].type = value;
-        }
     }
 }
 

--- a/src/math/curve-set.js
+++ b/src/math/curve-set.js
@@ -58,7 +58,7 @@ class CurveSet {
      *
      * @type {number}
      */
-     get length() {
+    get length() {
         return this.curves.length;
     }
 

--- a/src/math/mat3.js
+++ b/src/math/mat3.js
@@ -4,8 +4,6 @@ import { Vec3 } from './vec3.js';
 
 /**
  * A 3x3 matrix.
- *
- * @property {Float32Array} data Matrix elements in the form of a flat array.
  */
 class Mat3 {
     /**
@@ -16,6 +14,12 @@ class Mat3 {
         // to zero by default, so we only need to set the relevant elements to one.
         const data = new Float32Array(9);
         data[0] = data[4] = data[8] = 1;
+
+        /**
+         * Matrix elements in the form of a flat array.
+         *
+         * @type {Float32Array}
+         */
         this.data = data;
     }
 

--- a/src/math/mat4.js
+++ b/src/math/mat4.js
@@ -14,8 +14,6 @@ const scale = new Vec3();
 
 /**
  * A 4x4 matrix.
- *
- * @property {Float32Array} data Matrix elements in the form of a flat array.
  */
 class Mat4 {
     /**
@@ -26,6 +24,12 @@ class Mat4 {
         // to zero by default, so we only need to set the relevant elements to one.
         const data = new Float32Array(16);
         data[0] = data[5] = data[10] = data[15] = 1;
+
+        /**
+         * Matrix elements in the form of a flat array.
+         *
+         * @type {Float32Array}
+         */
         this.data = data;
     }
 

--- a/src/math/quat.js
+++ b/src/math/quat.js
@@ -8,66 +8,6 @@ import { Vec3 } from './vec3.js';
  */
 class Quat {
     /**
-     * @field
-     * @name Quat#x
-     * @type {number}
-     * @description The x component of the quaternion.
-     * @example
-     * var quat = new pc.Quat();
-     *
-     * // Get x
-     * var x = quat.x;
-     *
-     * // Set x
-     * quat.x = 0;
-     */
-
-    /**
-     * @field
-     * @name Quat#y
-     * @type {number}
-     * @description The y component of the quaternion.
-     * @example
-     * var quat = new pc.Quat();
-     *
-     * // Get y
-     * var y = quat.y;
-     *
-     * // Set y
-     * quat.y = 0;
-     */
-
-    /**
-     * @field
-     * @name Quat#z
-     * @type {number}
-     * @description The z component of the quaternion.
-     * @example
-     * var quat = new pc.Quat();
-     *
-     * // Get z
-     * var z = quat.z;
-     *
-     * // Set z
-     * quat.z = 0;
-     */
-
-    /**
-     * @field
-     * @name Quat#w
-     * @type {number}
-     * @description The w component of the quaternion.
-     * @example
-     * var quat = new pc.Quat();
-     *
-     * // Get w
-     * var w = quat.w;
-     *
-     * // Set w
-     * quat.w = 0;
-     */
-
-    /**
      * Create a new Quat instance.
      *
      * @param {number|number[]} [x] - The quaternion's x component. Default value 0. If x is an
@@ -78,9 +18,29 @@ class Quat {
      */
     constructor(x = 0, y = 0, z = 0, w = 1) {
         if (x.length === 4) {
+            /**
+             * The x component of the quaternion.
+             *
+             * @type {number}
+             */
             this.x = x[0];
+            /**
+             * The y component of the quaternion.
+             *
+             * @type {number}
+             */
             this.y = x[1];
+            /**
+             * The z component of the quaternion.
+             *
+             * @type {number}
+             */
             this.z = x[2];
+            /**
+             * The w component of the quaternion.
+             *
+             * @type {number}
+             */
             this.w = x[3];
         } else {
             this.x = x;

--- a/src/math/vec2.js
+++ b/src/math/vec2.js
@@ -3,38 +3,6 @@
  */
 class Vec2 {
     /**
-     * The first element of the vector.
-     *
-     * @field
-     * @name Vec2#x
-     * @type {number}
-     * @example
-     * var vec = new pc.Vec2(10, 20);
-     *
-     * // Get x
-     * var x = vec.x;
-     *
-     * // Set x
-     * vec.x = 0;
-     */
-
-    /**
-     * The second element of the vector.
-     *
-     * @field
-     * @name Vec2#y
-     * @type {number}
-     * @example
-     * var vec = new pc.Vec2(10, 20);
-     *
-     * // Get y
-     * var y = vec.y;
-     *
-     * // Set y
-     * vec.y = 0;
-     */
-
-    /**
      * Create a new Vec2 instance.
      *
      * @param {number|number[]} [x] - The x value. If x is an array of length 2, the array will be
@@ -45,7 +13,17 @@ class Vec2 {
      */
     constructor(x = 0, y = 0) {
         if (x.length === 2) {
+            /**
+             * The first component of the vector.
+             *
+             * @type {number}
+             */
             this.x = x[0];
+             /**
+              * The second component of the vector.
+              *
+              * @type {number}
+              */
             this.y = x[1];
         } else {
             this.x = x;

--- a/src/math/vec3.js
+++ b/src/math/vec3.js
@@ -3,51 +3,6 @@
  */
 class Vec3 {
     /**
-     * The first component of the vector.
-     *
-     * @name Vec3#x
-     * @type {number}
-     * @example
-     * var vec = new pc.Vec3(10, 20, 30);
-     *
-     * // Get x
-     * var x = vec.x;
-     *
-     * // Set x
-     * vec.x = 0;
-     */
-
-    /**
-     * The second component of the vector.
-     *
-     * @name Vec3#y
-     * @type {number}
-     * @example
-     * var vec = new pc.Vec3(10, 20, 30);
-     *
-     * // Get y
-     * var y = vec.y;
-     *
-     * // Set y
-     * vec.y = 0;
-     */
-
-    /**
-     * The third component of the vector.
-     *
-     * @name Vec3#z
-     * @type {number}
-     * @example
-     * var vec = new pc.Vec3(10, 20, 30);
-     *
-     * // Get z
-     * var z = vec.z;
-     *
-     * // Set z
-     * vec.z = 0;
-     */
-
-    /**
      * Creates a new Vec3 object.
      *
      * @param {number|number[]} [x] - The x value. If x is an array of length 3, the array will be
@@ -59,8 +14,23 @@ class Vec3 {
      */
     constructor(x = 0, y = 0, z = 0) {
         if (x.length === 3) {
+            /**
+             * The first component of the vector.
+             *
+             * @type {number}
+             */
             this.x = x[0];
+             /**
+              * The second component of the vector.
+              *
+              * @type {number}
+              */
             this.y = x[1];
+             /**
+              * The third component of the vector.
+              *
+              * @type {number}
+              */
             this.z = x[2];
         } else {
             this.x = x;

--- a/src/math/vec4.js
+++ b/src/math/vec4.js
@@ -3,70 +3,6 @@
  */
 class Vec4 {
     /**
-     * The first component of the vector.
-     *
-     * @field
-     * @name Vec4#x
-     * @type {number}
-     * @example
-     * var vec = new pc.Vec4(10, 20, 30, 40);
-     *
-     * // Get x
-     * var x = vec.x;
-     *
-     * // Set x
-     * vec.x = 0;
-     */
-
-    /**
-     * The second component of the vector.
-     *
-     * @field
-     * @name Vec4#y
-     * @type {number}
-     * @example
-     * var vec = new pc.Vec4(10, 20, 30, 40);
-     *
-     * // Get y
-     * var y = vec.y;
-     *
-     * // Set y
-     * vec.y = 0;
-     */
-
-    /**
-     * The third component of the vector.
-     *
-     * @field
-     * @name Vec4#z
-     * @type {number}
-     * @example
-     * var vec = new pc.Vec4(10, 20, 30, 40);
-     *
-     * // Get z
-     * var z = vec.z;
-     *
-     * // Set z
-     * vec.z = 0;
-     */
-
-    /**
-     * The fourth component of the vector.
-     *
-     * @field
-     * @name Vec4#w
-     * @type {number}
-     * @example
-     * var vec = new pc.Vec4(10, 20, 30, 40);
-     *
-     * // Get w
-     * var w = vec.w;
-     *
-     * // Set w
-     * vec.w = 0;
-     */
-
-    /**
      * Creates a new Vec4 object.
      *
      * @param {number|number[]} [x] - The x value. If x is an array of length 4, the array will be
@@ -79,9 +15,29 @@ class Vec4 {
      */
     constructor(x = 0, y = 0, z = 0, w = 0) {
         if (x.length === 4) {
+            /**
+             * The first component of the vector.
+             *
+             * @type {number}
+             */
             this.x = x[0];
+            /**
+             * The second component of the vector.
+             *
+             * @type {number}
+             */
             this.y = x[1];
+            /**
+             * The third component of the vector.
+             *
+             * @type {number}
+             */
             this.z = x[2];
+            /**
+             * The fourth component of the vector.
+             *
+             * @type {number}
+             */
             this.w = x[3];
         } else {
             this.x = x;

--- a/src/resources/texture.js
+++ b/src/resources/texture.js
@@ -184,16 +184,12 @@ class TextureHandler {
         };
     }
 
-    get crossOrigin() {
-        return this.imgParser.crossOrigin;
-    }
-
     set crossOrigin(value) {
         this.imgParser.crossOrigin = value;
     }
 
-    get maxRetries() {
-        return this.imgParser.maxRetries;
+    get crossOrigin() {
+        return this.imgParser.crossOrigin;
     }
 
     set maxRetries(value) {
@@ -203,6 +199,10 @@ class TextureHandler {
                 this.parsers[parser].maxRetries = value;
             }
         }
+    }
+
+    get maxRetries() {
+        return this.imgParser.maxRetries;
     }
 
     _getUrlWithoutParams(url) {

--- a/src/scene/camera.js
+++ b/src/scene/camera.js
@@ -62,10 +62,6 @@ class Camera {
         this.frustum = new Frustum();
     }
 
-    get aspectRatio() {
-        return this._aspectRatio;
-    }
-
     set aspectRatio(newValue) {
         if (this._aspectRatio !== newValue) {
             this._aspectRatio = newValue;
@@ -73,8 +69,8 @@ class Camera {
         }
     }
 
-    get aspectRatioMode() {
-        return this._aspectRatioMode;
+    get aspectRatio() {
+        return this._aspectRatio;
     }
 
     set aspectRatioMode(newValue) {
@@ -84,8 +80,8 @@ class Camera {
         }
     }
 
-    get calculateProjection() {
-        return this._calculateProjection;
+    get aspectRatioMode() {
+        return this._aspectRatioMode;
     }
 
     set calculateProjection(newValue) {
@@ -93,80 +89,80 @@ class Camera {
         this._projMatDirty = true;
     }
 
-    get calculateTransform() {
-        return this._calculateTransform;
+    get calculateProjection() {
+        return this._calculateProjection;
     }
 
     set calculateTransform(newValue) {
         this._calculateTransform = newValue;
     }
 
-    get clearColor() {
-        return this._clearColor;
+    get calculateTransform() {
+        return this._calculateTransform;
     }
 
     set clearColor(newValue) {
         this._clearColor.copy(newValue);
     }
 
-    get clearColorBuffer() {
-        return this._clearColorBuffer;
+    get clearColor() {
+        return this._clearColor;
     }
 
     set clearColorBuffer(newValue) {
         this._clearColorBuffer = newValue;
     }
 
-    get clearDepth() {
-        return this._clearDepth;
+    get clearColorBuffer() {
+        return this._clearColorBuffer;
     }
 
     set clearDepth(newValue) {
         this._clearDepth = newValue;
     }
 
-    get clearDepthBuffer() {
-        return this._clearDepthBuffer;
+    get clearDepth() {
+        return this._clearDepth;
     }
 
     set clearDepthBuffer(newValue) {
         this._clearDepthBuffer = newValue;
     }
 
-    get clearStencil() {
-        return this._clearStencil;
+    get clearDepthBuffer() {
+        return this._clearDepthBuffer;
     }
 
     set clearStencil(newValue) {
         this._clearStencil = newValue;
     }
 
-    get clearStencilBuffer() {
-        return this._clearStencilBuffer;
+    get clearStencil() {
+        return this._clearStencil;
     }
 
     set clearStencilBuffer(newValue) {
         this._clearStencilBuffer = newValue;
     }
 
-    get cullingMask() {
-        return this._cullingMask;
+    get clearStencilBuffer() {
+        return this._clearStencilBuffer;
     }
 
     set cullingMask(newValue) {
         this._cullingMask = newValue;
     }
 
-    get cullFaces() {
-        return this._cullFaces;
+    get cullingMask() {
+        return this._cullingMask;
     }
 
     set cullFaces(newValue) {
         this._cullFaces = newValue;
     }
 
-    get farClip() {
-        return this._farClip;
+    get cullFaces() {
+        return this._cullFaces;
     }
 
     set farClip(newValue) {
@@ -176,16 +172,16 @@ class Camera {
         }
     }
 
-    get flipFaces() {
-        return this._flipFaces;
+    get farClip() {
+        return this._farClip;
     }
 
     set flipFaces(newValue) {
         this._flipFaces = newValue;
     }
 
-    get fov() {
-        return this._fov;
+    get flipFaces() {
+        return this._flipFaces;
     }
 
     set fov(newValue) {
@@ -195,16 +191,16 @@ class Camera {
         }
     }
 
-    get frustumCulling() {
-        return this._frustumCulling;
+    get fov() {
+        return this._fov;
     }
 
     set frustumCulling(newValue) {
         this._frustumCulling = newValue;
     }
 
-    get horizontalFov() {
-        return this._horizontalFov;
+    get frustumCulling() {
+        return this._frustumCulling;
     }
 
     set horizontalFov(newValue) {
@@ -214,16 +210,16 @@ class Camera {
         }
     }
 
-    get layers() {
-        return this._layers;
+    get horizontalFov() {
+        return this._horizontalFov;
     }
 
     set layers(newValue) {
         this._layers = newValue.slice(0);
     }
 
-    get nearClip() {
-        return this._nearClip;
+    get layers() {
+        return this._layers;
     }
 
     set nearClip(newValue) {
@@ -233,16 +229,16 @@ class Camera {
         }
     }
 
-    get node() {
-        return this._node;
+    get nearClip() {
+        return this._nearClip;
     }
 
     set node(newValue) {
         this._node = newValue;
     }
 
-    get orthoHeight() {
-        return this._orthoHeight;
+    get node() {
+        return this._node;
     }
 
     set orthoHeight(newValue) {
@@ -252,8 +248,8 @@ class Camera {
         }
     }
 
-    get projection() {
-        return this._projection;
+    get orthoHeight() {
+        return this._orthoHeight;
     }
 
     set projection(newValue) {
@@ -263,33 +259,37 @@ class Camera {
         }
     }
 
+    get projection() {
+        return this._projection;
+    }
+
     get projectionMatrix() {
         this._evaluateProjectionMatrix();
         return this._projMat;
-    }
-
-    get rect() {
-        return this._rect;
     }
 
     set rect(newValue) {
         this._rect.copy(newValue);
     }
 
-    get renderTarget() {
-        return this._renderTarget;
+    get rect() {
+        return this._rect;
     }
 
     set renderTarget(newValue) {
         this._renderTarget = newValue;
     }
 
-    get scissorRect() {
-        return this._scissorRect;
+    get renderTarget() {
+        return this._renderTarget;
     }
 
     set scissorRect(newValue) {
         this._scissorRect.copy(newValue);
+    }
+
+    get scissorRect() {
+        return this._scissorRect;
     }
 
     get viewMatrix() {
@@ -301,15 +301,15 @@ class Camera {
         return this._viewMat;
     }
 
-    get vrDisplay() {
-        return this._vrDisplay;
-    }
-
     set vrDisplay(newValue) {
         this._vrDisplay = newValue;
         if (newValue) {
             newValue._camera = this;
         }
+    }
+
+    get vrDisplay() {
+        return this._vrDisplay;
     }
 
     /**

--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -145,13 +145,6 @@ class GraphNode extends EventHandler {
      *
      * @type {boolean}
      */
-    get enabled() {
-        // make sure to check this._enabled too because if that
-        // was false when a parent was updated the _enabledInHierarchy
-        // flag may not have been updated for optimization purposes
-        return this._enabled && this._enabledInHierarchy;
-    }
-
     set enabled(enabled) {
         if (this._enabled !== enabled) {
             this._enabled = enabled;
@@ -159,6 +152,13 @@ class GraphNode extends EventHandler {
             if (!this._parent || this._parent.enabled)
                 this._notifyHierarchyStateChanged(this, enabled);
         }
+    }
+
+    get enabled() {
+        // make sure to check this._enabled too because if that
+        // was false when a parent was updated the _enabledInHierarchy
+        // flag may not have been updated for optimization purposes
+        return this._enabled && this._enabledInHierarchy;
     }
 
     /**

--- a/src/scene/layer.js
+++ b/src/scene/layer.js
@@ -304,17 +304,13 @@ class Layer {
         this._lightCube = null;
     }
 
-    get renderTarget() {
-        return this._renderTarget;
-    }
-
     set renderTarget(rt) {
         this._renderTarget = rt;
         this._dirtyCameras = true;
     }
 
-    get enabled() {
-        return this._enabled;
+    get renderTarget() {
+        return this._renderTarget;
     }
 
     set enabled(val) {
@@ -330,16 +326,16 @@ class Layer {
         }
     }
 
-    get clearColor() {
-        return this._clearColor;
+    get enabled() {
+        return this._enabled;
     }
 
     set clearColor(val) {
         this._clearColor.copy(val);
     }
 
-    get clearColorBuffer() {
-        return this._clearColorBuffer;
+    get clearColor() {
+        return this._clearColor;
     }
 
     set clearColorBuffer(val) {
@@ -347,8 +343,8 @@ class Layer {
         this._dirtyCameras = true;
     }
 
-    get clearDepthBuffer() {
-        return this._clearDepthBuffer;
+    get clearColorBuffer() {
+        return this._clearColorBuffer;
     }
 
     set clearDepthBuffer(val) {
@@ -356,13 +352,17 @@ class Layer {
         this._dirtyCameras = true;
     }
 
-    get clearStencilBuffer() {
-        return this._clearStencilBuffer;
+    get clearDepthBuffer() {
+        return this._clearDepthBuffer;
     }
 
     set clearStencilBuffer(val) {
         this._clearStencilBuffer = val;
         this._dirtyCameras = true;
+    }
+
+    get clearStencilBuffer() {
+        return this._clearStencilBuffer;
     }
 
     /**

--- a/src/scene/light.js
+++ b/src/scene/light.js
@@ -178,6 +178,316 @@ class Light {
         this.visibleThisFrame = false;
     }
 
+    set numCascades(value) {
+        if (!this.cascades || this.numCascades != value) {
+            this.cascades = directionalCascades[value - 1];
+            this._shadowMatrixPalette = new Float32Array(4 * 16);   // always 4
+            this._shadowCascadeDistances = new Float32Array(4);     // always 4
+            this._destroyShadowMap();
+            this.updateKey();
+        }
+    }
+
+    get numCascades() {
+        return this.cascades.length;
+    }
+
+    set shadowMap(shadowMap) {
+        if (this._shadowMap !== shadowMap) {
+            this._destroyShadowMap();
+            this._shadowMap = shadowMap;
+        }
+    }
+
+    get shadowMap() {
+        return this._shadowMap;
+    }
+
+    // returns number of render targets to render the shadow map
+    get numShadowFaces() {
+        const type = this._type;
+        if (type === LIGHTTYPE_DIRECTIONAL) {
+            return this.numCascades;
+        } else if (type === LIGHTTYPE_OMNI) {
+            return 6;
+        }
+
+        return 1;
+    }
+
+    set type(value) {
+        if (this._type === value)
+            return;
+
+        this._type = value;
+        this._destroyShadowMap();
+        this.updateKey();
+
+        const stype = this._shadowType;
+        this._shadowType = null;
+        this.shadowType = stype; // refresh shadow type; switching from direct/spot to omni and back may change it
+    }
+
+    get type() {
+        return this._type;
+    }
+
+    set shape(value) {
+        if (this._shape === value)
+            return;
+
+        this._shape = value;
+        this._destroyShadowMap();
+        this.updateKey();
+
+        const stype = this._shadowType;
+        this._shadowType = null;
+        this.shadowType = stype; // refresh shadow type; switching shape and back may change it
+    }
+
+    get shape() {
+        return this._shape;
+    }
+
+    set shadowType(value) {
+        if (this._shadowType === value)
+            return;
+
+        const device = this.device;
+
+        if (this._type === LIGHTTYPE_OMNI)
+            value = SHADOW_PCF3; // VSM or HW PCF for omni lights is not supported yet
+
+        if (value === SHADOW_PCF5 && !device.webgl2) {
+            value = SHADOW_PCF3; // fallback from HW PCF to old PCF
+        }
+
+        if (value === SHADOW_VSM32 && !device.textureFloatRenderable) // fallback from vsm32 to vsm16
+            value = SHADOW_VSM16;
+
+        if (value === SHADOW_VSM16 && !device.textureHalfFloatRenderable) // fallback from vsm16 to vsm8
+            value = SHADOW_VSM8;
+
+        this._isVsm = value >= SHADOW_VSM8 && value <= SHADOW_VSM32;
+        this._isPcf = value === SHADOW_PCF5 || value === SHADOW_PCF3;
+
+        this._shadowType = value;
+        this._destroyShadowMap();
+        this.updateKey();
+    }
+
+    get shadowType() {
+        return this._shadowType;
+    }
+
+    set enabled(value) {
+        if (this._enabled !== value) {
+            this._enabled = value;
+            this.layersDirty();
+        }
+    }
+
+    get enabled() {
+        return this._enabled;
+    }
+
+    set castShadows(value) {
+        if (this._castShadows !== value) {
+            this._castShadows = value;
+            this._destroyShadowMap();
+            this.layersDirty();
+            this.updateKey();
+        }
+    }
+
+    get castShadows() {
+        return this._castShadows && this.mask !== MASK_LIGHTMAP && this.mask !== 0;
+    }
+
+    set shadowResolution(value) {
+        if (this._shadowResolution !== value) {
+            if (this._type === LIGHTTYPE_OMNI) {
+                value = Math.min(value, this.device.maxCubeMapSize);
+            } else {
+                value = Math.min(value, this.device.maxTextureSize);
+            }
+            this._shadowResolution = value;
+            this._destroyShadowMap();
+        }
+    }
+
+    get shadowResolution() {
+        return this._shadowResolution;
+    }
+
+    set vsmBlurSize(value) {
+        if (this._vsmBlurSize === value)
+            return;
+
+        if (value % 2 === 0) value++; // don't allow even size
+        this._vsmBlurSize = value;
+    }
+
+    get vsmBlurSize() {
+        return this._vsmBlurSize;
+    }
+
+    set normalOffsetBias(value) {
+        if (this._normalOffsetBias === value)
+            return;
+
+        if ((!this._normalOffsetBias && value) || (this._normalOffsetBias && !value)) {
+            this.updateKey();
+        }
+        this._normalOffsetBias = value;
+    }
+
+    get normalOffsetBias() {
+        return this._normalOffsetBias;
+    }
+
+    set falloffMode(value) {
+        if (this._falloffMode === value)
+            return;
+
+        this._falloffMode = value;
+        this.updateKey();
+    }
+
+    get falloffMode() {
+        return this._falloffMode;
+    }
+
+    set innerConeAngle(value) {
+        if (this._innerConeAngle === value)
+            return;
+
+        this._innerConeAngle = value;
+        this._innerConeAngleCos = Math.cos(value * Math.PI / 180);
+    }
+
+    get innerConeAngle() {
+        return this._innerConeAngle;
+    }
+
+    set outerConeAngle(value) {
+        if (this._outerConeAngle === value)
+            return;
+
+        this._outerConeAngle = value;
+        this._outerConeAngleCos = Math.cos(value * Math.PI / 180);
+    }
+
+    get outerConeAngle() {
+        return this._outerConeAngle;
+    }
+
+    set intensity(value) {
+        if (this._intensity !== value) {
+            this._intensity = value;
+            this._updateFinalColor();
+        }
+    }
+
+    get intensity() {
+        return this._intensity;
+    }
+
+    get cookieMatrix() {
+        if (!this._cookieMatrix) {
+            this._cookieMatrix = new Mat4();
+        }
+        return this._cookieMatrix;
+    }
+
+    get atlasViewport() {
+        if (!this._atlasViewport) {
+            this._atlasViewport = new Vec4(0, 0, 1, 1);
+        }
+        return this._atlasViewport;
+    }
+
+    set cookie(value) {
+        if (this._cookie === value)
+            return;
+
+        this._cookie = value;
+        this.updateKey();
+    }
+
+    get cookie() {
+        return this._cookie;
+    }
+
+    set cookieFalloff(value) {
+        if (this._cookieFalloff === value)
+            return;
+
+        this._cookieFalloff = value;
+        this.updateKey();
+    }
+
+    get cookieFalloff() {
+        return this._cookieFalloff;
+    }
+
+    set cookieChannel(value) {
+        if (this._cookieChannel === value)
+            return;
+
+        if (value.length < 3) {
+            const chr = value.charAt(value.length - 1);
+            const addLen = 3 - value.length;
+            for (let i = 0; i < addLen; i++)
+                value += chr;
+        }
+        this._cookieChannel = value;
+        this.updateKey();
+    }
+
+    get cookieChannel() {
+        return this._cookieChannel;
+    }
+
+    set cookieTransform(value) {
+        if (this._cookieTransform === value)
+            return;
+
+        this._cookieTransform = value;
+        this._cookieTransformSet = !!value;
+        if (value && !this._cookieOffset) {
+            this.cookieOffset = new Vec2(); // using transform forces using offset code
+            this._cookieOffsetSet = false;
+        }
+        this.updateKey();
+    }
+
+    get cookieTransform() {
+        return this._cookieTransform;
+    }
+
+    set cookieOffset(value) {
+        if (this._cookieOffset === value)
+            return;
+
+        const xformNew = !!(this._cookieTransformSet || value);
+        if (xformNew && !value && this._cookieOffset) {
+            this._cookieOffset.set(0, 0);
+        } else {
+            this._cookieOffset = value;
+        }
+        this._cookieOffsetSet = !!value;
+        if (value && !this._cookieTransform) {
+            this.cookieTransform = new Vec4(1, 1, 0, 0); // using offset forces using matrix code
+            this._cookieTransformSet = false;
+        }
+        this.updateKey();
+    }
+
+    get cookieOffset() {
+        return this._cookieOffset;
+    }
+
     destroy() {
         this._destroyShadowMap();
         this._renderData = null;
@@ -310,43 +620,6 @@ class Light {
         }
 
         return tmpBiases;
-    }
-
-    get numCascades() {
-        return this.cascades.length;
-    }
-
-    set numCascades(value) {
-        if (!this.cascades || this.numCascades != value) {
-            this.cascades = directionalCascades[value - 1];
-            this._shadowMatrixPalette = new Float32Array(4 * 16);   // always 4
-            this._shadowCascadeDistances = new Float32Array(4);     // always 4
-            this._destroyShadowMap();
-            this.updateKey();
-        }
-    }
-
-    get shadowMap() {
-        return this._shadowMap;
-    }
-
-    set shadowMap(shadowMap) {
-        if (this._shadowMap !== shadowMap) {
-            this._destroyShadowMap();
-            this._shadowMap = shadowMap;
-        }
-    }
-
-    // returns number of render targets to render the shadow map
-    get numShadowFaces() {
-        const type = this._type;
-        if (type === LIGHTTYPE_DIRECTIONAL) {
-            return this.numCascades;
-        } else if (type === LIGHTTYPE_OMNI) {
-            return 6;
-        }
-
-        return 1;
     }
 
     getColor() {
@@ -488,279 +761,6 @@ class Light {
         }
 
         this.key = key;
-    }
-
-    get type() {
-        return this._type;
-    }
-
-    set type(value) {
-        if (this._type === value)
-            return;
-
-        this._type = value;
-        this._destroyShadowMap();
-        this.updateKey();
-
-        const stype = this._shadowType;
-        this._shadowType = null;
-        this.shadowType = stype; // refresh shadow type; switching from direct/spot to omni and back may change it
-    }
-
-    get shape() {
-        return this._shape;
-    }
-
-    set shape(value) {
-        if (this._shape === value)
-            return;
-
-        this._shape = value;
-        this._destroyShadowMap();
-        this.updateKey();
-
-        const stype = this._shadowType;
-        this._shadowType = null;
-        this.shadowType = stype; // refresh shadow type; switching shape and back may change it
-    }
-
-    get shadowType() {
-        return this._shadowType;
-    }
-
-    set shadowType(value) {
-        if (this._shadowType === value)
-            return;
-
-        const device = this.device;
-
-        if (this._type === LIGHTTYPE_OMNI)
-            value = SHADOW_PCF3; // VSM or HW PCF for omni lights is not supported yet
-
-        if (value === SHADOW_PCF5 && !device.webgl2) {
-            value = SHADOW_PCF3; // fallback from HW PCF to old PCF
-        }
-
-        if (value === SHADOW_VSM32 && !device.textureFloatRenderable) // fallback from vsm32 to vsm16
-            value = SHADOW_VSM16;
-
-        if (value === SHADOW_VSM16 && !device.textureHalfFloatRenderable) // fallback from vsm16 to vsm8
-            value = SHADOW_VSM8;
-
-        this._isVsm = value >= SHADOW_VSM8 && value <= SHADOW_VSM32;
-        this._isPcf = value === SHADOW_PCF5 || value === SHADOW_PCF3;
-
-        this._shadowType = value;
-        this._destroyShadowMap();
-        this.updateKey();
-    }
-
-    get enabled() {
-        return this._enabled;
-    }
-
-    set enabled(value) {
-        if (this._enabled !== value) {
-            this._enabled = value;
-            this.layersDirty();
-        }
-    }
-
-    get castShadows() {
-        return this._castShadows && this.mask !== MASK_LIGHTMAP && this.mask !== 0;
-    }
-
-    set castShadows(value) {
-        if (this._castShadows !== value) {
-            this._castShadows = value;
-            this._destroyShadowMap();
-            this.layersDirty();
-            this.updateKey();
-        }
-    }
-
-    get shadowResolution() {
-        return this._shadowResolution;
-    }
-
-    set shadowResolution(value) {
-        if (this._shadowResolution !== value) {
-            if (this._type === LIGHTTYPE_OMNI) {
-                value = Math.min(value, this.device.maxCubeMapSize);
-            } else {
-                value = Math.min(value, this.device.maxTextureSize);
-            }
-            this._shadowResolution = value;
-            this._destroyShadowMap();
-        }
-    }
-
-    get vsmBlurSize() {
-        return this._vsmBlurSize;
-    }
-
-    set vsmBlurSize(value) {
-        if (this._vsmBlurSize === value)
-            return;
-
-        if (value % 2 === 0) value++; // don't allow even size
-        this._vsmBlurSize = value;
-    }
-
-    get normalOffsetBias() {
-        return this._normalOffsetBias;
-    }
-
-    set normalOffsetBias(value) {
-        if (this._normalOffsetBias === value)
-            return;
-
-        if ((!this._normalOffsetBias && value) || (this._normalOffsetBias && !value)) {
-            this.updateKey();
-        }
-        this._normalOffsetBias = value;
-    }
-
-    get falloffMode() {
-        return this._falloffMode;
-    }
-
-    set falloffMode(value) {
-        if (this._falloffMode === value)
-            return;
-
-        this._falloffMode = value;
-        this.updateKey();
-    }
-
-    get innerConeAngle() {
-        return this._innerConeAngle;
-    }
-
-    set innerConeAngle(value) {
-        if (this._innerConeAngle === value)
-            return;
-
-        this._innerConeAngle = value;
-        this._innerConeAngleCos = Math.cos(value * Math.PI / 180);
-    }
-
-    get outerConeAngle() {
-        return this._outerConeAngle;
-    }
-
-    set outerConeAngle(value) {
-        if (this._outerConeAngle === value)
-            return;
-
-        this._outerConeAngle = value;
-        this._outerConeAngleCos = Math.cos(value * Math.PI / 180);
-    }
-
-    get intensity() {
-        return this._intensity;
-    }
-
-    set intensity(value) {
-        if (this._intensity !== value) {
-            this._intensity = value;
-            this._updateFinalColor();
-        }
-    }
-
-    get cookieMatrix() {
-        if (!this._cookieMatrix) {
-            this._cookieMatrix = new Mat4();
-        }
-        return this._cookieMatrix;
-    }
-
-    get atlasViewport() {
-        if (!this._atlasViewport) {
-            this._atlasViewport = new Vec4(0, 0, 1, 1);
-        }
-        return this._atlasViewport;
-    }
-
-    get cookie() {
-        return this._cookie;
-    }
-
-    set cookie(value) {
-        if (this._cookie === value)
-            return;
-
-        this._cookie = value;
-        this.updateKey();
-    }
-
-    get cookieFalloff() {
-        return this._cookieFalloff;
-    }
-
-    set cookieFalloff(value) {
-        if (this._cookieFalloff === value)
-            return;
-
-        this._cookieFalloff = value;
-        this.updateKey();
-    }
-
-    get cookieChannel() {
-        return this._cookieChannel;
-    }
-
-    set cookieChannel(value) {
-        if (this._cookieChannel === value)
-            return;
-
-        if (value.length < 3) {
-            const chr = value.charAt(value.length - 1);
-            const addLen = 3 - value.length;
-            for (let i = 0; i < addLen; i++)
-                value += chr;
-        }
-        this._cookieChannel = value;
-        this.updateKey();
-    }
-
-    get cookieTransform() {
-        return this._cookieTransform;
-    }
-
-    set cookieTransform(value) {
-        if (this._cookieTransform === value)
-            return;
-
-        this._cookieTransform = value;
-        this._cookieTransformSet = !!value;
-        if (value && !this._cookieOffset) {
-            this.cookieOffset = new Vec2(); // using transform forces using offset code
-            this._cookieOffsetSet = false;
-        }
-        this.updateKey();
-    }
-
-    get cookieOffset() {
-        return this._cookieOffset;
-    }
-
-    set cookieOffset(value) {
-        if (this._cookieOffset === value)
-            return;
-
-        const xformNew = !!(this._cookieTransformSet || value);
-        if (xformNew && !value && this._cookieOffset) {
-            this._cookieOffset.set(0, 0);
-        } else {
-            this._cookieOffset = value;
-        }
-        this._cookieOffsetSet = !!value;
-        if (value && !this._cookieTransform) {
-            this.cookieTransform = new Vec4(1, 1, 0, 0); // using offset forces using matrix code
-            this._cookieTransformSet = false;
-        }
-        this.updateKey();
     }
 }
 

--- a/src/scene/lighting/lighting-params.js
+++ b/src/scene/lighting/lighting-params.js
@@ -21,40 +21,36 @@ class LightingParams {
         this._cookieAtlasResolution = 2048;
     }
 
-    get cells() {
-        return this._cells;
-    }
-
     set cells(value) {
         this._cells.copy(value);
     }
 
-    get maxLightsPerCell() {
-        return this._maxLightsPerCell;
+    get cells() {
+        return this._cells;
     }
 
     set maxLightsPerCell(value) {
         this._maxLightsPerCell = math.clamp(value, 1, 255);
     }
 
-    get cookieAtlasResolution() {
-        return this._cookieAtlasResolution;
+    get maxLightsPerCell() {
+        return this._maxLightsPerCell;
     }
 
     set cookieAtlasResolution(value) {
         this._cookieAtlasResolution = math.clamp(value, 32, this._maxTextureSize);
     }
 
-    get shadowAtlasResolution() {
-        return this._shadowAtlasResolution;
+    get cookieAtlasResolution() {
+        return this._cookieAtlasResolution;
     }
 
     set shadowAtlasResolution(value) {
         this._shadowAtlasResolution = math.clamp(value, 32, this._maxTextureSize);
     }
 
-    get shadowType() {
-        return this._shadowType;
+    get shadowAtlasResolution() {
+        return this._shadowAtlasResolution;
     }
 
     set shadowType(value) {
@@ -66,8 +62,8 @@ class LightingParams {
         }
     }
 
-    get cookiesEnabled() {
-        return this._cookiesEnabled;
+    get shadowType() {
+        return this._shadowType;
     }
 
     set cookiesEnabled(value) {
@@ -79,8 +75,8 @@ class LightingParams {
         }
     }
 
-    get areaLightsEnabled() {
-        return this._areaLightsEnabled;
+    get cookiesEnabled() {
+        return this._cookiesEnabled;
     }
 
     set areaLightsEnabled(value) {
@@ -96,8 +92,8 @@ class LightingParams {
         }
     }
 
-    get shadowsEnabled() {
-        return this._shadowsEnabled;
+    get areaLightsEnabled() {
+        return this._areaLightsEnabled;
     }
 
     set shadowsEnabled(value) {
@@ -107,6 +103,10 @@ class LightingParams {
             // lit shaders need to be rebuilt
             this._dirtyLightsFnc();
         }
+    }
+
+    get shadowsEnabled() {
+        return this._shadowsEnabled;
     }
 }
 

--- a/src/scene/lighting/world-clusters.js
+++ b/src/scene/lighting/world-clusters.js
@@ -71,6 +71,37 @@ class WorldClusters {
         this.registerUniforms(device);
     }
 
+    set maxCellLightCount(count) {
+
+        // each cell stores 4 lights (xyzw), so round up the count
+        const maxCellLightCount = math.roundUp(count, 4);
+        if (maxCellLightCount !== this._maxCellLightCount) {
+            this._maxCellLightCount = maxCellLightCount;
+            this._pixelsPerCellCount = this._maxCellLightCount / 4;
+            this._cellsDirty = true;
+        }
+    }
+
+    get maxCellLightCount() {
+        return this._maxCellLightCount;
+    }
+
+    set cells(value) {
+
+        // make sure we have whole numbers
+        tempVec3.copy(value).floor();
+
+        if (!this._cells.equals(tempVec3)) {
+            this._cells.copy(tempVec3);
+            this._cellsLimit.copy(tempVec3).sub(Vec3.ONE);
+            this._cellsDirty = true;
+        }
+    }
+
+    get cells() {
+        return this._cells;
+    }
+
     destroy() {
 
         this.lightsBuffer.destroy();
@@ -112,37 +143,6 @@ class WorldClusters {
         // compression limit 0
         this._clusterCompressionLimit0Id = device.scope.resolve("clusterCompressionLimit0");
         this._clusterCompressionLimit0Data = new Float32Array(2);
-    }
-
-    get maxCellLightCount() {
-        return this._maxCellLightCount;
-    }
-
-    set maxCellLightCount(count) {
-
-        // each cell stores 4 lights (xyzw), so round up the count
-        const maxCellLightCount = math.roundUp(count, 4);
-        if (maxCellLightCount !== this._maxCellLightCount) {
-            this._maxCellLightCount = maxCellLightCount;
-            this._pixelsPerCellCount = this._maxCellLightCount / 4;
-            this._cellsDirty = true;
-        }
-    }
-
-    get cells() {
-        return this._cells;
-    }
-
-    set cells(value) {
-
-        // make sure we have whole numbers
-        tempVec3.copy(value).floor();
-
-        if (!this._cells.equals(tempVec3)) {
-            this._cells.copy(tempVec3);
-            this._cellsLimit.copy(tempVec3).sub(Vec3.ONE);
-            this._cellsDirty = true;
-        }
     }
 
     // updates itself based on parameters stored in the scene

--- a/src/scene/materials/basic-material.js
+++ b/src/scene/materials/basic-material.js
@@ -6,13 +6,12 @@ import {
 
 import { Material } from './material.js';
 
+/** @typedef {import('../../graphics/texture.js').Texture} Texture */
+
 /**
  * A BasicMaterial is for rendering unlit geometry, either using a constant color or a color map
  * modulated with a color.
  *
- * @property {Color} color The flat color of the material (RGBA, where each component is 0 to 1).
- * @property {Texture|null} colorMap The color map of the material (default is null). If specified,
- * the color map is modulated by the color property.
  * @augments Material
  */
 class BasicMaterial extends Material {
@@ -33,9 +32,20 @@ class BasicMaterial extends Material {
     constructor() {
         super();
 
+        /**
+         * The flat color of the material (RGBA, where each component is 0 to 1).
+         *
+         * @type {Color}
+         */
         this.color = new Color(1, 1, 1, 1);
         this.colorUniform = new Float32Array(4);
 
+        /**
+         * The color map of the material (default is null). If specified, the color map is
+         * modulated by the color property.
+         *
+         * @type {Texture|null}
+         */
         this.colorMap = null;
         this.vertexColors = false;
     }

--- a/src/scene/materials/material.js
+++ b/src/scene/materials/material.js
@@ -148,69 +148,17 @@ class Material {
         this.dirty = true;
     }
 
-    get shader() {
-        return this._shader;
-    }
-
     set shader(shader) {
         this._shader = shader;
+    }
+
+    get shader() {
+        return this._shader;
     }
 
     // returns boolean depending on material being transparent
     get transparent() {
         return this.blend || this.blendSrc !== BLENDMODE_ONE || this.blendDst !== BLENDMODE_ZERO || this.blendEquation !== BLENDEQUATION_ADD;
-    }
-
-    get blendType() {
-        if (!this.transparent) {
-            return BLEND_NONE;
-        } else if ((this.blend) &&
-                   (this.blendSrc === BLENDMODE_SRC_ALPHA) &&
-                   (this.blendDst === BLENDMODE_ONE_MINUS_SRC_ALPHA) &&
-                   (this.blendEquation === BLENDEQUATION_ADD)) {
-            return BLEND_NORMAL;
-        } else if ((this.blend) &&
-                   (this.blendSrc === BLENDMODE_ONE) &&
-                   (this.blendDst === BLENDMODE_ONE) &&
-                   (this.blendEquation === BLENDEQUATION_ADD)) {
-            return BLEND_ADDITIVE;
-        } else if ((this.blend) &&
-                   (this.blendSrc === BLENDMODE_SRC_ALPHA) &&
-                   (this.blendDst === BLENDMODE_ONE) &&
-                   (this.blendEquation === BLENDEQUATION_ADD)) {
-            return BLEND_ADDITIVEALPHA;
-        } else if ((this.blend) &&
-                   (this.blendSrc === BLENDMODE_DST_COLOR) &&
-                   (this.blendDst === BLENDMODE_SRC_COLOR) &&
-                   (this.blendEquation === BLENDEQUATION_ADD)) {
-            return BLEND_MULTIPLICATIVE2X;
-        } else if ((this.blend) &&
-                   (this.blendSrc === BLENDMODE_ONE_MINUS_DST_COLOR) &&
-                   (this.blendDst === BLENDMODE_ONE) &&
-                   (this.blendEquation === BLENDEQUATION_ADD)) {
-            return BLEND_SCREEN;
-        } else if ((this.blend) &&
-                   (this.blendSrc === BLENDMODE_ONE) &&
-                   (this.blendDst === BLENDMODE_ONE) &&
-                   (this.blendEquation === BLENDEQUATION_MIN)) {
-            return BLEND_MIN;
-        } else if ((this.blend) &&
-                   (this.blendSrc === BLENDMODE_ONE) &&
-                   (this.blendDst === BLENDMODE_ONE) &&
-                   (this.blendEquation === BLENDEQUATION_MAX)) {
-            return BLEND_MAX;
-        } else if ((this.blend) &&
-                   (this.blendSrc === BLENDMODE_DST_COLOR) &&
-                   (this.blendDst === BLENDMODE_ZERO) &&
-                   (this.blendEquation === BLENDEQUATION_ADD)) {
-            return BLEND_MULTIPLICATIVE;
-        } else if ((this.blend) &&
-                   (this.blendSrc === BLENDMODE_ONE) &&
-                   (this.blendDst === BLENDMODE_ONE_MINUS_SRC_ALPHA) &&
-                   (this.blendEquation === BLENDEQUATION_ADD)) {
-            return BLEND_PREMULTIPLIED;
-        }
-        return BLEND_NORMAL;
     }
 
     set blendType(type) {
@@ -285,6 +233,58 @@ class Material {
             }
         }
         this._updateMeshInstanceKeys();
+    }
+
+    get blendType() {
+        if (!this.transparent) {
+            return BLEND_NONE;
+        } else if ((this.blend) &&
+                   (this.blendSrc === BLENDMODE_SRC_ALPHA) &&
+                   (this.blendDst === BLENDMODE_ONE_MINUS_SRC_ALPHA) &&
+                   (this.blendEquation === BLENDEQUATION_ADD)) {
+            return BLEND_NORMAL;
+        } else if ((this.blend) &&
+                   (this.blendSrc === BLENDMODE_ONE) &&
+                   (this.blendDst === BLENDMODE_ONE) &&
+                   (this.blendEquation === BLENDEQUATION_ADD)) {
+            return BLEND_ADDITIVE;
+        } else if ((this.blend) &&
+                   (this.blendSrc === BLENDMODE_SRC_ALPHA) &&
+                   (this.blendDst === BLENDMODE_ONE) &&
+                   (this.blendEquation === BLENDEQUATION_ADD)) {
+            return BLEND_ADDITIVEALPHA;
+        } else if ((this.blend) &&
+                   (this.blendSrc === BLENDMODE_DST_COLOR) &&
+                   (this.blendDst === BLENDMODE_SRC_COLOR) &&
+                   (this.blendEquation === BLENDEQUATION_ADD)) {
+            return BLEND_MULTIPLICATIVE2X;
+        } else if ((this.blend) &&
+                   (this.blendSrc === BLENDMODE_ONE_MINUS_DST_COLOR) &&
+                   (this.blendDst === BLENDMODE_ONE) &&
+                   (this.blendEquation === BLENDEQUATION_ADD)) {
+            return BLEND_SCREEN;
+        } else if ((this.blend) &&
+                   (this.blendSrc === BLENDMODE_ONE) &&
+                   (this.blendDst === BLENDMODE_ONE) &&
+                   (this.blendEquation === BLENDEQUATION_MIN)) {
+            return BLEND_MIN;
+        } else if ((this.blend) &&
+                   (this.blendSrc === BLENDMODE_ONE) &&
+                   (this.blendDst === BLENDMODE_ONE) &&
+                   (this.blendEquation === BLENDEQUATION_MAX)) {
+            return BLEND_MAX;
+        } else if ((this.blend) &&
+                   (this.blendSrc === BLENDMODE_DST_COLOR) &&
+                   (this.blendDst === BLENDMODE_ZERO) &&
+                   (this.blendEquation === BLENDEQUATION_ADD)) {
+            return BLEND_MULTIPLICATIVE;
+        } else if ((this.blend) &&
+                   (this.blendSrc === BLENDMODE_ONE) &&
+                   (this.blendDst === BLENDMODE_ONE_MINUS_SRC_ALPHA) &&
+                   (this.blendEquation === BLENDEQUATION_ADD)) {
+            return BLEND_PREMULTIPLIED;
+        }
+        return BLEND_NORMAL;
     }
 
     _cloneInternal(clone) {

--- a/src/scene/mesh-instance.js
+++ b/src/scene/mesh-instance.js
@@ -15,7 +15,6 @@ import {
 
 import { GraphNode } from './graph-node.js';
 import { LightmapCache } from './lightmapper/lightmap-cache.js';
-import { SkinInstance } from './skin-instance.js';
 
 /** @typedef {import('../graphics/texture.js').Texture} Texture */
 /** @typedef {import('../graphics/vertex-buffer.js').VertexBuffer} VertexBuffer */
@@ -23,6 +22,7 @@ import { SkinInstance } from './skin-instance.js';
 /** @typedef {import('./materials/material.js').Material} Material */
 /** @typedef {import('./mesh.js').Mesh} Mesh */
 /** @typedef {import('./morph-instance.js').MorphInstance} MorphInstance */
+/** @typedef {import('./skin-instance.js').SkinInstance} SkinInstance */
 
 const _tmpAabb = new BoundingBox();
 const _tempBoneAabb = new BoundingBox();

--- a/src/scene/mesh.js
+++ b/src/scene/mesh.js
@@ -22,6 +22,8 @@ import { RENDERSTYLE_SOLID, RENDERSTYLE_WIREFRAME, RENDERSTYLE_POINTS } from './
 import { getApplication } from '../framework/globals.js';
 
 /** @typedef {import('../graphics/graphics-device.js').GraphicsDevice} GraphicsDevice */
+/** @typedef {import('./morph.js').Morph} Morph */
+/** @typedef {import('./skin.js').Skin} Skin */
 
 let id = 0;
 
@@ -162,11 +164,6 @@ class GeometryVertexStream {
  * example sharing a Vertex or Index Buffer between multiple meshes. See {@link VertexBuffer},
  * {@link IndexBuffer} and {@link VertexFormat} for details.
  *
- * @property {VertexBuffer} vertexBuffer The vertex buffer holding the vertex data of the mesh.
- * @property {IndexBuffer[]} indexBuffer An array of index buffers. For unindexed meshes, this
- * array can be empty. The first index buffer in the array is used by {@link MeshInstance}s with a
- * renderStyle property set to {@link RENDERSTYLE_SOLID}. The second index buffer in the array is
- * used if renderStyle is set to {@link RENDERSTYLE_WIREFRAME}.
  * @property {object[]} primitive Array of primitive objects defining how vertex (and index) data
  * in the mesh should be interpreted by the graphics device.
  * @property {number} primitive[].type The type of primitive to render. Can be:
@@ -187,12 +184,6 @@ class GeometryVertexStream {
  * using the currently set index buffer and false otherwise.
  * {@link GraphicsDevice#draw}. The primitive is ordered based on render style like the indexBuffer
  * property.
- * @property {BoundingBox} aabb The axis-aligned bounding box for the object space vertices of this
- * mesh.
- * @property {Skin} [skin] The skin data (if any) that drives skinned mesh animations for this
- * mesh.
- * @property {Morph} [morph] The morph data (if any) that drives morph target animations for this
- * mesh.
  */
 class Mesh extends RefCountedObject {
     /**
@@ -205,14 +196,41 @@ class Mesh extends RefCountedObject {
         super();
         this.id = id++;
         this.device = graphicsDevice || getApplication().graphicsDevice;
+
+        /**
+         * The vertex buffer holding the vertex data of the mesh.
+         *
+         * @type {VertexBuffer}
+         */
         this.vertexBuffer = null;
+
+        /**
+         * An array of index buffers. For unindexed meshes, this array can be empty. The first
+         * index buffer in the array is used by {@link MeshInstance}s with a renderStyle property
+         * set to {@link RENDERSTYLE_SOLID}. The second index buffer in the array is used if
+         * renderStyle is set to {@link RENDERSTYLE_WIREFRAME}.
+         *
+         * @type {IndexBuffer[]}
+         */
         this.indexBuffer = [null];
         this.primitive = [{
             type: 0,
             base: 0,
             count: 0
         }];
+
+        /**
+         * The skin data (if any) that drives skinned mesh animations for this mesh.
+         *
+         * @type {Skin|null}
+         */
         this.skin = null;
+
+        /**
+         * The morph data (if any) that drives morph target animations for this mesh.
+         *
+         * @type {Morph|null}
+         */
         this.morph = null;
         this._geometryData = null;
 
@@ -223,12 +241,17 @@ class Mesh extends RefCountedObject {
         this.boneAabb = null;
     }
 
-    get aabb() {
-        return this._aabb;
-    }
-
+    /**
+     * The axis-aligned bounding box for the object space vertices of this mesh.
+     *
+     * @type {BoundingBox}
+     */
     set aabb(aabb) {
         this._aabb = aabb;
+    }
+
+    get aabb() {
+        return this._aabb;
     }
 
     /**
@@ -236,7 +259,6 @@ class Mesh extends RefCountedObject {
      * normally called by {@link Model#destroy} and does not need to be called manually.
      */
     destroy() {
-
         if (this.vertexBuffer) {
             this.vertexBuffer.destroy();
             this.vertexBuffer = null;

--- a/src/scene/morph-instance.js
+++ b/src/scene/morph-instance.js
@@ -6,6 +6,9 @@ import { RenderTarget } from '../graphics/render-target.js';
 
 import { Morph } from './morph.js';
 
+/** @typedef {import('../graphics/shader.js').Shader} Shader */
+/** @typedef {import('./mesh-instance.js').MeshInstance} MeshInstance */
+
 // vertex shader used to add morph targets from textures into render target
 const textureMorphVertexShader = `
     attribute vec2 vertex_position;
@@ -19,10 +22,6 @@ const textureMorphVertexShader = `
 /**
  * An instance of {@link Morph}. Contains weights to assign to every {@link MorphTarget}, manages
  * selection of active morph targets.
- *
- * @property {MeshInstance} meshInstance The mesh instance this morph instance controls the
- * morphing of.
- * @property {Morph} morph The morph with its targets, which is being instanced.
  */
 class MorphInstance {
     /**
@@ -31,9 +30,20 @@ class MorphInstance {
      * @param {Morph} morph - The {@link Morph} to instance.
      */
     constructor(morph) {
+        /**
+         * The morph with its targets, which is being instanced.
+         *
+         * @type {Morph}
+         */
         this.morph = morph;
         morph.incRefCount();
         this.device = morph.device;
+
+        /**
+         * The mesh instance this morph instance controls the morphing of.
+         *
+         * @type {MeshInstance}
+         */
         this.meshInstance = null;
 
         // weights
@@ -181,7 +191,13 @@ class MorphInstance {
         this._dirty = true;
     }
 
-    // generates fragment shader to blend number of textures using specified weights
+    /**
+     * Generate fragment shader to blend number of textures using specified weights.
+     *
+     * @param {number} count - Number of textures to blend.
+     * @returns {string} Fragment shader.
+     * @private
+     */
     _getFragmentShader(numTextures) {
 
         let fragmentShader = '';
@@ -208,7 +224,13 @@ class MorphInstance {
         return fragmentShader;
     }
 
-    // creates complete shader for texture based morphing
+    /**
+     * Create complete shader for texture based morphing.
+     *
+     * @param {number} count - Number of textures to blend.
+     * @returns {Shader} Shader.
+     * @private
+     */
     _getShader(count) {
 
         let shader = this.shaderCache[count];
@@ -227,7 +249,7 @@ class MorphInstance {
 
         const device = this.device;
 
-        // blend curently set up textures to render target
+        // blend currently set up textures to render target
         const submitBatch = (usedCount, blending) => {
 
             // factors

--- a/src/scene/morph-instance.js
+++ b/src/scene/morph-instance.js
@@ -192,9 +192,9 @@ class MorphInstance {
     }
 
     /**
-     * Generate fragment shader to blend number of textures using specified weights.
+     * Generate fragment shader to blend a number of textures using specified weights.
      *
-     * @param {number} count - Number of textures to blend.
+     * @param {number} numTextures - Number of textures to blend.
      * @returns {string} Fragment shader.
      * @private
      */

--- a/src/scene/render.js
+++ b/src/scene/render.js
@@ -26,9 +26,35 @@ class Render extends EventHandler {
     constructor() {
         super();
 
-        // meshes are reference counted, and this class owns the references and is responsible
-        // for releasing the meshes when they are no longer referenced
+        /**
+         * Meshes are reference counted, and this class owns the references and is responsible for
+         * releasing the meshes when they are no longer referenced.
+         *
+         * @type {Mesh[]}
+         * @private
+         */
         this._meshes = null;
+    }
+
+    /**
+     * The meshes that the render contains.
+     *
+     * @type {Mesh[]}
+     * @private
+     */
+    set meshes(value) {
+        // decrement references on the existing meshes
+        this.decRefMeshes();
+
+        // assign new meshes
+        this._meshes = value;
+        this.incRefMeshes();
+
+        this.fire('set:meshes', value);
+    }
+
+    get meshes() {
+        return this._meshes;
     }
 
     destroy() {
@@ -62,28 +88,6 @@ class Render extends EventHandler {
                 }
             }
         }
-    }
-
-    /**
-     * The meshes that the render contains.
-     *
-     * @type {Mesh[]}
-     * @private
-     */
-    get meshes() {
-        return this._meshes;
-    }
-
-    set meshes(value) {
-
-        // decrement references on the existing meshes
-        this.decRefMeshes();
-
-        // assign new meshes
-        this._meshes = value;
-        this.incRefMeshes();
-
-        this.fire('set:meshes', value);
     }
 }
 

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -258,7 +258,7 @@ class Scene extends EventHandler {
     /**
      * Returns the default layer used by the immediate drawing functions.
      *
-     * @returns {Layer}
+     * @type {Layer}
      * @private
      */
     get defaultDrawLayer() {

--- a/src/scene/skin-instance.js
+++ b/src/scene/skin-instance.js
@@ -45,6 +45,14 @@ class SkinInstance {
         }
     }
 
+    set rootBone(rootBone) {
+        this._rootBone = rootBone;
+    }
+
+    get rootBone() {
+        return this._rootBone;
+    }
+
     init(device, numBones) {
 
         if (device.supportsBoneTextures) {
@@ -78,14 +86,6 @@ class SkinInstance {
             this.boneTexture.destroy();
             this.boneTexture = null;
         }
-    }
-
-    get rootBone() {
-        return this._rootBone;
-    }
-
-    set rootBone(rootBone) {
-        this._rootBone = rootBone;
     }
 
     // resolved skin bones to a hierarchy with the rootBone at its root.

--- a/src/scene/sprite.js
+++ b/src/scene/sprite.js
@@ -70,6 +70,130 @@ class Sprite extends EventHandler {
         }
     }
 
+    /**
+     * The keys of the frames in the sprite atlas that this sprite is using.
+     *
+     * @type {string[]}
+     */
+     set frameKeys(value) {
+        this._frameKeys = value;
+
+        if (this._atlas && this._frameKeys) {
+            if (this._updatingProperties) {
+                this._meshesDirty = true;
+            } else {
+                this._createMeshes();
+            }
+        }
+
+        this.fire('set:frameKeys', value);
+    }
+
+    get frameKeys() {
+        return this._frameKeys;
+    }
+
+    /**
+     * The texture atlas.
+     *
+     * @type {TextureAtlas}
+     */
+    set atlas(value) {
+        if (value === this._atlas) return;
+
+        if (this._atlas) {
+            this._atlas.off('set:frames', this._onSetFrames, this);
+            this._atlas.off('set:frame', this._onFrameChanged, this);
+            this._atlas.off('remove:frame', this._onFrameRemoved, this);
+        }
+
+        this._atlas = value;
+        if (this._atlas && this._frameKeys) {
+            this._atlas.on('set:frames', this._onSetFrames, this);
+            this._atlas.on('set:frame', this._onFrameChanged, this);
+            this._atlas.on('remove:frame', this._onFrameRemoved, this);
+
+            if (this._updatingProperties) {
+                this._meshesDirty = true;
+            } else {
+                this._createMeshes();
+            }
+        }
+
+        this.fire('set:atlas', value);
+    }
+
+    get atlas() {
+        return this._atlas;
+    }
+
+    /**
+     * The number of pixels that map to one PlayCanvas unit.
+     *
+     * @type {number}
+     */
+    set pixelsPerUnit(value) {
+        if (this._pixelsPerUnit === value) return;
+
+        this._pixelsPerUnit = value;
+        this.fire('set:pixelsPerUnit', value);
+
+        // simple mode uses pixelsPerUnit to create the mesh so re-create those meshes
+        if (this._atlas && this._frameKeys && this.renderMode === SPRITE_RENDERMODE_SIMPLE) {
+            if (this._updatingProperties) {
+                this._meshesDirty = true;
+            } else {
+                this._createMeshes();
+            }
+        }
+    }
+
+    get pixelsPerUnit() {
+        return this._pixelsPerUnit;
+    }
+
+    /**
+     * The rendering mode of the sprite. Can be:
+     *
+     * - {@link SPRITE_RENDERMODE_SIMPLE}
+     * - {@link SPRITE_RENDERMODE_SLICED}
+     * - {@link SPRITE_RENDERMODE_TILED}
+     *
+     * @type {number}
+     */
+    set renderMode(value) {
+        if (this._renderMode === value)
+            return;
+
+        const prev = this._renderMode;
+        this._renderMode = value;
+        this.fire('set:renderMode', value);
+
+        // re-create the meshes if we're going from simple to 9-sliced or vice versa
+        if (prev === SPRITE_RENDERMODE_SIMPLE || value === SPRITE_RENDERMODE_SIMPLE) {
+            if (this._atlas && this._frameKeys) {
+                if (this._updatingProperties) {
+                    this._meshesDirty = true;
+                } else {
+                    this._createMeshes();
+                }
+            }
+        }
+    }
+
+    get renderMode() {
+        return this._renderMode;
+    }
+
+    /**
+     * An array that contains a mesh for each frame.
+     *
+     * @type {Mesh[]}
+     */
+    get meshes() {
+        return this._meshes;
+    }
+
     _createMeshes() {
         // destroy old meshes
         const len = this._meshes.length;
@@ -248,130 +372,6 @@ class Sprite extends EventHandler {
                 mesh.destroy();
         }
         this._meshes.length = 0;
-    }
-
-    /**
-     * The keys of the frames in the sprite atlas that this sprite is using.
-     *
-     * @type {string[]}
-     */
-    get frameKeys() {
-        return this._frameKeys;
-    }
-
-    set frameKeys(value) {
-        this._frameKeys = value;
-
-        if (this._atlas && this._frameKeys) {
-            if (this._updatingProperties) {
-                this._meshesDirty = true;
-            } else {
-                this._createMeshes();
-            }
-        }
-
-        this.fire('set:frameKeys', value);
-    }
-
-    /**
-     * The texture atlas.
-     *
-     * @type {TextureAtlas}
-     */
-    get atlas() {
-        return this._atlas;
-    }
-
-    set atlas(value) {
-        if (value === this._atlas) return;
-
-        if (this._atlas) {
-            this._atlas.off('set:frames', this._onSetFrames, this);
-            this._atlas.off('set:frame', this._onFrameChanged, this);
-            this._atlas.off('remove:frame', this._onFrameRemoved, this);
-        }
-
-        this._atlas = value;
-        if (this._atlas && this._frameKeys) {
-            this._atlas.on('set:frames', this._onSetFrames, this);
-            this._atlas.on('set:frame', this._onFrameChanged, this);
-            this._atlas.on('remove:frame', this._onFrameRemoved, this);
-
-            if (this._updatingProperties) {
-                this._meshesDirty = true;
-            } else {
-                this._createMeshes();
-            }
-        }
-
-        this.fire('set:atlas', value);
-    }
-
-    /**
-     * The number of pixels that map to one PlayCanvas unit.
-     *
-     * @type {number}
-     */
-    get pixelsPerUnit() {
-        return this._pixelsPerUnit;
-    }
-
-    set pixelsPerUnit(value) {
-        if (this._pixelsPerUnit === value) return;
-
-        this._pixelsPerUnit = value;
-        this.fire('set:pixelsPerUnit', value);
-
-        // simple mode uses pixelsPerUnit to create the mesh so re-create those meshes
-        if (this._atlas && this._frameKeys && this.renderMode === SPRITE_RENDERMODE_SIMPLE) {
-            if (this._updatingProperties) {
-                this._meshesDirty = true;
-            } else {
-                this._createMeshes();
-            }
-        }
-    }
-
-    /**
-     * The rendering mode of the sprite. Can be:
-     *
-     * - {@link SPRITE_RENDERMODE_SIMPLE}
-     * - {@link SPRITE_RENDERMODE_SLICED}
-     * - {@link SPRITE_RENDERMODE_TILED}
-     *
-     * @type {number}
-     */
-    get renderMode() {
-        return this._renderMode;
-    }
-
-    set renderMode(value) {
-        if (this._renderMode === value)
-            return;
-
-        const prev = this._renderMode;
-        this._renderMode = value;
-        this.fire('set:renderMode', value);
-
-        // re-create the meshes if we're going from simple to 9-sliced or vice versa
-        if (prev === SPRITE_RENDERMODE_SIMPLE || value === SPRITE_RENDERMODE_SIMPLE) {
-            if (this._atlas && this._frameKeys) {
-                if (this._updatingProperties) {
-                    this._meshesDirty = true;
-                } else {
-                    this._createMeshes();
-                }
-            }
-        }
-    }
-
-    /**
-     * An array that contains a mesh for each frame.
-     *
-     * @type {Mesh[]}
-     */
-    get meshes() {
-        return this._meshes;
     }
 }
 

--- a/src/scene/sprite.js
+++ b/src/scene/sprite.js
@@ -75,7 +75,7 @@ class Sprite extends EventHandler {
      *
      * @type {string[]}
      */
-     set frameKeys(value) {
+    set frameKeys(value) {
         this._frameKeys = value;
 
         if (this._atlas && this._frameKeys) {

--- a/src/scene/texture-atlas.js
+++ b/src/scene/texture-atlas.js
@@ -71,6 +71,7 @@ class TextureAtlas extends EventHandler {
         this._frames = value;
         this.fire('set:frames', value);
     }
+
     get frames() {
         return this._frames;
     }

--- a/src/scene/texture-atlas.js
+++ b/src/scene/texture-atlas.js
@@ -36,8 +36,43 @@ class TextureAtlas extends EventHandler {
     constructor() {
         super();
 
+        /**
+         * @type {Texture}
+         * @private
+         */
         this._texture = null;
+        /**
+         * @type {object}
+         * @private
+         */
         this._frames = null;
+    }
+
+    /**
+     * The texture used by the atlas.
+     *
+     * @type {Texture}
+     */
+    set texture(value) {
+        this._texture = value;
+        this.fire('set:texture', value);
+    }
+
+    get texture() {
+        return this._texture;
+    }
+
+    /**
+     * Contains frames which define portions of the texture atlas.
+     *
+     * @type {object}
+     */
+    set frames(value) {
+        this._frames = value;
+        this.fire('set:frames', value);
+    }
+    get frames() {
+        return this._frames;
     }
 
     /**
@@ -96,34 +131,6 @@ class TextureAtlas extends EventHandler {
         if (this._texture) {
             this._texture.destroy();
         }
-    }
-
-    /**
-     * The texture used by the atlas.
-     *
-     * @type {Texture}
-     */
-    get texture() {
-        return this._texture;
-    }
-
-    set texture(value) {
-        this._texture = value;
-        this.fire('set:texture', value);
-    }
-
-    /**
-     * Contains frames which define portions of the texture atlas.
-     *
-     * @type {object}
-     */
-    get frames() {
-        return this._frames;
-    }
-
-    set frames(value) {
-        this._frames = value;
-        this.fire('set:frames', value);
     }
 }
 

--- a/src/script/script-type.js
+++ b/src/script/script-type.js
@@ -58,7 +58,7 @@ class ScriptType extends EventHandler {
      *
      * @type {boolean}
      */
-     set enabled(value) {
+    set enabled(value) {
         this._enabled = !!value;
 
         if (this.enabled === this._enabledOld) return;

--- a/src/shape/oriented-box.js
+++ b/src/shape/oriented-box.js
@@ -37,6 +37,20 @@ class OrientedBox {
     }
 
     /**
+     * The world transform of the OBB.
+     *
+     * @type {Mat4}
+     */
+    set worldTransform(value) {
+        this._worldTransform.copy(value);
+        this._modelTransform.copy(value).invert();
+    }
+
+    get worldTransform() {
+        return this._worldTransform;
+    }
+
+    /**
      * Test if a ray intersects with the OBB.
      *
      * @param {Ray} ray - Ray to test against (direction must be normalized).
@@ -84,20 +98,6 @@ class OrientedBox {
         }
 
         return false;
-    }
-
-    /**
-     * The world transform of the OBB.
-     *
-     * @type {Mat4}
-     */
-    get worldTransform() {
-        return this._worldTransform;
-    }
-
-    set worldTransform(value) {
-        this._worldTransform.copy(value);
-        this._modelTransform.copy(value).invert();
     }
 }
 

--- a/src/sound/instance.js
+++ b/src/sound/instance.js
@@ -22,17 +22,8 @@ function capTime(time, duration) {
  *
  * @property {number} volume The volume modifier to play the sound with. In range 0-1.
  * @property {number} pitch The pitch modifier to play the sound with. Must be larger than 0.01.
- * @property {number} startTime The start time from which the sound will start playing.
  * @property {number} currentTime Gets or sets the current time of the sound that is playing. If
  * the value provided is bigger than the duration of the instance it will wrap from the beginning.
- * @property {number} duration The duration of the sound that the instance will play starting from
- * startTime.
- * @property {boolean} loop If true the instance will restart when it finishes playing.
- * @property {boolean} isPlaying Returns true if the instance is currently playing.
- * @property {boolean} isPaused Returns true if the instance is currently paused.
- * @property {boolean} isStopped Returns true if the instance is currently stopped.
- * @property {boolean} isSuspended Returns true if the instance is currently suspended because the
- * window is not focused.
  * @property {AudioBufferSourceNode} source Gets the source that plays the sound resource. If the
  * Web Audio API is not supported the type of source is
  * [Audio](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/audio). Source is only
@@ -134,6 +125,104 @@ class SoundInstance extends EventHandler {
         }
     }
 
+    /**
+     * The duration of the sound that the instance will play starting from startTime.
+     *
+     * @type {number}
+     */
+    set duration(value) {
+        this._duration = Math.max(0, Number(value) || 0);
+
+        // restart
+        const isPlaying = this._state === STATE_PLAYING;
+        this.stop();
+        if (isPlaying) {
+            this.play();
+        }
+    }
+
+    get duration() {
+        if (!this._sound) {
+            return 0;
+        }
+        if (this._duration) {
+            return capTime(this._duration, this._sound.duration);
+        }
+        return this._sound.duration;
+    }
+
+    /**
+     * Returns true if the instance is currently paused.
+     *
+     * @type {boolean}
+     */
+    get isPaused() {
+        return this._state === STATE_PAUSED;
+    }
+
+    /**
+     * Returns true if the instance is currently playing.
+     *
+     * @type {boolean}
+     */
+    get isPlaying() {
+        return this._state === STATE_PLAYING;
+    }
+
+    /**
+     * Returns true if the instance is currently stopped.
+     *
+     * @type {boolean}
+     */
+    get isStopped() {
+        return this._state === STATE_STOPPED;
+    }
+
+    /**
+     * Returns true if the instance is currently suspended because the window is not focused.
+     *
+     * @type {boolean}
+     */
+    get isSuspended() {
+        return this._suspended;
+    }
+
+    /**
+     * If true the instance will restart when it finishes playing.
+     *
+     * @type {boolean}
+     */
+    set loop(value) {
+        this._loop = !!value;
+        if (this.source) {
+            this.source.loop = this._loop;
+        }
+    }
+
+    get loop() {
+        return this._loop;
+    }
+
+    /**
+     * The start time from which the sound will start playing.
+     *
+     * @type {number}
+     */
+    set startTime(value) {
+        this._startTime = Math.max(0, Number(value) || 0);
+
+        // restart
+        const isPlaying = this._state === STATE_PLAYING;
+        this.stop();
+        if (isPlaying) {
+            this.play();
+        }
+    }
+
+    get startTime() {
+        return this._startTime;
+    }
+
     _onPlay() {
         this.fire('play');
 
@@ -180,20 +269,18 @@ class SoundInstance extends EventHandler {
     }
 
     /**
+     * Handle the manager's 'volumechange' event.
+     *
      * @private
-     * @function
-     * @name SoundInstance#_onManagerVolumeChange
-     * @description Handle the manager's 'volumechange' event.
      */
     _onManagerVolumeChange() {
         this.volume = this._volume;
     }
 
     /**
+     * Handle the manager's 'suspend' event.
+     *
      * @private
-     * @function
-     * @name SoundInstance#_onManagerSuspend
-     * @description Handle the manager's 'suspend' event.
      */
     _onManagerSuspend() {
         if (this._state === STATE_PLAYING && !this._suspended) {
@@ -203,79 +290,15 @@ class SoundInstance extends EventHandler {
     }
 
     /**
+     * Handle the manager's 'resume' event.
+     *
      * @private
-     * @function
-     * @name SoundInstance#_onManagerResume
-     * @description Handle the manager's 'resume' event.
      */
     _onManagerResume() {
         if (this._suspended) {
             this._suspended = false;
             this.resume();
         }
-    }
-
-    get loop() {
-        return this._loop;
-    }
-
-    set loop(value) {
-        this._loop = !!value;
-        if (this.source) {
-            this.source.loop = this._loop;
-        }
-    }
-
-    get startTime() {
-        return this._startTime;
-    }
-
-    set startTime(value) {
-        this._startTime = Math.max(0, Number(value) || 0);
-
-        // restart
-        const isPlaying = this._state === STATE_PLAYING;
-        this.stop();
-        if (isPlaying) {
-            this.play();
-        }
-    }
-
-    get duration() {
-        if (!this._sound) {
-            return 0;
-        }
-        if (this._duration) {
-            return capTime(this._duration, this._sound.duration);
-        }
-        return this._sound.duration;
-    }
-
-    set duration(value) {
-        this._duration = Math.max(0, Number(value) || 0);
-
-        // restart
-        const isPlaying = this._state === STATE_PLAYING;
-        this.stop();
-        if (isPlaying) {
-            this.play();
-        }
-    }
-
-    get isPlaying() {
-        return this._state === STATE_PLAYING;
-    }
-
-    get isPaused() {
-        return this._state === STATE_PAUSED;
-    }
-
-    get isStopped() {
-        return this._state === STATE_STOPPED;
-    }
-
-    get isSuspended() {
-        return this._suspended;
     }
 }
 

--- a/src/sound/manager.js
+++ b/src/sound/manager.js
@@ -10,11 +10,9 @@ import { Channel3d } from '../audio/channel3d.js';
 import { Listener } from './listener.js';
 
 /**
- * The SoundManager is used to load and play audio. As well as apply system-wide settings like
+ * The SoundManager is used to load and play audio. It also applies system-wide settings like
  * global volume, suspend and resume.
  *
- * @property {number} volume Global volume for the manager. All {@link SoundInstance}s will scale
- * their volume with this volume. Valid between [0, 1].
  * @augments EventHandler
  */
 class SoundManager extends EventHandler {
@@ -22,8 +20,8 @@ class SoundManager extends EventHandler {
      * Create a new SoundManager instance.
      *
      * @param {object} [options] - Options options object.
-     * @param {boolean} [options.forceWebAudioApi] - Always use the Web Audio API even check
-     * indicates that it if not available.
+     * @param {boolean} [options.forceWebAudioApi] - Always use the Web Audio API, even if check
+     * indicates that it is not available.
      */
     constructor(options) {
         super();
@@ -77,6 +75,37 @@ class SoundManager extends EventHandler {
 
         this._volume = 1;
         this.suspended = false;
+    }
+
+    /**
+     * Global volume for the manager. All {@link SoundInstance}s will scale their volume with this
+     * volume. Valid between [0, 1].
+     *
+     * @type {number}
+     */
+    set volume(volume) {
+        volume = math.clamp(volume, 0, 1);
+        this._volume = volume;
+        this.fire('volumechange', volume);
+    }
+
+    get volume() {
+        return this._volume;
+    }
+
+    get context() {
+        // lazy create the AudioContext if possible
+        if (!this._context) {
+            if (hasAudioContext() || this._forceWebAudioApi) {
+                if (typeof AudioContext !== 'undefined') {
+                    this._context = new AudioContext();
+                } else if (typeof webkitAudioContext !== 'undefined') {
+                    this._context = new webkitAudioContext();
+                }
+            }
+        }
+
+        return this._context;
     }
 
     suspend() {
@@ -176,31 +205,6 @@ class SoundManager extends EventHandler {
         }
 
         return channel;
-    }
-
-    get volume() {
-        return this._volume;
-    }
-
-    set volume(volume) {
-        volume = math.clamp(volume, 0, 1);
-        this._volume = volume;
-        this.fire('volumechange', volume);
-    }
-
-    get context() {
-        // lazy create the AudioContext if possible
-        if (!this._context) {
-            if (hasAudioContext() || this._forceWebAudioApi) {
-                if (typeof AudioContext !== 'undefined') {
-                    this._context = new AudioContext();
-                } else if (typeof webkitAudioContext !== 'undefined') {
-                    this._context = new webkitAudioContext();
-                }
-            }
-        }
-
-        return this._context;
     }
 }
 

--- a/src/xr/xr-input-source.js
+++ b/src/xr/xr-input-source.js
@@ -66,6 +66,154 @@ class XrInputSource extends EventHandler {
     }
 
     /**
+     * Unique number associated with instance of input source. Same physical devices when
+     * reconnected will not share this ID.
+     *
+     * @type {number}
+     */
+    get id() {
+        return this._id;
+    }
+
+    /**
+     * XRInputSource object that is associated with this input source.
+     *
+     * @type {object}
+     */
+    get inputSource() {
+        return this._xrInputSource;
+    }
+
+    /**
+     * Type of ray Input Device is based on. Can be one of the following:
+     *
+     * - {@link XRTARGETRAY_GAZE}: Gaze - indicates the target ray will originate at the viewer and
+     * follow the direction it is facing. This is commonly referred to as a "gaze input" device in
+     * the context of head-mounted displays.
+     * - {@link XRTARGETRAY_SCREEN}: Screen - indicates that the input source was an interaction
+     * with the canvas element associated with an inline session's output context, such as a mouse
+     * click or touch event.
+     * - {@link XRTARGETRAY_POINTER}: Tracked Pointer - indicates that the target ray originates
+     * from either a handheld device or other hand-tracking mechanism and represents that the user
+     * is using their hands or the held device for pointing.
+     *
+     * @type {string}
+     */
+    get targetRayMode() {
+        return this._xrInputSource.targetRayMode;
+    }
+
+    /**
+     * Describes which hand input source is associated with. Can be one of the following:
+     *
+     * - {@link XRHAND_NONE}: None - input source is not meant to be held in hands.
+     * - {@link XRHAND_LEFT}: Left - indicates that input source is meant to be held in left hand.
+     * - {@link XRHAND_RIGHT}: Right - indicates that input source is meant to be held in right
+     * hand.
+     *
+     * @type {string}
+     */
+    get handedness() {
+        return this._xrInputSource.handedness;
+    }
+
+    /**
+     * List of input profile names indicating both the preferred visual representation and behavior
+     * of the input source.
+     *
+     * @type {string[]}
+     */
+    get profiles() {
+        return this._xrInputSource.profiles;
+    }
+
+    /**
+     * If input source can be held, then it will have node with its world transformation, that can
+     * be used to position and rotate virtual joysticks based on it.
+     *
+     * @type {boolean}
+     */
+    get grip() {
+        return this._grip;
+    }
+
+    /**
+     * If input source is a tracked hand, then it will point to {@link XrHand} otherwise it is
+     * null.
+     *
+     * @type {XrHand|null}
+     */
+    get hand() {
+        return this._hand;
+    }
+
+    /**
+     * If input source has buttons, triggers, thumbstick or touchpad, then this object provides
+     * access to its states.
+     *
+     * @type {Gamepad|null}
+     */
+    get gamepad() {
+        return this._xrInputSource.gamepad || null;
+    }
+
+    /**
+     * True if input source is in active primary action between selectstart and selectend events.
+     *
+     * @type {boolean}
+     */
+    get selecting() {
+        return this._selecting;
+    }
+
+    /**
+     * True if input source is in active squeeze action between squeezestart and squeezeend events.
+     *
+     * @type {boolean}
+     */
+    get squeezing() {
+        return this._squeezing;
+    }
+
+    /**
+     * Set to true to allow input source to interact with Element components. Defaults to true.
+     *
+     * @type {boolean}
+     */
+    set elementInput(value) {
+        if (this._elementInput === value)
+            return;
+
+        this._elementInput = value;
+
+        if (!this._elementInput)
+            this._elementEntity = null;
+    }
+
+    get elementInput() {
+        return this._elementInput;
+    }
+
+    /**
+     * If {@link XrInputSource#elementInput} is true, this property will hold entity with Element
+     * component at which this input source is hovering, or null if not hovering over any element.
+     *
+     * @type {Entity|null}
+     */
+    get elementEntity() {
+        return this._elementEntity;
+    }
+
+    /**
+     * List of active {@link XrHitTestSource} instances created by this input source.
+     *
+     * @type {XrHitTestSource[]}
+     */
+    get hitTestSources() {
+        return this._hitTestSources;
+    }
+
+    /**
      * @event
      * @name XrInputSource#remove
      * @description Fired when {@link XrInputSource} is removed.
@@ -370,154 +518,6 @@ class XrInputSource extends EventHandler {
     onHitTestSourceRemove(hitTestSource) {
         const ind = this._hitTestSources.indexOf(hitTestSource);
         if (ind !== -1) this._hitTestSources.splice(ind, 1);
-    }
-
-    /**
-     * Unique number associated with instance of input source. Same physical devices when
-     * reconnected will not share this ID.
-     *
-     * @type {number}
-     */
-    get id() {
-        return this._id;
-    }
-
-    /**
-     * XRInputSource object that is associated with this input source.
-     *
-     * @type {object}
-     */
-    get inputSource() {
-        return this._xrInputSource;
-    }
-
-    /**
-     * Type of ray Input Device is based on. Can be one of the following:
-     *
-     * - {@link XRTARGETRAY_GAZE}: Gaze - indicates the target ray will originate at the viewer and
-     * follow the direction it is facing. This is commonly referred to as a "gaze input" device in
-     * the context of head-mounted displays.
-     * - {@link XRTARGETRAY_SCREEN}: Screen - indicates that the input source was an interaction
-     * with the canvas element associated with an inline session's output context, such as a mouse
-     * click or touch event.
-     * - {@link XRTARGETRAY_POINTER}: Tracked Pointer - indicates that the target ray originates
-     * from either a handheld device or other hand-tracking mechanism and represents that the user
-     * is using their hands or the held device for pointing.
-     *
-     * @type {string}
-     */
-    get targetRayMode() {
-        return this._xrInputSource.targetRayMode;
-    }
-
-    /**
-     * Describes which hand input source is associated with. Can be one of the following:
-     *
-     * - {@link XRHAND_NONE}: None - input source is not meant to be held in hands.
-     * - {@link XRHAND_LEFT}: Left - indicates that input source is meant to be held in left hand.
-     * - {@link XRHAND_RIGHT}: Right - indicates that input source is meant to be held in right
-     * hand.
-     *
-     * @type {string}
-     */
-    get handedness() {
-        return this._xrInputSource.handedness;
-    }
-
-    /**
-     * List of input profile names indicating both the preferred visual representation and behavior
-     * of the input source.
-     *
-     * @type {string[]}
-     */
-    get profiles() {
-        return this._xrInputSource.profiles;
-    }
-
-    /**
-     * If input source can be held, then it will have node with its world transformation, that can
-     * be used to position and rotate virtual joysticks based on it.
-     *
-     * @type {boolean}
-     */
-    get grip() {
-        return this._grip;
-    }
-
-    /**
-     * If input source is a tracked hand, then it will point to {@link XrHand} otherwise it is
-     * null.
-     *
-     * @type {XrHand|null}
-     */
-    get hand() {
-        return this._hand;
-    }
-
-    /**
-     * If input source has buttons, triggers, thumbstick or touchpad, then this object provides
-     * access to its states.
-     *
-     * @type {Gamepad|null}
-     */
-    get gamepad() {
-        return this._xrInputSource.gamepad || null;
-    }
-
-    /**
-     * True if input source is in active primary action between selectstart and selectend events.
-     *
-     * @type {boolean}
-     */
-    get selecting() {
-        return this._selecting;
-    }
-
-    /**
-     * True if input source is in active squeeze action between squeezestart and squeezeend events.
-     *
-     * @type {boolean}
-     */
-    get squeezing() {
-        return this._squeezing;
-    }
-
-    /**
-     * Set to true to allow input source to interact with Element components. Defaults to true.
-     *
-     * @type {boolean}
-     */
-    get elementInput() {
-        return this._elementInput;
-    }
-
-    set elementInput(value) {
-        if (this._elementInput === value)
-            return;
-
-        this._elementInput = value;
-
-        if (!this._elementInput)
-            this._elementEntity = null;
-    }
-
-    /**
-     * If {@link XrInputSource#elementInput} is true, this property will hold entity with Element
-     * component at which this input source is hovering, or null if not hovering over any element.
-     *
-     * @type {Entity|null}
-     */
-    get elementEntity() {
-        return this._elementEntity;
-    }
-
-    /**
-     * List of active {@link XrHitTestSource} instances created by this input source.
-     *
-     * @type {XrHitTestSource[]}
-     */
-    get hitTestSources() {
-        return this._hitTestSources;
     }
 }
 

--- a/src/xr/xr-tracked-image.js
+++ b/src/xr/xr-tracked-image.js
@@ -41,6 +41,60 @@ class XrTrackedImage extends EventHandler {
     }
 
     /**
+     * Image that is used for tracking.
+     *
+     * @type {HTMLCanvasElement|HTMLImageElement|SVGImageElement|HTMLVideoElement|Blob|ImageData|ImageBitmap}
+     */
+    get image() {
+        return this._image;
+    }
+
+    /**
+     * Width that is provided to assist tracking performance. This property can be updated only
+     * when the AR session is not running.
+     *
+     * @type {number}
+     */
+    set width(value) {
+        this._width = value;
+    }
+
+    get width() {
+        return this._width;
+    }
+
+    /**
+     * True if image is trackable. A too small resolution or invalid images can be untrackable by
+     * the underlying AR system.
+     *
+     * @type {boolean}
+     */
+    get trackable() {
+        return this._trackable;
+    }
+
+    /**
+     * True if image is in tracking state and being tracked in real world by the underlying AR
+     * system.
+     *
+     * @type {boolean}
+     */
+    get tracking() {
+        return this._tracking;
+    }
+
+    /**
+     * True if image was recently tracked but currently is not actively tracked due to inability of
+     * identifying the image by the underlying AR system. Position and rotation will be based on
+     * the previously known transformation assuming the tracked image has not moved.
+     *
+     * @type {boolean}
+     */
+    get emulated() {
+        return this._emulated;
+    }
+
+    /**
      * @event
      * @name XrTrackedImage#tracked
      * @description Fired when image becomes actively tracked.
@@ -106,60 +160,6 @@ class XrTrackedImage extends EventHandler {
     getRotation() {
         if (this._pose) this._rotation.copy(this._pose.transform.orientation);
         return this._rotation;
-    }
-
-    /**
-     * Image that is used for tracking.
-     *
-     * @type {HTMLCanvasElement|HTMLImageElement|SVGImageElement|HTMLVideoElement|Blob|ImageData|ImageBitmap}
-     */
-    get image() {
-        return this._image;
-    }
-
-    /**
-     * Width that is provided to assist tracking performance. This property can be updated only
-     * when the AR session is not running.
-     *
-     * @type {number}
-     */
-    get width() {
-        return this._width;
-    }
-
-    set width(value) {
-        this._width = value;
-    }
-
-    /**
-     * True if image is trackable. A too small resolution or invalid images can be untrackable by
-     * the underlying AR system.
-     *
-     * @type {boolean}
-     */
-    get trackable() {
-        return this._trackable;
-    }
-
-    /**
-     * True if image is in tracking state and being tracked in real world by the underlying AR
-     * system.
-     *
-     * @type {boolean}
-     */
-    get tracking() {
-        return this._tracking;
-    }
-
-    /**
-     * True if image was recently tracked but currently is not actively tracked due to inability of
-     * identifying the image by the underlying AR system. Position and rotation will be based on
-     * the previously known transformation assuming the tracked image has not moved.
-     *
-     * @type {boolean}
-     */
-    get emulated() {
-        return this._emulated;
     }
 }
 


### PR DESCRIPTION
This PR ensures that all getter/setter pairs first declare the setter and then the getter. Otherwise, the TypeScript compiler `tsc` will output `.d.ts` files with the getter before the docs for the property. This is mainly for readability.

All getter/setter pairs have been moved up to directly follow the constructor.

It also properly documents the instance properties of all math classes, which in turn fixes many TS declaration types across the API.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
