### PR TITLE
Examples: Fix to debug/profile iframe build

### DIFF
--- a/examples/package.json
+++ b/examples/package.json
@@ -15,8 +15,8 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "watch": "npm run build:example:data && npm run build:directory && npm run build:iframes && cross-env concurrently --kill-others \"npm run rollup:watch\"",
     "watch:iframes": "nodemon -e js,mjs,json,tsx --watch ../build --watch ./src/examples --exec npm run build:iframes",
-    "watch:iframes:debug": "ENGINE_PATH=../build/playcanvas.dbg.js npm run build:iframes",
-    "watch:iframes:profiler": "ENGINE_PATH=../build/playcanvas.prf.js npm run build:iframes"
+    "watch:iframes:debug": "ENGINE_PATH=/build/playcanvas.dbg.js npm run watch:iframes",
+    "watch:iframes:profiler": "ENGINE_PATH=/build/playcanvas.prf.js npm run watch:iframes"
   },
   "eslintConfig": {
     "root": true,


### PR DESCRIPTION
- done by Elliott, makes `npm run watch:iframes:debug` to work