### PR TITLE
Turn off Antialiasing on webkit 15.3 to avoid rendering issues

### DIFF
--- a/src/graphics/webgl/webgl-graphics-device.js
+++ b/src/graphics/webgl/webgl-graphics-device.js
@@ -259,7 +259,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
         // #4136 - turn off antialiasing on AppleWebKit browsers 15.4
         if (typeof navigator !== 'undefined') {
             const ua = navigator.userAgent;
-            if (ua.includes('AppleWebKit') && (ua.includes('15.4') || ua.includes('15_4'))) {
+            if (ua.includes('AppleWebKit') && (ua.includes('15.4') || ua.includes('15_4') || ||ua.includes("15.3")||ua.includes("15_3"))) {
                 options.antialias = false;
                 Debug.log("Antialiasing has been turned off due to rendering issues on AppleWebKit 15.4");
             }


### PR DESCRIPTION
Update #4141 

The same issue appeared in 15.3 and added as a workaround.
