### PR TITLE
WebGPU - fix rendering with single-sampled framebuffer

### DIFF
--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -243,9 +243,7 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
         this.initRenderTarget(rt);
 
         // assign current frame's render texture
-        if (outColorBuffer) {
-            wrt.assignColorTexture(outColorBuffer);
-        }
+        wrt.assignColorTexture(outColorBuffer);
 
         WebgpuDebug.end(this);
         WebgpuDebug.end(this);
@@ -411,6 +409,8 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
         Debug.assert(rt);
 
         this.renderTarget = rt;
+
+        /** @type {WebgpuRenderTarget} */
         const wrt = rt.impl;
 
         WebgpuDebug.internal(this);

--- a/src/platform/graphics/webgpu/webgpu-render-target.js
+++ b/src/platform/graphics/webgpu/webgpu-render-target.js
@@ -243,7 +243,8 @@ class WebgpuRenderTarget {
             colorAttachment.view = colorView;
         }
 
-        if (colorAttachment.view) {
+        // if we have color buffer, or at least a format (main framebuffer that get assigned later)
+        if (colorAttachment.view || this.colorFormat) {
             this.renderPassDescriptor.colorAttachments.push(colorAttachment);
         }
 

--- a/src/platform/graphics/webgpu/webgpu-render-target.js
+++ b/src/platform/graphics/webgpu/webgpu-render-target.js
@@ -243,7 +243,7 @@ class WebgpuRenderTarget {
             colorAttachment.view = colorView;
         }
 
-        // if we have color buffer, or at least a format (main framebuffer that get assigned later)
+        // if we have color a buffer, or at least a format (main framebuffer that gets assigned later)
         if (colorAttachment.view || this.colorFormat) {
             this.renderPassDescriptor.colorAttachments.push(colorAttachment);
         }


### PR DESCRIPTION
multisampled framebuffer was used and maintained, single-sampled got broken in the meantime.