### PR TITLE
Remove type aliases from `build/playcanvas.d.ts`

### DIFF
--- a/types_bundle_undollar.mjs
+++ b/types_bundle_undollar.mjs
@@ -1,0 +1,65 @@
+// > node types_bundle_undollar.mjs
+import {readFileSync, writeFileSync} from "fs";
+var content = readFileSync("build/playcanvas.d.ts", "utf8");
+/**
+ * This will contain all matches found via `regexType`, as long the class names are equal.
+ * 
+ * Example keys: `['AssetRegistry', 'GraphicsDevice', 'ResourceHandler', ...]`
+ * 
+ * @type {Set<string>}
+ */
+const seenTypes = new Set;
+const debug = false;
+/**
+ * This regular expression catches code like:
+ * 
+ * ```js
+ *   type AssetRegistry$2 = AssetRegistry$c;
+ *   type GraphicsDevice$3 = GraphicsDevice$l;
+ *   type ResourceHandler$3 = ResourceHandler$h;
+ * ```
+ */
+const regexType = /type ([a-zA-Z0-9]+)(\$[a-zA-Z0-9]*)? = ([a-zA-Z0-9]+)(\$[a-zA-Z0-9]*)?;/g;
+content = content.replace(regexType, (all, first, firstDollar, second, secondDollar) => {
+  if (first == second) {
+    seenTypes.add(first);
+    if (debug) {
+      console.log('==', {first, second});
+      return '// ' + all;
+    } else {
+      return '';
+    }
+  } else {
+    if (debug) {
+      console.log('!=', {first, second});
+    }
+    return all;
+  }
+});
+const longestTypesFirst = [...seenTypes].sort((a,b) => b.length - a.length);
+for (var seenType of longestTypesFirst) {
+  var regex = new RegExp(`${seenType}\\$[a-zA-Z0-9]+`, 'g');
+  content = content.replace(regex, (all) => {
+    if (debug) {
+      return '/*removed dollar*/ ' + seenType;
+    } else {
+      return seenType;
+    }
+  });
+}
+for (var seenType of longestTypesFirst) {
+  var regex = new RegExp(`${seenType} as ${seenType}`, 'g');
+  content = content.replace(regex, (all) => {
+    if (debug) {
+      return '/*removed as*/ ' + seenType;
+    } else {
+      return seenType;
+    }
+  });
+}
+if (debug) {
+  longestTypesFirst.forEach((seenType, i) => {
+    console.log(`longestTypesFirst[${i.toString().padStart(3)}] = ${seenType}`);
+  });
+}
+writeFileSync("build/playcanvas_new.d.ts", content);

--- a/types_bundle_undollar.mjs
+++ b/types_bundle_undollar.mjs
@@ -1,18 +1,21 @@
-// > node types_bundle_undollar.mjs
-import {readFileSync, writeFileSync} from "fs";
-var content = readFileSync("build/playcanvas.d.ts", "utf8");
+import fs from 'fs';
+
+let content = fs.readFileSync('build/playcanvas.d.ts', 'utf8');
+
 /**
  * This will contain all matches found via `regexType`, as long the class names are equal.
- * 
+ *
  * Example keys: `['AssetRegistry', 'GraphicsDevice', 'ResourceHandler', ...]`
- * 
+ *
  * @type {Set<string>}
  */
-const seenTypes = new Set;
+const seenTypes = new Set();
+
 const debug = false;
+
 /**
- * This regular expression catches code like:
- * 
+ * This regular expression matches code like:
+ *
  * ```js
  *   type AssetRegistry$2 = AssetRegistry$c;
  *   type GraphicsDevice$3 = GraphicsDevice$l;
@@ -20,46 +23,55 @@ const debug = false;
  * ```
  */
 const regexType = /type ([a-zA-Z0-9]+)(\$[a-zA-Z0-9]*)? = ([a-zA-Z0-9]+)(\$[a-zA-Z0-9]*)?;/g;
