### PR TITLE
Load old material glossiness correctly

### DIFF
--- a/src/framework/parsers/material/json-standard-material.js
+++ b/src/framework/parsers/material/json-standard-material.js
@@ -132,7 +132,9 @@ class JsonStandardMaterialParser {
             ['diffuseMapTint', 'diffuseTint'],
             ['specularMapTint', 'specularTint'],
             ['emissiveMapTint', 'emissiveTint'],
-            ['metalnessMapTint', 'metalnessTint']
+            ['metalnessMapTint', 'metalnessTint'],
+
+            ['clearCoatGlossiness', 'clearCoatGloss']
         ];
 
         // if an old property name exists without a new one,


### PR DESCRIPTION
The clearCoatGloss member of StandardMaterial was recently renamed to have consistent naming. This PR adds it to the renamed properties so it is correctly loaded.