### PR TITLE
Fix for multiple non clustered lights

### DIFF
--- a/src/scene/shader-lib/programs/lit-shader.js
+++ b/src/scene/shader-lib/programs/lit-shader.js
@@ -1250,7 +1250,7 @@ class LitShader {
                             hasCascades = true;
                         }
 
-                        backend.append(`    vec3 dShadowCoord = getShadowSampleCoord${i}(${shadowMatrix}, light${i}_shadowParams, vPositionW, dLightPosW, dLightDirW, dLightDirNormW, dVertexNormalW);`);
+                        backend.append(`    dShadowCoord = getShadowSampleCoord${i}(${shadowMatrix}, light${i}_shadowParams, vPositionW, dLightPosW, dLightDirW, dLightDirNormW, dVertexNormalW);`);
 
                         // If cascades are used, fade between them
                         if (hasCascades) {


### PR DESCRIPTION

<img width="885" alt="image" src="https://github.com/playcanvas/engine/assets/1721533/de299414-4f8b-480f-abf3-601e6b1389ed">

The lit shader currently fails to compile when using multiple non clustered lights. This PR removes the redefinition of the `dShadowCoord` variable on line 990.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