+
+// STEP 1: Delete all lines of the form: type <TYPE-ALIAS> = <TYPE-ALIAS>;
 content = content.replace(regexType, (all, first, firstDollar, second, secondDollar) => {
-  if (first == second) {
-    seenTypes.add(first);
-    if (debug) {
-      console.log('==', {first, second});
-      return '// ' + all;
-    } else {
-      return '';
+    if (first == second) {
+        seenTypes.add(first);
+        if (debug) {
+            console.log('==', { first, second });
+            return '// ' + all;
+        }
+        return '';
+
     }
-  } else {
     if (debug) {
-      console.log('!=', {first, second});
+        console.log('!=', { first, second });
     }
     return all;
-  }
+
 });
-const longestTypesFirst = [...seenTypes].sort((a,b) => b.length - a.length);
-for (var seenType of longestTypesFirst) {
-  var regex = new RegExp(`${seenType}\\$[a-zA-Z0-9]+`, 'g');
-  content = content.replace(regex, (all) => {
-    if (debug) {
-      return '/*removed dollar*/ ' + seenType;
-    } else {
-      return seenType;
-    }
-  });
+
+// STEP 2: Replace all aliased type names with the original type name.
+const longestTypesFirst = [...seenTypes].sort((a, b) => b.length - a.length);
+for (const seenType of longestTypesFirst) {
+    const regex = new RegExp(`${seenType}\\$[a-zA-Z0-9]+`, 'g');
+    content = content.replace(regex, (all) => {
+        if (debug) {
+            return '/*removed dollar*/ ' + seenType;
+        }
+        return seenType;
+
+    });
 }
-for (var seenType of longestTypesFirst) {
-  var regex = new RegExp(`${seenType} as ${seenType}`, 'g');
-  content = content.replace(regex, (all) => {
-    if (debug) {
-      return '/*removed as*/ ' + seenType;
-    } else {
-      return seenType;
-    }
-  });
+
+// STEP 3: Replace 'SomeType as SomeType' with 'SomeType'. This fixes the final export in the types
+// that export the alias type names as public API type names.
+for (const seenType of longestTypesFirst) {
+    const regex = new RegExp(`${seenType} as ${seenType}`, 'g');
+    content = content.replace(regex, (all) => {
+        if (debug) {
+            return '/*removed as*/ ' + seenType;
+        }
+        return seenType;
+
+    });
 }
+
 if (debug) {
-  longestTypesFirst.forEach((seenType, i) => {
-    console.log(`longestTypesFirst[${i.toString().padStart(3)}] = ${seenType}`);
-  });
+    longestTypesFirst.forEach((seenType, i) => {
+        console.log(`longestTypesFirst[${i.toString().padStart(3)}] = ${seenType}`);
+    });
 }
-writeFileSync("build/playcanvas_new.d.ts", content);
+
+fs.writeFileSync('build/playcanvas.d.ts', content);


### PR DESCRIPTION
This script turns code like this:

```ts
type AssetRegistry$2 = AssetRegistry$c;
type GraphicsDevice$3 = GraphicsDevice$l;
type ResourceHandler$3 = ResourceHandler$h;
/**
 * Resource handler used for loading {@link Sprite} resources.
 *
 * @implements {ResourceHandler}
 */
declare class SpriteHandler implements ResourceHandler$3 {
```

into this:

```ts
/**
 * Resource handler used for loading {@link Sprite} resources.
 *
 * @implements {ResourceHandler}
 */
declare class SpriteHandler implements ResourceHandler {
```

I didn't test it a lot yet, but at least VSCode finds no errors. Partly addresses https://github.com/playcanvas/engine/issues/3995

This script doesn't "integrate" with bundling or anything, its just creating a new file `build/playcanvas_new.d.ts` via `node types_bundle_undollar.mjs`.

It only messes with classes that it could detect from the `regexType`, so classes with the same name as native classes (`Touch` etc.) are left as they are:

![image](https://user-images.githubusercontent.com/5236548/153400570-772a25c7-1c30-4235-b481-4c1931eb6e03.png)

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
