### PR TITLE
Add touchenter event, add JSDoc, small refactor

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -3,7 +3,8 @@
         "baseUrl": ".",
         "checkJs": true,
         "module": "es6",
-        "target": "es6"
+        "target": "es6",
+        "strictNullChecks": true
     },
     "include": ["src/**/*"]
 }

--- a/src/platform/input/touch-event.js
+++ b/src/platform/input/touch-event.js
@@ -134,7 +134,7 @@ class TouchEvent {
      *
      * @param {number} id - The identifier of the touch.
      * @param {Touch[]|null} list - An array of touches to search.
-     * @returns {Touch} The {@link Touch} object or null.
+     * @returns {Touch|null} The {@link Touch} object or null.
      */
     getTouchById(id, list) {
         for (let i = 0, l = list.length; i < l; i++) {


### PR DESCRIPTION
Fixes #4755

Firing `mousemove` even when the mouse is outside the `ElementComponent` is actually correct behaviour and other elements depend on this, e.g. `ScrollViewComponent`. So the first misconception in the issue is to imply "mouse must be over element"  based on "mousemove". The events that actually give you this information are `mouseenter`/`mouseleave`.

That works just fine, but when I tested this on iPhone, I realized there isn't even a `touchenter` event yet, so this PR is adding that for the same abilities across plattforms.

I saw @jpauloruschel working with this and your last PR also changed the `mousemove` behaviour: https://github.com/playcanvas/engine/commit/ff00ed58a50f8f5633c39ae48842805183ac3244

IMO the current behaviour is exactly how it should be, otherwise any developer who can only rely on `mousemove` events trying to implement e.g. a custom scroll element simply has no events to base the scrolling behaviour on.

Maybe I am completely wrong, any thoughts/feedback?

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
