### PR TITLE
Example controls fix

### DIFF
--- a/examples/scripts/iframe/index.mustache
+++ b/examples/scripts/iframe/index.mustache
@@ -36,6 +36,8 @@
                 }
             });
         }
+        var event = new CustomEvent("exampleLoading");
+        window.top.dispatchEvent(event);
 
         // include the example class which contains the example function to execute and any assets to load
         {{{ exampleClass }}}

--- a/examples/src/app/example.tsx
+++ b/examples/src/app/example.tsx
@@ -29,6 +29,11 @@ class ControlLoader extends Component <ControlLoaderProps, ControlLoaderState> {
         this.state = {
             exampleLoaded: false
         };
+        window.addEventListener('exampleLoading', () => {
+            this.setState({
+                exampleLoaded: false
+            });
+        });
         window.addEventListener('exampleLoad', () => {
             this.setState({
                 exampleLoaded: true


### PR DESCRIPTION
Example controls should be rebuilt each time an example is executed, ensuring they are attached to the latest instance of an example.

Fixes #4529 

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
