### PR TITLE
Extracted webgl implementation of Vertex and Index buffer into separate modules

### DIFF
--- a/src/graphics/graphics-device.js
+++ b/src/graphics/graphics-device.js
@@ -825,12 +825,12 @@ class GraphicsDevice extends EventHandler {
     }
 
     // provide webgl implementation for the vertex buffer
-    implementVertexBuffer(vertexBuffer) {
+    createVertexBufferImpl(vertexBuffer) {
         return new WebglVertexBuffer(vertexBuffer);
     }
 
     // provide webgl implementation for the index buffer
-    implementIndexBuffer(indexBuffer) {
+    createIndexBufferImpl(indexBuffer) {
         return new WebglIndexBuffer(indexBuffer);
     }
 

--- a/src/graphics/index-buffer.js
+++ b/src/graphics/index-buffer.js
@@ -49,7 +49,7 @@ class IndexBuffer {
         this.numIndices = numIndices;
         this.usage = usage;
 
-        this.impl = graphicsDevice.implementIndexBuffer(this);
+        this.impl = graphicsDevice.createIndexBufferImpl(this);
 
         // Allocate the storage
         const bytesPerIndex = typedArrayIndexFormatsByteSize[format];

--- a/src/graphics/transform-feedback.js
+++ b/src/graphics/transform-feedback.js
@@ -96,7 +96,7 @@ class TransformFeedback {
         this._inputBuffer = inputBuffer;
         if (usage === BUFFER_GPUDYNAMIC && inputBuffer.usage !== usage) {
             // have to recreate input buffer with other usage
-            gl.bindBuffer(gl.ARRAY_BUFFER, inputBuffer.bufferId);
+            gl.bindBuffer(gl.ARRAY_BUFFER, inputBuffer.impl.bufferId);
             gl.bufferData(gl.ARRAY_BUFFER, inputBuffer.storage, gl.DYNAMIC_COPY);
         }
 
@@ -158,14 +158,14 @@ class TransformFeedback {
 
         // swap buffers
         if (swap) {
-            let tmp = this._inputBuffer.bufferId;
-            this._inputBuffer.bufferId = this._outputBuffer.bufferId;
-            this._outputBuffer.bufferId = tmp;
+            let tmp = this._inputBuffer.impl.bufferId;
+            this._inputBuffer.impl.bufferId = this._outputBuffer.impl.bufferId;
+            this._outputBuffer.impl.bufferId = tmp;
 
             // swap VAO
-            tmp = this._inputBuffer._vao;
-            this._inputBuffer._vao = this._outputBuffer._vao;
-            this._outputBuffer._vao = tmp;
+            tmp = this._inputBuffer.impl.vao;
+            this._inputBuffer.impl.vao = this._outputBuffer.impl.vao;
+            this._outputBuffer.impl.vao = tmp;
         }
     }
 

--- a/src/graphics/vertex-buffer.js
+++ b/src/graphics/vertex-buffer.js
@@ -65,15 +65,6 @@ class VertexBuffer {
         device._vram.vb -= this.storage.byteLength;
     }
 
-    set bufferId(value) {
-        console.error("Unsupported");
-    }
-
-    get bufferId() {
-        console.error("Unsupported");
-        return 0;
-    }
-
     /**
      * Called when the rendering context was lost. It releases all context related resources.
      *

--- a/src/graphics/vertex-buffer.js
+++ b/src/graphics/vertex-buffer.js
@@ -1,5 +1,5 @@
 import { Debug } from '../core/debug.js';
-import { BUFFER_DYNAMIC, BUFFER_GPUDYNAMIC, BUFFER_STATIC, BUFFER_STREAM } from './constants.js';
+import { BUFFER_STATIC } from './constants.js';
 
 /** @typedef {import('./graphics-device.js').GraphicsDevice} GraphicsDevice */
 /** @typedef {import('./vertex-format.js').VertexFormat} VertexFormat */
@@ -30,8 +30,7 @@ class VertexBuffer {
 
         this.id = id++;
 
-        // vertex array object
-        this._vao = null;
+        this.impl = graphicsDevice.implementVertexBuffer(this);
 
         // marks vertex buffer as instancing data
         this.instancing = false;
@@ -60,28 +59,28 @@ class VertexBuffer {
             device.buffers.splice(idx, 1);
         }
 
-        if (this.bufferId) {
+        this.impl.destroy(device);
 
-            // clear up bound vertex buffers
-            const gl = device.gl;
-            device.boundVao = null;
-            gl.bindVertexArray(null);
+        // TODO: double check this works correctly
+        device._vram.vb -= this.storage.byteLength;
+    }
 
-            // delete buffer
-            gl.deleteBuffer(this.bufferId);
-            device._vram.vb -= this.storage.byteLength;
-            this.bufferId = null;
-        }
+    set bufferId(value) {
+        console.error("Unsupported");
+    }
+
+    get bufferId() {
+        console.error("Unsupported");
+        return 0;
     }
 
     /**
-     * Called when the WebGL context was lost. It releases all context related resources.
+     * Called when the rendering context was lost. It releases all context related resources.
      *
      * @ignore
      */
     loseContext() {
-        this.bufferId = undefined;
-        this._vao = null;
+        this.impl.loseContext();
     }
 
     /**
@@ -128,35 +127,9 @@ class VertexBuffer {
      * returned to the control of the graphics driver.
      */
     unlock() {
+
         // Upload the new vertex data
-        const gl = this.device.gl;
-
-        if (!this.bufferId) {
-            this.bufferId = gl.createBuffer();
-        }
-
-        let glUsage;
-        switch (this.usage) {
-            case BUFFER_STATIC:
-                glUsage = gl.STATIC_DRAW;
-                break;
-            case BUFFER_DYNAMIC:
-                glUsage = gl.DYNAMIC_DRAW;
-                break;
-            case BUFFER_STREAM:
-                glUsage = gl.STREAM_DRAW;
-                break;
-            case BUFFER_GPUDYNAMIC:
-                if (this.device.webgl2) {
-                    glUsage = gl.DYNAMIC_COPY;
-                } else {
-                    glUsage = gl.STATIC_DRAW;
-                }
-                break;
-        }
-
-        gl.bindBuffer(gl.ARRAY_BUFFER, this.bufferId);
-        gl.bufferData(gl.ARRAY_BUFFER, this.storage, glUsage);
+        this.impl.unlock(this);
     }
 
     /**

--- a/src/graphics/vertex-buffer.js
+++ b/src/graphics/vertex-buffer.js
@@ -30,7 +30,7 @@ class VertexBuffer {
 
         this.id = id++;
 
-        this.impl = graphicsDevice.implementVertexBuffer(this);
+        this.impl = graphicsDevice.createVertexBufferImpl(this);
 
         // marks vertex buffer as instancing data
         this.instancing = false;

--- a/src/graphics/webgl/webgl-buffer.js
+++ b/src/graphics/webgl/webgl-buffer.js
@@ -1,0 +1,52 @@
+import { BUFFER_DYNAMIC, BUFFER_GPUDYNAMIC, BUFFER_STATIC, BUFFER_STREAM } from '../constants.js';
+
+/**
+ * A WebGl implementation of the Buffer.
+ */
+class WebglBuffer {
+    bufferId = null;
+
+    destroy(device) {
+        if (this.bufferId) {
+            device.gl.deleteBuffer(this.bufferId);
+            this.bufferId = null;
+        }
+    }
+
+    loseContext() {
+        this.bufferId = null;
+    }
+
+    unlock(device, usage, target, storage) {
+        const gl = device.gl;
+
+        if (!this.bufferId) {
+            this.bufferId = gl.createBuffer();
+        }
+
+        let glUsage;
+        switch (usage) {
+            case BUFFER_STATIC:
+                glUsage = gl.STATIC_DRAW;
+                break;
+            case BUFFER_DYNAMIC:
+                glUsage = gl.DYNAMIC_DRAW;
+                break;
+            case BUFFER_STREAM:
+                glUsage = gl.STREAM_DRAW;
+                break;
+            case BUFFER_GPUDYNAMIC:
+                if (device.webgl2) {
+                    glUsage = gl.DYNAMIC_COPY;
+                } else {
+                    glUsage = gl.STATIC_DRAW;
+                }
+                break;
+        }
+
+        gl.bindBuffer(target, this.bufferId);
+        gl.bufferData(target, storage, glUsage);
+    }
+}
+
+export { WebglBuffer };

--- a/src/graphics/webgl/webgl-buffer.js
+++ b/src/graphics/webgl/webgl-buffer.js
@@ -1,7 +1,9 @@
 import { BUFFER_DYNAMIC, BUFFER_GPUDYNAMIC, BUFFER_STATIC, BUFFER_STREAM } from '../constants.js';
 
 /**
- * A WebGl implementation of the Buffer.
+ * A WebGL implementation of the Buffer.
+ *
+ * @ignore
  */
 class WebglBuffer {
     bufferId = null;

--- a/src/graphics/webgl/webgl-index-buffer.js
+++ b/src/graphics/webgl/webgl-index-buffer.js
@@ -2,7 +2,9 @@ import { INDEXFORMAT_UINT8, INDEXFORMAT_UINT16, INDEXFORMAT_UINT32 } from '../co
 import { WebglBuffer } from "./webgl-buffer.js";
 
 /**
- * A WebGl implementation of the IndexBuffer.
+ * A WebGL implementation of the IndexBuffer.
+ *
+ * @ignore
  */
 class WebglIndexBuffer extends WebglBuffer {
     constructor(indexBuffer) {

--- a/src/graphics/webgl/webgl-index-buffer.js
+++ b/src/graphics/webgl/webgl-index-buffer.js
@@ -1,0 +1,69 @@
+import {
+    INDEXFORMAT_UINT8, INDEXFORMAT_UINT16, INDEXFORMAT_UINT32,
+    BUFFER_DYNAMIC, BUFFER_GPUDYNAMIC, BUFFER_STATIC, BUFFER_STREAM
+} from '../constants.js';
+
+/**
+ * A WebGl implementation of the IndexBuffer.
+ */
+class WebglIndexBuffer {
+    bufferId = null;
+
+    constructor(indexBuffer) {
+        const gl = indexBuffer.device.gl;
+
+        const format = indexBuffer.format;
+        if (format === INDEXFORMAT_UINT8) {
+            this.glFormat = gl.UNSIGNED_BYTE;
+        } else if (format === INDEXFORMAT_UINT16) {
+            this.glFormat = gl.UNSIGNED_SHORT;
+        } else if (format === INDEXFORMAT_UINT32) {
+            this.glFormat = gl.UNSIGNED_INT;
+        }
+    }
+
+    destroy(device) {
+        if (this.bufferId) {
+            device.gl.deleteBuffer(this.bufferId);
+            this.bufferId = null;
+        }
+    }
+
+    loseContext() {
+        this.bufferId = null;
+    }
+
+    unlock(indexBuffer) {
+
+        const gl = indexBuffer.device.gl;
+
+        if (!this.bufferId) {
+            this.bufferId = gl.createBuffer();
+        }
+
+        let glUsage;
+        switch (indexBuffer.usage) {
+            case BUFFER_STATIC:
+                glUsage = gl.STATIC_DRAW;
+                break;
+            case BUFFER_DYNAMIC:
+                glUsage = gl.DYNAMIC_DRAW;
+                break;
+            case BUFFER_STREAM:
+                glUsage = gl.STREAM_DRAW;
+                break;
+            case BUFFER_GPUDYNAMIC:
+                if (indexBuffer.device.webgl2) {
+                    glUsage = gl.DYNAMIC_COPY;
+                } else {
+                    glUsage = gl.STATIC_DRAW;
+                }
+                break;
+        }
+
+        gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, this.bufferId);
+        gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, indexBuffer.storage, glUsage);
+    }
+}
+
+export { WebglIndexBuffer };

--- a/src/graphics/webgl/webgl-index-buffer.js
+++ b/src/graphics/webgl/webgl-index-buffer.js
@@ -1,17 +1,14 @@
-import {
-    INDEXFORMAT_UINT8, INDEXFORMAT_UINT16, INDEXFORMAT_UINT32,
-    BUFFER_DYNAMIC, BUFFER_GPUDYNAMIC, BUFFER_STATIC, BUFFER_STREAM
-} from '../constants.js';
+import { INDEXFORMAT_UINT8, INDEXFORMAT_UINT16, INDEXFORMAT_UINT32 } from '../constants.js';
+import { WebglBuffer } from "./webgl-buffer.js";
 
 /**
  * A WebGl implementation of the IndexBuffer.
  */
-class WebglIndexBuffer {
-    bufferId = null;
-
+class WebglIndexBuffer extends WebglBuffer {
     constructor(indexBuffer) {
-        const gl = indexBuffer.device.gl;
+        super();
 
+        const gl = indexBuffer.device.gl;
         const format = indexBuffer.format;
         if (format === INDEXFORMAT_UINT8) {
             this.glFormat = gl.UNSIGNED_BYTE;
@@ -22,47 +19,10 @@ class WebglIndexBuffer {
         }
     }
 
-    destroy(device) {
-        if (this.bufferId) {
-            device.gl.deleteBuffer(this.bufferId);
-            this.bufferId = null;
-        }
-    }
-
-    loseContext() {
-        this.bufferId = null;
-    }
-
     unlock(indexBuffer) {
 
-        const gl = indexBuffer.device.gl;
-
-        if (!this.bufferId) {
-            this.bufferId = gl.createBuffer();
-        }
-
-        let glUsage;
-        switch (indexBuffer.usage) {
-            case BUFFER_STATIC:
-                glUsage = gl.STATIC_DRAW;
-                break;
-            case BUFFER_DYNAMIC:
-                glUsage = gl.DYNAMIC_DRAW;
-                break;
-            case BUFFER_STREAM:
-                glUsage = gl.STREAM_DRAW;
-                break;
-            case BUFFER_GPUDYNAMIC:
-                if (indexBuffer.device.webgl2) {
-                    glUsage = gl.DYNAMIC_COPY;
-                } else {
-                    glUsage = gl.STATIC_DRAW;
-                }
-                break;
-        }
-
-        gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, this.bufferId);
-        gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, indexBuffer.storage, glUsage);
+        const device = indexBuffer.device;
+        super.unlock(device, indexBuffer.usage, device.gl.ELEMENT_ARRAY_BUFFER, indexBuffer.storage);
     }
 }
 

--- a/src/graphics/webgl/webgl-vertex-buffer.js
+++ b/src/graphics/webgl/webgl-vertex-buffer.js
@@ -1,7 +1,9 @@
 import { WebglBuffer } from "./webgl-buffer.js";
 
 /**
- * A WebGl implementation of the VertexBuffer.
+ * A WebGL implementation of the VertexBuffer.
+ *
+ * @ignore
  */
 class WebglVertexBuffer extends WebglBuffer {
     // vertex array object

--- a/src/graphics/webgl/webgl-vertex-buffer.js
+++ b/src/graphics/webgl/webgl-vertex-buffer.js
@@ -1,65 +1,30 @@
-import { BUFFER_DYNAMIC, BUFFER_GPUDYNAMIC, BUFFER_STATIC, BUFFER_STREAM } from '../constants.js';
+import { WebglBuffer } from "./webgl-buffer.js";
 
 /**
  * A WebGl implementation of the VertexBuffer.
  */
-class WebglVertexBuffer {
+class WebglVertexBuffer extends WebglBuffer {
     // vertex array object
     vao = null;
 
-    bufferId = null;
-
     destroy(device) {
 
-        if (this.bufferId) {
+        super.destroy(device);
 
-            // clear up bound vertex buffers
-            const gl = device.gl;
-            device.boundVao = null;
-            gl.bindVertexArray(null);
-
-            // delete buffer
-            gl.deleteBuffer(this.bufferId);
-            this.bufferId = null;
-        }
+        // clear up bound vertex buffers
+        device.boundVao = null;
+        device.gl.bindVertexArray(null);
     }
 
     loseContext() {
-        this.bufferId = null;
+        super.loseContext();
         this.vao = null;
     }
 
     unlock(vertexBuffer) {
 
-        // Upload the new vertex data
-        const gl = vertexBuffer.device.gl;
-
-        if (!this.bufferId) {
-            this.bufferId = gl.createBuffer();
-        }
-
-        let glUsage;
-        switch (vertexBuffer.usage) {
-            case BUFFER_STATIC:
-                glUsage = gl.STATIC_DRAW;
-                break;
-            case BUFFER_DYNAMIC:
-                glUsage = gl.DYNAMIC_DRAW;
-                break;
-            case BUFFER_STREAM:
-                glUsage = gl.STREAM_DRAW;
-                break;
-            case BUFFER_GPUDYNAMIC:
-                if (vertexBuffer.device.webgl2) {
-                    glUsage = gl.DYNAMIC_COPY;
-                } else {
-                    glUsage = gl.STATIC_DRAW;
-                }
-                break;
-        }
-
-        gl.bindBuffer(gl.ARRAY_BUFFER, this.bufferId);
-        gl.bufferData(gl.ARRAY_BUFFER, vertexBuffer.storage, glUsage);
+        const device = vertexBuffer.device;
+        super.unlock(device, vertexBuffer.usage, device.gl.ARRAY_BUFFER, vertexBuffer.storage);
     }
 }
 

--- a/src/graphics/webgl/webgl-vertex-buffer.js
+++ b/src/graphics/webgl/webgl-vertex-buffer.js
@@ -1,0 +1,66 @@
+import { BUFFER_DYNAMIC, BUFFER_GPUDYNAMIC, BUFFER_STATIC, BUFFER_STREAM } from '../constants.js';
+
+/**
+ * A WebGl implementation of the VertexBuffer.
+ */
+class WebglVertexBuffer {
+    // vertex array object
+    vao = null;
+
+    bufferId = null;
+
+    destroy(device) {
+
+        if (this.bufferId) {
+
+            // clear up bound vertex buffers
+            const gl = device.gl;
+            device.boundVao = null;
+            gl.bindVertexArray(null);
+
+            // delete buffer
+            gl.deleteBuffer(this.bufferId);
+            this.bufferId = null;
+        }
+    }
+
+    loseContext() {
+        this.bufferId = null;
+        this.vao = null;
+    }
+
+    unlock(vertexBuffer) {
+
+        // Upload the new vertex data
+        const gl = vertexBuffer.device.gl;
+
+        if (!this.bufferId) {
+            this.bufferId = gl.createBuffer();
+        }
+
+        let glUsage;
+        switch (vertexBuffer.usage) {
+            case BUFFER_STATIC:
+                glUsage = gl.STATIC_DRAW;
+                break;
+            case BUFFER_DYNAMIC:
+                glUsage = gl.DYNAMIC_DRAW;
+                break;
+            case BUFFER_STREAM:
+                glUsage = gl.STREAM_DRAW;
+                break;
+            case BUFFER_GPUDYNAMIC:
+                if (vertexBuffer.device.webgl2) {
+                    glUsage = gl.DYNAMIC_COPY;
+                } else {
+                    glUsage = gl.STATIC_DRAW;
+                }
+                break;
+        }
+
+        gl.bindBuffer(gl.ARRAY_BUFFER, this.bufferId);
+        gl.bufferData(gl.ARRAY_BUFFER, vertexBuffer.storage, glUsage);
+    }
+}
+
+export { WebglVertexBuffer };


### PR DESCRIPTION
Related to: https://github.com/playcanvas/engine/issues/3986

This is part of refactoring plan, where all webgl specific functionality will move to graphics/webgl, allowing the WebGPU implementation.

- first step is to refactor IndexBuffer and VertexBuffer, and the shared buffer functionality has moved to WebglBuffer (which will also be used to implement UniformBuffer in the future)
- interfaces are private and are subject to change