### PR TITLE
Added null check on the mesh before getting the graphics device on material#destroy

### DIFF
--- a/src/scene/materials/material.js
+++ b/src/scene/materials/material.js
@@ -12,6 +12,7 @@ import {
     BLEND_MULTIPLICATIVE, BLEND_ADDITIVEALPHA, BLEND_MULTIPLICATIVE2X, BLEND_SCREEN,
     BLEND_MIN, BLEND_MAX
 } from '../constants.js';
+import { Debug } from "../../core/debug";
 import { DefaultMaterial } from './default-material.js';
 
 /** @typedef {import('../../graphics/texture.js').Texture} Texture */
@@ -468,9 +469,13 @@ class Material {
             }
             meshInstance._material = null;
 
-            const defaultMaterial = DefaultMaterial.get(meshInstance.mesh.device);
-            if (this !== defaultMaterial) {
-                meshInstance.material = defaultMaterial;
+            if (meshInstance.mesh) {
+                const defaultMaterial = DefaultMaterial.get(meshInstance.mesh.device);
+                if (this !== defaultMaterial) {
+                    meshInstance.material = defaultMaterial;
+                }
+            } else {
+                Debug.warn('pc.Material: MeshInstance mesh is null, default material cannot be assigned to the MeshInstance');
             }
         }
     }

--- a/src/scene/materials/material.js
+++ b/src/scene/materials/material.js
@@ -12,7 +12,7 @@ import {
     BLEND_MULTIPLICATIVE, BLEND_ADDITIVEALPHA, BLEND_MULTIPLICATIVE2X, BLEND_SCREEN,
     BLEND_MIN, BLEND_MAX
 } from '../constants.js';
-import { Debug } from "../../core/debug";
+import { Debug } from "../../core/debug.js";
 import { DefaultMaterial } from './default-material.js';
 
 /** @typedef {import('../../graphics/texture.js').Texture} Texture */


### PR DESCRIPTION
Fixes a client issue where there's an edge case that the mesh is destroyed but the material still has a reference for the mesh instance.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
