### PR TITLE
[BREAKING] Scene.gammaCorrection defaults to GAMMA_SRGB instead of GAMMA_NONE

### DIFF
--- a/examples/src/examples/animation/events.tsx
+++ b/examples/src/examples/animation/events.tsx
@@ -28,7 +28,7 @@ class EventsExample extends Example {
         // setup skydome
         app.scene.skyboxMip = 2;
         app.scene.setSkybox(assets['helipad.dds'].resources);
-
+        app.scene.skyboxIntensity = 0.4;    // make it darker
 
         // Create an Entity with a camera component
         const cameraEntity = new pc.Entity();

--- a/examples/src/examples/animation/locomotion.tsx
+++ b/examples/src/examples/animation/locomotion.tsx
@@ -56,7 +56,6 @@ class LocomotionExample extends Example {
             app.scene.skyboxMip = 2;
             app.scene.skyboxIntensity = 0.7;
             app.scene.setSkybox(assets.cubemap.resources);
-            app.scene.gammaCorrection = pc.GAMMA_SRGB;
             app.scene.toneMapping = pc.TONEMAP_ACES;
 
             // Create an Entity with a camera component

--- a/examples/src/examples/graphics/area-lights.tsx
+++ b/examples/src/examples/graphics/area-lights.tsx
@@ -132,7 +132,6 @@ class AreaLightsExample extends Example {
         app.setAreaLightLuts(assets.luts);
 
         // set up some general scene rendering properties
-        app.scene.gammaCorrection = pc.GAMMA_SRGB;
         app.scene.toneMapping = pc.TONEMAP_ACES;
 
         // setup skydome

--- a/examples/src/examples/graphics/area-picker.tsx
+++ b/examples/src/examples/graphics/area-picker.tsx
@@ -22,6 +22,7 @@ class AreaPickerExample extends Example {
         // setup skydome
         app.scene.skyboxMip = 2;
         app.scene.setSkybox(assets['helipad.dds'].resources);
+        app.scene.skyboxIntensity = 0.1;
 
         // use a quarter resolution for picker render target (faster but less precise - can miss small objects)
         const pickerScale = 0.25;

--- a/examples/src/examples/graphics/box-reflection.tsx
+++ b/examples/src/examples/graphics/box-reflection.tsx
@@ -210,7 +210,7 @@ class BoxReflectionExample extends Example {
             layers: [excludedLayer.id], // add it to excluded layer, we don't want the light captured in the reflection
             castShadows: false,
             color: pc.Color.WHITE,
-            intensity: 4,
+            intensity: 0.2,
             range: 1000
         });
 

--- a/examples/src/examples/graphics/clustered-area-lights.tsx
+++ b/examples/src/examples/graphics/clustered-area-lights.tsx
@@ -57,7 +57,6 @@ class AreaLightsExample extends Example {
         });
 
         // set up some general scene rendering properties
-        app.scene.gammaCorrection = pc.GAMMA_SRGB;
         app.scene.toneMapping = pc.TONEMAP_ACES;
 
         // enabled clustered lighting. This is a temporary API and will change in the future
@@ -192,7 +191,6 @@ class AreaLightsExample extends Example {
         app.setAreaLightLuts(assets.luts);
 
         // set up some general scene rendering properties
-        app.scene.gammaCorrection = pc.GAMMA_SRGB;
         app.scene.toneMapping = pc.TONEMAP_ACES;
 
         // create ground plane

--- a/examples/src/examples/graphics/clustered-lighting.tsx
+++ b/examples/src/examples/graphics/clustered-lighting.tsx
@@ -88,15 +88,15 @@ class ClusteredLightingExample extends Example {
 
         // create many omni lights that do not cast shadows
         let count = 30;
-        const intensity = 1.6;
         for (let i = 0; i < count; i++) {
-            const color = new pc.Color(intensity * Math.random(), intensity * Math.random(), intensity * Math.random(), 1);
+            const color = new pc.Color(Math.random(), Math.random(), Math.random(), 1);
             const lightPoint = new pc.Entity();
             lightPoint.addComponent("light", {
                 type: "omni",
                 color: color,
                 range: 12,
-                castShadows: false
+                castShadows: false,
+                falloffMode: pc.LIGHTFALLOFF_INVERSESQUARED
             });
 
             // attach a render component with a small sphere to each light
@@ -119,7 +119,7 @@ class ClusteredLightingExample extends Example {
         // create many spot lights
         count = 16;
         for (let i = 0; i < count; i++) {
-            const color = new pc.Color(intensity * Math.random(), intensity * Math.random(), intensity * Math.random(), 1);
+            const color = new pc.Color(Math.random(), Math.random(), Math.random(), 1);
             const lightSpot = new pc.Entity();
             lightSpot.addComponent("light", {
                 type: "spot",
@@ -152,7 +152,7 @@ class ClusteredLightingExample extends Example {
         dirLight.addComponent("light", {
             type: "directional",
             color: pc.Color.WHITE,
-            intensity: 0.2,
+            intensity: 0.15,
             range: 300,
             shadowDistance: 600,
             castShadows: true,

--- a/examples/src/examples/graphics/clustered-omni-shadows.tsx
+++ b/examples/src/examples/graphics/clustered-omni-shadows.tsx
@@ -63,6 +63,9 @@ class ClusteredShadowsOmniExample extends Example {
         const app = new pc.Application(canvas, {});
         app.start();
 
+        // set up some general scene rendering properties
+        app.scene.toneMapping = pc.TONEMAP_ACES;
+
         data.set('settings', {
             shadowAtlasResolution: 1300,     // shadow map resolution storing all shadows
             shadowType: pc.SHADOW_PCF3,      // shadow filter type
@@ -178,7 +181,7 @@ class ClusteredShadowsOmniExample extends Example {
             lightOmni.addComponent("light", {
                 type: "omni",
                 color: pc.Color.WHITE,
-                intensity: 13 / numLights,
+                intensity: 10 / numLights,
                 range: 350,
                 castShadows: true,
                 shadowBias: 0.2,

--- a/examples/src/examples/graphics/clustered-spot-shadows.tsx
+++ b/examples/src/examples/graphics/clustered-spot-shadows.tsx
@@ -106,7 +106,7 @@ class ClusteredSpotShadowsExample extends Example {
 
         // setup skydome as ambient light
         app.scene.skyboxMip = 3;
-        app.scene.skyboxIntensity = 0.4;
+        app.scene.skyboxIntensity = 0.1;
         app.scene.setSkybox(assets.cubemap.resources);
 
         // enabled clustered lighting. This is a temporary API and will change in the future

--- a/examples/src/examples/graphics/grab-pass.tsx
+++ b/examples/src/examples/graphics/grab-pass.tsx
@@ -100,7 +100,6 @@ class GrabPassExample extends Example {
         app.scene.exposure = 2;
         app.scene.setSkybox(assets['helipad.dds'].resources);
 
-        app.scene.gammaCorrection = pc.GAMMA_SRGB;
         app.scene.toneMapping = pc.TONEMAP_ACES;
 
         // Render meshes to immediate layer, which renders after skybox - to include skybox in the refraction.

--- a/examples/src/examples/graphics/hardware-instancing.tsx
+++ b/examples/src/examples/graphics/hardware-instancing.tsx
@@ -21,8 +21,11 @@ class HardwareInstancingExample extends Example {
 
         // setup skydome
         app.scene.skyboxMip = 2;
-        app.scene.exposure = 0.7;
+        app.scene.exposure = 0.3;
         app.scene.setSkybox(assets['helipad.dds'].resources);
+
+        // set up some general scene rendering properties
+        app.scene.toneMapping = pc.TONEMAP_ACES;
 
         // Set the canvas to fill the window and automatically change resolution to be the same as the canvas size
         app.setCanvasFillMode(pc.FILLMODE_FILL_WINDOW);

--- a/examples/src/examples/graphics/lights-baked-ao.tsx
+++ b/examples/src/examples/graphics/lights-baked-ao.tsx
@@ -104,7 +104,7 @@ class LightsBakedAOExample extends Example {
 
         // setup skydome - this is the main source of ambient light
         app.scene.skyboxMip = 3;
-        app.scene.skyboxIntensity = 1.5;
+        app.scene.skyboxIntensity = 0.6;
         app.scene.setSkybox(assets.cubemap.resources);
 
         // if skydome cubemap is disabled using HUD, a constant ambient color is used instead
@@ -136,7 +136,7 @@ class LightsBakedAOExample extends Example {
             shadowResolution: 2048,
             shadowType: pc.SHADOW_PCF3,
             color: new pc.Color(0.7, 0.7, 0.5),
-            intensity: 1.2
+            intensity: 1.6
         });
         app.root.addChild(lightDirectional);
         lightDirectional.setLocalEulerAngles(-55, 0, -30);
@@ -151,12 +151,12 @@ class LightsBakedAOExample extends Example {
             castShadows: true,
             normalOffsetBias: 0.05,
             shadowBias: 0.2,
-            shadowDistance: 50,
+            shadowDistance: 25,
             shadowResolution: 512,
             shadowType: pc.SHADOW_PCF3,
             color: pc.Color.YELLOW,
-            range: 10,
-            intensity: 0.7
+            range: 25,
+            intensity: 0.9
         });
         lightOmni.setLocalPosition(-4, 10, 5);
         app.root.addChild(lightOmni);
@@ -176,7 +176,7 @@ class LightsBakedAOExample extends Example {
             shadowType: pc.SHADOW_PCF3,
             color: pc.Color.RED,
             range: 10,
-            intensity: 2
+            intensity: 2.5
         });
         lightSpot.setLocalPosition(-5, 10, -7.5);
         app.root.addChild(lightSpot);
@@ -264,8 +264,8 @@ class LightsBakedAOExample extends Example {
                 cubemap: true,
                 hemisphere: true,
                 ambientBakeNumSamples: 20,
-                ambientBakeOcclusionContrast: 0,
-                ambientBakeOcclusionBrightness: 0.4
+                ambientBakeOcclusionContrast: -0.6,
+                ambientBakeOcclusionBrightness: -0.5
             },
             directional: {
                 enabled: true,

--- a/examples/src/examples/graphics/lights.tsx
+++ b/examples/src/examples/graphics/lights.tsx
@@ -88,7 +88,7 @@ class LightsExample extends Example {
         app.setCanvasFillMode(pc.FILLMODE_FILL_WINDOW);
         app.setCanvasResolution(pc.RESOLUTION_AUTO);
 
-        app.scene.ambientLight = new pc.Color(0.4, 0.4, 0.4);
+        app.scene.ambientLight = new pc.Color(0.2, 0.2, 0.2);
 
         // create an entity with the statue
         const entity = assets.statue.resource.instantiateRenderEntity();
@@ -124,17 +124,17 @@ class LightsExample extends Example {
         data.set('lights', {
             spot: {
                 enabled: true,
-                intensity: 0.6,
+                intensity: 0.8,
                 cookieIntensity: 1
             },
             omni: {
                 enabled: true,
-                intensity: 0.6,
+                intensity: 0.8,
                 cookieIntensity: 1
             },
             directional: {
                 enabled: true,
-                intensity: 0.6
+                intensity: 0.8
             }
         });
 

--- a/examples/src/examples/graphics/lines.tsx
+++ b/examples/src/examples/graphics/lines.tsx
@@ -21,7 +21,7 @@ class LinesExample extends Example {
 
         // setup skydome
         app.scene.skyboxMip = 2;
-        app.scene.exposure = 1.0;
+        app.scene.exposure = 0.2;
         app.scene.setSkybox(assets['helipad.dds'].resources);
         app.scene.skyboxRotation = new pc.Quat().setFromEulerAngles(0, 30, 0);
 

--- a/examples/src/examples/graphics/material-anisotropic.tsx
+++ b/examples/src/examples/graphics/material-anisotropic.tsx
@@ -23,7 +23,6 @@ class LightsExample extends Example {
         app.setCanvasFillMode(pc.FILLMODE_FILL_WINDOW);
         app.setCanvasResolution(pc.RESOLUTION_AUTO);
 
-        app.scene.gammaCorrection = pc.GAMMA_SRGB;
         app.scene.toneMapping = pc.TONEMAP_ACES;
         // Set the skybox to the 128x128 cubemap mipmap level
         app.scene.skyboxMip = 1;

--- a/examples/src/examples/graphics/material-clear-coat.tsx
+++ b/examples/src/examples/graphics/material-clear-coat.tsx
@@ -25,7 +25,6 @@ class MaterialClearCoatExample extends Example {
         app.setCanvasFillMode(pc.FILLMODE_FILL_WINDOW);
         app.setCanvasResolution(pc.RESOLUTION_AUTO);
 
-        app.scene.gammaCorrection = pc.GAMMA_SRGB;
         app.scene.toneMapping = pc.TONEMAP_ACES;
         // Set the skybox to the 128x128 cubemap mipmap level
         app.scene.skyboxMip = 1;

--- a/examples/src/examples/graphics/material-physical.tsx
+++ b/examples/src/examples/graphics/material-physical.tsx
@@ -24,7 +24,6 @@ class MaterialPhysicalExample extends Example {
         app.setCanvasFillMode(pc.FILLMODE_FILL_WINDOW);
         app.setCanvasResolution(pc.RESOLUTION_AUTO);
 
-        app.scene.gammaCorrection = pc.GAMMA_SRGB;
         app.scene.toneMapping = pc.TONEMAP_ACES;
         // Set the skybox to the 128x128 cubemap mipmap level
         app.scene.skyboxMip = 1;

--- a/examples/src/examples/graphics/material-translucent-specular.tsx
+++ b/examples/src/examples/graphics/material-translucent-specular.tsx
@@ -24,7 +24,6 @@ class MaterialTranslucentSpecularExample extends Example {
         app.setCanvasFillMode(pc.FILLMODE_FILL_WINDOW);
         app.setCanvasResolution(pc.RESOLUTION_AUTO);
 
-        app.scene.gammaCorrection = pc.GAMMA_SRGB;
         app.scene.toneMapping = pc.TONEMAP_ACES;
         // Set the skybox to the 128x128 cubemap mipmap level
         app.scene.skyboxMip = 1;

--- a/examples/src/examples/graphics/mesh-deformation.tsx
+++ b/examples/src/examples/graphics/mesh-deformation.tsx
@@ -25,7 +25,7 @@ class MeshDeformationExample extends Example {
 
         // setup skydome
         app.scene.skyboxMip = 2;
-        app.scene.exposure = 2;
+        app.scene.exposure = 1;
         app.scene.setSkybox(assets['helipad.dds'].resources);
 
         // Create an Entity with a camera component

--- a/examples/src/examples/graphics/mesh-morph-many.tsx
+++ b/examples/src/examples/graphics/mesh-morph-many.tsx
@@ -21,6 +21,7 @@ class MeshMorphManyExample extends Example {
 
         // setup skydome
         app.scene.skyboxMip = 2;
+        app.scene.exposure = 0.6;
         app.scene.setSkybox(assets['helipad.dds'].resources);
 
         // Set the canvas to fill the window and automatically change resolution to be the same as the canvas size

--- a/examples/src/examples/graphics/post-effects.tsx
+++ b/examples/src/examples/graphics/post-effects.tsx
@@ -112,7 +112,7 @@ class PostEffectsExample extends Example {
         // setup skydome
         app.scene.setSkybox(assets['helipad.dds'].resources);
         app.scene.skyboxMip = 3;
-        app.scene.exposure = 1.6;
+        app.scene.exposure = 1;
 
         // helper function to create a 3d primitive including its material
         function createPrimitive(primitiveType: string, position: pc.Vec3, scale: pc.Vec3, brightness: number, allowEmissive = true) {
@@ -165,7 +165,7 @@ class PostEffectsExample extends Example {
         }
 
         // create a sphere which represents the point of focus for the bokeh filter
-        const focusPrimitive = createPrimitive("sphere", pc.Vec3.ZERO, new pc.Vec3(10, 10, 10), 2.8, false);
+        const focusPrimitive = createPrimitive("sphere", pc.Vec3.ZERO, new pc.Vec3(10, 10, 10), 1.5, false);
 
         // add an omni light as a child of this sphere
         const light = new pc.Entity();

--- a/examples/src/examples/graphics/render-asset.tsx
+++ b/examples/src/examples/graphics/render-asset.tsx
@@ -56,7 +56,6 @@ class RenderAssetExample extends Example {
 
         // set skybox - this DDS file was 'prefiltered' in the PlayCanvas Editor and then downloaded.
         app.scene.setSkybox(assets["helipad.dds"].resources);
-        app.scene.gammaCorrection = pc.GAMMA_SRGB;
         app.scene.toneMapping = pc.TONEMAP_ACES;
         app.scene.skyboxMip = 1;
 

--- a/examples/src/examples/graphics/render-cubemap.tsx
+++ b/examples/src/examples/graphics/render-cubemap.tsx
@@ -27,7 +27,6 @@ class RenderCubemapExample extends Example {
         app.setCanvasResolution(pc.RESOLUTION_AUTO);
 
         // set up some general scene rendering properties
-        app.scene.gammaCorrection = pc.GAMMA_SRGB;
         app.scene.toneMapping = pc.TONEMAP_ACES;
 
         // setup skydome

--- a/examples/src/examples/graphics/render-to-texture.tsx
+++ b/examples/src/examples/graphics/render-to-texture.tsx
@@ -143,7 +143,6 @@ class RenderToTextureExample extends Example {
         app.scene.skyboxMip = 0;
         app.scene.setSkybox(assets['helipad.dds'].resources);
 
-        app.scene.gammaCorrection = pc.GAMMA_SRGB;
         app.scene.toneMapping = pc.TONEMAP_ACES;
 
         // update things each frame

--- a/examples/src/examples/graphics/shadow-cascades.tsx
+++ b/examples/src/examples/graphics/shadow-cascades.tsx
@@ -82,7 +82,6 @@ class ShadowCascadesExample extends Example {
         app.scene.skyboxMip = 3;
         app.scene.setSkybox(assets.helipad.resources);
         app.scene.skyboxRotation = new pc.Quat().setFromEulerAngles(0, -70, 0);
-        app.scene.gammaCorrection = pc.GAMMA_SRGB;
         app.scene.toneMapping = pc.TONEMAP_ACES;
 
         // instantiate the terrain

--- a/examples/src/examples/graphics/shapes.tsx
+++ b/examples/src/examples/graphics/shapes.tsx
@@ -16,6 +16,8 @@ class ShapesExample extends Example {
         app.setCanvasFillMode(pc.FILLMODE_FILL_WINDOW);
         app.setCanvasResolution(pc.RESOLUTION_AUTO);
 
+        app.scene.ambientLight = new pc.Color(0.2, 0.2, 0.2);
+
         // All render component primitive shape types
         const shapes = ["box", "plane", "cone", "cylinder", "sphere", "capsule"];
         let x = -1, y = -1;

--- a/examples/src/examples/graphics/texture-basis.tsx
+++ b/examples/src/examples/graphics/texture-basis.tsx
@@ -39,7 +39,6 @@ class TextureBasisExample extends Example {
         app.setCanvasResolution(pc.RESOLUTION_AUTO);
 
         // Set skybox
-        app.scene.gammaCorrection = pc.GAMMA_SRGB;
         app.scene.toneMapping = pc.TONEMAP_ACES;
         app.scene.skyboxMip = 1;
         app.scene.skyboxIntensity = 0.7;

--- a/examples/src/examples/physics/compound-collision.tsx
+++ b/examples/src/examples/physics/compound-collision.tsx
@@ -28,7 +28,7 @@ class CompoundCollisionExample extends Example {
             }
 
             // Create a couple of materials for our objects
-            const red = createMaterial(new pc.Color(1, 0.3, 0.3));
+            const red = createMaterial(new pc.Color(0.7, 0.3, 0.3));
             const gray = createMaterial(new pc.Color(0.7, 0.7, 0.7));
 
             // Define a scene hierarchy in JSON format. This is loaded/parsed in
@@ -261,7 +261,7 @@ class CompoundCollisionExample extends Example {
                     ]
                 }, {
                     name: 'Directional Light',
-                    rot: [45, 30, 0],
+                    rot: [45, 130, 0],
                     components: [
                         {
                             type: 'light',
@@ -270,6 +270,7 @@ class CompoundCollisionExample extends Example {
                                 castShadows: true,
                                 shadowDistance: 8,
                                 shadowBias: 0.1,
+                                intensity: 1,
                                 normalOffsetBias: 0.05
                             }
                         }

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -374,7 +374,7 @@ class Scene extends EventHandler {
      * - {@link GAMMA_NONE}
      * - {@link GAMMA_SRGB}
      *
-     * Defaults to {@link GAMMA_NONE}.
+     * Defaults to {@link GAMMA_SRGB}.
      *
      * @type {number}
      */

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -9,7 +9,7 @@ import { math } from '../math/math.js';
 
 import { CULLFACE_FRONT, PIXELFORMAT_RGBA32F, TEXTURETYPE_RGBM } from '../graphics/constants.js';
 
-import { BAKE_COLORDIR, FOG_NONE, GAMMA_NONE, GAMMA_SRGBHDR, LAYERID_IMMEDIATE, LAYERID_SKYBOX, LAYERID_WORLD, SHADER_FORWARDHDR, TONEMAP_LINEAR } from './constants.js';
+import { BAKE_COLORDIR, FOG_NONE, GAMMA_NONE, GAMMA_SRGBHDR, GAMMA_SRGB, LAYERID_IMMEDIATE, LAYERID_SKYBOX, LAYERID_WORLD, SHADER_FORWARDHDR, TONEMAP_LINEAR } from './constants.js';
 import { createBox } from './procedural.js';
 import { GraphNode } from './graph-node.js';
 import { Material } from './materials/material.js';
@@ -171,7 +171,7 @@ class Scene extends EventHandler {
 
         this._fog = FOG_NONE;
 
-        this._gammaCorrection = GAMMA_NONE;
+        this._gammaCorrection = GAMMA_SRGB;
         this._toneMapping = 0;
 
         /**


### PR DESCRIPTION
- breaking change for engine only users if they have not changed the default value, and use lighting: intensity of lights & skydome might need to be adjusted, alternatively GAMMA_NONE can be set.
- engine examples were adjusted to visually look good with the change if needed

Fixes https://github.com/playcanvas/engine/issues/3714