### PR TITLE
Apply polygon offset for shadows with WebGL1

### DIFF
--- a/src/graphics/program-lib/programs/lit-shader.js
+++ b/src/graphics/program-lib/programs/lit-shader.js
@@ -576,7 +576,7 @@ class LitShader {
         code += this.frontendFunc;
 
         const isVsm = shadowType === SHADOW_VSM8 || shadowType === SHADOW_VSM16 || shadowType === SHADOW_VSM32;
-        const applySlopeScaleBias = !device.webgl2 && device.extStandardDerivatives;
+        const applySlopeScaleBias = lightType === LIGHTTYPE_DIRECTIONAL && !device.webgl2 && device.extStandardDerivatives;
 
         if (lightType === LIGHTTYPE_OMNI || (isVsm && lightType !== LIGHTTYPE_DIRECTIONAL)) {
             code += "    float depth = min(distance(view_position, vPositionW) / light_radius, 0.99999);\n";

--- a/src/graphics/program-lib/programs/lit-shader.js
+++ b/src/graphics/program-lib/programs/lit-shader.js
@@ -576,6 +576,7 @@ class LitShader {
         code += this.frontendFunc;
 
         const isVsm = shadowType === SHADOW_VSM8 || shadowType === SHADOW_VSM16 || shadowType === SHADOW_VSM32;
+        const applySlopeScaleBias = !device.webgl2 && device.extStandardDerivatives;
 
         if (lightType === LIGHTTYPE_OMNI || (isVsm && lightType !== LIGHTTYPE_DIRECTIONAL)) {
             code += "    float depth = min(distance(view_position, vPositionW) / light_radius, 0.99999);\n";
@@ -583,14 +584,13 @@ class LitShader {
             code += "    float depth = gl_FragCoord.z;\n";
         }
 
+        if (applySlopeScaleBias) {
+            code += "    float minValue = 2.3374370500153186e-10; //(1.0 / 255.0) / (256.0 * 256.0 * 256.0);\n";
+            code += "    depth += polygonOffset.x * max(abs(dFdx(depth)), abs(dFdy(depth))) + minValue * polygonOffset.y;\n";
+        }
+
         if (shadowType === SHADOW_PCF3 && (!device.webgl2 || (lightType === LIGHTTYPE_OMNI && !options.clusteredLightingEnabled))) {
-            if (device.extStandardDerivatives && !device.webgl2) {
-                code += "    float minValue = 2.3374370500153186e-10; //(1.0 / 255.0) / (256.0 * 256.0 * 256.0);\n";
-                code += "    depth += polygonOffset.x * max(abs(dFdx(depth)), abs(dFdy(depth))) + minValue * polygonOffset.y;\n";
-                code += "    gl_FragColor = packFloat(depth);\n";
-            } else {
-                code += "    gl_FragColor = packFloat(depth);\n";
-            }
+            code += "    gl_FragColor = packFloat(depth);\n";
         } else if (shadowType === SHADOW_PCF3 || shadowType === SHADOW_PCF5) {
             code += "    gl_FragColor = vec4(1.0);\n"; // just the simplest code, color is not written anyway
 


### PR DESCRIPTION
### Description
Fixes #2780

Polygon offset is enabled in GL2 when rendering shadows. However, because GL1 doesn't support polygon offset, it has to be done programatically. We supported that, but only applied polygon offset for PCF3 shadows, so to make it consistent with both GL1 and GL2, this PR applies polygon offset by default if GL1 is enabled and the device supports derivatives. 

Test scene: https://playcanvas.com/editor/scene/1501582