### PR TITLE
Give ministats consistent screen size

### DIFF
--- a/extras/mini-stats/render2d.js
+++ b/extras/mini-stats/render2d.js
@@ -185,13 +185,11 @@ class Render2d {
         device.setIndexBuffer(this.indexBuffer);
         device.setShader(this.shader);
 
-        const pr = Math.min(device.maxPixelRatio, window.devicePixelRatio);
-
         // set shader uniforms
         this.clr.set(clr, 0);
         this.clrId.setValue(this.clr);
-        this.screenTextureSize[0] = device.width / pr;
-        this.screenTextureSize[1] = device.height / pr;
+        this.screenTextureSize[0] = device.canvas.scrollWidth;
+        this.screenTextureSize[1] = device.canvas.scrollHeight;
 
         // colors
         this.col0Id.setValue(this.col0);


### PR DESCRIPTION
Using CSS canvas size results in ministats rendering a consistent size on screen independent of rendering pixel ratio configuration.