### PR TITLE
Set failed flag in setShader()

### DIFF
--- a/src/graphics/graphics-device.js
+++ b/src/graphics/graphics-device.js
@@ -3690,10 +3690,11 @@ class GraphicsDevice extends EventHandler {
      */
     setShader(shader) {
         if (shader !== this.shader) {
-            if (!shader.ready) {
-                if (!this.postLink(shader)) {
-                    return false;
-                }
+            if (shader.failed) {
+                return false;
+            } else if (!shader.ready && !this.postLink(shader)) {
+                shader.failed = true;
+                return false;
             }
 
             this.shader = shader;

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -1369,7 +1369,6 @@ class ForwardRenderer {
                     const shader = drawCall._shader[pass];
                     if (!shader.failed && !device.setShader(shader)) {
                         Debug.error(`Error in material "${material.name}" with flags ${objDefs}`);
-                        shader.failed = true;
                     }
 
                     // Uniforms I: material


### PR DESCRIPTION
Set the shader `failed` flag in `GraphicsDevice.setShader` instead of forward renderer. This will result in all call sites will have the same behavior.