### PR TITLE
Sanity check on Scene data where the child entity is in the Entity data children list twice

### DIFF
--- a/src/resources/parser/scene.js
+++ b/src/resources/parser/scene.js
@@ -114,9 +114,16 @@ class SceneParser {
 
         // If the data mis matches the entities created, attempt
         // to recover
-        if (len !== children.length) {
+        let entityChildrenCount = 0;
+        for (let i = 0; i < children.length; i++) {
+            if (children[i] instanceof Entity) {
+                ++entityChildrenCount;
+            }
+        }
+
+        if (len !== entityChildrenCount) {
             Debug.warn('Scene entity data mismatch with created entities');
-            len = children.length;
+            len = entityChildrenCount;
         }
 
         for (let i = 0; i < len; i++) {

--- a/src/resources/parser/scene.js
+++ b/src/resources/parser/scene.js
@@ -1,6 +1,7 @@
 import { Entity } from '../../framework/entity.js';
 
 import { CompressUtils } from '../../compress/compress-utils.js';
+import { Debug } from "../../core/debug.js";
 import { Decompress } from '../../compress/decompress.js';
 
 class SceneParser {
@@ -110,6 +111,14 @@ class SceneParser {
         // Open all children and add them to the node
         len = entityData.children.length;
         const children = entity._children;
+
+        // If the data mis matches the entities created, attempt
+        // to recover
+        if (len !== children.length) {
+            Debug.warn('Scene entity data mismatch with created entities');
+            len = children.length;
+        }
+
         for (let i = 0; i < len; i++) {
             children[i] = this._openComponentData(children[i], entities);
         }

--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -1,3 +1,4 @@
+import { Debug } from "../core/debug.js";
 import { EventHandler } from '../core/event-handler.js';
 import { Tags } from '../core/tags.js';
 
@@ -1155,8 +1156,10 @@ class GraphNode extends EventHandler {
      * this.entity.addChild(e);
      */
     addChild(node) {
-        if (node._parent !== null)
-            throw new Error('GraphNode is already parented');
+        if (node._parent !== null) {
+            Debug.warn(`GraphNode '${node.name}' is already parented`);
+            return;
+        }
 
         // #if _DEBUG
         this._debugInsertChild(node);
@@ -1206,8 +1209,10 @@ class GraphNode extends EventHandler {
      * this.entity.insertChild(e, 1);
      */
     insertChild(node, index) {
-        if (node._parent !== null)
-            throw new Error('GraphNode is already parented');
+        if (node._parent !== null) {
+            Debug.warn('GraphNode is already parented');
+            return;
+        }
 
         // #if _DEBUG
         this._debugInsertChild(node);
@@ -1224,10 +1229,10 @@ class GraphNode extends EventHandler {
      */
     _debugInsertChild(node) {
         if (this === node)
-            throw new Error('GraphNode cannot be a child of itself');
+            throw new Error(`GraphNode '${node.name}' cannot be a child of itself`);
 
         if (this.isDescendantOf(node))
-            throw new Error('GraphNode cannot add an ancestor as a child');
+            throw new Error(`GraphNode '${node.name}' cannot add an ancestor as a child`);
     }
     // #endif
 


### PR DESCRIPTION
Related tickets: 

https://github.com/playcanvas/engine/issues/4228
https://github.com/playcanvas/editor/issues/758

I'm not advocating for this change as it seems like it could affect runtime performance but more to show what we would need if we wanted to make the engine resilient against scene corruption from the Editor in issue: https://github.com/playcanvas/editor/issues/758

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
