### PR TITLE
Glb parser: duplicate morph curve fix

### DIFF
--- a/src/framework/parsers/glb-parser.js
+++ b/src/framework/parsers/glb-parser.js
@@ -1591,9 +1591,9 @@ const createAnimation = function (gltfAnimation, animationIndex, gltfAccessors, 
 
         if (target.path.startsWith('weights')) {
             createMorphTargetCurves(curve, node, entityPath);
-            // after all morph targets in this curve have been included in the curveMap, this curve and its output data can be deleted
-            delete curveMap[channel.sampler];
-            delete outputMap[curve.output];
+            // as all individual morph targets in this morph curve have their own curve now, this morph curve should be flagged
+            // so it's not included in the final output
+            curveMap[channel.sampler].morphCurve = true;
         } else {
             curve.paths.push({
                 entityPath: entityPath,
@@ -1622,6 +1622,10 @@ const createAnimation = function (gltfAnimation, animationIndex, gltfAccessors, 
     // inputs arrays using the inputMap. Likewise for output values.
     for (const curveKey in curveMap) {
         const curveData = curveMap[curveKey];
+        // if the curveData contains a morph curve then do not add it to the final curve list as the individual morph target curves are included instead
+        if (curveData.morphCurve) {
+            continue;
+        }
         curves.push(new AnimCurve(
             curveData.paths,
             inputMap[curveData.input],


### PR DESCRIPTION
When a glb contains multiple morph curves referencing the same sampler, only the first will have its morph target curves created as its curveMap & outputMap references are deleted during the processing of the curve. This PR instead retains all mapped values while all curves in the glb are processed.

Fixes #4724 

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
