### PR TITLE
[Fix] Apply VMS blur to spot lights when clustered lighting is off

### DIFF
--- a/src/scene/renderer/shadow-renderer-directional.js
+++ b/src/scene/renderer/shadow-renderer-directional.js
@@ -230,7 +230,7 @@ class ShadowRendererDirectional {
 
         renderPass.after = () => {
             // after the pass is done, apply VSM blur if needed
-            this.shadowRenderer.renderVms(light, camera);
+            this.shadowRenderer.renderVsm(light, camera);
         };
 
         // setup render pass using any of the cameras, they all have the same pass related properties

--- a/src/scene/renderer/shadow-renderer-local.js
+++ b/src/scene/renderer/shadow-renderer-local.js
@@ -156,7 +156,7 @@ class ShadowRendererLocal {
         if (applyVsm) {
             renderPass.after = () => {
                 // after the pass is done, apply VSM blur if needed
-                this.shadowRenderer.renderVms(light, shadowCamera);
+                this.shadowRenderer.renderVsm(light, shadowCamera);
             };
         }
 

--- a/src/scene/renderer/shadow-renderer-local.js
+++ b/src/scene/renderer/shadow-renderer-local.js
@@ -141,7 +141,7 @@ class ShadowRendererLocal {
         }
     }
 
-    setupNonClusteredFaceRenderPass(frameGraph, light, face) {
+    setupNonClusteredFaceRenderPass(frameGraph, light, face, applyVsm) {
 
         const shadowCamera = this.shadowRenderer.prepareFace(light, null, face);
         const renderPass = new RenderPass(this.device, () => {
@@ -151,6 +151,14 @@ class ShadowRendererLocal {
         // clear the render target as well, as it contains a single shadow map
         this.shadowRenderer.setupRenderPass(renderPass, shadowCamera, true);
         DebugHelper.setName(renderPass, `SpotShadow-${light._node.name}`);
+
+        // apply vsm
+        if (applyVsm) {
+            renderPass.after = () => {
+                // after the pass is done, apply VSM blur if needed
+                this.shadowRenderer.renderVms(light, shadowCamera);
+            };
+        }
 
         frameGraph.addRenderPass(renderPass);
     }
@@ -166,7 +174,7 @@ class ShadowRendererLocal {
             const light = lightsSpot[i];
 
             if (this.shadowRenderer.needsShadowRendering(light)) {
-                this.setupNonClusteredFaceRenderPass(frameGraph, light, 0);
+                this.setupNonClusteredFaceRenderPass(frameGraph, light, 0, true);
             }
         }
 
@@ -179,7 +187,7 @@ class ShadowRendererLocal {
                 // create render pass per face
                 const faceCount = light.numShadowFaces;
                 for (let face = 0; face < faceCount; face++) {
-                    this.setupNonClusteredFaceRenderPass(frameGraph, light, face);
+                    this.setupNonClusteredFaceRenderPass(frameGraph, light, face, false);
                 }
             }
         }

--- a/src/scene/renderer/shadow-renderer.js
+++ b/src/scene/renderer/shadow-renderer.js
@@ -473,11 +473,11 @@ class ShadowRenderer {
             }
 
             // apply vsm
-            this.renderVms(light, camera);
+            this.renderVsm(light, camera);
         }
     }
 
-    renderVms(light, camera) {
+    renderVsm(light, camera) {
 
         // VSM blur if light supports vsm (directional and spot in general)
         if (light._isVsm && light._vsmBlurSize > 1) {


### PR DESCRIPTION
Fixes https://github.com/playcanvas/engine/issues/5286

- this got removed during a recent refactoring of local lights to use render passes