### PR TITLE
 An error occurs when the canvas is destroyed and created

### DIFF
--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -2006,6 +2006,7 @@ class Application extends EventHandler {
         if (getApplication() === this) {
             setApplication(null);
         }
+        samplesTexCache = {};
     }
 
     /**


### PR DESCRIPTION
Continued from the forum thread below.

There is a phenomenon that the render is broken when the app is destroyed and created without refreshing the page.

To solve this, we added a part to initialize samplesTexCache .

I haven't checked if there are any side effects, so please check and merge them or make additional corrections.

thank you.

Fixes #

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
