### PR TITLE
Lightmapper is compatible with clustered light mode

### DIFF
--- a/src/framework/components/light/component.js
+++ b/src/framework/components/light/component.js
@@ -7,7 +7,7 @@ import {
     LAYERID_WORLD,
     LIGHTSHAPE_PUNCTUAL,
     LIGHTFALLOFF_LINEAR,
-    MASK_BAKED, MASK_DYNAMIC, MASK_LIGHTMAP,
+    MASK_AFFECT_LIGHTMAPPED, MASK_AFFECT_DYNAMIC, MASK_BAKE,
     SHADOW_PCF3,
     SHADOWUPDATE_REALTIME
 } from '../../../scene/constants.js';
@@ -486,28 +486,28 @@ function _defineProps() {
     });
     _defineProperty("affectDynamic", true, function (newValue, oldValue) {
         if (newValue) {
-            this.light.mask |= MASK_DYNAMIC;
+            this.light.mask |= MASK_AFFECT_DYNAMIC;
         } else {
-            this.light.mask &= ~MASK_DYNAMIC;
+            this.light.mask &= ~MASK_AFFECT_DYNAMIC;
         }
         this.light.layersDirty();
     });
     _defineProperty("affectLightmapped", false, function (newValue, oldValue) {
         if (newValue) {
-            this.light.mask |= MASK_BAKED;
-            if (this.bake) this.light.mask &= ~MASK_LIGHTMAP;
+            this.light.mask |= MASK_AFFECT_LIGHTMAPPED;
+            if (this.bake) this.light.mask &= ~MASK_BAKE;
         } else {
-            this.light.mask &= ~MASK_BAKED;
-            if (this.bake) this.light.mask |= MASK_LIGHTMAP;
+            this.light.mask &= ~MASK_AFFECT_LIGHTMAPPED;
+            if (this.bake) this.light.mask |= MASK_BAKE;
         }
     });
     _defineProperty("bake", false, function (newValue, oldValue) {
         if (newValue) {
-            this.light.mask |= MASK_LIGHTMAP;
-            if (this.affectLightmapped) this.light.mask &= ~MASK_BAKED;
+            this.light.mask |= MASK_BAKE;
+            if (this.affectLightmapped) this.light.mask &= ~MASK_AFFECT_LIGHTMAPPED;
         } else {
-            this.light.mask &= ~MASK_LIGHTMAP;
-            if (this.affectLightmapped) this.light.mask |= MASK_BAKED;
+            this.light.mask &= ~MASK_BAKE;
+            if (this.affectLightmapped) this.light.mask |= MASK_AFFECT_LIGHTMAPPED;
         }
         this.light.layersDirty();
     });

--- a/src/graphics/program-lib/programs/standard.js
+++ b/src/graphics/program-lib/programs/standard.js
@@ -449,7 +449,7 @@ const standard = {
             lighting = true;
         }
 
