### PR TITLE
WebGPU clear renderer, allowing render target clear using a quad rendering 

### DIFF
--- a/src/framework/lightmapper/lightmapper.js
+++ b/src/framework/lightmapper/lightmapper.js
@@ -842,7 +842,7 @@ class Lightmapper {
         light.visibleThisFrame = true;
     }
 
-    renderShadowMap(shadowMapRendered, casters, lightArray, bakeLight) {
+    renderShadowMap(shadowMapRendered, casters, bakeLight) {
 
         const light = bakeLight.light;
         const isClustered = this.scene.clusteredLightingEnabled;
@@ -856,11 +856,12 @@ class Lightmapper {
 
             if (light.type === LIGHTTYPE_DIRECTIONAL) {
                 this.renderer._shadowRendererDirectional.cull(light, casters, this.camera);
-                this.renderer.shadowRenderer.render(light, this.camera);
             } else {
                 this.renderer._shadowRendererLocal.cull(light, casters);
-                this.renderer._shadowRendererLocal.render(lightArray[light.type], isClustered, this.camera);
             }
+
+            const insideRenderPass = false;
+            this.renderer.shadowRenderer.render(light, this.camera, insideRenderPass);
         }
 
         return true;
@@ -1019,7 +1020,7 @@ class Lightmapper {
                     }
 
                     // render light shadow map needs to be rendered
-                    shadowMapRendered = this.renderShadowMap(shadowMapRendered, casters, lightArray, bakeLight);
+                    shadowMapRendered = this.renderShadowMap(shadowMapRendered, casters, bakeLight);
 
                     if (clusteredLightingEnabled) {
                         const clusterLights = lightArray[LIGHTTYPE_SPOT].concat(lightArray[LIGHTTYPE_OMNI]);
@@ -1083,7 +1084,7 @@ class Lightmapper {
 
                         // prepare clustered lighting
                         if (clusteredLightingEnabled) {
-                            this.worldClusters.activate(this.renderer.lightTextureAtlas);
+                            this.worldClusters.activate();
                         }
 
                         this.renderer._forwardTime = 0;

--- a/src/platform/graphics/constants.js
+++ b/src/platform/graphics/constants.js
@@ -1043,6 +1043,20 @@ export const TEXTUREPROJECTION_EQUIRECT = "equirect";
 export const TEXTUREPROJECTION_OCTAHEDRAL = "octahedral";
 
 /**
+ * Shader source code uses GLSL language.
+ *
+ * @type {string}
+ */
+export const SHADERLANGUAGE_GLSL = 'glsl';
+
+/**
+ * Shader source code uses WGSL language.
+ *
+ * @type {string}
+ */
+export const SHADERLANGUAGE_WGSL = 'wgsl';
+
+/**
  * Signed byte vertex element type.
  *
  * @type {number}

--- a/src/platform/graphics/graphics-device.js
+++ b/src/platform/graphics/graphics-device.js
@@ -6,6 +6,8 @@ import { BlendState } from './blend-state.js';
 
 import {
     BUFFER_STATIC,
+    CLEARFLAG_COLOR,
+    CLEARFLAG_DEPTH,
     PRIMITIVE_POINTS, PRIMITIVE_TRIFAN, SEMANTIC_POSITION, TYPE_FLOAT32
 } from './constants.js';
 import { ScopeSpace } from './scope-space.js';
@@ -141,6 +143,13 @@ class GraphicsDevice extends EventHandler {
      * @ignore
      */
     blendState = new BlendState();
+
+    defaultClearOptions = {
+        color: [0, 0, 0, 1],
+        depth: 1,
+        stencil: 0,
+        flags: CLEARFLAG_COLOR | CLEARFLAG_DEPTH
+    };
 
     constructor(canvas) {
         super();

--- a/src/platform/graphics/shader.js
+++ b/src/platform/graphics/shader.js
@@ -38,14 +38,17 @@ class Shader {
      * used to manage this shader.
      * @param {object} definition - The shader definition from which to build the shader.
      * @param {string} [definition.name] - The name of the shader.
-     * @param {Object<string, string>} definition.attributes - Object detailing the mapping of
+     * @param {Object<string, string>} [definition.attributes] - Object detailing the mapping of
      * vertex shader attribute names to semantics SEMANTIC_*. This enables the engine to match
-     * vertex buffer data as inputs to the shader.
+     * vertex buffer data as inputs to the shader. When not specified, rendering without
+     * verex buffer is assumed.
      * @param {string} definition.vshader - Vertex shader source (GLSL code).
      * @param {string} [definition.fshader] - Fragment shader source (GLSL code). Optional when
      * useTransformFeedback is specified.
      * @param {boolean} [definition.useTransformFeedback] - Specifies that this shader outputs
      * post-VS data to a buffer.
+     * @param {string} [definition.shaderLanguage] - Specifies the shader language of vertex and
+     * fragment shaders. Defaults to {@link SHADERLANGUAGE_GLSL}.
      * @example
      * // Create a shader that renders primitives with a solid red color
      * var shaderDefinition = {

--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -444,13 +444,6 @@ class WebglGraphicsDevice extends GraphicsDevice {
             });
         }
 
-        this.defaultClearOptions = {
-            color: [0, 0, 0, 1],
-            depth: 1,
-            stencil: 0,
-            flags: CLEARFLAG_COLOR | CLEARFLAG_DEPTH
-        };
-
         this.glAddress = [
             gl.REPEAT,
             gl.CLAMP_TO_EDGE,

--- a/src/platform/graphics/webgpu/webgpu-clear-renderer.js
+++ b/src/platform/graphics/webgpu/webgpu-clear-renderer.js
@@ -1,19 +1,149 @@
-import { Debug } from "../../../core/debug.js";
+import { Debug, DebugHelper } from "../../../core/debug.js";
+import { BindBufferFormat, BindGroupFormat } from "../bind-group-format.js";
+import { UniformBufferFormat, UniformFormat } from "../uniform-buffer-format.js";
+import { BlendState } from "../blend-state.js";
+import {
+    PRIMITIVE_TRISTRIP, SHADERLANGUAGE_WGSL, SHADERSTAGE_FRAGMENT, SHADERSTAGE_VERTEX,
+    UNIFORMTYPE_FLOAT, UNIFORMTYPE_VEC4, UNIFORM_BUFFER_DEFAULT_SLOT_NAME, BINDGROUP_MESH, CLEARFLAG_COLOR, CLEARFLAG_DEPTH, CLEARFLAG_STENCIL
+} from "../constants.js";
+import { Shader } from "../shader.js";
+import { BindGroup } from "../bind-group.js";
+import { UniformBuffer } from "../uniform-buffer.js";
+import { DebugGraphics } from "../debug-graphics.js";
+
+const primitive = {
+    type: PRIMITIVE_TRISTRIP,
+    base: 0,
+    count: 4,
+    indexed: false
+};
 
 /**
  * A WebGPU helper class implementing a viewport clear operation. When rendering to a texture,
  * the whole surface can be cleared using loadOp, but if only a viewport needs to be cleared, or if
  * it needs to be cleared later during the rendering, this need to be archieved by rendering a quad.
+ * This class renders a full-screen quad, and expects the viewport / scissor to be set up to clip
+ * it to only required area.
  *
  * @ignore
  */
 class WebgpuClearRenderer {
-    clear(device, renderTarget, options) {
+    constructor(device) {
 
-        // this needs to handle (by rendering a quad):
-        // - clearing of a viewport
-        // - clearing of full render target in the middle of the render pass
-        Debug.logOnce("WebgpuGraphicsDevice.clear not implemented.");
+        // shader that can write out color and depth values
+        const code = `
+
+            struct ub_mesh {
+                color : vec4f,
+                depth: f32
+            }
+
+            @group(0) @binding(0) var<uniform> ubMesh : ub_mesh;
+
+            var<private> pos : array<vec2f, 4> = array<vec2f, 4>(
+                vec2(-1.0, 1.0), vec2(1.0, 1.0),
+                vec2(-1.0, -1.0), vec2(1.0, -1.0)
+            );
+
+            struct VertexOutput {
+                @builtin(position) position : vec4f
+            }
+
+            @vertex
+            fn vertexMain(@builtin(vertex_index) vertexIndex : u32) -> VertexOutput {
+                var output : VertexOutput;
+                output.position = vec4(pos[vertexIndex], ubMesh.depth, 1.0);
+                return output;
+            }
+
+            @fragment
+            fn fragmentMain() -> @location(0) vec4f {
+                return ubMesh.color;
+            }
+        `;
+
+        this.shader = new Shader(device, {
+            name: 'WebGPUClearRendererShader',
+            shaderLanguage: SHADERLANGUAGE_WGSL,
+            vshader: code,
+            fshader: code
+        });
+
+        // uniforms
+        this.uniformBuffer = new UniformBuffer(device, new UniformBufferFormat(device, [
+            new UniformFormat('color', UNIFORMTYPE_VEC4),
+            new UniformFormat('depth', UNIFORMTYPE_FLOAT)
+        ]));
+
+        // format of the bind group
+        const bindGroupFormat = new BindGroupFormat(device, [
+            new BindBufferFormat(UNIFORM_BUFFER_DEFAULT_SLOT_NAME, SHADERSTAGE_VERTEX | SHADERSTAGE_FRAGMENT)
+        ]);
+
+        // bind group
+        this.bindGroup = new BindGroup(device, bindGroupFormat, this.uniformBuffer);
+        DebugHelper.setName(this.bindGroup, `ClearRenderer-BindGroup_${this.bindGroup.id}`);
+
+        // uniform data
+        this.colorData = new Float32Array(4);
+        this.colorId = device.scope.resolve('color');
+        this.depthId = device.scope.resolve('depth');
+
+
+        // TODO: WebGPU does not handle depth state, and so we pass this hack to render pipeline creation
+        // to avoid depth test (always write)
+        this.shader.impl.hackAlwaysWrite = true;
+    }
+
+    clear(device, renderTarget, options, defaultOptions) {
+        options = options || defaultOptions;
+
+        const flags = options.flags ?? defaultOptions.flags;
+        if (flags !== 0) {
+
+            DebugGraphics.pushGpuMarker(device, 'CLEAR-RENDERER');
+
+            // setup clear color
+            if ((flags & CLEARFLAG_COLOR) && renderTarget.colorBuffer) {
+                const color = options.color ?? defaultOptions.color;
+                this.colorData.set(color);
+
+                device.setBlendState(BlendState.DEFAULT);
+            } else {
+                device.setBlendState(BlendState.NOWRITE);
+            }
+            this.colorId.setValue(this.colorData);
+
+            // setup depth clear
+            if ((flags & CLEARFLAG_DEPTH) && renderTarget.depth) {
+                const depth = options.depth ?? defaultOptions.depth;
+                this.depthId.setValue(depth);
+
+                // TODO: set up depth state to write / not write to depth
+
+            } else {
+                this.depthId.setValue(1);
+            }
+
+            // setup stencil clear
+            if ((flags & CLEARFLAG_STENCIL) && renderTarget.stencil) {
+                Debug.warnOnce("ClearRenderer does not support stencil clear at the moment");
+            }
+
+            // render 4 verticies without vertex buffer
+            device.setShader(this.shader);
+
+            const bindGroup = this.bindGroup;
+            if (bindGroup.defaultUniformBuffer) {
+                bindGroup.defaultUniformBuffer.update();
+            }
+            bindGroup.update();
+            device.setBindGroup(BINDGROUP_MESH, bindGroup);
+
+            device.draw(primitive);
+
+            DebugGraphics.popGpuMarker(device);
+        }
     }
 }
 

--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -33,8 +33,10 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
 
     /**
      * Object responsible for clearing the rendering surface by rendering a quad.
+     *
+     * @type { WebgpuClearRenderer }
      */
-    clearRenderer = new WebgpuClearRenderer();
+    clearRenderer;
 
     /**
      * Render pipeline currently set on the device.
@@ -180,6 +182,8 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
 
         this.createFramebuffer();
 
+        this.clearRenderer = new WebgpuClearRenderer(this);
+
         this.postInit();
 
         return this;
@@ -264,15 +268,17 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
 
             // vertex buffers
             const vb0 = this.vertexBuffers[0];
-            const vbSlot = this.submitVertexBuffer(vb0, 0);
             const vb1 = this.vertexBuffers[1];
-            if (vb1) {
-                this.submitVertexBuffer(vb1, vbSlot);
+            if (vb0) {
+                const vbSlot = this.submitVertexBuffer(vb0, 0);
+                if (vb1) {
+                    this.submitVertexBuffer(vb1, vbSlot);
+                }
             }
             this.vertexBuffers.length = 0;
 
             // render pipeline
-            const pipeline = this.renderPipeline.get(primitive, vb0.format, vb1?.format, this.shader, this.renderTarget,
+            const pipeline = this.renderPipeline.get(primitive, vb0?.format, vb1?.format, this.shader, this.renderTarget,
                                                      this.bindGroupFormats, this.blendState);
             Debug.assert(pipeline);
 
@@ -286,9 +292,9 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
             if (ib) {
                 this.indexBuffer = null;
                 passEncoder.setIndexBuffer(ib.impl.buffer, ib.impl.format);
-                passEncoder.drawIndexed(ib.numIndices, numInstances, 0, 0, 0);
+                passEncoder.drawIndexed(primitive.count, numInstances, 0, 0, 0);
             } else {
-                passEncoder.draw(vb0.numVertices, numInstances, 0, 0);
+                passEncoder.draw(primitive.count, numInstances, 0, 0);
             }
         }
     }
@@ -424,7 +430,7 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
 
     clear(options) {
         if (options.flags) {
-            this.clearRenderer.clear(this, this.renderTarget, options);
+            this.clearRenderer.clear(this, this.renderTarget, options, this.defaultClearOptions);
         }
     }
 

--- a/src/platform/graphics/webgpu/webgpu-texture.js
+++ b/src/platform/graphics/webgpu/webgpu-texture.js
@@ -125,8 +125,23 @@ class WebgpuTexture {
             usage: GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC
         };
 
+        Debug.call(() => {
+            device.wgpu.pushErrorScope('validation');
+        });
+
         this.gpuTexture = wgpu.createTexture(this.descr);
         DebugHelper.setLabel(this.gpuTexture, `${texture.name}${texture.cubemap ? '[cubemap]' : ''}${texture.volume ? '[3d]' : ''}`);
+
+        Debug.call(() => {
+            device.wgpu.popErrorScope().then((error) => {
+                if (error) {
+                    Debug.gpuError(error.message, {
+                        descr: this.descr,
+                        texture
+                    });
+                }
+            });
+        });
 
         // default texture view descriptor
         let viewDescr;

--- a/src/platform/graphics/webgpu/webgpu-vertex-buffer-layout.js
+++ b/src/platform/graphics/webgpu/webgpu-vertex-buffer-layout.js
@@ -42,7 +42,7 @@ class WebgpuVertexBufferLayout {
     }
 
     getKey(vertexFormat0, vertexFormat1 = null) {
-        return vertexFormat0.renderingHashString + (vertexFormat1 ? vertexFormat1.renderingHashString : '');
+        return `VB[${vertexFormat0?.renderingHashString}, ${vertexFormat1?.renderingHashString}]`;
     }
 
     /**
@@ -81,10 +81,11 @@ class WebgpuVertexBufferLayout {
             }
         };
 
-        addFormat(vertexFormat0);
-        if (vertexFormat1) {
+        if (vertexFormat0)
+            addFormat(vertexFormat0);
+
+        if (vertexFormat1)
             addFormat(vertexFormat1);
-        }
 
         return layout;
     }

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -1098,7 +1098,7 @@ class ForwardRenderer extends Renderer {
             // if this is not a first render action to the render target, or if the render target was not
             // fully cleared on pass start, we need to execute clears here
             if (!firstRenderAction || !camera.camera.fullSizeClearRect) {
-                this.clear(renderAction, camera.camera);
+                this.clear(camera.camera, renderAction.clearColor, renderAction.clearDepth, renderAction.clearStencil);
             }
 
             // #if _PROFILER

--- a/src/scene/renderer/renderer.js
+++ b/src/scene/renderer/renderer.js
@@ -358,6 +358,7 @@ class Renderer {
 
     /**
      * Clears the active render target. If the viewport is already set up, only its area is cleared.
+     *
      * @param {import('../camera.js').Camera} camera - The camera supplying the value to clear to.
      * @param {boolean} [clearColor] - True if the color buffer should be cleared. Uses the value
      * from the camra if not supplied.

--- a/src/scene/renderer/renderer.js
+++ b/src/scene/renderer/renderer.js
@@ -234,7 +234,7 @@ class Renderer {
         let h = Math.floor(rect.w * pixelHeight);
         device.setViewport(x, y, w, h);
 
-        // by default clear is using viewport rectangle. Use scissor rectangle when required.
+        // use viewport rectangle by default. Use scissor rectangle when required.
         if (camera._scissorRectClear) {
             const scissorRect = camera.scissorRect;
             x = Math.floor(scissorRect.x * pixelWidth);
@@ -245,34 +245,6 @@ class Renderer {
         device.setScissor(x, y, w, h);
 
         DebugGraphics.popGpuMarker(device);
-    }
-
-    /**
-     * Clear the current render target, using currently set up viewport.
-     *
-     * @param {import('../composition/render-action.js').RenderAction} renderAction - Render action
-     * containing the clear flags.
-     * @param {import('../camera.js').Camera} camera - Camera containing the clear values.
-     */
-    clear(renderAction, camera) {
-
-        const flags = (renderAction.clearColor ? CLEARFLAG_COLOR : 0) |
-                      (renderAction.clearDepth ? CLEARFLAG_DEPTH : 0) |
-                      (renderAction.clearStencil ? CLEARFLAG_STENCIL : 0);
-
-        if (flags) {
-            const device = this.device;
-            DebugGraphics.pushGpuMarker(device, 'CLEAR-VIEWPORT');
-
-            device.clear({
-                color: [camera._clearColor.r, camera._clearColor.g, camera._clearColor.b, camera._clearColor.a],
-                depth: camera._clearDepth,
-                stencil: camera._clearStencil,
-                flags: flags
-            });
-
-            DebugGraphics.popGpuMarker(device);
-        }
     }
 
     setCameraUniforms(camera, target) {
@@ -384,6 +356,37 @@ class Renderer {
         return viewCount;
     }
 
+    /**
+     * Clears the active render target. If the viewport is already set up, only its area is cleared.
+     * @param {import('../camera.js').Camera} camera - The camera supplying the value to clear to.
+     * @param {boolean} [clearColor] - True if the color buffer should be cleared. Uses the value
+     * from the camra if not supplied.
+     * @param {boolean} [clearDepth] - True if the depth buffer should be cleared. Uses the value
+     * from the camra if not supplied.
+     * @param {boolean} [clearStencil] - True if the stencil buffer should be cleared. Uses the
+     * value from the camra if not supplied.
+     */
+    clear(camera, clearColor, clearDepth, clearStencil) {
+
+        const flags = ((clearColor ?? camera._clearColorBuffer) ? CLEARFLAG_COLOR : 0) |
+                      ((clearDepth ?? camera._clearDepthBuffer) ? CLEARFLAG_DEPTH : 0) |
+                      ((clearStencil ?? camera._clearStencilBuffer) ? CLEARFLAG_STENCIL : 0);
+
+        if (flags) {
+            const device = this.device;
+            DebugGraphics.pushGpuMarker(device, 'CLEAR');
+
+            device.clear({
+                color: [camera._clearColor.r, camera._clearColor.g, camera._clearColor.b, camera._clearColor.a],
+                depth: camera._clearDepth,
+                stencil: camera._clearStencil,
+                flags: flags
+            });
+
+            DebugGraphics.popGpuMarker(device);
+        }
+    }
+
     // make sure colorWrite is set to true to all channels, if you want to fully clear the target
     // TODO: this function is only used from outside of forward renderer, and should be deprecated
     // when the functionality moves to the render passes. Note that Editor uses it as well.
@@ -411,9 +414,9 @@ class Renderer {
         this.setupViewport(camera, target);
 
         if (clear) {
+
             // use camera clear options if any
             const options = camera._clearOptions;
-
             device.clear(options ? options : {
                 color: [camera._clearColor.r, camera._clearColor.g, camera._clearColor.b, camera._clearColor.a],
                 depth: camera._clearDepth,

--- a/src/scene/renderer/shadow-renderer-directional.js
+++ b/src/scene/renderer/shadow-renderer-directional.js
@@ -49,6 +49,15 @@ function getDepthRange(cameraViewMatrix, aabbMin, aabbMax) {
  * @ignore
  */
 class ShadowRendererDirectional {
+    /** @type {import('./renderer.js').Renderer} */
+    renderer;
+
+    /** @type {import('./shadow-renderer.js').ShadowRenderer} */
+    shadowRenderer;
+
+    /** @type {import('../../platform/graphics/graphics-device.js').GraphicsDevice} */
+    device;
+
     constructor(renderer, shadowRenderer) {
         this.renderer = renderer;
         this.shadowRenderer = shadowRenderer;

--- a/src/scene/renderer/shadow-renderer-local.js
+++ b/src/scene/renderer/shadow-renderer-local.js
@@ -15,6 +15,15 @@ class ShadowRendererLocal {
     // temporary list to collect lights to render shadows for
     shadowLights = [];
 
+    /** @type {import('./renderer.js').Renderer} */
+    renderer;
+
+    /** @type {import('./shadow-renderer.js').ShadowRenderer} */
+    shadowRenderer;
+
+    /** @type {import('../../platform/graphics/graphics-device.js').GraphicsDevice} */
+    device;
+
     constructor(renderer, shadowRenderer) {
         this.renderer = renderer;
         this.shadowRenderer = shadowRenderer;
@@ -78,21 +87,6 @@ class ShadowRendererLocal {
         }
     }
 
-    // render local shadows without render passes, used by the lightmapper
-    render(lights, isClustered, camera) {
-        for (let i = 0; i < lights.length; i++) {
-            const light = lights[i];
-            Debug.assert(light._type !== LIGHTTYPE_DIRECTIONAL);
-
-            // skip clustered shadows with no assigned atlas slot
-            if (isClustered && !light.atlasViewportAllocated) {
-                continue;
-            }
-
-            this.shadowRenderer.render(light, camera);
-        }
-    }
-
     prepareLights(shadowLights, lights) {
 
         let shadowCamera;
@@ -129,6 +123,7 @@ class ShadowRendererLocal {
         if (count) {
 
             // setup render pass using any of the cameras, they all have the same pass related properties
+            // Note that the render pass is set up to not clear the render target, as individual shadow maps clear it
             this.shadowRenderer.setupRenderPass(renderPass, shadowCamera, false);
 
             // render shadows inside the pass
@@ -146,41 +141,48 @@ class ShadowRendererLocal {
         }
     }
 
-    buildNonClusteredRenderPass(frameGraph, lights) {
-        for (let i = 0; i < lights.length; i++) {
-            const light = lights[i];
+    setupNonClusteredFaceRenderPass(frameGraph, light, face) {
 
-            if (this.shadowRenderer.needsShadowRendering(light)) {
+        const shadowCamera = this.shadowRenderer.prepareFace(light, null, face);
+        const renderPass = new RenderPass(this.device, () => {
+            this.shadowRenderer.renderFace(light, null, face, false);
+        });
 
-                let shadowCamera;
-                const faceCount = light.numShadowFaces;
-                for (let face = 0; face < faceCount; face++) {
-                    shadowCamera = this.shadowRenderer.prepareFace(light, null, face);
-                }
+        // clear the render target as well, as it contains a single shadow map
+        this.shadowRenderer.setupRenderPass(renderPass, shadowCamera, true);
+        DebugHelper.setName(renderPass, `SpotShadow-${light._node.name}`);
 
-                const renderPass = new RenderPass(this.device, () => {
-
-                    // inside the render pass, render all faces
-                    for (let face = 0; face < faceCount; face++) {
-                        this.shadowRenderer.renderFace(light, null, face, false);
-                    }
-                });
-
-                this.shadowRenderer.setupRenderPass(renderPass, shadowCamera, true);
-                DebugHelper.setName(renderPass, `LocalShadow-${light._node.name}`);
-
-                frameGraph.addRenderPass(renderPass);
-            }
-        }
+        frameGraph.addRenderPass(renderPass);
     }
 
     /**
-     * Prepare render passes for rendering of shadows for local non-clustered lights. Each shadow
+     * Prepare render passes for rendering of shadows for local non-clustered lights. Each shadow face
      * is a separate render pass as it renders to a separate render target.
      */
     buildNonClusteredRenderPasses(frameGraph, lightsSpot, lightsOmni) {
-        this.buildNonClusteredRenderPass(frameGraph, lightsSpot);
-        this.buildNonClusteredRenderPass(frameGraph, lightsOmni);
+
+        // spot lights
+        for (let i = 0; i < lightsSpot.length; i++) {
+            const light = lightsSpot[i];
+
+            if (this.shadowRenderer.needsShadowRendering(light)) {
+                this.setupNonClusteredFaceRenderPass(frameGraph, light, 0);
+            }
+        }
+
+        // omni lights
+        for (let i = 0; i < lightsOmni.length; i++) {
+            const light = lightsOmni[i];
+
+            if (this.shadowRenderer.needsShadowRendering(light)) {
+
+                // create render pass per face
+                const faceCount = light.numShadowFaces;
+                for (let face = 0; face < faceCount; face++) {
+                    this.setupNonClusteredFaceRenderPass(frameGraph, light, face);
+                }
+            }
+        }
     }
 }
 

--- a/src/scene/renderer/shadow-renderer-local.js
+++ b/src/scene/renderer/shadow-renderer-local.js
@@ -1,9 +1,9 @@
-import { Debug, DebugHelper } from '../../core/debug.js';
+import { DebugHelper } from '../../core/debug.js';
 import { math } from '../../core/math/math.js';
 
 import { ShadowMap } from './shadow-map.js';
 import {
-    LIGHTTYPE_DIRECTIONAL, LIGHTTYPE_OMNI, LIGHTTYPE_SPOT
+    LIGHTTYPE_OMNI, LIGHTTYPE_SPOT
 } from '../constants.js';
 
 import { RenderPass } from '../../platform/graphics/render-pass.js';

--- a/src/scene/renderer/shadow-renderer.js
+++ b/src/scene/renderer/shadow-renderer.js
@@ -344,17 +344,19 @@ class ShadowRenderer {
         const rt = shadowCamera.renderTarget;
         renderPass.init(rt);
 
-        // only clear the render pass target if all faces (cascades) are getting rendered
-        if (clearRenderTarget) {
-            // color
-            const clearColor = shadowCamera.clearColorBuffer;
-            renderPass.colorOps.clear = clearColor;
-            if (clearColor)
-                renderPass.colorOps.clearValue.copy(shadowCamera.clearColor);
+        renderPass.depthStencilOps.clearDepthValue = 1;
+        renderPass.depthStencilOps.clearDepth = clearRenderTarget;
 
-            // depth
-            renderPass.depthStencilOps.storeDepth = !clearColor;
-            renderPass.setClearDepth(1.0);
+        // if rendering to depth buffer
+        if (rt.depthBuffer) {
+
+            renderPass.depthStencilOps.storeDepth = true;
+
+        } else { // rendering to color buffer
+
+            renderPass.colorOps.clearValue.copy(shadowCamera.clearColor);
+            renderPass.colorOps.clear = clearRenderTarget;
+            renderPass.depthStencilOps.storeDepth = false;
         }
 
         // not sampling dynamically generated cubemaps
@@ -372,7 +374,7 @@ class ShadowRenderer {
         const shadowCam = lightRenderData.shadowCamera;
 
         // camera clear setting
-        // Note: when clustered lighting is the only light type, this code can be moved to createShadowCamera function
+        // Note: when clustered lighting is the only lighting type, this code can be moved to createShadowCamera function
         ShadowRenderer.setShadowCameraSettings(shadowCam, this.device, shadowType, type, isClustered);
 
         // assign render target for the face
@@ -382,7 +384,7 @@ class ShadowRenderer {
         return shadowCam;
     }
 
-    renderFace(light, camera, face, clear) {
+    renderFace(light, camera, face, clear, insideRenderPass = true) {
 
         const device = this.device;
 
@@ -392,25 +394,32 @@ class ShadowRenderer {
 
         DebugGraphics.pushGpuMarker(device, `SHADOW ${light._node.name} FACE ${face}`);
 
-        this.setupRenderState(device, light);
-
         const lightRenderData = this.getLightRenderData(light, camera, face);
         const shadowCam = lightRenderData.shadowCamera;
 
         this.dispatchUniforms(light, shadowCam, lightRenderData, face);
 
         const rt = shadowCam.renderTarget;
-        this.renderer.setCameraUniforms(shadowCam, rt);
+        const renderer = this.renderer;
+        renderer.setCameraUniforms(shadowCam, rt);
         if (device.supportsUniformBuffers) {
-            this.renderer.setupViewUniformBuffers(lightRenderData.viewBindGroups, this.viewUniformFormat, this.viewBindGroupFormat, 1);
+            renderer.setupViewUniformBuffers(lightRenderData.viewBindGroups, this.viewUniformFormat, this.viewBindGroupFormat, 1);
         }
 
-        // if this is called from a render pass, no clearing takes place
-        if (clear) {
-            this.renderer.clearView(shadowCam, rt, true, false);
+        if (insideRenderPass) {
+            renderer.setupViewport(shadowCam, rt);
+
+            // clear here is used to clear a viewport inside render target.
+            if (clear) {
+                renderer.clear(shadowCam);
+            }
         } else {
-            this.renderer.setupViewport(shadowCam, rt);
+
+            // this is only used by lightmapper, till it's converted to render passes
+            renderer.clearView(shadowCam, rt, true, false);
         }
+
+        this.setupRenderState(device, light);
 
         // render mesh instances
         this.submitCasters(lightRenderData.visibleCasters, light);
@@ -420,11 +429,11 @@ class ShadowRenderer {
         DebugGraphics.popGpuMarker(device);
 
         // #if _PROFILER
-        this.renderer._shadowMapTime += now() - shadowMapStartTime;
+        renderer._shadowMapTime += now() - shadowMapStartTime;
         // #endif
     }
 
-    render(light, camera) {
+    render(light, camera, insideRenderPass = true) {
 
         if (this.needsShadowRendering(light)) {
             const faceCount = light.numShadowFaces;
@@ -432,7 +441,7 @@ class ShadowRenderer {
             // render faces
             for (let face = 0; face < faceCount; face++) {
                 this.prepareFace(light, camera, face);
-                this.renderFace(light, camera, face, true);
+                this.renderFace(light, camera, face, true, insideRenderPass);
             }
 
             // apply vsm


### PR DESCRIPTION
WebGPU does not have built-in functionality to clear render target. The whole surface can easily be cleared at the start of the pass, but not at a later stage, and not when only a viewport needs to be cleared. For these cases, a ClearRenderer is implemented, which renders a quad and writes the initial values as needed.

Public API:
A **definition** parameter, used by the **Shader** constructor:
**definition.shaderLanguage** - can be SHADERLANGUAGE_GLSL or SHADERLANGUAGE_WGSL

- a WGSL shader is used for clear rendering, and a basic support for these shaders is added
- WebGPU rendering now supports rendering without Vertex Buffer (vertex is generated using VertexID in the shader)
- shadow rendering has been updated to support ClearRenderer, which is used to clear part of the atlas in clustered mode
- this now also makes MultiView example to work on WebGPU

Note: A small hack is used (hackAlwaysWrite) to work around the missing WebGPU implementation of DepthState. To be removed in a future PR.