### PR TITLE
Add fitMode property on Image Elements.

### DIFF
--- a/src/framework/components/element/component.js
+++ b/src/framework/components/element/component.js
@@ -15,7 +15,7 @@ import { Entity } from '../../entity.js';
 
 import { Component } from '../component.js';
 
-import { ELEMENTTYPE_GROUP, ELEMENTTYPE_IMAGE, ELEMENTTYPE_TEXT } from './constants.js';
+import { ELEMENTTYPE_GROUP, ELEMENTTYPE_IMAGE, ELEMENTTYPE_TEXT, ELEMENT_IMAGE_ASPECT_NONE } from './constants.js';
 import { ImageElement } from './image-element.js';
 import { TextElement } from './text-element.js';
 
@@ -103,6 +103,8 @@ const matD = new Mat4();
  * textWidth. Only works for {@link ELEMENTTYPE_TEXT} types.
  * @property {boolean} autoHeight Automatically set the height of the component to be the same as
  * the textHeight. Only works for {@link ELEMENTTYPE_TEXT} types.
+ * @property {number} preserveAspect Sets how the content should be resized in order to preserve
+ * the aspect ratio of the source texture or sprite. Only works for {@link ELEMENTTYPE_IMAGE} types.
  * @property {number} fontAsset The id of the font asset used for rendering the text. Only works
  * for {@link ELEMENTTYPE_TEXT} types.
  * @property {Font} font The font used for rendering the text. Only works for
