### PR TITLE
Use highp samplers for clustered light data to avoid precision issues on some devices

### DIFF
--- a/src/scene/shader-lib/chunks/lit/frag/clusteredLight.js
+++ b/src/scene/shader-lib/chunks/lit/frag/clusteredLight.js
@@ -1,6 +1,6 @@
 export default /* glsl */`
-uniform sampler2D clusterWorldTexture;
-uniform sampler2D lightsTexture8;
+uniform highp sampler2D clusterWorldTexture;
+uniform highp sampler2D lightsTexture8;
 uniform highp sampler2D lightsTextureFloat;
 
 // complex ifdef expression are not supported, handle it here


### PR DESCRIPTION
Fixes all clustered lighting examples on my test device (Galaxy S10E with Exynos chipset).
Possibly fixes https://github.com/playcanvas/engine/issues/4969 but needs more testing on multiple devices.