### PR TITLE
Improvements to texture export functionality to handle compressed textures

### DIFF
--- a/extras/exporters/core-exporter.js
+++ b/extras/exporters/core-exporter.js
@@ -1,3 +1,23 @@
+import {
+    createShaderFromCode, Texture, BlendState, drawQuadWithShader, RenderTarget,
+    PIXELFORMAT_RGBA8, FILTER_LINEAR, ADDRESS_CLAMP_TO_EDGE
+} from 'playcanvas';
+
+const textureBlitVertexShader = `
+    attribute vec2 vertex_position;
+    varying vec2 uv0;
+    void main(void) {
+        gl_Position = vec4(vertex_position, 0.5, 1.0);
+        uv0 = vertex_position.xy * 0.5 + 0.5;
+    }`;
+
+const textureBlitFragmentShader = `
+    varying vec2 uv0;
+    uniform sampler2D blitTexture;
+    void main(void) {
+        gl_FragColor = texture2D(blitTexture, uv0);
+    }`;
+
 class CoreExporter {
     /**
      * Converts a texture to a canvas.
@@ -6,7 +26,7 @@ class CoreExporter {
      * @param {object} options - Object for passing optional arguments.
      * @param {Color} [options.color] - The tint color to modify the texture with.
      * @param {number} [options.maxTextureSize] - Maximum texture size. Texture is resized if over the size.
-     * @returns {HTMLCanvasElement|undefined} - The canvas element containing the image.
+     * @returns {Promise<HTMLCanvasElement>|Promise<undefined>} - The canvas element containing the image.
      */
     textureToCanvas(texture, options = {}) {
 
@@ -18,13 +38,7 @@ class CoreExporter {
             (typeof ImageBitmap !== 'undefined' && image instanceof ImageBitmap)) {
 
             // texture dimensions
-            let { width, height } = image;
-            const maxTextureSize = options.maxTextureSize;
-            if (maxTextureSize) {
-                const scale = Math.min(maxTextureSize / Math.max(width, height), 1);
-                width = Math.round(width * scale);
-                height = Math.round(height * scale);
-            }
+            const { width, height } = this.calcTextureSize(image.width, image.height, options.maxTextureSize);
 
             // convert to a canvas
             const canvas = document.createElement('canvas');
@@ -49,8 +63,65 @@ class CoreExporter {
                 context.putImageData(imagedata, 0, 0);
             }
 
-            return canvas;
+            return Promise.resolve(canvas);
         }
+
+        // for other image sources, for example compressed textures, we extract the data by rendering the texture to a render target
+        const device = texture.device;
+        const { width, height } = this.calcTextureSize(texture.width, texture.height, options.maxTextureSize);
+
+        const dstTexture = new Texture(device, {
+            name: 'ExtractedTexture',
+            width,
+            height,
+            format: PIXELFORMAT_RGBA8,
+            cubemap: false,
+            mipmaps: false,
+            minFilter: FILTER_LINEAR,
+            magFilter: FILTER_LINEAR,
+            addressU: ADDRESS_CLAMP_TO_EDGE,
+            addressV: ADDRESS_CLAMP_TO_EDGE
+        });
+
+        const renderTarget = new RenderTarget({
+            colorBuffer: dstTexture,
+            depth: false
+        });
+
+        // render to a render target using a blit shader
+        const shader = createShaderFromCode(device, textureBlitVertexShader, textureBlitFragmentShader, 'ShaderCoreExporterBlit');
+        device.scope.resolve('blitTexture').setValue(texture);
+        device.setBlendState(BlendState.NOBLEND);
+        drawQuadWithShader(device, renderTarget, shader);
+
+        // read back the pixels
+        // TODO: use async API when ready
+        const pixels = new Uint8ClampedArray(width * height * 4);
+        device.readPixels(0, 0, width, height, pixels);
+
+        dstTexture.destroy();
+        renderTarget.destroy();
+
+        // copy pixels to a canvas
+        const newImage = new ImageData(pixels, width, height);
+        const canvas = document.createElement('canvas');
+        canvas.width = width;
+        canvas.height = height;
+        const newContext = canvas.getContext('2d');
+        newContext.putImageData(newImage, 0, 0);
+
+        return Promise.resolve(canvas);
+    }
+
+    calcTextureSize(width, height, maxTextureSize) {
+
+        if (maxTextureSize) {
+            const scale = Math.min(maxTextureSize / Math.max(width, height), 1);
+            width = Math.round(width * scale);
+            height = Math.round(height * scale);
+        }
+
+        return { width, height };
     }
 }
 

--- a/extras/exporters/gltf-exporter.js
+++ b/extras/exporters/gltf-exporter.js
@@ -461,13 +461,27 @@ class GltfExporter extends CoreExporter {
         }
     }
 
