### PR TITLE
Remove many `ts-ignore` statements from examples

### DIFF
--- a/examples/src/app/control-panel.tsx
+++ b/examples/src/app/control-panel.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from 'react';
-// @ts-ignore: library file import
 import MonacoEditor from "@monaco-editor/react";
 import { Button, Container, Panel } from '@playcanvas/pcui/react';
 
@@ -21,7 +20,6 @@ const ControlPanel = (props: any) => {
         document.getElementById('paramButton').classList.toggle('selected');
         document.getElementById('codeButton').classList.toggle('selected');
         const controls = document.getElementById('controlPanel-controls');
-        // @ts-ignore
         controls.classList.remove('pcui-hidden');
     };
     const onClickCodeTab = () => {
@@ -36,7 +34,6 @@ const ControlPanel = (props: any) => {
         document.getElementById('paramButton').classList.toggle('selected');
         document.getElementById('codeButton').classList.toggle('selected');
         const controls = document.getElementById('controlPanel-controls');
-        // @ts-ignore
         controls.classList.add('pcui-hidden');
     };
 

--- a/examples/src/examples/graphics/clustered-area-lights.tsx
+++ b/examples/src/examples/graphics/clustered-area-lights.tsx
@@ -54,27 +54,19 @@ class AreaLightsExample {
             app.scene.toneMapping = pc.TONEMAP_ACES;
 
             // enabled clustered lighting. This is a temporary API and will change in the future
-            // @ts-ignore engine-tsd
             app.scene.clusteredLightingEnabled = true;
 
-            // adjust default clustered lighting parameters to handle many lights:
-            // @ts-ignore
+            // adjust default clustered lighting parameters to handle many lights
             const lighting = app.scene.lighting;
 
-            // 1) subdivide space with lights into this many cells:
-            // @ts-ignore engine-tsd
+            // 1) subdivide space with lights into this many cells
             lighting.cells = new pc.Vec3(30, 2, 30);
 
-            // 2) and allow this many lights per cell:
-            // @ts-ignore engine-tsd
+            // 2) and allow this many lights per cell
             lighting.maxLightsPerCell = 20;
 
-            // @ts-ignore engine-tsd
             lighting.areaLightsEnabled = true;
-
-            // @ts-ignore engine-tsd
             lighting.shadowsEnabled = false;
-
 
             // pure black material - used on back side of light objects
             const blackMaterial = new pc.StandardMaterial();

--- a/examples/src/examples/graphics/clustered-lighting.tsx
+++ b/examples/src/examples/graphics/clustered-lighting.tsx
@@ -30,21 +30,17 @@ class ClusteredLightingExample {
             app.start();
 
             // enabled clustered lighting. This is a temporary API and will change in the future
-            // @ts-ignore engine-tsd
             app.scene.clusteredLightingEnabled = true;
 
-            // @ts-ignore adjust default clustered lighting parameters to handle many lights:
+            // adjust default clustered lighting parameters to handle many lights
             const lighting = app.scene.lighting;
 
-            // 1) subdivide space with lights into this many cells:
-            // @ts-ignore engine-tsd
+            // 1) subdivide space with lights into this many cells
             lighting.cells = new pc.Vec3(12, 16, 12);
 
-            // 2) and allow this many lights per cell:
-            // @ts-ignore engine-tsd
+            // 2) and allow this many lights per cell
             lighting.maxLightsPerCell = 48;
 
-            // @ts-ignore engine-tsd
             lighting.shadowsEnabled = false;
 
             // Set the canvas to fill the window and automatically change resolution to be the same as the canvas size

--- a/examples/src/examples/graphics/clustered-omni-shadows.tsx
+++ b/examples/src/examples/graphics/clustered-omni-shadows.tsx
@@ -71,27 +71,21 @@ class ClusteredOmniShadowsExample {
             app.setCanvasResolution(pc.RESOLUTION_AUTO);
 
             // enabled clustered lighting. This is a temporary API and will change in the future
-            // @ts-ignore engine-tsd
             app.scene.clusteredLightingEnabled = true;
 
-            // adjust default clustered lighting parameters to handle many lights:
-            // @ts-ignore
+            // adjust default clustered lighting parameters to handle many lights
             const lighting = app.scene.lighting;
 
-            // 1) subdivide space with lights into this many cells:
-            // @ts-ignore engine-tsd
+            // 1) subdivide space with lights into this many cells
             lighting.cells = new pc.Vec3(16, 12, 16);
 
-            // 2) and allow this many lights per cell:
-            // @ts-ignore engine-tsd
+            // 2) and allow this many lights per cell
             lighting.maxLightsPerCell = 12;
 
             // enable clustered shadows (it's enabled by default as well)
-            // @ts-ignore engine-tsd
             lighting.shadowsEnabled = true;
 
             // enable clustered cookies
-            // @ts-ignore engine-tsd
             lighting.cookiesEnabled = true;
 
             // resolution of the shadow and cookie atlas
@@ -163,7 +157,6 @@ class ClusteredOmniShadowsExample {
                     assets.xmas_posz.id, assets.xmas_negz.id
                 ]
             });
-            // @ts-ignore engine-tsd
             cubemapAsset.loadFaces = true;
             app.assets.add(cubemapAsset);
 

--- a/examples/src/examples/graphics/clustered-spot-shadows.tsx
+++ b/examples/src/examples/graphics/clustered-spot-shadows.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-// @ts-ignore: library file import
 import * as pc from '../../../../';
 
 import { BindingTwoWay } from '@playcanvas/pcui';
@@ -99,28 +98,22 @@ class ClusteredSpotShadowsExample {
             app.scene.setSkybox(assets.cubemap.resources);
 
             // enabled clustered lighting. This is a temporary API and will change in the future
-            // @ts-ignore engine-tsd
             app.scene.clusteredLightingEnabled = true;
 
-            // adjust default clustered lighting parameters to handle many lights:
-            // @ts-ignore
+            // adjust default clustered lighting parameters to handle many lights
             const lighting = app.scene.lighting;
 
-            // 1) subdivide space with lights into this many cells:
-            // @ts-ignore engine-tsd
+            // 1) subdivide space with lights into this many cells
             lighting.cells = new pc.Vec3(12, 4, 12);
 
-            // 2) and allow this many lights per cell:
-            // @ts-ignore engine-tsd
+            // 2) and allow this many lights per cell
             const maxLights = 24;
             lighting.maxLightsPerCell = maxLights;
 
             // enable clustered shadows (it's enabled by default as well)
-            // @ts-ignore engine-tsd
             lighting.shadowsEnabled = true;
 
             // enable clustered cookies
-            // @ts-ignore engine-tsd
             lighting.cookiesEnabled = true;
 
             // resolution of the shadow and cookie atlas

--- a/examples/src/examples/graphics/ground-fog.tsx
+++ b/examples/src/examples/graphics/ground-fog.tsx
@@ -241,7 +241,6 @@ class GroundFogExample {
                 material.setParameter('uSoftening', data.get('data.softness') ? 50 : 1000);
 
                 // debug rendering of the deptht texture in the corner
-                // @ts-ignore engine-tsd
                 app.drawDepthTexture(0.7, -0.7, 0.5, 0.5);
             });
         });

