### PR TITLE
Use RGBA8 for png and jpg

### DIFF
--- a/src/framework/parsers/texture/img.js
+++ b/src/framework/parsers/texture/img.js
@@ -1,7 +1,5 @@
-import { path } from '../../../core/path.js';
-
 import {
-    PIXELFORMAT_RGB8, PIXELFORMAT_RGBA8, TEXHINT_ASSET
+    PIXELFORMAT_RGBA8, TEXHINT_ASSET
 } from '../../../platform/graphics/constants.js';
 import { Texture } from '../../../platform/graphics/texture.js';
 import { http } from '../../../platform/net/http.js';


### PR DESCRIPTION
The image loader was specifying RGB8 pixel format for JPG, but this incurs a format conversion cost when using ImageBitmap.

This PR standardises on RGBA8 instead, speeding up JPG loading in Chrome.
