### PR TITLE
Improvements to texture upload / cubemap support on WebGPU

### DIFF
--- a/examples/src/examples/graphics/clustered-omni-shadows.tsx
+++ b/examples/src/examples/graphics/clustered-omni-shadows.tsx
@@ -7,7 +7,6 @@ import { Observer } from '@playcanvas/observer';
 class ClusteredOmniShadowsExample {
     static CATEGORY = 'Graphics';
     static NAME = 'Clustered Omni Shadows';
-    static WEBGPU_ENABLED = true;
 
     controls(data: Observer) {
         return <>
@@ -95,7 +94,7 @@ class ClusteredOmniShadowsExample {
                 data.set('settings', {
                     shadowAtlasResolution: 1300,     // shadow map resolution storing all shadows
                     shadowType: pc.SHADOW_PCF3,      // shadow filter type
-                    shadowsEnabled: false,
+                    shadowsEnabled: true,
                     cookiesEnabled: true
                 });
 

--- a/examples/src/examples/graphics/clustered-omni-shadows.tsx
+++ b/examples/src/examples/graphics/clustered-omni-shadows.tsx
@@ -7,6 +7,7 @@ import { Observer } from '@playcanvas/observer';
 class ClusteredOmniShadowsExample {
     static CATEGORY = 'Graphics';
     static NAME = 'Clustered Omni Shadows';
+    static WEBGPU_ENABLED = true;
 
     controls(data: Observer) {
         return <>
@@ -94,7 +95,7 @@ class ClusteredOmniShadowsExample {
                 data.set('settings', {
                     shadowAtlasResolution: 1300,     // shadow map resolution storing all shadows
                     shadowType: pc.SHADOW_PCF3,      // shadow filter type
-                    shadowsEnabled: true,
+                    shadowsEnabled: false,
                     cookiesEnabled: true
                 });
 
@@ -183,7 +184,11 @@ class ClusteredOmniShadowsExample {
                         assets.xmas_posx.id, assets.xmas_negx.id,
                         assets.xmas_posy.id, assets.xmas_negy.id,
                         assets.xmas_posz.id, assets.xmas_negz.id
-                    ]
+                    ],
+
+                    // don't generate mipmaps for the cookie cubemap if clustered lighting is used,
+                    // as only top levels are copied to the cookie atlas.
+                    mipmaps: !app.scene.clusteredLightingEnabled
                 });
                 cubemapAsset.loadFaces = true;
                 app.assets.add(cubemapAsset);

--- a/src/core/debug.js
+++ b/src/core/debug.js
@@ -89,11 +89,12 @@ class Debug {
      * Info message logged no more than once.
      *
      * @param {string} message - The message to log.
+     * @param {...*} args - The values to be written to the log.
      */
-    static logOnce(message) {
+    static logOnce(message, ...args) {
         if (!Debug._loggedMessages.has(message)) {
             Debug._loggedMessages.add(message);
-            console.log(message);
+            console.log(message, ...args);
         }
     }
 
@@ -110,11 +111,12 @@ class Debug {
      * Warning message logged no more than once.
      *
      * @param {string} message - The message to log.
+     * @param {...*} args - The values to be written to the log.
      */
-    static warnOnce(message) {
+    static warnOnce(message, ...args) {
         if (!Debug._loggedMessages.has(message)) {
             Debug._loggedMessages.add(message);
-            console.warn(message);
+            console.warn(message, ...args);
         }
     }
 
@@ -131,11 +133,12 @@ class Debug {
      * Error message logged no more than once.
      *
      * @param {string} message - The message to log.
+     * @param {...*} args - The values to be written to the log.
      */
-    static errorOnce(message) {
+    static errorOnce(message, ...args) {
         if (!Debug._loggedMessages.has(message)) {
             Debug._loggedMessages.add(message);
-            console.error(message);
+            console.error(message, ...args);
         }
     }
 

--- a/src/framework/handlers/cubemap.js
+++ b/src/framework/handlers/cubemap.js
@@ -170,6 +170,7 @@ class CubemapHandler {
                     width: faceTextures[0].width,
                     height: faceTextures[0].height,
                     format: format === PIXELFORMAT_RGB8 ? PIXELFORMAT_RGBA8 : format,
+                    mipmaps: assetData.mipmaps ?? true,
                     levels: faceLevels,
                     minFilter: assetData.hasOwnProperty('minFilter') ? assetData.minFilter : faceTextures[0].minFilter,
                     magFilter: assetData.hasOwnProperty('magFilter') ? assetData.magFilter : faceTextures[0].magFilter,

--- a/src/platform/graphics/texture.js
+++ b/src/platform/graphics/texture.js
@@ -309,6 +309,16 @@ class Texture {
     }
 
     /**
+     * Returns number of required mip levels for the texture based on its dimensions and parameters.
+     *
+     * @ignore
+     * @type {number}
+     */
+    get requiredMipLevels() {
+        return this.mipmaps ? Math.floor(Math.log2(Math.max(this.width, this.height))) + 1 : 1;
+    }
+
+    /**
      * The minification filter to be applied to the texture. Can be:
      *
      * - {@link FILTER_NEAREST}

--- a/src/platform/graphics/webgl/webgl-texture.js
+++ b/src/platform/graphics/webgl/webgl-texture.js
@@ -287,10 +287,10 @@ class WebglTexture {
         let mipObject;
         let resMult;
 
-        const requiredMipLevels = Math.log2(Math.max(texture._width, texture._height)) + 1;
+        const requiredMipLevels = texture.requiredMipLevels;
 
+        // Upload all existing mip levels. Initialize 0 mip anyway.
         while (texture._levels[mipLevel] || mipLevel === 0) {
-            // Upload all existing mip levels. Initialize 0 mip anyway.
 
             if (!texture._needsUpload && mipLevel === 0) {
                 mipLevel++;

--- a/src/platform/graphics/webgpu/webgpu-mipmap-renderer.js
+++ b/src/platform/graphics/webgpu/webgpu-mipmap-renderer.js
@@ -64,9 +64,15 @@ class WebgpuMipmapRenderer {
      */
     generate(webgpuTexture) {
 
+        // ignore texture with no mipmaps
+        const textureDescr = webgpuTexture.descr;
+        if (textureDescr.mipLevelCount <= 1) {
+            return;
+        }
+
         // not all types are currently supported
         if (webgpuTexture.texture.cubemap || webgpuTexture.texture.volume) {
-            Debug.warnOnce('WebGPU mipmap generation is not supported for cubemaps or volume textures.');
+            Debug.warnOnce('WebGPU mipmap generation is not supported for cubemaps or volume texture.', webgpuTexture.texture);
             return;
         }
 
@@ -77,7 +83,6 @@ class WebgpuMipmapRenderer {
         Debug.assert(!device.insideRenderPass);
 
         const wgpu = device.wgpu;
-        const textureDescr = webgpuTexture.descr;
 
         /** @type {import('./webgpu-shader.js').WebgpuShader} */
         const webgpuShader = this.shader.impl;

--- a/src/platform/graphics/webgpu/webgpu-texture.js
+++ b/src/platform/graphics/webgpu/webgpu-texture.js
@@ -297,7 +297,7 @@ class WebgpuTexture {
         const wgpu = device.wgpu;
 
         // upload texture data if any
-        var anyUploads = false;
+        let anyUploads = false;
         const requiredMipLevels = texture.requiredMipLevels;
         for (let mipLevel = 0; mipLevel < requiredMipLevels; mipLevel++) {
 


### PR DESCRIPTION
WebGPU device can handle cubemap loading / uploading data (without mipmap generation).

In ClusteredOmniShadows example, clustered omni cookies now work.

![Screenshot 2023-04-28 at 15 47 23](https://user-images.githubusercontent.com/59932779/235182064-86c2bb7b-38f9-468e-b0c1-0556c8b7f780.png)
