### PR TITLE
Change `raycastAll` sorting default to `false`

### DIFF
--- a/src/framework/components/rigid-body/system.js
+++ b/src/framework/components/rigid-body/system.js
@@ -563,7 +563,7 @@ class RigidBodyComponentSystem extends ComponentSystem {
                 }
             }
 
-            if (options.sort === true) {
+            if (options.sort) {
                 results.sort((a, b) => a.hitFraction - b.hitFraction);
             }
         }

--- a/src/framework/components/rigid-body/system.js
+++ b/src/framework/components/rigid-body/system.js
@@ -526,7 +526,8 @@ class RigidBodyComponentSystem extends ComponentSystem {
      * @param {Vec3} start - The world space point where the ray starts.
      * @param {Vec3} end - The world space point where the ray ends.
      * @param {object} [options] - The additional options for the raycasting.
-     * @param {boolean} [options.sort] - Whether to sort raycast results based on distance. Defaults to true.
+     * @param {boolean} [options.sort] - Whether to sort raycast results based on distance with closest
+     * first. Defaults to true.
      * @returns {RaycastResult[]} An array of raycast hit results (0 length if there were no hits).
      */
     raycastAll(start, end, options = {}) {

--- a/src/framework/components/rigid-body/system.js
+++ b/src/framework/components/rigid-body/system.js
@@ -525,10 +525,11 @@ class RigidBodyComponentSystem extends ComponentSystem {
      *
      * @param {Vec3} start - The world space point where the ray starts.
      * @param {Vec3} end - The world space point where the ray ends.
+     * @param {object} [options] - The additional options for the raycasting.
+     * @param {boolean} [options.sort] - Whether to sort raycast results based on distance. Defaults to true.
      * @returns {RaycastResult[]} An array of raycast hit results (0 length if there were no hits).
-     * Results are sorted by distance with closest first.
      */
-    raycastAll(start, end) {
+    raycastAll(start, end, options = {}) {
         Debug.assert(Ammo.AllHitsRayResultCallback, 'pc.RigidBodyComponentSystem#raycastAll: Your version of ammo.js does not expose Ammo.AllHitsRayResultCallback. Update it to latest.');
 
         const results = [];
@@ -561,7 +562,9 @@ class RigidBodyComponentSystem extends ComponentSystem {
                 }
             }
 
-            results.sort((a, b) => a.hitFraction - b.hitFraction);
+            if (options.sort !== false) {
+                results.sort((a, b) => a.hitFraction - b.hitFraction);
+            }
         }
 
         Ammo.destroy(rayCallback);

--- a/src/framework/components/rigid-body/system.js
+++ b/src/framework/components/rigid-body/system.js
@@ -527,7 +527,7 @@ class RigidBodyComponentSystem extends ComponentSystem {
      * @param {Vec3} end - The world space point where the ray ends.
      * @param {object} [options] - The additional options for the raycasting.
      * @param {boolean} [options.sort] - Whether to sort raycast results based on distance with closest
-     * first. Defaults to true.
+     * first. Defaults to false.
      * @returns {RaycastResult[]} An array of raycast hit results (0 length if there were no hits).
      */
     raycastAll(start, end, options = {}) {
@@ -563,7 +563,7 @@ class RigidBodyComponentSystem extends ComponentSystem {
                 }
             }
 
-            if (options.sort !== false) {
+            if (options.sort === true) {
                 results.sort((a, b) => a.hitFraction - b.hitFraction);
             }
         }


### PR DESCRIPTION
As requested by @LeXXik in #5179, added an `options` parameter to `raycastAll` to allow non-sorting of results.

Changes to `RigidBodyComponentSystem` public API:
- `raycastFirst(start, end, options)`
- `raycastAll(start, end, options)`

Options declares as follow for not sorting:
```
{
    sort: false
}
```

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
