### PR TITLE
Fixes the type for nine sliced mode.

### DIFF
--- a/src/scene/materials/lit-options.js
+++ b/src/scene/materials/lit-options.js
@@ -71,7 +71,7 @@ class LitOptions {
 
     useMorphTextureBased = false;
 
-    nineSlicedMode = false;
+    nineSlicedMode = 0;
 
     clusteredLightingEnabled = true;
 


### PR DESCRIPTION
Fixes nineSlicedMode being defined as a boolean in the options class.

