### PR TITLE
Downscale oversized ImageBitmaps

### DIFF
--- a/src/platform/graphics/graphics-device.js
+++ b/src/platform/graphics/graphics-device.js
@@ -326,10 +326,14 @@ class GraphicsDevice extends EventHandler {
      * @ignore
      */
     _isBrowserInterface(texture) {
-        return (typeof HTMLCanvasElement !== 'undefined' && texture instanceof HTMLCanvasElement) ||
-                (typeof HTMLImageElement !== 'undefined' && texture instanceof HTMLImageElement) ||
-                (typeof HTMLVideoElement !== 'undefined' && texture instanceof HTMLVideoElement) ||
-                (typeof ImageBitmap !== 'undefined' && texture instanceof ImageBitmap);
+        return this._isImageBrowserInterface(texture) ||
+                (typeof HTMLCanvasElement !== 'undefined' && texture instanceof HTMLCanvasElement) ||
+                (typeof HTMLVideoElement !== 'undefined' && texture instanceof HTMLVideoElement);           
+    }
+
+    _isImageBrowserInterface(texture) {
+        return (typeof HTMLImageElement !== 'undefined' && texture instanceof HTMLImageElement) ||
+               (typeof ImageBitmap !== 'undefined' && texture instanceof ImageBitmap);
     }
 
     /**

--- a/src/platform/graphics/graphics-device.js
+++ b/src/platform/graphics/graphics-device.js
@@ -328,7 +328,7 @@ class GraphicsDevice extends EventHandler {
     _isBrowserInterface(texture) {
         return this._isImageBrowserInterface(texture) ||
                 (typeof HTMLCanvasElement !== 'undefined' && texture instanceof HTMLCanvasElement) ||
-                (typeof HTMLVideoElement !== 'undefined' && texture instanceof HTMLVideoElement);           
+                (typeof HTMLVideoElement !== 'undefined' && texture instanceof HTMLVideoElement);
     }
 
     _isImageBrowserInterface(texture) {

--- a/src/platform/graphics/graphics-device.js
+++ b/src/platform/graphics/graphics-device.js
@@ -332,8 +332,8 @@ class GraphicsDevice extends EventHandler {
     }
 
     _isImageBrowserInterface(texture) {
-        return (typeof HTMLImageElement !== 'undefined' && texture instanceof HTMLImageElement) ||
-               (typeof ImageBitmap !== 'undefined' && texture instanceof ImageBitmap);
+        return (typeof ImageBitmap !== 'undefined' && texture instanceof ImageBitmap) ||
+               (typeof HTMLImageElement !== 'undefined' && texture instanceof HTMLImageElement);
     }
 
     /**

--- a/src/platform/graphics/webgl/webgl-texture.js
+++ b/src/platform/graphics/webgl/webgl-texture.js
@@ -318,7 +318,7 @@ class WebglTexture {
 
                         let src = mipObject[face];
                         // Downsize images that are too large to be used as cube maps
-                        if (device._isImageBrowserInterface(src))
+                        if (device._isImageBrowserInterface(src)) {
                             if (src.width > device.maxCubeMapSize || src.height > device.maxCubeMapSize) {
                                 src = downsampleImage(src, device.maxCubeMapSize);
                                 if (mipLevel === 0) {
@@ -406,7 +406,7 @@ class WebglTexture {
                 // ----- 2D -----
                 if (device._isBrowserInterface(mipObject)) {
                     // Downsize images that are too large to be used as textures
-                    if (device._isImageBrowserInterface(mipObject))
+                    if (device._isImageBrowserInterface(mipObject)) {
                         if (mipObject.width > device.maxTextureSize || mipObject.height > device.maxTextureSize) {
                             mipObject = downsampleImage(mipObject, device.maxTextureSize);
                             if (mipLevel === 0) {

--- a/src/platform/graphics/webgl/webgl-texture.js
+++ b/src/platform/graphics/webgl/webgl-texture.js
@@ -318,7 +318,7 @@ class WebglTexture {
 
                         let src = mipObject[face];
                         // Downsize images that are too large to be used as cube maps
-                        if (src instanceof HTMLImageElement) {
+                        if (device._isImageBrowserInterface(src))
                             if (src.width > device.maxCubeMapSize || src.height > device.maxCubeMapSize) {
                                 src = downsampleImage(src, device.maxCubeMapSize);
                                 if (mipLevel === 0) {
@@ -406,7 +406,7 @@ class WebglTexture {
                 // ----- 2D -----
                 if (device._isBrowserInterface(mipObject)) {
                     // Downsize images that are too large to be used as textures
-                    if (mipObject instanceof HTMLImageElement) {
+                    if (device._isImageBrowserInterface(mipObject))
                         if (mipObject.width > device.maxTextureSize || mipObject.height > device.maxTextureSize) {
                             mipObject = downsampleImage(mipObject, device.maxTextureSize);
                             if (mipLevel === 0) {


### PR DESCRIPTION
Fixes #4782

ImageBitmap was recently made the default loading texture interface in #4584, but oversized textures weren't being downsized.