### PR TITLE
Remove duplicated anim export

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -217,7 +217,6 @@ export { AppBase, app } from './framework/app-base.js';
 export { Application } from './framework/application.js';
 export { AnimationComponent } from './framework/components/animation/component.js';
 export { AnimationComponentSystem } from './framework/components/animation/system.js';
-export * from './anim/controller/constants.js';
 export { AnimComponent } from './framework/components/anim/component.js';
 export { AnimComponentLayer } from './framework/components/anim/component-layer.js';
 export { AnimComponentSystem } from './framework/components/anim/system.js';


### PR DESCRIPTION
Removes a duplicated export of the anim controller constants.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
