### PR TITLE
Fix depth linearization

### DIFF
--- a/src/graphics/program-lib/chunks/common/frag/screenDepth.js
+++ b/src/graphics/program-lib/chunks/common/frag/screenDepth.js
@@ -13,13 +13,13 @@ uniform mat4 matrix_view;
 
 #ifndef CAMERAPLANES
 #define CAMERAPLANES
-uniform vec4 camera_params; // 1 / camera_far,      camera_far,     (1 - f / n) / 2,        (1 + f / n) / 2
+uniform vec4 camera_params; // 1 / camera_far,      camera_far,     camera_near,        _
 #endif
 
 #ifdef GL2
 float linearizeDepth(float z) {
     z = z * 2.0 - 1.0;
-    return 1.0 / (camera_params.z * z + camera_params.w);
+    return camera_params.z * camera_params.y / (camera_params.y + z * (camera_params.z - camera_params.y));
 }
 #else
 #ifndef UNPACKFLOAT

--- a/src/graphics/program-lib/chunks/common/frag/screenDepth.js
+++ b/src/graphics/program-lib/chunks/common/frag/screenDepth.js
@@ -11,15 +11,19 @@ uniform vec4 uScreenSize;
 uniform mat4 matrix_view;
 #endif
 
+
+
 #ifndef CAMERAPLANES
 #define CAMERAPLANES
-uniform vec4 camera_params; // 1 / camera_far,      camera_far,     camera_near,        _
+uniform vec4 camera_params; // 1 / camera_far,      camera_far,     camera_near,        is_ortho
 #endif
 
 #ifdef GL2
 float linearizeDepth(float z) {
-    z = z * 2.0 - 1.0;
-    return (camera_params.z * camera_params.y) / (camera_params.y + z * (camera_params.z - camera_params.y));
+    if (camera_params.w == 0.0)
+        return (camera_params.z * camera_params.y) / (camera_params.y + z * (camera_params.z - camera_params.y));
+    else
+        return camera_params.z + z * (camera_params.y - camera_params.z);
 }
 #else
 #ifndef UNPACKFLOAT
@@ -34,9 +38,9 @@ float unpackFloat(vec4 rgbaDepth) {
 // Retrieves rendered linear camera depth by UV
 float getLinearScreenDepth(vec2 uv) {
     #ifdef GL2
-    return linearizeDepth(texture2D(uSceneDepthMap, uv).r) * camera_params.y;
+        return linearizeDepth(texture2D(uSceneDepthMap, uv).r);
     #else
-    return unpackFloat(texture2D(uSceneDepthMap, uv)) * camera_params.y;
+        return unpackFloat(texture2D(uSceneDepthMap, uv)) * camera_params.y;
     #endif
 }
 

--- a/src/graphics/program-lib/chunks/common/frag/screenDepth.js
+++ b/src/graphics/program-lib/chunks/common/frag/screenDepth.js
@@ -19,7 +19,7 @@ uniform vec4 camera_params; // 1 / camera_far,      camera_far,     camera_near,
 #ifdef GL2
 float linearizeDepth(float z) {
     z = z * 2.0 - 1.0;
-    return camera_params.z * camera_params.y / (camera_params.y + z * (camera_params.z - camera_params.y));
+    return (camera_params.z * camera_params.y) / (camera_params.y + z * (camera_params.z - camera_params.y));
 }
 #else
 #ifndef UNPACKFLOAT

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -419,8 +419,8 @@ class ForwardRenderer {
         const f = camera._farClip;
         this.cameraParams[0] = 1 / f;
         this.cameraParams[1] = f;
-        this.cameraParams[2] = (1 - f / n) * 0.5;
-        this.cameraParams[3] = (1 + f / n) * 0.5;
+        this.cameraParams[2] = n;
+        this.cameraParams[3] = 0.0;
         this.cameraParamsId.setValue(this.cameraParams);
 
         if (this.device.supportsUniformBuffers) {

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -33,7 +33,7 @@ import {
     MASK_AFFECT_LIGHTMAPPED, MASK_AFFECT_DYNAMIC, MASK_BAKE,
     SHADOWUPDATE_NONE,
     SORTKEY_DEPTH, SORTKEY_FORWARD,
-    VIEW_CENTER, SHADOWUPDATE_THISFRAME, LAYERID_DEPTH
+    VIEW_CENTER, SHADOWUPDATE_THISFRAME, LAYERID_DEPTH, PROJECTION_ORTHOGRAPHIC
 } from '../constants.js';
 import { Material } from '../materials/material.js';
 import { LightTextureAtlas } from '../lighting/light-texture-atlas.js';
@@ -420,7 +420,12 @@ class ForwardRenderer {
         this.cameraParams[0] = 1 / f;
         this.cameraParams[1] = f;
         this.cameraParams[2] = n;
-        this.cameraParams[3] = 0.0;
+        if (camera.projection == PROJECTION_ORTHOGRAPHIC) {
+            this.cameraParams[3] = 1;
+        } else {
+            this.cameraParams[3] = 0;
+        }
+
         this.cameraParamsId.setValue(this.cameraParams);
 
         if (this.device.supportsUniformBuffers) {

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -420,11 +420,7 @@ class ForwardRenderer {
         this.cameraParams[0] = 1 / f;
         this.cameraParams[1] = f;
         this.cameraParams[2] = n;
-        if (camera.projection == PROJECTION_ORTHOGRAPHIC) {
-            this.cameraParams[3] = 1;
-        } else {
-            this.cameraParams[3] = 0;
-        }
+        this.cameraParams[3] = camera.projection == PROJECTION_ORTHOGRAPHIC ? 1 : 0;
 
         this.cameraParamsId.setValue(this.cameraParams);
 

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -420,7 +420,7 @@ class ForwardRenderer {
         this.cameraParams[0] = 1 / f;
         this.cameraParams[1] = f;
         this.cameraParams[2] = n;
-        this.cameraParams[3] = camera.projection == PROJECTION_ORTHOGRAPHIC ? 1 : 0;
+        this.cameraParams[3] = camera.projection === PROJECTION_ORTHOGRAPHIC ? 1 : 0;
 
         this.cameraParamsId.setValue(this.cameraParams);
 


### PR DESCRIPTION
Fixes #3411

Linearization of the depth buffer was done incorrectly, however it produced coherently variant results with a perspective projection, but not with an orthogonal one. That resulted in post effects linearizing depth producing incorrect results, such as the SSAO:

![Screenshot 2022-06-22 at 16 23 51](https://user-images.githubusercontent.com/107400752/175083987-deb03ca7-3482-4e9a-ad76-48f525b5e000.png)
 effect. 

With this PR, the results are more correct:

![Screenshot 2022-06-22 at 16 53 48](https://user-images.githubusercontent.com/107400752/175079578-0381634e-a573-4963-ab5c-4f1e2a41f869.png)

