### PR TITLE
Fix refraction chunks

### DIFF
--- a/src/scene/shader-lib/chunks/lit/frag/refractionCube.js
+++ b/src/scene/shader-lib/chunks/lit/frag/refractionCube.js
@@ -1,7 +1,7 @@
 export default /* glsl */`
 uniform float material_refractionIndex;
 
-vec3 refract2(vec3 viewVec, vec3 normal, vec3 viewDir, float IOR) {
+vec3 refract2(vec3 viewVec, vec3 normal, float IOR) {
     float vn = dot(viewVec, normal);
     float k = 1.0 - IOR * IOR * (1.0 - vn * vn);
     vec3 refrVec = IOR * viewVec - (IOR * vn + sqrt(k)) * normal;
@@ -15,8 +15,7 @@ void addRefraction(
     float gloss, 
     vec3 specularity, 
     vec3 albedo, 
-    float transmission, 
-    inout opacity
+    float transmission
 #if defined(LIT_IRIDESCENCE)
     , vec3 iridescenceFresnel,
     IridescenceArgs iridescence

--- a/src/scene/shader-lib/chunks/lit/frag/refractionDynamic.js
+++ b/src/scene/shader-lib/chunks/lit/frag/refractionDynamic.js
@@ -3,13 +3,6 @@ uniform float material_refractionIndex;
 uniform float material_invAttenuationDistance;
 uniform vec3 material_attenuation;
 
-vec3 refract2(vec3 viewVec, vec3 normal, float IOR) {
-    float vn = dot(viewVec, normal);
-    float k = 1.0 - IOR * IOR * (1.0 - vn * vn);
-    vec3 refrVec = IOR * viewVec - (IOR * vn + sqrt(k)) * normal;
-    return refrVec;
-}
-
 void addRefraction(
     vec3 worldNormal, 
     vec3 viewDir, 


### PR DESCRIPTION
- Remove refract2 from the dynamic refraction as it's not needed. 
- Fix signature of cube refraction.
- Remove superfluously added viewDir argument to refract2 in cube refraction.
