### PR TITLE
Disable normal bias with VSM

### DIFF
--- a/src/scene/shader-lib/programs/lit-shader.js
+++ b/src/scene/shader-lib/programs/lit-shader.js
@@ -1252,7 +1252,7 @@ class LitShader {
                     }
 
                     if (shadowReadMode !== null) {
-                        if (light._normalOffsetBias) {
+                        if (light._normalOffsetBias && !light._isVsm) {
                             func.append("#define SHADOW_SAMPLE_NORMAL_OFFSET");
                         }
                         if (lightType === LIGHTTYPE_DIRECTIONAL) {


### PR DESCRIPTION
In this PR #5333 I introduced a bug which caused VSM to potentially use normal bias, which is inconsistent with how the engine acted before. This PR fixes that issue. 