### PR TITLE
Optimized GPU cost if zero clustered lights

### DIFF
--- a/src/scene/lighting/world-clusters.js
+++ b/src/scene/lighting/world-clusters.js
@@ -113,6 +113,8 @@ class WorldClusters {
 
     registerUniforms(device) {
 
+        this._clusterSkipId = device.scope.resolve('clusterSkip');
+
         this._clusterMaxCellsId = device.scope.resolve('clusterMaxCells');
 
         this._clusterWorldTextureId = device.scope.resolve('clusterWorldTexture');
@@ -207,6 +209,9 @@ class WorldClusters {
     }
 
     updateUniforms() {
+
+        // skip clustered lights shader evaluation if only the dummy light exists
+        this._clusterSkipId.setValue(this._usedLights.length > 1 ? 0 : 1);
 
         this.lightsBuffer.updateUniforms();
 

--- a/src/scene/shader-lib/chunks/lit/frag/clusteredLight.js
+++ b/src/scene/shader-lib/chunks/lit/frag/clusteredLight.js
@@ -32,6 +32,9 @@ uniform highp sampler2D lightsTextureFloat;
     uniform vec4 lightsTextureInvSize;
 #endif
 
+// 1.0 if clustered lighting can be skipped (0 lights in the clusters)
+uniform float clusterSkip;
+
 uniform vec3 clusterCellsCountByBoundsSize;
 uniform vec3 clusterTextureSize;
 uniform vec3 clusterBoundsMin;
@@ -574,6 +577,11 @@ void evaluateClusterLight(float lightIndex) {
 }
 
 void addClusteredLights() {
+
+    // skip lights if no lights at all
+    if (clusterSkip > 0.5)
+        return;
+
     // world space position to 3d integer cell cordinates in the cluster structure
     vec3 cellCoords = floor((vPositionW - clusterBoundsMin) * clusterCellsCountByBoundsSize);
 


### PR DESCRIPTION
Fixed https://github.com/playcanvas/engine/issues/4762 (should at least, the case with no clustered lights). Not tested as no access to this HW.
Related to: https://github.com/playcanvas/engine/issues/4043

Skip all of the clustered light shader execution when there are 0 clustered lights. This should be very fast, as this is a uniform (constant) branch, and avoids few dynamic branches, which are slower on older HW.