### PR TITLE
Disable GPU particles on Mali G52 due to rendering artifacts 

### DIFF
--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -953,16 +953,10 @@ class WebglGraphicsDevice extends GraphicsDevice {
         this.unmaskedRenderer = ext ? gl.getParameter(ext.UNMASKED_RENDERER_WEBGL) : '';
         this.unmaskedVendor = ext ? gl.getParameter(ext.UNMASKED_VENDOR_WEBGL) : '';
 
-        // Check if we support GPU particles. At the moment, Samsung devices with Exynos (ARM) either crash or render
-        // incorrectly when using GPU for particles. See:
-        // https://github.com/playcanvas/engine/issues/3967
-        // https://github.com/playcanvas/engine/issues/3415
-        // https://github.com/playcanvas/engine/issues/4514
-        // Example UA matches: Starting 'SM' and any combination of letters or numbers:
-        // Mozilla/5.0 (Linux, Android 12; SM-G970F Build/SP1A.210812.016; wv)
-        // Mozilla/5.0 (Linux, Android 12; SM-G970F)
-        const samsungModelRegex = /SM-[a-zA-Z0-9]+/;
-        this.supportsGpuParticles = !(this.unmaskedVendor === 'ARM' && userAgent.match(samsungModelRegex));
+        // Mali-G52 has rendering issues with GPU particles including
+        // SM-A225M, M2003J15SC and KFRAWI (Amazon Fire HD 8 2022)
+        const maliRendererRegex = /\bMali-G52+/;
+        this.supportsGpuParticles = !(this.unmaskedRenderer.match(maliRendererRegex));
 
         ext = this.extTextureFilterAnisotropic;
         this.maxAnisotropy = ext ? gl.getParameter(ext.MAX_TEXTURE_MAX_ANISOTROPY_EXT) : 1;

--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -918,7 +918,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
     initializeCapabilities() {
         const gl = this.gl;
         let ext;
-        
+
         this.maxPrecision = this.precision = this.getPrecision();
 
         const contextAttribs = gl.getContextAttributes();

--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -918,9 +918,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
     initializeCapabilities() {
         const gl = this.gl;
         let ext;
-
-        const userAgent = typeof navigator !== 'undefined' ? navigator.userAgent : "";
-
+        
         this.maxPrecision = this.precision = this.getPrecision();
 
         const contextAttribs = gl.getContextAttributes();


### PR DESCRIPTION
Also enabled Samsung devices again as they no longer have issues rendering GPU particles except for G52

See thread: https://forum.playcanvas.com/t/particles-not-rendered-on-amazon-fire-tablet-hd-8/30660

Test project with the updated check: https://playcanv.as/b/9faf8adb

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
