### PR TITLE
Fix spec argument list order

### DIFF
--- a/src/scene/shader-lib/chunks/lit/frag/clusteredLight.js
+++ b/src/scene/shader-lib/chunks/lit/frag/clusteredLight.js
@@ -564,7 +564,7 @@ void evaluateLight(
                 // specular
                 #ifdef LIT_SPECULAR_FRESNEL
                     dSpecularLight += 
-                        getLightSpecular(halfDir, reflectionDir, viewDir, worldNormal, gloss, tbn) * falloffAttenuation * light.color * cookieAttenuation * 
+                        getLightSpecular(halfDir, reflectionDir, worldNormal, viewDir, dLightDirNormW, gloss, tbn) * falloffAttenuation * light.color * cookieAttenuation * 
                         getFresnel(
                             dot(viewDir, halfDir), 
                             gloss, 
@@ -575,14 +575,14 @@ void evaluateLight(
                         #endif
                             );
                 #else
-                    dSpecularLight += getLightSpecular(halfDir, reflectionDir, viewDir, worldNormal, gloss, tbn) * falloffAttenuation * light.color * cookieAttenuation * specularity;
+                    dSpecularLight += getLightSpecular(halfDir, reflectionDir, worldNormal, viewDir, dLightDirNormW, gloss, tbn) * falloffAttenuation * light.color * cookieAttenuation * specularity;
                 #endif
 
                 #ifdef LIT_CLEARCOAT
                     #ifdef LIT_SPECULAR_FRESNEL
-                        ccSpecularLight += getLightSpecular(halfDir, clearcoatReflectionDir, viewDir, clearcoat.worldNormal, clearcoat.gloss, tbn) * falloffAttenuation * light.color * cookieAttenuation * getFresnelCC(dot(viewDir, halfDir));
+                        ccSpecularLight += getLightSpecular(halfDir, clearcoatReflectionDir, clearcoat.worldNormal, viewDir, dLightDirNormW, clearcoat.gloss, tbn) * falloffAttenuation * light.color * cookieAttenuation * getFresnelCC(dot(viewDir, halfDir));
                     #else
-                        ccSpecularLight += getLightSpecular(halfDir, clearcoatReflectionDir, viewDir, clearcoat.worldNormal, clearcoat.gloss, tbn) * falloffAttenuation * light.color * cookieAttenuation; 
+                        ccSpecularLight += getLightSpecular(halfDir, clearcoatReflectionDir, clearcoat.worldNormal, viewDir, dLightDirNormW, clearcoat.gloss, tbn) * falloffAttenuation * light.color * cookieAttenuation; 
                     #endif
                 #endif
 

--- a/src/scene/shader-lib/chunks/lit/frag/lightSpecularAnisoGGX.js
+++ b/src/scene/shader-lib/chunks/lit/frag/lightSpecularAnisoGGX.js
@@ -32,7 +32,7 @@ float calcLightSpecular(float gloss, vec3 worldNormal, vec3 viewDir, vec3 h, vec
     return D * G;
 }
 
-float getLightSpecular(vec3 h, vec3 reflDir, vec3 worldNormal, vec3 viewDir, float gloss, mat3 tbn) {
-    return calcLightSpecular(gloss, worldNormal, viewDir, h, tbn);
+float getLightSpecular(vec3 h, vec3 reflDir, vec3 worldNormal, vec3 viewDir, vec3 lightDirNorm, float gloss, mat3 tbn) {
+    return calcLightSpecular(gloss, worldNormal, viewDir, h, lightDirNorm, tbn);
 }
 `;

--- a/src/scene/shader-lib/chunks/lit/frag/lightSpecularBlinn.js
+++ b/src/scene/shader-lib/chunks/lit/frag/lightSpecularBlinn.js
@@ -11,7 +11,7 @@ float calcLightSpecular(float gloss, vec3 worldNormal, vec3 h) {
     return pow(nh, specPow) * (specPow + 2.0) / 8.0;
 }
 
-float getLightSpecular(vec3 h, vec3 reflDir, vec3 worldNormal, vec3 viewDir, float gloss, mat3 tbn) {
+float getLightSpecular(vec3 h, vec3 reflDir, vec3 worldNormal, vec3 viewDir, vec3 lightDirNorm, float gloss, mat3 tbn) {
     return calcLightSpecular(gloss, worldNormal, h);
 }
 `;

--- a/src/scene/shader-lib/chunks/lit/frag/lightSpecularPhong.js
+++ b/src/scene/shader-lib/chunks/lit/frag/lightSpecularPhong.js
@@ -6,7 +6,7 @@ float calcLightSpecular(float gloss, vec3 reflDir, vec3 h, vec3 lightDirNorm) {
     return pow(max(dot(reflDir, -lightDirNorm), 0.0), specPow + 0.0001);
 }
 
-float getLightSpecular(vec3 h, vec3 reflDir, vec3 worldNormal, vec3 viewDir, float gloss, mat3 tbn) {
+float getLightSpecular(vec3 h, vec3 reflDir, vec3 worldNormal, vec3 viewDir, vec3 lightDirNorm, float gloss, mat3 tbn) {
     return calcLightSpecular(gloss, reflDir, h);
 }
 `;

--- a/src/scene/shader-lib/chunks/lit/frag/lightmapDirAdd.js
+++ b/src/scene/shader-lib/chunks/lit/frag/lightmapDirAdd.js
@@ -24,7 +24,7 @@ void addLightMap(
         dDiffuseLight += lightmap * nlight * 2.0;
 
         vec3 halfDirW = normalize(-dir + viewDir);
-        vec3 specularLight = lightmap * getLightSpecular(halfDirW, reflectionDir, viewDir, worldNormal, gloss);
+        vec3 specularLight = lightmap * getLightSpecular(halfDirW, reflectionDir, worldNormal, viewDir, gloss);
 
 #ifdef LIT_SPECULAR_FRESNEL
         specularLight *= 

--- a/src/scene/shader-lib/chunks/lit/frag/reflDirAniso.js
+++ b/src/scene/shader-lib/chunks/lit/frag/reflDirAniso.js
@@ -5,7 +5,7 @@ void getReflDir(vec3 worldNormal, vec3 viewDir, float gloss, mat3 tbn) {
     vec3 anisotropicDirection = anisotropy >= 0.0 ? tbn[1] : tbn[0];
     vec3 anisotropicTangent = cross(anisotropicDirection, viewDir);
     vec3 anisotropicNormal = cross(anisotropicTangent, anisotropicDirection);
-    vec3 bentNormal = normalize(mix(normalize(worldNormal, normalize(anisotropicNormal), anisotropy));
+    vec3 bentNormal = normalize(mix(normalize(worldNormal), normalize(anisotropicNormal), anisotropy));
     dReflDirW = reflect(-viewDir, bentNormal);
 }
 `;

--- a/src/scene/shader-lib/programs/lit-shader.js
+++ b/src/scene/shader-lib/programs/lit-shader.js
@@ -1267,10 +1267,10 @@ class LitShader {
 
                     // area light
                     if (options.useClearCoat) {
-                        backend.append("    ccSpecularLight += ccLTCSpecFres * get" + shapeString + "LightSpecular(litShaderArgs.clearcoat.worldNormal, dViewDirW) * dAtten * light" + i + "_color" + (usesCookieNow ? " * dAtten3" : "") + ";");
+                        backend.append(`    ccSpecularLight += ccLTCSpecFres * get${shapeString}LightSpecular(litShaderArgs.clearcoat.worldNormal, dViewDirW) * dAtten * light${i}_color` + (usesCookieNow ? " * dAtten3" : "") + ";");
                     }
                     if (options.useSpecular) {
-                        backend.append("    dSpecularLight += dLTCSpecFres * get" + shapeString + "LightSpecular(litShaderArgs.worldNormal, dViewDirW) * dAtten * light" + i + "_color" + (usesCookieNow ? " * dAtten3" : "") + ";");
+                        backend.append(`    dSpecularLight += dLTCSpecFres * get${shapeString}LightSpecular(litShaderArgs.worldNormal, dViewDirW) * dAtten * light${i}_color` + (usesCookieNow ? " * dAtten3" : "") + ";");
                     }
 
                 } else {
@@ -1281,7 +1281,7 @@ class LitShader {
 
                     // if LTC lights are present, specular must be accumulated with specularity (specularity is pre multiplied by punctual light fresnel)
                     if (options.useClearCoat) {
-                        backend.append(`    ccSpecularLight += getLightSpecular(dHalfDirW, ccReflDirW, litShaderArgs.clearcoat.worldNormal, dViewDirW, litShaderArgs.clearcoat.gloss, dTBN) * dAtten * light${i}_color` +
+                        backend.append(`    ccSpecularLight += getLightSpecular(dHalfDirW, ccReflDirW, litShaderArgs.clearcoat.worldNormal, dViewDirW, dLightDirNormW, litShaderArgs.clearcoat.gloss, dTBN) * dAtten * light${i}_color` +
                             (usesCookieNow ? " * dAtten3" : "") +
                             (calcFresnel ? " * getFresnelCC(dot(dViewDirW, dHalfDirW));" : ";"));
                     }
@@ -1290,7 +1290,7 @@ class LitShader {
                             (usesCookieNow ? " * dAtten3;" : ";"));
                     }
                     if (options.useSpecular) {
-                        backend.append(`    dSpecularLight += getLightSpecular(dHalfDirW, dReflDirW, litShaderArgs.worldNormal, dViewDirW, litShaderArgs.gloss, dTBN) * dAtten * light${i}_color` +
+                        backend.append(`    dSpecularLight += getLightSpecular(dHalfDirW, dReflDirW, litShaderArgs.worldNormal, dViewDirW, dLightDirNormW, litShaderArgs.gloss, dTBN) * dAtten * light${i}_color` +
                             (usesCookieNow ? " * dAtten3" : "") +
                             (calcFresnel ? ` 
                                 * getFresnel(


### PR DESCRIPTION
- Fixed getLightSpecular is being called incorrectly in some places.
- Fixed getLightSpecular not accepting normalized light direction, which is required by the anisotropic GGX model.
- Changed way we generate the lighting code to using template literals instead of string concatenation.
- Fixed accidentally deleted parenthesis in reflDirAniso.