### PR TITLE
Fix typo when setting the use AO and Lightmap vertex color flags.

### DIFF
--- a/src/scene/materials/standard-material-options-builder.js
+++ b/src/scene/materials/standard-material-options-builder.js
@@ -118,13 +118,13 @@ class StandardMaterialOptionsBuilder {
 
         // All texture related lit options
         options.litOptions.lightMapEnabled = options.lightMap;
-        options.litOptions.useLightMapVertexColors = options.lightVertexColors;
+        options.litOptions.useLightMapVertexColors = options.lightVertexColor;
         options.litOptions.dirLightMapEnabled = options.dirLightMap;
         options.litOptions.heightMapEnabled = options.heightMap;
         options.litOptions.normalMapEnabled = options.normalMap;
         options.litOptions.clearCoatNormalMapEnabled = options.clearCoatNormalMap;
         options.litOptions.aoMapEnabled = options.aoMap;
-        options.litOptions.useAoVertexColors = options.aoVertexColors;
+        options.litOptions.useAoVertexColors = options.aoVertexColor;
         options.litOptions.diffuseMapEnabled = options.diffuseMap;
     }
 


### PR DESCRIPTION
Fixes bug where AO wasn't used by shader due to a typo.