### PR TITLE
[Fix] Delete old property when the new one already exists

### DIFF
--- a/src/framework/parsers/material/json-standard-material.js
+++ b/src/framework/parsers/material/json-standard-material.js
@@ -143,8 +143,10 @@ class JsonStandardMaterialParser {
             const _old = RENAMED_PROPERTIES[i][0];
             const _new = RENAMED_PROPERTIES[i][1];
 
-            if (data[_old] !== undefined && !(data[_new] !== undefined)) {
-                data[_new] = data[_old];
+            if (data[_old] !== undefined) {
+                if (data[_new] === undefined) {
+                    data[_new] = data[_old];
+                }
                 delete data[_old];
             }
         }


### PR DESCRIPTION
Fixes # https://forum.playcanvas.com/t/console-warning-ignoring-unsupported-input-property-to-standard-material-clearcoatglossiness/29373/10

If a material contains the old and new property, delete the old property.