### PR TITLE
Texture related improvements to Gltf and USDZ Exporters

### DIFF
--- a/examples/src/examples/loaders/gltf-export.tsx
+++ b/examples/src/examples/loaders/gltf-export.tsx
@@ -59,6 +59,22 @@ class GltfExportExample {
                 entity3.setLocalScale(0.01, 0.01, 0.01);
                 app.root.addChild(entity3);
 
+                // a render component with a sphere and cone primitives
+                const material = new pc.StandardMaterial();
+                material.diffuse = pc.Color.RED;
+                material.update();
+
+                const entity = new pc.Entity("TwoMeshInstances");
+                entity.addComponent('render', {
+                    type: 'asset',
+                    meshInstances: [
+                        new pc.MeshInstance(pc.createSphere(app.graphicsDevice), material),
+                        new pc.MeshInstance(pc.createCone(app.graphicsDevice), material)
+                    ]
+                });
+                app.root.addChild(entity);
+                entity.setLocalPosition(0, 1.5, -1.5);
+
                 // Create an Entity with a camera component
                 const camera = new pc.Entity();
                 camera.addComponent("camera", {
@@ -79,7 +95,11 @@ class GltfExportExample {
                 const link = document.getElementById('ar-link');
 
                 // export the whole scene into a glb format
-                new pcx.GltfExporter().build(app.root).then((arrayBuffer: any) => {
+                const options = {
+                    maxTextureSize: 1024
+                };
+
+                new pcx.GltfExporter().build(app.root, options).then((arrayBuffer: any) => {
 
                     const blob = new Blob([arrayBuffer], { type: 'application/octet-stream' });
 

--- a/examples/src/examples/loaders/usdz-export.tsx
+++ b/examples/src/examples/loaders/usdz-export.tsx
@@ -55,7 +55,11 @@ class UsdzExportExample {
             const link = document.getElementById('ar-link');
 
             // convert the loaded entity into asdz file
-            new pcx.UsdzExporter().build(entity).then((arrayBuffer: any) => {
+            const options = {
+                maxTextureSize: 1024
+            };
+
+            new pcx.UsdzExporter().build(entity, options).then((arrayBuffer: any) => {
                 const blob = new Blob([arrayBuffer], { type: 'application/octet-stream' });
 
                 // On iPhone Safari, this link creates a clickable AR link on the screen. When this is clicked,

--- a/extras/exporters/core-exporter.js
+++ b/extras/exporters/core-exporter.js
@@ -1,0 +1,55 @@
+class CoreExporter {
+    /**
+     * Converts a source image specified in multiple formats to a canvas.
+     *
+     * @param {any} image - The source image to be converted.
+     * @param {object} options - Object for passing optional arguments.
+     * @param {Color} [options.color] - The tint color to modify the texture with.
+     * @param {number} [options.maxTextureSize] - Maximum texture size. Texture is resized if over the size.
+     * @returns {any} - The canvas element containing the image.
+     */
+    imageToCanvas(image, options = {}) {
+
+        if ((typeof HTMLImageElement !== 'undefined' && image instanceof HTMLImageElement) ||
+            (typeof HTMLCanvasElement !== 'undefined' && image instanceof HTMLCanvasElement) ||
+            (typeof OffscreenCanvas !== 'undefined' && image instanceof OffscreenCanvas) ||
+            (typeof ImageBitmap !== 'undefined' && image instanceof ImageBitmap)) {
+
+            // texture dimensions
+            let { width, height } = image;
+            const maxTextureSize = options.maxTextureSize;
+            if (maxTextureSize) {
+                const scale = Math.min(maxTextureSize / Math.max(width, height), 1);
+                width = Math.round(width * scale);
+                height = Math.round(height * scale);
+            }
+
+            // convert to a canvas
+            const canvas = document.createElement('canvas');
+            canvas.width = width;
+            canvas.height = height;
+            const context = canvas.getContext('2d');
+            context.drawImage(image, 0, 0, canvas.width, canvas.height);
+
+            // tint the texture by specified color
+            if (options.color) {
+                const { r, g, b } = options.color;
+
+                const imagedata = context.getImageData(0, 0, width, height);
+                const data = imagedata.data;
+
+                for (let i = 0; i < data.length; i += 4) {
+                    data[i + 0] = data[i + 0] * r;
+                    data[i + 1] = data[i + 1] * g;
+                    data[i + 2] = data[i + 2] * b;
+                }
+
+                context.putImageData(imagedata, 0, 0);
+            }
+
+            return canvas;
+        }
+    }
+}
+
+export { CoreExporter };

--- a/extras/exporters/gltf-exporter.js
+++ b/extras/exporters/gltf-exporter.js
@@ -492,7 +492,7 @@ class GltfExporter extends CoreExporter {
      *
      * @param {Entity} entity - The root of the entity hierarchy to convert.
      * @param {object} options - Object for passing optional arguments.
-     * @param {Color} [options.maxTextureSize] - Maximum texture size. Texture is resized if over the size.
+     * @param {number} [options.maxTextureSize] - Maximum texture size. Texture is resized if over the size.
      * @returns {ArrayBuffer} - The GLB file content.
      */
     build(entity, options = {}) {

--- a/extras/exporters/usdz-exporter.js
+++ b/extras/exporters/usdz-exporter.js
@@ -122,7 +122,7 @@ class UsdzExporter extends CoreExporter {
      *
      * @param {Entity} entity - The root of the entity hierarchy to convert.
      * @param {object} options - Object for passing optional arguments.
-     * @param {Color} [options.maxTextureSize] - Maximum texture size. Texture is resized if over the size.
+     * @param {number} [options.maxTextureSize] - Maximum texture size. Texture is resized if over the size.
      * @returns {ArrayBuffer} - The USDZ file content.
      */
     build(entity, options = {}) {

--- a/extras/exporters/usdz-exporter.js
+++ b/extras/exporters/usdz-exporter.js
@@ -1,3 +1,4 @@
+import { CoreExporter } from "./core-exporter.js";
 import { zipSync, strToU8 } from '../../node_modules/fflate/esm/browser.js';
 
 const ROOT_FILE_NAME = 'root';
@@ -56,7 +57,7 @@ def Xform "${nodeName}" (
 
 const materialValueTemplate = (type, name, value) => `                    ${type} inputs:${name} = ${value}`;
 
-class UsdzExporter {
+class UsdzExporter extends CoreExporter {
     /**
      * Maps a mesh to a reference (path) inside the usdz container
      *
@@ -116,7 +117,15 @@ class UsdzExporter {
         this.nodeNames = null;
     }
 
-    build(root) {
+    /**
+     * Converts a hierarchy of entities to USDZ format.
+     *
+     * @param {Entity} entity - The root of the entity hierarchy to convert.
+     * @param {object} options - Object for passing optional arguments.
+     * @param {Color} [options.maxTextureSize] - Maximum texture size. Texture is resized if over the size.
+     * @returns {ArrayBuffer} - The USDZ file content.
+     */
+    build(entity, options = {}) {
 
         this.init();
 
@@ -125,8 +134,8 @@ class UsdzExporter {
 
         // find all mesh instances
         const allMeshInstances = [];
-        if (root) {
-            const renders = root.findComponents("render");
+        if (entity) {
+            const renders = entity.findComponents("render");
             renders.forEach((render) => {
                 allMeshInstances.push(...render.meshInstances);
             });
@@ -144,6 +153,10 @@ class UsdzExporter {
         this.addFile(null, ROOT_FILE_NAME, '', rootContent);
 
         // process requested textures
+        const textureOptions = {
+            maxTextureSize: options.maxTextureSize
+        };
+
         const textureArray = Array.from(this.textureMap.keys());
         const promises = [];
         for (let i = 0; i < textureArray.length; i++) {
@@ -151,16 +164,17 @@ class UsdzExporter {
             // for now store all textures as png
             // TODO: consider jpg if the alpha channel is not used
             const isRGBA = true;
+            const mimeType = isRGBA ? 'image/png' : 'image/jpeg';
 
             const texture = textureArray[i];
             const mipObject = texture._levels[0];
 
             // convert texture data to canvas
-            const canvas = this.imageToCanvas(mipObject, undefined);
+            const canvas = this.imageToCanvas(mipObject, textureOptions);
 
             // async convert them to blog and then to array buffer
             // eslint-disable-next-line no-promise-executor-return
-            promises.push(new Promise(resolve => canvas.toBlob(resolve, isRGBA ? 'image/png' : 'image/jpeg', 1)).then(
+            promises.push(new Promise(resolve => canvas.toBlob(resolve, mimeType, 1)).then(
                 blob => blob.arrayBuffer()
             ));
         }
@@ -241,47 +255,6 @@ class UsdzExporter {
         this.files[ids.fileName] = contentU8;
 
         return ids.refName;
-    }
-
-    imageToCanvas(image, color) {
-
-        if ((typeof HTMLImageElement !== 'undefined' && image instanceof HTMLImageElement) ||
-            (typeof HTMLCanvasElement !== 'undefined' && image instanceof HTMLCanvasElement) ||
-            (typeof OffscreenCanvas !== 'undefined' && image instanceof OffscreenCanvas) ||
-            (typeof ImageBitmap !== 'undefined' && image instanceof ImageBitmap)) {
-
-            const scale = 1024 / Math.max(image.width, image.height);
-
-            const canvas = document.createElement('canvas');
-            canvas.width = image.width * Math.min(1, scale);
-            canvas.height = image.height * Math.min(1, scale);
-
-            const context = canvas.getContext('2d');
-            context.drawImage(image, 0, 0, canvas.width, canvas.height);
-
-            if (color !== undefined) {
-
-                const hex = parseInt(color, 16);
-
-                const r = (hex >> 16 & 255) / 255;
-                const g = (hex >> 8 & 255) / 255;
-                const b = (hex & 255) / 255;
-
-                const imagedata = context.getImageData(0, 0, canvas.width, canvas.height);
-                const data = imagedata.data;
-
-                for (let i = 0; i < data.length; i += 4) {
-
-                    data[i + 0] = data[i + 0] * r;
-                    data[i + 1] = data[i + 1] * g;
-                    data[i + 2] = data[i + 2] * b;
-                }
-
-                context.putImageData(imagedata, 0, 0);
-            }
-
-            return canvas;
-        }
     }
 
     getMaterialRef(material) {


### PR DESCRIPTION
- Gltf and USDZ exporters now support options

```
     * @param {object} options - Object for passing optional arguments.
     * @param {Color} [options.maxTextureSize] - Maximum texture size. Texture is resized if over the size.

```

- Gltf exporter handles diffuse texture

source scene:
![Screenshot 2022-10-03 at 12 34 50](https://user-images.githubusercontent.com/59932779/193570720-727ffb06-449b-4653-876c-e38208caa506.png)

exported glb:
![Screenshot 2022-10-03 at 12 34 30](https://user-images.githubusercontent.com/59932779/193570750-aa9a2eb8-9a3c-46b9-83f3-aac8eada250c.png)
