### PR TITLE
Debug logging of textures with their sizes in vram

### DIFF
--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -117,3 +117,10 @@ export const TRACEID_PIPELINELAYOUT_ALLOC = 'PipelineLayoutAlloc';
  * @type {string}
  */
 export const TRACE_ID_ELEMENT = "Element";
+
+/**
+ * Logs the vram use by all textures in memory.
+ *
+ * @type {string}
+ */
+export const TRACEID_TEXTURES = 'Textures';

--- a/src/core/tracing.js
+++ b/src/core/tracing.js
@@ -38,6 +38,7 @@ class Tracing {
      * - {@link TRACEID_VRAM_IB}
      * - {@link TRACEID_RENDERPIPELINE_ALLOC}
      * - {@link TRACEID_PIPELINELAYOUT_ALLOC}
+     * - {@link TRACEID_TEXTURES}
      *
      * @param {boolean} enabled - New enabled state for the channel.
      */

--- a/src/platform/graphics/graphics-device.js
+++ b/src/platform/graphics/graphics-device.js
@@ -2,6 +2,8 @@ import { Debug } from '../../core/debug.js';
 import { EventHandler } from '../../core/event-handler.js';
 import { platform } from '../../core/platform.js';
 import { now } from '../../core/time.js';
+import { Tracing } from '../../core/tracing.js';
+import { TRACEID_TEXTURES } from '../../core/constants.js';
 
 import {
     BUFFER_STATIC,
@@ -650,6 +652,23 @@ class GraphicsDevice extends EventHandler {
      */
     frameStart() {
         this.renderPassIndex = 0;
+
+        Debug.call(() => {
+
+            // log out all loaded textures, sorted by gpu memory size
+            if (Tracing.get(TRACEID_TEXTURES)) {
+                const textures = this.textures.slice();
+                textures.sort((a, b) => b.gpuSize - a.gpuSize);
+                Debug.log(`Textures: ${textures.length}`);
+                let textureTotal = 0;
+                textures.forEach((texture, index) => {
+                    const textureSize  = texture.gpuSize;
+                    textureTotal += textureSize;
+                    Debug.log(`${index}. ${texture.name} ${texture.width}x${texture.height} VRAM: ${(textureSize / 1024 / 1024).toFixed(2)} MB`);
+                });
+                Debug.log(`Total: ${(textureTotal / 1024 / 1024).toFixed(2)}MB`);
+            }
+        });
     }
 }
 


### PR DESCRIPTION
available in debug mode only, enabled by
```
Tracing.set(TRACEID_TEXTURES, true);
```

this logs all in memory textures at the start of the next frame, for example:

<img width="390" alt="Screenshot 2023-05-30 at 15 53 15" src="https://github.com/playcanvas/engine/assets/59932779/4b615be0-d3c4-43d8-b2a9-258ccdd5238c">

