### PR TITLE
Material registry

### DIFF
--- a/src/graphics/shader.js
+++ b/src/graphics/shader.js
@@ -1,5 +1,7 @@
 /** @typedef {import('./graphics-device.js').GraphicsDevice} GraphicsDevice */
 
+import { EventHandler } from '../core/event-handler.js';
+
 /**
  * A shader is a program that is responsible for rendering graphical primitives on a device's
  * graphics processor. The shader is generated from a shader definition. This shader definition
@@ -9,6 +11,10 @@
  * attributes specified in the vertex shader code.
  */
 class Shader {
+    // #if _DEBUG
+    static debugEvents = new EventHandler();
+    // #endif
+
     /**
      * Creates a new Shader instance.
      *

--- a/src/graphics/shader.js
+++ b/src/graphics/shader.js
@@ -1,6 +1,6 @@
-/** @typedef {import('./graphics-device.js').GraphicsDevice} GraphicsDevice */
-
 import { EventHandler } from '../core/event-handler.js';
+
+/** @typedef {import('./graphics-device.js').GraphicsDevice} GraphicsDevice */
 
 /**
  * A shader is a program that is responsible for rendering graphical primitives on a device's

--- a/src/graphics/webgl/webgl-shader.js
+++ b/src/graphics/webgl/webgl-shader.js
@@ -2,11 +2,11 @@ import { Debug } from '../../core/debug.js';
 import { now } from '../../core/time.js';
 import { Preprocessor } from '../../core/preprocessor.js';
 
+import { Shader } from '../shader.js';
 import { ShaderInput } from '../shader-input.js';
 import { SHADERTAG_MATERIAL, semanticToLocation } from '../constants.js';
 
 /** @typedef {import('../graphics-device.js').GraphicsDevice} GraphicsDevice */
-/** @typedef {import('../shader.js').Shader} Shader */
 
 /**
  * A WebGL implementation of the Shader.
@@ -204,6 +204,7 @@ class WebglShader {
 
             // #if _DEBUG
             console.error(message, definition);
+            Shader.debugEvents.fire('linkError', shader);
             // #else
             console.error(message);
             // #endif
@@ -283,6 +284,7 @@ class WebglShader {
             // #if _DEBUG
             error.shader = shader;
             console.error(message, error);
+            Shader.debugEvents.fire('compileError', shader);
             // #else
             console.error(message);
             // #endif

--- a/src/scene/materials/material-registry.js
+++ b/src/scene/materials/material-registry.js
@@ -3,8 +3,8 @@ import { Shader } from '../../graphics/shader.js';
 class MaterialRegistry {
     constructor() {
         this.materials = new Set();
-        Shader.debugEvents.on('compileError', (shader) => this.reportEffectedMaterials(shader));
-        Shader.debugEvents.on('linkError', (shader) => this.reportEffectedMaterials(shader));
+        Shader.debugEvents.on('compileError', shader => this.reportEffectedMaterials(shader));
+        Shader.debugEvents.on('linkError', shader => this.reportEffectedMaterials(shader));
     }
 
     add(material) {

--- a/src/scene/materials/material-registry.js
+++ b/src/scene/materials/material-registry.js
@@ -1,0 +1,55 @@
+import { Shader } from '../../graphics/shader.js';
+
+class MaterialRegistry {
+    constructor() {
+        this.materials = new Set();
+        Shader.debugEvents.on('compileError', (shader) => this.reportEffectedMaterials(shader));
+        Shader.debugEvents.on('linkError', (shader) => this.reportEffectedMaterials(shader));
+    }
+
+    add(material) {
+        this.materials.add(material);
+    }
+
+    remove(material) {
+        this.materials.delete(material);
+    }
+
+    reportEffectedMaterials(shader) {
+        // search for all materials making use of this shader
+        const materials = new Set();
+        this.materials.forEach((material) => {
+            // check the shader
+            if (material.shader === shader) {
+                materials.add(material);
+            }
+
+            // check material variants
+            Object.keys(material.variant || {}).forEach((variantIndex) => {
+                const variant = material.variant[variantIndex];
+                if (variant === shader) {
+                    materials.add(material);
+                }
+            });
+
+            // check mesh instance variants
+            material.meshInstances.forEach((meshInstance) => {
+                meshInstance._shader.forEach((variant) => {
+                    if (variant === shader) {
+                        materials.add(material);
+                    }
+                });
+            });
+        });
+
+        if (materials.size > 0) {
+            console.error(`Effected materials: `, Array.from(materials));
+        }
+    }
+}
+
+const materialRegistry = new MaterialRegistry();
+
+export {
+    materialRegistry
+};

--- a/src/scene/materials/material.js
+++ b/src/scene/materials/material.js
@@ -15,7 +15,10 @@ import {
 } from '../constants.js';
 import { Debug } from '../../core/debug.js';
 import { getDefaultMaterial } from './default-material.js';
+
+// #if _DEBUG
 import { materialRegistry } from './material-registry.js';
+// #endif
 
 /** @typedef {import('../../graphics/texture.js').Texture} Texture */
 
@@ -501,7 +504,7 @@ class Material {
         }
 
         // #if _DEBUG
-        materialRegistry.add(this);
+        materialRegistry.remove(this);
         // #endif
     }
 

--- a/src/scene/materials/material.js
+++ b/src/scene/materials/material.js
@@ -15,6 +15,7 @@ import {
 } from '../constants.js';
 import { Debug } from '../../core/debug.js';
 import { getDefaultMaterial } from './default-material.js';
+import { materialRegistry } from './material-registry.js';
 
 /** @typedef {import('../../graphics/texture.js').Texture} Texture */
 
@@ -120,6 +121,10 @@ class Material {
     constructor() {
         this.name = 'Untitled';
         this.id = id++;
+
+        // #if _DEBUG
+        materialRegistry.add(this);
+        // #endif
 
         this._shader = null;
         this.variants = {};
@@ -494,6 +499,10 @@ class Material {
                 Debug.warn('pc.Material: MeshInstance mesh is null, default material cannot be assigned to the MeshInstance');
             }
         }
+
+        // #if _DEBUG
+        materialRegistry.add(this);
+        // #endif
     }
 
     // registers mesh instance as referencing the material


### PR DESCRIPTION
This PR adds a debug-only `MaterialRegistry` class and shader events which fire when shader compilation fails.

These are used to output the impacted materials on compile failure.

The `MaterialRegistry` class is completely removed from the codebase in non-debug builds.