### PR TITLE
ShaderProcessor partially updating shader source to support uniform buffers

### DIFF
--- a/src/graphics/bind-group-format.js
+++ b/src/graphics/bind-group-format.js
@@ -50,7 +50,7 @@ class BindGroupFormat {
         /** @type {BindTextureFormat[]} */
         this.textureFormats = textureFormats;
 
-            // maps a texture format name to a slot index
+        // maps a texture format name to a slot index
         /** @type {Map<string, number>} */
         this.textureFormatsMap = new Map();
         textureFormats.forEach((tf, i) => this.textureFormatsMap.set(tf.name, i));

--- a/src/graphics/bind-group-format.js
+++ b/src/graphics/bind-group-format.js
@@ -50,7 +50,7 @@ class BindGroupFormat {
         /** @type {BindTextureFormat[]} */
         this.textureFormats = textureFormats;
 
-        // maps a texture format name to an slot index
+            // maps a texture format name to a slot index
         /** @type {Map<string, number>} */
         this.textureFormatsMap = new Map();
         textureFormats.forEach((tf, i) => this.textureFormatsMap.set(tf.name, i));

--- a/src/graphics/bind-group-format.js
+++ b/src/graphics/bind-group-format.js
@@ -50,7 +50,7 @@ class BindGroupFormat {
         /** @type {BindTextureFormat[]} */
         this.textureFormats = textureFormats;
 
-        // maps a texture format name to an index
+        // maps a texture format name to an slot index
         /** @type {Map<string, number>} */
         this.textureFormatsMap = new Map();
         textureFormats.forEach((tf, i) => this.textureFormatsMap.set(tf.name, i));
@@ -63,6 +63,16 @@ class BindGroupFormat {
      */
     destroy() {
         this.impl.destroy();
+    }
+
+    /**
+     * Returns slot index for a texture slot name.
+     *
+     * @param {string} name - The name of the texture slot.
+     * @returns {number} - The slot index.
+     */
+    getTextureSlot(name) {
+        return this.textureFormatsMap.get(name);
     }
 
     loseContext() {

--- a/src/graphics/constants.js
+++ b/src/graphics/constants.js
@@ -1109,6 +1109,9 @@ export const SHADERSTAGE_COMPUTE = 4;
 export const BINDGROUP_VIEW = 0;
 export const BINDGROUP_MESH = 1;
 
+// names of bind groups
+export const bindGroupNames = ['view', 'mesh'];
+
 // map of engine TYPE_*** enums to their corresponding typed array constructors and byte sizes
 export const typedArrayTypes = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array, Float32Array];
 export const typedArrayTypesByteSize = [1, 1, 2, 2, 4, 4, 4];

--- a/src/graphics/graphics-device.js
+++ b/src/graphics/graphics-device.js
@@ -145,7 +145,8 @@ class GraphicsDevice extends EventHandler {
             // #endif
             tex: 0,
             vb: 0,
-            ib: 0
+            ib: 0,
+            ub: 0
         };
 
         this._shaderStats = {

--- a/src/graphics/shader-processor-options.js
+++ b/src/graphics/shader-processor-options.js
@@ -13,7 +13,7 @@ class ShaderProcessorOptions {
     /**
      * Constructs shader processing options, used to process the shader for uniform buffer support.
      *
-     * @param {UniformBufferFormat} viewUniformFormat - Format if the uniform buffer.
+     * @param {UniformBufferFormat} viewUniformFormat - Format of the uniform buffer.
      * @param {BindGroupFormat} viewBindGroupFormat - Format of the bind group.
      */
     constructor(viewUniformFormat, viewBindGroupFormat) {

--- a/src/graphics/shader-processor-options.js
+++ b/src/graphics/shader-processor-options.js
@@ -1,0 +1,54 @@
+import { BINDGROUP_VIEW } from "./constants.js";
+
+/** @typedef {import('./bind-group-format.js').BindGroupFormat} BindGroupFormat */
+/** @typedef {import('./uniform-buffer-format.js').UniformBufferFormat} UniformBufferFormat */
+
+class ShaderProcessorOptions {
+    /** @type {Array<UniformBufferFormat>}*/
+    uniformFormats = [];
+
+    /** @type {Array<BindGroupFormat>}*/
+    bindGroupFormats = [];
+
+    /**
+     * Constructs shader processing options, used to process the shader for uniform buffer support.
+     *
+     * @param {UniformBufferFormat} viewUniformFormat - Format if the uniform buffer.
+     * @param {BindGroupFormat} viewBindGroupFormat - Format of the bind group.
+     */
+    constructor(viewUniformFormat, viewBindGroupFormat) {
+
+        // construct a sparse array
+        this.uniformFormats[BINDGROUP_VIEW] = viewUniformFormat;
+        this.bindGroupFormats[BINDGROUP_VIEW] = viewBindGroupFormat;
+    }
+
+    /**
+     * Get the bind group index for the uniform name.
+     *
+     * @param {string} name - The name of the uniform.
+     * @returns {number} - Returns the index if the uniform exists, -1 otherwise.
+     */
+    has(name) {
+
+        // uniform name
+        for (let i = 0; i < this.uniformFormats.length; i++) {
+            const uniformFormat = this.uniformFormats[i];
+            if (uniformFormat.get(name)) {
+                return i;
+            }
+        }
+
+        // texture name
+        for (let i = 0; i < this.bindGroupFormats.length; i++) {
+            const groupFormat = this.bindGroupFormats[i];
+            if (groupFormat.getTextureSlot(name)) {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+}
+
+export { ShaderProcessorOptions };

--- a/src/graphics/shader-processor.js
+++ b/src/graphics/shader-processor.js
@@ -1,0 +1,256 @@
+import { Debug } from '../core/debug.js';
+import { BINDGROUP_MESH, bindGroupNames, semanticToLocation } from './constants.js';
+
+/** @typedef {import('./bind-group-format.js').BindGroupFormat} BindGroupFormat */
+/** @typedef {import('./shader-processor-options.js').ShaderProcessorOptions} ShaderProcessorOptions */
+
+// accepted keywords
+const KEYWORD = /[ \t]*(\battribute\b|\bvarying\b|\bout\b|\buniform\b)/g;
+
+// match 'attribute' and anything else till ';'
+const KEYWORD_LINE = /(\battribute\b|\bvarying\b|\bout\b|\buniform\b)[ \t]*([^;]+)([;]+)/g;
+
+// marker for a place in the source code to be replaced by code
+const MARKER = '@@@';
+
+/**
+ * Pure static class implementing processing of GLSL shaders. It allocates
+ * fixed locations for attributes, and handles conversion of uniforms to
+ * uniform buffers.
+ *
+ * @ignore
+ */
+class ShaderProcessor {
+    /**
+     * Process the shader.
+     *
+     * @param {object} shaderDefinition - The shader definition.
+     * @returns {object} - The processed shader data.
+     */
+    static run(shaderDefinition) {
+
+        /** @type {Map<string, number>} */
+        const varyingMap = new Map();
+        const vshader = ShaderProcessor.vertex(shaderDefinition.vshader, shaderDefinition, varyingMap);
+        const fshader = ShaderProcessor.fragment(shaderDefinition.fshader, varyingMap);
+
+        // TODO: we could create a uniform buffer format for the mesh here
+
+        return {
+            vshader,
+            fshader
+        };
+    }
+
+    static vertex(src, shaderDefinition, varyingMap) {
+
+        const extracted = ShaderProcessor.extract(src, true);
+        src = extracted.src;
+
+        // convert a list of attributes to a shader block with fixed locations
+        const attributesBlock = ShaderProcessor.processAttributes(extracted.attributes, shaderDefinition.attributes);
+
+        // convert a list of varyings to a shader block
+        const varyingsBlock = ShaderProcessor.processVaryings(extracted.varyings, varyingMap, true);
+
+        // convert a list of uniforms to a uniforms block
+        const uniformsBlock = ShaderProcessor.processUniforms(extracted.uniforms, shaderDefinition.processingOptions);
+
+        // insert the blocks to the source
+        return src.replace(MARKER, attributesBlock + '\n' + varyingsBlock + '\n' + uniformsBlock);
+    }
+
+    static fragment(src, varyingMap) {
+
+        const extracted = ShaderProcessor.extract(src, false);
+        src = extracted.src;
+
+        // convert a list of varyings to a shader block
+        const varyingsBlock = ShaderProcessor.processVaryings(extracted.varyings, varyingMap, false);
+
+        // convert a list of outputs to a shader block
+        const outBlock = ShaderProcessor.processOuts(extracted.outs);
+
+        // insert the blocks to the source
+        return src.replace(MARKER, varyingsBlock + '\n' + outBlock);
+    }
+
+    // Extract required information from the shader source code.
+    static extract(src, isVertex) {
+
+        // collected data
+        const attributes = [];
+        const varyings = [];
+        const outs = [];
+        const uniforms = [];
+
+        // replacement marker - mark a first replacement place, this is where code
+        // blocks are injected later
+        let replacement = `${MARKER}\n`;
+
+        // extract relevant parts of the shader
+        let match;
+        while ((match = KEYWORD.exec(src)) !== null) {
+
+            const keyword = match[1];
+            switch (keyword) {
+                case 'attribute':
+                case 'varying':
+                case 'uniform':
+                case 'out': {
+
+                    // TODO: ignore fragment shader uniforms for now
+                    if (keyword === 'uniform' && !isVertex)
+                        break;
+
+                    // read the line
+                    KEYWORD_LINE.lastIndex = match.index;
+                    const lineMatch = KEYWORD_LINE.exec(src);
+
+                    if (keyword === 'attribute') {
+                        attributes.push(lineMatch[2]);
+                    } else if (keyword === 'varying') {
+                        varyings.push(lineMatch[2]);
+                    } else if (keyword === 'out') {
+                        outs.push(lineMatch[2]);
+                    } else if (keyword === 'uniform') {
+                        uniforms.push(lineMatch[2]);
+                    }
+
+                    // cut it out
+                    src = ShaderProcessor.cutOut(src, match.index, KEYWORD_LINE.lastIndex, replacement);
+                    KEYWORD.lastIndex = match.index + replacement.length;
+
+                    // only place a single replacement marker
+                    replacement = '';
+                    break;
+                }
+            }
+        }
+
+        return {
+            src,
+            attributes,
+            varyings,
+            outs,
+            uniforms
+        };
+    }
+
+    static generateUniformBuffer(uniforms, name, set, binding) {
+        // format: layout(set = 0, binding = 0, std140) uniform UniformsView {
+        return `layout(set = ${set}, binding = ${binding}, std140) uniform ${name} {\n` +
+            uniforms +
+            '};\n';
+    }
+
+    /**
+     * @param {Array<string>} uniformLines - Lines containing uniforms.
+     * @param {ShaderProcessorOptions} processingOptions - Uniform formats.
+     * @returns {string} - The code block with the uniform buffers.
+     */
+    static processUniforms(uniformLines, processingOptions) {
+        const uniformBlocks = [];
+
+        uniformLines.forEach((line) => {
+            const words = ShaderProcessor.splitToWords(line);
+            const type = words[0];
+            const name = words[1];
+
+            const generatedLine = `    ${type} ${name};`;
+            let index = processingOptions.has(name);
+
+            // unmatched uniform goes to mesh block
+            if (index < 0) {
+                index = BINDGROUP_MESH;
+            }
+
+            // add it to appropriate block
+            if (index >= 0) {
+                if (!uniformBlocks[index]) {
+                    uniformBlocks[index] = '';
+                }
+                uniformBlocks[index] += generatedLine + '\n';
+            }
+
+        });
+
+        // TODO: this nedes to be implemented for textures
+        const binding = 0;
+
+        // add up all blocks together
+        let code = '';
+        for (let i = 0; i < uniformBlocks.length; i++) {
+            code  += ShaderProcessor.generateUniformBuffer(uniformBlocks[i], `Uniforms_${bindGroupNames[i]}`, i, binding);
+            code  += '\n';
+        }
+
+        return code;
+    }
+
+    static processVaryings(varyingLines, varyingMap, isVertex) {
+        let block = '';
+        const op = isVertex ? 'out' : 'in';
+        varyingLines.forEach((line, index) => {
+            const words = ShaderProcessor.splitToWords(line);
+            const type = words[0];
+            const name = words[1];
+
+            if (isVertex) {
+                // store it in the map
+                varyingMap.set(name, index);
+            } else {
+                Debug.assert(varyingMap.has(name), `Fragment shader requires varying ${name} but vertex shader does not generate it.`);
+                index = varyingMap.get(name);
+            }
+
+            // generates: 'layout(location = 0) in vec4 position;'
+            block += `layout(location = ${index}) ${op} ${type} ${name};\n`;
+        });
+        return block;
+    }
+
+    static processOuts(outsLines) {
+        let block = '';
+        outsLines.forEach((line, index) => {
+            // generates: 'layout(location = 0) out vec4 gl_FragColor;'
+            block += `layout(location = ${index}) out ${line};\n`;
+        });
+        return block;
+    }
+
+    static processAttributes(attributeLines, shaderDefinitionAttributes) {
+        let block = '';
+        const usedLocations = {};
+        attributeLines.forEach((line) => {
+            const words = ShaderProcessor.splitToWords(line);
+            const type = words[0];
+            const name = words[1];
+
+            if (shaderDefinitionAttributes.hasOwnProperty(name)) {
+                const semantic = shaderDefinitionAttributes[name];
+                const location = semanticToLocation[semantic];
+
+                Debug.assert(!usedLocations.hasOwnProperty(location),
+                             `WARNING: Two vertex attribues are mapped to the same location in a shader: ${usedLocations[location]} and ${semantic}`);
+                usedLocations[location] = semantic;
+
+                // generates: 'layout(location = 0) in vec4 position;'
+                block += `layout(location = ${location}) in ${type} ${name};\n`;
+            }
+        });
+        return block;
+    }
+
+    static splitToWords(line) {
+        // remove any double spaces
+        line = line.replace(/\s+/g, ' ').trim();
+        return line.split(' ');
+    }
+
+    static cutOut(src, start, end, replacement) {
+        return src.substring(0, start) + replacement + src.substring(end);
+    }
+}
+
+export { ShaderProcessor };

--- a/src/graphics/shader.js
+++ b/src/graphics/shader.js
@@ -1,5 +1,6 @@
 import { TRACEID_SHADER_ALLOC } from '../core/constants.js';
 import { Debug } from '../core/debug.js';
+import { Preprocessor } from '../core/preprocessor.js';
 
 /** @typedef {import('./graphics-device.js').GraphicsDevice} GraphicsDevice */
 
@@ -60,6 +61,13 @@ class Shader {
         this.name = definition.name || 'Untitled';
 
         Debug.trace(TRACEID_SHADER_ALLOC, `Alloc: Id ${this.id} ${this.name}`);
+
+        Debug.assert(definition.vshader, 'No vertex shader has been specified when creating a shader.');
+        Debug.assert(definition.fshader, 'No fragment shader has been specified when creating a shader.');
+
+        // pre-process shader sources
+        definition.vshader = Preprocessor.run(definition.vshader);
+        definition.fshader = Preprocessor.run(definition.fshader);
 
         this.init();
 

--- a/src/graphics/uniform-buffer-format.js
+++ b/src/graphics/uniform-buffer-format.js
@@ -102,6 +102,16 @@ class UniformBufferFormat {
         }
         this.byteSize = byteSize;
     }
+
+    /**
+     * Returns format of a uniform with specified name.
+     *
+     * @param {string} name - The name of the uniform.
+     * @returns {UniformFormat} - The format of the uniform.
+     */
+    get(name) {
+        return this.map.get(name);
+    }
 }
 
 export { UniformFormat, UniformBufferFormat };

--- a/src/graphics/uniform-buffer.js
+++ b/src/graphics/uniform-buffer.js
@@ -18,6 +18,7 @@ class UniformBuffer {
     constructor(graphicsDevice, format) {
         this.device = graphicsDevice;
         this.format = format;
+        Debug.assert(format);
 
         this.impl = graphicsDevice.createUniformBufferImpl(this);
 
@@ -27,6 +28,8 @@ class UniformBuffer {
 
         this.storage = new ArrayBuffer(format.byteSize);
         this.storageFloat32 = new Float32Array(this.storage);
+
+        graphicsDevice._vram.ub += this.format.byteSize;
 
         // TODO: register with the device and handle lost context
         // this.device.buffers.push(this);
@@ -44,8 +47,7 @@ class UniformBuffer {
 
         this.impl.destroy(device);
 
-        // TODO: track used memory
-        // device._vram.vb -= this.storage.byteLength;
+        device._vram.ub -= this.format.byteSize;
     }
 
     /**
@@ -62,6 +64,7 @@ class UniformBuffer {
         Debug.assert(uniform, `Uniform [${name}] is not part of the Uniform buffer.`);
         if (uniform) {
             const offset = uniform.offset;
+            Debug.assert(value, `Value was not set when assigning to uniform [${name}]`);
             this.storageFloat32.set(value, offset);
         }
     }

--- a/src/graphics/webgl/webgl-shader.js
+++ b/src/graphics/webgl/webgl-shader.js
@@ -1,6 +1,5 @@
 import { Debug } from '../../core/debug.js';
 import { now } from '../../core/time.js';
-import { Preprocessor } from '../../core/preprocessor.js';
 
 import { ShaderInput } from '../shader-input.js';
 import { SHADERTAG_MATERIAL, semanticToLocation } from '../constants.js';
@@ -66,13 +65,6 @@ class WebglShader {
      */
     compileAndLink(device, shader) {
         const definition = shader.definition;
-        Debug.assert(definition.vshader, 'No vertex shader has been specified when creating a shader.');
-        Debug.assert(definition.fshader, 'No fragment shader has been specified when creating a shader.');
-
-        // resolve ifdefs
-        definition.vshader = Preprocessor.run(definition.vshader);
-        definition.fshader = Preprocessor.run(definition.fshader);
-
         const glVertexShader = this._compileShaderSource(device, definition.vshader, true);
         const glFragmentShader = this._compileShaderSource(device, definition.fshader, false);
 

--- a/src/scene/batching/batch-manager.js
+++ b/src/scene/batching/batch-manager.js
@@ -943,7 +943,7 @@ class BatchManager {
         }
 
         batch2.meshInstance.castShadow = batch.meshInstance.castShadow;
-        batch2.meshInstance._shader = batch.meshInstance._shader;
+        batch2.meshInstance._shader = batch.meshInstance._shader.slice();
 
         batch2.meshInstance.castShadow = batch.meshInstance.castShadow;
 

--- a/src/scene/materials/basic-material.js
+++ b/src/scene/materials/basic-material.js
@@ -5,6 +5,7 @@ import {
     SHADERDEF_SCREENSPACE, SHADERDEF_SKIN
 } from '../constants.js';
 
+import { ShaderProcessorOptions } from '../../graphics/shader-processor-options.js';
 import { Material } from './material.js';
 
 /** @typedef {import('../../graphics/texture.js').Texture} Texture */
@@ -89,7 +90,7 @@ class BasicMaterial extends Material {
         }
     }
 
-    getShaderVariant(device, scene, objDefs, staticLightList, pass, sortedLights) {
+    getShaderVariant(device, scene, objDefs, staticLightList, pass, sortedLights, viewUniformFormat, viewBindGroupFormat) {
         const options = {
             skin: objDefs && (objDefs & SHADERDEF_SKIN) !== 0,
             screenSpace: objDefs && (objDefs & SHADERDEF_SCREENSPACE) !== 0,
@@ -103,8 +104,11 @@ class BasicMaterial extends Material {
             diffuseMap: !!this.colorMap,
             pass: pass
         };
+
+        const processingOptions = new ShaderProcessorOptions(viewUniformFormat, viewBindGroupFormat);
+
         const library = device.getProgramLibrary();
-        return library.getProgram('basic', options);
+        return library.getProgram('basic', options, processingOptions);
     }
 }
 

--- a/src/scene/materials/material.js
+++ b/src/scene/materials/material.js
@@ -537,7 +537,7 @@ class Material {
             }
         }
 
-        this.meshInstances = null;
+        this.meshInstances.length = 0;
     }
 
     /**

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -19,6 +19,7 @@ import {
 import { ShaderPass } from '../shader-pass.js';
 import { Material } from './material.js';
 import { StandardMaterialOptionsBuilder } from './standard-material-options-builder.js';
+import { ShaderProcessorOptions } from '../../graphics/shader-processor-options.js';
 
 import { standardMaterialCubemapParameters, standardMaterialTextureParameters } from './standard-material-parameters.js';
 
@@ -716,7 +717,8 @@ class StandardMaterial extends Material {
         this._processParameters('_activeLightingParams');
     }
 
-    getShaderVariant(device, scene, objDefs, staticLightList, pass, sortedLights) {
+    getShaderVariant(device, scene, objDefs, staticLightList, pass, sortedLights, viewUniformFormat, viewBindGroupFormat) {
+
         // update prefiltered lighting data
         this.updateEnvUniforms(device, scene);
 
@@ -734,8 +736,10 @@ class StandardMaterial extends Material {
             options = this.onUpdateShader(options);
         }
 
+        const processingOptions = new ShaderProcessorOptions(viewUniformFormat, viewBindGroupFormat);
+
         const library = device.getProgramLibrary();
-        const shader = library.getProgram('standard', options);
+        const shader = library.getProgram('standard', options, processingOptions);
 
         this._dirtyShader = false;
         return shader;

--- a/src/scene/particle-system/particle-emitter.js
+++ b/src/scene/particle-system/particle-emitter.js
@@ -834,7 +834,7 @@ class ParticleEmitter {
             this.normalOption = hasNormal ? 2 : 1;
         }
         // getShaderVariant is also called by pc.Scene when all shaders need to be updated
-        this.material.getShaderVariant = function () {
+        this.material.getShaderVariant = function (dev, sc, defs, staticLightList, pass, sortedLights, viewUniformFormat, viewBindGroupFormat) {
 
             // The app works like this:
             // 1. Emitter init

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -1331,11 +1331,11 @@ class ForwardRenderer {
                             const variantKey = pass + '_' + objDefs + '_' + lightHash;
                             drawCall._shader[pass] = material.variants[variantKey];
                             if (!drawCall._shader[pass]) {
-                                drawCall.updatePassShader(scene, pass, null, sortedLights);
+                                drawCall.updatePassShader(scene, pass, null, sortedLights, this.viewUniformFormat, this.viewBindGroupFormat);
                                 material.variants[variantKey] = drawCall._shader[pass];
                             }
                         } else {
-                            drawCall.updatePassShader(scene, pass, drawCall._staticLightList, sortedLights);
+                            drawCall.updatePassShader(scene, pass, drawCall._staticLightList, sortedLights, this.viewUniformFormat, this.viewBindGroupFormat);
                         }
                         drawCall._lightHash = lightHash;
                     }

--- a/src/scene/sky.js
+++ b/src/scene/sky.js
@@ -43,7 +43,7 @@ class Sky {
 
         const material = new Material();
 
-        material.getShaderVariant = function (dev, sc, defs, staticLightList, pass) {
+        material.getShaderVariant = function (dev, sc, defs, staticLightList, pass, sortedLights, viewUniformFormat, viewBindGroupFormat) {
             const library = device.getProgramLibrary();
 
             if (texture.cubemap) {
@@ -67,8 +67,6 @@ class Sky {
                 toneMapping: (pass === SHADER_FORWARDHDR ? TONEMAP_LINEAR : scene.toneMapping)
             });
         };
-
-        material.shader = material.getShaderVariant();
 
         if (texture.cubemap) {
             material.setParameter('texture_cubeMap', texture);


### PR DESCRIPTION
a progress towards https://github.com/playcanvas/engine/issues/4261

- a GLSL shader processing in order to allow WebGL shader to be transformed info a format we can transpile to WebGPU. Initially in this PR, attributes, varyings and uniforms are extracted, and transforms  into required form - which means a fixed slot allocation, as well as uniform buffers.
- ProgramLibrary has been updated to allow this processing to be executed globally on any shader, which includes shaders set by the user directly on the Material, in addition to Standard, Basic, Sky, and Particle.

Additional changes:
- small clean up to material's handling of transparency functions.

Note: The shader processing does not currently execute on WebGl, but some shader functionality refactoring is used.