### PR TITLE
[Fix] Switching directional light to a clustered local light works.

### DIFF
--- a/src/scene/layer.js
+++ b/src/scene/layer.js
@@ -714,13 +714,13 @@ class Layer {
         if (!this._lightsSet.has(l)) {
             this._lightsSet.add(l);
 
-            if (l.type !== LIGHTTYPE_DIRECTIONAL) {
-                this._clusteredLightsSet.add(l);
-            }
-
             this._lights.push(l);
             this._dirtyLights = true;
             this._generateLightHash();
+        }
+
+        if (l.type !== LIGHTTYPE_DIRECTIONAL) {
+            this._clusteredLightsSet.add(l);
         }
     }
 
@@ -735,13 +735,13 @@ class Layer {
         if (this._lightsSet.has(l)) {
             this._lightsSet.delete(l);
 
-            if (l.type !== LIGHTTYPE_DIRECTIONAL) {
-                this._clusteredLightsSet.delete(l);
-            }
-
             this._lights.splice(this._lights.indexOf(l), 1);
             this._dirtyLights = true;
             this._generateLightHash();
+        }
+
+        if (l.type !== LIGHTTYPE_DIRECTIONAL) {
+            this._clusteredLightsSet.delete(l);
         }
     }
 


### PR DESCRIPTION
- switching light type currently adds light into a layer .. and layer handles the light being added there.
- that wasn't being correctly updating the clustered lights set, which this PR fixes