### PR TITLE
Return null if no variants are present

### DIFF
--- a/src/resources/parser/glb-container-resource.js
+++ b/src/resources/parser/glb-container-resource.js
@@ -194,7 +194,7 @@ class GlbContainerResource {
 
     // get material variants
     getMaterialVariants() {
-        return this.data.variants ? Object.keys(this.data.variants) : null;
+        return this.data.variants ? Object.keys(this.data.variants) : [];
     }
 
     // apply material variant to entity

--- a/src/resources/parser/glb-container-resource.js
+++ b/src/resources/parser/glb-container-resource.js
@@ -194,7 +194,7 @@ class GlbContainerResource {
 
     // get material variants
     getMaterialVariants() {
-        return Object.keys(this.data.variants);
+        return this.data.variants ? Object.keys(this.data.variants) : null;
     }
 
     // apply material variant to entity


### PR DESCRIPTION
### Description
Fixes error where Object.keys would take a null/undefined argument.