### PR TITLE
Add missing component properties to typings

### DIFF
--- a/src/framework/components/animation/component.js
+++ b/src/framework/components/animation/component.js
@@ -188,7 +188,7 @@ class AnimationComponent extends Component {
      * Set the model driven by this animation component.
      *
      * @param {Model} model - The model to set.
-     * @private
+     * @ignore
      */
     setModel(model) {
         const data = this.data;

--- a/src/framework/components/animation/component.js
+++ b/src/framework/components/animation/component.js
@@ -11,6 +11,7 @@ import { Asset } from '../../../asset/asset.js';
 
 import { Component } from '../component.js';
 
+/** @typedef {import('../../../scene/model.js').Model} Model */
 /** @typedef {import('../../entity.js').Entity} Entity */
 /** @typedef {import('./system.js').AnimationComponentSystem} AnimationComponentSystem */
 
@@ -26,6 +27,14 @@ import { Component } from '../component.js';
  * @augments Component
  */
 class AnimationComponent extends Component {
+    /* eslint-disable jsdoc/check-types */
+    /**
+     * @type {Object.<string, string>}
+     * @ignore
+     */
+    animationsIndex = {};
+    /* eslint-enable jsdoc/check-types */
+
     /**
      * Create a new AnimationComponent instance.
      *
@@ -34,8 +43,6 @@ class AnimationComponent extends Component {
      */
     constructor(system, entity) {
         super(system, entity);
-
-        this.animationsIndex = { };
 
         // Handle changes to the 'animations' value
         this.on('set_animations', this.onSetAnimations, this);
@@ -177,6 +184,12 @@ class AnimationComponent extends Component {
         return this.data.animations[name];
     }
 
+    /**
+     * Set the model driven by this animation component.
+     *
+     * @param {Model} model - The model to set.
+     * @private
+     */
     setModel(model) {
         const data = this.data;
 
@@ -194,6 +207,7 @@ class AnimationComponent extends Component {
         }
     }
 
+    /** @private */
     _resetAnimationController() {
         const data = this.data;
         data.skeleton = null;
@@ -202,6 +216,7 @@ class AnimationComponent extends Component {
         data.animEvaluator = null;
     }
 
+    /** @private */
     _createAnimationController() {
         const data = this.data;
         const model = data.model;
@@ -233,6 +248,10 @@ class AnimationComponent extends Component {
         }
     }
 
+    /**
+     * @param {number[]} ids - Array of animation asset ids.
+     * @private
+     */
     loadAnimationAssets(ids) {
         if (!ids || !ids.length)
             return;
@@ -280,6 +299,16 @@ class AnimationComponent extends Component {
         }
     }
 
+    /**
+     * Handle asset change events.
+     *
+     * @param {Asset} asset - The asset that changed.
+     * @param {string} attribute - The name of the asset attribute that changed. Can be 'data',
+     * 'file', 'resource' or 'resources'.
+     * @param {*} newValue - The new value of the specified asset property.
+     * @param {*} oldValue - The old value of the specified asset property.
+     * @private
+     */
     onAssetChanged(asset, attribute, newValue, oldValue) {
         if (attribute === 'resource' || attribute === 'resources') {
             // If the attribute is 'resources', newValue can be an empty array when the
@@ -356,6 +385,10 @@ class AnimationComponent extends Component {
         }
     }
 
+    /**
+     * @param {Asset} asset - The asset that was removed.
+     * @private
+     */
     onAssetRemoved(asset) {
         asset.off('remove', this.onAssetRemoved, this);
 
@@ -375,6 +408,7 @@ class AnimationComponent extends Component {
         }
     }
 
+    /** @private */
     _stopCurrentAnimation() {
         const data = this.data;
         data.currAnim = null;
@@ -452,24 +486,6 @@ class AnimationComponent extends Component {
         if (data.animEvaluator) {
             for (let i = 0; i < data.animEvaluator.clips.length; ++i) {
                 data.animEvaluator.clips[i].loop = data.loop;
-            }
-        }
-    }
-
-    onSetCurrentTime(name, oldValue, newValue) {
-        const data = this.data;
-
-        if (data.skeleton) {
-            const skeleton = data.skeleton;
-            skeleton.currentTime = newValue;
-            skeleton.addTime(0); // update
-            skeleton.updateGraph();
-        }
-
-        if (data.animEvaluator) {
-            const animEvaluator = data.animEvaluator;
-            for (let i = 0; i < animEvaluator.clips.length; ++i) {
-                animEvaluator.clips[i].time = newValue;
             }
         }
     }

--- a/src/framework/components/component.js
+++ b/src/framework/components/component.js
@@ -15,6 +15,7 @@ class Component extends EventHandler {
      * The ComponentSystem used to create this Component.
      *
      * @type {ComponentSystem}
+     * @ignore
      */
     system;
 
@@ -22,6 +23,7 @@ class Component extends EventHandler {
      * The Entity that this Component is attached to.
      *
      * @type {Entity}
+     * @ignore
      */
     entity;
 

--- a/src/framework/components/particle-system/component.js
+++ b/src/framework/components/particle-system/component.js
@@ -6,6 +6,10 @@ import { Asset } from '../../../asset/asset.js';
 
 import { Component } from '../component.js';
 
+/** @typedef {import('../../../asset/asset.js').Asset} Asset */
+/** @typedef {import('../../../math/curve.js').Curve} Curve */
+/** @typedef {import('../../../math/curve-set.js').CurveSet} CurveSet */
+/** @typedef {import('../../../math/vec3.js').Vec3} Vec3 */
 /** @typedef {import('../../entity.js').Entity} Entity */
 /** @typedef {import('./system.js').ParticleSystemComponentSystem} ParticleSystemComponentSystem */
 
@@ -254,6 +258,12 @@ let depthLayer;
  * @augments Component
  */
 class ParticleSystemComponent extends Component {
+    /** @private */
+    _requestedDepth = false;
+
+    /** @private */
+    _drawOrder = 0;
+
     /**
      * Create a new ParticleSystemComponent.
      *
@@ -285,9 +295,6 @@ class ParticleSystemComponent extends Component {
         GRAPH_PROPERTIES.forEach((prop) => {
             this.on(`set_${prop}`, this.onSetGraphProperty, this);
         });
-
-        this._requestedDepth = false;
-        this._drawOrder = 0;
     }
 
     set drawOrder(drawOrder) {

--- a/src/framework/components/render/component.js
+++ b/src/framework/components/render/component.js
@@ -27,6 +27,83 @@ import { EntityReference } from '../../utils/entity-reference.js';
  * @augments Component
  */
 class RenderComponent extends Component {
+    /** @private */
+    _type = 'asset';
+
+    /** @private */
+    _castShadows = true;
+
+    /** @private */
+    _receiveShadows = true;
+
+    /** @private */
+    _castShadowsLightmap = true;
+
+    /** @private */
+    _lightmapped = false;
+
+    /** @private */
+    _lightmapSizeMultiplier = 1;
+
+    /** @private */
+    _isStatic = false;
+
+    /** @private */
+    _batchGroupId = -1;
+
+    /** @private */
+    _layers = [LAYERID_WORLD]; // assign to the default world layer
+
+    /** @private */
+    _renderStyle = RENDERSTYLE_SOLID;
+
+    /**
+     * @type {MeshInstance[]}
+     * @private
+     */
+    _meshInstances = [];
+
+    /**
+     * @type {BoundingBox|null}
+     * @private
+     */
+    _customAabb = null;
+
+    /**
+     * Used by lightmapper.
+     *
+     * @type {{x: number, y: number, z: number, uv: number}|null}
+     * @ignore
+     */
+    _area = null;
+
+    /**
+     * @type {AssetReference}
+     * @private
+     */
+    _assetReference = [];
+
+    /**
+     * @type {AssetReference[]}
+     * @private
+     */
+    _materialReferences = [];
+
+    /**
+     * Material used to render meshes other than asset type. It gets priority when set to
+     * something else than defaultMaterial, otherwise materialASsets[0] is used.
+     *
+     * @type {Material}
+     * @private
+     */
+    _material;
+
+    /**
+     * @type {EntityReference}
+     * @private
+     */
+    _rootBone;
+
     /**
      * Create a new RenderComponent.
      *
@@ -35,32 +112,6 @@ class RenderComponent extends Component {
      */
     constructor(system, entity) {
         super(system, entity);
-
-        this._type = 'asset';
-        this._castShadows = true;
-        this._receiveShadows = true;
-        this._castShadowsLightmap = true;
-        this._lightmapped = false;
-        this._lightmapSizeMultiplier = 1;
-        this._isStatic = false;
-        this._batchGroupId = -1;
-
-        /**
-         * @type {MeshInstance[]}
-         * @private
-         */
-        this._meshInstances = [];
-        this._layers = [LAYERID_WORLD]; // assign to the default world layer
-        this._renderStyle = RENDERSTYLE_SOLID;
-
-        /**
-         * @type {BoundingBox}
-         * @private
-         */
-        this._customAabb = null;
-
-        // area - used by lightmapper
-        this._area = null;
 
         // the entity that represents the root bone if this render component has skinned meshes
         this._rootBone = new EntityReference(this, 'rootBone');
@@ -79,19 +130,10 @@ class RenderComponent extends Component {
             this
         );
 
-        /**
-         * Material used to render meshes other than asset type. It gets priority when set to
-         * something else than defaultMaterial, otherwise materialASsets[0] is used.
-         *
-         * @type {Material}
-         * @private
-         */
         this._material = system.defaultMaterial;
 
-        // material asset references
-        this._materialReferences = [];
-
-        // handle events when the entity is directly (or indirectly as a child of sub-hierarchy) added or removed from the parent
+        // handle events when the entity is directly (or indirectly as a child of sub-hierarchy)
+        // added or removed from the parent
         entity.on('remove', this.onRemoveChild, this);
         entity.on('removehierarchy', this.onRemoveChild, this);
         entity.on('insert', this.onInsertChild, this);
@@ -535,12 +577,17 @@ class RenderComponent extends Component {
         return this._assetReference.id;
     }
 
+    /**
+     * @param {Entity} entity - The entity set as the root bone.
+     * @private
+     */
     _onSetRootBone(entity) {
         if (entity) {
             this._onRootBoneChanged();
         }
     }
 
+    /** @private */
     _onRootBoneChanged() {
         // remove existing skin instances and create new ones, connected to new root bone
         this._clearSkinInstances();
@@ -549,6 +596,7 @@ class RenderComponent extends Component {
         }
     }
 
+    /** @private */
     destroyMeshInstances() {
 
         const meshInstances = this._meshInstances;
@@ -565,6 +613,7 @@ class RenderComponent extends Component {
         }
     }
 
+    /** @private */
     addToLayers() {
         const layers = this.system.app.scene.layers;
         for (let i = 0; i < this._layers.length; i++) {
@@ -587,10 +636,12 @@ class RenderComponent extends Component {
         }
     }
 
+    /** @private */
     onRemoveChild() {
         this.removeFromLayers();
     }
 
+    /** @private */
     onInsertChild() {
         if (this._meshInstances && this.enabled && this.entity.enabled) {
             this.addToLayers();

--- a/src/framework/components/rigid-body/system.js
+++ b/src/framework/components/rigid-body/system.js
@@ -18,10 +18,6 @@ let ammoRayStart, ammoRayEnd;
 
 /**
  * Object holding the result of a successful raycast hit.
- *
- * @property {Entity} entity The entity that was hit.
- * @property {Vec3} point The point at which the ray hit the entity in world space.
- * @property {Vec3} normal The normal vector of the surface where the ray hit in world space.
  */
 class RaycastResult {
     /**
@@ -30,24 +26,34 @@ class RaycastResult {
      * @param {Entity} entity - The entity that was hit.
      * @param {Vec3} point - The point at which the ray hit the entity in world space.
      * @param {Vec3} normal - The normal vector of the surface where the ray hit in world space.
+     * @hideconstructor
      */
     constructor(entity, point, normal) {
+        /**
+         * The entity that was hit.
+         *
+         * @type {Entity}
+         */
         this.entity = entity;
+
+        /**
+         * The point at which the ray hit the entity in world space.
+         *
+         * @type {Vec3}
+         */
         this.point = point;
+
+        /**
+         * The normal vector of the surface where the ray hit in world space.
+         *
+         * @type {Vec3}
+         */
         this.normal = normal;
     }
 }
 
 /**
  * Object holding the result of a contact between two rigid bodies.
- *
- * @property {Entity} a The first entity involved in the contact.
- * @property {Entity} b The second entity involved in the contact.
- * @property {Vec3} localPointA The point on Entity A where the contact occurred, relative to A.
- * @property {Vec3} localPointB The point on Entity B where the contact occurred, relative to B.
- * @property {Vec3} pointA The point on Entity A where the contact occurred, in world space.
- * @property {Vec3} pointB The point on Entity B where the contact occurred, in world space.
- * @property {Vec3} normal The normal vector of the contact on Entity B, in world space.
  */
 class SingleContactResult {
     /**
@@ -56,16 +62,65 @@ class SingleContactResult {
      * @param {Entity} a - The first entity involved in the contact.
      * @param {Entity} b - The second entity involved in the contact.
      * @param {ContactPoint} contactPoint - The contact point between the two entities.
+     * @hideconstructor
      */
     constructor(a, b, contactPoint) {
         if (arguments.length === 0) {
+            /**
+             * The first entity involved in the contact.
+             *
+             * @type {Entity}
+             */
             this.a = null;
+
+            /**
+             * The second entity involved in the contact.
+             *
+             * @type {Entity}
+             */
             this.b = null;
+
+            /**
+             * The total accumulated impulse applied by the constraint solver during the last
+             * sub-step. Describes how hard two bodies collided.
+             *
+             * @type {number}
+             */
             this.impulse = 0;
+
+            /**
+             * The point on Entity A where the contact occurred, relative to A.
+             *
+             * @type {Vec3}
+             */
             this.localPointA = new Vec3();
+
+            /**
+             * The point on Entity B where the contact occurred, relative to B.
+             *
+             * @type {Vec3}
+             */
             this.localPointB = new Vec3();
+
+            /**
+             * The point on Entity A where the contact occurred, in world space.
+             *
+             * @type {Vec3}
+             */
             this.pointA = new Vec3();
+
+            /**
+             * The point on Entity B where the contact occurred, in world space.
+             *
+             * @type {Vec3}
+             */
             this.pointB = new Vec3();
+
+            /**
+             * The normal vector of the contact on Entity B, in world space.
+             *
+             * @type {Vec3}
+             */
             this.normal = new Vec3();
         } else {
             this.a = a;
@@ -82,17 +137,6 @@ class SingleContactResult {
 
 /**
  * Object holding the result of a contact between two Entities.
- *
- * @property {Vec3} localPoint The point on the entity where the contact occurred, relative to the
- * entity.
- * @property {Vec3} localPointOther The point on the other entity where the contact occurred,
- * relative to the other entity.
- * @property {Vec3} point The point on the entity where the contact occurred, in world space.
- * @property {Vec3} pointOther The point on the other entity where the contact occurred, in world
- * space.
- * @property {Vec3} normal The normal vector of the contact on the other entity, in world space.
- * @property {number} impulse The total accumulated impulse applied by the constraint solver during
- * the last sub-step. Describes how hard two objects collide.
  */
 class ContactPoint {
     /**
@@ -109,22 +153,56 @@ class ContactPoint {
      * space.
      * @param {number} [impulse] - The total accumulated impulse applied by the constraint solver
      * during the last sub-step. Describes how hard two objects collide. Defaults to 0.
+     * @hideconstructor
      */
     constructor(localPoint = new Vec3(), localPointOther = new Vec3(), point = new Vec3(), pointOther = new Vec3(), normal = new Vec3(), impulse = 0) {
+        /**
+         * The point on the entity where the contact occurred, relative to the entity.
+         *
+         * @type {Vec3}
+         */
         this.localPoint = localPoint;
+
+        /**
+         * The point on the other entity where the contact occurred, relative to the other entity.
+         *
+         * @type {Vec3}
+         */
         this.localPointOther = localPointOther;
+
+        /**
+         * The point on the entity where the contact occurred, in world space.
+         *
+         * @type {Vec3}
+         */
         this.point = point;
+
+        /**
+         * The point on the other entity where the contact occurred, in world space.
+         *
+         * @type {Vec3}
+         */
         this.pointOther = pointOther;
+
+        /**
+         * The normal vector of the contact on the other entity, in world space.
+         *
+         * @type {Vec3}
+         */
         this.normal = normal;
+
+        /**
+         * The total accumulated impulse applied by the constraint solver during the last sub-step.
+         * Describes how hard two objects collide.
+         *
+         * @type {number}
+         */
         this.impulse = impulse;
     }
 }
 
 /**
  * Object holding the result of a contact between two Entities.
- *
- * @property {Entity} other The entity that was involved in the contact with this entity.
- * @property {ContactPoint[]} contacts An array of ContactPoints with the other entity.
  */
 class ContactResult {
     /**
@@ -132,9 +210,21 @@ class ContactResult {
      *
      * @param {Entity} other - The entity that was involved in the contact with this entity.
      * @param {ContactPoint[]} contacts - An array of ContactPoints with the other entity.
+     * @hideconstructor
      */
     constructor(other, contacts) {
+        /**
+         * The entity that was involved in the contact with this entity.
+         *
+         * @type {Entity}
+         */
         this.other = other;
+
+        /**
+         * An array of ContactPoints with the other entity.
+         *
+         * @type {ContactPoint[]}
+         */
         this.contacts = contacts;
     }
 }

--- a/src/framework/components/scrollbar/component.js
+++ b/src/framework/components/scrollbar/component.js
@@ -8,7 +8,6 @@ import { ElementDragHelper } from '../element/element-drag-helper.js';
 
 import { EntityReference } from '../../utils/entity-reference.js';
 
-/** @typedef {import('../../application.js').Application} Application */
 /** @typedef {import('../../entity.js').Entity} Entity */
 /** @typedef {import('./system.js').ScrollbarComponentSystem} ScrollbarComponentSystem */
 
@@ -39,8 +38,6 @@ class ScrollbarComponent extends Component {
      */
     constructor(system, entity) {
         super(system, entity);
-
-        this._app = system.app;
 
         this._handleReference = new EntityReference(this, 'handleEntity', {
             'element#gain': this._onHandleElementGain,

--- a/src/framework/utils/entity-reference.js
+++ b/src/framework/utils/entity-reference.js
@@ -110,7 +110,6 @@ import { EventHandler } from '../../core/event-handler.js';
  * of the parent component – you should never have to worry about manually calling
  * `Function.bind()`.
  *
- * @property {Entity} entity A reference to the entity, if present.
  * @augments EventHandler
  * @ignore
  */
@@ -406,12 +405,16 @@ class EntityReference extends EventHandler {
      *
      * @param {string} componentName - Name of the component.
      * @returns {boolean} True if the entity exists and has a component of the provided type.
-     * @private
      */
     hasComponent(componentName) {
         return (this._entity && this._entity.c) ? !!this._entity.c[componentName] : false;
     }
 
+    /**
+     * A reference to the entity, if present.
+     *
+     * @type {Entity}
+     */
     get entity() {
         return this._entity;
     }

--- a/types.mjs
+++ b/types.mjs
@@ -22,6 +22,8 @@ let dts = fs.readFileSync(path, 'utf8');
 dts = dts.replace('}, vertexCount?: number);', '}[], vertexCount?: number);');
 fs.writeFileSync(path, dts);
 
+const regexConstructor = /constructor\(([^)]+)\);/g;
+
 // Generate TS declarations for getter/setter pairs
 const getDeclarations = (properties) => {
     let declarations = '';
@@ -42,7 +44,20 @@ const componentProps = [
 
 path = './types/framework/components/component.d.ts';
 dts = fs.readFileSync(path, 'utf8');
-dts = dts.replace('get data(): any;', 'get data(): any;\n' + getDeclarations(componentProps));
+dts = dts.replace(regexConstructor, '$&\n' + getDeclarations(componentProps));
+fs.writeFileSync(path, dts);
+
+const animationComponentProps = [
+    ['activate', 'boolean'],
+    ['assets', 'any[]'],
+    ['loop', 'boolean'],
+    ['skeleton', 'any'],
+    ['speed', 'number']
+];
+
+path = './types/framework/components/animation/component.d.ts';
+dts = fs.readFileSync(path, 'utf8');
+dts = dts.replace(regexConstructor, '$&\n' + getDeclarations(animationComponentProps));
 fs.writeFileSync(path, dts);
 
 const buttonComponentProps = [
@@ -64,7 +79,7 @@ const buttonComponentProps = [
    
 path = './types/framework/components/button/component.d.ts';
 dts = fs.readFileSync(path, 'utf8');
-dts = dts.replace('constructor(system: ButtonComponentSystem, entity: Entity);', 'constructor(system: ButtonComponentSystem, entity: Entity);\n' + getDeclarations(buttonComponentProps));
+dts = dts.replace(regexConstructor, '$&\n' + getDeclarations(buttonComponentProps));
 fs.writeFileSync(path, dts);
 
 const cameraComponentProps = [
@@ -86,7 +101,21 @@ const cameraComponentProps = [
 
 path = './types/framework/components/camera/component.d.ts';
 dts = fs.readFileSync(path, 'utf8');
-dts = dts.replace('_postEffects: PostEffectQueue;', '_postEffects: PostEffectQueue;\n' + getDeclarations(cameraComponentProps));
+dts = dts.replace(regexConstructor, '$&\n' + getDeclarations(cameraComponentProps));
+fs.writeFileSync(path, dts);
+
+const collisionComponentProps = [
+    ['axis', 'number'],
+    ['halfExtents', 'any'],
+    ['height', 'number'],
+    ['model', 'any'],
+    ['radius', 'number'],
+    ['type', 'string']
+];
+
+path = './types/framework/components/collision/component.d.ts';
+dts = fs.readFileSync(path, 'utf8');
+dts = dts.replace(regexConstructor, '$&\n' + getDeclarations(collisionComponentProps));
 fs.writeFileSync(path, dts);
 
 const elementComponentProps = [
@@ -131,7 +160,7 @@ const elementComponentProps = [
 
 path = './types/framework/components/element/component.d.ts';
 dts = fs.readFileSync(path, 'utf8');
-dts = dts.replace('_maskedBy: any;', '_maskedBy: any;\n' + getDeclarations(elementComponentProps));
+dts = dts.replace(regexConstructor, '$&\n' + getDeclarations(elementComponentProps));
 fs.writeFileSync(path, dts);
 
 const lightComponentProps = [
@@ -173,14 +202,106 @@ const lightComponentProps = [
 
 path = './types/framework/components/light/component.d.ts';
 dts = fs.readFileSync(path, 'utf8');
-dts = dts.replace('entity: Entity);', 'entity: Entity);\n' + getDeclarations(lightComponentProps));
+dts = dts.replace(regexConstructor, '$&\n' + getDeclarations(lightComponentProps));
 fs.writeFileSync(path, dts);
 
-// TypeScript compiler is defining enabled in ParticleSystemComponent because it doesn't
-// know about the declaration in the Component base class, so remove it.
+const particleSystemComponentProps = [
+    ['alignToMotion', 'boolean'],
+    ['alphaGraph', 'Curve'],
+    ['alphaGraph2', 'Curve'],
+    ['animIndex', 'number'],
+    ['animLoop', 'boolean'],
+    ['animNumAnimations', 'number'],
+    ['animNumFrames', 'number'],
+    ['animSpeed', 'number'],
+    ['animStartFrame', 'number'],
+    ['animTilesX', 'number'],
+    ['animTilesY', 'number'],
+    ['autoPlay', 'boolean'],
+    ['blend', 'number'],
+    ['colorGraph', 'CurveSet'],
+    ['colorMapAsset', 'Asset'],
+    ['depthSoftening', 'number'],
+    ['depthWrite', 'boolean'],
+    ['emitterExtents', 'Vec3'],
+    ['emitterExtentsInner', 'Vec3'],
+    ['emitterRadius', 'number'],
+    ['emitterRadiusInner', 'number'],
+    ['emitterShape', 'number'],
+    ['halfLambert', 'boolean'],
+    ['initialVelocity', 'number'],
+    ['intensity', 'number'],
+    ['layers', 'number[]'],
+    ['lifetime', 'number'],
+    ['lighting', 'boolean'],
+    ['localSpace', 'boolean'],
+    ['localVelocityGraph', 'CurveSet'],
+    ['localVelocityGraph2', 'CurveSet'],
+    ['loop', 'boolean'],
+    ['noFog', 'boolean'],
+    ['normalMapAsset', 'Asset'],
+    ['numParticles', 'number'],
+    ['orientation', 'number'],
+    ['particleNormal', 'Vec3'],
+    ['preWarm', 'boolean'],
+    ['radialSpeedGraph', 'Curve'],
+    ['radialSpeedGraph2', 'Curve'],
+    ['randomizeAnimIndex', 'number'],
+    ['rate', 'number'],
+    ['rate2', 'number'],
+    ['renderAsset', 'Asset'],
+    ['rotationSpeedGraph', 'Curve'],
+    ['rotationSpeedGraph2', 'Curve'],
+    ['scaleGraph', 'Curve'],
+    ['scaleGraph2', 'Curve'],
+    ['screenSpace', 'boolean'],
+    ['sort', 'number'],
+    ['startAngle', 'number'],
+    ['startAngle2', 'number'],
+    ['stretch', 'number'],
+    ['velocityGraph', 'CurveSet'],
+    ['velocityGraph2', 'CurveSet'],
+    ['wrapBounds', 'Vec3']
+];
+
 path = './types/framework/components/particle-system/component.d.ts';
 dts = fs.readFileSync(path, 'utf8');
+// TypeScript compiler is defining enabled in ParticleSystemComponent because it doesn't
+// know about the declaration in the Component base class, so remove it.
+dts = dts.replace(regexConstructor, '$&\n' + getDeclarations(particleSystemComponentProps));
 dts = dts.replace('enabled: any;', '');
+fs.writeFileSync(path, dts);
+
+const scrollbarComponentProps = [
+    ['handleEntity', 'Entity'],
+    ['handleSize', 'number'],
+    ['orientation', 'number']
+];
+
+path = './types/framework/components/scrollbar/component.d.ts';
+dts = fs.readFileSync(path, 'utf8');
+dts = dts.replace(regexConstructor, '$&\n' + getDeclarations(scrollbarComponentProps));
+fs.writeFileSync(path, dts);
+
+const scrollViewComponentProps = [
+    ['bounceAmount', 'number'],
+    ['contentEntity', 'Entity'],
+    ['friction', 'number'],
+    ['horizontal', 'boolean'],
+    ['horizontalScrollbarEntity', 'Entity'],
+    ['horizontalScrollbarVisibility', 'number'],
+    ['mouseWheelSensitivity', 'Vec2'],
+    ['scrollMode', 'number'],
+    ['useMouseWheel', 'boolean'],
+    ['vertical', 'boolean'],
+    ['verticalScrollbarEntity', 'Entity'],
+    ['verticalScrollbarVisibility', 'number'],
+    ['viewportEntity', 'Entity']
+];
+
+path = './types/framework/components/scroll-view/component.d.ts';
+dts = fs.readFileSync(path, 'utf8');
+dts = dts.replace(regexConstructor, '$&\n' + getDeclarations(scrollViewComponentProps));
 fs.writeFileSync(path, dts);
 
 const standardMaterialProps = [


### PR DESCRIPTION
* Add the remaining missing component property getter/setters to the TypeScript declarations.
* Remove `AnimationComponent#onSetCurrentTime` which is not called from anywhere.
* Hide various physics related constructors from the docs.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
