### PR TITLE
XR session requests stencil buffer

### DIFF
--- a/src/xr/xr-manager.js
+++ b/src/xr/xr-manager.js
@@ -603,7 +603,11 @@ class XrManager extends EventHandler {
         this._camera.on('set_nearClip', onClipPlanesChange);
         this._camera.on('set_farClip', onClipPlanesChange);
 
-        this._baseLayer = new XRWebGLLayer(session, this.app.graphicsDevice.gl);
+        this._baseLayer = new XRWebGLLayer(session, this.app.graphicsDevice.gl, {
+            alpha: true,
+            depth: true,
+            stencil: true
+        });
 
         session.updateRenderState({
             baseLayer: this._baseLayer,


### PR DESCRIPTION
Fixes https://github.com/playcanvas/engine/issues/2465

When XR session starts, a stencil buffer is requested (which defaults to false).
Also requesting depth and alpha, even though those default to true https://developer.mozilla.org/en-US/docs/Web/API/XRWebGLLayer/XRWebGLLayer, but based on https://github.com/playcanvas/engine/issues/3031 it seems perhaps depth buffer is not getting created by default on all platforms.