### PR TITLE
Dot not build lighting shader if material.useLighting is false

### DIFF
--- a/src/scene/materials/standard-material-options-builder.js
+++ b/src/scene/materials/standard-material-options-builder.js
@@ -91,7 +91,7 @@ class StandardMaterialOptionsBuilder {
             options.clusteredLightingEnabled = false;
             options.clusteredLightingCookiesEnabled = false;
             options.clusteredLightingShadowsEnabled = false;
-            options.clusteredLightingAreaLightsEnabled = false;            
+            options.clusteredLightingAreaLightsEnabled = false;
         }
     }
 


### PR DESCRIPTION
- only generate lighting shader if material.useLighting is true. This avoids adding code which does not get used to UI and similar shaders.
- disable clustered lighting in the else branch as the options object gets reused, to override previous settings.