### PR TITLE
Add support for material variants

### DIFF
--- a/src/resources/container.js
+++ b/src/resources/container.js
@@ -90,11 +90,12 @@ class ContainerResource {
 
     /**
      * Applies a material variant to a set of mesh instances. Compared to the applyMaterialVariant,
-     * this method allows for setting the variant on a specific set of mesh instances instead of the 
+     * this method allows for setting the variant on a specific set of mesh instances instead of the
      * whole entity.
      *
-     * @param {string} name - Is the name of the variant, as quered from getMaterialVariants
+     * @param {string} name - The the name of the variant, as quered from getMaterialVariants
      * @param {MeshInstance[]} instances - An array of mesh instances
+     * @example
      * // load a glb file and instantiate an entity with a render component based on it
      * app.assets.loadFromUrl("statue.glb", "container", function (err, asset) {
      *     var entity = asset.resource.instantiateRenderEntity({
@@ -109,6 +110,20 @@ class ContainerResource {
      *     }
      */
     applyMaterialVariantInstances(name, instances) {}
+
+    /**
+     * Reset variant selection on entity hierarchy to use the default material
+     *
+     * @param {Entity} entity - The entity to reset variants on
+     */
+    resetMaterialVariant(entity) {}
+
+    /**
+     * Reset variant selection on set of mesh instances to use the default material
+     *
+     * @param {MeshInstance[]} instances - An array of mesh instances to reset variants on
+     */
+    resetMaterialVariantInstances(instances) {}
 }
 
 /**

--- a/src/resources/container.js
+++ b/src/resources/container.js
@@ -60,6 +60,24 @@ class ContainerResource {
     instantiateRenderEntity(options) {
         return null;
     }
+
+    /**
+     * Queries the list of available material variants.
+     *
+     * @returns {object} A map which maps a variant name as a string to the variant index
+     * @example
+     * // load a glb file and instantiate an entity with a render component based on it
+     * app.assets.loadFromUrl("statue.glb", "container", function (err, asset) {
+     *     var entity = asset.resource.instantiateRenderEntity({
+     *         castShadows: true
+     *     });
+     *     app.root.addChild(entity);
+     *     let materialVariants = Object.keys(asset.resource.getMaterialVariants());
+     *     const variantListOptions: Array<{ v:string, t:string }> = materialVariants.map((variant: string) => ({ v: variant, t: variant }));
+     */
+    getMaterialVariants() {
+        return null;
+    }
 }
 
 /**

--- a/src/resources/container.js
+++ b/src/resources/container.js
@@ -92,7 +92,7 @@ class ContainerResource {
      *         castShadows: true
      *     });
      *     app.root.addChild(entity);
-     *     let materialVariants = Object.keys(asset.resource.getMaterialVariants());
+     *     var materialVariants = Object.keys(asset.resource.getMaterialVariants());
      *     asset.resource.applyMaterialVariant(materialVariants[0], entity);
      */
     applyMaterialVariant(name, entity) {}
@@ -109,9 +109,9 @@ class ContainerResource {
      *         castShadows: true
      *     });
      *     app.root.addChild(entity);
-     *     let materialVariants = Object.keys(asset.resource.getMaterialVariants());
+     *     var materialVariants = Object.keys(asset.resource.getMaterialVariants());
      *     const renders = entity.findComponents("render");
