### PR TITLE
Updated Portal example to use layers

### DIFF
--- a/examples/src/examples/graphics/portal.tsx
+++ b/examples/src/examples/graphics/portal.tsx
@@ -161,7 +161,7 @@ class PortalExample {
         border.setLocalEulerAngles(90, 0, 0);
         border.setLocalScale(4.68, 1.17, 7.019);
 
-        // Create a Entity with a Box render component and a particle system
+        // Create an Entity with a Box render component and a particle system
         // This uses insidePortal script to set up its stencil testing
         // for inside the portal
         const box = new pc.Entity("Box");

--- a/examples/src/examples/graphics/portal.tsx
+++ b/examples/src/examples/graphics/portal.tsx
@@ -135,7 +135,7 @@ class PortalExample {
 
         // Create the portal entity - this plane is written to stencil buffer,
         // which is then used to test for inside / outside. This needs to render
-        // before all elements requring stencil buffer, so add ot to a portalLayer
+        // before all elements requiring stencil buffer, so add to to a portalLayer
         const portal = new pc.Entity("Portal");
         portal.addComponent('render', {
             type: 'plane',

--- a/examples/src/examples/graphics/portal.tsx
+++ b/examples/src/examples/graphics/portal.tsx
@@ -1,12 +1,10 @@
 import * as pc from '../../../../';
 
-
 class PortalExample {
     static CATEGORY = 'Graphics';
     static NAME = 'Portal';
 
     example(canvas: HTMLCanvasElement): void {
-
 
         // Create the application and start the update loop
         const app = new pc.Application(canvas, {
@@ -26,7 +24,7 @@ class PortalExample {
 
         let t = 0;
 
-        Rotator.prototype.update = function (dt) {
+        Rotator.prototype.update = function (dt: number) {
             t += dt;
             this.entity.setEulerAngles(0, Math.sin(t) * 20, 0);
         };
@@ -37,22 +35,18 @@ class PortalExample {
         const InsidePortal = pc.createScript('insidePortal');
 
         InsidePortal.prototype.initialize = function () {
-            const meshInstances = this.entity.model.meshInstances;
-            let mat, i;
             const stencil = new pc.StencilParameters({
                 func: pc.FUNC_NOTEQUAL,
                 ref: 0
             });
-            for (i = 0; i < meshInstances.length; i++) {
-                meshInstances[i].layer -= 2;
-                mat = meshInstances[i].material;
-                mat.stencilBack = mat.stencilFront = stencil;
+
+            for (const meshInstance of this.entity.render.meshInstances) {
+                meshInstance.material.stencilBack = meshInstance.material.stencilFront = stencil;
             }
 
             const prt = this.entity.particlesystem;
             if (prt) {
-                prt.emitter.meshInstance.layer -= 2;
-                mat = prt.emitter.material;
+                const mat = prt.emitter.material;
                 mat.stencilBack = mat.stencilFront = stencil;
             }
         };
@@ -63,22 +57,18 @@ class PortalExample {
         const OutsidePortal = pc.createScript('outsidePortal');
 
         OutsidePortal.prototype.initialize = function () {
-            const meshInstances = this.entity.model.meshInstances;
-            let mat, i;
             const stencil = new pc.StencilParameters({
                 func: pc.FUNC_EQUAL,
                 ref: 0
             });
-            for (i = 0; i < meshInstances.length; i++) {
-                meshInstances[i].layer--;
-                mat = meshInstances[i].material;
-                mat.stencilBack = mat.stencilFront = stencil;
+
+            for (const meshInstance of this.entity.render.meshInstances) {
+                meshInstance.material.stencilBack = meshInstance.material.stencilFront = stencil;
             }
 
             const prt = this.entity.particlesystem;
             if (prt) {
-                prt.emitter.meshInstance.meshes[i].layer--;
-                mat = prt.emitter.material;
+                const mat = prt.emitter.material;
                 mat.stencilBack = mat.stencilFront = stencil;
             }
         };
@@ -91,7 +81,7 @@ class PortalExample {
         // initialize code called once per entity
         Portal.prototype.initialize = function () {
             // We only want to write to the stencil buffer
-            const mat = this.entity.model.meshInstances[0].material;
+            const mat = this.entity.render.meshInstances[0].material;
             mat.depthWrite = false;
             mat.redWrite = mat.greenWrite = mat.blueWrite = mat.alphaWrite = false;
             mat.stencilBack = mat.stencilFront = new pc.StencilParameters({
@@ -99,6 +89,8 @@ class PortalExample {
             });
             mat.update();
         };
+
+        ///////////////////////////////////////////////
 
         app.scene.ambientLight = new pc.Color(0.2, 0.2, 0.2);
 
@@ -109,10 +101,21 @@ class PortalExample {
         borderMat.emissive.set(1, 0.4, 0);
         borderMat.update();
 
+        // find world layer - majority of objects render to this layer
+        const worldLayer = app.scene.layers.getLayerByName("World");
+
+        // portal layer - this is where the portal itself is written to
+        // the stencil buffer, and this needs to render first, so insert
+        // it before the world layer (at index 0)
+        const portalLayer = new pc.Layer({ name: "Portal" });
+        app.scene.layers.insert(portalLayer, 0);
+
         // Create an Entity with a camera component
+        // this camera renders both world and portal layers
         const camera = new pc.Entity();
         camera.addComponent('camera', {
-            clearColor: new pc.Color(0.12, 0.12, 0.12)
+            clearColor: new pc.Color(0.12, 0.12, 0.12),
+            layers: [worldLayer.id, portalLayer.id]
         });
         camera.setLocalPosition(7.5, 5.5, 6.1);
         camera.setLocalEulerAngles(-30, 45, 0);
@@ -130,33 +133,15 @@ class PortalExample {
         group.addComponent('script');
         group.script.create('rotator');
 
-        // Create a Entity with a Box model component
-        const box = new pc.Entity();
-        box.addComponent('model', {
-            type: 'box'
+        // Create the portal entity - this plane is written to stencil buffer,
+        // which is then used to test for inside / outside. This needs to render
+        // before all elements requring stencil buffer, so add ot to a portalLayer
+        const portal = new pc.Entity("Portal");
+        portal.addComponent('render', {
+            type: 'plane',
+            material: portalMat,
+            layers: [portalLayer.id]
         });
-        box.model.material = insideMat;
-        box.addComponent('particlesystem', {
-            numParticles: 128,
-            lifetime: 5,
-            rate: 0.1,
-            rate2: 0.1,
-            emitterShape: pc.EMITTERSHAPE_BOX,
-            emitterExtents: new pc.Vec3(0, 0, 0),
-            scaleGraph: new pc.Curve([0, 0.1]),
-            velocityGraph: new pc.CurveSet([[0, 3], [0, 3], [0, 3]]),
-            velocityGraph2: new pc.CurveSet([[0, -3], [0, -3], [0, -3]])
-        });
-        box.addComponent('script');
-        box.script.create('insidePortal');
-        box.setLocalPosition(0, 0.5, -1.936);
-
-        // Create the portal entity
-        const portal = new pc.Entity();
-        portal.addComponent('model', {
-            type: 'plane'
-        });
-        portal.model.material = portalMat;
         portal.addComponent('script');
         portal.script.create('portal');
         portal.setLocalPosition(0, 0, 0);
@@ -164,23 +149,49 @@ class PortalExample {
         portal.setLocalScale(4, 1, 6);
 
         // Create the portal border entity
-        const border = new pc.Entity();
-        border.addComponent('model', {
-            type: 'plane'
+        // this is set up for rendering outside the portal
+        const border = new pc.Entity("Border");
+        border.addComponent('render', {
+            type: 'plane',
+            material: borderMat
         });
-        border.model.material = borderMat;
         border.addComponent('script');
         border.script.create('outsidePortal');
         border.setLocalPosition(0, 0, 0);
         border.setLocalEulerAngles(90, 0, 0);
         border.setLocalScale(4.68, 1.17, 7.019);
 
-        // Create an entity with a sphere model component
-        const sphere = new pc.Entity();
-        sphere.addComponent('model', {
-            type: 'sphere'
+        // Create a Entity with a Box render component and a particle system
+        // This uses insidePortal script to set up its stencil testing
+        // for inside the portal
+        const box = new pc.Entity("Box");
+        box.addComponent('render', {
+            type: 'box',
+            material: insideMat
         });
-        sphere.model.material = outsideMat;
+        box.addComponent('particlesystem', {
+            numParticles: 256,
+            lifetime: 5,
+            rate: 0.02,
+            rate2: 0.03,
+            emitterShape: pc.EMITTERSHAPE_BOX,
+            emitterExtents: new pc.Vec3(0, 0, 0),
+            scaleGraph: new pc.Curve([0, 0.1]),
+            velocityGraph: new pc.CurveSet([[0, 3], [0, 3], [0, 3]]),
+            velocityGraph2: new pc.CurveSet([[0, -3], [0, -3], [0, -3]]),
+        });
+        box.addComponent('script');
+        box.script.create('insidePortal');
+        box.setLocalPosition(0, 0.5, -1.936);
+
+        // Create an entity with a sphere render component
+        // This uses outsidePortal script to set up its stencil testing
+        // for outside the portal
+        const sphere = new pc.Entity("Sphere");
+        sphere.addComponent('render', {
+            type: 'sphere',
+            material: outsideMat
+        });
         sphere.addComponent('script');
         sphere.script.create('outsidePortal');
         sphere.setLocalPosition(0, 0, -2.414);


### PR DESCRIPTION
Fixes https://github.com/playcanvas/engine/issues/2494

- updated the Portal example to not use deprecated meshInstance.layer property with some magical ordering, but uses a Portal layer to render the portal first.
- added comments to explain the functionality
- switched to use render components