### PR TITLE
Add .gitattributes to normalize how line endings are stored

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,12 +1,12 @@
-# This file normalizes line endings stored in the repo to LF.
+# This file normalizes line endings stored in the repo to LF (Unix/Git).
 # Contributors are still able to use their native line endings locally.
 # More info here: https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings
 
 # Set the default behavior, in case people don't have core.autocrlf set.
 * text=auto
 
-# Explicitly declare text files to be normalized and converted
-# to native line endings on checkout.
+# Explicitly declare text files to be normalized on checkin
+# and converted back to native line endings on checkout.
 *.js text
 *.json text
 *.mjs text
@@ -26,7 +26,7 @@
 *.yaml text
 *.babelrc text
 
-# Denote all files that are truly binary and should not be modified.
+# Denote all files that are truly binary and should therefore not be modified.
 *.png binary
 *.jpg binary
 *.glb binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,41 @@
+# This file normalizes line endings stored in the repo to LF.
+# Contributors are still able to use their native line endings locally.
+# More info here: https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings
+
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# Explicitly declare text files to be normalized and converted
+# to native line endings on checkout.
+*.js text
+*.json text
+*.mjs text
+*.cjs text
+*.jsx text
+*.ts text
+*.txt text
+*.tsx text
+*.md text
+*.html text
+*.gltf text
+*.glsl text
+*.css text
+*.mustache text
+*.obj text
+*.atlas text
+*.yaml text
+*.babelrc text
+
+# Denote all files that are truly binary and should not be modified.
+*.png binary
+*.jpg binary
+*.glb binary
+*.fbx binary
+*.wasm binary
+*.basis binary
+*.bin binary
+*.dds binary
+*.drc binary
+*.mp3 binary
+*.mp4 binary
+*.gz binary


### PR DESCRIPTION
Related to issue #4238

## Problem
Line endings in the repo are inconsistent between CRLF (Windows) and LF (Unix/Git).

## Solution
Add a .gitattributes file so that git will normalize files as they are checked in, while still allowing developers to use their native line endings locally. 

Issue #4238 suggests an additional cleanup task to fix existing files that were already checked in as CRLF. I am happy to open that task as a PR as well (just let me know), but I thought that the core maintainers might prefer to do so since it will be a scary diff (every line changed in 30 files).

## Context
Currently around 5% of the source files are stored as CRLF (Windows), and the other 95% are LF (Unix) (see full report in #4238).

This causes issues for developers on both platforms: 
* It can be tricky to ensure your editor retains the existing line endings for a given file, but if you change a file's line endings the resulting diff will show every line as changed. This makes it hard to review the PR! ([example](https://github.com/playcanvas/engine/pull/1824/commits/07f7ba2b8bc0c4b211cc9d0d506d28daa1b2e0b4))
* Developers might also be confused about whether they should be changing line endings deliberately for consistency. 
 For example, `mat4.js` and `vec2.js` use different line endings - should a developer change them to be consistent, or leave them as they are? What format should they use for a new file? 

By using `.gitattributes` to normalize line endings at checkin/checkout, no-one will have to think about line endings ever again 🥳

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
