### PR TITLE
instantiateRenderEntity sets up render assets on render components

### DIFF
--- a/src/asset/asset.js
+++ b/src/asset/asset.js
@@ -95,10 +95,10 @@ class Asset extends EventHandler {
 
         /**
          * The type of the asset. One of ["animation", "audio", "binary", "container", "cubemap",
-         * "css", "font", "json", "html", "material", "model", "script", "shader", "sprite",
+         * "css", "font", "json", "html", "material", "model", "render", "script", "shader", "sprite",
          * "template", "text", "texture"]
          *
-         * @type {("animation"|"audio"|"binary"|"container"|"cubemap"|"css"|"font"|"json"|"html"|"material"|"model"|"script"|"shader"|"sprite"|"template"|"text"|"texture")}
+         * @type {("animation"|"audio"|"binary"|"container"|"cubemap"|"css"|"font"|"json"|"html"|"material"|"model"|"render"|"script"|"shader"|"sprite"|"template"|"text"|"texture")}
          */
         this.type = type;
 

--- a/src/resources/parser/glb-container-resource.js
+++ b/src/resources/parser/glb-container-resource.js
@@ -99,7 +99,7 @@ class GlbContainerResource {
         };
 
         // helper function to recursively clone a hierarchy of GraphNodes to Entities
-        const cloneHierarchy = function (root, node, glb) {
+        const cloneHierarchy = (root, node, glb) => {
 
             const entity = new Entity();
             node._cloneInternal(entity);
@@ -109,6 +109,7 @@ class GlbContainerResource {
 
             // find all components needed for this node
             let attachedMi = null;
+            let renderAssset = null;
             for (let i = 0; i < glb.nodes.length; i++) {
                 const glbNode = glb.nodes[i];
                 if (glbNode === node) {
@@ -117,6 +118,7 @@ class GlbContainerResource {
                     // mesh
                     if (gltfNode.hasOwnProperty('mesh')) {
                         const meshGroup = glb.renders[gltfNode.mesh].meshes;
+                        renderAssset = this.renders[gltfNode.mesh];
                         for (var mi = 0; mi < meshGroup.length; mi++) {
                             const mesh = meshGroup[mi];
                             if (mesh) {
@@ -155,6 +157,7 @@ class GlbContainerResource {
             if (attachedMi) {
                 entity.addComponent("render", Object.assign({
                     type: "asset",
+                    asset: renderAssset,
                     meshInstances: attachedMi,
                     rootBone: root
                 }, options));

--- a/src/resources/parser/glb-container-resource.js
+++ b/src/resources/parser/glb-container-resource.js
@@ -109,7 +109,7 @@ class GlbContainerResource {
 
             // find all components needed for this node
             let attachedMi = null;
-            let renderAssset = null;
+            let renderAsset = null;
             for (let i = 0; i < glb.nodes.length; i++) {
                 const glbNode = glb.nodes[i];
                 if (glbNode === node) {
@@ -118,7 +118,7 @@ class GlbContainerResource {
                     // mesh
                     if (gltfNode.hasOwnProperty('mesh')) {
                         const meshGroup = glb.renders[gltfNode.mesh].meshes;
-                        renderAssset = this.renders[gltfNode.mesh];
+                        renderAsset = this.renders[gltfNode.mesh];
                         for (var mi = 0; mi < meshGroup.length; mi++) {
                             const mesh = meshGroup[mi];
                             if (mesh) {
@@ -157,7 +157,7 @@ class GlbContainerResource {
             if (attachedMi) {
                 entity.addComponent("render", Object.assign({
                     type: "asset",
-                    asset: renderAssset,
+                    asset: renderAsset,
                     meshInstances: attachedMi,
                     rootBone: root
                 }, options));

--- a/src/scene/render.js
+++ b/src/scene/render.js
@@ -16,13 +16,12 @@ import { EventHandler } from '../core/event-handler.js';
  * resource of a Render Asset.
  *
  * @augments EventHandler
+ * @ignore
  */
 class Render extends EventHandler {
     /**
      * Create a new Render instance. These are usually created by the GLB loader and not created
      * by hand.
-     *
-     * @hideconstructor
      */
     constructor() {
         super();

--- a/src/scene/render.js
+++ b/src/scene/render.js
@@ -21,6 +21,8 @@ class Render extends EventHandler {
     /**
      * Create a new Render instance. These are usually created by the GLB loader and not created
      * by hand.
+     *
+     * @hideconstructor
      */
     constructor() {
         super();

--- a/src/scene/render.js
+++ b/src/scene/render.js
@@ -16,7 +16,6 @@ import { EventHandler } from '../core/event-handler.js';
  * resource of a Render Asset.
  *
  * @augments EventHandler
- * @ignore
  */
 class Render extends EventHandler {
     /**


### PR DESCRIPTION
- When an Entity hierarchy was created using GlbContainer.instantiateRenderEntity, the render component didn't have .asset property set up. This is now fixed, and those properties point to a render assets.
- Additionally, a Render class is now public, as it is a type of the resource accessible using render component's asset property.