### PR TITLE
Partial Depth-GrabPass support for WebGPU

### DIFF
--- a/examples/src/examples/graphics/ground-fog.tsx
+++ b/examples/src/examples/graphics/ground-fog.tsx
@@ -71,8 +71,10 @@ class GroundFogExample {
                 vec4 diffusTexture2 = texture2D (uTexture, texCoord2);
                 float alpha = 0.5 * (diffusTexture0.r + diffusTexture1.r + diffusTexture2.r);
 
+                // use built-in getGrabScreenPos function to convert screen position to grab texture uv coords
+                vec2 screenCoord = getGrabScreenPos(screenPos);
+
                 // read the depth from the depth buffer
-                vec2 screenCoord = (screenPos.xy / screenPos.w) * 0.5 + 0.5;
                 float sceneDepth = getLinearScreenDepth(screenCoord) * camera_params.x;
 
                 // depth of the current fragment (on the fog plane)
@@ -221,7 +223,7 @@ class GroundFogExample {
                 // @ts-ignore
                 const vertex = `#define VERTEXSHADER\n` + pc.shaderChunks.screenDepthPS + files['shader.vert'];
                 // @ts-ignore
-                const fragment = `precision ${app.graphicsDevice.precision} float;\n` + pc.shaderChunks.screenDepthPS + files['shader.frag'];
+                const fragment = pc.shaderChunks.screenDepthPS + files['shader.frag'];
                 const shader = pc.createShaderFromCode(app.graphicsDevice, vertex, fragment, 'GroundFogShader');
 
                 // and set up a material using this shader

--- a/src/platform/graphics/shader-chunks/frag/shared.js
+++ b/src/platform/graphics/shader-chunks/frag/shared.js
@@ -1,0 +1,13 @@
+export default /* glsl */`
+
+// convert clip space position into texture coordinates to sample scene grab textures
+vec2 getGrabScreenPos(vec4 clipPos) {
+    vec2 uv = (clipPos.xy / clipPos.w) * 0.5 + 0.5;
+
+    #ifdef WEBGPU
+        uv.y = 1.0 - uv.y;
+    #endif
+
+    return uv;
+}
+`;

--- a/src/platform/graphics/shader-utils.js
+++ b/src/platform/graphics/shader-utils.js
@@ -11,6 +11,7 @@ import gles3FS from './shader-chunks/frag/gles3.js';
 import gles3VS from './shader-chunks/vert/gles3.js';
 import webgpuFS from './shader-chunks/frag/webgpu.js';
 import webgpuVS from './shader-chunks/vert/webgpu.js';
+import sharedFS from './shader-chunks/frag/shared.js';
 
 const _attrib2Semantic = {
     vertex_position: SEMANTIC_POSITION,
@@ -77,6 +78,7 @@ class ShaderUtils {
         ShaderUtils.versionCode(device) +
             ShaderUtils.precisionCode(device) + '\n' +
             fragDefines +
+            sharedFS +
             ShaderUtils.getShaderNameCode(name) +
             (options.fragmentCode || ShaderUtils.dummyFragmentCode());
 

--- a/src/platform/graphics/webgpu/webgpu-render-target.js
+++ b/src/platform/graphics/webgpu/webgpu-render-target.js
@@ -1,4 +1,4 @@
-import { Debug } from '../../../core/debug.js';
+import { Debug, DebugHelper } from '../../../core/debug.js';
 
 /**
  * A WebGPU implementation of the RenderTarget.
@@ -135,8 +135,14 @@ class WebgpuRenderTarget {
                 usage: GPUTextureUsage.RENDER_ATTACHMENT
             };
 
+            // single sampled depth buffer can be copied out (grab pass), multisampled cannot
+            if (samples <= 1) {
+                depthTextureDesc.usage |= GPUTextureUsage.COPY_SRC;
+            }
+
             // allocate depth buffer
             this.depthTexture = wgpu.createTexture(depthTextureDesc);
+            DebugHelper.setLabel(this.depthTexture, `${renderTarget.name}.depthTexture`);
 
             // @type {GPURenderPassDepthStencilAttachment}
             this.renderPassDescriptor.depthStencilAttachment = {

--- a/src/platform/graphics/webgpu/webgpu-texture.js
+++ b/src/platform/graphics/webgpu/webgpu-texture.js
@@ -103,7 +103,27 @@ class WebgpuTexture {
         this.gpuTexture = wgpu.createTexture(this.descr);
         DebugHelper.setLabel(this.gpuTexture, texture.name);
 
-        this.view = this.gpuTexture.createView();
+        // default texture view descriptor
+        // type {GPUTextureViewDescriptor}
+        const textureDescr = this.descr;
+        const viewDescr = {
+            format: textureDescr.format,
+            dimension: textureDescr.dimension,
+            aspect: 'all',
+            baseMipLevel: 0,
+            mipLevelCount: textureDescr.mipLevelCount,
+            baseArrayLayer: 0,
+            arrayLayerCount: 1
+        };
+
+        // some format require custom default texture view
+        if (this.texture.format === PIXELFORMAT_DEPTHSTENCIL) {
+            // we expose the depth part of the format
+            viewDescr.format = 'depth24plus';
+            viewDescr.aspect = 'depth-only';
+        }
+
+        this.view = this.gpuTexture.createView(viewDescr);
         DebugHelper.setLabel(this.view, `DefaultView: ${this.texture.name}`);
     }
 
@@ -133,7 +153,7 @@ class WebgpuTexture {
             };
 
             // TODO: this is temporary and needs to be made generic
-            if (this.texture.format === PIXELFORMAT_RGBA32F) {
+            if (this.texture.format === PIXELFORMAT_RGBA32F || this.texture.format === PIXELFORMAT_DEPTHSTENCIL) {
                 descr.magFilter = 'nearest';
                 descr.minFilter = 'nearest';
                 descr.mipmapFilter = 'nearest';

--- a/src/platform/graphics/webgpu/webgpu-vertex-buffer-layout.js
+++ b/src/platform/graphics/webgpu/webgpu-vertex-buffer-layout.js
@@ -64,7 +64,7 @@ class WebgpuVertexBufferLayout {
                 const location = semanticToLocation[element.name];
 
                 // A WGL shader needs attributes to have matching types, but glslang translator we use does not allow us to set those
-                Debug.assert(element.dataType === TYPE_FLOAT32, `Only float vertex attributes are supported, ${element.dataType} is not supported, semantic: ${element.name}.`);
+                Debug.assert(element.dataType === TYPE_FLOAT32, `Only float vertex attributes are supported, ${element.dataType} is not supported, semantic: ${element.name}.`, element);
 
                 attributes.push({
                     shaderLocation: location,

--- a/src/scene/shader-lib/chunks/lit/frag/refractionDynamic.js
+++ b/src/scene/shader-lib/chunks/lit/frag/refractionDynamic.js
@@ -26,15 +26,9 @@ void addRefraction() {
 
     // Project to texture space so we can sample it
     vec4 projectionPoint = matrix_viewProjection * pointOfRefraction;
-    vec2 uv = projectionPoint.xy / projectionPoint.ww;
-    uv += vec2(1.0);
-    uv *= vec2(0.5);
 
-    // Grab pass texture is upside down.
-    // TODO: At some point we should create some macro.
-    #ifdef WEBGPU
-        uv.y = 1.0 - uv.y;
-    #endif
+    // use built-in getGrabScreenPos function to convert screen position to grab texture uv coords
+    vec2 uv = getGrabScreenPos(projectionPoint);
 
     #ifdef SUPPORTS_TEXLOD
         // Use IOR and roughness to select mip


### PR DESCRIPTION
- depth grabpass texture only works when render target / framebuffer is single sampled, by copying out a depth texture. For multisampled case, WebGPU does not allow us to resolve / copy the multisampled depth, and a manual resolve using custom shader will need to be implemented in the future
- added a shared chunk to graphics, which gets included in all fragment shaders, for global built-in functions. Currently contains a function to generate texture coordinates for sampling from grab pass, and this handles the upside down case for WebGPU.