### PR TITLE
Fix specular fade not working properly.

### DIFF
--- a/src/graphics/program-lib/programs/lit-shader.js
+++ b/src/graphics/program-lib/programs/lit-shader.js
@@ -1322,17 +1322,17 @@ class LitShader {
             }
         }
 
+        if (options.useSpecularityFactor) {
+            code += "    dSpecularLight *= dSpecularityFactor;\n";
+        }
+        
         if (options.opacityFadesSpecular === false) {
             if (options.blendType === BLEND_NORMAL || options.blendType === BLEND_PREMULTIPLIED) {
-                code += "float specLum = dot((dSpecularLight + dReflection.rgb * dReflection.a) * dSpecularity, vec3( 0.2126, 0.7152, 0.0722 ));\n";
+                code += "float specLum = dot((dSpecularLight + dReflection.rgb * dReflection.a), vec3( 0.2126, 0.7152, 0.0722 ));\n";
                 code += "#ifdef CLEARCOAT\n specLum += dot(ccSpecularLight * ccSpecularity + ccReflection.rgb * ccReflection.a * ccSpecularity, vec3( 0.2126, 0.7152, 0.0722 ));\n#endif\n";
                 code += "dAlpha = clamp(dAlpha + gammaCorrectInput(specLum), 0.0, 1.0);\n";
             }
             code += "dAlpha *= material_alphaFade;\n";
-        }
-
-        if (options.useSpecularityFactor) {
-            code += "    dSpecularLight *= dSpecularityFactor;\n";
         }
 
         code += chunks.endPS;


### PR DESCRIPTION
### Description

Specular fade didn't work properly with the latest specular PR. 

Previously:
![image](https://user-images.githubusercontent.com/107400752/178251653-34ad8b47-4b6a-4d3c-a322-1a4674925984.png)

After fix:
![image](https://user-images.githubusercontent.com/107400752/178251765-3b754ca5-db56-4ed3-a7e9-7b3d6dc180ad.png)
