### PR TITLE
Improved shadow cascades rendering, allowing per cascade update

### DIFF
--- a/examples/src/examples/graphics/shadow-cascades.tsx
+++ b/examples/src/examples/graphics/shadow-cascades.tsx
@@ -208,9 +208,9 @@ class ShadowCascadesExample {
                 // move the clouds around
                 clouds.forEach((cloud, index: number) => {
                     const redialOffset = (index / clouds.length) * (6.24 / cloudSpeed);
-                    const radius = 8 + 2 * Math.sin(redialOffset);
+                    const radius = 9 + 4 * Math.sin(redialOffset);
                     const cloudTime = time + redialOffset;
-                    cloud.setLocalPosition(radius * Math.sin(cloudTime * cloudSpeed), 4, radius * Math.cos(cloudTime * cloudSpeed));
+                    cloud.setLocalPosition(2 + radius * Math.sin(cloudTime * cloudSpeed), 4, -5 + radius * Math.cos(cloudTime * cloudSpeed));
                 });
 
                 frameNumber++;

--- a/examples/src/examples/graphics/shadow-cascades.tsx
+++ b/examples/src/examples/graphics/shadow-cascades.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import * as pc from '../../../../';
 
 import { BindingTwoWay } from '@playcanvas/pcui';
-import { LabelGroup, Panel, SelectInput, SliderInput } from '@playcanvas/pcui/react';
+import { BooleanInput, LabelGroup, Panel, SelectInput, SliderInput } from '@playcanvas/pcui/react';
 import { Observer } from '@playcanvas/observer';
 
 class ShadowCascadesExample {
@@ -24,6 +24,9 @@ class ShadowCascadesExample {
                 </LabelGroup>}
                 <LabelGroup text='Count'>
                     <SliderInput binding={new BindingTwoWay()} link={{ observer: data, path: 'settings.light.numCascades' }} min={1} max={4} precision={0}/>
+                </LabelGroup>
+                <LabelGroup text='Every Frame'>
+                    <BooleanInput type='toggle' binding={new BindingTwoWay()} link={{ observer: data, path: 'settings.light.everyFrame' }} value={data.get('settings.light.everyFrame')}/>
                 </LabelGroup>
                 <LabelGroup text='Resolution'>
                     <SliderInput binding={new BindingTwoWay()} link={{ observer: data, path: 'settings.light.shadowResolution' }} min={128} max={2048} precision={0}/>
@@ -61,7 +64,8 @@ class ShadowCascadesExample {
                     shadowResolution: 2048,     // shadow map resolution storing 4 cascades
                     cascadeDistribution: 0.5,   // distribution of cascade distances to prefer sharpness closer to the camera
                     shadowType: pc.SHADOW_PCF3, // shadow filter type
-                    vsmBlurSize: 11             // shader filter blur size for VSM shadows
+                    vsmBlurSize: 11,            // shader filter blur size for VSM shadows
+                    everyFrame: true            // true if all cascades update every frame
                 }
             });
 
@@ -84,6 +88,34 @@ class ShadowCascadesExample {
             terrain.setLocalScale(30, 30, 30);
             app.root.addChild(terrain);
 
+            // get the clouds so that we can animate them
+            const srcClouds : Array<pc.Entity> = terrain.find((node: pc.GraphNode) => {
+
+                const isCloud = node.name.includes('Icosphere');
+
+                if (isCloud) {
+                    // no shadow receiving for clouds
+                    (node as pc.Entity).render.receiveShadows = false;
+                }
+
+                return isCloud;
+            });
+
+            // clone some additional clouds
+            const clouds : Array<pc.Entity> = [];
+            srcClouds.forEach((cloud) => {
+                clouds.push(cloud);
+
+                for (let i = 0; i < 3; i++) {
+                    const clone = cloud.clone() as pc.Entity;
+                    cloud.parent.addChild(clone);
+                    clouds.push(clone);
+                }
+            });
+
+            // shuffle the array to give clouds random order
+            clouds.sort(() => Math.random() - 0.5);
+
             // find a tree in the middle to use as a focus point
             const tree = terrain.findOne("name", "Arbol 2.002");
 
@@ -95,7 +127,7 @@ class ShadowCascadesExample {
             });
 
             // and position it in the world
