### PR TITLE
Remove destroyed asserts in render target as grab pass re-uses it when resizing

### DIFF
--- a/src/platform/graphics/render-target.js
+++ b/src/platform/graphics/render-target.js
@@ -167,8 +167,6 @@ class RenderTarget {
 
             this.destroyFrameBuffers();
         }
-
-        DebugHelper.setDestroyed(this);
     }
 
     /**
@@ -208,7 +206,6 @@ class RenderTarget {
      * @ignore
      */
     init() {
-        Debug.assertDestroyed(this);
         this.impl.init(this._device, this);
     }
 

--- a/src/platform/graphics/render-target.js
+++ b/src/platform/graphics/render-target.js
@@ -1,4 +1,4 @@
-import { Debug, DebugHelper } from '../../core/debug.js';
+import { Debug } from '../../core/debug.js';
 import { TRACEID_RENDER_TARGET_ALLOC } from '../../core/constants.js';
 import { PIXELFORMAT_DEPTH, PIXELFORMAT_DEPTHSTENCIL } from './constants.js';
 import { DebugGraphics } from './debug-graphics.js';


### PR DESCRIPTION
avoiding assert ‘RT was destroyed’ as grab pass destroyes it and reuses it. I’ll bring it back later when that is refactored.