### PR TITLE
Added changeScene API

### DIFF
--- a/src/framework/scene-registry.js
+++ b/src/framework/scene-registry.js
@@ -177,7 +177,7 @@ class SceneRegistry {
         }
 
         if (!sceneItem.url) {
-            callback("Cannot find scene when loading a scene");
+            callback("Cannot find scene to load");
             return;
         }
 

--- a/src/framework/scene-registry.js
+++ b/src/framework/scene-registry.js
@@ -312,13 +312,15 @@ class SceneRegistry {
      * });
      */
     loadSceneHierarchy(sceneItem, callback) {
+        const self = this;
+
         this._loadSceneData(sceneItem, false, function (err, sceneItem) {
             if (err) {
                 if (callback) callback(err);
                 return;
             }
 
-            this._addHierarchyToScene(sceneItem.url, sceneItem.data, callback);
+            self._addHierarchyToScene(sceneItem.url, sceneItem.data, callback);
         });
     }
 

--- a/src/framework/scene-registry.js
+++ b/src/framework/scene-registry.js
@@ -327,7 +327,7 @@ class SceneRegistry {
      * });
      */
     loadSceneHierarchy(sceneItem, callback) {
-        this._loadSceneHierarchy(sceneItem, callback);
+        this._loadSceneHierarchy(sceneItem, null, callback);
     }
 
     /**

--- a/src/framework/scene-registry.js
+++ b/src/framework/scene-registry.js
@@ -175,7 +175,7 @@ class SceneRegistry {
 
         url = sceneItem.url;
 
-        if (!sceneItem.url) {
+        if (!url) {
             callback("Cannot find scene to load");
             return;
         }

--- a/src/framework/scene-registry.js
+++ b/src/framework/scene-registry.js
@@ -367,7 +367,7 @@ class SceneRegistry {
      * @param {ChangeSceneCallback} [callback] - The function to call after loading,
      * passed (err, entity) where err is null if no errors occurred.
      * @example
-     * app.scenes.ChangeScene("Scene Name", function (err, entity) {
+     * app.scenes.changeScene("Scene Name", function (err, entity) {
      *     if (!err) {
      *         // success
      *     } else {

--- a/src/framework/scene-registry.js
+++ b/src/framework/scene-registry.js
@@ -4,7 +4,6 @@ import { Debug } from '../core/debug.js';
 import { ABSOLUTE_URL } from '../asset/constants.js';
 
 import { SceneRegistryItem } from './scene-registry-item.js';
-import { Entity } from './entity.js';
 
 /** @typedef {import('./app-base.js').AppBase} AppBase */
 
