### PR TITLE
Uniform buffer supports arrays

### DIFF
--- a/examples/src/examples/graphics/grab-pass.tsx
+++ b/examples/src/examples/graphics/grab-pass.tsx
@@ -33,6 +33,9 @@ class GrabPassExample {
             // roughness map
             uniform sampler2D uRoughnessMap;
 
+            // tint colors
+            uniform vec3 tints[4];
+
             // engine built-in constant storing render target size in .xy and inverse size in .zw
             uniform vec4 uScreenSize;
 
@@ -57,6 +60,10 @@ class GrabPassExample {
 
                 // get background pixel color with distorted offset
                 vec3 grabColor = texture2DLodEXT(uSceneColorMap, grabUv + offset, mipmap).rgb;
+
+                // tint the material based on mipmap
+                float tintIndex = clamp(mipmap, 0.0, 3.0);
+                grabColor *= tints[int(tintIndex)];
 
                 // brighten the refracted texture a little bit
                 // brighten even more the rough parts of the glass
@@ -182,6 +189,14 @@ class GrabPassExample {
 
                 // set roughness map
                 refractionMaterial.setParameter('uRoughnessMap', assets.roughness.resource);
+
+                // tint colors
+                refractionMaterial.setParameter('tints[0]', new Float32Array([
+                    1, 0.7, 0.7,    // red
+                    1, 1, 1,        // white
+                    0.7, 0.7, 1,    // blue
+                    1, 1, 1         // white
+                ]));
 
                 // transparency
                 refractionMaterial.blendType = pc.BLEND_NORMAL;

--- a/src/deprecated/deprecated.js
+++ b/src/deprecated/deprecated.js
@@ -46,7 +46,7 @@ import { getProgramLibrary, setProgramLibrary } from '../scene/shader-lib/get-pr
 import { RenderTarget } from '../platform/graphics/render-target.js';
 import { ScopeId } from '../platform/graphics/scope-id.js';
 import { Shader } from '../platform/graphics/shader.js';
-import { ShaderInput } from '../platform/graphics/shader-input.js';
+import { WebglShaderInput } from '../platform/graphics/webgl/webgl-shader-input.js';
 import { Texture } from '../platform/graphics/texture.js';
 import { VertexBuffer } from '../platform/graphics/vertex-buffer.js';
 import { VertexFormat } from '../platform/graphics/vertex-format.js';
@@ -405,7 +405,7 @@ export const gfx = {
     RenderTarget: RenderTarget,
     ScopeId: ScopeId,
     Shader: Shader,
-    ShaderInput: ShaderInput,
+    ShaderInput: WebglShaderInput,
     Texture: Texture,
     UnsupportedBrowserError: UnsupportedBrowserError,
     VertexBuffer: VertexBuffer,

--- a/src/platform/graphics/uniform-buffer.js
+++ b/src/platform/graphics/uniform-buffer.js
@@ -3,6 +3,7 @@ import {
     uniformTypeToName,
     UNIFORMTYPE_INT, UNIFORMTYPE_FLOAT, UNIFORMTYPE_VEC2, UNIFORMTYPE_VEC3,
     UNIFORMTYPE_VEC4, UNIFORMTYPE_IVEC2, UNIFORMTYPE_IVEC3, UNIFORMTYPE_IVEC4,
+    UNIFORMTYPE_FLOATARRAY, UNIFORMTYPE_VEC2ARRAY, UNIFORMTYPE_VEC3ARRAY,
     UNIFORMTYPE_MAT2, UNIFORMTYPE_MAT3
 } from './constants.js';
 
@@ -91,6 +92,30 @@ _updateFunctions[UNIFORMTYPE_MAT3] = (uniformBuffer, value, offset) => {
     dst[offset + 10] = value[8];
 };
 
+_updateFunctions[UNIFORMTYPE_FLOATARRAY] = function (uniformBuffer, value, offset, count) {
+    const dst = uniformBuffer.storageFloat32;
+    for (let i = 0; i < count; i++) {
+        dst[offset + i * 4] = value[i];
+    }
+};
+
+_updateFunctions[UNIFORMTYPE_VEC2ARRAY] = (uniformBuffer, value, offset, count) => {
+    const dst = uniformBuffer.storageFloat32;
+    for (let i = 0; i < count; i++) {
+        dst[offset + i * 4] = value[i * 2];
+        dst[offset + i * 4 + 1] = value[i * 2 + 1];
+    }
+};
+
+_updateFunctions[UNIFORMTYPE_VEC3ARRAY] = (uniformBuffer, value, offset, count) => {
+    const dst = uniformBuffer.storageFloat32;
+    for (let i = 0; i < count; i++) {
+        dst[offset + i * 4] = value[i * 3];
+        dst[offset + i * 4 + 1] = value[i * 3 + 1];
+        dst[offset + i * 4 + 2] = value[i * 3 + 2];
+    }
+};
+
 /**
  * A uniform buffer represents a GPU memory buffer storing the uniforms.
  *
@@ -159,9 +184,10 @@ class UniformBuffer {
         const value = uniformFormat.scopeId.value;
 
         if (value !== null && value !== undefined) {
-            const updateFunction = _updateFunctions[uniformFormat.type];
+
+            const updateFunction = _updateFunctions[uniformFormat.updateType];
             if (updateFunction) {
-                updateFunction(this, value, offset);
+                updateFunction(this, value, offset, uniformFormat.count);
             } else {
                 this.storageFloat32.set(value, offset);
             }

--- a/src/platform/graphics/webgl/webgl-shader-input.js
+++ b/src/platform/graphics/webgl/webgl-shader-input.js
@@ -1,17 +1,17 @@
 import { UNIFORMTYPE_FLOAT, UNIFORMTYPE_FLOATARRAY, UNIFORMTYPE_VEC2, UNIFORMTYPE_VEC3, UNIFORMTYPE_VEC4,
-    UNIFORMTYPE_VEC2ARRAY, UNIFORMTYPE_VEC3ARRAY, UNIFORMTYPE_VEC4ARRAY } from './constants.js';
-import { Version } from './version.js';
+    UNIFORMTYPE_VEC2ARRAY, UNIFORMTYPE_VEC3ARRAY, UNIFORMTYPE_VEC4ARRAY } from '../constants.js';
+import { Version } from '../version.js';
 
 /**
  * Representation of a shader uniform.
  *
  * @ignore
  */
-class ShaderInput {
+class WebglShaderInput {
     /**
-     * Create a new ShaderInput instance.
+     * Create a new WebglShaderInput instance.
      *
-     * @param {import('./graphics-device.js').GraphicsDevice} graphicsDevice - The graphics device
+     * @param {import('../graphics-device.js').GraphicsDevice} graphicsDevice - The graphics device
      * used to manage this shader input.
      * @param {string} name - The name of the shader input.
      * @param {number} type - The type of the shader input.
@@ -47,4 +47,4 @@ class ShaderInput {
     }
 }
 
-export { ShaderInput };
+export { WebglShaderInput };

--- a/src/platform/graphics/webgl/webgl-shader.js
+++ b/src/platform/graphics/webgl/webgl-shader.js
@@ -2,7 +2,7 @@ import { Debug } from '../../../core/debug.js';
 import { TRACEID_SHADER_COMPILE } from '../../../core/constants.js';
 import { now } from '../../../core/time.js';
 
-import { ShaderInput } from '../shader-input.js';
+import { WebglShaderInput } from './webgl-shader-input.js';
 import { SHADERTAG_MATERIAL, semanticToLocation } from '../constants.js';
 
 let _totalCompileTime = 0;
@@ -253,7 +253,7 @@ class WebglShader {
                 console.error(`Vertex shader attribute "${info.name}" is not mapped to a semantic in shader definition.`);
             }
 
-            const shaderInput = new ShaderInput(device, definition.attributes[info.name], device.pcUniformType[info.type], location);
+            const shaderInput = new WebglShaderInput(device, definition.attributes[info.name], device.pcUniformType[info.type], location);
 
             this.attributes.push(shaderInput);
         }
@@ -265,7 +265,7 @@ class WebglShader {
             const info = gl.getActiveUniform(glProgram, i++);
             const location = gl.getUniformLocation(glProgram, info.name);
 
-            const shaderInput = new ShaderInput(device, info.name, device.pcUniformType[info.type], location);
+            const shaderInput = new WebglShaderInput(device, info.name, device.pcUniformType[info.type], location);
 
             if (info.type === gl.SAMPLER_2D || info.type === gl.SAMPLER_CUBE ||
                 (device.webgl2 && (info.type === gl.SAMPLER_2D_SHADOW || info.type === gl.SAMPLER_CUBE_SHADOW || info.type === gl.SAMPLER_3D))

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -560,6 +560,7 @@ class ForwardRenderer extends Renderer {
         const passFlag = 1 << pass;
 
         // Render the scene
+        let skipMaterial = false;
         const preparedCallsCount = preparedCalls.drawCalls.length;
         for (let i = 0; i < preparedCallsCount; i++) {
 
@@ -585,6 +586,11 @@ class ForwardRenderer extends Renderer {
                     if (!shader.failed && !device.setShader(shader)) {
                         Debug.error(`Error compiling shader for material=${material.name} pass=${pass} objDefs=${objDefs}`, material);
                     }
+
+                    // skip rendering with the material if shader failed
+                    skipMaterial = shader.failed;
+                    if (skipMaterial)
+                        break;
 
                     // Uniforms I: material
                     material.setParameters(device);


### PR DESCRIPTION
- added support for uniform arrays of float, vec2, vec3 and vec4. Note that arrays of matrix types are not supported by our WebGL implementation nor UniformBuffers we use on WebGPU
- improved shader error logging / handling (avoids endless error scrolling)
- renamed ShaderInput to WebglShaderInput, as it's only used on WebGL platform
- updated GrabPass example to use uniform array to supply tint colors
![Screenshot 2022-12-19 at 15 39 19](https://user-images.githubusercontent.com/59932779/208466549-71927a2a-583c-4eb3-bf2a-3f41bbf6239c.png)
