### PR TITLE
GraphicsDevice uses 'high-performance' power preference by default

### DIFF
--- a/src/graphics/graphics-device.js
+++ b/src/graphics/graphics-device.js
@@ -349,12 +349,17 @@ class GraphicsDevice extends EventHandler {
             this.fire('devicerestored');
         };
 
+        // options defaults
+        options.stencil = true;
+        if (!options.powerPreference) {
+            options.powerPreference = 'high-performance';
+        }
+
         // Retrieve the WebGL context
         const preferWebGl2 = (options.preferWebGl2 !== undefined) ? options.preferWebGl2 : true;
 
         const names = preferWebGl2 ? ["webgl2", "webgl", "experimental-webgl"] : ["webgl", "experimental-webgl"];
         let gl = null;
-        options.stencil = true;
         for (let i = 0; i < names.length; i++) {
             gl = canvas.getContext(names[i], options);
 


### PR DESCRIPTION
Fixes https://github.com/playcanvas/engine/issues/3916

This is particularly important on macOS 15 on systems with two graphics adapters, as by default a low power system is used