### PR TITLE
Restore `StandardMaterial#reset`

### DIFF
--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -489,6 +489,10 @@ class StandardMaterial extends Material {
 
         this.shaderOptBuilder = new StandardMaterialOptionsBuilder();
 
+        this.reset();
+    }
+
+    reset() {
         // set default values
         Object.keys(_props).forEach((name) => {
             this[`_${name}`] = _props[name].value();


### PR DESCRIPTION
Temporarily restore `StandardMaterial#reset` since the Editor relies on it for now.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
