### PR TITLE
Refactor JSDoc blocks for events

### DIFF
--- a/src/asset/asset-registry.js
+++ b/src/asset/asset-registry.js
@@ -60,9 +60,9 @@ class AssetRegistry extends EventHandler {
     }
 
     /**
-     * @event
-     * @name AssetRegistry#load
-     * @description Fired when an asset completes loading.
+     * Fired when an asset completes loading.
+     *
+     * @event AssetRegistry#load
      * @param {Asset} asset - The asset that has just loaded.
      * @example
      * app.assets.on("load", function (asset) {
@@ -71,9 +71,9 @@ class AssetRegistry extends EventHandler {
      */
 
     /**
-     * @event
-     * @name AssetRegistry#load:[id]
-     * @description Fired when an asset completes loading.
+     * Fired when an asset completes loading.
+     *
+     * @event AssetRegistry#load:[id]
      * @param {Asset} asset - The asset that has just loaded.
      * @example
      * var id = 123456;
@@ -85,9 +85,9 @@ class AssetRegistry extends EventHandler {
      */
 
     /**
-     * @event
-     * @name AssetRegistry#load:url:[url]
-     * @description Fired when an asset completes loading.
+     * Fired when an asset completes loading.
+     *
+     * @event AssetRegistry#load:url:[url]
      * @param {Asset} asset - The asset that has just loaded.
      * @example
      * var id = 123456;
@@ -99,9 +99,9 @@ class AssetRegistry extends EventHandler {
      */
 
     /**
-     * @event
-     * @name AssetRegistry#add
-     * @description Fired when an asset is added to the registry.
+     * Fired when an asset is added to the registry.
+     *
+     * @event AssetRegistry#add
      * @param {Asset} asset - The asset that was added.
      * @example
      * app.assets.on("add", function (asset) {
@@ -110,9 +110,9 @@ class AssetRegistry extends EventHandler {
      */
 
     /**
-     * @event
-     * @name AssetRegistry#add:[id]
-     * @description Fired when an asset is added to the registry.
+     * Fired when an asset is added to the registry.
+     *
+     * @event AssetRegistry#add:[id]
      * @param {Asset} asset - The asset that was added.
      * @example
      * var id = 123456;
@@ -122,16 +122,16 @@ class AssetRegistry extends EventHandler {
      */
 
     /**
-     * @event
-     * @name AssetRegistry#add:url:[url]
-     * @description Fired when an asset is added to the registry.
+     * Fired when an asset is added to the registry.
+     *
+     * @event AssetRegistry#add:url:[url]
      * @param {Asset} asset - The asset that was added.
      */
 
     /**
-     * @event
-     * @name AssetRegistry#remove
-     * @description Fired when an asset is removed from the registry.
+     * Fired when an asset is removed from the registry.
+     *
+     * @event AssetRegistry#remove
      * @param {Asset} asset - The asset that was removed.
      * @example
      * app.assets.on("remove", function (asset) {
@@ -140,9 +140,9 @@ class AssetRegistry extends EventHandler {
      */
 
     /**
-     * @event
-     * @name AssetRegistry#remove:[id]
-     * @description Fired when an asset is removed from the registry.
+     * Fired when an asset is removed from the registry.
+     *
+     * @event AssetRegistry#remove:[id]
      * @param {Asset} asset - The asset that was removed.
      * @example
      * var id = 123456;
@@ -152,16 +152,16 @@ class AssetRegistry extends EventHandler {
      */
 
     /**
-     * @event
-     * @name AssetRegistry#remove:url:[url]
-     * @description Fired when an asset is removed from the registry.
+     * Fired when an asset is removed from the registry.
+     *
+     * @event AssetRegistry#remove:url:[url]
      * @param {Asset} asset - The asset that was removed.
      */
 
     /**
-     * @event
-     * @name AssetRegistry#error
-     * @description Fired when an error occurs during asset loading.
+     * Fired when an error occurs during asset loading.
+     *
+     * @event AssetRegistry#error
      * @param {string} err - The error message.
      * @param {Asset} asset - The asset that generated the error.
      * @example
@@ -174,9 +174,9 @@ class AssetRegistry extends EventHandler {
      */
 
     /**
-     * @event
-     * @name AssetRegistry#error:[id]
-     * @description Fired when an error occurs during asset loading.
+     * Fired when an error occurs during asset loading.
+     *
+     * @event AssetRegistry#error:[id]
      * @param {Asset} asset - The asset that generated the error.
      * @example
      * var id = 123456;

--- a/src/asset/asset.js
+++ b/src/asset/asset.js
@@ -154,6 +154,63 @@ class Asset extends EventHandler {
     }
 
     /**
+     * Fired when the asset has completed loading.
+     *
+     * @event Asset#load
+     * @param {Asset} asset - The asset that was loaded.
+     */
+
+    /**
+     * Fired just before the asset unloads the resource. This allows for the opportunity to prepare
+     * for an asset that will be unloaded. E.g. Changing the texture of a model to a default before
+     * the one it was using is unloaded.
+     *
+     * @event Asset#unload
+     * @param {Asset} asset - The asset that is due to be unloaded.
+     */
+
+    /**
+     * Fired when the asset is removed from the asset registry.
+     *
+     * @event Asset#remove
+     * @param {Asset} asset - The asset that was removed.
+     */
+
+    /**
+     * Fired if the asset encounters an error while loading.
+     *
+     * @event Asset#error
+     * @param {string} err - The error message.
+     * @param {Asset} asset - The asset that generated the error.
+     */
+
+    /**
+     * Fired when one of the asset properties `file`, `data`, `resource` or `resources` is changed.
+     *
+     * @event Asset#change
+     * @param {Asset} asset - The asset that was loaded.
+     * @param {string} property - The name of the property that changed.
+     * @param {*} value - The new property value.
+     * @param {*} oldValue - The old property value.
+     */
+
+    /**
+     * Fired when we add a new localized asset id to the asset.
+     *
+     * @event Asset#add:localized
+     * @param {string} locale - The locale.
+     * @param {number} assetId - The asset id we added.
+     */
+
+    /**
+     * Fired when we remove a localized asset id from the asset.
+     *
+     * @event Asset#remove:localized
+     * @param {string} locale - The locale.
+     * @param {number} assetId - The asset id we removed.
+     */
+
+    /**
      * The asset id.
      *
      * @type {number}
@@ -305,61 +362,6 @@ class Asset extends EventHandler {
     get loadFaces() {
         return this._loadFaces;
     }
-
-    /**
-     * @event
-     * @name Asset#load
-     * @description Fired when the asset has completed loading.
-     * @param {Asset} asset - The asset that was loaded.
-     */
-
-    /**
-     * @event
-     * @name Asset#unload
-     * @description Fired just before the asset unloads the resource. This allows for the opportunity to prepare for an asset that will be unloaded. E.g. Changing the texture of a model to a default before the one it was using is unloaded.
-     * @param {Asset} asset - The asset that is due to be unloaded.
-     */
-
-    /**
-     * @event
-     * @name Asset#remove
-     * @description Fired when the asset is removed from the asset registry.
-     * @param {Asset} asset - The asset that was removed.
-     */
-
-    /**
-     * @event
-     * @name Asset#error
-     * @description Fired if the asset encounters an error while loading.
-     * @param {string} err - The error message.
-     * @param {Asset} asset - The asset that generated the error.
-     */
-
-    /**
-     * @event
-     * @name Asset#change
-     * @description Fired when one of the asset properties `file`, `data`, `resource` or `resources` is changed.
-     * @param {Asset} asset - The asset that was loaded.
-     * @param {string} property - The name of the property that changed.
-     * @param {*} value - The new property value.
-     * @param {*} oldValue - The old property value.
-     */
-
-    /**
-     * @event
-     * @name Asset#add:localized
-     * @description Fired when we add a new localized asset id to the asset.
-     * @param {string} locale - The locale.
-     * @param {number} assetId - The asset id we added.
-     */
-
-    /**
-     * @event
-     * @name Asset#remove:localized
-     * @description Fired when we remove a localized asset id from the asset.
-     * @param {string} locale - The locale.
-     * @param {number} assetId - The asset id we removed.
-     */
 
     /**
      * Return the URL required to fetch the file for this asset.

--- a/src/core/tags.js
+++ b/src/core/tags.js
@@ -21,6 +21,26 @@ class Tags extends EventHandler {
     }
 
     /**
+     * @event Tags#add
+     * @param {string} tag - Name of a tag added to a set.
+     * @param {object} parent - Parent object who tags belong to.
+     */
+
+    /**
+     * @event Tags#remove
+     * @param {string} tag - Name of a tag removed from a set.
+     * @param {object} parent - Parent object who tags belong to.
+     */
+
+    /**
+     * Fires when tags have been added or removed. It will fire once on bulk changes, while
+     * `add`/`remove` will fire on each tag operation.
+     *
+     * @event Tags#change
+     * @param {object} [parent] - Parent object who tags belong to.
+     */
+
+    /**
      * Add a tag, duplicates are ignored. Can be array or comma separated arguments for multiple tags.
      *
      * @param {...*} name - Name of a tag, or array of tags.
@@ -237,27 +257,5 @@ class Tags extends EventHandler {
         return this._list.length;
     }
 }
-
-/**
- * @event
- * @name Tags#add
- * @param {string} tag - Name of a tag added to a set.
- * @param {object} parent - Parent object who tags belong to.
- */
-
-/**
- * @event
- * @name Tags#remove
- * @param {string} tag - Name of a tag removed from a set.
- * @param {object} parent - Parent object who tags belong to.
- */
-
-/**
- * @event
- * @name Tags#change
- * @param {object} [parent] - Parent object who tags belong to.
- * @description Fires when tags been added / removed.
- * It will fire once on bulk changes, while `add`/`remove` will fire on each tag operation.
- */
 
 export { Tags };

