### PR TITLE
Correctly encode form postdata

### DIFF
--- a/src/net/http.js
+++ b/src/net/http.js
@@ -374,7 +374,10 @@ class Http {
                                 } else {
                                     postdata += "&";
                                 }
-                                postdata += escape(key) + "=" + escape(options.postdata[key]);
+
+                                const encodedKey = encodeURIComponent(key);
+                                const encodedValue = encodeURIComponent(options.postdata[key]);
+                                postdata += `${encodedKey}=${encodedValue}`;
                             }
                         }
                         break;


### PR DESCRIPTION
Longstanding bug where `Http#request` uses the deprecated [`escape`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/escape) function instead of [`encodeURIComponent`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent).

Fixes #614

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
