### PR TITLE
Detect glb using file header

### DIFF
--- a/src/framework/components/animation/component.js
+++ b/src/framework/components/animation/component.js
@@ -10,7 +10,6 @@ import { Skeleton } from '../../../scene/animation/skeleton.js';
 import { Asset } from '../../asset/asset.js';
 
 import { Component } from '../component.js';
-import { revision, version } from "../../../core/core.js";
 
 /** @typedef {import('../../../scene/animation/animation.js').Animation} Animation */
 /** @typedef {import('../../../scene/model.js').Model} Model */

--- a/src/framework/parsers/glb-parser.js
+++ b/src/framework/parsers/glb-parser.js
@@ -2466,7 +2466,7 @@ const parseGlb = function (glbData, callback) {
 
 // parse the chunk of data, which can be glb or gltf
 const parseChunk = function (filename, data, callback) {
-    if (filename && filename.toLowerCase().endsWith('.glb') ||
+    if ((filename && filename.toLowerCase().endsWith('.glb')) ||
         (data[0] === 'g' && data[1] === 'l' && data[2] === 'T' && data[3] === 'F')) {
         parseGlb(data, callback);
     } else {

--- a/src/framework/parsers/glb-parser.js
+++ b/src/framework/parsers/glb-parser.js
@@ -2466,7 +2466,8 @@ const parseGlb = function (glbData, callback) {
 
 // parse the chunk of data, which can be glb or gltf
 const parseChunk = function (filename, data, callback) {
-    if (filename && filename.toLowerCase().endsWith('.glb')) {
+    if (filename && filename.toLowerCase().endsWith('.glb') ||
+        (data[0] === 'g' && data[1] === 'l' && data[2] === 'T' && data[3] === 'F')) {
         parseGlb(data, callback);
     } else {
         callback(null, {


### PR DESCRIPTION
It is not always possible to specify an accurate filename for model files.

This PR updates the test for selecting between glb and gltf file format by inspecting the file's magic bits.

Also fix a lint error introduced in an unrelated PR.