### PR TITLE
Fix light conservation also affecting ambient (diffuse) light.

### DIFF
--- a/src/scene/shader-lib/programs/lit-shader.js
+++ b/src/scene/shader-lib/programs/lit-shader.js
@@ -1015,6 +1015,9 @@ class LitShader {
 
         if (addAmbient) {
             code += "    addAmbient();\n";
+            if (options.conserveEnergy && options.useSpecular) {
+                code += `   dDiffuseLight = mix(dDiffuseLight, vec3(0), dSpecularity);`;
+            }
 
             // move ambient color out of diffuse (used by Lightmapper, to multiply ambient color by accumulated AO)
             if (options.separateAmbient) {


### PR DESCRIPTION
Fixes issue where the energy conservation option didn't apply to ambient lights. This PR pertains to the issue here: https://forum.playcanvas.com/t/changes-to-how-diffuse-specular-is-combined-since-v1-55/28984/10. 

In 1.55 we used to combine the diffuse and specular light with a linear interpolation at the end of the shader, which aimed to preserve the energy on the material, however when refactoring the specular lighting code, this code was removed. 

This PR reimplements it more correctly, by separately multiplying the diffuse and specular components with the weight factor, instead of doing it twice as we did before. 

Before:
![image](https://user-images.githubusercontent.com/107400752/211567382-fd7c1084-6452-4f3b-9fb2-9fd44879f496.png)

After: 
![image](https://user-images.githubusercontent.com/107400752/211575244-558ff3c6-8824-42d7-a60b-251cdb230481.png)

Disabling `conserveEnergy` on the material would make the change appear as in the Before picture. 