### PR TITLE
Add HQ reflections

### DIFF
--- a/src/graphics/program-lib/chunks/chunks.js
+++ b/src/graphics/program-lib/chunks/chunks.js
@@ -139,6 +139,7 @@ import reflDirPS from './lit/frag/reflDir.js';
 import reflDirAnisoPS from './lit/frag/reflDirAniso.js';
 import reflectionCCPS from './lit/frag/reflectionCC.js';
 import reflectionCubePS from './lit/frag/reflectionCube.js';
+import reflectionEnvHQPS from './lit/frag/reflectionEnvHQ.js';
 import reflectionEnvPS from './lit/frag/reflectionEnv.js';
 import reflectionSpherePS from './lit/frag/reflectionSphere.js';
 import reflectionSphereLowPS from './lit/frag/reflectionSphereLow.js';
@@ -343,6 +344,7 @@ const shaderChunks = {
     reflDirAnisoPS,
     reflectionCCPS,
     reflectionCubePS,
+    reflectionEnvHQPS,
     reflectionEnvPS,
     reflectionSpherePS,
     reflectionSphereLowPS,

--- a/src/graphics/program-lib/chunks/lit/frag/reflectionEnvHQ.js
+++ b/src/graphics/program-lib/chunks/lit/frag/reflectionEnvHQ.js
@@ -1,0 +1,28 @@
+export default /* glsl */`
+#ifndef ENV_ATLAS
+#define ENV_ATLAS
+uniform sampler2D texture_envAtlas;
+#endif
+uniform samplerCube texture_cubeMap;
+uniform float material_reflectivity;
+
+vec3 calcReflection(vec3 tReflDirW, float tGlossiness) {
+    vec3 dir = cubeMapProject(tReflDirW) * vec3(-1.0, 1.0, 1.0);
+    vec2 uv = toSphericalUv(dir);
+
+    // calculate roughness level
+    float level = saturate(1.0 - tGlossiness) * 5.0;
+    float ilevel = floor(level);
+    float flevel = level - ilevel;
+
+    vec3 sharp = $DECODE(textureCube(texture_cubeMap, fixSeams(dir)));
+    vec3 roughA = $DECODE(texture2D(texture_envAtlas, mapRoughnessUv(uv, ilevel)));
+    vec3 roughB = $DECODE(texture2D(texture_envAtlas, mapRoughnessUv(uv, ilevel + 1.0)));
+
+    return processEnvironment(mix(sharp, mix(roughA, roughB, flevel), min(level, 1.0)));
+}
+
+void addReflection() {   
+    dReflection += vec4(calcReflection(dReflDirW, dGlossiness), material_reflectivity);
+}
+`;

--- a/src/graphics/program-lib/programs/lit-shader.js
+++ b/src/graphics/program-lib/programs/lit-shader.js
@@ -822,7 +822,11 @@ class LitShader {
             }
         }
 
