### PR TITLE
Add null check before unbinding events sprite animation clip

### DIFF
--- a/src/framework/components/sprite/sprite-animation-clip.js
+++ b/src/framework/components/sprite/sprite-animation-clip.js
@@ -285,6 +285,10 @@ class SpriteAnimationClip extends EventHandler {
     }
 
     _unbindSpriteAsset(asset) {
+        if (!asset) {
+            return;
+        }
+
         asset.off('load', this._onSpriteAssetLoad, this);
         asset.off('remove', this._onSpriteAssetRemove, this);
 


### PR DESCRIPTION
Fixes bug where a sprite component in the Editor can have a 'missing' sprite asset reference where it's referencing a deleted sprite asset.

<img width="272" alt="image" src="https://user-images.githubusercontent.com/16639049/234288257-052356c2-4eb7-4317-a8e1-b2ba0016820e.png">


This means that `this._spriteAsset` is not null but won't return an asset when it tries to unbind events when destroyed.

Example project: https://playcanvas.com/project/1066480/overview/missing-sprite-crash

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
