### PR TITLE
Workaround for Samsung Exynos particle rendering/crash

### DIFF
--- a/src/graphics/webgl/webgl-graphics-device.js
+++ b/src/graphics/webgl/webgl-graphics-device.js
@@ -749,6 +749,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
      */
     initializeExtensions() {
         const gl = this.gl;
+        const userAgent = typeof navigator !== 'undefined' ? navigator.userAgent : "";
 
         const supportedExtensions = gl.getSupportedExtensions();
 
@@ -823,7 +824,18 @@ class WebglGraphicsDevice extends GraphicsDevice {
         // iOS exposes this for half precision render targets on both Webgl1 and 2 from iOS v 14.5beta
         this.extColorBufferHalfFloat = getExtension("EXT_color_buffer_half_float");
 
+        const ext = this.extDebugRendererInfo;
+        this.unmaskedRenderer = ext ? gl.getParameter(ext.UNMASKED_RENDERER_WEBGL) : '';
+        this.unmaskedVendor = ext ? gl.getParameter(ext.UNMASKED_VENDOR_WEBGL) : '';
+
         this.supportsInstancing = !!this.extInstancing;
+
+        // Check if we support GPU particles. At the moment, Samsung devices with Exynos (ARM) either crash or render
+        // incorrectly when using GPU for particles. See:
+        // https://github.com/playcanvas/engine/issues/3967
+        // https://github.com/playcanvas/engine/issues/3415
+        const samsungModelRegex = /SM-[a-zA-Z0-9]+\)/;
+        this.supportsGpuParticles = !(this.unmaskedVendor === 'ARM' && userAgent.match(samsungModelRegex));
     }
 
     /**
@@ -860,10 +872,6 @@ class WebglGraphicsDevice extends GraphicsDevice {
             this.maxColorAttachments = ext ? gl.getParameter(ext.MAX_COLOR_ATTACHMENTS_EXT) : 1;
             this.maxVolumeSize = 1;
         }
-
-        ext = this.extDebugRendererInfo;
-        this.unmaskedRenderer = ext ? gl.getParameter(ext.UNMASKED_RENDERER_WEBGL) : '';
-        this.unmaskedVendor = ext ? gl.getParameter(ext.UNMASKED_VENDOR_WEBGL) : '';
 
         ext = this.extTextureFilterAnisotropic;
         this.maxAnisotropy = ext ? gl.getParameter(ext.MAX_TEXTURE_MAX_ANISOTROPY_EXT) : 1;

--- a/src/graphics/webgl/webgl-graphics-device.js
+++ b/src/graphics/webgl/webgl-graphics-device.js
@@ -749,8 +749,6 @@ class WebglGraphicsDevice extends GraphicsDevice {
      */
     initializeExtensions() {
         const gl = this.gl;
-        const userAgent = typeof navigator !== 'undefined' ? navigator.userAgent : "";
-
         const supportedExtensions = gl.getSupportedExtensions();
 
         const getExtension = function () {
@@ -823,19 +821,6 @@ class WebglGraphicsDevice extends GraphicsDevice {
 
         // iOS exposes this for half precision render targets on both Webgl1 and 2 from iOS v 14.5beta
         this.extColorBufferHalfFloat = getExtension("EXT_color_buffer_half_float");
-
-        const ext = this.extDebugRendererInfo;
-        this.unmaskedRenderer = ext ? gl.getParameter(ext.UNMASKED_RENDERER_WEBGL) : '';
-        this.unmaskedVendor = ext ? gl.getParameter(ext.UNMASKED_VENDOR_WEBGL) : '';
-
-        this.supportsInstancing = !!this.extInstancing;
-
-        // Check if we support GPU particles. At the moment, Samsung devices with Exynos (ARM) either crash or render
-        // incorrectly when using GPU for particles. See:
-        // https://github.com/playcanvas/engine/issues/3967
-        // https://github.com/playcanvas/engine/issues/3415
-        const samsungModelRegex = /SM-[a-zA-Z0-9]+\)/;
-        this.supportsGpuParticles = !(this.unmaskedVendor === 'ARM' && userAgent.match(samsungModelRegex));
     }
 
     /**
@@ -847,11 +832,15 @@ class WebglGraphicsDevice extends GraphicsDevice {
         const gl = this.gl;
         let ext;
 
+        const userAgent = typeof navigator !== 'undefined' ? navigator.userAgent : "";
+
         this.maxPrecision = this.precision = this.getPrecision();
 
         const contextAttribs = gl.getContextAttributes();
         this.supportsMsaa = contextAttribs.antialias;
         this.supportsStencil = contextAttribs.stencil;
+
+        this.supportsInstancing = !!this.extInstancing;
 
         // Query parameter values from the WebGL context
         this.maxTextureSize = gl.getParameter(gl.MAX_TEXTURE_SIZE);
@@ -872,6 +861,17 @@ class WebglGraphicsDevice extends GraphicsDevice {
             this.maxColorAttachments = ext ? gl.getParameter(ext.MAX_COLOR_ATTACHMENTS_EXT) : 1;
             this.maxVolumeSize = 1;
         }
+
+        ext = this.extDebugRendererInfo;
+        this.unmaskedRenderer = ext ? gl.getParameter(ext.UNMASKED_RENDERER_WEBGL) : '';
+        this.unmaskedVendor = ext ? gl.getParameter(ext.UNMASKED_VENDOR_WEBGL) : '';
+
+        // Check if we support GPU particles. At the moment, Samsung devices with Exynos (ARM) either crash or render
+        // incorrectly when using GPU for particles. See:
+        // https://github.com/playcanvas/engine/issues/3967
+        // https://github.com/playcanvas/engine/issues/3415
+        const samsungModelRegex = /SM-[a-zA-Z0-9]+\)/;
+        this.supportsGpuParticles = !(this.unmaskedVendor === 'ARM' && userAgent.match(samsungModelRegex));
 
         ext = this.extTextureFilterAnisotropic;
         this.maxAnisotropy = ext ? gl.getParameter(ext.MAX_TEXTURE_MAX_ANISOTROPY_EXT) : 1;

--- a/src/scene/particle-system/particle-emitter.js
+++ b/src/scene/particle-system/particle-emitter.js
@@ -340,7 +340,7 @@ class ParticleEmitter {
 
         this.swapTex = false;
         this.useMesh = true;
-        this.useCpu = false;
+        this.useCpu = !graphicsDevice.supportsGpuParticles;
 
         this.pack8 = true;
         this.localBounds = new BoundingBox();


### PR DESCRIPTION
Added supportsGpuParticles flag to graphics device which checks against the Samsung model name and ARM chipset (exynos)

A search on GSM Arena for 'SM-' shows only Samsung devices so I'm reasonable confident there will be minimal false negatives where CPU is used for particles on non-Samsung devices.

https://www.gsmarena.com/results.php3?sQuickSearch=yes&sName=sm-

Worksaround:
https://github.com/playcanvas/engine/issues/3415
https://github.com/playcanvas/engine/issues/3460
https://github.com/playcanvas/engine/issues/3967

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
