### PR TITLE
LayerComposition's constructor no longer requires device as a parameter

### DIFF
--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -421,7 +421,7 @@ class Application extends EventHandler {
             passThrough: true
         });
 
-        const defaultLayerComposition = new LayerComposition(this.graphicsDevice, "default");
+        const defaultLayerComposition = new LayerComposition("default");
         defaultLayerComposition.pushOpaque(this.defaultLayerWorld);
         defaultLayerComposition.pushOpaque(this.defaultLayerDepth);
         defaultLayerComposition.pushOpaque(this.defaultLayerSkybox);
@@ -896,7 +896,7 @@ class Application extends EventHandler {
 
         // set up layers
         if (props.layers && props.layerOrder) {
-            const composition = new LayerComposition(this.graphicsDevice, "application");
+            const composition = new LayerComposition("application");
 
             const layers = {};
             for (const key in props.layers) {

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -1633,7 +1633,8 @@ class ForwardRenderer {
             }
 
             // Generate static lighting for meshes in this layer if needed
-            if (layer._needsStaticPrepare && layer._staticLightHash) {
+            // Note: Static lighting is not used when clustered lighting is enabled
+            if (layer._needsStaticPrepare && layer._staticLightHash && !this.scene.clusteredLightingEnabled) {
                 // TODO: reuse with the same staticLightHash
                 if (layer._staticPrepareDone) {
                     StaticMeshes.revert(layer.opaqueMeshInstances);
@@ -1856,7 +1857,7 @@ class ForwardRenderer {
         // #endif
 
         // Update static layer data, if something's changed
-        const updated = comp._update(clusteredLightingEnabled);
+        const updated = comp._update(device, clusteredLightingEnabled);
         const lightsChanged = (updated & COMPUPDATED_LIGHTS) !== 0;
 
         // #if _PROFILER

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -312,6 +312,7 @@ class Scene extends EventHandler {
 
     /**
      * List of all active composition mesh instances. Only for backwards compatibility.
+     * TODO: BatchManager is using it - perhaps that could be refactored
      *
      * @type {MeshInstance[]}
      * @private
@@ -322,7 +323,7 @@ class Scene extends EventHandler {
     get drawCalls() {
         let drawCalls = this.layers._meshInstances;
         if (!drawCalls.length) {
-            this.layers._update();
+            this.layers._update(this.device, this.clusteredLightingEnabled);
             drawCalls = this.layers._meshInstances;
         }
         return drawCalls;


### PR DESCRIPTION
LayerComposition was recently updated to accept GraphicsDevice parameter, to handle clustered lighting. This is causing a problem when using in Editor, as its LayerCompositions are created before the engine even starts.

This updates the engine to not pass the device to constructor, but pass it to _update function when required.

Even though this changes the API, the old version works harmlessly and device parameter is simply ignored.

There's also a small null check of material, which was removed recently but is occasionally causing null access in the Editor.