### PR TITLE
Revert "Fix EntityReference not finding the entity if the parent was not added to the scene yet. (#4081)"

### DIFF
--- a/test/framework/utils/entity-reference.test.mjs
+++ b/test/framework/utils/entity-reference.test.mjs
@@ -74,7 +74,7 @@ describe("EntityReference", function () {
         expect(reference.entity).to.equal(otherEntity1);
     });
 
-    it("attempts to resolve the entity reference if the parent component is not on the scene graph yet", function () {
+    it("does not attempt to resolve the entity reference if the parent component is not on the scene graph yet", function () {
         app.root.removeChild(testEntity);
 
         sinon.spy(app.root, "findByGuid");
@@ -82,38 +82,20 @@ describe("EntityReference", function () {
         const reference = new EntityReference(testComponent, "myEntity1");
         testComponent.myEntity1 = otherEntity1.getGuid();
 
-        expect(reference.entity).to.equal(otherEntity1);
-        expect(app.root.findByGuid.callCount).to.equal(1);
+        expect(reference.entity).to.equal(null);
+        expect(app.root.findByGuid.callCount).to.equal(0);
     });
 
-    it("resolves the entity reference when added to graph later and onParentComponentEnable() is called", function () {
-        app.root.removeChild(otherEntity1);
+    it("resolves the entity reference when onParentComponentEnable() is called", function () {
+        app.root.removeChild(testEntity);
 
         const reference = new EntityReference(testComponent, "myEntity1");
         testComponent.myEntity1 = otherEntity1.getGuid();
         expect(reference.entity).to.equal(null);
 
-        app.root.addChild(otherEntity1);
+        app.root.addChild(testEntity);
         reference.onParentComponentEnable();
 
-        expect(reference.entity).to.equal(otherEntity1);
-    });
-
-    it("resolves the entity reference when entity and parent are in their own graph", function () {
-        app.root.removeChild(testEntity);
-        app.root.removeChild(otherEntity1);
-        testEntity.root.addChild(otherEntity1);
-
-        const reference = new EntityReference(testComponent, "myEntity1");
-        testComponent.myEntity1 = otherEntity1.getGuid();
-        expect(reference.entity).to.equal(otherEntity1);
-    });
-
-    it("resolves the entity reference when entity is in scene graph but parent is not", function () {
-        app.root.removeChild(testEntity);
-
-        const reference = new EntityReference(testComponent, "myEntity1");
-        testComponent.myEntity1 = otherEntity1.getGuid();
         expect(reference.entity).to.equal(otherEntity1);
     });
 


### PR DESCRIPTION
This reverts commit 33af0a817dae2db5f996f66d2c546f0218009897, PR https://github.com/playcanvas/engine/pull/4081

Fixes https://github.com/playcanvas/engine/issues/4114 

Note that the original issue that the reverted PR was fixing is also fixed by https://github.com/playcanvas/engine/pull/4054.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
