### PR TITLE
[AnimComponent] Fix for layer masks in cloned components

### DIFF
--- a/src/framework/components/anim/system.js
+++ b/src/framework/components/anim/system.js
@@ -116,6 +116,7 @@ class AnimComponentSystem extends ComponentSystem {
             layers: entity.anim.layers,
             layerIndices: entity.anim.layerIndices,
             parameters: entity.anim.parameters,
+            masks
         };
         return this.addComponent(clone, data);
     }

--- a/src/framework/components/anim/system.js
+++ b/src/framework/components/anim/system.js
@@ -89,6 +89,22 @@ class AnimComponentSystem extends ComponentSystem {
     }
 
     cloneComponent(entity, clone) {
+        let masks;
+        // If the component doesn't specify a rootBone, any layer mask hierarchy should be updated from the old entity to the cloned entity.
+        if (!entity.anim.rootBone) {
+            masks = {};
+            entity.anim.layers.forEach((layer, i) => {
+                if (layer.mask) {
+                    const mask = {};
+                    Object.keys(layer.mask).forEach((path) => {
+                        // The base of all mask paths should be mapped from the previous entity to the cloned entity
+                        const clonePath = path.replace(path.split('/')[0], clone.name);
+                        mask[clonePath] = layer.mask[path];
+                    });
+                    masks[i] = { mask };
+                }
+            });
+        }
         const data = {
             stateGraphAsset: entity.anim.stateGraphAsset,
             animationAssets: entity.anim.animationAssets,
@@ -99,7 +115,8 @@ class AnimComponentSystem extends ComponentSystem {
             stateGraph: entity.anim.stateGraph,
             layers: entity.anim.layers,
             layerIndices: entity.anim.layerIndices,
-            parameters: entity.anim.parameters
+            parameters: entity.anim.parameters,
+            masks
         };
         return this.addComponent(clone, data);
     }

--- a/src/framework/components/anim/system.js
+++ b/src/framework/components/anim/system.js
@@ -90,8 +90,8 @@ class AnimComponentSystem extends ComponentSystem {
 
     cloneComponent(entity, clone) {
         let masks;
-        // If the component doesn't specify a rootBone, any layer mask hierarchy should be updated from the old entity to the cloned entity.
-        if (!entity.anim.rootBone) {
+        // If the component animaites from the components entity, any layer mask hierarchy should be updated from the old entity to the cloned entity.
+        if (!entity.anim.rootBone || entity.anim.rootBone === entity) {
             masks = {};
             entity.anim.layers.forEach((layer, i) => {
                 if (layer.mask) {
@@ -116,7 +116,6 @@ class AnimComponentSystem extends ComponentSystem {
             layers: entity.anim.layers,
             layerIndices: entity.anim.layerIndices,
             parameters: entity.anim.parameters,
-            masks
         };
         return this.addComponent(clone, data);
     }

--- a/src/framework/components/anim/system.js
+++ b/src/framework/components/anim/system.js
@@ -98,7 +98,9 @@ class AnimComponentSystem extends ComponentSystem {
                     const mask = {};
                     Object.keys(layer.mask).forEach((path) => {
                         // The base of all mask paths should be mapped from the previous entity to the cloned entity
-                        const clonePath = path.replace(path.split('/')[0], clone.name);
+                        const pathArr = path.split('/');
+                        pathArr.shift();
+                        const clonePath = [clone.name, ...pathArr].join('/');
                         mask[clonePath] = layer.mask[path];
                     });
                     masks[i] = { mask };


### PR DESCRIPTION
If an anim component is getting cloned and it is animating from the components own entity, we should be mapping all layer mask paths to start from the cloned entity rather than the old entity.

Fixes #4031 

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
