### PR TITLE
Preallocate `Float32Array` in `calculateNormals`/`calculateTangents`

### DIFF
--- a/src/resources/parser/glb-parser.js
+++ b/src/resources/parser/glb-parser.js
@@ -348,9 +348,7 @@ const generateNormals = function (sourceDesc, indices) {
     }
 
     // generate normals
-    const normalsTemp = calculateNormals(positions, indices);
-    const normals = new Float32Array(normalsTemp.length);
-    normals.set(normalsTemp);
+    const normals = calculateNormals(positions, indices);
 
     sourceDesc[SEMANTIC_NORMAL] = {
         buffer: normals.buffer,

--- a/src/scene/procedural.js
+++ b/src/scene/procedural.js
@@ -21,9 +21,9 @@ const shapePrimitives = [];
  * Generates normal information from the specified positions and triangle indices. See
  * {@link createMesh}.
  *
- * @param {number[]} positions - An array of 3-dimensional vertex positions.
- * @param {number[]} indices - An array of triangle indices.
- * @returns {number[]} An array of 3-dimensional vertex normals.
+ * @param {number[]|Uint16Array|Float32Array|Int8Array|Uint8Array|Int16Array|Int32Array|Uint32Array} positions - An array of 3-dimensional vertex positions.
+ * @param {number[]|Uint16Array|Float32Array|Int8Array|Uint8Array|Int16Array|Int32Array|Uint32Array} indices - An array of triangle indices.
+ * @returns {Float32Array} An array of 3-dimensional vertex normals.
  * @example
  * var normals = pc.calculateNormals(positions, indices);
  * var tangents = pc.calculateTangents(positions, normals, uvs, indices);
@@ -39,36 +39,31 @@ function calculateNormals(positions, indices) {
     const p1p3 = new Vec3();
     const faceNormal = new Vec3();
 
-    const normals = [];
-
-    // Initialize the normal array to zero
-    for (let i = 0; i < positions.length; i++) {
-        normals[i] = 0;
-    }
+    const normals = new Float32Array(positions.length);
 
     // Accumulate face normals for each vertex
     for (let i = 0; i < triangleCount; i++) {
-        const i1 = indices[i * 3];
-        const i2 = indices[i * 3 + 1];
-        const i3 = indices[i * 3 + 2];
+        const i1 = indices[i * 3    ] * 3;
+        const i2 = indices[i * 3 + 1] * 3;
+        const i3 = indices[i * 3 + 2] * 3;
 
-        p1.set(positions[i1 * 3], positions[i1 * 3 + 1], positions[i1 * 3 + 2]);
-        p2.set(positions[i2 * 3], positions[i2 * 3 + 1], positions[i2 * 3 + 2]);
-        p3.set(positions[i3 * 3], positions[i3 * 3 + 1], positions[i3 * 3 + 2]);
+        p1.set(positions[i1], positions[i1 + 1], positions[i1 + 2]);
+        p2.set(positions[i2], positions[i2 + 1], positions[i2 + 2]);
+        p3.set(positions[i3], positions[i3 + 1], positions[i3 + 2]);
 
         p1p2.sub2(p2, p1);
         p1p3.sub2(p3, p1);
         faceNormal.cross(p1p2, p1p3).normalize();
 
-        normals[i1 * 3]     += faceNormal.x;
-        normals[i1 * 3 + 1] += faceNormal.y;
-        normals[i1 * 3 + 2] += faceNormal.z;
-        normals[i2 * 3]     += faceNormal.x;
-        normals[i2 * 3 + 1] += faceNormal.y;
-        normals[i2 * 3 + 2] += faceNormal.z;
-        normals[i3 * 3]     += faceNormal.x;
-        normals[i3 * 3 + 1] += faceNormal.y;
-        normals[i3 * 3 + 2] += faceNormal.z;
+        normals[i1]     += faceNormal.x;
+        normals[i1 + 1] += faceNormal.y;
+        normals[i1 + 2] += faceNormal.z;
+        normals[i2]     += faceNormal.x;
+        normals[i2 + 1] += faceNormal.y;
+        normals[i2 + 2] += faceNormal.z;
+        normals[i3]     += faceNormal.x;
+        normals[i3 + 1] += faceNormal.y;
+        normals[i3 + 2] += faceNormal.z;
     }
 
     // Normalize all normals
@@ -93,7 +88,7 @@ function calculateNormals(positions, indices) {
  * @param {number[]} normals - An array of 3-dimensional vertex normals.
  * @param {number[]} uvs - An array of 2-dimensional vertex texture coordinates.
  * @param {number[]} indices - An array of triangle indices.
- * @returns {number[]} An array of 3-dimensional vertex tangents.
+ * @returns {Float32Array} An array of 3-dimensional vertex tangents.
  * @example
  * var tangents = pc.calculateTangents(positions, normals, uvs, indices);
  * var mesh = pc.createMesh(positions, normals, tangents, uvs, indices);
@@ -114,20 +109,28 @@ function calculateTangents(positions, normals, uvs, indices) {
     const tan1 = new Float32Array(vertexCount * 3);
     const tan2 = new Float32Array(vertexCount * 3);
 
-    const tangents = [];
+    const tangents = new Float32Array(vertexCount * 4);
 
     for (let i = 0; i < triangleCount; i++) {
         const i1 = indices[i * 3];
         const i2 = indices[i * 3 + 1];
         const i3 = indices[i * 3 + 2];
 
-        v1.set(positions[i1 * 3], positions[i1 * 3 + 1], positions[i1 * 3 + 2]);
-        v2.set(positions[i2 * 3], positions[i2 * 3 + 1], positions[i2 * 3 + 2]);
-        v3.set(positions[i3 * 3], positions[i3 * 3 + 1], positions[i3 * 3 + 2]);
+        const i1Duo = i1 * 2;
+        const i2Duo = i2 * 2;
+        const i3Duo = i3 * 2;
 
-        w1.set(uvs[i1 * 2], uvs[i1 * 2 + 1]);
-        w2.set(uvs[i2 * 2], uvs[i2 * 2 + 1]);
-        w3.set(uvs[i3 * 2], uvs[i3 * 2 + 1]);
+        const i1Trio = i1 * 3;
+        const i2Trio = i2 * 3;
+        const i3Trio = i3 * 3;
+
+        v1.set(positions[i1Trio], positions[i1Trio + 1], positions[i1Trio + 2]);
+        v2.set(positions[i2Trio], positions[i2Trio + 1], positions[i2Trio + 2]);
+        v3.set(positions[i3Trio], positions[i3Trio + 1], positions[i3Trio + 2]);
+
+        w1.set(uvs[i1Duo], uvs[i1Duo + 1]);
+        w2.set(uvs[i2Duo], uvs[i2Duo + 1]);
+        w3.set(uvs[i3Duo], uvs[i3Duo + 1]);
 
         const x1 = v2.x - v1.x;
         const x2 = v3.x - v1.x;
@@ -158,25 +161,25 @@ function calculateTangents(positions, normals, uvs, indices) {
                      (s1 * z2 - s2 * z1) * r);
         }
 
-        tan1[i1 * 3 + 0] += sdir.x;
-        tan1[i1 * 3 + 1] += sdir.y;
-        tan1[i1 * 3 + 2] += sdir.z;
-        tan1[i2 * 3 + 0] += sdir.x;
-        tan1[i2 * 3 + 1] += sdir.y;
-        tan1[i2 * 3 + 2] += sdir.z;
-        tan1[i3 * 3 + 0] += sdir.x;
-        tan1[i3 * 3 + 1] += sdir.y;
-        tan1[i3 * 3 + 2] += sdir.z;
+        tan1[i1Trio    ] += sdir.x;
+        tan1[i1Trio + 1] += sdir.y;
+        tan1[i1Trio + 2] += sdir.z;
+        tan1[i2Trio    ] += sdir.x;
+        tan1[i2Trio + 1] += sdir.y;
+        tan1[i2Trio + 2] += sdir.z;
+        tan1[i3Trio    ] += sdir.x;
+        tan1[i3Trio + 1] += sdir.y;
+        tan1[i3Trio + 2] += sdir.z;
 
-        tan2[i1 * 3 + 0] += tdir.x;
-        tan2[i1 * 3 + 1] += tdir.y;
-        tan2[i1 * 3 + 2] += tdir.z;
-        tan2[i2 * 3 + 0] += tdir.x;
-        tan2[i2 * 3 + 1] += tdir.y;
-        tan2[i2 * 3 + 2] += tdir.z;
-        tan2[i3 * 3 + 0] += tdir.x;
-        tan2[i3 * 3 + 1] += tdir.y;
-        tan2[i3 * 3 + 2] += tdir.z;
+        tan2[i1Trio    ] += tdir.x;
+        tan2[i1Trio + 1] += tdir.y;
+        tan2[i1Trio + 2] += tdir.z;
+        tan2[i2Trio    ] += tdir.x;
+        tan2[i2Trio + 1] += tdir.y;
+        tan2[i2Trio + 2] += tdir.z;
+        tan2[i3Trio    ] += tdir.x;
+        tan2[i3Trio + 1] += tdir.y;
+        tan2[i3Trio + 2] += tdir.z;
     }
 
     const t1 = new Vec3();

--- a/src/scene/procedural.js
+++ b/src/scene/procedural.js
@@ -97,7 +97,8 @@ function calculateTangents(positions, normals, uvs, indices) {
     // Lengyel's Method
     // http://web.archive.org/web/20180620024439/http://www.terathon.com/code/tangent.html
     const indicesLength = indices.length;
-    const vertexCount   = positions.length / 3;
+    const positionsLength = positions.length;
+    const vertexCount   = positionsLength / 3;
     const v1   = new Vec3();
     const v2   = new Vec3();
     const v3   = new Vec3();
@@ -188,13 +189,11 @@ function calculateTangents(positions, normals, uvs, indices) {
     const n = new Vec3();
     const temp = new Vec3();
 
-    for (let i = 0; i < vertexCount; i++) {
-        const iTrio = i * 3;
-        // `<< 2` is same as `* 4`
-        const iQuad = i << 2;
-        n.set(normals[iTrio], normals[iTrio + 1], normals[iTrio + 2]);
-        t1.set(tan1[iTrio], tan1[iTrio + 1], tan1[iTrio + 2]);
-        t2.set(tan2[iTrio], tan2[iTrio + 1], tan2[iTrio + 2]);
+    let iQuad = 0;
+    for (let i = 0; i < positionsLength; i += 3, iQuad += 4) {
+        n .set(normals[i], normals[i + 1], normals[i + 2]);
+        t1.set(   tan1[i],    tan1[i + 1],    tan1[i + 2]);
+        t2.set(   tan2[i],    tan2[i + 1],    tan2[i + 2]);
 
         // Gram-Schmidt orthogonalize
         const ndott = n.dot(t1);

--- a/src/shape/bounding-box.js
+++ b/src/shape/bounding-box.js
@@ -356,21 +356,26 @@ class BoundingBox {
     compute(vertices, numVerts) {
         numVerts = numVerts === undefined ? vertices.length / 3 : numVerts;
         if (numVerts > 0) {
-            const min = tmpVecA.set(vertices[0], vertices[1], vertices[2]);
-            const max = tmpVecB.set(vertices[0], vertices[1], vertices[2]);
-
-            for (let i = 1; i < numVerts; i++) {
-                const x = vertices[i * 3 + 0];
-                const y = vertices[i * 3 + 1];
-                const z = vertices[i * 3 + 2];
-                if (x < min.x) min.x = x;
-                if (y < min.y) min.y = y;
-                if (z < min.z) min.z = z;
-                if (x > max.x) max.x = x;
-                if (y > max.y) max.y = y;
-                if (z > max.z) max.z = z;
+            let minx = vertices[0];
+            let miny = vertices[1];
+            let minz = vertices[2];
+            let maxx = vertices[0];
+            let maxy = vertices[1];
+            let maxz = vertices[2];
+            const n = numVerts * 3;
+            for (let i = 3; i < n; i += 3) {
+                const x = vertices[i];
+                const y = vertices[i + 1];
+                const z = vertices[i + 2];
+                if (x < minx) minx = x;
+                if (y < miny) miny = y;
+                if (z < minz) minz = z;
+                if (x > maxx) maxx = x;
+                if (y > maxy) maxy = y;
+                if (z > maxz) maxz = z;
             }
-
+            const min = tmpVecA.set(minx, miny, minz);
+            const max = tmpVecB.set(maxx, maxy, maxz);
             this.setMinMax(min, max);
         }
     }


### PR DESCRIPTION
This is my first attempt at optimizing these two methods, since they became a bottle neck for procedural mesh generation:

Without PR:

![image](https://user-images.githubusercontent.com/5236548/161098001-f8ceefe2-9d1a-4e33-94a2-4b39b9589ade.png)

With PR:

![image](https://user-images.githubusercontent.com/5236548/161098207-86e66866-aa11-42f0-9d8e-a0229b596500.png)

I don't know if anyone relies upon returning of an `Array` instead of a `Float32Array`. Technically an `Array` is 64-bit double values and the length can be manipuliated afterwards, but does anyone need that?

I didn't test this barely at all yet and I have more ideas how it could be optimized. Would anyone want to add unit tests for normals/tangents to make sure its still correct?

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
