### PR TITLE
Removed double usage of temp global vec3 in compound collision offset

### DIFF
--- a/src/framework/components/collision/system.js
+++ b/src/framework/components/collision/system.js
@@ -17,7 +17,8 @@ import { CollisionComponentData } from './data.js';
 import { Trigger } from './trigger.js';
 
 const mat4 = new Mat4();
-const vec3 = new Vec3();
+const p1 = new Vec3();
+const p2 = new Vec3();
 const quat = new Quat();
 const tempGraphNode = new GraphNode();
 
@@ -783,7 +784,7 @@ class CollisionComponentSystem extends ComponentSystem {
         if (relative) {
             this._calculateNodeRelativeTransform(node, relative);
 
-            pos = vec3;
+            pos = p1;
             rot = quat;
 
             mat4.getTranslation(pos);
@@ -802,12 +803,13 @@ class CollisionComponentSystem extends ComponentSystem {
         if (component && component._hasOffset) {
             const lo = component.data.linearOffset;
             const ao = component.data.angularOffset;
+            const newOrigin = p2;
 
-            quat.copy(rot).transformVector(lo, vec3);
-            vec3.add((pos));
+            quat.copy(rot).transformVector(lo, newOrigin);
+            newOrigin.add(pos);
             quat.copy(rot).mul(ao);
 
-            origin.setValue(vec3.x, vec3.y, vec3.z);
+            origin.setValue(newOrigin.x, newOrigin.y, newOrigin.z);
             ammoQuat.setValue(quat.x, quat.y, quat.z, quat.w);
         } else {
             origin.setValue(pos.x, pos.y, pos.z);


### PR DESCRIPTION
Fixes https://github.com/playcanvas/engine/issues/5230

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