-        if (options.reflectionSource === 'envAtlas') {
+        if (options.reflectionSource === 'envAtlasHQ') {
+            code += options.fixSeams ? chunks.fixCubemapSeamsStretchPS : chunks.fixCubemapSeamsNonePS;
+            code += chunks.envAtlasPS;
+            code += chunks.reflectionEnvHQPS.replace(/\$DECODE/g, ChunkUtils.decodeFunc(options.reflectionEncoding));
+        } else if (options.reflectionSource === 'envAtlas') {
             code += chunks.envAtlasPS;
             code += chunks.reflectionEnvPS.replace(/\$DECODE/g, ChunkUtils.decodeFunc(options.reflectionEncoding));
         } else if (options.reflectionSource === 'cubeMap') {
@@ -930,7 +934,7 @@ class LitShader {
             if (options.ambientSource === 'ambientSH') {
                 code += chunks.ambientSHPS;
             } else if (options.ambientSource === 'envAtlas') {
-                if (options.reflectionSource !== 'envAtlas') {
+                if (options.reflectionSource !== 'envAtlas' && options.reflectionSource !== 'envAtlasHQ') {
                     code += chunks.envAtlasPS;
                 }
                 code += chunks.ambientEnvPS.replace(/\$DECODE/g, ChunkUtils.decodeFunc(options.ambientEncoding));

--- a/src/scene/materials/standard-material-options-builder.js
+++ b/src/scene/materials/standard-material-options-builder.js
@@ -203,7 +203,10 @@ class StandardMaterialOptionsBuilder {
         let usingSceneEnv = false;
 
         // source of environment reflections is as follows:
-        if (stdMat.envAtlas && !isPhong) {
+        if (stdMat.envAtlas && stdMat.cubeMap && !isPhong) {
+            options.reflectionSource = 'envAtlasHQ';
+            options.reflectionEncoding = stdMat.envAtlas.encoding;
+        } else if (stdMat.envAtlas && !isPhong) {
             options.reflectionSource = 'envAtlas';
             options.reflectionEncoding = stdMat.envAtlas.encoding;
         } else if (stdMat.cubeMap) {
@@ -212,6 +215,10 @@ class StandardMaterialOptionsBuilder {
         } else if (stdMat.sphereMap) {
             options.reflectionSource = 'sphereMap';
             options.reflectionEncoding = stdMat.sphereMap.encoding;
+        } else if (stdMat.useSkybox && scene.envAtlas && scene.skybox && !isPhong) {
+            options.reflectionSource = 'envAtlasHQ';
+            options.reflectionEncoding = scene.envAtlas.encoding;
+            usingSceneEnv = true;
         } else if (stdMat.useSkybox && scene.envAtlas && !isPhong) {
             options.reflectionSource = 'envAtlas';
             options.reflectionEncoding = scene.envAtlas.encoding;

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -783,8 +783,7 @@ class StandardMaterial extends Material {
             if (scene.envAtlas && scene.skybox && !isPhong) {
                 this._setParameter('texture_envAtlas', scene.envAtlas);
                 this._setParameter('texture_cubeMap', scene.skybox);
-            }
-            else if (scene.envAtlas && !isPhong) {
+            } else if (scene.envAtlas && !isPhong) {
                 this._setParameter('texture_envAtlas', scene.envAtlas);
             } else if (scene.skybox) {
                 this._setParameter('texture_cubeMap', scene.skybox);

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -483,7 +483,7 @@ let _params = new Set();
  * from per-instance {@link VertexBuffer} instead of shader's uniforms.
  * - useMorphPosition: if morphing code should be generated to morph positions.
  * - useMorphNormal: if morphing code should be generated to morph normals.
- * - reflectionSource: one of "envAtlas", "cubeMap", "sphereMap"
+ * - reflectionSource: one of "envAtlasHQ", "envAtlas", "cubeMap", "sphereMap"
  * - reflectionEncoding: one of null, "rgbm", "rgbe", "linear", "srgb"
  * - ambientSource: one of "ambientSH", "envAtlas", "constant"
  * - ambientEncoding: one of null, "rgbm", "rgbe", "linear", "srgb"
@@ -754,7 +754,10 @@ class StandardMaterial extends Material {
         const isPhong = this.shadingModel === SPECULAR_PHONG;
 
         // set overridden environment textures
-        if (this.envAtlas && !isPhong) {
+        if (this.envAtlas && this.cubeMap && !isPhong) {
+            this._setParameter('texture_envAtlas', this.envAtlas);
+            this._setParameter('texture_cubeMap', this.cubeMap);
+        } else if (this.envAtlas && !isPhong) {
             this._setParameter('texture_envAtlas', this.envAtlas);
         } else if (this.cubeMap) {
             this._setParameter('texture_cubeMap', this.cubeMap);
@@ -777,7 +780,11 @@ class StandardMaterial extends Material {
         const hasLocalEnvOverride = (this.envAtlas && !isPhong) || this.cubeMap || this.sphereMap;
 
         if (!hasLocalEnvOverride && this.useSkybox) {
-            if (scene.envAtlas && !isPhong) {
+            if (scene.envAtlas && scene.skybox && !isPhong) {
+                this._setParameter('texture_envAtlas', scene.envAtlas);
+                this._setParameter('texture_cubeMap', scene.skybox);
+            }
+            else if (scene.envAtlas && !isPhong) {
                 this._setParameter('texture_envAtlas', scene.envAtlas);
             } else if (scene.skybox) {
                 this._setParameter('texture_cubeMap', scene.skybox);


### PR DESCRIPTION
Fixes #4483

This PR adds a high quality ("HQ") reflection chunk which uses the original environment cubemap for sharp reflections and the envAtlas for blurry reflections.

The HQ chunk requires an additional sampler compared to the existing solution, but otherwise performance should be comparable. 

Before:
<img src="https://user-images.githubusercontent.com/11276292/183070289-587c73c6-b920-4f44-a0c2-4e3e298ac004.png" alt="before" width="512"/>

After:
<img src="https://user-images.githubusercontent.com/11276292/183070483-6cab327d-dd85-4368-9156-c74f97c5fd3d.png" alt="before" width="512"/>