### PR TITLE
Parameters for Object.assign in setXrProperties was wrong

### DIFF
--- a/src/scene/camera.js
+++ b/src/scene/camera.js
@@ -625,7 +625,7 @@ class Camera {
      * @param {number} [properties.nearClip] - Near clip.
      */
     setXrProperties(properties) {
-        Object.assign(properties, this._xrProperties);
+        Object.assign(this._xrProperties, properties);
         this._projMatDirty = true;
     }
 }


### PR DESCRIPTION
So the calculated properties for the physical camera (FOV etc) were never set and remained default

Fixes not being able to use the UI elements in AR

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
