### PR TITLE
[Fix] Fix to light options processing causing clustered shaders compilation when lights change

### DIFF
--- a/src/scene/shader-lib/programs/standard.js
+++ b/src/scene/shader-lib/programs/standard.js
@@ -59,15 +59,20 @@ const standard = {
         }
 
         if (options.litOptions) {
-            for (const m in options.litOptions)
-                key += m + options.litOptions[m];
-            if (options.litOptions.lights) {
-                const isClustered = options.litOptions.clusteredLightingEnabled;
-                for (let i = 0; i < options.litOptions.lights.length; i++) {
-                    const light = options.litOptions.lights[i];
-                    if (!isClustered || light._type === LIGHTTYPE_DIRECTIONAL) {
-                        key += light.key;
+
+            for (const m in options.litOptions) {
+
+                // handle lights in a custom way
+                if (m === 'lights') {
+                    const isClustered = options.litOptions.clusteredLightingEnabled;
+                    for (let i = 0; i < options.litOptions.lights.length; i++) {
+                        const light = options.litOptions.lights[i];
+                        if (!isClustered || light._type === LIGHTTYPE_DIRECTIONAL) {
+                            key += light.key;
+                        }
                     }
+                } else {
+                    key += m + options.litOptions[m];
                 }
             }
         }


### PR DESCRIPTION
- fixes a regression introduced in #4792 when light options were always copied, and should be ignored for local lights when clustered lighting is enabled

This was causing new shader to be created / compiled in ClusteredSpotLIghts example when adding lights.

![image](https://user-images.githubusercontent.com/59932779/211299355-f1f84a54-164c-4bf8-8996-eb6e07ca59aa.png)
