### PR TITLE
Debug rendering of world clusters (clustered lighting)

### DIFF
--- a/examples/src/examples/graphics/clustered-area-lights.tsx
+++ b/examples/src/examples/graphics/clustered-area-lights.tsx
@@ -213,7 +213,8 @@ class AreaLightsExample extends Example {
             attributes: {
                 inertiaFactor: 0.2,
                 focusEntity: ground,
-                distanceMax: 24
+                distanceMax: 60,
+                frameOnStart: false
             }
         });
         camera.script.create("orbitCameraInputMouse");

--- a/examples/src/examples/graphics/clustered-lighting.tsx
+++ b/examples/src/examples/graphics/clustered-lighting.tsx
@@ -10,6 +10,7 @@ class ClusteredLightingExample extends Example {
 
     load() {
         return <>
+            <AssetLoader name='script' type='script' url='static/scripts/camera/orbit-camera.js' />
             <AssetLoader name='normal' type='texture' url='static/assets/textures/normal-map.png' />
         </>;
     }
@@ -153,7 +154,7 @@ class ClusteredLightingExample extends Example {
             color: pc.Color.WHITE,
             intensity: 0.2,
             range: 300,
-            shadowDistance: 300,
+            shadowDistance: 600,
             castShadows: true,
             shadowBias: 0.2,
             normalOffsetBias: 0.05
@@ -163,12 +164,25 @@ class ClusteredLightingExample extends Example {
         // Create an entity with a camera component
         const camera = new pc.Entity();
         camera.addComponent("camera", {
-            clearColor: new pc.Color(0.2, 0.2, 0.2),
+            clearColor: new pc.Color(0.05, 0.05, 0.05),
             farClip: 500,
             nearClip: 0.1
         });
-        camera.setLocalPosition(120, 120, 120);
+        camera.setLocalPosition(140, 140, 140);
         camera.lookAt(new pc.Vec3(0, 40, 0));
+
+        // add orbit camera script with a mouse and a touch support
+        camera.addComponent("script");
+        camera.script.create("orbitCamera", {
+            attributes: {
+                inertiaFactor: 0.2,
+                focusEntity: app.root,
+                distanceMax: 400,
+                frameOnStart: false
+            }
+        });
+        camera.script.create("orbitCameraInputMouse");
+        camera.script.create("orbitCameraInputTouch");
         app.root.addChild(camera);
 
         // Set an update function on the app's update event

--- a/examples/src/examples/graphics/clustered-lighting.tsx
+++ b/examples/src/examples/graphics/clustered-lighting.tsx
@@ -171,7 +171,7 @@ class ClusteredLightingExample extends Example {
         camera.setLocalPosition(140, 140, 140);
         camera.lookAt(new pc.Vec3(0, 40, 0));
 
-        // add orbit camera script with a mouse and a touch support
+        // add orbit camera script with mouse and touch support
         camera.addComponent("script");
         camera.script.create("orbitCamera", {
             attributes: {

--- a/examples/src/examples/graphics/clustered-omni-shadows.tsx
+++ b/examples/src/examples/graphics/clustered-omni-shadows.tsx
@@ -88,7 +88,7 @@ class ClusteredShadowsOmniExample extends Example {
 
         // 2) and allow this many lights per cell:
         // @ts-ignore engine-tsd
-        lighting.maxLightsPerCell = 16;
+        lighting.maxLightsPerCell = 12;
 
         // enable clustered shadows (it's enabled by default as well)
         // @ts-ignore engine-tsd
@@ -210,7 +210,7 @@ class ClusteredShadowsOmniExample extends Example {
         const camera = new pc.Entity();
         camera.addComponent("camera", {
             fov: 80,
-            clearColor: new pc.Color(0.9, 0.9, 0.9),
+            clearColor: new pc.Color(0.1, 0.1, 0.1),
             farClip: 1500
         });
 
@@ -223,7 +223,8 @@ class ClusteredShadowsOmniExample extends Example {
             attributes: {
                 inertiaFactor: 0.2,
                 focusEntity: app.root,
-                distanceMax: 400
+                distanceMax: 1200,
+                frameOnStart: false
             }
         });
         camera.script.create("orbitCameraInputMouse");

--- a/examples/src/examples/graphics/clustered-spot-shadows.tsx
+++ b/examples/src/examples/graphics/clustered-spot-shadows.tsx
@@ -25,9 +25,11 @@ import Label from '@playcanvas/pcui/Label/component';
 class ClusteredSpotShadowsExample extends Example {
     static CATEGORY = 'Graphics';
     static NAME = 'Clustered Spot Shadows';
+    static ENGINE = 'DEBUG';
 
     load() {
         return <>
+            <AssetLoader name='script' type='script' url='static/scripts/camera/orbit-camera.js' />
             <AssetLoader name="channels" type="texture" url="static/assets/textures/channels.png" />
             <AssetLoader name='normal' type='texture' url='static/assets/textures/normal-map.png' />
             <AssetLoader name='cubemap' type='cubemap' url='static/assets/cubemaps/helipad.dds' data={{ type: pc.TEXTURETYPE_RGBM }}/>
@@ -58,6 +60,9 @@ class ClusteredSpotShadowsExample extends Example {
                 </LabelGroup>
                 <Button text='Add Light' onClick={() => data.emit('add')}/>
                 <Button text='Remove Light' onClick={() => data.emit('remove')}/>
+                <LabelGroup text='Debug'>
+                    <BooleanInput type='toggle' binding={new BindingTwoWay()} link={{ observer: data, path: 'settings.debug' }} value={data.get('settings.debug')}/>
+                </LabelGroup>
             </Panel>
         </>;
     }
@@ -73,7 +78,8 @@ class ClusteredSpotShadowsExample extends Example {
             shadowType: pc.SHADOW_PCF3,      // shadow filter type
             shadowsEnabled: true,
             cookiesEnabled: true,
-            numLights: 0
+            numLights: 0,
+            debug: false
         });
 
         // setup skydome as ambient light
@@ -91,7 +97,7 @@ class ClusteredSpotShadowsExample extends Example {
 
         // 1) subdivide space with lights into this many cells:
         // @ts-ignore engine-tsd
-        lighting.cells = new pc.Vec3(20, 2, 20);
+        lighting.cells = new pc.Vec3(12, 4, 12);
 
         // 2) and allow this many lights per cell:
         // @ts-ignore engine-tsd
@@ -150,7 +156,7 @@ class ClusteredSpotShadowsExample extends Example {
             return primitive;
         }
 
-        createPrimitive("box", new pc.Vec3(0, 0, 0), new pc.Vec3(500, 0, 500));
+        const ground = createPrimitive("box", new pc.Vec3(0, 0, 0), new pc.Vec3(500, 0, 500));
 
         const numTowers = 8;
         for (let i = 0; i < numTowers; i++) {
@@ -220,16 +226,38 @@ class ClusteredSpotShadowsExample extends Example {
         const camera = new pc.Entity();
         camera.addComponent("camera", {
             clearColor: new pc.Color(0.2, 0.2, 0.2),
-            farClip: 1000,
-            nearClip: 0.1
+            farClip: 2000,
+            nearClip: 1
         });
         app.root.addChild(camera);
+        camera.setLocalPosition(300 * Math.sin(0), 150, 300 * Math.cos(0));
+
+        // add orbit camera script with a mouse and a touch support
+        camera.addComponent("script");
+        camera.script.create("orbitCamera", {
+            attributes: {
+                inertiaFactor: 0.2,
+                focusEntity: ground,
+                distanceMax: 1200,
+                frameOnStart: false
+            }
+        });
+        camera.script.create("orbitCameraInputMouse");
+        camera.script.create("orbitCameraInputTouch");
 
         // handle HUD changes - update properties on the scene
         data.on('*:set', (path: string, value: any) => {
             const pathArray = path.split('.');
-            // @ts-ignore
-            lighting[pathArray[1]] = value;
+
+            if (pathArray[1] === 'debug') {
+
+                // debug rendering of lighting clusters on world layer
+                lighting.debugLayer = value ? app.scene.layers.getLayerByName("World").id : undefined;
+
+            } else {
+                // @ts-ignore
+                lighting[pathArray[1]] = value;
+            }
         });
 
         function updateLightCount() {
@@ -271,10 +299,6 @@ class ClusteredSpotShadowsExample extends Example {
 
                 spotlight.rotateLocal(90, 0, 0);
             });
-
-            // orbit the camera
-            camera.setLocalPosition(300 * Math.sin(time * 0.4), 150, 300 * Math.cos(time * 0.4));
-            camera.lookAt(new pc.Vec3(0, 0, 0));
 
             // display shadow texture (debug feature, only works when depth is stored as color, which is webgl1)
             // app.drawTexture(-0.7, 0.7, 0.4, 0.4, app.renderer.lightTextureAtlas.shadowMap.texture);

--- a/examples/src/examples/graphics/clustered-spot-shadows.tsx
+++ b/examples/src/examples/graphics/clustered-spot-shadows.tsx
@@ -232,7 +232,7 @@ class ClusteredSpotShadowsExample extends Example {
         app.root.addChild(camera);
         camera.setLocalPosition(300 * Math.sin(0), 150, 300 * Math.cos(0));
 
-        // add orbit camera script with a mouse and a touch support
+        // add orbit camera script with mouse and touch support
         camera.addComponent("script");
         camera.script.create("orbitCamera", {
             attributes: {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -128,7 +128,8 @@ const moduleOptions = {
 };
 
 const stripOptions = {
-    functions: ['Debug.assert', 'Debug.deprecated', 'Debug.warn', 'Debug.error', 'Debug.log', 'Debug.pushGpuMarker', 'Debug.popGpuMarker']
+    functions: ['Debug.assert', 'Debug.deprecated', 'Debug.warn', 'Debug.error', 'Debug.log', 'Debug.pushGpuMarker', 'Debug.popGpuMarker',
+        'WorldClustersDebug.render']
 };
 
 const target_release_es5 = {

--- a/src/scene/light.js
+++ b/src/scene/light.js
@@ -664,7 +664,7 @@ class Light {
             box.center.set(0, -range * 0.5, 0);
             box.halfExtents.set(scl, range * 0.5, scl);
 
-            box.setFromTransformedAabb(box, node.getWorldTransform());
+            box.setFromTransformedAabb(box, node.getWorldTransform(), true);
 
         } else if (this._type === LIGHTTYPE_OMNI) {
             box.center.copy(this._node.getPosition());

--- a/src/scene/lighting/lighting-params.js
+++ b/src/scene/lighting/lighting-params.js
@@ -19,6 +19,9 @@ class LightingParams {
 
         this._cookiesEnabled = false;
         this._cookieAtlasResolution = 2048;
+
+        // Layer ID of a layer for which the debug clustering is rendered
+        this.debugLayer = undefined;
     }
 
     set cells(value) {

--- a/src/scene/lighting/world-clusters-debug.js
+++ b/src/scene/lighting/world-clusters-debug.js
@@ -1,0 +1,189 @@
+import { Mat4 } from "../../math/mat4.js";
+import { Vec3 } from "../../math/vec3.js";
+import { Color } from "../../math/color.js";
+import { GraphNode } from "../graph-node.js";
+import { MeshInstance } from "../mesh-instance.js";
+import { PRIMITIVE_TRIANGLES } from '../../graphics/constants.js';
+import { Mesh } from "../mesh.js";
+
+class WorldClustersDebug {
+    static gridPositions = [];
+
+    static gridColors = [];
+
+    static mesh = null;
+
+    static meshInstance = null;
+
+    static colorLow = new Vec3(1, 1, 1);
+
+    static colorHigh = new Vec3(40, 0, 0);
+
+    static render(worldClusters, scene) {
+
+        const device = scene.device;
+        const cells = worldClusters.cells;
+        const lightsBuffer = worldClusters.lightsBuffer;
+        const boundsMin = lightsBuffer.boundsMin;
+        const boundsDelta = lightsBuffer.boundsDelta;
+        const boundsMax = boundsMin.clone().add(boundsDelta);
+        const cellDelta = lightsBuffer.boundsDelta.clone().div(cells);
+
+        const gridPositions = WorldClustersDebug.gridPositions;
+        const gridColors = WorldClustersDebug.gridColors;
+
+        const c1 = new Color(0.3, 0.3, 0.3);
+
+        const renderCellLines = (countA, countB, minA, deltaA, minB, deltaB, minC, maxC, order) => {
+            for (let a = 0; a <= countA; a++) {
+                for (let b = 0; b <= countB; b++) {
+                    const aa = minA + a * deltaA;
+                    const bb = minB + b * deltaB;
+                    if (order === 0)
+                        gridPositions.push(aa, minC, bb, aa, maxC, bb);
+                    else if (order === 1)
+                        gridPositions.push(aa, bb, minC, aa, bb, maxC);
+                    else if (order === 2)
+                        gridPositions.push(minC, aa, bb, maxC, aa, bb);
+                }
+            }
+        };
+
+        // generate grid lines
+        renderCellLines(cells.x, cells.z, boundsMin.x, cellDelta.x, boundsMin.z, cellDelta.z, boundsMin.y, boundsMax.y, 0);
+        renderCellLines(cells.x, cells.y, boundsMin.x, cellDelta.x, boundsMin.y, cellDelta.y, boundsMin.z, boundsMax.z, 1);
+        renderCellLines(cells.y, cells.z, boundsMin.y, cellDelta.y, boundsMin.z, cellDelta.z, boundsMin.x, boundsMax.x, 2);
+
+        // render grid lines
+        if (gridPositions.length) {
+
+            // update colors only when needed
+            const numVerts = gridPositions.length / 3;
+            if (numVerts != gridColors.length / 4) {
+                gridColors.length = 0;
+                for (let i = 0; i < numVerts; i++) {
+                    gridColors.push(c1.r, c1.g, c1.b, c1.a);
+                }
+            }
+
+            scene.drawLineArrays(gridPositions, gridColors);
+            gridPositions.length = 0;
+        }
+
+        // render cell occupancy
+        let mesh = WorldClustersDebug.mesh;
+        if (!mesh) {
+            mesh = new Mesh(device);
+            mesh.clear(true, true);
+            WorldClustersDebug.mesh = mesh;
+        }
+
+        const positions = [];
+        const colors = [];
+        const indices = [];
+
+        const divX = worldClusters._cells.x;
+        const divZ = worldClusters._cells.z;
+        const counts = worldClusters.counts;
+        const limit = worldClusters._maxCellLightCount;
+
+        const min = new Vec3();
+        const max = new Vec3();
+        const col = new Vec3();
+        const step = boundsDelta.clone().div(cells);
+
+        // add cubes with a color representing cell occupancy to the dynamic mesh
+        let cubes = 0;
+        for (let x = 0; x < cells.x; x++) {
+            for (let z = 0; z < cells.z; z++) {
+                for (let y = 0; y < cells.y; y++) {
+
+                    const clusterIndex = x + divX * (z + y * divZ);
+                    const count = counts[clusterIndex];
+
+                    if (count > 0) {
+
+                        // cube corneres
+                        min.x = boundsMin.x + step.x * x;
+                        min.y = boundsMin.y + step.y * y;
+                        min.z = boundsMin.z + step.z * z;
+                        max.add2(min, step);
+
+                        positions.push(min.x, min.y, max.z);
+                        positions.push(max.x, min.y, max.z);
+                        positions.push(max.x, max.y, max.z);
+                        positions.push(min.x, max.y, max.z);
+
+                        positions.push(max.x, min.y, min.z);
+                        positions.push(min.x, min.y, min.z);
+                        positions.push(min.x, max.y, min.z);
+                        positions.push(max.x, max.y, min.z);
+
+                        col.lerp(WorldClustersDebug.colorLow, WorldClustersDebug.colorHigh, count / limit).round();
+                        for (let c = 0; c < 8; c++) {
+                            colors.push(col.x, col.y, col.z, 1);
+                        }
+
+                        // back
+                        indices.push(cubes * 8 + 0, cubes * 8 + 1, cubes * 8 + 3);
+                        indices.push(cubes * 8 + 3, cubes * 8 + 1, cubes * 8 + 2);
+
+                        // front
+                        indices.push(cubes * 8 + 4, cubes * 8 + 5, cubes * 8 + 7);
+                        indices.push(cubes * 8 + 7, cubes * 8 + 5, cubes * 8 + 6);
+
+                        // top
+                        indices.push(cubes * 8 + 3, cubes * 8 + 2, cubes * 8 + 6);
+                        indices.push(cubes * 8 + 2, cubes * 8 + 7, cubes * 8 + 6);
+
+                        // bottom
+                        indices.push(cubes * 8 + 1, cubes * 8 + 0, cubes * 8 + 4);
+                        indices.push(cubes * 8 + 0, cubes * 8 + 5, cubes * 8 + 4);
+
+                        // right
+                        indices.push(cubes * 8 + 1, cubes * 8 + 4, cubes * 8 + 2);
+                        indices.push(cubes * 8 + 4, cubes * 8 + 7, cubes * 8 + 2);
+
+                        // left
+                        indices.push(cubes * 8 + 5, cubes * 8 + 0, cubes * 8 + 6);
+                        indices.push(cubes * 8 + 0, cubes * 8 + 3, cubes * 8 + 6);
+
+                        cubes++;
+                    }
+                }
+            }
+        }
+
+        if (cubes) {
+            mesh.setPositions(positions);
+            mesh.setColors32(colors);
+            mesh.setIndices(indices);
+            mesh.update(PRIMITIVE_TRIANGLES, false);
+
+
+            if (!WorldClustersDebug.meshInstance) {
+                const material = new pc.StandardMaterial();
+                material.useLighting = false;
+                material.emissive = new pc.Color(1, 1, 1);
+                material.emissiveVertexColor = true;
+                material.emissiveTint = false;
+                material.blendType = pc.BLEND_ADDITIVEALPHA;
+                material.depthWrite = false;
+                material.update();
+
+                const node = new GraphNode("WorldClustersDebug");
+                node.worldTransform = Mat4.IDENTITY;
+                node._dirtyWorld = node._dirtyNormal = false;
+
+                WorldClustersDebug.meshInstance = new MeshInstance(mesh, material, node);
+                WorldClustersDebug.meshInstance.cull = false;
+            }
+
+            // render
+            const meshInstance = WorldClustersDebug.meshInstance;
+            scene.immediate.drawMesh(meshInstance.material, meshInstance.node.worldTransform, null, meshInstance, scene.defaultDrawLayer);
+        }
+    }
+}
+
+export { WorldClustersDebug };

--- a/src/scene/lighting/world-clusters-debug.js
+++ b/src/scene/lighting/world-clusters-debug.js
@@ -59,7 +59,7 @@ class WorldClustersDebug {
 
             // update colors only when needed
             const numVerts = gridPositions.length / 3;
-            if (numVerts != gridColors.length / 4) {
+            if (numVerts !== gridColors.length / 4) {
                 gridColors.length = 0;
                 for (let i = 0; i < numVerts; i++) {
                     gridColors.push(c1.r, c1.g, c1.b, c1.a);

--- a/src/scene/lighting/world-clusters.js
+++ b/src/scene/lighting/world-clusters.js
@@ -36,9 +36,6 @@ class WorldClusters {
         // number of times a warning was reported
         this.reportCount = 0;
 
-        // bounds of all lights
-        this._bounds = new BoundingBox();
-
         // bounds of all light volumes (volume covered by the clusters)
         this.boundsMin = new Vec3();
         this.boundsMax = new Vec3();

--- a/src/shape/bounding-box.js
+++ b/src/shape/bounding-box.js
@@ -288,21 +288,49 @@ class BoundingBox {
      *
      * @param {BoundingBox} aabb - Box to transform and enclose.
      * @param {Mat4} m - Transformation matrix to apply to source AABB.
+     * @param {boolean} ignoreScale - If true is specified, a scale from the matrix is ignored. Defaults to false.
      */
-    setFromTransformedAabb(aabb, m) {
+    setFromTransformedAabb(aabb, m, ignoreScale = false) {
         const ac = aabb.center;
         const ar = aabb.halfExtents;
 
         const d = m.data;
-        const mx0 = d[0];
-        const mx1 = d[4];
-        const mx2 = d[8];
-        const my0 = d[1];
-        const my1 = d[5];
-        const my2 = d[9];
-        const mz0 = d[2];
-        const mz1 = d[6];
-        const mz2 = d[10];
+        let mx0 = d[0];
+        let mx1 = d[4];
+        let mx2 = d[8];
+        let my0 = d[1];
+        let my1 = d[5];
+        let my2 = d[9];
+        let mz0 = d[2];
+        let mz1 = d[6];
+        let mz2 = d[10];
+
+        // renormalize axis if scale is to be ignored
+        if (ignoreScale) {
+            let lengthSq = mx0 * mx0 + mx1 * mx1 + mx2 * mx2;
+            if (lengthSq > 0) {
+                const invLength = 1 / Math.sqrt(lengthSq);
+                mx0 *= invLength;
+                mx1 *= invLength;
+                mx2 *= invLength;
+            }
+
+            lengthSq = my0 * my0 + my1 * my1 + my2 * my2;
+            if (lengthSq > 0) {
+                const invLength = 1 / Math.sqrt(lengthSq);
+                my0 *= invLength;
+                my1 *= invLength;
+                my2 *= invLength;
+            }
+
+            lengthSq = mz0 * mz0 + mz1 * mz1 + mz2 * mz2;
+            if (lengthSq > 0) {
+                const invLength = 1 / Math.sqrt(lengthSq);
+                mz0 *= invLength;
+                mz1 *= invLength;
+                mz2 *= invLength;
+            }
+        }
 
         this.center.set(
             d[12] + mx0 * ac.x + mx1 * ac.y + mx2 * ac.z,


### PR DESCRIPTION
- new WorldClustersDebug class, available in the debug build of the engine, responsible for rendering cluster cells
- fix to bounding box evaluation of the spot light. It was incorrectly using scale of its worldMatrix to scale the bounds, making lights less likely to be culled, and also occupying large area in clusters.

**New API (private for now)**
- **app.scene.lighting.debugLayer** - allows to enable debug rendering of clusters on a layer, or disable it by setting to undefined

**Updated public API**
- **BoundingBox.setFromTransformedAabb** - added optional parameter allowing the scale to be ignored when aabb is transformed by a matrix

![Screenshot 2022-01-05 at 11 44 15](https://user-images.githubusercontent.com/59932779/148215754-b303521f-1412-4f8d-88e2-e0d25068507c.png)
