### PR TITLE
Add missing texture bias to channels

### DIFF
--- a/src/graphics/program-lib/chunks/lit/lightmapDir.frag.js
+++ b/src/graphics/program-lib/chunks/lit/lightmapDir.frag.js
@@ -3,8 +3,8 @@ uniform sampler2D texture_lightMap;
 uniform sampler2D texture_dirLightMap;
 
 void addLightMap() {
-    vec3 color = $texture2DSAMPLE(texture_lightMap, $UV).$CH;
-    vec3 dir = texture2D(texture_dirLightMap, $UV).xyz;
+    vec3 color = $texture2DSAMPLE(texture_lightMap, $UV, textureBias).$CH;
+    vec3 dir = texture2D(texture_dirLightMap, $UV, textureBias).xyz;
     if (dot(dir, vec3(1.0)) < 0.00001) {
         dDiffuseLight += color;
     } else {

--- a/src/graphics/program-lib/chunks/lit/lightmapSingle.frag.js
+++ b/src/graphics/program-lib/chunks/lit/lightmapSingle.frag.js
@@ -7,7 +7,7 @@ void addLightMap() {
     vec3 lm = vec3(1.0);
 
     #ifdef MAPTEXTURE
-    lm *= $texture2DSAMPLE(texture_lightMap, $UV).$CH;
+    lm *= $texture2DSAMPLE(texture_lightMap, $UV, textureBias).$CH;
     #endif
 
     #ifdef MAPVERTEX

--- a/src/graphics/program-lib/chunks/standard/clearCoat.frag.js
+++ b/src/graphics/program-lib/chunks/standard/clearCoat.frag.js
@@ -15,7 +15,7 @@ void getClearCoat() {
     #endif
 
     #ifdef MAPTEXTURE
-    ccSpecularity *= texture2D(texture_clearCoatMap, $UV).$CH;
+    ccSpecularity *= texture2D(texture_clearCoatMap, $UV, textureBias).$CH;
     #endif
 
     #ifdef MAPVERTEX

--- a/src/graphics/program-lib/chunks/standard/clearCoatGloss.frag.js
+++ b/src/graphics/program-lib/chunks/standard/clearCoatGloss.frag.js
@@ -15,7 +15,7 @@ void getClearCoatGlossiness() {
     #endif
 
     #ifdef MAPTEXTURE
-    ccGlossiness *= texture2D(texture_clearCoatGlossMap, $UV).$CH;
+    ccGlossiness *= texture2D(texture_clearCoatGlossMap, $UV, textureBias).$CH;
     #endif
 
     #ifdef MAPVERTEX

--- a/src/graphics/program-lib/chunks/standard/clearCoatNormal.frag.js
+++ b/src/graphics/program-lib/chunks/standard/clearCoatNormal.frag.js
@@ -6,7 +6,7 @@ uniform float material_clearCoatBumpiness;
 
 void getClearCoatNormal() {
     #ifdef MAPTEXTURE
-    vec3 normalMap = unpackNormal(texture2D(texture_clearCoatNormalMap, $UV));
+    vec3 normalMap = unpackNormal(texture2D(texture_clearCoatNormalMap, $UV, textureBias));
     normalMap = normalize(mix(vec3(0.0, 0.0, 1.0), normalMap, material_clearCoatBumpiness));
     ccNormalW = dTBN * normalMap;
     #else

--- a/src/graphics/program-lib/chunks/standard/diffuseDetailMap.frag.js
+++ b/src/graphics/program-lib/chunks/standard/diffuseDetailMap.frag.js
@@ -5,7 +5,7 @@ uniform sampler2D texture_diffuseDetailMap;
 
 vec3 addAlbedoDetail(vec3 albedo) {
     #ifdef MAPTEXTURE
-    vec3 albedoDetail = vec3(texture2D(texture_diffuseDetailMap, $UV).$CH);
+    vec3 albedoDetail = vec3(texture2D(texture_diffuseDetailMap, $UV, textureBias).$CH);
     return detailMode_$DETAILMODE(albedo, albedoDetail);
     #else
     return albedo;

--- a/src/graphics/program-lib/chunks/standard/emissive.frag.js
+++ b/src/graphics/program-lib/chunks/standard/emissive.frag.js
@@ -23,7 +23,7 @@ vec3 getEmission() {
     #endif
 
     #ifdef MAPTEXTURE
-    emission *= $texture2DSAMPLE(texture_emissiveMap, $UV).$CH;
+    emission *= $texture2DSAMPLE(texture_emissiveMap, $UV, textureBias).$CH;
     #endif
 
     #ifdef MAPVERTEX

--- a/src/graphics/program-lib/chunks/standard/gloss.frag.js
+++ b/src/graphics/program-lib/chunks/standard/gloss.frag.js
@@ -15,7 +15,7 @@ void getGlossiness() {
     #endif
 
     #ifdef MAPTEXTURE
-    dGlossiness *= texture2D(texture_glossMap, $UV).$CH;
+    dGlossiness *= texture2D(texture_glossMap, $UV, textureBias).$CH;
     #endif
 
     #ifdef MAPVERTEX


### PR DESCRIPTION
Fixes https://forum.playcanvas.com/t/sudden-fragment-shader-error-has-appeared-in-our-project/25424/8

Not all channels had textureBias applied, which is now required for ninesliced tiled rendering.

This PR adds the missing textureBias.