--- a/src/framework/components/button/component.js
+++ b/src/framework/components/button/component.js
@@ -543,118 +543,119 @@ function toColor3(color4) {
 }
 
 /**
- * @event
- * @name ButtonComponent#mousedown
- * @description Fired when the mouse is pressed while the cursor is on the component.
+ * Fired when the mouse is pressed while the cursor is on the component.
+ *
+ * @event ButtonComponent#mousedown
  * @param {ElementMouseEvent} event - The event.
  */
 
 /**
- * @event
- * @name ButtonComponent#mouseup
- * @description Fired when the mouse is released while the cursor is on the component.
+ * Fired when the mouse is released while the cursor is on the component.
+ *
+ * @event ButtonComponent#mouseup
  * @param {ElementMouseEvent} event - The event.
  */
 
 /**
- * @event
- * @name ButtonComponent#mouseenter
- * @description Fired when the mouse cursor enters the component.
+ * Fired when the mouse cursor enters the component.
+ *
+ * @event ButtonComponent#mouseenter
  * @param {ElementMouseEvent} event - The event.
  */
 
 /**
- * @event
- * @name ButtonComponent#mouseleave
- * @description Fired when the mouse cursor leaves the component.
+ * Fired when the mouse cursor leaves the component.
+ *
+ * @event ButtonComponent#mouseleave
  * @param {ElementMouseEvent} event - The event.
  */
 
 /**
- * @event
- * @name ButtonComponent#click
- * @description Fired when the mouse is pressed and released on the component or when a touch starts and ends on the component.
+ * Fired when the mouse is pressed and released on the component or when a touch starts and ends on
+ * the component.
+ *
+ * @event ButtonComponent#click
  * @param {ElementMouseEvent|ElementTouchEvent} event - The event.
  */
 
 /**
- * @event
- * @name ButtonComponent#touchstart
- * @description Fired when a touch starts on the component.
+ * Fired when a touch starts on the component.
+ *
+ * @event ButtonComponent#touchstart
  * @param {ElementTouchEvent} event - The event.
  */
 
 /**
- * @event
- * @name ButtonComponent#touchend
- * @description Fired when a touch ends on the component.
+ * Fired when a touch ends on the component.
+ *
+ * @event ButtonComponent#touchend
  * @param {ElementTouchEvent} event - The event.
  */
 
 /**
- * @event
- * @name ButtonComponent#touchcancel
- * @description Fired when a touch is canceled on the component.
+ * Fired when a touch is canceled on the component.
+ *
+ * @event ButtonComponent#touchcancel
  * @param {ElementTouchEvent} event - The event.
  */
 
 /**
- * @event
- * @name ButtonComponent#touchleave
- * @description Fired when a touch leaves the component.
+ * Fired when a touch leaves the component.
+ *
+ * @event ButtonComponent#touchleave
  * @param {ElementTouchEvent} event - The event.
  */
 
 /**
- * @event
- * @name ButtonComponent#selectstart
- * @description Fired when a xr select starts on the component.
+ * Fired when a xr select starts on the component.
+ *
+ * @event ButtonComponent#selectstart
  * @param {ElementSelectEvent} event - The event.
  */
 
 /**
- * @event
- * @name ButtonComponent#selectend
- * @description Fired when a xr select ends on the component.
+ * Fired when a xr select ends on the component.
+ *
+ * @event ButtonComponent#selectend
  * @param {ElementSelectEvent} event - The event.
  */
 
 /**
- * @event
- * @name ButtonComponent#selectenter
- * @description Fired when a xr select now hovering over the component.
+ * Fired when a xr select now hovering over the component.
+ *
+ * @event ButtonComponent#selectenter
  * @param {ElementSelectEvent} event - The event.
  */
 
 /**
- * @event
- * @name ButtonComponent#selectleave
- * @description Fired when a xr select not hovering over the component.
+ * Fired when a xr select not hovering over the component.
+ *
+ * @event ButtonComponent#selectleave
  * @param {ElementSelectEvent} event - The event.
  */
 
 /**
- * @event
- * @name ButtonComponent#hoverstart
- * @description Fired when the button changes state to be hovered.
+ * Fired when the button changes state to be hovered.
+ *
+ * @event ButtonComponent#hoverstart
  */
 
 /**
- * @event
- * @name ButtonComponent#hoverend
- * @description Fired when the button changes state to be not hovered.
+ * Fired when the button changes state to be not hovered.
+ *
+ * @event ButtonComponent#hoverend
  */
 
 /**
- * @event
- * @name ButtonComponent#pressedstart
- * @description Fired when the button changes state to be pressed.
+ * Fired when the button changes state to be pressed.
+ *
+ * @event ButtonComponent#pressedstart
  */
 
 /**
- * @event
- * @name ButtonComponent#pressedend
- * @description Fired when the button changes state to be not pressed.
+ * Fired when the button changes state to be not pressed.
+ *
+ * @event ButtonComponent#pressedend
  */
 
 export { ButtonComponent };

--- a/src/framework/components/collision/component.js
+++ b/src/framework/components/collision/component.js
@@ -78,41 +78,38 @@ class CollisionComponent extends Component {
         this.on('set_render', this.onSetRender, this);
     }
 
-    // Events Documentation
     /**
-     * @event
-     * @name CollisionComponent#contact
-     * @description The 'contact' event is fired when a contact occurs between two rigid bodies.
+     * The 'contact' event is fired when a contact occurs between two rigid bodies.
+     *
+     * @event CollisionComponent#contact
      * @param {ContactResult} result - Details of the contact between the two rigid bodies.
      */
 
     /**
-     * @event
-     * @name CollisionComponent#collisionstart
-     * @description The 'collisionstart' event is fired when two rigid bodies start touching.
+     * Fired when two rigid bodies start touching.
+     *
+     * @event CollisionComponent#collisionstart
      * @param {ContactResult} result - Details of the contact between the two Entities.
      */
 
     /**
-     * @event
-     * @name CollisionComponent#collisionend
-     * @description The 'collisionend' event is fired two rigid-bodies stop touching.
+     * Fired two rigid-bodies stop touching.
+     *
+     * @event CollisionComponent#collisionend
      * @param {Entity} other - The {@link Entity} that stopped touching this collision volume.
      */
 
     /**
-     * @event
-     * @name CollisionComponent#triggerenter
-     * @description The 'triggerenter' event is fired when a rigid body enters a trigger volume.
-     * a {@link RigidBodyComponent} attached.
+     * Fired when a rigid body enters a trigger volume.
+     *
+     * @event CollisionComponent#triggerenter
      * @param {Entity} other - The {@link Entity} that entered this collision volume.
      */
 
     /**
-     * @event
-     * @name CollisionComponent#triggerleave
-     * @description The 'triggerleave' event is fired when a rigid body exits a trigger volume.
-     * a {@link RigidBodyComponent} attached.
+     * Fired when a rigid body exits a trigger volume.
+     *
+     * @event CollisionComponent#triggerleave
      * @param {Entity} other - The {@link Entity} that exited this collision volume.
      */
 

--- a/src/framework/components/element/component.js
+++ b/src/framework/components/element/component.js
@@ -277,6 +277,87 @@ class ElementComponent extends Component {
         this._maskedBy = null; // the entity that is masking this element
     }
 
+    /**
+     * Fired when the mouse is pressed while the cursor is on the component. Only fired when
+     * useInput is true.
+     *
+     * @event ElementComponent#mousedown
+     * @param {ElementMouseEvent} event - The event.
+     */
+
+    /**
+     * Fired when the mouse is released while the cursor is on the component. Only fired when
+     * useInput is true.
+     *
+     * @event ElementComponent#mouseup
+     * @param {ElementMouseEvent} event - The event.
+     */
+
+    /**
+     * Fired when the mouse cursor enters the component. Only fired when useInput is true.
+     *
+     * @event ElementComponent#mouseenter
+     * @param {ElementMouseEvent} event - The event.
+     */
+
+    /**
+     * Fired when the mouse cursor leaves the component. Only fired when useInput is true.
+     *
+     * @event ElementComponent#mouseleave
+     * @param {ElementMouseEvent} event - The event.
+     */
+
+    /**
+     * Fired when the mouse cursor is moved on the component. Only fired when useInput is true.
+     *
+     * @event ElementComponent#mousemove
+     * @param {ElementMouseEvent} event - The event.
+     */
+
+    /**
+     * Fired when the mouse wheel is scrolled on the component. Only fired when useInput is true.
+     *
+     * @event ElementComponent#mousewheel
+     * @param {ElementMouseEvent} event - The event.
+     */
+
+    /**
+     * Fired when the mouse is pressed and released on the component or when a touch starts and
+     * ends on the component. Only fired when useInput is true.
+     *
+     * @event ElementComponent#click
+     * @param {ElementMouseEvent|ElementTouchEvent} event - The event.
+     */
+
+    /**
+     * Fired when a touch starts on the component. Only fired when useInput is true.
+     *
+     * @event ElementComponent#touchstart
+     * @param {ElementTouchEvent} event - The event.
+     */
+
+    /**
+     * Fired when a touch ends on the component. Only fired when useInput is true.
+     *
+     * @event ElementComponent#touchend
+     * @param {ElementTouchEvent} event - The event.
+     */
+
+    /**
+     * Fired when a touch moves after it started touching the component. Only fired when useInput
+     * is true.
+     *
+     * @event ElementComponent#touchmove
+     * @param {ElementTouchEvent} event - The event.
+     */
+
+    /**
+     * Fired when a touch is canceled on the component. Only fired when useInput is true.
+     *
+     * @event ElementComponent#touchcancel
+     * @param {ElementTouchEvent} event - The event.
+     */
+
     get _absLeft() {
         return this._localAnchor.x + this._margin.x;
     }
@@ -1742,82 +1823,5 @@ _define('shadowOffset');
 _define('enableMarkup');
 _define('rangeStart');
 _define('rangeEnd');
-
-// Events Documentation
-
-/**
- * @event
- * @name ElementComponent#mousedown
- * @description Fired when the mouse is pressed while the cursor is on the component. Only fired when useInput is true.
- * @param {ElementMouseEvent} event - The event.
- */
-
-/**
- * @event
- * @name ElementComponent#mouseup
- * @description Fired when the mouse is released while the cursor is on the component. Only fired when useInput is true.
- * @param {ElementMouseEvent} event - The event.
- */
-
-/**
- * @event
- * @name ElementComponent#mouseenter
- * @description Fired when the mouse cursor enters the component. Only fired when useInput is true.
- * @param {ElementMouseEvent} event - The event.
- */
-/**
- * @event
- * @name ElementComponent#mouseleave
- * @description Fired when the mouse cursor leaves the component. Only fired when useInput is true.
- * @param {ElementMouseEvent} event - The event.
- */
-/**
- * @event
- * @name ElementComponent#mousemove
- * @description Fired when the mouse cursor is moved on the component. Only fired when useInput is true.
- * @param {ElementMouseEvent} event - The event.
- */
-
-/**
- * @event
- * @name ElementComponent#mousewheel
- * @description Fired when the mouse wheel is scrolled on the component. Only fired when useInput is true.
- * @param {ElementMouseEvent} event - The event.
- */
-
-/**
- * @event
- * @name ElementComponent#click
- * @description Fired when the mouse is pressed and released on the component or when a touch starts and ends on the component. Only fired when useInput is true.
- * @param {ElementMouseEvent|ElementTouchEvent} event - The event.
- */
-
-/**
- * @event
- * @name ElementComponent#touchstart
- * @description Fired when a touch starts on the component. Only fired when useInput is true.
- * @param {ElementTouchEvent} event - The event.
- */
-
-/**
- * @event
- * @name ElementComponent#touchend
- * @description Fired when a touch ends on the component. Only fired when useInput is true.
- * @param {ElementTouchEvent} event - The event.
- */
-
-/**
- * @event
- * @name ElementComponent#touchmove
- * @description Fired when a touch moves after it started touching the component. Only fired when useInput is true.
- * @param {ElementTouchEvent} event - The event.
- */
-
-/**
- * @event
- * @name ElementComponent#touchcancel
- * @description Fired when a touch is canceled on the component. Only fired when useInput is true.
- * @param {ElementTouchEvent} event - The event.
- */
 
 export { ElementComponent };

--- a/src/framework/components/element/element-drag-helper.js
+++ b/src/framework/components/element/element-drag-helper.js
@@ -57,6 +57,25 @@ class ElementDragHelper extends EventHandler {
         this._toggleLifecycleListeners('on');
     }
 
