### PR TITLE
Change behaviour of lightSize

### DIFF
--- a/examples/src/examples/graphics/contact-hardening-shadows.tsx
+++ b/examples/src/examples/graphics/contact-hardening-shadows.tsx
@@ -197,7 +197,7 @@ class ContactHardeningShadowsExample {
                         range: 150,
                         shadowResolution: 2048,
                         shadowDistance: 100,
-                        lightSize: data.get('script.area.size'),
+                        penumbraSize: data.get('script.area.size'),
                         shadowType: data.get('script.area.shadowType'),
                         intensity: data.get('script.area.intensity'),
                         falloffMode: pc.LIGHTFALLOFF_INVERSESQUARED,
@@ -233,7 +233,7 @@ class ContactHardeningShadowsExample {
                         color: new pc.Color(1, 1, 1),
                         castShadows: true,
                         numCascades: 1,
-                        lightSize: data.get('script.directional.size'),
+                        penumbraSize: data.get('script.directional.size'),
                         shadowType: data.get('script.directional.shadowType'),
                         intensity: data.get('script.directional.intensity'),
                         shadowBias: 0.5,
@@ -249,7 +249,7 @@ class ContactHardeningShadowsExample {
                         type: "omni",
                         color: new pc.Color(1, 0.25, 0.25),
                         range: 25,
-                        lightSize: data.get('script.point.size'),
+                        penumbraSize: data.get('script.point.size'),
                         shadowType: data.get('script.point.shadowType'),
                         intensity: data.get('script.point.intensity'),
                         castShadows: true,
@@ -308,7 +308,7 @@ class ContactHardeningShadowsExample {
                                 brightMaterial.update();
                                 break;
                             case 'script.area.size':
-                                areaLight.light.lightSize = value;
+                                areaLight.light.penumbraSize = value;
                                 break;
                             case 'script.area.shadowType':
                                 areaLight.light.shadowType = parseInt(value);
@@ -320,7 +320,7 @@ class ContactHardeningShadowsExample {
                                 directionalLight.light.intensity = value;
                                 break;
                             case 'script.directional.size':
-                                directionalLight.light.lightSize = value;
+                                directionalLight.light.penumbraSize = value;
                                 break;
                             case 'script.directional.shadowType':
                                 directionalLight.light.shadowType = parseInt(value);
@@ -332,7 +332,7 @@ class ContactHardeningShadowsExample {
                                 lightOmni.light.intensity = value;
                                 break;
                             case 'script.point.size':
-                                lightOmni.light.lightSize = value;
+                                lightOmni.light.penumbraSize = value;
                                 break;
                             case 'script.point.shadowType':
                                 lightOmni.light.shadowType = parseInt(value);

--- a/src/framework/components/light/component.js
+++ b/src/framework/components/light/component.js
@@ -89,9 +89,9 @@ const _lightPropsDefault = [];
  * angle is specified in degrees. Affects spot lights only. Defaults to 40.
  * @property {number} outerConeAngle The angle at which the spotlight cone has faded to nothing.
  * The angle is specified in degrees. Affects spot lights only. Defaults to 45.
- * @property {number} lightSize Size of the light used for contact hardening shadows. For area lights
- * acts as a size multiplier with the area light dimensions. For punctual and directional lights
- * acts as the actual size of the light. Defaults to 1.0.
+ * @property {number} lightSize Size of penumbra for contact hardening shadows. For area lights
+ * acts as a multiplier with the dimensions of the area light. For punctual and directional lights
+ * it's the area size of the light. Defaults to 1.0.
  * @property {number} falloffMode Controls the rate at which a light attenuates from its position.
  * Can be:
  *

--- a/src/framework/components/light/component.js
+++ b/src/framework/components/light/component.js
@@ -89,7 +89,7 @@ const _lightPropsDefault = [];
  * angle is specified in degrees. Affects spot lights only. Defaults to 40.
  * @property {number} outerConeAngle The angle at which the spotlight cone has faded to nothing.
  * The angle is specified in degrees. Affects spot lights only. Defaults to 45.
- * @property {number} lightSize Size of penumbra for contact hardening shadows. For area lights
+ * @property {number} penumbraSize Size of penumbra for contact hardening shadows. For area lights
  * acts as a multiplier with the dimensions of the area light. For punctual and directional lights
  * it's the area size of the light. Defaults to 1.0.
  * @property {number} falloffMode Controls the rate at which a light attenuates from its position.
@@ -337,12 +337,12 @@ class LightComponent extends Component {
         return this.light.shadowUpdateOverrides;
     }
 
-    set lightSize(value) {
-        this.light.lightSize = value;
+    set penumbraSize(value) {
+        this.light.penumbraSize = value;
     }
 
-    get lightSize() {
-        return this.light.lightSize;
+    get penumbraSize() {
+        return this.light.penumbraSize;
     }
 }
 
@@ -567,7 +567,7 @@ function _defineProps() {
         }
     });
 
-    _lightProps.push("lightSize");
+    _lightProps.push("penumbraSize");
     _lightPropsDefault.push(1);
 }
 

--- a/src/scene/light.js
+++ b/src/scene/light.js
@@ -187,7 +187,7 @@ class Light {
         this._normalOffsetBias = 0.0;
         this.shadowUpdateMode = SHADOWUPDATE_REALTIME;
         this.shadowUpdateOverrides = null;
-        this._lightSize = 1.0;
+        this._penumbraSize = 1.0;
         this._isVsm = false;
         this._isPcf = true;
 
@@ -457,12 +457,12 @@ class Light {
         return this._outerConeAngle;
     }
 
-    set lightSize(value) {
-        this._lightSize = value;
+    set penumbraSize(value) {
+        this._penumbraSize = value;
     }
 
-    get lightSize() {
-        return this._lightSize;
+    get penumbraSize() {
+        return this._penumbraSize;
     }
 
     _updateOuterAngle(angle) {
@@ -675,7 +675,7 @@ class Light {
         clone.vsmBlurSize = this._vsmBlurSize;
         clone.vsmBlurMode = this.vsmBlurMode;
         clone.vsmBias = this.vsmBias;
-        clone.lightSize = this.lightSize;
+        clone.penumbraSize = this.penumbraSize;
         clone.shadowUpdateMode = this.shadowUpdateMode;
         clone.mask = this.mask;
 

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -111,7 +111,7 @@ class ForwardRenderer extends Renderer {
         this.lightCookieIntId = [];
         this.lightCookieMatrixId = [];
         this.lightCookieOffsetId = [];
-        this.lightSizeId = [];
+        this.lightShadowSearchAreaId = [];
         this.lightCameraParamsId = [];
 
         // shadow cascades
@@ -174,6 +174,7 @@ class ForwardRenderer extends Renderer {
         this.lightShadowMatrixId[i] = scope.resolve(light + '_shadowMatrix');
         this.lightShadowParamsId[i] = scope.resolve(light + '_shadowParams');
         this.lightShadowIntensity[i] = scope.resolve(light + '_shadowIntensity');
+        this.lightShadowSearchAreaId[i] = scope.resolve(light + '_shadowSearchArea');
         this.lightRadiusId[i] = scope.resolve(light + '_radius');
         this.lightPos[i] = new Float32Array(3);
         this.lightPosId[i] = scope.resolve(light + '_position');
@@ -187,7 +188,6 @@ class ForwardRenderer extends Renderer {
         this.lightCookieIntId[i] = scope.resolve(light + '_cookieIntensity');
         this.lightCookieMatrixId[i] = scope.resolve(light + '_cookieMatrix');
         this.lightCookieOffsetId[i] = scope.resolve(light + '_cookieOffset');
-        this.lightSizeId[i] = scope.resolve(light + '_size');
         this.lightCameraParamsId[i] = scope.resolve(light + '_cameraParams');
 
         // shadow cascades
@@ -259,7 +259,7 @@ class ForwardRenderer extends Renderer {
                 this.lightShadowIntensity[cnt].setValue(directional.shadowIntensity);
 
                 const pixelsPerMeter = 1.0 / (lightRenderData.shadowCamera.renderTarget.width / directional.lightSize);
-                this.lightSizeId[cnt].setValue(pixelsPerMeter);
+                this.lightShadowSearchAreaId[cnt].setValue(pixelsPerMeter);
 
                 const cameraParams = directional._shadowCameraParams;
                 cameraParams.length = 4;
@@ -333,7 +333,7 @@ class ForwardRenderer extends Renderer {
             this.lightShadowIntensity[cnt].setValue(omni.shadowIntensity);
 
             const pixelsPerMeter = 1.0 / (lightRenderData.shadowCamera.renderTarget.width / omni.lightSize);
-            this.lightSizeId[cnt].setValue(pixelsPerMeter);
+            this.lightShadowSearchAreaId[cnt].setValue(pixelsPerMeter);
             const cameraParams = omni._shadowCameraParams;
 
             cameraParams.length = 4;
@@ -401,7 +401,7 @@ class ForwardRenderer extends Renderer {
             const pixelsPerMeter = 1.0 / (lightRenderData.shadowCamera.renderTarget.width / spot.lightSize);
             const fov = lightRenderData.shadowCamera._fov * Math.PI / 180.0;
             const fovRatio = 1.0 / Math.tan(fov / 2.0);
-            this.lightSizeId[cnt].setValue(pixelsPerMeter * fovRatio);
+            this.lightShadowSearchAreaId[cnt].setValue(pixelsPerMeter * fovRatio);
 
             const cameraParams = spot._shadowCameraParams;
             cameraParams.length = 4;

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -258,7 +258,7 @@ class ForwardRenderer extends Renderer {
                 this.shadowCascadeCountId[cnt].setValue(directional.numCascades);
                 this.lightShadowIntensity[cnt].setValue(directional.shadowIntensity);
 
-                const pixelsPerMeter = 1.0 / (lightRenderData.shadowCamera.renderTarget.width / directional.lightSize);
+                const pixelsPerMeter = 1.0 / (lightRenderData.shadowCamera.renderTarget.width / penumbraSize);
                 this.lightShadowSearchAreaId[cnt].setValue(pixelsPerMeter);
 
                 const cameraParams = directional._shadowCameraParams;
@@ -332,7 +332,7 @@ class ForwardRenderer extends Renderer {
             this.lightShadowParamsId[cnt].setValue(params);
             this.lightShadowIntensity[cnt].setValue(omni.shadowIntensity);
 
-            const pixelsPerMeter = 1.0 / (lightRenderData.shadowCamera.renderTarget.width / omni.lightSize);
+            const pixelsPerMeter = 1.0 / (lightRenderData.shadowCamera.renderTarget.width / omni.penumbraSize);
             this.lightShadowSearchAreaId[cnt].setValue(pixelsPerMeter);
             const cameraParams = omni._shadowCameraParams;
 
@@ -398,7 +398,7 @@ class ForwardRenderer extends Renderer {
             this.lightShadowParamsId[cnt].setValue(params);
             this.lightShadowIntensity[cnt].setValue(spot.shadowIntensity);
 
-            const pixelsPerMeter = 1.0 / (lightRenderData.shadowCamera.renderTarget.width / spot.lightSize);
+            const pixelsPerMeter = 1.0 / (lightRenderData.shadowCamera.renderTarget.width / spot.penumbraSize);
             const fov = lightRenderData.shadowCamera._fov * Math.PI / 180.0;
             const fovRatio = 1.0 / Math.tan(fov / 2.0);
             this.lightShadowSearchAreaId[cnt].setValue(pixelsPerMeter * fovRatio);

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -258,7 +258,7 @@ class ForwardRenderer extends Renderer {
                 this.shadowCascadeCountId[cnt].setValue(directional.numCascades);
                 this.lightShadowIntensity[cnt].setValue(directional.shadowIntensity);
 
-                const pixelsPerMeter = 1.0 / (lightRenderData.shadowCamera.renderTarget.width / penumbraSize);
+                const pixelsPerMeter = 1.0 / (lightRenderData.shadowCamera.renderTarget.width / directional.penumbraSize);
                 this.lightShadowSearchAreaId[cnt].setValue(pixelsPerMeter);
 
                 const cameraParams = directional._shadowCameraParams;

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -257,11 +257,13 @@ class ForwardRenderer extends Renderer {
                 this.shadowCascadeDistancesId[cnt].setValue(directional._shadowCascadeDistances);
                 this.shadowCascadeCountId[cnt].setValue(directional.numCascades);
                 this.lightShadowIntensity[cnt].setValue(directional.shadowIntensity);
-                this.lightSizeId[cnt].setValue(directional.lightSize);
+
+                const pixelsPerMeter = 1.0 / (lightRenderData.shadowCamera.renderTarget.width / directional.lightSize);
+                this.lightSizeId[cnt].setValue(pixelsPerMeter);
 
                 const cameraParams = directional._shadowCameraParams;
                 cameraParams.length = 4;
-                cameraParams[0] = 2.0;
+                cameraParams[0] = 0;
                 cameraParams[1] = lightRenderData.shadowCamera._farClip;
                 cameraParams[2] = lightRenderData.shadowCamera._nearClip;
                 cameraParams[3] = 1;
@@ -329,12 +331,13 @@ class ForwardRenderer extends Renderer {
             params[3] = 1.0 / omni.attenuationEnd;
             this.lightShadowParamsId[cnt].setValue(params);
             this.lightShadowIntensity[cnt].setValue(omni.shadowIntensity);
-            this.lightSizeId[cnt].setValue(omni.lightSize);
 
-            const fov = lightRenderData.shadowCamera._fov * Math.PI / 180.0;
+            const pixelsPerMeter = 1.0 / (lightRenderData.shadowCamera.renderTarget.width / omni.lightSize);
+            this.lightSizeId[cnt].setValue(pixelsPerMeter);
             const cameraParams = omni._shadowCameraParams;
+
             cameraParams.length = 4;
-            cameraParams[0] = 1.0 / Math.tan(fov / 2.0);
+            cameraParams[0] = 0;
             cameraParams[1] = lightRenderData.shadowCamera._farClip;
             cameraParams[2] = lightRenderData.shadowCamera._nearClip;
             cameraParams[3] = 0;
@@ -394,12 +397,15 @@ class ForwardRenderer extends Renderer {
             params[3] = 1.0 / spot.attenuationEnd;
             this.lightShadowParamsId[cnt].setValue(params);
             this.lightShadowIntensity[cnt].setValue(spot.shadowIntensity);
-            this.lightSizeId[cnt].setValue(spot.lightSize);
 
+            const pixelsPerMeter = 1.0 / (lightRenderData.shadowCamera.renderTarget.width / spot.lightSize);
             const fov = lightRenderData.shadowCamera._fov * Math.PI / 180.0;
+            const fovRatio = 1.0 / Math.tan(fov / 2.0);
+            this.lightSizeId[cnt].setValue(pixelsPerMeter * fovRatio);
+
             const cameraParams = spot._shadowCameraParams;
             cameraParams.length = 4;
-            cameraParams[0] = 1.0 / Math.tan(fov / 2.0);
+            cameraParams[0] = 0;
             cameraParams[1] = lightRenderData.shadowCamera._farClip;
             cameraParams[2] = lightRenderData.shadowCamera._nearClip;
             cameraParams[3] = 0;

--- a/src/scene/shader-lib/chunks/lit/frag/shadowPCSS.js
+++ b/src/scene/shader-lib/chunks/lit/frag/shadowPCSS.js
@@ -147,12 +147,12 @@ float PCSSCube(samplerCube shadowMap, vec4 shadowParams, vec3 shadowCoords, vec4
     float receiverDepth = length(lightDir) * shadowParams.w + shadowParams.z;
     vec3 lightDirNorm = normalize(lightDir);
     
-    float averageBlocker = PCSSCubeBlockerDistance(shadowMap, lightDirNorm, samplePoints, receiverDepth, lightSize * 2.0);
+    float averageBlocker = PCSSCubeBlockerDistance(shadowMap, lightDirNorm, samplePoints, receiverDepth, lightSize);
     if (averageBlocker == -1.0) {
         return 1.0;
     } else {
 
-        float filterRadius = ((receiverDepth - averageBlocker) / averageBlocker) * lightSize * 2.0;
+        float filterRadius = ((receiverDepth - averageBlocker) / averageBlocker) * lightSize;
 
         float shadow = 0.0;
         for (int i = 0; i < PCSS_SAMPLE_COUNT; i++)

--- a/src/scene/shader-lib/chunks/lit/frag/shadowPCSS.js
+++ b/src/scene/shader-lib/chunks/lit/frag/shadowPCSS.js
@@ -73,7 +73,7 @@ float PCSSBlockerDistance(TEXTURE_ACCEPT(shadowMap), vec2 sampleCoords[PCSS_SAMP
     return -1.0;
 }
 
-float PCSS(TEXTURE_ACCEPT(shadowMap), vec3 shadowCoords, vec4 cameraParams, float oneOverShadowMapSize, vec2 lightSize) {
+float PCSS(TEXTURE_ACCEPT(shadowMap), vec3 shadowCoords, vec4 cameraParams, vec2 lightSize) {
     float receiverDepth = linearizeDepth(shadowCoords.z, cameraParams);
 #ifndef GL2
     // If using packed depth on GL1, we need to normalize to get the correct receiver depth
@@ -88,13 +88,12 @@ float PCSS(TEXTURE_ACCEPT(shadowMap), vec3 shadowCoords, vec4 cameraParams, floa
     }
 
     // Calculate the ratio of FOV between 45.0 degrees (tan(45) == 1) and the FOV of the camera    
-    float fovRatioAtDepth = cameraParams.x;
-    float averageBlocker = PCSSBlockerDistance(TEXTURE_PASS(shadowMap), samplePoints, shadowCoords.xy, oneOverShadowMapSize * lightSize * fovRatioAtDepth, receiverDepth);
+    float averageBlocker = PCSSBlockerDistance(TEXTURE_PASS(shadowMap), samplePoints, shadowCoords.xy, lightSize, receiverDepth);
     if (averageBlocker == -1.0) {
         return 1.0;
     } else {
 
-        vec2 filterRadius = ((receiverDepth - averageBlocker) / averageBlocker) * lightSize * oneOverShadowMapSize * fovRatioAtDepth;
+        vec2 filterRadius = ((receiverDepth - averageBlocker) / averageBlocker) * lightSize;
 
         float shadow = 0.0;
 
@@ -136,7 +135,7 @@ float PCSSCubeBlockerDistance(samplerCube shadowMap, vec3 lightDirNorm, vec3 sam
     return -1.0;
 }
 
-float PCSSCube(samplerCube shadowMap, vec4 shadowParams, vec3 shadowCoords, vec4 cameraParams, float oneOverShadowMapSize, float lightSize, vec3 lightDir) {
+float PCSSCube(samplerCube shadowMap, vec4 shadowParams, vec3 shadowCoords, vec4 cameraParams, float lightSize, vec3 lightDir) {
     
     vec3 samplePoints[PCSS_SAMPLE_COUNT];
     float noise = gradientNoise( gl_FragCoord.xy ) * 2.0 * PI;
@@ -148,12 +147,12 @@ float PCSSCube(samplerCube shadowMap, vec4 shadowParams, vec3 shadowCoords, vec4
     float receiverDepth = length(lightDir) * shadowParams.w + shadowParams.z;
     vec3 lightDirNorm = normalize(lightDir);
     
-    float averageBlocker = PCSSCubeBlockerDistance(shadowMap, lightDirNorm, samplePoints, receiverDepth, lightSize * oneOverShadowMapSize * 2.0);
+    float averageBlocker = PCSSCubeBlockerDistance(shadowMap, lightDirNorm, samplePoints, receiverDepth, lightSize * 2.0);
     if (averageBlocker == -1.0) {
         return 1.0;
     } else {
 
-        float filterRadius = ((receiverDepth - averageBlocker) / averageBlocker) * lightSize * oneOverShadowMapSize * 2.0;
+        float filterRadius = ((receiverDepth - averageBlocker) / averageBlocker) * lightSize * 2.0;
 
         float shadow = 0.0;
         for (int i = 0; i < PCSS_SAMPLE_COUNT; i++)
@@ -174,15 +173,15 @@ float PCSSCube(samplerCube shadowMap, vec4 shadowParams, vec3 shadowCoords, vec4
 }
 
 float getShadowPointPCSS(samplerCube shadowMap, vec3 shadowCoord, vec4 shadowParams, vec4 cameraParams, vec2 lightSize, vec3 lightDir) {
-    return PCSSCube(shadowMap, shadowParams, shadowCoord, cameraParams, (1.0 / shadowParams.x), lightSize.x, lightDir);
+    return PCSSCube(shadowMap, shadowParams, shadowCoord, cameraParams, lightSize.x, lightDir);
 }
 
 float getShadowSpotPCSS(TEXTURE_ACCEPT(shadowMap), vec3 shadowCoord, vec4 shadowParams, vec4 cameraParams, vec2 lightSize, vec3 lightDir) {
-    return PCSS(TEXTURE_PASS(shadowMap), shadowCoord, cameraParams, (1.0 / shadowParams.x), lightSize);
+    return PCSS(TEXTURE_PASS(shadowMap), shadowCoord, cameraParams, lightSize);
 }
 
 float getShadowPCSS(TEXTURE_ACCEPT(shadowMap), vec3 shadowCoord, vec4 shadowParams, vec4 cameraParams, vec2 lightSize, vec3 lightDir) {
-    return PCSS(TEXTURE_PASS(shadowMap), shadowCoord, cameraParams, (1.0 / shadowParams.x), lightSize);
+    return PCSS(TEXTURE_PASS(shadowMap), shadowCoord, cameraParams, lightSize);
 }
 
 `;

--- a/src/scene/shader-lib/chunks/lit/frag/shadowPCSS.js
+++ b/src/scene/shader-lib/chunks/lit/frag/shadowPCSS.js
@@ -73,7 +73,7 @@ float PCSSBlockerDistance(TEXTURE_ACCEPT(shadowMap), vec2 sampleCoords[PCSS_SAMP
     return -1.0;
 }
 
-float PCSS(TEXTURE_ACCEPT(shadowMap), vec3 shadowCoords, vec4 cameraParams, vec2 lightSize) {
+float PCSS(TEXTURE_ACCEPT(shadowMap), vec3 shadowCoords, vec4 cameraParams, vec2 shadowSearchArea) {
     float receiverDepth = linearizeDepth(shadowCoords.z, cameraParams);
 #ifndef GL2
     // If using packed depth on GL1, we need to normalize to get the correct receiver depth
@@ -88,12 +88,12 @@ float PCSS(TEXTURE_ACCEPT(shadowMap), vec3 shadowCoords, vec4 cameraParams, vec2
     }
 
     // Calculate the ratio of FOV between 45.0 degrees (tan(45) == 1) and the FOV of the camera    
-    float averageBlocker = PCSSBlockerDistance(TEXTURE_PASS(shadowMap), samplePoints, shadowCoords.xy, lightSize, receiverDepth);
+    float averageBlocker = PCSSBlockerDistance(TEXTURE_PASS(shadowMap), samplePoints, shadowCoords.xy, shadowSearchArea, receiverDepth);
     if (averageBlocker == -1.0) {
         return 1.0;
     } else {
 
-        vec2 filterRadius = ((receiverDepth - averageBlocker) / averageBlocker) * lightSize;
+        vec2 filterRadius = ((receiverDepth - averageBlocker) / averageBlocker) * shadowSearchArea;
 
         float shadow = 0.0;
 
@@ -113,11 +113,11 @@ float PCSS(TEXTURE_ACCEPT(shadowMap), vec3 shadowCoords, vec4 cameraParams, vec2
     } 
 }
 
-float PCSSCubeBlockerDistance(samplerCube shadowMap, vec3 lightDirNorm, vec3 samplePoints[PCSS_SAMPLE_COUNT], float z, float lightSize) {
+float PCSSCubeBlockerDistance(samplerCube shadowMap, vec3 lightDirNorm, vec3 samplePoints[PCSS_SAMPLE_COUNT], float z, float shadowSearchArea) {
     float blockers = 0.0;
     float averageBlocker = 0.0;
     for (int i = 0; i < PCSS_SAMPLE_COUNT; i++) {
-        vec3 sampleDir = lightDirNorm + samplePoints[i] * lightSize;
+        vec3 sampleDir = lightDirNorm + samplePoints[i] * shadowSearchArea;
         sampleDir = normalize(sampleDir);
 
     #ifdef GL2
@@ -135,7 +135,7 @@ float PCSSCubeBlockerDistance(samplerCube shadowMap, vec3 lightDirNorm, vec3 sam
     return -1.0;
 }
 
-float PCSSCube(samplerCube shadowMap, vec4 shadowParams, vec3 shadowCoords, vec4 cameraParams, float lightSize, vec3 lightDir) {
+float PCSSCube(samplerCube shadowMap, vec4 shadowParams, vec3 shadowCoords, vec4 cameraParams, float shadowSearchArea, vec3 lightDir) {
     
     vec3 samplePoints[PCSS_SAMPLE_COUNT];
     float noise = gradientNoise( gl_FragCoord.xy ) * 2.0 * PI;
@@ -147,12 +147,12 @@ float PCSSCube(samplerCube shadowMap, vec4 shadowParams, vec3 shadowCoords, vec4
     float receiverDepth = length(lightDir) * shadowParams.w + shadowParams.z;
     vec3 lightDirNorm = normalize(lightDir);
     
-    float averageBlocker = PCSSCubeBlockerDistance(shadowMap, lightDirNorm, samplePoints, receiverDepth, lightSize);
+    float averageBlocker = PCSSCubeBlockerDistance(shadowMap, lightDirNorm, samplePoints, receiverDepth, shadowSearchArea);
     if (averageBlocker == -1.0) {
         return 1.0;
     } else {
 
-        float filterRadius = ((receiverDepth - averageBlocker) / averageBlocker) * lightSize;
+        float filterRadius = ((receiverDepth - averageBlocker) / averageBlocker) * shadowSearchArea;
 
         float shadow = 0.0;
         for (int i = 0; i < PCSS_SAMPLE_COUNT; i++)
@@ -172,16 +172,16 @@ float PCSSCube(samplerCube shadowMap, vec4 shadowParams, vec3 shadowCoords, vec4
     }
 }
 
-float getShadowPointPCSS(samplerCube shadowMap, vec3 shadowCoord, vec4 shadowParams, vec4 cameraParams, vec2 lightSize, vec3 lightDir) {
-    return PCSSCube(shadowMap, shadowParams, shadowCoord, cameraParams, lightSize.x, lightDir);
+float getShadowPointPCSS(samplerCube shadowMap, vec3 shadowCoord, vec4 shadowParams, vec4 cameraParams, vec2 shadowSearchArea, vec3 lightDir) {
+    return PCSSCube(shadowMap, shadowParams, shadowCoord, cameraParams, shadowSearchArea.x, lightDir);
 }
 
-float getShadowSpotPCSS(TEXTURE_ACCEPT(shadowMap), vec3 shadowCoord, vec4 shadowParams, vec4 cameraParams, vec2 lightSize, vec3 lightDir) {
-    return PCSS(TEXTURE_PASS(shadowMap), shadowCoord, cameraParams, lightSize);
+float getShadowSpotPCSS(TEXTURE_ACCEPT(shadowMap), vec3 shadowCoord, vec4 shadowParams, vec4 cameraParams, vec2 shadowSearchArea, vec3 lightDir) {
+    return PCSS(TEXTURE_PASS(shadowMap), shadowCoord, cameraParams, shadowSearchArea);
 }
 
-float getShadowPCSS(TEXTURE_ACCEPT(shadowMap), vec3 shadowCoord, vec4 shadowParams, vec4 cameraParams, vec2 lightSize, vec3 lightDir) {
-    return PCSS(TEXTURE_PASS(shadowMap), shadowCoord, cameraParams, lightSize);
+float getShadowPCSS(TEXTURE_ACCEPT(shadowMap), vec3 shadowCoord, vec4 shadowParams, vec4 cameraParams, vec2 shadowSearchArea, vec3 lightDir) {
+    return PCSS(TEXTURE_PASS(shadowMap), shadowCoord, cameraParams, shadowSearchArea);
 }
 
 `;

--- a/src/scene/shader-lib/chunks/standard/frag/litShaderArgs.js
+++ b/src/scene/shader-lib/chunks/standard/frag/litShaderArgs.js
@@ -11,31 +11,31 @@ struct IridescenceArgs
 
 struct ClearcoatArgs
 {
+    // The normal used for the clearcoat layer
+    vec3 worldNormal;
+
     // Intensity of the clearcoat layer, range [0..1]
     float specularity;
 
     // Glossiness of clearcoat layer, range [0..1]
     float gloss;
-
-    // The normal used for the clearcoat layer
-    vec3 worldNormal;
 };
 
 struct SheenArgs
 {
-    // Glossiness of the sheen layer, range [0..1]
-    float gloss;
-
     // The color of the f0 specularity factor for the sheen layer
     vec3 specularity;
+
+    // Glossiness of the sheen layer, range [0..1]
+    float gloss;
 };
 
 struct LitShaderArguments {
-    // Transparency
-    float opacity;
-
     // Normal direction in world space
     vec3 worldNormal;
+
+    // Transparency
+    float opacity;
 
     // Surface albedo absorbance
     vec3 albedo;
@@ -43,38 +43,38 @@ struct LitShaderArguments {
     // Transmission factor (refraction), range [0..1]
     float transmission;
 
-    // Uniform thickness of medium, used by transmission, range [0..inf]
-    float thickness;
-
     // The f0 specularity factor
     vec3 specularity;
 
-    // The microfacet glossiness factor, range [0..1]
-    float gloss;
-
-    // Surface metalness factor, range [0..1]
-    float metalness;
-
-    // Specularity intensity factor, range [0..1]
-    float specularityFactor;
-
-    // Ambient occlusion amount, range [0..1]
-    float ao;
+    // Uniform thickness of medium, used by transmission, range [0..inf]
+    float thickness;
 
     // Emission color
     vec3 emission;
 
+    // Ambient occlusion amount, range [0..1]
+    float ao;
+
     // Light map color
     vec3 lightmap;
 
+    // Specularity intensity factor, range [0..1]
+    float specularityFactor;
+
     // Light map direction
     vec3 lightmapDir;
+
+    // The microfacet glossiness factor, range [0..1]
+    float gloss;
 
     // Iridescence extension arguments
     IridescenceArgs iridescence;
 
     // Clearcoat extension arguments
     ClearcoatArgs clearcoat;
+
+    // Surface metalness factor, range [0..1]
+    float metalness;
 
     // Sheen extension arguments
     SheenArgs sheen;

--- a/src/scene/shader-lib/programs/lit-shader.js
+++ b/src/scene/shader-lib/programs/lit-shader.js
@@ -1342,45 +1342,47 @@ class LitShader {
                 }
 
                 // specular / clear coat
-                if (lightShape !== LIGHTSHAPE_PUNCTUAL) {
+                if (light.affectSpecularity) {
+                    if (lightShape !== LIGHTSHAPE_PUNCTUAL) {
 
-                    // area light
-                    if (options.useClearCoat) {
-                        backend.append(`    ccSpecularLight += ccLTCSpecFres * get${shapeString}LightSpecular(litShaderArgs.clearcoat.worldNormal, dViewDirW) * dAtten * light${i}_color` + (usesCookieNow ? " * dAtten3" : "") + ";");
-                    }
-                    if (options.useSpecular) {
-                        backend.append(`    dSpecularLight += dLTCSpecFres * get${shapeString}LightSpecular(litShaderArgs.worldNormal, dViewDirW) * dAtten * light${i}_color` + (usesCookieNow ? " * dAtten3" : "") + ";");
-                    }
+                        // area light
+                        if (options.useClearCoat) {
+                            backend.append(`    ccSpecularLight += ccLTCSpecFres * get${shapeString}LightSpecular(litShaderArgs.clearcoat.worldNormal, dViewDirW) * dAtten * light${i}_color` + (usesCookieNow ? " * dAtten3" : "") + ";");
+                        }
+                        if (options.useSpecular) {
+                            backend.append(`    dSpecularLight += dLTCSpecFres * get${shapeString}LightSpecular(litShaderArgs.worldNormal, dViewDirW) * dAtten * light${i}_color` + (usesCookieNow ? " * dAtten3" : "") + ";");
+                        }
 
-                } else {
-                    var calcFresnel = false;
-                    if (lightType === LIGHTTYPE_DIRECTIONAL && options.fresnelModel > 0) {
-                        calcFresnel = true;
-                    }
+                    } else {
+                        var calcFresnel = false;
+                        if (lightType === LIGHTTYPE_DIRECTIONAL && options.fresnelModel > 0) {
+                            calcFresnel = true;
+                        }
 
-                    // if LTC lights are present, specular must be accumulated with specularity (specularity is pre multiplied by punctual light fresnel)
-                    if (options.useClearCoat) {
-                        backend.append(`    ccSpecularLight += getLightSpecular(dHalfDirW, ccReflDirW, litShaderArgs.clearcoat.worldNormal, dViewDirW, dLightDirNormW, litShaderArgs.clearcoat.gloss, dTBN) * dAtten * light${i}_color` +
-                            (usesCookieNow ? " * dAtten3" : "") +
-                            (calcFresnel ? " * getFresnelCC(dot(dViewDirW, dHalfDirW));" : ";"));
-                    }
-                    if (options.useSheen) {
-                        backend.append(`    sSpecularLight += getLightSpecularSheen(dHalfDirW, litShaderArgs.worldNormal, dViewDirW, dLightDirNormW, litShaderArgs.sheen.gloss) * dAtten * light${i}_color` +
-                            (usesCookieNow ? " * dAtten3;" : ";"));
-                    }
-                    if (options.useSpecular) {
-                        backend.append(`    dSpecularLight += getLightSpecular(dHalfDirW, dReflDirW, litShaderArgs.worldNormal, dViewDirW, dLightDirNormW, litShaderArgs.gloss, dTBN) * dAtten * light${i}_color` +
-                            (usesCookieNow ? " * dAtten3" : "") +
-                            (calcFresnel ? ` 
-                                * getFresnel(
-                                    dot(dViewDirW, dHalfDirW), 
-                                    litShaderArgs.gloss, 
-                                    litShaderArgs.specularity
-                                #if defined(LIT_IRIDESCENCE)
-                                    , iridescenceFresnel, 
-                                    litShaderArgs.iridescence
-                                #endif
-                                );` : `* litShaderArgs.specularity;`));
+                        // if LTC lights are present, specular must be accumulated with specularity (specularity is pre multiplied by punctual light fresnel)
+                        if (options.useClearCoat) {
+                            backend.append(`    ccSpecularLight += getLightSpecular(dHalfDirW, ccReflDirW, litShaderArgs.clearcoat.worldNormal, dViewDirW, dLightDirNormW, litShaderArgs.clearcoat.gloss, dTBN) * dAtten * light${i}_color` +
+                                (usesCookieNow ? " * dAtten3" : "") +
+                                (calcFresnel ? " * getFresnelCC(dot(dViewDirW, dHalfDirW));" : ";"));
+                        }
+                        if (options.useSheen) {
+                            backend.append(`    sSpecularLight += getLightSpecularSheen(dHalfDirW, litShaderArgs.worldNormal, dViewDirW, dLightDirNormW, litShaderArgs.sheen.gloss) * dAtten * light${i}_color` +
+                                (usesCookieNow ? " * dAtten3;" : ";"));
+                        }
+                        if (options.useSpecular) {
+                            backend.append(`    dSpecularLight += getLightSpecular(dHalfDirW, dReflDirW, litShaderArgs.worldNormal, dViewDirW, dLightDirNormW, litShaderArgs.gloss, dTBN) * dAtten * light${i}_color` +
+                                (usesCookieNow ? " * dAtten3" : "") +
+                                (calcFresnel ? ` 
+                                    * getFresnel(
+                                        dot(dViewDirW, dHalfDirW), 
+                                        litShaderArgs.gloss, 
+                                        litShaderArgs.specularity
+                                    #if defined(LIT_IRIDESCENCE)
+                                        , iridescenceFresnel, 
+                                        litShaderArgs.iridescence
+                                    #endif
+                                    );` : `* litShaderArgs.specularity;`));
+                        }
                     }
                 }
 

--- a/src/scene/shader-lib/programs/lit-shader.js
+++ b/src/scene/shader-lib/programs/lit-shader.js
@@ -644,10 +644,12 @@ class LitShader {
             const lightShape = (hasAreaLights && light._shape) ? light._shape : LIGHTSHAPE_PUNCTUAL;
 
             decl.append("uniform vec3 light" + i + "_color;");
+
             if (light._shadowType === SHADOW_PCSS && light.castShadows && !options.noShadow) {
                 decl.append(`uniform float light${i}_size;`);
                 decl.append(`uniform vec4 light${i}_cameraParams;`);
             }
+
             if (lightType === LIGHTTYPE_DIRECTIONAL) {
                 decl.append("uniform vec3 light" + i + "_direction;");
             } else {

--- a/src/scene/shader-lib/programs/lit-shader.js
+++ b/src/scene/shader-lib/programs/lit-shader.js
@@ -644,12 +644,10 @@ class LitShader {
             const lightShape = (hasAreaLights && light._shape) ? light._shape : LIGHTSHAPE_PUNCTUAL;
 
             decl.append("uniform vec3 light" + i + "_color;");
-
             if (light._shadowType === SHADOW_PCSS && light.castShadows && !options.noShadow) {
                 decl.append(`uniform float light${i}_size;`);
                 decl.append(`uniform vec4 light${i}_cameraParams;`);
             }
-
             if (lightType === LIGHTTYPE_DIRECTIONAL) {
                 decl.append("uniform vec3 light" + i + "_direction;");
             } else {
@@ -1342,47 +1340,45 @@ class LitShader {
                 }
 
                 // specular / clear coat
-                if (light.affectSpecularity) {
-                    if (lightShape !== LIGHTSHAPE_PUNCTUAL) {
+                if (lightShape !== LIGHTSHAPE_PUNCTUAL) {
 
-                        // area light
-                        if (options.useClearCoat) {
-                            backend.append(`    ccSpecularLight += ccLTCSpecFres * get${shapeString}LightSpecular(litShaderArgs.clearcoat.worldNormal, dViewDirW) * dAtten * light${i}_color` + (usesCookieNow ? " * dAtten3" : "") + ";");
-                        }
-                        if (options.useSpecular) {
-                            backend.append(`    dSpecularLight += dLTCSpecFres * get${shapeString}LightSpecular(litShaderArgs.worldNormal, dViewDirW) * dAtten * light${i}_color` + (usesCookieNow ? " * dAtten3" : "") + ";");
-                        }
+                    // area light
+                    if (options.useClearCoat) {
+                        backend.append(`    ccSpecularLight += ccLTCSpecFres * get${shapeString}LightSpecular(litShaderArgs.clearcoat.worldNormal, dViewDirW) * dAtten * light${i}_color` + (usesCookieNow ? " * dAtten3" : "") + ";");
+                    }
+                    if (options.useSpecular) {
+                        backend.append(`    dSpecularLight += dLTCSpecFres * get${shapeString}LightSpecular(litShaderArgs.worldNormal, dViewDirW) * dAtten * light${i}_color` + (usesCookieNow ? " * dAtten3" : "") + ";");
+                    }
 
-                    } else {
-                        var calcFresnel = false;
-                        if (lightType === LIGHTTYPE_DIRECTIONAL && options.fresnelModel > 0) {
-                            calcFresnel = true;
-                        }
+                } else {
+                    var calcFresnel = false;
+                    if (lightType === LIGHTTYPE_DIRECTIONAL && options.fresnelModel > 0) {
+                        calcFresnel = true;
+                    }
 
-                        // if LTC lights are present, specular must be accumulated with specularity (specularity is pre multiplied by punctual light fresnel)
-                        if (options.useClearCoat) {
-                            backend.append(`    ccSpecularLight += getLightSpecular(dHalfDirW, ccReflDirW, litShaderArgs.clearcoat.worldNormal, dViewDirW, dLightDirNormW, litShaderArgs.clearcoat.gloss, dTBN) * dAtten * light${i}_color` +
-                                (usesCookieNow ? " * dAtten3" : "") +
-                                (calcFresnel ? " * getFresnelCC(dot(dViewDirW, dHalfDirW));" : ";"));
-                        }
-                        if (options.useSheen) {
-                            backend.append(`    sSpecularLight += getLightSpecularSheen(dHalfDirW, litShaderArgs.worldNormal, dViewDirW, dLightDirNormW, litShaderArgs.sheen.gloss) * dAtten * light${i}_color` +
-                                (usesCookieNow ? " * dAtten3;" : ";"));
-                        }
-                        if (options.useSpecular) {
-                            backend.append(`    dSpecularLight += getLightSpecular(dHalfDirW, dReflDirW, litShaderArgs.worldNormal, dViewDirW, dLightDirNormW, litShaderArgs.gloss, dTBN) * dAtten * light${i}_color` +
-                                (usesCookieNow ? " * dAtten3" : "") +
-                                (calcFresnel ? ` 
-                                    * getFresnel(
-                                        dot(dViewDirW, dHalfDirW), 
-                                        litShaderArgs.gloss, 
-                                        litShaderArgs.specularity
-                                    #if defined(LIT_IRIDESCENCE)
-                                        , iridescenceFresnel, 
-                                        litShaderArgs.iridescence
-                                    #endif
-                                    );` : `* litShaderArgs.specularity;`));
-                        }
+                    // if LTC lights are present, specular must be accumulated with specularity (specularity is pre multiplied by punctual light fresnel)
+                    if (options.useClearCoat) {
+                        backend.append(`    ccSpecularLight += getLightSpecular(dHalfDirW, ccReflDirW, litShaderArgs.clearcoat.worldNormal, dViewDirW, dLightDirNormW, litShaderArgs.clearcoat.gloss, dTBN) * dAtten * light${i}_color` +
+                            (usesCookieNow ? " * dAtten3" : "") +
+                            (calcFresnel ? " * getFresnelCC(dot(dViewDirW, dHalfDirW));" : ";"));
+                    }
+                    if (options.useSheen) {
+                        backend.append(`    sSpecularLight += getLightSpecularSheen(dHalfDirW, litShaderArgs.worldNormal, dViewDirW, dLightDirNormW, litShaderArgs.sheen.gloss) * dAtten * light${i}_color` +
+                            (usesCookieNow ? " * dAtten3;" : ";"));
+                    }
+                    if (options.useSpecular) {
+                        backend.append(`    dSpecularLight += getLightSpecular(dHalfDirW, dReflDirW, litShaderArgs.worldNormal, dViewDirW, dLightDirNormW, litShaderArgs.gloss, dTBN) * dAtten * light${i}_color` +
+                            (usesCookieNow ? " * dAtten3" : "") +
+                            (calcFresnel ? ` 
+                                * getFresnel(
+                                    dot(dViewDirW, dHalfDirW), 
+                                    litShaderArgs.gloss, 
+                                    litShaderArgs.specularity
+                                #if defined(LIT_IRIDESCENCE)
+                                    , iridescenceFresnel, 
+                                    litShaderArgs.iridescence
+                                #endif
+                                );` : `* litShaderArgs.specularity;`));
                     }
                 }
 

--- a/src/scene/shader-lib/programs/lit-shader.js
+++ b/src/scene/shader-lib/programs/lit-shader.js
@@ -1298,11 +1298,11 @@ class LitShader {
                             // VSM
                             shadowCoordArgs = `${shadowCoordArgs}, ${evsmExp}, dLightDirW`;
                         } else if (pcssShadows) {
-                            let lightSizeArg = `vec2(light${i}_shadowSearchArea)`;
+                            let penumbraSizeArg = `vec2(light${i}_shadowSearchArea)`;
                             if (lightShape !== LIGHTSHAPE_PUNCTUAL) {
-                                lightSizeArg = `vec2(length(light${i}_halfWidth), length(light${i}_halfHeight)) * light${i}_shadowSearchArea`;
+                                penumbraSizeArg = `vec2(length(light${i}_halfWidth), length(light${i}_halfHeight)) * light${i}_shadowSearchArea`;
                             }
-                            shadowCoordArgs = `${shadowCoordArgs}, light${i}_cameraParams, ${lightSizeArg}, dLightDirW`;
+                            shadowCoordArgs = `${shadowCoordArgs}, light${i}_cameraParams, ${penumbraSizeArg}, dLightDirW`;
                         }
 
                         if (lightType === LIGHTTYPE_OMNI) {

--- a/src/scene/shader-lib/programs/lit-shader.js
+++ b/src/scene/shader-lib/programs/lit-shader.js
@@ -646,7 +646,7 @@ class LitShader {
             decl.append("uniform vec3 light" + i + "_color;");
 
             if (light._shadowType === SHADOW_PCSS && light.castShadows && !options.noShadow) {
-                decl.append(`uniform float light${i}_size;`);
+                decl.append(`uniform float light${i}_shadowSearchArea;`);
                 decl.append(`uniform vec4 light${i}_cameraParams;`);
             }
 
@@ -1298,9 +1298,9 @@ class LitShader {
                             // VSM
                             shadowCoordArgs = `${shadowCoordArgs}, ${evsmExp}, dLightDirW`;
                         } else if (pcssShadows) {
-                            let lightSizeArg = `vec2(light${i}_size)`;
+                            let lightSizeArg = `vec2(light${i}_shadowSearchArea)`;
                             if (lightShape !== LIGHTSHAPE_PUNCTUAL) {
-                                lightSizeArg = `vec2(length(light${i}_halfWidth), length(light${i}_halfHeight)) * light${i}_size`;
+                                lightSizeArg = `vec2(length(light${i}_halfWidth), length(light${i}_halfHeight)) * light${i}_shadowSearchArea`;
                             }
                             shadowCoordArgs = `${shadowCoordArgs}, light${i}_cameraParams, ${lightSizeArg}, dLightDirW`;
                         }


### PR DESCRIPTION
This PR changes the way lightSize modifies the softness of PCSS shadows. Instead of using lightSize directly, it's now a factor of how many pixels per meter to fetch, making the parameter more intuitive to use.

Also threw in a bunch of small optimisations. 