### PR TITLE
[Fix] Shadow renderer does not use nearClip of 0

### DIFF
--- a/src/scene/renderer/shadow-renderer.js
+++ b/src/scene/renderer/shadow-renderer.js
@@ -352,7 +352,7 @@ class ShadowRenderer {
             // look at the center from far away to include all casters during culling
             shadowCamNode.setPosition(center);
             shadowCamNode.translateLocal(0, 0, 1000000);
-            shadowCam.nearClip = 0;
+            shadowCam.nearClip = 0.01;
             shadowCam.farClip = 2000000;
             shadowCam.orthoHeight = radius;
 


### PR DESCRIPTION
Fixes: https://github.com/playcanvas/engine/issues/4858

- Shadow renderer uses ortho camera for shadow projection, for which the nearClip of 0 works fine. But Camera class itself evaluates a perspective projection for skydome (not used in this case), which cannot use clip plane of 0, causing NaN results. Those values are not used at all, but avoiding them anyways.