### PR TITLE
Support for KHR_materials_ior

### DIFF
--- a/src/graphics/program-lib/chunks/chunks.js
+++ b/src/graphics/program-lib/chunks/chunks.js
@@ -64,6 +64,7 @@ import gamma2_2PS from './common/frag/gamma2_2.js';
 import gles3PS from './common/frag/gles3.js';
 import gles3VS from './common/vert/gles3.js';
 import glossPS from './standard/frag/gloss.js';
+import iorPS from './standard/frag/ior.js';
 import instancingVS from './lit/vert/instancing.js';
 import lightDiffuseLambertPS from './lit/frag/lightDiffuseLambert.js';
 import lightDirPointPS from './lit/frag/lightDirPoint.js';
@@ -263,6 +264,7 @@ const shaderChunks = {
     gles3PS,
     gles3VS,
     glossPS,
+    iorPS,
     instancingVS,
     lightDiffuseLambertPS,
     lightDirPointPS,

--- a/src/graphics/program-lib/chunks/lit/frag/metalnessModulate.js
+++ b/src/graphics/program-lib/chunks/lit/frag/metalnessModulate.js
@@ -1,6 +1,9 @@
 export default /* glsl */`
-void getMetalnessModulate(float ior) {
-    vec3 dielectricF0 = ior * dSpecularity;
+
+uniform float material_f0;
+
+void getMetalnessModulate() {
+    vec3 dielectricF0 = material_f0 * dSpecularity;
     dSpecularity = mix(dielectricF0, dAlbedo, dMetalness);
     dAlbedo *= 1.0 - dMetalness;
 }

--- a/src/graphics/program-lib/chunks/lit/frag/refraction.js
+++ b/src/graphics/program-lib/chunks/lit/frag/refraction.js
@@ -14,7 +14,7 @@ void addRefraction(float ior) {
     vec4 tmpRefl = dReflection;
     dReflDirW = refract2(-dViewDirW, dNormalW, ior);
 
-    dReflection = vec4(0, 0, 0, 0);
+    dReflection = vec4(0);
     addReflection();
 
     dDiffuseLight = mix(dDiffuseLight, dReflection.rgb * dAlbedo, material_refraction);

--- a/src/graphics/program-lib/chunks/lit/frag/refraction.js
+++ b/src/graphics/program-lib/chunks/lit/frag/refraction.js
@@ -1,5 +1,5 @@
 export default /* glsl */`
-uniform float material_refraction, material_refractionIndex;
+uniform float material_refraction;
 
 vec3 refract2(vec3 viewVec, vec3 Normal, float IOR) {
     float vn = dot(viewVec, Normal);
@@ -8,17 +8,18 @@ vec3 refract2(vec3 viewVec, vec3 Normal, float IOR) {
     return refrVec;
 }
 
-void addRefraction() {
+void addRefraction(float ior) {
     // use same reflection code with refraction vector
-    vec3 tmp = dReflDirW;
-    vec4 tmp2 = dReflection;
-    dReflection = vec4(0.0);
-    dReflDirW = refract2(-dViewDirW, dNormalW, material_refractionIndex);
+    vec3 tmpDir = dReflDirW;
+    vec4 tmpRefl = dReflection;
+    dReflDirW = refract2(-dViewDirW, dNormalW, ior);
 
+    dReflection = vec4(0, 0, 0, 0);
     addReflection();
 
-    dDiffuseLight = mix(dDiffuseLight, dReflection.rgb * dAlbedo, material_refraction);
-    dReflDirW = tmp;
-    dReflection = tmp2;
+    //dDiffuseLight = mix(dDiffuseLight, dReflection.rgb * dAlbedo, material_refraction);
+    dReflection.rgb = dReflection.rgb * dAlbedo * material_refraction + tmpRefl.rgb;
+    dReflection.a = dReflection.a + tmpRefl.a;
+    dReflDirW = tmpDir;
 }
 `;

--- a/src/graphics/program-lib/chunks/lit/frag/refraction.js
+++ b/src/graphics/program-lib/chunks/lit/frag/refraction.js
@@ -17,9 +17,8 @@ void addRefraction(float ior) {
     dReflection = vec4(0, 0, 0, 0);
     addReflection();
 
-    //dDiffuseLight = mix(dDiffuseLight, dReflection.rgb * dAlbedo, material_refraction);
-    dReflection.rgb = dReflection.rgb * dAlbedo * material_refraction + tmpRefl.rgb;
-    dReflection.a = dReflection.a + tmpRefl.a;
+    dDiffuseLight = mix(dDiffuseLight, dReflection.rgb * dAlbedo, material_refraction);
+    dReflection = tmpRefl;    
     dReflDirW = tmpDir;
 }
 `;

--- a/src/graphics/program-lib/chunks/standard/frag/ior.js
+++ b/src/graphics/program-lib/chunks/standard/frag/ior.js
@@ -1,0 +1,16 @@
+export default /* glsl */`
+
+#ifdef MAPFLOAT
+uniform float material_refractionIndex;
+#endif
+
+void getRefractionIndex() {
+    float refractionIndex = 1.5;
+
+    #ifdef MAPFLOAT
+    refractionIndex = material_refractionIndex;
+    #endif
+
+    dIor = refractionIndex;
+}
+`;

--- a/src/graphics/program-lib/chunks/standard/frag/metalness.js
+++ b/src/graphics/program-lib/chunks/standard/frag/metalness.js
@@ -22,7 +22,6 @@ void getMetalness() {
     metalness *= saturate(vVertexColor.$VC);
     #endif
 
-    dIor = 0.04;
     dMetalness = metalness;
 }
 `;

--- a/src/graphics/program-lib/programs/lit-shader.js
+++ b/src/graphics/program-lib/programs/lit-shader.js
@@ -1035,7 +1035,7 @@ class LitShader {
         if ((this.lighting && options.useSpecular) || this.reflections) {
 
             if (options.useMetalness) {
-                code += "    getMetalnessModulate(dIor);\n";
+                code += "    getMetalnessModulate();\n";
             }
         }
 
@@ -1308,7 +1308,7 @@ class LitShader {
             }
 
             if (this.reflections && options.refraction) {
-                code += "    addRefraction();\n";
+                code += "    addRefraction(dIor);\n";
             }
         }
         code += "\n";

--- a/src/graphics/program-lib/programs/standard.js
+++ b/src/graphics/program-lib/programs/standard.js
@@ -305,13 +305,18 @@ const standard = {
             code.append(this._addMap("diffuse", "diffusePS", options, litShader.chunks));
             func.append("getAlbedo();");
 
+            if (options.refraction) {
+                decl.append("float dIor;");
+                code.append(this._addMap("refractionIndex", "iorPS", options, litShader.chunks));
+                func.append("getRefractionIndex();");
+            }
+
             // specularity & glossiness
             if ((litShader.lighting && options.useSpecular) || litShader.reflections) {
                 decl.append("vec3 dSpecularity;");
                 decl.append("float dGlossiness;");
                 if (options.useMetalness) {
                     decl.append("float dMetalness;");
-                    decl.append("float dIor;");
                     code.append(this._addMap("metalness", "metalnessPS", options, litShader.chunks));
                     func.append("getMetalness();");
                 }

--- a/src/resources/parser/glb-parser.js
+++ b/src/resources/parser/glb-parser.js
@@ -1126,7 +1126,9 @@ const extensionSpecular = function (data, material, textures) {
 };
 
 const extensionIor = function (data, material, textures) {
-    material.refractionIndex = data.ior;
+    if (data.hasOwnProperty('ior')) {
+        material.refractionIndex = data.ior;
+    }
 };
 
 const createMaterial = function (gltfMaterial, textures, flipV) {

--- a/src/resources/parser/glb-parser.js
+++ b/src/resources/parser/glb-parser.js
@@ -1125,6 +1125,12 @@ const extensionSpecular = function (data, material, textures) {
     }
 };
 
+const extensionIor = function (data, material, textures) {
+    material.refractionIndex = data.ior;
+    const f0sq = (data.ior - 1) / (data.ior + 1);
+    material.f0 = f0sq * f0sq;
+};
+
 const createMaterial = function (gltfMaterial, textures, flipV) {
     // TODO: integrate these shader chunks into the native engine
     const glossChunk = `
@@ -1290,7 +1296,8 @@ const createMaterial = function (gltfMaterial, textures, flipV) {
         "KHR_materials_pbrSpecularGlossiness": extensionPbrSpecGlossiness,
         "KHR_materials_clearcoat": extensionClearCoat,
         "KHR_materials_unlit": extensionUnlit,
-        "KHR_materials_specular": extensionSpecular
+        "KHR_materials_specular": extensionSpecular,
+        "KHR_materials_ior": extensionIor
     };
 
     // Handle extensions

--- a/src/resources/parser/glb-parser.js
+++ b/src/resources/parser/glb-parser.js
@@ -1127,8 +1127,6 @@ const extensionSpecular = function (data, material, textures) {
 
 const extensionIor = function (data, material, textures) {
     material.refractionIndex = data.ior;
-    const f0sq = (data.ior - 1) / (data.ior + 1);
-    material.f0 = f0sq * f0sq;
 };
 
 const createMaterial = function (gltfMaterial, textures, flipV) {

--- a/src/scene/materials/standard-material-options-builder.js
+++ b/src/scene/materials/standard-material-options-builder.js
@@ -162,6 +162,7 @@ class StandardMaterialOptionsBuilder {
         options.cubeMapProjection = stdMat.cubeMapProjection;
         options.customFragmentShader = stdMat.customFragmentShader;
         options.refraction = !!stdMat.refraction;
+        options.refractionIndexTint = (stdMat.refractionIndex !== 1.5) ? 1 : 0;
         options.useMetalness = stdMat.useMetalness;
         options.enableGGXSpecular = stdMat.enableGGXSpecular;
         options.msdf = !!stdMat.msdfMap;

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -645,7 +645,7 @@ class StandardMaterial extends Material {
 
             if (this.refractionIndex !== 1.5) {
                 const f0 = (this.refractionIndex - 1) / (this.refractionIndex + 1);
-                this._setParameter('material_f0', f0*f0);
+                this._setParameter('material_f0', f0 * f0);
             } else {
                 this._setParameter('material_f0', 0.04);
             }

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -220,7 +220,6 @@ let _params = new Set();
  * indices of refraction, the one around the object and the one of its own surface. In most
  * situations outer medium is air, so outerIor will be approximately 1. Then you only need to do
  * (1.0 / surfaceIor).
- * @property {number} f0 Defines the f0 weight as calculated using ((ior - 1) / (ior + 1))^2
  * @property {Color} emissive The emissive color of the material. This color value is 3-component
  * (RGB), where each component is between 0 and 1.
  * @property {boolean} emissiveTint Multiply emissive map and/or emissive vertex color by the
@@ -645,7 +644,8 @@ class StandardMaterial extends Material {
             }
 
             if (this.refractionIndex !== 1.5) {
-                this._setParameter('material_f0', this.f0);
+                const f0 = (this.refractionIndex - 1) / (this.refractionIndex + 1);
+                this._setParameter('material_f0', f0*f0);
             } else {
                 this._setParameter('material_f0', 0.04);
             }
@@ -1049,7 +1049,6 @@ function _defineMaterialProps() {
     _defineFloat('occludeSpecularIntensity', 1);
     _defineFloat('refraction', 0);
     _defineFloat('refractionIndex', 1.0 / 1.5); // approx. (air ior / glass ior)
-    _defineFloat('f0', 0.04);
     _defineFloat('metalness', 1);
     _defineFloat('anisotropy', 0);
     _defineFloat('clearCoat', 0);

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -220,6 +220,7 @@ let _params = new Set();
  * indices of refraction, the one around the object and the one of its own surface. In most
  * situations outer medium is air, so outerIor will be approximately 1. Then you only need to do
  * (1.0 / surfaceIor).
+ * @property {number} f0 Defines the f0 weight as calculated using ((ior - 1) / (ior + 1))^2
  * @property {Color} emissive The emissive color of the material. This color value is 3-component
  * (RGB), where each component is between 0 and 1.
  * @property {boolean} emissiveTint Multiply emissive map and/or emissive vertex color by the
@@ -642,6 +643,12 @@ class StandardMaterial extends Material {
             if (!this.specularityFactorMap || this.specularityFactor < 1) {
                 this._setParameter('material_specularityFactor', this.specularityFactor);
             }
+
+            if (this.refractionIndex != 1.5) {
+                this._setParameter('material_f0', this.f0);
+            } else {
+                this._setParameter('material_f0', 0.04);
+            }
         }
 
         if (this.enableGGXSpecular) {
@@ -1042,6 +1049,7 @@ function _defineMaterialProps() {
     _defineFloat('occludeSpecularIntensity', 1);
     _defineFloat('refraction', 0);
     _defineFloat('refractionIndex', 1.0 / 1.5); // approx. (air ior / glass ior)
+    _defineFloat('f0', 0.04);
     _defineFloat('metalness', 1);
     _defineFloat('anisotropy', 0);
     _defineFloat('clearCoat', 0);

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -644,7 +644,7 @@ class StandardMaterial extends Material {
                 this._setParameter('material_specularityFactor', this.specularityFactor);
             }
 
-            if (this.refractionIndex != 1.5) {
+            if (this.refractionIndex !== 1.5) {
                 this._setParameter('material_f0', this.f0);
             } else {
                 this._setParameter('material_f0', 0.04);


### PR DESCRIPTION
### Description

This PR adds support for controlling index of refraction (IOR) from the frontend of the shader chunks, adds support for the KHR_materials_ior extension, as well as precalculates the F0 specular factor with is dependent on IOR.

Fixes #3652 

This image illustrates, in Y diffuse color from black to red, in X refraction index from 1 to 2.
![image](https://user-images.githubusercontent.com/107400752/178753549-687ebcd4-4be5-4602-8b52-7e8fcd79c59a.png)

This illustrates the visual change on the specular when IOR is changed, as that impacts the f0 specular component. As in the previous image, in Y diffuse color ranges from black to red, in X refraction index from 1 to 2.
![image](https://user-images.githubusercontent.com/107400752/178753637-74a2515c-4ad9-48de-a046-02e8a26b39aa.png)
