### PR TITLE
Update basis initialisation to work with facebook games

### DIFF
--- a/src/framework/handlers/basis-worker.js
+++ b/src/framework/handlers/basis-worker.js
@@ -375,9 +375,6 @@ function BasisWorker() {
     };
 
     const workerInit = (config, callback) => {
-        // load the basis file (this is synchronous)
-        self.importScripts(config.basisUrl);
-
         // initialize the wasm module
         const instantiateWasmFunc = (imports, successCallback) => {
             WebAssembly.instantiate(config.module, imports)

--- a/src/framework/handlers/basis.js
+++ b/src/framework/handlers/basis.js
@@ -17,8 +17,13 @@ const getCompressionFormats = (device) => {
 
 // download basis code and compile the wasm module for use in workers
 const prepareWorkerModules = (config, callback) => {
-    const getWorkerBlob = () => {
-        const code = '(' + BasisWorker.toString() + ')()\n\n';
+    const getWorkerBlob = (basisCode) => {
+        const code = [
+            '/* basis */',
+            basisCode,
+            "",
+            '(' + BasisWorker.toString() + ')()\n\n'
+        ].join('\n');
         return new Blob([code], { type: 'application/javascript' });
     };
 
@@ -35,8 +40,7 @@ const prepareWorkerModules = (config, callback) => {
 
     const sendResponse = (basisCode, module) => {
         callback(null, {
-            workerUrl: URL.createObjectURL(getWorkerBlob()),
-            basisUrl: URL.createObjectURL(basisCode),
+            workerUrl: URL.createObjectURL(getWorkerBlob(basisCode)),
             module: module,
             rgbPriority: config.rgbPriority,
             rgbaPriority: config.rgbaPriority
@@ -44,7 +48,8 @@ const prepareWorkerModules = (config, callback) => {
     };
 
     const options = {
-        responseType: 'blob',
+        cache: true,
+        responseType: 'text',
         retry: config.maxRetries > 0,
         maxRetries: config.maxRetries
     };


### PR DESCRIPTION
Fixes #4780

PR #3277 changed the way the basis glue code was initialised in the web worker. Instead of manually combining the webworker source and basis glue code, it included the glue code as a webworker instead.

This PR reverts that change because facebook disallows webworkers importing scripts as blob.
