### PR TITLE
Split ShadowRenderer into class for local and clsas for directional lights

### DIFF
--- a/src/framework/lightmapper/lightmapper.js
+++ b/src/framework/lightmapper/lightmapper.js
@@ -75,7 +75,7 @@ class Lightmapper {
         this.scene = scene;
         this.renderer = renderer;
         this.assets = assets;
-        this.shadowMapCache = renderer._shadowRenderer.shadowMapCache;
+        this.shadowMapCache = renderer.shadowMapCache;
 
         this._tempSet = new Set();
         this._initCalled = false;
@@ -852,12 +852,12 @@ class Lightmapper {
             }
 
             if (light.type === LIGHTTYPE_DIRECTIONAL) {
-                this.renderer._shadowRenderer.cullDirectional(light, casters, this.camera);
+                this.renderer._shadowRendererDirectional.cull(light, casters, this.camera);
+                this.renderer.renderShadowsDirectional(lightArray[light.type], this.camera);
             } else {
-                this.renderer._shadowRenderer.cullLocal(light, casters);
+                this.renderer._shadowRendererLocal.cull(light, casters);
+                this.renderer.renderShadowsLocal(lightArray[light.type], this.camera);
             }
-
-            this.renderer.renderShadows(lightArray[light.type], this.camera);
         }
 
         return true;

