### PR TITLE
Fix regression of world space drag bug #3748 

### DIFF
--- a/src/framework/components/element/element-drag-helper.js
+++ b/src/framework/components/element/element-drag-helper.js
@@ -215,7 +215,7 @@ class ElementDragHelper extends EventHandler {
 
         dragScale.x = 1 / dragScale.x;
         dragScale.y = 1 / dragScale.y;
-        dragScale.z = 1 / dragScale.z;
+        dragScale.z = 0;
     }
 
     /**

--- a/src/framework/components/element/element-drag-helper.js
+++ b/src/framework/components/element/element-drag-helper.js
@@ -149,7 +149,7 @@ class ElementDragHelper extends EventHandler {
         this._determineInputPosition(event);
         this._chooseRayOriginAndDirection();
 
-        _plane.point.copy(this._element.entity.getLocalPosition());
+        _plane.point.copy(this._element.entity.getPosition());
         _plane.normal.copy(this._element.entity.forward).mulScalar(-1);
 
         const denominator = _plane.normal.dot(_ray.direction);


### PR DESCRIPTION
Fixes https://github.com/playcanvas/engine/issues/3748

PR https://github.com/playcanvas/engine/pull/4935 reintroduces the bug #3748

This PR zeros out the local Z translation of the drag in `_screenToLocal` so that the element can only move along it's local Y and X axis

1.59

https://user-images.githubusercontent.com/16639049/208466764-9a696a48-025e-40d8-94ef-fb0a17cebd34.mp4


With this PR and #4935

https://user-images.githubusercontent.com/16639049/208466741-67a52e15-fb32-43cc-8a56-8a7a72388750.mp4

CC @kungfooman 

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
