### PR TITLE
Texture based morphing support for WebGPU

### DIFF
--- a/examples/src/examples/animation/blend-trees-1d.tsx
+++ b/examples/src/examples/animation/blend-trees-1d.tsx
@@ -18,129 +18,165 @@ class BlendTrees1DExample {
 
     example(canvas: HTMLCanvasElement, data: any): void {
 
-        const app = new pc.Application(canvas, {
-            mouse: new pc.Mouse(document.body),
-            touch: new pc.TouchDevice(document.body),
-            elementInput: new pc.ElementInput(canvas)
-        });
-
         const assets = {
             'model': new pc.Asset('model', 'container', { url: '/static/assets/models/bitmoji.glb' }),
             'idleAnim': new pc.Asset('idleAnim', 'container', { url: '/static/assets/animations/bitmoji/idle.glb' }),
             'danceAnim': new pc.Asset('danceAnim', 'container', { url: '/static/assets/animations/bitmoji/win-dance.glb' }),
-            'helipad.dds': new pc.Asset('helipad.dds', 'cubemap', { url: '/static/assets/cubemaps/helipad.dds' }, { type: pc.TEXTURETYPE_RGBM }),
+            helipad: new pc.Asset('helipad-env-atlas', 'texture', { url: '/static/assets/cubemaps/helipad-env-atlas.png' }, { type: pc.TEXTURETYPE_RGBP }),
             'bloom': new pc.Asset('bloom', 'script', { url: '/static/scripts/posteffects/posteffect-bloom.js' })
         };
-        const assetListLoader = new pc.AssetListLoader(Object.values(assets), app.assets);
-        assetListLoader.load(() => {
-            // setup skydome
-            app.scene.exposure = 2;
-            app.scene.skyboxMip = 2;
-            app.scene.setSkybox(assets['helipad.dds'].resources);
 
-            // Create an Entity with a camera component
-            const cameraEntity = new pc.Entity();
-            cameraEntity.addComponent("camera", {
-                clearColor: new pc.Color(0.1, 0.1, 0.1)
-            });
-            cameraEntity.translate(0, 0.75, 3);
+        pc.createGraphicsDevice(canvas).then((device: pc.GraphicsDevice) => {
 
-            // add bloom postprocessing (this is ignored by the picker)
-            cameraEntity.addComponent("script");
-            cameraEntity.script.create("bloom", {
-                attributes: {
-                    bloomIntensity: 1,
-                    bloomThreshold: 0.7,
-                    blurAmount: 4
-                }
-            });
-            app.root.addChild(cameraEntity);
+            const createOptions = new pc.AppOptions();
+            createOptions.graphicsDevice = device;
 
-            // Create an entity with a light component
-            const lightEntity = new pc.Entity();
-            lightEntity.addComponent("light", {
-                castShadows: true,
-                intensity: 1.5,
-                normalOffsetBias: 0.02,
-                shadowType: pc.SHADOW_PCF5,
-                shadowDistance: 6,
-                shadowResolution: 2048,
-                shadowBias: 0.02
-            });
-            app.root.addChild(lightEntity);
-            lightEntity.setLocalEulerAngles(45, 30, 0);
+            createOptions.componentSystems = [
+                // @ts-ignore
+                pc.RenderComponentSystem,
+                // @ts-ignore
+                pc.CameraComponentSystem,
+                // @ts-ignore
+                pc.LightComponentSystem,
+                // @ts-ignore
+                pc.ScriptComponentSystem,
+                // @ts-ignore
+                pc.AnimComponentSystem
+            ];
+            createOptions.resourceHandlers = [
+                // @ts-ignore
+                pc.TextureHandler,
+                // @ts-ignore
+                pc.ContainerHandler,
+                // @ts-ignore
+                pc.ScriptHandler,
+                // @ts-ignore
+                pc.AnimClipHandler,
+                // @ts-ignore
+                pc.AnimStateGraphHandler
+            ];
 
-            // create an entity from the loaded model using the render component
-            const modelEntity = assets.model.resource.instantiateRenderEntity({
-                castShadows: true
-            });
+            const app = new pc.AppBase(canvas);
+            app.init(createOptions);
 
-            // add an anim component to the entity
-            modelEntity.addComponent('anim', {
-                activate: true
-            });
+            // Set the canvas to fill the window and automatically change resolution to be the same as the canvas size
+            app.setCanvasFillMode(pc.FILLMODE_FILL_WINDOW);
+            app.setCanvasResolution(pc.RESOLUTION_AUTO);
 
-            // create an anim state graph
-            const animStateGraphData = {
-                "layers": [
-                    {
-                        "name": "characterState",
-                        "states": [
-                            {
-                                "name": "START"
-                            },
-                            {
-                                "name": "Movement",
-                                "speed": 1.0,
-                                "loop": true,
-                                "blendTree": {
-                                    "type": "1D",
-                                    "parameter": "blend",
-                                    "children": [
-                                        {
-                                            "name": "Idle",
-                                            "point": 0.0
-                                        },
-                                        {
-                                            "name": "Dance",
-                                            "point": 1.0,
-                                            "speed": 0.85
-                                        }
-                                    ]
+            const assetListLoader = new pc.AssetListLoader(Object.values(assets), app.assets);
+            assetListLoader.load(() => {
+
+                app.start();
+
+                // setup skydome
+                app.scene.exposure = 2;
+                app.scene.skyboxMip = 2;
+                app.scene.envAtlas = assets.helipad.resource;
+
+                // Create an Entity with a camera component
+                const cameraEntity = new pc.Entity();
+                cameraEntity.addComponent("camera", {
+                    clearColor: new pc.Color(0.1, 0.1, 0.1)
+                });
+                cameraEntity.translate(0, 0.75, 3);
+
+                // add bloom postprocessing (this is ignored by the picker)
+                cameraEntity.addComponent("script");
+                cameraEntity.script.create("bloom", {
+                    attributes: {
+                        bloomIntensity: 1,
+                        bloomThreshold: 0.7,
+                        blurAmount: 4
+                    }
+                });
+                app.root.addChild(cameraEntity);
+
+                // Create an entity with a light component
+                const lightEntity = new pc.Entity();
+                lightEntity.addComponent("light", {
+                    castShadows: true,
+                    intensity: 1.5,
+                    normalOffsetBias: 0.02,
+                    shadowType: pc.SHADOW_PCF5,
+                    shadowDistance: 6,
+                    shadowResolution: 2048,
+                    shadowBias: 0.02
+                });
+                app.root.addChild(lightEntity);
+                lightEntity.setLocalEulerAngles(45, 30, 0);
+
+                // create an entity from the loaded model using the render component
+                const modelEntity = assets.model.resource.instantiateRenderEntity({
+                    castShadows: true
+                });
+
+                // add an anim component to the entity
+                modelEntity.addComponent('anim', {
+                    activate: true
+                });
+
+                // create an anim state graph
+                const animStateGraphData = {
+                    "layers": [
+                        {
+                            "name": "characterState",
+                            "states": [
+                                {
+                                    "name": "START"
+                                },
+                                {
+                                    "name": "Movement",
+                                    "speed": 1.0,
+                                    "loop": true,
+                                    "blendTree": {
+                                        "type": "1D",
+                                        "parameter": "blend",
+                                        "children": [
+                                            {
+                                                "name": "Idle",
+                                                "point": 0.0
+                                            },
+                                            {
+                                                "name": "Dance",
+                                                "point": 1.0,
+                                                "speed": 0.85
+                                            }
+                                        ]
+                                    }
                                 }
-                            }
-                        ],
-                        "transitions": [
-                            {
-                                "from": "START",
-                                "to": "Movement"
-                            }
-                        ]
+                            ],
+                            "transitions": [
+                                {
+                                    "from": "START",
+                                    "to": "Movement"
+                                }
+                            ]
+                        }
+                    ],
+                    "parameters": {
+                        "blend": {
+                            "name": "blend",
+                            "type": "FLOAT",
+                            "value": 0
+                        }
                     }
-                ],
-                "parameters": {
-                    "blend": {
-                        "name": "blend",
-                        "type": "FLOAT",
-                        "value": 0
-                    }
-                }
-            };
+                };
 
-            // load the state graph into the anim component
-            modelEntity.anim.loadStateGraph(animStateGraphData);
+                // load the state graph into the anim component
+                modelEntity.anim.loadStateGraph(animStateGraphData);
 
-            // load the state graph asset resource into the anim component
-            const characterStateLayer = modelEntity.anim.baseLayer;
-            characterStateLayer.assignAnimation('Movement.Idle', assets.idleAnim.resource.animations[0].resource);
-            characterStateLayer.assignAnimation('Movement.Dance', assets.danceAnim.resource.animations[0].resource);
+                // load the state graph asset resource into the anim component
+                const characterStateLayer = modelEntity.anim.baseLayer;
+                characterStateLayer.assignAnimation('Movement.Idle', assets.idleAnim.resource.animations[0].resource);
+                characterStateLayer.assignAnimation('Movement.Dance', assets.danceAnim.resource.animations[0].resource);
 
-            app.root.addChild(modelEntity);
+                app.root.addChild(modelEntity);
 
-            app.start();
+                app.start();
 
-            data.on('blend:set', (blend: number) => {
-                modelEntity.anim.setFloat('blend', blend);
+                data.on('blend:set', (blend: number) => {
+                    modelEntity.anim.setFloat('blend', blend);
+                });
             });
         });
     }

--- a/examples/src/examples/graphics/mesh-morph-many.tsx
+++ b/examples/src/examples/graphics/mesh-morph-many.tsx
@@ -1,161 +1,193 @@
 import * as pc from '../../../../';
 
-
 class MeshMorphManyExample {
     static CATEGORY = 'Graphics';
     static NAME = 'Mesh Morph Many';
 
-
     example(canvas: HTMLCanvasElement): void {
 
-        // Create the application and start the update loop
-        const app = new pc.Application(canvas, {});
-
         const assets = {
-            'helipad.dds': new pc.Asset('helipad.dds', 'cubemap', { url: '/static/assets/cubemaps/helipad.dds' }, { type: pc.TEXTURETYPE_RGBM })
+            helipad: new pc.Asset('helipad-env-atlas', 'texture', { url: '/static/assets/cubemaps/helipad-env-atlas.png' }, { type: pc.TEXTURETYPE_RGBP }),
         };
 
-        const assetListLoader = new pc.AssetListLoader(Object.values(assets), app.assets);
-        assetListLoader.load(() => {
-            app.start();
+        pc.createGraphicsDevice(canvas).then((device: pc.GraphicsDevice) => {
 
-            // setup skydome
-            app.scene.skyboxMip = 2;
-            app.scene.exposure = 0.6;
-            app.scene.setSkybox(assets['helipad.dds'].resources);
+            const createOptions = new pc.AppOptions();
+            createOptions.graphicsDevice = device;
+            createOptions.mouse = new pc.Mouse(document.body);
+            createOptions.touch = new pc.TouchDevice(document.body);
+            createOptions.keyboard = new pc.Keyboard(document.body);
+
+            createOptions.componentSystems = [
+                // @ts-ignore
+                pc.RenderComponentSystem,
+                // @ts-ignore
+                pc.CameraComponentSystem,
+                // @ts-ignore
+                pc.LightComponentSystem
+            ];
+            createOptions.resourceHandlers = [
+                // @ts-ignore
+                pc.TextureHandler
+            ];
+
+            const app = new pc.AppBase(canvas);
+            app.init(createOptions);
 
             // Set the canvas to fill the window and automatically change resolution to be the same as the canvas size
             app.setCanvasFillMode(pc.FILLMODE_FILL_WINDOW);
             app.setCanvasResolution(pc.RESOLUTION_AUTO);
 
-            // Create an entity with a directional light component
-            const light = new pc.Entity();
-            light.addComponent("light", {
-                type: "directional",
-                castShadows: true,
-                shadowBias: 0.5,
-                shadowDistance: 25,
-                color: new pc.Color(0.5, 0.5, 0.5)
-            });
-            app.root.addChild(light);
-            light.setLocalEulerAngles(45, 45, 0);
+            const assetListLoader = new pc.AssetListLoader(Object.values(assets), app.assets);
+            assetListLoader.load(() => {
 
-            // Create an entity with a camera component
-            const camera = new pc.Entity();
-            camera.addComponent("camera", {
-                clearColor: new pc.Color(0.1, 0.1, 0.1)
-            });
-            app.root.addChild(camera);
+                app.start();
 
-            // position the camera
-            camera.setLocalPosition(0, 4, 14);
-            camera.lookAt(pc.Vec3.ZERO);
+                // setup skydome
+                app.scene.skyboxMip = 2;
+                app.scene.exposure = 0.6;
+                app.scene.envAtlas = assets.helipad.resource;
 
-            // helper function to return the shortest distance from point [x, y, z] to a plane defined by [a, b, c] normal and constant d
-            const shortestDistance = function (x: number, y: number, z: number, a: number, b: number, c: number, d: number) {
-                d = Math.abs((a * x + b * y + c * z + d));
-                const e = Math.sqrt(a * a + b * b + c * c);
-                return d / e;
-            };
-
-            // helper function that creates a morph target from original positions, normals and indices, and a plane normal [nx, ny, nz]
-            const createMorphTarget = function (positions: string | any[], normals: any[], indices: any[], offset: number, nx: number, ny: number, nz: number) {
-
-                // modify vertices to separate array
-                const modifiedPositions = new Float32Array(positions.length);
-                let dist: number;
-                let i: number;
-                let displacement: number;
-                const limit = 0.2 + Math.random() * 0.5;
-                const range = 1 + 2 * Math.random();
-                for (i = 0; i < positions.length; i += 3) {
-                    // distance of the point to the specified plane
-                    dist = shortestDistance(positions[i], positions[i + 1], positions[i + 2], nx, ny, nz, offset);
-
-                    // modify distance to displacement amount - displace nearby points more than distant points
-                    displacement = pc.math.smoothstep(0, limit, dist);
-                    displacement = 1 - displacement;
-                    displacement *= range;
-
-                    // generate new position by extruding vertex along normal by displacement
-                    modifiedPositions[i] = positions[i] + normals[i] * displacement;
-                    modifiedPositions[i + 1] = positions[i + 1] + normals[i + 1] * displacement;
-                    modifiedPositions[i + 2] = positions[i + 2] + normals[i + 2] * displacement;
-                }
-
-                // generate normals based on modified positions and indices
-                // @ts-ignore engine-tsd
-                const modifiedNormals = new Float32Array(pc.calculateNormals(modifiedPositions, indices));
-
-                // generate delta positions and normals - as morph targets store delta between base position / normal and modified position / normal
-                for (i = 0; i < modifiedNormals.length; i++) {
-                    modifiedPositions[i] -= positions[i];
-                    modifiedNormals[i] -= normals[i];
-                }
-
-                // create a morph target
-                // @ts-ignore engine-tsd
-                return new pc.MorphTarget({
-                    deltaPositions: modifiedPositions,
-                    deltaNormals: modifiedNormals
+                // Create an entity with a directional light component
+                const light = new pc.Entity();
+                light.addComponent("light", {
+                    type: "directional",
+                    castShadows: true,
+                    shadowBias: 0.5,
+                    shadowDistance: 25,
+                    color: new pc.Color(0.5, 0.5, 0.5)
                 });
-            };
+                app.root.addChild(light);
+                light.setLocalEulerAngles(45, 45, 0);
 
-            // create the base mesh - a sphere, with higher amount of vertices / triangles
-            const mesh = pc.createCylinder(app.graphicsDevice, { height: 10, heightSegments: 200, capSegments: 100 });
+                // Create an entity with a camera component
+                const camera = new pc.Entity();
+                camera.addComponent("camera", {
+                    clearColor: new pc.Color(0.1, 0.1, 0.1)
+                });
+                app.root.addChild(camera);
 
-            // obtain base mesh vertex / index data
-            const srcPositions: Float32Array | number[] | Int8Array | Uint8Array | Uint8ClampedArray | Int16Array | Uint16Array | Int32Array | Uint32Array = [], srcNormals: Float32Array | number[] | Int8Array | Uint8Array | Uint8ClampedArray | Int16Array | Uint16Array | Int32Array | Uint32Array = [], indices: number[] | Uint8Array | Uint16Array | Uint32Array = [];
-            mesh.getPositions(srcPositions);
-            mesh.getNormals(srcNormals);
-            mesh.getIndices(indices);
+                // position the camera
+                camera.setLocalPosition(0, 4, 14);
+                camera.lookAt(pc.Vec3.ZERO);
 
-            // build morph targets by expanding a part of cylinder by the normal
-            const targets = [];
-            let startOffset = -4.5;
-            const endOffset = 4.5;
-            const count = 12;
-            const deltaOffset = (endOffset - startOffset) / (count - 1);
-            for (let o = 0; o < count; o++) {
-                targets.push(createMorphTarget(srcPositions, srcNormals, indices, startOffset, 0, 1, 0));
-                startOffset += deltaOffset;
-            }
+                // helper function to return the shortest distance from point [x, y, z] to a plane defined by [a, b, c] normal and constant d
+                const shortestDistance = function (x: number, y: number, z: number, a: number, b: number, c: number, d: number) {
+                    d = Math.abs((a * x + b * y + c * z + d));
+                    const e = Math.sqrt(a * a + b * b + c * c);
+                    return d / e;
+                };
 
-            // create a morph using these targets
-            mesh.morph = new pc.Morph(targets, app.graphicsDevice);
+                // helper function that creates a morph target from original positions, normals and indices, and a plane normal [nx, ny, nz]
+                const createMorphTarget = function (positions: string | any[], normals: any[], indices: any[], offset: number, nx: number, ny: number, nz: number) {
 
-            // material
-            const material = new pc.StandardMaterial();
-            material.shininess = 50;
-            material.metalness = 0.3;
-            material.useMetalness = true;
-            material.update();
+                    // modify vertices to separate array
+                    const modifiedPositions = new Float32Array(positions.length);
+                    let dist: number;
+                    let i: number;
+                    let displacement: number;
+                    const limit = 0.2 + Math.random() * 0.5;
+                    const range = 1 + 2 * Math.random();
+                    for (i = 0; i < positions.length; i += 3) {
+                        // distance of the point to the specified plane
+                        dist = shortestDistance(positions[i], positions[i + 1], positions[i + 2], nx, ny, nz, offset);
 
-            // Create the mesh instance
-            const meshInstance = new pc.MeshInstance(mesh, material);
+                        // modify distance to displacement amount - displace nearby points more than distant points
+                        displacement = pc.math.smoothstep(0, limit, dist);
+                        displacement = 1 - displacement;
+                        displacement *= range;
 
-            // add morph instance - this is where currently set weights are stored
-            const morphInstance = new pc.MorphInstance(mesh.morph);
-            meshInstance.morphInstance = morphInstance;
+                        // generate new position by extruding vertex along normal by displacement
+                        modifiedPositions[i] = positions[i] + normals[i] * displacement;
+                        modifiedPositions[i + 1] = positions[i + 1] + normals[i + 1] * displacement;
+                        modifiedPositions[i + 2] = positions[i + 2] + normals[i + 2] * displacement;
+                    }
 
-            // Create Entity and add it to the scene
-            const entity = new pc.Entity();
-            entity.addComponent("render", {
-                material: material,
-                meshInstances: [meshInstance]
-            });
-            entity.setLocalPosition(0, 0, 0);
-            app.root.addChild(entity);
+                    // generate normals based on modified positions and indices
+                    // @ts-ignore engine-tsd
+                    const modifiedNormals = new Float32Array(pc.calculateNormals(modifiedPositions, indices));
 
-            // update function called once per frame
-            let time = 0;
-            app.on("update", function (dt) {
-                time += dt;
+                    // generate delta positions and normals - as morph targets store delta between base position / normal and modified position / normal
+                    for (i = 0; i < modifiedNormals.length; i++) {
+                        modifiedPositions[i] -= positions[i];
+                        modifiedNormals[i] -= normals[i];
+                    }
 
-                // modify weights of all morph targets along sin curve with different frequency
-                for (let i = 0; i < targets.length; i++) {
-                    morphInstance.setWeight(i, Math.abs(Math.sin(time * 2 * (i + 5) / targets.length)));
+                    // create a morph target
+                    // @ts-ignore engine-tsd
+                    return new pc.MorphTarget({
+                        deltaPositions: modifiedPositions,
+                        deltaNormals: modifiedNormals
+                    });
+                };
+
+                // create the base mesh - a sphere, with higher amount of vertices / triangles
+                const mesh = pc.createCylinder(app.graphicsDevice, { height: 10, heightSegments: 200, capSegments: 100 });
+
+                // obtain base mesh vertex / index data
+                const srcPositions: Float32Array | number[] | Int8Array | Uint8Array | Uint8ClampedArray | Int16Array | Uint16Array | Int32Array | Uint32Array = [], srcNormals: Float32Array | number[] | Int8Array | Uint8Array | Uint8ClampedArray | Int16Array | Uint16Array | Int32Array | Uint32Array = [], indices: number[] | Uint8Array | Uint16Array | Uint32Array = [];
+                mesh.getPositions(srcPositions);
+                mesh.getNormals(srcNormals);
+                mesh.getIndices(indices);
+
+                // build morph targets by expanding a part of cylinder by the normal
+                const targets = [];
+                let startOffset = -4.5;
+                const endOffset = 4.5;
+                const count = 12;
+                const deltaOffset = (endOffset - startOffset) / (count - 1);
+                for (let o = 0; o < count; o++) {
+                    targets.push(createMorphTarget(srcPositions, srcNormals, indices, startOffset, 0, 1, 0));
+                    startOffset += deltaOffset;
                 }
+
+                // create a morph using these targets
+                mesh.morph = new pc.Morph(targets, app.graphicsDevice);
+
+                // material
+                const material = new pc.StandardMaterial();
+                material.shininess = 50;
+                material.metalness = 0.3;
+                material.useMetalness = true;
+                material.update();
+
+                // Create the mesh instance
+                const meshInstance = new pc.MeshInstance(mesh, material);
+
+                // add morph instance - this is where currently set weights are stored
+                const morphInstance = new pc.MorphInstance(mesh.morph);
+                meshInstance.morphInstance = morphInstance;
+
+                // Create Entity and add it to the scene
+                const entity = new pc.Entity();
+                entity.addComponent("render", {
+                    material: material,
+                    meshInstances: [meshInstance]
+                });
+                entity.setLocalPosition(0, 0, 0);
+                app.root.addChild(entity);
+
+                // update function called once per frame
+                let time = 0;
+                app.on("update", function (dt) {
+                    time += dt;
+
+                    // modify weights of all morph targets along sin curve with different frequency
+                    for (let i = 0; i < targets.length; i++) {
+                        morphInstance.setWeight(i, Math.abs(Math.sin(time * 2 * (i + 5) / targets.length)));
+                    }
+
+                    // debug display the morph target textures blended together
+                    if (morphInstance.texturePositions) {
+                        // @ts-ignore
+                        app.drawTexture(-0.7, -0.7, 0.4, 0.4, morphInstance.texturePositions);
+                    }
+
+                    if (morphInstance.textureNormals) {
+                        // @ts-ignore
+                        app.drawTexture(0.7, -0.7, 0.4, 0.4, morphInstance.textureNormals);
+                    }
+                });
             });
         });
     }

--- a/examples/src/examples/graphics/mesh-morph.tsx
+++ b/examples/src/examples/graphics/mesh-morph.tsx
@@ -6,137 +6,165 @@ class MeshMorphExample {
 
     example(canvas: HTMLCanvasElement): void {
 
-        // Create the application and start the update loop
-        const app = new pc.Application(canvas, {});
-        app.start();
+        pc.createGraphicsDevice(canvas).then((device: pc.GraphicsDevice) => {
 
-        // Set the canvas to fill the window and automatically change resolution to be the same as the canvas size
-        app.setCanvasFillMode(pc.FILLMODE_FILL_WINDOW);
-        app.setCanvasResolution(pc.RESOLUTION_AUTO);
+            const createOptions = new pc.AppOptions();
+            createOptions.graphicsDevice = device;
 
-        // Create an entity with a directional light component
-        const light = new pc.Entity();
-        light.addComponent("light", {
-            type: "directional"
-        });
-        app.root.addChild(light);
-        light.setLocalEulerAngles(45, 30, 0);
+            createOptions.componentSystems = [
+                // @ts-ignore
+                pc.RenderComponentSystem,
+                // @ts-ignore
+                pc.CameraComponentSystem,
+                // @ts-ignore
+                pc.LightComponentSystem
+            ];
 
-        // Create an entity with a camera component
-        const camera = new pc.Entity();
-        camera.addComponent("camera", {
-            clearColor: new pc.Color(0.1, 0.1, 0.1)
-        });
-        app.root.addChild(camera);
+            const app = new pc.AppBase(canvas);
+            app.init(createOptions);
+            app.start();
 
-        // helper function to return the shortest distance from point [x, y, z] to a plane defined by [a, b, c] normal
-        const shortestDistance = function (x: number, y: number, z: number, a: number, b: number, c: number) {
-            const d = Math.abs(a * x + b * y + c * z);
-            const e = Math.sqrt(a * a + b * b + c * c);
-            return d / e;
-        };
+            // Set the canvas to fill the window and automatically change resolution to be the same as the canvas size
+            app.setCanvasFillMode(pc.FILLMODE_FILL_WINDOW);
+            app.setCanvasResolution(pc.RESOLUTION_AUTO);
 
-        // helper function that creates a morph target from original positions, normals and indices, and a plane normal [nx, ny, nz]
-        const createMorphTarget = function (positions: string | any[], normals: any[], indices: any[], nx: number, ny: number, nz: number) {
-
-            // modify vertices to separate array
-            const modifiedPositions = new Float32Array(positions.length);
-            let dist: number, i: number, displacement: number;
-            const limit = 0.2;
-            for (i = 0; i < positions.length; i += 3) {
-                // distance of the point to the specified plane
-                dist = shortestDistance(positions[i], positions[i + 1], positions[i + 2], nx, ny, nz);
-
-                // modify distance to displacement amount - displace nearby points more than distant points
-                displacement = pc.math.smoothstep(0, limit, dist);
-                displacement = 1 - displacement;
-
-                // generate new position by extruding vertex along normal by displacement
-                modifiedPositions[i] = positions[i] + normals[i] * displacement;
-                modifiedPositions[i + 1] = positions[i + 1] + normals[i + 1] * displacement;
-                modifiedPositions[i + 2] = positions[i + 2] + normals[i + 2] * displacement;
-            }
-
-            // generate normals based on modified positions and indices
-            // @ts-ignore engine-tsd
-            const modifiedNormals = new Float32Array(pc.calculateNormals(modifiedPositions, indices));
-
-            // generate delta positions and normals - as morph targets store delta between base position / normal and modified position / normal
-            for (i = 0; i < modifiedNormals.length; i++) {
-                modifiedPositions[i] -= positions[i];
-                modifiedNormals[i] -= normals[i];
-            }
-
-            // create a morph target
-            // @ts-ignore engine-tsd
-            return new pc.MorphTarget({
-                deltaPositions: modifiedPositions,
-                deltaNormals: modifiedNormals
+            // Create an entity with a directional light component
+            const light = new pc.Entity();
+            light.addComponent("light", {
+                type: "directional"
             });
-        };
+            app.root.addChild(light);
+            light.setLocalEulerAngles(45, 30, 0);
 
-        const createMorphInstance = function (x: number | pc.Vec3, y: number, z: number) {
-            // create the base mesh - a sphere, with higher amount of vertices / triangles
-            const mesh = pc.createSphere(app.graphicsDevice, { latitudeBands: 200, longitudeBands: 200 });
-
-            // obtain base mesh vertex / index data
-            const srcPositions: Float32Array | number[] | Int8Array | Uint8Array | Uint8ClampedArray | Int16Array | Uint16Array | Int32Array | Uint32Array = [], srcNormals: Float32Array | number[] | Int8Array | Uint8Array | Uint8ClampedArray | Int16Array | Uint16Array | Int32Array | Uint32Array = [], indices: number[] | Uint8Array | Uint16Array | Uint32Array = [];
-            mesh.getPositions(srcPositions);
-            mesh.getNormals(srcNormals);
-            mesh.getIndices(indices);
-
-            // build 3 targets by expanding a part of sphere along 3 planes, specified by the normal
-            const targets = [];
-            targets.push(createMorphTarget(srcPositions, srcNormals, indices, 1, 0, 0));
-            targets.push(createMorphTarget(srcPositions, srcNormals, indices, 0, 1, 0));
-            targets.push(createMorphTarget(srcPositions, srcNormals, indices, 0, 0, 1));
-
-            // create a morph using these 3 targets
-            mesh.morph = new pc.Morph(targets, app.graphicsDevice);
-
-            // Create the mesh instance
-            const material = new pc.StandardMaterial();
-            const meshInstance = new pc.MeshInstance(mesh, material);
-
-            // add morph instance - this is where currently set weights are stored
-            const morphInstance = new pc.MorphInstance(mesh.morph);
-            meshInstance.morphInstance = morphInstance;
-
-            // Create Entity and add it to the scene
-            const entity = new pc.Entity();
-            entity.setLocalPosition(x, y, z);
-            app.root.addChild(entity);
-
-            // Add a render component with meshInstance
-            entity.addComponent('render', {
-                material: material,
-                meshInstances: [meshInstance]
+            // Create an entity with a camera component
+            const camera = new pc.Entity();
+            camera.addComponent("camera", {
+                clearColor: new pc.Color(0.1, 0.1, 0.1)
             });
+            app.root.addChild(camera);
 
-            return morphInstance;
-        };
+            // helper function to return the shortest distance from point [x, y, z] to a plane defined by [a, b, c] normal
+            const shortestDistance = function (x: number, y: number, z: number, a: number, b: number, c: number) {
+                const d = Math.abs(a * x + b * y + c * z);
+                const e = Math.sqrt(a * a + b * b + c * c);
+                return d / e;
+            };
 
-        // create 3 morph instances
-        const morphInstances: { setWeight: (arg0: number, arg1: number) => void; }[] = [];
-        for (let k = 0; k < 3; k++) {
-            morphInstances.push(createMorphInstance(Math.random() * 6 - 3, Math.random() * 6 - 3, Math.random() * 6 - 3));
-        }
+            // helper function that creates a morph target from original positions, normals and indices, and a plane normal [nx, ny, nz]
+            const createMorphTarget = function (positions: number[], normals: number[], indices: number[], nx: number, ny: number, nz: number) {
 
-        // update function called once per frame
-        let time = 0;
-        app.on("update", function (dt) {
-            time += dt;
+                // modify vertices to separate array
+                const modifiedPositions = new Float32Array(positions.length);
+                let dist: number, i: number, displacement: number;
+                const limit = 0.2;
+                for (i = 0; i < positions.length; i += 3) {
+                    // distance of the point to the specified plane
+                    dist = shortestDistance(positions[i], positions[i + 1], positions[i + 2], nx, ny, nz);
 
-            for (let m = 0; m < morphInstances.length; m++) {
-                // modify weights of all 3 morph targets along some sin curve with different frequency
-                morphInstances[m].setWeight(0, Math.abs(Math.sin(time + m)));
-                morphInstances[m].setWeight(1, Math.abs(Math.sin(time * 0.3 + m)));
-                morphInstances[m].setWeight(2, Math.abs(Math.sin(time * 0.7 + m)));
+                    // modify distance to displacement amount - displace nearby points more than distant points
+                    displacement = pc.math.smoothstep(0, limit, dist);
+                    displacement = 1 - displacement;
+
+                    // generate new position by extruding vertex along normal by displacement
+                    modifiedPositions[i] = positions[i] + normals[i] * displacement;
+                    modifiedPositions[i + 1] = positions[i + 1] + normals[i + 1] * displacement;
+                    modifiedPositions[i + 2] = positions[i + 2] + normals[i + 2] * displacement;
+                }
+
+                // generate normals based on modified positions and indices
+                // @ts-ignore engine-tsd
+                const modifiedNormals = new Float32Array(pc.calculateNormals(modifiedPositions, indices));
+
+                // generate delta positions and normals - as morph targets store delta between base position / normal and modified position / normal
+                for (i = 0; i < modifiedNormals.length; i++) {
+                    modifiedPositions[i] -= positions[i];
+                    modifiedNormals[i] -= normals[i];
+                }
+
+                // create a morph target
+                // @ts-ignore engine-tsd
+                return new pc.MorphTarget({
+                    deltaPositions: modifiedPositions,
+                    deltaNormals: modifiedNormals
+                });
+            };
+
+            const createMorphInstance = function (x: number, y: number, z: number) {
+                // create the base mesh - a sphere, with higher amount of vertices / triangles
+                const mesh = pc.createSphere(app.graphicsDevice, { latitudeBands: 200, longitudeBands: 200 });
+
+                // obtain base mesh vertex / index data
+                const srcPositions: number[] = [];
+                const srcNormals: number[] = [];
+                const indices: number[] = [];
+                mesh.getPositions(srcPositions);
+                mesh.getNormals(srcNormals);
+                mesh.getIndices(indices);
+
+                // build 3 targets by expanding a part of sphere along 3 planes, specified by the normal
+                const targets = [];
+                targets.push(createMorphTarget(srcPositions, srcNormals, indices, 1, 0, 0));
+                targets.push(createMorphTarget(srcPositions, srcNormals, indices, 0, 1, 0));
+                targets.push(createMorphTarget(srcPositions, srcNormals, indices, 0, 0, 1));
+
+                // create a morph using these 3 targets
+                mesh.morph = new pc.Morph(targets, app.graphicsDevice);
+
+                // Create the mesh instance
+                const material = new pc.StandardMaterial();
+                const meshInstance = new pc.MeshInstance(mesh, material);
+
+                // add morph instance - this is where currently set weights are stored
+                const morphInstance = new pc.MorphInstance(mesh.morph);
+                meshInstance.morphInstance = morphInstance;
+
+                // Create Entity and add it to the scene
+                const entity = new pc.Entity();
+                entity.setLocalPosition(x, y, z);
+                app.root.addChild(entity);
+
+                // Add a render component with meshInstance
+                entity.addComponent('render', {
+                    material: material,
+                    meshInstances: [meshInstance]
+                });
+
+                return morphInstance;
+            };
+
+            // create 3 morph instances
+            const morphInstances: pc.MorphInstance[] = [];
+            for (let k = 0; k < 3; k++) {
+                morphInstances.push(createMorphInstance(Math.random() * 6 - 3, Math.random() * 6 - 3, Math.random() * 6 - 3));
             }
 
-            // orbit camera around
-            camera.setLocalPosition(16 * Math.sin(time * 0.2), 4, 16 * Math.cos(time * 0.2));
-            camera.lookAt(pc.Vec3.ZERO);
+            // update function called once per frame
+            let time = 0;
+            app.on("update", function (dt) {
+                time += dt;
+
+                for (let m = 0; m < morphInstances.length; m++) {
+                    // modify weights of all 3 morph targets along some sin curve with different frequency
+                    morphInstances[m].setWeight(0, Math.abs(Math.sin(time + m)));
+                    morphInstances[m].setWeight(1, Math.abs(Math.sin(time * 0.3 + m)));
+                    morphInstances[m].setWeight(2, Math.abs(Math.sin(time * 0.7 + m)));
+                }
+
+                // orbit camera around
+                camera.setLocalPosition(16 * Math.sin(time * 0.2), 4, 16 * Math.cos(time * 0.2));
+                camera.lookAt(pc.Vec3.ZERO);
+
+                // debug display the morph target textures blended together
+                if (morphInstances[0].texturePositions) {
+                    // @ts-ignore
+                    app.drawTexture(-0.7, -0.7, 0.4, 0.4, morphInstances[0].texturePositions);
+                }
+
+                if (morphInstances[0].textureNormals) {
+                    // @ts-ignore
+                    app.drawTexture(0.7, -0.7, 0.4, 0.4, morphInstances[0].textureNormals);
+                }
+            });
         });
     }
 }

--- a/src/platform/graphics/shader-chunks/frag/shared.js
+++ b/src/platform/graphics/shader-chunks/frag/shared.js
@@ -10,4 +10,14 @@ vec2 getGrabScreenPos(vec4 clipPos) {
 
     return uv;
 }
+
+// convert uv coordinates to sample image effect texture (render target texture rendered without
+// forward renderer which does the flip in the projection matrix)
+vec2 getImageEffectUV(vec2 uv) {
+    #ifdef WEBGPU
+        uv.y = 1.0 - uv.y;
+    #endif
+
+    return uv;
+}
 `;

--- a/src/platform/graphics/shader-utils.js
+++ b/src/platform/graphics/shader-utils.js
@@ -69,6 +69,7 @@ class ShaderUtils {
         const vertDefines = options.vertexDefines || getDefines(webgpuVS, gles3VS, '', true);
         const vertCode = ShaderUtils.versionCode(device) +
             vertDefines +
+            sharedFS +
             ShaderUtils.getShaderNameCode(name) +
             options.vertexCode;
 

--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -281,6 +281,7 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
             // draw
             const ib = this.indexBuffer;
             if (ib) {
+                this.indexBuffer = null;
                 passEncoder.setIndexBuffer(ib.impl.buffer, ib.impl.format);
                 passEncoder.drawIndexed(ib.numIndices, numInstances, 0, 0, 0);
             } else {
@@ -393,6 +394,13 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
         // start the pass
         this.passEncoder = this.commandEncoder.beginRenderPass(wrt.renderPassDescriptor);
         DebugHelper.setLabel(this.passEncoder, renderPass.name);
+
+        // the pass always clears full target
+        // TODO: avoid this setting the actual viewport/scissor on webgpu as those are automatically reset to full
+        // render target. We just need to update internal state, for the get functionality to return it.
+        const { width, height } = rt;
+        this.setViewport(0, 0, width, height);
+        this.setScissor(0, 0, width, height);
 
         Debug.assert(!this.insideRenderPass, 'RenderPass cannot be started while inside another render pass.');
         this.insideRenderPass = true;

--- a/src/platform/graphics/webgpu/webgpu-render-pipeline.js
+++ b/src/platform/graphics/webgpu/webgpu-render-pipeline.js
@@ -138,25 +138,32 @@ class WebgpuRenderPipeline {
     }
 
     getBlend(renderState) {
-        // type {GPUBlendState}
-        const blend = {
-            color: {
-                operation: _blendOperation[renderState.blendEquationColor],
-                srcFactor: _blendFactor[renderState.blendSrcColor],
-                dstFactor: _blendFactor[renderState.blendDstColor]
-            },
-            alpha: {
-                operation: _blendOperation[renderState.blendEquationAlpha],
-                srcFactor: _blendFactor[renderState.blendSrcAlpha],
-                dstFactor: _blendFactor[renderState.blendDstAlpha]
-            }
-        };
 
-        // unsupported blend factors
-        Debug.assert(blend.color.srcFactor !== undefined);
-        Debug.assert(blend.color.dstFactor !== undefined);
-        Debug.assert(blend.alpha.srcFactor !== undefined);
-        Debug.assert(blend.alpha.dstFactor !== undefined);
+        // blend needs to be undefined when blending is disabled
+        let blend;
+
+        if (renderState.blending) {
+
+            // type {GPUBlendState}
+            blend = {
+                color: {
+                    operation: _blendOperation[renderState.blendEquationColor],
+                    srcFactor: _blendFactor[renderState.blendSrcColor],
+                    dstFactor: _blendFactor[renderState.blendDstColor]
+                },
+                alpha: {
+                    operation: _blendOperation[renderState.blendEquationAlpha],
+                    srcFactor: _blendFactor[renderState.blendSrcAlpha],
+                    dstFactor: _blendFactor[renderState.blendDstAlpha]
+                }
+            };
+
+            // unsupported blend factors
+            Debug.assert(blend.color.srcFactor !== undefined);
+            Debug.assert(blend.color.dstFactor !== undefined);
+            Debug.assert(blend.alpha.srcFactor !== undefined);
+            Debug.assert(blend.alpha.dstFactor !== undefined);
+        }
 
         return blend;
     }

--- a/src/platform/graphics/webgpu/webgpu-texture.js
+++ b/src/platform/graphics/webgpu/webgpu-texture.js
@@ -178,7 +178,9 @@ class WebgpuTexture {
             };
 
             // TODO: this is temporary and needs to be made generic
-            if (this.texture.format === PIXELFORMAT_RGBA32F || this.texture.format === PIXELFORMAT_DEPTHSTENCIL) {
+            if (this.texture.format === PIXELFORMAT_RGBA32F ||
+                this.texture.format === PIXELFORMAT_DEPTHSTENCIL ||
+                this.texture.format === PIXELFORMAT_RGBA16F) {
                 descr.magFilter = 'nearest';
                 descr.minFilter = 'nearest';
                 descr.mipmapFilter = 'nearest';

--- a/src/scene/morph-instance.js
+++ b/src/scene/morph-instance.js
@@ -67,8 +67,7 @@ class MorphInstance {
             const createRT = (name, textureVar) => {
 
                 // render to appropriate, RGBA formats, we cannot render to RGB float / half float format in WEbGL
-                const format = morph._renderTextureFormat === Morph.FORMAT_FLOAT ? PIXELFORMAT_RGBA32F : PIXELFORMAT_RGBA16F;
-                this[textureVar] = morph._createTexture(name, format);
+                this[textureVar] = morph._createTexture(name, morph._renderTextureFormat);
                 return new RenderTarget({
                     colorBuffer: this[textureVar],
                     depth: false

--- a/src/scene/morph-instance.js
+++ b/src/scene/morph-instance.js
@@ -1,12 +1,11 @@
 import { Debug } from '../core/debug.js';
 
-import { BLENDEQUATION_ADD, BLENDMODE_ONE, PIXELFORMAT_RGBA32F, PIXELFORMAT_RGBA16F } from '../platform/graphics/constants.js';
+import { BLENDEQUATION_ADD, BLENDMODE_ONE } from '../platform/graphics/constants.js';
 import { drawQuadWithShader } from './graphics/quad-render-utils.js';
 import { RenderTarget } from '../platform/graphics/render-target.js';
 import { DebugGraphics } from '../platform/graphics/debug-graphics.js';
 
 import { createShaderFromCode } from './shader-lib/utils.js';
-import { Morph } from './morph.js';
 
 // vertex shader used to add morph targets from textures into render target
 const textureMorphVertexShader = `

--- a/src/scene/morph-instance.js
+++ b/src/scene/morph-instance.js
@@ -25,13 +25,13 @@ class MorphInstance {
     /**
      * Create a new MorphInstance instance.
      *
-     * @param {Morph} morph - The {@link Morph} to instance.
+     * @param {import('./morph.js').Morph} morph - The {@link Morph} to instance.
      */
     constructor(morph) {
         /**
          * The morph with its targets, which is being instanced.
          *
-         * @type {Morph}
+         * @type {import('./morph.js').Morph}
          */
         this.morph = morph;
         morph.incRefCount();

--- a/src/scene/morph.js
+++ b/src/scene/morph.js
@@ -9,7 +9,7 @@ import { VertexFormat } from '../platform/graphics/vertex-format.js';
 
 import {
     BUFFER_STATIC, TYPE_FLOAT32, SEMANTIC_ATTR15, ADDRESS_CLAMP_TO_EDGE, FILTER_NEAREST,
-    PIXELFORMAT_RGBA16F, PIXELFORMAT_RGB32F
+    PIXELFORMAT_RGBA16F, PIXELFORMAT_RGB32F, PIXELFORMAT_RGBA32F
 } from '../platform/graphics/constants.js';
 import { GraphicsDeviceAccess } from '../platform/graphics/graphics-device-access.js';
 
@@ -25,8 +25,7 @@ class Morph extends RefCountedObject {
      *
      * @param {import('./morph-target.js').MorphTarget[]} targets - A list of morph targets.
      * @param {import('../platform/graphics/graphics-device.js').GraphicsDevice} graphicsDevice -
-     * The graphics device used to manage this morph target. If it is not provided, a device is
-     * obtained from the {@link Application}.
+     * The graphics device used to manage this morph target.
      */
     constructor(targets, graphicsDevice) {
         super();
@@ -43,16 +42,16 @@ class Morph extends RefCountedObject {
 
             // pick renderable format - prefer half-float
             if (this.device.extTextureHalfFloat && this.device.textureHalfFloatRenderable) {
-                this._renderTextureFormat = Morph.FORMAT_HALF_FLOAT;
+                this._renderTextureFormat = PIXELFORMAT_RGBA16F;
             } else if (this.device.extTextureFloat && this.device.textureFloatRenderable) {
-                this._renderTextureFormat = Morph.FORMAT_FLOAT;
+                this._renderTextureFormat = PIXELFORMAT_RGBA32F;
             }
 
             // pick texture format - prefer half-float
             if (this.device.extTextureHalfFloat && this.device.textureHalfFloatUpdatable) {
-                this._textureFormat = Morph.FORMAT_HALF_FLOAT;
+                this._textureFormat = PIXELFORMAT_RGBA16F;
             } else  if (this.device.extTextureFloat) {
-                this._textureFormat = Morph.FORMAT_FLOAT;
+                this._textureFormat = PIXELFORMAT_RGB32F;
             }
 
             // if both available, enable texture morphing
@@ -65,10 +64,6 @@ class Morph extends RefCountedObject {
         this._updateMorphFlags();
         this._calculateAabb();
     }
-
-    static FORMAT_FLOAT = 0;
-
-    static FORMAT_HALF_FLOAT = 1;
 
     get morphPositions() {
         return this._morphPositions;
@@ -175,7 +170,7 @@ class Morph extends RefCountedObject {
         let halfFloat = false;
         let numComponents = 3;  // RGB32 is used
         const float2Half = FloatPacking.float2Half;
-        if (this._textureFormat === Morph.FORMAT_HALF_FLOAT) {
+        if (this._textureFormat === PIXELFORMAT_RGBA16F) {
             halfFloat = true;
             numComponents = 4;  // RGBA16 is used, RGB16 does not work
         }
@@ -203,7 +198,7 @@ class Morph extends RefCountedObject {
 
             // create texture and assign it to target
             const target = deltaInfos[i].target;
-            const format = this._textureFormat === Morph.FORMAT_FLOAT ? PIXELFORMAT_RGB32F : PIXELFORMAT_RGBA16F;
+            const format = this._textureFormat;
             target._setTexture(deltaInfos[i].name, this._createTexture('MorphTarget', format, packedDeltas));
         }
 

--- a/src/scene/shader-lib/chunks/common/vert/transform.js
+++ b/src/scene/shader-lib/chunks/common/vert/transform.js
@@ -25,7 +25,8 @@ vec2 getTextureMorphCoords() {
     float morphGridU = vertexId - (morphGridV * textureSize.x);
 
     // convert grid coordinates to uv coordinates with half pixel offset
-    return (vec2(morphGridU, morphGridV) * invTextureSize) + (0.5 * invTextureSize);
+    vec2 uv = (vec2(morphGridU, morphGridV) * invTextureSize) + (0.5 * invTextureSize);
+    return getImageEffectUV(uv);
 }
 #endif
 


### PR DESCRIPTION
- support for texture based morphing on WebGPU
- converted 3 example to use createGraphicsDevice (no other large changes there)
- fixed no alpha blending (descriptor needs 'undefined')
- fixed non-indexed buffer rendering
- change morphing code to use texture format directly, instead of wrapping enums (will allow to add additional texture formats)
- added a shader macro to swap y-texture coordinates when sampling from render target that are not swapped using FlipY (this is for render targets that do not use projection matrix, so image based sampling)