### PR TITLE
Fix UI Element input events on multiple touches.

### DIFF
--- a/src/framework/components/element/element-drag-helper.js
+++ b/src/framework/components/element/element-drag-helper.js
@@ -83,7 +83,6 @@ class ElementDragHelper extends EventHandler {
 
     _toggleDragListeners(onOrOff) {
         const isOn = onOrOff === 'on';
-        const addOrRemoveEventListener = isOn ? 'addEventListener' : 'removeEventListener';
 
         // Prevent multiple listeners
         if (this._hasDragListeners && isOn) {
@@ -94,18 +93,17 @@ class ElementDragHelper extends EventHandler {
             this._handleMouseUpOrTouchEnd = this._onMouseUpOrTouchEnd.bind(this);
         }
 
-        // Note that we handle release events directly on the window object, rather than
-        // on app.mouse or app.touch. This is in order to correctly handle cases where the
-        // user releases the mouse/touch outside of the window.
+        // mouse events, if mouse is available
         if (this._app.mouse) {
-            this._app.mouse[onOrOff]('mousemove', this._onMove, this);
-            window[addOrRemoveEventListener]('mouseup', this._handleMouseUpOrTouchEnd, false);
+            this._element[onOrOff]('mousemove', this._onMove, this);
+            this._element[onOrOff]('mouseup', this._handleMouseUpOrTouchEnd, false);
         }
 
+        // touch events, if touch is available
         if (platform.touch) {
-            this._app.touch[onOrOff]('touchmove', this._onMove, this);
-            window[addOrRemoveEventListener]('touchend', this._handleMouseUpOrTouchEnd, false);
-            window[addOrRemoveEventListener]('touchcancel', this._handleMouseUpOrTouchEnd, false);
+            this._element[onOrOff]('touchmove', this._onMove, this);
+            this._element[onOrOff]('touchend', this._handleMouseUpOrTouchEnd, this);
+            this._element[onOrOff]('touchcancel', this._handleMouseUpOrTouchEnd, this);
         }
 
         this._hasDragListeners = isOn;

--- a/src/input/element-input.js
+++ b/src/input/element-input.js
@@ -513,8 +513,6 @@ class ElementInput {
             return;
 
         this._calcMouseCoords(event);
-        if (targetX === null)
-            return;
 
         this._onElementMouseEvent('mouseup', event);
     }
@@ -526,8 +524,6 @@ class ElementInput {
             return;
 
         this._calcMouseCoords(event);
-        if (targetX === null)
-            return;
 
         this._onElementMouseEvent('mousedown', event);
     }
@@ -536,8 +532,6 @@ class ElementInput {
         if (!this._enabled) return;
 
         this._calcMouseCoords(event);
-        if (targetX === null)
-            return;
 
         this._onElementMouseEvent('mousemove', event);
 
@@ -549,8 +543,6 @@ class ElementInput {
         if (!this._enabled) return;
 
         this._calcMouseCoords(event);
-        if (targetX === null)
-            return;
 
         this._onElementMouseEvent('mousewheel', event);
     }
@@ -647,19 +639,17 @@ class ElementInput {
 
             // check if touch was released over previously touch
             // element in order to fire click event
-            if (event.touches.length === 0) {
-                const coords = this._calcTouchCoords(touch);
+            const coords = this._calcTouchCoords(touch);
 
-                for (let c = cameras.length - 1; c >= 0; c--) {
-                    const hovered = this._getTargetElement(cameras[c], coords.x, coords.y);
-                    if (hovered === element) {
+            for (let c = cameras.length - 1; c >= 0; c--) {
+                const hovered = this._getTargetElement(cameras[c], coords.x, coords.y);
+                if (hovered === element) {
 
-                        if (!this._clickedEntities[element.entity.getGuid()]) {
-                            this._fireEvent('click', new ElementTouchEvent(event, element, camera, x, y, touch));
-                            this._clickedEntities[element.entity.getGuid()] = true;
-                        }
-
+                    if (!this._clickedEntities[element.entity.getGuid()]) {
+                        this._fireEvent('click', new ElementTouchEvent(event, element, camera, x, y, touch));
+                        this._clickedEntities[element.entity.getGuid()] = true;
                     }
+
                 }
             }
         }
@@ -701,9 +691,9 @@ class ElementInput {
     }
 
     _onElementMouseEvent(eventType, event) {
-        let element;
+        let element = null;
 
-        const hovered = this._hoveredElement;
+        const lastHovered = this._hoveredElement;
         this._hoveredElement = null;
 
         const cameras = this.app.systems.camera.cameras;
@@ -720,21 +710,25 @@ class ElementInput {
                 break;
         }
 
-        // fire mouse event
-        if (element) {
-            this._fireEvent(eventType, new ElementMouseEvent(event, element, camera, targetX, targetY, this._lastX, this._lastY));
+        // currently hovered element is whatever's being pointed by mouse (which may be null)
+        this._hoveredElement = element;
 
-            this._hoveredElement = element;
+        // if there was a pressed element, it takes full priority of 'move' and 'up' events
+        if ((eventType === 'mousemove' || eventType === 'mouseup') && this._pressedElement) {
+            this._fireEvent(eventType, new ElementMouseEvent(event, this._pressedElement, camera, targetX, targetY, this._lastX, this._lastY));
+        } else if (element) {
+            // otherwise, fire it to the currently hovered event
+            this._fireEvent(eventType, new ElementMouseEvent(event, element, camera, targetX, targetY, this._lastX, this._lastY));
 
             if (eventType === 'mousedown') {
                 this._pressedElement = element;
             }
         }
 
-        if (hovered !== this._hoveredElement) {
+        if (lastHovered !== this._hoveredElement) {
             // mouseleave event
-            if (hovered) {
-                this._fireEvent('mouseleave', new ElementMouseEvent(event, hovered, camera, targetX, targetY, this._lastX, this._lastY));
+            if (lastHovered) {
+                this._fireEvent('mouseleave', new ElementMouseEvent(event, lastHovered, camera, targetX, targetY, this._lastX, this._lastY));
             }
 
             // mouseenter event
@@ -880,20 +874,8 @@ class ElementInput {
         const rect = this._target.getBoundingClientRect();
         const left = Math.floor(rect.left);
         const top = Math.floor(rect.top);
-
-        // mouse is outside of canvas
-        if (event.clientX < left ||
-            event.clientX >= left + this._target.clientWidth ||
-            event.clientY < top ||
-            event.clientY >= top + this._target.clientHeight) {
-
-            targetX = null;
-            targetY = null;
-        } else {
-            // calculate coords and scale them to the graphicsDevice size
-            targetX = (event.clientX - left);
-            targetY = (event.clientY - top);
-        }
+        targetX = (event.clientX - left);
+        targetY = (event.clientY - top);
     }
 
     _calcTouchCoords(touch) {

--- a/tests/framework/components/element/test_elementdraghelper.js
+++ b/tests/framework/components/element/test_elementdraghelper.js
@@ -114,7 +114,7 @@ describe("pc.ElementDragHelper", function() {
             camera: camera
         });
 
-        app.mouse.fire("mousemove", {
+        element.fire("mousemove", {
             x: 51,
             y: 52
         });
@@ -132,7 +132,7 @@ describe("pc.ElementDragHelper", function() {
             camera: camera
         });
 
-        app.touch.fire("touchmove", {
+        element.fire("touchmove", {
             x: 51,
             y: 52
         });
@@ -149,7 +149,7 @@ describe("pc.ElementDragHelper", function() {
             camera: camera
         });
 
-        window.dispatchEvent(new Event('mouseup'));
+        element.fire('mouseup');
 
         expect(dragEndHandler.callCount).to.equal(1);
         expect(dragHelper.isDragging).to.equal(false);
@@ -169,7 +169,7 @@ describe("pc.ElementDragHelper", function() {
             camera: camera
         });
 
-        window.dispatchEvent(new Event(touchEventName));
+        element.fire(touchEventName);
 
         expect(dragEndHandler.callCount).to.equal(1);
         expect(dragHelper.isDragging).to.equal(false);
@@ -226,7 +226,7 @@ describe("pc.ElementDragHelper", function() {
             camera: camera
         });
 
-        app.mouse.fire("mousemove", {
+        element.fire("mousemove", {
             x: 60,
             y: 60
         });


### PR DESCRIPTION
Fixes https://github.com/playcanvas/engine/issues/4341 and https://github.com/playcanvas/engine/issues/4470

Issue https://github.com/playcanvas/engine/issues/4341's root cause is that the `element-drag-helper` class (used by `Scrollview` components and similar) uses Window DOM Events for handling dragging, and does not check the actual target of the event. This leads to *any* touch interaction being handled by *all* UI Elements at once. Issue https://github.com/playcanvas/engine/issues/4470 is also related to multitouch.

This PR makes the `element-drag-helper` use the Events triggered by `element-input` system (rather than Window DOM events) for handling dragging. The `element-input` system already contains all logic and checks necessary to figure out which is the correct element a given user events (like touch or mouse) should target.

The only reason `element-drag-helper` was still using Window DOM events was to handle the cases of outside-of-canvas events (like letting go of mouse or touch outside the bounds of the screen), whereas `element-input` system was not. This PR also addresses that by having `element-input` handle that use-case properly, by removing hard-coded checks that prevent such events from firing. Note that `element-input` system does also Window DOM events.

Finally, this PR also makes the `mouse` events also use `element-input` system so everything is standardised to use the same system.

## Testing

Test project with custom engine build: https://launch.playcanvas.com/1223792

### Before

Before, any touch event (to any target) was being processed by all `element-drag-helper`s, so there were flickering and unwanted movement of bars. Also, if there was any touch still active, you couldn't click the button. It would highlight, but not increase its value on click.

https://user-images.githubusercontent.com/6392953/185370766-69e91963-2463-436c-95d7-a479339f573b.MP4


### After

After, each touch finger is handled properly by its target element only, and you can click on the button.

https://user-images.githubusercontent.com/6392953/185370794-942e9b22-c84e-4580-a0fa-1fdc0491013b.MP4


I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
