### PR TITLE
Smart atlas slot distribution for clustered light shadows and cookies

### DIFF
--- a/examples/src/examples/graphics/clustered-spot-shadows.tsx
+++ b/examples/src/examples/graphics/clustered-spot-shadows.tsx
@@ -31,6 +31,7 @@ class ClusteredSpotShadowsExample extends Example {
         return <>
             <AssetLoader name='script' type='script' url='static/scripts/camera/orbit-camera.js' />
             <AssetLoader name="channels" type="texture" url="static/assets/textures/channels.png" />
+            <AssetLoader name="heart" type="texture" url="static/assets/textures/heart.png" />
             <AssetLoader name='normal' type='texture' url='static/assets/textures/normal-map.png' />
             <AssetLoader name='cubemap' type='cubemap' url='static/assets/cubemaps/helipad.dds' data={{ type: pc.TEXTURETYPE_RGBM }}/>
         </>;
@@ -38,7 +39,18 @@ class ClusteredSpotShadowsExample extends Example {
 
     controls(data: Observer) {
         return <>
-            <Panel headerText='Settings'>
+            <Panel headerText='Atlas'>
+                <LabelGroup text='Resolution'>
+                    <SliderInput binding={new BindingTwoWay()} link={{ observer: data, path: 'settings.shadowAtlasResolution' }} min={256} max={4096} precision={0}/>
+                </LabelGroup>
+                {<LabelGroup text='Split'>
+                    <SelectInput binding={new BindingTwoWay()} link={{ observer: data, path: 'settings.atlasSplit' }} type="number" options={[
+                        { v: 0, t: 'Automatic' },
+                        { v: 1, t: '7 Shadows' },
+                        { v: 2, t: '12 Shadows' },
+                        { v: 3, t: '16 Shadows' }
+                    ]} />
+                </LabelGroup>}
                 {<LabelGroup text='Filter'>
                     <SelectInput binding={new BindingTwoWay()} link={{ observer: data, path: 'settings.shadowType' }} type="number" options={[
                         { v: pc.SHADOW_PCF1, t: 'PCF1' },
@@ -46,22 +58,29 @@ class ClusteredSpotShadowsExample extends Example {
                         { v: pc.SHADOW_PCF5, t: 'PCF5' }
                     ]} />
                 </LabelGroup>}
-                <LabelGroup text='Shadow Res'>
-                    <SliderInput binding={new BindingTwoWay()} link={{ observer: data, path: 'settings.shadowAtlasResolution' }} min={256} max={4096} precision={0}/>
-                </LabelGroup>
+            </Panel>
+            <Panel headerText='Lights'>
                 <LabelGroup text='Shadows On'>
                     <BooleanInput type='toggle' binding={new BindingTwoWay()} link={{ observer: data, path: 'settings.shadowsEnabled' }} value={data.get('settings.shadowsEnabled')}/>
                 </LabelGroup>
                 <LabelGroup text='Cookies On'>
                     <BooleanInput type='toggle' binding={new BindingTwoWay()} link={{ observer: data, path: 'settings.cookiesEnabled' }} value={data.get('settings.cookiesEnabled')}/>
                 </LabelGroup>
-                <LabelGroup text='Light Count'>
-                    <Label binding={new BindingTwoWay()} link={{ observer: data, path: 'settings.numLights' }} value={data.get('settings.numLights')}/>
+                <LabelGroup text='Static'>
+                    <BooleanInput type='toggle' binding={new BindingTwoWay()} link={{ observer: data, path: 'settings.static' }} value={data.get('settings.static')}/>
                 </LabelGroup>
                 <Button text='Add Light' onClick={() => data.emit('add')}/>
                 <Button text='Remove Light' onClick={() => data.emit('remove')}/>
-                <LabelGroup text='Debug'>
+                <LabelGroup text='Light Count'>
+                    <Label binding={new BindingTwoWay()} link={{ observer: data, path: 'settings.numLights' }} value={data.get('settings.numLights')}/>
+                </LabelGroup>
+            </Panel>
+            <Panel headerText='Debug'>
+                <LabelGroup text='Cells'>
                     <BooleanInput type='toggle' binding={new BindingTwoWay()} link={{ observer: data, path: 'settings.debug' }} value={data.get('settings.debug')}/>
+                </LabelGroup>
+                <LabelGroup text='Atlas'>
+                    <BooleanInput type='toggle' binding={new BindingTwoWay()} link={{ observer: data, path: 'settings.debugAtlas' }} value={data.get('settings.debugAtlas')}/>
                 </LabelGroup>
             </Panel>
         </>;
@@ -79,7 +98,10 @@ class ClusteredSpotShadowsExample extends Example {
             shadowsEnabled: true,
             cookiesEnabled: true,
             numLights: 0,
-            debug: false
+            debug: false,
+            debugAtlas: false,
+            splitOptions: 0,
+            static: false
         });
 
         // setup skydome as ambient light
@@ -115,6 +137,19 @@ class ClusteredSpotShadowsExample extends Example {
         // resolution of the shadow and cookie atlas
         lighting.shadowAtlasResolution = data.get('settings.shadowAtlasResolution');
         lighting.cookieAtlasResolution = 1500;
+
+        const splitOptions = [
+            undefined,          // automatic - split atlas each frame to give all required lights an equal size
+            [2, 1, 1, 2, 1],    // 7 shadows: split atlas to 2x2 (first number), and split created quarters to 1x1, 1x1, 2x2, 1x1
+            [3, 2],             // 12 shadows: split atlas to 3x3 (first number), and split one of the created parts to 2x2
+            [4]                 // 16 shadows: split atlas to 4x4
+        ];
+
+        // lights are static (not moving and so do not need to update shadows) or dynamic
+        let lightsStatic = false;
+
+        // debug rendering is enabled
+        let debugAtlas = false;
 
         // Set the canvas to fill the window and automatically change resolution to be the same as the canvas size
         app.setCanvasFillMode(pc.FILLMODE_FILL_WINDOW);
@@ -156,6 +191,7 @@ class ClusteredSpotShadowsExample extends Example {
             return primitive;
         }
 
+        // create some visible geometry
         const ground = createPrimitive("box", new pc.Vec3(0, 0, 0), new pc.Vec3(500, 0, 500));
 
         const numTowers = 8;
@@ -176,11 +212,14 @@ class ClusteredSpotShadowsExample extends Example {
         const spotLightList: Array<pc.Entity> = [];
         const cookieChannels = ["r", "g", "b", "a", "rgb"];
 
-        function createLight() {
+        // helper function to create a light
+        function createLight(index: number) {
             const intensity = 1.5;
             const color = new pc.Color(intensity * Math.random(), intensity * Math.random(), intensity * Math.random(), 1);
-            const lightSpot = new pc.Entity("Spot");
-            const cookieChannel = cookieChannels[Math.floor(Math.random() * cookieChannels.length)];
+            const lightSpot = new pc.Entity(`Spot-${index}`);
+            const heartTexture = Math.random() < 0.5;
+            const cookieTexture = heartTexture ? assets.heart : assets.channels;
+            const cookieChannel = heartTexture ? "a" : cookieChannels[Math.floor(Math.random() * cookieChannels.length)];
 
             lightSpot.addComponent("light", {
                 type: "spot",
@@ -194,8 +233,11 @@ class ClusteredSpotShadowsExample extends Example {
                 normalOffsetBias: 0.1,
                 shadowResolution: 512,      // only used when clustering is off
 
+                // when lights are static, only render shadows one time (or as needed when they use different atlas slot)
+                shadowUpdateMode: lightsStatic ? pc.SHADOWUPDATE_THISFRAME : pc.SHADOWUPDATE_REALTIME,
+
                 // cookie texture
-                cookie: assets.channels.resource,
+                cookie: cookieTexture.resource,
                 cookieChannel: cookieChannel,
                 cookieIntensity: 0.5
             });
@@ -218,7 +260,7 @@ class ClusteredSpotShadowsExample extends Example {
         // create many spot lights
         const count = 10;
         for (let i = 0; i < count; i++) {
-            createLight();
+            createLight(i);
         }
         updateLightCount();
 
@@ -248,11 +290,25 @@ class ClusteredSpotShadowsExample extends Example {
         // handle HUD changes - update properties on the scene
         data.on('*:set', (path: string, value: any) => {
             const pathArray = path.split('.');
+            if (pathArray[1] === 'static') {
 
-            if (pathArray[1] === 'debug') {
+                lightsStatic = value;
+                updateLightCount();
+
+            } else if (pathArray[1] === 'atlasSplit') {
+
+                // assign atlas split option
+                lighting.atlasSplit = splitOptions[value];
+
+            } else if (pathArray[1] === 'debug') {
 
                 // debug rendering of lighting clusters on world layer
                 lighting.debugLayer = value ? app.scene.layers.getLayerByName("World").id : undefined;
+
+            } else if (pathArray[1] === 'debugAtlas') {
+
+                // show debug atlas
+                debugAtlas = value;
 
             } else {
                 // @ts-ignore
@@ -261,16 +317,25 @@ class ClusteredSpotShadowsExample extends Example {
         });
 
         function updateLightCount() {
+
+            // update the number on HUD
             data.set('settings.numLights', spotLightList.length);
+
+            // shadow update mode (need to force render shadow when we add / remove light, as they all move)
+            spotLightList.forEach((spot) => {
+                spot.light.shadowUpdateMode = lightsStatic ? pc.SHADOWUPDATE_THISFRAME : pc.SHADOWUPDATE_REALTIME;
+            });
         }
 
+        // add light button handler
         data.on('add', function () {
             if (spotLightList.length < maxLights) {
-                createLight();
+                createLight(spotLightList.length);
                 updateLightCount();
             }
         });
 
+        // remove light button handler
         data.on('remove', function () {
             if (spotLightList.length) {
                 const light = spotLightList.pop();
@@ -283,7 +348,11 @@ class ClusteredSpotShadowsExample extends Example {
         // Set an update function on the app's update event
         let time = 0;
         app.on("update", function (dt: number) {
-            time += dt * 0.15;
+
+            // don't move lights around when they're static
+            if (!lightsStatic) {
+                time += dt * 0.15;
+            }
 
             // rotate spot lights around
             const lightPos = new pc.Vec3();
@@ -301,10 +370,13 @@ class ClusteredSpotShadowsExample extends Example {
             });
 
             // display shadow texture (debug feature, only works when depth is stored as color, which is webgl1)
-            // app.drawTexture(-0.7, 0.7, 0.4, 0.4, app.renderer.lightTextureAtlas.shadowMap.texture);
+            // app.drawTexture(-0.7, 0.7, 0.4, 0.4, app.renderer.lightTextureAtlas.shadowAtlas.texture);
 
             // display cookie texture (debug feature)
-            // app.drawTexture(-0.7, 0.2, 0.4, 0.4, app.renderer.lightTextureAtlas.cookieAtlas);
+            if (debugAtlas) {
+                // @ts-ignore engine-tsd
+                app.drawTexture(-0.7, 0.2, 0.4, 0.4, app.renderer.lightTextureAtlas.cookieAtlas);
+            }
         });
     }
 }

--- a/examples/src/examples/graphics/clustered-spot-shadows.tsx
+++ b/examples/src/examples/graphics/clustered-spot-shadows.tsx
@@ -139,7 +139,7 @@ class ClusteredSpotShadowsExample extends Example {
         lighting.cookieAtlasResolution = 1500;
 
         const splitOptions = [
-            undefined,          // automatic - split atlas each frame to give all required lights an equal size
+            null,               // automatic - split atlas each frame to give all required lights an equal size
             [2, 1, 1, 2, 1],    // 7 shadows: split atlas to 2x2 (first number), and split created quarters to 1x1, 1x1, 2x2, 1x1
             [3, 2],             // 12 shadows: split atlas to 3x3 (first number), and split one of the created parts to 2x2
             [4]                 // 16 shadows: split atlas to 4x4

--- a/src/scene/camera.js
+++ b/src/scene/camera.js
@@ -2,6 +2,7 @@ import { Color } from '../math/color.js';
 import { Mat4 } from '../math/mat4.js';
 import { Vec3 } from '../math/vec3.js';
 import { Vec4 } from '../math/vec4.js';
+import { math } from '../math/math.js';
 
 import { Frustum } from '../shape/frustum.js';
 
@@ -464,6 +465,38 @@ class Camera {
     getProjectionMatrixSkybox() {
         this._evaluateProjectionMatrix();
         return this._projMatSkybox;
+    }
+
+    // returns estimated size of the sphere on the screen in range of [0..1]
+    // 0 - infinitely small, 1 - full screen or larger
+    getScreenSize(sphere) {
+
+        if (this._projection === PROJECTION_PERSPECTIVE) {
+
+            // camera to sphere distance
+            const distance = this._node.getPosition().distance(sphere.center);
+
+            // if we're inside the sphere
+            if (distance < sphere.radius) {
+                return 1;
+            }
+
+            // The view-angle of the bounding sphere rendered on screen
+            const viewAngle = Math.asin(sphere.radius / distance);
+
+            // This assumes the near clipping plane is at a distance of 1
+            const sphereViewHeight = Math.tan(viewAngle);
+
+            // The size of (half) the screen if the near clipping plane is at a distance of 1
+            const screenViewHeight = Math.tan((this._fov / 2) * math.DEG_TO_RAD);
+
+            // The ratio of the geometry's screen size compared to the actual size of the screen
+            return Math.min(sphereViewHeight / screenViewHeight, 1);
+
+        }
+
+        // ortho
+        return math.clamp(sphere.radius / this._orthoHeight, 0, 1);
     }
 }
 

--- a/src/scene/light.js
+++ b/src/scene/light.js
@@ -506,7 +506,7 @@ class Light {
 
     // prepares light for the frame rendering
     beginFrame() {
-        this.visibleThisFrame = this._type === LIGHTTYPE_DIRECTIONAL;
+        this.visibleThisFrame = this._type === LIGHTTYPE_DIRECTIONAL && this._enabled;
         this.maxScreenSize = 0;
         this.atlasViewportAllocated = false;
         this.atlasSlotUpdated = false;

--- a/src/scene/light.js
+++ b/src/scene/light.js
@@ -184,7 +184,7 @@ class Light {
         // true if the light is visible by any camera within a frame
         this.visibleThisFrame = false;
 
-        // maximum size of the light bouding sphere on the screen by any camera within a frame
+        // maximum size of the light bounding sphere on the screen by any camera within a frame
         // (used to estimate shadow resolution), range [0..1]
         this.maxScreenSize = 0;
     }

--- a/src/scene/lighting/light-texture-atlas.js
+++ b/src/scene/lighting/light-texture-atlas.js
@@ -88,6 +88,10 @@ class LightTextureAtlas {
 
     allocateShadowAtlas(resolution) {
         if (!this.shadowAtlas || this.shadowAtlas.texture.width !== resolution) {
+
+            // content of atlas is lost, force re-render of static shadows
+            this.version++;
+
             this.destroyShadowAtlas();
             this.shadowAtlas = ShadowMap.createAtlas(this.device, resolution, SHADOW_PCF3);
 
@@ -103,6 +107,10 @@ class LightTextureAtlas {
 
     allocateCookieAtlas(resolution) {
         if (!this.cookieAtlas || this.cookieAtlas.width !== resolution) {
+
+            // content of atlas is lost, force re-render of static cookies
+            this.version++;
+
             this.destroyCookieAtlas();
             this.cookieAtlas = CookieRenderer.createTexture(this.device, resolution);
 

--- a/src/scene/lighting/light-texture-atlas.js
+++ b/src/scene/lighting/light-texture-atlas.js
@@ -8,19 +8,25 @@ import { CookieRenderer } from '../renderer/cookie-renderer.js';
 import { ShadowMap } from '../renderer/shadow-map.js';
 
 const _tempArray = [];
+const _tempArray2 = [];
 const _viewport = new Vec4();
 const _scissor = new Vec4();
 
-// A class handling runtime allocation of slots in a texture. Used to allocate slots in the shadow map,
-// and will be used to allocate slots in the cookie texture atlas as well.
-// Note: this will be improved in the future to allocate different size for lights of different priority and screen size,
-// and also handle persistent slots for shadows that do not need to render each frame. Also some properties will be
-// exposed in some form to the user.
+class Slot {
+    constructor(rect) {
+        this.size = Math.floor(rect.w * 1024);  // size normalized to 1024 atlas
+        this.used = false;
+        this.lightId = -1;  // id of the light using the slot
+        this.rect = rect;
+    }
+}
+
+// A class handling runtime allocation of slots in a texture. It is used to allocate slots in the shadow and cookie atlas.
 class LightTextureAtlas {
     constructor(device) {
 
         this.device = device;
-        this.subdivision = 0;
+        this.version = 1;   // incremented each time slot configuration changes
 
         this.shadowAtlasResolution = 2048;
         this.shadowAtlas = null;
@@ -33,8 +39,11 @@ class LightTextureAtlas {
         this.cookieAtlas = null;
         this.cookieRenderTarget = null;
 
-        // available slots
+        // available slots (of type Slot)
         this.slots = [];
+
+        // current subdivision strategy - matches format of LightingParams.atlasSplit
+        this.atlasSplit = [];
 
         // offsets to individual faces of a cubemap inside 3x3 grid in an atlas slot
         this.cubeSlotsOffsets = [
@@ -45,6 +54,9 @@ class LightTextureAtlas {
             new Vec2(2, 0),
             new Vec2(2, 1)
         ];
+
+        // handles gap between slots
+        this.scissorVec = new Vec4();
 
         this.allocateShadowAtlas(1);  // placeholder as shader requires it
         this.allocateCookieAtlas(1);  // placeholder as shader requires it
@@ -81,6 +93,11 @@ class LightTextureAtlas {
 
             // avoid it being destroyed by lights
             this.shadowAtlas.cached = true;
+
+            // leave gap between individual tiles to avoid shadow / cookie sampling other tiles (enough for PCF5)
+            // note that this only fades / removes shadows on the edges, which is still not correct - a shader clipping is needed?
+            const scissorOffset = 4 / this.shadowAtlasResolution;
+            this.scissorVec.set(scissorOffset, scissorOffset, -2 * scissorOffset, -2 * scissorOffset);
         }
     }
 
@@ -122,22 +139,65 @@ class LightTextureAtlas {
         this._cookieAtlasTextureId.setValue(this.cookieAtlas);
     }
 
-    subdivide(numLights) {
+    subdivide(numLights, lightingParams) {
 
-        // required grid size
-        const gridSize = Math.ceil(Math.sqrt(numLights));
+        let atlasSplit = lightingParams.atlasSplit;
 
-        // subdivide the texture to required grid size
-        if (this.subdivision !== gridSize) {
-            this.subdivision = gridSize;
+        // if no user specified subdivision
+        if (!atlasSplit) {
 
+            // split to equal number of squares
+            const gridSize = Math.ceil(Math.sqrt(numLights));
+            atlasSplit = _tempArray2;
+            atlasSplit[0] = gridSize;
+            atlasSplit.length = 1;
+        }
+
+        // compare two arrays
+        const arraysEqual = (a, b) => a.length === b.length && a.every((v, i) => v === b[i]);
+
+        // if the split has changed, regenerate slots
+        if (!arraysEqual(atlasSplit, this.atlasSplit)) {
+
+            this.version++;
             this.slots.length = 0;
-            const invSize = 1 / gridSize;
-            for (let i = 0; i < gridSize; i++) {
-                for (let j = 0; j < gridSize; j++) {
-                    this.slots.push(new Vec4(i * invSize, j * invSize, invSize, invSize));
+
+            // store current settings
+            this.atlasSplit.length = 0;
+            this.atlasSplit.push(...atlasSplit);
+
+            // generate top level split
+            const splitCount = this.atlasSplit[0];
+            if (splitCount > 1) {
+                const invSize = 1 / splitCount;
+                for (let i = 0; i < splitCount; i++) {
+                    for (let j = 0; j < splitCount; j++) {
+                        const rect = new Vec4(i * invSize, j * invSize, invSize, invSize);
+                        const nextLevelSplit = this.atlasSplit[1 + i * splitCount + j];
+
+                        // if need to split again
+                        if (nextLevelSplit > 1) {
+                            for (let x = 0; x < nextLevelSplit; x++) {
+                                for (let y = 0; y < nextLevelSplit; y++) {
+                                    const invSizeNext = invSize / nextLevelSplit;
+                                    const rectNext = new Vec4(rect.x + x * invSizeNext, rect.y + y * invSizeNext, invSizeNext, invSizeNext);
+                                    this.slots.push(new Slot(rectNext));
+                                }
+                            }
+                        } else {
+                            this.slots.push(new Slot(rect));
+                        }
+                    }
                 }
+            } else {
+                // single slot
+                this.slots.push(new Slot(new Vec4(0, 0, 1, 1)));
             }
+
+            // sort slots descending
+            this.slots.sort((a, b) => {
+                return b.size - a.size;
+            });
         }
     }
 
@@ -147,8 +207,8 @@ class LightTextureAtlas {
         const shadowsEnabled = lightingParams.shadowsEnabled;
 
         // get all lights that need shadows or cookies, if those are enabled
-        let needsShadow = false;
-        let needsCookie = false;
+        let needsShadowAtlas = false;
+        let needsCookieAtlas = false;
         const lights = _tempArray;
         lights.length = 0;
 
@@ -156,10 +216,13 @@ class LightTextureAtlas {
             for (let i = 0; i < list.length; i++) {
                 const light = list[i];
                 if (light.visibleThisFrame) {
-                    needsShadow ||= shadowsEnabled && light.castShadows;
-                    needsCookie ||= cookiesEnabled && !!light.cookie;
+                    const lightShadow = shadowsEnabled && light.castShadows;
+                    const lightCookie = cookiesEnabled && !!light.cookie;
 
-                    if (needsShadow || needsCookie) {
+                    needsShadowAtlas ||= lightShadow;
+                    needsCookieAtlas ||= lightCookie;
+
+                    if (lightShadow || lightCookie) {
                         lights.push(light);
                     }
                 }
@@ -171,19 +234,82 @@ class LightTextureAtlas {
             processLights(omniLights);
         }
 
-        if (needsShadow) {
+        // sort lights by maxScreenSize - to have them ordered by atlas slot size
+        lights.sort((a, b) => {
+            return b.maxScreenSize - a.maxScreenSize;
+        });
+
+        if (needsShadowAtlas) {
             this.allocateShadowAtlas(this.shadowAtlasResolution);
         }
 
-        if (needsCookie) {
+        if (needsCookieAtlas) {
             this.allocateCookieAtlas(this.cookieAtlasResolution);
         }
 
-        if (needsShadow || needsCookie) {
-            this.subdivide(lights.length);
+        if (needsShadowAtlas || needsCookieAtlas) {
+            this.subdivide(lights.length, lightingParams);
         }
 
         return lights;
+    }
+
+    // configure light to use assigned slot
+    setupSlot(light, rect) {
+
+        light.atlasViewport.copy(rect);
+
+        const faceCount = light.numShadowFaces;
+        for (let face = 0; face < faceCount; face++) {
+
+            // setup slot for shadow and cookie
+            if (light.castShadows || light._cookie) {
+
+                _viewport.copy(rect);
+                _scissor.copy(rect);
+
+                // for spot lights in the atlas, make viewport slightly smaller to avoid sampling past the edges
+                if (light._type === LIGHTTYPE_SPOT) {
+                    _viewport.add(this.scissorVec);
+                }
+
+                // for cube map, allocate part of the slot
+                if (light._type === LIGHTTYPE_OMNI) {
+
+                    const smallSize = _viewport.z / 3;
+                    const offset = this.cubeSlotsOffsets[face];
+                    _viewport.x += smallSize * offset.x;
+                    _viewport.y += smallSize * offset.y;
+                    _viewport.z = smallSize;
+                    _viewport.w = smallSize;
+
+                    _scissor.copy(_viewport);
+                }
+
+                if (light.castShadows) {
+                    const lightRenderData = light.getRenderData(null, face);
+                    lightRenderData.shadowViewport.copy(_viewport);
+                    lightRenderData.shadowScissor.copy(_scissor);
+                }
+            }
+        }
+    }
+
+    // assign a slot to the light
+    assignSlot(light, slotIndex, slotReassigned) {
+
+        light.atlasViewportAllocated = true;
+
+        const slot = this.slots[slotIndex];
+        slot.lightId = light.id;
+        slot.used = true;
+
+        // slot is reassigned (content needs to be updated)
+        if (slotReassigned) {
+            light.atlasSlotUpdated = true;
+            light.atlasVersion = this.version;
+            light.atlasSlotIndex = slotIndex;
+        }
     }
 
     // update texture atlas for a list of lights
@@ -193,64 +319,52 @@ class LightTextureAtlas {
         this.shadowAtlasResolution = lightingParams.shadowAtlasResolution;
         this.cookieAtlasResolution = lightingParams.cookieAtlasResolution;
 
-        // process lights
+        // collect lights requiring atlas
         const lights = this.collectLights(spotLights, omniLights, lightingParams);
         if (lights.length > 0) {
 
-            // leave gap between individual tiles to avoid shadow / cookie sampling other tiles (5 pixels is enough for PCF5)
-            // note that this only fades / removes shadows on the edges, which is still not correct - a shader clipping is needed?
-            const scissorOffset = 4 / this.shadowAtlasResolution;
-            const scissorVec = new Vec4(scissorOffset, scissorOffset, -2 * scissorOffset, -2 * scissorOffset);
+            // mark all slots as unused
+            const slots = this.slots;
+            for (let i = 0; i < slots.length; i++) {
+                slots[i].used = false;
+            }
 
-            // assign atlas slots to lights
-            let usedCount = 0;
-            for (let i = 0; i < lights.length; i++) {
+            // assign slots to lights
+            const assignCount = Math.min(lights.length, slots.length);
 
+            // first pass - preserve allocated slots for lights requiring slot of the same size
+            for (let i = 0; i < assignCount; i++) {
                 const light = lights[i];
 
                 if (light.castShadows)
                     light._shadowMap = this.shadowAtlas;
 
-                // use a single slot for spot, and single slot for all 6 faces of cubemap as well
-                const slot = this.slots[usedCount];
-                usedCount++;
-
-                light.atlasViewport.copy(slot);
-
-                const faceCount = light.numShadowFaces;
-                for (let face = 0; face < faceCount; face++) {
-
-                    // setup slot for shadow and cookie
-                    if (light.castShadows || light._cookie) {
-
-                        _viewport.copy(slot);
-                        _scissor.copy(slot);
-
-                        // for spot lights in the atlas, make viewport slightly smaller to avoid sampling past the edges
-                        if (light._type === LIGHTTYPE_SPOT) {
-                            _viewport.add(scissorVec);
-                        }
-
-                        // for cube map, allocate part of the slot
-                        if (light._type === LIGHTTYPE_OMNI) {
-
-                            const smallSize = _viewport.z / 3;
-                            const offset = this.cubeSlotsOffsets[face];
-                            _viewport.x += smallSize * offset.x;
-                            _viewport.y += smallSize * offset.y;
-                            _viewport.z = smallSize;
-                            _viewport.w = smallSize;
-
-                            _scissor.copy(_viewport);
-                        }
-
-                        if (light.castShadows) {
-                            const lightRenderData = light.getRenderData(null, face);
-                            lightRenderData.shadowViewport.copy(_viewport);
-                            lightRenderData.shadowScissor.copy(_scissor);
-                        }
+                // if currently assigned slot is the same size as what is needed, and was last used by this light, reuse it
+                const previousSlot = slots[light.atlasSlotIndex];
+                if (light.atlasVersion === this.version && light.id === previousSlot?.lightId) {
+                    const previousSlot = slots[light.atlasSlotIndex];
+                    if (previousSlot.size === slots[i].size && !previousSlot.used) {
+                        this.assignSlot(light, light.atlasSlotIndex, false);
                     }
                 }
+            }
+
+            // second pass - assign slots to unhandled lights
+            let usedCount = 0;
+            for (let i = 0; i < assignCount; i++) {
+
+                // skip already used slots
+                while (usedCount < slots.length && slots[usedCount].used)
+                    usedCount++;
+
+                const light = lights[i];
+                if (!light.atlasViewportAllocated) {
+                    this.assignSlot(light, usedCount, true);
+                }
+
+                // set up all slots
+                const slot = slots[light.atlasSlotIndex];
+                this.setupSlot(light, slot.rect);
             }
         }
 

--- a/src/scene/lighting/light-texture-atlas.js
+++ b/src/scene/lighting/light-texture-atlas.js
@@ -338,6 +338,12 @@ class LightTextureAtlas {
             }
 
             // assign slots to lights
+            // The slot to light assignment logic:
+            // - internally the atlas slots are sorted in the descending order (done when atlas split changes)
+            // - every frame all visible lights are sorted by their screen space size (this handles all cameras where lights
+            //   are visible using max value)
+            // - all lights in this order get a slot size from the slot list in the same order. Care is taken to not reassign
+            //   slot if the size of it is the same and only index changes - this is done using two pass assignment
             const assignCount = Math.min(lights.length, slots.length);
 
             // first pass - preserve allocated slots for lights requiring slot of the same size

--- a/src/scene/lighting/lighting-params.js
+++ b/src/scene/lighting/lighting-params.js
@@ -21,9 +21,9 @@ class LightingParams {
         this._cookieAtlasResolution = 2048;
 
         // atlas split strategy
-        // undefined: per frame split atlas into equally sized squares for each shadowmap needed
+        // null: per frame split atlas into equally sized squares for each shadowmap needed
         // array: first number specifies top subdivision of the atlas, following numbers split next level (2 levels only)
-        this.atlasSplit = undefined;
+        this.atlasSplit = null;
 
         // Layer ID of a layer for which the debug clustering is rendered
         this.debugLayer = undefined;

--- a/src/scene/lighting/lighting-params.js
+++ b/src/scene/lighting/lighting-params.js
@@ -22,7 +22,7 @@ class LightingParams {
 
         // atlas split strategy
         // undefined: per frame split atlas into equally sized squares for each shadowmap needed
-        // array: first number specifies tol subdivision of the atlas, following numbers split next level (2 levels only)
+        // array: first number specifies top subdivision of the atlas, following numbers split next level (2 levels only)
         this.atlasSplit = undefined;
 
         // Layer ID of a layer for which the debug clustering is rendered

--- a/src/scene/lighting/lighting-params.js
+++ b/src/scene/lighting/lighting-params.js
@@ -20,6 +20,11 @@ class LightingParams {
         this._cookiesEnabled = false;
         this._cookieAtlasResolution = 2048;
 
+        // atlas split strategy
+        // undefined: per frame split atlas into equally sized squares for each shadowmap needed
+        // array: first number specifies tol subdivision of the atlas, following numbers split next level (2 levels only)
+        this.atlasSplit = undefined;
+
         // Layer ID of a layer for which the debug clustering is rendered
         this.debugLayer = undefined;
     }

--- a/src/scene/lighting/lights-buffer.js
+++ b/src/scene/lighting/lights-buffer.js
@@ -131,8 +131,9 @@ class LightsBuffer {
         LightsBuffer.initShaderDefines();
     }
 
-    static createTexture(device, width, height, format) {
+    static createTexture(device, width, height, format, name) {
         const tex = new Texture(device, {
+            name: name,
             width: width,
             height: height,
             mipmaps: false,
@@ -173,13 +174,13 @@ class LightsBuffer {
 
         // 8bit texture - to store data that can fit into 8bits to lower the bandwidth requirements
         this.lights8 = new Uint8ClampedArray(4 * pixelsPerLight8 * this.maxLights);
-        this.lightsTexture8 = LightsBuffer.createTexture(this.device, pixelsPerLight8, this.maxLights, PIXELFORMAT_R8_G8_B8_A8);
+        this.lightsTexture8 = LightsBuffer.createTexture(this.device, pixelsPerLight8, this.maxLights, PIXELFORMAT_R8_G8_B8_A8, "LightsTexture8");
         this._lightsTexture8Id = this.device.scope.resolve("lightsTexture8");
 
         // float texture
         if (pixelsPerLightFloat) {
             this.lightsFloat = new Float32Array(4 * pixelsPerLightFloat * this.maxLights);
-            this.lightsTextureFloat = LightsBuffer.createTexture(this.device, pixelsPerLightFloat, this.maxLights, PIXELFORMAT_RGBA32F);
+            this.lightsTextureFloat = LightsBuffer.createTexture(this.device, pixelsPerLightFloat, this.maxLights, PIXELFORMAT_RGBA32F, "LightsTextureFloat");
             this._lightsTextureFloatId = this.device.scope.resolve("lightsTextureFloat");
         } else {
             this.lightsFloat = null;
@@ -275,11 +276,11 @@ class LightsBuffer {
         return tempAreaLightSizes;
     }
 
-    addLightDataFlags(data8, index, light, isSpot) {
+    addLightDataFlags(data8, index, light, isSpot, castShadows) {
         data8[index + 0] = isSpot ? 255 : 0;
         data8[index + 1] = light._shape * 64;           // value 0..3
         data8[index + 2] = light._falloffMode * 255;    // value 0..1
-        data8[index + 3] = light.castShadows ? 255 : 0;
+        data8[index + 3] = castShadows ? 255 : 0;
     }
 
     addLightDataColor(data8, index, light, gammaCorrection, isCookie) {
@@ -367,9 +368,10 @@ class LightsBuffer {
     addLightData(light, lightIndex, gammaCorrection) {
 
         const isSpot = light._type === LIGHTTYPE_SPOT;
-        const isCookie = this.cookiesEnabled && !!light._cookie;
+        const hasAtlasViewport = light.atlasViewportAllocated; // if the light does not have viewport, it does not fit to the atlas
+        const isCookie = this.cookiesEnabled && !!light._cookie && hasAtlasViewport;
         const isArea = this.areaLightsEnabled && light.shape !== LIGHTSHAPE_PUNCTUAL;
-        const castShadows = this.shadowsEnabled && light.castShadows;
+        const castShadows = this.shadowsEnabled && light.castShadows && hasAtlasViewport;
         const pos = light._node.getPosition();
 
         let lightProjectionMatrix = null;   // light projection matrix - used for shadow map and cookie of spot light
@@ -392,7 +394,7 @@ class LightsBuffer {
         const data8Start = lightIndex * this.lightsTexture8.width * 4;
 
         // flags
-        this.addLightDataFlags(data8, data8Start + 4 * TextureIndex8.FLAGS, light, isSpot);
+        this.addLightDataFlags(data8, data8Start + 4 * TextureIndex8.FLAGS, light, isSpot, castShadows);
 
         // light color
         this.addLightDataColor(data8, data8Start + 4 * TextureIndex8.COLOR_A, light, gammaCorrection, isCookie);

--- a/src/scene/lighting/world-clusters.js
+++ b/src/scene/lighting/world-clusters.js
@@ -195,7 +195,7 @@ class WorldClusters {
             this._clusterTextureSizeData[2] = 1.0 / height;
 
             this.releaseClusterTexture();
-            this.clusterTexture = LightsBuffer.createTexture(this.device, width, height, PIXELFORMAT_R8_G8_B8_A8);
+            this.clusterTexture = LightsBuffer.createTexture(this.device, width, height, PIXELFORMAT_R8_G8_B8_A8, "ClusterTexture");
         }
     }
 

--- a/src/scene/renderer/cookie-renderer.js
+++ b/src/scene/renderer/cookie-renderer.js
@@ -78,6 +78,7 @@ class CookieRenderer {
     static createTexture(device, resolution) {
 
         const texture = new Texture(device, {
+            name: "CookieAtlas",
             width: resolution,
             height: resolution,
             format: PIXELFORMAT_R8_G8_B8_A8,
@@ -88,7 +89,6 @@ class CookieRenderer {
             addressU: ADDRESS_CLAMP_TO_EDGE,
             addressV: ADDRESS_CLAMP_TO_EDGE
         });
-        texture.name = "CookieAtlas";
 
         return texture;
     }

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -37,7 +37,6 @@ import { StaticMeshes } from './static-meshes.js';
 import { CookieRenderer } from './cookie-renderer.js';
 import { LightCamera } from './light-camera.js';
 import { WorldClustersDebug } from '../lighting/world-clusters-debug.js';
-import { Color } from '../../index.js';
 
 /** @typedef {import('../../graphics/graphics-device.js').GraphicsDevice} GraphicsDevice */
 

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -26,7 +26,7 @@ import {
     MASK_BAKED, MASK_DYNAMIC, MASK_LIGHTMAP,
     SHADOWUPDATE_NONE,
     SORTKEY_DEPTH, SORTKEY_FORWARD,
-    VIEW_CENTER, VIEW_LEFT, VIEW_RIGHT
+    VIEW_CENTER, VIEW_LEFT, VIEW_RIGHT, SHADOWUPDATE_THISFRAME
 } from '../constants.js';
 import { Material } from '../materials/material.js';
 import { LightTextureAtlas } from '../lighting/light-texture-atlas.js';
@@ -37,6 +37,7 @@ import { StaticMeshes } from './static-meshes.js';
 import { CookieRenderer } from './cookie-renderer.js';
 import { LightCamera } from './light-camera.js';
 import { WorldClustersDebug } from '../lighting/world-clusters-debug.js';
+import { Color } from '../../index.js';
 
 /** @typedef {import('../../graphics/graphics-device.js').GraphicsDevice} GraphicsDevice */
 
@@ -873,25 +874,32 @@ class ForwardRenderer {
     }
 
     cullLights(camera, lights) {
+
+        const clusteredLightingEnabled = this.scene.clusteredLightingEnabled;
+
         for (let i = 0; i < lights.length; i++) {
             const light = lights[i];
 
-            // if enabled light is not already marked as visible
-            if (!light.visibleThisFrame && light.enabled) {
+            if (light.enabled) {
 
-                if (light._type === LIGHTTYPE_DIRECTIONAL) {
-                    light.visibleThisFrame = true;
-                } else {
+                // directional lights are marked visible at the start of the frame
+                if (light._type !== LIGHTTYPE_DIRECTIONAL) {
                     light.getBoundingSphere(tempSphere);
                     if (camera.frustum.containsSphere(tempSphere)) {
                         light.visibleThisFrame = true;
+
+                        // maximum screen area taken by the light
+                        const screenSize = camera.getScreenSize(tempSphere);
+                        light.maxScreenSize = Math.max(light.maxScreenSize, screenSize);
                     } else {
                         // if shadow casting light does not have shadow map allocated, mark it visible to allocate shadow map
                         // Note: This won't be needed when clustered shadows are used, but at the moment even culled out lights
                         // are used for rendering, and need shadow map to be allocated
                         // TODO: delete this code when clusteredLightingEnabled is being removed and is on by default.
-                        if (light.castShadows && !light.shadowMap) {
-                            light.visibleThisFrame = true;
+                        if (!clusteredLightingEnabled) {
+                            if (light.castShadows && !light.shadowMap) {
+                                light.visibleThisFrame = true;
+                            }
                         }
                     }
                 }
@@ -1056,6 +1064,7 @@ class ForwardRenderer {
 
     renderShadows(lights, camera) {
 
+        const isClustered = this.scene.clusteredLightingEnabled;
         const device = this.device;
         device.grabPassAvailable = false;
 
@@ -1064,7 +1073,22 @@ class ForwardRenderer {
         // #endif
 
         for (let i = 0; i < lights.length; i++) {
-            this._shadowRenderer.render(lights[i], camera);
+            const light = lights[i];
+
+            if (isClustered) {
+
+                // skip clustered shadows with no assigned atlas slot
+                if (!light.atlasViewportAllocated) {
+                    continue;
+                }
+
+                // if atlas slot is reassigned, make sure shadow is updated
+                if (light.atlasSlotUpdated && light.shadowUpdateMode === SHADOWUPDATE_NONE) {
+                    light.shadowUpdateMode = SHADOWUPDATE_THISFRAME;
+                }
+            }
+
+            this._shadowRenderer.render(light, camera);
         }
 
         device.grabPassAvailable = true;
@@ -1078,7 +1102,17 @@ class ForwardRenderer {
 
         const cookieRenderTarget = this.lightTextureAtlas.cookieRenderTarget;
         for (let i = 0; i < lights.length; i++) {
-            this._cookieRenderer.render(lights[i], cookieRenderTarget);
+            const light = lights[i];
+
+            // skip clustered cookies with no assigned atlas slot
+            if (!light.atlasViewportAllocated)
+                continue;
+
+            // only render cookie when the slot is reassigned (assuming the cookie texture is static)
+            if (!light.atlasSlotUpdated)
+                continue;
+
+            this._cookieRenderer.render(light, cookieRenderTarget);
         }
     }
 
@@ -1561,7 +1595,7 @@ class ForwardRenderer {
         const lights = comp._lights;
         const lightCount = lights.length;
         for (let i = 0; i < lightCount; i++) {
-            lights[i].visibleThisFrame = lights[i]._type === LIGHTTYPE_DIRECTIONAL;
+            lights[i].beginFrame();
         }
     }
 

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -1074,7 +1074,7 @@ class ForwardRenderer {
         for (let i = 0; i < lights.length; i++) {
             const light = lights[i];
 
-            if (isClustered) {
+            if (isClustered && light._type !== LIGHTTYPE_DIRECTIONAL) {
 
                 // skip clustered shadows with no assigned atlas slot
                 if (!light.atlasViewportAllocated) {


### PR DESCRIPTION
This implements custom allocation strategy support for atlas used by shadows and cookies of cluster lights. This allows atlas to have slots of equal sizes (default allocation), or it can be split into slots of different sizes (for example 3 sizes), and the system assigned slots to lights based on their screen space size, which in effect is an LOD system allowing nearby (larger) lights to use higher resolution slots. When there is more lights than slots, the smallest screen area lights do not have slot allocated and simply don't use shadows / cookies.

The new (for now private) API:

**LightingParams.atlasSplit** = null;

Details:
```
// null: per frame split atlas into equally sized squares for each shadowmap / cookie needed
// array: fixed slot allocation - the first number specifies top subdivision of the atlas, following numbers
//            split next level (2 levels only)
```
Examples
```
// automatic - split atlas each frame to give all required lights an equal size
null,

// 7 shadows: split atlas to 2x2 (first number), and split created quarters to 1x1, 1x1, 2x2, 1x1
[2, 1, 1, 2, 1],

// 12 shadows: split atlas to 3x3 (first number), and split one of the created parts to 2x2
[3, 2],

// 16 shadows: split atlas to 4x4
[4]
```

This additionally adds support for SHADOWUPDATE_THISFRAME shadow update mode. This allows shadows to only render into the atlas one time, or when their slot allocation changes.

The slot to light assignment logic is following:
- internally the atlas slots are sorted in the descending order (done when atlas split changes)
- every frame all visible lights are sorted by their screen space size (this handles all cameras where lights are visible using max value)
- all lights in this order get a slot size from the slot list in the same order. Care is taken to not reassign slot if the size of it is the same and only index changes.

Example with all the new controls exposed to test all scenarios (see above mentioned split to create 12 slots)
Also note lights away from the camera use lower resolution shadows.
![Screenshot 2022-01-12 at 10 45 56](https://user-images.githubusercontent.com/59932779/149125984-d581d066-40de-433f-a594-7443712a9489.png)
