### PR TITLE
Add field declarations for all core classes

### DIFF
--- a/src/core/event-handler.js
+++ b/src/core/event-handler.js
@@ -14,34 +14,31 @@
 
 /**
  * Abstract base class that implements functionality for event handling.
+ *
+ * ```javascript
+ * var obj = new EventHandlerSubclass();
+ *
+ * // subscribe to an event
+ * obj.on('hello', function (str) {
+ *     console.log('event hello is fired', str);
+ * });
+ *
+ * // fire event
+ * obj.fire('hello', 'world');
+ * ```
  */
 class EventHandler {
     /**
-     * Create a new EventHandler instance.
-     *
-     * @example
-     * var obj = new EventHandlerSubclass();
-     *
-     * // subscribe to an event
-     * obj.on('hello', function (str) {
-     *     console.log('event hello is fired', str);
-     * });
-     *
-     * // fire event
-     * obj.fire('hello', 'world');
+     * @type {object}
+     * @private
      */
-    constructor() {
-        /**
-         * @type {object}
-         * @private
-         */
-        this._callbacks = { };
-        /**
-         * @type {object}
-         * @private
-         */
-        this._callbackActive = { };
-    }
+    _callbacks = {};
+
+    /**
+     * @type {object}
+     * @private
+     */
+    _callbackActive = {};
 
     /**
      * Reinitialize the event handler.
@@ -49,8 +46,8 @@ class EventHandler {
      * @private
      */
     initEventHandler() {
-        this._callbacks = { };
-        this._callbackActive = { };
+        this._callbacks = {};
+        this._callbackActive = {};
     }
 
     /**

--- a/src/core/math/color.js
+++ b/src/core/math/color.js
@@ -5,6 +5,31 @@ import { math } from './math.js';
  */
 class Color {
     /**
+     * The red component of the color.
+     *
+     * @type {number}
+     */
+    r;
+    /**
+     * The green component of the color.
+     *
+     * @type {number}
+     */
+    g;
+    /**
+     * The blue component of the color.
+     *
+     * @type {number}
+     */
+    b;
+    /**
+     * The alpha component of the color.
+     *
+     * @type {number}
+     */
+    a;
+
+    /**
      * Create a new Color object.
      *
      * @param {number|number[]} [r] - The value of the red component (0-1). Defaults to 0. If r is
@@ -16,29 +41,9 @@ class Color {
     constructor(r = 0, g = 0, b = 0, a = 1) {
         const length = r.length;
         if (length === 3 || length === 4) {
-            /**
-             * The red component of the color.
-             *
-             * @type {number}
-             */
             this.r = r[0];
-            /**
-             * The green component of the color.
-             *
-             * @type {number}
-             */
             this.g = r[1];
-            /**
-             * The blue component of the color.
-             *
-             * @type {number}
-             */
             this.b = r[2];
-            /**
-             * The alpha component of the color.
-             *
-             * @type {number}
-             */
             this.a = r[3] !== undefined ? r[3] : 1;
         } else {
             this.r = r;

--- a/src/core/math/color.js
+++ b/src/core/math/color.js
@@ -10,18 +10,21 @@ class Color {
      * @type {number}
      */
     r;
+
     /**
      * The green component of the color.
      *
      * @type {number}
      */
     g;
+
     /**
      * The blue component of the color.
      *
      * @type {number}
      */
     b;
+
     /**
      * The alpha component of the color.
      *

--- a/src/core/math/curve-evaluator.js
+++ b/src/core/math/curve-evaluator.js
@@ -9,18 +9,25 @@ import { math } from './math.js';
 class CurveEvaluator {
     /** @private */
     _curve;
+
     /** @private */
     _left = -Infinity;
+
     /** @private */
     _right = Infinity;
+
     /** @private */
     _recip = 0;
+
     /** @private */
     _p0 = 0;
+
     /** @private */
     _p1 = 0;
+
     /** @private */
     _m0 = 0;
+
     /** @private */
     _m1 = 0;
 

--- a/src/core/math/curve-evaluator.js
+++ b/src/core/math/curve-evaluator.js
@@ -7,6 +7,23 @@ import { math } from './math.js';
  * @ignore
  */
 class CurveEvaluator {
+    /** @private */
+    _curve;
+    /** @private */
+    _left = -Infinity;
+    /** @private */
+    _right = Infinity;
+    /** @private */
+    _recip = 0;
+    /** @private */
+    _p0 = 0;
+    /** @private */
+    _p1 = 0;
+    /** @private */
+    _m0 = 0;
+    /** @private */
+    _m1 = 0;
+
     /**
      * Create a new CurveEvaluator instance.
      *
@@ -15,13 +32,6 @@ class CurveEvaluator {
      */
     constructor(curve, time = 0) {
         this._curve = curve;
-        this._left = -Infinity;
-        this._right = Infinity;
-        this._recip = 0;
-        this._p0 = 0;
-        this._p1 = 0;
-        this._m0 = 0;
-        this._m1 = 0;
         this._reset(time);
     }
 

--- a/src/core/math/curve-set.js
+++ b/src/core/math/curve-set.js
@@ -6,6 +6,14 @@ import { CurveEvaluator } from './curve-evaluator.js';
  * A curve set is a collection of curves.
  */
 class CurveSet {
+    curves = [];
+
+    /**
+     * @type {number}
+     * @private
+     */
+    _type = CURVE_SMOOTHSTEP;
+
     /**
      * Creates a new CurveSet instance.
      *
@@ -28,14 +36,6 @@ class CurveSet {
      * ]);
      */
     constructor() {
-        this.curves = [];
-
-        /**
-         * @type {number}
-         * @private
-         */
-        this._type = CURVE_SMOOTHSTEP;
-
         if (arguments.length > 1) {
             for (let i = 0; i < arguments.length; i++) {
                 this.curves.push(new Curve(arguments[i]));

--- a/src/core/math/curve.js
+++ b/src/core/math/curve.js
@@ -8,6 +8,37 @@ import { CurveEvaluator } from './curve-evaluator.js';
  * type that specifies an interpolation scheme for the keys.
  */
 class Curve {
+    keys = [];
+
+    /**
+     * The curve interpolation scheme. Can be:
+     *
+     * - {@link CURVE_LINEAR}
+     * - {@link CURVE_SMOOTHSTEP}
+     * - {@link CURVE_SPLINE}
+     * - {@link CURVE_STEP}
+     *
+     * Defaults to {@link CURVE_SMOOTHSTEP}.
+     *
+     * @type {number}
+     */
+    type = CURVE_SMOOTHSTEP;
+
+    /**
+     * Controls how {@link CURVE_SPLINE} tangents are calculated. Valid range is between 0 and 1
+     * where 0 results in a non-smooth curve (equivalent to linear interpolation) and 1 results in
+     * a very smooth curve. Use 0.5 for a Catmull-rom spline.
+     *
+     * @type {number}
+     */
+    tension = 0.5;
+
+    /**
+     * @type {CurveEvaluator}
+     * @private
+     */
+    _eval = new CurveEvaluator(this);
+
     /**
      * Creates a new Curve instance.
      *
@@ -22,37 +53,6 @@ class Curve {
      * ]);
      */
     constructor(data) {
-        this.keys = [];
-
-        /**
-         * The curve interpolation scheme. Can be:
-         *
-         * - {@link CURVE_LINEAR}
-         * - {@link CURVE_SMOOTHSTEP}
-         * - {@link CURVE_SPLINE}
-         * - {@link CURVE_STEP}
-         *
-         * Defaults to {@link CURVE_SMOOTHSTEP}.
-         *
-         * @type {number}
-         */
-        this.type = CURVE_SMOOTHSTEP;
-
-        /**
-         * Controls how {@link CURVE_SPLINE} tangents are calculated. Valid range is between 0 and
-         * 1 where 0 results in a non-smooth curve (equivalent to linear interpolation) and 1
-         * results in a very smooth curve. Use 0.5 for a Catmull-rom spline.
-         *
-         * @type {number}
-         */
-        this.tension = 0.5;
-
-        /**
-         * @type {CurveEvaluator}
-         * @private
-         */
-        this._eval = new CurveEvaluator(this);
-
         if (data) {
             for (let i = 0; i < data.length - 1; i += 2) {
                 this.keys.push([data[i], data[i + 1]]);

--- a/src/core/math/mat3.js
+++ b/src/core/math/mat3.js
@@ -5,20 +5,19 @@ import { Vec3 } from './vec3.js';
  */
 class Mat3 {
     /**
+     * Matrix elements in the form of a flat array.
+     *
+     * @type {Float32Array}
+     */
+    data = new Float32Array(9);
+
+    /**
      * Create a new Mat3 instance. It is initialized to the identity matrix.
      */
     constructor() {
         // Create an identity matrix. Note that a new Float32Array has all elements set
         // to zero by default, so we only need to set the relevant elements to one.
-        const data = new Float32Array(9);
-        data[0] = data[4] = data[8] = 1;
-
-        /**
-         * Matrix elements in the form of a flat array.
-         *
-         * @type {Float32Array}
-         */
-        this.data = data;
+        this.data[0] = this.data[4] = this.data[8] = 1;
     }
 
     /**

--- a/src/core/math/mat4.js
+++ b/src/core/math/mat4.js
@@ -14,20 +14,19 @@ const scale = new Vec3();
  */
 class Mat4 {
     /**
+     * Matrix elements in the form of a flat array.
+     *
+     * @type {Float32Array}
+     */
+    data = new Float32Array(16);
+
+    /**
      * Create a new Mat4 instance. It is initialized to the identity matrix.
      */
     constructor() {
         // Create an identity matrix. Note that a new Float32Array has all elements set
         // to zero by default, so we only need to set the relevant elements to one.
-        const data = new Float32Array(16);
-        data[0] = data[5] = data[10] = data[15] = 1;
-
-        /**
-         * Matrix elements in the form of a flat array.
-         *
-         * @type {Float32Array}
-         */
-        this.data = data;
+        this.data[0] = this.data[5] = this.data[10] = this.data[15] = 1;
     }
 
     // Static function which evaluates perspective projection matrix half size at the near plane

--- a/src/core/math/quat.js
+++ b/src/core/math/quat.js
@@ -6,6 +6,31 @@ import { Vec3 } from './vec3.js';
  */
 class Quat {
     /**
+     * The x component of the quaternion.
+     *
+     * @type {number}
+     */
+    x;
+    /**
+     * The y component of the quaternion.
+     *
+     * @type {number}
+     */
+    y;
+    /**
+     * The z component of the quaternion.
+     *
+     * @type {number}
+     */
+    z;
+    /**
+     * The w component of the quaternion.
+     *
+     * @type {number}
+     */
+    w;
+
+    /**
      * Create a new Quat instance.
      *
      * @param {number|number[]} [x] - The quaternion's x component. Defaults to 0. If x is an array
@@ -16,29 +41,9 @@ class Quat {
      */
     constructor(x = 0, y = 0, z = 0, w = 1) {
         if (x.length === 4) {
-            /**
-             * The x component of the quaternion.
-             *
-             * @type {number}
-             */
             this.x = x[0];
-            /**
-             * The y component of the quaternion.
-             *
-             * @type {number}
-             */
             this.y = x[1];
-            /**
-             * The z component of the quaternion.
-             *
-             * @type {number}
-             */
             this.z = x[2];
-            /**
-             * The w component of the quaternion.
-             *
-             * @type {number}
-             */
             this.w = x[3];
         } else {
             this.x = x;

--- a/src/core/math/quat.js
+++ b/src/core/math/quat.js
@@ -11,18 +11,21 @@ class Quat {
      * @type {number}
      */
     x;
+
     /**
      * The y component of the quaternion.
      *
      * @type {number}
      */
     y;
+
     /**
      * The z component of the quaternion.
      *
      * @type {number}
      */
     z;
+
     /**
      * The w component of the quaternion.
      *

--- a/src/core/math/vec2.js
+++ b/src/core/math/vec2.js
@@ -8,6 +8,7 @@ class Vec2 {
      * @type {number}
      */
     x;
+
     /**
      * The second component of the vector.
      *

--- a/src/core/math/vec2.js
+++ b/src/core/math/vec2.js
@@ -3,6 +3,19 @@
  */
 class Vec2 {
     /**
+     * The first component of the vector.
+     *
+     * @type {number}
+     */
+    x;
+    /**
+     * The second component of the vector.
+     *
+     * @type {number}
+     */
+    y;
+
+    /**
      * Create a new Vec2 instance.
      *
      * @param {number|number[]} [x] - The x value. Defaults to 0. If x is an array of length 2, the
@@ -13,17 +26,7 @@ class Vec2 {
      */
     constructor(x = 0, y = 0) {
         if (x.length === 2) {
-            /**
-             * The first component of the vector.
-             *
-             * @type {number}
-             */
             this.x = x[0];
-             /**
-              * The second component of the vector.
-              *
-              * @type {number}
-              */
             this.y = x[1];
         } else {
             this.x = x;

--- a/src/core/math/vec3.js
+++ b/src/core/math/vec3.js
@@ -3,6 +3,27 @@
  */
 class Vec3 {
     /**
+     * The first component of the vector.
+     *
+     * @type {number}
+     */
+    x;
+
+    /**
+     * The second component of the vector.
+     *
+     * @type {number}
+     */
+    y;
+
+    /**
+     * The third component of the vector.
+     *
+     * @type {number}
+     */
+    z;
+
+    /**
      * Creates a new Vec3 object.
      *
      * @param {number|number[]} [x] - The x value. Defaults to 0. If x is an array of length 3, the
@@ -14,23 +35,8 @@ class Vec3 {
      */
     constructor(x = 0, y = 0, z = 0) {
         if (x.length === 3) {
-            /**
-             * The first component of the vector.
-             *
-             * @type {number}
-             */
             this.x = x[0];
-             /**
-              * The second component of the vector.
-              *
-              * @type {number}
-              */
             this.y = x[1];
-             /**
-              * The third component of the vector.
-              *
-              * @type {number}
-              */
             this.z = x[2];
         } else {
             this.x = x;

--- a/src/core/math/vec4.js
+++ b/src/core/math/vec4.js
@@ -8,18 +8,21 @@ class Vec4 {
      * @type {number}
      */
     x;
+
     /**
      * The second component of the vector.
      *
      * @type {number}
      */
     y;
+
     /**
      * The third component of the vector.
      *
      * @type {number}
      */
     z;
+
     /**
      * The fourth component of the vector.
      *

--- a/src/core/math/vec4.js
+++ b/src/core/math/vec4.js
@@ -3,6 +3,31 @@
  */
 class Vec4 {
     /**
+     * The first component of the vector.
+     *
+     * @type {number}
+     */
+    x;
+    /**
+     * The second component of the vector.
+     *
+     * @type {number}
+     */
+    y;
+    /**
+     * The third component of the vector.
+     *
+     * @type {number}
+     */
+    z;
+    /**
+     * The fourth component of the vector.
+     *
+     * @type {number}
+     */
+    w;
+
+    /**
      * Creates a new Vec4 object.
      *
      * @param {number|number[]} [x] - The x value. Defaults to 0. If x is an array of length 4, the
@@ -15,29 +40,9 @@ class Vec4 {
      */
     constructor(x = 0, y = 0, z = 0, w = 0) {
         if (x.length === 4) {
-            /**
-             * The first component of the vector.
-             *
-             * @type {number}
-             */
             this.x = x[0];
-            /**
-             * The second component of the vector.
-             *
-             * @type {number}
-             */
             this.y = x[1];
-            /**
-             * The third component of the vector.
-             *
-             * @type {number}
-             */
             this.z = x[2];
-            /**
-             * The fourth component of the vector.
-             *
-             * @type {number}
-             */
             this.w = x[3];
         } else {
             this.x = x;

--- a/src/core/object-pool.js
+++ b/src/core/object-pool.js
@@ -1,12 +1,36 @@
+/**
+ * A pool of reusable objects of the same type. Designed to promote reuse of objects to reduce
+ * garbage collection.
+ *
+ * @ignore
+ */
 class ObjectPool {
+    /**
+     * @type {object[]} - Array of object instances.
+     * @private
+     */
+    _pool = [];
+
+    /**
+     * @type {number} - The number of object instances that are currently allocated.
+     * @private
+     */
+    _count = 0;
+
+    /**
+     * @param {Function} constructorFunc - The constructor function for the objects in the pool.
+     * @param {number} size - The initial number of object instances to allocate.
+     */
     constructor(constructorFunc, size) {
         this._constructor = constructorFunc;
-        this._pool = [];
-        this._count = 0;
 
         this._resize(size);
     }
 
+    /**
+     * @param {number} size - The number of object instances to allocate.
+     * @private
+     */
     _resize(size) {
         if (size > this._pool.length) {
             for (let i = this._pool.length; i < size; i++) {
@@ -15,6 +39,12 @@ class ObjectPool {
         }
     }
 
+    /**
+     * Returns an object instance from the pool. If no instances are available, the pool will be
+     * doubled in size and a new instance will be returned.
+     *
+     * @returns {object} An object instance from the pool.
+     */
     allocate() {
         if (this._count >= this._pool.length) {
             this._resize(this._pool.length * 2);
@@ -22,6 +52,10 @@ class ObjectPool {
         return this._pool[this._count++];
     }
 
+    /**
+     * All object instances in the pool will be available again. The pool itself will not be
+     * resized.
+     */
     freeAll() {
         this._count = 0;
     }

--- a/src/core/ref-counted-cache.js
+++ b/src/core/ref-counted-cache.js
@@ -5,9 +5,9 @@
  */
 class RefCountedCache {
     /**
-     * The cache. The key is the object being stored in the cache. The value is ref count of
-     * the object. When that reaches zero, destroy function on the object gets called and
-     * object is removed from the cache.
+     * The cache. The key is the object being stored in the cache. The value is ref count of the
+     * object. When that reaches zero, destroy function on the object gets called and object is
+     * removed from the cache.
      *
      * @type {Map<object, number>}
      */

--- a/src/core/shape/bounding-box.js
+++ b/src/core/shape/bounding-box.js
@@ -17,17 +17,20 @@ class BoundingBox {
      * @type {Vec3}
      */
     center;
+
     /**
      * Half the distance across the box in each axis.
      *
      * @type {Vec3}
      */
     halfExtents;
+
     /**
      * @type {Vec3}
      * @private
      */
     _min = new Vec3();
+
     /**
      * @type {Vec3}
      * @private

--- a/src/core/shape/bounding-box.js
+++ b/src/core/shape/bounding-box.js
@@ -12,6 +12,29 @@ const tmpVecE = new Vec3();
  */
 class BoundingBox {
     /**
+     * Center of box.
+     *
+     * @type {Vec3}
+     */
+    center;
+    /**
+     * Half the distance across the box in each axis.
+     *
+     * @type {Vec3}
+     */
+    halfExtents;
+    /**
+     * @type {Vec3}
+     * @private
+     */
+    _min = new Vec3();
+    /**
+     * @type {Vec3}
+     * @private
+     */
+    _max = new Vec3();
+
+    /**
      * Create a new BoundingBox instance. The bounding box is axis-aligned.
      *
      * @param {Vec3} [center] - Center of box. The constructor takes a reference of this parameter.
@@ -22,29 +45,8 @@ class BoundingBox {
         Debug.assert(!Object.isFrozen(center), 'The constructor of \'BoundingBox\' does not accept a constant (frozen) object as a \'center\' parameter');
         Debug.assert(!Object.isFrozen(halfExtents), 'The constructor of \'BoundingBox\' does not accept a constant (frozen) object as a \'halfExtents\' parameter');
 
-        /**
-         * Center of box.
-         *
-         * @type {Vec3}
-         */
         this.center = center;
-        /**
-         * Half the distance across the box in each axis.
-         *
-         * @type {Vec3}
-         */
         this.halfExtents = halfExtents;
-
-        /**
-         * @type {Vec3}
-         * @private
-         */
-        this._min = new Vec3();
-        /**
-         * @type {Vec3}
-         * @private
-         */
-        this._max = new Vec3();
     }
 
     /**

--- a/src/core/shape/bounding-sphere.js
+++ b/src/core/shape/bounding-sphere.js
@@ -14,6 +14,7 @@ class BoundingSphere {
      * @type {Vec3}
      */
     center;
+
     /**
      * The radius of the bounding sphere.
      *

--- a/src/core/shape/bounding-sphere.js
+++ b/src/core/shape/bounding-sphere.js
@@ -9,6 +9,19 @@ const tmpVecB = new Vec3();
  */
 class BoundingSphere {
     /**
+     * Center of sphere.
+     *
+     * @type {Vec3}
+     */
+    center;
+    /**
+     * The radius of the bounding sphere.
+     *
+     * @type {number}
+     */
+    radius;
+
+    /**
      * Creates a new BoundingSphere instance.
      *
      * @param {Vec3} [center] - The world space coordinate marking the center of the sphere. The
@@ -21,17 +34,7 @@ class BoundingSphere {
     constructor(center = new Vec3(), radius = 0.5) {
         Debug.assert(!Object.isFrozen(center), 'The constructor of \'BoundingSphere\' does not accept a constant (frozen) object as a \'center\' parameter');
 
-        /**
-         * Center of sphere.
-         *
-         * @type {Vec3}
-         */
         this.center = center;
-        /**
-         * The radius of the bounding sphere.
-         *
-         * @type {number}
-         */
         this.radius = radius;
     }
 

--- a/src/core/shape/frustum.js
+++ b/src/core/shape/frustum.js
@@ -4,6 +4,8 @@
  * directly, but instead query {@link CameraComponent#frustum}.
  */
 class Frustum {
+    planes = [];
+
     /**
      * Create a new Frustum instance.
      *
@@ -11,7 +13,6 @@ class Frustum {
      * var frustum = new pc.Frustum();
      */
     constructor() {
-        this.planes = [];
         for (let i = 0; i < 6; i++)
             this.planes[i] = [];
     }

--- a/src/core/shape/oriented-box.js
+++ b/src/core/shape/oriented-box.js
@@ -15,6 +15,23 @@ const tmpMat4 = new Mat4();
  * Oriented Box.
  */
 class OrientedBox {
+    halfExtents;
+    /**
+     * @type {Mat4}
+     * @private
+     */
+    _modelTransform;
+    /**
+     * @type {Mat4}
+     * @private
+     */
+    _worldTransform;
+    /**
+     * @type {BoundingBox}
+     * @private
+     */
+    _aabb;
+
     /**
      * Create a new OrientedBox instance.
      *
@@ -29,20 +46,8 @@ class OrientedBox {
 
         this.halfExtents = halfExtents;
 
-        /**
-         * @type {Mat4}
-         * @private
-         */
         this._modelTransform = worldTransform.clone().invert();
-        /**
-         * @type {Mat4}
-         * @private
-         */
         this._worldTransform = worldTransform.clone();
-        /**
-         * @type {BoundingBox}
-         * @private
-         */
         this._aabb = new BoundingBox(new Vec3(), this.halfExtents);
     }
 

--- a/src/core/shape/oriented-box.js
+++ b/src/core/shape/oriented-box.js
@@ -16,16 +16,19 @@ const tmpMat4 = new Mat4();
  */
 class OrientedBox {
     halfExtents;
+
     /**
      * @type {Mat4}
      * @private
      */
     _modelTransform;
+
     /**
      * @type {Mat4}
      * @private
      */
     _worldTransform;
+
     /**
      * @type {BoundingBox}
      * @private

--- a/src/core/sorted-loop-array.js
+++ b/src/core/sorted-loop-array.js
@@ -7,6 +7,33 @@
  */
 class SortedLoopArray {
     /**
+     * The internal array that holds the actual array elements.
+     *
+     * @type {object[]}
+     */
+    items = [];
+    /**
+     * The number of elements in the array.
+     *
+     * @type {number}
+     */
+    length = 0;
+    /**
+     * The current index used to loop through the array. This gets modified if we add or remove
+     * elements from the array while looping. See the example to see how to loop through this
+     * array.
+     *
+     * @type {number}
+     */
+    loopIndex = -1;
+
+    /** @private */
+    _sortBy;
+
+    /** @private */
+    _sortHandler;
+
+    /**
      * Create a new SortedLoopArray instance.
      *
      * @param {object} args - Arguments.
@@ -23,27 +50,6 @@ class SortedLoopArray {
      * }
      */
     constructor(args) {
-        /**
-         * The internal array that holds the actual array elements.
-         *
-         * @type {object[]}
-         */
-        this.items = [];
-        /**
-         * The number of elements in the array.
-         *
-         * @type {number}
-         */
-        this.length = 0;
-        /**
-         * The current index used to loop through the array. This gets modified if we add or remove
-         * elements from the array while looping. See the example to see how to loop through this
-         * array.
-         *
-         * @type {number}
-         */
-        this.loopIndex = -1;
-
         this._sortBy = args.sortBy;
         this._sortHandler = this._doSort.bind(this);
     }

--- a/src/core/sorted-loop-array.js
+++ b/src/core/sorted-loop-array.js
@@ -12,12 +12,14 @@ class SortedLoopArray {
      * @type {object[]}
      */
     items = [];
+
     /**
      * The number of elements in the array.
      *
      * @type {number}
      */
     length = 0;
+
     /**
      * The current index used to loop through the array. This gets modified if we add or remove
      * elements from the array while looping. See the example to see how to loop through this

--- a/src/core/tags-cache.js
+++ b/src/core/tags-cache.js
@@ -1,6 +1,9 @@
 class TagsCache {
+    _index = {};
+
+    _key;
+
     constructor(key = null) {
-        this._index = {};
         this._key = key;
     }
 

--- a/src/core/tags.js
+++ b/src/core/tags.js
@@ -7,6 +7,12 @@ import { EventHandler } from './event-handler.js';
  * @augments EventHandler
  */
 class Tags extends EventHandler {
+    /** @private */
+    _index = {};
+
+    /** @private */
+    _list = [];
+
     /**
      * Create an instance of a Tags.
      *
@@ -15,8 +21,6 @@ class Tags extends EventHandler {
     constructor(parent) {
         super();
 
-        this._index = { };
-        this._list = [];
         this._parent = parent;
     }
 

--- a/src/core/uri.js
+++ b/src/core/uri.js
@@ -70,24 +70,28 @@ class URI {
      * @type {string}
      */
     scheme;
+
     /**
      * The authority. (e.g. `www.example.com`).
      *
      * @type {string}
      */
     authority;
+
     /**
      * The path. (e.g. /users/example).
      *
      * @type {string}
      */
     path;
+
     /**
      * The query, the section after a ?. (e.g. search=value).
      *
      * @type {string}
      */
     query;
+
     /**
      * The fragment, the section after a #.
      *

--- a/src/core/uri.js
+++ b/src/core/uri.js
@@ -65,42 +65,47 @@ const re = /^(([^:\/?#]+):)?(\/\/([^\/?#]*))?([^?#]*)(\?([^#]*))?(#(.*))?/;
  */
 class URI {
     /**
+     * The scheme. (e.g. http).
+     *
+     * @type {string}
+     */
+    scheme;
+    /**
+     * The authority. (e.g. `www.example.com`).
+     *
+     * @type {string}
+     */
+    authority;
+    /**
+     * The path. (e.g. /users/example).
+     *
+     * @type {string}
+     */
+    path;
+    /**
+     * The query, the section after a ?. (e.g. search=value).
+     *
+     * @type {string}
+     */
+    query;
+    /**
+     * The fragment, the section after a #.
+     *
+     * @type {string}
+     */
+    fragment;
+
+    /**
      * Create a new URI instance.
      *
      * @param {string} uri - URI string.
      */
     constructor(uri) {
         const result = uri.match(re);
-
-        /**
-         * The scheme. (e.g. http).
-         *
-         * @type {string}
-         */
         this.scheme = result[2];
-        /**
-         * The authority. (e.g. `www.example.com`).
-         *
-         * @type {string}
-         */
         this.authority = result[4];
-        /**
-         * The path. (e.g. /users/example).
-         *
-         * @type {string}
-         */
         this.path = result[5];
-        /**
-         * The query, the section after a ?. (e.g. search=value).
-         *
-         * @type {string}
-         */
         this.query = result[7];
-        /**
-         * The fragment, the section after a #.
-         *
-         * @type {string}
-         */
         this.fragment = result[9];
     }
 


### PR DESCRIPTION
This PR adds [field declarations](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Public_class_fields) for all classes in the `src/core` folder. This improves the Typedocs, changing this:

![image](https://user-images.githubusercontent.com/697563/216419593-1a13c29e-cefd-42da-93b0-9602a9e7d599.png)

Into this:

![image](https://user-images.githubusercontent.com/697563/216419757-da38d880-1cfc-46fc-8266-a9f620b6b44a.png)

It also further aligns the code with TypeScript, where field declarations are mandatory.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