+    /**
+     * Fired when a new drag operation starts.
+     *
+     * @event ElementDragHelper#drag:start
+     */
+
+    /**
+     * Fired when the current new drag operation ends.
+     *
+     * @event ElementDragHelper#drag:end
+     */
+
+    /**
+     * Fired whenever the position of the dragged element changes.
+     *
+     * @event ElementDragHelper#drag:move
+     * @param {Vec3} value - The current position.
+     */
+
     _toggleLifecycleListeners(onOrOff) {
         this._element[onOrOff]('mousedown', this._onMouseDownOrTouchStart, this);
         this._element[onOrOff]('touchstart', this._onMouseDownOrTouchStart, this);
@@ -228,25 +247,6 @@ class ElementDragHelper extends EventHandler {
     get isDragging() {
         return this._isDragging;
     }
-
-    /**
-     * @event
-     * @name ElementDragHelper#drag:start
-     * @description Fired when a new drag operation starts.
-     */
-
-    /**
-     * @event
-     * @name ElementDragHelper#drag:end
-     * @description Fired when the current new drag operation ends.
-     */
-
-    /**
-     * @event
-     * @name ElementDragHelper#drag:move
-     * @description Fired whenever the position of the dragged element changes.
-     * @param {Vec3} value - The current position.
-     */
 }
 
 export { ElementDragHelper };

--- a/src/framework/components/rigid-body/component.js
+++ b/src/framework/components/rigid-body/component.js
@@ -82,6 +82,41 @@ class RigidBodyComponent extends Component {
         this._type = BODYTYPE_STATIC;
     }
 
+    /**
+     * Fired when a contact occurs between two rigid bodies.
+     *
+     * @event RigidBodyComponent#contact
+     * @param {ContactResult} result - Details of the contact between the two rigid bodies.
+     */
+
+    /**
+     * Fired when two rigid bodies start touching.
+     *
+     * @event RigidBodyComponent#collisionstart
+     * @param {ContactResult} result - Details of the contact between the two rigid bodies.
+     */
+
+    /**
+     * Fired when two rigid bodies stop touching.
+     *
+     * @event RigidBodyComponent#collisionend
+     * @param {Entity} other - The {@link Entity} that stopped touching this rigid body.
+     */
+
+    /**
+     * Fired when a rigid body enters a trigger volume.
+     *
+     * @event RigidBodyComponent#triggerenter
+     * @param {Entity} other - The {@link Entity} with trigger volume that this rigid body entered.
+     */
+
+    /**
+     * Fired when a rigid body exits a trigger volume.
+     *
+     * @event RigidBodyComponent#triggerleave
+     * @param {Entity} other - The {@link Entity} with trigger volume that this rigid body exited.
+     */
+
     static onLibraryLoaded() {
 
         // Lazily create shared variable
@@ -985,41 +1020,5 @@ class RigidBodyComponent extends Component {
         this.disableSimulation();
     }
 }
-
-// Events Documentation
-/**
- * @event
- * @name RigidBodyComponent#contact
- * @description The 'contact' event is fired when a contact occurs between two rigid bodies.
- * @param {ContactResult} result - Details of the contact between the two rigid bodies.
- */
-
-/**
- * @event
- * @name RigidBodyComponent#collisionstart
- * @description The 'collisionstart' event is fired when two rigid bodies start touching.
- * @param {ContactResult} result - Details of the contact between the two rigid bodies.
- */
-
-/**
- * @event
- * @name RigidBodyComponent#collisionend
- * @description The 'collisionend' event is fired two rigid-bodies stop touching.
- * @param {Entity} other - The {@link Entity} that stopped touching this rigid body.
- */
-
-/**
- * @event
- * @name RigidBodyComponent#triggerenter
- * @description The 'triggerenter' event is fired when a rigid body enters a trigger volume.
- * @param {Entity} other - The {@link Entity} with trigger volume that this rigidbody entered.
- */
-
-/**
- * @event
- * @name RigidBodyComponent#triggerleave
- * @description The 'triggerleave' event is fired when a rigid body exits a trigger volume.
- * @param {Entity} other - The {@link Entity} with trigger volume that this rigidbody exited.
- */
 
 export { RigidBodyComponent };

--- a/src/framework/components/rigid-body/system.js
+++ b/src/framework/components/rigid-body/system.js
@@ -229,14 +229,6 @@ class ContactResult {
     }
 }
 
