### PR TITLE
Remove the types directory from our npm build

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "build/playcanvas.mjs",
     "build/playcanvas.dbg.js",
     "build/playcanvas.prf.js",
+    "build/playcanvas.d.ts",
     "build/playcanvas-extras.js",
     "scripts",
     "LICENSE",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "build/playcanvas.prf.js",
     "build/playcanvas-extras.js",
     "scripts",
-    "types",
     "LICENSE",
     "package.json",
     "README.md",


### PR DESCRIPTION
We no longer need to publish the types directory to npm so it should be removed from the files list in our package.json.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
