### PR TITLE
Eliminate `var` from the code base

### DIFF
--- a/src/core/core.js
+++ b/src/core/core.js
@@ -50,12 +50,12 @@ function type(obj) {
  * @param {object} ex - The object that is merged with target.
  * @returns {object} The target object.
  * @example
- * var A = {
+ * const A = {
  *     a: function () {
  *         console.log(this.a);
  *     }
  * };
- * var B = {
+ * const B = {
  *     b: function () {
  *         console.log(this.b);
  *     }

--- a/src/core/event-handler.js
+++ b/src/core/event-handler.js
@@ -16,7 +16,7 @@
  * Abstract base class that implements functionality for event handling.
  *
  * ```javascript
- * var obj = new EventHandlerSubclass();
+ * const obj = new EventHandlerSubclass();
  *
  * // subscribe to an event
  * obj.on('hello', function (str) {
@@ -109,7 +109,7 @@ class EventHandler {
      * @param {object} [scope] - Scope that was used as the this when the event is fired.
      * @returns {EventHandler} Self for chaining.
      * @example
-     * var handler = function () {
+     * const handler = function () {
      * };
      * obj.on('test', handler);
      *

--- a/src/core/events.js
+++ b/src/core/events.js
@@ -7,7 +7,7 @@ const events = {
      * @param {object} target - The object to add events to.
      * @returns {object} The target object.
      * @example
-     * var obj = { };
+     * const obj = { };
      * pc.events.attach(obj);
      * @ignore
      */

--- a/src/core/math/color.js
+++ b/src/core/math/color.js
@@ -73,8 +73,8 @@ class Color {
      * @param {Color} rhs - A color to copy to the specified color.
      * @returns {Color} Self for chaining.
      * @example
-     * var src = new pc.Color(1, 0, 0, 1);
-     * var dst = new pc.Color();
+     * const src = new pc.Color(1, 0, 0, 1);
+     * const dst = new pc.Color();
      *
      * dst.copy(src);
      *
@@ -95,8 +95,8 @@ class Color {
      * @param {Color} rhs - The color to compare to the specified color.
      * @returns {boolean} True if the colors are equal and false otherwise.
      * @example
-     * var a = new pc.Color(1, 0, 0, 1);
-     * var b = new pc.Color(1, 1, 0, 1);
+     * const a = new pc.Color(1, 0, 0, 1);
+     * const b = new pc.Color(1, 1, 0, 1);
      * console.log("The two colors are " + (a.equals(b) ? "equal" : "different"));
      */
     equals(rhs) {
@@ -131,9 +131,9 @@ class Color {
      * range, the linear interpolant will occur on a ray extrapolated from this line.
      * @returns {Color} Self for chaining.
      * @example
-     * var a = new pc.Color(0, 0, 0);
-     * var b = new pc.Color(1, 1, 0.5);
-     * var r = new pc.Color();
+     * const a = new pc.Color(0, 0, 0);
+     * const b = new pc.Color(1, 1, 0.5);
+     * const r = new pc.Color();
      *
      * r.lerp(a, b, 0);   // r is equal to a
      * r.lerp(a, b, 0.5); // r is 0.5, 0.5, 0.25
@@ -179,7 +179,7 @@ class Color {
      * @param {boolean} alpha - If true, the output string will include the alpha value.
      * @returns {string} The color in string form.
      * @example
-     * var c = new pc.Color(1, 1, 1);
+     * const c = new pc.Color(1, 1, 1);
      * // Outputs #ffffffff
      * console.log(c.toString());
      */

--- a/src/core/math/curve-set.js
+++ b/src/core/math/curve-set.js
@@ -20,7 +20,7 @@ class CurveSet {
      * @param {Array<number[]>} curveKeys - An array of arrays of keys (pairs of numbers with the
      * time first and value second).
      * @example
-     * var curveSet = new pc.CurveSet([
+     * const curveSet = new pc.CurveSet([
      *     [
      *         0, 0,        // At 0 time, value of 0
      *         0.33, 2,     // At 0.33 time, value of 2

--- a/src/core/math/curve.js
+++ b/src/core/math/curve.js
@@ -45,7 +45,7 @@ class Curve {
      * @param {number[]} [data] - An array of keys (pairs of numbers with the time first and value
      * second).
      * @example
-     * var curve = new pc.Curve([
+     * const curve = new pc.Curve([
      *     0, 0,        // At 0 time, value of 0
      *     0.33, 2,     // At 0.33 time, value of 2
      *     0.66, 2.6,   // At 0.66 time, value of 2.6

--- a/src/core/math/mat3.js
+++ b/src/core/math/mat3.js
@@ -25,8 +25,8 @@ class Mat3 {
      *
      * @returns {this} A duplicate matrix.
      * @example
-     * var src = new pc.Mat3().translate(10, 20, 30);
-     * var dst = src.clone();
+     * const src = new pc.Mat3().translate(10, 20, 30);
+     * const dst = src.clone();
      * console.log("The two matrices are " + (src.equals(dst) ? "equal" : "different"));
      */
     clone() {
@@ -41,8 +41,8 @@ class Mat3 {
      * @param {Mat3} rhs - A 3x3 matrix to be copied.
      * @returns {Mat3} Self for chaining.
      * @example
-     * var src = new pc.Mat3().translate(10, 20, 30);
-     * var dst = new pc.Mat3();
+     * const src = new pc.Mat3().translate(10, 20, 30);
+     * const dst = new pc.Mat3();
      * dst.copy(src);
      * console.log("The two matrices are " + (src.equals(dst) ? "equal" : "different"));
      */
@@ -69,7 +69,7 @@ class Mat3 {
      * @param {number[]} src - An array[9] to be copied.
      * @returns {Mat3} Self for chaining.
      * @example
-     * var dst = new pc.Mat3();
+     * const dst = new pc.Mat3();
      * dst.set([0, 1, 2, 3, 4, 5, 6, 7, 8]);
      */
     set(src) {
@@ -94,8 +94,8 @@ class Mat3 {
      * @param {Mat3} rhs - The other matrix.
      * @returns {boolean} True if the matrices are equal and false otherwise.
      * @example
-     * var a = new pc.Mat3().translate(10, 20, 30);
-     * var b = new pc.Mat3();
+     * const a = new pc.Mat3().translate(10, 20, 30);
+     * const b = new pc.Mat3();
      * console.log("The two matrices are " + (a.equals(b) ? "equal" : "different"));
      */
     equals(rhs) {
@@ -118,7 +118,7 @@ class Mat3 {
      *
      * @returns {boolean} True if the matrix is identity and false otherwise.
      * @example
-     * var m = new pc.Mat3();
+     * const m = new pc.Mat3();
      * console.log("The matrix is " + (m.isIdentity() ? "identity" : "not identity"));
      */
     isIdentity() {
@@ -164,7 +164,7 @@ class Mat3 {
      *
      * @returns {string} The matrix in string form.
      * @example
-     * var m = new pc.Mat3();
+     * const m = new pc.Mat3();
      * // Outputs [1, 0, 0, 0, 1, 0, 0, 0, 1]
      * console.log(m.toString());
      */
@@ -177,7 +177,7 @@ class Mat3 {
      *
      * @returns {Mat3} Self for chaining.
      * @example
-     * var m = new pc.Mat3();
+     * const m = new pc.Mat3();
      *
      * // Transpose in place
      * m.transpose();

--- a/src/core/math/mat4.js
+++ b/src/core/math/mat4.js
@@ -47,7 +47,7 @@ class Mat4 {
      * @param {Mat4} rhs - The 4x4 matrix used as the second operand of the addition.
      * @returns {Mat4} Self for chaining.
      * @example
-     * var m = new pc.Mat4();
+     * const m = new pc.Mat4();
      *
      * m.add2(pc.Mat4.IDENTITY, pc.Mat4.ONE);
      *
@@ -84,7 +84,7 @@ class Mat4 {
      * @param {Mat4} rhs - The 4x4 matrix used as the second operand of the addition.
      * @returns {Mat4} Self for chaining.
      * @example
-     * var m = new pc.Mat4();
+     * const m = new pc.Mat4();
      *
      * m.add(pc.Mat4.ONE);
      *
@@ -99,8 +99,8 @@ class Mat4 {
      *
      * @returns {this} A duplicate matrix.
      * @example
-     * var src = new pc.Mat4().setFromEulerAngles(10, 20, 30);
-     * var dst = src.clone();
+     * const src = new pc.Mat4().setFromEulerAngles(10, 20, 30);
+     * const dst = src.clone();
      * console.log("The two matrices are " + (src.equals(dst) ? "equal" : "different"));
      */
     clone() {
@@ -115,8 +115,8 @@ class Mat4 {
      * @param {Mat4} rhs - A 4x4 matrix to be copied.
      * @returns {Mat4} Self for chaining.
      * @example
-     * var src = new pc.Mat4().setFromEulerAngles(10, 20, 30);
-     * var dst = new pc.Mat4();
+     * const src = new pc.Mat4().setFromEulerAngles(10, 20, 30);
+     * const dst = new pc.Mat4();
      * dst.copy(src);
      * console.log("The two matrices are " + (src.equals(dst) ? "equal" : "different"));
      */
@@ -150,8 +150,8 @@ class Mat4 {
      * @param {Mat4} rhs - The other matrix.
      * @returns {boolean} True if the matrices are equal and false otherwise.
      * @example
-     * var a = new pc.Mat4().setFromEulerAngles(10, 20, 30);
-     * var b = new pc.Mat4();
+     * const a = new pc.Mat4().setFromEulerAngles(10, 20, 30);
+     * const b = new pc.Mat4();
      * console.log("The two matrices are " + (a.equals(b) ? "equal" : "different"));
      */
     equals(rhs) {
@@ -181,7 +181,7 @@ class Mat4 {
      *
      * @returns {boolean} True if the matrix is identity and false otherwise.
      * @example
-     * var m = new pc.Mat4();
+     * const m = new pc.Mat4();
      * console.log("The matrix is " + (m.isIdentity() ? "identity" : "not identity"));
      */
     isIdentity() {
@@ -213,9 +213,9 @@ class Mat4 {
      * @param {Mat4} rhs - The 4x4 matrix used as the second multiplicand of the operation.
      * @returns {Mat4} Self for chaining.
      * @example
-     * var a = new pc.Mat4().setFromEulerAngles(10, 20, 30);
-     * var b = new pc.Mat4().setFromAxisAngle(pc.Vec3.UP, 180);
-     * var r = new pc.Mat4();
+     * const a = new pc.Mat4().setFromEulerAngles(10, 20, 30);
+     * const b = new pc.Mat4().setFromAxisAngle(pc.Vec3.UP, 180);
+     * const r = new pc.Mat4();
      *
      * // r = a * b
      * r.mul2(a, b);
@@ -360,8 +360,8 @@ class Mat4 {
      * @param {Mat4} rhs - The 4x4 matrix used as the second multiplicand of the operation.
      * @returns {Mat4} Self for chaining.
      * @example
-     * var a = new pc.Mat4().setFromEulerAngles(10, 20, 30);
-     * var b = new pc.Mat4().setFromAxisAngle(pc.Vec3.UP, 180);
+     * const a = new pc.Mat4().setFromEulerAngles(10, 20, 30);
+     * const b = new pc.Mat4().setFromAxisAngle(pc.Vec3.UP, 180);
      *
      * // a = a * b
      * a.mul(b);
@@ -381,12 +381,12 @@ class Mat4 {
      * @returns {Vec3} The input point v transformed by the current instance.
      * @example
      * // Create a 3-dimensional point
-     * var v = new pc.Vec3(1, 2, 3);
+     * const v = new pc.Vec3(1, 2, 3);
      *
      * // Create a 4x4 rotation matrix
-     * var m = new pc.Mat4().setFromEulerAngles(10, 20, 30);
+     * const m = new pc.Mat4().setFromEulerAngles(10, 20, 30);
      *
-     * var tv = m.transformPoint(v);
+     * const tv = m.transformPoint(v);
      */
     transformPoint(vec, res = new Vec3()) {
         const m = this.data;
@@ -411,12 +411,12 @@ class Mat4 {
      * @returns {Vec3} The input vector v transformed by the current instance.
      * @example
      * // Create a 3-dimensional vector
-     * var v = new pc.Vec3(1, 2, 3);
+     * const v = new pc.Vec3(1, 2, 3);
      *
      * // Create a 4x4 rotation matrix
-     * var m = new pc.Mat4().setFromEulerAngles(10, 20, 30);
+     * const m = new pc.Mat4().setFromEulerAngles(10, 20, 30);
      *
-     * var tv = m.transformVector(v);
+     * const tv = m.transformVector(v);
      */
     transformVector(vec, res = new Vec3()) {
         const m = this.data;
@@ -441,13 +441,13 @@ class Mat4 {
      * @returns {Vec4} The input vector v transformed by the current instance.
      * @example
      * // Create an input 4-dimensional vector
-     * var v = new pc.Vec4(1, 2, 3, 4);
+     * const v = new pc.Vec4(1, 2, 3, 4);
      *
      * // Create an output 4-dimensional vector
-     * var result = new pc.Vec4();
+     * const result = new pc.Vec4();
      *
      * // Create a 4x4 rotation matrix
-     * var m = new pc.Mat4().setFromEulerAngles(10, 20, 30);
+     * const m = new pc.Mat4().setFromEulerAngles(10, 20, 30);
      *
      * m.transformVec4(v, result);
      */
@@ -481,10 +481,10 @@ class Mat4 {
      * @param {Vec3} up - 3-d vector holding the up direction.
      * @returns {Mat4} Self for chaining.
      * @example
-     * var position = new pc.Vec3(10, 10, 10);
-     * var target = new pc.Vec3(0, 0, 0);
-     * var up = new pc.Vec3(0, 1, 0);
-     * var m = new pc.Mat4().setLookAt(position, target, up);
+     * const position = new pc.Vec3(10, 10, 10);
+     * const target = new pc.Vec3(0, 0, 0);
+     * const up = new pc.Vec3(0, 1, 0);
+     * const m = new pc.Mat4().setLookAt(position, target, up);
      */
     setLookAt(position, target, up) {
         z.sub2(position, target).normalize();
@@ -531,7 +531,7 @@ class Mat4 {
      * @returns {Mat4} Self for chaining.
      * @example
      * // Create a 4x4 perspective projection matrix
-     * var f = pc.Mat4().setFrustum(-2, 2, -1, 1, 1, 1000);
+     * const f = pc.Mat4().setFrustum(-2, 2, -1, 1, 1, 1000);
      * @ignore
      */
     setFrustum(left, right, bottom, top, znear, zfar) {
@@ -577,7 +577,7 @@ class Mat4 {
      * @returns {Mat4} Self for chaining.
      * @example
      * // Create a 4x4 perspective projection matrix
-     * var persp = pc.Mat4().setPerspective(45, 16 / 9, 1, 1000);
+     * const persp = pc.Mat4().setPerspective(45, 16 / 9, 1, 1000);
      */
     setPerspective(fov, aspect, znear, zfar, fovIsHorizontal) {
         Mat4._getPerspectiveHalfSize(_halfSize, fov, aspect, znear, fovIsHorizontal);
@@ -601,7 +601,7 @@ class Mat4 {
      * @returns {Mat4} Self for chaining.
      * @example
      * // Create a 4x4 orthographic projection matrix
-     * var ortho = pc.Mat4().ortho(-2, 2, -2, 2, 1, 1000);
+     * const ortho = pc.Mat4().ortho(-2, 2, -2, 2, 1, 1000);
      */
     setOrtho(left, right, bottom, top, near, far) {
         const r = this.data;
@@ -635,7 +635,7 @@ class Mat4 {
      * @returns {Mat4} Self for chaining.
      * @example
      * // Create a 4x4 rotation matrix
-     * var rm = new pc.Mat4().setFromAxisAngle(pc.Vec3.UP, 90);
+     * const rm = new pc.Mat4().setFromAxisAngle(pc.Vec3.UP, 90);
      */
     setFromAxisAngle(axis, angle) {
         angle *= math.DEG_TO_RAD;
@@ -679,7 +679,7 @@ class Mat4 {
      * @returns {Mat4} Self for chaining.
      * @example
      * // Create a 4x4 translation matrix
-     * var tm = new pc.Mat4().setTranslate(10, 10, 10);
+     * const tm = new pc.Mat4().setTranslate(10, 10, 10);
      * @ignore
      */
     setTranslate(x, y, z) {
@@ -714,7 +714,7 @@ class Mat4 {
      * @returns {Mat4} Self for chaining.
      * @example
      * // Create a 4x4 scale matrix
-     * var sm = new pc.Mat4().setScale(10, 10, 10);
+     * const sm = new pc.Mat4().setScale(10, 10, 10);
      * @ignore
      */
     setScale(x, y, z) {
@@ -752,7 +752,7 @@ class Mat4 {
      * @returns {Mat4} Self for chaining.
      * @example
      * // Create a 4x4 viewport matrix which scales normalized view volume to full texture viewport
-     * var vm = new pc.Mat4().setViewport(0, 0, 1, 1);
+     * const vm = new pc.Mat4().setViewport(0, 0, 1, 1);
      * @ignore
      */
     setViewport(x, y, width, height) {
@@ -819,7 +819,7 @@ class Mat4 {
      * @returns {Mat4} Self for chaining.
      * @example
      * // Create a 4x4 rotation matrix of 180 degrees around the y-axis
-     * var rot = new pc.Mat4().setFromAxisAngle(pc.Vec3.UP, 180);
+     * const rot = new pc.Mat4().setFromAxisAngle(pc.Vec3.UP, 180);
      *
      * // Invert in place
      * rot.invert();
@@ -953,11 +953,11 @@ class Mat4 {
      * @param {Vec3} s - A 3-d vector scale.
      * @returns {Mat4} Self for chaining.
      * @example
-     * var t = new pc.Vec3(10, 20, 30);
-     * var r = new pc.Quat();
-     * var s = new pc.Vec3(2, 2, 2);
+     * const t = new pc.Vec3(10, 20, 30);
+     * const r = new pc.Quat();
+     * const s = new pc.Vec3(2, 2, 2);
      *
-     * var m = new pc.Mat4();
+     * const m = new pc.Mat4();
      * m.setTRS(t, r, s);
      */
     setTRS(t, r, s) {
@@ -1013,7 +1013,7 @@ class Mat4 {
      *
      * @returns {Mat4} Self for chaining.
      * @example
-     * var m = new pc.Mat4();
+     * const m = new pc.Mat4();
      *
      * // Transpose in place
      * m.transpose();
@@ -1102,10 +1102,10 @@ class Mat4 {
      * @returns {Vec3} The translation of the specified 4x4 matrix.
      * @example
      * // Create a 4x4 matrix
-     * var m = new pc.Mat4();
+     * const m = new pc.Mat4();
      *
      * // Query the translation component
-     * var t = new pc.Vec3();
+     * const t = new pc.Vec3();
      * m.getTranslation(t);
      */
     getTranslation(t = new Vec3()) {
@@ -1119,10 +1119,10 @@ class Mat4 {
      * @returns {Vec3} The x-axis of the specified 4x4 matrix.
      * @example
      * // Create a 4x4 matrix
-     * var m = new pc.Mat4();
+     * const m = new pc.Mat4();
      *
      * // Query the x-axis component
-     * var x = new pc.Vec3();
+     * const x = new pc.Vec3();
      * m.getX(x);
      */
     getX(x = new Vec3()) {
@@ -1136,10 +1136,10 @@ class Mat4 {
      * @returns {Vec3} The y-axis of the specified 4x4 matrix.
      * @example
      * // Create a 4x4 matrix
-     * var m = new pc.Mat4();
+     * const m = new pc.Mat4();
      *
      * // Query the y-axis component
-     * var y = new pc.Vec3();
+     * const y = new pc.Vec3();
      * m.getY(y);
      */
     getY(y = new Vec3()) {
@@ -1153,10 +1153,10 @@ class Mat4 {
      * @returns {Vec3} The z-axis of the specified 4x4 matrix.
      * @example
      * // Create a 4x4 matrix
-     * var m = new pc.Mat4();
+     * const m = new pc.Mat4();
      *
      * // Query the z-axis component
-     * var z = new pc.Vec3();
+     * const z = new pc.Vec3();
      * m.getZ(z);
      */
     getZ(z = new Vec3()) {
@@ -1170,7 +1170,7 @@ class Mat4 {
      * @returns {Vec3} The scale in X, Y and Z of the specified 4x4 matrix.
      * @example
      * // Query the scale component
-     * var scale = m.getScale();
+     * const scale = m.getScale();
      */
     getScale(scale = new Vec3()) {
         this.getX(x);
@@ -1204,7 +1204,7 @@ class Mat4 {
      * @param {number} ez - Angle to rotate around Z axis in degrees.
      * @returns {Mat4} Self for chaining.
      * @example
-     * var m = new pc.Mat4();
+     * const m = new pc.Mat4();
      * m.setFromEulerAngles(45, 90, 180);
      */
     setFromEulerAngles(ex, ey, ez) {
@@ -1257,9 +1257,9 @@ class Mat4 {
      * @returns {Vec3} A 3-d vector containing the Euler angles.
      * @example
      * // Create a 4x4 rotation matrix of 45 degrees around the y-axis
-     * var m = new pc.Mat4().setFromAxisAngle(pc.Vec3.UP, 45);
+     * const m = new pc.Mat4().setFromAxisAngle(pc.Vec3.UP, 45);
      *
-     * var eulers = m.getEulerAngles();
+     * const eulers = m.getEulerAngles();
      */
     getEulerAngles(eulers = new Vec3()) {
         this.getScale(scale);
@@ -1300,7 +1300,7 @@ class Mat4 {
      *
      * @returns {string} The matrix in string form.
      * @example
-     * var m = new pc.Mat4();
+     * const m = new pc.Mat4();
      * // Outputs [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]
      * console.log(m.toString());
      */

--- a/src/core/math/math.js
+++ b/src/core/math/math.js
@@ -39,7 +39,7 @@ const math = {
      * @returns {number[]} An array of 3 bytes.
      * @example
      * // Set bytes to [0x11, 0x22, 0x33]
-     * var bytes = pc.math.intToBytes24(0x112233);
+     * const bytes = pc.math.intToBytes24(0x112233);
      */
     intToBytes24: function (i) {
         const r = (i >> 16) & 0xff;
@@ -56,7 +56,7 @@ const math = {
      * @returns {number[]} An array of 4 bytes.
      * @example
      * // Set bytes to [0x11, 0x22, 0x33, 0x44]
-     * var bytes = pc.math.intToBytes32(0x11223344);
+     * const bytes = pc.math.intToBytes32(0x11223344);
      */
     intToBytes32: function (i) {
         const r = (i >> 24) & 0xff;
@@ -76,10 +76,10 @@ const math = {
      * @returns {number} A single unsigned 24 bit Number.
      * @example
      * // Set result1 to 0x112233 from an array of 3 values
-     * var result1 = pc.math.bytesToInt24([0x11, 0x22, 0x33]);
+     * const result1 = pc.math.bytesToInt24([0x11, 0x22, 0x33]);
      *
      * // Set result2 to 0x112233 from 3 discrete values
-     * var result2 = pc.math.bytesToInt24(0x11, 0x22, 0x33);
+     * const result2 = pc.math.bytesToInt24(0x11, 0x22, 0x33);
      */
     bytesToInt24: function (r, g, b) {
         if (r.length) {
@@ -100,10 +100,10 @@ const math = {
      * @returns {number} A single unsigned 32bit Number.
      * @example
      * // Set result1 to 0x11223344 from an array of 4 values
-     * var result1 = pc.math.bytesToInt32([0x11, 0x22, 0x33, 0x44]);
+     * const result1 = pc.math.bytesToInt32([0x11, 0x22, 0x33, 0x44]);
      *
      * // Set result2 to 0x11223344 from 4 discrete values
-     * var result2 = pc.math.bytesToInt32(0x11, 0x22, 0x33, 0x44);
+     * const result2 = pc.math.bytesToInt32(0x11, 0x22, 0x33, 0x44);
      */
     bytesToInt32: function (r, g, b, a) {
         if (r.length) {

--- a/src/core/math/quat.js
+++ b/src/core/math/quat.js
@@ -61,8 +61,8 @@ class Quat {
      *
      * @returns {this} A quaternion containing the result of the cloning.
      * @example
-     * var q = new pc.Quat(-0.11, -0.15, -0.46, 0.87);
-     * var qclone = q.clone();
+     * const q = new pc.Quat(-0.11, -0.15, -0.46, 0.87);
+     * const qclone = q.clone();
      *
      * console.log("The result of the cloning is: " + q.toString());
      */
@@ -86,8 +86,8 @@ class Quat {
      * @param {Quat} rhs - The quaternion to be copied.
      * @returns {Quat} Self for chaining.
      * @example
-     * var src = new pc.Quat();
-     * var dst = new pc.Quat();
+     * const src = new pc.Quat();
+     * const dst = new pc.Quat();
      * dst.copy(src, src);
      * console.log("The two quaternions are " + (src.equals(dst) ? "equal" : "different"));
      */
@@ -106,8 +106,8 @@ class Quat {
      * @param {Quat} rhs - The quaternion to be compared against.
      * @returns {boolean} True if the quaternions are equal and false otherwise.
      * @example
-     * var a = new pc.Quat();
-     * var b = new pc.Quat();
+     * const a = new pc.Quat();
+     * const b = new pc.Quat();
      * console.log("The two quaternions are " + (a.equals(b) ? "equal" : "different"));
      */
     equals(rhs) {
@@ -121,8 +121,8 @@ class Quat {
      * @param {number} [epsilon=1e-6] - The maximum difference between each component of the two quaternions. Defaults to 1e-6.
      * @returns {boolean} True if the quaternions are equal and false otherwise.
      * @example
-     * var a = new pc.Quat();
-     * var b = new pc.Quat();
+     * const a = new pc.Quat();
+     * const b = new pc.Quat();
      * console.log("The two quaternions are approximately " + (a.equalsApprox(b, 1e-9) ? "equal" : "different"));
      */
     equalsApprox(rhs, epsilon = 1e-6) {
@@ -140,10 +140,10 @@ class Quat {
      * @param {Vec3} axis - The 3-dimensional vector to receive the axis of rotation.
      * @returns {number} Angle, in degrees, of the rotation.
      * @example
-     * var q = new pc.Quat();
+     * const q = new pc.Quat();
      * q.setFromAxisAngle(new pc.Vec3(0, 1, 0), 90);
-     * var v = new pc.Vec3();
-     * var angle = q.getAxisAngle(v);
+     * const v = new pc.Vec3();
+     * const angle = q.getAxisAngle(v);
      * // Outputs 90
      * console.log(angle);
      * // Outputs [0, 1, 0]
@@ -212,7 +212,7 @@ class Quat {
      * @returns {Quat} Self for chaining.
      * @example
      * // Create a quaternion rotated 180 degrees around the y-axis
-     * var rot = new pc.Quat().setFromEulerAngles(0, 180, 0);
+     * const rot = new pc.Quat().setFromEulerAngles(0, 180, 0);
      *
      * // Invert in place
      * rot.invert();
@@ -226,8 +226,8 @@ class Quat {
      *
      * @returns {number} The magnitude of the specified quaternion.
      * @example
-     * var q = new pc.Quat(0, 0, 0, 5);
-     * var len = q.length();
+     * const q = new pc.Quat(0, 0, 0, 5);
+     * const len = q.length();
      * // Outputs 5
      * console.log("The length of the quaternion is: " + len);
      */
@@ -240,8 +240,8 @@ class Quat {
      *
      * @returns {number} The magnitude of the specified quaternion.
      * @example
-     * var q = new pc.Quat(3, 4, 0);
-     * var lenSq = q.lengthSq();
+     * const q = new pc.Quat(3, 4, 0);
+     * const lenSq = q.lengthSq();
      * // Outputs 25
      * console.log("The length squared of the quaternion is: " + lenSq);
      */
@@ -255,8 +255,8 @@ class Quat {
      * @param {Quat} rhs - The quaternion used as the second multiplicand of the operation.
      * @returns {Quat} Self for chaining.
      * @example
-     * var a = new pc.Quat().setFromEulerAngles(0, 30, 0);
-     * var b = new pc.Quat().setFromEulerAngles(0, 60, 0);
+     * const a = new pc.Quat().setFromEulerAngles(0, 30, 0);
+     * const b = new pc.Quat().setFromEulerAngles(0, 60, 0);
      *
      * // a becomes a 90 degree rotation around the Y axis
      * // In other words, a = a * b
@@ -290,9 +290,9 @@ class Quat {
      * @param {Quat} rhs - The quaternion used as the second multiplicand of the operation.
      * @returns {Quat} Self for chaining.
      * @example
-     * var a = new pc.Quat().setFromEulerAngles(0, 30, 0);
-     * var b = new pc.Quat().setFromEulerAngles(0, 60, 0);
-     * var r = new pc.Quat();
+     * const a = new pc.Quat().setFromEulerAngles(0, 30, 0);
+     * const b = new pc.Quat().setFromEulerAngles(0, 60, 0);
+     * const r = new pc.Quat();
      *
      * // r is set to a 90 degree rotation around the Y axis
      * // In other words, r = a * b
@@ -324,7 +324,7 @@ class Quat {
      *
      * @returns {Quat} The result of the normalization.
      * @example
-     * var v = new pc.Quat(0, 0, 0, 5);
+     * const v = new pc.Quat(0, 0, 0, 5);
      *
      * v.normalize();
      *
@@ -356,7 +356,7 @@ class Quat {
      * @param {number} w - The w component of the quaternion.
      * @returns {Quat} Self for chaining.
      * @example
-     * var q = new pc.Quat();
+     * const q = new pc.Quat();
      * q.set(1, 0, 0, 0);
      *
      * // Outputs 1, 0, 0, 0
@@ -378,7 +378,7 @@ class Quat {
      * @param {number} angle - Angle to rotate around the given axis in degrees.
      * @returns {Quat} Self for chaining.
      * @example
-     * var q = new pc.Quat();
+     * const q = new pc.Quat();
      * q.setFromAxisAngle(pc.Vec3.UP, 90);
      */
     setFromAxisAngle(axis, angle) {
@@ -405,12 +405,12 @@ class Quat {
      * @returns {Quat} Self for chaining.
      * @example
      * // Create a quaternion from 3 euler angles
-     * var q = new pc.Quat();
+     * const q = new pc.Quat();
      * q.setFromEulerAngles(45, 90, 180);
      *
      * // Create the same quaternion from a vector containing the same 3 euler angles
-     * var v = new pc.Vec3(45, 90, 180);
-     * var r = new pc.Quat();
+     * const v = new pc.Vec3(45, 90, 180);
+     * const r = new pc.Quat();
      * r.setFromEulerAngles(v);
      */
     setFromEulerAngles(ex, ey, ez) {
@@ -449,10 +449,10 @@ class Quat {
      * @returns {Quat} Self for chaining.
      * @example
      * // Create a 4x4 rotation matrix of 180 degrees around the y-axis
-     * var rot = new pc.Mat4().setFromAxisAngle(pc.Vec3.UP, 180);
+     * const rot = new pc.Mat4().setFromAxisAngle(pc.Vec3.UP, 180);
      *
      * // Convert to a quaternion
-     * var q = new pc.Quat().setFromMat4(rot);
+     * const q = new pc.Quat().setFromMat4(rot);
      */
     setFromMat4(m) {
         let m00, m01, m02, m10, m11, m12, m20, m21, m22,
@@ -602,10 +602,10 @@ class Quat {
      * in between generating a spherical interpolation between the two.
      * @returns {Quat} Self for chaining.
      * @example
-     * var q1 = new pc.Quat(-0.11, -0.15, -0.46, 0.87);
-     * var q2 = new pc.Quat(-0.21, -0.21, -0.67, 0.68);
+     * const q1 = new pc.Quat(-0.11, -0.15, -0.46, 0.87);
+     * const q2 = new pc.Quat(-0.21, -0.21, -0.67, 0.68);
      *
-     * var result;
+     * const result;
      * result = new pc.Quat().slerp(q1, q2, 0);   // Return q1
      * result = new pc.Quat().slerp(q1, q2, 0.5); // Return the midpoint interpolant
      * result = new pc.Quat().slerp(q1, q2, 1);   // Return q2
@@ -675,12 +675,12 @@ class Quat {
      * @returns {Vec3} The input vector v transformed by the current instance.
      * @example
      * // Create a 3-dimensional vector
-     * var v = new pc.Vec3(1, 2, 3);
+     * const v = new pc.Vec3(1, 2, 3);
      *
      * // Create a 4x4 rotation matrix
-     * var q = new pc.Quat().setFromEulerAngles(10, 20, 30);
+     * const q = new pc.Quat().setFromEulerAngles(10, 20, 30);
      *
-     * var tv = q.transformVector(v);
+     * const tv = q.transformVector(v);
      */
     transformVector(vec, res = new Vec3()) {
         const x = vec.x, y = vec.y, z = vec.z;
@@ -705,7 +705,7 @@ class Quat {
      *
      * @returns {string} The quaternion in string form.
      * @example
-     * var v = new pc.Quat(0, 0, 0, 1);
+     * const v = new pc.Quat(0, 0, 0, 1);
      * // Outputs [0, 0, 0, 1]
      * console.log(v.toString());
      */

--- a/src/core/math/vec2.js
+++ b/src/core/math/vec2.js
@@ -23,7 +23,7 @@ class Vec2 {
      * array will be used to populate all components.
      * @param {number} [y] - The y value. Defaults to 0.
      * @example
-     * var v = new pc.Vec2(1, 2);
+     * const v = new pc.Vec2(1, 2);
      */
     constructor(x = 0, y = 0) {
         if (x.length === 2) {
@@ -41,8 +41,8 @@ class Vec2 {
      * @param {Vec2} rhs - The vector to add to the specified vector.
      * @returns {Vec2} Self for chaining.
      * @example
-     * var a = new pc.Vec2(10, 10);
-     * var b = new pc.Vec2(20, 20);
+     * const a = new pc.Vec2(10, 10);
+     * const b = new pc.Vec2(20, 20);
      *
      * a.add(b);
      *
@@ -63,9 +63,9 @@ class Vec2 {
      * @param {Vec2} rhs - The second vector operand for the addition.
      * @returns {Vec2} Self for chaining.
      * @example
-     * var a = new pc.Vec2(10, 10);
-     * var b = new pc.Vec2(20, 20);
-     * var r = new pc.Vec2();
+     * const a = new pc.Vec2(10, 10);
+     * const b = new pc.Vec2(20, 20);
+     * const r = new pc.Vec2();
      *
      * r.add2(a, b);
      * // Outputs [30, 30]
@@ -85,7 +85,7 @@ class Vec2 {
      * @param {number} scalar - The number to add.
      * @returns {Vec2} Self for chaining.
      * @example
-     * var vec = new pc.Vec2(3, 4);
+     * const vec = new pc.Vec2(3, 4);
      *
      * vec.addScalar(2);
      *
@@ -104,8 +104,8 @@ class Vec2 {
      *
      * @returns {this} A 2-dimensional vector containing the result of the cloning.
      * @example
-     * var v = new pc.Vec2(10, 20);
-     * var vclone = v.clone();
+     * const v = new pc.Vec2(10, 20);
+     * const vclone = v.clone();
      * console.log("The result of the cloning is: " + vclone.toString());
      */
     clone() {
@@ -120,8 +120,8 @@ class Vec2 {
      * @param {Vec2} rhs - A vector to copy to the specified vector.
      * @returns {Vec2} Self for chaining.
      * @example
-     * var src = new pc.Vec2(10, 20);
-     * var dst = new pc.Vec2();
+     * const src = new pc.Vec2(10, 20);
+     * const dst = new pc.Vec2();
      *
      * dst.copy(src);
      *
@@ -141,9 +141,9 @@ class Vec2 {
      * @param {Vec2} rhs - The second 2-dimensional vector operand of the cross product.
      * @returns {number} The cross product of the two vectors.
      * @example
-     * var right = new pc.Vec2(1, 0);
-     * var up = new pc.Vec2(0, 1);
-     * var crossProduct = right.cross(up);
+     * const right = new pc.Vec2(1, 0);
+     * const up = new pc.Vec2(0, 1);
+     * const crossProduct = right.cross(up);
      *
      * // Prints 1
      * console.log("The result of the cross product is: " + crossProduct);
@@ -158,9 +158,9 @@ class Vec2 {
      * @param {Vec2} rhs - The second 2-dimensional vector to test.
      * @returns {number} The distance between the two vectors.
      * @example
-     * var v1 = new pc.Vec2(5, 10);
-     * var v2 = new pc.Vec2(10, 20);
-     * var d = v1.distance(v2);
+     * const v1 = new pc.Vec2(5, 10);
+     * const v2 = new pc.Vec2(10, 20);
+     * const d = v1.distance(v2);
      * console.log("The distance between v1 and v2 is: " + d);
      */
     distance(rhs) {
@@ -175,8 +175,8 @@ class Vec2 {
      * @param {Vec2} rhs - The vector to divide the specified vector by.
      * @returns {Vec2} Self for chaining.
      * @example
-     * var a = new pc.Vec2(4, 9);
-     * var b = new pc.Vec2(2, 3);
+     * const a = new pc.Vec2(4, 9);
+     * const b = new pc.Vec2(2, 3);
      *
      * a.div(b);
      *
@@ -197,9 +197,9 @@ class Vec2 {
      * @param {Vec2} rhs - The divisor vector (the vector dividing the dividend).
      * @returns {Vec2} Self for chaining.
      * @example
-     * var a = new pc.Vec2(4, 9);
-     * var b = new pc.Vec2(2, 3);
-     * var r = new pc.Vec2();
+     * const a = new pc.Vec2(4, 9);
+     * const b = new pc.Vec2(2, 3);
+     * const r = new pc.Vec2();
      *
      * r.div2(a, b);
      * // Outputs [2, 3]
@@ -219,7 +219,7 @@ class Vec2 {
      * @param {number} scalar - The number to divide by.
      * @returns {Vec2} Self for chaining.
      * @example
-     * var vec = new pc.Vec2(3, 6);
+     * const vec = new pc.Vec2(3, 6);
      *
      * vec.divScalar(3);
      *
@@ -240,9 +240,9 @@ class Vec2 {
      * @param {Vec2} rhs - The second 2-dimensional vector operand of the dot product.
      * @returns {number} The result of the dot product operation.
      * @example
-     * var v1 = new pc.Vec2(5, 10);
-     * var v2 = new pc.Vec2(10, 20);
-     * var v1dotv2 = v1.dot(v2);
+     * const v1 = new pc.Vec2(5, 10);
+     * const v2 = new pc.Vec2(10, 20);
+     * const v1dotv2 = v1.dot(v2);
      * console.log("The result of the dot product is: " + v1dotv2);
      */
     dot(rhs) {
@@ -255,8 +255,8 @@ class Vec2 {
      * @param {Vec2} rhs - The vector to compare to the specified vector.
      * @returns {boolean} True if the vectors are equal and false otherwise.
      * @example
-     * var a = new pc.Vec2(1, 2);
-     * var b = new pc.Vec2(4, 5);
+     * const a = new pc.Vec2(1, 2);
+     * const b = new pc.Vec2(4, 5);
      * console.log("The two vectors are " + (a.equals(b) ? "equal" : "different"));
      */
     equals(rhs) {
@@ -268,8 +268,8 @@ class Vec2 {
      *
      * @returns {number} The magnitude of the specified 2-dimensional vector.
      * @example
-     * var vec = new pc.Vec2(3, 4);
-     * var len = vec.length();
+     * const vec = new pc.Vec2(3, 4);
+     * const len = vec.length();
      * // Outputs 5
      * console.log("The length of the vector is: " + len);
      */
@@ -282,8 +282,8 @@ class Vec2 {
      *
      * @returns {number} The magnitude of the specified 2-dimensional vector.
      * @example
-     * var vec = new pc.Vec2(3, 4);
-     * var len = vec.lengthSq();
+     * const vec = new pc.Vec2(3, 4);
+     * const len = vec.lengthSq();
      * // Outputs 25
      * console.log("The length squared of the vector is: " + len);
      */
@@ -301,9 +301,9 @@ class Vec2 {
      * range, the linear interpolant will occur on a ray extrapolated from this line.
      * @returns {Vec2} Self for chaining.
      * @example
-     * var a = new pc.Vec2(0, 0);
-     * var b = new pc.Vec2(10, 10);
-     * var r = new pc.Vec2();
+     * const a = new pc.Vec2(0, 0);
+     * const b = new pc.Vec2(10, 10);
+     * const r = new pc.Vec2();
      *
      * r.lerp(a, b, 0);   // r is equal to a
      * r.lerp(a, b, 0.5); // r is 5, 5
@@ -322,8 +322,8 @@ class Vec2 {
      * @param {Vec2} rhs - The 2-dimensional vector used as the second multiplicand of the operation.
      * @returns {Vec2} Self for chaining.
      * @example
-     * var a = new pc.Vec2(2, 3);
-     * var b = new pc.Vec2(4, 5);
+     * const a = new pc.Vec2(2, 3);
+     * const b = new pc.Vec2(4, 5);
      *
      * a.mul(b);
      *
@@ -344,9 +344,9 @@ class Vec2 {
      * @param {Vec2} rhs - The 2-dimensional vector used as the second multiplicand of the operation.
      * @returns {Vec2} Self for chaining.
      * @example
-     * var a = new pc.Vec2(2, 3);
-     * var b = new pc.Vec2(4, 5);
-     * var r = new pc.Vec2();
+     * const a = new pc.Vec2(2, 3);
+     * const b = new pc.Vec2(4, 5);
+     * const r = new pc.Vec2();
      *
      * r.mul2(a, b);
      *
@@ -366,7 +366,7 @@ class Vec2 {
      * @param {number} scalar - The number to multiply by.
      * @returns {Vec2} Self for chaining.
      * @example
-     * var vec = new pc.Vec2(3, 6);
+     * const vec = new pc.Vec2(3, 6);
      *
      * vec.mulScalar(3);
      *
@@ -386,7 +386,7 @@ class Vec2 {
      *
      * @returns {Vec2} Self for chaining.
      * @example
-     * var v = new pc.Vec2(25, 0);
+     * const v = new pc.Vec2(25, 0);
      *
      * v.normalize();
      *
@@ -468,7 +468,7 @@ class Vec2 {
      * @param {number} y - The value to set on the second component of the vector.
      * @returns {Vec2} Self for chaining.
      * @example
-     * var v = new pc.Vec2();
+     * const v = new pc.Vec2();
      * v.set(5, 10);
      *
      * // Outputs 5, 10
@@ -487,8 +487,8 @@ class Vec2 {
      * @param {Vec2} rhs - The vector to subtract from the specified vector.
      * @returns {Vec2} Self for chaining.
      * @example
-     * var a = new pc.Vec2(10, 10);
-     * var b = new pc.Vec2(20, 20);
+     * const a = new pc.Vec2(10, 10);
+     * const b = new pc.Vec2(20, 20);
      *
      * a.sub(b);
      *
@@ -509,9 +509,9 @@ class Vec2 {
      * @param {Vec2} rhs - The second vector operand for the subtraction.
      * @returns {Vec2} Self for chaining.
      * @example
-     * var a = new pc.Vec2(10, 10);
-     * var b = new pc.Vec2(20, 20);
-     * var r = new pc.Vec2();
+     * const a = new pc.Vec2(10, 10);
+     * const b = new pc.Vec2(20, 20);
+     * const r = new pc.Vec2();
      *
      * r.sub2(a, b);
      *
@@ -531,7 +531,7 @@ class Vec2 {
      * @param {number} scalar - The number to subtract.
      * @returns {Vec2} Self for chaining.
      * @example
-     * var vec = new pc.Vec2(3, 4);
+     * const vec = new pc.Vec2(3, 4);
      *
      * vec.subScalar(2);
      *
@@ -550,7 +550,7 @@ class Vec2 {
      *
      * @returns {string} The vector in string form.
      * @example
-     * var v = new pc.Vec2(20, 10);
+     * const v = new pc.Vec2(20, 10);
      * // Outputs [20, 10]
      * console.log(v.toString());
      */

--- a/src/core/math/vec3.js
+++ b/src/core/math/vec3.js
@@ -31,7 +31,7 @@ class Vec3 {
      * @param {number} [y] - The y value. Defaults to 0.
      * @param {number} [z] - The z value. Defaults to 0.
      * @example
-     * var v = new pc.Vec3(1, 2, 3);
+     * const v = new pc.Vec3(1, 2, 3);
      */
     constructor(x = 0, y = 0, z = 0) {
         if (x.length === 3) {
@@ -51,8 +51,8 @@ class Vec3 {
      * @param {Vec3} rhs - The vector to add to the specified vector.
      * @returns {Vec3} Self for chaining.
      * @example
-     * var a = new pc.Vec3(10, 10, 10);
-     * var b = new pc.Vec3(20, 20, 20);
+     * const a = new pc.Vec3(10, 10, 10);
+     * const b = new pc.Vec3(20, 20, 20);
      *
      * a.add(b);
      *
@@ -74,9 +74,9 @@ class Vec3 {
      * @param {Vec3} rhs - The second vector operand for the addition.
      * @returns {Vec3} Self for chaining.
      * @example
-     * var a = new pc.Vec3(10, 10, 10);
-     * var b = new pc.Vec3(20, 20, 20);
-     * var r = new pc.Vec3();
+     * const a = new pc.Vec3(10, 10, 10);
+     * const b = new pc.Vec3(20, 20, 20);
+     * const r = new pc.Vec3();
      *
      * r.add2(a, b);
      * // Outputs [30, 30, 30]
@@ -97,7 +97,7 @@ class Vec3 {
      * @param {number} scalar - The number to add.
      * @returns {Vec3} Self for chaining.
      * @example
-     * var vec = new pc.Vec3(3, 4, 5);
+     * const vec = new pc.Vec3(3, 4, 5);
      *
      * vec.addScalar(2);
      *
@@ -117,8 +117,8 @@ class Vec3 {
      *
      * @returns {this} A 3-dimensional vector containing the result of the cloning.
      * @example
-     * var v = new pc.Vec3(10, 20, 30);
-     * var vclone = v.clone();
+     * const v = new pc.Vec3(10, 20, 30);
+     * const vclone = v.clone();
      * console.log("The result of the cloning is: " + vclone.toString());
      */
     clone() {
@@ -133,8 +133,8 @@ class Vec3 {
      * @param {Vec3} rhs - A vector to copy to the specified vector.
      * @returns {Vec3} Self for chaining.
      * @example
-     * var src = new pc.Vec3(10, 20, 30);
-     * var dst = new pc.Vec3();
+     * const src = new pc.Vec3(10, 20, 30);
+     * const dst = new pc.Vec3();
      *
      * dst.copy(src);
      *
@@ -156,7 +156,7 @@ class Vec3 {
      * @param {Vec3} rhs - The second 3-dimensional vector operand of the cross product.
      * @returns {Vec3} Self for chaining.
      * @example
-     * var back = new pc.Vec3().cross(pc.Vec3.RIGHT, pc.Vec3.UP);
+     * const back = new pc.Vec3().cross(pc.Vec3.RIGHT, pc.Vec3.UP);
      *
      * // Prints the Z axis (i.e. [0, 0, 1])
      * console.log("The result of the cross product is: " + back.toString());
@@ -183,9 +183,9 @@ class Vec3 {
      * @param {Vec3} rhs - The second 3-dimensional vector to test.
      * @returns {number} The distance between the two vectors.
      * @example
-     * var v1 = new pc.Vec3(5, 10, 20);
-     * var v2 = new pc.Vec3(10, 20, 40);
-     * var d = v1.distance(v2);
+     * const v1 = new pc.Vec3(5, 10, 20);
+     * const v2 = new pc.Vec3(10, 20, 40);
+     * const d = v1.distance(v2);
      * console.log("The distance between v1 and v2 is: " + d);
      */
     distance(rhs) {
@@ -201,8 +201,8 @@ class Vec3 {
      * @param {Vec3} rhs - The vector to divide the specified vector by.
      * @returns {Vec3} Self for chaining.
      * @example
-     * var a = new pc.Vec3(4, 9, 16);
-     * var b = new pc.Vec3(2, 3, 4);
+     * const a = new pc.Vec3(4, 9, 16);
+     * const b = new pc.Vec3(2, 3, 4);
      *
      * a.div(b);
      *
@@ -224,9 +224,9 @@ class Vec3 {
      * @param {Vec3} rhs - The divisor vector (the vector dividing the dividend).
      * @returns {Vec3} Self for chaining.
      * @example
-     * var a = new pc.Vec3(4, 9, 16);
-     * var b = new pc.Vec3(2, 3, 4);
-     * var r = new pc.Vec3();
+     * const a = new pc.Vec3(4, 9, 16);
+     * const b = new pc.Vec3(2, 3, 4);
+     * const r = new pc.Vec3();
      *
      * r.div2(a, b);
      * // Outputs [2, 3, 4]
@@ -247,7 +247,7 @@ class Vec3 {
      * @param {number} scalar - The number to divide by.
      * @returns {Vec3} Self for chaining.
      * @example
-     * var vec = new pc.Vec3(3, 6, 9);
+     * const vec = new pc.Vec3(3, 6, 9);
      *
      * vec.divScalar(3);
      *
@@ -269,9 +269,9 @@ class Vec3 {
      * @param {Vec3} rhs - The second 3-dimensional vector operand of the dot product.
      * @returns {number} The result of the dot product operation.
      * @example
-     * var v1 = new pc.Vec3(5, 10, 20);
-     * var v2 = new pc.Vec3(10, 20, 40);
-     * var v1dotv2 = v1.dot(v2);
+     * const v1 = new pc.Vec3(5, 10, 20);
+     * const v2 = new pc.Vec3(10, 20, 40);
+     * const v1dotv2 = v1.dot(v2);
      * console.log("The result of the dot product is: " + v1dotv2);
      */
     dot(rhs) {
@@ -284,8 +284,8 @@ class Vec3 {
      * @param {Vec3} rhs - The vector to compare to the specified vector.
      * @returns {boolean} True if the vectors are equal and false otherwise.
      * @example
-     * var a = new pc.Vec3(1, 2, 3);
-     * var b = new pc.Vec3(4, 5, 6);
+     * const a = new pc.Vec3(1, 2, 3);
+     * const b = new pc.Vec3(4, 5, 6);
      * console.log("The two vectors are " + (a.equals(b) ? "equal" : "different"));
      */
     equals(rhs) {
@@ -297,8 +297,8 @@ class Vec3 {
      *
      * @returns {number} The magnitude of the specified 3-dimensional vector.
      * @example
-     * var vec = new pc.Vec3(3, 4, 0);
-     * var len = vec.length();
+     * const vec = new pc.Vec3(3, 4, 0);
+     * const len = vec.length();
      * // Outputs 5
      * console.log("The length of the vector is: " + len);
      */
@@ -311,8 +311,8 @@ class Vec3 {
      *
      * @returns {number} The magnitude of the specified 3-dimensional vector.
      * @example
-     * var vec = new pc.Vec3(3, 4, 0);
-     * var len = vec.lengthSq();
+     * const vec = new pc.Vec3(3, 4, 0);
+     * const len = vec.lengthSq();
      * // Outputs 25
      * console.log("The length squared of the vector is: " + len);
      */
@@ -330,9 +330,9 @@ class Vec3 {
      * range, the linear interpolant will occur on a ray extrapolated from this line.
      * @returns {Vec3} Self for chaining.
      * @example
-     * var a = new pc.Vec3(0, 0, 0);
-     * var b = new pc.Vec3(10, 10, 10);
-     * var r = new pc.Vec3();
+     * const a = new pc.Vec3(0, 0, 0);
+     * const b = new pc.Vec3(10, 10, 10);
+     * const r = new pc.Vec3();
      *
      * r.lerp(a, b, 0);   // r is equal to a
      * r.lerp(a, b, 0.5); // r is 5, 5, 5
@@ -352,8 +352,8 @@ class Vec3 {
      * @param {Vec3} rhs - The 3-dimensional vector used as the second multiplicand of the operation.
      * @returns {Vec3} Self for chaining.
      * @example
-     * var a = new pc.Vec3(2, 3, 4);
-     * var b = new pc.Vec3(4, 5, 6);
+     * const a = new pc.Vec3(2, 3, 4);
+     * const b = new pc.Vec3(4, 5, 6);
      *
      * a.mul(b);
      *
@@ -375,9 +375,9 @@ class Vec3 {
      * @param {Vec3} rhs - The 3-dimensional vector used as the second multiplicand of the operation.
      * @returns {Vec3} Self for chaining.
      * @example
-     * var a = new pc.Vec3(2, 3, 4);
-     * var b = new pc.Vec3(4, 5, 6);
-     * var r = new pc.Vec3();
+     * const a = new pc.Vec3(2, 3, 4);
+     * const b = new pc.Vec3(4, 5, 6);
+     * const r = new pc.Vec3();
      *
      * r.mul2(a, b);
      *
@@ -398,7 +398,7 @@ class Vec3 {
      * @param {number} scalar - The number to multiply by.
      * @returns {Vec3} Self for chaining.
      * @example
-     * var vec = new pc.Vec3(3, 6, 9);
+     * const vec = new pc.Vec3(3, 6, 9);
      *
      * vec.mulScalar(3);
      *
@@ -419,7 +419,7 @@ class Vec3 {
      *
      * @returns {Vec3} Self for chaining.
      * @example
-     * var v = new pc.Vec3(25, 0, 0);
+     * const v = new pc.Vec3(25, 0, 0);
      *
      * v.normalize();
      *
@@ -506,8 +506,8 @@ class Vec3 {
      * @param {Vec3} rhs - The vector onto which the original vector will be projected on.
      * @returns {Vec3} Self for chaining.
      * @example
-     * var v = new pc.Vec3(5, 5, 5);
-     * var normal = new pc.Vec3(1, 0, 0);
+     * const v = new pc.Vec3(5, 5, 5);
+     * const normal = new pc.Vec3(1, 0, 0);
      *
      * v.project(normal);
      *
@@ -532,7 +532,7 @@ class Vec3 {
      * @param {number} z - The value to set on the third component of the vector.
      * @returns {Vec3} Self for chaining.
      * @example
-     * var v = new pc.Vec3();
+     * const v = new pc.Vec3();
      * v.set(5, 10, 20);
      *
      * // Outputs 5, 10, 20
@@ -552,8 +552,8 @@ class Vec3 {
      * @param {Vec3} rhs - The vector to subtract from the specified vector.
      * @returns {Vec3} Self for chaining.
      * @example
-     * var a = new pc.Vec3(10, 10, 10);
-     * var b = new pc.Vec3(20, 20, 20);
+     * const a = new pc.Vec3(10, 10, 10);
+     * const b = new pc.Vec3(20, 20, 20);
      *
      * a.sub(b);
      *
@@ -575,9 +575,9 @@ class Vec3 {
      * @param {Vec3} rhs - The second vector operand for the subtraction.
      * @returns {Vec3} Self for chaining.
      * @example
-     * var a = new pc.Vec3(10, 10, 10);
-     * var b = new pc.Vec3(20, 20, 20);
-     * var r = new pc.Vec3();
+     * const a = new pc.Vec3(10, 10, 10);
+     * const b = new pc.Vec3(20, 20, 20);
+     * const r = new pc.Vec3();
      *
      * r.sub2(a, b);
      *
@@ -598,7 +598,7 @@ class Vec3 {
      * @param {number} scalar - The number to subtract.
      * @returns {Vec3} Self for chaining.
      * @example
-     * var vec = new pc.Vec3(3, 4, 5);
+     * const vec = new pc.Vec3(3, 4, 5);
      *
      * vec.subScalar(2);
      *
@@ -618,7 +618,7 @@ class Vec3 {
      *
      * @returns {string} The vector in string form.
      * @example
-     * var v = new pc.Vec3(20, 10, 5);
+     * const v = new pc.Vec3(20, 10, 5);
      * // Outputs [20, 10, 5]
      * console.log(v.toString());
      */

--- a/src/core/math/vec4.js
+++ b/src/core/math/vec4.js
@@ -39,7 +39,7 @@ class Vec4 {
      * @param {number} [z] - The z value. Defaults to 0.
      * @param {number} [w] - The w value. Defaults to 0.
      * @example
-     * var v = new pc.Vec4(1, 2, 3, 4);
+     * const v = new pc.Vec4(1, 2, 3, 4);
      */
     constructor(x = 0, y = 0, z = 0, w = 0) {
         if (x.length === 4) {
@@ -61,8 +61,8 @@ class Vec4 {
      * @param {Vec4} rhs - The vector to add to the specified vector.
      * @returns {Vec4} Self for chaining.
      * @example
-     * var a = new pc.Vec4(10, 10, 10, 10);
-     * var b = new pc.Vec4(20, 20, 20, 20);
+     * const a = new pc.Vec4(10, 10, 10, 10);
+     * const b = new pc.Vec4(20, 20, 20, 20);
      *
      * a.add(b);
      *
@@ -85,9 +85,9 @@ class Vec4 {
      * @param {Vec4} rhs - The second vector operand for the addition.
      * @returns {Vec4} Self for chaining.
      * @example
-     * var a = new pc.Vec4(10, 10, 10, 10);
-     * var b = new pc.Vec4(20, 20, 20, 20);
-     * var r = new pc.Vec4();
+     * const a = new pc.Vec4(10, 10, 10, 10);
+     * const b = new pc.Vec4(20, 20, 20, 20);
+     * const r = new pc.Vec4();
      *
      * r.add2(a, b);
      * // Outputs [30, 30, 30]
@@ -109,7 +109,7 @@ class Vec4 {
      * @param {number} scalar - The number to add.
      * @returns {Vec4} Self for chaining.
      * @example
-     * var vec = new pc.Vec4(3, 4, 5, 6);
+     * const vec = new pc.Vec4(3, 4, 5, 6);
      *
      * vec.addScalar(2);
      *
@@ -130,8 +130,8 @@ class Vec4 {
      *
      * @returns {this} A 4-dimensional vector containing the result of the cloning.
      * @example
-     * var v = new pc.Vec4(10, 20, 30, 40);
-     * var vclone = v.clone();
+     * const v = new pc.Vec4(10, 20, 30, 40);
+     * const vclone = v.clone();
      * console.log("The result of the cloning is: " + vclone.toString());
      */
     clone() {
@@ -146,8 +146,8 @@ class Vec4 {
      * @param {Vec4} rhs - A vector to copy to the specified vector.
      * @returns {Vec4} Self for chaining.
      * @example
-     * var src = new pc.Vec4(10, 20, 30, 40);
-     * var dst = new pc.Vec4();
+     * const src = new pc.Vec4(10, 20, 30, 40);
+     * const dst = new pc.Vec4();
      *
      * dst.copy(src);
      *
@@ -168,8 +168,8 @@ class Vec4 {
      * @param {Vec4} rhs - The vector to divide the specified vector by.
      * @returns {Vec4} Self for chaining.
      * @example
-     * var a = new pc.Vec4(4, 9, 16, 25);
-     * var b = new pc.Vec4(2, 3, 4, 5);
+     * const a = new pc.Vec4(4, 9, 16, 25);
+     * const b = new pc.Vec4(2, 3, 4, 5);
      *
      * a.div(b);
      *
@@ -192,9 +192,9 @@ class Vec4 {
      * @param {Vec4} rhs - The divisor vector (the vector dividing the dividend).
      * @returns {Vec4} Self for chaining.
      * @example
-     * var a = new pc.Vec4(4, 9, 16, 25);
-     * var b = new pc.Vec4(2, 3, 4, 5);
-     * var r = new pc.Vec4();
+     * const a = new pc.Vec4(4, 9, 16, 25);
+     * const b = new pc.Vec4(2, 3, 4, 5);
+     * const r = new pc.Vec4();
      *
      * r.div2(a, b);
      * // Outputs [2, 3, 4, 5]
@@ -216,7 +216,7 @@ class Vec4 {
      * @param {number} scalar - The number to divide by.
      * @returns {Vec4} Self for chaining.
      * @example
-     * var vec = new pc.Vec4(3, 6, 9, 12);
+     * const vec = new pc.Vec4(3, 6, 9, 12);
      *
      * vec.divScalar(3);
      *
@@ -239,9 +239,9 @@ class Vec4 {
      * @param {Vec4} rhs - The second 4-dimensional vector operand of the dot product.
      * @returns {number} The result of the dot product operation.
      * @example
-     * var v1 = new pc.Vec4(5, 10, 20, 40);
-     * var v2 = new pc.Vec4(10, 20, 40, 80);
-     * var v1dotv2 = v1.dot(v2);
+     * const v1 = new pc.Vec4(5, 10, 20, 40);
+     * const v2 = new pc.Vec4(10, 20, 40, 80);
+     * const v1dotv2 = v1.dot(v2);
      * console.log("The result of the dot product is: " + v1dotv2);
      */
     dot(rhs) {
@@ -254,8 +254,8 @@ class Vec4 {
      * @param {Vec4} rhs - The vector to compare to the specified vector.
      * @returns {boolean} True if the vectors are equal and false otherwise.
      * @example
-     * var a = new pc.Vec4(1, 2, 3, 4);
-     * var b = new pc.Vec4(5, 6, 7, 8);
+     * const a = new pc.Vec4(1, 2, 3, 4);
+     * const b = new pc.Vec4(5, 6, 7, 8);
      * console.log("The two vectors are " + (a.equals(b) ? "equal" : "different"));
      */
     equals(rhs) {
@@ -267,8 +267,8 @@ class Vec4 {
      *
      * @returns {number} The magnitude of the specified 4-dimensional vector.
      * @example
-     * var vec = new pc.Vec4(3, 4, 0, 0);
-     * var len = vec.length();
+     * const vec = new pc.Vec4(3, 4, 0, 0);
+     * const len = vec.length();
      * // Outputs 5
      * console.log("The length of the vector is: " + len);
      */
@@ -281,8 +281,8 @@ class Vec4 {
      *
      * @returns {number} The magnitude of the specified 4-dimensional vector.
      * @example
-     * var vec = new pc.Vec4(3, 4, 0);
-     * var len = vec.lengthSq();
+     * const vec = new pc.Vec4(3, 4, 0);
+     * const len = vec.lengthSq();
      * // Outputs 25
      * console.log("The length squared of the vector is: " + len);
      */
@@ -300,9 +300,9 @@ class Vec4 {
      * range, the linear interpolant will occur on a ray extrapolated from this line.
      * @returns {Vec4} Self for chaining.
      * @example
-     * var a = new pc.Vec4(0, 0, 0, 0);
-     * var b = new pc.Vec4(10, 10, 10, 10);
-     * var r = new pc.Vec4();
+     * const a = new pc.Vec4(0, 0, 0, 0);
+     * const b = new pc.Vec4(10, 10, 10, 10);
+     * const r = new pc.Vec4();
      *
      * r.lerp(a, b, 0);   // r is equal to a
      * r.lerp(a, b, 0.5); // r is 5, 5, 5, 5
@@ -323,8 +323,8 @@ class Vec4 {
      * @param {Vec4} rhs - The 4-dimensional vector used as the second multiplicand of the operation.
      * @returns {Vec4} Self for chaining.
      * @example
-     * var a = new pc.Vec4(2, 3, 4, 5);
-     * var b = new pc.Vec4(4, 5, 6, 7);
+     * const a = new pc.Vec4(2, 3, 4, 5);
+     * const b = new pc.Vec4(4, 5, 6, 7);
      *
      * a.mul(b);
      *
@@ -347,9 +347,9 @@ class Vec4 {
      * @param {Vec4} rhs - The 4-dimensional vector used as the second multiplicand of the operation.
      * @returns {Vec4} Self for chaining.
      * @example
-     * var a = new pc.Vec4(2, 3, 4, 5);
-     * var b = new pc.Vec4(4, 5, 6, 7);
-     * var r = new pc.Vec4();
+     * const a = new pc.Vec4(2, 3, 4, 5);
+     * const b = new pc.Vec4(4, 5, 6, 7);
+     * const r = new pc.Vec4();
      *
      * r.mul2(a, b);
      *
@@ -371,7 +371,7 @@ class Vec4 {
      * @param {number} scalar - The number to multiply by.
      * @returns {Vec4} Self for chaining.
      * @example
-     * var vec = new pc.Vec4(3, 6, 9, 12);
+     * const vec = new pc.Vec4(3, 6, 9, 12);
      *
      * vec.mulScalar(3);
      *
@@ -393,7 +393,7 @@ class Vec4 {
      *
      * @returns {Vec4} Self for chaining.
      * @example
-     * var v = new pc.Vec4(25, 0, 0, 0);
+     * const v = new pc.Vec4(25, 0, 0, 0);
      *
      * v.normalize();
      *
@@ -489,7 +489,7 @@ class Vec4 {
      * @param {number} w - The value to set on the fourth component of the vector.
      * @returns {Vec4} Self for chaining.
      * @example
-     * var v = new pc.Vec4();
+     * const v = new pc.Vec4();
      * v.set(5, 10, 20, 40);
      *
      * // Outputs 5, 10, 20, 40
@@ -510,8 +510,8 @@ class Vec4 {
      * @param {Vec4} rhs - The vector to add to the specified vector.
      * @returns {Vec4} Self for chaining.
      * @example
-     * var a = new pc.Vec4(10, 10, 10, 10);
-     * var b = new pc.Vec4(20, 20, 20, 20);
+     * const a = new pc.Vec4(10, 10, 10, 10);
+     * const b = new pc.Vec4(20, 20, 20, 20);
      *
      * a.sub(b);
      *
@@ -534,9 +534,9 @@ class Vec4 {
      * @param {Vec4} rhs - The second vector operand for the subtraction.
      * @returns {Vec4} Self for chaining.
      * @example
-     * var a = new pc.Vec4(10, 10, 10, 10);
-     * var b = new pc.Vec4(20, 20, 20, 20);
-     * var r = new pc.Vec4();
+     * const a = new pc.Vec4(10, 10, 10, 10);
+     * const b = new pc.Vec4(20, 20, 20, 20);
+     * const r = new pc.Vec4();
      *
      * r.sub2(a, b);
      *
@@ -558,7 +558,7 @@ class Vec4 {
      * @param {number} scalar - The number to subtract.
      * @returns {Vec4} Self for chaining.
      * @example
-     * var vec = new pc.Vec4(3, 4, 5, 6);
+     * const vec = new pc.Vec4(3, 4, 5, 6);
      *
      * vec.subScalar(2);
      *
@@ -579,7 +579,7 @@ class Vec4 {
      *
      * @returns {string} The vector in string form.
      * @example
-     * var v = new pc.Vec4(20, 10, 5, 0);
+     * const v = new pc.Vec4(20, 10, 5, 0);
      * // Outputs [20, 10, 5, 0]
      * console.log(v.toString());
      */

--- a/src/core/path.js
+++ b/src/core/path.js
@@ -19,10 +19,10 @@ const path = {
      * @param {...string} section - Section of path to join. 2 or more can be provided as parameters.
      * @returns {string} The joined file path.
      * @example
-     * var path = pc.path.join('foo', 'bar');
+     * const path = pc.path.join('foo', 'bar');
      * console.log(path); // Prints 'foo/bar'
      * @example
-     * var path = pc.path.join('alpha', 'beta', 'gamma');
+     * const path = pc.path.join('alpha', 'beta', 'gamma');
      * console.log(path); // Prints 'alpha/beta/gamma'
      */
     join: function () {

--- a/src/core/shape/bounding-sphere.js
+++ b/src/core/shape/bounding-sphere.js
@@ -30,7 +30,7 @@ class BoundingSphere {
      * @param {number} [radius] - The radius of the bounding sphere. Defaults to 0.5.
      * @example
      * // Create a new bounding sphere centered on the origin with a radius of 0.5
-     * var sphere = new pc.BoundingSphere();
+     * const sphere = new pc.BoundingSphere();
      */
     constructor(center = new Vec3(), radius = 0.5) {
         Debug.assert(!Object.isFrozen(center), 'The constructor of \'BoundingSphere\' does not accept a constant (frozen) object as a \'center\' parameter');

--- a/src/core/shape/frustum.js
+++ b/src/core/shape/frustum.js
@@ -10,7 +10,7 @@ class Frustum {
      * Create a new Frustum instance.
      *
      * @example
-     * var frustum = new pc.Frustum();
+     * const frustum = new pc.Frustum();
      */
     constructor() {
         for (let i = 0; i < 6; i++)
@@ -24,11 +24,11 @@ class Frustum {
      * frustum.
      * @example
      * // Create a perspective projection matrix
-     * var projMat = pc.Mat4();
+     * const projMat = pc.Mat4();
      * projMat.setPerspective(45, 16 / 9, 1, 1000);
      *
      * // Create a frustum shape that is represented by the matrix
-     * var frustum = new pc.Frustum();
+     * const frustum = new pc.Frustum();
      * frustum.setFromMat4(projMat);
      */
     setFromMat4(matrix) {

--- a/src/core/shape/ray.js
+++ b/src/core/shape/ray.js
@@ -31,7 +31,7 @@ class Ray {
      * @example
      * // Create a new ray starting at the position of this entity and pointing down
      * // the entity's negative Z axis
-     * var ray = new pc.Ray(this.entity.getPosition(), this.entity.forward);
+     * const ray = new pc.Ray(this.entity.getPosition(), this.entity.forward);
      */
     constructor(origin, direction) {
         if (origin) {

--- a/src/core/sorted-loop-array.js
+++ b/src/core/sorted-loop-array.js
@@ -42,7 +42,7 @@ class SortedLoopArray {
      * @param {string} args.sortBy - The name of the field that each element in the array is going
      * to be sorted by.
      * @example
-     * var array = new pc.SortedLoopArray({ sortBy: 'priority' });
+     * const array = new pc.SortedLoopArray({ sortBy: 'priority' });
      * array.insert(item); // adds item to the right slot based on item.priority
      * array.append(item); // adds item to the end of the array
      * array.remove(item); // removes item from array

--- a/src/core/string.js
+++ b/src/core/string.js
@@ -130,7 +130,7 @@ const string = {
      * @param {object} [arguments] - All other arguments are substituted into the string.
      * @returns {string} The formatted string.
      * @example
-     * var s = pc.string.format("Hello {0}", "world");
+     * const s = pc.string.format("Hello {0}", "world");
      * console.log(s); // Prints "Hello world"
      */
     format: function (s) {

--- a/src/core/uri.js
+++ b/src/core/uri.js
@@ -147,9 +147,9 @@ class URI {
      *
      * @returns {object} The URI's query parameters converted to an Object.
      * @example
-     * var s = "http://example.com?a=1&b=2&c=3";
-     * var uri = new pc.URI(s);
-     * var q = uri.getQuery();
+     * const s = "http://example.com?a=1&b=2&c=3";
+     * const uri = new pc.URI(s);
+     * const q = uri.getQuery();
      * console.log(q.a); // logs "1"
      * console.log(q.b); // logs "2"
      * console.log(q.c); // logs "3"
@@ -173,8 +173,8 @@ class URI {
      *
      * @param {object} params - Key-Value pairs to encode into the query string.
      * @example
-     * var s = "http://example.com";
-     * var uri = new pc.URI(s);
+     * const s = "http://example.com";
+     * const uri = new pc.URI(s);
      * uri.setQuery({
      *     "a": 1,
      *     "b": 2

--- a/src/framework/app-base.js
+++ b/src/framework/app-base.js
@@ -105,12 +105,12 @@ let app = null;
  *
  * MyScript.prototype.initialize = function() {
  *     // Every script instance has a property 'this.app' accessible in the initialize...
- *     var app = this.app;
+ *     const app = this.app;
  * };
  *
  * MyScript.prototype.update = function(dt) {
  *     // ...and update functions.
- *     var app = this.app;
+ *     const app = this.app;
  * };
  * ```
  *
@@ -126,8 +126,8 @@ class AppBase extends EventHandler {
      * @param {HTMLCanvasElement} canvas - The canvas element.
      * @example
      * // Engine-only example: create the application manually
-     * var options = new AppOptions();
-     * var app = new pc.AppBase(canvas);
+     * const options = new AppOptions();
+     * const app = new pc.AppBase(canvas);
      * app.init(options);
      *
      * // Start the application's main loop
@@ -306,7 +306,7 @@ class AppBase extends EventHandler {
          * @type {Entity}
          * @example
          * // Return the first entity called 'Camera' in a depth-first search of the scene hierarchy
-         * var camera = this.app.root.findByName('Camera');
+         * const camera = this.app.root.findByName('Camera');
          */
         this.root = new Entity();
         this.root._enabledInHierarchy = true;
@@ -317,7 +317,7 @@ class AppBase extends EventHandler {
          * @type {AssetRegistry}
          * @example
          * // Search the asset registry for all assets with the tag 'vehicle'
-         * var vehicleAssets = this.app.assets.findByTag('vehicle');
+         * const vehicleAssets = this.app.assets.findByTag('vehicle');
          */
         this.assets = new AssetRegistry(this.loader);
         if (appOptions.assetPrefix) this.assets.prefix = appOptions.assetPrefix;
@@ -359,7 +359,7 @@ class AppBase extends EventHandler {
          * @type {SceneRegistry}
          * @example
          * // Search the scene registry for a item with the name 'racetrack1'
-         * var sceneItem = this.app.scenes.find('racetrack1');
+         * const sceneItem = this.app.scenes.find('racetrack1');
          *
          * // Load the scene using the item's url
          * this.app.scenes.loadScene(sceneItem.url);
@@ -635,7 +635,7 @@ class AppBase extends EventHandler {
      * this id. Otherwise current application will be returned.
      * @returns {AppBase|undefined} The running application, if any.
      * @example
-     * var app = pc.AppBase.getApplication();
+     * const app = pc.AppBase.getApplication();
      */
     static getApplication(id) {
         return id ? AppBase._applications[id] : getApplication();
@@ -1545,7 +1545,7 @@ class AppBase extends EventHandler {
      * @param {boolean} settings.render.ambientBake - Enable baking ambient light into lightmaps.
      * @param {number} settings.render.ambientBakeNumSamples - Number of samples to use when baking ambient light.
      * @param {number} settings.render.ambientBakeSpherePart - How much of the sphere to include when baking ambient light.
-     * @param {number} settings.render.ambientBakeOcclusionBrightness - Brighness of the baked ambient occlusion.
+     * @param {number} settings.render.ambientBakeOcclusionBrightness - Brightness of the baked ambient occlusion.
      * @param {number} settings.render.ambientBakeOcclusionContrast - Contrast of the baked ambient occlusion.
      * @param {number} settings.render.ambientLuminance - Lux (lm/m^2) value for ambient light intensity.
      *
@@ -1568,7 +1568,7 @@ class AppBase extends EventHandler {
      * Only lights with bakeDir=true will be used for generating the dominant light direction.
      * @example
      *
-     * var settings = {
+     * const settings = {
      *     physics: {
      *         gravity: [0, -9.8, 0]
      *     },
@@ -1706,19 +1706,19 @@ class AppBase extends EventHandler {
      * @param {Layer} [layer] - The layer to render the line into. Defaults to {@link LAYERID_IMMEDIATE}.
      * @example
      * // Render a 1-unit long white line
-     * var start = new pc.Vec3(0, 0, 0);
-     * var end = new pc.Vec3(1, 0, 0);
+     * const start = new pc.Vec3(0, 0, 0);
+     * const end = new pc.Vec3(1, 0, 0);
      * app.drawLine(start, end);
      * @example
      * // Render a 1-unit long red line which is not depth tested and renders on top of other geometry
-     * var start = new pc.Vec3(0, 0, 0);
-     * var end = new pc.Vec3(1, 0, 0);
+     * const start = new pc.Vec3(0, 0, 0);
+     * const end = new pc.Vec3(1, 0, 0);
      * app.drawLine(start, end, pc.Color.RED, false);
      * @example
      * // Render a 1-unit long white line into the world layer
-     * var start = new pc.Vec3(0, 0, 0);
-     * var end = new pc.Vec3(1, 0, 0);
-     * var worldLayer = app.scene.layers.getLayerById(pc.LAYERID_WORLD);
+     * const start = new pc.Vec3(0, 0, 0);
+     * const end = new pc.Vec3(1, 0, 0);
+     * const worldLayer = app.scene.layers.getLayerById(pc.LAYERID_WORLD);
      * app.drawLine(start, end, pc.Color.WHITE, true, worldLayer);
      */
     drawLine(start, end, color, depthTest, layer) {
@@ -1741,12 +1741,12 @@ class AppBase extends EventHandler {
      * @param {Layer} [layer] - The layer to render the lines into. Defaults to {@link LAYERID_IMMEDIATE}.
      * @example
      * // Render a single line, with unique colors for each point
-     * var start = new pc.Vec3(0, 0, 0);
-     * var end = new pc.Vec3(1, 0, 0);
+     * const start = new pc.Vec3(0, 0, 0);
+     * const end = new pc.Vec3(1, 0, 0);
      * app.drawLines([start, end], [pc.Color.RED, pc.Color.WHITE]);
      * @example
      * // Render 2 discrete line segments
-     * var points = [
+     * const points = [
      *     // Line 1
      *     new pc.Vec3(0, 0, 0),
      *     new pc.Vec3(1, 0, 0),
@@ -1754,7 +1754,7 @@ class AppBase extends EventHandler {
      *     new pc.Vec3(1, 1, 0),
      *     new pc.Vec3(1, 1, 1)
      * ];
-     * var colors = [
+     * const colors = [
      *     // Line 1
      *     pc.Color.RED,
      *     pc.Color.YELLOW,
@@ -1782,7 +1782,7 @@ class AppBase extends EventHandler {
      * @param {Layer} [layer] - The layer to render the lines into. Defaults to {@link LAYERID_IMMEDIATE}.
      * @example
      * // Render 2 discrete line segments
-     * var points = [
+     * const points = [
      *     // Line 1
      *     0, 0, 0,
      *     1, 0, 0,
@@ -1790,7 +1790,7 @@ class AppBase extends EventHandler {
      *     1, 1, 0,
      *     1, 1, 1
      * ];
-     * var colors = [
+     * const colors = [
      *     // Line 1
      *     1, 0, 0, 1,  // red
      *     0, 1, 0, 1,  // green
@@ -1817,7 +1817,7 @@ class AppBase extends EventHandler {
      * @param {Layer} [layer] - The layer to render the sphere into. Defaults to {@link LAYERID_IMMEDIATE}.
      * @example
      * // Render a red wire sphere with radius of 1
-     * var center = new pc.Vec3(0, 0, 0);
+     * const center = new pc.Vec3(0, 0, 0);
      * app.drawWireSphere(center, 1.0, pc.Color.RED);
      * @ignore
      */
@@ -1836,8 +1836,8 @@ class AppBase extends EventHandler {
      * @param {Layer} [layer] - The layer to render the sphere into. Defaults to {@link LAYERID_IMMEDIATE}.
      * @example
      * // Render a red wire aligned box
-     * var min = new pc.Vec3(-1, -1, -1);
-     * var max = new pc.Vec3(1, 1, 1);
+     * const min = new pc.Vec3(-1, -1, -1);
+     * const max = new pc.Vec3(1, 1, 1);
      * app.drawWireAlignedBox(min, max, pc.Color.RED);
      * @ignore
      */

--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -74,12 +74,12 @@ import { XrManager } from './xr/xr-manager.js';
  *
  * MyScript.prototype.initialize = function() {
  *     // Every script instance has a property 'this.app' accessible in the initialize...
- *     var app = this.app;
+ *     const app = this.app;
  * };
  *
  * MyScript.prototype.update = function(dt) {
  *     // ...and update functions.
- *     var app = this.app;
+ *     const app = this.app;
  * };
  * ```
  *
@@ -111,7 +111,7 @@ class Application extends AppBase {
      * @param {string[]} [options.scriptsOrder] - Scripts in order of loading first.
      * @example
      * // Engine-only example: create the application manually
-     * var app = new pc.Application(canvas, options);
+     * const app = new pc.Application(canvas, options);
      *
      * // Start the application's main loop
      * app.start();

--- a/src/framework/asset/asset-reference.js
+++ b/src/framework/asset/asset-reference.js
@@ -26,7 +26,7 @@ class AssetReference {
      * unload(propertyName, parent, asset).
      * @param {object} [scope] - The scope to call the callbacks in.
      * @example
-     * var reference = new pc.AssetReference('textureAsset', this, this.app.assets, {
+     * const reference = new pc.AssetReference('textureAsset', this, this.app.assets, {
      *     load: this.onTextureAssetLoad,
      *     add: this.onTextureAssetAdd,
      *     remove: this.onTextureAssetRemove

--- a/src/framework/asset/asset-registry.js
+++ b/src/framework/asset/asset-registry.js
@@ -75,8 +75,8 @@ class AssetRegistry extends EventHandler {
      * @event AssetRegistry#load:[id]
      * @param {Asset} asset - The asset that has just loaded.
      * @example
-     * var id = 123456;
-     * var asset = app.assets.get(id);
+     * const id = 123456;
+     * const asset = app.assets.get(id);
      * app.assets.on("load:" + id, function (asset) {
      *     console.log("asset loaded: " + asset.name);
      * });
@@ -89,8 +89,8 @@ class AssetRegistry extends EventHandler {
      * @event AssetRegistry#load:url:[url]
      * @param {Asset} asset - The asset that has just loaded.
      * @example
-     * var id = 123456;
-     * var asset = app.assets.get(id);
+     * const id = 123456;
+     * const asset = app.assets.get(id);
      * app.assets.on("load:url:" + asset.file.url, function (asset) {
      *     console.log("asset loaded: " + asset.name);
      * });
@@ -114,7 +114,7 @@ class AssetRegistry extends EventHandler {
      * @event AssetRegistry#add:[id]
      * @param {Asset} asset - The asset that was added.
      * @example
-     * var id = 123456;
+     * const id = 123456;
      * app.assets.on("add:" + id, function (asset) {
      *     console.log("Asset 123456 loaded");
      * });
@@ -144,7 +144,7 @@ class AssetRegistry extends EventHandler {
      * @event AssetRegistry#remove:[id]
      * @param {Asset} asset - The asset that was removed.
      * @example
-     * var id = 123456;
+     * const id = 123456;
      * app.assets.on("remove:" + id, function (asset) {
      *     console.log("Asset removed: " + asset.name);
      * });
@@ -164,8 +164,8 @@ class AssetRegistry extends EventHandler {
      * @param {string} err - The error message.
      * @param {Asset} asset - The asset that generated the error.
      * @example
-     * var id = 123456;
-     * var asset = app.assets.get(id);
+     * const id = 123456;
+     * const asset = app.assets.get(id);
      * app.assets.on("error", function (err, asset) {
      *     console.error(err);
      * });
@@ -178,8 +178,8 @@ class AssetRegistry extends EventHandler {
      * @event AssetRegistry#error:[id]
      * @param {Asset} asset - The asset that generated the error.
      * @example
-     * var id = 123456;
-     * var asset = app.assets.get(id);
+     * const id = 123456;
+     * const asset = app.assets.get(id);
      * app.assets.on("error:" + id, function (err, asset) {
      *     console.error(err);
      * });
@@ -208,7 +208,7 @@ class AssetRegistry extends EventHandler {
      *
      * @param {Asset} asset - The asset to add.
      * @example
-     * var asset = new pc.Asset("My Asset", "texture", {
+     * const asset = new pc.Asset("My Asset", "texture", {
      *     url: "../path/to/image.jpg"
      * });
      * app.assets.add(asset);
@@ -250,7 +250,7 @@ class AssetRegistry extends EventHandler {
      * @param {Asset} asset - The asset to remove.
      * @returns {boolean} True if the asset was successfully removed and false otherwise.
      * @example
-     * var asset = app.assets.get(100);
+     * const asset = app.assets.get(100);
      * app.assets.remove(asset);
      */
     remove(asset) {
@@ -309,7 +309,7 @@ class AssetRegistry extends EventHandler {
      * @param {number} id - The id of the asset to get.
      * @returns {Asset} The asset.
      * @example
-     * var asset = app.assets.get(100);
+     * const asset = app.assets.get(100);
      */
     get(id) {
         const idx = this._cache[id];
@@ -322,7 +322,7 @@ class AssetRegistry extends EventHandler {
      * @param {string} url - The url of the asset to get.
      * @returns {Asset} The asset.
      * @example
-     * var asset = app.assets.getByUrl("../path/to/image.jpg");
+     * const asset = app.assets.getByUrl("../path/to/image.jpg");
      */
     getByUrl(url) {
         const idx = this._urls[url];
@@ -336,11 +336,11 @@ class AssetRegistry extends EventHandler {
      * @param {Asset} asset - The asset to load.
      * @example
      * // load some assets
-     * var assetsToLoad = [
+     * const assetsToLoad = [
      *     app.assets.find("My Asset"),
      *     app.assets.find("Another Asset")
      * ];
-     * var count = 0;
+     * let count = 0;
      * assetsToLoad.forEach(function (assetToLoad) {
      *     assetToLoad.ready(function (asset) {
      *         count++;
@@ -427,7 +427,7 @@ class AssetRegistry extends EventHandler {
      * asset), where err is null if no errors were encountered.
      * @example
      * app.assets.loadFromUrl("../path/to/texture.jpg", "texture", function (err, asset) {
-     *     var texture = asset.resource;
+     *     const texture = asset.resource;
      * });
      */
     loadFromUrl(url, type, callback) {
@@ -445,9 +445,9 @@ class AssetRegistry extends EventHandler {
      * @param {LoadAssetCallback} callback - Function called when asset is loaded, passed (err,
      * asset), where err is null if no errors were encountered.
      * @example
-     * var file = magicallyAttainAFile();
+     * const file = magicallyAttainAFile();
      * app.assets.loadFromUrlAndFilename(URL.createObjectURL(file), "texture.png", "texture", function (err, asset) {
-     *     var texture = asset.resource;
+     *     const texture = asset.resource;
      * });
      */
     loadFromUrlAndFilename(url, filename, type, callback) {
@@ -597,7 +597,7 @@ class AssetRegistry extends EventHandler {
      * @param {string} [type] - The type of the Assets to find.
      * @returns {Asset[]} A list of all Assets found.
      * @example
-     * var assets = app.assets.findAll("myTextureAsset", "texture");
+     * const assets = app.assets.findAll("myTextureAsset", "texture");
      * console.log("Found " + assets.length + " assets called " + name);
      */
     findAll(name, type) {
@@ -636,16 +636,16 @@ class AssetRegistry extends EventHandler {
      * @param {...*} query - Name of a tag or array of tags.
      * @returns {Asset[]} A list of all Assets matched query.
      * @example
-     * var assets = app.assets.findByTag("level-1");
+     * const assets = app.assets.findByTag("level-1");
      * // returns all assets that tagged by `level-1`
      * @example
-     * var assets = app.assets.findByTag("level-1", "level-2");
+     * const assets = app.assets.findByTag("level-1", "level-2");
      * // returns all assets that tagged by `level-1` OR `level-2`
      * @example
-     * var assets = app.assets.findByTag(["level-1", "monster"]);
+     * const assets = app.assets.findByTag(["level-1", "monster"]);
      * // returns all assets that tagged by `level-1` AND `monster`
      * @example
-     * var assets = app.assets.findByTag(["level-1", "monster"], ["level-2", "monster"]);
+     * const assets = app.assets.findByTag(["level-1", "monster"], ["level-2", "monster"]);
      * // returns all assets that tagged by (`level-1` AND `monster`) OR (`level-2` AND `monster`)
      */
     findByTag() {
@@ -659,7 +659,7 @@ class AssetRegistry extends EventHandler {
      * Return `true` to include an asset in the returned array.
      * @returns {Asset[]} A list of all Assets found.
      * @example
-     * var assets = app.assets.filter(function (asset) {
+     * const assets = app.assets.filter(function (asset) {
      *     return asset.name.indexOf('monster') !== -1;
      * });
      * console.log("Found " + assets.length + " assets, where names contains 'monster'");
@@ -675,7 +675,7 @@ class AssetRegistry extends EventHandler {
      * @param {string} [type] - The type of the Asset to find.
      * @returns {Asset|null} A single Asset or null if no Asset is found.
      * @example
-     * var asset = app.assets.find("myTextureAsset", "texture");
+     * const asset = app.assets.find("myTextureAsset", "texture");
      */
     find(name, type) {
         // findAll returns an empty array the if the asset cannot be found so `asset` is

--- a/src/framework/asset/asset.js
+++ b/src/framework/asset/asset.js
@@ -77,7 +77,7 @@ class Asset extends EventHandler {
      * For more details on crossOrigin and its use, see
      * https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/crossOrigin.
      * @example
-     * var asset = new pc.Asset("a texture", "texture", {
+     * const asset = new pc.Asset("a texture", "texture", {
      *     url: "http://example.com/my/assets/here/texture.png"
      * });
      */
@@ -367,8 +367,8 @@ class Asset extends EventHandler {
      *
      * @returns {string|null} The URL. Returns null if the asset has no associated file.
      * @example
-     * var assets = app.assets.find("My Image", "texture");
-     * var img = "&lt;img src='" + assets[0].getFileUrl() + "'&gt;";
+     * const assets = app.assets.find("My Image", "texture");
+     * const img = "&lt;img src='" + assets[0].getFileUrl() + "'&gt;";
      */
     getFileUrl() {
         const file = this.file;
@@ -456,7 +456,7 @@ class Asset extends EventHandler {
      * the (asset) arguments.
      * @param {object} [scope] - Scope object to use when calling the callback.
      * @example
-     * var asset = app.assets.find("My Asset");
+     * const asset = app.assets.find("My Asset");
      * asset.ready(function (asset) {
      *   // asset loaded
      * });
@@ -486,7 +486,7 @@ class Asset extends EventHandler {
      * Destroys the associated resource and marks asset as unloaded.
      *
      * @example
-     * var asset = app.assets.find("My Asset");
+     * const asset = app.assets.find("My Asset");
      * asset.unload();
      * // asset.resource is null
      */

--- a/src/framework/bundle/bundle-registry.js
+++ b/src/framework/bundle/bundle-registry.js
@@ -304,7 +304,7 @@ class BundleRegistry {
      * error occurs. The callback expects the first argument to be the error message (if any) and
      * the second argument is the file blob URL.
      * @example
-     * var url = asset.getFileUrl().split('?')[0]; // get normalized asset URL
+     * const url = asset.getFileUrl().split('?')[0]; // get normalized asset URL
      * this.app.bundles.loadFile(url, function (err, blobUrl) {
      *     // do something with the blob URL
      * });

--- a/src/framework/components/camera/component.js
+++ b/src/framework/components/camera/component.js
@@ -21,7 +21,7 @@ import { Debug } from '../../../core/debug.js';
  *
  * ```javascript
  * // Add a pc.CameraComponent to an entity
- * var entity = new pc.Entity();
+ * const entity = new pc.Entity();
  * entity.addComponent('camera', {
  *     nearClip: 1,
  *     farClip: 100,
@@ -29,7 +29,7 @@ import { Debug } from '../../../core/debug.js';
  * });
  *
  * // Get the pc.CameraComponent on an entity
- * var cameraComponent = entity.camera;
+ * const cameraComponent = entity.camera;
  *
  * // Update a property on a camera component
  * entity.camera.nearClip = 2;
@@ -675,8 +675,8 @@ class CameraComponent extends Component {
      * coordinate result.
      * @example
      * // Get the start and end points of a 3D ray fired from a screen click position
-     * var start = entity.camera.screenToWorld(clickX, clickY, entity.camera.nearClip);
-     * var end = entity.camera.screenToWorld(clickX, clickY, entity.camera.farClip);
+     * const start = entity.camera.screenToWorld(clickX, clickY, entity.camera.nearClip);
+     * const end = entity.camera.screenToWorld(clickX, clickY, entity.camera.farClip);
      *
      * // Use the ray coordinates to perform a raycast
      * app.systems.rigidbody.raycastFirst(start, end, function (result) {

--- a/src/framework/components/light/component.js
+++ b/src/framework/components/light/component.js
@@ -29,7 +29,7 @@ const _lightPropsDefault = [];
  *
  * ```javascript
  * // Add a pc.LightComponent to an entity
- * var entity = new pc.Entity();
+ * const entity = new pc.Entity();
  * entity.addComponent('light', {
  *     type: "omni",
  *     color: new pc.Color(1, 0, 0),
@@ -37,7 +37,7 @@ const _lightPropsDefault = [];
  * });
  *
  * // Get the pc.LightComponent on an entity
- * var lightComponent = entity.light;
+ * const lightComponent = entity.light;
  *
  * // Update a property on a light component
  * entity.light.range = 20;

--- a/src/framework/components/rigid-body/component.js
+++ b/src/framework/components/rigid-body/component.js
@@ -661,18 +661,18 @@ class RigidBodyComponent extends Component {
      * @example
      * // Apply a force at the body's center
      * // Calculate a force vector pointing in the world space direction of the entity
-     * var force = this.entity.forward.clone().mulScalar(100);
+     * const force = this.entity.forward.clone().mulScalar(100);
      *
      * // Apply the force
      * this.entity.rigidbody.applyForce(force);
      * @example
      * // Apply a force at some relative offset from the body's center
      * // Calculate a force vector pointing in the world space direction of the entity
-     * var force = this.entity.forward.clone().mulScalar(100);
+     * const force = this.entity.forward.clone().mulScalar(100);
      *
      * // Calculate the world space relative offset
-     * var relativePos = new pc.Vec3();
-     * var childEntity = this.entity.findByName('Engine');
+     * const relativePos = new pc.Vec3();
+     * const childEntity = this.entity.findByName('Engine');
      * relativePos.sub2(childEntity.getPosition(), this.entity.getPosition());
      *
      * // Apply the force
@@ -711,7 +711,7 @@ class RigidBodyComponent extends Component {
      * @param {number} [z] - The z-component of the torque force in world-space.
      * @example
      * // Apply via vector
-     * var torque = new pc.Vec3(0, 10, 0);
+     * const torque = new pc.Vec3(0, 10, 0);
      * entity.rigidbody.applyTorque(torque);
      * @example
      * // Apply via numbers
@@ -750,13 +750,13 @@ class RigidBodyComponent extends Component {
      * local-space of the entity.
      * @example
      * // Apply an impulse along the world-space positive y-axis at the entity's position.
-     * var impulse = new pc.Vec3(0, 10, 0);
+     * const impulse = new pc.Vec3(0, 10, 0);
      * entity.rigidbody.applyImpulse(impulse);
      * @example
      * // Apply an impulse along the world-space positive y-axis at 1 unit down the positive
      * // z-axis of the entity's local-space.
-     * var impulse = new pc.Vec3(0, 10, 0);
-     * var relativePoint = new pc.Vec3(0, 0, 1);
+     * const impulse = new pc.Vec3(0, 10, 0);
+     * const relativePoint = new pc.Vec3(0, 0, 1);
      * entity.rigidbody.applyImpulse(impulse, relativePoint);
      * @example
      * // Apply an impulse along the world-space positive y-axis at the entity's position.
@@ -800,7 +800,7 @@ class RigidBodyComponent extends Component {
      * @param {number} [z] - The z-component of the torque impulse in world-space.
      * @example
      * // Apply via vector
-     * var torque = new pc.Vec3(0, 10, 0);
+     * const torque = new pc.Vec3(0, 10, 0);
      * entity.rigidbody.applyTorqueImpulse(torque);
      * @example
      * // Apply via numbers
@@ -986,7 +986,7 @@ class RigidBodyComponent extends Component {
      * entity.rigidbody.teleport(0, 0, 0);
      * @example
      * // Teleport the entity to world-space coordinate [1, 2, 3] and reset orientation
-     * var position = new pc.Vec3(1, 2, 3);
+     * const position = new pc.Vec3(1, 2, 3);
      * entity.rigidbody.teleport(position, pc.Vec3.ZERO);
      * @example
      * // Teleport the entity to world-space coordinate [1, 2, 3] and reset orientation

--- a/src/framework/components/script/component.js
+++ b/src/framework/components/script/component.js
@@ -589,7 +589,7 @@ class ScriptComponent extends Component {
      * @returns {import('../../script/script-type.js').ScriptType|null} If script is attached, the
      * instance is returned. Otherwise null is returned.
      * @example
-     * var controller = entity.script.get('playerController');
+     * const controller = entity.script.get('playerController');
      */
     get(nameOrType) {
         if (typeof nameOrType === 'string') {

--- a/src/framework/components/sound/component.js
+++ b/src/framework/components/sound/component.js
@@ -359,7 +359,7 @@ class SoundComponent extends Component {
      * @returns {SoundSlot|null} The new slot or null if the slot already exists.
      * @example
      * // get an asset by id
-     * var asset = app.assets.get(10);
+     * const asset = app.assets.get(10);
      * // add a slot
      * this.entity.sound.addSlot('beep', {
      *     asset: asset
@@ -487,7 +487,7 @@ class SoundComponent extends Component {
      * or if the SoundComponent has no slot with the specified name.
      * @example
      * // get asset by id
-     * var asset = app.assets.get(10);
+     * const asset = app.assets.get(10);
      * // create a slot and play it
      * this.entity.sound.addSlot('beep', {
      *     asset: asset

--- a/src/framework/components/sound/slot.js
+++ b/src/framework/components/sound/slot.js
@@ -280,10 +280,10 @@ class SoundSlot extends EventHandler {
      * the AudioContext. If unspecified then the firstNode will be connected to the destination
      * instead.
      * @example
-     * var context = app.systems.sound.context;
-     * var analyzer = context.createAnalyzer();
-     * var distortion = context.createWaveShaper();
-     * var filter = context.createBiquadFilter();
+     * const context = app.systems.sound.context;
+     * const analyzer = context.createAnalyzer();
+     * const distortion = context.createWaveShaper();
+     * const filter = context.createBiquadFilter();
      * analyzer.connect(distortion);
      * distortion.connect(filter);
      * slot.setExternalNodes(analyzer, filter);

--- a/src/framework/components/system.js
+++ b/src/framework/components/system.js
@@ -35,7 +35,7 @@ class ComponentSystem extends EventHandler {
      * @returns {import('./component.js').Component} Returns a Component of type defined by the
      * component system.
      * @example
-     * var entity = new pc.Entity(app);
+     * const entity = new pc.Entity(app);
      * app.systems.model.addComponent(entity, { type: 'box' });
      * // entity.model is now set to a pc.ModelComponent
      * @ignore

--- a/src/framework/entity.js
+++ b/src/framework/entity.js
@@ -231,7 +231,7 @@ class Entity extends GraphNode {
      * @param {import('./app-base.js').AppBase} [app] - The application the entity belongs to,
      * default is the current application.
      * @example
-     * var entity = new pc.Entity();
+     * const entity = new pc.Entity();
      *
      * // Add a Component to the Entity
      * entity.addComponent("camera", {
@@ -247,11 +247,11 @@ class Entity extends GraphNode {
      * entity.translate(10, 0, 0);
      *
      * // Or translate it by setting its position directly
-     * var p = entity.getPosition();
+     * const p = entity.getPosition();
      * entity.setPosition(p.x + 10, p.y, p.z);
      *
      * // Change the entity's rotation in local space
-     * var e = entity.getLocalEulerAngles();
+     * const e = entity.getLocalEulerAngles();
      * entity.setLocalEulerAngles(e.x, e.y + 90, e.z);
      *
      * // Or use rotateLocal
@@ -296,7 +296,7 @@ class Entity extends GraphNode {
      * @returns {import('./components/component.js').Component|null} The new Component that was
      * attached to the entity or null if there was an error.
      * @example
-     * var entity = new pc.Entity();
+     * const entity = new pc.Entity();
      *
      * // Add a light component with default properties
      * entity.addComponent("light");
@@ -325,7 +325,7 @@ class Entity extends GraphNode {
      *
      * @param {string} type - The name of the Component type.
      * @example
-     * var entity = new pc.Entity();
+     * const entity = new pc.Entity();
      * entity.addComponent("light"); // add new light component
      *
      * entity.removeComponent("light"); // remove light component
@@ -351,7 +351,7 @@ class Entity extends GraphNode {
      * the entity or any of its descendants has one. Returns undefined otherwise.
      * @example
      * // Get the first found light component in the hierarchy tree that starts with this entity
-     * var light = entity.findComponent("light");
+     * const light = entity.findComponent("light");
      */
     findComponent(type) {
         const entity = this.findOne(function (node) {
@@ -368,7 +368,7 @@ class Entity extends GraphNode {
      * in the entity or any of its descendants. Returns empty array if none found.
      * @example
      * // Get all light components in the hierarchy tree that starts with this entity
-     * var lights = entity.findComponents("light");
+     * const lights = entity.findComponents("light");
      */
     findComponents(type) {
         const entities = this.find(function (node) {
@@ -503,7 +503,7 @@ class Entity extends GraphNode {
      * recursively destroy all ancestor Entities.
      *
      * @example
-     * var firstChild = this.entity.children[0];
+     * const firstChild = this.entity.children[0];
      * firstChild.destroy(); // delete child, all components and remove from hierarchy
      */
     destroy() {
@@ -556,7 +556,7 @@ class Entity extends GraphNode {
      *
      * @returns {this} A new Entity which is a deep copy of the original.
      * @example
-     * var e = this.entity.clone();
+     * const e = this.entity.clone();
      *
      * // Add clone as a sibling to the original
      * this.entity.parent.addChild(e);

--- a/src/framework/graphics/picker.js
+++ b/src/framework/graphics/picker.js
@@ -89,10 +89,10 @@ class Picker {
      * that are in the selection.
      * @example
      * // Get the selection at the point (10,20)
-     * var selection = picker.getSelection(10, 20);
+     * const selection = picker.getSelection(10, 20);
      * @example
      * // Get all models in rectangle with corners at (10,20) and (20,40)
-     * var selection = picker.getSelection(10, 20, 10, 20);
+     * const selection = picker.getSelection(10, 20, 10, 20);
      */
     getSelection(x, y, width, height) {
         const device = this.device;

--- a/src/framework/handlers/container.js
+++ b/src/framework/handlers/container.js
@@ -24,7 +24,7 @@ class ContainerResource {
      * @example
      * // load a glb file and instantiate an entity with a model component based on it
      * app.assets.loadFromUrl("statue.glb", "container", function (err, asset) {
-     *     var entity = asset.resource.instantiateModelEntity({
+     *     const entity = asset.resource.instantiateModelEntity({
      *         castShadows: true
      *     });
      *     app.root.addChild(entity);
@@ -44,13 +44,13 @@ class ContainerResource {
      * @example
      * // load a glb file and instantiate an entity with a render component based on it
      * app.assets.loadFromUrl("statue.glb", "container", function (err, asset) {
-     *     var entity = asset.resource.instantiateRenderEntity({
+     *     const entity = asset.resource.instantiateRenderEntity({
      *         castShadows: true
      *     });
      *     app.root.addChild(entity);
      *
      *     // find all render components containing mesh instances, and change blend mode on their materials
-     *     var renders = entity.findComponents("render");
+     *     const renders = entity.findComponents("render");
      *     renders.forEach(function (render) {
      *         render.meshInstances.forEach(function (meshInstance) {
      *             meshInstance.material.blendType = pc.BLEND_MULTIPLICATIVE;
@@ -82,11 +82,11 @@ class ContainerResource {
      * @example
      * // load a glb file and instantiate an entity with a render component based on it
      * app.assets.loadFromUrl("statue.glb", "container", function (err, asset) {
-     *     var entity = asset.resource.instantiateRenderEntity({
+     *     const entity = asset.resource.instantiateRenderEntity({
      *         castShadows: true
      *     });
      *     app.root.addChild(entity);
-     *     var materialVariants = asset.resource.getMaterialVariants();
+     *     const materialVariants = asset.resource.getMaterialVariants();
      *     asset.resource.applyMaterialVariant(entity, materialVariants[0]);
      */
     applyMaterialVariant(entity, name) {}
@@ -103,14 +103,14 @@ class ContainerResource {
      * @example
      * // load a glb file and instantiate an entity with a render component based on it
      * app.assets.loadFromUrl("statue.glb", "container", function (err, asset) {
-     *     var entity = asset.resource.instantiateRenderEntity({
+     *     const entity = asset.resource.instantiateRenderEntity({
      *         castShadows: true
      *     });
      *     app.root.addChild(entity);
-     *     var materialVariants = asset.resource.getMaterialVariants();
-     *     var renders = entity.findComponents("render");
-     *     for (var i = 0; i < renders.length; i++) {
-     *         var renderComponent = renders[i];
+     *     const materialVariants = asset.resource.getMaterialVariants();
+     *     const renders = entity.findComponents("render");
+     *     for (let i = 0; i < renders.length; i++) {
+     *         const renderComponent = renders[i];
      *         asset.resource.applyMaterialVariantInstances(renderComponent.meshInstances, materialVariants[0]);
      *     }
      */
@@ -154,7 +154,7 @@ class ContainerResource {
  * For example, to receive a texture preprocess callback:
  *
  * ```javascript
- * var containerAsset = new pc.Asset(filename, 'container', { url: url, filename: filename }, null, {
+ * const containerAsset = new pc.Asset(filename, 'container', { url: url, filename: filename }, null, {
  *     texture: {
  *         preprocess(gltfTexture) { console.log("texture preprocess"); }
  *     },

--- a/src/framework/handlers/loader.js
+++ b/src/framework/handlers/loader.js
@@ -51,7 +51,7 @@ class ResourceLoader {
      * @param {import('./handler.js').ResourceHandler} handler - An instance of a resource handler
      * supporting at least `load()` and `open()`.
      * @example
-     * var loader = new ResourceLoader();
+     * const loader = new ResourceLoader();
      * loader.addHandler("json", new pc.JsonHandler());
      */
     addHandler(type, handler) {

--- a/src/framework/i18n/i18n.js
+++ b/src/framework/i18n/i18n.js
@@ -135,8 +135,8 @@ class I18n extends EventHandler {
      * locale.
      * @example
      * // With a defined dictionary of locales
-     * var availableLocales = { en: 'en-US', fr: 'fr-FR' };
-     * var locale = pc.I18n.getText('en-US', availableLocales);
+     * const availableLocales = { en: 'en-US', fr: 'fr-FR' };
+     * const locale = pc.I18n.getText('en-US', availableLocales);
      * // returns 'en'
      * @ignore
      */
@@ -153,7 +153,7 @@ class I18n extends EventHandler {
      * @returns {string} The locale found or if no locale is available returns the default en-US
      * locale.
      * @example
-     * var locale = this.app.i18n.getText('en-US');
+     * const locale = this.app.i18n.getText('en-US');
      */
     findAvailableLocale(desiredLocale) {
         if (this._translations[desiredLocale]) {
@@ -174,8 +174,8 @@ class I18n extends EventHandler {
      * then it will return the en-US translation. If no translation exists for that key then it will
      * return the localization key.
      * @example
-     * var localized = this.app.i18n.getText('localization-key');
-     * var localizedFrench = this.app.i18n.getText('localization-key', 'fr-FR');
+     * const localized = this.app.i18n.getText('localization-key');
+     * const localizedFrench = this.app.i18n.getText('localization-key', 'fr-FR');
      */
     getText(key, locale) {
         // default translation is the key
@@ -227,7 +227,7 @@ class I18n extends EventHandler {
      * will return the localization key.
      * @example
      * // manually replace {number} in the resulting translation with our number
-     * var localized = this.app.i18n.getPluralText('{number} apples', number).replace("{number}", number);
+     * const localized = this.app.i18n.getPluralText('{number} apples', number).replace("{number}", number);
      */
     getPluralText(key, n, locale) {
         // default translation is the key

--- a/src/framework/parsers/glb-container-resource.js
+++ b/src/framework/parsers/glb-container-resource.js
@@ -123,7 +123,7 @@ class GlbContainerResource {
                     if (gltfNode.hasOwnProperty('mesh')) {
                         const meshGroup = glb.renders[gltfNode.mesh].meshes;
                         renderAsset = this.renders[gltfNode.mesh];
-                        for (var mi = 0; mi < meshGroup.length; mi++) {
+                        for (let mi = 0; mi < meshGroup.length; mi++) {
                             const mesh = meshGroup[mi];
                             if (mesh) {
                                 const cloneMi = createMeshInstance(root, entity, mesh, glb.materials, glb.meshDefaultMaterials, glb.skins, gltfNode);
@@ -304,7 +304,7 @@ class GlbContainerResource {
                 const gltfNode = glb.gltf.nodes[i];
                 if (gltfNode.hasOwnProperty('mesh')) {
                     const meshGroup = glb.renders[gltfNode.mesh].meshes;
-                    for (var mi = 0; mi < meshGroup.length; mi++) {
+                    for (let mi = 0; mi < meshGroup.length; mi++) {
                         const mesh = meshGroup[mi];
                         if (mesh) {
                             createMeshInstance(model, mesh, glb.skins, skinInstances, glb.materials, node, gltfNode);

--- a/src/framework/scene-registry.js
+++ b/src/framework/scene-registry.js
@@ -226,7 +226,7 @@ class SceneRegistry {
      * @param {LoadSceneDataCallback} callback - The function to call after loading,
      * passed (err, sceneItem) where err is null if no errors occurred.
      * @example
-     * var sceneItem = app.scenes.find("Scene Name");
+     * const sceneItem = app.scenes.find("Scene Name");
      * app.scenes.loadSceneData(sceneItem, function (err, sceneItem) {
      *     if (err) {
      *         // error
@@ -243,7 +243,7 @@ class SceneRegistry {
      * @param {SceneRegistryItem | string} sceneItem - The scene item (which can be found with
      * {@link SceneRegistry#find} or URL of the scene file. Usually this will be "scene_id.json".
      * @example
-     * var sceneItem = app.scenes.find("Scene Name");
+     * const sceneItem = app.scenes.find("Scene Name");
      * app.scenes.unloadSceneData(sceneItem);
      */
     unloadSceneData(sceneItem) {
@@ -310,10 +310,10 @@ class SceneRegistry {
      * @param {LoadHierarchyCallback} callback - The function to call after loading,
      * passed (err, entity) where err is null if no errors occurred.
      * @example
-     * var sceneItem = app.scenes.find("Scene Name");
+     * const sceneItem = app.scenes.find("Scene Name");
      * app.scenes.loadSceneHierarchy(sceneItem, function (err, entity) {
      *     if (!err) {
-     *         var e = app.root.find("My New Entity");
+     *         const e = app.root.find("My New Entity");
      *     } else {
      *         // error
      *     }
@@ -331,7 +331,7 @@ class SceneRegistry {
      * @param {LoadSettingsCallback} callback - The function called after the settings
      * are applied. Passed (err) where err is null if no error occurred.
      * @example
-     * var sceneItem = app.scenes.find("Scene Name");
+     * const sceneItem = app.scenes.find("Scene Name");
      * app.scenes.loadSceneSettings(sceneItem, function (err) {
      *     if (!err) {
      *         // success

--- a/src/framework/xr/xr-depth-sensing.js
+++ b/src/framework/xr/xr-depth-sensing.js
@@ -15,10 +15,10 @@ import { XRDEPTHSENSINGUSAGE_CPU, XRDEPTHSENSINGUSAGE_GPU } from './constants.js
  *
  * ```javascript
  * // CPU path
- * var depthSensing = app.xr.depthSensing;
+ * const depthSensing = app.xr.depthSensing;
  * if (depthSensing.available) {
  *     // get depth in the middle of the screen, value is in meters
- *     var depth = depthSensing.getDepth(depthSensing.width / 2, depthSensing.height / 2);
+ *     const depth = depthSensing.getDepth(depthSensing.width / 2, depthSensing.height / 2);
  * }
  * ```
  *
@@ -319,7 +319,7 @@ class XrDepthSensing extends EventHandler {
      * @returns {number|null} Depth in meters or null if depth information is currently not
      * available.
      * @example
-     * var depth = app.xr.depthSensing.getDepth(u, v);
+     * const depth = app.xr.depthSensing.getDepth(u, v);
      * if (depth !== null) {
      *     // depth in meters
      * }
@@ -349,7 +349,7 @@ class XrDepthSensing extends EventHandler {
      * @type {boolean}
      * @example
      * if (app.xr.depthSensing.available) {
-     *     var depth = app.xr.depthSensing.getDepth(x, y);
+     *     const depth = app.xr.depthSensing.getDepth(x, y);
      * }
      */
     get available() {

--- a/src/framework/xr/xr-hit-test.js
+++ b/src/framework/xr/xr-hit-test.js
@@ -205,7 +205,7 @@ class XrHitTest extends EventHandler {
      *     }
      * });
      * @example
-     * var ray = new pc.Ray(new pc.Vec3(0, 0, 0), new pc.Vec3(0, -1, 0));
+     * const ray = new pc.Ray(new pc.Vec3(0, 0, 0), new pc.Vec3(0, -1, 0));
      * app.xr.hitTest.start({
      *     spaceType: pc.XRSPACE_LOCAL,
      *     offsetRay: ray,

--- a/src/framework/xr/xr-input-source.js
+++ b/src/framework/xr/xr-input-source.js
@@ -175,7 +175,7 @@ class XrInputSource extends EventHandler {
      * @event XrInputSource#select
      * @param {object} evt - XRInputSourceEvent event data from WebXR API.
      * @example
-     * var ray = new pc.Ray();
+     * const ray = new pc.Ray();
      * inputSource.on('select', function (evt) {
      *     ray.set(inputSource.getOrigin(), inputSource.getDirection());
      *     if (obj.intersectsRay(ray)) {

--- a/src/framework/xr/xr-input.js
+++ b/src/framework/xr/xr-input.js
@@ -75,7 +75,7 @@ class XrInput extends EventHandler {
      * @param {XrInputSource} inputSource - Input source that triggered select event.
      * @param {object} evt - XRInputSourceEvent event data from WebXR API.
      * @example
-     * var ray = new pc.Ray();
+     * const ray = new pc.Ray();
      * app.xr.input.on('select', function (inputSource, evt) {
      *     ray.set(inputSource.getOrigin(), inputSource.getDirection());
      *     if (obj.intersectsRay(ray)) {

--- a/src/framework/xr/xr-plane.js
+++ b/src/framework/xr/xr-plane.js
@@ -159,15 +159,15 @@ class XrPlane extends EventHandler {
      * @type {object[]}
      * @example
      * // prepare reusable objects
-     * var vecA = new pc.Vec3();
-     * var vecB = new pc.Vec3();
-     * var color = new pc.Color(1, 1, 1);
+     * const vecA = new pc.Vec3();
+     * const vecB = new pc.Vec3();
+     * const color = new pc.Color(1, 1, 1);
      *
      * // update Mat4 to plane position and rotation
      * transform.setTRS(plane.getPosition(), plane.getRotation(), pc.Vec3.ONE);
      *
      * // draw lines between points
-     * for (var i = 0; i < plane.points.length; i++) {
+     * for (let i = 0; i < plane.points.length; i++) {
      *     vecA.copy(plane.points[i]);
      *     vecB.copy(plane.points[(i + 1) % plane.points.length]);
      *

--- a/src/platform/graphics/graphics-device.js
+++ b/src/platform/graphics/graphics-device.js
@@ -405,7 +405,7 @@ class GraphicsDevice extends EventHandler {
      * @returns {import('./render-target.js').RenderTarget} The current render target.
      * @example
      * // Get the current render target
-     * var renderTarget = device.getRenderTarget();
+     * const renderTarget = device.getRenderTarget();
      */
     getRenderTarget() {
         return this.renderTarget;

--- a/src/platform/graphics/index-buffer.js
+++ b/src/platform/graphics/index-buffer.js
@@ -38,10 +38,10 @@ class IndexBuffer {
      * // static, hinting that the buffer will never be modified.
      * const indices = new UInt16Array([0, 1, 2]);
      * const indexBuffer = new pc.IndexBuffer(graphicsDevice,
-     *                                      pc.INDEXFORMAT_UINT16,
-     *                                      3,
-     *                                      pc.BUFFER_STATIC,
-     *                                      indices);
+     *                                        pc.INDEXFORMAT_UINT16,
+     *                                        3,
+     *                                        pc.BUFFER_STATIC,
+     *                                        indices);
      */
     constructor(graphicsDevice, format, numIndices, usage = BUFFER_STATIC, initialData) {
         // By default, index buffers are static (better for performance since buffer data can be cached in VRAM)

--- a/src/platform/graphics/index-buffer.js
+++ b/src/platform/graphics/index-buffer.js
@@ -36,8 +36,8 @@ class IndexBuffer {
      * @example
      * // Create an index buffer holding 3 16-bit indices. The buffer is marked as
      * // static, hinting that the buffer will never be modified.
-     * var indices = new UInt16Array([0, 1, 2]);
-     * var indexBuffer = new pc.IndexBuffer(graphicsDevice,
+     * const indices = new UInt16Array([0, 1, 2]);
+     * const indexBuffer = new pc.IndexBuffer(graphicsDevice,
      *                                      pc.INDEXFORMAT_UINT16,
      *                                      3,
      *                                      pc.BUFFER_STATIC,

--- a/src/platform/graphics/render-target.js
+++ b/src/platform/graphics/render-target.js
@@ -49,12 +49,12 @@ class RenderTarget {
      * Defaults to false. Ignored if depthBuffer is defined or depth is false.
      * @example
      * // Create a 512x512x24-bit render target with a depth buffer
-     * var colorBuffer = new pc.Texture(graphicsDevice, {
+     * const colorBuffer = new pc.Texture(graphicsDevice, {
      *     width: 512,
      *     height: 512,
      *     format: pc.PIXELFORMAT_RGB8
      * });
-     * var renderTarget = new pc.RenderTarget({
+     * const renderTarget = new pc.RenderTarget({
      *     colorBuffer: colorBuffer,
      *     depth: true
      * });

--- a/src/platform/graphics/shader.js
+++ b/src/platform/graphics/shader.js
@@ -51,7 +51,7 @@ class Shader {
      * fragment shaders. Defaults to {@link SHADERLANGUAGE_GLSL}.
      * @example
      * // Create a shader that renders primitives with a solid red color
-     * var shaderDefinition = {
+     * const shaderDefinition = {
      *     attributes: {
      *         aPosition: pc.SEMANTIC_POSITION
      *     },
@@ -73,7 +73,7 @@ class Shader {
      *     ].join("\n")
      * };
      *
-     * var shader = new pc.Shader(graphicsDevice, shaderDefinition);
+     * const shader = new pc.Shader(graphicsDevice, shaderDefinition);
      */
     constructor(graphicsDevice, definition) {
         this.id = id++;

--- a/src/platform/graphics/texture.js
+++ b/src/platform/graphics/texture.js
@@ -123,17 +123,17 @@ class Texture {
      * @param {Uint8Array[]} [options.levels] - Array of Uint8Array.
      * @example
      * // Create a 8x8x24-bit texture
-     * var texture = new pc.Texture(graphicsDevice, {
+     * const texture = new pc.Texture(graphicsDevice, {
      *     width: 8,
      *     height: 8,
      *     format: pc.PIXELFORMAT_RGB8
      * });
      *
      * // Fill the texture with a gradient
-     * var pixels = texture.lock();
-     * var count = 0;
-     * for (var i = 0; i < 8; i++) {
-     *     for (var j = 0; j < 8; j++) {
+     * const pixels = texture.lock();
+     * const count = 0;
+     * for (let i = 0; i < 8; i++) {
+     *     for (let j = 0; j < 8; j++) {
      *         pixels[count++] = i * 32;
      *         pixels[count++] = j * 32;
      *         pixels[count++] = 255;

--- a/src/platform/graphics/transform-feedback.js
+++ b/src/platform/graphics/transform-feedback.js
@@ -17,7 +17,7 @@ import { ShaderUtils } from './shader-utils.js';
  * 3. Create the shader using `TransformFeedback.createShader(device, vsCode, yourShaderName)`.
  * 4. Create/acquire the input vertex buffer. Can be any VertexBuffer, either manually created, or
  * from a Mesh.
- * 5. Create the TransformFeedback object: `var tf = new TransformFeedback(inputBuffer)`. This
+ * 5. Create the TransformFeedback object: `const tf = new TransformFeedback(inputBuffer)`. This
  * object will internally create an output buffer.
  * 6. Run the shader: `tf.process(shader)`. Shader will take the input buffer, process it and write
  * to the output buffer, then the input/output buffers will be automatically swapped, so you'll
@@ -42,17 +42,17 @@ import { ShaderUtils } from './shader-utils.js';
  *
  * ```javascript
  * // *** script asset ***
- * var TransformExample = pc.createScript('transformExample');
+ * const TransformExample = pc.createScript('transformExample');
  *
  * // attribute that references shader asset and material
  * TransformExample.attributes.add('shaderCode', { type: 'asset', assetType: 'shader' });
  * TransformExample.attributes.add('material', { type: 'asset', assetType: 'material' });
  *
  * TransformExample.prototype.initialize = function() {
- *     var device = this.app.graphicsDevice;
- *     var mesh = pc.createTorus(device, { tubeRadius: 0.01, ringRadius: 3 });
- *     var meshInstance = new pc.MeshInstance(mesh, this.material.resource);
- *     var entity = new pc.Entity();
+ *     const device = this.app.graphicsDevice;
+ *     const mesh = pc.createTorus(device, { tubeRadius: 0.01, ringRadius: 3 });
+ *     const meshInstance = new pc.MeshInstance(mesh, this.material.resource);
+ *     const entity = new pc.Entity();
  *     entity.addComponent('render', {
  *         type: 'asset',
  *         meshInstances: [meshInstance]
@@ -61,7 +61,7 @@ import { ShaderUtils } from './shader-utils.js';
  *
  *     // if webgl2 is not supported, transform-feedback is not available
  *     if (!device.webgl2) return;
- *     var inputBuffer = mesh.vertexBuffer;
+ *     const inputBuffer = mesh.vertexBuffer;
  *     this.tf = new pc.TransformFeedback(inputBuffer);
  *     this.shader = pc.TransformFeedback.createShader(device, this.shaderCode.resource, "tfMoveUp");
  * };

--- a/src/platform/graphics/transform-feedback.js
+++ b/src/platform/graphics/transform-feedback.js
@@ -42,7 +42,7 @@ import { ShaderUtils } from './shader-utils.js';
  *
  * ```javascript
  * // *** script asset ***
- * const TransformExample = pc.createScript('transformExample');
+ * var TransformExample = pc.createScript('transformExample');
  *
  * // attribute that references shader asset and material
  * TransformExample.attributes.add('shaderCode', { type: 'asset', assetType: 'shader' });

--- a/src/platform/graphics/vertex-format.js
+++ b/src/platform/graphics/vertex-format.js
@@ -103,12 +103,12 @@ class VertexFormat {
      * vertex format will be interleaved. (example: PNCPNCPNCPNC).
      * @example
      * // Specify 3-component positions (x, y, z)
-     * var vertexFormat = new pc.VertexFormat(graphicsDevice, [
+     * const vertexFormat = new pc.VertexFormat(graphicsDevice, [
      *     { semantic: pc.SEMANTIC_POSITION, components: 3, type: pc.TYPE_FLOAT32 }
      * ]);
      * @example
      * // Specify 2-component positions (x, y), a texture coordinate (u, v) and a vertex color (r, g, b, a)
-     * var vertexFormat = new pc.VertexFormat(graphicsDevice, [
+     * const vertexFormat = new pc.VertexFormat(graphicsDevice, [
      *     { semantic: pc.SEMANTIC_POSITION, components: 2, type: pc.TYPE_FLOAT32 },
      *     { semantic: pc.SEMANTIC_TEXCOORD0, components: 2, type: pc.TYPE_FLOAT32 },
      *     { semantic: pc.SEMANTIC_COLOR, components: 4, type: pc.TYPE_UINT8, normalize: true }

--- a/src/platform/graphics/vertex-iterator.js
+++ b/src/platform/graphics/vertex-iterator.js
@@ -252,7 +252,7 @@ class VertexIterator {
      * @param {number} [count] - Optional number of steps to move on when calling next. Defaults to
      * 1.
      * @example
-     * var iterator = new pc.VertexIterator(vertexBuffer);
+     * const iterator = new pc.VertexIterator(vertexBuffer);
      * iterator.element[pc.SEMANTIC_POSITION].set(-0.9, -0.9, 0.0);
      * iterator.element[pc.SEMANTIC_COLOR].set(255, 0, 0, 255);
      * iterator.next();
@@ -278,7 +278,7 @@ class VertexIterator {
      * buffer is unlocked and vertex data is uploaded to video memory.
      *
      * @example
-     * var iterator = new pc.VertexIterator(vertexBuffer);
+     * const iterator = new pc.VertexIterator(vertexBuffer);
      * iterator.element[pc.SEMANTIC_POSITION].set(-0.9, -0.9, 0.0);
      * iterator.element[pc.SEMANTIC_COLOR].set(255, 0, 0, 255);
      * iterator.next();

--- a/src/platform/input/controller.js
+++ b/src/platform/input/controller.js
@@ -23,7 +23,7 @@ class Controller {
      * @param {Mouse} [options.mouse] - A Mouse object to use.
      * @param {import('./game-pads.js').GamePads} [options.gamepads] - A Gamepads object to use.
      * @example
-     * var c = new pc.Controller(document);
+     * const c = new pc.Controller(document);
      *
      * // Register the "fire" action and assign it to both the Enter key and the space bar.
      * c.registerKeys("fire", [pc.KEY_ENTER, pc.KEY_SPACE]);

--- a/src/platform/input/game-pads.js
+++ b/src/platform/input/game-pads.js
@@ -813,7 +813,7 @@ class GamePads extends EventHandler {
      * @event GamePads#gamepadconnected
      * @param {GamePad} gamepad - The gamepad that was just connected.
      * @example
-     * var onPadConnected = function (pad) {
+     * const onPadConnected = function (pad) {
      *     if (!pad.mapping) {
      *         // Map the gamepad as the system could not find the proper map.
      *     } else {
@@ -829,7 +829,7 @@ class GamePads extends EventHandler {
      * @event GamePads#gamepaddisconnected
      * @param {GamePad} gamepad - The gamepad that was just disconnected.
      * @example
-     * var onPadDisconnected = function (pad) {
+     * const onPadDisconnected = function (pad) {
      *     // Pause the game.
      * };
      * app.keyboard.on("gamepaddisconnected", onPadDisconnected, this);
@@ -929,8 +929,8 @@ class GamePads extends EventHandler {
      * @returns {GamePad[]} An array of gamepads and mappings for the model of gamepad that is
      * attached.
      * @example
-     * var gamepads = new pc.GamePads();
-     * var pads = gamepads.poll();
+     * const gamepads = new pc.GamePads();
+     * const pads = gamepads.poll();
      */
     poll(pads = []) {
         if (pads.length > 0) {

--- a/src/platform/input/keyboard-event.js
+++ b/src/platform/input/keyboard-event.js
@@ -10,7 +10,7 @@ class KeyboardEvent {
      * event.
      * @param {globalThis.KeyboardEvent} event - The original browser event that was fired.
      * @example
-     * var onKeyDown = function (e) {
+     * const onKeyDown = function (e) {
      *     if (e.key === pc.KEY_SPACE) {
      *         // space key pressed
      *     }

--- a/src/platform/input/keyboard.js
+++ b/src/platform/input/keyboard.js
@@ -75,7 +75,7 @@ class Keyboard extends EventHandler {
      * event.
      * @example
      * // attach keyboard listeners to the window
-     * var keyboard = new pc.Keyboard(window);
+     * const keyboard = new pc.Keyboard(window);
      */
     constructor(element, options = {}) {
         super();
@@ -105,7 +105,7 @@ class Keyboard extends EventHandler {
      * @event Keyboard#keydown
      * @param {KeyboardEvent} event - The Keyboard event object. Note, this event is only valid for the current callback.
      * @example
-     * var onKeyDown = function (e) {
+     * const onKeyDown = function (e) {
      *     if (e.key === pc.KEY_SPACE) {
      *         // space key pressed
      *     }
@@ -120,7 +120,7 @@ class Keyboard extends EventHandler {
      * @event Keyboard#keyup
      * @param {KeyboardEvent} event - The Keyboard event object. Note, this event is only valid for the current callback.
      * @example
-     * var onKeyUp = function (e) {
+     * const onKeyUp = function (e) {
      *     if (e.key === pc.KEY_SPACE) {
      *         // space key released
      *     }

--- a/src/platform/sound/instance.js
+++ b/src/platform/sound/instance.js
@@ -815,10 +815,10 @@ class SoundInstance extends EventHandler {
      * @param {AudioNode} [lastNode] - The last node that will be connected to the destination of the AudioContext.
      * If unspecified then the firstNode will be connected to the destination instead.
      * @example
-     * var context = app.systems.sound.context;
-     * var analyzer = context.createAnalyzer();
-     * var distortion = context.createWaveShaper();
-     * var filter = context.createBiquadFilter();
+     * const context = app.systems.sound.context;
+     * const analyzer = context.createAnalyzer();
+     * const distortion = context.createWaveShaper();
+     * const filter = context.createBiquadFilter();
      * analyzer.connect(distortion);
      * distortion.connect(filter);
      * instance.setExternalNodes(analyzer, filter);

--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -502,12 +502,12 @@ class GraphNode extends EventHandler {
      * @returns {GraphNode[]} The array of graph nodes that match the search criteria.
      * @example
      * // Finds all nodes that have a model component and have 'door' in their lower-cased name
-     * var doors = house.find(function (node) {
+     * const doors = house.find(function (node) {
      *     return node.model && node.name.toLowerCase().indexOf('door') !== -1;
      * });
      * @example
      * // Finds all nodes that have the name property set to 'Test'
-     * var entities = parent.find('name', 'Test');
+     * const entities = parent.find('name', 'Test');
      */
     find(attr, value) {
         let result, results = [];
@@ -565,12 +565,12 @@ class GraphNode extends EventHandler {
      * node is found.
      * @example
      * // Find the first node that is called 'head' and has a model component
-     * var head = player.findOne(function (node) {
+     * const head = player.findOne(function (node) {
      *     return node.model && node.name === 'head';
      * });
      * @example
      * // Finds the first node that has the name property set to 'Test'
-     * var node = parent.findOne('name', 'Test');
+     * const node = parent.findOne('name', 'Test');
      */
     findOne(attr, value) {
         const len = this._children.length;
@@ -621,16 +621,16 @@ class GraphNode extends EventHandler {
      * @returns {GraphNode[]} A list of all graph nodes that match the query.
      * @example
      * // Return all graph nodes that tagged by `animal`
-     * var animals = node.findByTag("animal");
+     * const animals = node.findByTag("animal");
      * @example
      * // Return all graph nodes that tagged by `bird` OR `mammal`
-     * var birdsAndMammals = node.findByTag("bird", "mammal");
+     * const birdsAndMammals = node.findByTag("bird", "mammal");
      * @example
      * // Return all assets that tagged by `carnivore` AND `mammal`
-     * var meatEatingMammals = node.findByTag(["carnivore", "mammal"]);
+     * const meatEatingMammals = node.findByTag(["carnivore", "mammal"]);
      * @example
      * // Return all assets that tagged by (`carnivore` AND `mammal`) OR (`carnivore` AND `reptile`)
-     * var meatEatingMammalsAndReptiles = node.findByTag(["carnivore", "mammal"], ["carnivore", "reptile"]);
+     * const meatEatingMammalsAndReptiles = node.findByTag(["carnivore", "mammal"], ["carnivore", "reptile"]);
      */
     findByTag() {
         const query = arguments;
@@ -678,10 +678,10 @@ class GraphNode extends EventHandler {
      * null if no node is found.
      * @example
      * // String form
-     * var grandchild = this.entity.findByPath('child/grandchild');
+     * const grandchild = this.entity.findByPath('child/grandchild');
      * @example
      * // Array form
-     * var grandchild = this.entity.findByPath(['child', 'grandchild']);
+     * const grandchild = this.entity.findByPath(['child', 'grandchild']);
      */
     findByPath(path) {
         // accept either string path with '/' separators or array of parts.
@@ -762,7 +762,7 @@ class GraphNode extends EventHandler {
      *
      * @returns {Vec3} The world space rotation of the graph node in Euler angle form.
      * @example
-     * var angles = this.entity.getEulerAngles();
+     * const angles = this.entity.getEulerAngles();
      * angles.y = 180; // rotate the entity around Y by 180 degrees
      * this.entity.setEulerAngles(angles);
      */
@@ -778,7 +778,7 @@ class GraphNode extends EventHandler {
      *
      * @returns {Vec3} The local space rotation of the graph node as euler angles in XYZ order.
      * @example
-     * var angles = this.entity.getLocalEulerAngles();
+     * const angles = this.entity.getLocalEulerAngles();
      * angles.y = 180;
      * this.entity.setLocalEulerAngles(angles);
      */
@@ -794,7 +794,7 @@ class GraphNode extends EventHandler {
      *
      * @returns {Vec3} The local space position of the graph node.
      * @example
-     * var position = this.entity.getLocalPosition();
+     * const position = this.entity.getLocalPosition();
      * position.x += 1; // move the entity 1 unit along x.
      * this.entity.setLocalPosition(position);
      */
@@ -809,7 +809,7 @@ class GraphNode extends EventHandler {
      *
      * @returns {Quat} The local space rotation of the graph node as a quaternion.
      * @example
-     * var rotation = this.entity.getLocalRotation();
+     * const rotation = this.entity.getLocalRotation();
      */
     getLocalRotation() {
         return this.localRotation;
@@ -822,7 +822,7 @@ class GraphNode extends EventHandler {
      *
      * @returns {Vec3} The local space scale of the graph node.
      * @example
-     * var scale = this.entity.getLocalScale();
+     * const scale = this.entity.getLocalScale();
      * scale.x = 100;
      * this.entity.setLocalScale(scale);
      */
@@ -836,7 +836,7 @@ class GraphNode extends EventHandler {
      *
      * @returns {Mat4} The node's local transformation matrix.
      * @example
-     * var transform = this.entity.getLocalTransform();
+     * const transform = this.entity.getLocalTransform();
      */
     getLocalTransform() {
         if (this._dirtyLocal) {
@@ -853,7 +853,7 @@ class GraphNode extends EventHandler {
      *
      * @returns {Vec3} The world space position of the graph node.
      * @example
-     * var position = this.entity.getPosition();
+     * const position = this.entity.getPosition();
      * position.x = 10;
      * this.entity.setPosition(position);
      */
@@ -869,7 +869,7 @@ class GraphNode extends EventHandler {
      *
      * @returns {Quat} The world space rotation of the graph node as a quaternion.
      * @example
-     * var rotation = this.entity.getRotation();
+     * const rotation = this.entity.getRotation();
      */
     getRotation() {
         this.rotation.setFromMat4(this.getWorldTransform());
@@ -886,7 +886,7 @@ class GraphNode extends EventHandler {
      *
      * @returns {Vec3} The world space scale of the graph node.
      * @example
-     * var scale = this.entity.getScale();
+     * const scale = this.entity.getScale();
      * @ignore
      */
     getScale() {
@@ -901,7 +901,7 @@ class GraphNode extends EventHandler {
      *
      * @returns {Mat4} The node's world transformation matrix.
      * @example
-     * var transform = this.entity.getWorldTransform();
+     * const transform = this.entity.getWorldTransform();
      */
     getWorldTransform() {
         if (!this._dirtyLocal && !this._dirtyWorld)
@@ -966,7 +966,7 @@ class GraphNode extends EventHandler {
      * this.entity.setLocalEulerAngles(0, 90, 0);
      * @example
      * // Set rotation of 90 degrees around y-axis via a vector
-     * var angles = new pc.Vec3(0, 90, 0);
+     * const angles = new pc.Vec3(0, 90, 0);
      * this.entity.setLocalEulerAngles(angles);
      */
     setLocalEulerAngles(x, y, z) {
@@ -990,7 +990,7 @@ class GraphNode extends EventHandler {
      * this.entity.setLocalPosition(0, 10, 0);
      * @example
      * // Set via vector
-     * var pos = new pc.Vec3(0, 10, 0);
+     * const pos = new pc.Vec3(0, 10, 0);
      * this.entity.setLocalPosition(pos);
      */
     setLocalPosition(x, y, z) {
@@ -1019,7 +1019,7 @@ class GraphNode extends EventHandler {
      * this.entity.setLocalRotation(0, 0, 0, 1);
      * @example
      * // Set via quaternion
-     * var q = pc.Quat();
+     * const q = pc.Quat();
      * this.entity.setLocalRotation(q);
      */
     setLocalRotation(x, y, z, w) {
@@ -1046,7 +1046,7 @@ class GraphNode extends EventHandler {
      * this.entity.setLocalScale(10, 10, 10);
      * @example
      * // Set via vector
-     * var scale = new pc.Vec3(10, 10, 10);
+     * const scale = new pc.Vec3(10, 10, 10);
      * this.entity.setLocalScale(scale);
      */
     setLocalScale(x, y, z) {
@@ -1116,7 +1116,7 @@ class GraphNode extends EventHandler {
      * this.entity.setPosition(0, 10, 0);
      * @example
      * // Set via vector
-     * var position = new pc.Vec3(0, 10, 0);
+     * const position = new pc.Vec3(0, 10, 0);
      * this.entity.setPosition(position);
      */
     setPosition(x, y, z) {
@@ -1152,7 +1152,7 @@ class GraphNode extends EventHandler {
      * this.entity.setRotation(0, 0, 0, 1);
      * @example
      * // Set via quaternion
-     * var q = pc.Quat();
+     * const q = pc.Quat();
      * this.entity.setRotation(q);
      */
     setRotation(x, y, z, w) {
@@ -1189,7 +1189,7 @@ class GraphNode extends EventHandler {
      * this.entity.setEulerAngles(0, 90, 0);
      * @example
      * // Set rotation of 90 degrees around world-space y-axis via a vector
-     * var angles = new pc.Vec3(0, 90, 0);
+     * const angles = new pc.Vec3(0, 90, 0);
      * this.entity.setEulerAngles(angles);
      */
     setEulerAngles(x, y, z) {
@@ -1211,7 +1211,7 @@ class GraphNode extends EventHandler {
      *
      * @param {GraphNode} node - The new child to add.
      * @example
-     * var e = new pc.Entity(app);
+     * const e = new pc.Entity(app);
      * this.entity.addChild(e);
      */
     addChild(node) {
@@ -1226,7 +1226,7 @@ class GraphNode extends EventHandler {
      *
      * @param {GraphNode} node - The child to add.
      * @example
-     * var e = new pc.Entity(app);
+     * const e = new pc.Entity(app);
      * this.entity.addChildAndSaveTransform(e);
      * @ignore
      */
@@ -1252,7 +1252,7 @@ class GraphNode extends EventHandler {
      * @param {number} index - The index in the child list of the parent where the new node will be
      * inserted.
      * @example
-     * var e = new pc.Entity(app);
+     * const e = new pc.Entity(app);
      * this.entity.insertChild(e, 1);
      */
     insertChild(node, index) {
@@ -1351,7 +1351,7 @@ class GraphNode extends EventHandler {
      *
      * @param {GraphNode} child - The node to remove.
      * @example
-     * var child = this.entity.children[0];
+     * const child = this.entity.children[0];
      * this.entity.removeChild(child);
      */
     removeChild(child) {
@@ -1477,11 +1477,11 @@ class GraphNode extends EventHandler {
      * @param {number} [uz=0] - Z-component of the up vector for the look at transform.
      * @example
      * // Look at another entity, using the (default) positive y-axis for up
-     * var position = otherEntity.getPosition();
+     * const position = otherEntity.getPosition();
      * this.entity.lookAt(position);
      * @example
      * // Look at another entity, using the negative world y-axis for up
-     * var position = otherEntity.getPosition();
+     * const position = otherEntity.getPosition();
      * this.entity.lookAt(position, pc.Vec3.DOWN);
      * @example
      * // Look at the world space origin, using the (default) positive y-axis for up
@@ -1525,7 +1525,7 @@ class GraphNode extends EventHandler {
      * this.entity.translate(10, 0, 0);
      * @example
      * // Translate via vector
-     * var t = new pc.Vec3(10, 0, 0);
+     * const t = new pc.Vec3(10, 0, 0);
      * this.entity.translate(t);
      */
     translate(x, y, z) {
@@ -1553,7 +1553,7 @@ class GraphNode extends EventHandler {
      * this.entity.translateLocal(10, 0, 0);
      * @example
      * // Translate via vector
-     * var t = new pc.Vec3(10, 0, 0);
+     * const t = new pc.Vec3(10, 0, 0);
      * this.entity.translateLocal(t);
      */
     translateLocal(x, y, z) {
@@ -1584,7 +1584,7 @@ class GraphNode extends EventHandler {
      * this.entity.rotate(0, 90, 0);
      * @example
      * // Rotate via vector
-     * var r = new pc.Vec3(0, 90, 0);
+     * const r = new pc.Vec3(0, 90, 0);
      * this.entity.rotate(r);
      */
     rotate(x, y, z) {
@@ -1619,7 +1619,7 @@ class GraphNode extends EventHandler {
      * this.entity.rotateLocal(0, 90, 0);
      * @example
      * // Rotate via vector
-     * var r = new pc.Vec3(0, 90, 0);
+     * const r = new pc.Vec3(0, 90, 0);
      * this.entity.rotateLocal(r);
      */
     rotateLocal(x, y, z) {

--- a/src/scene/graphics/quad-render.js
+++ b/src/scene/graphics/quad-render.js
@@ -23,8 +23,8 @@ const _tempScissor = new Vec4();
  * Example:
  *
  * ```javascript
- * var = pc.createShaderFromCode(app.graphicsDevice, vertexShader, fragmentShader, `MyShader`);
- * var quad = new QuadRender(shader);
+ * const shader = pc.createShaderFromCode(app.graphicsDevice, vertexShader, fragmentShader, `MyShader`);
+ * const quad = new QuadRender(shader);
  * quad.render();
  * quad.destroy();
  * ```

--- a/src/scene/materials/basic-material.js
+++ b/src/scene/materials/basic-material.js
@@ -23,7 +23,7 @@ class BasicMaterial extends Material {
      *
      * @example
      * // Create a new Basic material
-     * var material = new pc.BasicMaterial();
+     * const material = new pc.BasicMaterial();
      *
      * // Set the material to have a texture map that is multiplied by a red color
      * material.color.set(1, 0, 0);

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -518,7 +518,7 @@ class StandardMaterial extends Material {
      *
      * @example
      * // Create a new Standard material
-     * var material = new pc.StandardMaterial();
+     * const material = new pc.StandardMaterial();
      *
      * // Update the material's diffuse and specular properties
      * material.diffuse.set(1, 0, 0);
@@ -528,7 +528,7 @@ class StandardMaterial extends Material {
      * material.update();
      * @example
      * // Create a new Standard material
-     * var material = new pc.StandardMaterial();
+     * const material = new pc.StandardMaterial();
      *
      * // Assign a texture to the diffuse slot
      * material.diffuseMap = texture;

--- a/src/scene/mesh-instance.js
+++ b/src/scene/mesh-instance.js
@@ -129,12 +129,12 @@ class MeshInstance {
      * component is attached to.
      * @example
      * // Create a mesh instance pointing to a 1x1x1 'cube' mesh
-     * var mesh = pc.createBox(graphicsDevice);
-     * var material = new pc.StandardMaterial();
+     * const mesh = pc.createBox(graphicsDevice);
+     * const material = new pc.StandardMaterial();
      *
-     * var meshInstance = new pc.MeshInstance(mesh, material);
+     * const meshInstance = new pc.MeshInstance(mesh, material);
      *
-     * var entity = new pc.Entity();
+     * const entity = new pc.Entity();
      * entity.addComponent('render', {
      *     meshInstances: [meshInstance]
      * });

--- a/src/scene/mesh.js
+++ b/src/scene/mesh.js
@@ -103,8 +103,8 @@ class GeometryVertexStream {
  * form a single triangle.
  *
  * ```javascript
- * var mesh = new pc.Mesh(device);
- * var positions = [
+ * const mesh = new pc.Mesh(device);
+ * const positions = [
  *     0, 0, 0, // pos 0
  *     1, 0, 0, // pos 1
  *     1, 1, 0  // pos 2
@@ -117,20 +117,20 @@ class GeometryVertexStream {
  * channel 0, and an index buffer to form two triangles. Float32Array is used for positions and uvs.
  *
  * ```javascript
- * var mesh = new pc.Mesh(device);
- * var positions = new Float32Array([
+ * const mesh = new pc.Mesh(device);
+ * const positions = new Float32Array([
  *     0, 0, 0, // pos 0
  *     1, 0, 0, // pos 1
  *     1, 1, 0, // pos 2
  *     0, 1, 0  // pos 3
  * ]);
- * var uvs = new Float32Array([
+ * const uvs = new Float32Array([
  *     0, 0, // uv 0
  *     1, 0, // uv 1
  *     1, 1, // uv 2
  *     0, 1  // uv 3
  * ]);
- * var indices = [
+ * const indices = [
  *     0, 1, 2, // triangle 0
  *     0, 2, 3  // triangle 1
  * ];

--- a/src/scene/model.js
+++ b/src/scene/model.js
@@ -41,7 +41,7 @@ class Model {
      *
      * @example
      * // Create a new model
-     * var model = new pc.Model();
+     * const model = new pc.Model();
      */
     constructor() {
         this.cameras = [];
@@ -94,7 +94,7 @@ class Model {
      *
      * @returns {Model} A clone of the specified model.
      * @example
-     * var clonedModel = model.clone();
+     * const clonedModel = model.clone();
      */
     clone() {
 
@@ -196,7 +196,7 @@ class Model {
      *
      * @example
      * model.generateWireframe();
-     * for (var i = 0; i < model.meshInstances.length; i++) {
+     * for (let i = 0; i < model.meshInstances.length; i++) {
      *     model.meshInstances[i].renderStyle = pc.RENDERSTYLE_WIREFRAME;
      * }
      */

--- a/src/scene/procedural.js
+++ b/src/scene/procedural.js
@@ -23,8 +23,8 @@ const shapePrimitives = [];
  * @param {number[]} indices - An array of triangle indices.
  * @returns {number[]} An array of 3-dimensional vertex normals.
  * @example
- * var normals = pc.calculateNormals(positions, indices);
- * var mesh = pc.createMesh(graphicsDevice, positions, {
+ * const normals = pc.calculateNormals(positions, indices);
+ * const mesh = pc.createMesh(graphicsDevice, positions, {
  *     normals: normals,
  *     uvs: uvs,
  *     indices: indices
@@ -96,8 +96,8 @@ function calculateNormals(positions, indices) {
  * @param {number[]} indices - An array of triangle indices.
  * @returns {number[]} An array of 3-dimensional vertex tangents.
  * @example
- * var tangents = pc.calculateTangents(positions, normals, uvs, indices);
- * var mesh = pc.createMesh(graphicsDevice, positions, {
+ * const tangents = pc.calculateTangents(positions, normals, uvs, indices);
+ * const mesh = pc.createMesh(graphicsDevice, positions, {
  *     normals: normals,
  *     tangents: tangents,
  *     uvs: uvs,
@@ -233,7 +233,7 @@ function calculateTangents(positions, normals, uvs, indices) {
  * @returns {Mesh} A new Mesh constructed from the supplied vertex and triangle data.
  * @example
  * // Create a simple, indexed triangle (with texture coordinates and vertex normals)
- * var mesh = pc.createMesh(graphicsDevice, [0, 0, 0, 1, 0, 0, 0, 1, 0], {
+ * const mesh = pc.createMesh(graphicsDevice, [0, 0, 0, 1, 0, 0, 0, 1, 0], {
  *     normals: [0, 0, 1, 0, 0, 1, 0, 0, 1],
  *     uvs: [0, 0, 1, 0, 0, 1],
  *     indices: [0, 1, 2]

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -291,10 +291,9 @@ class Scene extends EventHandler {
      * {@link LayerComposition}.
      * @example
      * this.app.scene.on('set:layers', function (oldComp, newComp) {
-     *     var list = newComp.layerList;
-     *     var layer;
-     *     for (var i = 0; i < list.length; i++) {
-     *         layer = list[i];
+     *     const list = newComp.layerList;
+     *     for (let i = 0; i < list.length; i++) {
+     *         const layer = list[i];
      *         switch (layer.name) {
      *             case 'MyLayer':
      *                 layer.onEnable = myOnEnableFunction;

--- a/src/scene/sprite.js
+++ b/src/scene/sprite.js
@@ -50,10 +50,10 @@ class Sprite extends EventHandler {
         super();
 
         this._device = device;
-        this._pixelsPerUnit = options && options.pixelsPerUnit !== undefined ? options.pixelsPerUnit : 1;
-        this._renderMode = options && options.renderMode !== undefined ? options.renderMode : SPRITE_RENDERMODE_SIMPLE;
-        this._atlas = options && options.atlas !== undefined ? options.atlas : null;
-        this._frameKeys = options && options.frameKeys !== undefined ? options.frameKeys : null;
+        this._pixelsPerUnit = options?.pixelsPerUnit ?? 1;
+        this._renderMode = options?.renderMode ?? SPRITE_RENDERMODE_SIMPLE;
+        this._atlas = options?.atlas ?? null;
+        this._frameKeys = options?.frameKeys ?? null;
         this._meshes = [];
 
         // set to true to update multiple

--- a/src/scene/sprite.js
+++ b/src/scene/sprite.js
@@ -50,10 +50,10 @@ class Sprite extends EventHandler {
         super();
 
         this._device = device;
-        this._pixelsPerUnit = options?.pixelsPerUnit ?? 1;
-        this._renderMode = options?.renderMode ?? SPRITE_RENDERMODE_SIMPLE;
-        this._atlas = options?.atlas ?? null;
-        this._frameKeys = options?.frameKeys ?? null;
+        this._pixelsPerUnit = options && options.pixelsPerUnit !== undefined ? options.pixelsPerUnit : 1;
+        this._renderMode = options && options.renderMode !== undefined ? options.renderMode : SPRITE_RENDERMODE_SIMPLE;
+        this._atlas = options && options.atlas !== undefined ? options.atlas : null;
+        this._frameKeys = options && options.frameKeys !== undefined ? options.frameKeys : null;
         this._meshes = [];
 
         // set to true to update multiple

--- a/src/scene/texture-atlas.js
+++ b/src/scene/texture-atlas.js
@@ -11,7 +11,7 @@ class TextureAtlas extends EventHandler {
      * Create a new TextureAtlas instance.
      *
      * @example
-     * var atlas = new pc.TextureAtlas();
+     * const atlas = new pc.TextureAtlas();
      * atlas.frames = {
      *     '0': {
      *         // rect has u, v, width and height in pixels


### PR DESCRIPTION
It's time. This PR eliminates almost all remaining instances of `var` in the engine codebase. These are almost all in the API ref docs. However, since even IE11 support both `let` and `const`, we should embrace these superior keywords everywhere.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
