### PR TITLE
Adding shadow intensity control to clustered lighting.

### DIFF
--- a/examples/src/examples/graphics/clustered-spot-shadows.tsx
+++ b/examples/src/examples/graphics/clustered-spot-shadows.tsx
@@ -43,6 +43,9 @@ class ClusteredSpotShadowsExample {
                 <LabelGroup text='Static'>
                     <BooleanInput type='toggle' binding={new BindingTwoWay()} link={{ observer: data, path: 'settings.static' }} value={data.get('settings.static')}/>
                 </LabelGroup>
+                <LabelGroup text='Shadow Intensity'>
+                    <SliderInput binding={new BindingTwoWay()} link={{ observer: data, path: 'settings.shadowIntensity' }} min={0} max={1} value={data.get('settings.shadowIntensity')}/>
+                </LabelGroup>
                 <Button text='Add Light' onClick={() => data.emit('add')}/>
                 <Button text='Remove Light' onClick={() => data.emit('remove')}/>
                 <LabelGroup text='Light Count'>
@@ -85,6 +88,7 @@ class ClusteredSpotShadowsExample {
                 shadowType: pc.SHADOW_PCF3,      // shadow filter type
                 shadowsEnabled: true,
                 cookiesEnabled: true,
+                shadowIntensity: 1,
                 numLights: 0,
                 debug: false,
                 debugAtlas: false,
@@ -291,7 +295,10 @@ class ClusteredSpotShadowsExample {
 
                     // show debug atlas
                     debugAtlas = value;
-
+                } else if (pathArray[1] === 'shadowIntensity') {
+                    for (let i = 0; i < spotLightList.length; i++) {
+                        spotLightList[i].light.shadowIntensity = value;
+                    }
                 } else {
                     // @ts-ignore
                     lighting[pathArray[1]] = value;

--- a/src/scene/lighting/lights-buffer.js
+++ b/src/scene/lighting/lights-buffer.js
@@ -276,11 +276,11 @@ class LightsBuffer {
         return tempAreaLightSizes;
     }
 
-    addLightDataFlags(data8, index, light, isSpot, castShadows) {
+    addLightDataFlags(data8, index, light, isSpot, castShadows, shadowIntensity) {
         data8[index + 0] = isSpot ? 255 : 0;
         data8[index + 1] = light._shape * 64;           // value 0..3
         data8[index + 2] = light._falloffMode * 255;    // value 0..1
-        data8[index + 3] = castShadows ? 255 : 0;
+        data8[index + 3] = castShadows ? shadowIntensity * 255 : 0;
     }
 
     addLightDataColor(data8, index, light, gammaCorrection, isCookie) {
@@ -400,7 +400,7 @@ class LightsBuffer {
         const data8Start = lightIndex * this.lightsTexture8.width * 4;
 
         // flags
-        this.addLightDataFlags(data8, data8Start + 4 * TextureIndex8.FLAGS, light, isSpot, castShadows);
+        this.addLightDataFlags(data8, data8Start + 4 * TextureIndex8.FLAGS, light, isSpot, castShadows, light.shadowIntensity);
 
         // light color
         this.addLightDataColor(data8, data8Start + 4 * TextureIndex8.COLOR_A, light, gammaCorrection, isCookie);

--- a/types-fixup.mjs
+++ b/types-fixup.mjs
@@ -178,6 +178,7 @@ const lightComponentProps = [
     ['range', 'number'],
     ['shadowBias', 'number'],
     ['shadowDistance', 'number'],
+    ['shadowIntensity', 'number'],
     ['shadowResolution', 'number'],
     ['shadowType', 'number'],
     ['shadowUpdateMode', 'number'],


### PR DESCRIPTION
Highjack the castShadows value to instead pass the shadow intensity. Shadow intensity 0 could just as well be castShadows: false.
Updated the spot light shadow example to allow for controlling the shadow intensity.