### PR TITLE
Clustered light cookie textures works on WebGPU

### DIFF
--- a/src/platform/graphics/shader-chunks/frag/gles2.js
+++ b/src/platform/graphics/shader-chunks/frag/gles2.js
@@ -1,10 +1,12 @@
 export default /* glsl */`
 #define texture2DBias texture2D
 
-// pass / accept shadow map as a function parameter, on webgl this is simply passsed as is and this is
-// needed for ebGPU
+// pass / accept shadow map or texture as a function parameter, on webgl this is simply passsed as is
+// but this is needed for WebGPU
 #define SHADOWMAP_PASS(name) name
 #define SHADOWMAP_ACCEPT(name) sampler2D name
+#define TEXTURE_PASS(name) name
+#define TEXTURE_ACCEPT(name) sampler2D name
 
 #ifndef SUPPORTS_TEXLOD
 

--- a/src/platform/graphics/shader-chunks/frag/gles3.js
+++ b/src/platform/graphics/shader-chunks/frag/gles3.js
@@ -19,10 +19,12 @@ out highp vec4 pc_fragColor;
 // lod instruction for DirectX correctly and uses SampleCmp instead of SampleCmpLevelZero or similar.
 #define textureShadow(res, uv) textureGrad(res, uv, vec2(1, 1), vec2(1, 1))
 
-// pass / accept shadow map as a function parameter, on webgl this is simply passsed as is and this is
-// needed for ebGPU
+// pass / accept shadow map or texture as a function parameter, on webgl this is simply passsed as is
+// but this is needed for WebGPU
 #define SHADOWMAP_PASS(name) name
 #define SHADOWMAP_ACCEPT(name) sampler2DShadow name
+#define TEXTURE_PASS(name) name
+#define TEXTURE_ACCEPT(name) sampler2D name
 
 #define GL2
 #define SUPPORTS_TEXLOD

--- a/src/platform/graphics/shader-chunks/frag/webgpu.js
+++ b/src/platform/graphics/shader-chunks/frag/webgpu.js
@@ -24,6 +24,8 @@ layout(location = 0) out highp vec4 pc_fragColor;
 // as the combined sampler can be only created at a point of use
 #define SHADOWMAP_PASS(name) name, name ## _sampler
 #define SHADOWMAP_ACCEPT(name) texture2D name, sampler name ## _sampler
+#define TEXTURE_PASS(name) name, name ## _sampler
+#define TEXTURE_ACCEPT(name) texture2D name, sampler name ## _sampler
 
 #define GL2
 #define WEBGPU

--- a/src/scene/shader-lib/chunks/lit/frag/clusteredLight.js
+++ b/src/scene/shader-lib/chunks/lit/frag/clusteredLight.js
@@ -403,9 +403,9 @@ void evaluateLight(ClusterLightData light) {
                     decodeClusterLightCookieData(light);
 
                     if (isClusteredLightSpot(light)) {
-                        dAtten3 = getCookie2DClustered(cookieAtlasTexture, lightProjectionMatrix, vPositionW, light.cookieIntensity, isClusteredLightCookieRgb(light), light.cookieChannelMask);
+                        dAtten3 = getCookie2DClustered(TEXTURE_PASS(cookieAtlasTexture), lightProjectionMatrix, vPositionW, light.cookieIntensity, isClusteredLightCookieRgb(light), light.cookieChannelMask);
                     } else {
-                        dAtten3 = getCookieCubeClustered(cookieAtlasTexture, dLightDirW, light.cookieIntensity, isClusteredLightCookieRgb(light), light.cookieChannelMask, shadowTextureResolution, shadowEdgePixels, light.omniAtlasViewport);
+                        dAtten3 = getCookieCubeClustered(TEXTURE_PASS(cookieAtlasTexture), dLightDirW, light.cookieIntensity, isClusteredLightCookieRgb(light), light.cookieChannelMask, shadowTextureResolution, shadowEdgePixels, light.omniAtlasViewport);
                     }
                 }
 

--- a/src/scene/shader-lib/chunks/lit/frag/clusteredLightCookies.js
+++ b/src/scene/shader-lib/chunks/lit/frag/clusteredLightCookies.js
@@ -1,18 +1,18 @@
 export default /* glsl */`
-vec3 _getCookieClustered(sampler2D tex, vec2 uv, float intensity, bool isRgb, vec4 cookieChannel) {
-    vec4 pixel = mix(vec4(1.0), texture2D(tex, uv), intensity);
+vec3 _getCookieClustered(TEXTURE_ACCEPT(tex), vec2 uv, float intensity, bool isRgb, vec4 cookieChannel) {
+    vec4 pixel = mix(vec4(1.0), texture2DLodEXT(tex, uv, 0.0), intensity);
     return isRgb == true ? pixel.rgb : vec3(dot(pixel, cookieChannel));
 }
 
 // getCookie2D for clustered lighting including channel selector
-vec3 getCookie2DClustered(sampler2D tex, mat4 transform, vec3 worldPosition, float intensity, bool isRgb, vec4 cookieChannel) {
+vec3 getCookie2DClustered(TEXTURE_ACCEPT(tex), mat4 transform, vec3 worldPosition, float intensity, bool isRgb, vec4 cookieChannel) {
     vec4 projPos = transform * vec4(worldPosition, 1.0);
-    return _getCookieClustered(tex, projPos.xy / projPos.w, intensity, isRgb, cookieChannel);
+    return _getCookieClustered(TEXTURE_PASS(tex), projPos.xy / projPos.w, intensity, isRgb, cookieChannel);
 }
 
 // getCookie for clustered omni light with the cookie texture being stored in the cookie atlas
-vec3 getCookieCubeClustered(sampler2D tex, vec3 dir, float intensity, bool isRgb, vec4 cookieChannel, float shadowTextureResolution, float shadowEdgePixels, vec3 omniAtlasViewport) {
+vec3 getCookieCubeClustered(TEXTURE_ACCEPT(tex), vec3 dir, float intensity, bool isRgb, vec4 cookieChannel, float shadowTextureResolution, float shadowEdgePixels, vec3 omniAtlasViewport) {
     vec2 uv = getCubemapAtlasCoordinates(omniAtlasViewport, shadowEdgePixels, shadowTextureResolution, dir);
-    return _getCookieClustered(tex, uv, intensity, isRgb, cookieChannel);
+    return _getCookieClustered(TEXTURE_PASS(tex), uv, intensity, isRgb, cookieChannel);
 }
 `;


### PR DESCRIPTION
- passing and receiving cookie texture using macro, to accommodate the sampler and the resource being separate on WebGPU, to make the shaders compile on WebGPU
- sample the clustered cookie texture using LOD instruction to avoid derivatives in the loops to help with DX11 shader compilation when cookies are used. The cookie atlas does not have mipmaps, so sampling level 0 works here.

![Screenshot 2023-01-20 at 11 02 29](https://user-images.githubusercontent.com/59932779/213680238-edd996db-87fd-4615-b14b-f383928bf8ff.png)
