### PR TITLE
Custom material type

### DIFF
--- a/examples/src/examples/graphics/custom-material.tsx
+++ b/examples/src/examples/graphics/custom-material.tsx
@@ -91,7 +91,7 @@ class CustomMaterialExample {
                 const light = new pc.Entity();
                 light.addComponent("light", {
                     type: "omni",
-                    color: new pc.Color(1, 1, 1),
+                    color: pc.Color.WHITE,
                     intensity: 1,
                     range: 100
                 });

--- a/examples/src/examples/graphics/custom-material.tsx
+++ b/examples/src/examples/graphics/custom-material.tsx
@@ -1,0 +1,147 @@
+import React from 'react';
+
+import * as pc from '../../../../';
+import { Panel, Button } from '@playcanvas/pcui/react';
+import { Observer } from '@playcanvas/observer';
+
+class CustomMaterialExample {
+    static CATEGORY = 'Graphics';
+    static NAME = 'Custom Material';
+
+    controls(data: Observer) {
+        return <></>;
+    }
+
+    example(canvas: HTMLCanvasElement, deviceType: string, data: any): void {
+
+        const assets = {
+            orbitCamera: new pc.Asset('script', 'script', { url: '/static/scripts/camera/orbit-camera.js' }),
+            helipad: new pc.Asset('helipad-env-atlas', 'texture', { url: '/static/assets/cubemaps/helipad-env-atlas.png' }, { type: pc.TEXTURETYPE_RGBP }),
+            font: new pc.Asset('font', 'font', { url: '/static/assets/fonts/arial.json' }),
+            checkerboard: new pc.Asset('checkerboard', 'texture', { url: '/static/assets/textures/checkboard.png' })
+        };
+
+        pc.createGraphicsDevice(canvas).then((device: pc.GraphicsDevice) => {
+
+            const createOptions = new pc.AppOptions();
+            createOptions.graphicsDevice = device;
+            createOptions.mouse = new pc.Mouse(document.body);
+            createOptions.touch = new pc.TouchDevice(document.body);
+            createOptions.keyboard = new pc.Keyboard(document.body);
+
+            createOptions.componentSystems = [
+                // @ts-ignore
+                pc.RenderComponentSystem,
+                // @ts-ignore
+                pc.CameraComponentSystem,
+                // @ts-ignore
+                pc.LightComponentSystem,
+                // @ts-ignore
+                pc.ScriptComponentSystem,
+                // @ts-ignore
+                pc.ElementComponentSystem
+            ];
+            createOptions.resourceHandlers = [
+                // @ts-ignore
+                pc.TextureHandler,
+                // @ts-ignore
+                pc.ContainerHandler,
+                // @ts-ignore
+                pc.ScriptHandler,
+                // @ts-ignore
+                pc.JsonHandler,
+                // @ts-ignore
+                pc.FontHandler
+            ];
+
+            const app = new pc.AppBase(canvas);
+            app.init(createOptions);
+
+            // Set the canvas to fill the window and automatically change resolution to be the same as the canvas size
+            app.setCanvasFillMode(pc.FILLMODE_FILL_WINDOW);
+            app.setCanvasResolution(pc.RESOLUTION_AUTO);
+
+            const assetListLoader = new pc.AssetListLoader(Object.values(assets), app.assets);
+            assetListLoader.load(() => {
+                app.start();
+
+                app.scene.envAtlas = assets.helipad.resource;
+                app.scene.clusteredLightingEnabled = false;
+
+                // Create an Entity with a camera component
+                const camera = new pc.Entity();
+                camera.addComponent("camera", {
+                    clearColor: new pc.Color(0.4, 0.45, 0.5)
+                });
+                camera.addComponent("script");
+                camera.script.create("orbitCamera", {
+                    attributes: {
+                        inertiaFactor: 0.2,
+                        distanceMin: 8,
+                        distanceMax: 50
+                    }
+                });
+                camera.script.create("orbitCameraInputMouse");
+                camera.script.create("orbitCameraInputTouch");
+                camera.translate(0, 1, 4);
+                camera.lookAt(0, 0, 0);
+                app.root.addChild(camera);
+
+                // Create an Entity with a omni light component and a sphere model component.
+                const light = new pc.Entity();
+                light.addComponent("light", {
+                    type: "omni",
+                    color: new pc.Color(1, 1, 1),
+                    intensity: 1,
+                    range: 100
+                });
+                light.translate(0, 3, 0);
+                app.root.addChild(light);
+
+                const material = new pc.CustomMaterial();
+                material.setParameter("texture_envAtlas", assets.helipad.resource);
+                material.setParameter("material_reflectivity", 1.0);
+                const options = new pc.LitOptions();
+                options.shadingModel = pc.SPECULAR_BLINN;
+                options.useSpecular = true;
+                options.useMetalness = true;
+                options.occludeSpecular = 1;
+                options.reflectionSource = 'envAtlas';
+                options.reflectionEncoding = assets.helipad.resource.encoding;
+                options.ambientSource = 'envAtlas';
+                options.ambientEncoding = assets.helipad.resource.encoding;
+                options.clusteredLightingEnabled = app.scene.clusteredLightingEnabled;
+                material.options = options;
+
+                const customLitArguments = `
+                LitShaderArguments evaluateFrontend() {
+                    LitShaderArguments args;
+                    args.emission = vec3(0, 0, 0);
+                    args.albedo = dVertexNormalW;
+                    args.metalness = 0.5;
+                    args.specularity = vec3(1,1,1);
+                    args.specularityFactor = 1.0;
+                    args.gloss = 0.5;
+                    args.worldNormal = dVertexNormalW;
+                    args.ao = 0.0;
+                    args.opacity = 1.0;
+                    return args;
+                }`;
+                material.customLitArguments = customLitArguments;
+                material.update();
+
+                // create primitive
+                const primitive = new pc.Entity();
+                primitive.addComponent('render', {
+                    type: "sphere",
+                    material: material
+                });
+
+                // set position and scale and add it to scene
+                app.root.addChild(primitive);
+            });
+        });
+    }
+}
+
+export default CustomMaterialExample;

--- a/examples/src/examples/graphics/custom-material.tsx
+++ b/examples/src/examples/graphics/custom-material.tsx
@@ -114,18 +114,16 @@ class CustomMaterialExample {
                 material.litOptions = options;
 
                 const argumentsChunk = `
-                LitShaderArguments evaluateFrontend() {
-                    LitShaderArguments args;
-                    args.emission = vec3(0, 0, 0);
-                    args.albedo = dVertexNormalW;
-                    args.metalness = 0.5;
-                    args.specularity = vec3(1,1,1);
-                    args.specularityFactor = 1.0;
-                    args.gloss = 0.5;
-                    args.worldNormal = dVertexNormalW;
-                    args.ao = 0.0;
-                    args.opacity = 1.0;
-                    return args;
+                void evaluateFrontend() {
+                    litArgs_emission = vec3(0, 0, 0);
+                    litArgs_albedo = dVertexNormalW;
+                    litArgs_metalness = 0.5;
+                    litArgs_specularity = vec3(1,1,1);
+                    litArgs_specularityFactor = 1.0;
+                    litArgs_gloss = 0.5;
+                    litArgs_worldNormal = dVertexNormalW;
+                    litArgs_ao = 0.0;
+                    litArgs_opacity = 1.0;
                 }`;
                 material.argumentsChunk = argumentsChunk;
                 material.update();

--- a/examples/src/examples/graphics/custom-material.tsx
+++ b/examples/src/examples/graphics/custom-material.tsx
@@ -1,18 +1,16 @@
-import React from 'react';
-
 import * as pc from '../../../../';
-import { Panel, Button } from '@playcanvas/pcui/react';
-import { Observer } from '@playcanvas/observer';
-
 class CustomMaterialExample {
     static CATEGORY = 'Graphics';
     static NAME = 'Custom Material';
+    static WEBGPU_ENABLED = true;
 
-    controls(data: Observer) {
-        return <></>;
-    }
+    example(canvas: HTMLCanvasElement, deviceType: string): void {
 
-    example(canvas: HTMLCanvasElement, deviceType: string, data: any): void {
+        const gfxOptions = {
+            deviceTypes: [deviceType],
+            glslangUrl: '/static/lib/glslang/glslang.js',
+            twgslUrl: '/static/lib/twgsl/twgsl.js'
+        };
 
         const assets = {
             orbitCamera: new pc.Asset('script', 'script', { url: '/static/scripts/camera/orbit-camera.js' }),
@@ -21,7 +19,7 @@ class CustomMaterialExample {
             checkerboard: new pc.Asset('checkerboard', 'texture', { url: '/static/assets/textures/checkboard.png' })
         };
 
-        pc.createGraphicsDevice(canvas).then((device: pc.GraphicsDevice) => {
+        pc.createGraphicsDevice(canvas, gfxOptions).then((device: pc.GraphicsDevice) => {
 
             const createOptions = new pc.AppOptions();
             createOptions.graphicsDevice = device;
@@ -66,7 +64,6 @@ class CustomMaterialExample {
                 app.start();
 
                 app.scene.envAtlas = assets.helipad.resource;
-                app.scene.clusteredLightingEnabled = false;
 
                 // Create an Entity with a camera component
                 const camera = new pc.Entity();

--- a/examples/src/examples/graphics/custom-material.tsx
+++ b/examples/src/examples/graphics/custom-material.tsx
@@ -111,7 +111,7 @@ class CustomMaterialExample {
                 options.ambientSource = 'envAtlas';
                 options.ambientEncoding = assets.helipad.resource.encoding;
                 options.clusteredLightingEnabled = app.scene.clusteredLightingEnabled;
-                material.options = options;
+                material.litOptions = options;
 
                 const customLitArguments = `
                 LitShaderArguments evaluateFrontend() {

--- a/examples/src/examples/graphics/custom-material.tsx
+++ b/examples/src/examples/graphics/custom-material.tsx
@@ -113,7 +113,7 @@ class CustomMaterialExample {
                 options.clusteredLightingEnabled = app.scene.clusteredLightingEnabled;
                 material.litOptions = options;
 
-                const customLitArguments = `
+                const argumentsChunk = `
                 LitShaderArguments evaluateFrontend() {
                     LitShaderArguments args;
                     args.emission = vec3(0, 0, 0);
@@ -127,7 +127,7 @@ class CustomMaterialExample {
                     args.opacity = 1.0;
                     return args;
                 }`;
-                material.customLitArguments = customLitArguments;
+                material.argumentsChunk = argumentsChunk;
                 material.update();
 
                 // create primitive

--- a/examples/src/examples/graphics/custom-material.tsx
+++ b/examples/src/examples/graphics/custom-material.tsx
@@ -16,7 +16,9 @@ class CustomMaterialExample {
             orbitCamera: new pc.Asset('script', 'script', { url: '/static/scripts/camera/orbit-camera.js' }),
             helipad: new pc.Asset('helipad-env-atlas', 'texture', { url: '/static/assets/cubemaps/helipad-env-atlas.png' }, { type: pc.TEXTURETYPE_RGBP }),
             font: new pc.Asset('font', 'font', { url: '/static/assets/fonts/arial.json' }),
-            checkerboard: new pc.Asset('checkerboard', 'texture', { url: '/static/assets/textures/checkboard.png' })
+            color: new pc.Asset('color', 'texture', { url: '/static/assets/textures/seaside-rocks01-color.jpg' }),
+            normal: new pc.Asset('normal', 'texture', { url: '/static/assets/textures/seaside-rocks01-normal.jpg' }),
+            gloss: new pc.Asset('gloss', 'texture', { url: '/static/assets/textures/seaside-rocks01-gloss.jpg' })
         };
 
         pc.createGraphicsDevice(canvas, gfxOptions).then((device: pc.GraphicsDevice) => {
@@ -74,8 +76,8 @@ class CustomMaterialExample {
                 camera.script.create("orbitCamera", {
                     attributes: {
                         inertiaFactor: 0.2,
-                        distanceMin: 8,
-                        distanceMax: 50
+                        distanceMin: 2,
+                        distanceMax: 15
                     }
                 });
                 camera.script.create("orbitCameraInputMouse");
@@ -90,14 +92,18 @@ class CustomMaterialExample {
                     type: "omni",
                     color: pc.Color.WHITE,
                     intensity: 1,
-                    range: 100
+                    range: 10
                 });
-                light.translate(0, 3, 0);
+                light.translate(0, 1, 0);
                 app.root.addChild(light);
 
                 const material = new pc.CustomMaterial();
                 material.setParameter("texture_envAtlas", assets.helipad.resource);
                 material.setParameter("material_reflectivity", 1.0);
+                material.setParameter("material_normalMapIntensity", 1.0);
+                material.setParameter("texture_diffuseMap", assets.color.resource);
+                material.setParameter("texture_glossMap", assets.gloss.resource);
+                material.setParameter("texture_normalMap", assets.normal.resource);
                 const options = new pc.LitOptions();
                 options.shadingModel = pc.SPECULAR_BLINN;
                 options.useSpecular = true;
@@ -108,17 +114,25 @@ class CustomMaterialExample {
                 options.ambientSource = 'envAtlas';
                 options.ambientEncoding = assets.helipad.resource.encoding;
                 options.clusteredLightingEnabled = app.scene.clusteredLightingEnabled;
+                options.normalMapEnabled = true;
                 material.litOptions = options;
 
                 const argumentsChunk = `
+                uniform sampler2D texture_diffuseMap;
+                uniform sampler2D texture_glossMap;
+                uniform sampler2D texture_normalMap;
+                uniform float material_normalMapIntensity;
                 void evaluateFrontend() {
                     litArgs_emission = vec3(0, 0, 0);
-                    litArgs_albedo = dVertexNormalW;
                     litArgs_metalness = 0.5;
                     litArgs_specularity = vec3(1,1,1);
                     litArgs_specularityFactor = 1.0;
-                    litArgs_gloss = 0.5;
-                    litArgs_worldNormal = dVertexNormalW;
+                    litArgs_gloss = texture2D(texture_glossMap, vUv0).r;
+
+                    vec3 normalMap = texture2D(texture_normalMap, vUv0).xyz * 2.0 - 1.0;
+                    litArgs_worldNormal = normalize(dTBN * mix(vec3(0,0,1), normalMap, material_normalMapIntensity));
+                    litArgs_albedo = vec3(0.2) + texture2D(texture_diffuseMap, vUv0).xyz;
+
                     litArgs_ao = 0.0;
                     litArgs_opacity = 1.0;
                 }`;
@@ -134,6 +148,12 @@ class CustomMaterialExample {
 
                 // set position and scale and add it to scene
                 app.root.addChild(primitive);
+
+                let time = 0;
+                app.on("update", function (dt: number) {
+                    time += dt;
+                    material.setParameter("material_normalMapIntensity", (Math.sin(time) + 1.0) * 0.5);
+                });
             });
         });
     }

--- a/examples/src/examples/graphics/custom-material.tsx
+++ b/examples/src/examples/graphics/custom-material.tsx
@@ -142,7 +142,7 @@ class CustomMaterialExample {
                     litArgs_ao = 0.0;
                     litArgs_opacity = 1.0;
                 }`;
-                material.argumentsChunk = argumentsChunk;
+                material.shaderChunk = argumentsChunk;
                 material.update();
 
                 // create primitive

--- a/examples/src/examples/graphics/custom-material.tsx
+++ b/examples/src/examples/graphics/custom-material.tsx
@@ -115,6 +115,8 @@ class CustomMaterialExample {
                 options.ambientEncoding = assets.helipad.resource.encoding;
                 options.clusteredLightingEnabled = app.scene.clusteredLightingEnabled;
                 options.normalMapEnabled = true;
+                options.useSpecularColor = true;
+                options.useSpecularityFactor = true;
                 material.litOptions = options;
 
                 const argumentsChunk = `
@@ -122,16 +124,19 @@ class CustomMaterialExample {
                 uniform sampler2D texture_glossMap;
                 uniform sampler2D texture_normalMap;
                 uniform float material_normalMapIntensity;
+                uniform vec3 material_specularRgb;
                 void evaluateFrontend() {
                     litArgs_emission = vec3(0, 0, 0);
                     litArgs_metalness = 0.5;
-                    litArgs_specularity = vec3(1,1,1);
+                    litArgs_specularity = material_specularRgb;
                     litArgs_specularityFactor = 1.0;
                     litArgs_gloss = texture2D(texture_glossMap, vUv0).r;
 
+                    litArgs_ior = 0.1;
+
                     vec3 normalMap = texture2D(texture_normalMap, vUv0).xyz * 2.0 - 1.0;
                     litArgs_worldNormal = normalize(dTBN * mix(vec3(0,0,1), normalMap, material_normalMapIntensity));
-                    litArgs_albedo = vec3(0.2) + texture2D(texture_diffuseMap, vUv0).xyz;
+                    litArgs_albedo = vec3(0.5) + texture2D(texture_diffuseMap, vUv0).xyz;
 
                     litArgs_ao = 0.0;
                     litArgs_opacity = 1.0;
@@ -152,6 +157,7 @@ class CustomMaterialExample {
                 let time = 0;
                 app.on("update", function (dt: number) {
                     time += dt;
+                    material.setParameter("material_specularRgb", [(Math.sin(time) + 1.0) * 0.5, (Math.cos(time * 0.5) + 1.0) * 0.5, (Math.sin(time * 0.7) + 1.0) * 0.5]);
                     material.setParameter("material_normalMapIntensity", (Math.sin(time) + 1.0) * 0.5);
                 });
             });

--- a/examples/src/examples/graphics/custom-material.tsx
+++ b/examples/src/examples/graphics/custom-material.tsx
@@ -2,6 +2,7 @@ import * as pc from '../../../../';
 class CustomMaterialExample {
     static CATEGORY = 'Graphics';
     static NAME = 'Custom Material';
+    static HIDDEN = true;
     static WEBGPU_ENABLED = true;
 
     example(canvas: HTMLCanvasElement, deviceType: string): void {

--- a/examples/src/examples/graphics/index.mjs
+++ b/examples/src/examples/graphics/index.mjs
@@ -8,6 +8,7 @@ import ClusteredLightingExample from "./clustered-lighting";
 import ClusteredOmniShadowsExample from "./clustered-omni-shadows";
 import ClusteredSpotShadowsExample from "./clustered-spot-shadows";
 import ContactHardeningShadowsExample from "./contact-hardening-shadows";
+import CustomMaterialExample from "./custom-material";
 import GrabPassExample from "./grab-pass";
 import GroundFogExample from "./ground-fog";
 import HardwareInstancingExample from "./hardware-instancing";
@@ -68,6 +69,7 @@ export {
     ClusteredOmniShadowsExample,
     ClusteredSpotShadowsExample,
     ContactHardeningShadowsExample,
+    CustomMaterialExample,
     GrabPassExample,
     GroundFogExample,
     HardwareInstancingExample,

--- a/src/index.js
+++ b/src/index.js
@@ -108,6 +108,7 @@ export { BatchGroup } from './scene/batching/batch-group.js';
 export { SkinBatchInstance } from './scene/batching/skin-batch-instance.js';
 export { BatchManager } from './scene/batching/batch-manager.js';
 export { Camera } from './scene/camera.js';
+export { CustomMaterial } from './scene/materials/custom-material.js';
 export { WorldClusters } from './scene/lighting/world-clusters.js';
 export { ForwardRenderer } from './scene/renderer/forward-renderer.js';
 export { GraphNode } from './scene/graph-node.js';

--- a/src/scene/materials/custom-material.js
+++ b/src/scene/materials/custom-material.js
@@ -21,7 +21,7 @@ class CustomMaterial extends Material {
         super();
 
         this._litOptions = new LitOptions();
-        this._customLitArguments = "";
+        this._argumentsChunk = "";
     }
 
     set litOptions(value) {
@@ -32,12 +32,12 @@ class CustomMaterial extends Material {
         return this._litOptions;
     }
 
-    set customLitArguments(value) {
-        this._customLitArguments = value;
+    set argumentsChunk(value) {
+        this._argumentsChunk = value;
     }
 
-    get customLitArguments() {
-        return this._customLitArguments;
+    get argumentsChunk() {
+        return this._argumentsChunk;
     }
 
     getShaderVariant(device, scene, objDefs, staticLightList, pass, sortedLights, viewUniformFormat, viewBindGroupFormat, vertexFormat) {
@@ -63,7 +63,7 @@ class CustomMaterial extends Material {
         collectLights(LIGHTTYPE_SPOT, sortedLights[LIGHTTYPE_SPOT], lightsFiltered, mask, staticLightList);
 
         this._litOptions.lights = lightsFiltered;
-        options.customLitArguments = this._customLitArguments;
+        options.customLitArguments = this._argumentsChunk;
 
         const processingOptions = new ShaderProcessorOptions(viewUniformFormat, viewBindGroupFormat, vertexFormat);
 

--- a/src/scene/materials/custom-material.js
+++ b/src/scene/materials/custom-material.js
@@ -1,0 +1,79 @@
+import { ShaderProcessorOptions } from '../../platform/graphics/shader-processor-options.js';
+import { LIGHTTYPE_DIRECTIONAL, LIGHTTYPE_OMNI, LIGHTTYPE_SPOT, MASK_AFFECT_DYNAMIC, SHADERDEF_INSTANCING, SHADERDEF_MORPH_NORMAL, SHADERDEF_MORPH_POSITION, SHADERDEF_MORPH_TEXTURE_BASED, SHADERDEF_SCREENSPACE, SHADERDEF_SKIN } from "../constants";
+import { getProgramLibrary } from "../shader-lib/get-program-library";
+import { LitOptions } from "./lit-options";
+import { collectLights } from "./lit-material-common.js";
+import { Material } from './material.js';
+import { custom } from '../shader-lib/programs/custom.js';
+
+/**
+ * A custom material provides a custom front-end part of a lit material
+ *
+ * @augments Material
+ */
+
+
+class CustomMaterial extends Material {
+    /**
+     * Create a new custom material instance.
+     */
+    constructor() {
+        super();
+
+        this._options = new LitOptions();
+        this._customLitArguments = "";
+    }
+
+    set options(value) {
+        this._options = value;
+    }
+
+    get options() {
+        return this._options;
+    }
+
+    set customLitArguments(value) {
+        this._customLitArguments = value;
+    }
+
+    get customLitArguments() {
+        return this._customLitArguments;
+    }
+
+    getShaderVariant(device, scene, objDefs, staticLightList, pass, sortedLights, viewUniformFormat, viewBindGroupFormat, vertexFormat) {
+
+        const options = {
+            skin: objDefs && (objDefs & SHADERDEF_SKIN) !== 0,
+            screenSpace: objDefs && (objDefs & SHADERDEF_SCREENSPACE) !== 0,
+            useInstancing: objDefs && (objDefs & SHADERDEF_INSTANCING) !== 0,
+            useMorphPosition: objDefs && (objDefs & SHADERDEF_MORPH_POSITION) !== 0,
+            useMorphNormal: objDefs && (objDefs & SHADERDEF_MORPH_NORMAL) !== 0,
+            useMorphTextureBased: objDefs && (objDefs & SHADERDEF_MORPH_TEXTURE_BASED) !== 0,
+
+            pass: pass,
+            litOptions: this._options
+        };
+
+        const lightsFiltered = [];
+        const mask = objDefs ? (objDefs >> 16) : MASK_AFFECT_DYNAMIC;
+        this._options.lightMaskDynamic = !!(mask & MASK_AFFECT_DYNAMIC);
+
+        collectLights(LIGHTTYPE_DIRECTIONAL, sortedLights[LIGHTTYPE_DIRECTIONAL], lightsFiltered, mask);
+        collectLights(LIGHTTYPE_OMNI, sortedLights[LIGHTTYPE_OMNI], lightsFiltered, mask, staticLightList);
+        collectLights(LIGHTTYPE_SPOT, sortedLights[LIGHTTYPE_SPOT], lightsFiltered, mask, staticLightList);
+
+        this._options.lights = lightsFiltered;
+        options.customLitArguments = this._customLitArguments;
+
+        const processingOptions = new ShaderProcessorOptions(viewUniformFormat, viewBindGroupFormat, vertexFormat);
+
+        const library = getProgramLibrary(device);
+        library.register('custom', custom);
+        const shader = library.getProgram('custom', options, processingOptions);
+
+        this._dirtyShader = false;
+        return shader;
+    }
+}
+
+export { CustomMaterial };

--- a/src/scene/materials/custom-material.js
+++ b/src/scene/materials/custom-material.js
@@ -20,16 +20,16 @@ class CustomMaterial extends Material {
     constructor() {
         super();
 
-        this._options = new LitOptions();
+        this._litOptions = new LitOptions();
         this._customLitArguments = "";
     }
 
-    set options(value) {
-        this._options = value;
+    set litOptions(value) {
+        this._litOptions = value;
     }
 
-    get options() {
-        return this._options;
+    get litOptions() {
+        return this._litOptions;
     }
 
     set customLitArguments(value) {
@@ -51,18 +51,18 @@ class CustomMaterial extends Material {
             useMorphTextureBased: objDefs && (objDefs & SHADERDEF_MORPH_TEXTURE_BASED) !== 0,
 
             pass: pass,
-            litOptions: this._options
+            litOptions: this._litOptions
         };
 
         const lightsFiltered = [];
         const mask = objDefs ? (objDefs >> 16) : MASK_AFFECT_DYNAMIC;
-        this._options.lightMaskDynamic = !!(mask & MASK_AFFECT_DYNAMIC);
+        this._litOptions.lightMaskDynamic = !!(mask & MASK_AFFECT_DYNAMIC);
 
         collectLights(LIGHTTYPE_DIRECTIONAL, sortedLights[LIGHTTYPE_DIRECTIONAL], lightsFiltered, mask);
         collectLights(LIGHTTYPE_OMNI, sortedLights[LIGHTTYPE_OMNI], lightsFiltered, mask, staticLightList);
         collectLights(LIGHTTYPE_SPOT, sortedLights[LIGHTTYPE_SPOT], lightsFiltered, mask, staticLightList);
 
-        this._options.lights = lightsFiltered;
+        this._litOptions.lights = lightsFiltered;
         options.customLitArguments = this._customLitArguments;
 
         const processingOptions = new ShaderProcessorOptions(viewUniformFormat, viewBindGroupFormat, vertexFormat);

--- a/src/scene/materials/custom-material.js
+++ b/src/scene/materials/custom-material.js
@@ -12,17 +12,10 @@ import { custom } from '../shader-lib/programs/custom.js';
  * @augments Material
  */
 
-
 class CustomMaterial extends Material {
-    /**
-     * Create a new custom material instance.
-     */
-    constructor() {
-        super();
+    _litOptions = new LitOptions();
 
-        this._litOptions = new LitOptions();
-        this._argumentsChunk = "";
-    }
+    _argumentsChunk = "";
 
     set litOptions(value) {
         this._litOptions = value;

--- a/src/scene/materials/custom-material.js
+++ b/src/scene/materials/custom-material.js
@@ -8,6 +8,7 @@ import { custom } from '../shader-lib/programs/custom.js';
 
 /**
  * A custom material provides a custom front-end part of a lit material
+ *
  * @ignore
  * @augments Material
  */

--- a/src/scene/materials/custom-material.js
+++ b/src/scene/materials/custom-material.js
@@ -8,6 +8,7 @@ import { custom } from '../shader-lib/programs/custom.js';
 
 /**
  * A custom material provides a custom shader chunk for the arguments passed to the lit shader.
+ *
  * @ignore
  */
 

--- a/src/scene/materials/custom-material.js
+++ b/src/scene/materials/custom-material.js
@@ -15,7 +15,7 @@ import { custom } from '../shader-lib/programs/custom.js';
 class CustomMaterial extends Material {
     _litOptions = new LitOptions();
 
-    _argumentsChunk = "";
+    _shaderChunk = "";
 
     _usedUvs = [true];
 
@@ -42,8 +42,8 @@ class CustomMaterial extends Material {
      *
      * @param {string} value - The shader chunk.
      */
-    set argumentsChunk(value) {
-        this._argumentsChunk = value;
+    set shaderChunk(value) {
+        this._shaderChunk = value;
     }
 
     /**
@@ -51,8 +51,8 @@ class CustomMaterial extends Material {
      *
      * @type {string}
      */
-    get argumentsChunk() {
-        return this._argumentsChunk;
+    get shaderChunk() {
+        return this._shaderChunk;
     }
 
     /**
@@ -87,7 +87,7 @@ class CustomMaterial extends Material {
         collectLights(LIGHTTYPE_SPOT, sortedLights[LIGHTTYPE_SPOT], lightsFiltered, mask, staticLightList);
 
         this._litOptions.lights = lightsFiltered;
-        options.customLitArguments = this._argumentsChunk;
+        options.customLitArguments = this._shaderChunk;
         options.usedUvs = this._usedUvs;
 
         const processingOptions = new ShaderProcessorOptions(viewUniformFormat, viewBindGroupFormat, vertexFormat);

--- a/src/scene/materials/custom-material.js
+++ b/src/scene/materials/custom-material.js
@@ -7,10 +7,8 @@ import { Material } from './material.js';
 import { custom } from '../shader-lib/programs/custom.js';
 
 /**
- * A custom material provides a custom front-end part of a lit material
- *
+ * A custom material provides a custom shader chunk for the arguments passed to the lit shader.
  * @ignore
- * @augments Material
  */
 
 class CustomMaterial extends Material {

--- a/src/scene/materials/custom-material.js
+++ b/src/scene/materials/custom-material.js
@@ -8,7 +8,7 @@ import { custom } from '../shader-lib/programs/custom.js';
 
 /**
  * A custom material provides a custom front-end part of a lit material
- *
+ * @ignore
  * @augments Material
  */
 

--- a/src/scene/materials/custom-material.js
+++ b/src/scene/materials/custom-material.js
@@ -17,18 +17,38 @@ class CustomMaterial extends Material {
 
     _argumentsChunk = "";
 
+    /**
+     * Set the lit options used to generate the lighting code for the shader.
+     *
+     * @param {LitOptions} value - The lit options.
+     */
     set litOptions(value) {
         this._litOptions = value;
     }
 
+    /**
+     * Get the lit options.
+     *
+     * @type {LitOptions}
+     */
     get litOptions() {
         return this._litOptions;
     }
 
+    /**
+     * Set the shader chunk used to feed arguments to the lit shader.
+     *
+     * @param {string} value - The shader chunk.
+     */
     set argumentsChunk(value) {
         this._argumentsChunk = value;
     }
 
+    /**
+     * Get the shader chunk used to describe the arguments to the lit shader.
+     *
+     * @type {string}
+     */
     get argumentsChunk() {
         return this._argumentsChunk;
     }

--- a/src/scene/materials/custom-material.js
+++ b/src/scene/materials/custom-material.js
@@ -17,6 +17,8 @@ class CustomMaterial extends Material {
 
     _argumentsChunk = "";
 
+    _usedUvs = [true];
+
     /**
      * Set the lit options used to generate the lighting code for the shader.
      *
@@ -53,6 +55,15 @@ class CustomMaterial extends Material {
         return this._argumentsChunk;
     }
 
+    /**
+     * Enable a specific UV channel.
+     *
+     * @param {number} value - The UV channel.
+     */
+    setUsedUv(value) {
+        this._usedUvs[value] = true;
+    }
+
     getShaderVariant(device, scene, objDefs, staticLightList, pass, sortedLights, viewUniformFormat, viewBindGroupFormat, vertexFormat) {
 
         const options = {
@@ -77,6 +88,7 @@ class CustomMaterial extends Material {
 
         this._litOptions.lights = lightsFiltered;
         options.customLitArguments = this._argumentsChunk;
+        options.usedUvs = this._usedUvs;
 
         const processingOptions = new ShaderProcessorOptions(viewUniformFormat, viewBindGroupFormat, vertexFormat);
 

--- a/src/scene/materials/lit-material-common.js
+++ b/src/scene/materials/lit-material-common.js
@@ -1,0 +1,28 @@
+import { LIGHTTYPE_DIRECTIONAL } from "../constants";
+
+const collectLights = (lType, lights, lightsFiltered, mask, staticLightList) => {
+    for (let i = 0; i < lights.length; i++) {
+        const light = lights[i];
+        if (light.enabled) {
+            if (light.mask & mask) {
+                if (lType !== LIGHTTYPE_DIRECTIONAL) {
+                    if (light.isStatic) {
+                        continue;
+                    }
+                }
+                lightsFiltered.push(light);
+            }
+        }
+    }
+
+    if (staticLightList) {
+        for (let i = 0; i < staticLightList.length; i++) {
+            const light = staticLightList[i];
+            if (light._type === lType) {
+                lightsFiltered.push(light);
+            }
+        }
+    }
+};
+
+export { collectLights };

--- a/src/scene/materials/lit-material-common.js
+++ b/src/scene/materials/lit-material-common.js
@@ -1,4 +1,4 @@
-import { LIGHTTYPE_DIRECTIONAL } from "../constants";
+import { LIGHTTYPE_DIRECTIONAL } from "../constants.js";
 
 const collectLights = (lType, lights, lightsFiltered, mask, staticLightList) => {
     for (let i = 0; i < lights.length; i++) {

--- a/src/scene/materials/standard-material-options-builder.js
+++ b/src/scene/materials/standard-material-options-builder.js
@@ -16,6 +16,7 @@ import {
     SPECULAR_PHONG
 } from '../constants.js';
 import { _matTex2D } from '../shader-lib/programs/standard.js';
+import { collectLights } from './lit-material-common.js';
 
 const arraysEqual = (a, b) => {
     if (a.length !== b.length) {
@@ -390,9 +391,9 @@ class StandardMaterialOptionsBuilder {
             options.litOptions.lightMaskDynamic = !!(mask & MASK_AFFECT_DYNAMIC);
 
             if (sortedLights) {
-                this._collectLights(LIGHTTYPE_DIRECTIONAL, sortedLights[LIGHTTYPE_DIRECTIONAL], lightsFiltered, mask);
-                this._collectLights(LIGHTTYPE_OMNI, sortedLights[LIGHTTYPE_OMNI], lightsFiltered, mask, staticLightList);
-                this._collectLights(LIGHTTYPE_SPOT, sortedLights[LIGHTTYPE_SPOT], lightsFiltered, mask, staticLightList);
+                collectLights(LIGHTTYPE_DIRECTIONAL, sortedLights[LIGHTTYPE_DIRECTIONAL], lightsFiltered, mask);
+                collectLights(LIGHTTYPE_OMNI, sortedLights[LIGHTTYPE_OMNI], lightsFiltered, mask, staticLightList);
+                collectLights(LIGHTTYPE_SPOT, sortedLights[LIGHTTYPE_SPOT], lightsFiltered, mask, staticLightList);
             }
             options.litOptions.lights = lightsFiltered;
         } else {
@@ -401,31 +402,6 @@ class StandardMaterialOptionsBuilder {
 
         if (options.litOptions.lights.length === 0) {
             options.litOptions.noShadow = true;
-        }
-    }
-
-    _collectLights(lType, lights, lightsFiltered, mask, staticLightList) {
-        for (let i = 0; i < lights.length; i++) {
-            const light = lights[i];
-            if (light.enabled) {
-                if (light.mask & mask) {
-                    if (lType !== LIGHTTYPE_DIRECTIONAL) {
-                        if (light.isStatic) {
-                            continue;
-                        }
-                    }
-                    lightsFiltered.push(light);
-                }
-            }
-        }
-
-        if (staticLightList) {
-            for (let i = 0; i < staticLightList.length; i++) {
-                const light = staticLightList[i];
-                if (light._type === lType) {
-                    lightsFiltered.push(light);
-                }
-            }
         }
     }
 

--- a/src/scene/materials/standard-material-options-builder.js
+++ b/src/scene/materials/standard-material-options-builder.js
@@ -242,6 +242,7 @@ class StandardMaterialOptionsBuilder {
         options.clearCoatTint = (stdMat.clearCoat !== 1.0) ? 1 : 0;
         options.clearCoatGloss = !!stdMat.clearCoatGloss;
         options.clearCoatGlossTint = (stdMat.clearCoatGloss !== 1.0) ? 1 : 0;
+        options.iorTint = stdMat.refractionIndex !== 1.0 / 1.5 ? 1 : 0;
 
         options.iridescenceTint = stdMat.iridescence !== 1.0 ? 1 : 0;
 

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -725,17 +725,6 @@ class StandardMaterial extends Material {
             if (!this.sheenGlossMap || this.sheenGlossTint) {
                 this._setParameter('material_sheenGloss', this.sheenGloss);
             }
-
-            if (this.refractionIndex === 0.0) {
-                this._setParameter('material_f0', 1.0);
-            } else if (this.refractionIndex !== 1.0 / 1.5) {
-                const oneOverRefractionIndex = 1.0 / this.refractionIndex;
-                const f0 = (oneOverRefractionIndex - 1) / (oneOverRefractionIndex + 1);
-                this._setParameter('material_f0', f0 * f0);
-            } else {
-                this._setParameter('material_f0', 0.04);
-            }
-
         }
 
         if (this.enableGGXSpecular) {

--- a/src/scene/shader-lib/chunks/chunks.js
+++ b/src/scene/shader-lib/chunks/chunks.js
@@ -65,6 +65,7 @@ import iridescenceDiffractionPS from './lit/frag/iridescenceDiffraction.js';
 import iridescencePS from './standard/frag/iridescence.js';
 import iridescenceThicknessPS from './standard/frag/iridescenceThickness.js';
 import instancingVS from './lit/vert/instancing.js';
+import iorPS from './standard/frag/ior.js';
 import lightDiffuseLambertPS from './lit/frag/lightDiffuseLambert.js';
 import lightDirPointPS from './lit/frag/lightDirPoint.js';
 import lightmapAddPS from './lit/frag/lightmapAdd.js';
@@ -275,6 +276,7 @@ const shaderChunks = {
     iridescencePS,
     iridescenceThicknessPS,
     instancingVS,
+    iorPS,
     lightDiffuseLambertPS,
     lightDirPointPS,
     lightmapAddPS,

--- a/src/scene/shader-lib/chunks/lit/frag/metalnessModulate.js
+++ b/src/scene/shader-lib/chunks/lit/frag/metalnessModulate.js
@@ -1,9 +1,7 @@
 export default /* glsl */`
 
-uniform float material_f0;
-
-vec3 getSpecularModulate(in vec3 specularity, in vec3 albedo, in float metalness) {
-    vec3 dielectricF0 = material_f0 * specularity;
+vec3 getSpecularModulate(in vec3 specularity, in vec3 albedo, in float metalness, in float f0) {
+    vec3 dielectricF0 = f0 * specularity;
     return mix(dielectricF0, albedo, metalness);
 }
 

--- a/src/scene/shader-lib/chunks/lit/frag/refractionCube.js
+++ b/src/scene/shader-lib/chunks/lit/frag/refractionCube.js
@@ -1,6 +1,4 @@
 export default /* glsl */`
-uniform float material_refractionIndex;
-
 vec3 refract2(vec3 viewVec, vec3 normal, float IOR) {
     float vn = dot(viewVec, normal);
     float k = 1.0 - IOR * IOR * (1.0 - vn * vn);
@@ -15,7 +13,8 @@ void addRefraction(
     float gloss, 
     vec3 specularity, 
     vec3 albedo, 
-    float transmission
+    float transmission,
+    float refractionIndex
 #if defined(LIT_IRIDESCENCE)
     , vec3 iridescenceFresnel,
     IridescenceArgs iridescence
@@ -23,7 +22,7 @@ void addRefraction(
 ) {
     // use same reflection code with refraction vector
     vec4 tmpRefl = dReflection;
-    vec3 reflectionDir = refract2(-viewDir, worldNormal, material_refractionIndex);
+    vec3 reflectionDir = refract2(-viewDir, worldNormal, refractionIndex);
     dReflection = vec4(0);
     addReflection(reflectionDir, gloss);
     dDiffuseLight = mix(dDiffuseLight, dReflection.rgb * albedo, transmission);

--- a/src/scene/shader-lib/chunks/lit/frag/refractionDynamic.js
+++ b/src/scene/shader-lib/chunks/lit/frag/refractionDynamic.js
@@ -1,5 +1,4 @@
 export default /* glsl */`
-uniform float material_refractionIndex;
 uniform float material_invAttenuationDistance;
 uniform vec3 material_attenuation;
 
@@ -10,7 +9,8 @@ void addRefraction(
     float gloss, 
     vec3 specularity, 
     vec3 albedo, 
-    float transmission
+    float transmission,
+    float refractionIndex
 #if defined(LIT_IRIDESCENCE)
     , vec3 iridescenceFresnel,
     IridescenceArgs iridescence
@@ -24,7 +24,7 @@ void addRefraction(
     modelScale.z = length(vec3(matrix_model[2].xyz));
 
     // Calculate the refraction vector, scaled by the thickness and scale of the object
-    vec3 refractionVector = normalize(refract(-viewDir, worldNormal, material_refractionIndex)) * thickness * modelScale;
+    vec3 refractionVector = normalize(refract(-viewDir, worldNormal, refractionIndex)) * thickness * modelScale;
 
     // The refraction point is the entry point + vector to exit point
     vec4 pointOfRefraction = vec4(vPositionW + refractionVector, 1.0);
@@ -37,7 +37,7 @@ void addRefraction(
 
     #ifdef SUPPORTS_TEXLOD
         // Use IOR and roughness to select mip
-        float iorToRoughness = (1.0 - gloss) * clamp((1.0 / material_refractionIndex) * 2.0 - 2.0, 0.0, 1.0);
+        float iorToRoughness = (1.0 - gloss) * clamp((1.0 / refractionIndex) * 2.0 - 2.0, 0.0, 1.0);
         float refractionLod = log2(uScreenSize.x) * iorToRoughness;
         vec3 refraction = texture2DLodEXT(uSceneColorMap, uv, refractionLod).rgb;
     #else

--- a/src/scene/shader-lib/chunks/standard/frag/ior.js
+++ b/src/scene/shader-lib/chunks/standard/frag/ior.js
@@ -1,0 +1,13 @@
+export default /* glsl */`
+#ifdef MAPFLOAT
+uniform float material_refractionIndex;
+#endif
+
+void getIor() {
+#ifdef MAPFLOAT
+    dIor = material_refractionIndex;
+#else
+    dIor = 1.0 / 1.5;
+#endif
+}
+`;

--- a/src/scene/shader-lib/chunks/standard/frag/litShaderArgs.js
+++ b/src/scene/shader-lib/chunks/standard/frag/litShaderArgs.js
@@ -36,14 +36,17 @@ vec3 litArgs_lightmapDir;
 // The microfacet glossiness factor, range [0..1]
 float litArgs_gloss;
 
+// The normal used for the clearcoat layer
+vec3 litArgs_clearcoat_worldNormal;
+
 // Iridescence effect intensity, range [0..1]
 float litArgs_iridescence_intensity;
 
+// The color of the f0 specularity factor for the sheen layer
+vec3 litArgs_sheen_specularity;
+
 // Thickness of the iridescent microfilm layer, value is in nanometers, range [0..1000]
 float litArgs_iridescence_thickness;
-
-// The normal used for the clearcoat layer
-vec3 litArgs_clearcoat_worldNormal;
 
 // Intensity of the clearcoat layer, range [0..1]
 float litArgs_clearcoat_specularity;
@@ -54,10 +57,10 @@ float litArgs_clearcoat_gloss;
 // Surface metalness factor, range [0..1]
 float litArgs_metalness;
 
-// The color of the f0 specularity factor for the sheen layer
-vec3 litArgs_sheen_specularity;
-
 // Glossiness of the sheen layer, range [0..1]
 float litArgs_sheen_gloss;
+
+// Index of refraction
+float litArgs_ior;
 
 `;

--- a/src/scene/shader-lib/programs/custom.js
+++ b/src/scene/shader-lib/programs/custom.js
@@ -1,7 +1,7 @@
 import { hashCode } from '../../../core/hash.js';
 import { ChunkBuilder } from '../chunk-builder.js';
 import { LitShader } from './lit-shader.js';
-import lit from './lit.js';
+import { lit } from './lit.js';
 
 const custom  = {
 

--- a/src/scene/shader-lib/programs/custom.js
+++ b/src/scene/shader-lib/programs/custom.js
@@ -46,7 +46,7 @@ const custom  = {
 
         decl.append(litShader.chunks.litShaderArgsPS);
         code.append(options.customLitArguments);
-        func.code = `LitShaderArguments litShaderArgs = evaluateFrontend();`;
+        func.code = `evaluateFrontend();`;
 
         func.code = `\n${func.code.split('\n').map(l => `    ${l}`).join('\n')}\n\n`;
         const useUv = [];

--- a/src/scene/shader-lib/programs/custom.js
+++ b/src/scene/shader-lib/programs/custom.js
@@ -1,0 +1,83 @@
+import { LIGHTTYPE_DIRECTIONAL } from '../../../scene/constants.js';
+import { hashCode } from '../../../core/hash.js';
+import { ChunkBuilder } from '../chunk-builder.js';
+import { LitShader } from './lit-shader.js';
+
+const custom  = {
+
+    /** @type { Function } */
+    generateKey: function (options) {
+        const props = [];
+        for (const prop in options) {
+            if (options.hasOwnProperty(prop) && prop !== "chunks" && prop !== "lights")
+                props.push(prop);
+        }
+
+        let key = "custom";
+
+        if (options.chunks) {
+            const chunks = [];
+            for (const p in options.chunks) {
+                if (options.chunks.hasOwnProperty(p)) {
+                    chunks.push(p + options.chunks[p]);
+                }
+            }
+            chunks.sort();
+            key += chunks;
+        }
+
+        if (options.litOptions) {
+
+            for (const m in options.litOptions) {
+
+                // handle lights in a custom way
+                if (m === 'lights') {
+                    const isClustered = options.litOptions.clusteredLightingEnabled;
+                    for (let i = 0; i < options.litOptions.lights.length; i++) {
+                        const light = options.litOptions.lights[i];
+                        if (!isClustered || light._type === LIGHTTYPE_DIRECTIONAL) {
+                            key += light.key;
+                        }
+                    }
+                } else {
+                    key += m + options.litOptions[m];
+                }
+            }
+        }
+
+        return hashCode(key);
+    },
+
+    /**
+     * @param {import('../../../platform/graphics/graphics-device.js').GraphicsDevice} device - The
+     * graphics device.
+     * @param {object} options - The lit options to be passed to the backend.
+     * @returns {object} Returns the created shader definition.
+     * @ignore
+     */
+    createShaderDefinition: function (device, options) {
+        const litShader = new LitShader(device, options.litOptions);
+
+        const decl = new ChunkBuilder();
+        const code = new ChunkBuilder();
+        const func = new ChunkBuilder();
+
+        // global texture bias for standard textures
+        decl.append(`uniform float textureBias;`);
+
+        decl.append(litShader.chunks.litShaderArgsPS);
+        code.append(options.customLitArguments);
+        func.code = `LitShaderArguments litShaderArgs = evaluateFrontend();`;
+
+        func.code = `\n${func.code.split('\n').map(l => `    ${l}`).join('\n')}\n\n`;
+        const useUv = [];
+        const useUnmodifiedUv = [];
+        const mapTransforms = [];
+        litShader.generateVertexShader(useUv, useUnmodifiedUv, mapTransforms);
+        litShader.generateFragmentShader(decl.code, code.code, func.code, "vUv0");
+
+        return litShader.getDefinition();
+    }
+};
+
+export { custom };

--- a/src/scene/shader-lib/programs/custom.js
+++ b/src/scene/shader-lib/programs/custom.js
@@ -1,49 +1,28 @@
-import { LIGHTTYPE_DIRECTIONAL } from '../../../scene/constants.js';
 import { hashCode } from '../../../core/hash.js';
 import { ChunkBuilder } from '../chunk-builder.js';
 import { LitShader } from './lit-shader.js';
+import lit from './lit.js';
 
 const custom  = {
 
     /** @type { Function } */
     generateKey: function (options) {
-        const props = [];
-        for (const prop in options) {
-            if (options.hasOwnProperty(prop) && prop !== "chunks" && prop !== "lights")
-                props.push(prop);
-        }
 
         let key = "custom";
 
+        const props = lit.buildPropertiesList(options);
+
+        key += lit.propertiesKey(props);
+
         if (options.chunks) {
-            const chunks = [];
-            for (const p in options.chunks) {
-                if (options.chunks.hasOwnProperty(p)) {
-                    chunks.push(p + options.chunks[p]);
-                }
-            }
-            chunks.sort();
-            key += chunks;
+            key += lit.chunksKey(options.chunks);
         }
 
         if (options.litOptions) {
-
-            for (const m in options.litOptions) {
-
-                // handle lights in a custom way
-                if (m === 'lights') {
-                    const isClustered = options.litOptions.clusteredLightingEnabled;
-                    for (let i = 0; i < options.litOptions.lights.length; i++) {
-                        const light = options.litOptions.lights[i];
-                        if (!isClustered || light._type === LIGHTTYPE_DIRECTIONAL) {
-                            key += light.key;
-                        }
-                    }
-                } else {
-                    key += m + options.litOptions[m];
-                }
-            }
+            key += lit.litOptionsKey(options.litOptions);
         }
+
+        key += options.customLitArguments;
 
         return hashCode(key);
     },

--- a/src/scene/shader-lib/programs/custom.js
+++ b/src/scene/shader-lib/programs/custom.js
@@ -30,7 +30,7 @@ const custom  = {
     /**
      * @param {import('../../../platform/graphics/graphics-device.js').GraphicsDevice} device - The
      * graphics device.
-     * @param {object} options - The lit options to be passed to the backend.
+     * @param {object} options - The options to be passed to the backend.
      * @returns {object} Returns the created shader definition.
      * @ignore
      */
@@ -49,10 +49,9 @@ const custom  = {
         func.code = `evaluateFrontend();`;
 
         func.code = `\n${func.code.split('\n').map(l => `    ${l}`).join('\n')}\n\n`;
-        const useUv = [];
-        const useUnmodifiedUv = [];
+        const usedUvSets = options.usedUvs || [true];
         const mapTransforms = [];
-        litShader.generateVertexShader(useUv, useUnmodifiedUv, mapTransforms);
+        litShader.generateVertexShader(usedUvSets, usedUvSets, mapTransforms);
         litShader.generateFragmentShader(decl.code, code.code, func.code, "vUv0");
 
         return litShader.getDefinition();

--- a/src/scene/shader-lib/programs/lit-shader.js
+++ b/src/scene/shader-lib/programs/lit-shader.js
@@ -1027,7 +1027,8 @@ class LitShader {
 
         if ((this.lighting && options.useSpecular) || this.reflections) {
             if (options.useMetalness) {
-                backend.append("    litArgs_specularity = getSpecularModulate(litArgs_specularity, litArgs_albedo, litArgs_metalness);");
+                backend.append("    float f0 = 1.0 / litArgs_ior; f0 = (f0 - 1.0) / (f0 + 1.0); f0 *= f0;");
+                backend.append("    litArgs_specularity = getSpecularModulate(litArgs_specularity, litArgs_albedo, litArgs_metalness, f0);");
                 backend.append("    litArgs_albedo = getAlbedoModulate(litArgs_albedo, litArgs_metalness);");
             }
 
@@ -1439,7 +1440,8 @@ class LitShader {
                         litArgs_gloss, 
                         litArgs_specularity, 
                         litArgs_albedo, 
-                        litArgs_transmission
+                        litArgs_transmission,
+                        litArgs_ior
                     #if defined(LIT_IRIDESCENCE)
                         , iridescenceFresnel, 
                         litArgs_iridescence

--- a/src/scene/shader-lib/programs/lit.js
+++ b/src/scene/shader-lib/programs/lit.js
@@ -11,7 +11,7 @@ const lit = {
         return props.sort();
     },
 
-    propertiesKey: function(props) {
+    propertiesKey: function (props) {
         let key = "";
         for (let i = 0; i < props.length; i++) {
             if (props[i])

--- a/src/scene/shader-lib/programs/lit.js
+++ b/src/scene/shader-lib/programs/lit.js
@@ -1,0 +1,59 @@
+import { LIGHTTYPE_DIRECTIONAL } from "../../constants";
+
+const lit = {
+
+    buildPropertiesList: function (options) {
+        const props = [];
+        for (const prop in options) {
+            if (options.hasOwnProperty(prop) && prop !== "chunks" && prop !== "lights")
+                props.push(prop);
+        }
+        return props.sort();
+    },
+
+    propertiesKey: function(props) {
+        let key = "";
+        for (let i = 0; i < props.length; i++) {
+            if (props[i])
+                key += props[i] + props[i];
+        }
+        return key;
+    },
+
+    litOptionsKey: function (options) {
+        let key = "";
+        for (const m in options) {
+
+            // handle lights in a custom way
+            if (m === 'lights') {
+                const isClustered = options.clusteredLightingEnabled;
+                for (let i = 0; i < options.lights.length; i++) {
+                    const light = options.lights[i];
+                    if (!isClustered || light._type === LIGHTTYPE_DIRECTIONAL) {
+                        key += light.key;
+                    }
+                }
+            } else {
+                key += m + options[m];
+            }
+        }
+        return key;
+    },
+
+    chunksKey: function (chunks) {
+        let key = "";
+        if (chunks) {
+            const chunks = [];
+            for (const p in chunks) {
+                if (chunks.hasOwnProperty(p)) {
+                    chunks.push(p + chunks[p]);
+                }
+            }
+            chunks.sort();
+            key += chunks;
+        }
+        return key;
+    }
+};
+
+export default lit;

--- a/src/scene/shader-lib/programs/lit.js
+++ b/src/scene/shader-lib/programs/lit.js
@@ -1,4 +1,4 @@
-import { LIGHTTYPE_DIRECTIONAL } from "../../constants";
+import { LIGHTTYPE_DIRECTIONAL } from "../../constants.js";
 
 const lit = {
 
@@ -56,4 +56,4 @@ const lit = {
     }
 };
 
-export default lit;
+export { lit };

--- a/src/scene/shader-lib/programs/lit.js
+++ b/src/scene/shader-lib/programs/lit.js
@@ -2,7 +2,7 @@ import { LIGHTTYPE_DIRECTIONAL } from "../../constants.js";
 
 const lit = {
 
-    buildPropertiesList: function (options) {
+    buildPropertiesList(options) {
         const props = [];
         for (const prop in options) {
             if (options.hasOwnProperty(prop) && prop !== "chunks" && prop !== "lights")
@@ -11,7 +11,7 @@ const lit = {
         return props.sort();
     },
 
-    propertiesKey: function (props) {
+    propertiesKey(props) {
         let key = "";
         for (let i = 0; i < props.length; i++) {
             if (props[i])
@@ -20,7 +20,7 @@ const lit = {
         return key;
     },
 
-    litOptionsKey: function (options) {
+    litOptionsKey(options) {
         let key = "";
         for (const m in options) {
 
@@ -40,7 +40,7 @@ const lit = {
         return key;
     },
 
-    chunksKey: function (chunks) {
+    chunksKey(chunks) {
         let key = "";
         if (chunks) {
             const chunks = [];

--- a/src/scene/shader-lib/programs/standard.js
+++ b/src/scene/shader-lib/programs/standard.js
@@ -2,7 +2,7 @@ import { hashCode } from '../../../core/hash.js';
 import { Debug } from '../../../core/debug.js';
 
 import {
-    BLEND_NONE, FRESNEL_SCHLICK, LIGHTTYPE_DIRECTIONAL,
+    BLEND_NONE, FRESNEL_SCHLICK,
     SPECULAR_PHONG,
     SPRITE_RENDERMODE_SLICED, SPRITE_RENDERMODE_TILED
 } from '../../constants.js';
@@ -11,7 +11,7 @@ import { LitShader } from './lit-shader.js';
 import { ChunkBuilder } from '../chunk-builder.js';
 import { ChunkUtils } from '../chunk-utils.js';
 import { StandardMaterialOptions } from '../../materials/standard-material-options.js';
-import lit from './lit.js';
+import { lit } from './lit.js';
 
 const _matTex2D = [];
 

--- a/src/scene/shader-lib/programs/standard.js
+++ b/src/scene/shader-lib/programs/standard.js
@@ -11,6 +11,7 @@ import { LitShader } from './lit-shader.js';
 import { ChunkBuilder } from '../chunk-builder.js';
 import { ChunkUtils } from '../chunk-utils.js';
 import { StandardMaterialOptions } from '../../materials/standard-material-options.js';
+import lit from './lit.js';
 
 const _matTex2D = [];
 
@@ -21,60 +22,28 @@ const standard = {
 
     /** @type { Function } */
     generateKey: function (options) {
-        const buildPropertiesList = function (options) {
-            const props = [];
-            for (const prop in options) {
-                if (options.hasOwnProperty(prop) && prop !== "chunks" && prop !== "lights")
-                    props.push(prop);
-            }
-            return props.sort();
-        };
-        let props;
-        if (options === this.optionsContextMin) {
-            if (!this.propsMin) this.propsMin = buildPropertiesList(options);
-            props = this.propsMin;
-        } else if (options === this.optionsContext) {
-            if (!this.props) this.props = buildPropertiesList(options);
-            props = this.props;
-        } else {
-            props = buildPropertiesList(options);
-        }
 
         let key = "standard";
 
-        for (let i = 0; i < props.length; i++) {
-            if (options[props[i]])
-                key += props[i] + options[props[i]];
+        let props;
+        if (options === this.optionsContextMin) {
+            if (!this.propsMin) this.propsMin = lit.buildPropertiesList(options);
+            props = this.propsMin;
+        } else if (options === this.optionsContext) {
+            if (!this.props) this.props = lit.buildPropertiesList(options);
+            props = this.props;
+        } else {
+            props = lit.buildPropertiesList(options);
         }
 
+        key += lit.propertiesKey(props);
+
         if (options.chunks) {
-            const chunks = [];
-            for (const p in options.chunks) {
-                if (options.chunks.hasOwnProperty(p)) {
-                    chunks.push(p + options.chunks[p]);
-                }
-            }
-            chunks.sort();
-            key += chunks;
+            key += lit.chunksKey(options.chunks);
         }
 
         if (options.litOptions) {
-
-            for (const m in options.litOptions) {
-
-                // handle lights in a custom way
-                if (m === 'lights') {
-                    const isClustered = options.litOptions.clusteredLightingEnabled;
-                    for (let i = 0; i < options.litOptions.lights.length; i++) {
-                        const light = options.litOptions.lights[i];
-                        if (!isClustered || light._type === LIGHTTYPE_DIRECTIONAL) {
-                            key += light.key;
-                        }
-                    }
-                } else {
-                    key += m + options.litOptions[m];
-                }
-            }
+            key += lit.litOptionsKey(options.litOptions);
         }
 
         return hashCode(key);

--- a/src/scene/shader-lib/programs/standard.js
+++ b/src/scene/shader-lib/programs/standard.js
@@ -393,6 +393,11 @@ const standard = {
                     code.append(this._addMap("metalness", "metalnessPS", options, litShader.chunks, textureMapping));
                     func.append("getMetalness();");
                     args.append("litArgs_metalness = dMetalness;");
+
+                    decl.append("float dIor;");
+                    code.append(this._addMap("ior", "iorPS", options, litShader.chunks, textureMapping));
+                    func.append("getIor();");
+                    args.append("litArgs_ior = dIor;");
                 }
                 if (options.litOptions.useSpecularityFactor) {
                     decl.append("float dSpecularityFactor;");


### PR DESCRIPTION
The custom material types allows for the user to provide a frontend shader chunk as code, as well as supplying the backend options without having to go through the StandardMaterial type to do so. 

This should finish the last step of #4250. 

An example use of this material can look as such:
```js
const material = new pc.CustomMaterial();
material.setParameter("texture_envAtlas", assets.helipad.resource);
material.setParameter("material_reflectivity", 1.0);
const options = new pc.LitOptions();
options.shadingModel = pc.SPECULAR_BLINN;
options.useSpecular = true;
options.useMetalness = true;
options.occludeSpecular = 1;
options.reflectionSource = 'envAtlas';
options.reflectionEncoding = assets.helipad.resource.encoding;
options.ambientSource = 'envAtlas';
options.ambientEncoding = assets.helipad.resource.encoding;
options.clusteredLightingEnabled = app.scene.clusteredLightingEnabled;
material.litOptions = options;

const shaderChunk = `
void evaluateFrontend() {
    litArgs_emission = vec3(0, 0, 0);
    litArgs_albedo = dVertexNormalW;
    litArgs_metalness = 0.5;
    litArgs_specularity = vec3(1,1,1);
    litArgs_specularityFactor = 1.0;
    litArgs_ior = 0.6667;
    litArgs_gloss = 0.5;
    litArgs_worldNormal = dVertexNormalW;
    litArgs_ao = 0.0;
    litArgs_opacity = 1.0;
}`;
material.shaderChunk = shaderChunk;
material.update();

// create primitive
const primitive = new pc.Entity();
primitive.addComponent('render', {
    type: "sphere",
    material: material
});
```

Note how the options are only for the lighting part of the shader, and the way arguments are passed to it is through a custom bit of code that evaluates the lit shader arguments. 