### PR TITLE
Debug shader output functionality

### DIFF
--- a/examples/src/examples/graphics/multi-view.tsx
+++ b/examples/src/examples/graphics/multi-view.tsx
@@ -1,11 +1,36 @@
+import React from 'react';
 import * as pc from '../../../../';
+import { BindingTwoWay, LabelGroup, Panel, SelectInput } from '@playcanvas/pcui/react';
+import { Observer } from '@playcanvas/observer';
 
 class MultiViewExample {
     static CATEGORY = 'Graphics';
     static NAME = 'Multi View';
     static WEBGPU_ENABLED = true;
 
-    example(canvas: HTMLCanvasElement, deviceType: string): void {
+    controls(data: Observer) {
+        return <>
+            <Panel headerText='Debug Shader Rendering'>
+                {<LabelGroup text='Mode'>
+                    <SelectInput binding={new BindingTwoWay()} link={{ observer: data, path: 'settings.shaderPassName' }} type="string" options={[
+                        { v: pc.SHADERTYPE_FORWARD, t: 'Normal' },
+                        { v: pc.SHADERTYPE_DEBUG_ALBEDO, t: 'Albedo' },
+                        { v: pc.SHADERTYPE_DEBUG_OPACITY, t: 'Opacity' },
+                        { v: pc.SHADERTYPE_DEBUG_WORLDNORMAL, t: 'World Normal' },
+                        { v: pc.SHADERTYPE_DEBUG_SPECULARITY, t: 'Specularity' },
+                        { v: pc.SHADERTYPE_DEBUG_GLOSS, t: 'Gloss' },
+                        { v: pc.SHADERTYPE_DEBUG_METALNESS, t: 'Metalness' },
+                        { v: pc.SHADERTYPE_DEBUG_AO, t: 'AO' },
+                        { v: pc.SHADERTYPE_DEBUG_EMISSION, t: 'Emission' },
+                        { v: pc.SHADERTYPE_DEBUG_LIGHTING, t: 'Lighting' },
+                        { v: pc.SHADERTYPE_DEBUG_UV0, t: 'UV0' }
+                    ]} />
+                </LabelGroup>}
+            </Panel>
+        </>;
+    }
+
+    example(canvas: HTMLCanvasElement, deviceType: string, data: any): void {
 
         // set up and load draco module, as the glb we load is draco compressed
         pc.WasmModule.setConfig('DracoDecoderModule', {
@@ -66,6 +91,10 @@ class MultiViewExample {
                 assetListLoader.load(() => {
 
                     app.start();
+
+                    data.set('settings', {
+                        shaderPassName: pc.SHADERTYPE_FORWARD
+                    });
 
                     // get the instance of the chess board and set up with render component
                     const boardEntity = assets.board.resource.instantiateRenderEntity({
@@ -136,6 +165,11 @@ class MultiViewExample {
                     app.scene.envAtlas = assets.helipad.resource;
                     app.scene.toneMapping = pc.TONEMAP_ACES;
                     app.scene.skyboxMip = 1;
+
+                    // handle HUD changes - update the debug mode on the top camera
+                    data.on('*:set', (path: string, value: any) => {
+                        cameraTop.camera.setShaderPassName(value);
+                    });
 
                     // update function called once per frame
                     let time = 0;

--- a/examples/src/examples/graphics/multi-view.tsx
+++ b/examples/src/examples/graphics/multi-view.tsx
@@ -13,17 +13,17 @@ class MultiViewExample {
             <Panel headerText='Debug Shader Rendering'>
                 {<LabelGroup text='Mode'>
                     <SelectInput binding={new BindingTwoWay()} link={{ observer: data, path: 'settings.shaderPassName' }} type="string" options={[
-                        { v: pc.SHADERTYPE_FORWARD, t: 'Normal' },
-                        { v: pc.SHADERTYPE_DEBUG_ALBEDO, t: 'Albedo' },
-                        { v: pc.SHADERTYPE_DEBUG_OPACITY, t: 'Opacity' },
-                        { v: pc.SHADERTYPE_DEBUG_WORLDNORMAL, t: 'World Normal' },
-                        { v: pc.SHADERTYPE_DEBUG_SPECULARITY, t: 'Specularity' },
-                        { v: pc.SHADERTYPE_DEBUG_GLOSS, t: 'Gloss' },
-                        { v: pc.SHADERTYPE_DEBUG_METALNESS, t: 'Metalness' },
-                        { v: pc.SHADERTYPE_DEBUG_AO, t: 'AO' },
-                        { v: pc.SHADERTYPE_DEBUG_EMISSION, t: 'Emission' },
-                        { v: pc.SHADERTYPE_DEBUG_LIGHTING, t: 'Lighting' },
-                        { v: pc.SHADERTYPE_DEBUG_UV0, t: 'UV0' }
+                        { v: pc.SHADERPASS_FORWARD, t: 'Normal' },
+                        { v: pc.SHADERPASS_ALBEDO, t: 'Albedo' },
+                        { v: pc.SHADERPASS_OPACITY, t: 'Opacity' },
+                        { v: pc.SHADERPASS_WORLDNORMAL, t: 'World Normal' },
+                        { v: pc.SHADERPASS_SPECULARITY, t: 'Specularity' },
+                        { v: pc.SHADERPASS_GLOSS, t: 'Gloss' },
+                        { v: pc.SHADERPASS_METALNESS, t: 'Metalness' },
+                        { v: pc.SHADERPASS_AO, t: 'AO' },
+                        { v: pc.SHADERPASS_EMISSION, t: 'Emission' },
+                        { v: pc.SHADERPASS_LIGHTING, t: 'Lighting' },
+                        { v: pc.SHADERPASS_UV0, t: 'UV0' }
                     ]} />
                 </LabelGroup>}
             </Panel>
@@ -93,7 +93,7 @@ class MultiViewExample {
                     app.start();
 
                     data.set('settings', {
-                        shaderPassName: pc.SHADERTYPE_FORWARD
+                        shaderPassName: pc.SHADERPASS_FORWARD
                     });
 
                     // get the instance of the chess board and set up with render component
@@ -168,7 +168,7 @@ class MultiViewExample {
 
                     // handle HUD changes - update the debug mode on the top camera
                     data.on('*:set', (path: string, value: any) => {
-                        cameraTop.camera.setShaderPassName(value);
+                        cameraTop.camera.setShaderPass(value);
                     });
 
                     // update function called once per frame

--- a/src/framework/components/camera/component.js
+++ b/src/framework/components/camera/component.js
@@ -135,7 +135,7 @@ class CameraComponent extends Component {
      *
      * Additionally, a new name can be specified, which creates a new shader pass with the given
      * name. The name provided can only use alphanumeric characters and underscores. When a shader
-     * is compiled for the new pass, a define is added to the shader. For example if the name is
+     * is compiled for the new pass, a define is added to the shader. For example, if the name is
      * 'custom_rendering', the define 'CUSTOM_RENDERING_PASS' is added to the shader, allowing the
      * shader code to conditionally execute code only when that shader pass is active.
      *

--- a/src/framework/components/camera/component.js
+++ b/src/framework/components/camera/component.js
@@ -145,7 +145,7 @@ class CameraComponent extends Component {
      * callback can modify the shader generation options specifically for this shader pass.
      *
      * ```javascript
-     * var shaderPassId = camera.setShaderPassName('custom_rendering');
+     * const shaderPassId = camera.setShaderPassName('custom_rendering');
      *
      * material.onUpdateShader = function (options) {
      *    if (options.pass === shaderPassId) {

--- a/src/framework/components/camera/component.js
+++ b/src/framework/components/camera/component.js
@@ -119,19 +119,19 @@ class CameraComponent extends Component {
      * Sets the name of the shader pass the camera will use when rendering.
      *
      * @param {string} name - The name of the shader pass. Defaults to undefined, which is
-     * equivalent to {@link SHADERTYPE_FORWARD}. Can be:
+     * equivalent to {@link SHADERPASS_FORWARD}. Can be:
      *
-     * - {@link SHADERTYPE_FORWARD}
-     * - {@link SHADERTYPE_DEBUG_ALBEDO}
-     * - {@link SHADERTYPE_DEBUG_OPACITY}
-     * - {@link SHADERTYPE_DEBUG_WORLDNORMAL}
-     * - {@link SHADERTYPE_DEBUG_SPECULARITY}
-     * - {@link SHADERTYPE_DEBUG_GLOSS}
-     * - {@link SHADERTYPE_DEBUG_METALNESS}
-     * - {@link SHADERTYPE_DEBUG_AO}
-     * - {@link SHADERTYPE_DEBUG_EMISSION}
-     * - {@link SHADERTYPE_DEBUG_LIGHTING}
-     * - {@link SHADERTYPE_DEBUG_UV0}
+     * - {@link SHADERPASS_FORWARD}
+     * - {@link SHADERPASS_ALBEDO}
+     * - {@link SHADERPASS_OPACITY}
+     * - {@link SHADERPASS_WORLDNORMAL}
+     * - {@link SHADERPASS_SPECULARITY}
+     * - {@link SHADERPASS_GLOSS}
+     * - {@link SHADERPASS_METALNESS}
+     * - {@link SHADERPASS_AO}
+     * - {@link SHADERPASS_EMISSION}
+     * - {@link SHADERPASS_LIGHTING}
+     * - {@link SHADERPASS_UV0}
      *
      * Additionally, a new name can be specified, which creates a new shader pass with the given
      * name. The name provided can only use alphanumeric characters and underscores. When a shader
@@ -145,7 +145,7 @@ class CameraComponent extends Component {
      * callback can modify the shader generation options specifically for this shader pass.
      *
      * ```javascript
-     * const shaderPassId = camera.setShaderPassName('custom_rendering');
+     * const shaderPassId = camera.setShaderPass('custom_rendering');
      *
      * material.onUpdateShader = function (options) {
      *    if (options.pass === shaderPassId) {
@@ -158,7 +158,7 @@ class CameraComponent extends Component {
      *
      * @returns {number} The id of the shader pass.
      */
-    setShaderPassName(name) {
+    setShaderPass(name) {
         const shaderPass =  ShaderPass.get(this.system.app.graphicsDevice);
         const shaderPassInfo = name ? shaderPass.allocate(name, {
             isForward: true
@@ -173,7 +173,7 @@ class CameraComponent extends Component {
      *
      * @returns {string} The name of the shader pass, or undefined if no shader pass is set.
      */
-    getShaderPassName() {
+    getShaderPass() {
         return this._camera.shaderPassInfo?.name;
     }
 

--- a/src/framework/components/camera/component.js
+++ b/src/framework/components/camera/component.js
@@ -119,8 +119,7 @@ class CameraComponent extends Component {
      * Sets the name of the shader pass the camera will use when rendering.
      *
      * @param {string} name - The name of the shader pass. Defaults to undefined, which is
-     * equivalent to {@link SHADERTYPE_FORWARD}.
-     * Can be:
+     * equivalent to {@link SHADERTYPE_FORWARD}. Can be:
      *
      * - {@link SHADERTYPE_FORWARD}
      * - {@link SHADERTYPE_DEBUG_ALBEDO}
@@ -139,6 +138,25 @@ class CameraComponent extends Component {
      * is compiled for the new pass, a define is added to the shader. For example if the name is
      * 'custom_rendering', the define 'CUSTOM_RENDERING_PASS' is added to the shader, allowing the
      * shader code to conditionally execute code only when that shader pass is active.
+     *
+     * Another instance where this approach may prove useful is when a camera needs to render a more
+     * cost-effective version of shaders, such as when creating a reflection texture. To accomplish
+     * this, a callback on the material that triggers during shader compilation can be used. This
+     * callback can modify the shader generation options specifically for this shader pass.
+     *
+     * ```javascript
+     * var shaderPassId = camera.setShaderPassName('custom_rendering');
+     *
+     * material.onUpdateShader = function (options) {
+     *    if (options.pass === shaderPassId) {
+     *        options.litOptions.normalMapEnabled = false;
+     *        options.litOptions.useSpecular = false;
+     *    }
+     *    return options;
+     * };
+     * ```
+     *
+     * @returns {number} The id of the shader pass.
      */
     setShaderPassName(name) {
         const shaderPass =  ShaderPass.get(this.system.app.graphicsDevice);
@@ -146,6 +164,8 @@ class CameraComponent extends Component {
             isForward: true
         }) : null;
         this._camera.shaderPassInfo = shaderPassInfo;
+
+        return shaderPassInfo.index;
     }
 
     /**

--- a/src/scene/camera.js
+++ b/src/scene/camera.js
@@ -24,6 +24,11 @@ const _frustumPoints = [new Vec3(), new Vec3(), new Vec3(), new Vec3(), new Vec3
  * @ignore
  */
 class Camera {
+    /**
+     * @type {import('./shader-pass.js').ShaderPassInfo|null}
+     */
+    shaderPassInfo;
+
     constructor() {
         this._aspectRatio = 16 / 9;
         this._aspectRatioMode = ASPECT_AUTO;
@@ -418,6 +423,8 @@ class Camera {
         this.aperture = other.aperture;
         this.shutter = other.shutter;
         this.sensitivity = other.sensitivity;
+
+        this.shaderPassInfo = other.shaderPassInfo;
 
         this._projMatDirty = true;
 

--- a/src/scene/constants.js
+++ b/src/scene/constants.js
@@ -658,98 +658,77 @@ export const SHADER_SHADOW = 4;
  *
  * @type {string}
  */
-export const SHADERTYPE_FORWARD = 'forward';
-
-/**
- * Shader that performs depth rendering.
- *
- * @type {string}
- */
-export const SHADERTYPE_DEPTH = 'depth';
-
-/**
- * Shader used for picking.
- *
- * @type {string}
- */
-export const SHADERTYPE_PICK = 'pick';
-
-/**
- * Shader used for rendering shadow textures.
- *
- * @type {string}
- */
-export const SHADERTYPE_SHADOW = 'shadow';
+export const SHADERPASS_FORWARD = 'forward';
 
 /**
  * Shader used for debug rendering of albedo.
  *
  * @type {string}
  */
-export const SHADERTYPE_DEBUG_ALBEDO = 'debug_albedo';
+export const SHADERPASS_ALBEDO = 'debug_albedo';
 
 /**
  * Shader used for debug rendering of world normal.
  *
  * @type {string}
  */
-export const SHADERTYPE_DEBUG_WORLDNORMAL = 'debug_world_normal';
+export const SHADERPASS_WORLDNORMAL = 'debug_world_normal';
 
 /**
  * Shader used for debug rendering of opacity.
  *
  * @type {string}
  */
-export const SHADERTYPE_DEBUG_OPACITY = 'debug_opacity';
+export const SHADERPASS_OPACITY = 'debug_opacity';
 
 /**
  * Shader used for debug rendering of specularity.
  *
  * @type {string}
  */
-export const SHADERTYPE_DEBUG_SPECULARITY = 'debug_specularity';
+export const SHADERPASS_SPECULARITY = 'debug_specularity';
 
 /**
  * Shader used for debug rendering of gloss.
  *
  * @type {string}
  */
-export const SHADERTYPE_DEBUG_GLOSS = 'debug_gloss';
+export const SHADERPASS_GLOSS = 'debug_gloss';
 
 /**
  * Shader used for debug rendering of metalness.
  *
  * @type {string}
  */
-export const SHADERTYPE_DEBUG_METALNESS = 'debug_metalness';
+export const SHADERPASS_METALNESS = 'debug_metalness';
 
 /**
  * Shader used for debug rendering of ao.
  *
  * @type {string}
  */
-export const SHADERTYPE_DEBUG_AO = 'debug_ao';
+export const SHADERPASS_AO = 'debug_ao';
 
 /**
  * Shader used for debug rendering of emission.
  *
  * @type {string}
  */
-export const SHADERTYPE_DEBUG_EMISSION = 'debug_emission';
+export const SHADERPASS_EMISSION = 'debug_emission';
 
 /**
  * Shader used for debug rendering of lighting.
  *
  * @type {string}
  */
-export const SHADERTYPE_DEBUG_LIGHTING = 'debug_lighting';
+export const SHADERPASS_LIGHTING = 'debug_lighting';
 
 /**
  * Shader used for debug rendering of UV0 texture coordinates.
  *
  * @type {string}
  */
-export const SHADERTYPE_DEBUG_UV0 = 'debug_uv0';
+export const SHADERPASS_UV0 = 'debug_uv0';
 
 /**
  * This mode renders a sprite as a simple quad.

--- a/src/scene/constants.js
+++ b/src/scene/constants.js
@@ -682,6 +682,76 @@ export const SHADERTYPE_PICK = 'pick';
 export const SHADERTYPE_SHADOW = 'shadow';
 
 /**
+ * Shader used for debug rendering of albedo.
+ *
+ * @type {string}
+ */
+export const SHADERTYPE_DEBUG_ALBEDO = 'debug_albedo';
+
+/**
+ * Shader used for debug rendering of world normal.
+ *
+ * @type {string}
+ */
+export const SHADERTYPE_DEBUG_WORLDNORMAL = 'debug_world_normal';
+
+/**
+ * Shader used for debug rendering of opacity.
+ *
+ * @type {string}
+ */
+export const SHADERTYPE_DEBUG_OPACITY = 'debug_opacity';
+
+/**
+ * Shader used for debug rendering of specularity.
+ *
+ * @type {string}
+ */
+export const SHADERTYPE_DEBUG_SPECULARITY = 'debug_specularity';
+
+/**
+ * Shader used for debug rendering of gloss.
+ *
+ * @type {string}
+ */
+export const SHADERTYPE_DEBUG_GLOSS = 'debug_gloss';
+
+/**
+ * Shader used for debug rendering of metalness.
+ *
+ * @type {string}
+ */
+export const SHADERTYPE_DEBUG_METALNESS = 'debug_metalness';
+
+/**
+ * Shader used for debug rendering of ao.
+ *
+ * @type {string}
+ */
+export const SHADERTYPE_DEBUG_AO = 'debug_ao';
+
+/**
+ * Shader used for debug rendering of emission.
+ *
+ * @type {string}
+ */
+export const SHADERTYPE_DEBUG_EMISSION = 'debug_emission';
+
+/**
+ * Shader used for debug rendering of lighting.
+ *
+ * @type {string}
+ */
+export const SHADERTYPE_DEBUG_LIGHTING = 'debug_lighting';
+
+/**
+ * Shader used for debug rendering of UV0 texture coordinates.
+ *
+ * @type {string}
+ */
+export const SHADERTYPE_DEBUG_UV0 = 'debug_uv0';
+
+/**
  * This mode renders a sprite as a simple quad.
  *
  * @type {number}

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -1100,12 +1100,15 @@ class ForwardRenderer extends Renderer {
             // has flipY enabled
             const flipFaces = !!(camera.camera._flipFaces ^ renderAction?.renderTarget?.flipY);
 
+            // shader pass - use setting from camera if available, otherwise use layer setting
+            const shaderPass = camera.camera.shaderPassInfo?.index ?? layer.shaderPass;
+
             const draws = this._forwardDrawCalls;
             this.renderForward(camera.camera,
                                visible.list,
                                visible.length,
                                layer._splitLights,
-                               layer.shaderPass,
+                               shaderPass,
                                layer.cullingMask,
                                layer.onDrawCall,
                                layer,

--- a/src/scene/shader-lib/chunks/chunks.js
+++ b/src/scene/shader-lib/chunks/chunks.js
@@ -27,6 +27,8 @@ import cookiePS from './lit/frag/cookie.js';
 import cubeMapProjectBoxPS from './lit/frag/cubeMapProjectBox.js';
 import cubeMapProjectNonePS from './lit/frag/cubeMapProjectNone.js';
 import cubeMapRotatePS from './lit/frag/cubeMapRotate.js';
+import debugOutputPS from './lit/frag/debug-output.js';
+import debugProcessFrontendPS from './lit/frag/debug-process-frontend.js';
 import decodePS from './common/frag/decode.js';
 import detailModesPS from './standard/frag/detailModes.js';
 import diffusePS from './standard/frag/diffuse.js';
@@ -233,6 +235,8 @@ const shaderChunks = {
     cubeMapProjectBoxPS,
     cubeMapProjectNonePS,
     cubeMapRotatePS,
+    debugOutputPS,
+    debugProcessFrontendPS,
     detailModesPS,
     diffusePS,
     diffuseDetailMapPS,

--- a/src/scene/shader-lib/chunks/lit/frag/debug-output.js
+++ b/src/scene/shader-lib/chunks/lit/frag/debug-output.js
@@ -1,0 +1,37 @@
+export default /* glsl */`
+#ifdef DEBUG_ALBEDO_PASS
+gl_FragColor = vec4(litShaderArgs.albedo , 1.0);
+#endif
+
+#ifdef DEBUG_UV0_PASS
+gl_FragColor = vec4(litShaderArgs.albedo , 1.0);
+#endif
+
+#ifdef DEBUG_WORLD_NORMAL_PASS
+gl_FragColor = vec4(litShaderArgs.worldNormal * 0.5 + 0.5, 1.0);
+#endif
+
+#ifdef DEBUG_OPACITY_PASS
+gl_FragColor = vec4(vec3(litShaderArgs.opacity) , 1.0);
+#endif
+
+#ifdef DEBUG_SPECULARITY_PASS
+gl_FragColor = vec4(litShaderArgs.specularity, 1.0);
+#endif
+
+#ifdef DEBUG_GLOSS_PASS
+gl_FragColor = vec4(vec3(litShaderArgs.gloss) , 1.0);
+#endif
+
+#ifdef DEBUG_METALNESS_PASS
+gl_FragColor = vec4(vec3(litShaderArgs.metalness) , 1.0);
+#endif
+
+#ifdef DEBUG_AO_PASS
+gl_FragColor = vec4(vec3(litShaderArgs.ao) , 1.0);
+#endif
+
+#ifdef DEBUG_EMISSION_PASS
+gl_FragColor = vec4(litShaderArgs.emission, 1.0);
+#endif
+`;

--- a/src/scene/shader-lib/chunks/lit/frag/debug-process-frontend.js
+++ b/src/scene/shader-lib/chunks/lit/frag/debug-process-frontend.js
@@ -1,0 +1,9 @@
+export default /* glsl */`
+#ifdef DEBUG_LIGHTING_PASS
+litShaderArgs.albedo = vec3(0.5);
+#endif
+
+#ifdef DEBUG_UV0_PASS
+litShaderArgs.albedo = vec3(vUv0, 0);
+#endif
+`;

--- a/src/scene/shader-lib/programs/basic.js
+++ b/src/scene/shader-lib/programs/basic.js
@@ -47,10 +47,10 @@ const basic = {
         }
 
         const shaderPassInfo = ShaderPass.get(device).getByIndex(options.pass);
-        const shaderPassDefine = shaderPassInfo.shaderDefine;
+        const shaderPassDefines = shaderPassInfo.shaderDefines;
 
         // GENERATE VERTEX SHADER
-        let vshader = shaderPassDefine;
+        let vshader = shaderPassDefines;
 
         // VERTEX SHADER DECLARATIONS
         vshader += shaderChunks.transformDeclVS;
@@ -102,7 +102,7 @@ const basic = {
         vshader += end();
 
         // GENERATE FRAGMENT SHADER
-        let fshader = shaderPassDefine;
+        let fshader = shaderPassDefines;
 
         // FRAGMENT SHADER DECLARATIONS
         if (options.vertexColors) {

--- a/src/scene/shader-lib/programs/lit-shader.js
+++ b/src/scene/shader-lib/programs/lit-shader.js
@@ -435,13 +435,13 @@ class LitShader {
             }
         });
 
-        const shaderPassDefine = this.shaderPassInfo.shaderDefine;
-        this.vshader = shaderPassDefine + this.varyings + code;
+        const shaderPassDefines = this.shaderPassInfo.shaderDefines;
+        this.vshader = shaderPassDefines + this.varyings + code;
     }
 
     _fsGetBeginCode() {
 
-        let code = this.shaderPassInfo.shaderDefine;
+        let code = this.shaderPassInfo.shaderDefines;
 
         for (let i = 0; i < this.defines.length; i++) {
             code += `#define ${this.defines[i]}\n`;
@@ -1413,6 +1413,7 @@ class LitShader {
             backend.append("    gl_FragColor = applyMsdf(gl_FragColor);");
         }
 
+        backend.append(chunks.debugOutputPS);
 
         if (hasPointLights) {
             func.prepend(chunks.lightDirPointPS);
@@ -1434,6 +1435,9 @@ class LitShader {
 
         const backendCode = `void evaluateBackend(LitShaderArguments litShaderArgs) {\n${backend.code}\n}`;
         func.append(backendCode);
+
+        code.append(chunks.debugProcessFrontendPS);
+
         code.append("    evaluateBackend(litShaderArgs);");
 
         code.append(end());

--- a/src/scene/shader-pass.js
+++ b/src/scene/shader-pass.js
@@ -35,10 +35,10 @@ class ShaderPassInfo {
         // assign options as properties to this object
         Object.assign(this, options);
 
-        this.initShaderDefine();
+        this.initShaderDefines();
     }
 
-    initShaderDefine() {
+    initShaderDefines() {
 
         let keyword;
         if (this.isShadow) {
@@ -51,8 +51,13 @@ class ShaderPassInfo {
             keyword = 'PICK';
         }
 
-        keyword ??= this.name.toUpperCase();
-        this.shaderDefine = `#define ${keyword}_PASS\n`;
+        // define based on on the options based name
+        const define1 = keyword ? `#define ${keyword}_PASS\n` : '';
+
+        // define based on the name
+        const define2 = `#define ${this.name.toUpperCase()}_PASS\n`;
+
+        this.shaderDefines = define1 + define2;
     }
 }
 
@@ -144,4 +149,4 @@ class ShaderPass {
     }
 }
 
-export { ShaderPass };
+export { ShaderPass, ShaderPassInfo };


### PR DESCRIPTION
Functionality, allowing a name of the shader pass to be set on camera, to be used for its rendering. There are multiple shader debug passes predefined, allowing debug rendering functionality.

Custom shader pass names can also be used. Possible use cases is where for example user wants to use cheaper shaders when rendering to reflection texture. They can use the shader define to skip some processing in some shader chunks. Alternatively, they can modify StandardMaterialOptions in a callback to disable shader features.

There are two new shader chunks:
- debug-output.js - inserted at the end of the generated shader, outputs data that are written to color render target based on the shader pass define
- debug-process-frontend - inserted before the front end data are passed to backend, allowing those to be modified. For example to render 'Lighting', the albedo is set to mid gray color here.

### New API:
![Screenshot 2023-04-21 at 16 45 06](https://user-images.githubusercontent.com/59932779/233679233-4d21ad8a-ec97-45c0-b076-78368e8d4998.png)
![Screenshot 2023-04-21 at 16 45 22](https://user-images.githubusercontent.com/59932779/233679244-27c30ce0-111b-442c-a994-7507859286a9.png)

### Example:
Multi-View example updated with dropdown (not all options are visible and scrolling is needing, which is not obvious)

![Screenshot 2023-04-21 at 14 42 59](https://user-images.githubusercontent.com/59932779/233651413-5c6f1033-5453-46be-a5d0-21ba85acd6b6.png)

https://user-images.githubusercontent.com/59932779/233651429-4411cb7f-de5c-4b36-ac8d-bd02c67668de.mov


