### PR TITLE
Move picker module from scene to framework

### DIFF
--- a/src/deprecated/deprecated.js
+++ b/src/deprecated/deprecated.js
@@ -64,7 +64,7 @@ import { Morph } from '../scene/morph.js';
 import { MeshInstance, Command } from '../scene/mesh-instance.js';
 import { Model } from '../scene/model.js';
 import { ParticleEmitter } from '../scene/particle-system/particle-emitter.js';
-import { Picker } from '../scene/picker.js';
+import { Picker } from '../framework/graphics/picker.js';
 import { Scene } from '../scene/scene.js';
 import { Skin } from '../scene/skin.js';
 import { SkinInstance } from '../scene/skin-instance.js';

--- a/src/framework/app-base.js
+++ b/src/framework/app-base.js
@@ -56,7 +56,7 @@ import { script } from './script.js';
 import { ApplicationStats } from './stats.js';
 import { Entity } from './entity.js';
 import { SceneRegistry } from './scene-registry.js';
-import { SceneGrab } from './scene-grab.js';
+import { SceneGrab } from './graphics/scene-grab.js';
 
 import {
     FILLMODE_FILL_WINDOW, FILLMODE_KEEP_ASPECT,

--- a/src/framework/graphics/picker.js
+++ b/src/framework/graphics/picker.js
@@ -1,25 +1,25 @@
-import { Color } from '../core/math/color.js';
+import { Color } from '../../core/math/color.js';
 
-import { ADDRESS_CLAMP_TO_EDGE, CLEARFLAG_DEPTH, FILTER_NEAREST, PIXELFORMAT_R8_G8_B8_A8 } from '../platform/graphics/constants.js';
-import { GraphicsDevice } from '../platform/graphics/graphics-device.js';
-import { RenderTarget } from '../platform/graphics/render-target.js';
-import { Texture } from '../platform/graphics/texture.js';
-import { DebugGraphics } from '../platform/graphics/debug-graphics.js';
+import { ADDRESS_CLAMP_TO_EDGE, CLEARFLAG_DEPTH, FILTER_NEAREST, PIXELFORMAT_R8_G8_B8_A8 } from '../../platform/graphics/constants.js';
+import { GraphicsDevice } from '../../platform/graphics/graphics-device.js';
+import { RenderTarget } from '../../platform/graphics/render-target.js';
+import { Texture } from '../../platform/graphics/texture.js';
+import { DebugGraphics } from '../../platform/graphics/debug-graphics.js';
 
-import { SHADER_PICK, SORTMODE_NONE } from './constants.js';
-import { Camera } from './camera.js';
-import { Command } from './mesh-instance.js';
-import { Layer } from './layer.js';
-import { LayerComposition } from './composition/layer-composition.js';
+import { SHADER_PICK, SORTMODE_NONE } from '../../scene/constants.js';
+import { Camera } from '../../scene/camera.js';
+import { Command } from '../../scene/mesh-instance.js';
+import { Layer } from '../../scene/layer.js';
+import { LayerComposition } from '../../scene/composition/layer-composition.js';
 
-import { getApplication } from '../framework/globals.js';
-import { Entity } from '../framework/entity.js';
-import { Debug } from '../core/debug.js';
+import { getApplication } from '../globals.js';
+import { Entity } from '../entity.js';
+import { Debug } from '../../core/debug.js';
 
-/** @typedef {import('../framework/app-base.js').AppBase} AppBase */
-/** @typedef {import('../framework/components/camera/component.js').CameraComponent} CameraComponent */
-/** @typedef {import('./mesh-instance.js').MeshInstance} MeshInstance */
-/** @typedef {import('./scene.js').Scene} Scene */
+/** @typedef {import('../app-base.js').AppBase} AppBase */
+/** @typedef {import('../components/camera/component.js').CameraComponent} CameraComponent */
+/** @typedef {import('../../scene/mesh-instance.js').MeshInstance} MeshInstance */
+/** @typedef {import('../../scene/scene.js').Scene} Scene */
 
 const tempSet = new Set();
 

--- a/src/framework/graphics/scene-grab.js
+++ b/src/framework/graphics/scene-grab.js
@@ -2,21 +2,21 @@ import {
     ADDRESS_CLAMP_TO_EDGE,
     FILTER_NEAREST, FILTER_LINEAR, FILTER_LINEAR_MIPMAP_LINEAR,
     PIXELFORMAT_DEPTHSTENCIL, PIXELFORMAT_R8_G8_B8_A8, PIXELFORMAT_R8_G8_B8
-} from '../platform/graphics/constants.js';
+} from '../../platform/graphics/constants.js';
 
-import { RenderTarget } from '../platform/graphics/render-target.js';
-import { Texture } from '../platform/graphics/texture.js';
-import { DebugGraphics } from '../platform/graphics/debug-graphics.js';
+import { RenderTarget } from '../../platform/graphics/render-target.js';
+import { Texture } from '../../platform/graphics/texture.js';
+import { DebugGraphics } from '../../platform/graphics/debug-graphics.js';
 
 import {
     LAYERID_DEPTH, LAYERID_WORLD,
     SHADER_DEPTH
-} from '../scene/constants.js';
+} from '../../scene/constants.js';
 
-import { Layer } from '../scene/layer.js';
+import { Layer } from '../../scene/layer.js';
 
-/** @typedef {import('../platform/graphics/graphics-device.js').GraphicsDevice} GraphicsDevice */
-/** @typedef {import('./components/camera/component.js').CameraComponent} CameraComponent */
+/** @typedef {import('../../platform/graphics/graphics-device.js').GraphicsDevice} GraphicsDevice */
+/** @typedef {import('../components/camera/component.js').CameraComponent} CameraComponent */
 
 // uniform names (first is current name, second one is deprecated name for compatibility)
 const _depthUniformNames = ['uSceneDepthMap', 'uDepthMap'];

--- a/src/index.js
+++ b/src/index.js
@@ -118,7 +118,6 @@ export { Morph } from './scene/morph.js';
 export { MorphInstance } from './scene/morph-instance.js';
 export { MorphTarget } from './scene/morph-target.js';
 export { ParticleEmitter } from './scene/particle-system/particle-emitter.js';
-export { Picker } from './scene/picker.js';
 export { Scene } from './scene/scene.js';
 export { Skin } from './scene/skin.js';
 export { SkinInstance } from './scene/skin-instance.js';
@@ -255,6 +254,9 @@ export { CanvasFont } from './framework/font/canvas-font.js';
 // FRAMEWORK / BUNDLE
 export { Bundle } from './framework/bundle/bundle.js';
 export { BundleRegistry } from './framework/bundle/bundle-registry.js';
+
+// FRAMEWORK / GRAPHICS
+export { Picker } from './framework/graphics/picker.js';
 
 // FRAMEWORK / HANDLERS
 export { basisInitialize, basisTranscode } from './framework/handlers/basis.js';


### PR DESCRIPTION
- it operates on entities and application and as such it belongs to the framework
- also moved framework/grab-pass.js to framework/graphics/grab-pass.js