### PR TITLE
Fix for blend tree animations

### DIFF
--- a/src/framework/components/anim/component.js
+++ b/src/framework/components/anim/component.js
@@ -370,11 +370,18 @@ class AnimComponent extends Component {
         }
         this._layers = [];
 
+        let containsBlendTree = false;
         for (let i = 0; i < stateGraph.layers.length; i++) {
             const layer = stateGraph.layers[i];
             this._addLayer.bind(this)({ ...layer });
+            if (layer.states.some(state => state.blendTree)) {
+                containsBlendTree = true;
+            }
         }
-        this.setupAnimationAssets();
+        // blend trees do not support the automatic assignment of animation assets
+        if (!containsBlendTree) {
+            this.setupAnimationAssets();
+        }
     }
 
     setupAnimationAssets() {


### PR DESCRIPTION
The anim component should not attempt to automatically assign animations to a state graph which contains blend trees. These are not yet supported in the editor and so require users to manually assign animations to each blend tree node. Exposing blend trees in the editor will require further design work to the anim component.

Recent changes to the anim component to assign empty states with animation tracks led to the anim component attempting to begin playing incomplete blend trees.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
