### PR TITLE
Enforce single quotes and disallow `var` in unit tests

### DIFF
--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -3,6 +3,7 @@
         "mocha": true
     },
     "rules": {
-        "no-unused-expressions": "off"
+        "no-unused-expressions": "off",
+        "quotes": ["error", "single"]
     }
 }

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -4,6 +4,7 @@
     },
     "rules": {
         "no-unused-expressions": "off",
+        "no-var": "error",
         "quotes": ["error", "single"]
     }
 }

--- a/test/anim/evaluator/anim-evaluator.test.mjs
+++ b/test/anim/evaluator/anim-evaluator.test.mjs
@@ -19,31 +19,31 @@ describe('AnimEvaluator', function () {
         const app = new Application(canvas);
 
         // build the graph to be animated
-        var parent = new GraphNode('parent');
-        var child1 = new GraphNode('child1');
-        var child2 = new GraphNode('child2');
+        const parent = new GraphNode('parent');
+        const child1 = new GraphNode('child1');
+        const child2 = new GraphNode('child2');
 
         app.root.addChild(parent);
         parent.addChild(child1);
         child1.addChild(child2);
         // create curve
-        var keys = new AnimData(1, [0, 1, 2]);
-        var translations = new AnimData(3, [0, 0, 0, 1, 0, 0, 1, 0, 1]);
-        var curvePath = {
+        const keys = new AnimData(1, [0, 1, 2]);
+        const translations = new AnimData(3, [0, 0, 0, 1, 0, 0, 1, 0, 1]);
+        const curvePath = {
             entityPath: ['child1'],
             component: 'graph',
             propertyPath: ['localPosition']
         };
-        var curve = new AnimCurve([curvePath], 0, 0, INTERPOLATION_LINEAR);
+        const curve = new AnimCurve([curvePath], 0, 0, INTERPOLATION_LINEAR);
 
         // construct the animation track
-        var track = new AnimTrack('test track', 2, [keys], [translations], [curve]);
+        const track = new AnimTrack('test track', 2, [keys], [translations], [curve]);
 
         // construct an animation clip
-        var clip = new AnimClip(track, 0.0, 1.0, true, true);
+        const clip = new AnimClip(track, 0.0, 1.0, true, true);
 
         // construct the animation evaluator
-        var animEvaluator = new AnimEvaluator(new DefaultAnimBinder(parent));
+        const animEvaluator = new AnimEvaluator(new DefaultAnimBinder(parent));
         animEvaluator.addClip(clip);
 
         // check initial state

--- a/test/anim/evaluator/anim-evaluator.test.mjs
+++ b/test/anim/evaluator/anim-evaluator.test.mjs
@@ -12,16 +12,16 @@ import { HTMLCanvasElement } from '@playcanvas/canvas-mock';
 
 import { expect } from 'chai';
 
-describe("AnimEvaluator", function () {
+describe('AnimEvaluator', function () {
 
-    it("AnimEvaluator: looping", function () {
+    it('AnimEvaluator: looping', function () {
         const canvas = new HTMLCanvasElement(500, 500);
         const app = new Application(canvas);
 
         // build the graph to be animated
-        var parent = new GraphNode("parent");
-        var child1 = new GraphNode("child1");
-        var child2 = new GraphNode("child2");
+        var parent = new GraphNode('parent');
+        var child1 = new GraphNode('child1');
+        var child2 = new GraphNode('child2');
 
         app.root.addChild(parent);
         parent.addChild(child1);
@@ -37,7 +37,7 @@ describe("AnimEvaluator", function () {
         var curve = new AnimCurve([curvePath], 0, 0, INTERPOLATION_LINEAR);
 
         // construct the animation track
-        var track = new AnimTrack("test track", 2, [keys], [translations], [curve]);
+        var track = new AnimTrack('test track', 2, [keys], [translations], [curve]);
 
         // construct an animation clip
         var clip = new AnimClip(track, 0.0, 1.0, true, true);

--- a/test/asset/asset-localized.test.mjs
+++ b/test/asset/asset-localized.test.mjs
@@ -20,7 +20,7 @@ describe('LocalizedAsset', function () {
     });
 
     it('sets defaultAsset and localizedAsset to the same id if defaultAsset has no localization', function () {
-        const asset = new Asset("Default Asset", "texture");
+        const asset = new Asset('Default Asset', 'texture');
 
         app.assets.add(asset);
 
@@ -32,7 +32,7 @@ describe('LocalizedAsset', function () {
     });
 
     it('does not add load and change events to the asset when autoLoad is false', function () {
-        const asset = new Asset("Default Asset", "texture");
+        const asset = new Asset('Default Asset', 'texture');
 
         app.assets.add(asset);
 
@@ -44,7 +44,7 @@ describe('LocalizedAsset', function () {
     });
 
     it('adds load, change and remove events to the asset when autoLoad is true', function () {
-        const asset = new Asset("Default Asset", "texture");
+        const asset = new Asset('Default Asset', 'texture');
 
         app.assets.add(asset);
 
@@ -58,7 +58,7 @@ describe('LocalizedAsset', function () {
     });
 
     it('adds events to the asset when autoLoad becomes true later', function () {
-        const asset = new Asset("Default Asset", "texture");
+        const asset = new Asset('Default Asset', 'texture');
 
         app.assets.add(asset);
 
@@ -73,8 +73,8 @@ describe('LocalizedAsset', function () {
     });
 
     it('picks the correct localizedAsset when the locale is already different', function () {
-        const asset = new Asset("Default Asset", "texture");
-        const asset2 = new Asset("Localized Asset", "texture");
+        const asset = new Asset('Default Asset', 'texture');
+        const asset2 = new Asset('Localized Asset', 'texture');
 
         asset.addLocalizedAssetId('fr', asset2.id);
 
@@ -91,8 +91,8 @@ describe('LocalizedAsset', function () {
     });
 
     it('changes the localized asset after defaultAsset and then the locale change', function () {
-        const asset = new Asset("Default Asset", "texture");
-        const asset2 = new Asset("Localized Asset", "texture");
+        const asset = new Asset('Default Asset', 'texture');
+        const asset2 = new Asset('Localized Asset', 'texture');
 
         asset.addLocalizedAssetId('fr', asset2.id);
 
@@ -110,8 +110,8 @@ describe('LocalizedAsset', function () {
     });
 
     it('removes events from the defaultAsset and localizedAsset is changed', function () {
-        const asset = new Asset("Default Asset", "texture");
-        const asset2 = new Asset("Localized Asset", "texture");
+        const asset = new Asset('Default Asset', 'texture');
+        const asset2 = new Asset('Localized Asset', 'texture');
 
         asset.addLocalizedAssetId('fr', asset2.id);
 
@@ -142,7 +142,7 @@ describe('LocalizedAsset', function () {
     });
 
     it('propagates asset events to LocalizedAsset', function () {
-        const asset = new Asset("Default Asset", "texture");
+        const asset = new Asset('Default Asset', 'texture');
 
         app.assets.add(asset);
 
@@ -176,8 +176,8 @@ describe('LocalizedAsset', function () {
     });
 
     it('uses only the defaultAsset when disableLocalization is true', function () {
-        const asset = new Asset("Default Asset", "texture");
-        const asset2 = new Asset("Localized Asset", "texture");
+        const asset = new Asset('Default Asset', 'texture');
+        const asset2 = new Asset('Localized Asset', 'texture');
 
         asset.addLocalizedAssetId('fr', asset2.id);
 
@@ -195,8 +195,8 @@ describe('LocalizedAsset', function () {
     });
 
     it('falls back to defaultAsset when a null asset is set for a locale', function () {
-        const asset = new Asset("Default Asset", "texture");
-        const asset2 = new Asset("Localized Asset", "texture");
+        const asset = new Asset('Default Asset', 'texture');
+        const asset2 = new Asset('Localized Asset', 'texture');
 
         asset.addLocalizedAssetId('fr', null);
 
@@ -213,8 +213,8 @@ describe('LocalizedAsset', function () {
     });
 
     it('fires add:localized on setting a new locale', function (done) {
-        const asset = new Asset("Default Asset", "texture");
-        const asset2 = new Asset("Localized Asset", "texture");
+        const asset = new Asset('Default Asset', 'texture');
+        const asset2 = new Asset('Localized Asset', 'texture');
 
         asset.on('add:localized', function (locale, assetId) {
             expect(locale).to.equal('fr');
@@ -226,8 +226,8 @@ describe('LocalizedAsset', function () {
     });
 
     it('fires remove:localized on removing a locale', function (done) {
-        const asset = new Asset("Default Asset", "texture");
-        const asset2 = new Asset("Localized Asset", "texture");
+        const asset = new Asset('Default Asset', 'texture');
+        const asset2 = new Asset('Localized Asset', 'texture');
 
         asset.addLocalizedAssetId('fr', asset2.id);
 
@@ -241,9 +241,9 @@ describe('LocalizedAsset', function () {
     });
 
     it('updates the localizedAsset on setting a localized asset for the current locale', function () {
-        const asset = new Asset("Default Asset", "texture");
+        const asset = new Asset('Default Asset', 'texture');
         app.assets.add(asset);
-        const asset2 = new Asset("Localized Asset", "texture");
+        const asset2 = new Asset('Localized Asset', 'texture');
         app.assets.add(asset2);
 
         const la = new LocalizedAsset(app);
@@ -256,9 +256,9 @@ describe('LocalizedAsset', function () {
     });
 
     it('updates the localizedAsset to the defaultAsset on removing a localized asset for the current locale', function () {
-        const asset = new Asset("Default Asset", "texture");
+        const asset = new Asset('Default Asset', 'texture');
         app.assets.add(asset);
-        const asset2 = new Asset("Localized Asset", "texture");
+        const asset2 = new Asset('Localized Asset', 'texture');
         app.assets.add(asset2);
 
         asset.addLocalizedAssetId('fr', asset2.id);
@@ -273,8 +273,8 @@ describe('LocalizedAsset', function () {
     });
 
     it('updates the localizedAsset on setting a localized asset for the current locale even if defaultAsset is added to the registry later', function () {
-        const asset = new Asset("Default Asset", "texture");
-        const asset2 = new Asset("Localized Asset", "texture");
+        const asset = new Asset('Default Asset', 'texture');
+        const asset2 = new Asset('Localized Asset', 'texture');
         app.assets.add(asset2);
 
         const la = new LocalizedAsset(app);
@@ -290,9 +290,9 @@ describe('LocalizedAsset', function () {
 
 
     it('switches LocalizedAsset to the defaultAsset by removing a localized asset from the registry', function () {
-        const asset = new Asset("Default Asset", "texture");
+        const asset = new Asset('Default Asset', 'texture');
         app.assets.add(asset);
-        const asset2 = new Asset("Localized Asset", "texture");
+        const asset2 = new Asset('Localized Asset', 'texture');
         app.assets.add(asset2);
 
         asset.addLocalizedAssetId('fr', asset2.id);
@@ -308,9 +308,9 @@ describe('LocalizedAsset', function () {
     });
 
     it('keeps same localizedAsset and adds "add" event handler on removing the defaultAsset from the registry', function () {
-        const asset = new Asset("Default Asset", "texture");
+        const asset = new Asset('Default Asset', 'texture');
         app.assets.add(asset);
-        const asset2 = new Asset("Localized Asset", "texture");
+        const asset2 = new Asset('Localized Asset', 'texture');
         app.assets.add(asset2);
 
         asset.addLocalizedAssetId('fr', asset2.id);
@@ -332,7 +332,7 @@ describe('LocalizedAsset', function () {
     describe('#destroy', function () {
 
         it('removes asset references and events', function () {
-            const asset = new Asset("Default Asset", "texture");
+            const asset = new Asset('Default Asset', 'texture');
 
             const la = new LocalizedAsset(app);
             la.defaultAsset = asset.id;

--- a/test/asset/asset-registry.test.mjs
+++ b/test/asset/asset-registry.test.mjs
@@ -35,7 +35,7 @@ describe('AssetRegistry', function () {
     describe('#add', function () {
 
         it('adds an asset', function () {
-            const asset = new Asset("Test Asset", 'text', {
+            const asset = new Asset('Test Asset', 'text', {
                 url: 'fake/url/file.txt'
             });
             app.assets.add(asset);
@@ -50,14 +50,14 @@ describe('AssetRegistry', function () {
     describe('#find', function () {
 
         it('works after removing an asset', function () {
-            const asset1 = new Asset("Asset 1", "text", {
-                url: "fake/one/file.txt"
+            const asset1 = new Asset('Asset 1', 'text', {
+                url: 'fake/one/file.txt'
             });
-            const asset2 = new Asset("Asset 2", "text", {
-                url: "fake/two/file.txt"
+            const asset2 = new Asset('Asset 2', 'text', {
+                url: 'fake/two/file.txt'
             });
-            const asset3 = new Asset("Asset 3", "text", {
-                url: "fake/three/file.txt"
+            const asset3 = new Asset('Asset 3', 'text', {
+                url: 'fake/three/file.txt'
             });
 
             app.assets.add(asset1);
@@ -76,7 +76,7 @@ describe('AssetRegistry', function () {
     describe('#get', function () {
 
         it('retrieves an asset by id', function () {
-            const asset = new Asset("Test Asset", 'text', {
+            const asset = new Asset('Test Asset', 'text', {
                 url: 'fake/url/file.txt'
             });
             app.assets.add(asset);
@@ -91,7 +91,7 @@ describe('AssetRegistry', function () {
     describe('#getByUrl', function () {
 
         it('retrieves an asset by url', function () {
-            const asset = new Asset("Test Asset", 'text', {
+            const asset = new Asset('Test Asset', 'text', {
                 url: 'fake/url/file.txt'
             });
             app.assets.add(asset);
@@ -102,14 +102,14 @@ describe('AssetRegistry', function () {
         });
 
         it('works after removing an asset', function () {
-            const asset1 = new Asset("Asset 1", "text", {
-                url: "fake/one/file.txt"
+            const asset1 = new Asset('Asset 1', 'text', {
+                url: 'fake/one/file.txt'
             });
-            const asset2 = new Asset("Asset 2", "text", {
-                url: "fake/two/file.txt"
+            const asset2 = new Asset('Asset 2', 'text', {
+                url: 'fake/two/file.txt'
             });
-            const asset3 = new Asset("Asset 3", "text", {
-                url: "fake/three/file.txt"
+            const asset3 = new Asset('Asset 3', 'text', {
+                url: 'fake/three/file.txt'
             });
 
             app.assets.add(asset1);
@@ -128,14 +128,14 @@ describe('AssetRegistry', function () {
     describe('#list', function () {
 
         it('lists all assets', function () {
-            const asset1 = new Asset("Asset 1", "text", {
-                url: "fake/one/file.txt"
+            const asset1 = new Asset('Asset 1', 'text', {
+                url: 'fake/one/file.txt'
             });
-            const asset2 = new Asset("Asset 2", "text", {
-                url: "fake/two/file.txt"
+            const asset2 = new Asset('Asset 2', 'text', {
+                url: 'fake/two/file.txt'
             });
-            const asset3 = new Asset("Asset 3", "text", {
-                url: "fake/three/file.txt"
+            const asset3 = new Asset('Asset 3', 'text', {
+                url: 'fake/three/file.txt'
             });
 
             app.assets.add(asset1);
@@ -233,14 +233,14 @@ describe('AssetRegistry', function () {
     describe('#remove', function () {
 
         it('removes by id', function () {
-            const asset1 = new Asset("Asset 1", "text", {
-                url: "fake/one/file.txt"
+            const asset1 = new Asset('Asset 1', 'text', {
+                url: 'fake/one/file.txt'
             });
-            const asset2 = new Asset("Asset 2", "text", {
-                url: "fake/two/file.txt"
+            const asset2 = new Asset('Asset 2', 'text', {
+                url: 'fake/two/file.txt'
             });
-            const asset3 = new Asset("Asset 3", "text", {
-                url: "fake/three/file.txt"
+            const asset3 = new Asset('Asset 3', 'text', {
+                url: 'fake/three/file.txt'
             });
 
             app.assets.add(asset1);

--- a/test/core/event-handler.test.mjs
+++ b/test/core/event-handler.test.mjs
@@ -7,13 +7,13 @@ describe('EventHandler', function () {
     describe('#hasEvent', function () {
 
         it('returns true if the event is registered', function () {
-            var e = new EventHandler();
+            const e = new EventHandler();
             e.on('test', function () { });
             expect(e.hasEvent('test')).to.be.true;
         });
 
         it('returns false if the event is not registered', function () {
-            var e = new EventHandler();
+            const e = new EventHandler();
             e.on('test', function () { });
             expect(e.hasEvent('hello')).to.be.false;
         });

--- a/test/framework/components/element/component.test.mjs
+++ b/test/framework/components/element/component.test.mjs
@@ -6,7 +6,7 @@ import { HTMLCanvasElement } from '@playcanvas/canvas-mock';
 
 import { expect } from 'chai';
 
-describe("ElementComponent", function () {
+describe('ElementComponent', function () {
     let app;
 
     beforeEach(function () {
@@ -18,11 +18,11 @@ describe("ElementComponent", function () {
         app.destroy();
     });
 
-    describe("#constructor", function () {
+    describe('#constructor', function () {
 
         it('creates a default element component', function () {
             const e = new Entity();
-            e.addComponent("element");
+            e.addComponent('element');
 
             expect(e.element.alignment).to.equal(null);
             expect(e.element.anchor.x).to.equal(0);

--- a/test/framework/components/layout-group/component.test.mjs
+++ b/test/framework/components/layout-group/component.test.mjs
@@ -9,7 +9,7 @@ import sinon from 'sinon';
 
 /** @typedef {import('../../../../src/framework/components/layout-group/system.js').LayoutGroupComponentSystem} LayoutGroupComponentSystem */
 
-describe("LayoutGroupComponent", function () {
+describe('LayoutGroupComponent', function () {
     /** @type {Application} */
     let app;
     /** @type {LayoutGroupComponentSystem} */
@@ -22,7 +22,7 @@ describe("LayoutGroupComponent", function () {
     let entity0_0_0;
 
     const buildLayoutGroupEntity = function (name) {
-        const entity = new Entity("myEntity" + name, app);
+        const entity = new Entity('myEntity' + name, app);
 
         app.systems.element.addComponent(entity, { type: ELEMENTTYPE_GROUP });
         app.systems.layoutgroup.addComponent(entity);
@@ -35,9 +35,9 @@ describe("LayoutGroupComponent", function () {
         app = new Application(canvas);
         system = app.systems.layoutgroup;
 
-        entity0 = buildLayoutGroupEntity("0");
-        entity0_0 = buildLayoutGroupEntity("0_0");
-        entity0_0_0 = buildLayoutGroupEntity("0_0_0");
+        entity0 = buildLayoutGroupEntity('0');
+        entity0_0 = buildLayoutGroupEntity('0_0');
+        entity0_0_0 = buildLayoutGroupEntity('0_0_0');
 
         app.root.addChild(entity0);
         entity0.addChild(entity0_0);
@@ -55,7 +55,7 @@ describe("LayoutGroupComponent", function () {
         app.destroy();
     });
 
-    it("reflows in ascending order of graph depth", function () {
+    it('reflows in ascending order of graph depth', function () {
         system.scheduleReflow(entity0_0.layoutgroup);
         system.scheduleReflow(entity0.layoutgroup);
         system.scheduleReflow(entity0_0_0.layoutgroup);
@@ -70,7 +70,7 @@ describe("LayoutGroupComponent", function () {
         expect(entity0_0.layoutgroup.reflow.calledBefore(entity0_0_0.layoutgroup.reflow)).to.be.true;
     });
 
-    it("reflows additional groups that are pushed during the reflow", function () {
+    it('reflows additional groups that are pushed during the reflow', function () {
         system.scheduleReflow(entity0.layoutgroup);
 
         let done = false;
@@ -94,7 +94,7 @@ describe("LayoutGroupComponent", function () {
         expect(entity0_0.layoutgroup.reflow.calledBefore(entity0_0_0.layoutgroup.reflow)).to.be.true;
     });
 
-    it("does not allow the same group to be pushed to the queue twice", function () {
+    it('does not allow the same group to be pushed to the queue twice', function () {
         system.scheduleReflow(entity0.layoutgroup);
         system.scheduleReflow(entity0.layoutgroup);
 
@@ -103,7 +103,7 @@ describe("LayoutGroupComponent", function () {
         expect(entity0.layoutgroup.reflow.callCount).to.equal(1);
     });
 
-    it("bails if the maximum iteration count is reached", function () {
+    it('bails if the maximum iteration count is reached', function () {
         sinon.stub(console, 'warn');
 
         system.scheduleReflow(entity0.layoutgroup);

--- a/test/framework/components/layout-group/layout-calculator.test.mjs
+++ b/test/framework/components/layout-group/layout-calculator.test.mjs
@@ -13,7 +13,7 @@ import { expect } from 'chai';
 
 /** @typedef {import('../../../../src/framework/components/element/component.js').ElementComponent} ElementComponent */
 
-describe("LayoutCalculator", function () {
+describe('LayoutCalculator', function () {
     /** @type {Application} */
     let app;
     /** @type {LayoutCalculator} */
@@ -37,7 +37,7 @@ describe("LayoutCalculator", function () {
     };
 
     const buildElement = function (properties) {
-        const entity = new Entity("myEntity", app);
+        const entity = new Entity('myEntity', app);
         const element = app.systems.element.addComponent(entity, { type: ELEMENTTYPE_GROUP });
 
         if (properties.layoutchild) {
@@ -268,7 +268,7 @@ describe("LayoutCalculator", function () {
         });
     };
 
-    it("throws an error if provided with an unrecognized orientation", function () {
+    it('throws an error if provided with an unrecognized orientation', function () {
         expect(function () {
             elements = mixedWidthElements;
             options.orientation = 42;
@@ -276,7 +276,7 @@ describe("LayoutCalculator", function () {
         }).to.throw('Unrecognized orientation value: 42');
     });
 
-    it("lays children out horizontally when orientation is ORIENTATION_HORIZONTAL", function () {
+    it('lays children out horizontally when orientation is ORIENTATION_HORIZONTAL', function () {
         elements = mixedWidthElements;
         options.orientation = ORIENTATION_HORIZONTAL;
 
@@ -286,7 +286,7 @@ describe("LayoutCalculator", function () {
         assertValues('y', [0,   0,   0,   0,   0]);
     });
 
-    it("lays children out vertically when orientation is ORIENTATION_VERTICAL", function () {
+    it('lays children out vertically when orientation is ORIENTATION_VERTICAL', function () {
         elements = mixedHeightElements;
         options.orientation = ORIENTATION_VERTICAL;
 
@@ -296,7 +296,7 @@ describe("LayoutCalculator", function () {
         assertValues('y', [0, 100, 150, 250, 270]);
     });
 
-    it("takes into account each element's pivot when calculating horizontal positions", function () {
+    it('takes into account each element\'s pivot when calculating horizontal positions', function () {
         elements = mixedWidthElements;
         options.orientation = ORIENTATION_HORIZONTAL;
 
@@ -309,7 +309,7 @@ describe("LayoutCalculator", function () {
         assertValues('y', [10,  10,   0,   0,   0], { approx: true });
     });
 
-    it("takes into account each element's pivot when calculating vertical positions", function () {
+    it('takes into account each element\'s pivot when calculating vertical positions', function () {
         elements = mixedHeightElements;
         options.orientation = ORIENTATION_VERTICAL;
 
@@ -322,7 +322,7 @@ describe("LayoutCalculator", function () {
         assertValues('y', [50, 110, 150, 250, 270], { approx: true });
     });
 
-    it("returns a layoutInfo object containing the layout bounds", function () {
+    it('returns a layoutInfo object containing the layout bounds', function () {
         elements = mixedWidthElementsWithLayoutChildComponents;
         options.wrap = true;
         options.orientation = ORIENTATION_HORIZONTAL;
@@ -362,7 +362,7 @@ describe("LayoutCalculator", function () {
         expect(layoutInfo.bounds.w).to.equal(100);
     });
 
-    it("{ wrap: false } FITTING_NONE does not adjust the size or position of elements to match the container size", function () {
+    it('{ wrap: false } FITTING_NONE does not adjust the size or position of elements to match the container size', function () {
         elements = mixedWidthElements;
         options.orientation = ORIENTATION_HORIZONTAL;
         options.widthFitting = FITTING_NONE;
@@ -376,7 +376,7 @@ describe("LayoutCalculator", function () {
         assertValues('calculatedHeight', [100, 100, 100, 100, 100]);
     });
 
-    it("{ wrap: false } FITTING_STRETCH uses natural widths when total is larger than container size", function () {
+    it('{ wrap: false } FITTING_STRETCH uses natural widths when total is larger than container size', function () {
         elements = mixedWidthElementsWithLayoutChildComponents;
         options.orientation = ORIENTATION_HORIZONTAL;
         options.widthFitting = FITTING_STRETCH;
@@ -391,7 +391,7 @@ describe("LayoutCalculator", function () {
         assertValues('calculatedHeight', [100, 100, 100, 100, 100]);
     });
 
-    it("{ wrap: false } FITTING_STRETCH stretches elements proportionally when natural widths are less than container size", function () {
+    it('{ wrap: false } FITTING_STRETCH stretches elements proportionally when natural widths are less than container size', function () {
         elements = mixedWidthElementsWithLayoutChildComponents;
         options.orientation = ORIENTATION_HORIZONTAL;
         options.widthFitting = FITTING_STRETCH;
@@ -406,7 +406,7 @@ describe("LayoutCalculator", function () {
         assertValues('calculatedHeight', [100, 100, 100, 100, 100]);
     });
 
-    it("{ wrap: false } FITTING_STRETCH does not make any elements wider than their maxWidth when increasing widths", function () {
+    it('{ wrap: false } FITTING_STRETCH does not make any elements wider than their maxWidth when increasing widths', function () {
         elements = mixedWidthElementsWithLayoutChildComponents;
         options.orientation = ORIENTATION_HORIZONTAL;
         options.widthFitting = FITTING_STRETCH;
@@ -421,7 +421,7 @@ describe("LayoutCalculator", function () {
         assertValues('calculatedHeight', [100, 100, 100, 100, 100]);
     });
 
-    it("{ wrap: false } FITTING_STRETCH distributes additional space among remaining elements when one element's maxWidth is very small", function () {
+    it('{ wrap: false } FITTING_STRETCH distributes additional space among remaining elements when one element\'s maxWidth is very small', function () {
         elements = mixedWidthElementsWithLayoutChildComponents;
         options.orientation = ORIENTATION_HORIZONTAL;
         options.widthFitting = FITTING_STRETCH;
@@ -443,7 +443,7 @@ describe("LayoutCalculator", function () {
         assertValues('calculatedHeight', [100, 100, 100,     100,     100]);
     });
 
-    it("{ wrap: false } FITTING_STRETCH includes spacing and padding in calculations", function () {
+    it('{ wrap: false } FITTING_STRETCH includes spacing and padding in calculations', function () {
         elements = mixedWidthElementsWithLayoutChildComponents;
         options.orientation = ORIENTATION_HORIZONTAL;
         options.widthFitting = FITTING_STRETCH;
@@ -461,7 +461,7 @@ describe("LayoutCalculator", function () {
         assertValues('calculatedHeight', [100, 100,     100, 100, 100]);
     });
 
-    it("{ wrap: false } FITTING_SHRINK uses natural widths when total is less than container size", function () {
+    it('{ wrap: false } FITTING_SHRINK uses natural widths when total is less than container size', function () {
         elements = mixedWidthElementsWithLayoutChildComponents;
         options.orientation = ORIENTATION_HORIZONTAL;
         options.widthFitting = FITTING_SHRINK;
@@ -476,7 +476,7 @@ describe("LayoutCalculator", function () {
         assertValues('calculatedHeight', [100, 100, 100, 100, 100]);
     });
 
-    it("{ wrap: false } FITTING_SHRINK shrinks elements proportionally when natural widths are greater than than container size", function () {
+    it('{ wrap: false } FITTING_SHRINK shrinks elements proportionally when natural widths are greater than than container size', function () {
         elements = mixedWidthElementsWithLayoutChildComponents;
         options.orientation = ORIENTATION_HORIZONTAL;
         options.widthFitting = FITTING_SHRINK;
@@ -491,7 +491,7 @@ describe("LayoutCalculator", function () {
         assertValues('calculatedHeight', [100,  100,   100,   100, 100]);
     });
 
-    it("{ wrap: false } FITTING_SHRINK does not make any elements smaller than their minWidth when reducing widths", function () {
+    it('{ wrap: false } FITTING_SHRINK does not make any elements smaller than their minWidth when reducing widths', function () {
         elements = mixedWidthElementsWithLayoutChildComponents;
         options.orientation = ORIENTATION_HORIZONTAL;
         options.widthFitting = FITTING_SHRINK;
@@ -506,7 +506,7 @@ describe("LayoutCalculator", function () {
         assertValues('calculatedHeight', [100, 100, 100, 100, 100]);
     });
 
-    it("{ wrap: false } FITTING_SHRINK distributes additional size reduction among remaining elements when one element's minWidth is very large", function () {
+    it('{ wrap: false } FITTING_SHRINK distributes additional size reduction among remaining elements when one element\'s minWidth is very large', function () {
         elements = mixedWidthElementsWithLayoutChildComponents;
         options.orientation = ORIENTATION_HORIZONTAL;
         options.widthFitting = FITTING_SHRINK;
@@ -527,7 +527,7 @@ describe("LayoutCalculator", function () {
         assertValues('calculatedHeight', [100,    100, 100, 100, 100]);
     });
 
-    it("{ wrap: false } FITTING_SHRINK includes spacing and padding in calculations", function () {
+    it('{ wrap: false } FITTING_SHRINK includes spacing and padding in calculations', function () {
         elements = mixedWidthElementsWithLayoutChildComponents;
         options.orientation = ORIENTATION_HORIZONTAL;
         options.widthFitting = FITTING_SHRINK;
@@ -545,7 +545,7 @@ describe("LayoutCalculator", function () {
         assertValues('calculatedHeight', [100, 100,  100, 100, 100]);
     });
 
-    it("{ wrap: false } FITTING_BOTH stretches elements proportionally when natural widths are less than container size", function () {
+    it('{ wrap: false } FITTING_BOTH stretches elements proportionally when natural widths are less than container size', function () {
         elements = mixedWidthElementsWithLayoutChildComponents;
         options.orientation = ORIENTATION_HORIZONTAL;
         options.widthFitting = FITTING_BOTH;
@@ -560,7 +560,7 @@ describe("LayoutCalculator", function () {
         assertValues('calculatedHeight', [100, 100, 100, 100, 100]);
     });
 
-    it("{ wrap: false } FITTING_BOTH shrinks elements proportionally when natural widths are greater than than container size", function () {
+    it('{ wrap: false } FITTING_BOTH shrinks elements proportionally when natural widths are greater than than container size', function () {
         elements = mixedWidthElementsWithLayoutChildComponents;
         options.orientation = ORIENTATION_HORIZONTAL;
         options.widthFitting = FITTING_BOTH;
@@ -575,7 +575,7 @@ describe("LayoutCalculator", function () {
         assertValues('calculatedHeight', [100,  100,   100,   100, 100]);
     });
 
-    it("{ wrap: false } can reverse elements on the x axis", function () {
+    it('{ wrap: false } can reverse elements on the x axis', function () {
         elements = mixedWidthElements;
         options.reverseX = true;
         options.orientation = ORIENTATION_HORIZONTAL;
@@ -588,7 +588,7 @@ describe("LayoutCalculator", function () {
         assertValues('y', [0,     0,  0,  0, 0]);
     });
 
-    it("{ wrap: false } can reverse elements on the y axis", function () {
+    it('{ wrap: false } can reverse elements on the y axis', function () {
         elements = mixedHeightElements;
         options.reverseY = true;
         options.orientation = ORIENTATION_VERTICAL;
@@ -601,7 +601,7 @@ describe("LayoutCalculator", function () {
         assertValues('y', [200, 150, 50, 30, 0]);
     });
 
-    it("{ wrap: false } can align to [1, 0.5]", function () {
+    it('{ wrap: false } can align to [1, 0.5]', function () {
         elements = mixedWidthElementsWithLayoutChildComponents;
         options.orientation = ORIENTATION_HORIZONTAL;
         options.widthFitting = FITTING_NONE;
@@ -616,7 +616,7 @@ describe("LayoutCalculator", function () {
         assertValues('y', [150, 150, 150, 150, 150]);
     });
 
-    it("{ wrap: false } can align to [0.5, 1]", function () {
+    it('{ wrap: false } can align to [0.5, 1]', function () {
         elements = mixedWidthElementsWithLayoutChildComponents;
         options.orientation = ORIENTATION_HORIZONTAL;
         options.widthFitting = FITTING_NONE;
@@ -631,7 +631,7 @@ describe("LayoutCalculator", function () {
         assertValues('y', [300, 300, 300, 300, 300]);
     });
 
-    it("{ wrap: false } can exclude elements from the layout", function () {
+    it('{ wrap: false } can exclude elements from the layout', function () {
         elements = mixedWidthElementsWithLayoutChildComponents;
         options.orientation = ORIENTATION_HORIZONTAL;
 
@@ -643,7 +643,7 @@ describe("LayoutCalculator", function () {
         assertValues('y', [0, 0,   0,   0,   0]);
     });
 
-    it("{ wrap: true } FITTING_NONE does not adjust the size or position of elements to match the container size", function () {
+    it('{ wrap: true } FITTING_NONE does not adjust the size or position of elements to match the container size', function () {
         elements = mixedWidthElements;
         options.wrap = true;
         options.orientation = ORIENTATION_HORIZONTAL;
@@ -659,7 +659,7 @@ describe("LayoutCalculator", function () {
         assertValues('calculatedHeight', [100, 100, 100, 100, 100]);
     });
 
-    it("{ wrap: true } FITTING_NONE calculates line positions based on the largest element on the line", function () {
+    it('{ wrap: true } FITTING_NONE calculates line positions based on the largest element on the line', function () {
         elements = mixedWidthElements;
         options.wrap = true;
         options.orientation = ORIENTATION_HORIZONTAL;
@@ -677,7 +677,7 @@ describe("LayoutCalculator", function () {
         assertValues('calculatedHeight', [100, 100, 200, 100, 100]);
     });
 
-    it("{ wrap: true } FITTING_NONE does not adjust the size or position of elements to match the container size", function () {
+    it('{ wrap: true } FITTING_NONE does not adjust the size or position of elements to match the container size', function () {
         elements = mixedWidthElements;
         options.wrap = true;
         options.orientation = ORIENTATION_HORIZONTAL;
@@ -693,7 +693,7 @@ describe("LayoutCalculator", function () {
         assertValues('calculatedHeight', [100, 100, 100, 100, 100]);
     });
 
-    it("{ wrap: true } FITTING_NONE includes spacing and padding in calculations", function () {
+    it('{ wrap: true } FITTING_NONE includes spacing and padding in calculations', function () {
         elements = mixedWidthElements;
         options.wrap = true;
         options.orientation = ORIENTATION_HORIZONTAL;
@@ -713,7 +713,7 @@ describe("LayoutCalculator", function () {
         assertValues('calculatedHeight', [100, 100, 100, 100, 100]);
     });
 
-    it("{ wrap: true } FITTING_NONE includes spacing when calculating line breaks", function () {
+    it('{ wrap: true } FITTING_NONE includes spacing when calculating line breaks', function () {
         elements = mixedWidthElements;
         elements[0].width = 100;
         elements[1].width = 100;
@@ -733,7 +733,7 @@ describe("LayoutCalculator", function () {
         assertValues('y', [0,    0,  0,   0, 100]);
     });
 
-    it("{ wrap: true } FITTING_STRETCH stretches elements proportionally when natural widths are less than container size", function () {
+    it('{ wrap: true } FITTING_STRETCH stretches elements proportionally when natural widths are less than container size', function () {
         elements = mixedWidthElementsWithLayoutChildComponents;
         options.wrap = true;
         options.orientation = ORIENTATION_HORIZONTAL;
@@ -749,7 +749,7 @@ describe("LayoutCalculator", function () {
         assertValues('calculatedHeight', [100,    100,     100, 100, 100]);
     });
 
-    it("{ wrap: true } FITTING_SHRINK stretches elements proportionally when natural widths are less than container size", function () {
+    it('{ wrap: true } FITTING_SHRINK stretches elements proportionally when natural widths are less than container size', function () {
         elements = mixedWidthElementsWithLayoutChildComponents;
         options.wrap = true;
         options.orientation = ORIENTATION_HORIZONTAL;
@@ -765,7 +765,7 @@ describe("LayoutCalculator", function () {
         assertValues('calculatedHeight', [100,    100,    100,    100, 100]);
     });
 
-    it("{ wrap: true } FITTING_BOTH stretches elements proportionally when natural widths are less than container size", function () {
+    it('{ wrap: true } FITTING_BOTH stretches elements proportionally when natural widths are less than container size', function () {
         elements = mixedWidthElementsWithLayoutChildComponents;
         options.wrap = true;
         options.orientation = ORIENTATION_HORIZONTAL;
@@ -781,7 +781,7 @@ describe("LayoutCalculator", function () {
         assertValues('calculatedHeight', [100,    100,     100, 100, 100]);
     });
 
-    it("{ wrap: true } can reverse elements on the x axis", function () {
+    it('{ wrap: true } can reverse elements on the x axis', function () {
         elements = mixedWidthElements;
         options.wrap = true;
         options.reverseX = true;
@@ -795,7 +795,7 @@ describe("LayoutCalculator", function () {
         assertValues('y', [0,   0,  0, 100, 100]);
     });
 
-    it("{ wrap: true } can reverse elements on the y axis", function () {
+    it('{ wrap: true } can reverse elements on the y axis', function () {
         elements = mixedWidthElements;
         options.wrap = true;
         options.reverseY = true;
@@ -809,7 +809,7 @@ describe("LayoutCalculator", function () {
         assertValues('y', [100, 100, 100, 0, 0]);
     });
 
-    it("{ wrap: true } can reverse elements both axes", function () {
+    it('{ wrap: true } can reverse elements both axes', function () {
         elements = mixedWidthElements;
         options.wrap = true;
         options.reverseX = true;
@@ -824,7 +824,7 @@ describe("LayoutCalculator", function () {
         assertValues('y', [100, 100, 100,  0, 0]);
     });
 
-    it("{ wrap: true } can align to [1, 0.5]", function () {
+    it('{ wrap: true } can align to [1, 0.5]', function () {
         elements = mixedWidthElementsWithLayoutChildComponents;
         options.wrap = true;
         options.orientation = ORIENTATION_HORIZONTAL;
@@ -841,7 +841,7 @@ describe("LayoutCalculator", function () {
         assertValues('y', [100, 100, 100, 200, 200]);
     });
 
-    it("{ wrap: true } can align to [0.5, 1]", function () {
+    it('{ wrap: true } can align to [0.5, 1]', function () {
         elements = mixedWidthElementsWithLayoutChildComponents;
         options.wrap = true;
         options.orientation = ORIENTATION_HORIZONTAL;
@@ -858,7 +858,7 @@ describe("LayoutCalculator", function () {
         assertValues('y', [200, 200, 200, 300, 300]);
     });
 
-    it("{ wrap: false } can exclude elements from the layout", function () {
+    it('{ wrap: false } can exclude elements from the layout', function () {
         elements = mixedWidthElementsWithLayoutChildComponents;
         options.wrap = true;
         options.orientation = ORIENTATION_HORIZONTAL;

--- a/test/framework/components/system.test.mjs
+++ b/test/framework/components/system.test.mjs
@@ -9,7 +9,7 @@ import { HTMLCanvasElement } from '@playcanvas/canvas-mock';
 
 import { expect } from 'chai';
 
-describe("ComponentSystem", function () {
+describe('ComponentSystem', function () {
     /** @type {Application} */
     let app;
     /** @type {ComponentSystem} */
@@ -26,9 +26,9 @@ describe("ComponentSystem", function () {
         app.destroy();
     });
 
-    describe("#initializeComponentData()", function () {
+    describe('#initializeComponentData()', function () {
 
-        it("works with a flat list of property names", function () {
+        it('works with a flat list of property names', function () {
             const component = {};
             const data = {
                 foo: 42,
@@ -42,7 +42,7 @@ describe("ComponentSystem", function () {
             expect(component.bar).to.equal(84);
         });
 
-        it("works with a list of property descriptor objects", function () {
+        it('works with a list of property descriptor objects', function () {
             const component = {};
             const data = {
                 rgbProperty: new Color(1, 2, 3),
@@ -101,7 +101,7 @@ describe("ComponentSystem", function () {
             expect(component.entityProperty).to.equal('abcde-12345');
         });
 
-        it("handles nulls", function () {
+        it('handles nulls', function () {
             const component = {};
             const data = {
                 rgbProperty: null,
@@ -139,7 +139,7 @@ describe("ComponentSystem", function () {
             expect(component.entityProperty).to.be.null;
         });
 
-        it("handles vec values being delivered as arrays", function () {
+        it('handles vec values being delivered as arrays', function () {
             const component = {};
             const data = {
                 rgbProperty: [1, 2, 3],
@@ -164,7 +164,7 @@ describe("ComponentSystem", function () {
             expect(component.vec4Property).to.not.equal(data.vec4Property);
         });
 
-        it("works if a normal value comes after an object value", function () {
+        it('works if a normal value comes after an object value', function () {
             const component = {};
             const data = {
                 vec: [1, 2, 3, 4],
@@ -172,7 +172,7 @@ describe("ComponentSystem", function () {
             };
             const properties = [
                 { name: 'vec', type: 'vec4' },
-                "num"
+                'num'
             ];
 
             system.initializeComponentData(component, data, properties);
@@ -184,7 +184,7 @@ describe("ComponentSystem", function () {
             expect(component.num).to.equal(42);
         });
 
-        it("throws if provided an unknown type", function () {
+        it('throws if provided an unknown type', function () {
             const component = {};
             const data = {
                 foo: 42
@@ -200,9 +200,9 @@ describe("ComponentSystem", function () {
 
     });
 
-    describe("#getPropertiesOfType()", function () {
+    describe('#getPropertiesOfType()', function () {
 
-        it("returns properties of the specified type", function () {
+        it('returns properties of the specified type', function () {
             system.schema = [
                 { name: 'foo', type: 'typeA' },
                 { name: 'bar', type: 'typeA' },
@@ -216,7 +216,7 @@ describe("ComponentSystem", function () {
             ]);
         });
 
-        it("returns an empty array if no properties match the specified type", function () {
+        it('returns an empty array if no properties match the specified type', function () {
             system.schema = [
                 { name: 'foo', type: 'typeA' },
                 { name: 'bar', type: 'typeA' },
@@ -227,7 +227,7 @@ describe("ComponentSystem", function () {
             expect(system.getPropertiesOfType('typeC')).to.deep.equal([]);
         });
 
-        it("doesn't throw an error if the system doesn't have a schema", function () {
+        it('doesn\'t throw an error if the system doesn\'t have a schema', function () {
             system.schema = null;
 
             expect(system.getPropertiesOfType('typeA')).to.deep.equal([]);

--- a/test/framework/entity.test.mjs
+++ b/test/framework/entity.test.mjs
@@ -215,7 +215,7 @@ describe('Entity', function () {
             root.destroy();
         });
 
-        it("returns a deep clone of the entity's subtree, including all components", function () {
+        it('returns a deep clone of the entity\'s subtree, including all components', function () {
             const subtree1 = createSubtree();
             const subtree2 = cloneSubtree(subtree1);
 
@@ -270,7 +270,7 @@ describe('Entity', function () {
             expect(subtree1.a_a_b.getGuid()).to.not.equal(subtree2.a_a_b.getGuid());
         });
 
-        it("resolves entity property references that refer to entities within the duplicated subtree", function () {
+        it('resolves entity property references that refer to entities within the duplicated subtree', function () {
             const subtree1 = createSubtree();
             subtree1.a.addComponent('dummy', { myEntity1: subtree1.a_a.getGuid(), myEntity2: subtree1.a_a_b.getGuid() });
             subtree1.a_a_a.addComponent('dummy', { myEntity1: subtree1.a.getGuid(), myEntity2: subtree1.a_b.getGuid() });
@@ -282,7 +282,7 @@ describe('Entity', function () {
             expect(subtree2.a_a_a.dummy.myEntity2).to.equal(subtree2.a_b.getGuid());
         });
 
-        it("resolves entity property references that refer to the cloned entity itself", function () {
+        it('resolves entity property references that refer to the cloned entity itself', function () {
             const subtree1 = createSubtree();
             subtree1.a.addComponent('dummy', { myEntity1: subtree1.a.getGuid() });
             subtree1.a_a_a.addComponent('dummy', { myEntity1: subtree1.a_a_a.getGuid() });
@@ -292,7 +292,7 @@ describe('Entity', function () {
             expect(subtree2.a_a_a.dummy.myEntity1).to.equal(subtree2.a_a_a.getGuid());
         });
 
-        it("does not attempt to resolve entity property references that refer to entities outside of the duplicated subtree", function () {
+        it('does not attempt to resolve entity property references that refer to entities outside of the duplicated subtree', function () {
             const root = new Entity('root', app);
             const sibling = new Entity('sibling', app);
 
@@ -307,7 +307,7 @@ describe('Entity', function () {
             expect(subtree2.a.dummy.myEntity2).to.equal(sibling.getGuid());
         });
 
-        it("ignores null and undefined entity property references", function () {
+        it('ignores null and undefined entity property references', function () {
             const subtree1 = createSubtree();
             subtree1.a.addComponent('dummy', { myEntity1: null, myEntity2: undefined });
 
@@ -316,7 +316,7 @@ describe('Entity', function () {
             expect(subtree2.a.dummy.myEntity2).to.be.undefined;
         });
 
-        it("resolves entity script attributes that refer to entities within the duplicated subtree", function () {
+        it('resolves entity script attributes that refer to entities within the duplicated subtree', function () {
             const TestScript = createScript('test');
             TestScript.attributes.add('entityAttr', { type: 'entity' });
             TestScript.attributes.add('entityArrayAttr', { type: 'entity', array: true });
@@ -363,7 +363,7 @@ describe('Entity', function () {
             expect(subtree2.a_a.script.test.entityArrayAttr[1].getGuid()).to.equal(subtree2.a_a_a.getGuid());
         });
 
-        it("resolves entity script attributes that refer to entities within the duplicated subtree after preloading has finished", function () {
+        it('resolves entity script attributes that refer to entities within the duplicated subtree after preloading has finished', function () {
             const TestScript = createScript('test');
             TestScript.attributes.add('entityAttr', { type: 'entity' });
             TestScript.attributes.add('entityArrayAttr', { type: 'entity', array: true });
@@ -413,7 +413,7 @@ describe('Entity', function () {
             expect(subtree2.a_a.script.test.entityArrayAttr[1].getGuid()).to.equal(subtree2.a_a_a.getGuid());
         });
 
-        it("does not attempt to resolve entity script attributes that refer to entities outside of the duplicated subtree", function () {
+        it('does not attempt to resolve entity script attributes that refer to entities outside of the duplicated subtree', function () {
             const TestScript = createScript('test');
             TestScript.attributes.add('entityAttr', { type: 'entity' });
             TestScript.attributes.add('entityArrayAttr', { type: 'entity', array: true });
@@ -444,7 +444,7 @@ describe('Entity', function () {
             expect(subtree2.a_a.script.test.entityArrayAttr[1].getGuid()).to.equal(app.root.getGuid());
         });
 
-        it("does not resolve entity script attributes that refer to entities within the duplicated subtree if app.useLegacyScriptAttributeCloning is true", function () {
+        it('does not resolve entity script attributes that refer to entities within the duplicated subtree if app.useLegacyScriptAttributeCloning is true', function () {
             const TestScript = createScript('test');
             TestScript.attributes.add('entityAttr', { type: 'entity' });
             TestScript.attributes.add('entityArrayAttr', { type: 'entity', array: true });

--- a/test/framework/utils/entity-reference.test.mjs
+++ b/test/framework/utils/entity-reference.test.mjs
@@ -11,7 +11,7 @@ import sinon from 'sinon';
 
 /** @typedef {import('../../../../src/framework/components/component.js').Component} Component */
 
-describe("EntityReference", function () {
+describe('EntityReference', function () {
     /** @type {Application} */
     let app;
     /** @type {Entity} */
@@ -29,12 +29,12 @@ describe("EntityReference", function () {
 
         app.systems.add(new DummyComponentSystem(app));
 
-        testEntity = new Entity("testEntity", app);
-        testComponent = testEntity.addComponent("dummy", {});
+        testEntity = new Entity('testEntity', app);
+        testComponent = testEntity.addComponent('dummy', {});
 
-        otherEntity1 = new Entity("otherEntity1", app);
-        otherEntity1.addComponent("dummy", {});
-        otherEntity2 = new Entity("otherEntity2", app);
+        otherEntity1 = new Entity('otherEntity1', app);
+        otherEntity1.addComponent('dummy', {});
+        otherEntity2 = new Entity('otherEntity2', app);
 
         app.root.addChild(testEntity);
         app.root.addChild(otherEntity1);
@@ -66,30 +66,30 @@ describe("EntityReference", function () {
         return (entity._callbacks && entity._callbacks[eventName] && entity._callbacks[eventName].length) || 0;
     }
 
-    it("provides a reference to the entity once the guid is populated", function () {
-        const reference = new EntityReference(testComponent, "myEntity1");
+    it('provides a reference to the entity once the guid is populated', function () {
+        const reference = new EntityReference(testComponent, 'myEntity1');
         expect(reference.entity).to.equal(null);
 
         testComponent.myEntity1 = otherEntity1.getGuid();
         expect(reference.entity).to.equal(otherEntity1);
     });
 
-    it("does not attempt to resolve the entity reference if the parent component is not on the scene graph yet", function () {
+    it('does not attempt to resolve the entity reference if the parent component is not on the scene graph yet', function () {
         app.root.removeChild(testEntity);
 
-        sinon.spy(app.root, "findByGuid");
+        sinon.spy(app.root, 'findByGuid');
 
-        const reference = new EntityReference(testComponent, "myEntity1");
+        const reference = new EntityReference(testComponent, 'myEntity1');
         testComponent.myEntity1 = otherEntity1.getGuid();
 
         expect(reference.entity).to.equal(null);
         expect(app.root.findByGuid.callCount).to.equal(0);
     });
 
-    it("resolves the entity reference when onParentComponentEnable() is called", function () {
+    it('resolves the entity reference when onParentComponentEnable() is called', function () {
         app.root.removeChild(testEntity);
 
-        const reference = new EntityReference(testComponent, "myEntity1");
+        const reference = new EntityReference(testComponent, 'myEntity1');
         testComponent.myEntity1 = otherEntity1.getGuid();
         expect(reference.entity).to.equal(null);
 
@@ -99,8 +99,8 @@ describe("EntityReference", function () {
         expect(reference.entity).to.equal(otherEntity1);
     });
 
-    it("nullifies the reference when the guid is nullified", function () {
-        const reference = new EntityReference(testComponent, "myEntity1");
+    it('nullifies the reference when the guid is nullified', function () {
+        const reference = new EntityReference(testComponent, 'myEntity1');
         testComponent.myEntity1 = otherEntity1.getGuid();
         expect(reference.entity).to.equal(otherEntity1);
 
@@ -108,8 +108,8 @@ describe("EntityReference", function () {
         expect(reference.entity).to.equal(null);
     });
 
-    it("nullifies the reference when the referenced entity is destroyed", function () {
-        const reference = new EntityReference(testComponent, "myEntity1");
+    it('nullifies the reference when the referenced entity is destroyed', function () {
+        const reference = new EntityReference(testComponent, 'myEntity1');
         testComponent.myEntity1 = otherEntity1.getGuid();
         expect(reference.entity).to.equal(otherEntity1);
 
@@ -117,10 +117,10 @@ describe("EntityReference", function () {
         expect(reference.entity).to.equal(null);
     });
 
-    it("removes all entity and component listeners when the guid is reassigned", function () {
-        const reference = new EntityReference(testComponent, "myEntity1", {
-            "entity#foo": sinon.stub(),
-            "dummy#bar": sinon.stub()
+    it('removes all entity and component listeners when the guid is reassigned', function () {
+        const reference = new EntityReference(testComponent, 'myEntity1', {
+            'entity#foo': sinon.stub(),
+            'dummy#bar': sinon.stub()
         });
         expect(reference).to.be.ok;
 
@@ -133,10 +133,10 @@ describe("EntityReference", function () {
         expect(getNumListenersForEvent(otherEntity1.dummy, 'bar')).to.equal(0);
     });
 
-    it("removes all entity and component listeners when the parent component is removed", function () {
-        const reference = new EntityReference(testComponent, "myEntity1", {
-            "entity#foo": sinon.stub(),
-            "dummy#bar": sinon.stub()
+    it('removes all entity and component listeners when the parent component is removed', function () {
+        const reference = new EntityReference(testComponent, 'myEntity1', {
+            'entity#foo': sinon.stub(),
+            'dummy#bar': sinon.stub()
         });
         expect(reference).to.be.ok;
 
@@ -153,10 +153,10 @@ describe("EntityReference", function () {
         expect(getNumListenersForEvent(app.systems.dummy, 'beforeremove')).to.equal(0);
     });
 
-    it("removes all entity and component listeners when the parent component's entity is destroyed", function () {
-        const reference = new EntityReference(testComponent, "myEntity1", {
-            "entity#foo": sinon.stub(),
-            "dummy#bar": sinon.stub()
+    it('removes all entity and component listeners when the parent component\'s entity is destroyed', function () {
+        const reference = new EntityReference(testComponent, 'myEntity1', {
+            'entity#foo': sinon.stub(),
+            'dummy#bar': sinon.stub()
         });
         expect(reference).to.be.ok;
 
@@ -173,11 +173,11 @@ describe("EntityReference", function () {
         expect(getNumListenersForEvent(app.systems.dummy, 'beforeremove')).to.equal(0);
     });
 
-    it("fires component gain events when a guid is first assigned, if the referenced entity already has the component", function () {
+    it('fires component gain events when a guid is first assigned, if the referenced entity already has the component', function () {
         const gainListener = sinon.stub();
 
-        const reference = new EntityReference(testComponent, "myEntity1", {
-            "dummy#gain": gainListener
+        const reference = new EntityReference(testComponent, 'myEntity1', {
+            'dummy#gain': gainListener
         });
         expect(reference).to.be.ok;
 
@@ -186,11 +186,11 @@ describe("EntityReference", function () {
         expect(gainListener.callCount).to.equal(1);
     });
 
-    it("fires component gain events once a component is added", function () {
+    it('fires component gain events once a component is added', function () {
         const gainListener = sinon.stub();
 
-        const reference = new EntityReference(testComponent, "myEntity2", {
-            "dummy#gain": gainListener
+        const reference = new EntityReference(testComponent, 'myEntity2', {
+            'dummy#gain': gainListener
         });
         expect(reference).to.be.ok;
 
@@ -198,18 +198,18 @@ describe("EntityReference", function () {
 
         expect(gainListener.callCount).to.equal(0);
 
-        otherEntity2.addComponent("dummy", {});
+        otherEntity2.addComponent('dummy', {});
 
         expect(gainListener.callCount).to.equal(1);
     });
 
-    it("fires component lose and gain events when a component is removed and re-added", function () {
+    it('fires component lose and gain events when a component is removed and re-added', function () {
         const gainListener = sinon.stub();
         const loseListener = sinon.stub();
 
-        const reference = new EntityReference(testComponent, "myEntity1", {
-            "dummy#gain": gainListener,
-            "dummy#lose": loseListener
+        const reference = new EntityReference(testComponent, 'myEntity1', {
+            'dummy#gain': gainListener,
+            'dummy#lose': loseListener
         });
         expect(reference).to.be.ok;
 
@@ -218,24 +218,24 @@ describe("EntityReference", function () {
         expect(gainListener.callCount).to.equal(1);
         expect(loseListener.callCount).to.equal(0);
 
-        otherEntity1.removeComponent("dummy");
+        otherEntity1.removeComponent('dummy');
 
         expect(gainListener.callCount).to.equal(1);
         expect(loseListener.callCount).to.equal(1);
 
-        otherEntity1.addComponent("dummy", {});
+        otherEntity1.addComponent('dummy', {});
 
         expect(gainListener.callCount).to.equal(2);
         expect(loseListener.callCount).to.equal(1);
     });
 
-    it("fires component lose events when the guid is reassigned, but only for component types that the entity had", function () {
+    it('fires component lose events when the guid is reassigned, but only for component types that the entity had', function () {
         const dummyLoseListener = sinon.stub();
         const lightLoseListener = sinon.stub();
 
-        const reference = new EntityReference(testComponent, "myEntity1", {
-            "dummy#lose": dummyLoseListener,
-            "light#lose": lightLoseListener
+        const reference = new EntityReference(testComponent, 'myEntity1', {
+            'dummy#lose': dummyLoseListener,
+            'light#lose': lightLoseListener
         });
         expect(reference).to.be.ok;
 
@@ -250,38 +250,38 @@ describe("EntityReference", function () {
         expect(lightLoseListener.callCount).to.equal(0);
     });
 
-    it("forwards any events dispatched by a component", function () {
+    it('forwards any events dispatched by a component', function () {
         const fooListener = sinon.stub();
         const barListener = sinon.stub();
 
-        const reference = new EntityReference(testComponent, "myEntity1", {
-            "dummy#foo": fooListener,
-            "dummy#bar": barListener
+        const reference = new EntityReference(testComponent, 'myEntity1', {
+            'dummy#foo': fooListener,
+            'dummy#bar': barListener
         });
         expect(reference).to.be.ok;
 
         testComponent.myEntity1 = otherEntity1.getGuid();
 
-        otherEntity1.dummy.fire("foo", "a", "b");
+        otherEntity1.dummy.fire('foo', 'a', 'b');
         expect(fooListener.callCount).to.equal(1);
-        expect(fooListener.getCall(0).args[0]).to.equal("a");
-        expect(fooListener.getCall(0).args[1]).to.equal("b");
+        expect(fooListener.getCall(0).args[0]).to.equal('a');
+        expect(fooListener.getCall(0).args[1]).to.equal('b');
         expect(barListener.callCount).to.equal(0);
 
-        otherEntity1.dummy.fire("bar", "c", "d");
+        otherEntity1.dummy.fire('bar', 'c', 'd');
         expect(fooListener.callCount).to.equal(1);
         expect(barListener.callCount).to.equal(1);
-        expect(barListener.getCall(0).args[0]).to.equal("c");
-        expect(barListener.getCall(0).args[1]).to.equal("d");
+        expect(barListener.getCall(0).args[0]).to.equal('c');
+        expect(barListener.getCall(0).args[1]).to.equal('d');
     });
 
-    it("correctly handles component event forwarding across component removal and subsequent re-addition", function () {
+    it('correctly handles component event forwarding across component removal and subsequent re-addition', function () {
         const fooListener = sinon.stub();
         const barListener = sinon.stub();
 
-        const reference = new EntityReference(testComponent, "myEntity1", {
-            "dummy#foo": fooListener,
-            "dummy#bar": barListener
+        const reference = new EntityReference(testComponent, 'myEntity1', {
+            'dummy#foo': fooListener,
+            'dummy#bar': barListener
         });
         expect(reference).to.be.ok;
 
@@ -289,53 +289,53 @@ describe("EntityReference", function () {
 
         const oldDummyComponent = otherEntity1.dummy;
 
-        otherEntity1.removeComponent("dummy");
+        otherEntity1.removeComponent('dummy');
 
-        oldDummyComponent.fire("foo");
-        oldDummyComponent.fire("bar");
+        oldDummyComponent.fire('foo');
+        oldDummyComponent.fire('bar');
         expect(fooListener.callCount).to.equal(0);
         expect(barListener.callCount).to.equal(0);
 
-        const newDummyComponent = otherEntity1.addComponent("dummy");
+        const newDummyComponent = otherEntity1.addComponent('dummy');
 
-        newDummyComponent.fire("foo");
-        newDummyComponent.fire("bar");
+        newDummyComponent.fire('foo');
+        newDummyComponent.fire('bar');
         expect(fooListener.callCount).to.equal(1);
         expect(barListener.callCount).to.equal(1);
     });
 
-    it("forwards any events dispatched by the entity", function () {
+    it('forwards any events dispatched by the entity', function () {
         const fooListener = sinon.stub();
         const barListener = sinon.stub();
 
-        const reference = new EntityReference(testComponent, "myEntity1", {
-            "entity#foo": fooListener,
-            "entity#bar": barListener
+        const reference = new EntityReference(testComponent, 'myEntity1', {
+            'entity#foo': fooListener,
+            'entity#bar': barListener
         });
         expect(reference).to.be.ok;
 
         testComponent.myEntity1 = otherEntity1.getGuid();
 
-        otherEntity1.fire("foo", "a", "b");
+        otherEntity1.fire('foo', 'a', 'b');
         expect(fooListener.callCount).to.equal(1);
-        expect(fooListener.getCall(0).args[0]).to.equal("a");
-        expect(fooListener.getCall(0).args[1]).to.equal("b");
+        expect(fooListener.getCall(0).args[0]).to.equal('a');
+        expect(fooListener.getCall(0).args[1]).to.equal('b');
         expect(barListener.callCount).to.equal(0);
 
-        otherEntity1.fire("bar", "c", "d");
+        otherEntity1.fire('bar', 'c', 'd');
         expect(fooListener.callCount).to.equal(1);
         expect(barListener.callCount).to.equal(1);
-        expect(barListener.getCall(0).args[0]).to.equal("c");
-        expect(barListener.getCall(0).args[1]).to.equal("d");
+        expect(barListener.getCall(0).args[0]).to.equal('c');
+        expect(barListener.getCall(0).args[1]).to.equal('d');
     });
 
-    it("correctly handles entity event forwarding across entity nullification and subsequent reassignment", function () {
+    it('correctly handles entity event forwarding across entity nullification and subsequent reassignment', function () {
         const fooListener = sinon.stub();
         const barListener = sinon.stub();
 
-        const reference = new EntityReference(testComponent, "myEntity1", {
-            "entity#foo": fooListener,
-            "entity#bar": barListener
+        const reference = new EntityReference(testComponent, 'myEntity1', {
+            'entity#foo': fooListener,
+            'entity#bar': barListener
         });
         expect(reference).to.be.ok;
 
@@ -343,48 +343,48 @@ describe("EntityReference", function () {
 
         testComponent.myEntity1 = null;
 
-        otherEntity1.fire("foo");
-        otherEntity1.fire("bar");
+        otherEntity1.fire('foo');
+        otherEntity1.fire('bar');
         expect(fooListener.callCount).to.equal(0);
         expect(barListener.callCount).to.equal(0);
 
         testComponent.myEntity1 = otherEntity2.getGuid();
 
-        otherEntity2.fire("foo");
-        otherEntity2.fire("bar");
+        otherEntity2.fire('foo');
+        otherEntity2.fire('bar');
         expect(fooListener.callCount).to.equal(1);
         expect(barListener.callCount).to.equal(1);
     });
 
-    it("validates the event map", function () {
+    it('validates the event map', function () {
         function testEventMap(eventMap) {
-            const reference = new EntityReference(testComponent, "myEntity1", eventMap);
+            const reference = new EntityReference(testComponent, 'myEntity1', eventMap);
             expect(reference).to.be.ok;
         }
 
         const callback = sinon.stub();
 
         expect(function () {
-            testEventMap({ "foo": callback });
-        }).to.throw("Invalid event listener description: `foo`");
+            testEventMap({ 'foo': callback });
+        }).to.throw('Invalid event listener description: `foo`');
 
         expect(function () {
-            testEventMap({ "foo#": callback });
-        }).to.throw("Invalid event listener description: `foo#`");
+            testEventMap({ 'foo#': callback });
+        }).to.throw('Invalid event listener description: `foo#`');
 
         expect(function () {
-            testEventMap({ "#foo": callback });
-        }).to.throw("Invalid event listener description: `#foo`");
+            testEventMap({ '#foo': callback });
+        }).to.throw('Invalid event listener description: `#foo`');
 
         expect(function () {
-            testEventMap({ "foo#bar": null });
-        }).to.throw("Invalid or missing callback for event listener `foo#bar`");
+            testEventMap({ 'foo#bar': null });
+        }).to.throw('Invalid or missing callback for event listener `foo#bar`');
     });
 
-    it("logs a warning if the entity property is set to anything other than a string, undefined or null", function () {
-        sinon.stub(console, "warn");
+    it('logs a warning if the entity property is set to anything other than a string, undefined or null', function () {
+        sinon.stub(console, 'warn');
 
-        const reference = new EntityReference(testComponent, "myEntity1");
+        const reference = new EntityReference(testComponent, 'myEntity1');
         expect(reference).to.be.ok;
 
         testComponent.myEntity1 = otherEntity1.getGuid();
@@ -396,45 +396,45 @@ describe("EntityReference", function () {
         testComponent.myEntity1 = {};
 
         expect(console.warn.callCount).to.equal(1);
-        expect(console.warn.getCall(0).args[0]).to.equal("Entity field `myEntity1` was set to unexpected type 'object'");
+        expect(console.warn.getCall(0).args[0]).to.equal('Entity field `myEntity1` was set to unexpected type \'object\'');
     });
 
-    it("set reference to a Entity instead of guid, converts property to guid", function () {
-        const reference = new EntityReference(testComponent, "myEntity1");
+    it('set reference to a Entity instead of guid, converts property to guid', function () {
+        const reference = new EntityReference(testComponent, 'myEntity1');
         testComponent.myEntity1 = otherEntity1;
 
-        expect(testComponent.myEntity1).to.equal(otherEntity1.getGuid(), "Component property converted to guid");
+        expect(testComponent.myEntity1).to.equal(otherEntity1.getGuid(), 'Component property converted to guid');
         expect(reference.entity).to.equal(otherEntity1);
     });
 
-    it("set reference to a Entity that is not in hierarchy, converts property to guid", function () {
-        const reference = new EntityReference(testComponent, "myEntity1");
+    it('set reference to a Entity that is not in hierarchy, converts property to guid', function () {
+        const reference = new EntityReference(testComponent, 'myEntity1');
         const entity = new Entity();
         testComponent.myEntity1 = entity;
 
-        expect(testComponent.myEntity1).to.equal(entity.getGuid(), "Component property converted to guid");
+        expect(testComponent.myEntity1).to.equal(entity.getGuid(), 'Component property converted to guid');
         expect(reference.entity).to.equal(entity);
     });
 
-    it("hasComponent() returns false if the entity is not present", function () {
-        const reference = new EntityReference(testComponent, "myEntity1");
+    it('hasComponent() returns false if the entity is not present', function () {
+        const reference = new EntityReference(testComponent, 'myEntity1');
 
-        expect(reference.hasComponent("dummy")).to.equal(false);
+        expect(reference.hasComponent('dummy')).to.equal(false);
     });
 
-    it("hasComponent() returns false if the entity is present but does not have a component of the provided type", function () {
-        const reference = new EntityReference(testComponent, "myEntity1");
+    it('hasComponent() returns false if the entity is present but does not have a component of the provided type', function () {
+        const reference = new EntityReference(testComponent, 'myEntity1');
         testComponent.myEntity1 = otherEntity1.getGuid();
-        otherEntity1.removeComponent("dummy");
+        otherEntity1.removeComponent('dummy');
 
-        expect(reference.hasComponent("dummy")).to.equal(false);
+        expect(reference.hasComponent('dummy')).to.equal(false);
     });
 
-    it("hasComponent() returns true if the entity is present and has a component of the provided type", function () {
-        const reference = new EntityReference(testComponent, "myEntity1");
+    it('hasComponent() returns true if the entity is present and has a component of the provided type', function () {
+        const reference = new EntityReference(testComponent, 'myEntity1');
         testComponent.myEntity1 = otherEntity1.getGuid();
 
-        expect(reference.hasComponent("dummy")).to.equal(true);
+        expect(reference.hasComponent('dummy')).to.equal(true);
     });
 
 });

--- a/test/math/mat4.test.mjs
+++ b/test/math/mat4.test.mjs
@@ -5,7 +5,7 @@ import { Vec4 } from '../../src/math/vec4.js';
 
 import { expect } from 'chai';
 
-describe("Mat4", function () {
+describe('Mat4', function () {
 
     describe('#data', function () {
 

--- a/test/scene/composition/layer-composition.test.mjs
+++ b/test/scene/composition/layer-composition.test.mjs
@@ -144,17 +144,17 @@ describe('LayerComposition', function () {
     describe('#sortTransparentLayers', function () {
 
         it('should return negative if the first layers are on top of the second layers', function () {
-            var layerFront = new Layer({ id: 2 });
-            var layerBack = new Layer({ id: 3 });
+            const layerFront = new Layer({ id: 2 });
+            const layerBack = new Layer({ id: 3 });
             this.composition.push(layerBack);
             this.composition.push(layerFront);
             expect(this.composition.sortTransparentLayers([layerFront.id], [layerBack.id])).to.be.below(0);
         });
 
         it('should return negative if one the first layers is on top of the second layers', function () {
-            var layerFront = new Layer({ id: 2 });
-            var layerMiddle = new Layer({ id: 3 });
-            var layerBack = new Layer({ id: 4 });
+            const layerFront = new Layer({ id: 2 });
+            const layerMiddle = new Layer({ id: 3 });
+            const layerBack = new Layer({ id: 4 });
             this.composition.push(layerBack);
             this.composition.push(layerMiddle);
             this.composition.push(layerFront);
@@ -167,17 +167,17 @@ describe('LayerComposition', function () {
         });
 
         it('should return positive if the second layers are on top of the first layers', function () {
-            var layerFront = new Layer({ id: 2 });
-            var layerBack = new Layer({ id: 3 });
+            const layerFront = new Layer({ id: 2 });
+            const layerBack = new Layer({ id: 3 });
             this.composition.push(layerBack);
             this.composition.push(layerFront);
             expect(this.composition.sortTransparentLayers([layerBack.id], [layerFront.id])).to.be.above(0);
         });
 
         it('should return positive if one the second layers is on top of the first layers', function () {
-            var layerFront = new Layer({ id: 2 });
-            var layerMiddle = new Layer({ id: 3 });
-            var layerBack = new Layer({ id: 4 });
+            const layerFront = new Layer({ id: 2 });
+            const layerMiddle = new Layer({ id: 3 });
+            const layerBack = new Layer({ id: 4 });
             this.composition.push(layerBack);
             this.composition.push(layerMiddle);
             this.composition.push(layerFront);
@@ -199,8 +199,8 @@ describe('LayerComposition', function () {
         });
 
         it('returns correct value after insert()', function () {
-            var layerFront = new Layer({ id: 2 });
-            var layerBack = new Layer({ id: 3 });
+            const layerFront = new Layer({ id: 2 });
+            const layerBack = new Layer({ id: 3 });
             this.composition.insert(layerFront, 0);
             this.composition.insert(layerBack, 0);
             expect(this.composition.sortTransparentLayers([layerBack.id], [layerFront.id])).to.be.above(0);
@@ -208,9 +208,9 @@ describe('LayerComposition', function () {
         });
 
         it('returns correct value after remove()', function () {
-            var layerFront = new Layer({ id: 2 });
-            var layerMiddle = new Layer({ id: 3 });
-            var layerBack = new Layer({ id: 4 });
+            const layerFront = new Layer({ id: 2 });
+            const layerMiddle = new Layer({ id: 3 });
+            const layerBack = new Layer({ id: 4 });
             this.composition.push(layerBack);
             this.composition.push(layerMiddle);
             this.composition.push(layerFront);
@@ -224,8 +224,8 @@ describe('LayerComposition', function () {
         });
 
         it('returns correct value after pushTransparent()', function () {
-            var layerFront = new Layer({ id: 2 });
-            var layerBack = new Layer({ id: 3 });
+            const layerFront = new Layer({ id: 2 });
+            const layerBack = new Layer({ id: 3 });
             this.composition.pushTransparent(layerBack);
             this.composition.pushTransparent(layerFront);
             expect(this.composition.sortTransparentLayers([layerBack.id], [layerFront.id])).to.be.above(0);
@@ -233,8 +233,8 @@ describe('LayerComposition', function () {
         });
 
         it('returns correct value after insertTransparent()', function () {
-            var layerFront = new Layer({ id: 2 });
-            var layerBack = new Layer({ id: 3 });
+            const layerFront = new Layer({ id: 2 });
+            const layerBack = new Layer({ id: 3 });
             this.composition.insertTransparent(layerFront, 0);
             this.composition.insertTransparent(layerBack, 0);
             expect(this.composition.sortTransparentLayers([layerBack.id], [layerFront.id])).to.be.above(0);
@@ -242,9 +242,9 @@ describe('LayerComposition', function () {
         });
 
         it('returns correct value after removeTransparent()', function () {
-            var layerFront = new Layer({ id: 2 });
-            var layerMiddle = new Layer({ id: 3 });
-            var layerBack = new Layer({ id: 4 });
+            const layerFront = new Layer({ id: 2 });
+            const layerMiddle = new Layer({ id: 3 });
+            const layerBack = new Layer({ id: 4 });
             this.composition.pushTransparent(layerBack);
             this.composition.pushTransparent(layerMiddle);
             this.composition.pushTransparent(layerFront);
@@ -262,17 +262,17 @@ describe('LayerComposition', function () {
     describe('#sortOpaqueLayers', function () {
 
         it('should return negative if the first layers are on top of the second layers', function () {
-            var layerFront = new Layer({ id: 2 });
-            var layerBack = new Layer({ id: 3 });
+            const layerFront = new Layer({ id: 2 });
+            const layerBack = new Layer({ id: 3 });
             this.composition.push(layerBack);
             this.composition.push(layerFront);
             expect(this.composition.sortOpaqueLayers([layerFront.id], [layerBack.id])).to.be.below(0);
         });
 
         it('should return negative if one the first layers is on top of the second layers', function () {
-            var layerFront = new Layer({ id: 2 });
-            var layerMiddle = new Layer({ id: 3 });
-            var layerBack = new Layer({ id: 4 });
+            const layerFront = new Layer({ id: 2 });
+            const layerMiddle = new Layer({ id: 3 });
+            const layerBack = new Layer({ id: 4 });
             this.composition.push(layerBack);
             this.composition.push(layerMiddle);
             this.composition.push(layerFront);
@@ -285,17 +285,17 @@ describe('LayerComposition', function () {
         });
 
         it('should return positive if the second layers are on top of the first layers', function () {
-            var layerFront = new Layer({ id: 2 });
-            var layerBack = new Layer({ id: 3 });
+            const layerFront = new Layer({ id: 2 });
+            const layerBack = new Layer({ id: 3 });
             this.composition.push(layerBack);
             this.composition.push(layerFront);
             expect(this.composition.sortOpaqueLayers([layerBack.id], [layerFront.id])).to.be.above(0);
         });
 
         it('should return positive if one the second layers is on top of the first layers', function () {
-            var layerFront = new Layer({ id: 2 });
-            var layerMiddle = new Layer({ id: 3 });
-            var layerBack = new Layer({ id: 4 });
+            const layerFront = new Layer({ id: 2 });
+            const layerMiddle = new Layer({ id: 3 });
+            const layerBack = new Layer({ id: 4 });
             this.composition.push(layerBack);
             this.composition.push(layerMiddle);
             this.composition.push(layerFront);
@@ -317,8 +317,8 @@ describe('LayerComposition', function () {
         });
 
         it('returns correct value after insert()', function () {
-            var layerFront = new Layer({ id: 2 });
-            var layerBack = new Layer({ id: 3 });
+            const layerFront = new Layer({ id: 2 });
+            const layerBack = new Layer({ id: 3 });
             this.composition.insert(layerFront, 0);
             this.composition.insert(layerBack, 0);
             expect(this.composition.sortOpaqueLayers([layerBack.id], [layerFront.id])).to.be.above(0);
@@ -326,9 +326,9 @@ describe('LayerComposition', function () {
         });
 
         it('returns correct value after remove()', function () {
-            var layerFront = new Layer({ id: 2 });
-            var layerMiddle = new Layer({ id: 3 });
-            var layerBack = new Layer({ id: 4 });
+            const layerFront = new Layer({ id: 2 });
+            const layerMiddle = new Layer({ id: 3 });
+            const layerBack = new Layer({ id: 4 });
             this.composition.push(layerBack);
             this.composition.push(layerMiddle);
             this.composition.push(layerFront);
@@ -342,8 +342,8 @@ describe('LayerComposition', function () {
         });
 
         it('returns correct value after pushOpaque()', function () {
-            var layerFront = new Layer({ id: 2 });
-            var layerBack = new Layer({ id: 3 });
+            const layerFront = new Layer({ id: 2 });
+            const layerBack = new Layer({ id: 3 });
             this.composition.pushOpaque(layerBack);
             this.composition.pushOpaque(layerFront);
             expect(this.composition.sortOpaqueLayers([layerBack.id], [layerFront.id])).to.be.above(0);
@@ -351,8 +351,8 @@ describe('LayerComposition', function () {
         });
 
         it('returns correct value after insertOpaque()', function () {
-            var layerFront = new Layer({ id: 2 });
-            var layerBack = new Layer({ id: 3 });
+            const layerFront = new Layer({ id: 2 });
+            const layerBack = new Layer({ id: 3 });
             this.composition.insertOpaque(layerFront, 0);
             this.composition.insertOpaque(layerBack, 0);
             expect(this.composition.sortOpaqueLayers([layerBack.id], [layerFront.id])).to.be.above(0);
@@ -360,9 +360,9 @@ describe('LayerComposition', function () {
         });
 
         it('returns correct value after removeOpaque()', function () {
-            var layerFront = new Layer({ id: 2 });
-            var layerMiddle = new Layer({ id: 3 });
-            var layerBack = new Layer({ id: 4 });
+            const layerFront = new Layer({ id: 2 });
+            const layerMiddle = new Layer({ id: 3 });
+            const layerBack = new Layer({ id: 4 });
             this.composition.pushOpaque(layerBack);
             this.composition.pushOpaque(layerMiddle);
             this.composition.pushOpaque(layerFront);

--- a/test/test-component/system.mjs
+++ b/test/test-component/system.mjs
@@ -4,7 +4,7 @@ import { ComponentSystem } from '../../src/framework/components/system.js';
 import { DummyComponent } from './component.mjs';
 import { DummyComponentData } from './data.mjs';
 
-var dummySchema = [
+const dummySchema = [
     'enabled',
     { name: 'myEntity1', type: 'entity' },
     { name: 'myEntity2', type: 'entity' }


### PR DESCRIPTION
* Enforce single quotes for all node-based unit tests (note that single quotes are used over double quotes in our codebase by over 2 to 1). I would like to see this standardized across the codebase.
* Migrate all occurrences of `var` to `let` and `const`.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
