### PR TITLE
[Fix] Fix to non-clustered omni shadow rendering

### DIFF
--- a/examples/src/examples/graphics/lights.tsx
+++ b/examples/src/examples/graphics/lights.tsx
@@ -92,7 +92,9 @@ class LightsExample {
                 // @ts-ignore
                 pc.TextureHandler,
                 // @ts-ignore
-                pc.ContainerHandler
+                pc.ContainerHandler,
+                // @ts-ignore
+                pc.CubemapHandler
             ];
 
             const app = new pc.AppBase(canvas);

--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -1866,7 +1866,10 @@ class WebglGraphicsDevice extends GraphicsDevice {
                 }
                 // #endif
 
-                continue; // Because unset constants shouldn't raise random errors
+                Debug.errorOnce(`Shader [${shader.label}] requires texture sampler [${samplerName}] which has not been set, while rendering [${DebugGraphics.toString()}]`);
+
+                // skip this draw call to avoid incorrect rendering / webgl errors
+                return;
             }
 
             if (samplerValue instanceof Texture) {
@@ -1920,6 +1923,9 @@ class WebglGraphicsDevice extends GraphicsDevice {
                 // Call the function to commit the uniform value
                 if (scopeId.value !== null) {
                     this.commitFunction[uniform.dataType](uniform, scopeId.value);
+                } else {
+                    // commented out till engine issue #4971 is sorted out
+                    // Debug.warnOnce(`Shader [${shader.label}] requires uniform [${uniform.scopeId.name}] which has not been set, while rendering [${DebugGraphics.toString()}]`);
                 }
             }
         }

--- a/src/scene/renderer/renderer.js
+++ b/src/scene/renderer/renderer.js
@@ -971,7 +971,9 @@ class Renderer {
 
         // update shadow / cookie atlas allocation for the visible lights. Update it after the ligthts were culled,
         // but before shadow maps were culling, as it might force some 'update once' shadows to cull.
-        this.updateLightTextureAtlas(comp);
+        if (this.scene.clusteredLightingEnabled) {
+            this.updateLightTextureAtlas(comp);
+        }
 
         // cull shadow casters for all lights
         this.cullShadowmaps(comp);

--- a/src/scene/renderer/shadow-renderer.js
+++ b/src/scene/renderer/shadow-renderer.js
@@ -322,7 +322,9 @@ class ShadowRenderer {
             light.shadowUpdateMode = SHADOWUPDATE_NONE;
         }
 
-        this.renderer._shadowMapUpdates += light.numShadowFaces;
+        if (needs) {
+            this.renderer._shadowMapUpdates += light.numShadowFaces;
+        }
 
         return needs;
     }


### PR DESCRIPTION
Sorts out an issue introduced here: https://github.com/playcanvas/engine/pull/4958
- only calls this.updateLightTextureAtlas for clustered lights

Additionally
- in Lights example adds a missing handler to load cookie cubemap
- does not increment _shadowMapUpdates unless the shadow actually renders
- added error when texture required by the uniform is missing, as that causes hard to debug issues like this:
<img width="1197" alt="Screenshot 2023-01-11 at 17 51 37" src="https://user-images.githubusercontent.com/59932779/212075793-188a7a08-cc11-4039-bd02-396877e6d4aa.png">

Now we get a lot more useful engine errors
![Screenshot 2023-01-12 at 11 13 48](https://user-images.githubusercontent.com/59932779/212075876-d6ddb38a-3f0d-46fb-a80c-30f81684f5f0.png)
