### PR TITLE
Fix GLB punctual lights with physical units

### DIFF
--- a/src/framework/components/light/system.js
+++ b/src/framework/components/light/system.js
@@ -11,8 +11,6 @@ import { LightComponentData } from './data.js';
 
 /** @typedef {import('../../app-base.js').AppBase} AppBase */
 
-
-
 /**
  * A Light Component is used to dynamically light the scene.
  *

--- a/src/framework/components/light/system.js
+++ b/src/framework/components/light/system.js
@@ -117,4 +117,4 @@ class LightComponentSystem extends ComponentSystem {
     }
 }
 
-export { LightComponentSystem };
+export { LightComponentSystem, lightTypes };

--- a/src/framework/components/light/system.js
+++ b/src/framework/components/light/system.js
@@ -1,8 +1,8 @@
 import { Color } from '../../../math/color.js';
 import { Vec2 } from '../../../math/vec2.js';
 
-import { LIGHTSHAPE_PUNCTUAL, LIGHTTYPE_DIRECTIONAL, LIGHTTYPE_OMNI, LIGHTTYPE_SPOT } from '../../../scene/constants.js';
-import { Light } from '../../../scene/light.js';
+import { LIGHTSHAPE_PUNCTUAL } from '../../../scene/constants.js';
+import { Light, lightTypes } from '../../../scene/light.js';
 
 import { ComponentSystem } from '../system.js';
 
@@ -11,12 +11,7 @@ import { LightComponentData } from './data.js';
 
 /** @typedef {import('../../app-base.js').AppBase} AppBase */
 