-    convertTextures(textures, json, options) {
+    convertTextures(srcTextures, options) {
 
         const textureOptions = {
             maxTextureSize: options.maxTextureSize
         };
 
-        for (let i = 0; i < textures.length; i++) {
+        const promises = [];
+        srcTextures.forEach((srcTexture) => {
+            const promise = this.textureToCanvas(srcTexture, textureOptions);
+            promise.then((canvas) => {
+                // eslint-disable-next-line no-promise-executor-return
+                return new Promise(resolve => resolve(canvas));
+            });
+            promises.push(promise);
+        });
+        return promises;
+    }
+
+    writeTextures(textures, textureCanvases, json, options) {
+
+        for (let i = 0; i < textureCanvases.length; i++) {
 
             // for now store all textures as png
             // TODO: consider jpg if the alpha channel is not used
@@ -476,7 +490,7 @@ class GltfExporter extends CoreExporter {
 
             // convert texture data to uri
             const texture = textures[i];
-            const canvas = this.textureToCanvas(texture, textureOptions);
+            const canvas = textureCanvases[i];
 
             // if texture format is supported
             if (canvas) {
@@ -506,41 +520,46 @@ class GltfExporter extends CoreExporter {
     }
 
     buildJson(resources, options) {
-        const json = {
-            asset: {
-                version: "2.0",
-                generator: "PlayCanvas GltfExporter"
-            },
-            scenes: [
-                {
-                    nodes: [
-                        0
-                    ]
-                }
-            ],
-            images: [
-            ],
-            samplers: [
-            ],
-            textures: [
-            ],
-            scene: 0
-        };
 
-        this.writeBuffers(resources, json);
-        this.writeBufferViews(resources, json);
-        this.writeCameras(resources, json);
-        this.writeNodes(resources, json);
-        this.writeMaterials(resources, json);
-        this.writeMeshes(resources, json);
-        this.convertTextures(resources.textures, json, options);
+        const promises = this.convertTextures(resources.textures, options);
+        return Promise.all(promises).then((textureCanvases) => {
 
-        // delete unused properties
-        if (!json.images.length) delete json.images;
-        if (!json.samplers.length) delete json.samplers;
-        if (!json.textures.length) delete json.textures;
+            const json = {
+                asset: {
+                    version: "2.0",
+                    generator: "PlayCanvas GltfExporter"
+                },
+                scenes: [
+                    {
+                        nodes: [
+                            0
+                        ]
+                    }
+                ],
+                images: [
+                ],
+                samplers: [
+                ],
+                textures: [
+                ],
+                scene: 0
+            };
 
-        return json;
+            this.writeBuffers(resources, json);
+            this.writeBufferViews(resources, json);
+            this.writeCameras(resources, json);
+            this.writeNodes(resources, json);
+            this.writeMaterials(resources, json);
+            this.writeMeshes(resources, json);
+            this.writeTextures(resources.textures, textureCanvases, json, options);
+
+            // delete unused properties
+            if (!json.images.length) delete json.images;
+            if (!json.samplers.length) delete json.samplers;
+            if (!json.textures.length) delete json.textures;
+
+            return json;
+        });
     }
 
     /**
@@ -549,82 +568,84 @@ class GltfExporter extends CoreExporter {
      * @param {Entity} entity - The root of the entity hierarchy to convert.
      * @param {object} options - Object for passing optional arguments.
      * @param {number} [options.maxTextureSize] - Maximum texture size. Texture is resized if over the size.
-     * @returns {ArrayBuffer} - The GLB file content.
+     * @returns {Promise<ArrayBuffer>} - The GLB file content.
      */
     build(entity, options = {}) {
         const resources = this.collectResources(entity);
 
-        const json = this.buildJson(resources, options);
-        const jsonText = JSON.stringify(json);
+        return this.buildJson(resources, options).then((json) => {
 
-        const headerLength = 12;
+            const jsonText = JSON.stringify(json);
 
-        const jsonHeaderLength = 8;
-        const jsonDataLength = jsonText.length;
-        const jsonPaddingLength = (4 - (jsonDataLength & 3)) & 3;
+            const headerLength = 12;
 
-        const binaryHeaderLength = 8;
-        let binaryDataLength = 0;
-        resources.buffers.forEach((buffer) => {
-            binaryDataLength += buffer.lock().byteLength;
-        });
-        binaryDataLength = math.roundUp(binaryDataLength, 4);
+            const jsonHeaderLength = 8;
+            const jsonDataLength = jsonText.length;
+            const jsonPaddingLength = (4 - (jsonDataLength & 3)) & 3;
 
-        let totalLength = headerLength + jsonHeaderLength + jsonDataLength + jsonPaddingLength;
-        if (binaryDataLength > 0) {
-            totalLength += binaryHeaderLength + binaryDataLength;
-        }
-
-        const glbBuffer = new ArrayBuffer(totalLength);
-        const glbView = new DataView(glbBuffer);
-
-        // GLB header
-        glbView.setUint32(0, 0x46546C67, true);
-        glbView.setUint32(4, 2, true);
-        glbView.setUint32(8, totalLength, true);
-
-        // JSON chunk header
-        glbView.setUint32(12, jsonDataLength + jsonPaddingLength, true);
-        glbView.setUint32(16, 0x4E4F534A, true);
-
-        let offset = headerLength + jsonHeaderLength;
-
-        // JSON data
-        for (let i = 0; i < jsonDataLength; i++) {
-            glbView.setUint8(offset + i, jsonText.charCodeAt(i));
-        }
-
-        offset += jsonDataLength;
-
-        for (let i = 0; i < jsonPaddingLength; i++) {
-            glbView.setUint8(offset + i, 0x20);
-        }
-
-        offset += jsonPaddingLength;
-
-        if (binaryDataLength > 0) {
-            // Binary chunk header
-            glbView.setUint32(offset, binaryDataLength, true);
-            glbView.setUint32(offset + 4, 0x004E4942, true);
-
-            offset += binaryHeaderLength;
-
+            const binaryHeaderLength = 8;
+            let binaryDataLength = 0;
             resources.buffers.forEach((buffer) => {
-                const srcBuffer = buffer.lock();
-                let src;
-                if (srcBuffer instanceof ArrayBuffer) {
-                    src = new Uint8Array(srcBuffer);
-                } else {
-                    src = new Uint8Array(srcBuffer.buffer, srcBuffer.byteOffset, srcBuffer.byteLength);
-                }
-                const dst = new Uint8Array(glbBuffer, offset, srcBuffer.byteLength);
-                dst.set(src);
-
-                offset += srcBuffer.byteLength;
+                binaryDataLength += buffer.lock().byteLength;
             });
-        }
+            binaryDataLength = math.roundUp(binaryDataLength, 4);
 
-        return Promise.resolve(glbBuffer);
+            let totalLength = headerLength + jsonHeaderLength + jsonDataLength + jsonPaddingLength;
+            if (binaryDataLength > 0) {
+                totalLength += binaryHeaderLength + binaryDataLength;
+            }
+
+            const glbBuffer = new ArrayBuffer(totalLength);
+            const glbView = new DataView(glbBuffer);
+
+            // GLB header
+            glbView.setUint32(0, 0x46546C67, true);
+            glbView.setUint32(4, 2, true);
+            glbView.setUint32(8, totalLength, true);
+
+            // JSON chunk header
+            glbView.setUint32(12, jsonDataLength + jsonPaddingLength, true);
+            glbView.setUint32(16, 0x4E4F534A, true);
+
+            let offset = headerLength + jsonHeaderLength;
+
+            // JSON data
+            for (let i = 0; i < jsonDataLength; i++) {
+                glbView.setUint8(offset + i, jsonText.charCodeAt(i));
+            }
+
+            offset += jsonDataLength;
+
+            for (let i = 0; i < jsonPaddingLength; i++) {
+                glbView.setUint8(offset + i, 0x20);
+            }
+
+            offset += jsonPaddingLength;
+
+            if (binaryDataLength > 0) {
+                // Binary chunk header
+                glbView.setUint32(offset, binaryDataLength, true);
+                glbView.setUint32(offset + 4, 0x004E4942, true);
+
+                offset += binaryHeaderLength;
+
+                resources.buffers.forEach((buffer) => {
+                    const srcBuffer = buffer.lock();
+                    let src;
+                    if (srcBuffer instanceof ArrayBuffer) {
+                        src = new Uint8Array(srcBuffer);
+                    } else {
+                        src = new Uint8Array(srcBuffer.buffer, srcBuffer.byteOffset, srcBuffer.byteLength);
+                    }
+                    const dst = new Uint8Array(glbBuffer, offset, srcBuffer.byteLength);
+                    dst.set(src);
+
+                    offset += srcBuffer.byteLength;
+                });
+            }
+
+            return Promise.resolve(glbBuffer);
+        });
     }
 }
 


### PR DESCRIPTION
Improvements to texture conversion code to canvas, which is internally used by Usdz and Gltf exporters. If the texture is not natively supported by the browser, it gets rendered by a simple shader to render target (which decompresses it from Basis or other compressed formats). We extract pixels from this render target and construct a canvas from it.

Note that this function has internally been made async and returns a promise, to in the future allow async getPixels call.

Additionally, the exporters themselves were update to use this modified function as async, so their internal flow has been changed a bit to handle this.

Fix: originally, those public export functions were incorrectly declaring return type as `ArrayBuffer`. This has now been fixed to declare it as `Promise<ArrayBuffer>` as that is what they are returning.