### PR TITLE
Return original source if preprocessor fails

### DIFF
--- a/src/core/preprocessor.js
+++ b/src/core/preprocessor.js
@@ -220,7 +220,7 @@ class Preprocessor {
 
         if (error) {
             Debug.error("Failed to preprocess shader: ", { source: originalSource });
-            return null;
+            return originalSource;
         }
 
         return source;

--- a/src/core/preprocessor.js
+++ b/src/core/preprocessor.js
@@ -219,7 +219,7 @@ class Preprocessor {
         }
 
         if (error) {
-            Debug.error("Failed to preprocess shader: ", { source: originalSource });
+            console.warn("Failed to preprocess shader: ", { source: originalSource });
             return originalSource;
         }
 


### PR DESCRIPTION
It seems a little safer to return the original shader source if preprocessing fails (rather than null) since the shader may still be valid.

Debug build of the engine outputs the details needed to debug failing shader.