### PR TITLE
[Fix] Fix issue with baking clustered lights

### DIFF
--- a/src/framework/lightmapper/bake-light.js
+++ b/src/framework/lightmapper/bake-light.js
@@ -57,6 +57,8 @@ class BakeLight {
 
         // destroy shadow map the light might have
         this.light._destroyShadowMap();
+
+        this.light.beginFrame();
     }
 
     endBake(shadowMapCache) {


### PR DESCRIPTION
Fixes https://github.com/playcanvas/editor/issues/905

the light needs to be prepared for the frame, to correctly handle atlas slot allocation.