### PR TITLE
Updated texture reprojection to work on WebGPU

### DIFF
--- a/examples/src/examples/graphics/box-reflection.tsx
+++ b/examples/src/examples/graphics/box-reflection.tsx
@@ -8,7 +8,6 @@ class BoxReflectionExample {
     static CATEGORY = 'Graphics';
     static NAME = 'Box Reflection';
 
-
     controls(data: Observer) {
         return <>
             <Panel headerText='Settings'>
@@ -38,12 +37,6 @@ class BoxReflectionExample {
 
     example(canvas: HTMLCanvasElement, data: any): void {
 
-        // Create the application and start the update loop
-        const app = new pc.Application(canvas, {
-            mouse: new pc.Mouse(document.body),
-            touch: new pc.TouchDevice(document.body)
-        });
-
         const assets = {
             'script1': new pc.Asset('script', 'script', { url: '/static/scripts/camera/orbit-camera.js' }),
             'script2': new pc.Asset('script', 'script', { url: '/static/scripts/utils/cubemap-renderer.js' }),
@@ -51,306 +44,347 @@ class BoxReflectionExample {
             'normal': new pc.Asset('normal', 'texture', { url: '/static/assets/textures/normal-map.png' })
         };
 
-        const assetListLoader = new pc.AssetListLoader(Object.values(assets), app.assets);
-        assetListLoader.load(() => {
-            app.start();
+        pc.createGraphicsDevice(canvas).then((device: pc.GraphicsDevice) => {
 
-            data.set('settings', {
-                updateFrequency: 10,
-                shininess: 80,
-                metalness: 0.9,
-                bumpiness: 0.2,
-                reflectivity: 0.5
-            });
+            const createOptions = new pc.AppOptions();
+            createOptions.graphicsDevice = device;
+            createOptions.mouse = new pc.Mouse(document.body);
+            createOptions.touch = new pc.TouchDevice(document.body);
+
+            createOptions.componentSystems = [
+                // @ts-ignore
+                pc.RenderComponentSystem,
+                // @ts-ignore
+                pc.CameraComponentSystem,
+                // @ts-ignore
+                pc.LightComponentSystem,
+                // @ts-ignore
+                pc.ScriptComponentSystem
+            ];
+            createOptions.resourceHandlers = [
+                // @ts-ignore
+                pc.ScriptHandler,
+                // @ts-ignore
+                pc.TextureHandler,
+                // @ts-ignore
+                pc.ContainerHandler
+            ];
+
+            const app = new pc.AppBase(canvas);
+            app.init(createOptions);
 
             // Set the canvas to fill the window and automatically change resolution to be the same as the canvas size
             app.setCanvasFillMode(pc.FILLMODE_FILL_WINDOW);
             app.setCanvasResolution(pc.RESOLUTION_AUTO);
 
-            // create a layer for object that do not render into reflection cubemap
-            const excludedLayer = new pc.Layer({ name: "Excluded" });
-            app.scene.layers.push(excludedLayer);
+            const assetListLoader = new pc.AssetListLoader(Object.values(assets), app.assets);
+            assetListLoader.load(() => {
 
-            // get world layer
-            const worldLayer = app.scene.layers.getLayerByName("World");
+                app.start();
 
-            // create an envAtlas texture, which will hold a prefiltering lighting generated from the cubemap.
-            // This represents a reflection prefiltered for different levels of roughness
-            const envAtlas = new pc.Texture(app.graphicsDevice, {
-                width: 512,
-                height: 512,
-                format: pc.PIXELFORMAT_RGBA8,
-                type: pc.TEXTURETYPE_RGBM,
-                projection: pc.TEXTUREPROJECTION_EQUIRECT,
-                addressU: pc.ADDRESS_CLAMP_TO_EDGE,
-                addressV: pc.ADDRESS_CLAMP_TO_EDGE,
-                mipmaps: false
-            });
-
-            // material for the walls
-            const roomMaterial = new pc.StandardMaterial();
-            roomMaterial.useMetalness = true;
-            roomMaterial.diffuse = pc.Color.WHITE;
-            roomMaterial.normalMap = assets.normal.resource;
-            roomMaterial.normalMapTiling.set(5, 5);
-            roomMaterial.bumpiness = 0.1;
-            roomMaterial.shininess = 90;
-            roomMaterial.reflectivity = 0.3;
-            // @ts-ignore
-            roomMaterial.envAtlas = envAtlas; // use reflection from env atlas
-            roomMaterial.metalness = 0.5;
-
-            // the material uses box projected cubemap for reflections. Set its bounding box the the size of the room
-            // so that the reflections line up
-            roomMaterial.cubeMapProjection = pc.CUBEPROJ_BOX;
-            roomMaterial.cubeMapProjectionBox = new pc.BoundingBox(new pc.Vec3(0, 200, 0), new pc.Vec3(400, 200, 400));
-            roomMaterial.update();
-
-            // material for the magenta emissive beams
-            const emissiveMaterial = new pc.StandardMaterial();
-            emissiveMaterial.emissive = pc.Color.MAGENTA;
-            emissiveMaterial.diffuse = pc.Color.BLACK;
-            emissiveMaterial.update();
-
-            // material for the white sphere representing an omni light
-            const lightMaterial = new pc.StandardMaterial();
-            lightMaterial.emissive = pc.Color.WHITE;
-            lightMaterial.diffuse = pc.Color.BLACK;
-            lightMaterial.update();
-
-            // material for the reflective sphere in the center
-            const sphereMaterial = new pc.StandardMaterial();
-            sphereMaterial.useMetalness = true;
-            sphereMaterial.diffuse = pc.Color.WHITE;
-            sphereMaterial.normalMap = assets.normal.resource;
-            sphereMaterial.normalMapTiling.set(5, 5);
-            sphereMaterial.bumpiness = 0.7;
-            sphereMaterial.shininess = 30;
-            sphereMaterial.metalness = 0.7;
-            sphereMaterial.reflectivity = 0.3;
-            // @ts-ignore
-            sphereMaterial.envAtlas = envAtlas; // use reflection from env atlas
-            sphereMaterial.update();
-
-            // set up video playback into a texture
-            const videoTexture = new pc.Texture(app.graphicsDevice, {
-                format: pc.PIXELFORMAT_RGB565,
-                mipmaps: false,
-                minFilter: pc.FILTER_LINEAR,
-                magFilter: pc.FILTER_LINEAR,
-                addressU: pc.ADDRESS_CLAMP_TO_EDGE,
-                addressV: pc.ADDRESS_CLAMP_TO_EDGE
-            });
-
-            // create a HTML element with the video
-            const video: HTMLVideoElement = document.createElement('video');
-            video.id = 'vid';
-            video.loop = true;
-            video.muted = true;
-            video.autoplay = true;
-            video.playsInline = true;
-            video.crossOrigin = "anonymous";
-            video.setAttribute('style', 'display: block; width: 1px; height: 1px; position: absolute; opacity: 0; z-index: -1000; top: 0px; pointer-events: none');
-            video.src = '/static/assets/video/SampleVideo_1280x720_1mb.mp4';
-            document.body.append(video);
-            video.addEventListener('canplaythrough', function () {
-                videoTexture.setSource(video);
-            });
-
-            // materials used on the TV screen to display the video texture
-            const screenMaterial = new pc.StandardMaterial();
-            screenMaterial.useLighting = false;
-            screenMaterial.emissiveMap = videoTexture;
-            screenMaterial.update();
-
-            // helper function to create a 3d primitive including its material
-            function createPrimitive(primitiveType: string, position: pc.Vec3, scale: pc.Vec3, material: pc.Material) {
-
-                // create the primitive using the material
-                const primitive = new pc.Entity();
-                primitive.addComponent('render', {
-                    type: primitiveType,
-                    material: material,
-                    layers: [worldLayer.id, excludedLayer.id]
+                data.set('settings', {
+                    updateFrequency: 10,
+                    shininess: 80,
+                    metalness: 0.9,
+                    bumpiness: 0.2,
+                    reflectivity: 0.5
                 });
 
-                // set position and scale and add it to scene
-                primitive.setLocalPosition(position);
-                primitive.setLocalScale(scale);
-                app.root.addChild(primitive);
-            }
+                // create a layer for object that do not render into reflection cubemap
+                const excludedLayer = new pc.Layer({ name: "Excluded" });
+                app.scene.layers.push(excludedLayer);
 
-            // create the ground plane from the boxes
-            createPrimitive("box", new pc.Vec3(0, 0, 0), new pc.Vec3(800, 2, 800), roomMaterial);
-            createPrimitive("box", new pc.Vec3(0, 400, 0), new pc.Vec3(800, 2, 800), roomMaterial);
+                // get world layer
+                const worldLayer = app.scene.layers.getLayerByName("World");
 
-            // walls
-            createPrimitive("box", new pc.Vec3(400, 200, 0), new pc.Vec3(2, 400, 800), roomMaterial);
-            createPrimitive("box", new pc.Vec3(-400, 200, 0), new pc.Vec3(2, 400, 800), roomMaterial);
-            createPrimitive("box", new pc.Vec3(0, 200, -400), new pc.Vec3(800, 400, 0), roomMaterial);
-            createPrimitive("box", new pc.Vec3(0, 200, 400), new pc.Vec3(800, 400, 0), roomMaterial);
+                // create an envAtlas texture, which will hold a prefiltered lighting generated from the cubemap.
+                // This represents a reflection prefiltered for different levels of roughness
+                const envAtlas = new pc.Texture(app.graphicsDevice, {
+                    width: 512,
+                    height: 512,
+                    format: pc.PIXELFORMAT_RGBA8,
+                    type: pc.TEXTURETYPE_RGBM,
+                    projection: pc.TEXTUREPROJECTION_EQUIRECT,
+                    addressU: pc.ADDRESS_CLAMP_TO_EDGE,
+                    addressV: pc.ADDRESS_CLAMP_TO_EDGE,
+                    mipmaps: false
+                });
 
-            // emissive pillars
-            createPrimitive("box", new pc.Vec3(400, 200, -50), new pc.Vec3(20, 400, 20), emissiveMaterial);
-            createPrimitive("box", new pc.Vec3(400, 200, 50), new pc.Vec3(20, 400, 20), emissiveMaterial);
-            createPrimitive("box", new pc.Vec3(-400, 200, 50), new pc.Vec3(20, 400, 20), emissiveMaterial);
-            createPrimitive("box", new pc.Vec3(-400, 200, -50), new pc.Vec3(20, 400, 20), emissiveMaterial);
-            createPrimitive("box", new pc.Vec3(0, 400, 50), new pc.Vec3(800, 20, 20), emissiveMaterial);
-            createPrimitive("box", new pc.Vec3(0, 400, -50), new pc.Vec3(800, 20, 20), emissiveMaterial);
-
-            // screen
-            createPrimitive("box", new pc.Vec3(0, 200, 400), new pc.Vec3(500, 250, 5), screenMaterial);
-
-            // batmobile
-            const batmobileEntity: pc.Entity = assets.batmobile.resource.instantiateRenderEntity();
-            batmobileEntity.setLocalScale(100, 100, 100);
-            batmobileEntity.rotateLocal(0, 0, 90);
-            app.root.addChild(batmobileEntity);
-
-            // apply shiny material to it
-            const renders: Array<pc.RenderComponent> = batmobileEntity.findComponents('render') as Array<pc.RenderComponent>;
-            renders.forEach((render) => {
-                for (let i = 0; i < render.meshInstances.length; i++) {
-                    const meshInstance = render.meshInstances[i];
-                    meshInstance.material = sphereMaterial;
-                }
-            });
-
-            // create an omni light white orbits the room to avoid it being completely dark
-            const lightOmni = new pc.Entity();
-            lightOmni.addComponent("light", {
-                type: "omni",
-                layers: [excludedLayer.id], // add it to excluded layer, we don't want the light captured in the reflection
-                castShadows: false,
-                color: pc.Color.WHITE,
-                intensity: 0.2,
-                range: 1000
-            });
-
-            // add a white sphere to light so that we can see where it is. This sphere is excluded from the reflections.
-            lightOmni.addComponent("render", {
-                type: "sphere",
-                layers: [excludedLayer.id],
-                material: lightMaterial
-            });
-            lightOmni.setLocalScale(20, 20, 20);
-            app.root.addChild(lightOmni);
-
-            // create an Entity with a camera component
-            const camera = new pc.Entity();
-            camera.addComponent("camera", {
-                fov: 100,
-                layers: [worldLayer.id, excludedLayer.id],
-                farClip: 1500
-            });
-            camera.setLocalPosition(270, 90, -260);
-
-            // add orbit camera script with a mouse and a touch support
-            camera.addComponent("script");
-            camera.script.create("orbitCamera", {
-                attributes: {
-                    inertiaFactor: 0.2,
-                    distanceMax: 390,
-                    frameOnStart: false
-                }
-            });
-            camera.script.create("orbitCameraInputMouse");
-            camera.script.create("orbitCameraInputTouch");
-            app.root.addChild(camera);
-
-            // create a probe object with cubemapRenderer script which takes care of rendering dynamic cubemap
-            const probe = new pc.Entity();
-            probe.addComponent('script');
-
-            // add camera component to the probe - this defines camera properties for cubemap rendering
-            probe.addComponent('camera', {
-
-                // optimization - no need to clear as all pixels get overwritten
-                clearColorBuffer: false,
-
-                // priority - render before world camera
-                priority: -1,
-
-                // only render meshes on the worldLayer (and not excluded layer)
-                layers: [worldLayer.id],
-
-                // disable as this is not a camera that renders cube map but only a container for properties for cube map rendering
-                enabled: false,
-
-                nearClip: 1,
-                farClip: 500
-            });
-
-            // Add a cubemap renderer script, which renders to a cubemap of size 128 with mipmaps, which is directly useable
-            // as a lighting source for envAtlas generation
-            // Position it in the center of the room.
-            probe.script.create('cubemapRenderer', {
-                attributes: {
-                    resolution: 128,
-                    mipmaps: true,
-                    depth: true
-                }
-            });
-            probe.setPosition(0, 200, 0);
-            app.root.addChild(probe);
-
-            // handle onCubemapPostRender event fired by the cubemapRenderer when all faces of the cubemap are done rendering
-            probe.on('onCubemapPostRender', () => {
-
-                // prefilter just rendered cubemap into envAtlas, so that it can be used for reflection during the rest of the frame
+                // material for the walls
+                const roomMaterial = new pc.StandardMaterial();
+                roomMaterial.useMetalness = true;
+                roomMaterial.diffuse = pc.Color.WHITE;
+                roomMaterial.normalMap = assets.normal.resource;
+                roomMaterial.normalMapTiling.set(5, 5);
+                roomMaterial.bumpiness = 0.1;
+                roomMaterial.shininess = 90;
+                roomMaterial.reflectivity = 0.3;
                 // @ts-ignore
-                pc.EnvLighting.generateAtlas(probe.script.cubemapRenderer.cubeMap, {
-                    target: envAtlas
-                });
-            });
+                roomMaterial.envAtlas = envAtlas; // use reflection from env atlas
+                roomMaterial.metalness = 0.5;
 
-            // Set an update function on the app's update event
-            let time = 0;
-            let updateProbeCount = 1;
-            let updateVideo = true;
-            app.on("update", function (dt: number) {
-                time += dt * 0.3;
-
-                // Update the video data to the texture every other frame
-                if (updateVideo) {
-                    videoTexture.upload();
-                }
-                updateVideo = !updateVideo;
-
-                // move the light around
-                lightOmni.setLocalPosition(300 * Math.sin(time), 300, 300 * Math.cos(time));
-
-                // update the reflection probe as needed
-                const updateFrequency = data.get('settings.updateFrequency');
-                updateProbeCount--;
-                if (updateFrequency === 0)
-                    updateProbeCount = 1;
-
-                if (updateProbeCount <= 0) {
-                    // enable probe rendering
-                    probe.enabled = true;
-                    updateProbeCount = updateFrequency;
-                } else {
-                    probe.enabled = false;
-                }
-
-                // update material properties based on settings
-                const shininess = data.get('settings.shininess');
-                const metalness = data.get('settings.metalness');
-                const bumpiness = data.get('settings.bumpiness');
-                const reflectivity = data.get('settings.reflectivity');
-
-                roomMaterial.shininess = shininess;
-                roomMaterial.metalness = metalness;
-                roomMaterial.bumpiness = bumpiness;
-                roomMaterial.reflectivity = reflectivity;
+                // the material uses box projected cubemap for reflections. Set its bounding box the the size of the room
+                // so that the reflections line up
+                roomMaterial.cubeMapProjection = pc.CUBEPROJ_BOX;
+                roomMaterial.cubeMapProjectionBox = new pc.BoundingBox(new pc.Vec3(0, 200, 0), new pc.Vec3(400, 200, 400));
                 roomMaterial.update();
 
-                sphereMaterial.shininess = shininess;
-                sphereMaterial.metalness = metalness;
-                sphereMaterial.bumpiness = bumpiness;
-                sphereMaterial.reflectivity = reflectivity;
+                // material for the magenta emissive beams
+                const emissiveMaterial = new pc.StandardMaterial();
+                emissiveMaterial.emissive = pc.Color.MAGENTA;
+                emissiveMaterial.diffuse = pc.Color.BLACK;
+                emissiveMaterial.update();
+
+                // material for the white sphere representing an omni light
+                const lightMaterial = new pc.StandardMaterial();
+                lightMaterial.emissive = pc.Color.WHITE;
+                lightMaterial.diffuse = pc.Color.BLACK;
+                lightMaterial.update();
+
+                // material for the reflective sphere in the center
+                const sphereMaterial = new pc.StandardMaterial();
+                sphereMaterial.useMetalness = true;
+                sphereMaterial.diffuse = pc.Color.WHITE;
+                sphereMaterial.normalMap = assets.normal.resource;
+                sphereMaterial.normalMapTiling.set(5, 5);
+                sphereMaterial.bumpiness = 0.7;
+                sphereMaterial.shininess = 30;
+                sphereMaterial.metalness = 0.7;
+                sphereMaterial.reflectivity = 0.3;
+                // @ts-ignore
+                sphereMaterial.envAtlas = envAtlas; // use reflection from env atlas
                 sphereMaterial.update();
+
+                let videoTexture : pc.Texture;
+                if (app.graphicsDevice.deviceType === pc.DEVICETYPE_WEBGL) {
+                    // set up video playback into a texture
+                    videoTexture = new pc.Texture(app.graphicsDevice, {
+                        format: pc.PIXELFORMAT_RGB565,
+                        mipmaps: false,
+                        minFilter: pc.FILTER_LINEAR,
+                        magFilter: pc.FILTER_LINEAR,
+                        addressU: pc.ADDRESS_CLAMP_TO_EDGE,
+                        addressV: pc.ADDRESS_CLAMP_TO_EDGE
+                    });
+
+                    // create a HTML element with the video
+                    const video: HTMLVideoElement = document.createElement('video');
+                    video.id = 'vid';
+                    video.loop = true;
+                    video.muted = true;
+                    video.autoplay = true;
+                    video.playsInline = true;
+                    video.crossOrigin = "anonymous";
+                    video.setAttribute('style', 'display: block; width: 1px; height: 1px; position: absolute; opacity: 0; z-index: -1000; top: 0px; pointer-events: none');
+                    video.src = '/static/assets/video/SampleVideo_1280x720_1mb.mp4';
+                    document.body.append(video);
+                    video.addEventListener('canplaythrough', function () {
+                        videoTexture.setSource(video);
+                    });
+                }
+
+                // materials used on the TV screen to display the video texture
+                const screenMaterial = new pc.StandardMaterial();
+                screenMaterial.useLighting = false;
+                screenMaterial.emissiveMap = videoTexture;
+                screenMaterial.update();
+
+                // helper function to create a 3d primitive including its material
+                function createPrimitive(primitiveType: string, position: pc.Vec3, scale: pc.Vec3, material: pc.Material) {
+
+                    // create the primitive using the material
+                    const primitive = new pc.Entity();
+                    primitive.addComponent('render', {
+                        type: primitiveType,
+                        material: material,
+                        layers: [worldLayer.id, excludedLayer.id],
+                        castShadows: false,
+                        receiveShadows: false
+                    });
+
+                    // set position and scale and add it to scene
+                    primitive.setLocalPosition(position);
+                    primitive.setLocalScale(scale);
+                    app.root.addChild(primitive);
+                }
+
+                // create the ground plane from the boxes
+                createPrimitive("box", new pc.Vec3(0, 0, 0), new pc.Vec3(800, 2, 800), roomMaterial);
+                createPrimitive("box", new pc.Vec3(0, 400, 0), new pc.Vec3(800, 2, 800), roomMaterial);
+
+                // walls
+                createPrimitive("box", new pc.Vec3(400, 200, 0), new pc.Vec3(2, 400, 800), roomMaterial);
+                createPrimitive("box", new pc.Vec3(-400, 200, 0), new pc.Vec3(2, 400, 800), roomMaterial);
+                createPrimitive("box", new pc.Vec3(0, 200, -400), new pc.Vec3(800, 400, 0), roomMaterial);
+                createPrimitive("box", new pc.Vec3(0, 200, 400), new pc.Vec3(800, 400, 0), roomMaterial);
+
+                // emissive pillars
+                createPrimitive("box", new pc.Vec3(400, 200, -50), new pc.Vec3(20, 400, 20), emissiveMaterial);
+                createPrimitive("box", new pc.Vec3(400, 200, 50), new pc.Vec3(20, 400, 20), emissiveMaterial);
+                createPrimitive("box", new pc.Vec3(-400, 200, 50), new pc.Vec3(20, 400, 20), emissiveMaterial);
+                createPrimitive("box", new pc.Vec3(-400, 200, -50), new pc.Vec3(20, 400, 20), emissiveMaterial);
+                createPrimitive("box", new pc.Vec3(0, 400, 50), new pc.Vec3(800, 20, 20), emissiveMaterial);
+                createPrimitive("box", new pc.Vec3(0, 400, -50), new pc.Vec3(800, 20, 20), emissiveMaterial);
+
+                // screen
+                createPrimitive("box", new pc.Vec3(0, 200, 400), new pc.Vec3(500, 250, 5), screenMaterial);
+
+                // batmobile
+                const batmobileEntity: pc.Entity = assets.batmobile.resource.instantiateRenderEntity({
+                    castShadows: false,
+                    receiveShadows: false
+                });
+                batmobileEntity.setLocalScale(100, 100, 100);
+                batmobileEntity.rotateLocal(0, 0, 90);
+                app.root.addChild(batmobileEntity);
+
+                // apply shiny material to it
+                const renders: Array<pc.RenderComponent> = batmobileEntity.findComponents('render') as Array<pc.RenderComponent>;
+                renders.forEach((render) => {
+                    for (let i = 0; i < render.meshInstances.length; i++) {
+                        const meshInstance = render.meshInstances[i];
+                        meshInstance.material = sphereMaterial;
+                    }
+                });
+
+                // create an omni light white orbits the room to avoid it being completely dark
+                const lightOmni = new pc.Entity();
+                lightOmni.addComponent("light", {
+                    type: "omni",
+                    layers: [excludedLayer.id], // add it to excluded layer, we don't want the light captured in the reflection
+                    castShadows: false,
+                    color: pc.Color.WHITE,
+                    intensity: 0.2,
+                    range: 1000
+                });
+
+                // add a white sphere to light so that we can see where it is. This sphere is excluded from the reflections.
+                lightOmni.addComponent("render", {
+                    type: "sphere",
+                    layers: [excludedLayer.id],
+                    material: lightMaterial,
+                    castShadows: false,
+                    receiveShadows: false
+                });
+                lightOmni.setLocalScale(20, 20, 20);
+                app.root.addChild(lightOmni);
+
+                // create an Entity with a camera component
+                const camera = new pc.Entity();
+                camera.addComponent("camera", {
+                    fov: 100,
+                    layers: [worldLayer.id, excludedLayer.id],
+                    farClip: 1500
+                });
+                camera.setLocalPosition(270, 90, -260);
+
+                // add orbit camera script with a mouse and a touch support
+                camera.addComponent("script");
+                camera.script.create("orbitCamera", {
+                    attributes: {
+                        inertiaFactor: 0.2,
+                        distanceMax: 390,
+                        frameOnStart: false
+                    }
+                });
+                camera.script.create("orbitCameraInputMouse");
+                camera.script.create("orbitCameraInputTouch");
+                app.root.addChild(camera);
+
+                // create a probe object with cubemapRenderer script which takes care of rendering dynamic cubemap
+                const probe = new pc.Entity();
+                probe.addComponent('script');
+
+                // add camera component to the probe - this defines camera properties for cubemap rendering
+                probe.addComponent('camera', {
+
+                    // optimization - no need to clear as all pixels get overwritten
+                    clearColorBuffer: false,
+
+                    // priority - render before world camera
+                    priority: -1,
+
+                    // only render meshes on the worldLayer (and not excluded layer)
+                    layers: [worldLayer.id],
+
+                    // disable as this is not a camera that renders cube map but only a container for properties for cube map rendering
+                    enabled: false,
+
+                    nearClip: 1,
+                    farClip: 500
+                });
+
+                // Add a cubemap renderer script, which renders to a cubemap of size 128 with mipmaps, which is directly useable
+                // as a lighting source for envAtlas generation
+                // Position it in the center of the room.
+                probe.script.create('cubemapRenderer', {
+                    attributes: {
+                        resolution: 128,
+                        mipmaps: true,
+                        depth: true
+                    }
+                });
+                probe.setPosition(0, 200, 0);
+                app.root.addChild(probe);
+
+                // handle onCubemapPostRender event fired by the cubemapRenderer when all faces of the cubemap are done rendering
+                probe.on('onCubemapPostRender', () => {
+
+                    // prefilter just rendered cubemap into envAtlas, so that it can be used for reflection during the rest of the frame
+                    // @ts-ignore
+                    pc.EnvLighting.generateAtlas(probe.script.cubemapRenderer.cubeMap, {
+                        target: envAtlas
+                    });
+                });
+
+                // Set an update function on the app's update event
+                let time = 0;
+                let updateProbeCount = 1;
+                let updateVideo = true;
+                app.on("update", function (dt: number) {
+                    time += dt * 0.3;
+
+                    // Update the video data to the texture every other frame
+                    if (updateVideo && videoTexture) {
+                        videoTexture.upload();
+                    }
+                    updateVideo = !updateVideo;
+
+                    // move the light around
+                    lightOmni.setLocalPosition(300 * Math.sin(time), 300, 300 * Math.cos(time));
+
+                    // update the reflection probe as needed
+                    const updateFrequency = data.get('settings.updateFrequency');
+                    updateProbeCount--;
+                    if (updateFrequency === 0)
+                        updateProbeCount = 1;
+
+                    if (updateProbeCount <= 0) {
+                        // enable probe rendering
+                        probe.enabled = true;
+                        updateProbeCount = updateFrequency;
+                    } else {
+                        probe.enabled = false;
+                    }
+
+                    // update material properties based on settings
+                    const shininess = data.get('settings.shininess');
+                    const metalness = data.get('settings.metalness');
+                    const bumpiness = data.get('settings.bumpiness');
+                    const reflectivity = data.get('settings.reflectivity');
+
+                    roomMaterial.shininess = shininess;
+                    roomMaterial.metalness = metalness;
+                    roomMaterial.bumpiness = bumpiness;
+                    roomMaterial.reflectivity = reflectivity;
+                    roomMaterial.update();
+
+                    sphereMaterial.shininess = shininess;
+                    sphereMaterial.metalness = metalness;
+                    sphereMaterial.bumpiness = bumpiness;
+                    sphereMaterial.reflectivity = reflectivity;
+                    sphereMaterial.update();
+                });
             });
         });
     }

--- a/examples/src/examples/graphics/material-basic.tsx
+++ b/examples/src/examples/graphics/material-basic.tsx
@@ -6,113 +6,135 @@ class MaterialBasicExample {
 
     example(canvas: HTMLCanvasElement): void {
 
-        // Create the application and start the update loop
-        const app = new pc.Application(canvas, {});
-
         const assets = {
             'font': new pc.Asset('font', 'font', { url: '/static/assets/fonts/arial.json' }),
             'rocks': new pc.Asset("rocks", "texture", { url: "/static/assets/textures/seaside-rocks01-diffuse-alpha.png" })
         };
 
-        const assetListLoader = new pc.AssetListLoader(Object.values(assets), app.assets);
-        assetListLoader.load(() => {
-            app.start();
+        pc.createGraphicsDevice(canvas).then((device: pc.GraphicsDevice) => {
+
+            const createOptions = new pc.AppOptions();
+            createOptions.graphicsDevice = device;
+
+            createOptions.componentSystems = [
+                // @ts-ignore
+                pc.RenderComponentSystem,
+                // @ts-ignore
+                pc.CameraComponentSystem,
+                // @ts-ignore
+                pc.ElementComponentSystem
+            ];
+            createOptions.resourceHandlers = [
+                // @ts-ignore
+                pc.TextureHandler,
+                // @ts-ignore
+                pc.FontHandler
+            ];
+
+            const app = new pc.AppBase(canvas);
+            app.init(createOptions);
 
             // Set the canvas to fill the window and automatically change resolution to be the same as the canvas size
             app.setCanvasFillMode(pc.FILLMODE_FILL_WINDOW);
             app.setCanvasResolution(pc.RESOLUTION_AUTO);
 
-            // Create an entity with a camera component
-            const camera = new pc.Entity();
-            camera.addComponent("camera", {
-                clearColor: new pc.Color(0.1, 0.1, 0.1, 1)
-            });
-            camera.translate(2, 1, 8);
-            camera.lookAt(new pc.Vec3(0, -0.3, 0));
-            app.root.addChild(camera);
+            const assetListLoader = new pc.AssetListLoader(Object.values(assets), app.assets);
+            assetListLoader.load(() => {
 
-            const NUM_BOXES = 5;
+                app.start();
 
-            // alpha blend modes for individual rows
-            const blendModes = [
-                pc.BLEND_ADDITIVE,
-                pc.BLEND_SUBTRACTIVE,
-                pc.BLEND_SCREEN,
-                pc.BLEND_NORMAL,
-                pc.BLEND_NONE
-            ];
-
-            const createPrimitive = function (x: number, y: number, z: number) : pc.Entity {
-
-                // a basic material, which does not have support for lighting
-                const material = new pc.BasicMaterial();
-
-                // diffuse color
-                material.color.set(x, y, 1 - y);
-
-                // diffuse texture with alpha channel for transparency
-                material.colorMap = assets.rocks.resource;
-
-                // disable culling to see back faces as well
-                material.cull = pc.CULLFACE_NONE;
-
-                // set up alpha test value
-                material.alphaTest = x / NUM_BOXES - 0.1;
-
-                // alpha blend mode
-                material.blendType = blendModes[y];
-
-                const box = new pc.Entity();
-                box.addComponent("render", {
-                    material: material,
-                    type: "box",
-
-                    // Note: basic material cannot currently cast shadows, disable it
-                    castShadows: false
+                // Create an entity with a camera component
+                const camera = new pc.Entity();
+                camera.addComponent("camera", {
+                    clearColor: new pc.Color(0.1, 0.1, 0.1, 1)
                 });
-                box.setLocalPosition(x - (NUM_BOXES - 1) * 0.5, y - (NUM_BOXES - 1) * 0.5, z);
-                box.setLocalScale(0.7, 0.7, 0.7);
-                app.root.addChild(box);
+                camera.translate(2, 1, 8);
+                camera.lookAt(new pc.Vec3(0, -0.3, 0));
+                app.root.addChild(camera);
 
-                return box;
-            };
+                const NUM_BOXES = 5;
 
-            const boxes: Array<pc.Entity> = [];
-            for (let i = 0; i < NUM_BOXES; i++) {
-                for (let j = 0; j < NUM_BOXES; j++) {
-                    boxes.push(createPrimitive(j, i, 0));
+                // alpha blend modes for individual rows
+                const blendModes = [
+                    pc.BLEND_ADDITIVE,
+                    pc.BLEND_SUBTRACTIVE,
+                    pc.BLEND_SCREEN,
+                    pc.BLEND_NORMAL,
+                    pc.BLEND_NONE
+                ];
+
+                const createPrimitive = function (x: number, y: number, z: number) : pc.Entity {
+
+                    // a basic material, which does not have support for lighting
+                    const material = new pc.BasicMaterial();
+
+                    // diffuse color
+                    material.color.set(x, y, 1 - y);
+
+                    // diffuse texture with alpha channel for transparency
+                    material.colorMap = assets.rocks.resource;
+
+                    // disable culling to see back faces as well
+                    material.cull = pc.CULLFACE_NONE;
+
+                    // set up alpha test value
+                    material.alphaTest = x / NUM_BOXES - 0.1;
+
+                    // alpha blend mode
+                    material.blendType = blendModes[y];
+
+                    const box = new pc.Entity();
+                    box.addComponent("render", {
+                        material: material,
+                        type: "box",
+
+                        // Note: basic material cannot currently cast shadows, disable it
+                        castShadows: false
+                    });
+                    box.setLocalPosition(x - (NUM_BOXES - 1) * 0.5, y - (NUM_BOXES - 1) * 0.5, z);
+                    box.setLocalScale(0.7, 0.7, 0.7);
+                    app.root.addChild(box);
+
+                    return box;
+                };
+
+                const boxes: Array<pc.Entity> = [];
+                for (let i = 0; i < NUM_BOXES; i++) {
+                    for (let j = 0; j < NUM_BOXES; j++) {
+                        boxes.push(createPrimitive(j, i, 0));
+                    }
                 }
-            }
 
-            const createText = function (fontAsset: pc.Asset, message: string, x: number, y: number, z: number, rot: number) {
-                // Create a text element-based entity
-                const text = new pc.Entity();
-                text.addComponent("element", {
-                    anchor: [0.5, 0.5, 0.5, 0.5],
-                    fontAsset: fontAsset,
-                    fontSize: 0.5,
-                    pivot: [0.5, 0.5],
-                    text: message,
-                    type: pc.ELEMENTTYPE_TEXT
-                });
-                text.setLocalPosition(x, y, z);
-                text.setLocalEulerAngles(0, 0, rot);
-                app.root.addChild(text);
-            };
+                const createText = function (fontAsset: pc.Asset, message: string, x: number, y: number, z: number, rot: number) {
+                    // Create a text element-based entity
+                    const text = new pc.Entity();
+                    text.addComponent("element", {
+                        anchor: [0.5, 0.5, 0.5, 0.5],
+                        fontAsset: fontAsset,
+                        fontSize: 0.5,
+                        pivot: [0.5, 0.5],
+                        text: message,
+                        type: pc.ELEMENTTYPE_TEXT
+                    });
+                    text.setLocalPosition(x, y, z);
+                    text.setLocalEulerAngles(0, 0, rot);
+                    app.root.addChild(text);
+                };
 
-            createText(assets.font, 'Alpha Test', 0, -(NUM_BOXES + 1) * 0.5, 0, 0);
-            createText(assets.font, 'Alpha Blend', -(NUM_BOXES + 1) * 0.5, 0, 0, 90);
+                createText(assets.font, 'Alpha Test', 0, -(NUM_BOXES + 1) * 0.5, 0, 0);
+                createText(assets.font, 'Alpha Blend', -(NUM_BOXES + 1) * 0.5, 0, 0, 90);
 
-            // Set an update function on the app's update event
-            let time = 0;
-            const rot = new pc.Quat();
-            app.on("update", function (dt: number) {
-                time += dt;
+                // Set an update function on the app's update event
+                let time = 0;
+                const rot = new pc.Quat();
+                app.on("update", function (dt: number) {
+                    time += dt;
 
-                // rotate the boxes
-                rot.setFromEulerAngles(20 * time, 30 * time, 0);
-                boxes.forEach((box) => {
-                    box.setRotation(rot);
+                    // rotate the boxes
+                    rot.setFromEulerAngles(20 * time, 30 * time, 0);
+                    boxes.forEach((box) => {
+                        box.setRotation(rot);
+                    });
                 });
             });
         });

--- a/examples/src/examples/graphics/render-cubemap.tsx
+++ b/examples/src/examples/graphics/render-cubemap.tsx
@@ -212,6 +212,9 @@ class RenderCubemapExample {
                 const textureOcta = createReprojectionTexture(pc.TEXTUREPROJECTION_OCTAHEDRAL, 64);
                 const textureOcta2 = createReprojectionTexture(pc.TEXTUREPROJECTION_OCTAHEDRAL, 32);
 
+                // create one envAtlas texture
+                const textureAtlas = createReprojectionTexture(pc.TEXTUREPROJECTION_OCTAHEDRAL, 512);
+
                 // update things each frame
                 let time = 0;
                 app.on("update", function (dt) {
@@ -262,6 +265,13 @@ class RenderCubemapExample {
                     });
                     // @ts-ignore engine-tsd
                     app.drawTexture(0.6, -0.7, 0.6, 0.3, textureEqui2);
+
+                    // cube -> envAtlas
+                    pc.EnvLighting.generateAtlas(srcCube, {
+                        target: textureAtlas
+                    });
+                    // @ts-ignore engine-tsd
+                    app.drawTexture(0, -0.7, 0.5, 0.4, textureAtlas);
                 });
             });
         });

--- a/src/platform/graphics/bind-group.js
+++ b/src/platform/graphics/bind-group.js
@@ -60,7 +60,7 @@ class BindGroup {
      */
     setUniformBuffer(name, uniformBuffer) {
         const index = this.format.bufferFormatsMap.get(name);
-        Debug.assert(index !== undefined, `Setting a uniform [${name}] on a bind group with id ${this.id} which does not contain in, while rendering [${DebugGraphics.toString()}]`);
+        Debug.assert(index !== undefined, `Setting a uniform [${name}] on a bind group with id ${this.id} which does not contain in, while rendering [${DebugGraphics.toString()}]`, this);
         if (this.uniformBuffers[index] !== uniformBuffer) {
             this.uniformBuffers[index] = uniformBuffer;
             this.dirty = true;
@@ -75,7 +75,7 @@ class BindGroup {
      */
     setTexture(name, texture) {
         const index = this.format.textureFormatsMap.get(name);
-        Debug.assert(index !== undefined, `Setting a texture [${name}] on a bind group with id: ${this.id} which does not contain in, while rendering [${DebugGraphics.toString()}]`);
+        Debug.assert(index !== undefined, `Setting a texture [${name}] on a bind group with id: ${this.id} which does not contain in, while rendering [${DebugGraphics.toString()}]`, this);
         if (this.textures[index] !== texture) {
             this.textures[index] = texture;
             this.dirty = true;
@@ -91,7 +91,7 @@ class BindGroup {
         for (let i = 0; i < textureFormats.length; i++) {
             const textureFormat = textureFormats[i];
             const value = textureFormat.scopeId.value;
-            Debug.assert(value, `Value was not set when assigning texture slot [${textureFormat.name}] to a bind group, while rendering [${DebugGraphics.toString()}]`);
+            Debug.assert(value, `Value was not set when assigning texture slot [${textureFormat.name}] to a bind group, while rendering [${DebugGraphics.toString()}]`, this);
             this.setTexture(textureFormat.name, value);
         }
 

--- a/src/platform/graphics/shader-chunks/frag/webgpu.js
+++ b/src/platform/graphics/shader-chunks/frag/webgpu.js
@@ -10,12 +10,12 @@ layout(location = 0) out highp vec4 pc_fragColor;
 #define texture2DBias(res, uv, bias) texture(sampler2D(res, res ## _sampler), uv, bias)
 #define texture2DLodEXT(res, uv, lod) textureLod(sampler2D(res, res ## _sampler), uv, lod)
 #define textureCube(res, uv) texture(samplerCube(res, res ## _sampler), uv)
+#define textureCubeLodEXT(res, uv, lod) textureLod(samplerCube(res, res ## _sampler), uv, lod)
 #define textureShadow(res, uv) texture(sampler2DShadow(res, res ## _sampler), uv)
 
 // TODO: implement other texture sampling macros
 // #define texture2DProj textureProj
 // #define texture2DProjLodEXT textureProjLod
-// #define textureCubeLodEXT textureLod
 // #define texture2DGradEXT textureGrad
 // #define texture2DProjGradEXT textureProjGrad
 // #define textureCubeGradEXT textureGrad

--- a/src/platform/graphics/shader-processor.js
+++ b/src/platform/graphics/shader-processor.js
@@ -52,6 +52,10 @@ class UniformLine {
         // type
         this.type = words.shift();
 
+        if (line.includes(',')) {
+            Debug.error(`A comma on a uniform line is not supported, split it into multiple uniforms: ${line}`, shader);
+        }
+
         // array of uniforms
         if (line.includes('[')) {
 

--- a/src/scene/shader-lib/chunks/lit/frag/cubeMapProjectBox.js
+++ b/src/scene/shader-lib/chunks/lit/frag/cubeMapProjectBox.js
@@ -1,5 +1,6 @@
 export default /* glsl */`
-uniform vec3 envBoxMin, envBoxMax;
+uniform vec3 envBoxMin;
+uniform vec3 envBoxMax;
 
 vec3 cubeMapProject(vec3 nrdir) {
     nrdir = cubeMapRotate(nrdir);


### PR DESCRIPTION
- updated reprojection shader to avoid unused uniforms, those are now included using defines only when needed
- updated few examples to use pc.createGraphicsDevice
- added envAtlas projection to cubemap rendering example
- disabled unsupported movie texture on WebGPU in box-reflection example
- small WebGPU changes to get it all to work

Mipmaps are not supported on WebGPU yet, so quality of some projections is not there yet. Also, some of them are upside down, which will be fixed in a separate PR

Screenshots from WebGPU:
![Screenshot 2023-02-01 at 10 51 19](https://user-images.githubusercontent.com/59932779/216026804-862f1f13-0f00-4ffb-a81d-974efd2c07ef.png)
![Screenshot 2023-02-01 at 10 50 53](https://user-images.githubusercontent.com/59932779/216026816-8835b32d-aa47-40db-b1fd-e7a372a4a9d3.png)
