### PR TITLE
Revert rename of the uniform used by the Picker shaders

### DIFF
--- a/src/framework/graphics/picker.js
+++ b/src/framework/graphics/picker.js
@@ -191,7 +191,7 @@ class Picker {
 
         const device = this.device;
         const self = this;
-        const pickColorId = device.scope.resolve('uPickColorId');
+        const pickColorId = device.scope.resolve('uColor');
 
         // camera
         this.cameraEntity = new Entity();

--- a/src/scene/shader-lib/programs/lit-shader.js
+++ b/src/scene/shader-lib/programs/lit-shader.js
@@ -454,14 +454,14 @@ class LitShader {
 
     _fsGetPickPassCode() {
         let code = this._fsGetBeginCode();
-        code += "uniform vec4 uPickColorId;\n";
+        code += "uniform vec4 uColor;\n";
         code += this.varyings;
         code += this.varyingDefines;
         code += this.frontendDecl;
         code += this.frontendCode;
         code += begin();
         code += this.frontendFunc;
-        code += "    gl_FragColor = uPickColorId;\n";
+        code += "    gl_FragColor = uColor;\n";
         code += end();
         return code;
     }


### PR DESCRIPTION
revert of https://github.com/playcanvas/engine/pull/5266 as Editor depends on the Basic shader for some picker meshes which uses generic uColor