### PR TITLE
Limit allowed samples on WebGPU when using multisampled render target

### DIFF
--- a/src/platform/graphics/render-target.js
+++ b/src/platform/graphics/render-target.js
@@ -113,11 +113,12 @@ class RenderTarget {
         Debug.assert(device, "Failed to obtain the device, colorBuffer nor depthBuffer store it.");
         this._device = device;
 
-        this._samples = Math.min(options.samples ?? 1, this._device.maxSamples);
+        const { maxSamples } = this._device;
+        this._samples = Math.min(options.samples ?? 1, maxSamples);
 
         // WebGPU only supports values of 1 or 4 for samples
         if (device.isWebGPU) {
-            this._samples = this._samples > 1 ? 4 : 1;
+            this._samples = this._samples > 1 ? maxSamples : 1;
         }
 
         this.autoResolve = options.autoResolve ?? true;

--- a/src/platform/graphics/render-target.js
+++ b/src/platform/graphics/render-target.js
@@ -115,6 +115,11 @@ class RenderTarget {
 
         this._samples = Math.min(options.samples ?? 1, this._device.maxSamples);
 
+        // WebGPU only supports values of 1 or 4 for samples
+        if (device.isWebGPU) {
+            this._samples = this._samples > 1 ? 4 : 1;
+        }
+
         this.autoResolve = options.autoResolve ?? true;
 
         // use specified name, otherwise get one from color or depth buffer


### PR DESCRIPTION
WebGPU only supports 1 or 4 samples, enforce this limitation