### PR TITLE
Remove `Object.defineProperty` from `SoundComponent`

### DIFF
--- a/src/framework/components/component.js
+++ b/src/framework/components/component.js
@@ -86,12 +86,11 @@ class Component extends EventHandler {
     }
 
     /**
-     * @private
-     * @name Component#data
+     * Access the component data directly. Usually you should access the data properties via the
+     * individual properties as modifying this data directly will not fire 'set' events.
+     *
      * @type {ComponentData}
-     * @description Access the component data directly.
-     * Usually you should access the data properties via the individual properties as
-     * modifying this data directly will not fire 'set' events.
+     * @private
      */
     get data() {
         const record = this.system.store[this.entity.getGuid()];

--- a/src/framework/components/sound/component.js
+++ b/src/framework/components/sound/component.js
@@ -13,24 +13,6 @@ import { SoundSlot } from './slot.js';
 /**
  * The Sound Component controls playback of {@link Sound}s.
  *
- * @property {number} volume The volume modifier to play the audio with. In range 0-1. Defaults to
- * 1.
- * @property {number} pitch The pitch modifier to play the audio with. Must be larger than 0.01.
- * Defaults to 1.
- * @property {string} distanceModel Determines which algorithm to use to reduce the volume of the
- * sound as it moves away from the listener. Can be:
- *
- * - {@link DISTANCE_LINEAR}
- * - {@link DISTANCE_INVERSE}
- * - {@link DISTANCE_EXPONENTIAL}
- *
- * Defaults to {@link DISTANCE_LINEAR}.
- * @property {number} refDistance The reference distance for reducing volume as the sound source
- * moves further from the listener. Defaults to 1.
- * @property {number} maxDistance The maximum distance from the listener at which audio falloff
- * stops. Note the volume of the audio is not 0 after this distance, but just doesn't fall off
- * anymore. Defaults to 10000.
- * @property {number} rollOffFactor The factor used in the falloff equation. Defaults to 1.
  * @augments Component
  */
 class SoundComponent extends Component {
@@ -43,12 +25,19 @@ class SoundComponent extends Component {
     constructor(system, entity) {
         super(system, entity);
 
+        /** @private */
         this._volume = 1;
+        /** @private */
         this._pitch = 1;
+        /** @private */
         this._positional = true;
+        /** @private */
         this._refDistance = 1;
+        /** @private */
         this._maxDistance = 10000;
+        /** @private */
         this._rollOffFactor = 1;
+        /** @private */
         this._distanceModel = DISTANCE_LINEAR;
 
         /* eslint-disable jsdoc/check-types */
@@ -59,7 +48,124 @@ class SoundComponent extends Component {
         this._slots = {};
         /* eslint-enable jsdoc/check-types */
 
+        /** @private */
         this._playingBeforeDisable = {};
+    }
+
+    /**
+     * Update the specified property on all sound instances.
+     *
+     * @param {string} property - The name of the SoundInstance property to update.
+     * @param {string|number} value - The value to set the property to.
+     * @param {boolean} isFactor - True if the value is a factor of the slot property or false
+     * if it is an absolute value.
+     * @private
+     */
+    _updateSoundInstances(property, value, isFactor) {
+        const slots = this._slots;
+        for (const key in slots) {
+            const slot = slots[key];
+            // only change value of non-overlapping instances
+            if (!slot.overlap) {
+                const instances = slot.instances;
+                for (let i = 0, len = instances.length; i < len; i++) {
+                    instances[i][property] = isFactor ? slot[property] * value : value;
+                }
+            }
+        }
+    }
+
+    /**
+     * Determines which algorithm to use to reduce the volume of the sound as it moves away from
+     * the listener. Can be:
+     *
+     * - {@link DISTANCE_LINEAR}
+     * - {@link DISTANCE_INVERSE}
+     * - {@link DISTANCE_EXPONENTIAL}
+     *
+     * Defaults to {@link DISTANCE_LINEAR}.
+     *
+     * @type {string}
+     */
+    set distanceModel(value) {
+        this._distanceModel = value;
+        this._updateSoundInstances('distanceModel', value, false);
+    }
+
+    get distanceModel() {
+        return this._distanceModel;
+    }
+
+    /**
+     * The maximum distance from the listener at which audio falloff stops. Note the volume of the
+     * audio is not 0 after this distance, but just doesn't fall off anymore. Defaults to 10000.
+     *
+     * @type {number}
+     */
+    set maxDistance(value) {
+        this._maxDistance = value;
+        this._updateSoundInstances('maxDistance', value, false);
+    }
+
+    get maxDistance() {
+        return this._maxDistance;
+    }
+
+    /**
+     * The reference distance for reducing volume as the sound source moves further from the
+     * listener. Defaults to 1.
+     *
+     * @type {number}
+     */
+    set refDistance(value) {
+        this._refDistance = value;
+        this._updateSoundInstances('refDistance', value, false);
+    }
+
+    get refDistance() {
+        return this._refDistance;
+    }
+
+    /**
+     * The factor used in the falloff equation. Defaults to 1.
+     *
+     * @type {number}
+     */
+    set rollOffFactor(value) {
+        this._rollOffFactor = value;
+        this._updateSoundInstances('rollOffFactor', value, false);
+    }
+
+    get rollOffFactor() {
+        return this._rollOffFactor;
+    }
+
+    /**
+     * The pitch modifier to play the audio with. Must be larger than 0.01. Defaults to 1.
+     *
+     * @type {number}
+     */
+    set pitch(value) {
+        this._pitch = value;
+        this._updateSoundInstances('pitch', value, true);
+    }
+
+    get pitch() {
+        return this._pitch;
+    }
+
+    /**
+     * The volume modifier to play the audio with. In range 0-1. Defaults to 1.
+     *
+     * @type {number}
+     */
+    set volume(value) {
+        this._volume = value;
+        this._updateSoundInstances('volume', value, true);
+    }
+
+    get volume() {
+        return this._volume;
     }
 
     /**
@@ -80,7 +186,7 @@ class SoundComponent extends Component {
                 const oldLength = instances.length;
 
                 // When the instance is stopped, it gets removed from the slot.instances array
-                // so we are going backwards to compenstate for that
+                // so we are going backwards to compensate for that
 
                 for (let i = oldLength - 1; i >= 0; i--) {
                     const isPlaying = instances[i].isPlaying || instances[i].isSuspended;
@@ -390,59 +496,6 @@ class SoundComponent extends Component {
         }
     }
 }
-
-function defineSoundPropertyBasic(publicName, privateName) {
-    Object.defineProperty(SoundComponent.prototype, publicName, {
-        get: function () {
-            return this[privateName];
-        },
-        set: function (newValue) {
-            this[privateName] = newValue;
-
-            const slots = this._slots;
-            for (const key in slots) {
-                const slot = slots[key];
-                // only change value of non-overlapping instances
-                if (!slot.overlap) {
-                    const instances = slot.instances;
-                    for (let i = 0, len = instances.length; i < len; i++) {
-                        instances[i][publicName] = newValue;
-                    }
-                }
-            }
-        }
-    });
-}
-
-function defineSoundPropertyFactor(publicName, privateName) {
-    Object.defineProperty(SoundComponent.prototype, publicName, {
-        get: function () {
-            return this[privateName];
-        },
-        set: function (newValue) {
-            this[privateName] = newValue;
-
-            const slots = this._slots;
-            for (const key in slots) {
-                const slot = slots[key];
-                // only change value of non-overlapping instances
-                if (!slot.overlap) {
-                    const instances = slot.instances;
-                    for (let i = 0, len = instances.length; i < len; i++) {
-                        instances[i][publicName] = slot[publicName] * newValue;
-                    }
-                }
-            }
-        }
-    });
-}
-
-defineSoundPropertyFactor('pitch', '_pitch');
-defineSoundPropertyFactor('volume', '_volume');
-defineSoundPropertyBasic('refDistance', '_refDistance');
-defineSoundPropertyBasic('maxDistance', '_maxDistance');
-defineSoundPropertyBasic('rollOffFactor', '_rollOffFactor');
-defineSoundPropertyBasic('distanceModel', '_distanceModel');
 
 // Events Documentation
 


### PR DESCRIPTION
This PR migrates `SoundComponent` away from using `Object.defineProperty` and uses regular ES6 getter/setters instead. This means that `tsc` can now generate a correct TypeScript declaration file for `SoundComponent`.

While the formatting introduces around 50 new lines, this is all due to JSDoc formatting. The code is probably as concise (or more so) than it was before.

This PR also updates the JSDoc block for `Component#data` to the new format (with fewer explicit tags).

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
