### PR TITLE
Standard shader ignores clustered light options when generating shaders

### DIFF
--- a/src/graphics/program-lib/programs/standard.js
+++ b/src/graphics/program-lib/programs/standard.js
@@ -80,8 +80,12 @@ const standard = {
         }
 
         if (options.lights) {
+            const isClustered = options.clusteredLightingEnabled;
             for (let i = 0; i < options.lights.length; i++) {
-                key += options.lights[i].key;
+                const light = options.lights[i];
+                if (!isClustered || light._type === LIGHTTYPE_DIRECTIONAL) {
+                    key += light.key;
+                }
             }
         }
 


### PR DESCRIPTION
Shader generates code handling clustered lights anyways, the specific counts of those lights do not need to create a new shader.

Performance when creating adding 5 clustered lights to the scene before (120ms shader compiles):
![Screenshot 2022-01-26 at 15 06 15](https://user-images.githubusercontent.com/59932779/151190681-a120a0c0-0aa0-4c7a-b987-795db1f3e09b.png)

and now:
![Screenshot 2022-01-26 at 14 57 38](https://user-images.githubusercontent.com/59932779/151190703-9fcf229a-67dc-4ace-81d1-41e9c5cf4b31.png)

