### PR TITLE
Added public API notes for the container resource

### DIFF
--- a/src/framework/handlers/container.js
+++ b/src/framework/handlers/container.js
@@ -8,6 +8,10 @@ import { GlbParser } from '../parsers/glb-parser.js';
  * @interface
  * @name ContainerResource
  * @description Container for a list of animations, textures, materials, renders and a model.
+ * @property {import('../asset/asset.js').Asset[]} renders An array of the Render assets.
+ * @property {import('../asset/asset.js').Asset[]} materials An array of {@link Material} and/or {@link StandardMaterial} assets.
+ * @property {import('../asset/asset.js').Asset[]} textures An array of the {@link Texture} assets.
+ * @property {import('../asset/asset.js').Asset[]} animations An array of the {@link Animation} assets.
  */
 class ContainerResource {
     /**


### PR DESCRIPTION
Fixes #3872

Adds public API for the different asset types

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
