### PR TITLE
[Fix] Improved handling of the ownership of Morph by Mesh

### DIFF
--- a/examples/src/examples/graphics/mesh-morph.tsx
+++ b/examples/src/examples/graphics/mesh-morph.tsx
@@ -132,7 +132,7 @@ class MeshMorphExample extends Example {
             time += dt;
 
             for (let m = 0; m < morphInstances.length; m++) {
-            // modify weights of all 3 morph targets along some sin curve with different frequency
+                // modify weights of all 3 morph targets along some sin curve with different frequency
                 morphInstances[m].setWeight(0, Math.abs(Math.sin(time + m)));
                 morphInstances[m].setWeight(1, Math.abs(Math.sin(time * 0.3 + m)));
                 morphInstances[m].setWeight(2, Math.abs(Math.sin(time * 0.7 + m)));

--- a/src/scene/mesh.js
+++ b/src/scene/mesh.js
@@ -227,12 +227,7 @@ class Mesh extends RefCountedObject {
          */
         this.skin = null;
 
-        /**
-         * The morph data (if any) that drives morph target animations for this mesh.
-         *
-         * @type {Morph|null}
-         */
-        this.morph = null;
+        this._morph = null;
         this._geometryData = null;
 
         // AABB for object space mesh vertices
@@ -240,6 +235,30 @@ class Mesh extends RefCountedObject {
 
         // Array of object space AABBs of vertices affected by each bone
         this.boneAabb = null;
+    }
+
+    /**
+     * The morph data (if any) that drives morph target animations for this mesh.
+     *
+     * @type {Morph|null}
+     */
+    set morph(morph) {
+
+        if (morph !== this._morph) {
+            if (this._morph) {
+                this._morph.decRefCount();
+            }
+
+            this._morph = morph;
+
+            if (morph) {
+                morph.incRefCount();
+            }
+        }
+    }
+
+    get morph() {
+        return this._morph;
     }
 
     /**
@@ -260,6 +279,19 @@ class Mesh extends RefCountedObject {
      * normally called by {@link Model#destroy} and does not need to be called manually.
      */
     destroy() {
+
+        const morph = this.morph;
+        if (morph) {
+
+            // this decreases ref count on the morph
+            this.morph = null;
+
+            // destroy morph
+            if (morph.getRefCount() < 1) {
+                morph.destroy();
+            }
+        }
+
         if (this.vertexBuffer) {
             this.vertexBuffer.destroy();
             this.vertexBuffer = null;


### PR DESCRIPTION
Fixes https://github.com/playcanvas/engine/issues/3824

Improvement to ownership of morph by the Mesh - it correctly handles ref-counting, similarly to how MeshInstance handles ownership of the Mesh, or the way MorphInstance handles Morph.