### PR TITLE
Fix import of prettier

### DIFF
--- a/examples/scripts/example-data.mjs
+++ b/examples/scripts/example-data.mjs
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import BabelParser from '@babel/parser';
-import Prettier from 'prettier/standalone';
+import Prettier from 'prettier/standalone.js';
 import Babel from '@babel/standalone';
 import formatters from '../src/app/helpers/formatters.mjs';
 import readDirectoryNames from '../src/app/helpers/read-dir-names.mjs';


### PR DESCRIPTION
Fixes import of prettier to not import it as a module but as a .js file. This fixes build issues with npm 19 and up. 