### PR TITLE
Add support for .opus audio files

### DIFF
--- a/src/net/http.js
+++ b/src/net/http.js
@@ -34,7 +34,8 @@ class Http {
         AAC: 'audio/aac',
         BIN: 'application/octet-stream',
         BASIS: 'image/basis',
-        GLB: 'model/gltf-binary'
+        GLB: 'model/gltf-binary',
+        OPUS: 'audio/ogg; codecs="opus"'
     };
 
     static ResponseType = {
@@ -55,7 +56,8 @@ class Http {
         '.aac',
         '.dds',
         '.basis',
-        '.glb'
+        '.glb',
+        '.opus'
     ];
 
     static retryDelay = 100;
@@ -474,7 +476,8 @@ class Http {
             Http.ContentType.BIN,
             Http.ContentType.DDS,
             Http.ContentType.BASIS,
-            Http.ContentType.GLB
+            Http.ContentType.GLB,
+            Http.ContentType.OPUS
         ];
         if (binTypes.indexOf(contentType) >= 0) {
             return true;

--- a/src/resources/audio.js
+++ b/src/resources/audio.js
@@ -34,15 +34,16 @@ const ie = (function () {
     return false;
 })();
 
-const toMIME = {
-    '.ogg': 'audio/ogg',
-    '.mp3': 'audio/mpeg',
-    '.wav': 'audio/x-wav',
-    '.mp4a': 'audio/mp4',
-    '.m4a': 'audio/mp4',
-    '.mp4': 'audio/mp4',
-    '.aac': 'audio/aac'
-};
+const supportedExtensions = [
+    '.ogg',
+    '.mp3',
+    '.wav',
+    '.mp4a',
+    '.m4a',
+    '.mp4',
+    '.aac',
+    '.opus'
+];
 
 /**
  * Resource handler used for loading {@link Sound} resources.
@@ -73,7 +74,7 @@ class AudioHandler {
     _isSupported(url) {
         const ext = path.getExtension(url);
 
-        if (toMIME[ext]) {
+        if (supportedExtensions.includes(ext)) {
             return true;
         }
         return false;

--- a/src/resources/audio.js
+++ b/src/resources/audio.js
@@ -74,7 +74,7 @@ class AudioHandler {
     _isSupported(url) {
         const ext = path.getExtension(url);
 
-        if (supportedExtensions.includes(ext)) {
+        if (supportedExtensions.indexOf(ext) > -1) {
             return true;
         }
         return false;

--- a/src/resources/audio.js
+++ b/src/resources/audio.js
@@ -74,10 +74,7 @@ class AudioHandler {
     _isSupported(url) {
         const ext = path.getExtension(url);
 
-        if (supportedExtensions.indexOf(ext) > -1) {
-            return true;
-        }
-        return false;
+        return supportedExtensions.indexOf(ext) > -1;
     }
 
     load(url, callback) {


### PR DESCRIPTION
These files are smaller than .mp3 and .ogg and are supported by all browsers except Safari [1].

1. https://caniuse.com/?search=opus


I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
