### PR TITLE
Dynamic refractions multiply albedo twice

### DIFF
--- a/src/graphics/program-lib/chunks/lit/frag/refractionDynamic.js
+++ b/src/graphics/program-lib/chunks/lit/frag/refractionDynamic.js
@@ -53,6 +53,6 @@ void addRefraction() {
 
     // Apply fresnel effect on refraction
     vec3 fresnel = vec3(1.0) - getFresnel(dot(dViewDirW, dNormalW), dSpecularity);
-    dDiffuseLight = mix(dDiffuseLight, refraction * dAlbedo * transmittance * fresnel, dTransmission);
+    dDiffuseLight = mix(dDiffuseLight, refraction * transmittance * fresnel, dTransmission);
 }
 `;


### PR DESCRIPTION
### Description
The combine function multiplies albedo already, so the added multiplication in the dynamic refractions chunk meant it was multiplied twice, leading to incorrectly dark refractions.
