### PR TITLE
Make `AppBase#_batcher` member private

### DIFF
--- a/src/framework/app-base.js
+++ b/src/framework/app-base.js
@@ -460,6 +460,7 @@ class AppBase extends EventHandler {
          * The application's batch manager.
          *
          * @type {import('../scene/batching/batch-manager.js').BatchManager}
+         * @private
          */
         this._batcher = null;
         if (appOptions.batchManager) {


### PR DESCRIPTION
Currently, this property of `AppBase` is surfaced in the API reference. `AppBase#batcher` is what should be used.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
