### PR TITLE
Small updates to improve WebGPU implementation

### DIFF
--- a/examples/webgpu-temp/index.html
+++ b/examples/webgpu-temp/index.html
@@ -54,7 +54,7 @@
         const assets = {
             'playcanvas': new Asset('color', 'texture', { url: '../assets/textures/playcanvas.png' }),
             'rocks': new Asset('color', 'texture', { url: '../assets/textures/seaside-rocks01-diffuse-alpha.png' }),
-            'model': new Asset('model', 'container', { url: '../assets/models/bitmoji.glb' }),
+            'model': new Asset('model', 'container', { url: '../assets/models/house.glb' }),
         };
 
         const vertexShaderGLSL = /* glsl */`
@@ -192,7 +192,7 @@ void main() {
             // Create an entity with a camera component
             const camera = new Entity();
             camera.addComponent("camera", {
-                clearColor: new Color(0.1, 0.1, 0.1, 1)
+                clearColor: new Color(0.4, 0.4, 0.4, 1)
             });
             app.root.addChild(camera);
             camera.setLocalPosition(0, 0, 5);
@@ -258,12 +258,22 @@ void main() {
 
             /////////////// skinning - commented out as it is still not functional
 
-            // const modelEntity = assets.model.resource.instantiateRenderEntity({
-            // });
+            const modelEntity = assets.model.resource.instantiateRenderEntity({
+            });
 
-            // const modelEntityParent = new Entity();
-            // modelEntityParent.addChild(modelEntity);
-            // app.root.addChild(modelEntityParent);
+            const renders = modelEntity.findComponents("render");
+            renders.forEach((render) => {
+                const meshInstances = render.meshInstances;
+                for (let i = 0; i < meshInstances.length; i++) {
+                    const meshInstance = meshInstances[i];
+                    meshInstance.material.useLighting = false;
+                }
+            });
+
+            const modelEntityParent = new Entity();
+            modelEntityParent.setLocalScale(20, 20, 20);
+            modelEntityParent.addChild(modelEntity);
+            app.root.addChild(modelEntityParent);
 
             ///////////////
 
@@ -322,6 +332,10 @@ void main() {
 
             const app = new AppBase(canvas);
             app.init(createOptions);
+
+            const lighting = app.scene.lighting;
+            lighting.shadowsEnabled = false;
+            lighting.cookiesEnabled = false;
 
             app.graphicsDevice.initWebGpu().then(() => {
                 console.log("gpu device async created");

--- a/src/graphics/program-lib/chunks/common/frag/webgpu.js
+++ b/src/graphics/program-lib/chunks/common/frag/webgpu.js
@@ -5,11 +5,11 @@ layout(location = 0) out highp vec4 pc_fragColor;
 
 #define texture2D(res, uv) texture(sampler2D(res, res ## _sampler), uv)
 #define texture2DBias(res, uv, bias) texture(sampler2D(res, res ## _sampler), uv, bias)
+#define texture2DLodEXT(res, uv, lod) textureLod(sampler2D(res, res ## _sampler), uv, lod)
 
 // TODO: implement other texture sampling macros
 // #define textureCube texture
 // #define texture2DProj textureProj
-// #define texture2DLodEXT textureLod
 // #define texture2DProjLodEXT textureProjLod
 // #define textureCubeLodEXT textureLod
 // #define texture2DGradEXT textureGrad

--- a/src/graphics/webgpu/webgpu-buffer.js
+++ b/src/graphics/webgpu/webgpu-buffer.js
@@ -60,7 +60,15 @@ class WebgpuBuffer {
             // this.buffer.unmap();
         }
 
-        const src = new Uint8Array(storage.buffer ? storage.buffer : storage);
+        // src size needs to be a multiple of 4 as well
+        let src = new Uint8Array(storage.buffer ? storage.buffer : storage);
+        if (src.byteLength !== this.buffer.size) {
+            const alignedSrc = new Uint8Array(this.buffer.size);
+            alignedSrc.set(src);
+            src = alignedSrc;
+        }
+
+        // copy data to the gpu buffer
         wgpu.queue.writeBuffer(this.buffer, 0, src, 0, src.length);
 
         // TODO: handle usage types:

--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -166,7 +166,7 @@ class GraphNode extends EventHandler {
          * @type {Mat3}
          * @private
          */
-        this.normalMatrix = new Mat3();
+        this._normalMatrix = new Mat3();
         /**
          * @type {boolean}
          * @private
@@ -267,6 +267,24 @@ class GraphNode extends EventHandler {
             this._forward = new Vec3();
         }
         return this.getWorldTransform().getZ(this._forward).normalize().mulScalar(-1);
+    }
+
+    /**
+     * A matrix used to transform the normal.
+     *
+     * @type  {Mat3}
+     * @ignore
+     */
+    get normalMatrix() {
+
+        const normalMat = this._normalMatrix;
+        if (this._dirtyNormal) {
+            this.getWorldTransform().invertTo3x3(normalMat);
+            normalMat.transpose();
+            this._dirtyNormal = false;
+        }
+
+        return normalMat;
     }
 
     /**

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -72,7 +72,7 @@ const worldMatZ = new Vec3();
 const webgl1DepthClearColor = new Color(254.0 / 255, 254.0 / 255, 254.0 / 255, 254.0 / 255);
 const tempSphere = new BoundingSphere();
 const boneTextureSize = [0, 0, 0, 0];
-let boneTexture, instancingData, modelMatrix, normalMatrix;
+let boneTexture, instancingData, modelMatrix;
 
 let keyA, keyB;
 
@@ -1056,13 +1056,7 @@ class ForwardRenderer {
             this.modelMatrixId.setValue(modelMatrix.data);
 
             if (normal) {
-                normalMatrix = meshInstance.node.normalMatrix;
-                if (meshInstance.node._dirtyNormal) {
-                    modelMatrix.invertTo3x3(normalMatrix);
-                    normalMatrix.transpose();
-                    meshInstance.node._dirtyNormal = false;
-                }
-                this.normalMatrixId.setValue(normalMatrix.data);
+                this.normalMatrixId.setValue(meshInstance.node.normalMatrix.data);
             }
 
             device.draw(mesh.primitive[style]);
@@ -1479,6 +1473,7 @@ class ForwardRenderer {
                     // TODO: model matrix setup is part of the drawInstance call, but with uniform buffer it's needed
                     // earlier here. This needs to be refactored for multi-view anyways.
                     this.modelMatrixId.setValue(drawCall.node.worldTransform.data);
+                    this.normalMatrixId.setValue(drawCall.node.normalMatrix.data);
 
                     // update mesh bind group / uniform buffer
                     const meshBindGroup = drawCall.getBindGroup(device, pass);


### PR DESCRIPTION
<img width="824" alt="Screenshot 2022-08-30 at 16 03 56" src="https://user-images.githubusercontent.com/59932779/187472388-4317f55d-ddfe-4183-b608-47e4b32beea3.png">

a house glb can be rendered on WebGPU (using standard shader, with lighting disabled)

- few lighting shader chunks are excluded when not needed
- refactored the normalMatrix (moved from forward renderer to Graph Node)
- handling of unaligned sized data to be copied to gpu buffer
- removed AREA_LUTS_PRECISION define and injecting the precision directly into the code