### PR TITLE
Fix bug where sheen wasn't appropriately layered

### DIFF
--- a/src/graphics/program-lib/programs/lit-shader.js
+++ b/src/graphics/program-lib/programs/lit-shader.js
@@ -1238,7 +1238,7 @@ class LitShader {
                         code +=  ";\n";
                     }
                     if (options.sheen) {
-                        code += "    dSpecularLight += getLightSpecularSheen(dHalfDirW) * dAtten * light" + i + "_color * sSpecularity";
+                        code += "    sSpecularLight += getLightSpecularSheen(dHalfDirW) * dAtten * light" + i + "_color * sSpecularity";
                         code += usesCookieNow ? " * dAtten3" : "";
                         code +=  ";\n";
                     }


### PR DESCRIPTION
### Description
Sheen per-light specular wasn't added to the sheen specularity layer, resulting in incorrect layering of sheen effects and energy preservation. 