### PR TITLE
When material is not set on mesh instance, warn and use default one.

### DIFF
--- a/src/scene/mesh-instance.js
+++ b/src/scene/mesh-instance.js
@@ -19,6 +19,7 @@ import {
 } from './constants.js';
 
 import { GraphNode } from './graph-node.js';
+import { getDefaultMaterial } from './materials/default-material.js';
 import { LightmapCache } from './lightmapper/lightmap-cache.js';
 
 /** @typedef {import('../graphics/texture.js').Texture} Texture */
@@ -745,6 +746,13 @@ class MeshInstance {
     updatePassShader(scene, pass, staticLightList, sortedLights, viewUniformFormat, viewBindGroupFormat) {
         this._shader[pass] = this.material.getShaderVariant(this.mesh.device, scene, this._shaderDefs, staticLightList, pass, sortedLights,
                                                             viewUniformFormat, viewBindGroupFormat);
+    }
+
+    ensureMaterial(device) {
+        if (!this.material) {
+            Debug.warn(`Mesh attached to entity '${this.node.name}' does not have a material, using a default one.`);
+            this.material = getDefaultMaterial(device);
+        }
     }
 
     // Parameter management

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -37,7 +37,6 @@ import {
 } from '../constants.js';
 import { Material } from '../materials/material.js';
 import { LightTextureAtlas } from '../lighting/light-texture-atlas.js';
-import { getDefaultMaterial } from '../materials/default-material.js';
 
 import { ShadowRenderer } from './shadow-renderer.js';
 import { StaticMeshes } from './static-meshes.js';
@@ -1291,9 +1290,7 @@ class ForwardRenderer {
                 }
                 // #endif
 
-                if (!drawCall.material)
-                    drawCall.material = getDefaultMaterial(device);
-
+                drawCall.ensureMaterial(device);
                 const material = drawCall.material;
 
                 const objDefs = drawCall._shaderDefs;

--- a/src/scene/renderer/shadow-renderer.js
+++ b/src/scene/renderer/shadow-renderer.js
@@ -490,6 +490,8 @@ class ShadowRenderer {
         for (let i = 0; i < count; i++) {
             const meshInstance = visibleCasters[i];
             const mesh = meshInstance.mesh;
+
+            meshInstance.ensureMaterial(device);
             const material = meshInstance.material;
 
             // set basic material states/parameters


### PR DESCRIPTION
- make this consistent for both forward and shadow renderer. Related to https://github.com/playcanvas/engine/issues/4498