### PR TITLE
Turn off Antialiasing on webkit 15.4 to avoid rendering issues

### DIFF
--- a/src/graphics/webgl/webgl-graphics-device.js
+++ b/src/graphics/webgl/webgl-graphics-device.js
@@ -255,6 +255,15 @@ class WebglGraphicsDevice extends GraphicsDevice {
             options.powerPreference = 'high-performance';
         }
 
+        // #4136 - turn off antialiasing on AppleWebKit browsers 15.4
+        if (typeof navigator !== 'undefined') {
+            const ua = navigator.userAgent;
+            if (ua.includes('AppleWebKit') && (ua.includes('15.4') || ua.includes('15_4'))) {
+                options.antialias = false;
+                Debug.log("Antialiasing has been turned off due to rendering issues on AppleWebKit 15.4");
+            }
+        }
+
         // Retrieve the WebGL context
         const preferWebGl2 = (options.preferWebGl2 !== undefined) ? options.preferWebGl2 : true;
 


### PR DESCRIPTION
Fixes https://github.com/playcanvas/engine/issues/4136

This is a workaround for rendering issue when antialiasing is enabled on Webkit based browsers (macOS and iOS) version 15.4. 

The disadvantage is that antialiasing is turned off even for applications that do not exhibit any rendering issues, but that is probably a safer option.