-     *     for (let i = 0; i < renders.length; i++) {
+     *     for (var i = 0; i < renders.length; i++) {
      *         const renderComponent = renders[i];
      *         asset.resource.applyMaterialVariantInstances(materialVariants[0], renderComponent.meshInstances);
      *     }

--- a/src/resources/container.js
+++ b/src/resources/container.js
@@ -2,6 +2,7 @@ import { path } from '../core/path.js';
 import { GlbParser } from './parser/glb-parser.js';
 
 /** @typedef {import('../framework/entity.js').Entity} Entity */
+/** @typedef {import('../scene/mesh-instance').MeshInstance} MeshInstance */
 /** @typedef {import('../framework/app-base.js').AppBase} AppBase */
 /** @typedef {import('./handler.js').ResourceHandler} ResourceHandler */
 /** @typedef {import('./handler.js').ResourceHandlerCallback} ResourceHandlerCallback */
@@ -78,6 +79,44 @@ class ContainerResource {
     getMaterialVariants() {
         return null;
     }
+
+    /**
+     * Applies a material variant to an entity
+     *
+     * @param {string} name - Is the name of the variant, as quered from getMaterialVariants
+     * @param {Entity} entity - Is the entity to which material variants will be applied
+     * @example
+     * // load a glb file and instantiate an entity with a render component based on it
+     * app.assets.loadFromUrl("statue.glb", "container", function (err, asset) {
+     *     var entity = asset.resource.instantiateRenderEntity({
+     *         castShadows: true
+     *     });
+     *     app.root.addChild(entity);
+     *     let materialVariants = Object.keys(asset.resource.getMaterialVariants());
+     *     asset.resource.applyMaterialVariant(materialVariants[0], entity);
+     */
+    applyMaterialVariant(name, entity) {}
+
+    /**
+     * Applies a material variant to a set of mesh instances. This method allows for a selective
+     * set of MeshInstances to apply a variant, instead of the entire entity
+     *
+     * @param {string} name - Is the name of the variant, as quered from getMaterialVariants
+     * @param {MeshInstance} [instances] - An array of mesh instances
+     * // load a glb file and instantiate an entity with a render component based on it
+     * app.assets.loadFromUrl("statue.glb", "container", function (err, asset) {
+     *     var entity = asset.resource.instantiateRenderEntity({
+     *         castShadows: true
+     *     });
+     *     app.root.addChild(entity);
+     *     let materialVariants = Object.keys(asset.resource.getMaterialVariants());
+     *     const renders = entity.findComponents("render");
+     *     for (let i = 0; i < renders.length; i++) {
+     *         const renderComponent = renders[i];
+     *         asset.resource.applyMaterialVariantInstances(materialVariants[0], renderComponent.meshInstances);
+     *     }
+     */
+    applyMaterialVariantInstances(name, instances) {}
 }
 
 /**

--- a/src/resources/container.js
+++ b/src/resources/container.js
@@ -74,8 +74,9 @@ class ContainerResource {
     /**
      * Applies a material variant to an entity hierarchy.
      *
-     * @param {string} name - The name of the variant, as quered from getMaterialVariants.
      * @param {Entity} entity - The entity root to which material variants will be applied
+     * @param {string} [name] - The name of the variant, as quered from getMaterialVariants,
+     * if null the variant will be reset to the default
      * @example
      * // load a glb file and instantiate an entity with a render component based on it
      * app.assets.loadFromUrl("statue.glb", "container", function (err, asset) {
@@ -86,15 +87,16 @@ class ContainerResource {
      *     var materialVariants = asset.resource.getMaterialVariants();
      *     asset.resource.applyMaterialVariant(materialVariants[0], entity);
      */
-    applyMaterialVariant(name, entity) {}
+    applyMaterialVariant(entity, name) {}
 
     /**
      * Applies a material variant to a set of mesh instances. Compared to the applyMaterialVariant,
      * this method allows for setting the variant on a specific set of mesh instances instead of the
      * whole entity.
      *
-     * @param {string} name - The the name of the variant, as quered from getMaterialVariants
      * @param {MeshInstance[]} instances - An array of mesh instances
+     * @param {string} [name] - The the name of the variant, as quered from getMaterialVariants,
+     * if null the variant will be reset to the default
      * @example
      * // load a glb file and instantiate an entity with a render component based on it
      * app.assets.loadFromUrl("statue.glb", "container", function (err, asset) {
@@ -109,21 +111,7 @@ class ContainerResource {
      *         asset.resource.applyMaterialVariantInstances(materialVariants[0], renderComponent.meshInstances);
      *     }
      */
-    applyMaterialVariantInstances(name, instances) {}
-
-    /**
-     * Reset variant selection on entity hierarchy to use the default material
-     *
-     * @param {Entity} entity - The entity to reset variants on
-     */
-    resetMaterialVariant(entity) {}
-
-    /**
-     * Reset variant selection on set of mesh instances to use the default material
-     *
-     * @param {MeshInstance[]} instances - An array of mesh instances to reset variants on
-     */
-    resetMaterialVariantInstances(instances) {}
+    applyMaterialVariantInstances(instances, name) {}
 }
 
 /**

--- a/src/resources/container.js
+++ b/src/resources/container.js
@@ -65,7 +65,7 @@ class ContainerResource {
     /**
      * Queries the list of available material variants.
      *
-     * @returns {object} A map which maps a variant name as a string to the variant index
+     * @returns {string[]} An array of variant names.
      * @example
      * // load a glb file and instantiate an entity with a render component based on it
      * app.assets.loadFromUrl("statue.glb", "container", function (err, asset) {
@@ -73,18 +73,18 @@ class ContainerResource {
      *         castShadows: true
      *     });
      *     app.root.addChild(entity);
-     *     let materialVariants = Object.keys(asset.resource.getMaterialVariants());
-     *     const variantListOptions: Array<{ v:string, t:string }> = materialVariants.map((variant: string) => ({ v: variant, t: variant }));
+     *     var materialVariants = asset.resource.getMaterialVariants();
+     *     var variantListOptions = materialVariants.map((variant) => ({ v: variant, t: variant }));
      */
     getMaterialVariants() {
         return null;
     }
 
     /**
-     * Applies a material variant to an entity
+     * Applies a material variant to an entity hierarchy.
      *
-     * @param {string} name - Is the name of the variant, as quered from getMaterialVariants
-     * @param {Entity} entity - Is the entity to which material variants will be applied
+     * @param {string} name - The name of the variant, as quered from getMaterialVariants
+     * @param {Entity} entity - The entity root to which material variants will be applied
      * @example
      * // load a glb file and instantiate an entity with a render component based on it
      * app.assets.loadFromUrl("statue.glb", "container", function (err, asset) {
@@ -102,7 +102,7 @@ class ContainerResource {
      * set of MeshInstances to apply a variant, instead of the entire entity
      *
      * @param {string} name - Is the name of the variant, as quered from getMaterialVariants
-     * @param {MeshInstance} [instances] - An array of mesh instances
+     * @param {MeshInstance[]} instances - An array of mesh instances
      * // load a glb file and instantiate an entity with a render component based on it
      * app.assets.loadFromUrl("statue.glb", "container", function (err, asset) {
      *     var entity = asset.resource.instantiateRenderEntity({

--- a/src/resources/container.js
+++ b/src/resources/container.js
@@ -75,7 +75,7 @@ class ContainerResource {
      * Applies a material variant to an entity hierarchy.
      *
      * @param {Entity} entity - The entity root to which material variants will be applied
-     * @param {string} [name] - The name of the variant, as quered from getMaterialVariants,
+     * @param {string} [name] - The name of the variant, as queried from getMaterialVariants,
      * if null the variant will be reset to the default
      * @example
      * // load a glb file and instantiate an entity with a render component based on it
@@ -85,7 +85,7 @@ class ContainerResource {
      *     });
      *     app.root.addChild(entity);
      *     var materialVariants = asset.resource.getMaterialVariants();
-     *     asset.resource.applyMaterialVariant(materialVariants[0], entity);
+     *     asset.resource.applyMaterialVariant(entity, materialVariants[0]);
      */
     applyMaterialVariant(entity, name) {}
 
