### PR TITLE
Change to static members of BlendState

### DIFF
--- a/src/deprecated/deprecated.js
+++ b/src/deprecated/deprecated.js
@@ -591,6 +591,8 @@ GraphicsDevice.prototype.removeShaderFromCache = function (shader) {
     getProgramLibrary(this).removeFromCache(shader);
 };
 
+BlendState.DEFAULT = Object.freeze(new BlendState());
+
 const _tempBlendState = new BlendState();
 const _tempDepthState = new DepthState();
 

--- a/src/framework/graphics/picker.js
+++ b/src/framework/graphics/picker.js
@@ -209,7 +209,7 @@ class Picker {
                 self.pickColor[1] = ((index >> 8) & 0xff) / 255;
                 self.pickColor[2] = (index & 0xff) / 255;
                 pickColorId.setValue(self.pickColor);
-                device.setBlendState(BlendState.DEFAULT);
+                device.setBlendState(BlendState.NOBLEND);
 
                 // keep the index -> meshInstance index mapping
                 self.mapping[index] = meshInstance;

--- a/src/framework/lightmapper/lightmapper.js
+++ b/src/framework/lightmapper/lightmapper.js
@@ -879,7 +879,7 @@ class Lightmapper {
             this.lightmapFilters.prepareDenoise(this.scene.lightmapFilterRange, this.scene.lightmapFilterSmoothness);
         }
 
-        device.setBlendState(BlendState.DEFAULT);
+        device.setBlendState(BlendState.NOBLEND);
         device.setDepthState(DepthState.NODEPTH);
         device.setStencilState(null, null);
 

--- a/src/platform/graphics/blend-state.js
+++ b/src/platform/graphics/blend-state.js
@@ -1,5 +1,5 @@
 import { BitPacking } from "../../core/math/bit-packing.js";
-import { BLENDEQUATION_ADD, BLENDMODE_ONE, BLENDMODE_ZERO } from '../../platform/graphics/constants.js';
+import { BLENDEQUATION_ADD, BLENDMODE_ONE, BLENDMODE_ZERO, BLENDMODE_SRC_ALPHA, BLENDMODE_ONE_MINUS_SRC_ALPHA } from '../../platform/graphics/constants.js';
 
 // masks (to only keep relevant bits)
 const opMask = 0b111;
@@ -227,12 +227,12 @@ class BlendState {
     }
 
     /**
-     * A default blend state that has blending disabled and writes to all color channels.
+     * A blend state that has blending disabled and writes to all color channels.
      *
      * @type {BlendState}
      * @readonly
      */
-    static DEFAULT = Object.freeze(new BlendState());
+    static NOBLEND = Object.freeze(new BlendState());
 
     /**
      * A blend state that does not write to color channels.
@@ -241,6 +241,14 @@ class BlendState {
      * @readonly
      */
     static NOWRITE = Object.freeze(new BlendState(undefined, undefined, undefined, undefined, undefined, undefined, undefined, false, false, false, false));
+
+    /**
+     * A blend state that does simple translucency using alpha channel.
+     *
+     * @type {BlendState}
+     * @readonly
+     */
+    static ALPHABLEND = Object.freeze(new BlendState(true, BLENDEQUATION_ADD, BLENDMODE_SRC_ALPHA, BLENDMODE_ONE_MINUS_SRC_ALPHA));
 }
 
 export { BlendState };

--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -90,7 +90,7 @@ function quadWithShader(device, target, shader) {
     device.updateBegin();
 
     device.setCullMode(CULLFACE_NONE);
-    device.setBlendState(BlendState.DEFAULT);
+    device.setBlendState(BlendState.NOBLEND);
     device.setDepthState(DepthState.NODEPTH);
     device.setStencilState(null, null);
 
@@ -2016,7 +2016,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
                     this.clearColor.set(r, g, b, a);
                 }
 
-                this.setBlendState(BlendState.DEFAULT);
+                this.setBlendState(BlendState.NOBLEND);
             }
 
             if (flags & CLEARFLAG_DEPTH) {

--- a/src/platform/graphics/webgpu/webgpu-clear-renderer.js
+++ b/src/platform/graphics/webgpu/webgpu-clear-renderer.js
@@ -105,7 +105,7 @@ class WebgpuClearRenderer {
                 const color = options.color ?? defaultOptions.color;
                 this.colorData.set(color);
 
-                device.setBlendState(BlendState.DEFAULT);
+                device.setBlendState(BlendState.NOBLEND);
             } else {
                 device.setBlendState(BlendState.NOWRITE);
             }

--- a/src/scene/graphics/post-effect.js
+++ b/src/scene/graphics/post-effect.js
@@ -81,7 +81,7 @@ class PostEffect {
             viewport = _viewport.set(rect.x * w, rect.y * h, rect.z * w, rect.w * h);
         }
 
-        this.device.setBlendState(BlendState.DEFAULT);
+        this.device.setBlendState(BlendState.NOBLEND);
         drawQuadWithShader(this.device, target, shader, viewport);
     }
 }