-// Events Documentation
-/**
- * @event
- * @name RigidBodyComponentSystem#contact
- * @description Fired when a contact occurs between two rigid bodies.
- * @param {SingleContactResult} result - Details of the contact between the two bodies.
- */
-
 const _schema = ['enabled'];
 
 /**
@@ -320,6 +312,18 @@ class RigidBodyComponentSystem extends ComponentSystem {
         this.on('remove', this.onRemove, this);
     }
 
+    /**
+     * Fired when a contact occurs between two rigid bodies.
+     *
+     * @event RigidBodyComponentSystem#contact
+     * @param {SingleContactResult} result - Details of the contact between the two bodies.
+     */
+
+    /**
+     * Called once Ammo has been loaded. Responsible for creating the physics world.
+     *
+     * @ignore
+     */
     onLibraryLoaded() {
         // Create the Ammo physics world
         if (typeof Ammo !== 'undefined') {

--- a/src/framework/components/script/component.js
+++ b/src/framework/components/script/component.js
@@ -64,15 +64,135 @@ class ScriptComponent extends Component {
         this.on('set_enabled', this._onSetEnabled, this);
     }
 
-    set enabled(value) {
-        const oldValue = this._enabled;
-        this._enabled = value;
-        this.fire('set', 'enabled', oldValue, value);
-    }
+    /**
+     * Fired when Component becomes enabled. Note: this event does not take in account entity or
+     * any of its parent enabled state.
+     *
+     * @event ScriptComponent#enable
+     * @example
+     * entity.script.on('enable', function () {
+     *     // component is enabled
+     * });
+     */
 
-    get enabled() {
-        return this._enabled;
-    }
+    /**
+     * Fired when Component becomes disabled. Note: this event does not take in account entity or
+     * any of its parent enabled state.
+     *
+     * @event ScriptComponent#disable
+     * @example
+     * entity.script.on('disable', function () {
+     *     // component is disabled
+     * });
+     */
+
+    /**
+     * Fired when Component changes state to enabled or disabled. Note: this event does not take in
+     * account entity or any of its parent enabled state.
+     *
+     * @event ScriptComponent#state
+     * @param {boolean} enabled - True if now enabled, False if disabled.
+     * @example
+     * entity.script.on('state', function (enabled) {
+     *     // component changed state
+     * });
+     */
+
+    /**
+     * Fired when Component is removed from entity.
+     *
+     * @event ScriptComponent#remove
+     * @example
+     * entity.script.on('remove', function () {
+     *     // entity has no more script component
+     * });
+     */
+
+    /**
+     * Fired when a script instance is created and attached to component.
+     *
+     * @event ScriptComponent#create
+     * @param {string} name - The name of the Script Type.
+     * @param {ScriptType} scriptInstance - The instance of the {@link ScriptType} that has been created.
+     * @example
+     * entity.script.on('create', function (name, scriptInstance) {
+     *     // new script instance added to component
+     * });
+     */
+
+    /**
+     * Fired when a script instance is created and attached to component.
+     *
+     * @event ScriptComponent#create:[name]
+     * @param {ScriptType} scriptInstance - The instance of the {@link ScriptType} that has been created.
+     * @example
+     * entity.script.on('create:playerController', function (scriptInstance) {
+     *     // new script instance 'playerController' is added to component
+     * });
+     */
+
+    /**
+     * Fired when a script instance is destroyed and removed from component.
+     *
+     * @event ScriptComponent#destroy
+     * @param {string} name - The name of the Script Type.
+     * @param {ScriptType} scriptInstance - The instance of the {@link ScriptType} that has been destroyed.
+     * @example
+     * entity.script.on('destroy', function (name, scriptInstance) {
+     *     // script instance has been destroyed and removed from component
+     * });
+     */
+
+    /**
+     * Fired when a script instance is destroyed and removed from component.
+     *
+     * @event ScriptComponent#destroy:[name]
+     * @param {ScriptType} scriptInstance - The instance of the {@link ScriptType} that has been destroyed.
+     * @example
+     * entity.script.on('destroy:playerController', function (scriptInstance) {
+     *     // script instance 'playerController' has been destroyed and removed from component
+     * });
+     */
+
+    /**
+     * Fired when a script instance is moved in component.
+     *
+     * @event ScriptComponent#move
+     * @param {string} name - The name of the Script Type.
+     * @param {ScriptType} scriptInstance - The instance of the {@link ScriptType} that has been moved.
+     * @param {number} ind - New position index.
+     * @param {number} indOld - Old position index.
+     * @example
+     * entity.script.on('move', function (name, scriptInstance, ind, indOld) {
+     *     // script instance has been moved in component
+     * });
+     */
+
+    /**
+     * Fired when a script instance is moved in component.
+     *
+     * @event ScriptComponent#move:[name]
+     * @param {ScriptType} scriptInstance - The instance of the {@link ScriptType} that has been moved.
+     * @param {number} ind - New position index.
+     * @param {number} indOld - Old position index.
+     * @example
+     * entity.script.on('move:playerController', function (scriptInstance, ind, indOld) {
+     *     // script instance 'playerController' has been moved in component
+     * });
+     */
+
+    /**
+     * Fired when a script instance had an exception.
+     *
+     * @event ScriptComponent#error
+     * @param {ScriptType} scriptInstance - The instance of the {@link ScriptType} that raised the exception.
+     * @param {Error} err - Native JS Error object with details of an error.
+     * @param {string} method - The method of the script instance that the exception originated from.
+     * @example
+     * entity.script.on('error', function (scriptInstance, err, method) {
+     *     // script instance caught an exception
+     * });
+     */
 
     /**
      * An array of all script instances attached to an entity. This array is read-only and should
@@ -124,6 +244,16 @@ class ScriptComponent extends Component {
         return this._scripts;
     }
 
+    set enabled(value) {
+        const oldValue = this._enabled;
+        this._enabled = value;
+        this.fire('set', 'enabled', oldValue, value);
+    }
+
+    get enabled() {
+        return this._enabled;
+    }
+
     static scriptMethods = {
         initialize: 'initialize',
         postInitialize: 'postInitialize',
@@ -131,136 +261,6 @@ class ScriptComponent extends Component {
         postUpdate: 'postUpdate',
         swap: 'swap'
     };
-
-    /**
-     * @event
-     * @name ScriptComponent#enable
-     * @description Fired when Component becomes enabled
-     * Note: this event does not take in account entity or any of its parent enabled state.
-     * @example
-     * entity.script.on('enable', function () {
-     *     // component is enabled
-     * });
-     */
-
-    /**
-     * @event
-     * @name ScriptComponent#disable
-     * @description Fired when Component becomes disabled
-     * Note: this event does not take in account entity or any of its parent enabled state.
-     * @example
-     * entity.script.on('disable', function () {
-     *     // component is disabled
-     * });
-     */
-
-    /**
-     * @event
-     * @name ScriptComponent#state
-     * @description Fired when Component changes state to enabled or disabled
-     * Note: this event does not take in account entity or any of its parent enabled state.
-     * @param {boolean} enabled - True if now enabled, False if disabled.
-     * @example
-     * entity.script.on('state', function (enabled) {
-     *     // component changed state
-     * });
-     */
-
-    /**
-     * @event
-     * @name ScriptComponent#remove
-     * @description Fired when Component is removed from entity.
-     * @example
-     * entity.script.on('remove', function () {
-     *     // entity has no more script component
-     * });
-     */
-
-    /**
-     * @event
-     * @name ScriptComponent#create
-     * @description Fired when a script instance is created and attached to component.
-     * @param {string} name - The name of the Script Type.
-     * @param {ScriptType} scriptInstance - The instance of the {@link ScriptType} that has been created.
-     * @example
-     * entity.script.on('create', function (name, scriptInstance) {
-     *     // new script instance added to component
-     * });
-     */
-
-    /**
-     * @event
-     * @name ScriptComponent#create:[name]
-     * @description Fired when a script instance is created and attached to component.
-     * @param {ScriptType} scriptInstance - The instance of the {@link ScriptType} that has been created.
-     * @example
-     * entity.script.on('create:playerController', function (scriptInstance) {
-     *     // new script instance 'playerController' is added to component
-     * });
-     */
-
-    /**
-     * @event
-     * @name ScriptComponent#destroy
-     * @description Fired when a script instance is destroyed and removed from component.
-     * @param {string} name - The name of the Script Type.
-     * @param {ScriptType} scriptInstance - The instance of the {@link ScriptType} that has been destroyed.
-     * @example
-     * entity.script.on('destroy', function (name, scriptInstance) {
-     *     // script instance has been destroyed and removed from component
-     * });
-     */
-
-    /**
-     * @event
-     * @name ScriptComponent#destroy:[name]
-     * @description Fired when a script instance is destroyed and removed from component.
-     * @param {ScriptType} scriptInstance - The instance of the {@link ScriptType} that has been destroyed.
-     * @example
-     * entity.script.on('destroy:playerController', function (scriptInstance) {
-     *     // script instance 'playerController' has been destroyed and removed from component
-     * });
-     */
-
-    /**
-     * @event
-     * @name ScriptComponent#move
-     * @description Fired when a script instance is moved in component.
-     * @param {string} name - The name of the Script Type.
-     * @param {ScriptType} scriptInstance - The instance of the {@link ScriptType} that has been moved.
-     * @param {number} ind - New position index.
-     * @param {number} indOld - Old position index.
-     * @example
-     * entity.script.on('move', function (name, scriptInstance, ind, indOld) {
-     *     // script instance has been moved in component
-     * });
-     */
-
-    /**
-     * @event
-     * @name ScriptComponent#move:[name]
-     * @description Fired when a script instance is moved in component.
-     * @param {ScriptType} scriptInstance - The instance of the {@link ScriptType} that has been moved.
-     * @param {number} ind - New position index.
-     * @param {number} indOld - Old position index.
-     * @example
-     * entity.script.on('move:playerController', function (scriptInstance, ind, indOld) {
-     *     // script instance 'playerController' has been moved in component
-     * });
-     */
-
-    /**
-     * @event
-     * @name ScriptComponent#error
-     * @description Fired when a script instance had an exception.
-     * @param {ScriptType} scriptInstance - The instance of the {@link ScriptType} that raised the exception.
-     * @param {Error} err - Native JS Error object with details of an error.
-     * @param {string} method - The method of the script instance that the exception originated from.
-     * @example
-     * entity.script.on('error', function (scriptInstance, err, method) {
-     *     // script instance caught an exception
-     * });
-     */
 
     onEnable() {
         this._beingEnabled = true;

--- a/src/framework/components/sound/component.js
+++ b/src/framework/components/sound/component.js
@@ -51,6 +51,46 @@ class SoundComponent extends Component {
     }
 
     /**
+     * Fired when a sound instance starts playing.
+     *
+     * @event SoundComponent#play
+     * @param {SoundSlot} slot - The slot whose instance started playing.
+     * @param {SoundInstance} instance - The instance that started playing.
+     */
+
+    /**
+     * Fired when a sound instance is paused.
+     *
+     * @event SoundComponent#pause
+     * @param {SoundSlot} slot - The slot whose instance was paused.
+     * @param {SoundInstance} instance - The instance that was paused created to play the sound.
+     */
+
+    /**
+     * Fired when a sound instance is resumed.
+     *
+     * @event SoundComponent#resume
+     * @param {SoundSlot} slot - The slot whose instance was resumed.
+     * @param {SoundInstance} instance - The instance that was resumed.
+     */
+
+    /**
+     * Fired when a sound instance is stopped.
+     *
+     * @event SoundComponent#stop
+     * @param {SoundSlot} slot - The slot whose instance was stopped.
+     * @param {SoundInstance} instance - The instance that was stopped.
+     */
+
+    /**
+     * Fired when a sound instance stops playing because it reached its ending.
+     *
+     * @event SoundComponent#end
+     * @param {SoundSlot} slot - The slot whose instance ended.
+     * @param {SoundInstance} instance - The instance that ended.
+     */
+
+    /**
      * Update the specified property on all sound instances.
      *
      * @param {string} property - The name of the SoundInstance property to update.
@@ -492,47 +532,5 @@ class SoundComponent extends Component {
         }
     }
 }
-
-// Events Documentation
-
-/**
- * @event
- * @name SoundComponent#play
- * @description Fired when a sound instance starts playing.
- * @param {SoundSlot} slot - The slot whose instance started playing.
- * @param {SoundInstance} instance - The instance that started playing.
- */
-
-/**
- * @event
- * @name SoundComponent#pause
- * @description Fired when a sound instance is paused.
- * @param {SoundSlot} slot - The slot whose instance was paused.
- * @param {SoundInstance} instance - The instance that was paused created to play the sound.
- */
-
-/**
- * @event
- * @name SoundComponent#resume
- * @description Fired when a sound instance is resumed..
- * @param {SoundSlot} slot - The slot whose instance was resumed.
- * @param {SoundInstance} instance - The instance that was resumed.
- */
-
-/**
- * @event
- * @name SoundComponent#stop
- * @description Fired when a sound instance is stopped.
- * @param {SoundSlot} slot - The slot whose instance was stopped.
- * @param {SoundInstance} instance - The instance that was stopped.
- */
-
-/**
- * @event
- * @name SoundComponent#end
- * @description Fired when a sound instance stops playing because it reached its ending.
- * @param {SoundSlot} slot - The slot whose instance ended.
- * @param {SoundInstance} instance - The instance that ended.
- */
 
 export { SoundComponent };

--- a/src/framework/components/sound/slot.js
+++ b/src/framework/components/sound/slot.js
@@ -104,6 +104,41 @@ class SoundSlot extends EventHandler {
     }
 
     /**
+     * Fired when a sound instance starts playing.
+     *
+     * @event SoundSlot#play
+     * @param {SoundInstance} instance - The instance that started playing.
+     */
+
+    /**
+     * Fired when a sound instance is paused.
+     *
+     * @event SoundSlot#pause
+     * @param {SoundInstance} instance - The instance that was paused created to play the sound.
+     */
+
+    /**
+     * Fired when a sound instance is resumed.
+     *
+     * @event SoundSlot#resume
+     * @param {SoundInstance} instance - The instance that was resumed.
+     */
+
+    /**
+     * Fired when a sound instance is stopped.
+     *
+     * @event SoundSlot#stop
+     * @param {SoundInstance} instance - The instance that was stopped.
+     */
+
+    /**
+     * Fired when the asset assigned to the slot is loaded.
+     *
+     * @event SoundSlot#load
+     * @param {Sound} sound - The sound resource that was loaded.
+     */
+
+    /**
      * Plays a sound. If {@link SoundSlot#overlap} is true the new sound instance will be played
      * independently of any other instances already playing. Otherwise existing sound instances
      * will stop before playing the new sound.
@@ -676,43 +711,6 @@ class SoundSlot extends EventHandler {
     get volume() {
         return this._volume;
     }
-
-    // Events Documentation
-
-    /**
-     * @event
-     * @name SoundSlot#play
-     * @description Fired when a sound instance starts playing.
-     * @param {SoundInstance} instance - The instance that started playing.
-     */
-
-    /**
-     * @event
-     * @name SoundSlot#pause
-     * @description Fired when a sound instance is paused.
-     * @param {SoundInstance} instance - The instance that was paused created to play the sound.
-     */
-
-    /**
-     * @event
-     * @name SoundSlot#resume
-     * @description Fired when a sound instance is resumed..
-     * @param {SoundInstance} instance - The instance that was resumed.
-     */
-
-    /**
-     * @event
-     * @name SoundSlot#stop
-     * @description Fired when a sound instance is stopped.
-     * @param {SoundInstance} instance - The instance that was stopped.
-     */
-
-    /**
-     * @event
-     * @name SoundSlot#load
-     * @description Fired when the asset assigned to the slot is loaded.
-     * @param {Sound} sound - The sound resource that was loaded.
-     */
 }
 
 export { SoundSlot };

--- a/src/framework/components/sprite/component.js
+++ b/src/framework/components/sprite/component.js
@@ -111,6 +111,48 @@ class SpriteComponent extends Component {
     }
 
     /**
+     * Fired when an animation clip starts playing.
+     *
+     * @event SpriteComponent#play
+     * @param {SpriteAnimationClip} clip - The clip that started playing.
+     */
+
+    /**
+     * Fired when an animation clip is paused.
+     *
+     * @event SpriteComponent#pause
+     * @param {SpriteAnimationClip} clip - The clip that was paused.
+     */
+
+    /**
+     * Fired when an animation clip is resumed.
+     *
+     * @event SpriteComponent#resume
+     * @param {SpriteAnimationClip} clip - The clip that was resumed.
+     */
+
+    /**
+     * Fired when an animation clip is stopped.
+     *
+     * @event SpriteComponent#stop
+     * @param {SpriteAnimationClip} clip - The clip that was stopped.
+     */
+
+    /**
+     * Fired when an animation clip stops playing because it reached its ending.
+     *
+     * @event SpriteComponent#end
+     * @param {SpriteAnimationClip} clip - The clip that ended.
+     */
+
+    /**
+     * Fired when an animation clip reached the end of its current loop.
+     *
+     * @event SpriteComponent#loop
+     * @param {SpriteAnimationClip} clip - The clip.
+     */
+
+    /**
      * The type of the SpriteComponent. Can be:
      *
      * - {@link SPRITETYPE_SIMPLE}: The component renders a single frame from a sprite asset.
@@ -937,50 +979,6 @@ class SpriteComponent extends Component {
 
         this._currentClip.stop();
     }
-
-    // Events Documentation
-
-    /**
-     * @event
-     * @name SpriteComponent#play
-     * @description Fired when an animation clip starts playing.
-     * @param {SpriteAnimationClip} clip - The clip that started playing.
-     */
-
-    /**
-     * @event
-     * @name SpriteComponent#pause
-     * @description Fired when an animation clip is paused.
-     * @param {SpriteAnimationClip} clip - The clip that was paused.
-     */
-
-    /**
-     * @event
-     * @name SpriteComponent#resume
-     * @description Fired when an animation clip is resumed.
-     * @param {SpriteAnimationClip} clip - The clip that was resumed.
-     */
-
-    /**
-     * @event
-     * @name SpriteComponent#stop
-     * @description Fired when an animation clip is stopped.
-     * @param {SpriteAnimationClip} clip - The clip that was stopped.
-     */
-
-    /**
-     * @event
-     * @name SpriteComponent#end
-     * @description Fired when an animation clip stops playing because it reached its ending.
-     * @param {SpriteAnimationClip} clip - The clip that ended.
-     */
-
-    /**
-     * @event
-     * @name SpriteComponent#loop
-     * @description Fired when an animation clip reached the end of its current loop.
-     * @param {SpriteAnimationClip} clip - The clip.
-     */
 }
 
 export { SpriteComponent };

--- a/src/framework/components/sprite/sprite-animation-clip.js
+++ b/src/framework/components/sprite/sprite-animation-clip.js
@@ -46,6 +46,42 @@ class SpriteAnimationClip extends EventHandler {
     }
 
     /**
+     * Fired when the clip starts playing.
+     *
+     * @event SpriteAnimationClip#play
+     */
+
+    /**
+     * Fired when the clip is paused.
+     *
+     * @event SpriteAnimationClip#pause
+     */
+
+    /**
+     * Fired when the clip is resumed.
+     *
+     * @event SpriteAnimationClip#resume
+     */
+
+    /**
+     * Fired when the clip is stopped.
+     *
+     * @event SpriteAnimationClip#stop
+     */
+
+    /**
+     * Fired when the clip stops playing because it reached its ending.
+     *
+     * @event SpriteAnimationClip#end
+     */
+
+    /**
+     * Fired when the clip reached the end of its current loop.
+     *
+     * @event SpriteAnimationClip#loop
+     */
+
+    /**
      * The total duration of the animation in seconds.
      *
      * @type {number}
@@ -445,44 +481,6 @@ class SpriteAnimationClip extends EventHandler {
         this.fire('stop');
         this._component.fire('stop', this);
     }
-
-    // Events Documentation
-
-    /**
-     * @event
-     * @name SpriteAnimationClip#play
-     * @description Fired when the clip starts playing.
-     */
-
-    /**
-     * @event
-     * @name SpriteAnimationClip#pause
-     * @description Fired when the clip is paused.
-     */
-
-    /**
-     * @event
-     * @name SpriteAnimationClip#resume
-     * @description Fired when the clip is resumed.
-     */
-
-    /**
-     * @event
-     * @name SpriteAnimationClip#stop
-     * @description Fired when the clip is stopped.
-     */
-
-    /**
-     * @event
-     * @name SpriteAnimationClip#end
-     * @description Fired when the clip stops playing because it reached its ending.
-     */
-
-    /**
-     * @event
-     * @name SpriteAnimationClip#loop
-     * @description Fired when the clip reached the end of its current loop.
-     */
 }
 
 export { SpriteAnimationClip };

