### PR TITLE
Add layer check between Camera and Element when testing for input.

### DIFF
--- a/src/framework/components/camera/component.js
+++ b/src/framework/components/camera/component.js
@@ -347,6 +347,10 @@ class CameraComponent extends Component {
         return this._camera.layers;
     }
 
+    get layersSet() {
+        return this._camera.layersSet;
+    }
+
     /**
      * The post effects queue for this camera. Use this to add or remove post effects from the camera.
      *

--- a/src/input/element-input.js
+++ b/src/input/element-input.js
@@ -948,6 +948,11 @@ class ElementInput {
         for (let i = 0, len = this._elements.length; i < len; i++) {
             const element = this._elements[i];
 
+            // check if any of the layers this element renders to is being rendered by the camera
+            if (!element.layers.some(v => camera.layers.indexOf(v) !== -1)) {
+                continue;
+            }
+
             if (element.screen && element.screen.screen.screenSpace) {
                 if (rayScreen === undefined) {
                     rayScreen = this._calculateRayScreen(x, y, camera, rayA) ? rayA : null;
@@ -998,6 +1003,11 @@ class ElementInput {
 
         for (let i = 0, len = this._elements.length; i < len; i++) {
             const element = this._elements[i];
+
+            // check if any of the layers this element renders to is being rendered by the camera
+            if (!element.layers.some(v => camera.layers.indexOf(v) !== -1)) {
+                continue;
+            }
 
             if (!element.screen || !element.screen.screen.screenSpace) {
                 if (this._checkElement(rayA, element, false) >= 0) {

--- a/src/input/element-input.js
+++ b/src/input/element-input.js
@@ -949,7 +949,7 @@ class ElementInput {
             const element = this._elements[i];
 
             // check if any of the layers this element renders to is being rendered by the camera
-            if (!element.layers.some(v => camera.layers.indexOf(v) !== -1)) {
+            if (!element.layers.some(v => camera.layersSet.has(v))) {
                 continue;
             }
 
@@ -1005,7 +1005,7 @@ class ElementInput {
             const element = this._elements[i];
 
             // check if any of the layers this element renders to is being rendered by the camera
-            if (!element.layers.some(v => camera.layers.indexOf(v) !== -1)) {
+            if (!element.layers.some(v => camera.layersSet.has(v))) {
                 continue;
             }
 

--- a/src/scene/camera.js
+++ b/src/scene/camera.js
@@ -42,6 +42,7 @@ class Camera {
         this._frustumCulling = true;
         this._horizontalFov = false;
         this._layers = [LAYERID_WORLD, LAYERID_DEPTH, LAYERID_SKYBOX, LAYERID_UI, LAYERID_IMMEDIATE];
+        this._layersSet = new Set(this._layers);
         this._nearClip = 0.1;
         this._node = null;
         this._orthoHeight = 10;
@@ -225,10 +226,15 @@ class Camera {
 
     set layers(newValue) {
         this._layers = newValue.slice(0);
+        this._layersSet = new Set(this._layers);
     }
 
     get layers() {
         return this._layers;
+    }
+
+    get layersSet() {
+        return this._layersSet;
     }
 
     set nearClip(newValue) {


### PR DESCRIPTION
Fixes https://github.com/playcanvas/engine/issues/4180

Add layer check between Camera and Element when testing for input, with performance-friendly implementation using a new `layersSet` property in Camera.

Tested against https://launch.playcanvas.com/1383836?debug=true and works as expected.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
