### PR TITLE
Shader texture bias and ao fixes

### DIFF
--- a/src/graphics/program-lib/chunks/ao.frag.js
+++ b/src/graphics/program-lib/chunks/ao.frag.js
@@ -3,7 +3,7 @@ export default /* glsl */`
 uniform sampler2D texture_aoMap;
 #endif
 
-void applyAO() {
+void getAO() {
     dAo = 1.0;
 
     #ifdef MAPTEXTURE
@@ -13,7 +13,5 @@ void applyAO() {
     #ifdef MAPVERTEX
     dAo *= saturate(vVertexColor.$VC);
     #endif
-
-    dDiffuseLight *= dAo;
 }
 `;

--- a/src/graphics/program-lib/chunks/aoDiffuseOcc.frag.js
+++ b/src/graphics/program-lib/chunks/aoDiffuseOcc.frag.js
@@ -1,0 +1,5 @@
+export default /* glsl */`
+void occludeDiffuse() {
+    dDiffuseLight *= dAo;
+}
+`;

--- a/src/graphics/program-lib/chunks/aoSpecOccConstSimple.frag.js
+++ b/src/graphics/program-lib/chunks/aoSpecOccConstSimple.frag.js
@@ -1,7 +1,6 @@
 export default /* glsl */`
 void occludeSpecular() {
-    float specOcc = dAo;
-    dSpecularLight *= specOcc;
-    dReflection *= specOcc;
+    dSpecularLight *= dAo;
+    dReflection *= dAo;
 }
 `;

--- a/src/graphics/program-lib/chunks/chunks.js
+++ b/src/graphics/program-lib/chunks/chunks.js
@@ -3,6 +3,7 @@ import ambientConstantPS from './ambientConstant.frag.js';
 import ambientEnvPS from './ambientEnv.frag.js';
 import ambientSHPS from './ambientSH.frag.js';
 import aoPS from './ao.frag.js';
+import aoDiffuseOccPS from './aoDiffuseOcc.frag.js';
 import aoSpecOccPS from './aoSpecOcc.frag.js';
 import aoSpecOccConstPS from './aoSpecOccConst.frag.js';
 import aoSpecOccConstSimplePS from './aoSpecOccConstSimple.frag.js';
@@ -205,6 +206,7 @@ const shaderChunks = {
     ambientEnvPS,
     ambientSHPS,
     aoPS,
+    aoDiffuseOccPS,
     aoSpecOccPS,
     aoSpecOccConstPS,
     aoSpecOccConstSimplePS,

--- a/src/graphics/program-lib/programs/standard.js
+++ b/src/graphics/program-lib/programs/standard.js
@@ -388,6 +388,7 @@ const standard = {
 
         code += varyings;
         if (options.alphaTest) {
+            code += "uniform float textureBias;";
             code += "float dAlpha;\n";
             code += this._addMap("opacity", "opacityPS", options, chunks);
             code += chunks.alphaTestPS;
@@ -811,6 +812,7 @@ const standard = {
             code += "uniform vec4 uColor;\n";
             code += varyings;
             if (options.alphaTest) {
+                code += "uniform float textureBias;";
                 code += "float dAlpha;\n";
                 code += this._addMap("opacity", "opacityPS", options, chunks);
                 code += chunks.alphaTestPS;
@@ -834,6 +836,7 @@ const standard = {
             code += varyings;
             code += chunks.packDepthPS;
             if (options.alphaTest) {
+                code += "uniform float textureBias;";
                 code += "float dAlpha;\n";
                 code += this._addMap("opacity", "opacityPS", options, chunks);
                 code += chunks.alphaTestPS;
@@ -1122,6 +1125,7 @@ const standard = {
         const useAo = options.aoMap || options.aoVertexColor;
         if (useAo) {
             code += this._addMap("ao", "aoPS", options, chunks);
+            code += chunks.aoDiffuseOccPS;
             if (options.occludeSpecular) {
                 if (options.occludeSpecular === SPECOCC_AO) {
                     code += options.occludeSpecularFloat ? chunks.aoSpecOccSimplePS : chunks.aoSpecOccConstSimplePS;
@@ -1412,6 +1416,10 @@ const standard = {
             }
 
             if (options.fresnelModel > 0) code += "   getFresnel();\n";
+
+            if (useAo) {
+                code += "  getAO();\n";
+            }
         }
 
         if (addAmbient) {
@@ -1429,7 +1437,7 @@ const standard = {
             code += "   dDiffuseLight *= material_ambient;\n";
         }
         if (useAo && !options.occludeDirect) {
-            code += "    applyAO();\n";
+            code += "    occludeDiffuse();\n";
         }
         if (options.lightMap || options.lightVertexColor) {
             code += "   addLightMap();\n";
@@ -1656,7 +1664,7 @@ const standard = {
 
         if (useAo) {
             if (options.occludeDirect) {
-                code += "    applyAO();\n";
+                code += "    occludeDiffuse();\n";
             }
             if (options.occludeSpecular) {
                 code += "    occludeSpecular();\n";


### PR DESCRIPTION
**This PR makes the following changes to the standard material**:
- declare global textureBias uniform in non-main pass (this was causing shader compile errors in shadows etc)
- split ambient occlusion into 'get' and 'apply' to match most other components. This change is made with a view to splitting out material front and back end.

**Chunk changes**:
- `ao.frag.js`:
    - rename function from `applyAo` to `getAo`
    - function only calculates and sets the global `dAo`, doesn't also apply the resulting value to diffuse
- added `aoDiffuseOcc.frag.js`
    - applies the calculated global `dAo` to the diffuse component