### PR TITLE
Clear wasm module global

### DIFF
--- a/src/core/wasm-module.js
+++ b/src/core/wasm-module.js
@@ -47,7 +47,13 @@ class Impl {
                 if (err) {
                     callback(err, null);
                 } else {
-                    window[moduleName]({
+                    const module = window[moduleName];
+
+                    // clear the module from the global window since we used to store global instance here
+                    window[moduleName] = undefined;
+
+                    // instantiate the module
+                    module({
                         locateFile: () => config.wasmUrl,
                         onAbort: () => {
                             callback('wasm module aborted.');


### PR DESCRIPTION
Glb-parser currently fails to work with draco because it looks at window global for wasm module.

This PR changes WasmModule to clear the global module object on window.