### PR TITLE
Add MDN links to Typedocs for browser APIs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "serve": "^14.2.0",
         "sinon": "^15.0.1",
         "typedoc": "^0.23.24",
+        "typedoc-plugin-mdn-links": "^2.0.2",
         "typescript": "^4.9.5",
         "xhr2": "^0.2.1"
       }
@@ -7470,6 +7471,15 @@
         "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x"
       }
     },
+    "node_modules/typedoc-plugin-mdn-links": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-mdn-links/-/typedoc-plugin-mdn-links-2.0.2.tgz",
+      "integrity": "sha512-Fzjvfsj3rxvmZNqWRvq9JTGBkOkrPp0kBtvJCJ4U5Jm14OF1KoRErtmwgVQcPLA5Xs8h5I/W4uZBaL8SDHsgxQ==",
+      "dev": true,
+      "peerDependencies": {
+        "typedoc": "0.22.x || 0.23.x"
+      }
+    },
     "node_modules/typedoc/node_modules/brace-expansion": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
@@ -13477,6 +13487,13 @@
           }
         }
       }
+    },
+    "typedoc-plugin-mdn-links": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-mdn-links/-/typedoc-plugin-mdn-links-2.0.2.tgz",
+      "integrity": "sha512-Fzjvfsj3rxvmZNqWRvq9JTGBkOkrPp0kBtvJCJ4U5Jm14OF1KoRErtmwgVQcPLA5Xs8h5I/W4uZBaL8SDHsgxQ==",
+      "dev": true,
+      "requires": {}
     },
     "typescript": {
       "version": "4.9.5",

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "serve": "^14.2.0",
     "sinon": "^15.0.1",
     "typedoc": "^0.23.24",
+    "typedoc-plugin-mdn-links": "^2.0.2",
     "typescript": "^4.9.5",
     "xhr2": "^0.2.1"
   },


### PR DESCRIPTION
Enable MDN links in the generated Typedoc API reference:

![mdnlinks](https://user-images.githubusercontent.com/697563/216579182-e7b7f4c2-f09c-45c2-9cc6-a3407fdd6b1f.gif)

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
