### PR TITLE
Remove VSM blur weights restriction

### DIFF
--- a/src/scene/renderer/shadow-renderer.js
+++ b/src/scene/renderer/shadow-renderer.js
@@ -30,11 +30,7 @@ function gauss(x, sigma) {
     return Math.exp(-(x * x) / (2.0 * sigma * sigma));
 }
 
-const maxBlurSize = 25;
 function gaussWeights(kernelSize) {
-    if (kernelSize > maxBlurSize) {
-        kernelSize = maxBlurSize;
-    }
     const sigma = (kernelSize - 1) / (2 * 3);
 
     const halfWidth = (kernelSize - 1) * 0.5;


### PR DESCRIPTION
The gaussian weights used in VSM blur step were being restricted to 25 samples resulting in large blurs effectively not working and also offsetting the resulting shadow maps.