### PR TITLE
Extend immediate mode line drawing with support for custom materials

### DIFF
--- a/src/framework/app-base.js
+++ b/src/framework/app-base.js
@@ -1729,8 +1729,59 @@ class AppBase extends EventHandler {
      * var worldLayer = app.scene.layers.getLayerById(pc.LAYERID_WORLD);
      * app.drawLine(start, end, pc.Color.WHITE, true, worldLayer);
      */
-    drawLine(start, end, color, depthTest, layer) {
+    drawLine(start, end, color, depthTest, layer = this.scene.defaultDrawLayer) {
         this.scene.drawLine(start, end, color, depthTest, layer);
+    }
+
+    /**
+     * Draws a single line using the given material. Line start and end coordinates are specified in world-space.
+     * We expose the following vertex attributes for the material:
+     *  - aPosition: pc.Vec3 (vertex position)
+     *  - aTAndLength: pc.Vec2 (x - 1D texture coordinate [0..1], y - line length)
+     *  - aColor: pc.Vec4 (vertex color)
+     *
+     * @param {Material} material - The material used for rendering the line.
+     * @param {Vec3} start - The start world-space coordinate of the line.
+     * @param {Vec3} end - The end world-space coordinate of the line.
+     * @param {Color} [color] - The color of the line. It defaults to white if not specified.
+     * @param {Layer} [layer] - The layer to render the line into. Defaults to {@link LAYERID_IMMEDIATE}.
+     * @example
+     * // Render a 1-unit long white line
+     * const material = new pc.BasicMaterial();
+     * material.vertexColors = true;
+     * material.blend = true;
+     * material.blendType = BLEND_NORMAL;
+     * material.depthTest = true;
+     * material.update();
+     * const start = new pc.Vec3(0, 0, 0);
+     * const end = new pc.Vec3(1, 0, 0);
+     * app.drawLineWithMaterial(material, start, end);
+     * @example
+     * // Render a 1-unit long red line which is not depth tested and renders on top of other geometry
+     * const material = new pc.BasicMaterial();
+     * material.vertexColors = true;
+     * material.blend = true;
+     * material.blendType = BLEND_NORMAL;
+     * material.depthTest = false;
+     * material.update();
+     * const start = new pc.Vec3(0, 0, 0);
+     * const end = new pc.Vec3(1, 0, 0);
+     * app.drawLineWithMaterial(material, start, end, pc.Color.RED);
+     * @example
+     * // Render a 1-unit long white line into the world layer
+     * const material = new pc.BasicMaterial();
+     * material.vertexColors = true;
+     * material.blend = true;
+     * material.blendType = BLEND_NORMAL;
+     * material.depthTest = true;
+     * material.update();
+     * const start = new pc.Vec3(0, 0, 0);
+     * const end = new pc.Vec3(1, 0, 0);
+     * const worldLayer = app.scene.layers.getLayerById(pc.LAYERID_WORLD);
+     * app.drawLineWithMaterial(material, start, end, pc.Color.WHITE, worldLayer);
+     */
+    drawLineWithMaterial(material, start, end, color, layer = this.scene.defaultDrawLayer) {
+        this.scene.drawLineWithMaterial(material, start, end, color, layer);
     }
 
     /**
@@ -1777,6 +1828,64 @@ class AppBase extends EventHandler {
     }
 
     /**
+     * Renders an arbitrary number of discrete line segments with a given material.
+     * The lines are not connected by each subsequent point in the array. Instead, they are individual segments
+     * specified by two points. Therefore, the lengths of the supplied position and color arrays must be the same
+     * and also must be a multiple of 2. The colors of the ends of each line segment will be interpolated along
+     * the length of each line.
+     * We expose the following vertex attributes for the material:
+     *  - aPosition: pc.Vec3 (vertex position)
+     *  - aTAndLength: pc.Vec2 (x - 1D texture coordinate [0..1], y - line length)
+     *  - aColor: pc.Vec4 (vertex color)
+     *
+     * @param {Material} material - The material used for rendering the lines.
+     * @param {Vec3[]} positions - An array of points to draw lines between. The length of the
+     * array must be a multiple of 2.
+     * @param {Color[]} colors - An array of colors to color the lines. This must be the same
+     * length as the position array. The length of the array must also be a multiple of 2.
+     * @param {Layer} [layer] - The layer to render the lines into. Defaults to {@link LAYERID_IMMEDIATE}.
+     * @example
+     * // Render a single line, with unique colors for each point
+     * const material = new pc.BasicMaterial();
+     * material.vertexColors = true;
+     * material.blend = true;
+     * material.blendType = BLEND_NORMAL;
+     * material.depthTest = false;
+     * material.update();
+     * const start = new pc.Vec3(0, 0, 0);
+     * const end = new pc.Vec3(1, 0, 0);
+     * app.drawLinesWithMaterial(material, [start, end], [pc.Color.RED, pc.Color.WHITE]);
+     * @example
+     * // Render 2 discrete line segments
+     * const material = new pc.BasicMaterial();
+     * material.vertexColors = true;
+     * material.blend = true;
+     * material.blendType = BLEND_NORMAL;
+     * material.depthTest = false;
+     * material.update();
+     * const points = [
+     *     // Line 1
+     *     new pc.Vec3(0, 0, 0),
+     *     new pc.Vec3(1, 0, 0),
+     *     // Line 2
+     *     new pc.Vec3(1, 1, 0),
+     *     new pc.Vec3(1, 1, 1)
+     * ];
+     * const colors = [
+     *     // Line 1
+     *     pc.Color.RED,
+     *     pc.Color.YELLOW,
+     *     // Line 2
+     *     pc.Color.CYAN,
+     *     pc.Color.BLUE
+     * ];
+     * app.drawLinesWithMaterial(material, points, colors);
+     */
+    drawLinesWithMaterial(material, positions, colors, layer = this.scene.defaultDrawLayer) {
+        this.scene.drawLinesWithMaterial(material, positions, colors, layer);
+    }
+
+    /**
      * Renders an arbitrary number of discrete line segments. The lines are not connected by each
      * subsequent point in the array. Instead, they are individual segments specified by two
      * points.
@@ -1810,6 +1919,51 @@ class AppBase extends EventHandler {
      */
     drawLineArrays(positions, colors, depthTest = true, layer = this.scene.defaultDrawLayer) {
         this.scene.drawLineArrays(positions, colors, depthTest, layer);
+    }
+
+    /**
+     * Renders an arbitrary number of discrete line segments with a given material.
+     * The lines are not connected by each subsequent point in the array. Instead, they are
+     * individual segments specified by two points.
+     * We expose the following vertex attributes for the material:
+     *  - aPosition: pc.Vec3 (vertex position)
+     *  - aTAndLength: pc.Vec2 (x - 1D texture coordinate [0..1], y - line length)
+     *  - aColor: pc.Vec4 (vertex color)
+     *
+     * @param {Material} material - The material used for rendering the lines.
+     * @param {number[]} positions - An array of points to draw lines between. Each point is
+     * represented by 3 numbers - x, y and z coordinate.
+     * @param {number[]} colors - An array of colors to color the lines. This must be the same
+     * length as the position array. The length of the array must also be a multiple of 2.
+     * @param {Layer} [layer] - The layer to render the lines into. Defaults to {@link LAYERID_IMMEDIATE}.
+     * @example
+     * // Render 2 discrete line segments
+     * const material = new pc.BasicMaterial();
+     * material.vertexColors = true;
+     * material.blend = true;
+     * material.blendType = BLEND_NORMAL;
+     * material.depthTest = false;
+     * material.update();
+     * const points = [
+     *     // Line 1
+     *     0, 0, 0,
+     *     1, 0, 0,
+     *     // Line 2
+     *     1, 1, 0,
+     *     1, 1, 1
+     * ];
+     * const colors = [
+     *     // Line 1
+     *     1, 0, 0, 1,  // red
+     *     0, 1, 0, 1,  // green
+     *     // Line 2
+     *     0, 0, 1, 1,  // blue
+     *     1, 1, 1, 1   // white
+     * ];
+     * app.drawLineArraysWithMaterial(material, points, colors);
+     */
+    drawLineArraysWithMaterial(material, positions, colors, layer = this.scene.defaultDrawLayer) {
+        this.scene.drawLineArraysWithMaterial(material, positions, colors, layer);
     }
 
     /**

--- a/src/scene/immediate/immediate-batch.js
+++ b/src/scene/immediate/immediate-batch.js
@@ -4,6 +4,7 @@ import { PRIMITIVE_LINES } from '../../platform/graphics/constants.js';
 import { Mesh } from '../../scene/mesh.js';
 import { MeshInstance } from '../../scene/mesh-instance.js';
 import { GraphNode } from '../../scene/graph-node.js';
+import { Vec3 } from '../../core/math/vec3.js';
 
 const identityGraphNode = new GraphNode();
 identityGraphNode.worldTransform = Mat4.IDENTITY;
@@ -18,9 +19,16 @@ class ImmediateBatch {
         // line data, arrays of numbers
         this.positions = [];
         this.colors = [];
+        // stores length of line for each vertex plus
+        // a normalized t [0..1] to know where we are on the
+        // line (more like a 1D UV)
+        this.tAndLength = [];
 
         this.mesh = new Mesh(device);
         this.meshInstance = null;
+
+        this.helperA = new Vec3();
+        this.helperB = new Vec3();
     }
 
     // add line positions and colors to the batch
@@ -29,10 +37,16 @@ class ImmediateBatch {
 
         // positions
         const destPos = this.positions;
+        const destTAndLength = this.tAndLength;
         const count = positions.length;
-        for (let i = 0; i < count; i++) {
-            const pos = positions[i];
-            destPos.push(pos.x, pos.y, pos.z);
+        for (let i = 0; i < count; i += 2) {
+            const pos1 = positions[i];
+            const pos2 = positions[i + 1];
+            destPos.push(pos1.x, pos1.y, pos1.z);
+            destPos.push(pos2.x, pos2.y, pos2.z);
+            const length = pos2.distance(pos1);
+            destTAndLength.push(0, length);
+            destTAndLength.push(1, length);
         }
 
         // colors
@@ -58,8 +72,18 @@ class ImmediateBatch {
 
         // positions
         const destPos = this.positions;
-        for (let i = 0; i < positions.length; i += 3) {
+        const destTAndLength = this.tAndLength;
+        for (let i = 0; i < positions.length; i += 6) {
             destPos.push(positions[i], positions[i + 1], positions[i + 2]);
+            this.helperA.set(positions[i], positions[i + 1], positions[i + 2]);
+
+            destPos.push(positions[i + 3], positions[i + 4], positions[i + 5]);
+            this.helperB.set(positions[i + 3], positions[i + 4], positions[i + 5]);
+
+            const length = this.helperB.distance(this.helperA);
+
+            destTAndLength.push(0, length);
+            destTAndLength.push(1, length);
         }
 
         // colors
@@ -84,6 +108,7 @@ class ImmediateBatch {
 
             // update mesh vertices
             this.mesh.setPositions(this.positions);
+            this.mesh.setUvs(0, this.tAndLength);
             this.mesh.setColors(this.colors);
             this.mesh.update(PRIMITIVE_LINES, false);
             if (!this.meshInstance) {
@@ -92,6 +117,7 @@ class ImmediateBatch {
 
             // clear lines when after they were rendered as their lifetime is one frame
             this.positions.length = 0;
+            this.tAndLength.length = 0;
             this.colors.length = 0;
 
             // inject mesh instance into visible list to be rendered

--- a/src/scene/immediate/immediate.js
+++ b/src/scene/immediate/immediate.js
@@ -66,7 +66,13 @@ class Immediate {
 
     // returns a batch for rendering lines to a layer with required depth testing state
     getBatch(layer, depthTest) {
+        // get batch for the material
+        const material = depthTest ? this.materialDepth : this.materialNoDepth;
+        return this.getBatchByMaterial(material, layer);
+    }
 
+    // returns a batch for rendering lines to a layer with given material
+    getBatchByMaterial(material, layer) {
         // get batches for the layer
         let batches = this.batchesMap.get(layer);
         if (!batches) {
@@ -76,9 +82,6 @@ class Immediate {
 
         // add it for rendering
         this.allBatches.add(batches);
-
-        // get batch for the material
-        const material = depthTest ? this.materialDepth : this.materialNoDepth;
         return batches.getBatch(material, layer);
     }
 

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -676,6 +676,21 @@ class Scene extends EventHandler {
         batch.addLinesArrays(positions, colors);
     }
 
+    drawLineWithMaterial(material, start, end, color = Color.WHITE, layer = this.defaultDrawLayer) {
+        const batch = this.immediate.getBatchByMaterial(material, layer);
+        batch.addLines([start, end], [color, color]);
+    }
+
+    drawLinesWithMaterial(material, positions, colors, layer = this.defaultDrawLayer) {
+        const batch = this.immediate.getBatchByMaterial(material, layer);
+        batch.addLines(positions, colors);
+    }
+
+    drawLineArraysWithMaterial(material, positions, colors, layer = this.defaultDrawLayer) {
+        const batch = this.immediate.getBatchByMaterial(material, layer);
+        batch.addLinesArrays(positions, colors);
+    }
+
     applySettings(settings) {
         const physics = settings.physics;
         const render = settings.render;


### PR DESCRIPTION
Hi PlayCanvas team,
please consider this PR that adds support for using custom materials when drawing lines in immediate mode.
It adds new methods to the `pc.Application`
```
drawLineWithMaterial
drawLinesWithMaterial
drawLineArraysWithMaterial
```
and leaves the rest of the line drawing functionality untouched. This could be extended to all debug drawing that draw lines `drawWireSphere` and `drawWireSphere` as well.

The goal of this PR is to be able to customize even further the drawing of debug lines, adding the possibility of drawing dashed lines, fading with distance, etc.
In order to achieve that we expose the following vertex attributes for the material:
 - `aPosition`: pc.Vec3 (vertex position)
 - `aTAndLength`: pc.Vec2 (x - 1D texture coordinate [0..1], y - line length. Not quite convinced about the name of this attribute)
 - `aColor`: pc.Vec4 (vertex color)

The `Lines` example is also updated to show the new capabilities and shows example of drawing dashed lines

![image](https://user-images.githubusercontent.com/139596/195663393-1e422f74-759b-4475-ad11-388b9fc1a35e.png)


I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
