### PR TITLE
Don't assume MRT extension is available on webgl1

### DIFF
--- a/src/platform/graphics/webgl/webgl-render-target.js
+++ b/src/platform/graphics/webgl/webgl-render-target.js
@@ -101,7 +101,7 @@ class WebglRenderTarget {
 
         // --- Init the provided color buffer (optional) ---
         const colorBufferCount = target._colorBuffers?.length ?? 0;
-        const attachmentBaseConstant = device.webgl2 ? gl.COLOR_ATTACHMENT0 : device.extDrawBuffers.COLOR_ATTACHMENT0_WEBGL;
+        const attachmentBaseConstant = device.webgl2 ? gl.COLOR_ATTACHMENT0 : (device.extDrawBuffers?.COLOR_ATTACHMENT0_WEBGL ?? gl.COLOR_ATTACHMENT0);
         const buffers = [];
         for (let i = 0; i < colorBufferCount; ++i) {
             const colorBuffer = target.getColorBuffer(i);


### PR DESCRIPTION
Fixes https://forum.playcanvas.com/t/getting-error-typeerror-cannot-read-properties-of-null-reading-color-attachment0-webgl-when-trying-to-run-a-recently-created-build-from-a-mobile-device/31914

