### PR TITLE
[FIX] Remove guard that always evaluates to true in wasmSupported

### DIFF
--- a/src/core/wasm-module.js
+++ b/src/core/wasm-module.js
@@ -3,20 +3,16 @@ class Impl {
 
     // returns true if the running host supports wasm modules (all browsers except IE)
     static wasmSupported() {
-        let supported = null;
-
-        if (supported === null) {
-            supported = (() => {
-                try {
-                    if (typeof WebAssembly === "object" && typeof WebAssembly.instantiate === "function") {
-                        const module = new WebAssembly.Module(Uint8Array.of(0x0, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00));
-                        if (module instanceof WebAssembly.Module)
-                            return new WebAssembly.Instance(module) instanceof WebAssembly.Instance;
-                    }
-                } catch (e) { }
-                return false;
-            })();
-        }
+        const supported = (() => {
+            try {
+                if (typeof WebAssembly === "object" && typeof WebAssembly.instantiate === "function") {
+                    const module = new WebAssembly.Module(Uint8Array.of(0x0, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00));
+                    if (module instanceof WebAssembly.Module)
+                        return new WebAssembly.Instance(module) instanceof WebAssembly.Instance;
+                }
+            } catch (e) { }
+            return false;
+        })();
 
         return supported;
     }


### PR DESCRIPTION
Fixes the following (from [lgtm.com](https://lgtm.com/projects/g/playcanvas/engine/snapshot/207d4fbf9c0e23e3feea5f96da7614710487c3b8/files/src/core/wasm-module.js?sort=name&dir=ASC&mode=heatmap#x4c53ea2a7a033341:1)):

![image](https://user-images.githubusercontent.com/697563/179516975-336cd185-f632-4619-930e-0d05ce02d3dc.png)

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
