### PR TITLE
All prefiltered env maps are rgbm

### DIFF
--- a/src/resources/cubemap.js
+++ b/src/resources/cubemap.js
@@ -120,7 +120,7 @@ class CubemapHandler {
                     resources[i + 1] = new Texture(this._device, {
                         name: cubemapAsset.name + '_prelitCubemap' + (tex.width >> i),
                         cubemap: true,
-                        type: getType() || tex.type,
+                        type: TEXTURETYPE_RGBM,
                         width: tex.width >> i,
                         height: tex.height >> i,
                         format: tex.format,


### PR DESCRIPTION
This PR fixes a case where the cubemap isn't RGBM. Since our prefiltered cubemaps are always generated as RGBM, we can set it directly.