### PR TITLE
Document math contructor default values

### DIFF
--- a/src/framework/entity.js
+++ b/src/framework/entity.js
@@ -44,142 +44,162 @@ import { Application } from './application.js';
  */
 class Entity extends GraphNode {
     /**
-     * Gets the {@link AnimComponent} attached to this entity. [read only]
+     * Gets the {@link AnimComponent} attached to this entity.
      *
      * @type {AnimComponent}
+     * @readonly
      */
     anim;
 
     /**
-     * Gets the {@link AnimationComponent} attached to this entity. [read only]
+     * Gets the {@link AnimationComponent} attached to this entity.
      *
      * @type {AnimationComponent}
+     * @readonly
      */
     animation;
 
     /**
-     * Gets the {@link AudioListenerComponent} attached to this entity. [read only]
+     * Gets the {@link AudioListenerComponent} attached to this entity.
      *
      * @type {AudioListenerComponent}
+     * @readonly
      */
-    audioListener;
+    audiolistener;
 
     /**
-     * Gets the {@link ButtonComponent} attached to this entity. [read only]
+     * Gets the {@link ButtonComponent} attached to this entity.
      *
      * @type {ButtonComponent}
+     * @readonly
      */
     button;
 
     /**
-     * Gets the {@link CameraComponent} attached to this entity. [read only]
+     * Gets the {@link CameraComponent} attached to this entity.
      *
      * @type {CameraComponent}
+     * @readonly
      */
     camera;
 
     /**
-     * Gets the {@link CollisionComponent} attached to this entity. [read only]
+     * Gets the {@link CollisionComponent} attached to this entity.
      *
      * @type {CollisionComponent}
+     * @readonly
      */
     collision;
 
     /**
-     * Gets the {@link ElementComponent} attached to this entity. [read only]
+     * Gets the {@link ElementComponent} attached to this entity.
      *
      * @type {ElementComponent}
+     * @readonly
      */
     element;
 
     /**
-     * Gets the {@link LayoutChildComponent} attached to this entity. [read only]
+     * Gets the {@link LayoutChildComponent} attached to this entity.
      *
      * @type {LayoutChildComponent}
+     * @readonly
      */
     layoutchild;
 
     /**
-     * Gets the {@link LayoutGroupComponent} attached to this entity. [read only]
+     * Gets the {@link LayoutGroupComponent} attached to this entity.
      *
      * @type {LayoutGroupComponent}
+     * @readonly
      */
     layoutgroup;
 
     /**
-     * Gets the {@link LightComponent} attached to this entity. [read only]
+     * Gets the {@link LightComponent} attached to this entity.
      *
      * @type {LightComponent}
+     * @readonly
      */
     light;
 
     /**
-     * Gets the {@link ModelComponent} attached to this entity. [read only]
+     * Gets the {@link ModelComponent} attached to this entity.
      *
      * @type {ModelComponent}
+     * @readonly
      */
     model;
 
     /**
-     * Gets the {@link ParticleSystemComponent} attached to this entity. [read only]
+     * Gets the {@link ParticleSystemComponent} attached to this entity.
      *
      * @type {ParticleSystemComponent}
+     * @readonly
      */
     particlesystem;
 
     /**
-     * Gets the {@link RenderComponent} attached to this entity. [read only]
+     * Gets the {@link RenderComponent} attached to this entity.
      *
      * @type {RenderComponent}
+     * @readonly
      */
     render;
 
     /**
-     * Gets the {@link RigidBodyComponent} attached to this entity. [read only]
+     * Gets the {@link RigidBodyComponent} attached to this entity.
      *
      * @type {RigidBodyComponent}
+     * @readonly
      */
     rigidbody;
 
     /**
-     * Gets the {@link ScreenComponent} attached to this entity. [read only]
+     * Gets the {@link ScreenComponent} attached to this entity.
      *
      * @type {ScreenComponent}
+     * @readonly
      */
     screen;
 
     /**
-     * Gets the {@link ScriptComponent} attached to this entity. [read only]
+     * Gets the {@link ScriptComponent} attached to this entity.
      *
      * @type {ScriptComponent}
+     * @readonly
      */
     script;
 
     /**
-     * Gets the {@link ScrollbarComponent} attached to this entity. [read only]
+     * Gets the {@link ScrollbarComponent} attached to this entity.
      *
      * @type {ScrollbarComponent}
+     * @readonly
      */
     scrollbar;
 
     /**
-     * Gets the {@link ScrollViewComponent} attached to this entity. [read only]
+     * Gets the {@link ScrollViewComponent} attached to this entity.
      *
      * @type {ScrollViewComponent}
+     * @readonly
      */
     scrollview;
 
     /**
-     * Gets the {@link SoundComponent} attached to this entity. [read only]
+     * Gets the {@link SoundComponent} attached to this entity.
      *
      * @type {SoundComponent}
+     * @readonly
      */
     sound;
 
     /**
-     * Gets the {@link SpriteComponent} attached to this entity. [read only]
+     * Gets the {@link SpriteComponent} attached to this entity.
      *
      * @type {SpriteComponent}
+     * @readonly
      */
     sprite;
 

--- a/src/math/color.js
+++ b/src/math/color.js
@@ -7,11 +7,11 @@ class Color {
     /**
      * Create a new Color object.
      *
-     * @param {number|number[]} [r] - The value of the red component (0-1). If r is an array of
-     * length 3 or 4, the array will be used to populate all components.
-     * @param {number} [g] - The value of the green component (0-1).
-     * @param {number} [b] - The value of the blue component (0-1).
-     * @param {number} [a] - The value of the alpha component (0-1).
+     * @param {number|number[]} [r] - The value of the red component (0-1). Defaults to 0. If r is
+     * an array of length 3 or 4, the array will be used to populate all components.
+     * @param {number} [g] - The value of the green component (0-1). Defaults to 0.
+     * @param {number} [b] - The value of the blue component (0-1). Defaults to 0.
+     * @param {number} [a] - The value of the alpha component (0-1). Defaults to 1.
      */
     constructor(r = 0, g = 0, b = 0, a = 1) {
         const length = r.length;

--- a/src/math/curve-set.js
+++ b/src/math/curve-set.js
@@ -29,6 +29,11 @@ class CurveSet {
      */
     constructor() {
         this.curves = [];
+
+        /**
+         * @type {number}
+         * @private
+         */
         this._type = CURVE_SMOOTHSTEP;
 
         if (arguments.length > 1) {

--- a/src/math/curve.js
+++ b/src/math/curve.js
@@ -6,19 +6,6 @@ import { CurveEvaluator } from './curve-evaluator.js';
 /**
  * A curve is a collection of keys (time/value pairs). The shape of the curve is defined by its
  * type that specifies an interpolation scheme for the keys.
- *
- * @property {number} length The number of keys in the curve. [read only].
- * @property {number} type The curve interpolation scheme. Can be:
- *
- * - {@link CURVE_LINEAR}
- * - {@link CURVE_SMOOTHSTEP}
- * - {@link CURVE_SPLINE}
- * - {@link CURVE_STEP}
- *
- * Defaults to {@link CURVE_SMOOTHSTEP}.
- * @property {number} tension Controls how {@link CURVE_SPLINE} tangents are calculated. Valid
- * range is between 0 and 1 where 0 results in a non-smooth curve (equivalent to linear
- * interpolation) and 1 results in a very smooth curve. Use 0.5 for a Catmull-rom spline.
  */
 class Curve {
     /**
@@ -36,8 +23,34 @@ class Curve {
      */
     constructor(data) {
         this.keys = [];
+
+        /**
+         * The curve interpolation scheme. Can be:
+         *
+         * - {@link CURVE_LINEAR}
+         * - {@link CURVE_SMOOTHSTEP}
+         * - {@link CURVE_SPLINE}
+         * - {@link CURVE_STEP}
+         *
+         * Defaults to {@link CURVE_SMOOTHSTEP}.
+         *
+         * @type {number}
+         */
         this.type = CURVE_SMOOTHSTEP;
-        this.tension = 0.5;                     // used for CURVE_SPLINE
+
+        /**
+         * Controls how {@link CURVE_SPLINE} tangents are calculated. Valid range is between 0 and
+         * 1 where 0 results in a non-smooth curve (equivalent to linear interpolation) and 1
+         * results in a very smooth curve. Use 0.5 for a Catmull-rom spline.
+         *
+         * @type {number}
+         */
+        this.tension = 0.5;
+
+        /**
+         * @type {CurveEvaluator}
+         * @private
+         */
         this._eval = new CurveEvaluator(this);
 
         if (data) {
@@ -47,6 +60,15 @@ class Curve {
         }
 
         this.sort();
+    }
+
+    /**
+     * Get the number of keys in the curve.
+     *
+     * @type {number}
+     */
+    get length() {
+        return this.keys.length;
     }
 
     /**
@@ -173,10 +195,6 @@ class Curve {
             result[i] = Math.min(max, Math.max(min, result[i]));
         }
         return result;
-    }
-
-    get length() {
-        return this.keys.length;
     }
 }
 

--- a/src/math/quat.js
+++ b/src/math/quat.js
@@ -10,11 +10,11 @@ class Quat {
     /**
      * Create a new Quat instance.
      *
-     * @param {number|number[]} [x] - The quaternion's x component. Default value 0. If x is an
-     * array of length 4, the array will be used to populate all components.
-     * @param {number} [y] - The quaternion's y component. Default value 0.
-     * @param {number} [z] - The quaternion's z component. Default value 0.
-     * @param {number} [w] - The quaternion's w component. Default value 1.
+     * @param {number|number[]} [x] - The quaternion's x component. Defaults to 0. If x is an array
+     * of length 4, the array will be used to populate all components.
+     * @param {number} [y] - The quaternion's y component. Defaults to 0.
+     * @param {number} [z] - The quaternion's z component. Defaults to 0.
+     * @param {number} [w] - The quaternion's w component. Defaults to 1.
      */
     constructor(x = 0, y = 0, z = 0, w = 1) {
         if (x.length === 4) {

--- a/src/math/vec2.js
+++ b/src/math/vec2.js
@@ -5,9 +5,9 @@ class Vec2 {
     /**
      * Create a new Vec2 instance.
      *
-     * @param {number|number[]} [x] - The x value. If x is an array of length 2, the array will be
-     * used to populate all components.
-     * @param {number} [y] - The y value.
+     * @param {number|number[]} [x] - The x value. Defaults to 0. If x is an array of length 2, the
+     * array will be used to populate all components.
+     * @param {number} [y] - The y value. Defaults to 0.
      * @example
      * var v = new pc.Vec2(1, 2);
      */

--- a/src/math/vec3.js
+++ b/src/math/vec3.js
@@ -5,10 +5,10 @@ class Vec3 {
     /**
      * Creates a new Vec3 object.
      *
-     * @param {number|number[]} [x] - The x value. If x is an array of length 3, the array will be
-     * used to populate all components.
-     * @param {number} [y] - The y value.
-     * @param {number} [z] - The z value.
+     * @param {number|number[]} [x] - The x value. Defaults to 0. If x is an array of length 3, the
+     * array will be used to populate all components.
+     * @param {number} [y] - The y value. Defaults to 0.
+     * @param {number} [z] - The z value. Defaults to 0.
      * @example
      * var v = new pc.Vec3(1, 2, 3);
      */

--- a/src/math/vec4.js
+++ b/src/math/vec4.js
@@ -5,11 +5,11 @@ class Vec4 {
     /**
      * Creates a new Vec4 object.
      *
-     * @param {number|number[]} [x] - The x value. If x is an array of length 4, the array will be
-     * used to populate all components.
-     * @param {number} [y] - The y value.
-     * @param {number} [z] - The z value.
-     * @param {number} [w] - The w value.
+     * @param {number|number[]} [x] - The x value. Defaults to 0. If x is an array of length 4, the
+     * array will be used to populate all components.
+     * @param {number} [y] - The y value. Defaults to 0.
+     * @param {number} [z] - The z value. Defaults to 0.
+     * @param {number} [w] - The w value. Defaults to 0.
      * @example
      * var v = new pc.Vec4(1, 2, 3, 4);
      */


### PR DESCRIPTION
Document the default values for all math related constructors consistently.

Also, mark entity components as read-only.

Supersedes #3749.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
