### PR TITLE
Remove firing of redundant `frameEnd` event

### DIFF
--- a/src/framework/app-base.js
+++ b/src/framework/app-base.js
@@ -2249,7 +2249,6 @@ const makeTick = function (_app) {
         _frameEndData.target = application;
 
         application.fire("frameend", _frameEndData);
-        application.fire("frameEnd", _frameEndData);// deprecated old event, remove when editor updated
 
         if (application.vr && application.vr.display && application.vr.display.presenting) {
             application.vr.display.submitFrame();


### PR DESCRIPTION
Remove the firing of an event that's no longer listened to by the Editor (it was removed back in December 2021 from `editor/public/js/launch/tools-frame.js`).

Fixes #2298

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
