### PR TITLE
Add test for null url in container loader

### DIFF
--- a/src/resources/container.js
+++ b/src/resources/container.js
@@ -118,9 +118,8 @@ class ContainerHandler {
     }
 
     _getParser(url) {
-        const ext = path.getExtension(this._getUrlWithoutParams(url)).toLowerCase().replace('.', '');
+        const ext = url ? path.getExtension(this._getUrlWithoutParams(url)).toLowerCase().replace('.', '') : null;
         return this.parsers[ext] || this.glbParser;
-
     }
 
     load(url, callback, asset) {


### PR DESCRIPTION
The editor sometimes attempts to load container assets with a null url. This stops the call from failing.