### PR TITLE
Use exponentiation operator instead of Math.pow

### DIFF
--- a/scripts/camera/follow-camera.js
+++ b/scripts/camera/follow-camera.js
@@ -58,7 +58,7 @@ FollowCamera.prototype.postUpdate = function (dt) {
         // Lerp the current camera position to where we want it to be
         // Note that the lerping is framerate independent
         // From: https://www.rorydriscoll.com/2016/03/07/frame-rate-independent-damping-using-lerp/
-        this.currentPos.lerp(this.currentPos, this.targetPos, 1 - Math.pow(1 - this.lerpAmount, dt));
+        this.currentPos.lerp(this.currentPos, this.targetPos, 1 - (1 - this.lerpAmount) ** dt);
 
         // Set the camera's position
         this.entity.setPosition(this.currentPos);

--- a/src/audio/channel3d.js
+++ b/src/audio/channel3d.js
@@ -149,7 +149,7 @@ if (!hasAudioContext()) {
         } else if (distanceModel === DISTANCE_INVERSE) {
             result = refDistance / (refDistance + rolloffFactor * (distance - refDistance));
         } else if (distanceModel === DISTANCE_EXPONENTIAL) {
-            result = Math.pow(distance / refDistance, -rolloffFactor);
+            result = (distance / refDistance) ** -rolloffFactor;
         }
         return math.clamp(result, 0, 1);
     };

