### PR TITLE
MRT support for WebGL2

### DIFF
--- a/examples/src/examples/graphics/mrt.tsx
+++ b/examples/src/examples/graphics/mrt.tsx
@@ -104,8 +104,8 @@ class MrtExample {
                         width: width,
                         height: height,
                         format: pc.PIXELFORMAT_R8_G8_B8_A8,
-                        mipmaps: false,
-                        minFilter: pc.FILTER_LINEAR,
+                        mipmaps: true,
+                        minFilter: pc.FILTER_LINEAR_MIPMAP_LINEAR,
                         magFilter: pc.FILTER_LINEAR,
                         addressU: pc.ADDRESS_CLAMP_TO_EDGE,
                         addressV: pc.ADDRESS_CLAMP_TO_EDGE

--- a/src/platform/graphics/graphics-device.js
+++ b/src/platform/graphics/graphics-device.js
@@ -90,6 +90,14 @@ class GraphicsDevice extends EventHandler {
     maxVolumeSize;
 
     /**
+     * The maximum supported number of color buffers attached to a render target.
+     *
+     * @type {number}
+     * @readonly
+     */
+    maxColorAttachments = 1;
+
+    /**
      * The highest shader precision supported by this graphics device. Can be 'hiphp', 'mediump' or
      * 'lowp'.
      *

--- a/src/platform/graphics/shader-chunks/frag/gles2.js
+++ b/src/platform/graphics/shader-chunks/frag/gles2.js
@@ -1,7 +1,7 @@
 export default /* glsl */`
 #define texture2DBias texture2D
 
-// pass / accept shadow map or texture as a function parameter, on webgl this is simply passsed as is
+// pass / accept shadow map or texture as a function parameter, on webgl this is simply passed as is
 // but this is needed for WebGPU
 #define SHADOWMAP_PASS(name) name
 #define SHADOWMAP_ACCEPT(name) sampler2D name

--- a/src/platform/graphics/shader-chunks/frag/gles3.js
+++ b/src/platform/graphics/shader-chunks/frag/gles3.js
@@ -1,7 +1,26 @@
 export default /* glsl */`
 #define varying in
-out highp vec4 pc_fragColor;
+
+layout(location = 0) out highp vec4 pc_fragColor;
+layout(location = 1) out highp vec4 pc_fragColor1;
+layout(location = 2) out highp vec4 pc_fragColor2;
+layout(location = 3) out highp vec4 pc_fragColor3;
+layout(location = 4) out highp vec4 pc_fragColor4;
+layout(location = 5) out highp vec4 pc_fragColor5;
+layout(location = 6) out highp vec4 pc_fragColor6;
+layout(location = 7) out highp vec4 pc_fragColor7;
+
 #define gl_FragColor pc_fragColor
+
+#define pcFragColor0 pc_fragColor
+#define pcFragColor1 pc_fragColor1
+#define pcFragColor2 pc_fragColor2
+#define pcFragColor3 pc_fragColor3
+#define pcFragColor4 pc_fragColor4
+#define pcFragColor5 pc_fragColor5
+#define pcFragColor6 pc_fragColor6
+#define pcFragColor7 pc_fragColor7
+
 #define texture2D texture
 #define texture2DBias texture
 #define textureCube texture
@@ -13,13 +32,13 @@ out highp vec4 pc_fragColor;
 #define texture2DProjGradEXT textureProjGrad
 #define textureCubeGradEXT textureGrad
 
-// sample shadows using textureGrad to remove derivates in the dynamic loops (which are used by
+// sample shadows using textureGrad to remove derivatives in the dynamic loops (which are used by
 // clustered lighting) - as DirectX shader compiler tries to unroll the loops and takes long time
 // to compile the shader. Using textureLod would be even better, but WebGl does not translate it to
 // lod instruction for DirectX correctly and uses SampleCmp instead of SampleCmpLevelZero or similar.
 #define textureShadow(res, uv) textureGrad(res, uv, vec2(1, 1), vec2(1, 1))
 
-// pass / accept shadow map or texture as a function parameter, on webgl this is simply passsed as is
+// pass / accept shadow map or texture as a function parameter, on webgl this is simply passed as is
 // but this is needed for WebGPU
 #define SHADOWMAP_PASS(name) name
 #define SHADOWMAP_ACCEPT(name) sampler2DShadow name

--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -940,6 +940,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
             this.maxDrawBuffers = gl.getParameter(gl.MAX_DRAW_BUFFERS);
             this.maxColorAttachments = gl.getParameter(gl.MAX_COLOR_ATTACHMENTS);
             this.maxVolumeSize = gl.getParameter(gl.MAX_3D_TEXTURE_SIZE);
+            this.supportsMrt = true;
         } else {
             ext = this.extDrawBuffers;
             this.maxDrawBuffers = ext ? gl.getParameter(ext.MAX_DRAW_BUFFERS_EXT) : 1;
@@ -1352,17 +1353,24 @@ class WebglGraphicsDevice extends GraphicsDevice {
         this.unbindVertexArray();
 
         const target = this.renderTarget;
+        const colorBufferCount = renderPass.colorArrayOps.length;
         if (target) {
 
-            // invalidate buffers to stop them being written to on tiled architextures
+            // invalidate buffers to stop them being written to on tiled architectures
             if (this.webgl2) {
                 invalidateAttachments.length = 0;
                 const gl = this.gl;
 
-                // invalidate color only if we don't need to resolve it
-                if (!(renderPass.colorOps?.store || renderPass.colorOps?.resolve)) {
-                    invalidateAttachments.push(gl.COLOR_ATTACHMENT0);
+                // color buffers
+                for (let i = 0; i < colorBufferCount; i++) {
+                    const colorOps = renderPass.colorArrayOps[i];
+
+                    // invalidate color only if we don't need to resolve it
+                    if (!(colorOps.store || colorOps.resolve)) {
+                        invalidateAttachments.push(gl.COLOR_ATTACHMENT0 + i);
+                    }
                 }
+
                 if (!renderPass.depthStencilOps.storeDepth) {
                     invalidateAttachments.push(gl.DEPTH_ATTACHMENT);
                 }
@@ -1380,7 +1388,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
                 }
             }
 
-            // resolve the color buffer
+            // resolve the color buffer (this resolves all MRT color buffers at once)
             if (renderPass.colorOps?.resolve) {
                 if (this.webgl2 && renderPass.samples > 1 && target.autoResolve) {
                     target.resolve(true, false);
@@ -1388,12 +1396,20 @@ class WebglGraphicsDevice extends GraphicsDevice {
             }
 
             // generate mipmaps
-            if (renderPass.colorOps?.mipmaps) {
-                const colorBuffer = target._colorBuffer;
-                if (colorBuffer && colorBuffer.impl._glTexture && colorBuffer.mipmaps && (colorBuffer.pot || this.webgl2)) {
-                    this.activeTexture(this.maxCombinedTextures - 1);
-                    this.bindTexture(colorBuffer);
-                    this.gl.generateMipmap(colorBuffer.impl._glTarget);
+            for (let i = 0; i < colorBufferCount; i++) {
+                const colorOps = renderPass.colorArrayOps[i];
+                if (colorOps.mipmaps) {
+                    const colorBuffer = target._colorBuffers[i];
+                    if (colorBuffer && colorBuffer.impl._glTexture && colorBuffer.mipmaps && (colorBuffer.pot || this.webgl2)) {
+
+                        DebugGraphics.pushGpuMarker(this, `MIPS${i}`);
+
+                        this.activeTexture(this.maxCombinedTextures - 1);
+                        this.bindTexture(colorBuffer);
+                        this.gl.generateMipmap(colorBuffer.impl._glTarget);
+
+                        DebugGraphics.popGpuMarker(this);
+                    }
                 }
             }
         }

--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -865,7 +865,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
             this.extDepthTexture = true;
         } else {
             this.extBlendMinmax = this.getExtension("EXT_blend_minmax");
-            this.extDrawBuffers = this.getExtension('EXT_draw_buffers');
+            this.extDrawBuffers = this.getExtension('WEBGL_draw_buffers');
             this.extInstancing = this.getExtension("ANGLE_instanced_arrays");
             if (this.extInstancing) {
                 // Install the WebGL 2 Instancing API for WebGL 1.0
@@ -943,8 +943,8 @@ class WebglGraphicsDevice extends GraphicsDevice {
             this.supportsMrt = true;
         } else {
             ext = this.extDrawBuffers;
-            this.maxDrawBuffers = ext ? gl.getParameter(ext.MAX_DRAW_BUFFERS_EXT) : 1;
-            this.maxColorAttachments = ext ? gl.getParameter(ext.MAX_COLOR_ATTACHMENTS_EXT) : 1;
+            this.maxDrawBuffers = ext ? gl.getParameter(ext.MAX_DRAW_BUFFERS_WEBGL) : 1;
+            this.maxColorAttachments = ext ? gl.getParameter(ext.MAX_COLOR_ATTACHMENTS_WEBGL) : 1;
             this.maxVolumeSize = 1;
         }
 

--- a/src/platform/graphics/webgl/webgl-render-target.js
+++ b/src/platform/graphics/webgl/webgl-render-target.js
@@ -1,4 +1,35 @@
 import { Debug } from "../../../core/debug.js";
+import { DebugGraphics } from "../debug-graphics.js";
+
+/**
+ * A private class representing a pair of framebuffers, when MSAA is used.
+ *
+ * @ignore
+ */
+class FramebufferPair {
+    /** Multi-sampled rendering framebuffer */
+    msaaFB;
+
+    /** Single-sampled resolve framebuffer */
+    resolveFB;
+
+    constructor(msaaFB, resolveFB) {
+        this.msaaFB = msaaFB;
+        this.resolveFB = resolveFB;
+    }
+
+    destroy(gl) {
+        if (this.msaaFB) {
+            gl.deleteRenderbuffer(this.msaaFB);
+            this.msaaFB = null;
+        }
+
+        if (this.resolveFB) {
+            gl.deleteRenderbuffer(this.resolveFB);
+            this.resolveFB = null;
+        }
+    }
+}
 
 /**
  * A WebGL implementation of the RenderTarget.
@@ -12,7 +43,15 @@ class WebglRenderTarget {
 
     _glResolveFrameBuffer = null;
 
-    _glMsaaColorBuffer = null;
+    /**
+     * A list of framebuffers created When MSAA and MRT are used together, one for each color buffer.
+     * This allows color buffers to be resolved separately.
+     *
+     * @type {FramebufferPair[]}
+     */
+    colorMrtFramebuffers = null;
+
+    _glMsaaColorBuffers = [];
 
     _glMsaaDepthBuffer = null;
 
@@ -33,10 +72,15 @@ class WebglRenderTarget {
             this._glResolveFrameBuffer = null;
         }
 
-        if (this._glMsaaColorBuffer) {
-            gl.deleteRenderbuffer(this._glMsaaColorBuffer);
-            this._glMsaaColorBuffer = null;
-        }
+        this._glMsaaColorBuffers.forEach((buffer) => {
+            gl.deleteRenderbuffer(buffer);
+        });
+        this._glMsaaColorBuffers.length = 0;
+
+        this.colorMrtFramebuffers?.forEach((framebuffer) => {
+            framebuffer.destroy(gl);
+        });
+        this.colorMrtFramebuffers = null;
 
         if (this._glMsaaDepthBuffer) {
             gl.deleteRenderbuffer(this._glMsaaDepthBuffer);
@@ -56,22 +100,32 @@ class WebglRenderTarget {
         device.setFramebuffer(this._glFrameBuffer);
 
         // --- Init the provided color buffer (optional) ---
-        const colorBuffer = target._colorBuffer;
-        if (colorBuffer) {
-            if (!colorBuffer.impl._glTexture) {
-                // Clamp the render buffer size to the maximum supported by the device
-                colorBuffer._width = Math.min(colorBuffer.width, device.maxRenderBufferSize);
-                colorBuffer._height = Math.min(colorBuffer.height, device.maxRenderBufferSize);
-                device.setTexture(colorBuffer, 0);
+        const colorBufferCount = target._colorBuffers?.length ?? 0;
+        const buffers = [];
+        for (let i = 0; i < colorBufferCount; ++i) {
+            const colorBuffer = target.getColorBuffer(i);
+            if (colorBuffer) {
+                if (!colorBuffer.impl._glTexture) {
+                    // Clamp the render buffer size to the maximum supported by the device
+                    colorBuffer._width = Math.min(colorBuffer.width, device.maxRenderBufferSize);
+                    colorBuffer._height = Math.min(colorBuffer.height, device.maxRenderBufferSize);
+                    device.setTexture(colorBuffer, 0);
+                }
+                // Attach the color buffer
+                gl.framebufferTexture2D(
+                    gl.FRAMEBUFFER,
+                    gl.COLOR_ATTACHMENT0 + i,
+                    colorBuffer._cubemap ? gl.TEXTURE_CUBE_MAP_POSITIVE_X + target._face : gl.TEXTURE_2D,
+                    colorBuffer.impl._glTexture,
+                    0
+                );
+
+                buffers.push(gl.COLOR_ATTACHMENT0 + i);
             }
-            // Attach the color buffer
-            gl.framebufferTexture2D(
-                gl.FRAMEBUFFER,
-                gl.COLOR_ATTACHMENT0,
-                colorBuffer._cubemap ? gl.TEXTURE_CUBE_MAP_POSITIVE_X + target._face : gl.TEXTURE_2D,
-                colorBuffer.impl._glTexture,
-                0
-            );
+        }
+
+        if (device.webgl2) {
+            gl.drawBuffers(buffers);
         }
 
         const depthBuffer = target._depthBuffer;
@@ -126,14 +180,19 @@ class WebglRenderTarget {
             this._glFrameBuffer = gl.createFramebuffer();
             device.setFramebuffer(this._glFrameBuffer);
 
-            // Create an optional MSAA color buffer
-            if (colorBuffer) {
-                if (!this._glMsaaColorBuffer) {
-                    this._glMsaaColorBuffer = gl.createRenderbuffer();
+            // Create an optional MSAA color buffers
+
+            const colorBufferCount = target._colorBuffers?.length ?? 0;
+            for (let i = 0; i < colorBufferCount; ++i) {
+                const colorBuffer = target.getColorBuffer(i);
+                if (colorBuffer) {
+                    const buffer = gl.createRenderbuffer();
+                    this._glMsaaColorBuffers.push(buffer);
+
+                    gl.bindRenderbuffer(gl.RENDERBUFFER, buffer);
+                    gl.renderbufferStorageMultisample(gl.RENDERBUFFER, target._samples, colorBuffer.impl._glInternalFormat, target.width, target.height);
+                    gl.framebufferRenderbuffer(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0 + i, gl.RENDERBUFFER, buffer);
                 }
-                gl.bindRenderbuffer(gl.RENDERBUFFER, this._glMsaaColorBuffer);
-                gl.renderbufferStorageMultisample(gl.RENDERBUFFER, target._samples, colorBuffer.impl._glInternalFormat, target.width, target.height);
-                gl.framebufferRenderbuffer(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.RENDERBUFFER, this._glMsaaColorBuffer);
             }
 
             // Optionally add a MSAA depth/stencil buffer
@@ -152,6 +211,51 @@ class WebglRenderTarget {
             }
 
             Debug.call(() => this._checkFbo(device, target, 'MSAA'));
+
+            if (colorBufferCount > 1) {
+                // create framebuffers allowing us to individually resolve each color buffer
+                this._createMsaaMrtFramebuffers(device, target, colorBufferCount);
+
+                // restore rendering back to the main framebuffer
+                device.setFramebuffer(this._glFrameBuffer);
+                gl.drawBuffers(buffers);
+            }
+        }
+    }
+
+    _createMsaaMrtFramebuffers(device, target, colorBufferCount) {
+
+        const gl = device.gl;
+        this.colorMrtFramebuffers = [];
+
+        for (let i = 0; i < colorBufferCount; ++i) {
+            const colorBuffer = target.getColorBuffer(i);
+
+            // src
+            const srcFramebuffer = gl.createFramebuffer();
+            device.setFramebuffer(srcFramebuffer);
+            const buffer = this._glMsaaColorBuffers[i];
+
+            gl.bindRenderbuffer(gl.RENDERBUFFER, buffer);
+            gl.renderbufferStorageMultisample(gl.RENDERBUFFER, target._samples, colorBuffer.impl._glInternalFormat, target.width, target.height);
+            gl.framebufferRenderbuffer(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.RENDERBUFFER, buffer);
+
+            gl.drawBuffers([gl.COLOR_ATTACHMENT0]);
+
+            Debug.call(() => this._checkFbo(device, target, `MSAA-MRT-src${i}`));
+
+            // dst
+            const dstFramebuffer = gl.createFramebuffer();
+            device.setFramebuffer(dstFramebuffer);
+            gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0,
+                                    colorBuffer._cubemap ? gl.TEXTURE_CUBE_MAP_POSITIVE_X + target._face : gl.TEXTURE_2D,
+                                    colorBuffer.impl._glTexture,
+                                    0
+            );
+
+            this.colorMrtFramebuffers[i] = new FramebufferPair(srcFramebuffer, dstFramebuffer);
+
+            Debug.call(() => this._checkFbo(device, target, `MSAA-MRT-dst${i}`));
         }
     }
 
@@ -186,19 +290,55 @@ class WebglRenderTarget {
         this._glFrameBuffer = null;
         this._glDepthBuffer = null;
         this._glResolveFrameBuffer = null;
-        this._glMsaaColorBuffer = null;
+        this._glMsaaColorBuffers.length = 0;
         this._glMsaaDepthBuffer = null;
+        this.colorMrtFramebuffers = null;
+    }
+
+    internalResolve(device, src, dst, target, mask) {
+
+        const gl = device.gl;
+        gl.bindFramebuffer(gl.READ_FRAMEBUFFER, src);
+        gl.bindFramebuffer(gl.DRAW_FRAMEBUFFER, dst);
+        gl.blitFramebuffer(0, 0, target.width, target.height,
+                           0, 0, target.width, target.height,
+                           mask,
+                           gl.NEAREST);
     }
 
     resolve(device, target, color, depth) {
         if (device.webgl2) {
+
             const gl = device.gl;
-            gl.bindFramebuffer(gl.READ_FRAMEBUFFER, this._glFrameBuffer);
-            gl.bindFramebuffer(gl.DRAW_FRAMEBUFFER, this._glResolveFrameBuffer);
-            gl.blitFramebuffer(0, 0, target.width, target.height,
-                               0, 0, target.width, target.height,
-                               (color ? gl.COLOR_BUFFER_BIT : 0) | (depth ? gl.DEPTH_BUFFER_BIT : 0),
-                               gl.NEAREST);
+
+            // if MRT is used, we need to resolve each buffer individually
+            if (this.colorMrtFramebuffers) {
+
+                // color
+                if (color) {
+                    for (let i = 0; i < this.colorMrtFramebuffers.length; i++) {
+                        const fbPair = this.colorMrtFramebuffers[i];
+
+                        DebugGraphics.pushGpuMarker(device, `RESOLVE-MRT${i}`);
+                        this.internalResolve(device, fbPair.msaaFB, fbPair.resolveFB, target, gl.COLOR_BUFFER_BIT);
+                        DebugGraphics.popGpuMarker(device);
+                    }
+                }
+
+                // depth
+                if (depth) {
+                    DebugGraphics.pushGpuMarker(device, `RESOLVE-MRT-DEPTH`);
+                    this.internalResolve(device, this._glFrameBuffer, this._glResolveFrameBuffer, target, gl.DEPTH_BUFFER_BIT);
+                    DebugGraphics.popGpuMarker(device);
+                }
+
+            } else {
+                DebugGraphics.pushGpuMarker(device, `RESOLVE`);
+                this.internalResolve(device, this._glFrameBuffer, this._glResolveFrameBuffer, target,
+                                     (color ? gl.COLOR_BUFFER_BIT : 0) | (depth ? gl.DEPTH_BUFFER_BIT : 0));
+                DebugGraphics.popGpuMarker(device);
+            }
+
             gl.bindFramebuffer(gl.FRAMEBUFFER, this._glFrameBuffer);
         }
     }

--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -106,6 +106,7 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
         this.maxTextureSize = limits.maxTextureDimension2D;
         this.maxCubeMapSize = limits.maxTextureDimension2D;
         this.maxVolumeSize = limits.maxTextureDimension3D;
+        this.maxColorAttachments = limits.maxColorAttachments;
         this.maxPixelRatio = 1;
         this.supportsInstancing = true;
         this.supportsUniformBuffers = true;


### PR DESCRIPTION
partially implements: https://github.com/playcanvas/engine/issues/4230

Follows the WebGPU implementation here https://github.com/playcanvas/engine/pull/5336 and implements matching functionality for WebGL2

## New API
Exposed existing **GraphicsDevice.maxColorAttachments** as a public API

![Screenshot 2023-05-26 at 16 49 01](https://github.com/playcanvas/engine/assets/59932779/9df77fbd-518d-41ff-91ae-ca59b73c3a4e)
