### PR TITLE
Improved handling of RenderTarget formats on WebGPU

### DIFF
--- a/src/platform/graphics/webgpu/webgpu-render-target.js
+++ b/src/platform/graphics/webgpu/webgpu-render-target.js
@@ -42,10 +42,14 @@ class WebgpuRenderTarget {
     constructor(renderTarget) {
         this.renderTarget = renderTarget;
 
+        // color format is based on the texture
+        if (renderTarget.colorBuffer) {
+            this.colorFormat = renderTarget.colorBuffer.impl.format;
+        }
+
         // TODO: handle shadow map case (depth only, no color)
 
-        // key used by render pipeline creation
-        this.key = `${this.colorFormat}-${renderTarget.depth ? this.depthFormat : ''}-${renderTarget.samples}`;
+        this.updateKey();
     }
 
     /**
@@ -61,6 +65,12 @@ class WebgpuRenderTarget {
 
         this.multisampledColorBuffer?.destroy();
         this.multisampledColorBuffer = null;
+    }
+
+    updateKey() {
+        // key used by render pipeline creation
+        const rt = this.renderTarget;
+        this.key = `${this.colorFormat}-${rt.depth ? this.depthFormat : ''}-${rt.samples}`;
     }
 
     /**
@@ -82,6 +92,10 @@ class WebgpuRenderTarget {
         } else {
             colorAttachment.view = view;
         }
+
+        // for main framebuffer, this is how the format is obtained
+        this.colorFormat = gpuTexture.format;
+        this.updateKey();
     }
 
     /**

--- a/src/platform/graphics/webgpu/webgpu-texture.js
+++ b/src/platform/graphics/webgpu/webgpu-texture.js
@@ -45,6 +45,7 @@ gpuTextureFormats[PIXELFORMAT_ASTC_4x4] = '';
 gpuTextureFormats[PIXELFORMAT_ATC_RGB] = '';
 gpuTextureFormats[PIXELFORMAT_ATC_RGBA] = '';
 
+// map of ADDRESS_*** to GPUAddressMode
 const gpuAddressModes = [];
 gpuAddressModes[ADDRESS_REPEAT] = 'repeat';
 gpuAddressModes[ADDRESS_CLAMP_TO_EDGE] = 'clamp-to-edge';
@@ -68,21 +69,25 @@ class WebgpuTexture {
     // type {GPUTextureDescriptor}
     descr;
 
+    // type {GPUTextureFormat}
+    format;
+
     constructor(texture) {
         /** @type {import('../texture.js').Texture} */
         this.texture = texture;
+
+        this.format = gpuTextureFormats[texture.format];
+        Debug.assert(this.format !== '', `WebGPU does not support texture format ${texture.format} for texture ${texture.name}`, texture);
     }
 
     create(device) {
 
         const texture = this.texture;
         const wgpu = device.wgpu;
-        const gpuFormat = gpuTextureFormats[texture.format];
-        Debug.assert(gpuFormat !== '', `WebGPU does not support texture format ${texture.format} for texture ${texture.name}`, texture);
 
         this.descr = {
             size: { width: texture.width, height: texture.height },
-            format: gpuFormat,
+            format: this.format,
             mipLevelCount: 1,
             sampleCount: 1,
             dimension: '2d',


### PR DESCRIPTION
- buffer (texture) format needs to match between the pass encoder expectation, and render pipeline. Set it up appropriately for both the main framebuffer, as well as texture based render targets.