### PR TITLE
Add/implement pc.EVENT_MOUSEOUT

### DIFF
--- a/src/platform/input/constants.js
+++ b/src/platform/input/constants.js
@@ -53,6 +53,13 @@ export const EVENT_MOUSEUP = 'mouseup';
 export const EVENT_MOUSEWHEEL = 'mousewheel';
 
 /**
+ * Name of event fired when the mouse moves out or enters another element.
+ *
+ * @type {string}
+ */
+export const EVENT_MOUSEOUT = 'mouseout';
+
+/**
  * Name of event fired when a new touch occurs. For example, a finger is placed on the device.
  *
  * @type {string}

--- a/src/platform/input/mouse-event.js
+++ b/src/platform/input/mouse-event.js
@@ -50,7 +50,7 @@ class MouseEvent {
              * @type {number}
              */
             this.y = coords.y;
-        } else if (isMousePointerLocked()) {
+        } else if (isMousePointerLocked() || event.type === 'mouseout') {
             this.x = 0;
             this.y = 0;
         } else {

--- a/src/platform/input/mouse.js
+++ b/src/platform/input/mouse.js
@@ -1,7 +1,7 @@
 import { platform } from '../../core/platform.js';
 import { EventHandler } from '../../core/event-handler.js';
 
-import { EVENT_MOUSEDOWN, EVENT_MOUSEMOVE, EVENT_MOUSEUP, EVENT_MOUSEWHEEL } from './constants.js';
+import { EVENT_MOUSEDOWN, EVENT_MOUSEMOVE, EVENT_MOUSEOUT, EVENT_MOUSEUP, EVENT_MOUSEWHEEL } from './constants.js';
 import { isMousePointerLocked, MouseEvent } from './mouse-event.js';
 
 /**
@@ -36,6 +36,7 @@ class Mouse extends EventHandler {
         this._downHandler = this._handleDown.bind(this);
         this._moveHandler = this._handleMove.bind(this);
         this._wheelHandler = this._handleWheel.bind(this);
+        this._outHandler = this._handleOut.bind(this);
         this._contextMenuHandler = (event) => {
             event.preventDefault();
         };
@@ -98,6 +99,7 @@ class Mouse extends EventHandler {
         window.addEventListener('mouseup', this._upHandler, opts);
         window.addEventListener('mousedown', this._downHandler, opts);
         window.addEventListener('mousemove', this._moveHandler, opts);
+        window.addEventListener('mouseout', this._outHandler, opts);
         window.addEventListener('wheel', this._wheelHandler, opts);
     }
 
@@ -113,6 +115,7 @@ class Mouse extends EventHandler {
         window.removeEventListener('mouseup', this._upHandler, opts);
         window.removeEventListener('mousedown', this._downHandler, opts);
         window.removeEventListener('mousemove', this._moveHandler, opts);
+        window.removeEventListener('mouseout', this._outHandler, opts);
         window.removeEventListener('wheel', this._wheelHandler, opts);
     }
 
@@ -287,6 +290,13 @@ class Mouse extends EventHandler {
         if (!e.event) return;
 
         this.fire(EVENT_MOUSEWHEEL, e);
+    }
+
+    _handleOut(event) {
+        const e = new MouseEvent(this, event);
+        if (!e.event) return;
+
+        this.fire(EVENT_MOUSEOUT, e);
     }
 
     _getTargetCoords(event) {


### PR DESCRIPTION
This event is missing, so devs always had to add custom event handling in their scripts, like here:

https://github.com/playcanvas/engine/blob/b07a438362a7a7e8ea4c9353dafecc808640556a/scripts/camera/orbit-camera.js#L378-L388

This will also simplify event handling later on based on https://github.com/playcanvas/engine/issues/4910, in short `ScriptType#listen` provides:

 - Less code
 - Automatically removing events on `disable`/`destroy`
 - Automatically adding them back on `enable`
 - Harder to get it wrong

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
