### PR TITLE
Remove transmission factor gamma decoding

### DIFF
--- a/src/scene/shader-lib/chunks/standard/frag/transmission.js
+++ b/src/scene/shader-lib/chunks/standard/frag/transmission.js
@@ -12,7 +12,7 @@ void getRefraction() {
     #endif
 
     #ifdef MAPTEXTURE
-    refraction *= gammaCorrectInput(texture2DBias($SAMPLER, $UV, textureBias)).$CH;
+    refraction *= texture2DBias($SAMPLER, $UV, textureBias).$CH;
     #endif
 
     #ifdef MAPVERTEX


### PR DESCRIPTION
### Description

Transmission factor was treated as if it's gamma encoded, but the in the glTF specification it's documented to be linear. 