### PR TITLE
Basic implementation of RenderPass based architecture

### DIFF
--- a/examples/src/examples/graphics/post-effects.tsx
+++ b/examples/src/examples/graphics/post-effects.tsx
@@ -284,8 +284,8 @@ class PostEffectsExample {
                 // - it's a negative distance between the camera and the focus sphere
                 camera.script.bokeh.focus = -focusPosition.sub(camera.getPosition()).length();
 
-                // display the depth texture if bokeh is enabled
-                if (camera.script.bokeh.enabled) {
+                // display the depth texture if it was rendered
+                if (data.get('scripts.bokeh.enabled') || data.get('scripts.ssao.enabled')) {
                     // @ts-ignore engine-tsd
                     app.drawDepthTexture(0.7, -0.7, 0.5, 0.5);
                 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -140,6 +140,7 @@ const stripOptions = {
         'Debug.log',
         'Debug.logOnce',
         'Debug.trace',
+        'DebugHelper.setName',
         'DebugGraphics.pushGpuMarker',
         'DebugGraphics.popGpuMarker',
         'WorldClustersDebug.render'

--- a/scripts/utils/cubemap-renderer.js
+++ b/scripts/utils/cubemap-renderer.js
@@ -70,6 +70,7 @@ CubemapRenderer.prototype.initialize = function () {
 
         // render target, connected to cubemap texture face
         var renderTarget = new pc.RenderTarget({
+            name: `CubemapRenderer-Face${i}`,
             colorBuffer: this.cubeMap,
             depth: this.depth,
             face: i,

--- a/scripts/utils/cubemap-renderer.js
+++ b/scripts/utils/cubemap-renderer.js
@@ -70,7 +70,7 @@ CubemapRenderer.prototype.initialize = function () {
 
         // render target, connected to cubemap texture face
         var renderTarget = new pc.RenderTarget({
-            name: `CubemapRenderer-Face${i}`,
+            name: 'CubemapRenderer-Face' + i,
             colorBuffer: this.cubeMap,
             depth: this.depth,
             face: i,

--- a/src/core/debug.js
+++ b/src/core/debug.js
@@ -167,4 +167,23 @@ class Debug {
     }
 }
 
-export { Debug };
+/**
+ * A helper debug functionality.
+ *
+ * @ignore
+ */
+class DebugHelper {
+    /**
+     * Set a name to the name property of the object. Executes only in the debug build.
+     *
+     * @param {Object} object - The object to assign the name to.
+     * @param {string} name - The name to assign.
+     */
+    static setName(object, name) {
+        if (object) {
+            object.name = name;
+        }
+    }
+}
+
+export { Debug, DebugHelper };

--- a/src/core/debug.js
+++ b/src/core/debug.js
@@ -47,6 +47,7 @@ class Debug {
      * @param {string} channel - Name of the trace channel. Can be
      *
      * - {@link TRACEID_RENDER_FRAME}
+     * - {@link TRACEID_RENDER_PASS}
      *
      * @param {boolean} enabled - new enabled state for it
      */

--- a/src/core/debug.js
+++ b/src/core/debug.js
@@ -44,7 +44,7 @@ class Debug {
     /**
      * Enable or disable trace channel
      *
-     * @param {string} channel - Name of the trace channel. Can be
+     * @param {string} channel - Name of the trace channel. Can be:
      *
      * - {@link TRACEID_RENDER_FRAME}
      * - {@link TRACEID_RENDER_PASS}

--- a/src/core/debug.js
+++ b/src/core/debug.js
@@ -1,8 +1,28 @@
 /**
- * Internal debug system - logs, assets and similar. Note that the functions only execute in the
- * debug build, and are stripped out in other builds.
+ * Logs a frame number.
  *
- * @ignore
+ * @type {string}
+ */
+export const TRACEID_RENDER_FRAME = 'RenderFrame';
+
+/**
+ * Logs a render target resolve operations.
+ *
+ * @type {string}
+ */
+export const TRACEID_RT_RESOLVE = 'RT-Resolve';
+
+/**
+ * Logs a render passes.
+ *
+ * @type {string}
+ */
+export const TRACEID_RENDER_PASS = 'RenderPass';
+
+/**
+ * Engine debug log system. Note that the logging only executes in the
+ * debug build of the engine, and is stripped out in other builds. It allows
+ * you to monitor logs from various engine systems.
  */
 class Debug {
     /**
@@ -24,7 +44,10 @@ class Debug {
     /**
      * Enable or disable trace channel
      *
-     * @param {string} channel - Name of the trace channel
+     * @param {string} channel - Name of the trace channel. Can be
+     *
+     * - {@link TRACEID_RENDER_FRAME}
+     *
      * @param {boolean} enabled - new enabled state for it
      */
     static setTrace(channel, enabled = true) {
@@ -42,6 +65,7 @@ class Debug {
      * Deprecated warning message.
      *
      * @param {string} message - The message to log.
+     * @ignore
      */
     static deprecated(message) {
         if (!Debug._loggedMessages.has(message)) {
@@ -55,6 +79,7 @@ class Debug {
      *
      * @param {boolean|object} assertion - The assertion to check.
      * @param {...*} args - The values to be written to the log.
+     * @ignore
      */
     static assert(assertion, ...args) {
         if (!assertion) {
@@ -66,6 +91,7 @@ class Debug {
      * Info message.
      *
      * @param {...*} args - The values to be written to the log.
+     * @ignore
      */
     static log(...args) {
         console.log(...args);
@@ -87,6 +113,7 @@ class Debug {
      * Warning message.
      *
      * @param {...*} args - The values to be written to the log.
+     * @ignore
      */
     static warn(...args) {
         console.warn(...args);
@@ -108,6 +135,7 @@ class Debug {
      * Error message.
      *
      * @param {...*} args - The values to be written to the log.
+     * @ignore
      */
     static error(...args) {
         console.error(...args);
@@ -130,6 +158,7 @@ class Debug {
      *
      * @param {string} channel - The trace channel
      * @param {...*} args - The values to be written to the log.
+     * @ignore
      */
     static trace(channel, ...args) {
         if (Debug._traceChannels.has(channel)) {

--- a/src/framework/app-base.js
+++ b/src/framework/app-base.js
@@ -6,7 +6,7 @@ import { platform } from '../core/platform.js';
 import { now } from '../core/time.js';
 import { path } from '../core/path.js';
 import { EventHandler } from '../core/event-handler.js';
-import { Debug, TRACEID_RENDER_PASS, TRACEID_RENDER_FRAME, TRACEID_RT_RESOLVE } from '../core/debug.js';
+import { Debug, TRACEID_RENDER_FRAME } from '../core/debug.js';
 
 import { math } from '../math/math.js';
 import { Color } from '../math/color.js';
@@ -2166,20 +2166,6 @@ const makeTick = function (_app) {
         application.update(dt);
 
         application.fire("framerender");
-
-
-
-
-        // !!!!!!!!!!!!! these lines needs to be removed !!!!!!!!!!
-        // (and likely imports of the constants)
-        const logThisFrame = (application.frame % 100) === 0;
-        Debug.setTrace(TRACEID_RENDER_FRAME, logThisFrame);
-        Debug.setTrace(TRACEID_RT_RESOLVE, logThisFrame);
-        Debug.setTrace(TRACEID_RENDER_PASS, logThisFrame);
-
-
-
-
 
         Debug.trace(TRACEID_RENDER_FRAME, `--- Frame ${application.frame}`);
 

--- a/src/framework/app-base.js
+++ b/src/framework/app-base.js
@@ -1201,8 +1201,8 @@ class AppBase extends EventHandler {
 
     /**
      * Render the application's scene. More specifically, the scene's {@link LayerComposition} is
-     * rendered by the application's {@link ForwardRenderer}. This function is called internally in
-     * the application's main loop and does not need to be called explicitly.
+     * rendered. This function is called internally in the application's main loop and does not
+     * need to be called explicitly.
      */
     render() {
         // #if _PROFILER

--- a/src/framework/app-base.js
+++ b/src/framework/app-base.js
@@ -454,7 +454,7 @@ class AppBase extends EventHandler {
          * @type {FrameGraph}
          * @ignore
          */
-        this.frameGraph = new FrameGraph();
+        this.frameGraph = new FrameGraph(this.graphicsDevice);
 
         /**
          * The run-time lightmapper.

--- a/src/framework/components/camera/component.js
+++ b/src/framework/components/camera/component.js
@@ -128,7 +128,7 @@ class CameraComponent extends Component {
      * Custom function that is called when postprocessing should execute.
      *
      * @type {Function}
-     * @private
+     * @ignore
      */
     onPostprocessing = null;
 
@@ -567,30 +567,24 @@ class CameraComponent extends Component {
      * @returns {number} The aspect ratio of the render target (or backbuffer).
      */
     calculateAspectRatio(rt) {
-        const src = rt ? rt : this.system.app.graphicsDevice;
-        const rect = this.rect;
-        return (src.width * rect.z) / (src.height * rect.w);
+        const device = this.system.app.graphicsDevice;
+        const width = rt ? rt.width : device.width;
+        const height = rt ? rt.height : device.height;
+        return (width * this.rect.z) / (height * this.rect.w);
     }
 
     /**
-     * Start rendering the frame for this camera.
+     * Prepare the camera for frame rendering.
      *
      * @param {RenderTarget} rt - Render target to which rendering will be performed. Will affect
      * camera's aspect ratio, if aspectRatioMode is {@link ASPECT_AUTO}.
      * @ignore
      */
-    frameBegin(rt) {
+    frameUpdate(rt) {
         if (this.aspectRatioMode === ASPECT_AUTO) {
             this.aspectRatio = this.calculateAspectRatio(rt);
         }
     }
-
-    /**
-     * End rendering the frame for this camera.
-     *
-     * @ignore
-     */
-    frameEnd() {}
 
     /**
      * Attempt to start XR session with this camera.

--- a/src/framework/components/camera/post-effect-queue.js
+++ b/src/framework/components/camera/post-effect-queue.js
@@ -322,8 +322,6 @@ class PostEffectQueue {
                     const len = this.effects.length;
                     if (len) {
 
-                        DebugGraphics.pushGpuMarker(this.app.graphicsDevice, 'Postprocess');
-
                         for (let i = 0; i < len; i++) {
                             const fx = this.effects[i];
 
@@ -343,8 +341,6 @@ class PostEffectQueue {
                             fx.effect.render(fx.inputTarget, destTarget, rect);
                             DebugGraphics.popGpuMarker(this.app.graphicsDevice);
                         }
-
-                        DebugGraphics.popGpuMarker(this.app.graphicsDevice);
                     }
                 }
             };

--- a/src/scene/composition/layer-composition.js
+++ b/src/scene/composition/layer-composition.js
@@ -100,7 +100,12 @@ class LayerComposition extends EventHandler {
          */
         this.cameras = [];
 
-        // the actual rendering sequence, generated based on layers and cameras
+        /**
+         * The actual rendering sequence, generated based on layers and cameras
+         *
+         * @type {RenderAction[]}
+         * @ignore
+         */
         this._renderActions = [];
 
         // all currently created light clusters, that need to be updated before rendering
@@ -577,6 +582,7 @@ class LayerComposition extends EventHandler {
     addRenderAction(renderActions, renderActionIndex, layer, layerIndex, cameraIndex, cameraFirstRenderAction, postProcessMarked) {
 
         // try and reuse object, otherwise allocate new
+        /** @type {RenderAction} */
         let renderAction = renderActions[renderActionIndex];
         if (!renderAction) {
             renderAction = renderActions[renderActionIndex] = new RenderAction();

--- a/src/scene/composition/render-action.js
+++ b/src/scene/composition/render-action.js
@@ -66,6 +66,10 @@ class RenderAction {
         this.viewBindGroups.length = 0;
     }
 
+    get hasDirectionalShadowLights() {
+        return this.directionalLights.length > 0;
+    }
+
     // prepares render action for re-use
     reset() {
         this.lightClusters = null;

--- a/src/scene/frame-graph.js
+++ b/src/scene/frame-graph.js
@@ -1,0 +1,35 @@
+import { Debug, TRACEID_RENDER_PASS } from '../core/debug.js';
+
+/** @typedef {import('./render-pass.js').RenderPass} RenderPass */
+
+class FrameGraph {
+    /** @type {RenderPass[]} */
+    renderPasses = [];
+
+    /**
+     * Add a render pass to the frame.
+     *
+     * @param {RenderPass} renderPass - The render pass to add.
+     */
+    add(renderPass) {
+        Debug.trace(TRACEID_RENDER_PASS,
+                    `RenderPass ${this.renderPasses.length}: ` +
+                    `RT: ${(renderPass.renderTarget ? renderPass.renderTarget.name : '').padEnd(30, ' ')} ` +
+                    `Name: ${renderPass.name}`);
+
+        this.renderPasses.push(renderPass);
+    }
+
+    reset() {
+        this.renderPasses.length = 0;
+    }
+
+    render() {
+        const renderPasses = this.renderPasses;
+        for (let i = 0; i < renderPasses.length; i++) {
+            renderPasses[i].execute();
+        }
+    }
+}
+
+export { FrameGraph };

--- a/src/scene/frame-graph.js
+++ b/src/scene/frame-graph.js
@@ -2,6 +2,11 @@ import { Debug, TRACEID_RENDER_PASS } from '../core/debug.js';
 
 /** @typedef {import('./render-pass.js').RenderPass} RenderPass */
 
+/**
+ * A frame graph represents a single rendering frame as a sequence of render passes.
+ *
+ * @ignore
+ */
 class FrameGraph {
     /** @type {RenderPass[]} */
     renderPasses = [];

--- a/src/scene/frame-graph.js
+++ b/src/scene/frame-graph.js
@@ -1,6 +1,8 @@
 import { Debug, TRACEID_RENDER_PASS } from '../core/debug.js';
+import { DebugGraphics } from '../graphics/debug-graphics.js';
 
 /** @typedef {import('./render-pass.js').RenderPass} RenderPass */
+/** @typedef {import('../graphics/graphics-device.js').GraphicsDevice} GraphicsDevice */
 
 /**
  * A frame graph represents a single rendering frame as a sequence of render passes.
@@ -10,6 +12,15 @@ import { Debug, TRACEID_RENDER_PASS } from '../core/debug.js';
 class FrameGraph {
     /** @type {RenderPass[]} */
     renderPasses = [];
+
+    /**
+     * Create a new FrameGraph instance.
+     *
+     * @param {GraphicsDevice} graphicsDevice - The graphics device used to manage this texture.
+     */
+    constructor(graphicsDevice) {
+        this.device = graphicsDevice;
+    }
 
     /**
      * Add a render pass to the frame.
@@ -32,7 +43,13 @@ class FrameGraph {
     render() {
         const renderPasses = this.renderPasses;
         for (let i = 0; i < renderPasses.length; i++) {
-            renderPasses[i].execute();
+            const renderPass = renderPasses[i];
+
+            DebugGraphics.pushGpuMarker(this.device, `Pass:${renderPass.name}`);
+
+            renderPass.execute();
+
+            DebugGraphics.popGpuMarker(this.device);
         }
     }
 }

--- a/src/scene/lightmapper/lightmapper.js
+++ b/src/scene/lightmapper/lightmapper.js
@@ -1091,6 +1091,8 @@ class Lightmapper {
 
                         this.renderer.renderForward(this.camera, rcv, rcv.length, lightArray, SHADER_FORWARDHDR);
 
+                        device.updateEnd();
+
                         // #if _PROFILER
                         this.stats.shadowMapTime += this.renderer._shadowMapTime;
                         this.stats.forwardTime += this.renderer._forwardTime;

--- a/src/scene/picker.js
+++ b/src/scene/picker.js
@@ -301,7 +301,8 @@ class Picker {
         this.mapping.length = 0;
 
         // render
-        this.app.renderer.renderComposition(this.layerComp);
+        this.app.renderer.buildFrameGraph(this.app.frameGraph, this.layerComp);
+        this.app.frameGraph.render();
     }
 
     updateCamera(srcCamera) {

--- a/src/scene/render-pass.js
+++ b/src/scene/render-pass.js
@@ -10,10 +10,18 @@ class RenderPass {
     /** @type {string} */
     name;
 
+    /**
+     * Creates an instance of the RenderPass.
+     *
+     * @param {RenderTarget} renderTarget - The render target to render into (output).
+     * @param {Function} execute - Custom function that is called when the pass needs to be
+     * rendered.
+     */
     constructor(renderTarget, execute) {
         /** @type {RenderTarget} */
         this.renderTarget = renderTarget;
 
+        /** @type {Function} */
         this.execute = execute;
     }
 }

--- a/src/scene/render-pass.js
+++ b/src/scene/render-pass.js
@@ -1,5 +1,11 @@
 /** @typedef {import('../graphics/render-target.js').RenderTarget} RenderTarget */
 
+/**
+ * A render pass represents a node in the frame graph, and encapsulates a system which
+ * renders to a render target using an execution callback.
+ *
+ * @ignore
+ */
 class RenderPass {
     /** @type {string} */
     name;

--- a/src/scene/render-pass.js
+++ b/src/scene/render-pass.js
@@ -1,12 +1,12 @@
 /** @typedef {import('../graphics/render-target.js').RenderTarget} RenderTarget */
 
 class RenderPass {
-    constructor(name, renderTarget, execute) {
+    /** @type {string} */
+    name;
+
+    constructor(renderTarget, execute) {
         /** @type {RenderTarget} */
         this.renderTarget = renderTarget;
-
-        /** @type {string} */
-        this.name = name;
 
         this.execute = execute;
     }

--- a/src/scene/render-pass.js
+++ b/src/scene/render-pass.js
@@ -1,0 +1,15 @@
+/** @typedef {import('../graphics/render-target.js').RenderTarget} RenderTarget */
+
+class RenderPass {
+    constructor(name, renderTarget, execute) {
+        /** @type {RenderTarget} */
+        this.renderTarget = renderTarget;
+
+        /** @type {string} */
+        this.name = name;
+
+        this.execute = execute;
+    }
+}
+
+export { RenderPass };

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -84,6 +84,8 @@ const _tempMaterialSet = new Set();
 
 /**
  * The forward renderer renders {@link Scene}s.
+ *
+ * @ignore
  */
 class ForwardRenderer {
     /** @type {boolean} */

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -42,10 +42,15 @@ import { StaticMeshes } from './static-meshes.js';
 import { CookieRenderer } from './cookie-renderer.js';
 import { LightCamera } from './light-camera.js';
 import { WorldClustersDebug } from '../lighting/world-clusters-debug.js';
+import { RenderPass } from '../render-pass.js';
 
+/** @typedef {import('../composition/render-action.js').RenderAction} RenderAction */
 /** @typedef {import('../../graphics/graphics-device.js').GraphicsDevice} GraphicsDevice */
 /** @typedef {import('../../framework/components/camera/component.js').CameraComponent} CameraComponent */
 /** @typedef {import('../layer.js').Layer} Layer */
+/** @typedef {import('../scene.js').Scene} Scene */
+/** @typedef {import('../frame-graph.js').FrameGraph} FrameGraph */
+/** @typedef {import('../composition/layer-composition.js').LayerComposition} LayerComposition */
 
 const viewInvMat = new Mat4();
 const viewMat = new Mat4();
@@ -81,6 +86,9 @@ const _tempMaterialSet = new Set();
  * The forward renderer renders {@link Scene}s.
  */
 class ForwardRenderer {
+    /** @type {boolean} */
+    clustersDebugRendered = false;
+
     /**
      * Create a new ForwardRenderer instance.
      *
@@ -89,6 +97,8 @@ class ForwardRenderer {
      */
     constructor(graphicsDevice) {
         this.device = graphicsDevice;
+
+        /** @type {Scene} */
         this.scene = null;
 
         this._shadowDrawCalls = 0;
@@ -442,7 +452,7 @@ class ForwardRenderer {
         }
     }
 
-    clearView(camera, target, clear, forceWrite, options) {
+    clearView(camera, target, clear, forceWrite) {
 
         const device = this.device;
         DebugGraphics.pushGpuMarker(device, 'CLEAR-VIEW');
@@ -477,8 +487,7 @@ class ForwardRenderer {
 
         if (clear) {
             // use camera clear options if any
-            if (!options)
-                options = camera._clearOptions;
+            const options = camera._clearOptions;
 
             device.clear(options ? options : {
                 color: [camera._clearColor.r, camera._clearColor.g, camera._clearColor.b, camera._clearColor.a],
@@ -1452,7 +1461,7 @@ class ForwardRenderer {
                 }
             }
         }
-        device.updateEnd();
+
         _drawCallList.length = 0;
 
         // #if _PROFILER
@@ -1516,7 +1525,19 @@ class ForwardRenderer {
         }
     }
 
-    beginLayers(comp) {
+    /**
+     * Updates the layer composition for rendering.
+     *
+     * @param {LayerComposition} comp - The layer composition to upodate.
+     * @param {boolean} clusteredLightingEnabled - True if clustered lighting is enabled.
+     * @returns {number} - Flags of what was updated
+     * @ignore
+     */
+    updateLayerComposition(comp, clusteredLightingEnabled) {
+
+        // #if _PROFILER
+        const layerCompositionUpdateTime = now();
+        // #endif
 
         const len = comp.layerList.length;
         for (let i = 0; i < len; i++) {
@@ -1566,6 +1587,15 @@ class ForwardRenderer {
                 layer._staticPrepareDone = true;
             }
         }
+
+        // Update static layer data, if something's changed
+        const updated = comp._update(this.device, clusteredLightingEnabled);
+
+        // #if _PROFILER
+        this._layerCompositionUpdateTime += now() - layerCompositionUpdateTime;
+        // #endif
+
+        return updated;
     }
 
     gpuUpdate(drawCalls) {
@@ -1680,6 +1710,8 @@ class ForwardRenderer {
 
         const renderActions = comp._renderActions;
         for (let i = 0; i < renderActions.length; i++) {
+
+            /** @type {RenderAction} */
             const renderAction = renderActions[i];
 
             // layer
@@ -1696,7 +1728,7 @@ class ForwardRenderer {
 
             if (camera) {
 
-                camera.frameBegin(renderAction.renderTarget);
+                camera.frameUpdate(renderAction.renderTarget);
 
                 // update camera and frustum once
                 if (renderAction.firstCameraUse) {
@@ -1729,8 +1761,6 @@ class ForwardRenderer {
                         layer.onPostCull(cameraPass);
                     }
                 }
-
-                camera.frameEnd();
             }
         }
 
@@ -1763,28 +1793,109 @@ class ForwardRenderer {
         // #endif
     }
 
-    renderComposition(comp) {
-        const device = this.device;
+    /**
+     * Builds a frame graph for the rendering of the whole frame.
+     *
+     * @param {FrameGraph} frameGraph - The frame-graph that is built.
+     * @param {LayerComposition} layerComposition - The layer composition used to build the frame graph.
+     * @ignore
+     */
+    buildFrameGraph(frameGraph, layerComposition) {
+
+        frameGraph.reset();
+
+        this.update(layerComposition);
+
         const clusteredLightingEnabled = this.scene.clusteredLightingEnabled;
+        if (clusteredLightingEnabled) {
+
+            // update shadow / cookie atlas allocation for the visible lights
+            this.updateLightTextureAtlas(layerComposition);
+
+            frameGraph.add(new RenderPass('ClusteredCookies', null, () => {
+                // render cookies for all local visible lights
+                if (this.scene.lighting.cookiesEnabled) {
+                    this.renderCookies(layerComposition._splitLights[LIGHTTYPE_SPOT]);
+                    this.renderCookies(layerComposition._splitLights[LIGHTTYPE_OMNI]);
+                }
+            }));
+        }
+
+        // pre-pass
+        frameGraph.add(new RenderPass('LocalShadowMaps', null, () => {
+
+            // render shadows for all local visible lights - these shadow maps are shared by all cameras
+            if (!clusteredLightingEnabled || (clusteredLightingEnabled && this.scene.lighting.shadowsEnabled)) {
+                this.renderShadows(layerComposition._splitLights[LIGHTTYPE_SPOT]);
+                this.renderShadows(layerComposition._splitLights[LIGHTTYPE_OMNI]);
+            }
+
+            // update light clusters
+            if (clusteredLightingEnabled) {
+                this.updateClusters(layerComposition);
+            }
+        }));
+
+        // main passes
+        let startIndex = 0;
+        let newStart = true;
+        let renderTarget = null;
+        const renderActions = layerComposition._renderActions;
+
+        for (let i = startIndex; i < renderActions.length; i++) {
+
+            const renderAction = renderActions[i];
+            const layer = layerComposition.layerList[renderAction.layerIndex];
+            const camera = layer.cameras[renderAction.cameraIndex];
+
+            // directional shadows get re-rendered for each camera
+            if (renderAction.hasDirectionalShadowLights && camera) {
+                frameGraph.add(new RenderPass(`DirShadowMap`, null, () => {
+                    this.renderPassDirectionalShadows(renderAction, layerComposition);
+                }));
+            }
+
+            // start of block of render actions rendering to the same render target
+            if (newStart) {
+                newStart = false;
+                startIndex = i;
+                renderTarget = renderAction.renderTarget;
+            }
+
+            // end of the block
+            const nextRenderAction = renderActions[i + 1];
+            if (!nextRenderAction || nextRenderAction.renderTarget != renderTarget || nextRenderAction.hasDirectionalShadowLights) {
+
+                const range = { start: startIndex, end: i };
+                frameGraph.add(new RenderPass(`LayerComposition ${startIndex}-${i}`, renderTarget, () => {
+                    this.renderPassRenderActions(layerComposition, range);
+                }));
+
+                // postprocessing
+                if (renderAction.triggerPostprocess && camera?.onPostprocessing) {
+                    frameGraph.add(new RenderPass(`Postprocess`, null, () => {
+                        this.renderPassPostprocessing(renderAction, layerComposition);
+                    }));
+                }
+
+                newStart = true;
+            }
+        }
+    }
+
+    update(comp) {
+
+        const clusteredLightingEnabled = this.scene.clusteredLightingEnabled;
+        this.clustersDebugRendered = false;
 
         this.initViewBindGroupFormat();
 
         // update the skybox, since this might change _meshInstances
         this.scene._updateSkybox(this.device);
 
-        this.beginLayers(comp);
-
-        // #if _PROFILER
-        const layerCompositionUpdateTime = now();
-        // #endif
-
-        // Update static layer data, if something's changed
-        const updated = comp._update(device, clusteredLightingEnabled);
+        // update layer composition if something has been invalidated
+        const updated = this.updateLayerComposition(comp, clusteredLightingEnabled);
         const lightsChanged = (updated & COMPUPDATED_LIGHTS) !== 0;
-
-        // #if _PROFILER
-        this._layerCompositionUpdateTime += now() - layerCompositionUpdateTime;
-        // #endif
 
         this.updateLightStats(comp, updated);
 
@@ -1798,196 +1909,199 @@ class ForwardRenderer {
 
         // GPU update for all visible objects
         this.gpuUpdate(comp._meshInstances);
+    }
 
-        if (clusteredLightingEnabled) {
+    /**
+     * Render pass representing the layer composition's render actions in the specified range.
+     *
+     * @param {LayerComposition} comp - the layer composition to render.
+     * @ignore
+     */
+    renderPassRenderActions(comp, range) {
 
-            // update shadow / cookie atlas allocation for the visible lights
-            this.updateLightTextureAtlas(comp);
-
-            // render cookies for all local visible lights
-            if (this.scene.lighting.cookiesEnabled) {
-                this.renderCookies(comp._splitLights[LIGHTTYPE_SPOT]);
-                this.renderCookies(comp._splitLights[LIGHTTYPE_OMNI]);
-            }
-        }
-
-        // render shadows for all local visible lights - these shadow maps are shared by all cameras
-        if (!clusteredLightingEnabled || (clusteredLightingEnabled && this.scene.lighting.shadowsEnabled)) {
-            this.renderShadows(comp._splitLights[LIGHTTYPE_SPOT]);
-            this.renderShadows(comp._splitLights[LIGHTTYPE_OMNI]);
-        }
-
-        // update light clusters
-        if (clusteredLightingEnabled) {
-            this.updateClusters(comp);
-        }
-
-        // Rendering
-        let sortTime, drawTime;
-        let clustersDebugRendered = false;
         const renderActions = comp._renderActions;
-        for (let i = 0; i < renderActions.length; i++) {
-            const renderAction = renderActions[i];
-
-            // layer
-            const layerIndex = renderAction.layerIndex;
-            const layer = comp.layerList[layerIndex];
-            const transparent = comp.subLayerList[layerIndex];
-
-            const cameraPass = renderAction.cameraIndex;
-            const camera = layer.cameras[cameraPass];
-
-            // render directional shadow maps for this camera - these get re-rendered for each camera
-            if (renderAction.directionalLights.length > 0) {
-                this.renderShadows(renderAction.directionalLights, camera.camera);
-            }
-
-            if (!layer.enabled || !comp.subLayerEnabled[layerIndex]) {
-                continue;
-            }
-
-            DebugGraphics.pushGpuMarker(this.device, camera ? camera.entity.name : 'noname');
-            DebugGraphics.pushGpuMarker(this.device, layer.name);
-
-            // #if _PROFILER
-            drawTime = now();
-            // #endif
-
-            if (camera) {
-                camera.frameBegin(renderAction.renderTarget);
-
-                // callback on the camera component before rendering with this camera for the first time during the frame
-                if (renderAction.firstCameraUse && camera.onPreRender) {
-                    camera.onPreRender();
-                }
-            }
-
-            // Call prerender callback if there's one
-            if (!transparent && layer.onPreRenderOpaque) {
-                layer.onPreRenderOpaque(cameraPass);
-            } else if (transparent && layer.onPreRenderTransparent) {
-                layer.onPreRenderTransparent(cameraPass);
-            }
-
-            // Called for the first sublayer and for every camera
-            if (!(layer._preRenderCalledForCameras & (1 << cameraPass))) {
-                if (layer.onPreRender) {
-                    layer.onPreRender(cameraPass);
-                }
-                layer._preRenderCalledForCameras |= 1 << cameraPass;
-            }
-
-            if (camera) {
-
-                // clear buffers
-                if (renderAction.clearColor || renderAction.clearDepth || renderAction.clearStencil) {
-
-                    // TODO: refactor clearView to accept flags from renderAction directly as well
-                    const backupColor = camera.camera._clearColorBuffer;
-                    const backupDepth = camera.camera._clearDepthBuffer;
-                    const backupStencil = camera.camera._clearStencilBuffer;
-
-                    camera.camera._clearColorBuffer = renderAction.clearColor;
-                    camera.camera._clearDepthBuffer = renderAction.clearDepth;
-                    camera.camera._clearStencilBuffer = renderAction.clearStencil;
-
-                    this.clearView(camera.camera, renderAction.renderTarget, true, true);
-
-                    camera.camera._clearColorBuffer = backupColor;
-                    camera.camera._clearDepthBuffer = backupDepth;
-                    camera.camera._clearStencilBuffer = backupStencil;
-                }
-
-                // #if _PROFILER
-                sortTime = now();
-                // #endif
-
-                layer._sortVisible(transparent, camera.camera.node, cameraPass);
-
-                 // #if _PROFILER
-                this._sortTime += now() - sortTime;
-                 // #endif
-
-                const objects = layer.instances;
-                const visible = transparent ? objects.visibleTransparent[cameraPass] : objects.visibleOpaque[cameraPass];
-
-                // add debug mesh instances to visible list
-                this.scene.immediate.onPreRenderLayer(layer, visible, transparent);
-
-                // Set the not very clever global variable which is only useful when there's just one camera
-                this.scene._activeCamera = camera.camera;
-
-                // Set camera shader constants, viewport, scissor, render target
-                this.setCamera(renderAction, camera.camera, renderAction.renderTarget);
-
-                // upload clustered lights uniforms
-                if (clusteredLightingEnabled && renderAction.lightClusters) {
-                    renderAction.lightClusters.activate(this.lightTextureAtlas);
-
-                    // debug rendering of clusters
-                    if (!clustersDebugRendered && this.scene.lighting.debugLayer === layer.id) {
-                        clustersDebugRendered = true;
-                        WorldClustersDebug.render(renderAction.lightClusters, this.scene);
-                    }
-                }
-
-                // enable flip faces if either the camera has _flipFaces enabled or the render target
-                // has flipY enabled
-                const flipFaces = !!(camera.camera._flipFaces ^ renderAction?.renderTarget?.flipY);
-
-                const draws = this._forwardDrawCalls;
-                this.renderForward(camera.camera,
-                                   visible.list,
-                                   visible.length,
-                                   layer._splitLights,
-                                   layer.shaderPass,
-                                   layer.cullingMask,
-                                   layer.onDrawCall,
-                                   layer,
-                                   flipFaces);
-                layer._forwardDrawCalls += this._forwardDrawCalls - draws;
-
-                // Revert temp frame stuff
-                device.setColorWrite(true, true, true, true);
-                device.setStencilTest(false); // don't leak stencil state
-                device.setAlphaToCoverage(false); // don't leak a2c state
-                device.setDepthBias(false);
-
-                camera.frameEnd();
-
-                // callback on the camera component when we're done rendering all layers with this camera
-                if (renderAction.lastCameraUse && camera.onPostRender) {
-                    camera.onPostRender();
-                }
-
-                // trigger postprocessing for camera
-                if (renderAction.triggerPostprocess && camera.onPostprocessing) {
-                    camera.onPostprocessing();
-                }
-            }
-
-            // Call layer's postrender callback if there's one
-            if (!transparent && layer.onPostRenderOpaque) {
-                layer.onPostRenderOpaque(cameraPass);
-            } else if (transparent && layer.onPostRenderTransparent) {
-                layer.onPostRenderTransparent(cameraPass);
-            }
-            if (layer.onPostRender && !(layer._postRenderCalledForCameras & (1 << cameraPass))) {
-                layer._postRenderCounter &= ~(transparent ? 2 : 1);
-                if (layer._postRenderCounter === 0) {
-                    layer.onPostRender(cameraPass);
-                    layer._postRenderCalledForCameras |= 1 << cameraPass;
-                    layer._postRenderCounter = layer._postRenderCounterMax;
-                }
-            }
-
-            DebugGraphics.popGpuMarker(this.device);
-            DebugGraphics.popGpuMarker(this.device);
-
-            // #if _PROFILER
-            layer._renderTime += now() - drawTime;
-            // #endif
+        for (let i = range.start; i <= range.end; i++) {
+            this.renderRenderAction(comp, renderActions[i]);
         }
+    }
+
+    /**
+     * Render pass for directional shadow maps of the camera.
+     *
+     * @param {RenderAction} renderAction - The render action.
+     * @param {LayerComposition} layerComposition - The layer composition.
+     * @ignore
+     */
+    renderPassDirectionalShadows(renderAction, layerComposition) {
+
+        Debug.assert(renderAction.directionalLights.length > 0);
+        const layer = layerComposition.layerList[renderAction.layerIndex];
+        const camera = layer.cameras[renderAction.cameraIndex];
+
+        this.renderShadows(renderAction.directionalLights, camera.camera);
+    }
+
+    renderPassPostprocessing(renderAction, layerComposition) {
+
+        const layer = layerComposition.layerList[renderAction.layerIndex];
+        const camera = layer.cameras[renderAction.cameraIndex];
+        Debug.assert(renderAction.triggerPostprocess && camera.onPostprocessing);
+
+        // trigger postprocessing for camera
+        camera.onPostprocessing();
+    }
+
+    renderRenderAction(comp, renderAction) {
+
+        const clusteredLightingEnabled = this.scene.clusteredLightingEnabled;
+        const device = this.device;
+
+        // layer
+        const layerIndex = renderAction.layerIndex;
+        const layer = comp.layerList[layerIndex];
+        const transparent = comp.subLayerList[layerIndex];
+
+        const cameraPass = renderAction.cameraIndex;
+        const camera = layer.cameras[cameraPass];
+
+        if (!layer.enabled || !comp.subLayerEnabled[layerIndex]) {
+            return;
+        }
+
+        DebugGraphics.pushGpuMarker(this.device, camera ? camera.entity.name : 'noname');
+        DebugGraphics.pushGpuMarker(this.device, layer.name);
+
+        // #if _PROFILER
+        const drawTime = now();
+        // #endif
+
+        if (camera) {
+            // callback on the camera component before rendering with this camera for the first time during the frame
+            if (renderAction.firstCameraUse && camera.onPreRender) {
+                camera.onPreRender();
+            }
+        }
+
+        // Call prerender callback if there's one
+        if (!transparent && layer.onPreRenderOpaque) {
+            layer.onPreRenderOpaque(cameraPass);
+        } else if (transparent && layer.onPreRenderTransparent) {
+            layer.onPreRenderTransparent(cameraPass);
+        }
+
+        // Called for the first sublayer and for every camera
+        if (!(layer._preRenderCalledForCameras & (1 << cameraPass))) {
+            if (layer.onPreRender) {
+                layer.onPreRender(cameraPass);
+            }
+            layer._preRenderCalledForCameras |= 1 << cameraPass;
+        }
+
+        if (camera) {
+
+            // clear buffers
+            if (renderAction.clearColor || renderAction.clearDepth || renderAction.clearStencil) {
+
+                // TODO: refactor clearView to accept flags from renderAction directly as well
+                const backupColor = camera.camera._clearColorBuffer;
+                const backupDepth = camera.camera._clearDepthBuffer;
+                const backupStencil = camera.camera._clearStencilBuffer;
+
+                camera.camera._clearColorBuffer = renderAction.clearColor;
+                camera.camera._clearDepthBuffer = renderAction.clearDepth;
+                camera.camera._clearStencilBuffer = renderAction.clearStencil;
+
+                this.clearView(camera.camera, renderAction.renderTarget, true, true);
+
+                camera.camera._clearColorBuffer = backupColor;
+                camera.camera._clearDepthBuffer = backupDepth;
+                camera.camera._clearStencilBuffer = backupStencil;
+            }
+
+            // #if _PROFILER
+            const sortTime = now();
+            // #endif
+
+            layer._sortVisible(transparent, camera.camera.node, cameraPass);
+
+            // #if _PROFILER
+            this._sortTime += now() - sortTime;
+            // #endif
+
+            const objects = layer.instances;
+            const visible = transparent ? objects.visibleTransparent[cameraPass] : objects.visibleOpaque[cameraPass];
+
+            // add debug mesh instances to visible list
+            this.scene.immediate.onPreRenderLayer(layer, visible, transparent);
+
+            // Set the not very clever global variable which is only useful when there's just one camera
+            this.scene._activeCamera = camera.camera;
+
+            // Set camera shader constants, viewport, scissor, render target
+            this.setCamera(renderAction, camera.camera, renderAction.renderTarget);
+
+            // upload clustered lights uniforms
+            if (clusteredLightingEnabled && renderAction.lightClusters) {
+                renderAction.lightClusters.activate(this.lightTextureAtlas);
+
+                // debug rendering of clusters
+                if (!this.clustersDebugRendered && this.scene.lighting.debugLayer === layer.id) {
+                    this.clustersDebugRendered = true;
+                    WorldClustersDebug.render(renderAction.lightClusters, this.scene);
+                }
+            }
+
+            // enable flip faces if either the camera has _flipFaces enabled or the render target
+            // has flipY enabled
+            const flipFaces = !!(camera.camera._flipFaces ^ renderAction?.renderTarget?.flipY);
+
+            const draws = this._forwardDrawCalls;
+            this.renderForward(camera.camera,
+                               visible.list,
+                               visible.length,
+                               layer._splitLights,
+                               layer.shaderPass,
+                               layer.cullingMask,
+                               layer.onDrawCall,
+                               layer,
+                               flipFaces);
+            layer._forwardDrawCalls += this._forwardDrawCalls - draws;
+
+            device.updateEnd();
+
+            // Revert temp frame stuff
+            device.setColorWrite(true, true, true, true);
+            device.setStencilTest(false); // don't leak stencil state
+            device.setAlphaToCoverage(false); // don't leak a2c state
+            device.setDepthBias(false);
+
+            // callback on the camera component when we're done rendering all layers with this camera
+            if (renderAction.lastCameraUse && camera.onPostRender) {
+                camera.onPostRender();
+            }
+        }
+
+        // Call layer's postrender callback if there's one
+        if (!transparent && layer.onPostRenderOpaque) {
+            layer.onPostRenderOpaque(cameraPass);
+        } else if (transparent && layer.onPostRenderTransparent) {
+            layer.onPostRenderTransparent(cameraPass);
+        }
+        if (layer.onPostRender && !(layer._postRenderCalledForCameras & (1 << cameraPass))) {
+            layer._postRenderCounter &= ~(transparent ? 2 : 1);
+            if (layer._postRenderCounter === 0) {
+                layer.onPostRender(cameraPass);
+                layer._postRenderCalledForCameras |= 1 << cameraPass;
+                layer._postRenderCounter = layer._postRenderCounterMax;
+            }
+        }
+
+        DebugGraphics.popGpuMarker(this.device);
+        DebugGraphics.popGpuMarker(this.device);
+
+        // #if _PROFILER
+        layer._renderTime += now() - drawTime;
+        // #endif
     }
 }
 

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -1930,20 +1930,6 @@ class ForwardRenderer {
     }
 
     /**
-     * Render pass representing the layer composition's render actions in the specified range.
-     *
-     * @param {LayerComposition} comp - the layer composition to render.
-     * @ignore
-     */
-    renderPassRenderActions(comp, range) {
-
-        const renderActions = comp._renderActions;
-        for (let i = range.start; i <= range.end; i++) {
-            this.renderRenderAction(comp, renderActions[i]);
-        }
-    }
-
-    /**
      * Render pass for directional shadow maps of the camera.
      *
      * @param {RenderAction} renderAction - The render action.
@@ -1967,6 +1953,20 @@ class ForwardRenderer {
 
         // trigger postprocessing for camera
         camera.onPostprocessing();
+    }
+
+    /**
+     * Render pass representing the layer composition's render actions in the specified range.
+     *
+     * @param {LayerComposition} comp - the layer composition to render.
+     * @ignore
+     */
+    renderPassRenderActions(comp, range) {
+
+        const renderActions = comp._renderActions;
+        for (let i = range.start; i <= range.end; i++) {
+            this.renderRenderAction(comp, renderActions[i]);
+        }
     }
 
     renderRenderAction(comp, renderAction) {

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -1516,17 +1516,7 @@ class ForwardRenderer {
         }
     }
 
-    beginCamera(renderAction, camera) {
-
-        camera.frameBegin(renderAction.renderTarget);
-
-        // callback on the camera component before rendering with this camera for the first time during the frame
-        if (renderAction.firstCameraUse && camera.onPreRender) {
-            camera.onPreRender();
-        }
-    }
-
-    beginComposition(comp) {
+    beginLayers(comp) {
 
         const len = comp.layerList.length;
         for (let i = 0; i < len; i++) {
@@ -1782,7 +1772,7 @@ class ForwardRenderer {
         // update the skybox, since this might change _meshInstances
         this.scene._updateSkybox(this.device);
 
-        this.beginComposition(comp);
+        this.beginLayers(comp);
 
         // #if _PROFILER
         const layerCompositionUpdateTime = now();
@@ -1864,7 +1854,12 @@ class ForwardRenderer {
             // #endif
 
             if (camera) {
-                this.beginCamera(renderAction, camera);
+                camera.frameBegin(renderAction.renderTarget);
+
+                // callback on the camera component before rendering with this camera for the first time during the frame
+                if (renderAction.firstCameraUse && camera.onPreRender) {
+                    camera.onPreRender();
+                }
             }
 
             // Call prerender callback if there's one

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -241,7 +241,7 @@ class Scene extends EventHandler {
          * shaders that reference global settings.
          *
          * @type {boolean}
-         * @private
+         * @ignore
          */
         this.updateShaders = true;
 


### PR DESCRIPTION
This is a first step in the implementation of https://github.com/playcanvas/engine/issues/4271. ForwardRenderer, instead of directly rendering the scene, performs two steps:
1. analyses the scene, and constructs a FrameGraph of rendering passes. Only layers rendered by the cameras are fully split into render passes, other rendering systems (shadows, grab passes, post-effects and similar) are inserted into the frame graph as black boxes. Those will be further broken down into actual render passes in the future.
2. renders the generated render passes

Other changes:
- making Debug.setTrace public, to allow external applications to enable log tracing
- added few trace ids for debug logging related to render passes

example of the trace output for post-effects engine example
![Screenshot 2022-05-25 at 11 47 48](https://user-images.githubusercontent.com/59932779/170245357-55058311-d66a-466e-a584-96cf10e096e9.png)

and here are the frame passes from the same example when postprocessing is disabled - this results in a smaller number of render passes, which in the future PRs will translate to a smaller number of multi-sampled resolves:
![Screenshot 2022-05-25 at 11 49 41](https://user-images.githubusercontent.com/59932779/170245719-19ff5f32-696a-4b84-9756-4a2b384cac14.png)

