### PR TITLE
Directional shadows are rendered using RenderPass setup

### DIFF
--- a/src/framework/lightmapper/lightmapper.js
+++ b/src/framework/lightmapper/lightmapper.js
@@ -853,7 +853,7 @@ class Lightmapper {
 
             if (light.type === LIGHTTYPE_DIRECTIONAL) {
                 this.renderer._shadowRendererDirectional.cull(light, casters, this.camera);
-                this.renderer.renderShadowsDirectional(lightArray[light.type], this.camera);
+                this.renderer._shadowRendererDirectional.render(light, this.camera);
             } else {
                 this.renderer._shadowRendererLocal.cull(light, casters);
                 this.renderer.renderShadowsLocal(lightArray[light.type], this.camera);

--- a/src/platform/graphics/render-pass.js
+++ b/src/platform/graphics/render-pass.js
@@ -130,12 +130,16 @@ class RenderPass {
      * graphics device.
      * @param {Function} execute - Custom function that is called when the pass needs to be
      * rendered.
+     * @param {Function} [after] - Custom function that is called after the pass has fnished.
      */
-    constructor(graphicsDevice, execute) {
+    constructor(graphicsDevice, execute, after = null) {
         this.device = graphicsDevice;
 
         /** @type {Function} */
         this.execute = execute;
+
+        /** @type {Function} */
+        this.after = after;
     }
 
     /**
@@ -216,6 +220,8 @@ class RenderPass {
         if (realPass) {
             device.endPass(this);
         }
+
+        this.after?.();
 
         DebugGraphics.popGpuMarker(device);
 

--- a/src/scene/frame-graph.js
+++ b/src/scene/frame-graph.js
@@ -131,17 +131,20 @@ class FrameGraph {
 
             this.renderPasses.forEach((renderPass, index) => {
 
+                const hasColor = renderPass.renderTarget?.colorBuffer;
+                const hasDepth = renderPass.renderTarget?.depth;
+                const hasStencil = renderPass.renderTarget?.stencil;
                 const rt = renderPass.renderTarget === undefined ? '' : ` RT: ${(renderPass.renderTarget ? renderPass.renderTarget.name : 'NULL')} ` +
-                    `${renderPass.renderTarget?.colorBuffer ? '[Color]' : ''}` +
-                    `${renderPass.renderTarget?.depth ? '[Depth]' : ''}` +
-                    `${renderPass.renderTarget?.stencil ? '[Stencil]' : ''}` +
+                    `${hasColor ? '[Color]' : ''}` +
+                    `${hasDepth ? '[Depth]' : ''}` +
+                    `${hasStencil ? '[Stencil]' : ''}` +
                     `${(renderPass.samples > 0 ? ' samples: ' + renderPass.samples : '')}`;
 
                 Debug.trace(TRACEID_RENDER_PASS,
                             `${index.toString().padEnd(2, ' ')}: ${renderPass.name.padEnd(20, ' ')}` +
                             rt.padEnd(30));
 
-                if (renderPass.colorOps) {
+                if (renderPass.colorOps && hasColor) {
                     Debug.trace(TRACEID_RENDER_PASS_DETAIL, `    colorOps: ` +
                                 `${renderPass.colorOps.clear ? 'clear' : 'load'}->` +
                                 `${renderPass.colorOps.store ? 'store' : 'discard'} ` +
@@ -150,13 +153,18 @@ class FrameGraph {
                 }
 
                 if (renderPass.depthStencilOps) {
-                    Debug.trace(TRACEID_RENDER_PASS_DETAIL, `    depthOps: ` +
-                                `${renderPass.depthStencilOps.clearDepth ? 'clear' : 'load'}->` +
-                                `${renderPass.depthStencilOps.storeDepth ? 'store' : 'discard'}`);
 
-                    Debug.trace(TRACEID_RENDER_PASS_DETAIL, `    stencOps: ` +
-                                `${renderPass.depthStencilOps.clearStencil ? 'clear' : 'load'}->` +
-                                `${renderPass.depthStencilOps.storeStencil ? 'store' : 'discard'}`);
+                    if (hasDepth) {
+                        Debug.trace(TRACEID_RENDER_PASS_DETAIL, `    depthOps: ` +
+                                    `${renderPass.depthStencilOps.clearDepth ? 'clear' : 'load'}->` +
+                                    `${renderPass.depthStencilOps.storeDepth ? 'store' : 'discard'}`);
+                    }
+
+                    if (hasStencil) {
+                        Debug.trace(TRACEID_RENDER_PASS_DETAIL, `    stencOps: ` +
+                                    `${renderPass.depthStencilOps.clearStencil ? 'clear' : 'load'}->` +
+                                    `${renderPass.depthStencilOps.storeStencil ? 'store' : 'discard'}`);
+                    }
                 }
             });
         }

--- a/src/scene/renderer/renderer.js
+++ b/src/scene/renderer/renderer.js
@@ -101,6 +101,7 @@ class Renderer {
         this._skinTime = 0;
         this._morphTime = 0;
         this._cullTime = 0;
+        this._shadowMapTime = 0;
         this._lightClustersTime = 0;
         this._layerCompositionUpdateTime = 0;
 
@@ -384,7 +385,7 @@ class Renderer {
 
     // make sure colorWrite is set to true to all channels, if you want to fully clear the target
     // TODO: this function is only used from outside of forward renderer, and should be deprecated
-    // when the functionality moves to the render passes.
+    // when the functionality moves to the render passes. Note that Editor uses it as well.
     setCamera(camera, target, clear, renderAction = null) {
 
         this.setCameraUniforms(camera, target, renderAction);


### PR DESCRIPTION
- refactored shadows rendering to be more modular
- based on this, directional shadow rendering has been refactored to utilize render pass, so that it can be used on WebGPU
- improved logging
- render pass has an `after` function which executes after the render pass
- shadow cascades now use single full render target clear, instead of clearing each cascade by viewport clear - that could speed up things
- tested all combinations of Webgl1 & 2 and clustered / non-clustered shadows + shadow cascades