-            camera.setLocalPosition(300, 60, 25);
+            camera.setLocalPosition(300, 160, 25);
 
             // add orbit camera script with a mouse and a touch support
             camera.addComponent("script");
@@ -129,21 +161,59 @@ class ShadowCascadesExample {
             app.root.addChild(dirLight);
             dirLight.setLocalEulerAngles(45, 350, 20);
 
+            // update mode of cascades
+            let updateEveryFrame = true;
+
             // handle HUD changes - update properties on the light
             data.on('*:set', (path: string, value: any) => {
                 const pathArray = path.split('.');
-                // @ts-ignore
-                dirLight.light[pathArray[2]] = value;
+
+                if (pathArray[2] === 'everyFrame') {
+                    updateEveryFrame = value;
+                } else {
+                    // @ts-ignore
+                    dirLight.light[pathArray[2]] = value;
+                }
             });
 
-            // on the first frame, when camera is updated, move it further away from the focus tree
-            let firstFrame = true;
-            app.on("update", function () {
-                if (firstFrame) {
-                    firstFrame = false;
+            const cloudSpeed = 0.2;
+            let frameNumber = 0;
+            let time = 0;
+            app.on("update", function (dt: number) {
+
+                time += dt;
+
+                // on the first frame, when camera is updated, move it further away from the focus tree
+                if (frameNumber === 0) {
                     // @ts-ignore engine-tsd
-                    camera.script.orbitCamera.distance = 320;
+                    camera.script.orbitCamera.distance = 470;
                 }
+
+                if (updateEveryFrame) {
+
+                    // no per cascade rendering control
+                    dirLight.light.faceUpdateModes = null;
+
+                } else {
+
+                    // set up shadow update modes, nearest cascade updates each frame, then next one every 5 and so on
+                    dirLight.light.faceUpdateModes = [
+                        pc.SHADOWUPDATE_THISFRAME,
+                        (frameNumber % 5) === 0 ? pc.SHADOWUPDATE_THISFRAME : pc.SHADOWUPDATE_NONE,
+                        (frameNumber % 10) === 0 ? pc.SHADOWUPDATE_THISFRAME : pc.SHADOWUPDATE_NONE,
+                        (frameNumber % 15) === 0 ? pc.SHADOWUPDATE_THISFRAME : pc.SHADOWUPDATE_NONE
+                    ];
+                }
+
+                // move the clouds around
+                clouds.forEach((cloud, index: number) => {
+                    const redialOffset = (index / clouds.length) * (6.24 / cloudSpeed);
+                    const radius = 8 + 2 * Math.sin(redialOffset);
+                    const cloudTime = time + redialOffset;
+                    cloud.setLocalPosition(radius * Math.sin(cloudTime * cloudSpeed), 4, radius * Math.cos(cloudTime * cloudSpeed));
+                });
+
+                frameNumber++;
             });
         });
     }

--- a/examples/src/examples/graphics/shadow-cascades.tsx
+++ b/examples/src/examples/graphics/shadow-cascades.tsx
@@ -192,12 +192,12 @@ class ShadowCascadesExample {
                 if (updateEveryFrame) {
 
                     // no per cascade rendering control
-                    dirLight.light.faceUpdateModes = null;
+                    dirLight.light.shadowUpdateOverrides = null;
 
                 } else {
 
-                    // set up shadow update modes, nearest cascade updates each frame, then next one every 5 and so on
-                    dirLight.light.faceUpdateModes = [
+                    // set up shadow update overrides, nearest cascade updates each frame, then next one every 5 and so on
+                    dirLight.light.shadowUpdateOverrides = [
                         pc.SHADOWUPDATE_THISFRAME,
                         (frameNumber % 5) === 0 ? pc.SHADOWUPDATE_THISFRAME : pc.SHADOWUPDATE_NONE,
                         (frameNumber % 10) === 0 ? pc.SHADOWUPDATE_THISFRAME : pc.SHADOWUPDATE_NONE,

--- a/src/framework/components/light/component.js
+++ b/src/framework/components/light/component.js
@@ -9,7 +9,7 @@ import {
     LIGHTFALLOFF_LINEAR,
     MASK_AFFECT_LIGHTMAPPED, MASK_AFFECT_DYNAMIC, MASK_BAKE,
     SHADOW_PCF3,
-    SHADOWUPDATE_REALTIME
+    SHADOWUPDATE_REALTIME, SHADOWUPDATE_THISFRAME
 } from '../../../scene/constants.js';
 
 import { Asset } from '../../asset/asset.js';
@@ -225,10 +225,6 @@ class LightComponent extends Component {
             this.onEnable();
     }
 
-    updateShadow() {
-        this.light.updateShadow();
-    }
-
     onCookieAssetSet() {
         let forceLoad = false;
 
@@ -320,6 +316,19 @@ class LightComponent extends Component {
 
         // remove cookie asset events
         this.cookieAsset = null;
+    }
+
+    /**
+     * Returns an array of SHADOWUPDATE_ setting per shadow cascade, or undefined if not used.
+     *
+     * @type {number[]}
+     */
+    set faceUpdateModes(values) {
+        this.light.faceUpdateModes = values;
+    }
+
+    get faceUpdateModes() {
+        return this.light.faceUpdateModes;
     }
 }
 

--- a/src/framework/components/light/component.js
+++ b/src/framework/components/light/component.js
@@ -9,7 +9,7 @@ import {
     LIGHTFALLOFF_LINEAR,
     MASK_AFFECT_LIGHTMAPPED, MASK_AFFECT_DYNAMIC, MASK_BAKE,
     SHADOW_PCF3,
-    SHADOWUPDATE_REALTIME, SHADOWUPDATE_THISFRAME
+    SHADOWUPDATE_REALTIME
 } from '../../../scene/constants.js';
 
 import { Asset } from '../../asset/asset.js';

--- a/src/framework/components/light/component.js
+++ b/src/framework/components/light/component.js
@@ -319,7 +319,7 @@ class LightComponent extends Component {
     }
 
     /**
-     * Returns an array of SHADOWUPDATE_ setting per shadow cascade, or undefined if not used.
+     * Returns an array of SHADOWUPDATE_ settings per shadow cascade, or undefined if not used.
      *
      * @type {number[]}
      */

--- a/src/framework/components/light/component.js
+++ b/src/framework/components/light/component.js
@@ -323,12 +323,12 @@ class LightComponent extends Component {
      *
      * @type {number[]}
      */
-    set faceUpdateModes(values) {
-        this.light.faceUpdateModes = values;
+    set shadowUpdateOverrides(values) {
+        this.light.shadowUpdateOverrides = values;
     }
 
-    get faceUpdateModes() {
-        return this.light.faceUpdateModes;
+    get shadowUpdateOverrides() {
+        return this.light.shadowUpdateOverrides;
     }
 }
 

--- a/src/framework/components/light/component.js
+++ b/src/framework/components/light/component.js
@@ -321,7 +321,7 @@ class LightComponent extends Component {
     /**
      * Returns an array of SHADOWUPDATE_ settings per shadow cascade, or undefined if not used.
      *
-     * @type {number[]}
+     * @type {number[] | null}
      */
     set shadowUpdateOverrides(values) {
         this.light.shadowUpdateOverrides = values;

--- a/src/scene/light.js
+++ b/src/scene/light.js
@@ -5,6 +5,8 @@ import { Vec2 } from '../core/math/vec2.js';
 import { Vec3 } from '../core/math/vec3.js';
 import { Vec4 } from '../core/math/vec4.js';
 
+import { DEVICETYPE_WEBGPU } from '../platform/graphics/constants.js';
+
 import {
     BLUR_GAUSSIAN,
     LIGHTTYPE_DIRECTIONAL, LIGHTTYPE_OMNI, LIGHTTYPE_SPOT,
@@ -171,6 +173,7 @@ class Light {
         this.shadowIntensity = 1.0;
         this._normalOffsetBias = 0.0;
         this.shadowUpdateMode = SHADOWUPDATE_REALTIME;
+        this.faceUpdateModes = null;
         this._isVsm = false;
         this._isPcf = true;
 
@@ -250,6 +253,7 @@ class Light {
 
         const stype = this._shadowType;
         this._shadowType = null;
+        this.faceUpdateModes = null;
         this.shadowType = stype; // refresh shadow type; switching from direct/spot to omni and back may change it
     }
 
@@ -294,7 +298,8 @@ class Light {
         if (this._type === LIGHTTYPE_OMNI)
             value = SHADOW_PCF3; // VSM or HW PCF for omni lights is not supported yet
 
-        if (value === SHADOW_PCF5 && !device.webgl2) {
+        const supportsPCF5 = device.webgl2 || device.deviceType === DEVICETYPE_WEBGPU;
+        if (value === SHADOW_PCF5 && !supportsPCF5) {
             value = SHADOW_PCF3; // fallback from HW PCF to old PCF
         }
 
@@ -574,6 +579,14 @@ class Light {
         if (this.shadowUpdateMode === SHADOWUPDATE_NONE) {
             this.shadowUpdateMode = SHADOWUPDATE_THISFRAME;
         }
+
+        if (this.faceUpdateModes) {
+            for (let i = 0; i < this.faceUpdateModes.length; i++) {
+                if (this.faceUpdateModes[i] === SHADOWUPDATE_NONE) {
+                    this.faceUpdateModes[i] = SHADOWUPDATE_THISFRAME;
+                }
+            }
+        }
     }
 
     // returns LightRenderData with matching camera and face
@@ -619,6 +632,10 @@ class Light {
         clone.vsmBias = this.vsmBias;
         clone.shadowUpdateMode = this.shadowUpdateMode;
         clone.mask = this.mask;
+
+        if (this.faceUpdateModes) {
+            clone.faceUpdateModes = this.faceUpdateModes.slice();
+        }
 
         // Spot properties
         clone.innerConeAngle = this._innerConeAngle;
@@ -799,12 +816,6 @@ class Light {
         }
 
         this._updateFinalColor();
-    }
-
-    updateShadow() {
-        if (this.shadowUpdateMode !== SHADOWUPDATE_REALTIME) {
-            this.shadowUpdateMode = SHADOWUPDATE_THISFRAME;
-        }
     }
 
     layersDirty() {

--- a/src/scene/light.js
+++ b/src/scene/light.js
@@ -173,7 +173,7 @@ class Light {
         this.shadowIntensity = 1.0;
         this._normalOffsetBias = 0.0;
         this.shadowUpdateMode = SHADOWUPDATE_REALTIME;
-        this.faceUpdateModes = null;
+        this.shadowUpdateOverrides = null;
         this._isVsm = false;
         this._isPcf = true;
 
@@ -253,7 +253,7 @@ class Light {
 
         const stype = this._shadowType;
         this._shadowType = null;
-        this.faceUpdateModes = null;
+        this.shadowUpdateOverrides = null;
         this.shadowType = stype; // refresh shadow type; switching from direct/spot to omni and back may change it
     }
 
@@ -580,10 +580,10 @@ class Light {
             this.shadowUpdateMode = SHADOWUPDATE_THISFRAME;
         }
 
-        if (this.faceUpdateModes) {
-            for (let i = 0; i < this.faceUpdateModes.length; i++) {
-                if (this.faceUpdateModes[i] === SHADOWUPDATE_NONE) {
-                    this.faceUpdateModes[i] = SHADOWUPDATE_THISFRAME;
+        if (this.shadowUpdateOverrides) {
+            for (let i = 0; i < this.shadowUpdateOverrides.length; i++) {
+                if (this.shadowUpdateOverrides[i] === SHADOWUPDATE_NONE) {
+                    this.shadowUpdateOverrides[i] = SHADOWUPDATE_THISFRAME;
                 }
             }
         }
@@ -633,8 +633,8 @@ class Light {
         clone.shadowUpdateMode = this.shadowUpdateMode;
         clone.mask = this.mask;
 
-        if (this.faceUpdateModes) {
-            clone.faceUpdateModes = this.faceUpdateModes.slice();
+        if (this.shadowUpdateOverrides) {
+            clone.shadowUpdateOverrides = this.shadowUpdateOverrides.slice();
         }
 
         // Spot properties

--- a/src/scene/renderer/shadow-renderer-directional.js
+++ b/src/scene/renderer/shadow-renderer-directional.js
@@ -64,11 +64,11 @@ class ShadowRendererDirectional extends ShadowRenderer {
         const nearDist = camera._nearClip;
         this.generateSplitDistances(light, nearDist, light.shadowDistance);
 
-        const faceUpdateModes = light.faceUpdateModes;
+        const shadowUpdateOverrides = light.shadowUpdateOverrides;
         for (let cascade = 0; cascade < light.numCascades; cascade++) {
 
             // if manually controlling cascade rendering and the cascade does not render this frame
-            if (faceUpdateModes?.[cascade] === SHADOWUPDATE_NONE) {
+            if (shadowUpdateOverrides?.[cascade] === SHADOWUPDATE_NONE) {
                 break;
             }
 
@@ -186,14 +186,14 @@ class ShadowRendererDirectional extends ShadowRenderer {
 
         // shadow cascades have more faces rendered within a singe render pass
         const faceCount = light.numShadowFaces;
-        const faceUpdateModes = light.faceUpdateModes;
+        const shadowUpdateOverrides = light.shadowUpdateOverrides;
 
         // prepare render targets / cameras for rendering
         let allCascadesRendering = true;
         let shadowCamera;
         for (let face = 0; face < faceCount; face++) {
 
-            if (faceUpdateModes?.[face] === SHADOWUPDATE_NONE)
+            if (shadowUpdateOverrides?.[face] === SHADOWUPDATE_NONE)
                 allCascadesRendering = false;
 
             shadowCamera = this.prepareFace(light, camera, face);
@@ -204,12 +204,12 @@ class ShadowRendererDirectional extends ShadowRenderer {
             // inside the render pass, render all faces
             for (let face = 0; face < faceCount; face++) {
 
-                if (faceUpdateModes?.[face] !== SHADOWUPDATE_NONE) {
+                if (shadowUpdateOverrides?.[face] !== SHADOWUPDATE_NONE) {
                     this.renderFace(light, camera, face, !allCascadesRendering);
                 }
 
-                if (faceUpdateModes?.[face] === SHADOWUPDATE_THISFRAME) {
-                    faceUpdateModes[face] = SHADOWUPDATE_NONE;
+                if (shadowUpdateOverrides?.[face] === SHADOWUPDATE_THISFRAME) {
+                    shadowUpdateOverrides[face] = SHADOWUPDATE_NONE;
                 }
             }
 

--- a/src/scene/renderer/shadow-renderer-directional.js
+++ b/src/scene/renderer/shadow-renderer-directional.js
@@ -1,10 +1,11 @@
 import { Debug, DebugHelper } from '../../core/debug.js';
+import { math } from '../../core/math/math.js';
 import { Vec3 } from '../../core/math/vec3.js';
 import { Mat4 } from '../../core/math/mat4.js';
 import { BoundingBox } from '../../core/shape/bounding-box.js';
 
 import {
-    LIGHTTYPE_DIRECTIONAL
+    LIGHTTYPE_DIRECTIONAL, SHADOWUPDATE_NONE, SHADOWUPDATE_THISFRAME
 } from '../constants.js';
 import { RenderPass } from '../../platform/graphics/render-pass.js';
 
@@ -63,7 +64,13 @@ class ShadowRendererDirectional extends ShadowRenderer {
         const nearDist = camera._nearClip;
         this.generateSplitDistances(light, nearDist, light.shadowDistance);
 
+        const faceUpdateModes = light.faceUpdateModes;
         for (let cascade = 0; cascade < light.numCascades; cascade++) {
+
+            // if manually controlling cascade rendering and the cascade does not render this frame
+            if (faceUpdateModes?.[cascade] === SHADOWUPDATE_NONE) {
+                break;
+            }
 
             const lightRenderData = light.getRenderData(camera, cascade);
             const shadowCam = lightRenderData.shadowCamera;
@@ -160,14 +167,35 @@ class ShadowRendererDirectional extends ShadowRenderer {
         }
     }
 
+    // function to generate frustum split distances
+    generateSplitDistances(light, nearDist, farDist) {
+
+        light._shadowCascadeDistances.fill(farDist);
+        for (let i = 1; i < light.numCascades; i++) {
+
+            //  lerp between linear and logarithmic distance, called practical split distance
+            const fraction = i / light.numCascades;
+            const linearDist = nearDist + (farDist - nearDist) * fraction;
+            const logDist = nearDist * (farDist / nearDist) ** fraction;
+            const dist = math.lerp(linearDist, logDist, light.cascadeDistribution);
+            light._shadowCascadeDistances[i - 1] = dist;
+        }
+    }
+
     addLightRenderPasses(frameGraph, light, camera) {
 
         // shadow cascades have more faces rendered within a singe render pass
         const faceCount = light.numShadowFaces;
+        const faceUpdateModes = light.faceUpdateModes;
 
         // prepare render targets / cameras for rendering
+        let allCascadesRendering = true;
         let shadowCamera;
         for (let face = 0; face < faceCount; face++) {
+
+            if (faceUpdateModes?.[face] === SHADOWUPDATE_NONE)
+                allCascadesRendering = false;
+
             shadowCamera = this.prepareFace(light, camera, face);
         }
 
@@ -175,7 +203,14 @@ class ShadowRendererDirectional extends ShadowRenderer {
 
             // inside the render pass, render all faces
             for (let face = 0; face < faceCount; face++) {
-                this.renderFace(light, camera, face, false);
+
+                if (faceUpdateModes?.[face] !== SHADOWUPDATE_NONE) {
+                    this.renderFace(light, camera, face, !allCascadesRendering);
+                }
+
+                if (faceUpdateModes?.[face] === SHADOWUPDATE_THISFRAME) {
+                    faceUpdateModes[face] = SHADOWUPDATE_NONE;
+                }
             }
 
         }, () => {
@@ -186,7 +221,7 @@ class ShadowRendererDirectional extends ShadowRenderer {
         });
 
         // setup render pass using any of the cameras, they all have the same pass related properties
-        this.setupRenderPass(renderPass, shadowCamera);
+        this.setupRenderPass(renderPass, shadowCamera, allCascadesRendering);
         DebugHelper.setName(renderPass, `DirShadow-${light._node.name}`);
 
         frameGraph.addRenderPass(renderPass);

--- a/src/scene/renderer/shadow-renderer.js
+++ b/src/scene/renderer/shadow-renderer.js
@@ -2,7 +2,6 @@ import { Debug } from '../../core/debug.js';
 import { now } from '../../core/time.js';
 import { Color } from '../../core/math/color.js';
 import { Mat4 } from '../../core/math/mat4.js';
-import { math } from '../../core/math/math.js';
 import { Vec3 } from '../../core/math/vec3.js';
 import { Vec4 } from '../../core/math/vec4.js';
 


### PR DESCRIPTION
**new API**, allowing control over per-cascade directional shadow rendering

<img width="675" alt="Screenshot 2022-12-13 at 10 22 04" src="https://user-images.githubusercontent.com/59932779/207292233-68a6cd3a-73ce-4851-a308-6d3a6bedd0f5.png">

- updated example to add a toggle to test it, and adjusted clouds to move around

<img width="761" alt="Screenshot 2022-12-13 at 10 22 25" src="https://user-images.githubusercontent.com/59932779/207292273-85f47936-3930-4d00-84d2-f7335fbf280b.png">

https://user-images.githubusercontent.com/59932779/207099462-09d18a12-9ab2-4891-86a2-0286a98250c8.mov

