### PR TITLE
Revert change from #4047 related to enabled in hierarchy

### DIFF
--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -1326,11 +1326,12 @@ class GraphNode extends EventHandler {
         // Clear parent
         child._parent = null;
 
+        // NOTE: see PR #4047 - this fix is removed for now as it breaks other things
         // notify the child hierarchy it has been removed from the parent,
         // which marks them as not enabled in hierarchy
-        if (child._enabledInHierarchy) {
-            child._notifyHierarchyStateChanged(child, false);
-        }
+        // if (child._enabledInHierarchy) {
+        //     child._notifyHierarchyStateChanged(child, false);
+        // }
 
         // alert children that they has been removed
         child._fireOnHierarchy('remove', 'removehierarchy', this);


### PR DESCRIPTION
This reverts the fix introduced here: https://github.com/playcanvas/engine/pull/4047

As it causes multiple issues in dependent code, see https://forum.playcanvas.com/t/memory-access-out-of-bound-v1-52-3-issue/24790 