### PR TITLE
ElementDragHelper#_toggleDragListeners: fix wrong `this` type

### DIFF
--- a/src/framework/components/element/element-drag-helper.js
+++ b/src/framework/components/element/element-drag-helper.js
@@ -85,7 +85,7 @@ class ElementDragHelper extends EventHandler {
      * @param {'on'|'off'} onOrOff - Either 'on' or 'off'.
      * @ignore
      */
-     _toggleDragListeners(onOrOff) {
+    _toggleDragListeners(onOrOff) {
         const isOn = onOrOff === 'on';
 
         // Prevent multiple listeners

--- a/src/framework/components/element/element-drag-helper.js
+++ b/src/framework/components/element/element-drag-helper.js
@@ -83,7 +83,7 @@ class ElementDragHelper extends EventHandler {
 
     /**
      * @param {'on'|'off'} onOrOff - Either 'on' or 'off'.
-     * @ignore
+     * @private
      */
     _toggleDragListeners(onOrOff) {
         const isOn = onOrOff === 'on';

--- a/src/framework/components/element/element-drag-helper.js
+++ b/src/framework/components/element/element-drag-helper.js
@@ -81,7 +81,11 @@ class ElementDragHelper extends EventHandler {
         this._element[onOrOff]('touchstart', this._onMouseDownOrTouchStart, this);
     }
 
-    _toggleDragListeners(onOrOff) {
+    /**
+     * @param {'on'|'off'} onOrOff - Either 'on' or 'off'.
+     * @ignore
+     */
+     _toggleDragListeners(onOrOff) {
         const isOn = onOrOff === 'on';
 
         // Prevent multiple listeners
@@ -89,21 +93,17 @@ class ElementDragHelper extends EventHandler {
             return;
         }
 
-        if (!this._handleMouseUpOrTouchEnd) {
-            this._handleMouseUpOrTouchEnd = this._onMouseUpOrTouchEnd.bind(this);
-        }
-
         // mouse events, if mouse is available
         if (this._app.mouse) {
             this._element[onOrOff]('mousemove', this._onMove, this);
-            this._element[onOrOff]('mouseup', this._handleMouseUpOrTouchEnd, false);
+            this._element[onOrOff]('mouseup', this._onMouseUpOrTouchEnd, this);
         }
 
         // touch events, if touch is available
         if (platform.touch) {
             this._element[onOrOff]('touchmove', this._onMove, this);
-            this._element[onOrOff]('touchend', this._handleMouseUpOrTouchEnd, this);
-            this._element[onOrOff]('touchcancel', this._handleMouseUpOrTouchEnd, this);
+            this._element[onOrOff]('touchend', this._onMouseUpOrTouchEnd, this);
+            this._element[onOrOff]('touchcancel', this._onMouseUpOrTouchEnd, this);
         }
 
         this._hasDragListeners = isOn;


### PR DESCRIPTION
So `this._element[onOrOff]` maps to either the on/off-method and the third argument can only be an optional scope. But the current code passes `false`, which basically means the scope of `this._element`. However, it is expecting `this`, so I assume this is the reason someone introduced the workaround:

```js
if (!this._handleMouseUpOrTouchEnd) {
    this._handleMouseUpOrTouchEnd = this._onMouseUpOrTouchEnd.bind(this);
}
```

Which works, but it's unidiomatic/cumbersome if one had just put in the right scope in the first place.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
