### PR TITLE
Quat: add the setBetweenVectors method and tests for it

### DIFF
--- a/src/core/math/quat.js
+++ b/src/core/math/quat.js
@@ -104,14 +104,22 @@ class Quat {
      * Reports whether two quaternions are equal.
      *
      * @param {Quat} rhs - The quaternion to be compared against.
+     * @param {number} [epsilon] - The maximum difference between each component of the two quaternions.
      * @returns {boolean} True if the quaternions are equal and false otherwise.
      * @example
      * var a = new pc.Quat();
      * var b = new pc.Quat();
      * console.log("The two quaternions are " + (a.equals(b) ? "equal" : "different"));
      */
-    equals(rhs) {
-        return ((this.x === rhs.x) && (this.y === rhs.y) && (this.z === rhs.z) && (this.w === rhs.w));
+    equals(rhs, epsilon) {
+        if (epsilon === undefined) {
+            return ((this.x === rhs.x) && (this.y === rhs.y) && (this.z === rhs.z) && (this.w === rhs.w));
+        } else {
+            return (Math.abs(this.x - rhs.x) < epsilon) &&
+                   (Math.abs(this.y - rhs.y) < epsilon) &&
+                   (Math.abs(this.z - rhs.z) < epsilon) &&
+                   (Math.abs(this.w - rhs.w) < epsilon);
+        }
     }
 
     /**
@@ -532,6 +540,46 @@ class Quat {
                 this.y = (m21 + m12) * rs;
             }
         }
+
+        return this;
+    }
+
+    /**
+     * Set the quaternion that represents the shortest rotation from one direction to another.
+     *
+     * @param {import('./vec3').Vec3} from - The direction to rotate from. It should be normalized.
+     * @param {import('./vec3').Vec3} to - The direction to rotate to. It should be normalized.
+     * @returns {Quat} Self for chaining.
+     *
+     * Prood of correctness: https://www.xarg.org/proof/quaternion-from-two-vectors/
+     */
+    setBetweenVectors(from, to) {
+        let dotProduct = 1 + from.dot(to);
+
+        if (dotProduct < Number.EPSILON) {
+            // the vectors point in opposite directions
+            // so we need to rotate 180 degrees around an arbitrary orthogonal axis
+
+            if (Math.abs(from.x) > Math.abs(from.y)) {
+                this.x = -from.z;
+                this.y = 0;
+                this.z = from.x;
+                this.w = 0;
+            } else {
+                this.x = 0;
+                this.y = -from.z;
+                this.z = from.y;
+                this.w = 0;
+            }
+        } else {
+            // cross product between the two vectors
+            this.x = from.y * to.z - from.z * to.y;
+            this.y = from.z * to.x - from.x * to.z;
+            this.z = from.x * to.y - from.y * to.x;
+            this.w = dotProduct;
+        }
+
+        this.normalize();
 
         return this;
     }

--- a/test/core/math/quat.test.mjs
+++ b/test/core/math/quat.test.mjs
@@ -95,6 +95,19 @@ describe('Quat', function () {
             expect(q1.equals(q2)).to.be.false;
         });
 
+        it('checks for equality of two different quaternions that are close enough', function () {
+            const q1 = new Quat(0.1, 0.2, 0.3, 0.4);
+            const q2 = new Quat(0.10000000000000001, 0.2, 0.3, 0.4);
+            const epsilon = 0.000001;
+            expect(q1.equals(q2, epsilon)).to.be.true;
+
+            const q3 = new Quat(0.1 + epsilon - Number.EPSILON, 0.2, 0.3, 0.4);
+            expect(q1.equals(q3, epsilon)).to.be.true;
+
+            const q4 = new Quat(0.1 + epsilon + Number.EPSILON, 0.2, 0.3, 0.4);
+            expect(q1.equals(q4, epsilon)).to.be.false;
+        });
+
     });
 
     describe('#getAxisAngle()', function () {
@@ -544,6 +557,56 @@ describe('Quat', function () {
             const q = new Quat();
             const m = new Mat4();
             expect(q.setFromMat4(m)).to.equal(q);
+        });
+
+    });
+
+    describe('#setBetweenVectors()', function () {
+
+        it('set the identity quaternion between equal directions', function () {
+            const v1 = new Vec3(1, 0, 0);
+            const v2 = new Vec3(1, 0, 0);
+
+            const q1 = new Quat().setBetweenVectors(v1, v2);
+            expect(q1.equals(Quat.IDENTITY)).to.be.true;
+
+
+            const v3 = new Vec3(0, 0, 0);
+            const v4 = new Vec3(0, 0, 0);
+
+            const q2 = new Quat().setBetweenVectors(v3, v4);
+            expect(q2.equals(Quat.IDENTITY)).to.be.true;
+        });
+
+        it('set the quaternion between different direction', function () {
+            const epsilon = 0.00001;
+
+            const v1 = new Vec3(1, 0, 0);
+            const v2 = new Vec3(0, 1, 0);
+
+            const q1 = new Quat().setBetweenVectors(v1, v2);
+            const q2 = new Quat().setFromEulerAngles(0, 0, 90);
+
+            expect(q1.equals(q2, epsilon)).to.be.true;
+
+            const v3 = new Vec3(1, 0, 0);
+            const v4 = new Vec3(1, 1, 0).normalize();
+
+            const q3 = new Quat().setBetweenVectors(v3, v4);
+            const q4 = new Quat().setFromEulerAngles(0, 0, 45);
+
+            expect(q3.equals(q4, epsilon)).to.be.true;
+
+            const q5 = new Quat().setFromEulerAngles(0, 0, 44);
+            expect(q3.equals(q5, epsilon)).to.be.false;
+
+        });
+
+        it('returns this', function () {
+            const q = new Quat();
+            const v1 = new Vec3();
+            const v2 = new Vec3();
+            expect(q.setBetweenVectors(v1, v2)).to.equal(q);
         });
 
     });


### PR DESCRIPTION
I have just read the next tweet: https://twitter.com/dejohn_paul/status/1633470425870004228

When I did a gizmo it was handy to have a function that returns a quaternion between two vectors. It'd help the author of the tweet.

So, MR adds the `setBetweenVectors` method to the quaternion class. It also adds second epsilon parameters to Quat.equals, that is used to compare almost equal quaternions.

NOTE: right now, `Quat.equals` considers `new Quat(0.1, 0.2, 0.3, 0.4)` and  `new Quat(-0.1, -0.2, -0.3, -0.4)` as non-equal that is not correct in semantic. Should we fix it?