### PR TITLE
Add asset type textureatlas

### DIFF
--- a/src/framework/asset/asset.js
+++ b/src/framework/asset/asset.js
@@ -55,7 +55,7 @@ class Asset extends EventHandler {
      * retrieve the asset.
      * @param {string} type - Type of asset. One of ["animation", "audio", "binary", "container",
      * "cubemap", "css", "font", "json", "html", "material", "model", "script", "shader", "sprite",
-     * "template", text", "texture"]
+     * "template", text", "texture", "textureatlas"]
      * @param {object} [file] - Details about the file the asset is made from. At the least must
      * contain the 'url' field. For assets that don't contain file data use null.
      * @param {string} [file.url] - The URL of the resource file that contains the asset data.
@@ -94,9 +94,9 @@ class Asset extends EventHandler {
         /**
          * The type of the asset. One of ["animation", "audio", "binary", "container", "cubemap",
          * "css", "font", "json", "html", "material", "model", "render", "script", "shader", "sprite",
-         * "template", "text", "texture"]
+         * "template", "text", "texture", "textureatlas"]
          *
-         * @type {("animation"|"audio"|"binary"|"container"|"cubemap"|"css"|"font"|"json"|"html"|"material"|"model"|"render"|"script"|"shader"|"sprite"|"template"|"text"|"texture")}
+         * @type {("animation"|"audio"|"binary"|"container"|"cubemap"|"css"|"font"|"json"|"html"|"material"|"model"|"render"|"script"|"shader"|"sprite"|"template"|"text"|"texture"|"textureatlas")}
          */
         this.type = type;
 

--- a/src/framework/asset/constants.js
+++ b/src/framework/asset/constants.js
@@ -77,10 +77,9 @@ export const ASSET_TEXT = 'text';
 export const ASSET_TEXTURE = 'texture';
 
 /**
- * @constant
+ * Asset type name for textureatlas.
+ *
  * @type {string}
- * @name ASSET_TEXTUREATLAS
- * @description Asset type name for textureatlas.
  */
 export const ASSET_TEXTUREATLAS = 'textureatlas';
 

--- a/src/framework/asset/constants.js
+++ b/src/framework/asset/constants.js
@@ -77,6 +77,14 @@ export const ASSET_TEXT = 'text';
 export const ASSET_TEXTURE = 'texture';
 
 /**
+ * @constant
+ * @type {string}
+ * @name ASSET_TEXTUREATLAS
+ * @description Asset type name for textureatlas.
+ */
+export const ASSET_TEXTUREATLAS = 'textureatlas';
+
+/**
  * Asset type name for cubemap.
  *
  * @type {string}


### PR DESCRIPTION
I added the missing string "textureatlas" to the definition of the asset type property.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
