### PR TITLE
[Examples Browser] Mini stats fix

### DIFF
--- a/examples/scripts/iframe/index.mustache
+++ b/examples/scripts/iframe/index.mustache
@@ -105,7 +105,7 @@
                 }).observe(canvasContainerElement);
             }
 
-            if ({{miniStats}}) {
+            if ({{miniStats}} && app.graphicsDevice.deviceType !== 'webgpu') {
                 // set up miniStats
                 var miniStats = new pcx.MiniStats(app);
                 if (urlParams.get('miniStats') === 'false') {
@@ -191,12 +191,18 @@
                     }
                 }
             });
+
             window.exampleFunction.apply(this, args);
-            if (pc.app && pc.app.graphicsDevice.canvas) {
-                setupApplication(pc.app);
+
+            const pollHandler = setInterval(appCreationPoll, 50);
+            function appCreationPoll() {
+                if (pc.app && pc.app.graphicsDevice.canvas) {
+                    clearInterval(pollHandler);
+                    setupApplication(pc.app);
+                    var event = new CustomEvent("exampleLoad");
+                    window.top.dispatchEvent(event);
+                }
             }
-            var event = new CustomEvent("exampleLoad");
-            window.top.dispatchEvent(event);
         }
     </script>
     <script>

--- a/examples/src/app/example.tsx
+++ b/examples/src/app/example.tsx
@@ -51,16 +51,9 @@ class ControlLoader extends Component <ControlLoaderProps, ControlLoaderState> {
                 exampleLoaded: true
             });
 
-
-            const pollHandler = setInterval(appCreationPoll, 50);
-            function appCreationPoll() {
-                if ((window as any).pc.app) {
-                    clearInterval(pollHandler);
-                    const app: { graphicsDevice: { deviceType: string } } = (window as any).pc.app;
-                    const activeDevice = app.graphicsDevice.deviceType;
-                    controlsObserver.emit('updateActiveDevice', activeDevice);
-                }
-            }
+            const app: { graphicsDevice: { deviceType: string } } = (window as any).pc.app;
+            const activeDevice = app.graphicsDevice.deviceType;
+            controlsObserver.emit('updateActiveDevice', activeDevice);
         });
     }
 
@@ -152,6 +145,7 @@ class Example extends Component <ExampleProps, ExampleState> {
             this.deviceTypeSelectInput.value = value;
         }
         this.setDisabledOptions(this.preferredGraphicsDevice, value);
+        document.getElementById('showMiniStatsButton').ui.enabled = value !== DEVICETYPE_WEBGPU;
     };
 
     onSetPreferredGraphicsDevice = (value: string) => {


### PR DESCRIPTION
Some examples now asynchronously create the application's graphics device. Mini stats should always be initialised after this has completed. It also doesn't yet support the WebGPU graphics device type, so the mini stats option has been disabled while that device type is active:
<img width="865" alt="image" src="https://user-images.githubusercontent.com/1721533/225649494-2976a0ff-8e00-4465-959d-04b784d7511d.png">

Fixes #5082


I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
