### PR TITLE
Extraced ScriptTypes from ScriptHandler to avoid circular dependency

### DIFF
--- a/src/framework/handlers/script.js
+++ b/src/framework/handlers/script.js
@@ -1,4 +1,5 @@
 import { script } from '../../framework/script.js';
+import { ScriptTypes } from '../script/script-types.js';
 
 /** @typedef {import('../../framework/app-base.js').AppBase} AppBase */
 /** @typedef {import('./handler.js').ResourceHandler} ResourceHandler */
@@ -30,16 +31,6 @@ class ScriptHandler {
         this._cache = { };
     }
 
-    static _types = [];
-
-    static _push(Type) {
-        if (script.legacy && ScriptHandler._types.length > 0) {
-            console.assert('Script Ordering Error. Contact support@playcanvas.com');
-        } else {
-            ScriptHandler._types.push(Type);
-        }
-    }
-
     load(url, callback) {
         // Scripts don't support bundling since we concatenate them. Below is for consistency.
         if (typeof url === 'string') {
@@ -57,8 +48,8 @@ class ScriptHandler {
                 if (script.legacy) {
                     let Type = null;
                     // pop the type from the loading stack
-                    if (ScriptHandler._types.length) {
-                        Type = ScriptHandler._types.pop();
+                    if (ScriptTypes._types.length) {
+                        Type = ScriptTypes._types.pop();
                     }
 
                     if (Type) {
@@ -73,10 +64,10 @@ class ScriptHandler {
                 } else {
                     const obj = { };
 
-                    for (let i = 0; i < ScriptHandler._types.length; i++)
-                        obj[ScriptHandler._types[i].name] = ScriptHandler._types[i];
+                    for (let i = 0; i < ScriptTypes._types.length; i++)
+                        obj[ScriptTypes._types[i].name] = ScriptTypes._types[i];
 
-                    ScriptHandler._types.length = 0;
+                    ScriptTypes._types.length = 0;
 
                     callback(null, obj, extra);
 

--- a/src/framework/script.js
+++ b/src/framework/script.js
@@ -1,8 +1,7 @@
 import { events } from '../core/events.js';
 
-import { ScriptHandler } from '../framework/handlers/script.js';
-
 import { getApplication } from './globals.js';
+import { ScriptTypes } from './script/script-types.js';
 
 /** @typedef {import('./app-base.js').AppBase} AppBase */
 
@@ -74,7 +73,7 @@ const script = {
         ScriptType._pcScriptName = name;
 
         // Push this onto loading stack
-        ScriptHandler._push(ScriptType);
+        ScriptTypes.push(ScriptType, _legacy);
 
         this.fire("created", name, callback);
     },

--- a/src/framework/script/script-types.js
+++ b/src/framework/script/script-types.js
@@ -1,0 +1,13 @@
+class ScriptTypes {
+    static _types = [];
+
+    static push(Type, isLegacy) {
+        if (isLegacy && ScriptTypes._types.length > 0) {
+            console.assert('Script Ordering Error. Contact support@playcanvas.com');
+        } else {
+            ScriptTypes._types.push(Type);
+        }
+    }
+}
+
+export { ScriptTypes };

--- a/src/framework/script/script.js
+++ b/src/framework/script/script.js
@@ -1,13 +1,12 @@
 import { Debug } from '../../core/debug.js';
 import { EventHandler } from '../../core/event-handler.js';
 
-import { ScriptHandler } from '../../framework/handlers/script.js';
-
 import { script } from '../script.js';
 import { AppBase } from '../app-base.js';
 
 import { ScriptAttributes } from './script-attributes.js';
 import { ScriptType } from './script-type.js';
+import { ScriptTypes } from './script-types.js';
 
 const reservedScriptNames = new Set([
     'system', 'entity', 'create', 'destroy', 'swap', 'move',
@@ -144,7 +143,7 @@ function registerScript(script, name, app) {
     const registry = app ? app.scripts : AppBase.getApplication().scripts;
     registry.add(script);
 
-    ScriptHandler._push(script);
+    ScriptTypes.push(script, script.legacy);
 }
 /* eslint-enable jsdoc/check-examples */
 


### PR DESCRIPTION
That looks like the last circular dependency. How do we disable them now?