### PR TITLE
Fix problematic use of indexOf

### DIFF
--- a/src/framework/components/anim/component-binder.js
+++ b/src/framework/components/anim/component-binder.js
@@ -196,7 +196,7 @@ class AnimComponentBinder extends DefaultAnimBinder {
         } else if (this.handlers && propertyHierarchy[0] === 'material' && propertyHierarchy.length === 2) {
             const materialPropertyName = propertyHierarchy[1];
             // if the property name ends in Map then we're binding a material texture
-            if (materialPropertyName.indexOf('Map') === materialPropertyName.length - 3) {
+            if (materialPropertyName.endsWith('Map')) {
                 return this.handlers.materialTexture(propertyComponent, materialPropertyName);
             }
         }


### PR DESCRIPTION
Fixes this:

![image](https://user-images.githubusercontent.com/697563/147753376-e17455f3-ac7c-432f-8752-dfd6529dc27a.png)

Note that it's safe to use `String#endsWith` because [we include it in our polyfills](https://github.com/playcanvas/engine/blob/dev/src/polyfill/string.js).

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
