### PR TITLE
enable support for retrying loading of container assets

### DIFF
--- a/src/resources/container.js
+++ b/src/resources/container.js
@@ -118,6 +118,19 @@ class ContainerHandler {
         this.parsers = { };
     }
 
+    set maxRetries(value) {
+        this.glbParser.maxRetries = value;
+        for (const parser in this.parsers) {
+            if (this.parsers.hasOwnProperty(parser)) {
+                this.parsers[parser].maxRetries = value;
+            }
+        }
+    }
+
+    get maxRetries() {
+        return this.glbParser.maxRetries;
+    }
+
     /**
      * @param {string} url - The resource URL.
      * @returns {string} The URL with query parameters removed.

--- a/src/resources/parser/glb-parser.js
+++ b/src/resources/parser/glb-parser.js
@@ -2294,7 +2294,7 @@ class GlbParser {
         this._device = device;
         this._assets = assets;
         this._defaultMaterial = getDefaultMaterial(device);
-        this._maxRetries = maxRetries;
+        this.maxRetries = maxRetries;
     }
 
     _getUrlWithoutParams(url) {
@@ -2322,7 +2322,7 @@ class GlbParser {
                         }
                     });
             }
-        }, asset, this._maxRetries);
+        }, asset, this.maxRetries);
     }
 
     open(url, data, asset) {

--- a/test/asset/asset-registry.test.mjs
+++ b/test/asset/asset-registry.test.mjs
@@ -3,22 +3,29 @@ import { Asset } from '../../src/asset/asset.js';
 import { AssetRegistry } from '../../src/asset/asset-registry.js';
 import { GlbContainerResource } from '../../src/resources/parser/glb-container-resource.js';
 import { ResourceLoader } from '../../src/resources/loader.js';
+import { http, Http } from '../../src/net/http.js';
 
 import { HTMLCanvasElement } from '@playcanvas/canvas-mock';
 
 import { expect } from 'chai';
+import sinon from 'sinon';
 
 describe('AssetRegistry', function () {
 
     let app;
+    let retryDelay;
 
     beforeEach(function () {
+        retryDelay = Http.retryDelay;
+        Http.retryDelay = 1;
         const canvas = new HTMLCanvasElement(500, 500);
         app = new Application(canvas);
     });
 
     afterEach(function () {
         app.destroy();
+        Http.retryDelay = retryDelay;
+        sinon.restore();
     });
 
     describe('#constructor', function () {
@@ -174,6 +181,15 @@ describe('AssetRegistry', function () {
                 expect(err).to.be.null;
                 expect(asset).to.be.instanceof(Asset);
                 expect(asset.resource).to.be.instanceof(GlbContainerResource);
+                done();
+            });
+        });
+
+        it('supports retry loading of container assets', function (done) {
+            sinon.spy(http, 'request');
+            app.loader.enableRetry(2);
+            app.assets.loadFromUrl(`${assetPath}someurl.glb`, 'container', function (err, asset) {
+                expect(http.request.callCount).to.equal(3);
                 done();
             });
         });


### PR DESCRIPTION
While tracking down an issue with my project, I noticed that playcanvas was not automatically retrying loading of GLB files when there was a network failure, like it does for other assets like texture files for instance.

This PR updates the `ContainerHandler` class to support updating `maxRetries` and forward it to any configured parsers, including the `GlbParser`, to which it delegates the loading of the asset by default.


I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
