### PR TITLE
Ambient lighting fix

### DIFF
--- a/src/graphics/program-lib/chunks/ambientEnv.frag.js
+++ b/src/graphics/program-lib/chunks/ambientEnv.frag.js
@@ -5,7 +5,7 @@ uniform sampler2D texture_envAtlas;
 #endif
 
 void addAmbient() {
-    vec3 dir = cubeMapRotate(dNormalW) * vec3(-1.0, 1.0, 1.0);
+    vec3 dir = normalize(cubeMapRotate(dNormalW) * vec3(-1.0, 1.0, 1.0));
     vec2 uv = mapUv(toSphericalUv(dir), vec4(128.0, 256.0 + 128.0, 64.0, 32.0) / atlasSize);
 
     vec4 raw = texture2D(texture_envAtlas, uv);


### PR DESCRIPTION
This PR fixes an occasional ambient lighting error. In some cases we were attempting to convert an unnormalised direction vector to spherical coordinates. This resulted in us invoking `asin(value)` with `|value| > 1.0` resulting in an undefined value.

This PR normalises the direction vector before conversion.

Before:
![Screenshot 2022-02-08 at 12 10 01](https://user-images.githubusercontent.com/11276292/152985177-1a1360d5-16f3-4e07-aefb-086d1f8c32d1.png)

After:
![Screenshot 2022-02-08 at 12 10 59](https://user-images.githubusercontent.com/11276292/152985210-56a42659-eeaf-473e-ba14-f0f9a5566929.png)

