### PR TITLE
Shader processor improvements related to bind groups format

### DIFF
--- a/src/graphics/bind-group-format.js
+++ b/src/graphics/bind-group-format.js
@@ -66,13 +66,32 @@ class BindGroupFormat {
     }
 
     /**
-     * Returns slot index for a texture slot name.
+     * Returns format of texture with specified name.
      *
      * @param {string} name - The name of the texture slot.
-     * @returns {number} - The slot index.
+     * @returns {BindTextureFormat} - The format.
      */
-    getTextureSlot(name) {
-        return this.textureFormatsMap.get(name);
+    getTexture(name) {
+        const index = this.textureFormatsMap.get(name);
+        if (index) {
+            return this.textureFormats[index];
+        }
+
+        return null;
+    }
+
+    getShaderDeclarationTextures(bindGroup) {
+        let code = '';
+        let bindIndex = this.bufferFormats.length;
+        this.textureFormats.forEach((format) => {
+
+            // TODO: suport different types of textures and samplers
+
+            code += `layout(set = ${bindGroup}, binding = ${bindIndex++}) uniform texture2D ${format.name};\n` +
+                    `layout(set = ${bindGroup}, binding = ${bindIndex++}) uniform sampler ${format.name}_sampler;\n`;
+        });
+
+        return code;
     }
 
     loseContext() {

--- a/src/graphics/constants.js
+++ b/src/graphics/constants.js
@@ -1100,6 +1100,33 @@ export const UNIFORMTYPE_VEC2ARRAY = 21;
 export const UNIFORMTYPE_VEC3ARRAY = 22;
 export const UNIFORMTYPE_VEC4ARRAY = 23;
 
+export const uniformTypeToName = [
+    'bool',
+    'int',
+    'float',
+    'vec2',
+    'vec3',
+    'vec4',
+    'ivec2',
+    'ivec3',
+    'ivec4',
+    'bec2',
+    'bec3',
+    'bec4',
+    'mat2',
+    'mat3',
+    'mat4',
+    'sampler2D',
+    'samplerCube',
+    '', // not directly handled: UNIFORMTYPE_FLOATARRAY
+    'sampler2DShadow',
+    'samplerCubeShadow',
+    'sampler3D',
+    '', // not directly handled: UNIFORMTYPE_VEC2ARRAY
+    '', // not directly handled: UNIFORMTYPE_VEC3ARRAY
+    '' // not directly handled: UNIFORMTYPE_VEC4ARRAY
+];
+
 // (bit-flags) shader stages for resource visibility on the GPU
 export const SHADERSTAGE_VERTEX = 1;
 export const SHADERSTAGE_FRAGMENT = 2;

--- a/src/graphics/shader-processor-options.js
+++ b/src/graphics/shader-processor-options.js
@@ -42,7 +42,7 @@ class ShaderProcessorOptions {
     }
 
     /**
-     * Get the bind group textur slot for the texture uniform name.
+     * Get the bind group texture slot for the texture uniform name.
      *
      * @param {string} name - The name of the texture uniform.
      * @returns {boolean} - Returns true if the texture uniform exists, false otherwise.

--- a/src/graphics/shader-processor-options.js
+++ b/src/graphics/shader-processor-options.js
@@ -27,27 +27,36 @@ class ShaderProcessorOptions {
      * Get the bind group index for the uniform name.
      *
      * @param {string} name - The name of the uniform.
-     * @returns {number} - Returns the index if the uniform exists, -1 otherwise.
+     * @returns {boolean} - Returns true if the uniform exists, false otherwise.
      */
-    has(name) {
+    hasUniform(name) {
 
-        // uniform name
         for (let i = 0; i < this.uniformFormats.length; i++) {
             const uniformFormat = this.uniformFormats[i];
             if (uniformFormat.get(name)) {
-                return i;
+                return true;
             }
         }
 
-        // texture name
+        return false;
+    }
+
+    /**
+     * Get the bind group textur slot for the texture uniform name.
+     *
+     * @param {string} name - The name of the texture uniform.
+     * @returns {boolean} - Returns true if the texture uniform exists, false otherwise.
+     */
+    hasTexture(name) {
+
         for (let i = 0; i < this.bindGroupFormats.length; i++) {
             const groupFormat = this.bindGroupFormats[i];
-            if (groupFormat.getTextureSlot(name)) {
-                return i;
+            if (groupFormat.getTexture(name)) {
+                return true;
             }
         }
 
-        return -1;
+        return false;
     }
 }
 

--- a/src/graphics/shader-processor.js
+++ b/src/graphics/shader-processor.js
@@ -39,8 +39,8 @@ class ShaderProcessor {
         const varyingMap = new Map();
 
         // extract lines of interests from both shaders
-        const vertexExtracted = ShaderProcessor.extract(shaderDefinition.vshader, true);
-        const fragmentExtracted = ShaderProcessor.extract(shaderDefinition.fshader, false);
+        const vertexExtracted = ShaderProcessor.extract(shaderDefinition.vshader);
+        const fragmentExtracted = ShaderProcessor.extract(shaderDefinition.fshader);
 
         // VS - convert a list of attributes to a shader block with fixed locations
         const attributesBlock = ShaderProcessor.processAttributes(vertexExtracted.attributes, shaderDefinition.attributes);
@@ -75,7 +75,7 @@ class ShaderProcessor {
     }
 
     // Extract required information from the shader source code.
-    static extract(src, isVertex) {
+    static extract(src) {
 
         // collected data
         const attributes = [];

--- a/src/graphics/shader-processor.js
+++ b/src/graphics/shader-processor.js
@@ -1,8 +1,16 @@
 import { Debug } from '../core/debug.js';
-import { BINDGROUP_MESH, bindGroupNames, semanticToLocation } from './constants.js';
+import {
+    BINDGROUP_MESH, uniformTypeToName, bindGroupNames, semanticToLocation,
+    SHADERSTAGE_VERTEX, SHADERSTAGE_FRAGMENT
+} from './constants.js';
+import { UniformFormat, UniformBufferFormat } from './uniform-buffer-format.js';
+import { UniformBuffer } from './uniform-buffer.js';
+import { BindGroupFormat, BindBufferFormat, BindTextureFormat } from './bind-group-format.js';
+import { BindGroup } from './bind-group.js';
 
 /** @typedef {import('./bind-group-format.js').BindGroupFormat} BindGroupFormat */
 /** @typedef {import('./shader-processor-options.js').ShaderProcessorOptions} ShaderProcessorOptions */
+/** @typedef {import('./graphics-device.js').GraphicsDevice} GraphicsDevice */
 
 // accepted keywords
 const KEYWORD = /[ \t]*(\battribute\b|\bvarying\b|\bout\b|\buniform\b)/g;
@@ -12,6 +20,10 @@ const KEYWORD_LINE = /(\battribute\b|\bvarying\b|\bout\b|\buniform\b)[ \t]*([^;]
 
 // marker for a place in the source code to be replaced by code
 const MARKER = '@@@';
+
+// const textureTypes = [
+//     'sampler2D'
+// ];
 
 /**
  * Pure static class implementing processing of GLSL shaders. It allocates
@@ -24,55 +36,49 @@ class ShaderProcessor {
     /**
      * Process the shader.
      *
+     * @param {GraphicsDevice} device - The graphics device.
      * @param {object} shaderDefinition - The shader definition.
      * @returns {object} - The processed shader data.
      */
-    static run(shaderDefinition) {
+    static run(device, shaderDefinition) {
 
         /** @type {Map<string, number>} */
         const varyingMap = new Map();
-        const vshader = ShaderProcessor.vertex(shaderDefinition.vshader, shaderDefinition, varyingMap);
-        const fshader = ShaderProcessor.fragment(shaderDefinition.fshader, varyingMap);
 
-        // TODO: we could create a uniform buffer format for the mesh here
+        // extract lines of interests from both shaders
+        const vertexExtracted = ShaderProcessor.extract(shaderDefinition.vshader, true);
+        const fragmentExtracted = ShaderProcessor.extract(shaderDefinition.fshader, false);
+
+        // VS - convert a list of attributes to a shader block with fixed locations
+        const attributesBlock = ShaderProcessor.processAttributes(vertexExtracted.attributes, shaderDefinition.attributes);
+
+        // VS - convert a list of varyings to a shader block
+        const vertexVaryingsBlock = ShaderProcessor.processVaryings(vertexExtracted.varyings, varyingMap, true);
+
+        // FS - convert a list of varyings to a shader block
+        const fragmentVaryingsBlock = ShaderProcessor.processVaryings(fragmentExtracted.varyings, varyingMap, false);
+
+        // FS - convert a list of outputs to a shader block
+        const outBlock = ShaderProcessor.processOuts(fragmentExtracted.outs);
+
+        // uniforms - merge vertex and fragment uniforms, and create shared uniform buffers
+        const uniforms = vertexExtracted.uniforms.concat(fragmentExtracted.uniforms);
+        const uniformsData = ShaderProcessor.processUniforms(device, uniforms, shaderDefinition.processingOptions);
+
+        // VS - insert the blocks to the source
+        const vBlock = attributesBlock + '\n' + vertexVaryingsBlock + '\n' + uniformsData.code;
+        const vshader = vertexExtracted.src.replace(MARKER, vBlock);
+
+        // FS - insert the blocks to the source
+        const fBlock = fragmentVaryingsBlock + '\n' + outBlock + '\n' + uniformsData.code;
+        const fshader = fragmentExtracted.src.replace(MARKER, fBlock);
 
         return {
-            vshader,
-            fshader
+            vshader: vshader,
+            fshader: fshader,
+            meshUniformBufferFormat: uniformsData.meshUniformBufferFormat,
+            meshBindGroupFormat: uniformsData.meshBindGroupFormat
         };
-    }
-
-    static vertex(src, shaderDefinition, varyingMap) {
-
-        const extracted = ShaderProcessor.extract(src, true);
-        src = extracted.src;
-
-        // convert a list of attributes to a shader block with fixed locations
-        const attributesBlock = ShaderProcessor.processAttributes(extracted.attributes, shaderDefinition.attributes);
-
-        // convert a list of varyings to a shader block
-        const varyingsBlock = ShaderProcessor.processVaryings(extracted.varyings, varyingMap, true);
-
-        // convert a list of uniforms to a uniforms block
-        const uniformsBlock = ShaderProcessor.processUniforms(extracted.uniforms, shaderDefinition.processingOptions);
-
-        // insert the blocks to the source
-        return src.replace(MARKER, attributesBlock + '\n' + varyingsBlock + '\n' + uniformsBlock);
-    }
-
-    static fragment(src, varyingMap) {
-
-        const extracted = ShaderProcessor.extract(src, false);
-        src = extracted.src;
-
-        // convert a list of varyings to a shader block
-        const varyingsBlock = ShaderProcessor.processVaryings(extracted.varyings, varyingMap, false);
-
-        // convert a list of outputs to a shader block
-        const outBlock = ShaderProcessor.processOuts(extracted.outs);
-
-        // insert the blocks to the source
-        return src.replace(MARKER, varyingsBlock + '\n' + outBlock);
     }
 
     // Extract required information from the shader source code.
@@ -98,10 +104,6 @@ class ShaderProcessor {
                 case 'varying':
                 case 'uniform':
                 case 'out': {
-
-                    // TODO: ignore fragment shader uniforms for now
-                    if (keyword === 'uniform' && !isVertex)
-                        break;
 
                     // read the line
                     KEYWORD_LINE.lastIndex = match.index;
@@ -137,55 +139,102 @@ class ShaderProcessor {
         };
     }
 
-    static generateUniformBuffer(uniforms, name, set, binding) {
-        // format: layout(set = 0, binding = 0, std140) uniform UniformsView {
-        return `layout(set = ${set}, binding = ${binding}, std140) uniform ${name} {\n` +
-            uniforms +
-            '};\n';
-    }
-
     /**
+     * @param {GraphicsDevice} device - The graphics device.
      * @param {Array<string>} uniformLines - Lines containing uniforms.
      * @param {ShaderProcessorOptions} processingOptions - Uniform formats.
-     * @returns {string} - The code block with the uniform buffers.
+     * @returns {object} - The uniform data.
      */
-    static processUniforms(uniformLines, processingOptions) {
-        const uniformBlocks = [];
+    static processUniforms(device, uniformLines, processingOptions) {
 
+        const isSampler = (uniformType) => {
+            return uniformType.indexOf('sampler') !== -1;
+        };
+
+        // split uniform lines into samplers and the rest
+        const uniformLinesSamplers = [];
+        const uniformLinesNonSamplers = [];
         uniformLines.forEach((line) => {
+            const words = ShaderProcessor.splitToWords(line);
+            const type = words[0];
+            if (isSampler(type)) {
+                uniformLinesSamplers.push(line);
+            } else {
+                uniformLinesNonSamplers.push(line);
+            }
+        });
+
+        // build mesh uniform buffer format
+        const meshUniforms = [];
+        uniformLinesNonSamplers.forEach((line) => {
             const words = ShaderProcessor.splitToWords(line);
             const type = words[0];
             const name = words[1];
 
-            const generatedLine = `    ${type} ${name};`;
-            let index = processingOptions.has(name);
-
-            // unmatched uniform goes to mesh block
-            if (index < 0) {
-                index = BINDGROUP_MESH;
+            // uniforms not already in supplied uniform buffers go to the mesh buffer
+            if (!processingOptions.hasUniform(name)) {
+                const uniformType = uniformTypeToName.indexOf(type);
+                Debug.assert(uniformType >= 0, `Uniform type ${type} is not recognized on line [${line}]`);
+                const uniform = new UniformFormat(name, uniformType);
+                meshUniforms.push(uniform);
             }
 
-            // add it to appropriate block
-            if (index >= 0) {
-                if (!uniformBlocks[index]) {
-                    uniformBlocks[index] = '';
-                }
-                uniformBlocks[index] += generatedLine + '\n';
-            }
+            // validate types in else
 
         });
+        const meshUniformBufferFormat = meshUniforms.length ? new UniformBufferFormat(meshUniforms) : null;
 
-        // TODO: this nedes to be implemented for textures
-        const binding = 0;
-
-        // add up all blocks together
-        let code = '';
-        for (let i = 0; i < uniformBlocks.length; i++) {
-            code  += ShaderProcessor.generateUniformBuffer(uniformBlocks[i], `Uniforms_${bindGroupNames[i]}`, i, binding);
-            code  += '\n';
+        // build mesh bind group format - start with uniform buffer
+        const bufferFormats = [];
+        if (meshUniformBufferFormat) {
+            // TODO: we could optimize visibility to only stages that use any of the data
+            bufferFormats.push(new BindBufferFormat('mesh', SHADERSTAGE_VERTEX | SHADERSTAGE_FRAGMENT));
         }
 
-        return code;
+        // add textures uniforms
+        const textureFormats = [];
+        uniformLinesSamplers.forEach((line) => {
+            const words = ShaderProcessor.splitToWords(line);
+            const name = words[1];
+
+            // unmached texture uniforms go to mesh block
+            if (!processingOptions.hasTexture(name)) {
+
+                // TODO: we could optimize visibility to only stages that use any of the data
+                textureFormats.push(new BindTextureFormat(name, SHADERSTAGE_VERTEX | SHADERSTAGE_FRAGMENT));
+            }
+
+            // validate types in else
+
+        });
+        const meshBindGroupFormat = new BindGroupFormat(device, bufferFormats, textureFormats);
+
+        // generate code for uniform buffers
+        let code = '';
+        processingOptions.uniformFormats.forEach((format, bindGroupIndex) => {
+            if (format) {
+                code += format.getShaderDeclaration(bindGroupIndex, 0);
+            }
+        });
+
+        // and also for generated mesh format, which is at the slot 0 of the bind group
+        code += meshUniformBufferFormat.getShaderDeclaration(BINDGROUP_MESH, 0);
+
+        // generate code for textures
+        processingOptions.bindGroupFormats.forEach((format, bindGroupIndex) => {
+            if (format) {
+                code += format.getShaderDeclarationTextures(bindGroupIndex);
+            }
+        });
+
+        // and also for generated mesh format
+        code += meshBindGroupFormat.getShaderDeclarationTextures(BINDGROUP_MESH);
+
+        return {
+            code,
+            meshUniformBufferFormat,
+            meshBindGroupFormat
+        };
     }
 
     static processVaryings(varyingLines, varyingMap, isVertex) {

--- a/src/graphics/shader-processor.js
+++ b/src/graphics/shader-processor.js
@@ -133,10 +133,18 @@ class ShaderProcessor {
     }
 
     /**
+     * Process the lines with uniforms. The function receives the lines containing all uniforms,
+     * both numerical as well as textures/samplers. The function also receives the format of uniform
+     * buffers (numerical) and bind groups (textures) for view and material level. All uniforms that
+     * match any of those are ignored, as those would be supplied by view / material level buffers.
+     * All leftover uniforms create uniform buffer and bind group for the mesh itself, containing
+     * uniforms that change on the level of the mesh.
+     *
      * @param {GraphicsDevice} device - The graphics device.
      * @param {Array<string>} uniformLines - Lines containing uniforms.
      * @param {ShaderProcessorOptions} processingOptions - Uniform formats.
-     * @returns {object} - The uniform data.
+     * @returns {object} - The uniform data. Returns a shader code block containing uniforms, to be
+     * inserted into the shader, as well as generated uniform format structures for the mesh level.
      */
     static processUniforms(device, uniformLines, processingOptions) {
 

--- a/src/graphics/shader-processor.js
+++ b/src/graphics/shader-processor.js
@@ -6,7 +6,6 @@ import {
 import { UniformFormat, UniformBufferFormat } from './uniform-buffer-format.js';
 import { BindGroupFormat, BindBufferFormat, BindTextureFormat } from './bind-group-format.js';
 
-/** @typedef {import('./bind-group-format.js').BindGroupFormat} BindGroupFormat */
 /** @typedef {import('./shader-processor-options.js').ShaderProcessorOptions} ShaderProcessorOptions */
 /** @typedef {import('./graphics-device.js').GraphicsDevice} GraphicsDevice */
 

--- a/src/graphics/shader-processor.js
+++ b/src/graphics/shader-processor.js
@@ -1,12 +1,10 @@
 import { Debug } from '../core/debug.js';
 import {
-    BINDGROUP_MESH, uniformTypeToName, bindGroupNames, semanticToLocation,
+    BINDGROUP_MESH, uniformTypeToName, semanticToLocation,
     SHADERSTAGE_VERTEX, SHADERSTAGE_FRAGMENT
 } from './constants.js';
 import { UniformFormat, UniformBufferFormat } from './uniform-buffer-format.js';
-import { UniformBuffer } from './uniform-buffer.js';
 import { BindGroupFormat, BindBufferFormat, BindTextureFormat } from './bind-group-format.js';
-import { BindGroup } from './bind-group.js';
 
 /** @typedef {import('./bind-group-format.js').BindGroupFormat} BindGroupFormat */
 /** @typedef {import('./shader-processor-options.js').ShaderProcessorOptions} ShaderProcessorOptions */

--- a/src/graphics/shader-processor.js
+++ b/src/graphics/shader-processor.js
@@ -18,10 +18,6 @@ const KEYWORD_LINE = /(\battribute\b|\bvarying\b|\bout\b|\buniform\b)[ \t]*([^;]
 // marker for a place in the source code to be replaced by code
 const MARKER = '@@@';
 
-// const textureTypes = [
-//     'sampler2D'
-// ];
-
 /**
  * Pure static class implementing processing of GLSL shaders. It allocates
  * fixed locations for attributes, and handles conversion of uniforms to

--- a/src/graphics/uniform-buffer-format.js
+++ b/src/graphics/uniform-buffer-format.js
@@ -1,5 +1,6 @@
 import { Debug } from '../core/debug.js';
 import {
+    uniformTypeToName, bindGroupNames,
     UNIFORMTYPE_BOOL, UNIFORMTYPE_INT, UNIFORMTYPE_FLOAT, UNIFORMTYPE_VEC2, UNIFORMTYPE_VEC3,
     UNIFORMTYPE_VEC4, UNIFORMTYPE_IVEC2, UNIFORMTYPE_IVEC3, UNIFORMTYPE_IVEC4, UNIFORMTYPE_BVEC2,
     UNIFORMTYPE_BVEC3, UNIFORMTYPE_BVEC4, UNIFORMTYPE_MAT4
@@ -111,6 +112,20 @@ class UniformBufferFormat {
      */
     get(name) {
         return this.map.get(name);
+    }
+
+    getShaderDeclaration(bindGroup, bindIndex) {
+
+        const name = bindGroupNames[bindGroup];
+        let code = `layout(set = ${bindGroup}, binding = ${bindIndex}, std140) uniform ub_${name} {\n`;
+
+        this.uniforms.forEach((uniform) => {
+            const typeString = uniformTypeToName[uniform.type];
+            Debug.assert(typeString.length > 0, `Uniform type ${uniform.type} is not handled.`);
+            code += `    ${typeString} ${uniform.name};\n`;
+        });
+
+        return code + '};\n';
     }
 }
 


### PR DESCRIPTION
- bind group format and bind uniform format classes can now generate relevant shader code blocks
- these are used to generate view uniform code blocks
- shader processor generates new 'mesh' bind group format instances for uniforms not used by other buffers, and generates code from those too

Note: This does not execute on WebGl (currently)