### PR TITLE
Draco url fix

### DIFF
--- a/src/framework/parsers/draco-decoder.js
+++ b/src/framework/parsers/draco-decoder.js
@@ -1,7 +1,5 @@
 import { WasmModule } from "../../core/wasm-module.js";
-import { ABSOLUTE_URL } from "../asset/constants.js";
 import { DracoWorker } from "./draco-worker.js";
-import { path } from '../../core/path.js';
 import { Debug } from "../../core/debug.js";
 import { http } from '../../platform/net/http.js';
 

--- a/src/framework/parsers/draco-decoder.js
+++ b/src/framework/parsers/draco-decoder.js
@@ -179,12 +179,7 @@ const initializeWorkers = (config) => {
     jobQueue = new JobQueue();
 
     // worker urls must be absolute
-    const absoluteUrl = (url) => {
-        return ABSOLUTE_URL.test(url) ? url : path.join(new URL(window.location.href).origin, url);
-    };
-    const jsUrl = absoluteUrl(config.jsUrl);
-    const wasmUrl = absoluteUrl(config.wasmUrl);
-    Promise.all([downloadScript(jsUrl), compileModule(wasmUrl)])
+    Promise.all([downloadScript(config.jsUrl), compileModule(config.wasmUrl)])
         .then(([dracoSource, dracoModule]) => {
             // build worker source
             const code = [

--- a/src/framework/parsers/draco-decoder.js
+++ b/src/framework/parsers/draco-decoder.js
@@ -163,8 +163,8 @@ const initializeWorkers = (config) => {
                 };
             } else {
                 config = {
-                    jsUrl: '/draco.wasm.js',
-                    wasmUrl: '/draco.wasm.wasm',
+                    jsUrl: 'draco.wasm.js',
+                    wasmUrl: 'draco.wasm.wasm',
                     numWorkers: defaultNumWorkers
                 };
             }


### PR DESCRIPTION
Use relative URLs for draco loading.

Absolute URLs are needed when web workers perform network requests. However the main thread is downloading and compiling the module.