### PR TITLE
anim-controller: fix transitions sorting / minimize code duplication

### DIFF
--- a/src/anim/controller/anim-controller.js
+++ b/src/anim/controller/anim-controller.js
@@ -1,4 +1,5 @@
 import { Debug } from '../../core/debug.js';
+import { sortPriority } from '../../core/sort.js';
 import { AnimClip } from '../evaluator/anim-clip.js';
 import { AnimState } from './anim-state.js';
 import { AnimNode } from './anim-node.js';
@@ -202,9 +203,7 @@ class AnimController {
             });
 
             // sort transitions in priority order
-            transitions.sort(function (a, b) {
-                return a.priority < b.priority;
-            });
+            sortPriority(transitions);
 
             this._findTransitionsFromStateCache[stateName] = transitions;
         }
@@ -220,9 +219,7 @@ class AnimController {
             });
 
             // sort transitions in priority order
-            transitions.sort(function (a, b) {
-                return a.priority < b.priority;
-            });
+            sortPriority(transitions);
 
             this._findTransitionsBetweenStatesCache[sourceStateName + '->' + destinationStateName] = transitions;
         }

--- a/src/core/sort.js
+++ b/src/core/sort.js
@@ -9,7 +9,7 @@ export const cmpPriority = (a, b) => a.priority - b.priority;
 /**
  * @param {Array<{priority: number}>} arr - Array to be sorted in place where each element contains
  * an object with at least a priority property.
- * @returns {Array<{priority: number}>} In place sorted array
+ * @returns {Array<{priority: number}>} In place sorted array.
  * @ignore
  */
 export const sortPriority = arr => arr.sort(cmpPriority);

--- a/src/core/sort.js
+++ b/src/core/sort.js
@@ -2,11 +2,13 @@
  * @param {{priority: number}} a - First object with priority property.
  * @param {{priority: number}} b - Second object with priority property.
  * @returns {number} A number indicating the relative position.
+ * @ignore
  */
 export const cmpPriority = (a, b) => a.priority - b.priority;
 
 /**
  * @param {Array<{priority: number}>} arr - Array to be sorted in place where each element contains an object with at least a priority property.
  * @returns {Array<{priority: number}>} In place sorted array
+ * @ignore
  */
 export const sortPriority = arr => arr.sort(cmpPriority);

--- a/src/core/sort.js
+++ b/src/core/sort.js
@@ -2,11 +2,9 @@
  * @param {{priority: number}} a
  * @param {{priority: number}} b
  */
-
 export const cmpPriority  = (a, b) => a.priority - b.priority;
 
 /**
  * @param {Array<{priority: number}>} arr
  */
-
 export const sortPriority = arr => arr.sort(cmpPriority);

--- a/src/core/sort.js
+++ b/src/core/sort.js
@@ -1,16 +1,12 @@
 /**
- * 
- * @param {{priority: number}} a 
- * @param {{priority: number}} b 
- * @returns 
+ * @param {{priority: number}} a
+ * @param {{priority: number}} b
  */
 
 export const cmpPriority  = (a, b) => a.priority - b.priority;
 
 /**
- * 
- * @param {Array<{priority: number}>} arr 
- * @returns 
+ * @param {Array<{priority: number}>} arr
  */
 
 export const sortPriority = arr => arr.sort(cmpPriority);

--- a/src/core/sort.js
+++ b/src/core/sort.js
@@ -1,10 +1,12 @@
 /**
- * @param {{priority: number}} a
- * @param {{priority: number}} b
+ * @param {{priority: number}} a - First object with priority property.
+ * @param {{priority: number}} b - Second object with priority property.
+ * @returns {number} A number indicating the relative position.
  */
-export const cmpPriority  = (a, b) => a.priority - b.priority;
+export const cmpPriority = (a, b) => a.priority - b.priority;
 
 /**
- * @param {Array<{priority: number}>} arr
+ * @param {Array<{priority: number}>} arr - Array to be sorted in place where each element contains an object with at least a priority property.
+ * @returns {Array<{priority: number}>} In place sorted array
  */
 export const sortPriority = arr => arr.sort(cmpPriority);

--- a/src/core/sort.js
+++ b/src/core/sort.js
@@ -1,0 +1,16 @@
+/**
+ * 
+ * @param {{priority: number}} a 
+ * @param {{priority: number}} b 
+ * @returns 
+ */
+
+export const cmpPriority  = (a, b) => a.priority - b.priority;
+
+/**
+ * 
+ * @param {Array<{priority: number}>} arr 
+ * @returns 
+ */
+
+export const sortPriority = arr => arr.sort(cmpPriority);

--- a/src/core/sort.js
+++ b/src/core/sort.js
@@ -7,7 +7,8 @@
 export const cmpPriority = (a, b) => a.priority - b.priority;
 
 /**
- * @param {Array<{priority: number}>} arr - Array to be sorted in place where each element contains an object with at least a priority property.
+ * @param {Array<{priority: number}>} arr - Array to be sorted in place where each element contains
+ * an object with at least a priority property.
  * @returns {Array<{priority: number}>} In place sorted array
  * @ignore
  */

--- a/src/framework/components/camera/system.js
+++ b/src/framework/components/camera/system.js
@@ -1,3 +1,4 @@
+import { sortPriority } from '../../../core/sort.js';
 import { Color } from '../../../math/color.js';
 import { Vec4 } from '../../../math/vec4.js';
 
@@ -169,21 +170,15 @@ class CameraComponentSystem extends ComponentSystem {
 
     addCamera(camera) {
         this.cameras.push(camera);
-        this.sortCamerasByPriority();
+        sortPriority(this.cameras);
     }
 
     removeCamera(camera) {
         const index = this.cameras.indexOf(camera);
         if (index >= 0) {
             this.cameras.splice(index, 1);
-            this.sortCamerasByPriority();
+            sortPriority(this.cameras);
         }
-    }
-
-    sortCamerasByPriority() {
-        this.cameras.sort(function (a, b) {
-            return a.priority - b.priority;
-        });
     }
 
     destroy() {

--- a/src/scene/composition/layer-composition.js
+++ b/src/scene/composition/layer-composition.js
@@ -1,6 +1,7 @@
 import { Debug } from '../../core/debug.js';
 import { EventHandler } from '../../core/event-handler.js';
 import { set } from '../../core/set-utils.js';
+import { sortPriority } from '../../core/sort.js';
 
 import {
     LAYERID_DEPTH,
@@ -277,7 +278,7 @@ class LayerComposition extends EventHandler {
 
             // sort cameras by priority
             if (this.cameras.length > 1) {
-                this.cameras.sort((a, b) => a.priority - b.priority);
+                sortPriority(this.cameras);
             }
 
             // collect a list of layers this camera renders


### PR DESCRIPTION
A sort function doesn't act on true/false, so this never sorted anything (copy/paste test for F12/DevTools):

```js
transitions = [
  {priority: 10},
  {priority: 50},
  {priority: 1},
  {priority: 2},
  {priority: 100},
  {priority: 3},
];
transitions.sort(function (a, b) {
    return a.priority < b.priority;
});
console.log(transitions.map(_ => _.priority));
```

Result: `[10, 50, 1, 2, 100, 3]` (its fixable by replacing `<` with `-`)

And then priority sorting is used in multiple places, so this PR reduces the code size/repetition of the same sorting function by just reusing functions (imo saving time and hopefully less bugs)

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
