### PR TITLE
Output treeshakeable module builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "main": "build/playcanvas.js",
   "module": "build/playcanvas.mjs/index.js",
   "types": "build/playcanvas.d.ts",
+  "sideEffects": false,
   "bugs": {
     "url": "https://github.com/playcanvas/engine/issues"
   },

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   ],
   "license": "MIT",
   "main": "build/playcanvas.js",
-  "module": "build/playcanvas.mjs",
+  "module": "build/playcanvas.mjs/index.js",
   "types": "build/playcanvas.d.ts",
   "bugs": {
     "url": "https://github.com/playcanvas/engine/issues"
@@ -109,6 +109,7 @@
     "build:release": "rollup -c --environment target:release",
     "build:debug": "rollup -c --environment target:debug",
     "build:dts": "tsc src/index.js --outDir types --allowJs --declaration --emitDeclarationOnly",
+    "build:extras": "rollup -c --environment target:extras",
     "build:es5": "rollup -c --environment target:es5",
     "build:es6": "rollup -c --environment target:es6",
     "build:profiler": "rollup -c --environment target:profiler",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -150,7 +150,8 @@ function buildTarget(buildType, moduleFormat) {
     const banner = {
         debug: ' (DEBUG PROFILER)',
         release: '',
-        profiler: ' (PROFILER)'
+        profiler: ' (PROFILER)',
+        min: null
     };
 
     const outputPlugins = {
@@ -190,7 +191,7 @@ function buildTarget(buildType, moduleFormat) {
     };
 
     const outputOptions = {
-        banner: getBanner(banner[buildType] || banner.release),
+        banner: banner[buildType] && getBanner(banner[buildType] || banner.release),
         plugins: outputPlugins[buildType || outputPlugins.release],
         format: outputFormat[moduleFormat],
         indent: '\t',

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -192,12 +192,13 @@ function buildTarget(buildType, moduleFormat) {
     const outputOptions = {
         banner: getBanner(banner[buildType] || banner.release),
         plugins: outputPlugins[buildType || outputPlugins.release],
-        file: `${outputFile[buildType]}${outputExtension[moduleFormat]}`,
         format: outputFormat[moduleFormat],
         indent: '\t',
         sourcemap: sourceMap[buildType] || sourceMap.release,
         name: 'pc'
     };
+
+    outputOptions[moduleFormat === 'es6' ? 'dir' : 'file'] = `${outputFile[buildType]}${outputExtension[moduleFormat]}`;
 
     const sdkVersion = {
         _CURRENT_SDK_VERSION: version,
@@ -241,6 +242,7 @@ function buildTarget(buildType, moduleFormat) {
     return {
         input: 'src/index.js',
         output: outputOptions,
+        preserveModules: moduleFormat === 'es6',
         plugins: [
             jscc(jsccOptions[buildType] || jsccOptions.release),
             shaderChunks(buildType !== 'debug'),
@@ -291,6 +293,8 @@ export default (args) => {
     const envTarget = process.env.target ? process.env.target.toLowerCase() : null;
     if (envTarget === 'types') {
         targets.push(target_types);
+    } else if (envTarget === 'extras') {
+        targets = targets.concat(target_extras);
     } else {
         ['release', 'debug', 'profiler', 'min'].forEach((t) => {
             ['es5', 'es6'].forEach((m) => {

--- a/src/framework/app-options.js
+++ b/src/framework/app-options.js
@@ -15,35 +15,35 @@ class AppOptions {
     /**
      * Input handler for {@link ElementComponent}s.
      *
-     * @type {ElementInput.constructor}
+     * @type {ElementInput}
      */
     elementInput;
 
     /**
      * Keyboard handler for input.
      *
-     * @type {Keyboard.constructor}
+     * @type {Keyboard}
      */
     keyboard;
 
     /**
      * Mouse handler for input.
      *
-     * @typeof {Mouse}
+     * @type {Mouse}
      */
     mouse;
 
     /**
      * TouchDevice handler for input.
      *
-     * @typeof {TouchDevice}
+     * @type {TouchDevice}
      */
     touch;
 
     /**
      * Gamepad handler for input.
      *
-     * @typeof {GamePads}
+     * @type {GamePads}
      */
     gamepads;
 
@@ -71,49 +71,49 @@ class AppOptions {
     /**
      * The sound manager
      *
-     * @typeof {SoundManager}
+     * @type {SoundManager}
      */
     soundManager;
 
     /**
      * The graphics device.
      *
-     * @typeof {GraphicsDevice}
+     * @type {GraphicsDevice}
      */
     graphicsDevice;
 
     /**
      * The lightmapper.
      *
-     * @type {Lightmapper.constructor}
+     * @type {Lightmapper}
      */
     lightmapper;
 
     /**
      * The BatchManager.
      *
-     * @type {BatchManager.constructor}
+     * @type {BatchManager}
      */
     batchManager;
 
     /**
      * The XrManager.
      *
-     * @typeof {XrManager}
+     * @type {XrManager}
      */
     xr;
 
     /**
      * The component systems the app requires.
      *
-     * @typeof {ComponentSystem.constructor[]}
+     * @type {ComponentSystem[]}
      */
     componentSystems = [];
 
     /**
      * The resource handlers the app requires.
      *
-     * @typeof {ResourceHandler.constructor[]}
+     * @type {ResourceHandler[]}
      */
     resourceHandlers = [];
 }

--- a/src/framework/app-options.js
+++ b/src/framework/app-options.js
@@ -15,35 +15,35 @@ class AppOptions {
     /**
      * Input handler for {@link ElementComponent}s.
      *
-     * @type {ElementInput}
+     * @type {ElementInput.constructor}
      */
     elementInput;
 
     /**
      * Keyboard handler for input.
      *
-     * @type {Keyboard}
+     * @type {Keyboard.constructor}
      */
     keyboard;
 
     /**
      * Mouse handler for input.
      *
-     * @type {Mouse}
+     * @typeof {Mouse}
      */
     mouse;
 
     /**
      * TouchDevice handler for input.
      *
-     * @type {TouchDevice}
+     * @typeof {TouchDevice}
      */
     touch;
 
     /**
      * Gamepad handler for input.
      *
-     * @type {GamePads}
+     * @typeof {GamePads}
      */
     gamepads;
 
@@ -71,49 +71,49 @@ class AppOptions {
     /**
      * The sound manager
      *
-     * @type {SoundManager}
+     * @typeof {SoundManager}
      */
     soundManager;
 
     /**
      * The graphics device.
      *
-     * @type {GraphicsDevice}
+     * @typeof {GraphicsDevice}
      */
     graphicsDevice;
 
     /**
      * The lightmapper.
      *
-     * @type {Lightmapper}
+     * @type {Lightmapper.constructor}
      */
     lightmapper;
 
     /**
      * The BatchManager.
      *
-     * @type {BatchManager}
+     * @type {BatchManager.constructor}
      */
     batchManager;
 
     /**
      * The XrManager.
      *
-     * @type {XrManager}
+     * @typeof {XrManager}
      */
     xr;
 
     /**
      * The component systems the app requires.
      *
-     * @type {ComponentSystem[]}
+     * @typeof {ComponentSystem.constructor[]}
      */
     componentSystems = [];
 
     /**
      * The resource handlers the app requires.
      *
-     * @type {ResourceHandler[]}
+     * @typeof {ResourceHandler.constructor[]}
      */
     resourceHandlers = [];
 }


### PR DESCRIPTION
This PR changes the engine es6/esm module output to preserve modules. This results in a hierarchy of files for es6 target, one module for each interface exported by index.js (the rest is not treeshakable and is placed directly into index.js).

Preserving modules will allow applications to treeshake the engine source.

We also remove the header comment from the minified build, otherwise it becomes bloated with comments (since each individual module gets it).