### PR TITLE
Clustered lighting uses texFetch instruction on WebGL2 to read data textures

### DIFF
--- a/src/core/preprocessor.js
+++ b/src/core/preprocessor.js
@@ -10,7 +10,7 @@ const KEYWORD = /[ \t]*#(ifn?def|if|endif|else|elif|define|undef|extension)/g;
 const DEFINE = /define[ \t]+([^\n]+)\r?(?:\n|$)/g;
 
 // #extension IDENTIFIER : enabled
-const EXTENSION = /extension[ \t]+([\w-]+)[ \t]*:[ \t]*enable/g;
+const EXTENSION = /extension[ \t]+([\w-]+)[ \t]*:[ \t]*(enable|require)/g;
 
 // #undef EXPRESSION
 const UNDEF = /undef[ \t]+([^\n]+)\r?(?:\n|$)/g;

--- a/src/platform/graphics/shader-chunks/frag/webgpu.js
+++ b/src/platform/graphics/shader-chunks/frag/webgpu.js
@@ -1,5 +1,8 @@
 export default /* glsl */`
 
+// texelFetch support and others
+#extension GL_EXT_samplerless_texture_functions : require
+
 layout(location = 0) out highp vec4 pc_fragColor;
 #define gl_FragColor pc_fragColor
 

--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -986,6 +986,9 @@ class WebglGraphicsDevice extends GraphicsDevice {
         // Don't allow area lights on old android devices, they often fail to compile the shader, run it incorrectly or are very slow.
         this.supportsAreaLights = this.webgl2 || !platform.android;
 
+        // supports texture fetch instruction
+        this.supportsTextureFetch = this.webgl2;
+
         // Also do not allow them when we only have small number of texture units
         if (this.maxTextures <= 8) {
             this.supportsAreaLights = false;

--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -79,6 +79,7 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
         this.supportsImageBitmap = true;
         this.extStandardDerivatives = true;
         this.areaLightLutFormat = PIXELFORMAT_RGBA32F;
+        this.supportsTextureFetch = true;
     }
 
     async initWebGpu(glslangUrl) {

--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -66,6 +66,7 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
         this.precision = 'hiphp';
         this.maxSamples = 4;
         this.maxTextures = 16;
+        this.maxPixelRatio = 1;
         this.supportsUniformBuffers = true;
         this.supportsBoneTextures = true;
         this.supportsMorphTargetTexturesCore = true;

--- a/src/scene/lighting/lights-buffer.js
+++ b/src/scene/lighting/lights-buffer.js
@@ -99,6 +99,9 @@ class LightsBuffer {
     // active light texture format, initialized at app start
     static lightTextureFormat = LightsBuffer.FORMAT_8BIT;
 
+    // on webgl2 we use texelFetch instruction to read data textures
+    static useTexelFetch = false;
+
     // defines used for unpacking of light textures to allow CPU packing to match the GPU unpacking
     static shaderDefines = '';
 
@@ -115,8 +118,9 @@ class LightsBuffer {
     // converts object with properties to a list of these as an example: "#define CLUSTER_TEXTURE_8_BLAH 1.5"
     static buildShaderDefines(object, prefix) {
         let str = '';
+        const floatOffset = LightsBuffer.useTexelFetch ? '' : '.5';
         Object.keys(object).forEach((key) => {
-            str += `\n#define ${prefix}${key} ${object[key]}.5`;
+            str += `\n#define ${prefix}${key} ${object[key]}${floatOffset}`;
         });
         return str;
     }
@@ -127,6 +131,8 @@ class LightsBuffer {
         // precision for texture storage
         // don't use float texture on devices with small number of texture units (as it uses both float and 8bit textures at the same time)
         LightsBuffer.lightTextureFormat = (device.extTextureFloat && device.maxTextures > 8) ? LightsBuffer.FORMAT_FLOAT : LightsBuffer.FORMAT_8BIT;
+
+        LightsBuffer.useTexelFetch = device.supportsTextureFetch;
 
         LightsBuffer.initShaderDefines();
     }

--- a/src/scene/lighting/world-clusters.js
+++ b/src/scene/lighting/world-clusters.js
@@ -115,6 +115,8 @@ class WorldClusters {
 
     registerUniforms(device) {
 
+        this._clusterMaxCellsId = device.scope.resolve('clusterMaxCells');
+
         this._clusterWorldTextureId = device.scope.resolve('clusterWorldTexture');
         this._clusterPixelsPerCellId = device.scope.resolve('clusterPixelsPerCell');
 
@@ -215,6 +217,8 @@ class WorldClusters {
         this._clusterWorldTextureId.setValue(this.clusterTexture);
 
         // uniform values
+        this._clusterMaxCellsId.setValue(this._pixelsPerCellCount);
+
         const boundsDelta = this.boundsDelta;
         this._clusterCellsCountByBoundsSizeData[0] = this._cells.x / boundsDelta.x;
         this._clusterCellsCountByBoundsSizeData[1] = this._cells.y / boundsDelta.y;

--- a/src/scene/shader-lib/chunks/lit/frag/clusteredLight.js
+++ b/src/scene/shader-lib/chunks/lit/frag/clusteredLight.js
@@ -142,7 +142,7 @@ vec4 decodeClusterLowRange4Vec4(vec4 d0, vec4 d1, vec4 d2, vec4 d3) {
 #ifdef GL2
 
     vec4 sampleLightsTexture8(const ClusterLightData clusterLightData, int index) {
-            return texelFetch(lightsTexture8, ivec2(index, clusterLightData.lightIndex), 0);
+        return texelFetch(lightsTexture8, ivec2(index, clusterLightData.lightIndex), 0);
     }
 
     vec4 sampleLightTextureF(const ClusterLightData clusterLightData, int index) {
@@ -154,7 +154,7 @@ vec4 decodeClusterLowRange4Vec4(vec4 d0, vec4 d1, vec4 d2, vec4 d3) {
     uniform vec4 lightsTextureInvSize;
 
     vec4 sampleLightsTexture8(const ClusterLightData clusterLightData, float index) {
-            return texture2DLodEXT(lightsTexture8, vec2(index * lightsTextureInvSize.z, clusterLightData.lightV), 0.0);
+        return texture2DLodEXT(lightsTexture8, vec2(index * lightsTextureInvSize.z, clusterLightData.lightV), 0.0);
     }
 
     vec4 sampleLightTextureF(const ClusterLightData clusterLightData, float index) {

--- a/src/scene/shader-lib/chunks/lit/frag/clusteredLight.js
+++ b/src/scene/shader-lib/chunks/lit/frag/clusteredLight.js
@@ -163,8 +163,6 @@ vec4 decodeClusterLowRange4Vec4(vec4 d0, vec4 d1, vec4 d2, vec4 d3) {
 
 #endif
 
-
-
 void decodeClusterLightCore(inout ClusterLightData clusterLightData, float lightIndex) {
 
     // light index


### PR DESCRIPTION
- this avoids a multiply per data sampling, and avoids possible uv coordinate rounding issues
- also using dynamic count in the for loop on webgl2 to avoid additional condition to exit the loop
- requiring extension on WebGPU platform to get access to texelFetch

screenshot to see the main clustered loop difference easier (WebGL2 vs WebGL1):
<img width="1128" alt="Screenshot 2022-11-18 at 14 40 54" src="https://user-images.githubusercontent.com/59932779/202730409-b24d437a-bd99-49cb-b419-2fad1e69e1a9.png">
