### PR TITLE
Examples load envLighting without mipmaps

### DIFF
--- a/examples/src/examples/animation/blend-trees-1d.tsx
+++ b/examples/src/examples/animation/blend-trees-1d.tsx
@@ -23,7 +23,7 @@ class BlendTrees1DExample {
             'model': new pc.Asset('model', 'container', { url: '/static/assets/models/bitmoji.glb' }),
             'idleAnim': new pc.Asset('idleAnim', 'container', { url: '/static/assets/animations/bitmoji/idle.glb' }),
             'danceAnim': new pc.Asset('danceAnim', 'container', { url: '/static/assets/animations/bitmoji/win-dance.glb' }),
-            helipad: new pc.Asset('helipad-env-atlas', 'texture', { url: '/static/assets/cubemaps/helipad-env-atlas.png' }, { type: pc.TEXTURETYPE_RGBP }),
+            helipad: new pc.Asset('helipad-env-atlas', 'texture', { url: '/static/assets/cubemaps/helipad-env-atlas.png' }, { type: pc.TEXTURETYPE_RGBP, mipmaps: false }),
             'bloom': new pc.Asset('bloom', 'script', { url: '/static/scripts/posteffects/posteffect-bloom.js' })
         };
 

--- a/examples/src/examples/animation/blend-trees-2d-cartesian.tsx
+++ b/examples/src/examples/animation/blend-trees-2d-cartesian.tsx
@@ -98,7 +98,7 @@ class BlendTrees2DCartesianExample {
             'walkAnim': new pc.Asset('idleAnim', 'container', { url: '/static/assets/animations/bitmoji/walk.glb' }),
             'eagerAnim': new pc.Asset('idleAnim', 'container', { url: '/static/assets/animations/bitmoji/idle-eager.glb' }),
             'danceAnim': new pc.Asset('danceAnim', 'container', { url: '/static/assets/animations/bitmoji/win-dance.glb' }),
-            helipad: new pc.Asset('helipad-env-atlas', 'texture', { url: '/static/assets/cubemaps/helipad-env-atlas.png' }, { type: pc.TEXTURETYPE_RGBP }),
+            helipad: new pc.Asset('helipad-env-atlas', 'texture', { url: '/static/assets/cubemaps/helipad-env-atlas.png' }, { type: pc.TEXTURETYPE_RGBP, mipmaps: false }),
             'bloom': new pc.Asset('bloom', 'script', { url: '/static/scripts/posteffects/posteffect-bloom.js' })
         };
 

--- a/examples/src/examples/animation/blend-trees-2d-directional.tsx
+++ b/examples/src/examples/animation/blend-trees-2d-directional.tsx
@@ -89,7 +89,7 @@ class BlendTrees2DDirectionalExample {
             'walkAnim': new pc.Asset('idleAnim', 'container', { url: '/static/assets/animations/bitmoji/walk.glb' }),
             'jogAnim': new pc.Asset('idleAnim', 'container', { url: '/static/assets/animations/bitmoji/run.glb' }),
             'danceAnim': new pc.Asset('danceAnim', 'container', { url: '/static/assets/animations/bitmoji/win-dance.glb' }),
-            helipad: new pc.Asset('helipad-env-atlas', 'texture', { url: '/static/assets/cubemaps/helipad-env-atlas.png' }, { type: pc.TEXTURETYPE_RGBP }),
+            helipad: new pc.Asset('helipad-env-atlas', 'texture', { url: '/static/assets/cubemaps/helipad-env-atlas.png' }, { type: pc.TEXTURETYPE_RGBP, mipmaps: false }),
             'bloom': new pc.Asset('bloom', 'script', { url: '/static/scripts/posteffects/posteffect-bloom.js' })
         };
 

