### PR TITLE
[Fix] Fix the way composition tests for dirty camera

### DIFF
--- a/src/scene/composition/layer-composition.js
+++ b/src/scene/composition/layer-composition.js
@@ -395,7 +395,7 @@ class LayerComposition extends EventHandler {
         }
 
         // allocate light clusteres if lights or meshes or cameras are modified
-        if (this._dirtyCameras || (result & (COMPUPDATED_LIGHTS | COMPUPDATED_INSTANCES))) {
+        if (result & (COMPUPDATED_LIGHTS | COMPUPDATED_LIGHTS | COMPUPDATED_INSTANCES)) {
 
             // prepare clustered lighting for render actions
             if (clusteredLightingEnabled) {
@@ -403,7 +403,7 @@ class LayerComposition extends EventHandler {
             }
         }
 
-        if ((result & COMPUPDATED_LIGHTS) || (result & COMPUPDATED_CAMERAS)) {
+        if (result & (COMPUPDATED_LIGHTS | COMPUPDATED_LIGHTS)) {
             this._logRenderActions();
         }
 

--- a/src/scene/composition/layer-composition.js
+++ b/src/scene/composition/layer-composition.js
@@ -395,7 +395,7 @@ class LayerComposition extends EventHandler {
         }
 
         // allocate light clusteres if lights or meshes or cameras are modified
-        if (result & (COMPUPDATED_LIGHTS | COMPUPDATED_LIGHTS | COMPUPDATED_INSTANCES)) {
+        if (result & (COMPUPDATED_CAMERAS | COMPUPDATED_LIGHTS | COMPUPDATED_INSTANCES)) {
 
             // prepare clustered lighting for render actions
             if (clusteredLightingEnabled) {


### PR DESCRIPTION
Fix issue introduced in #4434 where when the code was moved outside of the if, the test needs to be adjusted as the flag gets cleared inside the condition.