--- a/examples/src/examples/graphics/lights-baked-a-o.tsx
+++ b/examples/src/examples/graphics/lights-baked-a-o.tsx
@@ -280,7 +280,6 @@ class LightsBakedAOExample {
                     app.lightmapper.bake(null, bakeType);
 
                     // update stats with the bake duration
-                    // @ts-ignore engine-tsd
                     data.set('data.stats.duration', app.lightmapper.stats.totalRenderTime.toFixed(1) + 'ms');
                 }
             });

--- a/examples/src/examples/graphics/lights.tsx
+++ b/examples/src/examples/graphics/lights.tsx
@@ -45,7 +45,6 @@ class LightsExample {
         </>;
     }
 
-    // @ts-ignore: override class function$
     example(canvas: HTMLCanvasElement, data:any): void {
         function createMaterial(colors: any) {
             const material: any = new pc.StandardMaterial();
@@ -170,7 +169,6 @@ class LightsExample {
                     assets.xmas_posz.id, assets.xmas_negz.id
                 ]
             });
-            // @ts-ignore engine-tsd
             cubemapAsset.loadFaces = true;
             app.assets.add(cubemapAsset);
 

--- a/examples/src/examples/misc/spineboy.tsx
+++ b/examples/src/examples/misc/spineboy.tsx
@@ -4,8 +4,6 @@ class SpineboyExample {
     static CATEGORY = 'Misc';
     static NAME = 'Spineboy';
 
-
-    // @ts-ignore: override class function
     example(canvas: HTMLCanvasElement): void {
 
         const app = new pc.Application(canvas, {});

--- a/examples/src/examples/user-interface/text-emojis.tsx
+++ b/examples/src/examples/user-interface/text-emojis.tsx
@@ -57,7 +57,6 @@ class TextEmojisExample {
             const size = 64;
             const elSize = 32;
 
-            // @ts-ignore engine-tsd
             const canvasFont = new pc.CanvasFont(app, {
                 color: new pc.Color(1, 1, 1), // white
                 fontName: "Arial",

--- a/examples/src/examples/user-interface/world-to-screen.tsx
+++ b/examples/src/examples/user-interface/world-to-screen.tsx
@@ -91,7 +91,6 @@ class WorldToScreenExample {
                 screenPos.y *= pixelRatio;
 
                 // account for screen scaling
-                // @ts-ignore engine-tsd
                 const scale = screen.scale;
 
                 // invert the y position


### PR DESCRIPTION
With improvements to the Engine's TypeScript declarations, it was possible to remove 33 occurrences of `@ts-ignore` from the examples. Only 78 now remain in the entire Examples Browser.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
