### PR TITLE
Added attributes parameter to createShaderFromCode

### DIFF
--- a/examples/src/examples/graphics/shader-burn.tsx
+++ b/examples/src/examples/graphics/shader-burn.tsx
@@ -105,11 +105,11 @@ void main(void)
                 app.root.addChild(camera);
                 app.root.addChild(light);
 
-                const attributes = {
+                // Create the shader from the vertex and fragment shaders
+                const shader = pc.createShaderFromCode(app.graphicsDevice, files['shader.vert'], files['shader.frag'], 'myShader', {
                     aPosition: pc.SEMANTIC_POSITION,
                     aUv0: pc.SEMANTIC_TEXCOORD0
-                };
-                const shader = pc.createShaderFromCode(app.graphicsDevice, files['shader.vert'], files['shader.frag'], 'myShader', false, attributes);
+                });
 
                 // Create a new material with the new shader
                 const material = new pc.Material();

--- a/examples/src/examples/graphics/shader-burn.tsx
+++ b/examples/src/examples/graphics/shader-burn.tsx
@@ -105,16 +105,11 @@ void main(void)
                 app.root.addChild(camera);
                 app.root.addChild(light);
 
-                // Create the shader definition and shader from the vertex and fragment shaders
-                const shaderDefinition = {
-                    attributes: {
-                        aPosition: pc.SEMANTIC_POSITION,
-                        aUv0: pc.SEMANTIC_TEXCOORD0
-                    },
-                    vshader: files['shader.vert'],
-                    fshader: files['shader.frag']
+                const attributes = {
+                    aPosition: pc.SEMANTIC_POSITION,
+                    aUv0: pc.SEMANTIC_TEXCOORD0
                 };
-                const shader = new pc.Shader(app.graphicsDevice, shaderDefinition);
+                const shader = pc.createShaderFromCode(app.graphicsDevice, files['shader.vert'], files['shader.frag'], 'myShader', false, attributes);
 
                 // Create a new material with the new shader
                 const material = new pc.Material();

--- a/examples/src/examples/graphics/shader-toon.tsx
+++ b/examples/src/examples/graphics/shader-toon.tsx
@@ -123,17 +123,13 @@ void main(void)
                 app.root.addChild(camera);
                 app.root.addChild(light);
 
-                // Create the shader definition and shader from the vertex and fragment shaders
-                const shaderDefinition = {
-                    attributes: {
-                        aPosition: pc.SEMANTIC_POSITION,
-                        aNormal: pc.SEMANTIC_NORMAL,
-                        aUv: pc.SEMANTIC_TEXCOORD0
-                    },
-                    vshader: files['shader.vert'],
-                    fshader: files['shader.frag']
+                // Create the shader from the vertex and fragment shaders
+                const attributes = {
+                    aPosition: pc.SEMANTIC_POSITION,
+                    aNormal: pc.SEMANTIC_NORMAL,
+                    aUv: pc.SEMANTIC_TEXCOORD0
                 };
-                const shader = new pc.Shader(app.graphicsDevice, shaderDefinition);
+                const shader = pc.createShaderFromCode(app.graphicsDevice, files['shader.vert'], files['shader.frag'], 'myShader', false, attributes);
 
                 // Create a new material with the new shader
                 const material = new pc.Material();

--- a/examples/src/examples/graphics/shader-toon.tsx
+++ b/examples/src/examples/graphics/shader-toon.tsx
@@ -124,12 +124,11 @@ void main(void)
                 app.root.addChild(light);
 
                 // Create the shader from the vertex and fragment shaders
-                const attributes = {
+                const shader = pc.createShaderFromCode(app.graphicsDevice, files['shader.vert'], files['shader.frag'], 'myShader', {
                     aPosition: pc.SEMANTIC_POSITION,
                     aNormal: pc.SEMANTIC_NORMAL,
                     aUv: pc.SEMANTIC_TEXCOORD0
-                };
-                const shader = pc.createShaderFromCode(app.graphicsDevice, files['shader.vert'], files['shader.frag'], 'myShader', false, attributes);
+                });
 
                 // Create a new material with the new shader
                 const material = new pc.Material();

--- a/examples/src/examples/graphics/shader-wobble.tsx
+++ b/examples/src/examples/graphics/shader-wobble.tsx
@@ -99,11 +99,10 @@ void main(void)
                 app.root.addChild(light);
 
                 // Create the shader from the vertex and fragment shaders
-                const attributes = {
+                const shader = pc.createShaderFromCode(app.graphicsDevice, files['shader.vert'], files['shader.frag'], 'myShader', {
                     aPosition: pc.SEMANTIC_POSITION,
                     aUv0: pc.SEMANTIC_TEXCOORD0
-                };
-                const shader = pc.createShaderFromCode(app.graphicsDevice, files['shader.vert'], files['shader.frag'], 'myShader', false, attributes);
+                });
 
                 // Create a new material with the new shader
                 const material = new pc.Material();

--- a/examples/src/examples/graphics/shader-wobble.tsx
+++ b/examples/src/examples/graphics/shader-wobble.tsx
@@ -98,16 +98,12 @@ void main(void)
                 app.root.addChild(camera);
                 app.root.addChild(light);
 
-                // Create the shader definition and shader from the vertex and fragment shaders
-                const shaderDefinition = {
-                    attributes: {
-                        aPosition: pc.SEMANTIC_POSITION,
-                        aUv0: pc.SEMANTIC_TEXCOORD0
-                    },
-                    vshader: files['shader.vert'],
-                    fshader: files['shader.frag']
+                // Create the shader from the vertex and fragment shaders
+                const attributes = {
+                    aPosition: pc.SEMANTIC_POSITION,
+                    aUv0: pc.SEMANTIC_TEXCOORD0
                 };
-                const shader = new pc.Shader(app.graphicsDevice, shaderDefinition);
+                const shader = pc.createShaderFromCode(app.graphicsDevice, files['shader.vert'], files['shader.frag'], 'myShader', false, attributes);
 
                 // Create a new material with the new shader
                 const material = new pc.Material();

--- a/src/platform/graphics/webgl/webgl-shader.js
+++ b/src/platform/graphics/webgl/webgl-shader.js
@@ -329,7 +329,8 @@ class WebglShader {
 
             // Check attributes are correctly linked up
             if (definition.attributes[info.name] === undefined) {
-                console.error(`Vertex shader attribute "${info.name}" is not mapped to a semantic in shader definition.`);
+                console.error(`Vertex shader attribute "${info.name}" is not mapped to a semantic in shader definition, shader [${shader.label}]`, shader);
+                shader.failed = true;
             }
 
             const shaderInput = new WebglShaderInput(device, definition.attributes[info.name], device.pcUniformType[info.type], location);

--- a/src/scene/graphics/reproject-texture.js
+++ b/src/scene/graphics/reproject-texture.js
@@ -447,24 +447,13 @@ function reprojectTexture(source, target, options = {}) {
             `#define SOURCE_FUNC ${sourceFunc}\n` +
             `#define TARGET_FUNC ${targetFunc}\n` +
             `#define NUM_SAMPLES ${numSamples}\n` +
-            `#define NUM_SAMPLES_SQRT ${Math.round(Math.sqrt(numSamples)).toFixed(1)}\n` +
-            (device.extTextureLod ? `#define SUPPORTS_TEXLOD\n` : '');
-
-        let extensions = '';
-        if (!device.webgl2) {
-            extensions = '#extension GL_OES_standard_derivatives: enable\n';
-            if (device.extTextureLod) {
-                extensions += '#extension GL_EXT_shader_texture_lod: enable\n\n';
-            }
-        }
+            `#define NUM_SAMPLES_SQRT ${Math.round(Math.sqrt(numSamples)).toFixed(1)}\n`;
 
         shader = createShaderFromCode(
             device,
             vsCode,
             `${defines}\n${shaderChunks.reprojectPS}`,
-            shaderKey,
-            false,
-            extensions
+            shaderKey
         );
     }
 

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -547,8 +547,8 @@ class ForwardRenderer extends Renderer {
             }
         }
 
-        // process any catch of shaders created here
-        device.endShaderBatch();
+        // process the batch of shaders created here
+        device.endShaderBatch?.();
 
         return _drawCallList;
     }
@@ -583,7 +583,7 @@ class ForwardRenderer extends Renderer {
 
                     const shader = drawCall._shader[pass];
                     if (!shader.failed && !device.setShader(shader)) {
-                        Debug.error(`Error compiling shader for material=${material.name} pass=${pass} objDefs=${objDefs}`, material);
+                        Debug.error(`Error compiling shader [${shader.label}] for material=${material.name} pass=${pass} objDefs=${objDefs}`, material);
                     }
 
                     // skip rendering with the material if shader failed

--- a/src/scene/shader-lib/utils.js
+++ b/src/scene/shader-lib/utils.js
@@ -2,6 +2,7 @@ import { Shader } from '../../platform/graphics/shader.js';
 import { ShaderUtils } from '../../platform/graphics/shader-utils.js';
 import { shaderChunks } from './chunks/chunks.js';
 import { getProgramLibrary } from './get-program-library.js';
+import { Debug } from '../../core/debug.js';
 
 /**
  * Create a shader from named shader chunks.
@@ -30,13 +31,17 @@ function createShader(device, vsName, fsName, useTransformFeedback = false) {
  * @param {string} vsCode - The vertex shader code.
  * @param {string} fsCode - The fragment shader code.
  * @param {string} uniqueName - Unique name for the shader.
- * @param {boolean} [useTransformFeedback] - Whether to use transform feedback. Defaults to false.
  * @param {Object<string, string>} [attributes] - Object detailing the mapping of vertex shader
  * attribute names to semantics SEMANTIC_*. This enables the engine to match vertex buffer data as
  * inputs to the shader. Defaults to undefined, which generates the default attributes.
+ * @param {boolean} [useTransformFeedback] - Whether to use transform feedback. Defaults to false.
  * @returns {Shader} The newly created shader.
  */
-function createShaderFromCode(device, vsCode, fsCode, uniqueName, useTransformFeedback = false, attributes) {
+function createShaderFromCode(device, vsCode, fsCode, uniqueName, attributes, useTransformFeedback = false) {
+
+    // the function signature has changed, fail if called incorrectly
+    Debug.assert(typeof attributes !== 'boolean');
+
     const programLibrary = getProgramLibrary(device);
     let shader = programLibrary.getCachedShader(uniqueName);
     if (!shader) {

--- a/src/scene/shader-lib/utils.js
+++ b/src/scene/shader-lib/utils.js
@@ -31,11 +31,12 @@ function createShader(device, vsName, fsName, useTransformFeedback = false) {
  * @param {string} fsCode - The fragment shader code.
  * @param {string} uniqueName - Unique name for the shader.
  * @param {boolean} [useTransformFeedback] - Whether to use transform feedback. Defaults to false.
- * @param {string} [fragmentPreamble] - An optional 'preamble' string for the fragment shader. Defaults
- * to ''.
+ * @param {Object<string, string>} [attributes] - Object detailing the mapping of vertex shader
+ * attribute names to semantics SEMANTIC_*. This enables the engine to match vertex buffer data as
+ * inputs to the shader. Defaults to undefined, which generates the default attributes.
  * @returns {Shader} The newly created shader.
  */
-function createShaderFromCode(device, vsCode, fsCode, uniqueName, useTransformFeedback = false, fragmentPreamble = '') {
+function createShaderFromCode(device, vsCode, fsCode, uniqueName, useTransformFeedback = false, attributes) {
     const programLibrary = getProgramLibrary(device);
     let shader = programLibrary.getCachedShader(uniqueName);
     if (!shader) {
@@ -43,7 +44,7 @@ function createShaderFromCode(device, vsCode, fsCode, uniqueName, useTransformFe
             name: uniqueName,
             vertexCode: vsCode,
             fragmentCode: fsCode,
-            fragmentPreamble: fragmentPreamble,
+            attributes: attributes,
             useTransformFeedback: useTransformFeedback
         }));
         programLibrary.setCachedShader(uniqueName, shader);


### PR DESCRIPTION
- updated createShaderFromCode function to accept attributes object, which is commonly used. Also, removed fragmentPreamble parameter, as it's been used only once internally, and that is no longer needed.
- changed reproject-texture shader creation. It no longer needs to enable those extensions, as this is handled inside createShaderFromCode (tested on WebGL1)
- improved shader error reporting / handling
- updated shader*** examples to use createShaderFromCode, and confirmed they all work on WebGPU now
