### PR TITLE
Polyfill for `Object.values`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ import './polyfill/math-log2.js';
 import './polyfill/math-sign.js';
 import './polyfill/number-isfinite.js';
 import './polyfill/object-assign.js';
+import './polyfill/object-values.js';
 import './polyfill/pointer-lock.js';
 import './polyfill/request-animation-frame.js';
 import './polyfill/string.js';

--- a/src/polyfill/object-values.js
+++ b/src/polyfill/object-values.js
@@ -1,0 +1,3 @@
+Object.values = Object.values || function (object) {
+  return Object.keys(object).map(key => object[key]);
+};


### PR DESCRIPTION
Right now not every code path is polyfilled, for example this doesn't work in IE11:

```js
test = new pc.Entity('test');
test.addComponent('anim');
test.anim.dirtifyTargets();
```

Because of `Object.values`:

https://github.com/playcanvas/engine/blob/a69aa6111e307f785cbd95f9e6a56cf6c09f9cb9/src/framework/components/anim/component.js#L274-L279

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
