### PR TITLE
Fix call to `Array#concat` in `_findTransition`

### DIFF
--- a/src/anim/controller/anim-controller.js
+++ b/src/anim/controller/anim-controller.js
@@ -264,7 +264,7 @@ class AnimController {
 
         // If from and to are supplied, find transitions that include the required source and destination states
         if (from && to) {
-            transitions.concat(this._findTransitionsBetweenStates(from, to));
+            transitions = transitions.concat(this._findTransitionsBetweenStates(from, to));
         } else {
             // If no transition is active, look for transitions from the active & any states.
             if (!this._isTransitioning) {


### PR DESCRIPTION
Fixes #3854

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
