### PR TITLE
[Examples Browser] Thumbnail generation fix

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -120,7 +120,6 @@ example(canvas: HTMLCanvasElement, assets: {}, data: any) {
 Ensure you have a locally built version of the examples browser by running the commands in the `Local examples browser development` section. Then run `npm run serve` to serve the examples browser.
 
 You can view the full collection of example iframes by visiting [http://localhost:5000/iframe/]() in your browser.
-```
 
 ### Debug and performance engine development
 By default, the examples app uses the local version of the playcanvas engine located at `../build/playcanvas.js`. If you'd like to test the examples browser with the debug or performance versions of the engine instead, you can run `npm run watch:debug` or `npm run watch:profiler` commands.
@@ -144,6 +143,10 @@ npm run serve
 3) **Generate thumbnails** by first ensuring the examples browser is running on [http://localhost:5000]() then running the following command. This step will create the thumbnails directory for the browser and may take a while depending on the number of new examples or if this is first time it has been run locally.
 ```
 npm run build:thumbnails
+```
+If you are serving the examples browser from a different port, you can specify the port using the `PORT` environment variable:
+```
+PORT=5001 npm run build:thumbnails
 ```
 
 4) Copy the contents of the `./dist` directory to the root of the [playcanvas.github.io](https://github.com/playcanvas/playcanvas.github.io) repository. Be sure not to wipe the contents of the `pcui` subdirectory in that repository.

--- a/examples/scripts/thumbnails.mjs
+++ b/examples/scripts/thumbnails.mjs
@@ -24,42 +24,42 @@ categories.forEach(function (category) {
     });
 });
 
+if (!fs.existsSync(`${MAIN_DIR}/dist/thumbnails`)) {
+    fs.mkdirSync(`${MAIN_DIR}/dist/thumbnails`);
+}
+
+function kebabCaseToPascalCase(str) {
+    return str.split('-').map(s => s.charAt(0).toUpperCase() + s.substring(1)).join('');
+}
+
 async function takeScreenshots() {
     for (let i = 0; i < exampleList.length; i++) {
-        const example = exampleList[i].example;
-        const category = exampleList[i].category;
-        if (fs.existsSync(`${MAIN_DIR}/dist/thumbnails/${category}_${example}_large.png`)) {
+        const exampleListItem = exampleList[i];
+        const exampleSlug = exampleListItem.example;
+        const categorySlug = exampleListItem.category;
+        const example = kebabCaseToPascalCase(exampleListItem.example);
+        const category = kebabCaseToPascalCase(exampleListItem.category);
+        if (fs.existsSync(`${MAIN_DIR}/dist/thumbnails/${categorySlug}_${exampleSlug}_large.png`)) {
             console.log(`skipped: ${category}/${example}`);
             continue;
         }
+        const port = process.env.PORT || 5000;
         const browser = await puppeteer.launch();
         const page = await browser.newPage();
-        await page.goto(`http://localhost:5000/iframe/${category}/${example}?miniStats=false`);
+        await page.goto(`http://localhost:${port}/iframe/?category=${category}&example=${example}&miniStats=false`);
 
-        const promise = new Promise((resolve) => {
-            setTimeout(async () => {
+        await page.waitForFunction("pc.app?._time > 1000");
 
-                if (!fs.existsSync(`${MAIN_DIR}/dist/thumbnails`)) {
-                    fs.mkdirSync(`${MAIN_DIR}/dist/thumbnails`);
-                }
-                if (!fs.existsSync(`${MAIN_DIR}/dist/temp`)) {
-                    fs.mkdirSync(`${MAIN_DIR}/dist/temp`);
-                }
-
-                await page.screenshot({ path: `${MAIN_DIR}/dist/temp/${category}_${example}.png` });
-                await sharp(`${MAIN_DIR}/dist/temp/${category}_${example}.png`)
-                    .resize(320, 240)
-                    .toFile(`${MAIN_DIR}/dist/thumbnails/${category}_${example}_large.png`);
-                await sharp(`${MAIN_DIR}/dist/temp/${category}_${example}.png`)
-                    .resize(64, 48)
-                    .toFile(`${MAIN_DIR}/dist/thumbnails/${category}_${example}_small.png`);
-                console.log(`screenshot taken for: ${category}/${example}`);
-                await browser.close();
-                resolve();
-                fs.rmdirSync(`${MAIN_DIR}/dist/temp`, { recursive: true });
-            }, 5000);
-        });
-        await promise;
+        await page.screenshot({ path: `${MAIN_DIR}/dist/thumbnails/${categorySlug}_${exampleSlug}.png` });
+        await sharp(`${MAIN_DIR}/dist/thumbnails/${categorySlug}_${exampleSlug}.png`)
+            .resize(320, 240)
+            .toFile(`${MAIN_DIR}/dist/thumbnails/${categorySlug}_${exampleSlug}_large.png`);
+        await sharp(`${MAIN_DIR}/dist/thumbnails/${categorySlug}_${exampleSlug}.png`)
+            .resize(64, 48)
+            .toFile(`${MAIN_DIR}/dist/thumbnails/${categorySlug}_${exampleSlug}_small.png`);
+        fs.rmSync(`${MAIN_DIR}/dist/thumbnails/${categorySlug}_${exampleSlug}.png`);
+        console.log(`screenshot taken for: ${category}/${example}`);
+        await browser.close();
     }
 }
 

--- a/examples/src/iframe/index.html
+++ b/examples/src/iframe/index.html
@@ -73,7 +73,6 @@
                 categoryHeader.innerText = category;
                 examplesContainer.append(categoryHeader);
                 Object.keys(examples[category]).forEach(function(example) {
-                    console.log(example);
                     const exampleLink = document.createElement('a');
                     exampleLink.href = `?category=${category}&example=${example.replace('Example', '')}`;
                     exampleLink.innerText = example.replace('Example', '');

--- a/examples/src/iframe/index.html
+++ b/examples/src/iframe/index.html
@@ -48,8 +48,23 @@
         var event = new CustomEvent("exampleLoading");
         window.top.dispatchEvent(event);
 
+        const exampleMap = {};
+        function retrieveExample(category, example) {
+                const categoryMap = examples[Object.keys(examples).find(key => key.toLowerCase() === category.toLowerCase())];
+                if (!categoryMap) {
+                    console.error(`Category ${category} not found.`);
+                    return;
+                }
+                const exampleClass = categoryMap[Object.keys(categoryMap).find(key => key.toLowerCase() === `${example}Example`.toLowerCase())];
+                if (!exampleClass) {
+                    console.error(`Example ${example} not found.`);
+                    return;
+                }
+            return exampleClass;
+        }
+
         if (urlParams.get('category') && urlParams.get('example')) {
-            window.Example = examples[urlParams.get('category')][`${urlParams.get('example')}Example`];
+            window.Example = retrieveExample(urlParams.get('category'), urlParams.get('example'));
         } else {
             console.warn('No example specified, displaying a list of all examples instead.')
             const examplesContainer = document.createElement('div');
@@ -58,6 +73,7 @@
                 categoryHeader.innerText = category;
                 examplesContainer.append(categoryHeader);
                 Object.keys(examples[category]).forEach(function(example) {
+                    console.log(example);
                     const exampleLink = document.createElement('a');
                     exampleLink.href = `?category=${category}&example=${example.replace('Example', '')}`;
                     exampleLink.innerText = example.replace('Example', '');


### PR DESCRIPTION
Fixes the build script for the examples browser thumbnails. Also allows users to specify the port that their local examples browser instance is running on.

Includes an update to the examples browser readme.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
