### PR TITLE
Aces2 exposure fix

### DIFF
--- a/src/scene/shader-lib/chunks/common/frag/tonemappingAces2.js
+++ b/src/scene/shader-lib/chunks/common/frag/tonemappingAces2.js
@@ -24,7 +24,7 @@ vec3 RRTAndODTFit(vec3 v) {
 }
 
 vec3 toneMap(vec3 color) {
-    color *= exposure;
+    color *= exposure / 0.6;
     color = color * ACESInputMat;
 
     // Apply RRT and ODT


### PR DESCRIPTION
Aces2 tonemapping was too dark compared to the others because it was missing a / 0.6 term.

With this PR the brightness level of aces2 is in line with the others at a given exposure.