### PR TITLE
[Fix] Fix to script preloading

### DIFF
--- a/src/framework/app-base.js
+++ b/src/framework/app-base.js
@@ -853,7 +853,7 @@ class AppBase extends EventHandler {
                 let scriptUrl = scripts[i];
                 // support absolute URLs (for now)
                 if (!regex.test(scriptUrl.toLowerCase()) && this._scriptPrefix)
-                    scriptUrl = path.join(self._scriptPrefix, scripts[i]);
+                    scriptUrl = path.join(this._scriptPrefix, scripts[i]);
 
                 this.loader.load(scriptUrl, 'script', onLoad);
             }


### PR DESCRIPTION
FIx this for some / many projects, due to 'self' variable being undefined, and should be 'this' instead.
It's possible the code only hits this path for legacy scripts, as that's the repro project.

<img width="436" alt="Screenshot 2022-07-11 at 16 07 21" src="https://user-images.githubusercontent.com/59932779/178296225-a2adf108-efc7-4f03-b944-9f75a3ffe984.png">

