### PR TITLE
[Fix] Increase the shadow resolution in model-outline example to avoid banding

### DIFF
--- a/examples/src/examples/graphics/model-outline.tsx
+++ b/examples/src/examples/graphics/model-outline.tsx
@@ -23,6 +23,10 @@ class ModelOutlineExample {
 
             app.scene.ambientLight = new pc.Color(0.2, 0.2, 0.2);
 
+            // adjust default clustered lighting parameters to handle many lights
+            const lighting = app.scene.lighting;
+            lighting.shadowAtlasResolution = 4096;
+
             // helper function to create a primitive with shape type, position, scale, color and layer
             function createPrimitive(primitiveType: string, position: number | pc.Vec3, scale: number | pc.Vec3, color: pc.Color, layer: number[]) {
                 // create material of specified color


### PR DESCRIPTION
Fixes https://github.com/playcanvas/engine/issues/4473

by default, a shadow resolution for non-clustered light is 1024, which is the resolution for the cubemap face in face of omni light. Clustered atlas res was increased to provide similar resolution, to avoid banding - as the offset constants are resolution dependent.