### PR TITLE
Migrate `framework` `scene` and `resources` folders to single quotes

### DIFF
--- a/src/framework/components/anim/component-binder.js
+++ b/src/framework/components/anim/component-binder.js
@@ -154,10 +154,10 @@ class AnimComponentBinder extends DefaultAnimBinder {
         const key = path[path.length - 1];
 
         // if the object has a setter function, use it
-        const setterFuncName = "set" + key.substring(0, 1).toUpperCase() + key.substring(1);
+        const setterFuncName = 'set' + key.substring(0, 1).toUpperCase() + key.substring(1);
         if (obj[setterFuncName]) {
             // if the object has a setter function, use it
-            const getterFunc = obj["get" + key.substring(0, 1).toUpperCase() + key.substring(1)].bind(obj);
+            const getterFunc = obj['get' + key.substring(0, 1).toUpperCase() + key.substring(1)].bind(obj);
             let baseValues = getterFunc();
             baseValues = [baseValues.x, baseValues.y, baseValues.z, baseValues.w];
             const setterFunc = obj[setterFuncName].bind(obj);

--- a/src/framework/components/anim/component.js
+++ b/src/framework/components/anim/component.js
@@ -13,7 +13,7 @@ import { AnimComponentBinder } from './component-binder.js';
 import { AnimComponentLayer } from './component-layer.js';
 import { AnimStateGraph } from '../../../anim/state-graph/anim-state-graph.js';
 import { AnimEvents } from '../../../anim/evaluator/anim-events.js';
-import { Entity } from "../../entity.js";
+import { Entity } from '../../entity.js';
 
 /** @typedef {import('./system.js').AnimComponentSystem} AnimComponentSystem */
 
@@ -318,8 +318,8 @@ class AnimComponent extends Component {
         if (layer) return layer;
         const states = [
             {
-                "name": "START",
-                "speed": 1
+                'name': 'START',
+                'speed': 1
             }
         ];
         const transitions = [];
@@ -501,30 +501,30 @@ class AnimComponent extends Component {
     addAnimationState(nodeName, animTrack, speed = 1, loop = true, layerName = 'Base') {
         if (!this._stateGraph) {
             this.loadStateGraph(new AnimStateGraph({
-                "layers": [
+                'layers': [
                     {
-                        "name": layerName,
-                        "states": [
+                        'name': layerName,
+                        'states': [
                             {
-                                "name": "START",
-                                "speed": 1
+                                'name': 'START',
+                                'speed': 1
                             },
                             {
-                                "name": nodeName,
-                                "speed": speed,
-                                "loop": loop,
-                                "defaultState": true
+                                'name': nodeName,
+                                'speed': speed,
+                                'loop': loop,
+                                'defaultState': true
                             }
                         ],
-                        "transitions": [
+                        'transitions': [
                             {
-                                "from": 'START',
-                                "to": nodeName
+                                'from': 'START',
+                                'to': nodeName
                             }
                         ]
                     }
                 ],
-                "parameters": {}
+                'parameters': {}
             }));
         }
         const layer = this.findAnimationLayer(layerName);
@@ -558,30 +558,30 @@ class AnimComponent extends Component {
     assignAnimation(nodePath, animTrack, layerName, speed = 1, loop = true) {
         if (!this._stateGraph && nodePath.indexOf('.') === -1) {
             this.loadStateGraph(new AnimStateGraph({
-                "layers": [
+                'layers': [
                     {
-                        "name": "Base",
-                        "states": [
+                        'name': 'Base',
+                        'states': [
                             {
-                                "name": "START",
-                                "speed": 1
+                                'name': 'START',
+                                'speed': 1
                             },
                             {
-                                "name": nodePath,
-                                "speed": speed,
-                                "loop": loop,
-                                "defaultState": true
+                                'name': nodePath,
+                                'speed': speed,
+                                'loop': loop,
+                                'defaultState': true
                             }
                         ],
-                        "transitions": [
+                        'transitions': [
                             {
-                                "from": 'START',
-                                "to": nodePath
+                                'from': 'START',
+                                'to': nodePath
                             }
                         ]
                     }
                 ],
-                "parameters": {}
+                'parameters': {}
             }));
             this.baseLayer.assignAnimation(nodePath, animTrack);
             return;

--- a/src/framework/components/audio-listener/system.js
+++ b/src/framework/components/audio-listener/system.js
@@ -24,7 +24,7 @@ class AudioListenerComponentSystem extends ComponentSystem {
     constructor(app, manager) {
         super(app);
 
-        this.id = "audiolistener";
+        this.id = 'audiolistener';
 
         this.ComponentType = AudioListenerComponent;
         this.DataType = AudioListenerComponentData;

--- a/src/framework/components/audio-source/component.js
+++ b/src/framework/components/audio-source/component.js
@@ -47,15 +47,15 @@ class AudioSourceComponent extends Component {
     constructor(system, entity) {
         super(system, entity);
 
-        this.on("set_assets", this.onSetAssets, this);
-        this.on("set_loop", this.onSetLoop, this);
-        this.on("set_volume", this.onSetVolume, this);
-        this.on("set_pitch", this.onSetPitch, this);
-        this.on("set_minDistance", this.onSetMinDistance, this);
-        this.on("set_maxDistance", this.onSetMaxDistance, this);
-        this.on("set_rollOffFactor", this.onSetRollOffFactor, this);
-        this.on("set_distanceModel", this.onSetDistanceModel, this);
-        this.on("set_3d", this.onSet3d, this);
+        this.on('set_assets', this.onSetAssets, this);
+        this.on('set_loop', this.onSetLoop, this);
+        this.on('set_volume', this.onSetVolume, this);
+        this.on('set_pitch', this.onSetPitch, this);
+        this.on('set_minDistance', this.onSetMinDistance, this);
+        this.on('set_maxDistance', this.onSetMaxDistance, this);
+        this.on('set_rollOffFactor', this.onSetRollOffFactor, this);
+        this.on('set_distanceModel', this.onSetDistanceModel, this);
+        this.on('set_3d', this.onSet3d, this);
     }
 
     /**
@@ -351,7 +351,7 @@ class AudioSourceComponent extends Component {
                     _done();
                 }
                 // but if they are added insert them into source list
-                this.system.app.assets.on("add:" + ids[index], (asset) => {
+                this.system.app.assets.on('add:' + ids[index], (asset) => {
                     asset.ready((asset) => {
                         this.data.sources[asset.name] = asset.resource;
                     });

--- a/src/framework/components/audio-source/system.js
+++ b/src/framework/components/audio-source/system.js
@@ -45,7 +45,7 @@ class AudioSourceComponentSystem extends ComponentSystem {
     constructor(app, manager) {
         super(app);
 
-        this.id = "audiosource";
+        this.id = 'audiosource';
 
         this.ComponentType = AudioSourceComponent;
         this.DataType = AudioSourceComponentData;

--- a/src/framework/components/camera/component.js
+++ b/src/framework/components/camera/component.js
@@ -433,10 +433,10 @@ class CameraComponent extends Component {
 
     onLayersChanged(oldComp, newComp) {
         this.addCameraToLayers();
-        oldComp.off("add", this.onLayerAdded, this);
-        oldComp.off("remove", this.onLayerRemoved, this);
-        newComp.on("add", this.onLayerAdded, this);
-        newComp.on("remove", this.onLayerRemoved, this);
+        oldComp.off('add', this.onLayerAdded, this);
+        oldComp.off('remove', this.onLayerRemoved, this);
+        newComp.on('add', this.onLayerAdded, this);
+        newComp.on('remove', this.onLayerRemoved, this);
     }
 
     onLayerAdded(layer) {
@@ -458,10 +458,10 @@ class CameraComponent extends Component {
 
         system.addCamera(this);
 
-        scene.on("set:layers", this.onLayersChanged, this);
+        scene.on('set:layers', this.onLayersChanged, this);
         if (layers) {
-            layers.on("add", this.onLayerAdded, this);
-            layers.on("remove", this.onLayerRemoved, this);
+            layers.on('add', this.onLayerAdded, this);
+            layers.on('remove', this.onLayerRemoved, this);
         }
 
         if (this.enabled && this.entity.enabled) {
@@ -480,10 +480,10 @@ class CameraComponent extends Component {
 
         this.removeCameraFromLayers();
 
-        scene.off("set:layers", this.onLayersChanged, this);
+        scene.off('set:layers', this.onLayersChanged, this);
         if (layers) {
-            layers.off("add", this.onLayerAdded, this);
-            layers.off("remove", this.onLayerRemoved, this);
+            layers.off('add', this.onLayerAdded, this);
+            layers.off('remove', this.onLayerRemoved, this);
         }
 
         system.removeCamera(this);
@@ -574,7 +574,7 @@ class CameraComponent extends Component {
         }
 
         if (!this.system.app.vr) {
-            callback("VrManager not created. Enable VR in project settings.");
+            callback('VrManager not created. Enable VR in project settings.');
             return;
         }
 
@@ -606,7 +606,7 @@ class CameraComponent extends Component {
                 callback();
             }
         } else {
-            callback("No pc.VrDisplay to present");
+            callback('No pc.VrDisplay to present');
         }
     }
 
@@ -638,7 +638,7 @@ class CameraComponent extends Component {
                 callback();
             }
         } else {
-            callback("Not presenting VR");
+            callback('Not presenting VR');
         }
     }
 
@@ -717,7 +717,7 @@ class CameraComponent extends Component {
      */
     endXr(callback) {
         if (!this._camera.xr) {
-            if (callback) callback(new Error("Camera is not in XR"));
+            if (callback) callback(new Error('Camera is not in XR'));
             return;
         }
 

--- a/src/framework/components/camera/post-effect-queue.js
+++ b/src/framework/components/camera/post-effect-queue.js
@@ -316,7 +316,7 @@ class PostEffectQueue {
                     const len = this.effects.length;
                     if (len) {
 
-                        DebugGraphics.pushGpuMarker(this.app.graphicsDevice, "Postprocess");
+                        DebugGraphics.pushGpuMarker(this.app.graphicsDevice, 'Postprocess');
 
                         for (let i = 0; i < len; i++) {
                             const fx = this.effects[i];

--- a/src/framework/components/collision/component.js
+++ b/src/framework/components/collision/component.js
@@ -72,10 +72,10 @@ class CollisionComponent extends Component {
         this.on('set_radius', this.onSetRadius, this);
         this.on('set_height', this.onSetHeight, this);
         this.on('set_axis', this.onSetAxis, this);
-        this.on("set_asset", this.onSetAsset, this);
-        this.on("set_renderAsset", this.onSetRenderAsset, this);
-        this.on("set_model", this.onSetModel, this);
-        this.on("set_render", this.onSetRender, this);
+        this.on('set_asset', this.onSetAsset, this);
+        this.on('set_renderAsset', this.onSetRenderAsset, this);
+        this.on('set_model', this.onSetModel, this);
+        this.on('set_render', this.onSetRender, this);
     }
 
     // Events Documentation

--- a/src/framework/components/collision/system.js
+++ b/src/framework/components/collision/system.js
@@ -448,7 +448,7 @@ class CollisionMeshSystemImpl extends CollisionSystemImpl {
             });
             assets.load(asset);
         } else {
-            assets.once("add:" + id, (asset) => {
+            assets.once('add:' + id, (asset) => {
                 asset.ready((asset) => {
                     data[property] = asset.resource;
                     this.doRecreatePhysicalShape(component);
@@ -580,7 +580,7 @@ class CollisionComponentSystem extends ComponentSystem {
     constructor(app) {
         super(app);
 
-        this.id = "collision";
+        this.id = 'collision';
 
         this.ComponentType = CollisionComponent;
         this.DataType = CollisionComponentData;

--- a/src/framework/components/component.js
+++ b/src/framework/components/component.js
@@ -43,8 +43,8 @@ class Component extends EventHandler {
             this.buildAccessors(this.system.schema);
         }
 
-        this.on("set", function (name, oldValue, newValue) {
-            this.fire("set_" + name, name, oldValue, newValue);
+        this.on('set', function (name, oldValue, newValue) {
+            this.fire('set_' + name, name, oldValue, newValue);
         });
 
         this.on('set_enabled', this.onSetEnabled, this);

--- a/src/framework/components/element/component.js
+++ b/src/framework/components/element/component.js
@@ -451,7 +451,7 @@ class ElementComponent extends Component {
         }
 
         if (value > 0xFFFFFF) {
-            Debug.warn("Element.drawOrder larger than max size of: " + 0xFFFFFF);
+            Debug.warn('Element.drawOrder larger than max size of: ' + 0xFFFFFF);
             value = 0xFFFFFF;
         }
 
@@ -770,7 +770,7 @@ class ElementComponent extends Component {
             }
         } else {
             if (this._useInput === true) {
-                console.warn("Elements will not get any input events because this.system.app.elementInput is not created");
+                console.warn('Elements will not get any input events because this.system.app.elementInput is not created');
             }
         }
 
@@ -1157,7 +1157,7 @@ class ElementComponent extends Component {
         if (mask) {
             const ref = mask.element._image._maskRef;
             // #if _DEBUG
-            if (_debugLogging) console.log("masking: " + this.entity.name + " with " + ref);
+            if (_debugLogging) console.log('masking: ' + this.entity.name + ' with ' + ref);
             // #endif
 
             const sp = new StencilParameters({
@@ -1173,7 +1173,7 @@ class ElementComponent extends Component {
             this._maskedBy = mask;
         } else {
             // #if _DEBUG
-            if (_debugLogging) console.log("no masking on: " + this.entity.name);
+            if (_debugLogging) console.log('no masking on: ' + this.entity.name);
             // #endif
 
             // remove stencil params if this is image or text
@@ -1206,8 +1206,8 @@ class ElementComponent extends Component {
 
                 // #if _DEBUG
                 if (_debugLogging) {
-                    console.log("masking from: " + this.entity.name + " with " + (sp.ref + 1));
-                    console.log("depth++ to: ", depth);
+                    console.log('masking from: ' + this.entity.name + ' with ' + (sp.ref + 1));
+                    console.log('depth++ to: ', depth);
                 }
                 // #endif
 
@@ -1243,8 +1243,8 @@ class ElementComponent extends Component {
 
                 // #if _DEBUG
                 if (_debugLogging) {
-                    console.log("masking from: " + this.entity.name + " with " + sp.ref);
-                    console.log("depth++ to: ", depth);
+                    console.log('masking from: ' + this.entity.name + ' with ' + sp.ref);
+                    console.log('depth++ to: ', depth);
                 }
                 // #endif
 
@@ -1352,10 +1352,10 @@ class ElementComponent extends Component {
 
     onLayersChanged(oldComp, newComp) {
         this.addModelToLayers(this._image ? this._image._renderable.model : this._text._model);
-        oldComp.off("add", this.onLayerAdded, this);
-        oldComp.off("remove", this.onLayerRemoved, this);
-        newComp.on("add", this.onLayerAdded, this);
-        newComp.on("remove", this.onLayerRemoved, this);
+        oldComp.off('add', this.onLayerAdded, this);
+        oldComp.off('remove', this.onLayerRemoved, this);
+        newComp.on('add', this.onLayerAdded, this);
+        newComp.on('remove', this.onLayerRemoved, this);
     }
 
     onLayerAdded(layer) {
@@ -1387,24 +1387,24 @@ class ElementComponent extends Component {
             this.system.app.elementInput.addElement(this);
         }
 
-        this.system.app.scene.on("set:layers", this.onLayersChanged, this);
+        this.system.app.scene.on('set:layers', this.onLayersChanged, this);
         if (this.system.app.scene.layers) {
-            this.system.app.scene.layers.on("add", this.onLayerAdded, this);
-            this.system.app.scene.layers.on("remove", this.onLayerRemoved, this);
+            this.system.app.scene.layers.on('add', this.onLayerAdded, this);
+            this.system.app.scene.layers.on('remove', this.onLayerRemoved, this);
         }
 
         if (this._batchGroupId >= 0) {
             this.system.app.batcher.insert(BatchGroup.ELEMENT, this.batchGroupId, this.entity);
         }
 
-        this.fire("enableelement");
+        this.fire('enableelement');
     }
 
     onDisable() {
-        this.system.app.scene.off("set:layers", this.onLayersChanged, this);
+        this.system.app.scene.off('set:layers', this.onLayersChanged, this);
         if (this.system.app.scene.layers) {
-            this.system.app.scene.layers.off("add", this.onLayerAdded, this);
-            this.system.app.scene.layers.off("remove", this.onLayerRemoved, this);
+            this.system.app.scene.layers.off('add', this.onLayerAdded, this);
+            this.system.app.scene.layers.off('remove', this.onLayerRemoved, this);
         }
 
         if (this._image) this._image.onDisable();
@@ -1419,7 +1419,7 @@ class ElementComponent extends Component {
             this.system.app.batcher.remove(BatchGroup.ELEMENT, this.batchGroupId, this.entity);
         }
 
-        this.fire("disableelement");
+        this.fire('disableelement');
     }
 
     onRemove() {
@@ -1649,44 +1649,44 @@ function _define(name) {
     });
 }
 
-_define("fontSize");
-_define("minFontSize");
-_define("maxFontSize");
-_define("maxLines");
-_define("autoFitWidth");
-_define("autoFitHeight");
-_define("color");
-_define("font");
-_define("fontAsset");
-_define("spacing");
-_define("lineHeight");
-_define("wrapLines");
-_define("lines");
-_define("alignment");
-_define("autoWidth");
-_define("autoHeight");
-_define("rtlReorder");
-_define("unicodeConverter");
-_define("text");
-_define("key");
-_define("texture");
-_define("textureAsset");
-_define("material");
-_define("materialAsset");
-_define("sprite");
-_define("spriteAsset");
-_define("spriteFrame");
-_define("pixelsPerUnit");
-_define("opacity");
-_define("rect");
-_define("mask");
-_define("outlineColor");
-_define("outlineThickness");
-_define("shadowColor");
-_define("shadowOffset");
-_define("enableMarkup");
-_define("rangeStart");
-_define("rangeEnd");
+_define('fontSize');
+_define('minFontSize');
+_define('maxFontSize');
+_define('maxLines');
+_define('autoFitWidth');
+_define('autoFitHeight');
+_define('color');
+_define('font');
+_define('fontAsset');
+_define('spacing');
+_define('lineHeight');
+_define('wrapLines');
+_define('lines');
+_define('alignment');
+_define('autoWidth');
+_define('autoHeight');
+_define('rtlReorder');
+_define('unicodeConverter');
+_define('text');
+_define('key');
+_define('texture');
+_define('textureAsset');
+_define('material');
+_define('materialAsset');
+_define('sprite');
+_define('spriteAsset');
+_define('spriteFrame');
+_define('pixelsPerUnit');
+_define('opacity');
+_define('rect');
+_define('mask');
+_define('outlineColor');
+_define('outlineThickness');
+_define('shadowColor');
+_define('shadowOffset');
+_define('enableMarkup');
+_define('rangeStart');
+_define('rangeEnd');
 
 // Events Documentation
 

--- a/src/framework/components/element/image-element.js
+++ b/src/framework/components/element/image-element.js
@@ -639,9 +639,9 @@ class ImageElement {
     _bindMaterialAsset(asset) {
         if (!this._entity.enabled) return; // don't bind until element is enabled
 
-        asset.on("load", this._onMaterialLoad, this);
-        asset.on("change", this._onMaterialChange, this);
-        asset.on("remove", this._onMaterialRemove, this);
+        asset.on('load', this._onMaterialLoad, this);
+        asset.on('change', this._onMaterialChange, this);
+        asset.on('remove', this._onMaterialRemove, this);
 
         if (asset.resource) {
             this._onMaterialLoad(asset);
@@ -651,9 +651,9 @@ class ImageElement {
     }
 
     _unbindMaterialAsset(asset) {
-        asset.off("load", this._onMaterialLoad, this);
-        asset.off("change", this._onMaterialChange, this);
-        asset.off("remove", this._onMaterialRemove, this);
+        asset.off('load', this._onMaterialLoad, this);
+        asset.off('change', this._onMaterialChange, this);
+        asset.off('remove', this._onMaterialRemove, this);
     }
 
     _onMaterialChange() {
@@ -674,9 +674,9 @@ class ImageElement {
     _bindTextureAsset(asset) {
         if (!this._entity.enabled) return; // don't bind until element is enabled
 
-        asset.on("load", this._onTextureLoad, this);
-        asset.on("change", this._onTextureChange, this);
-        asset.on("remove", this._onTextureRemove, this);
+        asset.on('load', this._onTextureLoad, this);
+        asset.on('change', this._onTextureChange, this);
+        asset.on('remove', this._onTextureRemove, this);
 
         if (asset.resource) {
             this._onTextureLoad(asset);
@@ -686,9 +686,9 @@ class ImageElement {
     }
 
     _unbindTextureAsset(asset) {
-        asset.off("load", this._onTextureLoad, this);
-        asset.off("change", this._onTextureChange, this);
-        asset.off("remove", this._onTextureRemove, this);
+        asset.off('load', this._onTextureLoad, this);
+        asset.off('change', this._onTextureChange, this);
+        asset.off('remove', this._onTextureRemove, this);
     }
 
     _onTextureLoad(asset) {
@@ -715,9 +715,9 @@ class ImageElement {
     _bindSpriteAsset(asset) {
         if (!this._entity.enabled) return; // don't bind until element is enabled
 
-        asset.on("load", this._onSpriteAssetLoad, this);
-        asset.on("change", this._onSpriteAssetChange, this);
-        asset.on("remove", this._onSpriteAssetRemove, this);
+        asset.on('load', this._onSpriteAssetLoad, this);
+        asset.on('change', this._onSpriteAssetChange, this);
+        asset.on('remove', this._onSpriteAssetRemove, this);
 
         if (asset.resource) {
             this._onSpriteAssetLoad(asset);
@@ -727,12 +727,12 @@ class ImageElement {
     }
 
     _unbindSpriteAsset(asset) {
-        asset.off("load", this._onSpriteAssetLoad, this);
-        asset.off("change", this._onSpriteAssetChange, this);
-        asset.off("remove", this._onSpriteAssetRemove, this);
+        asset.off('load', this._onSpriteAssetLoad, this);
+        asset.off('change', this._onSpriteAssetChange, this);
+        asset.off('remove', this._onSpriteAssetRemove, this);
 
         if (asset.data.textureAtlasAsset) {
-            this._system.app.assets.off("load:" + asset.data.textureAtlasAsset, this._onTextureAtlasLoad, this);
+            this._system.app.assets.off('load:' + asset.data.textureAtlasAsset, this._onTextureAtlasLoad, this);
         }
     }
 
@@ -877,7 +877,7 @@ class ImageElement {
 
         // #if _DEBUG
         if (this._color === value) {
-            Debug.warn("Setting element.color to itself will have no effect");
+            Debug.warn('Setting element.color to itself will have no effect');
         }
         // #endif
 
@@ -1007,9 +1007,9 @@ class ImageElement {
                 assets.off('add:' + this._materialAsset, this._onMaterialAdded, this);
                 const _prev = assets.get(this._materialAsset);
                 if (_prev) {
-                    _prev.off("load", this._onMaterialLoad, this);
-                    _prev.off("change", this._onMaterialChange, this);
-                    _prev.off("remove", this._onMaterialRemove, this);
+                    _prev.off('load', this._onMaterialLoad, this);
+                    _prev.off('change', this._onMaterialChange, this);
+                    _prev.off('remove', this._onMaterialRemove, this);
                 }
             }
 
@@ -1052,17 +1052,17 @@ class ImageElement {
             }
 
             // default texture just uses emissive and opacity maps
-            this._renderable.setParameter("texture_emissiveMap", this._texture);
-            this._renderable.setParameter("texture_opacityMap", this._texture);
+            this._renderable.setParameter('texture_emissiveMap', this._texture);
+            this._renderable.setParameter('texture_opacityMap', this._texture);
             this._colorUniform[0] = this._color.r;
             this._colorUniform[1] = this._color.g;
             this._colorUniform[2] = this._color.b;
-            this._renderable.setParameter("material_emissive", this._colorUniform);
-            this._renderable.setParameter("material_opacity", this._color.a);
+            this._renderable.setParameter('material_emissive', this._colorUniform);
+            this._renderable.setParameter('material_opacity', this._color.a);
         } else {
             // clear texture params
-            this._renderable.deleteParameter("texture_emissiveMap");
-            this._renderable.deleteParameter("texture_opacityMap");
+            this._renderable.deleteParameter('texture_emissiveMap');
+            this._renderable.deleteParameter('texture_opacityMap');
         }
     }
 
@@ -1083,9 +1083,9 @@ class ImageElement {
                 assets.off('add:' + this._textureAsset, this._onTextureAdded, this);
                 const _prev = assets.get(this._textureAsset);
                 if (_prev) {
-                    _prev.off("load", this._onTextureLoad, this);
-                    _prev.off("change", this._onTextureChange, this);
-                    _prev.off("remove", this._onTextureRemove, this);
+                    _prev.off('load', this._onTextureLoad, this);
+                    _prev.off('change', this._onTextureChange, this);
+                    _prev.off('remove', this._onTextureRemove, this);
                 }
             }
 
@@ -1175,12 +1175,12 @@ class ImageElement {
 
         if (this._sprite && this._sprite.atlas && this._sprite.atlas.texture) {
             // default texture just uses emissive and opacity maps
-            this._renderable.setParameter("texture_emissiveMap", this._sprite.atlas.texture);
-            this._renderable.setParameter("texture_opacityMap", this._sprite.atlas.texture);
+            this._renderable.setParameter('texture_emissiveMap', this._sprite.atlas.texture);
+            this._renderable.setParameter('texture_opacityMap', this._sprite.atlas.texture);
         } else {
             // clear texture params
-            this._renderable.deleteParameter("texture_emissiveMap");
-            this._renderable.deleteParameter("texture_opacityMap");
+            this._renderable.deleteParameter('texture_emissiveMap');
+            this._renderable.deleteParameter('texture_opacityMap');
         }
 
         // clamp frame

--- a/src/framework/components/element/markup.js
+++ b/src/framework/components/element/markup.js
@@ -10,7 +10,7 @@ const EQUALS_TOKEN = 5;
 const STRING_TOKEN = 6;
 const IDENTIFIER_TOKEN = 7;
 const WHITESPACE_TOKEN = 8;
-const WHITESPACE_CHARS = " \t\n\r\v\f";
+const WHITESPACE_CHARS = ' \t\n\r\v\f';
 const IDENTIFIER_REGEX = /[A-Z|a-z|0-9|_|-|/]/;
 
 class Scanner {
@@ -20,7 +20,7 @@ class Scanner {
         this._last = 0;
         this._cur = (this._symbols.length > 0) ? this._symbols[0] : null;
         this._buf = [];
-        this._mode = "text";
+        this._mode = 'text';
         this._error = null;
     }
 
@@ -53,13 +53,13 @@ class Scanner {
 
     // print the scanner output
     debugPrint() {
-        const tokenStrings = ["EOF", "ERROR", "TEXT", "OPEN_BRACKET", "CLOSE_BRACKET", "EQUALS", "STRING", "IDENTIFIER", "WHITESPACE"];
+        const tokenStrings = ['EOF', 'ERROR', 'TEXT', 'OPEN_BRACKET', 'CLOSE_BRACKET', 'EQUALS', 'STRING', 'IDENTIFIER', 'WHITESPACE'];
         let token = this.read();
-        let result = "";
+        let result = '';
         while (true) {
-            result += (result.length > 0 ? "\n" : "") +
+            result += (result.length > 0 ? '\n' : '') +
                         tokenStrings[token] +
-                        " '" + this.buf().join("") + "'";
+                        ' \'' + this.buf().join('') + '\'';
             if (token === EOF_TOKEN || token === ERROR_TOKEN) {
                 break;
             }
@@ -74,7 +74,7 @@ class Scanner {
         if (this._eof()) {
             return EOF_TOKEN;
         }
-        return (this._mode === "text") ? this._text() : this._tag();
+        return (this._mode === 'text') ? this._text() : this._tag();
     }
 
     // read text block until eof or start of tag
@@ -84,21 +84,21 @@ class Scanner {
                 case null:
                     // reached end of input
                     return (this._buf.length > 0) ? TEXT_TOKEN : EOF_TOKEN;
-                case "[":
+                case '[':
                     // start of tag mode
-                    this._mode = "tag";
+                    this._mode = 'tag';
                     return (this._buf.length > 0) ? TEXT_TOKEN : this._tag();
-                case "\\":
+                case '\\':
                     // handle escape sequence
                     this._next();           // skip \
                     switch (this._cur) {
-                        case "[":
+                        case '[':
                             this._store();
                             break;
                         default:
                             // if we don't recognize the escape sequence, output
                             // the slash without interpretation and continue
-                            this._output("\\");
+                            this._output('\\');
                             break;
                     }
                     break;
@@ -113,30 +113,30 @@ class Scanner {
     _tag() {
         switch (this._cur) {
             case null:
-                this._error = "unexpected end of input reading tag";
+                this._error = 'unexpected end of input reading tag';
                 return ERROR_TOKEN;
-            case "[":
+            case '[':
                 this._store();
                 return OPEN_BRACKET_TOKEN;
-            case "]":
+            case ']':
                 this._store();
-                this._mode = "text";
+                this._mode = 'text';
                 return CLOSE_BRACKET_TOKEN;
-            case "=":
+            case '=':
                 this._store();
                 return EQUALS_TOKEN;
-            case " ":
-            case "\t":
-            case "\n":
-            case "\r":
-            case "\v":
-            case "\f":
+            case ' ':
+            case '\t':
+            case '\n':
+            case '\r':
+            case '\v':
+            case '\f':
                 return this._whitespace();
-            case "\"":
+            case '"':
                 return this._string();
             default:
                 if (!this._isIdentifierSymbol(this._cur)) {
-                    this._error = "unrecognized character";
+                    this._error = 'unrecognized character';
                     return ERROR_TOKEN;
                 }
                 return this._identifier();
@@ -156,9 +156,9 @@ class Scanner {
         while (true) {
             switch (this._cur) {
                 case null:
-                    this._error = "unexpected end of input reading string";
+                    this._error = 'unexpected end of input reading string';
                     return ERROR_TOKEN;
-                case "\"":
+                case '"':
                     this._next();           // skip "
                     return STRING_TOKEN;
                 default:
@@ -247,34 +247,34 @@ class Parser {
 
     // access an error message if the parser failed
     error() {
-        return "Error evaluating markup at #" + this._scanner.last().toString() +
-                " (" + (this._scanner.error() || this._error) + ")";
+        return 'Error evaluating markup at #' + this._scanner.last().toString() +
+                ' (' + (this._scanner.error() || this._error) + ')';
     }
 
     _parseTag(symbols, tags) {
         // first token after [ must be an identifier
         let token = this._scanner.read();
         if (token !== IDENTIFIER_TOKEN) {
-            this._error = "expected identifier";
+            this._error = 'expected identifier';
             return false;
         }
 
-        const name = this._scanner.buf().join("");
+        const name = this._scanner.buf().join('');
 
         // handle close tags
-        if (name[0] === "/") {
+        if (name[0] === '/') {
             for (let index = tags.length - 1; index >= 0; --index) {
-                if (name === "/" + tags[index].name && tags[index].end === null) {
+                if (name === '/' + tags[index].name && tags[index].end === null) {
                     tags[index].end = symbols.length;
                     token = this._scanner.read();
                     if (token !== CLOSE_BRACKET_TOKEN) {
-                        this._error = "expected close bracket";
+                        this._error = 'expected close bracket';
                         return false;
                     }
                     return true;
                 }
             }
-            this._error = "failed to find matching tag";
+            this._error = 'failed to find matching tag';
             return false;
         }
 
@@ -292,10 +292,10 @@ class Parser {
         if (token === EQUALS_TOKEN) {
             token = this._scanner.read();
             if (token !== STRING_TOKEN) {
-                this._error = "expected string";
+                this._error = 'expected string';
                 return false;
             }
-            tag.value = this._scanner.buf().join("");
+            tag.value = this._scanner.buf().join('');
             token = this._scanner.read();
         }
 
@@ -306,23 +306,23 @@ class Parser {
                     tags.push(tag);
                     return true;
                 case IDENTIFIER_TOKEN: {
-                    const identifier = this._scanner.buf().join("");
+                    const identifier = this._scanner.buf().join('');
                     token = this._scanner.read();
                     if (token !== EQUALS_TOKEN) {
-                        this._error = "expected equals";
+                        this._error = 'expected equals';
                         return false;
                     }
                     token = this._scanner.read();
                     if (token !== STRING_TOKEN) {
-                        this._error = "expected string";
+                        this._error = 'expected string';
                         return false;
                     }
-                    const value = this._scanner.buf().join("");
+                    const value = this._scanner.buf().join('');
                     tag.attributes[identifier] = value;
                     break;
                 }
                 default:
-                    this._error = "expected close bracket or identifier";
+                    this._error = 'expected close bracket or identifier';
                     return false;
             }
             token = this._scanner.read();

--- a/src/framework/components/element/system.js
+++ b/src/framework/components/element/system.js
@@ -333,7 +333,7 @@ class ElementComponentSystem extends ComponentSystem {
             if (msdf) {
                 if (!this.defaultScreenSpaceTextMaterial) {
                     this.defaultScreenSpaceTextMaterial = new StandardMaterial();
-                    this.defaultScreenSpaceTextMaterial.name = "defaultScreenSpaceTextMaterial";
+                    this.defaultScreenSpaceTextMaterial.name = 'defaultScreenSpaceTextMaterial';
                     this.defaultScreenSpaceTextMaterial.msdfMap = this._defaultTexture;
                     this.defaultScreenSpaceTextMaterial.useLighting = false;
                     this.defaultScreenSpaceTextMaterial.useGammaTonemap = false;
@@ -352,7 +352,7 @@ class ElementComponentSystem extends ComponentSystem {
             }
             if (!this.defaultScreenSpaceBitmapTextMaterial) {
                 this.defaultScreenSpaceBitmapTextMaterial = new StandardMaterial();
-                this.defaultScreenSpaceBitmapTextMaterial.name = "defaultScreenSpaceBitmapTextMaterial";
+                this.defaultScreenSpaceBitmapTextMaterial.name = 'defaultScreenSpaceBitmapTextMaterial';
                 this.defaultScreenSpaceBitmapTextMaterial.emissive.set(0.5, 0.5, 0.5); // set to non-(1,1,1) so that tint is actually applied
                 this.defaultScreenSpaceBitmapTextMaterial.emissiveMap = this._defaultTexture;
                 this.defaultScreenSpaceBitmapTextMaterial.emissiveTint = true;
@@ -376,7 +376,7 @@ class ElementComponentSystem extends ComponentSystem {
         if (msdf) {
             if (!this.defaultTextMaterial) {
                 this.defaultTextMaterial = new StandardMaterial();
-                this.defaultTextMaterial.name = "defaultTextMaterial";
+                this.defaultTextMaterial.name = 'defaultTextMaterial';
                 this.defaultTextMaterial.msdfMap = this._defaultTexture;
                 this.defaultTextMaterial.useLighting = false;
                 this.defaultTextMaterial.useGammaTonemap = false;
@@ -394,7 +394,7 @@ class ElementComponentSystem extends ComponentSystem {
         }
         if (!this.defaultBitmapTextMaterial) {
             this.defaultBitmapTextMaterial = new StandardMaterial();
-            this.defaultBitmapTextMaterial.name = "defaultBitmapTextMaterial";
+            this.defaultBitmapTextMaterial.name = 'defaultBitmapTextMaterial';
             this.defaultBitmapTextMaterial.emissive.set(0.5, 0.5, 0.5);  // set to non-(1,1,1) so that tint is actually applied
             this.defaultBitmapTextMaterial.emissiveTint = true;
             this.defaultBitmapTextMaterial.emissiveMap = this._defaultTexture;
@@ -422,7 +422,7 @@ class ElementComponentSystem extends ComponentSystem {
         material.emissiveMap = this._defaultTexture;
         material.emissiveTint = true;
         material.opacityMap = this._defaultTexture;
-        material.opacityMapChannel = "a";
+        material.opacityMapChannel = 'a';
         material.opacityTint = true;
         material.opacity = 0; // use non-1 opacity to compile shader correctly
         material.useLighting = false;
@@ -442,7 +442,7 @@ class ElementComponentSystem extends ComponentSystem {
                 if (nineSliced) {
                     if (!this.defaultScreenSpaceImageMask9SlicedMaterial) {
                         this.defaultScreenSpaceImageMask9SlicedMaterial = this._createBaseImageMaterial();
-                        this.defaultScreenSpaceImageMask9SlicedMaterial.name = "defaultScreenSpaceImageMask9SlicedMaterial";
+                        this.defaultScreenSpaceImageMask9SlicedMaterial.name = 'defaultScreenSpaceImageMask9SlicedMaterial';
                         this.defaultScreenSpaceImageMask9SlicedMaterial.nineSlicedMode = SPRITE_RENDERMODE_SLICED;
                         this.defaultScreenSpaceImageMask9SlicedMaterial.depthTest = false;
                         this.defaultScreenSpaceImageMask9SlicedMaterial.alphaTest = 1;
@@ -458,7 +458,7 @@ class ElementComponentSystem extends ComponentSystem {
                 } else if (nineSliceTiled) {
                     if (!this.defaultScreenSpaceImageMask9TiledMaterial) {
                         this.defaultScreenSpaceImageMask9TiledMaterial = this.defaultScreenSpaceImage9TiledMaterial.clone();
-                        this.defaultScreenSpaceImageMask9TiledMaterial.name = "defaultScreenSpaceImageMask9TiledMaterial";
+                        this.defaultScreenSpaceImageMask9TiledMaterial.name = 'defaultScreenSpaceImageMask9TiledMaterial';
                         this.defaultScreenSpaceImageMask9TiledMaterial.nineSlicedMode = SPRITE_RENDERMODE_TILED;
                         this.defaultScreenSpaceImageMask9TiledMaterial.depthTest = false;
                         this.defaultScreenSpaceImageMask9TiledMaterial.alphaTest = 1;
@@ -474,7 +474,7 @@ class ElementComponentSystem extends ComponentSystem {
                 } else {
                     if (!this.defaultScreenSpaceImageMaskMaterial) {
                         this.defaultScreenSpaceImageMaskMaterial = this._createBaseImageMaterial();
-                        this.defaultScreenSpaceImageMaskMaterial.name = "defaultScreenSpaceImageMaskMaterial";
+                        this.defaultScreenSpaceImageMaskMaterial.name = 'defaultScreenSpaceImageMaskMaterial';
                         this.defaultScreenSpaceImageMaskMaterial.depthTest = false;
                         this.defaultScreenSpaceImageMaskMaterial.alphaTest = 1;
                         this.defaultScreenSpaceImageMaskMaterial.redWrite = false;
@@ -491,7 +491,7 @@ class ElementComponentSystem extends ComponentSystem {
                 if (nineSliced) {
                     if (!this.defaultScreenSpaceImage9SlicedMaterial) {
                         this.defaultScreenSpaceImage9SlicedMaterial = this._createBaseImageMaterial();
-                        this.defaultScreenSpaceImage9SlicedMaterial.name = "defaultScreenSpaceImage9SlicedMaterial";
+                        this.defaultScreenSpaceImage9SlicedMaterial.name = 'defaultScreenSpaceImage9SlicedMaterial';
                         this.defaultScreenSpaceImage9SlicedMaterial.nineSlicedMode = SPRITE_RENDERMODE_SLICED;
                         this.defaultScreenSpaceImage9SlicedMaterial.depthTest = false;
                         this.defaultScreenSpaceImage9SlicedMaterial.update();
@@ -502,7 +502,7 @@ class ElementComponentSystem extends ComponentSystem {
                 } else if (nineSliceTiled) {
                     if (!this.defaultScreenSpaceImage9TiledMaterial) {
                         this.defaultScreenSpaceImage9TiledMaterial = this._createBaseImageMaterial();
-                        this.defaultScreenSpaceImage9TiledMaterial.name = "defaultScreenSpaceImage9TiledMaterial";
+                        this.defaultScreenSpaceImage9TiledMaterial.name = 'defaultScreenSpaceImage9TiledMaterial';
                         this.defaultScreenSpaceImage9TiledMaterial.nineSlicedMode = SPRITE_RENDERMODE_TILED;
                         this.defaultScreenSpaceImage9TiledMaterial.depthTest = false;
                         this.defaultScreenSpaceImage9TiledMaterial.update();
@@ -514,7 +514,7 @@ class ElementComponentSystem extends ComponentSystem {
                 } else {
                     if (!this.defaultScreenSpaceImageMaterial) {
                         this.defaultScreenSpaceImageMaterial = this._createBaseImageMaterial();
-                        this.defaultScreenSpaceImageMaterial.name = "defaultScreenSpaceImageMaterial";
+                        this.defaultScreenSpaceImageMaterial.name = 'defaultScreenSpaceImageMaterial';
                         this.defaultScreenSpaceImageMaterial.depthTest = false;
                         this.defaultScreenSpaceImageMaterial.update();
 
@@ -528,7 +528,7 @@ class ElementComponentSystem extends ComponentSystem {
                 if (nineSliced) {
                     if (!this.defaultImage9SlicedMaskMaterial) {
                         this.defaultImage9SlicedMaskMaterial = this._createBaseImageMaterial();
-                        this.defaultImage9SlicedMaskMaterial.name = "defaultImage9SlicedMaskMaterial";
+                        this.defaultImage9SlicedMaskMaterial.name = 'defaultImage9SlicedMaskMaterial';
                         this.defaultImage9SlicedMaskMaterial.nineSlicedMode = SPRITE_RENDERMODE_SLICED;
                         this.defaultImage9SlicedMaskMaterial.alphaTest = 1;
                         this.defaultImage9SlicedMaskMaterial.redWrite = false;
@@ -543,7 +543,7 @@ class ElementComponentSystem extends ComponentSystem {
                 } else if (nineSliceTiled) {
                     if (!this.defaultImage9TiledMaskMaterial) {
                         this.defaultImage9TiledMaskMaterial = this._createBaseImageMaterial();
-                        this.defaultImage9TiledMaskMaterial.name = "defaultImage9TiledMaskMaterial";
+                        this.defaultImage9TiledMaskMaterial.name = 'defaultImage9TiledMaskMaterial';
                         this.defaultImage9TiledMaskMaterial.nineSlicedMode = SPRITE_RENDERMODE_TILED;
                         this.defaultImage9TiledMaskMaterial.alphaTest = 1;
                         this.defaultImage9TiledMaskMaterial.redWrite = false;
@@ -558,7 +558,7 @@ class ElementComponentSystem extends ComponentSystem {
                 } else {
                     if (!this.defaultImageMaskMaterial) {
                         this.defaultImageMaskMaterial = this._createBaseImageMaterial();
-                        this.defaultImageMaskMaterial.name = "defaultImageMaskMaterial";
+                        this.defaultImageMaskMaterial.name = 'defaultImageMaskMaterial';
                         this.defaultImageMaskMaterial.alphaTest = 1;
                         this.defaultImageMaskMaterial.redWrite = false;
                         this.defaultImageMaskMaterial.greenWrite = false;
@@ -574,7 +574,7 @@ class ElementComponentSystem extends ComponentSystem {
                 if (nineSliced) {
                     if (!this.defaultImage9SlicedMaterial) {
                         this.defaultImage9SlicedMaterial = this._createBaseImageMaterial();
-                        this.defaultImage9SlicedMaterial.name = "defaultImage9SlicedMaterial";
+                        this.defaultImage9SlicedMaterial.name = 'defaultImage9SlicedMaterial';
                         this.defaultImage9SlicedMaterial.nineSlicedMode = SPRITE_RENDERMODE_SLICED;
                         this.defaultImage9SlicedMaterial.update();
 
@@ -584,7 +584,7 @@ class ElementComponentSystem extends ComponentSystem {
                 } else if (nineSliceTiled) {
                     if (!this.defaultImage9TiledMaterial) {
                         this.defaultImage9TiledMaterial = this._createBaseImageMaterial();
-                        this.defaultImage9TiledMaterial.name = "defaultImage9TiledMaterial";
+                        this.defaultImage9TiledMaterial.name = 'defaultImage9TiledMaterial';
                         this.defaultImage9TiledMaterial.nineSlicedMode = SPRITE_RENDERMODE_TILED;
                         this.defaultImage9TiledMaterial.update();
 
@@ -594,7 +594,7 @@ class ElementComponentSystem extends ComponentSystem {
                 } else {
                     if (!this.defaultImageMaterial) {
                         this.defaultImageMaterial = this._createBaseImageMaterial();
-                        this.defaultImageMaterial.name = "defaultImageMaterial";
+                        this.defaultImageMaterial.name = 'defaultImageMaterial';
                         this.defaultImageMaterial.update();
 
                         this.defaultImageMaterials.push(this.defaultImageMaterial);

--- a/src/framework/components/element/text-element.js
+++ b/src/framework/components/element/text-element.js
@@ -92,7 +92,7 @@ class TextElement {
         this._entity = element.entity;
 
         // public
-        this._text = "";            // the original user-defined text
+        this._text = '';            // the original user-defined text
         this._symbols = [];         // array of visible symbols with unicode processing and markup removed
         this._colorPalette = [];    // per-symbol color palette
         this._symbolColors = null;  // per-symbol color indexes. only set for text with markup.
@@ -302,7 +302,7 @@ class TextElement {
 
         // handle null string
         if (this._symbols.length === 0) {
-            this._symbols = [" "];
+            this._symbols = [' '];
         }
 
         // extract markup
@@ -366,7 +366,7 @@ class TextElement {
                     // }
 
                     // convert hex color
-                    if (c.length === 7 && c[0] === "#") {
+                    if (c.length === 7 && c[0] === '#') {
                         const hex = c.substring(1).toLowerCase();
 
                         if (paletteMap.hasOwnProperty(hex)) {
@@ -469,7 +469,7 @@ class TextElement {
                                         });
 
                 const mi = new MeshInstance(mesh, this._material, this._node);
-                mi.name = "Text Element: " + this._entity.name;
+                mi.name = 'Text Element: ' + this._entity.name;
                 mi.castShadow = false;
                 mi.receiveShadow = false;
                 mi.cull = !screenSpace;
@@ -492,28 +492,28 @@ class TextElement {
                     this._colorUniform[1] = this._color.g;
                     this._colorUniform[2] = this._color.b;
                 }
-                mi.setParameter("material_emissive", this._colorUniform);
-                mi.setParameter("material_opacity", this._color.a);
-                mi.setParameter("font_sdfIntensity", this._font.intensity);
-                mi.setParameter("font_pxrange", this._getPxRange(this._font));
-                mi.setParameter("font_textureWidth", this._font.data.info.maps[i].width);
+                mi.setParameter('material_emissive', this._colorUniform);
+                mi.setParameter('material_opacity', this._color.a);
+                mi.setParameter('font_sdfIntensity', this._font.intensity);
+                mi.setParameter('font_pxrange', this._getPxRange(this._font));
+                mi.setParameter('font_textureWidth', this._font.data.info.maps[i].width);
 
                 this._outlineColorUniform[0] = this._outlineColor.r;
                 this._outlineColorUniform[1] = this._outlineColor.g;
                 this._outlineColorUniform[2] = this._outlineColor.b;
                 this._outlineColorUniform[3] = this._outlineColor.a;
-                mi.setParameter("outline_color", this._outlineColorUniform);
-                mi.setParameter("outline_thickness", this._outlineThicknessScale * this._outlineThickness);
+                mi.setParameter('outline_color', this._outlineColorUniform);
+                mi.setParameter('outline_thickness', this._outlineThicknessScale * this._outlineThickness);
 
                 this._shadowColorUniform[0] = this._shadowColor.r;
                 this._shadowColorUniform[1] = this._shadowColor.g;
                 this._shadowColorUniform[2] = this._shadowColor.b;
                 this._shadowColorUniform[3] = this._shadowColor.a;
-                mi.setParameter("shadow_color", this._shadowColorUniform);
+                mi.setParameter('shadow_color', this._shadowColorUniform);
                 const ratio = -this._font.data.info.maps[i].width / this._font.data.info.maps[i].height;
                 this._shadowOffsetUniform[0] = this._shadowOffsetScale * this._shadowOffset.x;
                 this._shadowOffsetUniform[1] = ratio * this._shadowOffsetScale * this._shadowOffset.y;
-                mi.setParameter("shadow_offset", this._shadowOffsetUniform);
+                mi.setParameter('shadow_offset', this._shadowOffsetUniform);
 
                 meshInfo.meshInstance = mi;
 
@@ -1098,9 +1098,9 @@ class TextElement {
 
                 const mi = this._meshInfo[i].meshInstance;
                 if (mi) {
-                    mi.setParameter("font_sdfIntensity", this._font.intensity);
-                    mi.setParameter("font_pxrange", this._getPxRange(this._font));
-                    mi.setParameter("font_textureWidth", this._font.data.info.maps[i].width);
+                    mi.setParameter('font_sdfIntensity', this._font.intensity);
+                    mi.setParameter('font_pxrange', this._getPxRange(this._font));
+                    mi.setParameter('font_textureWidth', this._font.data.info.maps[i].width);
                 }
             }
         }
@@ -1113,13 +1113,13 @@ class TextElement {
     _setTextureParams(mi, texture) {
         if (this._font) {
             if (this._font.type === FONT_MSDF) {
-                mi.deleteParameter("texture_emissiveMap");
-                mi.deleteParameter("texture_opacityMap");
-                mi.setParameter("texture_msdfMap", texture);
+                mi.deleteParameter('texture_emissiveMap');
+                mi.deleteParameter('texture_opacityMap');
+                mi.setParameter('texture_msdfMap', texture);
             } else if (this._font.type === FONT_BITMAP) {
-                mi.deleteParameter("texture_msdfMap");
-                mi.setParameter("texture_emissiveMap", texture);
-                mi.setParameter("texture_opacityMap", texture);
+                mi.deleteParameter('texture_msdfMap');
+                mi.setParameter('texture_emissiveMap', texture);
+                mi.setParameter('texture_opacityMap', texture);
             }
         }
     }
@@ -1262,7 +1262,7 @@ class TextElement {
 
     set text(value) {
         this._i18nKey = null;
-        const str = value != null && value.toString() || "";
+        const str = value != null && value.toString() || '';
         this._setText(str);
     }
 
@@ -1296,7 +1296,7 @@ class TextElement {
 
         // #if _DEBUG
         if (this._color === value) {
-            console.warn("Setting element.color to itself will have no effect");
+            console.warn('Setting element.color to itself will have no effect');
         }
         // #endif
 
@@ -1471,9 +1471,9 @@ class TextElement {
                 // keep existing entry but set correct parameters to mesh instance
                 const mi = this._meshInfo[i].meshInstance;
                 if (mi) {
-                    mi.setParameter("font_sdfIntensity", this._font.intensity);
-                    mi.setParameter("font_pxrange", this._getPxRange(this._font));
-                    mi.setParameter("font_textureWidth", this._font.data.info.maps[i].width);
+                    mi.setParameter('font_sdfIntensity', this._font.intensity);
+                    mi.setParameter('font_pxrange', this._getPxRange(this._font));
+                    mi.setParameter('font_textureWidth', this._font.data.info.maps[i].width);
                     this._setTextureParams(mi, this._font.textures[i]);
                 }
             }
@@ -1622,7 +1622,7 @@ class TextElement {
 
         // #if _DEBUG
         if (this._outlineColor === value) {
-            console.warn("Setting element.outlineColor to itself will have no effect");
+            console.warn('Setting element.outlineColor to itself will have no effect');
         }
         // #endif
 
@@ -1646,7 +1646,7 @@ class TextElement {
 
             for (let i = 0, len = this._model.meshInstances.length; i < len; i++) {
                 const mi = this._model.meshInstances[i];
-                mi.setParameter("outline_color", this._outlineColorUniform);
+                mi.setParameter('outline_color', this._outlineColorUniform);
             }
         }
     }
@@ -1662,7 +1662,7 @@ class TextElement {
             if (this._model) {
                 for (let i = 0, len = this._model.meshInstances.length; i < len; i++) {
                     const mi = this._model.meshInstances[i];
-                    mi.setParameter("outline_thickness", this._outlineThicknessScale * this._outlineThickness);
+                    mi.setParameter('outline_thickness', this._outlineThicknessScale * this._outlineThickness);
                 }
             }
         }
@@ -1680,7 +1680,7 @@ class TextElement {
 
         // #if _DEBUG
         if (this._shadowColor === value) {
-            Debug.warn("Setting element.shadowColor to itself will have no effect");
+            Debug.warn('Setting element.shadowColor to itself will have no effect');
         }
         // #endif
 
@@ -1704,7 +1704,7 @@ class TextElement {
 
             for (let i = 0, len = this._model.meshInstances.length; i < len; i++) {
                 const mi = this._model.meshInstances[i];
-                mi.setParameter("shadow_color", this._shadowColorUniform);
+                mi.setParameter('shadow_color', this._shadowColorUniform);
             }
         }
     }
@@ -1727,7 +1727,7 @@ class TextElement {
                 this._shadowOffsetUniform[0] = this._shadowOffsetScale * this._shadowOffset.x;
                 this._shadowOffsetUniform[1] = ratio * this._shadowOffsetScale * this._shadowOffset.y;
                 const mi = this._model.meshInstances[i];
-                mi.setParameter("shadow_offset", this._shadowOffsetUniform);
+                mi.setParameter('shadow_offset', this._shadowOffsetUniform);
             }
         }
     }

--- a/src/framework/components/light/component.js
+++ b/src/framework/components/light/component.js
@@ -191,10 +191,10 @@ class LightComponent extends Component {
         if (this.enabled && this.entity.enabled) {
             this.addLightToLayers();
         }
-        oldComp.off("add", this.onLayerAdded, this);
-        oldComp.off("remove", this.onLayerRemoved, this);
-        newComp.on("add", this.onLayerAdded, this);
-        newComp.on("remove", this.onLayerRemoved, this);
+        oldComp.off('add', this.onLayerAdded, this);
+        oldComp.off('remove', this.onLayerRemoved, this);
+        newComp.on('add', this.onLayerAdded, this);
+        newComp.on('remove', this.onLayerRemoved, this);
     }
 
     onLayerAdded(layer) {
@@ -283,10 +283,10 @@ class LightComponent extends Component {
     onEnable() {
         this.light.enabled = true;
 
-        this.system.app.scene.on("set:layers", this.onLayersChanged, this);
+        this.system.app.scene.on('set:layers', this.onLayersChanged, this);
         if (this.system.app.scene.layers) {
-            this.system.app.scene.layers.on("add", this.onLayerAdded, this);
-            this.system.app.scene.layers.on("remove", this.onLayerRemoved, this);
+            this.system.app.scene.layers.on('add', this.onLayerAdded, this);
+            this.system.app.scene.layers.on('remove', this.onLayerRemoved, this);
         }
 
         if (this.enabled && this.entity.enabled) {
@@ -300,10 +300,10 @@ class LightComponent extends Component {
     onDisable() {
         this.light.enabled = false;
 
-        this.system.app.scene.off("set:layers", this.onLayersChanged, this);
+        this.system.app.scene.off('set:layers', this.onLayersChanged, this);
         if (this.system.app.scene.layers) {
-            this.system.app.scene.layers.off("add", this.onLayerAdded, this);
-            this.system.app.scene.layers.off("remove", this.onLayerRemoved, this);
+            this.system.app.scene.layers.off('add', this.onLayerAdded, this);
+            this.system.app.scene.layers.off('remove', this.onLayerRemoved, this);
         }
 
         this.removeLightFromLayers();
@@ -342,77 +342,77 @@ function _defineProperty(name, defaultValue, setFunc, skipEqualsCheck) {
 }
 
 function _defineProps() {
-    _defineProperty("enabled", true, function (newValue, oldValue) {
+    _defineProperty('enabled', true, function (newValue, oldValue) {
         this.onSetEnabled(null, oldValue, newValue);
     });
-    _defineProperty("light", null);
-    _defineProperty("type", 'directional', function (newValue, oldValue) {
+    _defineProperty('light', null);
+    _defineProperty('type', 'directional', function (newValue, oldValue) {
         this.system.changeType(this, oldValue, newValue);
         // refresh light properties because changing the type does not reset the
         // light properties
         this.refreshProperties();
     });
-    _defineProperty("color", new Color(1, 1, 1), function (newValue, oldValue) {
+    _defineProperty('color', new Color(1, 1, 1), function (newValue, oldValue) {
         this.light.setColor(newValue);
     }, true);
-    _defineProperty("intensity", 1, function (newValue, oldValue) {
+    _defineProperty('intensity', 1, function (newValue, oldValue) {
         this.light.intensity = newValue;
     });
-    _defineProperty("shape", LIGHTSHAPE_PUNCTUAL, function (newValue, oldValue) {
+    _defineProperty('shape', LIGHTSHAPE_PUNCTUAL, function (newValue, oldValue) {
         this.light.shape = newValue;
     });
-    _defineProperty("castShadows", false, function (newValue, oldValue) {
+    _defineProperty('castShadows', false, function (newValue, oldValue) {
         this.light.castShadows = newValue;
     });
-    _defineProperty("shadowDistance", 40, function (newValue, oldValue) {
+    _defineProperty('shadowDistance', 40, function (newValue, oldValue) {
         this.light.shadowDistance = newValue;
     });
-    _defineProperty("shadowResolution", 1024, function (newValue, oldValue) {
+    _defineProperty('shadowResolution', 1024, function (newValue, oldValue) {
         this.light.shadowResolution = newValue;
     });
-    _defineProperty("shadowBias", 0.05, function (newValue, oldValue) {
+    _defineProperty('shadowBias', 0.05, function (newValue, oldValue) {
         this.light.shadowBias = -0.01 * math.clamp(newValue, 0, 1);
     });
-    _defineProperty("numCascades", 1, function (newValue, oldValue) {
+    _defineProperty('numCascades', 1, function (newValue, oldValue) {
         this.light.numCascades = math.clamp(Math.floor(newValue), 1, 4);
     });
-    _defineProperty("bakeNumSamples", 1, function (newValue, oldValue) {
+    _defineProperty('bakeNumSamples', 1, function (newValue, oldValue) {
         this.light.bakeNumSamples = math.clamp(Math.floor(newValue), 1, 255);
     });
-    _defineProperty("bakeArea", 0, function (newValue, oldValue) {
+    _defineProperty('bakeArea', 0, function (newValue, oldValue) {
         this.light.bakeArea = math.clamp(newValue, 0, 180);
     });
-    _defineProperty("cascadeDistribution", 0.5, function (newValue, oldValue) {
+    _defineProperty('cascadeDistribution', 0.5, function (newValue, oldValue) {
         this.light.cascadeDistribution = math.clamp(newValue, 0, 1);
     });
-    _defineProperty("normalOffsetBias", 0, function (newValue, oldValue) {
+    _defineProperty('normalOffsetBias', 0, function (newValue, oldValue) {
         this.light.normalOffsetBias = math.clamp(newValue, 0, 1);
     });
-    _defineProperty("range", 10, function (newValue, oldValue) {
+    _defineProperty('range', 10, function (newValue, oldValue) {
         this.light.attenuationEnd = newValue;
     });
-    _defineProperty("innerConeAngle", 40, function (newValue, oldValue) {
+    _defineProperty('innerConeAngle', 40, function (newValue, oldValue) {
         this.light.innerConeAngle = newValue;
     });
-    _defineProperty("outerConeAngle", 45, function (newValue, oldValue) {
+    _defineProperty('outerConeAngle', 45, function (newValue, oldValue) {
         this.light.outerConeAngle = newValue;
     });
-    _defineProperty("falloffMode", LIGHTFALLOFF_LINEAR, function (newValue, oldValue) {
+    _defineProperty('falloffMode', LIGHTFALLOFF_LINEAR, function (newValue, oldValue) {
         this.light.falloffMode = newValue;
     });
-    _defineProperty("shadowType", SHADOW_PCF3, function (newValue, oldValue) {
+    _defineProperty('shadowType', SHADOW_PCF3, function (newValue, oldValue) {
         this.light.shadowType = newValue;
     });
-    _defineProperty("vsmBlurSize", 11, function (newValue, oldValue) {
+    _defineProperty('vsmBlurSize', 11, function (newValue, oldValue) {
         this.light.vsmBlurSize = newValue;
     });
-    _defineProperty("vsmBlurMode", BLUR_GAUSSIAN, function (newValue, oldValue) {
+    _defineProperty('vsmBlurMode', BLUR_GAUSSIAN, function (newValue, oldValue) {
         this.light.vsmBlurMode = newValue;
     });
-    _defineProperty("vsmBias", 0.01 * 0.25, function (newValue, oldValue) {
+    _defineProperty('vsmBias', 0.01 * 0.25, function (newValue, oldValue) {
         this.light.vsmBias = math.clamp(newValue, 0, 1);
     });
-    _defineProperty("cookieAsset", null, function (newValue, oldValue) {
+    _defineProperty('cookieAsset', null, function (newValue, oldValue) {
         if (this._cookieAssetId && ((newValue instanceof Asset && newValue.id === this._cookieAssetId) || newValue === this._cookieAssetId))
             return;
 
@@ -434,19 +434,19 @@ function _defineProps() {
             }
         }
     });
-    _defineProperty("cookie", null, function (newValue, oldValue) {
+    _defineProperty('cookie', null, function (newValue, oldValue) {
         this.light.cookie = newValue;
     });
-    _defineProperty("cookieIntensity", 1, function (newValue, oldValue) {
+    _defineProperty('cookieIntensity', 1, function (newValue, oldValue) {
         this.light.cookieIntensity = math.clamp(newValue, 0, 1);
     });
-    _defineProperty("cookieFalloff", true, function (newValue, oldValue) {
+    _defineProperty('cookieFalloff', true, function (newValue, oldValue) {
         this.light.cookieFalloff = newValue;
     });
-    _defineProperty("cookieChannel", "rgb", function (newValue, oldValue) {
+    _defineProperty('cookieChannel', 'rgb', function (newValue, oldValue) {
         this.light.cookieChannel = newValue;
     });
-    _defineProperty("cookieAngle", 0, function (newValue, oldValue) {
+    _defineProperty('cookieAngle', 0, function (newValue, oldValue) {
         if (newValue !== 0 || this.cookieScale !== null) {
             if (!this._cookieMatrix) this._cookieMatrix = new Vec4();
             let scx = 1;
@@ -463,7 +463,7 @@ function _defineProps() {
             this.light.cookieTransform = null;
         }
     });
-    _defineProperty("cookieScale", null, function (newValue, oldValue) {
+    _defineProperty('cookieScale', null, function (newValue, oldValue) {
         if (newValue !== null || this.cookieAngle !== 0) {
             if (!this._cookieMatrix) this._cookieMatrix = new Vec4();
             const scx = newValue.x;
@@ -476,16 +476,16 @@ function _defineProps() {
             this.light.cookieTransform = null;
         }
     }, true);
-    _defineProperty("cookieOffset", null, function (newValue, oldValue) {
+    _defineProperty('cookieOffset', null, function (newValue, oldValue) {
         this.light.cookieOffset = newValue;
     }, true);
-    _defineProperty("shadowUpdateMode", SHADOWUPDATE_REALTIME, function (newValue, oldValue) {
+    _defineProperty('shadowUpdateMode', SHADOWUPDATE_REALTIME, function (newValue, oldValue) {
         this.light.shadowUpdateMode = newValue;
     }, true);
-    _defineProperty("mask", 1, function (newValue, oldValue) {
+    _defineProperty('mask', 1, function (newValue, oldValue) {
         this.light.mask = newValue;
     });
-    _defineProperty("affectDynamic", true, function (newValue, oldValue) {
+    _defineProperty('affectDynamic', true, function (newValue, oldValue) {
         if (newValue) {
             this.light.mask |= MASK_AFFECT_DYNAMIC;
         } else {
@@ -493,7 +493,7 @@ function _defineProps() {
         }
         this.light.layersDirty();
     });
-    _defineProperty("affectLightmapped", false, function (newValue, oldValue) {
+    _defineProperty('affectLightmapped', false, function (newValue, oldValue) {
         if (newValue) {
             this.light.mask |= MASK_AFFECT_LIGHTMAPPED;
             if (this.bake) this.light.mask &= ~MASK_BAKE;
@@ -502,7 +502,7 @@ function _defineProps() {
             if (this.bake) this.light.mask |= MASK_BAKE;
         }
     });
-    _defineProperty("bake", false, function (newValue, oldValue) {
+    _defineProperty('bake', false, function (newValue, oldValue) {
         if (newValue) {
             this.light.mask |= MASK_BAKE;
             if (this.affectLightmapped) this.light.mask &= ~MASK_AFFECT_LIGHTMAPPED;
@@ -512,13 +512,13 @@ function _defineProps() {
         }
         this.light.layersDirty();
     });
-    _defineProperty("bakeDir", true, function (newValue, oldValue) {
+    _defineProperty('bakeDir', true, function (newValue, oldValue) {
         this.light.bakeDir = newValue;
     });
-    _defineProperty("isStatic", false, function (newValue, oldValue) {
+    _defineProperty('isStatic', false, function (newValue, oldValue) {
         this.light.isStatic = newValue;
     });
-    _defineProperty("layers", [LAYERID_WORLD], function (newValue, oldValue) {
+    _defineProperty('layers', [LAYERID_WORLD], function (newValue, oldValue) {
         for (let i = 0; i < oldValue.length; i++) {
             const layer = this.system.app.scene.layers.getLayerById(oldValue[i]);
             if (!layer) continue;

--- a/src/framework/components/light/system.js
+++ b/src/framework/components/light/system.js
@@ -69,7 +69,7 @@ class LightComponentSystem extends ComponentSystem {
             data.cookieScale = new Vec2(data.cookieScale[0], data.cookieScale[1]);
 
         if (data.enable) {
-            console.warn("WARNING: enable: Property is deprecated. Set enabled property instead.");
+            console.warn('WARNING: enable: Property is deprecated. Set enabled property instead.');
             data.enabled = data.enable;
         }
 
@@ -98,7 +98,7 @@ class LightComponentSystem extends ComponentSystem {
         const _props = _lightProps;
         for (let i = 0; i < _props.length; i++) {
             name = _props[i];
-            if (name === "light") continue;
+            if (name === 'light') continue;
             if (light[name] && light[name].clone) {
                 data[name] = light[name].clone();
             } else {

--- a/src/framework/components/model/component.js
+++ b/src/framework/components/model/component.js
@@ -732,10 +732,10 @@ class ModelComponent extends Component {
      */
     onLayersChanged(oldComp, newComp) {
         this.addModelToLayers();
-        oldComp.off("add", this.onLayerAdded, this);
-        oldComp.off("remove", this.onLayerRemoved, this);
-        newComp.on("add", this.onLayerAdded, this);
-        newComp.on("remove", this.onLayerRemoved, this);
+        oldComp.off('add', this.onLayerAdded, this);
+        oldComp.off('remove', this.onLayerRemoved, this);
+        newComp.on('add', this.onLayerAdded, this);
+        newComp.on('remove', this.onLayerRemoved, this);
     }
 
     /**
@@ -869,10 +869,10 @@ class ModelComponent extends Component {
         const app = this.system.app;
         const scene = app.scene;
 
-        scene.on("set:layers", this.onLayersChanged, this);
+        scene.on('set:layers', this.onLayersChanged, this);
         if (scene.layers) {
-            scene.layers.on("add", this.onLayerAdded, this);
-            scene.layers.on("remove", this.onLayerRemoved, this);
+            scene.layers.on('add', this.onLayerAdded, this);
+            scene.layers.on('remove', this.onLayerRemoved, this);
         }
 
         const isAsset = (this._type === 'asset');
@@ -920,10 +920,10 @@ class ModelComponent extends Component {
         const app = this.system.app;
         const scene = app.scene;
 
-        scene.off("set:layers", this.onLayersChanged, this);
+        scene.off('set:layers', this.onLayersChanged, this);
         if (scene.layers) {
-            scene.layers.off("add", this.onLayerAdded, this);
-            scene.layers.off("remove", this.onLayerRemoved, this);
+            scene.layers.off('add', this.onLayerAdded, this);
+            scene.layers.off('remove', this.onLayerRemoved, this);
         }
 
         if (this._batchGroupId >= 0) {

--- a/src/framework/components/particle-system/component.js
+++ b/src/framework/components/particle-system/component.js
@@ -273,15 +273,15 @@ class ParticleSystemComponent extends Component {
     constructor(system, entity) {
         super(system, entity);
 
-        this.on("set_colorMapAsset", this.onSetColorMapAsset, this);
-        this.on("set_normalMapAsset", this.onSetNormalMapAsset, this);
-        this.on("set_meshAsset", this.onSetMeshAsset, this);
-        this.on("set_mesh", this.onSetMesh, this);
-        this.on("set_renderAsset", this.onSetRenderAsset, this);
-        this.on("set_loop", this.onSetLoop, this);
-        this.on("set_blendType", this.onSetBlendType, this);
-        this.on("set_depthSoftening", this.onSetDepthSoftening, this);
-        this.on("set_layers", this.onSetLayers, this);
+        this.on('set_colorMapAsset', this.onSetColorMapAsset, this);
+        this.on('set_normalMapAsset', this.onSetNormalMapAsset, this);
+        this.on('set_meshAsset', this.onSetMeshAsset, this);
+        this.on('set_mesh', this.onSetMesh, this);
+        this.on('set_renderAsset', this.onSetRenderAsset, this);
+        this.on('set_loop', this.onSetLoop, this);
+        this.on('set_blendType', this.onSetBlendType, this);
+        this.on('set_depthSoftening', this.onSetDepthSoftening, this);
+        this.on('set_layers', this.onSetLayers, this);
 
         SIMPLE_PROPERTIES.forEach((prop) => {
             this.on(`set_${prop}`, this.onSetSimpleProperty, this);
@@ -343,10 +343,10 @@ class ParticleSystemComponent extends Component {
 
     onLayersChanged(oldComp, newComp) {
         this.addMeshInstanceToLayers();
-        oldComp.off("add", this.onLayerAdded, this);
-        oldComp.off("remove", this.onLayerRemoved, this);
-        newComp.on("add", this.onLayerAdded, this);
-        newComp.on("remove", this.onLayerRemoved, this);
+        oldComp.off('add', this.onLayerAdded, this);
+        oldComp.off('remove', this.onLayerRemoved, this);
+        newComp.on('add', this.onLayerAdded, this);
+        newComp.on('remove', this.onLayerRemoved, this);
     }
 
     onLayerAdded(layer) {
@@ -419,7 +419,7 @@ class ParticleSystemComponent extends Component {
             if (asset) {
                 this._bindColorMapAsset(asset);
             } else {
-                assets.once("add:" + newValue, (asset) => {
+                assets.once('add:' + newValue, (asset) => {
                     this._bindColorMapAsset(asset);
                 });
             }
@@ -485,7 +485,7 @@ class ParticleSystemComponent extends Component {
             if (asset) {
                 this._bindNormalMapAsset(asset);
             } else {
-                assets.once("add:" + newValue, (asset) => {
+                assets.once('add:' + newValue, (asset) => {
                     this._bindNormalMapAsset(asset);
                 });
             }
@@ -855,10 +855,10 @@ class ParticleSystemComponent extends Component {
             this.addMeshInstanceToLayers();
         }
 
-        this.system.app.scene.on("set:layers", this.onLayersChanged, this);
+        this.system.app.scene.on('set:layers', this.onLayersChanged, this);
         if (this.system.app.scene.layers) {
-            this.system.app.scene.layers.on("add", this.onLayerAdded, this);
-            this.system.app.scene.layers.on("remove", this.onLayerRemoved, this);
+            this.system.app.scene.layers.on('add', this.onLayerAdded, this);
+            this.system.app.scene.layers.on('remove', this.onLayerRemoved, this);
         }
 
         if (this.enabled && this.entity.enabled && data.depthSoftening) {
@@ -867,10 +867,10 @@ class ParticleSystemComponent extends Component {
     }
 
     onDisable() {
-        this.system.app.scene.off("set:layers", this.onLayersChanged, this);
+        this.system.app.scene.off('set:layers', this.onLayersChanged, this);
         if (this.system.app.scene.layers) {
-            this.system.app.scene.layers.off("add", this.onLayerAdded, this);
-            this.system.app.scene.layers.off("remove", this.onLayerRemoved, this);
+            this.system.app.scene.layers.off('add', this.onLayerAdded, this);
+            this.system.app.scene.layers.off('remove', this.onLayerRemoved, this);
         }
 
         if (this.emitter) {

--- a/src/framework/components/particle-system/system.js
+++ b/src/framework/components/particle-system/system.js
@@ -189,7 +189,7 @@ class ParticleSystemComponentSystem extends ComponentSystem {
 
                 sourceProp = sourceProp.clone();
                 data[prop] = sourceProp;
-            } else if (prop === "layers") {
+            } else if (prop === 'layers') {
                 data.layers = source.layers.slice(0);
             } else {
                 if (sourceProp !== null && sourceProp !== undefined) {

--- a/src/framework/components/render/component.js
+++ b/src/framework/components/render/component.js
@@ -678,10 +678,10 @@ class RenderComponent extends Component {
 
     onLayersChanged(oldComp, newComp) {
         this.addToLayers();
-        oldComp.off("add", this.onLayerAdded, this);
-        oldComp.off("remove", this.onLayerRemoved, this);
-        newComp.on("add", this.onLayerAdded, this);
-        newComp.on("remove", this.onLayerRemoved, this);
+        oldComp.off('add', this.onLayerAdded, this);
+        oldComp.off('remove', this.onLayerRemoved, this);
+        newComp.on('add', this.onLayerAdded, this);
+        newComp.on('remove', this.onLayerRemoved, this);
     }
 
     onLayerAdded(layer) {
@@ -704,10 +704,10 @@ class RenderComponent extends Component {
 
         this._cloneSkinInstances();
 
-        scene.on("set:layers", this.onLayersChanged, this);
+        scene.on('set:layers', this.onLayersChanged, this);
         if (scene.layers) {
-            scene.layers.on("add", this.onLayerAdded, this);
-            scene.layers.on("remove", this.onLayerRemoved, this);
+            scene.layers.on('add', this.onLayerAdded, this);
+            scene.layers.on('remove', this.onLayerRemoved, this);
         }
 
         const isAsset = (this._type === 'asset');
@@ -733,10 +733,10 @@ class RenderComponent extends Component {
         const app = this.system.app;
         const scene = app.scene;
 
-        scene.off("set:layers", this.onLayersChanged, this);
+        scene.off('set:layers', this.onLayersChanged, this);
         if (scene.layers) {
-            scene.layers.off("add", this.onLayerAdded, this);
-            scene.layers.off("remove", this.onLayerRemoved, this);
+            scene.layers.off('add', this.onLayerAdded, this);
+            scene.layers.off('remove', this.onLayerRemoved, this);
         }
 
         if (this._batchGroupId >= 0) {

--- a/src/framework/components/rigid-body/system.js
+++ b/src/framework/components/rigid-body/system.js
@@ -332,7 +332,7 @@ class RigidBodyComponentSystem extends ComponentSystem {
                 const checkForCollisionsPointer = Ammo.addFunction(this._checkForCollisions.bind(this), 'vif');
                 this.dynamicsWorld.setInternalTickCallback(checkForCollisionsPointer);
             } else {
-                Debug.warn("WARNING: This version of ammo.js can potentially fail to report contacts. Please update it to the latest version.");
+                Debug.warn('WARNING: This version of ammo.js can potentially fail to report contacts. Please update it to the latest version.');
             }
 
             // Lazily create temp vars
@@ -508,7 +508,7 @@ class RigidBodyComponentSystem extends ComponentSystem {
      * @returns {RaycastResult[]} An array of raycast hit results (0 length if there were no hits).
      */
     raycastAll(start, end) {
-        Debug.assert(Ammo.AllHitsRayResultCallback, "pc.RigidBodyComponentSystem#raycastAll: Your version of ammo.js does not expose Ammo.AllHitsRayResultCallback. Update it to latest.");
+        Debug.assert(Ammo.AllHitsRayResultCallback, 'pc.RigidBodyComponentSystem#raycastAll: Your version of ammo.js does not expose Ammo.AllHitsRayResultCallback. Update it to latest.');
 
         const results = [];
 
@@ -652,7 +652,7 @@ class RigidBodyComponentSystem extends ComponentSystem {
                         if (entity.trigger) {
                             // handle a trigger entity
                             if (entityCollision) {
-                                entityCollision.fire("triggerleave", other);
+                                entityCollision.fire('triggerleave', other);
                             }
                             if (other.rigidbody) {
                                 other.rigidbody.fire('triggerleave', entity);
@@ -660,10 +660,10 @@ class RigidBodyComponentSystem extends ComponentSystem {
                         } else if (!other.trigger) {
                             // suppress events if the other entity is a trigger
                             if (entityRigidbody) {
-                                entityRigidbody.fire("collisionend", other);
+                                entityRigidbody.fire('collisionend', other);
                             }
                             if (entityCollision) {
-                                entityCollision.fire("collisionend", other);
+                                entityCollision.fire('collisionend', other);
                             }
                         }
                     }
@@ -685,12 +685,12 @@ class RigidBodyComponentSystem extends ComponentSystem {
      */
     _hasContactEvent(entity) {
         const c = entity.collision;
-        if (c && (c.hasEvent("collisionstart") || c.hasEvent("collisionend") || c.hasEvent("contact"))) {
+        if (c && (c.hasEvent('collisionstart') || c.hasEvent('collisionend') || c.hasEvent('contact'))) {
             return true;
         }
 
         const r = entity.rigidbody;
-        return r && (r.hasEvent("collisionstart") || r.hasEvent("collisionend") || r.hasEvent("contact"));
+        return r && (r.hasEvent('collisionstart') || r.hasEvent('collisionend') || r.hasEvent('contact'));
     }
 
     /**
@@ -740,23 +740,23 @@ class RigidBodyComponentSystem extends ComponentSystem {
                 if ((flags0 & BODYFLAG_NORESPONSE_OBJECT) ||
                     (flags1 & BODYFLAG_NORESPONSE_OBJECT)) {
 
-                    const e0Events = e0.collision && (e0.collision.hasEvent("triggerenter") || e0.collision.hasEvent("triggerleave"));
-                    const e1Events = e1.collision && (e1.collision.hasEvent("triggerenter") || e1.collision.hasEvent("triggerleave"));
-                    const e0BodyEvents = e0.rigidbody && (e0.rigidbody.hasEvent("triggerenter") || e0.rigidbody.hasEvent("triggerleave"));
-                    const e1BodyEvents = e1.rigidbody && (e1.rigidbody.hasEvent("triggerenter") || e1.rigidbody.hasEvent("triggerleave"));
+                    const e0Events = e0.collision && (e0.collision.hasEvent('triggerenter') || e0.collision.hasEvent('triggerleave'));
+                    const e1Events = e1.collision && (e1.collision.hasEvent('triggerenter') || e1.collision.hasEvent('triggerleave'));
+                    const e0BodyEvents = e0.rigidbody && (e0.rigidbody.hasEvent('triggerenter') || e0.rigidbody.hasEvent('triggerleave'));
+                    const e1BodyEvents = e1.rigidbody && (e1.rigidbody.hasEvent('triggerenter') || e1.rigidbody.hasEvent('triggerleave'));
 
                     // fire triggerenter events for triggers
                     if (e0Events) {
                         newCollision = this._storeCollision(e0, e1);
                         if (newCollision && !(flags1 & BODYFLAG_NORESPONSE_OBJECT)) {
-                            e0.collision.fire("triggerenter", e1);
+                            e0.collision.fire('triggerenter', e1);
                         }
                     }
 
                     if (e1Events) {
                         newCollision = this._storeCollision(e1, e0);
                         if (newCollision && !(flags0 & BODYFLAG_NORESPONSE_OBJECT)) {
-                            e1.collision.fire("triggerenter", e0);
+                            e1.collision.fire('triggerenter', e0);
                         }
                     }
 
@@ -767,7 +767,7 @@ class RigidBodyComponentSystem extends ComponentSystem {
                         }
 
                         if (newCollision) {
-                            e0.rigidbody.fire("triggerenter", e1);
+                            e0.rigidbody.fire('triggerenter', e1);
                         }
                     }
 
@@ -777,13 +777,13 @@ class RigidBodyComponentSystem extends ComponentSystem {
                         }
 
                         if (newCollision) {
-                            e1.rigidbody.fire("triggerenter", e0);
+                            e1.rigidbody.fire('triggerenter', e0);
                         }
                     }
                 } else {
                     const e0Events = this._hasContactEvent(e0);
                     const e1Events = this._hasContactEvent(e1);
-                    const globalEvents = this.hasEvent("contact");
+                    const globalEvents = this.hasEvent('contact');
 
                     if (globalEvents || e0Events || e1Events) {
                         for (let j = 0; j < numContacts; j++) {
@@ -799,7 +799,7 @@ class RigidBodyComponentSystem extends ComponentSystem {
                             if (globalEvents) {
                                 // fire global contact event for every contact
                                 const result = this._createSingleContactResult(e0, e1, contactPoint);
-                                this.fire("contact", result);
+                                this.fire('contact', result);
                             }
                         }
 
@@ -808,16 +808,16 @@ class RigidBodyComponentSystem extends ComponentSystem {
                             newCollision = this._storeCollision(e0, e1);
 
                             if (e0.collision) {
-                                e0.collision.fire("contact", forwardResult);
+                                e0.collision.fire('contact', forwardResult);
                                 if (newCollision) {
-                                    e0.collision.fire("collisionstart", forwardResult);
+                                    e0.collision.fire('collisionstart', forwardResult);
                                 }
                             }
 
                             if (e0.rigidbody) {
-                                e0.rigidbody.fire("contact", forwardResult);
+                                e0.rigidbody.fire('contact', forwardResult);
                                 if (newCollision) {
-                                    e0.rigidbody.fire("collisionstart", forwardResult);
+                                    e0.rigidbody.fire('collisionstart', forwardResult);
                                 }
                             }
                         }
@@ -827,16 +827,16 @@ class RigidBodyComponentSystem extends ComponentSystem {
                             newCollision = this._storeCollision(e1, e0);
 
                             if (e1.collision) {
-                                e1.collision.fire("contact", reverseResult);
+                                e1.collision.fire('contact', reverseResult);
                                 if (newCollision) {
-                                    e1.collision.fire("collisionstart", reverseResult);
+                                    e1.collision.fire('collisionstart', reverseResult);
                                 }
                             }
 
                             if (e1.rigidbody) {
-                                e1.rigidbody.fire("contact", reverseResult);
+                                e1.rigidbody.fire('contact', reverseResult);
                                 if (newCollision) {
-                                    e1.rigidbody.fire("collisionstart", reverseResult);
+                                    e1.rigidbody.fire('collisionstart', reverseResult);
                                 }
                             }
                         }

--- a/src/framework/components/screen/component.js
+++ b/src/framework/components/screen/component.js
@@ -49,7 +49,7 @@ class ScreenComponent extends Component {
 
         this._elements = new Set();
 
-        system.app.graphicsDevice.on("resizecanvas", this._onResize, this);
+        system.app.graphicsDevice.on('resizecanvas', this._onResize, this);
     }
 
     /**
@@ -145,7 +145,7 @@ class ScreenComponent extends Component {
     }
 
     onRemove() {
-        this.system.app.graphicsDevice.off("resizecanvas", this._onResize, this);
+        this.system.app.graphicsDevice.off('resizecanvas', this._onResize, this);
         this.fire('remove');
 
         this._elements.forEach(element => element._onScreenRemove());
@@ -177,7 +177,7 @@ class ScreenComponent extends Component {
         if (!this.entity._dirtyLocal)
             this.entity._dirtifyLocal();
 
-        this.fire("set:resolution", this._resolution);
+        this.fire('set:resolution', this._resolution);
         this._elements.forEach(element => element._onScreenResize(this._resolution));
     }
 
@@ -200,7 +200,7 @@ class ScreenComponent extends Component {
         if (!this.entity._dirtyLocal)
             this.entity._dirtifyLocal();
 
-        this.fire("set:referenceresolution", this._resolution);
+        this.fire('set:referenceresolution', this._resolution);
         this._elements.forEach(element => element._onScreenResize(this._resolution));
     }
 
@@ -254,7 +254,7 @@ class ScreenComponent extends Component {
 
         this._scaleMode = value;
         this.resolution = this._resolution; // force update
-        this.fire("set:scalemode", this._scaleMode);
+        this.fire('set:scalemode', this._scaleMode);
     }
 
     get scaleMode() {
@@ -276,7 +276,7 @@ class ScreenComponent extends Component {
         if (!this.entity._dirtyLocal)
             this.entity._dirtifyLocal();
 
-        this.fire("set:scaleblend", this._scaleBlend);
+        this.fire('set:scaleblend', this._scaleBlend);
 
         this._elements.forEach(element => element._onScreenResize(this._resolution));
     }

--- a/src/framework/components/screen/constants.js
+++ b/src/framework/components/screen/constants.js
@@ -3,7 +3,7 @@
  *
  * @type {string}
  */
-export const SCALEMODE_NONE = "none";
+export const SCALEMODE_NONE = 'none';
 
 /**
  * Scale the {@link ScreenComponent} when the application's resolution is different than the
@@ -11,4 +11,4 @@ export const SCALEMODE_NONE = "none";
  *
  * @type {string}
  */
-export const SCALEMODE_BLEND = "blend";
+export const SCALEMODE_BLEND = 'blend';

--- a/src/framework/components/screen/system.js
+++ b/src/framework/components/screen/system.js
@@ -38,7 +38,7 @@ class ScreenComponentSystem extends ComponentSystem {
         // queue of callbacks
         this._drawOrderSyncQueue = new IndexedList();
 
-        this.app.graphicsDevice.on("resizecanvas", this._onResize, this);
+        this.app.graphicsDevice.on('resizecanvas', this._onResize, this);
 
         this.app.systems.on('update', this._onUpdate, this);
 
@@ -76,7 +76,7 @@ class ScreenComponentSystem extends ComponentSystem {
     destroy() {
         super.destroy();
 
-        this.app.graphicsDevice.off("resizecanvas", this._onResize, this);
+        this.app.graphicsDevice.off('resizecanvas', this._onResize, this);
         this.app.systems.off('update', this._onUpdate, this);
     }
 

--- a/src/framework/components/script-legacy/component.js
+++ b/src/framework/components/script-legacy/component.js
@@ -6,11 +6,11 @@ import { Component } from '../component.js';
 class ScriptLegacyComponent extends Component {
     constructor(system, entity) {
         super(system, entity);
-        this.on("set_scripts", this.onSetScripts, this);
+        this.on('set_scripts', this.onSetScripts, this);
     }
 
     send(name, functionName) {
-        Debug.deprecated("ScriptLegacyComponent.send() is deprecated and will be removed soon. Please use: http://developer.playcanvas.com/user-manual/scripting/communication/");
+        Debug.deprecated('ScriptLegacyComponent.send() is deprecated and will be removed soon. Please use: http://developer.playcanvas.com/user-manual/scripting/communication/');
 
         const args = Array.prototype.slice.call(arguments, 2);
         const instances = this.entity.script.instances;
@@ -109,7 +109,7 @@ class ScriptLegacyComponent extends Component {
     _loadFromCache(urls) {
         const cached = [];
 
-        const prefix = this.system.app._scriptPrefix || "";
+        const prefix = this.system.app._scriptPrefix || '';
         const regex = /^http(s)?:\/\//i;
 
         for (let i = 0, len = urls.length; i < len; i++) {
@@ -166,20 +166,20 @@ class ScriptLegacyComponent extends Component {
     _loadScripts(urls) {
         let count = urls.length;
 
-        const prefix = this.system.app._scriptPrefix || "";
+        const prefix = this.system.app._scriptPrefix || '';
 
         urls.forEach((url) => {
             let _url = null;
             let _unprefixed = null;
             // support absolute URLs (for now)
-            if (url.toLowerCase().startsWith("http://") || url.toLowerCase().startsWith("https://")) {
+            if (url.toLowerCase().startsWith('http://') || url.toLowerCase().startsWith('https://')) {
                 _unprefixed = url;
                 _url = url;
             } else {
                 _unprefixed = url;
                 _url = path.join(prefix, url);
             }
-            this.system.app.loader.load(_url, "script", (err, ScriptType) => {
+            this.system.app.loader.load(_url, 'script', (err, ScriptType) => {
                 count--;
                 if (!err) {
                     // ScriptType is null if the script is not a PlayCanvas script

--- a/src/framework/components/script-legacy/system.js
+++ b/src/framework/components/script-legacy/system.js
@@ -24,12 +24,12 @@ const _schema = [
     'runInTools'
 ];
 
-const INITIALIZE = "initialize";
-const POST_INITIALIZE = "postInitialize";
-const UPDATE = "update";
-const POST_UPDATE = "postUpdate";
-const FIXED_UPDATE = "fixedUpdate";
-const TOOLS_UPDATE = "toolsUpdate";
+const INITIALIZE = 'initialize';
+const POST_INITIALIZE = 'postInitialize';
+const UPDATE = 'update';
+const POST_UPDATE = 'postUpdate';
+const FIXED_UPDATE = 'fixedUpdate';
+const TOOLS_UPDATE = 'toolsUpdate';
 const ON_ENABLE = 'onEnable';
 const ON_DISABLE = 'onDisable';
 
@@ -261,7 +261,7 @@ class ScriptLegacyComponentSystem extends ComponentSystem {
     }
 
     broadcast(name, functionName) {
-        Debug.deprecated("ScriptLegacyComponentSystem.broadcast() is deprecated and will be removed soon. Please use: http://developer.playcanvas.com/user-manual/scripting/communication/");
+        Debug.deprecated('ScriptLegacyComponentSystem.broadcast() is deprecated and will be removed soon. Please use: http://developer.playcanvas.com/user-manual/scripting/communication/');
 
         const args = Array.prototype.slice.call(arguments, 2);
 
@@ -414,7 +414,7 @@ class ScriptLegacyComponentSystem extends ComponentSystem {
                 const oldValue = attribute.value;
                 attribute.value = value;
                 self._convertAttributeValue(attribute);
-                instance.instance.fire("set", attribute.name, oldValue, attribute.value);
+                instance.instance.fire('set', attribute.name, oldValue, attribute.value);
             },
             configurable: true
         });

--- a/src/framework/components/sound/system.js
+++ b/src/framework/components/sound/system.js
@@ -28,7 +28,7 @@ class SoundComponentSystem extends ComponentSystem {
     constructor(app, manager) {
         super(app);
 
-        this.id = "sound";
+        this.id = 'sound';
 
         this.ComponentType = SoundComponent;
         this.DataType = SoundComponentData;

--- a/src/framework/components/sprite/component.js
+++ b/src/framework/components/sprite/component.js
@@ -507,10 +507,10 @@ class SpriteComponent extends Component {
         const app = this.system.app;
         const scene = app.scene;
 
-        scene.on("set:layers", this._onLayersChanged, this);
+        scene.on('set:layers', this._onLayersChanged, this);
         if (scene.layers) {
-            scene.layers.on("add", this._onLayerAdded, this);
-            scene.layers.on("remove", this._onLayerRemoved, this);
+            scene.layers.on('add', this._onLayerAdded, this);
+            scene.layers.on('remove', this._onLayerRemoved, this);
         }
 
         this._showModel();
@@ -526,10 +526,10 @@ class SpriteComponent extends Component {
         const app = this.system.app;
         const scene = app.scene;
 
-        scene.off("set:layers", this._onLayersChanged, this);
+        scene.off('set:layers', this._onLayersChanged, this);
         if (scene.layers) {
-            scene.layers.off("add", this._onLayerAdded, this);
-            scene.layers.off("remove", this._onLayerRemoved, this);
+            scene.layers.off('add', this._onLayerAdded, this);
+            scene.layers.off('remove', this._onLayerRemoved, this);
         }
 
         this.stop();
@@ -799,10 +799,10 @@ class SpriteComponent extends Component {
     }
 
     _onLayersChanged(oldComp, newComp) {
-        oldComp.off("add", this.onLayerAdded, this);
-        oldComp.off("remove", this.onLayerRemoved, this);
-        newComp.on("add", this.onLayerAdded, this);
-        newComp.on("remove", this.onLayerRemoved, this);
+        oldComp.off('add', this.onLayerAdded, this);
+        oldComp.off('remove', this.onLayerRemoved, this);
+        newComp.on('add', this.onLayerAdded, this);
+        newComp.on('remove', this.onLayerRemoved, this);
 
         if (this.enabled && this.entity.enabled) {
             this._showModel();

--- a/src/framework/components/sprite/sprite-animation-clip.js
+++ b/src/framework/components/sprite/sprite-animation-clip.js
@@ -240,8 +240,8 @@ class SpriteAnimationClip extends EventHandler {
 
     // Hook up event handlers on sprite asset
     _bindSpriteAsset(asset) {
-        asset.on("load", this._onSpriteAssetLoad, this);
-        asset.on("remove", this._onSpriteAssetRemove, this);
+        asset.on('load', this._onSpriteAssetLoad, this);
+        asset.on('remove', this._onSpriteAssetRemove, this);
 
         if (asset.resource) {
             this._onSpriteAssetLoad(asset);
@@ -251,8 +251,8 @@ class SpriteAnimationClip extends EventHandler {
     }
 
     _unbindSpriteAsset(asset) {
-        asset.off("load", this._onSpriteAssetLoad, this);
-        asset.off("remove", this._onSpriteAssetRemove, this);
+        asset.off('load', this._onSpriteAssetLoad, this);
+        asset.off('remove', this._onSpriteAssetRemove, this);
 
         // unbind atlas
         if (asset.resource && asset.resource.atlas) {

--- a/src/framework/components/sprite/system.js
+++ b/src/framework/components/sprite/system.js
@@ -78,7 +78,7 @@ class SpriteComponentSystem extends ComponentSystem {
             material.emissiveMap = texture;
             material.emissiveMapTint = true;
             material.opacityMap = texture;
-            material.opacityMapChannel = "a";
+            material.opacityMapChannel = 'a';
             material.opacityTint = true;
             material.opacity = 0; // use non-1 opacity to compile shader correctly
             material.useLighting = false;

--- a/src/resources/animation.js
+++ b/src/resources/animation.js
@@ -54,7 +54,7 @@ class AnimationHandler {
 
     open(url, data) {
         if (path.getExtension(url).toLowerCase() === '.glb') {
-            const glbResources = GlbParser.parse("filename.glb", data, null);
+            const glbResources = GlbParser.parse('filename.glb', data, null);
             if (glbResources) {
                 const animations = glbResources.animations;
                 glbResources.destroy();
@@ -62,7 +62,7 @@ class AnimationHandler {
             }
             return null;
         }
-        return this["_parseAnimationV" + data.animation.version](data);
+        return this['_parseAnimationV' + data.animation.version](data);
     }
 
     patch(asset, assets) {

--- a/src/resources/audio.js
+++ b/src/resources/audio.js
@@ -154,7 +154,7 @@ class AudioHandler {
             } catch (e) {
                 // Some windows platforms will report Audio as available, then throw an exception when
                 // the object is created.
-                error("No support for Audio element");
+                error('No support for Audio element');
                 return;
             }
 

--- a/src/resources/basis.js
+++ b/src/resources/basis.js
@@ -26,7 +26,7 @@ const prepareWorkerModules = (config, callback) => {
 
     const wasmSupported = () => {
         try {
-            if (typeof WebAssembly === "object" && typeof WebAssembly.instantiate === "function") {
+            if (typeof WebAssembly === 'object' && typeof WebAssembly.instantiate === 'function') {
                 const module = new WebAssembly.Module(Uint8Array.of(0x0, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00));
                 if (module instanceof WebAssembly.Module)
                     return new WebAssembly.Instance(module) instanceof WebAssembly.Instance;
@@ -279,7 +279,7 @@ function basisInitialize(config) {
             return m.moduleName === 'BASIS';
         });
         if (wasmModule) {
-            const urlBase = window.ASSET_PREFIX || "";
+            const urlBase = window.ASSET_PREFIX || '';
             if (!config.glueUrl) {
                 config.glueUrl = urlBase + wasmModule.glueUrl;
             }

--- a/src/resources/bundle.js
+++ b/src/resources/bundle.js
@@ -46,10 +46,10 @@ class BundleHandler {
                 try {
                     self._untar(response, callback);
                 } catch (ex) {
-                    callback("Error loading bundle resource " + url.original + ": " + ex);
+                    callback('Error loading bundle resource ' + url.original + ': ' + ex);
                 }
             } else {
-                callback("Error loading bundle resource " + url.original + ": " + err);
+                callback('Error loading bundle resource ' + url.original + ': ' + err);
             }
         });
     }

--- a/src/resources/cubemap.js
+++ b/src/resources/cubemap.js
@@ -75,7 +75,7 @@ class CubemapHandler {
     // test whether two assets ids are the same
     compareAssetIds(assetIdA, assetIdB) {
         if (assetIdA && assetIdB) {
-            if (parseInt(assetIdA, 10) === assetIdA || typeof assetIdA === "string") {
+            if (parseInt(assetIdA, 10) === assetIdA || typeof assetIdA === 'string') {
                 return assetIdA === assetIdB;           // id or url
             }
             // else {
@@ -300,17 +300,17 @@ class CubemapHandler {
                         if (texAsset) {
                             processTexAsset(index, texAsset);
                         } else {
-                            onError(index, "failed to find dependent cubemap asset=" + assetId_);
+                            onError(index, 'failed to find dependent cubemap asset=' + assetId_);
                         }
                     }.bind(null, i, assetId));
                 }
             } else {
                 // assetId is a url or file object and we're responsible for creating it
-                const file = (typeof assetId === "string") ? {
+                const file = (typeof assetId === 'string') ? {
                     url: assetId,
                     filename: assetId
                 } : assetId;
-                texAsset = new Asset(cubemapAsset.name + "_part_" + i, "texture", file);
+                texAsset = new Asset(cubemapAsset.name + '_part_' + i, 'texture', file);
                 registry.add(texAsset);
                 registry.once('load:' + texAsset.id, onLoad.bind(self, i));
                 registry.once('error:' + texAsset.id, onError.bind(self, i));

--- a/src/resources/font.js
+++ b/src/resources/font.js
@@ -114,9 +114,9 @@ class FontHandler {
             };
 
             if (index === 0) {
-                loader.load(url, "texture", onLoaded);
+                loader.load(url, 'texture', onLoaded);
             } else {
-                loader.load(url.replace('.png', index + '.png'), "texture", onLoaded);
+                loader.load(url.replace('.png', index + '.png'), 'texture', onLoaded);
             }
         };
 

--- a/src/resources/loader.js
+++ b/src/resources/loader.js
@@ -99,7 +99,7 @@ class ResourceLoader {
     load(url, type, callback, asset) {
         const handler = this._handlers[type];
         if (!handler) {
-            const err = "No handler for asset type: " + type;
+            const err = 'No handler for asset type: ' + type;
             callback(err);
             return;
         }
@@ -217,7 +217,7 @@ class ResourceLoader {
     open(type, data) {
         const handler = this._handlers[type];
         if (!handler) {
-            console.warn("No resource handler found for: " + type);
+            console.warn('No resource handler found for: ' + type);
             return data;
         }
 
@@ -235,7 +235,7 @@ class ResourceLoader {
     patch(asset, assets) {
         const handler = this._handlers[asset.type];
         if (!handler)  {
-            console.warn("No resource handler found for: " + asset.type);
+            console.warn('No resource handler found for: ' + asset.type);
             return;
         }
 

--- a/src/resources/material.js
+++ b/src/resources/material.js
@@ -227,7 +227,7 @@ class MaterialHandler {
 
         const material = materialAsset.resource;
 
-        const pathMapping = (data.mappingFormat === "path");
+        const pathMapping = (data.mappingFormat === 'path');
 
         const TEXTURES = standardMaterialTextureParameters;
 

--- a/src/resources/model.js
+++ b/src/resources/model.js
@@ -88,7 +88,7 @@ class ModelHandler {
                 return p.parser.parse(data);
             }
         }
-        Debug.warn("pc.ModelHandler#open: No model parser found for: " + url);
+        Debug.warn('pc.ModelHandler#open: No model parser found for: ' + url);
         return null;
     }
 

--- a/src/resources/parser/glb-container-resource.js
+++ b/src/resources/parser/glb-container-resource.js
@@ -66,7 +66,7 @@ class GlbContainerResource {
 
     instantiateModelEntity(options) {
         const entity = new Entity();
-        entity.addComponent("model", Object.assign({ type: "asset", asset: this.model }, options));
+        entity.addComponent('model', Object.assign({ type: 'asset', asset: this.model }, options));
         return entity;
     }
 
@@ -155,8 +155,8 @@ class GlbContainerResource {
 
             // create render components for mesh instances
             if (attachedMi) {
-                entity.addComponent("render", Object.assign({
-                    type: "asset",
+                entity.addComponent('render', Object.assign({
+                    type: 'asset',
                     meshInstances: attachedMi,
                     rootBone: root
                 }, options));
@@ -187,7 +187,7 @@ class GlbContainerResource {
         });
 
         // return the scene hierarchy created from scene clones
-        return GlbContainerResource.createSceneHierarchy(sceneClones, "Entity");
+        return GlbContainerResource.createSceneHierarchy(sceneClones, 'Entity');
     }
 
     // helper function to create a single hierarchy from an array of nodes
@@ -246,7 +246,7 @@ class GlbContainerResource {
         }
 
         // node hierarchy for the model
-        model.graph = GlbContainerResource.createSceneHierarchy(glb.scenes, "GraphNode");
+        model.graph = GlbContainerResource.createSceneHierarchy(glb.scenes, 'GraphNode');
 
         // create mesh instance for meshes on nodes that are part of hierarchy
         for (let i = 0; i < glb.nodes.length; i++) {

--- a/src/resources/parser/glb-model.js
+++ b/src/resources/parser/glb-model.js
@@ -8,7 +8,7 @@ class GlbModelParser {
     }
 
     parse(data) {
-        const glbResources = GlbParser.parse("filename.glb", data, this._device);
+        const glbResources = GlbParser.parse('filename.glb', data, this._device);
         if (glbResources) {
             const model = GlbContainerResource.createModel(glbResources, this._defaultMaterial);
             glbResources.destroy();

--- a/src/resources/parser/glb-parser.js
+++ b/src/resources/parser/glb-parser.js
@@ -85,7 +85,7 @@ const isDataURI = function (uri) {
 };
 
 const getDataURIMimeType = function (uri) {
-    return uri.substring(uri.indexOf(":") + 1, uri.indexOf(";"));
+    return uri.substring(uri.indexOf(':') + 1, uri.indexOf(';'));
 };
 
 const getNumComponents = function (accessorType) {
@@ -197,7 +197,7 @@ const getAccessorData = function (gltfAccessor, bufferViews, flatten = false) {
         // get indices data
         const indicesAccessor = {
             count: sparse.count,
-            type: "SCALAR"
+            type: 'SCALAR'
         };
         const indices = getAccessorData(Object.assign(indicesAccessor, sparse.indices), bufferViews, true);
 
@@ -518,7 +518,7 @@ const createVertexBuffer = function (device, attributes, indices, accessors, buf
             useAttributes[attrib] = attributes[attrib];
 
             // build unique id for each attribute in format: Semantic:accessorIndex
-            attribIds.push(attrib + ":" + attributes[attrib]);
+            attribIds.push(attrib + ':' + attributes[attrib]);
         }
     }
 
@@ -677,7 +677,7 @@ const createSkin = function (device, gltfSkin, accessors, bufferViews, nodes, gl
     }
 
     // create a cache key from bone names and see if we have matching skin
-    const key = boneNames.join("#");
+    const key = boneNames.join('#');
     let skin = glbSkins.get(key);
     if (!skin) {
 
@@ -736,7 +736,7 @@ const createMesh = function (device, gltfMesh, accessors, bufferViews, callback,
                         }
 
                         if (!status || !status.ok() || outputGeometry.ptr == 0) {
-                            callback("Failed to decode draco compressed asset: " +
+                            callback('Failed to decode draco compressed asset: ' +
                             (status ? status.error_msg() : ('Mesh asset - invalid draco compressed geometry type: ' + geometryType)));
                             return;
                         }
@@ -773,7 +773,7 @@ const createMesh = function (device, gltfMesh, accessors, bufferViews, callback,
                         canUseMorph = false;
                     }
                 } else {
-                    Debug.warn("File contains draco compressed data, but DracoDecoderModule is not configured.");
+                    Debug.warn('File contains draco compressed data, but DracoDecoderModule is not configured.');
                 }
             }
         }
@@ -810,7 +810,7 @@ const createMesh = function (device, gltfMesh, accessors, bufferViews, callback,
 
                     // #if _DEBUG
                     if (vertexBuffer.numVertices > 0xFFFF) {
-                        console.warn("Glb file contains 32bit index buffer but these are not supported by this device - it may be rendered incorrectly.");
+                        console.warn('Glb file contains 32bit index buffer but these are not supported by this device - it may be rendered incorrectly.');
                     }
                     // #endif
 
@@ -883,90 +883,90 @@ const createMesh = function (device, gltfMesh, accessors, bufferViews, callback,
 const createMaterial = function (gltfMaterial, textures) {
     // TODO: integrate these shader chunks into the native engine
     const glossChunk = [
-        "#ifdef MAPFLOAT",
-        "uniform float material_shininess;",
-        "#endif",
-        "",
-        "#ifdef MAPTEXTURE",
-        "uniform sampler2D texture_glossMap;",
-        "#endif",
-        "",
-        "void getGlossiness() {",
-        "    dGlossiness = 1.0;",
-        "",
-        "#ifdef MAPFLOAT",
-        "    dGlossiness *= material_shininess;",
-        "#endif",
-        "",
-        "#ifdef MAPTEXTURE",
-        "    dGlossiness *= texture2D(texture_glossMap, $UV, textureBias).$CH;",
-        "#endif",
-        "",
-        "#ifdef MAPVERTEX",
-        "    dGlossiness *= saturate(vVertexColor.$VC);",
-        "#endif",
-        "",
-        "    dGlossiness = 1.0 - dGlossiness;",
-        "",
-        "    dGlossiness += 0.0000001;",
-        "}"
+        '#ifdef MAPFLOAT',
+        'uniform float material_shininess;',
+        '#endif',
+        '',
+        '#ifdef MAPTEXTURE',
+        'uniform sampler2D texture_glossMap;',
+        '#endif',
+        '',
+        'void getGlossiness() {',
+        '    dGlossiness = 1.0;',
+        '',
+        '#ifdef MAPFLOAT',
+        '    dGlossiness *= material_shininess;',
+        '#endif',
+        '',
+        '#ifdef MAPTEXTURE',
+        '    dGlossiness *= texture2D(texture_glossMap, $UV, textureBias).$CH;',
+        '#endif',
+        '',
+        '#ifdef MAPVERTEX',
+        '    dGlossiness *= saturate(vVertexColor.$VC);',
+        '#endif',
+        '',
+        '    dGlossiness = 1.0 - dGlossiness;',
+        '',
+        '    dGlossiness += 0.0000001;',
+        '}'
     ].join('\n');
 
     const specularChunk = [
-        "#ifdef MAPCOLOR",
-        "uniform vec3 material_specular;",
-        "#endif",
-        "",
-        "#ifdef MAPTEXTURE",
-        "uniform sampler2D texture_specularMap;",
-        "#endif",
-        "",
-        "void getSpecularity() {",
-        "    dSpecularity = vec3(1.0);",
-        "",
-        "    #ifdef MAPCOLOR",
-        "        dSpecularity *= material_specular;",
-        "    #endif",
-        "",
-        "    #ifdef MAPTEXTURE",
-        "        vec3 srgb = texture2D(texture_specularMap, $UV, textureBias).$CH;",
-        "        dSpecularity *= vec3(pow(srgb.r, 2.2), pow(srgb.g, 2.2), pow(srgb.b, 2.2));",
-        "    #endif",
-        "",
-        "    #ifdef MAPVERTEX",
-        "        dSpecularity *= saturate(vVertexColor.$VC);",
-        "    #endif",
-        "}"
+        '#ifdef MAPCOLOR',
+        'uniform vec3 material_specular;',
+        '#endif',
+        '',
+        '#ifdef MAPTEXTURE',
+        'uniform sampler2D texture_specularMap;',
+        '#endif',
+        '',
+        'void getSpecularity() {',
+        '    dSpecularity = vec3(1.0);',
+        '',
+        '    #ifdef MAPCOLOR',
+        '        dSpecularity *= material_specular;',
+        '    #endif',
+        '',
+        '    #ifdef MAPTEXTURE',
+        '        vec3 srgb = texture2D(texture_specularMap, $UV, textureBias).$CH;',
+        '        dSpecularity *= vec3(pow(srgb.r, 2.2), pow(srgb.g, 2.2), pow(srgb.b, 2.2));',
+        '    #endif',
+        '',
+        '    #ifdef MAPVERTEX',
+        '        dSpecularity *= saturate(vVertexColor.$VC);',
+        '    #endif',
+        '}'
     ].join('\n');
 
     const clearCoatGlossChunk = [
-        "#ifdef MAPFLOAT",
-        "uniform float material_clearCoatGlossiness;",
-        "#endif",
-        "",
-        "#ifdef MAPTEXTURE",
-        "uniform sampler2D texture_clearCoatGlossMap;",
-        "#endif",
-        "",
-        "void getClearCoatGlossiness() {",
-        "    ccGlossiness = 1.0;",
-        "",
-        "#ifdef MAPFLOAT",
-        "    ccGlossiness *= material_clearCoatGlossiness;",
-        "#endif",
-        "",
-        "#ifdef MAPTEXTURE",
-        "    ccGlossiness *= texture2D(texture_clearCoatGlossMap, $UV, textureBias).$CH;",
-        "#endif",
-        "",
-        "#ifdef MAPVERTEX",
-        "    ccGlossiness *= saturate(vVertexColor.$VC);",
-        "#endif",
-        "",
-        "    ccGlossiness = 1.0 - ccGlossiness;",
-        "",
-        "    ccGlossiness += 0.0000001;",
-        "}"
+        '#ifdef MAPFLOAT',
+        'uniform float material_clearCoatGlossiness;',
+        '#endif',
+        '',
+        '#ifdef MAPTEXTURE',
+        'uniform sampler2D texture_clearCoatGlossMap;',
+        '#endif',
+        '',
+        'void getClearCoatGlossiness() {',
+        '    ccGlossiness = 1.0;',
+        '',
+        '#ifdef MAPFLOAT',
+        '    ccGlossiness *= material_clearCoatGlossiness;',
+        '#endif',
+        '',
+        '#ifdef MAPTEXTURE',
+        '    ccGlossiness *= texture2D(texture_clearCoatGlossMap, $UV, textureBias).$CH;',
+        '#endif',
+        '',
+        '#ifdef MAPVERTEX',
+        '    ccGlossiness *= saturate(vVertexColor.$VC);',
+        '#endif',
+        '',
+        '    ccGlossiness = 1.0 - ccGlossiness;',
+        '',
+        '    ccGlossiness += 0.0000001;',
+        '}'
     ].join('\n');
 
     const zeros = [0, 0];
@@ -1253,9 +1253,9 @@ const createAnimation = function (gltfAnimation, animationIndex, gltfAccessors, 
     };
 
     const interpMap = {
-        "STEP": INTERPOLATION_STEP,
-        "LINEAR": INTERPOLATION_LINEAR,
-        "CUBICSPLINE": INTERPOLATION_CUBIC
+        'STEP': INTERPOLATION_STEP,
+        'LINEAR': INTERPOLATION_LINEAR,
+        'CUBICSPLINE': INTERPOLATION_CUBIC
     };
 
     const inputMap = { };
@@ -1382,7 +1382,7 @@ const createAnimation = function (gltfAnimation, animationIndex, gltfAccessors, 
     }
 
     return new AnimTrack(
-        gltfAnimation.hasOwnProperty('name') ? gltfAnimation.name : ("animation_" + animationIndex),
+        gltfAnimation.hasOwnProperty('name') ? gltfAnimation.name : ('animation_' + animationIndex),
         duration,
         inputs,
         outputs,
@@ -1395,7 +1395,7 @@ const createNode = function (gltfNode, nodeIndex) {
     if (gltfNode.hasOwnProperty('name') && gltfNode.name.length > 0) {
         entity.name = gltfNode.name;
     } else {
-        entity.name = "node_" + nodeIndex;
+        entity.name = 'node_' + nodeIndex;
     }
 
     // Parse transformation properties
@@ -1430,7 +1430,7 @@ const createNode = function (gltfNode, nodeIndex) {
 // creates a camera component on the supplied node, and returns it
 const createCamera = function (gltfCamera, node) {
 
-    const projection = gltfCamera.type === "orthographic" ? PROJECTION_ORTHOGRAPHIC : PROJECTION_PERSPECTIVE;
+    const projection = gltfCamera.type === 'orthographic' ? PROJECTION_ORTHOGRAPHIC : PROJECTION_PERSPECTIVE;
     const gltfProperties = projection === PROJECTION_ORTHOGRAPHIC ? gltfCamera.orthographic : gltfCamera.perspective;
 
     const componentData = {
@@ -1459,7 +1459,7 @@ const createCamera = function (gltfCamera, node) {
     }
 
     const cameraEntity = new Entity(gltfCamera.name);
-    cameraEntity.addComponent("camera", componentData);
+    cameraEntity.addComponent('camera', componentData);
     return cameraEntity;
 };
 
@@ -1468,7 +1468,7 @@ const createLight = function (gltfLight, node) {
 
     const lightProps = {
         enabled: false,
-        type: gltfLight.type === "point" ? "omni" : gltfLight.type,
+        type: gltfLight.type === 'point' ? 'omni' : gltfLight.type,
         color: gltfLight.hasOwnProperty('color') ? new Color(gltfLight.color) : Color.WHITE,
 
         // when range is not defined, infinity should be used - but that is causing infinity in bounds calculations
@@ -1494,7 +1494,7 @@ const createLight = function (gltfLight, node) {
     lightEntity.rotateLocal(90, 0, 0);
 
     // add component
-    lightEntity.addComponent("light", lightProps);
+    lightEntity.addComponent('light', lightProps);
     return lightEntity;
 };
 
@@ -1744,7 +1744,7 @@ const createResources = function (device, gltf, bufferViews, textureAssets, opti
     // Instead of bloating the engine forevermore with code to handle this case,
     // we now issue a warning instead and prompt user to reconvert their FBX.
     if (gltf.asset && gltf.asset.generator === 'PlayCanvas') {
-        Debug.warn(`glTF model may have flipped UVs. Please reconvert.`);
+        Debug.warn('glTF model may have flipped UVs. Please reconvert.');
     }
 
     const nodes = createNodes(gltf, options);
@@ -1883,14 +1883,14 @@ const loadImageAsync = function (gltfImage, index, bufferViews, urlBase, registr
                 if (isDataURI(gltfImage.uri)) {
                     loadTexture(gltfImage.uri, null, getDataURIMimeType(gltfImage.uri), null);
                 } else {
-                    loadTexture(path.join(urlBase, gltfImage.uri), null, null, { crossOrigin: "anonymous" });
+                    loadTexture(path.join(urlBase, gltfImage.uri), null, null, { crossOrigin: 'anonymous' });
                 }
             } else if (gltfImage.hasOwnProperty('bufferView') && gltfImage.hasOwnProperty('mimeType')) {
                 // bufferview
                 loadTexture(null, bufferViews[gltfImage.bufferView], gltfImage.mimeType, null);
             } else {
                 // fail
-                callback("Invalid image found in gltf (neither uri or bufferView found). index=" + index);
+                callback('Invalid image found in gltf (neither uri or bufferView found). index=' + index);
             }
         }
     });
@@ -2057,7 +2057,7 @@ const parseGltf = function (gltfChunk, callback) {
             return new TextDecoder().decode(array);
         }
 
-        let str = "";
+        let str = '';
         for (let i = 0; i < array.length; i++) {
             str += String.fromCharCode(array[i]);
         }
@@ -2086,17 +2086,17 @@ const parseGlb = function (glbData, callback) {
     const length = data.getUint32(8, true);
 
     if (magic !== 0x46546C67) {
-        callback("Invalid magic number found in glb header. Expected 0x46546C67, found 0x" + magic.toString(16));
+        callback('Invalid magic number found in glb header. Expected 0x46546C67, found 0x' + magic.toString(16));
         return;
     }
 
     if (version !== 2) {
-        callback("Invalid version number found in glb header. Expected 2, found " + version);
+        callback('Invalid version number found in glb header. Expected 2, found ' + version);
         return;
     }
 
     if (length <= 0 || length > data.byteLength) {
-        callback("Invalid length found in glb header. Found " + length);
+        callback('Invalid length found in glb header. Found ' + length);
         return;
     }
 
@@ -2106,7 +2106,7 @@ const parseGlb = function (glbData, callback) {
     while (offset < length) {
         const chunkLength = data.getUint32(offset, true);
         if (offset + chunkLength + 8 > data.byteLength) {
-            throw new Error("Invalid chunk length found in glb. Found " + chunkLength);
+            throw new Error('Invalid chunk length found in glb. Found ' + chunkLength);
         }
         const chunkType = data.getUint32(offset + 4, true);
         const chunkData = new Uint8Array(data.buffer, data.byteOffset + offset + 8, chunkLength);
@@ -2115,17 +2115,17 @@ const parseGlb = function (glbData, callback) {
     }
 
     if (chunks.length !== 1 && chunks.length !== 2) {
-        callback("Invalid number of chunks found in glb file.");
+        callback('Invalid number of chunks found in glb file.');
         return;
     }
 
     if (chunks[0].type !== 0x4E4F534A) {
-        callback("Invalid chunk type found in glb file. Expected 0x4E4F534A, found 0x" + chunks[0].type.toString(16));
+        callback('Invalid chunk type found in glb file. Expected 0x4E4F534A, found 0x' + chunks[0].type.toString(16));
         return;
     }
 
     if (chunks.length > 1 && chunks[1].type !== 0x004E4942) {
-        callback("Invalid chunk type found in glb file. Expected 0x004E4942, found 0x" + chunks[1].type.toString(16));
+        callback('Invalid chunk type found in glb file. Expected 0x004E4942, found 0x' + chunks[1].type.toString(16));
         return;
     }
 

--- a/src/resources/parser/json-model.js
+++ b/src/resources/parser/json-model.js
@@ -29,23 +29,23 @@ import { Skin } from '../../scene/skin.js';
 import { SkinInstance } from '../../scene/skin-instance.js';
 
 const JSON_PRIMITIVE_TYPE = {
-    "points": PRIMITIVE_POINTS,
-    "lines": PRIMITIVE_LINES,
-    "lineloop": PRIMITIVE_LINELOOP,
-    "linestrip": PRIMITIVE_LINESTRIP,
-    "triangles": PRIMITIVE_TRIANGLES,
-    "trianglestrip": PRIMITIVE_TRISTRIP,
-    "trianglefan": PRIMITIVE_TRIFAN
+    'points': PRIMITIVE_POINTS,
+    'lines': PRIMITIVE_LINES,
+    'lineloop': PRIMITIVE_LINELOOP,
+    'linestrip': PRIMITIVE_LINESTRIP,
+    'triangles': PRIMITIVE_TRIANGLES,
+    'trianglestrip': PRIMITIVE_TRISTRIP,
+    'trianglefan': PRIMITIVE_TRIFAN
 };
 
 const JSON_VERTEX_ELEMENT_TYPE = {
-    "int8": TYPE_INT8,
-    "uint8": TYPE_UINT8,
-    "int16": TYPE_INT16,
-    "uint16": TYPE_UINT16,
-    "int32": TYPE_INT32,
-    "uint32": TYPE_UINT32,
-    "float32": TYPE_FLOAT32
+    'int8': TYPE_INT8,
+    'uint8': TYPE_UINT8,
+    'int16': TYPE_INT16,
+    'uint16': TYPE_UINT16,
+    'int32': TYPE_INT32,
+    'uint32': TYPE_UINT32,
+    'float32': TYPE_FLOAT32
 };
 
 // Take PlayCanvas JSON model data and create pc.Model
@@ -62,7 +62,7 @@ class JsonModelParser {
         }
 
         if (modelData.version <= 1) {
-            Debug.warn("JsonModelParser#parse: Trying to parse unsupported model format.");
+            Debug.warn('JsonModelParser#parse: Trying to parse unsupported model format.');
             return null;
         }
 

--- a/src/resources/parser/material/json-standard-material.js
+++ b/src/resources/parser/material/json-standard-material.js
@@ -116,23 +116,23 @@ class JsonStandardMaterialParser {
         // list of properties that have been renamed in StandardMaterial
         // but may still exists in data in old format
         const RENAMED_PROPERTIES = [
-            ["bumpMapFactor", "bumpiness"],
+            ['bumpMapFactor', 'bumpiness'],
 
-            ["aoUvSet", "aoMapUv"],
+            ['aoUvSet', 'aoMapUv'],
 
-            ["aoMapVertexColor", "aoVertexColor"],
-            ["diffuseMapVertexColor", "diffuseVertexColor"],
-            ["emissiveMapVertexColor", "emissiveVertexColor"],
-            ["specularMapVertexColor", "specularVertexColor"],
-            ["metalnessMapVertexColor", "metalnessVertexColor"],
-            ["opacityMapVertexColor", "opacityVertexColor"],
-            ["glossMapVertexColor", "glossVertexColor"],
-            ["lightMapVertexColor", "lightVertexColor"],
+            ['aoMapVertexColor', 'aoVertexColor'],
+            ['diffuseMapVertexColor', 'diffuseVertexColor'],
+            ['emissiveMapVertexColor', 'emissiveVertexColor'],
+            ['specularMapVertexColor', 'specularVertexColor'],
+            ['metalnessMapVertexColor', 'metalnessVertexColor'],
+            ['opacityMapVertexColor', 'opacityVertexColor'],
+            ['glossMapVertexColor', 'glossVertexColor'],
+            ['lightMapVertexColor', 'lightVertexColor'],
 
-            ["diffuseMapTint", "diffuseTint"],
-            ["specularMapTint", "specularTint"],
-            ["emissiveMapTint", "emissiveTint"],
-            ["metalnessMapTint", "metalnessTint"]
+            ['diffuseMapTint', 'diffuseTint'],
+            ['specularMapTint', 'specularTint'],
+            ['emissiveMapTint', 'emissiveTint'],
+            ['metalnessMapTint', 'metalnessTint']
         ];
 
         // if an old property name exists without a new one,

--- a/src/resources/parser/texture/dds.js
+++ b/src/resources/parser/texture/dds.js
@@ -93,7 +93,7 @@ class DdsParser {
         }
 
         if (!format) {
-            Debug.error("This DDS pixel format is currently unsupported. Empty texture will be created instead.");
+            Debug.error('This DDS pixel format is currently unsupported. Empty texture will be created instead.');
             texture = new Texture(device, {
                 width: 4,
                 height: 4,

--- a/src/resources/parser/texture/hdr.js
+++ b/src/resources/parser/texture/hdr.js
@@ -66,7 +66,7 @@ class HdrParser {
         // require magic
         const magic = readStream.readLine();
         if (!magic.startsWith('#?RADIANCE')) {
-            Debug.error("radiance header has invalid magic");
+            Debug.error('radiance header has invalid magic');
             return null;
         }
 
@@ -87,14 +87,14 @@ class HdrParser {
 
         // we require FORMAT variable
         if (!variables.hasOwnProperty('FORMAT')) {
-            Debug.error("radiance header missing FORMAT variable");
+            Debug.error('radiance header missing FORMAT variable');
             return null;
         }
 
         // read the resolution specifier
         const resolution = readStream.readLine().split(' ');
         if (resolution.length !== 4) {
-            Debug.error("radiance header has invalid resolution");
+            Debug.error('radiance header has invalid resolution');
             return null;
         }
 
@@ -144,7 +144,7 @@ class HdrParser {
 
             // sanity check it
             if ((rgbe[2] << 8) + rgbe[3] !== width) {
-                Debug.error("radiance has invalid scanline width");
+                Debug.error('radiance has invalid scanline width');
                 return null;
             }
 
@@ -157,7 +157,7 @@ class HdrParser {
                         // run of the same value
                         count -= 128;
                         if (x + count > width) {
-                            Debug.error("radiance has invalid scanline data");
+                            Debug.error('radiance has invalid scanline data');
                             return null;
                         }
                         value = readStream.readU8();
@@ -167,7 +167,7 @@ class HdrParser {
                     } else {
                         // non-run
                         if (count === 0 || x + count > width) {
-                            Debug.error("radiance has invalid scanline data");
+                            Debug.error('radiance has invalid scanline data');
                             return null;
                         }
                         for (i = 0; i < count; ++i) {

--- a/src/resources/parser/texture/img.js
+++ b/src/resources/parser/texture/img.js
@@ -58,7 +58,7 @@ class ImgParser {
 
     open(url, data, device) {
         const ext = path.getExtension(url).toLowerCase();
-        const format = (ext === ".jpg" || ext === ".jpeg") ? PIXELFORMAT_R8_G8_B8 : PIXELFORMAT_R8_G8_B8_A8;
+        const format = (ext === '.jpg' || ext === '.jpeg') ? PIXELFORMAT_R8_G8_B8 : PIXELFORMAT_R8_G8_B8_A8;
         const texture = new Texture(device, {
             name: url,
             // #if _PROFILER
@@ -116,7 +116,7 @@ class ImgParser {
     _loadImageBitmap(url, originalUrl, crossOrigin, callback) {
         const options = {
             cache: true,
-            responseType: "blob",
+            responseType: 'blob',
             retry: this.maxRetries > 0,
             maxRetries: this.maxRetries
         };

--- a/src/resources/parser/texture/ktx.js
+++ b/src/resources/parser/texture/ktx.js
@@ -93,7 +93,7 @@ class KtxParser {
         if (IDENTIFIER[0] !== dataU32[0] ||
             IDENTIFIER[1] !== dataU32[1] ||
             IDENTIFIER[2] !== dataU32[2]) {
-            Debug.warn("Invalid definition header found in KTX file. Expected 0xAB4B5458, 0x203131BB, 0x0D0A1A0A");
+            Debug.warn('Invalid definition header found in KTX file. Expected 0xAB4B5458, 0x203131BB, 0x0D0A1A0A');
             return null;
         }
 
@@ -116,13 +116,13 @@ class KtxParser {
 
         // don't support volume textures
         if (header.pixelDepth > 1) {
-            Debug.warn("More than 1 pixel depth not supported!");
+            Debug.warn('More than 1 pixel depth not supported!');
             return null;
         }
 
         // don't support texture arrays
         if (header.numberOfArrayElements !== 0) {
-            Debug.warn("Array texture not supported!");
+            Debug.warn('Array texture not supported!');
             return null;
         }
 
@@ -130,7 +130,7 @@ class KtxParser {
 
         // only support subset of pixel formats
         if (format === undefined) {
-            Debug.warn("Unknown glInternalFormat: " + header.glInternalFormat);
+            Debug.warn('Unknown glInternalFormat: ' + header.glInternalFormat);
             return null;
         }
 

--- a/src/resources/parser/texture/ktx2.js
+++ b/src/resources/parser/texture/ktx2.js
@@ -60,7 +60,7 @@ class Ktx2Parser {
         // check magic header bits:  '«', 'K', 'T', 'X', ' ', '2', '0', '»', '\r', '\n', '\x1A', '\n'\
         const magic = [rs.readU32be(), rs.readU32be(), rs.readU32be()];
         if (magic[0] !== 0xAB4B5458 || magic[1] !== 0x203230BB || magic[2] !== 0x0D0A1A0A) {
-            Debug.warn("Invalid definition header found in KTX2 file. Expected 0xAB4B5458, 0x203131BB, 0x0D0A1A0A");
+            Debug.warn('Invalid definition header found in KTX2 file. Expected 0xAB4B5458, 0x203131BB, 0x0D0A1A0A');
             return null;
         }
 
@@ -100,7 +100,7 @@ class Ktx2Parser {
         // unpack data format descriptor
         const dfdTotalSize = rs.readU32();
         if (dfdTotalSize !== index.kvdByteOffset - index.dfdByteOffset) {
-            Debug.warn("Invalid file data encountered.");
+            Debug.warn('Invalid file data encountered.');
             return null;
         }
 

--- a/src/resources/script.js
+++ b/src/resources/script.js
@@ -26,7 +26,7 @@ class ScriptHandler {
 
     static _push(Type) {
         if (script.legacy && ScriptHandler._types.length > 0) {
-            console.assert("Script Ordering Error. Contact support@playcanvas.com");
+            console.assert('Script Ordering Error. Contact support@playcanvas.com');
         } else {
             ScriptHandler._types.push(Type);
         }
@@ -101,7 +101,7 @@ class ScriptHandler {
 
         let done = false;
         element.onload = element.onreadystatechange = function () {
-            if (!done && (!this.readyState || (this.readyState === "loaded" || this.readyState === "complete"))) {
+            if (!done && (!this.readyState || (this.readyState === 'loaded' || this.readyState === 'complete'))) {
                 done = true; // prevent double event firing
                 callback(null, url, element);
             }

--- a/src/resources/sprite.js
+++ b/src/resources/sprite.js
@@ -91,7 +91,7 @@ class SpriteHandler {
                 if (atlas) {
                     asset.data.textureAtlasAsset = atlas.id;
                 } else {
-                    console.warn("Could not find textureatlas with url: " + sprite.__data.textureAtlasAsset);
+                    console.warn('Could not find textureatlas with url: ' + sprite.__data.textureAtlasAsset);
                 }
             }
 

--- a/src/resources/template.js
+++ b/src/resources/template.js
@@ -24,7 +24,7 @@ class TemplateHandler {
 
         http.get(url.load, options, function (err, response) {
             if (err) {
-                callback("Error requesting template: " + url.original);
+                callback('Error requesting template: ' + url.original);
             } else {
                 callback(err, response);
             }

--- a/src/resources/texture-atlas.js
+++ b/src/resources/texture-atlas.js
@@ -17,18 +17,18 @@ import { TextureAtlas } from '../scene/texture-atlas.js';
 /** @typedef {import('./loader.js').ResourceLoader} ResourceLoader */
 
 const JSON_ADDRESS_MODE = {
-    "repeat": ADDRESS_REPEAT,
-    "clamp": ADDRESS_CLAMP_TO_EDGE,
-    "mirror": ADDRESS_MIRRORED_REPEAT
+    'repeat': ADDRESS_REPEAT,
+    'clamp': ADDRESS_CLAMP_TO_EDGE,
+    'mirror': ADDRESS_MIRRORED_REPEAT
 };
 
 const JSON_FILTER_MODE = {
-    "nearest": FILTER_NEAREST,
-    "linear": FILTER_LINEAR,
-    "nearest_mip_nearest": FILTER_NEAREST_MIPMAP_NEAREST,
-    "linear_mip_nearest": FILTER_LINEAR_MIPMAP_NEAREST,
-    "nearest_mip_linear": FILTER_NEAREST_MIPMAP_LINEAR,
-    "linear_mip_linear": FILTER_LINEAR_MIPMAP_LINEAR
+    'nearest': FILTER_NEAREST,
+    'linear': FILTER_LINEAR,
+    'nearest_mip_nearest': FILTER_NEAREST_MIPMAP_NEAREST,
+    'linear_mip_nearest': FILTER_LINEAR_MIPMAP_NEAREST,
+    'nearest_mip_linear': FILTER_NEAREST_MIPMAP_LINEAR,
+    'linear_mip_linear': FILTER_LINEAR_MIPMAP_LINEAR
 };
 
 const regexFrame = /^data\.frames\.(\d+)$/;
@@ -59,7 +59,7 @@ class TextureAtlasHandler {
         }
 
         const self = this;
-        const handler = this._loader.getHandler("texture");
+        const handler = this._loader.getHandler('texture');
 
         // if supplied with a json file url (probably engine-only)
         // load json data then load texture of same name
@@ -71,7 +71,7 @@ class TextureAtlasHandler {
                 if (!err) {
                     // load texture
                     const textureUrl = url.original.replace('.json', '.png');
-                    self._loader.load(textureUrl, "texture", function (err, texture) {
+                    self._loader.load(textureUrl, 'texture', function (err, texture) {
                         if (err) {
                             callback(err);
                         } else {
@@ -97,7 +97,7 @@ class TextureAtlasHandler {
             resource.texture = data.texture;
             resource.__data = data.data; // store data temporarily to be copied into asset
         } else {
-            const handler = this._loader.getHandler("texture");
+            const handler = this._loader.getHandler('texture');
             const texture = handler.open(url, data);
             if (!texture) return null;
             resource.texture = texture;

--- a/src/resources/texture.js
+++ b/src/resources/texture.js
@@ -23,25 +23,25 @@ import { HdrParser } from './parser/texture/hdr.js';
 /** @typedef {import('./loader.js').ResourceLoader} ResourceLoader */
 
 const JSON_ADDRESS_MODE = {
-    "repeat": ADDRESS_REPEAT,
-    "clamp": ADDRESS_CLAMP_TO_EDGE,
-    "mirror": ADDRESS_MIRRORED_REPEAT
+    'repeat': ADDRESS_REPEAT,
+    'clamp': ADDRESS_CLAMP_TO_EDGE,
+    'mirror': ADDRESS_MIRRORED_REPEAT
 };
 
 const JSON_FILTER_MODE = {
-    "nearest": FILTER_NEAREST,
-    "linear": FILTER_LINEAR,
-    "nearest_mip_nearest": FILTER_NEAREST_MIPMAP_NEAREST,
-    "linear_mip_nearest": FILTER_LINEAR_MIPMAP_NEAREST,
-    "nearest_mip_linear": FILTER_NEAREST_MIPMAP_LINEAR,
-    "linear_mip_linear": FILTER_LINEAR_MIPMAP_LINEAR
+    'nearest': FILTER_NEAREST,
+    'linear': FILTER_LINEAR,
+    'nearest_mip_nearest': FILTER_NEAREST_MIPMAP_NEAREST,
+    'linear_mip_nearest': FILTER_LINEAR_MIPMAP_NEAREST,
+    'nearest_mip_linear': FILTER_NEAREST_MIPMAP_LINEAR,
+    'linear_mip_linear': FILTER_LINEAR_MIPMAP_LINEAR
 };
 
 const JSON_TEXTURE_TYPE = {
-    "default": TEXTURETYPE_DEFAULT,
-    "rgbm": TEXTURETYPE_RGBM,
-    "rgbe": TEXTURETYPE_RGBE,
-    "swizzleGGGR": TEXTURETYPE_SWIZZLEGGGR
+    'default': TEXTURETYPE_DEFAULT,
+    'rgbm': TEXTURETYPE_RGBM,
+    'rgbe': TEXTURETYPE_RGBE,
+    'swizzleGGGR': TEXTURETYPE_SWIZZLEGGGR
 };
 
 /**

--- a/src/resources/untar.js
+++ b/src/resources/untar.js
@@ -133,7 +133,7 @@ function UntarScope(isWorker) {
 
         let normalFile = false;
         switch (type) {
-            case "0": case "": // Normal file
+            case '0': case '': // Normal file
                 // do not create blob URL if we are in a worker
                 // because if the worker is destroyed it will also destroy the blob URLs
                 normalFile = true;
@@ -142,19 +142,19 @@ function UntarScope(isWorker) {
                     url = URL.createObjectURL(blob);
                 }
                 break;
-            case "g": // Global PAX header
+            case 'g': // Global PAX header
                 this._globalPaxHeader = PaxHeader.parse(this._arrayBuffer, this._bytesRead, size);
                 break;
-            case "x": // PAX header
+            case 'x': // PAX header
                 this._paxHeader = PaxHeader.parse(this._arrayBuffer, this._bytesRead, size);
                 break;
-            case "1": // Link to another file already archived
-            case "2": // Symbolic link
-            case "3": // Character special device
-            case "4": // Block special device
-            case "5": // Directory
-            case "6": // FIFO special file
-            case "7": // Reserved
+            case '1': // Link to another file already archived
+            case '2': // Symbolic link
+            case '3': // Character special device
+            case '4': // Block special device
+            case '5': // Directory
+            case '6': // FIFO special file
+            case '7': // Reserved
             default: // Unknown file type
         }
 
@@ -170,7 +170,7 @@ function UntarScope(isWorker) {
             return null;
         }
 
-        if (ustarFormat.indexOf("ustar") !== -1) {
+        if (ustarFormat.indexOf('ustar') !== -1) {
             const namePrefix = headers.substr(345, 155).replace(/\0/g, '');
 
             if (namePrefix.length > 0) {

--- a/src/scene/area-light-luts.js
+++ b/src/scene/area-light-luts.js
@@ -28,7 +28,7 @@ const deviceCache = new DeviceCache();
 
 // static class managing LUT tables for the area lights
 class AreaLightLuts {
-    static createTexture(device, format, size, postfix = "") {
+    static createTexture(device, format, size, postfix = '') {
         const tex = new Texture(device, {
             width: size,
             height: size,
@@ -60,7 +60,7 @@ class AreaLightLuts {
 
     // placeholder LUT textures for area light
     static createPlaceholder(device) {
-        const texture = AreaLightLuts.createTexture(device, PIXELFORMAT_R8_G8_B8_A8, 2, "placeholder");
+        const texture = AreaLightLuts.createTexture(device, PIXELFORMAT_R8_G8_B8_A8, 2, 'placeholder');
 
         const pixels = texture.lock();
         pixels.fill(0);

--- a/src/scene/batching/batch-manager.js
+++ b/src/scene/batching/batch-manager.js
@@ -694,8 +694,8 @@ class BatchManager {
         // #endif
 
         if (!this._init) {
-            const boneLimit = "#define BONE_LIMIT " + this.device.getBoneLimit() + "\n";
-            this.transformVS = boneLimit + "#define DYNAMICBATCH\n" + shaderChunks.transformVS;
+            const boneLimit = '#define BONE_LIMIT ' + this.device.getBoneLimit() + '\n';
+            this.transformVS = boneLimit + '#define DYNAMICBATCH\n' + shaderChunks.transformVS;
             this.skinTexVS = shaderChunks.skinBatchTexVS;
             this.skinConstVS = shaderChunks.skinBatchConstVS;
             this.vertexFormats = {};

--- a/src/scene/composition/layer-composition.js
+++ b/src/scene/composition/layer-composition.js
@@ -35,7 +35,7 @@ class LayerComposition extends EventHandler {
      * @param {string} [name] - Optional non-unique name of the layer composition. Defaults to
      * "Untitled" if not specified.
      */
-    constructor(name = "Untitled") {
+    constructor(name = 'Untitled') {
         super();
 
         this.name = name;
@@ -130,7 +130,7 @@ class LayerComposition extends EventHandler {
 
             // create cluster structure with no lights
             this._emptyWorldClusters = new WorldClusters(device);
-            this._emptyWorldClusters.name = "ClusterEmpty";
+            this._emptyWorldClusters.name = 'ClusterEmpty';
 
             // update it once to avoid doing it each frame
             this._emptyWorldClusters.update([], false, null);
@@ -544,7 +544,7 @@ class LayerComposition extends EventHandler {
                             clusters = new WorldClusters(device);
                         }
 
-                        clusters.name = "Cluster-" + this._worldClusters.length;
+                        clusters.name = 'Cluster-' + this._worldClusters.length;
                         this._worldClusters.push(clusters);
                     }
 
@@ -664,7 +664,7 @@ class LayerComposition extends EventHandler {
 
         // #if _DEBUG
         if (this.logRenderActions) {
-            Debug.log("Render Actions for composition: " + this.name);
+            Debug.log('Render Actions for composition: ' + this.name);
             for (let i = 0; i < this._renderActions.length; i++) {
                 const ra = this._renderActions[i];
                 const layerIndex = ra.layerIndex;
@@ -673,22 +673,22 @@ class LayerComposition extends EventHandler {
                 const transparent = this.subLayerList[layerIndex];
                 const camera = layer.cameras[ra.cameraIndex];
                 const dirLightCount = ra.directionalLights.length;
-                const clear = (ra.clearColor ? "Color " : "..... ") + (ra.clearDepth ? "Depth " : "..... ") + (ra.clearStencil ? "Stencil" : ".......");
+                const clear = (ra.clearColor ? 'Color ' : '..... ') + (ra.clearDepth ? 'Depth ' : '..... ') + (ra.clearStencil ? 'Stencil' : '.......');
 
                 Debug.log(i +
-                    (" Cam: " + (camera ? camera.entity.name : "-")).padEnd(22, " ") +
-                    (" Lay: " + layer.name).padEnd(22, " ") +
-                    (transparent ? " TRANSP" : " OPAQUE") +
-                    (enabled ? " ENABLED " : " DISABLED") +
-                    " Meshes: ", (transparent ? layer.transparentMeshInstances.length : layer.opaqueMeshInstances.length) +
-                    (" RT: " + (ra.renderTarget ? ra.renderTarget.name : "-")).padEnd(30, " ") +
-                    " Clear: " + clear +
-                    " Lights: (" + layer._clusteredLightsSet.size + "/" + layer._lightsSet.size + ")" +
-                    " " + (ra.lightClusters !== this._emptyWorldClusters ? (ra.lightClusters.name) : "").padEnd(10, " ") +
-                    (ra.firstCameraUse ? " CAM-FIRST" : "") +
-                    (ra.lastCameraUse ? " CAM-LAST" : "") +
-                    (ra.triggerPostprocess ? " POSTPROCESS" : "") +
-                    (dirLightCount ? (" DirLights: " + dirLightCount) : "")
+                    (' Cam: ' + (camera ? camera.entity.name : '-')).padEnd(22, ' ') +
+                    (' Lay: ' + layer.name).padEnd(22, ' ') +
+                    (transparent ? ' TRANSP' : ' OPAQUE') +
+                    (enabled ? ' ENABLED ' : ' DISABLED') +
+                    ' Meshes: ', (transparent ? layer.transparentMeshInstances.length : layer.opaqueMeshInstances.length) +
+                    (' RT: ' + (ra.renderTarget ? ra.renderTarget.name : '-')).padEnd(30, ' ') +
+                    ' Clear: ' + clear +
+                    ' Lights: (' + layer._clusteredLightsSet.size + '/' + layer._lightsSet.size + ')' +
+                    ' ' + (ra.lightClusters !== this._emptyWorldClusters ? (ra.lightClusters.name) : '').padEnd(10, ' ') +
+                    (ra.firstCameraUse ? ' CAM-FIRST' : '') +
+                    (ra.lastCameraUse ? ' CAM-LAST' : '') +
+                    (ra.triggerPostprocess ? ' POSTPROCESS' : '') +
+                    (dirLightCount ? (' DirLights: ' + dirLightCount) : '')
                 );
             }
         }
@@ -697,7 +697,7 @@ class LayerComposition extends EventHandler {
 
     _isLayerAdded(layer) {
         if (this.layerList.indexOf(layer) >= 0) {
-            Debug.error("Layer is already added.");
+            Debug.error('Layer is already added.');
             return true;
         }
         return false;
@@ -706,7 +706,7 @@ class LayerComposition extends EventHandler {
     _isSublayerAdded(layer, transparent) {
         for (let i = 0; i < this.layerList.length; i++) {
             if (this.layerList[i] === layer && this.subLayerList[i] === transparent) {
-                Debug.error("Sublayer is already added.");
+                Debug.error('Sublayer is already added.');
                 return true;
             }
         }
@@ -732,7 +732,7 @@ class LayerComposition extends EventHandler {
         this._dirty = true;
         this._dirtyLights = true;
         this._dirtyCameras = true;
-        this.fire("add", layer);
+        this.fire('add', layer);
     }
 
     /**
@@ -755,7 +755,7 @@ class LayerComposition extends EventHandler {
         this._dirty = true;
         this._dirtyLights = true;
         this._dirtyCameras = true;
-        this.fire("add", layer);
+        this.fire('add', layer);
     }
 
     /**
@@ -778,7 +778,7 @@ class LayerComposition extends EventHandler {
             this._dirty = true;
             this._dirtyLights = true;
             this._dirtyCameras = true;
-            this.fire("remove", layer);
+            this.fire('remove', layer);
         }
 
         // update both orders
@@ -804,7 +804,7 @@ class LayerComposition extends EventHandler {
         this._dirty = true;
         this._dirtyLights = true;
         this._dirtyCameras = true;
-        this.fire("add", layer);
+        this.fire('add', layer);
     }
 
     /**
@@ -827,7 +827,7 @@ class LayerComposition extends EventHandler {
         this._dirty = true;
         this._dirtyLights = true;
         this._dirtyCameras = true;
-        this.fire("add", layer);
+        this.fire('add', layer);
     }
 
     /**
@@ -851,7 +851,7 @@ class LayerComposition extends EventHandler {
                 this._dirtyLights = true;
                 this._dirtyCameras = true;
                 if (this.layerList.indexOf(layer) < 0) {
-                    this.fire("remove", layer); // no sublayers left
+                    this.fire('remove', layer); // no sublayers left
                 }
                 return;
             }
@@ -872,7 +872,7 @@ class LayerComposition extends EventHandler {
         this._dirty = true;
         this._dirtyLights = true;
         this._dirtyCameras = true;
-        this.fire("add", layer);
+        this.fire('add', layer);
     }
 
     /**
@@ -894,7 +894,7 @@ class LayerComposition extends EventHandler {
         this._dirty = true;
         this._dirtyLights = true;
         this._dirtyCameras = true;
-        this.fire("add", layer);
+        this.fire('add', layer);
     }
 
     /**
@@ -917,7 +917,7 @@ class LayerComposition extends EventHandler {
                 this._dirtyLights = true;
                 this._dirtyCameras = true;
                 if (this.layerList.indexOf(layer) < 0) {
-                    this.fire("remove", layer); // no sublayers left
+                    this.fire('remove', layer); // no sublayers left
                 }
                 return;
             }

--- a/src/scene/constants.js
+++ b/src/scene/constants.js
@@ -294,12 +294,12 @@ export const SHADOW_COUNT = 6;
  * @ignore
  */
 export const shadowTypeToString = {};
-shadowTypeToString[SHADOW_PCF3] = "PCF3";
-shadowTypeToString[SHADOW_VSM8] = "VSM8";
-shadowTypeToString[SHADOW_VSM16] = "VSM16";
-shadowTypeToString[SHADOW_VSM32] = "VSM32";
-shadowTypeToString[SHADOW_PCF5] = "PCF5";
-shadowTypeToString[SHADOW_PCF1] = "PCF1";
+shadowTypeToString[SHADOW_PCF3] = 'PCF3';
+shadowTypeToString[SHADOW_VSM8] = 'VSM8';
+shadowTypeToString[SHADOW_VSM16] = 'VSM16';
+shadowTypeToString[SHADOW_VSM32] = 'VSM32';
+shadowTypeToString[SHADOW_PCF5] = 'PCF5';
+shadowTypeToString[SHADOW_PCF1] = 'PCF1';
 
 /**
  * Box filter.

--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -1156,7 +1156,7 @@ class GraphNode extends EventHandler {
      */
     addChild(node) {
         if (node._parent !== null)
-            throw new Error("GraphNode is already parented");
+            throw new Error('GraphNode is already parented');
 
         // #if _DEBUG
         this._debugInsertChild(node);
@@ -1207,7 +1207,7 @@ class GraphNode extends EventHandler {
      */
     insertChild(node, index) {
         if (node._parent !== null)
-            throw new Error("GraphNode is already parented");
+            throw new Error('GraphNode is already parented');
 
         // #if _DEBUG
         this._debugInsertChild(node);
@@ -1224,10 +1224,10 @@ class GraphNode extends EventHandler {
      */
     _debugInsertChild(node) {
         if (this === node)
-            throw new Error("GraphNode cannot be a child of itself");
+            throw new Error('GraphNode cannot be a child of itself');
 
         if (this.isDescendantOf(node))
-            throw new Error("GraphNode cannot add an ancestor as a child");
+            throw new Error('GraphNode cannot add an ancestor as a child');
     }
     // #endif
 

--- a/src/scene/immediate/immediate.js
+++ b/src/scene/immediate/immediate.js
@@ -126,7 +126,7 @@ class Immediate {
     getDepthTextureShader() {
         if (!this.depthTextureShader) {
 
-            const gl2 = this.device.webgl2 ? "#define GL2" : "";
+            const gl2 = this.device.webgl2 ? '#define GL2' : '';
             const shaderDefinition = {
                 attributes: {
                     aPosition: SEMANTIC_POSITION

--- a/src/scene/layer.js
+++ b/src/scene/layer.js
@@ -571,7 +571,7 @@ class Layer {
             if (this.onDisable) this.onDisable();
 
         } else if (this._refCounter === 0) {
-            Debug.warn("Trying to decrement layer counter below 0");
+            Debug.warn('Trying to decrement layer counter below 0');
             return;
         }
         this._refCounter--;
@@ -785,8 +785,8 @@ class Layer {
         // order of lights shouldn't matter
         if (this._lights.length > 0) {
             this._lights.sort(sortLights);
-            let str = "";
-            let strStatic = "";
+            let str = '';
+            let strStatic = '';
 
             for (let i = 0; i < this._lights.length; i++) {
                 if (this._lights[i].isStatic) {

--- a/src/scene/light.js
+++ b/src/scene/light.js
@@ -120,7 +120,7 @@ class Light {
         this._cookie = null; // light cookie texture (2D for spot, cubemap for omni)
         this.cookieIntensity = 1;
         this._cookieFalloff = true;
-        this._cookieChannel = "rgb";
+        this._cookieChannel = 'rgb';
         this._cookieTransform = null; // 2d rotation/scale matrix (spot only)
         this._cookieTransformUniform = new Float32Array(4);
         this._cookieOffset = null; // 2d position offset (spot only)

--- a/src/scene/lighting/light-texture-atlas.js
+++ b/src/scene/lighting/light-texture-atlas.js
@@ -123,11 +123,11 @@ class LightTextureAtlas {
     }
 
     allocateUniforms() {
-        this._shadowAtlasTextureId = this.device.scope.resolve("shadowAtlasTexture");
-        this._shadowAtlasParamsId = this.device.scope.resolve("shadowAtlasParams");
+        this._shadowAtlasTextureId = this.device.scope.resolve('shadowAtlasTexture');
+        this._shadowAtlasParamsId = this.device.scope.resolve('shadowAtlasParams');
         this._shadowAtlasParams = new Float32Array(2);
 
-        this._cookieAtlasTextureId = this.device.scope.resolve("cookieAtlasTexture");
+        this._cookieAtlasTextureId = this.device.scope.resolve('cookieAtlasTexture');
     }
 
     updateUniforms() {

--- a/src/scene/lighting/lighting-params.js
+++ b/src/scene/lighting/lighting-params.js
@@ -1,6 +1,6 @@
-import { Vec3 } from "../../math/vec3.js";
-import { math } from "../../math/math.js";
-import { SHADOW_PCF3 } from "../constants.js";
+import { Vec3 } from '../../math/vec3.js';
+import { math } from '../../math/math.js';
+import { SHADOW_PCF3 } from '../constants.js';
 
 class LightingParams {
     constructor(supportsAreaLights, maxTextureSize, dirtyLightsFnc) {

--- a/src/scene/lighting/lights-buffer.js
+++ b/src/scene/lighting/lights-buffer.js
@@ -100,21 +100,21 @@ class LightsBuffer {
     static lightTextureFormat = LightsBuffer.FORMAT_8BIT;
 
     // defines used for unpacking of light textures to allow CPU packing to match the GPU unpacking
-    static shaderDefines = "";
+    static shaderDefines = '';
 
     // creates list of defines specifying texture coordinates for decoding lights
     static initShaderDefines() {
-        const clusterTextureFormat = LightsBuffer.lightTextureFormat === LightsBuffer.FORMAT_FLOAT ? "FLOAT" : "8BIT";
+        const clusterTextureFormat = LightsBuffer.lightTextureFormat === LightsBuffer.FORMAT_FLOAT ? 'FLOAT' : '8BIT';
         LightsBuffer.shaderDefines = `
             \n#define CLUSTER_TEXTURE_${clusterTextureFormat}
-            ${LightsBuffer.buildShaderDefines(TextureIndex8, "CLUSTER_TEXTURE_8_")}
-            ${LightsBuffer.buildShaderDefines(TextureIndexFloat, "CLUSTER_TEXTURE_F_")}
+            ${LightsBuffer.buildShaderDefines(TextureIndex8, 'CLUSTER_TEXTURE_8_')}
+            ${LightsBuffer.buildShaderDefines(TextureIndexFloat, 'CLUSTER_TEXTURE_F_')}
         `;
     }
 
     // converts object with properties to a list of these as an example: "#define CLUSTER_TEXTURE_8_BLAH 1.5"
     static buildShaderDefines(object, prefix) {
-        let str = "";
+        let str = '';
         Object.keys(object).forEach((key) => {
             str += `\n#define ${prefix}${key} ${object[key]}.5`;
         });
@@ -174,14 +174,14 @@ class LightsBuffer {
 
         // 8bit texture - to store data that can fit into 8bits to lower the bandwidth requirements
         this.lights8 = new Uint8ClampedArray(4 * pixelsPerLight8 * this.maxLights);
-        this.lightsTexture8 = LightsBuffer.createTexture(this.device, pixelsPerLight8, this.maxLights, PIXELFORMAT_R8_G8_B8_A8, "LightsTexture8");
-        this._lightsTexture8Id = this.device.scope.resolve("lightsTexture8");
+        this.lightsTexture8 = LightsBuffer.createTexture(this.device, pixelsPerLight8, this.maxLights, PIXELFORMAT_R8_G8_B8_A8, 'LightsTexture8');
+        this._lightsTexture8Id = this.device.scope.resolve('lightsTexture8');
 
         // float texture
         if (pixelsPerLightFloat) {
             this.lightsFloat = new Float32Array(4 * pixelsPerLightFloat * this.maxLights);
-            this.lightsTextureFloat = LightsBuffer.createTexture(this.device, pixelsPerLightFloat, this.maxLights, PIXELFORMAT_RGBA32F, "LightsTextureFloat");
-            this._lightsTextureFloatId = this.device.scope.resolve("lightsTextureFloat");
+            this.lightsTextureFloat = LightsBuffer.createTexture(this.device, pixelsPerLightFloat, this.maxLights, PIXELFORMAT_RGBA32F, 'LightsTextureFloat');
+            this._lightsTextureFloatId = this.device.scope.resolve('lightsTextureFloat');
         } else {
             this.lightsFloat = null;
             this.lightsTextureFloat = null;
@@ -189,7 +189,7 @@ class LightsBuffer {
         }
 
         // inverse sizes for both textures
-        this._lightsTextureInvSizeId = this.device.scope.resolve("lightsTextureInvSize");
+        this._lightsTextureInvSizeId = this.device.scope.resolve('lightsTextureInvSize');
         this._lightsTextureInvSizeData = new Float32Array(4);
         this._lightsTextureInvSizeData[0] = pixelsPerLightFloat ? 1.0 / this.lightsTextureFloat.width : 0;
         this._lightsTextureInvSizeData[1] = pixelsPerLightFloat ? 1.0 / this.lightsTextureFloat.height : 0;
@@ -341,17 +341,17 @@ class LightsBuffer {
     }
 
     addLightDataCookies(data8, index, light) {
-        const isRgb = light._cookieChannel === "rgb";
+        const isRgb = light._cookieChannel === 'rgb';
         data8[index + 0] = Math.floor(light.cookieIntensity * 255);
         data8[index + 1] = isRgb ? 255 : 0;
         // we have two unused bytes here
 
         if (!isRgb) {
             const channel = light._cookieChannel;
-            data8[index + 4] = channel === "rrr" ? 255 : 0;
-            data8[index + 5] = channel === "ggg" ? 255 : 0;
-            data8[index + 6] = channel === "bbb" ? 255 : 0;
-            data8[index + 7] = channel === "aaa" ? 255 : 0;
+            data8[index + 4] = channel === 'rrr' ? 255 : 0;
+            data8[index + 5] = channel === 'ggg' ? 255 : 0;
+            data8[index + 6] = channel === 'bbb' ? 255 : 0;
+            data8[index + 7] = channel === 'aaa' ? 255 : 0;
         }
     }
 

--- a/src/scene/lighting/world-clusters-debug.js
+++ b/src/scene/lighting/world-clusters-debug.js
@@ -1,14 +1,14 @@
-import { Color } from "../../math/color.js";
-import { Mat4 } from "../../math/mat4.js";
-import { Vec3 } from "../../math/vec3.js";
+import { Color } from '../../math/color.js';
+import { Mat4 } from '../../math/mat4.js';
+import { Vec3 } from '../../math/vec3.js';
 
 import { PRIMITIVE_TRIANGLES } from '../../graphics/constants.js';
 
 import { BLEND_ADDITIVEALPHA } from '../../scene/constants.js';
-import { GraphNode } from "../graph-node.js";
-import { Mesh } from "../mesh.js";
-import { MeshInstance } from "../mesh-instance.js";
-import { StandardMaterial } from "../materials/standard-material.js";
+import { GraphNode } from '../graph-node.js';
+import { Mesh } from '../mesh.js';
+import { MeshInstance } from '../mesh-instance.js';
+import { StandardMaterial } from '../materials/standard-material.js';
 
 class WorldClustersDebug {
     static gridPositions = [];
@@ -175,7 +175,7 @@ class WorldClustersDebug {
                 material.depthWrite = false;
                 material.update();
 
-                const node = new GraphNode("WorldClustersDebug");
+                const node = new GraphNode('WorldClustersDebug');
                 node.worldTransform = Mat4.IDENTITY;
                 node._dirtyWorld = node._dirtyNormal = false;
 

--- a/src/scene/lighting/world-clusters.js
+++ b/src/scene/lighting/world-clusters.js
@@ -31,7 +31,7 @@ class ClusterLight {
 class WorldClusters {
     constructor(device) {
         this.device = device;
-        this.name = "Untitled";
+        this.name = 'Untitled';
 
         // number of times a warning was reported
         this.reportCount = 0;
@@ -115,30 +115,30 @@ class WorldClusters {
 
     registerUniforms(device) {
 
-        this._clusterWorldTextureId = device.scope.resolve("clusterWorldTexture");
-        this._clusterPixelsPerCellId = device.scope.resolve("clusterPixelsPerCell");
+        this._clusterWorldTextureId = device.scope.resolve('clusterWorldTexture');
+        this._clusterPixelsPerCellId = device.scope.resolve('clusterPixelsPerCell');
 
-        this._clusterTextureSizeId = device.scope.resolve("clusterTextureSize");
+        this._clusterTextureSizeId = device.scope.resolve('clusterTextureSize');
         this._clusterTextureSizeData = new Float32Array(3);
 
-        this._clusterBoundsMinId = device.scope.resolve("clusterBoundsMin");
+        this._clusterBoundsMinId = device.scope.resolve('clusterBoundsMin');
         this._clusterBoundsMinData = new Float32Array(3);
 
-        this._clusterBoundsDeltaId = device.scope.resolve("clusterBoundsDelta");
+        this._clusterBoundsDeltaId = device.scope.resolve('clusterBoundsDelta');
         this._clusterBoundsDeltaData = new Float32Array(3);
 
-        this._clusterCellsCountByBoundsSizeId = device.scope.resolve("clusterCellsCountByBoundsSize");
+        this._clusterCellsCountByBoundsSizeId = device.scope.resolve('clusterCellsCountByBoundsSize');
         this._clusterCellsCountByBoundsSizeData = new Float32Array(3);
 
-        this._clusterCellsDotId = device.scope.resolve("clusterCellsDot");
+        this._clusterCellsDotId = device.scope.resolve('clusterCellsDot');
         this._clusterCellsDotData = new Float32Array(3);
 
         // number of cells in each direction (vec3)
-        this._clusterCellsMaxId = device.scope.resolve("clusterCellsMax");
+        this._clusterCellsMaxId = device.scope.resolve('clusterCellsMax');
         this._clusterCellsMaxData = new Float32Array(3);
 
         // compression limit 0
-        this._clusterCompressionLimit0Id = device.scope.resolve("clusterCompressionLimit0");
+        this._clusterCompressionLimit0Id = device.scope.resolve('clusterCompressionLimit0');
         this._clusterCompressionLimit0Data = new Float32Array(2);
     }
 
@@ -174,7 +174,7 @@ class WorldClusters {
 
             // if the texture is allowed size
             Debug.assert(width <= maxTextureSize && height <= maxTextureSize,
-                         "Clustered lights parameters cause the texture size to be over the limit, please adjust them.");
+                         'Clustered lights parameters cause the texture size to be over the limit, please adjust them.');
 
             // maximum range of cells
             this._clusterCellsMaxData[0] = cx;
@@ -195,7 +195,7 @@ class WorldClusters {
             this._clusterTextureSizeData[2] = 1.0 / height;
 
             this.releaseClusterTexture();
-            this.clusterTexture = LightsBuffer.createTexture(this.device, width, height, PIXELFORMAT_R8_G8_B8_A8, "ClusterTexture");
+            this.clusterTexture = LightsBuffer.createTexture(this.device, width, height, PIXELFORMAT_R8_G8_B8_A8, 'ClusterTexture');
         }
     }
 
@@ -426,8 +426,8 @@ class WorldClusters {
         if (tooManyLights) {
             const reportLimit = 5;
             if (this.reportCount < reportLimit) {
-                console.warn("Too many lights in light cluster " + this.name + ", please adjust parameters." +
-                (this.reportCount == reportLimit - 1 ? " Giving up on reporting it." : ""));
+                console.warn('Too many lights in light cluster ' + this.name + ', please adjust parameters.' +
+                (this.reportCount == reportLimit - 1 ? ' Giving up on reporting it.' : ''));
                 this.reportCount++;
             }
         }

--- a/src/scene/lightmapper/bake-light-ambient.js
+++ b/src/scene/lightmapper/bake-light-ambient.js
@@ -11,9 +11,9 @@ const _tempPoint = new Vec3();
 class BakeLightAmbient extends BakeLight {
     constructor(scene) {
 
-        const lightEntity = new Entity("AmbientLight");
-        lightEntity.addComponent("light", {
-            type: "directional",
+        const lightEntity = new Entity('AmbientLight');
+        lightEntity.addComponent('light', {
+            type: 'directional',
             affectDynamic: true,
             affectLightmapped: false,
             bake: true,

--- a/src/scene/lightmapper/lightmap-filters.js
+++ b/src/scene/lightmapper/lightmap-filters.js
@@ -8,11 +8,11 @@ const DENOISE_FILTER_SIZE = 15;
 class LightmapFilters {
     constructor(device) {
         this.device = device;
-        this.shaderDilate = createShaderFromCode(device, shaderChunks.fullscreenQuadVS, shaderChunks.dilatePS, "lmDilate");
+        this.shaderDilate = createShaderFromCode(device, shaderChunks.fullscreenQuadVS, shaderChunks.dilatePS, 'lmDilate');
 
-        this.constantTexSource = device.scope.resolve("source");
+        this.constantTexSource = device.scope.resolve('source');
 
-        this.constantPixelOffset = device.scope.resolve("pixelOffset");
+        this.constantPixelOffset = device.scope.resolve('pixelOffset');
         this.pixelOffset = new Float32Array(2);
 
         // denoise is optional and gets created only when needed
@@ -37,11 +37,11 @@ class LightmapFilters {
     prepareDenoise(filterRange, filterSmoothness) {
 
         if (!this.shaderDenoise) {
-            this.shaderDenoise = createShaderFromCode(this.device, shaderChunks.fullscreenQuadVS, shaderChunks.bilateralDeNoisePS, "lmBilateralDeNoise");
+            this.shaderDenoise = createShaderFromCode(this.device, shaderChunks.fullscreenQuadVS, shaderChunks.bilateralDeNoisePS, 'lmBilateralDeNoise');
             this.sigmas = new Float32Array(2);
-            this.constantSigmas = this.device.scope.resolve("sigmas");
-            this.constantKernel = this.device.scope.resolve("kernel[0]");
-            this.bZnorm = this.device.scope.resolve("bZnorm");
+            this.constantSigmas = this.device.scope.resolve('sigmas');
+            this.constantKernel = this.device.scope.resolve('kernel[0]');
+            this.bZnorm = this.device.scope.resolve('bZnorm');
         }
 
         this.sigmas[0] = filterRange;

--- a/src/scene/lightmapper/lightmapper.js
+++ b/src/scene/lightmapper/lightmapper.js
@@ -88,7 +88,7 @@ class Lightmapper {
         this.passMaterials = [];
         this.ambientAOMaterial = null;
 
-        this.fog = "";
+        this.fog = '';
         this.ambientLight = new Color();
 
         // dictionary of spare render targets with color buffer for each used size
@@ -132,7 +132,7 @@ class Lightmapper {
             this.lightmapFilters = new LightmapFilters(device);
 
             // shader related
-            this.constantBakeDir = device.scope.resolve("bakeDir");
+            this.constantBakeDir = device.scope.resolve('bakeDir');
             this.materials = [];
 
             // small black texture
@@ -181,7 +181,7 @@ class Lightmapper {
             lightingParams.maxLightsPerCell = 4;
 
             this.worldClusters = new WorldClusters(device);
-            this.worldClusters.name = "ClusterLightmapper";
+            this.worldClusters.name = 'ClusterLightmapper';
         }
     }
 
@@ -224,7 +224,7 @@ class Lightmapper {
     createMaterialForPass(device, scene, pass, addAmbient) {
         const material = new StandardMaterial();
         material.name = `lmMaterial-pass:${pass}-ambient:${addAmbient}`;
-        material.chunks.transformVS = "#define UV1LAYOUT\n" + shaderChunks.transformVS; // draw UV1
+        material.chunks.transformVS = '#define UV1LAYOUT\n' + shaderChunks.transformVS; // draw UV1
 
         if (pass === PASS_COLOR) {
             let bakeLmEndChunk = shaderChunks.bakeLmEndPS; // encode to RGBM
@@ -244,14 +244,14 @@ class Lightmapper {
             material.chunks.endPS = bakeLmEndChunk;
             material.lightMap = this.blackTex;
         } else {
-            material.chunks.basePS = shaderChunks.basePS + "\nuniform sampler2D texture_dirLightMap;\nuniform float bakeDir;\n";
+            material.chunks.basePS = shaderChunks.basePS + '\nuniform sampler2D texture_dirLightMap;\nuniform float bakeDir;\n';
             material.chunks.endPS = shaderChunks.bakeDirLmEndPS;
         }
 
         // avoid writing unrelated things to alpha
-        material.chunks.outputAlphaPS = "\n";
-        material.chunks.outputAlphaOpaquePS = "\n";
-        material.chunks.outputAlphaPremulPS = "\n";
+        material.chunks.outputAlphaPS = '\n';
+        material.chunks.outputAlphaOpaquePS = '\n';
+        material.chunks.outputAlphaPremulPS = '\n';
         material.cull = CULLFACE_NONE;
         material.forceUv1 = true; // provide data to xformUv1
         material.update();
@@ -556,7 +556,7 @@ class Lightmapper {
 
         }
 
-        DebugGraphics.pushGpuMarker(this.device, "LMBake");
+        DebugGraphics.pushGpuMarker(this.device, 'LMBake');
 
         // bake nodes
         if (bakeNodes.length > 0) {
@@ -614,7 +614,7 @@ class Lightmapper {
 
             // texture and render target for each pass, stored per node
             for (let pass = 0; pass < passCount; pass++) {
-                const tex = this.createTexture(size, TEXTURETYPE_DEFAULT, ("lightmapper_lightmap_" + i));
+                const tex = this.createTexture(size, TEXTURETYPE_DEFAULT, ('lightmapper_lightmap_' + i));
                 LightmapCache.incRef(tex);
                 bakeNode.renderTargets[pass] = new RenderTarget({
                     colorBuffer: tex,
@@ -624,7 +624,7 @@ class Lightmapper {
 
             // single temporary render target of each size
             if (!this.renderTargets.has(size)) {
-                const tex = this.createTexture(size, TEXTURETYPE_DEFAULT, ("lightmapper_temp_lightmap_" + size));
+                const tex = this.createTexture(size, TEXTURETYPE_DEFAULT, ('lightmapper_temp_lightmap_' + size));
                 LightmapCache.incRef(tex);
                 this.renderTargets.set(size, new RenderTarget({
                     colorBuffer: tex,
@@ -987,7 +987,7 @@ class Lightmapper {
             // direction baking is not currently compatible with virtual lights, as we end up with no valid direction in lights penumbra
             if (passCount > 1 && numVirtualLights > 1 && bakeLight.light.bakeDir) {
                 numVirtualLights = 1;
-                Debug.warn("Lightmapper's BAKE_COLORDIR mode is not compatible with Light's bakeNumSamples larger than one. Forcing it to one.");
+                Debug.warn('Lightmapper\'s BAKE_COLORDIR mode is not compatible with Light\'s bakeNumSamples larger than one. Forcing it to one.');
             }
 
             for (let virtualLightIndex = 0; virtualLightIndex < numVirtualLights; virtualLightIndex++) {

--- a/src/scene/materials/material.js
+++ b/src/scene/materials/material.js
@@ -13,7 +13,7 @@ import {
     BLEND_MULTIPLICATIVE, BLEND_ADDITIVEALPHA, BLEND_MULTIPLICATIVE2X, BLEND_SCREEN,
     BLEND_MIN, BLEND_MAX
 } from '../constants.js';
-import { Debug } from "../../core/debug.js";
+import { Debug } from '../../core/debug.js';
 import { getDefaultMaterial } from './default-material.js';
 
 /** @typedef {import('../../graphics/texture.js').Texture} Texture */
@@ -118,7 +118,7 @@ class Material {
      * Create a new Material instance.
      */
     constructor() {
-        this.name = "Untitled";
+        this.name = 'Untitled';
         this.id = id++;
 
         this._shader = null;

--- a/src/scene/materials/standard-material-options-builder.js
+++ b/src/scene/materials/standard-material-options-builder.js
@@ -66,8 +66,8 @@ class StandardMaterialOptionsBuilder {
     _updateSharedOptions(options, scene, stdMat, objDefs, pass) {
         options.pass = pass;
         options.alphaTest = stdMat.alphaTest > 0;
-        options.forceFragmentPrecision = stdMat.forceFragmentPrecision || "";
-        options.chunks = stdMat.chunks || "";
+        options.forceFragmentPrecision = stdMat.forceFragmentPrecision || '';
+        options.chunks = stdMat.chunks || '';
         options.blendType = stdMat.blendType;
         options.forceUv1 = stdMat.forceUv1;
         options.separateAmbient = false;    // store ambient light color in separate variable, instead of adding it to diffuse directly
@@ -176,7 +176,7 @@ class StandardMaterialOptionsBuilder {
     }
 
     _updateEnvOptions(options, device, stdMat, scene) {
-        options.fog = stdMat.useFog ? scene.fog : "none";
+        options.fog = stdMat.useFog ? scene.fog : 'none';
         options.gamma = stdMat.useGammaTonemap ? scene.gammaCorrection : GAMMA_NONE;
         options.toneMap = stdMat.useGammaTonemap ? scene.toneMapping : -1;
         options.useRgbm = (stdMat.emissiveMap && stdMat.emissiveMap.type === TEXTURETYPE_RGBM) || (stdMat.lightMap && stdMat.lightMap.type === TEXTURETYPE_RGBM);
@@ -227,7 +227,7 @@ class StandardMaterialOptionsBuilder {
 
     _updateLightOptions(options, stdMat, objDefs, sortedLights, staticLightList) {
         options.lightMap = false;
-        options.lightMapChannel = "";
+        options.lightMapChannel = '';
         options.lightMapUv = 0;
         options.lightMapTransform = 0;
         options.lightMapWithoutAmbient = false;
@@ -239,7 +239,7 @@ class StandardMaterialOptionsBuilder {
             if ((objDefs & SHADERDEF_LM) !== 0) {
                 options.lightMapFormat = 1; // rgbm
                 options.lightMap = true;
-                options.lightMapChannel = "rgb";
+                options.lightMapChannel = 'rgb';
                 options.lightMapUv = 1;
                 options.lightMapTransform = 0;
                 options.lightMapWithoutAmbient = !stdMat.lightMap;
@@ -278,29 +278,29 @@ class StandardMaterialOptionsBuilder {
     }
 
     _updateTexOptions(options, stdMat, p, hasUv0, hasUv1, hasVcolor, minimalOptions) {
-        const mname = p + "Map";
-        const vname = p + "VertexColor";
-        const vcname = p + "VertexColorChannel";
-        const cname = mname + "Channel";
-        const tname = mname + "Transform";
-        const uname = mname + "Uv";
+        const mname = p + 'Map';
+        const vname = p + 'VertexColor';
+        const vcname = p + 'VertexColorChannel';
+        const cname = mname + 'Channel';
+        const tname = mname + 'Transform';
+        const uname = mname + 'Uv';
 
         // Avoid overriding previous lightMap properties
-        if (p !== "light") {
+        if (p !== 'light') {
             options[mname] = false;
-            options[cname] = "";
+            options[cname] = '';
             options[tname] = 0;
             options[uname] = 0;
         }
         options[vname] = false;
-        options[vcname] = "";
+        options[vcname] = '';
 
-        const isOpacity = p === "opacity";
+        const isOpacity = p === 'opacity';
         if (isOpacity && stdMat.blendType === BLEND_NONE && stdMat.alphaTest === 0.0 && !stdMat.alphaToCoverage)
             return;
 
         if (!minimalOptions || isOpacity) {
-            if (p !== "height" && stdMat[vname]) {
+            if (p !== 'height' && stdMat[vname]) {
                 if (hasVcolor) {
                     options[vname] = stdMat[vname];
                     options[vcname] = stdMat[vcname];

--- a/src/scene/materials/standard-material-validator.js
+++ b/src/scene/materials/standard-material-validator.js
@@ -80,7 +80,7 @@ class StandardMaterialValidator {
 
         const TYPES = standardMaterialParameterTypes;
 
-        const pathMapping = (data.mappingFormat === "path");
+        const pathMapping = (data.mappingFormat === 'path');
 
         for (const key in data) {
             const type = TYPES[key];
@@ -91,8 +91,8 @@ class StandardMaterialValidator {
                 continue;
             }
 
-            if (type.startsWith("enum")) {
-                const enumType = type.split(":")[1];
+            if (type.startsWith('enum')) {
+                const enumType = type.split(':')[1];
                 if (this.enumValidators[enumType]) {
                     if (!this.enumValidators[enumType](data[key])) {
                         this.setInvalid(key, data);
@@ -163,7 +163,7 @@ class StandardMaterialValidator {
                 }
 
             } else {
-                console.error("Unknown material type: " + type);
+                console.error('Unknown material type: ' + type);
             }
         }
 

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -571,12 +571,12 @@ class StandardMaterial extends Material {
     }
 
     _updateMap(p) {
-        const mname = p + "Map";
+        const mname = p + 'Map';
         const map = this[mname];
         if (map) {
-            this._setParameter("texture_" + mname, map);
+            this._setParameter('texture_' + mname, map);
 
-            const tname = mname + "Transform";
+            const tname = mname + 'Transform';
             const uniform = this.getUniform(tname);
             if (uniform) {
                 this._setParameters(uniform);
@@ -630,7 +630,7 @@ class StandardMaterial extends Material {
             this._setParameter('material_clearCoatBumpiness', this.clearCoatBumpiness);
         }
 
-        this._setParameter("material_shininess", getUniform('shininess'));
+        this._setParameter('material_shininess', getUniform('shininess'));
 
         if (!this.emissiveMap || this.emissiveTint) {
             this._setParameter('material_emissive', getUniform('emissive'));
@@ -655,7 +655,7 @@ class StandardMaterial extends Material {
         }
 
         if (this.cubeMapProjection === CUBEPROJ_BOX) {
-            this._setParameter(getUniform("cubeMapProjectionBox"));
+            this._setParameter(getUniform('cubeMapProjectionBox'));
         }
 
         for (const p in _matTex2D) {
@@ -844,7 +844,7 @@ function _defineTex2D(name, uv, channels, defChannel, vertexColor, detailMode) {
     if (channels > 0) {
         defineProp({
             name: `${name}MapChannel`,
-            defaultValue: defChannel ? defChannel : (channels > 1 ? "rgb" : "g")
+            defaultValue: defChannel ? defChannel : (channels > 1 ? 'rgb' : 'g')
         });
     }
 
@@ -857,7 +857,7 @@ function _defineTex2D(name, uv, channels, defChannel, vertexColor, detailMode) {
         if (channels > 0) {
             defineProp({
                 name: `${name}VertexColorChannel`,
-                defaultValue: defChannel ? defChannel : (channels > 1 ? "rgb" : "g")
+                defaultValue: defChannel ? defChannel : (channels > 1 ? 'rgb' : 'g')
             });
         }
     }
@@ -981,41 +981,41 @@ function _defineFlag(name, defaultValue) {
 }
 
 function _defineMaterialProps() {
-    _defineColor("ambient", new Color(0.7, 0.7, 0.7));
-    _defineColor("diffuse", new Color(1, 1, 1));
-    _defineColor("specular", new Color(0, 0, 0));
-    _defineColor("emissive", new Color(0, 0, 0));
-    _defineFloat("emissiveIntensity", 1);
+    _defineColor('ambient', new Color(0.7, 0.7, 0.7));
+    _defineColor('diffuse', new Color(1, 1, 1));
+    _defineColor('specular', new Color(0, 0, 0));
+    _defineColor('emissive', new Color(0, 0, 0));
+    _defineFloat('emissiveIntensity', 1);
 
-    _defineFloat("shininess", 25, (material, device, scene) => {
+    _defineFloat('shininess', 25, (material, device, scene) => {
         // Shininess is 0-100 value which is actually a 0-1 glossiness value.
         return material.shadingModel === SPECULAR_PHONG ?
             // legacy: expand back to specular power
             Math.pow(2, material.shininess * 0.01 * 11) :
             material.shininess * 0.01;
     });
-    _defineFloat("heightMapFactor", 1, (material, device, scene) => {
+    _defineFloat('heightMapFactor', 1, (material, device, scene) => {
         return material.heightMapFactor * 0.025;
     });
-    _defineFloat("opacity", 1);
-    _defineFloat("alphaFade", 1);
-    _defineFloat("alphaTest", 0);       // NOTE: overwrites Material.alphaTest
-    _defineFloat("bumpiness", 1);
-    _defineFloat("normalDetailMapBumpiness", 1);
-    _defineFloat("reflectivity", 1);
-    _defineFloat("occludeSpecularIntensity", 1);
-    _defineFloat("refraction", 0);
-    _defineFloat("refractionIndex", 1.0 / 1.5); // approx. (air ior / glass ior)
-    _defineFloat("metalness", 1);
-    _defineFloat("anisotropy", 0);
-    _defineFloat("clearCoat", 0);
-    _defineFloat("clearCoatGlossiness", 1);
-    _defineFloat("clearCoatBumpiness", 1);
-    _defineFloat("aoUvSet", 0, null); // legacy
+    _defineFloat('opacity', 1);
+    _defineFloat('alphaFade', 1);
+    _defineFloat('alphaTest', 0);       // NOTE: overwrites Material.alphaTest
+    _defineFloat('bumpiness', 1);
+    _defineFloat('normalDetailMapBumpiness', 1);
+    _defineFloat('reflectivity', 1);
+    _defineFloat('occludeSpecularIntensity', 1);
+    _defineFloat('refraction', 0);
+    _defineFloat('refractionIndex', 1.0 / 1.5); // approx. (air ior / glass ior)
+    _defineFloat('metalness', 1);
+    _defineFloat('anisotropy', 0);
+    _defineFloat('clearCoat', 0);
+    _defineFloat('clearCoatGlossiness', 1);
+    _defineFloat('clearCoatBumpiness', 1);
+    _defineFloat('aoUvSet', 0, null); // legacy
 
-    _defineObject("ambientSH");
+    _defineObject('ambientSH');
 
-    _defineObject("cubeMapProjectionBox", (material, device, scene) => {
+    _defineObject('cubeMapProjectionBox', (material, device, scene) => {
         const uniform = material._allocUniform('cubeMapProjectionBox', () => {
             return [{
                 name: 'envBoxMin',
@@ -1041,53 +1041,53 @@ function _defineMaterialProps() {
         return uniform;
     });
 
-    _defineFlag("ambientTint", false);
-    _defineFlag("diffuseTint", false);
-    _defineFlag("specularTint", false);
-    _defineFlag("emissiveTint", false);
-    _defineFlag("fastTbn", false);
-    _defineFlag("specularAntialias", false);
-    _defineFlag("useMetalness", false);
-    _defineFlag("enableGGXSpecular", false);
-    _defineFlag("occludeDirect", false);
-    _defineFlag("normalizeNormalMap", true);
-    _defineFlag("conserveEnergy", true);
-    _defineFlag("opacityFadesSpecular", true);
-    _defineFlag("occludeSpecular", SPECOCC_AO);
-    _defineFlag("shadingModel", SPECULAR_BLINN);
-    _defineFlag("fresnelModel", FRESNEL_SCHLICK); // NOTE: this has been made to match the default shading model (to fix a bug)
-    _defineFlag("cubeMapProjection", CUBEPROJ_NONE);
-    _defineFlag("customFragmentShader", null);
-    _defineFlag("forceFragmentPrecision", null);
-    _defineFlag("useFog", true);
-    _defineFlag("useLighting", true);
-    _defineFlag("useGammaTonemap", true);
-    _defineFlag("useSkybox", true);
-    _defineFlag("forceUv1", false);
-    _defineFlag("pixelSnap", false);
-    _defineFlag("twoSidedLighting", false);
-    _defineFlag("nineSlicedMode", undefined); // NOTE: this used to be SPRITE_RENDERMODE_SLICED but was undefined pre-Rollup
+    _defineFlag('ambientTint', false);
+    _defineFlag('diffuseTint', false);
+    _defineFlag('specularTint', false);
+    _defineFlag('emissiveTint', false);
+    _defineFlag('fastTbn', false);
+    _defineFlag('specularAntialias', false);
+    _defineFlag('useMetalness', false);
+    _defineFlag('enableGGXSpecular', false);
+    _defineFlag('occludeDirect', false);
+    _defineFlag('normalizeNormalMap', true);
+    _defineFlag('conserveEnergy', true);
+    _defineFlag('opacityFadesSpecular', true);
+    _defineFlag('occludeSpecular', SPECOCC_AO);
+    _defineFlag('shadingModel', SPECULAR_BLINN);
+    _defineFlag('fresnelModel', FRESNEL_SCHLICK); // NOTE: this has been made to match the default shading model (to fix a bug)
+    _defineFlag('cubeMapProjection', CUBEPROJ_NONE);
+    _defineFlag('customFragmentShader', null);
+    _defineFlag('forceFragmentPrecision', null);
+    _defineFlag('useFog', true);
+    _defineFlag('useLighting', true);
+    _defineFlag('useGammaTonemap', true);
+    _defineFlag('useSkybox', true);
+    _defineFlag('forceUv1', false);
+    _defineFlag('pixelSnap', false);
+    _defineFlag('twoSidedLighting', false);
+    _defineFlag('nineSlicedMode', undefined); // NOTE: this used to be SPRITE_RENDERMODE_SLICED but was undefined pre-Rollup
 
-    _defineTex2D("diffuse", 0, 3, "", true);
-    _defineTex2D("specular", 0, 3, "", true);
-    _defineTex2D("emissive", 0, 3, "", true);
-    _defineTex2D("normal", 0, -1, "", false);
-    _defineTex2D("metalness", 0, 1, "", true);
-    _defineTex2D("gloss", 0, 1, "", true);
-    _defineTex2D("opacity", 0, 1, "a", true);
-    _defineTex2D("height", 0, 1, "", false);
-    _defineTex2D("ao", 0, 1, "", true);
-    _defineTex2D("light", 1, 3, "", true);
-    _defineTex2D("msdf", 0, 3, "", false);
-    _defineTex2D("diffuseDetail", 0, 3, "", false, true);
-    _defineTex2D("normalDetail", 0, -1, "", false);
-    _defineTex2D("clearCoat", 0, 1, "", true);
-    _defineTex2D("clearCoatGloss", 0, 1, "", true);
-    _defineTex2D("clearCoatNormal", 0, -1, "", false);
+    _defineTex2D('diffuse', 0, 3, '', true);
+    _defineTex2D('specular', 0, 3, '', true);
+    _defineTex2D('emissive', 0, 3, '', true);
+    _defineTex2D('normal', 0, -1, '', false);
+    _defineTex2D('metalness', 0, 1, '', true);
+    _defineTex2D('gloss', 0, 1, '', true);
+    _defineTex2D('opacity', 0, 1, 'a', true);
+    _defineTex2D('height', 0, 1, '', false);
+    _defineTex2D('ao', 0, 1, '', true);
+    _defineTex2D('light', 1, 3, '', true);
+    _defineTex2D('msdf', 0, 3, '', false);
+    _defineTex2D('diffuseDetail', 0, 3, '', false, true);
+    _defineTex2D('normalDetail', 0, -1, '', false);
+    _defineTex2D('clearCoat', 0, 1, '', true);
+    _defineTex2D('clearCoatGloss', 0, 1, '', true);
+    _defineTex2D('clearCoatNormal', 0, -1, '', false);
 
-    _defineObject("cubeMap");
-    _defineObject("sphereMap");
-    _defineObject("envAtlas");
+    _defineObject('cubeMap');
+    _defineObject('sphereMap');
+    _defineObject('envAtlas');
 
     // prefiltered cubemap getter
     const getterFunc = function () {
@@ -1128,7 +1128,7 @@ function _defineMaterialProps() {
 
     const empty = [null, null, null, null, null, null];
 
-    definePropInternal("prefilteredCubemaps", () => empty.slice(), setterFunc, getterFunc);
+    definePropInternal('prefilteredCubemaps', () => empty.slice(), setterFunc, getterFunc);
 }
 
 _defineMaterialProps();

--- a/src/scene/mesh-instance.js
+++ b/src/scene/mesh-instance.js
@@ -574,7 +574,7 @@ class MeshInstance {
     }
 
     // shader uniform names for lightmaps
-    static lightmapParamNames = ["texture_lightMap", "texture_dirLightMap"];
+    static lightmapParamNames = ['texture_lightMap', 'texture_dirLightMap'];
 
     // generates wireframes for an array of mesh instances
     static _prepareRenderStyleForArray(meshInstances, renderStyle) {

--- a/src/scene/morph-instance.js
+++ b/src/scene/morph-instance.js
@@ -79,11 +79,11 @@ class MorphInstance {
             };
 
             if (morph.morphPositions) {
-                this.rtPositions = createRT("MorphRTPos", "texturePositions");
+                this.rtPositions = createRT('MorphRTPos', 'texturePositions');
             }
 
             if (morph.morphNormals) {
-                this.rtNormals = createRT("MorphRTNrm", "textureNormals");
+                this.rtNormals = createRT('MorphRTNrm', 'textureNormals');
             }
 
             // texture params
@@ -92,10 +92,10 @@ class MorphInstance {
 
             // resolve possible texture names
             for (let i = 0; i < this.maxSubmitCount; i++) {
-                this["morphBlendTex" + i] = this.device.scope.resolve("morphBlendTex" + i);
+                this['morphBlendTex' + i] = this.device.scope.resolve('morphBlendTex' + i);
             }
 
-            this.morphFactor = this.device.scope.resolve("morphFactor[0]");
+            this.morphFactor = this.device.scope.resolve('morphFactor[0]');
 
             // true indicates render target textures are full of zeros to avoid rendering to them when all weights are zero
             this.zeroTextures = false;
@@ -238,7 +238,7 @@ class MorphInstance {
         // if shader is not in cache, generate one
         if (!shader) {
             const fs = this._getFragmentShader(count);
-            shader = createShaderFromCode(this.device, textureMorphVertexShader, fs, "textureMorph" + count);
+            shader = createShaderFromCode(this.device, textureMorphVertexShader, fs, 'textureMorph' + count);
             this.shaderCache[count] = shader;
         }
 
@@ -277,7 +277,7 @@ class MorphInstance {
             if (tex) {
 
                 // texture
-                this["morphBlendTex" + usedCount].setValue(tex);
+                this['morphBlendTex' + usedCount].setValue(tex);
 
                 // weight
                 this._shaderMorphWeights[usedCount] = activeTarget.weight;
@@ -303,7 +303,7 @@ class MorphInstance {
 
         const device = this.device;
 
-        DebugGraphics.pushGpuMarker(device, "MorphUpdate");
+        DebugGraphics.pushGpuMarker(device, 'MorphUpdate');
 
         // update textures if active targets, or no active targets and textures need to be cleared
         if (this._activeTargets.length > 0 || !this.zeroTextures) {

--- a/src/scene/morph.js
+++ b/src/scene/morph.js
@@ -198,7 +198,7 @@ class Morph extends RefCountedObject {
             // create texture and assign it to target
             const target = deltaInfos[i].target;
             const format = this._textureFormat === Morph.FORMAT_FLOAT ? PIXELFORMAT_RGB32F : PIXELFORMAT_RGBA16F;
-            target._setTexture(deltaInfos[i].name, this._createTexture("MorphTarget", format, packedDeltas));
+            target._setTexture(deltaInfos[i].name, this._createTexture('MorphTarget', format, packedDeltas));
         }
 
         // create vertex stream with vertex_id used to map vertex to texture

--- a/src/scene/particle-system/gpu-updater.js
+++ b/src/scene/particle-system/gpu-updater.js
@@ -26,43 +26,43 @@ class ParticleGPUUpdater {
         this.inBoundsSizeUniform = new Float32Array(3);
         this.inBoundsCenterUniform = new Float32Array(3);
 
-        this.constantParticleTexIN = gd.scope.resolve("particleTexIN");
-        this.constantParticleTexOUT = gd.scope.resolve("particleTexOUT");
-        this.constantEmitterPos = gd.scope.resolve("emitterPos");
-        this.constantEmitterScale = gd.scope.resolve("emitterScale");
-        this.constantSpawnBounds = gd.scope.resolve("spawnBounds");
-        this.constantSpawnPosInnerRatio = gd.scope.resolve("spawnPosInnerRatio");
-        this.constantSpawnBoundsSphere = gd.scope.resolve("spawnBoundsSphere");
-        this.constantSpawnBoundsSphereInnerRatio = gd.scope.resolve("spawnBoundsSphereInnerRatio");
-        this.constantInitialVelocity = gd.scope.resolve("initialVelocity");
-        this.constantFrameRandom = gd.scope.resolve("frameRandom");
-        this.constantDelta = gd.scope.resolve("delta");
-        this.constantRate = gd.scope.resolve("rate");
-        this.constantRateDiv = gd.scope.resolve("rateDiv");
-        this.constantLifetime = gd.scope.resolve("lifetime");
-        this.constantGraphSampleSize = gd.scope.resolve("graphSampleSize");
-        this.constantGraphNumSamples = gd.scope.resolve("graphNumSamples");
-        this.constantInternalTex0 = gd.scope.resolve("internalTex0");
-        this.constantInternalTex1 = gd.scope.resolve("internalTex1");
-        this.constantInternalTex2 = gd.scope.resolve("internalTex2");
-        this.constantInternalTex3 = gd.scope.resolve("internalTex3");
-        this.constantEmitterMatrix = gd.scope.resolve("emitterMatrix");
-        this.constantEmitterMatrixInv = gd.scope.resolve("emitterMatrixInv");
-        this.constantNumParticles = gd.scope.resolve("numParticles");
-        this.constantNumParticlesPot = gd.scope.resolve("numParticlesPot");
-        this.constantLocalVelocityDivMult = gd.scope.resolve("localVelocityDivMult");
-        this.constantVelocityDivMult = gd.scope.resolve("velocityDivMult");
-        this.constantRotSpeedDivMult = gd.scope.resolve("rotSpeedDivMult");
-        this.constantSeed = gd.scope.resolve("seed");
-        this.constantStartAngle = gd.scope.resolve("startAngle");
-        this.constantStartAngle2 = gd.scope.resolve("startAngle2");
-        this.constantOutBoundsMul = gd.scope.resolve("outBoundsMul");
-        this.constantOutBoundsAdd = gd.scope.resolve("outBoundsAdd");
-        this.constantInBoundsSize = gd.scope.resolve("inBoundsSize");
-        this.constantInBoundsCenter = gd.scope.resolve("inBoundsCenter");
-        this.constantMaxVel = gd.scope.resolve("maxVel");
-        this.constantFaceTangent = gd.scope.resolve("faceTangent");
-        this.constantFaceBinorm = gd.scope.resolve("faceBinorm");
+        this.constantParticleTexIN = gd.scope.resolve('particleTexIN');
+        this.constantParticleTexOUT = gd.scope.resolve('particleTexOUT');
+        this.constantEmitterPos = gd.scope.resolve('emitterPos');
+        this.constantEmitterScale = gd.scope.resolve('emitterScale');
+        this.constantSpawnBounds = gd.scope.resolve('spawnBounds');
+        this.constantSpawnPosInnerRatio = gd.scope.resolve('spawnPosInnerRatio');
+        this.constantSpawnBoundsSphere = gd.scope.resolve('spawnBoundsSphere');
+        this.constantSpawnBoundsSphereInnerRatio = gd.scope.resolve('spawnBoundsSphereInnerRatio');
+        this.constantInitialVelocity = gd.scope.resolve('initialVelocity');
+        this.constantFrameRandom = gd.scope.resolve('frameRandom');
+        this.constantDelta = gd.scope.resolve('delta');
+        this.constantRate = gd.scope.resolve('rate');
+        this.constantRateDiv = gd.scope.resolve('rateDiv');
+        this.constantLifetime = gd.scope.resolve('lifetime');
+        this.constantGraphSampleSize = gd.scope.resolve('graphSampleSize');
+        this.constantGraphNumSamples = gd.scope.resolve('graphNumSamples');
+        this.constantInternalTex0 = gd.scope.resolve('internalTex0');
+        this.constantInternalTex1 = gd.scope.resolve('internalTex1');
+        this.constantInternalTex2 = gd.scope.resolve('internalTex2');
+        this.constantInternalTex3 = gd.scope.resolve('internalTex3');
+        this.constantEmitterMatrix = gd.scope.resolve('emitterMatrix');
+        this.constantEmitterMatrixInv = gd.scope.resolve('emitterMatrixInv');
+        this.constantNumParticles = gd.scope.resolve('numParticles');
+        this.constantNumParticlesPot = gd.scope.resolve('numParticlesPot');
+        this.constantLocalVelocityDivMult = gd.scope.resolve('localVelocityDivMult');
+        this.constantVelocityDivMult = gd.scope.resolve('velocityDivMult');
+        this.constantRotSpeedDivMult = gd.scope.resolve('rotSpeedDivMult');
+        this.constantSeed = gd.scope.resolve('seed');
+        this.constantStartAngle = gd.scope.resolve('startAngle');
+        this.constantStartAngle2 = gd.scope.resolve('startAngle2');
+        this.constantOutBoundsMul = gd.scope.resolve('outBoundsMul');
+        this.constantOutBoundsAdd = gd.scope.resolve('outBoundsAdd');
+        this.constantInBoundsSize = gd.scope.resolve('inBoundsSize');
+        this.constantInBoundsCenter = gd.scope.resolve('inBoundsCenter');
+        this.constantMaxVel = gd.scope.resolve('maxVel');
+        this.constantFaceTangent = gd.scope.resolve('faceTangent');
+        this.constantFaceBinorm = gd.scope.resolve('faceBinorm');
     }
 
     _setInputBounds() {
@@ -85,7 +85,7 @@ class ParticleGPUUpdater {
     // This shouldn't change emitter state, only read from it
     update(device, spawnMatrix, extentsInnerRatioUniform, delta, isOnStop) {
 
-        DebugGraphics.pushGpuMarker(device, "ParticleGPU");
+        DebugGraphics.pushGpuMarker(device, 'ParticleGPU');
 
         const emitter = this._emitter;
 
@@ -177,8 +177,8 @@ class ParticleGPUUpdater {
 
         // this.constantParticleTexOUT.setValue(texOUT);
 
-        emitter.material.setParameter("particleTexOUT", texIN);// OUT);
-        emitter.material.setParameter("particleTexIN", texOUT);// IN);
+        emitter.material.setParameter('particleTexOUT', texIN);// OUT);
+        emitter.material.setParameter('particleTexIN', texOUT);// IN);
         emitter.beenReset = false;
 
         emitter.swapTex = !emitter.swapTex;

--- a/src/scene/particle-system/particle-emitter.js
+++ b/src/scene/particle-system/particle-emitter.js
@@ -69,7 +69,7 @@ function _createTexture(device, width, height, pixelData, format = PIXELFORMAT_R
         addressU: ADDRESS_CLAMP_TO_EDGE,
         addressV: ADDRESS_CLAMP_TO_EDGE
     });
-    texture.name = "PSTexture";
+    texture.name = 'PSTexture';
 
     const pixels = texture.lock();
 
@@ -229,90 +229,90 @@ class ParticleEmitter {
         // Global system parameters
         setPropertyTarget = this;
         setPropertyOptions = options;
-        setProperty("numParticles", 1);                          // Amount of particles allocated (max particles = max GL texture width at this moment)
+        setProperty('numParticles', 1);                          // Amount of particles allocated (max particles = max GL texture width at this moment)
 
         if (this.numParticles > graphicsDevice.maxTextureSize) {
             Debug.warn(`WARNING: can't create more than ${graphicsDevice.maxTextureSize} particles on this device.`);
             this.numParticles = graphicsDevice.maxTextureSize;
         }
 
-        setProperty("rate", 1);                                  // Emission rate
-        setProperty("rate2", this.rate);
-        setProperty("lifetime", 50);                             // Particle lifetime
-        setProperty("emitterExtents", new Vec3(0, 0, 0));        // Spawn point divergence
-        setProperty("emitterExtentsInner", new Vec3(0, 0, 0));   // Volume inside emitterExtents to exclude from regeneration
-        setProperty("emitterRadius", 0);
-        setProperty("emitterRadiusInner", 0);                       // Same as ExtentsInner but for spherical volume
-        setProperty("emitterShape", EMITTERSHAPE_BOX);
-        setProperty("initialVelocity", 1);
-        setProperty("wrap", false);
-        setProperty("localSpace", false);
-        setProperty("screenSpace", false);
-        setProperty("wrapBounds", null);
-        setProperty("colorMap", this.defaultParamTexture);
-        setProperty("normalMap", null);
-        setProperty("loop", true);
-        setProperty("preWarm", false);
-        setProperty("sort", PARTICLESORT_NONE); // Sorting mode: 0 = none, 1 = by distance, 2 = by life, 3 = by -life;  Forces CPU mode if not 0
-        setProperty("mode", PARTICLEMODE_GPU);
-        setProperty("scene", null);
-        setProperty("lighting", false);
-        setProperty("halfLambert", false);
-        setProperty("intensity", 1.0);
-        setProperty("stretch", 0.0);
-        setProperty("alignToMotion", false);
-        setProperty("depthSoftening", 0);
-        setProperty("mesh", null);                              // Mesh to be used as particle. Vertex buffer is supposed to hold vertex position in first 3 floats of each vertex
+        setProperty('rate', 1);                                  // Emission rate
+        setProperty('rate2', this.rate);
+        setProperty('lifetime', 50);                             // Particle lifetime
+        setProperty('emitterExtents', new Vec3(0, 0, 0));        // Spawn point divergence
+        setProperty('emitterExtentsInner', new Vec3(0, 0, 0));   // Volume inside emitterExtents to exclude from regeneration
+        setProperty('emitterRadius', 0);
+        setProperty('emitterRadiusInner', 0);                       // Same as ExtentsInner but for spherical volume
+        setProperty('emitterShape', EMITTERSHAPE_BOX);
+        setProperty('initialVelocity', 1);
+        setProperty('wrap', false);
+        setProperty('localSpace', false);
+        setProperty('screenSpace', false);
+        setProperty('wrapBounds', null);
+        setProperty('colorMap', this.defaultParamTexture);
+        setProperty('normalMap', null);
+        setProperty('loop', true);
+        setProperty('preWarm', false);
+        setProperty('sort', PARTICLESORT_NONE); // Sorting mode: 0 = none, 1 = by distance, 2 = by life, 3 = by -life;  Forces CPU mode if not 0
+        setProperty('mode', PARTICLEMODE_GPU);
+        setProperty('scene', null);
+        setProperty('lighting', false);
+        setProperty('halfLambert', false);
+        setProperty('intensity', 1.0);
+        setProperty('stretch', 0.0);
+        setProperty('alignToMotion', false);
+        setProperty('depthSoftening', 0);
+        setProperty('mesh', null);                              // Mesh to be used as particle. Vertex buffer is supposed to hold vertex position in first 3 floats of each vertex
                                                                 // Leave undefined to use simple quads
-        setProperty("particleNormal", new Vec3(0, 1, 0));
-        setProperty("orientation", PARTICLEORIENTATION_SCREEN);
+        setProperty('particleNormal', new Vec3(0, 1, 0));
+        setProperty('orientation', PARTICLEORIENTATION_SCREEN);
 
-        setProperty("depthWrite", false);
-        setProperty("noFog", false);
-        setProperty("blendType", BLEND_NORMAL);
-        setProperty("node", null);
-        setProperty("startAngle", 0);
-        setProperty("startAngle2", this.startAngle);
+        setProperty('depthWrite', false);
+        setProperty('noFog', false);
+        setProperty('blendType', BLEND_NORMAL);
+        setProperty('node', null);
+        setProperty('startAngle', 0);
+        setProperty('startAngle2', this.startAngle);
 
-        setProperty("animTilesX", 1);
-        setProperty("animTilesY", 1);
-        setProperty("animStartFrame", 0);
-        setProperty("animNumFrames", 1);
-        setProperty("animNumAnimations", 1);
-        setProperty("animIndex", 0);
-        setProperty("randomizeAnimIndex", false);
-        setProperty("animSpeed", 1);
-        setProperty("animLoop", true);
+        setProperty('animTilesX', 1);
+        setProperty('animTilesY', 1);
+        setProperty('animStartFrame', 0);
+        setProperty('animNumFrames', 1);
+        setProperty('animNumAnimations', 1);
+        setProperty('animIndex', 0);
+        setProperty('randomizeAnimIndex', false);
+        setProperty('animSpeed', 1);
+        setProperty('animLoop', true);
 
         this._gpuUpdater = new ParticleGPUUpdater(this, gd);
         this._cpuUpdater = new ParticleCPUUpdater(this);
 
-        this.constantLightCube = gd.scope.resolve("lightCube[0]");
+        this.constantLightCube = gd.scope.resolve('lightCube[0]');
         this.emitterPosUniform = new Float32Array(3);
         this.wrapBoundsUniform = new Float32Array(3);
         this.emitterScaleUniform = new Float32Array([1, 1, 1]);
 
         // Time-dependent parameters
-        setProperty("colorGraph", default1Curve3);
-        setProperty("colorGraph2", this.colorGraph);
+        setProperty('colorGraph', default1Curve3);
+        setProperty('colorGraph2', this.colorGraph);
 
-        setProperty("scaleGraph", default1Curve);
-        setProperty("scaleGraph2", this.scaleGraph);
+        setProperty('scaleGraph', default1Curve);
+        setProperty('scaleGraph2', this.scaleGraph);
 
-        setProperty("alphaGraph", default1Curve);
-        setProperty("alphaGraph2", this.alphaGraph);
+        setProperty('alphaGraph', default1Curve);
+        setProperty('alphaGraph2', this.alphaGraph);
 
-        setProperty("localVelocityGraph", default0Curve3);
-        setProperty("localVelocityGraph2", this.localVelocityGraph);
+        setProperty('localVelocityGraph', default0Curve3);
+        setProperty('localVelocityGraph2', this.localVelocityGraph);
 
-        setProperty("velocityGraph", default0Curve3);
-        setProperty("velocityGraph2", this.velocityGraph);
+        setProperty('velocityGraph', default0Curve3);
+        setProperty('velocityGraph2', this.velocityGraph);
 
-        setProperty("rotationSpeedGraph", default0Curve);
-        setProperty("rotationSpeedGraph2", this.rotationSpeedGraph);
+        setProperty('rotationSpeedGraph', default0Curve);
+        setProperty('rotationSpeedGraph2', this.rotationSpeedGraph);
 
-        setProperty("radialSpeedGraph", default0Curve);
-        setProperty("radialSpeedGraph2", this.radialSpeedGraph);
+        setProperty('radialSpeedGraph', default0Curve);
+        setProperty('radialSpeedGraph2', this.radialSpeedGraph);
 
         this.lightCube = new Float32Array(6 * 3);
         this.lightCubeDir = new Array(6);
@@ -590,7 +590,7 @@ class ParticleEmitter {
         if (this.mesh) {
             const totalVertCount = this.numParticles * this.mesh.vertexBuffer.numVertices;
             if (totalVertCount > 65535) {
-                Debug.warn("WARNING: particle system can't render mesh particles because numParticles * numVertices is more than 65k. Reverting to quad particles.");
+                Debug.warn('WARNING: particle system can\'t render mesh particles because numParticles * numVertices is more than 65k. Reverting to quad particles.');
             } else {
                 this.useMesh = true;
             }
@@ -677,10 +677,10 @@ class ParticleEmitter {
 
         // Note: createShaderFromCode can return a shader from the cache (not a new shader) so we *should not* delete these shaders
         // when the particle emitter is destroyed
-        const params = this.emitterShape + "" + this.pack8 + "" + this.localSpace;
-        this.shaderParticleUpdateRespawn = createShaderFromCode(gd, shaderChunks.fullscreenQuadVS, shaderCodeRespawn, "fsQuad0" + params);
-        this.shaderParticleUpdateNoRespawn = createShaderFromCode(gd, shaderChunks.fullscreenQuadVS, shaderCodeNoRespawn, "fsQuad1" + params);
-        this.shaderParticleUpdateOnStop = createShaderFromCode(gd, shaderChunks.fullscreenQuadVS, shaderCodeOnStop, "fsQuad2" + params);
+        const params = this.emitterShape + '' + this.pack8 + '' + this.localSpace;
+        this.shaderParticleUpdateRespawn = createShaderFromCode(gd, shaderChunks.fullscreenQuadVS, shaderCodeRespawn, 'fsQuad0' + params);
+        this.shaderParticleUpdateNoRespawn = createShaderFromCode(gd, shaderChunks.fullscreenQuadVS, shaderCodeNoRespawn, 'fsQuad1' + params);
+        this.shaderParticleUpdateOnStop = createShaderFromCode(gd, shaderChunks.fullscreenQuadVS, shaderCodeOnStop, 'fsQuad2' + params);
 
         this.numParticleVerts = this.useMesh ? this.mesh.vertexBuffer.numVertices : 4;
         this.numParticleIndices = this.useMesh ? this.mesh.indexBuffer[0].numIndices : 6;
@@ -855,7 +855,7 @@ class ParticleEmitter {
             // set by Editor if running inside editor
             const inTools = this.emitter.inTools;
 
-            const shader = programLib.getProgram("particle", {
+            const shader = programLib.getProgram('particle', {
                 useCpu: this.emitter.useCpu,
                 normal: this.emitter.normalOption,
                 halflambert: this.emitter.halfLambert,
@@ -865,7 +865,7 @@ class ParticleEmitter {
                 mesh: this.emitter.useMesh,
                 gamma: this.emitter.scene ? this.emitter.scene.gammaCorrection : 0,
                 toneMap: this.emitter.scene ? this.emitter.scene.toneMapping : 0,
-                fog: (this.emitter.scene && !this.emitter.noFog) ? this.emitter.scene.fog : "none",
+                fog: (this.emitter.scene && !this.emitter.noFog) ? this.emitter.scene.fog : 'none',
                 wrap: this.emitter.wrap && this.emitter.wrapBounds,
                 localSpace: this.emitter.localSpace,
 
@@ -910,15 +910,15 @@ class ParticleEmitter {
         material.setParameter('scaleDivMult', this.scaleUMax[0]);
         material.setParameter('alphaDivMult', this.alphaUMax[0]);
         material.setParameter('radialSpeedDivMult', this.radialSpeedUMax[0]);
-        material.setParameter("graphNumSamples", this.precision);
-        material.setParameter("graphSampleSize", 1.0 / this.precision);
-        material.setParameter("emitterScale", new Float32Array([1, 1, 1]));
+        material.setParameter('graphNumSamples', this.precision);
+        material.setParameter('graphSampleSize', 1.0 / this.precision);
+        material.setParameter('emitterScale', new Float32Array([1, 1, 1]));
 
         if (this.pack8) {
             this._gpuUpdater._setInputBounds();
-            material.setParameter("inBoundsSize", this._gpuUpdater.inBoundsSizeUniform);
-            material.setParameter("inBoundsCenter", this._gpuUpdater.inBoundsCenterUniform);
-            material.setParameter("maxVel", this.maxVel);
+            material.setParameter('inBoundsSize', this._gpuUpdater.inBoundsSizeUniform);
+            material.setParameter('inBoundsCenter', this._gpuUpdater.inBoundsCenterUniform);
+            material.setParameter('maxVel', this.maxVel);
         }
 
         if (this.wrap && this.wrapBounds) {
@@ -967,8 +967,8 @@ class ParticleEmitter {
             tangent = new Float32Array([t.x, t.y, t.z]);
             binormal = new Float32Array([b.x, b.y, b.z]);
         }
-        this.material.setParameter("faceTangent", tangent);
-        this.material.setParameter("faceBinorm", binormal);
+        this.material.setParameter('faceTangent', tangent);
+        this.material.setParameter('faceBinorm', binormal);
     }
 
     // Declares vertex format, creates VB and IB
@@ -1179,13 +1179,13 @@ class ParticleEmitter {
         this.emitterScaleUniform[0] = emitterScale.x;
         this.emitterScaleUniform[1] = emitterScale.y;
         this.emitterScaleUniform[2] = emitterScale.z;
-        this.material.setParameter("emitterScale", this.emitterScaleUniform);
+        this.material.setParameter('emitterScale', this.emitterScaleUniform);
         if (this.localSpace && this.meshInstance.node) {
             emitterPos = this.meshInstance.node.getPosition();
             this.emitterPosUniform[0] = emitterPos.x;
             this.emitterPosUniform[1] = emitterPos.y;
             this.emitterPosUniform[2] = emitterPos.z;
-            this.material.setParameter("emitterPos", this.emitterPosUniform);
+            this.material.setParameter('emitterPos', this.emitterPosUniform);
         }
 
         this._compParticleFaceParams();

--- a/src/scene/picker.js
+++ b/src/scene/picker.js
@@ -46,7 +46,7 @@ class Picker {
     constructor(app, width, height) {
         if (app instanceof GraphicsDevice) {
             app = getApplication();
-            Debug.deprecated("pc.Picker now takes pc.Application as first argument. Passing pc.GraphicsDevice is deprecated.");
+            Debug.deprecated('pc.Picker now takes pc.Application as first argument. Passing pc.GraphicsDevice is deprecated.');
         }
 
         this.app = app;
@@ -99,7 +99,7 @@ class Picker {
         const device = this.device;
 
         if (typeof x === 'object') {
-            Debug.deprecated("Picker.getSelection:param 'rect' is deprecated, use 'x, y, width, height' instead.");
+            Debug.deprecated('Picker.getSelection:param \'rect\' is deprecated, use \'x, y, width, height\' instead.');
 
             const rect = x;
             x = rect.x;
@@ -192,11 +192,11 @@ class Picker {
 
         // camera
         this.cameraEntity = new Entity();
-        this.cameraEntity.addComponent("camera");
+        this.cameraEntity.addComponent('camera');
 
         // layer all meshes rendered for picking at added to
         this.layer = new Layer({
-            name: "Picker",
+            name: 'Picker',
             shaderPass: SHADER_PICK,
             opaqueSortMode: SORTMODE_NONE,
 
@@ -215,7 +215,7 @@ class Picker {
         this.layer.addCamera(this.cameraEntity.camera);
 
         // composition
-        this.layerComp = new LayerComposition("picker");
+        this.layerComp = new LayerComposition('picker');
         this.layerComp.pushOpaque(this.layer);
     }
 
@@ -233,7 +233,7 @@ class Picker {
 
         // handle deprecated arguments
         if (camera instanceof Camera) {
-            Debug.deprecated("pc.Picker#prepare now takes pc.CameraComponent as first argument. Passing pc.Camera is deprecated.");
+            Debug.deprecated('pc.Picker#prepare now takes pc.CameraComponent as first argument. Passing pc.Camera is deprecated.');
 
             // Get the camera component
             camera = camera.node.camera;
@@ -303,7 +303,7 @@ class Picker {
 
         // copy transform
         this.cameraEntity.copy(srcCamera.entity);
-        this.cameraEntity.name = "PickerCamera";
+        this.cameraEntity.name = 'PickerCamera';
 
         // copy camera component properties - which overwrites few properties we change to what is needed later
         const destCamera = this.cameraEntity.camera;

--- a/src/scene/procedural.js
+++ b/src/scene/procedural.js
@@ -1042,7 +1042,7 @@ function getShapePrimitive(device, type) {
                 break;
 
             default:
-                throw new Error("Invalid primitive type: " + type);
+                throw new Error('Invalid primitive type: ' + type);
         }
 
         // inc reference to keep primitive alive

--- a/src/scene/renderer/cookie-renderer.js
+++ b/src/scene/renderer/cookie-renderer.js
@@ -59,26 +59,26 @@ class CookieRenderer {
             this[shader] = createShaderFromCode(this.device, textureBlitVertexShader, fragment, `cookie_renderer_${shader}`);
 
         if (!this.blitTextureId)
-            this.blitTextureId = this.device.scope.resolve("blitTexture");
+            this.blitTextureId = this.device.scope.resolve('blitTexture');
 
         if (!this.invViewProjId)
-            this.invViewProjId = this.device.scope.resolve("invViewProj");
+            this.invViewProjId = this.device.scope.resolve('invViewProj');
 
         return this[shader];
     }
 
     get shader2d() {
-        return this.getShader("blitShader2d", textureBlitFragmentShader);
+        return this.getShader('blitShader2d', textureBlitFragmentShader);
     }
 
     get shaderCube() {
-        return this.getShader("blitShaderCube", textureCubeBlitFragmentShader);
+        return this.getShader('blitShaderCube', textureCubeBlitFragmentShader);
     }
 
     static createTexture(device, resolution) {
 
         const texture = new Texture(device, {
-            name: "CookieAtlas",
+            name: 'CookieAtlas',
             width: resolution,
             height: resolution,
             format: PIXELFORMAT_R8_G8_B8_A8,

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -161,9 +161,9 @@ class ForwardRenderer {
         this.alphaTestId = scope.resolve('alpha_ref');
         this.opacityMapId = scope.resolve('texture_opacityMap');
 
-        this.ambientId = scope.resolve("light_globalAmbient");
-        this.exposureId = scope.resolve("exposure");
-        this.skyboxIntensityId = scope.resolve("skyboxIntensity");
+        this.ambientId = scope.resolve('light_globalAmbient');
+        this.exposureId = scope.resolve('exposure');
+        this.skyboxIntensityId = scope.resolve('skyboxIntensity');
         this.lightColorId = [];
         this.lightDir = [];
         this.lightDirId = [];
@@ -193,7 +193,7 @@ class ForwardRenderer {
         this.screenSizeId = scope.resolve('uScreenSize');
         this._screenSize = new Float32Array(4);
 
-        this.twoSidedLightingNegScaleFactorId = scope.resolve("twoSidedLightingNegScaleFactor");
+        this.twoSidedLightingNegScaleFactorId = scope.resolve('twoSidedLightingNegScaleFactor');
 
         this.fogColor = new Float32Array(3);
         this.ambientColor = new Float32Array(3);
@@ -528,31 +528,31 @@ class ForwardRenderer {
     }
 
     _resolveLight(scope, i) {
-        const light = "light" + i;
-        this.lightColorId[i] = scope.resolve(light + "_color");
+        const light = 'light' + i;
+        this.lightColorId[i] = scope.resolve(light + '_color');
         this.lightDir[i] = new Float32Array(3);
-        this.lightDirId[i] = scope.resolve(light + "_direction");
-        this.lightShadowMapId[i] = scope.resolve(light + "_shadowMap");
-        this.lightShadowMatrixId[i] = scope.resolve(light + "_shadowMatrix");
-        this.lightShadowParamsId[i] = scope.resolve(light + "_shadowParams");
-        this.lightRadiusId[i] = scope.resolve(light + "_radius");
+        this.lightDirId[i] = scope.resolve(light + '_direction');
+        this.lightShadowMapId[i] = scope.resolve(light + '_shadowMap');
+        this.lightShadowMatrixId[i] = scope.resolve(light + '_shadowMatrix');
+        this.lightShadowParamsId[i] = scope.resolve(light + '_shadowParams');
+        this.lightRadiusId[i] = scope.resolve(light + '_radius');
         this.lightPos[i] = new Float32Array(3);
-        this.lightPosId[i] = scope.resolve(light + "_position");
+        this.lightPosId[i] = scope.resolve(light + '_position');
         this.lightWidth[i] = new Float32Array(3);
-        this.lightWidthId[i] = scope.resolve(light + "_halfWidth");
+        this.lightWidthId[i] = scope.resolve(light + '_halfWidth');
         this.lightHeight[i] = new Float32Array(3);
-        this.lightHeightId[i] = scope.resolve(light + "_halfHeight");
-        this.lightInAngleId[i] = scope.resolve(light + "_innerConeAngle");
-        this.lightOutAngleId[i] = scope.resolve(light + "_outerConeAngle");
-        this.lightCookieId[i] = scope.resolve(light + "_cookie");
-        this.lightCookieIntId[i] = scope.resolve(light + "_cookieIntensity");
-        this.lightCookieMatrixId[i] = scope.resolve(light + "_cookieMatrix");
-        this.lightCookieOffsetId[i] = scope.resolve(light + "_cookieOffset");
+        this.lightHeightId[i] = scope.resolve(light + '_halfHeight');
+        this.lightInAngleId[i] = scope.resolve(light + '_innerConeAngle');
+        this.lightOutAngleId[i] = scope.resolve(light + '_outerConeAngle');
+        this.lightCookieId[i] = scope.resolve(light + '_cookie');
+        this.lightCookieIntId[i] = scope.resolve(light + '_cookieIntensity');
+        this.lightCookieMatrixId[i] = scope.resolve(light + '_cookieMatrix');
+        this.lightCookieOffsetId[i] = scope.resolve(light + '_cookieOffset');
 
         // shadow cascades
-        this.shadowMatrixPaletteId[i] = scope.resolve(light + "_shadowMatrixPalette[0]");
-        this.shadowCascadeDistancesId[i] = scope.resolve(light + "_shadowCascadeDistances[0]");
-        this.shadowCascadeCountId[i] = scope.resolve(light + "_shadowCascadeCount");
+        this.shadowMatrixPaletteId[i] = scope.resolve(light + '_shadowMatrixPalette[0]');
+        this.shadowCascadeDistancesId[i] = scope.resolve(light + '_shadowCascadeDistances[0]');
+        this.shadowCascadeCountId[i] = scope.resolve(light + '_shadowCascadeCount');
     }
 
     setLTCDirectionalLight(wtm, cnt, dir, campos, far) {
@@ -1281,7 +1281,7 @@ class ForwardRenderer {
 
                     if (!drawCall._shader[pass] || drawCall._shaderDefs !== objDefs || drawCall._lightHash !== lightHash) {
                         if (!drawCall.isStatic) {
-                            const variantKey = pass + "_" + objDefs + "_" + lightHash;
+                            const variantKey = pass + '_' + objDefs + '_' + lightHash;
                             drawCall._shader[pass] = material.variants[variantKey];
                             if (!drawCall._shader[pass]) {
                                 this.updateShader(drawCall, objDefs, null, pass, sortedLights);
@@ -1894,7 +1894,7 @@ class ForwardRenderer {
                 continue;
             }
 
-            DebugGraphics.pushGpuMarker(this.device, camera ? camera.entity.name : "noname");
+            DebugGraphics.pushGpuMarker(this.device, camera ? camera.entity.name : 'noname');
             DebugGraphics.pushGpuMarker(this.device, layer.name);
 
             // #if _PROFILER

--- a/src/scene/renderer/light-camera.js
+++ b/src/scene/renderer/light-camera.js
@@ -58,7 +58,7 @@ class LightCamera {
 
         let cookieCamera = LightCamera._spotCookieCamera;
         if (!cookieCamera) {
-            cookieCamera = LightCamera.create("SpotCookieCamera", LIGHTTYPE_SPOT);
+            cookieCamera = LightCamera.create('SpotCookieCamera', LIGHTTYPE_SPOT);
             LightCamera._spotCookieCamera = cookieCamera;
         }
 

--- a/src/scene/renderer/shadow-renderer.js
+++ b/src/scene/renderer/shadow-renderer.js
@@ -109,15 +109,15 @@ class ShadowRenderer {
         this.lightTextureAtlas = lightTextureAtlas;
         const scope = this.device.scope;
 
-        this.polygonOffsetId = scope.resolve("polygonOffset");
+        this.polygonOffsetId = scope.resolve('polygonOffset');
         this.polygonOffset = new Float32Array(2);
 
         // VSM
-        this.sourceId = scope.resolve("source");
-        this.pixelOffsetId = scope.resolve("pixelOffset");
-        this.weightId = scope.resolve("weight[0]");
-        this.blurVsmShaderCode = [shaderChunks.blurVSMPS, "#define GAUSS\n" + shaderChunks.blurVSMPS];
-        const packed = "#define PACKED\n";
+        this.sourceId = scope.resolve('source');
+        this.pixelOffsetId = scope.resolve('pixelOffset');
+        this.weightId = scope.resolve('weight[0]');
+        this.blurVsmShaderCode = [shaderChunks.blurVSMPS, '#define GAUSS\n' + shaderChunks.blurVSMPS];
+        const packed = '#define PACKED\n';
         this.blurPackedVsmShaderCode = [packed + this.blurVsmShaderCode[0], packed + this.blurVsmShaderCode[1]];
 
         // cache for vsm blur shaders
@@ -141,7 +141,7 @@ class ShadowRenderer {
     // creates shadow camera for a light and sets up its constant properties
     static createShadowCamera(device, shadowType, type, face) {
 
-        const shadowCam = LightCamera.create("ShadowCamera", type, face);
+        const shadowCam = LightCamera.create('ShadowCamera', type, face);
 
         // don't clear the color buffer if rendering a depth map
         if (shadowType >= SHADOW_VSM8 && shadowType <= SHADOW_VSM32) {
@@ -580,13 +580,13 @@ class ShadowRenderer {
             this.blurVsmWeights[filterSize] = gaussWeights(filterSize);
 
             const blurVS = shaderChunks.fullscreenQuadVS;
-            let blurFS = "#define SAMPLES " + filterSize + "\n";
+            let blurFS = '#define SAMPLES ' + filterSize + '\n';
             if (isVsm8) {
                 blurFS += this.blurPackedVsmShaderCode[blurMode];
             } else {
                 blurFS += this.blurVsmShaderCode[blurMode];
             }
-            const blurShaderName = "blurVsm" + blurMode + "" + filterSize + "" + isVsm8;
+            const blurShaderName = 'blurVsm' + blurMode + '' + filterSize + '' + isVsm8;
             blurShader = createShaderFromCode(this.device, blurVS, blurFS, blurShaderName);
 
             if (isVsm8) {
@@ -603,7 +603,7 @@ class ShadowRenderer {
 
         const device = this.device;
 
-        DebugGraphics.pushGpuMarker(device, "VSM");
+        DebugGraphics.pushGpuMarker(device, 'VSM');
 
         const lightRenderData = light.getRenderData(light._type === LIGHTTYPE_DIRECTIONAL ? camera : null, 0);
         const shadowCam = lightRenderData.shadowCamera;

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -299,7 +299,7 @@ class Scene extends EventHandler {
     set clusteredLightingEnabled(value) {
 
         if (this._clusteredLightingEnabled && !value) {
-            console.error("Turning off enabled clustered lighting is not currently supported");
+            console.error('Turning off enabled clustered lighting is not currently supported');
             return;
         }
 
@@ -397,7 +397,7 @@ class Scene extends EventHandler {
     set layers(layers) {
         const prev = this._layers;
         this._layers = layers;
-        this.fire("set:layers", prev, layers);
+        this.fire('set:layers', prev, layers);
     }
 
     get layers() {
@@ -699,10 +699,10 @@ class Scene extends EventHandler {
         material.updateShader();
 
         if (skyboxTex.cubemap) {
-            material.setParameter("texture_cubeMap", skyboxTex);
+            material.setParameter('texture_cubeMap', skyboxTex);
         } else {
-            material.setParameter("texture_envAtlas", skyboxTex);
-            material.setParameter("mipLevel", this._skyboxMip);
+            material.setParameter('texture_envAtlas', skyboxTex);
+            material.setParameter('mipLevel', this._skyboxMip);
         }
 
         if (!this.skyboxRotation.equals(Quat.IDENTITY)) {
@@ -710,9 +710,9 @@ class Scene extends EventHandler {
             if (!this._skyboxRotationMat3) this._skyboxRotationMat3 = new Mat3();
             this._skyboxRotationMat4.setTRS(Vec3.ZERO, this._skyboxRotation, Vec3.ONE);
             this._skyboxRotationMat4.invertTo3x3(this._skyboxRotationMat3);
-            material.setParameter("cubeMapRotationMatrix", this._skyboxRotationMat3.data);
+            material.setParameter('cubeMapRotationMatrix', this._skyboxRotationMat3.data);
         } else {
-            material.setParameter("cubeMapRotationMatrix", Mat3.IDENTITY.data);
+            material.setParameter('cubeMapRotationMatrix', Mat3.IDENTITY.data);
         }
 
         material.cull = CULLFACE_FRONT;
@@ -720,7 +720,7 @@ class Scene extends EventHandler {
 
         const skyLayer = this.layers.getLayerById(LAYERID_SKYBOX);
         if (skyLayer) {
-            const node = new GraphNode("Skybox");
+            const node = new GraphNode('Skybox');
             const mesh = createBox(device);
             const meshInstance = new MeshInstance(mesh, material, node);
             meshInstance.cull = false;
@@ -737,7 +737,7 @@ class Scene extends EventHandler {
             skyLayer.addMeshInstances(model.meshInstances);
             this.skyLayer = skyLayer;
 
-            this.fire("set:skybox", skyboxTex);
+            this.fire('set:skybox', skyboxTex);
         }
     }
 

--- a/src/scene/skin-instance-cache.js
+++ b/src/scene/skin-instance-cache.js
@@ -21,7 +21,7 @@ class SkinInstanceCache {
     // #if _DEBUG
     // function that logs out the state of the skin instances cache
     static logCachedSkinInstances() {
-        console.log("CachedSkinInstances");
+        console.log('CachedSkinInstances');
         SkinInstanceCache._skinInstanceCache.forEach(function (array, rootBone) {
             console.log(`${rootBone.name}: Array(${array.length})`);
             for (let i = 0; i < array.length; i++) {


### PR DESCRIPTION
This is the second phase of migrating the engine to standardize on single quotes. This time, the folders updated are:

* `framework/components` (I left out the files in the root of `framework` because @mvaligursky has a PR open involving `AppBase`)
* `resources`
* `scene`

I suspect we'll need one or possibly two more phases to complete the switch.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
