### PR TITLE
Collision offset changes needed for Editor integration

### DIFF
--- a/src/framework/components/collision/component.js
+++ b/src/framework/components/collision/component.js
@@ -39,7 +39,7 @@ const _quat = new Quat();
  * Defaults to "box".
  * @property {Vec3} halfExtents The half-extents of the
  * box-shaped collision volume in the x, y and z axes. Defaults to [0.5, 0.5, 0.5].
- * @property {Vec3} linearOffset The positional offset of the collision shape from the Entity position in local space.
+ * @property {Vec3} linearOffset The positional offset of the collision shape from the Entity position along the local axes.
  * Defaults to [0, 0, 0].
  * @property {Quat} angularOffset The rotational offset of the collision shape from the Entity rotation in local space.
  * Defaults to identity.

--- a/src/framework/components/collision/system.js
+++ b/src/framework/components/collision/system.js
@@ -650,7 +650,13 @@ class CollisionComponentSystem extends ComponentSystem {
         }
 
         if (Array.isArray(data.angularOffset)) {
-            data.angularOffset = new Quat(data.angularOffset);
+            // Allow for euler angles to be passed as a 3 length array
+            const values = data.angularOffset;
+            if (values.length === 3) {
+                data.angularOffset = new Quat().setFromEulerAngles(values[0], values[1], values[2]);
+            } else {
+                data.angularOffset = new Quat(data.angularOffset);
+            }
         }
 
         const impl = this._createImplementation(data.type);


### PR DESCRIPTION
Fixes:

- JS docs for linear offset which used to imply that it would be offset in local space. It actually does it in world space but along the Entity's local axes
- On component creation, we accept euler angles as a number array of length 3 as well as a quat of length 4. This makes Editor integration a lot easier as it can store it in the data as a vec3 euler angles. Added benefit (which we should document?) is that at runtime, developers don't have to convert to a quat.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
