### PR TITLE
Fix gltf ior

### DIFF
--- a/src/resources/parser/glb-parser.js
+++ b/src/resources/parser/glb-parser.js
@@ -1129,7 +1129,7 @@ const extensionSpecular = function (data, material, textures) {
 
 const extensionIor = function (data, material, textures) {
     if (data.hasOwnProperty('ior')) {
-        material.refractionIndex = data.ior;
+        material.refractionIndex = 1.0 / data.ior;
     }
 };
 


### PR DESCRIPTION
We store 1.0 / ior, so set it correctly when loading gltf.