### PR TITLE
Updated the way WebGPU submits command buffers for rendering

### DIFF
--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -124,3 +124,10 @@ export const TRACE_ID_ELEMENT = "Element";
  * @type {string}
  */
 export const TRACEID_TEXTURES = 'Textures';
+
+/**
+ * Logs the render queue commands.
+ *
+ * @type {string}
+ */
+export const TRACEID_RENDER_QUEUE = 'RenderQueue';

--- a/src/framework/app-base.js
+++ b/src/framework/app-base.js
@@ -1192,6 +1192,10 @@ class AppBase extends EventHandler {
         this.graphicsDevice.frameStart();
     }
 
+    frameEnd() {
+        this.graphicsDevice.frameEnd();
+    }
+
     /**
      * Render the application's scene. More specifically, the scene's {@link LayerComposition} is
      * rendered. This function is called internally in the application's main loop and does not
@@ -2212,6 +2216,7 @@ const makeTick = function (_app) {
                 application.updateCanvasSize();
                 application.frameStart();
                 application.render();
+                application.frameEnd();
                 application.renderNextFrame = false;
 
                 Debug.trace(TRACEID_RENDER_FRAME_TIME, `-- RenderEnd ${now().toFixed(2)}ms`);

--- a/src/platform/graphics/graphics-device.js
+++ b/src/platform/graphics/graphics-device.js
@@ -696,6 +696,15 @@ class GraphicsDevice extends EventHandler {
             }
         });
     }
+
+    /**
+     * Function which executes at the end of the frame. This should not be called manually, as it is
+     * handled by the AppBase instance.
+     *
+     * @ignore
+     */
+    frameEnd() {
+    }
 }
 
 export { GraphicsDevice };

--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -2078,6 +2078,10 @@ class WebglGraphicsDevice extends GraphicsDevice {
         }
     }
 
+    submit() {
+        this.gl.flush();
+    }
+
     /**
      * Reads a block of pixels from a specified rectangle of the current color framebuffer into an
      * ArrayBufferView object.
@@ -2117,7 +2121,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
 
         const clientWaitAsync = (flags, interval_ms) => {
             const sync = gl.fenceSync(gl.SYNC_GPU_COMMANDS_COMPLETE, 0);
-            gl.flush();
+            this.submit();
 
             return new Promise((resolve, reject) => {
                 function test() {

--- a/src/platform/graphics/webgpu/webgpu-buffer.js
+++ b/src/platform/graphics/webgpu/webgpu-buffer.js
@@ -1,4 +1,5 @@
-import { DebugHelper } from '../../../core/debug.js';
+import { TRACEID_RENDER_QUEUE } from '../../core/constants.js';
+import { Debug, DebugHelper } from '../../../core/debug.js';
 
 /**
  * A WebGPU implementation of the Buffer.
@@ -77,6 +78,7 @@ class WebgpuBuffer {
         data.set(srcData);
 
         // copy data to the gpu buffer
+        Debug.trace(TRACEID_RENDER_QUEUE, `writeBuffer: ${this.buffer.label}`);
         wgpu.queue.writeBuffer(this.buffer, 0, data, 0, data.length);
 
         // TODO: handle usage types:

--- a/src/platform/graphics/webgpu/webgpu-buffer.js
+++ b/src/platform/graphics/webgpu/webgpu-buffer.js
@@ -1,4 +1,4 @@
-import { TRACEID_RENDER_QUEUE } from '../../core/constants.js';
+import { TRACEID_RENDER_QUEUE } from '../../../core/constants.js';
 import { Debug, DebugHelper } from '../../../core/debug.js';
 
 /**

--- a/src/platform/graphics/webgpu/webgpu-clear-renderer.js
+++ b/src/platform/graphics/webgpu/webgpu-clear-renderer.js
@@ -133,9 +133,7 @@ class WebgpuClearRenderer {
             device.setShader(this.shader);
 
             const bindGroup = this.bindGroup;
-            if (bindGroup.defaultUniformBuffer) {
-                bindGroup.defaultUniformBuffer.update();
-            }
+            bindGroup.defaultUniformBuffer.update();
             bindGroup.update();
             device.setBindGroup(BINDGROUP_MESH, bindGroup);
 

--- a/src/platform/graphics/webgpu/webgpu-mipmap-renderer.js
+++ b/src/platform/graphics/webgpu/webgpu-mipmap-renderer.js
@@ -77,11 +77,6 @@ class WebgpuMipmapRenderer {
         }
 
         const device = this.device;
-        DebugGraphics.pushGpuMarker(device, 'MIPMAP-RENDERER');
-
-        // cannot run this inside render pass
-        Debug.assert(!device.insideRenderPass, 'Mipmap generation cannot be run inside a render pass.', webgpuTexture.texture);
-
         const wgpu = device.wgpu;
 
         /** @type {import('./webgpu-shader.js').WebgpuShader} */
@@ -119,7 +114,11 @@ class WebgpuMipmapRenderer {
         }
 
         // loop through each mip level and render the previous level's contents into it.
