### PR TITLE
Exposed MeshInstance.castShadow

### DIFF
--- a/src/scene/mesh-instance.js
+++ b/src/scene/mesh-instance.js
@@ -76,6 +76,26 @@ class Command {
  */
 class MeshInstance {
     /**
+     * Enable rendering for this mesh instance. Use visible property to enable/disable
+     * rendering without overhead of removing from scene. But note that the mesh instance is
+     * still in the hierarchy and still in the draw call list.
+     *
+     * @type {boolean}
+     */
+    visible = true;
+
+    /**
+     * Enable shadow casting for this mesh instance. Use this property to enable/disable
+     * shadow casting without overhead of removing from scene. Note that this property does not
+     * add the mesh instance to appropriate list of shadow casters on a {@link pc.Layer}, but
+     * allows mesh to be skipped from shadow casting while it is in the list already. Defaults to
+     * false.
+     *
+     * @type {boolean}
+     */
+    castShadow = false;
+
+    /**
      * @type {import('./materials/material.js').Material}
      * @private
      */
@@ -156,25 +176,16 @@ class MeshInstance {
         this._lightHash = 0;
 
         // Render options
-        /**
-         * Enable rendering for this mesh instance. Use visible property to enable/disable
-         * rendering without overhead of removing from scene. But note that the mesh instance is
-         * still in the hierarchy and still in the draw call list.
-         *
-         * @type {boolean}
-         */
-        this.visible = true;
         this.layer = LAYER_WORLD; // legacy
         /** @private */
         this._renderStyle = RENDERSTYLE_SOLID;
-        this.castShadow = false;
         this._receiveShadow = true;
         this._screenSpace = false;
         this._noDepthDrawGl1 = false;
 
         /**
          * Controls whether the mesh instance can be culled by frustum culling
-         * ({@link CameraComponent#frustumCulling}).
+         * ({@link CameraComponent#frustumCulling}). Defaults to true.
          *
          * @type {boolean}
          */

--- a/src/scene/renderer/shadow-renderer.js
+++ b/src/scene/renderer/shadow-renderer.js
@@ -158,10 +158,12 @@ class ShadowRenderer {
         for (let i = 0; i < numInstances; i++) {
             const meshInstance = meshInstances[i];
 
-            if (!meshInstance.cull || meshInstance._isVisible(camera)) {
-                meshInstance.visibleThisFrame = true;
-                visible[count] = meshInstance;
-                count++;
+            if (meshInstance.castShadow) {
+                if (!meshInstance.cull || meshInstance._isVisible(camera)) {
+                    meshInstance.visibleThisFrame = true;
+                    visible[count] = meshInstance;
+                    count++;
+                }
             }
         }
 


### PR DESCRIPTION
Fixed https://github.com/playcanvas/engine/issues/5117

- **MeshInstance.castShadow** is now public API
- MeshInstance.castShadow is used during shadow casters culling to skip meshes not casting shadows, allowing fast way to temporarily disable shadow casting, similarly to MeshInstance.visible.
