### PR TITLE
[Fix] Added buffer allocation tracing, fixed Vertex buffer size stats

### DIFF
--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -47,3 +47,24 @@ export const TRACEID_TEXTURE_ALLOC = 'TextureAlloc';
  * @type {string}
  */
 export const TRACEID_SHADER_ALLOC = 'ShaderAlloc';
+
+/**
+ * Logs the vram use by the textures.
+ *
+ * @type {string}
+ */
+export const TRACEID_VRAM_TEXTURE = 'VRAM.Texture';
+
+/**
+ * Logs the vram use by the vertex buffers.
+ *
+ * @type {string}
+ */
+export const TRACEID_VRAM_VB = 'VRAM.Vb';
+
+/**
+ * Logs the vram use by the index buffers.
+ *
+ * @type {string}
+ */
+export const TRACEID_VRAM_IB = 'VRAM.Ib';

--- a/src/core/tracing.js
+++ b/src/core/tracing.js
@@ -24,6 +24,9 @@ class Tracing {
      * - {@link TRACEID_RENDER_TARGET_ALLOC}
      * - {@link TRACEID_TEXTURE_ALLOC}
      * - {@link TRACEID_SHADER_ALLOC}
+     * - {@link TRACEID_VRAM_TEXTURE}
+     * - {@link TRACEID_VRAM_VB}
+     * - {@link TRACEID_VRAM_IB}
      *
      * @param {boolean} enabled - New enabled state for the channel.
      */

--- a/src/graphics/texture.js
+++ b/src/graphics/texture.js
@@ -1,5 +1,5 @@
 import { Debug } from '../core/debug.js';
-import { TRACEID_TEXTURE_ALLOC } from '../core/constants.js';
+import { TRACEID_TEXTURE_ALLOC, TRACEID_VRAM_TEXTURE } from '../core/constants.js';
 import { math } from '../math/math.js';
 
 import {
@@ -317,6 +317,9 @@ class Texture {
      * @ignore
      */
     adjustVramSizeTracking(vram, size) {
+
+        Debug.trace(TRACEID_VRAM_TEXTURE, `${this.id} ${this.name} size: ${size} vram.texture: ${vram.tex} => ${vram.tex + size}`);
+
         vram.tex += size;
 
         // #if _PROFILER

--- a/src/graphics/webgl/webgl-buffer.js
+++ b/src/graphics/webgl/webgl-buffer.js
@@ -15,6 +15,10 @@ class WebglBuffer {
         }
     }
 
+    get initialized() {
+        return !!this.bufferId;
+    }
+
     loseContext() {
         this.bufferId = null;
     }


### PR DESCRIPTION
Fixes https://github.com/playcanvas/engine/issues/4531

- added allocation / deallocation trace logging for IBs, VBs and Textures
- fixed allocated vram tracing for vertex buffer, which can be shared between multiple meshes, to only change deallocation when actually deallocated.