### PR TITLE
Improve IntelliSense for some core classes

### DIFF
--- a/src/core/debug.js
+++ b/src/core/debug.js
@@ -1,10 +1,25 @@
-// Internal debug system - logs, assets and similar
-// Note that the functions only execute in the debug build, and are stripped out in other builds.
+/** @typedef {import('../graphics/graphics-device.js').GraphicsDevice} GraphicsDevice */
+
+/**
+ * Internal debug system - logs, assets and similar. Note that the functions only execute in the
+ * debug build, and are stripped out in other builds.
+ *
+ * @ignore
+ */
 class Debug {
-    // set storing already logged deprecated messages, to only print each unique message one time
+    /**
+     * Set storing already logged deprecated messages, to only print each unique message one time.
+     *
+     * @type {Set<string>}
+     * @private
+     */
     static _deprecatedMessages = new Set();
 
-    // deprecated warning message
+    /**
+     * Deprecated warning message.
+     *
+     * @param {string} message - The message to log.
+     */
     static deprecated(message) {
         if (!Debug._deprecatedMessages.has(message)) {
             Debug._deprecatedMessages.add(message);
@@ -12,34 +27,60 @@ class Debug {
         }
     }
 
-    // assertion error message. If the assertion is false, the error message is written to the log
+    /**
+     * Assertion error message. If the assertion is false, the error message is written to the log.
+     *
+     * @param {boolean} assertion - The assertion to check.
+     * @param {...*} args - The values to be written to the log.
+     */
     static assert(assertion, ...args) {
         if (!assertion) {
             console.error("ASSERT FAILED: ", ...args);
         }
     }
 
-    // info message
+    /**
+     * Info message.
+     *
+     * @param {...*} args - The values to be written to the log.
+     */
     static log(...args) {
         console.log(...args);
     }
 
-    // warning message
+    /**
+     * Warning message.
+     *
+     * @param {...*} args - The values to be written to the log.
+     */
     static warn(...args) {
         console.warn(...args);
     }
 
-    // error message
+    /**
+     * Error message.
+     *
+     * @param {...*} args - The values to be written to the log.
+     */
     static error(...args) {
         console.error(...args);
     }
 
-    // push GPU marker to the stack on the device
+    /**
+     * Push GPU marker to the stack on the device.
+     *
+     * @param {GraphicsDevice} device - The graphics device.
+     * @param {string} name - The name of the marker.
+     */
     static pushGpuMarker(device, name) {
         device.pushMarker(name);
     }
 
-    // pop GPU marker from the stack on the device
+    /**
+     * Pop GPU marker from the stack on the device.
+     *
+     * @param {GraphicsDevice} device - The graphics device.
+     */
     static popGpuMarker(device) {
         device.popMarker();
     }

--- a/src/core/ref-counted-cache.js
+++ b/src/core/ref-counted-cache.js
@@ -1,14 +1,21 @@
-// Class implementing reference counting cache for objects
+/**
+ * Class implementing reference counting cache for objects.
+ *
+ * @ignore
+ */
 class RefCountedCache {
-    constructor() {
-        // The cache. The key is the object being stored in the cache.
-        // The value is ref count of the object. When that reaches zero,
-        // destroy function on the object gets called and object is removed
-        // from the cache.
-        this.cache = new Map();
-    }
+    /**
+     * The cache. The key is the object being stored in the cache. The value is ref count of
+     * the object. When that reaches zero, destroy function on the object gets called and
+     * object is removed from the cache.
+     *
+     * @type {Map<object, number>}
+     */
+    cache = new Map();
 
-    // destroy all stored objects
+    /**
+     * Destroy all stored objects.
+     */
     destroy() {
         this.cache.forEach((refCount, object) => {
             object.destroy();
@@ -16,13 +23,21 @@ class RefCountedCache {
         this.cache.clear();
     }
 
-    // add object reference to the cache
+    /**
+     * Add object reference to the cache.
+     *
+     * @param {object} object - The object to add.
+     */
     incRef(object) {
         const refCount = (this.cache.get(object) || 0) + 1;
         this.cache.set(object, refCount);
     }
 
-    // remove object reference from the cache
+    /**
+     * Remove object reference from the cache.
+     *
+     * @param {object} object - The object to remove.
+     */
     decRef(object) {
         if (object) {
             let refCount = this.cache.get(object);

--- a/src/core/ref-counted-object.js
+++ b/src/core/ref-counted-object.js
@@ -1,22 +1,35 @@
-// base class implementing reference counting for objects
+/**
+ * Base class implementing reference counting for objects.
+ *
+ * @ignore
+ */
 class RefCountedObject {
-    constructor() {
-        // counter
-        this._refCount = 0;
-    }
+    /**
+     * @type {number}
+     * @private
+     */
+    _refCount = 0;
 
-    // inrements the counter
+    /**
+     * Inrements the counter.
+     */
     incRefCount() {
         this._refCount++;
     }
 
-    // decrements the counter. When the value reaches zero, destroy is called
+    /**
+     * Decrements the counter. When the value reaches zero, destroy is called.
+     */
     decRefCount() {
         this._refCount--;
     }
 
-    // returns current count
-    getRefCount() {
+    /**
+     * The current reference count.
+     *
+     * @type {number}
+     */
+    get refCount() {
         return this._refCount;
     }
 }

--- a/src/scene/mesh-instance.js
+++ b/src/scene/mesh-instance.js
@@ -538,7 +538,7 @@ class MeshInstance {
             this.mesh = null;
 
             // destroy mesh
-            if (mesh.getRefCount() < 1) {
+            if (mesh.refCount < 1) {
                 mesh.destroy();
             }
         }

--- a/src/scene/mesh.js
+++ b/src/scene/mesh.js
@@ -287,7 +287,7 @@ class Mesh extends RefCountedObject {
             this.morph = null;
 
             // destroy morph
-            if (morph.getRefCount() < 1) {
+            if (morph.refCount < 1) {
                 morph.destroy();
             }
         }

--- a/src/scene/morph-instance.js
+++ b/src/scene/morph-instance.js
@@ -133,7 +133,7 @@ class MorphInstance {
             morph.decRefCount();
 
             // destroy morph
-            if (morph.getRefCount() < 1) {
+            if (morph.refCount < 1) {
                 morph.destroy();
             }
         }

--- a/src/scene/render.js
+++ b/src/scene/render.js
@@ -68,7 +68,7 @@ class Render extends EventHandler {
                 const mesh = this._meshes[i];
                 if (mesh) {
                     mesh.decRefCount();
-                    if (mesh.getRefCount() < 1) {
+                    if (mesh.refCount < 1) {
                         mesh.destroy();
                         this._meshes[i] = null;
                     }

--- a/src/scene/skin-instance-cache.js
+++ b/src/scene/skin-instance-cache.js
@@ -25,7 +25,7 @@ class SkinInstanceCache {
         SkinInstanceCache._skinInstanceCache.forEach(function (array, rootBone) {
             console.log(`${rootBone.name}: Array(${array.length})`);
             for (let i = 0; i < array.length; i++) {
-                console.log(`  ${i}: RefCount ${array[i].getRefCount()}`);
+                console.log(`  ${i}: RefCount ${array[i].refCount}`);
             }
         });
     }
@@ -112,7 +112,7 @@ class SkinInstanceCache {
                         cachedObj.decRefCount();
 
                         // last reference, needs to be destroyed
-                        if (cachedObj.getRefCount() === 0) {
+                        if (cachedObj.refCount === 0) {
                             cachedObjArray.splice(cachedObjIndex, 1);
 
                             // if the array is empty


### PR DESCRIPTION
Add JSDoc blocks for `RefCountedObject`, `RefCountedCache` and `Debug` classes in order to improve IntelliSense in VS Code.

This PR also changes `RefCountedObject#getRefCount` to a getter: `RefCountedObject#refCount`

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
