### PR TITLE
Assert when required dependencies for LayoutGroup component are missing

### DIFF
--- a/src/framework/components/layout-group/component.js
+++ b/src/framework/components/layout-group/component.js
@@ -1,3 +1,4 @@
+import { Debug } from '../../../core/debug.js';
 import { Vec2 } from '../../../core/math/vec2.js';
 import { Vec4 } from '../../../core/math/vec4.js';
 
@@ -69,8 +70,11 @@ class LayoutGroupComponent extends Component {
         // Listen for ElementComponents and LayoutChildComponents being added
         // to self or to children - covers cases where they are not already
         // present at the point when this component is constructed.
+        Debug.assert(system.app.systems.element, `System 'element' doesn't exist`);
         system.app.systems.element.on('add', this._onElementOrLayoutComponentAdd, this);
         system.app.systems.element.on('beforeremove', this._onElementOrLayoutComponentRemove, this);
+
+        Debug.assert(system.app.systems.layoutchild, `System 'layoutchild' doesn't exist`);
         system.app.systems.layoutchild.on('add', this._onElementOrLayoutComponentAdd, this);
         system.app.systems.layoutchild.on('beforeremove', this._onElementOrLayoutComponentRemove, this);
     }


### PR DESCRIPTION
- to indicate the need to import the component, instead of just a null access