### PR TITLE
Public log tracing functionality

### DIFF
--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -1,0 +1,42 @@
+/**
+ * Logs a frame number.
+ *
+ * @type {string}
+ */
+export const TRACEID_RENDER_FRAME = 'RenderFrame';
+
+ /**
+  * Logs basic information about generated render passes.
+  *
+  * @type {string}
+  */
+export const TRACEID_RENDER_PASS = 'RenderPass';
+
+ /**
+  * Logs additional detail for render passes.
+  *
+  * @type {string}
+  */
+export const TRACEID_RENDER_PASS_DETAIL = 'RenderPassDetail';
+
+ /**
+  * Logs render actions created by the layer composition. Only executes when the
+  * layer composition changes.
+  *
+  * @type {string}
+  */
+export const TRACEID_RENDER_ACTION = 'RenderAction';
+
+ /**
+  * Logs the allocation of render targets.
+  *
+  * @type {string}
+  */
+export const TRACEID_RENDER_TARGET_ALLOC = 'RenderTargetAlloc';
+
+ /**
+  * Logs the allocation of textures.
+  *
+  * @type {string}
+  */
+export const TRACEID_TEXTURE_ALLOC = 'TextureAlloc';

--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -5,38 +5,38 @@
  */
 export const TRACEID_RENDER_FRAME = 'RenderFrame';
 
- /**
-  * Logs basic information about generated render passes.
-  *
-  * @type {string}
-  */
+/**
+ * Logs basic information about generated render passes.
+ *
+ * @type {string}
+ */
 export const TRACEID_RENDER_PASS = 'RenderPass';
 
- /**
-  * Logs additional detail for render passes.
-  *
-  * @type {string}
-  */
+/**
+ * Logs additional detail for render passes.
+ *
+ * @type {string}
+ */
 export const TRACEID_RENDER_PASS_DETAIL = 'RenderPassDetail';
 
- /**
-  * Logs render actions created by the layer composition. Only executes when the
-  * layer composition changes.
-  *
-  * @type {string}
-  */
+/**
+ * Logs render actions created by the layer composition. Only executes when the
+ * layer composition changes.
+ *
+ * @type {string}
+ */
 export const TRACEID_RENDER_ACTION = 'RenderAction';
 
- /**
-  * Logs the allocation of render targets.
-  *
-  * @type {string}
-  */
+/**
+ * Logs the allocation of render targets.
+ *
+ * @type {string}
+ */
 export const TRACEID_RENDER_TARGET_ALLOC = 'RenderTargetAlloc';
 
- /**
-  * Logs the allocation of textures.
-  *
-  * @type {string}
-  */
+/**
+ * Logs the allocation of textures.
+ *
+ * @type {string}
+ */
 export const TRACEID_TEXTURE_ALLOC = 'TextureAlloc';

