### PR TITLE
Clear coat fresnel fix

### DIFF
--- a/src/graphics/program-lib/chunks/lit/frag/combine.js
+++ b/src/graphics/program-lib/chunks/lit/frag/combine.js
@@ -17,8 +17,8 @@ vec3 combineColor() {
     ret = ret * sheenScaling + sSpecularLight + sReflection.rgb * sReflection.a;
 #endif
 #ifdef LIT_CLEARCOAT
-    float clearCoatScaling = 1.0 - ccFresnel * ccReflection.a;
-    ret = ret * clearCoatScaling + ccSpecularLight + ccReflection.rgb * ccReflection.a;
+    float clearCoatScaling = 1.0 - ccFresnel * ccSpecularity * max(max(ccReflection.r, ccReflection.g), ccReflection.b);
+    ret = ret * clearCoatScaling + (ccSpecularLight + ccReflection.rgb) * ccSpecularity;
 #endif
 
     return ret;

--- a/src/graphics/program-lib/chunks/lit/frag/combine.js
+++ b/src/graphics/program-lib/chunks/lit/frag/combine.js
@@ -17,7 +17,7 @@ vec3 combineColor() {
     ret = ret * sheenScaling + sSpecularLight + sReflection.rgb * sReflection.a;
 #endif
 #ifdef LIT_CLEARCOAT
-    float clearCoatScaling = 1.0 - ccFresnel * ccSpecularity * max(max(ccReflection.r, ccReflection.g), ccReflection.b);
+    float clearCoatScaling = 1.0 - ccFresnel * ccSpecularity;
     ret = ret * clearCoatScaling + (ccSpecularLight + ccReflection.rgb) * ccSpecularity;
 #endif
 

--- a/src/graphics/program-lib/chunks/lit/frag/fresnelSchlick.js
+++ b/src/graphics/program-lib/chunks/lit/frag/fresnelSchlick.js
@@ -10,4 +10,9 @@ vec3 getFresnel(float cosTheta, vec3 f0) {
         return ret;
     #endif    
 }
+
+float getFresnelCC(float cosTheta) {
+    float fresnel = pow(1.0 - max(cosTheta, 0.0), 5.0);
+    return 0.04 + (1.0 - 0.04) * fresnel;
+}
 `;

--- a/src/graphics/program-lib/chunks/lit/frag/reflectionCC.js
+++ b/src/graphics/program-lib/chunks/lit/frag/reflectionCC.js
@@ -1,9 +1,7 @@
 export default /* glsl */`
 #ifdef LIT_CLEARCOAT
-uniform float material_clearCoatReflectivity;
-
 void addReflectionCC() {
-    ccReflection += vec4(calcReflection(ccReflDirW, ccGlossiness), material_clearCoatReflectivity);
+    ccReflection += calcReflection(ccReflDirW, ccGlossiness);
 }
 #endif
 `;

--- a/src/graphics/program-lib/chunks/lit/frag/start.js
+++ b/src/graphics/program-lib/chunks/lit/frag/start.js
@@ -4,6 +4,6 @@ void main(void) {
 
     #ifdef LIT_CLEARCOAT
     ccSpecularLight = vec3(0);
-    ccReflection = vec4(0);
+    ccReflection = vec3(0);
     #endif
 `;

--- a/src/graphics/program-lib/programs/lit-shader.js
+++ b/src/graphics/program-lib/programs/lit-shader.js
@@ -1038,8 +1038,8 @@ class LitShader {
                 if (options.clearCoat) {
                     code += "    addReflectionCC();\n";
                     if (options.fresnelModel > 0) {
-                        code += "    ccFresnel = dot(dViewDirW, ccNormalW);\n";
-                        code += "    ccReflection.rgb *= getFresnel(ccFresnel, vec3(ccSpecularity));\n";
+                        code += "    ccFresnel = getFresnelCC(dot(dViewDirW, ccNormalW));\n";
+                        code += "    ccReflection.rgb *= ccFresnel;\n";
                     }  else {
                         code += "    ccFresnel = 0.0;\n";
                         code += "    ccReflection.rgb *= ccSpecularity;\n";

--- a/src/graphics/program-lib/programs/lit-shader.js
+++ b/src/graphics/program-lib/programs/lit-shader.js
@@ -1311,7 +1311,7 @@ class LitShader {
         if (options.opacityFadesSpecular === false) {
             if (options.blendType === BLEND_NORMAL || options.blendType === BLEND_PREMULTIPLIED) {
                 code += "float specLum = dot((dSpecularLight + dReflection.rgb * dReflection.a), vec3( 0.2126, 0.7152, 0.0722 ));\n";
-                code += "#ifdef LIT_CLEARCOAT\n specLum += dot(ccSpecularLight * ccSpecularity + ccReflection.rgb * ccReflection.a * ccSpecularity, vec3( 0.2126, 0.7152, 0.0722 ));\n#endif\n";
+                code += "#ifdef LIT_CLEARCOAT\n specLum += dot(ccSpecularLight * ccSpecularity + ccReflection.rgb * ccSpecularity, vec3( 0.2126, 0.7152, 0.0722 ));\n#endif\n";
                 code += "dAlpha = clamp(dAlpha + gammaCorrectInput(specLum), 0.0, 1.0);\n";
             }
             code += "dAlpha *= material_alphaFade;\n";
@@ -1369,7 +1369,7 @@ class LitShader {
         if (code.includes("dAtten3")) structCode += "vec3 dAtten3;\n";
         if (code.includes("dMsdf")) structCode += "vec4 dMsdf;\n";
         if (code.includes("ccFresnel")) structCode += "float ccFresnel;\n";
-        if (code.includes("ccReflection")) structCode += "vec4 ccReflection;\n";
+        if (code.includes("ccReflection")) structCode += "vec3 ccReflection;\n";
         if (code.includes("ccReflDirW")) structCode += "vec3 ccReflDirW;\n";
         if (code.includes("ccSpecularLight")) structCode += "vec3 ccSpecularLight;\n";
         if (code.includes("ccSpecularityNoFres")) structCode += "float ccSpecularityNoFres;\n";

--- a/src/scene/materials/standard-material-options-builder.js
+++ b/src/scene/materials/standard-material-options-builder.js
@@ -131,7 +131,7 @@ class StandardMaterialOptionsBuilder {
                              (stdMat.specularTint || (!stdMat.specularMap && !stdMat.specularVertexColor)) &&
                              notWhite(stdMat.specular);
 
-        const specularityFactorTint = useSpecular && stdMat.useMetalness &&
+        const specularityFactorTint = useSpecular && stdMat.useMetalnessSpecularColor &&
                                       (stdMat.specularityFactorTint || (stdMat.specularityFactor < 1 && !stdMat.specularityFactorMap));
 
         const emissiveTintColor = !stdMat.emissiveMap || (notWhite(stdMat.emissive) && stdMat.emissiveTint);
@@ -145,7 +145,7 @@ class StandardMaterialOptionsBuilder {
         options.diffuseTint = diffuseTint ? 2 : 0;
         options.specularTint = specularTint ? 2 : 0;
         options.specularityFactorTint = specularityFactorTint ? 1 : 0;
-        options.useSpecularityFactor = specularityFactorTint || !!stdMat.specularityFactorMap;
+        options.useSpecularityFactor = (specularityFactorTint || !!stdMat.specularityFactorMap) && stdMat.useMetalnessSpecularColor;
         options.useSpecularColor = useSpecularColor;
         options.metalnessTint = (stdMat.useMetalness && stdMat.metalness < 1) ? 1 : 0;
         options.glossTint = 1;

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -701,7 +701,6 @@ class StandardMaterial extends Material {
         if (this.clearCoat > 0) {
             this._setParameter('material_clearCoat', this.clearCoat);
             this._setParameter('material_clearCoatGlossiness', this.clearCoatGlossiness);
-            this._setParameter('material_clearCoatReflectivity', this.clearCoat); // for now don't separate this
             this._setParameter('material_clearCoatBumpiness', this.clearCoatBumpiness);
         }
 


### PR DESCRIPTION
### Description
Fixes issues related to clear coat and specularity factor. Clear coat should use a white fresnel and weight that against the other layers.

Specularity factor should only be used in case specular color with metalness is enabled. 

Actually, we supply the reflectivity factor twice and it's saved in both ccReflections.a and ccSpecularity, as the material_clearCoat and material_clearCoatReflectivity is the same value, so in the combine we can get away with just using ccSpecularity. 

Fixes #4459.