### PR TITLE
Variable rename in the clustered lighting shader to avoid the use of reserved word

### DIFF
--- a/src/platform/graphics/webgpu/webgpu-texture.js
+++ b/src/platform/graphics/webgpu/webgpu-texture.js
@@ -14,7 +14,7 @@ import {
 
 // map of PIXELFORMAT_*** to GPUTextureFormat
 const gpuTextureFormats = [];
-gpuTextureFormats[PIXELFORMAT_A8] = 'r8unorm';
+gpuTextureFormats[PIXELFORMAT_A8] = '';
 gpuTextureFormats[PIXELFORMAT_L8] = 'r8unorm';
 gpuTextureFormats[PIXELFORMAT_LA8] = 'rg8unorm';
 gpuTextureFormats[PIXELFORMAT_RGB565] = '';

--- a/src/scene/lighting/world-clusters.js
+++ b/src/scene/lighting/world-clusters.js
@@ -1,7 +1,7 @@
 import { Vec3 } from '../../core/math/vec3.js';
 import { math } from '../../core/math/math.js';
 import { BoundingBox } from '../../core/shape/bounding-box.js';
-import { PIXELFORMAT_A8 } from '../../platform/graphics/constants.js';
+import { PIXELFORMAT_L8 } from '../../platform/graphics/constants.js';
 import { LIGHTTYPE_DIRECTIONAL, LIGHTTYPE_SPOT, MASK_AFFECT_DYNAMIC, MASK_AFFECT_LIGHTMAPPED } from '../constants.js';
 import { LightsBuffer } from './lights-buffer.js';
 import { Debug } from '../../core/debug.js';
@@ -194,7 +194,7 @@ class WorldClusters {
             this._clusterTextureSizeData[2] = 1.0 / height;
 
             this.releaseClusterTexture();
-            this.clusterTexture = LightsBuffer.createTexture(this.device, width, height, PIXELFORMAT_A8, 'ClusterTexture');
+            this.clusterTexture = LightsBuffer.createTexture(this.device, width, height, PIXELFORMAT_L8, 'ClusterTexture');
         }
     }
 

--- a/src/scene/shader-lib/chunks/lit/frag/clusteredLight.js
+++ b/src/scene/shader-lib/chunks/lit/frag/clusteredLight.js
@@ -49,7 +49,7 @@ struct ClusterLightData {
     vec3 halfWidth;
 
     // type of the light (spot or omni)
-    float type;
+    float lightType;
 
     // area light sizes / orientation
     vec3 halfHeight;
@@ -121,7 +121,7 @@ mat4 lightProjectionMatrix;
 #define isClusteredLightCastShadow(light) ( light.shadowIntensity > 0.0 )
 #define isClusteredLightCookie(light) (light.cookie > 0.5 )
 #define isClusteredLightCookieRgb(light) (light.cookieRgb > 0.5 )
-#define isClusteredLightSpot(light) ( light.type > 0.5 )
+#define isClusteredLightSpot(light) ( light.lightType > 0.5 )
 #define isClusteredLightFalloffLinear(light) ( light.falloffMode < 0.5 )
 
 // macros to test light shape
@@ -181,7 +181,7 @@ void decodeClusterLightCore(inout ClusterLightData clusterLightData, float light
 
     // shared data from 8bit texture
     vec4 lightInfo = sampleLightsTexture8(clusterLightData, CLUSTER_TEXTURE_8_FLAGS);
-    clusterLightData.type = lightInfo.x;
+    clusterLightData.lightType = lightInfo.x;
     clusterLightData.shape = lightInfo.y;
     clusterLightData.falloffMode = lightInfo.z;
     clusterLightData.shadowIntensity = lightInfo.w;

--- a/src/scene/shader-lib/chunks/lit/frag/clusteredLight.js
+++ b/src/scene/shader-lib/chunks/lit/frag/clusteredLight.js
@@ -593,7 +593,7 @@ void addClusteredLights() {
             for (int lightCellIndex = 0; lightCellIndex < clusterMaxCells; lightCellIndex++) {
 
                 // using a single channel texture with data in alpha channel
-                float lightIndex = texelFetch(clusterWorldTexture, ivec2(int(clusterU) + lightCellIndex, clusterV), 0).a;
+                float lightIndex = texelFetch(clusterWorldTexture, ivec2(int(clusterU) + lightCellIndex, clusterV), 0).x;
                 evaluateClusterLight(lightIndex * 255.0); 
             }
 
@@ -605,7 +605,7 @@ void addClusteredLights() {
             const float maxLightCells = 256.0;
             for (float lightCellIndex = 0.5; lightCellIndex < maxLightCells; lightCellIndex++) {
 
-                float lightIndex = texture2DLodEXT(clusterWorldTexture, vec2(clusterTextureSize.y * (clusterU + lightCellIndex), clusterV), 0.0).a;
+                float lightIndex = texture2DLodEXT(clusterWorldTexture, vec2(clusterTextureSize.y * (clusterU + lightCellIndex), clusterV), 0.0).x;
 
                 if (lightIndex <= 0.0)
                     return;


### PR DESCRIPTION
- `type` cannot be variable name as its a reserved word in WGSL
- Switch clustered world texture from A8 to L8 as WebGPU does not have a direct A8 equivalent