### PR TITLE
Fixed issue (#3733) that prevents XR from working in certain circumstances

### DIFF
--- a/src/framework/app-base.js
+++ b/src/framework/app-base.js
@@ -2179,30 +2179,34 @@ const makeTick = function (_app) {
         application._inFrameUpdate = true;
         application.fire("frameupdate", ms);
 
+        let shouldRenderFrame = true;
+
         if (frame) {
-            application.xr?.update(frame);
+            shouldRenderFrame = application.xr?.update(frame);
             application.graphicsDevice.defaultFramebuffer = frame.session.renderState.baseLayer.framebuffer;
         } else {
             application.graphicsDevice.defaultFramebuffer = null;
         }
 
-        application.update(dt);
+        if (shouldRenderFrame) {
+            application.update(dt);
 
-        application.fire("framerender");
+            application.fire("framerender");
 
-        Debug.trace(TRACEID_RENDER_FRAME, `--- Frame ${application.frame}`);
+            Debug.trace(TRACEID_RENDER_FRAME, `--- Frame ${application.frame}`);
 
-        if (application.autoRender || application.renderNextFrame) {
-            application.updateCanvasSize();
-            application.render();
-            application.renderNextFrame = false;
+            if (application.autoRender || application.renderNextFrame) {
+                application.updateCanvasSize();
+                application.render();
+                application.renderNextFrame = false;
+            }
+
+            // set event data
+            _frameEndData.timestamp = now();
+            _frameEndData.target = application;
+
+            application.fire("frameend", _frameEndData);
         }
-
-        // set event data
-        _frameEndData.timestamp = now();
-        _frameEndData.target = application;
-
-        application.fire("frameend", _frameEndData);
 
         application._inFrameUpdate = false;
 

--- a/src/xr/xr-manager.js
+++ b/src/xr/xr-manager.js
@@ -668,7 +668,7 @@ class XrManager extends EventHandler {
 
     /**
      * @param {*} frame - XRFrame from requestAnimationFrame callback.
-     * 
+     *
      * @returns {boolean} True if update was successful, false otherwise.
      * @ignore
      */

--- a/src/xr/xr-manager.js
+++ b/src/xr/xr-manager.js
@@ -688,7 +688,7 @@ class XrManager extends EventHandler {
 
         if (!pose) return false;
 
-        const lengthNew = pose ? pose.views.length : 0;
+        const lengthNew = pose.views.length;
 
         if (lengthNew > this.views.length) {
             // add new views into list


### PR DESCRIPTION
Fixes #3733 

Fixed bug where having another WebGL instance open in the same browser stops the experience from launching properly.

The problem was solved by preventing playcanvas from rendering new frames when it cannot get the pose of the connected xr device.

It was tested with Oculus Quest 1 and 2 on both Airlink and the link cable.

This is my first PR, so if I need to make any changes let me know.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
