### PR TITLE
Further cleanup / optimization to the way face culling is handled

### DIFF
--- a/src/core/math/mat4.js
+++ b/src/core/math/mat4.js
@@ -1182,6 +1182,20 @@ class Mat4 {
     }
 
     /**
+     * -1 if the the matrix has an odd number of negative scales (mirrored); 1 otherwise.
+     *
+     * @type {number}
+     * @ignore
+     */
+    get scaleSign() {
+        this.getX(x);
+        this.getY(y);
+        this.getZ(z);
+        x.cross(x, y);
+        return x.dot(z) < 0 ? -1 : 1;
+    }
+
+    /**
      * Sets the specified matrix to a rotation matrix defined by Euler angles. The Euler angles are
      * specified in XYZ order and in degrees.
      *

--- a/src/scene/batching/batch-manager.js
+++ b/src/scene/batching/batch-manager.js
@@ -64,16 +64,8 @@ const _triStripIndices = [0, 1, 3, 0, 3, 2];
 
 const mat3 = new Mat3();
 
-const worldMatX = new Vec3();
-const worldMatY = new Vec3();
-const worldMatZ = new Vec3();
 function getScaleSign(mi) {
-    const wt = mi.node.worldTransform;
-    wt.getX(worldMatX);
-    wt.getY(worldMatY);
-    wt.getZ(worldMatZ);
-    worldMatX.cross(worldMatX, worldMatY);
-    return worldMatX.dot(worldMatZ) >= 0 ? 1 : -1;
+    return mi.node.worldTransform.scaleSign;
 }
 
 /**
@@ -884,7 +876,7 @@ class BatchManager {
             meshInstance.drawOrder = batch.origMeshInstances[0].drawOrder;
             meshInstance.stencilFront = batch.origMeshInstances[0].stencilFront;
             meshInstance.stencilBack = batch.origMeshInstances[0].stencilBack;
-            meshInstance.flipFaces = getScaleSign(batch.origMeshInstances[0]) < 0;
+            meshInstance.flipFacesFactor = getScaleSign(batch.origMeshInstances[0]);
             meshInstance.castShadow = batch.origMeshInstances[0].castShadow;
 
             batch.meshInstance = meshInstance;

--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -22,9 +22,6 @@ const invParentRot = new Quat();
 const matrix = new Mat4();
 const target = new Vec3();
 const up = new Vec3();
-const _worldMatX = new Vec3();
-const _worldMatY = new Vec3();
-const _worldMatZ = new Vec3();
 
 /**
  * Callback used by {@link GraphNode#find} and {@link GraphNode#findOne} to search through a graph
@@ -181,7 +178,7 @@ class GraphNode extends EventHandler {
          * @type {number}
          * @private
          */
-        this._negativeScaleWorld = 0;
+        this._worldScaleSign = 0;
 
         /**
          * @type {Mat3}
@@ -922,19 +919,13 @@ class GraphNode extends EventHandler {
      * @returns {number} -1 if world transform has negative scale, 1 otherwise.
      * @ignore
      */
-    get negativeScaleWorld() {
+    get worldScaleSign() {
 
-        if (this._negativeScaleWorld === 0) {
-
-            const wt = this.getWorldTransform();
-            wt.getX(_worldMatX);
-            wt.getY(_worldMatY);
-            wt.getZ(_worldMatZ);
-            _worldMatX.cross(_worldMatX, _worldMatY);
-            this._negativeScaleWorld = _worldMatX.dot(_worldMatZ) < 0 ? -1 : 1;
+        if (this._worldScaleSign === 0) {
+            this._worldScaleSign = this.getWorldTransform().scaleSign;
         }
 
-        return this._negativeScaleWorld;
+        return this._worldScaleSign;
     }
 
     /**
@@ -1105,7 +1096,7 @@ class GraphNode extends EventHandler {
             }
         }
         this._dirtyNormal = true;
-        this._negativeScaleWorld = 0;   // world matrix is dirty, mark this flag dirty too
+        this._worldScaleSign = 0;   // world matrix is dirty, mark this flag dirty too
         this._aabbVer++;
     }
 

--- a/src/scene/mesh-instance.js
+++ b/src/scene/mesh-instance.js
@@ -256,7 +256,7 @@ class MeshInstance {
         this.stencilBack = null;
 
         // Negative scale batching support
-        this.flipFaces = false;
+        this.flipFacesFactor = 1;
     }
 
     /**

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -541,6 +541,7 @@ class ForwardRenderer extends Renderer {
         const device = this.device;
         const scene = this.scene;
         const passFlag = 1 << pass;
+        const flipFactor = flipFaces ? -1 : 1;
 
         // Render the scene
         let skipMaterial = false;
@@ -604,7 +605,7 @@ class ForwardRenderer extends Renderer {
 
                 DebugGraphics.pushGpuMarker(device, `Node: ${drawCall.node.name}`);
 
-                this.setCullMode(camera._cullFaces, flipFaces, drawCall);
+                this.setupCullMode(camera._cullFaces, flipFactor, drawCall);
 
                 const stencilFront = drawCall.stencilFront || material.stencilFront;
                 const stencilBack = drawCall.stencilBack || material.stencilBack;

--- a/src/scene/renderer/renderer.js
+++ b/src/scene/renderer/renderer.js
@@ -429,20 +429,14 @@ class Renderer {
         DebugGraphics.popGpuMarker(device);
     }
 
-    setCullMode(cullFaces, flip, drawCall) {
+    setupCullMode(cullFaces, flipFactor, drawCall) {
         const material = drawCall.material;
         let mode = CULLFACE_NONE;
         if (cullFaces) {
             let flipFaces = 1;
 
             if (material.cull === CULLFACE_FRONT || material.cull === CULLFACE_BACK) {
-                if (drawCall.flipFaces)
-                    flipFaces *= -1;
-
-                if (flip)
-                    flipFaces *= -1;
-
-                flipFaces *= drawCall.node.negativeScaleWorld;
+                flipFaces = flipFactor * drawCall.flipFacesFactor * drawCall.node.worldScaleSign;
             }
 
             if (flipFaces < 0) {
@@ -454,7 +448,7 @@ class Renderer {
         this.device.setCullMode(mode);
 
         if (mode === CULLFACE_NONE && material.cull === CULLFACE_NONE) {
-            this.twoSidedLightingNegScaleFactorId.setValue(drawCall.node.negativeScaleWorld);
+            this.twoSidedLightingNegScaleFactorId.setValue(drawCall.node.worldScaleSign);
         }
     }
 

--- a/src/scene/renderer/shadow-renderer.js
+++ b/src/scene/renderer/shadow-renderer.js
@@ -280,7 +280,7 @@ class ShadowRenderer {
 
             if (material.chunks) {
 
-                renderer.setCullMode(true, false, meshInstance);
+                renderer.setupCullMode(true, 1, meshInstance);
 
                 // Uniforms I (shadow): material
                 material.setParameters(device);


### PR DESCRIPTION
- moved shared `scaleSign` getter to Mat4
- passing face culling as a number (-1 or 1) instead of bool which we need to convert to numbers, to speed up per frame cost.