--- a/examples/src/examples/animation/events.tsx
+++ b/examples/src/examples/animation/events.tsx
@@ -10,7 +10,7 @@ class EventsExample {
         const assets = {
             'model': new pc.Asset('model', 'container', { url: '/static/assets/models/bitmoji.glb' }),
             'walkAnim': new pc.Asset('walkAnim', 'container', { url: '/static/assets/animations/bitmoji/walk.glb' }),
-            helipad: new pc.Asset('helipad-env-atlas', 'texture', { url: '/static/assets/cubemaps/helipad-env-atlas.png' }, { type: pc.TEXTURETYPE_RGBP }),
+            helipad: new pc.Asset('helipad-env-atlas', 'texture', { url: '/static/assets/cubemaps/helipad-env-atlas.png' }, { type: pc.TEXTURETYPE_RGBP, mipmaps: false }),
             'bloom': new pc.Asset('bloom', 'script', { url: '/static/scripts/posteffects/posteffect-bloom.js' })
         };
         const gfxOptions = {

--- a/examples/src/examples/animation/layer-masks.tsx
+++ b/examples/src/examples/animation/layer-masks.tsx
@@ -47,7 +47,7 @@ class LayerMasksExample {
             'idleEagerAnim': new pc.Asset('idleEagerAnim', 'container', { url: '/static/assets/animations/bitmoji/idle-eager.glb' }),
             'walkAnim': new pc.Asset('walkAnim', 'container', { url: '/static/assets/animations/bitmoji/walk.glb' }),
             'danceAnim': new pc.Asset('danceAnim', 'container', { url: '/static/assets/animations/bitmoji/win-dance.glb' }),
-            helipad: new pc.Asset('helipad-env-atlas', 'texture', { url: '/static/assets/cubemaps/helipad-env-atlas.png' }, { type: pc.TEXTURETYPE_RGBP }),
+            helipad: new pc.Asset('helipad-env-atlas', 'texture', { url: '/static/assets/cubemaps/helipad-env-atlas.png' }, { type: pc.TEXTURETYPE_RGBP, mipmaps: false }),
             'bloom': new pc.Asset('bloom', 'script', { url: '/static/scripts/posteffects/posteffect-bloom.js' })
         };
 

--- a/examples/src/examples/animation/locomotion.tsx
+++ b/examples/src/examples/animation/locomotion.tsx
@@ -37,7 +37,7 @@ class LocomotionExample {
                 'walkAnim': new pc.Asset('walkAnim', 'container', { url: '/static/assets/animations/bitmoji/walk.glb' }),
                 'jogAnim': new pc.Asset('jogAnim', 'container', { url: '/static/assets/animations/bitmoji/run.glb' }),
                 'jumpAnim': new pc.Asset('jumpAnim', 'container', { url: '/static/assets/animations/bitmoji/jump-flip.glb' }),
-                helipad: new pc.Asset('helipad-env-atlas', 'texture', { url: '/static/assets/cubemaps/helipad-env-atlas.png' }, { type: pc.TEXTURETYPE_RGBP }),
+                helipad: new pc.Asset('helipad-env-atlas', 'texture', { url: '/static/assets/cubemaps/helipad-env-atlas.png' }, { type: pc.TEXTURETYPE_RGBP, mipmaps: false }),
             };
 
             const gfxOptions = {

--- a/examples/src/examples/graphics/area-lights.tsx
+++ b/examples/src/examples/graphics/area-lights.tsx
@@ -15,7 +15,7 @@ class AreaLightsExample {
             'gloss': new pc.Asset('gloss', 'texture', { url: '/static/assets/textures/seaside-rocks01-gloss.jpg' }),
             'statue': new pc.Asset('statue', 'container', { url: '/static/assets/models/statue.glb' }),
             'luts': new pc.Asset('luts', 'json', { url: '/static/assets/json/area-light-luts.json' }),
-            helipad: new pc.Asset('helipad-env-atlas', 'texture', { url: '/static/assets/cubemaps/helipad-env-atlas.png' }, { type: pc.TEXTURETYPE_RGBP })
+            helipad: new pc.Asset('helipad-env-atlas', 'texture', { url: '/static/assets/cubemaps/helipad-env-atlas.png' }, { type: pc.TEXTURETYPE_RGBP, mipmaps: false })
         };
 
         const gfxOptions = {

--- a/examples/src/examples/graphics/area-picker.tsx
+++ b/examples/src/examples/graphics/area-picker.tsx
@@ -8,7 +8,7 @@ class AreaPickerExample {
 
         const assets = {
             'bloom': new pc.Asset('bloom', 'script', { url: '/static/scripts/posteffects/posteffect-bloom.js' }),
-            helipad: new pc.Asset('helipad-env-atlas', 'texture', { url: '/static/assets/cubemaps/helipad-env-atlas.png' }, { type: pc.TEXTURETYPE_RGBP }),
+            helipad: new pc.Asset('helipad-env-atlas', 'texture', { url: '/static/assets/cubemaps/helipad-env-atlas.png' }, { type: pc.TEXTURETYPE_RGBP, mipmaps: false }),
         };
 
         const gfxOptions = {

--- a/examples/src/examples/graphics/asset-viewer.tsx
+++ b/examples/src/examples/graphics/asset-viewer.tsx
@@ -21,7 +21,7 @@ class AssetViewerExample {
 
         const assets = {
             orbitCamera: new pc.Asset('script', 'script', { url: '/static/scripts/camera/orbit-camera.js' }),
-            helipad: new pc.Asset('helipad-env-atlas', 'texture', { url: '/static/assets/cubemaps/helipad-env-atlas.png' }, { type: pc.TEXTURETYPE_RGBP }),
+            helipad: new pc.Asset('helipad-env-atlas', 'texture', { url: '/static/assets/cubemaps/helipad-env-atlas.png' }, { type: pc.TEXTURETYPE_RGBP, mipmaps: false }),
             dish: new pc.Asset('dish', 'container', { url: '/static/assets/models/IridescentDishWithOlives.glb' }),
             mosquito: new pc.Asset('mosquito', 'container', { url: '/static/assets/models/MosquitoInAmber.glb' }),
             sheen: new pc.Asset('sheen', 'container', { url: '/static/assets/models/SheenChair.glb' }),

--- a/examples/src/examples/graphics/ground-fog.tsx
+++ b/examples/src/examples/graphics/ground-fog.tsx
@@ -107,7 +107,7 @@ class GroundFogExample {
         const assets = {
             'script': new pc.Asset('script', 'script', { url: '/static/scripts/camera/orbit-camera.js' }),
             'terrain': new pc.Asset('terrain', 'container', { url: '/static/assets/models/terrain.glb' }),
-            'helipad': new pc.Asset('helipad-env-atlas', 'texture', { url: '/static/assets/cubemaps/helipad-env-atlas.png' }, { type: pc.TEXTURETYPE_RGBP }),
+            'helipad': new pc.Asset('helipad-env-atlas', 'texture', { url: '/static/assets/cubemaps/helipad-env-atlas.png' }, { type: pc.TEXTURETYPE_RGBP, mipmaps: false }),
             'texture': new pc.Asset('color', 'texture', { url: '/static/assets/textures/clouds.jpg' })
         };
 

--- a/examples/src/examples/graphics/hardware-instancing.tsx
+++ b/examples/src/examples/graphics/hardware-instancing.tsx
@@ -8,7 +8,7 @@ class HardwareInstancingExample {
     example(canvas: HTMLCanvasElement, deviceType: string): void {
 
         const assets = {
-            helipad: new pc.Asset('helipad-env-atlas', 'texture', { url: '/static/assets/cubemaps/helipad-env-atlas.png' }, { type: pc.TEXTURETYPE_RGBP })
+            helipad: new pc.Asset('helipad-env-atlas', 'texture', { url: '/static/assets/cubemaps/helipad-env-atlas.png' }, { type: pc.TEXTURETYPE_RGBP, mipmaps: false })
         };
 
         const gfxOptions = {

--- a/examples/src/examples/graphics/light-physical-units.tsx
+++ b/examples/src/examples/graphics/light-physical-units.tsx
@@ -59,7 +59,7 @@ class LightPhysicalUnitsExample {
 
         const assets = {
             orbitCamera: new pc.Asset('script', 'script', { url: '/static/scripts/camera/orbit-camera.js' }),
-            helipad: new pc.Asset('helipad-env-atlas', 'texture', { url: '/static/assets/cubemaps/helipad-env-atlas.png' }, { type: pc.TEXTURETYPE_RGBP }),
+            helipad: new pc.Asset('helipad-env-atlas', 'texture', { url: '/static/assets/cubemaps/helipad-env-atlas.png' }, { type: pc.TEXTURETYPE_RGBP, mipmaps: false }),
             lights: new pc.Asset('lights', 'container', { url: '/static/assets/models/Lights.glb' }),
             sheen: new pc.Asset('sheen', 'container', { url: '/static/assets/models/SheenChair.glb' }),
             color: new pc.Asset('color', 'texture', { url: '/static/assets/textures/seaside-rocks01-color.jpg' }),

--- a/examples/src/examples/graphics/lights-baked-a-o.tsx
+++ b/examples/src/examples/graphics/lights-baked-a-o.tsx
@@ -71,7 +71,7 @@ class LightsBakedAOExample {
     example(canvas: HTMLCanvasElement, deviceType: string, data: any): void {
 
         const assets = {
-            helipad: new pc.Asset('helipad-env-atlas', 'texture', { url: '/static/assets/cubemaps/helipad-env-atlas.png' }, { type: pc.TEXTURETYPE_RGBP }),
+            helipad: new pc.Asset('helipad-env-atlas', 'texture', { url: '/static/assets/cubemaps/helipad-env-atlas.png' }, { type: pc.TEXTURETYPE_RGBP, mipmaps: false }),
             'house': new pc.Asset('house', 'container', { url: '/static/assets/models/house.glb' }),
             'script': new pc.Asset('script', 'script', { url: '/static/scripts/camera/orbit-camera.js' })
         };

--- a/examples/src/examples/graphics/lines.tsx
+++ b/examples/src/examples/graphics/lines.tsx
@@ -8,7 +8,7 @@ class LinesExample {
     example(canvas: HTMLCanvasElement, deviceType: string): void {
 
         const assets = {
-            'helipad': new pc.Asset('helipad-env-atlas', 'texture', { url: '/static/assets/cubemaps/helipad-env-atlas.png' }, { type: pc.TEXTURETYPE_RGBP })
+            'helipad': new pc.Asset('helipad-env-atlas', 'texture', { url: '/static/assets/cubemaps/helipad-env-atlas.png' }, { type: pc.TEXTURETYPE_RGBP, mipmaps: false })
         };
 
         const gfxOptions = {

--- a/examples/src/examples/graphics/material-clear-coat.tsx
+++ b/examples/src/examples/graphics/material-clear-coat.tsx
@@ -8,7 +8,7 @@ class MaterialClearCoatExample {
     example(canvas: HTMLCanvasElement, deviceType: string): void {
 
         const assets = {
-            helipad: new pc.Asset('helipad-env-atlas', 'texture', { url: '/static/assets/cubemaps/helipad-env-atlas.png' }, { type: pc.TEXTURETYPE_RGBP }),
+            helipad: new pc.Asset('helipad-env-atlas', 'texture', { url: '/static/assets/cubemaps/helipad-env-atlas.png' }, { type: pc.TEXTURETYPE_RGBP, mipmaps: false }),
             'normal': new pc.Asset('normal', 'texture', { url: '/static/assets/textures/flakes5n.png' }),
             'diffuse': new pc.Asset('diffuse', 'texture', { url: '/static/assets/textures/flakes5c.png' }),
             'other': new pc.Asset('other', 'texture', { url: '/static/assets/textures/flakes5o.png' })

--- a/examples/src/examples/graphics/material-physical.tsx
+++ b/examples/src/examples/graphics/material-physical.tsx
@@ -8,7 +8,7 @@ class MaterialPhysicalExample {
     example(canvas: HTMLCanvasElement, deviceType: string): void {
 
         const assets = {
-            helipad: new pc.Asset('helipad-env-atlas', 'texture', { url: '/static/assets/cubemaps/helipad-env-atlas.png' }, { type: pc.TEXTURETYPE_RGBP }),
+            helipad: new pc.Asset('helipad-env-atlas', 'texture', { url: '/static/assets/cubemaps/helipad-env-atlas.png' }, { type: pc.TEXTURETYPE_RGBP, mipmaps: false }),
             'font': new pc.Asset('font', 'font', { url: '/static/assets/fonts/arial.json' })
         };
 

--- a/examples/src/examples/graphics/material-translucent-specular.tsx
+++ b/examples/src/examples/graphics/material-translucent-specular.tsx
@@ -8,7 +8,7 @@ class MaterialTranslucentSpecularExample {
     example(canvas: HTMLCanvasElement, deviceType: string): void {
 
         const assets = {
-            helipad: new pc.Asset('helipad-env-atlas', 'texture', { url: '/static/assets/cubemaps/helipad-env-atlas.png' }, { type: pc.TEXTURETYPE_RGBP }),
+            helipad: new pc.Asset('helipad-env-atlas', 'texture', { url: '/static/assets/cubemaps/helipad-env-atlas.png' }, { type: pc.TEXTURETYPE_RGBP, mipmaps: false }),
             'font': new pc.Asset('font', 'font', { url: '/static/assets/fonts/arial.json' })
         };
 

--- a/examples/src/examples/graphics/mesh-deformation.tsx
+++ b/examples/src/examples/graphics/mesh-deformation.tsx
@@ -9,7 +9,7 @@ class MeshDeformationExample {
 
         const assets = {
             'statue': new pc.Asset('statue', 'container', { url: '/static/assets/models/statue.glb' }),
-            'helipad': new pc.Asset('helipad-env-atlas', 'texture', { url: '/static/assets/cubemaps/helipad-env-atlas.png' }, { type: pc.TEXTURETYPE_RGBP })
+            'helipad': new pc.Asset('helipad-env-atlas', 'texture', { url: '/static/assets/cubemaps/helipad-env-atlas.png' }, { type: pc.TEXTURETYPE_RGBP, mipmaps: false })
         };
 
         const gfxOptions = {

--- a/examples/src/examples/graphics/mesh-morph-many.tsx
+++ b/examples/src/examples/graphics/mesh-morph-many.tsx
@@ -8,7 +8,7 @@ class MeshMorphManyExample {
     example(canvas: HTMLCanvasElement, deviceType: string): void {
 
         const assets = {
-            helipad: new pc.Asset('helipad-env-atlas', 'texture', { url: '/static/assets/cubemaps/helipad-env-atlas.png' }, { type: pc.TEXTURETYPE_RGBP }),
+            helipad: new pc.Asset('helipad-env-atlas', 'texture', { url: '/static/assets/cubemaps/helipad-env-atlas.png' }, { type: pc.TEXTURETYPE_RGBP, mipmaps: false }),
         };
 
         const gfxOptions = {

--- a/examples/src/examples/graphics/multi-view.tsx
+++ b/examples/src/examples/graphics/multi-view.tsx
@@ -44,7 +44,7 @@ class MultiViewExample {
         function demo() {
             const assets = {
                 'script': new pc.Asset('script', 'script', { url: '/static/scripts/camera/orbit-camera.js' }),
-                'helipad': new pc.Asset('helipad-env-atlas', 'texture', { url: '/static/assets/cubemaps/helipad-env-atlas.png' }, { type: pc.TEXTURETYPE_RGBP }),
+                'helipad': new pc.Asset('helipad-env-atlas', 'texture', { url: '/static/assets/cubemaps/helipad-env-atlas.png' }, { type: pc.TEXTURETYPE_RGBP, mipmaps: false }),
                 'board': new pc.Asset('statue', 'container', { url: '/static/assets/models/chess-board.glb' })
             };
 

--- a/examples/src/examples/graphics/portal.tsx
+++ b/examples/src/examples/graphics/portal.tsx
@@ -8,7 +8,7 @@ class PortalExample {
     example(canvas: HTMLCanvasElement, deviceType: string): void {
 
         const assets = {
-            'helipad': new pc.Asset('helipad-env-atlas', 'texture', { url: '/static/assets/cubemaps/helipad-env-atlas.png' }, { type: pc.TEXTURETYPE_RGBP }),
+            'helipad': new pc.Asset('helipad-env-atlas', 'texture', { url: '/static/assets/cubemaps/helipad-env-atlas.png' }, { type: pc.TEXTURETYPE_RGBP, mipmaps: false }),
             'portal': new pc.Asset('portal', 'container', { url: '/static/assets/models/portal.glb' }),
             'statue': new pc.Asset('statue', 'container', { url: '/static/assets/models/statue.glb' }),
             'bitmoji': new pc.Asset('bitmoji', 'container', { url: '/static/assets/models/bitmoji.glb' })

--- a/examples/src/examples/graphics/post-effects.tsx
+++ b/examples/src/examples/graphics/post-effects.tsx
@@ -97,7 +97,7 @@ class PostEffectsExample {
             'vignette': new pc.Asset('vignette', 'script', { url: '/static/scripts/posteffects/posteffect-vignette.js' }),
             'ssao': new pc.Asset('ssao', 'script', { url: '/static/scripts/posteffects/posteffect-ssao.js' }),
             'font': new pc.Asset('font', 'font', { url: '/static/assets/fonts/arial.json' }),
-            helipad: new pc.Asset('helipad-env-atlas', 'texture', { url: '/static/assets/cubemaps/helipad-env-atlas.png' }, { type: pc.TEXTURETYPE_RGBP })
+            helipad: new pc.Asset('helipad-env-atlas', 'texture', { url: '/static/assets/cubemaps/helipad-env-atlas.png' }, { type: pc.TEXTURETYPE_RGBP, mipmaps: false })
         };
 
         const gfxOptions = {

--- a/examples/src/examples/graphics/reflection-cubemap.tsx
+++ b/examples/src/examples/graphics/reflection-cubemap.tsx
@@ -8,7 +8,7 @@ class ReflectionCubemapExample {
     example(canvas: HTMLCanvasElement, deviceType: string): void {
 
         const assets = {
-            helipad: new pc.Asset('helipad-env-atlas', 'texture', { url: '/static/assets/cubemaps/helipad-env-atlas.png' }, { type: pc.TEXTURETYPE_RGBP }),
+            helipad: new pc.Asset('helipad-env-atlas', 'texture', { url: '/static/assets/cubemaps/helipad-env-atlas.png' }, { type: pc.TEXTURETYPE_RGBP, mipmaps: false }),
             'script': new pc.Asset('script', 'script', { url: '/static/scripts/utils/cubemap-renderer.js' })
         };
 

--- a/examples/src/examples/graphics/render-asset.tsx
+++ b/examples/src/examples/graphics/render-asset.tsx
@@ -8,7 +8,7 @@ class RenderAssetExample {
     example(canvas: HTMLCanvasElement, deviceType: string): void {
 
         const assets = {
-            'helipad': new pc.Asset('helipad-env-atlas', 'texture', { url: '/static/assets/cubemaps/helipad-env-atlas.png' }, { type: pc.TEXTURETYPE_RGBP }),
+            'helipad': new pc.Asset('helipad-env-atlas', 'texture', { url: '/static/assets/cubemaps/helipad-env-atlas.png' }, { type: pc.TEXTURETYPE_RGBP, mipmaps: false }),
             'statue': new pc.Asset('statue', 'container', { url: '/static/assets/models/statue.glb' }),
             'cube': new pc.Asset('cube', 'container', { url: '/static/assets/models/playcanvas-cube.glb' })
         };

--- a/examples/src/examples/graphics/render-to-texture.tsx
+++ b/examples/src/examples/graphics/render-to-texture.tsx
@@ -17,7 +17,7 @@ class RenderToTextureExample {
         // - camera - this camera renders into main framebuffer, objects from World, Excluded and also Skybox layers
 
         const assets = {
-            helipad: new pc.Asset('helipad-env-atlas', 'texture', { url: '/static/assets/cubemaps/helipad-env-atlas.png' }, { type: pc.TEXTURETYPE_RGBP }),
+            helipad: new pc.Asset('helipad-env-atlas', 'texture', { url: '/static/assets/cubemaps/helipad-env-atlas.png' }, { type: pc.TEXTURETYPE_RGBP, mipmaps: false }),
             'script': new pc.Asset('script', 'script', { url: '/static/scripts/camera/orbit-camera.js' })
         };
 

--- a/examples/src/examples/graphics/shader-compile.tsx
+++ b/examples/src/examples/graphics/shader-compile.tsx
@@ -17,7 +17,7 @@ class ShaderCompileExample {
             'normal': new pc.Asset('normal', 'texture', { url: '/static/assets/textures/seaside-rocks01-normal.jpg' }),
             'gloss': new pc.Asset('gloss', 'texture', { url: '/static/assets/textures/seaside-rocks01-gloss.jpg' }),
             'luts': new pc.Asset('luts', 'json', { url: '/static/assets/json/area-light-luts.json' }),
-            helipad: new pc.Asset('helipad-env-atlas', 'texture', { url: '/static/assets/cubemaps/helipad-env-atlas.png' }, { type: pc.TEXTURETYPE_RGBP }),
+            helipad: new pc.Asset('helipad-env-atlas', 'texture', { url: '/static/assets/cubemaps/helipad-env-atlas.png' }, { type: pc.TEXTURETYPE_RGBP, mipmaps: false }),
         };
 
         const assetListLoader = new pc.AssetListLoader(Object.values(assets), app.assets);

--- a/examples/src/examples/graphics/shadow-cascades.tsx
+++ b/examples/src/examples/graphics/shadow-cascades.tsx
@@ -45,7 +45,7 @@ class ShadowCascadesExample {
         const assets = {
             'script': new pc.Asset('script', 'script', { url: '/static/scripts/camera/orbit-camera.js' }),
             'terrain': new pc.Asset('terrain', 'container', { url: '/static/assets/models/terrain.glb' }),
-            helipad: new pc.Asset('helipad-env-atlas', 'texture', { url: '/static/assets/cubemaps/helipad-env-atlas.png' }, { type: pc.TEXTURETYPE_RGBP })
+            helipad: new pc.Asset('helipad-env-atlas', 'texture', { url: '/static/assets/cubemaps/helipad-env-atlas.png' }, { type: pc.TEXTURETYPE_RGBP, mipmaps: false })
         };
 
         const gfxOptions = {

--- a/examples/src/examples/input/gamepad.tsx
+++ b/examples/src/examples/input/gamepad.tsx
@@ -9,7 +9,7 @@ class GamepadExample {
         // Create the application and start the update loop
 
         const assets = {
-            'helipad': new pc.Asset('helipad-env-atlas', 'texture', { url: '/static/assets/cubemaps/helipad-env-atlas.png' }, { type: pc.TEXTURETYPE_RGBP }),
+            'helipad': new pc.Asset('helipad-env-atlas', 'texture', { url: '/static/assets/cubemaps/helipad-env-atlas.png' }, { type: pc.TEXTURETYPE_RGBP, mipmaps: false }),
             'statue': new pc.Asset('statue', 'container', { url: '/static/assets/models/statue.glb' })
         };
 

--- a/examples/src/examples/input/keyboard.tsx
+++ b/examples/src/examples/input/keyboard.tsx
@@ -8,7 +8,7 @@ class KeyboardExample {
     example(canvas: HTMLCanvasElement, deviceType: string): void {
 
         const assets = {
-            'helipad': new pc.Asset('helipad-env-atlas', 'texture', { url: '/static/assets/cubemaps/helipad-env-atlas.png' }, { type: pc.TEXTURETYPE_RGBP }),
+            'helipad': new pc.Asset('helipad-env-atlas', 'texture', { url: '/static/assets/cubemaps/helipad-env-atlas.png' }, { type: pc.TEXTURETYPE_RGBP, mipmaps: false }),
             'statue': new pc.Asset('statue', 'container', { url: '/static/assets/models/statue.glb' })
         };
 

--- a/examples/src/examples/input/mouse.tsx
+++ b/examples/src/examples/input/mouse.tsx
@@ -8,7 +8,7 @@ class MouseExample {
 
     example(canvas: HTMLCanvasElement, deviceType: string): void {
         const assets = {
-            'helipad': new pc.Asset('helipad-env-atlas', 'texture', { url: '/static/assets/cubemaps/helipad-env-atlas.png' }, { type: pc.TEXTURETYPE_RGBP }),
+            'helipad': new pc.Asset('helipad-env-atlas', 'texture', { url: '/static/assets/cubemaps/helipad-env-atlas.png' }, { type: pc.TEXTURETYPE_RGBP, mipmaps: false }),
             'statue': new pc.Asset('statue', 'container', { url: '/static/assets/models/statue.glb' })
         };
 

--- a/examples/src/examples/loaders/gltf-export.tsx
+++ b/examples/src/examples/loaders/gltf-export.tsx
@@ -28,7 +28,7 @@ class GltfExportExample {
         function demo() {
 
             const assets = {
-                'helipad': new pc.Asset('helipad-env-atlas', 'texture', { url: '/static/assets/cubemaps/helipad-env-atlas.png' }, { type: pc.TEXTURETYPE_RGBP }),
+                'helipad': new pc.Asset('helipad-env-atlas', 'texture', { url: '/static/assets/cubemaps/helipad-env-atlas.png' }, { type: pc.TEXTURETYPE_RGBP, mipmaps: false }),
                 'bench': new pc.Asset('bench', 'container', { url: '/static/assets/models/bench_wooden_01.glb' }),
                 'model': new pc.Asset('model', 'container', { url: '/static/assets/models/bitmoji.glb' }),
                 'board': new pc.Asset('statue', 'container', { url: '/static/assets/models/chess-board.glb' })

--- a/examples/src/examples/loaders/usdz-export.tsx
+++ b/examples/src/examples/loaders/usdz-export.tsx
@@ -17,7 +17,7 @@ class UsdzExportExample {
     example(canvas: HTMLCanvasElement, deviceType: string, pcx: any, data: any): void {
 
         const assets = {
-            'helipad': new pc.Asset('helipad-env-atlas', 'texture', { url: '/static/assets/cubemaps/helipad-env-atlas.png' }, { type: pc.TEXTURETYPE_RGBP }),
+            'helipad': new pc.Asset('helipad-env-atlas', 'texture', { url: '/static/assets/cubemaps/helipad-env-atlas.png' }, { type: pc.TEXTURETYPE_RGBP, mipmaps: false }),
             'bench': new pc.Asset('bench', 'container', { url: '/static/assets/models/bench_wooden_01.glb' })
         };
 

--- a/examples/src/examples/physics/offset-collision.tsx
+++ b/examples/src/examples/physics/offset-collision.tsx
@@ -20,7 +20,7 @@ class OffsetCollisionExample {
             const assets = {
                 'model': new pc.Asset('model', 'container', {url: '/static/assets/models/bitmoji.glb'}),
                 'idleAnim': new pc.Asset('idleAnim', 'container', {url: '/static/assets/animations/bitmoji/idle.glb'}),
-                helipad: new pc.Asset('helipad-env-atlas', 'texture', { url: '/static/assets/cubemaps/helipad-env-atlas.png' }, { type: pc.TEXTURETYPE_RGBP }),
+                helipad: new pc.Asset('helipad-env-atlas', 'texture', { url: '/static/assets/cubemaps/helipad-env-atlas.png' }, { type: pc.TEXTURETYPE_RGBP, mipmaps: false }),
             };
 
             const gfxOptions = {

--- a/examples/src/examples/physics/vehicle.tsx
+++ b/examples/src/examples/physics/vehicle.tsx
@@ -18,7 +18,7 @@ class VehicleExample {
         function demo() {
 
             const assets = {
-                helipad: new pc.Asset('helipad-env-atlas', 'texture', { url: '/static/assets/cubemaps/helipad-env-atlas.png' }, { type: pc.TEXTURETYPE_RGBP }),
+                helipad: new pc.Asset('helipad-env-atlas', 'texture', { url: '/static/assets/cubemaps/helipad-env-atlas.png' }, { type: pc.TEXTURETYPE_RGBP, mipmaps: false }),
                 'script1': new pc.Asset('script1', 'script', { url: '/static/scripts/camera/tracking-camera.js' }),
                 'script2': new pc.Asset('script2', 'script', { url: '/static/scripts/physics/render-physics.js' }),
                 'script3': new pc.Asset('script3', 'script', { url: '/static/scripts/physics/action-physics-reset.js' }),


### PR DESCRIPTION
- this is to avoid the mipmap flag being changed after the texture has been created, which is not supported by WebGPU device at the moment