### PR TITLE
[FIX] Correctly convert 2 spaces to tabs for extras

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -33,7 +33,7 @@ function spacesToTabs() {
         transform(code, id) {
             if (!filter(id)) return;
             return {
-                code: code.replace(/  /g, '\t'), // eslint-disable-line no-regex-spaces
+                code: code.replace(/ {2}/g, '\t'),
                 map: { mappings: '' }
             };
         }
@@ -56,7 +56,7 @@ function shaderChunks(removeComments) {
                 glsl = glsl.replace(/\r/g, '');
 
                 // 4 spaces to tabs
-                glsl = glsl.replace(/    /g, '\t'); // eslint-disable-line no-regex-spaces
+                glsl = glsl.replace(/ {4}/g, '\t');
 
                 if (removeComments) {
                     // Remove comments
@@ -291,7 +291,7 @@ function scriptTarget(name, input, output) {
         },
         plugins: [
             babel(es5Options),
-            spacesToTabs
+            spacesToTabs()
         ]
     };
 }


### PR DESCRIPTION
* `spaceToTabs` plugin was not being called for extras lib and VoxParser script. Fixing this reduces extras from 26KB to 24KB
* Correctly address lint error for regexes with multiple spaces

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
