### PR TITLE
Glb container parse event

### DIFF
--- a/src/framework/parsers/glb-container-parser.js
+++ b/src/framework/parsers/glb-container-parser.js
@@ -20,6 +20,7 @@ class GlbContainerParser {
             if (err) {
                 callback(err);
             } else {
+                asset.fire('parse', asset);
                 GlbParser.parse(
                     this._getUrlWithoutParams(url.original),
                     path.extractPath(url.load),


### PR DESCRIPTION
This PR introduces change where `parse` event is fired on a container asset to indicate that data was downloaded and parsing is about to begin.

This functionality adds more control over loading process, where e.g. we can start loading low priority assets immediately after container asset has downloaded, without needing to wait for its parsing as well, in effect shortening total loading time.