### PR TITLE
Refactored out access to getApplication in Mesh, Morph and Scene

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -177,6 +177,7 @@ const moduleOptions = {
 
 const stripFunctions = [
     'Debug.assert',
+    'Debug.assertDeprecated',
     'Debug.call',
     'Debug.deprecated',
     'Debug.warn',

--- a/src/core/debug.js
+++ b/src/core/debug.js
@@ -28,6 +28,18 @@ class Debug {
     }
 
     /**
+     * Assertion deprecated message. If the assertion is false, the deprecated message is written to the log.
+     *
+     * @param {boolean|object} assertion - The assertion to check.
+     * @param {string} message - The message to log.
+     */
+    static assertDeprecated(assertion, message) {
+        if (!assertion) {
+            Debug.deprecated(message);
+        }
+    }
+
+    /**
      * Assertion error message. If the assertion is false, the error message is written to the log.
      *
      * @param {boolean|object} assertion - The assertion to check.

--- a/src/framework/app-base.js
+++ b/src/framework/app-base.js
@@ -20,6 +20,7 @@ import { http } from '../platform/net/http.js';
 import {
     PRIMITIVE_TRIANGLES, PRIMITIVE_TRIFAN, PRIMITIVE_TRISTRIP
 } from '../platform/graphics/constants.js';
+import { GraphicsDeviceAccess } from '../platform/graphics/graphics-device-access.js';
 import { setProgramLibrary } from '../scene/shader-lib/get-program-library.js';
 import { ProgramLibrary } from '../scene/shader-lib/program-library.js';
 
@@ -281,6 +282,7 @@ class AppBase extends EventHandler {
          * @type {GraphicsDevice}
          */
         this.graphicsDevice = device;
+        GraphicsDeviceAccess.set(device);
 
         this._initDefaultMaterial();
         this._initProgramLibrary();

--- a/src/framework/globals.js
+++ b/src/framework/globals.js
@@ -1,3 +1,5 @@
+import { GraphicsDeviceAccess } from "../platform/graphics/graphics-device-access.js";
+
 let currentApplication;
 
 function getApplication() {
@@ -6,6 +8,7 @@ function getApplication() {
 
 function setApplication(app) {
     currentApplication = app;
+    GraphicsDeviceAccess.set(app?.graphicsDevice);
 }
 
 export {

--- a/src/platform/graphics/graphics-device-access.js
+++ b/src/platform/graphics/graphics-device-access.js
@@ -1,0 +1,21 @@
+/**
+ * A static class providing access to current GraphicsDevice. Note that this should not be used
+ * to access graphics device normally, and is provided only as a way of obtaining it to preserve
+ * backwards API compatibility. In normal situations, a device needs to be passed in to classes
+ * that need it.
+ *
+ * @ignore
+ */
+class GraphicsDeviceAccess {
+    static _graphicsDevice = null;
+
+    static set(graphicsDevice) {
+        GraphicsDeviceAccess._graphicsDevice = graphicsDevice;
+    }
+
+    static get() {
+        return GraphicsDeviceAccess._graphicsDevice;
+    }
+}
+
+export { GraphicsDeviceAccess };

--- a/src/scene/mesh.js
+++ b/src/scene/mesh.js
@@ -16,10 +16,9 @@ import { IndexBuffer } from '../platform/graphics/index-buffer.js';
 import { VertexBuffer } from '../platform/graphics/vertex-buffer.js';
 import { VertexFormat } from '../platform/graphics/vertex-format.js';
 import { VertexIterator } from '../platform/graphics/vertex-iterator.js';
+import { GraphicsDeviceAccess } from '../platform/graphics/graphics-device-access.js';
 
 import { RENDERSTYLE_SOLID, RENDERSTYLE_WIREFRAME, RENDERSTYLE_POINTS } from './constants.js';
-
-import { getApplication } from '../framework/globals.js';
 
 /** @typedef {import('../platform/graphics/graphics-device.js').GraphicsDevice} GraphicsDevice */
 /** @typedef {import('./morph.js').Morph} Morph */
@@ -175,7 +174,8 @@ class Mesh extends RefCountedObject {
     constructor(graphicsDevice) {
         super();
         this.id = id++;
-        this.device = graphicsDevice || getApplication().graphicsDevice;
+        Debug.assertDeprecated(graphicsDevice, "Mesh constructor takes a GraphicsDevice as a parameter, and it was not provided.");
+        this.device = graphicsDevice || GraphicsDeviceAccess.get();
 
         /**
          * The vertex buffer holding the vertex data of the mesh.

--- a/src/scene/morph.js
+++ b/src/scene/morph.js
@@ -6,12 +6,12 @@ import { BoundingBox } from '../core/shape/bounding-box.js';
 import { Texture } from '../platform/graphics/texture.js';
 import { VertexBuffer } from '../platform/graphics/vertex-buffer.js';
 import { VertexFormat } from '../platform/graphics/vertex-format.js';
-import { getApplication } from '../framework/globals.js';
 
 import {
     BUFFER_STATIC, TYPE_FLOAT32, SEMANTIC_ATTR15, ADDRESS_CLAMP_TO_EDGE, FILTER_NEAREST,
     PIXELFORMAT_RGBA16F, PIXELFORMAT_RGB32F
 } from '../platform/graphics/constants.js';
+import { GraphicsDeviceAccess } from '../platform/graphics/graphics-device-access.js';
 
 /** @typedef {import('../platform/graphics/graphics-device.js').GraphicsDevice} GraphicsDevice */
 /** @typedef {import('./morph-target.js').MorphTarget} MorphTarget */
@@ -33,10 +33,11 @@ class Morph extends RefCountedObject {
     constructor(targets, graphicsDevice) {
         super();
 
+        Debug.assertDeprecated(graphicsDevice, "Morph constructor takes a GraphicsDevice as a parameter, and it was not provided.");
+        this.device = graphicsDevice || GraphicsDeviceAccess.get();
+
         // validation
         targets.forEach(target => Debug.assert(!target.used, 'The target specified has already been used to create a Morph, use its clone instead.'));
-
-        this.device = graphicsDevice || getApplication().graphicsDevice;
         this._targets = targets.slice();
 
         // default to texture based morphing if available

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -1,3 +1,4 @@
+import { Debug } from '../core/debug.js';
 import { EventHandler } from '../core/event-handler.js';
 
 import { Color } from '../core/math/color.js';
@@ -5,13 +6,14 @@ import { Vec3 } from '../core/math/vec3.js';
 import { Quat } from '../core/math/quat.js';
 import { math } from '../core/math/math.js';
 
+import { GraphicsDeviceAccess } from '../platform/graphics/graphics-device-access.js';
+
 import { BAKE_COLORDIR, FOG_NONE, GAMMA_SRGB, LAYERID_IMMEDIATE } from './constants.js';
 import { Sky } from './sky.js';
 import { LightingParams } from './lighting/lighting-params.js';
 import { Immediate } from './immediate/immediate.js';
 
 import { EnvLighting } from './graphics/env-lighting.js';
-import { getApplication } from '../framework/globals.js';
 
 /** @typedef {import('../framework/entity.js').Entity} Entity */
 /** @typedef {import('../platform/graphics/graphics-device.js').GraphicsDevice} GraphicsDevice */
@@ -173,7 +175,8 @@ class Scene extends EventHandler {
     constructor(graphicsDevice) {
         super();
 
-        this.device = graphicsDevice || getApplication().graphicsDevice;
+        Debug.assertDeprecated(graphicsDevice, "Scene constructor takes a GraphicsDevice as a parameter, and it was not provided.");
+        this.device = graphicsDevice || GraphicsDeviceAccess.get();
 
         this._gravity = new Vec3(0, -9.8, 0);
 


### PR DESCRIPTION
This resolve the incorrect imports:
```
(!) Incorrect import: [scene/mesh.js] -> [../framework/globals.js]
(!) Incorrect import: [scene/morph.js] -> [../framework/globals.js]
(!) Incorrect import: [scene/scene.js] -> [../framework/globals.js]
```

Internal GraphicsDeviceAccess class mirrors functionality of getApplicatin(), on a platform level.

Also added deprecated messaged at the points of its use to provide API compatibility.