### PR TITLE
Add retry option for glue and fallback downloading methods

### DIFF
--- a/src/resources/basis.js
+++ b/src/resources/basis.js
@@ -18,7 +18,7 @@ const getCompressionFormats = (device) => {
 };
 
 // download basis code and compile the wasm module for use in workers
-const prepareWorkerModules = (config, callback) => {
+const prepareWorkerModules = (config, maxRetries, callback) => {
     const getWorkerBlob = () => {
         const code = '(' + BasisWorker.toString() + ')()\n\n';
         return new Blob([code], { type: 'application/javascript' });
@@ -45,12 +45,18 @@ const prepareWorkerModules = (config, callback) => {
         });
     };
 
+    const options = {
+        responseType: 'blob',
+        retry: maxRetries > 0,
+        maxRetries: maxRetries
+    };
+
     if (config.glueUrl && config.wasmUrl && wasmSupported()) {
         let basisCode = null;
         let module = null;
 
         // download glue script
-        http.get(config.glueUrl, { responseType: 'blob' }, (err, response) => {
+        http.get(config.glueUrl, options, (err, response) => {
             if (err) {
                 callback(err);
             } else {
@@ -98,7 +104,7 @@ const prepareWorkerModules = (config, callback) => {
             compileManual();
         }
     } else {
-        http.get(config.fallbackUrl, { responseType: 'blob' }, (err, response) => {
+        http.get(config.fallbackUrl, options, (err, response) => {
             if (err) {
                 callback(err, null);
             } else {

--- a/src/resources/basis.js
+++ b/src/resources/basis.js
@@ -257,7 +257,7 @@ let initializing = false;
  * @param {string[]} [config.rgbaPriority] - Array of texture compression formats in priority order
  * for textures with alpha. The supported compressed formats are: 'astc', 'atc', 'dxt', 'etc1',
  * 'etc2', 'pvr'.
- * @param {number} [config.maxRetries] - Number of http load retry attempts.
+ * @param {number} [config.maxRetries] - Number of http load retry attempts. Defaults to 5.
  */
 function basisInitialize(config) {
     if (initializing) {
@@ -300,7 +300,7 @@ function basisInitialize(config) {
 
         config.rgbPriority = config.rgbPriority || defaultRgbPriority;
         config.rgbaPriority = config.rgbaPriority || defaultRgbaPriority;
-        config.maxRetries = config.maxRetries || defaultMaxRetries;
+        config.maxRetries = config.hasOwnProperty('maxRetries') ? config.maxRetries : defaultMaxRetries;
 
         prepareWorkerModules(config, (err, clientConfig) => {
             if (err) {

--- a/src/resources/basis.js
+++ b/src/resources/basis.js
@@ -18,7 +18,7 @@ const getCompressionFormats = (device) => {
 };
 
 // download basis code and compile the wasm module for use in workers
-const prepareWorkerModules = (config, maxRetries, callback) => {
+const prepareWorkerModules = (config, callback) => {
     const getWorkerBlob = () => {
         const code = '(' + BasisWorker.toString() + ')()\n\n';
         return new Blob([code], { type: 'application/javascript' });
@@ -47,8 +47,8 @@ const prepareWorkerModules = (config, maxRetries, callback) => {
 
     const options = {
         responseType: 'blob',
-        retry: maxRetries > 0,
-        maxRetries: maxRetries
+        retry: config.maxRetries > 0,
+        maxRetries: config.maxRetries
     };
 
     if (config.glueUrl && config.wasmUrl && wasmSupported()) {
@@ -223,6 +223,7 @@ class BasisClient {
 const defaultNumWorkers = 1;
 const defaultRgbPriority = ['etc1', 'etc2', 'astc', 'dxt', 'pvr', 'atc'];
 const defaultRgbaPriority = ['astc', 'dxt', 'etc2', 'pvr', 'atc'];
+const defaultMaxRetries = 5;
 
 // global state
 const queue = new BasisQueue();
@@ -256,6 +257,7 @@ let initializing = false;
  * @param {string[]} [config.rgbaPriority] - Array of texture compression formats in priority order
  * for textures with alpha. The supported compressed formats are: 'astc', 'atc', 'dxt', 'etc1',
  * 'etc2', 'pvr'.
+ * @param {number} [config.maxRetries] - Number of http load retry attempts.
  */
 function basisInitialize(config) {
     if (initializing) {
@@ -298,6 +300,7 @@ function basisInitialize(config) {
 
         config.rgbPriority = config.rgbPriority || defaultRgbPriority;
         config.rgbaPriority = config.rgbaPriority || defaultRgbaPriority;
+        config.maxRetries = config.maxRetries || defaultMaxRetries;
 
         prepareWorkerModules(config, (err, clientConfig) => {
             if (err) {


### PR DESCRIPTION
Fixes #4078

Adds `maxRetries`. Consistent with: https://github.com/playcanvas/engine/blob/main/src/resources/scene-utils.js#L14.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).