### PR TITLE
[Fix] GltfExporter correctly exports buffer views for non-interleaved vertex data

### DIFF
--- a/extras/exporters/core-exporter.js
+++ b/extras/exporters/core-exporter.js
@@ -1,14 +1,16 @@
 class CoreExporter {
     /**
-     * Converts a source image specified in multiple formats to a canvas.
+     * Converts a texture to a canvas.
      *
-     * @param {any} image - The source image to be converted.
+     * @param {Texture} texture - The source texture to be converted.
      * @param {object} options - Object for passing optional arguments.
      * @param {Color} [options.color] - The tint color to modify the texture with.
      * @param {number} [options.maxTextureSize] - Maximum texture size. Texture is resized if over the size.
      * @returns {any} - The canvas element containing the image.
      */
-    imageToCanvas(image, options = {}) {
+    textureToCanvas(texture, options = {}) {
+
+        const image = texture.getSource();
 
         if ((typeof HTMLImageElement !== 'undefined' && image instanceof HTMLImageElement) ||
             (typeof HTMLCanvasElement !== 'undefined' && image instanceof HTMLCanvasElement) ||

--- a/extras/exporters/gltf-exporter.js
+++ b/extras/exporters/gltf-exporter.js
@@ -508,6 +508,11 @@ class GltfExporter extends CoreExporter {
         this.writeMeshes(resources, json);
         this.convertTextures(resources.textures, json, options);
 
+        // delete unused properties
+        if (!json.images.length) delete json.images;
+        if (!json.samplers.length) delete json.samplers;
+        if (!json.textures.length) delete json.textures;
+
         return json;
     }
 

--- a/extras/exporters/gltf-exporter.js
+++ b/extras/exporters/gltf-exporter.js
@@ -184,24 +184,28 @@ class GltfExporter extends CoreExporter {
 
         resources.buffers.forEach((buffer) => {
 
+            const addBufferView = (target, byteLength, byteOffset, byteStride) => {
+
+                const bufferView =  {
+                    target: target,
+                    buffer: 0,
+                    byteLength: byteLength,
+                    byteOffset: byteOffset,
+                    byteStride: byteStride
+                };
+
+                return json.bufferViews.push(bufferView) - 1;
+            };
+
             const arrayBuffer = buffer.lock();
 
             if (buffer instanceof pc.VertexBuffer) {
 
                 const format = buffer.getFormat();
-
                 if (format.interleaved) {
 
-                    const bufferView = {
-                        target: ARRAY_BUFFER,
-                        buffer: 0,
-                        byteLength: arrayBuffer.byteLength,
-                        byteOffset: offset,
-                        byteStride: format.size
-                    };
-
-                    const count = json.bufferViews.push(bufferView);
-                    resources.bufferViewMap.set(buffer, [count - 1]);
+                    const bufferViewIndex = addBufferView(ARRAY_BUFFER, arrayBuffer.byteLength, offset, format.size);
+                    resources.bufferViewMap.set(buffer, [bufferViewIndex]);
 
                 } else {
 
@@ -209,31 +213,18 @@ class GltfExporter extends CoreExporter {
                     const bufferViewIndices = [];
                     format.elements.forEach((element) => {
 
-                        const bufferView = {
-                            target: ARRAY_BUFFER,
-                            buffer: 0,
-                            byteLength: element.size * format.vertexCount,
-                            byteOffset: offset + element.offset
-                        };
+                        const bufferViewIndex = addBufferView(ARRAY_BUFFER, element.size * format.vertexCount, offset + element.offset);
+                        bufferViewIndices.push(bufferViewIndex);
 
-                        const count = json.bufferViews.push(bufferView);
-                        bufferViewIndices.push(count - 1);
                     });
 
                     resources.bufferViewMap.set(buffer, bufferViewIndices);
                 }
 
-            } else {
+            } else {    // index buffer
 
-                const bufferView = {
-                    target: ELEMENT_ARRAY_BUFFER,
-                    buffer: 0,
-                    byteLength: arrayBuffer.byteLength,
-                    byteOffset: offset
-                };
-
-                const count = json.bufferViews.push(bufferView);
-                resources.bufferViewMap.set(buffer, [count - 1]);
+                const bufferViewIndex = addBufferView(ELEMENT_ARRAY_BUFFER, arrayBuffer.byteLength, offset);
+                resources.bufferViewMap.set(buffer, [bufferViewIndex]);
 
             }
 

--- a/extras/exporters/gltf-exporter.js
+++ b/extras/exporters/gltf-exporter.js
@@ -213,7 +213,7 @@ class GltfExporter extends CoreExporter {
                     const bufferViewIndices = [];
                     format.elements.forEach((element) => {
 
-                        const bufferViewIndex = addBufferView(ARRAY_BUFFER, element.size * format.vertexCount, offset + element.offset);
+                        const bufferViewIndex = addBufferView(ARRAY_BUFFER, element.size * format.vertexCount, offset + element.offset, element.size);
                         bufferViewIndices.push(bufferViewIndex);
 
                     });

--- a/extras/exporters/gltf-exporter.js
+++ b/extras/exporters/gltf-exporter.js
@@ -383,11 +383,11 @@ class GltfExporter extends CoreExporter {
                     mesh.primitives.push(primitive);
 
                     // vertex buffer
-                    const vertexBuffer = meshInstance.mesh.vertexBuffer;
+                    const { vertexBuffer } = meshInstance.mesh;
+                    const { format } = vertexBuffer;
+                    const { interleaved, elements } = format;
                     const numVertices = vertexBuffer.getNumVertices();
-                    const vertexFormat = vertexBuffer.getFormat();
-                    const interleaved = vertexFormat.interleaved;
-                    vertexFormat.elements.forEach((element, elementIndex) => {
+                    elements.forEach((element, elementIndex) => {
 
                         const viewIndex = resources.bufferViewMap.get(vertexBuffer)[interleaved ? 0 : elementIndex];
 
@@ -454,7 +454,7 @@ class GltfExporter extends CoreExporter {
             const mimeType = isRGBA ? 'image/png' : 'image/jpeg';
 
             const texture = textures[i];
-            const mipObject = texture._levels[0];
+            const mipObject = texture.getSource();
 
             // convert texture data to uri
             const canvas = this.imageToCanvas(mipObject, textureOptions);

--- a/extras/exporters/gltf-exporter.js
+++ b/extras/exporters/gltf-exporter.js
@@ -453,28 +453,34 @@ class GltfExporter extends CoreExporter {
             const isRGBA = true;
             const mimeType = isRGBA ? 'image/png' : 'image/jpeg';
 
-            const texture = textures[i];
-            const mipObject = texture.getSource();
-
             // convert texture data to uri
-            const canvas = this.imageToCanvas(mipObject, textureOptions);
-            const uri = canvas.toDataURL(mimeType);
+            const texture = textures[i];
+            const canvas = this.textureToCanvas(texture, textureOptions);
 
-            json.images[i] = {
-                'uri': uri
-            };
+            // if texture format is supported
+            if (canvas) {
+                const uri = canvas.toDataURL(mimeType);
 
-            json.samplers[i] = {
-                'minFilter': getFilter(texture.minFilter),
-                'magFilter': getFilter(texture.magFilter),
-                'wrapS': getWrap(texture.addressU),
-                'wrapT': getWrap(texture.addressV)
-            };
+                json.images[i] = {
+                    'uri': uri
+                };
 
-            json.textures[i] = {
-                'sampler': i,
-                'source': i
-            };
+                json.samplers[i] = {
+                    'minFilter': getFilter(texture.minFilter),
+                    'magFilter': getFilter(texture.magFilter),
+                    'wrapS': getWrap(texture.addressU),
+                    'wrapT': getWrap(texture.addressV)
+                };
+
+                json.textures[i] = {
+                    'sampler': i,
+                    'source': i
+                };
+            } else {
+                // ignore it
+                console.log(`Export of texture ${texture.name} is not currently supported.`);
+                textures[i] = null;
+            }
         }
     }
 

--- a/extras/exporters/usdz-exporter.js
+++ b/extras/exporters/usdz-exporter.js
@@ -167,7 +167,7 @@ class UsdzExporter extends CoreExporter {
             const mimeType = isRGBA ? 'image/png' : 'image/jpeg';
 
             const texture = textureArray[i];
-            const mipObject = texture._levels[0];
+            const mipObject = texture.getSource();
 
             // convert texture data to canvas
             const canvas = this.imageToCanvas(mipObject, textureOptions);

--- a/extras/exporters/usdz-exporter.js
+++ b/extras/exporters/usdz-exporter.js
@@ -166,17 +166,23 @@ class UsdzExporter extends CoreExporter {
             const isRGBA = true;
             const mimeType = isRGBA ? 'image/png' : 'image/jpeg';
 
-            const texture = textureArray[i];
-            const mipObject = texture.getSource();
-
             // convert texture data to canvas
-            const canvas = this.imageToCanvas(mipObject, textureOptions);
+            const texture = textureArray[i];
+            const canvas = this.textureToCanvas(texture, textureOptions);
 
-            // async convert them to blog and then to array buffer
-            // eslint-disable-next-line no-promise-executor-return
-            promises.push(new Promise(resolve => canvas.toBlob(resolve, mimeType, 1)).then(
-                blob => blob.arrayBuffer()
-            ));
+            // if texture format is supported
+            if (canvas) {
+
+                // async convert them to blog and then to array buffer
+                // eslint-disable-next-line no-promise-executor-return
+                promises.push(new Promise(resolve => canvas.toBlob(resolve, mimeType, 1)).then(
+                    blob => blob.arrayBuffer()
+                ));
+
+            } else {
+                // ignore it
+                console.log(`Export of texture ${texture.name} is not currently supported.`);
+            }
         }
 
         // when all textures are converted


### PR DESCRIPTION
- Previously, a non-interleaved vertex buffer was stored using a single buffer view, which is not correct according to specs, as there is no single stride that can be specified for elements using it.
- This stores a per element buffer view for non=interleaved vertex formats, and removes last validation errors.

Additionally, handling of unsupported textures is now handled without crashing (by ignoring them), for both gltf and usdz exporters.