### PR TITLE
Changes to make BoxReflection example work more reliably

### DIFF
--- a/examples/src/examples/graphics/box-reflection.tsx
+++ b/examples/src/examples/graphics/box-reflection.tsx
@@ -262,7 +262,10 @@ class BoxReflectionExample {
             layers: [worldLayer.id],
 
             // disable as this is not a camera that renders cube map but only a container for properties for cube map rendering
-            enabled: false
+            enabled: false,
+
+            nearClip: 1,
+            farClip: 500
         });
 
         // Add a cubemap renderer script, which renders to a cubemap of size 128 with mipmaps, which is directly useable

--- a/src/graphics/webgl/webgl-graphics-device.js
+++ b/src/graphics/webgl/webgl-graphics-device.js
@@ -1270,7 +1270,8 @@ class WebglGraphicsDevice extends GraphicsDevice {
                     gl.renderbufferStorage(gl.RENDERBUFFER, gl.DEPTH_STENCIL, target.width, target.height);
                     gl.framebufferRenderbuffer(gl.FRAMEBUFFER, gl.DEPTH_STENCIL_ATTACHMENT, gl.RENDERBUFFER, target._glDepthBuffer);
                 } else {
-                    gl.renderbufferStorage(gl.RENDERBUFFER, gl.DEPTH_COMPONENT16, target.width, target.height);
+                    const depthFormat = this.webgl2 ? gl.DEPTH_COMPONENT32F : gl.DEPTH_COMPONENT16;
+                    gl.renderbufferStorage(gl.RENDERBUFFER, depthFormat, target.width, target.height);
                     gl.framebufferRenderbuffer(gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT, gl.RENDERBUFFER, target._glDepthBuffer);
                 }
                 gl.bindRenderbuffer(gl.RENDERBUFFER, null);


### PR DESCRIPTION
Fixes https://github.com/playcanvas/engine/issues/4066

- changed the default format of the depth buffer on webgl2 platform to 32bit, from 16bit. In case MSAA is used, this format now matches the format depth was getting resolved to, potentially avoiding format conversion
- adjusted camera near/far distance for when box-reflection example renders into cubemap, to avoid hitting precision issues on 16bit depth buffer (on webgl1 only with this change)