### PR TITLE
Fix appearance of asset-viewer example

### DIFF
--- a/examples/src/examples/graphics/asset-viewer.tsx
+++ b/examples/src/examples/graphics/asset-viewer.tsx
@@ -186,7 +186,7 @@ class AssetViewerExample {
                 normalOffsetBias: 0.05,
                 shadowResolution: 2048
             });
-            directionalLight.setEulerAngles(45, 35, 0);
+            directionalLight.setEulerAngles(45, 180, 0);
             app.root.addChild(directionalLight);
 
 


### PR DESCRIPTION
### Description

With some changes made recently, a bug was fixed which resulted in the refraction factor sometimes not getting generated for volumetric refractions. With this bugfix, the mosquito in amber looked very opaque in the asset-viewer example due to diffuse light having a bigger impact on the final rendering result. 

This PR rotates the directional light to better show the amber is transparent:

Before:
![image](https://user-images.githubusercontent.com/107400752/200287374-359269e0-d441-49db-9257-38c2a63ac2c0.png)

After:
![image](https://user-images.githubusercontent.com/107400752/200287130-98f2eb43-279e-47ec-bb68-292b1048e42c.png)