### PR TITLE
Fix to depth-grab pass on WebGl1

### DIFF
--- a/src/scene/graphics/scene-grab.js
+++ b/src/scene/graphics/scene-grab.js
@@ -145,6 +145,7 @@ class SceneGrab {
                 renderTarget._depthBuffer = buffer;
             } else {
                 renderTarget._colorBuffer = buffer;
+                renderTarget._colorBuffers = [buffer];
             }
         } else {
 


### PR DESCRIPTION
Fixed https://github.com/playcanvas/engine/issues/5400

The issue was introduced in #5353 by adding an array of color targets, which matches the single entry from before. GL1 version of grab pass hacks internals of RenderTarget and wasn't handling this.