### PR TITLE
Enable IntelliSense for WebGL API

### DIFF
--- a/src/graphics/graphics-device.js
+++ b/src/graphics/graphics-device.js
@@ -892,7 +892,7 @@ class GraphicsDevice extends EventHandler {
 
         const supportedExtensions = gl.getSupportedExtensions();
 
-        const getExtension = () => {
+        const getExtension = function () {
             for (let i = 0; i < arguments.length; i++) {
                 if (supportedExtensions.indexOf(arguments[i]) !== -1) {
                     return gl.getExtension(arguments[i]);

--- a/src/graphics/graphics-device.js
+++ b/src/graphics/graphics-device.js
@@ -227,6 +227,7 @@ class GraphicsDevice extends EventHandler {
      * The WebGL context managed by this graphics device.
      *
      * @type {WebGLRenderingContext}
+     * @ignore
      */
     gl;
 

--- a/src/graphics/graphics-device.js
+++ b/src/graphics/graphics-device.js
@@ -266,7 +266,7 @@ class GraphicsDevice extends EventHandler {
      */
     precision;
 
-     /**
+    /**
      * The scope namespace for shader attributes and variables.
      *
      * @type {ScopeSpace}

--- a/src/graphics/graphics-device.js
+++ b/src/graphics/graphics-device.js
@@ -300,6 +300,7 @@ class GraphicsDevice extends EventHandler {
      * being used.
      *
      * @type {boolean}
+     * @ignore
      */
     webgl2;
 

--- a/src/graphics/graphics-device.js
+++ b/src/graphics/graphics-device.js
@@ -224,9 +224,12 @@ class GraphicsDevice extends EventHandler {
     canvas;
 
     /**
-     * The WebGL context managed by this graphics device.
+     * The WebGL context managed by this graphics device. The type could also technically be
+     * `WebGLRenderingContext` if WebGL 2.0 is not available. But in order for IntelliSense to be
+     * able to function for all WebGL calls in the codebase, we specify `WebGL2RenderingContext`
+     * here instead.
      *
-     * @type {WebGLRenderingContext}
+     * @type {WebGL2RenderingContext}
      * @ignore
      */
     gl;

--- a/src/graphics/graphics-device.js
+++ b/src/graphics/graphics-device.js
@@ -224,7 +224,7 @@ class GraphicsDevice extends EventHandler {
     canvas;
 
     /**
-     * The WebGL context managed by this graphics device. The type could also technically be
+     * The WebGL context managed by the graphics device. The type could also technically be
      * `WebGLRenderingContext` if WebGL 2.0 is not available. But in order for IntelliSense to be
      * able to function for all WebGL calls in the codebase, we specify `WebGL2RenderingContext`
      * here instead.

--- a/src/graphics/reproject-texture.js
+++ b/src/graphics/reproject-texture.js
@@ -436,9 +436,13 @@ function reprojectTexture(source, target, options = {}) {
             `#define NUM_SAMPLES ${numSamples}\n` +
             (device.extTextureLod ? `#define SUPPORTS_TEXLOD\n` : '');
 
-        const extensions =
-            device.webgl2 ?
-                null : `#extension GL_OES_standard_derivatives: enable\n${device.extTextureLod ? "#extension GL_EXT_shader_texture_lod: enable\n" : ""}`;
+        let extensions = '';
+        if (!device.webgl2) {
+            extensions = '#extension GL_OES_standard_derivatives: enable\n';
+            if (device.extTextureLod) {
+                extensions += '#extension GL_EXT_shader_texture_lod: enable\n\n';
+            }
+        }
 
         shader = createShaderFromCode(
             device,


### PR DESCRIPTION
This PR correctly sets the type of the `gl` property of the `GraphicsDevice` which suddenly enables IntelliSense when working with the WebGL API:

![intellisense](https://user-images.githubusercontent.com/697563/151722191-3195d266-ff9a-494a-a610-d5087436515d.gif)

It also:
* Ensures `createShaderFromCode` is not passed `null` from `reprojectTexture`.
* Simplifies `GraphicsDevice#initializeExtensions`.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
