### PR TITLE
Rename the uniform name of the picker shader variant to limit conflicts

### DIFF
--- a/src/framework/graphics/picker.js
+++ b/src/framework/graphics/picker.js
@@ -191,7 +191,7 @@ class Picker {
 
         const device = this.device;
         const self = this;
-        const pickColorId = device.scope.resolve('uColor');
+        const pickColorId = device.scope.resolve('uPickColorId');
 
         // camera
         this.cameraEntity = new Entity();

--- a/src/scene/shader-lib/programs/lit-shader.js
+++ b/src/scene/shader-lib/programs/lit-shader.js
@@ -452,13 +452,13 @@ class LitShader {
 
     _fsGetPickPassCode() {
         let code = this._fsGetBeginCode();
-        code += "uniform vec4 uColor;\n";
+        code += "uniform vec4 uPickColorId;\n";
         code += this.varyings;
         code += this.frontendDecl;
         code += this.frontendCode;
         code += begin();
         code += this.frontendFunc;
-        code += "    gl_FragColor = uColor;\n";
+        code += "    gl_FragColor = uPickColorId;\n";
         code += end();
         return code;
     }


### PR DESCRIPTION
Just a rename to avoid conflict with uniform of the same name users often add to shaders.