### PR TITLE
AnimBlendTree fix

### DIFF
--- a/src/framework/anim/controller/anim-controller.js
+++ b/src/framework/anim/controller/anim-controller.js
@@ -583,9 +583,9 @@ class AnimController {
         this._animEvaluator.update(dt, this.activeState.hasAnimations);
     }
 
-    findParameter(name) {
+    findParameter = (name) => {
         return this._findParameter(name);
-    }
+    };
 }
 
 export { AnimController };

--- a/src/framework/components/anim/component.js
+++ b/src/framework/components/anim/component.js
@@ -292,8 +292,8 @@ class AnimComponent extends Component {
             transitions,
             this._activate,
             this,
-            this.findParameter.bind(this),
-            this.consumeTrigger.bind(this)
+            this.findParameter,
+            this.consumeTrigger
         );
         this._layers.push(new AnimComponentLayer(name, controller, this, weight, blendType));
         this._layerIndices[name] = layerIndex;
@@ -631,13 +631,13 @@ class AnimComponent extends Component {
         Debug.log(`Cannot set parameter value. No parameter found in anim controller named "${name}" of type "${type}"`);
     }
 
-    findParameter(name) {
+    findParameter = (name) => {
         return this._parameters[name];
-    }
+    };
 
-    consumeTrigger(name) {
+    consumeTrigger = (name) => {
         this._consumedTriggers.add(name);
-    }
+    };
 
     /**
      * Returns a float parameter value by name.

--- a/src/framework/components/anim/component.js
+++ b/src/framework/components/anim/component.js
@@ -631,10 +631,25 @@ class AnimComponent extends Component {
         Debug.log(`Cannot set parameter value. No parameter found in anim controller named "${name}" of type "${type}"`);
     }
 
+    /**
+     * Returns the parameter object for the specified parameter name. This function is anonymous so that it can be passed to the AnimController
+     * while still being called in the scope of the AnimComponent.
+     *
+     * @param {string} name - The name of the parameter to return the value of.
+     * @returns {object} The parameter object.
+     * @private
+     */
     findParameter = (name) => {
         return this._parameters[name];
     };
 
+    /**
+     * Sets a trigger parameter as having been used by a transition. This function is anonymous so that it can be passed to the AnimController
+     * while still being called in the scope of the AnimComponent.
+     *
+     * @param {string} name - The name of the trigger to set as consumed.
+     * @private
+     */
     consumeTrigger = (name) => {
         this._consumedTriggers.add(name);
     };


### PR DESCRIPTION
The findParameter and comsumeTrigger functions should always be called in the AnimController's scope so that they have access to its private variables. Setting these functions as anonymous ensures they are always called with this scope, even when they are passed to and called by the various AnimBlendTree classes.

Fixes #5398

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
