### PR TITLE
Glb-parser morph target fix

### DIFF
--- a/src/resources/parser/glb-parser.js
+++ b/src/resources/parser/glb-parser.js
@@ -1415,6 +1415,10 @@ const createAnimation = function (gltfAnimation, animationIndex, gltfAccessors, 
     // All morph targets are included in a single channel of the animation, with all targets output data interleaved with each other.
     // This function splits each morph target out into it a curve with its own output data, allowing us to animate each morph target independently by name.
     const createMorphTargetCurves = (curve, node, entityPath) => {
+        if (!outputMap[curve.output]) {
+            Debug.warn(`glb-parser: No output data is available for the morph target curve (${entityPath}/graph/weights). Skipping.`);
+            return;
+        }
         const morphTargetCount = outputMap[curve.output].data.length / inputMap[curve.input].data.length;
         const keyframeCount = outputMap[curve.output].data.length / morphTargetCount;
 


### PR DESCRIPTION
When the glb parser is creating animations, it should skip morph target curves that have no coinciding output data. In this instance debug users should be given a warning.

Fixes #4472 

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
