### PR TITLE
Fix XR JSDoc type tags

### DIFF
--- a/src/xr/constants.js
+++ b/src/xr/constants.js
@@ -2,7 +2,7 @@
  * Inline - always available type of session. It has limited features availability and is rendered
  * into HTML element.
  *
- * @type string
+ * @type {string}
  */
 export const XRTYPE_INLINE = 'inline';
 
@@ -10,7 +10,7 @@ export const XRTYPE_INLINE = 'inline';
  * Immersive VR - session that provides exclusive access to VR device with best available tracking
  * features.
  *
- * @type string
+ * @type {string}
  */
 export const XRTYPE_VR = 'immersive-vr';
 
@@ -18,14 +18,14 @@ export const XRTYPE_VR = 'immersive-vr';
  * Immersive AR - session that provides exclusive access to VR/AR device that is intended to be
  * blended with real-world environment.
  *
- * @type string
+ * @type {string}
  */
 export const XRTYPE_AR = 'immersive-ar';
 
 /**
  * Viewer - always supported space with some basic tracking capabilities.
  *
- * @type string
+ * @type {string}
  */
 export const XRSPACE_VIEWER = 'viewer';
 
@@ -37,7 +37,7 @@ export const XRSPACE_VIEWER = 'viewer';
  * with 6DoF tracking, local reference spaces should emphasize keeping the origin stable relative
  * to the user's environment.
  *
- * @type string
+ * @type {string}
  */
 export const XRSPACE_LOCAL = 'local';
 
@@ -50,7 +50,7 @@ export const XRSPACE_LOCAL = 'local';
  * that purpose. For devices with 6DoF tracking, local-floor reference spaces should emphasize
  * keeping the origin stable relative to the user's environment.
  *
- * @type string
+ * @type {string}
  */
 export const XRSPACE_LOCALFLOOR = 'local-floor';
 
@@ -60,7 +60,7 @@ export const XRSPACE_LOCALFLOOR = 'local-floor';
  * space is optimized for keeping the native origin and bounds geometry stable relative to the
  * user's environment.
  *
- * @type string
+ * @type {string}
  */
 export const XRSPACE_BOUNDEDFLOOR = 'bounded-floor';
 
@@ -70,7 +70,7 @@ export const XRSPACE_BOUNDEDFLOOR = 'bounded-floor';
  * reference space is optimized for stability around the user's current position, and as such the
  * native origin may drift over time.
  *
- * @type string
+ * @type {string}
  */
 export const XRSPACE_UNBOUNDED = 'unbounded';
 
@@ -79,7 +79,7 @@ export const XRSPACE_UNBOUNDED = 'unbounded';
  * facing. This is commonly referred to as a "gaze input" device in the context of head-mounted
  * displays.
  *
- * @type string
+ * @type {string}
  */
 export const XRTARGETRAY_GAZE = 'gaze';
 
@@ -87,7 +87,7 @@ export const XRTARGETRAY_GAZE = 'gaze';
  * Screen - indicates that the input source was an interaction with the canvas element associated
  * with an inline session's output context, such as a mouse click or touch event.
  *
- * @type string
+ * @type {string}
  */
 export const XRTARGETRAY_SCREEN = 'screen';
 
@@ -96,28 +96,28 @@ export const XRTARGETRAY_SCREEN = 'screen';
  * other hand-tracking mechanism and represents that the user is using their hands or the held
  * device for pointing.
  *
- * @type string
+ * @type {string}
  */
 export const XRTARGETRAY_POINTER = 'tracked-pointer';
 
 /**
  * None - input source is not meant to be held in hands.
  *
- * @type string
+ * @type {string}
  */
 export const XRHAND_NONE = 'none';
 
 /**
  * Left - indicates that input source is meant to be held in left hand.
  *
- * @type string
+ * @type {string}
  */
 export const XRHAND_LEFT = 'left';
 
 /**
  * Right - indicates that input source is meant to be held in right hand.
  *
- * @type string
+ * @type {string}
  */
 export const XRHAND_RIGHT = 'right';
 
@@ -125,7 +125,7 @@ export const XRHAND_RIGHT = 'right';
  * Point - indicates that the hit test results will be computed based on the feature points
  * detected by the underlying Augmented Reality system.
  *
- * @type string
+ * @type {string}
  */
 export const XRTRACKABLE_POINT = 'point';
 
@@ -133,7 +133,7 @@ export const XRTRACKABLE_POINT = 'point';
  * Plane - indicates that the hit test results will be computed based on the planes detected by the
  * underlying Augmented Reality system.
  *
- * @type string
+ * @type {string}
  */
 export const XRTRACKABLE_PLANE = 'plane';
 
@@ -141,7 +141,7 @@ export const XRTRACKABLE_PLANE = 'plane';
  * Mesh - indicates that the hit test results will be computed based on the meshes detected by the
  * underlying Augmented Reality system.
  *
- * @type string
+ * @type {string}
  */
 export const XRTRACKABLE_MESH = 'mesh';
 
@@ -149,14 +149,14 @@ export const XRTRACKABLE_MESH = 'mesh';
  * CPU - indicates that depth sensing preferred usage is CPU. This usage path is guaranteed to be
  * supported.
  *
- * @type string
+ * @type {string}
  */
 export const XRDEPTHSENSINGUSAGE_CPU = 'cpu-optimized';
 
 /**
  * GPU - indicates that depth sensing preferred usage is GPU.
  *
- * @type string
+ * @type {string}
  */
 export const XRDEPTHSENSINGUSAGE_GPU = 'gpu-optimized';
 
@@ -164,13 +164,13 @@ export const XRDEPTHSENSINGUSAGE_GPU = 'gpu-optimized';
  * Luminance Alpha - indicates that depth sensing preferred raw data format is Luminance Alpha.
  * This format is guaranteed to be supported.
  *
- * @type string
+ * @type {string}
  */
 export const XRDEPTHSENSINGFORMAT_L8A8 = 'luminance-alpha';
 
 /**
  * Float 32 - indicates that depth sensing preferred raw data format is Float 32.
  *
- * @type string
+ * @type {string}
  */
 export const XRDEPTHSENSINGFORMAT_F32 = 'float32';


### PR DESCRIPTION
Add missing curly braces to `@type` tag for XR constants.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
