### PR TITLE
Gitignore ignores stats.html

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ node_modules
 npm-debug.log
 scripts/parsers/vox-parser.js
 types
+stats.html


### PR DESCRIPTION
file created by the build of the treemap