### PR TITLE
Delete call to `events.attach` for `ComponentSystem`

### DIFF
--- a/src/framework/components/system.js
+++ b/src/framework/components/system.js
@@ -24,12 +24,11 @@ class ComponentSystem extends EventHandler {
 
         this.app = app;
 
-        // The store where all pc.ComponentData objects are kept
+        // The store where all ComponentData objects are kept
         this.store = {};
         this.schema = [];
     }
 
-    // Instance methods
     /**
      * Create new {@link Component} and component data instances and attach them to the entity.
      *

--- a/src/framework/components/system.js
+++ b/src/framework/components/system.js
@@ -1,4 +1,3 @@
-import { events } from '../../core/events.js';
 import { EventHandler } from '../../core/event-handler.js';
 
 import { Color } from '../../math/color.js';

--- a/src/framework/components/system.js
+++ b/src/framework/components/system.js
@@ -214,7 +214,4 @@ function convertValue(value, type) {
     }
 }
 
-// Add event support
-events.attach(ComponentSystem);
-
 export { ComponentSystem };


### PR DESCRIPTION
Remove redundant call to `events.attach` for `ComponentSystem`. `ComponentSystem` subclasses from `EventHandler` and gets the events functionality from there.

I'm fairly sure that this should have been deleted in https://github.com/playcanvas/engine/pull/3557 by @OlegGedzjuns.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