--- a/src/framework/entity.js
+++ b/src/framework/entity.js
@@ -697,9 +697,9 @@ function resolveDuplicatedEntityReferenceProperties(oldSubtreeRoot, oldEntity, n
 }
 
 /**
- * @event
- * @name Entity#destroy
- * @description Fired after the entity is destroyed.
+ * Fired after the entity is destroyed.
+ *
+ * @event Entity#destroy
  * @param {Entity} entity - The entity that was destroyed.
  * @example
  * entity.on("destroy", function (e) {

--- a/src/graphics/graphics-device.js
+++ b/src/graphics/graphics-device.js
@@ -175,6 +175,17 @@ class GraphicsDevice extends EventHandler {
         this.programLib = new ProgramLibrary(this);
     }
 
+    /**
+     * Fired when the canvas is resized.
+     *
+     * @event GraphicsDevice#resizecanvas
+     * @param {number} width - The new width of the canvas in pixels.
+     * @param {number} height - The new height of the canvas in pixels.
+     */
+
+    /**
+     * Destroy the graphics device.
+     */
     destroy() {
         // fire the destroy event.
         // textures and other device resources may destroy themselves in response.

--- a/src/graphics/webgl/webgl-graphics-device.js
+++ b/src/graphics/webgl/webgl-graphics-device.js
@@ -160,14 +160,6 @@ function testTextureFloatHighPrecision(device) {
 }
 
 /**
- * @event
- * @name GraphicsDevice#resizecanvas
- * @description The 'resizecanvas' event is fired when the canvas is resized.
- * @param {number} width - The new width of the canvas in pixels.
- * @param {number} height - The new height of the canvas in pixels.
- */
-
-/**
  * The graphics device manages the underlying graphics context. It is responsible for submitting
  * render state changes and graphics primitives to the hardware. A graphics device is tied to a
  * specific canvas HTML element. It is valid to have more than one canvas element per page and

--- a/src/input/keyboard.js
+++ b/src/input/keyboard.js
@@ -53,36 +53,6 @@ const _keyCodeToKeyIdentifier = {
 };
 
 /**
- * @event
- * @name Keyboard#keydown
- * @description Event fired when a key is pressed.
- * @param {KeyboardEvent} event - The Keyboard event object. Note, this event is only valid for the current callback.
- * @example
- * var onKeyDown = function (e) {
- *     if (e.key === pc.KEY_SPACE) {
- *         // space key pressed
- *     }
- *     e.event.preventDefault(); // Use original browser event to prevent browser action.
- * };
- * app.keyboard.on("keydown", onKeyDown, this);
- */
-
-/**
- * @event
- * @name Keyboard#keyup
- * @description Event fired when a key is released.
- * @param {KeyboardEvent} event - The Keyboard event object. Note, this event is only valid for the current callback.
- * @example
- * var onKeyUp = function (e) {
- *     if (e.key === pc.KEY_SPACE) {
- *         // space key released
- *     }
- *     e.event.preventDefault(); // Use original browser event to prevent browser action.
- * };
- * app.keyboard.on("keyup", onKeyUp, this);
- */
-
-/**
  * A Keyboard device bound to an Element. Allows you to detect the state of the key presses. Note
  * that the Keyboard object must be attached to an Element before it can detect any key presses.
  *
@@ -128,6 +98,36 @@ class Keyboard extends EventHandler {
         this.preventDefault = options.preventDefault || false;
         this.stopPropagation = options.stopPropagation || false;
     }
+
+    /**
+     * Fired when a key is pressed.
+     *
+     * @event Keyboard#keydown
+     * @param {KeyboardEvent} event - The Keyboard event object. Note, this event is only valid for the current callback.
+     * @example
+     * var onKeyDown = function (e) {
+     *     if (e.key === pc.KEY_SPACE) {
+     *         // space key pressed
+     *     }
+     *     e.event.preventDefault(); // Use original browser event to prevent browser action.
+     * };
+     * app.keyboard.on("keydown", onKeyDown, this);
+     */
+
+    /**
+     * Fired when a key is released.
+     *
+     * @event Keyboard#keyup
+     * @param {KeyboardEvent} event - The Keyboard event object. Note, this event is only valid for the current callback.
+     * @example
+     * var onKeyUp = function (e) {
+     *     if (e.key === pc.KEY_SPACE) {
+     *         // space key released
+     *     }
+     *     e.event.preventDefault(); // Use original browser event to prevent browser action.
+     * };
+     * app.keyboard.on("keyup", onKeyUp, this);
+     */
 
     /**
      * Attach the keyboard event handlers to an Element.

--- a/src/input/mouse.js
+++ b/src/input/mouse.js
@@ -4,35 +4,6 @@ import { EventHandler } from '../core/event-handler.js';
 import { EVENT_MOUSEDOWN, EVENT_MOUSEMOVE, EVENT_MOUSEUP, EVENT_MOUSEWHEEL } from './constants.js';
 import { isMousePointerLocked, MouseEvent } from './mouse-event.js';
 
-// Events Documentation
-/**
- * @event
- * @name Mouse#mousemove
- * @description Fired when the mouse is moved.
- * @param {MouseEvent} event - The MouseEvent object.
- */
-
-/**
- * @event
- * @name Mouse#mousedown
- * @description Fired when a mouse button is pressed.
- * @param {MouseEvent} event - The MouseEvent object.
- */
-
-/**
- * @event
- * @name Mouse#mouseup
- * @description Fired when a mouse button is released.
- * @param {MouseEvent} event - The MouseEvent object.
- */
-
-/**
- * @event
- * @name Mouse#mousewheel
- * @description Fired when a mouse wheel is moved.
- * @param {MouseEvent} event - The MouseEvent object.
- */
-
 /**
  * Callback used by {@link Mouse#enablePointerLock} and {@link Application#disablePointerLock}.
  *
@@ -74,6 +45,34 @@ class Mouse extends EventHandler {
 
         this.attach(element);
     }
+
+    /**
+     * Fired when the mouse is moved.
+     *
+     * @event Mouse#mousemove
+     * @param {MouseEvent} event - The MouseEvent object.
+     */
+
+    /**
+     * Fired when a mouse button is pressed.
+     *
+     * @event Mouse#mousedown
+     * @param {MouseEvent} event - The MouseEvent object.
+     */
+
+    /**
+     * Fired when a mouse button is released.
+     *
+     * @event Mouse#mouseup
+     * @param {MouseEvent} event - The MouseEvent object.
+     */
+
+    /**
+     * Fired when a mouse wheel is moved.
+     *
+     * @event Mouse#mousewheel
+     * @param {MouseEvent} event - The MouseEvent object.
+     */
 
     /**
      * Check if the mouse pointer has been locked, using {@link Mouse#enabledPointerLock}.

--- a/src/scene/render.js
+++ b/src/scene/render.js
@@ -3,14 +3,6 @@ import { EventHandler } from '../core/event-handler.js';
 /** @typedef {import('./mesh.js').Mesh} Mesh */
 
 /**
- * @event
- * @private
- * @name Render#set:meshes
- * @description Fired when the meshes are set
- * @param {Mesh[]} meshes - The meshes
- */
-
-/**
  * A render contains an array of meshes that are referenced by a single hierarchy node in a GLB
  * model, and are accessible using {@link ContainerResource#renders} property. The render is the
  * resource of a Render Asset.
@@ -35,6 +27,14 @@ class Render extends EventHandler {
          */
         this._meshes = null;
     }
+
+    /**
+     * Fired when the meshes are set.
+     *
+     * @event Render#set:meshes
+     * @param {Mesh[]} meshes - The meshes.
+     * @ignore
+     */
 
     /**
      * The meshes that the render contains.

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -256,6 +256,39 @@ class Scene extends EventHandler {
     }
 
     /**
+     * Fired when the skybox is set.
+     *
+     * @event Scene#set:skybox
+     * @param {Texture} usedTex - Previously used cubemap texture. New is in the {@link Scene#skybox}.
+     */
+
+    /**
+     * Fired when the layer composition is set. Use this event to add callbacks or advanced
+     * properties to your layers.
+     *
+     * @event Scene#set:layers
+     * @param {LayerComposition} oldComp - Previously used {@link LayerComposition}.
+     * @param {LayerComposition} newComp - Newly set {@link LayerComposition}.
+     * @example
+     * this.app.scene.on('set:layers', function (oldComp, newComp) {
+     *     var list = newComp.layerList;
+     *     var layer;
+     *     for (var i = 0; i < list.length; i++) {
+     *         layer = list[i];
+     *         switch (layer.name) {
+     *             case 'MyLayer':
+     *                 layer.onEnable = myOnEnableFunction;
+     *                 layer.onDisable = myOnDisableFunction;
+     *                 break;
+     *             case 'MyOtherLayer':
+     *                 layer.shaderPass = myShaderPass;
+     *                 break;
+     *         }
+     *     }
+     * });
+     */
+
+    /**
      * Returns the default layer used by the immediate drawing functions.
      *
      * @type {Layer}
@@ -807,38 +840,6 @@ class Scene extends EventHandler {
     getModels(model) {
         return this._models;
     }
-
-    /**
-     * @event
-     * @name Scene#set:skybox
-     * @description Fired when the skybox is set.
-     * @param {Texture} usedTex - Previously used cubemap texture. New is in the {@link Scene#skybox}.
-     */
-
-    /**
-     * @event
-     * @name Scene#set:layers
-     * @description Fired when the layer composition is set. Use this event to add callbacks or advanced properties to your layers.
-     * @param {LayerComposition} oldComp - Previously used {@link LayerComposition}.
-     * @param {LayerComposition} newComp - Newly set {@link LayerComposition}.
-     * @example
-     * this.app.scene.on('set:layers', function (oldComp, newComp) {
-     *     var list = newComp.layerList;
-     *     var layer;
-     *     for (var i = 0; i < list.length; i++) {
-     *         layer = list[i];
-     *         switch (layer.name) {
-     *             case 'MyLayer':
-     *                 layer.onEnable = myOnEnableFunction;
-     *                 layer.onDisable = myOnDisableFunction;
-     *                 break;
-     *             case 'MyOtherLayer':
-     *                 layer.shaderPass = myShaderPass;
-     *                 break;
-     *         }
-     *     }
-     * });
-     */
 }
 
 export { Scene };

