### PR TITLE
[FIX] Don't use bitwise op to set boolean

### DIFF
--- a/src/framework/components/scroll-view/component.js
+++ b/src/framework/components/scroll-view/component.js
@@ -230,11 +230,10 @@ class ScrollViewComponent extends Component {
             this._velocity.set(0, 0, 0);
         }
 
-        let hasChanged = false;
-        hasChanged |= this._updateAxis(x, 'x', ORIENTATION_HORIZONTAL);
-        hasChanged |= this._updateAxis(y, 'y', ORIENTATION_VERTICAL);
+        const xChanged = this._updateAxis(x, 'x', ORIENTATION_HORIZONTAL);
+        const yChanged = this._updateAxis(y, 'y', ORIENTATION_VERTICAL);
 
-        if (hasChanged) {
+        if (xChanged || yChanged) {
             this.fire('set:scroll', this._scroll);
         }
     }


### PR DESCRIPTION
Interesting bug. The code actually works but it's just plain wrong. Bitwise `|=` is used to set a boolean. This means that `hasChanged` ends up being set to `0` or `1` instead of `true` or `false`. The original developer meant to use `||=` but frankly, I think my mini-rework here is easier on the eye.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
