### PR TITLE
LitOptions class to hold backend options

### DIFF
--- a/src/deprecated/deprecated.js
+++ b/src/deprecated/deprecated.js
@@ -788,7 +788,7 @@ _defineAlias('opacityVertexColor', 'opacityMapVertexColor');
 _defineAlias('lightVertexColor', 'lightMapVertexColor');
 
 function _defineOption(name, newName) {
-    if (name !== 'chunks') {
+    if (name !== 'chunks' || name == 'pass') {
         Object.defineProperty(StandardMaterialOptions.prototype, name, {
             get: function () {
                 Debug.deprecated(`Getting pc.Options#${name} has been deprecated as the property has been moved to pc.Options.LitOptions#${newName || name}.`);

--- a/src/deprecated/deprecated.js
+++ b/src/deprecated/deprecated.js
@@ -71,7 +71,7 @@ import { SkinInstance } from '../scene/skin-instance.js';
 import { StandardMaterial } from '../scene/materials/standard-material.js';
 import { Batch } from '../scene/batching/batch.js';
 import { getDefaultMaterial } from '../scene/materials/default-material.js';
-import { Options } from '../scene/materials/options.js';
+import { StandardMaterialOptions } from '../scene/materials/standard-material-options.js';
 import { LitOptions } from '../scene/materials/lit-options.js';
 
 import { Animation, Key, Node } from '../scene/animation/animation.js';
@@ -787,17 +787,19 @@ _defineAlias('glossVertexColor', 'glossMapVertexColor');
 _defineAlias('opacityVertexColor', 'opacityMapVertexColor');
 _defineAlias('lightVertexColor', 'lightMapVertexColor');
 
-function _defineOption(name) {
-    Object.defineProperty(Options.prototype, name, {
+function _defineOption(name, newName) {
+    Object.defineProperty(StandardMaterialOptions.prototype, name, {
         get: function () {
-            Debug.deprecated(`Getting pc.Options#${name} has been deprecated as the property has been moved to pc.Options.LitOptions.`);
-            return null;
+            Debug.deprecated(`Getting pc.Options#${name} has been deprecated as the property has been moved to pc.Options.LitOptions#${newName || name}.`);
+            return this.litOptions[newName || name];
         },
         set: function (value) {
-            Debug.deprecated(`Setting pc.Options#${name} has been deprecated as the property has been moved to pc.Options.LitOptions.`);
+            Debug.deprecated(`Setting pc.Options#${name} has been deprecated as the property has been moved to pc.Options.LitOptions#${newName || name}.`);
+            this.litOptions[newName || name] = value;
         }
     });
 }
+_defineOption('refraction', 'useRefraction');
 
 const tempOptions = new LitOptions();
 const litOptionProperties = Object.getOwnPropertyNames(tempOptions);

--- a/src/deprecated/deprecated.js
+++ b/src/deprecated/deprecated.js
@@ -788,16 +788,18 @@ _defineAlias('opacityVertexColor', 'opacityMapVertexColor');
 _defineAlias('lightVertexColor', 'lightMapVertexColor');
 
 function _defineOption(name, newName) {
-    Object.defineProperty(StandardMaterialOptions.prototype, name, {
-        get: function () {
-            Debug.deprecated(`Getting pc.Options#${name} has been deprecated as the property has been moved to pc.Options.LitOptions#${newName || name}.`);
-            return this.litOptions[newName || name];
-        },
-        set: function (value) {
-            Debug.deprecated(`Setting pc.Options#${name} has been deprecated as the property has been moved to pc.Options.LitOptions#${newName || name}.`);
-            this.litOptions[newName || name] = value;
-        }
-    });
+    if (name !== 'chunks') {
+        Object.defineProperty(StandardMaterialOptions.prototype, name, {
+            get: function () {
+                Debug.deprecated(`Getting pc.Options#${name} has been deprecated as the property has been moved to pc.Options.LitOptions#${newName || name}.`);
+                return this.litOptions[newName || name];
+            },
+            set: function (value) {
+                Debug.deprecated(`Setting pc.Options#${name} has been deprecated as the property has been moved to pc.Options.LitOptions#${newName || name}.`);
+                this.litOptions[newName || name] = value;
+            }
+        });
+    }
 }
 _defineOption('refraction', 'useRefraction');
 

--- a/src/deprecated/deprecated.js
+++ b/src/deprecated/deprecated.js
@@ -788,7 +788,7 @@ _defineAlias('opacityVertexColor', 'opacityMapVertexColor');
 _defineAlias('lightVertexColor', 'lightMapVertexColor');
 
 function _defineOption(name, newName) {
-    if (name !== 'chunks' || name == 'pass') {
+    if (name !== 'chunks' || name !== 'pass') {
         Object.defineProperty(StandardMaterialOptions.prototype, name, {
             get: function () {
                 Debug.deprecated(`Getting pc.Options#${name} has been deprecated as the property has been moved to pc.Options.LitOptions#${newName || name}.`);

--- a/src/deprecated/deprecated.js
+++ b/src/deprecated/deprecated.js
@@ -788,7 +788,7 @@ _defineAlias('opacityVertexColor', 'opacityMapVertexColor');
 _defineAlias('lightVertexColor', 'lightMapVertexColor');
 
 function _defineOption(name, newName) {
-    if (name !== 'chunks' || name !== 'pass') {
+    if (name !== 'chunks' && name !== 'pass') {
         Object.defineProperty(StandardMaterialOptions.prototype, name, {
             get: function () {
                 Debug.deprecated(`Getting pc.Options#${name} has been deprecated as the property has been moved to pc.Options.LitOptions#${newName || name}.`);

--- a/src/deprecated/deprecated.js
+++ b/src/deprecated/deprecated.js
@@ -788,7 +788,7 @@ _defineAlias('opacityVertexColor', 'opacityMapVertexColor');
 _defineAlias('lightVertexColor', 'lightMapVertexColor');
 
 function _defineOption(name, newName) {
-    if (name !== 'chunks' && name !== 'pass') {
+    if (name !== 'chunks' && name !== '_pass') {
         Object.defineProperty(StandardMaterialOptions.prototype, name, {
             get: function () {
                 Debug.deprecated(`Getting pc.Options#${name} has been deprecated as the property has been moved to pc.Options.LitOptions#${newName || name}.`);

--- a/src/deprecated/deprecated.js
+++ b/src/deprecated/deprecated.js
@@ -71,6 +71,8 @@ import { SkinInstance } from '../scene/skin-instance.js';
 import { StandardMaterial } from '../scene/materials/standard-material.js';
 import { Batch } from '../scene/batching/batch.js';
 import { getDefaultMaterial } from '../scene/materials/default-material.js';
+import { Options } from '../scene/materials/options.js';
+import { LitOptions } from '../scene/materials/lit-options.js';
 
 import { Animation, Key, Node } from '../scene/animation/animation.js';
 import { Skeleton } from '../scene/animation/skeleton.js';
@@ -784,6 +786,24 @@ _defineAlias('metalnessVertexColor', 'metalnessMapVertexColor');
 _defineAlias('glossVertexColor', 'glossMapVertexColor');
 _defineAlias('opacityVertexColor', 'opacityMapVertexColor');
 _defineAlias('lightVertexColor', 'lightMapVertexColor');
+
+function _defineOption(name) {
+    Object.defineProperty(Options.prototype, name, {
+        get: function () {
+            Debug.deprecated(`Getting pc.Options#${name} has been deprecated as the property has been moved to pc.Options.LitOptions.`);
+            return null;
+        },
+        set: function (value) {
+            Debug.deprecated(`Setting pc.Options#${name} has been deprecated as the property has been moved to pc.Options.LitOptions.`);
+        }
+    });
+}
+
+const tempOptions = new LitOptions();
+const litOptionProperties = Object.getOwnPropertyNames(tempOptions);
+for (const litOption in litOptionProperties) {
+    _defineOption(litOptionProperties[litOption]);
+}
 
 // ANIMATION
 

--- a/src/index.js
+++ b/src/index.js
@@ -115,6 +115,7 @@ export { Layer } from './scene/layer.js';
 export { LayerComposition } from './scene/composition/layer-composition.js';
 export { Light } from './scene/light.js';
 export { LightingParams } from './scene/lighting/lighting-params.js';
+export { LitOptions } from './scene/materials/lit-options.js';
 export { Material } from './scene/materials/material.js';
 export { Mesh } from './scene/mesh.js';
 export { MeshInstance, Command } from './scene/mesh-instance.js';
@@ -129,7 +130,6 @@ export { SkinInstance } from './scene/skin-instance.js';
 export { Sprite } from './scene/sprite.js';
 export { StandardMaterial } from './scene/materials/standard-material.js';
 export { StandardMaterialOptions } from './scene/materials/standard-material-options.js';
-export { LitOptions } from './scene/materials/lit-options.js';
 export { StencilParameters } from './scene/stencil-parameters.js';
 export { TextureAtlas } from './scene/texture-atlas.js';
 

--- a/src/index.js
+++ b/src/index.js
@@ -128,6 +128,8 @@ export { Skin } from './scene/skin.js';
 export { SkinInstance } from './scene/skin-instance.js';
 export { Sprite } from './scene/sprite.js';
 export { StandardMaterial } from './scene/materials/standard-material.js';
+export { StandardMaterialOptions } from './scene/materials/standard-material-options.js';
+export { LitOptions } from './scene/materials/lit-options.js';
 export { StencilParameters } from './scene/stencil-parameters.js';
 export { TextureAtlas } from './scene/texture-atlas.js';
 

--- a/src/scene/materials/lit-options.js
+++ b/src/scene/materials/lit-options.js
@@ -145,8 +145,7 @@ class LitOptions {
     }
 
     get pass() {
-        Debug.warn(`pc.LitOptions#pass should be accessed by its parent pc.StandardMaterialOptions.`);
-        return 0;
+        return this._pass;
     }
 }
 

--- a/src/scene/materials/lit-options.js
+++ b/src/scene/materials/lit-options.js
@@ -1,6 +1,6 @@
 import { Debug } from 'src/core/debug.js';
 import {
-    BLEND_NONE, GAMMA_NONE
+    BLEND_NONE, FOG_NONE, GAMMA_NONE
 } from '../constants.js';
 
 /**
@@ -119,7 +119,7 @@ class LitOptions {
         this.useMetalness = false;
         this.useDynamicRefraction = false;
 
-        this.fog = 'none';
+        this.fog = FOG_NONE;
         this.gamma = GAMMA_NONE;
         this.toneMap = -1;
         this.fixSeams = false;

--- a/src/scene/materials/lit-options.js
+++ b/src/scene/materials/lit-options.js
@@ -4,6 +4,9 @@ import {
 } from '../constants.js';
 
 /**
+ * The lit options determines how the lit-shader gets generated. It specifies a set of
+ * parameters which triggers different fragment and vertex shader generation in the backend.
+ *
  * @property {object} chunks Object containing custom shader chunks that will replace default ones.
  * @property {string} customFragmentShader Replaced the whole fragment shader with this string.
  * @property {number} fog The type of fog being applied in the shader. See {@link Scene#fog} for the list of

--- a/src/scene/materials/lit-options.js
+++ b/src/scene/materials/lit-options.js
@@ -2,8 +2,10 @@ import {
     BLEND_NONE, GAMMA_NONE
 } from '../constants.js';
 
+import { StandardMaterialOptions } from './standard-material-options.js';
 /**
- * - pass: value of {@link Layer#shaderPass} of the Layer being rendered.
+ * - pass: value of {@link Layer#shaderPass} of the Layer being rendered. Must be set to the
+ * same in {@link StandardMaterialOptions#pass}.
  * - chunks: Object containing custom shader chunks that will replace default ones.
  * - customFragmentShader: Completely replace fragment shader with this code.
  * - fog: the type of fog being applied in the shader. See {@link Scene#fog} for the list of

--- a/src/scene/materials/lit-options.js
+++ b/src/scene/materials/lit-options.js
@@ -1,51 +1,48 @@
+import { Debug } from 'src/core/debug.js';
 import {
     BLEND_NONE, GAMMA_NONE
 } from '../constants.js';
 
 /**
- * - pass: value of {@link Layer#shaderPass} of the Layer being rendered. Must be set to the
- * same in {@link StandardMaterialOptions#pass}.
- * - chunks: Object containing custom shader chunks that will replace default ones.
- * - customFragmentShader: Completely replace fragment shader with this code.
- * - fog: the type of fog being applied in the shader. See {@link Scene#fog} for the list of
+ * @property {object} chunks Object containing custom shader chunks that will replace default ones.
+ * @property {string} customFragmentShader Replaced the whole fragment shader with this string.
+ * @property {number} fog The type of fog being applied in the shader. See {@link Scene#fog} for the list of
  * possible values.
- * - gamma: the type of gamma correction being applied in the shader. See
+ * @property {number} gamma The type of gamma correction being applied in the shader. See
  * {@link Scene#gammaCorrection} for the list of possible values.
- * - toneMap: the type of tone mapping being applied in the shader. See {@link Scene#toneMapping}
+ * @property {number} toneMap The type of tone mapping being applied in the shader. See {@link Scene#toneMapping}
  * for the list of possible values.
- * - conserveEnergy: the value of {@link StandardMaterial#conserveEnergy}.
- * - occludeSpecular: the value of {@link StandardMaterial#occludeSpecular}.
- * - occludeDirect: the value of {@link StandardMaterial#occludeDirect}.
- * - shadingModel: the value of {@link StandardMaterial#shadingModel}.
- * - fresnelModel: the value of {@link StandardMaterial#fresnelModel}.
- * - cubeMapProjection: the value of {@link StandardMaterial#cubeMapProjection}.
- * - useMetalness: the value of {@link StandardMaterial#useMetalness}.
- * - blendType: the value of {@link Material#blendType}.
- * - twoSidedLighting: the value of {@link Material#twoSidedLighting}.
- * - occludeSpecularFloat: defines if {@link StandardMaterial#occludeSpecularIntensity} constant
+ * @property {boolean} conserveEnergy The value of {@link StandardMaterial#conserveEnergy}.
+ * @property {number} occludeSpecular The value of {@link StandardMaterial#occludeSpecular}.
+ * @property {boolean} occludeDirect The value of {@link StandardMaterial#occludeDirect}.
+ * @property {number} shadingModel The value of {@link StandardMaterial#shadingModel}.
+ * @property {number} fresnelModel The value of {@link StandardMaterial#fresnelModel}.
+ * @property {number} cubeMapProjection The value of {@link StandardMaterial#cubeMapProjection}.
+ * @property {boolean} useMetalness The value of {@link StandardMaterial#useMetalness}.
+ * @property {number} blendType The value of {@link Material#blendType}.
+ * @property {boolean} twoSidedLighting The value of {@link Material#twoSidedLighting}.
+ * @property {number} occludeSpecularFloat Defines if {@link StandardMaterial#occludeSpecularIntensity} constant
  * should affect specular occlusion.
- * - alphaTest: enable alpha testing. See {@link Material#alphaTest}.
- * - alphaToCoverage: enable alpha to coverage. See {@link Material#alphaToCoverage}.
- * - opacityFadesSpecular: enable specular fade. See {@link Material#opacityFadesSpecular}.
- * - ambientSH: if ambient spherical harmonics are used. Ambient SH replace prefiltered cubemap
+ * @property {boolean} alphaTest Enable alpha testing. See {@link Material#alphaTest}.
+ * @property {boolean} alphaToCoverage Enable alpha to coverage. See {@link Material#alphaToCoverage}.
+ * @property {boolean} opacityFadesSpecular Enable specular fade. See {@link Material#opacityFadesSpecular}.
+ * @property {float} ambientSH If ambient spherical harmonics are used. Ambient SH replace prefiltered cubemap
  * ambient on certain platform (mostly Android) for performance reasons.
- * - useSpecular: if any specular or reflections are needed at all.
- * - fixSeams: if cubemaps require seam fixing (see {@link Texture#options.fixCubemapSeams}).
- * - forceFragmentPrecision: Override fragment shader numeric precision. Can be "lowp", "mediump",
+ * @property {boolean} useSpecular If any specular or reflections are needed at all.
+ * @property {boolean} fixSeams If cubemaps require seam fixing (see {@link Texture#options.fixCubemapSeams}).
+ * @property {string} forceFragmentPrecision Override fragment shader numeric precision. Can be "lowp", "mediump",
  * "highp" or null to use default.
- * - fastTbn: Use slightly cheaper normal mapping code (skip tangent space normalization). Can look
+ * @property {boolean} fastTbn Use slightly cheaper normal mapping code (skip tangent space normalization). Can look
  * buggy sometimes.
- * - useRefraction: if refraction is used.
- * - skyboxIntensity: if reflected skybox intensity should be modulated.
- * - useCubeMapRotation: if cube map rotation is enabled.
- * - useInstancing: if hardware instancing compatible shader should be generated. Transform is read
+ * @property {boolean} useRefraction If refraction is used.
+ * @property {number} skyboxIntensity If reflected skybox intensity should be modulated.
+ * @property {boolean} useCubeMapRotation If cube map rotation is enabled.
+ * @property {boolean} useInstancing If hardware instancing compatible shader should be generated. Transform is read
  * from per-instance {@link VertexBuffer} instead of shader's uniforms.
- * - useMorphPosition: if morphing code should be generated to morph positions.
- * - useMorphNormal: if morphing code should be generated to morph normals.
- * - reflectionSource: one of "envAtlasHQ", "envAtlas", "cubeMap", "sphereMap"
- * - reflectionEncoding: one of null, "rgbm", "rgbe", "linear", "srgb"
- * - ambientSource: one of "ambientSH", "envAtlas", "constant"
- * - ambientEncoding: one of null, "rgbm", "rgbe", "linear", "srgb"
+ * @property {boolean} useMorphPosition If morphing code should be generated to morph positions.
+ * @property {boolean} useMorphNormal If morphing code should be generated to morph normals.
+ * @property {string} reflectionSource One of "envAtlasHQ", "envAtlas", "cubeMap", "sphereMap"
+ * @property {boolean} ambientSource One of "ambientSH", "envAtlas", "constant"
  */
 class LitOptions {
     constructor() {
@@ -141,6 +138,15 @@ class LitOptions {
         this.lights = [];
         this.noShadow = false;
         this.lightMaskDynamic = 0x0;
+    }
+
+    set pass(p) {
+        Debug.warn(`pc.LitOptions#pass should be set by its parent pc.StandardMaterialOptions, setting it directly has no effect.`);
+    }
+
+    get pass() {
+        Debug.warn(`pc.LitOptions#pass should be accessed by its parent pc.StandardMaterialOptions.`);
+        return 0;
     }
 }
 

--- a/src/scene/materials/lit-options.js
+++ b/src/scene/materials/lit-options.js
@@ -2,7 +2,6 @@ import {
     BLEND_NONE, GAMMA_NONE
 } from '../constants.js';
 
-import { StandardMaterialOptions } from './standard-material-options.js';
 /**
  * - pass: value of {@link Layer#shaderPass} of the Layer being rendered. Must be set to the
  * same in {@link StandardMaterialOptions#pass}.

--- a/src/scene/materials/lit-options.js
+++ b/src/scene/materials/lit-options.js
@@ -41,8 +41,8 @@ import {
  * from per-instance {@link VertexBuffer} instead of shader's uniforms.
  * @property {boolean} useMorphPosition If morphing code should be generated to morph positions.
  * @property {boolean} useMorphNormal If morphing code should be generated to morph normals.
- * @property {string} reflectionSource One of "envAtlasHQ", "envAtlas", "cubeMap", "sphereMap"
- * @property {boolean} ambientSource One of "ambientSH", "envAtlas", "constant"
+ * @property {string} reflectionSource One of "envAtlasHQ", "envAtlas", "cubeMap", "sphereMap".
+ * @property {boolean} ambientSource One of "ambientSH", "envAtlas", "constant".
  */
 class LitOptions {
     constructor() {

--- a/src/scene/materials/lit-options.js
+++ b/src/scene/materials/lit-options.js
@@ -2,6 +2,50 @@ import {
     BLEND_NONE, GAMMA_NONE
 } from '../constants.js';
 
+/**
+ * - pass: value of {@link Layer#shaderPass} of the Layer being rendered.
+ * - chunks: Object containing custom shader chunks that will replace default ones.
+ * - customFragmentShader: Completely replace fragment shader with this code.
+ * - fog: the type of fog being applied in the shader. See {@link Scene#fog} for the list of
+ * possible values.
+ * - gamma: the type of gamma correction being applied in the shader. See
+ * {@link Scene#gammaCorrection} for the list of possible values.
+ * - toneMap: the type of tone mapping being applied in the shader. See {@link Scene#toneMapping}
+ * for the list of possible values.
+ * - conserveEnergy: the value of {@link StandardMaterial#conserveEnergy}.
+ * - occludeSpecular: the value of {@link StandardMaterial#occludeSpecular}.
+ * - occludeDirect: the value of {@link StandardMaterial#occludeDirect}.
+ * - shadingModel: the value of {@link StandardMaterial#shadingModel}.
+ * - fresnelModel: the value of {@link StandardMaterial#fresnelModel}.
+ * - cubeMapProjection: the value of {@link StandardMaterial#cubeMapProjection}.
+ * - useMetalness: the value of {@link StandardMaterial#useMetalness}.
+ * - blendType: the value of {@link Material#blendType}.
+ * - twoSidedLighting: the value of {@link Material#twoSidedLighting}.
+ * - occludeSpecularFloat: defines if {@link StandardMaterial#occludeSpecularIntensity} constant
+ * should affect specular occlusion.
+ * - alphaTest: enable alpha testing. See {@link Material#alphaTest}.
+ * - alphaToCoverage: enable alpha to coverage. See {@link Material#alphaToCoverage}.
+ * - opacityFadesSpecular: enable specular fade. See {@link Material#opacityFadesSpecular}.
+ * - ambientSH: if ambient spherical harmonics are used. Ambient SH replace prefiltered cubemap
+ * ambient on certain platform (mostly Android) for performance reasons.
+ * - useSpecular: if any specular or reflections are needed at all.
+ * - fixSeams: if cubemaps require seam fixing (see {@link Texture#options.fixCubemapSeams}).
+ * - forceFragmentPrecision: Override fragment shader numeric precision. Can be "lowp", "mediump",
+ * "highp" or null to use default.
+ * - fastTbn: Use slightly cheaper normal mapping code (skip tangent space normalization). Can look
+ * buggy sometimes.
+ * - useRefraction: if refraction is used.
+ * - skyboxIntensity: if reflected skybox intensity should be modulated.
+ * - useCubeMapRotation: if cube map rotation is enabled.
+ * - useInstancing: if hardware instancing compatible shader should be generated. Transform is read
+ * from per-instance {@link VertexBuffer} instead of shader's uniforms.
+ * - useMorphPosition: if morphing code should be generated to morph positions.
+ * - useMorphNormal: if morphing code should be generated to morph normals.
+ * - reflectionSource: one of "envAtlasHQ", "envAtlas", "cubeMap", "sphereMap"
+ * - reflectionEncoding: one of null, "rgbm", "rgbe", "linear", "srgb"
+ * - ambientSource: one of "ambientSH", "envAtlas", "constant"
+ * - ambientEncoding: one of null, "rgbm", "rgbe", "linear", "srgb"
+ */
 class LitOptions {
     constructor() {
         this.hasTangents = false;

--- a/src/scene/materials/lit-options.js
+++ b/src/scene/materials/lit-options.js
@@ -1,4 +1,4 @@
-import { Debug } from 'src/core/debug.js';
+import { Debug } from '../../core/debug.js';
 import {
     BLEND_NONE, FOG_NONE, GAMMA_NONE
 } from '../constants.js';

--- a/src/scene/materials/lit-options.js
+++ b/src/scene/materials/lit-options.js
@@ -1,0 +1,102 @@
+import {
+    BLEND_NONE, GAMMA_NONE
+} from '../constants.js';
+
+class LitOptions {
+    constructor() {
+        this.hasTangents = false;
+        this.chunks = [];
+
+        this.pass = 0;
+        this.alphaTest = false;
+        this.forceFragmentPrecision = false;
+        this.blendType = BLEND_NONE;
+        this.separateAmbient = false;
+        this.screenSpace = false;
+        this.skin = false;
+        this.useInstancing = false;
+        this.useMorphPosition = false;
+        this.useMorphNormal = false;
+        this.useMorphTextureBased = false;
+
+        this.nineSlicedMode = false;
+
+        this.clusteredLightingEnabled = true;
+ 
+        this.clusteredLightingCookiesEnabled = false;
+        this.clusteredLightingShadowsEnabled = false;
+        this.clusteredLightingShadowType = 0;
+        this.clusteredLightingAreaLightsEnabled = false;
+
+        this.vertexColors = false;
+        this.lightMapEnabled = false;
+        this.lightMapVertexColors = false;
+        this.dirLightMapEnabled = false;
+        this.heightMapEnabled = false;
+        this.normalMapEnabled = false;
+        this.clearCoatNormalMapEnabled = false;
+        this.aoMapEnabled = false;
+        this.aoVertexColors = false;
+        this.diffuseMapEnabled = false;
+
+        this.useAmbientTint = false;
+        this.customFragmentShader = null;
+        this.pixelSnap = false;
+
+        this.useClearCoatNormalMap = false;
+        this.useDiffuseMap = false;
+        this.useAoMap = false;
+
+        this.detailModes = 0;
+        this.shadingModel = 0;
+        this.ambientSH = false;
+        this.fastTbn = false;
+        this.twoSidedLighting = false;
+        this.occludeSpecular = false;
+        this.occludeSpecularFloat = false;
+
+        this.useMsdf = false;
+        this.msdfTextAttribute = 0;
+
+        this.alphaToCoverage = false;
+        this.opacityFadesSpecular = false;
+
+        this.cubeMapProjection = false;
+
+        this.occludeDirect = false;
+        this.conserveEnergy = false;
+        this.useSpecular = false;
+        this.useSpecularityFactor = false;
+        this.useSpecularColor = false;
+        this.enableGGXSpecular = false;
+        this.fresnelModel = 0;
+        this.useRefraction = false;
+        this.useClearCoat = false;
+        this.useSheen = false;
+        this.useIridescence = false;
+        this.useMetalness = false;
+        this.useDynamicRefraction = false;
+
+        this.fog = 'none';
+        this.gamma = GAMMA_NONE;
+        this.toneMap = -1;
+        this.fixSeams = false;
+
+        this.reflectionSource = null;
+        this.reflectionEncoding = null;
+        this.ambientSource = 'constant';
+        this.ambientEncoding = null;
+
+        // TODO: add a test for if non skybox cubemaps have rotation (when this is supported) - for now assume no non-skybox cubemap rotation
+        this.skyboxIntensity = 1.0;
+        this.useCubeMapRotation = false;
+
+        this.lightMapWithoutAmbient = false;
+
+        this.lights = [];
+        this.noShadow = false;
+        this.lightMaskDynamic = 0x0;
+    }
+}
+
+export { LitOptions };

--- a/src/scene/materials/lit-options.js
+++ b/src/scene/materials/lit-options.js
@@ -22,7 +22,7 @@ class LitOptions {
         this.nineSlicedMode = false;
 
         this.clusteredLightingEnabled = true;
- 
+
         this.clusteredLightingCookiesEnabled = false;
         this.clusteredLightingShadowsEnabled = false;
         this.clusteredLightingShadowType = 0;

--- a/src/scene/materials/lit-options.js
+++ b/src/scene/materials/lit-options.js
@@ -49,7 +49,7 @@ class LitOptions {
         this.hasTangents = false;
         this.chunks = [];
 
-        this.pass = 0;
+        this._pass = 0;
         this.alphaTest = false;
         this.forceFragmentPrecision = false;
         this.blendType = BLEND_NONE;

--- a/src/scene/materials/lit-options.js
+++ b/src/scene/materials/lit-options.js
@@ -30,13 +30,13 @@ class LitOptions {
 
         this.vertexColors = false;
         this.lightMapEnabled = false;
-        this.lightMapVertexColors = false;
+        this.useLightMapVertexColors = false;
         this.dirLightMapEnabled = false;
         this.heightMapEnabled = false;
         this.normalMapEnabled = false;
         this.clearCoatNormalMapEnabled = false;
         this.aoMapEnabled = false;
-        this.aoVertexColors = false;
+        this.useAoVertexColors = false;
         this.diffuseMapEnabled = false;
 
         this.useAmbientTint = false;

--- a/src/scene/materials/options.js
+++ b/src/scene/materials/options.js
@@ -1,7 +1,0 @@
-class Options {
-    constructor() {
-        this.chunks = [];
-    }
-}
-
-export { Options };

--- a/src/scene/materials/options.js
+++ b/src/scene/materials/options.js
@@ -1,0 +1,7 @@
+class Options {
+    constructor() {
+        this.chunks = [];
+    }
+}
+
+export { Options };

--- a/src/scene/materials/standard-material-options-builder.js
+++ b/src/scene/materials/standard-material-options-builder.js
@@ -70,6 +70,7 @@ class StandardMaterialOptionsBuilder {
         options.forceUv1 = stdMat.forceUv1;
         options.chunks = stdMat.chunks || '';
 
+        options.pass = pass;
         options.litOptions.pass = pass;
         options.litOptions.alphaTest = stdMat.alphaTest > 0;
         options.litOptions.forceFragmentPrecision = stdMat.forceFragmentPrecision || '';

--- a/src/scene/materials/standard-material-options-builder.js
+++ b/src/scene/materials/standard-material-options-builder.js
@@ -17,6 +17,8 @@ import {
 } from '../constants.js';
 import { _matTex2D } from '../shader-lib/programs/standard.js';
 
+import { LitOptions } from './lit-options.js';
+
 const arraysEqual = (a, b) => {
     if (a.length !== b.length) {
         return false;
@@ -44,7 +46,7 @@ class StandardMaterialOptionsBuilder {
 
     // Minimal options for Depth and Shadow passes
     updateMinRef(options, scene, stdMat, objDefs, staticLightList, pass, sortedLights) {
-        options.litOptions = {};
+        options.litOptions = new LitOptions();
         this._updateSharedOptions(options, scene, stdMat, objDefs, pass);
         this._updateMinOptions(options, stdMat);
         this._updateUVOptions(options, stdMat, objDefs, true);
@@ -52,7 +54,7 @@ class StandardMaterialOptionsBuilder {
     }
 
     updateRef(options, scene, stdMat, objDefs, staticLightList, pass, sortedLights) {
-        options.litOptions = {};
+        options.litOptions = new LitOptions();
         this._updateSharedOptions(options, scene, stdMat, objDefs, pass);
         this._updateEnvOptions(options, stdMat, scene);
         this._updateMaterialOptions(options, stdMat);
@@ -248,7 +250,7 @@ class StandardMaterialOptionsBuilder {
         options.sheenGlossinessTint = 1;
 
         // LIT OPTIONS
-        options.litOptions.ambientTint = options.ambientTint;
+        options.litOptions.useAmbientTint = options.ambientTint;
         options.litOptions.customFragmentShader = stdMat.customFragmentShader;
         options.litOptions.pixelSnap = stdMat.pixelSnap;
 

--- a/src/scene/materials/standard-material-options-builder.js
+++ b/src/scene/materials/standard-material-options-builder.js
@@ -122,13 +122,13 @@ class StandardMaterialOptionsBuilder {
 
         // All texture related lit options
         options.litOptions.lightMapEnabled = options.lightMap;
-        options.litOptions.lightMapVertexColors = options.lightVertexColors;
+        options.litOptions.useLightMapVertexColors = options.lightVertexColors;
         options.litOptions.dirLightMapEnabled = options.dirLightMap;
         options.litOptions.heightMapEnabled = options.heightMap;
         options.litOptions.normalMapEnabled = options.normalMap;
         options.litOptions.clearCoatNormalMapEnabled = options.clearCoatNormalMap;
         options.litOptions.aoMapEnabled = options.aoMap;
-        options.litOptions.aoVertexColors = options.aoVertexColors;
+        options.litOptions.useAoVertexColors = options.aoVertexColors;
         options.litOptions.diffuseMapEnabled = options.diffuseMap;
     }
 

--- a/src/scene/materials/standard-material-options-builder.js
+++ b/src/scene/materials/standard-material-options-builder.js
@@ -46,7 +46,6 @@ class StandardMaterialOptionsBuilder {
 
     // Minimal options for Depth and Shadow passes
     updateMinRef(options, scene, stdMat, objDefs, staticLightList, pass, sortedLights) {
-        options.litOptions = new LitOptions();
         this._updateSharedOptions(options, scene, stdMat, objDefs, pass);
         this._updateMinOptions(options, stdMat);
         this._updateUVOptions(options, stdMat, objDefs, true);
@@ -54,7 +53,6 @@ class StandardMaterialOptionsBuilder {
     }
 
     updateRef(options, scene, stdMat, objDefs, staticLightList, pass, sortedLights) {
-        options.litOptions = new LitOptions();
         this._updateSharedOptions(options, scene, stdMat, objDefs, pass);
         this._updateEnvOptions(options, stdMat, scene);
         this._updateMaterialOptions(options, stdMat);
@@ -281,7 +279,7 @@ class StandardMaterialOptionsBuilder {
         options.litOptions.useSpecularColor = useSpecularColor;
         options.litOptions.enableGGXSpecular = stdMat.enableGGXSpecular;
         options.litOptions.fresnelModel = stdMat.fresnelModel;
-        options.litOptions.useRefraction = (stdMat.refraction || !!stdMat.refractionMap) && (stdMat.useDynamicRefraction || !!options.reflectionSource);
+        options.litOptions.useRefraction = (stdMat.refraction || !!stdMat.refractionMap) && (stdMat.useDynamicRefraction || !!options.litOptions.reflectionSource);
         options.litOptions.useClearCoat = !!stdMat.clearCoat;
         options.litOptions.useSheen = stdMat.useSheen;
         options.litOptions.useIridescence = stdMat.useIridescence && stdMat.iridescence !== 0.0;

--- a/src/scene/materials/standard-material-options-builder.js
+++ b/src/scene/materials/standard-material-options-builder.js
@@ -55,8 +55,8 @@ class StandardMaterialOptionsBuilder {
         this._updateEnvOptions(options, stdMat, scene);
         this._updateMaterialOptions(options, stdMat);
         if (pass === SHADER_FORWARDHDR) {
-            if (options.gamma) options.gamma = GAMMA_SRGBHDR;
-            options.toneMap = TONEMAP_LINEAR;
+            if (options.litOptions.gamma) options.litOptions.gamma = GAMMA_SRGBHDR;
+            options.litOptions.toneMap = TONEMAP_LINEAR;
         }
         options.litOptions.hasTangents = objDefs && ((objDefs & SHADERDEF_TANGENTS) !== 0);
         this._updateLightOptions(options, scene, stdMat, objDefs, sortedLights, staticLightList);
@@ -69,7 +69,6 @@ class StandardMaterialOptionsBuilder {
         options.chunks = stdMat.chunks || '';
 
         options.pass = pass;
-        options.litOptions.pass = pass;
         options.litOptions.alphaTest = stdMat.alphaTest > 0;
         options.litOptions.forceFragmentPrecision = stdMat.forceFragmentPrecision || '';
         options.litOptions.blendType = stdMat.blendType;

--- a/src/scene/materials/standard-material-options-builder.js
+++ b/src/scene/materials/standard-material-options-builder.js
@@ -17,8 +17,6 @@ import {
 } from '../constants.js';
 import { _matTex2D } from '../shader-lib/programs/standard.js';
 
-import { LitOptions } from './lit-options.js';
-
 const arraysEqual = (a, b) => {
     if (a.length !== b.length) {
         return false;

--- a/src/scene/materials/standard-material-options.js
+++ b/src/scene/materials/standard-material-options.js
@@ -1,4 +1,4 @@
-import { LitOptions } from "./lit-options";
+import { LitOptions } from "./lit-options.js";
 
 /**
  * - pass: value of {@link Layer#shaderPass} of the Layer being rendered. Must be set to the

--- a/src/scene/materials/standard-material-options.js
+++ b/src/scene/materials/standard-material-options.js
@@ -1,24 +1,22 @@
 import { LitOptions } from "./lit-options.js";
 
 /**
- * - pass: value of {@link Layer#shaderPass} of the Layer being rendered. Must be set to the
+ * @property {number} pass Value of {@link Layer#shaderPass} of the Layer being rendered. Must be set to the
  * same in {@link LitOptions#pass}.
- * - forceUv1: if UV1 (second set of texture coordinates) is required in the shader. Will be
+ * @property {boolean} forceUv1 If UV1 (second set of texture coordinates) is required in the shader. Will be
  * declared as "vUv1" and passed to the fragment shader.
- * - ambientTint: the value of {@link StandardMaterial#ambientTint}.
- * - diffuseTint: defines if {@link StandardMaterial#diffuse} constant should affect diffuse color.
- * - specularTint: defines if {@link StandardMaterial#specular} constant should affect specular
+ * @property {boolean} ambientTint The value of {@link StandardMaterial#ambientTint}.
+ * @property {boolean} diffuseTint Defines if {@link StandardMaterial#diffuse} constant should affect diffuse color.
+ * @property {boolean} specularTint Defines if {@link StandardMaterial#specular} constant should affect specular
  * color.
- * - metalnessTint: defines if {@link StandardMaterial#metalness} constant should affect metalness
+ * @property {boolean} metalnessTint Defines if {@link StandardMaterial#metalness} constant should affect metalness
  * value.
- * - glossTint: defines if {@link StandardMaterial#shininess} constant should affect glossiness
+ * @property {boolean} glossTint Defines if {@link StandardMaterial#shininess} constant should affect glossiness
  * value.
- * - emissiveTint: defines if {@link StandardMaterial#emissive} constant should affect emission
+ * @property {boolean} emissiveTint Defines if {@link StandardMaterial#emissive} constant should affect emission
  * value.
- * - opacityTint: defines if {@link StandardMaterial#opacity} constant should affect opacity value.
- * - emissiveEncoding: how emissiveMap is encoded. This value is based on Texture#encoding.
- * - lightMapEncoding: how lightMap is encoded. This value is based on on Texture#encoding.
- * - packedNormal: if normal map contains X in RGB, Y in Alpha, and Z must be reconstructed.
+ * @property {boolean} opacityTint Defines if {@link StandardMaterial#opacity} constant should affect opacity value.
+ * @property {boolean} packedNormal If normal map contains X in RGB, Y in Alpha, and Z must be reconstructed.
  *
  */
 class StandardMaterialOptions {
@@ -38,6 +36,15 @@ class StandardMaterialOptions {
         this.packedNormal = false;
 
         this.litOptions = new LitOptions();
+    }
+
+    set pass(p) {
+        this.pass = p;
+        this.litOptions.pass = p;
+    }
+
+    get pass() {
+        return this.pass;
     }
 }
 

--- a/src/scene/materials/standard-material-options.js
+++ b/src/scene/materials/standard-material-options.js
@@ -22,7 +22,7 @@ import { LitOptions } from "./lit-options.js";
 class StandardMaterialOptions {
     constructor() {
         this.chunks = [];
-        this.pass = 0;
+        this._pass = 0;
         this.forceUv1 = false;
         this.ambientTint = false;
         this.diffuseTint = false;
@@ -39,12 +39,12 @@ class StandardMaterialOptions {
     }
 
     set pass(p) {
-        this.pass = p;
-        this.litOptions.pass = p;
+        this._pass = p;
+        this.litOptions._pass = p;
     }
 
     get pass() {
-        return this.pass;
+        return this._pass;
     }
 }
 

--- a/src/scene/materials/standard-material-options.js
+++ b/src/scene/materials/standard-material-options.js
@@ -1,6 +1,41 @@
+import { LitOptions } from "./lit-options";
+
+/**
+ * - forceUv1: if UV1 (second set of texture coordinates) is required in the shader. Will be
+ * declared as "vUv1" and passed to the fragment shader.
+ * - ambientTint: the value of {@link StandardMaterial#ambientTint}.
+ * - diffuseTint: defines if {@link StandardMaterial#diffuse} constant should affect diffuse color.
+ * - specularTint: defines if {@link StandardMaterial#specular} constant should affect specular
+ * color.
+ * - metalnessTint: defines if {@link StandardMaterial#metalness} constant should affect metalness
+ * value.
+ * - glossTint: defines if {@link StandardMaterial#shininess} constant should affect glossiness
+ * value.
+ * - emissiveTint: defines if {@link StandardMaterial#emissive} constant should affect emission
+ * value.
+ * - opacityTint: defines if {@link StandardMaterial#opacity} constant should affect opacity value.
+ * - emissiveEncoding: how emissiveMap is encoded. This value is based on Texture#encoding.
+ * - lightMapEncoding: how lightMap is encoded. This value is based on on Texture#encoding.
+ * - packedNormal: if normal map contains X in RGB, Y in Alpha, and Z must be reconstructed.
+ *
+ */
 class StandardMaterialOptions {
     constructor() {
         this.chunks = [];
+
+        this.forceUv1 = false;
+        this.ambientTint = false;
+        this.diffuseTint = false;
+        this.specularTint = false;
+        this.metalnessTint = false;
+        this.glossTint = false;
+        this.emissiveTint = false;
+        this.opacityTint = false;
+        this.emissiveEncoding = 'linear';
+        this.lightMapEncoding = 'linear';
+        this.packedNormal = false;
+
+        this.litOptions = new LitOptions();
     }
 }
 

--- a/src/scene/materials/standard-material-options.js
+++ b/src/scene/materials/standard-material-options.js
@@ -1,0 +1,7 @@
+class StandardMaterialOptions {
+    constructor() {
+        this.chunks = [];
+    }
+}
+
+export { StandardMaterialOptions };

--- a/src/scene/materials/standard-material-options.js
+++ b/src/scene/materials/standard-material-options.js
@@ -1,6 +1,9 @@
 import { LitOptions } from "./lit-options.js";
 
 /**
+ * The standard material options define a set of options used to control the shader frontend shader generation,
+ * such as textures, tints and multipliers.
+ *
  * @property {number} pass Value of {@link Layer#shaderPass} of the Layer being rendered. Must be set to the
  * same in {@link LitOptions#pass}.
  * @property {boolean} forceUv1 If UV1 (second set of texture coordinates) is required in the shader. Will be
@@ -17,7 +20,6 @@ import { LitOptions } from "./lit-options.js";
  * value.
  * @property {boolean} opacityTint Defines if {@link StandardMaterial#opacity} constant should affect opacity value.
  * @property {boolean} packedNormal If normal map contains X in RGB, Y in Alpha, and Z must be reconstructed.
- *
  */
 class StandardMaterialOptions {
     constructor() {

--- a/src/scene/materials/standard-material-options.js
+++ b/src/scene/materials/standard-material-options.js
@@ -1,6 +1,8 @@
 import { LitOptions } from "./lit-options";
 
 /**
+ * - pass: value of {@link Layer#shaderPass} of the Layer being rendered. Must be set to the
+ * same in {@link LitOptions#pass}.
  * - forceUv1: if UV1 (second set of texture coordinates) is required in the shader. Will be
  * declared as "vUv1" and passed to the fragment shader.
  * - ambientTint: the value of {@link StandardMaterial#ambientTint}.
@@ -22,7 +24,7 @@ import { LitOptions } from "./lit-options";
 class StandardMaterialOptions {
     constructor() {
         this.chunks = [];
-
+        this.pass = 0;
         this.forceUv1 = false;
         this.ambientTint = false;
         this.diffuseTint = false;

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -19,8 +19,6 @@ import { getProgramLibrary } from '../shader-lib/get-program-library.js';
 import { _matTex2D, standard } from '../shader-lib/programs/standard.js';
 import { Material } from './material.js';
 import { StandardMaterialOptionsBuilder } from './standard-material-options-builder.js';
-import { StandardMaterialOptions } from './standard-material-options.js';
-import { LitOptions } from './lit-options.js';
 import { standardMaterialCubemapParameters, standardMaterialTextureParameters } from './standard-material-parameters.js';
 
 // properties that get created on a standard material

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -34,10 +34,11 @@ let _params = new Set();
  * Callback used by {@link StandardMaterial#onUpdateShader}.
  *
  * @callback UpdateShaderCallback
- * @param {*} options - An object with shader generator settings (based on current material and
- * scene properties), that you can change and then return. Properties of the object passed into
- * this function are documented in {@link StandardMaterial#onUpdateShader}.
- * @returns {*} Returned settings will be used by the shader.
+ * @param {StandardMaterialOptions} options - An object with shader generator settings (based on current
+ * material and scene properties), that you can change and then return. Properties of the object passed
+ * into this function are documented in {@link StandardMaterial}. Also contains a member named litOptions
+ * which holds some of the options only used by the lit shader backend {@link LitOptions}.
+ * @returns {StandardMaterialOptions} Returned settings will be used by the shader.
  */
 
 /**

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -20,7 +20,6 @@ import { _matTex2D, standard } from '../shader-lib/programs/standard.js';
 import { Material } from './material.js';
 import { StandardMaterialOptionsBuilder } from './standard-material-options-builder.js';
 import { standardMaterialCubemapParameters, standardMaterialTextureParameters } from './standard-material-parameters.js';
-import { LitOptions } from './lit-options.js';
 
 // properties that get created on a standard material
 const _props = {};
@@ -898,13 +897,6 @@ class StandardMaterial extends Material {
         // execute user callback to modify the options
         if (this.onUpdateShader) {
             options = this.onUpdateShader(options);
-            const litOptions = new LitOptions();
-            for (const key in options) {
-                if (key !== "chunks" &&
-                 litOptions[key] !== undefined) {
-                    Debug.warn(`Option moved to options.litOptions: ${key}`);
-                }
-            }
         }
 
         const processingOptions = new ShaderProcessorOptions(viewUniformFormat, viewBindGroupFormat);

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -19,6 +19,8 @@ import { getProgramLibrary } from '../shader-lib/get-program-library.js';
 import { _matTex2D, standard } from '../shader-lib/programs/standard.js';
 import { Material } from './material.js';
 import { StandardMaterialOptionsBuilder } from './standard-material-options-builder.js';
+import { StandardMaterialOptions } from './standard-material-options.js';
+import { LitOptions } from './lit-options.js';
 import { standardMaterialCubemapParameters, standardMaterialTextureParameters } from './standard-material-parameters.js';
 
 // properties that get created on a standard material
@@ -500,68 +502,8 @@ let _params = new Set();
  * on the same material. For example, you may wish to render a depth or normal pass using textures
  * assigned to the material, a reflection pass with simpler shaders and so on. These properties are
  * split into two sections, generic standard material options and lit options. Properties of the
- * standard material topions passed into this function are:
- * - forceUv1: if UV1 (second set of texture coordinates) is required in the shader. Will be
- * declared as "vUv1" and passed to the fragment shader.
- * - ambientTint: the value of {@link StandardMaterial#ambientTint}.
- * - diffuseTint: defines if {@link StandardMaterial#diffuse} constant should affect diffuse color.
- * - specularTint: defines if {@link StandardMaterial#specular} constant should affect specular
- * color.
- * - metalnessTint: defines if {@link StandardMaterial#metalness} constant should affect metalness
- * value.
- * - glossTint: defines if {@link StandardMaterial#shininess} constant should affect glossiness
- * value.
- * - emissiveTint: defines if {@link StandardMaterial#emissive} constant should affect emission
- * value.
- * - opacityTint: defines if {@link StandardMaterial#opacity} constant should affect opacity value.
- * - emissiveEncoding: how emissiveMap is encoded. This value is based on Texture#encoding.
- * - lightMapEncoding: how lightMap is encoded. This value is based on on Texture#encoding.
- * - packedNormal: if normal map contains X in RGB, Y in Alpha, and Z must be reconstructed.
- *
- * And the properties of the lit options are:
- *
- * - pass: value of {@link Layer#shaderPass} of the Layer being rendered.
- * - chunks: Object containing custom shader chunks that will replace default ones.
- * - customFragmentShader: Completely replace fragment shader with this code.
- * - fog: the type of fog being applied in the shader. See {@link Scene#fog} for the list of
- * possible values.
- * - gamma: the type of gamma correction being applied in the shader. See
- * {@link Scene#gammaCorrection} for the list of possible values.
- * - toneMap: the type of tone mapping being applied in the shader. See {@link Scene#toneMapping}
- * for the list of possible values.
- * - conserveEnergy: the value of {@link StandardMaterial#conserveEnergy}.
- * - occludeSpecular: the value of {@link StandardMaterial#occludeSpecular}.
- * - occludeDirect: the value of {@link StandardMaterial#occludeDirect}.
- * - shadingModel: the value of {@link StandardMaterial#shadingModel}.
- * - fresnelModel: the value of {@link StandardMaterial#fresnelModel}.
- * - cubeMapProjection: the value of {@link StandardMaterial#cubeMapProjection}.
- * - useMetalness: the value of {@link StandardMaterial#useMetalness}.
- * - blendType: the value of {@link Material#blendType}.
- * - twoSidedLighting: the value of {@link Material#twoSidedLighting}.
- * - occludeSpecularFloat: defines if {@link StandardMaterial#occludeSpecularIntensity} constant
- * should affect specular occlusion.
- * - alphaTest: enable alpha testing. See {@link Material#alphaTest}.
- * - alphaToCoverage: enable alpha to coverage. See {@link Material#alphaToCoverage}.
- * - opacityFadesSpecular: enable specular fade. See {@link Material#opacityFadesSpecular}.
- * - ambientSH: if ambient spherical harmonics are used. Ambient SH replace prefiltered cubemap
- * ambient on certain platform (mostly Android) for performance reasons.
- * - useSpecular: if any specular or reflections are needed at all.
- * - fixSeams: if cubemaps require seam fixing (see {@link Texture#options.fixCubemapSeams}).
- * - forceFragmentPrecision: Override fragment shader numeric precision. Can be "lowp", "mediump",
- * "highp" or null to use default.
- * - fastTbn: Use slightly cheaper normal mapping code (skip tangent space normalization). Can look
- * buggy sometimes.
- * - useRefraction: if refraction is used.
- * - skyboxIntensity: if reflected skybox intensity should be modulated.
- * - useCubeMapRotation: if cube map rotation is enabled.
- * - useInstancing: if hardware instancing compatible shader should be generated. Transform is read
- * from per-instance {@link VertexBuffer} instead of shader's uniforms.
- * - useMorphPosition: if morphing code should be generated to morph positions.
- * - useMorphNormal: if morphing code should be generated to morph normals.
- * - reflectionSource: one of "envAtlasHQ", "envAtlas", "cubeMap", "sphereMap"
- * - reflectionEncoding: one of null, "rgbm", "rgbe", "linear", "srgb"
- * - ambientSource: one of "ambientSH", "envAtlas", "constant"
- * - ambientEncoding: one of null, "rgbm", "rgbe", "linear", "srgb"
+ * standard material options are {@link StandardMaterialOptions} and the options for the lit options
+ * are {@link LitOptions}
  * @augments Material
  */
 class StandardMaterial extends Material {

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -501,7 +501,7 @@ let _params = new Set();
  * assigned to the material, a reflection pass with simpler shaders and so on. These properties are
  * split into two sections, generic standard material options and lit options. Properties of the
  * standard material options are {@link StandardMaterialOptions} and the options for the lit options
- * are {@link LitOptions}
+ * are {@link LitOptions}.
  * @augments Material
  */
 class StandardMaterial extends Material {

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -498,30 +498,12 @@ let _params = new Set();
  * properties), that you can change and then return. Returned value will be used instead. This is
  * mostly useful when rendering the same set of objects, but with different shader variations based
  * on the same material. For example, you may wish to render a depth or normal pass using textures
- * assigned to the material, a reflection pass with simpler shaders and so on. Properties of the
- * object passed into this function are:
- *
- * - pass: value of {@link Layer#shaderPass} of the Layer being rendered.
- * - chunks: Object containing custom shader chunks that will replace default ones.
- * - customFragmentShader: Completely replace fragment shader with this code.
+ * assigned to the material, a reflection pass with simpler shaders and so on. These properties are
+ * split into two sections, generic standard material options and lit options. Properties of the
+ * standard material topions passed into this function are:
  * - forceUv1: if UV1 (second set of texture coordinates) is required in the shader. Will be
  * declared as "vUv1" and passed to the fragment shader.
- * - fog: the type of fog being applied in the shader. See {@link Scene#fog} for the list of
- * possible values.
- * - gamma: the type of gamma correction being applied in the shader. See
- * {@link Scene#gammaCorrection} for the list of possible values.
- * - toneMap: the type of tone mapping being applied in the shader. See {@link Scene#toneMapping}
- * for the list of possible values.
  * - ambientTint: the value of {@link StandardMaterial#ambientTint}.
- * - conserveEnergy: the value of {@link StandardMaterial#conserveEnergy}.
- * - occludeSpecular: the value of {@link StandardMaterial#occludeSpecular}.
- * - occludeDirect: the value of {@link StandardMaterial#occludeDirect}.
- * - shadingModel: the value of {@link StandardMaterial#shadingModel}.
- * - fresnelModel: the value of {@link StandardMaterial#fresnelModel}.
- * - cubeMapProjection: the value of {@link StandardMaterial#cubeMapProjection}.
- * - useMetalness: the value of {@link StandardMaterial#useMetalness}.
- * - blendType: the value of {@link Material#blendType}.
- * - twoSidedLighting: the value of {@link Material#twoSidedLighting}.
  * - diffuseTint: defines if {@link StandardMaterial#diffuse} constant should affect diffuse color.
  * - specularTint: defines if {@link StandardMaterial#specular} constant should affect specular
  * color.
@@ -532,26 +514,44 @@ let _params = new Set();
  * - emissiveTint: defines if {@link StandardMaterial#emissive} constant should affect emission
  * value.
  * - opacityTint: defines if {@link StandardMaterial#opacity} constant should affect opacity value.
+ * - emissiveEncoding: how emissiveMap is encoded. This value is based on Texture#encoding.
+ * - lightMapEncoding: how lightMap is encoded. This value is based on on Texture#encoding.
+ * - packedNormal: if normal map contains X in RGB, Y in Alpha, and Z must be reconstructed.
+ *
+ * And the properties of the lit options are:
+ *
+ * - pass: value of {@link Layer#shaderPass} of the Layer being rendered.
+ * - chunks: Object containing custom shader chunks that will replace default ones.
+ * - customFragmentShader: Completely replace fragment shader with this code.
+ * - fog: the type of fog being applied in the shader. See {@link Scene#fog} for the list of
+ * possible values.
+ * - gamma: the type of gamma correction being applied in the shader. See
+ * {@link Scene#gammaCorrection} for the list of possible values.
+ * - toneMap: the type of tone mapping being applied in the shader. See {@link Scene#toneMapping}
+ * for the list of possible values.
+ * - conserveEnergy: the value of {@link StandardMaterial#conserveEnergy}.
+ * - occludeSpecular: the value of {@link StandardMaterial#occludeSpecular}.
+ * - occludeDirect: the value of {@link StandardMaterial#occludeDirect}.
+ * - shadingModel: the value of {@link StandardMaterial#shadingModel}.
+ * - fresnelModel: the value of {@link StandardMaterial#fresnelModel}.
+ * - cubeMapProjection: the value of {@link StandardMaterial#cubeMapProjection}.
+ * - useMetalness: the value of {@link StandardMaterial#useMetalness}.
+ * - blendType: the value of {@link Material#blendType}.
+ * - twoSidedLighting: the value of {@link Material#twoSidedLighting}.
  * - occludeSpecularFloat: defines if {@link StandardMaterial#occludeSpecularIntensity} constant
  * should affect specular occlusion.
  * - alphaTest: enable alpha testing. See {@link Material#alphaTest}.
  * - alphaToCoverage: enable alpha to coverage. See {@link Material#alphaToCoverage}.
  * - opacityFadesSpecular: enable specular fade. See {@link Material#opacityFadesSpecular}.
- * - alphaFade: fade value. See {@link Material#alphaFade}.
- * - sphereMap: if {@link StandardMaterial#sphereMap} is used.
- * - cubeMap: if {@link StandardMaterial#cubeMap} is used.
  * - ambientSH: if ambient spherical harmonics are used. Ambient SH replace prefiltered cubemap
  * ambient on certain platform (mostly Android) for performance reasons.
  * - useSpecular: if any specular or reflections are needed at all.
  * - fixSeams: if cubemaps require seam fixing (see {@link Texture#options.fixCubemapSeams}).
- * - emissiveEncoding: how emissiveMap is encoded. This value is based on Texture#encoding.
- * - lightMapEncoding: how lightMap is encoded. This value is based on on Texture#encoding.
- * - packedNormal: if normal map contains X in RGB, Y in Alpha, and Z must be reconstructed.
  * - forceFragmentPrecision: Override fragment shader numeric precision. Can be "lowp", "mediump",
  * "highp" or null to use default.
  * - fastTbn: Use slightly cheaper normal mapping code (skip tangent space normalization). Can look
  * buggy sometimes.
- * - refraction: if refraction is used.
+ * - useRefraction: if refraction is used.
  * - skyboxIntensity: if reflected skybox intensity should be modulated.
  * - useCubeMapRotation: if cube map rotation is enabled.
  * - useInstancing: if hardware instancing compatible shader should be generated. Transform is read

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -20,6 +20,7 @@ import { _matTex2D, standard } from '../shader-lib/programs/standard.js';
 import { Material } from './material.js';
 import { StandardMaterialOptionsBuilder } from './standard-material-options-builder.js';
 import { standardMaterialCubemapParameters, standardMaterialTextureParameters } from './standard-material-parameters.js';
+import { LitOptions } from './lit-options.js';
 
 // properties that get created on a standard material
 const _props = {};
@@ -897,6 +898,13 @@ class StandardMaterial extends Material {
         // execute user callback to modify the options
         if (this.onUpdateShader) {
             options = this.onUpdateShader(options);
+            const litOptions = new LitOptions();
+            for (const key in options) {
+                if (key !== "chunks" &&
+                 litOptions[key] !== undefined) {
+                    Debug.warn(`Option moved to options.litOptions: ${key}`);
+                }
+            }
         }
 
         const processingOptions = new ShaderProcessorOptions(viewUniformFormat, viewBindGroupFormat);

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -34,11 +34,11 @@ let _params = new Set();
  * Callback used by {@link StandardMaterial#onUpdateShader}.
  *
  * @callback UpdateShaderCallback
- * @param {StandardMaterialOptions} options - An object with shader generator settings (based on current
+ * @param {import('./standard-material-options.js').StandardMaterialOptions} options - An object with shader generator settings (based on current
  * material and scene properties), that you can change and then return. Properties of the object passed
  * into this function are documented in {@link StandardMaterial}. Also contains a member named litOptions
  * which holds some of the options only used by the lit shader backend {@link LitOptions}.
- * @returns {StandardMaterialOptions} Returned settings will be used by the shader.
+ * @returns {import('./standard-material-options.js').StandardMaterialOptions} Returned settings will be used by the shader.
  */
 
 /**

--- a/src/scene/shader-lib/program-library.js
+++ b/src/scene/shader-lib/program-library.js
@@ -5,6 +5,7 @@ import { Shader } from '../../platform/graphics/shader.js';
 
 import { SHADER_FORWARD, SHADER_DEPTH, SHADER_PICK, SHADER_SHADOW } from '../constants.js';
 import { ShaderPass } from '../shader-pass.js';
+import { StandardMaterialOptions } from '../materials/standard-material-options.js';
 
 /**
  * A class responsible for creation and caching of required shaders.
@@ -37,8 +38,8 @@ class ProgramLibrary {
 
         // Unique non-cached programs collection to dump and update game shaders cache
         this._programsCollection = [];
-        this._defaultStdMatOption = {};
-        this._defaultStdMatOptionMin = {};
+        this._defaultStdMatOption = new StandardMaterialOptions();
+        this._defaultStdMatOptionMin = new StandardMaterialOptions();
 
         standardMaterial.shaderOptBuilder.updateRef(
             this._defaultStdMatOption, {}, standardMaterial, null, [], SHADER_FORWARD, null);

--- a/src/scene/shader-lib/program-library.js
+++ b/src/scene/shader-lib/program-library.js
@@ -95,7 +95,7 @@ class ProgramLibrary {
 
             const device = this._device;
             def = generator.createShaderDefinition(device, options);
-            def.name = `${name}-pass:${options.pass}`;
+            def.name = `${name}-pass:${options.litOptions?.pass}`;
             this.definitionsCache.set(key, def);
         }
         return def;
@@ -151,7 +151,7 @@ class ProgramLibrary {
         let opt = {};
         if (name === "standard") {
             // For standard material saving all default values is overkill, so we store only diff
-            const defaultMat = this._getDefaultStdMatOptions(options.pass);
+            const defaultMat = this._getDefaultStdMatOptions(options.litOptions?.pass);
 
             for (const p in options) {
                 if ((options.hasOwnProperty(p) && defaultMat[p] !== options[p]) || p === "pass")
@@ -234,7 +234,7 @@ class ProgramLibrary {
                 // back into the loaded options
                 if (cache[i].name === "standard") {
                     const opt = cache[i].options;
-                    const defaultMat = this._getDefaultStdMatOptions(opt.pass);
+                    const defaultMat = this._getDefaultStdMatOptions(opt.litOptions?.pass);
                     for (const p in defaultMat) {
                         if (defaultMat.hasOwnProperty(p) && opt[p] === undefined)
                             opt[p] = defaultMat[p];

--- a/src/scene/shader-lib/program-library.js
+++ b/src/scene/shader-lib/program-library.js
@@ -96,7 +96,7 @@ class ProgramLibrary {
 
             const device = this._device;
             def = generator.createShaderDefinition(device, options);
-            def.name = `${name}-pass:${options.litOptions?.pass}`;
+            def.name = `${name}-pass:${options.pass}`;
             this.definitionsCache.set(key, def);
         }
         return def;
@@ -152,7 +152,7 @@ class ProgramLibrary {
         let opt = {};
         if (name === "standard") {
             // For standard material saving all default values is overkill, so we store only diff
-            const defaultMat = this._getDefaultStdMatOptions(options.litOptions?.pass);
+            const defaultMat = this._getDefaultStdMatOptions(options.pass);
 
             for (const p in options) {
                 if ((options.hasOwnProperty(p) && defaultMat[p] !== options[p]) || p === "pass")
@@ -235,7 +235,7 @@ class ProgramLibrary {
                 // back into the loaded options
                 if (cache[i].name === "standard") {
                     const opt = cache[i].options;
-                    const defaultMat = this._getDefaultStdMatOptions(opt.litOptions?.pass);
+                    const defaultMat = this._getDefaultStdMatOptions(opt.pass);
                     for (const p in defaultMat) {
                         if (defaultMat.hasOwnProperty(p) && opt[p] === undefined)
                             opt[p] = defaultMat[p];

--- a/src/scene/shader-lib/programs/lit-shader.js
+++ b/src/scene/shader-lib/programs/lit-shader.js
@@ -895,7 +895,7 @@ class LitShader {
             }
         }
 
-        if (options.ambientTint && !useOldAmbient) {
+        if (options.useAmbientTint && !useOldAmbient) {
             code += "uniform vec3 material_ambient;\n";
         }
 
@@ -1017,7 +1017,7 @@ class LitShader {
             }
         }
 
-        if (options.ambientTint && !useOldAmbient) {
+        if (options.useAmbientTint && !useOldAmbient) {
             code += "    dDiffuseLight *= material_ambient;\n";
         }
 

--- a/src/scene/shader-lib/programs/lit-shader.js
+++ b/src/scene/shader-lib/programs/lit-shader.js
@@ -750,7 +750,7 @@ class LitShader {
             }
         }
 
-        const useAo = options.aoMapEnabled || options.aoVertexColors;
+        const useAo = options.aoMapEnabled || options.useAoVertexColors;
 
         if (useAo) {
             code += chunks.aoDiffuseOccPS;
@@ -876,11 +876,11 @@ class LitShader {
         code += chunks.combinePS;
 
         // lightmap support
-        if (options.lightMapEnabled || options.lightMapVertexColors) {
+        if (options.lightMapEnabled || options.useLightMapVertexColors) {
             code += (options.useSpecular && options.dirLightMapEnabled) ? chunks.lightmapDirAddPS : chunks.lightmapAddPS;
         }
 
-        const addAmbient = (!options.lightMapEnabled && !options.lightMapVertexColors) || options.lightMapWithoutAmbient;
+        const addAmbient = (!options.lightMapEnabled && !options.useLightMapVertexColors) || options.lightMapWithoutAmbient;
 
         if (addAmbient) {
             if (options.ambientSource === 'ambientSH') {
@@ -1025,7 +1025,7 @@ class LitShader {
             code += "    occludeDiffuse();\n";
         }
 
-        if (options.lightMapEnabled || options.lightMapVertexColors) {
+        if (options.lightMapEnabled || options.useLightMapVertexColors) {
             code += "    addLightMap();\n";
         }
 

--- a/src/scene/shader-lib/programs/standard.js
+++ b/src/scene/shader-lib/programs/standard.js
@@ -89,7 +89,7 @@ const standard = {
     _getUvSourceExpression: function (transformPropName, uVPropName, options) {
         const transformId = options[transformPropName];
         const uvChannel = options[uVPropName];
-        const isMainPass = ShaderPass.isForward(options.litOptions.pass);
+        const isMainPass = ShaderPass.isForward(options.pass);
 
         let expression;
         if (isMainPass && options.litOptions.nineSlicedMode === SPRITE_RENDERMODE_SLICED) {
@@ -293,7 +293,7 @@ const standard = {
             decl.append(`uniform float textureBias;`);
         }
 
-        if (ShaderPass.isForward(options.litOptions.pass)) {
+        if (ShaderPass.isForward(options.pass)) {
             // parallax
             if (options.heightMap) {
                 // if (!options.normalMap) {

--- a/src/scene/shader-lib/programs/standard.js
+++ b/src/scene/shader-lib/programs/standard.js
@@ -10,14 +10,14 @@ import { ShaderPass } from '../../shader-pass.js';
 import { LitShader } from './lit-shader.js';
 import { ChunkBuilder } from '../chunk-builder.js';
 import { ChunkUtils } from '../chunk-utils.js';
-import { Options } from '../../materials/options.js';
+import { StandardMaterialOptions } from '../../materials/standard-material-options.js';
 
 const _matTex2D = [];
 
 const standard = {
     // Shared Standard Material option structures
-    optionsContext: new Options(),
-    optionsContextMin: new Options(),
+    optionsContext: new StandardMaterialOptions(),
+    optionsContextMin: new StandardMaterialOptions(),
 
     /** @type { Function } */
     generateKey: function (options) {

--- a/src/scene/shader-lib/programs/standard.js
+++ b/src/scene/shader-lib/programs/standard.js
@@ -10,13 +10,14 @@ import { ShaderPass } from '../../shader-pass.js';
 import { LitShader } from './lit-shader.js';
 import { ChunkBuilder } from '../chunk-builder.js';
 import { ChunkUtils } from '../chunk-utils.js';
+import { Options } from '../../materials/options.js';
 
 const _matTex2D = [];
 
 const standard = {
     // Shared Standard Material option structures
-    optionsContext: {},
-    optionsContextMin: {},
+    optionsContext: new Options(),
+    optionsContextMin: new Options(),
 
     /** @type { Function } */
     generateKey: function (options) {


### PR DESCRIPTION
### Description

Fixes #4871. 

The backend options for the lit shader are now defined in their own class, which makes it possible to know what options are available. 

Additionally, this allows us to validate options which might have moved to the backend object, and inform developers if they are still expecting the option to be there. This primarily pertains to options set through the onUpdateShader callback. 