### PR TITLE
Refactor of private ShaderPass class to be dynamic instead of hardcoded

### DIFF
--- a/src/deprecated/deprecated.js
+++ b/src/deprecated/deprecated.js
@@ -1002,7 +1002,7 @@ _defineAlias('sheenGloss', 'sheenGlossiess');
 _defineAlias('clearCoatGloss', 'clearCostGlossiness');
 
 function _defineOption(name, newName) {
-    if (name !== 'chunks' && name !== '_pass') {
+    if (name !== 'chunks' && name !== '_pass' && name !== '_isForwardPass') {
         Object.defineProperty(StandardMaterialOptions.prototype, name, {
             get: function () {
                 Debug.deprecated(`Getting pc.Options#${name} has been deprecated as the property has been moved to pc.Options.LitOptions#${newName || name}.`);

--- a/src/index.js
+++ b/src/index.js
@@ -125,6 +125,7 @@ export { MorphTarget } from './scene/morph-target.js';
 export { ParticleEmitter } from './scene/particle-system/particle-emitter.js';
 export { QuadRender } from './scene/graphics/quad-render.js';
 export { Scene } from './scene/scene.js';
+export { ShaderPass } from './scene/shader-pass.js';
 export { Skin } from './scene/skin.js';
 export { SkinInstance } from './scene/skin-instance.js';
 export { Sprite } from './scene/sprite.js';

--- a/src/scene/constants.js
+++ b/src/scene/constants.js
@@ -650,30 +650,8 @@ export const SHADER_DEPTH = 2;
 // shader pass used by the Picker class to render mesh ID
 export const SHADER_PICK = 3;
 
-// next shader pass constants are undocumented - see ShaderPass class
-export const SHADER_SHADOW = 4; // start of shadow related pass constants
-// 4 = PCF3 DIR
-// 5 = VSM8 DIR
-// 6 = VSM16 DIR
-// 7 = VSM32 DIR
-// 8 = PCF5 DIR
-// 9 = PCF1 DIR
-
-// 10 = PCF3 OMNI
-// 11 = VSM8 OMNI
-// 12 = VSM16 OMNI
-// 13 = VSM32 OMNI
-// 14 = PCF5 OMNI
-// 15 = PCF1 OMNI
-
-// 16 = PCF3 SPOT
-// 17 = VSM8 SPOT
-// 18 = VSM16 SPOT
-// 19 = VSM32 SPOT
-// 20 = PCF5 SPOT
-// 21 = PCF1 SPOT
-
-// Note: the Editor is using constant 24 for its internal purpose
+// shadow pass used by the shadow rendering code
+export const SHADER_SHADOW = 4;
 
 /**
  * Shader that performs forward rendering.

--- a/src/scene/materials/lit-options.js
+++ b/src/scene/materials/lit-options.js
@@ -19,6 +19,8 @@ class LitOptions {
 
     _pass = 0;
 
+    _isForwardPass = false;
+
     /**
      * Enable alpha testing. See {@link Material#alphaTest}.
      *
@@ -327,6 +329,14 @@ class LitOptions {
 
     get pass() {
         return this._pass;
+    }
+
+    set isForwardPass(p) {
+        Debug.warn(`pc.LitOptions#isForwardPass should be set by its parent pc.StandardMaterialOptions, setting it directly has no effect.`);
+    }
+
+    get isForwardPass() {
+        return this._isForwardPass;
     }
 }
 

--- a/src/scene/materials/standard-material-options.js
+++ b/src/scene/materials/standard-material-options.js
@@ -8,6 +8,9 @@ class StandardMaterialOptions {
     /** @private */
     _pass = 0;
 
+    /** @private */
+    _isForwardPass = false;
+
     chunks = [];
 
     /**
@@ -114,6 +117,15 @@ class StandardMaterialOptions {
 
     get pass() {
         return this._pass;
+    }
+
+    set isForwardPass(value) {
+        this._isForwardPass = value;
+        this.litOptions._isForwardPass = value;
+    }
+
+    get isForwardPass() {
+        return this._isForwardPass;
     }
 }
 

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -832,7 +832,8 @@ class StandardMaterial extends Material {
         this.updateEnvUniforms(device, scene);
 
         // Minimal options for Depth and Shadow passes
-        const minimalOptions = pass === SHADER_DEPTH || pass === SHADER_PICK || ShaderPass.isShadow(pass);
+        const shaderPassInfo = ShaderPass.get(device).getByIndex(pass);
+        const minimalOptions = pass === SHADER_DEPTH || pass === SHADER_PICK || shaderPassInfo.isShadowPass;
         let options = minimalOptions ? standard.optionsContextMin : standard.optionsContext;
 
         if (minimalOptions)

--- a/src/scene/particle-system/particle-emitter.js
+++ b/src/scene/particle-system/particle-emitter.js
@@ -32,7 +32,8 @@ import {
     EMITTERSHAPE_BOX,
     PARTICLEMODE_GPU,
     PARTICLEORIENTATION_SCREEN, PARTICLEORIENTATION_WORLD,
-    PARTICLESORT_NONE
+    PARTICLESORT_NONE,
+    SHADER_FORWARD
 } from '../constants.js';
 import { Mesh } from '../mesh.js';
 import { MeshInstance } from '../mesh-instance.js';
@@ -857,6 +858,7 @@ class ParticleEmitter {
             const processingOptions = new ShaderProcessorOptions(viewUniformFormat, viewBindGroupFormat);
 
             const shader = programLib.getProgram('particle', {
+                pass: SHADER_FORWARD,
                 useCpu: this.emitter.useCpu,
                 normal: this.emitter.normalOption,
                 halflambert: this.emitter.halfLambert,

--- a/src/scene/renderer/shadow-renderer.js
+++ b/src/scene/renderer/shadow-renderer.js
@@ -72,6 +72,14 @@ function getDepthKey(meshInstance) {
  */
 class ShadowRenderer {
     /**
+     * A cache of shadow passes. First index is looked up by light type, second by shadow type.
+     *
+     * @type {import('../shader-pass.js').ShaderPassInfo[][]}
+     * @private
+     */
+    shadowPassCache = [];
+
+    /**
      * @param {import('./renderer.js').Renderer} renderer - The renderer.
      * @param {import('../lighting/light-texture-atlas.js').LightTextureAtlas} lightTextureAtlas - The
      * shadow map atlas.
@@ -243,6 +251,31 @@ class ShadowRenderer {
         }
     }
 
+    getShadowPass(light) {
+
+        // get shader pass from cache for this light type and shadow type
+        const lightType = light._type;
+        const shadowType = light._shadowType;
+        let shadowPassInfo = this.shadowPassCache[lightType]?.[shadowType];
+        if (!shadowPassInfo) {
+
+            // new shader pass if not in cache
+            const shadowPassName = `ShadowPass_${lightType}_${shadowType}`;
+            shadowPassInfo = ShaderPass.get(this.device).allocate(shadowPassName, {
+                isShadow: true,
+                lightType: lightType,
+                shadowType: shadowType
+            });
+
+            // add it to the cache
+            if (!this.shadowPassCache[lightType])
+                this.shadowPassCache[lightType] = [];
+            this.shadowPassCache[lightType][shadowType] = shadowPassInfo;
+        }
+
+        return shadowPassInfo.index;
+    }
+
     /**
      * @param {import('../mesh-instance.js').MeshInstance[]} visibleCasters - Visible mesh
      * instances.
@@ -254,9 +287,7 @@ class ShadowRenderer {
         const renderer = this.renderer;
         const scene = renderer.scene;
         const passFlags = 1 << SHADER_SHADOW;
-
-        // Sort shadow casters
-        const shadowPass = ShaderPass.getShadow(light._type, light._shadowType);
+        const shadowPass = this.getShadowPass(light);
 
         // TODO: Similarly to forward renderer, a shader creation part of this loop should be split into a separate loop,
         // and endShaderBatch should be called at its end

--- a/src/scene/shader-lib/program-library.js
+++ b/src/scene/shader-lib/program-library.js
@@ -131,9 +131,16 @@ class ProgramLibrary {
             const generatedShaderDef = this.generateShaderDefinition(generator, name, generationKey, options);
             Debug.assert(generatedShaderDef);
 
+            // use shader pass name if known
+            let passName = '';
+            if (options.pass) {
+                const shaderPassInfo = ShaderPass.get(this._device).getByIndex(options.pass);
+                passName = `-${shaderPassInfo.name}`;
+            }
+
             // create a shader definition for the shader that will include the processingOptions
             const shaderDefinition = {
-                name: `${generatedShaderDef.name}-processed`,
+                name: `${generatedShaderDef.name}${passName}-proc`,
                 attributes: generatedShaderDef.attributes,
                 vshader: generatedShaderDef.vshader,
                 fshader: generatedShaderDef.fshader,
@@ -224,7 +231,8 @@ class ProgramLibrary {
     }
 
     _getDefaultStdMatOptions(pass) {
-        return (pass === SHADER_DEPTH || pass === SHADER_PICK || ShaderPass.isShadow(pass)) ?
+        const shaderPassInfo = ShaderPass.get(this._device).getByIndex(pass);
+        return (pass === SHADER_DEPTH || pass === SHADER_PICK || shaderPassInfo.isShadow) ?
             this._defaultStdMatOptionMin : this._defaultStdMatOption;
     }
 

--- a/src/scene/shader-lib/programs/basic.js
+++ b/src/scene/shader-lib/programs/basic.js
@@ -46,7 +46,8 @@ const basic = {
             attributes.vertex_texCoord0 = SEMANTIC_TEXCOORD0;
         }
 
-        const shaderPassDefine = ShaderPass.getPassShaderDefine(options.pass);
+        const shaderPassInfo = ShaderPass.get(device).getByIndex(options.pass);
+        const shaderPassDefine = shaderPassInfo.shaderDefine;
 
         // GENERATE VERTEX SHADER
         let vshader = shaderPassDefine;

--- a/src/scene/shader-lib/programs/standard.js
+++ b/src/scene/shader-lib/programs/standard.js
@@ -94,7 +94,7 @@ const standard = {
     _getUvSourceExpression: function (transformPropName, uVPropName, options) {
         const transformId = options[transformPropName];
         const uvChannel = options[uVPropName];
-        const isMainPass = ShaderPass.isForward(options.pass);
+        const isMainPass = options.isForwardPass;
 
         let expression;
         if (isMainPass && options.litOptions.nineSlicedMode === SPRITE_RENDERMODE_SLICED) {
@@ -240,6 +240,11 @@ const standard = {
      * @ignore
      */
     createShaderDefinition: function (device, options) {
+
+        const shaderPassInfo = ShaderPass.get(device).getByIndex(options.pass);
+        const isForwardPass = shaderPassInfo.isForward;
+        options.isForwardPass = isForwardPass;
+
         const litShader = new LitShader(device, options.litOptions);
 
         // generate vertex shader
@@ -308,7 +313,7 @@ const standard = {
             decl.append(`uniform float textureBias;`);
         }
 
-        if (ShaderPass.isForward(options.pass)) {
+        if (isForwardPass) {
             // parallax
             if (options.heightMap) {
                 // if (!options.normalMap) {

--- a/src/scene/shader-pass.js
+++ b/src/scene/shader-pass.js
@@ -66,7 +66,6 @@ class ShaderPass {
      * Allocated shader passes, map of a shader pass name to info.
      *
      * @type {Map<string, ShaderPassInfo>}
-     * @ignore
      */
     passesNamed = new Map();
 
@@ -74,7 +73,6 @@ class ShaderPass {
      * Allocated shader passes, indexed by their index.
      *
      * @type {Array<ShaderPassInfo>}
-     * @ignore
      */
     passesIndexed = [];
 

--- a/src/scene/shader-pass.js
+++ b/src/scene/shader-pass.js
@@ -1,110 +1,148 @@
 import { Debug } from '../core/debug.js';
 import {
-    SHADER_FORWARD, SHADER_FORWARDHDR, SHADER_DEPTH, SHADER_PICK,
-    SHADER_SHADOW, SHADOW_COUNT, LIGHTTYPE_COUNT,
-    SHADERTYPE_FORWARD, SHADERTYPE_DEPTH, SHADERTYPE_PICK, SHADERTYPE_SHADOW
+    SHADER_FORWARD, SHADER_FORWARDHDR, SHADER_DEPTH, SHADER_PICK, SHADER_SHADOW
 } from './constants.js';
 
+import { DeviceCache } from '../platform/graphics/device-cache.js';
+
+// device cache storing shader pass data per device
+const shaderPassDeviceCache = new DeviceCache();
+
 /**
- * A pure static utility class, responsible for math operations on the shader pass constants.
+ * Info about a shader pass. Shader pass is represented by a unique index and a name, and the
+ * index is used to access the shader required for the pass, from an array stored in the
+ * material or mesh instance.
+ *
+ * @ignore
+ */
+class ShaderPassInfo {
+    /** @type {number} */
+    index;
+
+    /** @type {string} */
+    name;
+
+    /** @type {string} */
+    shaderDefine;
+
+    constructor(name, index, options = {}) {
+
+        Debug.assert(/^[a-zA-Z][_a-zA-Z0-9]*$/.test(name), `ShaderPass name can only contain letters, numbers and underscores and start with a letter: ${name}`);
+
+        this.name = name;
+        this.index = index;
+
+        // assign options as properties to this object
+        Object.assign(this, options);
+
+        this.initShaderDefine();
+    }
+
+    initShaderDefine() {
+
+        let keyword;
+        if (this.isShadow) {
+            keyword = 'SHADOW';
+        } else if (this.isForward) {
+            keyword = 'FORWARD';
+        } else if (this.index === SHADER_DEPTH) {
+            keyword = 'DEPTH';
+        } else if (this.index === SHADER_PICK) {
+            keyword = 'PICK';
+        }
+
+        keyword ??= this.name.toUpperCase();
+        this.shaderDefine = `#define ${keyword}_PASS\n`;
+    }
+}
+
+/**
+ * Class responsible for management of shader passes, associated with a device.
  *
  * @ignore
  */
 class ShaderPass {
     /**
-     * Returns the shader type given the shader pass.
+     * Allocated shader passes, map of a shader pass name to info.
      *
-     * @param {number} shaderPass - The shader pass.
-     * @returns {string} - The shader type.
+     * @type {Map<string, ShaderPassInfo>}
+     * @ignore
      */
-    static getType(shaderPass) {
-        switch (shaderPass) {
-            case SHADER_FORWARD:
-            case SHADER_FORWARDHDR:
-                return SHADERTYPE_FORWARD;
-            case SHADER_DEPTH:
-                return SHADERTYPE_DEPTH;
-            case SHADER_PICK:
-                return SHADERTYPE_PICK;
-            default:
-                return (shaderPass >= SHADER_SHADOW && shaderPass < SHADER_SHADOW + SHADOW_COUNT * LIGHTTYPE_COUNT) ? SHADERTYPE_SHADOW : SHADERTYPE_FORWARD;
+    passesNamed = new Map();
+
+    /**
+     * Allocated shader passes, indexed by their index.
+     *
+     * @type {Array<ShaderPassInfo>}
+     * @ignore
+     */
+    passesIndexed = [];
+
+    /** Next available index */
+    nextIndex = 0;
+
+    constructor() {
+
+        const add = (name, index, options) => {
+            const info = this.allocate(name, options);
+            Debug.assert(info.index === index);
+        };
+
+        // add default passes in the required order, to match the constants
+        add('forward', SHADER_FORWARD, { isForward: true });
+        add('forward_hdr', SHADER_FORWARDHDR, { isForward: true });
+        add('depth', SHADER_DEPTH);
+        add('pick', SHADER_PICK);
+        add('shadow', SHADER_SHADOW);
+    }
+
+    /**
+     * Get access to the shader pass instance for the specified device.
+     *
+     * @param {import('./graphics-device.js').GraphicsDevice} device - The graphics device.
+     * @returns { ShaderPass } The shader pass instance for the specified device.
+     */
+    static get(device) {
+        Debug.assert(device);
+
+        return shaderPassDeviceCache.get(device, () => {
+            return new ShaderPass();
+        });
+    }
+
+    /**
+     * Allocates a shader pass with the specified name and options.
+     *
+     * @param {string} name - A name of the shader pass.
+     * @param {object} options - Options for the shader pass, which are added as properties to the
+     * shader pass info.
+     * @returns {ShaderPassInfo} The allocated shader pass info.
+     */
+    allocate(name, options) {
+        let info = this.passesNamed.get(name);
+        if (info === undefined) {
+            info = new ShaderPassInfo(name, this.nextIndex, options);
+            this.passesNamed.set(info.name, info);
+            this.passesIndexed[info.index] = info;
+            this.nextIndex++;
         }
+        return info;
     }
 
     /**
-     * Returns true if the shader pass is a forward shader pass.
+     * Return the shader pass info for the specified index.
      *
-     * @param {number} pass - The shader pass.
-     * @returns {boolean} - True if the pass is a forward shader pass.
+     * @param {number} index - The shader pass index.
+     * @returns {ShaderPassInfo} - The shader pass info.
      */
-    static isForward(pass) {
-        return this.getType(pass) === SHADERTYPE_FORWARD;
+    getByIndex(index) {
+        const info = this.passesIndexed[index];
+        Debug.assert(info);
+        return info;
     }
 
-    /**
-     * Returns true if the shader pass is a shadow shader pass.
-     *
-     * @param {number} pass - The shader pass.
-     * @returns {boolean} - True if the pass is a shadow shader pass.
-     */
-    static isShadow(pass) {
-        return this.getType(pass) === SHADERTYPE_SHADOW;
-    }
-
-    /**
-     * Returns the light type based on the shader shadow pass.
-     *
-     * @param {number} pass - The shader pass.
-     * @returns {number} - A light type.
-     */
-    static toLightType(pass) {
-        Debug.assert(ShaderPass.isShadow(pass));
-        const shadowMode = pass - SHADER_SHADOW;
-        return Math.floor(shadowMode / SHADOW_COUNT);
-    }
-
-    /**
-     * Returns the shadow type based on the shader shadow pass.
-     *
-     * @param {number} pass - The shader pass.
-     * @returns {number} - A shadow type.
-     */
-    static toShadowType(pass) {
-        Debug.assert(ShaderPass.isShadow(pass));
-        const shadowMode = pass - SHADER_SHADOW;
-        const lightType = Math.floor(shadowMode / SHADOW_COUNT);
-        return shadowMode - lightType * SHADOW_COUNT;
-    }
-
-    /**
-     * Returns a shader pass for specified light and shadow type.
-     *
-     * @param {number} lightType - A light type.
-     * @param {number} shadowType - A shadow type.
-     * @returns {number} - A shader pass.
-     */
-    static getShadow(lightType, shadowType) {
-        const shadowMode = shadowType + lightType * SHADOW_COUNT;
-        const pass = SHADER_SHADOW + shadowMode;
-        Debug.assert(ShaderPass.isShadow(pass));
-        return pass;
-    }
-
-    /**
-     * Returns the define code line for the shader pass.
-     *
-     * @param {number} pass - The shader pass.
-     * @returns {string} - A code line.
-     */
-    static getPassShaderDefine(pass) {
-        if (pass === SHADER_PICK) {
-            return '#define PICK_PASS\n';
-        } else if (pass === SHADER_DEPTH) {
-            return '#define DEPTH_PASS\n';
-        } else if (ShaderPass.isShadow(pass)) {
-            return '#define SHADOW_PASS\n';
-        }
-        return '';
+    getByName(name) {
+        return this.passesNamed.get(name);
     }
 }
 

--- a/src/scene/sky.js
+++ b/src/scene/sky.js
@@ -34,21 +34,21 @@ class Sky {
 
         material.getShaderVariant = function (dev, sc, defs, staticLightList, pass, sortedLights, viewUniformFormat, viewBindGroupFormat) {
 
-            const options = texture.cubemap ? {
-                type: 'cubemap',
-                encoding: texture.encoding,
-                useIntensity: scene.skyboxIntensity !== 1 || scene.physicalUnits,
-                mip: texture.fixCubemapSeams ? scene.skyboxMip : 0,
-                fixSeams: texture.fixCubemapSeams,
-                gamma: (pass === SHADER_FORWARDHDR ? (scene.gammaCorrection ? GAMMA_SRGBHDR : GAMMA_NONE) : scene.gammaCorrection),
-                toneMapping: (pass === SHADER_FORWARDHDR ? TONEMAP_LINEAR : scene.toneMapping)
-            } : {
-                type: 'envAtlas',
+            const options = {
+                pass: pass,
                 encoding: texture.encoding,
                 useIntensity: scene.skyboxIntensity !== 1 || scene.physicalUnits,
                 gamma: (pass === SHADER_FORWARDHDR ? (scene.gammaCorrection ? GAMMA_SRGBHDR : GAMMA_NONE) : scene.gammaCorrection),
                 toneMapping: (pass === SHADER_FORWARDHDR ? TONEMAP_LINEAR : scene.toneMapping)
             };
+
+            if (texture.cubemap) {
+                options.type = 'cubemap';
+                options.mip = texture.fixCubemapSeams ? scene.skyboxMip : 0;
+                options.fixSeams = texture.fixCubemapSeams;
+            } else {
+                options.type = 'envAtlas';
+            }
 
             const processingOptions = new ShaderProcessorOptions(viewUniformFormat, viewBindGroupFormat);
 


### PR DESCRIPTION
In the past, a shader pass ids were hardcoded, for example forward, depth, pick, and a whole list of them for combinations of light type and shadow type. The Editor also uses hardcoded number, which was limiting what can be done in the engine (separate PR to address). The shader pass dictates a shader needed for the pass - each pass generates a new shader for its specific requirements.

In order to make the engine more flexible, this has been now changed to a dynamic solution, where renderers can request shader creation for any number of passes. This will allow is to easily add debug rendering ('render albedo, render normal' ..).

For each shader pass, a new define is added to a shader, allowing per pass customization, i.e:
- SHADOW_PASS (existing), but also
- CUSTOM_PASS (based on 'custom' shader pass name)

Each shader pass created can have additional options to be attached, to be used by the generator.

There will be a separate follow up PR taking advantage of this to implement some debug rendering.

Note that few shader passes related to public constants commonly used are pre-created to guarantee their order matches the constants:

```
        add('depth', SHADER_DEPTH);
        add('pick', SHADER_PICK);
        add('shadow', SHADER_SHADOW);
```

Example logging of shader pass creation logging when rendering shadows for few different light types.

![Screenshot 2023-04-18 at 12 26 18](https://user-images.githubusercontent.com/59932779/233361414-f58bff03-dbe8-4afe-a33c-4c6d3f7d99e8.png)
