### PR TITLE
Remove unused auto instancing code

### DIFF
--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -1344,7 +1344,6 @@ class Application extends EventHandler {
         stats.sortTime = this.renderer._sortTime;
         stats.skinTime = this.renderer._skinTime;
         stats.morphTime = this.renderer._morphTime;
-        stats.instancingTime = this.renderer._instancingTime;
         stats.lightClusters = this.renderer._lightClusters;
         stats.lightClustersTime = this.renderer._lightClustersTime;
         stats.otherPrimitives = 0;
@@ -1364,7 +1363,6 @@ class Application extends EventHandler {
         this.renderer._sortTime = 0;
         this.renderer._skinTime = 0;
         this.renderer._morphTime = 0;
-        this.renderer._instancingTime = 0;
         this.renderer._shadowMapTime = 0;
         this.renderer._depthMapTime = 0;
         this.renderer._forwardTime = 0;
@@ -1387,7 +1385,6 @@ class Application extends EventHandler {
         this.renderer._skinDrawCalls = 0;
         this.renderer._immediateRendered = 0;
         this.renderer._instancedDrawCalls = 0;
-        this.renderer._removedByInstancing = 0;
 
         this.stats.misc.renderTargetCreationTime = this.graphicsDevice.renderTargetCreationTime;
 

--- a/src/graphics/webgl/webgl-graphics-device.js
+++ b/src/graphics/webgl/webgl-graphics-device.js
@@ -227,8 +227,6 @@ class WebglGraphicsDevice extends GraphicsDevice {
     constructor(canvas, options = {}) {
         super(canvas);
 
-        this._enableAutoInstancing = false;
-        this.autoInstancingMaxObjects = 16384;
         this.defaultFramebuffer = null;
 
         this.updateClientRect();
@@ -2774,20 +2772,6 @@ class WebglGraphicsDevice extends GraphicsDevice {
 
     get fullscreen() {
         return !!document.fullscreenElement;
-    }
-
-    /**
-     * Automatic instancing.
-     *
-     * @type {boolean}
-     * @ignore
-     */
-    set enableAutoInstancing(value) {
-        this._enableAutoInstancing = value && this.extInstancing;
-    }
-
-    get enableAutoInstancing() {
-        return this._enableAutoInstancing;
     }
 
     /**

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -8,15 +8,12 @@ import { Vec3 } from '../../math/vec3.js';
 import { BoundingSphere } from '../../shape/bounding-sphere.js';
 
 import {
-    BUFFER_DYNAMIC,
     CLEARFLAG_COLOR, CLEARFLAG_DEPTH, CLEARFLAG_STENCIL,
     CULLFACE_BACK, CULLFACE_FRONT, CULLFACE_FRONTANDBACK, CULLFACE_NONE,
     FUNC_ALWAYS, FUNC_LESSEQUAL,
     SEMANTIC_ATTR,
     STENCILOP_KEEP
 } from '../../graphics/constants.js';
-import { VertexBuffer } from '../../graphics/vertex-buffer.js';
-import { VertexFormat } from '../../graphics/vertex-format.js';
 import { DebugGraphics } from '../../graphics/debug-graphics.js';
 
 import {
@@ -73,8 +70,6 @@ let boneTexture, instancingData, modelMatrix, normalMatrix;
 
 let keyA, keyB;
 
-let _autoInstanceBuffer = null;
-
 let _skinUpdateIndex = 0;
 
 const _drawCallList = {
@@ -114,8 +109,6 @@ class ForwardRenderer {
         this._sortTime = 0;
         this._skinTime = 0;
         this._morphTime = 0;
-        this._instancingTime = 0;
-        this._removedByInstancing = 0;
         this._layerCompositionUpdateTime = 0;
         this._lightClustersTime = 0;
         this._lightClusters = 0;
@@ -1007,11 +1000,6 @@ class ForwardRenderer {
                 this._instancedDrawCalls++;
                 device.setVertexBuffer(instancingData.vertexBuffer);
                 device.draw(mesh.primitive[style], instancingData.count);
-                if (instancingData.vertexBuffer === _autoInstanceBuffer) {
-                    this._removedByInstancing += instancingData.count;
-                    meshInstance.instancingData = null;
-                    return instancingData.count - 1;
-                }
             }
         } else {
             modelMatrix = meshInstance.node.worldTransform;
@@ -1045,11 +1033,6 @@ class ForwardRenderer {
             if (instancingData.count > 0) {
                 this._instancedDrawCalls++;
                 device.draw(mesh.primitive[style], instancingData.count, true);
-                if (instancingData.vertexBuffer === _autoInstanceBuffer) {
-                    this._removedByInstancing += instancingData.count;
-                    meshInstance.instancingData = null;
-                    return instancingData.count - 1;
-                }
             }
         } else {
             // matrices are already set
@@ -1531,14 +1514,6 @@ class ForwardRenderer {
         // #if _PROFILER
         this._forwardTime += now() - forwardStartTime;
         // #endif
-    }
-
-    setupInstancing(device) {
-        if (device.enableAutoInstancing) {
-            if (!_autoInstanceBuffer) {
-                _autoInstanceBuffer = new VertexBuffer(device, VertexFormat.defaultInstancingFormat, device.autoInstancingMaxObjects, BUFFER_DYNAMIC);
-            }
-        }
     }
 
     updateShaders(drawCalls, onlyLitShaders) {

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -1019,8 +1019,6 @@ class ForwardRenderer {
         }
 
         DebugGraphics.popGpuMarker(device);
-
-        return 0;
     }
 
     // used for stereo
@@ -1040,8 +1038,6 @@ class ForwardRenderer {
         }
 
         DebugGraphics.popGpuMarker(device);
-
-        return 0;
     }
 
     renderShadows(lights, camera) {
@@ -1458,7 +1454,7 @@ class ForwardRenderer {
                     this.viewProjId.setValue(viewProjMatL.data);
                     this.dispatchViewPos(viewPosL);
 
-                    i += this.drawInstance(device, drawCall, mesh, style, true);
+                    this.drawInstance(device, drawCall, mesh, style, true);
                     this._forwardDrawCalls++;
 
                     // Right
@@ -1471,7 +1467,7 @@ class ForwardRenderer {
                     this.viewProjId.setValue(viewProjMatR.data);
                     this.dispatchViewPos(viewPosR);
 
-                    i += this.drawInstance2(device, drawCall, mesh, style);
+                    this.drawInstance2(device, drawCall, mesh, style);
                     this._forwardDrawCalls++;
                 } else if (camera.xr && camera.xr.session && camera.xr.views.length) {
                     const views = camera.xr.views;
@@ -1490,15 +1486,15 @@ class ForwardRenderer {
                         this.viewPosId.setValue(view.position);
 
                         if (v === 0) {
-                            i += this.drawInstance(device, drawCall, mesh, style, true);
+                            this.drawInstance(device, drawCall, mesh, style, true);
                         } else {
-                            i += this.drawInstance2(device, drawCall, mesh, style);
+                            this.drawInstance2(device, drawCall, mesh, style);
                         }
 
                         this._forwardDrawCalls++;
                     }
                 } else {
-                    i += this.drawInstance(device, drawCall, mesh, style, true);
+                    this.drawInstance(device, drawCall, mesh, style, true);
                     this._forwardDrawCalls++;
                 }
 

--- a/src/scene/renderer/shadow-renderer.js
+++ b/src/scene/renderer/shadow-renderer.js
@@ -504,7 +504,7 @@ class ShadowRenderer {
             device.setIndexBuffer(mesh.indexBuffer[style]);
 
             // draw
-            i += forwardRenderer.drawInstance(device, meshInstance, mesh, style);
+            forwardRenderer.drawInstance(device, meshInstance, mesh, style);
             forwardRenderer._shadowDrawCalls++;
         }
     }


### PR DESCRIPTION
Code doesn't do anything and was left from the past.

Removing the `enableAutoInstancing` getter and setter could be a breaking change for users still calling these methods (even though they don't do anything).

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
