### PR TITLE
Morph: fix options handling and targets validation

### DIFF
--- a/src/scene/morph.js
+++ b/src/scene/morph.js
@@ -29,19 +29,19 @@ class Morph extends RefCountedObject {
      * @param {import('./morph-target.js').MorphTarget[]} targets - A list of morph targets.
      * @param {import('../platform/graphics/graphics-device.js').GraphicsDevice} graphicsDevice -
      * The graphics device used to manage this morph target.
-     * @param {object} options - Object for passing optional arguments.
-     * @param {boolean} options.preferHighPrecision - True if high precision storage should be
+     * @param {object} [options] - Object for passing optional arguments.
+     * @param {boolean} [options.preferHighPrecision] - True if high precision storage should be
      * prefered. This is faster to create and allows higher precision, but takes more memory and
      * might be slower to render. Defaults to false.
      */
-    constructor(targets, graphicsDevice, { preferHighPrecision = false }) {
+    constructor(targets, graphicsDevice, { preferHighPrecision = false } = {}) {
         super();
 
         Debug.assertDeprecated(graphicsDevice, "Morph constructor takes a GraphicsDevice as a parameter, and it was not provided.");
         this.device = graphicsDevice || GraphicsDeviceAccess.get();
 
         this.preferHighPrecision = preferHighPrecision;
-debugger;
+
         // validation
         Debug.assert(targets.every(target => !target.used), 'A specified target has already been used to create a Morph, use its clone instead.');
         this._targets = targets.slice();

--- a/src/scene/morph.js
+++ b/src/scene/morph.js
@@ -13,10 +13,6 @@ import {
 } from '../platform/graphics/constants.js';
 import { GraphicsDeviceAccess } from '../platform/graphics/graphics-device-access.js';
 
-const defaultOptions = {
-    preferHighPrecision: false
-};
-
 /**
  * Contains a list of {@link MorphTarget}, a combined delta AABB and some associated data.
  */
@@ -38,16 +34,16 @@ class Morph extends RefCountedObject {
      * prefered. This is faster to create and allows higher precision, but takes more memory and
      * might be slower to render. Defaults to false.
      */
-    constructor(targets, graphicsDevice, options = defaultOptions) {
+    constructor(targets, graphicsDevice, { preferHighPrecision = false }) {
         super();
 
         Debug.assertDeprecated(graphicsDevice, "Morph constructor takes a GraphicsDevice as a parameter, and it was not provided.");
         this.device = graphicsDevice || GraphicsDeviceAccess.get();
 
-        this.preferHighPrecision = options.preferHighPrecision;
-
+        this.preferHighPrecision = preferHighPrecision;
+debugger;
         // validation
-        targets.forEach(target => Debug.assert(!target.used, 'The target specified has already been used to create a Morph, use its clone instead.'));
+        Debug.assert(targets.every(target => !target.used), 'A specified target has already been used to create a Morph, use its clone instead.');
         this._targets = targets.slice();
 
         // default to texture based morphing if available


### PR DESCRIPTION
This PR is fixing two issues:

1) `Morph#preferHighPrecision` being `undefined`, because:

https://github.com/playcanvas/engine/blob/1855a582409e35480fe48bc5d3a473597ae149dd/src/framework/parsers/glb-parser.js#L888-L890

Because `assetOptions.morphPreferHighPrecision` is `undefined`.

The intention of the code is clear, but the objects aren't merged as probably intended here. Once an object is given, it will be used as-is no matter what, without any kind of internal merging. So we end up with `undefined` instead of `boolean` (which will make all `=== true/false` fail all the time).

2) Not enough AST shaking to remove the `Debug.assert` from `build/playcanvas.js`:

![image](https://github.com/playcanvas/engine/assets/5236548/f9dd3c60-ad8c-4df3-979f-70fc18f3f09e)


I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
