### PR TITLE
Fix typo in `StandardMaterialValidator`

### DIFF
--- a/src/scene/materials/standard-material-validator.js
+++ b/src/scene/materials/standard-material-validator.js
@@ -117,7 +117,7 @@ class StandardMaterialValidator {
                     // this counts as a valid input
                     // null texture reference is also valid
                 } else {
-                    if (!(typeof data[key] === 'string' || data[key === null])) {
+                    if (!(typeof data[key] === 'string' || data[key] === null)) {
                         if (!(data[key] instanceof Texture)) {
                             this.setInvalid(key, data);
                         }


### PR DESCRIPTION
I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