--- a/src/scene/renderer/shadow-map-cache.js
+++ b/src/scene/renderer/shadow-map-cache.js
@@ -11,22 +11,22 @@ import { ShadowMap } from './shadow-map.js';
 class ShadowMapCache {
     constructor() {
         // maps a shadow map key to an array of shadow maps in the cache
-        this.shadowMapCache = new Map();
+        this.cache = new Map();
     }
 
     destroy() {
         this.clear();
-        this.shadowMapCache = null;
+        this.cache = null;
     }
 
     // remove all shadowmaps from the cache
     clear() {
-        this.shadowMapCache.forEach((shadowMaps) => {
+        this.cache.forEach((shadowMaps) => {
             shadowMaps.forEach((shadowMap) => {
                 shadowMap.destroy();
             });
         });
-        this.shadowMapCache.clear();
+        this.cache.clear();
     }
 
     // generates a string key for the shadow map required by the light
@@ -42,7 +42,7 @@ class ShadowMapCache {
 
         // get matching shadow buffer from the cache
         const key = this.getKey(light);
-        const shadowMaps = this.shadowMapCache.get(key);
+        const shadowMaps = this.cache.get(key);
         if (shadowMaps && shadowMaps.length) {
             return shadowMaps.pop();
         }
@@ -56,11 +56,11 @@ class ShadowMapCache {
     // returns shadow map for the light back to the cache
     add(light, shadowMap) {
         const key = this.getKey(light);
-        const shadowMaps = this.shadowMapCache.get(key);
+        const shadowMaps = this.cache.get(key);
         if (shadowMaps) {
             shadowMaps.push(shadowMap);
         } else {
-            this.shadowMapCache.set(key, [shadowMap]);
+            this.cache.set(key, [shadowMap]);
         }
     }
 }

--- a/src/scene/renderer/shadow-renderer-directional.js
+++ b/src/scene/renderer/shadow-renderer-directional.js
@@ -1,0 +1,158 @@
+import { Vec3 } from '../../core/math/vec3.js';
+import { Mat4 } from '../../core/math/mat4.js';
+import { BoundingBox } from '../../core/shape/bounding-box.js';
+
+import { ShadowRenderer } from "./shadow-renderer.js";
+import { ShadowMap } from './shadow-map.js';
+
+const visibleSceneAabb = new BoundingBox();
+const center = new Vec3();
+const shadowCamView = new Mat4();
+
+const aabbPoints = [
+    new Vec3(), new Vec3(), new Vec3(), new Vec3(),
+    new Vec3(), new Vec3(), new Vec3(), new Vec3()
+];
+
+// evaluate depth range the aabb takes in the space of the camera
+const _depthRange = { min: 0, max: 0 };
+function getDepthRange(cameraViewMatrix, aabbMin, aabbMax) {
+    aabbPoints[0].x = aabbPoints[1].x = aabbPoints[2].x = aabbPoints[3].x = aabbMin.x;
+    aabbPoints[1].y = aabbPoints[3].y = aabbPoints[7].y = aabbPoints[5].y = aabbMin.y;
+    aabbPoints[2].z = aabbPoints[3].z = aabbPoints[6].z = aabbPoints[7].z = aabbMin.z;
+    aabbPoints[4].x = aabbPoints[5].x = aabbPoints[6].x = aabbPoints[7].x = aabbMax.x;
+    aabbPoints[0].y = aabbPoints[2].y = aabbPoints[4].y = aabbPoints[6].y = aabbMax.y;
+    aabbPoints[0].z = aabbPoints[1].z = aabbPoints[4].z = aabbPoints[5].z = aabbMax.z;
+
+    let minz = 9999999999;
+    let maxz = -9999999999;
+
+    for (let i = 0; i < 8; ++i) {
+        cameraViewMatrix.transformPoint(aabbPoints[i], aabbPoints[i]);
+        const z = aabbPoints[i].z;
+        if (z < minz) minz = z;
+        if (z > maxz) maxz = z;
+    }
+
+    _depthRange.min = minz;
+    _depthRange.max = maxz;
+    return _depthRange;
+}
+
+/**
+ * @ignore
+ */
+class ShadowRendererDirectional extends ShadowRenderer {
+    // cull directional shadow map
+    cull(light, drawCalls, camera) {
+
+        // force light visibility if function was manually called
+        light.visibleThisFrame = true;
+
+        if (!light._shadowMap) {
+            light._shadowMap = ShadowMap.create(this.device, light);
+        }
+
+        // generate splits for the cascades
+        const nearDist = camera._nearClip;
+        this.generateSplitDistances(light, nearDist, light.shadowDistance);
+
+        for (let cascade = 0; cascade < light.numCascades; cascade++) {
+
+            const lightRenderData = light.getRenderData(camera, cascade);
+            const shadowCam = lightRenderData.shadowCamera;
+
+            // assign render target
+            // Note: this is done during rendering for all shadow maps, but do it here for the case shadow rendering for the directional light
+            // is disabled - we need shadow map to be assigned for rendering to work even in this case. This needs further refactoring - as when
+            // shadow rendering is set to SHADOWUPDATE_NONE, we should not even execute shadow map culling
+            shadowCam.renderTarget = light._shadowMap.renderTargets[0];
+
+            // viewport
+            lightRenderData.shadowViewport.copy(light.cascades[cascade]);
+            lightRenderData.shadowScissor.copy(light.cascades[cascade]);
+
+            const shadowCamNode = shadowCam._node;
+            const lightNode = light._node;
+
+            shadowCamNode.setPosition(lightNode.getPosition());
+
+            // Camera looks down the negative Z, and directional light points down the negative Y
+            shadowCamNode.setRotation(lightNode.getRotation());
+            shadowCamNode.rotateLocal(-90, 0, 0);
+
+            // get camera's frustum corners for the cascade, convert them to world space and find their center
+            const frustumNearDist = cascade === 0 ? nearDist : light._shadowCascadeDistances[cascade - 1];
+            const frustumFarDist = light._shadowCascadeDistances[cascade];
+            const frustumPoints = camera.getFrustumCorners(frustumNearDist, frustumFarDist);
+            center.set(0, 0, 0);
+            const cameraWorldMat = camera.node.getWorldTransform();
+            for (let i = 0; i < 8; i++) {
+                cameraWorldMat.transformPoint(frustumPoints[i], frustumPoints[i]);
+                center.add(frustumPoints[i]);
+            }
+            center.mulScalar(1 / 8);
+
+            // radius of the world space bounding sphere for the frustum slice
+            let radius = 0;
+            for (let i = 0; i < 8; i++) {
+                const dist = frustumPoints[i].sub(center).length();
+                if (dist > radius)
+                    radius = dist;
+            }
+
+            // axis of light coordinate system
+            const right = shadowCamNode.right;
+            const up = shadowCamNode.up;
+            const lightDir = shadowCamNode.forward;
+
+            // transform the sphere's center into the center of the shadow map, pixel aligned.
+            // this makes the shadow map stable and avoids shimmering on the edges when the camera moves
+            const sizeRatio = 0.25 * light._shadowResolution / radius;
+            const x = Math.ceil(center.dot(up) * sizeRatio) / sizeRatio;
+            const y = Math.ceil(center.dot(right) * sizeRatio) / sizeRatio;
+
+            const scaledUp = up.mulScalar(x);
+            const scaledRight = right.mulScalar(y);
+            const dot = center.dot(lightDir);
+            const scaledDir = lightDir.mulScalar(dot);
+            center.add2(scaledUp, scaledRight).add(scaledDir);
+
+            // look at the center from far away to include all casters during culling
+            shadowCamNode.setPosition(center);
+            shadowCamNode.translateLocal(0, 0, 1000000);
+            shadowCam.nearClip = 0.01;
+            shadowCam.farClip = 2000000;
+            shadowCam.orthoHeight = radius;
+
+            // cull shadow casters
+            this.renderer.updateCameraFrustum(shadowCam);
+            this.cullShadowCasters(drawCalls, lightRenderData.visibleCasters, shadowCam);
+
+            // find out AABB of visible shadow casters
+            let emptyAabb = true;
+            const visibleCasters = lightRenderData.visibleCasters;
+            for (let i = 0; i < visibleCasters.length; i++) {
+                const meshInstance = visibleCasters[i];
+
+                if (emptyAabb) {
+                    emptyAabb = false;
+                    visibleSceneAabb.copy(meshInstance.aabb);
+                } else {
+                    visibleSceneAabb.add(meshInstance.aabb);
+                }
+            }
+
+            // calculate depth range of the caster's AABB from the point of view of the shadow camera
+            shadowCamView.copy(shadowCamNode.getWorldTransform()).invert();
+            const depthRange = getDepthRange(shadowCamView, visibleSceneAabb.getMin(), visibleSceneAabb.getMax());
+
+            // adjust shadow camera's near and far plane to the depth range of casters to maximize precision
+            // of values stored in the shadow map. Make it slightly larger to avoid clipping on near / far plane.
+            shadowCamNode.translateLocal(0, 0, depthRange.max + 0.1);
+            shadowCam.farClip = depthRange.max - depthRange.min + 0.2;
+        }
+    }
+}
+
+export { ShadowRendererDirectional };

--- a/src/scene/renderer/shadow-renderer-local.js
+++ b/src/scene/renderer/shadow-renderer-local.js
@@ -1,0 +1,71 @@
+import { math } from '../../core/math/math.js';
+
+import { ShadowRenderer } from "./shadow-renderer.js";
+import { ShadowMap } from './shadow-map.js';
+import {
+    LIGHTTYPE_OMNI, LIGHTTYPE_SPOT
+} from '../constants.js';
+
+/**
+ * @ignore
+ */
+class ShadowRendererLocal extends ShadowRenderer {
+    // cull local shadow map
+    cull(light, drawCalls) {
+
+        const isClustered = this.renderer.scene.clusteredLightingEnabled;
+
+        // force light visibility if function was manually called
+        light.visibleThisFrame = true;
+
+        // allocate shadow map unless in clustered lighting mode
+        if (!isClustered) {
+            if (!light._shadowMap) {
+                light._shadowMap = ShadowMap.create(this.device, light);
+            }
+        }
+
+        const type = light._type;
+        const faceCount = type === LIGHTTYPE_SPOT ? 1 : 6;
+
+        for (let face = 0; face < faceCount; face++) {
+
+            // render data are shared between cameras for local lights, so pass null for camera
+            const lightRenderData = light.getRenderData(null, face);
+            const shadowCam = lightRenderData.shadowCamera;
+
+            shadowCam.nearClip = light.attenuationEnd / 1000;
+            shadowCam.farClip = light.attenuationEnd;
+
+            const shadowCamNode = shadowCam._node;
+            const lightNode = light._node;
+            shadowCamNode.setPosition(lightNode.getPosition());
+
+            if (type === LIGHTTYPE_SPOT) {
+                shadowCam.fov = light._outerConeAngle * 2;
+
+                // Camera looks down the negative Z, and spot light points down the negative Y
+                shadowCamNode.setRotation(lightNode.getRotation());
+                shadowCamNode.rotateLocal(-90, 0, 0);
+
+            } else if (type === LIGHTTYPE_OMNI) {
+
+                // when rendering omni shadows to an atlas, use larger fov by few pixels to allow shadow filtering to stay on a single face
+                if (isClustered) {
+                    const tileSize = this.lightTextureAtlas.shadowAtlasResolution * light.atlasViewport.z / 3;    // using 3x3 for cubemap
+                    const texelSize = 2 / tileSize;
+                    const filterSize = texelSize * this.lightTextureAtlas.shadowEdgePixels;
+                    shadowCam.fov = Math.atan(1 + filterSize) * math.RAD_TO_DEG * 2;
+                } else {
+                    shadowCam.fov = 90;
+                }
+            }
+
+            // cull shadow casters
+            this.renderer.updateCameraFrustum(shadowCam);
+            this.cullShadowCasters(drawCalls, lightRenderData.visibleCasters, shadowCam);
+        }
+    }
+}
+
+export { ShadowRendererLocal };


### PR DESCRIPTION
- no functionality changes, simply splitting the class and moving culling function out, and a custom simplified functions in forward renderer
- in preparation of conversion of shadow renderer into render passes, allowing directional shadows to be done in larger separation