### PR TITLE
Fix AudioContext not resuming properly.

### DIFF
--- a/src/sound/instance.js
+++ b/src/sound/instance.js
@@ -134,31 +134,6 @@ class SoundInstance extends EventHandler {
         this._playWhenLoaded = true;
 
         /**
-         * Set to true if a play() request was issued when the AudioContext was still suspended,
-         * and will therefore wait until it is resumed to play the audio.
-         *
-         * @type {boolean}
-         * @private
-         */
-        this._waitingContextSuspension = false;
-
-        /**
-         * Set to true if a stop() request was issued while _waitingContextSuspension was also true.
-         *
-         * @type {boolean}
-         * @private
-         */
-        this._stopOnWaitingContextSuspension = false;
-
-        /**
-         * Set to true if a pause() request was issued while _waitingContextSuspension was also true.
-         *
-         * @type {boolean}
-         * @private
-         */
-        this._pauseOnWaitingContextSuspension = false;
-
-        /**
          * @type {number}
          * @private
          */
@@ -242,6 +217,31 @@ class SoundInstance extends EventHandler {
              * @private
              */
             this._lastNode = null;
+
+            /**
+             * Set to true if a play() request was issued when the AudioContext was still suspended,
+             * and will therefore wait until it is resumed to play the audio.
+             *
+             * @type {boolean}
+             * @private
+             */
+            this._waitingContextSuspension = false;
+
+            /**
+             * Set to true if a stop() request was issued while _waitingContextSuspension was also true.
+             *
+             * @type {boolean}
+             * @private
+             */
+            this._stopOnWaitingContextSuspension = false;
+
+            /**
+             * Set to true if a pause() request was issued while _waitingContextSuspension was also true.
+             *
+             * @type {boolean}
+             * @private
+             */
+            this._pauseOnWaitingContextSuspension = false;
 
             this._initializeNodes();
 
@@ -534,8 +534,6 @@ class SoundInstance extends EventHandler {
 
     /** @private */
     _onEnded() {
-        console.log(`instance:_onEnded()`);
-
         // the callback is not fired synchronously
         // so only decrement _suspendEndEvent when the
         // callback is fired
@@ -567,7 +565,6 @@ class SoundInstance extends EventHandler {
      * @private
      */
     _onManagerSuspend() {
-        console.log(`instance._onManagerSuspend()`);
         if (this._state === STATE_PLAYING && !this._suspended) {
             this._suspended = true;
             this.pause();
@@ -580,7 +577,6 @@ class SoundInstance extends EventHandler {
      * @private
      */
     _onManagerResume() {
-        console.log(`instance._onManagerResume()`);
         if (this._suspended) {
             this._suspended = false;
             this.resume();
@@ -628,14 +624,12 @@ class SoundInstance extends EventHandler {
 
         // manager is suspended so audio cannot start now - wait for manager to resume
         if (this._manager.suspended) {
-            console.log(`instance.play(): manager is suspended, waiting for 'resume'`);
             this._manager.once('resume', this._playAudioImmediate, this);
             this._waitingContextSuspension = true;
 
             return false;
         }
 
-        console.log(`instance.play(): manager is not suspended, playing now!`);
         this._playAudioImmediate();
 
         return true;
@@ -648,7 +642,6 @@ class SoundInstance extends EventHandler {
      * @private
      */
     _playAudioImmediate() {
-        console.log(`instance.play.playAudio()`);
         this._waitingContextSuspension = false;
 
         if (!this.source) {
@@ -689,12 +682,10 @@ class SoundInstance extends EventHandler {
         }
 
         if (this._pauseOnWaitingContextSuspension) {
-            console.log(`instance.play.playAudio(): _pauseOnWaitingContextSuspension`);
             this._pauseOnWaitingContextSuspension = false;
             this.pause();
         }
         if (this._stopOnWaitingContextSuspension) {
-            console.log(`instance.play.playAudio(): _stopOnWaitingContextSuspension`);
             this._stopOnWaitingContextSuspension = false;
             this.stop();
         }
@@ -717,7 +708,6 @@ class SoundInstance extends EventHandler {
 
         // play() was issued but hasn't actually started yet - so simply set the flag to pause later.
         if (this._waitingContextSuspension) {
-            console.log(`instance.pause(): _waitingContextSuspension - set _pauseOnWaitingContextSuspension`);
             this._pauseOnWaitingContextSuspension = true;
             return true;
         }
@@ -755,7 +745,6 @@ class SoundInstance extends EventHandler {
 
         // play() was issued but hasn't actually started yet - so simply reset the pause flag.
         if (this._waitingContextSuspension) {
-            console.log(`instance.resume(): _waitingContextSuspension - reset _pauseOnWaitingContextSuspension`);
             this._pauseOnWaitingContextSuspension = false;
             return true;
         }
@@ -816,7 +805,6 @@ class SoundInstance extends EventHandler {
 
         // play() was issued but hasn't actually started yet - so simply set a flag to stop later.
         if (this._waitingContextSuspension) {
-            console.log(`instance.stop(): _waitingContextSuspension - set _stopOnWaitingContextSuspension`);
             this._stopOnWaitingContextSuspension = true;
             return true;
         }


### PR DESCRIPTION
Fixes https://github.com/playcanvas/engine/issues/3977

## Summary

Fix `AudioContext` not resuming properly in Mobile devices. Previously, the `AudioContext` often broke when minimising / switching tabs and going back to the page. Once broken, no Audio could be played, and the only resolution was reloading the entire page. This PR addresses this by re-writing the entire `SoundManager ` suspend / resume flow.

I've added documentation to the code, but basically:
- If `AudioContext` is locked (verifiable by checking if the `AudioContext.state` is `suspended` right after creation), all `SoundInstance`s will wait until the Context is unlocked to actually start playing;
- Once unlocked, `SoundManager.resume()` (called manually or automatically on `visibilitychange`) will call `audioContext.resume()` if state was `interrupted`, and `SoundInstance`s will only resume once that call was successful;
- Once unlocked, every time the `AudioContext`'s `state` chages (`onstatechange`), an additional check will be made to resume the `AudioContext`.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).

## Testing

Test project using custom engine with changes: https://playcanv.as/p/nwJQKFeE/

Tested the following situations on iPhone Chrome and Safari:

- Test 1
    1. Open page
    2. Tap to start playing audio
    3. Minimize app, wait 30 seconds
    4. Back to app, audio resumes immediately
- Test 2
    1. Open page
    2. Minimize app, wait 30 seconds
    3. Back to app, audio doesn't resume (still locked)
    4. Tap to unlock, audio plays
- Test 3
    1. Open page
    2. Tap to start playing audio
    3. Minimize app, turn off screen, wait 30 seconds
    4. Turn screen back on, back to app, audio resumes immediately
   

Tested the following situations on MacBook Chrome and Safari:

- Test 1
    1. Open page
    2. Click to start playing audio
    3. Minimize app, wait 30 seconds
    4. Back to app, audio resumes immediately
- Test 2
    1. Open page
    2. Minimize app, wait 30 seconds
    3. Back to app, audio doesn't resume (still locked)
    4. Tap to unlock, audio plays

Tested the following situtation on MacBook & iPhone Chrome & Safari:

![Screenshot 2022-08-01 at 14 10 18](https://user-images.githubusercontent.com/6392953/182155272-c883f50b-3faa-4ccf-8dba-d5bc9fc545ad.png)

(Available here: https://playcanv.as/p/nwJQKFeE/) Wait for tank to pass through each sphere - which performs the action in the text. This is done so there's no user interaction which would unlock the page - this way we can test what happens when context is unlocked in various stages.