### PR TITLE
Fix cross origin docs

### DIFF
--- a/src/framework/asset/asset.js
+++ b/src/framework/asset/asset.js
@@ -72,8 +72,8 @@ class Asset extends EventHandler {
      * materials).
      * @param {object} [options] - The asset handler options. For container options see
      * {@link ContainerHandler}.
-     * @param {boolean} [options.crossOrigin] - For use with texture resources. For
-     * browser-supported image formats only, enable cross origin.
+     * @param {string} [options.crossOrigin] - For use with browser-supported texture resources
+     * only, override the default cross origin.
      * @example
      * var asset = new pc.Asset("a texture", "texture", {
      *     url: "http://example.com/my/assets/here/texture.png"

--- a/src/framework/asset/asset.js
+++ b/src/framework/asset/asset.js
@@ -72,7 +72,7 @@ class Asset extends EventHandler {
      * materials).
      * @param {object} [options] - The asset handler options. For container options see
      * {@link ContainerHandler}.
-     * @param {string} [options.crossOrigin] - For use with browser-supported texture resources
+     * @param {string|null} [options.crossOrigin] - For use with browser-supported texture resources
      * only, override the default cross origin.
      * @example
      * var asset = new pc.Asset("a texture", "texture", {


### PR DESCRIPTION
The cross origin specifier for texture assets should be a string not a boolean as the value is used directly (see https://github.com/playcanvas/engine/blob/main/src/framework/parsers/texture/img.js#L51).