### PR TITLE
Animation resource with events fix

### DIFF
--- a/src/framework/components/anim/component.js
+++ b/src/framework/components/anim/component.js
@@ -12,7 +12,6 @@ import {
 import { AnimComponentBinder } from './component-binder.js';
 import { AnimComponentLayer } from './component-layer.js';
 import { AnimStateGraph } from '../../../anim/state-graph/anim-state-graph.js';
-import { AnimEvents } from '../../../anim/evaluator/anim-events.js';
 import { Entity } from '../../entity.js';
 
 /** @typedef {import('./system.js').AnimComponentSystem} AnimComponentSystem */
@@ -429,10 +428,6 @@ class AnimComponent extends Component {
     }
 
     onAnimationAssetLoaded(layerName, stateName, asset) {
-        const animTrack = asset.resource;
-        if (asset.data.events) {
-            animTrack.events = new AnimEvents(Object.values(asset.data.events));
-        }
         this.findAnimationLayer(layerName).assignAnimation(stateName, asset.resource);
     }
 

--- a/src/resources/animation.js
+++ b/src/resources/animation.js
@@ -6,6 +6,7 @@ import { Vec3 } from '../math/vec3.js';
 import { http, Http } from '../net/http.js';
 
 import { Animation, Key, Node } from '../animation/animation.js';
+import { AnimEvents } from '../anim/evaluator/anim-events.js';
 
 import { GlbParser } from '../resources/parser/glb-parser.js';
 
@@ -60,11 +61,16 @@ class AnimationHandler {
         });
     }
 
-    open(url, data) {
+    open(url, data, asset) {
         if (path.getExtension(url).toLowerCase() === '.glb') {
             const glbResources = GlbParser.parse('filename.glb', data, null);
             if (glbResources) {
                 const animations = glbResources.animations;
+                if (asset?.data?.events) {
+                    for (let i = 0; i < animations.length; i++) {
+                        animations[i].events = new AnimEvents(Object.values(asset.data.events));
+                    }
+                }
                 glbResources.destroy();
                 return animations;
             }


### PR DESCRIPTION
Previously events from an animation asset were assigned to each AnimTrack when an anim state graph is loaded. However it's now possible to load AnimTracks without creating a state graph (using the assignAnimation API). This meant animations loaded this way would not have any events from their asset assigned to them. This PR moves the assignment of events to the animation resource handler instead. Ensuring that events are always added to AnimTracks that are created via animation assets.

Fixes #4542 

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
