### PR TITLE
Fix material thickness and texture transforms

### DIFF
--- a/src/resources/parser/glb-parser.js
+++ b/src/resources/parser/glb-parser.js
@@ -1124,6 +1124,9 @@ const extensionSpecular = function (data, material, textures) {
         material.specularEncoding = 'srgb';
         material.specularMap = textures[data.specularColorTexture.index];
         material.specularMapChannel = 'rgb';
+
+        extractTextureTransform(data.specularColorTexture, material, ['specular']);
+
     }
     if (data.hasOwnProperty('specularColorFactor')) {
         const color = data.specularColorFactor;
@@ -1140,6 +1143,7 @@ const extensionSpecular = function (data, material, textures) {
     if (data.hasOwnProperty('specularTexture')) {
         material.specularityFactorMapChannel = 'a';
         material.specularityFactorMap = textures[data.specularTexture.index];
+        extractTextureTransform(data.specularTexture, material, ['specularityFactor']);
     }
 };
 
@@ -1159,6 +1163,7 @@ const extensionTransmission = function (data, material, textures) {
     if (data.hasOwnProperty('transmissionTexture')) {
         material.refractionMapChannel = 'r';
         material.refractionMap = textures[data.transmissionTexture.index];
+        extractTextureTransform(data.transmissionTexture, material, ['refraction']);
     }
 };
 
@@ -1172,6 +1177,7 @@ const extensionSheen = function (data, material, textures) {
     }
     if (data.hasOwnProperty('sheenColorTexture')) {
         material.sheenMap = textures[data.sheenColorTexture.index];
+        extractTextureTransform(data.sheenColorTexture, material, ['sheen']);
     }
     if (data.hasOwnProperty('sheenRoughnessFactor')) {
         material.sheenGlossiness = data.sheenRoughnessFactor;
@@ -1181,6 +1187,7 @@ const extensionSheen = function (data, material, textures) {
     if (data.hasOwnProperty('sheenRoughnessTexture')) {
         material.sheenGlossinessMap = textures[data.sheenRoughnessTexture.index];
         material.sheenGlossinessMapChannel = 'a';
+        extractTextureTransform(data.sheenRoughnessTexture, material, ['sheenGlossiness']);
     }
 
     const sheenGlossChunk = `
@@ -1223,6 +1230,7 @@ const extensionVolume = function (data, material, textures) {
     }
     if (data.hasOwnProperty('thicknessTexture')) {
         material.thicknessMap = textures[data.thicknessTexture.index];
+        extractTextureTransform(data.thicknessTexture, material, ['thickness']);
     }
     if (data.hasOwnProperty('attenuationDistance')) {
         material.attenuationDistance = data.attenuationDistance;

--- a/src/scene/materials/standard-material-options-builder.js
+++ b/src/scene/materials/standard-material-options-builder.js
@@ -170,8 +170,8 @@ class StandardMaterialOptionsBuilder {
         options.customFragmentShader = stdMat.customFragmentShader;
         options.refraction = !!stdMat.refraction || !!stdMat.refractionMap;
         options.useDynamicRefraction = stdMat.useDynamicRefraction;
-        options.refractionIndexTint = (stdMat.refractionIndex !== 1.5) ? 1 : 0;
-        options.thicknessTint = (stdMat.useDynamicRefraction && stdMat.thickness < 1) ? 1 : 0;
+        options.refractionIndexTint = (stdMat.refractionIndex !== 1.0 / 1.5) ? 1 : 0;
+        options.thicknessTint = (stdMat.useDynamicRefraction && stdMat.thickness > 1) ? 1 : 0;
         options.useMetalness = stdMat.useMetalness;
         options.specularEncoding = stdMat.specularEncoding === undefined ? 'linear' : stdMat.specularEncoding;
         options.enableGGXSpecular = stdMat.enableGGXSpecular;


### PR DESCRIPTION
### Description

Our extensions implementation were not extracting texture transforms for the textures. This would cause issues importing assets with for example gltf pack where texture transforms would be applied automatically. 

Thickness was wrongfully not tinted if it was below 1, but in fact thickness is a scale factor meant to scale the texture input. As a result, the DragonAttenuation glTF looks much better.

![image](https://user-images.githubusercontent.com/107400752/186141045-646dd66e-e078-4761-8a89-0aaf9cfea44f.png)


Also, IOR would default to 0.667 in the shader if 1.5 was used, which is incorrect as it should be 1.0 / 1.5. This should be indeed VERY hard to reproduce for a user, so very unlikely anyone encountered this as an issue.