### PR TITLE
[Fix] Fix vertex shader attribute validation to support builtins

### DIFF
--- a/src/graphics/webgl/webgl-shader.js
+++ b/src/graphics/webgl/webgl-shader.js
@@ -8,12 +8,6 @@ import { getProgramLibrary } from '../get-program-library.js';
 /** @typedef {import('./webgl-graphics-device.js').WebglGraphicsDevice} WebglGraphicsDevice */
 /** @typedef {import('../shader.js').Shader} Shader */
 
-/**
- * A WebGL implementation of the Shader.
- *
- * @ignore
- */
-
 const _vertexShaderBuiltins = [
     'gl_VertexID',
     'gl_InstanceID',
@@ -21,6 +15,12 @@ const _vertexShaderBuiltins = [
     'gl_BaseVertex',
     'gl_BaseInstance'
 ];
+
+/**
+ * A WebGL implementation of the Shader.
+ *
+ * @ignore
+ */
 class WebglShader {
     constructor(shader) {
         this.init();

--- a/src/graphics/webgl/webgl-shader.js
+++ b/src/graphics/webgl/webgl-shader.js
@@ -224,6 +224,7 @@ class WebglShader {
             info = gl.getActiveAttrib(glProgram, i++);
             location = gl.getAttribLocation(glProgram, info.name);
 
+            // a built-in attribute for which we do not need to provide any data
             if (info.name === 'gl_VertexID')
                 continue;
 

--- a/src/graphics/webgl/webgl-shader.js
+++ b/src/graphics/webgl/webgl-shader.js
@@ -13,6 +13,14 @@ import { getProgramLibrary } from '../get-program-library.js';
  *
  * @ignore
  */
+
+const _vertexShaderBuiltins = [
+    'gl_VertexID',
+    'gl_InstanceID',
+    'gl_DrawID',
+    'gl_BaseVertex',
+    'gl_BaseInstance'
+];
 class WebglShader {
     constructor(shader) {
         this.init();
@@ -215,17 +223,15 @@ class WebglShader {
             return false;
         }
 
-        let i, info, location, shaderInput;
-
         // Query the program for each vertex buffer input (GLSL 'attribute')
-        i = 0;
+        let i = 0;
         const numAttributes = gl.getProgramParameter(glProgram, gl.ACTIVE_ATTRIBUTES);
         while (i < numAttributes) {
-            info = gl.getActiveAttrib(glProgram, i++);
-            location = gl.getAttribLocation(glProgram, info.name);
+            const info = gl.getActiveAttrib(glProgram, i++);
+            const location = gl.getAttribLocation(glProgram, info.name);
 
-            // a built-in attribute for which we do not need to provide any data
-            if (info.name === 'gl_VertexID')
+            // a built-in attributes for which we do not need to provide any data
+            if (_vertexShaderBuiltins.find(name => name === info.name) !== undefined)
                 continue;
 
             // Check attributes are correctly linked up
@@ -233,7 +239,7 @@ class WebglShader {
                 console.error(`Vertex shader attribute "${info.name}" is not mapped to a semantic in shader definition.`);
             }
 
-            shaderInput = new ShaderInput(device, definition.attributes[info.name], device.pcUniformType[info.type], location);
+            const shaderInput = new ShaderInput(device, definition.attributes[info.name], device.pcUniformType[info.type], location);
 
             this.attributes.push(shaderInput);
         }
@@ -242,10 +248,10 @@ class WebglShader {
         i = 0;
         const numUniforms = gl.getProgramParameter(glProgram, gl.ACTIVE_UNIFORMS);
         while (i < numUniforms) {
-            info = gl.getActiveUniform(glProgram, i++);
-            location = gl.getUniformLocation(glProgram, info.name);
+            const info = gl.getActiveUniform(glProgram, i++);
+            const location = gl.getUniformLocation(glProgram, info.name);
 
-            shaderInput = new ShaderInput(device, info.name, device.pcUniformType[info.type], location);
+            const shaderInput = new ShaderInput(device, info.name, device.pcUniformType[info.type], location);
 
             if (info.type === gl.SAMPLER_2D || info.type === gl.SAMPLER_CUBE ||
                 (device.webgl2 && (info.type === gl.SAMPLER_2D_SHADOW || info.type === gl.SAMPLER_CUBE_SHADOW || info.type === gl.SAMPLER_3D))

--- a/src/graphics/webgl/webgl-shader.js
+++ b/src/graphics/webgl/webgl-shader.js
@@ -224,6 +224,9 @@ class WebglShader {
             info = gl.getActiveAttrib(glProgram, i++);
             location = gl.getAttribLocation(glProgram, info.name);
 
+            if (info.name === 'gl_VertexID')
+                continue;
+
             // Check attributes are correctly linked up
             if (definition.attributes[info.name] === undefined) {
                 console.error(`Vertex shader attribute "${info.name}" is not mapped to a semantic in shader definition.`);


### PR DESCRIPTION
Fix the error report and following null access when built in attributes, such as gl_VertexID or gl_InstanceID, are used in the vertex shader:

reported error:
`ASSERT FAILED:
Vertex shader attribute "gl_VertexID" is not mapped to a semantic in shader definition.`