### PR TITLE
Internal Ammo variables are initialized when Ammo loads

### DIFF
--- a/src/framework/components/rigid-body/component.js
+++ b/src/framework/components/rigid-body/component.js
@@ -65,15 +65,6 @@ class RigidBodyComponent extends Component {
     constructor(system, entity) {
         super(system, entity);
 
-        // Lazily create shared variable
-        if (typeof Ammo !== 'undefined' && !ammoTransform) {
-            ammoTransform = new Ammo.btTransform();
-            ammoVec1 = new Ammo.btVector3();
-            ammoVec2 = new Ammo.btVector3();
-            ammoQuat = new Ammo.btQuaternion();
-            ammoOrigin = new Ammo.btVector3(0, 0, 0);
-        }
-
         this._angularDamping = 0;
         this._angularFactor = new Vec3(1, 1, 1);
         this._angularVelocity = new Vec3();
@@ -89,6 +80,18 @@ class RigidBodyComponent extends Component {
         this._rollingFriction = 0;
         this._simulationEnabled = false;
         this._type = BODYTYPE_STATIC;
+    }
+
+    static onLibraryLoaded() {
+
+        // Lazily create shared variable
+        if (typeof Ammo !== 'undefined' && !ammoTransform) {
+            ammoTransform = new Ammo.btTransform();
+            ammoVec1 = new Ammo.btVector3();
+            ammoVec2 = new Ammo.btVector3();
+            ammoQuat = new Ammo.btQuaternion();
+            ammoOrigin = new Ammo.btVector3(0, 0, 0);
+        }
     }
 
     /**

--- a/src/framework/components/rigid-body/system.js
+++ b/src/framework/components/rigid-body/system.js
@@ -217,6 +217,7 @@ class RigidBodyComponentSystem extends ComponentSystem {
             // Lazily create temp vars
             ammoRayStart = new Ammo.btVector3();
             ammoRayEnd = new Ammo.btVector3();
+            RigidBodyComponent.onLibraryLoaded();
 
             this.contactPointPool = new ObjectPool(ContactPoint, 1);
             this.contactResultPool = new ObjectPool(ContactResult, 1);


### PR DESCRIPTION
Fixes https://github.com/playcanvas/engine/issues/3915 by creating those internal temp variables when Ammo is loaded, and not when each RigidBody component is created, allowing components to be created even when Ammo is not loaded yet.