### PR TITLE
Use better defaults for physically based camera parameters

### DIFF
--- a/src/framework/components/camera/component.js
+++ b/src/framework/components/camera/component.js
@@ -392,7 +392,7 @@ class CameraComponent extends Component {
     }
 
     /**
-     * Set camera aperture in f-stops, the default value is 1.0. Higher value means less exposure.
+     * Set camera aperture in f-stops, the default value is 16.0. Higher value means less exposure.
      *
      * @type {number}
      */
@@ -405,7 +405,7 @@ class CameraComponent extends Component {
     }
 
     /**
-     * Set camera sensitivity in ISO, the default value is 100. Higher value means more exposure.
+     * Set camera sensitivity in ISO, the default value is 1000. Higher value means more exposure.
      *
      * @type {number}
      */
@@ -418,7 +418,7 @@ class CameraComponent extends Component {
     }
 
     /**
-     * Set camera shutter speed in seconds, the default value is 1s. Longer shutter means more exposure.
+     * Set camera shutter speed in seconds, the default value is 1/1000s. Longer shutter means more exposure.
      *
      * @type {number}
      */

--- a/src/scene/camera.js
+++ b/src/scene/camera.js
@@ -51,9 +51,9 @@ class Camera {
         this._renderTarget = null;
         this._scissorRect = new Vec4(0, 0, 1, 1);
         this._scissorRectClear = false; // by default rect is used when clearing. this allows scissorRect to be used when clearing.
-        this._aperture = 1.0;
-        this._shutter = 1;
-        this._sensitivity = 100;
+        this._aperture = 16.0;
+        this._shutter = 1.0 / 1000.0;
+        this._sensitivity = 1000;
 
         this._projMat = new Mat4();
         this._projMatDirty = true;


### PR DESCRIPTION
### Description
This is to make sure that shutter speed and aperture won't have too big of an impact on depth of field and motion blur, given the eventual future where we might want to have those effect depend on the camera parameters.
