### PR TITLE
[FIX] Correct type of `AnimClip` eventHandler parameter

### DIFF
--- a/src/anim/evaluator/anim-clip.js
+++ b/src/anim/evaluator/anim-clip.js
@@ -1,6 +1,7 @@
 import { AnimSnapshot } from './anim-snapshot.js';
 
 /** @typedef {import('./anim-track.js').AnimTrack} AnimTrack */
+/** @typedef {import('../../core/event-handler.js').EventHandler} EventHandler */
 
 // TODO: add configurable looping start/end times?
 
@@ -19,7 +20,7 @@ class AnimClip {
      * @param {number} speed - Speed of the animation playback.
      * @param {boolean} playing - true if the clip is playing and false otherwise.
      * @param {boolean} loop - Whether the clip should loop.
-     * @param {Function} eventHandler - The handler to call when an event is fired by the clip.
+     * @param {EventHandler} [eventHandler] - The handler to call when an event is fired by the clip.
      */
     constructor(track, time, speed, playing, loop, eventHandler) {
         this._name = track.name;        // default to track name


### PR DESCRIPTION
Fix JSDoc declaration for `eventHandler` parameter of the `AnimClip` constructor.

Fixes #4117

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
