### PR TITLE
[Examples Browser] Example iframe ie11 support and refactor

### DIFF
--- a/examples/package-lock.json
+++ b/examples/package-lock.json
@@ -2826,6 +2826,12 @@
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
+    "promise-polyfill": {
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.1.3.tgz",
+      "integrity": "sha512-MG5r82wBzh7pSKDRa9y+vllNHz3e3d4CNj1PQE4BQYxLme0gKYYBm9YENq+UkEikyZ0XbiGWxYlVw3Rl9O/U8g==",
+      "dev": true
+    },
     "prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -3992,6 +3998,12 @@
         "prepend-http": "^2.0.0"
       }
     },
+    "url-search-params-polyfill": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/url-search-params-polyfill/-/url-search-params-polyfill-8.1.1.tgz",
+      "integrity": "sha512-KmkCs6SjE6t4ihrfW9JelAPQIIIFbJweaaSLTh/4AO+c58JlDcb+GbdPt8yr5lRcFg4rPswRFRRhBGpWwh0K/Q==",
+      "dev": true
+    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -4020,6 +4032,12 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
+      "dev": true
+    },
+    "whatwg-fetch": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.4.0.tgz",
+      "integrity": "sha512-rsum2ulz2iuZH08mJkT0Yi6JnKhwdw4oeyMjokgxd+mmqYSd9cPpOQf01TIWgjxG/U4+QR+AwKq6lSbXVxkyoQ==",
       "dev": true
     },
     "whatwg-url": {

--- a/examples/package.json
+++ b/examples/package.json
@@ -11,7 +11,7 @@
     "build:iframes": "node --es-module-specifier-resolution=node ./scripts/iframe/index.mjs",
     "build:thumbnails": "node --es-module-specifier-resolution=node ./scripts/thumbnails.mjs",
     "rollup:watch": "rollup -c -w",
-    "serve": "serve dist",
+    "serve": "serve dist -l 5000",
     "test": "echo \"Error: no test specified\" && exit 1",
     "watch": "npm run build:example:data && npm run build:directory && npm run build:iframes && cross-env concurrently --kill-others \"npm run rollup:watch\"",
     "watch:iframes": "nodemon -e js,mjs,json,tsx --watch ../build --watch ./src/examples --exec npm run build:iframes",
@@ -63,6 +63,7 @@
     "monaco-editor": "^0.31.1",
     "nodemon": "^2.0.15",
     "prettier": "^2.5.1",
+    "promise-polyfill": "^8.1.3",
     "prop-types": "^15.7.2",
     "puppeteer": "^13.1.2",
     "react": "^17.0.1",
@@ -76,7 +77,9 @@
     "serve": "^13.0.2",
     "sharp": "^0.29.3",
     "tslib": "^2.3.1",
-    "typescript": "^4.5.5"
+    "typescript": "^4.5.5",
+    "url-search-params-polyfill": "^8.1.1",
+    "whatwg-fetch": "^3.4.0"
   },
   "author": "PlayCanvas <support@playcanvas.com>",
   "license": "MIT",

--- a/examples/scripts/iframe/index.mjs
+++ b/examples/scripts/iframe/index.mjs
@@ -15,6 +15,9 @@ const MAIN_DIR = `${__dirname}/../../`;
 fse.copySync(`${MAIN_DIR}/../build/`, `${MAIN_DIR}/dist/build/`);
 fs.copyFileSync(`${MAIN_DIR}/lib/wasm-loader.js`, `${MAIN_DIR}/dist/build/wasm-loader.js`);
 fs.copyFileSync(`${MAIN_DIR}/./node_modules/@playcanvas/observer/dist/index.js`, `${MAIN_DIR}/dist/build/playcanvas-observer.js`);
