### PR TITLE
Moved compiled shader cache from device to DeviceCache instance

### DIFF
--- a/src/platform/graphics/device-cache.js
+++ b/src/platform/graphics/device-cache.js
@@ -27,6 +27,11 @@ class DeviceCache {
             device.on('destroy', () => {
                 this.remove(device);
             });
+
+            // when the context is lost, call optional loseContext on its entry
+            device.on('devicelost', () => {
+                this._cache.get(device)?.loseContext?.(device);
+            });
         }
 
         return this._cache.get(device);
@@ -38,7 +43,7 @@ class DeviceCache {
      * @param {import('./graphics-device.js').GraphicsDevice} device - The graphics device.
      */
     remove(device) {
-        this._cache.get(device)?.destroy();
+        this._cache.get(device)?.destroy(device);
         this._cache.delete(device);
     }
 }

--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -738,7 +738,6 @@ class WebglGraphicsDevice extends GraphicsDevice {
             gl.deleteTransformFeedback(this.feedback);
         }
 
-        this.clearShaderCache();
         this.clearVertexArrayObjectCache();
 
         this.canvas.removeEventListener('webglcontextlost', this._contextLostHandler, false);
@@ -1089,10 +1088,6 @@ class WebglGraphicsDevice extends GraphicsDevice {
 
     initializeContextCaches() {
         super.initializeContextCaches();
-
-        // Shader code to WebGL shader cache
-        this.vertexShaderCache = {};
-        this.fragmentShaderCache = {};
 
         // cache of VAOs
         this._vaoMap = new Map();
@@ -2769,23 +2764,6 @@ class WebglGraphicsDevice extends GraphicsDevice {
             return PIXELFORMAT_RGBA32F;
         } /* else */
         return null;
-    }
-
-    /**
-     * Frees memory from all shaders ever allocated with this device.
-     *
-     * @ignore
-     */
-    clearShaderCache() {
-        const gl = this.gl;
-        for (const shaderSrc in this.fragmentShaderCache) {
-            gl.deleteShader(this.fragmentShaderCache[shaderSrc]);
-            delete this.fragmentShaderCache[shaderSrc];
-        }
-        for (const shaderSrc in this.vertexShaderCache) {
-            gl.deleteShader(this.vertexShaderCache[shaderSrc]);
-            delete this.vertexShaderCache[shaderSrc];
-        }
     }
 
     /**

--- a/src/platform/graphics/webgl/webgl-shader.js
+++ b/src/platform/graphics/webgl/webgl-shader.js
@@ -21,7 +21,7 @@ class CompiledShaderCache {
     // maps shader source to a compiled WebGL shader
     map = new Map();
 
-    // destroy all created shaders when the device is dstroyed
+    // destroy all created shaders when the device is destroyed
     destroy(device) {
         this.map.forEach((shader) => {
             device.gl.deleteShader(shader);

--- a/src/platform/graphics/webgl/webgl-shader.js
+++ b/src/platform/graphics/webgl/webgl-shader.js
@@ -4,6 +4,7 @@ import { now } from '../../../core/time.js';
 
 import { WebglShaderInput } from './webgl-shader-input.js';
 import { SHADERTAG_MATERIAL, semanticToLocation } from '../constants.js';
+import { DeviceCache } from '../device-cache.js';
 
 let _totalCompileTime = 0;
 
@@ -14,6 +15,27 @@ const _vertexShaderBuiltins = [
     'gl_BaseVertex',
     'gl_BaseInstance'
 ];
+
+// class used to hold compiled WebGL vertex or fragment shaders in the device cache
+class CompiledShaderCache {
+    // maps shader source to a compiled WebGL shader
+    map = new Map();
+
+    // destroy all created shaders when the device is dstroyed
+    destroy(device) {
+        this.map.forEach((shader) => {
+            device.gl.deleteShader(shader);
+        });
+    }
+
+    // just empty the cache when the context is lost
+    loseContext(device) {
+        this.map.clear();
+    }
+}
+
+const _vertexShaderCache = new DeviceCache();
+const _fragmentShaderCache = new DeviceCache();
 
 /**
  * A WebGL implementation of the Shader.
@@ -148,8 +170,15 @@ class WebglShader {
      */
     _compileShaderSource(device, src, isVertexShader) {
         const gl = device.gl;
-        const shaderCache = isVertexShader ? device.vertexShaderCache : device.fragmentShaderCache;
-        let glShader = shaderCache[src];
+
+        // device cache for current device, containing cache of compiled shaders
+        const shaderDeviceCache = isVertexShader ? _vertexShaderCache : _fragmentShaderCache;
+        const shaderCache = shaderDeviceCache.get(device, () => {
+            return new CompiledShaderCache();
+        });
+
+        // try to get compiled shader from the cache
+        let glShader = shaderCache.map.get(src);
 
         if (!glShader) {
             // #if _PROFILER
@@ -165,7 +194,7 @@ class WebglShader {
             gl.shaderSource(glShader, src);
             gl.compileShader(glShader);
 
-            shaderCache[src] = glShader;
+            shaderCache.map.set(src, glShader);
 
             // #if _PROFILER
             const endTime = now();

--- a/src/scene/shader-lib/program-library.js
+++ b/src/scene/shader-lib/program-library.js
@@ -158,6 +158,8 @@ class ProgramLibrary {
                 if ((options.hasOwnProperty(p) && defaultMat[p] !== options[p]) || p === "pass")
                     opt[p] = options[p];
             }
+
+            // Note: this was added in #4792 and it does not filter out the default values, like the loop above
             for (const p in options.litOptions) {
                 opt[p] = options.litOptions[p];
             }


### PR DESCRIPTION
- small refactor, to move a cache of compiled vertex / fragment shaders away from GraphicsDevice, as only WebglShader needs it.
- improved DeviceCache class to handle optional lostContext