### PR TITLE
Test for ImageBitmap support at startup

### DIFF
--- a/src/graphics/webgl/webgl-graphics-device.js
+++ b/src/graphics/webgl/webgl-graphics-device.js
@@ -191,7 +191,7 @@ function testImageBitmap(device) {
 
             // read pixels
             const rt = new RenderTarget({ colorBuffer: texture, depth: false });
-            device.setFramebuffer(rt._glFrameBuffer);
+            device.setFramebuffer(rt.impl._glFrameBuffer);
             device.initRenderTarget(rt);
 
             const data = new Uint8ClampedArray(4);

--- a/src/graphics/webgl/webgl-graphics-device.js
+++ b/src/graphics/webgl/webgl-graphics-device.js
@@ -179,7 +179,7 @@ function testImageBitmap(device) {
     ]);
 
     return createImageBitmap(new Blob([pngBytes], { type: 'image/png' }), { premultiplyAlpha: 'none' })
-        .then(image => {
+        .then((image) => {
             // create the texture
             const texture = new Texture(device, {
                 width: 1,
@@ -357,7 +357,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
 
         // start async image bitmap test
         this.supportsImageBitmap = null;
-        testImageBitmap(this).then(result => {
+        testImageBitmap(this).then((result) => {
             this.supportsImageBitmap = result;
         });
 

--- a/src/graphics/webgl/webgl-graphics-device.js
+++ b/src/graphics/webgl/webgl-graphics-device.js
@@ -159,9 +159,17 @@ function testTextureFloatHighPrecision(device) {
     return f === 0;
 }
 
-// This function returns a promise which will asynchronously test the level of
-// support for ImageBitmap image loading in the current browser. Promise resolves
-// to true if ImageBitmap is supported, otherwise false.
+// ImageBitmap current state (Sep 2022):
+// - Lastest Chrome and Firefox browsers appear to support the ImageBitmap API fine (though
+//   there are likely still issues with older versions of both).
+// - Safari supports the API, but completely destroys some pngs. For example the cubemaps in
+//   steampunk slots https://playcanvas.com/editor/scene/524858. See the webkit issue
+//   https://bugs.webkit.org/show_bug.cgi?id=182424 for status.
+// - Some applications assume that PNGs loaded by the engine use HTMLImageBitmap interface and
+//   fail when using ImageBitmap. For example, Space Base project fails because it uses engine
+//   texture assets on the dom https://playcanvas.com/editor/scene/446278.
+
+// This function tests whether the current browser destroys PNG data or not.
 function testImageBitmap(device) {
     // 1x1 png image containing rgba(1, 2, 3, 63)
     const pngBytes = new Uint8Array([

--- a/src/graphics/webgl/webgl-graphics-device.js
+++ b/src/graphics/webgl/webgl-graphics-device.js
@@ -357,9 +357,11 @@ class WebglGraphicsDevice extends GraphicsDevice {
 
         // start async image bitmap test
         this.supportsImageBitmap = null;
-        testImageBitmap(this).then((result) => {
-            this.supportsImageBitmap = result;
-        });
+        if (typeof ImageBitmap !== 'undefined') {
+            testImageBitmap(this).then((result) => {
+                this.supportsImageBitmap = result;
+            });
+        }
 
         this.defaultClearOptions = {
             color: [0, 0, 0, 1],

--- a/src/graphics/webgl/webgl-graphics-device.js
+++ b/src/graphics/webgl/webgl-graphics-device.js
@@ -159,6 +159,44 @@ function testTextureFloatHighPrecision(device) {
     return f === 0;
 }
 
+// This function returns a promise which will asynchronously test the level of
+// support for ImageBitmap image loading in the current browser. Promise resolves
+// to true if ImageBitmap is supported, otherwise false.
+function testImageBitmap(device) {
+    // 1x1 png image containing rgba(1, 2, 3, 63)
+    const pngBytes = new Uint8Array([
+        137, 80, 78, 71, 13, 10, 26, 10, 0, 0, 0, 13, 73, 72, 68, 82, 0, 0, 0, 1, 0, 0, 0, 1, 8, 6, 0, 0, 0, 31, 21,
+        196, 137, 0, 0, 0, 13, 73, 68, 65, 84, 120, 218, 99, 100, 100, 98, 182, 7, 0, 0, 89, 0, 71, 67, 133, 148, 237,
+        0, 0, 0, 0, 73, 69, 78, 68, 174, 66, 96, 130
+    ]);
+
+    return createImageBitmap(new Blob([pngBytes], { type: 'image/png' }), { premultiplyAlpha: 'none' })
+        .then(image => {
+            // create the texture
+            const texture = new Texture(device, {
+                width: 1,
+                height: 1,
+                format: PIXELFORMAT_R8_G8_B8_A8,
+                mipmaps: false,
+                levels: [image]
+            });
+
+            // read pixels
+            const rt = new RenderTarget({ colorBuffer: texture, depth: false });
+            device.setFramebuffer(rt._glFrameBuffer);
+            device.initRenderTarget(rt);
+
+            const data = new Uint8ClampedArray(4);
+            device.gl.readPixels(0, 0, 1, 1, device.gl.RGBA, device.gl.UNSIGNED_BYTE, data);
+
+            rt.destroy();
+            texture.destroy();
+
+            return data[0] === 1 && data[1] === 2 && data[2] === 3 && data[3] === 63;
+        })
+        .catch(e => false);
+}
+
 /**
  * The graphics device manages the underlying graphics context. It is responsible for submitting
  * render state changes and graphics primitives to the hardware. A graphics device is tied to a
@@ -308,6 +346,12 @@ class WebglGraphicsDevice extends GraphicsDevice {
         this.initializeCapabilities();
         this.initializeRenderState();
         this.initializeContextCaches();
+
+        // start async image bitmap test
+        this.supportsImageBitmap = null;
+        testImageBitmap(this).then(result => {
+            this.supportsImageBitmap = result;
+        });
 
         this.defaultClearOptions = {
             color: [0, 0, 0, 1],

--- a/src/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/graphics/webgpu/webgpu-graphics-device.js
@@ -70,6 +70,7 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
         this.extTextureFloat = true;
         this.extTextureHalfFloat = false; // TODO: likely supported as well
         this.boneLimit = 1024;
+        this.supportsImageBitmap = true;
     }
 
     async initWebGpu() {

--- a/src/resources/parser/texture/img.js
+++ b/src/resources/parser/texture/img.js
@@ -21,9 +21,7 @@ class ImgParser {
         // by default don't try cross-origin, because some browsers send different cookies (e.g. safari) if this is set.
         this.crossOrigin = registry.prefix ? 'anonymous' : null;
         this.maxRetries = 0;
-        this.useImageBitmap = () => {
-            return device.supportsImageBitmap;
-        };
+        this.device = device;
     }
 
     load(url, callback, asset) {
@@ -50,7 +48,7 @@ class ImgParser {
             crossOrigin = this.crossOrigin;
         }
 
-        if (this.useImageBitmap()) {
+        if (this.device.supportsImageBitmap) {
             this._loadImageBitmap(url.load, url.original, crossOrigin, handler);
         } else {
             this._loadImage(url.load, url.original, crossOrigin, handler);

--- a/src/resources/parser/texture/img.js
+++ b/src/resources/parser/texture/img.js
@@ -2,8 +2,7 @@ import { path } from '../../../core/path.js';
 import { http } from '../../../net/http.js';
 
 import {
-    PIXELFORMAT_R8_G8_B8, PIXELFORMAT_R8_G8_B8_A8, TEXHINT_ASSET,
-    DEVICETYPE_WEBGPU
+    PIXELFORMAT_R8_G8_B8, PIXELFORMAT_R8_G8_B8_A8, TEXHINT_ASSET
 } from '../../../graphics/constants.js';
 import { Texture } from '../../../graphics/texture.js';
 
@@ -24,7 +23,7 @@ class ImgParser {
         this.maxRetries = 0;
         this.useImageBitmap = () => {
             return device.supportsImageBitmap;
-        }
+        };
     }
 
     load(url, callback, asset) {

--- a/src/resources/parser/texture/img.js
+++ b/src/resources/parser/texture/img.js
@@ -28,6 +28,11 @@ class ImgParser {
         const hasContents = !!asset?.file?.contents;
 
         if (hasContents) {
+            // ImageBitmap interface can load iage
+            if (this.device.supportsImageBitmap) {
+                this._loadImageBitmapFromData(asset.file.contents, callback);
+                return;
+            }
             url = {
                 load: URL.createObjectURL(new Blob([asset.file.contents])),
                 original: url.original
@@ -130,6 +135,12 @@ class ImgParser {
                     .catch(e => callback(e));
             }
         });
+    }
+
+    _loadImageBitmapFromData(data, callback) {
+        createImageBitmap(new Blob([data]), { premultiplyAlpha: 'none' })
+            .then(imageBitmap => callback(null, imageBitmap))
+            .catch(e => callback(e));
     }
 }
 

--- a/src/resources/parser/texture/img.js
+++ b/src/resources/parser/texture/img.js
@@ -18,24 +18,13 @@ import { ABSOLUTE_URL } from '../../../asset/constants.js';
  * @ignore
  */
 class ImgParser {
-    constructor(registry) {
+    constructor(registry, device) {
         // by default don't try cross-origin, because some browsers send different cookies (e.g. safari) if this is set.
         this.crossOrigin = registry.prefix ? 'anonymous' : null;
         this.maxRetries = 0;
-
-        // ImageBitmap current state (Sep 2022):
-        // - Lastest Chrome and Firefox browsers appear to support the ImageBitmap API fine (though
-        //   there are likely still issues with older versions of both).
-        // - Safari supports the API, but completely destroys some pngs. For example the cubemaps in
-        //   steampunk slots https://playcanvas.com/editor/scene/524858. See the webkit issue
-        //   https://bugs.webkit.org/show_bug.cgi?id=182424 for status.
-        // - Some applications assume that PNGs loaded by the engine use HTMLImageBitmap interface and
-        //   fail when using ImageBitmap. For example, Space Base project fails because it uses engine
-        //   texture assets on the dom https://playcanvas.com/editor/scene/446278.
-
-        // only enable when running webgpu
-        const isWebGPU = registry?._loader?._app?.graphicsDevice?.deviceType === DEVICETYPE_WEBGPU;
-        this.useImageBitmap = isWebGPU;
+        this.useImageBitmap = () => {
+            return device.supportsImageBitmap;
+        }
     }
 
     load(url, callback, asset) {
@@ -62,7 +51,7 @@ class ImgParser {
             crossOrigin = this.crossOrigin;
         }
 
-        if (this.useImageBitmap) {
+        if (this.useImageBitmap()) {
             this._loadImageBitmap(url.load, url.original, crossOrigin, handler);
         } else {
             this._loadImage(url.load, url.original, crossOrigin, handler);

--- a/src/resources/texture.js
+++ b/src/resources/texture.js
@@ -180,7 +180,7 @@ class TextureHandler {
 
         // img parser handles all browser-supported image formats, this
         // parser will be used when other more specific parsers are not found.
-        this.imgParser = new ImgParser(assets);
+        this.imgParser = new ImgParser(assets, device);
 
         this.parsers = {
             dds: new DdsParser(assets),


### PR DESCRIPTION
We recently disabled ImageBitmap support again after finding issues in Safari (#4596).

This PR introduces a test at startup for determining whether ImageBitmap support is solid or not.