### PR TITLE
Plane/Ray add copy/clone methods + prefer ownership over references

### DIFF
--- a/src/core/shape/plane.js
+++ b/src/core/shape/plane.js
@@ -9,16 +9,40 @@ const tmpVecA = new Vec3();
  */
 class Plane {
     /**
+     * The starting point of the plane.
+     *
+     * @type {Vec3}
+     */
+    point = new Vec3();
+
+    /**
+     * The normal of the plane.
+     *
+     * @type {Vec3}
+     */
+    normal = new Vec3();
+
+    /**
      * Create a new Plane instance.
      *
-     * @param {Vec3} [point] - Point position on the plane. The constructor takes a reference of
-     * this parameter.
-     * @param {Vec3} [normal] - Normal of the plane. The constructor takes a reference of this
-     * parameter.
+     * @param {Vec3} [point] - Point position on the plane. The constructor copies this parameter.
+     * @param {Vec3} [normal] - Normal of the plane. The constructor copies this parameter.
      */
-    constructor(point = new Vec3(), normal = new Vec3(0, 0, 1)) {
-        this.point = point;
-        this.normal = normal;
+    constructor(point = Vec3.ZERO, normal = Vec3.BACK) {
+        this.set(point, normal);
+    }
+
+    /**
+     * Sets point and normal to the supplied vector values.
+     *
+     * @param {Vec3} point - The starting point of the plane.
+     * @param {Vec3} normal - The normal of the plane.
+     * @returns {Plane} Self for chaining.
+     */
+    set(point, normal) {
+        this.point.copy(point);
+        this.normal.copy(normal);
+        return this;
     }
 
     /**
@@ -60,6 +84,25 @@ class Plane {
             point.copy(ray.direction).mulScalar(t).add(ray.origin);
 
         return intersects;
+    }
+
+    /**
+     * Copies the contents of a source Plane.
+     *
+     * @param {Plane} src - The Plane to copy from.
+     * @returns {Plane} Self for chaining.
+     */
+    copy(src) {
+        return this.set(src.point, src.normal);
+    }
+
+    /**
+     * Returns a clone of the Plane.
+     *
+     * @returns {this} A duplicate Plane.
+     */
+    clone() {
+        return new this.constructor(this.point, this.normal);
     }
 }
 

--- a/src/core/shape/plane.js
+++ b/src/core/shape/plane.js
@@ -11,6 +11,7 @@ class Plane {
     /**
      * The starting point of the plane.
      *
+     * @readonly
      * @type {Vec3}
      */
     point = new Vec3();
@@ -18,6 +19,7 @@ class Plane {
     /**
      * The normal of the plane.
      *
+     * @readonly
      * @type {Vec3}
      */
     normal = Vec3.BACK.clone();

--- a/src/core/shape/plane.js
+++ b/src/core/shape/plane.js
@@ -13,14 +13,14 @@ class Plane {
      *
      * @type {Vec3}
      */
-    point = new Vec3();
+    point = Vec3.ZERO.clone();
 
     /**
      * The normal of the plane.
      *
      * @type {Vec3}
      */
-    normal = new Vec3();
+    normal = Vec3.BACK.clone();
 
     /**
      * Create a new Plane instance.
@@ -28,8 +28,13 @@ class Plane {
      * @param {Vec3} [point] - Point position on the plane. The constructor copies this parameter.
      * @param {Vec3} [normal] - Normal of the plane. The constructor copies this parameter.
      */
-    constructor(point = Vec3.ZERO, normal = Vec3.BACK) {
-        this.set(point, normal);
+    constructor(point, normal) {
+        if (point) {
+            this.point.copy(point);
+        }
+        if (normal) {
+            this.normal.copy(normal);
+        }
     }
 
     /**

--- a/src/core/shape/plane.js
+++ b/src/core/shape/plane.js
@@ -13,7 +13,7 @@ class Plane {
      *
      * @type {Vec3}
      */
-    point = Vec3.ZERO.clone();
+    point = new Vec3();
 
     /**
      * The normal of the plane.

--- a/src/core/shape/ray.js
+++ b/src/core/shape/ray.js
@@ -9,14 +9,14 @@ class Ray {
      *
      * @type {Vec3}
      */
-    origin = new Vec3();
+    origin = Vec3.ZERO.clone();
 
     /**
      * The direction of the ray.
      *
      * @type {Vec3}
      */
-    direction = new Vec3();
+    direction = Vec3.FORWARD.clone();
 
     /**
      * Creates a new Ray instance. The ray is infinite, starting at a given origin and pointing in
@@ -31,8 +31,13 @@ class Ray {
      * // the entity's negative Z axis
      * var ray = new pc.Ray(this.entity.getPosition(), this.entity.forward);
      */
-    constructor(origin = Vec3.ZERO, direction = Vec3.FORWARD) {
-        this.set(origin, direction);
+    constructor(origin, direction) {
+        if (origin) {
+            this.origin.copy(origin);
+        }
+        if (direction) {
+            this.direction.copy(direction);
+        }
     }
 
     /**

--- a/src/core/shape/ray.js
+++ b/src/core/shape/ray.js
@@ -9,7 +9,7 @@ class Ray {
      *
      * @type {Vec3}
      */
-    origin = Vec3.ZERO.clone();
+    origin = new Vec3();
 
     /**
      * The direction of the ray.

--- a/src/core/shape/ray.js
+++ b/src/core/shape/ray.js
@@ -1,4 +1,3 @@
-import { Debug } from '../debug.js';
 import { Vec3 } from '../math/vec3.js';
 
 /**
@@ -6,34 +5,34 @@ import { Vec3 } from '../math/vec3.js';
  */
 class Ray {
     /**
+     * The starting point of the ray.
+     *
+     * @type {Vec3}
+     */
+    origin = new Vec3();
+
+    /**
+     * The direction of the ray.
+     *
+     * @type {Vec3}
+     */
+    direction = new Vec3();
+
+    /**
      * Creates a new Ray instance. The ray is infinite, starting at a given origin and pointing in
      * a given direction.
      *
-     * @param {Vec3} [origin] - The starting point of the ray. The constructor takes a reference of
+     * @param {Vec3} [origin] - The starting point of the ray. The constructor copies
      * this parameter. Defaults to the origin (0, 0, 0).
-     * @param {Vec3} [direction] - The direction of the ray. The constructor takes a reference of
+     * @param {Vec3} [direction] - The direction of the ray. The constructor copies
      * this parameter. Defaults to a direction down the world negative Z axis (0, 0, -1).
      * @example
      * // Create a new ray starting at the position of this entity and pointing down
      * // the entity's negative Z axis
      * var ray = new pc.Ray(this.entity.getPosition(), this.entity.forward);
      */
-    constructor(origin = new Vec3(), direction = new Vec3(0, 0, -1)) {
-        Debug.assert(!Object.isFrozen(origin), 'The constructor of \'Ray\' does not accept a constant (frozen) object as a \'origin\' parameter');
-        Debug.assert(!Object.isFrozen(direction), 'The constructor of \'Ray\' does not accept a constant (frozen) object as a \'direction\' parameter');
-
-        /**
-         * The starting point of the ray.
-         *
-         * @type {Vec3}
-         */
-        this.origin = origin;
-        /**
-         * The direction of the ray.
-         *
-         * @type {Vec3}
-         */
-        this.direction = direction;
+    constructor(origin = Vec3.ZERO, direction = Vec3.FORWARD) {
+        this.set(origin, direction);
     }
 
     /**
@@ -47,6 +46,25 @@ class Ray {
         this.origin.copy(origin);
         this.direction.copy(direction);
         return this;
+    }
+
+    /**
+     * Copies the contents of a source Ray.
+     *
+     * @param {Ray} src - The Ray to copy from.
+     * @returns {Ray} Self for chaining.
+     */
+    copy(src) {
+        return this.set(src.origin, src.direction);
+    }
+
+    /**
+     * Returns a clone of the Ray.
+     *
+     * @returns {this} A duplicate Ray.
+     */
+    clone() {
+        return new this.constructor(this.origin, this.direction);
     }
 }
 

--- a/src/core/shape/ray.js
+++ b/src/core/shape/ray.js
@@ -7,6 +7,7 @@ class Ray {
     /**
      * The starting point of the ray.
      *
+     * @readonly
      * @type {Vec3}
      */
     origin = new Vec3();
@@ -14,6 +15,7 @@ class Ray {
     /**
      * The direction of the ray.
      *
+     * @readonly
      * @type {Vec3}
      */
     direction = Vec3.FORWARD.clone();


### PR DESCRIPTION
We are preaching that devs should use `Vec3.FORWARD` etc. but then these two classes don't even support it.

This also adds `copy` and `clone` methods that I always expect (but then I run into script errors).

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
