### PR TITLE
[Examples Browser] Add overflow scroll bars into the examples browser

### DIFF
--- a/examples/src/static/styles.css
+++ b/examples/src/static/styles.css
@@ -436,7 +436,7 @@ body {
 }
 
 ::-webkit-scrollbar {
-    width: 0px;
+    width: 8px;
     height: 8px;
 }
 ::-webkit-scrollbar-track {


### PR DESCRIPTION
This PR adds scroll bars to all elements that have content which flows over their boundaries.
<img width="315" alt="image" src="https://user-images.githubusercontent.com/1721533/236183508-f8b96e5b-0285-477d-8248-6522fe22031b.png">
![image](https://user-images.githubusercontent.com/1721533/236183235-6a624669-4aaa-4b3e-b9df-367bdfed9644.png)

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
