### PR TITLE
Add types to standard shader options to highlight their incorrect use

### DIFF
--- a/src/scene/shader-lib/programs/lit-shader.js
+++ b/src/scene/shader-lib/programs/lit-shader.js
@@ -55,6 +55,7 @@ class LitShader {
      * graphics device.
      * @param {import('../../../scene/materials/lit-options.js').LitOptions} options - The
      * lit options.
+     * @ignore
      */
     constructor(device, options) {
         this.device = device;

--- a/src/scene/shader-lib/programs/lit-shader.js
+++ b/src/scene/shader-lib/programs/lit-shader.js
@@ -50,6 +50,12 @@ const builtinVaryings = {
 };
 
 class LitShader {
+    /**
+     * @param {import('../../../platform/graphics/graphics-device.js').GraphicsDevice} device - The
+     * graphics device.
+     * @param {import('../../../scene/materials/lit-options.js').LitOptions} options - The
+     * lit options.
+     */
     constructor(device, options) {
         this.device = device;
         this.options = options;

--- a/src/scene/shader-lib/programs/standard.js
+++ b/src/scene/shader-lib/programs/standard.js
@@ -232,7 +232,13 @@ const standard = {
         }
     },
 
-    /** @type { Function } */
+    /**
+     * @param {import('../../../platform/graphics/graphics-device.js').GraphicsDevice} device - The
+     * graphics device.
+     * @param {StandardMaterialOptions} options - The create options.
+     * @returns {object} Returns the created shader definition.
+     * @ignore
+     */
     createShaderDefinition: function (device, options) {
         const litShader = new LitShader(device, options.litOptions);
 


### PR DESCRIPTION
This highlights the issue mentioned here: https://forum.playcanvas.com/t/what-is-this-error/29834

<img width="1057" alt="Screenshot 2023-02-22 at 11 02 57" src="https://user-images.githubusercontent.com/59932779/220601991-1884ecb4-efc3-4543-903a-7b5a3731d760.png">

but also other code that might not work as expected:

<img width="877" alt="Screenshot 2023-02-22 at 11 03 54" src="https://user-images.githubusercontent.com/59932779/220602208-5232b79c-3655-41db-94fd-bc35453412a3.png">

<img width="869" alt="Screenshot 2023-02-22 at 11 04 11" src="https://user-images.githubusercontent.com/59932779/220602227-a2087c2e-299c-48fa-861a-85c2fb0c27a1.png">
