### PR TITLE
[FIX] Fall back to previous Web Audio API spec as required

### DIFF
--- a/src/audio/channel3d.js
+++ b/src/audio/channel3d.js
@@ -1,3 +1,5 @@
+import { Debug } from '../core/debug.js';
+
 import { math } from '../math/math.js';
 import { Vec3 } from '../math/vec3.js';
 
@@ -48,20 +50,26 @@ class Channel3d extends Channel {
         return this.position;
     }
 
+    setPosition(position) {
+        this.position.copy(position);
+        const panner = this.panner;
+        if ('positionX' in panner) {
+            panner.positionX.value = position.x;
+            panner.positionY.value = position.y;
+            panner.positionZ.value = position.z;
+        } else if (panner.setPosition) { // Firefox (and legacy browsers)
+            panner.setPosition(position.x, position.y, position.z);
+        }
+    }
+
     getVelocity() {
+        Debug.warn('Channel3d#getVelocity is not implemented.');
         return this.velocity;
     }
 
-    setPosition(position) {
-        this.position.copy(position);
-        this.panner.positionX.value = position.x;
-        this.panner.positionY.value = position.y;
-        this.panner.positionZ.value = position.z;
-    }
-
     setVelocity(velocity) {
+        Debug.warn('Channel3d#setVelocity is not implemented.');
         this.velocity.copy(velocity);
-        this.panner.setVelocity(velocity.x, velocity.y, velocity.z);
     }
 
     getMaxDistance() {
@@ -160,10 +168,6 @@ if (!hasAudioContext()) {
                 const v = this.getVolume();
                 this.source.volume = v * factor;
             }
-        },
-
-        setVelocity: function (velocity) {
-            this.velocity.copy(velocity);
         },
 
         getMaxDistance: function () {

--- a/src/sound/listener.js
+++ b/src/sound/listener.js
@@ -1,3 +1,5 @@
+import { Debug } from '../core/debug.js';
+
 import { Vec3 } from '../math/vec3.js';
 import { Mat4 } from '../math/mat4.js';
 
@@ -56,9 +58,13 @@ class Listener {
         this.position.copy(position);
         const listener = this.listener;
         if (listener) {
-            listener.positionX.value = position.x;
-            listener.positionY.value = position.y;
-            listener.positionZ.value = position.z;
+            if ('positionX' in listener) {
+                listener.positionX.value = position.x;
+                listener.positionY.value = position.y;
+                listener.positionZ.value = position.z;
+            } else if (listener.setPosition) { // Firefox (and legacy browsers)
+                listener.setPosition(position.x, position.y, position.z);
+            }
         }
     }
 
@@ -66,8 +72,10 @@ class Listener {
      * Get the velocity of the listener.
      *
      * @returns {Vec3} The velocity of the listener.
+     * @deprecated
      */
     getVelocity() {
+        Debug.warn('Listener#getVelocity is not implemented.');
         return this.velocity;
     }
 
@@ -75,15 +83,10 @@ class Listener {
      * Set the velocity of the listener.
      *
      * @param {Vec3} velocity - The new velocity of the listener.
+     * @deprecated
      */
     setVelocity(velocity) {
-        this.velocity.copy(velocity);
-        const listener = this.listener;
-        if (listener) {
-            listener.positionX.value = velocity.x;
-            listener.positionY.value = velocity.y;
-            listener.positionZ.value = velocity.z;
-        }
+        Debug.warn('Listener#setVelocity is not implemented.');
     }
 
     /**
@@ -96,13 +99,17 @@ class Listener {
         const listener = this.listener;
         if (listener) {
             const m = orientation.data;
-            listener.forwardX.value = -m[8];
-            listener.forwardY.value = -m[9];
-            listener.forwardZ.value = -m[10];
+            if ('forwardX' in listener) {
+                listener.forwardX.value = -m[8];
+                listener.forwardY.value = -m[9];
+                listener.forwardZ.value = -m[10];
 
-            listener.upX.value = m[4];
-            listener.upY.value = m[5];
-            listener.upZ.value = m[6];
+                listener.upX.value = m[4];
+                listener.upY.value = m[5];
+                listener.upZ.value = m[6];
+            } else if (listener.setOrientation) { // Firefox (and legacy browsers)
+                listener.setOrientation(-m[8], -m[9], -m[10], m[4], m[5], m[6]);
+            }
         }
     }
 


### PR DESCRIPTION
Adhere to the 'up-to-date' Web Audio API specification, but do not assume it is always supported. Instead, fallback to older versions of the spec as required. At the time of writing, Firefox still only implements a previous version of the spec.

This PR also takes to opportunity to officially deprecate/retire API related to listener/sound velocity.

Tested on Windows 10 in:

* IE11
* Chrome
* Firefox

Fixes #4137

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
