### PR TITLE
[Anim Component] Unloaded animation assignment fix

### DIFF
--- a/src/framework/anim/controller/anim-controller.js
+++ b/src/framework/anim/controller/anim-controller.js
@@ -455,6 +455,7 @@ class AnimController {
             this._stateNames.push(path[0]);
         }
         state.addAnimation(path, animTrack);
+        this._animEvaluator.updateClipTrack(state.name, animTrack);
         if (speed !== undefined) {
             state.speed = speed;
         }

--- a/src/framework/anim/evaluator/anim-clip.js
+++ b/src/framework/anim/evaluator/anim-clip.js
@@ -42,6 +42,11 @@ class AnimClip {
         return this._name;
     }
 
+    set track(track) {
+        this._track = track;
+        this._snapshot = new AnimSnapshot(track);
+    }
+
     get track() {
         return this._track;
     }

--- a/src/framework/anim/evaluator/anim-evaluator.js
+++ b/src/framework/anim/evaluator/anim-evaluator.js
@@ -146,6 +146,15 @@ class AnimEvaluator {
         }
     }
 
+    updateClipTrack(name, animTrack) {
+        this._clips.forEach((clip) => {
+            if (clip.name.includes(name)) {
+                clip.track = animTrack;
+            }
+        });
+        this.rebind();
+    }
+
     /**
      * Returns the first clip which matches the given name, or null if no such clip was found.
      *

--- a/src/framework/components/anim/system.js
+++ b/src/framework/components/anim/system.js
@@ -53,6 +53,7 @@ class AnimComponentSystem extends ComponentSystem {
                     layer._controller._states[stateKey]._animationList.forEach((node) => {
                         if (!node.animTrack || node.animTrack === AnimTrack.EMPTY) {
                             const animationAsset = this.app.assets.get(layer._component._animationAssets[layer.name + ':' + node.name].asset);
+                            // If there is an animation asset that hasn't been loaded, assign it once it has loaded. If it is already loaded it will be assigned already.
                             if (animationAsset && !animationAsset.loaded) {
                                 animationAsset.once('load', () => {
                                     component.layers[i].assignAnimation(node.name, animationAsset.resource);

--- a/src/framework/components/anim/system.js
+++ b/src/framework/components/anim/system.js
@@ -1,3 +1,4 @@
+import { AnimTrack } from '../../anim/evaluator/anim-track.js';
 import { Component } from '../component.js';
 import { ComponentSystem } from '../system.js';
 
@@ -50,7 +51,16 @@ class AnimComponentSystem extends ComponentSystem {
             data.layers.forEach((layer, i) => {
                 layer._controller.states.forEach((stateKey) => {
                     layer._controller._states[stateKey]._animationList.forEach((node) => {
-                        component.layers[i].assignAnimation(node.name, node.animTrack);
+                        if (!node.animTrack || node.animTrack === AnimTrack.EMPTY) {
+                            const animationAsset = pc.app.assets.get(layer._component._animationAssets[layer.name + ':' + node.name].asset);
+                            if (animationAsset && !animationAsset.loaded) {
+                                animationAsset.once('load', () => {
+                                    component.layers[i].assignAnimation(node.name, animationAsset.resource);
+                                });
+                            }
+                        } else {
+                            component.layers[i].assignAnimation(node.name, node.animTrack);
+                        }
                     });
                 });
             });

--- a/src/framework/components/anim/system.js
+++ b/src/framework/components/anim/system.js
@@ -52,7 +52,7 @@ class AnimComponentSystem extends ComponentSystem {
                 layer._controller.states.forEach((stateKey) => {
                     layer._controller._states[stateKey]._animationList.forEach((node) => {
                         if (!node.animTrack || node.animTrack === AnimTrack.EMPTY) {
-                            const animationAsset = pc.app.assets.get(layer._component._animationAssets[layer.name + ':' + node.name].asset);
+                            const animationAsset = this.app.assets.get(layer._component._animationAssets[layer.name + ':' + node.name].asset);
                             if (animationAsset && !animationAsset.loaded) {
                                 animationAsset.once('load', () => {
                                     component.layers[i].assignAnimation(node.name, animationAsset.resource);

--- a/test/framework/anim/controller/anim-controller.test.mjs
+++ b/test/framework/anim/controller/anim-controller.test.mjs
@@ -68,7 +68,8 @@ describe('AnimController', function () {
                 priority: 3
             }
         ];
-        const animBinder = new AnimComponentBinder(this, new Entity(), 'layer', {}, 0);
+        const graph = new Entity();
+        const animBinder = new AnimComponentBinder({ entity: graph }, graph, 'layer', {}, 0);
         animBinder.resolve = () => {};
         const animEvaluator = new AnimEvaluator(animBinder);
         controller = new AnimController(


### PR DESCRIPTION
Fix an issue when assigning unloaded animation assets into the anim component. It will now load any unloaded assets before assigning them to the appropriate state. Any AnimClips from states that have been assigned should also be updated with the new AnimTrack.


I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
