### PR TITLE
Partial cubemap support for WebGPU

### DIFF
--- a/scripts/utils/cubemap-renderer.js
+++ b/scripts/utils/cubemap-renderer.js
@@ -46,6 +46,7 @@ CubemapRenderer.prototype.initialize = function () {
 
     // Create cubemap render target with specified resolution and mipmap generation
     this.cubeMap = new pc.Texture(this.app.graphicsDevice, {
+        name: this.entity.name + ':CubemapRenderer-' + resolution,
         width: resolution,
         height: resolution,
         format: pc.PIXELFORMAT_RGBA8,

--- a/src/platform/graphics/bind-group-format.js
+++ b/src/platform/graphics/bind-group-format.js
@@ -1,9 +1,18 @@
 import { TRACEID_BINDGROUPFORMAT_ALLOC } from '../../core/constants.js';
 import { Debug, DebugHelper } from '../../core/debug.js';
 
-import { TEXTUREDIMENSION_2D, SAMPLETYPE_FLOAT, SAMPLETYPE_DEPTH } from './constants.js';
+import {
+    TEXTUREDIMENSION_2D, TEXTUREDIMENSION_CUBE, TEXTUREDIMENSION_3D,
+    SAMPLETYPE_FLOAT, SAMPLETYPE_DEPTH
+} from './constants.js';
 
 let id = 0;
+
+const textureDimensionInfo = {
+    [TEXTUREDIMENSION_2D]: 'texture2D',
+    [TEXTUREDIMENSION_CUBE]: 'textureCube',
+    [TEXTUREDIMENSION_3D]: 'texture3D'
+};
 
 /**
  * @ignore
@@ -112,11 +121,13 @@ class BindGroupFormat {
         let bindIndex = this.bufferFormats.length;
         this.textureFormats.forEach((format) => {
 
-            // TODO: suport different types of textures and samplers
-            Debug.assert(format.textureDimension === TEXTUREDIMENSION_2D);
-            Debug.assert(format.sampleType !== SAMPLETYPE_DEPTH);
+            const textureType = textureDimensionInfo[format.textureDimension];
+            Debug.assert(textureType, "Unsupported texture type");
 
-            code += `layout(set = ${bindGroup}, binding = ${bindIndex++}) uniform texture2D ${format.name};\n` +
+            // TODO: suport depth samplers
+            Debug.assert(format.sampleType !== SAMPLETYPE_DEPTH, format);
+
+            code += `layout(set = ${bindGroup}, binding = ${bindIndex++}) uniform ${textureType} ${format.name};\n` +
                     `layout(set = ${bindGroup}, binding = ${bindIndex++}) uniform sampler ${format.name}_sampler;\n`;
         });
 

--- a/src/platform/graphics/shader-chunks/frag/webgpu.js
+++ b/src/platform/graphics/shader-chunks/frag/webgpu.js
@@ -9,9 +9,9 @@ layout(location = 0) out highp vec4 pc_fragColor;
 #define texture2D(res, uv) texture(sampler2D(res, res ## _sampler), uv)
 #define texture2DBias(res, uv, bias) texture(sampler2D(res, res ## _sampler), uv, bias)
 #define texture2DLodEXT(res, uv, lod) textureLod(sampler2D(res, res ## _sampler), uv, lod)
+#define textureCube(res, uv) texture(samplerCube(res, res ## _sampler), uv)
 
 // TODO: implement other texture sampling macros
-// #define textureCube texture
 // #define texture2DProj textureProj
 // #define texture2DProjLodEXT textureProjLod
 // #define textureCubeLodEXT textureLod

--- a/src/platform/graphics/shader-utils.js
+++ b/src/platform/graphics/shader-utils.js
@@ -75,7 +75,7 @@ class ShaderUtils {
         // fragment code
         const fragDefines = options.fragmentDefines || getDefines(webgpuFS, gles3FS, gles2FS, false);
         const fragCode = (options.fragmentPreamble || '') +
-        ShaderUtils.versionCode(device) +
+            ShaderUtils.versionCode(device) +
             ShaderUtils.precisionCode(device) + '\n' +
             fragDefines +
             sharedFS +
@@ -134,27 +134,32 @@ class ShaderUtils {
 
         let code = '';
 
+        if (forcePrecision && forcePrecision !== 'highp' && forcePrecision !== 'mediump' && forcePrecision !== 'lowp') {
+            forcePrecision = null;
+        }
+
+        if (forcePrecision) {
+            if (forcePrecision === 'highp' && device.maxPrecision !== 'highp') {
+                forcePrecision = 'mediump';
+            }
+            if (forcePrecision === 'mediump' && device.maxPrecision === 'lowp') {
+                forcePrecision = 'lowp';
+            }
+        }
+
+        const precision = forcePrecision ? forcePrecision : device.precision;
+
         if (device.deviceType === DEVICETYPE_WEBGL) {
 
-            if (forcePrecision && forcePrecision !== 'highp' && forcePrecision !== 'mediump' && forcePrecision !== 'lowp') {
-                forcePrecision = null;
-            }
-
-            if (forcePrecision) {
-                if (forcePrecision === 'highp' && device.maxPrecision !== 'highp') {
-                    forcePrecision = 'mediump';
-                }
-                if (forcePrecision === 'mediump' && device.maxPrecision === 'lowp') {
-                    forcePrecision = 'lowp';
-                }
-            }
-
-            const precision = forcePrecision ? forcePrecision : device.precision;
             code = `precision ${precision} float;\n`;
 
             if (device.webgl2) {
                 code += `precision ${precision} sampler2DShadow;\n`;
             }
+
+        } else { // WebGPU
+
+            code = `precision ${precision} float;\nprecision ${precision} int;\n`;
         }
 
         return code;

--- a/src/platform/graphics/webgpu/webgpu-render-target.js
+++ b/src/platform/graphics/webgpu/webgpu-render-target.js
@@ -159,7 +159,19 @@ class WebgpuRenderTarget {
         this.renderPassDescriptor.colorAttachments = [colorAttachment];
 
         const colorBuffer = renderTarget.colorBuffer;
-        const colorView = colorBuffer ? colorBuffer.impl.getView(device) : null;
+        let colorView = null;
+        if (colorBuffer) {
+            colorView = colorBuffer.impl.getView(device);
+
+            // cubemap face view - face is a single 2d array layer in order [+X, -X, +Y, -Y, +Z, -Z]
+            if (colorBuffer.cubemap) {
+                colorView = colorBuffer.impl.createView({
+                    dimension: '2d',
+                    baseArrayLayer: renderTarget.face,
+                    arrayLayerCount: 1
+                });
+            }
+        }
 
         // multi-sampled color buffer
         if (samples > 1) {

--- a/src/platform/graphics/webgpu/webgpu-shader.js
+++ b/src/platform/graphics/webgpu/webgpu-shader.js
@@ -48,19 +48,27 @@ class WebgpuShader {
     }
 
     process() {
+        const shader = this.shader;
+
         // process the shader source to allow for uniforms
-        const processed = ShaderProcessor.run(this.shader.device, this.shader.definition, this.shader);
+        const processed = ShaderProcessor.run(shader.device, shader.definition, shader);
 
         // keep reference to processed shaders in debug mode
         Debug.call(() => {
             this.processed = processed;
         });
 
-        this._vertexCode = this.transpile(processed.vshader, 'vertex', this.shader.definition.vshader);
-        this._fragmentCode = this.transpile(processed.fshader, 'fragment', this.shader.definition.fshader);
+        this._vertexCode = this.transpile(processed.vshader, 'vertex', shader.definition.vshader);
+        this._fragmentCode = this.transpile(processed.fshader, 'fragment', shader.definition.fshader);
 
-        this.shader.meshUniformBufferFormat = processed.meshUniformBufferFormat;
-        this.shader.meshBindGroupFormat = processed.meshBindGroupFormat;
+        if (!(this._vertexCode && this._fragmentCode)) {
+            shader.failed = true;
+        } else {
+            shader.ready = true;
+        }
+
+        shader.meshUniformBufferFormat = processed.meshUniformBufferFormat;
+        shader.meshBindGroupFormat = processed.meshBindGroupFormat;
     }
 
     transpile(src, shaderType, originalSrc) {


### PR DESCRIPTION
- cubemap can be used by the shader, and it can be used as a render target
- upload of texture data into a cubemap is still not supported
- the render target cubemap is flipped upside-down. Setting RenderTarget.flipY to false instead of true (as required by WebGl) fixes this. This will be addressed at a later stage.
- refactor of shader precision code generation set it up for WebGPU shaders
- improved handling of failed-to-compile webgpu shaders by skipping the drawCall, instead of trying to render it and bringing down the whole rendering.

https://user-images.githubusercontent.com/59932779/205905854-23c76512-5524-43a9-9304-bc954e09343d.mov

