### PR TITLE
Alpha test fix

### DIFF
--- a/src/scene/renderer/renderer.js
+++ b/src/scene/renderer/renderer.js
@@ -505,6 +505,8 @@ class Renderer {
         // Alpha test
         if (material.opacityMap) {
             this.opacityMapId.setValue(material.opacityMap);
+        }
+        if (material.opacityMap || material.alphaTest > 0) {
             this.alphaTestId.setValue(material.alphaTest);
         }
     }


### PR DESCRIPTION
Fixes #5115 

The material alpha test value wasn't being set without an alpha map specified.