@@ -240,6 +242,9 @@ class ElementComponent extends Component {
         this._group = null;
 
         this._drawOrder = 0;
+
+        // aspect ratio
+        this._preserveAspect = ELEMENT_IMAGE_ASPECT_NONE;
 
         // input related
         this._useInput = false;
@@ -779,6 +784,23 @@ class ElementComponent extends Component {
 
     get useInput() {
         return this._useInput;
+    }
+
+    /**
+     *
+     *
+     * @type {number}
+     */
+    set preserveAspect(value) {
+        this._preserveAspect = value;
+        this._calculateSize(true, true);
+        if (this._image) {
+            this._image.refreshMesh();
+        }
+    }
+
+    get preserveAspect() {
+        return this._preserveAspect;
     }
 
     /**

--- a/src/framework/components/element/component.js
+++ b/src/framework/components/element/component.js
@@ -15,7 +15,7 @@ import { Entity } from '../../entity.js';
 
 import { Component } from '../component.js';
 
-import { ELEMENTTYPE_GROUP, ELEMENTTYPE_IMAGE, ELEMENTTYPE_TEXT, ELEMENT_IMAGE_FIT_STRETCH } from './constants.js';
+import { ELEMENTTYPE_GROUP, ELEMENTTYPE_IMAGE, ELEMENTTYPE_TEXT, FITMODE_STRETCH } from './constants.js';
 import { ImageElement } from './image-element.js';
 import { TextElement } from './text-element.js';
 
@@ -244,7 +244,7 @@ class ElementComponent extends Component {
         this._drawOrder = 0;
 
         // Fit mode
-        this._fitMode = ELEMENT_IMAGE_FIT_STRETCH;
+        this._fitMode = FITMODE_STRETCH;
 
         // input related
         this._useInput = false;

--- a/src/framework/components/element/component.js
+++ b/src/framework/components/element/component.js
@@ -788,7 +788,11 @@ class ElementComponent extends Component {
 
     /**
      * Set how the content should be fitted and preserve the aspect ratio of the source texture or sprite.
-     * Only works for {@link ELEMENTTYPE_IMAGE} types.
+     * Only works for {@link ELEMENTTYPE_IMAGE} types. Can be:
+     *
+     * - {@link FITMODE_STRETCH}: Fit the content exactly to Element's bounding box.
+     * - {@link FITMODE_CONTAIN}: Fit the content within the Element's bounding box while preserving its Aspect Ratio.
+     * - {@link FITMODE_COVER}: Fit the content to cover the entire Element's bounding box while preserving its Aspect Ratio.
      *
      * @type {string}
      */

--- a/src/framework/components/element/component.js
+++ b/src/framework/components/element/component.js
@@ -103,7 +103,7 @@ const matD = new Mat4();
  * textWidth. Only works for {@link ELEMENTTYPE_TEXT} types.
  * @property {boolean} autoHeight Automatically set the height of the component to be the same as
  * the textHeight. Only works for {@link ELEMENTTYPE_TEXT} types.
- * @property {number} preserveAspect Sets how the content should be resized in order to preserve
+ * @property {string} preserveAspect Sets how the content should be resized in order to preserve
  * the aspect ratio of the source texture or sprite. Only works for {@link ELEMENTTYPE_IMAGE} types.
  * @property {number} fontAsset The id of the font asset used for rendering the text. Only works
  * for {@link ELEMENTTYPE_TEXT} types.
@@ -790,7 +790,7 @@ class ElementComponent extends Component {
      * Sets how the content should be resized in order to preserve the aspect ratio of the source texture or sprite.
      * Only works for {@link ELEMENTTYPE_IMAGE} types.
      *
-     * @type {number}
+     * @type {string}
      */
     set preserveAspect(value) {
         this._preserveAspect = value;

--- a/src/framework/components/element/component.js
+++ b/src/framework/components/element/component.js
@@ -15,7 +15,7 @@ import { Entity } from '../../entity.js';
 
 import { Component } from '../component.js';
 
-import { ELEMENTTYPE_GROUP, ELEMENTTYPE_IMAGE, ELEMENTTYPE_TEXT, ELEMENT_IMAGE_ASPECT_NONE } from './constants.js';
+import { ELEMENTTYPE_GROUP, ELEMENTTYPE_IMAGE, ELEMENTTYPE_TEXT, ELEMENT_IMAGE_FIT_STRETCH } from './constants.js';
 import { ImageElement } from './image-element.js';
 import { TextElement } from './text-element.js';
 
@@ -103,8 +103,8 @@ const matD = new Mat4();
  * textWidth. Only works for {@link ELEMENTTYPE_TEXT} types.
  * @property {boolean} autoHeight Automatically set the height of the component to be the same as
  * the textHeight. Only works for {@link ELEMENTTYPE_TEXT} types.
- * @property {string} preserveAspect Sets how the content should be resized in order to preserve
- * the aspect ratio of the source texture or sprite. Only works for {@link ELEMENTTYPE_IMAGE} types.
+ * @property {string} fitMode Set how the content should be fitted and preserve the aspect ratio of
+ * the source texture or sprite. Only works for {@link ELEMENTTYPE_IMAGE} types.
  * @property {number} fontAsset The id of the font asset used for rendering the text. Only works
  * for {@link ELEMENTTYPE_TEXT} types.
  * @property {Font} font The font used for rendering the text. Only works for
@@ -243,8 +243,8 @@ class ElementComponent extends Component {
 
         this._drawOrder = 0;
 
-        // aspect ratio
-        this._preserveAspect = ELEMENT_IMAGE_ASPECT_NONE;
+        // Fit mode
+        this._fitMode = ELEMENT_IMAGE_FIT_STRETCH;
 
         // input related
         this._useInput = false;
@@ -787,21 +787,21 @@ class ElementComponent extends Component {
     }
 
     /**
-     * Sets how the content should be resized in order to preserve the aspect ratio of the source texture or sprite.
+     * Set how the content should be fitted and preserve the aspect ratio of the source texture or sprite.
      * Only works for {@link ELEMENTTYPE_IMAGE} types.
      *
      * @type {string}
      */
-    set preserveAspect(value) {
-        this._preserveAspect = value;
+    set fitMode(value) {
+        this._fitMode = value;
         this._calculateSize(true, true);
         if (this._image) {
             this._image.refreshMesh();
         }
     }
 
-    get preserveAspect() {
-        return this._preserveAspect;
+    get fitMode() {
+        return this._fitMode;
     }
 
     /**

--- a/src/framework/components/element/component.js
+++ b/src/framework/components/element/component.js
@@ -787,7 +787,8 @@ class ElementComponent extends Component {
     }
 
     /**
-     *
+     * Sets how the content should be resized in order to preserve the aspect ratio of the source texture or sprite.
+     * Only works for {@link ELEMENTTYPE_IMAGE} types.
      *
      * @type {number}
      */

--- a/src/framework/components/element/constants.js
+++ b/src/framework/components/element/constants.js
@@ -22,20 +22,20 @@ export const ELEMENTTYPE_TEXT = 'text';
 /**
  * Disable Aspect Ratio content resizing.
  *
- * @type {number}
+ * @type {string}
  */
-export const ELEMENT_IMAGE_ASPECT_NONE = 0;
+export const ELEMENT_IMAGE_ASPECT_NONE = 'none';
 
 /**
  * Resize the content to fit within the Element's bounding box.
  *
- * @type {number}
+ * @type {string}
  */
-export const ELEMENT_IMAGE_ASPECT_CONTAIN = 1;
+export const ELEMENT_IMAGE_ASPECT_CONTAIN = 'contain';
 
 /**
  * Resize the content to cover the entire Element's bounding box.
  *
- * @type {number}
+ * @type {string}
  */
-export const ELEMENT_IMAGE_ASPECT_COVER = 2;
+export const ELEMENT_IMAGE_ASPECT_COVER = 'cover';

--- a/src/framework/components/element/constants.js
+++ b/src/framework/components/element/constants.js
@@ -24,7 +24,7 @@ export const ELEMENTTYPE_TEXT = 'text';
  *
  * @type {string}
  */
-export const ELEMENT_IMAGE_FIT_STRETCH = 'stretch';
+export const FITMODE_STRETCH = 'stretch';
 
 /**
  * Fit the content within the Element's bounding box while
@@ -32,7 +32,7 @@ export const ELEMENT_IMAGE_FIT_STRETCH = 'stretch';
  *
  * @type {string}
  */
-export const ELEMENT_IMAGE_FIT_CONTAIN = 'contain';
+export const FITMODE_CONTAIN = 'contain';
 
 /**
  * Fit the content to cover the entire Element's bounding box while
@@ -40,4 +40,4 @@ export const ELEMENT_IMAGE_FIT_CONTAIN = 'contain';
  *
  * @type {string}
  */
-export const ELEMENT_IMAGE_FIT_COVER = 'cover';
+export const FITMODE_COVER = 'cover';

--- a/src/framework/components/element/constants.js
+++ b/src/framework/components/element/constants.js
@@ -18,3 +18,24 @@ export const ELEMENTTYPE_IMAGE = 'image';
  * @type {string}
  */
 export const ELEMENTTYPE_TEXT = 'text';
+
+/**
+ * Disable Aspect Ratio content resizing.
+ *
+ * @type {number}
+ */
+export const ELEMENT_IMAGE_ASPECT_NONE = 0;
+
+/**
+ * Resize the content to fit within the Element's bounding box.
+ *
+ * @type {number}
+ */
+export const ELEMENT_IMAGE_ASPECT_CONTAIN = 1;
+
+/**
+ * Resize the content to cover the entire Element's bounding box.
+ *
+ * @type {number}
+ */
+export const ELEMENT_IMAGE_ASPECT_COVER = 2;

--- a/src/framework/components/element/constants.js
+++ b/src/framework/components/element/constants.js
@@ -20,22 +20,24 @@ export const ELEMENTTYPE_IMAGE = 'image';
 export const ELEMENTTYPE_TEXT = 'text';
 
 /**
- * Disable Aspect Ratio content resizing.
+ * Fit the content to the exact Element's bounding box.
  *
  * @type {string}
  */
-export const ELEMENT_IMAGE_ASPECT_NONE = 'none';
+export const ELEMENT_IMAGE_FIT_STRETCH = 'stretch';
 
 /**
- * Resize the content to fit within the Element's bounding box.
+ * Fit the content within the Element's bounding box while
+ * preserving its Aspect Ratio.
  *
  * @type {string}
  */
-export const ELEMENT_IMAGE_ASPECT_CONTAIN = 'contain';
+export const ELEMENT_IMAGE_FIT_CONTAIN = 'contain';
 
 /**
- * Resize the content to cover the entire Element's bounding box.
+ * Fit the content to cover the entire Element's bounding box while
+ * preserving its Aspect Ratio.
  *
  * @type {string}
  */
-export const ELEMENT_IMAGE_ASPECT_COVER = 'cover';
+export const ELEMENT_IMAGE_FIT_COVER = 'cover';

--- a/src/framework/components/element/constants.js
+++ b/src/framework/components/element/constants.js
@@ -20,23 +20,21 @@ export const ELEMENTTYPE_IMAGE = 'image';
 export const ELEMENTTYPE_TEXT = 'text';
 
 /**
- * Fit the content to the exact Element's bounding box.
+ * Fit the content exactly to Element's bounding box.
  *
  * @type {string}
  */
 export const FITMODE_STRETCH = 'stretch';
 
 /**
- * Fit the content within the Element's bounding box while
- * preserving its Aspect Ratio.
+ * Fit the content within the Element's bounding box while preserving its Aspect Ratio.
  *
  * @type {string}
  */
 export const FITMODE_CONTAIN = 'contain';
 
 /**
- * Fit the content to cover the entire Element's bounding box while
- * preserving its Aspect Ratio.
+ * Fit the content to cover the entire Element's bounding box while preserving its Aspect Ratio.
  *
  * @type {string}
  */

--- a/src/framework/components/element/image-element.js
+++ b/src/framework/components/element/image-element.js
@@ -460,11 +460,11 @@ class ImageElement {
         let w = element.calculatedWidth;
         let h = element.calculatedHeight;
 
-        if (element.preserveAspect != ELEMENT_IMAGE_ASPECT_NONE && this._targetAspectRatio > 0) {
+        if (element.preserveAspect !== ELEMENT_IMAGE_ASPECT_NONE && this._targetAspectRatio > 0) {
             const actualRatio = element.calculatedWidth / element.calculatedHeight;
             // check which coordinate must change in order to preserve the source aspect ratio
-            if ((element.preserveAspect == ELEMENT_IMAGE_ASPECT_CONTAIN && actualRatio > this._targetAspectRatio) ||
-                (element.preserveAspect == ELEMENT_IMAGE_ASPECT_COVER && actualRatio < this._targetAspectRatio)) {
+            if ((element.preserveAspect === ELEMENT_IMAGE_ASPECT_CONTAIN && actualRatio > this._targetAspectRatio) ||
+                (element.preserveAspect === ELEMENT_IMAGE_ASPECT_COVER && actualRatio < this._targetAspectRatio)) {
                 // use 'height' to re-calculate width
                 w = element.calculatedHeight * this._targetAspectRatio;
             } else {
@@ -617,7 +617,7 @@ class ImageElement {
 
             // re-calculate aspect ratio from sprite frame
             const frameData = this._sprite.atlas.frames[this._sprite.frameKeys[this._spriteFrame]];
-            if (frameData) {
+            if (frameData?.rect.w > 0) {
                 this._targetAspectRatio = frameData.rect.z / frameData.rect.w;
             }
         }
@@ -1094,7 +1094,7 @@ class ImageElement {
             const newAspectRatio = this._texture.width / this._texture.height;
             if (newAspectRatio != this._targetAspectRatio) {
                 this._targetAspectRatio = newAspectRatio;
-                if (this._element.preserveAspect != ELEMENT_IMAGE_ASPECT_NONE) {
+                if (this._element.preserveAspect !== ELEMENT_IMAGE_ASPECT_NONE) {
                     this.refreshMesh();
                 }
             }
@@ -1107,7 +1107,7 @@ class ImageElement {
             // this is needed in order to properly reset the mesh to 'stretch' across the entire element bounds
             // when resetting the texture
             this._targetAspectRatio = -1;
-            if (this._element.preserveAspect != ELEMENT_IMAGE_ASPECT_NONE) {
+            if (this._element.preserveAspect !== ELEMENT_IMAGE_ASPECT_NONE) {
                 this.refreshMesh();
             }
         }

--- a/src/framework/components/element/image-element.js
+++ b/src/framework/components/element/image-element.js
@@ -601,7 +601,7 @@ class ImageElement {
     // if the sprite is 9-sliced or the default mesh from the
     // image element and calls _updateMesh or sets meshDirty to true
     // if the component is currently being initialized. Also updates
-    // aspect ratio. /We need to call _updateSprite every time
+    // aspect ratio. We need to call _updateSprite every time
     // something related to the sprite asset changes
     _updateSprite() {
         let nineSlice = false;

--- a/src/framework/components/element/image-element.js
+++ b/src/framework/components/element/image-element.js
@@ -27,7 +27,7 @@ import { MeshInstance } from '../../../scene/mesh-instance.js';
 import { Model } from '../../../scene/model.js';
 import { StencilParameters } from '../../../scene/stencil-parameters.js';
 
-import { ELEMENT_IMAGE_FIT_STRETCH, ELEMENT_IMAGE_FIT_CONTAIN, ELEMENT_IMAGE_FIT_COVER } from './constants.js';
+import { FITMODE_STRETCH, FITMODE_CONTAIN, FITMODE_COVER } from './constants.js';
 
 import { Asset } from '../../../asset/asset.js';
 
@@ -460,11 +460,11 @@ class ImageElement {
         let w = element.calculatedWidth;
         let h = element.calculatedHeight;
 
-        if (element.fitMode !== ELEMENT_IMAGE_FIT_STRETCH && this._targetAspectRatio > 0) {
+        if (element.fitMode !== FITMODE_STRETCH && this._targetAspectRatio > 0) {
             const actualRatio = element.calculatedWidth / element.calculatedHeight;
             // check which coordinate must change in order to preserve the source aspect ratio
-            if ((element.fitMode === ELEMENT_IMAGE_FIT_CONTAIN && actualRatio > this._targetAspectRatio) ||
-                (element.fitMode === ELEMENT_IMAGE_FIT_COVER && actualRatio < this._targetAspectRatio)) {
+            if ((element.fitMode === FITMODE_CONTAIN && actualRatio > this._targetAspectRatio) ||
+                (element.fitMode === FITMODE_COVER && actualRatio < this._targetAspectRatio)) {
                 // use 'height' to re-calculate width
                 w = element.calculatedHeight * this._targetAspectRatio;
             } else {
@@ -1094,7 +1094,7 @@ class ImageElement {
             const newAspectRatio = this._texture.width / this._texture.height;
             if (newAspectRatio != this._targetAspectRatio) {
                 this._targetAspectRatio = newAspectRatio;
-                if (this._element.fitMode !== ELEMENT_IMAGE_FIT_STRETCH) {
+                if (this._element.fitMode !== FITMODE_STRETCH) {
                     this.refreshMesh();
                 }
             }
@@ -1107,7 +1107,7 @@ class ImageElement {
             // this is needed in order to properly reset the mesh to 'stretch' across the entire element bounds
             // when resetting the texture
             this._targetAspectRatio = -1;
-            if (this._element.fitMode !== ELEMENT_IMAGE_FIT_STRETCH) {
+            if (this._element.fitMode !== FITMODE_STRETCH) {
                 this.refreshMesh();
             }
         }

--- a/src/framework/components/element/image-element.js
+++ b/src/framework/components/element/image-element.js
@@ -27,6 +27,8 @@ import { MeshInstance } from '../../../scene/mesh-instance.js';
 import { Model } from '../../../scene/model.js';
 import { StencilParameters } from '../../../scene/stencil-parameters.js';
 
+import { ELEMENT_IMAGE_ASPECT_NONE, ELEMENT_IMAGE_ASPECT_CONTAIN, ELEMENT_IMAGE_ASPECT_COVER } from './constants.js';
+
 import { Asset } from '../../../asset/asset.js';
 
 // #if _DEBUG
@@ -273,6 +275,7 @@ class ImageElement {
         this._sprite = null;
         this._spriteFrame = 0;
         this._pixelsPerUnit = null;
+        this._targetAspectRatio = -1; // will be set when assigning textures
 
         this._rect = new Vec4(0, 0, 1, 1); // x, y, w, h
 
@@ -454,8 +457,21 @@ class ImageElement {
 
     _updateMesh(mesh) {
         const element = this._element;
-        const w = element.calculatedWidth;
-        const h = element.calculatedHeight;
+        let w = element.calculatedWidth;
+        let h = element.calculatedHeight;
+
+        if (element.preserveAspect != ELEMENT_IMAGE_ASPECT_NONE && this._targetAspectRatio > 0) {
+            const actualRatio = element.calculatedWidth / element.calculatedHeight;
+            // check which coordinate must change in order to preserve the source aspect ratio
+            if ((element.preserveAspect == ELEMENT_IMAGE_ASPECT_CONTAIN && actualRatio > this._targetAspectRatio) ||
+                (element.preserveAspect == ELEMENT_IMAGE_ASPECT_COVER && actualRatio < this._targetAspectRatio)) {
+                // use 'height' to re-calculate width
+                w = element.calculatedHeight * this._targetAspectRatio;
+            } else {
+                // use 'width' to re-calculate height
+                h = element.calculatedWidth / this._targetAspectRatio;
+            }
+        }
 
         // update material
         const screenSpace = element._isScreenSpace();
@@ -584,21 +600,35 @@ class ImageElement {
     // Gets the mesh from the sprite asset
     // if the sprite is 9-sliced or the default mesh from the
     // image element and calls _updateMesh or sets meshDirty to true
-    // if the component is currently being initialized. We need to call
-    // _updateSprite every time something related to the sprite asset changes
+    // if the component is currently being initialized. Also updates
+    // aspect ratio. /We need to call _updateSprite every time
+    // something related to the sprite asset changes
     _updateSprite() {
         let nineSlice = false;
         let mesh = null;
 
-        // take mesh from sprite
+        // reset target aspect ratio
+        this._targetAspectRatio = -1;
+
         if (this._sprite && this._sprite.atlas) {
+            // take mesh from sprite
             mesh = this._sprite.meshes[this.spriteFrame];
             nineSlice = this._sprite.renderMode === SPRITE_RENDERMODE_SLICED || this._sprite.renderMode === SPRITE_RENDERMODE_TILED;
+
+            // re-calculate aspect ratio from sprite frame
+            const frameData = this._sprite.atlas.frames[this._sprite.frameKeys[this._spriteFrame]];
+            if (frameData) {
+                this._targetAspectRatio = frameData.rect.z / frameData.rect.w;
+            }
         }
 
         // if we use 9 slicing then use that mesh otherwise keep using the default mesh
         this.mesh = nineSlice ? mesh : this._defaultMesh;
 
+        this.refreshMesh();
+    }
+
+    refreshMesh() {
         if (this.mesh) {
             if (!this._element._beingInitialized) {
                 this._updateMesh(this.mesh);
@@ -1059,10 +1089,27 @@ class ImageElement {
             this._colorUniform[2] = this._color.b;
             this._renderable.setParameter('material_emissive', this._colorUniform);
             this._renderable.setParameter('material_opacity', this._color.a);
+
+            // if texture's aspect ratio changed and the element needs to preserve aspect ratio, refresh the mesh
+            const newAspectRatio = this._texture.width / this._texture.height;
+            if (newAspectRatio != this._targetAspectRatio) {
+                this._targetAspectRatio = newAspectRatio;
+                if (this._element.preserveAspect != ELEMENT_IMAGE_ASPECT_NONE) {
+                    this.refreshMesh();
+                }
+            }
         } else {
             // clear texture params
             this._renderable.deleteParameter('texture_emissiveMap');
             this._renderable.deleteParameter('texture_opacityMap');
+
+            // reset target aspect ratio and refresh mesh if there is an aspect ratio setting
+            // this is needed in order to properly reset the mesh to 'stretch' across the entire element bounds
+            // when resetting the texture
+            this._targetAspectRatio = -1;
+            if (this._element.preserveAspect != ELEMENT_IMAGE_ASPECT_NONE) {
+                this.refreshMesh();
+            }
         }
     }
 

--- a/src/framework/components/element/image-element.js
+++ b/src/framework/components/element/image-element.js
@@ -27,7 +27,7 @@ import { MeshInstance } from '../../../scene/mesh-instance.js';
 import { Model } from '../../../scene/model.js';
 import { StencilParameters } from '../../../scene/stencil-parameters.js';
 
-import { ELEMENT_IMAGE_ASPECT_NONE, ELEMENT_IMAGE_ASPECT_CONTAIN, ELEMENT_IMAGE_ASPECT_COVER } from './constants.js';
+import { ELEMENT_IMAGE_FIT_STRETCH, ELEMENT_IMAGE_FIT_CONTAIN, ELEMENT_IMAGE_FIT_COVER } from './constants.js';
 
 import { Asset } from '../../../asset/asset.js';
 
@@ -460,11 +460,11 @@ class ImageElement {
         let w = element.calculatedWidth;
         let h = element.calculatedHeight;
 
-        if (element.preserveAspect !== ELEMENT_IMAGE_ASPECT_NONE && this._targetAspectRatio > 0) {
+        if (element.fitMode !== ELEMENT_IMAGE_FIT_STRETCH && this._targetAspectRatio > 0) {
             const actualRatio = element.calculatedWidth / element.calculatedHeight;
             // check which coordinate must change in order to preserve the source aspect ratio
-            if ((element.preserveAspect === ELEMENT_IMAGE_ASPECT_CONTAIN && actualRatio > this._targetAspectRatio) ||
-                (element.preserveAspect === ELEMENT_IMAGE_ASPECT_COVER && actualRatio < this._targetAspectRatio)) {
+            if ((element.fitMode === ELEMENT_IMAGE_FIT_CONTAIN && actualRatio > this._targetAspectRatio) ||
+                (element.fitMode === ELEMENT_IMAGE_FIT_COVER && actualRatio < this._targetAspectRatio)) {
                 // use 'height' to re-calculate width
                 w = element.calculatedHeight * this._targetAspectRatio;
             } else {
@@ -1094,7 +1094,7 @@ class ImageElement {
             const newAspectRatio = this._texture.width / this._texture.height;
             if (newAspectRatio != this._targetAspectRatio) {
                 this._targetAspectRatio = newAspectRatio;
-                if (this._element.preserveAspect !== ELEMENT_IMAGE_ASPECT_NONE) {
+                if (this._element.fitMode !== ELEMENT_IMAGE_FIT_STRETCH) {
                     this.refreshMesh();
                 }
             }
@@ -1107,7 +1107,7 @@ class ImageElement {
             // this is needed in order to properly reset the mesh to 'stretch' across the entire element bounds
             // when resetting the texture
             this._targetAspectRatio = -1;
-            if (this._element.preserveAspect !== ELEMENT_IMAGE_ASPECT_NONE) {
+            if (this._element.fitMode !== ELEMENT_IMAGE_FIT_STRETCH) {
                 this.refreshMesh();
             }
         }

--- a/src/framework/components/element/system.js
+++ b/src/framework/components/element/system.js
@@ -177,8 +177,8 @@ class ElementComponentSystem extends ComponentSystem {
             component.useInput = data.useInput;
         }
 
-        if (data.preserveAspect !== undefined) {
-            component.preserveAspect = data.preserveAspect;
+        if (data.fitMode !== undefined) {
+            component.fitMode = data.fitMode;
         }
 
         component.batchGroupId = data.batchGroupId === undefined || data.batchGroupId === null ? -1 : data.batchGroupId;
@@ -319,7 +319,7 @@ class ElementComponentSystem extends ComponentSystem {
             fontAsset: source.fontAsset,
             font: source.font,
             useInput: source.useInput,
-            preserveAspect: source.preserveAspect,
+            fitMode: source.fitMode,
             batchGroupId: source.batchGroupId,
             mask: source.mask,
             outlineColor: source.outlineColor && source.outlineColor.clone() || source.outlineColor,

--- a/src/framework/components/element/system.js
+++ b/src/framework/components/element/system.js
@@ -177,6 +177,10 @@ class ElementComponentSystem extends ComponentSystem {
             component.useInput = data.useInput;
         }
 
+        if (data.preserveAspect !== undefined) {
+            component.preserveAspect = data.preserveAspect;
+        }
+
         component.batchGroupId = data.batchGroupId === undefined || data.batchGroupId === null ? -1 : data.batchGroupId;
 
         if (data.layers && Array.isArray(data.layers)) {
@@ -315,6 +319,7 @@ class ElementComponentSystem extends ComponentSystem {
             fontAsset: source.fontAsset,
             font: source.font,
             useInput: source.useInput,
+            preserveAspect: source.preserveAspect,
             batchGroupId: source.batchGroupId,
             mask: source.mask,
             outlineColor: source.outlineColor && source.outlineColor.clone() || source.outlineColor,

--- a/tests/framework/components/element/test_imageelement.js
+++ b/tests/framework/components/element/test_imageelement.js
@@ -1046,20 +1046,6 @@ describe('pc.ImageElement', function () {
         expect(e.element.texture).to.be.equal(texture);
     });
 
-    it('Setting texture on image element sets target aspect ratio', function () {
-        var e = new pc.Entity();
-        e.addComponent('element', {
-            type: 'image',
-            textureAsset: assets.texture.id
-        });
-
-        var texture = new pc.Texture(app.graphicsDevice);
-
-        e.element.texture = texture;
-
-        expect(e.element._image._targetAspectRatio).to.be.equal(1);
-    });
-
     it('Setting texture on image element clears sprite asset', function () {
         var e = new pc.Entity();
         e.addComponent('element', {
@@ -1172,7 +1158,7 @@ describe('pc.ImageElement', function () {
         expect(copy.element.sprite).to.equal(e.element.sprite);
     });
 
-    it('Setting texture and changing the aspectRatio setting changes the mesh', function () {
+    it('Setting texture and changing the fitMode setting changes the mesh', function () {
         var e = new pc.Entity();
         e.addComponent('element', {
             type: 'image',
@@ -1189,7 +1175,7 @@ describe('pc.ImageElement', function () {
         expect(e.element._image._targetAspectRatio).to.be.equal(1); // setting texture sets target aspect ratio
 
         // no aspect ratio fitting
-        expect(e.element.preserveAspect).to.equal(pc.ELEMENT_IMAGE_ASPECT_NONE);
+        expect(e.element.fitMode).to.equal(pc.ELEMENT_IMAGE_FIT_STRETCH);
         expect(e.element._image.mesh.aabb.center.x).to.equal(25);
         expect(e.element._image.mesh.aabb.center.y).to.equal(12.5);
         expect(e.element._image.mesh.aabb.halfExtents.x).to.equal(25);
@@ -1197,7 +1183,7 @@ describe('pc.ImageElement', function () {
 
         // change aspect ratio should trigger _updateMesh
         var spy = sandbox.spy(pc.ImageElement.prototype, '_updateMesh');
-        e.element.preserveAspect = pc.ELEMENT_IMAGE_ASPECT_CONTAIN;
+        e.element.fitMode = pc.ELEMENT_IMAGE_FIT_CONTAIN;
         expect(spy.calledOnce).to.equal(true);
 
         expect(e.element._image.mesh.aabb.center.x).to.equal(12.5);

--- a/tests/framework/components/element/test_imageelement.js
+++ b/tests/framework/components/element/test_imageelement.js
@@ -1172,7 +1172,7 @@ describe('pc.ImageElement', function () {
         expect(copy.element.sprite).to.equal(e.element.sprite);
     });
 
-    it('Setting texture ', function () {
+    it('Setting texture and changing the aspectRatio setting changes the mesh', function () {
         var e = new pc.Entity();
         e.addComponent('element', {
             type: 'image',

--- a/tests/framework/components/element/test_imageelement.js
+++ b/tests/framework/components/element/test_imageelement.js
@@ -1189,7 +1189,7 @@ describe('pc.ImageElement', function () {
         expect(e.element._image._targetAspectRatio).to.be.equal(1); // setting texture sets target aspect ratio
 
         // no aspect ratio fitting
-        expect(e.element.preserveAspect).to.equal(0);
+        expect(e.element.preserveAspect).to.equal(pc.ELEMENT_IMAGE_ASPECT_NONE);
         expect(e.element._image.mesh.aabb.center.x).to.equal(25);
         expect(e.element._image.mesh.aabb.center.y).to.equal(12.5);
         expect(e.element._image.mesh.aabb.halfExtents.x).to.equal(25);
@@ -1197,7 +1197,7 @@ describe('pc.ImageElement', function () {
 
         // change aspect ratio should trigger _updateMesh
         var spy = sandbox.spy(pc.ImageElement.prototype, '_updateMesh');
-        e.element.preserveAspect = 1;
+        e.element.preserveAspect = pc.ELEMENT_IMAGE_ASPECT_CONTAIN;
         expect(spy.calledOnce).to.equal(true);
 
         expect(e.element._image.mesh.aabb.center.x).to.equal(12.5);

--- a/tests/framework/components/element/test_imageelement.js
+++ b/tests/framework/components/element/test_imageelement.js
@@ -1175,7 +1175,7 @@ describe('pc.ImageElement', function () {
         expect(e.element._image._targetAspectRatio).to.be.equal(1); // setting texture sets target aspect ratio
 
         // no aspect ratio fitting
-        expect(e.element.fitMode).to.equal(pc.ELEMENT_IMAGE_FIT_STRETCH);
+        expect(e.element.fitMode).to.equal(pc.FITMODE_STRETCH);
         expect(e.element._image.mesh.aabb.center.x).to.equal(25);
         expect(e.element._image.mesh.aabb.center.y).to.equal(12.5);
         expect(e.element._image.mesh.aabb.halfExtents.x).to.equal(25);
@@ -1183,7 +1183,7 @@ describe('pc.ImageElement', function () {
 
         // change aspect ratio should trigger _updateMesh
         var spy = sandbox.spy(pc.ImageElement.prototype, '_updateMesh');
-        e.element.fitMode = pc.ELEMENT_IMAGE_FIT_CONTAIN;
+        e.element.fitMode = pc.FITMODE_CONTAIN;
         expect(spy.calledOnce).to.equal(true);
 
         expect(e.element._image.mesh.aabb.center.x).to.equal(12.5);

--- a/tests/framework/components/element/test_imageelement.js
+++ b/tests/framework/components/element/test_imageelement.js
@@ -545,11 +545,11 @@ describe('pc.ImageElement', function () {
         expect(e.element.spriteFrame).to.equal(0);
     });
 
-    it('Image element spriteFrame clamped to the latest frame available to the sprite when the frame keys of the sprite change', function () {
+    it('Image element spriteFrame clamped to the latest frame available to the sprite when the frame keys of the sprite change with correct aspect ratio', function () {
         var atlas = new pc.TextureAtlas();
         atlas.frames = {
-            0: { rect: new pc.Vec4(), pivot: new pc.Vec2() },
-            1: { rect: new pc.Vec4(), pivot: new pc.Vec2() }
+            0: { rect: new pc.Vec4(0, 0, 32, 32), pivot: new pc.Vec2() },
+            1: { rect: new pc.Vec4(0, 0, 16, 32), pivot: new pc.Vec2() }
         };
         atlas.texture = new pc.Texture(app.graphicsDevice);
 
@@ -564,9 +564,12 @@ describe('pc.ImageElement', function () {
         });
         app.root.addChild(e);
         expect(e.element.spriteFrame).to.equal(1);
+        expect(e.element._image._targetAspectRatio).to.equal(0.5);
 
         e.element.sprite.frameKeys = [0];
         expect(e.element.spriteFrame).to.equal(0);
+
+        expect(e.element._image._targetAspectRatio).to.equal(1);
     });
 
     it('Image element calls _updateMesh when its sprite is 9-sliced and the sprite\'s PPU changes', function () {
@@ -1043,6 +1046,20 @@ describe('pc.ImageElement', function () {
         expect(e.element.texture).to.be.equal(texture);
     });
 
+    it('Setting texture on image element sets target aspect ratio', function () {
+        var e = new pc.Entity();
+        e.addComponent('element', {
+            type: 'image',
+            textureAsset: assets.texture.id
+        });
+
+        var texture = new pc.Texture(app.graphicsDevice);
+
+        e.element.texture = texture;
+
+        expect(e.element._image._targetAspectRatio).to.be.equal(1);
+    });
+
     it('Setting texture on image element clears sprite asset', function () {
         var e = new pc.Entity();
         e.addComponent('element', {
@@ -1153,5 +1170,39 @@ describe('pc.ImageElement', function () {
 
         expect(copy.element.spriteAsset).to.be.null;
         expect(copy.element.sprite).to.equal(e.element.sprite);
+    });
+
+    it('Setting texture ', function () {
+        var e = new pc.Entity();
+        e.addComponent('element', {
+            type: 'image',
+            width: 50,
+            height: 25,
+            textureAsset: assets.texture.id
+        });
+        app.root.addChild(e);
+
+        var texture = new pc.Texture(app.graphicsDevice);
+
+        e.element.texture = texture;
+
+        expect(e.element._image._targetAspectRatio).to.be.equal(1); // setting texture sets target aspect ratio
+
+        // no aspect ratio fitting
+        expect(e.element.preserveAspect).to.equal(0);
+        expect(e.element._image.mesh.aabb.center.x).to.equal(25);
+        expect(e.element._image.mesh.aabb.center.y).to.equal(12.5);
+        expect(e.element._image.mesh.aabb.halfExtents.x).to.equal(25);
+        expect(e.element._image.mesh.aabb.halfExtents.y).to.equal(12.5);
+
+        // change aspect ratio should trigger _updateMesh
+        var spy = sandbox.spy(pc.ImageElement.prototype, '_updateMesh');
+        e.element.preserveAspect = 1;
+        expect(spy.calledOnce).to.equal(true);
+
+        expect(e.element._image.mesh.aabb.center.x).to.equal(12.5);
+        expect(e.element._image.mesh.aabb.center.y).to.equal(12.5);
+        expect(e.element._image.mesh.aabb.halfExtents.x).to.equal(12.5);
+        expect(e.element._image.mesh.aabb.halfExtents.y).to.equal(12.5);
     });
 });


### PR DESCRIPTION
Fixes https://github.com/playcanvas/engine/issues/3726

Adds a new property to `Element` component, used only on `Image`: `fitMode`. Set how the content should be fitted and preserve the aspect ratio of the source texture or sprite. (nomenclature is borrowed from https://developer.mozilla.org/en-US/docs/Web/CSS/object-fit):
- `stretch` (default; `pc.FITMODE_STRETCH`): Fit the content exactly to the Element's bounding box.
- `contain` (`pc.FITMODE_CONTAIN`): Fit the content within the Element's bounding box while preserving its Aspect Ratio.
- `cover` (`pc.FITMODE_COVER`): Fit the content to cover the entire Element's bounding box while preserving its Aspect Ratio.

![Screenshot 2022-04-25 at 14 41 18](https://user-images.githubusercontent.com/6392953/165101036-cb78ee65-eaad-4f3c-b3b3-1b30a5aa183d.png)

_the white boxes are other Image elements placed on top of the actual image and are there just to represent the actual bounds of each *Element*_


#### Extra: Cover + Masking

The `cover` setting works very well with an additional `mask` `Element` if the desired effect is to clip the content to only display the part _inside_ the bounding box:

![mask](https://user-images.githubusercontent.com/6392953/164683539-e11cf80f-7f74-40b7-a188-c0d9310e0f49.gif)

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
