### PR TITLE
Improvements to Texture implementation of cubemaps for WebGPU

### DIFF
--- a/examples/src/examples/graphics/reflection-cubemap.tsx
+++ b/examples/src/examples/graphics/reflection-cubemap.tsx
@@ -145,9 +145,7 @@ class ReflectionCubemapExample {
                 shinyBall.script.create('cubemapRenderer', {
                     attributes: {
                         resolution: 256,
-
-                        // TODO: WebGPU does not yet support cubemap mipmap generation after rendering
-                        mipmaps: !app.graphicsDevice.isWebGPU,
+                        mipmaps: true,
                         depth: true
                     }
                 });

--- a/src/platform/graphics/texture-utils.js
+++ b/src/platform/graphics/texture-utils.js
@@ -1,0 +1,82 @@
+import {
+    pixelFormatByteSizes, pixelFormatBlockSizes,
+    PIXELFORMAT_PVRTC_2BPP_RGB_1, PIXELFORMAT_PVRTC_2BPP_RGBA_1
+} from './constants.js';
+
+/**
+ * A class providing utility functions for textures.
+ *
+ * @ignore
+ */
+class TextureUtils {
+    /**
+     * Calculate the dimension of a texture at a specific mip level.
+     *
+     * @param {number} dimension - Texture dimension at level 0.
+     * @param {number} mipLevel - Mip level.
+     * @returns {number} The dimension of the texture at the specified mip level.
+     */
+    static calcLevelDimension(dimension, mipLevel) {
+        return Math.max(dimension >> mipLevel, 1);
+    }
+
+    /**
+     * Calculate the size in bytes of the texture level given its format and dimensions
+     *
+     * @param {number} width - Texture's width.
+     * @param {number} height - Texture's height.
+     * @param {number} format - Texture's pixel format PIXELFORMAT_***.
+     * @returns {number} The number of bytes of GPU memory required for the texture.
+     * @ignore
+     */
+    static calcLevelGpuSize(width, height, format) {
+
+        const pixelSize = pixelFormatByteSizes.get(format) ?? 0;
+        if (pixelSize > 0) {
+            return width * height * pixelSize;
+        }
+
+        const blockSize = pixelFormatBlockSizes.get(format) ?? 0;
+        let blockWidth = Math.floor((width + 3) / 4);
+        const blockHeight = Math.floor((height + 3) / 4);
+
+        if (format === PIXELFORMAT_PVRTC_2BPP_RGB_1 ||
+            format === PIXELFORMAT_PVRTC_2BPP_RGBA_1) {
+            blockWidth = Math.max(Math.floor(blockWidth / 2), 1);
+        }
+
+        return blockWidth * blockHeight * blockSize;
+    }
+
+    /**
+     * Calculate the GPU memory required for a texture.
+     *
+     * @param {number} width - Texture's width.
+     * @param {number} height - Texture's height.
+     * @param {number} depth - Texture's depth.
+     * @param {number} format - Texture's pixel format PIXELFORMAT_***.
+     * @param {boolean} mipmaps - True if the texture includes mipmaps, false otherwise.
+     * @param {boolean} cubemap - True is the texture is a cubemap, false otherwise.
+     * @returns {number} The number of bytes of GPU memory required for the texture.
+     * @ignore
+     */
+    static calcGpuSize(width, height, depth, format, mipmaps, cubemap) {
+        let result = 0;
+
+        while (1) {
+            result += TextureUtils.calcLevelGpuSize(width, height, format);
+
+            // we're done if mipmaps aren't required or we've calculated the smallest mipmap level
+            if (!mipmaps || ((width === 1) && (height === 1) && (depth === 1))) {
+                break;
+            }
+            width = Math.max(width >> 1, 1);
+            height = Math.max(height >> 1, 1);
+            depth = Math.max(depth >> 1, 1);
+        }
+
+        return result * (cubemap ? 6 : 1);
+    }
+}
+
+export { TextureUtils };

--- a/src/platform/graphics/texture-utils.js
+++ b/src/platform/graphics/texture-utils.js
@@ -21,7 +21,7 @@ class TextureUtils {
     }
 
     /**
-     * Calculate the size in bytes of the texture level given its format and dimensions
+     * Calculate the size in bytes of the texture level given its format and dimensions.
      *
      * @param {number} width - Texture's width.
      * @param {number} height - Texture's height.

--- a/src/platform/graphics/webgpu/webgpu-mipmap-renderer.js
+++ b/src/platform/graphics/webgpu/webgpu-mipmap-renderer.js
@@ -71,8 +71,8 @@ class WebgpuMipmapRenderer {
         }
 
         // not all types are currently supported
-        if (webgpuTexture.texture.cubemap || webgpuTexture.texture.volume) {
-            Debug.warnOnce('WebGPU mipmap generation is not supported for cubemaps or volume texture.', webgpuTexture.texture);
+        if (webgpuTexture.texture.volume) {
+            Debug.warnOnce('WebGPU mipmap generation is not supported volume texture.', webgpuTexture.texture);
             return;
         }
 
@@ -106,47 +106,59 @@ class WebgpuMipmapRenderer {
         });
         DebugHelper.setLabel(pipeline, 'RenderPipeline-MipmapRenderer');
 
-        let srcView = webgpuTexture.createView({
-            baseMipLevel: 0,
-            mipLevelCount: 1
-        });
+        const numFaces = webgpuTexture.texture.cubemap ? 6 : 1;
+
+        const srcViews = [];
+        for (let face = 0; face < numFaces; face++) {
+            srcViews.push(webgpuTexture.createView({
+                dimension: '2d',
+                baseMipLevel: 0,
+                mipLevelCount: 1,
+                baseArrayLayer: face
+            }));
+        }
 
         // loop through each mip level and render the previous level's contents into it.
         const commandEncoder = wgpu.createCommandEncoder();
         for (let i = 1; i < textureDescr.mipLevelCount; i++) {
 
-            const dstView = webgpuTexture.createView({
-                baseMipLevel: i,
-                mipLevelCount: 1
-            });
+            for (let face = 0; face < numFaces; face++) {
 
-            const passEncoder = commandEncoder.beginRenderPass({
-                colorAttachments: [{
-                    view: dstView,
-                    loadOp: 'clear',
-                    storeOp: 'store'
-                }]
-            });
-            DebugHelper.setLabel(passEncoder, `MipmapRenderer-PassEncoder_${i}`);
+                const dstView = webgpuTexture.createView({
+                    dimension: '2d',
+                    baseMipLevel: i,
+                    mipLevelCount: 1,
+                    baseArrayLayer: face
+                });
 
-            const bindGroup = wgpu.createBindGroup({
-                layout: pipeline.getBindGroupLayout(0),
-                entries: [{
-                    binding: 0,
-                    resource: this.minSampler
-                }, {
-                    binding: 1,
-                    resource: srcView
-                }]
-            });
+                const passEncoder = commandEncoder.beginRenderPass({
+                    colorAttachments: [{
+                        view: dstView,
+                        loadOp: 'clear',
+                        storeOp: 'store'
+                    }]
+                });
+                DebugHelper.setLabel(passEncoder, `MipmapRenderer-PassEncoder_${i}`);
 
-            passEncoder.setPipeline(pipeline);
-            passEncoder.setBindGroup(0, bindGroup);
-            passEncoder.draw(4);
-            passEncoder.end();
+                const bindGroup = wgpu.createBindGroup({
+                    layout: pipeline.getBindGroupLayout(0),
+                    entries: [{
+                        binding: 0,
+                        resource: this.minSampler
+                    }, {
+                        binding: 1,
+                        resource: srcViews[face]
+                    }]
+                });
 
-            // next iteration
-            srcView = dstView;
+                passEncoder.setPipeline(pipeline);
+                passEncoder.setBindGroup(0, bindGroup);
+                passEncoder.draw(4);
+                passEncoder.end();
+
+                // next iteration
+                srcViews[face] = dstView;
+            }
         }
 
         wgpu.queue.submit([commandEncoder.finish()]);


### PR DESCRIPTION
- moved few static functions from Texture class to TextureUtils class, allowing those to be called from WebgpuTexture without circular refs.
- implemented support for loading data in TypeArrays into cubemap faces for WebGPU
- implemented support for mipmap generation of cubemaps for WebGPU