### PR TITLE
WebGPU support for rendering to shadow map for Directional lights

### DIFF
--- a/src/framework/lightmapper/lightmapper.js
+++ b/src/framework/lightmapper/lightmapper.js
@@ -853,7 +853,7 @@ class Lightmapper {
 
             if (light.type === LIGHTTYPE_DIRECTIONAL) {
                 this.renderer._shadowRendererDirectional.cull(light, casters, this.camera);
-                this.renderer._shadowRendererDirectional.render(light, this.camera);
+                this.renderer.shadowRenderer.render(light, this.camera);
             } else {
                 this.renderer._shadowRendererLocal.cull(light, casters);
                 this.renderer.renderShadowsLocal(lightArray[light.type], this.camera);

--- a/src/platform/graphics/shader.js
+++ b/src/platform/graphics/shader.js
@@ -85,7 +85,7 @@ class Shader {
 
         this.impl = graphicsDevice.createShaderImpl(this);
 
-        Debug.trace(TRACEID_SHADER_ALLOC, `Alloc: Id ${this.id} ${this.name}`, {
+        Debug.trace(TRACEID_SHADER_ALLOC, `Alloc: ${this.label}`, {
             instance: this
         });
     }
@@ -98,6 +98,10 @@ class Shader {
     init() {
         this.ready = false;
         this.failed = false;
+    }
+
+    get label() {
+        return `Shader Id ${this.id} ${this.name}`;
     }
 
     /**

--- a/src/platform/graphics/webgpu/webgpu-render-pipeline.js
+++ b/src/platform/graphics/webgpu/webgpu-render-pipeline.js
@@ -172,19 +172,25 @@ class WebgpuRenderPipeline {
             format: renderTarget.impl.depthFormat
         } : undefined;
 
+        const vertexModule = wgpu.createShaderModule({
+            code: webgpuShader.vertexCode
+        });
+        DebugHelper.setLabel(vertexModule, `Vertex ${webgpuShader.shader.label}`);
+
+        const fragmentModule = wgpu.createShaderModule({
+            code: webgpuShader.fragmentCode
+        });
+        DebugHelper.setLabel(fragmentModule, `Fragment ${webgpuShader.shader.label}`);
+
         // type {GPURenderPipelineDescriptor}
         const descr = {
             vertex: {
-                module: wgpu.createShaderModule({
-                    code: webgpuShader.vertexCode
-                }),
+                module: vertexModule,
                 entryPoint: 'main',
                 buffers: vertexBufferLayout
             },
             fragment: {
-                module: wgpu.createShaderModule({
-                    code: webgpuShader.fragmentCode
-                }),
+                module: fragmentModule,
                 entryPoint: 'main',
                 targets: [{
                     format: renderTarget.impl.colorFormat,

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -438,7 +438,7 @@ class ForwardRenderer extends Renderer {
                 }
             }
 
-            this._shadowRendererLocal.render(light, camera);
+            this.shadowRenderer.render(light, camera);
         }
     }
 
@@ -675,19 +675,7 @@ class ForwardRenderer extends Renderer {
                 this.setMorphing(device, drawCall.morphInstance);
                 this.setSkinning(device, drawCall);
 
-                if (supportsUniformBuffers) {
-
-                    // TODO: model matrix setup is part of the drawInstance call, but with uniform buffer it's needed
-                    // earlier here. This needs to be refactored for multi-view anyways.
-                    this.modelMatrixId.setValue(drawCall.node.worldTransform.data);
-                    this.normalMatrixId.setValue(drawCall.node.normalMatrix.data);
-
-                    // update mesh bind group / uniform buffer
-                    const meshBindGroup = drawCall.getBindGroup(device, pass);
-                    meshBindGroup.defaultUniformBuffer.update();
-                    meshBindGroup.update();
-                    device.setBindGroup(BINDGROUP_MESH, meshBindGroup);
-                }
+                this.setupMeshUniformBuffers(drawCall, pass);
 
                 const style = drawCall.renderStyle;
                 device.setIndexBuffer(mesh.indexBuffer[style]);
@@ -995,7 +983,8 @@ class ForwardRenderer extends Renderer {
      */
     update(comp) {
 
-        this.baseUpdate();
+        this.frameUpdate();
+        this.shadowRenderer.frameUpdate();
 
         const clusteredLightingEnabled = this.scene.clusteredLightingEnabled;
 
@@ -1138,7 +1127,10 @@ class ForwardRenderer extends Renderer {
             // Set the not very clever global variable which is only useful when there's just one camera
             this.scene._activeCamera = camera.camera;
 
-            this.setCameraUniforms(camera.camera, renderAction.renderTarget, renderAction);
+            const viewCount = this.setCameraUniforms(camera.camera, renderAction.renderTarget);
+            if (device.supportsUniformBuffers) {
+                this.setupViewUniformBuffers(renderAction.viewBindGroups, this.viewUniformFormat, this.viewBindGroupFormat, viewCount);
+            }
 
             // enable flip faces if either the camera has _flipFaces enabled or the render target
             // has flipY enabled

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -6,8 +6,7 @@ import { Color } from '../../core/math/color.js';
 
 import {
     FUNC_ALWAYS,
-    STENCILOP_KEEP,
-    BINDGROUP_MESH
+    STENCILOP_KEEP
 } from '../../platform/graphics/constants.js';
 import { DebugGraphics } from '../../platform/graphics/debug-graphics.js';
 import { RenderPass } from '../../platform/graphics/render-pass.js';
@@ -557,7 +556,6 @@ class ForwardRenderer extends Renderer {
 
     renderForwardInternal(camera, preparedCalls, sortedLights, pass, drawCallback, flipFaces) {
         const device = this.device;
-        const supportsUniformBuffers = device.supportsUniformBuffers;
         const scene = this.scene;
         const passFlag = 1 << pass;
 

--- a/src/scene/renderer/shadow-renderer-local.js
+++ b/src/scene/renderer/shadow-renderer-local.js
@@ -1,6 +1,5 @@
 import { math } from '../../core/math/math.js';
 
-import { ShadowRenderer } from "./shadow-renderer.js";
 import { ShadowMap } from './shadow-map.js';
 import {
     LIGHTTYPE_OMNI, LIGHTTYPE_SPOT
@@ -9,7 +8,13 @@ import {
 /**
  * @ignore
  */
-class ShadowRendererLocal extends ShadowRenderer {
+class ShadowRendererLocal {
+    constructor(renderer, shadowRenderer) {
+        this.renderer = renderer;
+        this.shadowRenderer = shadowRenderer;
+        this.device = renderer.device;
+    }
+
     // cull local shadow map
     cull(light, drawCalls) {
 
@@ -52,9 +57,9 @@ class ShadowRendererLocal extends ShadowRenderer {
 
                 // when rendering omni shadows to an atlas, use larger fov by few pixels to allow shadow filtering to stay on a single face
                 if (isClustered) {
-                    const tileSize = this.lightTextureAtlas.shadowAtlasResolution * light.atlasViewport.z / 3;    // using 3x3 for cubemap
+                    const tileSize = this.shadowRenderer.lightTextureAtlas.shadowAtlasResolution * light.atlasViewport.z / 3;    // using 3x3 for cubemap
                     const texelSize = 2 / tileSize;
-                    const filterSize = texelSize * this.lightTextureAtlas.shadowEdgePixels;
+                    const filterSize = texelSize * this.shadowRenderer.lightTextureAtlas.shadowEdgePixels;
                     shadowCam.fov = Math.atan(1 + filterSize) * math.RAD_TO_DEG * 2;
                 } else {
                     shadowCam.fov = 90;
@@ -63,7 +68,7 @@ class ShadowRendererLocal extends ShadowRenderer {
 
             // cull shadow casters
             this.renderer.updateCameraFrustum(shadowCam);
-            this.cullShadowCasters(drawCalls, lightRenderData.visibleCasters, shadowCam);
+            this.shadowRenderer.cullShadowCasters(drawCalls, lightRenderData.visibleCasters, shadowCam);
         }
     }
 }

--- a/src/scene/renderer/shadow-renderer.js
+++ b/src/scene/renderer/shadow-renderer.js
@@ -5,7 +5,7 @@ import { Mat4 } from '../../core/math/mat4.js';
 import { Vec3 } from '../../core/math/vec3.js';
 import { Vec4 } from '../../core/math/vec4.js';
 
-import { BINDGROUP_MESH, FUNC_LESSEQUAL, SHADERSTAGE_FRAGMENT, SHADERSTAGE_VERTEX, UNIFORMTYPE_MAT4, UNIFORM_BUFFER_DEFAULT_SLOT_NAME } from '../../platform/graphics/constants.js';
+import { FUNC_LESSEQUAL, SHADERSTAGE_FRAGMENT, SHADERSTAGE_VERTEX, UNIFORMTYPE_MAT4, UNIFORM_BUFFER_DEFAULT_SLOT_NAME } from '../../platform/graphics/constants.js';
 import { DebugGraphics } from '../../platform/graphics/debug-graphics.js';
 import { drawQuadWithShader } from '../../platform/graphics/simple-post-effect.js';
 
@@ -255,7 +255,6 @@ class ShadowRenderer {
         const renderer = this.renderer;
         const scene = renderer.scene;
         const passFlags = 1 << SHADER_SHADOW;
-        const supportsUniformBuffers = device.supportsUniformBuffers;
 
         // Sort shadow casters
         const shadowPass = ShaderPass.getShadow(light._type, light._shadowType);


### PR DESCRIPTION
WebGPU platform can render to a shadow map for directional light. The shadow map cannot be still used to sample from, that would be done in a follow up PR.

Part of the changes is refactoring of ShadowRendererLocal and ShadowRendererDirectional - those no longer extend the ShadowRenderer, but share a single instance of it, to limit some resource duplication.

![Screenshot 2022-12-14 at 11 32 20](https://user-images.githubusercontent.com/59932779/207593666-f49efb9c-b140-42f9-b001-f3199c077f77.png)
