### PR TITLE
Switch box-reflection example to refresh envmap every 10 frames

### DIFF
--- a/examples/src/examples/graphics/box-reflection.tsx
+++ b/examples/src/examples/graphics/box-reflection.tsx
@@ -34,7 +34,7 @@ class BoxReflectionExample {
                     <SelectInput binding={new BindingTwoWay()} link={{ observer: data, path: 'settings.updateFrequency' }} type="number" options={[
                         { v: 0, t: 'Once' },
                         { v: 1, t: 'Every frame' },
-                        { v: 5, t: 'Every 5 frames' },
+                        { v: 10, t: 'Every 10 frames' },
                         { v: 30, t: 'Every 30 frames' }
                     ]} />
                 </LabelGroup>}
@@ -58,7 +58,7 @@ class BoxReflectionExample {
         app.start();
 
         data.set('settings', {
-            updateFrequency: 1,
+            updateFrequency: 10,
             shininess: 90,
             metalness: 0.7,
             bumpiness: 0.2


### PR DESCRIPTION
To improve out of the box performance on mobile devices