### PR TITLE
Bump allocation for Uniform Buffers on WebGPU

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
       "glslang": "readonly",
       "GPUBufferUsage": "readonly",
       "GPUColorWrite": "readonly",
+      "GPUMapMode": "readonly",
       "GPUShaderStage": "readonly",
       "GPUTextureUsage": "readonly",
       "opentype": "readonly",

--- a/src/platform/graphics/bind-group.js
+++ b/src/platform/graphics/bind-group.js
@@ -20,6 +20,17 @@ class BindGroup {
      */
     renderVersionUpdated = -1;
 
+    /** @type {import('./uniform-buffer.js').UniformBuffer[]} */
+    uniformBuffers;
+
+    /**
+     * An array of offsets for each uniform buffer in the bind group. This is the offset in the
+     * buffer where the uniform buffer data starts.
+     *
+     * @type {number[]}
+     */
+    uniformBufferOffsets = [];
+
     /**
      * Create a new Bind Group.
      *
@@ -106,6 +117,20 @@ class BindGroup {
             const value = textureFormat.scopeId.value;
             Debug.assert(value, `Value was not set when assigning texture slot [${textureFormat.name}] to a bind group, while rendering [${DebugGraphics.toString()}]`, this);
             this.setTexture(textureFormat.name, value);
+        }
+
+        // update uniform buffer offsets
+        this.uniformBufferOffsets.length = this.uniformBuffers.length;
+        for (let i = 0; i < this.uniformBuffers.length; i++) {
+            const uniformBuffer = this.uniformBuffers[i];
+
+            // offset
+            this.uniformBufferOffsets[i] = uniformBuffer.offset;
+
+            // test if any of the uniform buffers have changed (not their content, but the buffer container itself)
+            if (this.renderVersionUpdated < uniformBuffer.renderVersionDirty) {
+                this.dirty = true;
+            }
         }
 
         if (this.dirty) {

--- a/src/platform/graphics/dynamic-buffers.js
+++ b/src/platform/graphics/dynamic-buffers.js
@@ -118,8 +118,8 @@ class DynamicBuffers {
      * Create the system of dynamic buffers.
      *
      * @param {import('./graphics-device.js').GraphicsDevice} device - The graphics device.
-     * @param {*} bufferSize - The size of the underlying large buffers.
-     * @param {*} bufferAlignment - Alignment of each allocation.
+     * @param {number} bufferSize - The size of the underlying large buffers.
+     * @param {number} bufferAlignment - Alignment of each allocation.
      */
     constructor(device, bufferSize, bufferAlignment) {
         this.device = device;

--- a/src/platform/graphics/dynamic-buffers.js
+++ b/src/platform/graphics/dynamic-buffers.js
@@ -1,0 +1,218 @@
+import { Debug } from '../../core/debug.js';
+import { math } from '../../core/math/math.js';
+
+/**
+ * A base class representing a single per platform buffer.
+ *
+ * @ignore
+ */
+class DynamicBuffer {
+    /** @type {import('./graphics-device.js').GraphicsDevice} */
+    device;
+
+    constructor(device) {
+        this.device = device;
+    }
+}
+
+/**
+ * A container for storing the used areas of a pair of staging and gpu buffers.
+ *
+ * @ignore
+ */
+class UsedBuffer {
+    /** @type {DynamicBuffer} */
+    gpuBuffer;
+
+    /** @type {DynamicBuffer} */
+    stagingBuffer;
+
+    /**
+     * The beginning position of the used area that needs to be copied from staging to to the GPU
+     * buffer.
+     *
+     * @type {number}
+     */
+    offset;
+
+    /**
+     * Used byte size of the buffer, from the offset.
+     *
+     * @type {number}
+     */
+    size;
+}
+
+/**
+ * A container for storing the return values of an allocation function.
+ *
+ * @ignore
+ */
+class DynamicBufferAllocation {
+    /**
+     * The storage access to the allocated data in the staging buffer.
+     *
+     * @type {Int32Array}
+     */
+    storage;
+
+    /**
+     * The gpu buffer this allocation will be copied to.
+     *
+     * @type {DynamicBuffer}
+     */
+    gpuBuffer;
+
+    /**
+     * Offset in the gpuBuffer where the data will be copied to.
+     *
+     * @type {number}
+     */
+    offset;
+}
+
+/**
+ * The DynamicBuffers class provides a dynamic memory allocation system for uniform buffer data,
+ * particularly for non-persistent uniform buffers. This class utilizes a bump allocator to
+ * efficiently allocate aligned memory space from a set of large buffers managed internally. To
+ * utilize this system, the user writes data to CPU-accessible staging buffers. When submitting
+ * command buffers that require these buffers, the system automatically uploads the data to the GPU
+ * buffers. This approach ensures efficient memory management and smooth data transfer between the
+ * CPU and GPU.
+ *
+ * @ignore
+ */
+class DynamicBuffers {
+    /**
+     * Allocation size of the underlying buffers.
+     *
+     * @type {number}
+     */
+    bufferSize;
+
+    /**
+     * Internally allocated gpu buffers.
+     *
+     * @type {DynamicBuffer[]}
+     */
+    gpuBuffers = [];
+
+    /**
+     * Internally allocated staging buffers (CPU writable)
+     *
+     * @type {DynamicBuffer[]}
+     */
+    stagingBuffers = [];
+
+    /**
+     * @type {UsedBuffer[]}
+     */
+    usedBuffers = [];
+
+    /**
+     * @type {UsedBuffer}
+     */
+    activeBuffer = null;
+
+    /**
+     * Create the system of dynamic buffers.
+     *
+     * @param {import('./graphics-device.js').GraphicsDevice} device - The graphics device.
+     * @param {*} bufferSize - The size of the underlying large buffers.
+     * @param {*} bufferAlignment - Alignment of each allocation.
+     */
+    constructor(device, bufferSize, bufferAlignment) {
+        this.device = device;
+        this.bufferSize = bufferSize;
+        this.bufferAlignment = bufferAlignment;
+    }
+
+    /**
+     * Destroy the system of dynamic buffers.
+     */
+    destroy() {
+
+        this.gpuBuffers.forEach((gpuBuffer) => {
+            gpuBuffer.destroy(this.device);
+        });
+        this.gpuBuffers = null;
+
+        this.stagingBuffers.forEach((stagingBuffer) => {
+            stagingBuffer.destroy(this.device);
+        });
+        this.stagingBuffers = null;
+
+        this.usedBuffers = null;
+        this.activeBuffer = null;
+    }
+
+    /**
+     * Allocate an aligned space of the given size from a dynamic buffer.
+     *
+     * @param {DynamicBufferAllocation} allocation - The allocation info to fill.
+     * @param {number} size - The size of the allocation.
+     */
+    alloc(allocation, size) {
+
+        // if we have active buffer without enough space
+        if (this.activeBuffer) {
+            const alignedStart = math.roundUp(this.activeBuffer.size, this.bufferAlignment);
+            const space = this.bufferSize - alignedStart;
+            if (space < size) {
+
+                // we're done with this buffer, schedule it for submit
+                this.scheduleSubmit();
+            }
+        }
+
+        // if we don't have an active buffer, allocate new one
+        if (!this.activeBuffer) {
+
+            // gpu buffer
+            let gpuBuffer = this.gpuBuffers.pop();
+            if (!gpuBuffer) {
+                gpuBuffer = this.createBuffer(this.device, this.bufferSize, false);
+            }
+
+            // staging buffer
+            let stagingBuffer = this.stagingBuffers.pop();
+            if (!stagingBuffer) {
+                stagingBuffer = this.createBuffer(this.device, this.bufferSize, true);
+            }
+
+            this.activeBuffer = new UsedBuffer();
+            this.activeBuffer.stagingBuffer = stagingBuffer;
+            this.activeBuffer.gpuBuffer = gpuBuffer;
+            this.activeBuffer.offset = 0;
+            this.activeBuffer.size = 0;
+        }
+
+        // allocate from active buffer
+        const activeBuffer = this.activeBuffer;
+        const alignedStart = math.roundUp(activeBuffer.size, this.bufferAlignment);
+        Debug.assert(alignedStart + size <= this.bufferSize, `The allocation size of ${size} is larger than the buffer size of ${this.bufferSize}`);
+
+        allocation.gpuBuffer = activeBuffer.gpuBuffer;
+        allocation.offset = alignedStart;
+        allocation.storage = activeBuffer.stagingBuffer.alloc(alignedStart, size);
+
+        // take the allocation from the buffer
+        activeBuffer.size = alignedStart + size;
+    }
+
+    scheduleSubmit() {
+
+        if (this.activeBuffer) {
+            this.usedBuffers.push(this.activeBuffer);
+            this.activeBuffer = null;
+        }
+    }
+
+    submit() {
+
+        // schedule currently active buffer for submit
+        this.scheduleSubmit();
+    }
+}
+
+export { DynamicBuffer, DynamicBuffers, DynamicBufferAllocation };

--- a/src/platform/graphics/graphics-device.js
+++ b/src/platform/graphics/graphics-device.js
@@ -244,6 +244,14 @@ class GraphicsDevice extends EventHandler {
      */
     stencilBack = new StencilParameters();
 
+    /**
+     * The dynamic buffer manager.
+     *
+     * @type {import('./dynamic-buffers.js').DynamicBuffers}
+     * @ignore
+     */
+    dynamicBuffers;
+
     defaultClearOptions = {
         color: [0, 0, 0, 1],
         depth: 1,
@@ -355,6 +363,9 @@ class GraphicsDevice extends EventHandler {
 
         this.quadVertexBuffer?.destroy();
         this.quadVertexBuffer = null;
+
+        this.dynamicBuffers?.destroy();
+        this.dynamicBuffers = null;
     }
 
     onDestroyShader(shader) {

--- a/src/platform/graphics/texture.js
+++ b/src/platform/graphics/texture.js
@@ -47,6 +47,13 @@ class Texture {
     /** @protected */
     _lockedLevel = -1;
 
+    /**
+     * A render version used to track the last time the texture properties requiring bind group
+     * to be updated were changed.
+     *
+     * @type {number}
+     * @ignore
+     */
     renderVersionDirty = 0;
 
     /**

--- a/src/platform/graphics/webgpu/webgpu-bind-group-format.js
+++ b/src/platform/graphics/webgpu/webgpu-bind-group-format.js
@@ -100,7 +100,8 @@ class WebgpuBindGroupFormat {
                     type: 'uniform', // "uniform", "storage", "read-only-storage"
 
                     // whether this binding requires a dynamic offset
-                    hasDynamicOffset: false
+                    // currently all UBs are dynamic and need the offset
+                    hasDynamicOffset: true
 
                     // defaults to 0 meaning no validation, can do early size validation using it
                     // minBindingSize

--- a/src/platform/graphics/webgpu/webgpu-bind-group.js
+++ b/src/platform/graphics/webgpu/webgpu-bind-group.js
@@ -61,7 +61,7 @@ class WebgpuBindGroup {
         // uniform buffers
         let index = 0;
         bindGroup.uniformBuffers.forEach((ub) => {
-            const buffer = ub.impl.buffer;
+            const buffer = ub.persistent ? ub.impl.buffer : ub.allocation.gpuBuffer.buffer;
             Debug.assert(buffer, 'NULL uniform buffer cannot be used by the bind group');
             Debug.call(() => {
                 this.debugFormat += `${index}: UB\n`;
@@ -70,7 +70,9 @@ class WebgpuBindGroup {
             entries.push({
                 binding: index++,
                 resource: {
-                    buffer: buffer
+                    buffer: buffer,
+                    offset: 0,
+                    size: ub.format.byteSize
                 }
             });
         });

--- a/src/platform/graphics/webgpu/webgpu-clear-renderer.js
+++ b/src/platform/graphics/webgpu/webgpu-clear-renderer.js
@@ -75,7 +75,7 @@ class WebgpuClearRenderer {
         this.uniformBuffer = new UniformBuffer(device, new UniformBufferFormat(device, [
             new UniformFormat('color', UNIFORMTYPE_VEC4),
             new UniformFormat('depth', UNIFORMTYPE_FLOAT)
-        ]));
+        ]), false);
 
         // format of the bind group
         const bindGroupFormat = new BindGroupFormat(device, [
@@ -129,7 +129,7 @@ class WebgpuClearRenderer {
 
             device.setCullMode(CULLFACE_NONE);
 
-            // render 4 verticies without vertex buffer
+            // render 4 vertices without vertex buffer
             device.setShader(this.shader);
 
             const bindGroup = this.bindGroup;

--- a/src/platform/graphics/webgpu/webgpu-dynamic-buffer.js
+++ b/src/platform/graphics/webgpu/webgpu-dynamic-buffer.js
@@ -1,0 +1,61 @@
+import { DebugHelper } from "../../../core/debug.js";
+import { DynamicBuffer } from "../dynamic-buffers.js";
+
+/**
+ * @ignore
+ */
+class WebgpuDynamicBuffer extends DynamicBuffer {
+    /**
+     * @type {GPUBuffer}
+     * @private
+     */
+    buffer = null;
+
+    /**
+     * CPU access over the whole buffer.
+     *
+     * @type {ArrayBuffer}
+     */
+    mappedRange = null;
+
+    constructor(device, size, isStaging) {
+        super(device);
+
+        this.buffer = device.wgpu.createBuffer({
+            size: size,
+            usage: isStaging ? GPUBufferUsage.MAP_WRITE | GPUBufferUsage.COPY_SRC : GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+            mappedAtCreation: isStaging
+        });
+
+        if (isStaging) {
+            this.onAvailable();
+        }
+
+        // staging buffers are not stored in vram, but add them for tracking purposes anyways
+        device._vram.ub += size;
+
+        DebugHelper.setLabel(this.buffer, `DynamicBuffer-${isStaging ? 'Staging' : 'Gpu'}`);
+    }
+
+    destroy(device) {
+
+        device._vram.ub -= this.buffer.size;
+
+        this.buffer.destroy();
+        this.buffer = null;
+    }
+
+    /**
+     * Called when the staging buffer is mapped for writing.
+     */
+    onAvailable() {
+        // map the whole buffer
+        this.mappedRange = this.buffer.getMappedRange();
+    }
+
+    alloc(offset, size) {
+        return new Int32Array(this.mappedRange, offset, size / 4);
+    }
+}
+
+export { WebgpuDynamicBuffer };

--- a/src/platform/graphics/webgpu/webgpu-dynamic-buffers.js
+++ b/src/platform/graphics/webgpu/webgpu-dynamic-buffers.js
@@ -1,0 +1,93 @@
+import { DebugHelper } from "../../../core/debug.js";
+import { DebugGraphics } from "../debug-graphics.js";
+import { DynamicBuffers } from "../dynamic-buffers.js";
+import { WebgpuDynamicBuffer } from "./webgpu-dynamic-buffer.js";
+
+class WebgpuDynamicBuffers extends DynamicBuffers {
+    /**
+     * Staging buffers which are getting copied over to gpu buffers in the the command buffer waiting
+     * to be submitted. When those command buffers are submitted, we can mapAsync these staging
+     * buffers for reuse.
+     *
+     * @type {WebgpuDynamicBuffer[]}
+     */
+    pendingStagingBuffers = [];
+
+    createBuffer(device, size, isStaging) {
+        return new WebgpuDynamicBuffer(device, size, isStaging);
+    }
+
+    /**
+     * Submit all used buffers to the device.
+     */
+    submit() {
+
+        super.submit();
+
+        // submit all used buffers
+        const count = this.usedBuffers.length;
+        if (count) {
+
+            const device = this.device;
+            const gpuBuffers = this.gpuBuffers;
+
+            // new command encoder, as buffer copies need to be submitted before the currently recorded
+            // rendering encoder is submitted
+            const commandEncoder = device.wgpu.createCommandEncoder();
+            DebugHelper.setLabel(commandEncoder, 'DynamicBuffersSubmit');
+
+            DebugGraphics.pushGpuMarker(device, 'DynamicBuffersSubmit');
+
+            // run this loop backwards to preserve the order of buffers in gpuBuffers array
+            for (let i = count - 1; i >= 0; i--) {
+                const usedBuffer = this.usedBuffers[i];
+                const { stagingBuffer, gpuBuffer, offset, size } = usedBuffer;
+
+                // unmap staging buffer (we're done writing to it on CPU)
+                const src = stagingBuffer.buffer;
+                src.unmap();
+
+                // schedule data copy from staging to gpu buffer
+                commandEncoder.copyBufferToBuffer(src, offset, gpuBuffer.buffer, offset, size);
+
+                // gpu buffer can be reused immediately
+                gpuBuffers.push(gpuBuffer);
+            }
+
+            DebugGraphics.popGpuMarker(device);
+
+            // schedule the command buffer to run before all currently scheduled command buffers
+            const cb = commandEncoder.finish();
+            DebugHelper.setLabel(cb, 'DynamicBuffers');
+            device.addCommandBuffer(cb, true);
+
+            // keep the used staging buffers in the pending list
+            for (let i = 0; i < count; i++) {
+                const stagingBuffer = this.usedBuffers[i].stagingBuffer;
+                this.pendingStagingBuffers.push(stagingBuffer);
+            }
+            this.usedBuffers.length = 0;
+        }
+    }
+
+    /**
+     * Called when all scheduled command buffers are submitted to the device.
+     */
+    onCommandBuffersSubmitted() {
+        // map the staging buffers for write to alow them to be reused - this resolves when the CBs
+        // using them are done on the GPU
+        const count = this.pendingStagingBuffers.length;
+        if (count) {
+            for (let i = 0; i < count; i++) {
+                const stagingBuffer = this.pendingStagingBuffers[i];
+                stagingBuffer.buffer.mapAsync(GPUMapMode.WRITE).then(() => {
+                    stagingBuffer.onAvailable();
+                    this.stagingBuffers.push(stagingBuffer);
+                });
+            }
+            this.pendingStagingBuffers.length = 0;
+        }
+    }
+}
+
+export { WebgpuDynamicBuffers };

--- a/src/platform/graphics/webgpu/webgpu-texture.js
+++ b/src/platform/graphics/webgpu/webgpu-texture.js
@@ -408,10 +408,10 @@ class WebgpuTexture {
             depthOrArrayLayers: 1   // single layer
         };
 
-        // submit existing commands before copying to preserve order
+        // submit existing scheduled commands to the queue before copying to preserve the order
         device.submit();
 
-        Debug.trace(TRACEID_RENDER_QUEUE, `CopyImage2Tex: mip:${mipLevel} face:${face} ${this.texture.name}`);
+        Debug.trace(TRACEID_RENDER_QUEUE, `IMAGE-TO-TEX: mip:${mipLevel} face:${face} ${this.texture.name}`);
         device.wgpu.queue.copyExternalImageToTexture(src, dst, copySize);
     }
 
@@ -457,10 +457,10 @@ class WebgpuTexture {
             depthOrArrayLayers: 1
         };
 
-        // submit existing commands before copying to preserve order
+        // submit existing scheduled commands to the queue before copying to preserve the order
         device.submit();
 
-        Debug.trace(TRACEID_RENDER_QUEUE, `writeTex: mip:${mipLevel} face:${face} ${this.texture.name}`);
+        Debug.trace(TRACEID_RENDER_QUEUE, `WRITE-TEX: mip:${mipLevel} face:${face} ${this.texture.name}`);
         wgpu.queue.writeTexture(dest, data, dataLayout, size);
     }
 }

--- a/src/scene/graphics/quad-render-utils.js
+++ b/src/scene/graphics/quad-render-utils.js
@@ -75,10 +75,6 @@ function drawQuadWithShader(device, target, shader, rect, scissorRect) {
 
     renderPass.render();
 
-    // TODO: remove this submission, when UB allocates from per frame buffers. For now, we need to submit the command buffer,
-    // as we're destroying the UB buffer on the next line, and the command buffer needs to be submitted before that.
-    device.submit();
-
     quad.destroy();
 }
 

--- a/src/scene/graphics/quad-render.js
+++ b/src/scene/graphics/quad-render.js
@@ -62,7 +62,7 @@ class QuadRender {
             // uniform buffer
             const ubFormat = this.shader.meshUniformBufferFormat;
             if (ubFormat) {
-                this.uniformBuffer = new UniformBuffer(device, ubFormat);
+                this.uniformBuffer = new UniformBuffer(device, ubFormat, false);
             }
 
             // bind group
@@ -119,9 +119,7 @@ class QuadRender {
         if (device.supportsUniformBuffers) {
 
             const bindGroup = this.bindGroup;
-            if (bindGroup.defaultUniformBuffer) {
-                bindGroup.defaultUniformBuffer.update();
-            }
+            bindGroup.defaultUniformBuffer?.update();
             bindGroup.update();
             device.setBindGroup(BINDGROUP_MESH, bindGroup);
         }

--- a/src/scene/mesh-instance.js
+++ b/src/scene/mesh-instance.js
@@ -442,7 +442,7 @@ class MeshInstance {
             // mesh uniform buffer
             const ubFormat = shader.meshUniformBufferFormat;
             Debug.assert(ubFormat);
-            const uniformBuffer = new UniformBuffer(device, ubFormat);
+            const uniformBuffer = new UniformBuffer(device, ubFormat, false);
 
             // mesh bind group
             const bindGroupFormat = shader.meshBindGroupFormat;

--- a/src/scene/renderer/renderer.js
+++ b/src/scene/renderer/renderer.js
@@ -701,7 +701,7 @@ class Renderer {
         Debug.assert(viewCount === 1, "This code does not handle the viewCount yet");
 
         while (viewBindGroups.length < viewCount) {
-            const ub = new UniformBuffer(device, viewUniformFormat);
+            const ub = new UniformBuffer(device, viewUniformFormat, false);
             const bg = new BindGroup(device, viewBindGroupFormat, ub);
             DebugHelper.setName(bg, `ViewBindGroup_${bg.id}`);
             viewBindGroups.push(bg);


### PR DESCRIPTION
Before this PR, each UniformBuffer would allocate its internal GPUBuffer storage, and per frame copy the CPU storage content to it using writeBuffer. This required many writeBuffer calls, which is expensive on both CPU and GPU time.

This PR implement more performant implementation. Under the hood, a one or more large (1MB) gpu buffers are allocated, and a pool of staging buffers of the same size. Individual uniform buffers allocate storage using bump allocator from the staging buffers. Then, just before the command buffers are submitted, a command buffer is added to execute first, which copies the used staging buffers to the gpu buffers. 
Here's an example of used buffers for many example. Note that the number of staging buffers gets larger each time a command buffers are submitted, as they can no longer use already existing staging buffer.

![buffer-allocation](https://github.com/playcanvas/engine/assets/59932779/59b3bf0b-3347-436f-9097-502a57d1d69a)

This PR also cleans up some temporary solutions introduced in #5423 to limit the number of expensive submit commands per frame. Before, command buffer of each render pass would be submitted separately, while now those are batched to a very small number.

As an example, the shadow cascades example is using a single submit, first copying the staging buffers to gpu buffers, following by a single command buffer render all shadow cascade render passes, followed the the forward pass of the scene:

![shadow-cascades](https://github.com/playcanvas/engine/assets/59932779/8412bd25-b6e6-486c-a6ae-959c7ca5fbd3)

Multi view example similarly renders the whole scene using a single submit for all command buffers:

![multi-view](https://github.com/playcanvas/engine/assets/59932779/e26fa414-e43f-4488-b199-d0e89c90a3df)

If there are texture uploads done in a frame (typically a very small number of places), for example in this case the bone texture used by the skinning, and clustered lights updated on CPU, we end up with two submits:

![texture-uploads](https://github.com/playcanvas/engine/assets/59932779/acc45c81-d710-4f21-b420-eb5a10ed4be5)

All rendering submitted from the update functions of the script are submitted separately for now (could be a single submit as well), for example reflection-cubemap example which renders the scene using a single submit, and does multiple texture reprojections using draQuadWithShader within the scripts:

![reflectio-cubemap](https://github.com/playcanvas/engine/assets/59932779/0e2aa8af-4684-4e58-bb1d-38ee0196bce2)

## Performance

CPU frame time for the hierarchy example with 5000 or so meshes:
- WebGPU before: 57ms
- WebGPU now: 48ms (15% improvement)
- for comparison, WebGL time: 14ms

GPU times (these are based on the GPU duration reported by Chrome Profiler only, not sure about their reliability / what else they capture). I do not think this is reliable at all.
- WebGPU before: 12.8ms
- WebGPU now: 11.8ms
- WebGL time: hard to estimate in browser, too many displayed bars.