### PR TITLE
Fix color mix in the linear fog

### DIFF
--- a/src/graphics/program-lib/chunks/lit/frag/fogLinear.js
+++ b/src/graphics/program-lib/chunks/lit/frag/fogLinear.js
@@ -8,7 +8,6 @@ vec3 addFog(vec3 color) {
     float depth = gl_FragCoord.z / gl_FragCoord.w;
     float fogFactor = (fog_end - depth) / (fog_end - fog_start);
     fogFactor = clamp(fogFactor, 0.0, 1.0);
-    fogFactor = gammaCorrectInput(fogFactor);
     return mix(fog_color * dBlendModeFogFactor, color, fogFactor);
 }
 `;


### PR DESCRIPTION
Colors has to be mixed in the linear space (not factor) similar to [fogExp.js](https://github.com/playcanvas/engine/blob/main/src/graphics/program-lib/chunks/lit/frag/fogExp.js#L10).

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
