### PR TITLE
Reverted API change to ForwardRenderer.setCamera as Editor uses it

### DIFF
--- a/src/scene/lightmapper/lightmapper.js
+++ b/src/scene/lightmapper/lightmapper.js
@@ -1075,7 +1075,7 @@ class Lightmapper {
                         this.renderer.updateShaders(rcv);
 
                         // ping-ponging output
-                        this.renderer.setCamera(null, this.camera, tempRT, true);
+                        this.renderer.setCamera(this.camera, tempRT, true);
 
                         if (pass === PASS_DIR) {
                             this.constantBakeDir.setValue(bakeLight.light.bakeDir ? 1 : 0);

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -323,7 +323,8 @@ class ForwardRenderer {
     }
 
     // make sure colorWrite is set to true to all channels, if you want to fully clear the target
-    setCamera(renderAction, camera, target, clear) {
+    setCamera(camera, target, clear, renderAction = null) {
+
         let transform;
 
         let viewCount = 1;
@@ -2058,7 +2059,7 @@ class ForwardRenderer {
             this.scene._activeCamera = camera.camera;
 
             // Set camera shader constants, viewport, scissor, render target
-            this.setCamera(renderAction, camera.camera, renderAction.renderTarget);
+            this.setCamera(camera.camera, renderAction.renderTarget, false, renderAction);
 
             // upload clustered lights uniforms
             if (clusteredLightingEnabled && renderAction.lightClusters) {

--- a/src/scene/renderer/shadow-renderer.js
+++ b/src/scene/renderer/shadow-renderer.js
@@ -549,7 +549,7 @@ class ShadowRenderer {
 
                 this.dispatchUniforms(light, shadowCam, lightRenderData, face);
 
-                forwardRenderer.setCamera(null, shadowCam, shadowCam.renderTarget, true);
+                forwardRenderer.setCamera(shadowCam, shadowCam.renderTarget, true);
 
                 // render mesh instances
                 this.submitCasters(lightRenderData.visibleCasters, light);


### PR DESCRIPTION
Editor uses it directly, so avoid parameter order change