### PR TITLE
Workaround for 8bit GLB index buffers not supported on WebGPU

### DIFF
--- a/examples/src/examples/graphics/light-physical-units.tsx
+++ b/examples/src/examples/graphics/light-physical-units.tsx
@@ -6,6 +6,7 @@ import { Observer } from '@playcanvas/observer';
 class LightPhysicalUnitsExample {
     static CATEGORY = 'Graphics';
     static NAME = 'Light Physical Units';
+    static WEBGPU_ENABLED = true;
 
     controls(data: Observer) {
         return <>

--- a/src/framework/parsers/glb-parser.js
+++ b/src/framework/parsers/glb-parser.js
@@ -883,6 +883,14 @@ const createMesh = function (device, gltfMesh, accessors, bufferViews, callback,
                     indices = new Uint16Array(indices);
                 }
 
+                if (indexFormat === INDEXFORMAT_UINT8 && device.isWebGPU) {
+                    Debug.warn('Glb file contains 8bit index buffer but these are not supported by WebGPU - converting to 16bit.');
+
+                    // convert to 16bit
+                    indexFormat = INDEXFORMAT_UINT16;
+                    indices = new Uint16Array(indices);
+                }
+
                 const indexBuffer = new IndexBuffer(device, indexFormat, indices.length, BUFFER_STATIC, indices);
                 mesh.indexBuffer[0] = indexBuffer;
                 mesh.primitive[0].count = indices.length;


### PR DESCRIPTION
- if glb contains 8bit index buffers, convert them to 16bit on WebGPU platform, where 8bit is not supported
- enabled light-physical-units example on WebGPU now that it works