### PR TITLE
[Fix] WebGPU correctly specifies element type with a single component

### DIFF
--- a/src/platform/graphics/webgpu/webgpu-render-pipeline.js
+++ b/src/platform/graphics/webgpu/webgpu-render-pipeline.js
@@ -162,7 +162,8 @@ class WebgpuRenderPipeline {
             format: renderTarget.impl.depthFormat
         } : undefined;
 
-        return wgpu.createRenderPipeline({
+        // type {GPURenderPipelineDescriptor}
+        const descr = {
             vertex: {
                 module: wgpu.createShaderModule({
                     code: webgpuShader.vertexCode
@@ -194,7 +195,9 @@ class WebgpuRenderPipeline {
 
             // uniform / texture binding layout
             layout: pipelineLayout
-        });
+        };
+
+        return wgpu.createRenderPipeline(descr);
     }
 }
 

--- a/src/platform/graphics/webgpu/webgpu-vertex-buffer-layout.js
+++ b/src/platform/graphics/webgpu/webgpu-vertex-buffer-layout.js
@@ -69,7 +69,7 @@ class WebgpuVertexBufferLayout {
                 attributes.push({
                     shaderLocation: location,
                     offset: interleaved ? element.offset : 0,
-                    format: `${gpuVertexFormats[element.dataType]}x${element.numComponents}`
+                    format: `${gpuVertexFormats[element.dataType]}${element.numComponents > 1 ? 'x' + element.numComponents : ''}`
                 });
 
                 if (!interleaved || i === elementCount - 1) {


### PR DESCRIPTION
- instead of `floatx1` it needs to be just `float`.
- this fixes the dynamic batching example for WebGPU (without shadows)

![Screenshot 2022-11-23 at 15 09 05](https://user-images.githubusercontent.com/59932779/203580984-58a10398-591d-4d05-b870-f2cdbb27746a.png)
