### PR TITLE
sound currentTime needs to be called before state change

### DIFF
--- a/src/platform/sound/instance.js
+++ b/src/platform/sound/instance.js
@@ -712,6 +712,9 @@ class SoundInstance extends EventHandler {
             return false;
         }
 
+        // start at point where sound was paused
+        let offset = this.currentTime;
+
         // set state back to playing
         this._state = STATE_PLAYING;
 
@@ -723,9 +726,6 @@ class SoundInstance extends EventHandler {
         if (!this.source) {
             this._createSource();
         }
-
-        // start at point where sound was paused
-        let offset = this.currentTime;
 
         // if the user set the 'currentTime' property while the sound
         // was paused then use that as the offset instead


### PR DESCRIPTION
currentTime getter checks if the state is paused. If it isn't, then it updates the _currentTme based on real time since the sound was started

See https://github.com/playcanvas/engine/blob/main/src/platform/sound/instance.js#L313

Fixes #5240 

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
