### PR TITLE
Fix Specularity Factor tint with map

### DIFF
--- a/src/scene/materials/standard-material-options-builder.js
+++ b/src/scene/materials/standard-material-options-builder.js
@@ -122,7 +122,7 @@ class StandardMaterialOptionsBuilder {
                             notWhite(stdMat.diffuse);
 
         const useSpecular = !!(stdMat.useMetalness || stdMat.specularMap || stdMat.sphereMap || stdMat.cubeMap ||
-                            notBlack(stdMat.specular) || stdMat.specularityFactor < 1 ||
+                            notBlack(stdMat.specular) || stdMat.specularityFactor > 0 ||
                             stdMat.enableGGXSpecular ||
                             (stdMat.clearCoat > 0));
 
@@ -131,7 +131,8 @@ class StandardMaterialOptionsBuilder {
                              (stdMat.specularTint || (!stdMat.specularMap && !stdMat.specularVertexColor)) &&
                              notWhite(stdMat.specular);
 
-        const specularityFactorTint = useSpecular && stdMat.useMetalness && (stdMat.specularityFactor < 1 && !stdMat.specularityFactorMap);
+        const specularityFactorTint = useSpecular && stdMat.useMetalness &&
+                                      (stdMat.specularityFactorTint || (stdMat.specularityFactor < 1 && !stdMat.specularityFactorMap));
 
         const emissiveTintColor = !stdMat.emissiveMap || (notWhite(stdMat.emissive) && stdMat.emissiveTint);
         const emissiveTintIntensity = (stdMat.emissiveIntensity !== 1);

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -671,7 +671,7 @@ class StandardMaterial extends Material {
             if (!this.specularMap || this.specularTint) {
                 this._setParameter('material_specular', getUniform('specular'));
             }
-            if (!this.specularityFactorMap || this.specularityFactor < 1) {
+            if (!this.specularityFactorMap || this.specularityFactorTint) {
                 this._setParameter('material_specularityFactor', this.specularityFactor);
             }
             if (!this.sheenMap || this.sheenTint) {


### PR DESCRIPTION
### Description
Specularity Factor tint doesn't work if a specularity factor map is supplied. This PR fixes that, and also uses specularityFactor > 0 as a condition for potentially disabling specular effects.  