### PR TITLE
Fix to window resizing on WebGPU when post-effects are used

### DIFF
--- a/src/framework/components/camera/post-effect-queue.js
+++ b/src/framework/components/camera/post-effect-queue.js
@@ -119,6 +119,7 @@ class PostEffectQueue {
         rt.destroyFrameBuffers();
         rt.destroyTextureBuffers();
         rt._colorBuffer = this._allocateColorBuffer(format, name);
+        rt._colorBuffers = [rt._colorBuffer];
     }
 
     _destroyOffscreenTarget(rt) {

--- a/src/platform/graphics/webgpu/webgpu-render-target.js
+++ b/src/platform/graphics/webgpu/webgpu-render-target.js
@@ -315,7 +315,7 @@ class WebgpuRenderTarget {
                 size: [width, height, 1],
                 dimension: '2d',
                 sampleCount: samples,
-                format: this.colorAttachments[index].format,
+                format: this.colorAttachments[index]?.format ?? colorBuffer.impl.format,
                 usage: GPUTextureUsage.RENDER_ATTACHMENT
             };
 


### PR DESCRIPTION
- caused by changes and refactoring for MRT