### PR TITLE
Added another check condition if it's safari on iOS.

### DIFF
--- a/src/core/platform.js
+++ b/src/core/platform.js
@@ -8,6 +8,7 @@ let touch = false;
 let gamepads = false;
 let workers = false;
 let passiveEvents = false;
+let safariOnIos = false;
 
 if (typeof navigator !== 'undefined') {
     const ua = navigator.userAgent;
@@ -30,6 +31,9 @@ if (typeof navigator !== 'undefined') {
         desktop = false;
         mobile = true;
         ios = true;
+        if (/safari/i.test(ua)) {
+            safariOnIos = true;
+        }
     }
 
     if (typeof window !== 'undefined') {
@@ -157,7 +161,14 @@ const platform = {
      * @type {boolean}
      * @ignore
      */
-    passiveEvents: passiveEvents
+    passiveEvents: passiveEvents,
+
+    /**
+     * if it's safari on iOS.
+     *
+     * @type {boolean}
+     */
+    safariOnIos: safariOnIos
 };
 
 export { platform };

--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -370,6 +370,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
 
         const isChrome = platform.browser && !!window.chrome;
         const isSafari = platform.browser && !!window.safari;
+        const isSafariOnIos = platform.browser && platform.safariOnIos;
         const isMac = platform.browser && navigator.appVersion.indexOf("Mac") !== -1;
 
         // enable temporary texture unit workaround on desktop safari
@@ -392,7 +393,8 @@ class WebglGraphicsDevice extends GraphicsDevice {
         this.initializeContextCaches();
 
         // only enable ImageBitmap on chrome
-        this.supportsImageBitmap = !isSafari && typeof ImageBitmap !== 'undefined';
+        // Need to double check about safari
+        this.supportsImageBitmap = !isSafari && !isSafariOnIos && typeof ImageBitmap !== 'undefined';
 
         this.glAddress = [
             gl.REPEAT,


### PR DESCRIPTION
Fixes #

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).

### Description
On the relatively latest safari on iOS, it keeps trying to load image via _loadImageBitmapFromBlob method.

```javascript
        if (hasContents) {
            // ImageBitmap interface can load iage
            if (this.device.supportsImageBitmap) {
                this._loadImageBitmapFromBlob(new Blob([asset.file.contents]), callback);
                return;
            }
            url = {
                load: URL.createObjectURL(new Blob([asset.file.contents])),
                original: url.original
            };
        }
``` 

According to the code from webgl-graphics-device, it shouldn't be loaded via the method.
Somehow, checking 'Safari' isn't working as expected.

Added additional check condition when it is ios device.

Affected files are
- platform.js
- webgl-graphics-device.js


<img width="1140" alt="SafariOnIosImageBitmap" src="https://github.com/playcanvas/engine/assets/13344642/99d6f7e7-167c-4c2c-980e-f57f8f882b58">
