### PR TITLE
Temporarily disable ParticleSystems on WebGPU to avoid errors

### DIFF
--- a/examples/src/examples/graphics/render-to-texture.tsx
+++ b/examples/src/examples/graphics/render-to-texture.tsx
@@ -3,6 +3,7 @@ import * as pc from '../../../../';
 class RenderToTextureExample {
     static CATEGORY = 'Graphics';
     static NAME = 'Render to Texture';
+    static WEBGPU_ENABLED = true;
 
     example(canvas: HTMLCanvasElement, deviceType: string): void {
 

--- a/src/framework/components/particle-system/component.js
+++ b/src/framework/components/particle-system/component.js
@@ -760,6 +760,11 @@ class ParticleSystemComponent extends Component {
             }
         }
 
+        // WebGPU does not support particle systems, ignore them
+        if (this.system.app.graphicsDevice.disableParticleSystem) {
+            return;
+        }
+
         if (!this.emitter) {
             let mesh = data.mesh;
 

--- a/src/framework/components/particle-system/system.js
+++ b/src/framework/components/particle-system/system.js
@@ -213,7 +213,7 @@ class ParticleSystemComponentSystem extends ComponentSystem {
 
                 if (data.enabled && entity.enabled) {
                     const emitter = entity.particlesystem.emitter;
-                    if (!emitter.meshInstance.visible) continue;
+                    if (!emitter?.meshInstance.visible) continue;
 
                     // Bake ambient and directional lighting into one ambient cube
                     // TODO: only do if lighting changed

--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -86,6 +86,9 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
 
     initDeviceCaps() {
 
+        // temporarily disabled functionality which is not supported to avoid errors
+        this.disableParticleSystem = true;
+
         const limits = this.gpuAdapter.limits;
 
         this.precision = 'highp';


### PR DESCRIPTION
- particle systems are currently not supported on WebGPU - disable them to avoid errors if those are in the scene
- enabled RenderToTexture example for WebGPU, as now it runs (apart from particles)