### PR TITLE
Fixed nine-sliced tiled elements

### DIFF
--- a/src/graphics/program-lib/programs/standard.js
+++ b/src/graphics/program-lib/programs/standard.js
@@ -269,7 +269,11 @@ const standard = {
         let lightingUv = "";
 
         // global texture bias for standard textures
-        decl.append("uniform float textureBias;");
+        if (options.nineSlicedMode === SPRITE_RENDERMODE_TILED) {
+            decl.append(`const float textureBias = -1000.0;`);
+        } else {
+            decl.append(`uniform float textureBias;`);
+        }
 
         if (ShaderPass.isForward(options.pass)) {
             // parallax

--- a/src/resources/parser/glb-parser.js
+++ b/src/resources/parser/glb-parser.js
@@ -2293,7 +2293,7 @@ const parseGltf = function (gltfChunk, callback) {
 
     // check required extensions
     const extensionsRequired = gltf?.extensionsRequired || [];
-    if (!dracoDecoderInstance && extensionsRequired.indexOf('KHR_draco_mesh_compression') !== -1) {
+    if (!dracoDecoderInstance && !window.DracoDecoderModule && extensionsRequired.indexOf('KHR_draco_mesh_compression') !== -1) {
         WasmModule.getInstance('DracoDecoderModule', (instance) => {
             dracoDecoderInstance = instance;
             callback(null, gltf);

--- a/src/resources/parser/glb-parser.js
+++ b/src/resources/parser/glb-parser.js
@@ -61,7 +61,7 @@ let dracoDecoderInstance = null;
 
 const getGlobalDracoDecoderModule = () => {
     return typeof window !== 'undefined' && window.DracoDecoderModule;
-}
+};
 
 // resources loaded from GLB file that the parser returns
 class GlbResources {

--- a/src/resources/parser/glb-parser.js
+++ b/src/resources/parser/glb-parser.js
@@ -2293,7 +2293,7 @@ const parseGltf = function (gltfChunk, callback) {
 
     // check required extensions
     const extensionsRequired = gltf?.extensionsRequired || [];
-    if (!dracoDecoderInstance && !window.DracoDecoderModule && extensionsRequired.indexOf('KHR_draco_mesh_compression') !== -1) {
+    if (!dracoDecoderInstance && !(window && window.DracoDecoderModule) && extensionsRequired.indexOf('KHR_draco_mesh_compression') !== -1) {
         WasmModule.getInstance('DracoDecoderModule', (instance) => {
             dracoDecoderInstance = instance;
             callback(null, gltf);

--- a/src/resources/parser/glb-parser.js
+++ b/src/resources/parser/glb-parser.js
@@ -59,6 +59,10 @@ import { WasmModule } from '../../core/wasm-module.js';
 // instance of the draco decoder
 let dracoDecoderInstance = null;
 
+const getGlobalDracoDecoderModule = () => {
+    return typeof window !== 'undefined' && window.DracoDecoderModule;
+}
+
 // resources loaded from GLB file that the parser returns
 class GlbResources {
     constructor(gltf) {
@@ -764,7 +768,7 @@ const createMesh = function (device, gltfMesh, accessors, bufferViews, callback,
             if (extensions.hasOwnProperty('KHR_draco_mesh_compression')) {
 
                 // access DracoDecoderModule
-                const decoderModule = dracoDecoderInstance || window.DracoDecoderModule;
+                const decoderModule = dracoDecoderInstance || getGlobalDracoDecoderModule();
                 if (decoderModule) {
                     const extDraco = extensions.KHR_draco_mesh_compression;
                     if (extDraco.hasOwnProperty('attributes')) {
@@ -2293,7 +2297,7 @@ const parseGltf = function (gltfChunk, callback) {
 
     // check required extensions
     const extensionsRequired = gltf?.extensionsRequired || [];
-    if (!dracoDecoderInstance && !(window && window.DracoDecoderModule) && extensionsRequired.indexOf('KHR_draco_mesh_compression') !== -1) {
+    if (!dracoDecoderInstance && !getGlobalDracoDecoderModule() && extensionsRequired.indexOf('KHR_draco_mesh_compression') !== -1) {
         WasmModule.getInstance('DracoDecoderModule', (instance) => {
             dracoDecoderInstance = instance;
             callback(null, gltf);


### PR DESCRIPTION
Fixes #4508

Bug was introduced in #4254. Texture mipmaps must be disabled in nineslice-tiled rendering. We use textureBias to accomplish this.