### PR TITLE
Update torus primitive

### DIFF
--- a/examples/src/examples/graphics/lights-baked.tsx
+++ b/examples/src/examples/graphics/lights-baked.tsx
@@ -15,7 +15,7 @@ class LightsBakedExample {
         app.setCanvasResolution(pc.RESOLUTION_AUTO);
 
         // All render component primitive shape types
-        const shapes = ["box", "cone", "cylinder", "sphere", "capsule"];
+        const shapes = ["box", "cone", "cylinder", "sphere", "capsule", "torus"];
 
         for (let i = 0; i < 40; i++) {
             const shape = shapes[Math.floor(Math.random() * shapes.length)];

--- a/src/framework/components/model/component.js
+++ b/src/framework/components/model/component.js
@@ -203,6 +203,7 @@ class ModelComponent extends Component {
      * - "cylinder": The component will render a cylinder (radius 0.5, height 1)
      * - "plane": The component will render a plane (1 unit in each dimension)
      * - "sphere": The component will render a sphere (radius 0.5)
+     * - "torus": The component will render a torus (tubeRadius: 0.2, ringRadius: 0.3)
      *
      * @type {string}
      */

--- a/src/framework/components/render/component.js
+++ b/src/framework/components/render/component.js
@@ -196,6 +196,7 @@ class RenderComponent extends Component {
      * - "cylinder": The component will render a cylinder (radius 0.5, height 1)
      * - "plane": The component will render a plane (1 unit in each dimension)
      * - "sphere": The component will render a sphere (radius 0.5)
+     * - "torus": The component will render a torus (tubeRadius: 0.2, ringRadius: 0.3)
      *
      * @type {string}
      */

--- a/src/scene/procedural.js
+++ b/src/scene/procedural.js
@@ -344,6 +344,7 @@ function createTorus(device, opts) {
     const options = {
         normals: normals,
         uvs: uvs,
+        uvs1: uvs,
         indices: indices
     };
 
@@ -1039,6 +1040,11 @@ function getShapePrimitive(device, type) {
             case 'sphere':
                 mesh = createSphere(device, { radius: 0.5 });
                 area = { x: Math.PI, y: Math.PI, z: Math.PI, uv: 1 };
+                break;
+
+            case 'torus':
+                mesh = createTorus(device, { tubeRadius: 0.2, ringRadius: 0.3 });
+                area = { x: Math.PI * 0.5 * 0.5 - Math.PI * 0.1 * 0.1, y: 0.4, z: 0.4, uv: 1 };
                 break;
 
             default:


### PR DESCRIPTION
This PR:
- adds support for torus to `getShapePrimitive`
- calculates torus area
- sets the second set of UVs on torus prim (like the others)

! Make torus great again !