### PR TITLE
Reset default specular to 1.

### DIFF
--- a/examples/src/examples/graphics/material-translucent-specular.tsx
+++ b/examples/src/examples/graphics/material-translucent-specular.tsx
@@ -54,6 +54,7 @@ class MaterialTranslucentSpecularExample {
             const createSphere = function (x: number, y: number, z: number) {
                 const material = new pc.StandardMaterial();
                 material.diffuse = new pc.Color(0.7, 0.7, 0.7);
+                material.specular = new pc.Color(1, 1, 1);
                 material.metalness = 0.0;
                 material.shininess = ((z) / (NUM_SPHERES_Z - 1) * 50) + 50;
                 material.useMetalness = true;

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -1010,7 +1010,7 @@ function _defineFlag(name, defaultValue) {
 function _defineMaterialProps() {
     _defineColor('ambient', new Color(0.7, 0.7, 0.7));
     _defineColor('diffuse', new Color(1, 1, 1));
-    _defineColor('specular', new Color(1, 1, 1));
+    _defineColor('specular', new Color(0, 0, 0));
     _defineColor('emissive', new Color(0, 0, 0));
     _defineFloat('emissiveIntensity', 1);
     _defineFloat('specularityFactor', 1);

--- a/test/scene/materials/standard-material.test.mjs
+++ b/test/scene/materials/standard-material.test.mjs
@@ -231,9 +231,9 @@ describe('StandardMaterial', function () {
         expect(material.shininess).to.equal(25);
 
         expect(material.specular).to.be.instanceof(Color);
-        expect(material.specular.r).to.equal(1);
-        expect(material.specular.g).to.equal(1);
-        expect(material.specular.b).to.equal(1);
+        expect(material.specular.r).to.equal(0);
+        expect(material.specular.g).to.equal(0);
+        expect(material.specular.b).to.equal(0);
         expect(material.specularMap).to.be.null;
         expect(material.specularMapChannel).to.equal('rgb');
         expect(material.specularMapOffset).to.be.an.instanceof(Vec2);


### PR DESCRIPTION
### Description

Relates to: #4386 & #4419. 

This PR reverts default specular to 0. For materials created in code using metalness, there might be a loss of specular highlights due to specular tint having an effect even on metalness materials. To fix this, on your material, set the specular like so:

``` material.specular = new pc.Color(1, 1, 1); ```