@@ -395,11 +394,8 @@ class SceneRegistry {
             const rootChildren = self._app.root.children;
             while (rootChildren.length > 0) {
                 const child = rootChildren[0];
-                if (child instanceof Entity) {
-                    child.destroy();
-                } else {
-                    child.parent.removeChild(child);
-                }
+                child.reparent(null);
+                child.destroy?.();
             }
 
             self._app.applySceneSettings(sceneItem.data.settings);

--- a/src/framework/scene-registry.js
+++ b/src/framework/scene-registry.js
@@ -382,6 +382,7 @@ class SceneRegistry {
         }
 
         const app = this._app;
+        const self = this;
 
         this._loadSceneData(sceneItem, false, function (err, sceneItem) {
             if (err) {

--- a/src/framework/scene-registry.js
+++ b/src/framework/scene-registry.js
@@ -188,14 +188,14 @@ class SceneRegistry {
             callback(null, sceneItem);
             return;
         }
-        
+
         // include asset prefix if present
         if (app.assets && app.assets.prefix && !ABSOLUTE_URL.test(url)) {
             url = path.join(app.assets.prefix, url);
         }
-        
+
         sceneItem._onLoadedCallbacks.push(callback);
-        
+
         if (!sceneItem._loading) {
             // Because we need to load scripts before we instance the hierarchy (i.e. before we create script components)
             // Split loading into load and open
@@ -264,7 +264,7 @@ class SceneRegistry {
 
     _addHierarchyToScene(url, data, callback) {
         const app = this._app;
-        
+
         // called after scripts are preloaded
         const _loaded = function () {
             // Because we need to load scripts before we instance the hierarchy (i.e. before we create script components)

--- a/src/framework/scene-registry.js
+++ b/src/framework/scene-registry.js
@@ -166,10 +166,11 @@ class SceneRegistry {
 
         // If it's just a URL or scene name then attempt to find
         // the scene item in the registry else create a temp
-        // SceneRegistryItem to use for this function
+        // SceneRegistryItem to use for this function as the scene
+        // may not have been added to the registry
         let url = sceneItem;
         if (typeof sceneItem === 'string') {
-            sceneItem = this.findByUrl(url) || this.find(url) || new SceneRegistryItem('Untitled', null);
+            sceneItem = this.findByUrl(url) || this.find(url) || new SceneRegistryItem('Untitled', url);
         }
 
         url = sceneItem.url;

--- a/src/framework/scene-registry.js
+++ b/src/framework/scene-registry.js
@@ -178,7 +178,7 @@ class SceneRegistry {
         }
 
         if (!sceneItem.url) {
-            callback("URL or SceneRegistryItem is null when loading a scene");
+            callback("Cannot find scene when loading a scene");
             return;
         }
 

--- a/src/framework/scene-registry.js
+++ b/src/framework/scene-registry.js
@@ -343,11 +343,9 @@ class SceneRegistry {
      * });
      */
     loadSceneSettings(sceneItem, callback) {
-        const app = this._app;
-
         this._loadSceneData(sceneItem, false, (err, sceneItem) => {
             if (!err) {
-                app.applySceneSettings(sceneItem.data.settings);
+                this._app.applySceneSettings(sceneItem.data.settings);
                 if (callback) {
                     callback(null);
                 }

--- a/src/framework/scene-registry.js
+++ b/src/framework/scene-registry.js
@@ -164,19 +164,15 @@ class SceneRegistry {
         // that is loaded so we don't do a subsequent http requests
         // on the same scene later
 
-        // If it's just a URL then attempt to find the scene item in
-        // the registry else create a temp SceneRegistryItem to use
-        // for this function
+        // If it's just a URL or scene name then attempt to find
+        // the scene item in the registry else create a temp
+        // SceneRegistryItem to use for this function
         let url = sceneItem;
-
-        if (sceneItem instanceof SceneRegistryItem) {
-            url = sceneItem.url;
-        } else {
-            sceneItem = this.findByUrl(url);
-            if (!sceneItem) {
-                sceneItem = new SceneRegistryItem('Untitled', url);
-            }
+        if (typeof sceneItem === 'string') {
+            sceneItem = this.findByUrl(url) || this.find(url) || new SceneRegistryItem('Untitled', null);
         }
+
+        url = sceneItem.url;
 
         if (!sceneItem.url) {
             callback("Cannot find scene to load");
@@ -228,7 +224,7 @@ class SceneRegistry {
      * scene loading quicker for the user.
      *
      * @param {SceneRegistryItem | string} sceneItem - The scene item (which can be found with
-     * {@link SceneRegistry#find} or URL of the scene file. Usually this will be "scene_id.json".
+     * {@link SceneRegistry#find}, URL of the scene file (e.g."scene_id.json") or name of the scene.
      * @param {LoadSceneDataCallback} callback - The function to call after loading,
      * passed (err, sceneItem) where err is null if no errors occurred.
      * @example
@@ -300,7 +296,7 @@ class SceneRegistry {
      * application root Entity.
      *
      * @param {SceneRegistryItem | string} sceneItem - The scene item (which can be found with
-     * {@link SceneRegistry#find} or URL of the scene file. Usually this will be "scene_id.json".
+     * {@link SceneRegistry#find}, URL of the scene file (e.g."scene_id.json") or name of the scene.
      * @param {LoadHierarchyCallback} callback - The function to call after loading,
      * passed (err, entity) where err is null if no errors occurred.
      * @example
@@ -330,7 +326,7 @@ class SceneRegistry {
      * Load a scene file and apply the scene settings to the current scene.
      *
      * @param {SceneRegistryItem | string} sceneItem - The scene item (which can be found with
-     * {@link SceneRegistry#find} or URL of the scene file. Usually this will be "scene_id.json".
+     * {@link SceneRegistry#find}, URL of the scene file (e.g."scene_id.json") or name of the scene.
      * @param {LoadSettingsCallback} callback - The function called after the settings
      * are applied. Passed (err) where err is null if no error occurred.
      * @example
@@ -365,7 +361,7 @@ class SceneRegistry {
      * entities and graph nodes under `app.root` and load the scene settings and hierarchy.
      *
      * @param {SceneRegistryItem | string} sceneItem - The scene item (which can be found with
-     * {@link SceneRegistry#find} or name of the scene.".
+     * {@link SceneRegistry#find}, URL of the scene file (e.g."scene_id.json") or name of the scene.
      * @param {ChangeSceneCallback} [callback] - The function to call after loading,
      * passed (err, entity) where err is null if no errors occurred.
      * @example
@@ -378,10 +374,6 @@ class SceneRegistry {
      * });
      */
     changeScene(sceneItem, callback) {
-        if (!(sceneItem instanceof SceneRegistryItem)) {
-            sceneItem = this.find(sceneItem);
-        }
-
         const app = this._app;
         const self = this;
 

--- a/src/framework/scene-registry.js
+++ b/src/framework/scene-registry.js
@@ -197,7 +197,7 @@ class SceneRegistry {
             // Split loading into load and open
             const handler = app.loader.getHandler("hierarchy");
 
-            handler.load(url, function (err, data) {
+            handler.load(url, (err, data) => {
                 sceneItem.data = data;
                 sceneItem._loading = false;
 
@@ -262,7 +262,7 @@ class SceneRegistry {
         const app = this._app;
 
         // called after scripts are preloaded
-        const _loaded = function () {
+        const _loaded = () => {
             // Because we need to load scripts before we instance the hierarchy (i.e. before we create script components)
             // Split loading into load and open
 
@@ -312,7 +312,7 @@ class SceneRegistry {
     loadSceneHierarchy(sceneItem, callback) {
         const self = this;
 
-        this._loadSceneData(sceneItem, false, function (err, sceneItem) {
+        this._loadSceneData(sceneItem, false, (err, sceneItem) => {
             if (err) {
                 if (callback) callback(err);
                 return;
@@ -342,7 +342,7 @@ class SceneRegistry {
     loadSceneSettings(sceneItem, callback) {
         const app = this._app;
 
-        this._loadSceneData(sceneItem, false, function (err, sceneItem) {
+        this._loadSceneData(sceneItem, false, (err, sceneItem) => {
             if (!err) {
                 app.applySceneSettings(sceneItem.data.settings);
                 if (callback) {
@@ -377,7 +377,7 @@ class SceneRegistry {
         const app = this._app;
         const self = this;
 
-        this._loadSceneData(sceneItem, false, function (err, sceneItem) {
+        this._loadSceneData(sceneItem, false, (err, sceneItem) => {
             if (err) {
                 if (callback) {
                     callback(err);
@@ -419,7 +419,7 @@ class SceneRegistry {
             url = path.join(app.assets.prefix, url);
         }
 
-        handler.load(url, function (err, data) {
+        handler.load(url, (err, data) => {
             if (!err) {
                 const _loaded = function () {
                     // parse and create scene

--- a/src/framework/scene-registry.js
+++ b/src/framework/scene-registry.js
@@ -414,7 +414,7 @@ class SceneRegistry {
 
         handler.load(url, (err, data) => {
             if (!err) {
-                const _loaded = function () {
+                const _loaded = () => {
                     // parse and create scene
                     app.systems.script.preloading = true;
                     const scene = handler.open(url, data);

--- a/test/framework/scene-registry.test.mjs
+++ b/test/framework/scene-registry.test.mjs
@@ -146,16 +146,6 @@ describe('SceneRegistry', function () {
             expect(sceneItem._loading).to.equal(false);
         });
 
-        it('try to load scene data that does not exist by name', async function () {
-            const registry = new SceneRegistry(app);
-            registry.add('New Scene 1', `${assetPath}scene.json`);
-
-            const err = await promisedLoadSceneData(registry, 'Scene 2');
-
-            expect(err).to.exist;
-            expect(err).to.equal('Cannot find scene to load');
-        });
-
         it('try to load scene data that by name', async function () {
             const registry = new SceneRegistry(app);
             registry.add('New Scene 1', `${assetPath}scene.json`);

--- a/test/framework/scene-registry.test.mjs
+++ b/test/framework/scene-registry.test.mjs
@@ -99,11 +99,11 @@ describe('SceneRegistry', function () {
 
     });
 
-    const promisedLoadSceneData = function (registry, sceneItemOrUrl) {
+    const promisedLoadSceneData = function (registry, sceneItemOrNameOrUrl) {
         return new Promise(function (resolve, reject) {
-            registry.loadSceneData(sceneItemOrUrl, function (err, sceneItem) {
+            registry.loadSceneData(sceneItemOrNameOrUrl, function (err, sceneItem) {
                 if (err) {
-                    reject(err);
+                    resolve(err);
                 }
 
                 resolve(sceneItem);
@@ -146,6 +146,37 @@ describe('SceneRegistry', function () {
             expect(sceneItem._loading).to.equal(false);
         });
 
+        it('try to load scene data that does not exist by name', async function () {
+            const registry = new SceneRegistry(app);
+            registry.add('New Scene 1', `${assetPath}scene.json`);
+
+            const err = await promisedLoadSceneData(registry, 'Scene 2');
+
+            expect(err).to.exist;
+            expect(err).to.equal('Cannot find scene to load');
+        });
+
+        it('try to load scene data that by name', async function () {
+            const registry = new SceneRegistry(app);
+            registry.add('New Scene 1', `${assetPath}scene.json`);
+
+            const sceneItem = await promisedLoadSceneData(registry, 'New Scene 1');
+
+            expect(sceneItem).to.exist;
+            expect(sceneItem.data).to.exist;
+            expect(sceneItem._loading).to.equal(false);
+        });
+
+        it('try to load scene data that by URL', async function () {
+            const registry = new SceneRegistry(app);
+            registry.add('New Scene 1', `${assetPath}scene.json`);
+
+            const sceneItem = await promisedLoadSceneData(registry, `${assetPath}scene.json`);
+
+            expect(sceneItem).to.exist;
+            expect(sceneItem.data).to.exist;
+            expect(sceneItem._loading).to.equal(false);
+        });
     });
 
     describe('#remove', function () {


### PR DESCRIPTION
### Updated: Tue 20 Sep 2022

This is to address the many topics for switching scene in PlayCanvas. The page and helper script I wrote doesn't seem to be enough https://developer.playcanvas.com/en/user-manual/packs/loading-scenes/

So I'm adding the most common use case to the API.

Changing scenes becomes a one liner with this change where it loads the scene data, destroys all entities under the `app.root` and adds the scene settings and hierarchy:

```
this.app.scenes.changeScene('name of scene');
```

This PR also adds support for loading scene settings/hierarchy by name, again reducing the extra boilerplate that the user needs to write.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
