### PR TITLE
StencilParameters support on WebGPU

### DIFF
--- a/examples/src/examples/graphics/portal.tsx
+++ b/examples/src/examples/graphics/portal.tsx
@@ -5,190 +5,218 @@ class PortalExample {
     static NAME = 'Portal';
     static WEBGPU_ENABLED = true;
 
-
     example(canvas: HTMLCanvasElement, deviceType: string): void {
 
-        // Create the application and start the update loop
-        const app = new pc.Application(canvas, {
-            keyboard: new pc.Keyboard(window)
-        });
-
         const assets = {
-            'helipad.dds': new pc.Asset('helipad.dds', 'cubemap', { url: '/static/assets/cubemaps/helipad.dds' }, { type: pc.TEXTURETYPE_RGBM }),
+            'helipad': new pc.Asset('helipad-env-atlas', 'texture', { url: '/static/assets/cubemaps/helipad-env-atlas.png' }, { type: pc.TEXTURETYPE_RGBP }),
             'portal': new pc.Asset('portal', 'container', { url: '/static/assets/models/portal.glb' }),
             'statue': new pc.Asset('statue', 'container', { url: '/static/assets/models/statue.glb' }),
             'bitmoji': new pc.Asset('bitmoji', 'container', { url: '/static/assets/models/bitmoji.glb' })
         };
 
-        const assetListLoader = new pc.AssetListLoader(Object.values(assets), app.assets);
-        assetListLoader.load(() => {
+        const gfxOptions = {
+            deviceTypes: [deviceType],
+            glslangUrl: '/static/lib/glslang/glslang.js',
+            twgslUrl: '/static/lib/twgsl/twgsl.js'
+        };
+
+        pc.createGraphicsDevice(canvas, gfxOptions).then((device: pc.GraphicsDevice) => {
+
+            const createOptions = new pc.AppOptions();
+            createOptions.graphicsDevice = device;
+
+            createOptions.componentSystems = [
+                // @ts-ignore
+                pc.RenderComponentSystem,
+                // @ts-ignore
+                pc.CameraComponentSystem,
+                // @ts-ignore
+                pc.LightComponentSystem,
+                // @ts-ignore
+                pc.ScriptComponentSystem
+            ];
+            createOptions.resourceHandlers = [
+                // @ts-ignore
+                pc.TextureHandler,
+                // @ts-ignore
+                pc.ContainerHandler,
+                // @ts-ignore
+                pc.ScriptHandler
+            ];
+
+            const app = new pc.AppBase(canvas);
+            app.init(createOptions);
 
             // Set the canvas to fill the window and automatically change resolution to be the same as the canvas size
             app.setCanvasFillMode(pc.FILLMODE_FILL_WINDOW);
             app.setCanvasResolution(pc.RESOLUTION_AUTO);
 
-            app.start();
+            const assetListLoader = new pc.AssetListLoader(Object.values(assets), app.assets);
+            assetListLoader.load(() => {
 
-            // set skybox - this DDS file was 'prefiltered' in the PlayCanvas Editor and then downloaded.
-            app.scene.setSkybox(assets["helipad.dds"].resources);
-            app.scene.toneMapping = pc.TONEMAP_ACES;
-            app.scene.skyboxMip = 1;
-            app.scene.skyboxIntensity = 0.7;
+                app.start();
 
-            ////////////////////////////////
-            // Script to rotate the scene //
-            ////////////////////////////////
-            const Rotator = pc.createScript('rotator');
+                // set skybox - this DDS file was 'prefiltered' in the PlayCanvas Editor and then downloaded.
+                app.scene.envAtlas = assets.helipad.resource;
+                app.scene.toneMapping = pc.TONEMAP_ACES;
+                app.scene.skyboxMip = 1;
+                app.scene.skyboxIntensity = 0.7;
 
-            let t = 0;
+                ////////////////////////////////
+                // Script to rotate the scene //
+                ////////////////////////////////
+                const Rotator = pc.createScript('rotator');
 
-            Rotator.prototype.update = function (dt: number) {
-                t += dt;
-                this.entity.setEulerAngles(0, Math.sin(t) * 40, 0);
-            };
+                let t = 0;
 
-            //////////////////////////////////////////////////
-            // Script to set up rendering the portal itself //
-            //////////////////////////////////////////////////
-            const Portal = pc.createScript('portal');
+                Rotator.prototype.update = function (dt: number) {
+                    t += dt;
+                    this.entity.setEulerAngles(0, Math.sin(t) * 40, 0);
+                };
 
-            // initialize code called once per entity
-            Portal.prototype.initialize = function () {
+                //////////////////////////////////////////////////
+                // Script to set up rendering the portal itself //
+                //////////////////////////////////////////////////
+                const Portal = pc.createScript('portal');
 
-                // increment value in stencil (from 0 to 1) for stencil geometry
-                const stencil = new pc.StencilParameters({
-                    zpass: pc.STENCILOP_INCREMENT
+                // initialize code called once per entity
+                Portal.prototype.initialize = function () {
+
+                    // increment value in stencil (from 0 to 1) for stencil geometry
+                    const stencil = new pc.StencilParameters({
+                        zpass: pc.STENCILOP_INCREMENT
+                    });
+
+                    // set the stencil and other parameters on all materials
+                    const renders: Array<pc.RenderComponent> = this.entity.findComponents("render");
+                    renders.forEach((render) => {
+                        for (const meshInstance of render.meshInstances) {
+                            const mat = meshInstance.material;
+                            mat.stencilBack = mat.stencilFront = stencil;
+
+                            // We only want to write to the stencil buffer
+                            mat.depthWrite = false;
+                            mat.redWrite = mat.greenWrite = mat.blueWrite = mat.alphaWrite = false;
+                            mat.update();
+                        }
+                    });
+                };
+
+                /////////////////////////////////////////////////////////////////////////////
+                // Script to set stencil options for entities inside or outside the portal //
+                /////////////////////////////////////////////////////////////////////////////
+
+                const PortalGeometry = pc.createScript('portalGeometry');
+
+                PortalGeometry.attributes.add('inside', {
+                    type: 'boolean',
+                    default: true,
+                    title: 'True indicating the geometry is inside the portal, false for outside'
                 });
 
-                // set the stencil and other parameters on all materials
-                const renders: Array<pc.RenderComponent> = this.entity.findComponents("render");
-                renders.forEach((render) => {
-                    for (const meshInstance of render.meshInstances) {
-                        const mat = meshInstance.material;
-                        mat.stencilBack = mat.stencilFront = stencil;
+                PortalGeometry.prototype.initialize = function () {
 
-                        // We only want to write to the stencil buffer
-                        mat.depthWrite = false;
-                        mat.redWrite = mat.greenWrite = mat.blueWrite = mat.alphaWrite = false;
-                        mat.update();
+                    // based on value in the stencil buffer (0 outside, 1 inside), either render
+                    // the geometry when the value is equal, or not equal to zero.
+                    const stencil = new pc.StencilParameters({
+                        func: this.inside ? pc.FUNC_NOTEQUAL : pc.FUNC_EQUAL,
+                        ref: 0
+                    });
+
+                    // set the stencil parameters on all materials
+                    const renders: Array<pc.RenderComponent> = this.entity.findComponents("render");
+                    renders.forEach((render) => {
+                        for (const meshInstance of render.meshInstances) {
+                            meshInstance.material.stencilBack = meshInstance.material.stencilFront = stencil;
+                        }
+                    });
+                };
+
+                /////////////////////////////////////////////////////////////////////////////
+
+                // find world layer - majority of objects render to this layer
+                const worldLayer = app.scene.layers.getLayerByName("World");
+
+                // find skybox layer - to enable it for the camera
+                const skyboxLayer = app.scene.layers.getLayerByName("Skybox");
+
+                // portal layer - this is where the portal geometry is written to the stencil
+                // buffer, and this needs to render first, so insert it before the world layer
+                const portalLayer = new pc.Layer({ name: "Portal" });
+                app.scene.layers.insert(portalLayer, 0);
+
+                // Create an Entity with a camera component
+                // this camera renders both world and portal layers
+                const camera = new pc.Entity();
+                camera.addComponent('camera', {
+                    layers: [worldLayer.id, portalLayer.id, skyboxLayer.id]
+                });
+                camera.setLocalPosition(7, 5.5, 7.1);
+                camera.setLocalEulerAngles(-27, 45, 0);
+                app.root.addChild(camera);
+
+                // Create an Entity with a directional light component
+                const light = new pc.Entity();
+                light.addComponent('light', {
+                    type: 'directional',
+                    color: new pc.Color(1, 1, 1)
+                });
+                light.setEulerAngles(45, 35, 0);
+                app.root.addChild(light);
+
+                // Create a root for the graphical scene
+                const group = new pc.Entity();
+                group.addComponent('script');
+                group.script.create('rotator');
+                app.root.addChild(group);
+
+                // Create the portal entity - this plane is written to stencil buffer,
+                // which is then used to test for inside / outside. This needs to render
+                // before all elements requiring stencil buffer, so add to to a portalLayer.
+                // This is the plane that fills the inside of the portal geometry.
+                const portal = new pc.Entity("Portal");
+                portal.addComponent('render', {
+                    type: 'plane',
+                    material: new pc.StandardMaterial(),
+                    layers: [portalLayer.id]
+                });
+                portal.addComponent('script');
+                portal.script.create('portal'); // comment out this line to see the geometry
+                portal.setLocalPosition(0, 0.4, -0.3);
+                portal.setLocalEulerAngles(90, 0, 0);
+                portal.setLocalScale(3.7, 1, 6.7);
+                group.addChild(portal);
+
+                // Create the portal visual geometry
+                const portalEntity = assets.portal.resource.instantiateRenderEntity();
+                portalEntity.setLocalPosition(0, -3, 0);
+                portalEntity.setLocalScale(0.02, 0.02, 0.02);
+                group.addChild(portalEntity);
+
+                // Create a statue entity, whic is visible inside the portal only
+                const statue = assets.statue.resource.instantiateRenderEntity();
+                statue.addComponent('script');
+                statue.script.create('portalGeometry', {
+                    attributes: {
+                        inside: true
                     }
                 });
-            };
+                statue.setLocalPosition(0, -1, -2);
+                statue.setLocalScale(0.25, 0.25, 0.25);
+                group.addChild(statue);
 
-            /////////////////////////////////////////////////////////////////////////////
-            // Script to set stencil options for entities inside or outside the portal //
-            /////////////////////////////////////////////////////////////////////////////
-
-            const PortalGeometry = pc.createScript('portalGeometry');
-
-            PortalGeometry.attributes.add('inside', {
-                type: 'boolean',
-                default: true,
-                title: 'True indicating the geometry is inside the portal, false for outside'
-            });
-
-            PortalGeometry.prototype.initialize = function () {
-
-                // based on value in the stencil buffer (0 outside, 1 inside), either render
-                // the geometry when the value is equal, or not equal to zero.
-                const stencil = new pc.StencilParameters({
-                    func: this.inside ? pc.FUNC_NOTEQUAL : pc.FUNC_EQUAL,
-                    ref: 0
-                });
-
-                // set the stencil parameters on all materials
-                const renders: Array<pc.RenderComponent> = this.entity.findComponents("render");
-                renders.forEach((render) => {
-                    for (const meshInstance of render.meshInstances) {
-                        meshInstance.material.stencilBack = meshInstance.material.stencilFront = stencil;
+                // Create a bitmoji entity, whic is visible outside the portal only
+                const bitmoji = assets.bitmoji.resource.instantiateRenderEntity();
+                bitmoji.addComponent('script');
+                bitmoji.script.create('portalGeometry', {
+                    attributes: {
+                        inside: false
                     }
                 });
-            };
-
-            /////////////////////////////////////////////////////////////////////////////
-
-            // find world layer - majority of objects render to this layer
-            const worldLayer = app.scene.layers.getLayerByName("World");
-
-            // find skybox layer - to enable it for the camera
-            const skyboxLayer = app.scene.layers.getLayerByName("Skybox");
-
-            // portal layer - this is where the portal geometry is written to the stencil
-            // buffer, and this needs to render first, so insert it before the world layer
-            const portalLayer = new pc.Layer({ name: "Portal" });
-            app.scene.layers.insert(portalLayer, 0);
-
-            // Create an Entity with a camera component
-            // this camera renders both world and portal layers
-            const camera = new pc.Entity();
-            camera.addComponent('camera', {
-                layers: [worldLayer.id, portalLayer.id, skyboxLayer.id]
+                bitmoji.setLocalPosition(0, -1, -2);
+                bitmoji.setLocalScale(2.5, 2.5, 2.5);
+                group.addChild(bitmoji);
             });
-            camera.setLocalPosition(7, 5.5, 7.1);
-            camera.setLocalEulerAngles(-27, 45, 0);
-            app.root.addChild(camera);
-
-            // Create an Entity with a directional light component
-            const light = new pc.Entity();
-            light.addComponent('light', {
-                type: 'directional',
-                color: new pc.Color(1, 1, 1)
-            });
-            light.setEulerAngles(45, 35, 0);
-            app.root.addChild(light);
-
-            // Create a root for the graphical scene
-            const group = new pc.Entity();
-            group.addComponent('script');
-            group.script.create('rotator');
-            app.root.addChild(group);
-
-            // Create the portal entity - this plane is written to stencil buffer,
-            // which is then used to test for inside / outside. This needs to render
-            // before all elements requiring stencil buffer, so add to to a portalLayer.
-            // This is the plane that fills the inside of the portal geometry.
-            const portal = new pc.Entity("Portal");
-            portal.addComponent('render', {
-                type: 'plane',
-                material: new pc.StandardMaterial(),
-                layers: [portalLayer.id]
-            });
-            portal.addComponent('script');
-            portal.script.create('portal'); // comment out this line to see the geometry
-            portal.setLocalPosition(0, 0.4, -0.3);
-            portal.setLocalEulerAngles(90, 0, 0);
-            portal.setLocalScale(3.7, 1, 6.7);
-            group.addChild(portal);
-
-            // Create the portal visual geometry
-            const portalEntity = assets.portal.resource.instantiateRenderEntity();
-            portalEntity.setLocalPosition(0, -3, 0);
-            portalEntity.setLocalScale(0.02, 0.02, 0.02);
-            group.addChild(portalEntity);
-
-            // Create a statue entity, whic is visible inside the portal only
-            const statue = assets.statue.resource.instantiateRenderEntity();
-            statue.addComponent('script');
-            statue.script.create('portalGeometry', {
-                attributes: {
-                    inside: true
-                }
-            });
-            statue.setLocalPosition(0, -1, -2);
-            statue.setLocalScale(0.25, 0.25, 0.25);
-            group.addChild(statue);
-
-            // Create a bitmoji entity, whic is visible outside the portal only
-            const bitmoji = assets.bitmoji.resource.instantiateRenderEntity();
-            bitmoji.addComponent('script');
-            bitmoji.script.create('portalGeometry', {
-                attributes: {
-                    inside: false
-                }
-            });
-            bitmoji.setLocalPosition(0, -1, -2);
-            bitmoji.setLocalScale(2.5, 2.5, 2.5);
-            group.addChild(bitmoji);
         });
     }
 }

--- a/examples/src/examples/graphics/portal.tsx
+++ b/examples/src/examples/graphics/portal.tsx
@@ -3,6 +3,7 @@ import * as pc from '../../../../';
 class PortalExample {
     static CATEGORY = 'Graphics';
     static NAME = 'Portal';
+    static WEBGPU_ENABLED = true;
 
 
     example(canvas: HTMLCanvasElement, deviceType: string): void {

--- a/examples/src/examples/user-interface/scroll-view.tsx
+++ b/examples/src/examples/user-interface/scroll-view.tsx
@@ -3,6 +3,7 @@ import * as pc from '../../../../';
 class ScrollViewExample {
     static CATEGORY = 'User Interface';
     static NAME = 'Scroll View';
+    static WEBGPU_ENABLED = true;
 
     example(canvas: HTMLCanvasElement, deviceType: string): void {
 

--- a/extras/mini-stats/render2d.js
+++ b/extras/mini-stats/render2d.js
@@ -179,6 +179,7 @@ class Render2d {
         device.setCullMode(CULLFACE_NONE);
         device.setBlendState(this.blendState);
         device.setDepthState(DepthState.NODEPTH);
+        device.setStencilState(null, null);
 
         device.setVertexBuffer(buffer, 0);
         device.setIndexBuffer(this.indexBuffer);

--- a/src/framework/components/element/component.js
+++ b/src/framework/components/element/component.js
@@ -9,7 +9,7 @@ import { FUNC_ALWAYS, FUNC_EQUAL, STENCILOP_INCREMENT, STENCILOP_REPLACE } from 
 
 import { LAYERID_UI } from '../../../scene/constants.js';
 import { BatchGroup } from '../../../scene/batching/batch-group.js';
-import { StencilParameters } from '../../../scene/stencil-parameters.js';
+import { StencilParameters } from '../../../platform/graphics/stencil-parameters.js';
 
 import { Entity } from '../../entity.js';
 
@@ -1304,15 +1304,11 @@ class ElementComponent extends Component {
             if (_debugLogging) console.log('masking: ' + this.entity.name + ' with ' + ref);
             // #endif
 
-            const sp = new StencilParameters({
+            // if this is image or text, set the stencil parameters
+            renderableElement?._setStencil(new StencilParameters({
                 ref: ref,
                 func: FUNC_EQUAL
-            });
-
-            // if this is image or text, set the stencil parameters
-            if (renderableElement && renderableElement._setStencil) {
-                renderableElement._setStencil(sp);
-            }
+            }));
 
             this._maskedBy = mask;
         } else {

--- a/src/framework/components/element/component.js
+++ b/src/framework/components/element/component.js
@@ -1317,9 +1317,8 @@ class ElementComponent extends Component {
             // #endif
 
             // remove stencil params if this is image or text
-            if (renderableElement && renderableElement._setStencil) {
-                renderableElement._setStencil(null);
-            }
+            renderableElement?._setStencil(null);
+
             this._maskedBy = null;
         }
     }
@@ -1357,9 +1356,7 @@ class ElementComponent extends Component {
             // recurse through all children
             const children = this.entity.children;
             for (let i = 0, l = children.length; i < l; i++) {
-                if (children[i].element) {
-                    children[i].element._updateMask(currentMask, depth);
-                }
+                children[i].element?._updateMask(currentMask, depth);
             }
 
             // if mask counter was increased, decrement it as we come back up the hierarchy
@@ -1394,9 +1391,7 @@ class ElementComponent extends Component {
             // recurse through all children
             const children = this.entity.children;
             for (let i = 0, l = children.length; i < l; i++) {
-                if (children[i].element) {
-                    children[i].element._updateMask(currentMask, depth);
-                }
+                children[i].element?._updateMask(currentMask, depth);
             }
 
             // decrement mask counter as we come back up the hierarchy

--- a/src/framework/components/element/image-element.js
+++ b/src/framework/components/element/image-element.js
@@ -26,7 +26,7 @@ import { GraphNode } from '../../../scene/graph-node.js';
 import { Mesh } from '../../../scene/mesh.js';
 import { MeshInstance } from '../../../scene/mesh-instance.js';
 import { Model } from '../../../scene/model.js';
-import { StencilParameters } from '../../../scene/stencil-parameters.js';
+import { StencilParameters } from '../../../platform/graphics/stencil-parameters.js';
 
 import { FITMODE_STRETCH, FITMODE_CONTAIN, FITMODE_COVER } from './constants.js';
 

--- a/src/framework/lightmapper/lightmapper.js
+++ b/src/framework/lightmapper/lightmapper.js
@@ -881,6 +881,7 @@ class Lightmapper {
 
         device.setBlendState(BlendState.DEFAULT);
         device.setDepthState(DepthState.NODEPTH);
+        device.setStencilState(null, null);
 
         for (let node = 0; node < bakeNodes.length; node++) {
             const bakeNode = bakeNodes[node];

--- a/src/index.js
+++ b/src/index.js
@@ -130,7 +130,7 @@ export { SkinInstance } from './scene/skin-instance.js';
 export { Sprite } from './scene/sprite.js';
 export { StandardMaterial } from './scene/materials/standard-material.js';
 export { StandardMaterialOptions } from './scene/materials/standard-material-options.js';
-export { StencilParameters } from './scene/stencil-parameters.js';
+export { StencilParameters } from './platform/graphics/stencil-parameters.js';
 export { TextureAtlas } from './scene/texture-atlas.js';
 
 // SCENE / ANIMATION

--- a/src/platform/graphics/constants.js
+++ b/src/platform/graphics/constants.js
@@ -907,7 +907,7 @@ export const STENCILOP_KEEP = 0;
 export const STENCILOP_ZERO = 1;
 
 /**
- * Replace value with the reference value (see {@link GraphicsDevice#setStencilFunc}).
+ * Replace value with the reference value (see {@link StencilParameters}).
  *
  * @type {number}
  */

--- a/src/platform/graphics/graphics-device-create.js
+++ b/src/platform/graphics/graphics-device-create.js
@@ -16,6 +16,10 @@ import { WebglGraphicsDevice } from './webgl/webgl-graphics-device.js';
  * {@link DEVICETYPE_WEBGPU}, or leave it empty.
  * @param {boolean} [options.antialias] - Boolean that indicates whether or not to perform
  * anti-aliasing if possible. Defaults to true.
+ * @param {boolean} [options.depth=true] - Boolean that indicates that the drawing buffer is
+ * requested to have a depth buffer of at least 16 bits.
+ * @param {boolean} [options.stencil=true] - Boolean that indicates that the drawing buffer is
+ * requested to have a stencil buffer of at least 8 bits.
  * @param {string} [options.glslangUrl] - An url to glslang script, required if
  * {@link DEVICETYPE_WEBGPU} type is added to deviceTypes array. Not used for
  * {@link DEVICETYPE_WEBGL} device type creation.
@@ -23,9 +27,6 @@ import { WebglGraphicsDevice } from './webgl/webgl-graphics-device.js';
  * @returns {Promise} - Promise object representing the created graphics device.
  */
 function createGraphicsDevice(canvas, options = {}) {
-
-    // defaults
-    options.antialias ??= true;
 
     const deviceTypes = options.deviceTypes ?? [];
 

--- a/src/platform/graphics/graphics-device.js
+++ b/src/platform/graphics/graphics-device.js
@@ -209,10 +209,17 @@ class GraphicsDevice extends EventHandler {
 
     static EVENT_RESIZE = 'resizecanvas';
 
-    constructor(canvas) {
+    constructor(canvas, options) {
         super();
 
         this.canvas = canvas;
+
+        // copy options and handle defaults
+        this.initOptions = { ...options };
+        this.initOptions.depth ??= true;
+        this.initOptions.stencil ??= true;
+        this.initOptions.antialias ??= true;
+        this.initOptions.powerPreference ??= 'high-performance';
 
         // local width/height without pixelRatio applied
         this._width = 0;

--- a/src/platform/graphics/graphics-device.js
+++ b/src/platform/graphics/graphics-device.js
@@ -14,6 +14,7 @@ import { DepthState } from './depth-state.js';
 import { ScopeSpace } from './scope-space.js';
 import { VertexBuffer } from './vertex-buffer.js';
 import { VertexFormat } from './vertex-format.js';
+import { StencilParameters } from './stencil-parameters.js';
 
 /**
  * The graphics device manages the underlying graphics context. It is responsible for submitting
@@ -177,6 +178,27 @@ class GraphicsDevice extends EventHandler {
      * @ignore
      */
     depthState = new DepthState();
+
+    /**
+     * True if stencil is enabled and stencilFront and stencilBack are used
+     *
+     * @ignore
+     */
+    stencilEnabled = false;
+
+    /**
+     * The current front stencil parameters.
+     *
+     * @ignore
+     */
+    stencilFront = new StencilParameters();
+
+    /**
+     * The current back stencil parameters.
+     *
+     * @ignore
+     */
+    stencilBack = new StencilParameters();
 
     defaultClearOptions = {
         color: [0, 0, 0, 1],

--- a/src/platform/graphics/graphics-device.js
+++ b/src/platform/graphics/graphics-device.js
@@ -352,6 +352,19 @@ class GraphicsDevice extends EventHandler {
     }
 
     /**
+     * Sets the specified stencil state. If both stencilFront and stencilBack are null, stencil
+     * operation is disabled.
+     *
+     * @param {StencilParameters} [stencilFront] - The front stencil parameters. Defaults to
+     * {@link StencilParameters#DEFAULT} if not specified.
+     * @param {StencilParameters} [stencilBack] - The back stencil parameters. Defaults to
+     * {@link StencilParameters#DEFAULT} if not specified.
+     */
+    setStencilState(stencilFront, stencilBack) {
+        Debug.assert(false);
+    }
+
+    /**
      * Sets the specified blend state.
      *
      * @param {BlendState} blendState - New blend state.

--- a/src/platform/graphics/stencil-parameters.js
+++ b/src/platform/graphics/stencil-parameters.js
@@ -69,6 +69,10 @@ class StencilParameters {
         this.zpass = options.zpass ?? STENCILOP_KEEP;
     }
 
+    // TODO: we could store the key as a property and only update it when the parameters change,
+    // by using a dirty flag. But considering stencil is used rarely, this can be done at a later
+    // stage. This function is only called when the stencil state is enabled. We could also use
+    // BitField to store the parameters and to speed up the key generation.
     get key() {
         const { func, ref, fail, zfail, zpass, readMask, writeMask } = this;
         return `${func},${ref},${fail},${zfail},${zpass},${readMask},${writeMask}`;

--- a/src/platform/graphics/stencil-parameters.js
+++ b/src/platform/graphics/stencil-parameters.js
@@ -1,4 +1,4 @@
-import { FUNC_ALWAYS, STENCILOP_KEEP } from '../platform/graphics/constants.js';
+import { FUNC_ALWAYS, STENCILOP_KEEP } from './constants.js';
 
 /**
  * Holds stencil test settings.
@@ -56,9 +56,9 @@ class StencilParameters {
     /**
      * Create a new StencilParameters instance.
      *
-     * @param {object} options - Options object to configure the stencil parameters.
+     * @param {object} [options] - Options object to configure the stencil parameters.
      */
-    constructor(options) {
+    constructor(options = {}) {
         this.func = options.func ?? FUNC_ALWAYS;
         this.ref = options.ref ?? 0;
         this.readMask = options.readMask ?? 0xFF;
@@ -69,22 +69,45 @@ class StencilParameters {
         this.zpass = options.zpass ?? STENCILOP_KEEP;
     }
 
+    get key() {
+        const { func, ref, fail, zfail, zpass, readMask, writeMask } = this;
+        return `${func},${ref},${fail},${zfail},${zpass},${readMask},${writeMask}`;
+    }
+
+    /**
+     * Copies the contents of a source stencil parameters to this stencil parameters.
+     *
+     * @param {StencilParameters} rhs - A stencil parameters to copy from.
+     * @returns {StencilParameters} Self for chaining.
+     */
+    copy(rhs) {
+        this.func = rhs.func;
+        this.ref = rhs.ref;
+        this.readMask = rhs.readMask;
+        this.writeMask = rhs.writeMask;
+        this.fail = rhs.fail;
+        this.zfail = rhs.zfail;
+        this.zpass = rhs.zpass;
+        return this;
+    }
+
     /**
      * Clone the stencil parameters.
      *
      * @returns {StencilParameters} A cloned StencilParameters object.
      */
     clone() {
-        return new StencilParameters({
-            func: this.func,
-            ref: this.ref,
-            readMask: this.readMask,
-            writeMask: this.writeMask,
-            fail: this.fail,
-            zfail: this.zfail,
-            zpass: this.zpass
-        });
+        const clone = new this.constructor();
+        return clone.copy(this);
     }
+
+    /**
+     * A default stencil state.
+     *
+     * @type {StencilParameters}
+     * @readonly
+     */
+    static DEFAULT = Object.freeze(new StencilParameters());
 }
 
 export { StencilParameters };

--- a/src/platform/graphics/stencil-parameters.js
+++ b/src/platform/graphics/stencil-parameters.js
@@ -5,49 +5,71 @@ import { FUNC_ALWAYS, STENCILOP_KEEP } from './constants.js';
  */
 class StencilParameters {
     /**
-     * Sets stencil test function. See {@link GraphicsDevice#setStencilFunc}.
+     * A comparison function that decides if the pixel should be written, based on the current
+     * stencil buffer value, reference value, and mask value. Can be:
+     *
+     * - {@link FUNC_NEVER}: never pass
+     * - {@link FUNC_LESS}: pass if (ref & mask) < (stencil & mask)
+     * - {@link FUNC_EQUAL}: pass if (ref & mask) == (stencil & mask)
+     * - {@link FUNC_LESSEQUAL}: pass if (ref & mask) <= (stencil & mask)
+     * - {@link FUNC_GREATER}: pass if (ref & mask) > (stencil & mask)
+     * - {@link FUNC_NOTEQUAL}: pass if (ref & mask) != (stencil & mask)
+     * - {@link FUNC_GREATEREQUAL}: pass if (ref & mask) >= (stencil & mask)
+     * - {@link FUNC_ALWAYS}: always pass
      *
      * @type {number}
      */
     func;
 
     /**
-     * Sets stencil test reference value. See {@link GraphicsDevice#setStencilFunc}.
+     * Sets stencil test reference value used in comparisons.
      *
      * @type {number}
      */
     ref;
 
     /**
-     * Sets operation to perform if stencil test is failed. See {@link GraphicsDevice#setStencilOperation}.
+     * Operation to perform if stencil test is failed. Can be:
+     *
+     * - {@link STENCILOP_KEEP}: don't change the stencil buffer value
+     * - {@link STENCILOP_ZERO}: set value to zero
+     * - {@link STENCILOP_REPLACE}: replace value with the reference value.
+     * - {@link STENCILOP_INCREMENT}: increment the value
+     * - {@link STENCILOP_INCREMENTWRAP}: increment the value, but wrap it to zero when it's larger
+     * than a maximum representable value
+     * - {@link STENCILOP_DECREMENT}: decrement the value
+     * - {@link STENCILOP_DECREMENTWRAP}: decrement the value, but wrap it to a maximum
+     * representable value, if the current value is 0
+     * - {@link STENCILOP_INVERT}: invert the value bitwise
      *
      * @type {number}
      */
     fail;
 
     /**
-     * Sets operation to perform if depth test is failed. See {@link GraphicsDevice#setStencilOperation}.
+     * Operation to perform if depth test is failed. Accepts the same values as `fail`.
      *
      * @type {number}
      */
     zfail;
 
     /**
-     * Sets operation to perform if both stencil and depth test are passed. See {@link GraphicsDevice#setStencilOperation}.
+     * Operation to perform if both stencil and depth test are passed. Accepts the same values as
+     * `fail`.
      *
      * @type {number}
      */
     zpass;
 
     /**
-     * Sets stencil test reading mask. See {@link GraphicsDevice#setStencilFunc}.
+     * Mask applied to stencil buffer value and reference value before comparison.
      *
      * @type {number}
      */
     readMask;
 
     /**
-     * Sets stencil test writing mask. See {@link GraphicsDevice#setStencilOperation}.
+     * A bit mask applied to the stencil value, when written.
      *
      * @type {number}
      */

--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -321,7 +321,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
      * alpha buffer.
      * @param {boolean} [options.depth=true] - Boolean that indicates that the drawing buffer is
      * requested to have a depth buffer of at least 16 bits.
-     * @param {boolean} [options.stencil=false] - Boolean that indicates that the drawing buffer is
+     * @param {boolean} [options.stencil=true] - Boolean that indicates that the drawing buffer is
      * requested to have a stencil buffer of at least 8 bits.
      * @param {boolean} [options.antialias=true] - Boolean that indicates whether or not to perform
      * anti-aliasing if possible.
@@ -349,7 +349,8 @@ class WebglGraphicsDevice extends GraphicsDevice {
      * compatible graphics adapter for an immersive XR device.
      */
     constructor(canvas, options = {}) {
-        super(canvas);
+        super(canvas, options);
+        options = this.initOptions;
 
         this.defaultFramebuffer = null;
 
@@ -372,12 +373,6 @@ class WebglGraphicsDevice extends GraphicsDevice {
             this.contextLost = false;
             this.fire('devicerestored');
         };
-
-        // options defaults
-        options.stencil = true;
-        if (!options.powerPreference) {
-            options.powerPreference = 'high-performance';
-        }
 
         // #4136 - turn off antialiasing on AppleWebKit browsers 15.4
         const ua = (typeof navigator !== 'undefined') && navigator.userAgent;

--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -37,6 +37,7 @@ import { ShaderUtils } from '../shader-utils.js';
 import { Shader } from '../shader.js';
 import { BlendState } from '../blend-state.js';
 import { DepthState } from '../depth-state.js';
+import { StencilParameters } from '../stencil-parameters.js';
 
 const invalidateAttachments = [];
 
@@ -2481,6 +2482,32 @@ class WebglGraphicsDevice extends GraphicsDevice {
         if ((r !== c.r) || (g !== c.g) || (b !== c.b) || (a !== c.a)) {
             this.gl.blendColor(r, g, b, a);
             c.set(r, g, b, a);
+        }
+    }
+
+    setStencilState(stencilFront, stencilBack) {
+        if (stencilFront || stencilBack) {
+            this.setStencilTest(true);
+            if (stencilFront === stencilBack) {
+
+                // identical front/back stencil
+                this.setStencilFunc(stencilFront.func, stencilFront.ref, stencilFront.readMask);
+                this.setStencilOperation(stencilFront.fail, stencilFront.zfail, stencilFront.zpass, stencilFront.writeMask);
+
+            } else {
+
+                // front
+                stencilFront ??= StencilParameters.DEFAULT;
+                this.setStencilFuncFront(stencilFront.func, stencilFront.ref, stencilFront.readMask);
+                this.setStencilOperationFront(stencilFront.fail, stencilFront.zfail, stencilFront.zpass, stencilFront.writeMask);
+
+                // back
+                stencilBack ??= StencilParameters.DEFAULT;
+                this.setStencilFuncBack(stencilBack.func, stencilBack.ref, stencilBack.readMask);
+                this.setStencilOperationBack(stencilBack.fail, stencilBack.zfail, stencilBack.zpass, stencilBack.writeMask);
+            }
+        } else {
+            this.setStencilTest(false);
         }
     }
 

--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -92,6 +92,7 @@ function quadWithShader(device, target, shader) {
     device.setCullMode(CULLFACE_NONE);
     device.setBlendState(BlendState.DEFAULT);
     device.setDepthState(DepthState.NODEPTH);
+    device.setStencilState(null, null);
 
     device.setVertexBuffer(device.quadVertexBuffer, 0);
     device.setShader(shader);

--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -2210,12 +2210,6 @@ class WebglGraphicsDevice extends GraphicsDevice {
         this.gl.polygonOffset(slopeBias, constBias);
     }
 
-    /**
-     * Enables or disables stencil test.
-     *
-     * @param {boolean} enable - True to enable stencil test and false to disable it.
-     * @ignore
-     */
     setStencilTest(enable) {
         if (this.stencil !== enable) {
             const gl = this.gl;
@@ -2228,56 +2222,16 @@ class WebglGraphicsDevice extends GraphicsDevice {
         }
     }
 
-    /**
-     * Configures stencil test for both front and back faces.
-     *
-     * @param {number} func - A comparison function that decides if the pixel should be written,
-     * based on the current stencil buffer value, reference value, and mask value. Can be:
-     *
-     * - {@link FUNC_NEVER}: never pass
-     * - {@link FUNC_LESS}: pass if (ref & mask) < (stencil & mask)
-     * - {@link FUNC_EQUAL}: pass if (ref & mask) == (stencil & mask)
-     * - {@link FUNC_LESSEQUAL}: pass if (ref & mask) <= (stencil & mask)
-     * - {@link FUNC_GREATER}: pass if (ref & mask) > (stencil & mask)
-     * - {@link FUNC_NOTEQUAL}: pass if (ref & mask) != (stencil & mask)
-     * - {@link FUNC_GREATEREQUAL}: pass if (ref & mask) >= (stencil & mask)
-     * - {@link FUNC_ALWAYS}: always pass
-     *
-     * @param {number} ref - Reference value used in comparison.
-     * @param {number} mask - Mask applied to stencil buffer value and reference value before
-     * comparison.
-     * @ignore
-     */
     setStencilFunc(func, ref, mask) {
         if (this.stencilFuncFront !== func || this.stencilRefFront !== ref || this.stencilMaskFront !== mask ||
             this.stencilFuncBack !== func || this.stencilRefBack !== ref || this.stencilMaskBack !== mask) {
-            const gl = this.gl;
-            gl.stencilFunc(this.glComparison[func], ref, mask);
+            this.gl.stencilFunc(this.glComparison[func], ref, mask);
             this.stencilFuncFront = this.stencilFuncBack = func;
             this.stencilRefFront = this.stencilRefBack = ref;
             this.stencilMaskFront = this.stencilMaskBack = mask;
         }
     }
 
-    /**
-     * Configures stencil test for front faces.
-     *
-     * @param {number} func - A comparison function that decides if the pixel should be written,
-     * based on the current stencil buffer value, reference value, and mask value. Can be:
-     *
-     * - {@link FUNC_NEVER}: never pass
-     * - {@link FUNC_LESS}: pass if (ref & mask) < (stencil & mask)
-     * - {@link FUNC_EQUAL}: pass if (ref & mask) == (stencil & mask)
-     * - {@link FUNC_LESSEQUAL}: pass if (ref & mask) <= (stencil & mask)
-     * - {@link FUNC_GREATER}: pass if (ref & mask) > (stencil & mask)
-     * - {@link FUNC_NOTEQUAL}: pass if (ref & mask) != (stencil & mask)
-     * - {@link FUNC_GREATEREQUAL}: pass if (ref & mask) >= (stencil & mask)
-     * - {@link FUNC_ALWAYS}: always pass
-     *
-     * @param {number} ref - Reference value used in comparison.
-     * @param {number} mask - Mask applied to stencil buffer value and reference value before comparison.
-     * @ignore
-     */
     setStencilFuncFront(func, ref, mask) {
         if (this.stencilFuncFront !== func || this.stencilRefFront !== ref || this.stencilMaskFront !== mask) {
             const gl = this.gl;
@@ -2288,25 +2242,6 @@ class WebglGraphicsDevice extends GraphicsDevice {
         }
     }
 
-    /**
-     * Configures stencil test for back faces.
-     *
-     * @param {number} func - A comparison function that decides if the pixel should be written,
-     * based on the current stencil buffer value, reference value, and mask value. Can be:
-     *
-     * - {@link FUNC_NEVER}: never pass
-     * - {@link FUNC_LESS}: pass if (ref & mask) < (stencil & mask)
-     * - {@link FUNC_EQUAL}: pass if (ref & mask) == (stencil & mask)
-     * - {@link FUNC_LESSEQUAL}: pass if (ref & mask) <= (stencil & mask)
-     * - {@link FUNC_GREATER}: pass if (ref & mask) > (stencil & mask)
-     * - {@link FUNC_NOTEQUAL}: pass if (ref & mask) != (stencil & mask)
-     * - {@link FUNC_GREATEREQUAL}: pass if (ref & mask) >= (stencil & mask)
-     * - {@link FUNC_ALWAYS}: always pass
-     *
-     * @param {number} ref - Reference value used in comparison.
-     * @param {number} mask - Mask applied to stencil buffer value and reference value before comparison.
-     * @ignore
-     */
     setStencilFuncBack(func, ref, mask) {
         if (this.stencilFuncBack !== func || this.stencilRefBack !== ref || this.stencilMaskBack !== mask) {
             const gl = this.gl;
@@ -2317,30 +2252,6 @@ class WebglGraphicsDevice extends GraphicsDevice {
         }
     }
 
-    /**
-     * Configures how stencil buffer values should be modified based on the result of depth/stencil
-     * tests. Works for both front and back faces.
-     *
-     * @param {number} fail - Action to take if stencil test is failed. Can be:
-     *
-     * - {@link STENCILOP_KEEP}: don't change the stencil buffer value
-     * - {@link STENCILOP_ZERO}: set value to zero
-     * - {@link STENCILOP_REPLACE}: replace value with the reference value (see {@link GraphicsDevice#setStencilFunc})
-     * - {@link STENCILOP_INCREMENT}: increment the value
-     * - {@link STENCILOP_INCREMENTWRAP}: increment the value, but wrap it to zero when it's larger
-     * than a maximum representable value
-     * - {@link STENCILOP_DECREMENT}: decrement the value
-     * - {@link STENCILOP_DECREMENTWRAP}: decrement the value, but wrap it to a maximum
-     * representable value, if the current value is 0
-     * - {@link STENCILOP_INVERT}: invert the value bitwise
-     *
-     * @param {number} zfail - Action to take if depth test is failed.  Accepts the same values as
-     * `fail`.
-     * @param {number} zpass - Action to take if both depth and stencil test are passed. Accepts
-     * the same values as `fail`.
-     * @param {number} writeMask - A bit mask applied to the reference value, when written.
-     * @ignore
-     */
     setStencilOperation(fail, zfail, zpass, writeMask) {
         if (this.stencilFailFront !== fail || this.stencilZfailFront !== zfail || this.stencilZpassFront !== zpass ||
             this.stencilFailBack !== fail || this.stencilZfailBack !== zfail || this.stencilZpassBack !== zpass) {
@@ -2356,30 +2267,6 @@ class WebglGraphicsDevice extends GraphicsDevice {
         }
     }
 
-    /**
-     * Configures how stencil buffer values should be modified based on the result of depth/stencil
-     * tests. Works for front faces.
-     *
-     * @param {number} fail - Action to take if stencil test is failed. Can be:
-     *
-     * - {@link STENCILOP_KEEP}: don't change the stencil buffer value
-     * - {@link STENCILOP_ZERO}: set value to zero
-     * - {@link STENCILOP_REPLACE}: replace value with the reference value (see {@link GraphicsDevice#setStencilFunc})
-     * - {@link STENCILOP_INCREMENT}: increment the value
-     * - {@link STENCILOP_INCREMENTWRAP}: increment the value, but wrap it to zero when it's larger
-     * than a maximum representable value
-     * - {@link STENCILOP_DECREMENT}: decrement the value
-     * - {@link STENCILOP_DECREMENTWRAP}: decrement the value, but wrap it to a maximum
-     * representable value, if the current value is 0
-     * - {@link STENCILOP_INVERT}: invert the value bitwise
-     *
-     * @param {number} zfail - Action to take if depth test is failed.  Accepts the same values as
-     * `fail`.
-     * @param {number} zpass - Action to take if both depth and stencil test are passed.  Accepts
-     * the same values as `fail`.
-     * @param {number} writeMask - A bit mask applied to the reference value, when written.
-     * @ignore
-     */
     setStencilOperationFront(fail, zfail, zpass, writeMask) {
         if (this.stencilFailFront !== fail || this.stencilZfailFront !== zfail || this.stencilZpassFront !== zpass) {
             this.gl.stencilOpSeparate(this.gl.FRONT, this.glStencilOp[fail], this.glStencilOp[zfail], this.glStencilOp[zpass]);
@@ -2393,30 +2280,6 @@ class WebglGraphicsDevice extends GraphicsDevice {
         }
     }
 
-    /**
-     * Configures how stencil buffer values should be modified based on the result of depth/stencil
-     * tests. Works for back faces.
-     *
-     * @param {number} fail - Action to take if stencil test is failed. Can be:
-     *
-     * - {@link STENCILOP_KEEP}: don't change the stencil buffer value
-     * - {@link STENCILOP_ZERO}: set value to zero
-     * - {@link STENCILOP_REPLACE}: replace value with the reference value (see {@link GraphicsDevice#setStencilFunc})
-     * - {@link STENCILOP_INCREMENT}: increment the value
-     * - {@link STENCILOP_INCREMENTWRAP}: increment the value, but wrap it to zero when it's larger
-     * than a maximum representable value
-     * - {@link STENCILOP_DECREMENT}: decrement the value
-     * - {@link STENCILOP_DECREMENTWRAP}: decrement the value, but wrap it to a maximum
-     * representable value, if the current value is 0
-     * - {@link STENCILOP_INVERT}: invert the value bitwise
-     *
-     * @param {number} zfail - Action to take if depth test is failed. Accepts the same values as
-     * `fail`.
-     * @param {number} zpass - Action to take if both depth and stencil test are passed. Accepts
-     * the same values as `fail`.
-     * @param {number} writeMask - A bit mask applied to the reference value, when written.
-     * @ignore
-     */
     setStencilOperationBack(fail, zfail, zpass, writeMask) {
         if (this.stencilFailBack !== fail || this.stencilZfailBack !== zfail || this.stencilZpassBack !== zpass) {
             this.gl.stencilOpSeparate(this.gl.BACK, this.glStencilOp[fail], this.glStencilOp[zfail], this.glStencilOp[zpass]);

--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -2214,6 +2214,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
      * Enables or disables stencil test.
      *
      * @param {boolean} enable - True to enable stencil test and false to disable it.
+     * @ignore
      */
     setStencilTest(enable) {
         if (this.stencil !== enable) {
@@ -2245,6 +2246,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
      * @param {number} ref - Reference value used in comparison.
      * @param {number} mask - Mask applied to stencil buffer value and reference value before
      * comparison.
+     * @ignore
      */
     setStencilFunc(func, ref, mask) {
         if (this.stencilFuncFront !== func || this.stencilRefFront !== ref || this.stencilMaskFront !== mask ||
@@ -2274,6 +2276,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
      *
      * @param {number} ref - Reference value used in comparison.
      * @param {number} mask - Mask applied to stencil buffer value and reference value before comparison.
+     * @ignore
      */
     setStencilFuncFront(func, ref, mask) {
         if (this.stencilFuncFront !== func || this.stencilRefFront !== ref || this.stencilMaskFront !== mask) {
@@ -2302,6 +2305,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
      *
      * @param {number} ref - Reference value used in comparison.
      * @param {number} mask - Mask applied to stencil buffer value and reference value before comparison.
+     * @ignore
      */
     setStencilFuncBack(func, ref, mask) {
         if (this.stencilFuncBack !== func || this.stencilRefBack !== ref || this.stencilMaskBack !== mask) {
@@ -2335,6 +2339,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
      * @param {number} zpass - Action to take if both depth and stencil test are passed. Accepts
      * the same values as `fail`.
      * @param {number} writeMask - A bit mask applied to the reference value, when written.
+     * @ignore
      */
     setStencilOperation(fail, zfail, zpass, writeMask) {
         if (this.stencilFailFront !== fail || this.stencilZfailFront !== zfail || this.stencilZpassFront !== zpass ||
@@ -2373,6 +2378,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
      * @param {number} zpass - Action to take if both depth and stencil test are passed.  Accepts
      * the same values as `fail`.
      * @param {number} writeMask - A bit mask applied to the reference value, when written.
+     * @ignore
      */
     setStencilOperationFront(fail, zfail, zpass, writeMask) {
         if (this.stencilFailFront !== fail || this.stencilZfailFront !== zfail || this.stencilZpassFront !== zpass) {
@@ -2409,6 +2415,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
      * @param {number} zpass - Action to take if both depth and stencil test are passed. Accepts
      * the same values as `fail`.
      * @param {number} writeMask - A bit mask applied to the reference value, when written.
+     * @ignore
      */
     setStencilOperationBack(fail, zfail, zpass, writeMask) {
         if (this.stencilFailBack !== fail || this.stencilZfailBack !== zfail || this.stencilZpassBack !== zpass) {

--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -65,7 +65,9 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
     commandEncoder;
 
     constructor(canvas, options = {}) {
-        super(canvas);
+        super(canvas, options);
+        options = this.initOptions;
+
         this.isWebGPU = true;
         this._deviceType = DEVICETYPE_WEBGPU;
 
@@ -235,7 +237,8 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
         this.frameBuffer = new RenderTarget({
             name: 'WebgpuFramebuffer',
             graphicsDevice: this,
-            depth: true,
+            depth: this.initOptions.depth,
+            stencil: this.initOptions.stencil,
             samples: this.samples
         });
     }

--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -544,15 +544,6 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
     setDepthBiasValues(constBias, slopeBias) {
     }
 
-    setStencilTest(enable) {
-    }
-
-    setStencilFunc(func, ref, mask) {
-    }
-
-    setStencilOperation(fail, zfail, zpass, writeMask) {
-    }
-
     setViewport(x, y, w, h) {
         // TODO: only execute when it changes. Also, the viewport of encoder  matches the rendering attachments,
         // so we can skip this if fullscreen

--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -19,6 +19,7 @@ import { WebgpuVertexBuffer } from './webgpu-vertex-buffer.js';
 import { WebgpuClearRenderer } from './webgpu-clear-renderer.js';
 import { DebugGraphics } from '../debug-graphics.js';
 import { WebgpuDebug } from './webgpu-debug.js';
+import { StencilParameters } from '../stencil-parameters.js';
 
 class WebgpuGraphicsDevice extends GraphicsDevice {
     /**
@@ -373,7 +374,8 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
 
             // render pipeline
             const pipeline = this.renderPipeline.get(primitive, vb0?.format, vb1?.format, this.shader, this.renderTarget,
-                                                     this.bindGroupFormats, this.blendState, this.depthState, this.cullMode);
+                                                     this.bindGroupFormats, this.blendState, this.depthState, this.cullMode,
+                                                     this.stencilEnabled, this.stencilFront, this.stencilBack);
             Debug.assert(pipeline);
 
             if (this.pipeline !== pipeline) {
@@ -420,6 +422,16 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
 
     setDepthState(depthState) {
         this.depthState.copy(depthState);
+    }
+
+    setStencilState(stencilFront, stencilBack) {
+        if (stencilFront || stencilBack) {
+            this.stencilEnabled = true;
+            this.stencilFront.copy(stencilFront ?? StencilParameters.DEFAULT);
+            this.stencilBack.copy(stencilBack ?? StencilParameters.DEFAULT);
+        } else {
+            this.stencilEnabled = false;
+        }
     }
 
     setBlendColor(r, g, b, a) {

--- a/src/platform/graphics/webgpu/webgpu-render-pipeline.js
+++ b/src/platform/graphics/webgpu/webgpu-render-pipeline.js
@@ -41,7 +41,7 @@ const _blendFactor = [
     'one-minus-constant'    // BLENDMODE_ONE_MINUS_CONSTANT
 ];
 
-const _depthCompareFunction = [
+const _compareFunction = [
     'never',                // FUNC_NEVER
     'less',                 // FUNC_LESS
     'equal',                // FUNC_EQUAL
@@ -56,6 +56,17 @@ const _cullModes = [
     'none',                 // CULLFACE_NONE
     'back',                 // CULLFACE_BACK
     'front'                 // CULLFACE_FRONT
+];
+
+const _stencilOps = [
+    'keep',                 // STENCILOP_KEEP
+    'zero',                 // STENCILOP_ZERO
+    'replace',              // STENCILOP_REPLACE
+    'increment-clamp',      // STENCILOP_INCREMENT
+    'increment-wrap',       // STENCILOP_INCREMENTWRAP
+    'decrement-clamp',      // STENCILOP_DECREMENT
+    'decrement-wrap',       // STENCILOP_DECREMENTWRAP
+    'invert'                // STENCILOP_INVERT
 ];
 
 // temp array to avoid allocation
@@ -84,10 +95,12 @@ class WebgpuRenderPipeline {
         this.cache = new Map();
     }
 
-    get(primitive, vertexFormat0, vertexFormat1, shader, renderTarget, bindGroupFormats, blendState, depthState, cullMode) {
+    get(primitive, vertexFormat0, vertexFormat1, shader, renderTarget, bindGroupFormats, blendState,
+        depthState, cullMode, stencilEnabled, stencilFront, stencilBack) {
 
         // render pipeline unique key
-        const key = this.getKey(primitive, vertexFormat0, vertexFormat1, shader, renderTarget, bindGroupFormats, blendState, depthState, cullMode);
+        const key = this.getKey(primitive, vertexFormat0, vertexFormat1, shader, renderTarget, bindGroupFormats,
+                                blendState, depthState, cullMode, stencilEnabled, stencilFront, stencilBack);
 
         // cached pipeline
         let pipeline = this.cache.get(key);
@@ -103,7 +116,8 @@ class WebgpuRenderPipeline {
             const vertexBufferLayout = this.vertexBufferLayout.get(vertexFormat0, vertexFormat1);
 
             // pipeline
-            pipeline = this.create(primitiveTopology, shader, renderTarget, pipelineLayout, blendState, depthState, vertexBufferLayout, cullMode);
+            pipeline = this.create(primitiveTopology, shader, renderTarget, pipelineLayout, blendState,
+                                   depthState, vertexBufferLayout, cullMode, stencilEnabled, stencilFront, stencilBack);
             this.cache.set(key, pipeline);
         }
 
@@ -114,7 +128,8 @@ class WebgpuRenderPipeline {
      * Generate a unique key for the render pipeline. Keep this function as lean as possible,
      * as it executes for each draw call.
      */
-    getKey(primitive, vertexFormat0, vertexFormat1, shader, renderTarget, bindGroupFormats, blendState, depthState, cullMode) {
+    getKey(primitive, vertexFormat0, vertexFormat1, shader, renderTarget, bindGroupFormats,
+        blendState, depthState, cullMode, stencilEnabled, stencilFront, stencilBack) {
 
         let bindGroupKey = '';
         for (let i = 0; i < bindGroupFormats.length; i++) {
@@ -123,9 +138,10 @@ class WebgpuRenderPipeline {
 
         const vertexBufferLayoutKey = this.vertexBufferLayout.getKey(vertexFormat0, vertexFormat1);
         const renderTargetKey = renderTarget.impl.key;
+        const stencilKey = stencilEnabled ? stencilFront.key + stencilBack.key : '';
 
         return vertexBufferLayoutKey + shader.impl.vertexCode + shader.impl.fragmentCode +
-            renderTargetKey + primitive.type + bindGroupKey + blendState.key + depthState.key + cullMode;
+            renderTargetKey + primitive.type + bindGroupKey + blendState.key + depthState.key + cullMode + stencilKey;
     }
 
     // TODO: this could be cached using bindGroupKey
@@ -190,30 +206,65 @@ class WebgpuRenderPipeline {
     }
 
     /** @private */
-    getDepthStencil(depthState, renderTarget) {
+    getDepthStencil(depthState, renderTarget, stencilEnabled, stencilFront, stencilBack) {
 
         /** @type {GPUDepthStencilState} */
         let depthStencil;
         const { depth, stencil } = renderTarget;
         if (depth || stencil) {
+
+            // format of depth-stencil attachment
             depthStencil = {
                 format: renderTarget.impl.depthFormat
             };
 
+            // depth
             if (depth) {
                 depthStencil.depthWriteEnabled = depthState.write;
-                depthStencil.depthCompare = _depthCompareFunction[depthState.func];
+                depthStencil.depthCompare = _compareFunction[depthState.func];
             } else {
                 // if render target does not have depth buffer
                 depthStencil.depthWriteEnabled = false;
                 depthStencil.depthCompare = 'always';
             }
+
+            // stencil
+            if (stencil && stencilEnabled) {
+
+                // Note that WebGPU only supports a single mask, we use the one from front, but not from back.
+                depthStencil.stencilReadMas = stencilFront.readMask;
+                depthStencil.stencilWriteMask = stencilFront.writeMask;
+
+                depthStencil.stencilFront = {
+                    compare: _compareFunction[stencilFront.func],
+
+
+                    // TODO: ???
+                    // webgl: stencil-fail, zpass, zfail
+                    // webgpu: stencil-fail, stencil-pass, zfail
+
+
+                    failOp: _stencilOps[stencilFront.fail],
+                    passOp: _stencilOps[stencilFront.fail],
+                    depthFailOp: _stencilOps[stencilFront.fail]
+                };
+
+                depthStencil.stencilBack = {
+
+                    // TODO: do this too
+
+                };
+            }
+
+
+
         }
 
         return depthStencil;
     }
 
-    create(primitiveTopology, shader, renderTarget, pipelineLayout, blendState, depthState, vertexBufferLayout, cullMode) {
+    create(primitiveTopology, shader, renderTarget, pipelineLayout, blendState, depthState, vertexBufferLayout,
+        cullMode, stencilEnabled, stencilFront, stencilBack) {
 
         const wgpu = this.device.wgpu;
 
@@ -233,7 +284,7 @@ class WebgpuRenderPipeline {
                 cullMode: _cullModes[cullMode]
             },
 
-            depthStencil: this.getDepthStencil(depthState, renderTarget),
+            depthStencil: this.getDepthStencil(depthState, renderTarget, stencilEnabled, stencilFront, stencilBack),
 
             multisample: {
                 count: renderTarget.samples

--- a/src/platform/graphics/webgpu/webgpu-render-pipeline.js
+++ b/src/platform/graphics/webgpu/webgpu-render-pipeline.js
@@ -237,27 +237,18 @@ class WebgpuRenderPipeline {
 
                 depthStencil.stencilFront = {
                     compare: _compareFunction[stencilFront.func],
-
-
-                    // TODO: ???
-                    // webgl: stencil-fail, zpass, zfail
-                    // webgpu: stencil-fail, stencil-pass, zfail
-
-
                     failOp: _stencilOps[stencilFront.fail],
-                    passOp: _stencilOps[stencilFront.fail],
-                    depthFailOp: _stencilOps[stencilFront.fail]
+                    passOp: _stencilOps[stencilFront.zpass],
+                    depthFailOp: _stencilOps[stencilFront.zfail]
                 };
 
                 depthStencil.stencilBack = {
-
-                    // TODO: do this too
-
+                    compare: _compareFunction[stencilBack.func],
+                    failOp: _stencilOps[stencilBack.fail],
+                    passOp: _stencilOps[stencilBack.zpass],
+                    depthFailOp: _stencilOps[stencilBack.zfail]
                 };
             }
-
-
-
         }
 
         return depthStencil;

--- a/src/scene/graphics/quad-render-utils.js
+++ b/src/scene/graphics/quad-render-utils.js
@@ -39,6 +39,7 @@ function drawQuadWithShader(device, target, shader, rect, scissorRect) {
 
     device.setCullMode(CULLFACE_NONE);
     device.setDepthState(DepthState.NODEPTH);
+    device.setStencilState(null, null);
 
     // prepare the quad for rendering with the shader
     const quad = new QuadRender(shader);

--- a/src/scene/materials/material.js
+++ b/src/scene/materials/material.js
@@ -410,13 +410,10 @@ class Material {
 
         this.depthBias = source.depthBias;
         this.slopeDepthBias = source.slopeDepthBias;
-        if (source.stencilFront) this.stencilFront = source.stencilFront.clone();
+
+        this.stencilFront = source.stencilFront?.clone();
         if (source.stencilBack) {
-            if (source.stencilFront === source.stencilBack) {
-                this.stencilBack = this.stencilFront;
-            } else {
-                this.stencilBack = source.stencilBack.clone();
-            }
+            this.stencilBack = source.stencilFront === source.stencilBack ? this.stencilFront : source.stencilBack.clone();
         }
 
         return this;

--- a/src/scene/materials/material.js
+++ b/src/scene/materials/material.js
@@ -119,14 +119,14 @@ class Material {
     /**
      * Stencil parameters for front faces (default is null).
      *
-     * @type {import('../stencil-parameters.js').StencilParameters|null}
+     * @type {import('../../platform/graphics/stencil-parameters.js').StencilParameters|null}
      */
     stencilFront = null;
 
     /**
      * Stencil parameters for back faces (default is null).
      *
-     * @type {import('../stencil-parameters.js').StencilParameters|null}
+     * @type {import('../../platform/graphics/stencil-parameters.js').StencilParameters|null}
      */
     stencilBack = null;
 

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -4,10 +4,6 @@ import { Debug, DebugHelper } from '../../core/debug.js';
 import { Vec3 } from '../../core/math/vec3.js';
 import { Color } from '../../core/math/color.js';
 
-import {
-    FUNC_ALWAYS,
-    STENCILOP_KEEP
-} from '../../platform/graphics/constants.js';
 import { DebugGraphics } from '../../platform/graphics/debug-graphics.js';
 import { RenderPass } from '../../platform/graphics/render-pass.js';
 

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -1112,7 +1112,7 @@ class ForwardRenderer extends Renderer {
             // TODO: this should not be here, as each rendering / clearing should explicitly set up what
             // it requires (the properties are part of render pipeline on WebGPU anyways)
             device.setBlendState(BlendState.DEFAULT);
-            device.setStencilTest(false); // don't leak stencil state
+            device.setStencilState(null, null);
             device.setAlphaToCoverage(false); // don't leak a2c state
             device.setDepthBias(false);
         }

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -607,39 +607,9 @@ class ForwardRenderer extends Renderer {
 
                 this.setupCullMode(camera._cullFaces, flipFactor, drawCall);
 
-                const stencilFront = drawCall.stencilFront || material.stencilFront;
-                const stencilBack = drawCall.stencilBack || material.stencilBack;
-
-                if (stencilFront || stencilBack) {
-                    device.setStencilTest(true);
-                    if (stencilFront === stencilBack) {
-                        // identical front/back stencil
-                        device.setStencilFunc(stencilFront.func, stencilFront.ref, stencilFront.readMask);
-                        device.setStencilOperation(stencilFront.fail, stencilFront.zfail, stencilFront.zpass, stencilFront.writeMask);
-                    } else {
-                        // separate
-                        if (stencilFront) {
-                            // set front
-                            device.setStencilFuncFront(stencilFront.func, stencilFront.ref, stencilFront.readMask);
-                            device.setStencilOperationFront(stencilFront.fail, stencilFront.zfail, stencilFront.zpass, stencilFront.writeMask);
-                        } else {
-                            // default front
-                            device.setStencilFuncFront(FUNC_ALWAYS, 0, 0xFF);
-                            device.setStencilOperationFront(STENCILOP_KEEP, STENCILOP_KEEP, STENCILOP_KEEP, 0xFF);
-                        }
-                        if (stencilBack) {
-                            // set back
-                            device.setStencilFuncBack(stencilBack.func, stencilBack.ref, stencilBack.readMask);
-                            device.setStencilOperationBack(stencilBack.fail, stencilBack.zfail, stencilBack.zpass, stencilBack.writeMask);
-                        } else {
-                            // default back
-                            device.setStencilFuncBack(FUNC_ALWAYS, 0, 0xFF);
-                            device.setStencilOperationBack(STENCILOP_KEEP, STENCILOP_KEEP, STENCILOP_KEEP, 0xFF);
-                        }
-                    }
-                } else {
-                    device.setStencilTest(false);
-                }
+                const stencilFront = drawCall.stencilFront ?? material.stencilFront;
+                const stencilBack = drawCall.stencilBack ?? material.stencilBack;
+                device.setStencilState(stencilFront, stencilBack);
 
                 const mesh = drawCall.mesh;
 
@@ -655,9 +625,7 @@ class ForwardRenderer extends Renderer {
                 const style = drawCall.renderStyle;
                 device.setIndexBuffer(mesh.indexBuffer[style]);
 
-                if (drawCallback) {
-                    drawCallback(drawCall, i);
-                }
+                drawCallback?.(drawCall, i);
 
                 if (camera.xr && camera.xr.session && camera.xr.views.length) {
                     const views = camera.xr.views;

--- a/src/scene/renderer/shadow-renderer.js
+++ b/src/scene/renderer/shadow-renderer.js
@@ -201,6 +201,7 @@ class ShadowRenderer {
 
         device.setBlendState(useShadowSampler ? this.blendStateNoWrite : this.blendStateWrite);
         device.setDepthState(DepthState.DEFAULT);
+        device.setStencilState(null, null);
     }
 
     restoreRenderState(device) {

--- a/test/scene/materials/material.test.mjs
+++ b/test/scene/materials/material.test.mjs
@@ -23,8 +23,8 @@ describe('Material', function () {
         expect(material.redWrite).to.equal(true);
         expect(material.shader).to.be.null;
         expect(material.slopeDepthBias).to.equal(0);
-        expect(material.stencilBack).to.be.null;
-        expect(material.stencilFront).to.be.null;
+        expect(material.stencilBack).to.not.exist;
+        expect(material.stencilFront).to.not.exist;
     }
 
     describe('#constructor()', function () {


### PR DESCRIPTION
- Portal and ScrollView engine examples now work on WebGPU
- StencilParameters file / class was moved from scene to platform/graphics, along BlendState and DepthState, as a data container for the main API allowing stencil parameters setup.
- WebgpuGraphicsDevice now handles stencil buffer on the main framebuffer, specified by the creation options.
- WebglGraphicsDevice construction now handles options.stencil. Before it was hardcoded to true.


### new API
```
	GraphicsDevice.setStencilState(stencilFront, stencilBack);
```

### deprecated API on WebglGraphicsDevice:
- The functionality is still there, but no longer exposed / documented.
```
	setStencilTest
	setStencilFunc
	setStencilFuncFront
	setStencilFuncBack
	setStencilOperation
	setStencilOperationFront
	setStencilOperationBack
```

Possible future improvements: https://github.com/playcanvas/engine/issues/5244