### PR TITLE
[FIX] Move closing parentheses to the right place

### DIFF
--- a/examples/src/app/helpers/formatters.mjs
+++ b/examples/src/app/helpers/formatters.mjs
@@ -66,9 +66,9 @@ const getExampleClassFromTextFile = (Babel, text) => {
 };
 
 const getEngineTypeFromClass = (text) => {
-    if (text.indexOf(`_defineProperty(Example, "ENGINE", 'DEBUG');` !== -1)) {
+    if (text.indexOf(`_defineProperty(Example, "ENGINE", 'DEBUG');`) !== -1) {
         return 'DEBUG';
-    } else if (text.indexOf(`_defineProperty(Example, "ENGINE", 'PERFORMANCE');` !== -1)) {
+    } else if (text.indexOf(`_defineProperty(Example, "ENGINE", 'PERFORMANCE');`) !== -1) {
         return 'PERFORMANCE';
     }
     return null;


### PR DESCRIPTION
Fix this:

![image](https://user-images.githubusercontent.com/697563/168820528-c1de6294-00ee-49aa-8a8f-5566169713bf.png)


I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
