### PR TITLE
Additional flexibility for Morph targets

### DIFF
--- a/src/resources/container.js
+++ b/src/resources/container.js
@@ -139,6 +139,10 @@ class ContainerResource {
  * |---------------------------------------------------------------------|
  * ```
  *
+ * Additional options that can be passed for glTF files:
+ * [options.morphPreserveData] - When true, the morph target keeps its data passed using the options,
+ * allowing the clone operation.
+ *
  * For example, to receive a texture preprocess callback:
  *
  * ```javascript

--- a/src/resources/parser/glb-parser.js
+++ b/src/resources/parser/glb-parser.js
@@ -756,7 +756,7 @@ const createSkin = function (device, gltfSkin, accessors, bufferViews, nodes, gl
 const tempMat = new Mat4();
 const tempVec = new Vec3();
 
-const createMesh = function (device, gltfMesh, accessors, bufferViews, callback, flipV, vertexBufferDict, meshVariants, meshDefaultMaterials) {
+const createMesh = function (device, gltfMesh, accessors, bufferViews, callback, flipV, vertexBufferDict, meshVariants, meshDefaultMaterials, assetOptions) {
     const meshes = [];
 
     gltfMesh.primitives.forEach(function (primitive) {
@@ -940,6 +940,7 @@ const createMesh = function (device, gltfMesh, accessors, bufferViews, callback,
                         options.defaultWeight = gltfMesh.weights[index];
                     }
 
+                    options.preserveData = assetOptions.morphPreserveData;
                     targets.push(new MorphTarget(options));
                 });
 
@@ -1801,7 +1802,7 @@ const createSkins = function (device, gltf, nodes, bufferViews) {
     });
 };
 
-const createMeshes = function (device, gltf, bufferViews, callback, flipV, meshVariants, meshDefaultMaterials) {
+const createMeshes = function (device, gltf, bufferViews, callback, flipV, meshVariants, meshDefaultMaterials, options) {
     if (!gltf.hasOwnProperty('meshes') || gltf.meshes.length === 0 ||
         !gltf.hasOwnProperty('accessors') || gltf.accessors.length === 0 ||
         !gltf.hasOwnProperty('bufferViews') || gltf.bufferViews.length === 0) {
@@ -1812,7 +1813,7 @@ const createMeshes = function (device, gltf, bufferViews, callback, flipV, meshV
     const vertexBufferDict = {};
 
     return gltf.meshes.map(function (gltfMesh) {
-        return createMesh(device, gltfMesh, gltf.accessors, bufferViews, callback, flipV, vertexBufferDict, meshVariants, meshDefaultMaterials);
+        return createMesh(device, gltfMesh, gltf.accessors, bufferViews, callback, flipV, vertexBufferDict, meshVariants, meshDefaultMaterials, options);
     });
 };
 
@@ -2061,7 +2062,7 @@ const createResources = function (device, gltf, bufferViews, textureAssets, opti
     const variants = createVariants(gltf);
     const meshVariants = {};
     const meshDefaultMaterials = {};
-    const meshes = createMeshes(device, gltf, bufferViews, callback, flipV, meshVariants, meshDefaultMaterials);
+    const meshes = createMeshes(device, gltf, bufferViews, callback, flipV, meshVariants, meshDefaultMaterials, options);
     const skins = createSkins(device, gltf, nodes, bufferViews);
 
     // create renders to wrap meshes

--- a/src/scene/mesh-instance.js
+++ b/src/scene/mesh-instance.js
@@ -541,11 +541,15 @@ class MeshInstance {
      */
     set skinInstance(val) {
         this._skinInstance = val;
-        this._shaderDefs = val ? (this._shaderDefs | SHADERDEF_SKIN) : (this._shaderDefs & ~SHADERDEF_SKIN);
-        for (let i = 0; i < this._shader.length; i++) {
-            this._shader[i] = null;
-        }
 
+        let shaderDefs = this._shaderDefs;
+        shaderDefs = val ? (shaderDefs | SHADERDEF_SKIN) : (shaderDefs & ~SHADERDEF_SKIN);
+
+        // if shaderDefs have changed
+        if (shaderDefs !== this._shaderDefs) {
+            this._shaderDefs = shaderDefs;
+            this.clearShaders();
+        }
         this._setupSkinUpdate();
     }
 
@@ -559,16 +563,26 @@ class MeshInstance {
      * @type {MorphInstance}
      */
     set morphInstance(val) {
-        this._morphInstance = val;
-        if (this._morphInstance) {
-            this._morphInstance.meshInstance = this;
-        }
 
-        this._shaderDefs = (val && val.morph.useTextureMorph) ? (this._shaderDefs | SHADERDEF_MORPH_TEXTURE_BASED) : (this._shaderDefs & ~SHADERDEF_MORPH_TEXTURE_BASED);
-        this._shaderDefs = (val && val.morph.morphPositions) ? (this._shaderDefs | SHADERDEF_MORPH_POSITION) : (this._shaderDefs & ~SHADERDEF_MORPH_POSITION);
-        this._shaderDefs = (val && val.morph.morphNormals) ? (this._shaderDefs | SHADERDEF_MORPH_NORMAL) : (this._shaderDefs & ~SHADERDEF_MORPH_NORMAL);
-        for (let i = 0; i < this._shader.length; i++) {
-            this._shader[i] = null;
+        // release existing
+        this._morphInstance?.destroy();
+
+
+console.log("assign morph instance", val);
+
+
+        // assign new
+        this._morphInstance = val;
+
+        let shaderDefs = this._shaderDefs;
+        shaderDefs = (val && val.morph.useTextureMorph) ? (shaderDefs | SHADERDEF_MORPH_TEXTURE_BASED) : (shaderDefs & ~SHADERDEF_MORPH_TEXTURE_BASED);
+        shaderDefs = (val && val.morph.morphPositions) ? (shaderDefs | SHADERDEF_MORPH_POSITION) : (shaderDefs & ~SHADERDEF_MORPH_POSITION);
+        shaderDefs = (val && val.morph.morphNormals) ? (shaderDefs | SHADERDEF_MORPH_NORMAL) : (shaderDefs & ~SHADERDEF_MORPH_NORMAL);
+
+        // if shaderDefs have changed
+        if (shaderDefs !== this._shaderDefs) {
+            this._shaderDefs = shaderDefs;
+            this.clearShaders();
         }
     }
 
@@ -643,17 +657,13 @@ class MeshInstance {
         this.setRealtimeLightmap(MeshInstance.lightmapParamNames[0], null);
         this.setRealtimeLightmap(MeshInstance.lightmapParamNames[1], null);
 
-        if (this._skinInstance) {
-            this._skinInstance.destroy();
-            this._skinInstance = null;
-        }
+        this._skinInstance?.destroy();
+        this._skinInstance = null;
 
-        if (this.morphInstance) {
-            this.morphInstance.destroy();
-            this.morphInstance = null;
-        }
+        this.morphInstance?.destroy();
+        this.morphInstance = null;
 
-        this.destroyBindGroups();
+        this.clearShaders();
 
         // make sure material clears references to this meshInstance
         this.material = null;

--- a/src/scene/mesh-instance.js
+++ b/src/scene/mesh-instance.js
@@ -567,10 +567,6 @@ class MeshInstance {
         // release existing
         this._morphInstance?.destroy();
 
-
-console.log("assign morph instance", val);
-
-
         // assign new
         this._morphInstance = val;
 

--- a/src/scene/morph-instance.js
+++ b/src/scene/morph-instance.js
@@ -8,7 +8,6 @@ import { Debug } from '../core/debug.js';
 import { Morph } from './morph.js';
 
 /** @typedef {import('../graphics/shader.js').Shader} Shader */
-/** @typedef {import('./mesh-instance.js').MeshInstance} MeshInstance */
 
 // vertex shader used to add morph targets from textures into render target
 const textureMorphVertexShader = `
@@ -39,13 +38,6 @@ class MorphInstance {
         this.morph = morph;
         morph.incRefCount();
         this.device = morph.device;
-
-        /**
-         * The mesh instance this morph instance controls the morphing of.
-         *
-         * @type {MeshInstance}
-         */
-        this.meshInstance = null;
 
         // weights
         this._weights = [];
@@ -126,8 +118,6 @@ class MorphInstance {
      */
     destroy() {
 
-        this.meshInstance = null;
-
         // don't destroy shader as it's in the cache and can be used by other materials
         this.shader = null;
 
@@ -172,8 +162,7 @@ class MorphInstance {
      * @returns {MorphInstance} A clone of the specified MorphInstance.
      */
     clone() {
-        const clone = new MorphInstance(this.morph);
-        return clone;
+        return new MorphInstance(this.morph);
     }
 
     _getWeightIndex(key) {

--- a/src/scene/morph-target.js
+++ b/src/scene/morph-target.js
@@ -12,6 +12,11 @@ import { VertexFormat } from '../graphics/vertex-format.js';
  */
 class MorphTarget {
     /**
+     * A used flag. A morph target can be used / owned by the Morph class only one time.
+     */
+    used = false;
+
+    /**
      * Create a new MorphTarget instance.
      *
      * @param {object} options - Object for passing optional arguments.
@@ -27,6 +32,8 @@ class MorphTarget {
      * @param {BoundingBox} [options.aabb] - Bounding box. Will be automatically generated, if
      * undefined.
      * @param {number} [options.defaultWeight] - Default blend weight to use for this morph target.
+     * @param {boolean} [options.preserveData] - When true, the morph target keeps its data passed using the options,
+     * allowing the clone operation.
      */
     constructor(options) {
 
@@ -49,6 +56,21 @@ class MorphTarget {
 
         // store delta positions, used by aabb evaluation
         this.deltaPositions = options.deltaPositions;
+    }
+
+    destroy() {
+
+        this._vertexBufferPositions?.destroy();
+        this._vertexBufferPositions = null;
+
+        this._vertexBufferNormals?.destroy();
+        this._vertexBufferNormals = null;
+
+        this.texturePositions?.destroy();
+        this.texturePositions = null;
+
+        this.textureNormals?.destroy();
+        this.textureNormals = null;
     }
 
     /**
@@ -77,10 +99,26 @@ class MorphTarget {
         return !!this._vertexBufferNormals || !!this.textureNormals;
     }
 
+    /**
+     * Returns an identical copy of the specified morph target. This can only be used if the morph target
+     * was created with options.preserveData set to true.
+     *
+     * @returns {MorphTarget} A morph target instance containing the result of the cloning.
+     */
+    clone() {
+        Debug.assert(this.options, 'MorphTarget cannot be cloned, was it created with a preserveData option?');
+        return new MorphTarget(this.options);
+    }
+
     _postInit() {
 
         // release original data
-        this.options = null;
+        if (!this.options.preserveData) {
+            this.options = null;
+        }
+
+        // mark it as used
+        this.used = true;
     }
 
     _initVertexBuffers(graphicsDevice) {
@@ -109,28 +147,6 @@ class MorphTarget {
 
     _setTexture(name, texture) {
         this[name] = texture;
-    }
-
-    destroy() {
-
-        if (this._vertexBufferPositions) {
-            this._vertexBufferPositions.destroy();
-            this._vertexBufferPositions = null;
-        }
-
-        if (this._vertexBufferNormals) {
-            this._vertexBufferNormals.destroy();
-            this._vertexBufferNormals = null;
-        }
-
-        if (this.texturePositions) {
-            this.texturePositions.destroy();
-            this.texturePositions = null;
-        }
-        if (this.textureNormals) {
-            this.textureNormals.destroy();
-            this.textureNormals = null;
-        }
     }
 }
 

--- a/src/scene/morph.js
+++ b/src/scene/morph.js
@@ -1,3 +1,4 @@
+import { Debug } from '../core/debug.js';
 import { RefCountedObject } from '../core/ref-counted-object.js';
 import { Vec3 } from '../math/vec3.js';
 import { FloatPacking } from '../math/float-packing.js';
@@ -29,8 +30,11 @@ class Morph extends RefCountedObject {
     constructor(targets, graphicsDevice) {
         super();
 
+        // validation
+        targets.forEach(target => Debug.assert(!target.used, 'The target specified has already been used to create a Morph, use its clone instead.'));
+
         this.device = graphicsDevice || getApplication().graphicsDevice;
-        this._targets = targets;
+        this._targets = targets.slice();
 
         // default to texture based morphing if available
         if (this.device.supportsMorphTargetTexturesCore) {
@@ -212,10 +216,8 @@ class Morph extends RefCountedObject {
      * Frees video memory allocated by this object.
      */
     destroy() {
-        if (this.vertexBufferIds) {
-            this.vertexBufferIds.destroy();
-            this.vertexBufferIds = null;
-        }
+        this.vertexBufferIds?.destroy();
+        this.vertexBufferIds = null;
 
         for (let i = 0; i < this._targets.length; i++) {
             this._targets[i].destroy();


### PR DESCRIPTION
Added a flexibility to allow morph target sets used by morphing to be created at runtime. The use case:
- load multiple glb models with morph targets / a single glb with many morph targets
- create a list of morph targets from any (compatible) sources, from one of multiple files
- use this new set of morph targets to morph a mesh

In a more specific example, you can load a single glb with a mesh and few basic morph targets, and load additional glb with additional morph targets. From those, create a single list with all of these morph targets, and use them in a single mesh.

example:
```
// the glb assets needs to be loaded with _morphPreserveData_ flag
var asset = new pc.Asset('model', 'container', { url: '/file.glb' }, undefined, {
    morphPreserveData: true
});

// you can create a list of morph targets from multiple sources, using a clone function:
var targets = [target1.clone(), target2.clone()];

// set up the mesh instance to use them
mesh.morph = new pc.Morph(targets, app.graphicsDevice);
meshInstance.morphInstance = new pc.MorphInstance(mesh.morph);
```