### PR TITLE
Fix grab pass with downscaled render target

### DIFF
--- a/src/framework/scene-grab.js
+++ b/src/framework/scene-grab.js
@@ -81,12 +81,9 @@ class SceneGrab {
     }
 
     resizeCondition(source, requestedRenderTarget, device) {
-        const width = source ? source.width : device.width;
-        const height = source ? source.height : device.height;
-        if (requestedRenderTarget) {
-            return width !== requestedRenderTarget.width || height !== requestedRenderTarget.height;
-        }
-        return width !== device.width || height !== device.height;
+        const width = source?.width || device.width;
+        const height = source?.height || device.height;
+        return width !== requestedRenderTarget?.width || height !== requestedRenderTarget?.height;
     }
 
     allocateRenderTarget(renderTarget, sourceRenderTarget, device, format, isDepth, mipmaps, isDepthUniforms) {

--- a/src/framework/scene-grab.js
+++ b/src/framework/scene-grab.js
@@ -80,11 +80,13 @@ class SceneGrab {
         });
     }
 
-    resizeCondition(originalRenderTarget, requestedRenderTarget, device) {
-        if (originalRenderTarget && requestedRenderTarget) {
-            return originalRenderTarget.width !== requestedRenderTarget.width || originalRenderTarget.height !== requestedRenderTarget.height;
+    resizeCondition(source, requestedRenderTarget, device) {
+        const width = source ? source.width : device.width;
+        const height = source ? source.height : device.height;
+        if (requestedRenderTarget) {
+            return width !== requestedRenderTarget.width || height !== requestedRenderTarget.height;
         }
-        return originalRenderTarget?.width !== device.width || originalRenderTarget?.height !== device.height;
+        return width !== device.width || height !== device.height;
     }
 
     allocateRenderTarget(renderTarget, sourceRenderTarget, device, format, isDepth, mipmaps, isDepthUniforms) {

--- a/src/framework/scene-grab.js
+++ b/src/framework/scene-grab.js
@@ -183,7 +183,7 @@ class SceneGrab {
                 }
 
                 if (camera.renderSceneDepthMap) {
-                    
+
                     // reallocate RT if needed
                     if (self.resizeCondition(this.depthRenderTarget, camera.renderTarget?.depthBuffer, device)) {
                         self.releaseRenderTarget(this.depthRenderTarget);

--- a/src/framework/scene-grab.js
+++ b/src/framework/scene-grab.js
@@ -80,6 +80,13 @@ class SceneGrab {
         });
     }
 
+    resizeCondition(originalRenderTarget, requestedRenderTarget, device) {
+        if (originalRenderTarget && requestedRenderTarget) {
+            return originalRenderTarget.width !== requestedRenderTarget.width || originalRenderTarget.height !== requestedRenderTarget.height;
+        }
+        return originalRenderTarget?.width !== device.width || originalRenderTarget?.height !== device.height;
+    }
+
     allocateRenderTarget(renderTarget, sourceRenderTarget, device, format, isDepth, mipmaps, isDepthUniforms) {
 
         // texture / uniform names: new one (first), as well as old one  (second) for compatibility
@@ -153,7 +160,7 @@ class SceneGrab {
                 if (camera.renderSceneColorMap) {
 
                     // allocate / resize existing RT as needed
-                    if (this.colorRenderTarget?.width !== camera.renderTarget?.colorBuffer?.width || this.colorRenderTarget?.height !== camera.renderTarget?.colorBuffer?.height) {
+                    if (self.resizeCondition(this.colorRenderTarget, camera.renderTarget?.colorBuffer, device)) {
                         self.releaseRenderTarget(this.colorRenderTarget);
                         this.colorRenderTarget = self.allocateRenderTarget(this.colorRenderTarget, camera.renderTarget, device, this.colorFormat, false, true, false);
                     }
@@ -176,9 +183,9 @@ class SceneGrab {
                 }
 
                 if (camera.renderSceneDepthMap) {
-
+                    
                     // reallocate RT if needed
-                    if (this.depthRenderTarget?.width !== camera.renderTarget?.colorBuffer?.width || this.depthRenderTarget?.height !== camera.renderTarget?.colorBuffer?.height) {
+                    if (self.resizeCondition(this.depthRenderTarget, camera.renderTarget?.depthBuffer, device)) {
                         self.releaseRenderTarget(this.depthRenderTarget);
                         this.depthRenderTarget = self.allocateRenderTarget(this.depthRenderTarget, camera.renderTarget, device, PIXELFORMAT_DEPTHSTENCIL, true, false, true);
                     }
@@ -247,7 +254,7 @@ class SceneGrab {
                 if (camera.renderSceneDepthMap) {
 
                     // reallocate RT if needed
-                    if (!this.depthRenderTarget.depthBuffer || this.depthRenderTarget.width !== camera.renderTarget?.depthBuffer?.width || this.depthRenderTarget.height !== camera.renderTarget?.depthBuffer?.height) {
+                    if (self.resizeCondition(this.depthRenderTarget, camera.renderTarget?.depthBuffer, device)) {
                         this.depthRenderTarget.destroyTextureBuffers();
                         this.depthRenderTarget = self.allocateRenderTarget(this.depthRenderTarget, camera.renderTarget, device, PIXELFORMAT_R8_G8_B8_A8, false, false, true);
                     }
@@ -301,7 +308,7 @@ class SceneGrab {
                 if (camera.renderSceneColorMap) {
 
                     // reallocate RT if needed
-                    if (this.colorRenderTarget?.width !== camera.renderTarget?.colorBuffer?.width || this.colorRenderTarget?.height !== camera.renderTarget?.colorBuffer?.height) {
+                    if (self.resizeCondition(this.colorRenderTarget, camera.renderTarget?.colorBuffer, device)) {
                         self.releaseRenderTarget(this.colorRenderTarget);
                         this.colorRenderTarget = self.allocateRenderTarget(this.colorRenderTarget, camera.renderTarget, device, this.colorFormat, false, false, false);
                     }


### PR DESCRIPTION
### Description
Fixes bug when pixel scaling was used with refractive objects. Fixes #4580.

Used to look like this:

![image](https://user-images.githubusercontent.com/107400752/186714246-8c21475a-c204-47a3-a028-474096818698.png)

After fix:

![image](https://user-images.githubusercontent.com/107400752/186714428-d16093dc-e773-4130-a4e4-25b94f77806f.png)
