### PR TITLE
Add Vec3 Support for setFromEulerAngles() pc.Quat function

### DIFF
--- a/src/math/quat.js
+++ b/src/math/quat.js
@@ -372,15 +372,28 @@ class Quat {
     /**
      * Sets a quaternion from Euler angles specified in XYZ order.
      *
-     * @param {number} ex - Angle to rotate around X axis in degrees.
+     * @param {number|Vec3} ex - Angle to rotate around X axis in degrees. If ex is a Vec3,
+     * the Vec3 will be used to populate the first 3 components.
      * @param {number} ey - Angle to rotate around Y axis in degrees.
      * @param {number} ez - Angle to rotate around Z axis in degrees.
      * @returns {Quat} Self for chaining.
      * @example
+     * // Create a quaternion from 3 euler angles
      * var q = new pc.Quat();
      * q.setFromEulerAngles(45, 90, 180);
+     *
+     * // Create the same quaternion from a vector containing the same 3 euler angles
+     * var v = new Vec3(45, 90, 180);
+     * var r = new pc.Quat();
+     * r.setFromEulerAngles(v);
      */
     setFromEulerAngles(ex, ey, ez) {
+        if (ex instanceof Vec3) {
+            ez = ex.z;
+            ey = ex.y;
+            ex = ex.x;
+        }
+
         const halfToRad = 0.5 * math.DEG_TO_RAD;
         ex *= halfToRad;
         ey *= halfToRad;

--- a/test/math/quat.test.mjs
+++ b/test/math/quat.test.mjs
@@ -486,16 +486,23 @@ describe('Quat', function () {
             it('sets the quaternion from ' + x + '°, ' + y + '°, ' + z + '°', function () {
                 const q1 = new Quat();
                 const q2 = new Quat();
+                const q3 = new Quat();
                 const m = new Mat4();
 
                 q1.setFromEulerAngles(x, y, z);
                 m.setFromEulerAngles(x, y, z);
                 q2.setFromMat4(m);
+                q3.setFromEulerAngles(new Vec3(x, y, z));
 
                 expect(q1.x).to.be.closeTo(q2.x, 0.0001);
                 expect(q1.y).to.be.closeTo(q2.y, 0.0001);
                 expect(q1.z).to.be.closeTo(q2.z, 0.0001);
                 expect(q1.w).to.be.closeTo(q2.w, 0.0001);
+
+                expect(q3.x).to.be.closeTo(q2.x, 0.0001);
+                expect(q3.y).to.be.closeTo(q2.y, 0.0001);
+                expect(q3.z).to.be.closeTo(q2.z, 0.0001);
+                expect(q3.w).to.be.closeTo(q2.w, 0.0001);
             });
         });
 


### PR DESCRIPTION
Fixes #3633

**Discussion**
I thought of two ways to instantiate `ex`, `ey`, and `ez` given the condition where `ex instanceof Vec3` is true:
1. Prematurely optimize by setting `ex = ex.x` so we don't have to make a clone of `ex`. A rule of thumb in software development is that "premature optimization is the root of all evil". However, since this is a game engine where optimization matters, I think it is okay to bend the rules. If reviewer says otherwise, I will make changes based on their suggestions.
```js
if (ex instanceof Vec3) {
    ez = ex.z;
    ey = ex.y;
    ex = ex.x;
}
```

2. Clone `ex` and use the cloned `Vec3` to instantiate `ex`, `ey`, and `ez`. Depending on the person, this might be easier to understand that option 1. But there is a small performance penalty because this creates an extra `Vec3` object.
```js
if (ex instanceof Vec3) {
    const v = ex.clone();
    ex = v.x;
    ey = v.y;
    ez = v.z;
}
```
I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
