### PR TITLE
Fix EntityReference not finding the entity if the parent was not added to the scene yet.

### DIFF
--- a/src/framework/utils/entity-reference.js
+++ b/src/framework/utils/entity-reference.js
@@ -266,11 +266,12 @@ class EntityReference extends EventHandler {
             nextEntityGuid = nextEntity.getGuid();
             this._parentComponent.data[this._entityPropertyName] = nextEntityGuid;
         } else {
-            const appRoot = this._parentComponent.system.app.root;
-            const isOnSceneGraph = this._parentComponent.entity.isDescendantOf(appRoot);
+            // If value is the GUID, look for the entity from the root of the parent entity.
+            // We use entity.root rather than app.root because the parent entity may be detached
+            // from the scene, and the value is referencing an entity within this detached graph.
+            const root = this._parentComponent.entity.root;
 
-            const searchRoot = isOnSceneGraph ? appRoot : this._parentComponent.entity;
-            nextEntity = nextEntityGuid ? searchRoot.findByGuid(nextEntityGuid) : null;
+            nextEntity = nextEntityGuid ? root.findByGuid(nextEntityGuid) : null;
         }
 
         const hasChanged = this._entity !== nextEntity;

--- a/src/framework/utils/entity-reference.js
+++ b/src/framework/utils/entity-reference.js
@@ -266,10 +266,11 @@ class EntityReference extends EventHandler {
             nextEntityGuid = nextEntity.getGuid();
             this._parentComponent.data[this._entityPropertyName] = nextEntityGuid;
         } else {
-            const root = this._parentComponent.system.app.root;
-            const isOnSceneGraph = this._parentComponent.entity.isDescendantOf(root);
+            const appRoot = this._parentComponent.system.app.root;
+            const isOnSceneGraph = this._parentComponent.entity.isDescendantOf(appRoot);
 
-            nextEntity = (isOnSceneGraph && nextEntityGuid) ? root.findByGuid(nextEntityGuid) : null;
+            const searchRoot = isOnSceneGraph ? appRoot : this._parentComponent.entity;
+            nextEntity = nextEntityGuid ? searchRoot.findByGuid(nextEntityGuid) : null;
         }
 
         const hasChanged = this._entity !== nextEntity;

--- a/src/framework/utils/entity-reference.js
+++ b/src/framework/utils/entity-reference.js
@@ -265,16 +265,14 @@ class EntityReference extends EventHandler {
             nextEntity = nextEntityGuid;
             nextEntityGuid = nextEntity.getGuid();
             this._parentComponent.data[this._entityPropertyName] = nextEntityGuid;
-        } else {
-            if (nextEntityGuid) {
-                // If value is the GUID, look for the entity from the root of the parent entity.
-                // We use both entity.root and app.root because the parent entity may be detached
-                // from the scene, and the value could be referencing an entity within this detached graph.
-                const sceneRoot = this._parentComponent.system.app.root;
-                const entityRoot = this._parentComponent.entity.root;
+        } else if (nextEntityGuid) {
+            // If value is the GUID, look for the entity from the root of the parent entity.
+            // We use both entity.root and app.root because the parent entity may be detached
+            // from the scene, and the value could be referencing an entity within this detached graph.
+            const sceneRoot = this._parentComponent.system.app.root;
+            const entityRoot = this._parentComponent.entity.root;
 
-                nextEntity = entityRoot.findByGuid(nextEntityGuid) || sceneRoot.findByGuid(nextEntityGuid);
-            }
+            nextEntity = entityRoot.findByGuid(nextEntityGuid) || sceneRoot.findByGuid(nextEntityGuid);
         }
 
         const hasChanged = this._entity !== nextEntity;

