### PR TITLE
Refactoring to get more of the standard shader compile for WebGPU

### DIFF
--- a/examples/webgpu-temp/index.html
+++ b/examples/webgpu-temp/index.html
@@ -49,10 +49,12 @@
         import { CameraComponentSystem } from '../../src/framework/components/camera/system.js';
         import { LightComponentSystem } from '../../src/framework/components/light/system.js';
         import { TextureHandler } from '../../src/resources/texture.js';
+        import { ContainerHandler } from '../../src/resources/container.js';
 
         const assets = {
             'playcanvas': new Asset('color', 'texture', { url: '../assets/textures/playcanvas.png' }),
-            'rocks': new Asset('color', 'texture', { url: '../assets/textures/seaside-rocks01-diffuse-alpha.png' })
+            'rocks': new Asset('color', 'texture', { url: '../assets/textures/seaside-rocks01-diffuse-alpha.png' }),
+            'model': new Asset('model', 'container', { url: '../assets/models/bitmoji.glb' }),
         };
 
         const vertexShaderGLSL = /* glsl */`
@@ -86,8 +88,9 @@ void main() {
 // in 
 varying vec2 uv;
 
-// out
-out highp vec4 outColor;
+// out - TODO: use shader intro which handles this per platform
+layout(location = 0) out highp vec4 pc_fragColor;
+#define gl_FragColor pc_fragColor
 
 uniform vec3 material_diffuse;
 
@@ -96,7 +99,7 @@ uniform sampler2D texture_emissiveMap;
 void main() {
     vec4 tex = texture2D(texture_emissiveMap, uv);
     vec3 diffuse = tex.xyz * material_diffuse;
-    outColor = vec4(diffuse, 1.0);
+    gl_FragColor = vec4(diffuse, 1.0);
 }
         `;
 