--- a/src/script/script-type.js
+++ b/src/script/script-type.js
@@ -97,6 +97,101 @@ class ScriptType extends EventHandler {
     }
 
     /**
+     * Fired when a script instance becomes enabled.
+     *
+     * @event ScriptType#enable
+     * @example
+     * PlayerController.prototype.initialize = function () {
+     *     this.on('enable', function () {
+     *         // Script Instance is now enabled
+     *     });
+     * };
+     */
+
+    /**
+     * Fired when a script instance becomes disabled.
+     *
+     * @event ScriptType#disable
+     * @example
+     * PlayerController.prototype.initialize = function () {
+     *     this.on('disable', function () {
+     *         // Script Instance is now disabled
+     *     });
+     * };
+     */
+
+    /**
+     * Fired when a script instance changes state to enabled or disabled.
+     *
+     * @event ScriptType#state
+     * @param {boolean} enabled - True if now enabled, False if disabled.
+     * @example
+     * PlayerController.prototype.initialize = function () {
+     *     this.on('state', function (enabled) {
+     *         console.log('Script Instance is now ' + (enabled ? 'enabled' : 'disabled'));
+     *     });
+     * };
+     */
+
+    /**
+     * Fired when a script instance is destroyed and removed from component.
+     *
+     * @event ScriptType#destroy
+     * @example
+     * PlayerController.prototype.initialize = function () {
+     *     this.on('destroy', function () {
+     *         // no more part of an entity
+     *         // good place to cleanup entity from destroyed script
+     *     });
+     * };
+     */
+
+    /**
+     * Fired when any script attribute has been changed.
+     *
+     * @event ScriptType#attr
+     * @param {string} name - Name of attribute.
+     * @param {object} value - New value.
+     * @param {object} valueOld - Old value.
+     * @example
+     * PlayerController.prototype.initialize = function () {
+     *     this.on('attr', function (name, value, valueOld) {
+     *         console.log(name + ' been changed from ' + valueOld + ' to ' + value);
+     *     });
+     * };
+     */
+
+    /**
+     * Fired when a specific script attribute has been changed.
+     *
+     * @event ScriptType#attr:[name]
+     * @param {object} value - New value.
+     * @param {object} valueOld - Old value.
+     * @example
+     * PlayerController.prototype.initialize = function () {
+     *     this.on('attr:speed', function (value, valueOld) {
+     *         console.log('speed been changed from ' + valueOld + ' to ' + value);
+     *     });
+     * };
+     */
+
+    /**
+     * Fired when a script instance had an exception. The script instance will be automatically
+     * disabled.
+     *
+     * @event ScriptType#error
+     * @param {Error} err - Native JavaScript Error object with details of error.
+     * @param {string} method - The method of the script instance that the exception originated from.
+     * @example
+     * PlayerController.prototype.initialize = function () {
+     *     this.on('error', function (err, method) {
+     *         // caught an exception
+     *         console.log(err.stack);
+     *     });
+     * };
+     */
+
+    /**
      * True if the instance of this type is in running state. False when script is not running,
      * because the Entity or any of its parents are disabled or the {@link ScriptComponent} is
      * disabled or the Script Instance is disabled. When disabled no update methods will be called
@@ -293,100 +388,6 @@ class ScriptType extends EventHandler {
      * gets redefined. If the new ScriptType has a `swap` method in its prototype,
      * then it will be executed to perform hot-reload at runtime.
      * @param {ScriptType} old - Old instance of the scriptType to copy data to the new instance.
-     */
-
-    /**
-     * @event
-     * @name ScriptType#enable
-     * @description Fired when a script instance becomes enabled.
-     * @example
-     * PlayerController.prototype.initialize = function () {
-     *     this.on('enable', function () {
-     *         // Script Instance is now enabled
-     *     });
-     * };
-     */
-
-    /**
-     * @event
-     * @name ScriptType#disable
-     * @description Fired when a script instance becomes disabled.
-     * @example
-     * PlayerController.prototype.initialize = function () {
-     *     this.on('disable', function () {
-     *         // Script Instance is now disabled
-     *     });
-     * };
-     */
-
-    /**
-     * @event
-     * @name ScriptType#state
-     * @description Fired when a script instance changes state to enabled or disabled.
-     * @param {boolean} enabled - True if now enabled, False if disabled.
-     * @example
-     * PlayerController.prototype.initialize = function () {
-     *     this.on('state', function (enabled) {
-     *         console.log('Script Instance is now ' + (enabled ? 'enabled' : 'disabled'));
-     *     });
-     * };
-     */
-
-    /**
-     * @event
-     * @name ScriptType#destroy
-     * @description Fired when a script instance is destroyed and removed from component.
-     * @example
-     * PlayerController.prototype.initialize = function () {
-     *     this.on('destroy', function () {
-     *         // no more part of an entity
-     *         // good place to cleanup entity from destroyed script
-     *     });
-     * };
-     */
-
-    /**
-     * @event
-     * @name ScriptType#attr
-     * @description Fired when any script attribute has been changed.
-     * @param {string} name - Name of attribute.
-     * @param {object} value - New value.
-     * @param {object} valueOld - Old value.
-     * @example
-     * PlayerController.prototype.initialize = function () {
-     *     this.on('attr', function (name, value, valueOld) {
-     *         console.log(name + ' been changed from ' + valueOld + ' to ' + value);
-     *     });
-     * };
-     */
-
-    /**
-     * @event
-     * @name ScriptType#attr:[name]
-     * @description Fired when a specific script attribute has been changed.
-     * @param {object} value - New value.
-     * @param {object} valueOld - Old value.
-     * @example
-     * PlayerController.prototype.initialize = function () {
-     *     this.on('attr:speed', function (value, valueOld) {
-     *         console.log('speed been changed from ' + valueOld + ' to ' + value);
-     *     });
-     * };
-     */
-
-    /**
-     * @event
-     * @name ScriptType#error
-     * @description Fired when a script instance had an exception. The script instance will be automatically disabled.
-     * @param {Error} err - Native JavaScript Error object with details of error.
-     * @param {string} method - The method of the script instance that the exception originated from.
-     * @example
-     * PlayerController.prototype.initialize = function () {
-     *     this.on('error', function (err, method) {
-     *         // caught an exception
-     *         console.log(err.stack);
-     *     });
-     * };
      */
 }
 

--- a/src/sound/instance.js
+++ b/src/sound/instance.js
@@ -238,6 +238,36 @@ class SoundInstance extends EventHandler {
     }
 
     /**
+     * Fired when the instance starts playing its source.
+     *
+     * @event SoundInstance#play
+     */
+
+    /**
+     * Fired when the instance is paused.
+     *
+     * @event SoundInstance#pause
+     */
+
+    /**
+     * Fired when the instance is resumed.
+     *
+     * @event SoundInstance#resume
+     */
+
+    /**
+     * Fired when the instance is stopped.
+     *
+     * @event SoundInstance#stop
+     */
+
+    /**
+     * Fired when the sound currently played by the instance ends.
+     *
+     * @event SoundInstance#end
+     */
+
+    /**
      * Gets or sets the current time of the sound that is playing. If the value provided is bigger
      * than the duration of the instance it will wrap from the beginning.
      *
@@ -1101,37 +1131,5 @@ if (!hasAudioContext()) {
         }
     });
 }
-
-// Events Documentation
-
-/**
- * @event
- * @name SoundInstance#play
- * @description Fired when the instance starts playing its source.
- */
-
-/**
- * @event
- * @name SoundInstance#pause
- * @description Fired when the instance is paused.
- */
-
-/**
- * @event
- * @name SoundInstance#resume
- * @description Fired when the instance is resumed.
- */
-
-/**
- * @event
- * @name SoundInstance#stop
- * @description Fired when the instance is stopped.
- */
-
-/**
- * @event
- * @name SoundInstance#end
- * @description Fired when the sound currently played by the instance ends.
- */
 
 export { SoundInstance };

--- a/src/xr/xr-depth-sensing.js
+++ b/src/xr/xr-depth-sensing.js
@@ -159,28 +159,23 @@ class XrDepthSensing extends EventHandler {
         }
     }
 
-    /** @ignore */
-    destroy() {
-        this._texture.destroy();
-        this._texture = null;
-    }
-
     /**
-     * @event
-     * @name XrDepthSensing#available
-     * @description Fired when depth sensing data becomes available.
+     * Fired when depth sensing data becomes available.
+     *
+     * @event XrDepthSensing#available
      */
 
     /**
-     * @event
-     * @name XrDepthSensing#unavailable
-     * @description Fired when depth sensing data becomes unavailable.
+     * Fired when depth sensing data becomes unavailable.
+     *
+     * @event XrDepthSensing#unavailable
      */
 
     /**
-     * @event
-     * @name XrDepthSensing#resize
-     * @description Fired when the depth sensing texture been resized. The {@link XrDepthSensing#uvMatrix} needs to be updated for relevant shaders.
+     * Fired when the depth sensing texture been resized. The {@link XrDepthSensing#uvMatrix} needs
+     * to be updated for relevant shaders.
+     *
+     * @event XrDepthSensing#resize
      * @param {number} width - The new width of the depth texture in pixels.
      * @param {number} height - The new height of the depth texture in pixels.
      * @example
@@ -188,6 +183,12 @@ class XrDepthSensing extends EventHandler {
      *     material.setParameter('matrix_depth_uv', depthSensing.uvMatrix);
      * });
      */