--- a/src/core/debug.js
+++ b/src/core/debug.js
@@ -1,7 +1,10 @@
+import { Tracing } from "./tracing.js";
+
 /**
  * Engine debug log system. Note that the logging only executes in the
- * debug build of the engine, and is stripped out in other builds. It allows
- * you to monitor logs from various engine systems.
+ * debug build of the engine, and is stripped out in other builds.
+ *
+ * @ignore
  */
 class Debug {
     /**
@@ -13,53 +16,9 @@ class Debug {
     static _loggedMessages = new Set();
 
     /**
-     * Set storing names of enabled trace channels
-     *
-     * @type {Set<string>}
-     * @private
-     */
-    static _traceChannels = new Set();
-
-    /**
-     * Enable or disable trace channel
-     *
-     * @param {string} channel - Name of the trace channel. Can be:
-     *
-     * - {@link TRACEID_RENDER_FRAME}
-     * - {@link TRACEID_RENDER_PASS}
-     * - {@link TRACEID_RENDER_PASS_DETAIL}
-     * - {@link TRACEID_RENDER_ACTION}
-     * - {@link TRACEID_RENDER_TARGET_ALLOC}
-     * - {@link TRACEID_TEXTURE_ALLOC}
-     *
-     * @param {boolean} enabled - new enabled state for it
-     */
-    static setTrace(channel, enabled = true) {
-
-        // #if _DEBUG
-        if (enabled) {
-            Debug._traceChannels.add(channel);
-        } else {
-            Debug._traceChannels.delete(channel);
-        }
-        // #endif
-    }
-
-    /**
-     * Test if the trace channel is enabled.
-     *
-     * @param {string} channel - Name of the trace channnel.
-     * @returns {boolean} - True if the trace channel is enabled.
-     */
-    static getTrace(channel) {
-        return Debug._traceChannels.has(channel);
-    }
-
-    /**
      * Deprecated warning message.
      *
      * @param {string} message - The message to log.
-     * @ignore
      */
     static deprecated(message) {
         if (!Debug._loggedMessages.has(message)) {
@@ -73,7 +32,6 @@ class Debug {
      *
      * @param {boolean|object} assertion - The assertion to check.
      * @param {...*} args - The values to be written to the log.
-     * @ignore
      */
     static assert(assertion, ...args) {
         if (!assertion) {
@@ -85,7 +43,6 @@ class Debug {
      * Executes a function in debug mode only.
      *
      * @param {Function} func - Function to call.
-     * @ignore
      */
     static call(func) {
         func();
@@ -95,7 +52,6 @@ class Debug {
      * Info message.
      *
      * @param {...*} args - The values to be written to the log.
-     * @ignore
      */
     static log(...args) {
         console.log(...args);
@@ -105,7 +61,6 @@ class Debug {
      * Info message logged no more than once.
      *
      * @param {string} message - The message to log.
-     * @ignore
      */
     static logOnce(message) {
         if (!Debug._loggedMessages.has(message)) {
@@ -118,7 +73,6 @@ class Debug {
      * Warning message.
      *
      * @param {...*} args - The values to be written to the log.
-     * @ignore
      */
     static warn(...args) {
         console.warn(...args);
@@ -128,7 +82,6 @@ class Debug {
      * Warning message logged no more than once.
      *
      * @param {string} message - The message to log.
-     * @ignore
      */
     static warnOnce(message) {
         if (!Debug._loggedMessages.has(message)) {
@@ -141,7 +94,6 @@ class Debug {
      * Error message.
      *
      * @param {...*} args - The values to be written to the log.
-     * @ignore
      */
     static error(...args) {
         console.error(...args);
@@ -151,7 +103,6 @@ class Debug {
      * Error message logged no more than once.
      *
      * @param {string} message - The message to log.
-     * @ignore
      */
     static errorOnce(message) {
         if (!Debug._loggedMessages.has(message)) {
@@ -165,10 +116,9 @@ class Debug {
      *
      * @param {string} channel - The trace channel
      * @param {...*} args - The values to be written to the log.
-     * @ignore
      */
     static trace(channel, ...args) {
-        if (Debug._traceChannels.has(channel)) {
+        if (Tracing.get(channel)) {
             console.log(`${channel.padEnd(20, ' ')}|`, ...args);
         }
     }

--- a/src/core/debug.js
+++ b/src/core/debug.js
@@ -1,47 +1,4 @@
 /**
- * Logs a frame number.
- *
- * @type {string}
- */
-export const TRACEID_RENDER_FRAME = 'RenderFrame';
-
-/**
- * Logs basic information about generated render passes.
- *
- * @type {string}
- */
-export const TRACEID_RENDER_PASS = 'RenderPass';
-
-/**
- * Logs additional detail for render passes.
- *
- * @type {string}
- */
-export const TRACEID_RENDER_PASS_DETAIL = 'RenderPassDetail';
-
-/**
- * Logs render actions created by the layer composition. Only executes when the
- * layer composition changes.
- *
- * @type {string}
- */
-export const TRACEID_RENDER_ACTION = 'RenderAction';
-
-/**
- * Logs the allocation of render targets.
- *
- * @type {string}
- */
-export const TRACEID_RENDER_TARGET_ALLOC = 'RenderTargetAlloc';
-
-/**
- * Logs the allocation of textures.
- *
- * @type {string}
- */
-export const TRACEID_TEXTURE_ALLOC = 'TextureAlloc';
-
-/**
  * Engine debug log system. Note that the logging only executes in the
  * debug build of the engine, and is stripped out in other builds. It allows
  * you to monitor logs from various engine systems.

--- a/src/core/tracing.js
+++ b/src/core/tracing.js
@@ -1,9 +1,9 @@
 /**
- * A log tracing functionality, allowing for tracing of the internal functionality
- * of the engine. Note that the trace logging only takes place in the debug build
- * of the engine, and is stripped out in other builds.
+ * Log tracing functionality, allowing for tracing of the internal functionality of the engine.
+ * Note that the trace logging only takes place in the debug build of the engine and is stripped
+ * out in other builds.
  */
-class Tracing {
+ class Tracing {
     /**
      * Set storing names of enabled trace channels
      *

--- a/src/core/tracing.js
+++ b/src/core/tracing.js
@@ -5,7 +5,7 @@
  */
  class Tracing {
     /**
-     * Set storing names of enabled trace channels
+     * Set storing the names of enabled trace channels.
      *
      * @type {Set<string>}
      * @private
@@ -13,7 +13,7 @@
     static _traceChannels = new Set();
 
     /**
-     * Enable or disable trace channel
+     * Enable or disable a trace channel.
      *
      * @param {string} channel - Name of the trace channel. Can be:
      *
@@ -24,7 +24,7 @@
      * - {@link TRACEID_RENDER_TARGET_ALLOC}
      * - {@link TRACEID_TEXTURE_ALLOC}
      *
-     * @param {boolean} enabled - new enabled state for it
+     * @param {boolean} enabled - New enabled state for the channel.
      */
     static set(channel, enabled = true) {
 

--- a/src/core/tracing.js
+++ b/src/core/tracing.js
@@ -1,0 +1,51 @@
+/**
+ * A log tracing functionality, allowing for tracing of the internal functionality
+ * of the engine. Note that the trace logging only takes place in the debug build
+ * of the engine, and is stripped out in other builds.
+ */
+class Tracing {
+    /**
+     * Set storing names of enabled trace channels
+     *
+     * @type {Set<string>}
+     * @private
+     */
+    static _traceChannels = new Set();
+
+    /**
+     * Enable or disable trace channel
+     *
+     * @param {string} channel - Name of the trace channel. Can be:
+     *
+     * - {@link TRACEID_RENDER_FRAME}
+     * - {@link TRACEID_RENDER_PASS}
+     * - {@link TRACEID_RENDER_PASS_DETAIL}
+     * - {@link TRACEID_RENDER_ACTION}
+     * - {@link TRACEID_RENDER_TARGET_ALLOC}
+     * - {@link TRACEID_TEXTURE_ALLOC}
+     *
+     * @param {boolean} enabled - new enabled state for it
+     */
+    static set(channel, enabled = true) {
+
+        // #if _DEBUG
+        if (enabled) {
+            Tracing._traceChannels.add(channel);
+        } else {
+            Tracing._traceChannels.delete(channel);
+        }
+        // #endif
+    }
+
+    /**
+     * Test if the trace channel is enabled.
+     *
+     * @param {string} channel - Name of the trace channnel.
+     * @returns {boolean} - True if the trace channel is enabled.
+     */
+    static get(channel) {
+        return Tracing._traceChannels.has(channel);
+    }
+}
+
+export { Tracing };

--- a/src/core/tracing.js
+++ b/src/core/tracing.js
@@ -3,7 +3,7 @@
  * Note that the trace logging only takes place in the debug build of the engine and is stripped
  * out in other builds.
  */
- class Tracing {
+class Tracing {
     /**
      * Set storing the names of enabled trace channels.
      *

--- a/src/framework/app-base.js
+++ b/src/framework/app-base.js
@@ -6,7 +6,8 @@ import { platform } from '../core/platform.js';
 import { now } from '../core/time.js';
 import { path } from '../core/path.js';
 import { EventHandler } from '../core/event-handler.js';
-import { Debug, TRACEID_RENDER_FRAME } from '../core/debug.js';
+import { Debug } from '../core/debug.js';
+import { TRACEID_RENDER_FRAME } from '../core/constants.js';
 
 import { math } from '../math/math.js';
 import { Color } from '../math/color.js';

--- a/src/graphics/render-target.js
+++ b/src/graphics/render-target.js
@@ -1,4 +1,5 @@
-import { Debug, TRACEID_RENDER_TARGET_ALLOC } from '../core/debug.js';
+import { Debug } from '../core/debug.js';
+import { TRACEID_RENDER_TARGET_ALLOC } from '../core/constants.js';
 import { PIXELFORMAT_DEPTH, PIXELFORMAT_DEPTHSTENCIL } from './constants.js';
 import { DebugGraphics } from './debug-graphics.js';
 import { GraphicsDevice } from './graphics-device.js';

--- a/src/graphics/texture.js
+++ b/src/graphics/texture.js
@@ -1,4 +1,5 @@
-import { Debug, TRACEID_TEXTURE_ALLOC } from '../core/debug.js';
+import { Debug } from '../core/debug.js';
+import { TRACEID_TEXTURE_ALLOC } from '../core/constants.js';
 import { math } from '../math/math.js';
 
 import {

--- a/src/index.js
+++ b/src/index.js
@@ -28,7 +28,7 @@ export { SortedLoopArray } from './core/sorted-loop-array.js';
 export { Tags } from './core/tags.js';
 export { Timer, now } from './core/time.js';
 export { URI, createURI } from './core/uri.js';
-export { Debug } from './core/debug.js';
+export { Tracing } from './core/tracing.js';
 
 // NET
 export { http, Http } from './net/http.js';

--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,7 @@ import './polyfill/typedarray-fill.js';
 import './polyfill/OESVertexArrayObject.js';
 
 // CORE
+export * from './core/constants.js';
 export { apps, common, config, data, extend, isDefined, revision, type, version } from './core/core.js';
 export { events } from './core/events.js';
 export { guid } from './core/guid.js';

--- a/src/scene/composition/layer-composition.js
+++ b/src/scene/composition/layer-composition.js
@@ -1,4 +1,5 @@
-import { Debug, TRACEID_RENDER_ACTION } from '../../core/debug.js';
+import { TRACEID_RENDER_ACTION } from '../../core/constants.js';
+import { Debug } from '../../core/debug.js';
 import { EventHandler } from '../../core/event-handler.js';
 import { set } from '../../core/set-utils.js';
 import { sortPriority } from '../../core/sort.js';

--- a/src/scene/composition/layer-composition.js
+++ b/src/scene/composition/layer-composition.js
@@ -1,5 +1,6 @@
 import { TRACEID_RENDER_ACTION } from '../../core/constants.js';
 import { Debug } from '../../core/debug.js';
+import { Tracing } from '../../core/tracing.js';
 import { EventHandler } from '../../core/event-handler.js';
 import { set } from '../../core/set-utils.js';
 import { sortPriority } from '../../core/sort.js';
@@ -676,7 +677,7 @@ class LayerComposition extends EventHandler {
     _logRenderActions() {
 
         // #if _DEBUG
-        if (Debug.getTrace(TRACEID_RENDER_ACTION)) {
+        if (Tracing.get(TRACEID_RENDER_ACTION)) {
             Debug.trace(TRACEID_RENDER_ACTION, 'Render Actions for composition: ' + this.name);
             for (let i = 0; i < this._renderActions.length; i++) {
                 const ra = this._renderActions[i];

--- a/src/scene/frame-graph.js
+++ b/src/scene/frame-graph.js
@@ -1,5 +1,6 @@
 import { TRACEID_RENDER_PASS, TRACEID_RENDER_PASS_DETAIL } from '../core/constants.js';
 import { Debug } from '../core/debug.js';
+import { Tracing } from '../core/tracing.js';
 
 /** @typedef {import('../graphics/render-pass.js').RenderPass} RenderPass */
 /** @typedef {import('../graphics/render-target.js').RenderTarget} RenderTarget */
@@ -129,7 +130,7 @@ class FrameGraph {
 
     log() {
         // #if _DEBUG
-        if (Debug.getTrace(TRACEID_RENDER_PASS) || Debug.getTrace(TRACEID_RENDER_PASS_DETAIL)) {
+        if (Tracing.get(TRACEID_RENDER_PASS) || Tracing.get(TRACEID_RENDER_PASS_DETAIL)) {
 
             this.renderPasses.forEach((renderPass, index) => {
 

--- a/src/scene/frame-graph.js
+++ b/src/scene/frame-graph.js
@@ -1,4 +1,5 @@
-import { Debug, TRACEID_RENDER_PASS, TRACEID_RENDER_PASS_DETAIL } from '../core/debug.js';
+import { TRACEID_RENDER_PASS, TRACEID_RENDER_PASS_DETAIL } from '../core/constants.js';
+import { Debug } from '../core/debug.js';
 
 /** @typedef {import('../graphics/render-pass.js').RenderPass} RenderPass */
 /** @typedef {import('../graphics/render-target.js').RenderTarget} RenderTarget */


### PR DESCRIPTION
changes:
- Debug class is no longer exported, and it is completely stripped in non-debug builds
- Tracing class is public and exported, with new public API (see below)
- tracing channel constants were moved to core/constants.js and exported

**new API:**
```
// enable / disable tracing of channel
pc.Tracing.set(pc.TRACEID_RENDER_PASS, true);

// query status of the tracing channel - true or false
pc.Tracing.get(pc.TRACEID_RENDER_PASS);
```