### PR TITLE
Fix lightmapping with 1.62

### DIFF
--- a/src/framework/lightmapper/lightmapper.js
+++ b/src/framework/lightmapper/lightmapper.js
@@ -8,6 +8,7 @@ import { BoundingBox } from '../../core/shape/bounding-box.js';
 import {
     ADDRESS_CLAMP_TO_EDGE,
     CHUNKAPI_1_55,
+    CHUNKAPI_1_62,
     CULLFACE_NONE,
     FILTER_LINEAR, FILTER_NEAREST,
     PIXELFORMAT_RGBA8,
@@ -222,7 +223,7 @@ class Lightmapper {
     createMaterialForPass(device, scene, pass, addAmbient) {
         const material = new StandardMaterial();
         material.name = `lmMaterial-pass:${pass}-ambient:${addAmbient}`;
-        material.chunks.APIVersion = CHUNKAPI_1_55;
+        material.chunks.APIVersion = CHUNKAPI_1_62;
         material.chunks.transformVS = '#define UV1LAYOUT\n' + shaderChunks.transformVS; // draw UV1
 
         if (pass === PASS_COLOR) {

--- a/src/framework/lightmapper/lightmapper.js
+++ b/src/framework/lightmapper/lightmapper.js
@@ -7,7 +7,6 @@ import { BoundingBox } from '../../core/shape/bounding-box.js';
 
 import {
     ADDRESS_CLAMP_TO_EDGE,
-    CHUNKAPI_1_55,
     CHUNKAPI_1_62,
     CULLFACE_NONE,
     FILTER_LINEAR, FILTER_NEAREST,

--- a/src/scene/shader-lib/chunks/lit/frag/clusteredLight.js
+++ b/src/scene/shader-lib/chunks/lit/frag/clusteredLight.js
@@ -593,6 +593,8 @@ void evaluateLight(
             #endif
         }
     }
+
+    // Write to global attenuation values (for lightmapper)
     dAtten = falloffAttenuation;
     dAttenD = diffuseAttenuation;
     dAtten3 = cookieAttenuation;

--- a/src/scene/shader-lib/chunks/lit/frag/clusteredLight.js
+++ b/src/scene/shader-lib/chunks/lit/frag/clusteredLight.js
@@ -593,6 +593,9 @@ void evaluateLight(
             #endif
         }
     }
+    dAtten = falloffAttenuation;
+    dAttenD = diffuseAttenuation;
+    dAtten3 = cookieAttenuation;
 }
 
 void evaluateClusterLight(

--- a/src/scene/shader-lib/chunks/lit/frag/clusteredLight.js
+++ b/src/scene/shader-lib/chunks/lit/frag/clusteredLight.js
@@ -451,11 +451,11 @@ void evaluateLight(
                         getShadowCoordPerspZbufferNormalOffset(lightProjectionMatrix, shadowParams, geometricNormal);
                         
                         #if defined(CLUSTER_SHADOW_TYPE_PCF1)
-                            float shadow = getShadowSpotClusteredPCF1(SHADOWMAP_PASS(shadowAtlasTexture), shadowParams, dLightDirW);
+                            float shadow = getShadowSpotClusteredPCF1(SHADOWMAP_PASS(shadowAtlasTexture), shadowParams);
                         #elif defined(CLUSTER_SHADOW_TYPE_PCF3)
-                            float shadow = getShadowSpotClusteredPCF3(SHADOWMAP_PASS(shadowAtlasTexture), dShadowCoord, shadowParams, dLightDirW);
+                            float shadow = getShadowSpotClusteredPCF3(SHADOWMAP_PASS(shadowAtlasTexture), dShadowCoord, shadowParams);
                         #elif defined(CLUSTER_SHADOW_TYPE_PCF5)
-                            float shadow = getShadowSpotClusteredPCF5(SHADOWMAP_PASS(shadowAtlasTexture), dShadowCoord, shadowParams, dLightDirW);
+                            float shadow = getShadowSpotClusteredPCF5(SHADOWMAP_PASS(shadowAtlasTexture), dShadowCoord, shadowParams);
                         #endif
                         falloffAttenuation *= mix(1.0, shadow, light.shadowIntensity);
 

--- a/src/scene/shader-lib/chunks/lit/frag/clusteredLightShadows.js
+++ b/src/scene/shader-lib/chunks/lit/frag/clusteredLightShadows.js
@@ -101,7 +101,7 @@ export default /* glsl */`
 
     #if defined(CLUSTER_SHADOW_TYPE_PCF1)
 
-    float getShadowSpotClusteredPCF1(SHADOWMAP_ACCEPT(shadowMap), vec3 shadowCoord, vec4 shadowParams, vec3 lightDir) {
+    float getShadowSpotClusteredPCF1(SHADOWMAP_ACCEPT(shadowMap), vec3 shadowCoord, vec4 shadowParams) {
         return textureShadow(shadowMap, shadowCoord);
     }
 
@@ -109,7 +109,7 @@ export default /* glsl */`
 
     #if defined(CLUSTER_SHADOW_TYPE_PCF3)
 
-    float getShadowSpotClusteredPCF3(SHADOWMAP_ACCEPT(shadowMap), vec3 shadowCoord, vec4 shadowParams, vec3 lightDir) {
+    float getShadowSpotClusteredPCF3(SHADOWMAP_ACCEPT(shadowMap), vec3 shadowCoord, vec4 shadowParams) {
         return getShadowSpotPCF3x3(SHADOWMAP_PASS(shadowMap), shadowCoord, shadowParams);
     }
 
@@ -117,7 +117,7 @@ export default /* glsl */`
 
     #if defined(CLUSTER_SHADOW_TYPE_PCF5)
 
-    float getShadowSpotClusteredPCF5(SHADOWMAP_ACCEPT(shadowMap), vec3 shadowCoord, vec4 shadowParams, vec3 lightDir) {
+    float getShadowSpotClusteredPCF5(SHADOWMAP_ACCEPT(shadowMap), vec3 shadowCoord, vec4 shadowParams) {
         return getShadowPCF5x5(SHADOWMAP_PASS(shadowMap), shadowCoord, shadowParams.xyz);
     }
     #endif
@@ -126,7 +126,7 @@ export default /* glsl */`
 
     #if defined(CLUSTER_SHADOW_TYPE_PCF1)
 
-    float getShadowSpotClusteredPCF1(sampler2D shadowMap, vec3 shadowCoord, vec4 shadowParams, vec3 lightDir) {
+    float getShadowSpotClusteredPCF1(sampler2D shadowMap, vec3 shadowCoord, vec4 shadowParams) {
 
         float depth = unpackFloat(textureShadow(shadowMap, shadowCoord.xy));
 
@@ -138,7 +138,7 @@ export default /* glsl */`
 
     #if defined(CLUSTER_SHADOW_TYPE_PCF3)
 
-    float getShadowSpotClusteredPCF3(sampler2D shadowMap, vec3 shadowCoord, vec4 shadowParams, vec3 lightDir) {
+    float getShadowSpotClusteredPCF3(sampler2D shadowMap, vec3 shadowCoord, vec4 shadowParams) {
         return getShadowSpotPCF3x3(shadowMap, shadowCoord, shadowParams);
     }
 
@@ -147,7 +147,7 @@ export default /* glsl */`
     #if defined(CLUSTER_SHADOW_TYPE_PCF5)
 
     // we don't have PCF5 implementation for webgl1, use PCF3
-    float getShadowSpotClusteredPCF5(sampler2D shadowMap, vec3 shadowCoord, vec4 shadowParams, vec3 lightDir) {
+    float getShadowSpotClusteredPCF5(sampler2D shadowMap, vec3 shadowCoord, vec4 shadowParams) {
         return getShadowSpotPCF3x3(shadowMap, shadowCoord, shadowParams);
     }
 

--- a/src/scene/shader-lib/chunks/lit/frag/lightSpecularPhong.js
+++ b/src/scene/shader-lib/chunks/lit/frag/lightSpecularPhong.js
@@ -1,5 +1,5 @@
 export default /* glsl */`
-float calcLightSpecular(float gloss, vec3 reflDir, vec3 h, vec3 lightDirNorm) {
+float calcLightSpecular(float gloss, vec3 reflDir, vec3 lightDirNorm) {
     float specPow = gloss;
 
     // Hack: On Mac OS X, calling pow with zero for the exponent generates hideous artifacts so bias up a little
@@ -7,6 +7,6 @@ float calcLightSpecular(float gloss, vec3 reflDir, vec3 h, vec3 lightDirNorm) {
 }
 
 float getLightSpecular(vec3 h, vec3 reflDir, vec3 worldNormal, vec3 viewDir, vec3 lightDirNorm, float gloss, mat3 tbn) {
-    return calcLightSpecular(gloss, reflDir, h);
+    return calcLightSpecular(gloss, reflDir, lightDirNorm);
 }
 `;

--- a/src/scene/shader-lib/chunks/lit/frag/lightmapAdd.js
+++ b/src/scene/shader-lib/chunks/lit/frag/lightmapAdd.js
@@ -1,5 +1,19 @@
 export default /* glsl */`
-void addLightMap(vec3 lightmap, vec3 dir, vec3 worldNormal, vec3 viewDir, vec3 reflectionDir, float gloss, vec3 specularity, inout vec3 lightDirNorm, vec3 vertexNormal, IridescenceArgs iridescence) {
+void addLightMap(
+    vec3 lightmap, 
+    vec3 dir, 
+    vec3 worldNormal, 
+    vec3 viewDir, 
+    vec3 reflectionDir, 
+    float gloss, 
+    vec3 specularity, 
+    vec3 vertexNormal, 
+    mat3 tbn
+#if defined(LIT_IRIDESCENCE)
+    vec3 iridescenceFresnel, 
+    IridescenceArgs iridescence
+#endif
+) {
     dDiffuseLight += lightmap;
 }
 `;

--- a/src/scene/shader-lib/chunks/lit/frag/lightmapDirAdd.js
+++ b/src/scene/shader-lib/chunks/lit/frag/lightmapDirAdd.js
@@ -7,34 +7,34 @@ void addLightMap(
     vec3 reflectionDir, 
     float gloss, 
     vec3 specularity, 
-    inout vec3 lightDirNorm, 
     vec3 vertexNormal, 
+    mat3 tbn
+#if defined(LIT_IRIDESCENCE)
     vec3 iridescenceFresnel, 
     IridescenceArgs iridescence
+#endif
 ) {
     if (dot(dir, dir) < 0.0001) {
         dDiffuseLight += lightmap;
     } else {
-        lightDirNorm = dir;
-
-        float vlight = saturate(dot(lightDirNorm, -vertexNormal));
-        float flight = saturate(dot(lightDirNorm, -worldNormal));
+        float vlight = saturate(dot(dir, -vertexNormal));
+        float flight = saturate(dot(dir, -worldNormal));
         float nlight = (flight / max(vlight, 0.01)) * 0.5;
 
         dDiffuseLight += lightmap * nlight * 2.0;
 
-        vec3 halfDirW = normalize(-dir + viewDir);
-        vec3 specularLight = lightmap * getLightSpecular(halfDirW, reflectionDir, worldNormal, viewDir, gloss);
+        vec3 halfDir = normalize(-dir + viewDir);
+        vec3 specularLight = lightmap * getLightSpecular(halfDir, reflectionDir, worldNormal, viewDir, dir, gloss, tbn);
 
 #ifdef LIT_SPECULAR_FRESNEL
         specularLight *= 
-            getFresnel(dot(viewDir, halfDirW), 
+            getFresnel(dot(viewDir, halfDir), 
             gloss, 
             specularity
-            #if defined(LIT_IRIDESCENCE)
+        #if defined(LIT_IRIDESCENCE)
             , iridescenceFresnel,
             iridescence
-            #endif
+        #endif
             );
 #endif
 

--- a/src/scene/shader-lib/chunks/lit/frag/spot.js
+++ b/src/scene/shader-lib/chunks/lit/frag/spot.js
@@ -1,6 +1,6 @@
 export default /* glsl */`
-float getSpotEffect(vec3 lightSpotDirW, float lightInnerConeAngle, float lightOuterConeAngle, vec3 lightDirNorm) {
-    float cosAngle = dot(lightDirNorm, lightSpotDirW);
+float getSpotEffect(vec3 lightSpotDir, float lightInnerConeAngle, float lightOuterConeAngle, vec3 lightDirNorm) {
+    float cosAngle = dot(lightDirNorm, lightSpotDir);
     return smoothstep(lightOuterConeAngle, lightInnerConeAngle, cosAngle);
 }
 `;

--- a/src/scene/shader-lib/programs/lit-shader.js
+++ b/src/scene/shader-lib/programs/lit-shader.js
@@ -1053,7 +1053,21 @@ class LitShader {
         }
 
         if (options.lightMapEnabled || options.useLightMapVertexColors) {
-            backend.append("    addLightMap(litShaderArgs.lightmap, litShaderArgs.lightmapDir, litShaderArgs.worldNormal, dViewDirW, dReflDirW, litShaderArgs.gloss, litShaderArgs.specularity, dLightDirNormW, dVertexNormalW, litShaderArgs.iridescence);");
+            backend.append(`    addLightMap(
+                litShaderArgs.lightmap, 
+                litShaderArgs.lightmapDir, 
+                litShaderArgs.worldNormal, 
+                dViewDirW, 
+                dReflDirW, 
+                litShaderArgs.gloss, 
+                litShaderArgs.specularity, 
+                dVertexNormalW,
+                dTBN
+            #if defined(LIT_IRIDESCENCE)
+                , iridescenceFresnel,
+                litShaderArgs.iridescence
+            #endif
+                );`);
         }
 
         if (this.lighting || this.reflections) {


### PR DESCRIPTION
- Writes to dAtten, dAttenD and dAtten3 from clusteredLighting.js for any shaders that might need those values later (such as the lightmapper).
- Remove redundant passing of the half vector to the phong specular function.
- Fixed calls to addLightMap to correctly include the iridescence fresnel.