### PR TITLE
Don’t log version/revision message if those are not valid

### DIFF
--- a/src/framework/app-base.js
+++ b/src/framework/app-base.js
@@ -162,9 +162,9 @@ class AppBase extends EventHandler {
     constructor(canvas) {
         super();
 
-        // #if _DEBUG
-        console.log(`Powered by PlayCanvas ${version} ${revision}`);
-        // #endif
+        if (version.indexOf('$') < 0) {
+            Debug.log(`Powered by PlayCanvas ${version} ${revision}`);
+        }
 
         // Store application instance
         AppBase._applications[canvas.id] = this;

--- a/src/framework/app-base.js
+++ b/src/framework/app-base.js
@@ -163,7 +163,7 @@ class AppBase extends EventHandler {
         super();
 
         // #if _DEBUG
-        if (version.indexOf('$') < 0) {
+        if (version?.indexOf('$') < 0) {
             Debug.log(`Powered by PlayCanvas ${version} ${revision}`);
         }
         // #endif

--- a/src/framework/app-base.js
+++ b/src/framework/app-base.js
@@ -162,9 +162,11 @@ class AppBase extends EventHandler {
     constructor(canvas) {
         super();
 
+        // #if _DEBUG
         if (version.indexOf('$') < 0) {
             Debug.log(`Powered by PlayCanvas ${version} ${revision}`);
         }
+        // #endif
 
         // Store application instance
         AppBase._applications[canvas.id] = this;


### PR DESCRIPTION
Fixes https://github.com/playcanvas/engine/issues/4420
- don't log it if the version contains '$' which is only in the default value.