### PR TITLE
Fixes and workarounds to bring multiple examples to work on WebGPU

### DIFF
--- a/examples/src/examples/graphics/clustered-area-lights.tsx
+++ b/examples/src/examples/graphics/clustered-area-lights.tsx
@@ -6,6 +6,7 @@ import { Observer } from '@playcanvas/observer';
 class AreaLightsExample {
     static CATEGORY = 'Graphics';
     static NAME = 'Clustered Area Lights';
+    static WEBGPU_ENABLED = true;
 
     controls(data: Observer) {
         return <>

--- a/examples/src/examples/graphics/ground-fog.tsx
+++ b/examples/src/examples/graphics/ground-fog.tsx
@@ -7,6 +7,7 @@ import { Observer } from '@playcanvas/observer';
 class GroundFogExample {
     static CATEGORY = 'Graphics';
     static NAME = 'Ground Fog';
+    static WEBGPU_ENABLED = true;
 
     static FILES = {
         'shader.vert': /* glsl */ `
@@ -113,7 +114,10 @@ class GroundFogExample {
         const gfxOptions = {
             deviceTypes: [deviceType],
             glslangUrl: '/static/lib/glslang/glslang.js',
-            twgslUrl: '/static/lib/twgsl/twgsl.js'
+            twgslUrl: '/static/lib/twgsl/twgsl.js',
+
+            // WebGPU does not currently support antialiased depth resolve, disable it till we implement a shader resolve solution
+            antialias: false
         };
 
         pc.createGraphicsDevice(canvas, gfxOptions).then((device: pc.GraphicsDevice) => {

--- a/examples/src/examples/graphics/post-effects.tsx
+++ b/examples/src/examples/graphics/post-effects.tsx
@@ -7,6 +7,7 @@ import { Observer } from '@playcanvas/observer';
 class PostEffectsExample {
     static CATEGORY = 'Graphics';
     static NAME = 'Post Effects';
+    static WEBGPU_ENABLED = true;
 
     controls(data: Observer) {
         return <>
@@ -102,7 +103,10 @@ class PostEffectsExample {
         const gfxOptions = {
             deviceTypes: [deviceType],
             glslangUrl: '/static/lib/glslang/glslang.js',
-            twgslUrl: '/static/lib/twgsl/twgsl.js'
+            twgslUrl: '/static/lib/twgsl/twgsl.js',
+
+            // WebGPU does not currently support antialiased depth resolve, disable it till we implement a shader resolve solution
+            antialias: false
         };
 
         pc.createGraphicsDevice(canvas, gfxOptions).then((device: pc.GraphicsDevice) => {

--- a/src/platform/graphics/graphics-device-create.js
+++ b/src/platform/graphics/graphics-device-create.js
@@ -14,6 +14,8 @@ import { WebglGraphicsDevice } from './webgl/webgl-graphics-device.js';
  * specified array does not contain [{@link DEVICETYPE_WEBGL2} or {@link DEVICETYPE_WEBGL1}], those
  * are internally added to its end in this order. Typically, you'd only specify
  * {@link DEVICETYPE_WEBGPU}, or leave it empty.
+ * @param {boolean} [options.antialias] - Boolean that indicates whether or not to perform
+ * anti-aliasing if possible. Defaults to true.
  * @param {string} [options.glslangUrl] - An url to glslang script, required if
  * {@link DEVICETYPE_WEBGPU} type is added to deviceTypes array. Not used for
  * {@link DEVICETYPE_WEBGL} device type creation.
@@ -21,6 +23,9 @@ import { WebglGraphicsDevice } from './webgl/webgl-graphics-device.js';
  * @returns {Promise} - Promise object representing the created graphics device.
  */
 function createGraphicsDevice(canvas, options = {}) {
+
+    // defaults
+    options.antialias ??= true;
 
     const deviceTypes = options.deviceTypes ?? [];
 

--- a/src/platform/graphics/graphics-device.js
+++ b/src/platform/graphics/graphics-device.js
@@ -152,7 +152,7 @@ class GraphicsDevice extends EventHandler {
       * True if 16-bit floating-point textures can be used as a frame buffer.
       *
       * @type {boolean}
-     * @readonly
+      * @readonly
       */
     textureHalfFloatRenderable;
 

--- a/src/platform/graphics/graphics-device.js
+++ b/src/platform/graphics/graphics-device.js
@@ -28,6 +28,7 @@ class GraphicsDevice extends EventHandler {
      * The canvas DOM element that provides the underlying WebGL context used by the graphics device.
      *
      * @type {HTMLCanvasElement}
+     * @readonly
      */
     canvas;
 
@@ -35,6 +36,7 @@ class GraphicsDevice extends EventHandler {
      * True if the deviceType is WebGPU
      *
      * @type {boolean}
+     * @readonly
      */
     isWebGPU = false;
 
@@ -42,6 +44,7 @@ class GraphicsDevice extends EventHandler {
      * The scope namespace for shader attributes and variables.
      *
      * @type {ScopeSpace}
+     * @readonly
      */
     scope;
 
@@ -49,6 +52,7 @@ class GraphicsDevice extends EventHandler {
      * The maximum number of supported bones using uniform buffers.
      *
      * @type {number}
+     * @readonly
      */
     boneLimit;
 
@@ -56,6 +60,7 @@ class GraphicsDevice extends EventHandler {
      * The maximum supported texture anisotropy setting.
      *
      * @type {number}
+     * @readonly
      */
     maxAnisotropy;
 
@@ -63,6 +68,7 @@ class GraphicsDevice extends EventHandler {
      * The maximum supported dimension of a cube map.
      *
      * @type {number}
+     * @readonly
      */
     maxCubeMapSize;
 
@@ -70,6 +76,7 @@ class GraphicsDevice extends EventHandler {
      * The maximum supported dimension of a texture.
      *
      * @type {number}
+     * @readonly
      */
     maxTextureSize;
 
@@ -77,6 +84,7 @@ class GraphicsDevice extends EventHandler {
      * The maximum supported dimension of a 3D texture (any axis).
      *
      * @type {number}
+     * @readonly
      */
     maxVolumeSize;
 
@@ -85,8 +93,17 @@ class GraphicsDevice extends EventHandler {
      * 'lowp'.
      *
      * @type {string}
+     * @readonly
      */
     precision;
+
+    /**
+     * The number of hardware anti-aliasing samples used by the frame buffer.
+     *
+     * @readonly
+     * @type {number}
+     */
+    samples;
 
     /**
      * Currently active render target.
@@ -96,6 +113,14 @@ class GraphicsDevice extends EventHandler {
      */
     renderTarget = null;
 
+    /**
+     * Index of the currently active render pass.
+     *
+     * @type {number}
+     * @ignore
+     */
+    renderPassIndex;
+
     /** @type {boolean} */
     insideRenderPass = false;
 
@@ -103,6 +128,7 @@ class GraphicsDevice extends EventHandler {
      * True if hardware instancing is supported.
      *
      * @type {boolean}
+     * @readonly
      */
     supportsInstancing;
 
@@ -118,6 +144,7 @@ class GraphicsDevice extends EventHandler {
      * True if 32-bit floating-point textures can be used as a frame buffer.
      *
      * @type {boolean}
+     * @readonly
      */
     textureFloatRenderable;
 
@@ -125,6 +152,7 @@ class GraphicsDevice extends EventHandler {
       * True if 16-bit floating-point textures can be used as a frame buffer.
       *
       * @type {boolean}
+     * @readonly
       */
     textureHalfFloatRenderable;
 
@@ -539,6 +567,7 @@ class GraphicsDevice extends EventHandler {
      * @ignore
      */
     frameStart() {
+        this.renderPassIndex = 0;
     }
 }
 

--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -68,6 +68,9 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
         this.isWebGPU = true;
         this._deviceType = DEVICETYPE_WEBGPU;
 
+        // WebGPU currently only supports 1 and 4 samples
+        this.samples = options.antialias ? 4 : 1;
+
         this.initDeviceCaps();
     }
 
@@ -198,7 +201,7 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
             name: 'WebgpuFramebuffer',
             graphicsDevice: this,
             depth: true,
-            samples: 4
+            samples: this.samples
         });
     }
 
@@ -215,6 +218,8 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
     }
 
     frameStart() {
+
+        super.frameStart();
 
         WebgpuDebug.memory(this);
         WebgpuDebug.validate(this);
@@ -587,7 +592,7 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
             // cannot copy depth from multisampled buffer. On WebGPU, it cannot be resolve at the end of the pass either,
             // and so we need to implement a custom depth resolve shader based copy
             // This is currently needed for uSceneDepthMap when the camera renders to multisampled render target
-            Debug.assert(source.samples <= 1, `copyRenderTarget does not currently support copy of depth from multisampled texture`, sourceRT);
+            Debug.assert(source.samples <= 1, `copyRenderTarget does not currently support copy of depth from multisampled texture ${sourceRT.name}`, sourceRT);
 
             /** @type {GPUImageCopyTexture} */
             const copySrc = {

--- a/src/platform/graphics/webgpu/webgpu-render-target.js
+++ b/src/platform/graphics/webgpu/webgpu-render-target.js
@@ -120,6 +120,7 @@ class WebgpuRenderTarget {
         this.assignedColorTexture = gpuTexture;
 
         const view = gpuTexture.createView();
+        DebugHelper.setLabel(view, 'Framebuffer.assignedColor');
 
         // use it as render buffer or resolve target
         const colorAttachment = this.renderPassDescriptor.colorAttachments[0];
@@ -145,6 +146,8 @@ class WebgpuRenderTarget {
     init(device, renderTarget) {
 
         Debug.assert(!this.initialized);
+        Debug.assert(this.renderPassDescriptor, 'The render target has been destroyed and cannot be used anymore.', { renderTarget });
+
         const wgpu = device.wgpu;
 
         WebgpuDebug.memory(device);
@@ -234,8 +237,11 @@ class WebgpuRenderTarget {
 
             // allocate multi-sampled color buffer
             this.multisampledColorBuffer = wgpu.createTexture(multisampledTextureDesc);
+            DebugHelper.setLabel(this.multisampledColorBuffer, `${renderTarget.name}.multisampledColor`);
 
             colorAttachment.view = this.multisampledColorBuffer.createView();
+            DebugHelper.setLabel(colorAttachment.view, `${renderTarget.name}.multisampledColorView`);
+
             colorAttachment.resolveTarget = colorView;
 
         } else {

--- a/src/scene/frame-graph.js
+++ b/src/scene/frame-graph.js
@@ -1,7 +1,3 @@
-import { TRACEID_RENDER_PASS, TRACEID_RENDER_PASS_DETAIL } from '../core/constants.js';
-import { Debug } from '../core/debug.js';
-import { Tracing } from '../core/tracing.js';
-
 /**
  * A frame graph represents a single rendering frame as a sequence of render passes.
  *
@@ -121,58 +117,6 @@ class FrameGraph {
         for (let i = 0; i < renderPasses.length; i++) {
             renderPasses[i].render();
         }
-
-        this.log(device);
-    }
-
-    log(device) {
-        // #if _DEBUG
-        if (Tracing.get(TRACEID_RENDER_PASS) || Tracing.get(TRACEID_RENDER_PASS_DETAIL)) {
-
-            this.renderPasses.forEach((renderPass, index) => {
-
-                let rt = renderPass.renderTarget;
-                if (rt === null && device.isWebGPU) {
-                    rt = device.frameBuffer;
-                }
-                const hasColor = rt?.colorBuffer ?? rt?.impl.assignedColorTexture;
-                const hasDepth = rt?.depth;
-                const hasStencil = rt?.stencil;
-                const rtInfo = rt === undefined ? '' : ` RT: ${(rt ? rt.name : 'NULL')} ` +
-                    `${hasColor ? '[Color]' : ''}` +
-                    `${hasDepth ? '[Depth]' : ''}` +
-                    `${hasStencil ? '[Stencil]' : ''}` +
-                    `${(renderPass.samples > 0 ? ' samples: ' + renderPass.samples : '')}`;
-
-                Debug.trace(TRACEID_RENDER_PASS,
-                            `${index.toString().padEnd(2, ' ')}: ${renderPass.name.padEnd(20, ' ')}` +
-                            rtInfo.padEnd(30));
-
-                if (renderPass.colorOps && hasColor) {
-                    Debug.trace(TRACEID_RENDER_PASS_DETAIL, `    colorOps: ` +
-                                `${renderPass.colorOps.clear ? 'clear' : 'load'}->` +
-                                `${renderPass.colorOps.store ? 'store' : 'discard'} ` +
-                                `${renderPass.colorOps.resolve ? 'resolve ' : ''}` +
-                                `${renderPass.colorOps.mipmaps ? 'mipmaps ' : ''}`);
-                }
-
-                if (renderPass.depthStencilOps) {
-
-                    if (hasDepth) {
-                        Debug.trace(TRACEID_RENDER_PASS_DETAIL, `    depthOps: ` +
-                                    `${renderPass.depthStencilOps.clearDepth ? 'clear' : 'load'}->` +
-                                    `${renderPass.depthStencilOps.storeDepth ? 'store' : 'discard'}`);
-                    }
-
-                    if (hasStencil) {
-                        Debug.trace(TRACEID_RENDER_PASS_DETAIL, `    stencOps: ` +
-                                    `${renderPass.depthStencilOps.clearStencil ? 'clear' : 'load'}->` +
-                                    `${renderPass.depthStencilOps.storeStencil ? 'store' : 'discard'}`);
-                    }
-                }
-            });
-        }
-        // #endif
     }
 }
 


### PR DESCRIPTION
Enabled WebGPU for examples:
	- post-effects
	- clustered area lights
	- ground fog

Added support for `options.antialias` when creating WebGPU device, instead of always using multisampling.

Workarounds:
- on WebGPU we don't have a support for depth buffer resolve with this is multi-sampled. We need to implemented a shader  based resolve, to have access to scene depth. For now, in the examples that need scene depth, multisampling has been turned off.
- added workaround for storing multisampled color when the same multisampled buffer is rendered to multiple times. Needs better solution.

Improved render pass logging - moved it from FrameGraph logging to logging during rendering, to log data for render passes that are not part of FrameGraph yet (ad-hoc render passes). This allows us to see render passes from post-effects and similar:

![Screenshot 2023-03-20 at 12 08 16](https://user-images.githubusercontent.com/59932779/226364577-2346477b-086c-44ae-9df1-eba922ac7bad.png)
