### PR TITLE
Element component: mark a batch group as dirty if an attribute has been changed

### DIFF
--- a/src/framework/components/element/component.js
+++ b/src/framework/components/element/component.js
@@ -1667,10 +1667,18 @@ function _define(name) {
             return null;
         },
         set: function (value) {
-            if (this._text) {
-                this._text[name] = value;
-            } else if (this._image) {
-                this._image[name] = value;
+            if (this._text && this._text[name] !== value ||
+                this._image && this._image[name] !== value) {
+
+                if (this._text) {
+                    this._text[name] = value;
+                } else if (this._image) {
+                    this._image[name] = value;
+                }
+
+                if (this.batchGroupId !== -1 && this.system.app.batcher) {
+                    this.system.app.batcher.markGroupDirty(this.batchGroupId);
+                }
             }
         }
     });


### PR DESCRIPTION
Fixes [#2579](https://github.com/playcanvas/engine/issues/2579)

MR makes batch group dirty if an element has been changed. So, a user don't have to mark a batch group as dirty manually, because it is error-prone.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
