### PR TITLE
Removed setting material.blend as not needed by ParticleEmitter

### DIFF
--- a/src/scene/particle-system/particle-emitter.js
+++ b/src/scene/particle-system/particle-emitter.js
@@ -697,7 +697,6 @@ class ParticleEmitter {
         this.material.name = this.node.name;
         this.material.cull = CULLFACE_NONE;
         this.material.alphaWrite = false;
-        this.material.blend = true;
         this.material.blendType = this.blendType;
 
         this.material.depthWrite = this.depthWrite;


### PR DESCRIPTION
removed using deprecated property, as its not needed, setting blendType sets this automatically as needed