### PR TITLE
Update to WebGL shader compilation and linking

### DIFF
--- a/src/platform/graphics/device-cache.js
+++ b/src/platform/graphics/device-cache.js
@@ -43,7 +43,7 @@ class DeviceCache {
      * @param {import('./graphics-device.js').GraphicsDevice} device - The graphics device.
      */
     remove(device) {
-        this._cache.get(device)?.destroy(device);
+        this._cache.get(device)?.destroy?.(device);
         this._cache.delete(device);
     }
 }

--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -1156,6 +1156,15 @@ class WebglGraphicsDevice extends GraphicsDevice {
     }
 
     /**
+     * Called after a batch of shaders was created, to guide in their optimal preparation for rendering.
+     *
+     * @ignore
+     */
+    endShaderBatch() {
+        WebglShader.endShaderBatch(this);
+    }
+
+    /**
      * Set the active rectangle for rendering on the specified device.
      *
      * @param {number} x - The pixel space x-coordinate of the bottom left corner of the viewport.

--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -2714,7 +2714,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
         if (shader !== this.shader) {
             if (shader.failed) {
                 return false;
-            } else if (!shader.ready && !shader.impl.postLink(this, shader)) {
+            } else if (!shader.ready && !shader.impl.finalize(this, shader)) {
                 shader.failed = true;
                 return false;
             }

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -513,6 +513,9 @@ class ForwardRenderer extends Renderer {
 
                 if (!drawCall._shader[pass] || drawCall._shaderDefs !== objDefs || drawCall._lightHash !== lightHash) {
 
+                    // marker to allow us to see the source node for shader alloc
+                    DebugGraphics.pushGpuMarker(device, drawCall.node.name);
+
                     // draw calls not using static lights use variants cache on material to quickly find the shader, as they are all
                     // the same for the same pass, using all lights of the scene
                     if (!drawCall.isStatic) {
@@ -529,6 +532,8 @@ class ForwardRenderer extends Renderer {
                         drawCall.updatePassShader(scene, pass, drawCall._staticLightList, sortedLights, this.viewUniformFormat, this.viewBindGroupFormat);
                     }
                     drawCall._lightHash = lightHash;
+
+                    DebugGraphics.popGpuMarker(device);
                 }
 
                 Debug.assert(drawCall._shader[pass], "no shader for pass", material);
@@ -541,6 +546,9 @@ class ForwardRenderer extends Renderer {
                 prevStatic = drawCall.isStatic;
             }
         }
+
+        // process any catch of shaders created here
+        device.endShaderBatch();
 
         return _drawCallList;
     }

--- a/src/scene/renderer/shadow-renderer.js
+++ b/src/scene/renderer/shadow-renderer.js
@@ -259,6 +259,9 @@ class ShadowRenderer {
         // Sort shadow casters
         const shadowPass = ShaderPass.getShadow(light._type, light._shadowType);
 
+        // TODO: Similarly to forward renderer, a shader creation part of this loop should be split into a separate loop,
+        // and endShaderBatch should be called at its end
+
         // Render
         const count = visibleCasters.length;
         for (let i = 0; i < count; i++) {


### PR DESCRIPTION
Fixes https://github.com/playcanvas/engine/issues/3559

Situation before:
- when a shader is created (which happens at a point the mesh using it needs to be rendered), it would internally compile both vertex and fragment shaders, and then it would immediate link them and wait for the result, blocking the main thread till the shaders are compiled.

Situation now:
- The way forward renderer mesh drawing loop was refactored months ago is that we loop over the meshes in two passes. In the first loop, we just create shaders if those are missing. The second loop uses those shaders for rendering. With this PR, the shader creation was changed to only trigger their compilation. The shader linking takes place when a batch of shaders is created by forward renderer - basically after shaders for a layer are created (so one batch for shadows, one for forward pass for example). This only kicks off linking of all those new shaders, without waiting for the results, so they can link in parallel. Waiting on the result is done when the shader is set up for rendering.

What this delivers is conceptually this (2 meshes with 2 shaders):

**Before:**
```
shader1.vertex.compile
shader1.fragment.compile
shader1.link
shader1.finalize **(blocking)**
shader2.vertex.compile
shader2.fragment.compile
shader2.link
shader2.finalize **(blocking)**
```

**Now:**
```
shader1.vertex.compile
shader1.fragment.compile
shader2.vertex.compile
shader2.fragment.compile
shader1.link
shader2.link
shader1.finalize **(blocking)**
shader2.finalize **(blocking)**
```

Note that those loops execute per render layer / render pass, so shadows would do compile/link/finalize on shaders before main forward pass woud.

The actual log from multi-view engine example (the number is unique ID of the shader):
![Screenshot 2023-01-10 at 17 32 34](https://user-images.githubusercontent.com/59932779/211621859-2bca80a9-b8bf-4ceb-b633-216b1edc8123.png)

In a larger project, I see a lot more shaders getting compiled before any linking, for example
![Screenshot 2023-01-10 at 17 38 34](https://user-images.githubusercontent.com/59932779/211623095-36091fe3-69ec-4c60-a450-26d34921ad5a.png)


So in theory, this does the right thing, but in practise, on few projects I have tried, I cannot see a performance difference (using Chrome on both MacOS and Windows).