### PR TITLE
Fix vector subtraction comments

### DIFF
--- a/src/math/vec2.js
+++ b/src/math/vec2.js
@@ -480,7 +480,7 @@ class Vec2 {
     /**
      * Subtracts a 2-dimensional vector from another in place.
      *
-     * @param {Vec2} rhs - The vector to add to the specified vector.
+     * @param {Vec2} rhs - The vector to subtract from the specified vector.
      * @returns {Vec2} Self for chaining.
      * @example
      * var a = new pc.Vec2(10, 10);
@@ -501,8 +501,8 @@ class Vec2 {
     /**
      * Subtracts two 2-dimensional vectors from one another and returns the result.
      *
-     * @param {Vec2} lhs - The first vector operand for the addition.
-     * @param {Vec2} rhs - The second vector operand for the addition.
+     * @param {Vec2} lhs - The first vector operand for the subtraction.
+     * @param {Vec2} rhs - The second vector operand for the subtraction.
      * @returns {Vec2} Self for chaining.
      * @example
      * var a = new pc.Vec2(10, 10);

--- a/src/math/vec3.js
+++ b/src/math/vec3.js
@@ -543,7 +543,7 @@ class Vec3 {
     /**
      * Subtracts a 3-dimensional vector from another in place.
      *
-     * @param {Vec3} rhs - The vector to add to the specified vector.
+     * @param {Vec3} rhs - The vector to subtract from the specified vector.
      * @returns {Vec3} Self for chaining.
      * @example
      * var a = new pc.Vec3(10, 10, 10);
@@ -565,8 +565,8 @@ class Vec3 {
     /**
      * Subtracts two 3-dimensional vectors from one another and returns the result.
      *
-     * @param {Vec3} lhs - The first vector operand for the addition.
-     * @param {Vec3} rhs - The second vector operand for the addition.
+     * @param {Vec3} lhs - The first vector operand for the subtraction.
+     * @param {Vec3} rhs - The second vector operand for the subtraction.
      * @returns {Vec3} Self for chaining.
      * @example
      * var a = new pc.Vec3(10, 10, 10);


### PR DESCRIPTION
# Fixed
- Replaced incorrect mentions of addition for subtraction in vector subtraction methods (sub, sub2) for 'vec2' class.
- Replaced incorrect mentions of addition for subtraction in vector subtraction methods (sub, sub2) for 'vec3' class.