### PR TITLE
[Anim Component] Fix exit time conditions for non looping animations

### DIFF
--- a/src/framework/anim/controller/anim-controller.js
+++ b/src/framework/anim/controller/anim-controller.js
@@ -306,8 +306,13 @@ class AnimController {
                     progressBefore -= Math.floor(progressBefore);
                     progress -= Math.floor(progress);
                 }
-                // return false if exit time isn't within the frames delta time
-                if (!(transition.exitTime > progressBefore && transition.exitTime <= progress)) {
+                // if the delta time is 0 and the progress matches the exit time, the exitTime condition has been met
+                if (progress === progressBefore) {
+                    if (progress !== transition.exitTime) {
+                        return null;
+                    }
+                // otherwise if the delta time is greater than 0, return false if exit time isn't within the frames delta time
+                } else if (!(transition.exitTime > progressBefore && transition.exitTime <= progress)) {
                     return null;
                 }
             }
@@ -516,8 +521,17 @@ class AnimController {
         let state;
         let animation;
         let clip;
-        this._timeInStateBefore = this._timeInState;
-        this._timeInState += dt * this.activeState.speed;
+        // update time when looping or when the active state is not at the end of its duration
+        if (this.activeState.loop || this._timeInState < this.activeStateDuration) {
+            this._timeInStateBefore = this._timeInState;
+            this._timeInState += dt * this.activeState.speed;
+            // if the active state is not looping and the time in state is greater than the duration, set the time in state to the state duration
+            // and update the delta time accordingly
+            if (!this.activeState.loop && this._timeInState > this.activeStateDuration) {
+                this._timeInState = this.activeStateDuration;
+                dt = this.activeStateDuration - this._timeInStateBefore;
+            }
+        }
 
         // transition between states if a transition is available from the active state
         const transition = this._findTransition(this._activeStateName);

--- a/src/framework/anim/controller/anim-controller.js
+++ b/src/framework/anim/controller/anim-controller.js
@@ -134,9 +134,6 @@ class AnimController {
 
     get activeStateDuration() {
         if (this._activeStateDurationDirty) {
-            if (this.activeStateName === ANIM_STATE_START || this.activeStateName === ANIM_STATE_END)
-                return 0.0;
-
             let maxDuration = 0.0;
             for (let i = 0; i < this.activeStateAnimations.length; i++) {
                 const activeClip = this._animEvaluator.findClip(this.activeStateAnimations[i].name);


### PR DESCRIPTION
The anim controller shouldn't update the state time when a non looping animation has completed its playback. Additionally  states that have finished their playback should have their exit time conditions checked as if they were playing.

Fixes #4427

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
