### PR TITLE
Add missing JSDoc param

### DIFF
--- a/src/graphics/webgl/webgl-shader.js
+++ b/src/graphics/webgl/webgl-shader.js
@@ -125,6 +125,7 @@ class WebglShader {
     /**
      * Compiles an individual shader.
      *
+     * @param {WebglGraphicsDevice} device - The graphics device.
      * @param {string} src - The shader source code.
      * @param {boolean} isVertexShader - True if the shader is a vertex shader, false if it is a
      * fragment shader.


### PR DESCRIPTION
Add missing `@param` tag from `WebglShader` JSDoc block.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
