### PR TITLE
[Fix] Fix to sharing of clustered light buffer between layers

### DIFF
--- a/src/scene/layer.js
+++ b/src/scene/layer.js
@@ -444,6 +444,16 @@ class Layer {
     }
 
     /**
+     * True if the layer contains omni or spot lights
+     *
+     * @type {boolean}
+     * @ignore
+     */
+    get hasClusteredLights() {
+        return this._clusteredLightsSet.size > 0;
+    }
+
+    /**
      * @type {RenderTarget}
      * @ignore
      */


### PR DESCRIPTION
- sharing with an empty clusters is avoided
- disable whitespaces in dif
- fixes clustered lighting working with Layers.tsx, as its first sub-layer had no meshes, and empty clusters from it were shared.