### PR TITLE
AssetListLoader fix

### DIFF
--- a/src/asset/asset-list-loader.js
+++ b/src/asset/asset-list-loader.js
@@ -127,7 +127,7 @@ class AssetListLoader extends EventHandler {
             }
         });
         if (!loadingAssets && this._waitingAssets.size === 0) {
-            this.fire("load", Array.from(this._assets));
+            this._loadingComplete();
         }
     }
 

--- a/test/asset/asset-list-loader.test.mjs
+++ b/test/asset/asset-list-loader.test.mjs
@@ -113,7 +113,7 @@ describe('AssetListLoader', function () {
 
     describe('#load', function () {
 
-        it('can succeed if an asset is already loaded', function (done) {
+        it('can call the ready callback if an asset is already loaded', function (done) {
             const asset = new Asset('model', 'container', { url: `${assetPath}test.glb` });
             const assetListLoader = new AssetListLoader([asset], app.assets);
             asset.on('load', (asset) => {
@@ -125,6 +125,19 @@ describe('AssetListLoader', function () {
                     done();
                 });
                 assetListLoader.load();
+            });
+            app.assets.add(asset);
+            app.assets.load(asset);
+        });
+
+        it('can call the load callback if an asset is already loaded', function (done) {
+            const asset = new Asset('model', 'container', { url: `${assetPath}test.glb` });
+            const assetListLoader = new AssetListLoader([asset], app.assets);
+            asset.on('load', (asset) => {
+                expect(asset.loaded).to.equal(true);
+                assetListLoader.load(() => {
+                    done();
+                });
             });
             app.assets.add(asset);
             app.assets.load(asset);


### PR DESCRIPTION
The AssetListLoader should call loadingComplete in the load function, even if all assets have been previously loaded. The loadingComplete function will internally fire the load event as necessary. This mirrors the functionality of the ready function. I've also added a test for this case.

Fixes #4512

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
