### PR TITLE
Make 5x5 shadows a little more consistent

### DIFF
--- a/src/scene/shader-lib/chunks/lit/frag/shadowStandardGL2.js
+++ b/src/scene/shader-lib/chunks/lit/frag/shadowStandardGL2.js
@@ -53,7 +53,6 @@ float _getShadowPCF5x5(sampler2DShadow shadowMap, vec3 shadowParams) {
 
     sum *= 1.0f / 144.0;
 
-    sum = gammaCorrectInput(sum); // gives softer gradient
     sum = saturate(sum);
 
     return sum;


### PR DESCRIPTION
This PR removes a "softer gradient" term in the PCF 5x5 shadow calculation. This gradient term resulted in 5x5 shadows looking different to 3x3, when 5x5 should just be a higher quality compared to 3x3.

See comparison below:

<img width="600" alt="pcf-3x3" src="https://user-images.githubusercontent.com/11276292/200311709-88bd071d-a706-4c63-85f9-fb3fe79f24e5.png">
<img width="600" alt="pcf-5x5" src="https://user-images.githubusercontent.com/11276292/200311714-fb3be7b1-ed8e-4d77-ab67-db26aef703fb.png">
<img width="600" alt="pcf-5x5-gradient" src="https://user-images.githubusercontent.com/11276292/200311721-89957225-b4e4-4e08-8961-e623e7275c03.png">
