### PR TITLE
[Fix] Fix to render asset id assignment to component when creating glb instance

### DIFF
--- a/src/framework/components/render/component.js
+++ b/src/framework/components/render/component.js
@@ -559,7 +559,7 @@ class RenderComponent extends Component {
      * @type {Asset|number}
      */
     set asset(value) {
-        const id = (value instanceof Asset ? value.id : value);
+        const id = value instanceof Asset ? value.id : value;
         if (this._assetReference.id === id) return;
 
         if (this._assetReference.asset && this._assetReference.asset.resource) {
@@ -575,6 +575,18 @@ class RenderComponent extends Component {
 
     get asset() {
         return this._assetReference.id;
+    }
+
+    /**
+     * Assign asset id to the component, without updating the component with the new asset.
+     * This can be used to assign the asset id to already fully created component.
+     *
+     * @param {Asset|number} asset - The render asset or asset id to assign.
+     * @ignore
+     */
+    assignAsset(asset) {
+        const id = asset instanceof Asset ? asset.id : asset;
+        this._assetReference.id = id;
     }
 
     /**

--- a/src/resources/parser/glb-container-resource.js
+++ b/src/resources/parser/glb-container-resource.js
@@ -157,10 +157,12 @@ class GlbContainerResource {
             if (attachedMi) {
                 entity.addComponent("render", Object.assign({
                     type: "asset",
-                    asset: renderAsset,
                     meshInstances: attachedMi,
                     rootBone: root
                 }, options));
+
+                // assign asset id without recreating mesh instances which are already set up with materials
+                entity.render.assignAsset(renderAsset);
             }
 
             // recursively clone children


### PR DESCRIPTION
Improvement to #4039, which was setting an asset id on a render component being created from the glb. The assignment was causing the render asset to reload, which does not support materials, causing missing materials.

This PR addresses this by only assigning the asset id, without triggering the component mesh instances to be recreated from it.