### PR TITLE
Remove debug warning in `GraphNode#removeChild`

### DIFF
--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -1,4 +1,3 @@
-import { Debug } from '../core/debug.js';
 import { EventHandler } from '../core/event-handler.js';
 import { Tags } from '../core/tags.js';
 

--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -1297,7 +1297,6 @@ class GraphNode extends EventHandler {
     removeChild(child) {
         const index = this._children.indexOf(child);
         if (index === -1) {
-            Debug.warn(`GraphNode#removeChild: '${child.name}' is not a child of '${this.name}'`);
             return;
         }
 


### PR DESCRIPTION
The engine internally can, in some instances, try to remove a child of a node which is not actually a child. We should eliminate those cases. But for now, I'm backing out this debug warning.

Fixes #3945 

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
