### PR TITLE
Added ScriptType listen and unlisten API for easier Event subscription handling

### DIFF
--- a/src/framework/script/script-type.js
+++ b/src/framework/script/script-type.js
@@ -3,13 +3,13 @@ import { EventHandler } from '../../core/event-handler.js';
 
 import { SCRIPT_INITIALIZE, SCRIPT_POST_INITIALIZE } from './constants.js';
 import { ScriptAttributes } from './script-attributes.js';
-import { c } from "sinon/lib/sinon/spy-formatters.js";
 
 const funcNameRegex = new RegExp('^\\s*function(?:\\s|\\s*\\/\\*.*\\*\\/\\s*)+([^\\(\\s\\/]*)\\s*');
 
 /**
  * EventListener object used for storing what events on EventHandlers the ScriptType is listening for.
- * @typedef {Object} EventListener
+ *
+ * @typedef {object} EventListener
  * @property {EventHandler} eventHandler - EventHandler to listen for events on.
  * @property {string} name - Name of the event to bind the callback to.
  * @property {HandleEventCallback} callback - Function that is called when event is fired. Note

--- a/src/framework/script/script-type.js
+++ b/src/framework/script/script-type.js
@@ -248,9 +248,10 @@ class ScriptType extends EventHandler {
     }
 
     /**
-     * Attach an event handler to an event.
+     * Listen for an event on an EventHandler. The ScriptType will add and remove the event listeners on the
+     * EventHandler automatically when the ScriptType is enabled, disabled and destroyed.
      *
-     * @param {EventHandler} eventHandler - Name of the event to bind the callback to.
+     * @param {EventHandler} eventHandler - EventHandler to listen for events on.
      * @param {string} name - Name of the event to bind the callback to.
      * @param {HandleEventCallback} callback - Function that is called when event is fired. Note
      * the callback is limited to 8 arguments.
@@ -262,6 +263,7 @@ class ScriptType extends EventHandler {
      *     console.log(a + b);
      * }, this);
      * eventHandler.fire('test', 1, 2); // prints 3 to the console
+     * @see {@link unlisten} to remove listeners to an event on an EventHandler.
      */
     listen(eventHandler, name, callback, scope) {
         this._listeners.push({
@@ -278,7 +280,35 @@ class ScriptType extends EventHandler {
         return this;
     }
 
+    /**
+     * Removes a listener for an event on an EventHandler that was added by {@link listen}.
+     *
+     * @param {EventHandler} eventHandler - EventHandler that was originally listened to.
+     * @param {string} name - Name of the event that was originally listened to.
+     * @param {HandleEventCallback} callback - Function that was used as the callback when the event was originally
+     * listened to.
+     * @param {object} [scope] - Object that was used as the scope when the event was originally listened to
+     * @returns {ScriptType} Self for chaining.
+     * @example
+     * this.unlisten(eventHandler, 'test', callbackFunction, this);
+     * @see {@link listen} to listen to events on an EventHandler.
+     */
     unlisten(eventHandler, name, callback, scope) {
+        let found = false;
+        for (let i = 0; i < this._listeners.length; ++i) {
+            const l = this._listeners[i];
+            if (l.eventHandler === eventHandler && l.name === name && l.callback === callback && l.scope === scope) {
+                this._listeners.splice(i, 1);
+                eventHandler.off(name, callback, scope);
+                found = true;
+                break;
+            }
+        }
+
+        if (!found) {
+            Debug.warn(`${this.__name}: Cannot find listener to remove for event ${name}. Please check where you originally listened for the event.`);
+        }
+
         return this;
     }
 

--- a/src/framework/script/script-type.js
+++ b/src/framework/script/script-type.js
@@ -8,6 +8,16 @@ import { c } from "sinon/lib/sinon/spy-formatters.js";
 const funcNameRegex = new RegExp('^\\s*function(?:\\s|\\s*\\/\\*.*\\*\\/\\s*)+([^\\(\\s\\/]*)\\s*');
 
 /**
+ * EventListener object used for storing what events on EventHandlers the ScriptType is listening for.
+ * @typedef {Object} EventListener
+ * @property {EventHandler} eventHandler - EventHandler to listen for events on.
+ * @property {string} name - Name of the event to bind the callback to.
+ * @property {HandleEventCallback} callback - Function that is called when event is fired. Note
+ * the callback is limited to 8 arguments.
+ * @property {object} [scope] - Object to use as 'this' when the event is fired.
+ */
+
+/**
  * Represents the type of a script. It is returned by {@link createScript}. Also referred to as
  * Script Type.
  *
@@ -61,7 +71,7 @@ class ScriptType extends EventHandler {
     _postInitialized;
 
     /**
-     * @type {any[]}
+     * @type {EventListener[]}
      * @private
      */
     _listeners;
@@ -255,15 +265,11 @@ class ScriptType extends EventHandler {
      * @param {string} name - Name of the event to bind the callback to.
      * @param {HandleEventCallback} callback - Function that is called when event is fired. Note
      * the callback is limited to 8 arguments.
-     * @param {object} [scope] - Object to use as 'this' when the event is fired, defaults to
-     * current this.
+     * @param {object} [scope] - Object to use as 'this' when the event is fired.
      * @returns {ScriptType} Self for chaining.
      * @example
-     * this.listen(eventHandler, 'test', function (a, b) {
-     *     console.log(a + b);
-     * }, this);
-     * eventHandler.fire('test', 1, 2); // prints 3 to the console
-     * @see {@link unlisten} to remove listeners to an event on an EventHandler.
+     * this.listen(this.app.mouse, 'mousemove', this.onMouseMove, this);
+     * @see {@link ScriptType#unlisten} to remove listeners to an event on an EventHandler.
      */
     listen(eventHandler, name, callback, scope) {
         this._listeners.push({
@@ -281,7 +287,7 @@ class ScriptType extends EventHandler {
     }
 
     /**
-     * Removes a listener for an event on an EventHandler that was added by {@link listen}.
+     * Removes a listener for an event on an EventHandler that was added by {@link ScriptType#listen}.
      *
      * @param {EventHandler} eventHandler - EventHandler that was originally listened to.
      * @param {string} name - Name of the event that was originally listened to.
@@ -290,8 +296,8 @@ class ScriptType extends EventHandler {
      * @param {object} [scope] - Object that was used as the scope when the event was originally listened to
      * @returns {ScriptType} Self for chaining.
      * @example
-     * this.unlisten(eventHandler, 'test', callbackFunction, this);
-     * @see {@link listen} to listen to events on an EventHandler.
+     * this.unlisten(this.app.mouse, 'mousemove', this.onMouseMove, this);
+     * @see {@link ScriptType#listen} to listen to events on an EventHandler.
      */
     unlisten(eventHandler, name, callback, scope) {
         let found = false;

--- a/src/framework/script/script-type.js
+++ b/src/framework/script/script-type.js
@@ -6,6 +6,8 @@ import { ScriptAttributes } from './script-attributes.js';
 
 const funcNameRegex = new RegExp('^\\s*function(?:\\s|\\s*\\/\\*.*\\*\\/\\s*)+([^\\(\\s\\/]*)\\s*');
 
+/** @typedef {import('../../core/event-handler.js').HandleEventCallback} HandleEventCallback */
+
 /**
  * EventListener object used for storing what events on EventHandlers the ScriptType is listening for.
  *
@@ -15,6 +17,7 @@ const funcNameRegex = new RegExp('^\\s*function(?:\\s|\\s*\\/\\*.*\\*\\/\\s*)+([
  * @property {HandleEventCallback} callback - Function that is called when event is fired. Note
  * the callback is limited to 8 arguments.
  * @property {object} [scope] - Object to use as 'this' when the event is fired.
+ * @private
  */
 
 /**

--- a/src/framework/script/script-type.js
+++ b/src/framework/script/script-type.js
@@ -269,7 +269,6 @@ class ScriptType extends EventHandler {
      * @param {HandleEventCallback} callback - Function that is called when event is fired. Note
      * the callback is limited to 8 arguments.
      * @param {object} [scope] - Object to use as 'this' when the event is fired.
-     * @returns {ScriptType} Self for chaining.
      * @example
      * this.listen(this.app.mouse, 'mousemove', this.onMouseMove, this);
      * @see {@link ScriptType#unlisten} to remove listeners to an event on an EventHandler.
@@ -285,8 +284,6 @@ class ScriptType extends EventHandler {
         if (this.enabled) {
             eventHandler.on(name, callback, scope);
         }
-
-        return this;
     }
 
     /**
@@ -297,7 +294,6 @@ class ScriptType extends EventHandler {
      * @param {HandleEventCallback} callback - Function that was used as the callback when the event was originally
      * listened to.
      * @param {object} [scope] - Object that was used as the scope when the event was originally listened to
-     * @returns {ScriptType} Self for chaining.
      * @example
      * this.unlisten(this.app.mouse, 'mousemove', this.onMouseMove, this);
      * @see {@link ScriptType#listen} to listen to events on an EventHandler.
@@ -317,8 +313,6 @@ class ScriptType extends EventHandler {
         if (!found) {
             Debug.warn(`${this.__name}: Cannot find listener to remove for event ${name}. Please check where you originally listened for the event.`);
         }
-
-        return this;
     }
 
     /**

--- a/src/framework/script/script-type.js
+++ b/src/framework/script/script-type.js
@@ -299,20 +299,16 @@ class ScriptType extends EventHandler {
      * @see {@link ScriptType#listen} to listen to events on an EventHandler.
      */
     unlisten(eventHandler, name, callback, scope) {
-        let found = false;
         for (let i = 0; i < this._listeners.length; ++i) {
             const l = this._listeners[i];
             if (l.eventHandler === eventHandler && l.name === name && l.callback === callback && l.scope === scope) {
                 this._listeners.splice(i, 1);
                 eventHandler.off(name, callback, scope);
-                found = true;
-                break;
+                return;
             }
         }
 
-        if (!found) {
-            Debug.warn(`${this.__name}: Cannot find listener to remove for event ${name}. Please check where you originally listened for the event.`);
-        }
+        Debug.warn(`${this.__name}: Cannot find listener to remove for event ${name}. Please check where you originally listened for the event.`);
     }
 
     /**

--- a/test/framework/script/script-type.mjs
+++ b/test/framework/script/script-type.mjs
@@ -1,0 +1,84 @@
+import { Application } from '../../../src/framework/application.js';
+import { createScript } from "../../../src/framework/script/script.js";
+import { Entity } from '../../../src/framework/entity.js';
+import { EventHandler } from "../../../src/core/event-handler.js";
+import { ScriptComponent } from '../../../src/framework/components/script/component.js';
+
+import { DummyComponentSystem } from '../test-component/system.mjs';
+
+import { HTMLCanvasElement } from '@playcanvas/canvas-mock';
+
+import { expect } from 'chai';
+
+describe('ScriptType', function () {
+
+    let app;
+    let entity;
+    let scriptInstance;
+    let eventHandler;
+
+    beforeEach(function () {
+        const canvas = new HTMLCanvasElement(500, 500);
+        app = new Application(canvas);
+
+        app.systems.add(new DummyComponentSystem(app));
+
+        createScript('testScriptType');
+
+        entity = new Entity();
+        entity.addComponent('script');
+
+        app.root.addChild(entity);
+
+        scriptInstance = entity.script.create('testScriptType');
+        eventHandler = new EventHandler();
+    });
+
+    afterEach(function () {
+        entity.destroy();
+        app.destroy();
+
+        app = null;
+        entity = null;
+        scriptInstance = null;
+        eventHandler = null;
+    });
+
+    describe('#listen', function () {
+        it(`adds an event subscription to the Event Handler that's passed to it`, function () {
+            scriptInstance.listen(eventHandler, 'test', function () {
+                this.listenCalled = true;
+            }, scriptInstance);
+
+            eventHandler.fire('test');
+
+            expect(scriptInstance.listenCalled).to.equal(true);
+        });
+
+        it(`removes and adds the event subscription when enabled, disabled, destroyed`, function () {
+            scriptInstance.listenCalled = false;
+
+            scriptInstance.listen(eventHandler, 'test', function () {
+                this.listenCalled = true;
+            }, scriptInstance);
+
+            scriptInstance.enabled = false;
+            eventHandler.fire('test');
+            expect(scriptInstance.listenCalled).to.equal(false);
+
+            scriptInstance.listenCalled = false;
+            scriptInstance.enabled = true;
+            eventHandler.fire('test');
+            expect(scriptInstance.listenCalled).to.equal(true);
+
+            scriptInstance.listenCalled = false;
+            entity.script.destroy('testScriptType');
+            eventHandler.fire('test');
+            expect(scriptInstance.listenCalled).to.equal(false);
+        });
+
+        // What happens when listen is called when it is disabled first
+        // What happens when the component is disabled/enabled
+        // What happens when the entity is cloned
+    });
+});

--- a/test/framework/script/script-type.mjs
+++ b/test/framework/script/script-type.mjs
@@ -157,5 +157,34 @@ describe('ScriptType', function () {
             expect(scriptInstance.listenCalled2).not.to.equal(true);
             expect(scriptInstance.listenCalled3).to.equal(true);
         });
+
+        it(`removes the correct event subscription from the Event Handler without scope object`, function () {
+            let callback2Flag = false;
+
+            const callback1 = function () {
+                this.listenCalled1 = true;
+            };
+            const callback2 = function () {
+                callback2Flag = true;
+            };
+            const callback3 = function () {
+                this.listenCalled3 = true;
+            };
+
+            scriptInstance.listen(eventHandler, 'test1', callback1, scriptInstance);
+            scriptInstance.listen(eventHandler, 'test2', callback2);
+            scriptInstance.listen(eventHandler, 'test3', callback3, scriptInstance);
+
+            scriptInstance.unlisten(eventHandler, 'test2', callback2);
+
+            eventHandler.fire('test1');
+            eventHandler.fire('test2');
+            eventHandler.fire('test3');
+
+            expect(scriptInstance.listenCalled1).to.equal(true);
+            expect(scriptInstance.listenCalled3).to.equal(true);
+
+            expect(callback2Flag).to.equal(false);
+        });
     });
 });

--- a/test/framework/script/script-type.mjs
+++ b/test/framework/script/script-type.mjs
@@ -67,11 +67,13 @@ describe('ScriptType', function () {
             expect(scriptInstance.listenCalled).to.equal(false);
 
             scriptInstance.listenCalled = false;
+
             scriptInstance.enabled = true;
             eventHandler.fire('test');
             expect(scriptInstance.listenCalled).to.equal(true);
 
             scriptInstance.listenCalled = false;
+
             entity.script.destroy('testScriptType');
             eventHandler.fire('test');
             expect(scriptInstance.listenCalled).to.equal(false);
@@ -89,11 +91,13 @@ describe('ScriptType', function () {
             expect(scriptInstance.listenCalled).to.equal(false);
 
             scriptInstance.listenCalled = false;
+
             entity.script.enabled = true;
             eventHandler.fire('test');
             expect(scriptInstance.listenCalled).to.equal(true);
 
             scriptInstance.listenCalled = false;
+
             entity.removeComponent('script');
             eventHandler.fire('test');
             expect(scriptInstance.listenCalled).to.equal(false);

--- a/test/framework/script/script-type.mjs
+++ b/test/framework/script/script-type.mjs
@@ -103,7 +103,59 @@ describe('ScriptType', function () {
             expect(scriptInstance.listenCalled).to.equal(false);
         });
 
-        // What happens when listen is called when it is disabled first
-        // What happens when the entity is cloned
+        it(`doesn't add subscription if Script component is disabled before listen is called`, function () {
+            entity.script.enabled = false;
+
+            scriptInstance.listenCalled = false;
+
+            scriptInstance.listen(eventHandler, 'test', function () {
+                this.listenCalled = true;
+            }, scriptInstance);
+
+            eventHandler.fire('test');
+            expect(scriptInstance.listenCalled).to.equal(false);
+        });
+    });
+
+    describe('#unlisten', function () {
+        it(`removes an event subscription from the Event Handler`, function () {
+            const callback = function () {
+                this.listenCalled = true;
+            };
+
+            scriptInstance.listen(eventHandler, 'test', callback, scriptInstance);
+            scriptInstance.unlisten(eventHandler, 'test', callback, scriptInstance);
+
+            scriptInstance.listenCalled = false;
+            eventHandler.fire('test');
+
+            expect(scriptInstance.listenCalled).to.equal(false);
+        });
+
+        it(`removes the correct event subscription from the Event Handler when multiple are used`, function () {
+            const callback1 = function () {
+                this.listenCalled1 = true;
+            };
+            const callback2 = function () {
+                this.listenCalled2 = true;
+            };
+            const callback3 = function () {
+                this.listenCalled3 = true;
+            };
+
+            scriptInstance.listen(eventHandler, 'test1', callback1, scriptInstance);
+            scriptInstance.listen(eventHandler, 'test2', callback2, scriptInstance);
+            scriptInstance.listen(eventHandler, 'test3', callback3, scriptInstance);
+
+            scriptInstance.unlisten(eventHandler, 'test2', callback2, scriptInstance);
+
+            eventHandler.fire('test1');
+            eventHandler.fire('test2');
+            eventHandler.fire('test3');
+
+            expect(scriptInstance.listenCalled1).to.equal(true);
+            expect(scriptInstance.listenCalled2).not.to.equal(true);
+            expect(scriptInstance.listenCalled3).to.equal(true);
+        });
     });
 });

--- a/test/framework/script/script-type.mjs
+++ b/test/framework/script/script-type.mjs
@@ -55,7 +55,7 @@ describe('ScriptType', function () {
             expect(scriptInstance.listenCalled).to.equal(true);
         });
 
-        it(`removes and adds the event subscription when enabled, disabled, destroyed`, function () {
+        it(`removes and adds the event subscription when script instance enabled, disabled, destroyed`, function () {
             scriptInstance.listenCalled = false;
 
             scriptInstance.listen(eventHandler, 'test', function () {
@@ -77,8 +77,29 @@ describe('ScriptType', function () {
             expect(scriptInstance.listenCalled).to.equal(false);
         });
 
+        it(`removes and adds the event subscription when Script component enabled, disabled, destroyed`, function () {
+            scriptInstance.listenCalled = false;
+
+            scriptInstance.listen(eventHandler, 'test', function () {
+                this.listenCalled = true;
+            }, scriptInstance);
+
+            entity.script.enabled = false;
+            eventHandler.fire('test');
+            expect(scriptInstance.listenCalled).to.equal(false);
+
+            scriptInstance.listenCalled = false;
+            entity.script.enabled = true;
+            eventHandler.fire('test');
+            expect(scriptInstance.listenCalled).to.equal(true);
+
+            scriptInstance.listenCalled = false;
+            entity.removeComponent('script');
+            eventHandler.fire('test');
+            expect(scriptInstance.listenCalled).to.equal(false);
+        });
+
         // What happens when listen is called when it is disabled first
-        // What happens when the component is disabled/enabled
         // What happens when the entity is cloned
     });
 });

--- a/test/framework/script/script-type.mjs
+++ b/test/framework/script/script-type.mjs
@@ -1,8 +1,7 @@
 import { Application } from '../../../src/framework/application.js';
-import { createScript } from "../../../src/framework/script/script.js";
+import { createScript } from '../../../src/framework/script/script.js';
 import { Entity } from '../../../src/framework/entity.js';
-import { EventHandler } from "../../../src/core/event-handler.js";
-import { ScriptComponent } from '../../../src/framework/components/script/component.js';
+import { EventHandler } from '../../../src/core/event-handler.js';
 
 import { DummyComponentSystem } from '../test-component/system.mjs';
 
@@ -45,7 +44,7 @@ describe('ScriptType', function () {
     });
 
     describe('#listen', function () {
-        it(`adds an event subscription to the Event Handler that's passed to it`, function () {
+        it('adds an event subscription to the Event Handler that\'s passed to it', function () {
             scriptInstance.listen(eventHandler, 'test', function () {
                 this.listenCalled = true;
             }, scriptInstance);
@@ -55,7 +54,7 @@ describe('ScriptType', function () {
             expect(scriptInstance.listenCalled).to.equal(true);
         });
 
-        it(`removes and adds the event subscription when script instance enabled, disabled, destroyed`, function () {
+        it('removes and adds the event subscription when script instance enabled, disabled, destroyed', function () {
             scriptInstance.listenCalled = false;
 
             scriptInstance.listen(eventHandler, 'test', function () {
@@ -79,7 +78,7 @@ describe('ScriptType', function () {
             expect(scriptInstance.listenCalled).to.equal(false);
         });
 
-        it(`removes and adds the event subscription when Script component enabled, disabled, destroyed`, function () {
+        it('removes and adds the event subscription when Script component enabled, disabled, destroyed', function () {
             scriptInstance.listenCalled = false;
 
             scriptInstance.listen(eventHandler, 'test', function () {
@@ -103,7 +102,7 @@ describe('ScriptType', function () {
             expect(scriptInstance.listenCalled).to.equal(false);
         });
 
-        it(`doesn't add subscription if Script component is disabled before listen is called`, function () {
+        it('doesn\'t add subscription if Script component is disabled before listen is called', function () {
             entity.script.enabled = false;
 
             scriptInstance.listenCalled = false;
@@ -118,7 +117,7 @@ describe('ScriptType', function () {
     });
 
     describe('#unlisten', function () {
-        it(`removes an event subscription from the Event Handler`, function () {
+        it('removes an event subscription from the Event Handler', function () {
             const callback = function () {
                 this.listenCalled = true;
             };
@@ -132,7 +131,7 @@ describe('ScriptType', function () {
             expect(scriptInstance.listenCalled).to.equal(false);
         });
 
-        it(`removes the correct event subscription from the Event Handler when multiple are used`, function () {
+        it('removes the correct event subscription from the Event Handler when multiple are used', function () {
             const callback1 = function () {
                 this.listenCalled1 = true;
             };
@@ -158,7 +157,7 @@ describe('ScriptType', function () {
             expect(scriptInstance.listenCalled3).to.equal(true);
         });
 
-        it(`removes the correct event subscription from the Event Handler without scope object`, function () {
+        it('removes the correct event subscription from the Event Handler without scope object', function () {
             let callback2Flag = false;
 
             const callback1 = function () {


### PR DESCRIPTION
Fixes https://github.com/playcanvas/engine/issues/4910

Test project with the debug version of the engine already included. It has buttons to change scene (destroying entities) and to disable/enable entities with scripts that are listening for mouse and touch events.

https://playcanvas.com/project/1078046/overview/listen-api-test-project

PR includes automated tests as well

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
