### PR TITLE
Support tuples for JSDoc

### DIFF
--- a/conf-api.json
+++ b/conf-api.json
@@ -1,7 +1,8 @@
 {
     "plugins": [
         "plugins/markdown",
-        "./node_modules/jsdoc-tsimport-plugin/index.js"
+        "./node_modules/jsdoc-tsimport-plugin/index.js",
+        "supportTuples"
     ],
     "recurseDepth": 10,
     "source": {

--- a/supportTuples.js
+++ b/supportTuples.js
@@ -1,0 +1,8 @@
+const catharsis = require("catharsis");
+const originalParse = catharsis.parse;
+catharsis.parse = function(str) {
+  if (str[0] == '[') {
+    return originalParse('Array<*>');
+  }
+  return originalParse(...arguments);
+}


### PR DESCRIPTION
Fixes https://github.com/playcanvas/engine/pull/4197#issuecomment-1164984831

Issue open since 2015: https://github.com/jsdoc/jsdoc/issues/1073
Issue open since 2019: https://github.com/jsdoc/jsdoc/issues/1703

Based on that they couldn't care enough for the last 7 years, I just fixed the `Catharsis#parse` function myself.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
