### PR TITLE
Unset deleted render target

### DIFF
--- a/src/graphics/render-target.js
+++ b/src/graphics/render-target.js
@@ -163,6 +163,10 @@ class RenderTarget {
                 device.targets.splice(idx, 1);
             }
 
+            if (device.renderTarget === this) {
+                device.setRenderTarget(null);
+            }
+
             this.destroyFrameBuffers();
         }
     }


### PR DESCRIPTION
Unset the render target on the device after it has being destroyed.

I encountered a destroyed render target being set on the device again (because drawQuadWithShader restores the previous render target), resulting in an FRAMEBUFFER_INCOMPLETE_ATTACHMENT error.
