### PR TITLE
Small fixes to WebGPU rendering to cubemap with mipmaps

### DIFF
--- a/examples/src/examples/graphics/reflection-cubemap.tsx
+++ b/examples/src/examples/graphics/reflection-cubemap.tsx
@@ -145,7 +145,9 @@ class ReflectionCubemapExample {
                 shinyBall.script.create('cubemapRenderer', {
                     attributes: {
                         resolution: 256,
-                        mipmaps: true,
+
+                        // TODO: WebGPU does not yet support cubemap mipmap generation after rendering
+                        mipmaps: !app.graphicsDevice.isWebGPU,
                         depth: true
                     }
                 });

--- a/src/platform/graphics/webgpu/webgpu-render-target.js
+++ b/src/platform/graphics/webgpu/webgpu-render-target.js
@@ -214,16 +214,20 @@ class WebgpuRenderTarget {
         if (colorBuffer) {
 
             // render to top mip level in case of mip-mapped buffer
-            colorView = colorBuffer.impl.createView({
-                mipLevelCount: 1
-            });
+            const mipLevelCount = 1;
 
             // cubemap face view - face is a single 2d array layer in order [+X, -X, +Y, -Y, +Z, -Z]
             if (colorBuffer.cubemap) {
                 colorView = colorBuffer.impl.createView({
                     dimension: '2d',
                     baseArrayLayer: renderTarget.face,
-                    arrayLayerCount: 1
+                    arrayLayerCount: 1,
+                    mipLevelCount
+                });
+            } else {
+
+                colorView = colorBuffer.impl.createView({
+                    mipLevelCount
                 });
             }
         }

--- a/src/platform/graphics/webgpu/webgpu-texture.js
+++ b/src/platform/graphics/webgpu/webgpu-texture.js
@@ -310,14 +310,16 @@ class WebgpuTexture {
                         for (let face = 0; face < 6; face++) {
 
                             const faceSource = mipObject[face];
-                            if (this.isExternalImage(faceSource)) {
+                            if (faceSource) {
+                                if (this.isExternalImage(faceSource)) {
 
-                                this.uploadExternalImage(device, faceSource, mipLevel, face);
-                                anyUploads = true;
+                                    this.uploadExternalImage(device, faceSource, mipLevel, face);
+                                    anyUploads = true;
 
-                            } else {
+                                } else {
 
-                                Debug.error('Unsupported texture source data for cubemap face', faceSource);
+                                    Debug.error('Unsupported texture source data for cubemap face', faceSource);
+                                }
                             }
                         }
 


### PR DESCRIPTION
- not trying to upload null data (as its a render target)
- rendering to a single mipmap of cubemap with mipmaps
- disabled cubemap mips in the example due to not having a mi[map generation for cubemap yet (and so mipmap sampling gets dark (uninitialized) face mipmaps)