### PR TITLE
Shader compilation error: fix the 'shadow' redefinition

### DIFF
--- a/src/graphics/program-lib/programs/lit-shader.js
+++ b/src/graphics/program-lib/programs/lit-shader.js
@@ -1211,16 +1211,16 @@ class LitShader {
                             if (light._normalOffsetBias) {
                                 code += "    normalOffsetPointShadow(light" + i + "_shadowParams);\n";
                             }
-                            code += "    float shadow = getShadowPoint" + shadowReadMode + shadowCoordArgs;
-                            code += `    dAtten *= mix(1.0f, shadow, light${i}_shadowIntensity);\n`;
+                            code += `    float shadow${i} = getShadowPoint${shadowReadMode}${shadowCoordArgs}`;
+                            code += `    dAtten *= mix(1.0f, shadow${i}, light${i}_shadowIntensity);\n`;
                         } else {
                             const shadowMatArg = `light${i}_shadowMatrix`;
                             const shadowParamArg = `light${i}_shadowParams`;
                             code += this._nonPointShadowMapProjection(device, options.lights[i], shadowMatArg, shadowParamArg, i);
 
                             if (lightType === LIGHTTYPE_SPOT) shadowReadMode = "Spot" + shadowReadMode;
-                            code += "    float shadow = getShadow" + shadowReadMode + "(light" + i + "_shadowMap, light" + i + "_shadowParams" + (light._isVsm ? ", " + evsmExp : "") + ");\n";
-                            code += `    dAtten *= mix(1.0f, shadow, light${i}_shadowIntensity);\n`;
+                            code += `    float shadow${i} = getShadow${shadowReadMode}(light${i}_shadowMap, light${i}_shadowParams${(light._isVsm ? ", " + evsmExp : "")});\n`;
+                            code += `    dAtten *= mix(1.0f, shadow${i}, light${i}_shadowIntensity);\n`;
                         }
                     }
                 }


### PR DESCRIPTION
The "shadow" variable can be unexpectedly redefined because it is defined in the loop.

<img width="656" alt="Screen Shot 2022-06-30 at 18 48 59" src="https://user-images.githubusercontent.com/104348270/176708508-af15038f-a7f4-41b0-af56-cd980864e73b.png">

So, this MR adds index to the variables.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
