### PR TITLE
Fix cubeMapRotation uniform

### DIFF
--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -2,7 +2,6 @@ import { Debug } from '../../core/debug.js';
 
 import { Color } from '../../core/math/color.js';
 import { Vec2 } from '../../core/math/vec2.js';
-import { Quat } from '../../core/math/quat.js';
 import { math } from '../../core/math/math.js';
 
 import { _matTex2D, standard } from '../../scene/shader-lib/programs/standard.js';

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -803,10 +803,6 @@ class StandardMaterial extends Material {
             } else if (scene.skybox) {
                 this._setParameter('texture_cubeMap', scene.skybox);
             }
-
-            if (!scene.skyboxRotation.equals(Quat.IDENTITY) && scene._skyboxRotationMat3) {
-                this._setParameter('cubeMapRotationMatrix', scene._skyboxRotationMat3.data);
-            }
         }
 
         this._processParameters('_activeLightingParams');

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -176,6 +176,7 @@ class ForwardRenderer {
         this.ambientId = scope.resolve('light_globalAmbient');
         this.exposureId = scope.resolve('exposure');
         this.skyboxIntensityId = scope.resolve('skyboxIntensity');
+        this.cubeMapRotationMatrixId = scope.resolve('cubeMapRotationMatrix');
         this.lightColorId = [];
         this.lightDir = [];
         this.lightDirId = [];
@@ -577,9 +578,8 @@ class ForwardRenderer {
         }
         this.ambientId.setValue(this.ambientColor);
 
-        if (scene.sky) {
-            this.skyboxIntensityId.setValue(scene.physicalUnits ? scene.skyboxLuminance : scene.skyboxIntensity);
-        }
+        this.skyboxIntensityId.setValue(scene.physicalUnits ? scene.skyboxLuminance : scene.skyboxIntensity);
+        this.cubeMapRotationMatrixId.setValue(scene._skyboxRotationMat3.data);
     }
 
     _resolveLight(scope, i) {

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -5,6 +5,8 @@ import { Color } from '../core/math/color.js';
 import { Vec3 } from '../core/math/vec3.js';
 import { Quat } from '../core/math/quat.js';
 import { math } from '../core/math/math.js';
+import { Mat3 } from '../core/math/mat3.js';
+import { Mat4 } from '../core/math/mat4.js';
 
 import { GraphicsDeviceAccess } from '../platform/graphics/graphics-device-access.js';
 
@@ -223,8 +225,8 @@ class Scene extends EventHandler {
         this._skyboxMip = 0;
 
         this._skyboxRotation = new Quat();
-        this._skyboxRotationMat3 = null;
-        this._skyboxRotationMat4 = null;
+        this._skyboxRotationMat3 = new Mat3();
+        this._skyboxRotationMat4 = new Mat4();
 
         // ambient light lightmapping properties
         this._ambientBakeNumSamples = 1;
@@ -616,6 +618,12 @@ class Scene extends EventHandler {
     set skyboxRotation(value) {
         if (!this._skyboxRotation.equals(value)) {
             this._skyboxRotation.copy(value);
+            if (value.equals(Quat.IDENTITY)) {
+                this._skyboxRotationMat3.setIdentity();
+            } else {
+                this._skyboxRotationMat4.setTRS(Vec3.ZERO, value, Vec3.ONE);
+                this._skyboxRotationMat4.invertTo3x3(this._skyboxRotationMat3);
+            }
             this._resetSky();
         }
     }

--- a/src/scene/sky.js
+++ b/src/scene/sky.js
@@ -77,17 +77,6 @@ class Sky {
             material.setParameter('mipLevel', scene._skyboxMip);
         }
 
-        if (!scene.skyboxRotation.equals(Quat.IDENTITY)) {
-            _mat4 = _mat4 || new Mat4();
-            this._rotationMat3 = this._rotationMat3 || new Mat3();
-
-            _mat4.setTRS(Vec3.ZERO, scene._skyboxRotation, Vec3.ONE);
-            _mat4.invertTo3x3(this._rotationMat3);
-            material.setParameter('cubeMapRotationMatrix', this._rotationMat3.data);
-        } else {
-            material.setParameter('cubeMapRotationMatrix', Mat3.IDENTITY.data);
-        }
-
         material.cull = CULLFACE_FRONT;
         material.depthWrite = false;
 

--- a/src/scene/sky.js
+++ b/src/scene/sky.js
@@ -1,8 +1,3 @@
-import { Mat3 } from '../core/math/mat3.js';
-import { Mat4 } from '../core/math/mat4.js';
-import { Vec3 } from '../core/math/vec3.js';
-import { Quat } from '../core/math/quat.js';
-
 import { CULLFACE_FRONT } from '../platform/graphics/constants.js';
 
 import { GAMMA_NONE, GAMMA_SRGBHDR, LAYERID_SKYBOX, SHADER_FORWARDHDR, TONEMAP_LINEAR } from './constants.js';
@@ -17,9 +12,6 @@ import { getProgramLibrary } from './shader-lib/get-program-library.js';
 /** @typedef {import('../platform/graphics/graphics-device.js').GraphicsDevice} GraphicsDevice */
 /** @typedef {import('./scene.js').Scene} Scene */
 
-/** @type {Mat4} */
-let _mat4;
-
 /**
  * A visual representation of the sky.
  *
@@ -32,9 +24,6 @@ class Sky {
      * @type {MeshInstance}
      */
     meshInstance;
-
-    /** @type {Mat3} */
-    _rotationMat3;
 
     /**
      * @param {GraphicsDevice} device - The graphics device.


### PR DESCRIPTION
This PR fixes an issue where reflections seemingly disappear when the sky is disabled.

The issue was the skybox rotation matrix not ever being set - resulting in a null rotation matrix and no reflections.

This PR calculates the scene's skybox rotation directly in the scene and sets it once on the uniforms in the forward renderer.

Also, skyboxIntensity is now updated even if sky was null.
