### PR TITLE
More nullish coalescing refactoring

### DIFF
--- a/src/framework/components/collision/system.js
+++ b/src/framework/components/collision/system.js
@@ -233,9 +233,9 @@ class CollisionSphereSystemImpl extends CollisionSystemImpl {
 // Capsule Collision System
 class CollisionCapsuleSystemImpl extends CollisionSystemImpl {
     createPhysicalShape(entity, data) {
-        const axis = (data.axis !== undefined) ? data.axis : 1;
-        const radius = data.radius || 0.5;
-        const height = Math.max((data.height || 2) - 2 * radius, 0);
+        const axis = data.axis ?? 1;
+        const radius = data.radius ?? 0.5;
+        const height = Math.max((data.height ?? 2) - 2 * radius, 0);
 
         let shape = null;
 
@@ -260,9 +260,9 @@ class CollisionCapsuleSystemImpl extends CollisionSystemImpl {
 // Cylinder Collision System
 class CollisionCylinderSystemImpl extends CollisionSystemImpl {
     createPhysicalShape(entity, data) {
-        const axis = (data.axis !== undefined) ? data.axis : 1;
-        const radius = (data.radius !== undefined) ? data.radius : 0.5;
-        const height = (data.height !== undefined) ? data.height : 1;
+        const axis = data.axis ?? 1;
+        const radius = data.radius ?? 0.5;
+        const height = data.height ?? 1;
 
         let halfExtents = null;
         let shape = null;
@@ -294,9 +294,9 @@ class CollisionCylinderSystemImpl extends CollisionSystemImpl {
 // Cone Collision System
 class CollisionConeSystemImpl extends CollisionSystemImpl {
     createPhysicalShape(entity, data) {
-        const axis = (data.axis !== undefined) ? data.axis : 1;
-        const radius = (data.radius !== undefined) ? data.radius : 0.5;
-        const height = (data.height !== undefined) ? data.height : 1;
+        const axis = data.axis ?? 1;
+        const radius = data.radius ?? 0.5;
+        const height = data.height ?? 1;
 
         let shape = null;
 

--- a/src/framework/components/sprite/system.js
+++ b/src/framework/components/sprite/system.js
@@ -154,9 +154,9 @@ class SpriteComponentSystem extends ComponentSystem {
 
         if (data.color !== undefined) {
             if (data.color instanceof Color) {
-                component.color.set(data.color.r, data.color.g, data.color.b, data.opacity !== undefined ? data.opacity : 1);
+                component.color.set(data.color.r, data.color.g, data.color.b, data.opacity ?? 1);
             } else {
-                component.color.set(data.color[0], data.color[1], data.color[2], data.opacity !== undefined ? data.opacity : 1);
+                component.color.set(data.color[0], data.color[1], data.color[2], data.opacity ?? 1);
             }
 
             /* eslint-disable no-self-assign */

--- a/src/framework/parsers/scene.js
+++ b/src/framework/parsers/scene.js
@@ -54,7 +54,7 @@ class SceneParser {
 
         entity.setGuid(data.resource_id);
         this._setPosRotScale(entity, data, compressed);
-        entity._enabled = data.enabled !== undefined ? data.enabled : true;
+        entity._enabled = data.enabled ?? true;
 
         if (this._isTemplate) {
             entity._template = true;

--- a/src/platform/graphics/render-target.js
+++ b/src/platform/graphics/render-target.js
@@ -4,11 +4,6 @@ import { PIXELFORMAT_DEPTH, PIXELFORMAT_DEPTHSTENCIL } from './constants.js';
 import { DebugGraphics } from './debug-graphics.js';
 import { GraphicsDevice } from './graphics-device.js';
 
-const defaultOptions = {
-    depth: true,
-    face: 0
-};
-
 let id = 0;
 
 /**
@@ -18,7 +13,7 @@ class RenderTarget {
     /**
      * Creates a new RenderTarget instance. A color buffer or a depth buffer must be set.
      *
-     * @param {object} options - Object for passing optional arguments.
+     * @param {object} [options] - Object for passing optional arguments.
      * @param {boolean} [options.autoResolve] - If samples > 1, enables or disables automatic MSAA
      * resolve after rendering to this RT (see {@link RenderTarget#resolve}). Defaults to true.
      * @param {import('./texture.js').Texture} [options.colorBuffer] - The texture that this render
@@ -68,7 +63,7 @@ class RenderTarget {
      * renderTarget.destroy();
      * camera.renderTarget = null;
      */
-    constructor(options) {
+    constructor(options = {}) {
         this.id = id++;
 
         const _arg2 = arguments[1];
@@ -92,9 +87,8 @@ class RenderTarget {
         }
 
         // Process optional arguments
-        options = (options !== undefined) ? options : defaultOptions;
         this._depthBuffer = options.depthBuffer;
-        this._face = (options.face !== undefined) ? options.face : 0;
+        this._face = options.face ?? 0;
 
         if (this._depthBuffer) {
             const format = this._depthBuffer._format;
@@ -110,8 +104,8 @@ class RenderTarget {
                 this._stencil = false;
             }
         } else {
-            this._depth = (options.depth !== undefined) ? options.depth : true;
-            this._stencil = (options.stencil !== undefined) ? options.stencil : false;
+            this._depth = options.depth ?? true;
+            this._stencil = options.stencil ?? false;
         }
 
         // device, from one of the buffers
@@ -119,8 +113,9 @@ class RenderTarget {
         Debug.assert(device, "Failed to obtain the device, colorBuffer nor depthBuffer store it.");
         this._device = device;
 
-        this._samples = (options.samples !== undefined) ? Math.min(options.samples, this._device.maxSamples) : 1;
-        this.autoResolve = (options.autoResolve !== undefined) ? options.autoResolve : true;
+        this._samples = Math.min(options.samples ?? 1, this._device.maxSamples);
+
+        this.autoResolve = options.autoResolve ?? true;
 
         // use specified name, otherwise get one from color or depth buffer
         this.name = options.name;
@@ -135,7 +130,7 @@ class RenderTarget {
         }
 
         // render image flipped in Y
-        this.flipY = !!options.flipY;
+        this.flipY = options.flipY ?? false;
 
         // device specific implementation
         this.impl = device.createRenderTargetImpl(this);
@@ -201,7 +196,7 @@ class RenderTarget {
     }
 
     /**
-     * Initialises the resources associated with this render target.
+     * Initializes the resources associated with this render target.
      *
      * @ignore
      */

--- a/src/platform/graphics/texture.js
+++ b/src/platform/graphics/texture.js
@@ -118,7 +118,15 @@ class Texture {
      * Defaults to false.
      * @param {boolean} [options.volume] - Specifies whether the texture is to be a 3D volume
      * (WebGL2 only). Defaults to false.
-     * @param {string} [options.type] - Specifies the image type, see {@link TEXTURETYPE_DEFAULT}.
+     * @param {string} [options.type] - Specifies the texture type.  Can be:
+     *
+     * - {@link TEXTURETYPE_DEFAULT}
+     * - {@link TEXTURETYPE_RGBM}
+     * - {@link TEXTURETYPE_RGBE}
+     * - {@link TEXTURETYPE_RGBP}
+     * - {@link TEXTURETYPE_SWIZZLEGGGR}
+     *
+     * Defaults to {@link TEXTURETYPE_DEFAULT}.
      * @param {boolean} [options.fixCubemapSeams] - Specifies whether this cubemap texture requires
      * special seam fixing shader code to look right. Defaults to false.
      * @param {boolean} [options.flipY] - Specifies whether the texture should be flipped in the

--- a/src/platform/graphics/texture.js
+++ b/src/platform/graphics/texture.js
@@ -172,6 +172,9 @@ class Texture {
         this._width = options.width ?? 4;
         this._height = options.height ?? 4;
 
+        this._format = options.format ?? PIXELFORMAT_RGBA8;
+        this._compressed = isCompressedPixelFormat(this._format);
+
         if (graphicsDevice.webgl2) {
             this._volume = options.volume ?? false;
             this._depth = options.depth ?? 1;
@@ -179,9 +182,6 @@ class Texture {
             this._volume = false;
             this._depth = 1;
         }
-
-        this._format = options.format ?? PIXELFORMAT_RGBA8;
-        this._compressed = isCompressedPixelFormat(this._format);
 
         this._cubemap = options.cubemap ?? false;
         this.fixCubemapSeams = options.fixCubemapSeams ?? false;

--- a/src/platform/graphics/texture.js
+++ b/src/platform/graphics/texture.js
@@ -30,12 +30,34 @@ let id = 0;
  */
 class Texture {
     /**
+     * The name of the texture.
+     *
+     * @type {string}
+     */
+    name;
+
+    /** @protected */
+    _isRenderTarget = false;
+
+    /** @protected */
+    _gpuSize = 0;
+
+    /** @protected */
+    id = id++;
+
+    /** @protected */
+    _invalid = false;
+
+    /** @protected */
+    _lockedLevel = -1;
+
+    /**
      * Create a new Texture instance.
      *
      * @param {import('./graphics-device.js').GraphicsDevice} graphicsDevice - The graphics device
      * used to manage this texture.
      * @param {object} [options] - Object for passing optional arguments.
-     * @param {string} [options.name] - The name of the texture.
+     * @param {string} [options.name] - The name of the texture. Defaults to null.
      * @param {number} [options.width] - The width of the texture in pixels. Defaults to 4.
      * @param {number} [options.height] - The height of the texture in pixels. Defaults to 4.
      * @param {number} [options.depth] - The number of depth slices in a 3D texture (WebGL2 only).
@@ -76,7 +98,7 @@ class Texture {
      * - {@link TEXTUREPROJECTION_EQUIRECT}
      * - {@link TEXTUREPROJECTION_OCTAHEDRAL}
      *
-     * Defaults to {@link TEXTUREPROJECTION_CUBE} if options.cubemap is specified, otherwise
+     * Defaults to {@link TEXTUREPROJECTION_CUBE} if options.cubemap is true, otherwise
      * {@link TEXTUREPROJECTION_NONE}.
      * @param {number} [options.minFilter] - The minification filter type to use. Defaults to
      * {@link FILTER_LINEAR_MIPMAP_LINEAR}.
@@ -141,121 +163,70 @@ class Texture {
      * }
      * texture.unlock();
      */
-    constructor(graphicsDevice, options) {
-        this.id = id++;
+    constructor(graphicsDevice, options = {}) {
         this.device = graphicsDevice;
-        Debug.assert(this.device, "Texture contructor requires a graphicsDevice to be valid");
+        Debug.assert(this.device, "Texture constructor requires a graphicsDevice to be valid");
 
-        /**
-         * The name of the texture. Defaults to null.
-         *
-         * @type {string}
-         */
-        this.name = null;
+        this.name = options.name ?? null;
 
-        this._width = 4;
-        this._height = 4;
-        this._depth = 1;
+        this._width = options.width ?? 4;
+        this._height = options.height ?? 4;
 
-        this._format = PIXELFORMAT_RGBA8;
-        this.type = TEXTURETYPE_DEFAULT;
-        this.projection = TEXTUREPROJECTION_NONE;
-
-        this._cubemap = false;
-        this._volume = false;
-        this.fixCubemapSeams = false;
-        this._flipY = false;
-        this._premultiplyAlpha = false;
-
-        this._isRenderTarget = false;
-
-        this._mipmaps = true;
-
-        this._minFilter = FILTER_LINEAR_MIPMAP_LINEAR;
-        this._magFilter = FILTER_LINEAR;
-        this._anisotropy = 1;
-        this._addressU = ADDRESS_REPEAT;
-        this._addressV = ADDRESS_REPEAT;
-        this._addressW = ADDRESS_REPEAT;
-
-        this._compareOnRead = false;
-        this._compareFunc = FUNC_LESS;
-
-        // #if _PROFILER
-        this.profilerHint = 0;
-        // #endif
-
-        if (options !== undefined) {
-            if (options.name !== undefined) {
-                this.name = options.name;
-            }
-            this._width = (options.width !== undefined) ? options.width : this._width;
-            this._height = (options.height !== undefined) ? options.height : this._height;
-
-            this._format = (options.format !== undefined) ? options.format : this._format;
-
-            if (options.hasOwnProperty('type')) {
-                this.type = options.type;
-            } else if (options.hasOwnProperty('rgbm')) {
-                Debug.deprecated("options.rgbm is deprecated. Use options.type instead.");
-                this.type = options.rgbm ? TEXTURETYPE_RGBM : TEXTURETYPE_DEFAULT;
-            } else if (options.hasOwnProperty('swizzleGGGR')) {
-                Debug.deprecated("options.swizzleGGGR is deprecated. Use options.type instead.");
-                this.type = options.swizzleGGGR ? TEXTURETYPE_SWIZZLEGGGR : TEXTURETYPE_DEFAULT;
-            }
-
-            if (options.mipmaps !== undefined) {
-                this._mipmaps = options.mipmaps;
-            } else {
-                this._mipmaps = (options.autoMipmap !== undefined) ? options.autoMipmap : this._mipmaps;
-            }
-
-            this._levels = options.levels;
-
-            this._cubemap = (options.cubemap !== undefined) ? options.cubemap : this._cubemap;
-            this.fixCubemapSeams = (options.fixCubemapSeams !== undefined) ? options.fixCubemapSeams : this.fixCubemapSeams;
-
-            if (this._cubemap) {
-                this.projection = TEXTUREPROJECTION_CUBE;
-            } else if (options.projection && options.projection !== TEXTUREPROJECTION_CUBE) {
-                this.projection = options.projection;
-            }
-
-            this._minFilter = (options.minFilter !== undefined) ? options.minFilter : this._minFilter;
-            this._magFilter = (options.magFilter !== undefined) ? options.magFilter : this._magFilter;
-            this._anisotropy = (options.anisotropy !== undefined) ? options.anisotropy : this._anisotropy;
-            this._addressU = (options.addressU !== undefined) ? options.addressU : this._addressU;
-            this._addressV = (options.addressV !== undefined) ? options.addressV : this._addressV;
-
-            this._compareOnRead = (options.compareOnRead !== undefined) ? options.compareOnRead : this._compareOnRead;
-            this._compareFunc = (options._compareFunc !== undefined) ? options._compareFunc : this._compareFunc;
-
-            this._flipY = (options.flipY !== undefined) ? options.flipY : this._flipY;
-            this._premultiplyAlpha = (options.premultiplyAlpha !== undefined) ? options.premultiplyAlpha : this._premultiplyAlpha;
-
-            if (graphicsDevice.webgl2) {
-                this._depth = (options.depth !== undefined) ? options.depth : this._depth;
-                this._volume = (options.volume !== undefined) ? options.volume : this._volume;
-                this._addressW = (options.addressW !== undefined) ? options.addressW : this._addressW;
-            }
-
-            // #if _PROFILER
-            this.profilerHint = (options.profilerHint !== undefined) ? options.profilerHint : this.profilerHint;
-            // #endif
+        if (graphicsDevice.webgl2) {
+            this._volume = options.volume ?? false;
+            this._depth = options.depth ?? 1;
+        } else {
+            this._volume = false;
+            this._depth = 1;
         }
 
+        this._format = options.format ?? PIXELFORMAT_RGBA8;
         this._compressed = isCompressedPixelFormat(this._format);
 
-        // Mip levels
-        this._invalid = false;
-        this._lockedLevel = -1;
+        this._cubemap = options.cubemap ?? false;
+        this.fixCubemapSeams = options.fixCubemapSeams ?? false;
+        this._flipY = options.flipY ?? false;
+        this._premultiplyAlpha = options.premultiplyAlpha ?? false;
+
+        this._mipmaps = options.mipmaps ?? options.autoMipmap ?? true;
+        this._minFilter = options.minFilter ?? FILTER_LINEAR_MIPMAP_LINEAR;
+        this._magFilter = options.magFilter ?? FILTER_LINEAR;
+        this._anisotropy = options.anisotropy ?? 1;
+        this._addressU = options.addressU ?? ADDRESS_REPEAT;
+        this._addressV = options.addressV ?? ADDRESS_REPEAT;
+        this._addressW = options.addressW ?? ADDRESS_REPEAT;
+
+        this._compareOnRead = options.compareOnRead ?? false;
+        this._compareFunc = options.compareFunc ?? FUNC_LESS;
+
+        this.type = TEXTURETYPE_DEFAULT;
+        if (options.hasOwnProperty('type')) {
+            this.type = options.type;
+        } else if (options.hasOwnProperty('rgbm')) {
+            Debug.deprecated("options.rgbm is deprecated. Use options.type instead.");
+            this.type = options.rgbm ? TEXTURETYPE_RGBM : TEXTURETYPE_DEFAULT;
+        } else if (options.hasOwnProperty('swizzleGGGR')) {
+            Debug.deprecated("options.swizzleGGGR is deprecated. Use options.type instead.");
+            this.type = options.swizzleGGGR ? TEXTURETYPE_SWIZZLEGGGR : TEXTURETYPE_DEFAULT;
+        }
+
+        this.projection = TEXTUREPROJECTION_NONE;
+        if (this._cubemap) {
+            this.projection = TEXTUREPROJECTION_CUBE;
+        } else if (options.projection && options.projection !== TEXTUREPROJECTION_CUBE) {
+            this.projection = options.projection;
+        }
+
+        // #if _PROFILER
+        this.profilerHint = options.profilerHint ?? 0;
+        // #endif
+
+        this._levels = options.levels;
         if (!this._levels) {
             this._levels = this._cubemap ? [[null, null, null, null, null, null]] : [null];
         }
 
         this.dirtyAll();
-
-        this._gpuSize = 0;
 
         this.impl = graphicsDevice.createTextureImpl(this);
 

--- a/src/scene/procedural.js
+++ b/src/scene/procedural.js
@@ -1,6 +1,5 @@
 import { Vec2 } from '../core/math/vec2.js';
 import { Vec3 } from '../core/math/vec3.js';
-import { Debug } from '../core/debug.js';
 
 import {
     SEMANTIC_TANGENT, SEMANTIC_BLENDWEIGHT, SEMANTIC_BLENDINDICES,
@@ -306,13 +305,13 @@ function createMesh(device, positions, opts) {
  * @param {boolean} [opts.calculateTangents] - Generate tangent information (defaults to false).
  * @returns {Mesh} A new torus-shaped mesh.
  */
-function createTorus(device, opts) {
+function createTorus(device, opts = {}) {
     // Check the supplied options and provide defaults for unspecified ones
-    const rc = opts && opts.tubeRadius !== undefined ? opts.tubeRadius : 0.2;
-    const rt = opts && opts.ringRadius !== undefined ? opts.ringRadius : 0.3;
-    const segments = opts && opts.segments !== undefined ? opts.segments : 30;
-    const sides = opts && opts.sides !== undefined ? opts.sides : 20;
-    const calcTangents = opts && opts.calculateTangents !== undefined ? opts.calculateTangents : false;
+    const rc = opts.tubeRadius ?? 0.2;
+    const rt = opts.ringRadius ?? 0.3;
+    const segments = opts.segments ?? 30;
+    const sides = opts.sides ?? 20;
+    const calcTangents = opts.calculateTangents ?? false;
 
     // Variable declarations
     const positions = [];
@@ -603,20 +602,13 @@ function _createConeData(baseRadius, peakRadius, height, heightSegments, capSegm
  * @param {boolean} [opts.calculateTangents] - Generate tangent information (defaults to false).
  * @returns {Mesh} A new cylinder-shaped mesh.
  */
-function createCylinder(device, opts) {
-    // #if _DEBUG
-    if (opts && opts.hasOwnProperty('baseRadius') && !opts.hasOwnProperty('radius')) {
-        Debug.deprecated('"baseRadius" in arguments, use "radius" instead');
-    }
-    // #endif
-
+function createCylinder(device, opts = {}) {
     // Check the supplied options and provide defaults for unspecified ones
-    let radius = opts && (opts.radius || opts.baseRadius);
-    radius = radius !== undefined ? radius : 0.5;
-    const height = opts && opts.height !== undefined ? opts.height : 1.0;
-    const heightSegments = opts && opts.heightSegments !== undefined ? opts.heightSegments : 5;
-    const capSegments = opts && opts.capSegments !== undefined ? opts.capSegments : 20;
-    const calcTangents = opts && opts.calculateTangents !== undefined ? opts.calculateTangents : false;
+    const radius = opts.radius ?? 0.5;
+    const height = opts.height ?? 1;
+    const heightSegments = opts.heightSegments ?? 5;
+    const capSegments = opts.capSegments ?? 20;
+    const calcTangents = opts.calculateTangents ?? false;
 
     // Create vertex data for a cone that has a base and peak radius that is the same (i.e. a cylinder)
     const options = _createConeData(radius, radius, height, heightSegments, capSegments, false);
@@ -652,13 +644,13 @@ function createCylinder(device, opts) {
  * @param {boolean} [opts.calculateTangents] - Generate tangent information (defaults to false).
  * @returns {Mesh} A new cylinder-shaped mesh.
  */
-function createCapsule(device, opts) {
+function createCapsule(device, opts = {}) {
     // Check the supplied options and provide defaults for unspecified ones
-    const radius = opts && opts.radius !== undefined ? opts.radius : 0.3;
-    const height = opts && opts.height !== undefined ? opts.height : 1.0;
-    const heightSegments = opts && opts.heightSegments !== undefined ? opts.heightSegments : 1;
-    const sides = opts && opts.sides !== undefined ? opts.sides : 20;
-    const calcTangents = opts && opts.calculateTangents !== undefined ? opts.calculateTangents : false;
+    const radius = opts.radius ?? 0.3;
+    const height = opts.height ?? 1;
+    const heightSegments = opts.heightSegments ?? 1;
+    const sides = opts.sides ?? 20;
+    const calcTangents = opts.calculateTangents ?? false;
 
     // Create vertex data for a cone that has a base and peak radius that is the same (i.e. a cylinder)
     const options = _createConeData(radius, radius, height - 2 * radius, heightSegments, sides, true);
@@ -693,14 +685,14 @@ function createCapsule(device, opts) {
  * @param {boolean} [opts.calculateTangents] - Generate tangent information (defaults to false).
  * @returns {Mesh} A new cone-shaped mesh.
  */
-function createCone(device, opts) {
+function createCone(device, opts = {}) {
     // Check the supplied options and provide defaults for unspecified ones
-    const baseRadius = opts && opts.baseRadius !== undefined ? opts.baseRadius : 0.5;
-    const peakRadius = opts && opts.peakRadius !== undefined ? opts.peakRadius : 0.0;
-    const height = opts && opts.height !== undefined ? opts.height : 1.0;
-    const heightSegments = opts && opts.heightSegments !== undefined ? opts.heightSegments : 5;
-    const capSegments = opts && opts.capSegments !== undefined ? opts.capSegments : 18;
-    const calcTangents = opts && opts.calculateTangents !== undefined ? opts.calculateTangents : false;
+    const baseRadius = opts.baseRadius ?? 0.5;
+    const peakRadius = opts.peakRadius ?? 0;
+    const height = opts.height ?? 1;
+    const heightSegments = opts.heightSegments ?? 5;
+    const capSegments = opts.capSegments ?? 18;
+    const calcTangents = opts.calculateTangents ?? false;
 
     const options = _createConeData(baseRadius, peakRadius, height, heightSegments, capSegments, false);
 
@@ -732,12 +724,12 @@ function createCone(device, opts) {
  * @param {boolean} [opts.calculateTangents] - Generate tangent information (defaults to false).
  * @returns {Mesh} A new sphere-shaped mesh.
  */
-function createSphere(device, opts) {
+function createSphere(device, opts = {}) {
     // Check the supplied options and provide defaults for unspecified ones
-    const radius = opts && opts.radius !== undefined ? opts.radius : 0.5;
-    const latitudeBands = opts && opts.latitudeBands !== undefined ? opts.latitudeBands : 16;
-    const longitudeBands = opts && opts.longitudeBands !== undefined ? opts.longitudeBands : 16;
-    const calcTangents = opts && opts.calculateTangents !== undefined ? opts.calculateTangents : false;
+    const radius = opts.radius ?? 0.5;
+    const latitudeBands = opts.latitudeBands ?? 16;
+    const longitudeBands = opts.longitudeBands ?? 16;
+    const calcTangents = opts.calculateTangents ?? false;
 
     // Variable declarations
     const positions = [];
@@ -815,12 +807,12 @@ function createSphere(device, opts) {
  * @param {boolean} [opts.calculateTangents] - Generate tangent information (defaults to false).
  * @returns {Mesh} A new plane-shaped mesh.
  */
-function createPlane(device, opts) {
+function createPlane(device, opts = {}) {
     // Check the supplied options and provide defaults for unspecified ones
-    const he = opts && opts.halfExtents !== undefined ? opts.halfExtents : new Vec2(0.5, 0.5);
-    const ws = opts && opts.widthSegments !== undefined ? opts.widthSegments : 5;
-    const ls = opts && opts.lengthSegments !== undefined ? opts.lengthSegments : 5;
-    const calcTangents = opts && opts.calculateTangents !== undefined ? opts.calculateTangents : false;
+    const he = opts.halfExtents ?? new Vec2(0.5, 0.5);
+    const ws = opts.widthSegments ?? 5;
+    const ls = opts.lengthSegments ?? 5;
+    const calcTangents = opts.calculateTangents ?? false;
 
     // Variable declarations
     const positions = [];
@@ -898,13 +890,13 @@ function createPlane(device, opts) {
  * @param {boolean} [opts.calculateTangents] - Generate tangent information (defaults to false).
  * @returns {Mesh} A new box-shaped mesh.
  */
-function createBox(device, opts) {
+function createBox(device, opts = {}) {
     // Check the supplied options and provide defaults for unspecified ones
-    const he = opts && opts.halfExtents !== undefined ? opts.halfExtents : new Vec3(0.5, 0.5, 0.5);
-    const ws = opts && opts.widthSegments !== undefined ? opts.widthSegments : 1;
-    const ls = opts && opts.lengthSegments !== undefined ? opts.lengthSegments : 1;
-    const hs = opts && opts.heightSegments !== undefined ? opts.heightSegments : 1;
-    const calcTangents = opts && opts.calculateTangents !== undefined ? opts.calculateTangents : false;
+    const he = opts.halfExtents ?? new Vec3(0.5, 0.5, 0.5);
+    const ws = opts.widthSegments ?? 1;
+    const ls = opts.lengthSegments ?? 1;
+    const hs = opts.heightSegments ?? 1;
+    const calcTangents = opts.calculateTangents ?? false;
 
     const corners = [
         new Vec3(-he.x, -he.y, he.z),
@@ -1030,7 +1022,7 @@ function getShapePrimitive(device, type) {
         switch (type) {
 
             case 'box':
-                mesh = createBox(device, { halfExtents: new Vec3(0.5, 0.5, 0.5) });
+                mesh = createBox(device);
                 area = { x: 2, y: 2, z: 2, uv: (2.0 / 3) };
                 break;
 


### PR DESCRIPTION
Make further use of nullish coalescing (`??`) in the codebase. The `Texture` constructor in particular has been heavily simplified (by around 50%).

Mesh shape creation functions have also been simplified.

Minor breaking change:
* `baseRadius` option is now removed from `createCylinder` function. This was [deprecated in July 2017](https://github.com/playcanvas/engine/pull/973). This is highly unlikely to affect anybody.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
