### PR TITLE
Add missing properties to TypeScript declarations

### DIFF
--- a/examples/src/examples/graphics/render-asset.tsx
+++ b/examples/src/examples/graphics/render-asset.tsx
@@ -35,7 +35,7 @@ class RenderAssetExample {
         app.root.addChild(cubeEntities[0]);
 
         // clone another copy of it and add it to scene
-        cubeEntities[1] = cubeEntities[0].clone();
+        cubeEntities[1] = cubeEntities[0].clone() as pc.Entity;
         cubeEntities[1].setLocalPosition(-7, 12, 0);
         cubeEntities[1].setLocalScale(3, 3, 3);
         app.root.addChild(cubeEntities[1]);

--- a/src/framework/components/button/component.js
+++ b/src/framework/components/button/component.js
@@ -10,6 +10,8 @@ import { Component } from '../component.js';
 import { BUTTON_TRANSITION_MODE_SPRITE_CHANGE, BUTTON_TRANSITION_MODE_TINT } from './constants.js';
 import { ELEMENTTYPE_GROUP } from '../element/constants.js';
 
+/** @typedef {import('../../../asset/asset.js').Asset} Asset */
+/** @typedef {import('../../../math/vec4.js').Vec4} Vec4 */
 /** @typedef {import('../../entity.js').Entity} Entity */
 /** @typedef {import('./system.js').ButtonComponentSystem} ButtonComponentSystem */
 

--- a/src/framework/components/camera/component.js
+++ b/src/framework/components/camera/component.js
@@ -6,6 +6,7 @@ import { Component } from '../component.js';
 import { PostEffectQueue } from './post-effect-queue.js';
 
 /** @typedef {import('../../../graphics/render-target.js').RenderTarget} RenderTarget */
+/** @typedef {import('../../../math/color.js').Color} Color */
 /** @typedef {import('../../../math/mat4.js').Mat4} Mat4 */
 /** @typedef {import('../../../math/vec3.js').Vec3} Vec3 */
 /** @typedef {import('../../../math/vec4.js').Vec4} Vec4 */

--- a/src/framework/components/element/component.js
+++ b/src/framework/components/element/component.js
@@ -19,6 +19,11 @@ import { ELEMENTTYPE_GROUP, ELEMENTTYPE_IMAGE, ELEMENTTYPE_TEXT } from './consta
 import { ImageElement } from './image-element.js';
 import { TextElement } from './text-element.js';
 
+/** @typedef {import('../../../math/color.js').Color} Color */
+/** @typedef {import('../../../font/font.js').Font} Font */
+/** @typedef {import('../../../graphics/texture.js').Texture} Texture */
+/** @typedef {import('../../../scene/materials/material.js').Material} Material */
+/** @typedef {import('../../../scene/sprite.js').Sprite} Sprite */
 /** @typedef {import('./system.js').ElementComponentSystem} ElementComponentSystem */
 
 // #if _DEBUG

--- a/src/framework/components/light/component.js
+++ b/src/framework/components/light/component.js
@@ -16,6 +16,8 @@ import { Asset } from '../../../asset/asset.js';
 
 import { Component } from '../component.js';
 
+/** @typedef {import('../../../math/color.js').Color} Color */
+/** @typedef {import('../../../math/vec2.js').Vec2} Vec2 */
 /** @typedef {import('../../entity.js').Entity} Entity */
 /** @typedef {import('./system.js').LightComponentSystem} LightComponentSystem */
 

--- a/src/framework/entity.js
+++ b/src/framework/entity.js
@@ -542,7 +542,7 @@ class Entity extends GraphNode {
      * Create a deep copy of the Entity. Duplicate the full Entity hierarchy, with all Components
      * and all descendants. Note, this Entity is not in the hierarchy and must be added manually.
      *
-     * @returns {Entity} A new Entity which is a deep copy of the original.
+     * @returns {GraphNode} A new Entity which is a deep copy of the original.
      * @example
      * var e = this.entity.clone();
      *

--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -405,7 +405,6 @@ class GraphNode extends EventHandler {
      * Clone a graph node.
      *
      * @returns {GraphNode} A clone of the specified graph node.
-     * @ignore
      */
     clone() {
         const clone = new GraphNode();

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -19,6 +19,11 @@ import { StandardMaterialOptionsBuilder } from './standard-material-options-buil
 
 import { standardMaterialCubemapParameters, standardMaterialTextureParameters } from './standard-material-parameters.js';
 
+/** @typedef {import('../../graphics/texture.js').Texture} Texture */
+/** @typedef {import('../../math/color.js').Color} Color */
+/** @typedef {import('../../math/vec2.js').Vec2} Vec2 */
+/** @typedef {import('../../shape/bounding-box.js').BoundingBox} BoundingBox */
+
 // properties that get created on a standard material
 const _props = {};
 

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -32,10 +32,10 @@ let _params = new Set();
  * Callback used by {@link StandardMaterial#onUpdateShader}.
  *
  * @callback updateShaderCallback
- * @param {object} options - An object with shader generator settings (based on current material
- * and scene properties), that you can change and then return. Properties of the object passed into
+ * @param {*} options - An object with shader generator settings (based on current material and
+ * scene properties), that you can change and then return. Properties of the object passed into
  * this function are documented in {@link StandardMaterial#onUpdateShader}.
- * @returns {object} Returned settings will be used by the shader.
+ * @returns {*} Returned settings will be used by the shader.
  */
 
 /**
@@ -448,7 +448,6 @@ class StandardMaterial extends Material {
 
     static CUBEMAP_PARAMETERS = standardMaterialCubemapParameters;
 
-    /* eslint-disable jsdoc/check-types */
     /**
      * Create a new StandardMaterial instance.
      *
@@ -492,6 +491,7 @@ class StandardMaterial extends Material {
         this.reset();
     }
 
+    /* eslint-disable jsdoc/check-types */
     reset() {
         // set default values
         Object.keys(_props).forEach((name) => {

--- a/src/script/script-type.js
+++ b/src/script/script-type.js
@@ -216,11 +216,11 @@ class ScriptType extends EventHandler {
     }
 
     /**
-     * @callback scriptTypeCallback
+     * @callback scriptTypeInitializeCallback
      */
 
     /**
-     * @callback scriptTypeDeltaTimeCallback
+     * @callback scriptTypeUpdateCallback
      * @param {number} dt - The delta time in seconds since the last frame.
      */
 
@@ -232,14 +232,14 @@ class ScriptType extends EventHandler {
     /**
      * Called when script is about to run for the first time.
      *
-     * @type {scriptTypeCallback}
+     * @type {scriptTypeInitializeCallback}
      */
     initialize;
 
     /**
      * Called after all initialize methods are executed in the same tick or enabling chain of actions.
      *
-     * @type {scriptTypeCallback}
+     * @type {scriptTypeInitializeCallback}
      */
     postInitialize;
 
@@ -247,7 +247,7 @@ class ScriptType extends EventHandler {
      * Called for enabled (running state) scripts on each tick. It is passed the delta time in
      * seconds since the last frame.
      *
-     * @type {scriptTypeDeltaTimeCallback}
+     * @type {scriptTypeUpdateCallback}
      */
     update;
 
@@ -255,7 +255,7 @@ class ScriptType extends EventHandler {
      * Called for enabled (running state) scripts on each tick, after update. It is passed the
      * delta time in seconds since the last frame.
      *
-     * @type {scriptTypeDeltaTimeCallback}
+     * @type {scriptTypeUpdateCallback}
      */
     postUpdate;
 

--- a/src/script/script-type.js
+++ b/src/script/script-type.js
@@ -216,39 +216,58 @@ class ScriptType extends EventHandler {
     }
 
     /**
-     * @function
-     * @name ScriptType#[initialize]
-     * @description Called when script is about to run for the first time.
+     * @callback scriptTypeCallback
      */
 
     /**
-     * @function
-     * @name ScriptType#[postInitialize]
-     * @description Called after all initialize methods are executed in the same tick or enabling chain of actions.
-     */
-
-    /**
-     * @function
-     * @name ScriptType#[update]
-     * @description Called for enabled (running state) scripts on each tick.
+     * @callback scriptTypeDeltaTimeCallback
      * @param {number} dt - The delta time in seconds since the last frame.
      */
 
     /**
-     * @function
-     * @name ScriptType#[postUpdate]
-     * @description Called for enabled (running state) scripts on each tick, after update.
-     * @param {number} dt - The delta time in seconds since the last frame.
+     * @callback scriptTypeSwapCallback
+     * @param {ScriptType} old - The delta time in seconds since the last frame.
      */
 
     /**
-     * @function
-     * @name ScriptType#[swap]
-     * @description Called when a ScriptType that already exists in the registry
-     * gets redefined. If the new ScriptType has a `swap` method in its prototype,
-     * then it will be executed to perform hot-reload at runtime.
-     * @param {ScriptType} old - Old instance of the scriptType to copy data to the new instance.
+     * Called when script is about to run for the first time.
+     *
+     * @type {scriptTypeCallback}
      */
+    initialize;
+
+    /**
+     * Called after all initialize methods are executed in the same tick or enabling chain of actions.
+     *
+     * @type {scriptTypeCallback}
+     */
+    postInitialize;
+
+    /**
+     * Called for enabled (running state) scripts on each tick. It is passed the delta time in
+     * seconds since the last frame.
+     *
+     * @type {scriptTypeDeltaTimeCallback}
+     */
+    update;
+
+    /**
+     * Called for enabled (running state) scripts on each tick, after update. It is passed the
+     * delta time in seconds since the last frame.
+     *
+     * @type {scriptTypeDeltaTimeCallback}
+     */
+    postUpdate;
+
+    /**
+     * Called when a ScriptType that already exists in the registry gets redefined. If the new
+     * ScriptType has a `swap` method in its prototype, then it will be executed to perform
+     * hot-reload at runtime. It is passed the old instance of the scriptType to copy data to the
+     * new instance.
+     *
+     * @type {scriptTypeSwapCallback}
+     */
+    swap;
 
     /**
      * @event

--- a/types.mjs
+++ b/types.mjs
@@ -22,6 +22,7 @@ let dts = fs.readFileSync(path, 'utf8');
 dts = dts.replace('}, vertexCount?: number);', '}[], vertexCount?: number);');
 fs.writeFileSync(path, dts);
 
+// Generate TS declarations for getter/setter pairs
 const getDeclarations = (properties) => {
     let declarations = '';
 
@@ -67,10 +68,9 @@ dts = dts.replace('constructor(system: ButtonComponentSystem, entity: Entity);',
 fs.writeFileSync(path, dts);
 
 const cameraComponentProps = [
-    ['aspectRatio', 'number'],
     ['aspectRatioMode', 'number'],
     ['calculateProjection', 'calculateMatrixCallback'],
-    ['calculateTransform', 'calculateTransformCallback'],
+    ['calculateTransform', 'calculateMatrixCallback'],
     ['clearColor', 'Color'],
     ['cullFaces', 'boolean'],
     ['farClip', 'number'],
@@ -174,6 +174,13 @@ const lightComponentProps = [
 path = './types/framework/components/light/component.d.ts';
 dts = fs.readFileSync(path, 'utf8');
 dts = dts.replace('entity: Entity);', 'entity: Entity);\n' + getDeclarations(lightComponentProps));
+fs.writeFileSync(path, dts);
+
+// TypeScript compiler is defining enabled in ParticleSystemComponent because it doesn't
+// know about the declaration in the Component base class, so remove it.
+path = './types/framework/components/particle-system/component.d.ts';
+dts = fs.readFileSync(path, 'utf8');
+dts = dts.replace('enabled: any;', '');
 fs.writeFileSync(path, dts);
 
 const standarMaterialProps = [

--- a/types.mjs
+++ b/types.mjs
@@ -17,7 +17,321 @@ paths.forEach(path => {
 
 // Fix up description parameter for VertexFormat constructor because tsc
 // doesn't recognize it as an array
-const path = './types/graphics/vertex-format.d.ts';
+let path = './types/graphics/vertex-format.d.ts';
 let dts = fs.readFileSync(path, 'utf8');
 dts = dts.replace('}, vertexCount?: number);', '}[], vertexCount?: number);');
+fs.writeFileSync(path, dts);
+
+const getDeclarations = (properties) => {
+    let declarations = '';
+
+    properties.forEach(prop => {
+        declarations += `
+    set ${prop[0]}(arg: ${prop[1]});
+    get ${prop[0]}(): ${prop[1]};
+`;
+    });
+
+    return declarations;
+};
+
+const componentProps = [
+    ['enabled', 'boolean']
+];
+
+path = './types/framework/components/component.d.ts';
+dts = fs.readFileSync(path, 'utf8');
+dts = dts.replace('get data(): any;', 'get data(): any;\n' + getDeclarations(componentProps));
+fs.writeFileSync(path, dts);
+
+const buttonComponentProps = [
+    ['active', 'boolean'],
+    ['fadeDuration', 'number'],
+    ['hitPadding', 'Vec4'],
+    ['hoverSpriteAsset', 'Asset'],
+    ['hoverSpriteFrame', 'number'],
+    ['hoverTint', 'Color'],
+    ['imageEntity', 'Entity'],
+    ['inactiveSpriteAsset', 'Asset'],
+    ['inactiveSpriteFrame', 'number'],
+    ['inactiveTint', 'Color'],
+    ['pressedSpriteAsset', 'Asset'],
+    ['pressedSpriteFrame', 'number'],
+    ['pressedTint', 'Color'],
+    ['transitionMode', 'number']
+];
+   
+path = './types/framework/components/button/component.d.ts';
+dts = fs.readFileSync(path, 'utf8');
+dts = dts.replace('constructor(system: ButtonComponentSystem, entity: Entity);', 'constructor(system: ButtonComponentSystem, entity: Entity);\n' + getDeclarations(buttonComponentProps));
+fs.writeFileSync(path, dts);
+
+const cameraComponentProps = [
+    ['aspectRatio', 'number'],
+    ['aspectRatioMode', 'number'],
+    ['calculateProjection', 'calculateMatrixCallback'],
+    ['calculateTransform', 'calculateTransformCallback'],
+    ['clearColor', 'Color'],
+    ['cullFaces', 'boolean'],
+    ['farClip', 'number'],
+    ['flipFaces', 'boolean'],
+    ['fov', 'number'],
+    ['frustumCulling', 'boolean'],
+    ['horizontalFov', 'boolean'],
+    ['nearClip', 'number'],
+    ['orthoHeight', 'number'],
+    ['projection', 'number'],
+    ['scissorRect', 'Vec4']
+];
+
+path = './types/framework/components/camera/component.d.ts';
+dts = fs.readFileSync(path, 'utf8');
+dts = dts.replace('_postEffects: PostEffectQueue;', '_postEffects: PostEffectQueue;\n' + getDeclarations(cameraComponentProps));
+fs.writeFileSync(path, dts);
+
+const elementComponentProps = [
+    ['alignment', 'Vec2'],
+    ['autoFitHeight', 'boolean'],
+    ['autoFitWidth', 'boolean'],
+    ['autoHeight', 'boolean'],
+    ['autoWidth', 'boolean'],
+    ['color', 'Color'],
+    ['enableMarkup', 'boolean'],
+    ['font', 'Font'],
+    ['fontAsset', 'number'],
+    ['fontSize', 'number'],
+    ['key', 'string'],
+    ['lineHeight', 'number'],
+    ['mask', 'boolean'],
+    ['material', 'Material'],
+    ['materialAsset', 'number'],
+    ['maxFontSize', 'number'],
+    ['maxLines', 'number'],
+    ['minFontSize', 'number'],
+    ['opacity', 'number'],
+    ['outlineColor', 'Color'],
+    ['outlineThickness', 'number'],
+    ['pixelsPerUnit', 'number'],
+    ['rangeEnd', 'number'],
+    ['rangeStart', 'number'],
+    ['rect', 'Vec4'],
+    ['rtlReorder', 'boolean'],
+    ['shadowColor', 'Color'],
+    ['shadowOffset', 'number'],
+    ['spacing', 'number'],
+    ['sprite', 'Sprite'],
+    ['spriteAsset', 'number'],
+    ['spriteFrame', 'number'],
+    ['text', 'string'],
+    ['texture', 'Texture'],
+    ['textureAsset', 'number'],
+    ['unicodeConverter', 'boolean'],
+    ['wrapLines', 'boolean']
+];
+
+path = './types/framework/components/element/component.d.ts';
+dts = fs.readFileSync(path, 'utf8');
+dts = dts.replace('_maskedBy: any;', '_maskedBy: any;\n' + getDeclarations(elementComponentProps));
+fs.writeFileSync(path, dts);
+
+const lightComponentProps = [
+    ['affectDynamic', 'boolean'],
+    ['affectLightmapped', 'boolean'],
+    ['bake', 'boolean'],
+    ['bakeArea', 'number'],
+    ['bakeDir', 'boolean'],
+    ['bakeNumSamples', 'number'],
+    ['cascadeDistribution', 'number'],
+    ['castShadows', 'boolean'],
+    ['color', 'Color'],
+    ['cookieAngle', 'number'],
+    ['cookieChannel', 'string'],
+    ['cookieFalloff', 'boolean'],
+    ['cookieIntensity', 'number'],
+    ['cookieOffset', 'Vec2'],
+    ['cookieScale', 'Vec2'],
+    ['falloffMode', 'number'],
+    ['innerConeAngle', 'number'],
+    ['intensity', 'number'],
+    ['isStatic', 'boolean'],
+    ['layers', 'number[]'],
+    ['mask', 'number'],
+    ['normalOffsetBias', 'number'],
+    ['numCascades', 'number'],
+    ['outerConeAngle', 'number'],
+    ['range', 'number'],
+    ['shadowBias', 'number'],
+    ['shadowDistance', 'number'],
+    ['shadowResolution', 'number'],
+    ['shadowType', 'number'],
+    ['shadowUpdateMode', 'number'],
+    ['shape', 'number'],
+    ['type', 'string'],
+    ['vsmBlurMode', 'number'],
+    ['vsmBlurSize', 'number']
+];
+
+path = './types/framework/components/light/component.d.ts';
+dts = fs.readFileSync(path, 'utf8');
+dts = dts.replace('entity: Entity);', 'entity: Entity);\n' + getDeclarations(lightComponentProps));
+fs.writeFileSync(path, dts);
+
+const standarMaterialProps = [
+    ['alphaFade', 'boolean'],
+    ['ambient', 'Color'],
+    ['ambientTint', 'boolean'],
+    ['anisotropy', 'number'],
+    ['aoMap', 'Texture'],
+    ['aoMapChannel', 'string'],
+    ['aoMapOffset', 'Vec2'],
+    ['aoMapRotation', 'number'],
+    ['aoMapTiling', 'Vec2'],
+    ['aoMapUv', 'number'],
+    ['aoVertexColor', 'boolean'],
+    ['aoVertexColorChannel', 'string'],
+    ['bumpiness', 'number'],
+    ['clearCoat', 'number'],
+    ['clearCoatBumpiness', 'number'],
+    ['clearCoatGlossMap', 'Texture'],
+    ['clearCoatGlossMapChannel', 'string'],
+    ['clearCoatGlossMapOffset', 'Vec2'],
+    ['clearCoatGlossMapRotation', 'number'],
+    ['clearCoatGlossMapTiling', 'Vec2'],
+    ['clearCoatGlossMapUv', 'number'],
+    ['clearCoatGlossVertexColor', 'boolean'],
+    ['clearCoatGlossVertexColorChannel', 'string'],
+    ['clearCoatGlossiness', 'number'],
+    ['clearCoatMap', 'Texture'],
+    ['clearCoatMapChannel', 'string'],
+    ['clearCoatMapOffset', 'Vec2'],
+    ['clearCoatMapRotation', 'number'],
+    ['clearCoatMapTiling', 'Vec2'],
+    ['clearCoatMapUv', 'number'],
+    ['clearCoatNormalMap', 'Texture'],
+    ['clearCoatNormalMapOffset', 'Vec2'],
+    ['clearCoatNormalMapRotation', 'number'],
+    ['clearCoatNormalMapTiling', 'Vec2'],
+    ['clearCoatNormalMapUv', 'number'],
+    ['clearCoatVertexColor', 'boolean'],
+    ['clearCoatVertexColorChannel', 'string'],
+    ['conserveEnergy', 'boolean'],
+    ['cubeMap', 'Texture'],
+    ['cubeMapProjection', 'number'],
+    ['cubeMapProjectionBox', 'BoundingBox'],
+    ['diffuse', 'Color'],
+    ['diffuseDetailMap', 'Texture'],
+    ['diffuseDetailMapChannel', 'string'],
+    ['diffuseDetailMapOffset', 'Vec2'],
+    ['diffuseDetailMapRotation', 'number'],
+    ['diffuseDetailMapTiling', 'Vec2'],
+    ['diffuseDetailMapUv', 'number'],
+    ['diffuseDetailMode', 'string'],
+    ['diffuseMap', 'Texture'],
+    ['diffuseMapChannel', 'string'],
+    ['diffuseMapOffset', 'Vec2'],
+    ['diffuseMapRotation', 'number'],
+    ['diffuseMapTiling', 'Vec2'],
+    ['diffuseMapUv', 'number'],
+    ['diffuseTint', 'boolean'],
+    ['diffuseVertexColor', 'boolean'],
+    ['diffuseVertexColorChannel', 'string'],
+    ['emissive', 'Color'],
+    ['emissiveIntensity', 'number'],
+    ['emissiveMap', 'Texture'],
+    ['emissiveMapChannel', 'string'],
+    ['emissiveMapOffset', 'Vec2'],
+    ['emissiveMapRotation', 'number'],
+    ['emissiveMapTiling', 'Vec2'],
+    ['emissiveMapUv', 'number'],
+    ['emissiveTint', 'boolean'],
+    ['emissiveVertexColor', 'boolean'],
+    ['emissiveVertexColorChannel', 'string'],
+    ['enableGGXSpecular', 'boolean'],
+    ['fresnelModel', 'number'],
+    ['glossMap', 'Texture'],
+    ['glossMapChannel', 'string'],
+    ['glossMapOffset', 'Vec2'],
+    ['glossMapRotation', 'number'],
+    ['glossMapTiling', 'Vec2'],
+    ['glossMapUv', 'number'],
+    ['glossVertexColor', 'boolean'],
+    ['glossVertexColorChannel', 'string'],
+    ['heightMap', 'Texture'],
+    ['heightMapChannel', 'string'],
+    ['heightMapFactor', 'number'],
+    ['heightMapOffset', 'Vec2'],
+    ['heightMapRotation', 'number'],
+    ['heightMapTiling', 'Vec2'],
+    ['heightMapUv', 'number'],
+    ['lightMap', 'Texture'],
+    ['lightMapChannel', 'string'],
+    ['lightMapOffset', 'Vec2'],
+    ['lightMapRotation', 'number'],
+    ['lightMapTiling', 'Vec2'],
+    ['lightMapUv', 'number'],
+    ['lightVertexColor', 'boolean'],
+    ['lightVertexColorChannel', 'string'],
+    ['metalness', 'number'],
+    ['metalnessMap', 'Texture'],
+    ['metalnessMapChannel', 'string'],
+    ['metalnessMapOffset', 'Vec2'],
+    ['metalnessMapRotation', 'number'],
+    ['metalnessMapTiling', 'Vec2'],
+    ['metalnessMapUv', 'number'],
+    ['metalnessVertexColor', 'boolean'],
+    ['metalnessVertexColorChannel', 'string'],
+    ['normalDetailMap', 'Texture'],
+    ['normalDetailMapBumpiness', 'number'],
+    ['normalDetailMapOffset', 'Vec2'],
+    ['normalDetailMapRotation', 'number'],
+    ['normalDetailMapTiling', 'Vec2'],
+    ['normalDetailMapUv', 'number'],
+    ['normalMap', 'Texture'],
+    ['normalMapOffset', 'Vec2'],
+    ['normalMapRotation', 'number'],
+    ['normalMapTiling', 'Vec2'],
+    ['normalMapUv', 'number'],
+    ['occludeDirect', 'number'],
+    ['occludeSpecular', 'number'],
+    ['occludeSpecularIntensity', 'number'],
+    ['onUpdateShader', 'updateShaderCallback'],
+    ['opacity', 'number'],
+    ['opacityFadesSpecular', 'boolean'],
+    ['opacityMap', 'Texture'],
+    ['opacityMapChannel', 'string'],
+    ['opacityMapOffset', 'Vec2'],
+    ['opacityMapRotation', 'number'],
+    ['opacityMapTiling', 'Vec2'],
+    ['opacityMapUv', 'number'],
+    ['opacityVertexColor', 'boolean'],
+    ['opacityVertexColorChannel', 'string'],
+    ['pixelSnap', 'boolean'],
+    ['reflectivity', 'number'],
+    ['refraction', 'number'],
+    ['refractionIndex', 'number'],
+    ['shadingModel', 'number'],
+    ['shininess', 'number'],
+    ['specular', 'Color'],
+    ['specularAntialias', 'boolean'],
+    ['specularMap', 'Texture'],
+    ['specularMapChannel', 'string'],
+    ['specularMapOffset', 'Vec2'],
+    ['specularMapRotation', 'number'],
+    ['specularMapTiling', 'Vec2'],
+    ['specularMapUv', 'number'],
+    ['specularTint', 'boolean'],
+    ['specularVertexColor', 'boolean'],
+    ['specularVertexColorChannel', 'string'],
+    ['sphereMap', 'Texture'],
+    ['twoSidedLighting', 'boolean'],
+    ['useFog', 'boolean'],
+    ['useGammaTonemap', 'boolean'],
+    ['useLighting', 'boolean'],
+    ['useMetalness', 'boolean'],
+    ['useSkybox', 'boolean']
+];
+
+path = './types/scene/materials/standard-material.d.ts';
+dts = fs.readFileSync(path, 'utf8');
+dts = dts.replace('reset(): void;', 'reset(): void;\n' + getDeclarations(standarMaterialProps));
 fs.writeFileSync(path, dts);


### PR DESCRIPTION
Add properties defined with `Object.defineProperty` to the TypeScript declarations. This addresses classes like `StandardMaterial`, `ButtonComponent`, `CameraComponent`, ElementComponent` and `LightComponent`.

🚨 THIS IS A TEMPORARY FIX TO ENABLE US TO RELEASE 1.52.0 🚨

Instead of fixing the actual source to enable the TypeScript compiler to pick up the programmatically defined properties, this PR post-processes the generated `.d.ts` files, inserting the missing properties as necessary. This works, but is susceptible to breakage if the API in the corresponding modules changes.

Anyway, with this PR, the Examples Browser now builds without errors.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
