### PR TITLE
Improve JSDocs for `RigidBodyComponent`

### DIFF
--- a/src/framework/components/component.js
+++ b/src/framework/components/component.js
@@ -12,7 +12,6 @@ class Component extends EventHandler {
      * The ComponentSystem used to create this Component.
      *
      * @type {import('./system.js').ComponentSystem}
-     * @ignore
      */
     system;
 
@@ -20,7 +19,6 @@ class Component extends EventHandler {
      * The Entity that this Component is attached to.
      *
      * @type {import('../entity.js').Entity}
-     * @ignore
      */
     entity;
 
@@ -49,6 +47,7 @@ class Component extends EventHandler {
         this.on('set_enabled', this.onSetEnabled, this);
     }
 
+    /** @ignore */
     static _buildAccessors(obj, schema) {
         // Create getter/setter pairs for each property defined in the schema
         schema.forEach(function (descriptor) {
@@ -73,10 +72,12 @@ class Component extends EventHandler {
         obj._accessorsBuilt = true;
     }
 
+    /** @ignore */
     buildAccessors(schema) {
         Component._buildAccessors(this, schema);
     }
 
+    /** @ignore */
     onSetEnabled(name, oldValue, newValue) {
         if (oldValue !== newValue) {
             if (this.entity.enabled) {
@@ -89,12 +90,15 @@ class Component extends EventHandler {
         }
     }
 
+    /** @ignore */
     onEnable() {
     }
 
+    /** @ignore */
     onDisable() {
     }
 
+    /** @ignore */
     onPostStateChange() {
     }
 

--- a/src/framework/components/rigid-body/component.js
+++ b/src/framework/components/rigid-body/component.js
@@ -1,5 +1,3 @@
-import { Debug } from '../../../core/debug.js';
-
 import { Quat } from '../../../core/math/quat.js';
 import { Vec3 } from '../../../core/math/vec3.js';
 
@@ -14,7 +12,7 @@ import { Component } from '../component.js';
 
 // Shared math variable to avoid excessive allocation
 let ammoTransform;
-let ammoVec1, ammoVec2, ammoQuat, ammoOrigin;
+let ammoVec1, ammoVec2, ammoQuat;
 
 /**
  * The rigidbody component, when combined with a {@link CollisionComponent}, allows your entities
@@ -55,32 +53,46 @@ let ammoVec1, ammoVec2, ammoQuat, ammoOrigin;
 class RigidBodyComponent extends Component {
     /** @private */
     _angularDamping = 0;
+
     /** @private */
     _angularFactor = new Vec3(1, 1, 1);
+
     /** @private */
     _angularVelocity = new Vec3();
+
     /** @private */
     _body = null;
+
     /** @private */
     _friction = 0.5;
+
     /** @private */
     _group = BODYGROUP_STATIC;
+
     /** @private */
     _linearDamping = 0;
+
     /** @private */
     _linearFactor = new Vec3(1, 1, 1);
+
     /** @private */
     _linearVelocity = new Vec3();
+
     /** @private */
     _mask = BODYMASK_NOT_STATIC;
+
     /** @private */
     _mass = 1;
+
     /** @private */
     _restitution = 0;
+
     /** @private */
     _rollingFriction = 0;
+
     /** @private */
     _simulationEnabled = false;
+
     /** @private */
     _type = BODYTYPE_STATIC;
 
@@ -138,7 +150,6 @@ class RigidBodyComponent extends Component {
             ammoVec1 = new Ammo.btVector3();
             ammoVec2 = new Ammo.btVector3();
             ammoQuat = new Ammo.btQuaternion();
-            ammoOrigin = new Ammo.btVector3(0, 0, 0);
         }
     }
 
@@ -750,7 +761,7 @@ class RigidBodyComponent extends Component {
      * // z-axis of the entity's local-space.
      * entity.rigidbody.applyImpulse(0, 10, 0, 0, 0, 1);
      */
-    applyImpulse(x, y, z) {
+    applyImpulse(x, y, z, px, py, pz) {
         const body = this._body;
         if (body) {
             body.activate();


### PR DESCRIPTION
Improves JSDocs for `RigidBodyComponent`. This, in turn, improves the TypeScript declarations. For example:

```
teleport(...args: any[]): void;
```

is now:

```
teleport(x: Vec3 | number, y?: Quat | Vec3 | number, z?: number, rx?: number, ry?: number, rz?: number): void;
```

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
