### PR TITLE
Really really disable mipmaps on RGBE

### DIFF
--- a/src/resources/parser/texture/hdr.js
+++ b/src/resources/parser/texture/hdr.js
@@ -43,7 +43,7 @@ class HdrParser {
             // #endif
             addressU: ADDRESS_REPEAT,
             addressV: ADDRESS_CLAMP_TO_EDGE,
-            minFilter: FILTER_NEAREST_MIPMAP_NEAREST,
+            minFilter: FILTER_NEAREST,
             magFilter: FILTER_NEAREST,
             width: textureData.width,
             height: textureData.height,

--- a/src/resources/parser/texture/hdr.js
+++ b/src/resources/parser/texture/hdr.js
@@ -5,7 +5,7 @@ import { Texture } from '../../../graphics/texture.js';
 import {
     TEXHINT_ASSET,
     ADDRESS_REPEAT, ADDRESS_CLAMP_TO_EDGE,
-    FILTER_NEAREST_MIPMAP_NEAREST, FILTER_NEAREST,
+    FILTER_NEAREST,
     PIXELFORMAT_R8_G8_B8_A8,
     TEXTURETYPE_RGBE
 } from '../../../graphics/constants.js';


### PR DESCRIPTION
Disable mipmaps a lot when loading RGBE.

Not doing so resulted in banding artifacts when converting HDR equirect to RGBM lighting cubemap.