### PR TITLE
Support loading cubemap prefiltered envatlas

### DIFF
--- a/src/framework/handlers/cubemap.js
+++ b/src/framework/handlers/cubemap.js
@@ -1,6 +1,6 @@
 import {
     ADDRESS_CLAMP_TO_EDGE, PIXELFORMAT_RGB8, PIXELFORMAT_RGBA8,
-    TEXTURETYPE_DEFAULT, TEXTURETYPE_RGBM
+    TEXTURETYPE_DEFAULT, TEXTURETYPE_RGBM, TEXTURETYPE_RGBP
 } from '../../platform/graphics/constants.js';
 import { Texture } from '../../platform/graphics/texture.js';
 
@@ -115,22 +115,28 @@ class CubemapHandler {
             // prelit asset changed
             if (assets[0]) {
                 tex = assets[0].resource;
-                for (i = 0; i < 6; ++i) {
-                    resources[i + 1] = new Texture(this._device, {
-                        name: cubemapAsset.name + '_prelitCubemap' + (tex.width >> i),
-                        cubemap: true,
-                        // assume prefiltered data has same encoding as the faces asset
-                        type: getType() || tex.type,
-                        width: tex.width >> i,
-                        height: tex.height >> i,
-                        format: tex.format,
-                        levels: [tex._levels[i]],
-                        fixCubemapSeams: true,
-                        addressU: ADDRESS_CLAMP_TO_EDGE,
-                        addressV: ADDRESS_CLAMP_TO_EDGE,
-                        // generate cubemaps on the top level only
-                        mipmaps: i === 0
-                    });
+                if (tex.cubemap) {
+                    for (i = 0; i < 6; ++i) {
+                        resources[i + 1] = new Texture(this._device, {
+                            name: cubemapAsset.name + '_prelitCubemap' + (tex.width >> i),
+                            cubemap: true,
+                            // assume prefiltered data has same encoding as the faces asset
+                            type: getType() || tex.type,
+                            width: tex.width >> i,
+                            height: tex.height >> i,
+                            format: tex.format,
+                            levels: [tex._levels[i]],
+                            fixCubemapSeams: true,
+                            addressU: ADDRESS_CLAMP_TO_EDGE,
+                            addressV: ADDRESS_CLAMP_TO_EDGE,
+                            // generate cubemaps on the top level only
+                            mipmaps: i === 0
+                        });
+                    }
+                } else {
+                    // prefiltered data is an env atlas
+                    tex.type = TEXTURETYPE_RGBP;
+                    resources[1] = tex;
                 }
             }
         } else {

--- a/src/scene/graphics/env-lighting.js
+++ b/src/scene/graphics/env-lighting.js
@@ -2,7 +2,7 @@ import { Vec4 } from '../../core/math/vec4.js';
 import { Texture } from '../../platform/graphics/texture.js';
 import { reprojectTexture } from './reproject-texture.js';
 import {
-    TEXTURETYPE_DEFAULT, TEXTURETYPE_RGBM,
+    TEXTURETYPE_DEFAULT, TEXTURETYPE_RGBP as RGBA8_TYPE,
     TEXTUREPROJECTION_EQUIRECT,
     ADDRESS_CLAMP_TO_EDGE,
     PIXELFORMAT_RGBA8, PIXELFORMAT_RGBA16F, PIXELFORMAT_RGBA32F
@@ -10,7 +10,6 @@ import {
 import { DebugGraphics } from '../../platform/graphics/debug-graphics.js';
 
 const fixCubemapSeams = true;
-const RGBA8_TYPE = TEXTURETYPE_RGBM;
 
 // calculate the number of mipmap levels given texture dimensions
 const calcLevels = (width, height = 0) => {

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -790,8 +790,10 @@ class Scene extends EventHandler {
         } else {
             this.skybox = cubemaps[0] || null;
             if (cubemaps[1] && !cubemaps[1].cubemap) {
+                // prefiltered data is an env atlas
                 this.envAtlas = cubemaps[1];
             } else {
+                // prefiltered data is a set of cubemaps
                 this.prefilteredCubemaps = cubemaps.slice(1);
             }
         }

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -789,7 +789,11 @@ class Scene extends EventHandler {
             this.prefilteredCubemaps = [null, null, null, null, null, null];
         } else {
             this.skybox = cubemaps[0] || null;
-            this.prefilteredCubemaps = cubemaps.slice(1);
+            if (cubemaps[1] && !cubemaps[1].cubemap) {
+                this.envAtlas = cubemaps[1];
+            } else {
+                this.prefilteredCubemaps = cubemaps.slice(1);
+            }
         }
     }
 


### PR DESCRIPTION
This PR:
- adds cubemap asset support for specifying envAtlas prefiltered lighting
- defaults envLighting to RGBP format
