### PR TITLE
BasicMaterial shader name for Spector

### DIFF
--- a/src/core/tracing.js
+++ b/src/core/tracing.js
@@ -23,6 +23,7 @@ class Tracing {
      * - {@link TRACEID_RENDER_ACTION}
      * - {@link TRACEID_RENDER_TARGET_ALLOC}
      * - {@link TRACEID_TEXTURE_ALLOC}
+     * - {@link TRACEID_SHADER_ALLOC}
      *
      * @param {boolean} enabled - New enabled state for the channel.
      */

--- a/src/graphics/program-lib/programs/basic.js
+++ b/src/graphics/program-lib/programs/basic.js
@@ -9,6 +9,9 @@ import {
 
 import { begin, end, fogCode, precisionCode, skinCode } from './common.js';
 
+// Spector integration
+const shaderNameCode = '#define SHADER_NAME BasicMaterial\n';
+
 const basic = {
     generateKey: function (options) {
         let key = 'basic';
@@ -45,7 +48,7 @@ const basic = {
         }
 
         // GENERATE VERTEX SHADER
-        let code = '';
+        let code = shaderNameCode;
 
         // VERTEX SHADER DECLARATIONS
         code += shaderChunks.transformDeclVS;
@@ -100,6 +103,7 @@ const basic = {
 
         // GENERATE FRAGMENT SHADER
         code = precisionCode(device);
+        code += shaderNameCode;
 
         // FRAGMENT SHADER DECLARATIONS
         if (options.vertexColors) {


### PR DESCRIPTION
- Spector JS integration for basic material shaders
- added TRACEID_SHADER_ALLOC to jsdocs