### PR TITLE
WebGPU rendering improvements for GLB test files

### DIFF
--- a/examples/webgpu-temp/one.html
+++ b/examples/webgpu-temp/one.html
@@ -272,7 +272,6 @@ void main() {
             app.root.addChild(modelEntityParent);
 
             // LIGHT 
-
             const lightOmni = new Entity("Omni");
             lightOmni.addComponent("light", {
                 type: "omni",
@@ -286,6 +285,23 @@ void main() {
             app.root.addChild(lightOmni);
 
             ///////////
+
+
+            const lightDir = new Entity();
+            lightDir.addComponent("light", {
+                type: "directional",
+                color: new Color(1, 1, 1),
+                castShadows: false,
+                shadowBias: 0.2,
+                shadowDistance: 25,
+                normalOffsetBias: 0.05,
+                shadowResolution: 2048
+            });
+            lightDir.setLocalEulerAngles(45, 30, 0);
+            app.root.addChild(lightDir);
+
+
+
 
             let time = 0;
             const rot = new Quat();
@@ -327,8 +343,8 @@ void main() {
 
             // Tracing.set(TRACEID_RENDER_FRAME, true);
             // Tracing.set(TRACEID_RENDER_PASS, true);
-            Tracing.set(TRACEID_TEXTURE_ALLOC, true);
-            //Tracing.set(TRACEID_SHADER_ALLOC, true);
+            //Tracing.set(TRACEID_TEXTURE_ALLOC, true);
+            Tracing.set(TRACEID_SHADER_ALLOC, true);
 
             const canvas = document.querySelector('#gpuCanvas');
 

--- a/examples/webgpu-temp/two.html
+++ b/examples/webgpu-temp/two.html
@@ -1,0 +1,156 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8" />
+    <title>WebGPU Test</title>
+    <meta name="description" content="WebGPU Test" />
+    <script src="./libs/glslang.js"></script>
+</head>
+
+<body style="margin: 0px;">
+    <div class="warning" style="display:none;">
+        <p>
+            The browser you are using does not seem to support WebGPU rendering. At this time,
+            WebGPU implementations are under continuous development, so consider installing a developer
+            build, such as <a href="https://www.google.com/chrome/canary/">Google Chrome Canary</a>.
+        </p>
+    </div>
+    <canvas id="gpuCanvas" width="800" height="600"></canvas>
+
+    <script type="module">
+
+        import { Asset } from "../../src/framework/asset/asset.js";
+        import { AssetListLoader } from "../../src/framework/asset/asset-list-loader.js";
+        import { AppBase } from "../../src/framework/app-base.js";
+        import { AppOptions } from "../../src/framework/app-options.js";
+        import { WebgpuGraphicsDevice } from '../../src/platform/graphics/webgpu/webgpu-graphics-device.js';
+        import { WebglGraphicsDevice } from '../../src/platform/graphics/webgl/webgl-graphics-device.js';
+        import { Shader } from '../../src/platform/graphics/shader.js';
+        import { Texture } from '../../src/platform/graphics/texture.js';
+        import { RenderTarget } from '../../src/platform/graphics/render-target.js';
+        import {
+            SEMANTIC_TEXCOORD0, SEMANTIC_POSITION, CULLFACE_NONE,
+            PIXELFORMAT_R8_G8_B8_A8, FILTER_LINEAR, ADDRESS_CLAMP_TO_EDGE
+        } from '../../src/platform/graphics/constants.js';
+        import { Entity } from "../../src/framework/entity.js";
+        import { Tracing } from "../../src/core/tracing.js";
+        import { 
+            TRACEID_RENDER_FRAME, TRACEID_RENDER_PASS, TRACEID_RENDER_PASS_DETAIL, TRACEID_SHADER_ALLOC, TRACEID_TEXTURE_ALLOC
+        } from "../../src/core/constants.js";
+        import { Color } from "../../src/core/math/color.js";
+        import { Vec3 } from "../../src/core/math/vec3.js";
+        import { Quat } from "../../src/core/math/quat.js";
+        import { StandardMaterial } from "../../src/scene/materials/standard-material.js";
+        import { BLEND_ADDITIVE, BLEND_SUBTRACTIVE, BLEND_SCREEN, BLEND_NORMAL, BLEND_NONE } from "../../src/scene/constants.js";
+
+        import { Material } from "../../src/scene/materials/material.js";
+        import { BasicMaterial } from "../../src/scene/materials/basic-material.js";
+        import { RenderComponentSystem } from '../../src/framework/components/render/system.js';
+        import { CameraComponentSystem } from '../../src/framework/components/camera/system.js';
+        import { LightComponentSystem } from '../../src/framework/components/light/system.js';
+        import { TextureHandler } from '../../src/framework/handlers/texture.js';
+        import { ContainerHandler } from '../../src/framework/handlers/container.js';
+
+        const assets = {
+            'playcanvas': new Asset('playcanvas.png', 'texture', { url: '../assets/textures/playcanvas.png' }),
+//            'model': new Asset('model', 'container', { url: '../assets/models/house.glb' }),
+            'model': new Asset('model', 'container', { url: '../assets/models/statue.glb' }),
+//            'model': new Asset('model', 'container', { url: '../assets/models/batmobile-armored.glb' }),
+//            'model': new Asset('model', 'container', { url: '../assets/models/terrain.glb' }),
+        };
+
+        function onLoaded(app) {
+
+            app.start();
+
+            // Create an entity with a camera component
+            const camera = new Entity();
+            camera.addComponent("camera", {
+                clearColor: new Color(0.4, 0.4, 0.4, 1)
+            });
+            app.root.addChild(camera);
+            camera.setLocalPosition(0, 0, 5);
+
+            camera.clearColorBuffer = false;
+
+            const modelEntity = assets.model.resource.instantiateRenderEntity({
+            });
+
+            const modelEntityParent = new Entity();
+            modelEntityParent.setLocalScale(20, 20, 20);
+            modelEntityParent.addChild(modelEntity);
+            app.root.addChild(modelEntityParent);
+
+            const lightDir = new Entity();
+            lightDir.addComponent("light", {
+                type: "directional",
+                color: new Color(1, 1, 1),
+                castShadows: false,
+                shadowBias: 0.2,
+                shadowDistance: 25,
+                normalOffsetBias: 0.05,
+                shadowResolution: 2048
+            });
+            lightDir.setLocalEulerAngles(45, 30, 0);
+            app.root.addChild(lightDir);
+
+            let time = 0;
+            const rot = new Quat();
+            app.on("update", function (dt) {
+                time += dt;
+
+                // slowly orbit camera around
+                camera.setLocalPosition(420 * Math.cos(time * 0.2), 300, 420 * Math.sin(time * 0.2));
+                camera.lookAt(new Vec3(0, 150, 0));
+            });
+
+        }
+
+        function main() {
+
+            console.log("example start");
+
+            // Tracing.set(TRACEID_RENDER_FRAME, true);
+            // Tracing.set(TRACEID_RENDER_PASS, true);
+            //Tracing.set(TRACEID_TEXTURE_ALLOC, true);
+            Tracing.set(TRACEID_SHADER_ALLOC, true);
+
+            const canvas = document.querySelector('#gpuCanvas');
+
+            const createOptions = new AppOptions();
+            createOptions.graphicsDevice = new WebgpuGraphicsDevice(canvas, {});
+//            createOptions.graphicsDevice = new WebglGraphicsDevice(canvas, {});
+            createOptions.componentSystems = [
+                RenderComponentSystem,
+                CameraComponentSystem,
+                LightComponentSystem,
+            ];
+            createOptions.resourceHandlers = [
+                TextureHandler,
+                ContainerHandler
+            ];
+
+            const app = new AppBase(canvas);
+            app.init(createOptions);
+
+            const lighting = app.scene.lighting;
+            lighting.shadowsEnabled = false;
+            lighting.cookiesEnabled = false;
+
+            app.graphicsDevice.initWebGpu().then(() => {
+                console.log("gpu device async created");
+
+                const assetListLoader = new AssetListLoader(Object.values(assets), app.assets);
+                assetListLoader.load(() => {
+                    onLoaded(app);
+                });
+
+            }).catch(console.error);
+        }
+
+        window.addEventListener('load', main);
+    </script>
+</body>
+
+</html>

--- a/src/platform/graphics/webgpu/webgpu-buffer.js
+++ b/src/platform/graphics/webgpu/webgpu-buffer.js
@@ -61,15 +61,13 @@ class WebgpuBuffer {
         }
 
         // src size needs to be a multiple of 4 as well
-        let src = new Uint8Array(storage.buffer ? storage.buffer : storage);
-        if (src.byteLength !== this.buffer.size) {
-            const alignedSrc = new Uint8Array(this.buffer.size);
-            alignedSrc.set(src);
-            src = alignedSrc;
-        }
+        const srcOffset = storage.byteOffset ?? 0;
+        const srcData = new Uint8Array(storage.buffer ?? storage, srcOffset, storage.byteLength);
+        const data = new Uint8Array(this.buffer.size);
+        data.set(srcData);
 
         // copy data to the gpu buffer
-        wgpu.queue.writeBuffer(this.buffer, 0, src, 0, src.length);
+        wgpu.queue.writeBuffer(this.buffer, 0, data, 0, data.length);
 
         // TODO: handle usage types:
         // - BUFFER_STATIC, BUFFER_DYNAMIC, BUFFER_STREAM, BUFFER_GPUDYNAMIC

--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -72,6 +72,7 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
         this.extTextureHalfFloat = false; // TODO: likely supported as well
         this.boneLimit = 1024;
         this.supportsImageBitmap = true;
+        this.extStandardDerivatives = true;
     }
 
     async initWebGpu() {
@@ -175,6 +176,8 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
         // render pipeline
         const pipeline = this.renderPipeline.get(primitive, vb.format, null, this.shader, this.renderTarget,
                                                  this.bindGroupFormats, this.renderState);
+        Debug.assert(pipeline);
+
         if (this.pipeline !== pipeline) {
             this.pipeline = pipeline;
             passEncoder.setPipeline(pipeline);
@@ -263,6 +266,9 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
 
         // TODO: test single command encoder for the whole frame
         this.commandEncoder = this.wgpu.createCommandEncoder();
+
+        // clear cached encoder state
+        this.pipeline = null;
 
         // start the pass
         this.passEncoder = this.commandEncoder.beginRenderPass(wrt.renderPassDescriptor);

--- a/src/platform/graphics/webgpu/webgpu-texture.js
+++ b/src/platform/graphics/webgpu/webgpu-texture.js
@@ -20,7 +20,7 @@ gpuTextureFormats[PIXELFORMAT_L8_A8] = '';
 gpuTextureFormats[PIXELFORMAT_R5_G6_B5] = '';
 gpuTextureFormats[PIXELFORMAT_R5_G5_B5_A1] = '';
 gpuTextureFormats[PIXELFORMAT_R4_G4_B4_A4] = '';
-gpuTextureFormats[PIXELFORMAT_R8_G8_B8] = '';
+gpuTextureFormats[PIXELFORMAT_R8_G8_B8] = 'bgra8unorm';
 gpuTextureFormats[PIXELFORMAT_R8_G8_B8_A8] = 'bgra8unorm';
 gpuTextureFormats[PIXELFORMAT_DXT1] = '';
 gpuTextureFormats[PIXELFORMAT_DXT3] = '';
@@ -118,7 +118,7 @@ class WebgpuTexture {
         const texture = this.texture;
         const wgpu = device.wgpu;
         const gpuFormat = gpuTextureFormats[texture.format];
-        Debug.assert(gpuFormat !== '', `WebGPU does not support texture format ${texture.format}`, texture);
+        Debug.assert(gpuFormat !== '', `WebGPU does not support texture format ${texture.format} for texture ${texture.name}`, texture);
 
         /** @type {GPUTextureDescriptor} */
         const textureDescriptor = {

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -1322,29 +1322,29 @@ class ForwardRenderer {
                     if (material._dirtyBlend) {
                         scene.layers._dirtyBlend = true;
                     }
-
-                    if (!drawCall._shader[pass] || drawCall._shaderDefs !== objDefs || drawCall._lightHash !== lightHash) {
-
-                        // draw calls not using static lights use variants cache on material to quickly find the shader, as they are all
-                        // the same for the same pass, using all lights of the scene
-                        if (!drawCall.isStatic) {
-                            const variantKey = pass + '_' + objDefs + '_' + lightHash;
-                            drawCall._shader[pass] = material.variants[variantKey];
-                            if (!drawCall._shader[pass]) {
-                                drawCall.updatePassShader(scene, pass, null, sortedLights, this.viewUniformFormat, this.viewBindGroupFormat);
-                                material.variants[variantKey] = drawCall._shader[pass];
-                            }
-                        } else {
-
-                            // static lights generate unique shader per draw call, as static lights are unique per draw call,
-                            // and so variants cache is not used
-                            drawCall.updatePassShader(scene, pass, drawCall._staticLightList, sortedLights, this.viewUniformFormat, this.viewBindGroupFormat);
-                        }
-                        drawCall._lightHash = lightHash;
-                    }
-
-                    Debug.assert(drawCall._shader[pass], "no shader for pass", material);
                 }
+
+                if (!drawCall._shader[pass] || drawCall._shaderDefs !== objDefs || drawCall._lightHash !== lightHash) {
+
+                    // draw calls not using static lights use variants cache on material to quickly find the shader, as they are all
+                    // the same for the same pass, using all lights of the scene
+                    if (!drawCall.isStatic) {
+                        const variantKey = pass + '_' + objDefs + '_' + lightHash;
+                        drawCall._shader[pass] = material.variants[variantKey];
+                        if (!drawCall._shader[pass]) {
+                            drawCall.updatePassShader(scene, pass, null, sortedLights, this.viewUniformFormat, this.viewBindGroupFormat);
+                            material.variants[variantKey] = drawCall._shader[pass];
+                        }
+                    } else {
+
+                        // static lights generate unique shader per draw call, as static lights are unique per draw call,
+                        // and so variants cache is not used
+                        drawCall.updatePassShader(scene, pass, drawCall._staticLightList, sortedLights, this.viewUniformFormat, this.viewBindGroupFormat);
+                    }
+                    drawCall._lightHash = lightHash;
+                }
+
+                Debug.assert(drawCall._shader[pass], "no shader for pass", material);
 
                 addCall(drawCall, material !== prevMaterial, !prevMaterial || lightMask !== prevLightMask);
 
@@ -1352,7 +1352,6 @@ class ForwardRenderer {
                 prevObjDefs = objDefs;
                 prevLightMask = lightMask;
                 prevStatic = drawCall.isStatic;
-
             }
         }
 


### PR DESCRIPTION
- fixed webgpu buffer creation when the storage is part of large ArrayBuffer
- fixed handling of pipeline cache
- support for RGB8 texture format (converts to RGBA8)
- forward renderer sets pass shader for all meshes instances, not only when material changes

![Screenshot 2022-10-20 at 14 35 20](https://user-images.githubusercontent.com/59932779/196968549-3a0ce1b7-9e09-4fb1-9ef8-c751200fd084.png)
