### PR TITLE
Revert change to env loading

### DIFF
--- a/src/resources/cubemap.js
+++ b/src/resources/cubemap.js
@@ -120,11 +120,7 @@ class CubemapHandler {
                     resources[i + 1] = new Texture(this._device, {
                         name: cubemapAsset.name + '_prelitCubemap' + (tex.width >> i),
                         cubemap: true,
-                        // we have some old assets that were not created in RGBM format (see Gangnam
-                        // project). These assets appear to have predated the texture type member. So
-                        // here we assume assets with a texture type member were created in RGBM and
-                        // older assets were created without.
-                        type: getType() ? TEXTURETYPE_RGBM : TEXTURETYPE_DEFAULT,
+                        type: getType() || tex.type,
                         width: tex.width >> i,
                         height: tex.height >> i,
                         format: tex.format,

--- a/src/resources/cubemap.js
+++ b/src/resources/cubemap.js
@@ -120,6 +120,7 @@ class CubemapHandler {
                     resources[i + 1] = new Texture(this._device, {
                         name: cubemapAsset.name + '_prelitCubemap' + (tex.width >> i),
                         cubemap: true,
+                        // assume prefiltered data has same encoding as the faces asset
                         type: getType() || tex.type,
                         width: tex.width >> i,
                         height: tex.height >> i,


### PR DESCRIPTION
A recent change to env loading has been found to break existing legacy projects.

Rather than attempting to address env map mismatch in the engine we will address it in the editor at prefilter time instead.