### PR TITLE
Export TextureUtils.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -66,6 +66,7 @@ export { ScopeId } from './platform/graphics/scope-id.js';
 export { ScopeSpace } from './platform/graphics/scope-space.js';
 export { Shader } from './platform/graphics/shader.js';
 export { Texture } from './platform/graphics/texture.js';
+export { TextureUtils } from './platform/graphics/texture-utils.js';
 export { TransformFeedback } from './platform/graphics/transform-feedback.js';
 export { VertexBuffer } from './platform/graphics/vertex-buffer.js';
 export { VertexFormat } from './platform/graphics/vertex-format.js';


### PR DESCRIPTION
This PR exports `TextureUtils` class.

`Texture.calcGpuSize()` function was moved to `TextureUtils` in #5372. Even though the function is flagged internal/ignore, the editor uses it and now no longer works.

We should consider exposing `TextureUtils` as public API.