### PR TITLE
Fix refraction bug

### DIFF
--- a/src/graphics/program-lib/programs/lit-shader.js
+++ b/src/graphics/program-lib/programs/lit-shader.js
@@ -781,15 +781,16 @@ class LitShader {
             if (options.clearCoat) {
                 code += chunks.reflectionCCPS;
             }
-            if (options.refraction) {
-                if (options.useDynamicRefraction) {
-                    code += chunks.refractionDynamicPS;
-                } else {
-                    code += chunks.refractionCubePS;
-                }
-            }
             if (options.sheen) {
                 code += chunks.reflectionSheenPS;
+            }
+        }
+
+        if (options.refraction) {
+            if (options.useDynamicRefraction) {
+                code += chunks.refractionDynamicPS;
+            } else if (this.reflections) {
+                code += chunks.refractionCubePS;
             }
         }
 
@@ -1277,7 +1278,7 @@ class LitShader {
                 }
             }
 
-            if (this.reflections && options.refraction) {
+            if (options.refraction) {
                 code += "    addRefraction();\n";
             }
         }

--- a/src/scene/materials/standard-material-options-builder.js
+++ b/src/scene/materials/standard-material-options-builder.js
@@ -168,7 +168,7 @@ class StandardMaterialOptionsBuilder {
         options.fastTbn = stdMat.fastTbn;
         options.cubeMapProjection = stdMat.cubeMapProjection;
         options.customFragmentShader = stdMat.customFragmentShader;
-        options.refraction = !!stdMat.refraction || !!stdMat.refractionMap;
+        options.refraction = (stdMat.refraction || !!stdMat.refractionMap) && (stdMat.useDynamicRefraction || !!options.reflectionSource);
         options.useDynamicRefraction = stdMat.useDynamicRefraction;
         options.refractionIndexTint = (stdMat.refractionIndex !== 1.0 / 1.5) ? 1 : 0;
         options.thicknessTint = (stdMat.useDynamicRefraction && stdMat.thickness !== 1.0) ? 1 : 0;


### PR DESCRIPTION
### Description
Refractions would be turned off if there was no environment map present. This was due to legacy code assuming we need an environment map for refractions, which we don't if we use dynamic refractions. This PR fixes that bug. 