### PR TITLE
Add constant blend mode and factor

### DIFF
--- a/src/graphics/constants.js
+++ b/src/graphics/constants.js
@@ -99,28 +99,28 @@ export const BLENDMODE_ONE_MINUS_DST_ALPHA = 10;
 
 /**
  * Multiplies all colors by a constant color.
- * 
+ *
  * @type {number}
  */
 export const BLENDMODE_CONSTANT_COLOR = 11;
 
 /**
  * Multiplies all colors by 1 minus a constant color.
- * 
+ *
  * @type {number}
  */
 export const BLENDMODE_ONE_MINUS_CONSTANT_COLOR = 12;
 
 /**
  * Multiplies all colors by a constant alpha value.
- * 
+ *
  * @type {number}
  */
 export const BLENDMODE_CONSTANT_ALPHA = 13;
 
 /**
  * Multiplies all colors by 1 minus a constant alpha value.
- * 
+ *
  * @type {number}
  */
 export const BLENDMODE_ONE_MINUS_CONSTANT_ALPHA = 14;

--- a/src/graphics/constants.js
+++ b/src/graphics/constants.js
@@ -98,6 +98,34 @@ export const BLENDMODE_DST_ALPHA = 9;
 export const BLENDMODE_ONE_MINUS_DST_ALPHA = 10;
 
 /**
+ * Multiplies all colors by a constant color.
+ * 
+ * @type {number}
+ */
+export const BLENDMODE_CONSTANT_COLOR = 11;
+
+/**
+ * Multiplies all colors by 1 minus a constant color.
+ * 
+ * @type {number}
+ */
+export const BLENDMODE_ONE_MINUS_CONSTANT_COLOR = 12;
+
+/**
+ * Multiplies all colors by a constant alpha value.
+ * 
+ * @type {number}
+ */
+export const BLENDMODE_CONSTANT_ALPHA = 13;
+
+/**
+ * Multiplies all colors by 1 minus a constant alpha value.
+ * 
+ * @type {number}
+ */
+export const BLENDMODE_ONE_MINUS_CONSTANT_ALPHA = 14;
+
+/**
  * Add the results of the source and destination fragment multiplies.
  *
  * @type {number}

--- a/src/graphics/webgl/webgl-graphics-device.js
+++ b/src/graphics/webgl/webgl-graphics-device.js
@@ -2470,7 +2470,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
             this.gl.blendColor(r, g, b, a);
             c.set(r, g, b, a);
         }
-    }   
+    }
 
     /**
      * Controls how triangles are culled based on their face direction. The default cull mode is

--- a/src/graphics/webgl/webgl-graphics-device.js
+++ b/src/graphics/webgl/webgl-graphics-device.js
@@ -35,6 +35,7 @@ import { WebglIndexBuffer } from './webgl-index-buffer.js';
 import { WebglShader } from './webgl-shader.js';
 import { WebglTexture } from './webgl-texture.js';
 import { WebglRenderTarget } from './webgl-render-target.js';
+import { Color } from '../../math/color.js';
 
 /** @typedef {import('../index-buffer.js').IndexBuffer} IndexBuffer */
 /** @typedef {import('../shader.js').Shader} Shader */
@@ -338,7 +339,11 @@ class WebglGraphicsDevice extends GraphicsDevice {
             gl.SRC_ALPHA_SATURATE,
             gl.ONE_MINUS_SRC_ALPHA,
             gl.DST_ALPHA,
-            gl.ONE_MINUS_DST_ALPHA
+            gl.ONE_MINUS_DST_ALPHA,
+            gl.CONSTANT_COLOR,
+            gl.ONE_MINUS_CONSTANT_COLOR,
+            gl.CONSTANT_ALPHA,
+            gl.ONE_MINUS_CONSTANT_ALPHA
         ];
 
         this.glComparison = [
@@ -915,6 +920,9 @@ class WebglGraphicsDevice extends GraphicsDevice {
         gl.blendFunc(gl.ONE, gl.ZERO);
         gl.blendEquation(gl.FUNC_ADD);
 
+        this.blendColor = new Color(0, 0, 0, 0);
+        gl.blendColor(0, 0, 0, 0);
+
         this.writeRed = true;
         this.writeGreen = true;
         this.writeBlue = true;
@@ -963,10 +971,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
         this.clearDepth = 1;
         gl.clearDepth(1);
 
-        this.clearRed = 0;
-        this.clearBlue = 0;
-        this.clearGreen = 0;
-        this.clearAlpha = 0;
+        this.clearColor = new Color(0, 0, 0, 0);
         gl.clearColor(0, 0, 0, 0);
 
         this.clearStencil = 0;
@@ -1879,12 +1884,10 @@ class WebglGraphicsDevice extends GraphicsDevice {
      * @ignore
      */
     setClearColor(r, g, b, a) {
-        if ((r !== this.clearRed) || (g !== this.clearGreen) || (b !== this.clearBlue) || (a !== this.clearAlpha)) {
+        const c = this.clearColor;
+        if ((r !== c.r) || (g !== c.g) || (b !== c.b) || (a !== c.a)) {
             this.gl.clearColor(r, g, b, a);
-            this.clearRed = r;
-            this.clearGreen = g;
-            this.clearBlue = b;
-            this.clearAlpha = a;
+            this.clearColor.set(r, g, b, a);
         }
     }
 
@@ -2355,6 +2358,10 @@ class WebglGraphicsDevice extends GraphicsDevice {
      * - {@link BLENDMODE_ONE_MINUS_SRC_ALPHA}
      * - {@link BLENDMODE_DST_ALPHA}
      * - {@link BLENDMODE_ONE_MINUS_DST_ALPHA}
+     * - {@link BLENDMODE_CONSTANT_COLOR}
+     * - {@link BLENDMODE_ONE_MINUS_CONSTANT_COLOR}
+     * - {@link BLENDMODE_CONSTANT_ALPHA}
+     * - {@link BLENDMODE_ONE_MINUS_CONSTANT_ALPHA}
      *
      * @param {number} blendSrc - The source blend function.
      * @param {number} blendDst - The destination blend function.
@@ -2447,6 +2454,23 @@ class WebglGraphicsDevice extends GraphicsDevice {
             this.separateAlphaEquation = true;
         }
     }
+
+    /**
+     * Set the source and destination blending factors.
+     *
+     * @param {number} r - The red component in the range of 0 to 1. Default value is 0.
+     * @param {number} g - The green component in the range of 0 to 1. Default value is 0.
+     * @param {number} b - The blue component in the range of 0 to 1. Default value is 0.
+     * @param {number} a - The alpha component in the range of 0 to 1. Default value is 0.
+     * @ignore
+     */
+    setBlendColor(r, g, b, a) {
+        const c = this.blendColor;
+        if ((r !== c.r) || (g !== c.g) || (b !== c.b) || (a !== c.a)) {
+            this.gl.blendColor(r, g, b, a);
+            c.set(r, g, b, a);
+        }
+    }   
 
     /**
      * Controls how triangles are culled based on their face direction. The default cull mode is


### PR DESCRIPTION
This PR adds the missing blend modes (as documented [here](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/blendFunc)) to the webgl graphics device.

Also adds `device.setBlendColor` render state.

These states are needed in the model-viewer multiframe rendering [here](https://github.com/playcanvas/model-viewer/blob/main/src/multiframe.ts#L240).