### PR TITLE
Improvements to clustered lighting shader compilation speed on Windows (DirectX)

### DIFF
--- a/examples/src/examples/graphics/grab-pass.tsx
+++ b/examples/src/examples/graphics/grab-pass.tsx
@@ -1,6 +1,5 @@
 import * as pc from '../../../../';
 
-
 class GrabPassExample {
     static CATEGORY = 'Graphics';
     static NAME = 'Grab Pass';
@@ -24,8 +23,6 @@ class GrabPassExample {
             }
         `,
         'shader.frag': /* glsl */`
-            precision mediump float;
-
             // use the special uSceneColorMap texture, which is a built-in texture containing
             // a copy of the color buffer at the point of capture, inside the Depth layer.
             uniform sampler2D uSceneColorMap;
@@ -59,12 +56,7 @@ class GrabPassExample {
                 float mipmap = roughness * 5.0;
 
                 // get background pixel color with distorted offset
-                #ifdef GL2
-                    // only webgl2 (and webgl1 extension - not handled here) supports reading specified mipmap
-                    vec3 grabColor = texture2DLodEXT(uSceneColorMap, grabUv + offset, mipmap).rgb;
-                #else
-                    vec3 grabColor = texture2D(uSceneColorMap, grabUv + offset).rgb;
-                #endif
+                vec3 grabColor = texture2DLodEXT(uSceneColorMap, grabUv + offset, mipmap).rgb;
 
                 // brighten the refracted texture a little bit
                 // brighten even more the rough parts of the glass

--- a/src/platform/graphics/shader-chunks/frag/gles2.js
+++ b/src/platform/graphics/shader-chunks/frag/gles2.js
@@ -1,3 +1,18 @@
 export default /* glsl */`
 #define texture2DBias texture2D
+
+#ifndef SUPPORTS_TEXLOD
+
+// fallback for lod instructions
+#define texture2DLodEXT texture2D
+#define texture2DProjLodEXT textureProj
+#define textureCubeLodEXT textureCube
+#define textureShadow texture2D
+
+#else
+
+#define textureShadow(res, uv) texture2DGradEXT(res, uv, vec2(1, 1), vec2(1, 1))
+
+#endif
+
 `;

--- a/src/platform/graphics/shader-chunks/frag/gles3.js
+++ b/src/platform/graphics/shader-chunks/frag/gles3.js
@@ -12,6 +12,13 @@ out highp vec4 pc_fragColor;
 #define texture2DGradEXT textureGrad
 #define texture2DProjGradEXT textureProjGrad
 #define textureCubeGradEXT textureGrad
+
+// sample shadows using textureGrad to remove derivates in the dynamic loops (which are used by
+// clustered lighting) - as DirectX shader compiler tries to unroll the loops and takes long time
+// to compile the shader. Using textureLod would be even better, but WebGl does not translate it to
+// lod instruction for DirectX correctly and uses SampleCmp instead of SampleCmpLevelZero or similar.
+#define textureShadow(res, uv) textureGrad(res, uv, vec2(1, 1), vec2(1, 1))
+
 #define GL2
 #define SUPPORTS_TEXLOD
 `;

--- a/src/platform/graphics/webgl/webgl-shader.js
+++ b/src/platform/graphics/webgl/webgl-shader.js
@@ -229,8 +229,8 @@ class WebglShader {
             // #if _DEBUG
 
             // log translated shaders
-            definition.translatedFrag = gl.getExtension('WEBGL_debug_shaders').getTranslatedShaderSource(this.glFragmentShader);
-            definition.translatedVert = gl.getExtension('WEBGL_debug_shaders').getTranslatedShaderSource(this.glVertexShader);
+            definition.translatedFrag = gl.getExtension('WEBGL_debug_shaders')?.getTranslatedShaderSource(this.glFragmentShader);
+            definition.translatedVert = gl.getExtension('WEBGL_debug_shaders')?.getTranslatedShaderSource(this.glVertexShader);
 
             console.error(message, definition);
             // #else

--- a/src/platform/graphics/webgl/webgl-shader.js
+++ b/src/platform/graphics/webgl/webgl-shader.js
@@ -227,6 +227,11 @@ class WebglShader {
             const message = "Failed to link shader program. Error: " + gl.getProgramInfoLog(glProgram);
 
             // #if _DEBUG
+
+            // log translated shaders
+            definition.translatedFrag = gl.getExtension('WEBGL_debug_shaders').getTranslatedShaderSource(this.glFragmentShader);
+            definition.translatedVert = gl.getExtension('WEBGL_debug_shaders').getTranslatedShaderSource(this.glVertexShader);
+
             console.error(message, definition);
             // #else
             console.error(message);

--- a/src/scene/shader-lib/chunks/lit/frag/clusteredLight.js
+++ b/src/scene/shader-lib/chunks/lit/frag/clusteredLight.js
@@ -135,19 +135,12 @@ vec4 decodeClusterLowRange4Vec4(vec4 d0, vec4 d1, vec4 d2, vec4 d3) {
     );
 }
 
-// use LOD sampling if supported to sample data textures as it has better chance of getting skipped inside dynamic branches
-#ifdef SUPPORTS_TEXLOD
-    #define textureData(texture, uv) texture2DLodEXT(texture, uv, 0.0)
-#else
-    #define textureData(texture, uv) texture2D(texture, uv)
-#endif
-
 vec4 sampleLightsTexture8(const ClusterLightData clusterLightData, float index) {
-    return textureData(lightsTexture8, vec2(index * lightsTextureInvSize.z, clusterLightData.lightV));
+    return texture2DLodEXT(lightsTexture8, vec2(index * lightsTextureInvSize.z, clusterLightData.lightV), 0.0);
 }
 
 vec4 sampleLightTextureF(const ClusterLightData clusterLightData, float index) {
-    return textureData(lightsTextureFloat, vec2(index * lightsTextureInvSize.x, clusterLightData.lightV));
+    return texture2DLodEXT(lightsTextureFloat, vec2(index * lightsTextureInvSize.x, clusterLightData.lightV), 0.0);
 }
 
 void decodeClusterLightCore(inout ClusterLightData clusterLightData, float lightIndex) {
@@ -568,7 +561,7 @@ void addClusteredLights() {
         const float maxLightCells = 256.0 / 4.0;  // 8 bit index, each stores 4 lights
         for (float lightCellIndex = 0.5; lightCellIndex < maxLightCells; lightCellIndex++) {
 
-            vec4 lightIndices = textureData(clusterWorldTexture, vec2(clusterTextureSize.y * (clusterU + lightCellIndex), clusterV));
+            vec4 lightIndices = texture2DLodEXT(clusterWorldTexture, vec2(clusterTextureSize.y * (clusterU + lightCellIndex), clusterV), 0.0);
             vec4 indices = lightIndices * 255.0;
 
             // evaluate up to 4 lights. This is written using a loop instead of manually unrolling to keep shader compile time smaller

--- a/src/scene/shader-lib/chunks/lit/frag/clusteredLightShadows.js
+++ b/src/scene/shader-lib/chunks/lit/frag/clusteredLightShadows.js
@@ -11,7 +11,7 @@ export default /* glsl */`
         vec2 uv = getCubemapAtlasCoordinates(omniAtlasViewport, shadowEdgePixels, shadowTextureResolution, dir);
 
         float shadowZ = length(dir) * shadowParams.w + shadowParams.z;
-        return texture(shadowMap, vec3(uv, shadowZ));
+        return textureShadow(shadowMap, vec3(uv, shadowZ));
     }
 
     #endif
@@ -54,7 +54,7 @@ export default /* glsl */`
         vec2 uv = getCubemapAtlasCoordinates(omniAtlasViewport, shadowEdgePixels, shadowTextureResolution, dir);
 
         // no filter shadow sampling
-        float depth = unpackFloat(texture2D(shadowMap, uv));
+        float depth = unpackFloat(textureShadow(shadowMap, uv));
         float shadowZ = length(dir) * shadowParams.w + shadowParams.z;
         return depth > shadowZ ? 1.0 : 0.0;
     }
@@ -102,7 +102,7 @@ export default /* glsl */`
     #if defined(CLUSTER_SHADOW_TYPE_PCF1)
 
     float getShadowSpotClusteredPCF1(sampler2DShadow shadowMap, vec4 shadowParams) {
-        return texture(shadowMap, dShadowCoord);
+        return textureShadow(shadowMap, dShadowCoord);
     }
 
     #endif
@@ -128,7 +128,7 @@ export default /* glsl */`
 
     float getShadowSpotClusteredPCF1(sampler2D shadowMap, vec4 shadowParams) {
 
-        float depth = unpackFloat(texture2D(shadowMap, dShadowCoord.xy));
+        float depth = unpackFloat(textureShadow(shadowMap, dShadowCoord.xy));
 
         return depth > dShadowCoord.z ? 1.0 : 0.0;
 

--- a/src/scene/shader-lib/chunks/lit/frag/ltc.js
+++ b/src/scene/shader-lib/chunks/lit/frag/ltc.js
@@ -128,7 +128,7 @@ vec3 ccLTCSpecFres;
 #endif
 vec3 getLTCLightSpecFres(vec2 uv, vec3 tSpecularity)
 {
-    vec4 t2 = texture2D( areaLightsLutTex2, uv );
+    vec4 t2 = texture2DLodEXT(areaLightsLutTex2, uv, 0.0);
 
     #ifdef AREA_R8_G8_B8_A8_LUTS
     t2 *= vec4(0.693103,1,1,1);
@@ -366,7 +366,7 @@ float LTC_EvaluateDisk(vec3 N, vec3 V, vec3 P, mat3 Minv, Coords points)
     vec2 uv = vec2(avgDir.z * 0.5 + 0.5, formFactor);
     uv = uv*LUT_SCALE + LUT_BIAS;
 
-    float scale = texture2D( areaLightsLutTex2, uv ).w;
+    float scale = texture2DLodEXT(areaLightsLutTex2, uv, 0.0).w;
 
     return formFactor*scale;
 }
@@ -387,7 +387,7 @@ float getSphereLightDiffuse() {
 
 mat3 getLTCLightInvMat(vec2 uv)
 {
-    vec4 t1 = texture2D( areaLightsLutTex1, uv );
+    vec4 t1 = texture2DLodEXT(areaLightsLutTex1, uv, 0.0);
 
     #ifdef AREA_R8_G8_B8_A8_LUTS
     t1 *= vec4(1.001, 0.3239, 0.60437568, 1.0);

--- a/src/scene/shader-lib/chunks/lit/frag/refractionDynamic.js
+++ b/src/scene/shader-lib/chunks/lit/frag/refractionDynamic.js
@@ -30,7 +30,7 @@ void addRefraction() {
     uv += vec2(1.0);
     uv *= vec2(0.5);
 
-    #ifdef GL2
+    #ifdef SUPPORTS_TEXLOD
         // Use IOR and roughness to select mip
         float iorToRoughness = (1.0 - dGlossiness) * clamp((1.0 / material_refractionIndex) * 2.0 - 2.0, 0.0, 1.0);
         float refractionLod = log2(uScreenSize.x) * iorToRoughness;

--- a/src/scene/shader-lib/chunks/lit/frag/shadowStandard.js
+++ b/src/scene/shader-lib/chunks/lit/frag/shadowStandard.js
@@ -44,10 +44,10 @@ float _getShadowPCF3x3(sampler2DShadow shadowMap, vec3 shadowParams) {
     u1 = u1 * shadowMapSizeInv + base_uv.x;
     v1 = v1 * shadowMapSizeInv + base_uv.y;
 
-    sum += uw0 * vw0 * texture(shadowMap, vec3(u0, v0, z));
-    sum += uw1 * vw0 * texture(shadowMap, vec3(u1, v0, z));
-    sum += uw0 * vw1 * texture(shadowMap, vec3(u0, v1, z));
-    sum += uw1 * vw1 * texture(shadowMap, vec3(u1, v1, z));
+    sum += uw0 * vw0 * textureShadow(shadowMap, vec3(u0, v0, z));
+    sum += uw1 * vw0 * textureShadow(shadowMap, vec3(u1, v0, z));
+    sum += uw0 * vw1 * textureShadow(shadowMap, vec3(u0, v1, z));
+    sum += uw1 * vw1 * textureShadow(shadowMap, vec3(u1, v1, z));
 
     sum *= 1.0f / 16.0;
     return sum;
@@ -91,15 +91,15 @@ float _getShadowPCF3x3(sampler2D shadowMap, vec3 shadowParams) {
     float dx1 = xoffset;
 
     mat3 depthKernel;
-    depthKernel[0][0] = unpackFloat(texture2D(shadowMap, shadowCoord.xy + vec2(dx0, dx0)));
-    depthKernel[0][1] = unpackFloat(texture2D(shadowMap, shadowCoord.xy + vec2(dx0, 0.0)));
-    depthKernel[0][2] = unpackFloat(texture2D(shadowMap, shadowCoord.xy + vec2(dx0, dx1)));
-    depthKernel[1][0] = unpackFloat(texture2D(shadowMap, shadowCoord.xy + vec2(0.0, dx0)));
-    depthKernel[1][1] = unpackFloat(texture2D(shadowMap, shadowCoord.xy));
-    depthKernel[1][2] = unpackFloat(texture2D(shadowMap, shadowCoord.xy + vec2(0.0, dx1)));
-    depthKernel[2][0] = unpackFloat(texture2D(shadowMap, shadowCoord.xy + vec2(dx1, dx0)));
-    depthKernel[2][1] = unpackFloat(texture2D(shadowMap, shadowCoord.xy + vec2(dx1, 0.0)));
-    depthKernel[2][2] = unpackFloat(texture2D(shadowMap, shadowCoord.xy + vec2(dx1, dx1)));
+    depthKernel[0][0] = unpackFloat(textureShadow(shadowMap, shadowCoord.xy + vec2(dx0, dx0)));
+    depthKernel[0][1] = unpackFloat(textureShadow(shadowMap, shadowCoord.xy + vec2(dx0, 0.0)));
+    depthKernel[0][2] = unpackFloat(textureShadow(shadowMap, shadowCoord.xy + vec2(dx0, dx1)));
+    depthKernel[1][0] = unpackFloat(textureShadow(shadowMap, shadowCoord.xy + vec2(0.0, dx0)));
+    depthKernel[1][1] = unpackFloat(textureShadow(shadowMap, shadowCoord.xy));
+    depthKernel[1][2] = unpackFloat(textureShadow(shadowMap, shadowCoord.xy + vec2(0.0, dx1)));
+    depthKernel[2][0] = unpackFloat(textureShadow(shadowMap, shadowCoord.xy + vec2(dx1, dx0)));
+    depthKernel[2][1] = unpackFloat(textureShadow(shadowMap, shadowCoord.xy + vec2(dx1, 0.0)));
+    depthKernel[2][2] = unpackFloat(textureShadow(shadowMap, shadowCoord.xy + vec2(dx1, dx1)));
 
     return _xgetShadowPCF3x3(depthKernel, shadowMap, shadowParams);
 }

--- a/src/scene/shader-lib/chunks/lit/frag/shadowStandardGL2.js
+++ b/src/scene/shader-lib/chunks/lit/frag/shadowStandardGL2.js
@@ -39,17 +39,17 @@ float _getShadowPCF5x5(sampler2DShadow shadowMap, vec3 shadowParams) {
     u2 = u2 * shadowMapSizeInv + base_uv.x;
     v2 = v2 * shadowMapSizeInv + base_uv.y;
 
-    sum += uw0 * vw0 * texture(shadowMap, vec3(u0, v0, z));
-    sum += uw1 * vw0 * texture(shadowMap, vec3(u1, v0, z));
-    sum += uw2 * vw0 * texture(shadowMap, vec3(u2, v0, z));
+    sum += uw0 * vw0 * textureShadow(shadowMap, vec3(u0, v0, z));
+    sum += uw1 * vw0 * textureShadow(shadowMap, vec3(u1, v0, z));
+    sum += uw2 * vw0 * textureShadow(shadowMap, vec3(u2, v0, z));
 
-    sum += uw0 * vw1 * texture(shadowMap, vec3(u0, v1, z));
-    sum += uw1 * vw1 * texture(shadowMap, vec3(u1, v1, z));
-    sum += uw2 * vw1 * texture(shadowMap, vec3(u2, v1, z));
+    sum += uw0 * vw1 * textureShadow(shadowMap, vec3(u0, v1, z));
+    sum += uw1 * vw1 * textureShadow(shadowMap, vec3(u1, v1, z));
+    sum += uw2 * vw1 * textureShadow(shadowMap, vec3(u2, v1, z));
 
-    sum += uw0 * vw2 * texture(shadowMap, vec3(u0, v2, z));
-    sum += uw1 * vw2 * texture(shadowMap, vec3(u1, v2, z));
-    sum += uw2 * vw2 * texture(shadowMap, vec3(u2, v2, z));
+    sum += uw0 * vw2 * textureShadow(shadowMap, vec3(u0, v2, z));
+    sum += uw1 * vw2 * textureShadow(shadowMap, vec3(u1, v2, z));
+    sum += uw2 * vw2 * textureShadow(shadowMap, vec3(u2, v2, z));
 
     sum *= 1.0f / 144.0;
 


### PR DESCRIPTION
Shader compilation speed improvements of around 50% on Windows Platform (when using DirectX backend), when clustered lights are used, and especially with area lights and shadows. DirectX shader compiler does not allow gradient instructions inside of the loops with varying number of iterations, and attemps to unroll the loops, which in the mentioned cases takes a long time. The solution is to avoid using gradient instructions inside the loop.

### Details:
- macros to allow texture2DLodEXT texture sampling on all platforms (simulated on Webgl1 without the extension). This is used to read clustered light data without gradients, and also read area lights LUTs. (and also in one engine example)
- new textureShadow macro to sample shadow map without gradients (internally uses textureGrad, as textureLod seems to have WebGL translation issue when used with shadow samplers)

### Timings

All with area lights enabled, and PCF3 shadows, up to date Chrome browser.

Windows, original state
<img width="965" alt="original area + pcf3" src="https://user-images.githubusercontent.com/59932779/196671169-dc9a2588-1bd1-47d6-b489-8015f8b9d3db.png">

Windows, now
<img width="960" alt="now area + pcf3" src="https://user-images.githubusercontent.com/59932779/196671292-aee4bfc1-c8d3-4f95-b812-fe3f35d1ce8a.png">

### Other timings for comparison

Windows, clustered lights disabled (using old lighting code)
<img width="960" alt="windows non-clustered" src="https://user-images.githubusercontent.com/59932779/196671824-b416e643-77f9-4656-b11f-813838cc43aa.png">

Mac OS on the first run
![mac first run](https://user-images.githubusercontent.com/59932779/196671535-f5da1734-872d-4173-b2f1-0161109bac19.png)

Mac OS on the following runs (some caching takes place?)
![mac next run](https://user-images.githubusercontent.com/59932779/196671682-94141379-b900-4a33-9b9e-6525928781b9.png)

Mac OS with clustered lights enabled, first run
![mac non-clustered](https://user-images.githubusercontent.com/59932779/196671747-473f5d33-20e2-47f7-b010-dbe2fc2245cc.png)
