### PR TITLE
Initial MRT implementation for WebGPU

### DIFF
--- a/examples/src/examples/graphics/index.mjs
+++ b/examples/src/examples/graphics/index.mjs
@@ -31,6 +31,7 @@ import ModelAssetExample from "./model-asset";
 import ModelOutlineExample from "./model-outline";
 import ModelTexturedBoxExample from "./model-textured-box";
 import MultiViewExample from "./multi-view";
+import MrtExample from "./mrt";
 import PainterExample from "./painter";
 import PaintMeshExample from "./paint-mesh";
 import ParticlesAnimIndexExample from "./particles-anim-index";
@@ -89,6 +90,7 @@ export {
     ModelOutlineExample,
     ModelTexturedBoxExample,
     MultiViewExample,
+    MrtExample,
     PainterExample,
     PaintMeshExample,
     ParticlesAnimIndexExample,

--- a/examples/src/examples/graphics/mrt.tsx
+++ b/examples/src/examples/graphics/mrt.tsx
@@ -1,0 +1,201 @@
+import * as pc from '../../../../';
+
+class MrtExample {
+    static CATEGORY = 'Graphics';
+    static NAME = 'Multi Render Targets';
+    static WEBGPU_ENABLED = true;
+
+    static FILES = {
+
+        // shader chunk which outputs to multiple render targets
+        // Note: gl_FragColor is not modified, and so the forward pass output is used for target 0
+        'output.frag': /* glsl */`
+            #ifdef MYMRT_PASS
+                // output world normal to target 1
+                gl_FragColor1 = vec4(litShaderArgs.worldNormal * 0.5 + 0.5, 1.0);
+
+                // output gloss to target 2
+                gl_FragColor2 = vec4(vec3(litShaderArgs.gloss) , 1.0);
+            #endif
+        `
+    };
+
+    example(canvas: HTMLCanvasElement, deviceType: string, files: { 'output.frag': string, }): void {
+
+        // set up and load draco module, as the glb we load is draco compressed
+        pc.WasmModule.setConfig('DracoDecoderModule', {
+            glueUrl: '/static/lib/draco/draco.wasm.js',
+            wasmUrl: '/static/lib/draco/draco.wasm.wasm',
+            fallbackUrl: '/static/lib/draco/draco.js'
+        });
+
+        const assets = {
+            'board': new pc.Asset('statue', 'container', { url: '/static/assets/models/chess-board.glb' }),
+            helipad: new pc.Asset('helipad-env-atlas', 'texture', { url: '/static/assets/cubemaps/helipad-env-atlas.png' }, { type: pc.TEXTURETYPE_RGBP, mipmaps: false })
+        };
+
+        const gfxOptions = {
+            deviceTypes: [deviceType],
+            glslangUrl: '/static/lib/glslang/glslang.js',
+            twgslUrl: '/static/lib/twgsl/twgsl.js'
+        };
+
+        pc.createGraphicsDevice(canvas, gfxOptions).then((device: pc.GraphicsDevice) => {
+
+            const createOptions = new pc.AppOptions();
+            createOptions.graphicsDevice = device;
+            createOptions.keyboard = new pc.Keyboard(document.body);
+
+            createOptions.componentSystems = [
+                // @ts-ignore
+                pc.RenderComponentSystem,
+                // @ts-ignore
+                pc.CameraComponentSystem,
+                // @ts-ignore
+                pc.LightComponentSystem,
+                // @ts-ignore
+                pc.ScriptComponentSystem,
+                // @ts-ignore
+                pc.ScreenComponentSystem,
+                // @ts-ignore
+                pc.ElementComponentSystem
+            ];
+            createOptions.resourceHandlers = [
+                // @ts-ignore
+                pc.ScriptHandler,
+                // @ts-ignore
+                pc.TextureHandler,
+                // @ts-ignore
+                pc.ContainerHandler,
+                // @ts-ignore
+                pc.FontHandler
+            ];
+
+            const app = new pc.AppBase(canvas);
+            app.init(createOptions);
+
+            // Set the canvas to fill the window and automatically change resolution to be the same as the canvas size
+            app.setCanvasFillMode(pc.FILLMODE_FILL_WINDOW);
+            app.setCanvasResolution(pc.RESOLUTION_AUTO);
+
+            const assetListLoader = new pc.AssetListLoader(Object.values(assets), app.assets);
+            assetListLoader.load(() => {
+
+                app.start();
+
+                // setup skydome
+                app.scene.envAtlas = assets.helipad.resource;
+                app.scene.skyboxMip = 1;
+                app.scene.toneMapping = pc.TONEMAP_ACES;
+
+
+                // get world and skybox layers
+                const worldLayer = app.scene.layers.getLayerByName("World");
+                const skyboxLayer = app.scene.layers.getLayerByName("Skybox");
+
+                // create a layer for object that render into texture, add it right after the world layer
+                const rtLayer = new pc.Layer({ name: "RTLayer" });
+                app.scene.layers.insert(rtLayer, 1);
+
+                // helper function to create a texture to render to
+                const createTexture = (name: string, width: number, height: number) => {
+                    return new pc.Texture(app.graphicsDevice, {
+                        name: name,
+                        width: width,
+                        height: height,
+                        format: pc.PIXELFORMAT_R8_G8_B8_A8,
+                        mipmaps: false,
+                        minFilter: pc.FILTER_LINEAR,
+                        magFilter: pc.FILTER_LINEAR,
+                        addressU: pc.ADDRESS_CLAMP_TO_EDGE,
+                        addressV: pc.ADDRESS_CLAMP_TO_EDGE
+                    });
+                };
+
+                // create textures and render target for rendering into, including depth buffer
+                const texture0 = createTexture('RT-texture-0', 512, 512);
+                const texture1 = createTexture('RT-texture-1', 512, 512);
+                const texture2 = createTexture('RT-texture-2', 512, 512);
+
+                // render to multiple targets if supported
+                const colorBuffers = app.graphicsDevice.supportsMrt ? [texture0, texture1, texture2] : [texture0];
+                const renderTarget = new pc.RenderTarget({
+                    name: `MRT`,
+                    colorBuffers: colorBuffers,
+                    depth: true,
+                    flipY: true,
+                    samples: 2
+                });
+
+                // Create texture camera, which renders entities in RTLayer into the texture
+                const textureCamera = new pc.Entity("TextureCamera");
+                textureCamera.addComponent("camera", {
+                    layers: [rtLayer.id],
+                    farClip: 500,
+
+                    // set the priority of textureCamera to lower number than the priority of the main camera (which is at default 0)
+                    // to make it rendered first each frame
+                    priority: -1,
+
+                    // this camera renders into texture target
+                    renderTarget: renderTarget
+                });
+                app.root.addChild(textureCamera);
+
+                // if MRT is supported, set the shader pass to use MRT output
+                if (app.graphicsDevice.supportsMrt) {
+                    textureCamera.camera.setShaderPass('MyMRT');
+                }
+
+                // get the instance of the chess board. Render it into RTLayer only.
+                const boardEntity = assets.board.resource.instantiateRenderEntity({
+                    layers: [rtLayer.id]
+                });
+                app.root.addChild(boardEntity);
+
+                // override output shader chunk for the material of the chess board, to inject our
+                // custom shader chunk which outputs to multiple render targets during our custom
+                // shader pass
+                const outputChunk = files['output.frag'];
+                const renders: Array<pc.RenderComponent> = boardEntity.findComponents("render");
+                renders.forEach((render) => {
+
+                    const meshInstances = render.meshInstances;
+                    for (let i = 0; i < meshInstances.length; i++) {
+                        // @ts-ignore engine-tsd
+                        meshInstances[i].material.chunks.outputPS = outputChunk;
+                    }
+                });
+
+                // Create an Entity with a camera component
+                const camera: any = new pc.Entity();
+                camera.addComponent("camera", {
+                    layers: [worldLayer.id, skyboxLayer.id]
+                });
+                app.root.addChild(camera);
+
+                // update things every frame
+                let angle = 1;
+                app.on("update", function (dt: any) {
+                    angle += dt;
+
+                    // orbit the camera around
+                    textureCamera.setLocalPosition(110 * Math.sin(angle * 0.2), 45, 110 * Math.cos(angle * 0.2));
+                    textureCamera.lookAt(pc.Vec3.ZERO);
+
+                    // debug draw the texture on the screen in the world layer of the main camera
+                    // @ts-ignore engine-tsd
+                    app.drawTexture(0, 0.4, 1, 1, texture0, null, worldLayer);
+
+                    // @ts-ignore engine-tsd
+                    app.drawTexture(-0.5, -0.5, 0.7, 0.7, texture1, null, worldLayer);
+
+                    // @ts-ignore engine-tsd
+                    app.drawTexture(0.5, -0.5, 0.7, 0.7, texture2, null, worldLayer);
+                });
+            });
+        });
+    }
+}
+
+export default MrtExample;

--- a/examples/src/examples/graphics/mrt.tsx
+++ b/examples/src/examples/graphics/mrt.tsx
@@ -12,10 +12,10 @@ class MrtExample {
         'output.frag': /* glsl */`
             #ifdef MYMRT_PASS
                 // output world normal to target 1
-                gl_FragColor1 = vec4(litShaderArgs.worldNormal * 0.5 + 0.5, 1.0);
+                pcFragColor1 = vec4(litShaderArgs.worldNormal * 0.5 + 0.5, 1.0);
 
                 // output gloss to target 2
-                gl_FragColor2 = vec4(vec3(litShaderArgs.gloss) , 1.0);
+                pcFragColor2 = vec4(vec3(litShaderArgs.gloss) , 1.0);
             #endif
         `
     };

--- a/examples/src/examples/graphics/reflection-planar.tsx
+++ b/examples/src/examples/graphics/reflection-planar.tsx
@@ -40,7 +40,7 @@ class ReflectionPlanarExample {
     example(canvas: HTMLCanvasElement, deviceType: string, files: { 'shader.vert': string, 'shader.frag': string }): void {
 
         const assets = {
-            envatlas: new pc.Asset('helipad-env-atlas', 'texture', { url: '/static/assets/cubemaps/dancing-hall-env-atlas.png' }, { type: pc.TEXTURETYPE_RGBP }),
+            envatlas: new pc.Asset('helipad-env-atlas', 'texture', { url: '/static/assets/cubemaps/dancing-hall-env-atlas.png' }, { type: pc.TEXTURETYPE_RGBP, mipmaps: false }),
             'statue': new pc.Asset('statue', 'container', { url: '/static/assets/models/statue.glb' }),
             'script': new pc.Asset('script', 'script', { url: '/static/scripts/utils/planar-renderer.js' })
         };

--- a/src/platform/graphics/graphics-device.js
+++ b/src/platform/graphics/graphics-device.js
@@ -115,6 +115,15 @@ class GraphicsDevice extends EventHandler {
     supportsStencil;
 
     /**
+     * True if Multiple Render Targets feature is supported. This refers to the ability to render to
+     * multiple color textures with a single draw call.
+     *
+     * @readonly
+     * @type {boolean}
+     */
+    supportsMrt = false;
+
+    /**
      * Currently active render target.
      *
      * @type {import('./render-target.js').RenderTarget}

--- a/src/platform/graphics/shader-chunks/frag/webgpu.js
+++ b/src/platform/graphics/shader-chunks/frag/webgpu.js
@@ -13,13 +13,15 @@ layout(location = 6) out highp vec4 pc_fragColor6;
 layout(location = 7) out highp vec4 pc_fragColor7;
 
 #define gl_FragColor pc_fragColor
-#define gl_FragColor1 pc_fragColor1
-#define gl_FragColor2 pc_fragColor2
-#define gl_FragColor3 pc_fragColor3
-#define gl_FragColor4 pc_fragColor4
-#define gl_FragColor5 pc_fragColor5
-#define gl_FragColor6 pc_fragColor6
-#define gl_FragColor7 pc_fragColor7
+
+#define pcFragColor0 pc_fragColor
+#define pcFragColor1 pc_fragColor1
+#define pcFragColor2 pc_fragColor2
+#define pcFragColor3 pc_fragColor3
+#define pcFragColor4 pc_fragColor4
+#define pcFragColor5 pc_fragColor5
+#define pcFragColor6 pc_fragColor6
+#define pcFragColor7 pc_fragColor7
 
 #define texture2D(res, uv) texture(sampler2D(res, res ## _sampler), uv)
 #define texture2DBias(res, uv, bias) texture(sampler2D(res, res ## _sampler), uv, bias)

--- a/src/platform/graphics/shader-chunks/frag/webgpu.js
+++ b/src/platform/graphics/shader-chunks/frag/webgpu.js
@@ -4,7 +4,22 @@ export default /* glsl */`
 #extension GL_EXT_samplerless_texture_functions : require
 
 layout(location = 0) out highp vec4 pc_fragColor;
+layout(location = 1) out highp vec4 pc_fragColor1;
+layout(location = 2) out highp vec4 pc_fragColor2;
+layout(location = 3) out highp vec4 pc_fragColor3;
+layout(location = 4) out highp vec4 pc_fragColor4;
+layout(location = 5) out highp vec4 pc_fragColor5;
+layout(location = 6) out highp vec4 pc_fragColor6;
+layout(location = 7) out highp vec4 pc_fragColor7;
+
 #define gl_FragColor pc_fragColor
+#define gl_FragColor1 pc_fragColor1
+#define gl_FragColor2 pc_fragColor2
+#define gl_FragColor3 pc_fragColor3
+#define gl_FragColor4 pc_fragColor4
+#define gl_FragColor5 pc_fragColor5
+#define gl_FragColor6 pc_fragColor6
+#define gl_FragColor7 pc_fragColor7
 
 #define texture2D(res, uv) texture(sampler2D(res, res ## _sampler), uv)
 #define texture2DBias(res, uv, bias) texture(sampler2D(res, res ## _sampler), uv, bias)

--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -1297,7 +1297,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
         // clear the render target
         const colorOps = renderPass.colorOps;
         const depthStencilOps = renderPass.depthStencilOps;
-        if (colorOps.clear || depthStencilOps.clearDepth || depthStencilOps.clearStencil) {
+        if (colorOps?.clear || depthStencilOps.clearDepth || depthStencilOps.clearStencil) {
 
             // the pass always clears full target
             const rt = renderPass.renderTarget;
@@ -1309,7 +1309,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
             let clearFlags = 0;
             const clearOptions = {};
 
-            if (colorOps.clear) {
+            if (colorOps?.clear) {
                 clearFlags |= CLEARFLAG_COLOR;
                 clearOptions.color = [colorOps.clearValue.r, colorOps.clearValue.g, colorOps.clearValue.b, colorOps.clearValue.a];
             }
@@ -1360,7 +1360,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
                 const gl = this.gl;
 
                 // invalidate color only if we don't need to resolve it
-                if (!(renderPass.colorOps.store || renderPass.colorOps.resolve)) {
+                if (!(renderPass.colorOps?.store || renderPass.colorOps?.resolve)) {
                     invalidateAttachments.push(gl.COLOR_ATTACHMENT0);
                 }
                 if (!renderPass.depthStencilOps.storeDepth) {
@@ -1381,14 +1381,14 @@ class WebglGraphicsDevice extends GraphicsDevice {
             }
 
             // resolve the color buffer
-            if (renderPass.colorOps.resolve) {
+            if (renderPass.colorOps?.resolve) {
                 if (this.webgl2 && renderPass.samples > 1 && target.autoResolve) {
                     target.resolve(true, false);
                 }
             }
 
             // generate mipmaps
-            if (renderPass.colorOps.mipmaps) {
+            if (renderPass.colorOps?.mipmaps) {
                 const colorBuffer = target._colorBuffer;
                 if (colorBuffer && colorBuffer.impl._glTexture && colorBuffer.mipmaps && (colorBuffer.pot || this.webgl2)) {
                     this.activeTexture(this.maxCombinedTextures - 1);

--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -195,7 +195,7 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
 
         /**
          * @type {GPUDevice}
-         * @ignore
+         * @private
          */
         this.wgpu = await this.gpuAdapter.requestDevice({
             requiredFeatures,

--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -114,6 +114,7 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
         this.supportsAreaLights = true;
         this.supportsDepthShadow = true;
         this.supportsGpuParticles = false;
+        this.supportsMrt = true;
         this.extUintElement = true;
         this.extTextureFloat = true;
         this.textureFloatRenderable = true;
@@ -194,7 +195,7 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
 
         /**
          * @type {GPUDevice}
-         * @private
+         * @ignore
          */
         this.wgpu = await this.gpuAdapter.requestDevice({
             requiredFeatures,
@@ -297,7 +298,7 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
         const wrt = rt.impl;
 
         // assign the format, allowing following init call to use it to allocate matching multisampled buffer
-        wrt.colorFormat = outColorBuffer.format;
+        wrt.setColorAttachment(0, undefined, outColorBuffer.format);
 
         this.initRenderTarget(rt);
 
@@ -556,8 +557,11 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
         this.insideRenderPass = false;
 
         // generate mipmaps
-        if (renderPass.colorOps.mipmaps) {
-            this.mipmapRenderer.generate(renderPass.renderTarget.colorBuffer.impl);
+        for (let i = 0; i < renderPass.colorArrayOps.length; i++) {
+            const colorOps = renderPass.colorArrayOps[i];
+            if (colorOps.mipmaps) {
+                this.mipmapRenderer.generate(renderPass.renderTarget._colorBuffers[i].impl);
+            }
         }
     }
 

--- a/src/platform/graphics/webgpu/webgpu-render-pipeline.js
+++ b/src/platform/graphics/webgpu/webgpu-render-pipeline.js
@@ -295,21 +295,25 @@ class WebgpuRenderPipeline {
             layout: pipelineLayout
         };
 
-        // provide fragment targets only when render target contains color buffer, otherwise rendering to depth only
-        // TODO: the exclusion of fragment here should be reflected in the key generation (no blend, no frag ..)
-        const colorFormat = renderTarget.impl.colorFormat;
-        if (colorFormat) {
+        const colorAttachments = renderTarget.impl.colorAttachments;
+        if (colorAttachments.length > 0) {
 
+            // the same write mask is used by all color buffers, to match the WebGL behavior
             let writeMask = 0;
             if (blendState.redWrite) writeMask |= GPUColorWrite.RED;
             if (blendState.greenWrite) writeMask |= GPUColorWrite.GREEN;
             if (blendState.blueWrite) writeMask |= GPUColorWrite.BLUE;
             if (blendState.alphaWrite) writeMask |= GPUColorWrite.ALPHA;
 
-            descr.fragment.targets.push({
-                format: colorFormat,
-                writeMask: writeMask,
-                blend: this.getBlend(blendState)
+            // the same blend state is used by all color buffers, to match the WebGL behavior
+            const blend = this.getBlend(blendState);
+
+            colorAttachments.forEach((attachment) => {
+                descr.fragment.targets.push({
+                    format: attachment.format,
+                    writeMask: writeMask,
+                    blend: blend
+                });
             });
         }
 

--- a/src/platform/graphics/webgpu/webgpu-render-target.js
+++ b/src/platform/graphics/webgpu/webgpu-render-target.js
@@ -7,11 +7,15 @@ import { WebgpuDebug } from './webgpu-debug.js';
  * @ignore
  */
 class ColorAttachment {
-    /** @type {GPUTextureFormat} */
+    /**
+     * @type {GPUTextureFormat}
+     * @private
+     */
     format;
 
     /**
      * @type {GPUTexture}
+     * @private
      */
     multisampledBuffer;
 
@@ -40,7 +44,10 @@ class WebgpuRenderTarget {
     /** @type {ColorAttachment[]} */
     colorAttachments = [];
 
-    /** @type {GPUTextureFormat} */
+    /**
+     * @type {GPUTextureFormat}
+     * @private
+     */
     depthFormat;
 
     /** @type {boolean} */
@@ -264,6 +271,9 @@ class WebgpuRenderTarget {
         }
     }
 
+    /**
+     * @private
+     */
     initColor(wgpu, renderTarget, index) {
         // Single-sampled color buffer gets passed in:
         // - for normal render target, constructor takes the color buffer as an option

--- a/src/scene/frame-graph.js
+++ b/src/scene/frame-graph.js
@@ -44,8 +44,12 @@ class FrameGraph {
                 if (prevPass) {
 
                     // if we use the RT without clearing, make sure the previous pass stores data
-                    if (!renderPass.colorOps.clear) {
-                        prevPass.colorOps.store = true;
+                    const count = renderPass.colorArrayOps.length;
+                    for (let j = 0; j < count; j++) {
+                        const colorOps = renderPass.colorArrayOps[j];
+                        if (!colorOps.clear) {
+                            prevPass.colorArrayOps[j].store = true;
+                        }
                     }
                     if (!renderPass.depthStencilOps.clearDepth) {
                         prevPass.depthStencilOps.storeDepth = true;
@@ -77,7 +81,10 @@ class FrameGraph {
 
                 // if previous pass used the same cubemap texture, it does not need mipmaps generated
                 if (lastCubeTexture === thisTexture) {
-                    lastCubeRenderPass.colorOps.mipmaps = false;
+                    const count = lastCubeRenderPass.colorArrayOps.length;
+                    for (let j = 0; j < count; j++) {
+                        lastCubeRenderPass.colorArrayOps[j].mipmaps = false;
+                    }
                 }
 
                 lastCubeTexture = renderTarget.colorBuffer;

--- a/src/scene/shader-lib/chunks/chunks.js
+++ b/src/scene/shader-lib/chunks/chunks.js
@@ -89,6 +89,7 @@ import normalSkinnedVS from './lit/vert/normalSkinned.js';
 import normalXYPS from './standard/frag/normalXY.js';
 import normalXYZPS from './standard/frag/normalXYZ.js';
 import opacityPS from './standard/frag/opacity.js';
+import outputPS from './lit/frag/output.js';
 import outputAlphaPS from './lit/frag/outputAlpha.js';
 import outputAlphaOpaquePS from './lit/frag/outputAlphaOpaque.js';
 import outputAlphaPremulPS from './lit/frag/outputAlphaPremul.js';
@@ -296,6 +297,7 @@ const shaderChunks = {
     normalXYPS,
     normalXYZPS,
     opacityPS,
+    outputPS,
     outputAlphaPS,
     outputAlphaOpaquePS,
     outputAlphaPremulPS,

--- a/src/scene/shader-lib/chunks/lit/frag/output.js
+++ b/src/scene/shader-lib/chunks/lit/frag/output.js
@@ -1,0 +1,2 @@
+export default /* glsl */`
+`;

--- a/src/scene/shader-lib/programs/lit-shader.js
+++ b/src/scene/shader-lib/programs/lit-shader.js
@@ -1433,6 +1433,7 @@ class LitShader {
             backend.append("    gl_FragColor = applyMsdf(gl_FragColor);");
         }
 
+        backend.append(chunks.outputPS);
         backend.append(chunks.debugOutputPS);
 
         if (hasPointLights) {


### PR DESCRIPTION
partially implements: https://github.com/playcanvas/engine/issues/4230

Initial multi render target rendering using WebGPU. This allows a single draw call to be rendered into more than one color buffer.

## New API:

- **GraphicsDevice. supportsMrt** - true if MRT is supported, which is WebGPU only for now, soon WebGL2 and WebGL1 with an extension.

- options passed to RenderTarget constructor can contain: **options.colorBuffers** - The textures that this render target will treat as a rendering surfaces. If this option is set, the colorBuffer option is ignored.

- **RenderTarget.getColorBuffer(index)** - returns color buffer with index. This is in addition to existing **RenderTarget.colorBuffer**, which returns buffer with index 0.

- new shader chunk **OutputPS**, empty by default. Override allows output to additional color buffers.

## Basic usage:

1. set up chunk that uses a shader pass to output data into additional color outputs:
```
material.chunks.outputPS = `
  #ifdef MYMRT_PASS
      // optionally override value in pcFragColor0 if needed, otherwise outputs the standard shader output
      pcFragColor1 = vec4(litShaderArgs.worldNormal * 0.5 + 0.5, 1.0);
  #endif
`;
```

2. create render target with multiple buffers
```
  const renderTarget = new pc.RenderTarget({
      colorBuffers: [texture0, texture1],
      depth: true
  });
```

3. enable shader pass that matches the shader chunk on a camera using the render target:
```
    textureCamera.camera.setShaderPass('MyMRT');
```

## Render pass tracing

![Screenshot 2023-05-17 at 14 13 15](https://github.com/playcanvas/engine/assets/59932779/124599b1-5854-463a-b9e4-367b50b82299)

## Example: MRT

https://github.com/playcanvas/engine/assets/59932779/87254539-08a8-4039-88a3-72701829daec

