### PR TITLE
[Breaking] AnimController time in state fix

### DIFF
--- a/src/framework/anim/controller/anim-controller.js
+++ b/src/framework/anim/controller/anim-controller.js
@@ -516,7 +516,7 @@ class AnimController {
         let animation;
         let clip;
         this._timeInStateBefore = this._timeInState;
-        this._timeInState += dt;
+        this._timeInState += dt * this.activeState.speed;
 
         // transition between states if a transition is available from the active state
         const transition = this._findTransition(this._activeStateName);


### PR DESCRIPTION
The AnimController class doesn't factor in the speed of the current state when tracking the total time that state has been active. This means transitions with an exit time parameter will not trigger as designed (based on the normalised duration of the active state) unless that source state has a speed of 1.

This PR addresses this bug, but in doing so will change the behaviour of all transition's that use an exit time to determine when to move from a state with a modified speed. It also affects the values returned by the AnimComponentLayer#activeStateCurrentTime and AnimComponentLayer#activeStateProgress properties. When the active state has a modified speed value, these functions now return values which account for that speed.

Fixes #3837

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
