### PR TITLE
Deallocate internal resources for post effects

### DIFF
--- a/scripts/posteffects/posteffect-bloom.js
+++ b/scripts/posteffects/posteffect-bloom.js
@@ -192,6 +192,7 @@ BloomEffect.prototype._destroy = function () {
             this.targets[i].destroy();
         }
     }
+    this.targets.length = 0;
 };
 
 BloomEffect.prototype._resize = function (target) {
@@ -206,7 +207,6 @@ BloomEffect.prototype._resize = function (target) {
     this._destroy();
 
     // Render targets
-    this.targets = [];
     var i;
     for (i = 0; i < 2; i++) {
         var colorBuffer = new pc.Texture(this.device, {

--- a/scripts/posteffects/posteffect-bloom.js
+++ b/scripts/posteffects/posteffect-bloom.js
@@ -210,6 +210,7 @@ BloomEffect.prototype._resize = function (target) {
     var i;
     for (i = 0; i < 2; i++) {
         var colorBuffer = new pc.Texture(this.device, {
+            name: "Bloom Texture" + i,
             format: pc.PIXELFORMAT_R8_G8_B8_A8,
             width: width >> 1,
             height: height >> 1,
@@ -221,6 +222,7 @@ BloomEffect.prototype._resize = function (target) {
         colorBuffer.addressV = pc.ADDRESS_CLAMP_TO_EDGE;
         colorBuffer.name = 'pe-bloom';
         var bloomTarget = new pc.RenderTarget({
+            name: "Bloom Render Target " + i,
             colorBuffer: colorBuffer,
             depth: false
         });

--- a/scripts/posteffects/posteffect-bloom.js
+++ b/scripts/posteffects/posteffect-bloom.js
@@ -184,7 +184,18 @@ function BloomEffect(graphicsDevice) {
 BloomEffect.prototype = Object.create(pc.PostEffect.prototype);
 BloomEffect.prototype.constructor = BloomEffect;
 
+BloomEffect.prototype._destroy = function () {
+    if (this.targets) {
+        var i;
+        for (i = 0; i < this.targets.length; i++) {
+            this.targets[i].destroyTextureBuffers();
+            this.targets[i].destroy();
+        }
+    }
+};
+
 BloomEffect.prototype._resize = function (target) {
+
 
     var width = target.colorBuffer.width;
     var height = target.colorBuffer.height;
@@ -192,17 +203,11 @@ BloomEffect.prototype._resize = function (target) {
     if (width === this.width && height === this.height)
         return;
 
-    var i;
-    if (this.targets) {
-        for (i = 0; i < this.targets.length; i++) {
-            this.targets[i].destroyFrameBuffers();
-            this.targets[i].destroyTextureBuffers();
-            this.targets[i].destroy();
-        }
-    }
+    this._destroy();
 
     // Render targets
     this.targets = [];
+    var i;
     for (i = 0; i < 2; i++) {
         var colorBuffer = new pc.Texture(this.device, {
             format: pc.PIXELFORMAT_R8_G8_B8_A8,
@@ -314,5 +319,6 @@ Bloom.prototype.initialize = function () {
 
     this.on('destroy', function () {
         queue.removeEffect(this.effect);
+        this._destroy();
     });
 };

--- a/scripts/posteffects/posteffect-ssao.js
+++ b/scripts/posteffects/posteffect-ssao.js
@@ -382,7 +382,20 @@ function SSAOEffect(graphicsDevice, ssaoScript) {
 SSAOEffect.prototype = Object.create(pc.PostEffect.prototype);
 SSAOEffect.prototype.constructor = SSAOEffect;
 
+SSAOEffect.prototype._destroy = function () {
+    if (this.target) {
+        this.target.destroyTextureBuffers();
+        this.target.destroy();
+        this.target = null;
+
+        this.blurTarget.destroyTextureBuffers();
+        this.blurTarget.destroy();
+        this.blurTarget = null;
+    }
+};
+
 SSAOEffect.prototype._resize = function (target) {
+
 
     var width = Math.ceil(target.colorBuffer.width / this.device.maxPixelRatio / this.downscale);
     var height = Math.ceil(target.colorBuffer.height / this.device.maxPixelRatio / this.downscale);
@@ -394,17 +407,9 @@ SSAOEffect.prototype._resize = function (target) {
     // Render targets
     this.width = width;
     this.height = height;
-    if (this.target) {
-        this.target.destroyFrameBuffers();
-        this.target.destroyTextureBuffers();
-        this.target.destroy();
-        this.target = null;
 
-        this.blurTarget.destroyFrameBuffers();
-        this.blurTarget.destroyTextureBuffers();
-        this.blurTarget.destroy();
-        this.blurTarget = null;
-    }
+    this._destroy();
+
     var ssaoResultBuffer = new pc.Texture(this.device, {
         format: pc.PIXELFORMAT_R8_G8_B8_A8,
         minFilter: pc.FILTER_LINEAR,
@@ -554,5 +559,6 @@ SSAO.prototype.initialize = function () {
 
     this.on('destroy', function () {
         queue.removeEffect(this.effect);
+        this.effect._destroy();
     });
 };

--- a/scripts/posteffects/posteffect-ssao.js
+++ b/scripts/posteffects/posteffect-ssao.js
@@ -389,7 +389,7 @@ SSAOEffect.prototype._destroy = function () {
         this.target = null;
 
     }
-    
+
     if (this.blurTarget) {
         this.blurTarget.destroyTextureBuffers();
         this.blurTarget.destroy();

--- a/scripts/posteffects/posteffect-ssao.js
+++ b/scripts/posteffects/posteffect-ssao.js
@@ -388,6 +388,9 @@ SSAOEffect.prototype._destroy = function () {
         this.target.destroy();
         this.target = null;
 
+    }
+    
+    if (this.blurTarget) {
         this.blurTarget.destroyTextureBuffers();
         this.blurTarget.destroy();
         this.blurTarget = null;
@@ -422,6 +425,7 @@ SSAOEffect.prototype._resize = function (target) {
     });
     ssaoResultBuffer.name = 'SSAO Result';
     this.target = new pc.RenderTarget({
+        name: "SSAO Result Render Target",
         colorBuffer: ssaoResultBuffer,
         depth: false
     });
@@ -438,6 +442,7 @@ SSAOEffect.prototype._resize = function (target) {
     });
     ssaoBlurBuffer.name = 'SSAO Blur';
     this.blurTarget = new pc.RenderTarget({
+        name: "SSAO Blur Render Target",
         colorBuffer: ssaoBlurBuffer,
         depth: false
     });


### PR DESCRIPTION
### Description

Moves the deallocation of the internal render targets for bloom and SSAO to its own function such that we can deallocate said buffers when we disable the effects. 