### PR TITLE
Render target limits number of samples to supported maximum

### DIFF
--- a/examples/src/examples/graphics/render-to-texture.tsx
+++ b/examples/src/examples/graphics/render-to-texture.tsx
@@ -70,7 +70,8 @@ class RenderToTextureExample extends Example {
             colorBuffer: texture,
             depth: true,
             // @ts-ignore
-            flipY: true
+            flipY: true,
+            samples: 2
         });
 
         // create a layer for object that do not render into texture

--- a/src/graphics/graphics-device.js
+++ b/src/graphics/graphics-device.js
@@ -1339,7 +1339,7 @@ class GraphicsDevice extends EventHandler {
         // #endif
 
         // Set RT's device
-        target._device = this;
+        target.device = this;
         const gl = this.gl;
 
         // ##### Create main FBO #####

--- a/src/graphics/graphics-device.js
+++ b/src/graphics/graphics-device.js
@@ -1338,8 +1338,6 @@ class GraphicsDevice extends EventHandler {
         });
         // #endif
 
-        // Set RT's device
-        target.device = this;
         const gl = this.gl;
 
         // ##### Create main FBO #####

--- a/src/graphics/render-target.js
+++ b/src/graphics/render-target.js
@@ -88,9 +88,6 @@ class RenderTarget {
             this._colorBuffer._isRenderTarget = true;
         }
 
-        // device, gets assigned when the framebuffer is created during the rendering
-        this._device = null;
-
         this._glFrameBuffer = null;
         this._glDepthBuffer = null;
 
@@ -117,7 +114,11 @@ class RenderTarget {
             this._stencil = (options.stencil !== undefined) ? options.stencil : false;
         }
 
-        this._samples = (options.samples !== undefined) ? options.samples : 1;
+        // device, from one of the buffers
+        this._device = this._colorBuffer?.device || this._depthBuffer?.device;
+        Debug.assert(this._device, "Failed to obtain the device, colorBuffer nor depthBuffer store it.");
+
+        this._samples = (options.samples !== undefined) ? Math.min(options.samples, this._device.maxSamples) : 1;
         this.autoResolve = (options.autoResolve !== undefined) ? options.autoResolve : true;
         this._glResolveFrameBuffer = null;
         this._glMsaaColorBuffer = null;
@@ -310,17 +311,6 @@ class RenderTarget {
      */
     get height() {
         return this._colorBuffer ? this._colorBuffer.height : this._depthBuffer.height;
-    }
-
-    set device(device) {
-        this._device = device;
-
-        // validate properties
-        this._samples = Math.min(this._samples, device.maxSamples);
-    }
-
-    get device() {
-        return this._device;
     }
 }
 

--- a/src/graphics/render-target.js
+++ b/src/graphics/render-target.js
@@ -311,6 +311,17 @@ class RenderTarget {
     get height() {
         return this._colorBuffer ? this._colorBuffer.height : this._depthBuffer.height;
     }
+
+    set device(device) {
+        this._device = device;
+
+        // validate properties
+        this._samples = Math.min(this._samples, device.maxSamples);
+    }
+
+    get device() {
+        return this._device;
+    }
 }
 
 export { RenderTarget };


### PR DESCRIPTION
Fixes https://github.com/playcanvas/engine/issues/3813

If more than supported number of samples are requested, the value is clamped to valid range when the framebuffer is created.