### PR TITLE
Add switch to enable/disable specular color with metalness workflow

### DIFF
--- a/src/framework/app-base.js
+++ b/src/framework/app-base.js
@@ -853,7 +853,7 @@ class AppBase extends EventHandler {
                 let scriptUrl = scripts[i];
                 // support absolute URLs (for now)
                 if (!regex.test(scriptUrl.toLowerCase()) && this._scriptPrefix)
-                    scriptUrl = path.join(self._scriptPrefix, scripts[i]);
+                    scriptUrl = path.join(this._scriptPrefix, scripts[i]);
 
                 this.loader.load(scriptUrl, 'script', onLoad);
             }

--- a/src/graphics/program-lib/programs/standard.js
+++ b/src/graphics/program-lib/programs/standard.js
@@ -320,7 +320,11 @@ const standard = {
                     code.append(this._addMap("specularityFactor", "specularityFactorPS", options, litShader.chunks));
                     func.append("getSpecularityFactor();");
                 }
-                code.append(this._addMap("specular", "specularPS", options, litShader.chunks));
+                if (options.useSpecularColor) {
+                    code.append(this._addMap("specular", "specularPS", options, litShader.chunks));
+                } else {
+                    code.append("void getSpecularity() { dSpecularity = vec3(1); }");
+                }
                 code.append(this._addMap("gloss", "glossPS", options, litShader.chunks));
                 func.append("getGlossiness();");
                 func.append("getSpecularity();");

