### PR TITLE
Updated JSDocs of AppOptions to be JSDocs compatible

### DIFF
--- a/src/framework/app-options.js
+++ b/src/framework/app-options.js
@@ -85,21 +85,21 @@ class AppOptions {
     /**
      * The lightmapper.
      *
-     * @type {typeof Lightmapper}
+     * @type {Lightmapper}
      */
     lightmapper;
 
     /**
      * The BatchManager.
      *
-     * @type {typeof BatchManager}
+     * @type {BatchManager}
      */
     batchManager;
 
     /**
      * The XrManager.
      *
-     * @type {typeof XrManager}
+     * @type {XrManager}
      */
     xr;
 


### PR DESCRIPTION
Fixes https://github.com/playcanvas/engine/issues/4318

- making JSDocs to be happy, even though the type is not exactly correct. I don’t see a way for other solution for now.