### PR TITLE
glb: bufferView can be undefined

### DIFF
--- a/src/framework/parsers/glb-parser.js
+++ b/src/framework/parsers/glb-parser.js
@@ -235,7 +235,7 @@ const getAccessorData = function (gltfAccessor, bufferViews, flatten = false) {
             }
         }
     } else {
-        if (gltfAccessor.bufferView) {
+        if (gltfAccessor.hasOwnProperty("bufferView")) {
             const bufferView = bufferViews[gltfAccessor.bufferView];
             if (flatten && bufferView.hasOwnProperty('byteStride')) {
                 // flatten stridden data
@@ -610,7 +610,6 @@ const createVertexBuffer = function (device, attributes, indices, accessors, buf
                 normalize: accessor.normalized
             };
         }
-        console.log(sourceDesc)
 
         // generate normals if they're missing (this should probably be a user option)
         if (!sourceDesc.hasOwnProperty(SEMANTIC_NORMAL)) {

--- a/src/framework/parsers/glb-parser.js
+++ b/src/framework/parsers/glb-parser.js
@@ -191,7 +191,6 @@ const getAccessorData = function (gltfAccessor, bufferViews, flatten = false) {
         return null;
     }
 
-    const bufferView = bufferViews[gltfAccessor.bufferView];
     let result;
 
     if (gltfAccessor.sparse) {
@@ -235,26 +234,33 @@ const getAccessorData = function (gltfAccessor, bufferViews, flatten = false) {
                 result[targetIndex * numComponents + j] = values[i * numComponents + j];
             }
         }
-    } else if (flatten && bufferView.hasOwnProperty('byteStride')) {
-        // flatten stridden data
-        const bytesPerElement = numComponents * dataType.BYTES_PER_ELEMENT;
-        const storage = new ArrayBuffer(gltfAccessor.count * bytesPerElement);
-        const tmpArray = new Uint8Array(storage);
-
-        let dstOffset = 0;
-        for (let i = 0; i < gltfAccessor.count; ++i) {
-            // no need to add bufferView.byteOffset because accessor takes this into account
-            let srcOffset = (gltfAccessor.byteOffset || 0) + i * bufferView.byteStride;
-            for (let b = 0; b < bytesPerElement; ++b) {
-                tmpArray[dstOffset++] = bufferView[srcOffset++];
-            }
-        }
-
-        result = new dataType(storage);
     } else {
-        result = new dataType(bufferView.buffer,
-                              bufferView.byteOffset + (gltfAccessor.byteOffset || 0),
-                              gltfAccessor.count * numComponents);
+        if (gltfAccessor.bufferView) {
+            const bufferView = bufferViews[gltfAccessor.bufferView];
+            if (flatten && bufferView.hasOwnProperty('byteStride')) {
+                // flatten stridden data
+                const bytesPerElement = numComponents * dataType.BYTES_PER_ELEMENT;
+                const storage = new ArrayBuffer(gltfAccessor.count * bytesPerElement);
+                const tmpArray = new Uint8Array(storage);
+
+                let dstOffset = 0;
+                for (let i = 0; i < gltfAccessor.count; ++i) {
+                    // no need to add bufferView.byteOffset because accessor takes this into account
+                    let srcOffset = (gltfAccessor.byteOffset || 0) + i * bufferView.byteStride;
+                    for (let b = 0; b < bytesPerElement; ++b) {
+                        tmpArray[dstOffset++] = bufferView[srcOffset++];
+                    }
+                }
+
+                result = new dataType(storage);
+            } else {
+                result = new dataType(bufferView.buffer,
+                                      bufferView.byteOffset + (gltfAccessor.byteOffset || 0),
+                                      gltfAccessor.count * numComponents);
+            }
+        } else {
+            result = new dataType(gltfAccessor.count * numComponents);
+        }
     }
 
     return result;
@@ -592,7 +598,7 @@ const createVertexBuffer = function (device, attributes, indices, accessors, buf
             const bufferView = bufferViews[accessor.bufferView];
             const semantic = gltfToEngineSemanticMap[attrib];
             const size = getNumComponents(accessor.type) * getComponentSizeInBytes(accessor.componentType);
-            const stride = bufferView.hasOwnProperty('byteStride') ? bufferView.byteStride : size;
+            const stride = bufferView && bufferView.hasOwnProperty('byteStride') ? bufferView.byteStride : size;
             sourceDesc[semantic] = {
                 buffer: accessorData.buffer,
                 size: size,
@@ -604,6 +610,7 @@ const createVertexBuffer = function (device, attributes, indices, accessors, buf
                 normalize: accessor.normalized
             };
         }
+        console.log(sourceDesc)
 
         // generate normals if they're missing (this should probably be a user option)
         if (!sourceDesc.hasOwnProperty(SEMANTIC_NORMAL)) {


### PR DESCRIPTION
Right now if bufferView of accessor is undefined the engine cannot parse glb.
As you can see [here](https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#_accessor_bufferview) bufferview is not required. PR fixes it.

Project example: https://playcanvas.com/editor/project/1041648

The custom build of the engine:
<img width="1026" alt="Screenshot 2023-02-20 at 18 56 26" src="https://user-images.githubusercontent.com/104348270/220139765-d9f6bcb6-32c9-4284-bd9c-15fa140131a0.png">

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
