### PR TITLE
Handle scenes with skybox

### DIFF
--- a/src/scene/materials/standard-material-options-builder.js
+++ b/src/scene/materials/standard-material-options-builder.js
@@ -200,6 +200,10 @@ class StandardMaterialOptionsBuilder {
             options.reflectionSource = 'envAtlas';
             options.reflectionEncoding = scene.envAtlas.encoding;
             usingSceneEnv = true;
+        } else if (stdMat.useSkybox && scene.skybox) {
+            options.reflectionSource = 'cubeMap';
+            options.reflectionEncoding = scene.skybox.encoding;
+            usingSceneEnv = true;
         } else {
             options.reflectionSource = null;
             options.reflectionEncoding = null;

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -289,11 +289,12 @@ let _params = new Set();
  * @property {number} heightMapRotation Controls the 2D rotation (in degrees) of the height map.
  * @property {number} heightMapFactor Height map multiplier. Affects the strength of the parallax
  * effect.
- * @property {Texture|null} sphereMap The spherical environment map of the material (default is
- * null). Affects reflections.
+ * @property {Texture|null} envAtlas The prefiltered environment lighting atlas (default is null).
+ * This setting overrides cubeMap and sphereMap and will replace the scene lighting environment.
  * @property {Texture|null} cubeMap The cubic environment map of the material (default is null).
- * Overrides sphereMap. Affects reflections. If cubemap is prefiltered, will also affect ambient
- * color.
+ * This setting overrides sphereMap and will replace the scene lighting environment.
+ * @property {Texture|null} sphereMap The spherical environment map of the material (default is
+ * null). This will replace the scene lighting environment.
  * @property {number} cubeMapProjection The type of projection applied to the cubeMap property:
  * - {@link CUBEPROJ_NONE}: The cube map is treated as if it is infinitely far away.
  * - {@link CUBEPROJ_BOX}: Box-projection based on a world space axis-aligned bounding box.

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -691,7 +691,7 @@ class StandardMaterial extends Material {
 
         // set overridden environment textures
         if (this.envAtlas && !isPhong) {
-            this._setParameter('texture_envAtlas', envAtlas);
+            this._setParameter('texture_envAtlas', this.envAtlas);
         } else if (this.cubeMap) {
             this._setParameter('texture_cubeMap', this.cubeMap);
         } else if (this.sphereMap) {


### PR DESCRIPTION
Object reflections were being ignored if the scene cubemap didn't have prefiltered lighting data.

This scene has a cubemap without prefiltering and a simple material with refraction enabled.

Before:
![Screenshot 2022-07-05 at 18 42 34](https://user-images.githubusercontent.com/11276292/177385901-9adf53d3-1e0b-449a-9150-ed594dab97c3.png)

After:
![Screenshot 2022-07-05 at 18 42 36](https://user-images.githubusercontent.com/11276292/177385757-382738a7-083c-4b36-94ff-35322286dfd1.png)