### PR TITLE
Convert local light shadow rendering to use render passes

### DIFF
--- a/src/framework/lightmapper/lightmapper.js
+++ b/src/framework/lightmapper/lightmapper.js
@@ -845,10 +845,12 @@ class Lightmapper {
     renderShadowMap(shadowMapRendered, casters, lightArray, bakeLight) {
 
         const light = bakeLight.light;
+        const isClustered = this.scene.clusteredLightingEnabled;
+
         if (!shadowMapRendered && light.castShadows) {
 
             // allocate shadow map from the cache to avoid per light allocation
-            if (!light.shadowMap && !this.scene.clusteredLightingEnabled) {
+            if (!light.shadowMap && !isClustered) {
                 light.shadowMap = this.shadowMapCache.get(this.device, light);
             }
 
@@ -857,7 +859,7 @@ class Lightmapper {
                 this.renderer.shadowRenderer.render(light, this.camera);
             } else {
                 this.renderer._shadowRendererLocal.cull(light, casters);
-                this.renderer.renderShadowsLocal(lightArray[light.type], this.camera);
+                this.renderer._shadowRendererLocal.render(lightArray[light.type], isClustered, this.camera);
             }
         }
 

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -416,23 +416,6 @@ class ForwardRenderer extends Renderer {
         }
     }
 
-    renderShadowsLocal(lights, camera) {
-
-        const isClustered = this.scene.clusteredLightingEnabled;
-
-        for (let i = 0; i < lights.length; i++) {
-            const light = lights[i];
-            Debug.assert(light._type !== LIGHTTYPE_DIRECTIONAL);
-
-            // skip clustered shadows with no assigned atlas slot
-            if (isClustered && !light.atlasViewportAllocated) {
-                continue;
-            }
-
-            this.shadowRenderer.render(light, camera);
-        }
-    }
-
     // execute first pass over draw calls, in order to update materials / shaders
     // TODO: implement this: https://developer.mozilla.org/en-US/docs/Web/API/WebGL_API/WebGL_best_practices#compile_shaders_and_link_programs_in_parallel
     // where instead of compiling and linking shaders, which is serial operation, we compile all of them and then link them, allowing the work to
@@ -814,42 +797,53 @@ class ForwardRenderer extends Renderer {
      */
     buildFrameGraph(frameGraph, layerComposition) {
 
+        const clusteredLightingEnabled = this.scene.clusteredLightingEnabled;
         frameGraph.reset();
 
         this.update(layerComposition);
 
-        const clusteredLightingEnabled = this.scene.clusteredLightingEnabled;
+        // clustered lighting render passes
         if (clusteredLightingEnabled) {
 
-            const renderPass = new RenderPass(this.device, () => {
-                // render cookies for all local visible lights
-                if (this.scene.lighting.cookiesEnabled) {
-                    this.renderCookies(layerComposition._splitLights[LIGHTTYPE_SPOT]);
-                    this.renderCookies(layerComposition._splitLights[LIGHTTYPE_OMNI]);
+            // cookies
+            {
+                const renderPass = new RenderPass(this.device, () => {
+                    // render cookies for all local visible lights
+                    if (this.scene.lighting.cookiesEnabled) {
+                        this.renderCookies(layerComposition._splitLights[LIGHTTYPE_SPOT]);
+                        this.renderCookies(layerComposition._splitLights[LIGHTTYPE_OMNI]);
+                    }
+                });
+                renderPass.requiresCubemaps = false;
+                DebugHelper.setName(renderPass, 'ClusteredCookies');
+                frameGraph.addRenderPass(renderPass);
+            }
+
+            // local shadows - these are shared by all cameras (not entirely correctly)
+            {
+                const renderPass = new RenderPass(this.device);
+                DebugHelper.setName(renderPass, 'ClusteredLocalShadows');
+                renderPass.requiresCubemaps = false;
+                frameGraph.addRenderPass(renderPass);
+
+                // render shadows only when needed
+                if (this.scene.lighting.shadowsEnabled) {
+                    const splitLights = layerComposition._splitLights;
+                    this._shadowRendererLocal.prepareClusteredRenderPass(renderPass, splitLights[LIGHTTYPE_SPOT], splitLights[LIGHTTYPE_OMNI]);
                 }
-            });
-            renderPass.requiresCubemaps = false;
-            DebugHelper.setName(renderPass, 'ClusteredCookies');
-            frameGraph.addRenderPass(renderPass);
+
+                // update clusters all the time
+                renderPass.after = () => {
+                    this.updateClusters(layerComposition);
+                };
+            }
+
+        } else {
+
+            // non-clustered local shadows - these are shared by all cameras (not entirely correctly)
+            const splitLights = layerComposition._splitLights;
+            this._shadowRendererLocal.buildNonClusteredRenderPasses(frameGraph, splitLights[LIGHTTYPE_SPOT], splitLights[LIGHTTYPE_OMNI]);
         }
-
-        // local shadows
-        const renderPass = new RenderPass(this.device, () => {
-
-            // render shadows for all local visible lights - these shadow maps are shared by all cameras
-            if (!clusteredLightingEnabled || (clusteredLightingEnabled && this.scene.lighting.shadowsEnabled)) {
-                this.renderShadowsLocal(layerComposition._splitLights[LIGHTTYPE_SPOT]);
-                this.renderShadowsLocal(layerComposition._splitLights[LIGHTTYPE_OMNI]);
-            }
-
-            // update light clusters
-            if (clusteredLightingEnabled) {
-                this.updateClusters(layerComposition);
-            }
-        });
-        renderPass.requiresCubemaps = false;
-        DebugHelper.setName(renderPass, 'LocalShadowMaps');
-        frameGraph.addRenderPass(renderPass);
 
         // main passes
         let startIndex = 0;


### PR DESCRIPTION
Render passes are used to render local light (spot & omni) shadows:
- for clustered lights, as those are all in a single shadow atlas, all shadows are rendered inside a single render pass
- for non-clustered lights, as those use shadow map each, each shadow map generates a render pass

Note that lightmapper does not use shadow passes, and so renders shadows using original solution not using render passes. Tested both in clustered and non-clustered mode.

This will allow the local shadows to be supported by WebGPU (separate PR).