### PR TITLE
[Anim Component] Fix for resetting parameters

### DIFF
--- a/src/framework/anim/controller/anim-controller.js
+++ b/src/framework/anim/controller/anim-controller.js
@@ -29,20 +29,21 @@ class AnimController {
      * @param {object[]} states - The list of states used to form the controller state graph.
      * @param {object[]} transitions - The list of transitions used to form the controller state
      * graph.
-     * @param {object[]} parameters - The anim components parameters.
      * @param {boolean} activate - Determines whether the anim controller should automatically play
      * once all {@link AnimNodes} are assigned animations.
      * @param {import('../../../core/event-handler.js').EventHandler} eventHandler - The event
      * handler which should be notified with anim events.
-     * @param {Set} consumedTriggers - Used to set triggers back to their default state after they
+     * @param {Function} findParameter - Retrieves a parameter which is used to control the transition between states.
+     * @param {Function} consumeTrigger - Used to set triggers back to their default state after they
      * have been consumed by a transition.
      */
-    constructor(animEvaluator, states, transitions, parameters, activate, eventHandler, consumedTriggers) {
+    constructor(animEvaluator, states, transitions, activate, eventHandler, findParameter, consumeTrigger) {
         this._animEvaluator = animEvaluator;
         this._states = {};
         this._stateNames = [];
         this._eventHandler = eventHandler;
-        this._consumedTriggers = consumedTriggers;
+        this._findParameter = findParameter;
+        this._consumeTrigger = consumeTrigger;
         for (let i = 0; i < states.length; i++) {
             this._states[states[i].name] = new AnimState(
                 this,
@@ -60,7 +61,6 @@ class AnimController {
         });
         this._findTransitionsFromStateCache = {};
         this._findTransitionsBetweenStatesCache = {};
-        this._parameters = parameters;
         this._previousStateName = null;
         this._activeStateName = ANIM_STATE_START;
         this._playing = false;
@@ -227,7 +227,7 @@ class AnimController {
         const conditions = transition.conditions;
         for (let i = 0; i < conditions.length; i++) {
             const condition = conditions[i];
-            const parameter = this.findParameter(condition.parameterName);
+            const parameter = this._findParameter(condition.parameterName);
             switch (condition.predicate) {
                 case ANIM_GREATER_THAN:
                     if (!(parameter.value > condition.value)) return false;
@@ -339,9 +339,9 @@ class AnimController {
         // turn off any triggers which were required to activate this transition
         for (let i = 0; i < transition.conditions.length; i++) {
             const condition = transition.conditions[i];
-            const parameter = this.findParameter(condition.parameterName);
+            const parameter = this._findParameter(condition.parameterName);
             if (parameter.type === ANIM_PARAMETER_TRIGGER) {
-                this._consumedTriggers.add(condition.parameterName);
+                this._consumeTrigger(condition.parameterName);
             }
         }
 
@@ -584,7 +584,7 @@ class AnimController {
     }
 
     findParameter(name) {
-        return this._parameters[name];
+        return this._findParameter(name);
     }
 }
 

--- a/src/framework/anim/controller/anim-state.js
+++ b/src/framework/anim/controller/anim-state.js
@@ -44,7 +44,6 @@ class AnimState {
         this._speed = speed;
         this._loop = loop;
         this._hasAnimations = false;
-        const findParameter = this._controller.findParameter.bind(this._controller);
         if (blendTree) {
             this._blendTree = this._createTree(
                 blendTree.type,
@@ -56,7 +55,7 @@ class AnimState {
                 blendTree.children,
                 blendTree.syncAnimations,
                 this._createTree,
-                findParameter
+                this._controller.findParameter
             );
         } else {
             this._blendTree = new AnimNode(this, null, name, 1.0, speed);

--- a/test/framework/anim/controller/anim-controller.test.mjs
+++ b/test/framework/anim/controller/anim-controller.test.mjs
@@ -72,20 +72,22 @@ describe('AnimController', function () {
         const animBinder = new AnimComponentBinder({ entity: graph }, graph, 'layer', {}, 0);
         animBinder.resolve = () => {};
         const animEvaluator = new AnimEvaluator(animBinder);
+        const parameters = {
+            'param': {
+                'name': 'param',
+                'type': 'FLOAT',
+                'value': 0.5
+            }
+        };
+        const consumedTriggers = new Set();
         controller = new AnimController(
             animEvaluator,
             states,
             transitions,
-            {
-                'param': {
-                    'name': 'param',
-                    'type': 'FLOAT',
-                    'value': 0.5
-                }
-            }, // parameters
             true, // activate
             null, // event handler
-            new Set() // consumed triggers
+            name => parameters[name],
+            name => consumedTriggers.add(name)
         );
         // add tracks
         const curves = [new AnimCurve(['path/to/entity'], 0, 0, INTERPOLATION_LINEAR)];


### PR DESCRIPTION
Resetting the anim component was causing its parameters object to reference parameters directly from the state graph resource. This could lead to other anim components that are instantiated with this resource having incorrect initial data. The parameters object is now deep copied when resetting the graph.

The reference that each anim controller had to the parameters object was also broken when resetting, leading to subsequent parameter changes not being reflected in previously instantiated anim controllers. This has been fixed by passing each controller a function to retrieve parameters directly from the anim component's parameters object.

Fixes #4709

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
