### PR TITLE
Handle default material for createModel

### DIFF
--- a/src/resources/parser/glb-container-resource.js
+++ b/src/resources/parser/glb-container-resource.js
@@ -259,7 +259,8 @@ class GlbContainerResource {
     static createModel(glb, defaultMaterial) {
 
         const createMeshInstance = function (model, mesh, skins, skinInstances, materials, node, gltfNode) {
-            const material = (mesh.materialIndex === undefined) ? defaultMaterial : materials[mesh.materialIndex];
+            const materialIndex = meshDefaultMaterials[mesh.id];
+            const material = (materialIndex === undefined) ? defaultMaterial : materials[materialIndex];
             const meshInstance = new MeshInstance(mesh, material, node);
 
             if (mesh.morph) {

--- a/src/resources/parser/glb-container-resource.js
+++ b/src/resources/parser/glb-container-resource.js
@@ -259,7 +259,7 @@ class GlbContainerResource {
     static createModel(glb, defaultMaterial) {
 
         const createMeshInstance = function (model, mesh, skins, skinInstances, materials, node, gltfNode) {
-            const materialIndex = meshDefaultMaterials[mesh.id];
+            const materialIndex = glb.meshDefaultMaterials[mesh.id];
             const material = (materialIndex === undefined) ? defaultMaterial : materials[materialIndex];
             const meshInstance = new MeshInstance(mesh, material, node);
 


### PR DESCRIPTION
### Description

The changes done with variants in #4528 didn't also implement how to pick the default material when using the createModel API. 