--- a/src/framework/components/screen/component.js
+++ b/src/framework/components/screen/component.js
@@ -126,7 +126,7 @@ class ScreenComponent extends Component {
         // the combined scale is 1 for an even blend
         const lx = Math.log2(resolution.x / referenceResolution.x);
         const ly = Math.log2(resolution.y / referenceResolution.y);
-        return Math.pow(2, (lx * (1 - this._scaleBlend) + ly * this._scaleBlend));
+        return 2 ** (lx * (1 - this._scaleBlend) + ly * this._scaleBlend);
     }
 
     _onResize(width, height) {

--- a/src/graphics/prefilter-cubemap.js
+++ b/src/graphics/prefilter-cubemap.js
@@ -193,7 +193,7 @@ function shFromCubemap(device, source, dontFlipX) {
                         value *= a * 8.0;
                         value *= value;
                     } else {
-                        value = Math.pow(value, 2.2);
+                        value **= 2.2;
                     }
 
                     sh[coef1 + c] += value * weight1;

--- a/src/graphics/reproject-texture.js
+++ b/src/graphics/reproject-texture.js
@@ -115,7 +115,7 @@ const packSamples = (samples) => {
 // generate a vector on the hemisphere with phong reflection distribution
 const hemisphereSamplePhong = (dstVec, x, y, specularPower) => {
     const phi = y * 2 * Math.PI;
-    const cosTheta = Math.pow(1 - x, 1 / (specularPower + 1));
+    const cosTheta = (1 - x) ** (1 / (specularPower + 1));
     const sinTheta = Math.sqrt(1 - cosTheta * cosTheta);
     dstVec.set(Math.cos(phi) * sinTheta, Math.sin(phi) * sinTheta, cosTheta).normalize();
 };

--- a/src/graphics/webgl/webgl-texture.js
+++ b/src/graphics/webgl/webgl-texture.js
@@ -341,7 +341,7 @@ class WebglTexture {
                     }
                 } else {
                     // Upload the byte array
-                    resMult = 1 / Math.pow(2, mipLevel);
+                    resMult = 1 / 2 ** mipLevel;
                     for (face = 0; face < 6; face++) {
                         if (!texture._levelsUpdated[0][face])
                             continue;
@@ -378,7 +378,7 @@ class WebglTexture {
                 // ----- 3D -----
                 // Image/canvas/video not supported (yet?)
                 // Upload the byte array
-                resMult = 1 / Math.pow(2, mipLevel);
+                resMult = 1 / 2 ** mipLevel;
                 if (texture._compressed) {
                     gl.compressedTexImage3D(gl.TEXTURE_3D,
                                             mipLevel,
@@ -429,7 +429,7 @@ class WebglTexture {
                     );
                 } else {
                     // Upload the byte array
-                    resMult = 1 / Math.pow(2, mipLevel);
+                    resMult = 1 / 2 ** mipLevel;
                     if (texture._compressed) {
                         gl.compressedTexImage2D(
                             gl.TEXTURE_2D,

--- a/src/math/float-packing.js
+++ b/src/math/float-packing.js
@@ -128,7 +128,7 @@ class FloatPacking {
     static float2MantissaExponent(value, array, offset, numBytes) {
         // exponent is increased by one, so that 2^exponent is larger than the value
         const exponent = Math.floor(Math.log2(Math.abs(value))) + 1;
-        value /= Math.pow(2, exponent);
+        value /= 2 ** exponent;
 
         // value is now in -1..1 range, store it using specified number of bytes less one
         FloatPacking.float2BytesRange(value, array, offset, -1, 1, numBytes - 1);

--- a/src/net/http.js
+++ b/src/net/http.js
@@ -571,7 +571,7 @@ class Http {
         if (options.retry && options.retries < options.maxRetries) {
             options.retries++;
             options.retrying = true; // used to stop retrying when both onError and xhr.onerror are called
-            const retryDelay = math.clamp(Math.pow(2, options.retries) * Http.retryDelay, 0, options.maxRetryDelay || 5000);
+            const retryDelay = math.clamp(2 ** options.retries * Http.retryDelay, 0, options.maxRetryDelay || 5000);
             console.log(`${method}: ${url} - Error ${xhr.status}. Retrying in ${retryDelay} ms`);
 
             setTimeout(() => {

--- a/src/resources/parser/glb-parser.js
+++ b/src/resources/parser/glb-parser.js
@@ -1079,7 +1079,7 @@ const createMaterial = function (gltfMaterial, textures, flipV) {
         if (specData.hasOwnProperty('diffuseFactor')) {
             color = specData.diffuseFactor;
             // Convert from linear space to sRGB space
-            material.diffuse.set(Math.pow(color[0], 1 / 2.2), Math.pow(color[1], 1 / 2.2), Math.pow(color[2], 1 / 2.2));
+            material.diffuse.set(color[0] ** (1 / 2.2), color[1] ** (1 / 2.2), color[2] ** (1 / 2.2));
             material.opacity = color[3];
         } else {
             material.diffuse.set(1, 1, 1);
@@ -1100,7 +1100,7 @@ const createMaterial = function (gltfMaterial, textures, flipV) {
         if (specData.hasOwnProperty('specularFactor')) {
             color = specData.specularFactor;
             // Convert from linear space to sRGB space
-            material.specular.set(Math.pow(color[0], 1 / 2.2), Math.pow(color[1], 1 / 2.2), Math.pow(color[2], 1 / 2.2));
+            material.specular.set(color[0] ** (1 / 2.2), color[1] ** (1 / 2.2), color[2] ** (1 / 2.2));
         } else {
             material.specular.set(1, 1, 1);
         }
@@ -1126,7 +1126,7 @@ const createMaterial = function (gltfMaterial, textures, flipV) {
         if (pbrData.hasOwnProperty('baseColorFactor')) {
             color = pbrData.baseColorFactor;
             // Convert from linear space to sRGB space
-            material.diffuse.set(Math.pow(color[0], 1 / 2.2), Math.pow(color[1], 1 / 2.2), Math.pow(color[2], 1 / 2.2));
+            material.diffuse.set(color[0] ** (1 / 2.2), color[1] ** (1 / 2.2), color[2] ** (1 / 2.2));
             material.opacity = color[3];
         } else {
             material.diffuse.set(1, 1, 1);
@@ -1187,7 +1187,7 @@ const createMaterial = function (gltfMaterial, textures, flipV) {
     if (gltfMaterial.hasOwnProperty('emissiveFactor')) {
         color = gltfMaterial.emissiveFactor;
         // Convert from linear space to sRGB space
-        material.emissive.set(Math.pow(color[0], 1 / 2.2), Math.pow(color[1], 1 / 2.2), Math.pow(color[2], 1 / 2.2));
+        material.emissive.set(color[0] ** (1 / 2.2), color[1] ** (1 / 2.2), color[2] ** (1 / 2.2));
         material.emissiveTint = true;
     } else {
         material.emissive.set(0, 0, 0);

--- a/src/resources/parser/texture/img.js
+++ b/src/resources/parser/texture/img.js
@@ -93,7 +93,7 @@ class ImgParser {
             if (retryTimeout) return;
 
             if (maxRetries > 0 && ++retries <= maxRetries) {
-                const retryDelay = Math.pow(2, retries) * 100;
+                const retryDelay = 2 ** retries * 100;
                 console.log(`Error loading Texture from: '${originalUrl}' - Retrying in ${retryDelay}ms...`);
 
                 const idx = url.indexOf('?');

--- a/src/scene/light.js
+++ b/src/scene/light.js
@@ -144,7 +144,7 @@ class Light {
 
         // Cache of light property data in a format more friendly for shader uniforms
         this._finalColor = new Float32Array([0.8, 0.8, 0.8]);
-        const c = Math.pow(this._finalColor[0], 2.2);
+        const c = this._finalColor[0] ** 2.2;
         this._linearFinalColor = new Float32Array([c, c, c]);
 
         this._position = new Vec3(0, 0, 0);
@@ -707,13 +707,13 @@ class Light {
         finalColor[1] = g * i;
         finalColor[2] = b * i;
         if (i >= 1) {
-            linearFinalColor[0] = Math.pow(r, 2.2) * i;
-            linearFinalColor[1] = Math.pow(g, 2.2) * i;
-            linearFinalColor[2] = Math.pow(b, 2.2) * i;
+            linearFinalColor[0] = r ** 2.2 * i;
+            linearFinalColor[1] = g ** 2.2 * i;
+            linearFinalColor[2] = b ** 2.2 * i;
         } else {
-            linearFinalColor[0] = Math.pow(finalColor[0], 2.2);
-            linearFinalColor[1] = Math.pow(finalColor[1], 2.2);
-            linearFinalColor[2] = Math.pow(finalColor[2], 2.2);
+            linearFinalColor[0] = finalColor[0] ** 2.2;
+            linearFinalColor[1] = finalColor[1] ** 2.2;
+            linearFinalColor[2] = finalColor[2] ** 2.2;
         }
     }
 

--- a/src/scene/lightmapper/bake-light-ambient.js
+++ b/src/scene/lightmapper/bake-light-ambient.js
@@ -47,8 +47,8 @@ class BakeLightAmbient extends BakeLight {
         // the fact N dot L used to bake it lowers total intensity
         const gamma = this.scene.gammaCorrection ? 2.2 : 1;
         const fullIntensity = 2 * Math.PI * this.scene.ambientBakeSpherePart;
-        const linearIntensity = Math.pow(fullIntensity, gamma);
-        this.light.intensity = Math.pow(linearIntensity / numVirtualLights, 1 / gamma);
+        const linearIntensity = fullIntensity ** gamma;
+        this.light.intensity = (linearIntensity / numVirtualLights) ** (1 / gamma);
     }
 }
 

--- a/src/scene/lightmapper/bake-light-simple.js
+++ b/src/scene/lightmapper/bake-light-simple.js
@@ -35,8 +35,8 @@ class BakeLightSimple extends BakeLight {
 
         // divide intensity by number of virtual lights (in linear space)
         const gamma = this.scene.gammaCorrection ? 2.2 : 1;
-        const linearIntensity = Math.pow(this.intensity, gamma);
-        light.intensity = Math.pow(linearIntensity / numVirtualLights, 1 / gamma);
+        const linearIntensity = this.intensity ** gamma;
+        light.intensity = (linearIntensity / numVirtualLights) ** (1 / gamma);
     }
 }
 

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -930,9 +930,9 @@ function _defineColor(name, defaultValue) {
         const gamma = material.useGammaTonemap && scene.gammaCorrection;
 
         if (gamma) {
-            uniform[0] = Math.pow(color.r, 2.2);
-            uniform[1] = Math.pow(color.g, 2.2);
-            uniform[2] = Math.pow(color.b, 2.2);
+            uniform[0] = color.r ** 2.2;
+            uniform[1] = color.g ** 2.2;
+            uniform[2] = color.b ** 2.2;
         } else {
             uniform[0] = color.r;
             uniform[1] = color.g;
@@ -989,7 +989,7 @@ function _defineMaterialProps() {
         // Shininess is 0-100 value which is actually a 0-1 glossiness value.
         return material.shadingModel === SPECULAR_PHONG ?
             // legacy: expand back to specular power
-            Math.pow(2, material.shininess * 0.01 * 11) :
+            2 ** (material.shininess * 0.01 * 11) :
             material.shininess * 0.01;
     });
     _defineFloat('heightMapFactor', 1, (material, device, scene) => {

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -564,7 +564,7 @@ class ForwardRenderer {
         this.ambientColor[2] = scene.ambientLight.b;
         if (scene.gammaCorrection) {
             for (let i = 0; i < 3; i++) {
-                this.ambientColor[i] = this.ambientColor[i] ** 2.2;
+                this.ambientColor[i] **= 2.2;
             }
         }
         this.ambientId.setValue(this.ambientColor);
@@ -1677,7 +1677,7 @@ class ForwardRenderer {
             this.fogColor[2] = scene.fogColor.b;
             if (scene.gammaCorrection) {
                 for (let i = 0; i < 3; i++) {
-                    this.fogColor[i] = this.fogColor[i] ** 2.2;
+                    this.fogColor[i] **= 2.2;
                 }
             }
             this.fogColorId.setValue(this.fogColor);

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -564,7 +564,7 @@ class ForwardRenderer {
         this.ambientColor[2] = scene.ambientLight.b;
         if (scene.gammaCorrection) {
             for (let i = 0; i < 3; i++) {
-                this.ambientColor[i] = Math.pow(this.ambientColor[i], 2.2);
+                this.ambientColor[i] = this.ambientColor[i] ** 2.2;
             }
         }
         this.ambientId.setValue(this.ambientColor);
@@ -1677,7 +1677,7 @@ class ForwardRenderer {
             this.fogColor[2] = scene.fogColor.b;
             if (scene.gammaCorrection) {
                 for (let i = 0; i < 3; i++) {
-                    this.fogColor[i] = Math.pow(this.fogColor[i], 2.2);
+                    this.fogColor[i] = this.fogColor[i] ** 2.2;
                 }
             }
             this.fogColorId.setValue(this.fogColor);

--- a/src/sound/instance3d.js
+++ b/src/sound/instance3d.js
@@ -210,7 +210,7 @@ if (!hasAudioContext()) {
         } else if (distanceModel === DISTANCE_INVERSE) {
             result = refDistance / (refDistance + rollOffFactor * (distance - refDistance));
         } else if (distanceModel === DISTANCE_EXPONENTIAL) {
-            result = Math.pow(distance / refDistance, -rollOffFactor);
+            result = (distance / refDistance) ** -rollOffFactor;
         }
         return math.clamp(result, 0, 1);
     };

--- a/test/math/math.test.mjs
+++ b/test/math/math.test.mjs
@@ -66,7 +66,7 @@ describe('math', function () {
 
         it('returns 2 ^ 24 - 1 when all supplied bytes are 255', function () {
             const uint24 = math.bytesToInt24(255, 255, 255);
-            expect(uint24).to.equal(Math.pow(2, 24) - 1);
+            expect(uint24).to.equal(2 ** 24 - 1);
         });
 
     });
@@ -90,7 +90,7 @@ describe('math', function () {
 
         it('returns 2 ^ 32 - 1 when all supplied bytes are 255', function () {
             const uint32 = math.bytesToInt32(255, 255, 255, 255);
-            expect(uint32).to.equal(Math.pow(2, 32) - 1);
+            expect(uint32).to.equal(2 ** 32 - 1);
         });
 
     });


### PR DESCRIPTION
JavaScript now support the [exponentiation operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Exponentiation) (`**`). This essentially does the same thing as [`Math.pow`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/pow). There is an ESLint rule called [`prefer-exponentiation-operator`](https://eslint.org/docs/latest/rules/prefer-exponentiation-operator) (which we currently have disabled) - and it makes the argument for the rule as follows:

    Introduced in ES2016, the infix exponentiation operator ** is an alternative for the standard Math.pow function.

    Infix notation is considered to be more readable and thus more preferable than the function notation.

So this PR is a suggestion to poll opinion as to whether we adopt officially `**`.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
