### PR TITLE
Added Container asset option skipMeshes, to ignore mesh loading from glb

### DIFF
--- a/src/framework/handlers/container.js
+++ b/src/framework/handlers/container.js
@@ -145,6 +145,8 @@ class ContainerResource {
  * Additional options that can be passed for glTF files:
  * [options.morphPreserveData] - When true, the morph target keeps its data passed using the options,
  * allowing the clone operation.
+ * [options.skipMeshes] - When true, the meshes from the container are not created. This can be
+ * useful if you only need access to textures or animations and similar.
  *
  * For example, to receive a texture preprocess callback:
  *

--- a/src/framework/parsers/glb-parser.js
+++ b/src/framework/parsers/glb-parser.js
@@ -1734,6 +1734,10 @@ const createMeshes = function (device, gltf, bufferViews, callback, flipV, meshV
         return [];
     }
 
+    if (options.skipMeshes) {
+        return [];
+    }
+
     // dictionary of vertex buffers to avoid duplicates
     const vertexBufferDict = {};
 


### PR DESCRIPTION
- added this instead of process option for the meshes, at least temporarily, to allow to skip meshes being created when the glb is loaded. Useful if only animations or similar are needed.
- exposing process / preprocess callback would be more generic, but createMesh function in glb-parser takes many complicated parameters, so that is not as useful for the users