### PR TITLE
Improved shadow cascades for WebGPU

### DIFF
--- a/examples/src/examples/graphics/shadow-cascades.tsx
+++ b/examples/src/examples/graphics/shadow-cascades.tsx
@@ -8,7 +8,6 @@ class ShadowCascadesExample {
     static CATEGORY = 'Graphics';
     static NAME = 'Shadow Cascades';
 
-
     controls(data: Observer) {
         return <>
             <Panel headerText='Shadow Cascade Settings'>
@@ -42,177 +41,205 @@ class ShadowCascadesExample {
 
     example(canvas: HTMLCanvasElement, data: any): void {
 
-        const app = new pc.Application(canvas, {
-            mouse: new pc.Mouse(document.body),
-            touch: new pc.TouchDevice(document.body)
-        });
-
         const assets = {
             'script': new pc.Asset('script', 'script', { url: '/static/scripts/camera/orbit-camera.js' }),
             'terrain': new pc.Asset('terrain', 'container', { url: '/static/assets/models/terrain.glb' }),
-            'helipad': new pc.Asset('helipad', 'cubemap', { url: '/static/assets/cubemaps/helipad.dds' }, { type: pc.TEXTURETYPE_RGBM })
+            helipad: new pc.Asset('helipad-env-atlas', 'texture', { url: '/static/assets/cubemaps/helipad-env-atlas.png' }, { type: pc.TEXTURETYPE_RGBP })
         };
 
-        const assetListLoader = new pc.AssetListLoader(Object.values(assets), app.assets);
-        assetListLoader.load(() => {
-            app.start();
+        pc.createGraphicsDevice(canvas).then((device: pc.GraphicsDevice) => {
 
-            data.set('settings', {
-                light: {
-                    numCascades: 4,             // number of cascades
-                    shadowResolution: 2048,     // shadow map resolution storing 4 cascades
-                    cascadeDistribution: 0.5,   // distribution of cascade distances to prefer sharpness closer to the camera
-                    shadowType: pc.SHADOW_PCF3, // shadow filter type
-                    vsmBlurSize: 11,            // shader filter blur size for VSM shadows
-                    everyFrame: true            // true if all cascades update every frame
-                }
-            });
+            const createOptions = new pc.AppOptions();
+            createOptions.graphicsDevice = device;
+            createOptions.mouse = new pc.Mouse(document.body);
+            createOptions.touch = new pc.TouchDevice(document.body);
 
-            // Set the canvas to fill the window and automatically change resolution to be the same as the canvas size
-            app.setCanvasFillMode(pc.FILLMODE_FILL_WINDOW);
-            app.setCanvasResolution(pc.RESOLUTION_AUTO);
+            createOptions.componentSystems = [
+                // @ts-ignore
+                pc.RenderComponentSystem,
+                // @ts-ignore
+                pc.CameraComponentSystem,
+                // @ts-ignore
+                pc.LightComponentSystem,
+                // @ts-ignore
+                pc.ScriptComponentSystem
+            ];
+            createOptions.resourceHandlers = [
+                // @ts-ignore
+                pc.TextureHandler,
+                // @ts-ignore
+                pc.ContainerHandler,
+                // @ts-ignore
+                pc.ScriptHandler
+            ];
 
-            window.addEventListener("resize", function () {
-                app.resizeCanvas(canvas.width, canvas.height);
-            });
+            const app = new pc.AppBase(canvas);
+            app.init(createOptions);
 
-            // setup skydome
-            app.scene.skyboxMip = 3;
-            app.scene.setSkybox(assets.helipad.resources);
-            app.scene.skyboxRotation = new pc.Quat().setFromEulerAngles(0, -70, 0);
-            app.scene.toneMapping = pc.TONEMAP_ACES;
+            const assetListLoader = new pc.AssetListLoader(Object.values(assets), app.assets);
+            assetListLoader.load(() => {
 
-            // instantiate the terrain
-            const terrain = assets.terrain.resource.instantiateRenderEntity();
-            terrain.setLocalScale(30, 30, 30);
-            app.root.addChild(terrain);
+                app.start();
 
-            // get the clouds so that we can animate them
-            const srcClouds : Array<pc.Entity> = terrain.find((node: pc.GraphNode) => {
-
-                const isCloud = node.name.includes('Icosphere');
-
-                if (isCloud) {
-                    // no shadow receiving for clouds
-                    (node as pc.Entity).render.receiveShadows = false;
-                }
-
-                return isCloud;
-            });
-
-            // clone some additional clouds
-            const clouds : Array<pc.Entity> = [];
-            srcClouds.forEach((cloud) => {
-                clouds.push(cloud);
-
-                for (let i = 0; i < 3; i++) {
-                    const clone = cloud.clone() as pc.Entity;
-                    cloud.parent.addChild(clone);
-                    clouds.push(clone);
-                }
-            });
-
-            // shuffle the array to give clouds random order
-            clouds.sort(() => Math.random() - 0.5);
-
-            // find a tree in the middle to use as a focus point
-            const tree = terrain.findOne("name", "Arbol 2.002");
-
-            // create an Entity with a camera component
-            const camera = new pc.Entity();
-            camera.addComponent("camera", {
-                clearColor: new pc.Color(0.9, 0.9, 0.9),
-                farClip: 1000
-            });
-
-            // and position it in the world
-            camera.setLocalPosition(300, 160, 25);
-
-            // add orbit camera script with a mouse and a touch support
-            camera.addComponent("script");
-            camera.script.create("orbitCamera", {
-                attributes: {
-                    inertiaFactor: 0.2,
-                    focusEntity: tree,
-                    distanceMax: 600
-                }
-            });
-            camera.script.create("orbitCameraInputMouse");
-            camera.script.create("orbitCameraInputTouch");
-            app.root.addChild(camera);
-
-            // Create a directional light casting cascaded shadows
-            const dirLight = new pc.Entity();
-            dirLight.addComponent("light", {
-                ...{
-                    type: "directional",
-                    color: pc.Color.WHITE,
-                    shadowBias: 0.3,
-                    normalOffsetBias: 0.2,
-                    intensity: 1.0,
-
-                    // enable shadow casting
-                    castShadows: true,
-                    shadowDistance: 1000
-                },
-                ...data.get('settings.light')
-            });
-            app.root.addChild(dirLight);
-            dirLight.setLocalEulerAngles(45, 350, 20);
-
-            // update mode of cascades
-            let updateEveryFrame = true;
-
-            // handle HUD changes - update properties on the light
-            data.on('*:set', (path: string, value: any) => {
-                const pathArray = path.split('.');
-
-                if (pathArray[2] === 'everyFrame') {
-                    updateEveryFrame = value;
-                } else {
-                    // @ts-ignore
-                    dirLight.light[pathArray[2]] = value;
-                }
-            });
-
-            const cloudSpeed = 0.2;
-            let frameNumber = 0;
-            let time = 0;
-            app.on("update", function (dt: number) {
-
-                time += dt;
-
-                // on the first frame, when camera is updated, move it further away from the focus tree
-                if (frameNumber === 0) {
-                    // @ts-ignore engine-tsd
-                    camera.script.orbitCamera.distance = 470;
-                }
-
-                if (updateEveryFrame) {
-
-                    // no per cascade rendering control
-                    dirLight.light.shadowUpdateOverrides = null;
-
-                } else {
-
-                    // set up shadow update overrides, nearest cascade updates each frame, then next one every 5 and so on
-                    dirLight.light.shadowUpdateOverrides = [
-                        pc.SHADOWUPDATE_THISFRAME,
-                        (frameNumber % 5) === 0 ? pc.SHADOWUPDATE_THISFRAME : pc.SHADOWUPDATE_NONE,
-                        (frameNumber % 10) === 0 ? pc.SHADOWUPDATE_THISFRAME : pc.SHADOWUPDATE_NONE,
-                        (frameNumber % 15) === 0 ? pc.SHADOWUPDATE_THISFRAME : pc.SHADOWUPDATE_NONE
-                    ];
-                }
-
-                // move the clouds around
-                clouds.forEach((cloud, index: number) => {
-                    const redialOffset = (index / clouds.length) * (6.24 / cloudSpeed);
-                    const radius = 9 + 4 * Math.sin(redialOffset);
-                    const cloudTime = time + redialOffset;
-                    cloud.setLocalPosition(2 + radius * Math.sin(cloudTime * cloudSpeed), 4, -5 + radius * Math.cos(cloudTime * cloudSpeed));
+                data.set('settings', {
+                    light: {
+                        numCascades: 4,             // number of cascades
+                        shadowResolution: 2048,     // shadow map resolution storing 4 cascades
+                        cascadeDistribution: 0.5,   // distribution of cascade distances to prefer sharpness closer to the camera
+                        shadowType: pc.SHADOW_PCF3, // shadow filter type
+                        vsmBlurSize: 11,            // shader filter blur size for VSM shadows
+                        everyFrame: true            // true if all cascades update every frame
+                    }
                 });
 
-                frameNumber++;
+                // Set the canvas to fill the window and automatically change resolution to be the same as the canvas size
+                app.setCanvasFillMode(pc.FILLMODE_FILL_WINDOW);
+                app.setCanvasResolution(pc.RESOLUTION_AUTO);
+
+                window.addEventListener("resize", function () {
+                    app.resizeCanvas(canvas.width, canvas.height);
+                });
+
+                // setup skydome
+                app.scene.skyboxMip = 3;
+                app.scene.envAtlas = assets.helipad.resource;
+                app.scene.skyboxRotation = new pc.Quat().setFromEulerAngles(0, -70, 0);
+                app.scene.toneMapping = pc.TONEMAP_ACES;
+
+                // instantiate the terrain
+                const terrain: pc.Entity = assets.terrain.resource.instantiateRenderEntity();
+                terrain.setLocalScale(30, 30, 30);
+                app.root.addChild(terrain);
+
+                // get the clouds so that we can animate them
+                // @ts-ignore
+                const srcClouds : Array<pc.Entity> = terrain.find((node: pc.GraphNode) => {
+
+                    const isCloud = node.name.includes('Icosphere');
+
+                    if (isCloud) {
+                        // no shadow receiving for clouds
+                        (node as pc.Entity).render.receiveShadows = false;
+                    }
+
+                    return isCloud;
+                });
+
+                // clone some additional clouds
+                const clouds : Array<pc.Entity> = [];
+                srcClouds.forEach((cloud) => {
+                    clouds.push(cloud);
+
+                    for (let i = 0; i < 3; i++) {
+                        const clone = cloud.clone() as pc.Entity;
+                        cloud.parent.addChild(clone);
+                        clouds.push(clone);
+                    }
+                });
+
+                // shuffle the array to give clouds random order
+                clouds.sort(() => Math.random() - 0.5);
+
+                // find a tree in the middle to use as a focus point
+                // @ts-ignore
+                const tree = terrain.findOne("name", "Arbol 2.002");
+
+                // create an Entity with a camera component
+                const camera = new pc.Entity();
+                camera.addComponent("camera", {
+                    clearColor: new pc.Color(0.9, 0.9, 0.9),
+                    farClip: 1000
+                });
+
+                // and position it in the world
+                camera.setLocalPosition(300, 160, 25);
+
+                // add orbit camera script with a mouse and a touch support
+                camera.addComponent("script");
+                camera.script.create("orbitCamera", {
+                    attributes: {
+                        inertiaFactor: 0.2,
+                        focusEntity: tree,
+                        distanceMax: 600
+                    }
+                });
+                camera.script.create("orbitCameraInputMouse");
+                camera.script.create("orbitCameraInputTouch");
+                app.root.addChild(camera);
+
+                // Create a directional light casting cascaded shadows
+                const dirLight = new pc.Entity();
+                dirLight.addComponent("light", {
+                    ...{
+                        type: "directional",
+                        color: pc.Color.WHITE,
+                        shadowBias: 0.3,
+                        normalOffsetBias: 0.2,
+                        intensity: 1.0,
+
+                        // enable shadow casting
+                        castShadows: true,
+                        shadowDistance: 1000
+                    },
+                    ...data.get('settings.light')
+                });
+                app.root.addChild(dirLight);
+                dirLight.setLocalEulerAngles(45, 350, 20);
+
+                // update mode of cascades
+                let updateEveryFrame = true;
+
+                // handle HUD changes - update properties on the light
+                data.on('*:set', (path: string, value: any) => {
+                    const pathArray = path.split('.');
+
+                    if (pathArray[2] === 'everyFrame') {
+                        updateEveryFrame = value;
+                    } else {
+                        // @ts-ignore
+                        dirLight.light[pathArray[2]] = value;
+                    }
+                });
+
+                const cloudSpeed = 0.2;
+                let frameNumber = 0;
+                let time = 0;
+                app.on("update", function (dt: number) {
+
+                    time += dt;
+
+                    // on the first frame, when camera is updated, move it further away from the focus tree
+                    if (frameNumber === 0) {
+                        // @ts-ignore engine-tsd
+                        camera.script.orbitCamera.distance = 470;
+                    }
+
+                    if (updateEveryFrame) {
+
+                        // no per cascade rendering control
+                        dirLight.light.shadowUpdateOverrides = null;
+
+                    } else {
+
+                        // set up shadow update overrides, nearest cascade updates each frame, then next one every 5 and so on
+                        dirLight.light.shadowUpdateOverrides = [
+                            pc.SHADOWUPDATE_THISFRAME,
+                            (frameNumber % 5) === 0 ? pc.SHADOWUPDATE_THISFRAME : pc.SHADOWUPDATE_NONE,
+                            (frameNumber % 10) === 0 ? pc.SHADOWUPDATE_THISFRAME : pc.SHADOWUPDATE_NONE,
+                            (frameNumber % 15) === 0 ? pc.SHADOWUPDATE_THISFRAME : pc.SHADOWUPDATE_NONE
+                        ];
+                    }
+
+                    // move the clouds around
+                    clouds.forEach((cloud, index: number) => {
+                        const redialOffset = (index / clouds.length) * (6.24 / cloudSpeed);
+                        const radius = 9 + 4 * Math.sin(redialOffset);
+                        const cloudTime = time + redialOffset;
+                        cloud.setLocalPosition(2 + radius * Math.sin(cloudTime * cloudSpeed), 4, -5 + radius * Math.cos(cloudTime * cloudSpeed));
+                    });
+
+                    frameNumber++;
+                });
             });
         });
     }

--- a/src/platform/graphics/constants.js
+++ b/src/platform/graphics/constants.js
@@ -1129,6 +1129,7 @@ export const UNIFORMTYPE_TEXTURE3D = 20;
 export const UNIFORMTYPE_VEC2ARRAY = 21;
 export const UNIFORMTYPE_VEC3ARRAY = 22;
 export const UNIFORMTYPE_VEC4ARRAY = 23;
+export const UNIFORMTYPE_MAT4ARRAY = 24;
 
 export const uniformTypeToName = [
     'bool',

--- a/src/platform/graphics/uniform-buffer-format.js
+++ b/src/platform/graphics/uniform-buffer-format.js
@@ -5,7 +5,8 @@ import {
     UNIFORMTYPE_BOOL, UNIFORMTYPE_INT, UNIFORMTYPE_FLOAT, UNIFORMTYPE_VEC2, UNIFORMTYPE_VEC3,
     UNIFORMTYPE_VEC4, UNIFORMTYPE_IVEC2, UNIFORMTYPE_IVEC3, UNIFORMTYPE_IVEC4, UNIFORMTYPE_BVEC2,
     UNIFORMTYPE_BVEC3, UNIFORMTYPE_BVEC4, UNIFORMTYPE_MAT4, UNIFORMTYPE_MAT2, UNIFORMTYPE_MAT3,
-    UNIFORMTYPE_FLOATARRAY, UNIFORMTYPE_VEC2ARRAY, UNIFORMTYPE_VEC3ARRAY, UNIFORMTYPE_VEC4ARRAY
+    UNIFORMTYPE_FLOATARRAY, UNIFORMTYPE_VEC2ARRAY, UNIFORMTYPE_VEC3ARRAY, UNIFORMTYPE_VEC4ARRAY,
+    UNIFORMTYPE_MAT4ARRAY
 } from './constants.js';
 
 // map of UNIFORMTYPE_*** to number of 32bit elements
@@ -77,6 +78,8 @@ class UniformFormat {
                 case UNIFORMTYPE_VEC2: this.updateType = UNIFORMTYPE_VEC2ARRAY; break;
                 case UNIFORMTYPE_VEC3: this.updateType = UNIFORMTYPE_VEC3ARRAY; break;
                 case UNIFORMTYPE_VEC4: this.updateType = UNIFORMTYPE_VEC4ARRAY; break;
+                case UNIFORMTYPE_MAT4: this.updateType = UNIFORMTYPE_MAT4ARRAY; break;
+
                 default:
                     Debug.error(`Uniform array of type ${uniformTypeToName[type]} is not supported when processing uniform '${name}'.`);
                     Debug.call(() => {

--- a/src/scene/shader-lib/programs/lit-shader.js
+++ b/src/scene/shader-lib/programs/lit-shader.js
@@ -179,10 +179,9 @@ class LitShader {
         // shadow coordinate generation
         code += coordsFunctionName + shadowCoordArgs;
 
-        if (this.device.deviceType !== DEVICETYPE_WEBGPU) {
-            // stop shadow at the far distance
-            code += `fadeShadow(light${lightIndex}_shadowCascadeDistances);\n`;
-        }
+        // stop shadow at the far distance
+        code += `fadeShadow(light${lightIndex}_shadowCascadeDistances);\n`;
+
         return code;
     }
 
@@ -656,13 +655,8 @@ class LitShader {
 
                 // directional (cascaded) shadows
                 if (lightType === LIGHTTYPE_DIRECTIONAL) {
-
-                    // TODO: add support for shadow cascades to WebGPU
-                    if (device.deviceType !== DEVICETYPE_WEBGPU) {
-                        code += "uniform mat4 light" + i + "_shadowMatrixPalette[4];\n";
-                        code += "uniform float light" + i + "_shadowCascadeDistances[4];\n";
-                    }
-
+                    code += "uniform mat4 light" + i + "_shadowMatrixPalette[4];\n";
+                    code += "uniform float light" + i + "_shadowCascadeDistances[4];\n";
                     code += "uniform float light" + i + "_shadowCascadeCount;\n";
                 }
 


### PR DESCRIPTION
- the example is almost working, just need some small fixes at a later stage, related to shadow cascades being upside down or similar.
- converted the example to use createGraphicsDevice
- enabled shadow cascades in lit shader now that WebGPU handles uniform arrays