### PR TITLE
Exposed build targets for rollup visualizers: network and sunburst

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,6 +116,8 @@
     "build:es6": "rollup -c --environment target:es6",
     "build:profiler": "rollup -c --environment target:profiler",
     "build:treemap": "npm run build:es5 -- --environment treemap",
+    "build:treenet": "npm run build:es5 -- --environment treenet",
+    "build:treesun": "npm run build:es5 -- --environment treesun",
     "build:types": "npm run build:dts && node types-fixup.mjs && rollup -c --environment target:types && node types-undollar.mjs",
     "build:sourcemaps": "npm run build -- -m",
     "build:publish": "npm run build && npm run build:types",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -163,8 +163,23 @@ function buildTarget(buildType, moduleFormat) {
 
     if (process.env.treemap) {
         outputPlugins.min.push(visualizer({
+            filename: 'treemap.html',
             brotliSize: true,
             gzipSize: true
+        }));
+    }
+
+    if (process.env.treenet) {
+        outputPlugins.min.push(visualizer({
+            filename: 'treenet.html',
+            template: 'network'
+        }));
+    }
+
+    if (process.env.treesun) {
+        outputPlugins.min.push(visualizer({
+            filename: 'treesun.html',
+            template: 'sunburst'
         }));
     }
 


### PR DESCRIPTION
Sunburst
<img width="1082" alt="Screenshot 2022-10-04 at 16 01 28" src="https://user-images.githubusercontent.com/59932779/193854931-ca0c6103-4b0e-495a-822d-9b57ef389498.png">

Network - useful to find why a module is imported (not as useful for us at the moment, but could be in the future).
<img width="651" alt="Screenshot 2022-10-04 at 16 02 13" src="https://user-images.githubusercontent.com/59932779/193855126-24b5d82b-1d33-45e5-9f29-7ea2b0f481b8.png">
