### PR TITLE
Properly deprecated Timer class

### DIFF
--- a/src/core/time.js
+++ b/src/core/time.js
@@ -9,45 +9,4 @@ const now = (typeof window !== 'undefined') && window.performance && window.perf
     performance.now.bind(performance) :
     Date.now;
 
-/**
- * A Timer counts milliseconds from when start() is called until when stop() is called.
- *
- * @ignore
- */
-class Timer {
-    /**
-     * Create a new Timer instance.
-     */
-    constructor() {
-        this._isRunning = false;
-        this._a = 0;
-        this._b = 0;
-    }
-
-    /**
-     * Start the timer.
-     */
-    start() {
-        this._isRunning = true;
-        this._a = now();
-    }
-
-    /**
-     * Stop the timer.
-     */
-    stop() {
-        this._isRunning = false;
-        this._b = now();
-    }
-
-    /**
-     * Get the number of milliseconds that passed between start() and stop() being called.
-     *
-     * @returns {number} The elapsed milliseconds.
-     */
-    getMilliseconds() {
-        return this._b - this._a;
-    }
-}
-
-export { now, Timer };
+export { now };

--- a/src/deprecated/deprecated.js
+++ b/src/deprecated/deprecated.js
@@ -1,6 +1,6 @@
 import { revision, version } from '../core/core.js';
 import { string } from '../core/string.js';
-import { Timer, now } from '../core/time.js';
+import { now } from '../core/time.js';
 import { Debug } from '../core/debug.js';
 
 import { math } from '../core/math/math.js';
@@ -170,6 +170,28 @@ string.startsWith = function (s, subs) {
     Debug.deprecated('pc.string.startsWith is deprecated. Use String#startsWith instead.');
     return s.startsWith(subs);
 };
+
+class Timer {
+    constructor() {
+        this._isRunning = false;
+        this._a = 0;
+        this._b = 0;
+    }
+
+    start() {
+        this._isRunning = true;
+        this._a = now();
+    }
+
+    stop() {
+        this._isRunning = false;
+        this._b = now();
+    }
+
+    getMilliseconds() {
+        return this._b - this._a;
+    }
+}
 
 export const time = {
     now: now,

--- a/src/index.js
+++ b/src/index.js
@@ -27,7 +27,7 @@ export { WasmModule } from './core/wasm-module.js';
 export { ReadStream } from './core/read-stream.js';
 export { SortedLoopArray } from './core/sorted-loop-array.js';
 export { Tags } from './core/tags.js';
-export { Timer, now } from './core/time.js';
+export { now } from './core/time.js';
 export { URI, createURI } from './core/uri.js';
 export { Tracing } from './core/tracing.js';
 


### PR DESCRIPTION
- the class was deprecated for a long time, and so I’ve moved it to deprecated file to not contribute to code size when using modules