### PR TITLE
[FIX] Various Examples Browser LGTM errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
     - name: Install dependencies
       run: npm ci
     - name: Build PlayCanvas (ES6-only)
-      run: npm run build:es5
+      run: npm run build:es6
     - name: Build TypeScript declarations
       run: npm run build:types
     - name: Build Examples Browser

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,11 +98,12 @@ jobs:
       uses: actions/setup-node@v2.5.1
       with:
         node-version: 12.x
+    - name: Install dependencies
+      run: npm ci
     - name: Build PlayCanvas (ES6-only)
-      run: |
-        npm ci
-        npm run build:es6
-        npm run build:types
+      run: npm run build:es5
+    - name: Build TypeScript declarations
+      run: npm run build:types
     - name: Build Examples Browser
       working-directory: ./examples
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,3 +87,24 @@ jobs:
       run: sudo apt-get install xvfb
     - name: Run unit tests
       run: xvfb-run --auto-servernum npm run test:karma
+
+  build-examples:
+    name: Build Examples Browser
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Setup Node.js 12.x
+      uses: actions/setup-node@v2.5.1
+      with:
+        node-version: 12.x
+    - name: Build PlayCanvas (ES6-only)
+      run: |
+        npm ci
+        npm run build:es6
+        npm run build:types
+    - name: Build Examples Browser
+      working-directory: ./examples
+      run: |
+        npm ci
+        npm run build

--- a/examples/rollup.config.js
+++ b/examples/rollup.config.js
@@ -29,8 +29,10 @@ export default {
         resolve(),
         typescript(),
         replace({
-            defaultAssignMent: true,
-            'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV)
+            values: {
+                'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV)
+            },
+            preventAssignment: true
         }),
         (process.env.NODE_ENV === 'production' && terser())
     ]

--- a/examples/src/app/example.tsx
+++ b/examples/src/app/example.tsx
@@ -1,7 +1,5 @@
 import React, { Component } from 'react';
 // @ts-ignore: library file import
-import { Observer } from '@playcanvas/observer';
-// @ts-ignore: library file import
 import Container from '@playcanvas/pcui/Container/component';
 // @ts-ignore: library file import
 import Spinner from '@playcanvas/pcui/Spinner/component';

--- a/examples/src/examples/animation/blend-trees-2d-cartesian.tsx
+++ b/examples/src/examples/animation/blend-trees-2d-cartesian.tsx
@@ -2,9 +2,6 @@ import React, { useEffect } from 'react';
 import * as pc from '../../../../';
 import { AssetLoader } from '../../app/helpers/loader';
 
