### PR TITLE
[Fix] Do not dispatch local lights when clustered lighting is enabled

### DIFF
--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -606,6 +606,7 @@ class ForwardRenderer extends Renderer {
         const scene = this.scene;
         const passFlag = 1 << pass;
         const flipFactor = flipFaces ? -1 : 1;
+        const clusteredLightingEnabled = this.scene.clusteredLightingEnabled;
 
         // Render the scene
         let skipMaterial = false;
@@ -647,7 +648,10 @@ class ForwardRenderer extends Renderer {
 
                     if (lightMaskChanged) {
                         const usedDirLights = this.dispatchDirectLights(sortedLights[LIGHTTYPE_DIRECTIONAL], scene, lightMask, camera);
-                        this.dispatchLocalLights(sortedLights, scene, lightMask, usedDirLights, drawCall._staticLightList);
+
+                        if (!clusteredLightingEnabled) {
+                            this.dispatchLocalLights(sortedLights, scene, lightMask, usedDirLights, drawCall._staticLightList);
+                        }
                     }
 
                     this.alphaTestId.setValue(material.alphaTest);


### PR DESCRIPTION
As local lights (uniforms) are not used when clustered lighting is enabled, lights are supplied inside the textures.

This fixes a crash, when clustered lighting is enabled, and an omni or spot light with shadows enabled is invisible in the frustum. Its shadow map does not exist in this case, and we get crash like this:

<img width="532" alt="Screenshot 2023-06-28 at 14 36 47" src="https://github.com/playcanvas/engine/assets/59932779/54fb240f-217c-4d65-a908-617978b30160">
