### PR TITLE
[FIX] Superfluous argument to `WebglTexture` constructor

### DIFF
--- a/src/graphics/texture.js
+++ b/src/graphics/texture.js
@@ -256,7 +256,7 @@ class Texture {
 
         this._gpuSize = 0;
 
-        this.impl = graphicsDevice.createTextureImpl(this);
+        this.impl = graphicsDevice.createTextureImpl();
 
         // track the texture
         graphicsDevice.textures.push(this);

--- a/src/graphics/webgl/webgl-graphics-device.js
+++ b/src/graphics/webgl/webgl-graphics-device.js
@@ -674,8 +674,8 @@ class WebglGraphicsDevice extends GraphicsDevice {
         return new WebglShader(shader);
     }
 
-    createTextureImpl(texture) {
-        return new WebglTexture(texture);
+    createTextureImpl() {
+        return new WebglTexture();
     }
 
     // #if _DEBUG


### PR DESCRIPTION
Fixes:

![image](https://user-images.githubusercontent.com/697563/160235726-2bbb0b32-ba49-4b8a-8751-7d2e380981dc.png)

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
