### PR TITLE
AnimController activate state progress fix

### DIFF
--- a/src/anim/controller/anim-controller.js
+++ b/src/anim/controller/anim-controller.js
@@ -187,7 +187,7 @@ class AnimController {
 
         const activeClip = this._animEvaluator.findClip(this.activeStateAnimations[0].name);
         if (activeClip) {
-            return time / activeClip.track.duration;
+            return time / activeClip.track.duration * this.activeState.speed;
         }
 
         return null;


### PR DESCRIPTION
When animating properties with a graph, the activate state's progress should be affected by the active state's speed property.

Fixes #3837

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
