### PR TITLE
Don’t include code using vertex_tangent unless needed

### DIFF
--- a/src/scene/shader-lib/chunks/lit/vert/tangentBinormal.js
+++ b/src/scene/shader-lib/chunks/lit/vert/tangentBinormal.js
@@ -6,8 +6,4 @@ vec3 getTangent() {
 vec3 getBinormal() {
     return cross(vNormalW, vTangentW) * vertex_tangent.w;
 }
-
-vec3 getObjectSpaceUp() {
-    return normalize(dNormalMatrix * vec3(0, 1, 0));
-}
 `;

--- a/src/scene/shader-lib/programs/lit-shader.js
+++ b/src/scene/shader-lib/programs/lit-shader.js
@@ -273,8 +273,7 @@ class LitShader {
                 codeBody += "   vTangentW   = getTangent();\n";
                 codeBody += "   vBinormalW  = getBinormal();\n";
             } else if (options.enableGGXSpecular || !device.extStandardDerivatives) {
-                code += chunks.tangentBinormalVS;
-                codeBody += "   vObjectSpaceUpW  = getObjectSpaceUp();\n";
+                codeBody += "   vObjectSpaceUpW = normalize(dNormalMatrix * vec3(0, 1, 0));\n";
             }
         }
 


### PR DESCRIPTION
Chunk tangentBinormalVS contains handling of tangent and binormal, and should only be included if vertex buffer contains tangent, gated by options.hasTangents. But unrelated getObjectSpaceUp was included in this chunk and needed in cases hasTangent was false. This was adding `attribute vec4 vertex_tangent;` to vertex shader even though vertex format did not have tangent, failing on WebGPU. 
The unrelated `getObjectSpaceUp` has been removed from the chunk now.