+fs.copyFileSync(`${MAIN_DIR}/./node_modules/url-search-params-polyfill/index.js`, `${MAIN_DIR}/dist/build/urlSearchParamsPolyfill.js`);
+fs.copyFileSync(`${MAIN_DIR}/./node_modules/promise-polyfill/dist/polyfill.min.js`, `${MAIN_DIR}/dist/build/promisePolyfill.js`);
+fs.copyFileSync(`${MAIN_DIR}/./node_modules/whatwg-fetch/dist/fetch.umd.js`, `${MAIN_DIR}/dist/build/fetchPolyfill.js`);
 
 const EXAMPLE_CONSTS = [
     "vshader",

--- a/examples/scripts/iframe/index.mustache
+++ b/examples/scripts/iframe/index.mustache
@@ -64,10 +64,8 @@
         // get url parameters
         var queryString = window.location.search;
         var urlParams = new URLSearchParams(queryString);
-
     </script>
     <script>
-
         function loadEngine(callback) {
             const enginePath = urlParams.get('use_local_engine') || "{{{enginePath}}}";
 
@@ -200,24 +198,24 @@
         }
     </script>
     <script>
-            // create the example observer 
-            var data = new observer.Observer({});
-            window.top.observerData = data;
+        // create the example observer 
+        var data = new observer.Observer({});
+        window.top.observerData = data;
 
-            // load the engine, create the application, load the resources if necessary, then call the example
-            loadEngine(function() {
-                var canvas = document.getElementById('application-canvas');
+        // load the engine, create the application, load the resources if necessary, then call the example
+        loadEngine(function() {
+            var canvas = document.getElementById('application-canvas');
 
-                const app = createApplication(canvas);
+            const app = createApplication(canvas);
 
-                if (!window.loadFunction) {
-                    callExample(app, canvas, {}, data);
-                } else {
-                    loadResources(app, function(assetManifest) {
-                        callExample(app, canvas, assetManifest, data);
-                    });
-                }
-            });
+            if (!window.loadFunction) {
+                callExample(app, canvas, {}, data);
+            } else {
+                loadResources(app, function(assetManifest) {
+                    callExample(app, canvas, assetManifest, data);
+                });
+            }
+        });
     </script>
 </body>
 </html>

--- a/examples/scripts/iframe/index.mustache
+++ b/examples/scripts/iframe/index.mustache
@@ -1,13 +1,12 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <script crossorigin src="https://unpkg.com/react@17/umd/react.development.js"></script>
-    <script crossorigin src="https://unpkg.com/react-dom@17/umd/react-dom.development.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/regenerator-runtime@0.13.9/runtime.min.js"> </script>
-    <script src="{{{enginePath}}}"></script>
     <script src="../../build/playcanvas-extras.js"></script>
     <script src="../../build/playcanvas-observer.js"></script>
     <script src="../../build/wasm-loader.js"></script>
+    <script src="../../build/urlSearchParamsPolyfill.js"></script>
+    <script src="../../build/promisePolyfill.js"></script>
+    <script src="../../build/fetchPolyfill.js"></script>
     <link rel="stylesheet" href="/styles.css">
     <style>
         body {
@@ -20,7 +19,6 @@
         }
     </style>
 </head>
-
 <body>
     <div id="app">
         <div id="appInner">
@@ -28,17 +26,65 @@
         </div>
     </div>
     <script>
-        {{{ exampleConstValues }}}.forEach(function(s) {
-            window[s.k] = s.v;
-        });
+        // polyfill slice on UInt8Array
+        if (!Uint8Array.prototype.slice) {
+            Object.defineProperty(Uint8Array.prototype, 'slice', {
+                value: function (begin, end) {
+                    return new Uint8Array(Array.prototype.slice.call(this, begin, end));
+                }
+            });
+        }
 
-        function loadExample(exampleFunction, loadFunction, controlsFunction) {
-            var data = new observer.Observer({});
-            window.top.observerData = data;
-            window.top.pc = pc;
+        // include any constants necessary for the example
+        var constValues = {{{ exampleConstValues }}};
+        for (var i = 0; i < constValues.length; i++) {
+            windows[constValues.k] = constValues.v;
+        }
 
-            var canvas = document.getElementById('application-canvas');
+        // include the example class which contains the example function to execute and any assets to load
+        {{{ exampleClass }}}
+        var example = new Example();
 
+        var useTypeScript = window.top.localStorage.getItem('useTypeScript') === 'true';
+        window.exampleFunction = window.top.localStorage.getItem(window.top.location.hash.replace('#', ''));
+        if (!window.exampleFunction) {
+            window.exampleFunction = example.example
+        } else {
+            if (useTypeScript) {
+                window.exampleFunction = window.top.Babel.transform(exampleFunction, {
+                    retainLines: true,
+                    filename: 'transformedScript.tsx',
+                    presets: ["react", "typescript", "env"]
+                }).code;
+            }
+            window.exampleFunction = new Function('app', 'canvas', 'assets', 'data', exampleFunction);
+        }
+        window.loadFunction = example.load;
+
+        // get url parameters
+        var queryString = window.location.search;
+        var urlParams = new URLSearchParams(queryString);
+
+    </script>
+    <script>
+
+        function loadEngine(callback) {
+            const enginePath = urlParams.get('use_local_engine') || "{{{enginePath}}}";
+
+            fetch(enginePath)
+                .then(function(response) { return response.text() })
+                .then(function(data) {
+                    var module = {
+                        exports: {}
+                    };
+                    window.pc = (Function('module', 'exports', data).call(module, module, module.exports), module).exports;
+                    window.top.pc = window.pc;
+                    callback();
+                });
+        }
+
+        function createApplication(canvas) {
+            // create the app
             var app = new pc.Application(canvas, {
                 mouse: new pc.Mouse(document.body),
                 touch: new pc.TouchDevice(document.body),
@@ -50,142 +96,128 @@
                 }
             });
 
+            // set up miniStats
             var miniStats = new pcx.MiniStats(app);
-
-            var queryString = window.location.search;
-            var urlParams = new URLSearchParams(queryString);
             if (urlParams.get('miniStats') === 'false') {
                 miniStats.enabled = false;
             }
-
             app.on('update', function () {
                 if (window.top._showMiniStats !== undefined) miniStats.enabled = window.top._showMiniStats;
             });
 
+            // handle resizing
             var canvasContainerElement = canvas.parentElement;
             canvas.setAttribute('width', window.innerWidth + 'px');
             canvas.setAttribute('height', window.innerHeight + 'px');
             var resizeTimeout = null;
             app.setCanvasResolution(pc.RESOLUTION_AUTO);
-            if (ResizeObserver) {
+            if (window.ResizeObserver) {
                 new ResizeObserver(function() {
-                    if (resizeTimeout) {
-                        window.clearTimeout(resizeTimeout);
-                    }
-                    resizeTimeout = setTimeout(function () {
-                        canvas.width = canvasContainerElement.clientWidth;
-                        canvas.height = canvasContainerElement.clientHeight;
-                    });
+                    canvas.width = canvasContainerElement.clientWidth;
+                    canvas.height = canvasContainerElement.clientHeight;
                 }).observe(canvasContainerElement);
             }
 
-            var assets;
-            if (!loadFunction) {
-                assets = [];
-            } else {
-                assets = loadFunction().props.children;
-                if (!Array.isArray(assets)) {
-                    assets = [assets];
-                }
+            return app;
+        }
+
+        function loadResource(app, resource, callback) {
+            if (!resource.type) {
+                fetch(resource.url)
+                    .then(function(response) { return response.text() })
+                    .then(function(data) {
+                        var module = {
+                            exports: {}
+                        };
+                        window[resource.name] = (Function('module', 'exports', data).call(module, module, module.exports), module).exports;
+                        callback({});
+                    });
+                return;
             }
+            if (resource.data) {
+                var asset = new pc.Asset(
+                    resource.name,
+                    resource.type,
+                    resource.type === "cubemap" ? {
+                        url: resource.url
+                    } : null,
+                    resource.data
+                );
+                asset.on("load", function (asset) {
+                    callback(asset);
+                });
+                app.assets.add(asset);
+                app.assets.load(asset);
+            } else {
+                app.assets.loadFromUrl(resource.url, resource.type, function (
+                    err,
+                    asset
+                ) {
+                    if (!err && asset) {
+                        callback(asset);
+                    }
+                });
+            }
+        }
 
-            assets = assets.map(function (c) {
-                return c.props;
-            });
+        function loadResources(app, callback) {
+            var assets = [];
+            var assetManifest = {};
 
-            var manifest = {};
+            // stub out react
+            window.React = { createElement: function(type, props) { if (type === 'div') assets.push(props); } };
+            // call the stubbed load function
+            window.loadFunction();
 
-            // count of assets to load
             var count = assets.length;
-
             function onLoadedResource(key, asset) {
                 count--;
                 if (key) {
-                    manifest[key] = asset;
+                    assetManifest[key] = asset;
                 }
                 if (count <= 0) {
-                    if (location.pathname.includes('misc/mini-stats')) {
-                        exampleFunction(app, canvas, pcx);
-                    } else {
-                        exampleFunction(app, canvas, manifest, data);
-                    }
-                    var event = new CustomEvent("exampleLoad");
-                    window.top.dispatchEvent(event);
+                    callback(assetManifest);
                 }
-            }
-
-            if (assets.length === 0) {
-                onLoadedResource();
             }
 
             assets.forEach(function (resource) {
-                if (!resource.type) {
-                    fetch(resource.url)
-                        .then(function(response) { return response.text() })
-                        .then(function(data) {
-                            var module = {
-                                exports: {}
-                            };
-                            window[resource.name] = (Function('module', 'exports', data).call(module, module, module.exports), module).exports;
-                            onLoadedResource();
-                        });
-                    return;
-                }
-                if (resource.data) {
-                    var asset = new pc.Asset(
-                        resource.name,
-                        resource.type,
-                        resource.type === "cubemap" ? {
-                            url: resource.url
-                        } : null,
-                        resource.data
-                    );
-                    asset.on("load", function (asset) {
-                        onLoadedResource(resource.name, asset);
-                    });
-                    app.assets.add(asset);
-                    app.assets.load(asset);
-                } else {
-                    app.assets.loadFromUrl(resource.url, resource.type, function (
-                        err,
-                        asset
-                    ) {
-                        if (!err && asset) {
-                            onLoadedResource(resource.name, asset);
-                        }
-                    });
-                }
+                loadResource(app, resource, function(asset) {
+                    onLoadedResource(resource.name, asset);
+                });
             });
         }
 
-        {{{ exampleClass }}}
-
-        pc.basisInitialize({
-            glueUrl: '../../static/lib/basis/basis.wasm.js',
-            wasmUrl: '../../static/lib/basis/basis.wasm.wasm',
-            fallbackUrl: '../../static/lib/basis/basis.js'
-        });
-
-
-        var e = new Example();
-
-        var useTypeScript = window.top.localStorage.getItem('useTypeScript') === 'true';
-
-        var exampleFunction = window.top.localStorage.getItem(window.top.location.hash.replace('#', ''));
-        if (!exampleFunction) {
-            exampleFunction = e.example
-        } else {
-            if (useTypeScript) {
-                exampleFunction = window.top.Babel.transform(exampleFunction, {
-                    retainLines: true,
-                    filename: `transformedScript.tsx`,
-                    presets: ["react", "typescript", "env"]
-                }).code;
+        function callExample(app, canvas, assetManifest, data) {
+            if (location.pathname.indexOf('misc/mini-stats') !== -1) {
+                window.exampleFunction(app, canvas, pcx);
+            } else {
+                window.exampleFunction(app, canvas, assetManifest, data, wasmSupported, loadWasmModuleAsync);
             }
-            exampleFunction = new Function('app', 'canvas', 'assets', 'data', exampleFunction);
+            if (window.top.location.pathname.indexOf('iframe') === -1) {
+                var event = new CustomEvent("exampleLoad");
+                window.top.dispatchEvent(event);
+            }
         }
-        loadExample.bind(this)(exampleFunction, e.load, e.controls);
+    </script>
+    <script>
+            // create the example observer 
+            var data = new observer.Observer({});
+            window.top.observerData = data;
+
+            // load the engine, create the application, load the resources if necessary, then call the example
+            loadEngine(function() {
+                var canvas = document.getElementById('application-canvas');
+
+                const app = createApplication(canvas);
+
+                if (!window.loadFunction) {
+                    callExample(app, canvas, {}, data);
+                } else {
+                    loadResources(app, function(assetManifest) {
+                        callExample(app, canvas, assetManifest, data);
+                    });
+                }
+            });
     </script>
 </body>
-
 </html>


### PR DESCRIPTION
The PR enables support for the examples browser iframes in ie11 through the use of the necessary polyfills and the removal and incompatible syntax. It also includes the following changes:

- The iframe template has been refactored into a more readable layout by isolating it's logic into smaller functions.

- Engine versions can now be loaded into each iframe via a url parameter, making backwards compatibility testing simpler. 

- Moved the examples browser server port back to 5000 from 3000.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
