### PR TITLE
Clear DebugGraphics gpu call stack each frame

### DIFF
--- a/src/framework/app-base.js
+++ b/src/framework/app-base.js
@@ -17,6 +17,7 @@ import {
     PRIMITIVE_TRIANGLES, PRIMITIVE_TRIFAN, PRIMITIVE_TRISTRIP
 } from '../platform/graphics/constants.js';
 import { GraphicsDeviceAccess } from '../platform/graphics/graphics-device-access.js';
+import { DebugGraphics } from '../platform/graphics/debug-graphics.js';
 import { http } from '../platform/net/http.js';
 
 import {
@@ -1214,6 +1215,7 @@ class AppBase extends EventHandler {
 
     // render a layer composition
     renderComposition(layerComposition) {
+        DebugGraphics.clearGpuMarkers();
         this.renderer.buildFrameGraph(this.frameGraph, layerComposition);
         this.frameGraph.render(this.graphicsDevice);
     }

--- a/src/platform/graphics/debug-graphics.js
+++ b/src/platform/graphics/debug-graphics.js
@@ -14,6 +14,14 @@ class DebugGraphics {
     static markers = [];
 
     /**
+     * Clear internal stack of the GPU markers. It should be called at the start of the frame to
+     * prevent the array growing if there are exceptions during the rendering.
+     */
+    static clearGpuMarkers() {
+        DebugGraphics.markers.length = 0;
+    }
+
+    /**
      * Push GPU marker to the stack on the device.
      *
      * @param {import('./graphics-device.js').GraphicsDevice} device - The graphics device.


### PR DESCRIPTION
- if we get an expection every frame, the stack grows and error messages using it get super long. Clear it at the start of the frame.