### PR TITLE
[Fix] Fix to recently introduced issue with Basic shader generator

### DIFF
--- a/src/graphics/program-lib/programs/basic.js
+++ b/src/graphics/program-lib/programs/basic.js
@@ -51,6 +51,12 @@ const basic = {
         // GENERATE VERTEX SHADER
         let code = versionCode(device) + shaderNameCode;
 
+        if (device.deviceType === DEVICETYPE_WEBGPU) {
+            code += shaderChunks.webgpuVS;
+        } else if (device.webgl2) {
+            code += shaderChunks.gles3VS;
+        }
+
         // VERTEX SHADER DECLARATIONS
         code += shaderChunks.transformDeclVS;
 
@@ -108,6 +114,8 @@ const basic = {
 
         if (device.deviceType === DEVICETYPE_WEBGPU) {
             code += shaderChunks.webgpuPS;
+        } else if (device.webgl2) {
+            code += shaderChunks.gles3PS;
         }
 
         // FRAGMENT SHADER DECLARATIONS


### PR DESCRIPTION
Fix to issue introduced in #4497. Now that the version is specified for basic material shaders, chunks with webgl2 defines are needed as well.