### PR TITLE
Fix the destroy callback in Bloom

### DIFF
--- a/scripts/posteffects/posteffect-bloom.js
+++ b/scripts/posteffects/posteffect-bloom.js
@@ -296,5 +296,5 @@ Bloom.prototype.initialize = function () {
     this.on('destroy', function () {
         queue.removeEffect(this.effect);
         this.effect._destroy();
-    }, this);
+    });
 };

--- a/scripts/posteffects/posteffect-bloom.js
+++ b/scripts/posteffects/posteffect-bloom.js
@@ -295,6 +295,6 @@ Bloom.prototype.initialize = function () {
 
     this.on('destroy', function () {
         queue.removeEffect(this.effect);
-        this._destroy();
-    });
+        this.effect._destroy();
+    }, this);
 };


### PR DESCRIPTION
_destroy is defined in this.effect.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).