### PR TITLE
Expose buildHitCorners function in ElementInput 

### DIFF
--- a/src/framework/input/element-input.js
+++ b/src/framework/input/element-input.js
@@ -987,96 +987,6 @@ class ElementInput {
         return result;
     }
 
-    // In most cases the corners used for hit testing will just be the element's
-    // screen corners. However, in cases where the element has additional hit
-    // padding specified, we need to expand the screenCorners to incorporate the
-    // padding.
-    _buildHitCorners(element, screenOrWorldCorners, scaleX, scaleY, scaleZ) {
-        let hitCorners = screenOrWorldCorners;
-        const button = element.entity && element.entity.button;
-
-        if (button) {
-            const hitPadding = element.entity.button.hitPadding || ZERO_VEC4;
-
-            _paddingTop.copy(element.entity.up);
-            _paddingBottom.copy(_paddingTop).mulScalar(-1);
-            _paddingRight.copy(element.entity.right);
-            _paddingLeft.copy(_paddingRight).mulScalar(-1);
-
-            _paddingTop.mulScalar(hitPadding.w * scaleY);
-            _paddingBottom.mulScalar(hitPadding.y * scaleY);
-            _paddingRight.mulScalar(hitPadding.z * scaleX);
-            _paddingLeft.mulScalar(hitPadding.x * scaleX);
-
-            _cornerBottomLeft.copy(hitCorners[0]).add(_paddingBottom).add(_paddingLeft);
-            _cornerBottomRight.copy(hitCorners[1]).add(_paddingBottom).add(_paddingRight);
-            _cornerTopRight.copy(hitCorners[2]).add(_paddingTop).add(_paddingRight);
-            _cornerTopLeft.copy(hitCorners[3]).add(_paddingTop).add(_paddingLeft);
-
-            hitCorners = [_cornerBottomLeft, _cornerBottomRight, _cornerTopRight, _cornerTopLeft];
-        }
-
-        // make sure the corners are in the right order [bl, br, tr, tl]
-        // for x and y: simply invert what is considered "left/right" and "top/bottom"
-        if (scaleX < 0) {
-            const left = hitCorners[2].x;
-            const right = hitCorners[0].x;
-            hitCorners[0].x = left;
-            hitCorners[1].x = right;
-            hitCorners[2].x = right;
-            hitCorners[3].x = left;
-        }
-        if (scaleY < 0) {
-            const bottom = hitCorners[2].y;
-            const top = hitCorners[0].y;
-            hitCorners[0].y = bottom;
-            hitCorners[1].y = bottom;
-            hitCorners[2].y = top;
-            hitCorners[3].y = top;
-        }
-        // if z is inverted, entire element is inverted, so flip it around by swapping corner points 2 and 0
-        if (scaleZ < 0) {
-            const x = hitCorners[2].x;
-            const y = hitCorners[2].y;
-            const z = hitCorners[2].z;
-
-            hitCorners[2].x = hitCorners[0].x;
-            hitCorners[2].y = hitCorners[0].y;
-            hitCorners[2].z = hitCorners[0].z;
-            hitCorners[0].x = x;
-            hitCorners[0].y = y;
-            hitCorners[0].z = z;
-        }
-
-        return hitCorners;
-    }
-
-    _calculateScaleToScreen(element) {
-        let current = element.entity;
-        const screenScale = element.screen.screen.scale;
-
-        _accumulatedScale.set(screenScale, screenScale, screenScale);
-
-        while (current && !current.screen) {
-            _accumulatedScale.mul(current.getLocalScale());
-            current = current.parent;
-        }
-
-        return _accumulatedScale;
-    }
-
-    _calculateScaleToWorld(element) {
-        let current = element.entity;
-        _accumulatedScale.set(1, 1, 1);
-
-        while (current) {
-            _accumulatedScale.mul(current.getLocalScale());
-            current = current.parent;
-        }
-
-        return _accumulatedScale;
-    }
-
     _calculateRayScreen(x, y, camera, ray) {
         const sw = this.app.graphicsDevice.width;
         const sh = this.app.graphicsDevice.height;
@@ -1157,14 +1067,104 @@ class ElementInput {
 
         let scale;
         if (screen) {
-            scale = this._calculateScaleToScreen(element);
+            scale = ElementInput.calculateScaleToScreen(element);
         } else {
-            scale = this._calculateScaleToWorld(element);
+            scale = ElementInput.calculateScaleToWorld(element);
         }
 
-        const corners = this._buildHitCorners(element, screen ? element.screenCorners : element.worldCorners, scale.x, scale.y, scale.z);
+        const corners = ElementInput.buildHitCorners(element, screen ? element.screenCorners : element.worldCorners, scale.x, scale.y, scale.z);
 
         return intersectLineQuad(ray.origin, ray.end, corners);
+    }
+
+    // In most cases the corners used for hit testing will just be the element's
+    // screen corners. However, in cases where the element has additional hit
+    // padding specified, we need to expand the screenCorners to incorporate the
+    // padding.
+    static buildHitCorners(element, screenOrWorldCorners, scaleX, scaleY, scaleZ) {
+        let hitCorners = screenOrWorldCorners;
+        const button = element.entity && element.entity.button;
+
+        if (button) {
+            const hitPadding = element.entity.button.hitPadding || ZERO_VEC4;
+
+            _paddingTop.copy(element.entity.up);
+            _paddingBottom.copy(_paddingTop).mulScalar(-1);
+            _paddingRight.copy(element.entity.right);
+            _paddingLeft.copy(_paddingRight).mulScalar(-1);
+
+            _paddingTop.mulScalar(hitPadding.w * scaleY);
+            _paddingBottom.mulScalar(hitPadding.y * scaleY);
+            _paddingRight.mulScalar(hitPadding.z * scaleX);
+            _paddingLeft.mulScalar(hitPadding.x * scaleX);
+
+            _cornerBottomLeft.copy(hitCorners[0]).add(_paddingBottom).add(_paddingLeft);
+            _cornerBottomRight.copy(hitCorners[1]).add(_paddingBottom).add(_paddingRight);
+            _cornerTopRight.copy(hitCorners[2]).add(_paddingTop).add(_paddingRight);
+            _cornerTopLeft.copy(hitCorners[3]).add(_paddingTop).add(_paddingLeft);
+
+            hitCorners = [_cornerBottomLeft, _cornerBottomRight, _cornerTopRight, _cornerTopLeft];
+        }
+
+        // make sure the corners are in the right order [bl, br, tr, tl]
+        // for x and y: simply invert what is considered "left/right" and "top/bottom"
+        if (scaleX < 0) {
+            const left = hitCorners[2].x;
+            const right = hitCorners[0].x;
+            hitCorners[0].x = left;
+            hitCorners[1].x = right;
+            hitCorners[2].x = right;
+            hitCorners[3].x = left;
+        }
+        if (scaleY < 0) {
+            const bottom = hitCorners[2].y;
+            const top = hitCorners[0].y;
+            hitCorners[0].y = bottom;
+            hitCorners[1].y = bottom;
+            hitCorners[2].y = top;
+            hitCorners[3].y = top;
+        }
+        // if z is inverted, entire element is inverted, so flip it around by swapping corner points 2 and 0
+        if (scaleZ < 0) {
+            const x = hitCorners[2].x;
+            const y = hitCorners[2].y;
+            const z = hitCorners[2].z;
+
+            hitCorners[2].x = hitCorners[0].x;
+            hitCorners[2].y = hitCorners[0].y;
+            hitCorners[2].z = hitCorners[0].z;
+            hitCorners[0].x = x;
+            hitCorners[0].y = y;
+            hitCorners[0].z = z;
+        }
+
+        return hitCorners;
+    }
+
+    static calculateScaleToScreen(element) {
+        let current = element.entity;
+        const screenScale = element.screen.screen.scale;
+
+        _accumulatedScale.set(screenScale, screenScale, screenScale);
+
+        while (current && !current.screen) {
+            _accumulatedScale.mul(current.getLocalScale());
+            current = current.parent;
+        }
+
+        return _accumulatedScale;
+    }
+
+    static calculateScaleToWorld(element) {
+        let current = element.entity;
+        _accumulatedScale.set(1, 1, 1);
+
+        while (current) {
+            _accumulatedScale.mul(current.getLocalScale());
+            current = current.parent;
+        }
+
+        return _accumulatedScale;
     }
 }
 

