### PR TITLE
Remove many `@ts-ignore` statements from examples

### DIFF
--- a/examples/src/examples/animation/blend-trees-2d-cartesian.tsx
+++ b/examples/src/examples/animation/blend-trees-2d-cartesian.tsx
@@ -79,12 +79,10 @@ class BlendTrees2DCartesianExample {
             const mouseEvent = (e: any) => {
                 if (e.targetTouches) {
                     const offset = canvas.getBoundingClientRect();
-                    // @ts-ignore engine-tsd
-                    position = new pc.Vec2(e.targetTouches[0].clientX - offset.x, e.targetTouches[0].clientY - offset.y).scale(1 / (width / 2)).sub(new pc.Vec2(1.0, 1.0));
+                    position = new pc.Vec2(e.targetTouches[0].clientX - offset.x, e.targetTouches[0].clientY - offset.y).mulScalar(1 / (width / 2)).sub(pc.Vec2.ONE);
                 } else {
                     if (e.buttons) {
-                        // @ts-ignore engine-tsd
-                        position = new pc.Vec2(e.offsetX, e.offsetY).scale(1 / (width / 2)).sub(new pc.Vec2(1.0, 1.0));
+                        position = new pc.Vec2(e.offsetX, e.offsetY).mulScalar(1 / (width / 2)).sub(pc.Vec2.ONE);
                     } else {
                         return;
                     }

--- a/examples/src/examples/animation/blend-trees-2d-directional.tsx
+++ b/examples/src/examples/animation/blend-trees-2d-directional.tsx
@@ -77,8 +77,7 @@ class BlendTrees2DDirectionalExample {
             drawPosition(ctx);
             const mouseEvent = (e: any) => {
                 if (e.buttons) {
-                    // @ts-ignore engine-tsd
-                    position = new pc.Vec2(e.offsetX, e.offsetY).scale(1 / (width / 2)).sub(new pc.Vec2(1.0, 1.0));
+                    position = new pc.Vec2(e.offsetX, e.offsetY).mulScalar(1 / (width / 2)).sub(pc.Vec2.ONE);
                     position.y *= -1.0;
                     modelEntity.anim.setFloat('posX', position.x);
                     modelEntity.anim.setFloat('posY', position.y);

--- a/examples/src/examples/animation/component-properties.tsx
+++ b/examples/src/examples/animation/component-properties.tsx
@@ -166,7 +166,6 @@ class ComponentPropertiesExample {
             ]
         };
 
-        // @ts-ignore
         const animClipHandler = new pc.AnimClipHandler();
         const animClipStaticLight = animClipHandler.open(undefined, animClipStaticLightData);
         const animClipFlashingLight = animClipHandler.open(undefined, animClipFlashingLightData);

--- a/examples/src/examples/animation/events.tsx
+++ b/examples/src/examples/animation/events.tsx
@@ -77,7 +77,6 @@ class EventsExample {
             const j = Math.floor(pos.z + 0.5);
             const colorVec = new pc.Vec3(Math.random(), Math.random(), Math.random());
             colorVec.mulScalar(1 / colorVec.length());
-            // @ts-ignore engine-tsd
             boxes[`${i}${j}`].model.material.emissive = new pc.Color(colorVec.x, colorVec.y, colorVec.z);
             highlightedBoxes.push(boxes[`${i}${j}`]);
         };
@@ -104,7 +103,7 @@ class EventsExample {
         });
 
         const walkTrack = assets.walkAnim.resource.animations[0].resource;
-        // @ts-ignore engine-tsd
+
         // Add two anim events to the walk animation, one for each foot step. These events should occur just as each foot touches the ground
         walkTrack.events = new pc.AnimEvents([
             {
@@ -130,7 +129,6 @@ class EventsExample {
         app.on('update', (dt) => {
             // on update, iterate over any currently highlighted boxes and reduce their emissive property
             highlightedBoxes.forEach((box: pc.Entity) => {
-                // @ts-ignore engine-tsd
                 const emissive = box.model.material.emissive;
                 emissive.lerp(emissive, pc.Color.BLACK, 0.08);
                 box.model.material.update();

--- a/examples/src/examples/animation/locomotion.tsx
+++ b/examples/src/examples/animation/locomotion.tsx
@@ -291,12 +291,9 @@ class LocomotionExample {
             Locomotion.prototype.onMouseDown = function (event: any) {
                 if (event.button !== 0) return;
                 // Set the character target position to a position on the plane that the user has clicked
-                const cameraEntity = app.root.findByName('Camera');
-                // @ts-ignore engine-tsd
+                const cameraEntity = app.root.findByName('Camera') as pc.Entity;
                 const near = cameraEntity.camera.screenToWorld(event.x, event.y, cameraEntity.camera.nearClip);
-                // @ts-ignore engine-tsd
                 const far = cameraEntity.camera.screenToWorld(event.x, event.y, cameraEntity.camera.farClip);
-                // @ts-ignore engine-tsd
                 const result = app.systems.rigidbody.raycastFirst(far, near);
                 if (result) {
                     targetPosition = new pc.Vec3(result.point.x, 0, result.point.z);
@@ -334,13 +331,11 @@ class LocomotionExample {
                     const distance = targetPosition.clone().sub(currentPosition);
                     const direction = distance.clone().normalize();
                     characterDirection = new pc.Vec3().sub(direction);
-                    // @ts-ignore engine-tsd
-                    const movement = direction.clone().scale(dt * moveSpeed);
+                    const movement = direction.clone().mulScalar(dt * moveSpeed);
                     if (movement.length() < distance.length()) {
                         currentPosition.add(movement);
                         characterEntity.setPosition(currentPosition);
-                        // @ts-ignore engine-tsd
-                        characterEntity.lookAt(characterEntity.position.clone().add(characterDirection));
+                        characterEntity.lookAt(characterEntity.getPosition().clone().add(characterDirection));
                     } else {
                         currentPosition.copy(targetPosition);
                         characterEntity.setPosition(currentPosition);

--- a/examples/src/examples/animation/tween.tsx
+++ b/examples/src/examples/animation/tween.tsx
@@ -66,12 +66,10 @@ class TweenExample {
             sphere.addComponent("render", {
                 type: "sphere"
             });
-            // @ts-ignore engine-tsd
-            sphere.render.material.diffuse.set(1, 0, 0);
-            // @ts-ignore engine-tsd
-            sphere.render.material.specular.set(0.6, 0.6, 0.6);
-            // @ts-ignore engine-tsd
-            sphere.render.material.shininess = 20;
+            const material = sphere.render.material as pc.StandardMaterial;
+            material.diffuse.set(1, 0, 0);
+            material.specular.set(0.6, 0.6, 0.6);
+            material.shininess = 20;
 
             sphere.addComponent("script");
             sphere.script.create("tween", {

--- a/examples/src/examples/graphics/area-picker.tsx
+++ b/examples/src/examples/graphics/area-picker.tsx
@@ -108,14 +108,13 @@ class AreaPickerExample {
         }
 
         // sets material emissive color to specified color
-        function highlightMaterial(material: pc.Material, color: pc.Color) {
-            // @ts-ignore engine-tsd
+        function highlightMaterial(material: pc.StandardMaterial, color: pc.Color) {
             material.emissive = color;
             material.update();
         }
 
         // array of highlighted materials
-        const highlights: any = [];
+        const highlights: pc.StandardMaterial[] = [];
 
         // update each frame
         let time = 0;

--- a/examples/src/examples/graphics/layers.tsx
+++ b/examples/src/examples/graphics/layers.tsx
@@ -94,7 +94,6 @@ class LayersExample {
                 blueBox.rotate(0, -10 * dt, 0);
             }
 
-            // @ts-ignore engine-tsd
             blueBox.model.meshInstances[0].layer = 10;
         });
     }

--- a/examples/src/examples/graphics/mesh-morph-many.tsx
+++ b/examples/src/examples/graphics/mesh-morph-many.tsx
@@ -137,7 +137,6 @@ class MeshMorphManyExample {
 
         // add morph instance - this is where currently set weights are stored
         const morphInstance = new pc.MorphInstance(mesh.morph);
-        // @ts-ignore engine-tsd
         meshInstance.morphInstance = morphInstance;
 
         // Create Entity and add it to the scene

--- a/examples/src/examples/graphics/mesh-morph.tsx
+++ b/examples/src/examples/graphics/mesh-morph.tsx
@@ -79,7 +79,6 @@ class MeshMorphExample {
 
         const createMorphInstance = function (x: number | pc.Vec3, y: number, z: number) {
             // create the base mesh - a sphere, with higher amount of vertices / triangles
-            // @ts-ignore engine-tsd
             const mesh = pc.createSphere(app.graphicsDevice, { latitudeBands: 200, longitudeBands: 200 });
 
             // obtain base mesh vertex / index data
@@ -103,7 +102,6 @@ class MeshMorphExample {
 
             // add morph instance - this is where currently set weights are stored
             const morphInstance = new pc.MorphInstance(mesh.morph);
-            // @ts-ignore engine-tsd
             meshInstance.morphInstance = morphInstance;
 
             // Create Entity and add it to the scene

--- a/examples/src/examples/graphics/model-outline.tsx
+++ b/examples/src/examples/graphics/model-outline.tsx
@@ -65,7 +65,6 @@ class ModelOutlineExample {
         app.scene.layers.insert(outlineLayer, 0);
 
         // set up layer to render to the render target
-        // @ts-ignore engine-tsd
         outlineLayer.renderTarget = renderTarget;
 
         // get world layer
@@ -136,7 +135,6 @@ class ModelOutlineExample {
                 colorBuffer: texture,
                 depth: true
             });
-            // @ts-ignore engine-tsd
             outlineLayer.renderTarget = renderTarget;
 
             app.scene.layers.insert(outlineLayer, 0);

--- a/examples/src/examples/graphics/render-cubemap.tsx
+++ b/examples/src/examples/graphics/render-cubemap.tsx
@@ -43,7 +43,6 @@ class RenderCubemapExample {
             app.root.addChild(entity);
 
             // create hight resolution sphere
-            // @ts-ignore engine-tsd
             const mesh = pc.createSphere(app.graphicsDevice, { latitudeBands: 200, longitudeBands: 200 });
 
             // Add a render component with the mesh
@@ -203,7 +202,6 @@ class RenderCubemapExample {
             for (let e = 0; e < entities.length; e++) {
                 const scale = (e + 1) / entities.length;
                 const offset = time + e * 200;
-                // @ts-ignore engine-tsd
                 entities[e].setLocalPosition(7 * Math.sin(offset), 2 * (e - 3), 7 * Math.cos(offset));
                 entities[e].rotate(1 * scale, 2 * scale, 3 * scale);
             }

--- a/examples/src/examples/graphics/render-to-texture.tsx
+++ b/examples/src/examples/graphics/render-to-texture.tsx
@@ -69,7 +69,6 @@ class RenderToTextureExample {
         const renderTarget = new pc.RenderTarget({
             colorBuffer: texture,
             depth: true,
-            // @ts-ignore
             flipY: true,
             samples: 2
         });
@@ -135,9 +134,9 @@ class RenderToTextureExample {
         tv.setLocalEulerAngles(90, 0, 0);
         tv.render.castShadows = false;
         tv.render.receiveShadows = false;
-        // @ts-ignore engine-tsd
-        tv.render.material.emissiveMap = texture;     // assign the rendered texture as an emissive texture
-        tv.render.material.update();
+        const material = tv.render.material as pc.StandardMaterial;
+        material.emissiveMap = texture;     // assign the rendered texture as an emissive texture
+        material.update();
 
         // setup skydome, use top mipmap level of cubemap (full resolution)
         app.scene.skyboxMip = 0;

--- a/examples/src/examples/graphics/shader-burn.tsx
+++ b/examples/src/examples/graphics/shader-burn.tsx
@@ -111,8 +111,9 @@ class ShaderBurnExample {
             const meshInstances = render.meshInstances;
             for (let i = 0; i < meshInstances.length; i++) {
                 const meshInstance = meshInstances[i];
-                // @ts-ignore
-                if (!originalTexture) originalTexture = meshInstance.material.diffuseMap;
+                if (!originalTexture) {
+                    originalTexture = meshInstance.material.diffuseMap;
+                }
                 meshInstance.material = material;
             }
         });

--- a/examples/src/examples/graphics/shader-toon.tsx
+++ b/examples/src/examples/graphics/shader-toon.tsx
@@ -127,8 +127,9 @@ class ShaderToonExample {
             const meshInstances = render.meshInstances;
             for (let i = 0; i < meshInstances.length; i++) {
                 const meshInstance = meshInstances[i];
-                // @ts-ignore
-                if (!originalTexture) originalTexture = meshInstance.material.diffuseMap;
+                if (!originalTexture) {
+                    originalTexture = meshInstance.material.diffuseMap;
+                }
                 meshInstance.material = material;
             }
         });

--- a/examples/src/examples/graphics/shader-wobble.tsx
+++ b/examples/src/examples/graphics/shader-wobble.tsx
@@ -101,14 +101,15 @@ class ShaderWobbleExample {
         app.root.addChild(entity);
 
         // Set the new material on all meshes in the model, and use original texture from the model on the new material
-        let originalTexture:pc.Texture = null;
+        let originalTexture: pc.Texture = null;
         const renders: Array<pc.RenderComponent> = entity.findComponents("render");
         renders.forEach((render) => {
             const meshInstances = render.meshInstances;
             for (let i = 0; i < meshInstances.length; i++) {
                 const meshInstance = meshInstances[i];
-                // @ts-ignore
-                if (!originalTexture) originalTexture = meshInstance.material.diffuseMap;
+                if (!originalTexture) {
+                    originalTexture = meshInstance.material.diffuseMap;
+                }
                 meshInstance.material = material;
             }
         });

--- a/examples/src/examples/graphics/texture-basis.tsx
+++ b/examples/src/examples/graphics/texture-basis.tsx
@@ -25,7 +25,6 @@ class TextureBasisExample {
         // Create the application and start the update loop
         const app = new pc.Application(canvas, {});
 
-        // @ts-ignore engine-tsd
         pc.basisInitialize({
             glueUrl: 'static/lib/basis/basis.wasm.js',
             wasmUrl: 'static/lib/basis/basis.wasm.wasm',

--- a/examples/src/examples/loaders/obj.tsx
+++ b/examples/src/examples/loaders/obj.tsx
@@ -38,7 +38,6 @@ class ObjExample {
                 const mis = entity.model.model.meshInstances;
                 for (let i = 0; i < mis.length; i++) {
                     mis[i].material = new pc.StandardMaterial();
-                    // @ts-ignore engine-tsd
                     mis[i].material.diffuse = new pc.Color(pc.math.random(0, 1), pc.math.random(0, 1), pc.math.random(0, 1));
                     mis[i].material.update();
                 }

--- a/examples/src/examples/physics/falling-shapes.tsx
+++ b/examples/src/examples/physics/falling-shapes.tsx
@@ -30,7 +30,6 @@ class FallingShapesExample {
             app.scene.ambientLight = new pc.Color(0.2, 0.2, 0.2);
 
             // Set the gravity for our rigid bodies
-            // @ts-ignore engine-tsd
             app.systems.rigidbody.gravity.set(0, -9.81, 0);
 
             function createMaterial(color: pc.Color) {

--- a/examples/src/examples/physics/raycast.tsx
+++ b/examples/src/examples/physics/raycast.tsx
@@ -117,14 +117,12 @@ class RaycastExample {
                 // Render the ray used in the raycast
                 app.drawLine(start, end, white);
 
-                // @ts-ignore engine-tsd
                 const result = app.systems.rigidbody.raycastFirst(start, end);
                 if (result) {
                     result.entity.render.material = red;
 
                     // Render the normal on the surface from the hit point
-                    // @ts-ignore engine-tsd
-                    temp.copy(result.normal).scale(0.3).add(result.point);
+                    temp.copy(result.normal).mulScalar(0.3).add(result.point);
                     app.drawLine(result.point, temp, blue);
                 }
 
@@ -135,14 +133,12 @@ class RaycastExample {
                 // Render the ray used in the raycast
                 app.drawLine(start, end, white);
 
-                // @ts-ignore engine-tsd
                 const results = app.systems.rigidbody.raycastAll(start, end);
-                results.forEach(function (result: { entity: pc.Entity, point: pc.Vec3 }) {
+                results.forEach(function (result: pc.RaycastResult) {
                     result.entity.render.material = red;
 
                     // Render the normal on the surface from the hit point
-                    // @ts-ignore engine-tsd
-                    temp.copy(result.normal).scale(0.3).add(result.point);
+                    temp.copy(result.normal).mulScalar(0.3).add(result.point);
                     app.drawLine(result.point, temp, blue);
                 }, this);
             });

--- a/examples/src/examples/xr/vr-movement.tsx
+++ b/examples/src/examples/xr/vr-movement.tsx
@@ -185,8 +185,7 @@ class VrMovementExample {
                             tmpVec2A.x = t;
 
                             // set movement speed
-                            // @ts-ignore engine-tsd
-                            tmpVec2A.scale(movementSpeed * dt);
+                            tmpVec2A.mulScalar(movementSpeed * dt);
                             // move camera parent based on calculated movement vector
                             cameraParent.translate(tmpVec2A.x, 0, tmpVec2A.y);
                         }
@@ -213,8 +212,7 @@ class VrMovementExample {
                             tmpVec3A.copy(c.getLocalPosition());
                             cameraParent.translateLocal(tmpVec3A);
                             cameraParent.rotateLocal(0, Math.sign(rotate) * rotateSpeed, 0);
-                            // @ts-ignore engine-tsd
-                            cameraParent.translateLocal(tmpVec3A.scale(-1));
+                            cameraParent.translateLocal(tmpVec3A.mulScalar(-1));
                         }
                     }
                 }
@@ -227,8 +225,7 @@ class VrMovementExample {
                     // render controller ray
                     tmpVec3A.copy(inputSource.getOrigin());
                     tmpVec3B.copy(inputSource.getDirection());
-                    // @ts-ignore engine-tsd
-                    tmpVec3B.scale(100).add(tmpVec3A);
+                    tmpVec3B.mulScalar(100).add(tmpVec3A);
                     app.drawLine(tmpVec3A, tmpVec3B, lineColor);
 
                     // render controller

--- a/examples/src/examples/xr/xr-picking.tsx
+++ b/examples/src/examples/xr/xr-picking.tsx
@@ -155,10 +155,10 @@ class XrPickingExample {
             app.on('update', function () {
                 for (let i = 0; i < app.xr.input.inputSources.length; i++) {
                     const inputSource = app.xr.input.inputSources[i];
+                    const direction = inputSource.getDirection();
+                    const origin = inputSource.getOrigin();
 
-                    tmpVec.copy(inputSource.getDirection());
-                    // @ts-ignore engine-tsd
-                    tmpVec.scale(100).add(inputSource.getOrigin());
+                    tmpVec.copy(direction).mulScalar(100).add(origin);
 
                     app.drawLine(inputSource.getOrigin(), tmpVec, lineColor);
                 }

--- a/src/framework/components/registry.js
+++ b/src/framework/components/registry.js
@@ -1,12 +1,223 @@
 import { EventHandler } from '../../core/event-handler.js';
 
+/** @typedef {import('./anim/system.js').AnimComponentSystem} AnimComponentSystem */
+/** @typedef {import('./animation/system.js').AnimationComponentSystem} AnimationComponentSystem */
+/** @typedef {import('./audio-listener/system.js').AudioListenerComponentSystem} AudioListenerComponentSystem */
+/** @typedef {import('./audio-source/system.js').AudioSourceComponentSystem} AudioSourceComponentSystem */
+/** @typedef {import('./button/system.js').ButtonComponentSystem} ButtonComponentSystem */
+/** @typedef {import('./camera/system.js').CameraComponentSystem} CameraComponentSystem */
+/** @typedef {import('./collision/system.js').CollisionComponentSystem} CollisionComponentSystem */
+/** @typedef {import('./element/system.js').ElementComponentSystem} ElementComponentSystem */
+/** @typedef {import('./joint/system.js').JointComponentSystem} JointComponentSystem */
+/** @typedef {import('./layout-child/system.js').LayoutChildComponentSystem} LayoutChildComponentSystem */
+/** @typedef {import('./layout-group/system.js').LayoutGroupComponentSystem} LayoutGroupComponentSystem */
+/** @typedef {import('./light/system.js').LightComponentSystem} LightComponentSystem */
+/** @typedef {import('./model/system.js').ModelComponentSystem} ModelComponentSystem */
+/** @typedef {import('./particle-system/system.js').ParticleSystemComponentSystem} ParticleSystemComponentSystem */
+/** @typedef {import('./render/system.js').RenderComponentSystem} RenderComponentSystem */
+/** @typedef {import('./rigid-body/system.js').RigidBodyComponentSystem} RigidBodyComponentSystem */
+/** @typedef {import('./screen/system.js').ScreenComponentSystem} ScreenComponentSystem */
+/** @typedef {import('./script/system.js').ScriptComponentSystem} ScriptComponentSystem */
+/** @typedef {import('./scrollbar/system.js').ScrollbarComponentSystem} ScrollbarComponentSystem */
+/** @typedef {import('./scroll-view/system.js').ScrollViewComponentSystem} ScrollViewComponentSystem */
+/** @typedef {import('./sound/system.js').SoundComponentSystem} SoundComponentSystem */
+/** @typedef {import('./sprite/system.js').SpriteComponentSystem} SpriteComponentSystem */
+/** @typedef {import('./zone/system.js').ZoneComponentSystem} ZoneComponentSystem */
+
 /**
  * Store, access and delete instances of the various ComponentSystems.
  */
 class ComponentSystemRegistry extends EventHandler {
     /**
-     * Create a new ComponentSystemRegistry instance.
+     * Gets the {@link AnimComponentSystem} from the registry.
+     *
+     * @type {AnimComponentSystem}
+     * @readonly
      */
+    anim;
+
+    /**
+     * Gets the {@link AnimationComponentSystem} from the registry.
+     *
+     * @type {AnimationComponentSystem}
+     * @readonly
+     */
+    animation;
+
+    /**
+     * Gets the {@link AudioListenerComponentSystem} from the registry.
+     *
+     * @type {AudioListenerComponentSystem}
+     * @readonly
+     */
+    audiolistener;
+
+    /**
+     * Gets the {@link AudioSourceComponentSystem} from the registry.
+     *
+     * @type {AudioSourceComponentSystem}
+     * @readonly
+     * @ignore
+     */
+    audiosource;
+
+    /**
+     * Gets the {@link ButtonComponentSystem} from the registry.
+     *
+     * @type {ButtonComponentSystem}
+     * @readonly
+     */
+    button;
+
+    /**
+     * Gets the {@link CameraComponentSystem} from the registry.
+     *
+     * @type {CameraComponentSystem}
+     * @readonly
+     */
+    camera;
+
+    /**
+     * Gets the {@link CollisionComponentSystem} from the registry.
+     *
+     * @type {CollisionComponentSystem}
+     * @readonly
+     */
+    collision;
+
+    /**
+     * Gets the {@link ElementComponentSystem} from the registry.
+     *
+     * @type {ElementComponentSystem}
+     * @readonly
+     */
+    element;
+
+    /**
+     * Gets the {@link JointComponentSystem} from the registry.
+     *
+     * @type {JointComponentSystem}
+     * @readonly
+     * @ignore
+     */
+    joint;
+
+    /**
+     * Gets the {@link LayoutChildComponentSystem} from the registry.
+     *
+     * @type {LayoutChildComponentSystem}
+     * @readonly
+     */
+    layoutchild;
+
+    /**
+     * Gets the {@link LayoutGroupComponentSystem} from the registry.
+     *
+     * @type {LayoutGroupComponentSystem}
+     * @readonly
+     */
+    layoutgroup;
+
+    /**
+     * Gets the {@link LightComponentSystem} from the registry.
+     *
+     * @type {LightComponentSystem}
+     * @readonly
+     */
+    light;
+
+    /**
+     * Gets the {@link ModelComponentSystem} from the registry.
+     *
+     * @type {ModelComponentSystem}
+     * @readonly
+     */
+    model;
+
+    /**
+     * Gets the {@link ParticleSystemComponentSystem} from the registry.
+     *
+     * @type {ParticleSystemComponentSystem}
+     * @readonly
+     */
+    particlesystem;
+
+    /**
+     * Gets the {@link RenderComponentSystem} from the registry.
+     *
+     * @type {RenderComponentSystem}
+     * @readonly
+     */
+    render;
+
+    /**
+     * Gets the {@link RigidBodyComponentSystem} from the registry.
+     *
+     * @type {RigidBodyComponentSystem}
+     * @readonly
+     */
+    rigidbody;
+
+    /**
+     * Gets the {@link ScreenComponentSystem} from the registry.
+     *
+     * @type {ScreenComponentSystem}
+     * @readonly
+     */
+    screen;
+
+    /**
+     * Gets the {@link ScriptComponentSystem} from the registry.
+     *
+     * @type {ScriptComponentSystem}
+     * @readonly
+     */
+    script;
+
+    /**
+     * Gets the {@link ScrollbarComponentSystem} from the registry.
+     *
+     * @type {ScrollbarComponentSystem}
+     * @readonly
+     */
+    scrollbar;
+
+    /**
+     * Gets the {@link ScrollViewComponentSystem} from the registry.
+     *
+     * @type {ScrollViewComponentSystem}
+     * @readonly
+     */
+    scrollview;
+
+    /**
+     * Gets the {@link SoundComponentSystem} from the registry.
+     *
+     * @type {SoundComponentSystem}
+     * @readonly
+     */
+    sound;
+
+    /**
+     * Gets the {@link SpriteComponentSystem} from the registry.
+     *
+     * @type {SpriteComponentSystem}
+     * @readonly
+     */
+    sprite;
+
+    /**
+     * Gets the {@link ZoneComponentSystem} from the registry.
+     *
+     * @type {ZoneComponentSystem}
+     * @readonly
+     * @ignore
+     */
+    zone;
+
+     /**
+      * Create a new ComponentSystemRegistry instance.
+      */
     constructor() {
         super();
 


### PR DESCRIPTION
Fix many occurrences of `ts-ignore` in the example source code.

This PR also improves the types for `ComponentSystemRegistry`.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
