### PR TITLE
When Texture#_glTexture is accessed, print deprecated message

### DIFF
--- a/src/deprecated/deprecated.js
+++ b/src/deprecated/deprecated.js
@@ -462,7 +462,7 @@ Object.defineProperties(Texture.prototype, {
     },
 
     _glTexture: {
-        get: function() {
+        get: function () {
             Debug.deprecated("pc.Texture#_glTexture is no longer available, use Use pc.Texture.impl._glTexture instead.");
             return null;
         }

--- a/src/deprecated/deprecated.js
+++ b/src/deprecated/deprecated.js
@@ -464,7 +464,7 @@ Object.defineProperties(Texture.prototype, {
     _glTexture: {
         get: function () {
             Debug.deprecated("pc.Texture#_glTexture is no longer available, use Use pc.Texture.impl._glTexture instead.");
-            return null;
+            return this.impl._glTexture;
         }
     }
 });

--- a/src/deprecated/deprecated.js
+++ b/src/deprecated/deprecated.js
@@ -459,6 +459,13 @@ Object.defineProperties(Texture.prototype, {
             Debug.deprecated("pc.Texture#swizzleGGGR is deprecated. Use pc.Texture#type instead.");
             this.type = swizzleGGGR ? TEXTURETYPE_SWIZZLEGGGR : TEXTURETYPE_DEFAULT;
         }
+    },
+
+    _glTexture: {
+        get: function() {
+            Debug.deprecated("pc.Texture#_glTexture is no longer available, use Use pc.Texture.impl._glTexture instead.");
+            return null;
+        }
     }
 });
 


### PR DESCRIPTION
Fixes: https://github.com/playcanvas/engine/issues/4087

Even though _glTexture is a private member, it's used in few publicly available scripts .. and so when this is used, a deprecated message is logged out allowing the user to fix their code easily.

The deprecated function returns the correct value, and so it functions even without a client change.