### PR TITLE
Fix issue with texture sharing not working consistently

### DIFF
--- a/src/scene/materials/standard-material-options-builder.js
+++ b/src/scene/materials/standard-material-options-builder.js
@@ -108,7 +108,6 @@ class StandardMaterialOptionsBuilder {
         this._mapXForms = [];
 
         const uniqueTextureMap = {};
-        this.uniqueTextureMappingCounter = 0;
         for (const p in _matTex2D) {
             this._updateTexOptions(options, stdMat, p, hasUv0, hasUv1, hasVcolor, minimalOptions, uniqueTextureMap);
         }
@@ -358,9 +357,8 @@ class StandardMaterialOptionsBuilder {
                     const mapId = stdMat[mname].id;
                     let identifier = uniqueTextureMap[mapId];
                     if (identifier === undefined) {
-                        uniqueTextureMap[mapId] = this.uniqueTextureMappingCounter;
-                        identifier = this.uniqueTextureMappingCounter;
-                        this.uniqueTextureMappingCounter++;
+                        uniqueTextureMap[mapId] = p;
+                        identifier = p;
                     }
 
                     options[mname] = !!stdMat[mname];


### PR DESCRIPTION
### Description
The previous method of using a counter to assign a texture slot to an index might have caused issues where the unique texture map could've produced identical results even if the texture sharing had changed. 

