### PR TITLE
Some JSDoc fixes for src/graphics and src/script

### DIFF
--- a/src/graphics/env-lighting.js
+++ b/src/graphics/env-lighting.js
@@ -93,7 +93,7 @@ class EnvLighting {
      * if target isn't specified. Defaults to 128.
      * @returns {Texture} The resulting cubemap.
      */
-    static generateLightingSource(source, options = null) {
+    static generateLightingSource(source, options) {
         const device = source.device;
 
         DebugGraphics.pushGpuMarker(device, "genLightingSource");
@@ -138,7 +138,7 @@ class EnvLighting {
      * lighting. Defaults to 2048.
      * @returns {Texture} The resulting atlas
      */
-    static generateAtlas(source, options = null) {
+    static generateAtlas(source, options) {
         const device = source.device;
         const format = lightingPixelFormat(device);
 
@@ -216,7 +216,7 @@ class EnvLighting {
      * Generate the environment lighting atlas from prefiltered cubemap data.
      *
      * @param {Texture[]} sources - Array of 6 prefiltered textures.
-     * @param {object} options - The options object
+     * @param {object} [options] - The options object
      * @param {Texture} [options.target] - The target texture. If one is not provided then a
      * new texture will be created and returned.
      * @param {number} [options.size] - Size of the target texture to create. Only used if
@@ -227,7 +227,7 @@ class EnvLighting {
      * lighting. Default is 2048.
      * @returns {Texture} The resulting atlas texture.
      */
-    static generatePrefilteredAtlas(sources, options = null) {
+    static generatePrefilteredAtlas(sources, options) {
         const device = sources[0].device;
         const format = lightingPixelFormat(device);
 

--- a/src/graphics/texture.js
+++ b/src/graphics/texture.js
@@ -121,6 +121,7 @@ class Texture {
      * - {@link FUNC_NOTEQUAL}
      *
      * Defaults to {@link FUNC_LESS}.
+     * @param {Uint8Array[]} [options.levels] - Array of Uint8Array.
      * @example
      * // Create a 8x8x24-bit texture
      * var texture = new pc.Texture(graphicsDevice, {

--- a/src/graphics/webgl/webgl-graphics-device.js
+++ b/src/graphics/webgl/webgl-graphics-device.js
@@ -217,12 +217,12 @@ class WebglGraphicsDevice extends GraphicsDevice {
      *
      * @param {boolean} [options.failIfMajorPerformanceCaveat=false] - Boolean that indicates if a
      * context will be created if the system performance is low or if no hardware GPU is available.
-     * @param {boolean} [options.preferWebGl2=true] - Boolean that indicates if a
-     * WebGl2 context should be preferred.
+     * @param {boolean} [options.preferWebGl2=true] - Boolean that indicates if a WebGl2 context
+     * should be preferred.
      * @param {boolean} [options.desynchronized=false] - Boolean that hints the user agent to
      * reduce the latency by desynchronizing the canvas paint cycle from the event loop.
-     * @param {boolean} [options.xrCompatible] - Boolean that hints to the user agent to
-     * use a compatible graphics adapter for an immersive XR device.
+     * @param {boolean} [options.xrCompatible] - Boolean that hints to the user agent to use a
+     * compatible graphics adapter for an immersive XR device.
      */
     constructor(canvas, options = {}) {
         super(canvas);

--- a/src/graphics/webgl/webgl-graphics-device.js
+++ b/src/graphics/webgl/webgl-graphics-device.js
@@ -206,7 +206,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
      * @param {boolean} [options.preserveDrawingBuffer=false] - If the value is true the buffers
      * will not be cleared and will preserve their values until cleared or overwritten by the
      * author.
-     * @param {'default'|'high-performance'|'low-power'} [options.powerPreference ='default'] - A
+     * @param {'default'|'high-performance'|'low-power'} [options.powerPreference='default'] - A
      * hint to the user agent indicating what configuration of GPU is suitable for the WebGL
      * context. Possible values are:
      *
@@ -217,8 +217,12 @@ class WebglGraphicsDevice extends GraphicsDevice {
      *
      * @param {boolean} [options.failIfMajorPerformanceCaveat=false] - Boolean that indicates if a
      * context will be created if the system performance is low or if no hardware GPU is available.
+     * @param {boolean} [options.preferWebGl2=true] - Boolean that indicates if a
+     * WebGl2 context should be preferred.
      * @param {boolean} [options.desynchronized=false] - Boolean that hints the user agent to
      * reduce the latency by desynchronizing the canvas paint cycle from the event loop.
+     * @param {boolean} [options.xrCompatible] - Boolean that hints to the user agent to
+     * use a compatible graphics adapter for an immersive XR device.
      */
     constructor(canvas, options = {}) {
         super(canvas);

--- a/src/script/script-type.js
+++ b/src/script/script-type.js
@@ -307,7 +307,7 @@ class ScriptType extends EventHandler {
     }
 
     /**
-     * @param {boolean} force - Set to true to force initialization of the attributes.
+     * @param {boolean} [force] - Set to true to force initialization of the attributes.
      * @private
      */
     __initializeAttributes(force) {


### PR DESCRIPTION
A few more JSDoc fixes, detected by automatically inserting type assertions using AST rewritting + manual testing.

1) `[options]` means either `undefined` or any object, not `null`.
2) Info for `xrCompatible`: https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/getContext

(if there are any questions, I would like to discuss it)

If this is fixed, this can also be fixed (after updated `playcanvas.d.ts` is released on `npm`):

https://github.com/playcanvas/model-viewer/blob/f564de56d751c1175d33287f3a09d00db93e9ba3/src/viewer.ts#L428-L429

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
