### PR TITLE
Remove `Object.defineProperty` from `LayoutChildComponent`

### DIFF
--- a/src/framework/components/layout-child/component.js
+++ b/src/framework/components/layout-child/component.js
@@ -7,18 +7,6 @@ import { Component } from '../component.js';
  * A LayoutChildComponent enables the Entity to control the sizing applied to it by its parent
  * {@link LayoutGroupComponent}.
  *
- * @property {number} minWidth The minimum width the element should be rendered at.
- * @property {number} minHeight The minimum height the element should be rendered at.
- * @property {number} maxWidth The maximum width the element should be rendered at.
- * @property {number} maxHeight The maximum height the element should be rendered at.
- * @property {number} fitWidthProportion The amount of additional horizontal space that the element
- * should take up, if necessary to satisfy a Stretch/Shrink fitting calculation. This is specified
- * as a proportion, taking into account the proportion values of other siblings.
- * @property {number} fitHeightProportion The amount of additional vertical space that the element
- * should take up, if necessary to satisfy a Stretch/Shrink fitting calculation. This is specified
- * as a proportion, taking into account the proportion values of other siblings.
- * @property {boolean} excludeFromLayout If set to true, the child will be excluded from all layout
- * calculations.
  * @augments Component
  */
 class LayoutChildComponent extends Component {
@@ -32,39 +20,137 @@ class LayoutChildComponent extends Component {
     constructor(system, entity) {
         super(system, entity);
 
+        /** @private */
         this._minWidth = 0;
+        /** @private */
         this._minHeight = 0;
+        /** @private */
         this._maxWidth = null;
+        /** @private */
         this._maxHeight = null;
+        /** @private */
         this._fitWidthProportion = 0;
+        /** @private */
         this._fitHeightProportion = 0;
+        /** @private */
         this._excludeFromLayout = false;
     }
-}
 
-function defineResizeProperty(name) {
-    const _name = '_' + name;
-
-    Object.defineProperty(LayoutChildComponent.prototype, name, {
-        get: function () {
-            return this[_name];
-        },
-
-        set: function (value) {
-            if (this[_name] !== value) {
-                this[_name] = value;
-                this.fire('resize');
-            }
+    /**
+     * The minimum width the element should be rendered at.
+     *
+     * @type {number}
+     */
+    set minWidth(value) {
+        if (value !== this._minWidth) {
+            this._minWidth = value;
+            this.fire('resize');
         }
-    });
-}
+    }
 
-defineResizeProperty('minWidth');
-defineResizeProperty('minHeight');
-defineResizeProperty('maxWidth');
-defineResizeProperty('maxHeight');
-defineResizeProperty('fitWidthProportion');
-defineResizeProperty('fitHeightProportion');
-defineResizeProperty('excludeFromLayout');
+    get minWidth() {
+        return this._minWidth;
+    }
+
+    /**
+     * The minimum height the element should be rendered at.
+     *
+     * @type {number}
+     */
+    set minHeight(value) {
+        if (value !== this._minHeight) {
+            this._minHeight = value;
+            this.fire('resize');
+        }
+    }
+
+    get minHeight() {
+        return this._minHeight;
+    }
+
+    /**
+     * The maximum width the element should be rendered at.
+     *
+     * @type {number|null}
+     */
+    set maxWidth(value) {
+        if (value !== this._maxWidth) {
+            this._maxWidth = value;
+            this.fire('resize');
+        }
+    }
+
+    get maxWidth() {
+        return this._maxWidth;
+    }
+
+    /**
+     * The maximum height the element should be rendered at.
+     *
+     * @type {number|null}
+     */
+    set maxHeight(value) {
+        if (value !== this._maxHeight) {
+            this._maxHeight = value;
+            this.fire('resize');
+        }
+    }
+
+    get maxHeight() {
+        return this._maxHeight;
+    }
+
+    /**
+     * The amount of additional horizontal space that the element should take up, if necessary to
+     * satisfy a Stretch/Shrink fitting calculation. This is specified as a proportion, taking into
+     * account the proportion values of other siblings.
+     *
+     * @type {number}
+     */
+    set fitWidthProportion(value) {
+        if (value !== this._fitWidthProportion) {
+            this._fitWidthProportion = value;
+            this.fire('resize');
+        }
+    }
+
+    get fitWidthProportion() {
+        return this._fitWidthProportion;
+    }
+
+    /**
+     * The amount of additional vertical space that the element should take up, if necessary to
+     * satisfy a Stretch/Shrink fitting calculation. This is specified as a proportion, taking into
+     * account the proportion values of other siblings.
+     *
+     * @type {number}
+     */
+    set fitHeightProportion(value) {
+        if (value !== this._fitHeightProportion) {
+            this._fitHeightProportion = value;
+            this.fire('resize');
+        }
+    }
+
+    get fitHeightProportion() {
+        return this._fitHeightProportion;
+    }
+
+    /**
+     * If set to true, the child will be excluded from all layout calculations.
+     *
+     * @type {boolean}
+     */
+    set excludeFromLayout(value) {
+        if (value !== this._excludeFromLayout) {
+            this._excludeFromLayout = value;
+            this.fire('resize');
+        }
+    }
+
+    get excludeFromLayout() {
+        return this._excludeFromLayout;
+    }
+}
 
 export { LayoutChildComponent };

--- a/src/framework/components/layout-group/component.js
+++ b/src/framework/components/layout-group/component.js
@@ -35,15 +35,25 @@ class LayoutGroupComponent extends Component {
     constructor(system, entity) {
         super(system, entity);
 
+        /** @private */
         this._orientation = ORIENTATION_HORIZONTAL;
+        /** @private */
         this._reverseX = false;
+        /** @private */
         this._reverseY = true;
+        /** @private */
         this._alignment = new Vec2(0, 1);
+        /** @private */
         this._padding = new Vec4();
+        /** @private */
         this._spacing = new Vec2();
+        /** @private */
         this._widthFitting = FITTING_NONE;
+        /** @private */
         this._heightFitting = FITTING_NONE;
+        /** @private */
         this._wrap = false;
+        /** @private */
         this._layoutCalculator = new LayoutCalculator();
 
         // Listen for the group container being resized


### PR DESCRIPTION
Enable correct TypeScript declarations to be generated for `LayoutChildComponent` by switch using of `Object.defineProperty` to ES6 class getters/setters. Also improves Intellisense in VS Code.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
