### PR TITLE
Element Drag Helper - Screen to Local gives wrong values if parent is scaled

### DIFF
--- a/src/framework/components/element/element-drag-helper.js
+++ b/src/framework/components/element/element-drag-helper.js
@@ -149,7 +149,7 @@ class ElementDragHelper extends EventHandler {
         this._determineInputPosition(event);
         this._chooseRayOriginAndDirection();
 
-        _plane.point.copy(this._element.entity.getLocalPosition());
+        _plane.point.copy(this._element.entity.getPosition());
         _plane.normal.copy(this._element.entity.forward).mulScalar(-1);
 
         const denominator = _plane.normal.dot(_ray.direction);


### PR DESCRIPTION
Fixes #4934

`_screenToLocal` was using localPosition which meant if the parent of the element is scaled and not at 0, 0, 0 (which is the case for most 3D screens where the default is 0.01 scale), the calculated intersection would be incorrect and the local Z value would change

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
