### PR TITLE
Fix texture sharing change triggering shader build

### DIFF
--- a/src/resources/material.js
+++ b/src/resources/material.js
@@ -186,8 +186,7 @@ class MaterialHandler {
 
     _onTextureLoad(parameterName, materialAsset, textureAsset) {
         this._assignTexture(parameterName, materialAsset, textureAsset.resource);
-        if (--materialAsset.textureLoadCount === 0)
-            materialAsset.resource.update();
+        materialAsset.resource.update();
     }
 
     _onTextureAdd(parameterName, materialAsset, textureAsset) {
@@ -248,8 +247,6 @@ class MaterialHandler {
         const TEXTURES = standardMaterialTextureParameters;
 
         let i, name, assetReference;
-        materialAsset.textureLoadCount = 0;
-
         // iterate through all texture parameters
         for (i = 0; i < TEXTURES.length; i++) {
             name = TEXTURES[i];
@@ -267,7 +264,6 @@ class MaterialHandler {
 
             if (dataAssetId && (!materialTexture || !dataValidated || isPlaceHolderTexture)) {
                 if (!assetReference) {
-                    materialAsset.textureLoadCount++;
                     assetReference = new AssetReference(name, materialAsset, assets, {
                         load: this._onTextureLoad,
                         add: this._onTextureAdd,
@@ -288,7 +284,6 @@ class MaterialHandler {
                 if (assetReference.asset) {
                     if (assetReference.asset.resource) {
                         // asset is already loaded
-                        materialAsset.textureLoadCount--;
                         this._assignTexture(name, materialAsset, assetReference.asset.resource);
                     } else {
                         this._assignPlaceholderTexture(name, materialAsset);

--- a/src/resources/material.js
+++ b/src/resources/material.js
@@ -186,7 +186,8 @@ class MaterialHandler {
 
     _onTextureLoad(parameterName, materialAsset, textureAsset) {
         this._assignTexture(parameterName, materialAsset, textureAsset.resource);
-        materialAsset.resource.update();
+        if (--materialAsset.textureLoadCount === 0)
+            materialAsset.resource.update();
     }
 
     _onTextureAdd(parameterName, materialAsset, textureAsset) {
@@ -247,6 +248,8 @@ class MaterialHandler {
         const TEXTURES = standardMaterialTextureParameters;
 
         let i, name, assetReference;
+        materialAsset.textureLoadCount = 0;
+
         // iterate through all texture parameters
         for (i = 0; i < TEXTURES.length; i++) {
             name = TEXTURES[i];
@@ -264,6 +267,7 @@ class MaterialHandler {
 
             if (dataAssetId && (!materialTexture || !dataValidated || isPlaceHolderTexture)) {
                 if (!assetReference) {
+                    materialAsset.textureLoadCount++;
                     assetReference = new AssetReference(name, materialAsset, assets, {
                         load: this._onTextureLoad,
                         add: this._onTextureAdd,
@@ -284,6 +288,7 @@ class MaterialHandler {
                 if (assetReference.asset) {
                     if (assetReference.asset.resource) {
                         // asset is already loaded
+                        materialAsset.textureLoadCount--;
                         this._assignTexture(name, materialAsset, assetReference.asset.resource);
                     } else {
                         this._assignPlaceholderTexture(name, materialAsset);

--- a/src/scene/materials/standard-material-options-builder.js
+++ b/src/scene/materials/standard-material-options-builder.js
@@ -107,10 +107,11 @@ class StandardMaterialOptionsBuilder {
         options.vertexColors = false;
         this._mapXForms = [];
 
-        const textureMappingCounter = { value: 0 };
-        const textureMap = {};
+        const uniqueTextureMappingCounter = { value: 0 };
+        const uniqueTextureMap = {};
+        this.uniqueTextureMappingCounter = 0;
         for (const p in _matTex2D) {
-            this._updateTexOptions(options, stdMat, p, hasUv0, hasUv1, hasVcolor, minimalOptions, textureMappingCounter, textureMap);
+            this._updateTexOptions(options, stdMat, p, hasUv0, hasUv1, hasVcolor, minimalOptions, uniqueTextureMap);
         }
         this._mapXForms = null;
     }
@@ -314,7 +315,7 @@ class StandardMaterialOptionsBuilder {
         }
     }
 
-    _updateTexOptions(options, stdMat, p, hasUv0, hasUv1, hasVcolor, minimalOptions, textureMappingCounter, textureMap) {
+    _updateTexOptions(options, stdMat, p, hasUv0, hasUv1, hasVcolor, minimalOptions, uniqueTextureMap) {
         const mname = p + 'Map';
         const vname = p + 'VertexColor';
         const vcname = p + 'VertexColorChannel';
@@ -352,12 +353,15 @@ class StandardMaterialOptionsBuilder {
                 if (stdMat[uname] === 1 && !hasUv1) allow = false;
                 if (allow) {
 
+                    // create an intermediate map between the textures and their slots
+                    // to ensure the unique texture mapping isn't dependent on the texture id
+                    // as that will change when textures are changed, even if the sharing is the same
                     const mapId = stdMat[mname].id;
-                    let identifier = textureMap[mapId];
+                    let identifier = uniqueTextureMap[mapId];
                     if (identifier === undefined) {
-                        textureMap[mapId] = textureMappingCounter.value;
-                        identifier = textureMappingCounter.value;
-                        textureMappingCounter.value++;
+                        uniqueTextureMap[mapId] = this.uniqueTextureMappingCounter;
+                        identifier = this.uniqueTextureMappingCounter;
+                        this.uniqueTextureMappingCounter++;
                     }
 
                     options[mname] = !!stdMat[mname];

--- a/src/scene/materials/standard-material-options-builder.js
+++ b/src/scene/materials/standard-material-options-builder.js
@@ -107,7 +107,6 @@ class StandardMaterialOptionsBuilder {
         options.vertexColors = false;
         this._mapXForms = [];
 
-        const uniqueTextureMappingCounter = { value: 0 };
         const uniqueTextureMap = {};
         this.uniqueTextureMappingCounter = 0;
         for (const p in _matTex2D) {

--- a/src/scene/materials/standard-material-options-builder.js
+++ b/src/scene/materials/standard-material-options-builder.js
@@ -106,8 +106,11 @@ class StandardMaterialOptionsBuilder {
 
         options.vertexColors = false;
         this._mapXForms = [];
+
+        const textureMappingCounter = { value: 0 };
+        const textureMap = {};
         for (const p in _matTex2D) {
-            this._updateTexOptions(options, stdMat, p, hasUv0, hasUv1, hasVcolor, minimalOptions);
+            this._updateTexOptions(options, stdMat, p, hasUv0, hasUv1, hasVcolor, minimalOptions, textureMappingCounter, textureMap);
         }
         this._mapXForms = null;
     }
@@ -311,7 +314,7 @@ class StandardMaterialOptionsBuilder {
         }
     }
 
-    _updateTexOptions(options, stdMat, p, hasUv0, hasUv1, hasVcolor, minimalOptions) {
+    _updateTexOptions(options, stdMat, p, hasUv0, hasUv1, hasVcolor, minimalOptions, textureMappingCounter, textureMap) {
         const mname = p + 'Map';
         const vname = p + 'VertexColor';
         const vcname = p + 'VertexColorChannel';
@@ -348,8 +351,17 @@ class StandardMaterialOptionsBuilder {
                 if (stdMat[uname] === 0 && !hasUv0) allow = false;
                 if (stdMat[uname] === 1 && !hasUv1) allow = false;
                 if (allow) {
+
+                    const mapId = stdMat[mname].id;
+                    let identifier = textureMap[mapId];
+                    if (identifier === undefined) {
+                        textureMap[mapId] = textureMappingCounter.value;
+                        identifier = textureMappingCounter.value;
+                        textureMappingCounter.value++;
+                    }
+
                     options[mname] = !!stdMat[mname];
-                    options[iname] = stdMat[mname].id;
+                    options[iname] = identifier;
                     options[tname] = this._getMapTransformID(stdMat.getUniform(tname), stdMat[uname]);
                     options[cname] = stdMat[cname];
                     options[uname] = stdMat[uname];

--- a/src/scene/materials/standard-material-options-builder.js
+++ b/src/scene/materials/standard-material-options-builder.js
@@ -326,6 +326,7 @@ class StandardMaterialOptionsBuilder {
             options[cname] = '';
             options[tname] = 0;
             options[uname] = 0;
+            options[iname] = undefined;
         }
         options[vname] = false;
         options[vcname] = '';
@@ -348,7 +349,7 @@ class StandardMaterialOptionsBuilder {
                 if (stdMat[uname] === 1 && !hasUv1) allow = false;
                 if (allow) {
                     options[mname] = !!stdMat[mname];
-                    options[iname] = stdMat[mname].name;
+                    options[iname] = stdMat[mname].id;
                     options[tname] = this._getMapTransformID(stdMat.getUniform(tname), stdMat[uname]);
                     options[cname] = stdMat[cname];
                     options[uname] = stdMat[uname];


### PR DESCRIPTION
### Description

With the new shared sampler code, it's important we know that a shader has to be rebuilt whenever it changes a texture since that might change the way textures are being shared. This PR fixes that issue by always setting the xMapIdentifier in the options such that it becomes part of the options key. 

This PR also defers updating the material until after all textures have loaded. This is to save time not having to potentially recompiling shaders in between each texture load. 