### PR TITLE
[Fix] Improvement to Entity.destroy

### DIFF
--- a/src/framework/entity.js
+++ b/src/framework/entity.js
@@ -552,19 +552,17 @@ class Entity extends GraphNode {
         if (this._parent)
             this._parent.removeChild(this);
 
+        // recursively destroy all children
         const children = this._children;
-        let child = children.shift();
-        while (child) {
+        while (children.length) {
+
+            // remove a child from the array and disconnect it from the parent
+            const child = children.pop();
+            child._parent = null;
+
             if (child instanceof Entity) {
                 child.destroy();
             }
-
-            // make sure child._parent is null because
-            // we have removed it from the children array before calling
-            // destroy on it
-            child._parent = null;
-
-            child = children.shift();
         }
 
         // fire destroy event


### PR DESCRIPTION
Fixes https://github.com/playcanvas/engine/issues/3954

- when the child is removed from the array, clear the parent as well, before calling destroy, to avoid it from trying to remove it from the array again
- use pop instead of shift, which is faster, and we don't really care about the order of children destruction.