### PR TITLE
Fix AudioContext not being properly resumed on iOS 15.

### DIFF
--- a/src/sound/manager.js
+++ b/src/sound/manager.js
@@ -55,7 +55,9 @@ class SoundManager extends EventHandler {
         this._forceWebAudioApi = options.forceWebAudioApi;
 
         this._resumeContext = null;
+        this._resumeContextAttached = false;
         this._unlock = null;
+        this._unlockAttached = false;
 
         if (hasAudioContext() || this._forceWebAudioApi) {
             this._addAudioContextUserInteractionListeners();
@@ -139,13 +141,13 @@ class SoundManager extends EventHandler {
     }
 
     destroy() {
-        if (this._resumeContext && !!this._resumeContextIsAttached) {
+        if (this._resumeContext && this._resumeContextAttached) {
             USER_INPUT_EVENTS.forEach((eventName) => {
                 window.removeEventListener(eventName, this._resumeContext);
             });
         }
 
-        if (this._unlock && !!this._unlockAttached) {
+        if (this._unlock && this._unlockAttached) {
             window.removeEventListener('touchend', this._unlock);
         }
 
@@ -257,19 +259,19 @@ class SoundManager extends EventHandler {
                         window.removeEventListener(eventName, this._resumeContext);
                     });
 
-                    this._resumeContextIsAttached = false;
+                    this._resumeContextAttached = false;
                 } else {
                     this.context.resume();
                 }
             };
         }
 
-        if (!this._resumeContextIsAttached) {
+        if (!this._resumeContextAttached) {
             USER_INPUT_EVENTS.forEach((eventName) => {
                 window.addEventListener(eventName, this._resumeContext);
             });
 
-            this._resumeContextIsAttached = true;
+            this._resumeContextAttached = true;
         }
 
         // iOS only starts sound as a response to user interaction

--- a/src/sound/manager.js
+++ b/src/sound/manager.js
@@ -254,7 +254,7 @@ class SoundManager extends EventHandler {
         // resume AudioContext on user interaction because of autoplay policy
         if (!this._resumeContext) {
             this._resumeContext = () => {
-                if (!this.context || this.context.state === 'running') {
+                if (!this.context || this.context.state === CONTEXT_STATE_RUNNING) {
                     USER_INPUT_EVENTS.forEach((eventName) => {
                         window.removeEventListener(eventName, this._resumeContext);
                     });

--- a/src/sound/manager.js
+++ b/src/sound/manager.js
@@ -127,11 +127,15 @@ class SoundManager extends EventHandler {
                 if (this._context) {
                     this._state = this._context.state;
 
-                    // When the browser window loses focus (i.e. switching tab, hiding the app on mobile, etc), the AudioContext state
-                    // will be set to 'interrupted' (on iOS Safari) or 'suspended' (on other browsers), and 'resume' must be expliclty called.
+                    // When the browser window loses focus (i.e. switching tab, hiding the app on mobile, etc),
+                    // the AudioContext state will be set to 'interrupted' (on iOS Safari) or 'suspended'(on other
+                    // browsers), and 'resume' must be expliclty called.
                     this._context.onstatechange = () => {
-                        // _context.state will have the state its transitioning to, while _state contains the current state
-                        if ((this._state === 'suspended' || this._state === 'interrupted') && this._context.state === 'running') {
+                        if (!this._context) return;
+
+                        // _context.state will have the state its transitioning to, and _state is the current state
+                        if ((this._state === 'suspended' || this._state === 'interrupted') &&
+                            this._context.state === 'running') {
                             // explicitly call .resume() when going from suspended or interrupted to running
                             this._context.resume();
                         }
@@ -155,9 +159,9 @@ class SoundManager extends EventHandler {
             this.fire('resume');
         };
 
-        // When the browser window loses focus (i.e. switching tab, hiding the app on mobile, etc), the AudioContext state
-        // will be set to 'interrupted' (on iOS Safari) or 'suspended' (on other browsers), and 'resume' must be called.
-        // If the AudioContext has not yet been resumed, call for a resume.
+        // When the browser window loses focus (i.e. switching tab, hiding the app on mobile, etc), the AudioContext
+        // state will be set to 'interrupted' (on iOS Safari) or 'suspended' (on other browsers), and 'resume' must
+        // be called. If the AudioContext has not yet been resumed, call for a resume.
         if ((hasAudioContext() || this._forceWebAudioApi) && this._context &&
             (this._state === 'interrupted' || this._state === 'suspended')) {
             this.context.resume().then(resumeFunction);

--- a/src/sound/manager.js
+++ b/src/sound/manager.js
@@ -32,7 +32,9 @@ class SoundManager extends EventHandler {
          */
         this._context = null;
         /**
-         * @type {string} the current state of the underlying AudioContext
+         * The current state of the underlying AudioContext.
+         *
+         * @type {string}
          * @private
          */
         this._state = 'not created';
@@ -121,19 +123,21 @@ class SoundManager extends EventHandler {
                 } else if (typeof webkitAudioContext !== 'undefined') {
                     this._context = new webkitAudioContext();
                 }
-                this._state = this._context.state;
 
-                // When the browser window looses focus (i.e. switching tab, hiding the app on Mobile, etc), the AudioContext state
-                // will be set to 'interrupted' (on iOS Safari) or 'suspended' (on other browsers), and 'resume' must be expliclty called.
-                const self = this;
-                this._context.onstatechange = function () {
-                    // _context.state will have the state its transitioning to, while _state contains the current state
-                    if ((self._state === 'suspended' || self._state === 'interrupted') && self._context.state === 'running') {
-                        // explicitly call .resume() when going from suspended or interrupted to running
-                        self._context.resume();
-                    }
-                    self._state = self._context.state;
-                };
+                if (this._context) {
+                    this._state = this._context.state;
+
+                    // When the browser window loses focus (i.e. switching tab, hiding the app on mobile, etc), the AudioContext state
+                    // will be set to 'interrupted' (on iOS Safari) or 'suspended' (on other browsers), and 'resume' must be expliclty called.
+                    this._context.onstatechange = () => {
+                        // _context.state will have the state its transitioning to, while _state contains the current state
+                        if ((this._state === 'suspended' || this._state === 'interrupted') && this._context.state === 'running') {
+                            // explicitly call .resume() when going from suspended or interrupted to running
+                            this._context.resume();
+                        }
+                        this._state = this._context.state;
+                    };
+                }
             }
         }
 
@@ -151,7 +155,7 @@ class SoundManager extends EventHandler {
             this.fire('resume');
         };
 
-        // When the browser window looses focus (i.e. switching tab, hiding the app on Mobile, etc), the AudioContext state
+        // When the browser window loses focus (i.e. switching tab, hiding the app on mobile, etc), the AudioContext state
         // will be set to 'interrupted' (on iOS Safari) or 'suspended' (on other browsers), and 'resume' must be called.
         // If the AudioContext has not yet been resumed, call for a resume.
         if ((hasAudioContext() || this._forceWebAudioApi) && this._context &&


### PR DESCRIPTION
Fixes https://github.com/playcanvas/engine/issues/3977

Fix issues on the `AudioContext` not being properly resumed, especially on iOS 15. This is done by explicitly calling `.resume()` on the `AudioContext` when required. Extra checks were added to make sure `resume` is only called when the window is being re-focused, and the state is going from `suspended` or `interrupted` back to `running` - otherwise exceptions are thrown. Additionally, if for any reason the context can't be resumed successfully, the Auto-Play event listeners are re-bound so that the audio can be resumed later.

Documentation:
- https://developer.mozilla.org/en-US/docs/Web/API/AudioContext
- https://developer.mozilla.org/en-US/docs/Web/API/BaseAudioContext/state
- https://developer.mozilla.org/en-US/docs/Web/API/BaseAudioContext/statechange_event
- https://developer.mozilla.org/en-US/docs/Web/API/AudioContext/resume
- https://developers.google.com/web/updates/2018/11/web-audio-autoplay


As far as I could test, this new code behaves well with all of our current target devices and browsers, but we could also consider using external libraries for this kind of stuff, such as the ones below (pending analysis, of course).
- https://github.com/chrisguttandin/standardized-audio-context
- https://howlerjs.com/


New test scenarios in Safari iOS 15:
- Launch game with audio, change Tabs (audio stops), change back to game (audio resumes)
- Launch game with audio, close Safari (audio stops), wait some time (from immediate to around 40 seconds), open Safari (audio resumes)
- Launch game with audio, wait for 30 second auto-lock (audio stops), wait some time (from immediate to around 40 seconds), unlock phone (audio resumes)
- Launch game with audio, close browser, lock phone. Go back several minutes later: requires interaction due to auto-play policy.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
