### PR TITLE
[Fix] setting xr managed references to null after cleanup

### DIFF
--- a/src/xr/xr-manager.js
+++ b/src/xr/xr-manager.js
@@ -569,14 +569,6 @@ class XrManager extends EventHandler {
 
         // clean up once session is ended
         const onEnd = () => {
-            this._session = null;
-            this._referenceSpace = null;
-            this.views = [];
-            this._width = 0;
-            this._height = 0;
-            this._type = null;
-            this._spaceType = null;
-
             if (this._camera) {
                 this._camera.off('set_nearClip', onClipPlanesChange);
                 this._camera.off('set_farClip', onClipPlanesChange);
@@ -589,6 +581,14 @@ class XrManager extends EventHandler {
             session.removeEventListener('visibilitychange', onVisibilityChange);
 
             if (!failed) this.fire('end');
+
+            this._session = null;
+            this._referenceSpace = null;
+            this.views = [];
+            this._width = 0;
+            this._height = 0;
+            this._type = null;
+            this._spaceType = null;
 
             // old requestAnimationFrame will never be triggered,
             // so queue up new tick


### PR DESCRIPTION
Fixes https://github.com/playcanvas/engine/issues/4115 by cleaning references after end event, not before.