### PR TITLE
WebXR - Fixed bug where the wrong number of views is being added

### DIFF
--- a/src/framework/xr/xr-manager.js
+++ b/src/framework/xr/xr-manager.js
@@ -696,7 +696,8 @@ class XrManager extends EventHandler {
 
         if (lengthNew > this.views.length) {
             // add new views into list
-            for (let i = 0; i <= (lengthNew - this.views.length); i++) {
+            const viewAddCount = (lengthNew - this.views.length);
+            for (let i = 0; i <= viewAddCount; i++) {
                 let view = this.viewsPool.pop();
                 if (!view) {
                     view = {

--- a/src/framework/xr/xr-manager.js
+++ b/src/framework/xr/xr-manager.js
@@ -694,32 +694,28 @@ class XrManager extends EventHandler {
         const lengthOld = this.views.length;
         const lengthNew = pose.views.length;
 
-        if (lengthNew > this.views.length) {
-            // add new views into list
-            while (lengthNew > this.views.length) {
-                let view = this.viewsPool.pop();
-                if (!view) {
-                    view = {
-                        viewport: new Vec4(),
-                        projMat: new Mat4(),
-                        viewMat: new Mat4(),
-                        viewOffMat: new Mat4(),
-                        viewInvMat: new Mat4(),
-                        viewInvOffMat: new Mat4(),
-                        projViewOffMat: new Mat4(),
-                        viewMat3: new Mat3(),
-                        position: new Float32Array(3),
-                        rotation: new Quat()
-                    };
-                }
+        while (lengthNew > this.views.length) {
+            let view = this.viewsPool.pop();
+            if (!view) {
+                view = {
+                    viewport: new Vec4(),
+                    projMat: new Mat4(),
+                    viewMat: new Mat4(),
+                    viewOffMat: new Mat4(),
+                    viewInvMat: new Mat4(),
+                    viewInvOffMat: new Mat4(),
+                    projViewOffMat: new Mat4(),
+                    viewMat3: new Mat3(),
+                    position: new Float32Array(3),
+                    rotation: new Quat()
+                };
+            }
 
-                this.views.push(view);
-            }
-        } else if (lengthNew <= this.views.length) {
-            // remove views from list into pool
-            while (lengthNew < this.views.length) {
-                this.viewsPool.push(this.views.pop());
-            }
+            this.views.push(view);
+        }
+        // remove views from list into pool
+        while (lengthNew < this.views.length) {
+            this.viewsPool.push(this.views.pop());
         }
 
         // reset position

--- a/src/framework/xr/xr-manager.js
+++ b/src/framework/xr/xr-manager.js
@@ -696,8 +696,7 @@ class XrManager extends EventHandler {
 
         if (lengthNew > this.views.length) {
             // add new views into list
-            const viewAddCount = (lengthNew - this.views.length);
-            for (let i = 0; i <= viewAddCount; i++) {
+            while (lengthNew > this.views.length) {
                 let view = this.viewsPool.pop();
                 if (!view) {
                     view = {
@@ -718,7 +717,7 @@ class XrManager extends EventHandler {
             }
         } else if (lengthNew <= this.views.length) {
             // remove views from list into pool
-            for (let i = 0; i < (this.views.length - lengthNew); i++) {
+            while (lengthNew < this.views.length) {
                 this.viewsPool.push(this.views.pop());
             }
         }


### PR DESCRIPTION
Fixes an error in WebXR on some devices that have more than 2 viewports about view being undefined

<img width="536" alt="image" src="https://user-images.githubusercontent.com/16639049/217869987-54f621b6-d993-42f3-95b7-dcaf56cf3620.png">

This is because when we add views to an array in the loop, we are also using the length of that array to calculate how many to add which means the total number to add gets smaller each loop.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
