### PR TITLE
Disable ImageBitmap in Safari

### DIFF
--- a/src/framework/parsers/texture/img-alpha-test.js
+++ b/src/framework/parsers/texture/img-alpha-test.js
@@ -83,6 +83,4 @@ class ImgAlphaTest {
     }
 }
 
-export {
-    ImgAlphaTest
-};
+export { ImgAlphaTest };

--- a/src/framework/parsers/texture/img-alpha-test.js
+++ b/src/framework/parsers/texture/img-alpha-test.js
@@ -1,6 +1,6 @@
-import { Texture } from '../../../platform/graphics/texture.js';
 import { PIXELFORMAT_RGBA8 } from '../../../platform/graphics/constants.js';
 import { RenderTarget } from '../../../platform/graphics/render-target.js';
+import { Texture } from '../../../platform/graphics/texture.js';
 
 //
 // Current state of ImageBitmap (April 2023):

--- a/src/framework/parsers/texture/img-alpha-test.js
+++ b/src/framework/parsers/texture/img-alpha-test.js
@@ -1,6 +1,6 @@
-import { Texture } from '../texture.js';
-import { PIXELFORMAT_RGBA8 } from '../constants.js';
-import { RenderTarget } from '../render-target.js';
+import { Texture } from '../../../platform/graphics/texture.js';
+import { PIXELFORMAT_RGBA8 } from '../../../platform/graphics/constants.js';
+import { RenderTarget } from '../../../platform/graphics/render-target.js';
 
 //
 // Current state of ImageBitmap (April 2023):
@@ -44,7 +44,7 @@ const testAlpha = (device, image) => {
     texture.destroy();
 
     return data[0] === 1 && data[1] === 2 && data[2] === 3 && data[3] === 63;
-}
+};
 
 // Test whether ImageBitmap correctly loads PNG alpha data.
 const testImageBitmapAlpha = (device) => {
@@ -58,7 +58,7 @@ const testImageBitmapAlpha = (device) => {
             return testAlpha(device, image);
         })
         .catch(e => false);
-}
+};
 
 // Test whether image element correctly loads PNG alpha data.
 const testImgElementAlpha = (device) => {
@@ -69,9 +69,9 @@ const testImgElementAlpha = (device) => {
             resolve(testAlpha(device, image));
         };
     });
-}
+};
 
