### PR TITLE
Fix unpacking of msdf markup params

### DIFF
--- a/src/graphics/program-lib/chunks/common/vert/msdf.js
+++ b/src/graphics/program-lib/chunks/common/vert/msdf.js
@@ -8,20 +8,23 @@ varying vec4 shadow_color;
 varying vec2 shadow_offset;
 
 void unpackMsdfParams() {
-    outline_color.rb = mod(vertex_outlineParameters.xy, 256.) / 256.;
-    outline_color.ga = vertex_outlineParameters.xy / 256. / 256.;
+    vec3 little = mod(vertex_outlineParameters, 256.);
+    vec3 big = (vertex_outlineParameters - little) / 256.;
+
+    outline_color.rb = little.xy / 255.;
+    outline_color.ga = big.xy / 255.;
 
     // _outlineThicknessScale === 0.2
-    outline_thickness = vertex_outlineParameters.z / 255. * 0.2;
+    outline_thickness = little.z / 255. * 0.2;
 
-    vec3 little = mod(vertex_shadowParameters, 256.) / 256.;
-    vec3 big = vertex_shadowParameters / 256. / 256.;
+    little = mod(vertex_shadowParameters, 256.);
+    big = (vertex_shadowParameters - little) / 256.;
 
-    shadow_color.rb = little.xy;
-    shadow_color.ga = big.xy;
+    shadow_color.rb = little.xy / 255.;
+    shadow_color.ga = big.xy / 255.;
 
-    // vec2(little.z, big.z) * 2. srink from (0.5, 0.5) to (1, 1)
+    // vec2(little.z, big.z) / 127. - 1. remaps shadow offset from [0, 254] to [-1, 1]
     // _shadowOffsetScale === 0.005
-    shadow_offset = (vec2(little.z, big.z) * 2. - 1.) * 0.005;
+    shadow_offset = (vec2(little.z, big.z) / 127. - 1.) * 0.005;
 }
 `;


### PR DESCRIPTION
Fixes: https://github.com/playcanvas/engine/issues/4595

At the moment, unpacking function of text markup parameters isn't the exact inverse of packing, especially on shadow offset.

Simple example of the issue is to keep default settings for shadow (ie. white text with a black shadow at an offset of (0, 0)) and toggling markup without actually using any tag. It gives something like this (slightly visible on black background, obvious on white blackground):
![image](https://user-images.githubusercontent.com/1902874/187478750-f65ba588-a2e1-487d-943c-3d7aefa0dc4c.png)

This is because an offset of (0, 0) is packed as 127 + 127 * 256 = 32639 but unpacked as ((32639 % 256) / 256 * 2 - 1, (32639 / 256 / 256) * 2 - 1) = (-0.008, -0.004).

This corrected function gives the expected rendering:
![image](https://user-images.githubusercontent.com/1902874/187479826-89275649-6455-4de4-a320-1fbecfef3356.png)

Color unpacking error is barely visible but comes from the same kind of difference (packed by multiplying by 255, unpacked by dividing by 256).


I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).