### PR TITLE
Standard shader compatibility improvements for WebGPU

### DIFF
--- a/examples/webgpu-temp/index.html
+++ b/examples/webgpu-temp/index.html
@@ -33,7 +33,7 @@
         import { Entity } from "../../src/framework/entity.js";
         import { Tracing } from "../../src/core/tracing.js";
         import { 
-            TRACEID_RENDER_FRAME, TRACEID_RENDER_PASS, TRACEID_RENDER_PASS_DETAIL
+            TRACEID_RENDER_FRAME, TRACEID_RENDER_PASS, TRACEID_RENDER_PASS_DETAIL, TRACEID_SHADER_ALLOC
         } from "../../src/core/constants.js";
         import { Color } from "../../src/math/color.js";
         import { Vec3 } from "../../src/math/vec3.js";
@@ -143,25 +143,26 @@ void main() {
 
         function createPrimitive2(app, numBoxes, x, y, z, blendMode) {
 
-            // a basic material, which does not have support for lighting
+            /*
+            // basic material
             const material = new BasicMaterial();
-
-            // diffuse color
             material.color.set(x, y, 1 - y);
-
-            // diffuse texture with alpha channel for transparency
             material.colorMap = textures[1].resource;
-
-            // disable culling to see back faces as well
             material.cull = CULLFACE_NONE;
-
-            // set up alpha test value
             material.alphaTest = x / numBoxes - 0.1;
-
-            // alpha blend mode
             material.blendType = blendMode;
+            */
 
-            const box = new Entity();
+            // standard material
+            const material = new StandardMaterial();
+            material.useLighting = false;
+            material.emissive = new Color(x, y, 1 - y);
+            material.emissiveTint = true;
+            material.blendType = blendMode;
+            material.emissiveMap = textures[1].resource;
+            material.update();
+
+            const box = new Entity("Box-primitive2");
             box.addComponent("render", {
                 material: material,
                 type: "box",
@@ -180,6 +181,7 @@ void main() {
 
             // Tracing.set(TRACEID_RENDER_FRAME, true);
             // Tracing.set(TRACEID_RENDER_PASS, true);
+            Tracing.set(TRACEID_SHADER_ALLOC, true);
 
             app.start();
 

--- a/examples/webgpu-temp/index.html
+++ b/examples/webgpu-temp/index.html
@@ -20,6 +20,8 @@
 
     <script type="module">
 
+        import { Asset } from "../../src/asset/asset.js";
+        import { AssetListLoader } from "../../src/asset/asset-list-loader.js";
         import { AppBase } from "../../src/framework/app-base.js";
         import { AppOptions } from "../../src/framework/app-options.js";
         import { WebgpuGraphicsDevice } from '../../src/graphics/webgpu/webgpu-graphics-device.js';
@@ -48,31 +50,10 @@
         import { LightComponentSystem } from '../../src/framework/components/light/system.js';
         import { TextureHandler } from '../../src/resources/texture.js';
 
-        const textures = [
-            {
-                url: "../assets/textures/playcanvas.png"
-            },
-            {
-                url: "../assets/textures/seaside-rocks01-diffuse-alpha.png"
-            },
-        ];
-
-        // texture loader
-        let countToLoad = textures.length;
-        const loadTexture = (app, destination, url) => {
-            const asset = app.assets.loadFromUrl(url, 'texture', function (error, asset) {
-                if (error) {
-                    console.error(error);
-                    return;
-                }
-                destination.resource = asset.resource;
-                countToLoad--;
-
-                if (countToLoad === 0) {
-                    onLoaded(app);
-                }
-            });
-        }
+        const assets = {
+            'playcanvas': new Asset('color', 'texture', { url: '../assets/textures/playcanvas.png' }),
+            'rocks': new Asset('color', 'texture', { url: '../assets/textures/seaside-rocks01-diffuse-alpha.png' })
+        };
 
         const vertexShaderGLSL = /* glsl */`
 
@@ -124,7 +105,7 @@ void main() {
             const material = new Material();
             material.shader = shader;
             material.setParameter('material_diffuse', [color.r, color.g, color.b]);
-            material.setParameter('texture_emissiveMap', textures[0].resource);
+            material.setParameter('texture_emissiveMap', assets.playcanvas.resource);
 
             // create primitive
             const primitive = new Entity(primitiveType);
@@ -147,7 +128,7 @@ void main() {
             // basic material
             const material = new BasicMaterial();
             material.color.set(x, y, 1 - y);
-            material.colorMap = textures[1].resource;
+            material.colorMap = assets.rocks.resource;
             material.cull = CULLFACE_NONE;
             material.alphaTest = x / numBoxes - 0.1;
             material.blendType = blendMode;
@@ -159,7 +140,7 @@ void main() {
             material.emissive = new Color(x, y, 1 - y);
             material.emissiveTint = true;
             material.blendType = blendMode;
-            material.emissiveMap = textures[1].resource;
+            material.emissiveMap = assets.rocks.resource;
             material.update();
 
             const box = new Entity("Box-primitive2");
@@ -301,7 +282,7 @@ void main() {
                 textureCamera.setLocalPosition(20 * Math.cos(time * 0.2), 2, 20 * Math.sin(time * 0.2));
                 textureCamera.lookAt(Vec3.ZERO);
 
-                app.drawTexture(0.6, -0.7, 0.6, 0.3, textures[0].resource);
+                app.drawTexture(0.6, -0.7, 0.6, 0.3, assets.rocks.resource);
                 app.drawTexture(-0.6, -0.7, 0.6, 0.5, renderTexture);
             });
 
@@ -330,10 +311,11 @@ void main() {
             app.graphicsDevice.initWebGpu().then(() => {
                 console.log("gpu device async created");
 
-                // load textures
-                textures.forEach((texture) => {
-                    loadTexture(app, texture, texture.url);
+                const assetListLoader = new AssetListLoader(Object.values(assets), app.assets);
+                assetListLoader.load(() => {
+                    onLoaded(app);
                 });
+
             }).catch(console.error);
         }
 

--- a/src/graphics/graphics-device.js
+++ b/src/graphics/graphics-device.js
@@ -183,6 +183,9 @@ class GraphicsDevice extends EventHandler {
         // Create the ScopeNamespace for shader attributes and variables
         this.scope = new ScopeSpace("Device");
 
+        this.textureBias = this.scope.resolve("textureBias");
+        this.textureBias.setValue(0.0);
+
         // Create the program library instance
         this.programLib = new ProgramLibrary(this);
     }

--- a/src/graphics/program-lib/chunks/chunks.js
+++ b/src/graphics/program-lib/chunks/chunks.js
@@ -58,6 +58,7 @@ import fullscreenQuadPS from './common/frag/fullscreenQuad.js';
 import fullscreenQuadVS from './common/vert/fullscreenQuad.js';
 import gamma1_0PS from './common/frag/gamma1_0.js';
 import gamma2_2PS from './common/frag/gamma2_2.js';
+import gles2PS from './common/frag/gles2.js';
 import gles3PS from './common/frag/gles3.js';
 import gles3VS from './common/vert/gles3.js';
 import glossPS from './standard/frag/gloss.js';
@@ -265,6 +266,7 @@ const shaderChunks = {
     fullscreenQuadVS,
     gamma1_0PS,
     gamma2_2PS,
+    gles2PS,
     gles3PS,
     gles3VS,
     glossPS,

--- a/src/graphics/program-lib/chunks/common/frag/gles2.js
+++ b/src/graphics/program-lib/chunks/common/frag/gles2.js
@@ -1,0 +1,3 @@
+export default /* glsl */`
+#define texture2DBias texture2D
+`;

--- a/src/graphics/program-lib/chunks/common/frag/gles3.js
+++ b/src/graphics/program-lib/chunks/common/frag/gles3.js
@@ -3,6 +3,7 @@ export default /* glsl */`
 out highp vec4 pc_fragColor;
 #define gl_FragColor pc_fragColor
 #define texture2D texture
+#define texture2DBias texture
 #define textureCube texture
 #define texture2DProj textureProj
 #define texture2DLodEXT textureLod

--- a/src/graphics/program-lib/chunks/common/frag/webgpu.js
+++ b/src/graphics/program-lib/chunks/common/frag/webgpu.js
@@ -3,6 +3,7 @@ out highp vec4 pc_fragColor;
 #define gl_FragColor pc_fragColor
 
 #define texture2D(res, uv) texture(sampler2D(res, res ## _sampler), uv)
+#define texture2DBias(res, uv, bias) texture(sampler2D(res, res ## _sampler), uv, bias)
 
 // TODO: implement other texture sampling macros
 // #define textureCube texture

--- a/src/graphics/program-lib/chunks/standard/frag/ao.js
+++ b/src/graphics/program-lib/chunks/standard/frag/ao.js
@@ -7,7 +7,7 @@ void getAO() {
     dAo = 1.0;
 
     #ifdef MAPTEXTURE
-    dAo *= texture2D(texture_aoMap, $UV, textureBias).$CH;
+    dAo *= texture2DBias(texture_aoMap, $UV, textureBias).$CH;
     #endif
 
     #ifdef MAPVERTEX

--- a/src/graphics/program-lib/chunks/standard/frag/clearCoat.js
+++ b/src/graphics/program-lib/chunks/standard/frag/clearCoat.js
@@ -15,7 +15,7 @@ void getClearCoat() {
     #endif
 
     #ifdef MAPTEXTURE
-    ccSpecularity *= texture2D(texture_clearCoatMap, $UV, textureBias).$CH;
+    ccSpecularity *= texture2DBias(texture_clearCoatMap, $UV, textureBias).$CH;
     #endif
 
     #ifdef MAPVERTEX

--- a/src/graphics/program-lib/chunks/standard/frag/clearCoatGloss.js
+++ b/src/graphics/program-lib/chunks/standard/frag/clearCoatGloss.js
@@ -15,7 +15,7 @@ void getClearCoatGlossiness() {
     #endif
 
     #ifdef MAPTEXTURE
-    ccGlossiness *= texture2D(texture_clearCoatGlossMap, $UV, textureBias).$CH;
+    ccGlossiness *= texture2DBias(texture_clearCoatGlossMap, $UV, textureBias).$CH;
     #endif
 
     #ifdef MAPVERTEX

--- a/src/graphics/program-lib/chunks/standard/frag/clearCoatNormal.js
+++ b/src/graphics/program-lib/chunks/standard/frag/clearCoatNormal.js
@@ -6,7 +6,7 @@ uniform float material_clearCoatBumpiness;
 
 void getClearCoatNormal() {
 #ifdef MAPTEXTURE
-    vec3 normalMap = unpackNormal(texture2D(texture_clearCoatNormalMap, $UV, textureBias));
+    vec3 normalMap = unpackNormal(texture2DBias(texture_clearCoatNormalMap, $UV, textureBias));
     normalMap = mix(vec3(0.0, 0.0, 1.0), normalMap, material_clearCoatBumpiness);
     ccNormalW = normalize(dTBN * normalMap);
 #else

--- a/src/graphics/program-lib/chunks/standard/frag/diffuse.js
+++ b/src/graphics/program-lib/chunks/standard/frag/diffuse.js
@@ -15,7 +15,7 @@ void getAlbedo() {
 #endif
 
 #ifdef MAPTEXTURE
-    vec3 albedoBase = gammaCorrectInput(texture2D(texture_diffuseMap, $UV, textureBias).$CH);
+    vec3 albedoBase = gammaCorrectInput(texture2DBias(texture_diffuseMap, $UV, textureBias).$CH);
     dAlbedo *= addAlbedoDetail(albedoBase);
 #endif
 

--- a/src/graphics/program-lib/chunks/standard/frag/diffuseDetailMap.js
+++ b/src/graphics/program-lib/chunks/standard/frag/diffuseDetailMap.js
@@ -5,7 +5,7 @@ uniform sampler2D texture_diffuseDetailMap;
 
 vec3 addAlbedoDetail(vec3 albedo) {
 #ifdef MAPTEXTURE
-    vec3 albedoDetail = gammaCorrectInput(texture2D(texture_diffuseDetailMap, $UV, textureBias).$CH);
+    vec3 albedoDetail = gammaCorrectInput(texture2DBias(texture_diffuseDetailMap, $UV, textureBias).$CH);
     return detailMode_$DETAILMODE(albedo, albedoDetail);
 #else
     return albedo;

--- a/src/graphics/program-lib/chunks/standard/frag/emissive.js
+++ b/src/graphics/program-lib/chunks/standard/frag/emissive.js
@@ -23,7 +23,7 @@ void getEmission() {
     #endif
 
     #ifdef MAPTEXTURE
-    dEmission *= $DECODE(texture2D(texture_emissiveMap, $UV, textureBias)).$CH;
+    dEmission *= $DECODE(texture2DBias(texture_emissiveMap, $UV, textureBias)).$CH;
     #endif
 
     #ifdef MAPVERTEX

--- a/src/graphics/program-lib/chunks/standard/frag/gloss.js
+++ b/src/graphics/program-lib/chunks/standard/frag/gloss.js
@@ -15,7 +15,7 @@ void getGlossiness() {
     #endif
 
     #ifdef MAPTEXTURE
-    dGlossiness *= texture2D(texture_glossMap, $UV, textureBias).$CH;
+    dGlossiness *= texture2DBias(texture_glossMap, $UV, textureBias).$CH;
     #endif
 
     #ifdef MAPVERTEX

--- a/src/graphics/program-lib/chunks/standard/frag/lightmapDir.js
+++ b/src/graphics/program-lib/chunks/standard/frag/lightmapDir.js
@@ -3,9 +3,9 @@ uniform sampler2D texture_lightMap;
 uniform sampler2D texture_dirLightMap;
 
 void getLightMap() {
-    dLightmap = $DECODE(texture2D(texture_lightMap, $UV, textureBias)).$CH;
+    dLightmap = $DECODE(texture2DBias(texture_lightMap, $UV, textureBias)).$CH;
 
-    vec3 dir = texture2D(texture_dirLightMap, $UV, textureBias).xyz * 2.0 - 1.0;
+    vec3 dir = texture2DBias(texture_dirLightMap, $UV, textureBias).xyz * 2.0 - 1.0;
     float dirDot = dot(dir, dir);
     dLightmapDir = (dirDot > 0.001) ? dir / sqrt(dirDot) : vec3(0.0);
 }

--- a/src/graphics/program-lib/chunks/standard/frag/lightmapSingle.js
+++ b/src/graphics/program-lib/chunks/standard/frag/lightmapSingle.js
@@ -7,7 +7,7 @@ void getLightMap() {
     dLightmap = vec3(1.0);
 
     #ifdef MAPTEXTURE
-    dLightmap *= $DECODE(texture2D(texture_lightMap, $UV, textureBias)).$CH;
+    dLightmap *= $DECODE(texture2DBias(texture_lightMap, $UV, textureBias)).$CH;
     #endif
 
     #ifdef MAPVERTEX

--- a/src/graphics/program-lib/chunks/standard/frag/metalness.js
+++ b/src/graphics/program-lib/chunks/standard/frag/metalness.js
@@ -15,7 +15,7 @@ void getMetalness() {
     #endif
 
     #ifdef MAPTEXTURE
-    metalness *= texture2D(texture_metalnessMap, $UV, textureBias).$CH;
+    metalness *= texture2DBias(texture_metalnessMap, $UV, textureBias).$CH;
     #endif
 
     #ifdef MAPVERTEX

--- a/src/graphics/program-lib/chunks/standard/frag/normalDetailMap.js
+++ b/src/graphics/program-lib/chunks/standard/frag/normalDetailMap.js
@@ -13,7 +13,7 @@ vec3 blendNormals(vec3 n1, vec3 n2) {
 
 vec3 addNormalDetail(vec3 normalMap) {
 #ifdef MAPTEXTURE
-    vec3 normalDetailMap = unpackNormal(texture2D(texture_normalDetailMap, $UV, textureBias));
+    vec3 normalDetailMap = unpackNormal(texture2DBias(texture_normalDetailMap, $UV, textureBias));
     normalDetailMap = mix(vec3(0.0, 0.0, 1.0), normalDetailMap, material_normalDetailMapBumpiness);
     return blendNormals(normalMap, normalDetailMap);
 #else

--- a/src/graphics/program-lib/chunks/standard/frag/normalMap.js
+++ b/src/graphics/program-lib/chunks/standard/frag/normalMap.js
@@ -6,7 +6,7 @@ uniform float material_bumpiness;
 
 void getNormal() {
 #ifdef MAPTEXTURE
-    vec3 normalMap = unpackNormal(texture2D(texture_normalMap, $UV, textureBias));
+    vec3 normalMap = unpackNormal(texture2DBias(texture_normalMap, $UV, textureBias));
     normalMap = mix(vec3(0.0, 0.0, 1.0), normalMap, material_bumpiness);
     dNormalW = normalize(dTBN * addNormalDetail(normalMap));
 #else

--- a/src/graphics/program-lib/chunks/standard/frag/opacity.js
+++ b/src/graphics/program-lib/chunks/standard/frag/opacity.js
@@ -15,7 +15,7 @@ void getOpacity() {
     #endif
 
     #ifdef MAPTEXTURE
-    dAlpha *= texture2D(texture_opacityMap, $UV, textureBias).$CH;
+    dAlpha *= texture2DBias(texture_opacityMap, $UV, textureBias).$CH;
     #endif
 
     #ifdef MAPVERTEX

--- a/src/graphics/program-lib/chunks/standard/frag/parallax.js
+++ b/src/graphics/program-lib/chunks/standard/frag/parallax.js
@@ -5,7 +5,7 @@ uniform float material_heightMapFactor;
 void getParallax() {
     float parallaxScale = material_heightMapFactor;
 
-    float height = texture2D(texture_heightMap, $UV, textureBias).$CH;
+    float height = texture2DBias(texture_heightMap, $UV, textureBias).$CH;
     height = height * parallaxScale - parallaxScale*0.5;
     vec3 viewDirT = dViewDirW * dTBN;
 

--- a/src/graphics/program-lib/chunks/standard/frag/sheen.js
+++ b/src/graphics/program-lib/chunks/standard/frag/sheen.js
@@ -16,7 +16,7 @@ void getSheen() {
     #endif
 
     #ifdef MAPTEXTURE
-    sheenColor *= $DECODE(texture2D(texture_sheenMap, $UV, textureBias)).$CH;
+    sheenColor *= $DECODE(texture2DBias(texture_sheenMap, $UV, textureBias)).$CH;
     #endif
 
     #ifdef MAPVERTEX

--- a/src/graphics/program-lib/chunks/standard/frag/sheenGloss.js
+++ b/src/graphics/program-lib/chunks/standard/frag/sheenGloss.js
@@ -15,7 +15,7 @@ void getSheenGlossiness() {
     #endif
 
     #ifdef MAPTEXTURE
-    sheenGlossiness *= texture2D(texture_sheenGlossinessMap, $UV, textureBias).$CH;
+    sheenGlossiness *= texture2DBias(texture_sheenGlossinessMap, $UV, textureBias).$CH;
     #endif
 
     #ifdef MAPVERTEX

--- a/src/graphics/program-lib/chunks/standard/frag/specular.js
+++ b/src/graphics/program-lib/chunks/standard/frag/specular.js
@@ -16,7 +16,7 @@ void getSpecularity() {
     #endif
 
     #ifdef MAPTEXTURE
-    specularColor *= $DECODE(texture2D(texture_specularMap, $UV, textureBias)).$CH;
+    specularColor *= $DECODE(texture2DBias(texture_specularMap, $UV, textureBias)).$CH;
     #endif
 
     #ifdef MAPVERTEX

--- a/src/graphics/program-lib/chunks/standard/frag/specularityFactor.js
+++ b/src/graphics/program-lib/chunks/standard/frag/specularityFactor.js
@@ -16,7 +16,7 @@ void getSpecularityFactor() {
     #endif
 
     #ifdef MAPTEXTURE
-    specularityFactor *= texture2D(texture_specularityFactorMap, $UV, textureBias).$CH;
+    specularityFactor *= texture2DBias(texture_specularityFactorMap, $UV, textureBias).$CH;
     #endif
 
     #ifdef MAPVERTEX

--- a/src/graphics/program-lib/chunks/standard/frag/thickness.js
+++ b/src/graphics/program-lib/chunks/standard/frag/thickness.js
@@ -15,7 +15,7 @@ void getThickness() {
     #endif
 
     #ifdef MAPTEXTURE
-    dThickness *= texture2D(texture_thicknessMap, $UV, textureBias).$CH;
+    dThickness *= texture2DBias(texture_thicknessMap, $UV, textureBias).$CH;
     #endif
 
     #ifdef MAPVERTEX

--- a/src/graphics/program-lib/chunks/standard/frag/transmission.js
+++ b/src/graphics/program-lib/chunks/standard/frag/transmission.js
@@ -16,7 +16,7 @@ void getRefraction() {
     #endif
 
     #ifdef MAPTEXTURE
-    refraction *= gammaCorrectInput(texture2D(texture_refractionMap, $UV, textureBias)).$CH;
+    refraction *= gammaCorrectInput(texture2DBias(texture_refractionMap, $UV, textureBias)).$CH;
     #endif
 
     #ifdef MAPVERTEX

--- a/src/graphics/program-lib/programs/common.js
+++ b/src/graphics/program-lib/programs/common.js
@@ -129,7 +129,6 @@ function vertexIntro(device, name, pass, extensionCode) {
 function fragmentIntro(device, name, pass, extensionCode, forcePrecision) {
 
     let code = versionCode(device);
-    code += precisionCode(device, forcePrecision, true);
 
     if (device.deviceType === DEVICETYPE_WEBGPU) {
 
@@ -154,9 +153,12 @@ function fragmentIntro(device, name, pass, extensionCode, forcePrecision) {
                 code += "#extension GL_EXT_shader_texture_lod : enable\n";
                 code += "#define SUPPORTS_TEXLOD\n";
             }
+
+            code += shaderChunks.gles2PS;
         }
     }
 
+    code += precisionCode(device, forcePrecision, true);
     code += getShaderNameCode(name);
     code += ShaderPass.getPassShaderDefine(pass);
 

--- a/src/graphics/uniform-buffer-format.js
+++ b/src/graphics/uniform-buffer-format.js
@@ -83,6 +83,7 @@ class UniformFormat {
     }
 
     // std140 rules: https://registry.khronos.org/OpenGL/specs/gl/glspec45.core.pdf#page=159
+    // TODO: this support limited subset of functionality, arrays and structs are not supported.
     calculateOffset(offset) {
 
         // Note: vec3 has the same alignment as vec4

--- a/src/graphics/uniform-buffer.js
+++ b/src/graphics/uniform-buffer.js
@@ -1,8 +1,99 @@
 import { Debug } from '../core/debug.js';
+import {
+    uniformTypeToName,
+    UNIFORMTYPE_INT, UNIFORMTYPE_FLOAT, UNIFORMTYPE_VEC2, UNIFORMTYPE_VEC3,
+    UNIFORMTYPE_VEC4, UNIFORMTYPE_IVEC2, UNIFORMTYPE_IVEC3, UNIFORMTYPE_IVEC4,
+    UNIFORMTYPE_MAT2, UNIFORMTYPE_MAT3
+} from './constants.js';
 
 /** @typedef {import('./graphics-device.js').GraphicsDevice} GraphicsDevice */
 /** @typedef {import('./uniform-buffer-format.js').UniformBufferFormat} UniformBufferFormat */
 /** @typedef {import('./uniform-buffer-format.js').UniformFormat} UniformFormat */
+
+// Uniform buffer set functions - only implemented for types for which the default
+// array to buffer copy does not work, or could be slower.
+const _updateFunctions = [];
+
+_updateFunctions[UNIFORMTYPE_FLOAT] = function (uniformBuffer, value, offset) {
+    const dst = uniformBuffer.storageFloat32;
+    dst[offset] = value;
+};
+
+_updateFunctions[UNIFORMTYPE_VEC2] = (uniformBuffer, value, offset) => {
+    const dst = uniformBuffer.storageFloat32;
+    dst[offset] = value[0];
+    dst[offset + 1] = value[1];
+};
+
+_updateFunctions[UNIFORMTYPE_VEC3] = (uniformBuffer, value, offset) => {
+    const dst = uniformBuffer.storageFloat32;
+    dst[offset] = value[0];
+    dst[offset + 1] = value[1];
+    dst[offset + 2] = value[2];
+};
+
+_updateFunctions[UNIFORMTYPE_VEC4] = (uniformBuffer, value, offset) => {
+    const dst = uniformBuffer.storageFloat32;
+    dst[offset] = value[0];
+    dst[offset + 1] = value[1];
+    dst[offset + 2] = value[2];
+    dst[offset + 3] = value[3];
+};
+
+_updateFunctions[UNIFORMTYPE_INT] = function (uniformBuffer, value, offset) {
+    const dst = uniformBuffer.storageInt32;
+    dst[offset] = value;
+};
+
+_updateFunctions[UNIFORMTYPE_IVEC2] = function (uniformBuffer, value, offset) {
+    const dst = uniformBuffer.storageInt32;
+    dst[offset] = value[0];
+    dst[offset + 1] = value[1];
+};
+
+_updateFunctions[UNIFORMTYPE_IVEC3] = function (uniformBuffer, value, offset) {
+    const dst = uniformBuffer.storageInt32;
+    dst[offset] = value[0];
+    dst[offset + 1] = value[1];
+    dst[offset + 2] = value[2];
+};
+
+_updateFunctions[UNIFORMTYPE_IVEC4] = function (uniformBuffer, value, offset) {
+    const dst = uniformBuffer.storageInt32;
+    dst[offset] = value[0];
+    dst[offset + 1] = value[1];
+    dst[offset + 2] = value[2];
+    dst[offset + 3] = value[3];
+};
+
+// convert from continuous array to vec2[3] with padding to vec4[2]
+_updateFunctions[UNIFORMTYPE_MAT2] = (uniformBuffer, value, offset) => {
+    const dst = uniformBuffer.storageFloat32;
+    dst[offset] = value[0];
+    dst[offset + 1] = value[1];
+
+    dst[offset + 4] = value[2];
+    dst[offset + 5] = value[3];
+
+    dst[offset + 8] = value[4];
+    dst[offset + 9] = value[5];
+};
+
+// convert from continuous array to vec3[3] with padding to vec4[3]
+_updateFunctions[UNIFORMTYPE_MAT3] = (uniformBuffer, value, offset) => {
+    const dst = uniformBuffer.storageFloat32;
+    dst[offset] = value[0];
+    dst[offset + 1] = value[1];
+    dst[offset + 2] = value[2];
+
+    dst[offset + 4] = value[3];
+    dst[offset + 5] = value[4];
+    dst[offset + 6] = value[5];
+
+    dst[offset + 8] = value[6];
+    dst[offset + 9] = value[7];
+    dst[offset + 10] = value[8];
+};
 
 /**
  * A uniform buffer represents a GPU memory buffer storing the uniforms.
@@ -23,12 +114,9 @@ class UniformBuffer {
 
         this.impl = graphicsDevice.createUniformBufferImpl(this);
 
-
-        // TODO: maybe size rounding up should be done here and not per platform
-
-
         this.storage = new ArrayBuffer(format.byteSize);
         this.storageFloat32 = new Float32Array(this.storage);
+        this.storageInt32 = new Int32Array(this.storage);
 
         graphicsDevice._vram.ub += this.format.byteSize;
 
@@ -69,10 +157,19 @@ class UniformBuffer {
     setUniform(uniformFormat) {
         Debug.assert(uniformFormat);
         const offset = uniformFormat.offset;
-
         const value = uniformFormat.scopeId.value;
-        Debug.assert(value !== undefined, `Value was not set when assigning to uniform [${uniformFormat.name}]`);
-        this.storageFloat32.set(value, offset);
+
+        if (value !== null && value !== undefined) {
+            const updateFunction = _updateFunctions[uniformFormat.type];
+            if (updateFunction) {
+                updateFunction(this, value, offset);
+            } else {
+                this.storageFloat32.set(value, offset);
+            }
+        } else {
+            Debug.warnOnce(`Value was not set when assigning to uniform [${uniformFormat.name}]` +
+                            `, expected type ${uniformTypeToName[uniformFormat.type]}`);
+        }
     }
 
     /**

--- a/src/graphics/webgl/webgl-graphics-device.js
+++ b/src/graphics/webgl/webgl-graphics-device.js
@@ -584,9 +584,6 @@ class WebglGraphicsDevice extends GraphicsDevice {
         }
 
         this.constantTexSource = this.scope.resolve("source");
-        this.textureBias = this.scope.resolve("textureBias");
-
-        this.textureBias.setValue(0.0);
 
         if (this.extTextureFloat) {
             if (this.webgl2) {

--- a/src/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/graphics/webgpu/webgpu-graphics-device.js
@@ -307,11 +307,11 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
 
     // #if _DEBUG
     pushMarker(name) {
-        // this.commandEncoder?.pushDebugGroup(name);
+        this.passEncoder?.pushDebugGroup(name);
     }
 
     popMarker() {
-        // this.commandEncoder?.popDebugGroup();
+        this.passEncoder?.popDebugGroup();
     }
     // #endif
 }

--- a/src/resources/parser/glb-parser.js
+++ b/src/resources/parser/glb-parser.js
@@ -1081,7 +1081,7 @@ const extensionClearCoat = function (data, material, textures) {
         #endif
         
         #ifdef MAPTEXTURE
-            ccGlossiness *= texture2D(texture_clearCoatGlossMap, $UV, textureBias).$CH;
+            ccGlossiness *= texture2DBias(texture_clearCoatGlossMap, $UV, textureBias).$CH;
         #endif
         
         #ifdef MAPVERTEX
@@ -1200,7 +1200,7 @@ const extensionSheen = function (data, material, textures) {
         #endif
 
         #ifdef MAPTEXTURE
-        sheenGlossiness *= texture2D(texture_sheenGlossinessMap, $UV, textureBias).$CH;
+        sheenGlossiness *= texture2DBias(texture_sheenGlossinessMap, $UV, textureBias).$CH;
         #endif
 
         #ifdef MAPVERTEX
@@ -1258,7 +1258,7 @@ const createMaterial = function (gltfMaterial, textures, flipV) {
         #endif
         
         #ifdef MAPTEXTURE
-            dGlossiness *= texture2D(texture_glossMap, $UV, textureBias).$CH;
+            dGlossiness *= texture2DBias(texture_glossMap, $UV, textureBias).$CH;
         #endif
         
         #ifdef MAPVERTEX


### PR DESCRIPTION
- 2d texture sampling is using texture2DBias instead of texture2D to allow macro replacement for WebGPU
- Uniform buffer handles additional uniform types - alignment, setup
- adding extensions earlier in the shader code to avoid warnings