### PR TITLE
Examples browser iframe fixes

### DIFF
--- a/examples/scripts/iframe/index.mjs
+++ b/examples/scripts/iframe/index.mjs
@@ -18,6 +18,7 @@ fs.copyFileSync(`${MAIN_DIR}/./node_modules/@playcanvas/observer/dist/index.js`,
 fs.copyFileSync(`${MAIN_DIR}/./node_modules/url-search-params-polyfill/index.js`, `${MAIN_DIR}/dist/build/urlSearchParamsPolyfill.js`);
 fs.copyFileSync(`${MAIN_DIR}/./node_modules/promise-polyfill/dist/polyfill.min.js`, `${MAIN_DIR}/dist/build/promisePolyfill.js`);
 fs.copyFileSync(`${MAIN_DIR}/./node_modules/whatwg-fetch/dist/fetch.umd.js`, `${MAIN_DIR}/dist/build/fetchPolyfill.js`);
+fs.copyFileSync(`${MAIN_DIR}/./node_modules/regenerator-runtime/runtime.js`, `${MAIN_DIR}/dist/build/regeneratorRuntimePolyfill.js`);
 
 const EXAMPLE_CONSTS = [
     "vshader",
@@ -55,10 +56,22 @@ function buildExample(category, filename) {
     if (!fs.existsSync(`${MAIN_DIR}/dist/iframe/${category}/`)) {
         fs.mkdirSync(`${MAIN_DIR}/dist/iframe/${category}/`);
     }
+    let enginePath;
+    switch (formatters.getEngineTypeFromClass(exampleClass)) {
+        case "DEBUG":
+            enginePath = '/build/playcanvas.dbg.js';
+            break;
+        case "PERFORMANCE":
+            enginePath = '/build/playcanvas.prf.js';
+            break;
+        default:
+            enginePath = '/build/playcanvas.js';
+            break;
+    }
     fs.writeFileSync(`${MAIN_DIR}/dist/iframe/${category}/${filename.replace(".tsx", "")}.html`, loadHtmlTemplate({
         exampleClass: exampleClass,
         exampleConstValues: JSON.stringify(exampleConstValues),
-        enginePath: process.env.ENGINE_PATH || '../../build/playcanvas.js'
+        enginePath: process.env.ENGINE_PATH || enginePath
     }));
 }
 

--- a/examples/scripts/iframe/index.mustache
+++ b/examples/scripts/iframe/index.mustache
@@ -7,6 +7,7 @@
     <script src="../../build/urlSearchParamsPolyfill.js"></script>
     <script src="../../build/promisePolyfill.js"></script>
     <script src="../../build/fetchPolyfill.js"></script>
+    <script src="../../build/regeneratorRuntimePolyfill.js"></script>
     <link rel="stylesheet" href="/styles.css">
     <style>
         body {
@@ -38,7 +39,7 @@
         // include any constants necessary for the example
         var constValues = {{{ exampleConstValues }}};
         for (var i = 0; i < constValues.length; i++) {
-            windows[constValues.k] = constValues.v;
+            window[constValues[i].k] = constValues[i].v;
         }
 
         // include the example class which contains the example function to execute and any assets to load
@@ -119,6 +120,15 @@
             return app;
         }
 
+        function hasBasisAssets (assets) {
+        for (let i = 0; i < assets.length; i++) {
+            if (assets[i].url && assets[i].url.includes('.basis')) {
+                return true;
+            }
+        }
+        return false;
+    };
+
         function loadResource(app, resource, callback) {
             if (!resource.type) {
                 fetch(resource.url)
@@ -164,8 +174,17 @@
 
             // stub out react
             window.React = { createElement: function(type, props) { if (type === 'div') assets.push(props); } };
-            // call the stubbed load function
+            // call the stubbed load function to add all assets to the assets list
             window.loadFunction();
+
+            // if we have any basis assets then initialize basis
+            if (hasBasisAssets(assets)) {
+                pc.basisInitialize({
+                    glueUrl: '/static/lib/basis/basis.wasm.js',
+                    wasmUrl: '/static/lib/basis/basis.wasm.wasm',
+                    fallbackUrl: '/static/lib/basis/basis.js'
+                });
+            }
 
             var count = assets.length;
             function onLoadedResource(key, asset) {

--- a/examples/src/app/helpers/formatters.mjs
+++ b/examples/src/app/helpers/formatters.mjs
@@ -1,3 +1,4 @@
+import { useCallback } from "react";
 
 const findClosingBracketMatchIndex = (str, pos) => {
     if (str[pos] != '{') throw new Error("No '{' at index " + pos);
@@ -79,8 +80,18 @@ const getExampleClassFromTextFile = (Babel, text) => {
     return text;
 };
 
+const getEngineTypeFromClass = (text) => {
+    if (text.indexOf(`_defineProperty(Example, "ENGINE", 'DEBUG');` !== -1)) {
+        return 'DEBUG';
+    } else if (text.indexOf(`_defineProperty(Example, "ENGINE", 'PERFORMANCE');` !== -1)) {
+        return 'PERFORMANCE';
+    }
+    return null;
+};
+
 export default {
     getTypeScriptFunctionFromText: getTypeScriptFunctionFromText,
     getInnerFunctionText: getInnerFunctionText,
-    getExampleClassFromTextFile: getExampleClassFromTextFile
+    getExampleClassFromTextFile: getExampleClassFromTextFile,
+    getEngineTypeFromClass: getEngineTypeFromClass
 };

--- a/examples/src/app/helpers/formatters.mjs
+++ b/examples/src/app/helpers/formatters.mjs
@@ -1,5 +1,3 @@
-import { useCallback } from "react";
-
 const findClosingBracketMatchIndex = (str, pos) => {
     if (str[pos] != '{') throw new Error("No '{' at index " + pos);
     let depth = 1;


### PR DESCRIPTION
- The iframe should support loading different engine types based on the examples static engine property. Fixes (#3984)
- Iframes were not supporting basis examples. Basis should be initialised for examples that contain basis assets.
- Constants were not being correctly placed on the window object.
- IE11 requires a regenerator polyfill for the promise / fetch calls.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
