### PR TITLE
Precision of MorphTarget data can be specified

### DIFF
--- a/src/framework/handlers/container.js
+++ b/src/framework/handlers/container.js
@@ -145,6 +145,9 @@ class ContainerResource {
  * Additional options that can be passed for glTF files:
  * [options.morphPreserveData] - When true, the morph target keeps its data passed using the options,
  * allowing the clone operation.
+ * [options.morphPreferHighPrecision] - When true, high precision storage for morph targets should
+ * be prefered. This is faster to create and allows higher precision, but takes more memory and
+ * might be slower to render. Defaults to false.
  * [options.skipMeshes] - When true, the meshes from the container are not created. This can be
  * useful if you only need access to textures or animations and similar.
  *

--- a/src/framework/parsers/glb-parser.js
+++ b/src/framework/parsers/glb-parser.js
@@ -943,7 +943,9 @@ const createMesh = function (device, gltfMesh, accessors, bufferViews, callback,
                     targets.push(new MorphTarget(options));
                 });
 
-                mesh.morph = new Morph(targets, device);
+                mesh.morph = new Morph(targets, device, {
+                    preferHighPrecision: assetOptions.morphPreferHighPrecision
+                });
             }
         }
 


### PR DESCRIPTION
Currently, morph target can be stored in float or half float precision. Half float was preferred and used if available, as it uses less storage and bandwidth. It's slower to create, as float arrays need to be converted to half floats.

This PR allows to specify if high precision should be the preferred format, in order to optimise the startup time.

example:
```
const asset = new pc.Asset('model', 'container', { url: '/asset.glb' }, undefined, {
   morphPreferHighPrecision: true
});
```