### PR TITLE
[BREAKING] UI Scroll Views now work in XR

### DIFF
--- a/src/framework/components/element/element-drag-helper.js
+++ b/src/framework/components/element/element-drag-helper.js
@@ -79,6 +79,7 @@ class ElementDragHelper extends EventHandler {
     _toggleLifecycleListeners(onOrOff) {
         this._element[onOrOff]('mousedown', this._onMouseDownOrTouchStart, this);
         this._element[onOrOff]('touchstart', this._onMouseDownOrTouchStart, this);
+        this._element[onOrOff]('selectstart', this._onMouseDownOrTouchStart, this);
     }
 
     /**
@@ -105,6 +106,10 @@ class ElementDragHelper extends EventHandler {
             this._element[onOrOff]('touchend', this._onMouseUpOrTouchEnd, this);
             this._element[onOrOff]('touchcancel', this._onMouseUpOrTouchEnd, this);
         }
+
+        // webxr events
+        this._element[onOrOff]('selectmove', this._onMove, this);
+        this._element[onOrOff]('selectend', this._onMouseUpOrTouchEnd, this);
 
         this._hasDragListeners = isOn;
     }
@@ -140,16 +145,20 @@ class ElementDragHelper extends EventHandler {
      * This method calculates the `Vec3` intersection point of plane/ray intersection based on
      * the mouse/touch input event. If there is no intersection, it returns `null`.
      *
-     * @param {import('../../input/element-input').ElementTouchEvent} event - The event.
+     * @param {import('../../input/element-input').ElementTouchEvent | import('../../input/element-input').ElementMouseEvent | import('../../input/element-input').ElementSelectEvent} event - The event.
      * @returns {Vec3|null} The `Vec3` intersection point of plane/ray intersection, if there
      * is an intersection, otherwise `null`
      * @private
      */
     _screenToLocal(event) {
-        this._determineInputPosition(event);
-        this._chooseRayOriginAndDirection();
+        if (event.inputSource) {
+            _ray.set(event.inputSource.getOrigin(), event.inputSource.getDirection());
+        } else {
+            this._determineInputPosition(event);
+            this._chooseRayOriginAndDirection();
+        }
 
-        _plane.point.copy(this._element.entity.getLocalPosition());
+        _plane.point.copy(this._element.entity.getPosition());
         _plane.normal.copy(this._element.entity.forward).mulScalar(-1);
 
         const denominator = _plane.normal.dot(_ray.direction);
@@ -215,7 +224,7 @@ class ElementDragHelper extends EventHandler {
 
         dragScale.x = 1 / dragScale.x;
         dragScale.y = 1 / dragScale.y;
-        dragScale.z = 1 / dragScale.z;
+        dragScale.z = 0;
     }
 
     /**

--- a/src/framework/input/element-input.js
+++ b/src/framework/input/element-input.js
@@ -837,6 +837,10 @@ class ElementInput {
             if (hoveredNow) this._fireEvent('selectenter', new ElementSelectEvent(event, hoveredNow, camera, inputSource));
         }
 
+        if (eventType === 'selectmove' && hoveredBefore) {
+            this._fireEvent('selectmove', new ElementSelectEvent(event, hoveredBefore, camera, inputSource));
+        }
+
         if (eventType === 'selectstart') {
             this._selectedPressedElements[inputSource.id] = hoveredNow;
             if (hoveredNow) this._fireEvent('selectstart', new ElementSelectEvent(event, hoveredNow, camera, inputSource));

--- a/src/framework/input/element-input.js
+++ b/src/framework/input/element-input.js
@@ -837,8 +837,9 @@ class ElementInput {
             if (hoveredNow) this._fireEvent('selectenter', new ElementSelectEvent(event, hoveredNow, camera, inputSource));
         }
 
-        if (eventType === 'selectmove' && hoveredBefore) {
-            this._fireEvent('selectmove', new ElementSelectEvent(event, hoveredBefore, camera, inputSource));
+        const pressed = this._selectedPressedElements[inputSource.id];
+        if (eventType === 'selectmove' && pressed) {
+            this._fireEvent('selectmove', new ElementSelectEvent(event, pressed, camera, inputSource));
         }
 
         if (eventType === 'selectstart') {
@@ -846,16 +847,19 @@ class ElementInput {
             if (hoveredNow) this._fireEvent('selectstart', new ElementSelectEvent(event, hoveredNow, camera, inputSource));
         }
 
-        const pressed = this._selectedPressedElements[inputSource.id];
         if (!inputSource.elementInput && pressed) {
             delete this._selectedPressedElements[inputSource.id];
-            if (hoveredBefore) this._fireEvent('selectend', new ElementSelectEvent(event, hoveredBefore, camera, inputSource));
+            if (hoveredBefore) {
+                this._fireEvent('selectend', new ElementSelectEvent(event, pressed, camera, inputSource));
+            }
         }
 
         if (eventType === 'selectend' && inputSource.elementInput) {
             delete this._selectedPressedElements[inputSource.id];
 
-            if (hoveredBefore) this._fireEvent('selectend', new ElementSelectEvent(event, hoveredBefore, camera, inputSource));
+            if (pressed) {
+                this._fireEvent('selectend', new ElementSelectEvent(event, pressed, camera, inputSource));
+            }
 
             if (pressed && pressed === hoveredBefore) {
                 this._fireEvent('click', new ElementSelectEvent(event, pressed, camera, inputSource));


### PR DESCRIPTION
Fixes #3983

Tested in AR and VR with these projects that already have the PR engine build in them:
- https://playcanvas.com/project/1021298/overview/f-webxr-ui-interaction
- https://playcanvas.com/project/1020950/overview/vr-scrolling-elements

https://user-images.githubusercontent.com/16639049/208667064-2c011316-0f4b-4604-a2f3-5ad8b18abb80.mp4

Breaking change: The `selectend` XR input event for elements has changed to work like `touchend` where it fires the event on the element that it was originally pressed on rather than the element that it is currently on.

I believe this will affect a very small number of users as typically they would either use `click` event to know if a button has been pressed or `selectstart` if they wanted an immediately response.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