-// @ts-ignore: library file import
-import { Observer } from '@playcanvas/observer';
-
 class BlendTrees2DCartesianExample {
     static CATEGORY = 'Animation';
     static NAME = 'Blend Trees 2D Cartesian';

--- a/examples/src/examples/animation/blend-trees-2d-directional.tsx
+++ b/examples/src/examples/animation/blend-trees-2d-directional.tsx
@@ -2,9 +2,6 @@ import React, { useEffect } from 'react';
 import * as pc from '../../../../';
 import { AssetLoader } from '../../app/helpers/loader';
 
-// @ts-ignore: library file import
-import { Observer } from '@playcanvas/observer';
-
 class BlendTrees2DDirectionalExample {
     static CATEGORY = 'Animation';
     static NAME = 'Blend Trees 2D Directional';

--- a/examples/src/examples/animation/locomotion.tsx
+++ b/examples/src/examples/animation/locomotion.tsx
@@ -12,7 +12,6 @@ import BooleanInput from '@playcanvas/pcui/BooleanInput/component';
 import BindingTwoWay from '@playcanvas/pcui/BindingTwoWay';
 // @ts-ignore: library file import
 import { Observer } from '@playcanvas/observer';
-import { wasmSupported, loadWasmModuleAsync } from '../../wasm-loader';
 
 class LocomotionExample {
     static CATEGORY = 'Animation';

--- a/examples/src/examples/graphics/hierarchy.tsx
+++ b/examples/src/examples/graphics/hierarchy.tsx
@@ -98,7 +98,6 @@ class HierarchyExample {
 
         // update each frame
         let time = 0;
-        const switchTime = 0;
         app.on("update", function (dt) {
             time += dt;
 

--- a/examples/src/examples/graphics/lines.tsx
+++ b/examples/src/examples/graphics/lines.tsx
@@ -85,10 +85,6 @@ class LinesExample {
             color.lerp(pc.Color.GREEN, pc.Color.RED, pc.math.clamp((point.y + 3) * 0.25, 0, 1));
         }
 
-        // access to two layers used to render lines
-        const worldLayer = app.scene.layers.getLayerByName("World");
-        const immediateLayer = app.scene.layers.getLayerById(pc.LAYERID_IMMEDIATE);
-
         // Set an update function on the app's update event
         let time = 0;
         app.on("update", function (dt) {

--- a/examples/src/examples/graphics/lines.tsx
+++ b/examples/src/examples/graphics/lines.tsx
@@ -153,12 +153,6 @@ class LinesExample {
                     30 + 20 * Math.cos(time * 0.2 + offset)
                 );
 
-                // half of them uses depth testing, the others do not, and so lines show through the mesh
-                const depthTest = i < 0.5 * numMeshes;
-
-                // half of them are rendered in immediate layer, the other half in world layer
-                const layer = i < 0.5 * numMeshes ? immediateLayer : worldLayer;
-
                 // rotate the meshes
                 entity.rotate((i + 1) * dt, 4 * (i + 1) * dt, 6 * (i + 1) * dt);
 

--- a/examples/src/examples/graphics/mesh-morph-many.tsx
+++ b/examples/src/examples/graphics/mesh-morph-many.tsx
@@ -73,7 +73,6 @@ class MeshMorphManyExample {
                 dist = shortestDistance(positions[i], positions[i + 1], positions[i + 2], nx, ny, nz, offset);
 
                 // modify distance to displacement amount - displace nearby points more than distant points
-                displacement = pc.math.clamp(dist, 0, limit);
                 displacement = pc.math.smoothstep(0, limit, dist);
                 displacement = 1 - displacement;
                 displacement *= range;

--- a/examples/src/examples/graphics/mesh-morph.tsx
+++ b/examples/src/examples/graphics/mesh-morph.tsx
@@ -49,7 +49,6 @@ class MeshMorphExample {
                 dist = shortestDistance(positions[i], positions[i + 1], positions[i + 2], nx, ny, nz);
 
                 // modify distance to displacement amount - displace nearby points more than distant points
-                displacement = pc.math.clamp(dist, 0, limit);
                 displacement = pc.math.smoothstep(0, limit, dist);
                 displacement = 1 - displacement;
 

--- a/examples/src/examples/graphics/painter.tsx
+++ b/examples/src/examples/graphics/painter.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import * as pc from '../../../../';
 
 

--- a/examples/src/examples/graphics/portal.tsx
+++ b/examples/src/examples/graphics/portal.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import * as pc from '../../../../';
 
 

--- a/examples/src/examples/loaders/index.mjs
+++ b/examples/src/examples/loaders/index.mjs
@@ -1,7 +1,7 @@
 import DracoGlbExample from "./draco-glb";
 import LoadersGlExample from "./loaders-gl";
-import GlbExample from './Glb';
-import ObjExample from './Obj';
+import GlbExample from './glb';
+import ObjExample from './obj';
 
 export {
     DracoGlbExample,

--- a/src/font/canvas-font.js
+++ b/src/font/canvas-font.js
@@ -19,6 +19,7 @@ const DEFAULT_TEXTURE_SIZE = 512;
  * Represents the resource of a canvas font asset.
  *
  * @augments EventHandler
+ * @ignore
  */
 class CanvasFont extends EventHandler {
     /**

--- a/src/framework/components/element/component.js
+++ b/src/framework/components/element/component.js
@@ -106,7 +106,7 @@ const matD = new Mat4();
  * the textHeight. Only works for {@link ELEMENTTYPE_TEXT} types.
  * @property {number} fontAsset The id of the font asset used for rendering the text. Only works
  * for {@link ELEMENTTYPE_TEXT} types.
- * @property {Font} font The font used for rendering the text. Only works for
+ * @property {Font|CanvasFont} font The font used for rendering the text. Only works for
  * {@link ELEMENTTYPE_TEXT} types.
  * @property {number} fontSize The size of the font. Only works for {@link ELEMENTTYPE_TEXT} types.
  * @property {boolean} autoFitWidth When true the font size and line height will scale so that the

--- a/src/framework/components/element/component.js
+++ b/src/framework/components/element/component.js
@@ -20,6 +20,7 @@ import { ImageElement } from './image-element.js';
 import { TextElement } from './text-element.js';
 
 /** @typedef {import('../../../math/color.js').Color} Color */
+/** @typedef {import('../../../font/canvas-font.js').CanvasFont} CanvasFont */
 /** @typedef {import('../../../font/font.js').Font} Font */
 /** @typedef {import('../../../graphics/texture.js').Texture} Texture */
 /** @typedef {import('../../../scene/materials/material.js').Material} Material */

--- a/src/framework/components/element/component.js
+++ b/src/framework/components/element/component.js
@@ -107,7 +107,7 @@ const matD = new Mat4();
  * the textHeight. Only works for {@link ELEMENTTYPE_TEXT} types.
  * @property {number} fontAsset The id of the font asset used for rendering the text. Only works
  * for {@link ELEMENTTYPE_TEXT} types.
- * @property {Font|CanvasFont} font The font used for rendering the text. Only works for
+ * @property {Font} font The font used for rendering the text. Only works for
  * {@link ELEMENTTYPE_TEXT} types.
  * @property {number} fontSize The size of the font. Only works for {@link ELEMENTTYPE_TEXT} types.
  * @property {boolean} autoFitWidth When true the font size and line height will scale so that the

--- a/types.mjs
+++ b/types.mjs
@@ -97,7 +97,7 @@ const elementComponentProps = [
     ['autoWidth', 'boolean'],
     ['color', 'Color'],
     ['enableMarkup', 'boolean'],
-    ['font', 'Font'],
+    ['font', 'Font|CanvasFont'],
     ['fontAsset', 'number'],
     ['fontSize', 'number'],
     ['key', 'string'],


### PR DESCRIPTION
* Fix 11 errors in the examples reported by [LGTM](https://lgtm.com/projects/g/playcanvas/engine/alerts/?mode=list&severity=).
* Add building of the Examples Browser to GitHub Actions.
* Fix type of `ElementComponent#font` to also access `CanvasFont`.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
