### PR TITLE
Use skyboxIntensity if spheremap is used

### DIFF
--- a/src/scene/materials/standard-material-options-builder.js
+++ b/src/scene/materials/standard-material-options-builder.js
@@ -186,7 +186,6 @@ class StandardMaterialOptionsBuilder {
 
         let usingSceneEnv = false;
 
-        // use skybox intensity if either a sphere or cubemap is used on the material
         let usingSphereMap = false;
 
         // source of environment reflections is as follows:

--- a/src/scene/materials/standard-material-options-builder.js
+++ b/src/scene/materials/standard-material-options-builder.js
@@ -186,6 +186,9 @@ class StandardMaterialOptionsBuilder {
 
         let usingSceneEnv = false;
 
+        // use skybox intensity if either a sphere or cubemap is used on the material
+        let usingSphereMap = false;
+
         // source of environment reflections is as follows:
         if (stdMat.envAtlas && !isPhong) {
             options.reflectionSource = 'envAtlas';
@@ -196,6 +199,7 @@ class StandardMaterialOptionsBuilder {
         } else if (stdMat.sphereMap) {
             options.reflectionSource = 'sphereMap';
             options.reflectionEncoding = stdMat.sphereMap.encoding;
+            usingSphereMap = true;
         } else if (stdMat.useSkybox && scene.envAtlas && !isPhong) {
             options.reflectionSource = 'envAtlas';
             options.reflectionEncoding = scene.envAtlas.encoding;
@@ -221,7 +225,7 @@ class StandardMaterialOptionsBuilder {
         }
 
         // TODO: add a test for if non skybox cubemaps have rotation (when this is supported) - for now assume no non-skybox cubemap rotation
-        options.skyboxIntensity = usingSceneEnv && (scene.skyboxIntensity !== 1);
+        options.skyboxIntensity = (usingSceneEnv || usingSphereMap) && (scene.skyboxIntensity !== 1);
         options.useCubeMapRotation = usingSceneEnv && scene.skyboxRotation && !scene.skyboxRotation.equals(Quat.IDENTITY);
     }
 


### PR DESCRIPTION
Fixes #4106

PR #3980 was made to fix bug #3979 but introduced bug #4106.

This PR has been checked against test projects in #3979 and #4106


I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
