### PR TITLE
Do not declare MRT shader ouputs over the specified number

### DIFF
--- a/src/platform/graphics/shader-chunks/frag/gles2.js
+++ b/src/platform/graphics/shader-chunks/frag/gles2.js
@@ -1,14 +1,38 @@
 export default /* glsl */`
-#define texture2DBias texture2D
 
+#if COLOR_ATTACHMENT_0
 #define pcFragColor0 gl_FragData[0]
+#endif
+
+#if COLOR_ATTACHMENT_1
 #define pcFragColor1 gl_FragData[1]
+#endif
+
+#if COLOR_ATTACHMENT_2
 #define pcFragColor2 gl_FragData[2]
+#endif
+
+#if COLOR_ATTACHMENT_3
 #define pcFragColor3 gl_FragData[3]
+#endif
+
+#if COLOR_ATTACHMENT_4
 #define pcFragColor4 gl_FragData[4]
+#endif
+
+#if COLOR_ATTACHMENT_5
 #define pcFragColor5 gl_FragData[5]
+#endif
+
+#if COLOR_ATTACHMENT_6
 #define pcFragColor6 gl_FragData[6]
+#endif
+
+#if COLOR_ATTACHMENT_7
 #define pcFragColor7 gl_FragData[7]
+#endif
+
+#define texture2DBias texture2D
 
 // pass / accept shadow map or texture as a function parameter, on webgl this is simply passed as is
 // but this is needed for WebGPU

--- a/src/platform/graphics/shader-chunks/frag/gles3.js
+++ b/src/platform/graphics/shader-chunks/frag/gles3.js
@@ -1,14 +1,35 @@
 export default /* glsl */`
-#define varying in
-
+#if COLOR_ATTACHMENT_0
 layout(location = 0) out highp vec4 pc_fragColor;
+#endif
+
+#if COLOR_ATTACHMENT_1
 layout(location = 1) out highp vec4 pc_fragColor1;
+#endif
+
+#if COLOR_ATTACHMENT_2
 layout(location = 2) out highp vec4 pc_fragColor2;
+#endif
+
+#if COLOR_ATTACHMENT_3
 layout(location = 3) out highp vec4 pc_fragColor3;
+#endif
+
+#if COLOR_ATTACHMENT_4
 layout(location = 4) out highp vec4 pc_fragColor4;
+#endif
+
+#if COLOR_ATTACHMENT_5
 layout(location = 5) out highp vec4 pc_fragColor5;
+#endif
+
+#if COLOR_ATTACHMENT_6
 layout(location = 6) out highp vec4 pc_fragColor6;
+#endif
+
+#if COLOR_ATTACHMENT_7
 layout(location = 7) out highp vec4 pc_fragColor7;
+#endif
 
 #define gl_FragColor pc_fragColor
 
@@ -20,6 +41,8 @@ layout(location = 7) out highp vec4 pc_fragColor7;
 #define pcFragColor5 pc_fragColor5
 #define pcFragColor6 pc_fragColor6
 #define pcFragColor7 pc_fragColor7
+
+#define varying in
 
 #define texture2D texture
 #define texture2DBias texture

--- a/src/platform/graphics/shader-utils.js
+++ b/src/platform/graphics/shader-utils.js
@@ -58,8 +58,17 @@ class ShaderUtils {
         Debug.assert(options);
 
         const getDefines = (gpu, gl2, gl1, isVertex) => {
-            return device.isWebGPU ? gpu :
+
+            const deviceIntro = device.isWebGPU ? gpu :
                 (device.webgl2 ? gl2 : ShaderUtils.gl1Extensions(device, options) + gl1);
+
+            // a define per supported color attachment, which strips out unsupported output definitions in the deviceIntro
+            let attachmentsDefine = '';
+            for (let i = 0; i < device.maxColorAttachments; i++) {
+                attachmentsDefine += `#define COLOR_ATTACHMENT_${i}\n`;
+            }
+
+            return attachmentsDefine + deviceIntro;
         };
 
         const name = options.name ?? 'Untitled';


### PR DESCRIPTION
Fixes https://github.com/playcanvas/engine/issues/5393

We used to declare 8 MRT outputs for all fragment shaders, assuming the compiler would ignore unused ones. Turns out this fails on some android devices that only support 4 attachments.

This PR addresses it by only declaring supported outputs, by stripping unsupported outputs using ifdefs. On a device with only 4 attachments, the generated code (after the pre-processor steps) looks like this, with only 4 instead of 8 outputs:

![Screenshot 2023-06-15 at 11 15 24](https://github.com/playcanvas/engine/assets/59932779/856c9eb3-7e74-4676-8f7f-64499bbff402)
