### PR TITLE
Fix lightmap dir not using halfdir

### DIFF
--- a/src/graphics/program-lib/chunks/lit/frag/clusteredLight.js
+++ b/src/graphics/program-lib/chunks/lit/frag/clusteredLight.js
@@ -512,7 +512,7 @@ void evaluateLight(ClusterLightData light) {
             // specular and clear coat are material settings and get included by a define based on the material
             #ifdef CLUSTER_SPECULAR
 
-                vec3 halfDir = normalize(normalize(-dLightDirNormW) + normalize(dViewDirW));
+                vec3 halfDir = normalize(-dLightDirNormW + dViewDirW);
                 
                 // specular
                 #ifdef CLUSTER_SPECULAR_FRESNEL

--- a/src/graphics/program-lib/chunks/lit/frag/lightmapDirAdd.js
+++ b/src/graphics/program-lib/chunks/lit/frag/lightmapDirAdd.js
@@ -11,7 +11,7 @@ void addLightMap() {
 
         dDiffuseLight += dLightmap * nlight * 2.0;
     }
-
-    dSpecularLight += dLightmap * getLightSpecular();
+    vec3 halfDir = normalize(normalize(-dLightDirNormW) + normalize(dViewDirW));
+    dSpecularLight += dLightmap * getLightSpecular(halfDir);
 }
 `;

--- a/src/graphics/program-lib/chunks/lit/frag/lightmapDirAdd.js
+++ b/src/graphics/program-lib/chunks/lit/frag/lightmapDirAdd.js
@@ -11,7 +11,7 @@ void addLightMap() {
 
         dDiffuseLight += dLightmap * nlight * 2.0;
     }
-    vec3 halfDir = normalize(normalize(-dLightDirNormW) + normalize(dViewDirW));
+    vec3 halfDir = normalize(-dLightDirNormW + dViewDirW);
     dSpecularLight += dLightmap * getLightSpecular(halfDir);
 }
 `;


### PR DESCRIPTION
### Description

Fixes lightmapDir.js using getLightSpecular but not providing a half direction for the light. This issue was introduced in #4386.