### PR TITLE
Rename material uniform glossiness to gloss

### DIFF
--- a/src/framework/parsers/glb-parser.js
+++ b/src/framework/parsers/glb-parser.js
@@ -18,7 +18,7 @@ import {
     PRIMITIVE_LINELOOP, PRIMITIVE_LINESTRIP, PRIMITIVE_LINES, PRIMITIVE_POINTS, PRIMITIVE_TRIANGLES, PRIMITIVE_TRIFAN, PRIMITIVE_TRISTRIP,
     SEMANTIC_POSITION, SEMANTIC_NORMAL, SEMANTIC_TANGENT, SEMANTIC_COLOR, SEMANTIC_BLENDINDICES, SEMANTIC_BLENDWEIGHT,
     SEMANTIC_TEXCOORD0, SEMANTIC_TEXCOORD1, SEMANTIC_TEXCOORD2, SEMANTIC_TEXCOORD3, SEMANTIC_TEXCOORD4, SEMANTIC_TEXCOORD5, SEMANTIC_TEXCOORD6, SEMANTIC_TEXCOORD7,
-    TYPE_INT8, TYPE_UINT8, TYPE_INT16, TYPE_UINT16, TYPE_INT32, TYPE_UINT32, TYPE_FLOAT32, CHUNKAPI_1_58
+    TYPE_INT8, TYPE_UINT8, TYPE_INT16, TYPE_UINT16, TYPE_INT32, TYPE_UINT32, TYPE_FLOAT32
 } from '../../platform/graphics/constants.js';
 import { IndexBuffer } from '../../platform/graphics/index-buffer.js';
 import { Texture } from '../../platform/graphics/texture.js';
