### PR TITLE
ElementDragHelper: Fix drag NaN

### DIFF
--- a/src/framework/components/element/component.js
+++ b/src/framework/components/element/component.js
@@ -1021,8 +1021,10 @@ class ElementComponent extends Component {
      * @private
      */
     _setPosition(x, y, z) {
-        if (!this.element.screen)
-            return Entity.prototype.setPosition.call(this, x, y, z);
+        if (!this.element.screen) {
+            Entity.prototype.setPosition.call(this, x, y, z);
+            return;
+        }
 
         if (x instanceof Vec3) {
             position.copy(x);

--- a/src/framework/components/element/component.js
+++ b/src/framework/components/element/component.js
@@ -674,27 +674,33 @@ class ElementComponent extends Component {
      * The position of the pivot of the component relative to its anchor. Each value ranges from 0
      * to 1 where [0,0] is the bottom left and [1,1] is the top right.
      *
-     * @type {Vec2}
+     * @example
+     * pc.app.root.findByName("Inventory").element.pivot = [Math.random() * 0.1, Math.random() * 0.1];
+     * @example
+     * pc.app.root.findByName("Inventory").element.pivot = new pc.Vec2(Math.random() * 0.1, Math.random() * 0.1);
+     * 
+     * @type {Vec2 | number[]}
      */
     set pivot(value) {
-        const prevX = this._pivot.x;
-        const prevY = this._pivot.y;
+        const { _pivot, _margin } = this;
+        const prevX = _pivot.x;
+        const prevY = _pivot.y;
 
         if (value instanceof Vec2) {
-            this._pivot.set(value.x, value.y);
+            _pivot.copy(value);
         } else {
-            this._pivot.set(value[0], value[1]);
+            _pivot.set(...value);
         }
 
-        const mx = this._margin.x + this._margin.z;
-        const dx = this._pivot.x - prevX;
-        this._margin.x += mx * dx;
-        this._margin.z -= mx * dx;
+        const mx = _margin.x + _margin.z;
+        const dx = _pivot.x - prevX;
+        _margin.x += mx * dx;
+        _margin.z -= mx * dx;
 
-        const my = this._margin.y + this._margin.w;
-        const dy = this._pivot.y - prevY;
-        this._margin.y += my * dy;
-        this._margin.w -= my * dy;
+        const my = _margin.y + _margin.w;
+        const dy = _pivot.y - prevY;
+        _margin.y += my * dy;
+        _margin.w -= my * dy;
 
         this._anchorDirty = true;
         this._cornersDirty = true;
@@ -706,7 +712,7 @@ class ElementComponent extends Component {
         // in order for them to update their position
         this._flagChildrenAsDirty();
 
-        this.fire('set:pivot', this._pivot);
+        this.fire('set:pivot', _pivot);
     }
 
     get pivot() {

--- a/src/framework/components/element/component.js
+++ b/src/framework/components/element/component.js
@@ -1018,7 +1018,7 @@ class ElementComponent extends Component {
      * @param {number|Vec3} x - The x coordinate or Vec3
      * @param {number} y - The y coordinate
      * @param {number} z - The z coordinate
-     * @returns {void}
+     * @private
      */
     _setPosition(x, y, z) {
         if (!this.element.screen)
@@ -1044,6 +1044,7 @@ class ElementComponent extends Component {
      * @param {number|Vec3} x - The x coordinate or Vec3
      * @param {number} y - The y coordinate
      * @param {number} z - The z coordinate
+     * @private
      */
     _setLocalPosition(x, y, z) {
         if (x instanceof Vec3) {
@@ -1595,8 +1596,11 @@ class ElementComponent extends Component {
      * assumes these properties are up to date
      * _margin
      *
-     * @param {boolean} propagateCalculatedWidth - If true, call `_setWidth` instead of `_setCalculatedWidth`
-     * @param {boolean} propagateCalculatedHeight - If true, call `_setHeight` instead of `_setCalculatedHeight`
+     * @param {boolean} propagateCalculatedWidth - If true, call `_setWidth` instead
+     * of `_setCalculatedWidth`
+     * @param {boolean} propagateCalculatedHeight - If true, call `_setHeight` instead
+     * of `_setCalculatedHeight`
+     * @private
      */
     _calculateSize(propagateCalculatedWidth, propagateCalculatedHeight) {
         // can't calculate if local anchors are wrong
@@ -1632,6 +1636,7 @@ class ElementComponent extends Component {
      * Internal set width without updating margin.
      *
      * @param {number} w - The new width.
+     * @private
      */
     _setWidth(w) {
         this._width = w;
@@ -1644,6 +1649,7 @@ class ElementComponent extends Component {
      * Internal set height without updating margin.
      *
      * @param {number} h - The new height.
+     * @private
      */
     _setHeight(h) {
         this._height = h;
@@ -1657,6 +1663,7 @@ class ElementComponent extends Component {
      *
      * @param {number} value - The new calculated width.
      * @param {boolean} updateMargins - Update margins or not.
+     * @private
      */
     _setCalculatedWidth(value, updateMargins) {
         if (Math.abs(value - this._calculatedWidth) <= 1e-4)
@@ -1682,6 +1689,7 @@ class ElementComponent extends Component {
      *
      * @param {number} value - The new calculated height.
      * @param {boolean} updateMargins - Update margins or not.
+     * @private
      */
     _setCalculatedHeight(value, updateMargins) {
         if (Math.abs(value - this._calculatedHeight) <= 1e-4)

--- a/src/framework/components/element/component.js
+++ b/src/framework/components/element/component.js
@@ -1595,8 +1595,8 @@ class ElementComponent extends Component {
      * assumes these properties are up to date
      * _margin
      *
-     * @param {boolean} propagateCalculatedWidth 
-     * @param {boolean} propagateCalculatedHeight 
+     * @param {boolean} propagateCalculatedWidth - If true, call `_setWidth` instead of `_setCalculatedWidth`
+     * @param {boolean} propagateCalculatedHeight - If true, call `_setHeight` instead of `_setCalculatedHeight`
      */
     _calculateSize(propagateCalculatedWidth, propagateCalculatedHeight) {
         // can't calculate if local anchors are wrong

--- a/src/framework/components/element/component.js
+++ b/src/framework/components/element/component.js
@@ -397,13 +397,18 @@ class ElementComponent extends Component {
      * of the anchor are not equal. In that case the component will be resized to cover that entire
      * area. e.g. a value of [0, 0, 1, 1] will make the component resize exactly as its parent.
      *
-     * @type {Vec4}
+     * @example
+     * pc.app.root.findByName("Inventory").element.anchor = new pc.Vec4(Math.random() * 0.1, 0, 1, 0);
+     * @example
+     * pc.app.root.findByName("Inventory").element.anchor = [Math.random() * 0.1, 0, 1, 0];
+     * 
+     * @type {Vec4 | number[]}
      */
     set anchor(value) {
         if (value instanceof Vec4) {
-            this._anchor.set(value.x, value.y, value.z, value.w);
+            this._anchor.copy(value);
         } else {
-            this._anchor.set(value[0], value[1], value[2], value[3]);
+            this._anchor.set(...value);
         }
 
         if (!this.entity._parent && !this.screen) {

--- a/src/framework/components/element/component.js
+++ b/src/framework/components/element/component.js
@@ -1593,10 +1593,14 @@ class ElementComponent extends Component {
     }
 
     /**
-     * recalculates
-     * localAnchor, width, height, (local position is updated if anchors are split)
-     * assumes these properties are up to date
-     * _margin
+     * Recalculates these properties:
+     *   - `_localAnchor`
+     *   - `width`
+     *   - `height`
+     *   - Local position is updated if anchors are split
+     *
+     * Assumes these properties are up to date:
+     *   - `_margin`
      *
      * @param {boolean} propagateCalculatedWidth - If true, call `_setWidth` instead
      * of `_setCalculatedWidth`

--- a/src/framework/components/element/component.js
+++ b/src/framework/components/element/component.js
@@ -1563,10 +1563,15 @@ class ElementComponent extends Component {
         this.off();
     }
 
-    // recalculates
-    // localAnchor, width, height, (local position is updated if anchors are split)
-    // assumes these properties are up to date
-    // _margin
+    /**
+     * recalculates
+     * localAnchor, width, height, (local position is updated if anchors are split)
+     * assumes these properties are up to date
+     * _margin
+     * 
+     * @param {boolean} propagateCalculatedWidth 
+     * @param {boolean} propagateCalculatedHeight 
+     */
     _calculateSize(propagateCalculatedWidth, propagateCalculatedHeight) {
         // can't calculate if local anchors are wrong
         if (!this.entity._parent && !this.screen) return;
@@ -1597,7 +1602,11 @@ class ElementComponent extends Component {
         this._sizeDirty = false;
     }
 
-    // internal set width without updating margin
+    /**
+     * Internal set width without updating margin.
+     * 
+     * @param {number} w 
+     */
     _setWidth(w) {
         this._width = w;
         this._setCalculatedWidth(w, false);
@@ -1605,7 +1614,11 @@ class ElementComponent extends Component {
         this.fire('set:width', this._width);
     }
 
-    // internal set height without updating margin
+    /**
+     * Internal set height without updating margin.
+     * 
+     * @param {number} h 
+     */
     _setHeight(h) {
         this._height = h;
         this._setCalculatedHeight(h, false);
@@ -1613,6 +1626,11 @@ class ElementComponent extends Component {
         this.fire('set:height', this._height);
     }
 
+    /**
+     * 
+     * @param {number} value 
+     * @param {boolean} updateMargins 
+     */
     _setCalculatedWidth(value, updateMargins) {
         if (Math.abs(value - this._calculatedWidth) <= 1e-4)
             return;
@@ -1632,6 +1650,12 @@ class ElementComponent extends Component {
         this.fire('resize', this._calculatedWidth, this._calculatedHeight);
     }
 
+    /**
+     * 
+     * @param {number} value 
+     * @param {boolean} updateMargins 
+     * @returns 
+     */
     _setCalculatedHeight(value, updateMargins) {
         if (Math.abs(value - this._calculatedHeight) <= 1e-4)
             return;

--- a/src/framework/components/element/component.js
+++ b/src/framework/components/element/component.js
@@ -401,7 +401,7 @@ class ElementComponent extends Component {
      * pc.app.root.findByName("Inventory").element.anchor = new pc.Vec4(Math.random() * 0.1, 0, 1, 0);
      * @example
      * pc.app.root.findByName("Inventory").element.anchor = [Math.random() * 0.1, 0, 1, 0];
-     * 
+     *
      * @type {Vec4 | number[]}
      */
     set anchor(value) {
@@ -683,7 +683,7 @@ class ElementComponent extends Component {
      * pc.app.root.findByName("Inventory").element.pivot = [Math.random() * 0.1, Math.random() * 0.1];
      * @example
      * pc.app.root.findByName("Inventory").element.pivot = new pc.Vec2(Math.random() * 0.1, Math.random() * 0.1);
-     * 
+     *
      * @type {Vec2 | number[]}
      */
     set pivot(value) {
@@ -1012,6 +1012,14 @@ class ElementComponent extends Component {
         this.entity.setLocalPosition = Entity.prototype.setLocalPosition;
     }
 
+    /**
+     * Patched method for setting the position.
+     *
+     * @param {number|Vec3} x - The x coordinate or Vec3
+     * @param {number} y - The y coordinate
+     * @param {number} z - The z coordinate
+     * @returns {void}
+     */
     _setPosition(x, y, z) {
         if (!this.element.screen)
             return Entity.prototype.setPosition.call(this, x, y, z);
@@ -1030,6 +1038,13 @@ class ElementComponent extends Component {
             this._dirtifyLocal();
     }
 
+    /**
+     * Patched method for setting the local position.
+     *
+     * @param {number|Vec3} x - The x coordinate or Vec3
+     * @param {number} y - The y coordinate
+     * @param {number} z - The z coordinate
+     */
     _setLocalPosition(x, y, z) {
         if (x instanceof Vec3) {
             this.localPosition.copy(x);
@@ -1579,7 +1594,7 @@ class ElementComponent extends Component {
      * localAnchor, width, height, (local position is updated if anchors are split)
      * assumes these properties are up to date
      * _margin
-     * 
+     *
      * @param {boolean} propagateCalculatedWidth 
      * @param {boolean} propagateCalculatedHeight 
      */
@@ -1615,8 +1630,8 @@ class ElementComponent extends Component {
 
     /**
      * Internal set width without updating margin.
-     * 
-     * @param {number} w 
+     *
+     * @param {number} w - The new width.
      */
     _setWidth(w) {
         this._width = w;
@@ -1627,8 +1642,8 @@ class ElementComponent extends Component {
 
     /**
      * Internal set height without updating margin.
-     * 
-     * @param {number} h 
+     *
+     * @param {number} h - The new height.
      */
     _setHeight(h) {
         this._height = h;
@@ -1638,9 +1653,10 @@ class ElementComponent extends Component {
     }
 
     /**
-     * 
-     * @param {number} value 
-     * @param {boolean} updateMargins 
+     * This method sets the calculated width value and optionally updates the margins.
+     *
+     * @param {number} value - The new calculated width.
+     * @param {boolean} updateMargins - Update margins or not.
      */
     _setCalculatedWidth(value, updateMargins) {
         if (Math.abs(value - this._calculatedWidth) <= 1e-4)
@@ -1662,10 +1678,10 @@ class ElementComponent extends Component {
     }
 
     /**
-     * 
-     * @param {number} value 
-     * @param {boolean} updateMargins 
-     * @returns 
+     * This method sets the calculated height value and optionally updates the margins.
+     *
+     * @param {number} value - The new calculated height.
+     * @param {boolean} updateMargins - Update margins or not.
      */
     _setCalculatedHeight(value, updateMargins) {
         if (Math.abs(value - this._calculatedHeight) <= 1e-4)

--- a/src/framework/components/element/component.js
+++ b/src/framework/components/element/component.js
@@ -687,25 +687,25 @@ class ElementComponent extends Component {
      * @type {Vec2 | number[]}
      */
     set pivot(value) {
-        const { _pivot, _margin } = this;
-        const prevX = _pivot.x;
-        const prevY = _pivot.y;
+        const { pivot, margin } = this;
+        const prevX = pivot.x;
+        const prevY = pivot.y;
 
         if (value instanceof Vec2) {
-            _pivot.copy(value);
+            pivot.copy(value);
         } else {
-            _pivot.set(...value);
+            pivot.set(...value);
         }
 
-        const mx = _margin.x + _margin.z;
-        const dx = _pivot.x - prevX;
-        _margin.x += mx * dx;
-        _margin.z -= mx * dx;
+        const mx = margin.x + margin.z;
+        const dx = pivot.x - prevX;
+        margin.x += mx * dx;
+        margin.z -= mx * dx;
 
-        const my = _margin.y + _margin.w;
-        const dy = _pivot.y - prevY;
-        _margin.y += my * dy;
-        _margin.w -= my * dy;
+        const my = margin.y + margin.w;
+        const dy = pivot.y - prevY;
+        margin.y += my * dy;
+        margin.w -= my * dy;
 
         this._anchorDirty = true;
         this._cornersDirty = true;
@@ -717,7 +717,7 @@ class ElementComponent extends Component {
         // in order for them to update their position
         this._flagChildrenAsDirty();
 
-        this.fire('set:pivot', _pivot);
+        this.fire('set:pivot', pivot);
     }
 
     get pivot() {

--- a/src/framework/components/element/element-drag-helper.js
+++ b/src/framework/components/element/element-drag-helper.js
@@ -9,6 +9,8 @@ import { ElementComponent } from './component.js';
 import { Ray } from '../../../shape/ray.js';
 import { Plane } from '../../../shape/plane.js';
 
+/** @typedef {import('../../../input/element-input').ElementTouchEvent} ElementTouchEvent */
+
 const _inputScreenPosition = new Vec2();
 const _inputWorldPosition = new Vec3();
 const _ray = new Ray();
@@ -136,6 +138,15 @@ class ElementDragHelper extends EventHandler {
         }
     }
 
+    /**
+     * This method calculates the `Vec3` intersection point of plane/ray intersection based on
+     * the mouse/touch input event. If there is no intersection, it returns `null`.
+     *
+     * @param {ElementTouchEvent} event - The event.
+     * @returns {Vec3|null} The `Vec3` intersection point of plane/ray intersection, if there
+     * is an intersection, otherwise `null`
+     * @private
+     */
     _screenToLocal(event) {
         this._determineInputPosition(event);
         this._chooseRayOriginAndDirection();
@@ -209,22 +220,33 @@ class ElementDragHelper extends EventHandler {
         dragScale.z = 1 / dragScale.z;
     }
 
+    /**
+     * This method is linked to `_element` events: `mousemove` and `touchmove`
+     *
+     * @param {ElementTouchEvent} event - The event.
+     * @private
+     */
     _onMove(event) {
-        const { _element, _deltaMousePosition, _deltaHandlePosition, _axis } = this;
-        if (_element && this._isDragging && this.enabled && _element.enabled && _element.entity.enabled) {
+        const {
+            _element: element,
+            _deltaMousePosition: deltaMousePosition,
+            _deltaHandlePosition: deltaHandlePosition,
+            _axis: axis
+        } = this;
+        if (element && this._isDragging && this.enabled && element.enabled && element.entity.enabled) {
             const currentMousePosition = this._screenToLocal(event);
             if (currentMousePosition) {
-                _deltaMousePosition.sub2(currentMousePosition, this._dragStartMousePosition);
-                _deltaHandlePosition.add2(this._dragStartHandlePosition, _deltaMousePosition);
+                deltaMousePosition.sub2(currentMousePosition, this._dragStartMousePosition);
+                deltaHandlePosition.add2(this._dragStartHandlePosition, deltaMousePosition);
 
-                if (_axis) {
-                    const currentPosition = _element.entity.getLocalPosition();
-                    const constrainedAxis = OPPOSITE_AXIS[_axis];
-                    _deltaHandlePosition[constrainedAxis] = currentPosition[constrainedAxis];
+                if (axis) {
+                    const currentPosition = element.entity.getLocalPosition();
+                    const constrainedAxis = OPPOSITE_AXIS[axis];
+                    deltaHandlePosition[constrainedAxis] = currentPosition[constrainedAxis];
                 }
 
-                _element.entity.setLocalPosition(_deltaHandlePosition);
-                this.fire('drag:move', _deltaHandlePosition);
+                element.entity.setLocalPosition(deltaHandlePosition);
+                this.fire('drag:move', deltaHandlePosition);
             }
         }
     }

--- a/src/framework/components/element/element-drag-helper.js
+++ b/src/framework/components/element/element-drag-helper.js
@@ -140,7 +140,7 @@ class ElementDragHelper extends EventHandler {
         this._determineInputPosition(event);
         this._chooseRayOriginAndDirection();
 
-        _plane.point.copy(this._element.entity.getPosition());
+        _plane.point.copy(this._element.entity.getLocalPosition());
         _plane.normal.copy(this._element.entity.forward).mulScalar(-1);
 
         const denominator = _plane.normal.dot(_ray.direction);

--- a/src/framework/components/element/element-drag-helper.js
+++ b/src/framework/components/element/element-drag-helper.js
@@ -6,8 +6,8 @@ import { Vec2 } from '../../../math/vec2.js';
 import { Vec3 } from '../../../math/vec3.js';
 
 import { ElementComponent } from './component.js';
-import { Ray } from '../../../shape/ray';
-import { Plane } from '../../../shape/plane';
+import { Ray } from '../../../shape/ray.js';
+import { Plane } from '../../../shape/plane.js';
 
 const _inputScreenPosition = new Vec2();
 const _inputWorldPosition = new Vec3();
@@ -178,7 +178,7 @@ class ElementDragHelper extends EventHandler {
     _chooseRayOriginAndDirection() {
         if (this._element.screen && this._element.screen.screen.screenSpace) {
             _ray.origin.set(_inputScreenPosition.x, -_inputScreenPosition.y, 0);
-            _ray.direction.set(0, 0, -1);
+            _ray.direction.copy(Vec3.FORWARD);
         } else {
             _inputWorldPosition.copy(this._dragCamera.screenToWorld(_inputScreenPosition.x, _inputScreenPosition.y, 1));
             _ray.origin.copy(this._dragCamera.entity.getPosition());
@@ -214,8 +214,8 @@ class ElementDragHelper extends EventHandler {
         if (_element && this._isDragging && this.enabled && _element.enabled && _element.entity.enabled) {
             const currentMousePosition = this._screenToLocal(event);
             if (currentMousePosition) {
-                _deltaMousePosition.copy(currentMousePosition).sub(this._dragStartMousePosition);
-                _deltaHandlePosition.copy(this._dragStartHandlePosition).add(_deltaMousePosition);
+                _deltaMousePosition.sub2(currentMousePosition, this._dragStartMousePosition);
+                _deltaHandlePosition.add2(this._dragStartHandlePosition, _deltaMousePosition);
 
                 if (_axis) {
                     const currentPosition = _element.entity.getLocalPosition();

--- a/src/framework/components/element/element-drag-helper.js
+++ b/src/framework/components/element/element-drag-helper.js
@@ -210,21 +210,21 @@ class ElementDragHelper extends EventHandler {
     }
 
     _onMove(event) {
-        if (this._element && this._isDragging && this.enabled && this._element.enabled && this._element.entity.enabled) {
+        const { _element, _deltaMousePosition, _deltaHandlePosition, _axis } = this;
+        if (_element && this._isDragging && this.enabled && _element.enabled && _element.entity.enabled) {
             const currentMousePosition = this._screenToLocal(event);
+            if (currentMousePosition) {
+                _deltaMousePosition.copy(currentMousePosition).sub(this._dragStartMousePosition);
+                _deltaHandlePosition.copy(this._dragStartHandlePosition).add(_deltaMousePosition);
 
-            if (this._dragStartMousePosition && currentMousePosition) {
-                this._deltaMousePosition.copy(currentMousePosition).sub(this._dragStartMousePosition);
-                this._deltaHandlePosition.copy(this._dragStartHandlePosition).add(this._deltaMousePosition);
-
-                if (this._axis) {
-                    const currentPosition = this._element.entity.getLocalPosition();
-                    const constrainedAxis = OPPOSITE_AXIS[this._axis];
-                    this._deltaHandlePosition[constrainedAxis] = currentPosition[constrainedAxis];
+                if (_axis) {
+                    const currentPosition = _element.entity.getLocalPosition();
+                    const constrainedAxis = OPPOSITE_AXIS[_axis];
+                    _deltaHandlePosition[constrainedAxis] = currentPosition[constrainedAxis];
                 }
 
-                this._element.entity.setLocalPosition(this._deltaHandlePosition);
-                this.fire('drag:move', this._deltaHandlePosition);
+                _element.entity.setLocalPosition(_deltaHandlePosition);
+                this.fire('drag:move', _deltaHandlePosition);
             }
         }
     }

--- a/src/framework/components/element/element-drag-helper.js
+++ b/src/framework/components/element/element-drag-helper.js
@@ -6,13 +6,13 @@ import { Vec2 } from '../../../math/vec2.js';
 import { Vec3 } from '../../../math/vec3.js';
 
 import { ElementComponent } from './component.js';
+import { Ray } from '../../../shape/ray';
+import { Plane } from '../../../shape/plane';
 
 const _inputScreenPosition = new Vec2();
 const _inputWorldPosition = new Vec3();
-const _rayOrigin = new Vec3();
-const _rayDirection = new Vec3();
-const _planeOrigin = new Vec3();
-const _planeNormal = new Vec3();
+const _ray = new Ray();
+const _plane = new Plane();
 const _entityRotation = new Quat();
 
 const OPPOSITE_AXIS = {
@@ -140,16 +140,16 @@ class ElementDragHelper extends EventHandler {
         this._determineInputPosition(event);
         this._chooseRayOriginAndDirection();
 
-        _planeOrigin.copy(this._element.entity.getPosition());
-        _planeNormal.copy(this._element.entity.forward).mulScalar(-1);
+        _plane.point.copy(this._element.entity.getPosition());
+        _plane.normal.copy(this._element.entity.forward).mulScalar(-1);
 
-        const denominator = _planeNormal.dot(_rayDirection);
+        const denominator = _plane.normal.dot(_ray.direction);
 
         // If the ray and plane are not parallel
         if (Math.abs(denominator) > 0) {
-            const rayOriginToPlaneOrigin = _planeOrigin.sub(_rayOrigin);
-            const collisionDistance = rayOriginToPlaneOrigin.dot(_planeNormal) / denominator;
-            const position = _rayOrigin.add(_rayDirection.mulScalar(collisionDistance));
+            const rayOriginToPlaneOrigin = _plane.point.sub(_ray.origin);
+            const collisionDistance = rayOriginToPlaneOrigin.dot(_plane.normal) / denominator;
+            const position = _ray.origin.add(_ray.direction.mulScalar(collisionDistance));
 
             _entityRotation.copy(this._element.entity.getRotation()).invert().transformVector(position, position);
 
@@ -177,12 +177,12 @@ class ElementDragHelper extends EventHandler {
 
     _chooseRayOriginAndDirection() {
         if (this._element.screen && this._element.screen.screen.screenSpace) {
-            _rayOrigin.set(_inputScreenPosition.x, -_inputScreenPosition.y, 0);
-            _rayDirection.set(0, 0, -1);
+            _ray.origin.set(_inputScreenPosition.x, -_inputScreenPosition.y, 0);
+            _ray.direction.set(0, 0, -1);
         } else {
             _inputWorldPosition.copy(this._dragCamera.screenToWorld(_inputScreenPosition.x, _inputScreenPosition.y, 1));
-            _rayOrigin.copy(this._dragCamera.entity.getPosition());
-            _rayDirection.copy(_inputWorldPosition).sub(_rayOrigin).normalize();
+            _ray.origin.copy(this._dragCamera.entity.getPosition());
+            _ray.direction.copy(_inputWorldPosition).sub(_ray.origin).normalize();
         }
     }
 

--- a/src/shape/plane.js
+++ b/src/shape/plane.js
@@ -19,8 +19,8 @@ class Plane {
      * parameter.
      */
     constructor(point = new Vec3(), normal = new Vec3(0, 0, 1)) {
-        this.normal = normal;
         this.point = point;
+        this.normal = normal;
     }
 
     /**


### PR DESCRIPTION
Fixes #4635 and #3748

The deltas in `ElementDragHelper#_onMove` become larger every frame, because one is using global position and the other takes local position... that goes well for a few frames, but then explodes into either extremely near 0 or Infinity. And in the case of Infinity it perpetuates itself further into NaN.

I also did some refactoring, which reduces the amount of code while using less method calls and less property lookups, which also reduces the amount of code.

It was quite some work to actually find the bug Infinity/NaN bug, so I added JSDoc along the way...

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
