### PR TITLE
Lightmapper fixes

### DIFF
--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -1606,7 +1606,7 @@ class Application extends EventHandler {
      *
      * @param {boolean} settings.render.ambientBake - Enable baking ambient light into lightmaps.
      * @param {number} settings.render.ambientBakeNumSamples - Number of samples to use when baking ambient light.
-     * @param {number} settings.render.ambientBakeSpherePart - Which part of the sphere to bake.
+     * @param {number} settings.render.ambientBakeSpherePart - How much of the sphere to include when baking ambient light.
      * @param {number} settings.render.ambientBakeOcclusionBrightness - Brighness of the baked ambient occlusion.
      * @param {number} settings.render.ambientBakeOcclusionContrast - Contrast of the baked ambient occlusion.
      *

--- a/src/scene/lightmapper/bake-light-ambient.js
+++ b/src/scene/lightmapper/bake-light-ambient.js
@@ -25,7 +25,8 @@ class BakeLightAmbient extends BakeLight {
             shadowResolution: 2048,
             shadowType: SHADOW_PCF3,
             color: Color.WHITE,
-            intensity: 1
+            intensity: 1,
+            bakeDir: false
         });
 
         super(scene, lightEntity.light.light);

--- a/src/scene/lightmapper/lightmapper.js
+++ b/src/scene/lightmapper/lightmapper.js
@@ -985,7 +985,7 @@ class Lightmapper {
             let numVirtualLights = bakeLight.numVirtualLights;
 
             // direction baking is not currently compatible with virtual lights, as we end up with no valid direction in lights penumbra
-            if (passCount > 1 && numVirtualLights > 1) {
+            if (passCount > 1 && numVirtualLights > 1 && bakeLight.light.bakeDir) {
                 numVirtualLights = 1;
                 Debug.warn("Lightmapper's BAKE_COLORDIR mode is not compatible with Light's bakeNumSamples larger than one. Forcing it to one.");
             }

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -620,18 +620,21 @@ class Scene extends EventHandler {
             this._skyboxRotation.setFromEulerAngles(render.skyboxRotation[0], render.skyboxRotation[1], render.skyboxRotation[2]);
         }
 
-        const apply = (name) => {
-            if (render.hasOwnProperty(name)) {
-                this[name] = render[name];
+        // bake settings
+        [
+            'lightmapFilterEnable',
+            'lightmapFilterRange',
+            'lightmapFilterSmoothness',
+            'ambientBake',
+            'ambientBakeNumSamples',
+            'ambientBakeSpherePart',
+            'ambientBakeOcclusionBrightness',
+            'ambientBakeOcclusionContrast'
+        ].forEach(setting => {
+            if (render.hasOwnProperty(setting)) {
+                this[setting] = render[setting];
             }
-        };
-
-        // bake
-        apply('ambientBake');
-        apply('ambientBakeNumSamples');
-        apply('ambientBakeSpherePart');
-        apply('ambientBakeOcclusionBrightness');
-        apply('ambientBakeOcclusionContrast');
+        });
 
         this._resetSkyboxModel();
     }

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -630,7 +630,7 @@ class Scene extends EventHandler {
             'ambientBakeSpherePart',
             'ambientBakeOcclusionBrightness',
             'ambientBakeOcclusionContrast'
-        ].forEach(setting => {
+        ].forEach((setting) => {
             if (render.hasOwnProperty(setting)) {
                 this[setting] = render[setting];
             }


### PR DESCRIPTION
This PR fixes the case where directional light and ambient light baking wasn't working when lightmap type color + direction was selected globally.

Also added support for the following scene lightmapper settings:
- lightmapFilterEnable
- lightmapFilterRange
- lightmapFilterSmoothness