### PR TITLE
2D UI rendering honors RenderTarget.flipY option

### DIFF
--- a/src/graphics/program-lib/chunks/transform.vert.js
+++ b/src/graphics/program-lib/chunks/transform.vert.js
@@ -3,6 +3,10 @@ export default /* glsl */`
 uniform vec4 uScreenSize;
 #endif
 
+#ifdef SCREENSPACE
+uniform float projectionFlipY;
+#endif
+
 #ifdef MORPHING
 uniform vec4 morph_weights_a;
 uniform vec4 morph_weights_b;
@@ -95,6 +99,7 @@ vec4 getPosition() {
     #else
     #ifdef SCREENSPACE
     screenPos = posW;
+    screenPos.y *= projectionFlipY;
     #else
     screenPos = matrix_viewProjection * posW;
     #endif

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -122,6 +122,7 @@ class ForwardRenderer {
         this.viewId3 = scope.resolve('matrix_view3');
         this.viewInvId = scope.resolve('matrix_viewInverse');
         this.viewProjId = scope.resolve('matrix_viewProjection');
+        this.flipYId = scope.resolve('projectionFlipY');
         this.viewPos = new Float32Array(3);
         this.viewPosId = scope.resolve('view_position');
         this.nearClipId = scope.resolve('camera_near');
@@ -352,6 +353,8 @@ class ForwardRenderer {
                 this.viewProjId.setValue(viewProjMat.data);
                 this.projSkyboxId.setValue(camera.getProjectionMatrixSkybox().data);
             }
+
+            this.flipYId.setValue(target?.flipY ? -1 : 1);
 
             // View Position (world space)
             this.dispatchViewPos(camera._node.getPosition());


### PR DESCRIPTION
Fixes https://github.com/playcanvas/engine/issues/4097

For 3D rendering, the flipY is handling by inverse scaling the projection matrix. 2D rendering does not use projection matrix (vertices are in screen space directly), and so a flip sign is manually applied in the vertex shader.