### PR TITLE
Prefiltered lighting fixes

### DIFF
--- a/src/scene/materials/lit-options.js
+++ b/src/scene/materials/lit-options.js
@@ -288,8 +288,8 @@ class LitOptions {
      * @type {string}
      */
     reflectionSource = null;
-
     reflectionEncoding = null;
+    reflectionCubemapEncoding = null;
 
     /**
      * One of "ambientSH", "envAtlas", "constant".

--- a/src/scene/materials/lit-options.js
+++ b/src/scene/materials/lit-options.js
@@ -288,7 +288,9 @@ class LitOptions {
      * @type {string}
      */
     reflectionSource = null;
+
     reflectionEncoding = null;
+
     reflectionCubemapEncoding = null;
 
     /**

--- a/src/scene/materials/standard-material-options-builder.js
+++ b/src/scene/materials/standard-material-options-builder.js
@@ -305,6 +305,7 @@ class StandardMaterialOptionsBuilder {
         if (stdMat.envAtlas && stdMat.cubeMap && !isPhong) {
             options.litOptions.reflectionSource = 'envAtlasHQ';
             options.litOptions.reflectionEncoding = stdMat.envAtlas.encoding;
+            options.litOptions.reflectionCubemapEncoding = stdMat.cubeMap.encoding;
         } else if (stdMat.envAtlas && !isPhong) {
             options.litOptions.reflectionSource = 'envAtlas';
             options.litOptions.reflectionEncoding = stdMat.envAtlas.encoding;
@@ -317,6 +318,7 @@ class StandardMaterialOptionsBuilder {
         } else if (stdMat.useSkybox && scene.envAtlas && scene.skybox && !isPhong) {
             options.litOptions.reflectionSource = 'envAtlasHQ';
             options.litOptions.reflectionEncoding = scene.envAtlas.encoding;
+            options.litOptions.reflectionCubemapEncoding = scene.skybox.encoding;
             usingSceneEnv = true;
         } else if (stdMat.useSkybox && scene.envAtlas && !isPhong) {
             options.litOptions.reflectionSource = 'envAtlas';

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -786,14 +786,17 @@ class Scene extends EventHandler {
     setSkybox(cubemaps) {
         if (!cubemaps) {
             this.skybox = null;
+            this.envAtlas = null;
             this.prefilteredCubemaps = [null, null, null, null, null, null];
         } else {
             this.skybox = cubemaps[0] || null;
             if (cubemaps[1] && !cubemaps[1].cubemap) {
                 // prefiltered data is an env atlas
                 this.envAtlas = cubemaps[1];
+                this.prefilteredCubemaps = [null, null, null, null, null, null];
             } else {
                 // prefiltered data is a set of cubemaps
+                this.envAtlas = null;
                 this.prefilteredCubemaps = cubemaps.slice(1);
             }
         }

--- a/src/scene/shader-lib/chunks/lit/frag/reflectionEnvHQ.js
+++ b/src/scene/shader-lib/chunks/lit/frag/reflectionEnvHQ.js
@@ -15,7 +15,7 @@ vec3 calcReflection(vec3 reflDir, float gloss) {
     float ilevel = floor(level);
     float flevel = level - ilevel;
 
-    vec3 sharp = $DECODE(textureCube(texture_cubeMap, fixSeams(dir)));
+    vec3 sharp = $DECODE_CUBEMAP(textureCube(texture_cubeMap, fixSeams(dir)));
     vec3 roughA = $DECODE(texture2D(texture_envAtlas, mapRoughnessUv(uv, ilevel)));
     vec3 roughB = $DECODE(texture2D(texture_envAtlas, mapRoughnessUv(uv, ilevel + 1.0)));
 

--- a/src/scene/shader-lib/programs/lit-shader.js
+++ b/src/scene/shader-lib/programs/lit-shader.js
@@ -768,8 +768,10 @@ class LitShader {
         if (options.reflectionSource === 'envAtlasHQ') {
             func.append(options.fixSeams ? chunks.fixCubemapSeamsStretchPS : chunks.fixCubemapSeamsNonePS);
             func.append(chunks.envAtlasPS);
-            func.append(chunks.reflectionEnvHQPS.replace(/\$DECODE_CUBEMAP/g, ChunkUtils.decodeFunc(options.reflectionCubemapEncoding))
-                                                .replace(/\$DECODE/g, ChunkUtils.decodeFunc(options.reflectionEncoding)));
+            func.append(chunks.reflectionEnvHQPS
+                .replace(/\$DECODE_CUBEMAP/g, ChunkUtils.decodeFunc(options.reflectionCubemapEncoding))
+                .replace(/\$DECODE/g, ChunkUtils.decodeFunc(options.reflectionEncoding))
+            );
         } else if (options.reflectionSource === 'envAtlas') {
             func.append(chunks.envAtlasPS);
             func.append(chunks.reflectionEnvPS.replace(/\$DECODE/g, ChunkUtils.decodeFunc(options.reflectionEncoding)));

--- a/src/scene/shader-lib/programs/lit-shader.js
+++ b/src/scene/shader-lib/programs/lit-shader.js
@@ -768,7 +768,8 @@ class LitShader {
         if (options.reflectionSource === 'envAtlasHQ') {
             func.append(options.fixSeams ? chunks.fixCubemapSeamsStretchPS : chunks.fixCubemapSeamsNonePS);
             func.append(chunks.envAtlasPS);
-            func.append(chunks.reflectionEnvHQPS.replace(/\$DECODE/g, ChunkUtils.decodeFunc(options.reflectionEncoding)));
+            func.append(chunks.reflectionEnvHQPS.replace(/\$DECODE_CUBEMAP/g, ChunkUtils.decodeFunc(options.reflectionCubemapEncoding))
+                                                .replace(/\$DECODE/g, ChunkUtils.decodeFunc(options.reflectionEncoding)));
         } else if (options.reflectionSource === 'envAtlas') {
             func.append(chunks.envAtlasPS);
             func.append(chunks.reflectionEnvPS.replace(/\$DECODE/g, ChunkUtils.decodeFunc(options.reflectionEncoding)));


### PR DESCRIPTION
This PR fixes a few environment lighting issues in the engine:
- store encoding for envAtlas and cubemap faces separately since they are possibly different
- reset scene envAtlas/prefilteredLighting correctly