### PR TITLE
Build with join

### DIFF
--- a/src/framework/parsers/draco-decoder.js
+++ b/src/framework/parsers/draco-decoder.js
@@ -1,6 +1,7 @@
 import { WasmModule } from "../../core/wasm-module.js";
 import { ABSOLUTE_URL } from "../asset/constants.js";
 import { DracoWorker } from "./draco-worker.js";
+import { path } from '../../core/path.js';
 import { Debug } from "../../core/debug.js";
 import { http } from '../../platform/net/http.js';
 
@@ -179,7 +180,7 @@ const initializeWorkers = (config) => {
 
     // worker urls must be absolute
     const absoluteUrl = (url) => {
-        return ABSOLUTE_URL.test(url) ? url : new URL(window.location.href).origin + url;
+        return ABSOLUTE_URL.test(url) ? url : path.join(new URL(window.location.href).origin, url);
     };
     const jsUrl = absoluteUrl(config.jsUrl);
     const wasmUrl = absoluteUrl(config.wasmUrl);


### PR DESCRIPTION
Local build of project using draco were missing the path separator when constructing relative URL paths.