### PR TITLE
Include WebGPU support in all built targets

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -74,9 +74,7 @@ export { VertexIterator } from './platform/graphics/vertex-iterator.js';
 export { WebglGraphicsDevice } from './platform/graphics/webgl/webgl-graphics-device.js';
 
 // PLATFORM / GRAPHICS / webgpu
-// #if _DEBUG
 export { WebgpuGraphicsDevice } from './platform/graphics/webgpu/webgpu-graphics-device.js';
-// #endif
 
 // PLATFORM / INPUT
 export * from './platform/input/constants.js';

--- a/src/platform/graphics/graphics-device-create.js
+++ b/src/platform/graphics/graphics-device-create.js
@@ -1,9 +1,6 @@
 import { Debug } from '../../core/debug.js';
 
-// #if _DEBUG
 import { WebgpuGraphicsDevice } from './webgpu/webgpu-graphics-device.js';
-// #endif
-
 import { DEVICETYPE_WEBGL, DEVICETYPE_WEBGPU } from './constants.js';
 import { WebglGraphicsDevice } from './webgl/webgl-graphics-device.js';
 
@@ -27,12 +24,10 @@ function createGraphicsDevice(canvas, options = {}) {
     for (let i = 0; i < options.deviceTypes.length; i++) {
         const deviceType = options.deviceTypes[i];
 
-        // #if _DEBUG
         if (deviceType === DEVICETYPE_WEBGPU && window?.navigator?.gpu) {
             device = new WebgpuGraphicsDevice(canvas, options);
             return device.initWebGpu(options.glslangUrl, options.twgslUrl);
         }
-        // #endif
 
         if (deviceType === DEVICETYPE_WEBGL) {
             device = new WebglGraphicsDevice(canvas, options);


### PR DESCRIPTION
- till now, WebGPU support was only included with the debug build of the engine
- from now, it's part of all builds
- not that this has no impact on module based engine, as it's up to the users to import it or not, this is ES5 change only.
- the difference in size for a zipped up minified version of the engine is 9kb
- this still does not make WebGPU version to be used automatically in any way, and users need to use pc.createGraphicsDevice api and request WebGPU, so this has no impact on any current projects.

size without WebGPU
<img width="535" alt="webgl only" src="https://user-images.githubusercontent.com/59932779/216356544-1e8da8e7-7b7a-42c3-b1d9-b5ef9ca8bff5.png">

size with WebGPU
<img width="532" alt="webgk + webgpu" src="https://user-images.githubusercontent.com/59932779/216356588-b5f6bb2c-3211-49b5-b890-e967fda3a1b5.png">

