### PR TITLE
AnimTargetValue fix

### DIFF
--- a/src/anim/evaluator/anim-target-value.js
+++ b/src/anim/evaluator/anim-target-value.js
@@ -122,7 +122,7 @@ class AnimTargetValue {
     }
 
     unbind() {
-        if (!this._normalizeWeights) {
+        if (this.setter) {
             this.setter(this.baseValue);
         }
     }


### PR DESCRIPTION
Before calling the AnimTargetValue's setter function, it should always check for null.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
