### PR TITLE
IBL aliasing fix

### DIFF
--- a/src/graphics/program-lib/chunks/reflectionEnv.frag.js
+++ b/src/graphics/program-lib/chunks/reflectionEnv.frag.js
@@ -29,12 +29,13 @@ vec3 calcReflection(vec3 tReflDirW, float tGlossiness) {
     float level = saturate(1.0 - tGlossiness) * 5.0;
     float ilevel = floor(level);
 
+    // accessing the shiny (top level) reflection - perform manual mipmap lookup
+    float level2 = shinyMipLevel(uv * atlasSize);
+    float ilevel2 = floor(level2);
+
     vec2 uv0, uv1;
     float weight;
     if (ilevel == 0.0) {
-        // accessing the shiny (top level) reflection - perform manual mipmap lookup
-        float level2 = shinyMipLevel(uv * atlasSize);
-        float ilevel2 = floor(level2);
         uv0 = mapMip(uv, ilevel2);
         uv1 = mapMip(uv, ilevel2 + 1.0);
         weight = level2 - ilevel2;


### PR DESCRIPTION
The IBL reflection shader was only calculating sharp UVs on sharp reflection pixels.

Since the GPU calculates derivatives across a 2x2 set of pixels, there were slivers of pixels between sharp and blurry reflections where derivatives were wrong as a result.

Since we use these derivatives to determine which mipmap level to sample, the invalid mipmap resulted in aliasing as highlighted below (click to see the aliasing more clearly):
![Screenshot 2022-01-28 at 14 21 48](https://user-images.githubusercontent.com/11276292/151564485-3d5818ff-3e5c-43a5-99c3-2f103471fbae.png)

Always calculating the UV results in correct derivatives:
![Screenshot 2022-01-28 at 14 25 32](https://user-images.githubusercontent.com/11276292/151565342-f2864793-5af1-4ebb-99c3-a203c48ef1f8.png)

