### PR TITLE
Fix for PCF1 filtering of shadows

### DIFF
--- a/src/scene/shader-lib/chunks/lit/frag/shadowStandard.js
+++ b/src/scene/shader-lib/chunks/lit/frag/shadowStandard.js
@@ -62,7 +62,7 @@ float getShadowSpotPCF3x3(SHADOWMAP_ACCEPT(shadowMap), vec3 shadowCoord, vec4 sh
     return _getShadowPCF3x3(SHADOWMAP_PASS(shadowMap), shadowCoord, shadowParams.xyz);
 }
 
-float getShadowPCF1x1(SHADOWMAP_ACCEPT(shadowMap), vec3 shadowCoord, vec3 shadowParams) {
+float getShadowPCF1x1(SHADOWMAP_ACCEPT(shadowMap), vec3 shadowCoord, vec4 shadowParams) {
     return textureShadow(shadowMap, shadowCoord);
 }
 
@@ -125,7 +125,7 @@ float _getShadowPCF1x1(sampler2D shadowMap, vec3 shadowCoord) {
     return shadowSample > shadowCoord.z ? 1.0 : 0.0;
 }
 
-float getShadowPCF1x1(sampler2D shadowMap, vec3 shadowCoord, vec3 shadowParams) {
+float getShadowPCF1x1(sampler2D shadowMap, vec3 shadowCoord, vec4 shadowParams) {
     return _getShadowPCF1x1(shadowMap, shadowCoord);
 }
 


### PR DESCRIPTION
The getShadow functions are now always called with four shadow parameters. The PCF1 function args have been updated to reflect this.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
