### PR TITLE
Change GLBs to load refractionIndex as 1.0 / ior

### DIFF
--- a/src/resources/parser/glb-parser.js
+++ b/src/resources/parser/glb-parser.js
@@ -1129,7 +1129,7 @@ const extensionSpecular = function (data, material, textures) {
 
 const extensionIor = function (data, material, textures) {
     if (data.hasOwnProperty('ior')) {
-        material.refractionIndex = data.ior;
+        material.refractionIndex = 1.0 / data.ior;
     }
 };
 


### PR DESCRIPTION
### Description
With refractionIndex being redefined to mean 1.0 / IOR, we have to also make sure the GLB loader feeds the value correctly. 