### PR TITLE
Fixes some WebGL types

### DIFF
--- a/src/graphics/shader-input.js
+++ b/src/graphics/shader-input.js
@@ -16,7 +16,7 @@ class ShaderInput {
      * @param {GraphicsDevice} graphicsDevice - The graphics device used to manage this shader input.
      * @param {string} name - The name of the shader input.
      * @param {number} type - The type of the shader input.
-     * @param {number} locationId - The location id of the shader input.
+     * @param {number | WebGLUniformLocation} locationId - The location id of the shader input.
      */
     constructor(graphicsDevice, name, type, locationId) {
         // Set the shader attribute location

--- a/src/graphics/webgl/webgl-shader.js
+++ b/src/graphics/webgl/webgl-shader.js
@@ -5,7 +5,7 @@ import { Preprocessor } from '../../core/preprocessor.js';
 import { ShaderInput } from '../shader-input.js';
 import { SHADERTAG_MATERIAL, semanticToLocation } from '../constants.js';
 
-/** @typedef {import('../graphics-device.js').GraphicsDevice} GraphicsDevice */
+/** @typedef {import('./webgl-graphics-device.js').WebglGraphicsDevice} WebglGraphicsDevice */
 /** @typedef {import('../shader.js').Shader} Shader */
 
 /**
@@ -34,6 +34,8 @@ class WebglShader {
      * @param {Shader} shader - The shader to free.
      */
     destroy(shader) {
+        /** @type {WebglGraphicsDevice} */
+        // @ts-ignore
         const device = shader.device;
         const idx = device.shaders.indexOf(shader);
         if (idx !== -1) {
@@ -50,7 +52,7 @@ class WebglShader {
     /**
      * Restore shader after the context has been obtained.
      *
-     * @param {GraphicsDevice} device - The graphics device.
+     * @param {WebglGraphicsDevice} device - The graphics device.
      * @param {Shader} shader - The shader to restore.
      */
     restoreContext(device, shader) {
@@ -60,7 +62,7 @@ class WebglShader {
     /**
      * Compile and link a shader program.
      *
-     * @param {GraphicsDevice} device - The graphics device.
+     * @param {WebglGraphicsDevice} device - The graphics device.
      * @param {Shader} shader - The shader to compile.
      */
     compileAndLink(device, shader) {
@@ -173,7 +175,7 @@ class WebglShader {
     /**
      * Extract attribute and uniform information from a successfully linked shader.
      *
-     * @param {GraphicsDevice} device - The graphics device.
+     * @param {WebglGraphicsDevice} device - The graphics device.
      * @param {Shader} shader - The shader to query.
      * @returns {boolean} True if the shader was successfully queried and false otherwise.
      */
@@ -265,7 +267,7 @@ class WebglShader {
     /**
      * Check the compilation status of a shader.
      *
-     * @param {GraphicsDevice} device - The graphics device.
+     * @param {WebglGraphicsDevice} device - The graphics device.
      * @param {Shader} shader - The shader to query.
      * @param {WebGLShader} glShader - The WebGL shader.
      * @param {string} source - The shader source code.


### PR DESCRIPTION
First I just wanted to fix this line:

```js
            location = gl.getUniformLocation(glProgram, info.name);

            shaderInput = new ShaderInput(device, info.name, device.pcUniformType[info.type], location);
```

`location` is a `WebGLUniformLocation`, while `ShaderInput` just treats it as a `number`. So maybe `ShaderInput` should at some point also have its own `Webgl` wrapper? And then it escalated to get the other types right.

API: https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/getUniformLocation

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
