### PR TITLE
use uint8array instead of uint8clamppedarray

### DIFF
--- a/src/graphics/reproject-texture.js
+++ b/src/graphics/reproject-texture.js
@@ -286,7 +286,7 @@ const packSamplesTex = (device, name, samples) => {
 
     const w = Math.min(numSamples, 512);
     const h = Math.ceil(numSamples / w);
-    const data = new Uint8ClampedArray(w * h * 4);
+    const data = new Uint8Array(w * h * 4);
 
     // normalize float data and pack into rgba8
     let off = 0;


### PR DESCRIPTION
Fix for [this](https://forum.playcanvas.com/t/skyboxes-broken-on-mobile-with-the-current-engine-1-51-5/24008) forum issue.

iOS 13 specifically doesn't accept Uint8ClampedArray. Use Uint8Array instead.

Tested on macos chrome & safari, android 12 and ios 15, 14, 13.