### PR TITLE
[Breaking] Enable clustered lighting by default

### DIFF
--- a/examples/src/examples/graphics/area-lights.tsx
+++ b/examples/src/examples/graphics/area-lights.tsx
@@ -128,6 +128,9 @@ class AreaLightsExample {
 
             app.start();
 
+            // enable area lights which are disabled by default for clustered lighting
+            app.scene.lighting.areaLightsEnabled = true;
+
             // set the loaded area light LUT data
             app.setAreaLightLuts(assets.luts);
 

--- a/examples/src/examples/graphics/lights.tsx
+++ b/examples/src/examples/graphics/lights.tsx
@@ -88,6 +88,10 @@ class LightsExample {
             app.setCanvasFillMode(pc.FILLMODE_FILL_WINDOW);
             app.setCanvasResolution(pc.RESOLUTION_AUTO);
 
+            // enable cookies which are disabled by default for clustered lighting
+            app.scene.lighting.cookiesEnabled = true;
+
+            // ambient lighting
             app.scene.ambientLight = new pc.Color(0.2, 0.2, 0.2);
 
             // create an entity with the statue

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -218,7 +218,7 @@ class Scene extends EventHandler {
         this._lightmapFilterSmoothness = 0.2;
 
         // clustered lighting
-        this._clusteredLightingEnabled = false;
+        this._clusteredLightingEnabled = true;
         this._lightingParams = new LightingParams(this.device.supportsAreaLights, this.device.maxTextureSize, () => {
             this._layers._dirtyLights = true;
         });
@@ -298,8 +298,8 @@ class Scene extends EventHandler {
 
     set clusteredLightingEnabled(value) {
 
-        if (this._clusteredLightingEnabled && !value) {
-            console.error('Turning off enabled clustered lighting is not currently supported');
+        if (!this._clusteredLightingEnabled && value) {
+            console.error('Turning on disabled clustered lighting is not currently supported');
             return;
         }
 


### PR DESCRIPTION
Until now, the clustered lighting was a feature the user had to opt in.
This PR makes it the default option, and the original lighting system is opt in.

If the original system needs to be used, this is the API to call:
```
            app.scene.clusteredLightingEnabled = false;
```

Note that by default, the area lights and cookie textures are disabled for clustered lighting (in order to keep the shader smaller / faster to compile), and can be enabled this way if needed:
```
            app.scene.lighting.cookiesEnabled = true;
            app.scene.lighting.areaLightsEnabled = true;
```