### PR TITLE
Adds support for refraction as a texture and KHR_materials_transmission

### DIFF
--- a/src/graphics/program-lib/chunks/chunks.js
+++ b/src/graphics/program-lib/chunks/chunks.js
@@ -187,6 +187,7 @@ import tonemappingLinearPS from './common/frag/tonemappingLinear.js';
 import tonemappingNonePS from './common/frag/tonemappingNone.js';
 import transformVS from './common/vert/transform.js';
 import transformDeclVS from './common/vert/transformDecl.js';
+import transmissionPS from './standard/frag/transmission.js';
 import uv0VS from './lit/vert/uv0.js';
 import uv1VS from './lit/vert/uv1.js';
 import viewDirPS from './lit/frag/viewDir.js';
@@ -389,6 +390,7 @@ const shaderChunks = {
     tonemappingNonePS,
     transformVS,
     transformDeclVS,
+    transmissionPS,
     uv0VS,
     uv1VS,
     viewDirPS,

--- a/src/graphics/program-lib/chunks/lit/frag/refraction.js
+++ b/src/graphics/program-lib/chunks/lit/frag/refraction.js
@@ -1,5 +1,4 @@
 export default /* glsl */`
-uniform float material_refraction;
 uniform float material_refractionIndex;
 
 vec3 refract2(vec3 viewVec, vec3 Normal, float IOR) {
@@ -16,10 +15,11 @@ void addRefraction() {
     dReflDirW = refract2(-dViewDirW, dNormalW, material_refractionIndex);
 
     dReflection = vec4(0);
+
     addReflection();
 
-    dDiffuseLight = mix(dDiffuseLight, dReflection.rgb * dAlbedo, material_refraction);
-    dReflection = tmpRefl;    
+    dDiffuseLight = mix(dDiffuseLight, dReflection.rgb * dAlbedo, dTransmission);
+    dReflection = tmpRefl;
     dReflDirW = tmpDir;
 }
 `;

--- a/src/graphics/program-lib/chunks/standard/frag/transmission.js
+++ b/src/graphics/program-lib/chunks/standard/frag/transmission.js
@@ -1,0 +1,28 @@
+export default /* glsl */`
+
+#ifdef MAPFLOAT
+uniform float material_refraction;
+#endif
+
+#ifdef MAPTEXTURE
+uniform sampler2D texture_refractionMap;
+#endif
+
+void getRefraction() {
+    float refraction = 1.0;
+
+    #ifdef MAPFLOAT
+    refraction = material_refraction;
+    #endif
+
+    #ifdef MAPTEXTURE
+    refraction *= texture2DSRGB(texture_refractionMap, $UV, textureBias).$CH;
+    #endif
+
+    #ifdef MAPVERTEX
+    refraction *= saturate(vVertexColor.$VC);
+    #endif
+
+    dTransmission = refraction;
+}
+`;

--- a/src/graphics/program-lib/programs/standard.js
+++ b/src/graphics/program-lib/programs/standard.js
@@ -324,6 +324,12 @@ const standard = {
             code.append(this._addMap("diffuse", "diffusePS", options, litShader.chunks));
             func.append("getAlbedo();");
 
+            if (options.refraction) {
+                decl.append("float dTransmission;");
+                code.append(this._addMap("refraction", "transmissionPS", options, litShader.chunks));
+                func.append("getRefraction();");
+            }
+
             // specularity & glossiness
             if ((litShader.lighting && options.useSpecular) || litShader.reflections) {
                 decl.append("vec3 dSpecularity;");

--- a/src/resources/parser/glb-parser.js
+++ b/src/resources/parser/glb-parser.js
@@ -1132,6 +1132,17 @@ const extensionIor = function (data, material, textures) {
     }
 };
 
+const extensionTransmission = function (data, material, textures) {
+    material.blendType = BLEND_NORMAL; 
+    if (data.hasOwnProperty('transmissionFactor')) {
+        material.refraction = data.transmissionFactor;
+    }
+    if (data.hasOwnProperty('transmissionTexture')) {
+        material.refractionMapChannel = 'r';
+        material.refractionMap = textures[data.transmissionTexture.index];
+    }
+};
+
 const createMaterial = function (gltfMaterial, textures, flipV) {
     // TODO: integrate these shader chunks into the native engine
     const glossChunk = `
@@ -1298,7 +1309,8 @@ const createMaterial = function (gltfMaterial, textures, flipV) {
         "KHR_materials_clearcoat": extensionClearCoat,
         "KHR_materials_unlit": extensionUnlit,
         "KHR_materials_specular": extensionSpecular,
-        "KHR_materials_ior": extensionIor
+        "KHR_materials_ior": extensionIor,
+        "KHR_materials_transmission": extensionTransmission
     };
 
     // Handle extensions

--- a/src/resources/parser/glb-parser.js
+++ b/src/resources/parser/glb-parser.js
@@ -1133,7 +1133,7 @@ const extensionIor = function (data, material, textures) {
 };
 
 const extensionTransmission = function (data, material, textures) {
-    material.blendType = BLEND_NORMAL; 
+    material.blendType = BLEND_NORMAL;
     if (data.hasOwnProperty('transmissionFactor')) {
         material.refraction = data.transmissionFactor;
     }

--- a/src/scene/materials/standard-material-options-builder.js
+++ b/src/scene/materials/standard-material-options-builder.js
@@ -168,7 +168,7 @@ class StandardMaterialOptionsBuilder {
         options.fastTbn = stdMat.fastTbn;
         options.cubeMapProjection = stdMat.cubeMapProjection;
         options.customFragmentShader = stdMat.customFragmentShader;
-        options.refraction = !!stdMat.refraction;
+        options.refraction = !!stdMat.refraction || !!stdMat.refractionMap;
         options.refractionIndexTint = (stdMat.refractionIndex !== 1.5) ? 1 : 0;
         options.useMetalness = stdMat.useMetalness;
         options.enableGGXSpecular = stdMat.enableGGXSpecular;

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -217,6 +217,15 @@ let _params = new Set();
  * "r", "g", "b" or "a".
  * @property {number} refraction Defines the visibility of refraction. Material can refract the
  * same cube map as used for reflections.
+ * @property {Texture|null} refractionMap The map of the refraction visibility.
+ * @property {number} refractionMapUv Refraction map UV channel.
+ * @property {Vec2} refractionMapTiling Controls the 2D tiling of the refraction map.
+ * @property {Vec2} refractionMapOffset Controls the 2D offset of the refraction map. Each component is
+ * between 0 and 1.
+ * @property {number} refractionMapRotation Controls the 2D rotation (in degrees) of the emissive
+ * map.
+ * @property {string} refractionMapChannel Color channels of the refraction map to use. Can be "r",
+ * "g", "b", "a", "rgb" or any swizzled combination.
  * @property {number} refractionIndex Defines the index of refraction, i.e. The amount of
  * distortion. The value is calculated as (outerIor / surfaceIor), where inputs are measured
  * indices of refraction, the one around the object and the one of its own surface. In most
@@ -1114,6 +1123,7 @@ function _defineMaterialProps() {
     _defineTex2D('metalness', 0, 1, '', true);
     _defineTex2D('gloss', 0, 1, '', true);
     _defineTex2D('opacity', 0, 1, 'a', true);
+    _defineTex2D('refraction', 0, 1, '', true);
     _defineTex2D('height', 0, 1, '', false);
     _defineTex2D('ao', 0, 1, '', true);
     _defineTex2D('light', 1, 3, '', true);


### PR DESCRIPTION
### Description

This PR adds support for the KHR_materials_transmission as well as provides a new texture to the standard material for refraction. Fixes #3648.

This image shows the glTF example TransmissionTest. Note that we don't deal with handling refraction of the opaque objects in the scene in this PR.
![image](https://user-images.githubusercontent.com/107400752/179032717-c6c0b914-2910-4817-84e8-7e95a366b666.png)
