### PR TITLE
Options split

### DIFF
--- a/examples/src/examples/graphics/hardware-instancing.tsx
+++ b/examples/src/examples/graphics/hardware-instancing.tsx
@@ -60,7 +60,7 @@ class HardwareInstancingExample {
                 // create standard material and enable instancing on it
                 const material = new pc.StandardMaterial();
                 material.onUpdateShader = function (options) {
-                    options.useInstancing = true;
+                    options.litOptions.useInstancing = true;
                     return options;
                 };
                 material.shininess = 60;

--- a/src/framework/lightmapper/lightmapper.js
+++ b/src/framework/lightmapper/lightmapper.js
@@ -269,9 +269,9 @@ class Lightmapper {
             this.ambientAOMaterial = this.createMaterialForPass(device, scene, 0, true);
             this.ambientAOMaterial.onUpdateShader = function (options) {
                 // mark LM as without ambient, to add it
-                options.lightMapWithoutAmbient = true;
+                options.litOptions.lightMapWithoutAmbient = true;
                 // don't add ambient to diffuse directly but keep it separate, to allow AO to be multiplied in
-                options.separateAmbient = true;
+                options.litOptions.separateAmbient = true;
                 return options;
             };
         }

--- a/src/scene/materials/standard-material-options-builder.js
+++ b/src/scene/materials/standard-material-options-builder.js
@@ -347,11 +347,18 @@ class StandardMaterialOptionsBuilder {
         }
         options[vname] = false;
         options[vcname] = '';
-        options.litOptions[vname] = options[vname];
+        const litOptions = {
+            enabled: false,
+            transform: 0,
+            uv: 0,
+            vertexColors: false
+        };
 
         const isOpacity = p === 'opacity';
-        if (isOpacity && stdMat.blendType === BLEND_NONE && stdMat.alphaTest === 0.0 && !stdMat.alphaToCoverage)
+        if (isOpacity && stdMat.blendType === BLEND_NONE && stdMat.alphaTest === 0.0 && !stdMat.alphaToCoverage) {
+            options.litOptions[p] = litOptions;
             return;
+        }
 
         if (!minimalOptions || isOpacity) {
             if (p !== 'height' && stdMat[vname]) {
@@ -386,11 +393,12 @@ class StandardMaterialOptionsBuilder {
             }
         }
 
-        const litOptionsName = 'use' + mname[0].toUpperCase() + mname.substring(1);
-        options.litOptions[litOptionsName] = options[mname];
-        options.litOptions[tname] = options[tname];
-        options.litOptions[uname] = options[uname];
-        options.litOptions.useVertexColors = options.vertexColors;
+        litOptions.enabled = options[mname];
+        litOptions.tranform = options[tname];
+        litOptions.uv = options[uname];
+        litOptions.vertexColors = options[vname];
+        options.litOptions[p] = litOptions;
+        options.litOptions.vertexColors = options.vertexColors;
     }
 
     _collectLights(lType, lights, lightsFiltered, mask, staticLightList) {

--- a/src/scene/materials/standard-material-options-builder.js
+++ b/src/scene/materials/standard-material-options-builder.js
@@ -343,6 +343,8 @@ class StandardMaterialOptionsBuilder {
         }
         options[vname] = false;
         options[vcname] = '';
+        options.litOptions[vname] = options[vname];
+        options.litOptions[vcname] = options[vcname];
 
         const isOpacity = p === 'opacity';
         if (isOpacity && stdMat.blendType === BLEND_NONE && stdMat.alphaTest === 0.0 && !stdMat.alphaToCoverage)
@@ -386,8 +388,6 @@ class StandardMaterialOptionsBuilder {
         options.litOptions[cname] = options[cname];
         options.litOptions[tname] = options[tname];
         options.litOptions[uname] = options[uname];
-        options.litOptions[vname] = options[vname];
-        options.litOptions[vcname] = options[vcname];
         options.litOptions.vertexColors = options.vertexColors;
     }
 

--- a/src/scene/materials/standard-material-options-builder.js
+++ b/src/scene/materials/standard-material-options-builder.js
@@ -44,12 +44,15 @@ class StandardMaterialOptionsBuilder {
 
     // Minimal options for Depth and Shadow passes
     updateMinRef(options, scene, stdMat, objDefs, staticLightList, pass, sortedLights) {
+        options.litOptions = {};
         this._updateSharedOptions(options, scene, stdMat, objDefs, pass);
         this._updateMinOptions(options, stdMat);
         this._updateUVOptions(options, stdMat, objDefs, true);
+        options.litOptions.chunks = options.chunks;
     }
 
     updateRef(options, scene, stdMat, objDefs, staticLightList, pass, sortedLights) {
+        options.litOptions = {};
         this._updateSharedOptions(options, scene, stdMat, objDefs, pass);
         this._updateEnvOptions(options, stdMat, scene);
         this._updateMaterialOptions(options, stdMat);
@@ -57,40 +60,42 @@ class StandardMaterialOptionsBuilder {
             if (options.gamma) options.gamma = GAMMA_SRGBHDR;
             options.toneMap = TONEMAP_LINEAR;
         }
-        options.hasTangents = objDefs && ((objDefs & SHADERDEF_TANGENTS) !== 0);
-        this._updateLightOptions(options, scene, stdMat, objDefs, sortedLights, staticLightList);
+        options.litOptions.hasTangents = objDefs && ((objDefs & SHADERDEF_TANGENTS) !== 0);
+        this._updateLightOptions(options, stdMat, objDefs, sortedLights, staticLightList);
         this._updateUVOptions(options, stdMat, objDefs, false);
+        options.litOptions.chunks = options.chunks;
     }
 
     _updateSharedOptions(options, scene, stdMat, objDefs, pass) {
-        options.pass = pass;
-        options.alphaTest = stdMat.alphaTest > 0;
-        options.forceFragmentPrecision = stdMat.forceFragmentPrecision || '';
-        options.chunks = stdMat.chunks || '';
-        options.blendType = stdMat.blendType;
         options.forceUv1 = stdMat.forceUv1;
-        options.separateAmbient = false;    // store ambient light color in separate variable, instead of adding it to diffuse directly
-        options.screenSpace = objDefs && (objDefs & SHADERDEF_SCREENSPACE) !== 0;
-        options.skin = objDefs && (objDefs & SHADERDEF_SKIN) !== 0;
-        options.useInstancing = objDefs && (objDefs & SHADERDEF_INSTANCING) !== 0;
-        options.useMorphPosition = objDefs && (objDefs & SHADERDEF_MORPH_POSITION) !== 0;
-        options.useMorphNormal = objDefs && (objDefs & SHADERDEF_MORPH_NORMAL) !== 0;
-        options.useMorphTextureBased = objDefs && (objDefs & SHADERDEF_MORPH_TEXTURE_BASED) !== 0;
+        options.chunks = stdMat.chunks || '';
 
-        options.nineSlicedMode = stdMat.nineSlicedMode || 0;
+        options.litOptions.pass = pass;
+        options.litOptions.alphaTest = stdMat.alphaTest > 0;
+        options.litOptions.forceFragmentPrecision = stdMat.forceFragmentPrecision || '';
+        options.litOptions.blendType = stdMat.blendType;
+        options.litOptions.separateAmbient = false;    // store ambient light color in separate variable, instead of adding it to diffuse directly
+        options.litOptions.screenSpace = objDefs && (objDefs & SHADERDEF_SCREENSPACE) !== 0;
+        options.litOptions.skin = objDefs && (objDefs & SHADERDEF_SKIN) !== 0;
+        options.litOptions.useInstancing = objDefs && (objDefs & SHADERDEF_INSTANCING) !== 0;
+        options.litOptions.useMorphPosition = objDefs && (objDefs & SHADERDEF_MORPH_POSITION) !== 0;
+        options.litOptions.useMorphNormal = objDefs && (objDefs & SHADERDEF_MORPH_NORMAL) !== 0;
+        options.litOptions.useMorphTextureBased = objDefs && (objDefs & SHADERDEF_MORPH_TEXTURE_BASED) !== 0;
+
+        options.litOptions.nineSlicedMode = stdMat.nineSlicedMode || 0;
 
         // clustered lighting features (in shared options as shadow pass needs this too)
         if (scene.clusteredLightingEnabled && stdMat.useLighting) {
-            options.clusteredLightingEnabled = true;
-            options.clusteredLightingCookiesEnabled = scene.lighting.cookiesEnabled;
-            options.clusteredLightingShadowsEnabled = scene.lighting.shadowsEnabled;
-            options.clusteredLightingShadowType = scene.lighting.shadowType;
-            options.clusteredLightingAreaLightsEnabled = scene.lighting.areaLightsEnabled;
+            options.litOptions.clusteredLightingEnabled = true;
+            options.litOptions.clusteredLightingCookiesEnabled = scene.lighting.cookiesEnabled;
+            options.litOptions.clusteredLightingShadowsEnabled = scene.lighting.shadowsEnabled;
+            options.litOptions.clusteredLightingShadowType = scene.lighting.shadowType;
+            options.litOptions.clusteredLightingAreaLightsEnabled = scene.lighting.areaLightsEnabled;
         } else {
-            options.clusteredLightingEnabled = false;
-            options.clusteredLightingCookiesEnabled = false;
-            options.clusteredLightingShadowsEnabled = false;
-            options.clusteredLightingAreaLightsEnabled = false;
+            options.litOptions.clusteredLightingEnabled = false;
+            options.litOptions.clusteredLightingCookiesEnabled = false;
+            options.litOptions.clusteredLightingShadowsEnabled = false;
+            options.litOptions.clusteredLightingAreaLightsEnabled = false;
         }
     }
 
@@ -104,7 +109,7 @@ class StandardMaterialOptionsBuilder {
             hasVcolor = (objDefs & SHADERDEF_VCOLOR) !== 0;
         }
 
-        options.vertexColors = false;
+        options.litOptions.vertexColors = false;
         this._mapXForms = [];
 
         const uniqueTextureMap = {};
@@ -116,7 +121,7 @@ class StandardMaterialOptionsBuilder {
 
     _updateMinOptions(options, stdMat) {
         options.opacityTint = stdMat.opacity !== 1 && stdMat.blendType !== BLEND_NONE;
-        options.lights = [];
+        options.litOptions.lights = [];
     }
 
     _updateMaterialOptions(options, stdMat) {
@@ -142,72 +147,76 @@ class StandardMaterialOptionsBuilder {
         const isPackedNormalMap = stdMat.normalMap ? (stdMat.normalMap.format === PIXELFORMAT_DXT5 || stdMat.normalMap.type === TEXTURETYPE_SWIZZLEGGGR) : false;
 
         options.opacityTint = (stdMat.opacity !== 1 && stdMat.blendType !== BLEND_NONE) ? 1 : 0;
-        options.blendMapsWithColors = true;
         options.ambientTint = stdMat.ambientTint;
         options.diffuseTint = diffuseTint ? 2 : 0;
         options.specularTint = specularTint ? 2 : 0;
         options.specularityFactorTint = specularityFactorTint ? 1 : 0;
-        options.useSpecularityFactor = (specularityFactorTint || !!stdMat.specularityFactorMap) && stdMat.useMetalnessSpecularColor;
-        options.useSpecularColor = useSpecularColor;
         options.metalnessTint = (stdMat.useMetalness && stdMat.metalness < 1) ? 1 : 0;
         options.glossTint = 1;
         options.emissiveTint = (emissiveTintColor ? 2 : 0) + (emissiveTintIntensity ? 1 : 0);
-        options.alphaToCoverage = stdMat.alphaToCoverage;
-        options.normalizeNormalMap = stdMat.normalizeNormalMap;
-        options.ambientSH = !!stdMat.ambientSH;
-        options.useSpecular = useSpecular;
         options.diffuseEncoding = stdMat.diffuseMap?.encoding;
         options.diffuseDetailEncoding = stdMat.diffuseDetailMap?.encoding;
         options.emissiveEncoding = stdMat.emissiveMap?.encoding;
         options.lightMapEncoding = stdMat.lightMap?.encoding;
-        options.conserveEnergy = stdMat.conserveEnergy;
-        options.opacityFadesSpecular = stdMat.opacityFadesSpecular;
-        options.alphaFade = stdMat.alphaFade;
-        options.occludeSpecular = stdMat.occludeSpecular;
-        options.occludeSpecularFloat = (stdMat.occludeSpecularIntensity !== 1.0);
-        options.occludeDirect = stdMat.occludeDirect;
-        options.shadingModel = stdMat.shadingModel;
-        options.fresnelModel = stdMat.fresnelModel;
         options.packedNormal = isPackedNormalMap;
-        options.fastTbn = stdMat.fastTbn;
-        options.cubeMapProjection = stdMat.cubeMapProjection;
-        options.customFragmentShader = stdMat.customFragmentShader;
-        options.refraction = (stdMat.refraction || !!stdMat.refractionMap) && (stdMat.useDynamicRefraction || !!options.reflectionSource);
         options.refractionTint = (stdMat.refraction !== 1.0) ? 1 : 0;
-        options.useDynamicRefraction = stdMat.useDynamicRefraction;
         options.refractionIndexTint = (stdMat.refractionIndex !== 1.0 / 1.5) ? 1 : 0;
         options.thicknessTint = (stdMat.useDynamicRefraction && stdMat.thickness !== 1.0) ? 1 : 0;
-        options.useMetalness = stdMat.useMetalness;
         options.specularEncoding = stdMat.specularEncoding || 'linear';
         options.sheenEncoding = stdMat.sheenEncoding || 'linear';
-        options.enableGGXSpecular = stdMat.enableGGXSpecular;
-        options.msdf = !!stdMat.msdfMap;
-        options.msdfTextAttribute = !!stdMat.msdfTextAttribute;
-        options.twoSidedLighting = stdMat.twoSidedLighting;
-        options.pixelSnap = stdMat.pixelSnap;
         options.aoMapUv = stdMat.aoUvSet; // backwards compatibility
         options.diffuseDetail = !!stdMat.diffuseMap;
         options.normalDetail = !!stdMat.normalMap;
         options.diffuseDetailMode = stdMat.diffuseDetailMode;
-        options.detailModes = !!options.diffuseDetail;
-        options.clearCoat = !!stdMat.clearCoat;
         options.clearCoatTint = (stdMat.clearCoat !== 1.0) ? 1 : 0;
         options.clearCoatGlossiness = !!stdMat.clearCoatGlossiness;
         options.clearCoatGlossTint = (stdMat.clearCoatGlossiness !== 1.0) ? 1 : 0;
 
-        options.iridescence = stdMat.useIridescence && stdMat.iridescence !== 0.0;
         options.iridescenceTint = stdMat.iridescence !== 1.0 ? 1 : 0;
 
-        options.sheen = stdMat.useSheen;
         options.sheenTint = (stdMat.useSheen && notWhite(stdMat.sheen)) ? 2 : 0;
         options.sheenGlossinessTint = 1;
+
+        // LIT OPTIONS
+        options.litOptions.customFragmentShader = stdMat.customFragmentShader;
+        options.litOptions.pixelSnap = stdMat.pixelSnap;
+
+        options.litOptions.detailModes = !!options.diffuseDetail;
+        options.litOptions.shadingModel = stdMat.shadingModel;
+        options.litOptions.ambientSH = !!stdMat.ambientSH;
+        options.litOptions.fastTbn = stdMat.fastTbn;
+        options.litOptions.twoSidedLighting = stdMat.twoSidedLighting;
+        options.litOptions.occludeSpecular = stdMat.occludeSpecular;
+        options.litOptions.occludeSpecularFloat = (stdMat.occludeSpecularIntensity !== 1.0);
+
+        options.litOptions.useMsdf = !!stdMat.msdfMap;
+        options.litOptions.msdfTextAttribute = !!stdMat.msdfTextAttribute;
+
+        options.litOptions.alphaToCoverage = stdMat.alphaToCoverage;
+        options.litOptions.opacityFadesSpecular = stdMat.opacityFadesSpecular;
+
+        options.litOptions.cubeMapProjection = stdMat.cubeMapProjection;
+
+        options.litOptions.occludeDirect = stdMat.occludeDirect;
+        options.litOptions.conserveEnergy = stdMat.conserveEnergy;
+        options.litOptions.useSpecular = useSpecular;
+        options.litOptions.useSpecularityFactor = (specularityFactorTint || !!stdMat.specularityFactorMap) && stdMat.useMetalnessSpecularColor;
+        options.litOptions.useSpecularColor = useSpecularColor;
+        options.litOptions.enableGGXSpecular = stdMat.enableGGXSpecular;
+        options.litOptions.fresnelModel = stdMat.fresnelModel;
+        options.litOptions.useRefraction = (stdMat.refraction || !!stdMat.refractionMap) && (stdMat.useDynamicRefraction || !!options.reflectionSource);
+        options.litOptions.useClearCoat = !!stdMat.clearCoat;
+        options.litOptions.useSheen = stdMat.useSheen;
+        options.litOptions.useIridescence = stdMat.useIridescence && stdMat.iridescence !== 0.0;
+        options.litOptions.useMetalness = stdMat.useMetalness;
+        options.litOptions.useDynamicRefraction = stdMat.useDynamicRefraction;
     }
 
     _updateEnvOptions(options, stdMat, scene) {
-        options.fog = stdMat.useFog ? scene.fog : 'none';
-        options.gamma = stdMat.useGammaTonemap ? scene.gammaCorrection : GAMMA_NONE;
-        options.toneMap = stdMat.useGammaTonemap ? scene.toneMapping : -1;
-        options.fixSeams = (stdMat.cubeMap ? stdMat.cubeMap.fixCubemapSeams : false);
+        options.litOptions.fog = stdMat.useFog ? scene.fog : 'none';
+        options.litOptions.gamma = stdMat.useGammaTonemap ? scene.gammaCorrection : GAMMA_NONE;
+        options.litOptions.toneMap = stdMat.useGammaTonemap ? scene.toneMapping : -1;
+        options.litOptions.fixSeams = (stdMat.cubeMap ? stdMat.cubeMap.fixCubemapSeams : false);
 
         const isPhong = stdMat.shadingModel === SPECULAR_PHONG;
 
@@ -215,79 +224,79 @@ class StandardMaterialOptionsBuilder {
 
         // source of environment reflections is as follows:
         if (stdMat.envAtlas && stdMat.cubeMap && !isPhong) {
-            options.reflectionSource = 'envAtlasHQ';
-            options.reflectionEncoding = stdMat.envAtlas.encoding;
+            options.litOptions.reflectionSource = 'envAtlasHQ';
+            options.litOptions.reflectionEncoding = stdMat.envAtlas.encoding;
         } else if (stdMat.envAtlas && !isPhong) {
-            options.reflectionSource = 'envAtlas';
-            options.reflectionEncoding = stdMat.envAtlas.encoding;
+            options.litOptions.reflectionSource = 'envAtlas';
+            options.litOptions.reflectionEncoding = stdMat.envAtlas.encoding;
         } else if (stdMat.cubeMap) {
-            options.reflectionSource = 'cubeMap';
-            options.reflectionEncoding = stdMat.cubeMap.encoding;
+            options.litOptions.reflectionSource = 'cubeMap';
+            options.litOptions.reflectionEncoding = stdMat.cubeMap.encoding;
         } else if (stdMat.sphereMap) {
-            options.reflectionSource = 'sphereMap';
-            options.reflectionEncoding = stdMat.sphereMap.encoding;
+            options.litOptions.reflectionSource = 'sphereMap';
+            options.litOptions.reflectionEncoding = stdMat.sphereMap.encoding;
         } else if (stdMat.useSkybox && scene.envAtlas && scene.skybox && !isPhong) {
-            options.reflectionSource = 'envAtlasHQ';
-            options.reflectionEncoding = scene.envAtlas.encoding;
+            options.litOptions.reflectionSource = 'envAtlasHQ';
+            options.litOptions.reflectionEncoding = scene.envAtlas.encoding;
             usingSceneEnv = true;
         } else if (stdMat.useSkybox && scene.envAtlas && !isPhong) {
-            options.reflectionSource = 'envAtlas';
-            options.reflectionEncoding = scene.envAtlas.encoding;
+            options.litOptions.reflectionSource = 'envAtlas';
+            options.litOptions.reflectionEncoding = scene.envAtlas.encoding;
             usingSceneEnv = true;
         } else if (stdMat.useSkybox && scene.skybox) {
-            options.reflectionSource = 'cubeMap';
-            options.reflectionEncoding = scene.skybox.encoding;
+            options.litOptions.reflectionSource = 'cubeMap';
+            options.litOptions.reflectionEncoding = scene.skybox.encoding;
             usingSceneEnv = true;
         } else {
-            options.reflectionSource = null;
-            options.reflectionEncoding = null;
+            options.litOptions.reflectionSource = null;
+            options.litOptions.reflectionEncoding = null;
         }
 
         // source of environment ambient is as follows:
         if (stdMat.ambientSH && !isPhong) {
-            options.ambientSource = 'ambientSH';
-            options.ambientEncoding = null;
+            options.litOptions.ambientSource = 'ambientSH';
+            options.litOptions.ambientEncoding = null;
         } else {
             const envAtlas = stdMat.envAtlas || (stdMat.useSkybox && scene.envAtlas ? scene.envAtlas : null);
             if (envAtlas && !isPhong) {
-                options.ambientSource = 'envAtlas';
-                options.ambientEncoding = envAtlas.encoding;
+                options.litOptions.ambientSource = 'envAtlas';
+                options.litOptions.ambientEncoding = envAtlas.encoding;
             } else {
-                options.ambientSource = 'constant';
-                options.ambientEncoding = null;
+                options.litOptions.ambientSource = 'constant';
+                options.litOptions.ambientEncoding = null;
             }
         }
 
         // TODO: add a test for if non skybox cubemaps have rotation (when this is supported) - for now assume no non-skybox cubemap rotation
-        options.skyboxIntensity = usingSceneEnv && (scene.skyboxIntensity !== 1 || scene.physicalUnits);
-        options.useCubeMapRotation = usingSceneEnv && scene.skyboxRotation && !scene.skyboxRotation.equals(Quat.IDENTITY);
+        options.litOptions.skyboxIntensity = usingSceneEnv && (scene.skyboxIntensity !== 1 || scene.physicalUnits);
+        options.litOptions.useCubeMapRotation = usingSceneEnv && scene.skyboxRotation && !scene.skyboxRotation.equals(Quat.IDENTITY);
     }
 
-    _updateLightOptions(options, scene, stdMat, objDefs, sortedLights, staticLightList) {
-        options.lightMap = false;
-        options.lightMapChannel = '';
-        options.lightMapUv = 0;
-        options.lightMapTransform = 0;
-        options.lightMapWithoutAmbient = false;
-        options.dirLightMap = false;
+    _updateLightOptions(options, stdMat, objDefs, sortedLights, staticLightList) {
+        options.litOptions.lightMap = false;
+        options.litOptions.lightMapChannel = '';
+        options.litOptions.lightMapUv = 0;
+        options.litOptions.lightMapTransform = 0;
+        options.litOptions.lightMapWithoutAmbient = false;
+        options.litOptions.dirLightMap = false;
 
         if (objDefs) {
-            options.noShadow = (objDefs & SHADERDEF_NOSHADOW) !== 0;
+            options.litOptions.noShadow = (objDefs & SHADERDEF_NOSHADOW) !== 0;
 
             if ((objDefs & SHADERDEF_LM) !== 0) {
-                options.lightMapEncoding = scene.lightmapPixelFormat === PIXELFORMAT_RGBA8 ? 'rgbm' : 'linear';
-                options.lightMap = true;
-                options.lightMapChannel = 'rgb';
-                options.lightMapUv = 1;
-                options.lightMapTransform = 0;
-                options.lightMapWithoutAmbient = !stdMat.lightMap;
+                options.litOptions.lightMapEncoding = 'rgbm';
+                options.litOptions.lightMap = true;
+                options.litOptions.lightMapChannel = 'rgb';
+                options.litOptions.lightMapUv = 1;
+                options.litOptions.lightMapTransform = 0;
+                options.litOptions.lightMapWithoutAmbient = !stdMat.lightMap;
                 if ((objDefs & SHADERDEF_DIRLM) !== 0) {
-                    options.dirLightMap = true;
+                    options.litOptions.dirLightMap = true;
                 }
 
                 // if lightmaps contain baked ambient light, disable real-time ambient light
                 if ((objDefs & SHADERDEF_LMAMBIENT) !== 0) {
-                    options.lightMapWithoutAmbient = false;
+                    options.litOptions.lightMapWithoutAmbient = false;
                 }
             }
         }
@@ -297,20 +306,20 @@ class StandardMaterialOptionsBuilder {
             const mask = objDefs ? (objDefs >> 16) : MASK_AFFECT_DYNAMIC;
 
             // mask to select lights (dynamic vs lightmapped) when using clustered lighting
-            options.lightMaskDynamic = !!(mask & MASK_AFFECT_DYNAMIC);
+            options.litOptions.lightMaskDynamic = !!(mask & MASK_AFFECT_DYNAMIC);
 
             if (sortedLights) {
                 this._collectLights(LIGHTTYPE_DIRECTIONAL, sortedLights[LIGHTTYPE_DIRECTIONAL], lightsFiltered, mask);
                 this._collectLights(LIGHTTYPE_OMNI, sortedLights[LIGHTTYPE_OMNI], lightsFiltered, mask, staticLightList);
                 this._collectLights(LIGHTTYPE_SPOT, sortedLights[LIGHTTYPE_SPOT], lightsFiltered, mask, staticLightList);
             }
-            options.lights = lightsFiltered;
+            options.litOptions.lights = lightsFiltered;
         } else {
-            options.lights = [];
+            options.litOptions.lights = [];
         }
 
-        if (options.lights.length === 0) {
-            options.noShadow = true;
+        if (options.litOptions.lights.length === 0) {
+            options.litOptions.noShadow = true;
         }
     }
 
@@ -326,10 +335,10 @@ class StandardMaterialOptionsBuilder {
         // Avoid overriding previous lightMap properties
         if (p !== 'light') {
             options[mname] = false;
+            options[iname] = undefined;
             options[cname] = '';
             options[tname] = 0;
             options[uname] = 0;
-            options[iname] = undefined;
         }
         options[vname] = false;
         options[vcname] = '';
@@ -370,6 +379,15 @@ class StandardMaterialOptionsBuilder {
                 }
             }
         }
+
+        options.litOptions[mname] = options[mname];
+        options.litOptions[iname] = options[iname];
+        options.litOptions[cname] = options[cname];
+        options.litOptions[tname] = options[tname];
+        options.litOptions[uname] = options[uname];
+        options.litOptions[vname] = options[vname];
+        options.litOptions[vcname] = options[vcname];
+        options.litOptions.vertexColors = options.vertexColors;
     }
 
     _collectLights(lType, lights, lightsFiltered, mask, staticLightList) {

--- a/src/scene/materials/standard-material-options-builder.js
+++ b/src/scene/materials/standard-material-options-builder.js
@@ -182,6 +182,10 @@ class StandardMaterialOptionsBuilder {
         options.litOptions.customFragmentShader = stdMat.customFragmentShader;
         options.litOptions.pixelSnap = stdMat.pixelSnap;
 
+        options.litOptions.useClearCoatNormalMap = !!stdMat.clearCoatNormalMap;
+        options.litOptions.useDiffuseMap = !!stdMat.diffuseMap;
+        options.litOptions.useAoMap = !!stdMat.aoMap;
+
         options.litOptions.detailModes = !!options.diffuseDetail;
         options.litOptions.shadingModel = stdMat.shadingModel;
         options.litOptions.ambientSH = !!stdMat.ambientSH;
@@ -274,25 +278,25 @@ class StandardMaterialOptionsBuilder {
     }
 
     _updateLightOptions(options, stdMat, objDefs, sortedLights, staticLightList) {
-        options.litOptions.lightMap = false;
+        options.litOptions.useLightMap = false;
         options.litOptions.lightMapChannel = '';
         options.litOptions.lightMapUv = 0;
         options.litOptions.lightMapTransform = 0;
         options.litOptions.lightMapWithoutAmbient = false;
-        options.litOptions.dirLightMap = false;
+        options.litOptions.useDirLightMap = false;
 
         if (objDefs) {
             options.litOptions.noShadow = (objDefs & SHADERDEF_NOSHADOW) !== 0;
 
             if ((objDefs & SHADERDEF_LM) !== 0) {
                 options.litOptions.lightMapEncoding = 'rgbm';
-                options.litOptions.lightMap = true;
+                options.litOptions.useLightMap = true;
                 options.litOptions.lightMapChannel = 'rgb';
                 options.litOptions.lightMapUv = 1;
                 options.litOptions.lightMapTransform = 0;
                 options.litOptions.lightMapWithoutAmbient = !stdMat.lightMap;
                 if ((objDefs & SHADERDEF_DIRLM) !== 0) {
-                    options.litOptions.dirLightMap = true;
+                    options.litOptions.useDirLightMap = true;
                 }
 
                 // if lightmaps contain baked ambient light, disable real-time ambient light
@@ -388,7 +392,7 @@ class StandardMaterialOptionsBuilder {
         options.litOptions[cname] = options[cname];
         options.litOptions[tname] = options[tname];
         options.litOptions[uname] = options[uname];
-        options.litOptions.vertexColors = options.vertexColors;
+        options.litOptions.useVertexColors = options.vertexColors;
     }
 
     _collectLights(lType, lights, lightsFiltered, mask, staticLightList) {

--- a/src/scene/materials/standard-material-options-builder.js
+++ b/src/scene/materials/standard-material-options-builder.js
@@ -278,25 +278,25 @@ class StandardMaterialOptionsBuilder {
     }
 
     _updateLightOptions(options, stdMat, objDefs, sortedLights, staticLightList) {
-        options.litOptions.useLightMap = false;
-        options.litOptions.lightMapChannel = '';
-        options.litOptions.lightMapUv = 0;
-        options.litOptions.lightMapTransform = 0;
+        options.lightMap = false;
+        options.lightMapChannel = '';
+        options.lightMapUv = 0;
+        options.lightMapTransform = 0;
         options.litOptions.lightMapWithoutAmbient = false;
-        options.litOptions.useDirLightMap = false;
+        options.dirLightMap = false;
 
         if (objDefs) {
             options.litOptions.noShadow = (objDefs & SHADERDEF_NOSHADOW) !== 0;
 
             if ((objDefs & SHADERDEF_LM) !== 0) {
-                options.litOptions.lightMapEncoding = 'rgbm';
-                options.litOptions.useLightMap = true;
-                options.litOptions.lightMapChannel = 'rgb';
-                options.litOptions.lightMapUv = 1;
-                options.litOptions.lightMapTransform = 0;
+                options.lightMapEncoding = 'rgbm';
+                options.lightMap = true;
+                options.lightMapChannel = 'rgb';
+                options.lightMapUv = 1;
+                options.lightMapTransform = 0;
                 options.litOptions.lightMapWithoutAmbient = !stdMat.lightMap;
                 if ((objDefs & SHADERDEF_DIRLM) !== 0) {
-                    options.litOptions.useDirLightMap = true;
+                    options.dirLightMap = true;
                 }
 
                 // if lightmaps contain baked ambient light, disable real-time ambient light
@@ -348,7 +348,6 @@ class StandardMaterialOptionsBuilder {
         options[vname] = false;
         options[vcname] = '';
         options.litOptions[vname] = options[vname];
-        options.litOptions[vcname] = options[vcname];
 
         const isOpacity = p === 'opacity';
         if (isOpacity && stdMat.blendType === BLEND_NONE && stdMat.alphaTest === 0.0 && !stdMat.alphaToCoverage)
@@ -387,9 +386,8 @@ class StandardMaterialOptionsBuilder {
             }
         }
 
-        options.litOptions[mname] = options[mname];
-        options.litOptions[iname] = options[iname];
-        options.litOptions[cname] = options[cname];
+        const litOptionsName = 'use' + mname[0].toUpperCase() + mname.substring(1);
+        options.litOptions[litOptionsName] = options[mname];
         options.litOptions[tname] = options[tname];
         options.litOptions[uname] = options[uname];
         options.litOptions.useVertexColors = options.vertexColors;

--- a/src/scene/materials/standard-material-options-builder.js
+++ b/src/scene/materials/standard-material-options-builder.js
@@ -61,7 +61,7 @@ class StandardMaterialOptionsBuilder {
             options.toneMap = TONEMAP_LINEAR;
         }
         options.litOptions.hasTangents = objDefs && ((objDefs & SHADERDEF_TANGENTS) !== 0);
-        this._updateLightOptions(options, stdMat, objDefs, sortedLights, staticLightList);
+        this._updateLightOptions(options, scene, stdMat, objDefs, sortedLights, staticLightList);
         this._updateUVOptions(options, stdMat, objDefs, false);
         options.litOptions.chunks = options.chunks;
     }
@@ -347,7 +347,7 @@ class StandardMaterialOptionsBuilder {
         options.litOptions.useCubeMapRotation = usingSceneEnv && scene.skyboxRotation && !scene.skyboxRotation.equals(Quat.IDENTITY);
     }
 
-    _updateLightOptions(options, stdMat, objDefs, sortedLights, staticLightList) {
+    _updateLightOptions(options, scene, stdMat, objDefs, sortedLights, staticLightList) {
         options.lightMap = false;
         options.lightMapChannel = '';
         options.lightMapUv = 0;
@@ -359,7 +359,7 @@ class StandardMaterialOptionsBuilder {
             options.litOptions.noShadow = (objDefs & SHADERDEF_NOSHADOW) !== 0;
 
             if ((objDefs & SHADERDEF_LM) !== 0) {
-                options.lightMapEncoding = 'rgbm';
+                options.lightMapEncoding = scene.lightmapPixelFormat === PIXELFORMAT_RGBA8 ? 'rgbm' : 'linear';
                 options.lightMap = true;
                 options.lightMapChannel = 'rgb';
                 options.lightMapUv = 1;

--- a/src/scene/materials/standard-material-options-builder.js
+++ b/src/scene/materials/standard-material-options-builder.js
@@ -178,6 +178,7 @@ class StandardMaterialOptionsBuilder {
         options.sheenGlossinessTint = 1;
 
         // LIT OPTIONS
+        options.litOptions.ambientTint = options.ambientTint;
         options.litOptions.customFragmentShader = stdMat.customFragmentShader;
         options.litOptions.pixelSnap = stdMat.pixelSnap;
 

--- a/src/scene/shader-lib/program-library.js
+++ b/src/scene/shader-lib/program-library.js
@@ -75,9 +75,9 @@ class ProgramLibrary {
         let def = this.definitionsCache.get(key);
         if (!def) {
             let lights;
-            if (options.lights) {
-                lights = options.lights;
-                options.lights = lights.map(function (l) {
+            if (options.litOptions?.lights) {
+                lights = options.litOptions.lights;
+                options.litOptions.lights = lights.map(function (l) {
                     // TODO: refactor this to avoid creating a clone of the light.
                     const lcopy = l.clone ? l.clone() : l;
                     lcopy.key = l.key;
@@ -87,8 +87,8 @@ class ProgramLibrary {
 
             this.storeNewProgram(name, options);
 
-            if (options.lights)
-                options.lights = lights;
+            if (options.litOptions?.lights)
+                options.litOptions.lights = lights;
 
             if (this._precached)
                 Debug.log(`ProgramLibrary#getProgram: Cache miss for shader ${name} key ${key} after shaders precaching`);
@@ -156,6 +156,9 @@ class ProgramLibrary {
             for (const p in options) {
                 if ((options.hasOwnProperty(p) && defaultMat[p] !== options[p]) || p === "pass")
                     opt[p] = options[p];
+            }
+            for (const p in options.litOptions) {
+                opt[p] = options.litOptions[p];
             }
         } else {
             // Other shaders have only dozen params

--- a/src/scene/shader-lib/programs/lit-shader.js
+++ b/src/scene/shader-lib/programs/lit-shader.js
@@ -87,9 +87,9 @@ class LitShader {
 
         this.lighting = (options.lights.length > 0) || options.useDirLightMap || options.clusteredLightingEnabled;
         this.reflections = !!options.reflectionSource;
-        if (!options.useSpecular) options.specularMap = options.glossMap = null;
+        if (!options.useSpecular) options.useSpecularMap = options.useGlossMap = false;
         this.shadowPass = ShaderPass.isShadow(options.pass);
-        this.needsNormal = this.lighting || this.reflections || options.useSpecular || options.ambientSH || options.heightMap || options.enableGGXSpecular ||
+        this.needsNormal = this.lighting || this.reflections || options.useSpecular || options.ambientSH || options.useHeightMap || options.enableGGXSpecular ||
                             (options.clusteredLightingEnabled && !this.shadowPass) || options.useClearCoatNormalMap;
         this.needsSceneColor = options.useDynamicRefraction;
         this.needsScreenSize = options.useDynamicRefraction;
@@ -259,7 +259,7 @@ class LitShader {
                 codeBody += "   vNormalV    = getViewNormal();\n";
             }
 
-            if (options.hasTangents && (options.heightMap || options.normalMap || options.enableGGXSpecular)) {
+            if (options.hasTangents && (options.useHeightMap || options.useNormalMap || options.enableGGXSpecular)) {
                 this.attributes.vertex_tangent = SEMANTIC_TANGENT;
                 code += chunks.tangentBinormalVS;
                 codeBody += "   vTangentW   = getTangent();\n";
@@ -702,13 +702,13 @@ class LitShader {
         code += "\n"; // End of uniform declarations
 
         // TBN
-        const hasTBN = this.needsNormal && (options.normalMap || options.useClearCoatNormalMap || (options.enableGGXSpecular && !options.heightMap));
+        const hasTBN = this.needsNormal && (options.useNormalMap || options.useClearCoatNormalMap || (options.enableGGXSpecular && !options.useHeightMap));
 
         if (hasTBN) {
             if (options.hasTangents) {
                 code += options.fastTbn ? chunks.TBNfastPS : chunks.TBNPS;
             } else {
-                if (device.extStandardDerivatives && (options.normalMap || options.useClearCoatNormalMap)) {
+                if (device.extStandardDerivatives && (options.useNormalMap || options.useClearCoatNormalMap)) {
                     code += chunks.TBNderivativePS.replace(/\$UV/g, this.lightingUv);
                 } else {
                     code += chunks.TBNObjectSpacePS;
@@ -966,7 +966,7 @@ class LitShader {
                 code += "    dVertexNormalW = normalize(vNormalW);\n";
             }
 
-            if ((options.heightMap || options.normalMap) && options.hasTangents) {
+            if ((options.useHeightMap || options.useNormalMap) && options.hasTangents) {
                 if (options.twoSidedLighting) {
                     code += "    dTangentW = gl_FrontFacing ? vTangentW * twoSidedLightingNegScaleFactor : -vTangentW * twoSidedLightingNegScaleFactor;\n";
                     code += "    dBinormalW = gl_FrontFacing ? vBinormalW * twoSidedLightingNegScaleFactor : -vBinormalW * twoSidedLightingNegScaleFactor;\n";

--- a/src/scene/shader-lib/programs/lit-shader.js
+++ b/src/scene/shader-lib/programs/lit-shader.js
@@ -85,7 +85,7 @@ class LitShader {
             this.chunks = shaderChunks;
         }
 
-        this.lighting = (options.lights.length > 0) || !!options.dirLightMap || !!options.clusteredLightingEnabled;
+        this.lighting = (options.lights.length > 0) || options.useDirLightMap || options.clusteredLightingEnabled;
         this.reflections = !!options.reflectionSource;
         if (!options.useSpecular) options.specularMap = options.glossMap = null;
         this.shadowPass = ShaderPass.isShadow(options.pass);
@@ -293,7 +293,7 @@ class LitShader {
         this.varyings = codes[1];
         codeBody = codes[2];
 
-        if (options.vertexColors) {
+        if (options.useVertexColors) {
             this.attributes.vertex_color = SEMANTIC_COLOR;
             codeBody += "   vVertexColor = vertex_color;\n";
         }
@@ -751,7 +751,7 @@ class LitShader {
             }
         }
 
-        const useAo = options.aoMap || options.aoVertexColor;
+        const useAo = options.useAoMap || options.aoVertexColor;
 
         if (useAo) {
             code += chunks.aoDiffuseOccPS;
@@ -867,7 +867,7 @@ class LitShader {
                 code += options.shadingModel === SPECULAR_PHONG ? chunks.lightSpecularPhongPS : (options.enableGGXSpecular ? chunks.lightSpecularAnisoGGXPS : chunks.lightSpecularBlinnPS);
             }
 
-            if (!options.fresnelModel && !this.reflections && !options.diffuseMap) {
+            if (!options.fresnelModel && !this.reflections && !options.useDiffuseMap) {
                 code += "    uniform vec3 material_ambient;\n";
                 code += "#define LIT_OLD_AMBIENT";
                 useOldAmbient = true;
@@ -877,11 +877,11 @@ class LitShader {
         code += chunks.combinePS;
 
         // lightmap support
-        if (options.lightMap || options.lightVertexColor) {
-            code += (options.useSpecular && options.dirLightMap) ? chunks.lightmapDirAddPS : chunks.lightmapAddPS;
+        if (options.useLightMap || options.lightVertexColor) {
+            code += (options.useSpecular && options.useDirLightMap) ? chunks.lightmapDirAddPS : chunks.lightmapAddPS;
         }
 
-        const addAmbient = (!options.lightMap && !options.lightVertexColor) || options.lightMapWithoutAmbient;
+        const addAmbient = (!options.useLightMap && !options.lightVertexColor) || options.lightMapWithoutAmbient;
 
         if (addAmbient) {
             if (options.ambientSource === 'ambientSH') {
@@ -1026,7 +1026,7 @@ class LitShader {
             code += "    occludeDiffuse();\n";
         }
 
-        if (options.lightMap || options.lightVertexColor) {
+        if (options.useLightMap || options.lightVertexColor) {
             code += "    addLightMap();\n";
         }
 

--- a/src/scene/shader-lib/programs/standard.js
+++ b/src/scene/shader-lib/programs/standard.js
@@ -448,7 +448,7 @@ const standard = {
                 if (lightmapDir) {
                     decl.append("vec3 dLightmapDir;");
                 }
-                code.append(this._addMap("light", lightmapChunkPropName, options, litShader.chunks, textureMapping, options.litOptions.lightMapEncoding));
+                code.append(this._addMap("light", lightmapChunkPropName, options, litShader.chunks, textureMapping, options.lightMapEncoding));
                 func.append("getLightMap();");
             }
 

--- a/src/scene/shader-lib/programs/standard.js
+++ b/src/scene/shader-lib/programs/standard.js
@@ -441,8 +441,8 @@ const standard = {
             }
 
             // lightmap
-            if (options.litOptions.light?.enabled || options.light?.vertexColors) {
-                const lightmapDir = (options.litOptions.dirLight?.enabled && options.litOptions.useSpecular);
+            if (options.litOptions.lightMapEnabled || options.lightMapVertexColors) {
+                const lightmapDir = (options.litOptions.dirLightMapEnabled && options.litOptions.useSpecular);
                 const lightmapChunkPropName = lightmapDir ? 'lightmapDirPS' : 'lightmapSinglePS';
                 decl.append("vec3 dLightmap;");
                 if (lightmapDir) {

--- a/src/scene/shader-lib/programs/standard.js
+++ b/src/scene/shader-lib/programs/standard.js
@@ -57,12 +57,16 @@ const standard = {
             key += chunks;
         }
 
-        if (options.litOptions.lights) {
-            const isClustered = options.litOptions.clusteredLightingEnabled;
-            for (let i = 0; i < options.litOptions.lights.length; i++) {
-                const light = options.litOptions.lights[i];
-                if (!isClustered || light._type === LIGHTTYPE_DIRECTIONAL) {
-                    key += light.key;
+        if (options.litOptions) {
+            for (const m in options.litOptions)
+                key += m + options.litOptions[m];
+            if (options.litOptions.lights) {
+                const isClustered = options.litOptions.clusteredLightingEnabled;
+                for (let i = 0; i < options.litOptions.lights.length; i++) {
+                    const light = options.litOptions.lights[i];
+                    if (!isClustered || light._type === LIGHTTYPE_DIRECTIONAL) {
+                        key += light.key;
+                    }
                 }
             }
         }

--- a/src/scene/shader-lib/programs/standard.js
+++ b/src/scene/shader-lib/programs/standard.js
@@ -273,7 +273,7 @@ const standard = {
         litShader.generateVertexShader(useUv, useUnmodifiedUv, mapTransforms);
 
         // handle fragment shader
-        if (options.shadingModel === SPECULAR_PHONG) {
+        if (options.litOptions.shadingModel === SPECULAR_PHONG) {
             options.litOptions.fresnelModel = 0;
             options.litOptions.ambientSH = false;
         } else {
@@ -441,8 +441,8 @@ const standard = {
             }
 
             // lightmap
-            if (options.litOptions.lightMap || options.lightVertexColor) {
-                const lightmapDir = (options.litOptions.dirLightMap && options.litOptions.useSpecular);
+            if (options.litOptions.useLightMap || options.lightVertexColor) {
+                const lightmapDir = (options.litOptions.useDirLightMap && options.litOptions.useSpecular);
                 const lightmapChunkPropName = lightmapDir ? 'lightmapDirPS' : 'lightmapSinglePS';
                 decl.append("vec3 dLightmap;");
                 if (lightmapDir) {

--- a/src/scene/shader-lib/programs/standard.js
+++ b/src/scene/shader-lib/programs/standard.js
@@ -441,8 +441,8 @@ const standard = {
             }
 
             // lightmap
-            if (options.litOptions.useLightMap || options.lightVertexColor) {
-                const lightmapDir = (options.litOptions.useDirLightMap && options.litOptions.useSpecular);
+            if (options.litOptions.light?.enabled || options.light?.vertexColors) {
+                const lightmapDir = (options.litOptions.dirLight?.enabled && options.litOptions.useSpecular);
                 const lightmapChunkPropName = lightmapDir ? 'lightmapDirPS' : 'lightmapSinglePS';
                 decl.append("vec3 dLightmap;");
                 if (lightmapDir) {

--- a/src/scene/shader-lib/programs/standard.js
+++ b/src/scene/shader-lib/programs/standard.js
@@ -57,10 +57,10 @@ const standard = {
             key += chunks;
         }
 
-        if (options.lights) {
-            const isClustered = options.clusteredLightingEnabled;
-            for (let i = 0; i < options.lights.length; i++) {
-                const light = options.lights[i];
+        if (options.litOptions.lights) {
+            const isClustered = options.litOptions.clusteredLightingEnabled;
+            for (let i = 0; i < options.litOptions.lights.length; i++) {
+                const light = options.litOptions.lights[i];
                 if (!isClustered || light._type === LIGHTTYPE_DIRECTIONAL) {
                     key += light.key;
                 }
@@ -84,12 +84,12 @@ const standard = {
     _getUvSourceExpression: function (transformPropName, uVPropName, options) {
         const transformId = options[transformPropName];
         const uvChannel = options[uVPropName];
-        const isMainPass = ShaderPass.isForward(options.pass);
+        const isMainPass = ShaderPass.isForward(options.litOptions.pass);
 
         let expression;
-        if (isMainPass && options.nineSlicedMode === SPRITE_RENDERMODE_SLICED) {
+        if (isMainPass && options.litOptions.nineSlicedMode === SPRITE_RENDERMODE_SLICED) {
             expression = "nineSlicedUv";
-        } else if (isMainPass && options.nineSlicedMode === SPRITE_RENDERMODE_TILED) {
+        } else if (isMainPass && options.litOptions.nineSlicedMode === SPRITE_RENDERMODE_TILED) {
             expression = "nineSlicedUv";
         } else {
             if (transformId === 0) {
@@ -172,7 +172,7 @@ const standard = {
                     // is never decoded).
                     subCode = subCode.replace(/\$DECODE/g, 'passThrough');
                 } else {
-                    subCode = subCode.replace(/\$DECODE/g, ChunkUtils.decodeFunc((!options.gamma && encoding === 'srgb') ? 'linear' : encoding));
+                    subCode = subCode.replace(/\$DECODE/g, ChunkUtils.decodeFunc((!options.litOptions.gamma && encoding === 'srgb') ? 'linear' : encoding));
                 }
 
                 // continue to support $texture2DSAMPLE
@@ -221,7 +221,7 @@ const standard = {
 
     /** @type { Function } */
     createShaderDefinition: function (device, options) {
-        const litShader = new LitShader(device, options);
+        const litShader = new LitShader(device, options.litOptions);
 
         // generate vertex shader
         const useUv = [];
@@ -270,10 +270,10 @@ const standard = {
 
         // handle fragment shader
         if (options.shadingModel === SPECULAR_PHONG) {
-            options.fresnelModel = 0;
-            options.ambientSH = false;
+            options.litOptions.fresnelModel = 0;
+            options.litOptions.ambientSH = false;
         } else {
-            options.fresnelModel = (options.fresnelModel === 0) ? FRESNEL_SCHLICK : options.fresnelModel;
+            options.litOptions.fresnelModel = (options.litOptions.fresnelModel === 0) ? FRESNEL_SCHLICK : options.litOptions.fresnelModel;
         }
 
         const decl = new ChunkBuilder();
@@ -282,13 +282,13 @@ const standard = {
         let lightingUv = "";
 
         // global texture bias for standard textures
-        if (options.nineSlicedMode === SPRITE_RENDERMODE_TILED) {
+        if (options.litOptions.nineSlicedMode === SPRITE_RENDERMODE_TILED) {
             decl.append(`const float textureBias = -1000.0;`);
         } else {
             decl.append(`uniform float textureBias;`);
         }
 
-        if (ShaderPass.isForward(options.pass)) {
+        if (ShaderPass.isForward(options.litOptions.pass)) {
             // parallax
             if (options.heightMap) {
                 // if (!options.normalMap) {
@@ -302,11 +302,11 @@ const standard = {
             }
 
             // opacity
-            if (options.blendType !== BLEND_NONE || options.alphaTest || options.alphaToCoverage) {
+            if (options.litOptions.blendType !== BLEND_NONE || options.litOptions.alphaTest || options.litOptions.alphaToCoverage) {
                 decl.append("float dAlpha;");
                 code.append(this._addMap("opacity", "opacityPS", options, litShader.chunks, textureMapping));
                 func.append("getOpacity();");
-                if (options.alphaTest) {
+                if (options.litOptions.alphaTest) {
                     code.append(litShader.chunks.alphaTestPS);
                     func.append("alphaTest(dAlpha);");
                 }
@@ -320,7 +320,7 @@ const standard = {
                     // TODO: let each normalmap input (normalMap, normalDetailMap, clearCoatNormalMap) independently decide which unpackNormal to use.
                     code.append(options.packedNormal ? litShader.chunks.normalXYPS : litShader.chunks.normalXYZPS);
 
-                    if (!options.hasTangents) {
+                    if (!options.litOptions.hasTangents) {
                         // TODO: generalize to support each normalmap input (normalMap, normalDetailMap, clearCoatNormalMap) independently
                         const baseName = options.normalMap ? "normalMap" : "clearCoatNormalMap";
                         lightingUv = this._getUvSourceExpression(`${baseName}Transform`, `${baseName}Uv`, options);
@@ -352,7 +352,7 @@ const standard = {
             code.append(this._addMap("diffuse", "diffusePS", options, litShader.chunks, textureMapping, options.diffuseEncoding));
             func.append("getAlbedo();");
 
-            if (options.refraction) {
+            if (options.litOptions.useRefraction) {
                 decl.append("float dTransmission;");
                 code.append(this._addMap("refraction", "transmissionPS", options, litShader.chunks, textureMapping));
                 func.append("getRefraction();");
@@ -362,7 +362,7 @@ const standard = {
                 func.append("getThickness();");
             }
 
-            if (options.iridescence) {
+            if (options.litOptions.useIridescence) {
                 decl.append("vec3 dIridescenceFresnel;");
                 decl.append("float dIridescence;");
                 code.append(this._addMap("iridescence", "iridescencePS", options, litShader.chunks, textureMapping));
@@ -374,10 +374,10 @@ const standard = {
             }
 
             // specularity & glossiness
-            if ((litShader.lighting && options.useSpecular) || litShader.reflections) {
+            if ((litShader.lighting && options.litOptions.useSpecular) || litShader.reflections) {
                 decl.append("vec3 dSpecularity;");
                 decl.append("float dGlossiness;");
-                if (options.sheen) {
+                if (options.litOptions.useSheen) {
                     decl.append("vec3 sSpecularity;");
                     code.append(this._addMap("sheen", "sheenPS", options, litShader.chunks, textureMapping, options.sheenEncoding));
                     func.append("getSheen();");
@@ -386,17 +386,17 @@ const standard = {
                     code.append(this._addMap("sheenGlossiness", "sheenGlossPS", options, litShader.chunks, textureMapping));
                     func.append("getSheenGlossiness();");
                 }
-                if (options.useMetalness) {
+                if (options.litOptions.useMetalness) {
                     decl.append("float dMetalness;");
                     code.append(this._addMap("metalness", "metalnessPS", options, litShader.chunks, textureMapping));
                     func.append("getMetalness();");
                 }
-                if (options.useSpecularityFactor) {
+                if (options.litOptions.useSpecularityFactor) {
                     decl.append("float dSpecularityFactor;");
                     code.append(this._addMap("specularityFactor", "specularityFactorPS", options, litShader.chunks, textureMapping));
                     func.append("getSpecularityFactor();");
                 }
-                if (options.useSpecularColor) {
+                if (options.litOptions.useSpecularColor) {
                     code.append(this._addMap("specular", "specularPS", options, litShader.chunks, textureMapping, options.specularEncoding));
                 } else {
                     code.append("void getSpecularity() { dSpecularity = vec3(1); }");
@@ -422,7 +422,7 @@ const standard = {
             func.append("getEmission();");
 
             // clearcoat
-            if (options.clearCoat > 0) {
+            if (options.litOptions.useClearCoat) {
                 decl.append("float ccSpecularity;");
                 decl.append("float ccGlossiness;");
                 decl.append("vec3 ccNormalW;");
@@ -437,14 +437,14 @@ const standard = {
             }
 
             // lightmap
-            if (options.lightMap || options.lightVertexColor) {
-                const lightmapDir = (options.dirLightMap && options.useSpecular);
+            if (options.litOptions.lightMap || options.lightVertexColor) {
+                const lightmapDir = (options.litOptions.dirLightMap && options.litOptions.useSpecular);
                 const lightmapChunkPropName = lightmapDir ? 'lightmapDirPS' : 'lightmapSinglePS';
                 decl.append("vec3 dLightmap;");
                 if (lightmapDir) {
                     decl.append("vec3 dLightmapDir;");
                 }
-                code.append(this._addMap("light", lightmapChunkPropName, options, litShader.chunks, textureMapping, options.lightMapEncoding));
+                code.append(this._addMap("light", lightmapChunkPropName, options, litShader.chunks, textureMapping, options.litOptions.lightMapEncoding));
                 func.append("getLightMap();");
             }
 
@@ -458,7 +458,7 @@ const standard = {
 
         } else {
             // all other passes require only opacity
-            if (options.alphaTest) {
+            if (options.litOptions.alphaTest) {
                 decl.append("float dAlpha;");
                 code.append(this._addMap("opacity", "opacityPS", options, litShader.chunks, textureMapping));
                 code.append(litShader.chunks.alphaTestPS);


### PR DESCRIPTION
### Description

First pass on splitting material options between frontend and backend. In this PR, the same options are passed as both, but this will allow for stripping down the input parameters according to what's needed for frontend and backend.  

### Public API changes
The material onUpdateShader callbacks may not work if the standard material variable being changed has been moved to litOptions, in which case the callback must be adjusted to work with options split. 