### PR TITLE
Envatlas mipmap fix

### DIFF
--- a/src/graphics/env-lighting.js
+++ b/src/graphics/env-lighting.js
@@ -161,7 +161,7 @@ class EnvLighting {
 
         // generate mipmaps
         const rect = new Vec4(0, 0, 512 * s, 256 * s);
-        const levels = calcLevels(512);
+        const levels = calcLevels(256) - calcLevels(4);
         for (let i = 0; i < levels; ++i) {
             reprojectTexture(source, result, {
                 numSamples: 1,

--- a/src/graphics/program-lib/chunks/lit/reflectionEnv.frag.js
+++ b/src/graphics/program-lib/chunks/lit/reflectionEnv.frag.js
@@ -18,7 +18,7 @@ float shinyMipLevel(vec2 uv) {
     // calculate min of both sets of dF to handle discontinuity at the azim edge
     float maxd = min(max(dot(dx, dx), dot(dy, dy)), max(dot(dx2, dx2), dot(dy2, dy2)));
 
-    return clamp(0.5 * log2(maxd) - 1.0 + textureBias, 0.0, 6.0);
+    return clamp(0.5 * log2(maxd) - 1.0 + textureBias, 0.0, 5.0);
 }
 
 vec3 calcReflection(vec3 tReflDirW, float tGlossiness) {


### PR DESCRIPTION
We generate a 1-pixel border around equirect mipmaps in the envatlas and must be careful not to rely on smaller mips which are predominantly mipmap border (i.e. sizes 1x1, 2x2, 4x4).

This PR removes the last level of mipmap we were relying on from the shiny reflections, because it was causing unruly aliasing on thin sliver polygons.

Here is a closeup of a vehicle under harsh lighting conditions demonstrating the aliasing before and after:

![env-aliasing](https://user-images.githubusercontent.com/11276292/162767377-12f52dd8-1297-43f9-8b4f-5c39a5ac93e7.png)
