### PR TITLE
Fix shift out of range

### DIFF
--- a/src/math/math.js
+++ b/src/math/math.js
@@ -115,7 +115,7 @@ const math = {
 
         // Why ((r << 24)>>>0)?
         // << operator uses signed 32 bit numbers, so 128<<24 is negative.
-        // >>> used unsigned so >>>32 converts back to an unsigned.
+        // >>> used unsigned so >>>0 converts back to an unsigned.
         // See http://stackoverflow.com/questions/1908492/unsigned-integer-in-javascript
         return ((r << 24) | (g << 16) | (b << 8) | a) >>> 0;
     },

--- a/src/math/math.js
+++ b/src/math/math.js
@@ -1,7 +1,3 @@
-// Scratch buffer for bytesToInt32
-const buffer = new ArrayBuffer(4);
-const view = new DataView(buffer);
-
 /**
  * Math API.
  *
@@ -116,11 +112,12 @@ const math = {
             g = r[1];
             r = r[0];
         }
-        view.setUint8(0, r);
-        view.setUint8(1, g);
-        view.setUint8(2, b);
-        view.setUint8(3, a);
-        return view.getUint32(0);
+
+        // Why ((r << 24)>>>0)?
+        // << operator uses signed 32 bit numbers, so 128<<24 is negative.
+        // >>> used unsigned so >>>32 converts back to an unsigned.
+        // See http://stackoverflow.com/questions/1908492/unsigned-integer-in-javascript
+        return ((r << 24) | (g << 16) | (b << 8) | a) >>> 0;
     },
 
     /**

--- a/src/math/math.js
+++ b/src/math/math.js
@@ -1,3 +1,4 @@
+// Scratch buffer for bytesToInt32
 const buffer = new ArrayBuffer(4);
 const view = new DataView(buffer);
 

--- a/src/math/math.js
+++ b/src/math/math.js
@@ -1,3 +1,6 @@
+const buffer = new ArrayBuffer(4);
+const view = new DataView(buffer);
+
 /**
  * Math API.
  *
@@ -112,11 +115,11 @@ const math = {
             g = r[1];
             r = r[0];
         }
-        // Why ((r << 24)>>>32)?
-        // << operator uses signed 32 bit numbers, so 128<<24 is negative.
-        // >>> used unsigned so >>>32 converts back to an unsigned.
-        // See http://stackoverflow.com/questions/1908492/unsigned-integer-in-javascript
-        return ((r << 24) | (g << 16) | (b << 8) | a) >>> 32;
+        view.setUint8(0, r);
+        view.setUint8(1, g);
+        view.setUint8(2, b);
+        view.setUint8(3, a);
+        return view.getUint32(0);
     },
 
     /**

--- a/test/math/math.test.mjs
+++ b/test/math/math.test.mjs
@@ -59,10 +59,24 @@ describe('math', function () {
 
     describe('#bytesToInt32', function () {
 
-        it('converts a 4-element byte array to an integer', function () {
-            var b = [0xaa, 0xbb, 0xcc, 0xdd];
-            var i = math.bytesToInt32(b);
-            expect(i).to.equal(0xaabbccdd);
+        it('packs 4 unsigned bytes into a 32-bit unsigned int', function () {
+            const uint32 = math.bytesToInt32(0xaa, 0xbb, 0xcc, 0xdd);
+            expect(uint32).to.equal(0xaabbccdd);
+        });
+
+        it('packs an array of 4 unsigned bytes into a 32-bit unsigned int', function () {
+            var uint32 = math.bytesToInt32([0xaa, 0xbb, 0xcc, 0xdd]);
+            expect(uint32).to.equal(0xaabbccdd);
+        });
+
+        it('returns 0 when all supplied bytes are 0', function () {
+            const uint32 = math.bytesToInt32(0, 0, 0, 0);
+            expect(uint32).to.equal(0);
+        });
+
+        it('returns 2 ^ 32 - 1 when all supplied bytes are 255', function () {
+            const uint32 = math.bytesToInt32(255, 255, 255, 255);
+            expect(uint32).to.equal(Math.pow(2, 32) - 1);
         });
 
     });

--- a/test/math/math.test.mjs
+++ b/test/math/math.test.mjs
@@ -7,7 +7,7 @@ describe('math', function () {
     describe('#DEG_TO_RAD', function () {
 
         it('converts degrees to radians', function () {
-            var deg = 180;
+            const deg = 180;
             expect(deg * math.DEG_TO_RAD).to.equal(Math.PI);
         });
 
@@ -16,7 +16,7 @@ describe('math', function () {
     describe('#RAD_TO_DEG', function () {
 
         it('converts radians to degrees', function () {
-            var rad = Math.PI;
+            const rad = Math.PI;
             expect(rad * math.RAD_TO_DEG).to.equal(180);
         });
 
@@ -49,10 +49,24 @@ describe('math', function () {
 
     describe('#bytesToInt24', function () {
 
-        it('converts a 3-element byte array to an integer', function () {
-            var b = [0xaa, 0xbb, 0xcc];
-            var i = math.bytesToInt24(b);
-            expect(i).to.equal(0xaabbcc);
+        it('packs 3 unsigned bytes into a 24-bit unsigned int', function () {
+            const uint24 = math.bytesToInt24(0xaa, 0xbb, 0xcc);
+            expect(uint24).to.equal(0xaabbcc);
+        });
+
+        it('packs an array of 3 unsigned bytes into a 24-bit unsigned int', function () {
+            const uint24 = math.bytesToInt24([0xaa, 0xbb, 0xcc]);
+            expect(uint24).to.equal(0xaabbcc);
+        });
+
+        it('returns 0 when all supplied bytes are 0', function () {
+            const uint24 = math.bytesToInt24(0, 0, 0);
+            expect(uint24).to.equal(0);
+        });
+
+        it('returns 2 ^ 24 - 1 when all supplied bytes are 255', function () {
+            const uint24 = math.bytesToInt24(255, 255, 255);
+            expect(uint24).to.equal(Math.pow(2, 24) - 1);
         });
 
     });
@@ -65,7 +79,7 @@ describe('math', function () {
         });
 
         it('packs an array of 4 unsigned bytes into a 32-bit unsigned int', function () {
-            var uint32 = math.bytesToInt32([0xaa, 0xbb, 0xcc, 0xdd]);
+            const uint32 = math.bytesToInt32([0xaa, 0xbb, 0xcc, 0xdd]);
             expect(uint32).to.equal(0xaabbccdd);
         });
 
@@ -100,8 +114,8 @@ describe('math', function () {
     describe('#intToBytes24', function () {
 
         it('converts an integer to a 3-element byte array', function () {
-            var i = 0x112233;
-            var b = math.intToBytes24(i);
+            const i = 0x112233;
+            const b = math.intToBytes24(i);
             expect(b[0]).to.equal(0x11);
             expect(b[1]).to.equal(0x22);
             expect(b[2]).to.equal(0x33);
@@ -112,8 +126,8 @@ describe('math', function () {
     describe('#intToBytes32', function () {
 
         it('converts an integer to a 4-element byte array', function () {
-            var i = 0x11223344;
-            var b = math.intToBytes32(i);
+            const i = 0x11223344;
+            const b = math.intToBytes32(i);
             expect(b[0]).to.equal(0x11);
             expect(b[1]).to.equal(0x22);
             expect(b[2]).to.equal(0x33);
@@ -220,7 +234,7 @@ describe('math', function () {
     describe('#random', function () {
 
         it('returns a random number between 0 and 1', function () {
-            var r = math.random(100, 101);
+            const r = math.random(100, 101);
             expect(r).to.be.at.least(100);
             expect(r).to.be.at.most(101);
         });


### PR DESCRIPTION
Fixes:

![image](https://user-images.githubusercontent.com/697563/148836588-592f554b-f0e4-4367-b526-25e3c6d86e83.png)

While the code in `bytesToInt32` works fine, LGTM complains, but also, it requires fairly deep understanding of how numbers are represented in JavaScript. This PR makes the code far easier for anybody to understand. And yes, I know it will be slower, but for readability purposes (plus fixing that LGTM error), I'm happy to update it.

The PR also improves related unit tests as well.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
