### PR TITLE
Only add the shared sampler if the chunk uses the $SAMPLER macro.

### DIFF
--- a/src/graphics/program-lib/programs/standard.js
+++ b/src/graphics/program-lib/programs/standard.js
@@ -157,7 +157,7 @@ const standard = {
 
             subCode = subCode.replace(/\$UV/g, uv).replace(/\$CH/g, options[channelPropName]);
 
-            if (mapping && subCode.search(/\$SAMPLER/g)) {
+            if (mapping && subCode.search(/\$SAMPLER/g) !== -1) {
                 let samplerName = "texture_" + mapPropName;
                 const alias = mapping[textureIdentifier];
                 if (alias) {

--- a/src/graphics/program-lib/programs/standard.js
+++ b/src/graphics/program-lib/programs/standard.js
@@ -157,7 +157,7 @@ const standard = {
 
             subCode = subCode.replace(/\$UV/g, uv).replace(/\$CH/g, options[channelPropName]);
 
-            if (mapping) {
+            if (mapping && subCode.search(/\$SAMPLER/g)) {
                 let samplerName = "texture_" + mapPropName;
                 const alias = mapping[textureIdentifier];
                 if (alias) {


### PR DESCRIPTION
### Description

Make sure chunks that don't use the $SAMPLER macro doesn't have its samplers declared in the preamble of the shader frontend. 
