### PR TITLE
[Fix] Adding early out for clustered lights to fix performance regression

### DIFF
--- a/src/scene/shader-lib/chunks/lit/frag/clusteredLight.js
+++ b/src/scene/shader-lib/chunks/lit/frag/clusteredLight.js
@@ -594,6 +594,10 @@ void addClusteredLights() {
 
                 // using a single channel texture with data in alpha channel
                 float lightIndex = texelFetch(clusterWorldTexture, ivec2(int(clusterU) + lightCellIndex, clusterV), 0).x;
+
+                if (lightIndex <= 0.0)
+                        return;
+
                 evaluateClusterLight(lightIndex * 255.0); 
             }
 


### PR DESCRIPTION
Fixes https://github.com/playcanvas/engine/issues/5087
Regression was introduced in https://github.com/playcanvas/engine/pull/5012