### PR TITLE
Move deprecated properties out of standard-material.js

### DIFF
--- a/src/deprecated/deprecated.js
+++ b/src/deprecated/deprecated.js
@@ -638,6 +638,31 @@ Material.prototype.setShader = function (shader) {
     this.shader = shader;
 };
 
+function _defineAlias(newName, oldName) {
+    Object.defineProperty(StandardMaterial.prototype, oldName, {
+        get: function () {
+            Debug.deprecated(`pc.StandardMaterial#${oldName} is deprecated. Use pc.StandardMaterial#${newName} instead.`);
+            return this[newName];
+        },
+        set: function (value) {
+            Debug.deprecated(`pc.StandardMaterial#${oldName} is deprecated. Use pc.StandardMaterial#${newName} instead.`);
+            this[newName] = value;
+        }
+    });
+}
+
+_defineAlias("diffuseTint", "diffuseMapTint");
+_defineAlias("specularTint", "specularMapTint");
+_defineAlias("emissiveTint", "emissiveMapTint");
+_defineAlias("aoVertexColor", "aoMapVertexColor");
+_defineAlias("diffuseVertexColor", "diffuseMapVertexColor");
+_defineAlias("specularVertexColor", "specularMapVertexColor");
+_defineAlias("emissiveVertexColor", "emissiveMapVertexColor");
+_defineAlias("metalnessVertexColor", "metalnessMapVertexColor");
+_defineAlias("glossVertexColor", "glossMapVertexColor");
+_defineAlias("opacityVertexColor", "opacityMapVertexColor");
+_defineAlias("lightVertexColor", "lightMapVertexColor");
+
 // ANIMATION
 
 export const anim = {

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -970,17 +970,6 @@ function _defineObject(name, getUniformFunc) {
     defineUniform(name, getUniformFunc);
 }
 
-function _defineAlias(newName, oldName) {
-    Object.defineProperty(StandardMaterial.prototype, oldName, {
-        get: function () {
-            return this[newName];
-        },
-        set: function (value) {
-            this[newName] = value;
-        }
-    });
-}
-
 function _defineFlag(name, defaultValue) {
     defineProp({
         name: name,
@@ -1096,18 +1085,6 @@ function _defineMaterialProps() {
     _defineObject("cubeMap");
     _defineObject("sphereMap");
     _defineObject("envAtlas");
-
-    _defineAlias("diffuseTint", "diffuseMapTint");
-    _defineAlias("specularTint", "specularMapTint");
-    _defineAlias("emissiveTint", "emissiveMapTint");
-    _defineAlias("aoVertexColor", "aoMapVertexColor");
-    _defineAlias("diffuseVertexColor", "diffuseMapVertexColor");
-    _defineAlias("specularVertexColor", "specularMapVertexColor");
-    _defineAlias("emissiveVertexColor", "emissiveMapVertexColor");
-    _defineAlias("metalnessVertexColor", "metalnessMapVertexColor");
-    _defineAlias("glossVertexColor", "glossMapVertexColor");
-    _defineAlias("opacityVertexColor", "opacityMapVertexColor");
-    _defineAlias("lightVertexColor", "lightMapVertexColor");
 
     // prefiltered cubemap getter
     const getterFunc = function () {


### PR DESCRIPTION
Moved aliased (deprecated) `StandardMaterial`  properties from `standard-material.js` to `deprecated.js`.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
