### PR TITLE
Add support for iridescence

### DIFF
--- a/src/graphics/program-lib/chunks/chunks.js
+++ b/src/graphics/program-lib/chunks/chunks.js
@@ -58,6 +58,9 @@ import gles2PS from './common/frag/gles2.js';
 import gles3PS from './common/frag/gles3.js';
 import gles3VS from './common/vert/gles3.js';
 import glossPS from './standard/frag/gloss.js';
+import iridescenceDiffractionPS from './lit/frag/iridescenceDiffraction.js';
+import iridescencePS from './standard/frag/iridescence.js';
+import iridescenceThicknessPS from './standard/frag/iridescenceThickness.js';
 import instancingVS from './lit/vert/instancing.js';
 import lightDiffuseLambertPS from './lit/frag/lightDiffuseLambert.js';
 import lightDirPointPS from './lit/frag/lightDirPoint.js';
@@ -262,6 +265,9 @@ const shaderChunks = {
     gles3PS,
     gles3VS,
     glossPS,
+    iridescenceDiffractionPS,
+    iridescencePS,
+    iridescenceThicknessPS,
     instancingVS,
     lightDiffuseLambertPS,
     lightDirPointPS,

--- a/src/graphics/program-lib/chunks/lit/frag/fresnelSchlick.js
+++ b/src/graphics/program-lib/chunks/lit/frag/fresnelSchlick.js
@@ -3,6 +3,11 @@ export default /* glsl */`
 vec3 getFresnel(float cosTheta, vec3 f0) {
     float fresnel = pow(1.0 - max(cosTheta, 0.0), 5.0);
     float glossSq = dGlossiness * dGlossiness;
-    return f0 + (max(vec3(glossSq), f0) - f0) * fresnel;
+    vec3 ret = f0 + (max(vec3(glossSq), f0) - f0) * fresnel;
+    #ifdef LIT_IRIDESCENCE
+        return mix(ret, dIridescenceFresnel, vec3(dIridescence));
+    #else
+        return ret;
+    #endif    
 }
 `;

--- a/src/graphics/program-lib/chunks/lit/frag/iridescenceDiffraction.js
+++ b/src/graphics/program-lib/chunks/lit/frag/iridescenceDiffraction.js
@@ -98,12 +98,6 @@ vec3 calcIridescence(float outsideIor, float cosTheta, vec3 base_f0) {
     return max(i, vec3(0.0));
 }
 
-vec3 calcIridescenceF0(vec3 iridescence, float cosTheta) {
-    float x = clamp(1.0 - cosTheta, 0.0, 1.0);
-    float x5 = clamp(pow(x, 5.0), 0.0, 1.0);
-    return (iridescence - x5) / (1.0 - x5);
-}
-
 void getIridescence(float cosTheta) {
     dIridescenceFresnel = calcIridescence(1.0, cosTheta, dSpecularity);
 }

--- a/src/graphics/program-lib/chunks/lit/frag/iridescenceDiffraction.js
+++ b/src/graphics/program-lib/chunks/lit/frag/iridescenceDiffraction.js
@@ -37,14 +37,14 @@ vec3 iridescence_sensitivity(float opd, vec3 shift) {
     return XYZ_TO_REC709 * xyz;
 }
 
-float iridescenceFresnel(float cosTheta, float f0) {
+float iridescence_fresnel(float cosTheta, float f0) {
     float x = clamp(1.0 - cosTheta, 0.0, 1.0);
     float x2 = x * x;
     float x5 = x * x2 * x2;
     return f0 + (1.0 - f0) * x5;
 } 
 
-vec3 iridescenceFresnel(float cosTheta, vec3 f0) {
+vec3 iridescence_fresnel(float cosTheta, vec3 f0) {
     float x = clamp(1.0 - cosTheta, 0.0, 1.0);
     float x2 = x * x;
     float x5 = x * x2 * x2; 
@@ -64,7 +64,7 @@ vec3 calcIridescence(float outsideIor, float cosTheta, vec3 base_f0) {
     float cosTheta2 = sqrt(cosTheta2Sq);
 
     float r0 = iridescence_iorToFresnel(iridescenceIor, outsideIor);
-    float r12 = iridescenceFresnel(cosTheta, r0);
+    float r12 = iridescence_fresnel(cosTheta, r0);
     float r21 = r12;
     float t121 = 1.0 - r12;
 
@@ -73,7 +73,7 @@ vec3 calcIridescence(float outsideIor, float cosTheta, vec3 base_f0) {
 
     vec3 baseIor = iridescence_fresnelToIor(base_f0 + vec3(0.0001));
     vec3 r1 = iridescence_iorToFresnel(baseIor, iridescenceIor);
-    vec3 r23 = iridescenceFresnel(cosTheta2, r1);
+    vec3 r23 = iridescence_fresnel(cosTheta2, r1);
 
     vec3 phi23 = vec3(0.0);
     if (baseIor[0] < iridescenceIor) phi23[0] = PI;

--- a/src/graphics/program-lib/chunks/lit/frag/iridescenceDiffraction.js
+++ b/src/graphics/program-lib/chunks/lit/frag/iridescenceDiffraction.js
@@ -1,0 +1,110 @@
+export default /* glsl */`
+uniform float material_iridescenceRefractionIndex;
+
+#ifndef PI
+#define PI 3.14159265
+#endif
+
+float iridescence_iorToFresnel(float transmittedIor, float incidentIor) {
+    return pow((transmittedIor - incidentIor) / (transmittedIor + incidentIor), 2.0);
+}
+
+vec3 iridescence_iorToFresnel(vec3 transmittedIor, float incidentIor) {
+    return pow((transmittedIor - vec3(incidentIor)) / (transmittedIor + vec3(incidentIor)), vec3(2.0));
+}
+
+vec3 iridescence_fresnelToIor(vec3 f0) {
+    vec3 sqrtF0 = sqrt(f0);
+    return (vec3(1.0) + sqrtF0) / (vec3(1.0) - sqrtF0);
+}
+
+vec3 iridescence_sensitivity(float opd, vec3 shift) {
+    float phase = 2.0 * PI * opd * 1.0e-9;
+    const vec3 val = vec3(5.4856e-13, 4.4201e-13, 5.2481e-13);
+    const vec3 pos = vec3(1.6810e+06, 1.7953e+06, 2.2084e+06);
+    const vec3 var = vec3(4.3278e+09, 9.3046e+09, 6.6121e+09);
+
+    vec3 xyz = val * sqrt(2.0 * PI * var) * cos(pos * phase + shift) * exp(-pow(phase, 2.0) * var);
+    xyz.x += 9.7470e-14 * sqrt(2.0 * PI * 4.5282e+09) * cos(2.2399e+06 * phase + shift[0]) * exp(-4.5282e+09 * pow(phase, 2.0));
+    xyz /= vec3(1.0685e-07);
+
+    const mat3 XYZ_TO_REC709 = mat3(
+        3.2404542, -0.9692660,  0.0556434,
+       -1.5371385,  1.8760108, -0.2040259,
+       -0.4985314,  0.0415560,  1.0572252
+    );
+
+    return XYZ_TO_REC709 * xyz;
+}
+
+float iridescenceFresnel(float cosTheta, float f0) {
+    float x = clamp(1.0 - cosTheta, 0.0, 1.0);
+    float x2 = x * x;
+    float x5 = x * x2 * x2;
+    return f0 + (1.0 - f0) * x5;
+} 
+
+vec3 iridescenceFresnel(float cosTheta, vec3 f0) {
+    float x = clamp(1.0 - cosTheta, 0.0, 1.0);
+    float x2 = x * x;
+    float x5 = x * x2 * x2; 
+    return f0 + (vec3(1.0) - f0) * x5;
+}
+
+vec3 calcIridescence(float outsideIor, float cosTheta, vec3 base_f0) {
+
+    float iridescenceIor = mix(outsideIor, material_iridescenceRefractionIndex, smoothstep(0.0, 0.03, dIridescenceThickness));
+    float sinTheta2Sq = pow(outsideIor / iridescenceIor, 2.0) * (1.0 - pow(cosTheta, 2.0));
+    float cosTheta2Sq = 1.0 - sinTheta2Sq;
+
+    if (cosTheta2Sq < 0.0) {
+        return vec3(1.0);
+    }
+
+    float cosTheta2 = sqrt(cosTheta2Sq);
+
+    float r0 = iridescence_iorToFresnel(iridescenceIor, outsideIor);
+    float r12 = iridescenceFresnel(cosTheta, r0);
+    float r21 = r12;
+    float t121 = 1.0 - r12;
+
+    float phi12 = iridescenceIor < outsideIor ? PI : 0.0;
+    float phi21 = PI - phi12;
+
+    vec3 baseIor = iridescence_fresnelToIor(base_f0 + vec3(0.0001));
+    vec3 r1 = iridescence_iorToFresnel(baseIor, iridescenceIor);
+    vec3 r23 = iridescenceFresnel(cosTheta2, r1);
+
+    vec3 phi23 = vec3(0.0);
+    if (baseIor[0] < iridescenceIor) phi23[0] = PI;
+    if (baseIor[1] < iridescenceIor) phi23[1] = PI;
+    if (baseIor[2] < iridescenceIor) phi23[2] = PI;
+    float opd = 2.0 * iridescenceIor * dIridescenceThickness * cosTheta2;
+    vec3 phi = vec3(phi21) + phi23; 
+
+    vec3 r123Sq = clamp(r12 * r23, 1e-5, 0.9999);
+    vec3 r123 = sqrt(r123Sq);
+    vec3 rs = pow(t121, 2.0) * r23 / (1.0 - r123Sq);
+
+    vec3 c0 = r12 + rs;
+    vec3 i = c0;
+
+    vec3 cm = rs - t121;
+    for (int m = 1; m <= 2; m++) {
+        cm *= r123;
+        vec3 sm = 2.0 * iridescence_sensitivity(float(m) * opd, float(m) * phi);
+        i += cm * sm;
+    }
+    return max(i, vec3(0.0));
+}
+
+vec3 calcIridescenceF0(vec3 iridescence, float cosTheta) {
+    float x = clamp(1.0 - cosTheta, 0.0, 1.0);
+    float x5 = clamp(pow(x, 5.0), 0.0, 1.0);
+    return (iridescence - x5) / (1.0 - x5);
+}
+
+void getIridescence(float cosTheta) {
+    dIridescenceFresnel = calcIridescence(1.0, cosTheta, dSpecularity);
+}
+`;

--- a/src/graphics/program-lib/chunks/standard/frag/iridescence.js
+++ b/src/graphics/program-lib/chunks/standard/frag/iridescence.js
@@ -1,0 +1,23 @@
+export default /* glsl */`
+#ifdef MAPFLOAT
+uniform float material_iridescence;
+#endif
+
+#ifdef MAPTEXTURE
+uniform sampler2D texture_iridescenceMap;
+#endif
+
+void getIridescence() {
+    float iridescence = 1.0;
+
+    #ifdef MAPFLOAT
+    iridescence *= material_iridescence;
+    #endif
+
+    #ifdef MAPTEXTURE
+    iridescence *= texture2DBias(texture_iridescenceMap, $UV, textureBias).$CH;
+    #endif
+
+    dIridescence = iridescence; 
+}
+`;

--- a/src/graphics/program-lib/chunks/standard/frag/iridescenceThickness.js
+++ b/src/graphics/program-lib/chunks/standard/frag/iridescenceThickness.js
@@ -1,0 +1,20 @@
+export default /* glsl */`
+uniform float material_iridescenceThicknessMax;
+
+#ifdef MAPTEXTURE
+uniform sampler2D texture_iridescenceThicknessMap;
+uniform float material_iridescenceThicknessMin;
+#endif
+
+void getIridescenceThickness() {
+
+    #ifdef MAPTEXTURE
+    float blend = texture2DBias(texture_iridescenceThicknessMap, $UV, textureBias).$CH;
+    float iridescenceThickness = mix(material_iridescenceThicknessMin, material_iridescenceThicknessMax, blend);
+    #else
+    float iridescenceThickness = material_iridescenceThicknessMax;
+    #endif
+
+    dIridescenceThickness = iridescenceThickness; 
+}
+`;

--- a/src/graphics/program-lib/programs/lit-shader.js
+++ b/src/graphics/program-lib/programs/lit-shader.js
@@ -585,6 +585,10 @@ class LitShader {
             if (options.sheen) {
                 this.defines.push("LIT_SHEEN");
             }
+
+            if (options.iridescence) {
+                this.defines.push("LIT_IRIDESCENCE");
+            }
         }
 
         // FRAGMENT SHADER INPUTS: UNIFORMS
@@ -743,6 +747,10 @@ class LitShader {
 
             if (options.fresnelModel === FRESNEL_SCHLICK) {
                 code += chunks.fresnelSchlickPS;
+            }
+
+            if (options.iridescence) {
+                code += chunks.iridescenceDiffractionPS;
             }
         }
 
@@ -992,9 +1000,12 @@ class LitShader {
         }
 
         if ((this.lighting && options.useSpecular) || this.reflections) {
-
             if (options.useMetalness) {
                 code += "    getMetalnessModulate();\n";
+            }
+
+            if (options.iridescence) {
+                code += "    getIridescence(saturate(dot(dViewDirW, dNormalW)));\n";
             }
         }
 

--- a/src/graphics/program-lib/programs/standard.js
+++ b/src/graphics/program-lib/programs/standard.js
@@ -349,6 +349,17 @@ const standard = {
                 func.append("getThickness();");
             }
 
+            if (options.iridescence) {
+                decl.append("vec3 dIridescenceFresnel;");
+                decl.append("float dIridescence;");
+                code.append(this._addMap("iridescence", "iridescencePS", options, litShader.chunks));
+                func.append("getIridescence();");
+
+                decl.append("float dIridescenceThickness;");
+                code.append(this._addMap("iridescenceThickness", "iridescenceThicknessPS", options, litShader.chunks));
+                func.append("getIridescenceThickness();");
+            }
+
             // specularity & glossiness
             if ((litShader.lighting && options.useSpecular) || litShader.reflections) {
                 decl.append("vec3 dSpecularity;");

--- a/src/resources/parser/glb-parser.js
+++ b/src/resources/parser/glb-parser.js
@@ -1249,6 +1249,7 @@ const extensionEmissiveStrength = function (data, material, textures) {
 };
 
 const extensionIridescence = function (data, material, textures) {
+    material.useIridescence = true;
     if (data.hasOwnProperty('iridescenceFactor')) {
         material.iridescence = data.iridescenceFactor;
     }
@@ -1439,7 +1440,7 @@ const createMaterial = function (gltfMaterial, textures, flipV) {
         "KHR_materials_clearcoat": extensionClearCoat,
         "KHR_materials_emissive_strength": extensionEmissiveStrength,
         "KHR_materials_ior": extensionIor,
-        "KHR_material_iridescence": extensionIridescence,
+        "KHR_materials_iridescence": extensionIridescence,
         "KHR_materials_pbrSpecularGlossiness": extensionPbrSpecGlossiness,
         "KHR_materials_sheen": extensionSheen,
         "KHR_materials_specular": extensionSpecular,

--- a/src/resources/parser/glb-parser.js
+++ b/src/resources/parser/glb-parser.js
@@ -1248,6 +1248,32 @@ const extensionEmissiveStrength = function (data, material, textures) {
     }
 };
 
+const extensionIridescence = function (data, material, textures) {
+    if (data.hasOwnProperty('iridescenceFactor')) {
+        material.iridescence = data.iridescenceFactor;
+    }
+    if (data.hasOwnProperty('iridescenceTexture')) {
+        material.iridescenceMapChannel = 'r';
+        material.iridescenceMap = textures[data.iridescenceTexture.index];
+        extractTextureTransform(data.iridescenceTexture, material, ['iridescence']);
+
+    }
+    if (data.hasOwnProperty('iridescenceIor')) {
+        material.iridescenceRefractionIndex = data.iridescenceIor;
+    }
+    if (data.hasOwnProperty('iridescenceThicknessMinimum')) {
+        material.iridescenceThicknessMin = data.iridescenceThicknessMinimum;
+    }
+    if (data.hasOwnProperty('iridescenceThicknessMaximum')) {
+        material.iridescenceThicknessMax = data.iridescenceThicknessMaximum;
+    }
+    if (data.hasOwnProperty('iridescenceThicknessTexture')) {
+        material.iridescenceThicknessMapChannel = 'g';
+        material.iridescenceThicknessMap = textures[data.iridescenceThicknessTexture.index];
+        extractTextureTransform(data.iridescenceThicknessTexture, material, ['iridescenceThickness']);
+    }
+};
+
 const createMaterial = function (gltfMaterial, textures, flipV) {
     // TODO: integrate these shader chunks into the native engine
     const glossChunk = `
@@ -1413,6 +1439,7 @@ const createMaterial = function (gltfMaterial, textures, flipV) {
         "KHR_materials_clearcoat": extensionClearCoat,
         "KHR_materials_emissive_strength": extensionEmissiveStrength,
         "KHR_materials_ior": extensionIor,
+        "KHR_material_iridescence": extensionIridescence,
         "KHR_materials_pbrSpecularGlossiness": extensionPbrSpecGlossiness,
         "KHR_materials_sheen": extensionSheen,
         "KHR_materials_specular": extensionSpecular,

--- a/src/scene/materials/standard-material-options-builder.js
+++ b/src/scene/materials/standard-material-options-builder.js
@@ -190,6 +190,9 @@ class StandardMaterialOptionsBuilder {
         options.clearCoatGlossiness = !!stdMat.clearCoatGlossiness;
         options.clearCoatGlossTint = (stdMat.clearCoatGlossiness !== 1.0) ? 1 : 0;
 
+        options.iridescence = stdMat.useIridescence && stdMat.iridescence !== 0.0;
+        options.iridescenceTint = stdMat.iridescence !== 1.0 ? 1 : 0;
+
         options.sheen = stdMat.useSheen;
         options.sheenTint = (stdMat.useSheen && notWhite(stdMat.sheen)) ? 2 : 0;
         options.sheenGlossinessTint = 1;

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -1117,6 +1117,11 @@ function _defineMaterialProps() {
     _defineFloat('clearCoatBumpiness', 1);
     _defineFloat('aoUvSet', 0, null); // legacy
 
+    _defineFloat('iridescence', 0);
+    _defineFloat('iridescenceRefractionIndex', 1.0 / 1.5);
+    _defineFloat('iridescenceThicknessMin', 0);
+    _defineFloat('iridescenceThicknessMax', 0);
+
     _defineObject('ambientSH');
 
     _defineObject('cubeMapProjectionBox', (material, device, scene) => {
@@ -1197,6 +1202,9 @@ function _defineMaterialProps() {
     _defineTex2D('clearCoatNormal', 0, -1, '', false);
     _defineTex2D('sheen', 0, 3, '', true);
     _defineTex2D('sheenGloss', 0, 1, '', true);
+
+    _defineTex2D('iridescence', 0, 1, '', true);
+    _defineTex2D('iridescenceThickness', 0, 1, '', true);
 
     _defineObject('cubeMap');
     _defineObject('sphereMap');

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -725,6 +725,13 @@ class StandardMaterial extends Material {
             this._setParameter('material_invAttenuationDistance', this.attenuationDistance === 0 ? 0 : 1.0 / this.attenuationDistance);
         }
 
+        if (this.useIridescence) {
+            this._setParameter('material_iridescence', this.iridescence);
+            this._setParameter('material_iridescenceRefractionIndex', this.iridescenceRefractionIndex);
+            this._setParameter('material_iridescenceThicknessMin', this.iridescenceThicknessMin);
+            this._setParameter('material_iridescenceThicknessMax', this.iridescenceThicknessMax);
+        }
+
         this._setParameter('material_opacity', this.opacity);
 
         if (this.opacityFadesSpecular === false) {
@@ -1180,6 +1187,7 @@ function _defineMaterialProps() {
     _defineFlag('twoSidedLighting', false);
     _defineFlag('nineSlicedMode', undefined); // NOTE: this used to be SPRITE_RENDERMODE_SLICED but was undefined pre-Rollup
     _defineFlag('msdfTextAttribute', false);
+    _defineFlag('useIridescence', false);
 
     _defineTex2D('diffuse', 0, 3, '', true);
     _defineTex2D('specular', 0, 3, '', true);


### PR DESCRIPTION
### Description
Add support for iridescent materials as well as the KHR_materials_iridescence extension. Iridescence is a fresnel effect which causes wavelength interference, thus altering the reflected colour of the surface. It's modelled as a film layer on the base material, meaning it's applied underneath both sheen and clear coat. 

Fixes #4564.

Iridescent metal spheres:
![image](https://user-images.githubusercontent.com/107400752/189347776-c84a46e3-8c48-4261-9b8f-c544df0eeeb4.png)

Iridescent dielectric spheres:
![image](https://user-images.githubusercontent.com/107400752/189347829-d2a63545-8441-48f3-b3c8-1a4687951a70.png)

Iridescent transparent material:
https://user-images.githubusercontent.com/107400752/189347966-78cf1aab-c3f4-4334-b1b4-13b60f6075f4.mp4


