### PR TITLE
Get sourcemaps working

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "@playcanvas/eslint-config": "^1.1.1",
         "@playcanvas/jsdoc-template": "^1.0.25",
         "@rollup/plugin-babel": "^5.3.1",
-        "@rollup/plugin-replace": "^4.0.0",
         "@rollup/plugin-strip": "^2.1.0",
         "@rollup/pluginutils": "^4.2.1",
         "c8": "^7.11.3",
@@ -1855,42 +1854,6 @@
       }
     },
     "node_modules/@rollup/plugin-babel/node_modules/estree-walker": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
-      "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
-      "dev": true
-    },
-    "node_modules/@rollup/plugin-replace": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-4.0.0.tgz",
-      "integrity": "sha512-+rumQFiaNac9y64OHtkHGmdjm7us9bo1PlbgQfdihQtuNxzjpaB064HbRnewUOggLQxVCCyINfStkgmBeQpv1g==",
-      "dev": true,
-      "dependencies": {
-        "@rollup/pluginutils": "^3.1.0",
-        "magic-string": "^0.25.7"
-      },
-      "peerDependencies": {
-        "rollup": "^1.20.0 || ^2.0.0"
-      }
-    },
-    "node_modules/@rollup/plugin-replace/node_modules/@rollup/pluginutils": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
-      "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
-      "dev": true,
-      "dependencies": {
-        "@types/estree": "0.0.39",
-        "estree-walker": "^1.0.1",
-        "picomatch": "^2.2.2"
-      },
-      "engines": {
-        "node": ">= 8.0.0"
-      },
-      "peerDependencies": {
-        "rollup": "^1.20.0||^2.0.0"
-      }
-    },
-    "node_modules/@rollup/plugin-replace/node_modules/estree-walker": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
       "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
@@ -8058,35 +8021,6 @@
       "requires": {
         "@babel/helper-module-imports": "^7.10.4",
         "@rollup/pluginutils": "^3.1.0"
-      },
-      "dependencies": {
-        "@rollup/pluginutils": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
-          "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
-          "dev": true,
-          "requires": {
-            "@types/estree": "0.0.39",
-            "estree-walker": "^1.0.1",
-            "picomatch": "^2.2.2"
-          }
-        },
-        "estree-walker": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
-          "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
-          "dev": true
-        }
-      }
-    },
-    "@rollup/plugin-replace": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-4.0.0.tgz",
-      "integrity": "sha512-+rumQFiaNac9y64OHtkHGmdjm7us9bo1PlbgQfdihQtuNxzjpaB064HbRnewUOggLQxVCCyINfStkgmBeQpv1g==",
-      "dev": true,
-      "requires": {
-        "@rollup/pluginutils": "^3.1.0",
-        "magic-string": "^0.25.7"
       },
       "dependencies": {
         "@rollup/pluginutils": {

--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
     "@playcanvas/eslint-config": "^1.1.1",
     "@playcanvas/jsdoc-template": "^1.0.25",
     "@rollup/plugin-babel": "^5.3.1",
-    "@rollup/plugin-replace": "^4.0.0",
     "@rollup/plugin-strip": "^2.1.0",
     "@rollup/pluginutils": "^4.2.1",
     "c8": "^7.11.3",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -199,15 +199,18 @@ function buildTarget(buildType, moduleFormat) {
 
     const sdkVersion = {
         _CURRENT_SDK_VERSION: version,
-        _CURRENT_SDK_REVISION: revision,
+        _CURRENT_SDK_REVISION: revision
     };
 
     const jsccOptions = {
         debug: {
-            values: { ...sdkVersion, ...{
-                _DEBUG: 1,
-                _PROFILER: 1
-            }},
+            values: {
+                ...sdkVersion,
+                ...{
+                    _DEBUG: 1,
+                    _PROFILER: 1
+                }
+            },
             keepLines: true,
             sourcemap: 'inline'
         },
@@ -215,9 +218,12 @@ function buildTarget(buildType, moduleFormat) {
             values: sdkVersion
         },
         profiler: {
-            values: { ...sdkVersion, ...{
-                _PROFILER: 1
-            }}
+            values: {
+                ...sdkVersion,
+                ...{
+                    _PROFILER: 1
+                }
+            }
         }
     };
 

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -4,8 +4,8 @@
  * @description Root namespace for the PlayCanvas Engine.
  */
 
-const version = '__CURRENT_SDK_VERSION__';
-const revision = '__REVISION__';
+const version = '$_CURRENT_SDK_VERSION';
+const revision = '$_CURRENT_SDK_REVISION';
 const config = { };
 const common = { };
 const apps = { }; // Storage for the applications using the PlayCanvas Engine


### PR DESCRIPTION
Fixes: #3996

This PR updates the engine rollup build script as follows:
- remove rollup-replace plugin for setting module version and revision, use jscc for this instead
- disable tabsToSpaces and shaderChunks processing in debug build, which appears to break sourcemaps (presumably because sourcemaps aren't returned from these functions)

With these changes in place sourcemaps work correctly in Chrome.