### PR TITLE
Fix for invalid shaders with Ao

### DIFF
--- a/src/graphics/program-lib/programs/standard.js
+++ b/src/graphics/program-lib/programs/standard.js
@@ -1424,10 +1424,10 @@ const standard = {
             }
 
             if (options.fresnelModel > 0) code += "   getFresnel();\n";
+        }
 
-            if (useAo) {
-                code += "  getAO();\n";
-            }
+        if (useAo) {
+            code += "  getAO();\n";
         }
 
         if (addAmbient) {


### PR DESCRIPTION
Fixes https://forum.playcanvas.com/t/weird-lighting-issue-in-new-engine-version-1-53-2/25441/7

In some cases `getAO()` wasn't being called.