### PR TITLE
Refactored ProgramLibrary to use the DeviceCache

### DIFF
--- a/src/deprecated/deprecated.js
+++ b/src/deprecated/deprecated.js
@@ -41,7 +41,8 @@ import { GraphicsDevice } from '../graphics/graphics-device.js';
 import { IndexBuffer } from '../graphics/index-buffer.js';
 import { createFullscreenQuad, drawFullscreenQuad, PostEffect } from '../graphics/post-effect.js';
 import { PostEffectQueue } from '../framework/components/camera/post-effect-queue.js';
-import { getProgramLibrary, ProgramLibrary } from '../graphics/program-library.js';
+import { ProgramLibrary } from '../graphics/program-library.js';
+import { getProgramLibrary } from '../graphics/get-program-library.js';
 import { RenderTarget } from '../graphics/render-target.js';
 import { ScopeId } from '../graphics/scope-id.js';
 import { Shader } from '../graphics/shader.js';
@@ -499,6 +500,11 @@ GraphicsDevice.prototype.getProgramLibrary = function () {
 
 GraphicsDevice.prototype.setProgramLibrary = function () {
     Debug.deprecated(`pc.GraphicsDevice#setProgramLibrary is deprecated.`);
+};
+
+GraphicsDevice.prototype.removeShaderFromCache = function(shader) {
+    Debug.deprecated(`pc.GraphicsDevice#removeShaderFromCache is deprecated.`);
+    getProgramLibrary(this).removeFromCache(shader);
 };
 
 // SCENE

--- a/src/deprecated/deprecated.js
+++ b/src/deprecated/deprecated.js
@@ -42,7 +42,7 @@ import { IndexBuffer } from '../graphics/index-buffer.js';
 import { createFullscreenQuad, drawFullscreenQuad, PostEffect } from '../graphics/post-effect.js';
 import { PostEffectQueue } from '../framework/components/camera/post-effect-queue.js';
 import { ProgramLibrary } from '../graphics/program-library.js';
-import { getProgramLibrary } from '../graphics/get-program-library.js';
+import { getProgramLibrary, setProgramLibrary } from '../graphics/get-program-library.js';
 import { RenderTarget } from '../graphics/render-target.js';
 import { ScopeId } from '../graphics/scope-id.js';
 import { Shader } from '../graphics/shader.js';
@@ -498,8 +498,9 @@ GraphicsDevice.prototype.getProgramLibrary = function () {
     return getProgramLibrary(this);
 };
 
-GraphicsDevice.prototype.setProgramLibrary = function () {
+GraphicsDevice.prototype.setProgramLibrary = function (lib) {
     Debug.deprecated(`pc.GraphicsDevice#setProgramLibrary is deprecated.`);
+    setProgramLibrary(this, lib);
 };
 
 GraphicsDevice.prototype.removeShaderFromCache = function (shader) {

--- a/src/deprecated/deprecated.js
+++ b/src/deprecated/deprecated.js
@@ -41,7 +41,7 @@ import { GraphicsDevice } from '../graphics/graphics-device.js';
 import { IndexBuffer } from '../graphics/index-buffer.js';
 import { createFullscreenQuad, drawFullscreenQuad, PostEffect } from '../graphics/post-effect.js';
 import { PostEffectQueue } from '../framework/components/camera/post-effect-queue.js';
-import { ProgramLibrary } from '../graphics/program-library.js';
+import { getProgramLibrary, ProgramLibrary } from '../graphics/program-library.js';
 import { RenderTarget } from '../graphics/render-target.js';
 import { ScopeId } from '../graphics/scope-id.js';
 import { Shader } from '../graphics/shader.js';
@@ -491,6 +491,15 @@ Object.defineProperties(Texture.prototype, {
         }
     }
 });
+
+GraphicsDevice.prototype.getProgramLibrary = function () {
+    Debug.deprecated(`pc.GraphicsDevice#getProgramLibrary is deprecated.`);
+    return getProgramLibrary(this);
+};
+
+GraphicsDevice.prototype.setProgramLibrary = function () {
+    Debug.deprecated(`pc.GraphicsDevice#setProgramLibrary is deprecated.`);
+};
 
 // SCENE
 

--- a/src/deprecated/deprecated.js
+++ b/src/deprecated/deprecated.js
@@ -502,7 +502,7 @@ GraphicsDevice.prototype.setProgramLibrary = function () {
     Debug.deprecated(`pc.GraphicsDevice#setProgramLibrary is deprecated.`);
 };
 
-GraphicsDevice.prototype.removeShaderFromCache = function(shader) {
+GraphicsDevice.prototype.removeShaderFromCache = function (shader) {
     Debug.deprecated(`pc.GraphicsDevice#removeShaderFromCache is deprecated.`);
     getProgramLibrary(this).removeFromCache(shader);
 };

--- a/src/framework/app-base.js
+++ b/src/framework/app-base.js
@@ -20,6 +20,8 @@ import { http } from '../net/http.js';
 import {
     PRIMITIVE_TRIANGLES, PRIMITIVE_TRIFAN, PRIMITIVE_TRISTRIP
 } from '../graphics/constants.js';
+import { setProgramLibrary } from '../graphics/get-program-library.js';
+import { ProgramLibrary } from '../graphics/program-library.js';
 
 import {
     LAYERID_DEPTH, LAYERID_IMMEDIATE, LAYERID_SKYBOX, LAYERID_UI, LAYERID_WORLD,
@@ -281,6 +283,7 @@ class AppBase extends EventHandler {
         this.graphicsDevice = device;
 
         this._initDefaultMaterial();
+        this._initProgramLibrary();
         this.stats = new ApplicationStats(device);
 
         /**
@@ -663,6 +666,12 @@ class AppBase extends EventHandler {
         material.name = "Default Material";
         material.shadingModel = SPECULAR_BLINN;
         setDefaultMaterial(this.graphicsDevice, material);
+    }
+
+    /** @private */
+    _initProgramLibrary() {
+        const library = new ProgramLibrary(this.graphicsDevice, new StandardMaterial());
+        setProgramLibrary(this.graphicsDevice, library);
     }
 
     /**

--- a/src/graphics/get-program-library.js
+++ b/src/graphics/get-program-library.js
@@ -1,0 +1,37 @@
+import { Debug } from '../core/debug.js';
+import { DeviceCache } from './device-cache.js';
+
+/** @typedef {import('./graphics-device.js').GraphicsDevice} GraphicsDevice */
+/** @typedef {import('./program-library.js').ProgramLibrary} ProgramLibrary */
+
+// Device cache storing a program library
+const programLibraryDeviceCache = new DeviceCache();
+
+/**
+ * Returns program library for a specified instance of a device.
+ *
+ * @param {GraphicsDevice} device - The graphics device used to own the material.
+ * @returns {ProgramLibrary} The instance of {@link ProgramLibrary}
+ * @ignore
+ */
+function getProgramLibrary(device) {
+    const library = programLibraryDeviceCache.get(device);
+    Debug.assert(library);
+    return library;
+}
+
+/**
+ * Assigns the program library to device cache
+ *
+ * @param {GraphicsDevice} device - The graphics device used to own the program library.
+ * @param {ProgramLibrary} library - The instance of {@link ProgramLibrary}
+ * @ignore
+ */
+function setProgramLibrary(device, library) {
+    Debug.assert(library);
+    programLibraryDeviceCache.get(device, () => {
+        return library;
+    });
+}
+
+export { getProgramLibrary, setProgramLibrary };

--- a/src/graphics/get-program-library.js
+++ b/src/graphics/get-program-library.js
@@ -21,7 +21,7 @@ function getProgramLibrary(device) {
 }
 
 /**
- * Assigns the program library to device cache
+ * Assigns the program library to device cache.
  *
  * @param {GraphicsDevice} device - The graphics device used to own the program library.
  * @param {ProgramLibrary} library - The instance of {@link ProgramLibrary}

--- a/src/graphics/get-program-library.js
+++ b/src/graphics/get-program-library.js
@@ -10,7 +10,7 @@ const programLibraryDeviceCache = new DeviceCache();
 /**
  * Returns program library for a specified instance of a device.
  *
- * @param {GraphicsDevice} device - The graphics device used to own the material.
+ * @param {GraphicsDevice} device - The graphics device used to own the program library.
  * @returns {ProgramLibrary} The instance of {@link ProgramLibrary}
  * @ignore
  */

--- a/src/graphics/get-program-library.js
+++ b/src/graphics/get-program-library.js
@@ -24,7 +24,7 @@ function getProgramLibrary(device) {
  * Assigns the program library to device cache.
  *
  * @param {GraphicsDevice} device - The graphics device used to own the program library.
- * @param {ProgramLibrary} library - The instance of {@link ProgramLibrary}
+ * @param {ProgramLibrary} library - The instance of {@link ProgramLibrary}.
  * @ignore
  */
 function setProgramLibrary(device, library) {

--- a/src/graphics/graphics-device.js
+++ b/src/graphics/graphics-device.js
@@ -3,7 +3,6 @@ import { platform } from '../core/platform.js';
 import { now } from '../core/time.js';
 
 import { ScopeSpace } from './scope-space.js';
-import { ProgramLibrary } from './program-library.js';
 
 import {
     PRIMITIVE_POINTS, PRIMITIVE_TRIFAN
@@ -192,9 +191,6 @@ class GraphicsDevice extends EventHandler {
 
         this.textureBias = this.scope.resolve("textureBias");
         this.textureBias.setValue(0.0);
-
-        // Create the program library instance
-        this.programLib = new ProgramLibrary(this);
     }
 
     /**
@@ -230,29 +226,6 @@ class GraphicsDevice extends EventHandler {
         this.vertexBuffers = [];
         this.shader = null;
         this.renderTarget = null;
-    }
-
-    /**
-     * Retrieves the program library assigned to the specified graphics device.
-     *
-     * @returns {ProgramLibrary} The program library assigned to the device.
-     * @ignore
-     */
-    getProgramLibrary() {
-        return this.programLib;
-    }
-
-    /**
-     * Assigns a program library to the specified device. By default, a graphics device is created
-     * with a program library that manages all of the programs that are used to render any
-     * graphical primitives. However, this function allows the user to replace the existing program
-     * library with a new one.
-     *
-     * @param {ProgramLibrary} programLib - The program library to assign to the device.
-     * @ignore
-     */
-    setProgramLibrary(programLib) {
-        this.programLib = programLib;
     }
 
     /**

--- a/src/graphics/program-lib/utils.js
+++ b/src/graphics/program-lib/utils.js
@@ -7,6 +7,7 @@ import {
 import { Shader } from '../shader.js';
 
 import { shaderChunks } from './chunks/chunks.js';
+import { getProgramLibrary } from '../program-library.js';
 
 import { dummyFragmentCode, precisionCode, versionCode } from './programs/common.js';
 
@@ -102,7 +103,7 @@ function createShader(device, vsName, psName, useTransformFeedback = false) {
  * @returns {Shader} The newly created shader.
  */
 function createShaderFromCode(device, vsCode, psCode, uName, useTransformFeedback = false, psPreamble = "") {
-    const shaderCache = device.programLib._cache;
+    const shaderCache = getProgramLibrary(device)._cache;
     const cached = shaderCache[uName];
     if (cached !== undefined) return cached;
 

--- a/src/graphics/program-lib/utils.js
+++ b/src/graphics/program-lib/utils.js
@@ -7,7 +7,7 @@ import {
 import { Shader } from '../shader.js';
 
 import { shaderChunks } from './chunks/chunks.js';
-import { getProgramLibrary } from '../program-library.js';
+import { getProgramLibrary } from '../get-program-library.js';
 
 import { dummyFragmentCode, precisionCode, versionCode } from './programs/common.js';
 

--- a/src/graphics/program-library.js
+++ b/src/graphics/program-library.js
@@ -4,14 +4,7 @@ import { version, revision } from '../core/core.js';
 import { Shader } from './shader.js';
 
 import { SHADER_FORWARD, SHADER_DEPTH, SHADER_PICK, SHADER_SHADOW } from '../scene/constants.js';
-import { StandardMaterial } from '../scene/materials/standard-material.js';
 import { ShaderPass } from '../scene/shader-pass.js';
-import { DeviceCache } from './device-cache.js';
-
-/** @typedef {import('./graphics-device.js').GraphicsDevice} GraphicsDevice */
-
-// Device cache storing a program library
-const programLibraryDeviceCache = new DeviceCache();
 
 /**
  * A class responsible for creation and caching of required shaders.
@@ -29,7 +22,7 @@ class ProgramLibrary {
      */
     processedCache = new Map();
 
-    constructor(device) {
+    constructor(device, standardMaterial) {
         this._device = device;
         this._cache = {};
         this._generators = {};
@@ -41,11 +34,10 @@ class ProgramLibrary {
         this._defaultStdMatOption = {};
         this._defaultStdMatOptionMin = {};
 
-        const m = new StandardMaterial();
-        m.shaderOptBuilder.updateRef(
-            this._defaultStdMatOption, {}, m, null, [], SHADER_FORWARD, null);
-        m.shaderOptBuilder.updateMinRef(
-            this._defaultStdMatOptionMin, {}, m, null, [], SHADER_SHADOW, null);
+        standardMaterial.shaderOptBuilder.updateRef(
+            this._defaultStdMatOption, {}, standardMaterial, null, [], SHADER_FORWARD, null);
+        standardMaterial.shaderOptBuilder.updateMinRef(
+            this._defaultStdMatOptionMin, {}, standardMaterial, null, [], SHADER_SHADOW, null);
     }
 
     destroy() {
@@ -231,17 +223,4 @@ class ProgramLibrary {
     }
 }
 
-/**
- * Returns program library for a specified instance of a device.
- *
- * @param {GraphicsDevice} device - The graphics device used to own the material.
- * @returns {ProgramLibrary} The instance of {@link ProgramLibrary}
- * @ignore
- */
-function getProgramLibrary(device) {
-    return programLibraryDeviceCache.get(device, () => {
-        return new ProgramLibrary(device);
-    });
-}
-
-export { ProgramLibrary, getProgramLibrary };
+export { ProgramLibrary };

--- a/src/graphics/reproject-texture.js
+++ b/src/graphics/reproject-texture.js
@@ -11,7 +11,7 @@ import { ChunkUtils } from './program-lib/chunk-utils.js';
 import { shaderChunks } from './program-lib/chunks/chunks.js';
 import { RenderTarget } from './render-target.js';
 import { GraphicsDevice } from './graphics-device.js';
-import { getProgramLibrary } from './program-library.js';
+import { getProgramLibrary } from './get-program-library.js';
 import { Texture } from './texture.js';
 import { DebugGraphics } from './debug-graphics.js';
 import { DeviceCache } from './device-cache.js';

--- a/src/graphics/reproject-texture.js
+++ b/src/graphics/reproject-texture.js
@@ -11,6 +11,7 @@ import { ChunkUtils } from './program-lib/chunk-utils.js';
 import { shaderChunks } from './program-lib/chunks/chunks.js';
 import { RenderTarget } from './render-target.js';
 import { GraphicsDevice } from './graphics-device.js';
+import { getProgramLibrary } from './program-library.js';
 import { Texture } from './texture.js';
 import { DebugGraphics } from './debug-graphics.js';
 import { DeviceCache } from './device-cache.js';
@@ -437,7 +438,7 @@ function reprojectTexture(source, target, options = {}) {
 
     const device = source.device;
 
-    let shader = device.programLib._cache[shaderKey];
+    let shader = getProgramLibrary(device)._cache[shaderKey];
     if (!shader) {
         const defines =
             `#define PROCESS_FUNC ${processFunc}\n` +

--- a/src/graphics/webgl/webgl-graphics-device.js
+++ b/src/graphics/webgl/webgl-graphics-device.js
@@ -29,6 +29,7 @@ import { shaderChunks } from '../program-lib/chunks/chunks.js';
 import { RenderTarget } from '../render-target.js';
 import { Texture } from '../texture.js';
 import { DebugGraphics } from '../debug-graphics.js';
+import { getProgramLibrary } from '../program-library.js';
 
 import { WebglVertexBuffer } from './webgl-vertex-buffer.js';
 import { WebglIndexBuffer } from './webgl-index-buffer.js';
@@ -2734,7 +2735,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
             delete this.vertexShaderCache[shaderSrc];
         }
 
-        this.programLib.clearCache();
+        getProgramLibrary(this).clearCache();
     }
 
     /**
@@ -2758,7 +2759,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
      * @ignore
      */
     removeShaderFromCache(shader) {
-        this.programLib.removeFromCache(shader);
+        getProgramLibrary(this).removeFromCache(shader);
     }
 
     /**

--- a/src/graphics/webgl/webgl-graphics-device.js
+++ b/src/graphics/webgl/webgl-graphics-device.js
@@ -29,7 +29,6 @@ import { shaderChunks } from '../program-lib/chunks/chunks.js';
 import { RenderTarget } from '../render-target.js';
 import { Texture } from '../texture.js';
 import { DebugGraphics } from '../debug-graphics.js';
-import { getProgramLibrary } from '../program-library.js';
 
 import { WebglVertexBuffer } from './webgl-vertex-buffer.js';
 import { WebglIndexBuffer } from './webgl-index-buffer.js';
@@ -2734,8 +2733,6 @@ class WebglGraphicsDevice extends GraphicsDevice {
             gl.deleteShader(this.vertexShaderCache[shaderSrc]);
             delete this.vertexShaderCache[shaderSrc];
         }
-
-        getProgramLibrary(this).clearCache();
     }
 
     /**
@@ -2750,16 +2747,6 @@ class WebglGraphicsDevice extends GraphicsDevice {
         });
 
         this._vaoMap.clear();
-    }
-
-    /**
-     * Removes a shader from the cache.
-     *
-     * @param {Shader} shader - The shader to remove from the cache.
-     * @ignore
-     */
-    removeShaderFromCache(shader) {
-        getProgramLibrary(this).removeFromCache(shader);
     }
 
     /**

--- a/src/graphics/webgl/webgl-shader.js
+++ b/src/graphics/webgl/webgl-shader.js
@@ -3,6 +3,7 @@ import { now } from '../../core/time.js';
 
 import { ShaderInput } from '../shader-input.js';
 import { SHADERTAG_MATERIAL, semanticToLocation } from '../constants.js';
+import { getProgramLibrary } from '../get-program-library.js';
 
 /** @typedef {import('./webgl-graphics-device.js').WebglGraphicsDevice} WebglGraphicsDevice */
 /** @typedef {import('../shader.js').Shader} Shader */
@@ -35,7 +36,7 @@ class WebglShader {
         if (this.glProgram) {
             device.gl.deleteProgram(this.glProgram);
             this.glProgram = null;
-            device.removeShaderFromCache(shader);
+            getProgramLibrary(device).removeFromCache(shader);
         }
     }
 

--- a/src/scene/materials/basic-material.js
+++ b/src/scene/materials/basic-material.js
@@ -7,7 +7,7 @@ import {
 
 import { basic } from '../../graphics/program-lib/programs/basic.js';
 import { ShaderProcessorOptions } from '../../graphics/shader-processor-options.js';
-import { getProgramLibrary } from '../../graphics/program-library.js';
+import { getProgramLibrary } from '../../graphics/get-program-library.js';
 import { Material } from './material.js';
 
 /** @typedef {import('../../graphics/texture.js').Texture} Texture */

--- a/src/scene/materials/basic-material.js
+++ b/src/scene/materials/basic-material.js
@@ -7,6 +7,7 @@ import {
 
 import { basic } from '../../graphics/program-lib/programs/basic.js';
 import { ShaderProcessorOptions } from '../../graphics/shader-processor-options.js';
+import { getProgramLibrary } from '../../graphics/program-library.js';
 import { Material } from './material.js';
 
 /** @typedef {import('../../graphics/texture.js').Texture} Texture */
@@ -108,7 +109,7 @@ class BasicMaterial extends Material {
 
         const processingOptions = new ShaderProcessorOptions(viewUniformFormat, viewBindGroupFormat);
 
-        const library = device.getProgramLibrary();
+        const library = getProgramLibrary(device);
         library.register('basic', basic);
 
         return library.getProgram('basic', options, processingOptions);

--- a/src/scene/materials/default-material.js
+++ b/src/scene/materials/default-material.js
@@ -1,6 +1,9 @@
 import { Debug } from '../../core/debug.js';
 import { DeviceCache } from '../../graphics/device-cache.js';
 
+/** @typedef {import('../../graphics/graphics-device.js').GraphicsDevice} GraphicsDevice */
+/** @typedef {import('./standard-material.js').StandardMaterial} StandardMaterial */
+
 // device cache storing default material
 const defaultMaterialDeviceCache = new DeviceCache();
 

--- a/src/scene/materials/material.js
+++ b/src/scene/materials/material.js
@@ -16,6 +16,7 @@ import {
 import { Debug } from '../../core/debug.js';
 import { getDefaultMaterial } from './default-material.js';
 import { ShaderProcessorOptions } from '../../graphics/shader-processor-options.js';
+import { getProgramLibrary } from '../../graphics/program-library.js';
 
 /** @typedef {import('../../graphics/texture.js').Texture} Texture */
 /** @typedef {import('../../graphics/shader.js').Shader} Shader */
@@ -402,7 +403,7 @@ class Material {
 
         // temporarily register the program generator
         const libraryModuleName = 'shader';
-        const library = device.getProgramLibrary();
+        const library = getProgramLibrary(device);
         Debug.assert(!library.isRegistered(libraryModuleName));
         library.register(libraryModuleName, materialGenerator);
 

--- a/src/scene/materials/material.js
+++ b/src/scene/materials/material.js
@@ -16,7 +16,7 @@ import {
 import { Debug } from '../../core/debug.js';
 import { getDefaultMaterial } from './default-material.js';
 import { ShaderProcessorOptions } from '../../graphics/shader-processor-options.js';
-import { getProgramLibrary } from '../../graphics/program-library.js';
+import { getProgramLibrary } from '../../graphics/get-program-library.js';
 
 /** @typedef {import('../../graphics/texture.js').Texture} Texture */
 /** @typedef {import('../../graphics/shader.js').Shader} Shader */

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -20,7 +20,7 @@ import { ShaderPass } from '../shader-pass.js';
 import { Material } from './material.js';
 import { StandardMaterialOptionsBuilder } from './standard-material-options-builder.js';
 import { ShaderProcessorOptions } from '../../graphics/shader-processor-options.js';
-import { getProgramLibrary } from '../../graphics/program-library.js';
+import { getProgramLibrary } from '../../graphics/get-program-library.js';
 
 import { standardMaterialCubemapParameters, standardMaterialTextureParameters } from './standard-material-parameters.js';
 

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -20,6 +20,7 @@ import { ShaderPass } from '../shader-pass.js';
 import { Material } from './material.js';
 import { StandardMaterialOptionsBuilder } from './standard-material-options-builder.js';
 import { ShaderProcessorOptions } from '../../graphics/shader-processor-options.js';
+import { getProgramLibrary } from '../../graphics/program-library.js';
 
 import { standardMaterialCubemapParameters, standardMaterialTextureParameters } from './standard-material-parameters.js';
 
@@ -832,7 +833,7 @@ class StandardMaterial extends Material {
 
         const processingOptions = new ShaderProcessorOptions(viewUniformFormat, viewBindGroupFormat);
 
-        const library = device.getProgramLibrary();
+        const library = getProgramLibrary(device);
         library.register('standard', standard);
         const shader = library.getProgram('standard', options, processingOptions);
 

--- a/src/scene/particle-system/particle-emitter.js
+++ b/src/scene/particle-system/particle-emitter.js
@@ -31,6 +31,7 @@ import { VertexBuffer } from '../../graphics/vertex-buffer.js';
 import { VertexFormat } from '../../graphics/vertex-format.js';
 import { DeviceCache } from '../../graphics/device-cache.js';
 import { particle } from '../../graphics/program-lib/programs/particle.js';
+import { getProgramLibrary } from '../../graphics/program-library.js';
 
 import {
     BLEND_NORMAL,
@@ -828,8 +829,8 @@ class ParticleEmitter {
     }
 
     regenShader() {
-        const programLib = this.graphicsDevice.getProgramLibrary();
-        this.graphicsDevice.programLib.register('particle', particle);
+        const programLib = getProgramLibrary(this.graphicsDevice);
+        programLib.register('particle', particle);
 
         const hasNormal = (this.normalMap !== null);
         this.normalOption = 0;

--- a/src/scene/particle-system/particle-emitter.js
+++ b/src/scene/particle-system/particle-emitter.js
@@ -31,7 +31,7 @@ import { VertexBuffer } from '../../graphics/vertex-buffer.js';
 import { VertexFormat } from '../../graphics/vertex-format.js';
 import { DeviceCache } from '../../graphics/device-cache.js';
 import { particle } from '../../graphics/program-lib/programs/particle.js';
-import { getProgramLibrary } from '../../graphics/program-library.js';
+import { getProgramLibrary } from '../../graphics/get-program-library.js';
 
 import {
     BLEND_NORMAL,

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -104,6 +104,7 @@ class ForwardRenderer {
      */
     constructor(graphicsDevice) {
         this.device = graphicsDevice;
+        const device = this.device;
 
         /** @type {Scene|null} */
         this.scene = null;
@@ -126,10 +127,6 @@ class ForwardRenderer {
         this._layerCompositionUpdateTime = 0;
         this._lightClustersTime = 0;
         this._lightClusters = 0;
-
-        // Shaders
-        const device = this.device;
-        this.library = device.getProgramLibrary();
 
         // texture atlas managing shadow map / cookie texture atlassing for omni and spot lights
         this.lightTextureAtlas = new LightTextureAtlas(device);

--- a/src/scene/sky.js
+++ b/src/scene/sky.js
@@ -11,6 +11,7 @@ import { GraphNode } from './graph-node.js';
 import { Material } from './materials/material.js';
 import { MeshInstance } from './mesh-instance.js';
 import { skybox } from '../graphics/program-lib/programs/skybox.js';
+import { getProgramLibrary } from '../graphics/program-library.js';
 
 /** @typedef {import('../graphics/texture.js').Texture} Texture */
 /** @typedef {import('../graphics/graphics-device.js').GraphicsDevice} GraphicsDevice */
@@ -45,7 +46,7 @@ class Sky {
         const material = new Material();
 
         material.getShaderVariant = function (dev, sc, defs, staticLightList, pass, sortedLights, viewUniformFormat, viewBindGroupFormat) {
-            const library = device.getProgramLibrary();
+            const library = getProgramLibrary(device);
             library.register('skybox', skybox);
 
             if (texture.cubemap) {

--- a/src/scene/sky.js
+++ b/src/scene/sky.js
@@ -11,7 +11,7 @@ import { GraphNode } from './graph-node.js';
 import { Material } from './materials/material.js';
 import { MeshInstance } from './mesh-instance.js';
 import { skybox } from '../graphics/program-lib/programs/skybox.js';
-import { getProgramLibrary } from '../graphics/program-library.js';
+import { getProgramLibrary } from '../graphics/get-program-library.js';
 
 /** @typedef {import('../graphics/texture.js').Texture} Texture */
 /** @typedef {import('../graphics/graphics-device.js').GraphicsDevice} GraphicsDevice */


### PR DESCRIPTION
- removed an instance of ProgramLibrary from GraphicsDevice, removing a circular references, and breaking dependency of Graphics on what should be a higher level library

deprecated function on the GraphicsDevice:
```
getProgramLibrary();
setProgramLibrary(programLib);
removeShaderFromCache(shader);
```

removed circular dependencies:
```
src/graphics/program-lib/utils.js -> src/graphics/program-library.js -> src/scene/materials/standard-material.js
 -> src/graphics/env-lighting.js -> src/graphics/reproject-texture.js -> src/graphics/program-lib/utils.js

src/graphics/program-library.js -> src/scene/materials/standard-material.js -> src/graphics/env-lighting.js
 -> src/graphics/reproject-texture.js -> src/graphics/program-library.js

src/graphics/program-library.js -> src/scene/materials/standard-material.js -> src/scene/materials/material.js
 -> src/graphics/program-library.js
```