### PR TITLE
WebGPU support to shadow atlas (shadow cascades + clustered shadows)

### DIFF
--- a/src/framework/app-base.js
+++ b/src/framework/app-base.js
@@ -1894,7 +1894,12 @@ class AppBase extends EventHandler {
      * @param {Layer} [layer] - The layer to render the texture into. Defaults to {@link LAYERID_IMMEDIATE}.
      * @ignore
      */
-    drawTexture(x, y, width, height, texture, material, layer = this.scene.defaultDrawLayer) {
+    drawTexture(x, y, width, height, texture, material, layer = this.scene.defaultDrawLayer, filterable = true) {
+
+        // only WebGPU supports filterable parameter to be false, allowing a depth texture / shadow
+        // map to be fetched (without filtering) and rendered
+        if (filterable === false && !this.graphicsDevice.isWebGPU)
+            return;
 
         // TODO: if this is used for anything other than debug texture display, we should optimize this to avoid allocations
         const matrix = new Mat4();
@@ -1903,7 +1908,7 @@ class AppBase extends EventHandler {
         if (!material) {
             material = new Material();
             material.setParameter("colorMap", texture);
-            material.shader = this.scene.immediate.getTextureShader();
+            material.shader = filterable ? this.scene.immediate.getTextureShader() : this.scene.immediate.getUnfilterableTextureShader();
             material.update();
         }
 

--- a/src/framework/app-base.js
+++ b/src/framework/app-base.js
@@ -1892,6 +1892,9 @@ class AppBase extends EventHandler {
      * @param {import('../platform/graphics/texture.js').Texture} texture - The texture to render.
      * @param {Material} material - The material used when rendering the texture.
      * @param {Layer} [layer] - The layer to render the texture into. Defaults to {@link LAYERID_IMMEDIATE}.
+     * @param {boolean} [filterable] - Indicate if the texture can be sampled using filtering.
+     * Passing false uses unfiltered sampling, allowing a depth texture to be sampled on WebGPU.
+     * Defaults to true.
      * @ignore
      */
     drawTexture(x, y, width, height, texture, material, layer = this.scene.defaultDrawLayer, filterable = true) {

--- a/src/platform/graphics/constants.js
+++ b/src/platform/graphics/constants.js
@@ -1010,9 +1010,9 @@ export const TEXTUREDIMENSION_CUBE = 'cube';
 export const TEXTUREDIMENSION_CUBE_ARRAY = 'cube-array';
 export const TEXTUREDIMENSION_3D = '3d';
 
-export const SAMPLETYPE_FLOAT = 'float';
-export const SAMPLETYPE_UNFILTERABLE_FLOAT = 'unfilterable-float';
-export const SAMPLETYPE_DEPTH = 'depth';
+export const SAMPLETYPE_FLOAT = 0;
+export const SAMPLETYPE_UNFILTERABLE_FLOAT = 1;
+export const SAMPLETYPE_DEPTH = 2;
 
 /**
  * Texture data is not stored a specific projection format.

--- a/src/platform/graphics/webgpu/webgpu-bind-group-format.js
+++ b/src/platform/graphics/webgpu/webgpu-bind-group-format.js
@@ -3,10 +3,15 @@ import { SAMPLETYPE_FLOAT, SAMPLETYPE_UNFILTERABLE_FLOAT, SAMPLETYPE_DEPTH } fro
 
 import { WebgpuUtils } from './webgpu-utils.js';
 
-const samplerTypes = { };
+const samplerTypes = [];
 samplerTypes[SAMPLETYPE_FLOAT] = 'filtering';
 samplerTypes[SAMPLETYPE_UNFILTERABLE_FLOAT] = 'non-filtering';
 samplerTypes[SAMPLETYPE_DEPTH] = 'comparison';
+
+const sampleTypes = [];
+sampleTypes[SAMPLETYPE_FLOAT] = 'float';
+sampleTypes[SAMPLETYPE_UNFILTERABLE_FLOAT] = 'unfilterable-float';
+sampleTypes[SAMPLETYPE_DEPTH] = 'depth';
 
 /**
  * A WebGPU implementation of the BindGroupFormat, which is a wrapper over GPUBindGroupLayout.
@@ -112,7 +117,10 @@ class WebgpuBindGroupFormat {
             const viewDimension = textureFormat.textureDimension;
             const multisampled = false;
 
-            key += `#${index}T:${visibility}-${sampleType}-${viewDimension}-${multisampled}`;
+            const gpuSampleType = sampleTypes[sampleType];
+            Debug.assert(gpuSampleType);
+
+            key += `#${index}T:${visibility}-${gpuSampleType}-${viewDimension}-${multisampled}`;
 
             entries.push({
                 binding: index++,
@@ -120,7 +128,7 @@ class WebgpuBindGroupFormat {
                 texture: {
                     // Indicates the type required for texture views bound to this binding.
                     // "float", "unfilterable-float", "depth", "sint", "uint",
-                    sampleType: sampleType,
+                    sampleType: gpuSampleType,
 
                     // Indicates the required dimension for texture views bound to this binding.
                     // "1d", "2d", "2d-array", "cube", "cube-array", "3d"
@@ -132,10 +140,10 @@ class WebgpuBindGroupFormat {
             });
 
             // sampler
-            const type = samplerTypes[sampleType];
-            Debug.assert(type);
+            const gpuSamplerType = samplerTypes[sampleType];
+            Debug.assert(gpuSamplerType);
 
-            key += `#${index}S:${visibility}-${type}`;
+            key += `#${index}S:${visibility}-${gpuSamplerType}`;
 
             entries.push({
                 binding: index++,
@@ -143,7 +151,7 @@ class WebgpuBindGroupFormat {
                 sampler: {
                     // Indicates the required type of a sampler bound to this bindings
                     // 'filtering', 'non-filtering', 'comparison'
-                    type: type
+                    type: gpuSamplerType
                 }
             });
         });

--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -457,12 +457,16 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
         // TODO: this condition should be removed, it's here to handle fake grab pass, which should be refactored instead
         if (this.passEncoder) {
 
+            if (!this.renderTarget.flipY) {
+                y = this.renderTarget.height - y - h;
+            }
+
             this.vx = x;
             this.vy = y;
             this.vw = w;
             this.vh = h;
 
-            this.passEncoder.setViewport(x, this.renderTarget.height - y - h, w, h, 0, 1);
+            this.passEncoder.setViewport(x, y, w, h, 0, 1);
         }
     }
 
@@ -472,12 +476,16 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
         // TODO: this condition should be removed, it's here to handle fake grab pass, which should be refactored instead
         if (this.passEncoder) {
 
+            if (!this.renderTarget.flipY) {
+                y = this.renderTarget.height - y - h;
+            }
+
             this.sx = x;
             this.sy = y;
             this.sw = w;
             this.sh = h;
 
-            this.passEncoder.setScissorRect(x, this.renderTarget.height - y - h, w, h);
+            this.passEncoder.setScissorRect(x, y, w, h);
         }
     }
 

--- a/src/platform/graphics/webgpu/webgpu-texture.js
+++ b/src/platform/graphics/webgpu/webgpu-texture.js
@@ -9,7 +9,7 @@ import {
     PIXELFORMAT_DEPTHSTENCIL, PIXELFORMAT_111110F, PIXELFORMAT_SRGB, PIXELFORMAT_SRGBA, PIXELFORMAT_ETC1,
     PIXELFORMAT_ETC2_RGB, PIXELFORMAT_ETC2_RGBA, PIXELFORMAT_PVRTC_2BPP_RGB_1, PIXELFORMAT_PVRTC_2BPP_RGBA_1,
     PIXELFORMAT_PVRTC_4BPP_RGB_1, PIXELFORMAT_PVRTC_4BPP_RGBA_1, PIXELFORMAT_ASTC_4x4, PIXELFORMAT_ATC_RGB,
-    PIXELFORMAT_ATC_RGBA, PIXELFORMAT_BGRA8
+    PIXELFORMAT_ATC_RGBA, PIXELFORMAT_BGRA8, SAMPLETYPE_UNFILTERABLE_FLOAT, SAMPLETYPE_DEPTH
 } from '../constants.js';
 
 // map of PIXELFORMAT_*** to GPUTextureFormat
@@ -72,10 +72,15 @@ class WebgpuTexture {
     view;
 
     /**
-     * @type {GPUSampler}
+     * An array of samplers, addressed by SAMPLETYPE_*** constant, allowing texture to be sampled
+     * using different samplers. Most textures are sampled as interpolated floats, but some can
+     * additionally be sampled using non-interpolated floats (raw data) or compare sampling
+     * (shadow maps).
+     *
+     * @type {GPUSampler[]}
      * @private
      */
-    sampler;
+    samplers = [];
 
     /**
      * @type {GPUTextureDescriptor}
@@ -184,15 +189,21 @@ class WebgpuTexture {
     }
 
     // TODO: handle the case where those properties get changed
+    // TODO: share a globl map of samplers. Possibly even use shared samplers for bind group,
+    // or maybe even have some attached in view bind group and use globally
 
     /**
      * @param {any} device - The Graphics Device.
+     * @param {number} [sampleType] - A sample type for the sampler, SAMPLETYPE_*** constant. If not
+     * specified, the sampler type is based on the texture format / texture sampling type.
      * @returns {any} - Returns the sampler.
      */
-    getSampler(device) {
-        if (!this.sampler) {
+    getSampler(device, sampleType) {
+        let sampler = this.samplers[sampleType];
+        if (!sampler) {
 
             const texture = this.texture;
+            let label;
 
             /** @type GPUSamplerDescriptor */
             const descr = {
@@ -201,30 +212,51 @@ class WebgpuTexture {
                 addressModeW: gpuAddressModes[texture.addressW]
             };
 
-            // TODO: this is temporary and needs to be made generic
-            if (this.texture.format === PIXELFORMAT_RGBA32F ||
-                this.texture.format === PIXELFORMAT_DEPTHSTENCIL ||
-                this.texture.format === PIXELFORMAT_RGBA16F) {
-                descr.magFilter = 'nearest';
-                descr.minFilter = 'nearest';
-                descr.mipmapFilter = 'nearest';
-            } else if (texture.compareOnRead) { // depth compare sampler
-                // TODO: depth texture can be exposed for sampling, not only compare sampling (for example debug
-                // rendering of depth). Find some good way to expose this, perhaps based on what sampling shader needs.
+            // default for compare sampling of texture
+            if (!sampleType && texture.compareOnRead) {
+                sampleType = SAMPLETYPE_DEPTH;
+            }
+
+            if (sampleType === SAMPLETYPE_DEPTH) {
+
+                // depth compare sampling
                 descr.compare = 'less';
                 descr.magFilter = 'linear';
                 descr.minFilter = 'linear';
+                label = 'Compare';
+
+            } else if (sampleType === SAMPLETYPE_UNFILTERABLE_FLOAT) {
+
+                // webgpu cannot currently filter float / half float textures
+                descr.magFilter = 'nearest';
+                descr.minFilter = 'nearest';
+                descr.mipmapFilter = 'nearest';
+                label = 'Unfilterable';
+
             } else {
-                descr.magFilter = 'linear';
-                descr.minFilter = 'linear';
-                descr.mipmapFilter = 'linear';
+
+                // TODO: this is temporary and needs to be made generic
+                if (this.texture.format === PIXELFORMAT_RGBA32F ||
+                    this.texture.format === PIXELFORMAT_DEPTHSTENCIL ||
+                    this.texture.format === PIXELFORMAT_RGBA16F) {
+                    descr.magFilter = 'nearest';
+                    descr.minFilter = 'nearest';
+                    descr.mipmapFilter = 'nearest';
+                    label = 'Nearest';
+                } else {
+                    descr.magFilter = 'linear';
+                    descr.minFilter = 'linear';
+                    descr.mipmapFilter = 'linear';
+                    label = 'Linear';
+                }
             }
 
-            this.sampler = device.wgpu.createSampler(descr);
-            DebugHelper.setLabel(this.sampler, `LinearSampler`);
+            sampler = device.wgpu.createSampler(descr);
+            DebugHelper.setLabel(sampler, label);
+            this.samplers[sampleType] = sampler;
         }
 
-        return this.sampler;
+        return sampler;
     }
 
     loseContext() {

--- a/src/platform/graphics/webgpu/webgpu-texture.js
+++ b/src/platform/graphics/webgpu/webgpu-texture.js
@@ -189,7 +189,7 @@ class WebgpuTexture {
     }
 
     // TODO: handle the case where those properties get changed
-    // TODO: share a globl map of samplers. Possibly even use shared samplers for bind group,
+    // TODO: share a global map of samplers. Possibly even use shared samplers for bind group,
     // or maybe even have some attached in view bind group and use globally
 
     /**

--- a/src/scene/immediate/immediate.js
+++ b/src/scene/immediate/immediate.js
@@ -82,52 +82,57 @@ class Immediate {
         return batches.getBatch(material, layer);
     }
 
-    // shared vertex shader for textured quad rendering
-    static getTextureVS() {
-        return `
-            attribute vec2 vertex_position;
-            uniform mat4 matrix_model;
-            varying vec2 uv0;
-            void main(void) {
-                gl_Position = matrix_model * vec4(vertex_position, 0, 1);
-                uv0 = vertex_position.xy + 0.5;
-            }
-        `;
+    getShader(id, fragment) {
+        if (!this[id]) {
+            // shared vertex shader for textured quad rendering
+            const vertex = `
+                attribute vec2 vertex_position;
+                uniform mat4 matrix_model;
+                varying vec2 uv0;
+                void main(void) {
+                    gl_Position = matrix_model * vec4(vertex_position, 0, 1);
+                    uv0 = vertex_position.xy + 0.5;
+                }
+            `;
+
+            this[id] = createShaderFromCode(this.device, vertex, fragment, `DebugShader:${id}`);
+        }
+        return this[id];
     }
 
     // shader used to display texture
     getTextureShader() {
-        if (!this.textureShader) {
-            const fshader = `
-                varying vec2 uv0;
-                uniform sampler2D colorMap;
-                void main (void) {
-                    gl_FragColor = vec4(texture2D(colorMap, uv0).xyz, 1);
-                }
-            `;
+        return this.getShader('textureShader', `
+            varying vec2 uv0;
+            uniform sampler2D colorMap;
+            void main (void) {
+                gl_FragColor = vec4(texture2D(colorMap, uv0).xyz, 1);
+            }
+        `);
+    }
 
-            this.textureShader = createShaderFromCode(this.device, Immediate.getTextureVS(), fshader, 'DebugTextureShader');
-        }
-
-        return this.textureShader;
+    // shader used to display infilterable texture sampled using texelFetch
+    getUnfilterableTextureShader() {
+        return this.getShader('textureShaderUnfilterable', `
+            varying vec2 uv0;
+            uniform highp sampler2D colorMap;
+            void main (void) {
+                ivec2 uv = ivec2(uv0 * textureSize(colorMap, 0));
+                gl_FragColor = vec4(texelFetch(colorMap, uv, 0).xyz, 1);
+            }
+        `);
     }
 
     // shader used to display depth texture
     getDepthTextureShader() {
-        if (!this.depthTextureShader) {
-            const fshader = `
-                ${shaderChunks.screenDepthPS}
-                varying vec2 uv0;
-                void main() {
-                    float depth = getLinearScreenDepth(uv0) * camera_params.x;
-                    gl_FragColor = vec4(vec3(depth), 1.0);
-                }
-            `;
-
-            this.depthTextureShader = createShaderFromCode(this.device, Immediate.getTextureVS(), fshader, 'DebugDepthTextureShader');
-        }
-
-        return this.depthTextureShader;
+        return this.getShader('depthTextureShader', `
+            ${shaderChunks.screenDepthPS}
+            varying vec2 uv0;
+            void main() {
+                float depth = getLinearScreenDepth(uv0) * camera_params.x;
+                gl_FragColor = vec4(vec3(depth), 1.0);
+            }
+        `);
     }
 
     // creates mesh used to render a quad

--- a/src/scene/lighting/light-texture-atlas.js
+++ b/src/scene/lighting/light-texture-atlas.js
@@ -135,7 +135,8 @@ class LightTextureAtlas {
         // shadow atlas texture
         const isShadowFilterPcf = true;
         const rt = this.shadowAtlas.renderTargets[0];
-        const shadowBuffer = (this.device.webgl2 && isShadowFilterPcf) ? rt.depthBuffer : rt.colorBuffer;
+        const isDepthShadow = (this.device.isWebGPU || this.device.webgl2) && isShadowFilterPcf;
+        const shadowBuffer = isDepthShadow ? rt.depthBuffer : rt.colorBuffer;
         this._shadowAtlasTextureId.setValue(shadowBuffer);
 
         // shadow atlas params

--- a/src/scene/renderer/renderer.js
+++ b/src/scene/renderer/renderer.js
@@ -664,7 +664,8 @@ class Renderer {
             this.viewBindGroupFormat = new BindGroupFormat(this.device, [
                 new BindBufferFormat(UNIFORM_BUFFER_DEFAULT_SLOT_NAME, SHADERSTAGE_VERTEX | SHADERSTAGE_FRAGMENT)
             ], [
-                new BindTextureFormat('lightsTextureFloat', SHADERSTAGE_FRAGMENT, TEXTUREDIMENSION_2D, SAMPLETYPE_UNFILTERABLE_FLOAT)
+                new BindTextureFormat('lightsTextureFloat', SHADERSTAGE_FRAGMENT, TEXTUREDIMENSION_2D, SAMPLETYPE_UNFILTERABLE_FLOAT),
+                new BindTextureFormat('lightsTexture8', SHADERSTAGE_FRAGMENT, TEXTUREDIMENSION_2D, SAMPLETYPE_UNFILTERABLE_FLOAT)
             ]);
         }
     }

--- a/src/scene/shader-lib/chunks/lit/frag/clusteredLight.js
+++ b/src/scene/shader-lib/chunks/lit/frag/clusteredLight.js
@@ -428,11 +428,11 @@ void evaluateLight(ClusterLightData light) {
                         getShadowCoordPerspZbufferNormalOffset(lightProjectionMatrix, shadowParams);
                         
                         #if defined(CLUSTER_SHADOW_TYPE_PCF1)
-                            float shadow = getShadowSpotClusteredPCF1(shadowAtlasTexture, shadowParams);
+                            float shadow = getShadowSpotClusteredPCF1(SHADOWMAP_PASS(shadowAtlasTexture), shadowParams);
                         #elif defined(CLUSTER_SHADOW_TYPE_PCF3)
-                            float shadow = getShadowSpotClusteredPCF3(shadowAtlasTexture, shadowParams);
+                            float shadow = getShadowSpotClusteredPCF3(SHADOWMAP_PASS(shadowAtlasTexture), shadowParams);
                         #elif defined(CLUSTER_SHADOW_TYPE_PCF5)
-                            float shadow = getShadowSpotClusteredPCF5(shadowAtlasTexture, shadowParams);
+                            float shadow = getShadowSpotClusteredPCF5(SHADOWMAP_PASS(shadowAtlasTexture), shadowParams);
                         #endif
                         dAtten *= mix(1.0, shadow, light.shadowIntensity);
 
@@ -442,11 +442,11 @@ void evaluateLight(ClusterLightData light) {
                         normalOffsetPointShadow(shadowParams);  // normalBias adjusted for distance
 
                         #if defined(CLUSTER_SHADOW_TYPE_PCF1)
-                            float shadow = getShadowOmniClusteredPCF1(shadowAtlasTexture, shadowParams, light.omniAtlasViewport, shadowEdgePixels, dLightDirW);
+                            float shadow = getShadowOmniClusteredPCF1(SHADOWMAP_PASS(shadowAtlasTexture), shadowParams, light.omniAtlasViewport, shadowEdgePixels, dLightDirW);
                         #elif defined(CLUSTER_SHADOW_TYPE_PCF3)
-                            float shadow = getShadowOmniClusteredPCF3(shadowAtlasTexture, shadowParams, light.omniAtlasViewport, shadowEdgePixels, dLightDirW);
+                            float shadow = getShadowOmniClusteredPCF3(SHADOWMAP_PASS(shadowAtlasTexture), shadowParams, light.omniAtlasViewport, shadowEdgePixels, dLightDirW);
                         #elif defined(CLUSTER_SHADOW_TYPE_PCF5)
-                            float shadow = getShadowOmniClusteredPCF5(shadowAtlasTexture, shadowParams, light.omniAtlasViewport, shadowEdgePixels, dLightDirW);
+                            float shadow = getShadowOmniClusteredPCF5(SHADOWMAP_PASS(shadowAtlasTexture), shadowParams, light.omniAtlasViewport, shadowEdgePixels, dLightDirW);
                         #endif
                         dAtten *= mix(1.0, shadow, light.shadowIntensity);
                     }

--- a/src/scene/shader-lib/chunks/lit/frag/clusteredLightShadows.js
+++ b/src/scene/shader-lib/chunks/lit/frag/clusteredLightShadows.js
@@ -5,7 +5,7 @@ export default /* glsl */`
 
     #if defined(CLUSTER_SHADOW_TYPE_PCF1)
 
-    float getShadowOmniClusteredPCF1(sampler2DShadow shadowMap, vec4 shadowParams, vec3 omniAtlasViewport, float shadowEdgePixels, vec3 dir) {
+    float getShadowOmniClusteredPCF1(SHADOWMAP_ACCEPT(shadowMap), vec4 shadowParams, vec3 omniAtlasViewport, float shadowEdgePixels, vec3 dir) {
 
         float shadowTextureResolution = shadowParams.x;
         vec2 uv = getCubemapAtlasCoordinates(omniAtlasViewport, shadowEdgePixels, shadowTextureResolution, dir);
@@ -18,28 +18,28 @@ export default /* glsl */`
 
     #if defined(CLUSTER_SHADOW_TYPE_PCF3)
 
-    float getShadowOmniClusteredPCF3(sampler2DShadow shadowMap, vec4 shadowParams, vec3 omniAtlasViewport, float shadowEdgePixels, vec3 dir) {
+    float getShadowOmniClusteredPCF3(SHADOWMAP_ACCEPT(shadowMap), vec4 shadowParams, vec3 omniAtlasViewport, float shadowEdgePixels, vec3 dir) {
 
         float shadowTextureResolution = shadowParams.x;
         vec2 uv = getCubemapAtlasCoordinates(omniAtlasViewport, shadowEdgePixels, shadowTextureResolution, dir);
 
         float shadowZ = length(dir) * shadowParams.w + shadowParams.z;
         dShadowCoord = vec3(uv, shadowZ);
-        return getShadowPCF3x3(shadowMap, shadowParams.xyz);
+        return getShadowPCF3x3(SHADOWMAP_PASS(shadowMap), shadowParams.xyz);
     }
 
     #endif
 
     #if defined(CLUSTER_SHADOW_TYPE_PCF5)
 
-    float getShadowOmniClusteredPCF5(sampler2DShadow shadowMap, vec4 shadowParams, vec3 omniAtlasViewport, float shadowEdgePixels, vec3 dir) {
+    float getShadowOmniClusteredPCF5(SHADOWMAP_ACCEPT(shadowMap), vec4 shadowParams, vec3 omniAtlasViewport, float shadowEdgePixels, vec3 dir) {
 
         float shadowTextureResolution = shadowParams.x;
         vec2 uv = getCubemapAtlasCoordinates(omniAtlasViewport, shadowEdgePixels, shadowTextureResolution, dir);
 
         float shadowZ = length(dir) * shadowParams.w + shadowParams.z;
         dShadowCoord = vec3(uv, shadowZ);
-        return getShadowPCF5x5(shadowMap, shadowParams.xyz);
+        return getShadowPCF5x5(SHADOWMAP_PASS(shadowMap), shadowParams.xyz);
     }
 
     #endif
@@ -101,7 +101,7 @@ export default /* glsl */`
 
     #if defined(CLUSTER_SHADOW_TYPE_PCF1)
 
-    float getShadowSpotClusteredPCF1(sampler2DShadow shadowMap, vec4 shadowParams) {
+    float getShadowSpotClusteredPCF1(SHADOWMAP_ACCEPT(shadowMap), vec4 shadowParams) {
         return textureShadow(shadowMap, dShadowCoord);
     }
 
@@ -109,16 +109,16 @@ export default /* glsl */`
 
     #if defined(CLUSTER_SHADOW_TYPE_PCF3)
 
-    float getShadowSpotClusteredPCF3(sampler2DShadow shadowMap, vec4 shadowParams) {
-        return getShadowSpotPCF3x3(shadowMap, shadowParams);
+    float getShadowSpotClusteredPCF3(SHADOWMAP_ACCEPT(shadowMap), vec4 shadowParams) {
+        return getShadowSpotPCF3x3(SHADOWMAP_PASS(shadowMap), shadowParams);
     }
 
     #endif
 
     #if defined(CLUSTER_SHADOW_TYPE_PCF5)
 
-    float getShadowSpotClusteredPCF5(sampler2DShadow shadowMap, vec4 shadowParams) {
-        return getShadowPCF5x5(shadowMap, shadowParams.xyz);
+    float getShadowSpotClusteredPCF5(SHADOWMAP_ACCEPT(shadowMap), vec4 shadowParams) {
+        return getShadowPCF5x5(SHADOWMAP_PASS(shadowMap), shadowParams.xyz);
     }
     #endif
 


### PR DESCRIPTION
- shadow shaders updated to work with WebGPU
- added a private way to display unfiltered texture for debugging, such as shadow map (WebGPU only) - this involved supporting multiple samplers per texture.
- handling renderTarget.flipY when rendering using a viewport (shadow atlas) by flipping viewport as well on WebGPU
- using WebGPU error scopes to report bind group validation errors with additional relevant data (used descriptors ...) to considerably improve understanding of those errors. To be used to validate other WeGPU APIs in the future. Based on https://toji.dev/webgpu-best-practices/error-handling

Missing for full support of clustered shadows:
- support to clear only part of the render target (viewport) - WebGPU does not have a clear function to do this, and it needs to be implemented using a quad draw. Separate PR. This is to handle a case where not all shadows are updated per frame, and so the whole render target cannot get cleared.

https://user-images.githubusercontent.com/59932779/222208711-cc3eea9a-fbd6-4555-9bee-6a59c3875f01.mov

