### PR TITLE
GLB parser - check for empty curveData path arrays

### DIFF
--- a/src/resources/parser/glb-parser.js
+++ b/src/resources/parser/glb-parser.js
@@ -1626,7 +1626,7 @@ const createAnimation = function (gltfAnimation, animationIndex, gltfAccessors, 
 
         // if this target is a set of quaternion keys, make note of its index so we can perform
         // quaternion-specific processing on it.
-        if (curveData.paths[0].propertyPath[0] === 'localRotation' && curveData.interpolation !== INTERPOLATION_CUBIC) {
+        if (curveData.paths.length > 0 && curveData.paths[0].propertyPath[0] === 'localRotation' && curveData.interpolation !== INTERPOLATION_CUBIC) {
             quatArrays.push(curves[curves.length - 1].output);
         }
     }


### PR DESCRIPTION
Animation curves which contained no paths cause an error when parsing a GLB. The path array size should be checked before it is accessed.

Fixes #4613

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
