### PR TITLE
Remove logging from the grab pass example

### DIFF
--- a/examples/src/examples/graphics/grab-pass.tsx
+++ b/examples/src/examples/graphics/grab-pass.tsx
@@ -90,10 +90,6 @@ void main(void)
 
         const assetListLoader = new pc.AssetListLoader(Object.values(assets), app.assets);
         assetListLoader.load(() => {
-
-            Object.values(assets).forEach((asset) => {
-                console.log(asset, asset.loaded);
-            });
             // Set the canvas to fill the window and automatically change resolution to be the same as the canvas size
             app.setCanvasFillMode(pc.FILLMODE_FILL_WINDOW);
             app.setCanvasResolution(pc.RESOLUTION_AUTO);


### PR DESCRIPTION
Remove an unnecessary log from the grab pass example code. This was used to debug the AssetListLoader during development.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
