### PR TITLE
fix: Entity.Clone() should have return type Entity

### DIFF
--- a/src/framework/components/element/component.js
+++ b/src/framework/components/element/component.js
@@ -226,6 +226,11 @@ class ElementComponent extends Component {
 
         this._patch();
 
+        /**
+         * The Entity with a ScreenComponent that this component belongs to
+         *
+         * @type {Entity}
+         */
         this.screen = null;
 
         this._type = ELEMENTTYPE_GROUP;

--- a/src/framework/components/script/component.js
+++ b/src/framework/components/script/component.js
@@ -73,7 +73,7 @@ class ScriptComponent extends Component {
      * An array of all script instances attached to an entity. This array is read-only and should
      * not be modified by developer.
      *
-     * @type {ScriptType[]}
+     * @param {ScriptType[]} value
      */
     set scripts(value) {
         this._scriptsData = value;

--- a/src/framework/entity.js
+++ b/src/framework/entity.js
@@ -587,7 +587,7 @@ class Entity extends GraphNode {
      * Create a deep copy of the Entity. Duplicate the full Entity hierarchy, with all Components
      * and all descendants. Note, this Entity is not in the hierarchy and must be added manually.
      *
-     * @returns {GraphNode} A new Entity which is a deep copy of the original.
+     * @returns {Entity} A new Entity which is a deep copy of the original.
      * @example
      * var e = this.entity.clone();
      *

--- a/src/scene/mesh-instance.js
+++ b/src/scene/mesh-instance.js
@@ -124,7 +124,7 @@ class MeshInstance {
          */
         this.node = node;           // The node that defines the transform of the mesh instance
         this._mesh = mesh;          // The mesh that this instance renders
-        mesh.incRefCount();
+        mesh.incRefCount(); 
         this.material = material;   // The material with which to render this instance
 
         this._shaderDefs = MASK_AFFECT_DYNAMIC << 16; // 2 byte toggles, 2 bytes light mask; Default value is no toggles and mask = pc.MASK_AFFECT_DYNAMIC
@@ -365,7 +365,7 @@ class MeshInstance {
     /**
      * The material used by this mesh instance.
      *
-     * @type {Material}
+     * @param {Material} material
      */
     set material(material) {
         for (let i = 0; i < this._shader.length; i++) {

--- a/types-fixup.mjs
+++ b/types-fixup.mjs
@@ -49,7 +49,8 @@ fs.writeFileSync(path, dts);
 
 const animationComponentProps = [
     ['activate', 'boolean'],
-    ['assets', 'any[]'],
+    ['assets', 'Asset[]|number[]'],
+    ['animations', '{[string]: Animation}'],
     ['loop', 'boolean'],
     ['skeleton', 'any'],
     ['speed', 'number']


### PR DESCRIPTION
Fixes #
fix: AnimationComponent assets should be of type `Asset[]|number[]`
fix: AnimationComponent animations should be of type `{[string]: Animation}`
fix: ScreenComponent.screen should be of type Entity
fix: ScriptComponent.scripts should be of type `ScriptType[]`
fix: MeshInstance.material should be of type Material

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
