### PR TITLE
[Anim Component] Fix for the normalizeWeights property

### DIFF
--- a/src/framework/components/anim/component.js
+++ b/src/framework/components/anim/component.js
@@ -456,7 +456,7 @@ class AnimComponent extends Component {
         const assetId = this._stateGraphAsset;
         this.removeStateGraph();
         if (assetId) {
-            const stateGraph = this.system.app.assets.get(this.stateGraphAsset).resource;
+            const stateGraph = this.system.app.assets.get(assetId).resource;
             this.loadStateGraph(stateGraph);
         }
     }

--- a/src/framework/components/anim/component.js
+++ b/src/framework/components/anim/component.js
@@ -106,7 +106,7 @@ class AnimComponent extends Component {
      */
     set normalizeWeights(value) {
         this._normalizeWeights = value;
-        this.resetStateGraph();
+        this.unbind();
     }
 
     get normalizeWeights() {
@@ -447,16 +447,15 @@ class AnimComponent extends Component {
         this._layerIndices = {};
         this._parameters = {};
         this._playing = false;
-        Object.keys(this._targets).forEach((targetKey) => {
-            this._targets[targetKey].unbind();
-        });
+        this.unbind();
         // clear all targets from previous binding
         this._targets = {};
     }
 
     resetStateGraph() {
+        const assetId = this._stateGraphAsset;
         this.removeStateGraph();
-        if (this.stateGraphAsset) {
+        if (assetId) {
             const stateGraph = this.system.app.assets.get(this.stateGraphAsset).resource;
             this.loadStateGraph(stateGraph);
         }
@@ -472,6 +471,14 @@ class AnimComponent extends Component {
             const layerPlaying = this._layers[i].playing;
             this._layers[i].reset();
             this._layers[i].playing = layerPlaying;
+        }
+    }
+
+    unbind() {
+        if (!this._normalizeWeights) {
+            Object.keys(this._targets).forEach((targetKey) => {
+                this._targets[targetKey].unbind();
+            });
         }
     }
 

--- a/src/framework/components/anim/component.js
+++ b/src/framework/components/anim/component.js
@@ -452,15 +452,6 @@ class AnimComponent extends Component {
         this._targets = {};
     }
 
-    resetStateGraph() {
-        const assetId = this._stateGraphAsset;
-        this.removeStateGraph();
-        if (assetId) {
-            const stateGraph = this.system.app.assets.get(assetId).resource;
-            this.loadStateGraph(stateGraph);
-        }
-    }
-
     /**
      * Reset all of the components layers and parameters to their initial states. If a layer was
      * playing before it will continue playing.

--- a/src/framework/components/model/component.js
+++ b/src/framework/components/model/component.js
@@ -342,13 +342,9 @@ class ModelComponent extends Component {
             if (this.entity.animation)
                 this.entity.animation.setModel(this._model);
 
-            // Update any animation component
+            // Update any anim component
             if (this.entity.anim) {
-                if (this.entity.anim.playing) {
-                    this.entity.anim.rebind();
-                } else {
-                    this.entity.anim.resetStateGraph();
-                }
+                this.entity.anim.rebind();
             }
             // trigger event handler to load mapping
             // for new model


### PR DESCRIPTION
Previously when setting the normalizeWeights property, the state graph was reset in order to unbind any dirty targets it contained. This PR moves the target unbinding to its own function so that the normalizeWeights setter can call it directly. It also removes the resetStateGraph function which is no longer necessary.

Fixes #4189 

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