--- a/src/framework/utils/entity-reference.js
+++ b/src/framework/utils/entity-reference.js
@@ -258,7 +258,7 @@ class EntityReference extends EventHandler {
 
     _updateEntityReference() {
         let nextEntityGuid = this._parentComponent.data[this._entityPropertyName];
-        let nextEntity;
+        let nextEntity = null;
 
         if (nextEntityGuid instanceof Entity) {
             // if value is set to a Entity itself replace value with the GUID
@@ -274,8 +274,6 @@ class EntityReference extends EventHandler {
                 const entityRoot = this._parentComponent.entity.root;
 
                 nextEntity = entityRoot.findByGuid(nextEntityGuid) || sceneRoot.findByGuid(nextEntityGuid);
-            } else {
-                nextEntity = null;
             }
         }
 

--- a/src/framework/utils/entity-reference.js
+++ b/src/framework/utils/entity-reference.js
@@ -235,15 +235,11 @@ class EntityReference extends EventHandler {
 
     /**
      * Must be called from the parent component's onEnable() method in order for entity references
-     * to be correctly resolved when {@link Entity#clone} is called.
+     * to be correctly resolved when the referenced entity was not in the same graph as the parent.
      *
      * @private
      */
     onParentComponentEnable() {
-        // When an entity is cloned via the JS API, we won't be able to resolve the
-        // entity reference until the cloned entity has been added to the scene graph.
-        // We can detect this by waiting for the parent component to be enabled, in the
-        // specific case where we haven't yet been able to resolve an entity reference.
         if (!this._entity) {
             this._updateEntityReference();
         }

--- a/src/framework/utils/entity-reference.js
+++ b/src/framework/utils/entity-reference.js
@@ -266,12 +266,17 @@ class EntityReference extends EventHandler {
             nextEntityGuid = nextEntity.getGuid();
             this._parentComponent.data[this._entityPropertyName] = nextEntityGuid;
         } else {
-            // If value is the GUID, look for the entity from the root of the parent entity.
-            // We use entity.root rather than app.root because the parent entity may be detached
-            // from the scene, and the value is referencing an entity within this detached graph.
-            const root = this._parentComponent.entity.root;
+            if (nextEntityGuid) {
+                // If value is the GUID, look for the entity from the root of the parent entity.
+                // We use both entity.root and app.root because the parent entity may be detached
+                // from the scene, and the value could be referencing an entity within this detached graph.
+                const sceneRoot = this._parentComponent.system.app.root;
+                const entityRoot = this._parentComponent.entity.root;
 
-            nextEntity = nextEntityGuid ? root.findByGuid(nextEntityGuid) : null;
+                nextEntity = entityRoot.findByGuid(nextEntityGuid) || sceneRoot.findByGuid(nextEntityGuid);
+            } else {
+                nextEntity = null;
+            }
         }
 
         const hasChanged = this._entity !== nextEntity;

--- a/tests/framework/utils/test_entityreference.js
+++ b/tests/framework/utils/test_entityreference.js
@@ -1,4 +1,4 @@
-describe("pc.EntityReference", function () {
+describe.only("pc.EntityReference", function () {
     var app;
     var testEntity;
     var testComponent;
@@ -54,7 +54,7 @@ describe("pc.EntityReference", function () {
         expect(reference.entity).to.equal(otherEntity1);
     });
 
-    it("does not attempt to resolve the entity reference if the parent component is not on the scene graph yet", function () {
+    it("attempts to resolve the entity reference if the parent component is not on the scene graph yet", function () {
         app.root.removeChild(testEntity);
 
         sinon.spy(app.root, "findByGuid");
@@ -62,20 +62,38 @@ describe("pc.EntityReference", function () {
         var reference = new pc.EntityReference(testComponent, "myEntity1");
         testComponent.myEntity1 = otherEntity1.getGuid();
 
-        expect(reference.entity).to.equal(null);
-        expect(app.root.findByGuid.callCount).to.equal(0);
+        expect(reference.entity).to.equal(otherEntity1);
+        expect(app.root.findByGuid.callCount).to.equal(1);
     });
 
-    it("resolves the entity reference when onParentComponentEnable() is called", function () {
-        app.root.removeChild(testEntity);
+    it("resolves the entity reference when added to graph later and onParentComponentEnable() is called", function () {
+        app.root.removeChild(otherEntity1);
 
         var reference = new pc.EntityReference(testComponent, "myEntity1");
         testComponent.myEntity1 = otherEntity1.getGuid();
         expect(reference.entity).to.equal(null);
 
-        app.root.addChild(testEntity);
+        app.root.addChild(otherEntity1);
         reference.onParentComponentEnable();
 
+        expect(reference.entity).to.equal(otherEntity1);
+    });
+
+    it("resolves the entity reference when entity and parent are in their own graph", function () {
+        app.root.removeChild(testEntity);
+        app.root.removeChild(otherEntity1);
+        testEntity.root.addChild(otherEntity1);
+
+        var reference = new pc.EntityReference(testComponent, "myEntity1");
+        testComponent.myEntity1 = otherEntity1.getGuid();
+        expect(reference.entity).to.equal(otherEntity1);
+    });
+
+    it("resolves the entity reference when entity is in scene graph but parent is not", function () {
+        app.root.removeChild(testEntity);
+
+        var reference = new pc.EntityReference(testComponent, "myEntity1");
+        testComponent.myEntity1 = otherEntity1.getGuid();
         expect(reference.entity).to.equal(otherEntity1);
     });
 

--- a/tests/framework/utils/test_entityreference.js
+++ b/tests/framework/utils/test_entityreference.js
@@ -1,4 +1,4 @@
-describe.only("pc.EntityReference", function () {
+describe("pc.EntityReference", function () {
     var app;
     var testEntity;
     var testComponent;


### PR DESCRIPTION
Fixes https://github.com/playcanvas/engine/issues/1996

This PR fixes an issue in the `EntityReference` class, which is used for managing references between entities like, for instance, a `Button`'s `imageEntity` (https://developer.playcanvas.com/api/pc.ButtonComponent.html#imageEntity): if the parent entity (the one that contains the `EntityReference`) is not in the scene graph (not a descendant to the App's `root`), and the reference is made via a `guid` (string), the reference is never found.

The fix is simply to always check against the parent entity's root - which, would be either be `app.root`, or the root of the detached graph.

This issue is especially noticeable when cloning entities or templates which contain such references internally.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
