### PR TITLE
Fix typo with lightMapVertexColors and refer to proper frontend option.

### DIFF
--- a/src/scene/shader-lib/programs/standard.js
+++ b/src/scene/shader-lib/programs/standard.js
@@ -450,8 +450,8 @@ const standard = {
             }
 
             // lightmap
-            if (options.litOptions.lightMapEnabled || options.lightMapVertexColors) {
-                const lightmapDir = (options.litOptions.dirLightMapEnabled && options.litOptions.useSpecular);
+            if (options.lightMap || options.lightVertexColor) {
+                const lightmapDir = (options.dirLightMap && options.litOptions.useSpecular);
                 const lightmapChunkPropName = lightmapDir ? 'lightmapDirPS' : 'lightmapSinglePS';
                 decl.append("vec3 dLightmap;");
                 if (lightmapDir) {


### PR DESCRIPTION
Fixes error with shader compilation with lightmaps enabled. The error is caused by using an option that lives in the lit options, but is presumed to also exist on the frontend options. 

Instead of using lit options, this PR changes that code to rely on the frontend options instead. 

This bug was caused by #4792. 