### PR TITLE
Deprecated constants are now hidden from JSDoc

### DIFF
--- a/src/math/constants.js
+++ b/src/math/constants.js
@@ -18,6 +18,7 @@ export const CURVE_SMOOTHSTEP = 1;
  *
  * @type {number}
  * @deprecated
+ * @ignore
  */
 export const CURVE_CATMULL = 2;
 
@@ -27,6 +28,7 @@ export const CURVE_CATMULL = 2;
  *
  * @type {number}
  * @deprecated
+ * @ignore
  */
 export const CURVE_CARDINAL = 3;
 

--- a/src/scene/constants.js
+++ b/src/scene/constants.js
@@ -507,6 +507,7 @@ export const GAMMA_SRGB = 1;
  *
  * @type {number}
  * @deprecated
+ * @ignore
  */
 export const GAMMA_SRGBFAST = 2; // deprecated
 


### PR DESCRIPTION
to hide these from public documentation