--- a/src/scene/graphics/prefilter-cubemap.js
+++ b/src/scene/graphics/prefilter-cubemap.js
@@ -96,7 +96,7 @@ function shFromCubemap(device, source, dontFlipX) {
                     depth: false
                 });
                 constantTexSource.setValue(tex);
-                device.setBlendState(BlendState.DEFAULT);
+                device.setBlendState(BlendState.NOBLEND);
                 drawQuadWithShader(device, targ, shader);
 
                 const gl = device.gl;

--- a/src/scene/graphics/reproject-texture.js
+++ b/src/scene/graphics/reproject-texture.js
@@ -465,7 +465,7 @@ function reprojectTexture(source, target, options = {}) {
 
     // render state
     // TODO: set up other render state here to expected state
-    device.setBlendState(BlendState.DEFAULT);
+    device.setBlendState(BlendState.NOBLEND);
 
     const constantSource = device.scope.resolve(source.cubemap ? "sourceCube" : "sourceTex");
     Debug.assert(constantSource);

--- a/src/scene/graphics/scene-grab.js
+++ b/src/scene/graphics/scene-grab.js
@@ -391,7 +391,7 @@ class SceneGrab {
 
             onDrawCall: function () {
                 // writing depth to color render target, force no blending and writing to all channels
-                device.setBlendState(BlendState.DEFAULT);
+                device.setBlendState(BlendState.NOBLEND);
             },
 
             onPostRenderOpaque: function (cameraPass) {

--- a/src/scene/morph-instance.js
+++ b/src/scene/morph-instance.js
@@ -267,7 +267,7 @@ class MorphInstance {
             this.morphFactor.setValue(this._shaderMorphWeights);
 
             // alpha blending - first pass gets none, following passes are additive
-            device.setBlendState(blending ? blendStateAdditive : BlendState.DEFAULT);
+            device.setBlendState(blending ? blendStateAdditive : BlendState.NOBLEND);
 
             // render quad with shader for required number of textures
             const shader = this._getShader(usedCount);

--- a/src/scene/particle-system/gpu-updater.js
+++ b/src/scene/particle-system/gpu-updater.js
@@ -92,7 +92,7 @@ class ParticleGPUUpdater {
 
         const emitter = this._emitter;
 
-        device.setBlendState(BlendState.DEFAULT);
+        device.setBlendState(BlendState.NOBLEND);
         device.setDepthState(DepthState.NODEPTH);
         device.setCullMode(CULLFACE_NONE);
 

--- a/src/scene/renderer/cookie-renderer.js
+++ b/src/scene/renderer/cookie-renderer.js
@@ -128,7 +128,7 @@ class CookieRenderer {
             this.blitTextureId.setValue(light.cookie);
 
             // render state
-            device.setBlendState(BlendState.DEFAULT);
+            device.setBlendState(BlendState.NOBLEND);
 
             // render it to a viewport of the target
             for (let face = 0; face < faceCount; face++) {

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -1118,7 +1118,7 @@ class ForwardRenderer extends Renderer {
             // Revert temp frame stuff
             // TODO: this should not be here, as each rendering / clearing should explicitly set up what
             // it requires (the properties are part of render pipeline on WebGPU anyways)
-            device.setBlendState(BlendState.DEFAULT);
+            device.setBlendState(BlendState.NOBLEND);
             device.setStencilState(null, null);
             device.setAlphaToCoverage(false); // don't leak a2c state
             device.setDepthBias(false);

--- a/src/scene/renderer/shadow-renderer.js
+++ b/src/scene/renderer/shadow-renderer.js
@@ -524,7 +524,7 @@ class ShadowRenderer {
         DebugGraphics.pushGpuMarker(device, `VSM ${light._node.name}`);
 
         // render state
-        device.setBlendState(BlendState.DEFAULT);
+        device.setBlendState(BlendState.NOBLEND);
 
         const lightRenderData = light.getRenderData(light._type === LIGHTTYPE_DIRECTIONAL ? camera : null, 0);
         const shadowCam = lightRenderData.shadowCamera;


### PR DESCRIPTION
- deprecated `BlendState.DEFAULT` due to non-obvious naming
- replaced it by `BlendState.NOBLEND`
- added `BlendState.ALPHABLEND` which is commonly used