### PR TITLE
Fix packSamples calculating out-of-bounds

### DIFF
--- a/src/scene/graphics/reproject-texture.js
+++ b/src/scene/graphics/reproject-texture.js
@@ -68,11 +68,11 @@ const packSamples = (samples) => {
 
     // normalize float data and pack into rgba8
     let off = 0;
-    for (let i = 0; i < numSamples; ++i) {
-        packFloat32ToRGBA8(samples[i * 4 + 0] * 0.5 + 0.5, data, off + 0);
-        packFloat32ToRGBA8(samples[i * 4 + 1] * 0.5 + 0.5, data, off + 4);
-        packFloat32ToRGBA8(samples[i * 4 + 2] * 0.5 + 0.5, data, off + 8);
-        packFloat32ToRGBA8(samples[i * 4 + 3] / 8, data, off + 12);
+    for (let i = 0; i < numSamples; i += 4) {
+        packFloat32ToRGBA8(samples[i + 0] * 0.5 + 0.5, data, off + 0);
+        packFloat32ToRGBA8(samples[i + 1] * 0.5 + 0.5, data, off + 4);
+        packFloat32ToRGBA8(samples[i + 2] * 0.5 + 0.5, data, off + 8);
+        packFloat32ToRGBA8(samples[i + 3] / 8, data, off + 12);
         off += 16;
     }
 


### PR DESCRIPTION
Fixes #4860

Hi @slimbuck, you suggested `i < numSamples / 4` and then keep the `* 4`, but getting rid of all these divisions/multiplications via a simple `+` feels a bit too tempting, are you okay rewriting the for-loop like this?

To make sure the functionality didn't change, I wrote a little test (requires src/index.js changes tho to export `packSamples`):

```js
const { data } = pc.packSamples([
    0.1, 0.2, 0.3, 0.4, // row 1
    0.5, 0.6, 0.7, 0.8,
    0.1, 0.2, 0.3, 0.4, // same row 1 for control
]);
console.table([
    [...data.slice( 0, 16)],
    [...data.slice(16, 32)],
    [...data.slice(32, 48)],
]);
data;
```

Output for with and without PR is the same:

![image](https://user-images.githubusercontent.com/5236548/202695845-9d094ed2-7341-45f2-bb47-dbfac7613897.png)

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
