### PR TITLE
Clamp shadow distance to camera far plane

### DIFF
--- a/src/scene/renderer/shadow-renderer-directional.js
+++ b/src/scene/renderer/shadow-renderer-directional.js
@@ -76,7 +76,7 @@ class ShadowRendererDirectional {
 
         // generate splits for the cascades
         const nearDist = camera._nearClip;
-        this.generateSplitDistances(light, nearDist, light.shadowDistance);
+        this.generateSplitDistances(light, nearDist, Math.min(camera._farClip, light.shadowDistance));
 
         const shadowUpdateOverrides = light.shadowUpdateOverrides;
         for (let cascade = 0; cascade < light.numCascades; cascade++) {


### PR DESCRIPTION
Shadow cascades weren't taking the camera's far clipping plane into consideration when generating cascades.

This PR clamps shadow distance so cascades are more optimally placed.

With optimal near and far camera clipping planes, shadow resolution is improved:

**Before:**
<img width="2025" alt="Screenshot 2023-03-22 at 13 10 44" src="https://user-images.githubusercontent.com/11276292/226914973-7f45c512-980f-45a3-bc43-1328eb42c75e.png">

**After:**
<img width="2025" alt="Screenshot 2023-03-22 at 13 11 21" src="https://user-images.githubusercontent.com/11276292/226915109-025d416d-04ee-46bb-b626-a86b5a1f58d7.png">
