### PR TITLE
Add support for PCF1 to directional / spot lights

### DIFF
--- a/examples/src/examples/graphics/shadow-cascades.tsx
+++ b/examples/src/examples/graphics/shadow-cascades.tsx
@@ -14,6 +14,7 @@ class ShadowCascadesExample {
             <Panel headerText='Shadow Cascade Settings'>
                 {<LabelGroup text='Filtering'>
                     <SelectInput binding={new BindingTwoWay()} link={{ observer: data, path: 'settings.light.shadowType' }} type="number" options={[
+                        { v: pc.SHADOW_PCF1, t: 'PCF1' },
                         { v: pc.SHADOW_PCF3, t: 'PCF3' },
                         { v: pc.SHADOW_PCF5, t: 'PCF5' },
                         { v: pc.SHADOW_VSM8, t: 'VSM8' },

--- a/src/scene/light.js
+++ b/src/scene/light.js
@@ -334,7 +334,7 @@ class Light {
             value = SHADOW_VSM8;
 
         this._isVsm = value >= SHADOW_VSM8 && value <= SHADOW_VSM32;
-        this._isPcf = value === SHADOW_PCF5 || value === SHADOW_PCF3 || value === SHADOW_PCF1;
+        this._isPcf = value === SHADOW_PCF1 || value === SHADOW_PCF3 || value === SHADOW_PCF5;
 
         this._shadowType = value;
         this._destroyShadowMap();

--- a/src/scene/light.js
+++ b/src/scene/light.js
@@ -9,7 +9,7 @@ import {
     BLUR_GAUSSIAN,
     LIGHTTYPE_DIRECTIONAL, LIGHTTYPE_OMNI, LIGHTTYPE_SPOT,
     MASK_BAKE, MASK_AFFECT_DYNAMIC,
-    SHADOW_PCF3, SHADOW_PCF5, SHADOW_VSM8, SHADOW_VSM16, SHADOW_VSM32,
+    SHADOW_PCF1, SHADOW_PCF3, SHADOW_PCF5, SHADOW_VSM8, SHADOW_VSM16, SHADOW_VSM32,
     SHADOWUPDATE_NONE, SHADOWUPDATE_REALTIME, SHADOWUPDATE_THISFRAME,
     LIGHTSHAPE_PUNCTUAL, LIGHTFALLOFF_LINEAR
 } from './constants.js';
@@ -334,7 +334,7 @@ class Light {
             value = SHADOW_VSM8;
 
         this._isVsm = value >= SHADOW_VSM8 && value <= SHADOW_VSM32;
-        this._isPcf = value === SHADOW_PCF5 || value === SHADOW_PCF3;
+        this._isPcf = value === SHADOW_PCF5 || value === SHADOW_PCF3 || value === SHADOW_PCF1;
 
         this._shadowType = value;
         this._destroyShadowMap();

--- a/src/scene/renderer/shadow-map.js
+++ b/src/scene/renderer/shadow-map.js
@@ -10,7 +10,7 @@ import { Texture } from '../../platform/graphics/texture.js';
 
 import {
     LIGHTTYPE_OMNI,
-    SHADOW_PCF3, SHADOW_PCF5, SHADOW_VSM16, SHADOW_VSM32
+    SHADOW_PCF1, SHADOW_PCF3, SHADOW_PCF5, SHADOW_VSM16, SHADOW_VSM32
 } from '../constants.js';
 
 
@@ -51,7 +51,7 @@ class ShadowMap {
             return PIXELFORMAT_RGBA16F;
         } else if (shadowType === SHADOW_PCF5) {
             return PIXELFORMAT_DEPTH;
-        } else if (shadowType === SHADOW_PCF3 && device.supportsDepthShadow) {
+        } else if ((shadowType === SHADOW_PCF1 || shadowType === SHADOW_PCF3) && device.supportsDepthShadow) {
             return PIXELFORMAT_DEPTH;
         }
 
@@ -59,7 +59,7 @@ class ShadowMap {
     }
 
     static getShadowFiltering(device, shadowType) {
-        if (shadowType === SHADOW_PCF3 && !device.supportsDepthShadow) {
+        if ((shadowType === SHADOW_PCF1 || shadowType === SHADOW_PCF3) && !device.supportsDepthShadow) {
             return FILTER_NEAREST;
         } else if (shadowType === SHADOW_VSM32) {
             return device.extTextureFloatLinear ? FILTER_LINEAR : FILTER_NEAREST;
@@ -116,7 +116,7 @@ class ShadowMap {
         });
 
         let target = null;
-        if (shadowType === SHADOW_PCF5 || (shadowType === SHADOW_PCF3 && device.supportsDepthShadow)) {
+        if (shadowType === SHADOW_PCF5 || ((shadowType === SHADOW_PCF1 || shadowType === SHADOW_PCF3) && device.supportsDepthShadow)) {
 
             // enable hardware PCF when sampling the depth texture
             texture.compareOnRead = true;

--- a/src/scene/renderer/shadow-renderer.js
+++ b/src/scene/renderer/shadow-renderer.js
@@ -13,7 +13,7 @@ import {
     BLUR_GAUSSIAN,
     LIGHTTYPE_DIRECTIONAL, LIGHTTYPE_OMNI,
     SHADER_SHADOW,
-    SHADOW_PCF3, SHADOW_PCF5, SHADOW_VSM8, SHADOW_VSM32,
+    SHADOW_PCF1, SHADOW_PCF3, SHADOW_PCF5, SHADOW_VSM8, SHADOW_VSM32,
     SHADOWUPDATE_NONE, SHADOWUPDATE_THISFRAME,
     SORTKEY_DEPTH
 } from '../constants.js';
@@ -147,7 +147,7 @@ class ShadowRenderer {
 
         // normal omni shadows on webgl2 encode depth in RGBA8 and do manual PCF sampling
         // clustered omni shadows on webgl2 use depth format and hardware PCF sampling
-        let hwPcf = shadowType === SHADOW_PCF5 || (shadowType === SHADOW_PCF3 && device.supportsDepthShadow);
+        let hwPcf = shadowType === SHADOW_PCF5 || ((shadowType === SHADOW_PCF1 || shadowType === SHADOW_PCF3) && device.supportsDepthShadow);
         if (type === LIGHTTYPE_OMNI && !isClustered) {
             hwPcf = false;
         }

--- a/src/scene/shader-lib/chunks/lit/frag/shadowStandard.js
+++ b/src/scene/shader-lib/chunks/lit/frag/shadowStandard.js
@@ -62,6 +62,26 @@ float getShadowSpotPCF3x3(SHADOWMAP_ACCEPT(shadowMap), vec3 shadowCoord, vec4 sh
     return _getShadowPCF3x3(SHADOWMAP_PASS(shadowMap), shadowCoord, shadowParams.xyz);
 }
 
+float _getShadowPCF1x1(SHADOWMAP_ACCEPT(shadowMap), vec3 shadowCoord, vec3 shadowParams) {
+    float z = shadowCoord.z;
+    vec2 uv = shadowCoord.xy * shadowParams.x; // 1 unit - 1 texel
+    float shadowMapSizeInv = 1.0 / shadowParams.x;
+    vec2 base_uv = floor(uv + 0.5);
+    float s = (uv.x + 0.5 - base_uv.x);
+    float t = (uv.y + 0.5 - base_uv.y);
+    base_uv -= vec2(0.5);
+    base_uv *= shadowMapSizeInv;
+    return textureShadow(shadowMap, vec3(base_uv, z));
+}
+
+float getShadowPCF1x1(SHADOWMAP_ACCEPT(shadowMap), vec3 shadowCoord, vec3 shadowParams) {
+    return _getShadowPCF1x1(SHADOWMAP_PASS(shadowMap), shadowCoord, shadowParams);
+}
+
+float getShadowSpotPCF1x1(SHADOWMAP_ACCEPT(shadowMap), vec3 shadowCoord, vec4 shadowParams) {
+    return _getShadowPCF1x1(SHADOWMAP_PASS(shadowMap), shadowCoord, shadowParams.xyz);
+}
+
 #else // GL1
 
 float _xgetShadowPCF3x3(mat3 depthKernel, vec3 shadowCoord, sampler2D shadowMap, vec3 shadowParams) {
@@ -110,6 +130,19 @@ float getShadowPCF3x3(sampler2D shadowMap, vec3 shadowCoord, vec3 shadowParams) 
 
 float getShadowSpotPCF3x3(sampler2D shadowMap, vec3 shadowCoord, vec4 shadowParams) {
     return _getShadowPCF3x3(shadowMap, shadowCoord, shadowParams.xyz);
+}
+
+float _getShadowPCF1x1(sampler2D shadowMap, vec3 shadowCoord) {
+    float shadowSample = unpackFloat(textureShadow(shadowMap, shadowCoord.xy));
+    return shadowSample > shadowCoord.z ? 1.0 : 0.0;
+}
+
+float getShadowPCF1x1(sampler2D shadowMap, vec3 shadowCoord, vec3 shadowParams) {
+    return _getShadowPCF1x1(shadowMap, shadowCoord);
+}
+
+float getShadowSpotPCF1x1(sampler2D shadowMap, vec3 shadowCoord, vec4 shadowParams) {
+    return _getShadowPCF1x1(shadowMap, shadowCoord);
 }
 #endif
 

--- a/src/scene/shader-lib/chunks/lit/frag/shadowStandard.js
+++ b/src/scene/shader-lib/chunks/lit/frag/shadowStandard.js
@@ -62,24 +62,12 @@ float getShadowSpotPCF3x3(SHADOWMAP_ACCEPT(shadowMap), vec3 shadowCoord, vec4 sh
     return _getShadowPCF3x3(SHADOWMAP_PASS(shadowMap), shadowCoord, shadowParams.xyz);
 }
 
-float _getShadowPCF1x1(SHADOWMAP_ACCEPT(shadowMap), vec3 shadowCoord, vec3 shadowParams) {
-    float z = shadowCoord.z;
-    vec2 uv = shadowCoord.xy * shadowParams.x; // 1 unit - 1 texel
-    float shadowMapSizeInv = 1.0 / shadowParams.x;
-    vec2 base_uv = floor(uv + 0.5);
-    float s = (uv.x + 0.5 - base_uv.x);
-    float t = (uv.y + 0.5 - base_uv.y);
-    base_uv -= vec2(0.5);
-    base_uv *= shadowMapSizeInv;
-    return textureShadow(shadowMap, vec3(base_uv, z));
-}
-
 float getShadowPCF1x1(SHADOWMAP_ACCEPT(shadowMap), vec3 shadowCoord, vec3 shadowParams) {
-    return _getShadowPCF1x1(SHADOWMAP_PASS(shadowMap), shadowCoord, shadowParams);
+    return textureShadow(shadowMap, shadowCoord);
 }
 
 float getShadowSpotPCF1x1(SHADOWMAP_ACCEPT(shadowMap), vec3 shadowCoord, vec4 shadowParams) {
-    return _getShadowPCF1x1(SHADOWMAP_PASS(shadowMap), shadowCoord, shadowParams.xyz);
+    return textureShadow(shadowMap, shadowCoord);
 }
 
 #else // GL1

--- a/src/scene/shader-lib/programs/lit-shader.js
+++ b/src/scene/shader-lib/programs/lit-shader.js
@@ -521,7 +521,7 @@ class LitShader {
         code += this.frontendDecl;
         code += this.frontendCode;
 
-        if (shadowType === SHADOW_PCF3 && (!device.webgl2 || !device.isWebGPU || lightType === LIGHTTYPE_OMNI)) {
+        if ((shadowType === SHADOW_PCF1 || shadowType === SHADOW_PCF3) && (!device.webgl2 || !device.isWebGPU || lightType === LIGHTTYPE_OMNI)) {
             code += chunks.packDepthPS;
         } else if (shadowType === SHADOW_VSM8) {
             code += "vec2 encodeFloatRG( float v ) {\n";
@@ -551,9 +551,9 @@ class LitShader {
         }
 
         const pcfOmniShadows = device.webgl2 || device.isWebGPU;
-        if (shadowType === SHADOW_PCF3 && (!pcfOmniShadows || (lightType === LIGHTTYPE_OMNI && !options.clusteredLightingEnabled))) {
+        if ((shadowType === SHADOW_PCF1 || shadowType === SHADOW_PCF3) && (!pcfOmniShadows || (lightType === LIGHTTYPE_OMNI && !options.clusteredLightingEnabled))) {
             code += "    gl_FragColor = packFloat(depth);\n";
-        } else if (shadowType === SHADOW_PCF3 || shadowType === SHADOW_PCF5 || shadowType === SHADOW_PCF1) {
+        } else if (shadowType === SHADOW_PCF1 || shadowType === SHADOW_PCF3 || shadowType === SHADOW_PCF5) {
             code += "    gl_FragColor = vec4(1.0);\n"; // just the simplest code, color is not written anyway
 
             // clustered omni light is using shadow sampler and needs to write custom depth
@@ -851,7 +851,7 @@ class LitShader {
             if (shadowedDirectionalLightUsed) {
                 func.append(chunks.shadowCascadesPS);
             }
-            if (shadowTypeUsed[SHADOW_PCF3]) {
+            if (shadowTypeUsed[SHADOW_PCF1] || shadowTypeUsed[SHADOW_PCF3]) {
                 func.append(chunks.shadowStandardPS);
             }
             if (shadowTypeUsed[SHADOW_PCF5] && (device.webgl2 || device.isWebGPU)) {
@@ -1239,6 +1239,8 @@ class LitShader {
                         }
                     } else if (light._shadowType === SHADOW_PCF5) {
                         shadowReadMode = "PCF5x5";
+                    } else if (light._shadowType === SHADOW_PCF1) {
+                        shadowReadMode = "PCF1x1";
                     } else {
                         shadowReadMode = "PCF3x3";
                     }

--- a/src/scene/shader-lib/programs/lit-shader.js
+++ b/src/scene/shader-lib/programs/lit-shader.js
@@ -1224,25 +1224,40 @@ class LitShader {
                 if (light.castShadows && !options.noShadow) {
                     let shadowReadMode = null;
                     let evsmExp;
-                    if (light._shadowType === SHADOW_VSM8) {
-                        shadowReadMode = "VSM8";
-                        evsmExp = "0.0";
-                    } else if (light._shadowType === SHADOW_VSM16) {
-                        shadowReadMode = "VSM16";
-                        evsmExp = "5.54";
-                    } else if (light._shadowType === SHADOW_VSM32) {
-                        shadowReadMode = "VSM32";
-                        if (device.textureFloatHighPrecision) {
-                            evsmExp = "15.0";
-                        } else {
-                            evsmExp = "5.54";
+                    switch (light._shadowType) {
+                        case SHADOW_VSM8: {
+                            shadowReadMode = "VSM8";
+                            evsmExp = "0.0";
+                            break;
                         }
-                    } else if (light._shadowType === SHADOW_PCF5) {
-                        shadowReadMode = "PCF5x5";
-                    } else if (light._shadowType === SHADOW_PCF1) {
-                        shadowReadMode = "PCF1x1";
-                    } else {
-                        shadowReadMode = "PCF3x3";
+                        case SHADOW_VSM16: {
+                            shadowReadMode = "VSM16";
+                            evsmExp = "5.54";
+                            break;
+                        }
+                        case SHADOW_VSM32: {
+                            shadowReadMode = "VSM32";
+                            if (device.textureFloatHighPrecision) {
+                                evsmExp = "15.0";
+                            } else {
+                                evsmExp = "5.54";
+                            }
+                            break;
+                        }
+                        case SHADOW_PCF1: {
+                            shadowReadMode = "PCF1x1";
+                            break;
+                        }
+                        case SHADOW_PCF5: {
+                            shadowReadMode = "PCF5x5";
+                            break;
+                        }
+                        case SHADOW_PCF3:
+                        default:
+                        {
+                            shadowReadMode = "PCF3x3";
+                            break;
+                        }
                     }
 
                     if (shadowReadMode !== null) {

--- a/src/scene/shader-lib/programs/lit-shader.js
+++ b/src/scene/shader-lib/programs/lit-shader.js
@@ -1225,17 +1225,15 @@ class LitShader {
                     let shadowReadMode = null;
                     let evsmExp;
                     switch (light._shadowType) {
-                        case SHADOW_VSM8: {
+                        case SHADOW_VSM8:
                             shadowReadMode = "VSM8";
                             evsmExp = "0.0";
                             break;
-                        }
-                        case SHADOW_VSM16: {
+                        case SHADOW_VSM16:
                             shadowReadMode = "VSM16";
                             evsmExp = "5.54";
                             break;
-                        }
-                        case SHADOW_VSM32: {
+                        case SHADOW_VSM32:
                             shadowReadMode = "VSM32";
                             if (device.textureFloatHighPrecision) {
                                 evsmExp = "15.0";
@@ -1243,21 +1241,16 @@ class LitShader {
                                 evsmExp = "5.54";
                             }
                             break;
-                        }
-                        case SHADOW_PCF1: {
+                        case SHADOW_PCF1:
                             shadowReadMode = "PCF1x1";
                             break;
-                        }
-                        case SHADOW_PCF5: {
+                        case SHADOW_PCF5:
                             shadowReadMode = "PCF5x5";
                             break;
-                        }
                         case SHADOW_PCF3:
                         default:
-                        {
                             shadowReadMode = "PCF3x3";
                             break;
-                        }
                     }
 
                     if (shadowReadMode !== null) {


### PR DESCRIPTION
Updates the light component with support for the PCF1 shadow type when either the directional or spot light type has been selected.

<img width="504" alt="image" src="https://github.com/playcanvas/engine/assets/1721533/16e957b2-ffe2-452a-a169-7594e7e010aa">

Also updates the shadow cascades example with this option.

This is the final change necessary to close #3194

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
