### PR TITLE
Moved lightmapper only chunks to separate module to allow for their tree-shaking

### DIFF
--- a/src/graphics/program-lib/chunks/chunks-lightmapper.js
+++ b/src/graphics/program-lib/chunks/chunks-lightmapper.js
@@ -1,0 +1,13 @@
+import bakeDirLmEndPS from './lightmapper/frag/bakeDirLmEnd.js';
+import bakeLmEndPS from './lightmapper/frag/bakeLmEnd.js';
+import dilatePS from './lightmapper/frag/dilate.js';
+import bilateralDeNoisePS from './lightmapper/frag/bilateralDeNoise.js';
+
+const shaderChunksLightmapper = {
+    bakeDirLmEndPS,
+    bakeLmEndPS,
+    dilatePS,
+    bilateralDeNoisePS
+};
+
+export { shaderChunksLightmapper };

--- a/src/graphics/program-lib/chunks/chunks.js
+++ b/src/graphics/program-lib/chunks/chunks.js
@@ -8,8 +8,6 @@ import aoSpecOccPS from './lit/frag/aoSpecOcc.js';
 import aoSpecOccConstPS from './lit/frag/aoSpecOccConst.js';
 import aoSpecOccConstSimplePS from './lit/frag/aoSpecOccConstSimple.js';
 import aoSpecOccSimplePS from './lit/frag/aoSpecOccSimple.js';
-import bakeDirLmEndPS from './lightmapper/frag/bakeDirLmEnd.js';
-import bakeLmEndPS from './lightmapper/frag/bakeLmEnd.js';
 import basePS from './lit/frag/base.js';
 import baseVS from './lit/vert/base.js';
 import baseNineSlicedPS from './lit/frag/baseNineSliced.js';
@@ -33,8 +31,6 @@ import decodePS from './common/frag/decode.js';
 import detailModesPS from './standard/frag/detailModes.js';
 import diffusePS from './standard/frag/diffuse.js';
 import diffuseDetailMapPS from './standard/frag/diffuseDetailMap.js';
-import dilatePS from './lightmapper/frag/dilate.js';
-import bilateralDeNoisePS from './lightmapper/frag/bilateralDeNoise.js';
 import emissivePS from './standard/frag/emissive.js';
 import encodePS from './common/frag/encode.js';
 import endPS from './lit/frag/end.js';
@@ -216,8 +212,6 @@ const shaderChunks = {
     aoSpecOccConstPS,
     aoSpecOccConstSimplePS,
     aoSpecOccSimplePS,
-    bakeDirLmEndPS,
-    bakeLmEndPS,
     basePS,
     baseVS,
     baseNineSlicedPS,
@@ -240,8 +234,6 @@ const shaderChunks = {
     detailModesPS,
     diffusePS,
     diffuseDetailMapPS,
-    dilatePS,
-    bilateralDeNoisePS,
     decodePS,
     emissivePS,
     encodePS,

--- a/src/scene/lightmapper/lightmap-filters.js
+++ b/src/scene/lightmapper/lightmap-filters.js
@@ -1,5 +1,6 @@
 import { createShaderFromCode } from '../../graphics/program-lib/utils.js';
 import { shaderChunks } from '../../graphics/program-lib/chunks/chunks.js';
+import { shaderChunksLightmapper } from '../../graphics/program-lib/chunks/chunks-lightmapper.js';
 
 // size of the kernel - needs to match the constant in the shader
 const DENOISE_FILTER_SIZE = 15;
@@ -8,7 +9,7 @@ const DENOISE_FILTER_SIZE = 15;
 class LightmapFilters {
     constructor(device) {
         this.device = device;
-        this.shaderDilate = createShaderFromCode(device, shaderChunks.fullscreenQuadVS, shaderChunks.dilatePS, 'lmDilate');
+        this.shaderDilate = createShaderFromCode(device, shaderChunks.fullscreenQuadVS, shaderChunksLightmapper.dilatePS, 'lmDilate');
 
         this.constantTexSource = device.scope.resolve('source');
 
@@ -37,7 +38,7 @@ class LightmapFilters {
     prepareDenoise(filterRange, filterSmoothness) {
 
         if (!this.shaderDenoise) {
-            this.shaderDenoise = createShaderFromCode(this.device, shaderChunks.fullscreenQuadVS, shaderChunks.bilateralDeNoisePS, 'lmBilateralDeNoise');
+            this.shaderDenoise = createShaderFromCode(this.device, shaderChunks.fullscreenQuadVS, shaderChunksLightmapper.bilateralDeNoisePS, 'lmBilateralDeNoise');
             this.sigmas = new Float32Array(2);
             this.constantSigmas = this.device.scope.resolve('sigmas');
             this.constantKernel = this.device.scope.resolve('kernel[0]');

--- a/src/scene/lightmapper/lightmapper.js
+++ b/src/scene/lightmapper/lightmapper.js
@@ -17,6 +17,7 @@ import {
     TEXTURETYPE_DEFAULT, TEXTURETYPE_RGBM
 } from '../../graphics/constants.js';
 import { shaderChunks } from '../../graphics/program-lib/chunks/chunks.js';
+import { shaderChunksLightmapper } from '../../graphics/program-lib/chunks/chunks-lightmapper.js';
 import { drawQuadWithShader } from '../../graphics/simple-post-effect.js';
 import { RenderTarget } from '../../graphics/render-target.js';
 import { Texture } from '../../graphics/texture.js';
@@ -229,7 +230,7 @@ class Lightmapper {
         material.chunks.transformVS = '#define UV1LAYOUT\n' + shaderChunks.transformVS; // draw UV1
 
         if (pass === PASS_COLOR) {
-            let bakeLmEndChunk = shaderChunks.bakeLmEndPS; // encode to RGBM
+            let bakeLmEndChunk = shaderChunksLightmapper.bakeLmEndPS; // encode to RGBM
             if (addAmbient) {
                 // diffuse light stores accumulated AO, apply contrast and brightness to it
                 // and multiply ambient light color by the AO
@@ -247,7 +248,7 @@ class Lightmapper {
             material.lightMap = this.blackTex;
         } else {
             material.chunks.basePS = shaderChunks.basePS + '\nuniform sampler2D texture_dirLightMap;\nuniform float bakeDir;\n';
-            material.chunks.endPS = shaderChunks.bakeDirLmEndPS;
+            material.chunks.endPS = shaderChunksLightmapper.bakeDirLmEndPS;
         }
 
         // avoid writing unrelated things to alpha


### PR DESCRIPTION
Small optimization - if the Lightmapper is not used in the AppOptions, those chunks won’t be included in the build.