### PR TITLE
Handle Area Lights LUT textures destruction when device is destroyed

### DIFF
--- a/src/graphics/device-cache.js
+++ b/src/graphics/device-cache.js
@@ -27,12 +27,21 @@ class DeviceCache {
 
             // when the device is destroyed, destroy and remove its entry
             device.on('destroy', () => {
-                this._cache.get(device)?.destroy();
-                this._cache.delete(device);
+                this.remove(device);
             });
         }
 
         return this._cache.get(device);
+    }
+
+    /**
+     * Destroyes and removes the content of the cache associated with the device
+     *
+     * @param {GraphicsDevice} device - The graphics device.
+     */
+    remove(device) {
+        this._cache.get(device)?.destroy();
+        this._cache.delete(device);
     }
 }
 


### PR DESCRIPTION
- the placeholder LUT was never released
- the real LUTs were not destroyed when the device was destroyed