### PR TITLE
[FIX] Type of `cache` paramater for `Http` functions

### DIFF
--- a/src/net/http.js
+++ b/src/net/http.js
@@ -83,7 +83,7 @@ class Http {
      * @param {object} options - Additional options.
      * @param {object} [options.headers] - HTTP headers to add to the request.
      * @param {boolean} [options.async] - Make the request asynchronously. Defaults to true.
-     * @param {object} [options.cache] - If false, then add a timestamp to the request to prevent caching.
+     * @param {boolean} [options.cache] - If false, then add a timestamp to the request to prevent caching.
      * @param {boolean} [options.withCredentials] - Send cookies with this request. Defaults to false.
      * @param {string} [options.responseType] - Override the response type.
      * @param {Document|object} [options.postdata] - Data to send in the body of the request.
@@ -141,7 +141,7 @@ class Http {
      * @param {object} options - Additional options.
      * @param {object} [options.headers] - HTTP headers to add to the request.
      * @param {boolean} [options.async] - Make the request asynchronously. Defaults to true.
-     * @param {object} [options.cache] - If false, then add a timestamp to the request to prevent caching.
+     * @param {boolean} [options.cache] - If false, then add a timestamp to the request to prevent caching.
      * @param {boolean} [options.withCredentials] - Send cookies with this request. Defaults to false.
      * @param {string} [options.responseType] - Override the response type.
      * @param {boolean} [options.retry] - If true then if the request fails it will be retried with an exponential backoff.
@@ -196,7 +196,7 @@ class Http {
      * @param {object} options - Additional options.
      * @param {object} [options.headers] - HTTP headers to add to the request.
      * @param {boolean} [options.async] - Make the request asynchronously. Defaults to true.
-     * @param {object} [options.cache] - If false, then add a timestamp to the request to prevent caching.
+     * @param {boolean} [options.cache] - If false, then add a timestamp to the request to prevent caching.
      * @param {boolean} [options.withCredentials] - Send cookies with this request. Defaults to false.
      * @param {string} [options.responseType] - Override the response type.
      * @param {boolean} [options.retry] - If true then if the request fails it will be retried with an exponential backoff.


### PR DESCRIPTION
Fix incorrect typing of `cache` property for various `Http` functions. This enables the viewer's TypeScript codebase to successfully compile.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