@@ -1223,8 +1223,6 @@ const createMaterial = function (gltfMaterial, textures, flipV) {
 
     material.specularTint = true;
     material.specularVertexColor = true;
-
-    material.chunks.APIVersion = CHUNKAPI_1_58;
 
     if (gltfMaterial.hasOwnProperty('name')) {
         material.name = gltfMaterial.name;

--- a/src/platform/graphics/constants.js
+++ b/src/platform/graphics/constants.js
@@ -1258,3 +1258,4 @@ export const CHUNKAPI_1_55 = '1.55';
 export const CHUNKAPI_1_56 = '1.56';
 export const CHUNKAPI_1_57 = '1.57';
 export const CHUNKAPI_1_58 = '1.58';
+export const CHUNKAPI_1_60 = '1.60';

--- a/src/platform/graphics/constants.js
+++ b/src/platform/graphics/constants.js
@@ -1248,7 +1248,7 @@ semanticToLocation[SEMANTIC_ATTR13] = 13;
 semanticToLocation[SEMANTIC_ATTR14] = 14;
 semanticToLocation[SEMANTIC_ATTR15] = 15;
 
-/**s
+/**
  * Chunk API versions
  *
  * @type {string}

--- a/src/platform/graphics/constants.js
+++ b/src/platform/graphics/constants.js
@@ -1257,4 +1257,5 @@ export const CHUNKAPI_1_51 = '1.51';
 export const CHUNKAPI_1_55 = '1.55';
 export const CHUNKAPI_1_56 = '1.56';
 export const CHUNKAPI_1_57 = '1.57';
+export const CHUNKAPI_1_58 = '1.58';
 export const CHUNKAPI_1_60 = '1.60';

--- a/src/platform/graphics/constants.js
+++ b/src/platform/graphics/constants.js
@@ -1257,5 +1257,4 @@ export const CHUNKAPI_1_51 = '1.51';
 export const CHUNKAPI_1_55 = '1.55';
 export const CHUNKAPI_1_56 = '1.56';
 export const CHUNKAPI_1_57 = '1.57';
-export const CHUNKAPI_1_58 = '1.58';
 export const CHUNKAPI_1_60 = '1.60';

--- a/src/platform/graphics/constants.js
+++ b/src/platform/graphics/constants.js
@@ -1248,7 +1248,7 @@ semanticToLocation[SEMANTIC_ATTR13] = 13;
 semanticToLocation[SEMANTIC_ATTR14] = 14;
 semanticToLocation[SEMANTIC_ATTR15] = 15;
 
-/**
+/**s
  * Chunk API versions
  *
  * @type {string}

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -702,7 +702,7 @@ class StandardMaterial extends Material {
                 this._setParameter('material_sheen', getUniform('sheen'));
             }
             if (!this.sheenGlossMap || this.sheenGlossTint) {
-                this._setParameter('material_sheenGlossiness', this.sheenGloss);
+                this._setParameter('material_sheenGloss', this.sheenGloss);
             }
 
             if (this.refractionIndex !== 1.0 / 1.5) {
@@ -721,11 +721,11 @@ class StandardMaterial extends Material {
 
         if (this.clearCoat > 0) {
             this._setParameter('material_clearCoat', this.clearCoat);
-            this._setParameter('material_clearCoatGlossiness', this.clearCoatGloss);
+            this._setParameter('material_clearCoatGloss', this.clearCoatGloss);
             this._setParameter('material_clearCoatBumpiness', this.clearCoatBumpiness);
         }
 
-        this._setParameter('material_glossiness', getUniform('gloss'));
+        this._setParameter('material_gloss', getUniform('gloss'));
 
         if (!this.emissiveMap || this.emissiveTint) {
             this._setParameter('material_emissive', getUniform('emissive'));

--- a/src/scene/shader-lib/chunks/chunk-validation.js
+++ b/src/scene/shader-lib/chunks/chunk-validation.js
@@ -1,4 +1,4 @@
-import { CHUNKAPI_1_51, CHUNKAPI_1_55, CHUNKAPI_1_56, CHUNKAPI_1_57, CHUNKAPI_1_58, CHUNKAPI_1_60 } from '../../../platform/graphics/constants.js';
+import { CHUNKAPI_1_51, CHUNKAPI_1_55, CHUNKAPI_1_56, CHUNKAPI_1_57, CHUNKAPI_1_60 } from '../../../platform/graphics/constants.js';
 import { Debug } from '../../../core/debug.js';
 import { shaderChunks } from './chunks.js';
 

--- a/src/scene/shader-lib/chunks/chunk-validation.js
+++ b/src/scene/shader-lib/chunks/chunk-validation.js
@@ -1,4 +1,4 @@
-import { CHUNKAPI_1_51, CHUNKAPI_1_55, CHUNKAPI_1_56, CHUNKAPI_1_57, CHUNKAPI_1_58 } from '../../../platform/graphics/constants.js';
+import { CHUNKAPI_1_51, CHUNKAPI_1_55, CHUNKAPI_1_56, CHUNKAPI_1_57, CHUNKAPI_1_58, CHUNKAPI_1_60 } from '../../../platform/graphics/constants.js';
 import { Debug } from '../../../core/debug.js';
 import { shaderChunks } from './chunks.js';
 
@@ -6,11 +6,12 @@ const chunkVersions = {
     // frontend
     aoPS: CHUNKAPI_1_57,
     clearCoatPS: CHUNKAPI_1_57,
-    clearCoatGlossPS: CHUNKAPI_1_57,
+    clearCoatGlossPS: CHUNKAPI_1_60,
     clearCoatNormalPS: CHUNKAPI_1_57,
     diffusePS: CHUNKAPI_1_57,
     diffuseDetailMapPS: CHUNKAPI_1_57,
     emissivePS: CHUNKAPI_1_57,
+    glossPS: CHUNKAPI_1_60,
     lightmapDirPS: CHUNKAPI_1_55,
     lightmapSinglePS: CHUNKAPI_1_55,
     metalnessPS: CHUNKAPI_1_57,
@@ -19,7 +20,7 @@ const chunkVersions = {
     opacityPS: CHUNKAPI_1_57,
     parallaxPS: CHUNKAPI_1_57,
     sheenPS: CHUNKAPI_1_57,
-    sheenGlossPS: CHUNKAPI_1_58,
+    sheenGlossPS: CHUNKAPI_1_60,
     specularPS: CHUNKAPI_1_57,
     specularityFactorPS: CHUNKAPI_1_57,
     thicknessPS: CHUNKAPI_1_57,

--- a/src/scene/shader-lib/chunks/standard/frag/clearCoatGloss.js
+++ b/src/scene/shader-lib/chunks/standard/frag/clearCoatGloss.js
@@ -1,13 +1,13 @@
 export default /* glsl */`
 #ifdef MAPFLOAT
-uniform float material_clearCoatGlossiness;
+uniform float material_clearCoatGloss;
 #endif
 
 void getClearCoatGlossiness() {
     ccGlossiness = 1.0;
 
     #ifdef MAPFLOAT
-    ccGlossiness *= material_clearCoatGlossiness;
+    ccGlossiness *= material_clearCoatGloss;
     #endif
 
     #ifdef MAPTEXTURE

--- a/src/scene/shader-lib/chunks/standard/frag/gloss.js
+++ b/src/scene/shader-lib/chunks/standard/frag/gloss.js
@@ -1,13 +1,13 @@
 export default /* glsl */`
 #ifdef MAPFLOAT
-uniform float material_glossiness;
+uniform float material_gloss;
 #endif
 
 void getGlossiness() {
     dGlossiness = 1.0;
 
     #ifdef MAPFLOAT
-    dGlossiness *= material_glossiness;
+    dGlossiness *= material_gloss;
     #endif
 
     #ifdef MAPTEXTURE

--- a/src/scene/shader-lib/chunks/standard/frag/sheenGloss.js
+++ b/src/scene/shader-lib/chunks/standard/frag/sheenGloss.js
@@ -1,13 +1,13 @@
 export default /* glsl */`
 #ifdef MAPFLOAT
-uniform float material_sheenGlossiness;
+uniform float material_sheenGloss;
 #endif
 
 void getSheenGlossiness() {
     float sheenGlossiness = 1.0;
 
     #ifdef MAPFLOAT
-    sheenGlossiness *= material_sheenGlossiness;
+    sheenGlossiness *= material_sheenGloss;
     #endif
 
     #ifdef MAPTEXTURE


### PR DESCRIPTION
Fixes #4952

Rename material uniforms from glossiness -> gloss and update chunk API versions.