### PR TITLE
Material#clone: return polymorphic this type

### DIFF
--- a/src/scene/materials/material.js
+++ b/src/scene/materials/material.js
@@ -338,7 +338,7 @@ class Material {
     /**
      * Clone a material.
      *
-     * @returns {Material} A newly cloned material.
+     * @returns {this} A newly cloned material.
      */
     clone() {
         const clone = new this.constructor();


### PR DESCRIPTION
Fixes one issue in https://github.com/playcanvas/engine/issues/3995

Before you had to write:

```js
const a = new StandardMaterial;
const b = a.clone() as StandardMaterial;
```

Now its just:

```js
const a = new StandardMaterial;
const b = a.clone();
```

And the type is correctly inferred:

![image](https://user-images.githubusercontent.com/5236548/153707527-52ce7778-3cf9-4f90-9670-e03654492f6f.png)

Because the type system can infer the correct type from `this`: https://www.typescriptlang.org/docs/handbook/advanced-types.html#polymorphic-this-types

JSDoc doesn't support `this` as type yet, but I made a PR for that too: https://github.com/playcanvas/playcanvas-jsdoc-template/pull/38

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
