### PR TITLE
Fix to the way WebGPU device handles render target resizing

### DIFF
--- a/src/platform/graphics/webgpu/webgpu-render-target.js
+++ b/src/platform/graphics/webgpu/webgpu-render-target.js
@@ -78,12 +78,14 @@ class WebgpuRenderTarget {
     }
 
     /**
+     * Release associated resources. Note that this needs to leave this instance in a state where
+     * it can be re-initialized again, which is used by render target resizing.
+     *
      * @param {import('../webgpu/webgpu-graphics-device.js').WebgpuGraphicsDevice} device - The
      * graphics device.
      */
     destroy(device) {
         this.initialized = false;
-        this.renderPassDescriptor = null;
 
         if (this.depthTextureInternal) {
             this.depthTexture?.destroy();
@@ -146,7 +148,6 @@ class WebgpuRenderTarget {
     init(device, renderTarget) {
 
         Debug.assert(!this.initialized);
-        Debug.assert(this.renderPassDescriptor, 'The render target has been destroyed and cannot be used anymore.', { renderTarget });
 
         const wgpu = device.wgpu;
 


### PR DESCRIPTION
- this is a non-conventional destroy function in a way that the class needs to be useable again, which is used by render target resizing by post-effect-queue.