### PR TITLE
Add `RaycastResult` sorting on `RigidBodyComponentSystem#raycastAll`

### DIFF
--- a/src/framework/components/rigid-body/system.js
+++ b/src/framework/components/rigid-body/system.js
@@ -23,9 +23,10 @@ class RaycastResult {
      * @param {import('../../entity.js').Entity} entity - The entity that was hit.
      * @param {Vec3} point - The point at which the ray hit the entity in world space.
      * @param {Vec3} normal - The normal vector of the surface where the ray hit in world space.
+     * @param {number} hitFraction - The distance percentage at which the collision occurred from starting point.
      * @hideconstructor
      */
-    constructor(entity, point, normal) {
+    constructor(entity, point, normal, hitFraction) {
         /**
          * The entity that was hit.
          *

--- a/src/framework/components/rigid-body/system.js
+++ b/src/framework/components/rigid-body/system.js
@@ -525,7 +525,8 @@ class RigidBodyComponentSystem extends ComponentSystem {
      *
      * @param {Vec3} start - The world space point where the ray starts.
      * @param {Vec3} end - The world space point where the ray ends.
-     * @returns {RaycastResult[]} An array of raycast hit results (0 length if there were no hits). Results are sorted by distance with closest first.
+     * @returns {RaycastResult[]} An array of raycast hit results (0 length if there were no hits).
+     * Results are sorted by distance with closest first.
      */
     raycastAll(start, end) {
         Debug.assert(Ammo.AllHitsRayResultCallback, 'pc.RigidBodyComponentSystem#raycastAll: Your version of ammo.js does not expose Ammo.AllHitsRayResultCallback. Update it to latest.');

--- a/src/framework/components/rigid-body/system.js
+++ b/src/framework/components/rigid-body/system.js
@@ -23,7 +23,8 @@ class RaycastResult {
      * @param {import('../../entity.js').Entity} entity - The entity that was hit.
      * @param {Vec3} point - The point at which the ray hit the entity in world space.
      * @param {Vec3} normal - The normal vector of the surface where the ray hit in world space.
-     * @param {number} hitFraction - The distance normalized percentage (between 0 and 1) at which the collision occurred from starting point.
+     * @param {number} hitFraction - The normalized distance (between 0 and 1) at which the ray hit
+     * occurred from the starting point.
      * @hideconstructor
      */
     constructor(entity, point, normal, hitFraction) {
@@ -49,7 +50,8 @@ class RaycastResult {
         this.normal = normal;
 
         /**
-         * The distance normalized percentage (between 0 and 1) at which the collision occurred from starting point.
+         * The normalized distance (between 0 and 1) at which the ray hit occurred from the
+         * starting point.
          *
          * @type {number}
          */

--- a/src/framework/components/rigid-body/system.js
+++ b/src/framework/components/rigid-body/system.js
@@ -46,6 +46,13 @@ class RaycastResult {
          * @type {Vec3}
          */
         this.normal = normal;
+
+        /**
+         * The distance percentage at which the collision occurred from starting point.
+         *
+         * @type {number}
+         */
+        this.hitFraction = hitFraction;
     }
 }
 
@@ -489,7 +496,8 @@ class RigidBodyComponentSystem extends ComponentSystem {
                 result = new RaycastResult(
                     body.entity,
                     new Vec3(point.x(), point.y(), point.z()),
-                    new Vec3(normal.x(), normal.y(), normal.z())
+                    new Vec3(normal.x(), normal.y(), normal.z()),
+                    rayCallback.get_m_closestHitFraction()
                 );
 
                 // keeping for backwards compatibility
@@ -530,6 +538,7 @@ class RigidBodyComponentSystem extends ComponentSystem {
             const collisionObjs = rayCallback.get_m_collisionObjects();
             const points = rayCallback.get_m_hitPointWorld();
             const normals = rayCallback.get_m_hitNormalWorld();
+            const hitFractions = rayCallback.get_m_hitFractions();
 
             const numHits = collisionObjs.size();
             for (let i = 0; i < numHits; i++) {
@@ -540,11 +549,15 @@ class RigidBodyComponentSystem extends ComponentSystem {
                     const result = new RaycastResult(
                         body.entity,
                         new Vec3(point.x(), point.y(), point.z()),
-                        new Vec3(normal.x(), normal.y(), normal.z())
+                        new Vec3(normal.x(), normal.y(), normal.z()),
+                        hitFractions.at(i)
                     );
+
                     results.push(result);
                 }
             }
+
+            results.sort((a, b) => a.hitFraction - b.hitFraction);
         }
 
         Ammo.destroy(rayCallback);

--- a/src/framework/components/rigid-body/system.js
+++ b/src/framework/components/rigid-body/system.js
@@ -23,7 +23,7 @@ class RaycastResult {
      * @param {import('../../entity.js').Entity} entity - The entity that was hit.
      * @param {Vec3} point - The point at which the ray hit the entity in world space.
      * @param {Vec3} normal - The normal vector of the surface where the ray hit in world space.
-     * @param {number} hitFraction - The distance percentage at which the collision occurred from starting point.
+     * @param {number} hitFraction - The distance normalized percentage (between 0 and 1) at which the collision occurred from starting point.
      * @hideconstructor
      */
     constructor(entity, point, normal, hitFraction) {
@@ -49,7 +49,7 @@ class RaycastResult {
         this.normal = normal;
 
         /**
-         * The distance percentage at which the collision occurred from starting point.
+         * The distance normalized percentage (between 0 and 1) at which the collision occurred from starting point.
          *
          * @type {number}
          */

--- a/src/framework/components/rigid-body/system.js
+++ b/src/framework/components/rigid-body/system.js
@@ -521,11 +521,11 @@ class RigidBodyComponentSystem extends ComponentSystem {
     /**
      * Raycast the world and return all entities the ray hits. It returns an array of
      * {@link RaycastResult}, one for each hit. If no hits are detected, the returned array will be
-     * of length 0.
+     * of length 0. Results are sorted by distance with closest first.
      *
      * @param {Vec3} start - The world space point where the ray starts.
      * @param {Vec3} end - The world space point where the ray ends.
-     * @returns {RaycastResult[]} An array of raycast hit results (0 length if there were no hits).
+     * @returns {RaycastResult[]} An array of raycast hit results (0 length if there were no hits). Results are sorted by distance with closest first.
      */
     raycastAll(start, end) {
         Debug.assert(Ammo.AllHitsRayResultCallback, 'pc.RigidBodyComponentSystem#raycastAll: Your version of ammo.js does not expose Ammo.AllHitsRayResultCallback. Update it to latest.');


### PR DESCRIPTION
Fixes #5162 

Implements `RaycastResult` distance sorting for `RigidBodyComponentSystem#raycastAll`. As API was never documented as having the results sorted by any manner I don't think that would count as breaking. I also exposed `hitFraction` which was used for the sorting and is a very useful information to know where the hit occurred.

Changes to `RaycastResult` public API:
- \+ `hitFraction`: The fraction the hit happened. Can be used to know which one came first based on distance.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
