### PR TITLE
Exclude area lights LTC shader chunk if clustered area lights are disabled

### DIFF
--- a/src/scene/shader-lib/chunks/chunks.js
+++ b/src/scene/shader-lib/chunks/chunks.js
@@ -72,7 +72,7 @@ import lightSpecularAnisoGGXPS from './lit/frag/lightSpecularAnisoGGX.js';
 import lightSpecularBlinnPS from './lit/frag/lightSpecularBlinn.js';
 import lightSpecularPhongPS from './lit/frag/lightSpecularPhong.js';
 import lightSheenPS from './lit/frag/lightSheen.js';
-import ltc from './lit/frag/ltc.js';
+import ltcPS from './lit/frag/ltc.js';
 import metalnessPS from './standard/frag/metalness.js';
 import msdfPS from './common/frag/msdf.js';
 import metalnessModulatePS from './lit/frag/metalnessModulate.js';
@@ -277,7 +277,7 @@ const shaderChunks = {
     lightSpecularBlinnPS,
     lightSpecularPhongPS,
     lightSheenPS,
-    ltc,
+    ltcPS,
     metalnessPS,
     metalnessModulatePS,
     msdfPS,

--- a/src/scene/shader-lib/programs/lit-shader.js
+++ b/src/scene/shader-lib/programs/lit-shader.js
@@ -863,7 +863,7 @@ class LitShader {
 
         if (this.lighting) {
             code += chunks.lightDiffuseLambertPS;
-            if (hasAreaLights || options.clusteredLightingEnabled) code += chunks.ltc;
+            if (hasAreaLights || options.clusteredLightingAreaLightsEnabled) code += chunks.ltcPS;
         }
 
         code += '\n';


### PR DESCRIPTION
- hopefuly a small shader compilation speed improvement, even though the code was not executed