### PR TITLE
Fix disabling derivatives not generating vObjectSpaceUpW.

### DIFF
--- a/src/scene/shader-lib/programs/lit-shader.js
+++ b/src/scene/shader-lib/programs/lit-shader.js
@@ -264,7 +264,7 @@ class LitShader {
                 code += chunks.tangentBinormalVS;
                 codeBody += "   vTangentW   = getTangent();\n";
                 codeBody += "   vBinormalW  = getBinormal();\n";
-            } else if (options.enableGGXSpecular) {
+            } else if (options.enableGGXSpecular || !device.extStandardDerivatives) {
                 code += chunks.tangentBinormalVS;
                 codeBody += "   vObjectSpaceUpW  = getObjectSpaceUp();\n";
             }


### PR DESCRIPTION
### Description

Fixes #4772 by generating the vObjectSpaceUpW not only when GGX is enabled but also when we don't use standard derivatives, thus allowing us to calculate the TBN without them. 

