### PR TITLE
Fix sheen glossiness and colour not getting applied correctly

### DIFF
--- a/src/graphics/program-lib/programs/standard.js
+++ b/src/graphics/program-lib/programs/standard.js
@@ -355,7 +355,7 @@ const standard = {
                 decl.append("float dGlossiness;");
                 if (options.sheen) {
                     decl.append("vec3 sSpecularity;");
-                    code.append(this._addMap("sheen", "sheenPS", options, litShader.chunks));
+                    code.append(this._addMap("sheen", "sheenPS", options, litShader.chunks, options.sheenEncoding));
                     func.append("getSheen();");
 
                     decl.append("float sGlossiness;");

--- a/src/resources/parser/glb-parser.js
+++ b/src/resources/parser/glb-parser.js
@@ -1177,6 +1177,7 @@ const extensionSheen = function (data, material, textures) {
     }
     if (data.hasOwnProperty('sheenColorTexture')) {
         material.sheenMap = textures[data.sheenColorTexture.index];
+        material.sheenEncoding = 'srgb';
         extractTextureTransform(data.sheenColorTexture, material, ['sheen']);
     }
     if (data.hasOwnProperty('sheenRoughnessFactor')) {

--- a/src/scene/materials/standard-material-options-builder.js
+++ b/src/scene/materials/standard-material-options-builder.js
@@ -173,8 +173,8 @@ class StandardMaterialOptionsBuilder {
         options.refractionIndexTint = (stdMat.refractionIndex !== 1.0 / 1.5) ? 1 : 0;
         options.thicknessTint = (stdMat.useDynamicRefraction && stdMat.thickness !== 1.0) ? 1 : 0;
         options.useMetalness = stdMat.useMetalness;
-        options.specularEncoding = stdMat.specularEncoding === undefined ? 'linear' : stdMat.specularEncoding;
-        options.sheenEncoding = stdMat.sheenEncoding === undefined ? 'linear' : stdMat.sheenEncoding;
+        options.specularEncoding = stdMat.specularEncoding || 'linear';
+        options.sheenEncoding = stdMat.sheenEncoding || 'linear';
         options.enableGGXSpecular = stdMat.enableGGXSpecular;
         options.msdf = !!stdMat.msdfMap;
         options.msdfTextAttribute = !!stdMat.msdfTextAttribute;

--- a/src/scene/materials/standard-material-options-builder.js
+++ b/src/scene/materials/standard-material-options-builder.js
@@ -191,7 +191,7 @@ class StandardMaterialOptionsBuilder {
 
         options.sheen = stdMat.useSheen;
         options.sheenTint = (stdMat.useSheen && notWhite(stdMat.sheen)) ? 2 : 0;
-        options.sheenGlossinessTint = (stdMat.useSheen && stdMat.sheenGlossiness < 1) ? 1 : 0;
+        options.sheenGlossinessTint = 1;
     }
 
     _updateEnvOptions(options, stdMat, scene) {

--- a/src/scene/materials/standard-material-options-builder.js
+++ b/src/scene/materials/standard-material-options-builder.js
@@ -174,6 +174,7 @@ class StandardMaterialOptionsBuilder {
         options.thicknessTint = (stdMat.useDynamicRefraction && stdMat.thickness !== 1.0) ? 1 : 0;
         options.useMetalness = stdMat.useMetalness;
         options.specularEncoding = stdMat.specularEncoding === undefined ? 'linear' : stdMat.specularEncoding;
+        options.sheenEncoding = stdMat.sheenEncoding === undefined ? 'linear' : stdMat.sheenEncoding;
         options.enableGGXSpecular = stdMat.enableGGXSpecular;
         options.msdf = !!stdMat.msdfMap;
         options.msdfTextAttribute = !!stdMat.msdfTextAttribute;

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -1195,6 +1195,8 @@ function _defineMaterialProps() {
     _defineTex2D('clearCoat', 0, 1, '', true);
     _defineTex2D('clearCoatGloss', 0, 1, '', true);
     _defineTex2D('clearCoatNormal', 0, -1, '', false);
+    _defineTex2D('sheen', 0, 3, '', true);
+    _defineTex2D('sheenGloss', 0, 1, '', true);
 
     _defineObject('cubeMap');
     _defineObject('sphereMap');


### PR DESCRIPTION
### Description
Fixes a bunch of issues with sheen. The first of which is that due to glossiness being roughness from glTF, we can't optimise the value out sheen glossiness tinting if the value is 1.0. 

Furthermore, it turns out the sheen textures weren't even applied, so this PR fixes that as well. 
