### PR TITLE
Optimization to Morph.aabb calculation

### DIFF
--- a/src/scene/mesh-instance.js
+++ b/src/scene/mesh-instance.js
@@ -377,7 +377,8 @@ class MeshInstance {
 
                 // update local space bounding box by morph targets
                 if (this.mesh && this.mesh.morph) {
-                    localAabb._expand(this.mesh.morph.aabb.getMin(), this.mesh.morph.aabb.getMax());
+                    const morphAabb = this.mesh.morph.aabb;
+                    localAabb._expand(morphAabb.getMin(), morphAabb.getMax());
                 }
 
                 toWorldSpace = true;

--- a/src/scene/morph-target.js
+++ b/src/scene/morph-target.js
@@ -49,12 +49,7 @@ class MorphTarget {
         this._defaultWeight = options.defaultWeight || 0;
 
         // bounds
-        this.aabb = options.aabb;
-        if (!this.aabb) {
-            this.aabb = new BoundingBox();
-            if (options.deltaPositions)
-                this.aabb.compute(options.deltaPositions);
-        }
+        this._aabb = options.aabb;
 
         // store delta positions, used by aabb evaluation
         this.deltaPositions = options.deltaPositions;
@@ -91,6 +86,18 @@ class MorphTarget {
      */
     get defaultWeight() {
         return this._defaultWeight;
+    }
+
+    get aabb() {
+
+        // lazy evaluation, which allows us to skip this completely if customAABB is used
+        if (!this._aabb) {
+            this._aabb = new BoundingBox();
+            if (this.deltaPositions)
+                this._aabb.compute(this.deltaPositions);
+        }
+
+        return this._aabb;
     }
 
     get morphPositions() {


### PR DESCRIPTION
Aabb for MorphTarget and Morph are evaluated lazily, to avoid their calculation for cases those are not used:
- when mesh using the morph is also skinned (that has different path for aabb evaluation that takes bones into account)
- when a customAabb is set up for a render/model component, that uses morph

This saves around 40ms on skinned character with many morph targets on Pixel 3A device.