### PR TITLE
Http arrayBuffer fix

### DIFF
--- a/src/platform/net/http.js
+++ b/src/platform/net/http.js
@@ -535,12 +535,12 @@ class Http {
         }
         try {
             // Check the content type to see if we want to parse it
-            if (contentType === Http.ContentType.JSON || url.split('?')[0].endsWith('.json')) {
-                // It's a JSON response
-                response = JSON.parse(xhr.responseText);
-            } else if (this._isBinaryContentType(contentType) || this._isBinaryResponseType(xhr.responseType)) {
+            if (this._isBinaryContentType(contentType) || this._isBinaryResponseType(xhr.responseType)) {
                 // It's a binary response
                 response = xhr.response;
+            } else if (contentType === Http.ContentType.JSON || url.split('?')[0].endsWith('.json')) {
+                // It's a JSON response
+                response = JSON.parse(xhr.responseText);
             } else if (xhr.responseType === Http.ResponseType.DOCUMENT || contentType === Http.ContentType.XML) {
                 // It's an XML response
                 response = xhr.responseXML;


### PR DESCRIPTION
Currently, when requesting an arrayBuffer download of files served with content `application/json`, http handler attempts to access `xhr.responseText` which results in an error being thrown.

(This error is currently firing when loading a gltf file from a server which specifies gltf with content type `application/json`).

This PR changes the test order to handle binary first.