### PR TITLE
Anim folder circular dependency

### DIFF
--- a/src/framework/anim/evaluator/anim-blend.js
+++ b/src/framework/anim/evaluator/anim-blend.js
@@ -1,0 +1,90 @@
+class AnimBlend {
+    static _dot(a, b) {
+        const len  = a.length;
+        let result = 0;
+        for (let i = 0; i < len; ++i) {
+            result += a[i] * b[i];
+        }
+        return result;
+    }
+
+    static _normalize(a) {
+        let l = AnimBlend._dot(a, a);
+        if (l > 0) {
+            l = 1.0 / Math.sqrt(l);
+            const len = a.length;
+            for (let i = 0; i < len; ++i) {
+                a[i] *= l;
+            }
+        }
+    }
+
+    static _set(a, b, type) {
+        const len  = a.length;
+
+        if (type === 'quaternion') {
+            let l = AnimBlend._dot(b, b);
+            if (l > 0) {
+                l = 1.0 / Math.sqrt(l);
+            }
+            for (let i = 0; i < len; ++i) {
+                a[i] = b[i] * l;
+            }
+        } else {
+            for (let i = 0; i < len; ++i) {
+                a[i] = b[i];
+            }
+        }
+    }
+
+    static _blendVec(a, b, t, additive) {
+        const it = additive ? 1.0 : 1.0 - t;
+        const len = a.length;
+        for (let i = 0; i < len; ++i) {
+            a[i] = a[i] * it + b[i] * t;
+        }
+    }
+
+    static _blendQuat(a, b, t, additive) {
+        const len = a.length;
+        const it = additive ? 1.0 : 1.0 - t;
+
+        // negate b if a and b don't lie in the same winding (due to
+        // double cover). if we don't do this then often rotations from
+        // one orientation to another go the long way around.
+        if (AnimBlend._dot(a, b) < 0) {
+            t = -t;
+        }
+
+        for (let i = 0; i < len; ++i) {
+            a[i] = a[i] * it + b[i] * t;
+        }
+
+        if (!additive) {
+            AnimBlend._normalize(a);
+        }
+    }
+
+    static _blend(a, b, t, type, additive) {
+        if (type === 'quaternion') {
+            AnimBlend._blendQuat(a, b, t, additive);
+        } else {
+            AnimBlend._blendVec(a, b, t, additive);
+        }
+    }
+
+    static _stableSort(a, lessFunc) {
+        const len = a.length;
+        for (let i = 0; i < len - 1; ++i) {
+            for (let j = i + 1; j < len; ++j) {
+                if (lessFunc(a[j], a[i])) {
+                    const tmp = a[i];
+                    a[i] = a[j];
+                    a[j] = tmp;
+                }
+            }
+        }
+    }
+}
+
+export { AnimBlend };

