### PR TITLE
[FIX] Docs tweaks for RefCountedObject

### DIFF
--- a/src/core/ref-counted-object.js
+++ b/src/core/ref-counted-object.js
@@ -1,5 +1,5 @@
 /**
- * Base class implementing reference counting for objects.
+ * Base class that implements reference counting for objects.
  *
  * @ignore
  */
@@ -11,14 +11,14 @@ class RefCountedObject {
     _refCount = 0;
 
     /**
-     * Inrements the counter.
+     * Increments the reference counter.
      */
     incRefCount() {
         this._refCount++;
     }
 
     /**
-     * Decrements the counter. When the value reaches zero, destroy is called.
+     * Decrements the reference counter.
      */
     decRefCount() {
         this._refCount--;


### PR DESCRIPTION
The docs for `RefCountedObject#decRefCount` are misleading, saying `destroy` is called. Also 'increment` is spelled wrong.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
