### PR TITLE
[FIX] Entity components and systems in the registry can be undefined

### DIFF
--- a/src/framework/components/registry.js
+++ b/src/framework/components/registry.js
@@ -31,7 +31,7 @@ class ComponentSystemRegistry extends EventHandler {
     /**
      * Gets the {@link AnimComponentSystem} from the registry.
      *
-     * @type {AnimComponentSystem}
+     * @type {AnimComponentSystem|undefined}
      * @readonly
      */
     anim;
@@ -39,7 +39,7 @@ class ComponentSystemRegistry extends EventHandler {
     /**
      * Gets the {@link AnimationComponentSystem} from the registry.
      *
-     * @type {AnimationComponentSystem}
+     * @type {AnimationComponentSystem|undefined}
      * @readonly
      */
     animation;
@@ -47,7 +47,7 @@ class ComponentSystemRegistry extends EventHandler {
     /**
      * Gets the {@link AudioListenerComponentSystem} from the registry.
      *
-     * @type {AudioListenerComponentSystem}
+     * @type {AudioListenerComponentSystem|undefined}
      * @readonly
      */
     audiolistener;
@@ -55,7 +55,7 @@ class ComponentSystemRegistry extends EventHandler {
     /**
      * Gets the {@link AudioSourceComponentSystem} from the registry.
      *
-     * @type {AudioSourceComponentSystem}
+     * @type {AudioSourceComponentSystem|undefined}
      * @readonly
      * @ignore
      */
@@ -64,7 +64,7 @@ class ComponentSystemRegistry extends EventHandler {
     /**
      * Gets the {@link ButtonComponentSystem} from the registry.
      *
-     * @type {ButtonComponentSystem}
+     * @type {ButtonComponentSystem|undefined}
      * @readonly
      */
     button;
@@ -72,7 +72,7 @@ class ComponentSystemRegistry extends EventHandler {
     /**
      * Gets the {@link CameraComponentSystem} from the registry.
      *
-     * @type {CameraComponentSystem}
+     * @type {CameraComponentSystem|undefined}
      * @readonly
      */
     camera;
@@ -80,7 +80,7 @@ class ComponentSystemRegistry extends EventHandler {
     /**
      * Gets the {@link CollisionComponentSystem} from the registry.
      *
-     * @type {CollisionComponentSystem}
+     * @type {CollisionComponentSystem|undefined}
      * @readonly
      */
     collision;
@@ -88,7 +88,7 @@ class ComponentSystemRegistry extends EventHandler {
     /**
      * Gets the {@link ElementComponentSystem} from the registry.
      *
-     * @type {ElementComponentSystem}
+     * @type {ElementComponentSystem|undefined}
      * @readonly
      */
     element;
@@ -96,7 +96,7 @@ class ComponentSystemRegistry extends EventHandler {
     /**
      * Gets the {@link JointComponentSystem} from the registry.
      *
-     * @type {JointComponentSystem}
+     * @type {JointComponentSystem|undefined}
      * @readonly
      * @ignore
      */
@@ -105,7 +105,7 @@ class ComponentSystemRegistry extends EventHandler {
     /**
      * Gets the {@link LayoutChildComponentSystem} from the registry.
      *
-     * @type {LayoutChildComponentSystem}
+     * @type {LayoutChildComponentSystem|undefined}
      * @readonly
      */
     layoutchild;
@@ -113,7 +113,7 @@ class ComponentSystemRegistry extends EventHandler {
     /**
      * Gets the {@link LayoutGroupComponentSystem} from the registry.
      *
-     * @type {LayoutGroupComponentSystem}
+     * @type {LayoutGroupComponentSystem|undefined}
      * @readonly
      */
     layoutgroup;
@@ -121,7 +121,7 @@ class ComponentSystemRegistry extends EventHandler {
     /**
      * Gets the {@link LightComponentSystem} from the registry.
      *
-     * @type {LightComponentSystem}
+     * @type {LightComponentSystem|undefined}
      * @readonly
      */
     light;
@@ -129,7 +129,7 @@ class ComponentSystemRegistry extends EventHandler {
     /**
      * Gets the {@link ModelComponentSystem} from the registry.
      *
-     * @type {ModelComponentSystem}
+     * @type {ModelComponentSystem|undefined}
      * @readonly
      */
     model;
@@ -137,7 +137,7 @@ class ComponentSystemRegistry extends EventHandler {
     /**
      * Gets the {@link ParticleSystemComponentSystem} from the registry.
      *
-     * @type {ParticleSystemComponentSystem}
+     * @type {ParticleSystemComponentSystem|undefined}
      * @readonly
      */
     particlesystem;
@@ -145,7 +145,7 @@ class ComponentSystemRegistry extends EventHandler {
     /**
      * Gets the {@link RenderComponentSystem} from the registry.
      *
-     * @type {RenderComponentSystem}
+     * @type {RenderComponentSystem|undefined}
      * @readonly
      */
     render;
@@ -153,7 +153,7 @@ class ComponentSystemRegistry extends EventHandler {
     /**
      * Gets the {@link RigidBodyComponentSystem} from the registry.
      *
-     * @type {RigidBodyComponentSystem}
+     * @type {RigidBodyComponentSystem|undefined}
      * @readonly
      */
     rigidbody;
@@ -161,7 +161,7 @@ class ComponentSystemRegistry extends EventHandler {
     /**
      * Gets the {@link ScreenComponentSystem} from the registry.
      *
-     * @type {ScreenComponentSystem}
+     * @type {ScreenComponentSystem|undefined}
      * @readonly
      */
     screen;
@@ -169,7 +169,7 @@ class ComponentSystemRegistry extends EventHandler {
     /**
      * Gets the {@link ScriptComponentSystem} from the registry.
      *
-     * @type {ScriptComponentSystem}
+     * @type {ScriptComponentSystem|undefined}
      * @readonly
      */
     script;
@@ -177,7 +177,7 @@ class ComponentSystemRegistry extends EventHandler {
     /**
      * Gets the {@link ScrollbarComponentSystem} from the registry.
      *
-     * @type {ScrollbarComponentSystem}
+     * @type {ScrollbarComponentSystem|undefined}
      * @readonly
      */
     scrollbar;
@@ -185,7 +185,7 @@ class ComponentSystemRegistry extends EventHandler {
     /**
      * Gets the {@link ScrollViewComponentSystem} from the registry.
      *
-     * @type {ScrollViewComponentSystem}
+     * @type {ScrollViewComponentSystem|undefined}
      * @readonly
      */
     scrollview;
@@ -193,7 +193,7 @@ class ComponentSystemRegistry extends EventHandler {
     /**
      * Gets the {@link SoundComponentSystem} from the registry.
      *
-     * @type {SoundComponentSystem}
+     * @type {SoundComponentSystem|undefined}
      * @readonly
      */
     sound;
@@ -201,7 +201,7 @@ class ComponentSystemRegistry extends EventHandler {
     /**
      * Gets the {@link SpriteComponentSystem} from the registry.
      *
-     * @type {SpriteComponentSystem}
+     * @type {SpriteComponentSystem|undefined}
      * @readonly
      */
     sprite;
@@ -209,7 +209,7 @@ class ComponentSystemRegistry extends EventHandler {
     /**
      * Gets the {@link ZoneComponentSystem} from the registry.
      *
-     * @type {ZoneComponentSystem}
+     * @type {ZoneComponentSystem|undefined}
      * @readonly
      * @ignore
      */

--- a/src/framework/entity.js
+++ b/src/framework/entity.js
@@ -52,7 +52,7 @@ class Entity extends GraphNode {
     /**
      * Gets the {@link AnimComponent} attached to this entity.
      *
-     * @type {AnimComponent}
+     * @type {AnimComponent|undefined}
      * @readonly
      */
     anim;
@@ -60,7 +60,7 @@ class Entity extends GraphNode {
     /**
      * Gets the {@link AnimationComponent} attached to this entity.
      *
-     * @type {AnimationComponent}
+     * @type {AnimationComponent|undefined}
      * @readonly
      */
     animation;
@@ -68,7 +68,7 @@ class Entity extends GraphNode {
     /**
      * Gets the {@link AudioListenerComponent} attached to this entity.
      *
-     * @type {AudioListenerComponent}
+     * @type {AudioListenerComponent|undefined}
      * @readonly
      */
     audiolistener;
@@ -76,7 +76,7 @@ class Entity extends GraphNode {
     /**
      * Gets the {@link ButtonComponent} attached to this entity.
      *
-     * @type {ButtonComponent}
+     * @type {ButtonComponent|undefined}
      * @readonly
      */
     button;
@@ -84,7 +84,7 @@ class Entity extends GraphNode {
     /**
      * Gets the {@link CameraComponent} attached to this entity.
      *
-     * @type {CameraComponent}
+     * @type {CameraComponent|undefined}
      * @readonly
      */
     camera;
@@ -92,7 +92,7 @@ class Entity extends GraphNode {
     /**
      * Gets the {@link CollisionComponent} attached to this entity.
      *
-     * @type {CollisionComponent}
+     * @type {CollisionComponent|undefined}
      * @readonly
      */
     collision;
@@ -100,7 +100,7 @@ class Entity extends GraphNode {
     /**
      * Gets the {@link ElementComponent} attached to this entity.
      *
-     * @type {ElementComponent}
+     * @type {ElementComponent|undefined}
      * @readonly
      */
     element;
@@ -108,7 +108,7 @@ class Entity extends GraphNode {
     /**
      * Gets the {@link LayoutChildComponent} attached to this entity.
      *
-     * @type {LayoutChildComponent}
+     * @type {LayoutChildComponent|undefined}
      * @readonly
      */
     layoutchild;
@@ -116,7 +116,7 @@ class Entity extends GraphNode {
     /**
      * Gets the {@link LayoutGroupComponent} attached to this entity.
      *
-     * @type {LayoutGroupComponent}
+     * @type {LayoutGroupComponent|undefined}
      * @readonly
      */
     layoutgroup;
@@ -124,7 +124,7 @@ class Entity extends GraphNode {
     /**
      * Gets the {@link LightComponent} attached to this entity.
      *
-     * @type {LightComponent}
+     * @type {LightComponent|undefined}
      * @readonly
      */
     light;
@@ -132,7 +132,7 @@ class Entity extends GraphNode {
     /**
      * Gets the {@link ModelComponent} attached to this entity.
      *
-     * @type {ModelComponent}
+     * @type {ModelComponent|undefined}
      * @readonly
      */
     model;
@@ -140,7 +140,7 @@ class Entity extends GraphNode {
     /**
      * Gets the {@link ParticleSystemComponent} attached to this entity.
      *
-     * @type {ParticleSystemComponent}
+     * @type {ParticleSystemComponent|undefined}
      * @readonly
      */
     particlesystem;
@@ -148,7 +148,7 @@ class Entity extends GraphNode {
     /**
      * Gets the {@link RenderComponent} attached to this entity.
      *
-     * @type {RenderComponent}
+     * @type {RenderComponent|undefined}
      * @readonly
      */
     render;
@@ -156,7 +156,7 @@ class Entity extends GraphNode {
     /**
      * Gets the {@link RigidBodyComponent} attached to this entity.
      *
-     * @type {RigidBodyComponent}
+     * @type {RigidBodyComponent|undefined}
      * @readonly
      */
     rigidbody;
@@ -164,7 +164,7 @@ class Entity extends GraphNode {
     /**
      * Gets the {@link ScreenComponent} attached to this entity.
      *
-     * @type {ScreenComponent}
+     * @type {ScreenComponent|undefined}
      * @readonly
      */
     screen;
@@ -172,7 +172,7 @@ class Entity extends GraphNode {
     /**
      * Gets the {@link ScriptComponent} attached to this entity.
      *
-     * @type {ScriptComponent}
+     * @type {ScriptComponent|undefined}
      * @readonly
      */
     script;
@@ -180,7 +180,7 @@ class Entity extends GraphNode {
     /**
      * Gets the {@link ScrollbarComponent} attached to this entity.
      *
-     * @type {ScrollbarComponent}
+     * @type {ScrollbarComponent|undefined}
      * @readonly
      */
     scrollbar;
@@ -188,7 +188,7 @@ class Entity extends GraphNode {
     /**
      * Gets the {@link ScrollViewComponent} attached to this entity.
      *
-     * @type {ScrollViewComponent}
+     * @type {ScrollViewComponent|undefined}
      * @readonly
      */
     scrollview;
@@ -196,7 +196,7 @@ class Entity extends GraphNode {
     /**
      * Gets the {@link SoundComponent} attached to this entity.
      *
-     * @type {SoundComponent}
+     * @type {SoundComponent|undefined}
      * @readonly
      */
     sound;
@@ -204,7 +204,7 @@ class Entity extends GraphNode {
     /**
      * Gets the {@link SpriteComponent} attached to this entity.
      *
-     * @type {SpriteComponent}
+     * @type {SpriteComponent|undefined}
      * @readonly
      */
     sprite;


### PR DESCRIPTION
Tighten up the JSDoc typings for components on `Entity` and component systems on `ComponentSystemRegistry` which can also be `undefined`.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
