### PR TITLE
[Fix] Removed children are no longer marked as enabled in hierarchy

### DIFF
--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -1304,6 +1304,12 @@ class GraphNode extends EventHandler {
         // Clear parent
         child._parent = null;
 
+        // notify the child hierarchy it has been removed from the parent,
+        // which marks them as not enabled in hierarchy
+        if (child._enabledInHierarchy) {
+            child._notifyHierarchyStateChanged(child, false);
+        }
+
         // alert children that they has been removed
         child._fireOnHierarchy('remove', 'removehierarchy', this);
 


### PR DESCRIPTION
Fixes #2464

When a child GraphNode is removed from the parent, the removed hierarchy nodes have _enabledInHierarchy set to false. Without this, when any node is added to this removed hierarchy, it's believed to be active.