### PR TITLE
Change VertexFormat.defaultInstancingFormat from a property to a function

### DIFF
--- a/examples/src/examples/graphics/hardware-instancing.tsx
+++ b/examples/src/examples/graphics/hardware-instancing.tsx
@@ -105,7 +105,8 @@ class HardwareInstancingExample {
                     }
 
                     // create static vertex buffer containing the matrices
-                    const vertexBuffer = new pc.VertexBuffer(app.graphicsDevice, pc.VertexFormat.defaultInstancingFormat, instanceCount, pc.BUFFER_STATIC, matrices);
+                    const vertexBuffer = new pc.VertexBuffer(app.graphicsDevice, pc.VertexFormat.getDefaultInstancingFormat(app.graphicsDevice),
+                                                             instanceCount, pc.BUFFER_STATIC, matrices);
 
                     // initialize instancing using the vertex buffer on meshInstance of the created box
                     const boxMeshInst = box.render.meshInstances[0];

--- a/examples/src/examples/misc/mini-stats.tsx
+++ b/examples/src/examples/misc/mini-stats.tsx
@@ -180,7 +180,8 @@ class MiniStatsExample {
                     // add vertex buffer
                     const vertexCount = 500;
                     const data = new Float32Array(vertexCount * 16);
-                    vertexBuffer = new pc.VertexBuffer(app.graphicsDevice, pc.VertexFormat.defaultInstancingFormat, vertexCount, pc.BUFFER_STATIC, data);
+                    vertexBuffer = new pc.VertexBuffer(app.graphicsDevice, pc.VertexFormat.getDefaultInstancingFormat(app.graphicsDevice),
+                                                       vertexCount, pc.BUFFER_STATIC, data);
                     vertexBuffers.push(vertexBuffer);
 
                     // allocate texture

--- a/src/deprecated/deprecated.js
+++ b/src/deprecated/deprecated.js
@@ -51,6 +51,8 @@ import { Texture } from '../platform/graphics/texture.js';
 import { VertexBuffer } from '../platform/graphics/vertex-buffer.js';
 import { VertexFormat } from '../platform/graphics/vertex-format.js';
 import { VertexIterator } from '../platform/graphics/vertex-iterator.js';
+import { ShaderUtils } from '../platform/graphics/shader-utils.js';
+import { GraphicsDeviceAccess } from '../platform/graphics/graphics-device-access.js';
 
 import { PROJECTION_ORTHOGRAPHIC, PROJECTION_PERSPECTIVE, LAYERID_IMMEDIATE, LINEBATCH_OVERLAY, LAYERID_WORLD } from '../scene/constants.js';
 import { calculateTangents, createBox, createCapsule, createCone, createCylinder, createMesh, createPlane, createSphere, createTorus } from '../scene/procedural.js';
@@ -111,7 +113,6 @@ import {
 import { RigidBodyComponent } from '../framework/components/rigid-body/component.js';
 import { RigidBodyComponentSystem } from '../framework/components/rigid-body/system.js';
 import { basisInitialize } from '../framework/handlers/basis.js';
-import { ShaderUtils } from '../platform/graphics/shader-utils.js';
 
 // CORE
 
@@ -461,6 +462,13 @@ Object.defineProperties(RenderTarget.prototype, {
         set: function (rgbm) {
             Debug.deprecated('pc.RenderTarget#_glFrameBuffer is deprecated. Use pc.RenderTarget.impl#_glFrameBuffer instead.');
         }
+    }
+});
+
+Object.defineProperty(VertexFormat, 'defaultInstancingFormat', {
+    get: function () {
+        Debug.deprecated('pc.VertexFormat.defaultInstancingFormat is deprecated, use pc.VertexFormat.getDefaultInstancingFormat(graphicsDevice).');
+        return VertexFormat.getDefaultInstancingFormat(GraphicsDeviceAccess.get());
     }
 });
 

--- a/src/platform/graphics/vertex-format.js
+++ b/src/platform/graphics/vertex-format.js
@@ -200,12 +200,15 @@ class VertexFormat {
     /**
      * The {@link VertexFormat} used to store matrices of type {@link Mat4} for hardware instancing.
      *
-     * @type {VertexFormat}
+     * @param {import('./graphics-device.js').GraphicsDevice} graphicsDevice - The graphics device
+     * used to create this vertex format.
+     *
+     * @returns {VertexFormat}
      */
-    static get defaultInstancingFormat() {
+    static getDefaultInstancingFormat(graphicsDevice) {
 
         if (!VertexFormat._defaultInstancingFormat) {
-            VertexFormat._defaultInstancingFormat = new VertexFormat(null, [
+            VertexFormat._defaultInstancingFormat = new VertexFormat(graphicsDevice, [
                 { semantic: SEMANTIC_ATTR12, components: 4, type: TYPE_FLOAT32 },
                 { semantic: SEMANTIC_ATTR13, components: 4, type: TYPE_FLOAT32 },
                 { semantic: SEMANTIC_ATTR14, components: 4, type: TYPE_FLOAT32 },

--- a/src/platform/graphics/vertex-format.js
+++ b/src/platform/graphics/vertex-format.js
@@ -203,7 +203,7 @@ class VertexFormat {
      * @param {import('./graphics-device.js').GraphicsDevice} graphicsDevice - The graphics device
      * used to create this vertex format.
      *
-     * @returns {VertexFormat}
+     * @returns {VertexFormat} The default instancing vertex format.
      */
     static getDefaultInstancingFormat(graphicsDevice) {
 


### PR DESCRIPTION
- it fixes currently broken hardware-instancing example
- the reason is that VertexFormat needs graphicsDevice parameter, which wasn't used before, but now it is .. and so we need to pass in the graphics device.
- backwards compatibility preserved using a deprecated function