@@ -253,6 +256,17 @@ void main() {
             app.root.addChild(textureCamera);
             textureCamera.setLocalPosition(0, 0, 12);
 
+            /////////////// skinning - commented out as it is still not functional
+
+            // const modelEntity = assets.model.resource.instantiateRenderEntity({
+            // });
+
+            // const modelEntityParent = new Entity();
+            // modelEntityParent.addChild(modelEntity);
+            // app.root.addChild(modelEntityParent);
+
+            ///////////////
+
 
             let time = 0;
             const rot = new Quat();
@@ -303,6 +317,7 @@ void main() {
             ];
             createOptions.resourceHandlers = [
                 TextureHandler,
+                ContainerHandler
             ];
 
             const app = new AppBase(canvas);

--- a/src/graphics/graphics-device.js
+++ b/src/graphics/graphics-device.js
@@ -50,6 +50,13 @@ class GraphicsDevice extends EventHandler {
     scope;
 
     /**
+     * The maximum number of supported bones using uniform buffers.
+     *
+     * @type {number}
+     */
+    boneLimit;
+
+    /**
      * The maximum supported texture anisotropy setting.
      *
      * @type {number}
@@ -434,6 +441,32 @@ class GraphicsDevice extends EventHandler {
 
     get maxPixelRatio() {
         return this._maxPixelRatio;
+    }
+
+    /**
+     * Queries the maximum number of bones that can be referenced by a shader. The shader
+     * generators (programlib) use this number to specify the matrix array size of the uniform
+     * 'matrix_pose[0]'. The value is calculated based on the number of available uniform vectors
+     * available after subtracting the number taken by a typical heavyweight shader. If a different
+     * number is required, it can be tuned via {@link GraphicsDevice#setBoneLimit}.
+     *
+     * @returns {number} The maximum number of bones that can be supported by the host hardware.
+     * @ignore
+     */
+    getBoneLimit() {
+        return this.boneLimit;
+    }
+
+    /**
+     * Specifies the maximum number of bones that the device can support on the current hardware.
+     * This function allows the default calculated value based on available vector uniforms to be
+     * overridden.
+     *
+     * @param {number} maxBones - The maximum number of bones supported by the host hardware.
+     * @ignore
+     */
+    setBoneLimit(maxBones) {
+        this.boneLimit = maxBones;
     }
 }
 

--- a/src/graphics/program-lib/chunks/common/frag/webgpu.js
+++ b/src/graphics/program-lib/chunks/common/frag/webgpu.js
@@ -1,5 +1,6 @@
 export default /* glsl */`
-out highp vec4 pc_fragColor;
+
+layout(location = 0) out highp vec4 pc_fragColor;
 #define gl_FragColor pc_fragColor
 
 #define texture2D(res, uv) texture(sampler2D(res, res ## _sampler), uv)

--- a/src/graphics/shader-processor.js
+++ b/src/graphics/shader-processor.js
@@ -27,7 +27,9 @@ class UniformLine {
     constructor(line) {
         this.line = line;
 
-        const words = this.splitToWords(line);
+        // split to words handling any number of spaces
+        const words = line.trim().split(/\s+/);
+
         this.precision = undefined;
         this.type = words[0];
         this.name = words[1];
@@ -38,15 +40,8 @@ class UniformLine {
             this.type = words[1];
             this.name = words[2];
         }
-    }
 
-    splitToWords(line) {
-        // remove any double spaces
-        return line.trim().split(/\s+/);
-    }
-
-    get isSampler() {
-        return this.type.indexOf('sampler') !== -1;
+        this.isSampler = this.type.indexOf('sampler') !== -1;
     }
 }
 

--- a/src/graphics/shader-processor.js
+++ b/src/graphics/shader-processor.js
@@ -90,11 +90,7 @@ class ShaderProcessor {
         const uniforms = vertexExtracted.uniforms.concat(fragmentExtracted.uniforms);
 
         // parse uniform lines
-        /** @type {Array<UniformLine>} */
-        const parsedUniforms = [];
-        uniforms.forEach((line) => {
-            parsedUniforms.push(new UniformLine(line));
-        });
+        const parsedUniforms = uniforms.map(line => new UniformLine(line));
 
         const uniformsData = ShaderProcessor.processUniforms(device, parsedUniforms, shaderDefinition.processingOptions);
 

--- a/src/graphics/shader-processor.js
+++ b/src/graphics/shader-processor.js
@@ -42,8 +42,7 @@ class UniformLine {
 
     splitToWords(line) {
         // remove any double spaces
-        line = line.replace(/\s+/g, ' ').trim();
-        return line.split(' ');
+        return line.trim().split(/\s+/);
     }
 
     get isSampler() {

--- a/src/graphics/shader-processor.js
+++ b/src/graphics/shader-processor.js
@@ -11,13 +11,45 @@ import { BindGroupFormat, BindBufferFormat, BindTextureFormat } from './bind-gro
 /** @typedef {import('./graphics-device.js').GraphicsDevice} GraphicsDevice */
 
 // accepted keywords
-const KEYWORD = /[ \t]*(\battribute\b|\bvarying\b|\bout\b|\buniform\b)/g;
+// TODO: 'out' keyword is not in the list, as handling it is more complicated due
+// to 'out' keyword also being used to mark output only function parameters.
+const KEYWORD = /[ \t]*(\battribute\b|\bvarying\b|\buniform\b)/g;
 
 // match 'attribute' and anything else till ';'
 const KEYWORD_LINE = /(\battribute\b|\bvarying\b|\bout\b|\buniform\b)[ \t]*([^;]+)([;]+)/g;
 
 // marker for a place in the source code to be replaced by code
 const MARKER = '@@@';
+
+const precisionQualifiers = new Set(['highp', 'mediump', 'lowp']);
+
+class UniformLine {
+    constructor(line) {
+        this.line = line;
+
+        const words = this.splitToWords(line);
+        this.precision = undefined;
+        this.type = words[0];
+        this.name = words[1];
+
+        // if this is a precision qualifier
+        if (precisionQualifiers.has(this.type)) {
+            this.precision = words[0];
+            this.type = words[1];
+            this.name = words[2];
+        }
+    }
+
+    splitToWords(line) {
+        // remove any double spaces
+        line = line.replace(/\s+/g, ' ').trim();
+        return line.split(' ');
+    }
+
+    get isSampler() {
+        return this.type.indexOf('sampler') !== -1;
+    }
+}
 
 /**
  * Pure static class implementing processing of GLSL shaders. It allocates
@@ -57,7 +89,15 @@ class ShaderProcessor {
 
         // uniforms - merge vertex and fragment uniforms, and create shared uniform buffers
         const uniforms = vertexExtracted.uniforms.concat(fragmentExtracted.uniforms);
-        const uniformsData = ShaderProcessor.processUniforms(device, uniforms, shaderDefinition.processingOptions);
+
+        // parse uniform lines
+        /** @type {Array<UniformLine>} */
+        const parsedUniforms = [];
+        uniforms.forEach((line) => {
+            parsedUniforms.push(new UniformLine(line));
+        });
+
+        const uniformsData = ShaderProcessor.processUniforms(device, parsedUniforms, shaderDefinition.processingOptions);
 
         // VS - insert the blocks to the source
         const vBlock = attributesBlock + '\n' + vertexVaryingsBlock + '\n' + uniformsData.code;
@@ -142,43 +182,35 @@ class ShaderProcessor {
      * uniforms that change on the level of the mesh.
      *
      * @param {GraphicsDevice} device - The graphics device.
-     * @param {Array<string>} uniformLines - Lines containing uniforms.
+     * @param {Array<UniformLine>} uniforms - Lines containing uniforms.
      * @param {ShaderProcessorOptions} processingOptions - Uniform formats.
      * @returns {object} - The uniform data. Returns a shader code block containing uniforms, to be
      * inserted into the shader, as well as generated uniform format structures for the mesh level.
      */
-    static processUniforms(device, uniformLines, processingOptions) {
-
-        const isSampler = (uniformType) => {
-            return uniformType.indexOf('sampler') !== -1;
-        };
+    static processUniforms(device, uniforms, processingOptions) {
 
         // split uniform lines into samplers and the rest
+        /** @type {Array<UniformLine>} */
         const uniformLinesSamplers = [];
+        /** @type {Array<UniformLine>} */
         const uniformLinesNonSamplers = [];
-        uniformLines.forEach((line) => {
-            const words = ShaderProcessor.splitToWords(line);
-            const type = words[0];
-            if (isSampler(type)) {
-                uniformLinesSamplers.push(line);
+        uniforms.forEach((uniform) => {
+            if (uniform.isSampler) {
+                uniformLinesSamplers.push(uniform);
             } else {
-                uniformLinesNonSamplers.push(line);
+                uniformLinesNonSamplers.push(uniform);
             }
         });
 
         // build mesh uniform buffer format
         const meshUniforms = [];
-        uniformLinesNonSamplers.forEach((line) => {
-            const words = ShaderProcessor.splitToWords(line);
-            const type = words[0];
-            const name = words[1];
-
+        uniformLinesNonSamplers.forEach((uniform) => {
             // uniforms not already in supplied uniform buffers go to the mesh buffer
-            if (!processingOptions.hasUniform(name)) {
-                const uniformType = uniformTypeToName.indexOf(type);
-                Debug.assert(uniformType >= 0, `Uniform type ${type} is not recognized on line [${line}]`);
-                const uniform = new UniformFormat(name, uniformType);
-                meshUniforms.push(uniform);
+            if (!processingOptions.hasUniform(uniform.name)) {
+                const uniformType = uniformTypeToName.indexOf(uniform.type);
+                Debug.assert(uniformType >= 0, `Uniform type ${uniform.type} is not recognized on line [${uniform.line}]`);
+                const uniformFormat = new UniformFormat(uniform.name, uniformType);
+                meshUniforms.push(uniformFormat);
             }
 
             // validate types in else
@@ -195,15 +227,12 @@ class ShaderProcessor {
 
         // add textures uniforms
         const textureFormats = [];
-        uniformLinesSamplers.forEach((line) => {
-            const words = ShaderProcessor.splitToWords(line);
-            const name = words[1];
-
+        uniformLinesSamplers.forEach((uniform) => {
             // unmached texture uniforms go to mesh block
-            if (!processingOptions.hasTexture(name)) {
+            if (!processingOptions.hasTexture(uniform.name)) {
 
                 // TODO: we could optimize visibility to only stages that use any of the data
-                textureFormats.push(new BindTextureFormat(name, SHADERSTAGE_VERTEX | SHADERSTAGE_FRAGMENT));
+                textureFormats.push(new BindTextureFormat(uniform.name, SHADERSTAGE_VERTEX | SHADERSTAGE_FRAGMENT));
             }
 
             // validate types in else

--- a/src/graphics/shader.js
+++ b/src/graphics/shader.js
@@ -76,10 +76,6 @@ class Shader {
         this.definition = definition;
         this.name = definition.name || 'Untitled';
 
-        Debug.trace(TRACEID_SHADER_ALLOC, `Alloc: Id ${this.id} ${this.name}`, {
-            definition
-        });
-
         Debug.assert(definition.vshader, 'No vertex shader has been specified when creating a shader.');
         Debug.assert(definition.fshader, 'No fragment shader has been specified when creating a shader.');
 
@@ -90,6 +86,10 @@ class Shader {
         this.init();
 
         this.impl = graphicsDevice.createShaderImpl(this);
+
+        Debug.trace(TRACEID_SHADER_ALLOC, `Alloc: Id ${this.id} ${this.name}`, {
+            instance: this
+        });
     }
 
     /**

--- a/src/graphics/webgl/webgl-graphics-device.js
+++ b/src/graphics/webgl/webgl-graphics-device.js
@@ -2665,32 +2665,6 @@ class WebglGraphicsDevice extends GraphicsDevice {
     }
 
     /**
-     * Queries the maximum number of bones that can be referenced by a shader. The shader
-     * generators (programlib) use this number to specify the matrix array size of the uniform
-     * 'matrix_pose[0]'. The value is calculated based on the number of available uniform vectors
-     * available after subtracting the number taken by a typical heavyweight shader. If a different
-     * number is required, it can be tuned via {@link GraphicsDevice#setBoneLimit}.
-     *
-     * @returns {number} The maximum number of bones that can be supported by the host hardware.
-     * @ignore
-     */
-    getBoneLimit() {
-        return this.boneLimit;
-    }
-
-    /**
-     * Specifies the maximum number of bones that the device can support on the current hardware.
-     * This function allows the default calculated value based on available vector uniforms to be
-     * overridden.
-     *
-     * @param {number} maxBones - The maximum number of bones supported by the host hardware.
-     * @ignore
-     */
-    setBoneLimit(maxBones) {
-        this.boneLimit = maxBones;
-    }
-
-    /**
      * Frees memory from all shaders ever allocated with this device.
      *
      * @ignore

--- a/src/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/graphics/webgpu/webgpu-graphics-device.js
@@ -65,6 +65,11 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
         this.precision = 'hiphp';
         this.maxSamples = 4;
         this.supportsUniformBuffers = true;
+        this.supportsBoneTextures = true;
+        this.supportsMorphTargetTexturesCore = true;
+        this.extTextureFloat = true;
+        this.extTextureHalfFloat = false; // TODO: likely supported as well
+        this.boneLimit = 1024;
     }
 
     async initWebGpu() {

--- a/src/graphics/webgpu/webgpu-shader.js
+++ b/src/graphics/webgpu/webgpu-shader.js
@@ -53,6 +53,11 @@ class WebgpuShader {
         // process the shader source to allow for uniforms
         const processed = ShaderProcessor.run(this.shader.device, this.shader.definition);
 
+        // keep reference to processed shaders in debug mode
+        Debug.call(() => {
+            this.processed = processed;
+        });
+
         this._vertexCode = this.transpile(processed.vshader, 'vertex', this.shader.definition.vshader);
         this._fragmentCode = this.transpile(processed.fshader, 'fragment', this.shader.definition.fshader);
 


### PR DESCRIPTION
- WIP on loading glb model and rendering it on WebGPU device
- moved bone limits from webgl device to the device to share it across platforms
- updated shader processor to handle precision specification for uniforms
- updated shader processor to ignore out keywords for now, as those are handled differently for now (we only need more generic solution when we add support for MRT)