### PR TITLE
Implement/use defineProtoFunc for better polyfills

### DIFF
--- a/src/math/mat3.js
+++ b/src/math/mat3.js
@@ -170,13 +170,7 @@ class Mat3 {
      * console.log(m.toString());
      */
     toString() {
-        let t = '[';
-        for (let i = 0; i < 9; i++) {
-            t += this.data[i];
-            t += (i !== 8) ? ', ' : '';
-        }
-        t += ']';
-        return t;
+        return '[' + this.data.join(', ') + ']';
     }
 
     /**

--- a/src/math/mat4.js
+++ b/src/math/mat4.js
@@ -1258,13 +1258,7 @@ class Mat4 {
      * console.log(m.toString());
      */
     toString() {
-        let t = '[';
-        for (let i = 0; i < 16; i += 1) {
-            t += this.data[i];
-            t += (i !== 15) ? ', ' : '';
-        }
-        t += ']';
-        return t;
+        return '[' + this.data.join(', ') + ']';
     }
 
     /**

--- a/src/polyfill/array-fill.js
+++ b/src/polyfill/array-fill.js
@@ -1,40 +1,37 @@
+import { defineProtoFunc } from "./defineProtoFunc.js";
+
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/fill#polyfill
-if (!Array.prototype.fill) {
-    Object.defineProperty(Array.prototype, 'fill', {
-        value: function(value) {
-  
-            // Steps 1-2.
-            if (this == null) {
-                throw new TypeError('this is null or not defined');
-            }
-    
-            var O = Object(this);
-    
-            // Steps 3-5.
-            var len = O.length >>> 0;
-    
-            // Steps 6-7.
-            var start = arguments[1];
-            var relativeStart = start >> 0;
-    
-            // Step 8.
-            var k = relativeStart < 0 ? Math.max(len + relativeStart, 0) : Math.min(relativeStart, len);
-    
-            // Steps 9-10.
-            var end = arguments[2];
-            var relativeEnd = end === undefined ? len : end >> 0;
-    
-            // Step 11.
-            var finalValue = relativeEnd < 0 ? Math.max(len + relativeEnd, 0) : Math.min(relativeEnd, len);
-    
-            // Step 12.
-            while (k < finalValue) {
-                O[k] = value;
-                k++;
-            }
-    
-            // Step 13.
-            return O;
-        }
-    });
-}
+defineProtoFunc(Array, 'fill', function(value) {
+    // Steps 1-2.
+    if (this == null) {
+        throw new TypeError('this is null or not defined');
+    }
+
+    var O = Object(this);
+
+    // Steps 3-5.
+    var len = O.length >>> 0;
+
+    // Steps 6-7.
+    var start = arguments[1];
+    var relativeStart = start >> 0;
+
+    // Step 8.
+    var k = relativeStart < 0 ? Math.max(len + relativeStart, 0) : Math.min(relativeStart, len);
+
+    // Steps 9-10.
+    var end = arguments[2];
+    var relativeEnd = end === undefined ? len : end >> 0;
+
+    // Step 11.
+    var finalValue = relativeEnd < 0 ? Math.max(len + relativeEnd, 0) : Math.min(relativeEnd, len);
+
+    // Step 12.
+    while (k < finalValue) {
+        O[k] = value;
+        k++;
+    }
+
+    // Step 13.
+    return O;
+});

--- a/src/polyfill/array-find-index.js
+++ b/src/polyfill/array-find-index.js
@@ -1,4 +1,4 @@
-import { defineProtoFunc } from "./defineProtoFunc";
+import { defineProtoFunc } from "./defineProtoFunc.js";
 
 // https://tc39.github.io/ecma262/#sec-array.prototype.findindex
 defineProtoFunc(Array, 'findIndex', function(predicate) {

--- a/src/polyfill/array-find-index.js
+++ b/src/polyfill/array-find-index.js
@@ -1,46 +1,42 @@
+import { defineProtoFunc } from "./defineProtoFunc";
+
 // https://tc39.github.io/ecma262/#sec-array.prototype.findindex
-if (!Array.prototype.findIndex) {
-    Object.defineProperty(Array.prototype, 'findIndex', {
-        value: function(predicate) {
-            // 1. Let O be ? ToObject(this value).
-            if (this == null) {
-                throw new TypeError('"this" is null or not defined');
-            }
-    
-            var o = Object(this);
-    
-            // 2. Let len be ? ToLength(? Get(O, "length")).
-            var len = o.length >>> 0;
-    
-            // 3. If IsCallable(predicate) is false, throw a TypeError exception.
-            if (typeof predicate !== 'function') {
-                throw new TypeError('predicate must be a function');
-            }
-    
-            // 4. If thisArg was supplied, let T be thisArg; else let T be undefined.
-            var thisArg = arguments[1];
-    
-            // 5. Let k be 0.
-            var k = 0;
-    
-            // 6. Repeat, while k < len
-            while (k < len) {
-                // a. Let Pk be ! ToString(k).
-                // b. Let kValue be ? Get(O, Pk).
-                // c. Let testResult be ToBoolean(? Call(predicate, T, « kValue, k, O »)).
-                // d. If testResult is true, return k.
-                var kValue = o[k];
-                if (predicate.call(thisArg, kValue, k, o)) {
-                    return k;
-                }
-                // e. Increase k by 1.
-                k++;
-            }
-    
-            // 7. Return -1.
-            return -1;
-        },
-        configurable: true,
-        writable: true
-    });
-}
+defineProtoFunc(Array, 'findIndex', function(predicate) {
+    // 1. Let O be ? ToObject(this value).
+    if (this == null) {
+        throw new TypeError('"this" is null or not defined');
+    }
+
+    var o = Object(this);
+
+    // 2. Let len be ? ToLength(? Get(O, "length")).
+    var len = o.length >>> 0;
+
+    // 3. If IsCallable(predicate) is false, throw a TypeError exception.
+    if (typeof predicate !== 'function') {
+        throw new TypeError('predicate must be a function');
+    }
+
+    // 4. If thisArg was supplied, let T be thisArg; else let T be undefined.
+    var thisArg = arguments[1];
+
+    // 5. Let k be 0.
+    var k = 0;
+
+    // 6. Repeat, while k < len
+    while (k < len) {
+        // a. Let Pk be ! ToString(k).
+        // b. Let kValue be ? Get(O, Pk).
+        // c. Let testResult be ToBoolean(? Call(predicate, T, « kValue, k, O »)).
+        // d. If testResult is true, return k.
+        var kValue = o[k];
+        if (predicate.call(thisArg, kValue, k, o)) {
+            return k;
+        }
+        // e. Increase k by 1.
+        k++;
+    }
+
+    // 7. Return -1.
+    return -1;
+});

--- a/src/polyfill/array-find.js
+++ b/src/polyfill/array-find.js
@@ -1,46 +1,42 @@
+import { defineProtoFunc } from "./defineProtoFunc";
+
 // https://tc39.github.io/ecma262/#sec-array.prototype.find
-if (!Array.prototype.find) {
-    Object.defineProperty(Array.prototype, 'find', {
-        value: function(predicate) {
-            // 1. Let O be ? ToObject(this value).
-            if (this == null) {
-                throw TypeError('"this" is null or not defined');
-            }
+defineProtoFunc(Array, 'find', function(predicate) {
+    // 1. Let O be ? ToObject(this value).
+    if (this == null) {
+        throw TypeError('"this" is null or not defined');
+    }
 
-            var o = Object(this);
+    var o = Object(this);
 
-            // 2. Let len be ? ToLength(? Get(O, "length")).
-            var len = o.length >>> 0;
+    // 2. Let len be ? ToLength(? Get(O, "length")).
+    var len = o.length >>> 0;
 
-            // 3. If IsCallable(predicate) is false, throw a TypeError exception.
-            if (typeof predicate !== 'function') {
-                throw TypeError('predicate must be a function');
-            }
+    // 3. If IsCallable(predicate) is false, throw a TypeError exception.
+    if (typeof predicate !== 'function') {
+        throw TypeError('predicate must be a function');
+    }
 
-            // 4. If thisArg was supplied, let T be thisArg; else let T be undefined.
-            var thisArg = arguments[1];
+    // 4. If thisArg was supplied, let T be thisArg; else let T be undefined.
+    var thisArg = arguments[1];
 
-            // 5. Let k be 0.
-            var k = 0;
+    // 5. Let k be 0.
+    var k = 0;
 
-            // 6. Repeat, while k < len
-            while (k < len) {
-                // a. Let Pk be ! ToString(k).
-                // b. Let kValue be ? Get(O, Pk).
-                // c. Let testResult be ToBoolean(? Call(predicate, T, « kValue, k, O »)).
-                // d. If testResult is true, return kValue.
-                var kValue = o[k];
-                if (predicate.call(thisArg, kValue, k, o)) {
-                    return kValue;
-                }
-                // e. Increase k by 1.
-                k++;
-            }
+    // 6. Repeat, while k < len
+    while (k < len) {
+        // a. Let Pk be ! ToString(k).
+        // b. Let kValue be ? Get(O, Pk).
+        // c. Let testResult be ToBoolean(? Call(predicate, T, « kValue, k, O »)).
+        // d. If testResult is true, return kValue.
+        var kValue = o[k];
+        if (predicate.call(thisArg, kValue, k, o)) {
+            return kValue;
+        }
+        // e. Increase k by 1.
+        k++;
+    }
 
-            // 7. Return undefined.
-            return undefined;
-        },
-        configurable: true,
-        writable: true
-    });
-}
+    // 7. Return undefined.
+    return undefined;
+});

--- a/src/polyfill/array-find.js
+++ b/src/polyfill/array-find.js
@@ -1,4 +1,4 @@
-import { defineProtoFunc } from "./defineProtoFunc";
+import { defineProtoFunc } from "./defineProtoFunc.js";
 
 // https://tc39.github.io/ecma262/#sec-array.prototype.find
 defineProtoFunc(Array, 'find', function(predicate) {

--- a/src/polyfill/defineProtoFunc.js
+++ b/src/polyfill/defineProtoFunc.js
@@ -1,0 +1,16 @@
+/**
+ * 
+ * @param {ObjectConstructor} cls 
+ * @param {string} name 
+ * @param {Function} func 
+ */
+export function defineProtoFunc(cls, name, func) {
+  if (!cls.prototype[name]) {
+      Object.defineProperty(cls.prototype, name, {
+          value: func,
+          configurable: true,
+          enumerable: false,
+          writable: true
+      });
+  }
+}

--- a/src/polyfill/defineProtoFunc.js
+++ b/src/polyfill/defineProtoFunc.js
@@ -1,8 +1,10 @@
 /**
+ * A short hand function to polyfill prototype methods which are not iterated in e.g. for-in loops.
  * 
  * @param {ObjectConstructor} cls 
  * @param {string} name 
  * @param {Function} func 
+ * @ignore
  */
 export function defineProtoFunc(cls, name, func) {
   if (!cls.prototype[name]) {

--- a/src/polyfill/string.js
+++ b/src/polyfill/string.js
@@ -1,32 +1,28 @@
+import { defineProtoFunc } from "./defineProtoFunc";
+
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/endsWith#Polyfill
-if (!String.prototype.endsWith) {
-    String.prototype.endsWith = function(search, this_len) {
-        if (this_len === undefined || this_len > this.length) {
-            this_len = this.length;
-        }
-        return this.substring(this_len - search.length, this_len) === search;
-    };
-}
+defineProtoFunc(String, 'endsWith', function(search, this_len) {
+    if (this_len === undefined || this_len > this.length) {
+        this_len = this.length;
+    }
+    return this.substring(this_len - search.length, this_len) === search;
+});
 
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/includes#Polyfill
-if (!String.prototype.includes) {
-    String.prototype.includes = function(search, start) {
-        'use strict';
-        if (typeof start !== 'number') {
-            start = 0;
-        }
+defineProtoFunc(String, 'includes', function(search, start) {
+    'use strict';
+    if (typeof start !== 'number') {
+        start = 0;
+    }
 
-        if (start + search.length > this.length) {
-            return false;
-        } else {
-            return this.indexOf(search, start) !== -1;
-        }
-    };
-}
+    if (start + search.length > this.length) {
+        return false;
+    } else {
+        return this.indexOf(search, start) !== -1;
+    }
+});
 
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith#Polyfill
-if (!String.prototype.startsWith) {
-    String.prototype.startsWith = function(search, pos) {
-        return this.substr(!pos || pos < 0 ? 0 : +pos, search.length) === search;
-    };
-}
+defineProtoFunc(String, 'startsWith', function(search, pos) {
+    return this.substr(!pos || pos < 0 ? 0 : +pos, search.length) === search;
+});

--- a/src/polyfill/string.js
+++ b/src/polyfill/string.js
@@ -1,4 +1,4 @@
-import { defineProtoFunc } from "./defineProtoFunc";
+import { defineProtoFunc } from "./defineProtoFunc.js";
 
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/endsWith#Polyfill
 defineProtoFunc(String, 'endsWith', function(search, this_len) {

--- a/src/polyfill/typedarray-fill.js
+++ b/src/polyfill/typedarray-fill.js
@@ -10,7 +10,7 @@ const typedArrays = [
     Uint32Array,
     Float32Array
 ];
-for (var typedArray of typedArrays) {
+for (const typedArray of typedArrays) {
     // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/fill#polyfill
     defineProtoFunc(typedArray, "fill", Array.prototype.fill);
     defineProtoFunc(typedArray, "join", Array.prototype.join);

--- a/src/polyfill/typedarray-fill.js
+++ b/src/polyfill/typedarray-fill.js
@@ -1,4 +1,4 @@
-import { defineProtoFunc } from "./defineProtoFunc";
+import { defineProtoFunc } from "./defineProtoFunc.js";
 
 const typedArrays = [
     Int8Array,

--- a/src/polyfill/typedarray-fill.js
+++ b/src/polyfill/typedarray-fill.js
@@ -1,32 +1,17 @@
-// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/fill#polyfill
-if (!Int8Array.prototype.fill) {
-    Int8Array.prototype.fill = Array.prototype.fill;
-}
+import { defineProtoFunc } from "./defineProtoFunc";
 
-if (!Uint8Array.prototype.fill) {
-    Uint8Array.prototype.fill = Array.prototype.fill;
-}
-
-if (!Uint8ClampedArray.prototype.fill) {
-    Uint8ClampedArray.prototype.fill = Array.prototype.fill;
-}
-
-if (!Int16Array.prototype.fill) {
-    Int16Array.prototype.fill = Array.prototype.fill;
-}
-
-if (!Uint16Array.prototype.fill) {
-    Uint16Array.prototype.fill = Array.prototype.fill;
-}
-
-if (!Int32Array.prototype.fill) {
-    Int32Array.prototype.fill = Array.prototype.fill;
-}
-
-if (!Uint32Array.prototype.fill) {
-    Uint32Array.prototype.fill = Array.prototype.fill;
-}
-
-if (!Float32Array.prototype.fill) {
-    Float32Array.prototype.fill = Array.prototype.fill;
+const typedArrays = [
+    Int8Array,
+    Uint8Array,
+    Uint8ClampedArray,
+    Int16Array,
+    Uint16Array,
+    Int32Array,
+    Uint32Array,
+    Float32Array
+];
+for (var typedArray of typedArrays) {
+    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/fill#polyfill
+    defineProtoFunc(typedArray, "fill", Array.prototype.fill);
+    defineProtoFunc(typedArray, "join", Array.prototype.join);
 }


### PR DESCRIPTION
Some polyfill functions are just added to e.g. `String.prototype.endsWith` without using `Object.defineProperty` and this causes `for-in` loops to show "funny" results:

E.g. Internet Explorer results before:

![image](https://user-images.githubusercontent.com/5236548/152781919-c6519e0e-4474-4bdf-b5f2-f31ce42de32c.png)

![image](https://user-images.githubusercontent.com/5236548/152782114-28359e32-eab3-4254-9d80-838a6f85d90b.png)

This PR makes it less code + more polyfills (`String#join` on all typed arrays)

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
