### PR TITLE
Fix biasing issues with WGL1

### DIFF
--- a/src/graphics/program-lib/chunks/lit/frag/shadowCoordPerspZbuffer.js
+++ b/src/graphics/program-lib/chunks/lit/frag/shadowCoordPerspZbuffer.js
@@ -8,7 +8,7 @@ void _getShadowCoordPerspZbuffer(mat4 shadowMatrix, vec4 shadowParams, vec3 wPos
 
 void getShadowCoordPerspZbufferNormalOffset(mat4 shadowMatrix, vec4 shadowParams) {
     float distScale = abs(dot(vPositionW - dLightPosW, dLightDirNormW)); // fov?
-    vec3 wPos = vPositionW + dVertexNormalW * shadowParams.y * clamp(1.0 - dot(dVertexNormalW, -dLightDirNormW), 0.0, 1.0) * distScale;
+    vec3 wPos = vPositionW + dVertexNormalW * shadowParams.y;
     _getShadowCoordPerspZbuffer(shadowMatrix, shadowParams, wPos);
 }
 

--- a/src/graphics/program-lib/programs/lit-shader.js
+++ b/src/graphics/program-lib/programs/lit-shader.js
@@ -576,7 +576,7 @@ class LitShader {
         code += this.frontendFunc;
 
         const isVsm = shadowType === SHADOW_VSM8 || shadowType === SHADOW_VSM16 || shadowType === SHADOW_VSM32;
-        const applySlopeScaleBias = lightType === LIGHTTYPE_DIRECTIONAL && !device.webgl2 && device.extStandardDerivatives;
+        const applySlopeScaleBias = !device.webgl2 && device.extStandardDerivatives;
 
         if (lightType === LIGHTTYPE_OMNI || (isVsm && lightType !== LIGHTTYPE_DIRECTIONAL)) {
             code += "    float depth = min(distance(view_position, vPositionW) / light_radius, 0.99999);\n";


### PR DESCRIPTION
Normal bias is not angle dependent anymore. Slope scale bias is applied to all light sources when rendering the shadow map if running WGL1.

Fixes #4540
