### PR TITLE
Deprecated property: Layer.renderTarget

### DIFF
--- a/src/deprecated/deprecated.js
+++ b/src/deprecated/deprecated.js
@@ -75,6 +75,7 @@ import { Batch } from '../scene/batching/batch.js';
 import { getDefaultMaterial } from '../scene/materials/default-material.js';
 import { StandardMaterialOptions } from '../scene/materials/standard-material-options.js';
 import { LitOptions } from '../scene/materials/lit-options.js';
+import { Layer } from '../scene/layer.js';
 
 import { Animation, Key, Node } from '../scene/animation/animation.js';
 import { Skeleton } from '../scene/animation/skeleton.js';
@@ -607,6 +608,17 @@ Object.defineProperty(Scene.prototype, 'models', {
             this._models = [];
         }
         return this._models;
+    }
+});
+
+Object.defineProperty(Layer.prototype, 'renderTarget', {
+    set: function (rt) {
+        Debug.deprecated(`pc.Layer#renderTarget is deprecated. Set the render target on the camera instead.`);
+        this._renderTarget = rt;
+        this._dirtyCameras = true;
+    },
+    get: function () {
+        return this._renderTarget;
     }
 });
 

--- a/src/scene/layer.js
+++ b/src/scene/layer.js
@@ -448,23 +448,6 @@ class Layer {
     }
 
     /**
-     * @type {import('../platform/graphics/render-target.js').RenderTarget}
-     * @ignore
-     */
-    set renderTarget(rt) {
-        /**
-         * @type {import('../platform/graphics/render-target.js').RenderTarget}
-         * @private
-         */
-        this._renderTarget = rt;
-        this._dirtyCameras = true;
-    }
-
-    get renderTarget() {
-        return this._renderTarget;
-    }
-
-    /**
      * Enable the layer. Disabled layers are skipped. Defaults to true.
      *
      * @type {boolean}


### PR DESCRIPTION
- this property has not been public for almost 2 years now, it’s time to deprecate it properly, as it no longer is the recommended way of rendering to texture. The property still works as before, but logs a warning message.