### PR TITLE
Shader compilation timing and avoid compilation of unprocessed shaders

### DIFF
--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -49,6 +49,13 @@ export const TRACEID_TEXTURE_ALLOC = 'TextureAlloc';
 export const TRACEID_SHADER_ALLOC = 'ShaderAlloc';
 
 /**
+ * Logs the compilation time of shaders.
+ *
+ * @type {string}
+ */
+export const TRACEID_SHADER_COMPILE = 'ShaderCompile';
+
+/**
  * Logs the vram use by the textures.
  *
  * @type {string}

--- a/src/core/tracing.js
+++ b/src/core/tracing.js
@@ -24,6 +24,7 @@ class Tracing {
      * - {@link TRACEID_RENDER_TARGET_ALLOC}
      * - {@link TRACEID_TEXTURE_ALLOC}
      * - {@link TRACEID_SHADER_ALLOC}
+     * - {@link TRACEID_SHADER_COMPILE}
      * - {@link TRACEID_VRAM_TEXTURE}
      * - {@link TRACEID_VRAM_VB}
      * - {@link TRACEID_VRAM_IB}

--- a/src/scene/graphics/reproject-texture.js
+++ b/src/scene/graphics/reproject-texture.js
@@ -438,7 +438,7 @@ function reprojectTexture(source, target, options = {}) {
 
     const device = source.device;
 
-    let shader = getProgramLibrary(device)._cache[shaderKey];
+    let shader = getProgramLibrary(device).getCachedShader(shaderKey);
     if (!shader) {
         const defines =
             `#define PROCESS_FUNC ${processFunc}\n` +

--- a/src/scene/shader-lib/utils.js
+++ b/src/scene/shader-lib/utils.js
@@ -36,8 +36,8 @@ function createShader(device, vsName, fsName, useTransformFeedback = false) {
  * @returns {Shader} The newly created shader.
  */
 function createShaderFromCode(device, vsCode, fsCode, uniqueName, useTransformFeedback = false, fragmentPreamble = '') {
-    const shaderCache = getProgramLibrary(device)._cache;
-    let shader = shaderCache[uniqueName];
+    const programLibrary = getProgramLibrary(device);
+    let shader = programLibrary.getCachedShader(uniqueName);
     if (!shader) {
         shader = ShaderUtils.createShader(device, {
             name: uniqueName,
@@ -46,7 +46,7 @@ function createShaderFromCode(device, vsCode, fsCode, uniqueName, useTransformFe
             fragmentPreamble: fragmentPreamble,
             useTransformFeedback: useTransformFeedback
         });
-        shaderCache[uniqueName] = shader;
+        programLibrary.setCachedShader(uniqueName, shader);
     }
     return shader;
 }


### PR DESCRIPTION
- shader compilation timing can be traced out by
`pc.Tracing.set(pc.TRACEID_SHADER_COMPILE, true);`
This tries to report only the time the compilation is blocking the main thread, not the part a shader is being compiled before it's needed. So only the actual cost.

example:
![Screenshot 2022-10-14 at 17 51 46](https://user-images.githubusercontent.com/59932779/195901319-8e7c1761-19e3-4c6a-848d-21223a8d6f14.png)

- a bug fix, where a temporary shader was created and stored in the cache, which would trigger its compilation. This has been changed to store only the shader definitions.