-        const commandEncoder = wgpu.createCommandEncoder();
+        const commandEncoder = device.commandEncoder ?? wgpu.createCommandEncoder();
+        DebugHelper.setLabel(commandEncoder, 'MipmapRendererEncoder');
+
+        DebugGraphics.pushGpuMarker(device, 'MIPMAP-RENDERER');
+
         for (let i = 1; i < textureDescr.mipLevelCount; i++) {
 
             for (let face = 0; face < numFaces; face++) {
@@ -161,12 +160,18 @@ class WebgpuMipmapRenderer {
             }
         }
 
-        wgpu.queue.submit([commandEncoder.finish()]);
+        DebugGraphics.popGpuMarker(device);
+
+        // submit the encoded commands if we created the encoder
+        if (!device.commandEncoder) {
+
+            const cb = commandEncoder.finish();
+            DebugHelper.setLabel(cb, 'MipmapRenderer-CommandBuffer');
+            device.addCommandBuffer(cb);
+        }
 
         // clear invalidated state
         device.pipeline = null;
-
-        DebugGraphics.popGpuMarker(device);
     }
 }
 

--- a/src/platform/graphics/webgpu/webgpu-texture.js
+++ b/src/platform/graphics/webgpu/webgpu-texture.js
@@ -1,3 +1,4 @@
+import { TRACEID_RENDER_QUEUE } from '../../../core/constants.js';
 import { Debug, DebugHelper } from '../../../core/debug.js';
 import { math } from '../../../core/math/math.js';
 
@@ -314,7 +315,6 @@ class WebgpuTexture {
 
         const texture = this.texture;
         if (texture._levels) {
-            const wgpu = device.wgpu;
 
             // upload texture data if any
             let anyUploads = false;
@@ -337,7 +337,7 @@ class WebgpuTexture {
 
                                 } else if (ArrayBuffer.isView(faceSource)) { // typed array
 
-                                    this.uploadTypedArrayData(wgpu, faceSource, mipLevel, face);
+                                    this.uploadTypedArrayData(device, faceSource, mipLevel, face);
                                     anyUploads = true;
 
                                 } else {
@@ -360,7 +360,7 @@ class WebgpuTexture {
 
                         } else if (ArrayBuffer.isView(mipObject)) { // typed array
 
-                            this.uploadTypedArrayData(wgpu, mipObject, mipLevel, 0);
+                            this.uploadTypedArrayData(device, mipObject, mipLevel, 0);
                             anyUploads = true;
 
                         } else {
@@ -408,12 +408,17 @@ class WebgpuTexture {
             depthOrArrayLayers: 1   // single layer
         };
 
+        // submit existing commands before copying to preserve order
+        device.submit();
+
+        Debug.trace(TRACEID_RENDER_QUEUE, `CopyImage2Tex: mip:${mipLevel} face:${face} ${this.texture.name}`);
         device.wgpu.queue.copyExternalImageToTexture(src, dst, copySize);
     }
 
-    uploadTypedArrayData(wgpu, data, mipLevel, face) {
+    uploadTypedArrayData(device, data, mipLevel, face) {
 
         const texture = this.texture;
+        const wgpu = device.wgpu;
 
         /** @type {GPUImageCopyTexture} */
         const dest = {
@@ -452,6 +457,10 @@ class WebgpuTexture {
             depthOrArrayLayers: 1
         };
 
+        // submit existing commands before copying to preserve order
+        device.submit();
+
+        Debug.trace(TRACEID_RENDER_QUEUE, `writeTex: mip:${mipLevel} face:${face} ${this.texture.name}`);
         wgpu.queue.writeTexture(dest, data, dataLayout, size);
     }
 }

--- a/src/scene/graphics/quad-render-utils.js
+++ b/src/scene/graphics/quad-render-utils.js
@@ -35,8 +35,6 @@ function drawQuadWithShader(device, target, shader, rect, scissorRect) {
         }
     });
 
-    DebugGraphics.pushGpuMarker(device, "drawQuadWithShader");
-
     device.setCullMode(CULLFACE_NONE);
     device.setDepthState(DepthState.NODEPTH);
     device.setStencilState(null, null);
@@ -55,7 +53,9 @@ function drawQuadWithShader(device, target, shader, rect, scissorRect) {
 
     // prepare a render pass to render the quad to the render target
     const renderPass = new RenderPass(device, () => {
+        DebugGraphics.pushGpuMarker(device, "drawQuadWithShader");
         quad.render(rect, scissorRect);
+        DebugGraphics.popGpuMarker(device);
     });
     DebugHelper.setName(renderPass, `RenderPass-drawQuadWithShader${target ? `-${target.name}` : 'Framebuffer'}`);
     renderPass.init(target);
@@ -74,9 +74,12 @@ function drawQuadWithShader(device, target, shader, rect, scissorRect) {
     }
 
     renderPass.render();
-    quad.destroy();
 
-    DebugGraphics.popGpuMarker(device);
+    // TODO: remove this submission, when UB allocates from per frame buffers. For now, we need to submit the command buffer,
+    // as we're destroying the UB buffer on the next line, and the command buffer needs to be submitted before that.
+    device.submit();
+
+    quad.destroy();
 }
 
 /**


### PR DESCRIPTION
A system is implemented to minimize the number of relatively expensive command buffer (CB) submits:
- CBs are collected into an array and submitted only when needed
- care is taken to keep CB submission in the same order as other operations in the gpu queue
- mipmaps for render target textures are generated as part of the same command buffer, instead of a separate CB
- gpu markers were moved to be captured by respective CBs

TODO: This is not completely finished, and the system is not enabled yet, until further work is done in a separate PR. Currently (subject to change):
- when CB for a render pass is created, it's submitted immediately. This is required to make sure queue.writeBuffer for UBs are done in the correct order, which will be addressed separately.