### PR TITLE
Expanded Texture class by handling of WebGPU functionality

### DIFF
--- a/src/platform/graphics/graphics-device.js
+++ b/src/platform/graphics/graphics-device.js
@@ -134,6 +134,14 @@ class GraphicsDevice extends EventHandler {
     supportsMrt = false;
 
     /**
+     * True if the device supports volume textures.
+     *
+     * @readonly
+     * @type {boolean}
+     */
+    supportsVolumeTextures = false;
+
+    /**
      * Currently active render target.
      *
      * @type {import('./render-target.js').RenderTarget}

--- a/src/platform/graphics/texture.js
+++ b/src/platform/graphics/texture.js
@@ -59,7 +59,7 @@ class Texture {
      * @param {string} [options.name] - The name of the texture. Defaults to null.
      * @param {number} [options.width] - The width of the texture in pixels. Defaults to 4.
      * @param {number} [options.height] - The height of the texture in pixels. Defaults to 4.
-     * @param {number} [options.depth] - The number of depth slices in a 3D texture (WebGL2 only).
+     * @param {number} [options.depth] - The number of depth slices in a 3D texture (not supported by WebGl1).
      * Defaults to 1 (single 2D image).
      * @param {number} [options.format] - The pixel format of the texture. Can be:
      *
@@ -116,7 +116,7 @@ class Texture {
      * @param {boolean} [options.cubemap] - Specifies whether the texture is to be a cubemap.
      * Defaults to false.
      * @param {boolean} [options.volume] - Specifies whether the texture is to be a 3D volume
-     * (WebGL2 only). Defaults to false.
+     * (not supported by WebGL1). Defaults to false.
      * @param {string} [options.type] - Specifies the texture type.  Can be:
      *
      * - {@link TEXTURETYPE_DEFAULT}
@@ -137,9 +137,9 @@ class Texture {
      * @param {boolean} [options.compareOnRead] - When enabled, and if texture format is
      * {@link PIXELFORMAT_DEPTH} or {@link PIXELFORMAT_DEPTHSTENCIL}, hardware PCF is enabled for
      * this texture, and you can get filtered results of comparison using texture() in your shader
-     * (WebGL2 only). Defaults to false.
+     * (not supported by WebGL1). Defaults to false.
      * @param {number} [options.compareFunc] - Comparison function when compareOnRead is enabled
-     * (WebGL2 only). Can be:
+     * (not supported by WebGL1). Can be:
      *
      * - {@link FUNC_LESS}
      * - {@link FUNC_LESSEQUAL}
@@ -182,7 +182,7 @@ class Texture {
         this._format = options.format ?? PIXELFORMAT_RGBA8;
         this._compressed = isCompressedPixelFormat(this._format);
 
-        if (graphicsDevice.webgl2) {
+        if (graphicsDevice.supportsVolumeTextures) {
             this._volume = options.volume ?? false;
             this._depth = options.depth ?? 1;
         } else {
@@ -405,7 +405,7 @@ class Texture {
     }
 
     /**
-     * The addressing mode to be applied to the 3D texture depth (WebGL2 only). Can be:
+     * The addressing mode to be applied to the 3D texture depth (not supported on WebGL1). Can be:
      *
      * - {@link ADDRESS_REPEAT}
      * - {@link ADDRESS_CLAMP_TO_EDGE}
@@ -414,7 +414,7 @@ class Texture {
      * @type {number}
      */
     set addressW(addressW) {
-        if (!this.device.webgl2) return;
+        if (!this.device.supportsVolumeTextures) return;
         if (!this._volume) {
             Debug.warn("pc.Texture#addressW: Can't set W addressing mode for a non-3D texture.");
             return;
@@ -432,7 +432,7 @@ class Texture {
     /**
      * When enabled, and if texture format is {@link PIXELFORMAT_DEPTH} or
      * {@link PIXELFORMAT_DEPTHSTENCIL}, hardware PCF is enabled for this texture, and you can get
-     * filtered results of comparison using texture() in your shader (WebGL2 only).
+     * filtered results of comparison using texture() in your shader (not supported on WebGL1).
      *
      * @type {boolean}
      */
@@ -448,7 +448,7 @@ class Texture {
     }
 
     /**
-     * Comparison function when compareOnRead is enabled (WebGL2 only). Possible values:
+     * Comparison function when compareOnRead is enabled (not supported on WebGL1). Possible values:
      *
      * - {@link FUNC_LESS}
      * - {@link FUNC_LESSEQUAL}
@@ -527,7 +527,7 @@ class Texture {
     }
 
     /**
-     * The number of depth slices in a 3D texture (WebGL2 only).
+     * The number of depth slices in a 3D texture.
      *
      * @type {number}
      */
@@ -704,7 +704,7 @@ class Texture {
         return result * (cubemap ? 6 : 1);
     }
 
-    // Force a full resubmission of the texture to WebGL (used on a context restore event)
+    // Force a full resubmission of the texture to the GPU (used on a context restore event)
     dirtyAll() {
         this._levelsUpdated = this._cubemap ? [[true, true, true, true, true, true]] : [true];
 

--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -943,6 +943,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
             this.maxColorAttachments = gl.getParameter(gl.MAX_COLOR_ATTACHMENTS);
             this.maxVolumeSize = gl.getParameter(gl.MAX_3D_TEXTURE_SIZE);
             this.supportsMrt = true;
+            this.supportsVolumeTextures = true;
         } else {
             ext = this.extDrawBuffers;
             this.supportsMrt = !!ext;

--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -110,6 +110,7 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
         this.maxPixelRatio = 1;
         this.supportsInstancing = true;
         this.supportsUniformBuffers = true;
+        this.supportsVolumeTextures = true;
         this.supportsBoneTextures = true;
         this.supportsMorphTargetTexturesCore = true;
         this.supportsAreaLights = true;


### PR DESCRIPTION
Code cleanup to handle WebGPU similarly to WebGl2

### New public API
- **GraphicsDevice.supportsVolumeTextures** - true on WebGl2 and WebGPU