-class WebglImageTest {
+class ImgAlphaTest {
     static run(device) {
         testImageBitmapAlpha(device).then((result) => {
             console.log(`imageBitmapIsCorrect=${result}`);
@@ -84,5 +84,5 @@ class WebglImageTest {
 }
 
 export {
-    WebglImageTest
+    ImgAlphaTest
 };

--- a/src/framework/parsers/texture/img.js
+++ b/src/framework/parsers/texture/img.js
@@ -6,8 +6,9 @@ import { http } from '../../../platform/net/http.js';
 
 import { ABSOLUTE_URL } from '../../asset/constants.js';
 import { ImgAlphaTest } from './img-alpha-test.js';
-import { Debug } from '../../../core/debug.js';
+// #if _DEBUG
 import { Tracing } from '../../../core/tracing.js';
+// #endif
 
 /** @typedef {import('../../handlers/texture.js').TextureParser} TextureParser */
 
@@ -25,11 +26,11 @@ class ImgParser {
         this.device = device;
 
         // run image alpha test
-        Debug.call(() => {
-            if (Tracing.get('IMG_ALPHA_TEST')) {
-                ImgAlphaTest.run(this.device);
-            }
-        });
+        // #if _DEBUG
+        if (Tracing.get('IMG_ALPHA_TEST')) {
+            ImgAlphaTest.run(this.device);
+        }
+        // #endif
     }
 
     load(url, callback, asset) {

--- a/src/framework/parsers/texture/img.js
+++ b/src/framework/parsers/texture/img.js
@@ -61,8 +61,6 @@ class ImgParser {
     }
 
     open(url, data, device) {
-        const ext = path.getExtension(url).toLowerCase();
-        const format = (ext === '.jpg' || ext === '.jpeg') ? PIXELFORMAT_RGB8 : PIXELFORMAT_RGBA8;
         const texture = new Texture(device, {
             name: url,
             // #if _PROFILER
@@ -70,7 +68,7 @@ class ImgParser {
             // #endif
             width: data.width,
             height: data.height,
-            format: format
+            format: PIXELFORMAT_RGBA8
         });
         texture.setSource(data);
         return texture;
@@ -129,7 +127,8 @@ class ImgParser {
                 callback(err);
             } else {
                 createImageBitmap(blob, {
-                    premultiplyAlpha: 'none'
+                    premultiplyAlpha: 'none',
+                    colorSpaceConversion: 'none'
                 })
                     .then(imageBitmap => callback(null, imageBitmap))
                     .catch(e => callback(e));
@@ -138,7 +137,10 @@ class ImgParser {
     }
 
     _loadImageBitmapFromData(data, callback) {
-        createImageBitmap(new Blob([data]), { premultiplyAlpha: 'none' })
+        createImageBitmap(new Blob([data]), {
+            premultiplyAlpha: 'none',
+            colorSpaceConversion: 'none'
+        })
             .then(imageBitmap => callback(null, imageBitmap))
             .catch(e => callback(e));
     }

--- a/src/framework/parsers/texture/img.js
+++ b/src/framework/parsers/texture/img.js
@@ -5,6 +5,9 @@ import { Texture } from '../../../platform/graphics/texture.js';
 import { http } from '../../../platform/net/http.js';
 
 import { ABSOLUTE_URL } from '../../asset/constants.js';
+import { ImgAlphaTest } from './img-alpha-test.js';
+import { Debug } from '../../../core/debug.js';
+import { Tracing } from '../../../core/tracing.js';
 
 /** @typedef {import('../../handlers/texture.js').TextureParser} TextureParser */
 
@@ -20,6 +23,13 @@ class ImgParser {
         this.crossOrigin = registry.prefix ? 'anonymous' : null;
         this.maxRetries = 0;
         this.device = device;
+
+        // run image alpha test
+        Debug.call(() => {
+            if (Tracing.get('IMG_ALPHA_TEST')) {
+                ImgAlphaTest.run(this.device);
+            }
+        });
     }
 
     load(url, callback, asset) {

--- a/src/framework/parsers/texture/img.js
+++ b/src/framework/parsers/texture/img.js
@@ -5,8 +5,8 @@ import { Texture } from '../../../platform/graphics/texture.js';
 import { http } from '../../../platform/net/http.js';
 
 import { ABSOLUTE_URL } from '../../asset/constants.js';
-import { ImgAlphaTest } from './img-alpha-test.js';
 // #if _DEBUG
+import { ImgAlphaTest } from './img-alpha-test.js';
 import { Tracing } from '../../../core/tracing.js';
 // #endif
 

--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -394,7 +394,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
         this.initializeContextCaches();
 
         // only enable ImageBitmap on chrome
-        this.supportsImageBitmap = isChrome && typeof ImageBitmap !== 'undefined';
+        this.supportsImageBitmap = !isSafari && typeof ImageBitmap !== 'undefined';
 
         this.glAddress = [
             gl.REPEAT,

--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -380,7 +380,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
         this._tempEnableSafariTextureUnitWorkaround = isSafari;
 
         // enable temporary workaround for glBlitFramebuffer failing on Mac Chrome (#2504)
-        this._tempMacChromeBlitFramebufferWorkaround = isMac && isChrome && !gl.alpha;
+        this._tempMacChromeBlitFramebufferWorkaround = isMac && isChrome && !options.alpha;
 
         // init polyfill for VAOs under webgl1
         if (!this.webgl2) {
@@ -396,7 +396,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
         this.initializeContextCaches();
 
         // only enable ImageBitmap on chrome
-        this.supportsImageBitmap = typeof ImageBitmap !== 'undefined' && isChrome;
+        this.supportsImageBitmap = isChrome && typeof ImageBitmap !== 'undefined';
 
         // run image alpha test
         Debug.call(() => {

--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -1,6 +1,5 @@
 import { setupVertexArrayObject } from '../../../polyfill/OESVertexArrayObject.js';
 import { Debug } from '../../../core/debug.js';
-import { Tracing } from '../../../core/tracing.js';
 import { platform } from '../../../core/platform.js';
 import { Color } from '../../../core/math/color.js';
 
@@ -30,7 +29,6 @@ import { Texture } from '../texture.js';
 import { DebugGraphics } from '../debug-graphics.js';
 
 import { WebglVertexBuffer } from './webgl-vertex-buffer.js';
-import { WebglImageTest } from './wegbl-image-test.js';
 import { WebglIndexBuffer } from './webgl-index-buffer.js';
 import { WebglShader } from './webgl-shader.js';
 import { WebglTexture } from './webgl-texture.js';
@@ -397,13 +395,6 @@ class WebglGraphicsDevice extends GraphicsDevice {
 
         // only enable ImageBitmap on chrome
         this.supportsImageBitmap = isChrome && typeof ImageBitmap !== 'undefined';
-
-        // run image alpha test
-        Debug.call(() => {
-            if (Tracing.get('IMAGE_ALPHA_TEST')) {
-                WebglImageTest.run(this);
-            }
-        });
 
         this.glAddress = [
             gl.REPEAT,

--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -363,7 +363,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
         }
 
         this.gl = gl;
-        this.webgl2 = gl instanceof WebGL2RenderingContext;
+        this.webgl2 = typeof WebGL2RenderingContext !== 'undefined' && gl instanceof WebGL2RenderingContext;
         this._deviceType = this.webgl2 ? DEVICETYPE_WEBGL2 : DEVICETYPE_WEBGL1;
 
         // pixel format of the framebuffer
@@ -394,7 +394,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
         this.initializeContextCaches();
 
         // only enable ImageBitmap on chrome
-        this.supportsImageBitmap = isChrome;
+        this.supportsImageBitmap = typeof ImageBitmap !== 'undefined' && isChrome;
 
         // run image alpha test
         Debug.call(() => {

--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -1,5 +1,6 @@
 import { setupVertexArrayObject } from '../../../polyfill/OESVertexArrayObject.js';
 import { Debug } from '../../../core/debug.js';
+import { Tracing } from '../../../core/tracing.js';
 import { platform } from '../../../core/platform.js';
 import { Color } from '../../../core/math/color.js';
 
@@ -29,6 +30,7 @@ import { Texture } from '../texture.js';
 import { DebugGraphics } from '../debug-graphics.js';
 
 import { WebglVertexBuffer } from './webgl-vertex-buffer.js';
+import { WebglImageTest } from './wegbl-image-test.js';
 import { WebglIndexBuffer } from './webgl-index-buffer.js';
 import { WebglShader } from './webgl-shader.js';
 import { WebglTexture } from './webgl-texture.js';
@@ -236,52 +238,6 @@ function testTextureFloatHighPrecision(device) {
     return f === 0;
 }
 
-// ImageBitmap current state (Sep 2022):
-// - Lastest Chrome and Firefox browsers appear to support the ImageBitmap API fine (though
-//   there are likely still issues with older versions of both).
-// - Safari supports the API, but completely destroys some pngs. For example the cubemaps in
-//   steampunk slots https://playcanvas.com/editor/scene/524858. See the webkit issue
-//   https://bugs.webkit.org/show_bug.cgi?id=182424 for status.
-// - Some applications assume that PNGs loaded by the engine use HTMLImageBitmap interface and
-//   fail when using ImageBitmap. For example, Space Base project fails because it uses engine
-//   texture assets on the dom https://playcanvas.com/editor/scene/446278.
-
-// This function tests whether the current browser destroys PNG data or not.
-function testImageBitmap(device) {
-    // 1x1 png image containing rgba(1, 2, 3, 63)
-    const pngBytes = new Uint8Array([
-        137, 80, 78, 71, 13, 10, 26, 10, 0, 0, 0, 13, 73, 72, 68, 82, 0, 0, 0, 1, 0, 0, 0, 1, 8, 6, 0, 0, 0, 31, 21,
-        196, 137, 0, 0, 0, 13, 73, 68, 65, 84, 120, 218, 99, 100, 100, 98, 182, 7, 0, 0, 89, 0, 71, 67, 133, 148, 237,
-        0, 0, 0, 0, 73, 69, 78, 68, 174, 66, 96, 130
-    ]);
-
-    return createImageBitmap(new Blob([pngBytes], { type: 'image/png' }), { premultiplyAlpha: 'none' })
-        .then((image) => {
-            // create the texture
-            const texture = new Texture(device, {
-                width: 1,
-                height: 1,
-                format: PIXELFORMAT_RGBA8,
-                mipmaps: false,
-                levels: [image]
-            });
-
-            // read pixels
-            const rt = new RenderTarget({ colorBuffer: texture, depth: false });
-            device.setFramebuffer(rt.impl._glFrameBuffer);
-            device.initRenderTarget(rt);
-
-            const data = new Uint8ClampedArray(4);
-            device.gl.readPixels(0, 0, 1, 1, device.gl.RGBA, device.gl.UNSIGNED_BYTE, data);
-
-            rt.destroy();
-            texture.destroy();
-
-            return data[0] === 1 && data[1] === 2 && data[2] === 3 && data[3] === 63;
-        })
-        .catch(e => false);
-}
-
 /**
  * The graphics device manages the underlying graphics context. It is responsible for submitting
  * render state changes and graphics primitives to the hardware. A graphics device is tied to a
@@ -386,25 +342,29 @@ class WebglGraphicsDevice extends GraphicsDevice {
             Debug.log("Antialiasing has been turned off due to rendering issues on AppleWebKit 15.4");
         }
 
-        // Retrieve the WebGL context
-        const preferWebGl2 = (options.preferWebGl2 !== undefined) ? options.preferWebGl2 : true;
-
-        const names = preferWebGl2 ? ["webgl2", "webgl", "experimental-webgl"] : ["webgl", "experimental-webgl"];
         let gl = null;
-        for (let i = 0; i < names.length; i++) {
-            gl = canvas.getContext(names[i], options);
 
-            if (gl) {
-                this.webgl2 = (names[i] === DEVICETYPE_WEBGL2);
-                this._deviceType = this.webgl2 ? DEVICETYPE_WEBGL2 : DEVICETYPE_WEBGL1;
-                break;
+        // Retrieve the WebGL context
+        if (options.gl) {
+            gl = options.gl;
+        } else {
+            const preferWebGl2 = (options.preferWebGl2 !== undefined) ? options.preferWebGl2 : true;
+            const names = preferWebGl2 ? ["webgl2", "webgl", "experimental-webgl"] : ["webgl", "experimental-webgl"];
+            for (let i = 0; i < names.length; i++) {
+                gl = canvas.getContext(names[i], options);
+                if (gl) {
+                    break;
+                }
             }
         }
-        this.gl = gl;
 
         if (!gl) {
             throw new Error("WebGL not supported");
         }
+
+        this.gl = gl;
+        this.webgl2 = gl instanceof WebGL2RenderingContext;
+        this._deviceType = this.webgl2 ? DEVICETYPE_WEBGL2 : DEVICETYPE_WEBGL1;
 
         // pixel format of the framebuffer
         const alphaBits = gl.getParameter(gl.ALPHA_BITS);
@@ -412,12 +372,13 @@ class WebglGraphicsDevice extends GraphicsDevice {
 
         const isChrome = platform.browser && !!window.chrome;
         const isMac = platform.browser && navigator.appVersion.indexOf("Mac") !== -1;
+        const isSafari = platform.browser && !!window.safari;
 
         // enable temporary texture unit workaround on desktop safari
-        this._tempEnableSafariTextureUnitWorkaround = platform.browser && !!window.safari;
+        this._tempEnableSafariTextureUnitWorkaround = isSafari;
 
         // enable temporary workaround for glBlitFramebuffer failing on Mac Chrome (#2504)
-        this._tempMacChromeBlitFramebufferWorkaround = isMac && isChrome && !options.alpha;
+        this._tempMacChromeBlitFramebufferWorkaround = isMac && isChrome && !gl.alpha;
 
         // init polyfill for VAOs under webgl1
         if (!this.webgl2) {
@@ -432,13 +393,15 @@ class WebglGraphicsDevice extends GraphicsDevice {
         this.initializeRenderState();
         this.initializeContextCaches();
 
-        // start async image bitmap test
-        this.supportsImageBitmap = null;
-        if (typeof ImageBitmap !== 'undefined') {
-            testImageBitmap(this).then((result) => {
-                this.supportsImageBitmap = result;
-            });
-        }
+        // only enable ImageBitmap on chrome
+        this.supportsImageBitmap = isChrome;
+
+        // run image test
+        Debug.call(() => {
+            if (Tracing.get('RUN_IMAGE_ALPHA_TEST')) {
+                WebglImageTest.run(this);
+            }
+        });
 
         this.glAddress = [
             gl.REPEAT,

--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -396,9 +396,9 @@ class WebglGraphicsDevice extends GraphicsDevice {
         // only enable ImageBitmap on chrome
         this.supportsImageBitmap = isChrome;
 
-        // run image test
+        // run image alpha test
         Debug.call(() => {
-            if (Tracing.get('RUN_IMAGE_ALPHA_TEST')) {
+            if (Tracing.get('IMAGE_ALPHA_TEST')) {
                 WebglImageTest.run(this);
             }
         });

--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -371,8 +371,8 @@ class WebglGraphicsDevice extends GraphicsDevice {
         this.framebufferFormat = alphaBits ? PIXELFORMAT_RGBA8 : PIXELFORMAT_RGB8;
 
         const isChrome = platform.browser && !!window.chrome;
-        const isMac = platform.browser && navigator.appVersion.indexOf("Mac") !== -1;
         const isSafari = platform.browser && !!window.safari;
+        const isMac = platform.browser && navigator.appVersion.indexOf("Mac") !== -1;
 
         // enable temporary texture unit workaround on desktop safari
         this._tempEnableSafariTextureUnitWorkaround = isSafari;

--- a/src/platform/graphics/webgl/wegbl-image-test.js
+++ b/src/platform/graphics/webgl/wegbl-image-test.js
@@ -1,0 +1,83 @@
+import { Texture } from '../texture.js';
+import { PIXELFORMAT_RGBA8 } from '../constants.js';
+import { RenderTarget } from '../render-target.js';
+
+// ImageBitmap current state (April 2023):
+// Chrome MacOS and Android (Pixel 3a and Pixel 7 Pro):
+//   Correctly loads PNG alpha and runs faster (significantly so on mobile) than HTMLImageElement.
+// Firefox on MacOS:
+//   Correctly loads PNG alpha, but runs significantly slower than HTMLImageElement.
+// Safari on MacOS and iOS (iPhone 8 and iPhone 13 Pro Max):
+//   Incorrectly loads PNG alpha and runs significantly slower than HTMLImageElement.
+
+// 1x1 png image containing rgba(1, 2, 3, 63)
+const pngBytes = new Uint8Array([
+    137, 80, 78, 71, 13, 10, 26, 10, 0, 0, 0, 13, 73, 72, 68, 82, 0, 0, 0, 1, 0, 0, 0, 1, 8, 6, 0, 0, 0, 31, 21,
+    196, 137, 0, 0, 0, 13, 73, 68, 65, 84, 120, 218, 99, 100, 100, 98, 182, 7, 0, 0, 89, 0, 71, 67, 133, 148, 237,
+    0, 0, 0, 0, 73, 69, 78, 68, 174, 66, 96, 130
+]);
+
+const testAlpha = (device, image) => {
+    // create the texture
+    const texture = new Texture(device, {
+        width: 1,
+        height: 1,
+        format: PIXELFORMAT_RGBA8,
+        mipmaps: false,
+        levels: [image]
+    });
+
+    // read pixels
+    const rt = new RenderTarget({ colorBuffer: texture, depth: false });
+    device.setFramebuffer(rt.impl._glFrameBuffer);
+    device.initRenderTarget(rt);
+
+    const data = new Uint8ClampedArray(4);
+    device.gl.readPixels(0, 0, 1, 1, device.gl.RGBA, device.gl.UNSIGNED_BYTE, data);
+
+    rt.destroy();
+    texture.destroy();
+
+    return data[0] === 1 && data[1] === 2 && data[2] === 3 && data[3] === 63;
+}
+
+// Test whether ImageBitmap correctly loads PNG alpha data.
+const testImageBitmapAlpha = (device) => {
+    return createImageBitmap(new Blob([pngBytes], {
+        type: 'image/png'
+    }), {
+        premultiplyAlpha: 'none',
+        colorSpaceConversion: 'none'
+    })
+        .then((image) => {
+            return testAlpha(device, image);
+        })
+        .catch(e => false);
+}
+
+// Test whether image element correctly loads PNG alpha data.
+const testImgElementAlpha = (device) => {
+    return new Promise((resolve, reject) => {
+        const image = new Image();
+        image.src = URL.createObjectURL(new Blob([pngBytes]));
+        image.onload = () => {
+            resolve(testAlpha(device, image));
+        };
+    });
+}
+
+class WebglImageTest {
+    static run(device) {
+        testImageBitmapAlpha(device).then((result) => {
+            console.log(`imageBitmapIsCorrect=${result}`);
+        });
+
+        testImgElementAlpha(device).then((result) => {
+            console.log(`imgElementIsCorrect=${result}`);
+        });
+    }
+}
+
+export {
+    WebglImageTest
+};

--- a/src/platform/graphics/webgl/wegbl-image-test.js
+++ b/src/platform/graphics/webgl/wegbl-image-test.js
@@ -2,13 +2,18 @@ import { Texture } from '../texture.js';
 import { PIXELFORMAT_RGBA8 } from '../constants.js';
 import { RenderTarget } from '../render-target.js';
 
-// ImageBitmap current state (April 2023):
+//
+// Current state of ImageBitmap (April 2023):
+//
 // Chrome MacOS and Android (Pixel 3a and Pixel 7 Pro):
 //   Correctly loads PNG alpha and runs faster (significantly so on mobile) than HTMLImageElement.
-// Firefox on MacOS:
+//
+// Firefox MacOS:
 //   Correctly loads PNG alpha, but runs significantly slower than HTMLImageElement.
-// Safari on MacOS and iOS (iPhone 8 and iPhone 13 Pro Max):
+//
+// Safari MacOS and iOS (iPhone 8 and iPhone 13 Pro Max):
 //   Incorrectly loads PNG alpha and runs significantly slower than HTMLImageElement.
+//
 
 // 1x1 png image containing rgba(1, 2, 3, 63)
 const pngBytes = new Uint8Array([


### PR DESCRIPTION
ImageBitmap only loads images faster than HTMLImageElement on Chrome.

Instead of performing an async canvas test for ImageBitmap at startup, we instead simply limit it to Chrome. The async startup test was returning too slowly in some applications and so wasn't reliable anyway.

For future testing, the alpha test functionality has been kept, though moved out of the graphics device. The test can be performed at startup in debug build by enabling the trace `IMG_ALPHA_TEST`.