### PR TITLE
Update programlib

### DIFF
--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -2,6 +2,11 @@ import { platform } from '../core/platform.js';
 
 import { WebglGraphicsDevice } from '../graphics/webgl/webgl-graphics-device.js';
 
+import { basic } from '../graphics/program-lib/programs/basic.js';
+import { particle } from '../graphics/program-lib/programs/particle.js';
+import { skybox } from '../graphics/program-lib/programs/skybox.js';
+import { standard } from '../graphics/program-lib/programs/standard.js';
+
 import { SoundManager } from '../sound/manager.js';
 
 import { Lightmapper } from '../scene/lightmapper/lightmapper.js';
@@ -154,7 +159,15 @@ class Application extends AppBase {
         }
         options.graphicsDeviceOptions.alpha = options.graphicsDeviceOptions.alpha || false;
 
-        return new WebglGraphicsDevice(canvas, options.graphicsDeviceOptions);
+        const device = new WebglGraphicsDevice(canvas, options.graphicsDeviceOptions);
+
+        // register shader programs
+        device.programLib.register('basic', basic);
+        device.programLib.register('particle', particle);
+        device.programLib.register('skybox', skybox);
+        device.programLib.register('standard', standard);
+
+        return device;
     }
 
     addComponentSystems(appOptions) {

--- a/src/graphics/graphics-device.js
+++ b/src/graphics/graphics-device.js
@@ -2,7 +2,6 @@ import { EventHandler } from '../core/event-handler.js';
 import { platform } from '../core/platform.js';
 
 import { ScopeSpace } from './scope-space.js';
-import { programlib } from './program-lib/program-lib.js';
 import { ProgramLibrary } from './program-library.js';
 
 import {
@@ -172,9 +171,8 @@ class GraphicsDevice extends EventHandler {
         // Create the ScopeNamespace for shader attributes and variables
         this.scope = new ScopeSpace("Device");
 
+        // Create the program library instance
         this.programLib = new ProgramLibrary(this);
-        for (const generator in programlib)
-            this.programLib.register(generator, programlib[generator]);
     }
 
     destroy() {

--- a/src/graphics/program-lib/program-lib.js
+++ b/src/graphics/program-lib/program-lib.js
@@ -1,8 +1,4 @@
 import { begin, dummyFragmentCode, end, fogCode, gammaCode, precisionCode, skinCode, tonemapCode, versionCode } from './programs/common.js';
-import { basic } from './programs/basic.js';
-import { particle } from './programs/particle.js';
-import { skybox } from './programs/skybox.js';
-import { standard } from './programs/standard.js';
 
 const programlib = {
     begin: begin,
@@ -14,11 +10,6 @@ const programlib = {
     skinCode: skinCode,
     tonemapCode: tonemapCode,
     versionCode: versionCode,
-
-    basic: basic,
-    particle: particle,
-    skybox: skybox,
-    standard: standard
 };
 
 export { programlib };

--- a/src/graphics/program-library.js
+++ b/src/graphics/program-library.js
@@ -3,8 +3,9 @@ import { version, revision } from '../core/core.js';
 
 import { Shader } from './shader.js';
 
-import { SHADER_FORWARD, SHADER_FORWARDHDR, SHADER_PICK, SHADER_SHADOW } from '../scene/constants.js';
+import { SHADER_FORWARD, SHADER_DEPTH, SHADER_PICK, SHADER_SHADOW } from '../scene/constants.js';
 import { StandardMaterial } from '../scene/materials/standard-material.js';
+import { ShaderPass } from '../scene/shader-pass.js';
 
 // Public interface
 class ProgramLibrary {
@@ -19,11 +20,12 @@ class ProgramLibrary {
         this._programsCollection = [];
         this._defaultStdMatOption = {};
         this._defaultStdMatOptionMin = {};
+
         const m = new StandardMaterial();
         m.shaderOptBuilder.updateRef(
-            this._defaultStdMatOption, device, {}, m, null, [], SHADER_FORWARD, null, null);
+            this._defaultStdMatOption, {}, m, null, [], SHADER_FORWARD, null);
         m.shaderOptBuilder.updateMinRef(
-            this._defaultStdMatOptionMin, device, {}, m, null, [], SHADER_SHADOW, null, null);
+            this._defaultStdMatOptionMin, {}, m, null, [], SHADER_SHADOW, null);
     }
 
     register(name, generator) {
@@ -145,7 +147,7 @@ class ProgramLibrary {
     }
 
     _getDefaultStdMatOptions(pass) {
-        return (pass > SHADER_FORWARDHDR && pass <= SHADER_PICK) ?
+        return (pass === SHADER_DEPTH || pass === SHADER_PICK || ShaderPass.isShadow(pass)) ?
             this._defaultStdMatOptionMin : this._defaultStdMatOption;
     }
 

--- a/src/scene/materials/standard-material-options-builder.js
+++ b/src/scene/materials/standard-material-options-builder.js
@@ -44,15 +44,15 @@ class StandardMaterialOptionsBuilder {
     }
 
     // Minimal options for Depth and Shadow passes
-    updateMinRef(options, device, scene, stdMat, objDefs, staticLightList, pass, sortedLights) {
+    updateMinRef(options, scene, stdMat, objDefs, staticLightList, pass, sortedLights) {
         this._updateSharedOptions(options, scene, stdMat, objDefs, pass);
         this._updateMinOptions(options, stdMat);
         this._updateUVOptions(options, stdMat, objDefs, true);
     }
 
-    updateRef(options, device, scene, stdMat, objDefs, staticLightList, pass, sortedLights) {
+    updateRef(options, scene, stdMat, objDefs, staticLightList, pass, sortedLights) {
         this._updateSharedOptions(options, scene, stdMat, objDefs, pass);
-        this._updateEnvOptions(options, device, stdMat, scene);
+        this._updateEnvOptions(options, stdMat, scene);
         this._updateMaterialOptions(options, stdMat);
         if (pass === SHADER_FORWARDHDR) {
             if (options.gamma) options.gamma = GAMMA_SRGBHDR;
@@ -175,7 +175,7 @@ class StandardMaterialOptionsBuilder {
         options.clearCoatGlossTint = (stdMat.clearCoatGlossiness !== 1.0) ? 1 : 0;
     }
 
-    _updateEnvOptions(options, device, stdMat, scene) {
+    _updateEnvOptions(options, stdMat, scene) {
         options.fog = stdMat.useFog ? scene.fog : 'none';
         options.gamma = stdMat.useGammaTonemap ? scene.gammaCorrection : GAMMA_NONE;
         options.toneMap = stdMat.useGammaTonemap ? scene.toneMapping : -1;

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -715,9 +715,9 @@ class StandardMaterial extends Material {
         let options = minimalOptions ? standard.optionsContextMin : standard.optionsContext;
 
         if (minimalOptions)
-            this.shaderOptBuilder.updateMinRef(options, device, scene, this, objDefs, staticLightList, pass, sortedLights);
+            this.shaderOptBuilder.updateMinRef(options, scene, this, objDefs, staticLightList, pass, sortedLights);
         else
-            this.shaderOptBuilder.updateRef(options, device, scene, this, objDefs, staticLightList, pass, sortedLights);
+            this.shaderOptBuilder.updateRef(options, scene, this, objDefs, staticLightList, pass, sortedLights);
 
         if (this.onUpdateShader) {
             options = this.onUpdateShader(options);


### PR DESCRIPTION
This PR:
- registers programs in the application directly on the device instead of using the `programlib` object
- remove unused `device` object from StandardMaterialOptionsBuilder
- fix `ProgramLibrary` test with SHADER_ defines updated in #4328