### PR TITLE
Fix omni light shadows with PCSS and clustered

### DIFF
--- a/src/scene/shader-lib/programs/lit-shader.js
+++ b/src/scene/shader-lib/programs/lit-shader.js
@@ -450,7 +450,7 @@ class LitShader {
 
         // If not a directional light and using clustered, fall back to using PCF3x3 if shadow type isn't supported
         if (lightType !== LIGHTTYPE_DIRECTIONAL && options.clusteredLightingEnabled) {
-            if (shadowType !== SHADOW_PCF1 || shadowType !== SHADOW_PCF3 || shadowType !== SHADOW_PCF5) {
+            if (shadowType === SHADOW_VSM8 || shadowType === SHADOW_VSM16 || shadowType === SHADOW_VSM32 || shadowType === SHADOW_PCSS) {
                 shadowType = SHADOW_PCF3;
             }
         }

--- a/src/scene/shader-lib/programs/lit-shader.js
+++ b/src/scene/shader-lib/programs/lit-shader.js
@@ -520,9 +520,16 @@ class LitShader {
             code += "    gl_FragColor = packFloat(depth);\n";
         } else if (!isVsm) {
             code += "    gl_FragColor = vec4(1.0);\n"; // just the simplest code, color is not written anyway
+            const useDepthComponent = shadowType === SHADOW_PCF1 || shadowType === SHADOW_PCF3 || shadowType === SHADOW_PCF5 ||
+                (lightType === LIGHTTYPE_OMNI && options.clusteredLightingEnabled);
 
+            if (useDepthComponent) {
+                code += "    gl_FragDepth = depth;\n";
+            } else {
+                code += "    gl_FragColor.r = depth;\n";
+            }
             // clustered omni light is using shadow sampler and needs to write custom depth
-            if (shadowType === SHADOW_PCSS || (lightType === LIGHTTYPE_OMNI && !options.clusteredLightingEnabled)) {
+            if (shadowType === SHADOW_PCSS && (lightType !== LIGHTTYPE_OMNI && options.clusteredLightingEnabled)) {
                 code += "   gl_FragColor.r = depth;\n";
             } else if (options.clusteredLightingEnabled && lightType === LIGHTTYPE_OMNI && device.supportsDepthShadow) {
                 code += "    gl_FragDepth = depth;\n";

--- a/src/scene/shader-lib/programs/lit-shader.js
+++ b/src/scene/shader-lib/programs/lit-shader.js
@@ -520,10 +520,10 @@ class LitShader {
             code += "    gl_FragColor = packFloat(depth);\n";
         } else if (!isVsm) {
             code += "    gl_FragColor = vec4(1.0);\n"; // just the simplest code, color is not written anyway
-            const useDepthComponent = shadowType === SHADOW_PCF1 || shadowType === SHADOW_PCF3 || shadowType === SHADOW_PCF5 ||
+            const exportDepth = shadowType === SHADOW_PCF1 || shadowType === SHADOW_PCF3 || shadowType === SHADOW_PCF5 ||
                 (lightType === LIGHTTYPE_OMNI && options.clusteredLightingEnabled);
 
-            if (useDepthComponent) {
+            if (exportDepth) {
                 code += "    gl_FragDepth = depth;\n";
             } else {
                 code += "    gl_FragColor.r = depth;\n";


### PR DESCRIPTION
Fixes https://github.com/playcanvas/engine/issues/5444

Omni light shadows when using PCSS would try to output to PCSS style R32F but reading D32F. This PR fixes that bug and also refactors the way we select whether or not we output to depth component or not more clearly. 