### PR TITLE
Added AnimCurve and AnimData back to API Docs

### DIFF
--- a/src/framework/anim/evaluator/anim-curve.js
+++ b/src/framework/anim/evaluator/anim-curve.js
@@ -1,8 +1,6 @@
 /**
  * Animation curve links an input data set to an output data set and defines the interpolation
  * method to use.
- *
- * @ignore
  */
 class AnimCurve {
     /**

--- a/src/framework/anim/evaluator/anim-data.js
+++ b/src/framework/anim/evaluator/anim-data.js
@@ -1,7 +1,5 @@
 /**
  * Wraps a set of data used in animation.
- *
- * @ignore
  */
 class AnimData {
     /**


### PR DESCRIPTION
Fixes #4829 

Removed `@ignore` from `AnimCurve` and `AnimData` to fix missing links from [AnimTrack](https://developer.playcanvas.com/en/api/pc.AnimTrack.html)

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
