### PR TITLE
Clustered lighting is enabled by default and public

### DIFF
--- a/examples/src/examples/graphics/area-lights.tsx
+++ b/examples/src/examples/graphics/area-lights.tsx
@@ -128,6 +128,9 @@ class AreaLightsExample {
 
             app.start();
 
+            // enable area lights which are disabled by default for clustered lighting
+            app.scene.lighting.areaLightsEnabled = true;
+
             // set the loaded area light LUT data
             app.setAreaLightLuts(assets.luts);
 

--- a/examples/src/examples/graphics/lights.tsx
+++ b/examples/src/examples/graphics/lights.tsx
@@ -88,6 +88,10 @@ class LightsExample {
             app.setCanvasFillMode(pc.FILLMODE_FILL_WINDOW);
             app.setCanvasResolution(pc.RESOLUTION_AUTO);
 
+            // enable cookies which are disabled by default for clustered lighting
+            app.scene.lighting.cookiesEnabled = true;
+
+            // ambient lighting
             app.scene.ambientLight = new pc.Color(0.2, 0.2, 0.2);
 
             // create an entity with the statue

--- a/src/framework/app-base.js
+++ b/src/framework/app-base.js
@@ -1568,6 +1568,22 @@ class AppBase extends EventHandler {
      * @param {number} settings.render.ambientBakeOcclusionBrightness - Brighness of the baked ambient occlusion.
      * @param {number} settings.render.ambientBakeOcclusionContrast - Contrast of the baked ambient occlusion.
      *
+     * @param {boolean} settings.render.clusteredLightingEnabled - Enable clustered lighting.
+     * @param {boolean} settings.render.lightingShadowsEnabled - If set to true, the clustered lighting will support shadows.
+     * @param {boolean} settings.render.lightingCookiesEnabled - If set to true, the clustered lighting will support cookie textures.
+     * @param {boolean} settings.render.lightingAreaLightsEnabled - If set to true, the clustered lighting will support area lights.
+     * @param {number} settings.render.lightingShadowAtlasResolution - Resolution of the atlas texture storing all non-directional shadow textures.
+     * @param {number} settings.render.lightingCookieAtlasResolution - Resolution of the atlas texture storing all non-directional cookie textures.
+     * @param {number} settings.render.lightingMaxLightsPerCell - Maximum number of lights a cell can store.
+     * @param {number} settings.render.lightingShadowType - The type of shadow filtering used by all shadows. Can be:
+     *
+     * - {@link SHADOW_PCF1}: PCF 1x1 sampling.
+     * - {@link SHADOW_PCF3}: PCF 3x3 sampling.
+     * - {@link SHADOW_PCF5}: PCF 5x5 sampling. Falls back to {@link SHADOW_PCF3} on WebGL 1.0.
+     *
+     * @param {Vec3} settings.render.lightingCells - Number of cells along each world-space axis the space containing lights
+     * is subdivided into.
+     *
      * Only lights with bakeDir=true will be used for generating the dominant light direction.
      * @example
      *

--- a/src/scene/lighting/lighting-params.js
+++ b/src/scene/lighting/lighting-params.js
@@ -2,6 +2,20 @@ import { Vec3 } from '../../math/vec3.js';
 import { math } from '../../math/math.js';
 import { SHADOW_PCF3 } from '../constants.js';
 
+/**
+ * Lighting parameters, allow configuration of the global lighting parameters.
+ * For details see [Clustered Lighting](https://developer.playcanvas.com/en/user-manual/graphics/lighting/clustered-lighting/)
+ *
+ * @property {number} debugLayer Layer ID of a layer to contain the debug rendering
+ * of clustered lighting. Defaults to undefined, which disables the debug rendering.
+ * Debug rendering is only included in the debug version of the engine.
+ *
+ * @property {Array<number>|null} atlasSplit Atlas textures split description, which applies
+ * to both the shadow and cookie texture atlas. Defaults to null, which enables to automatic
+ * split mode. For details see [Configuring Atlas Split](https://developer.playcanvas.com/en/user-manual/graphics/lighting/clustered-lighting/#configuring-atlas)
+ *
+ * @hideconstructor
+ */
 class LightingParams {
     constructor(supportsAreaLights, maxTextureSize, dirtyLightsFnc) {
         this._maxTextureSize = maxTextureSize;
@@ -29,6 +43,23 @@ class LightingParams {
         this.debugLayer = undefined;
     }
 
+    applySettings(render) {
+        this.shadowsEnabled = render.lightingShadowsEnabled;
+        this.cookiesEnabled = render.lightingCookiesEnabled;
+        this.areaLightsEnabled = render.lightingAreaLightsEnabled;
+        this.shadowAtlasResolution = render.lightingShadowAtlasResolution;
+        this.cookieAtlasResolution = render.lightingCookieAtlasResolution;
+        this.maxLightsPerCell = render.lightingMaxLightsPerCell;
+        this.shadowType = render.lightingShadowType;
+        this.cell = new Vec3(render.lightingCells);
+    }
+
+    /**
+     * Number of cells along each world-space axis the space containing lights
+     * is subdivided into. Defaults to Vec(10, 3, 10).
+     *
+     * @type {Vec3}
+     */
     set cells(value) {
         this._cells.copy(value);
     }
@@ -37,6 +68,11 @@ class LightingParams {
         return this._cells;
     }
 
+    /**
+     * Maximum number of lights a cell can store. Defaults to 255.
+     *
+     * @type {number}
+     */
     set maxLightsPerCell(value) {
         this._maxLightsPerCell = math.clamp(value, 1, 255);
     }
@@ -45,6 +81,12 @@ class LightingParams {
         return this._maxLightsPerCell;
     }
 
+    /**
+     * Resolution of the atlas texture storing all non-directional cookie textures.
+     * Defaults to 2048.
+     *
+     * @type {number}
+     */
     set cookieAtlasResolution(value) {
         this._cookieAtlasResolution = math.clamp(value, 32, this._maxTextureSize);
     }
@@ -53,6 +95,12 @@ class LightingParams {
         return this._cookieAtlasResolution;
     }
 
+    /**
+     * Resolution of the atlas texture storing all non-directional shadow textures.
+     * Defaults to 2048.
+     *
+     * @type {number}
+     */
     set shadowAtlasResolution(value) {
         this._shadowAtlasResolution = math.clamp(value, 32, this._maxTextureSize);
     }
@@ -61,6 +109,17 @@ class LightingParams {
         return this._shadowAtlasResolution;
     }
 
+    /**
+     * The type of shadow filtering used by all shadows. Can be:
+     *
+     * - {@link SHADOW_PCF1}: PCF 1x1 sampling.
+     * - {@link SHADOW_PCF3}: PCF 3x3 sampling.
+     * - {@link SHADOW_PCF5}: PCF 5x5 sampling. Falls back to {@link SHADOW_PCF3} on WebGL 1.0.
+     *
+     * Defaults to {@link SHADOW_PCF3}
+     *
+     * @type {number}
+     */
     set shadowType(value) {
         if (this._shadowType !== value) {
             this._shadowType = value;
@@ -74,6 +133,12 @@ class LightingParams {
         return this._shadowType;
     }
 
+    /**
+     * If set to true, the clustered lighting will support cookie textures.
+     * Defaults to false.
+     *
+     * @type {boolean}
+     */
     set cookiesEnabled(value) {
         if (this._cookiesEnabled !== value) {
             this._cookiesEnabled = value;
@@ -87,6 +152,12 @@ class LightingParams {
         return this._cookiesEnabled;
     }
 
+    /**
+     * If set to true, the clustered lighting will support area lights.
+     * Defaults to false.
+     *
+     * @type {boolean}
+     */
     set areaLightsEnabled(value) {
 
         // ignore if not supported
@@ -104,6 +175,12 @@ class LightingParams {
         return this._areaLightsEnabled;
     }
 
+    /**
+     * If set to true, the clustered lighting will support shadows.
+     * Defaults to true.
+     *
+     * @type {boolean}
+     */
     set shadowsEnabled(value) {
         if (this._shadowsEnabled !== value) {
             this._shadowsEnabled = value;

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -216,7 +216,7 @@ class Scene extends EventHandler {
         this._lightmapFilterSmoothness = 0.2;
 
         // clustered lighting
-        this._clusteredLightingEnabled = false;
+        this._clusteredLightingEnabled = true;
         this._lightingParams = new LightingParams(this.device.supportsAreaLights, this.device.maxTextureSize, () => {
             this._layers._dirtyLights = true;
         });
@@ -324,10 +324,16 @@ class Scene extends EventHandler {
         return this._ambientBakeSpherePart;
     }
 
+    /**
+     * True if the clustered lighting is enabled. Set to false before the first frame is rendered
+     * to use non-clustered lighting. Defaults to true.
+     *
+     * @type {boolean}
+     */
     set clusteredLightingEnabled(value) {
 
-        if (this._clusteredLightingEnabled && !value) {
-            console.error('Turning off enabled clustered lighting is not currently supported');
+        if (!this._clusteredLightingEnabled && value) {
+            console.error('Turning on disabled clustered lighting is not currently supported');
             return;
         }
 
@@ -432,6 +438,11 @@ class Scene extends EventHandler {
         return this._layers;
     }
 
+    /**
+     * A {@link LightingParams} that defines lighting parameters.
+     *
+     * @type {LightingParams}
+     */
     get lighting() {
         return this._lightingParams;
     }
@@ -647,6 +658,9 @@ class Scene extends EventHandler {
         if (render.skyboxRotation) {
             this._skyboxRotation.setFromEulerAngles(render.skyboxRotation[0], render.skyboxRotation[1], render.skyboxRotation[2]);
         }
+
+        this.clusteredLightingEnabled = render.clusteredLightingEnabled;
+        this.lighting.applySettings(render);
 
         // bake settings
         [


### PR DESCRIPTION
Fixes https://github.com/playcanvas/engine/issues/4576
related to: https://github.com/playcanvas/engine/pull/4364

- Clustered lighting in the Engine is now enabled by default
- Scene.applySettings handles lighting params, allowing those to be exposed in the Editor (separate PR)
- The public API been documented
Scene properties:
![Screenshot 2022-08-25 at 11 16 45](https://user-images.githubusercontent.com/59932779/186628802-a6c108bb-8d05-49c1-ad41-0c98cdbfdf61.png)
![Screenshot 2022-08-25 at 11 25 00](https://user-images.githubusercontent.com/59932779/186628816-aad69b90-5e1e-4dae-af99-65c9c0ce1fe4.png)

The new referenced class:
![Screenshot 2022-08-25 at 11 25 42](https://user-images.githubusercontent.com/59932779/186628853-348e4d7c-572c-4eb1-a010-0a883f091043.png)
![Screenshot 2022-08-25 at 11 25 51](https://user-images.githubusercontent.com/59932779/186628872-9043f267-9379-4b8d-8cef-2a6933a73f96.png)

Added documentation for additional members in AppBase.applySceneSettings
![Screenshot 2022-08-25 at 12 12 51](https://user-images.githubusercontent.com/59932779/186638789-1a34bcc5-e905-490f-b618-a76714365a36.png)

