### PR TITLE
Sync screens draw order on set Priority.

### DIFF
--- a/src/framework/components/screen/component.js
+++ b/src/framework/components/screen/component.js
@@ -287,8 +287,8 @@ class ScreenComponent extends Component {
 
     /**
      * Priority determines the order in which Screen components in the same layer are rendered.
-     * Number must be an integer between 0 and 255.
-     * Priority is set into the top 8 bits of the drawOrder property in an element.
+     * Number must be an integer between 0 and 255. Priority is set into the top 8 bits of the
+     * drawOrder property in an element.
      *
      * @type {number}
      */

--- a/src/framework/components/screen/component.js
+++ b/src/framework/components/screen/component.js
@@ -291,7 +291,6 @@ class ScreenComponent extends Component {
      * Priority is set into the top 8 bits of the drawOrder property in an element.
      *
      * @type {number}
-     * @public
      */
     set priority(value) {
         if (value > 0xFF) {

--- a/src/framework/components/screen/component.js
+++ b/src/framework/components/screen/component.js
@@ -299,6 +299,7 @@ class ScreenComponent extends Component {
         }
 
         this._priority = value;
+        this.syncDrawOrder();
     }
 
     get priority() {

--- a/src/framework/components/screen/component.js
+++ b/src/framework/components/screen/component.js
@@ -297,6 +297,9 @@ class ScreenComponent extends Component {
             Debug.warn(`Clamping screen priority from ${value} to 255`);
             value = 0xFF;
         }
+        if (this._priority === value) {
+            return;
+        }
 
         this._priority = value;
         this.syncDrawOrder();

--- a/src/framework/components/screen/component.js
+++ b/src/framework/components/screen/component.js
@@ -286,8 +286,8 @@ class ScreenComponent extends Component {
     }
 
     /**
-     * Priority determines the order in which screens components are rendered.
-     * Needs to be an integer between 0 and 255.
+     * Priority determines the order in which Screen components in the same layer are rendered.
+     * Number must be an integer between 0 and 255.
      * Priority is set into the top 8 bits of the drawOrder property in an element.
      *
      * @type {number}

--- a/src/framework/components/screen/component.js
+++ b/src/framework/components/screen/component.js
@@ -286,11 +286,12 @@ class ScreenComponent extends Component {
     }
 
     /**
-     * Priority determines the order in which screens components are rendered. Priority is set into
-     * the top 8 bits of the drawOrder property in an element.
+     * Priority determines the order in which screens components are rendered.
+     * Needs to be an integer between 0 and 255.
+     * Priority is set into the top 8 bits of the drawOrder property in an element.
      *
      * @type {number}
-     * @private
+     * @public
      */
     set priority(value) {
         if (value > 0xFF) {


### PR DESCRIPTION
Part of https://github.com/playcanvas/engine/issues/3514

This PR makes it so the raw order of UI Elements is refreshed properly when changing a `Screen`'s `priority` attribute.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
