### PR TITLE
Run scenes with corrupted data

### DIFF
--- a/src/framework/parsers/scene.js
+++ b/src/framework/parsers/scene.js
@@ -98,29 +98,28 @@ class SceneParser {
         // Create components in order
         const systemsList = this._app.systems.list;
 
-        if (entity) {
-            let len = systemsList.length;
-            const entityData = entities[entity.getGuid()];
-            for (let i = 0; i < len; i++) {
-                const system = systemsList[i];
-                const componentData = entityData.components[system.id];
-                if (componentData) {
-                    system.addComponent(entity, componentData);
-                }
+        let len = systemsList.length;
+        const entityData = entities[entity.getGuid()];
+        for (let i = 0; i < len; i++) {
+            const system = systemsList[i];
+            const componentData = entityData.components[system.id];
+            if (componentData) {
+                system.addComponent(entity, componentData);
             }
-
-            // Open all children and add them to the node
-            len = entityData.children.length;
-            const children = entity._children;
-            for (let i = 0; i < len; i++) {
-                children[i] = this._openComponentData(children[i], entities);
-            }
-
-            return entity;
         }
 
-        Debug.warn("Scene data is invalid where an Entity doesn't exist. Please check the scene data");
-        return new Entity();
+        // Open all children and add them to the node
+        len = entityData.children.length;
+        const children = entity._children;
+        for (let i = 0; i < len; i++) {
+            if (children[i]) {
+                children[i] = this._openComponentData(children[i], entities);
+            } else {
+                Debug.warn(`Scene data is invalid where a child under "${entity.name}" Entity doesn't exist. Please check the scene data.`);
+            }
+        }
+
+        return entity;
     }
 }
 

--- a/src/framework/parsers/scene.js
+++ b/src/framework/parsers/scene.js
@@ -2,6 +2,7 @@ import { Entity } from '../entity.js';
 
 import { CompressUtils } from '../../scene/compress/compress-utils.js';
 import { Decompress } from '../../scene/compress/decompress.js';
+import { Debug } from "../../core/debug.js";
 
 class SceneParser {
     constructor(app, isTemplate) {
@@ -97,24 +98,29 @@ class SceneParser {
         // Create components in order
         const systemsList = this._app.systems.list;
 
-        let len = systemsList.length;
-        const entityData = entities[entity.getGuid()];
-        for (let i = 0; i < len; i++) {
-            const system = systemsList[i];
-            const componentData = entityData.components[system.id];
-            if (componentData) {
-                system.addComponent(entity, componentData);
+        if (entity) {
+            let len = systemsList.length;
+            const entityData = entities[entity.getGuid()];
+            for (let i = 0; i < len; i++) {
+                const system = systemsList[i];
+                const componentData = entityData.components[system.id];
+                if (componentData) {
+                    system.addComponent(entity, componentData);
+                }
             }
+
+            // Open all children and add them to the node
+            len = entityData.children.length;
+            const children = entity._children;
+            for (let i = 0; i < len; i++) {
+                children[i] = this._openComponentData(children[i], entities);
+            }
+
+            return entity;
         }
 
-        // Open all children and add them to the node
-        len = entityData.children.length;
-        const children = entity._children;
-        for (let i = 0; i < len; i++) {
-            children[i] = this._openComponentData(children[i], entities);
-        }
-
-        return entity;
+        Debug.warn("Scene data is invalid where an Entity doesn't exist. Please check the scene data");
+        return new Entity();
     }
 }
 


### PR DESCRIPTION
Related to https://github.com/playcanvas/editor/issues/758

We have existing scenes that could be corrupted by this issue and at the moment, they fail to launch leaving users confused.

This PR allows these scenes to launch with a warning

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).

Tested against:
https://playcanvas.com/project/923035/overview/double-graphnode-parent

Current
<img width="466" alt="image" src="https://user-images.githubusercontent.com/16639049/203539903-0d7e0be4-f1ef-41a4-9594-dae606723e8d.png">

With this PR
<img width="684" alt="image" src="https://user-images.githubusercontent.com/16639049/203539979-de49661c-c26f-4e60-aba9-bea0db08c1e6.png">
