### PR TITLE
WebGPU handles texture filtering and addressing property changes

### DIFF
--- a/src/platform/graphics/bind-group.js
+++ b/src/platform/graphics/bind-group.js
@@ -13,6 +13,14 @@ let id = 0;
  */
 class BindGroup {
     /**
+     * A render version the bind group was last updated on.
+     *
+     * @type {number}
+     * @ignore
+     */
+    renderVersionUpdated = -1;
+
+    /**
      * Create a new Bind Group.
      *
      * @param {import('./graphics-device.js').GraphicsDevice} graphicsDevice - The graphics device
@@ -79,6 +87,9 @@ class BindGroup {
         if (this.textures[index] !== texture) {
             this.textures[index] = texture;
             this.dirty = true;
+        } else if (this.renderVersionUpdated < texture.renderVersionDirty) {
+            // if the texture properties have changed
+            this.dirty = true;
         }
     }
 
@@ -86,6 +97,8 @@ class BindGroup {
      * Applies any changes made to the bind group's properties.
      */
     update() {
+
+        // TODO: implement faster version of this, which does not call SetTexture, which does a map lookup
 
         const textureFormats = this.format.textureFormats;
         for (let i = 0; i < textureFormats.length; i++) {
@@ -97,6 +110,7 @@ class BindGroup {
 
         if (this.dirty) {
             this.dirty = false;
+            this.renderVersionUpdated = this.device.renderVersion;
             this.impl.update(this);
         }
     }

--- a/src/platform/graphics/graphics-device.js
+++ b/src/platform/graphics/graphics-device.js
@@ -142,6 +142,15 @@ class GraphicsDevice extends EventHandler {
     renderTarget = null;
 
     /**
+     * A version number that is incremented every frame. This is used to detect if some object were
+     * invalidated.
+     *
+     * @type {number}
+     * @ignore
+     */
+    renderVersion = 0;
+
+    /**
      * Index of the currently active render pass.
      *
      * @type {number}
@@ -660,6 +669,7 @@ class GraphicsDevice extends EventHandler {
      */
     frameStart() {
         this.renderPassIndex = 0;
+        this.renderVersion++;
 
         Debug.call(() => {
 

--- a/src/platform/graphics/texture.js
+++ b/src/platform/graphics/texture.js
@@ -48,6 +48,8 @@ class Texture {
     /** @protected */
     _lockedLevel = -1;
 
+    renderVersionDirty = 0;
+
     /**
      * Create a new Texture instance.
      *
@@ -231,9 +233,9 @@ class Texture {
             this._levels = this._cubemap ? [[null, null, null, null, null, null]] : [null];
         }
 
-        this.dirtyAll();
-
         this.impl = graphicsDevice.createTextureImpl(this);
+
+        this.dirtyAll();
 
         // track the texture
         graphicsDevice.textures.push(this);
@@ -305,6 +307,11 @@ class Texture {
         // #endif
     }
 
+    propertyChanged(flag) {
+        this.impl.propertyChanged(flag);
+        this.renderVersionDirty = this.device.renderVersion;
+    }
+
     /**
      * Returns number of required mip levels for the texture based on its dimensions and parameters.
      *
@@ -330,7 +337,7 @@ class Texture {
     set minFilter(v) {
         if (this._minFilter !== v) {
             this._minFilter = v;
-            this._parameterFlags |= 1;
+            this.propertyChanged(1);
         }
     }
 
@@ -349,7 +356,7 @@ class Texture {
     set magFilter(v) {
         if (this._magFilter !== v) {
             this._magFilter = v;
-            this._parameterFlags |= 2;
+            this.propertyChanged(2);
         }
     }
 
@@ -369,7 +376,7 @@ class Texture {
     set addressU(v) {
         if (this._addressU !== v) {
             this._addressU = v;
-            this._parameterFlags |= 4;
+            this.propertyChanged(4);
         }
     }
 
@@ -389,7 +396,7 @@ class Texture {
     set addressV(v) {
         if (this._addressV !== v) {
             this._addressV = v;
-            this._parameterFlags |= 8;
+            this.propertyChanged(8);
         }
     }
 
@@ -414,7 +421,7 @@ class Texture {
         }
         if (addressW !== this._addressW) {
             this._addressW = addressW;
-            this._parameterFlags |= 16;
+            this.propertyChanged(16);
         }
     }
 
@@ -432,7 +439,7 @@ class Texture {
     set compareOnRead(v) {
         if (this._compareOnRead !== v) {
             this._compareOnRead = v;
-            this._parameterFlags |= 32;
+            this.propertyChanged(32);
         }
     }
 
@@ -455,7 +462,7 @@ class Texture {
     set compareFunc(v) {
         if (this._compareFunc !== v) {
             this._compareFunc = v;
-            this._parameterFlags |= 64;
+            this.propertyChanged(64);
         }
     }
 
@@ -472,7 +479,7 @@ class Texture {
     set anisotropy(v) {
         if (this._anisotropy !== v) {
             this._anisotropy = v;
-            this._parameterFlags |= 128;
+            this.propertyChanged(128);
         }
     }
 
@@ -705,7 +712,7 @@ class Texture {
         this._needsMipmapsUpload = this._mipmaps;
         this._mipmapsUploaded = false;
 
-        this._parameterFlags = 255; // 1 | 2 | 4 | 8 | 16 | 32 | 64 | 128
+        this.propertyChanged(255);  // 1 | 2 | 4 | 8 | 16 | 32 | 64 | 128
     }
 
     /**

--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -1586,7 +1586,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
      */
     setTextureParameters(texture) {
         const gl = this.gl;
-        const flags = texture._parameterFlags;
+        const flags = texture.impl.dirtyParameterFlags;
         const target = texture.impl._glTarget;
 
         if (flags & 1) {
@@ -1651,10 +1651,11 @@ class WebglGraphicsDevice extends GraphicsDevice {
      */
     setTexture(texture, textureUnit) {
 
-        if (!texture.impl._glTexture)
-            texture.impl.initialize(this, texture);
+        const impl = texture.impl;
+        if (!impl._glTexture)
+            impl.initialize(this, texture);
 
-        if (texture._parameterFlags > 0 || texture._needsUpload || texture._needsMipmapsUpload) {
+        if (impl.dirtyParameterFlags > 0 || texture._needsUpload || texture._needsMipmapsUpload) {
 
             // Ensure the specified texture unit is active
             this.activeTexture(textureUnit);
@@ -1662,13 +1663,13 @@ class WebglGraphicsDevice extends GraphicsDevice {
             // Ensure the texture is bound on correct target of the specified texture unit
             this.bindTexture(texture);
 
-            if (texture._parameterFlags) {
+            if (impl.dirtyParameterFlags) {
                 this.setTextureParameters(texture);
-                texture._parameterFlags = 0;
+                impl.dirtyParameterFlags = 0;
             }
 
             if (texture._needsUpload || texture._needsMipmapsUpload) {
-                texture.impl.upload(this, texture);
+                impl.upload(this, texture);
                 texture._needsUpload = false;
                 texture._needsMipmapsUpload = false;
             }

--- a/src/platform/graphics/webgl/webgl-texture.js
+++ b/src/platform/graphics/webgl/webgl-texture.js
@@ -59,6 +59,8 @@ class WebglTexture {
 
     _glPixelType;
 
+    dirtyParameterFlags = 0;
+
     destroy(device) {
         if (this._glTexture) {
 
@@ -80,6 +82,10 @@ class WebglTexture {
 
     loseContext() {
         this._glTexture = null;
+    }
+
+    propertyChanged(flag) {
+        this.dirtyParameterFlags |= flag;
     }
 
     initialize(device, texture) {


### PR DESCRIPTION
- when filtering of addressing properties of the texture change, a bind group gets re-created to reflect the change on WebGPU
- small refactor to how this is handled on WebGL as well