### PR TITLE
Actually, thickness can be < 1 as well...

### DIFF
--- a/src/scene/materials/standard-material-options-builder.js
+++ b/src/scene/materials/standard-material-options-builder.js
@@ -171,7 +171,7 @@ class StandardMaterialOptionsBuilder {
         options.refraction = !!stdMat.refraction || !!stdMat.refractionMap;
         options.useDynamicRefraction = stdMat.useDynamicRefraction;
         options.refractionIndexTint = (stdMat.refractionIndex !== 1.0 / 1.5) ? 1 : 0;
-        options.thicknessTint = (stdMat.useDynamicRefraction && stdMat.thickness > 1) ? 1 : 0;
+        options.thicknessTint = (stdMat.useDynamicRefraction && stdMat.thickness !== 1.0) ? 1 : 0;
         options.useMetalness = stdMat.useMetalness;
         options.specularEncoding = stdMat.specularEncoding === undefined ? 'linear' : stdMat.specularEncoding;
         options.enableGGXSpecular = stdMat.enableGGXSpecular;


### PR DESCRIPTION
### Description

Thickness can also be between (0..1] so we shouldn't just disable thickness tint if it's 1.0.