### PR TITLE
[Fix] Fixing null access in the bloom post effect

### DIFF
--- a/scripts/posteffects/posteffect-bloom.js
+++ b/scripts/posteffects/posteffect-bloom.js
@@ -171,6 +171,8 @@ function BloomEffect(graphicsDevice) {
         fshader: bloomCombineFrag
     });
 
+    this.targets = [];
+
     // Effect defaults
     this.bloomThreshold = 0.25;
     this.blurAmount = 4;


### PR DESCRIPTION
the targets variable was never initialized to an array