### PR TITLE
[Fix] Fix null access caused in clustered light code when no meshes use lights

### DIFF
--- a/src/scene/composition/layer-composition.js
+++ b/src/scene/composition/layer-composition.js
@@ -542,6 +542,8 @@ class LayerComposition extends EventHandler {
             const ra = this._renderActions[i];
             const layer = this.layerList[ra.layerIndex];
 
+            ra.lightClusters = null;
+
             // if the layer has lights used by clusters
             if (layer.hasClusteredLights) {
 


### PR DESCRIPTION
Fixes #4950 

Caused by keeping a reference to released WorldClusters in case a layer no longer has meshes, instead of setting it to null.