### PR TITLE
Capitalize callback types

### DIFF
--- a/src/asset/asset-registry.js
+++ b/src/asset/asset-registry.js
@@ -14,7 +14,7 @@ import { Asset } from './asset.js';
 /**
  * Callback used by {@link AssetRegistry#filter} to filter assets.
  *
- * @callback filterAssetCallback
+ * @callback FilterAssetCallback
  * @param {Asset} asset - The current asset to filter.
  * @returns {boolean} Return `true` to include asset to result list.
  */
@@ -23,7 +23,7 @@ import { Asset } from './asset.js';
  * Callback used by {@link AssetRegistry#loadFromUrl} and called when an asset is loaded (or an
  * error occurs).
  *
- * @callback loadAssetCallback
+ * @callback LoadAssetCallback
  * @param {string|null} err - The error message is null if no errors were encountered.
  * @param {Asset} [asset] - The loaded asset if no errors were encountered.
  */
@@ -424,7 +424,7 @@ class AssetRegistry extends EventHandler {
      *
      * @param {string} url - The url to load.
      * @param {string} type - The type of asset to load.
-     * @param {loadAssetCallback} callback - Function called when asset is loaded, passed (err,
+     * @param {LoadAssetCallback} callback - Function called when asset is loaded, passed (err,
      * asset), where err is null if no errors were encountered.
      * @example
      * app.assets.loadFromUrl("../path/to/texture.jpg", "texture", function (err, asset) {
@@ -443,7 +443,7 @@ class AssetRegistry extends EventHandler {
      * @param {string} url - The url to load.
      * @param {string} filename - The filename of the asset to load.
      * @param {string} type - The type of asset to load.
-     * @param {loadAssetCallback} callback - Function called when asset is loaded, passed (err,
+     * @param {LoadAssetCallback} callback - Function called when asset is loaded, passed (err,
      * asset), where err is null if no errors were encountered.
      * @example
      * var file = magicallyAttainAFile();
@@ -656,7 +656,7 @@ class AssetRegistry extends EventHandler {
     /**
      * Return all Assets that satisfy a filter callback.
      *
-     * @param {filterAssetCallback} callback - The callback function that is used to filter assets.
+     * @param {FilterAssetCallback} callback - The callback function that is used to filter assets.
      * Return `true` to include an asset in the returned array.
      * @returns {Asset[]} A list of all Assets found.
      * @example

--- a/src/asset/asset.js
+++ b/src/asset/asset.js
@@ -11,7 +11,7 @@ import { getApplication } from '../framework/globals.js';
 import { http } from '../net/http.js';
 
 /** @typedef {import('./asset-registry.js').AssetRegistry} AssetRegistry */
-/** @typedef {import('../resources/loader.js').resourceLoaderCallback} resourceLoaderCallback */
+/** @typedef {import('../resources/loader.js').ResourceLoaderCallback} ResourceLoaderCallback */
 
 // auto incrementing number for asset ids
 let assetIdCounter = -1;
@@ -29,7 +29,7 @@ const VARIANT_DEFAULT_PRIORITY = ['pvr', 'dxt', 'etc2', 'etc1', 'basis'];
 /**
  * Callback used by {@link Asset#ready} and called when an asset is ready.
  *
- * @callback assetReadyCallback
+ * @callback AssetReadyCallback
  * @param {Asset} asset - The ready asset.
  */
 
@@ -450,7 +450,7 @@ class Asset extends EventHandler {
      * Take a callback which is called as soon as the asset is loaded. If the asset is already
      * loaded the callback is called straight away.
      *
-     * @param {assetReadyCallback} callback - The function called when the asset is ready. Passed
+     * @param {AssetReadyCallback} callback - The function called when the asset is ready. Passed
      * the (asset) arguments.
      * @param {object} [scope] - Scope object to use when calling the callback.
      * @example
@@ -521,7 +521,7 @@ class Asset extends EventHandler {
      * via http.
      *
      * @param {string} loadUrl - The URL as passed into the handler
-     * @param {resourceLoaderCallback} callback - The callback function to receive results.
+     * @param {ResourceLoaderCallback} callback - The callback function to receive results.
      * @param {Asset} [asset] - The asset
      * @param {number} maxRetries - Number of retries if http download is required
      * @ignore

--- a/src/core/event-handler.js
+++ b/src/core/event-handler.js
@@ -1,7 +1,7 @@
 /**
  * Callback used by {@link EventHandler} functions. Note the callback is limited to 8 arguments.
  *
- * @callback handleEventCallback
+ * @callback HandleEventCallback
  * @param {*} [arg1] - First argument that is passed from caller.
  * @param {*} [arg2] - Second argument that is passed from caller.
  * @param {*} [arg3] - Third argument that is passed from caller.
@@ -57,7 +57,7 @@ class EventHandler {
      * Registers a new event handler.
      *
      * @param {string} name - Name of the event to bind the callback to.
-     * @param {handleEventCallback} callback - Function that is called when event is fired. Note
+     * @param {HandleEventCallback} callback - Function that is called when event is fired. Note
      * the callback is limited to 8 arguments.
      * @param {object} [scope] - Object to use as 'this' when the event is fired, defaults to
      * current this.
@@ -85,7 +85,7 @@ class EventHandler {
      * Attach an event handler to an event.
      *
      * @param {string} name - Name of the event to bind the callback to.
-     * @param {handleEventCallback} callback - Function that is called when event is fired. Note
+     * @param {HandleEventCallback} callback - Function that is called when event is fired. Note
      * the callback is limited to 8 arguments.
      * @param {object} [scope] - Object to use as 'this' when the event is fired, defaults to
      * current this.
@@ -108,7 +108,7 @@ class EventHandler {
      * unbound.
      *
      * @param {string} [name] - Name of the event to unbind.
-     * @param {handleEventCallback} [callback] - Function to be unbound.
+     * @param {HandleEventCallback} [callback] - Function to be unbound.
      * @param {object} [scope] - Scope that was used as the this when the event is fired.
      * @returns {EventHandler} Self for chaining.
      * @example
@@ -228,7 +228,7 @@ class EventHandler {
      * Attach an event handler to an event. This handler will be removed after being fired once.
      *
      * @param {string} name - Name of the event to bind the callback to.
-     * @param {handleEventCallback} callback - Function that is called when event is fired. Note
+     * @param {HandleEventCallback} callback - Function that is called when event is fired. Note
      * the callback is limited to 8 arguments.
      * @param {object} [scope] - Object to use as 'this' when the event is fired, defaults to
      * current this.

--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -152,14 +152,14 @@ class Progress {
  * Callback used by {@link Application#configure} when configuration file is loaded and parsed (or
  * an error occurs).
  *
- * @callback configureAppCallback
+ * @callback ConfigureAppCallback
  * @param {string|null} err - The error message in the case where the loading or parsing fails.
  */
 
 /**
  * Callback used by {@link Application#preload} when all assets (marked as 'preload') are loaded.
  *
- * @callback preloadAppCallback
+ * @callback PreloadAppCallback
  */
 
 let app = null;
@@ -785,7 +785,7 @@ class Application extends EventHandler {
      * registry.
      *
      * @param {string} url - The URL of the configuration file to load.
-     * @param {configureAppCallback} callback - The Function called when the configuration file is
+     * @param {ConfigureAppCallback} callback - The Function called when the configuration file is
      * loaded and parsed (or an error occurs).
      */
     configure(url, callback) {
@@ -814,7 +814,7 @@ class Application extends EventHandler {
     /**
      * Load all assets in the asset registry that are marked as 'preload'.
      *
-     * @param {preloadAppCallback} callback - Function called when all assets are loaded.
+     * @param {PreloadAppCallback} callback - Function called when all assets are loaded.
      */
     preload(callback) {
         this.fire("preload:start");

--- a/src/framework/components/camera/component.js
+++ b/src/framework/components/camera/component.js
@@ -11,7 +11,7 @@ import { PostEffectQueue } from './post-effect-queue.js';
 /** @typedef {import('../../../math/vec3.js').Vec3} Vec3 */
 /** @typedef {import('../../../math/vec4.js').Vec4} Vec4 */
 /** @typedef {import('../../../shape/frustum.js').Frustum} Frustum */
-/** @typedef {import('../../../xr/xr-manager.js').xrErrorCallback} xrErrorCallback */
+/** @typedef {import('../../../xr/xr-manager.js').XrErrorCallback} XrErrorCallback */
 /** @typedef {import('../../entity.js').Entity} Entity */
 /** @typedef {import('./system.js').CameraComponentSystem} CameraComponentSystem */
 
@@ -38,7 +38,7 @@ const properties = [
 /**
  * Callback used by {@link CameraComponent#calculateTransform} and {@link CameraComponent#calculateProjection}.
  *
- * @callback calculateMatrixCallback
+ * @callback CalculateMatrixCallback
  * @param {Mat4} transformMatrix - Output of the function.
  * @param {number} view - Type of view. Can be {@link VIEW_CENTER}, {@link VIEW_LEFT} or {@link VIEW_RIGHT}. Left and right are only used in stereo rendering.
  */
@@ -46,7 +46,7 @@ const properties = [
 /**
  * Callback used by {@link CameraComponent#enterVr} and {@link CameraComponent#exitVr}.
  *
- * @callback vrCameraCallback
+ * @callback VrCameraCallback
  * @param {string|null} err - On success it is null on failure it is the error message.
  */
 
@@ -107,7 +107,7 @@ const properties = [
  * @property {boolean} frustumCulling Controls the culling of mesh instances against the camera
  * frustum, i.e. if objects outside of camera should be omitted from rendering. If false, all mesh
  * instances in the scene are rendered by the camera, regardless of visibility. Defaults to false.
- * @property {calculateMatrixCallback} calculateTransform Custom function you can provide to
+ * @property {CalculateMatrixCallback} calculateTransform Custom function you can provide to
  * calculate the camera transformation matrix manually. Can be used for complex effects like
  * reflections. Function is called using component's scope. Arguments:
  *
@@ -115,7 +115,7 @@ const properties = [
  * - view: Type of view. Can be {@link VIEW_CENTER}, {@link VIEW_LEFT} or {@link VIEW_RIGHT}.
  *
  * Left and right are only used in stereo rendering.
- * @property {calculateMatrixCallback} calculateProjection Custom function you can provide to
+ * @property {CalculateMatrixCallback} calculateProjection Custom function you can provide to
  * calculate the camera projection matrix manually. Can be used for complex effects like doing
  * oblique projection. Function is called using component's scope. Arguments:
  *
@@ -532,7 +532,7 @@ class CameraComponent extends Component {
      * @function
      * @name CameraComponent#enterVr
      * @description Attempt to start presenting this camera to a {@link VrDisplay}.
-     * @param {vrCameraCallback} callback - Function called once to indicate success
+     * @param {VrCameraCallback} callback - Function called once to indicate success
      * of failure. The callback takes one argument (err).
      * On success it returns null on failure it returns the error message.
      * @example
@@ -554,7 +554,7 @@ class CameraComponent extends Component {
      * @description Attempt to start presenting this camera to a {@link VrDisplay}.
      * @param {VrDisplay} display - The VrDisplay to present. If not supplied this uses
      * {@link VrManager#display} as the default.
-     * @param {vrCameraCallback} callback - Function called once to indicate success
+     * @param {VrCameraCallback} callback - Function called once to indicate success
      * of failure. The callback takes one argument (err). On success it returns null on
      * failure it returns the error message.
      * @example
@@ -613,7 +613,7 @@ class CameraComponent extends Component {
     /**
      * Attempt to stop presenting this camera.
      *
-     * @param {vrCameraCallback} callback - Function called once to indicate success of failure.
+     * @param {VrCameraCallback} callback - Function called once to indicate success of failure.
      * The callback takes one argument (err). On success it returns null on failure it returns the
      * error message.
      * @example
@@ -675,7 +675,7 @@ class CameraComponent extends Component {
      * used for getting access to additional WebXR spec extensions.
      * @param {boolean} [options.imageTracking] - Set to true to attempt to enable {@link XrImageTracking}.
      * @param {boolean} [options.planeDetection] - Set to true to attempt to enable {@link XrPlaneDetection}.
-     * @param {xrErrorCallback} [options.callback] - Optional callback function called once the
+     * @param {XrErrorCallback} [options.callback] - Optional callback function called once the
      * session is started. The callback has one argument Error - it is null if the XR session
      * started successfully.
      * @param {object} [options.depthSensing] - Optional object with depth sensing parameters to
@@ -707,7 +707,7 @@ class CameraComponent extends Component {
     /**
      * Attempt to end XR session of this camera.
      *
-     * @param {xrErrorCallback} [callback] - Optional callback function called once session is
+     * @param {XrErrorCallback} [callback] - Optional callback function called once session is
      * ended. The callback has one argument Error - it is null if successfully ended XR session.
      * @example
      * // On an entity with a camera component

--- a/src/framework/scene-registry.js
+++ b/src/framework/scene-registry.js
@@ -11,7 +11,7 @@ import { SceneRegistryItem } from './scene-registry-item.js';
 /**
  * Callback used by {@link SceneRegistry#loadSceneHierarchy}.
  *
- * @callback loadHierarchyCallback
+ * @callback LoadHierarchyCallback
  * @param {string|null} err - The error message in the case where the loading or parsing fails.
  * @param {Entity} [entity] - The loaded root entity if no errors were encountered.
  */
@@ -19,14 +19,14 @@ import { SceneRegistryItem } from './scene-registry-item.js';
 /**
  * Callback used by {@link SceneRegistry#loadSceneSettings}.
  *
- * @callback loadSettingsCallback
+ * @callback LoadSettingsCallback
  * @param {string|null} err - The error message in the case where the loading or parsing fails.
  */
 
 /**
  * Callback used by {@link SceneRegistry#loadScene}.
  *
- * @callback loadSceneCallback
+ * @callback LoadSceneCallback
  * @param {string|null} err - The error message in the case where the loading or parsing fails.
  * @param {Entity} [entity] - The loaded root entity if no errors were encountered.
  */
@@ -34,7 +34,7 @@ import { SceneRegistryItem } from './scene-registry-item.js';
 /**
  * Callback used by {@link SceneRegistry#loadSceneData}.
  *
- * @callback loadSceneDataCallback
+ * @callback LoadSceneDataCallback
  * @param {string|null} err - The error message in the case where the loading or parsing fails.
  * @param {SceneRegistryItem} [sceneItem] - The scene registry item if no errors were encountered.
  */
@@ -220,7 +220,7 @@ class SceneRegistry {
      *
      * @param {SceneRegistryItem | string} sceneItem - The scene item (which can be found with
      * {@link SceneRegistry#find} or URL of the scene file. Usually this will be "scene_id.json".
-     * @param {loadSceneDataCallback} callback - The function to call after loading,
+     * @param {LoadSceneDataCallback} callback - The function to call after loading,
      * passed (err, sceneItem) where err is null if no errors occurred.
      * @example
      * var sceneItem = app.scenes.find("Scene Name");
@@ -259,7 +259,7 @@ class SceneRegistry {
      *
      * @param {SceneRegistryItem | string} sceneItem - The scene item (which can be found with
      * {@link SceneRegistry#find} or URL of the scene file. Usually this will be "scene_id.json".
-     * @param {loadHierarchyCallback} callback - The function to call after loading,
+     * @param {LoadHierarchyCallback} callback - The function to call after loading,
      * passed (err, entity) where err is null if no errors occurred.
      * @example
      * var sceneItem = app.scenes.find("Scene Name");
@@ -318,7 +318,7 @@ class SceneRegistry {
      *
      * @param {SceneRegistryItem | string} sceneItem - The scene item (which can be found with
      * {@link SceneRegistry#find} or URL of the scene file. Usually this will be "scene_id.json".
-     * @param {loadSettingsCallback} callback - The function called after the settings
+     * @param {LoadSettingsCallback} callback - The function called after the settings
      * are applied. Passed (err) where err is null if no error occurred.
      * @example
      * var sceneItem = app.scenes.find("Scene Name");
@@ -352,7 +352,7 @@ class SceneRegistry {
      * {@link Application}.
      *
      * @param {string} url - The URL of the scene file.
-     * @param {loadSceneCallback} callback - The function called after the settings are
+     * @param {LoadSceneCallback} callback - The function called after the settings are
      * applied. Passed (err, scene) where err is null if no error occurred and scene is the
      * {@link Scene}.
      */

--- a/src/framework/script.js
+++ b/src/framework/script.js
@@ -9,14 +9,14 @@ import { getApplication } from './globals.js';
 /**
  * Callback used by {@link script.createLoadingScreen}.
  *
- * @callback createScreenCallback
+ * @callback CreateScreenCallback
  * @param {Application} app - The application.
  */
 
 /**
  * Callback used by {@link script.create}.
  *
- * @callback createScriptCallback
+ * @callback CreateScriptCallback
  * @param {Application} app - The application.
  * @returns {object} Return the Type of the script resource to be instanced for each Entity.
  * @ignore
@@ -44,7 +44,7 @@ const script = {
      * instantiated when attached to Entities.
      *
      * @param {string} name - The name of the script object.
-     * @param {createScriptCallback} callback - The callback function which is passed an
+     * @param {CreateScriptCallback} callback - The callback function which is passed an
      * {@link Application} object, which is used to access Entities and Components, and should
      * return the Type of the script resource to be instanced for each Entity.
      * @example
@@ -144,7 +144,7 @@ const script = {
      * this to work you need to set the project's loading screen script to the script that calls
      * this method.
      *
-     * @param {createScreenCallback} callback - A function which can set up and tear down a
+     * @param {CreateScreenCallback} callback - A function which can set up and tear down a
      * customized loading screen.
      * @example
      * pc.script.createLoadingScreen(function (app) {

--- a/src/input/mouse.js
+++ b/src/input/mouse.js
@@ -36,7 +36,7 @@ import { isMousePointerLocked, MouseEvent } from './mouse-event.js';
 /**
  * Callback used by {@link Mouse#enablePointerLock} and {@link Application#disablePointerLock}.
  *
- * @callback lockMouseCallback
+ * @callback LockMouseCallback
  */
 
 /**
@@ -143,9 +143,9 @@ class Mouse extends EventHandler {
      * - Enabling pointer lock can only be initiated by a user action e.g. in the event handler for
      * a mouse or keyboard input.
      *
-     * @param {lockMouseCallback} [success] - Function called if the request for mouse lock is
+     * @param {LockMouseCallback} [success] - Function called if the request for mouse lock is
      * successful.
-     * @param {lockMouseCallback} [error] - Function called if the request for mouse lock is
+     * @param {LockMouseCallback} [error] - Function called if the request for mouse lock is
      * unsuccessful.
      */
     enablePointerLock(success, error) {
@@ -179,7 +179,7 @@ class Mouse extends EventHandler {
     /**
      * Return control of the mouse cursor to the user.
      *
-     * @param {lockMouseCallback} [success] - Function called when the mouse lock is disabled.
+     * @param {LockMouseCallback} [success] - Function called when the mouse lock is disabled.
      */
     disablePointerLock(success) {
         if (!document.exitPointerLock) {

--- a/src/net/http.js
+++ b/src/net/http.js
@@ -9,7 +9,7 @@ import { math } from '../math/math.js';
  * Callback used by {@link Http#get}, {@link Http#post}, {@link Http#put}, {@link Http#del}, and
  * {@link Http#request}.
  *
- * @callback httpResponseCallback
+ * @callback HttpResponseCallback
  * @param {number|string|Error|null} err - The error code, message, or exception in the case where the request fails.
  * @param {*} [response] - The response data if no errors were encountered. (format depends on response type: text, Object, ArrayBuffer, XML).
  */
@@ -65,7 +65,7 @@ class Http {
      * @name Http#get
      * @description Perform an HTTP GET request to the given url.
      * @param {string} url - The URL to make the request to.
-     * @param {httpResponseCallback} callback - The callback used when the response has returned. Passed (err, data)
+     * @param {HttpResponseCallback} callback - The callback used when the response has returned. Passed (err, data)
      * where data is the response (format depends on response type: text, Object, ArrayBuffer, XML) and
      * err is the error code.
      * @example
@@ -93,7 +93,7 @@ class Http {
      * @param {boolean} [options.retry] - If true then if the request fails it will be retried with an exponential backoff.
      * @param {number} [options.maxRetries] - If options.retry is true this specifies the maximum number of retries. Defaults to 5.
      * @param {number} [options.maxRetryDelay] - If options.retry is true this specifies the maximum amount of time to wait between retries in milliseconds. Defaults to 5000.
-     * @param {httpResponseCallback} callback - The callback used when the response has returned. Passed (err, data)
+     * @param {HttpResponseCallback} callback - The callback used when the response has returned. Passed (err, data)
      * where data is the response (format depends on response type: text, Object, ArrayBuffer, XML) and
      * err is the error code.
      * @example
@@ -119,7 +119,7 @@ class Http {
      * Some content types are handled automatically. If postdata is an XML Document, it is handled. If
      * the Content-Type header is set to 'application/json' then the postdata is JSON stringified.
      * Otherwise, by default, the data is sent as form-urlencoded.
-     * @param {httpResponseCallback} callback - The callback used when the response has returned. Passed (err, data)
+     * @param {HttpResponseCallback} callback - The callback used when the response has returned. Passed (err, data)
      * where data is the response (format depends on response type: text, Object, ArrayBuffer, XML) and
      * err is the error code.
      * @example
@@ -147,7 +147,7 @@ class Http {
      * @param {boolean} [options.retry] - If true then if the request fails it will be retried with an exponential backoff.
      * @param {number} [options.maxRetries] - If options.retry is true this specifies the maximum number of retries. Defaults to 5.
      * @param {number} [options.maxRetryDelay] - If options.retry is true this specifies the maximum amount of time to wait between retries in milliseconds. Defaults to 5000.
-     * @param {httpResponseCallback} callback - The callback used when the response has returned. Passed (err, data)
+     * @param {HttpResponseCallback} callback - The callback used when the response has returned. Passed (err, data)
      * where data is the response (format depends on response type: text, Object, ArrayBuffer, XML) and
      * err is the error code.
      * @example
@@ -174,7 +174,7 @@ class Http {
      * Some content types are handled automatically. If postdata is an XML Document, it is handled. If
      * the Content-Type header is set to 'application/json' then the postdata is JSON stringified.
      * Otherwise, by default, the data is sent as form-urlencoded.
-     * @param {httpResponseCallback} callback - The callback used when the response has returned. Passed (err, data)
+     * @param {HttpResponseCallback} callback - The callback used when the response has returned. Passed (err, data)
      * where data is the response (format depends on response type: text, Object, ArrayBuffer, XML) and
      * err is the error code.
      * @example
@@ -202,7 +202,7 @@ class Http {
      * @param {boolean} [options.retry] - If true then if the request fails it will be retried with an exponential backoff.
      * @param {number} [options.maxRetries] - If options.retry is true this specifies the maximum number of retries. Defaults to 5.
      * @param {number} [options.maxRetryDelay] - If options.retry is true this specifies the maximum amount of time to wait between retries in milliseconds. Defaults to 5000.
-     * @param {httpResponseCallback} callback - The callback used when the response has returned. Passed (err, data)
+     * @param {HttpResponseCallback} callback - The callback used when the response has returned. Passed (err, data)
      * where data is the response (format depends on response type: text, Object, ArrayBuffer, XML) and
      * err is the error code.
      * @example
@@ -225,7 +225,7 @@ class Http {
      * @name Http#del
      * @description Perform an HTTP DELETE request to the given url.
      * @param {object} url - The URL to make the request to.
-     * @param {httpResponseCallback} callback - The callback used when the response has returned. Passed (err, data)
+     * @param {HttpResponseCallback} callback - The callback used when the response has returned. Passed (err, data)
      * where data is the response (format depends on response type: text, Object, ArrayBuffer, XML) and
      * err is the error code.
      * @example
@@ -253,7 +253,7 @@ class Http {
      * @param {boolean} [options.retry] - If true then if the request fails it will be retried with an exponential backoff.
      * @param {number} [options.maxRetries] - If options.retry is true this specifies the maximum number of retries. Defaults to 5.
      * @param {number} [options.maxRetryDelay] - If options.retry is true this specifies the maximum amount of time to wait between retries in milliseconds. Defaults to 5000.
-     * @param {httpResponseCallback} callback - The callback used when the response has returned. Passed (err, data)
+     * @param {HttpResponseCallback} callback - The callback used when the response has returned. Passed (err, data)
      * where data is the response (format depends on response type: text, Object, ArrayBuffer, XML) and
      * err is the error code.
      * @example
@@ -276,7 +276,7 @@ class Http {
      * @description Make a general purpose HTTP request.
      * @param {string} method - The HTTP method "GET", "POST", "PUT", "DELETE".
      * @param {string} url - The url to make the request to.
-     * @param {httpResponseCallback} callback - The callback used when the response has returned. Passed (err, data)
+     * @param {HttpResponseCallback} callback - The callback used when the response has returned. Passed (err, data)
      * where data is the response (format depends on response type: text, Object, ArrayBuffer, XML) and
      * err is the error code.
      * @example
@@ -305,7 +305,7 @@ class Http {
      * Some content types are handled automatically. If postdata is an XML Document, it is handled. If
      * the Content-Type header is set to 'application/json' then the postdata is JSON stringified.
      * Otherwise, by default, the data is sent as form-urlencoded.
-     * @param {httpResponseCallback} callback - The callback used when the response has returned. Passed (err, data)
+     * @param {HttpResponseCallback} callback - The callback used when the response has returned. Passed (err, data)
      * where data is the response (format depends on response type: text, Object, ArrayBuffer, XML) and
      * err is the error code.
      * @example

--- a/src/resources/handler.js
+++ b/src/resources/handler.js
@@ -4,7 +4,7 @@
 /**
  * Callback used by {@link ResourceHandler#load} when a resource is loaded (or an error occurs).
  *
- * @callback resourceHandlerCallback
+ * @callback ResourceHandlerCallback
  * @param {string|null} err - The error message in the case where the load fails.
  * @param {*} [response] - The raw data that has been successfully loaded.
  */
@@ -25,7 +25,7 @@ class ResourceHandler {
      * @param {string} [url.load] - The URL to be used for loading the resource.
      * @param {string} [url.original] - The original URL to be used for identifying the resource
      * format. This is necessary when loading, for example from blob.
-     * @param {resourceHandlerCallback} callback - The callback used when the resource is loaded or an error occurs.
+     * @param {ResourceHandlerCallback} callback - The callback used when the resource is loaded or an error occurs.
      * @param {Asset} [asset] - Optional asset that is passed by ResourceLoader.
      */
     load(url, callback, asset) {

--- a/src/resources/loader.js
+++ b/src/resources/loader.js
@@ -4,7 +4,7 @@
 /** @typedef {import('./handler.js').ResourceHandler} ResourceHandler */
 
 /**
- * @callback resourceLoaderCallback
+ * @callback ResourceLoaderCallback
  * @description Callback used by {@link ResourceLoader#load} when a resource is loaded (or an error occurs).
  * @param {string|null} err - The error message in the case where the load fails.
  * @param {*} [resource] - The resource that has been successfully loaded.
@@ -87,7 +87,7 @@ class ResourceLoader {
      *
      * @param {string} url - The URL of the resource to load.
      * @param {string} type - The type of resource expected.
-     * @param {resourceLoaderCallback} callback - The callback used when the resource is loaded or
+     * @param {ResourceLoaderCallback} callback - The callback used when the resource is loaded or
      * an error occurs. Passed (err, resource) where err is null if there are no errors.
      * @param {Asset} [asset] - Optional asset that is passed into handler
      * @example

--- a/src/resources/model.js
+++ b/src/resources/model.js
@@ -14,7 +14,7 @@ import { DefaultMaterial } from '../scene/materials/default-material.js';
 /**
  * Callback used by {@link ModelHandler#addParser} to decide on which parser to use.
  *
- * @callback addParserCallback
+ * @callback AddParserCallback
  * @param {string} url - The resource url.
  * @param {object} data - The raw model data.
  * @returns {boolean} Return true if this parser should be used to parse the data into a
@@ -155,7 +155,7 @@ class ModelHandler {
      * Add a parser that converts raw data into a {@link Model}. Default parser is for JSON models.
      *
      * @param {object} parser - See JsonModelParser for example.
-     * @param {addParserCallback} decider - Function that decides on which parser to use. Function
+     * @param {AddParserCallback} decider - Function that decides on which parser to use. Function
      * should take (url, data) arguments and return true if this parser should be used to parse the
      * data into a {@link Model}. The first parser to return true is used.
      */

--- a/src/resources/texture.js
+++ b/src/resources/texture.js
@@ -19,7 +19,7 @@ import { HdrParser } from './parser/texture/hdr.js';
 /** @typedef {import('../asset/asset-registry.js').AssetRegistry} AssetRegistry */
 /** @typedef {import('../graphics/graphics-device.js').GraphicsDevice} GraphicsDevice */
 /** @typedef {import('./handler.js').ResourceHandler} ResourceHandler */
-/** @typedef {import('./handler.js').resourceHandlerCallback} resourceHandlerCallback */
+/** @typedef {import('./handler.js').ResourceHandlerCallback} ResourceHandlerCallback */
 /** @typedef {import('./loader.js').ResourceLoader} ResourceLoader */
 
 const JSON_ADDRESS_MODE = {
@@ -60,7 +60,7 @@ class TextureParser {
      * @param {object} url - The URL of the resource to load.
      * @param {string} url.load - The URL to use for loading the resource.
      * @param {string} url.original - The original URL useful for identifying the resource type.
-     * @param {resourceHandlerCallback} callback - The callback used when the resource is loaded or an error occurs.
+     * @param {ResourceHandlerCallback} callback - The callback used when the resource is loaded or an error occurs.
      * @param {Asset} [asset] - Optional asset that is passed by ResourceLoader.
      */
     load(url, callback, asset) {

--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -26,7 +26,7 @@ const up = new Vec3();
  * Callback used by {@link GraphNode#find} and {@link GraphNode#findOne} to search through a graph
  * node and all of its descendants.
  *
- * @callback findNodeCallback
+ * @callback FindNodeCallback
  * @param {GraphNode} node - The current graph node.
  * @returns {boolean} Returning `true` will result in that node being returned from
  * {@link GraphNode#find} or {@link GraphNode#findOne}.
@@ -36,7 +36,7 @@ const up = new Vec3();
  * Callback used by {@link GraphNode#forEach} to iterate through a graph node and all of its
  * descendants.
  *
- * @callback forEachNodeCallback
+ * @callback ForEachNodeCallback
  * @param {GraphNode} node - The current graph node.
  */
 
@@ -427,7 +427,7 @@ class GraphNode extends EventHandler {
      * Search the graph node and all of its descendants for the nodes that satisfy some search
      * criteria.
      *
-     * @param {findNodeCallback|string} attr - This can either be a function or a string. If it's a
+     * @param {FindNodeCallback|string} attr - This can either be a function or a string. If it's a
      * function, it is executed for each descendant node to test if node satisfies the search
      * logic. Returning true from the function will include the node into the results. If it's a
      * string then it represents the name of a field or a method of the node. If this is the name
@@ -489,7 +489,7 @@ class GraphNode extends EventHandler {
      * Search the graph node and all of its descendants for the first node that satisfies some
      * search criteria.
      *
-     * @param {findNodeCallback|string} attr - This can either be a function or a string. If it's a
+     * @param {FindNodeCallback|string} attr - This can either be a function or a string. If it's a
      * function, it is executed for each descendant node to test if node satisfies the search
      * logic. Returning true from the function will result in that node being returned from
      * findOne. If it's a string then it represents the name of a field or a method of the node. If
@@ -638,7 +638,7 @@ class GraphNode extends EventHandler {
     /**
      * Executes a provided function once on this graph node and all of its descendants.
      *
-     * @param {forEachNodeCallback} callback - The function to execute on the graph node and each
+     * @param {ForEachNodeCallback} callback - The function to execute on the graph node and each
      * descendant.
      * @param {object} [thisArg] - Optional value to use as this when executing callback function.
      * @example

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -36,7 +36,7 @@ let _params = new Set();
 /**
  * Callback used by {@link StandardMaterial#onUpdateShader}.
  *
- * @callback updateShaderCallback
+ * @callback UpdateShaderCallback
  * @param {*} options - An object with shader generator settings (based on current material and
  * scene properties), that you can change and then return. Properties of the object passed into
  * this function are documented in {@link StandardMaterial#onUpdateShader}.
@@ -366,7 +366,7 @@ let _params = new Set();
  * pixel perfect 2D graphics.
  * @property {boolean} twoSidedLighting Calculate proper normals (and therefore lighting) on
  * backfaces.
- * @property {updateShaderCallback} onUpdateShader A custom function that will be called after all
+ * @property {UpdateShaderCallback} onUpdateShader A custom function that will be called after all
  * shader generator properties are collected and before shader code is generated. This function
  * will receive an object with shader generator settings (based on current material and scene
  * properties), that you can change and then return. Returned value will be used instead. This is

--- a/src/scene/mesh-instance.js
+++ b/src/scene/mesh-instance.js
@@ -62,7 +62,7 @@ class Command {
  * Callback used by {@link Layer} to calculate the "sort distance" for a {@link MeshInstance},
  * which determines its place in the render order.
  *
- * @callback calculateSortDistanceCallback
+ * @callback CalculateSortDistanceCallback
  * @param {MeshInstance} meshInstance - The mesh instance.
  * @param {Vec3} cameraPosition - The position of the camera.
  * @param {Vec3} cameraForward - The forward vector of the camera.
@@ -417,7 +417,7 @@ class MeshInstance {
      * the center of the mesh instance's axis-aligned bounding box. This option can be particularly
      * useful for rendering transparent meshes in a better order than default.
      *
-     * @type {calculateSortDistanceCallback}
+     * @type {CalculateSortDistanceCallback}
      */
     set calculateSortDistance(calculateSortDistance) {
         this._calculateSortDistance = calculateSortDistance;

--- a/src/vr/vr-display.js
+++ b/src/vr/vr-display.js
@@ -11,7 +11,7 @@ import { RESOLUTION_AUTO } from '../framework/constants.js';
 /**
  * Callback used by {@link VrDisplay#requestPresent} and {@link VrDisplay#exitPresent}.
  *
- * @callback vrDisplayCallback
+ * @callback VrDisplayCallback
  * @param {string|null} err - The error message if presenting fails, or null if the call succeeds.
  * @ignore
  */
@@ -19,7 +19,7 @@ import { RESOLUTION_AUTO } from '../framework/constants.js';
 /**
  * Callback used by {@link VrDisplay#requestAnimationFrame}.
  *
- * @callback vrFrameCallback
+ * @callback VrFrameCallback
  * @ignore
  */
 
@@ -251,7 +251,7 @@ class VrDisplay extends EventHandler {
     /**
      * Try to present full screen VR content on this display.
      *
-     * @param {vrDisplayCallback} callback - Called when the request is completed. Callback takes a
+     * @param {VrDisplayCallback} callback - Called when the request is completed. Callback takes a
      * single argument (err) that is the error message return if presenting fails, or null if the
      * call succeeds. Usually called by {@link CameraComponent#enterVr}.
      * @deprecated
@@ -277,7 +277,7 @@ class VrDisplay extends EventHandler {
     /**
      * Try to stop presenting VR content on this display.
      *
-     * @param {vrDisplayCallback} callback - Called when the request is completed. Callback takes a
+     * @param {VrDisplayCallback} callback - Called when the request is completed. Callback takes a
      * single argument (err) that is the error message return if presenting fails, or null if the
      * call succeeds. Usually called by {@link CameraComponent#exitVr}.
      * @deprecated
@@ -303,7 +303,7 @@ class VrDisplay extends EventHandler {
      * Used in the main application loop instead of the regular `window.requestAnimationFrame`.
      * Usually only called from inside {@link Application}.
      *
-     * @param {vrFrameCallback} fn - Function called when it is time to update the frame.
+     * @param {VrFrameCallback} fn - Function called when it is time to update the frame.
      * @deprecated
      */
     requestAnimationFrame(fn) {

--- a/src/xr/xr-hit-test.js
+++ b/src/xr/xr-hit-test.js
@@ -10,7 +10,7 @@ import { XrHitTestSource } from './xr-hit-test-source.js';
 /**
  * Callback used by {@link XrHitTest#start} and {@link XrHitTest#startForInputSource}.
  *
- * @callback xrHitTestStartCallback
+ * @callback XrHitTestStartCallback
  * @param {Error|null} err - The Error object if failed to create hit test source or null.
  * @param {XrHitTestSource|null} hitTestSource - Object that provides access to hit results against
  * real world geometry.
@@ -192,7 +192,7 @@ class XrHitTest extends EventHandler {
      * based on the meshes detected by the underlying Augmented Reality system.
      *
      * @param {Ray} [options.offsetRay] - Optional ray by which hit test ray can be offset.
-     * @param {xrHitTestStartCallback} [options.callback] - Optional callback function called once
+     * @param {XrHitTestStartCallback} [options.callback] - Optional callback function called once
      * hit test source is created or failed.
      * @example
      * app.xr.hitTest.start({

--- a/src/xr/xr-input-source.js
+++ b/src/xr/xr-input-source.js
@@ -9,7 +9,7 @@ import { Ray } from '../shape/ray.js';
 import { XrHand } from './xr-hand.js';
 
 /** @typedef {import('../framework/entity.js').Entity} Entity */
-/** @typedef {import('./xr-hit-test.js').xrHitTestStartCallback} xrHitTestStartCallback */
+/** @typedef {import('./xr-hit-test.js').XrHitTestStartCallback} XrHitTestStartCallback */
 /** @typedef {import('./xr-hit-test-source.js').XrHitTestSource} XrHitTestSource */
 /** @typedef {import('./xr-manager.js').XrManager} XrManager */
 
@@ -577,7 +577,7 @@ class XrInputSource extends EventHandler {
      * based on the meshes detected by the underlying Augmented Reality system.
      *
      * @param {Ray} [options.offsetRay] - Optional ray by which hit test ray can be offset.
-     * @param {xrHitTestStartCallback} [options.callback] - Optional callback function called once
+     * @param {XrHitTestStartCallback} [options.callback] - Optional callback function called once
      * hit test source is created or failed.
      * @example
      * app.xr.input.on('add', function (inputSource) {

--- a/src/xr/xr-manager.js
+++ b/src/xr/xr-manager.js
@@ -23,7 +23,7 @@ import { XrPlaneDetection } from './xr-plane-detection.js';
 /**
  * Callback used by {@link XrManager#endXr} and {@link XrManager#startXr}.
  *
- * @callback xrErrorCallback
+ * @callback XrErrorCallback
  * @param {Error|null} err - The Error object or null if operation was successful.
  */
 
@@ -333,7 +333,7 @@ class XrManager extends EventHandler {
      * {@link XrImageTracking}.
      * @param {boolean} [options.planeDetection] - Set to true to attempt to enable
      * {@link XrPlaneDetection}.
-     * @param {xrErrorCallback} [options.callback] - Optional callback function called once session
+     * @param {XrErrorCallback} [options.callback] - Optional callback function called once session
      * is started. The callback has one argument Error - it is null if successfully started XR
      * session.
      * @param {object} [options.depthSensing] - Optional object with depth sensing parameters to
@@ -462,7 +462,7 @@ class XrManager extends EventHandler {
      * @param {string} type - Session type.
      * @param {string} spaceType - Reference space type.
      * @param {*} options - Session options.
-     * @param {xrErrorCallback} callback - Error callback.
+     * @param {XrErrorCallback} callback - Error callback.
      * @private
      */
     _onStartOptionsReady(type, spaceType, options, callback) {
@@ -483,7 +483,7 @@ class XrManager extends EventHandler {
      * Attempts to end XR session and optionally fires callback when session is ended or failed to
      * end.
      *
-     * @param {xrErrorCallback} [callback] - Optional callback function called once session is
+     * @param {XrErrorCallback} [callback] - Optional callback function called once session is
      * started. The callback has one argument Error - it is null if successfully started XR
      * session.
      * @example

--- a/types-fixup.mjs
+++ b/types-fixup.mjs
@@ -84,8 +84,8 @@ fs.writeFileSync(path, dts);
 
 const cameraComponentProps = [
     ['aspectRatioMode', 'number'],
-    ['calculateProjection', 'calculateMatrixCallback'],
-    ['calculateTransform', 'calculateMatrixCallback'],
+    ['calculateProjection', 'CalculateMatrixCallback'],
+    ['calculateTransform', 'CalculateMatrixCallback'],
     ['clearColor', 'Color'],
     ['cullFaces', 'boolean'],
     ['farClip', 'number'],
@@ -422,7 +422,7 @@ const standardMaterialProps = [
     ['occludeDirect', 'number'],
     ['occludeSpecular', 'number'],
     ['occludeSpecularIntensity', 'number'],
-    ['onUpdateShader', 'updateShaderCallback'],
+    ['onUpdateShader', 'UpdateShaderCallback'],
     ['opacity', 'number'],
     ['opacityFadesSpecular', 'boolean'],
     ['opacityMap', 'Texture'],


### PR DESCRIPTION
This PR capitalizes the types of callbacks in the engine, which feels more consistent with the rest of the API.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
