### PR TITLE
Include extras in published package

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "build/playcanvas.prf.mjs",
     "build/playcanvas.d.ts",
     "build/playcanvas-extras.js",
+    "build/playcanvas-extras.mjs",
     "scripts",
     "LICENSE",
     "package.json",


### PR DESCRIPTION
The es6 module build of extras was never included in the published package, but should have been.