### PR TITLE
Deprecate `createStyle` function

### DIFF
--- a/src/deprecated/deprecated.js
+++ b/src/deprecated/deprecated.js
@@ -245,6 +245,18 @@ export function makeArray(arr) {
     return Array.prototype.slice.call(arr);
 }
 
+export function createStyle(cssString) {
+    const result = document.createElement('style');
+    result.type = 'text/css';
+    if (result.styleSheet) {
+        result.styleSheet.cssText = cssString;
+    } else {
+        result.appendChild(document.createTextNode(cssString));
+    }
+
+    return result;
+}
+
 // MATH
 
 math.INV_LOG2 = Math.LOG2E;

--- a/src/framework/handlers/css.js
+++ b/src/framework/handlers/css.js
@@ -40,26 +40,4 @@ class CssHandler {
     }
 }
 
-/**
- * Creates a &lt;style&gt; DOM element from a string that contains CSS.
- *
- * @param {string} cssString - A string that contains valid CSS.
- * @returns {Element} The style DOM element.
- * @example
- * var css = 'body {height: 100;}';
- * var style = pc.createStyle(css);
- * document.head.appendChild(style);
- */
-function createStyle(cssString) {
-    const result = document.createElement('style');
-    result.type = 'text/css';
-    if (result.styleSheet) {
-        result.styleSheet.cssText = cssString;
-    } else {
-        result.appendChild(document.createTextNode(cssString));
-    }
-
-    return result;
-}
-
-export { createStyle, CssHandler };
+export { CssHandler };

--- a/src/index.js
+++ b/src/index.js
@@ -273,7 +273,7 @@ export { AudioHandler } from './framework/handlers/audio.js';
 export { BinaryHandler } from './framework/handlers/binary.js';
 export { BundleHandler } from './framework/handlers/bundle.js';
 export { ContainerHandler, ContainerResource } from './framework/handlers/container.js';
-export { createStyle, CssHandler } from './framework/handlers/css.js';
+export { CssHandler } from './framework/handlers/css.js';
 export { CubemapHandler } from './framework/handlers/cubemap.js';
 export { FolderHandler } from './framework/handlers/folder.js';
 export { FontHandler } from './framework/handlers/font.js';


### PR DESCRIPTION
The `createStyle` function is not required internally and the PlayCanvas Engine API shouldn't be in the business of providing utility functions for working with the DOM. If it's needed, an application can implement this itself.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
