### PR TITLE
Morph target animation fix

### DIFF
--- a/src/anim/binder/default-anim-binder.js
+++ b/src/anim/binder/default-anim-binder.js
@@ -79,6 +79,11 @@ class DefaultAnimBinder {
             },
 
             'weight': function (node, weightName) {
+                if (weightName.indexOf('name.') === 0) {
+                    weightName = weightName.replace('name.', '');
+                } else {
+                    weightName = Number(weightName);
+                }
                 const meshInstances = findMeshInstances(node);
                 if (meshInstances) {
                     for (let i = 0; i < meshInstances.length; ++i) {

--- a/src/resources/parser/glb-parser.js
+++ b/src/resources/parser/glb-parser.js
@@ -1463,7 +1463,7 @@ const createAnimation = function (gltfAnimation, animationIndex, gltfAccessors, 
         for (let i = 0; i < meshes.length; i++) {
             const mesh = meshes[i];
             if (mesh.name === nodeName && mesh.hasOwnProperty('extras') && mesh.extras.hasOwnProperty('targetNames') && mesh.extras.targetNames[weightIndex]) {
-                return mesh.extras.targetNames[weightIndex];
+                return `name.${mesh.extras.targetNames[weightIndex]}`;
             }
         }
         return weightIndex;


### PR DESCRIPTION
Morph target animation curves that are named via the glb mesh's extras property should be differentiated from index based curves.

Fixes #4522
Fixes #4520

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