-const lightTypes = {
-    'directional': LIGHTTYPE_DIRECTIONAL,
-    'omni': LIGHTTYPE_OMNI,
-    'point': LIGHTTYPE_OMNI,
-    'spot': LIGHTTYPE_SPOT
-};
+
 
 /**
  * A Light Component is used to dynamically light the scene.
@@ -117,4 +112,4 @@ class LightComponentSystem extends ComponentSystem {
     }
 }
 
-export { LightComponentSystem, lightTypes };
+export { LightComponentSystem };

--- a/src/resources/parser/glb-parser.js
+++ b/src/resources/parser/glb-parser.js
@@ -34,11 +34,9 @@ import {
     ASPECT_MANUAL, ASPECT_AUTO, SPECOCC_AO
 } from '../../scene/constants.js';
 
-import { lightTypes } from '../../framework/components/light/system.js';
-
 import { calculateNormals } from '../../scene/procedural.js';
 import { GraphNode } from '../../scene/graph-node.js';
-import { Light } from '../../scene/light.js';
+import { Light, lightTypes } from '../../scene/light.js';
 import { Mesh } from '../../scene/mesh.js';
 import { Morph } from '../../scene/morph.js';
 import { MorphTarget } from '../../scene/morph-target.js';

--- a/src/resources/parser/glb-parser.js
+++ b/src/resources/parser/glb-parser.js
@@ -1794,8 +1794,7 @@ const createLight = function (gltfLight, node) {
                 lightProps.luminance = gltfLight.intensity * Light.getLightUnitConversion(LIGHTTYPE_OMNI);
                 break;
             case "directional":
-                // Directional light luminance is already in lux
-                lightProps.luminance = gltfLight.intensity;
+                lightProps.luminance = gltfLight.intensity * Light.getLightUnitConversion(LIGHTTYPE_DIRECTIONAL);
                 break;
         }
     }

--- a/src/resources/parser/glb-parser.js
+++ b/src/resources/parser/glb-parser.js
@@ -31,8 +31,10 @@ import { VertexFormat } from '../../graphics/vertex-format.js';
 import {
     BLEND_NONE, BLEND_NORMAL, LIGHTFALLOFF_INVERSESQUARED,
     PROJECTION_ORTHOGRAPHIC, PROJECTION_PERSPECTIVE,
-    ASPECT_MANUAL, ASPECT_AUTO, SPECOCC_AO, LIGHTTYPE_SPOT, LIGHTTYPE_OMNI, LIGHTTYPE_DIRECTIONAL
+    ASPECT_MANUAL, ASPECT_AUTO, SPECOCC_AO
 } from '../../scene/constants.js';
+
+import { lightTypes } from '../../framework/components/light/system.js';
 
 import { calculateNormals } from '../../scene/procedural.js';
 import { GraphNode } from '../../scene/graph-node.js';
@@ -1786,17 +1788,7 @@ const createLight = function (gltfLight, node) {
     // glTF stores light already in energy/area, but we need to provide the light with only the energy parameter,
     // so we need the intensities in candela back to lumen
     if (gltfLight.hasOwnProperty("intensity")) {
-        switch (gltfLight.type) {
-            case "spot":
-                lightProps.luminance = gltfLight.intensity * Light.getLightUnitConversion(LIGHTTYPE_SPOT, gltfLight.spot.outerConeAngle, gltfLight.spot.innerConeAngle);
-                break;
-            case "point":
-                lightProps.luminance = gltfLight.intensity * Light.getLightUnitConversion(LIGHTTYPE_OMNI);
-                break;
-            case "directional":
-                lightProps.luminance = gltfLight.intensity * Light.getLightUnitConversion(LIGHTTYPE_DIRECTIONAL);
-                break;
-        }
+        lightProps.luminance = gltfLight.intensity * Light.getLightUnitConversion(lightTypes[lightProps.type], lightProps.outerConeAngle, lightProps.innerConeAngle);
     }
 
     // Rotate to match light orientation in glTF specification

--- a/src/resources/parser/glb-parser.js
+++ b/src/resources/parser/glb-parser.js
@@ -30,7 +30,6 @@ import { VertexFormat } from '../../graphics/vertex-format.js';
 
 import {
     BLEND_NONE, BLEND_NORMAL, LIGHTFALLOFF_INVERSESQUARED,
-    LIGHTTYPE_DIRECTIONAL, LIGHTTYPE_OMNI, LIGHTTYPE_SPOT,
     PROJECTION_ORTHOGRAPHIC, PROJECTION_PERSPECTIVE,
     ASPECT_MANUAL, ASPECT_AUTO, SPECOCC_AO
 } from '../../scene/constants.js';

--- a/src/scene/light.js
+++ b/src/scene/light.js
@@ -25,6 +25,13 @@ const tmpBiases = {
 
 const chanId = { r: 0, g: 1, b: 2, a: 3 };
 
+const lightTypes = {
+    'directional': LIGHTTYPE_DIRECTIONAL,
+    'omni': LIGHTTYPE_OMNI,
+    'point': LIGHTTYPE_OMNI,
+    'spot': LIGHTTYPE_SPOT
+};
+
 // viewport in shadows map for cascades for directional light
 const directionalCascades = [
     [new Vec4(0, 0, 1, 1)],
@@ -855,4 +862,4 @@ class Light {
     }
 }
 
-export { Light };
+export { Light, lightTypes };

--- a/src/scene/light.js
+++ b/src/scene/light.js
@@ -640,8 +640,8 @@ class Light {
     /**
      * Get conversion factor for luminance -> light specific light unit
      * @param {number} type - The type of light
-     * @param {number} outerAngle - The outer angle of a spot light
-     * @param {number} innerAngle - The inner angle of a spot light
+     * @param {number} [outerAngle] - The outer angle of a spot light
+     * @param {number} [innerAngle] - The inner angle of a spot light
      * @returns {number} The scaling factor to multiply with the luminance value
      */
     static getLightUnitConversion(type, outerAngle = 1, innerAngle = 0) {

--- a/src/scene/light.js
+++ b/src/scene/light.js
@@ -638,12 +638,12 @@ class Light {
     }
 
     /**
-     * Get conversion factor for luminance -> light specific light unit
+     * Get conversion factor for luminance -> light specific light unit.
      *
-     * @param {number} type - The type of light
-     * @param {number} [outerAngle] - The outer angle of a spot light
-     * @param {number} [innerAngle] - The inner angle of a spot light
-     * @returns {number} The scaling factor to multiply with the luminance value
+     * @param {number} type - The type of light.
+     * @param {number} [outerAngle] - The outer angle of a spot light.
+     * @param {number} [innerAngle] - The inner angle of a spot light.
+     * @returns {number} The scaling factor to multiply with the luminance value.
      */
     static getLightUnitConversion(type, outerAngle = 1, innerAngle = 0) {
         switch (type) {

--- a/src/scene/light.js
+++ b/src/scene/light.js
@@ -639,6 +639,7 @@ class Light {
 
     /**
      * Get conversion factor for luminance -> light specific light unit
+     *
      * @param {number} type - The type of light
      * @param {number} [outerAngle] - The outer angle of a spot light
      * @param {number} [innerAngle] - The inner angle of a spot light

--- a/src/scene/light.js
+++ b/src/scene/light.js
@@ -637,6 +637,31 @@ class Light {
         return clone;
     }
 
+    /**
+     * Get conversion factor for luminance -> light specific light unit
+     * @param {number} type - The type of light
+     * @param {number} outerAngle - The outer angle of a spot light
+     * @param {number} innerAngle - The inner angle of a spot light
+     * @returns {number} The scaling factor to multiply with the luminance value
+     */
+    static getLightUnitConversion(type, outerAngle = 1, innerAngle = 0) {
+        switch (type) {
+            case LIGHTTYPE_SPOT: {
+                const falloffEnd = Math.cos(outerAngle);
+                const falloffStart = Math.cos(innerAngle);
+
+                // https://github.com/mmp/pbrt-v4/blob/faac34d1a0ebd24928828fe9fa65b65f7efc5937/src/pbrt/lights.cpp#L1463
+                return (2 * Math.PI * ((1 - falloffStart) + (falloffStart - falloffEnd) / 2.0));
+            }
+            case LIGHTTYPE_OMNI:
+                // https://google.github.io/filament/Filament.md.html#lighting/directlighting/punctuallights/pointlights
+                return (4 * Math.PI);
+            case LIGHTTYPE_DIRECTIONAL:
+                // https://google.github.io/filament/Filament.md.html#lighting/directlighting/directionallights
+                return 1;
+        }
+    }
+
     // returns the bias (.x) and normalBias (.y) value for lights as passed to shaders by uniforms
     // Note: this needs to be revisited and simplified
     // Note: vsmBias is not used at all for omni light, even though it is editable in the Editor
@@ -735,22 +760,12 @@ class Light {
         // To calculate the lux, which is lm/m^2, we need to convert from luminous power
         if (this._usePhysicalUnits) {
             switch (this._type) {
-                case LIGHTTYPE_SPOT: {
-                    const falloffEnd = Math.cos(this._outerConeAngle * Math.PI / 180.0);
-                    const falloffStart = Math.cos(this._innerConeAngle * Math.PI / 180.0);
-
-                    // https://github.com/mmp/pbrt-v4/blob/faac34d1a0ebd24928828fe9fa65b65f7efc5937/src/pbrt/lights.cpp#L1463
-                    i = this._luminance / (2 * Math.PI * ((1 - falloffStart) + (falloffStart - falloffEnd) / 2.0));
+                case LIGHTTYPE_SPOT:
+                    i = this._luminance / Light.getLightUnitConversion(this._type, this._outerConeAngle * Math.PI / 180.0, this._innerConeAngle * Math.PI / 180.0);
                     break;
-                }
                 case LIGHTTYPE_OMNI:
-                    // https://google.github.io/filament/Filament.md.html#lighting/directlighting/punctuallights/pointlights
-                    i = this._luminance / (4 * Math.PI);
-                    break;
                 case LIGHTTYPE_DIRECTIONAL:
-                    // https://google.github.io/filament/Filament.md.html#lighting/directlighting/directionallights
-                    // Directional light luminance is already in lux
-                    i = this._luminance;
+                    i = this._luminance / Light.getLightUnitConversion(this._type);
                     break;
             }
         }

--- a/src/scene/light.js
+++ b/src/scene/light.js
@@ -645,7 +645,7 @@ class Light {
      * @param {number} [innerAngle] - The inner angle of a spot light.
      * @returns {number} The scaling factor to multiply with the luminance value.
      */
-    static getLightUnitConversion(type, outerAngle = 1, innerAngle = 0) {
+    static getLightUnitConversion(type, outerAngle = Math.PI / 4, innerAngle = 0) {
         switch (type) {
             case LIGHTTYPE_SPOT: {
                 const falloffEnd = Math.cos(outerAngle);
@@ -762,7 +762,7 @@ class Light {
         if (this._usePhysicalUnits) {
             switch (this._type) {
                 case LIGHTTYPE_SPOT:
-                    i = this._luminance / Light.getLightUnitConversion(this._type, this._outerConeAngle * Math.PI / 180.0, this._innerConeAngle * Math.PI / 180.0);
+                    i = this._luminance / Light.getLightUnitConversion(this._type, this._outerConeAngle * math.DEG_TO_RAD, this._innerConeAngle * math.DEG_TO_RAD);
                     break;
                 case LIGHTTYPE_OMNI:
                 case LIGHTTYPE_DIRECTIONAL:

--- a/src/scene/light.js
+++ b/src/scene/light.js
@@ -767,15 +767,7 @@ class Light {
 
         // To calculate the lux, which is lm/m^2, we need to convert from luminous power
         if (this._usePhysicalUnits) {
-            switch (this._type) {
-                case LIGHTTYPE_SPOT:
-                    i = this._luminance / Light.getLightUnitConversion(this._type, this._outerConeAngle * math.DEG_TO_RAD, this._innerConeAngle * math.DEG_TO_RAD);
-                    break;
-                case LIGHTTYPE_OMNI:
-                case LIGHTTYPE_DIRECTIONAL:
-                    i = this._luminance / Light.getLightUnitConversion(this._type);
-                    break;
-            }
+            i = this._luminance / Light.getLightUnitConversion(this._type, this._outerConeAngle * math.DEG_TO_RAD, this._innerConeAngle * math.DEG_TO_RAD);
         }
 
         const finalColor = this._finalColor;

--- a/src/scene/materials/standard-material-options-builder.js
+++ b/src/scene/materials/standard-material-options-builder.js
@@ -259,7 +259,7 @@ class StandardMaterialOptionsBuilder {
         }
 
         // TODO: add a test for if non skybox cubemaps have rotation (when this is supported) - for now assume no non-skybox cubemap rotation
-        options.skyboxIntensity = usingSceneEnv && (scene.skyboxIntensity !== 1 || scene.skyboxLuminance !== 0);
+        options.skyboxIntensity = usingSceneEnv && (scene.skyboxIntensity !== 1 || scene.physicalUnits);
         options.useCubeMapRotation = usingSceneEnv && scene.skyboxRotation && !scene.skyboxRotation.equals(Quat.IDENTITY);
     }
 

--- a/src/scene/materials/standard-material-options-builder.js
+++ b/src/scene/materials/standard-material-options-builder.js
@@ -106,8 +106,11 @@ class StandardMaterialOptionsBuilder {
 
         options.vertexColors = false;
         this._mapXForms = [];
+
+        const uniqueTextureMap = {};
+        this.uniqueTextureMappingCounter = 0;
         for (const p in _matTex2D) {
-            this._updateTexOptions(options, stdMat, p, hasUv0, hasUv1, hasVcolor, minimalOptions);
+            this._updateTexOptions(options, stdMat, p, hasUv0, hasUv1, hasVcolor, minimalOptions, uniqueTextureMap);
         }
         this._mapXForms = null;
     }
@@ -311,7 +314,7 @@ class StandardMaterialOptionsBuilder {
         }
     }
 
-    _updateTexOptions(options, stdMat, p, hasUv0, hasUv1, hasVcolor, minimalOptions) {
+    _updateTexOptions(options, stdMat, p, hasUv0, hasUv1, hasVcolor, minimalOptions, uniqueTextureMap) {
         const mname = p + 'Map';
         const vname = p + 'VertexColor';
         const vcname = p + 'VertexColorChannel';
@@ -326,6 +329,7 @@ class StandardMaterialOptionsBuilder {
             options[cname] = '';
             options[tname] = 0;
             options[uname] = 0;
+            options[iname] = undefined;
         }
         options[vname] = false;
         options[vcname] = '';
@@ -347,8 +351,20 @@ class StandardMaterialOptionsBuilder {
                 if (stdMat[uname] === 0 && !hasUv0) allow = false;
                 if (stdMat[uname] === 1 && !hasUv1) allow = false;
                 if (allow) {
+
+                    // create an intermediate map between the textures and their slots
+                    // to ensure the unique texture mapping isn't dependent on the texture id
+                    // as that will change when textures are changed, even if the sharing is the same
+                    const mapId = stdMat[mname].id;
+                    let identifier = uniqueTextureMap[mapId];
+                    if (identifier === undefined) {
+                        uniqueTextureMap[mapId] = this.uniqueTextureMappingCounter;
+                        identifier = this.uniqueTextureMappingCounter;
+                        this.uniqueTextureMappingCounter++;
+                    }
+
                     options[mname] = !!stdMat[mname];
-                    options[iname] = stdMat[mname].name;
+                    options[iname] = identifier;
                     options[tname] = this._getMapTransformID(stdMat.getUniform(tname), stdMat[uname]);
                     options[cname] = stdMat[cname];
                     options[uname] = stdMat[uname];

--- a/src/scene/sky.js
+++ b/src/scene/sky.js
@@ -52,7 +52,7 @@ class Sky {
                 return library.getProgram('skybox', {
                     type: 'cubemap',
                     encoding: texture.encoding,
-                    useIntensity: scene.skyboxIntensity !== 1 || scene.skyboxLuminance !== 0,
+                    useIntensity: scene.skyboxIntensity !== 1 || scene.physicalUnits,
                     mip: texture.fixCubemapSeams ? scene.skyboxMip : 0,
                     fixSeams: texture.fixCubemapSeams,
                     gamma: (pass === SHADER_FORWARDHDR ? (scene.gammaCorrection ? GAMMA_SRGBHDR : GAMMA_NONE) : scene.gammaCorrection),
@@ -63,7 +63,7 @@ class Sky {
             return library.getProgram('skybox', {
                 type: 'envAtlas',
                 encoding: texture.encoding,
-                useIntensity: scene.skyboxIntensity !== 1 || scene.skyboxLuminance !== 0,
+                useIntensity: scene.skyboxIntensity !== 1 || scene.physicalUnits,
                 gamma: (pass === SHADER_FORWARDHDR ? (scene.gammaCorrection ? GAMMA_SRGBHDR : GAMMA_NONE) : scene.gammaCorrection),
                 toneMapping: (pass === SHADER_FORWARDHDR ? TONEMAP_LINEAR : scene.toneMapping)
             });


### PR DESCRIPTION
### Description

The GLB parser doesn't set the luminance parameter on the light entities it creates, resulting in no lights being visible in GLBs when physical lights are enabled. 

This PR also fixes another bug where sky light intensity can't be 0 when physical units are enabled. 