--- a/src/framework/anim/evaluator/anim-blend.js
+++ b/src/framework/anim/evaluator/anim-blend.js
@@ -1,5 +1,5 @@
 class AnimBlend {
-    static _dot(a, b) {
+    static dot(a, b) {
         const len  = a.length;
         let result = 0;
         for (let i = 0; i < len; ++i) {
@@ -8,8 +8,8 @@ class AnimBlend {
         return result;
     }
 
-    static _normalize(a) {
-        let l = AnimBlend._dot(a, a);
+    static normalize(a) {
+        let l = AnimBlend.dot(a, a);
         if (l > 0) {
             l = 1.0 / Math.sqrt(l);
             const len = a.length;
@@ -19,11 +19,11 @@ class AnimBlend {
         }
     }
 
-    static _set(a, b, type) {
+    static set(a, b, type) {
         const len  = a.length;
 
         if (type === 'quaternion') {
-            let l = AnimBlend._dot(b, b);
+            let l = AnimBlend.dot(b, b);
             if (l > 0) {
                 l = 1.0 / Math.sqrt(l);
             }
@@ -37,7 +37,7 @@ class AnimBlend {
         }
     }
 
-    static _blendVec(a, b, t, additive) {
+    static blendVec(a, b, t, additive) {
         const it = additive ? 1.0 : 1.0 - t;
         const len = a.length;
         for (let i = 0; i < len; ++i) {
@@ -45,14 +45,14 @@ class AnimBlend {
         }
     }
 
-    static _blendQuat(a, b, t, additive) {
+    static blendQuat(a, b, t, additive) {
         const len = a.length;
         const it = additive ? 1.0 : 1.0 - t;
 
         // negate b if a and b don't lie in the same winding (due to
         // double cover). if we don't do this then often rotations from
         // one orientation to another go the long way around.
-        if (AnimBlend._dot(a, b) < 0) {
+        if (AnimBlend.dot(a, b) < 0) {
             t = -t;
         }
 
@@ -61,19 +61,19 @@ class AnimBlend {
         }
 
         if (!additive) {
-            AnimBlend._normalize(a);
+            AnimBlend.normalize(a);
         }
     }
 
-    static _blend(a, b, t, type, additive) {
+    static blend(a, b, t, type, additive) {
         if (type === 'quaternion') {
-            AnimBlend._blendQuat(a, b, t, additive);
+            AnimBlend.blendQuat(a, b, t, additive);
         } else {
-            AnimBlend._blendVec(a, b, t, additive);
+            AnimBlend.blendVec(a, b, t, additive);
         }
     }
 
-    static _stableSort(a, lessFunc) {
+    static stableSort(a, lessFunc) {
         const len = a.length;
         for (let i = 0; i < len - 1; ++i) {
             for (let j = i + 1; j < len; ++j) {

--- a/src/framework/anim/evaluator/anim-evaluator.js
+++ b/src/framework/anim/evaluator/anim-evaluator.js
@@ -194,7 +194,7 @@ class AnimEvaluator {
         const order = clips.map(function (c, i) {
             return i;
         });
-        AnimBlend._stableSort(order, function (a, b) {
+        AnimBlend.stableSort(order, function (a, b) {
             return clips[a].blendOrder < clips[b].blendOrder;
         });
 
@@ -220,7 +220,7 @@ class AnimEvaluator {
                     output = outputs[j];
                     value = output.value;
 
-                    AnimBlend._set(value, input, output.target.type);
+                    AnimBlend.set(value, input, output.target.type);
 
                     output.blendCounter++;
                 }
@@ -231,9 +231,9 @@ class AnimEvaluator {
                     value = output.value;
 
                     if (output.blendCounter === 0) {
-                        AnimBlend._set(value, input, output.target.type);
+                        AnimBlend.set(value, input, output.target.type);
                     } else {
-                        AnimBlend._blend(value, input, blendWeight, output.target.type);
+                        AnimBlend.blend(value, input, blendWeight, output.target.type);
                     }
 
                     output.blendCounter++;

--- a/src/framework/anim/evaluator/anim-target-value.js
+++ b/src/framework/anim/evaluator/anim-target-value.js
@@ -86,9 +86,9 @@ class AnimTargetValue {
     updateValue(index, value) {
         // always reset the value of the target when the counter is 0
         if (this.counter === 0) {
-            AnimBlend._set(this.value, AnimTargetValue.IDENTITY_QUAT_ARR, this.valueType);
+            AnimBlend.set(this.value, AnimTargetValue.IDENTITY_QUAT_ARR, this.valueType);
             if (!this._normalizeWeights) {
-                AnimBlend._blend(this.value, this.baseValue, 1, this.valueType);
+                AnimBlend.blend(this.value, this.baseValue, 1, this.valueType);
             }
         }
         if (!this.mask[index] || this.getWeight(index) === 0) return;
@@ -108,15 +108,15 @@ class AnimTargetValue {
                 AnimTargetValue.quatArr[1] = v.y;
                 AnimTargetValue.quatArr[2] = v.z;
                 AnimTargetValue.quatArr[3] = v.w;
-                AnimBlend._set(this.value, AnimTargetValue.quatArr, this.valueType);
+                AnimBlend.set(this.value, AnimTargetValue.quatArr, this.valueType);
             } else {
                 AnimTargetValue.vecArr[0] = value[0] - this.baseValue[0];
                 AnimTargetValue.vecArr[1] = value[1] - this.baseValue[1];
                 AnimTargetValue.vecArr[2] = value[2] - this.baseValue[2];
-                AnimBlend._blend(this.value, AnimTargetValue.vecArr, this.getWeight(index), this.valueType, true);
+                AnimBlend.blend(this.value, AnimTargetValue.vecArr, this.getWeight(index), this.valueType, true);
             }
         } else {
-            AnimBlend._blend(this.value, value, this.getWeight(index), this.valueType);
+            AnimBlend.blend(this.value, value, this.getWeight(index), this.valueType);
         }
         if (this.setter) this.setter(this.value);
     }

--- a/src/framework/anim/evaluator/anim-target-value.js
+++ b/src/framework/anim/evaluator/anim-target-value.js
@@ -1,6 +1,6 @@
 import { Quat } from '../../../core/math/quat.js';
 import { ANIM_LAYER_ADDITIVE, ANIM_LAYER_OVERWRITE } from '../controller/constants.js';
-import { AnimEvaluator } from './anim-evaluator.js';
+import { AnimBlend } from './anim-blend.js';
 import { math } from '../../../core/math/math.js';
 
 /**
@@ -86,9 +86,9 @@ class AnimTargetValue {
     updateValue(index, value) {
         // always reset the value of the target when the counter is 0
         if (this.counter === 0) {
-            AnimEvaluator._set(this.value, AnimTargetValue.IDENTITY_QUAT_ARR, this.valueType);
+            AnimBlend._set(this.value, AnimTargetValue.IDENTITY_QUAT_ARR, this.valueType);
             if (!this._normalizeWeights) {
-                AnimEvaluator._blend(this.value, this.baseValue, 1, this.valueType);
+                AnimBlend._blend(this.value, this.baseValue, 1, this.valueType);
             }
         }
         if (!this.mask[index] || this.getWeight(index) === 0) return;
@@ -108,15 +108,15 @@ class AnimTargetValue {
                 AnimTargetValue.quatArr[1] = v.y;
                 AnimTargetValue.quatArr[2] = v.z;
                 AnimTargetValue.quatArr[3] = v.w;
-                AnimEvaluator._set(this.value, AnimTargetValue.quatArr, this.valueType);
+                AnimBlend._set(this.value, AnimTargetValue.quatArr, this.valueType);
             } else {
                 AnimTargetValue.vecArr[0] = value[0] - this.baseValue[0];
                 AnimTargetValue.vecArr[1] = value[1] - this.baseValue[1];
                 AnimTargetValue.vecArr[2] = value[2] - this.baseValue[2];
-                AnimEvaluator._blend(this.value, AnimTargetValue.vecArr, this.getWeight(index), this.valueType, true);
+                AnimBlend._blend(this.value, AnimTargetValue.vecArr, this.getWeight(index), this.valueType, true);
             }
         } else {
-            AnimEvaluator._blend(this.value, value, this.getWeight(index), this.valueType);
+            AnimBlend._blend(this.value, value, this.getWeight(index), this.valueType);
         }
         if (this.setter) this.setter(this.value);
     }


### PR DESCRIPTION
Removes the circular dependency from the anim folder. The AnimTargetValue class is a dependency of AnimEvaluator, however it was using a couple of static blending functions from AnimEvaluator. These static functions have been moved to their own class called AnimBlend.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
