### PR TITLE
SSAO delayed resize fix

### DIFF
--- a/scripts/posteffects/posteffect-bloom.js
+++ b/scripts/posteffects/posteffect-bloom.js
@@ -229,7 +229,7 @@ BloomEffect.prototype.resize = function (target) {
 
         this.targets.push(bloomTarget);
     }
-}
+};
 
 Object.assign(BloomEffect.prototype, {
     render: function (inputTarget, outputTarget, rect) {

--- a/scripts/posteffects/posteffect-bloom.js
+++ b/scripts/posteffects/posteffect-bloom.js
@@ -189,7 +189,7 @@ BloomEffect.prototype.constructor = BloomEffect;
 BloomEffect.prototype.resize = function (target) {
 
     var width, height;
-    if (target == null) {
+    if (target === null) {
         width = this.device.width;
         height = this.device.height;
     } else {
@@ -197,11 +197,11 @@ BloomEffect.prototype.resize = function (target) {
         height = target.colorBuffer.height;
     }
 
-    if (width == this.width && height == this.height)
+    if (width === this.width && height === this.height)
         return;
 
     if (this.targets) {
-        for (let i = 0; i < this.targets.length; i++) {
+        for (var i = 0; i < this.targets.length; i++) {
             this.targets[i].destroyFrameBuffers();
             this.targets[i].destroyTextureBuffers();
             this.targets[i].destroy();

--- a/scripts/posteffects/posteffect-bloom.js
+++ b/scripts/posteffects/posteffect-bloom.js
@@ -200,8 +200,9 @@ BloomEffect.prototype.resize = function (target) {
     if (width === this.width && height === this.height)
         return;
 
+    var i;
     if (this.targets) {
-        for (var i = 0; i < this.targets.length; i++) {
+        for (i = 0; i < this.targets.length; i++) {
             this.targets[i].destroyFrameBuffers();
             this.targets[i].destroyTextureBuffers();
             this.targets[i].destroy();
@@ -210,7 +211,7 @@ BloomEffect.prototype.resize = function (target) {
 
     // Render targets
     this.targets = [];
-    for (var i = 0; i < 2; i++) {
+    for (i = 0; i < 2; i++) {
         var colorBuffer = new pc.Texture(this.device, {
             format: pc.PIXELFORMAT_R8_G8_B8_A8,
             width: width >> 1,

--- a/scripts/posteffects/posteffect-ssao.js
+++ b/scripts/posteffects/posteffect-ssao.js
@@ -20,14 +20,13 @@ function SSAOEffect(graphicsDevice, ssaoScript) {
     var vshader = [
         (graphicsDevice.webgl2) ? ("#version 300 es\n\n" + pc.shaderChunks.gles3VS) : "",
         graphicsDevice.webgl2 ? "" : "#extension GL_OES_standard_derivatives: enable\n",
-        graphicsDevice.webgl2 ? "" : "attribute vec2 aPosition;",
         "",
         "varying vec2 vUv0;",
         "",
         "void main(void)",
         "{",
-        graphicsDevice.webgl2 ? "    vUv0 = vec2((gl_VertexID << 1) & 2, gl_VertexID & 2);" : "   vUv0 = (aPosition.xy + 1.0) * 0.5;",
-        graphicsDevice.webgl2 ? "    gl_Position = vec4(vUv0 * 2.0f - 1.0f, 0.0f, 1.0f);" : "    gl_Position = vec4(aPosition, 0.0, 1.0);",
+        "   vUv0 = (aPosition.xy + 1.0) * 0.5;",
+        "   gl_Position = vec4(aPosition, 0.0, 1.0);",
         "}"
     ].join("\n");
 

--- a/scripts/posteffects/posteffect-ssao.js
+++ b/scripts/posteffects/posteffect-ssao.js
@@ -20,6 +20,7 @@ function SSAOEffect(graphicsDevice, ssaoScript) {
     var vshader = [
         (graphicsDevice.webgl2) ? ("#version 300 es\n\n" + pc.shaderChunks.gles3VS) : "",
         graphicsDevice.webgl2 ? "" : "#extension GL_OES_standard_derivatives: enable\n",
+        "attribute vec2 aPosition;",
         "",
         "varying vec2 vUv0;",
         "",
@@ -377,16 +378,22 @@ function SSAOEffect(graphicsDevice, ssaoScript) {
     this.samples = 20;
     this.downscale = 1.0;
 
-    this.resize();
+    this.resize(null);
 }
 
 SSAOEffect.prototype = Object.create(pc.PostEffect.prototype);
 SSAOEffect.prototype.constructor = SSAOEffect;
 
-SSAOEffect.prototype.resize = function () {
+SSAOEffect.prototype.resize = function (target) {
 
-    var width = Math.ceil(this.device.width / this.device.maxPixelRatio / this.downscale);
-    var height = Math.ceil(this.device.height / this.device.maxPixelRatio / this.downscale);
+    var width, height;
+    if (target == null) {
+        width = Math.ceil(this.device.width / this.device.maxPixelRatio / this.downscale);
+        height = Math.ceil(this.device.height / this.device.maxPixelRatio / this.downscale);
+    } else {
+        width = Math.ceil(target.colorBuffer.width / this.device.maxPixelRatio / this.downscale);
+        height = Math.ceil(target.colorBuffer.height / this.device.maxPixelRatio / this.downscale);
+    }
 
     // If no change, skip resize
     if (width == this.width && height == this.height)

--- a/scripts/posteffects/posteffect-ssao.js
+++ b/scripts/posteffects/posteffect-ssao.js
@@ -554,12 +554,7 @@ SSAO.prototype.initialize = function () {
         if (!this.enabled) return;
         this.effect.resize();
     });
-
-    this.app.graphicsDevice.on('resizecanvas', () => {
-        if (!this.enabled) return;
-        this.effect.resize();
-    });
-
+    
     this.on('destroy', function () {
         queue.removeEffect(this.effect);
     });

--- a/scripts/posteffects/posteffect-ssao.js
+++ b/scripts/posteffects/posteffect-ssao.js
@@ -554,7 +554,7 @@ SSAO.prototype.initialize = function () {
         if (!this.enabled) return;
         this.effect.resize();
     });
-    
+
     this.on('destroy', function () {
         queue.removeEffect(this.effect);
     });

--- a/scripts/posteffects/posteffect-ssao.js
+++ b/scripts/posteffects/posteffect-ssao.js
@@ -17,23 +17,25 @@ function SSAOEffect(graphicsDevice, ssaoScript) {
     this.ssaoScript = ssaoScript;
     this.needsDepthBuffer = true;
 
+    var vshader = [
+        (graphicsDevice.webgl2) ? ("#version 300 es\n\n" + pc.shaderChunks.gles3VS) : "",
+        graphicsDevice.webgl2 ? "" : "#extension GL_OES_standard_derivatives: enable\n",
+        graphicsDevice.webgl2 ? "" : "attribute vec2 aPosition;",
+        "",
+        "varying vec2 vUv0;",
+        "",
+        "void main(void)",
+        "{",
+        graphicsDevice.webgl2 ? "    vUv0 = vec2((gl_VertexID << 1) & 2, gl_VertexID & 2);" : "   vUv0 = (aPosition.xy + 1.0) * 0.5;",
+        graphicsDevice.webgl2 ? "    gl_Position = vec4(vUv0 * 2.0f - 1.0f, 0.0f, 1.0f);" : "    gl_Position = vec4(aPosition, 0.0, 1.0);",
+        "}"
+    ].join("\n");
+
     this.ssaoShader = new pc.Shader(graphicsDevice, {
         attributes: {
             aPosition: pc.SEMANTIC_POSITION
         },
-        vshader: [
-            (graphicsDevice.webgl2) ? ("#version 300 es\n\n" + pc.shaderChunks.gles3VS) : "",
-            graphicsDevice.webgl2 ? "" : "#extension GL_OES_standard_derivatives: enable\n",
-            "attribute vec2 aPosition;",
-            "",
-            "varying vec2 vUv0;",
-            "",
-            "void main(void)",
-            "{",
-            "    gl_Position = vec4(aPosition, 0.0, 1.0);",
-            "    vUv0 = (aPosition.xy + 1.0) * 0.5;",
-            "}"
-        ].join("\n"),
+        vshader: vshader,
         fshader: [
             (graphicsDevice.webgl2) ? ("#version 300 es\n\n" + pc.shaderChunks.gles3PS) : "",
             graphicsDevice.webgl2 ? "" : "#extension GL_OES_standard_derivatives: enable\n",
@@ -267,19 +269,7 @@ function SSAOEffect(graphicsDevice, ssaoScript) {
         attributes: {
             aPosition: pc.SEMANTIC_POSITION
         },
-        vshader: [
-            (graphicsDevice.webgl2) ? ("#version 300 es\n\n" + pc.shaderChunks.gles3VS) : "",
-            graphicsDevice.webgl2 ? "" : "#extension GL_OES_standard_derivatives: enable\n",
-            "attribute vec2 aPosition;",
-            "",
-            "varying vec2 vUv0;",
-            "",
-            "void main(void)",
-            "{",
-            "    gl_Position = vec4(aPosition, 0.0, 1.0);",
-            "    vUv0 = (aPosition.xy + 1.0) * 0.5;",
-            "}"
-        ].join("\n"),
+        vshader: vshader,
         fshader: [
             (graphicsDevice.webgl2) ? ("#version 300 es\n\n" + pc.shaderChunks.gles3PS) : "",
             graphicsDevice.webgl2 ? "" : "#extension GL_OES_standard_derivatives: enable\n",
@@ -362,19 +352,7 @@ function SSAOEffect(graphicsDevice, ssaoScript) {
         attributes: {
             aPosition: pc.SEMANTIC_POSITION
         },
-        vshader: [
-            (graphicsDevice.webgl2) ? ("#version 300 es\n\n" + pc.shaderChunks.gles3VS) : "",
-            graphicsDevice.webgl2 ? "" : "#extension GL_OES_standard_derivatives: enable\n",
-            "attribute vec2 aPosition;",
-            "",
-            "varying vec2 vUv0;",
-            "",
-            "void main(void)",
-            "{",
-            "    gl_Position = vec4(aPosition, 0.0, 1.0);",
-            "    vUv0 = (aPosition.xy + 1.0) * 0.5;",
-            "}"
-        ].join("\n"),
+        vshader: vshader,
         fshader: [
             (graphicsDevice.webgl2) ? ("#version 300 es\n\n" + pc.shaderChunks.gles3PS) : "",
             graphicsDevice.webgl2 ? "" : "#extension GL_OES_standard_derivatives: enable\n",

--- a/scripts/posteffects/posteffect-ssao.js
+++ b/scripts/posteffects/posteffect-ssao.js
@@ -387,7 +387,7 @@ SSAOEffect.prototype.constructor = SSAOEffect;
 SSAOEffect.prototype.resize = function (target) {
 
     var width, height;
-    if (target == null) {
+    if (target === null) {
         width = Math.ceil(this.device.width / this.device.maxPixelRatio / this.downscale);
         height = Math.ceil(this.device.height / this.device.maxPixelRatio / this.downscale);
     } else {
@@ -396,7 +396,7 @@ SSAOEffect.prototype.resize = function (target) {
     }
 
     // If no change, skip resize
-    if (width == this.width && height == this.height)
+    if (width === this.width && height === this.height)
         return;
 
     // Render targets

--- a/src/framework/components/camera/post-effect-queue.js
+++ b/src/framework/components/camera/post-effect-queue.js
@@ -381,7 +381,7 @@ class PostEffectQueue {
         for (let i = 0, len = effects.length; i < len; i++) {
             const fx = effects[i];
             if (fx.effect.resize !== undefined)
-                fx.effect.resize();
+                fx.effect.resize(fx.inputTarget);
             if (fx.inputTarget.width !== desiredWidth ||
                 fx.inputTarget.height !== desiredHeight)  {
                 this._resizeOffscreenTarget(fx.inputTarget);

--- a/src/framework/components/camera/post-effect-queue.js
+++ b/src/framework/components/camera/post-effect-queue.js
@@ -64,14 +64,6 @@ class PostEffectQueue {
 
         this.renderTargetScale = 1;
 
-        /**
-         * The time in milliseconds since the last resize.
-         *
-         * @type {number}
-         * @private
-         */
-        this.resizeLast = 0;
-
         camera.on('set:rect', this.onCameraRectChanged, this);
     }
 
@@ -369,8 +361,6 @@ class PostEffectQueue {
     }
 
     resizeRenderTargets() {
-
-        this.resizeLast = now();
 
         const rect = this.camera.rect;
         const desiredWidth = Math.floor(rect.z * this.app.graphicsDevice.width * this.renderTargetScale);

--- a/src/framework/components/camera/post-effect-queue.js
+++ b/src/framework/components/camera/post-effect-queue.js
@@ -1,5 +1,3 @@
-import { now } from '../../../core/time.js';
-
 import { ADDRESS_CLAMP_TO_EDGE, FILTER_NEAREST, PIXELFORMAT_R8_G8_B8_A8 } from '../../../graphics/constants.js';
 import { DebugGraphics } from '../../../graphics/debug-graphics.js';
 import { RenderTarget } from '../../../graphics/render-target.js';


### PR DESCRIPTION
Fixes #4239 

Removed the resize timeouts. Added a general resize callback to the post effects such that they can handle resize. 

Bloom needs such a callback to adapt it's internal targets (which should save performance when viewport is small). 