### PR TITLE
Spot lights with zero size outer cone are filtered out from clustered lights

### DIFF
--- a/src/scene/lighting/world-clusters.js
+++ b/src/scene/lighting/world-clusters.js
@@ -274,8 +274,8 @@ class WorldClusters {
 
         lights.forEach((light) => {
             const runtimeLight = !!(light.mask & (MASK_AFFECT_DYNAMIC | MASK_AFFECT_LIGHTMAPPED));
-            const nonZeroSpotCone = light.type !== LIGHTTYPE_SPOT || light._outerConeAngle > 0;
-            if (light.enabled && light.type !== LIGHTTYPE_DIRECTIONAL && light.visibleThisFrame && light.intensity > 0 && runtimeLight && nonZeroSpotCone) {
+            const zeroAngleSpotlight = light.type === LIGHTTYPE_SPOT && light._outerConeAngle === 0;
+            if (light.enabled && light.type !== LIGHTTYPE_DIRECTIONAL && light.visibleThisFrame && light.intensity > 0 && runtimeLight && !zeroAngleSpotlight ) {
 
                 // within light limit
                 if (lightIndex < maxLights) {

--- a/src/scene/lighting/world-clusters.js
+++ b/src/scene/lighting/world-clusters.js
@@ -2,7 +2,7 @@ import { Vec3 } from '../../core/math/vec3.js';
 import { math } from '../../core/math/math.js';
 import { BoundingBox } from '../../core/shape/bounding-box.js';
 import { PIXELFORMAT_RGBA8 } from '../../platform/graphics/constants.js';
-import { LIGHTTYPE_DIRECTIONAL, MASK_AFFECT_DYNAMIC, MASK_AFFECT_LIGHTMAPPED } from '../constants.js';
+import { LIGHTTYPE_DIRECTIONAL, LIGHTTYPE_SPOT, MASK_AFFECT_DYNAMIC, MASK_AFFECT_LIGHTMAPPED } from '../constants.js';
 import { LightsBuffer } from './lights-buffer.js';
 import { Debug } from '../../core/debug.js';
 
@@ -274,7 +274,8 @@ class WorldClusters {
 
         lights.forEach((light) => {
             const runtimeLight = !!(light.mask & (MASK_AFFECT_DYNAMIC | MASK_AFFECT_LIGHTMAPPED));
-            if (light.enabled && light.type !== LIGHTTYPE_DIRECTIONAL && light.visibleThisFrame && light.intensity > 0 && runtimeLight) {
+            const nonZeroSpotCone = light.type !== LIGHTTYPE_SPOT || light._outerConeAngle > 0;
+            if (light.enabled && light.type !== LIGHTTYPE_DIRECTIONAL && light.visibleThisFrame && light.intensity > 0 && runtimeLight && nonZeroSpotCone) {
 
                 // within light limit
                 if (lightIndex < maxLights) {

--- a/src/scene/lighting/world-clusters.js
+++ b/src/scene/lighting/world-clusters.js
@@ -275,7 +275,7 @@ class WorldClusters {
         lights.forEach((light) => {
             const runtimeLight = !!(light.mask & (MASK_AFFECT_DYNAMIC | MASK_AFFECT_LIGHTMAPPED));
             const zeroAngleSpotlight = light.type === LIGHTTYPE_SPOT && light._outerConeAngle === 0;
-            if (light.enabled && light.type !== LIGHTTYPE_DIRECTIONAL && light.visibleThisFrame && light.intensity > 0 && runtimeLight && !zeroAngleSpotlight ) {
+            if (light.enabled && light.type !== LIGHTTYPE_DIRECTIONAL && light.visibleThisFrame && light.intensity > 0 && runtimeLight && !zeroAngleSpotlight) {
 
                 // within light limit
                 if (lightIndex < maxLights) {


### PR DESCRIPTION
Fixes https://github.com/playcanvas/engine/issues/4861

It fixes the issue with spot light with 0 outer angle still rendering something in case other spot lights are nearby. When the other spot light moves, the shape gets affected - somehow we access wrong data somewhere / pixels are interpolated that should not. I tried to use textureFetch to avoid it without success so far: https://github.com/playcanvas/engine/pull/4863