### PR TITLE
Gltf parser supports EXT_texture_webp

### DIFF
--- a/src/framework/parsers/glb-parser.js
+++ b/src/framework/parsers/glb-parser.js
@@ -2171,6 +2171,7 @@ const createTextures = (gltf, images, options) => {
             // resolve image index
             gltfImageIndex = gltfImageIndex ??
                              gltfTexture?.extensions?.KHR_texture_basisu?.source ??
+                             gltfTexture?.extensions?.EXT_texture_webp?.source ??
                              gltfTexture.source;
 
             const cloneAsset = seenImages.has(gltfImageIndex);


### PR DESCRIPTION
fixes https://github.com/playcanvas/engine/issues/5211

if the fallback texture is not available, a webp texture is used