### PR TITLE
Revert enabling image bitmap

### DIFF
--- a/src/resources/parser/texture/img.js
+++ b/src/resources/parser/texture/img.js
@@ -21,7 +21,13 @@ class ImgParser {
         // by default don't try cross-origin, because some browsers send different cookies (e.g. safari) if this is set.
         this.crossOrigin = registry.prefix ? 'anonymous' : null;
         this.maxRetries = 0;
-        this.useImageBitmap = typeof ImageBitmap !== 'undefined';
+        // ImageBitmap current state (Sep 2022):
+        // - Lastest Chrome and Firefox browsers appear to support the ImageBitmap API fine (though
+        //   there are likely still issues with older versions of both).
+        // - Safari supports the API, but completely destroys some pngs. For example the cubemaps in
+        //   steampunk slots https://playcanvas.com/editor/scene/524858. See the webkit issue
+        //   https://bugs.webkit.org/show_bug.cgi?id=182424 for status.
+        this.useImageBitmap = false; // typeof ImageBitmap !== 'undefined';
     }
 
     load(url, callback, asset) {

--- a/src/resources/parser/texture/img.js
+++ b/src/resources/parser/texture/img.js
@@ -2,7 +2,8 @@ import { path } from '../../../core/path.js';
 import { http } from '../../../net/http.js';
 
 import {
-    PIXELFORMAT_R8_G8_B8, PIXELFORMAT_R8_G8_B8_A8, TEXHINT_ASSET
+    PIXELFORMAT_R8_G8_B8, PIXELFORMAT_R8_G8_B8_A8, TEXHINT_ASSET,
+    DEVICETYPE_WEBGPU
 } from '../../../graphics/constants.js';
 import { Texture } from '../../../graphics/texture.js';
 
@@ -21,6 +22,7 @@ class ImgParser {
         // by default don't try cross-origin, because some browsers send different cookies (e.g. safari) if this is set.
         this.crossOrigin = registry.prefix ? 'anonymous' : null;
         this.maxRetries = 0;
+
         // ImageBitmap current state (Sep 2022):
         // - Lastest Chrome and Firefox browsers appear to support the ImageBitmap API fine (though
         //   there are likely still issues with older versions of both).
@@ -30,7 +32,10 @@ class ImgParser {
         // - Some applications assume that PNGs loaded by the engine use HTMLImageBitmap interface and
         //   fail when using ImageBitmap. For example, Space Base project fails because it uses engine
         //   texture assets on the dom https://playcanvas.com/editor/scene/446278.
-        this.useImageBitmap = false; // typeof ImageBitmap !== 'undefined';
+
+        // only enable when running webgpu
+        const isWebGPU = registry?._loader?._app?.graphicsDevice?.deviceType === DEVICETYPE_WEBGPU;
+        this.useImageBitmap = isWebGPU;
     }
 
     load(url, callback, asset) {

--- a/src/resources/parser/texture/img.js
+++ b/src/resources/parser/texture/img.js
@@ -27,6 +27,9 @@ class ImgParser {
         // - Safari supports the API, but completely destroys some pngs. For example the cubemaps in
         //   steampunk slots https://playcanvas.com/editor/scene/524858. See the webkit issue
         //   https://bugs.webkit.org/show_bug.cgi?id=182424 for status.
+        // - Some applications assume that PNGs loaded by the engine use HTMLImageBitmap interface and
+        //   fail when using ImageBitmap. For example, Space Base project fails because it uses engine
+        //   texture assets on the dom https://playcanvas.com/editor/scene/446278.
         this.useImageBitmap = false; // typeof ImageBitmap !== 'undefined';
     }
 


### PR DESCRIPTION
This PR reverts #4584.

After doing some testing it seems ImageBitmap is still not well supported across browsers. Details have been left in the code for next time.

It might be worth investigating more closely which browsers have concrete support for ImageBitmap and start selectively enabling the interface on those browsers.