### PR TITLE
Fix prefiltering bug

### DIFF
--- a/src/graphics/program-lib/chunks/reproject.frag
+++ b/src/graphics/program-lib/chunks/reproject.frag
@@ -31,7 +31,7 @@ uniform vec4 params;
 // params2:
 // x - target image total pixels
 // y - source cubemap size
-uniform vec4 params2;
+uniform vec2 params2;
 
 float targetFace() { return params.x; }
 float specularPower() { return params.y; }
@@ -40,8 +40,6 @@ float targetCubeSeamScale() { return params.w; }
 
 float targetTotalPixels() { return params2.x; }
 float sourceTotalPixels() { return params2.y; }
-float targetSize() {  return params2.z; }
-float sourceSize() {  return params2.w; }
 
 float PI = 3.141592653589793;
 
@@ -138,7 +136,7 @@ vec4 sampleEquirect(vec3 dir) {
 }
 
 vec4 sampleCubemap(vec3 dir) {
-    return textureCube(sourceCube, modifySeams(dir, sourceCubeSeamScale()));
+    return textureCube(sourceCube, modifySeams(dir, 1.0 - sourceCubeSeamScale()));
 }
 
 vec4 sampleCubemap(vec2 sph) {
@@ -160,9 +158,9 @@ vec4 sampleEquirect(vec3 dir, float mipLevel) {
 
 vec4 sampleCubemap(vec3 dir, float mipLevel) {
 #ifdef SUPPORTS_TEXLOD
-    return textureCubeLodEXT(sourceCube, modifySeams(dir, 1.0 - exp2(mipLevel) / sourceSize()), mipLevel);
+    return textureCubeLodEXT(sourceCube, modifySeams(dir, 1.0 - exp2(mipLevel) * sourceCubeSeamScale()), mipLevel);
 #else
-    return textureCube(sourceCube, modifySeams(dir, 1.0 - exp2(mipLevel) / sourceSize()));
+    return textureCube(sourceCube, modifySeams(dir, 1.0 - exp2(mipLevel) * sourceCubeSeamScale()));
 #endif
 }
 
@@ -247,7 +245,7 @@ vec3 getDirectionCubemap() {
         vec = vec3(-st.x, -st.y, -1);
     }
 
-    return normalize(modifySeams(vec, 1.0 / targetCubeSeamScale()));
+    return normalize(modifySeams(vec, 1.0 / (1.0 - targetCubeSeamScale())));
 }
 
 mat3 matrixFromVector(vec3 n) { // frisvad

--- a/src/graphics/reproject-texture.js
+++ b/src/graphics/reproject-texture.js
@@ -284,7 +284,7 @@ const packSamplesTex = (device, name, samples) => {
     const numSamples = samples.length;
 
     const w = Math.min(numSamples, 512);
-    const h = Math.max(1, Math.floor(numSamples / w));
+    const h = Math.ceil(numSamples / w);
     const data = new Uint8ClampedArray(w * h * 4);
 
     // normalize float data and pack into rgba8
@@ -479,15 +479,13 @@ function reprojectTexture(source, target, options = {}) {
     const params = [
         0,
         specularPower,
-        1.0 - (source.fixCubemapSeams ? 1.0 / source.width : 0.0),          // source seam scale
-        1.0 - (target.fixCubemapSeams ? 1.0 / target.width : 0.0)           // target seam scale
+        source.fixCubemapSeams ? 1.0 / source.width : 0.0,          // source seam scale
+        target.fixCubemapSeams ? 1.0 / target.width : 0.0           // target seam scale
     ];
 
     const params2 = [
         target.width * target.height * (target.cubemap ? 6 : 1),
-        source.width * source.height * (source.cubemap ? 6 : 1),
-        target.width,
-        source.width
+        source.width * source.height * (source.cubemap ? 6 : 1)
     ];
 
     if (processFunc.startsWith('prefilterSamples')) {


### PR DESCRIPTION
This PR fixes an incorrect cubemap seams calculation when seams were disabled. This resulted in filtering artifacts under intense light.

Old:
![Screenshot 2021-12-22 at 16 16 16](https://user-images.githubusercontent.com/11276292/147122916-0113f884-5c31-4462-a73b-eeccf48d8f1e.png)
New:
![Screenshot 2021-12-22 at 16 16 18](https://user-images.githubusercontent.com/11276292/147122926-99d03f94-b4cd-45f2-b9f1-bd5e16902a8c.png)

Thanks to @Maksims for reporting this issue.