### PR TITLE
Fix warnings from Typedoc build

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "watch:es6": "npm run build:es6 -- -w",
     "watch:profiler": "npm run build:profiler -- -w",
     "docs": "jsdoc -c conf-api.json",
-    "typedocs": "typedoc --entryPoints ./src/index.js --excludeNotDocumented --out typedocs",
+    "typedocs": "typedoc --entryPoints ./src/index.js --excludeNotDocumented --name \"PlayCanvas Engine API\" --out typedocs",
     "lint": "eslint --ext .js,.mjs extras scripts src test rollup.config.mjs",
     "serve": "serve build -l 51000",
     "test": "mocha --recursive --require test/fixtures.mjs",

--- a/src/core/string.js
+++ b/src/core/string.js
@@ -124,7 +124,7 @@ const string = {
     ASCII_LETTERS: ASCII_LETTERS,
 
     /**
-     * Return a string with {n} replaced with the n-th argument.
+     * Return a string with \{n\} replaced with the n-th argument.
      *
      * @param {string} s - The string to format.
      * @param {object} [arguments] - All other arguments are substituted into the string.

--- a/src/framework/asset/asset-list-loader.js
+++ b/src/framework/asset/asset-list-loader.js
@@ -5,20 +5,22 @@ import { Asset } from './asset.js';
 /**
  * Used to load a group of assets and fires a callback when all assets are loaded.
  *
+ * ```javascript
+ * const assets = [
+ *     new Asset('model', 'container', { url: `http://example.com/asset.glb` }),
+ *     new Asset('styling', 'css', { url: `http://example.com/asset.css` })
+ * ];
+ * const assetListLoader = new AssetListLoader(assets, app.assets);
+ * assetListLoader.load((err, failed) => {
+ *     if (err) {
+ *         console.error(`${failed.length} assets failed to load`);
+ *     } else {
+ *         console.log(`${assets.length} assets loaded`);
+ *    }
+ * });
+ * ```
+ *
  * @augments EventHandler
- * @example
- *  const assets = [
- *      new Asset('model', 'container', { url: `http://example.com/asset.glb` }),
- *      new Asset('styling', 'css', { url: `http://example.com/asset.css` })
- *  ];
- *  const assetListLoader = new AssetListLoader(assets, app.assets);
- *  assetListLoader.load((err, failed) => {
- *      if (err) {
- *          console.error(`${failed.length} assets failed to load`);
- *      } else {
- *          console.log(`${assets.length} assets loaded`);
- *     }
- *  });
  */
 class AssetListLoader extends EventHandler {
     /**

--- a/src/framework/components/light/component.js
+++ b/src/framework/components/light/component.js
@@ -57,10 +57,10 @@ const _lightPropsDefault = [];
  * @property {number} luminance The physically based luminance. Only used if scene.physicalUnits is true. Defaults to 0.
  * @property {number} shape The light source shape. Can be:
  *
- * - {@link pc.LIGHTSHAPE_PUNCTUAL}: Infinitesimally small point.
- * - {@link pc.LIGHTSHAPE_RECT}: Rectangle shape.
- * - {@link pc.LIGHTSHAPE_DISK}: Disk shape.
- * - {@link pc.LIGHTSHAPE_SPHERE}: Sphere shape.
+ * - {@link LIGHTSHAPE_PUNCTUAL}: Infinitesimally small point.
+ * - {@link LIGHTSHAPE_RECT}: Rectangle shape.
+ * - {@link LIGHTSHAPE_DISK}: Disk shape.
+ * - {@link LIGHTSHAPE_SPHERE}: Sphere shape.
  *
  * Defaults to pc.LIGHTSHAPE_PUNCTUAL.
  * @property {boolean} castShadows If enabled the light will cast shadows. Defaults to false.

--- a/src/framework/entity.js
+++ b/src/framework/entity.js
@@ -60,7 +60,7 @@ class Entity extends GraphNode {
     button;
 
     /**
-     * Gets the {@link CameraComponent}} attached to this entity.
+     * Gets the {@link CameraComponent} attached to this entity.
      *
      * @type {import('./components/camera/component.js').CameraComponent|undefined}
      * @readonly

--- a/src/framework/script/script.js
+++ b/src/framework/script/script.js
@@ -43,7 +43,7 @@ function getReservedScriptNames() {
  * @example
  * var Turning = pc.createScript('turn');
  *
- * // define `speed` attribute that is available in Editor UI
+ * // define 'speed' attribute that is available in Editor UI
  * Turning.attributes.add('speed', {
  *     type: 'number',
  *     default: 180,

--- a/src/platform/graphics/shader.js
+++ b/src/platform/graphics/shader.js
@@ -31,7 +31,7 @@ class Shader {
     /**
      * Creates a new Shader instance.
      *
-     * Consider {@link pc.createShaderFromCode} as a simpler and more powerful way to create
+     * Consider {@link createShaderFromCode} as a simpler and more powerful way to create
      * a shader.
      *
      * @param {import('./graphics-device.js').GraphicsDevice} graphicsDevice - The graphics device

--- a/src/platform/input/touch-event.js
+++ b/src/platform/input/touch-event.js
@@ -4,7 +4,7 @@
  *
  * @param {globalThis.Touch} touch - The browser Touch object.
  * @returns {object} The coordinates of the touch relative to the touch.target element. In the
- * format {x, y}.
+ * format \{x, y\}.
  */
 function getTouchTargetCoords(touch) {
     let totalOffsetX = 0;

--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -479,7 +479,7 @@ class GraphNode extends EventHandler {
      * will be checked against the value of the property.
      * @returns {GraphNode[]} The array of graph nodes that match the search criteria.
      * @example
-     * // Finds all nodes that have a model component and have `door` in their lower-cased name
+     * // Finds all nodes that have a model component and have 'door' in their lower-cased name
      * var doors = house.find(function (node) {
      *     return node.model && node.name.toLowerCase().indexOf('door') !== -1;
      * });
@@ -542,7 +542,7 @@ class GraphNode extends EventHandler {
      * @returns {GraphNode|null} A graph node that match the search criteria. Returns null if no
      * node is found.
      * @example
-     * // Find the first node that is called `head` and has a model component
+     * // Find the first node that is called 'head' and has a model component
      * var head = player.findOne(function (node) {
      *     return node.model && node.name === 'head';
      * });


### PR DESCRIPTION
Fixes several warnings generated by the Typedoc docs build. These mainly concern unexpected braces in JSDoc tag blocks.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
