### PR TITLE
Added w component to the origin and direction for XRRay

### DIFF
--- a/src/xr/xr-hit-test.js
+++ b/src/xr/xr-hit-test.js
@@ -236,7 +236,11 @@ class XrHitTest extends EventHandler {
 
         let xrRay;
         const offsetRay = options.offsetRay;
-        if (offsetRay) xrRay = new XRRay(new DOMPoint(offsetRay.origin.x, offsetRay.origin.y, offsetRay.origin.z), new DOMPoint(offsetRay.direction.x, offsetRay.direction.y, offsetRay.direction.z));
+        if (offsetRay) {
+            const origin = new DOMPoint(offsetRay.origin.x, offsetRay.origin.y, offsetRay.origin.z, 1.0);
+            const direction = new DOMPoint(offsetRay.direction.x, offsetRay.direction.y, offsetRay.direction.z, 0.0);
+            xrRay = new XRRay(origin, direction);
+        }
 
         const callback = options.callback;
 


### PR DESCRIPTION
The w component is needed according to the docs for XRRay: https://developer.mozilla.org/en-US/docs/Web/API/XRRay/XRRay

Fixes https://github.com/playcanvas/engine/issues/4371

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
