### PR TITLE
Make touch events passive like mouse events

### DIFF
--- a/src/input/touch-device.js
+++ b/src/input/touch-device.js
@@ -1,3 +1,5 @@
+import { platform } from '../core/platform.js';
+
 import { EventHandler } from '../core/event-handler.js';
 
 import { TouchEvent } from './touch-event.js';
@@ -40,10 +42,11 @@ class TouchDevice extends EventHandler {
 
         this._element = element;
 
-        this._element.addEventListener('touchstart', this._startHandler, false);
-        this._element.addEventListener('touchend', this._endHandler, false);
-        this._element.addEventListener('touchmove', this._moveHandler, false);
-        this._element.addEventListener('touchcancel', this._cancelHandler, false);
+        const opts = platform.passiveEvents ? { passive: true } : false;
+        this._element.addEventListener('touchstart', this._startHandler, opts);
+        this._element.addEventListener('touchend', this._endHandler, opts);
+        this._element.addEventListener('touchmove', this._moveHandler, opts);
+        this._element.addEventListener('touchcancel', this._cancelHandler, opts);
     }
 
     /**

--- a/src/input/touch-device.js
+++ b/src/input/touch-device.js
@@ -1,5 +1,4 @@
 import { platform } from '../core/platform.js';
-
 import { EventHandler } from '../core/event-handler.js';
 
 import { TouchEvent } from './touch-event.js';


### PR DESCRIPTION
Prevent console messages like:
 ```
[Violation] Added non-passive event listener to a scroll-blocking 'touchmove' event. Consider marking event handler as 'passive' to make the page more responsive. See https://www.chromestatus.com/feature/5745543795965952
```

See also: https://github.com/playcanvas/engine/blob/9a0697c6b2cd521db510df49f90028f414006696/src/input/element-input.js#L421-L426


I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
