### PR TITLE
[Fix] GltfExporter correctly handles multiple mesh instances per entity

### DIFF
--- a/extras/exporters/gltf-exporter.js
+++ b/extras/exporters/gltf-exporter.js
@@ -112,7 +112,7 @@ class GltfExporter {
                 collectMeshInstances(entity.render.meshInstances);
             }
 
-            if (entity.model && entity.model.enabled) {
+            if (entity.model && entity.model.enabled && entity.model.meshInstances) {
                 collectMeshInstances(entity.model.meshInstances);
             }
         });


### PR DESCRIPTION
- before, we would walk all mesh instances in a render component, and store their index as a mesh index of a node. The problem was that if there were multiple mesh instances, the index would get overwritten and only the last mesh would be assigned
- this PR changes the way mesh instances are collected to collect them per node. And from all of these, a single gltf mesh is created, with each mesh instance forming a primitive.
- this also makes export of model components working - as all mesh instances are attached to a root node, even though internally they store the node they need the transform from.

In the screenshot, both a sphere and a cone are added to a single render component, and both meshes are exported. Before, only the cone (second mesh) would be visible.
![Screenshot 2022-09-30 at 14 08 36](https://user-images.githubusercontent.com/59932779/193276715-3c3f2c1f-deb9-4577-b728-0957ccb79b8a.png)

