### PR TITLE
Simplify LayoutGroupComponent initialization

### DIFF
--- a/src/framework/components/layout-group/component.js
+++ b/src/framework/components/layout-group/component.js
@@ -22,57 +22,6 @@ function isEnabledAndHasEnabledElement(entity) {
  * A LayoutGroupComponent enables the Entity to position and scale child {@link ElementComponent}s
  * according to configurable layout rules.
  *
- * @property {number} orientation Whether the layout should run horizontally or vertically. Can be:
- *
- * - {@link ORIENTATION_HORIZONTAL}
- * - {@link ORIENTATION_VERTICAL}
- *
- * Defaults to {@link ORIENTATION_HORIZONTAL}.
- * @property {boolean} reverseX Reverses the order of children along the x axis. Defaults to false.
- * @property {boolean} reverseY Reverses the order of children along the y axis. Defaults to true.
- * @property {Vec2} alignment Specifies the horizontal and vertical alignment of child elements.
- * Values range from 0 to 1 where [0, 0] is the bottom left and [1, 1] is the top right. Defaults
- * to [0, 1].
- * @property {Vec4} padding Padding to be applied inside the container before positioning any
- * children. Specified as left, bottom, right and top values. Defaults to [0, 0, 0, 0] (no
- * padding).
- * @property {Vec2} spacing Spacing to be applied between each child element. Defaults to [0, 0]
- * (no spacing).
- * @property {number} widthFitting Fitting logic to be applied when positioning and scaling child
- * elements. Can be:
- *
- * - {@link FITTING_NONE}: Child elements will be rendered at their natural size.
- * - {@link FITTING_STRETCH}: When the natural size of all child elements does not fill the width
- * of the container, children will be stretched to fit. The rules for how each child will be
- * stretched are outlined below:
- *   1. Sum the {@link LayoutChildComponent#fitWidthProportion} values of each child and normalize
- * so that all values sum to 1.
- *   2. Apply the natural width of each child.
- *   3. If there is space remaining in the container, distribute it to each child based on the
- * normalized {@link LayoutChildComponent#fitWidthProportion} values, but do not exceed the
- * {@link LayoutChildComponent#maxWidth} of each child.
- * - {@link FITTING_SHRINK}: When the natural size of all child elements overflows the width of the
- * container, children will be shrunk to fit. The rules for how each child will be stretched are
- * outlined below:
- *   1. Sum the {@link LayoutChildComponent#fitWidthProportion} values of each child and normalize
- * so that all values sum to 1.
- *   2. Apply the natural width of each child.
- *   3. If the new total width of all children exceeds the available space of the container, reduce
- * each child's width proportionally based on the normalized {@link
- * LayoutChildComponent#fitWidthProportion} values, but do not exceed the {@link
- * LayoutChildComponent#minWidth} of each child.
- * - {@link FITTING_BOTH}: Applies both STRETCH and SHRINK logic as necessary.
- *
- * Defaults to {@link FITTING_NONE}.
- * @property {number} heightFitting Identical to {@link LayoutGroupComponent#widthFitting} but for
- * the Y axis. Defaults to {@link FITTING_NONE}.
- * @property {boolean} wrap Whether or not to wrap children onto a new row/column when the size of
- * the container is exceeded. Defaults to false, which means that children will be be rendered in a
- * single row (horizontal orientation) or column (vertical orientation). Note that setting wrap to
- * true makes it impossible for the {@link FITTING_BOTH} fitting mode to operate in any logical
- * manner. For this reason, when wrap is true, a {@link LayoutGroupComponent#widthFitting} or
- * {@link LayoutGroupComponent#heightFitting} mode of {@link FITTING_BOTH} will be coerced to
- * {@link FITTING_STRETCH}.
  * @augments Component
  */
 class LayoutGroupComponent extends Component {
@@ -116,6 +65,188 @@ class LayoutGroupComponent extends Component {
         system.app.systems.element.on('beforeremove', this._onElementOrLayoutComponentRemove, this);
         system.app.systems.layoutchild.on('add', this._onElementOrLayoutComponentAdd, this);
         system.app.systems.layoutchild.on('beforeremove', this._onElementOrLayoutComponentRemove, this);
+    }
+
+    /**
+     * Whether the layout should run horizontally or vertically. Can be:
+     *
+     * - {@link ORIENTATION_HORIZONTAL}
+     * - {@link ORIENTATION_VERTICAL}
+     *
+     * Defaults to {@link ORIENTATION_HORIZONTAL}.
+     *
+     * @type {number}
+     */
+    set orientation(value) {
+        if (value !== this._orientation) {
+            this._orientation = value;
+            this._scheduleReflow();
+        }
+    }
+
+    get orientation() {
+        return this._orientation;
+    }
+
+    /**
+     * Reverses the order of children along the x axis. Defaults to false.
+     *
+     * @type {boolean}
+     */
+    set reverseX(value) {
+        if (value !== this._reverseX) {
+            this._reverseX = value;
+            this._scheduleReflow();
+        }
+    }
+
+    get reverseX() {
+        return this._reverseX;
+    }
+
+    /**
+     * Reverses the order of children along the y axis. Defaults to true.
+     *
+     * @type {boolean}
+     */
+    set reverseY(value) {
+        if (value !== this._reverseY) {
+            this._reverseY = value;
+            this._scheduleReflow();
+        }
+    }
+
+    get reverseY() {
+        return this._reverseY;
+    }
+
+    /**
+     * Specifies the horizontal and vertical alignment of child elements. Values range from 0 to 1
+     * where [0, 0] is the bottom left and [1, 1] is the top right. Defaults to [0, 1].
+     *
+     * @type {Vec2}
+     */
+    set alignment(value) {
+        if (!value.equals(this._alignment)) {
+            this._alignment.copy(value);
+            this._scheduleReflow();
+        }
+    }
+
+    get alignment() {
+        return this._alignment;
+    }
+
+    /**
+     * Padding to be applied inside the container before positioning any children. Specified as
+     * left, bottom, right and top values. Defaults to [0, 0, 0, 0] (no padding).
+     *
+     * @type {Vec4}
+     */
+    set padding(value) {
+        if (!value.equals(this._padding)) {
+            this._padding.copy(value);
+            this._scheduleReflow();
+        }
+    }
+
+    get padding() {
+        return this._padding;
+    }
+
+    /**
+     * Spacing to be applied between each child element. Defaults to [0, 0] (no spacing).
+     *
+     * @type {Vec2}
+     */
+    set spacing(value) {
+        if (!value.equals(this._spacing)) {
+            this._spacing.copy(value);
+            this._scheduleReflow();
+        }
+    }
+
+    get spacing() {
+        return this._spacing;
+    }
+
+    /**
+     * Fitting logic to be applied when positioning and scaling child elements. Can be:
+     *
+     * - {@link FITTING_NONE}: Child elements will be rendered at their natural size.
+     * - {@link FITTING_STRETCH}: When the natural size of all child elements does not fill the width
+     * of the container, children will be stretched to fit. The rules for how each child will be
+     * stretched are outlined below:
+     *   1. Sum the {@link LayoutChildComponent#fitWidthProportion} values of each child and normalize
+     * so that all values sum to 1.
+     *   2. Apply the natural width of each child.
+     *   3. If there is space remaining in the container, distribute it to each child based on the
+     * normalized {@link LayoutChildComponent#fitWidthProportion} values, but do not exceed the
+     * {@link LayoutChildComponent#maxWidth} of each child.
+     * - {@link FITTING_SHRINK}: When the natural size of all child elements overflows the width of the
+     * container, children will be shrunk to fit. The rules for how each child will be stretched are
+     * outlined below:
+     *   1. Sum the {@link LayoutChildComponent#fitWidthProportion} values of each child and normalize
+     * so that all values sum to 1.
+     *   2. Apply the natural width of each child.
+     *   3. If the new total width of all children exceeds the available space of the container, reduce
+     * each child's width proportionally based on the normalized {@link
+     * LayoutChildComponent#fitWidthProportion} values, but do not exceed the {@link
+     * LayoutChildComponent#minWidth} of each child.
+     * - {@link FITTING_BOTH}: Applies both STRETCH and SHRINK logic as necessary.
+     *
+     * Defaults to {@link FITTING_NONE}.
+     *
+     * @type {number}
+     */
+    set widthFitting(value) {
+        if (value !== this._widthFitting) {
+            this._widthFitting = value;
+            this._scheduleReflow();
+        }
+    }
+
+    get widthFitting() {
+        return this._widthFitting;
+    }
+
+    /**
+     * Identical to {@link LayoutGroupComponent#widthFitting} but for the Y axis. Defaults to
+     * {@link FITTING_NONE}.
+     *
+     * @type {number}
+     */
+    set heightFitting(value) {
+        if (value !== this._heightFitting) {
+            this._heightFitting = value;
+            this._scheduleReflow();
+        }
+    }
+
+    get heightFitting() {
+        return this._heightFitting;
+    }
+
+    /**
+     * Whether or not to wrap children onto a new row/column when the size of the container is
+     * exceeded. Defaults to false, which means that children will be be rendered in a single row
+     * (horizontal orientation) or column (vertical orientation). Note that setting wrap to true
+     * makes it impossible for the {@link FITTING_BOTH} fitting mode to operate in any logical
+     * manner. For this reason, when wrap is true, a {@link LayoutGroupComponent#widthFitting} or
+     * {@link LayoutGroupComponent#heightFitting} mode of {@link FITTING_BOTH} will be coerced to
+     * {@link FITTING_STRETCH}.
+     *
+     * @type {boolean}
+     */
+    set wrap(value) {
+        if (value !== this._wrap) {
+            this._wrap = value;
+            this._scheduleReflow();
+        }
+    }
+
+    get wrap() {
+        return this._wrap;
     }
 
     _isSelfOrChild(entity) {
@@ -220,32 +351,5 @@ class LayoutGroupComponent extends Component {
         this.system.app.systems.layoutchild.off('beforeremove', this._onElementOrLayoutComponentRemove, this);
     }
 }
-
-function defineReflowSchedulingProperty(name) {
-    const _name = '_' + name;
-
-    Object.defineProperty(LayoutGroupComponent.prototype, name, {
-        get: function () {
-            return this[_name];
-        },
-
-        set: function (value) {
-            if (this[_name] !== value) {
-                this[_name] = value;
-                this._scheduleReflow();
-            }
-        }
-    });
-}
-
-defineReflowSchedulingProperty('orientation');
-defineReflowSchedulingProperty('reverseX');
-defineReflowSchedulingProperty('reverseY');
-defineReflowSchedulingProperty('alignment');
-defineReflowSchedulingProperty('padding');
-defineReflowSchedulingProperty('spacing');
-defineReflowSchedulingProperty('widthFitting');
-defineReflowSchedulingProperty('heightFitting');
-defineReflowSchedulingProperty('wrap');
 
 export { LayoutGroupComponent };

--- a/src/framework/components/layout-group/system.js
+++ b/src/framework/components/layout-group/system.js
@@ -48,40 +48,13 @@ class LayoutGroupComponentSystem extends ComponentSystem {
         if (data.reverseX !== undefined) component.reverseX = data.reverseX;
         if (data.reverseY !== undefined) component.reverseY = data.reverseY;
         if (data.alignment !== undefined) {
-            if (data.alignment instanceof Vec2) {
-                component.alignment.copy(data.alignment);
-            } else {
-                component.alignment.set(data.alignment[0], data.alignment[1]);
-            }
-
-            /* eslint-disable no-self-assign */
-            // force update
-            component.alignment = component.alignment;
-            /* eslint-enable no-self-assign */
+            component.alignment = Array.isArray(data.alignment) ? new Vec2(data.alignment) : data.alignment;
         }
         if (data.padding !== undefined) {
-            if (data.padding instanceof Vec4) {
-                component.padding.copy(data.padding);
-            } else {
-                component.padding.set(data.padding[0], data.padding[1], data.padding[2], data.padding[3]);
-            }
-
-            /* eslint-disable no-self-assign */
-            // force update
-            component.padding = component.padding;
-            /* eslint-enable no-self-assign */
+            component.padding = Array.isArray(data.padding) ? new Vec4(data.padding) : data.padding;
         }
         if (data.spacing !== undefined) {
-            if (data.spacing instanceof Vec2) {
-                component.spacing.copy(data.spacing);
-            } else {
-                component.spacing.set(data.spacing[0], data.spacing[1]);
-            }
-
-            /* eslint-disable no-self-assign */
-            // force update
-            component.spacing = component.spacing;
-            /* eslint-enable no-self-assign */
+            component.spacing = Array.isArray(data.spacing) ? new Vec2(data.spacing) : data.spacing;
         }
         if (data.widthFitting !== undefined) component.widthFitting = data.widthFitting;
         if (data.heightFitting !== undefined) component.heightFitting = data.heightFitting;


### PR DESCRIPTION
Logic in `LayoutGroupComponentSystem#initializeComponentData` was overly complex. I suspect the author was trying extremely hard to avoid any allocations. However, in any given project, not many layoutgroup components are normally created, and these days, vectors are very quick to allocate (because they're no longer based on `Float32Array`s). Anyway, this PR simplifies it hugely.

Fixes:

![image](https://user-images.githubusercontent.com/697563/149976905-87a63ef6-6f70-479c-b362-24a2dc00315b.png)

The PR also gets rid of programmatic creation of properties on `LayoutGroupComponent` and uses regular ES6 getters/setters instead.

BREAKING CHANGE: The component no longer stores the reference to set vectors. Instead, it copies vectors into ones owned by the component. Before, this would fire two reflow events:

```
const padding = new pc.Vec4(1, 1, 1, 1);
entity.layoutgroup.padding = padding;
entity.layoutgroup.padding = padding;
```

Now it just reflows after the first set, and not the second.

You also used to be able to do:

```
const padding = new pc.Vec4(1, 1, 1, 1);
entity.layoutgroup.padding = padding;
padding.set(2, 2, 2, 2);
entity.layoutgroup.wrap = !entity.layoutgroup.wrap; // force a reflow by changing another property - padding also changes
```

Now, the setting of the `padding` variable above will be ignored.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
