### PR TITLE
Register shader generators at the point of use instead of always

### DIFF
--- a/src/framework/app-base.js
+++ b/src/framework/app-base.js
@@ -21,11 +21,6 @@ import {
     PRIMITIVE_TRIANGLES, PRIMITIVE_TRIFAN, PRIMITIVE_TRISTRIP
 } from '../graphics/constants.js';
 
-import { basic } from '../graphics/program-lib/programs/basic.js';
-import { particle } from '../graphics/program-lib/programs/particle.js';
-import { skybox } from '../graphics/program-lib/programs/skybox.js';
-import { standard } from '../graphics/program-lib/programs/standard.js';
-
 import {
     LAYERID_DEPTH, LAYERID_IMMEDIATE, LAYERID_SKYBOX, LAYERID_UI, LAYERID_WORLD,
     SORTMODE_NONE, SORTMODE_MANUAL, SPECULAR_BLINN
@@ -283,12 +278,6 @@ class AppBase extends EventHandler {
          * @type {GraphicsDevice}
          */
         this.graphicsDevice = device;
-
-        // register shader programs
-        device.programLib.register('basic', basic);
-        device.programLib.register('particle', particle);
-        device.programLib.register('skybox', skybox);
-        device.programLib.register('standard', standard);
 
         this._initDefaultMaterial();
         this.stats = new ApplicationStats(device);

--- a/src/scene/materials/basic-material.js
+++ b/src/scene/materials/basic-material.js
@@ -5,6 +5,7 @@ import {
     SHADERDEF_SCREENSPACE, SHADERDEF_SKIN
 } from '../constants.js';
 
+import { basic } from '../../graphics/program-lib/programs/basic.js';
 import { ShaderProcessorOptions } from '../../graphics/shader-processor-options.js';
 import { Material } from './material.js';
 
@@ -108,6 +109,8 @@ class BasicMaterial extends Material {
         const processingOptions = new ShaderProcessorOptions(viewUniformFormat, viewBindGroupFormat);
 
         const library = device.getProgramLibrary();
+        library.register('basic', basic);
+
         return library.getProgram('basic', options, processingOptions);
     }
 }

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -827,6 +827,7 @@ class StandardMaterial extends Material {
         const processingOptions = new ShaderProcessorOptions(viewUniformFormat, viewBindGroupFormat);
 
         const library = device.getProgramLibrary();
+        library.register('standard', standard);
         const shader = library.getProgram('standard', options, processingOptions);
 
         this._dirtyShader = false;

--- a/src/scene/particle-system/particle-emitter.js
+++ b/src/scene/particle-system/particle-emitter.js
@@ -30,6 +30,7 @@ import { Texture } from '../../graphics/texture.js';
 import { VertexBuffer } from '../../graphics/vertex-buffer.js';
 import { VertexFormat } from '../../graphics/vertex-format.js';
 import { DeviceCache } from '../../graphics/device-cache.js';
+import { particle } from '../../graphics/program-lib/programs/particle.js';
 
 import {
     BLEND_NORMAL,
@@ -828,6 +829,8 @@ class ParticleEmitter {
 
     regenShader() {
         const programLib = this.graphicsDevice.getProgramLibrary();
+        this.graphicsDevice.programLib.register('particle', particle);
+
         const hasNormal = (this.normalMap !== null);
         this.normalOption = 0;
         if (this.lighting) {

--- a/src/scene/sky.js
+++ b/src/scene/sky.js
@@ -10,6 +10,7 @@ import { createBox } from './procedural.js';
 import { GraphNode } from './graph-node.js';
 import { Material } from './materials/material.js';
 import { MeshInstance } from './mesh-instance.js';
+import { skybox } from '../graphics/program-lib/programs/skybox.js';
 
 /** @typedef {import('../graphics/texture.js').Texture} Texture */
 /** @typedef {import('../graphics/graphics-device.js').GraphicsDevice} GraphicsDevice */
@@ -45,6 +46,7 @@ class Sky {
 
         material.getShaderVariant = function (dev, sc, defs, staticLightList, pass, sortedLights, viewUniformFormat, viewBindGroupFormat) {
             const library = device.getProgramLibrary();
+            library.register('skybox', skybox);
 
             if (texture.cubemap) {
                 return library.getProgram('skybox', {


### PR DESCRIPTION
- this removes relevant imports and allows improved tree-shaking - for example if particle systems are not used at all, generator code can be excluded (needs further improvement to handle relevant shader chunks as well)