### PR TITLE
Sparse accessor fix

### DIFF
--- a/src/framework/parsers/glb-parser.js
+++ b/src/framework/parsers/glb-parser.js
@@ -208,7 +208,7 @@ const getAccessorData = function (gltfAccessor, bufferViews, flatten = false) {
         // data values data
         const valuesAccessor = {
             count: sparse.count,
-            type: gltfAccessor.scalar,
+            type: gltfAccessor.type,
             componentType: gltfAccessor.componentType
         };
         const values = getAccessorData(Object.assign(valuesAccessor, sparse.values), bufferViews, true);


### PR DESCRIPTION
We were managing to load sparse accessors with undefined `accessor.type` because `getNumComponents` function defaults to 3, which is the usual case for sparse accessors on morph targets.