### PR TITLE
Split the reflection and light sheen calculations

### DIFF
--- a/src/graphics/program-lib/chunks/chunks.js
+++ b/src/graphics/program-lib/chunks/chunks.js
@@ -71,6 +71,7 @@ import lightmapSinglePS from './standard/frag/lightmapSingle.js';
 import lightSpecularAnisoGGXPS from './lit/frag/lightSpecularAnisoGGX.js';
 import lightSpecularBlinnPS from './lit/frag/lightSpecularBlinn.js';
 import lightSpecularPhongPS from './lit/frag/lightSpecularPhong.js';
+import lightSheenPS from './lit/frag/lightSheen.js';
 import ltc from './lit/frag/ltc.js';
 import metalnessPS from './standard/frag/metalness.js';
 import msdfPS from './common/frag/msdf.js';
@@ -91,7 +92,6 @@ import outputTex2DPS from './common/frag/outputTex2D.js';
 import packDepthPS from './common/frag/packDepth.js';
 import sheenPS from './standard/frag/sheen.js';
 import sheenGlossPS from './standard/frag/sheenGloss.js';
-import sheenCharliePS from './lit/frag/sheenCharlie.js';
 import parallaxPS from './standard/frag/parallax.js';
 import particlePS from './particle/frag/particle.js';
 import particleVS from './particle/vert/particle.js';
@@ -142,6 +142,7 @@ import reflectionCubePS from './lit/frag/reflectionCube.js';
 import reflectionEnvPS from './lit/frag/reflectionEnv.js';
 import reflectionSpherePS from './lit/frag/reflectionSphere.js';
 import reflectionSphereLowPS from './lit/frag/reflectionSphereLow.js';
+import reflectionSheenPS from './lit/frag/reflectionSheen.js';
 import refractionPS from './lit/frag/refraction.js';
 import reprojectPS from './common/frag/reproject.js';
 import screenDepthPS from './common/frag/screenDepth.js';
@@ -272,6 +273,7 @@ const shaderChunks = {
     lightSpecularAnisoGGXPS,
     lightSpecularBlinnPS,
     lightSpecularPhongPS,
+    lightSheenPS,
     ltc,
     metalnessPS,
     metalnessModulatePS,
@@ -292,7 +294,6 @@ const shaderChunks = {
     packDepthPS,
     sheenPS,
     sheenGlossPS,
-    sheenCharliePS,
     parallaxPS,
     particlePS,
     particleVS,
@@ -343,6 +344,7 @@ const shaderChunks = {
     reflectionEnvPS,
     reflectionSpherePS,
     reflectionSphereLowPS,
+    reflectionSheenPS,
     refractionPS,
     reprojectPS,
     screenDepthPS,

--- a/src/graphics/program-lib/chunks/lit/frag/lightSheen.js
+++ b/src/graphics/program-lib/chunks/lit/frag/lightSheen.js
@@ -19,15 +19,4 @@ float getLightSpecularSheen(vec3 h) {
     float V = sheenV(dNormalW, dViewDirW, -dLightDirNormW);
     return D * V;
 }
-
-void addReflectionSheen() {
-    float NoV = dot(dNormalW, dViewDirW);
-    float alphaG = sGlossiness * sGlossiness;
-
-    // Avoid using a LUT and approximate the values analytically
-    float a = sGlossiness < 0.25 ? -339.2 * alphaG + 161.4 * sGlossiness - 25.9 : -8.48 * alphaG + 14.3 * sGlossiness - 9.95;
-    float b = sGlossiness < 0.25 ? 44.0 * alphaG - 23.7 * sGlossiness + 3.26 : 1.97 * alphaG - 3.27 * sGlossiness + 0.72;
-    float DG = exp( a * NoV + b ) + ( sGlossiness < 0.25 ? 0.0 : 0.1 * ( sGlossiness - 0.25 ) );
-    sReflection += vec4(calcReflection(dReflDirW, sGlossiness), saturate(DG * 1.0/PI));
-}
 `;

--- a/src/graphics/program-lib/chunks/lit/frag/reflectionSheen.js
+++ b/src/graphics/program-lib/chunks/lit/frag/reflectionSheen.js
@@ -1,0 +1,13 @@
+export default /* glsl */`
+
+void addReflectionSheen() {
+    float NoV = dot(dNormalW, dViewDirW);
+    float alphaG = sGlossiness * sGlossiness;
+
+    // Avoid using a LUT and approximate the values analytically
+    float a = sGlossiness < 0.25 ? -339.2 * alphaG + 161.4 * sGlossiness - 25.9 : -8.48 * alphaG + 14.3 * sGlossiness - 9.95;
+    float b = sGlossiness < 0.25 ? 44.0 * alphaG - 23.7 * sGlossiness + 3.26 : 1.97 * alphaG - 3.27 * sGlossiness + 0.72;
+    float DG = exp( a * NoV + b ) + ( sGlossiness < 0.25 ? 0.0 : 0.1 * ( sGlossiness - 0.25 ) );
+    sReflection += vec4(calcReflection(dReflDirW, sGlossiness), saturate(DG * 1.0/PI));
+}
+`;

--- a/src/graphics/program-lib/programs/lit-shader.js
+++ b/src/graphics/program-lib/programs/lit-shader.js
@@ -838,8 +838,12 @@ class LitShader {
                 code += chunks.refractionPS;
             }
             if (options.sheen) {
-                code += chunks.sheenCharliePS;
+                code += chunks.reflectionSheenPS;
             }
+        }
+
+        if (options.sheen) {
+            code += chunks.lightSheenPS;
         }
 
         // clustered lighting

--- a/src/scene/materials/standard-material-parameters.js
+++ b/src/scene/materials/standard-material-parameters.js
@@ -108,6 +108,7 @@ const standardMaterialParameterTypes = {
     clearCoatNormalMapOffset: 'vec2',
     clearCoatNormalMapRotation: 'number',
 
+    useSheen: 'boolean',
     sheen: 'rgb',
     sheenMap: 'texture',
     sheenMapChannel: 'string',

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -256,6 +256,7 @@ let _params = new Set();
  * emissiveTint are set, they'll be multiplied by vertex colors.
  * @property {string} emissiveVertexColorChannel Vertex color channels to use for emission. Can be
  * "r", "g", "b", "a", "rgb" or any swizzled combination.
+ * @property {boolean} useSheen Toggle sheen specular effect on/off.
  * @property {Color} sheen The specular color of the sheen (fabric) microfiber structure. This color value is 3-component
  * (RGB), where each component is between 0 and 1.
  * @property {boolean} sheenTint Multiply sheen map and/or sheen vertex color by the constant sheen value.

--- a/types-fixup.mjs
+++ b/types-fixup.mjs
@@ -444,6 +444,7 @@ const standardMaterialProps = [
     ['specularityFactorMapRotation', 'number'],
     ['specularityFactorMapTiling', 'Vec2'],
     ['specularityFactorMapUv', 'number'],
+    ['useSheen', 'boolean'],
     ['sheen', 'Color'],
     ['sheenMap', 'Texture|null'],
     ['sheenMapChannel', 'string'],


### PR DESCRIPTION
### Description

The previous approach assumed that sheen and reflections were always both enabled at the same time, since the addReflectionSheen function relies on calcReflections. This is of course incorrect for materials where no environment maps are used. 

Add the useSheen boolean to the public API of the material. This will toggle the sheen effect on and off.