-        if (options.clusteredLightingEnabled && options.useLighting) {
+        if (options.clusteredLightingEnabled) {
             lighting = true;
         }
 
@@ -1292,6 +1292,9 @@ const standard = {
             usesCookie = true;
 
             code += chunks.floatUnpackingPS;
+
+            if (options.lightMaskDynamic)
+                code += "\n#define CLUSTER_MESH_DYNAMIC_LIGHTS";
 
             if (options.clusteredLightingCookiesEnabled)
                 code += "\n#define CLUSTER_COOKIES";

--- a/src/scene/constants.js
+++ b/src/scene/constants.js
@@ -617,9 +617,10 @@ export const SHADOWUPDATE_REALTIME = 2;
 export const SORTKEY_FORWARD = 0;
 export const SORTKEY_DEPTH = 1;
 
-export const MASK_DYNAMIC = 1;
-export const MASK_BAKED = 2;
-export const MASK_LIGHTMAP = 4;
+// flags used on the mask property of the Light, and also on mask property of the MeshInstance
+export const MASK_AFFECT_DYNAMIC = 1;
+export const MASK_AFFECT_LIGHTMAPPED = 2;
+export const MASK_BAKE = 4;
 
 /**
  * Render shaded materials with gamma correction and tonemapping.

--- a/src/scene/light.js
+++ b/src/scene/light.js
@@ -8,7 +8,7 @@ import { Vec4 } from '../math/vec4.js';
 import {
     BLUR_GAUSSIAN,
     LIGHTTYPE_DIRECTIONAL, LIGHTTYPE_OMNI, LIGHTTYPE_SPOT,
-    MASK_LIGHTMAP, MASK_DYNAMIC,
+    MASK_BAKE, MASK_AFFECT_DYNAMIC,
     SHADOW_PCF3, SHADOW_PCF5, SHADOW_VSM8, SHADOW_VSM16, SHADOW_VSM32,
     SHADOWUPDATE_NONE, SHADOWUPDATE_REALTIME, SHADOWUPDATE_THISFRAME,
     LIGHTSHAPE_PUNCTUAL, LIGHTFALLOFF_LINEAR
@@ -102,7 +102,7 @@ class Light {
         this._intensity = 1;
         this._castShadows = false;
         this._enabled = false;
-        this.mask = MASK_DYNAMIC;
+        this.mask = MASK_AFFECT_DYNAMIC;
         this.isStatic = false;
         this.key = 0;
         this.bakeDir = true;
@@ -317,7 +317,7 @@ class Light {
     }
 
     get castShadows() {
-        return this._castShadows && this.mask !== MASK_LIGHTMAP && this.mask !== 0;
+        return this._castShadows && this.mask !== MASK_BAKE && this.mask !== 0;
     }
 
     set shadowResolution(value) {

--- a/src/scene/lighting/world-clusters.js
+++ b/src/scene/lighting/world-clusters.js
@@ -2,7 +2,7 @@ import { Vec3 } from '../../math/vec3.js';
 import { math } from '../../math/math.js';
 import { BoundingBox } from '../../shape/bounding-box.js';
 import { PIXELFORMAT_R8_G8_B8_A8 } from '../../graphics/constants.js';
-import { LIGHTTYPE_DIRECTIONAL } from '../constants.js';
+import { LIGHTTYPE_DIRECTIONAL, MASK_AFFECT_DYNAMIC, MASK_AFFECT_LIGHTMAPPED } from '../constants.js';
 import { LightsBuffer } from './lights-buffer.js';
 import { Debug } from '../../core/debug.js';
 
@@ -276,7 +276,8 @@ class WorldClusters {
 
             // use enabled and visible lights
             const light = lights[i];
-            if (light.enabled && light.type !== LIGHTTYPE_DIRECTIONAL && light.visibleThisFrame && light.intensity > 0) {
+            const runtimeLight = !!(light.mask & (MASK_AFFECT_DYNAMIC | MASK_AFFECT_LIGHTMAPPED));
+            if (light.enabled && light.type !== LIGHTTYPE_DIRECTIONAL && light.visibleThisFrame && light.intensity > 0 && runtimeLight) {
 
                 // within light limit
                 if (lightIndex < maxLights) {

--- a/src/scene/lightmapper/bake-light.js
+++ b/src/scene/lightmapper/bake-light.js
@@ -63,9 +63,11 @@ class BakeLight {
         const light = this.light;
         light.enabled = false;
 
-        // return shadow map to the cache
-        if (light.shadowMap && light.shadowMap.cached) {
-            shadowMapCache.add(light, light.shadowMap);
+        if (light.shadowMap) {
+            // return shadow map to the cache
+            if (light.shadowMap.cached)
+                shadowMapCache.add(light, light.shadowMap);
+
             light.shadowMap = null;
         }
     }

--- a/src/scene/lightmapper/lightmapper.js
+++ b/src/scene/lightmapper/lightmapper.js
@@ -162,14 +162,26 @@ class Lightmapper {
         // create light cluster structure
         if (this.scene.clusteredLightingEnabled) {
 
+            // create light params, and base most parameters on the lighting params of the scene
             const lightingParams = new LightingParams(device.supportsAreaLights, device.maxTextureSize, () => {});
             this.lightingParams = lightingParams;
 
+            const srcParams = this.scene.lighting;
+            lightingParams.shadowsEnabled = srcParams.shadowsEnabled;
+            lightingParams.shadowAtlasResolution = srcParams.shadowAtlasResolution;
+
+            lightingParams.cookiesEnabled = srcParams.cookiesEnabled;
+            lightingParams.cookieAtlasResolution = srcParams.cookieAtlasResolution;
+
+            lightingParams.areaLightsEnabled = srcParams.areaLightsEnabled;
+
+            // some custom lightmapping params - we bake single light a time
             lightingParams.cells = new Vec3(3, 3, 3);
             lightingParams.maxLightsPerCell = 4;
 
-            // TODO: this is resolution for clustered lights only (omni and spot), we might need to expose some control over this
-            lightingParams.shadowAtlasResolution = 1024;
+
+
+            console.log("HEY");
 
             this.worldClusters = new WorldClusters(device);
             this.worldClusters.name = "ClusterLightmapper";

--- a/src/scene/lightmapper/lightmapper.js
+++ b/src/scene/lightmapper/lightmapper.js
@@ -484,7 +484,7 @@ class Lightmapper {
                         meshInstance._shaderDefs |= shaderDefs;
                     }
 
-                    // only lights that affect lightmapped objects are used on this mesh now that is baked
+                    // only lights that affect lightmapped objects are used on this mesh now that it is baked
                     meshInstance.mask = MASK_AFFECT_LIGHTMAPPED;
 
                     // textures

--- a/src/scene/lightmapper/lightmapper.js
+++ b/src/scene/lightmapper/lightmapper.js
@@ -179,10 +179,6 @@ class Lightmapper {
             lightingParams.cells = new Vec3(3, 3, 3);
             lightingParams.maxLightsPerCell = 4;
 
-
-
-            console.log("HEY");
-
             this.worldClusters = new WorldClusters(device);
             this.worldClusters.name = "ClusterLightmapper";
         }

--- a/src/scene/materials/standard-material-options-builder.js
+++ b/src/scene/materials/standard-material-options-builder.js
@@ -8,6 +8,7 @@ import {
     BLEND_NONE,
     GAMMA_NONE, GAMMA_SRGBHDR,
     LIGHTTYPE_DIRECTIONAL, LIGHTTYPE_OMNI, LIGHTTYPE_SPOT,
+    MASK_AFFECT_DYNAMIC,
     SHADER_FORWARDHDR,
     SHADERDEF_DIRLM, SHADERDEF_INSTANCING, SHADERDEF_LM, SHADERDEF_MORPH_POSITION, SHADERDEF_MORPH_NORMAL, SHADERDEF_NOSHADOW, SHADERDEF_MORPH_TEXTURE_BASED,
     SHADERDEF_SCREENSPACE, SHADERDEF_SKIN, SHADERDEF_TANGENTS, SHADERDEF_UV0, SHADERDEF_UV1, SHADERDEF_VCOLOR, SHADERDEF_LMAMBIENT,
@@ -253,7 +254,11 @@ class StandardMaterialOptionsBuilder {
 
         if (stdMat.useLighting) {
             const lightsFiltered = [];
-            const mask = objDefs ? (objDefs >> 16) : 1;
+            const mask = objDefs ? (objDefs >> 16) : MASK_AFFECT_DYNAMIC;
+
+            // mask to select lights (dynamic vs lightmapped) when using clustered lighting
+            options.lightMaskDynamic = !!(mask & MASK_AFFECT_DYNAMIC);
+
             if (sortedLights) {
                 this._collectLights(LIGHTTYPE_DIRECTIONAL, sortedLights[LIGHTTYPE_DIRECTIONAL], lightsFiltered, mask);
                 this._collectLights(LIGHTTYPE_OMNI, sortedLights[LIGHTTYPE_OMNI], lightsFiltered, mask, staticLightList);

--- a/src/scene/mesh-instance.js
+++ b/src/scene/mesh-instance.js
@@ -4,7 +4,7 @@ import { BoundingSphere } from '../shape/bounding-sphere.js';
 import {
     BLEND_NONE, BLEND_NORMAL,
     LAYER_WORLD,
-    MASK_DYNAMIC, MASK_LIGHTMAP, MASK_BAKED,
+    MASK_AFFECT_DYNAMIC, MASK_BAKE, MASK_AFFECT_LIGHTMAPPED,
     RENDERSTYLE_SOLID,
     SHADER_FORWARD, SHADER_FORWARDHDR,
     SHADERDEF_UV0, SHADERDEF_UV1, SHADERDEF_VCOLOR, SHADERDEF_TANGENTS, SHADERDEF_NOSHADOW, SHADERDEF_SKIN,
@@ -122,7 +122,7 @@ class MeshInstance {
         mesh.incRefCount();
         this.material = material;   // The material with which to render this instance
 
-        this._shaderDefs = MASK_DYNAMIC << 16; // 2 byte toggles, 2 bytes light mask; Default value is no toggles and mask = pc.MASK_DYNAMIC
+        this._shaderDefs = MASK_AFFECT_DYNAMIC << 16; // 2 byte toggles, 2 bytes light mask; Default value is no toggles and mask = pc.MASK_AFFECT_DYNAMIC
         this._shaderDefs |= mesh.vertexBuffer.format.hasUv0 ? SHADERDEF_UV0 : 0;
         this._shaderDefs |= mesh.vertexBuffer.format.hasUv1 ? SHADERDEF_UV1 : 0;
         this._shaderDefs |= mesh.vertexBuffer.format.hasColor ? SHADERDEF_VCOLOR : 0;
@@ -741,12 +741,12 @@ class MeshInstance {
 
     setLightmapped(value) {
         if (value) {
-            this.mask = (this.mask | MASK_BAKED) & ~(MASK_DYNAMIC | MASK_LIGHTMAP);
+            this.mask = (this.mask | MASK_AFFECT_LIGHTMAPPED) & ~(MASK_AFFECT_DYNAMIC | MASK_BAKE);
         } else {
             this.setRealtimeLightmap(MeshInstance.lightmapParamNames[0], null);
             this.setRealtimeLightmap(MeshInstance.lightmapParamNames[1], null);
             this._shaderDefs &= ~(SHADERDEF_LM | SHADERDEF_DIRLM | SHADERDEF_LMAMBIENT);
-            this.mask = (this.mask | MASK_DYNAMIC) & ~(MASK_BAKED | MASK_LIGHTMAP);
+            this.mask = (this.mask | MASK_AFFECT_DYNAMIC) & ~(MASK_AFFECT_LIGHTMAPPED | MASK_BAKE);
         }
     }
 

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -23,7 +23,7 @@ import {
     FOG_NONE, FOG_LINEAR,
     LIGHTTYPE_DIRECTIONAL, LIGHTTYPE_OMNI, LIGHTTYPE_SPOT,
     LIGHTSHAPE_PUNCTUAL,
-    MASK_BAKED, MASK_DYNAMIC, MASK_LIGHTMAP,
+    MASK_AFFECT_LIGHTMAPPED, MASK_AFFECT_DYNAMIC, MASK_BAKE,
     SHADOWUPDATE_NONE,
     SORTKEY_DEPTH, SORTKEY_FORWARD,
     VIEW_CENTER, VIEW_LEFT, VIEW_RIGHT, SHADOWUPDATE_THISFRAME
@@ -1702,10 +1702,10 @@ class ForwardRenderer {
             for (let i = 0; i < stats.lights; i++) {
                 const l = comp._lights[i];
                 if (l.enabled) {
-                    if ((l.mask & MASK_DYNAMIC) || (l.mask & MASK_BAKED)) { // if affects dynamic or baked objects in real-time
+                    if ((l.mask & MASK_AFFECT_DYNAMIC) || (l.mask & MASK_AFFECT_LIGHTMAPPED)) { // if affects dynamic or baked objects in real-time
                         stats.dynamicLights++;
                     }
-                    if (l.mask & MASK_LIGHTMAP) { // if baked into lightmaps
+                    if (l.mask & MASK_BAKE) { // if baked into lightmaps
                         stats.bakedLights++;
                     }
                 }


### PR DESCRIPTION
- Lightmapper can use clustered lights when baking now - it internally allocates clustered lights structure which is updated with lights during baking.

- Clustered lighting has been improved to support flags on the light: affectLightmapped, affectRealtime.

- Renamed light mask constant to match the light properties (those are all private)
<img width="655" alt="Screenshot 2022-01-17 at 17 49 14" src="https://user-images.githubusercontent.com/59932779/149817476-b3e5c5d5-4a25-4bf7-8fdf-209993d3434b.png">

