### PR TITLE
Remove Model from ParticleSystemComponent

### DIFF
--- a/src/framework/components/particle-system/component.js
+++ b/src/framework/components/particle-system/component.js
@@ -301,7 +301,7 @@ class ParticleSystemComponent extends Component {
         return this._drawOrder;
     }
 
-    addModelToLayers() {
+    addMeshInstanceToLayers() {
         if (!this.emitter) return;
         for (let i = 0; i < this.layers.length; i++) {
             const layer = this.system.app.scene.layers.getLayerById(this.layers[i]);
@@ -311,7 +311,7 @@ class ParticleSystemComponent extends Component {
         }
     }
 
-    removeModelFromLayers(model) {
+    removeMeshInstanceFromLayers() {
         if (!this.emitter) return;
         for (let i = 0; i < this.layers.length; i++) {
             const layer = this.system.app.scene.layers.getLayerById(this.layers[i]);
@@ -336,7 +336,7 @@ class ParticleSystemComponent extends Component {
     }
 
     onLayersChanged(oldComp, newComp) {
-        this.addModelToLayers();
+        this.addMeshInstanceToLayers();
         oldComp.off("add", this.onLayerAdded, this);
         oldComp.off("remove", this.onLayerRemoved, this);
         newComp.on("add", this.onLayerAdded, this);
@@ -846,7 +846,7 @@ class ParticleSystemComponent extends Component {
         }
 
         if (this.emitter.colorMap) {
-            this.addModelToLayers();
+            this.addMeshInstanceToLayers();
         }
 
         this.system.app.scene.on("set:layers", this.onLayersChanged, this);
@@ -868,7 +868,7 @@ class ParticleSystemComponent extends Component {
         }
 
         if (this.emitter) {
-            this.removeModelFromLayers();
+            this.removeMeshInstanceFromLayers();
             if (this.data.depthSoftening) this._releaseDepth();
 
             // clear camera as it isn't updated while disabled and we don't want to hold

--- a/src/framework/components/particle-system/component.js
+++ b/src/framework/components/particle-system/component.js
@@ -1,6 +1,5 @@
 import { LAYERID_DEPTH } from '../../../scene/constants.js';
 import { Mesh } from '../../../scene/mesh.js';
-import { Model } from '../../../scene/model.js';
 import { ParticleEmitter } from '../../../scene/particle-system/particle-emitter.js';
 
 import { Asset } from '../../../asset/asset.js';

--- a/src/framework/components/particle-system/data.js
+++ b/src/framework/components/particle-system/data.js
@@ -77,8 +77,6 @@ class ParticleSystemComponentData {
 
         this.blendType = BLEND_NORMAL;
 
-        this.model = null;
-
         this.enabled = true;
 
         this.paused = false;

--- a/src/framework/components/particle-system/system.js
+++ b/src/framework/components/particle-system/system.js
@@ -213,7 +213,7 @@ class ParticleSystemComponentSystem extends ComponentSystem {
                 const data = component.data;
 
                 if (data.enabled && entity.enabled) {
-                    const emitter = data.model.emitter;
+                    const emitter = entity.particlesystem.emitter;
                     if (!emitter.meshInstance.visible) continue;
 
                     // Bake ambient and directional lighting into one ambient cube


### PR DESCRIPTION
This PR removes the unnecessary `Model` that holds the emitter's mesh instance in the `ParticleSystemComponent`.

Fixes #746

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
