### PR TITLE
Small ForwardRenderer change in a way view uniform buffers are setup

### DIFF
--- a/src/scene/picker.js
+++ b/src/scene/picker.js
@@ -183,7 +183,7 @@ class Picker {
         this.cameraEntity.camera.renderTarget = null;
 
         if (this._renderTarget) {
-            this._renderTarget._colorBuffer.destroy();
+            this._renderTarget.destroyTextureBuffers();
             this._renderTarget.destroy();
             this._renderTarget = null;
         }

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -326,7 +326,7 @@ class ForwardRenderer {
         }
     }
 
-    setCameraUniforms(camera, target) {
+    setCameraUniforms(camera, target, renderAction) {
 
         let transform;
 
@@ -422,6 +422,10 @@ class ForwardRenderer {
         this.cameraParams[3] = (1 + f / n) * 0.5;
         this.cameraParamsId.setValue(this.cameraParams);
 
+        if (this.device.supportsUniformBuffers) {
+            this.setupViewUniformBuffers(renderAction, viewCount);
+        }
+
         return viewCount;
     }
 
@@ -430,12 +434,8 @@ class ForwardRenderer {
     // when the functionality moves to the render passes.
     setCamera(camera, target, clear, renderAction = null) {
 
-        const viewCount = this.setCameraUniforms(camera, target);
+        const viewCount = this.setCameraUniforms(camera, target, renderAction);
         this.clearView(camera, target, clear, false);
-
-        if (this.device.supportsUniformBuffers) {
-            this.setupViewUniformBuffers(renderAction, viewCount);
-        }
     }
 
     setupViewUniformBuffers(renderAction, viewCount) {
@@ -2167,7 +2167,7 @@ class ForwardRenderer {
             // Set the not very clever global variable which is only useful when there's just one camera
             this.scene._activeCamera = camera.camera;
 
-            this.setCameraUniforms(camera.camera, renderAction.renderTarget);
+            this.setCameraUniforms(camera.camera, renderAction.renderTarget, renderAction);
 
             // upload clustered lights uniforms
             if (clusteredLightingEnabled && renderAction.lightClusters) {

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -425,8 +425,6 @@ class ForwardRenderer {
         if (this.device.supportsUniformBuffers) {
             this.setupViewUniformBuffers(renderAction, viewCount);
         }
-
-        return viewCount;
     }
 
     // make sure colorWrite is set to true to all channels, if you want to fully clear the target
@@ -434,7 +432,7 @@ class ForwardRenderer {
     // when the functionality moves to the render passes.
     setCamera(camera, target, clear, renderAction = null) {
 
-        const viewCount = this.setCameraUniforms(camera, target, renderAction);
+        this.setCameraUniforms(camera, target, renderAction);
         this.clearView(camera, target, clear, false);
     }
 


### PR DESCRIPTION
- updated to work with recent changes to render passes, unused on Webgl at this time.