### PR TITLE
Audio fix for safari desktop

### DIFF
--- a/src/platform/sound/manager.js
+++ b/src/platform/sound/manager.js
@@ -15,7 +15,7 @@ const CONTEXT_STATE_RUNNING = 'running';
  * List of Window events to listen when AudioContext needs to be unlocked.
  */
 const USER_INPUT_EVENTS = [
-    'click', 'touchstart'
+    'click', 'touchstart', 'mousedown'
 ];
 
 /**


### PR DESCRIPTION
Desktop Safari seems to resume the audio context on `mousedown` event, not the `click` or `touchstart` event like elsewhere.