### PR TITLE
Fix using fresnel incorrectly with lightmaps.

### DIFF
--- a/src/graphics/program-lib/chunks/lit/frag/lightmapDirAdd.js
+++ b/src/graphics/program-lib/chunks/lit/frag/lightmapDirAdd.js
@@ -14,7 +14,7 @@ void addLightMap() {
         vec3 halfDirW = normalize(-dLightmapDir + dViewDirW);
         vec3 specularLight = dLightmap * getLightSpecular(halfDirW);
 
-        #ifdef LIT_SPECULAR
+        #ifdef LIT_SPECULAR_FRESNEL
         specularLight *= getFresnel(dot(dViewDirW, halfDirW), dSpecularity);
         #endif
 


### PR DESCRIPTION
### Description

LightmapDirAdd incorrectly used LIT_SPECULAR and not LIT_SPECULAR_FRESNEL to decide whether or not to use fresnel.