### PR TITLE
[Anim Binder] Animate multiple valid morph instances

### DIFF
--- a/src/framework/anim/binder/default-anim-binder.js
+++ b/src/framework/anim/binder/default-anim-binder.js
@@ -85,18 +85,27 @@ class DefaultAnimBinder {
                     weightName = Number(weightName);
                 }
                 const meshInstances = findMeshInstances(node);
+                let setters;
                 if (meshInstances) {
                     for (let i = 0; i < meshInstances.length; ++i) {
                         if (meshInstances[i].node.name === node.name && meshInstances[i].morphInstance) {
+                            if (!setters) setters = [];
                             const morphInstance = meshInstances[i].morphInstance;
                             const func = (value) => {
                                 morphInstance.setWeight(weightName, value[0]);
                             };
-                            return DefaultAnimBinder.createAnimTarget(func, 'number', 1, node, `weight.${weightName}`);
+                            setters.push(func);
                         }
                     }
                 }
-
+                if (setters) {
+                    const callSetters = (value) => {
+                        for (let i = 0; i < setters.length; ++i) {
+                            setters[i](value);
+                        }
+                    };
+                    return DefaultAnimBinder.createAnimTarget(callSetters, 'number', 1, node, `weight.${weightName}`);
+                }
                 return null;
             },
             'materialTexture': (node, textureName) => {


### PR DESCRIPTION
Currently when binding a morph target animation curve to an Entity, the weight handler creates a single AnimTarget instance which can be used to animate the first valid MorphInstance it finds for that Entity. This AnimTarget should instead update all valid MorphInstances.

Fixes #

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
