### PR TITLE
[FIX] Back out tuple notation which is not supported by JSDoc

### DIFF
--- a/src/graphics/program-lib/programs/lit-shader.js
+++ b/src/graphics/program-lib/programs/lit-shader.js
@@ -308,7 +308,6 @@ class LitShader {
             }
         }
 
-        /** @type {[string, string, string, any[]]} */
         const codes = [code, this.varyings, codeBody, []];
 
         mapTransforms.forEach((mapTransform) => {

--- a/src/graphics/webgl/webgl-shader.js
+++ b/src/graphics/webgl/webgl-shader.js
@@ -291,7 +291,7 @@ class WebglShader {
      *
      * @param {string} src - The shader source code.
      * @param {string} infoLog - The info log returned from WebGL on a failed shader compilation.
-     * @returns {[string, {message?: string, line?: number, source?: string}]} A tuple where the first element is the 10 lines of code around the first
+     * @returns {Array} An array where the first element is the 10 lines of code around the first
      * detected error, and the second element an object storing the error messsage, line number and
      * complete shader source.
      * @private


### PR DESCRIPTION
Back out recently introduced tuple type notation that is not supported by JSDoc. A workaround to add support for this was proposed [here](https://github.com/playcanvas/engine/pull/4368). However, I'm not convinced we want to start working around JSDoc issues at this time so I'm simply backing out the two changes that are currently preventing the API reference manual from building.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
