### PR TITLE
When stringifying uniform format, ignore assigned values

### DIFF
--- a/src/graphics/scope-id.js
+++ b/src/graphics/scope-id.js
@@ -24,6 +24,13 @@ class ScopeId {
         this.versionObject = new VersionedObject();
     }
 
+    // Don't stringify ScopeId to JSON by JSON.stringify, as this stores 'value'
+    // which is not needed. This is used when stringifying a uniform buffer format, which
+    // internally stores the scope.
+    toJSON(key) {
+        return undefined;
+    }
+
     /**
      * Set variable value.
      *

--- a/src/scene/immediate/immediate.js
+++ b/src/scene/immediate/immediate.js
@@ -210,7 +210,7 @@ class Immediate {
     }
 
     getGraphNode(matrix) {
-        const graphNode = new GraphNode();
+        const graphNode = new GraphNode('ImmediateDebug');
         graphNode.worldTransform = matrix;
         graphNode._dirtyWorld = graphNode._dirtyNormal = false;
 


### PR DESCRIPTION
- optimization, to not pollute shader generation key by uniform values, forcing new shaders. This is related to meshInstances created each frame on platforms using uniform buffers (WebGPU at the moment)
- also added a name to internal graph node to help with debugging