### PR TITLE
AnimBinder path resolution update

### DIFF
--- a/src/anim/binder/default-anim-binder.js
+++ b/src/anim/binder/default-anim-binder.js
@@ -156,6 +156,10 @@ class DefaultAnimBinder {
         let node;
         if (this.graph) {
             node = this.graph.findByPath(path.entityPath);
+            // if the path is not found under the given root node, try to find the path using the root node as the base of the path instead
+            if (!node) {
+                node = this.graph.findByPath(path.entityPath.slice(1));
+            }
         }
         if (!node) {
             node = this.nodes[path.entityPath[path.entityPath.length - 1] || ""];


### PR DESCRIPTION
This PR updates the AnimBinder to support two types of animation curve paths.
The first is currently supported in the engine and looks something like this:
```
RootBone/RootNode/Hips/etc/etc
```
This covers the case where the entity that the anim component is attached to (RootBone), is the parent of the GLB hierarchy to be animated. The GLB hierarchy in this instance starts at RootNode.

The second type of path which is supported in this PR looks like:
```
RootBone/Hips/etc/etc
```
This will occur when the entity that the anim component is attached to (RootBone) is also the root of the GLB hierachy which is being animated. FBX's loaded using the editor's import hierarchy feature will have this structure. The GLB hierarchy in this instance starts at RootBone.

Fixes: https://github.com/playcanvas/editor/issues/602

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