@@ -105,10 +105,10 @@ class ContainerResource {
      *     });
      *     app.root.addChild(entity);
      *     var materialVariants = asset.resource.getMaterialVariants();
-     *     const renders = entity.findComponents("render");
+     *     var renders = entity.findComponents("render");
      *     for (var i = 0; i < renders.length; i++) {
-     *         const renderComponent = renders[i];
-     *         asset.resource.applyMaterialVariantInstances(materialVariants[0], renderComponent.meshInstances);
+     *         var renderComponent = renders[i];
+     *         asset.resource.applyMaterialVariantInstances(renderComponent.meshInstances, materialVariants[0]);
      *     }
      */
     applyMaterialVariantInstances(instances, name) {}

--- a/src/resources/container.js
+++ b/src/resources/container.js
@@ -66,15 +66,6 @@ class ContainerResource {
      * Queries the list of available material variants.
      *
      * @returns {string[]} An array of variant names.
-     * @example
-     * // load a glb file and instantiate an entity with a render component based on it
-     * app.assets.loadFromUrl("statue.glb", "container", function (err, asset) {
-     *     var entity = asset.resource.instantiateRenderEntity({
-     *         castShadows: true
-     *     });
-     *     app.root.addChild(entity);
-     *     var materialVariants = asset.resource.getMaterialVariants();
-     *     var variantListOptions = materialVariants.map((variant) => ({ v: variant, t: variant }));
      */
     getMaterialVariants() {
         return null;
@@ -83,7 +74,7 @@ class ContainerResource {
     /**
      * Applies a material variant to an entity hierarchy.
      *
-     * @param {string} name - The name of the variant, as quered from getMaterialVariants
+     * @param {string} name - The name of the variant, as quered from getMaterialVariants.
      * @param {Entity} entity - The entity root to which material variants will be applied
      * @example
      * // load a glb file and instantiate an entity with a render component based on it
@@ -92,14 +83,15 @@ class ContainerResource {
      *         castShadows: true
      *     });
      *     app.root.addChild(entity);
-     *     var materialVariants = Object.keys(asset.resource.getMaterialVariants());
+     *     var materialVariants = asset.resource.getMaterialVariants();
      *     asset.resource.applyMaterialVariant(materialVariants[0], entity);
      */
     applyMaterialVariant(name, entity) {}
 
     /**
-     * Applies a material variant to a set of mesh instances. This method allows for a selective
-     * set of MeshInstances to apply a variant, instead of the entire entity
+     * Applies a material variant to a set of mesh instances. Compared to the applyMaterialVariant,
+     * this method allows for setting the variant on a specific set of mesh instances instead of the 
+     * whole entity.
      *
      * @param {string} name - Is the name of the variant, as quered from getMaterialVariants
      * @param {MeshInstance[]} instances - An array of mesh instances
@@ -109,7 +101,7 @@ class ContainerResource {
      *         castShadows: true
      *     });
      *     app.root.addChild(entity);
-     *     var materialVariants = Object.keys(asset.resource.getMaterialVariants());
+     *     var materialVariants = asset.resource.getMaterialVariants();
      *     const renders = entity.findComponents("render");
      *     for (var i = 0; i < renders.length; i++) {
      *         const renderComponent = renders[i];

--- a/src/resources/parser/glb-container-resource.js
+++ b/src/resources/parser/glb-container-resource.js
@@ -200,7 +200,7 @@ class GlbContainerResource {
     applyMaterialVariant(name, entity) {
         const variant = this.data.variants[name];
         if (!variant)
-            return;        
+            return;
         const renders = entity.findComponents("render");
         for (let i = 0; i < renders.length; i++) {
             const renderComponent = renders[i];

--- a/src/resources/parser/glb-container-resource.js
+++ b/src/resources/parser/glb-container-resource.js
@@ -199,6 +199,10 @@ class GlbContainerResource {
 
     // apply material variant to entity
     applyMaterialVariant(name, entity) {
+        if (!name) {
+            this.resetMaterialVariant(entity);
+            return;
+        }
         const variant = this.data.variants[name];
         if (variant === undefined) {
             Debug.warn(`No variant named ${name} exists in resource`);
@@ -211,8 +215,21 @@ class GlbContainerResource {
         }
     }
 
+    // reset material variants on entity
+    resetMaterialVariant(entity) {
+        const renders = entity.findComponents("render");
+        for (let i = 0; i < renders.length; i++) {
+            const renderComponent = renders[i];
+            this._resetMaterialVariant(renderComponent.meshInstances);
+        }
+    }
+
     // apply material variant to mesh instances
     applyMaterialVariantInstances(name, instances) {
+        if (!name) {
+            this.resetMaterialVariantInstances(instances);
+            return;
+        }
         const variant = this.data.variants[name];
         if (variant === undefined) {
             Debug.warn(`No variant named ${name} exists in resource`);
@@ -221,13 +238,26 @@ class GlbContainerResource {
         this._applyMaterialVariant(variant, instances);
     }
 
+    // reset material variant on instances
+    resetMaterialVariantInstances(instances) {
+        this._resetMaterialVariant(instances);
+    }
+
     // internally apply variant to instances
     _applyMaterialVariant(variant, instances) {
         instances.forEach((instance) => {
             const meshVariants = this.data.meshVariants[instance.mesh.id];
             if (meshVariants) {
                 instance.material = this.data.materials[meshVariants[variant]];
+                Debug.assert(instance.material);
             }
+        });
+    }
+
+    // internally apply the default material
+    _resetMaterialVariant(instances) {
+        instances.forEach((instances) => {
+            instances.material = this._defaultMaterial;
         });
     }
 

--- a/src/resources/parser/glb-container-resource.js
+++ b/src/resources/parser/glb-container-resource.js
@@ -196,8 +196,23 @@ class GlbContainerResource {
         return this.data.variants;
     }
 
+    // apply material variant to entity
+    applyMaterialVariant(name, entity) {
+        const renders = entity.findComponents("render");
+        for (let i = 0; i < renders.length; i++) {
+            const renderComponent = renders[i];
+            const variant = this.data.variants[name];
+            renderComponent.meshInstances.forEach((instance) => {
+                const meshVariants = this.data.meshVariants[instance.mesh.id];
+                if (meshVariants) {
+                    instance.material = this.data.materials[meshVariants[variant]];
+                }
+            });
+        }
+    }
+
     // apply material variant to mesh instances
-    applyMaterialVariant(name, instances) {
+    applyMaterialVariantInstances(name, instances) {
         const variant = this.data.variants[name];
         instances.forEach((instance) => {
             const meshVariants = this.data.meshVariants[instance.mesh.id];

--- a/src/resources/parser/glb-container-resource.js
+++ b/src/resources/parser/glb-container-resource.js
@@ -230,9 +230,9 @@ class GlbContainerResource {
                 const meshVariants = this.data.meshVariants[instance.mesh.id];
                 if (meshVariants) {
                     instance.material = this.data.materials[meshVariants[variant]];
-                    Debug.assert(instance.material);
                 }
             }
+            Debug.assert(instance.material);
         });
     }
 

--- a/src/resources/parser/glb-container-resource.js
+++ b/src/resources/parser/glb-container-resource.js
@@ -199,12 +199,12 @@ class GlbContainerResource {
     // apply material variant to mesh instances
     applyMaterialVariant(name, instances, index) {
         const variant = this.data.variants[name];
-        const meshVariant = this.data.meshVariants[index];
-        if (meshVariant[variant]) {
-            instances.forEach((instance) => {
-                instance.material = this.data.materials[meshVariant[variant]];
-            });
-        }
+        instances.forEach((instance) => {
+            const meshVariants = this.data.meshVariants[instance.mesh.id];
+            if (meshVariants) {
+                instance.material = this.data.materials[meshVariants[variant]];
+            }
+        });
     }
 
     // helper function to create a single hierarchy from an array of nodes

--- a/src/resources/parser/glb-container-resource.js
+++ b/src/resources/parser/glb-container-resource.js
@@ -197,7 +197,7 @@ class GlbContainerResource {
     }
 
     // apply material variant to mesh instances
-    applyMaterialVariant(name, instances, index) {
+    applyMaterialVariant(name, instances) {
         const variant = this.data.variants[name];
         instances.forEach((instance) => {
             const meshVariants = this.data.meshVariants[instance.mesh.id];

--- a/src/resources/parser/glb-container-resource.js
+++ b/src/resources/parser/glb-container-resource.js
@@ -198,9 +198,9 @@ class GlbContainerResource {
     }
 
     // apply material variant to entity
-    applyMaterialVariant(name, entity) {
+    applyMaterialVariant(entity, name) {
         if (!name) {
-            this.resetMaterialVariant(entity);
+            this._resetMaterialVariant(entity);
             return;
         }
         const variant = this.data.variants[name];
@@ -216,18 +216,18 @@ class GlbContainerResource {
     }
 
     // reset material variants on entity
-    resetMaterialVariant(entity) {
+    _resetMaterialVariant(entity) {
         const renders = entity.findComponents("render");
         for (let i = 0; i < renders.length; i++) {
             const renderComponent = renders[i];
-            this._resetMaterialVariant(renderComponent.meshInstances);
+            this._resetMaterialVariantInstances(renderComponent.meshInstances);
         }
     }
 
     // apply material variant to mesh instances
-    applyMaterialVariantInstances(name, instances) {
+    applyMaterialVariantInstances(instances, name) {
         if (!name) {
-            this.resetMaterialVariantInstances(instances);
+            this._resetMaterialVariantInstances(instances);
             return;
         }
         const variant = this.data.variants[name];
@@ -239,8 +239,10 @@ class GlbContainerResource {
     }
 
     // reset material variant on instances
-    resetMaterialVariantInstances(instances) {
-        this._resetMaterialVariant(instances);
+    _resetMaterialVariantInstances(instances) {
+        instances.forEach((instances) => {
+            instances.material = this._defaultMaterial;
+        });
     }
 
     // internally apply variant to instances
@@ -251,13 +253,6 @@ class GlbContainerResource {
                 instance.material = this.data.materials[meshVariants[variant]];
                 Debug.assert(instance.material);
             }
-        });
-    }
-
-    // internally apply the default material
-    _resetMaterialVariant(instances) {
-        instances.forEach((instances) => {
-            instances.material = this._defaultMaterial;
         });
     }
 

--- a/src/resources/parser/glb-container-resource.js
+++ b/src/resources/parser/glb-container-resource.js
@@ -5,6 +5,7 @@ import { MorphInstance } from '../../scene/morph-instance.js';
 import { SkinInstance } from '../../scene/skin-instance.js';
 import { SkinInstanceCache } from '../../scene/skin-instance-cache.js';
 import { Model } from '../../scene/model.js';
+import { Debug } from '../../core/debug.js';
 
 // Container resource returned by the GlbParser. Implements the ContainerResource interface.
 class GlbContainerResource {
@@ -199,25 +200,29 @@ class GlbContainerResource {
     // apply material variant to entity
     applyMaterialVariant(name, entity) {
         const variant = this.data.variants[name];
-        if (!variant)
+        if (variant === undefined) {
+            Debug.warn(`No variant named ${name} exists in resource`);
             return;
+        }
         const renders = entity.findComponents("render");
         for (let i = 0; i < renders.length; i++) {
             const renderComponent = renders[i];
-            renderComponent.meshInstances.forEach((instance) => {
-                const meshVariants = this.data.meshVariants[instance.mesh.id];
-                if (meshVariants) {
-                    instance.material = this.data.materials[meshVariants[variant]];
-                }
-            });
+            this._applyMaterialVariant(variant, renderComponent.meshInstances);
         }
     }
 
     // apply material variant to mesh instances
     applyMaterialVariantInstances(name, instances) {
         const variant = this.data.variants[name];
-        if (!variant)
+        if (variant === undefined) {
+            Debug.warn(`No variant named ${name} exists in resource`);
             return;
+        }
+        this._applyMaterialVariant(variant, instances);
+    }
+
+    // internally apply variant to instances
+    _applyMaterialVariant(variant, instances) {
         instances.forEach((instance) => {
             const meshVariants = this.data.meshVariants[instance.mesh.id];
             if (meshVariants) {

--- a/src/resources/parser/glb-container-resource.js
+++ b/src/resources/parser/glb-container-resource.js
@@ -200,7 +200,11 @@ class GlbContainerResource {
     // apply material variant to entity
     applyMaterialVariant(entity, name) {
         if (!name) {
-            this._resetMaterialVariant(entity);
+            const renders = entity.findComponents("render");
+            for (let i = 0; i < renders.length; i++) {
+                const renderComponent = renders[i];
+                this._resetMaterialVariantInstances(renderComponent.meshInstances);
+            }
             return;
         }
         const variant = this.data.variants[name];
@@ -212,15 +216,6 @@ class GlbContainerResource {
         for (let i = 0; i < renders.length; i++) {
             const renderComponent = renders[i];
             this._applyMaterialVariant(variant, renderComponent.meshInstances);
-        }
-    }
-
-    // reset material variants on entity
-    _resetMaterialVariant(entity) {
-        const renders = entity.findComponents("render");
-        for (let i = 0; i < renders.length; i++) {
-            const renderComponent = renders[i];
-            this._resetMaterialVariantInstances(renderComponent.meshInstances);
         }
     }
 

--- a/src/resources/parser/glb-container-resource.js
+++ b/src/resources/parser/glb-container-resource.js
@@ -199,15 +199,7 @@ class GlbContainerResource {
 
     // apply material variant to entity
     applyMaterialVariant(entity, name) {
-        if (!name) {
-            const renders = entity.findComponents("render");
-            for (let i = 0; i < renders.length; i++) {
-                const renderComponent = renders[i];
-                this._resetMaterialVariantInstances(renderComponent.meshInstances);
-            }
-            return;
-        }
-        const variant = this.data.variants[name];
+        const variant = name ? this.data.variants[name] : null;
         if (variant === undefined) {
             Debug.warn(`No variant named ${name} exists in resource`);
             return;
@@ -221,11 +213,7 @@ class GlbContainerResource {
 
     // apply material variant to mesh instances
     applyMaterialVariantInstances(instances, name) {
-        if (!name) {
-            this._resetMaterialVariantInstances(instances);
-            return;
-        }
-        const variant = this.data.variants[name];
+        const variant = name ? this.data.variants[name] : null;
         if (variant === undefined) {
             Debug.warn(`No variant named ${name} exists in resource`);
             return;
@@ -233,20 +221,17 @@ class GlbContainerResource {
         this._applyMaterialVariant(variant, instances);
     }
 
-    // reset material variant on instances
-    _resetMaterialVariantInstances(instances) {
-        instances.forEach((instances) => {
-            instances.material = this._defaultMaterial;
-        });
-    }
-
     // internally apply variant to instances
     _applyMaterialVariant(variant, instances) {
         instances.forEach((instance) => {
-            const meshVariants = this.data.meshVariants[instance.mesh.id];
-            if (meshVariants) {
-                instance.material = this.data.materials[meshVariants[variant]];
-                Debug.assert(instance.material);
+            if (variant === null) {
+                instance.material = this._defaultMaterial;
+            } else {
+                const meshVariants = this.data.meshVariants[instance.mesh.id];
+                if (meshVariants) {
+                    instance.material = this.data.materials[meshVariants[variant]];
+                    Debug.assert(instance.material);
+                }
             }
         });
     }

--- a/src/resources/parser/glb-container-resource.js
+++ b/src/resources/parser/glb-container-resource.js
@@ -190,6 +190,22 @@ class GlbContainerResource {
         return GlbContainerResource.createSceneHierarchy(sceneClones, 'Entity');
     }
 
+    // get material variants
+    getMaterialVariants() {
+        return this.data.variants;
+    }
+
+    // apply material variant to mesh instances
+    applyMaterialVariant(name, instances, index) {
+        const variant = this.data.variants[name];
+        const meshVariant = this.data.meshVariants[index];
+        if (meshVariant[variant]) {
+            instances.forEach((instance) => {
+                instance.material = this.data.materials[meshVariant[variant]];
+            });
+        }
+    }
+
     // helper function to create a single hierarchy from an array of nodes
     static createSceneHierarchy(sceneNodes, nodeType) {
 

--- a/src/resources/parser/glb-container-resource.js
+++ b/src/resources/parser/glb-container-resource.js
@@ -198,10 +198,12 @@ class GlbContainerResource {
 
     // apply material variant to entity
     applyMaterialVariant(name, entity) {
+        const variant = this.data.variants[name];
+        if (!variant)
+            return;        
         const renders = entity.findComponents("render");
         for (let i = 0; i < renders.length; i++) {
             const renderComponent = renders[i];
-            const variant = this.data.variants[name];
             renderComponent.meshInstances.forEach((instance) => {
                 const meshVariants = this.data.meshVariants[instance.mesh.id];
                 if (meshVariants) {
@@ -214,6 +216,8 @@ class GlbContainerResource {
     // apply material variant to mesh instances
     applyMaterialVariantInstances(name, instances) {
         const variant = this.data.variants[name];
+        if (!variant)
+            return;
         instances.forEach((instance) => {
             const meshVariants = this.data.meshVariants[instance.mesh.id];
             if (meshVariants) {

--- a/src/resources/parser/glb-container-resource.js
+++ b/src/resources/parser/glb-container-resource.js
@@ -193,7 +193,7 @@ class GlbContainerResource {
 
     // get material variants
     getMaterialVariants() {
-        return this.data.variants;
+        return Object.keys(this.data.variants);
     }
 
     // apply material variant to entity

--- a/src/resources/parser/glb-container-resource.js
+++ b/src/resources/parser/glb-container-resource.js
@@ -75,10 +75,11 @@ class GlbContainerResource {
         const defaultMaterial = this._defaultMaterial;
         const skinnedMeshInstances = [];
 
-        const createMeshInstance = function (root, entity, mesh, materials, skins, gltfNode) {
+        const createMeshInstance = function (root, entity, mesh, materials, meshDefaultMaterials, skins, gltfNode) {
 
             // clone mesh instance
-            const material = (mesh.materialIndex === undefined) ? defaultMaterial : materials[mesh.materialIndex];
+            const materialIndex = meshDefaultMaterials[mesh.id];
+            const material = (materialIndex === undefined) ? defaultMaterial : materials[materialIndex];
             const meshInstance = new MeshInstance(mesh, material);
 
             // create morph instance
@@ -122,7 +123,7 @@ class GlbContainerResource {
                         for (var mi = 0; mi < meshGroup.length; mi++) {
                             const mesh = meshGroup[mi];
                             if (mesh) {
-                                const cloneMi = createMeshInstance(root, entity, mesh, glb.materials, glb.skins, gltfNode);
+                                const cloneMi = createMeshInstance(root, entity, mesh, glb.materials, glb.meshDefaultMaterials, glb.skins, gltfNode);
 
                                 // add it to list
                                 if (!attachedMi) {

--- a/src/resources/parser/glb-parser.js
+++ b/src/resources/parser/glb-parser.js
@@ -2030,8 +2030,8 @@ const createResources = function (device, gltf, bufferViews, textureAssets, opti
         return textureAsset.resource;
     }), options, flipV);
     const variants = createVariants(gltf);
-    const meshVariants = [];
-    const meshDefaultMaterials = [];
+    const meshVariants = {};
+    const meshDefaultMaterials = {};
     const meshes = createMeshes(device, gltf, bufferViews, callback, flipV, meshVariants, meshDefaultMaterials);
     const skins = createSkins(device, gltf, nodes, bufferViews);
 

--- a/src/resources/parser/glb-parser.js
+++ b/src/resources/parser/glb-parser.js
@@ -841,14 +841,6 @@ const createMesh = function (device, gltfMesh, accessors, bufferViews, callback,
                     Debug.warn('File contains draco compressed data, but DracoDecoderModule is not configured.');
                 }
             }
-            if (extensions.hasOwnProperty("KHR_materials_variants")) {
-                const variants = extensions.KHR_materials_variants;
-                variants.mappings.forEach((mapping) => {
-                    mapping.variants.forEach((variant) => {
-                        meshVariants.at(-1)[variant] = mapping.material;
-                    });
-                });
-            }
         }
 
         // if mesh was not constructed from draco data, use uncompressed
@@ -897,6 +889,17 @@ const createMesh = function (device, gltfMesh, accessors, bufferViews, callback,
                 mesh.primitive[0].count = indices.length;
             } else {
                 mesh.primitive[0].count = vertexBuffer.numVertices;
+            }
+
+            if (primitive.hasOwnProperty("extensions") && primitive.extensions.hasOwnProperty("KHR_materials_variants")) {
+                const variants = primitive.extensions.KHR_materials_variants;
+                const tempMapping = {};
+                variants.mappings.forEach((mapping) => {
+                    mapping.variants.forEach((variant) => {
+                        tempMapping[variant] = mapping.material;
+                    });
+                });
+                meshVariants[mesh.id] = tempMapping;
             }
 
             meshDefaultMaterials[mesh.id] = primitive.material;

--- a/src/resources/parser/glb-parser.js
+++ b/src/resources/parser/glb-parser.js
@@ -1812,9 +1812,10 @@ const createVariants = function (gltf) {
     if (!gltf.hasOwnProperty("extensions") || !gltf.extensions.hasOwnProperty("KHR_materials_variants"))
         return null;
 
+    const data = gltf.extensions.KHR_materials_variants.variants;
     const variants = {};
-    for (let i = 0; i < gltf.extensions.KHR_materials_variants.variants.length; i++) {
-        variants[gltf.extensions.KHR_materials_variants.variants[i].name] = i;
+    for (let i = 0; i < data.length; i++) {
+        variants[data[i].name] = i;
     }
     return variants;
 };

--- a/src/resources/parser/glb-parser.js
+++ b/src/resources/parser/glb-parser.js
@@ -764,7 +764,6 @@ const createMesh = function (device, gltfMesh, accessors, bufferViews, callback,
         let primitiveType, vertexBuffer, numIndices;
         let indices = null;
         let canUseMorph = true;
-        meshVariants.push({});
 
         // try and get draco compressed data first
         if (primitive.hasOwnProperty('extensions')) {


### PR DESCRIPTION
### Description
Adds support for KHR_materials_variants as well as provides an API for changing the material. Also fixes the default material index ownership, having them live in the container instead of on the mesh. 

![image](https://user-images.githubusercontent.com/107400752/183929736-c5ce9d8f-54ff-411b-aa22-6ff764eb05d8.png)

![image](https://user-images.githubusercontent.com/107400752/183929550-21a5bb97-87ae-41e5-888f-56b8ec2466ce.png)

Fixes #3647

### API changes
- Adds getMaterialVariants to GlbContainerResource. This API fetches the list of variants present in the GLB.
- Adds applyMaterialVariant(name, entity) to GlbContainerResource. This API applies a material variant to all mesh instances in the render component of an entity. 
- Adds applyMaterialVariantInstances(name, instances) to GlbContainerResource. This API applies a material variant to a set of mesh instances, using the GlbContainerResource as the source of the variants, their mappings, and the materials. 