### PR TITLE
Fix: Shadow markup requires color attribute

### DIFF
--- a/src/graphics/program-lib/chunks/common/vert/msdf.js
+++ b/src/graphics/program-lib/chunks/common/vert/msdf.js
@@ -10,13 +10,18 @@ varying vec2 shadow_offset;
 void unpackMsdfParams() {
     outline_color.rb = mod(vertex_outlineParameters.xy, 256.) / 256.;
     outline_color.ga = vertex_outlineParameters.xy / 256. / 256.;
-    outline_thickness = vertex_outlineParameters.z / 255.;
+
+    // _outlineThicknessScale === 0.2
+    outline_thickness = vertex_outlineParameters.z / 255. * 0.2;
 
     vec3 little = mod(vertex_shadowParameters, 256.) / 256.;
     vec3 big = vertex_shadowParameters / 256. / 256.;
 
     shadow_color.rb = little.xy;
     shadow_color.ga = big.xy;
-    shadow_offset = vec2(little.z, big.z);
+
+    // vec2(little.z, big.z) * 2. srink from (0.5, 0.5) to (1, 1)
+    // _shadowOffsetScale === 0.005
+    shadow_offset = (vec2(little.z, big.z) * 2. - 1.) * 0.005;
 }
 `;

--- a/tests/framework/components/element/test_textelement.js
+++ b/tests/framework/components/element/test_textelement.js
@@ -62,6 +62,16 @@ describe("pc.TextElement", function () {
         expect(element._text.symbolColors).to.deep.equal(expectedLineColors);
     };
 
+    var assertLineOutlineParams = function (expectedLineOutlineParams) {
+        expect(element._text.symbolOutlineParams.length).to.equal(expectedLineOutlineParams.length);
+        expect(element._text.symbolOutlineParams).to.deep.equal(expectedLineOutlineParams);
+    };
+
+    var assertLineShadowParams = function (expectedLineShadowParams) {
+        expect(element._text.symbolShadowParams.length).to.equal(expectedLineShadowParams.length);
+        expect(element._text.symbolShadowParams).to.deep.equal(expectedLineShadowParams);
+    };
+
     // Creates data for a single translation as if it was a whole asset
     var createTranslation = function (locale, key, translations) {
         var messages = {};
@@ -1614,7 +1624,7 @@ describe("pc.TextElement", function () {
             "text element [color=\"#ff0000\"]in red or not"
         ]);
 
-        expect(element._text.symbolColors).to.equal(null);
+        assertLineColors(new Array(43).fill([255, 255, 255]))
     });
 
     it('text markup with escaping open bracket', function () {
@@ -1627,7 +1637,67 @@ describe("pc.TextElement", function () {
             "text element [color=\"#ff0000\"]in red or not"
         ]);
 
-        expect(element._text.symbolColors).to.equal(null);
+        assertLineColors(new Array(43).fill([255, 255, 255]))
+    });
+
+    it('text markup shadow tag', function () {
+        registerRtlHandler('\r');
+        element.fontAsset = fontAsset;
+        element.rtlReorder = true;
+        element.enableMarkup = true;
+        element.autoWidth = true;
+        element.shadowColor = new pc.Color(1, 1, 0, 1);
+        element.shadowOffset = new pc.Vec2(0.5, -1);
+
+        element.text = "text [shadow color=\"#00ff00bb\" offset=\"1\"]element[/shadow] [shadow color=\"#ff0000\"]in red[/shadow] [shadow offset=\"1\"]or[/shadow] not";
+
+        assertLineContents([
+            "text element in red or not"
+        ]);
+
+        // (r, g, b, a, offsetx, offsety)
+        var d1 = [255, 255, 0, 255, 64, -127];
+        var g = [0, 255, 0, 187, 127, 127];
+        var r = [255, 0, 0, 255, 64, -127];
+        var d2 = [255, 255, 0, 255, 127, 127];
+
+        assertLineShadowParams([
+            d1, d1, d1, d1, d1,
+            g, g, g, g, g, g, g, d1,
+            r, r, r, r, r, r, d1,
+            d2, d2, d1,
+            d1, d1, d1
+        ]);
+    });
+
+    it('text markup outline tag', function () {
+        registerRtlHandler('\r');
+        element.fontAsset = fontAsset;
+        element.rtlReorder = true;
+        element.enableMarkup = true;
+        element.autoWidth = true;
+        element.outlineColor = new pc.Color(1, 1, 0, 1);
+        element.outlineThickness = 1;
+
+        element.text = "text [outline color=\"#00ff00bb\" thickness=\"0.5\"]element[/outline] [outline color=\"#ff0000\"]in red[/outline] [outline thickness=\"1\"]or[/outline] not";
+
+        assertLineContents([
+            "text element in red or not"
+        ]);
+
+        // (r, g, b, a, thickness)
+        var d1 = [255, 255, 0, 255, 255];
+        var g = [0, 255, 0, 187, 128];
+        var r = [255, 0, 0, 255, 255];
+        var d2 = [255, 255, 0, 255, 255];
+
+        assertLineOutlineParams([
+            d1, d1, d1, d1, d1,
+            g, g, g, g, g, g, g, d1,
+            r, r, r, r, r, r, d1,
+            d2, d2, d1,
+            d1, d1, d1
+        ]);
     });
 
     it('text markup with attributes', function () {


### PR DESCRIPTION
Fixes [#4308](https://github.com/playcanvas/engine/issues/4308)

Changed encoding of shadow offsets/outline thickness in WebGL buffers.

Suggested: **enableMarkups** switches uniforms to attributes even if there is no tags. So, if user need to improve batching they just set **enableMarkups**.

Tests: added 2 tests according to the issue.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