--- a/src/resources/parser/glb-parser.js
+++ b/src/resources/parser/glb-parser.js
@@ -1103,6 +1103,7 @@ const extensionUnlit = function (data, material, textures) {
 
 const extensionSpecular = function (data, material, textures) {
     let color;
+    material.useSpecularF0 = true;
     if (data.hasOwnProperty('specularColorTexture')) {
         material.specularMap = textures[data.specularColorTexture.index];
         material.specularMapChannel = 'rgb';

--- a/src/resources/parser/glb-parser.js
+++ b/src/resources/parser/glb-parser.js
@@ -1103,7 +1103,7 @@ const extensionUnlit = function (data, material, textures) {
 
 const extensionSpecular = function (data, material, textures) {
     let color;
-    material.useMetalnessSpecularTint = true;
+    material.useMetalnessSpecularColor = true;
     if (data.hasOwnProperty('specularColorTexture')) {
         material.specularMap = textures[data.specularColorTexture.index];
         material.specularMapChannel = 'rgb';

--- a/src/resources/parser/glb-parser.js
+++ b/src/resources/parser/glb-parser.js
@@ -1103,7 +1103,7 @@ const extensionUnlit = function (data, material, textures) {
 
 const extensionSpecular = function (data, material, textures) {
     let color;
-    material.useSpecularF0 = true;
+    material.useMetalnessSpecularTint = true;
     if (data.hasOwnProperty('specularColorTexture')) {
         material.specularMap = textures[data.specularColorTexture.index];
         material.specularMapChannel = 'rgb';

--- a/src/scene/materials/standard-material-options-builder.js
+++ b/src/scene/materials/standard-material-options-builder.js
@@ -122,7 +122,8 @@ class StandardMaterialOptionsBuilder {
                             stdMat.enableGGXSpecular ||
                             (stdMat.clearCoat > 0));
 
-        const specularTint = useSpecular && (!stdMat.useMetalness || stdMat.useMetalnessSpecularTint) &&
+        const useSpecularColor = (!stdMat.useMetalness || stdMat.useMetalnessSpecularColor);
+        const specularTint = useSpecular && useSpecularColor &&
                              (stdMat.specularTint || (!stdMat.specularMap && !stdMat.specularVertexColor)) &&
                              notWhite(stdMat.specular);
 
@@ -140,6 +141,7 @@ class StandardMaterialOptionsBuilder {
         options.specularTint = specularTint ? 2 : 0;
         options.specularityFactorTint = specularityFactorTint ? 1 : 0;
         options.useSpecularityFactor = specularityFactorTint || !!stdMat.specularityFactorMap;
+        options.useSpecularColor = useSpecularColor;
         options.metalnessTint = (stdMat.useMetalness && stdMat.metalness < 1) ? 1 : 0;
         options.glossTint = 1;
         options.emissiveTint = (emissiveTintColor ? 2 : 0) + (emissiveTintIntensity ? 1 : 0);

--- a/src/scene/materials/standard-material-options-builder.js
+++ b/src/scene/materials/standard-material-options-builder.js
@@ -122,7 +122,7 @@ class StandardMaterialOptionsBuilder {
                             stdMat.enableGGXSpecular ||
                             (stdMat.clearCoat > 0));
 
-        const specularTint = useSpecular && (stdMat.useMetalness === stdMat.useMetalnessSpecularTint) &&
+        const specularTint = useSpecular && (!stdMat.useMetalness || stdMat.useMetalnessSpecularTint) &&
                              (stdMat.specularTint || (!stdMat.specularMap && !stdMat.specularVertexColor)) &&
                              notWhite(stdMat.specular);
 

--- a/src/scene/materials/standard-material-options-builder.js
+++ b/src/scene/materials/standard-material-options-builder.js
@@ -122,11 +122,11 @@ class StandardMaterialOptionsBuilder {
                             stdMat.enableGGXSpecular ||
                             (stdMat.clearCoat > 0));
 
-        const specularTint = useSpecular && (stdMat.useMetalness === stdMat.useSpecularF0) &&
+        const specularTint = useSpecular && (stdMat.useMetalness === stdMat.useMetalnessSpecularTint) &&
                              (stdMat.specularTint || (!stdMat.specularMap && !stdMat.specularVertexColor)) &&
                              notWhite(stdMat.specular);
 
-        const specularityFactorTint = useSpecular && stdMat.useMetalness && stdMat.useSpecularF0 && (stdMat.specularityFactor < 1 && !stdMat.specularityFactorMap);
+        const specularityFactorTint = useSpecular && stdMat.useMetalness && stdMat.useMetalnessSpecularTint && (stdMat.specularityFactor < 1 && !stdMat.specularityFactorMap);
 
         const emissiveTintColor = !stdMat.emissiveMap || (notWhite(stdMat.emissive) && stdMat.emissiveTint);
         const emissiveTintIntensity = (stdMat.emissiveIntensity !== 1);

--- a/src/scene/materials/standard-material-options-builder.js
+++ b/src/scene/materials/standard-material-options-builder.js
@@ -122,11 +122,11 @@ class StandardMaterialOptionsBuilder {
                             stdMat.enableGGXSpecular ||
                             (stdMat.clearCoat > 0));
 
-        const specularTint = useSpecular &&
+        const specularTint = useSpecular && (stdMat.useMetalness == stdMat.useSpecularF0) &&
                              (stdMat.specularTint || (!stdMat.specularMap && !stdMat.specularVertexColor)) &&
                              notWhite(stdMat.specular);
 
-        const specularityFactorTint = useSpecular && stdMat.useMetalness && (stdMat.specularityFactor < 1 && !stdMat.specularityFactorMap);
+        const specularityFactorTint = useSpecular && stdMat.useMetalness && stdMat.useSpecularF0 && (stdMat.specularityFactor < 1 && !stdMat.specularityFactorMap);
 
         const emissiveTintColor = !stdMat.emissiveMap || (notWhite(stdMat.emissive) && stdMat.emissiveTint);
         const emissiveTintIntensity = (stdMat.emissiveIntensity !== 1);

--- a/src/scene/materials/standard-material-options-builder.js
+++ b/src/scene/materials/standard-material-options-builder.js
@@ -126,7 +126,7 @@ class StandardMaterialOptionsBuilder {
                              (stdMat.specularTint || (!stdMat.specularMap && !stdMat.specularVertexColor)) &&
                              notWhite(stdMat.specular);
 
-        const specularityFactorTint = useSpecular && stdMat.useMetalness && stdMat.useMetalnessSpecularTint && (stdMat.specularityFactor < 1 && !stdMat.specularityFactorMap);
+        const specularityFactorTint = useSpecular && stdMat.useMetalness && (stdMat.specularityFactor < 1 && !stdMat.specularityFactorMap);
 
         const emissiveTintColor = !stdMat.emissiveMap || (notWhite(stdMat.emissive) && stdMat.emissiveTint);
         const emissiveTintIntensity = (stdMat.emissiveIntensity !== 1);

--- a/src/scene/materials/standard-material-options-builder.js
+++ b/src/scene/materials/standard-material-options-builder.js
@@ -122,7 +122,7 @@ class StandardMaterialOptionsBuilder {
                             stdMat.enableGGXSpecular ||
                             (stdMat.clearCoat > 0));
 
-        const specularTint = useSpecular && (stdMat.useMetalness == stdMat.useSpecularF0) &&
+        const specularTint = useSpecular && (stdMat.useMetalness === stdMat.useSpecularF0) &&
                              (stdMat.specularTint || (!stdMat.specularMap && !stdMat.specularVertexColor)) &&
                              notWhite(stdMat.specular);
 

--- a/src/scene/materials/standard-material-options-builder.js
+++ b/src/scene/materials/standard-material-options-builder.js
@@ -123,7 +123,7 @@ class StandardMaterialOptionsBuilder {
                             (stdMat.clearCoat > 0));
 
         const useSpecularColor = (!stdMat.useMetalness || stdMat.useMetalnessSpecularColor);
-        const specularTint = useSpecular && useSpecularColor &&
+        const specularTint = useSpecular &&
                              (stdMat.specularTint || (!stdMat.specularMap && !stdMat.specularVertexColor)) &&
                              notWhite(stdMat.specular);
 

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -1077,7 +1077,7 @@ function _defineMaterialProps() {
     _defineFlag('emissiveTint', false);
     _defineFlag('fastTbn', false);
     _defineFlag('useMetalness', false);
-    _defineFlag('useMetalnessSpecularTint', false);
+    _defineFlag('useMetalnessSpecularColor', false);
     _defineFlag('enableGGXSpecular', false);
     _defineFlag('occludeDirect', false);
     _defineFlag('normalizeNormalMap', true);

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -181,7 +181,7 @@ let _params = new Set();
  * alternative to specular color to save space. With metaless == 0, the pixel is assumed to be
  * dielectric, and diffuse color is used as normal. With metaless == 1, the pixel is fully
  * metallic, and diffuse color is used as specular color instead.
- * @property {boolean} useMetalnessSpecularTint When metalness is enabled, use the specular map to apply color tint to specular reflections
+ * @property {boolean} useMetalnessSpecularColor When metalness is enabled, use the specular map to apply color tint to specular reflections
  * at direct angles.
  * @property {number} metalness Defines how much the surface is metallic. From 0 (dielectric) to 1
  * (metal).

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -181,6 +181,8 @@ let _params = new Set();
  * alternative to specular color to save space. With metaless == 0, the pixel is assumed to be
  * dielectric, and diffuse color is used as normal. With metaless == 1, the pixel is fully
  * metallic, and diffuse color is used as specular color instead.
+ * @property {boolean} useSpecularF0 Use specular map to apply color tint to specular reflections
+ * at direct angles.
  * @property {number} metalness Defines how much the surface is metallic. From 0 (dielectric) to 1
  * (metal).
  * @property {Texture|null} metalnessMap Monochrome metalness map (default is null).
@@ -1075,6 +1077,7 @@ function _defineMaterialProps() {
     _defineFlag('emissiveTint', false);
     _defineFlag('fastTbn', false);
     _defineFlag('useMetalness', false);
+    _defineFlag('useSpecularF0', false);
     _defineFlag('enableGGXSpecular', false);
     _defineFlag('occludeDirect', false);
     _defineFlag('normalizeNormalMap', true);

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -181,7 +181,7 @@ let _params = new Set();
  * alternative to specular color to save space. With metaless == 0, the pixel is assumed to be
  * dielectric, and diffuse color is used as normal. With metaless == 1, the pixel is fully
  * metallic, and diffuse color is used as specular color instead.
- * @property {boolean} useSpecularF0 Use specular map to apply color tint to specular reflections
+ * @property {boolean} useMetalnessSpecularTint Use specular map to apply color tint to specular reflections
  * at direct angles.
  * @property {number} metalness Defines how much the surface is metallic. From 0 (dielectric) to 1
  * (metal).
@@ -1077,7 +1077,7 @@ function _defineMaterialProps() {
     _defineFlag('emissiveTint', false);
     _defineFlag('fastTbn', false);
     _defineFlag('useMetalness', false);
-    _defineFlag('useSpecularF0', false);
+    _defineFlag('useMetalnessSpecularTint', false);
     _defineFlag('enableGGXSpecular', false);
     _defineFlag('occludeDirect', false);
     _defineFlag('normalizeNormalMap', true);


### PR DESCRIPTION
### Description

The metalness workflow recently exposed specular color modulation for F0 reflections, however it caused some issues related to default specular color. This PR addresses this issue by adding a switch which explicitly enables specular tinting with metalness, forcing users who want this feature to first turn the flag on, and then assign specular color values.

Relates to #4423 #4386 and #4419.