### PR TITLE
Fix `Entity#destroy`

### DIFF
--- a/src/framework/components/model/component.js
+++ b/src/framework/components/model/component.js
@@ -300,7 +300,7 @@ class ModelComponent extends Component {
             this._model._immutable = false;
 
             this.removeModelFromLayers();
-            this.entity.removeChild(this._model.getGraph());
+            this._model.getGraph().destroy();
             delete this._model._entity;
 
             if (this._clonedModel) {

--- a/src/framework/entity.js
+++ b/src/framework/entity.js
@@ -514,38 +514,12 @@ class Entity extends GraphNode {
             this.c[name].enabled = false;
         }
 
+        super.destroy();
+
         // Remove all components
         for (const name in this.c) {
             this.c[name].system.removeComponent(this);
         }
-
-        // Detach from parent
-        this._parent?.removeChild(this);
-
-        // If an Entity is in a GraphNode, recursive destroy'ing will never get to them.
-        // Therefore we have to find these special cases and destroy iteratively.
-        const isEntityChildOfGraphNode = _ => _ instanceof Entity && _.parent?.constructor === GraphNode;
-        const entitiesInGraphNodes = this.find(isEntityChildOfGraphNode);
-        entitiesInGraphNodes.forEach(e => e.destroy());
-
-        // recursively destroy all children
-        const children = this._children;
-        while (children.length) {
-
-            // remove a child from the array and disconnect it from the parent
-            const child = children.pop();
-            child._parent = null;
-
-            if (child instanceof Entity) {
-                child.destroy();
-            }
-        }
-
-        // fire destroy event
-        this.fire('destroy', this);
-
-        // clear all events
-        this.off();
 
         // remove from entity index
         if (this._guid) {

--- a/src/framework/entity.js
+++ b/src/framework/entity.js
@@ -520,8 +520,13 @@ class Entity extends GraphNode {
         }
 
         // Detach from parent
-        if (this._parent)
-            this._parent.removeChild(this);
+        this._parent?.removeChild(this);
+
+        // If an Entity is in a GraphNode, recursive destroy'ing will never get to them.
+        // Therefore we have to find these special cases and destroy iteratively.
+        const isEntityChildOfGraphNode = _ => _ instanceof Entity && _.parent?.constructor === GraphNode;
+        const entitiesInGraphNodes = this.find(isEntityChildOfGraphNode);
+        entitiesInGraphNodes.forEach(e => e.destroy());
 
         // recursively destroy all children
         const children = this._children;

--- a/src/framework/entity.js
+++ b/src/framework/entity.js
@@ -514,12 +514,12 @@ class Entity extends GraphNode {
             this.c[name].enabled = false;
         }
 
-        super.destroy();
-
         // Remove all components
         for (const name in this.c) {
             this.c[name].system.removeComponent(this);
         }
+
+        super.destroy();
 
         // remove from entity index
         if (this._guid) {

--- a/src/framework/scene-registry.js
+++ b/src/framework/scene-registry.js
@@ -381,11 +381,6 @@ class SceneRegistry {
             while (children.length) {
                 children[0].destroy();
             }
-            Debug.assert(
-                Object.keys(app._entityIndex).length === 0,
-                "Destroyed all entities but these entities survived:",
-                app._entityIndex
-            );
             app.applySceneSettings(sceneItem.data.settings);
         };
 

--- a/src/framework/scene-registry.js
+++ b/src/framework/scene-registry.js
@@ -376,14 +376,16 @@ class SceneRegistry {
         const app = this._app;
 
         const onBeforeAddHierarchy = (sceneItem) => {
-            // Destroy/Remove all nodes on the app.root
-            const rootChildren = app.root.children;
-            while (rootChildren.length > 0) {
-                const child = rootChildren[0];
-                child.reparent(null);
-                child.destroy?.();
+            // Destroy all nodes on the app.root
+            const { children } = app.root;
+            while (children.length) {
+                children[0].destroy();
             }
-
+            Debug.assert(
+                Object.keys(app._entityIndex).length === 0,
+                "Destroyed all entities but these entities survived:",
+                app._entityIndex
+            );
             app.applySceneSettings(sceneItem.data.settings);
         };
 

--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -480,6 +480,37 @@ class GraphNode extends EventHandler {
         return this;
     }
 
+
+    /**
+     * Detach it from the hierarchy. Then recursively destroy all ancestors.
+     *
+     * @example
+     * const firstChild = this.entity.children[0];
+     * firstChild.destroy(); // delete child, all components and remove from hierarchy
+     */
+    destroy() {
+        // Detach from parent
+        this._parent?.removeChild(this);
+
+        // Recursively destroy all children
+        const children = this._children;
+        while (children.length) {
+            // Remove last child from the array
+            const child = children.pop();
+            // Disconnect it from the parent: this is only an optimisation step, to prevent calling
+            // GraphNode#removeChild which would try to refind it via this._children.indexOf (which
+            // will fail, because we just removed it).
+            child._parent = null;
+            child.destroy();
+        }
+
+        // fire destroy event
+        this.fire('destroy', this);
+
+        // clear all events
+        this.off();
+    }
+
     /**
      * Search the graph node and all of its descendants for the nodes that satisfy some search
      * criteria.
@@ -1347,6 +1378,7 @@ class GraphNode extends EventHandler {
      * this.entity.removeChild(child);
      */
     removeChild(child) {
+        console.log("trying to find child...", child);
         const index = this._children.indexOf(child);
         if (index === -1) {
             return;

--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -482,7 +482,7 @@ class GraphNode extends EventHandler {
 
 
     /**
-     * Detach it from the hierarchy. Then recursively destroy all ancestors.
+     * Detach a GraphNode from the hierarchy. Then recursively destroy all ancestors.
      *
      * @example
      * const firstChild = this.entity.children[0];

--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -482,7 +482,7 @@ class GraphNode extends EventHandler {
 
 
     /**
-     * Detach a GraphNode from the hierarchy. Then recursively destroy all ancestors.
+     * Detach a GraphNode from the hierarchy and recursively destroy all children.
      *
      * @example
      * const firstChild = this.entity.children[0];

--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -1378,7 +1378,6 @@ class GraphNode extends EventHandler {
      * this.entity.removeChild(child);
      */
     removeChild(child) {
-        console.log("trying to find child...", child);
         const index = this._children.indexOf(child);
         if (index === -1) {
             return;

--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -497,7 +497,7 @@ class GraphNode extends EventHandler {
         while (children.length) {
             // Remove last child from the array
             const child = children.pop();
-            // Disconnect it from the parent: this is only an optimisation step, to prevent calling
+            // Disconnect it from the parent: this is only an optimization step, to prevent calling
             // GraphNode#removeChild which would try to refind it via this._children.indexOf (which
             // will fail, because we just removed it).
             child._parent = null;


### PR DESCRIPTION
Fixes #4649

The main issue is simply that `GraphNode` has no `destroy` method and if a `Entity` is inside a `GraphNode`... it will never be deleted.

I can imagine many solutions, but simply to get the conversations going I propose this one...

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
