### PR TITLE
Examples browser dependency upgrade

### DIFF
--- a/examples/package-lock.json
+++ b/examples/package-lock.json
@@ -16,7 +16,7 @@
         "@monaco-editor/react": "^4.4.5",
         "@playcanvas/eslint-config": "^1.1.1",
         "@playcanvas/observer": "1.3.6",
-        "@playcanvas/pcui": "^3.3.1",
+        "@playcanvas/pcui": "^4.0.0",
         "@rollup/plugin-alias": "^4.0.2",
         "@rollup/plugin-commonjs": "^22.0.0",
         "@rollup/plugin-node-resolve": "^13.3.0",
@@ -372,9 +372,9 @@
       "dev": true
     },
     "node_modules/@playcanvas/pcui": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@playcanvas/pcui/-/pcui-3.3.1.tgz",
-      "integrity": "sha512-zy+kz4toS5lLEFYkDNi1La40BE++SMCa/iBlETUsHDCAcYaxx7yX0aYjvKXN7VTF8T0BhGt4VP3CsQlLxJTOSw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@playcanvas/pcui/-/pcui-4.0.0.tgz",
+      "integrity": "sha512-TG3VroX0TqMZSAKPazCCd3HtJamzcnKATljY+acTYSev8vv1jC5ZsjAXdlnS7xK39vDGooCs4kL5fWZf+PUK3A==",
       "dev": true,
       "dependencies": {
         "@playcanvas/observer": "^1.3.6"
@@ -5591,9 +5591,9 @@
       "dev": true
     },
     "@playcanvas/pcui": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@playcanvas/pcui/-/pcui-3.3.1.tgz",
-      "integrity": "sha512-zy+kz4toS5lLEFYkDNi1La40BE++SMCa/iBlETUsHDCAcYaxx7yX0aYjvKXN7VTF8T0BhGt4VP3CsQlLxJTOSw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@playcanvas/pcui/-/pcui-4.0.0.tgz",
+      "integrity": "sha512-TG3VroX0TqMZSAKPazCCd3HtJamzcnKATljY+acTYSev8vv1jC5ZsjAXdlnS7xK39vDGooCs4kL5fWZf+PUK3A==",
       "dev": true,
       "requires": {
         "@playcanvas/observer": "^1.3.6"

--- a/examples/package.json
+++ b/examples/package.json
@@ -48,7 +48,7 @@
     "@monaco-editor/react": "^4.4.5",
     "@playcanvas/eslint-config": "^1.1.1",
     "@playcanvas/observer": "1.3.6",
-    "@playcanvas/pcui": "^3.3.1",
+    "@playcanvas/pcui": "^4.0.0",
     "@rollup/plugin-alias": "^4.0.2",
     "@rollup/plugin-commonjs": "^22.0.0",
     "@rollup/plugin-node-resolve": "^13.3.0",


### PR DESCRIPTION
Bump the version of PCUI used in the examples browser to 4.0.0.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