--- a/src/framework/input/element-input.js
+++ b/src/framework/input/element-input.js
@@ -1072,7 +1072,7 @@ class ElementInput {
             scale = ElementInput.calculateScaleToWorld(element);
         }
 
-        const corners = ElementInput.buildHitCorners(element, screen ? element.screenCorners : element.worldCorners, scale.x, scale.y, scale.z);
+        const corners = ElementInput.buildHitCorners(element, screen ? element.screenCorners : element.worldCorners, scale);
 
         return intersectLineQuad(ray.origin, ray.end, corners);
     }
@@ -1081,7 +1081,7 @@ class ElementInput {
     // screen corners. However, in cases where the element has additional hit
     // padding specified, we need to expand the screenCorners to incorporate the
     // padding.
-    static buildHitCorners(element, screenOrWorldCorners, scaleX, scaleY, scaleZ) {
+    static buildHitCorners(element, screenOrWorldCorners, scale) {
         let hitCorners = screenOrWorldCorners;
         const button = element.entity && element.entity.button;
 
@@ -1093,10 +1093,10 @@ class ElementInput {
             _paddingRight.copy(element.entity.right);
             _paddingLeft.copy(_paddingRight).mulScalar(-1);
 
-            _paddingTop.mulScalar(hitPadding.w * scaleY);
-            _paddingBottom.mulScalar(hitPadding.y * scaleY);
-            _paddingRight.mulScalar(hitPadding.z * scaleX);
-            _paddingLeft.mulScalar(hitPadding.x * scaleX);
+            _paddingTop.mulScalar(hitPadding.w * scale.y);
+            _paddingBottom.mulScalar(hitPadding.y * scale.y);
+            _paddingRight.mulScalar(hitPadding.z * scale.x);
+            _paddingLeft.mulScalar(hitPadding.x * scale.x);
 
             _cornerBottomLeft.copy(hitCorners[0]).add(_paddingBottom).add(_paddingLeft);
             _cornerBottomRight.copy(hitCorners[1]).add(_paddingBottom).add(_paddingRight);
@@ -1108,7 +1108,7 @@ class ElementInput {
 
         // make sure the corners are in the right order [bl, br, tr, tl]
         // for x and y: simply invert what is considered "left/right" and "top/bottom"
-        if (scaleX < 0) {
+        if (scale.x < 0) {
             const left = hitCorners[2].x;
             const right = hitCorners[0].x;
             hitCorners[0].x = left;
@@ -1116,7 +1116,7 @@ class ElementInput {
             hitCorners[2].x = right;
             hitCorners[3].x = left;
         }
-        if (scaleY < 0) {
+        if (scale.y < 0) {
             const bottom = hitCorners[2].y;
             const top = hitCorners[0].y;
             hitCorners[0].y = bottom;
@@ -1125,7 +1125,7 @@ class ElementInput {
             hitCorners[3].y = top;
         }
         // if z is inverted, entire element is inverted, so flip it around by swapping corner points 2 and 0
-        if (scaleZ < 0) {
+        if (scale.z < 0) {
             const x = hitCorners[2].x;
             const y = hitCorners[2].y;
             const z = hitCorners[2].z;

--- a/src/framework/input/element-input.js
+++ b/src/framework/input/element-input.js
@@ -1081,6 +1081,7 @@ class ElementInput {
     // screen corners. However, in cases where the element has additional hit
     // padding specified, we need to expand the screenCorners to incorporate the
     // padding.
+    // NOTE: Used by Editor for visualization in the viewport
     static buildHitCorners(element, screenOrWorldCorners, scale) {
         let hitCorners = screenOrWorldCorners;
         const button = element.entity && element.entity.button;
@@ -1141,6 +1142,7 @@ class ElementInput {
         return hitCorners;
     }
 
+    // NOTE: Used by Editor for visualization in the viewport
     static calculateScaleToScreen(element) {
         let current = element.entity;
         const screenScale = element.screen.screen.scale;
@@ -1155,6 +1157,7 @@ class ElementInput {
         return _accumulatedScale;
     }
 
+    // NOTE: Used by Editor for visualization in the viewport
     static calculateScaleToWorld(element) {
         let current = element.entity;
         _accumulatedScale.set(1, 1, 1);


### PR DESCRIPTION
Related to https://github.com/playcanvas/editor/issues/896 where I would like visualise the hit area in the Editor like so:

<img width="470" alt="image" src="https://user-images.githubusercontent.com/16639049/202207279-306854f3-1464-4694-83b9-aa2078fbe330.png">

Not sure how to go about this. All the math used to workout the button hit area is in ElementInput.

For testing purposes, I've just made them static so I can access them in the Editor as private API

```
// Add the padding to the existing world corners
// We are always in world space in the Editor
const elementScale = pc.ElementInput.calculateScaleToWorld(entity.element)
hitCorners = pc.ElementInput.buildHitCorners(entity.element, hitCorners, elementScale.x, elementScale.y, elementScale.z);

renderLineCorners[0].copy(hitCorners[0]);
renderLineCorners[1].copy(hitCorners[1]);
renderLineCorners[2].copy(hitCorners[1]);
renderLineCorners[3].copy(hitCorners[2]);
renderLineCorners[4].copy(hitCorners[2]);
renderLineCorners[5].copy(hitCorners[3]);
renderLineCorners[6].copy(hitCorners[3]);
renderLineCorners[7].copy(hitCorners[0]);

app.renderLines(renderLineCorners, cornerColor, immediateRenderOptions);
```

This works of course but just feels wrong to have this as the standard.

So I'm think on doing:
1. Leaving it as is for minimal change to the engine
2. Making this public API and/or moving these to some utils namespace and making it public API
3. Making a separate, public function for this in ButtonComponent that gets the worldHitCorners

I'm leaning towards 3 but could use some input

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
