### PR TITLE
Remove energy conservation for ambient light when using the phong model.

### DIFF
--- a/src/scene/materials/standard-material-options-builder.js
+++ b/src/scene/materials/standard-material-options-builder.js
@@ -275,7 +275,7 @@ class StandardMaterialOptionsBuilder {
         options.litOptions.cubeMapProjection = stdMat.cubeMapProjection;
 
         options.litOptions.occludeDirect = stdMat.occludeDirect;
-        options.litOptions.conserveEnergy = stdMat.conserveEnergy;
+        options.litOptions.conserveEnergy = stdMat.conserveEnergy && stdMat.shadingModel !== SPECULAR_PHONG;
         options.litOptions.useSpecular = useSpecular;
         options.litOptions.useSpecularityFactor = (specularityFactorTint || !!stdMat.specularityFactorMap) && stdMat.useMetalnessSpecularColor;
         options.litOptions.useSpecularColor = useSpecularColor;

--- a/src/scene/shader-lib/programs/lit-shader.js
+++ b/src/scene/shader-lib/programs/lit-shader.js
@@ -1015,7 +1015,7 @@ class LitShader {
 
         if (addAmbient) {
             code += "    addAmbient();\n";
-            if (options.conserveEnergy && options.useSpecular && options.shadingModel !== SPECULAR_PHONG) {
+            if (options.conserveEnergy && options.useSpecular) {
                 code += `   dDiffuseLight = dDiffuseLight * (1.0 - dSpecularity);`;
             }
 

--- a/src/scene/shader-lib/programs/lit-shader.js
+++ b/src/scene/shader-lib/programs/lit-shader.js
@@ -1015,7 +1015,7 @@ class LitShader {
 
         if (addAmbient) {
             code += "    addAmbient();\n";
-            if (options.conserveEnergy && options.useSpecular) {
+            if (options.conserveEnergy && options.useSpecular && options.shadingModel !== SPECULAR_PHONG) {
                 code += `   dDiffuseLight = dDiffuseLight * (1.0 - dSpecularity);`;
             }
 


### PR DESCRIPTION
The energy conservation introduced in #4961 was applied when using the phong model, even if it shouldn't have. 