### PR TITLE
Fix error when a non image element is assigned to imageEntity on button.

### DIFF
--- a/src/framework/components/button/component.js
+++ b/src/framework/components/button/component.js
@@ -456,7 +456,7 @@ class ButtonComponent extends Component {
     }
 
     _applyTintImmediately(tintColor) {
-        if (!tintColor || !this._imageReference.hasComponent('element'))
+        if (!tintColor || !this._imageReference.hasComponent('element') || this._imageReference.entity.element.type != ELEMENTTYPE_IMAGE)
             return;
 
         const color3 = toColor3(tintColor);
@@ -473,7 +473,7 @@ class ButtonComponent extends Component {
     }
 
     _applyTintWithTween(tintColor) {
-        if (!tintColor || !this._imageReference.hasComponent('element'))
+        if (!tintColor || !this._imageReference.hasComponent('element') || this._imageReference.entity.element.type != ELEMENTTYPE_IMAGE)
             return;
 
         const color3 = toColor3(tintColor);


### PR DESCRIPTION
This fixes an exception when a button is first enabled when the `imageEntity` is assigned an entity with an element, but is not an image element type.
`element.color` is null which causes an error in both `applyTint` functions.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