+
+    /** @ignore */
+    destroy() {
+        this._texture.destroy();
+        this._texture = null;
+    }
 
     /** @private */
     _onSessionStart() {

--- a/src/xr/xr-hand.js
+++ b/src/xr/xr-hand.js
@@ -128,15 +128,15 @@ class XrHand extends EventHandler {
     }
 
     /**
-     * @event
-     * @name XrHand#tracking
-     * @description Fired when tracking becomes available.
+     * Fired when tracking becomes available.
+     *
+     * @event XrHand#tracking
      */
 
     /**
-     * @event
-     * @name XrHand#trackinglost
-     * @description Fired when tracking is lost.
+     * Fired when tracking is lost.
+     *
+     * @event XrHand#trackinglost
      */
 
     /**

--- a/src/xr/xr-hit-test-source.js
+++ b/src/xr/xr-hit-test-source.js
@@ -59,9 +59,9 @@ class XrHitTestSource extends EventHandler {
     }
 
     /**
-     * @event
-     * @name XrHitTestSource#remove
-     * @description Fired when {@link XrHitTestSource} is removed.
+     * Fired when {@link XrHitTestSource} is removed.
+     *
+     * @event XrHitTestSource#remove
      * @example
      * hitTestSource.once('remove', function () {
      *     // hit test source has been removed
@@ -69,12 +69,14 @@ class XrHitTestSource extends EventHandler {
      */
 
     /**
-     * @event
-     * @name XrHitTestSource#result
-     * @description Fired when hit test source receives new results. It provides transform information that tries to match real world picked geometry.
+     * Fired when hit test source receives new results. It provides transform information that
+     * tries to match real world picked geometry.
+     *
+     * @event XrHitTestSource#result
      * @param {Vec3} position - Position of hit test.
      * @param {Quat} rotation - Rotation of hit test.
-     * @param {XrInputSource|null} inputSource - If is transient hit test source, then it will provide related input source.
+     * @param {XrInputSource|null} inputSource - If is transient hit test source, then it will
+     * provide related input source.
      * @example
      * hitTestSource.on('result', function (position, rotation, inputSource) {
      *     target.setPosition(position);

--- a/src/xr/xr-hit-test.js
+++ b/src/xr/xr-hit-test.js
@@ -66,9 +66,9 @@ class XrHitTest extends EventHandler {
     }
 
     /**
-     * @event
-     * @name XrHitTest#add
-     * @description Fired when new {@link XrHitTestSource} is added to the list.
+     * Fired when new {@link XrHitTestSource} is added to the list.
+     *
+     * @event XrHitTest#add
      * @param {XrHitTestSource} hitTestSource - Hit test source that has been added.
      * @example
      * app.xr.hitTest.on('add', function (hitTestSource) {
@@ -77,9 +77,9 @@ class XrHitTest extends EventHandler {
      */
 
     /**
-     * @event
-     * @name XrHitTest#remove
-     * @description Fired when {@link XrHitTestSource} is removed to the list.
+     * Fired when {@link XrHitTestSource} is removed to the list.
+     *
+     * @event XrHitTest#remove
      * @param {XrHitTestSource} hitTestSource - Hit test source that has been removed.
      * @example
      * app.xr.hitTest.on('remove', function (hitTestSource) {
@@ -88,9 +88,10 @@ class XrHitTest extends EventHandler {
      */
 
     /**
-     * @event
-     * @name XrHitTest#result
-     * @description Fired when hit test source receives new results. It provides transform information that tries to match real world picked geometry.
+     * Fired when hit test source receives new results. It provides transform information that
+     * tries to match real world picked geometry.
+     *
+     * @event XrHitTest#result
      * @param {XrHitTestSource} hitTestSource - Hit test source that produced the hit result.
      * @param {Vec3} position - Position of hit test.
      * @param {Quat} rotation - Rotation of hit test.
@@ -103,10 +104,10 @@ class XrHitTest extends EventHandler {
      */
 
     /**
-     * @event
-     * @name XrHitTest#error
+     * Fired when failed create hit test source.
+     *
+     * @event XrHitTest#error
      * @param {Error} error - Error object related to failure of creating hit test source.
-     * @description Fired when failed create hit test source.
      */
 
     /** @private */

--- a/src/xr/xr-image-tracking.js
+++ b/src/xr/xr-image-tracking.js
@@ -54,11 +54,11 @@ class XrImageTracking extends EventHandler {
     }
 
     /**
-     * @event
-     * @name XrImageTracking#error
+     * Fired when the XR session is started, but image tracking failed to process the provided
+     * images.
+     *
+     * @event XrImageTracking#error
      * @param {Error} error - Error object related to a failure of image tracking.
-     * @description Fired when the XR session is started, but image tracking failed to process the
-     * provided images.
      */
 
     /**

--- a/src/xr/xr-input-source.js
+++ b/src/xr/xr-input-source.js
@@ -166,6 +166,111 @@ class XrInputSource extends EventHandler {
     }
 
     /**
+     * Fired when {@link XrInputSource} is removed.
+     *
+     * @event XrInputSource#remove
+     * @example
+     * inputSource.once('remove', function () {
+     *     // input source is not available anymore
+     * });
+     */
+
+    /**
+     * Fired when input source has triggered primary action. This could be pressing a trigger
+     * button, or touching a screen.
+     *
+     * @event XrInputSource#select
+     * @param {object} evt - XRInputSourceEvent event data from WebXR API.
+     * @example
+     * var ray = new pc.Ray();
+     * inputSource.on('select', function (evt) {
+     *     ray.set(inputSource.getOrigin(), inputSource.getDirection());
+     *     if (obj.intersectsRay(ray)) {
+     *         // selected an object with input source
+     *     }
+     * });
+     */
+
+    /**
+     * Fired when input source has started to trigger primary action.
+     *
+     * @event XrInputSource#selectstart
+     * @param {object} evt - XRInputSourceEvent event data from WebXR API.
+     */
+
+    /**
+     * Fired when input source has ended triggering primary action.
+     *
+     * @event XrInputSource#selectend
+     * @param {object} evt - XRInputSourceEvent event data from WebXR API.
+     */
+
+    /**
+     * Fired when input source has triggered squeeze action. This is associated with "grabbing"
+     * action on the controllers.
+     *
+     * @event XrInputSource#squeeze
+     * @param {object} evt - XRInputSourceEvent event data from WebXR API.
+     */
+
+    /**
+     * Fired when input source has started to trigger squeeze action.
+     *
+     * @event XrInputSource#squeezestart
+     * @param {object} evt - XRInputSourceEvent event data from WebXR API.
+     * @example
+     * inputSource.on('squeezestart', function (evt) {
+     *     if (obj.containsPoint(inputSource.getPosition())) {
+     *         // grabbed an object
+     *     }
+     * });
+     */
+
+    /**
+     * Fired when input source has ended triggering squeeze action.
+     *
+     * @event XrInputSource#squeezeend
+     * @param {object} evt - XRInputSourceEvent event data from WebXR API.
+     */
+
+    /**
+     * Fired when new {@link XrHitTestSource} is added to the input source.
+     *
+     * @event XrInputSource#hittest:add
+     * @param {XrHitTestSource} hitTestSource - Hit test source that has been added.
+     * @example
+     * inputSource.on('hittest:add', function (hitTestSource) {
+     *     // new hit test source is added
+     * });
+     */
+
+    /**
+     * Fired when {@link XrHitTestSource} is removed to the the input source.
+     *
+     * @event XrInputSource#hittest:remove
+     * @param {XrHitTestSource} hitTestSource - Hit test source that has been removed.
+     * @example
+     * inputSource.on('remove', function (hitTestSource) {
+     *     // hit test source is removed
+     * });
+     */
+
+    /**
+     * Fired when hit test source receives new results. It provides transform information that
+     * tries to match real world picked geometry.
+     *
+     * @event XrInputSource#hittest:result
+     * @param {XrHitTestSource} hitTestSource - Hit test source that produced the hit result.
+     * @param {Vec3} position - Position of hit test.
+     * @param {Quat} rotation - Rotation of hit test.
+     * @example
+     * inputSource.on('hittest:result', function (hitTestSource, position, rotation) {
+     *     target.setPosition(position);
+     *     target.setRotation(rotation);
+     * });
+     */
+
+    /**
      * Unique number associated with instance of input source. Same physical devices when
      * reconnected will not share this ID.
      *
@@ -312,108 +417,6 @@ class XrInputSource extends EventHandler {
     get hitTestSources() {
         return this._hitTestSources;
     }
-
-    /**
-     * @event
-     * @name XrInputSource#remove
-     * @description Fired when {@link XrInputSource} is removed.
-     * @example
-     * inputSource.once('remove', function () {
-     *     // input source is not available anymore
-     * });
-     */
-
-    /**
-     * @event
-     * @name XrInputSource#select
-     * @description Fired when input source has triggered primary action. This could be pressing a trigger button, or touching a screen.
-     * @param {object} evt - XRInputSourceEvent event data from WebXR API.
-     * @example
-     * var ray = new pc.Ray();
-     * inputSource.on('select', function (evt) {
-     *     ray.set(inputSource.getOrigin(), inputSource.getDirection());
-     *     if (obj.intersectsRay(ray)) {
-     *         // selected an object with input source
-     *     }
-     * });
-     */
-
-    /**
-     * @event
-     * @name XrInputSource#selectstart
-     * @description Fired when input source has started to trigger primary action.
-     * @param {object} evt - XRInputSourceEvent event data from WebXR API.
-     */
-
-    /**
-     * @event
-     * @name XrInputSource#selectend
-     * @description Fired when input source has ended triggering primary action.
-     * @param {object} evt - XRInputSourceEvent event data from WebXR API.
-     */
-
-    /**
-     * @event
-     * @name XrInputSource#squeeze
-     * @description Fired when input source has triggered squeeze action. This is associated with "grabbing" action on the controllers.
-     * @param {object} evt - XRInputSourceEvent event data from WebXR API.
-     */
-
-    /**
-     * @event
-     * @name XrInputSource#squeezestart
-     * @description Fired when input source has started to trigger squeeze action.
-     * @param {object} evt - XRInputSourceEvent event data from WebXR API.
-     * @example
-     * inputSource.on('squeezestart', function (evt) {
-     *     if (obj.containsPoint(inputSource.getPosition())) {
-     *         // grabbed an object
-     *     }
-     * });
-     */
-
-    /**
-     * @event
-     * @name XrInputSource#squeezeend
-     * @description Fired when input source has ended triggering squeeze action.
-     * @param {object} evt - XRInputSourceEvent event data from WebXR API.
-     */
-
-    /**
-     * @event
-     * @name XrInputSource#hittest:add
-     * @description Fired when new {@link XrHitTestSource} is added to the input source.
-     * @param {XrHitTestSource} hitTestSource - Hit test source that has been added.
-     * @example
-     * inputSource.on('hittest:add', function (hitTestSource) {
-     *     // new hit test source is added
-     * });
-     */
-
-    /**
-     * @event
-     * @name XrInputSource#hittest:remove
-     * @description Fired when {@link XrHitTestSource} is removed to the the input source.
-     * @param {XrHitTestSource} hitTestSource - Hit test source that has been removed.
-     * @example
-     * inputSource.on('remove', function (hitTestSource) {
-     *     // hit test source is removed
-     * });
-     */
-
-    /**
-     * @event
-     * @name XrInputSource#hittest:result
-     * @description Fired when hit test source receives new results. It provides transform information that tries to match real world picked geometry.
-     * @param {XrHitTestSource} hitTestSource - Hit test source that produced the hit result.
-     * @param {Vec3} position - Position of hit test.
-     * @param {Quat} rotation - Rotation of hit test.
-     * @example
-     * inputSource.on('hittest:result', function (hitTestSource, position, rotation) {
-     *     target.setPosition(position);
-     *     target.setRotation(rotation);
-     * });
-     */
 
     /**
      * @param {*} frame - XRFrame from requestAnimationFrame callback.

--- a/src/xr/xr-input.js
+++ b/src/xr/xr-input.js
@@ -48,9 +48,9 @@ class XrInput extends EventHandler {
     }
 
     /**
-     * @event
-     * @name XrInput#add
-     * @description Fired when new {@link XrInputSource} is added to the list.
+     * Fired when new {@link XrInputSource} is added to the list.
+     *
+     * @event XrInput#add
      * @param {XrInputSource} inputSource - Input source that has been added.
      * @example
      * app.xr.input.on('add', function (inputSource) {
@@ -59,9 +59,9 @@ class XrInput extends EventHandler {
      */
 
     /**
-     * @event
-     * @name XrInput#remove
-     * @description Fired when {@link XrInputSource} is removed to the list.
+     * Fired when {@link XrInputSource} is removed to the list.
+     *
+     * @event XrInput#remove
      * @param {XrInputSource} inputSource - Input source that has been removed.
      * @example
      * app.xr.input.on('remove', function (inputSource) {
@@ -70,9 +70,10 @@ class XrInput extends EventHandler {
      */
 
     /**
-     * @event
-     * @name XrInput#select
-     * @description Fired when {@link XrInputSource} has triggered primary action. This could be pressing a trigger button, or touching a screen.
+     * Fired when {@link XrInputSource} has triggered primary action. This could be pressing a
+     * trigger button, or touching a screen.
+     *
+     * @event XrInput#select
      * @param {XrInputSource} inputSource - Input source that triggered select event.
      * @param {object} evt - XRInputSourceEvent event data from WebXR API.
      * @example
@@ -86,33 +87,34 @@ class XrInput extends EventHandler {
      */
 
     /**
-     * @event
-     * @name XrInput#selectstart
-     * @description Fired when {@link XrInputSource} has started to trigger primary action.
+     * Fired when {@link XrInputSource} has started to trigger primary action.
+     *
+     * @event XrInput#selectstart
      * @param {XrInputSource} inputSource - Input source that triggered selectstart event.
      * @param {object} evt - XRInputSourceEvent event data from WebXR API.
      */
 
     /**
-     * @event
-     * @name XrInput#selectend
-     * @description Fired when {@link XrInputSource} has ended triggerring primary action.
+     * Fired when {@link XrInputSource} has ended triggerring primary action.
+     *
+     * @event XrInput#selectend
      * @param {XrInputSource} inputSource - Input source that triggered selectend event.
      * @param {object} evt - XRInputSourceEvent event data from WebXR API.
      */
 
     /**
-     * @event
-     * @name XrInput#squeeze
-     * @description Fired when {@link XrInputSource} has triggered squeeze action. This is associated with "grabbing" action on the controllers.
+     * Fired when {@link XrInputSource} has triggered squeeze action. This is associated with
+     * "grabbing" action on the controllers.
+     *
+     * @event XrInput#squeeze
      * @param {XrInputSource} inputSource - Input source that triggered squeeze event.
      * @param {object} evt - XRInputSourceEvent event data from WebXR API.
      */
 
     /**
-     * @event
-     * @name XrInput#squeezestart
-     * @description Fired when {@link XrInputSource} has started to trigger sqeeze action.
+     * Fired when {@link XrInputSource} has started to trigger sqeeze action.
+     *
+     * @event XrInput#squeezestart
      * @param {XrInputSource} inputSource - Input source that triggered squeezestart event.
      * @param {object} evt - XRInputSourceEvent event data from WebXR API.
      * @example
@@ -124,9 +126,9 @@ class XrInput extends EventHandler {
      */
 
     /**
-     * @event
-     * @name XrInput#squeezeend
-     * @description Fired when {@link XrInputSource} has ended triggerring sqeeze action.
+     * Fired when {@link XrInputSource} has ended triggerring sqeeze action.
+     *
+     * @event XrInput#squeezeend
      * @param {XrInputSource} inputSource - Input source that triggered squeezeend event.
      * @param {object} evt - XRInputSourceEvent event data from WebXR API.
      */

--- a/src/xr/xr-light-estimation.js
+++ b/src/xr/xr-light-estimation.js
@@ -94,16 +94,16 @@ class XrLightEstimation extends EventHandler {
     }
 
     /**
-     * @event
-     * @name XrLightEstimation#available
-     * @description Fired when light estimation data becomes available.
+     * Fired when light estimation data becomes available.
+     *
+     * @event XrLightEstimation#available
      */
 
     /**
-     * @event
-     * @name XrLightEstimation#error
+     * Fired when light estimation has failed to start.
+     *
+     * @event XrLightEstimation#error
      * @param {Error} error - Error object related to failure of light estimation start.
-     * @description Fired when light estimation has failed to start.
      * @example
      * app.xr.lightEstimation.on('error', function (ex) {
      *     // has failed to start

--- a/src/xr/xr-manager.js
+++ b/src/xr/xr-manager.js
@@ -228,19 +228,9 @@ class XrManager extends EventHandler {
     }
 
     /**
-     * Destroys the XrManager instance.
+     * Fired when availability of specific XR type is changed.
      *
-     * @ignore
-     */
-    destroy() {
-        this.depthSensing.destroy();
-        this.depthSensing = null;
-    }
-
-    /**
-     * @event
-     * @name XrManager#available
-     * @description Fired when availability of specific XR type is changed.
+     * @event XrManager#available
      * @param {string} type - The session type that has changed availability.
      * @param {boolean} available - True if specified session type is now available.
      * @example
@@ -250,9 +240,9 @@ class XrManager extends EventHandler {
      */
 
     /**
-     * @event
-     * @name XrManager#available:[type]
-     * @description Fired when availability of specific XR type is changed.
+     * Fired when availability of specific XR type is changed.
+     *
+     * @event XrManager#available:[type]
      * @param {boolean} available - True if specified session type is now available.
      * @example
      * app.xr.on('available:' + pc.XRTYPE_VR, function (available) {
@@ -261,9 +251,9 @@ class XrManager extends EventHandler {
      */
 
     /**
-     * @event
-     * @name XrManager#start
-     * @description Fired when XR session is started.
+     * Fired when XR session is started.
+     *
+     * @event XrManager#start
      * @example
      * app.xr.on('start', function () {
      *     // XR session has started
@@ -271,9 +261,9 @@ class XrManager extends EventHandler {
      */
 
     /**
-     * @event
-     * @name XrManager#end
-     * @description Fired when XR session is ended.
+     * Fired when XR session is ended.
+     *
+     * @event XrManager#end
      * @example
      * app.xr.on('end', function () {
      *     // XR session has ended
@@ -281,10 +271,11 @@ class XrManager extends EventHandler {
      */
 
     /**
-     * @event
-     * @name XrManager#update
-     * @param {object} frame - [XRFrame](https://developer.mozilla.org/en-US/docs/Web/API/XRFrame) object that can be used for interfacing directly with WebXR APIs.
-     * @description Fired when XR session is updated, providing relevant XRFrame object.
+     * Fired when XR session is updated, providing relevant XRFrame object.
+     *
+     * @event XrManager#update
+     * @param {object} frame - [XRFrame](https://developer.mozilla.org/en-US/docs/Web/API/XRFrame)
+     * object that can be used for interfacing directly with WebXR APIs.
      * @example
      * app.xr.on('update', function (frame) {
      *
@@ -292,15 +283,26 @@ class XrManager extends EventHandler {
      */
 
     /**
-     * @event
-     * @name XrManager#error
-     * @param {Error} error - Error object related to failure of session start or check of session type support.
-     * @description Fired when XR session is failed to start or failed to check for session type support.
+     * Fired when XR session is failed to start or failed to check for session type support.
+     *
+     * @event XrManager#error
+     * @param {Error} error - Error object related to failure of session start or check of session
+     * type support.
      * @example
      * app.xr.on('error', function (ex) {
      *     // XR session has failed to start, or failed to check for session type support
      * });
      */
+
+    /**
+     * Destroys the XrManager instance.
+     *
+     * @ignore
+     */
+    destroy() {
+        this.depthSensing.destroy();
+        this.depthSensing = null;
+    }
 
     /**
      * Attempts to start XR session for provided {@link CameraComponent} and optionally fires

--- a/src/xr/xr-plane-detection.js
+++ b/src/xr/xr-plane-detection.js
@@ -69,21 +69,21 @@ class XrPlaneDetection extends EventHandler {
     }
 
     /**
-     * @event
-     * @name XrPlaneDetection#available
-     * @description Fired when plane detection becomes available.
+     * Fired when plane detection becomes available.
+     *
+     * @event XrPlaneDetection#available
      */
 
     /**
-     * @event
-     * @name XrPlaneDetection#unavailable
-     * @description Fired when plane detection becomes unavailable.
+     * Fired when plane detection becomes unavailable.
+     *
+     * @event XrPlaneDetection#unavailable
      */
 
     /**
-     * @event
-     * @name XrPlaneDetection#add
-     * @description Fired when new {@link XrPlane} is added to the list.
+     * Fired when new {@link XrPlane} is added to the list.
+     *
+     * @event XrPlaneDetection#add
      * @param {XrPlane} plane - Plane that has been added.
      * @example
      * app.xr.planeDetection.on('add', function (plane) {
@@ -92,9 +92,9 @@ class XrPlaneDetection extends EventHandler {
      */
 
     /**
-     * @event
-     * @name XrPlaneDetection#remove
-     * @description Fired when a {@link XrPlane} is removed from the list.
+     * Fired when a {@link XrPlane} is removed from the list.
+     *
+     * @event XrPlaneDetection#remove
      * @param {XrPlane} plane - Plane that has been removed.
      * @example
      * app.xr.planeDetection.on('remove', function (plane) {

--- a/src/xr/xr-plane.js
+++ b/src/xr/xr-plane.js
@@ -71,9 +71,9 @@ class XrPlane extends EventHandler {
     }
 
     /**
-     * @event
-     * @name XrPlane#remove
-     * @description Fired when {@link XrPlane} is removed.
+     * Fired when {@link XrPlane} is removed.
+     *
+     * @event XrPlane#remove
      * @example
      * plane.once('remove', function () {
      *     // plane is not available anymore
@@ -81,9 +81,10 @@ class XrPlane extends EventHandler {
      */
 
     /**
-     * @event
-     * @name XrPlane#change
-     * @description Fired when {@link XrPlane} attributes such as: orientation and/or points have been changed. Position and rotation can change at any time without triggering a `change` event.
+     * Fired when {@link XrPlane} attributes such as: orientation and/or points have been changed.
+     * Position and rotation can change at any time without triggering a `change` event.
+     *
+     * @event XrPlane#change
      * @example
      * plane.on('change', function () {
      *     // plane has been changed

--- a/src/xr/xr-tracked-image.js
+++ b/src/xr/xr-tracked-image.js
@@ -92,6 +92,18 @@ class XrTrackedImage extends EventHandler {
     }
 
     /**
+     * Fired when image becomes actively tracked.
+     *
+     * @event XrTrackedImage#tracked
+     */
+
+    /**
+     * Fired when image is no more actively tracked.
+     *
+     * @event XrTrackedImage#untracked
+     */
+
+    /**
      * Image that is used for tracking.
      *
      * @type {HTMLCanvasElement|HTMLImageElement|SVGImageElement|HTMLVideoElement|Blob|ImageData|ImageBitmap}
@@ -144,18 +156,6 @@ class XrTrackedImage extends EventHandler {
     get emulated() {
         return this._emulated;
     }
-
-    /**
-     * @event
-     * @name XrTrackedImage#tracked
-     * @description Fired when image becomes actively tracked.
-     */
-
-    /**
-     * @event
-     * @name XrTrackedImage#untracked
-     * @description Fired when image is no more actively tracked.
-     */
 
     /**
      * @returns {Promise<ImageBitmap>} Promise that resolves to an image bitmap.


### PR DESCRIPTION
* Drop the `@name` tag from all events in favor of the `@event` tag.
* Drop the `@description` tag from all events. Now, only 45 instances of the superfluous `@description` tag remain in the codebase.
* Move all events to a consistent location in a module. After the constructor seemed common so I standardized on that for now.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
