### PR TITLE
Additional envAtlas fixes

### DIFF
--- a/src/framework/handlers/loader.js
+++ b/src/framework/handlers/loader.js
@@ -78,6 +78,10 @@ class ResourceLoader {
         return this._handlers[type];
     }
 
+    static makeKey(url, type) {
+        return `${url}-${type}`;
+    }
+
     /**
      * Make a request for a resource from a remote URL. Parse the returned data using the handler
      * for the specified type. When loaded and parsed, use the callback to return an instance of
@@ -109,7 +113,7 @@ class ResourceLoader {
             return;
         }
 
-        const key = url + type;
+        const key = ResourceLoader.makeKey(url, type);
 
         if (this._cache[key] !== undefined) {
             // in cache
@@ -188,7 +192,9 @@ class ResourceLoader {
     }
 
     _onSuccess(key, result, extra) {
-        this._cache[key] = result;
+        if (result !== null) {
+            this._cache[key] = result;
+        }
         for (let i = 0; i < this._requests[key].length; i++) {
             this._requests[key][i](null, result, extra);
         }
@@ -250,7 +256,8 @@ class ResourceLoader {
      * @param {string} type - The type of resource.
      */
     clearCache(url, type) {
-        delete this._cache[url + type];
+        const key = ResourceLoader.makeKey(url, type);
+        delete this._cache[key];
     }
 
     /**
@@ -261,8 +268,9 @@ class ResourceLoader {
      * @returns {*} The resource loaded from the cache.
      */
     getFromCache(url, type) {
-        if (this._cache[url + type]) {
-            return this._cache[url + type];
+        const key = ResourceLoader.makeKey(url, type);
+        if (this._cache[key]) {
+            return this._cache[key];
         }
         return undefined;
     }

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -8,7 +8,7 @@ import { Mat3 } from '../core/math/mat3.js';
 import { Mat4 } from '../core/math/mat4.js';
 
 import { GraphicsDeviceAccess } from '../platform/graphics/graphics-device-access.js';
-import { PIXELFORMAT_RGBA8, ADDRESS_REPEAT, ADDRESS_CLAMP_TO_EDGE, FILTER_LINEAR } from '../platform/graphics/constants.js';
+import { PIXELFORMAT_RGBA8, ADDRESS_CLAMP_TO_EDGE, FILTER_LINEAR } from '../platform/graphics/constants.js';
 
 import { BAKE_COLORDIR, FOG_NONE, GAMMA_SRGB, LAYERID_IMMEDIATE } from './constants.js';
 import { Sky } from './sky.js';

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -209,7 +209,7 @@ class Scene extends EventHandler {
          * @type {import('../platform/graphics/texture.js').Texture[]}
          * @private
          */
-        this._prefilteredCubemaps = [null, null, null, null, null, null];
+        this._prefilteredCubemaps = [];
 
         /**
          * Environment lighting atlas
@@ -398,11 +398,17 @@ class Scene extends EventHandler {
 
             // make sure required options are set up on the texture
             if (value) {
-                value.addressU = ADDRESS_REPEAT;
+                value.addressU = ADDRESS_CLAMP_TO_EDGE;
                 value.addressV = ADDRESS_CLAMP_TO_EDGE;
                 value.minFilter = FILTER_LINEAR;
                 value.magFilter = FILTER_LINEAR;
                 value.mipmaps = false;
+            }
+
+            this._prefilteredCubemaps = [];
+            if (this._internalEnvAtlas) {
+                this._internalEnvAtlas.destroy();
+                this._internalEnvAtlas = null;
             }
 
             this._resetSky();
@@ -517,41 +523,31 @@ class Scene extends EventHandler {
      * @type {import('../platform/graphics/texture.js').Texture[]}
      */
     set prefilteredCubemaps(value) {
-        const cubemaps = this._prefilteredCubemaps;
-
         value = value || [];
-
-        let changed = false;
-        let complete = true;
-        for (let i = 0; i < 6; ++i) {
-            const v = value[i] || null;
-            if (cubemaps[i] !== v) {
-                cubemaps[i] = v;
-                changed = true;
-            }
-            complete = complete && (!!cubemaps[i]);
-        }
+        const cubemaps = this._prefilteredCubemaps;
+        const changed = cubemaps.length !== value.length || cubemaps.some((c, i) => c !== value[i]);
 
         if (changed) {
-            this._resetSky();
+            const complete = value.length === 6 && value.every(c => !!c);
 
             if (complete) {
                 // update env atlas
-                this._internalEnvAtlas = EnvLighting.generatePrefilteredAtlas(cubemaps, {
+                this._internalEnvAtlas = EnvLighting.generatePrefilteredAtlas(value, {
                     target: this._internalEnvAtlas
                 });
 
-                if (!this._envAtlas) {
-                    // user hasn't set an envAtlas already, set it to the internal one
-                    this.envAtlas = this._internalEnvAtlas;
+                // user hasn't set an envAtlas already, set it to the internal one
+                this._envAtlas = this._internalEnvAtlas;
+            } else {
+                if (this._internalEnvAtlas) {
+                    this._internalEnvAtlas.destroy();
+                    this._internalEnvAtlas = null;
                 }
-            } else if (this._internalEnvAtlas) {
-                if (this._envAtlas === this._internalEnvAtlas) {
-                    this.envAtlas = null;
-                }
-                this._internalEnvAtlas.destroy();
-                this._internalEnvAtlas = null;
+                this._envAtlas = null;
             }
+
+            this._prefilteredCubemaps = value.slice();
+            this._resetSky();
         }
     }
 
@@ -787,12 +783,10 @@ class Scene extends EventHandler {
         if (!cubemaps) {
             this.skybox = null;
             this.envAtlas = null;
-            this.prefilteredCubemaps = [null, null, null, null, null, null];
         } else {
             this.skybox = cubemaps[0] || null;
             if (cubemaps[1] && !cubemaps[1].cubemap) {
                 // prefiltered data is an env atlas
-                this.prefilteredCubemaps = [null, null, null, null, null, null];
                 this.envAtlas = cubemaps[1];
             } else {
                 // prefiltered data is a set of cubemaps

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -536,7 +536,6 @@ class Scene extends EventHandler {
                     target: this._internalEnvAtlas
                 });
 
-                // user hasn't set an envAtlas already, set it to the internal one
                 this._envAtlas = this._internalEnvAtlas;
             } else {
                 if (this._internalEnvAtlas) {


### PR DESCRIPTION
This is a followup to #5389.

This PR address a few remaining cubemap and prefiltered lighting issues:
- setting the scene envAtlas or prefilteredCubemaps clears the other
- don't store null values in the loader cache