### PR TITLE
Disable depth write on semitransparent gltf materials

### DIFF
--- a/src/resources/parser/glb-parser.js
+++ b/src/resources/parser/glb-parser.js
@@ -1154,7 +1154,7 @@ const createMaterial = function (gltfMaterial, textures) {
                 break;
             case 'BLEND':
                 material.blendType = BLEND_NORMAL;
-                // note: by default don't write depth on semitrans materials
+                // note: by default don't write depth on semitransparent materials
                 material.depthWrite = false;
                 break;
             default:

--- a/src/resources/parser/glb-parser.js
+++ b/src/resources/parser/glb-parser.js
@@ -1154,6 +1154,8 @@ const createMaterial = function (gltfMaterial, textures) {
                 break;
             case 'BLEND':
                 material.blendType = BLEND_NORMAL;
+                // note: by default don't write depth on semitrans materials
+                material.depthWrite = false;
                 break;
             default:
             case 'OPAQUE':


### PR DESCRIPTION
This PR disables depth write for semitransparent materials loaded in gltf.

Has the following benefits:
- overlapping semitransparent surfaces don't obscure each other
- possible rendering performance improvement due to not unnecessarily writing to depth buffer