### PR TITLE
Tracing console calls can print out the stack

### DIFF
--- a/src/core/debug.js
+++ b/src/core/debug.js
@@ -131,7 +131,11 @@ class Debug {
      */
     static trace(channel, ...args) {
         if (Tracing.get(channel)) {
-            console.log(`${channel.padEnd(20, ' ')}|`, ...args);
+            console.groupCollapsed(`${channel.padEnd(20, ' ')}|`, ...args);
+            if (Tracing.stack) {
+                console.trace();
+            }
+            console.groupEnd();
         }
     }
 }

--- a/src/core/tracing.js
+++ b/src/core/tracing.js
@@ -13,6 +13,13 @@ class Tracing {
     static _traceChannels = new Set();
 
     /**
+     * Enable call stack logging for trace calls. Defaults to false.
+     *
+     * @type {boolean}
+     */
+    static stack = false;
+
+    /**
      * Enable or disable a trace channel.
      *
      * @param {string} channel - Name of the trace channel. Can be:


### PR DESCRIPTION
**API:** 
    pc.Tracing.stack = true;

result - tracing calls area group, allowing it to expand the line to display a call-stack

![Screenshot 2022-11-01 at 10 48 45](https://user-images.githubusercontent.com/59932779/199224055-8adb626b-1c79-4d3e-881f-f9d0ef03ec88.png)
