### PR TITLE
Fixed bug where raycast filter tags caused exception

### DIFF
--- a/src/framework/components/rigid-body/system.js
+++ b/src/framework/components/rigid-body/system.js
@@ -616,7 +616,7 @@ class RigidBodyComponentSystem extends ComponentSystem {
                 const body = Ammo.castObject(collisionObjs.at(i), Ammo.btRigidBody);
 
                 if (body && body.entity) {
-                    if (options.filterTags && !body.entity.has(...options.filterTags) || options.filterCallback && !options.filterCallback(body.entity)) {
+                    if (options.filterTags && !body.entity.tags.has(...options.filterTags) || options.filterCallback && !options.filterCallback(body.entity)) {
                         continue;
                     }
 


### PR DESCRIPTION
Fixes 1.62 bug where using filtertags for raycasting will cause an exception.

CC @MushAsterion 

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
