### PR TITLE
Updated createGraphicsDevice with easier way to create WebGL1 device

### DIFF
--- a/examples/src/examples/graphics/box-reflection.tsx
+++ b/examples/src/examples/graphics/box-reflection.tsx
@@ -156,7 +156,7 @@ class BoxReflectionExample {
                 sphereMaterial.update();
 
                 let videoTexture : pc.Texture;
-                if (app.graphicsDevice.deviceType === pc.DEVICETYPE_WEBGL) {
+                if (!app.graphicsDevice.isWebGPU) {
                     // set up video playback into a texture
                     videoTexture = new pc.Texture(app.graphicsDevice, {
                         format: pc.PIXELFORMAT_RGB565,

--- a/examples/webgpu-temp/four.html
+++ b/examples/webgpu-temp/four.html
@@ -28,7 +28,7 @@
         import { Texture } from '../../src/platform/graphics/texture.js';
         import { RenderTarget } from '../../src/platform/graphics/render-target.js';
         import {
-            DEVICETYPE_WEBGL, DEVICETYPE_WEBGPU,
+            DEVICETYPE_WEBGPU,
             SEMANTIC_TEXCOORD0, SEMANTIC_POSITION, CULLFACE_NONE,
             PIXELFORMAT_RGBA8, FILTER_LINEAR, ADDRESS_CLAMP_TO_EDGE
         } from '../../src/platform/graphics/constants.js';
@@ -110,7 +110,7 @@
 
             const canvas = document.querySelector('#gpuCanvas');
             const gfxOptions = {
-                deviceTypes: [DEVICETYPE_WEBGPU, DEVICETYPE_WEBGL],
+                deviceTypes: [DEVICETYPE_WEBGPU],
                 glslangUrl: '../src/lib/glslang/glslang.js',
                 twgslUrl: '../src/lib/twgsl/twgsl.js'
             };

--- a/examples/webgpu-temp/one.html
+++ b/examples/webgpu-temp/one.html
@@ -29,7 +29,7 @@
         import { RenderTarget } from '../../src/platform/graphics/render-target.js';
         import { drawQuadWithShader } from '../../src/scene/graphics/quad-render-utils.js';
         import {
-            DEVICETYPE_WEBGL, DEVICETYPE_WEBGPU,
+            DEVICETYPE_WEBGPU,
             SEMANTIC_TEXCOORD0, SEMANTIC_POSITION, CULLFACE_NONE,
             PIXELFORMAT_RGBA8, FILTER_LINEAR, ADDRESS_CLAMP_TO_EDGE
         } from '../../src/platform/graphics/constants.js';
@@ -376,7 +376,7 @@ void main() {
 
             const canvas = document.querySelector('#gpuCanvas');
             const gfxOptions = {
-                deviceTypes: [DEVICETYPE_WEBGPU, DEVICETYPE_WEBGL],
+                deviceTypes: [DEVICETYPE_WEBGPU],
                 glslangUrl: '../src/lib/glslang/glslang.js',
                 twgslUrl: '../src/lib/twgsl/twgsl.js'
             };

--- a/examples/webgpu-temp/three.html
+++ b/examples/webgpu-temp/three.html
@@ -28,7 +28,7 @@
         import { Texture } from '../../src/platform/graphics/texture.js';
         import { RenderTarget } from '../../src/platform/graphics/render-target.js';
         import {
-            DEVICETYPE_WEBGL, DEVICETYPE_WEBGPU,
+            DEVICETYPE_WEBGPU,
             SEMANTIC_TEXCOORD0, SEMANTIC_POSITION, CULLFACE_NONE,
             PIXELFORMAT_RGBA8, FILTER_LINEAR, ADDRESS_CLAMP_TO_EDGE
         } from '../../src/platform/graphics/constants.js';
@@ -217,7 +217,7 @@
 
             const canvas = document.querySelector('#gpuCanvas');
             const gfxOptions = {
-                deviceTypes: [DEVICETYPE_WEBGPU, DEVICETYPE_WEBGL],
+                deviceTypes: [DEVICETYPE_WEBGPU],
                 glslangUrl: '../src/lib/glslang/glslang.js',
                 twgslUrl: '../src/lib/twgsl/twgsl.js'
             };

--- a/examples/webgpu-temp/two.html
+++ b/examples/webgpu-temp/two.html
@@ -28,7 +28,7 @@
         import { Texture } from '../../src/platform/graphics/texture.js';
         import { RenderTarget } from '../../src/platform/graphics/render-target.js';
         import {
-            DEVICETYPE_WEBGL, DEVICETYPE_WEBGPU,
+            DEVICETYPE_WEBGPU,
             SEMANTIC_TEXCOORD0, SEMANTIC_POSITION, CULLFACE_NONE,
             PIXELFORMAT_RGBA8, FILTER_LINEAR, ADDRESS_CLAMP_TO_EDGE
         } from '../../src/platform/graphics/constants.js';
@@ -117,7 +117,7 @@
 
             const canvas = document.querySelector('#gpuCanvas');
             const gfxOptions = {
-                deviceTypes: [DEVICETYPE_WEBGPU, DEVICETYPE_WEBGL],
+                deviceTypes: [DEVICETYPE_WEBGPU],
                 glslangUrl: '../src/lib/glslang/glslang.js',
                 twgslUrl: '../src/lib/twgsl/twgsl.js'
             };

--- a/src/platform/graphics/constants.js
+++ b/src/platform/graphics/constants.js
@@ -1159,11 +1159,18 @@ export const uniformTypeToName = [
 ];
 
 /**
- * A WebGL device type.
+ * A WebGL 1 device type.
  *
  * @type {string}
  */
-export const DEVICETYPE_WEBGL = 'webgl';
+export const DEVICETYPE_WEBGL1 = 'webgl1';
+
+/**
+ * A WebGL 2 device type.
+ *
+ * @type {string}
+ */
+export const DEVICETYPE_WEBGL2 = 'webgl2';
 
 /**
  * A WebGPU device type.

--- a/src/platform/graphics/graphics-device.js
+++ b/src/platform/graphics/graphics-device.js
@@ -30,12 +30,11 @@ class GraphicsDevice extends EventHandler {
     canvas;
 
     /**
-     * The graphics device type, DEVICETYPE_WEBGL or DEVICETYPE_WEBGPU.
+     * True if the deviceType is WebGPU
      *
-     * @type {string}
-     * @ignore
+     * @type {boolean}
      */
-    deviceType;
+    isWebGPU = false;
 
     /**
      * The scope namespace for shader attributes and variables.

--- a/src/platform/graphics/shader-utils.js
+++ b/src/platform/graphics/shader-utils.js
@@ -1,6 +1,5 @@
 import { Debug } from "../../core/debug.js";
 import {
-    DEVICETYPE_WEBGPU, DEVICETYPE_WEBGL,
     SEMANTIC_POSITION, SEMANTIC_NORMAL, SEMANTIC_TANGENT, SEMANTIC_TEXCOORD0, SEMANTIC_TEXCOORD1, SEMANTIC_TEXCOORD2,
     SEMANTIC_TEXCOORD3, SEMANTIC_TEXCOORD4, SEMANTIC_TEXCOORD5, SEMANTIC_TEXCOORD6, SEMANTIC_TEXCOORD7,
     SEMANTIC_COLOR, SEMANTIC_BLENDINDICES, SEMANTIC_BLENDWEIGHT
@@ -59,7 +58,7 @@ class ShaderUtils {
         Debug.assert(options);
 
         const getDefines = (gpu, gl2, gl1, isVertex) => {
-            return device.deviceType === DEVICETYPE_WEBGPU ? gpu :
+            return device.isWebGPU ? gpu :
                 (device.webgl2 ? gl2 : ShaderUtils.gl1Extensions(device, options) + gl1);
         };
 
@@ -125,7 +124,7 @@ class ShaderUtils {
     }
 
     static versionCode(device) {
-        if (device.deviceType === DEVICETYPE_WEBGPU) {
+        if (device.isWebGPU) {
             return '#version 450\n';
         }
         return device.webgl2 ? "#version 300 es\n" : "";
@@ -150,7 +149,7 @@ class ShaderUtils {
 
         const precision = forcePrecision ? forcePrecision : device.precision;
 
-        if (device.deviceType === DEVICETYPE_WEBGL) {
+        if (!device.isWebGPU) {
 
             code = `precision ${precision} float;\n`;
 

--- a/src/platform/graphics/vertex-format.js
+++ b/src/platform/graphics/vertex-format.js
@@ -5,7 +5,7 @@ import { math } from '../../core/math/math.js';
 
 import {
     SEMANTIC_TEXCOORD0, SEMANTIC_TEXCOORD1, SEMANTIC_ATTR12, SEMANTIC_ATTR13, SEMANTIC_ATTR14, SEMANTIC_ATTR15,
-    SEMANTIC_COLOR, SEMANTIC_TANGENT, TYPE_FLOAT32, typedArrayTypesByteSize, vertexTypesNames, DEVICETYPE_WEBGPU, DEVICETYPE_WEBGL
+    SEMANTIC_COLOR, SEMANTIC_TANGENT, TYPE_FLOAT32, typedArrayTypesByteSize, vertexTypesNames
 } from './constants.js';
 
 /**
@@ -140,7 +140,7 @@ class VertexFormat {
             elementSize = elementDesc.components * typedArrayTypesByteSize[elementDesc.type];
 
             // WebGPU has limited element size support (for example uint16x3 is not supported)
-            Debug.assert(graphicsDevice.deviceType !== DEVICETYPE_WEBGPU || [2, 4, 8, 12, 16].includes(elementSize),
+            Debug.assert(!graphicsDevice.isWebGPU || [2, 4, 8, 12, 16].includes(elementSize),
                          `WebGPU does not support the format of vertex element ${elementDesc.semantic} : ${vertexTypesNames[elementDesc.type]} x ${elementDesc.components}`);
 
             // align up the offset to elementSize (when vertexCount is specified only - case of non-interleaved format)
@@ -227,7 +227,7 @@ class VertexFormat {
      */
     update() {
         // Note that this is used only by vertex attribute morphing on the WebGL.
-        Debug.assert(this.device.deviceType === DEVICETYPE_WEBGL, `VertexFormat#update is not supported on WebGPU and VertexFormat cannot be modified.`);
+        Debug.assert(!this.device.isWebGPU, `VertexFormat#update is not supported on WebGPU and VertexFormat cannot be modified.`);
         this._evaluateHash();
     }
 

--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -4,7 +4,6 @@ import { platform } from '../../../core/platform.js';
 import { Color } from '../../../core/math/color.js';
 
 import {
-    DEVICETYPE_WEBGL,
     ADDRESS_CLAMP_TO_EDGE,
     BLENDEQUATION_ADD,
     BLENDMODE_ZERO, BLENDMODE_ONE,
@@ -361,7 +360,6 @@ class WebglGraphicsDevice extends GraphicsDevice {
      */
     constructor(canvas, options = {}) {
         super(canvas);
-        this.deviceType = DEVICETYPE_WEBGL;
 
         this.defaultFramebuffer = null;
 

--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -1,7 +1,7 @@
 import { Debug, DebugHelper } from '../../../core/debug.js';
 
 import {
-    DEVICETYPE_WEBGPU, PIXELFORMAT_RGBA32F, PIXELFORMAT_RGBA8, PIXELFORMAT_BGRA8, CULLFACE_BACK
+    PIXELFORMAT_RGBA32F, PIXELFORMAT_RGBA8, PIXELFORMAT_BGRA8, CULLFACE_BACK
 } from '../constants.js';
 import { GraphicsDevice } from '../graphics-device.js';
 import { RenderTarget } from '../render-target.js';
@@ -69,7 +69,7 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
 
     constructor(canvas, options = {}) {
         super(canvas);
-        this.deviceType = DEVICETYPE_WEBGPU;
+        this.isWebGPU = true;
 
         // TODO: refactor as needed
         this.writeRed = true;

--- a/src/scene/frame-graph.js
+++ b/src/scene/frame-graph.js
@@ -1,7 +1,6 @@
 import { TRACEID_RENDER_PASS, TRACEID_RENDER_PASS_DETAIL } from '../core/constants.js';
 import { Debug } from '../core/debug.js';
 import { Tracing } from '../core/tracing.js';
-import { DEVICETYPE_WEBGPU } from '../platform/graphics/constants.js';
 
 /**
  * A frame graph represents a single rendering frame as a sequence of render passes.
@@ -133,7 +132,7 @@ class FrameGraph {
             this.renderPasses.forEach((renderPass, index) => {
 
                 let rt = renderPass.renderTarget;
-                if (rt === null && device.deviceType === DEVICETYPE_WEBGPU) {
+                if (rt === null && device.isWebGPU) {
                     rt = device.frameBuffer;
                 }
                 const hasColor = rt?.colorBuffer ?? rt?.impl.assignedColorTexture;

--- a/src/scene/graphics/quad-render-utils.js
+++ b/src/scene/graphics/quad-render-utils.js
@@ -1,7 +1,7 @@
 import { Debug, DebugHelper } from '../../core/debug.js';
 import { Vec4 } from '../../core/math/vec4.js';
 
-import { CULLFACE_NONE, DEVICETYPE_WEBGPU } from '../../platform/graphics/constants.js';
+import { CULLFACE_NONE } from '../../platform/graphics/constants.js';
 import { DebugGraphics } from '../../platform/graphics/debug-graphics.js';
 import { RenderPass } from '../../platform/graphics/render-pass.js';
 import { QuadRender } from './quad-render.js';
@@ -66,7 +66,7 @@ function drawQuadWithShader(device, target, shader, rect, scissorRect, useBlend 
     renderPass.depthStencilOps.clearDepth = false;
 
     // TODO: this is temporary, till the webgpu supports setDepthTest
-    if (device.deviceType === DEVICETYPE_WEBGPU) {
+    if (device.isWebGPU) {
         renderPass.depthStencilOps.clearDepth = true;
     }
 
@@ -99,7 +99,7 @@ function drawQuadWithShader(device, target, shader, rect, scissorRect, useBlend 
  * @param {boolean} [useBlend] - True to enable blending. Defaults to false, disabling blending.
  */
 function drawTexture(device, texture, target, shader, rect, scissorRect, useBlend = false) {
-    Debug.assert(device.deviceType !== DEVICETYPE_WEBGPU, 'pc.drawTexture is not currently supported on WebGPU platform.');
+    Debug.assert(!device.isWebGPU, 'pc.drawTexture is not currently supported on WebGPU platform.');
     shader = shader || device.getCopyShader();
     device.constantTexSource.setValue(texture);
     drawQuadWithShader(device, target, shader, rect, scissorRect, useBlend);

--- a/src/scene/graphics/scene-grab.js
+++ b/src/scene/graphics/scene-grab.js
@@ -1,7 +1,6 @@
 import { Debug } from '../../core/debug.js';
 
 import {
-    DEVICETYPE_WEBGPU,
     ADDRESS_CLAMP_TO_EDGE,
     FILTER_NEAREST, FILTER_LINEAR, FILTER_LINEAR_MIPMAP_LINEAR,
     PIXELFORMAT_DEPTHSTENCIL, PIXELFORMAT_RGBA8
@@ -56,7 +55,7 @@ class SceneGrab {
 
         // create a depth layer, which is a default depth layer, but also a template used
         // to patch application created depth layers to behave as one
-        if (this.device.webgl2 || this.device.deviceType === DEVICETYPE_WEBGPU) {
+        if (this.device.webgl2 || this.device.isWebGPU) {
             this.initMainPath();
         } else {
             this.initFallbackPath();
@@ -74,7 +73,7 @@ class SceneGrab {
     static requiresRenderPass(device, camera) {
 
         // just copy out the textures, no render pass needed
-        if (device.webgl2 || device.deviceType === DEVICETYPE_WEBGPU) {
+        if (device.webgl2 || device.isWebGPU) {
             return false;
         }
 
@@ -209,7 +208,7 @@ class SceneGrab {
 
                     const colorBuffer = this.colorRenderTarget.colorBuffer;
 
-                    if (device.deviceType === DEVICETYPE_WEBGPU) {
+                    if (device.isWebGPU) {
 
                         device.copyRenderTarget(camera.renderTarget, this.colorRenderTarget, true, false);
 

--- a/src/scene/renderer/renderer.js
+++ b/src/scene/renderer/renderer.js
@@ -15,7 +15,6 @@ import { LightTextureAtlas } from '../lighting/light-texture-atlas.js';
 import { Material } from '../materials/material.js';
 
 import {
-    DEVICETYPE_WEBGPU,
     CLEARFLAG_COLOR, CLEARFLAG_DEPTH, CLEARFLAG_STENCIL,
     BINDGROUP_MESH, BINDGROUP_VIEW, UNIFORM_BUFFER_DEFAULT_SLOT_NAME,
     UNIFORMTYPE_MAT4,
@@ -326,7 +325,7 @@ class Renderer {
             }
 
             // update depth range of projection matrices (-1..1 to 0..1)
-            if (this.device.deviceType === DEVICETYPE_WEBGPU) {
+            if (this.device.isWebGPU) {
                 projMat = _tempProjMat2.mul2(_fixProjRangeMat, projMat);
                 projMatSkybox = _tempProjMat3.mul2(_fixProjRangeMat, projMatSkybox);
             }

--- a/src/scene/renderer/shadow-map.js
+++ b/src/scene/renderer/shadow-map.js
@@ -3,8 +3,7 @@ import {
     FILTER_LINEAR, FILTER_NEAREST,
     FUNC_LESS,
     PIXELFORMAT_DEPTH, PIXELFORMAT_RGBA8, PIXELFORMAT_RGBA16F, PIXELFORMAT_RGBA32F,
-    TEXHINT_SHADOWMAP,
-    DEVICETYPE_WEBGPU
+    TEXHINT_SHADOWMAP
 } from '../../platform/graphics/constants.js';
 import { RenderTarget } from '../../platform/graphics/render-target.js';
 import { Texture } from '../../platform/graphics/texture.js';
@@ -136,7 +135,7 @@ class ShadowMap {
         }
 
         // TODO: this is temporary, and will be handle on generic level for all render targets for WebGPU
-        if (device.deviceType === DEVICETYPE_WEBGPU) {
+        if (device.isWebGPU) {
             target.flipY = true;
         }
 

--- a/src/scene/renderer/shadow-renderer.js
+++ b/src/scene/renderer/shadow-renderer.js
@@ -5,7 +5,7 @@ import { Mat4 } from '../../core/math/mat4.js';
 import { Vec3 } from '../../core/math/vec3.js';
 import { Vec4 } from '../../core/math/vec4.js';
 
-import { DEVICETYPE_WEBGPU, FUNC_LESSEQUAL, SHADERSTAGE_FRAGMENT, SHADERSTAGE_VERTEX, UNIFORMTYPE_MAT4, UNIFORM_BUFFER_DEFAULT_SLOT_NAME } from '../../platform/graphics/constants.js';
+import { FUNC_LESSEQUAL, SHADERSTAGE_FRAGMENT, SHADERSTAGE_VERTEX, UNIFORMTYPE_MAT4, UNIFORM_BUFFER_DEFAULT_SLOT_NAME } from '../../platform/graphics/constants.js';
 import { DebugGraphics } from '../../platform/graphics/debug-graphics.js';
 import { drawQuadWithShader } from '../graphics/quad-render-utils.js';
 
@@ -170,7 +170,7 @@ class ShadowRenderer {
         const isClustered = this.renderer.scene.clusteredLightingEnabled;
 
         // depth bias
-        if (device.webgl2 || device.deviceType === DEVICETYPE_WEBGPU) {
+        if (device.webgl2 || device.isWebGPU) {
             if (light._type === LIGHTTYPE_OMNI && !isClustered) {
                 device.setDepthBias(false);
             } else {

--- a/src/scene/shader-lib/programs/lit-shader.js
+++ b/src/scene/shader-lib/programs/lit-shader.js
@@ -3,8 +3,7 @@ import {
     SEMANTIC_BLENDINDICES, SEMANTIC_BLENDWEIGHT, SEMANTIC_COLOR, SEMANTIC_NORMAL, SEMANTIC_POSITION, SEMANTIC_TANGENT,
     SEMANTIC_TEXCOORD0, SEMANTIC_TEXCOORD1,
     SHADERTAG_MATERIAL,
-    PIXELFORMAT_RGBA8,
-    DEVICETYPE_WEBGPU
+    PIXELFORMAT_RGBA8
 } from '../../../platform/graphics/constants.js';
 import { shaderChunks } from '../chunks/chunks.js';
 import { ChunkUtils } from '../chunk-utils.js';
@@ -189,7 +188,7 @@ class LitShader {
         const shadowCoordArgs = `(${shadowMatArg}, ${shadowParamArg});\n`;
         if (!light._normalOffsetBias || light._isVsm) {
             if (light._type === LIGHTTYPE_SPOT) {
-                if (light._isPcf && (device.webgl2 || device.extStandardDerivatives || device.deviceType === DEVICETYPE_WEBGPU)) {
+                if (light._isPcf && (device.webgl2 || device.extStandardDerivatives || device.isWebGPU)) {
                     return "       getShadowCoordPerspZbuffer" + shadowCoordArgs;
                 }
                 return "       getShadowCoordPersp" + shadowCoordArgs;
@@ -197,7 +196,7 @@ class LitShader {
             return this._directionalShadowMapProjection(light, shadowCoordArgs, shadowParamArg, lightIndex, "getShadowCoordOrtho");
         }
         if (light._type === LIGHTTYPE_SPOT) {
-            if (light._isPcf && (device.webgl2 || device.extStandardDerivatives || device.deviceType === DEVICETYPE_WEBGPU)) {
+            if (light._isPcf && (device.webgl2 || device.extStandardDerivatives || device.isWebGPU)) {
                 return "       getShadowCoordPerspZbufferNormalOffset" + shadowCoordArgs;
             }
             return "       getShadowCoordPerspNormalOffset" + shadowCoordArgs;
@@ -477,7 +476,7 @@ class LitShader {
 
         let code = this._fsGetBeginCode();
 
-        if (device.extStandardDerivatives && !device.webgl2 && device.deviceType !== DEVICETYPE_WEBGPU) {
+        if (device.extStandardDerivatives && !device.webgl2 && !device.isWebGPU) {
             code += 'uniform vec2 polygonOffset;\n';
         }
 
@@ -500,7 +499,7 @@ class LitShader {
         code += this.frontendDecl;
         code += this.frontendCode;
 
-        if (shadowType === SHADOW_PCF3 && (!device.webgl2 || device.deviceType !== DEVICETYPE_WEBGPU || lightType === LIGHTTYPE_OMNI)) {
+        if (shadowType === SHADOW_PCF3 && (!device.webgl2 || !device.isWebGPU || lightType === LIGHTTYPE_OMNI)) {
             code += chunks.packDepthPS;
         } else if (shadowType === SHADOW_VSM8) {
             code += "vec2 encodeFloatRG( float v ) {\n";
@@ -516,7 +515,7 @@ class LitShader {
         code += this.frontendFunc;
 
         const isVsm = shadowType === SHADOW_VSM8 || shadowType === SHADOW_VSM16 || shadowType === SHADOW_VSM32;
-        const applySlopeScaleBias = !device.webgl2 && device.extStandardDerivatives && device.deviceType !== DEVICETYPE_WEBGPU;
+        const applySlopeScaleBias = !device.webgl2 && device.extStandardDerivatives && !device.isWebGPU;
 
         if (lightType === LIGHTTYPE_OMNI || (isVsm && lightType !== LIGHTTYPE_DIRECTIONAL)) {
             code += "    float depth = min(distance(view_position, vPositionW) / light_radius, 0.99999);\n";
@@ -828,7 +827,7 @@ class LitShader {
             if (shadowTypeUsed[SHADOW_PCF3]) {
                 code += chunks.shadowStandardPS;
             }
-            if (shadowTypeUsed[SHADOW_PCF5] && (device.webgl2 || device.deviceType === DEVICETYPE_WEBGPU)) {
+            if (shadowTypeUsed[SHADOW_PCF5] && (device.webgl2 || device.isWebGPU)) {
                 code += chunks.shadowStandardGL2PS;
             }
             if (useVsm) {
@@ -844,7 +843,7 @@ class LitShader {
                 }
             }
 
-            if (!(device.webgl2 || device.extStandardDerivatives || device.deviceType === DEVICETYPE_WEBGPU)) {
+            if (!(device.webgl2 || device.extStandardDerivatives || device.isWebGPU)) {
                 code += chunks.biasConstPS;
             }
 


### PR DESCRIPTION
Adjusted createGraphicsDevice function:
- WebGL2 and WebGL1 fallbacks are automatically added to the list

So the two typical scenarios:
1. called with **[] or undefined**: WebGL2 and WebGL1 are added to the array internally
2. called with **[WebGPU]** - WebGL2 and WebGL1 are added to the array internally, and are used as a falback if WebGPU is not supported.
But users can still specify these 3 constants in their preferred order.

- added `device.isWebGPU`, instead of existing `device.deviceType === DEVICETYPE_WEBGPU`, as that does not require constant import and is shorter / easier to use.
