### PR TITLE
Normalize TBN

### DIFF
--- a/src/graphics/program-lib/chunks/lit/frag/TBNderivative.js
+++ b/src/graphics/program-lib/chunks/lit/frag/TBNderivative.js
@@ -17,9 +17,10 @@ void getTBN() {
     vec3 T = dp2perp * duv1.x + dp1perp * duv2.x;
     vec3 B = dp2perp * duv1.y + dp1perp * duv2.y;
 
-    // construct a scale-invariant frame
-    float denom = max( dot(T,T), dot(B,B) );
-    float invmax = (denom == 0.0) ? 0.0 : tbnBasis / sqrt( denom );
-    dTBN = mat3(T * invmax, -B * invmax, dVertexNormalW );
+    dTBN = mat3(
+        normalize(T * tbnBasis),
+        normalize(-B * tbnBasis),
+        normalize(dVertexNormalW)
+    );
 }
 `;

--- a/src/graphics/program-lib/chunks/lit/frag/TBNderivative.js
+++ b/src/graphics/program-lib/chunks/lit/frag/TBNderivative.js
@@ -20,7 +20,7 @@ void getTBN() {
     dTBN = mat3(
         normalize(T * tbnBasis),
         normalize(-B * tbnBasis),
-        normalize(dVertexNormalW)
+        dVertexNormalW
     );
 }
 `;


### PR DESCRIPTION
Tangen, bitangent and normal have to be orthonormal.

This MR does not fix https://github.com/playcanvas/engine/issues/2787 but improves it.
It looks like Playcanvas Editor has to keep tangents/bitangents while converting fbx=>glb

- Before: 
<img width="681" alt="Screen Shot 2022-07-01 at 17 43 09" src="https://user-images.githubusercontent.com/104348270/176907268-49454328-8085-4579-b0c0-12ef3e04eb38.png">

- After:
<img width="681" alt="Screen Shot 2022-07-01 at 17 43 14" src="https://user-images.githubusercontent.com/104348270/176907300-2f78c1a4-6a1c-4184-936a-e6527ebe8527.png">

Tangent visualization of a test model:

- Before:
<img width="1196" alt="Screen Shot 2022-07-01 at 16 39 07" src="https://user-images.githubusercontent.com/104348270/176907457-bcac97a1-b0e4-40e7-a616-2d6f96ffd26d.png">

- After:
<img width="1196" alt="Screen Shot 2022-07-01 at 16 39 11" src="https://user-images.githubusercontent.com/104348270/176907505-70fe1b0f-9614-4349-ac34-efde46add023.png">

It looks like there is still something wrong with TBN matrix.



I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
