### PR TITLE
Examples es5 build fix

### DIFF
--- a/examples/rollup.config.js
+++ b/examples/rollup.config.js
@@ -121,15 +121,16 @@ const builds = [
         input: 'src/iframe/index.mjs',
         output: {
             name: 'bundle',
-            format: 'umd',
+            format: 'es',
             dir: 'dist/iframe',
-            sourcemap: process.env.NODE_ENV === 'development' ? 'inline' : false,
+            sourcemap: process.env.NODE_ENV === 'development' ? 'inline' : false
         },
         plugins: [
             alias({
                 entries: {
                     'playcanvas': ENGINE_PATH,
-                    '../../../build/playcanvas.js': ENGINE_PATH
+                    '../../../build/playcanvas.js': ENGINE_PATH,
+                    'pc-alias': ENGINE_PATH.includes('.mjs') ? './pc-es6.mjs' : './pc-es5.mjs'
                 }
             }),
             commonjs(),

--- a/examples/src/iframe/index.mjs
+++ b/examples/src/iframe/index.mjs
@@ -7,13 +7,10 @@ import '../../lib/objectValuesPolyfill.js';
 import * as observer from '@playcanvas/observer';
 import * as pcui from '@playcanvas/pcui/react';
 import React from 'react';
-import * as pc from '../../../build/playcanvas.js';
+import 'pc-alias';
 import * as pcx from '../../../build/playcanvas-extras.mjs/index.js';
 
 window.observer = observer;
 window.pcui = window.top.pcui || pcui;
 window.React = window.top.React || React;
-window.pc = pc;
-// make pc available outside of the iframe
-window.top.pc = pc;
 window.pcx = pcx;

--- a/examples/src/iframe/pc-es5.mjs
+++ b/examples/src/iframe/pc-es5.mjs
@@ -1,0 +1,4 @@
+import pc from '../../../build/playcanvas.js';
+window.pc = pc;
+// make pc available outside of the iframe
+window.top.pc = window.pc;

--- a/examples/src/iframe/pc-es6.mjs
+++ b/examples/src/iframe/pc-es6.mjs
@@ -1,0 +1,4 @@
+import * as pc from '../../../build/playcanvas.js';
+window.pc = pc;
+// make pc available outside of the iframe
+window.top.pc = window.pc;


### PR DESCRIPTION
Examples which accessed the global pc object were failing as es5 builds exported PlayCanvas under the default name.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
