### PR TITLE
[FIX] remove extraneous bracket in diffuseDetailMap shader chunk

### DIFF
--- a/src/graphics/program-lib/chunks/standard/frag/diffuseDetailMap.js
+++ b/src/graphics/program-lib/chunks/standard/frag/diffuseDetailMap.js
@@ -5,7 +5,7 @@ uniform sampler2D texture_diffuseDetailMap;
 
 vec3 addAlbedoDetail(vec3 albedo) {
 #ifdef MAPTEXTURE
-    vec3 albedoDetail = gammaCorrectInput(texture2D(texture_diffuseDetailMap, $UV, textureBias).$CH));
+    vec3 albedoDetail = gammaCorrectInput(texture2D(texture_diffuseDetailMap, $UV, textureBias).$CH);
     return detailMode_$DETAILMODE(albedo, albedoDetail);
 #else
     return albedo;


### PR DESCRIPTION
This fixes shader compilation for materials that use diffuseDetailMap textures

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
