### PR TITLE
[Fix] Define pc_fragColor in all cases

### DIFF
--- a/src/platform/graphics/shader-chunks/frag/gles2.js
+++ b/src/platform/graphics/shader-chunks/frag/gles2.js
@@ -1,8 +1,6 @@
 export default /* glsl */`
 
-#if COLOR_ATTACHMENT_0
 #define pcFragColor0 gl_FragData[0]
-#endif
 
 #if COLOR_ATTACHMENT_1
 #define pcFragColor1 gl_FragData[1]

--- a/src/platform/graphics/shader-chunks/frag/gles3.js
+++ b/src/platform/graphics/shader-chunks/frag/gles3.js
@@ -1,7 +1,5 @@
 export default /* glsl */`
-#if COLOR_ATTACHMENT_0
 layout(location = 0) out highp vec4 pc_fragColor;
-#endif
 
 #if COLOR_ATTACHMENT_1
 layout(location = 1) out highp vec4 pc_fragColor1;


### PR DESCRIPTION
define `pc_fragColor` in all cases, as COLOR_ATTACHMENT_0 is only defined when creating shader using `createShaderFromCode` but not `new Shader()`.

This fixes some compiling issue with custom shaders.