### PR TITLE
Import types for JSDocs

### DIFF
--- a/src/core/math/random.js
+++ b/src/core/math/random.js
@@ -13,7 +13,7 @@ const random = {
     /**
      * Return a pseudo-random 2D point inside a unit circle with uniform distribution.
      *
-     * @param {Vec2} point - The returned generated point.
+     * @param {import('./vec2.js').Vec2} point - The returned generated point.
      * @ignore
      */
     circlePoint: function (point) {
@@ -27,7 +27,7 @@ const random = {
      * Generates evenly distributed deterministic points inside a unit circle using Fermat's spiral
      * and Vogel's method.
      *
-     * @param {Vec2} point - The returned generated point.
+     * @param {import('./vec2.js').Vec2} point - The returned generated point.
      * @param {number} index - Index of the point to generate, in the range from 0 to numPoints - 1.
      * @param {number} numPoints - The total number of points of the set.
      * @ignore
@@ -47,7 +47,7 @@ const random = {
      * sphere). For example by specifying 0.4 and 0.6 and start and end, a band around the equator
      * would be generated.
      *
-     * @param {Vec3} point - The returned generated point.
+     * @param {import('./vec3.js').Vec3} point - The returned generated point.
      * @param {number} index - Index of the point to generate, in the range from 0 to numPoints - 1.
      * @param {number} numPoints - The total number of points of the set.
      * @param {number} [start] - Part on the sphere along y axis to start the points, in the range

--- a/src/framework/anim/controller/anim-blend-tree-1d.js
+++ b/src/framework/anim/controller/anim-blend-tree-1d.js
@@ -12,13 +12,14 @@ class AnimBlendTree1D extends AnimBlendTree {
     /**
      * Create a new BlendTree1D instance.
      *
-     * @param {AnimState} state - The AnimState that this AnimBlendTree belongs to.
+     * @param {import('./anim-state.js').AnimState} state - The AnimState that this AnimBlendTree
+     * belongs to.
      * @param {AnimBlendTree|null} parent - The parent of the AnimBlendTree. If not null, the
      * AnimNode is stored as part of a {@link AnimBlendTree} hierarchy.
-     * @param {string} name - The name of the BlendTree. Used when assigning a {@link AnimTrack} to
-     * its children.
-     * @param {number|Vec2} point - The coordinate/vector thats used to determine the weight of this
-     * node when it's part of a {@link AnimBlendTree}.
+     * @param {string} name - The name of the BlendTree. Used when assigning an {@link AnimTrack}
+     * to its children.
+     * @param {number|import('../../../core/math/vec2.js').Vec2} point - The coordinate/vector
+     * that's used to determine the weight of this node when it's part of an {@link AnimBlendTree}.
      * @param {string[]} parameters - The anim component parameters which are used to calculate the
      * current weights of the blend trees children.
      * @param {object[]} children - The child nodes that this blend tree should create. Can either

--- a/src/framework/anim/controller/anim-blend-tree.js
+++ b/src/framework/anim/controller/anim-blend-tree.js
@@ -12,13 +12,14 @@ class AnimBlendTree extends AnimNode {
     /**
      * Create a new AnimBlendTree instance.
      *
-     * @param {AnimState} state - The AnimState that this AnimBlendTree belongs to.
+     * @param {import('./anim-state.js').AnimState} state - The AnimState that this AnimBlendTree
+     * belongs to.
      * @param {AnimBlendTree|null} parent - The parent of the AnimBlendTree. If not null, the
      * AnimNode is stored as part of a {@link AnimBlendTree} hierarchy.
-     * @param {string} name - The name of the BlendTree. Used when assigning a {@link AnimTrack} to
-     * its children.
-     * @param {number|Vec2} point - The coordinate/vector thats used to determine the weight of this
-     * node when it's part of a {@link AnimBlendTree}.
+     * @param {string} name - The name of the BlendTree. Used when assigning an {@link AnimTrack}
+     * to its children.
+     * @param {number|import('../../../core/math/vec2.js').Vec2} point - The coordinate/vector
+     * that's used to determine the weight of this node when it's part of an {@link AnimBlendTree}.
      * @param {string[]} parameters - The anim component parameters which are used to calculate the
      * current weights of the blend trees children.
      * @param {object[]} children - The child nodes that this blend tree should create. Can either

--- a/src/framework/anim/controller/anim-node.js
+++ b/src/framework/anim/controller/anim-node.js
@@ -11,13 +11,14 @@ class AnimNode {
     /**
      * Create a new AnimNode instance.
      *
-     * @param {AnimState} state - The AnimState that this BlendTree belongs to.
-     * @param {BlendTree|null} parent - The parent of the AnimNode. If not null, the AnimNode is
-     * stored as part of a {@link BlendTree} hierarchy.
-     * @param {string} name - The name of the AnimNode. Used when assigning a {@link AnimTrack} to
+     * @param {import('./anim-state.js').AnimState} state - The AnimState that this BlendTree
+     * belongs to.
+     * @param {import('./anim-blend-tree.js').AnimBlendTree|null} parent - The parent of the AnimNode.
+     * If not null, the AnimNode is stored as part of an {@link AnimBlendTree} hierarchy.
+     * @param {string} name - The name of the AnimNode. Used when assigning an {@link AnimTrack} to
      * it.
      * @param {number[]|number} point - The coordinate/vector thats used to determine the weight of
-     * this node when it's part of a {@link BlendTree}.
+     * this node when it's part of an {@link AnimBlendTree}.
      * @param {number} [speed] - The speed that its {@link AnimTrack} should play at. Defaults to 1.
      */
     constructor(state, parent, name, point, speed = 1) {

--- a/src/framework/anim/controller/anim-state.js
+++ b/src/framework/anim/controller/anim-state.js
@@ -28,7 +28,8 @@ class AnimState {
     /**
      * Create a new AnimState instance.
      *
-     * @param {AnimController} controller - The controller this AnimState is associated with.
+     * @param {import('./anim-controller.js').AnimController} controller - The controller this
+     * AnimState is associated with.
      * @param {string} name - The name of the state. Used to find this state when the controller
      * transitions between states and links animations.
      * @param {number} [speed] - The speed animations in the state should play at. Individual

--- a/src/framework/components/button/component.js
+++ b/src/framework/components/button/component.js
@@ -551,28 +551,28 @@ function toColor3(color4) {
  * Fired when the mouse is pressed while the cursor is on the component.
  *
  * @event ButtonComponent#mousedown
- * @param {ElementMouseEvent} event - The event.
+ * @param {import('../../input/element-input.js').ElementMouseEvent} event - The event.
  */
 
 /**
  * Fired when the mouse is released while the cursor is on the component.
  *
  * @event ButtonComponent#mouseup
- * @param {ElementMouseEvent} event - The event.
+ * @param {import('../../input/element-input.js').ElementMouseEvent} event - The event.
  */
 
 /**
  * Fired when the mouse cursor enters the component.
  *
  * @event ButtonComponent#mouseenter
- * @param {ElementMouseEvent} event - The event.
+ * @param {import('../../input/element-input.js').ElementMouseEvent} event - The event.
  */
 
 /**
  * Fired when the mouse cursor leaves the component.
  *
  * @event ButtonComponent#mouseleave
- * @param {ElementMouseEvent} event - The event.
+ * @param {import('../../input/element-input.js').ElementMouseEvent} event - The event.
  */
 
 /**
@@ -580,63 +580,63 @@ function toColor3(color4) {
  * the component.
  *
  * @event ButtonComponent#click
- * @param {ElementMouseEvent|ElementTouchEvent} event - The event.
+ * @param {import('../../input/element-input.js').ElementMouseEvent|import('../../input/element-input.js').ElementTouchEvent} event - The event.
  */
 
 /**
  * Fired when a touch starts on the component.
  *
  * @event ButtonComponent#touchstart
- * @param {ElementTouchEvent} event - The event.
+ * @param {import('../../input/element-input.js').ElementTouchEvent} event - The event.
  */
 
 /**
  * Fired when a touch ends on the component.
  *
  * @event ButtonComponent#touchend
- * @param {ElementTouchEvent} event - The event.
+ * @param {import('../../input/element-input.js').ElementTouchEvent} event - The event.
  */
 
 /**
  * Fired when a touch is canceled on the component.
  *
  * @event ButtonComponent#touchcancel
- * @param {ElementTouchEvent} event - The event.
+ * @param {import('../../input/element-input.js').ElementTouchEvent} event - The event.
  */
 
 /**
  * Fired when a touch leaves the component.
  *
  * @event ButtonComponent#touchleave
- * @param {ElementTouchEvent} event - The event.
+ * @param {import('../../input/element-input.js').ElementTouchEvent} event - The event.
  */
 
 /**
  * Fired when a xr select starts on the component.
  *
  * @event ButtonComponent#selectstart
- * @param {ElementSelectEvent} event - The event.
+ * @param {import('../../input/element-input.js').ElementSelectEvent} event - The event.
  */
 
 /**
  * Fired when a xr select ends on the component.
  *
  * @event ButtonComponent#selectend
- * @param {ElementSelectEvent} event - The event.
+ * @param {import('../../input/element-input.js').ElementSelectEvent} event - The event.
  */
 
 /**
  * Fired when a xr select now hovering over the component.
  *
  * @event ButtonComponent#selectenter
- * @param {ElementSelectEvent} event - The event.
+ * @param {import('../../input/element-input.js').ElementSelectEvent} event - The event.
  */
 
 /**
  * Fired when a xr select not hovering over the component.
  *
  * @event ButtonComponent#selectleave
- * @param {ElementSelectEvent} event - The event.
+ * @param {import('../../input/element-input.js').ElementSelectEvent} event - The event.
  */
 
 /**

--- a/src/framework/components/collision/component.js
+++ b/src/framework/components/collision/component.js
@@ -348,7 +348,7 @@ class CollisionComponent extends Component {
     }
 
     /**
-     * @param {GraphNode} parent - The parent node.
+     * @param {import('../../../scene/graph-node.js').GraphNode} parent - The parent node.
      * @private
      */
     _onInsert(parent) {

--- a/src/framework/components/collision/trigger.js
+++ b/src/framework/components/collision/trigger.js
@@ -12,8 +12,9 @@ class Trigger {
     /**
      * Create a new Trigger instance.
      *
-     * @param {AppBase} app - The running {@link AppBase}.
-     * @param {Component} component - The component for which the trigger will be created.
+     * @param {import('../../app-base.js').AppBase} app - The running {@link AppBase}.
+     * @param {import('../component.js').Component} component - The component for which the trigger
+     * will be created.
      * @param {ComponentData} data - The data for the component.
      */
     constructor(app, component, data) {

--- a/src/framework/components/element/component.js
+++ b/src/framework/components/element/component.js
@@ -272,7 +272,7 @@ class ElementComponent extends Component {
      * useInput is true.
      *
      * @event ElementComponent#mousedown
-     * @param {ElementMouseEvent} event - The event.
+     * @param {import('../../input/element-input.js').ElementMouseEvent} event - The event.
      */
 
     /**
@@ -280,35 +280,35 @@ class ElementComponent extends Component {
      * useInput is true.
      *
      * @event ElementComponent#mouseup
-     * @param {ElementMouseEvent} event - The event.
+     * @param {import('../../input/element-input.js').ElementMouseEvent} event - The event.
      */
 
     /**
      * Fired when the mouse cursor enters the component. Only fired when useInput is true.
      *
      * @event ElementComponent#mouseenter
-     * @param {ElementMouseEvent} event - The event.
+     * @param {import('../../input/element-input.js').ElementMouseEvent} event - The event.
      */
 
     /**
      * Fired when the mouse cursor leaves the component. Only fired when useInput is true.
      *
      * @event ElementComponent#mouseleave
-     * @param {ElementMouseEvent} event - The event.
+     * @param {import('../../input/element-input.js').ElementMouseEvent} event - The event.
      */
 
     /**
      * Fired when the mouse cursor is moved on the component. Only fired when useInput is true.
      *
      * @event ElementComponent#mousemove
-     * @param {ElementMouseEvent} event - The event.
+     * @param {import('../../input/element-input.js').ElementMouseEvent} event - The event.
      */
 
     /**
      * Fired when the mouse wheel is scrolled on the component. Only fired when useInput is true.
      *
      * @event ElementComponent#mousewheel
-     * @param {ElementMouseEvent} event - The event.
+     * @param {import('../../input/element-input.js').ElementMouseEvent} event - The event.
      */
 
     /**
@@ -316,21 +316,21 @@ class ElementComponent extends Component {
      * ends on the component. Only fired when useInput is true.
      *
      * @event ElementComponent#click
-     * @param {ElementMouseEvent|ElementTouchEvent} event - The event.
+     * @param {import('../../input/element-input.js').ElementMouseEvent|import('../../input/element-input.js').ElementTouchEvent} event - The event.
      */
 
     /**
      * Fired when a touch starts on the component. Only fired when useInput is true.
      *
      * @event ElementComponent#touchstart
-     * @param {ElementTouchEvent} event - The event.
+     * @param {import('../../input/element-input.js').ElementTouchEvent} event - The event.
      */
 
     /**
      * Fired when a touch ends on the component. Only fired when useInput is true.
      *
      * @event ElementComponent#touchend
-     * @param {ElementTouchEvent} event - The event.
+     * @param {import('../../input/element-input.js').ElementTouchEvent} event - The event.
      */
 
     /**
@@ -338,14 +338,14 @@ class ElementComponent extends Component {
      * is true.
      *
      * @event ElementComponent#touchmove
-     * @param {ElementTouchEvent} event - The event.
+     * @param {import('../../input/element-input.js').ElementTouchEvent} event - The event.
      */
 
     /**
      * Fired when a touch is canceled on the component. Only fired when useInput is true.
      *
      * @event ElementComponent#touchcancel
-     * @param {ElementTouchEvent} event - The event.
+     * @param {import('../../input/element-input.js').ElementTouchEvent} event - The event.
      */
 
     get _absLeft() {

--- a/src/framework/components/model/component.js
+++ b/src/framework/components/model/component.js
@@ -733,7 +733,7 @@ class ModelComponent extends Component {
     }
 
     /**
-     * @param {Layer} layer - The layer that was added.
+     * @param {import('../../../scene/layer.js').Layer} layer - The layer that was added.
      * @private
      */
     onLayerAdded(layer) {
@@ -743,7 +743,7 @@ class ModelComponent extends Component {
     }
 
     /**
-     * @param {Layer} layer - The layer that was removed.
+     * @param {import('../../../scene/layer.js').Layer} layer - The layer that was removed.
      * @private
      */
     onLayerRemoved(layer) {

--- a/src/framework/components/sound/slot.js
+++ b/src/framework/components/sound/slot.js
@@ -134,7 +134,8 @@ class SoundSlot extends EventHandler {
      * Fired when the asset assigned to the slot is loaded.
      *
      * @event SoundSlot#load
-     * @param {Sound} sound - The sound resource that was loaded.
+     * @param {import('../../../platform/sound/sound.js').Sound} sound - The sound resource that
+     * was loaded.
      */
 
     /**

--- a/src/framework/components/sprite/component.js
+++ b/src/framework/components/sprite/component.js
@@ -229,7 +229,7 @@ class SpriteComponent extends Component {
     /**
      * The current sprite.
      *
-     * @type {Sprite}
+     * @type {import('../../../scene/sprite.js').Sprite}
      */
     set sprite(value) {
         this._currentClip.sprite = value;

--- a/src/framework/xr/xr-hit-test-source.js
+++ b/src/framework/xr/xr-hit-test-source.js
@@ -72,8 +72,8 @@ class XrHitTestSource extends EventHandler {
      * @event XrHitTestSource#result
      * @param {Vec3} position - Position of hit test.
      * @param {Quat} rotation - Rotation of hit test.
-     * @param {XrInputSource|null} inputSource - If is transient hit test source, then it will
-     * provide related input source.
+     * @param {import('./xr-input-source.js').XrInputSource|null} inputSource - If is transient hit
+     * test source, then it will provide related input source.
      * @example
      * hitTestSource.on('result', function (position, rotation, inputSource) {
      *     target.setPosition(position);

--- a/src/framework/xr/xr-hit-test.js
+++ b/src/framework/xr/xr-hit-test.js
@@ -90,9 +90,10 @@ class XrHitTest extends EventHandler {
      *
      * @event XrHitTest#result
      * @param {XrHitTestSource} hitTestSource - Hit test source that produced the hit result.
-     * @param {Vec3} position - Position of hit test.
-     * @param {Quat} rotation - Rotation of hit test.
-     * @param {XrInputSource|null} inputSource - If is transient hit test source, then it will provide related input source.
+     * @param {import('../../core/math/vec3.js').Vec3} position - Position of hit test.
+     * @param {import('../../core/math/quat.js').Quat} rotation - Rotation of hit test.
+     * @param {import('./xr-input-source.js').XrInputSource|null} inputSource - If is transient hit
+     * test source, then it will provide related input source.
      * @example
      * app.xr.hitTest.on('result', function (hitTestSource, position, rotation, inputSource) {
      *     target.setPosition(position);

--- a/src/platform/sound/manager.js
+++ b/src/platform/sound/manager.js
@@ -127,8 +127,8 @@ class SoundManager extends EventHandler {
     /**
      * Create a new {@link Channel} and begin playback of the sound.
      *
-     * @param {Sound} sound - The Sound object to play.
-     * @param {object} options - Optional options object.
+     * @param {import('./sound.js').Sound} sound - The Sound object to play.
+     * @param {object} [options] - Optional options object.
      * @param {number} [options.volume] - The volume to playback at, between 0 and 1.
      * @param {boolean} [options.loop] - Whether to loop the sound when it reaches the end.
      * @returns {Channel} The channel playing the sound.
@@ -146,8 +146,8 @@ class SoundManager extends EventHandler {
     /**
      * Create a new {@link Channel3d} and begin playback of the sound at the position specified.
      *
-     * @param {Sound} sound - The Sound object to play.
-     * @param {Vec3} position - The position of the sound in 3D space.
+     * @param {import('./sound.js').Sound} sound - The Sound object to play.
+     * @param {import('../../core/math/vec3.js').Vec3} position - The position of the sound in 3D space.
      * @param {object} options - Optional options object.
      * @param {number} [options.volume] - The volume to playback at, between 0 and 1.
      * @param {boolean} [options.loop] - Whether to loop the sound when it reaches the end.

--- a/src/scene/compress/compress-utils.js
+++ b/src/scene/compress/compress-utils.js
@@ -5,7 +5,7 @@ const CompressUtils = {
      * @name CompressUtils#setCompressedPRS
      * @description Set position, rotation and scale of an entity using compressed
      * scene format.
-     * @param {Entity} entity - The entity.
+     * @param {import('../../framework/entity.js').Entity} entity - The entity.
      * @param {object} data - Json entity data from a compressed scene.
      * @param {object} compressed - Compression metadata.
      */

--- a/src/scene/layer.js
+++ b/src/scene/layer.js
@@ -844,8 +844,8 @@ class Layer {
     /**
      * @param {import('./mesh-instance.js').MeshInstance[]} drawCalls - Array of mesh instances.
      * @param {number} drawCallsCount - Number of mesh instances.
-     * @param {Vec3} camPos - Camera position.
-     * @param {Vec3} camFwd - Camera forward vector.
+     * @param {import('../core/math/vec3.js').Vec3} camPos - Camera position.
+     * @param {import('../core/math/vec3.js').Vec3} camFwd - Camera forward vector.
      * @private
      */
     _calculateSortDistances(drawCalls, drawCallsCount, camPos, camFwd) {

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -372,7 +372,7 @@ class Scene extends EventHandler {
      * List of all active composition mesh instances. Only for backwards compatibility.
      * TODO: BatchManager is using it - perhaps that could be refactored
      *
-     * @type {MeshInstance[]}
+     * @type {import('./mesh-instance.js').MeshInstance[]}
      * @private
      */
     set drawCalls(value) {

--- a/src/scene/shader-pass.js
+++ b/src/scene/shader-pass.js
@@ -102,7 +102,8 @@ class ShaderPass {
     /**
      * Get access to the shader pass instance for the specified device.
      *
-     * @param {import('./graphics-device.js').GraphicsDevice} device - The graphics device.
+     * @param {import('../platform/graphics/graphics-device.js').GraphicsDevice} device - The
+     * graphics device.
      * @returns { ShaderPass } The shader pass instance for the specified device.
      */
     static get(device) {


### PR DESCRIPTION
Fixes many instances where the type of something in the JSDocs is not found.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
