### PR TITLE
Optimize `AssetRegistry` class

### DIFF
--- a/src/framework/asset/asset-registry.js
+++ b/src/framework/asset/asset-registry.js
@@ -249,7 +249,7 @@ class AssetRegistry extends EventHandler {
 
         this.fire('add', asset);
         this.fire('add:' + asset.id, asset);
-        if (asset.file)
+        if (asset.file?.url)
             this.fire('add:url:' + asset.file.url, asset);
 
         if (asset.preload)

--- a/src/framework/asset/asset-registry.js
+++ b/src/framework/asset/asset-registry.js
@@ -272,7 +272,7 @@ class AssetRegistry extends EventHandler {
 
         this._idToAsset.delete(asset.id);
 
-        if (asset.file) {
+        if (asset.file?.url) {
             this._urlToAsset.delete(asset.file.url);
         }
 

--- a/src/framework/asset/asset-registry.js
+++ b/src/framework/asset/asset-registry.js
@@ -432,7 +432,7 @@ class AssetRegistry extends EventHandler {
      * @param {LoadAssetCallback} callback - Function called when asset is loaded, passed (err,
      * asset), where err is null if no errors were encountered.
      * @example
-     * const file = magicallyAttainAFile();
+     * const file = magicallyObtainAFile();
      * app.assets.loadFromUrlAndFilename(URL.createObjectURL(file), "texture.png", "texture", function (err, asset) {
      *     const texture = asset.resource;
      * });
@@ -617,10 +617,8 @@ class AssetRegistry extends EventHandler {
      * Return `true` to include an asset in the returned array.
      * @returns {Asset[]} A list of all Assets found.
      * @example
-     * const assets = app.assets.filter(function (asset) {
-     *     return asset.name.indexOf('monster') !== -1;
-     * });
-     * console.log("Found " + assets.length + " assets, where names contains 'monster'");
+     * const assets = app.assets.filter(asset => asset.name.includes('monster'));
+     * console.log(`Found ${assets.length} assets with a name containing 'monster'`);
      */
     filter(callback) {
         return Array.from(this._assets).filter(asset => callback(asset));
@@ -646,8 +644,8 @@ class AssetRegistry extends EventHandler {
      * @param {string} [type] - The type of the Assets to find.
      * @returns {Asset[]} A list of all Assets found.
      * @example
-     * const assets = app.assets.findAll("myTextureAsset", "texture");
-     * console.log("Found " + assets.length + " assets called " + name);
+     * const assets = app.assets.findAll('brick', 'texture');
+     * console.log(`Found ${assets.length} texture assets named 'brick'`);
      */
     findAll(name, type) {
         return Array.from(this._assets).filter(asset => asset.name === name && (!type || asset.type === type));

--- a/src/framework/asset/asset-registry.js
+++ b/src/framework/asset/asset-registry.js
@@ -37,13 +37,13 @@ class AssetRegistry extends EventHandler {
      * @type {Set<Asset>}
      * @private
      */
-   _assets = new Set();
+    _assets = new Set();
 
     /**
      * @type {Map<number, Asset>}
      * @private
      */
-   _idToAsset = new Map();
+    _idToAsset = new Map();
 
     /**
      * @type {Map<string, Asset>}

--- a/src/framework/asset/asset-registry.js
+++ b/src/framework/asset/asset-registry.js
@@ -34,6 +34,38 @@ import { Asset } from './asset.js';
  */
 class AssetRegistry extends EventHandler {
     /**
+     * @type {Set<Asset>}
+     * @private
+     */
+   _assets = new Set();
+
+    /**
+     * @type {Map<number, Asset>}
+     * @private
+     */
+   _idToAsset = new Map();
+
+    /**
+     * @type {Map<string, Asset>}
+     * @private
+     */
+    _urlToAsset = new Map();
+
+    /**
+     * Index for looking up by tags.
+     *
+     * @private
+     */
+    _tags = new TagsCache('_id');
+
+    /**
+     * A URL prefix that will be added to all asset loading requests.
+     *
+     * @type {string|null}
+     */
+    prefix = null;
+
+    /**
      * Create an instance of an AssetRegistry.
      *
      * @param {import('../handlers/loader.js').ResourceLoader} loader - The ResourceLoader used to
@@ -43,19 +75,6 @@ class AssetRegistry extends EventHandler {
         super();
 
         this._loader = loader;
-
-        this._assets = []; // list of all assets
-        this._cache = {}; // index for looking up assets by id
-        this._names = {}; // index for looking up assets by name
-        this._tags = new TagsCache('_id'); // index for looking up by tags
-        this._urls = {}; // index for looking up assets by url
-
-        /**
-         * A URL prefix that will be added to all asset loading requests.
-         *
-         * @type {string}
-         */
-        this.prefix = null;
     }
 
     /**
@@ -192,15 +211,12 @@ class AssetRegistry extends EventHandler {
      * @param {object} filters - Properties to filter on, currently supports: 'preload: true|false'.
      * @returns {Asset[]} The filtered list of assets.
      */
-    list(filters) {
-        filters = filters || {};
-        return this._assets.filter((asset) => {
-            let include = true;
-            if (filters.preload !== undefined) {
-                include = (asset.preload === filters.preload);
-            }
-            return include;
-        });
+    list(filters = {}) {
+        const assets = Array.from(this._assets);
+        if (filters.preload !== undefined) {
+            return assets.filter(asset => asset.preload === filters.preload);
+        }
+        return assets;
     }
 
     /**
@@ -214,20 +230,16 @@ class AssetRegistry extends EventHandler {
      * app.assets.add(asset);
      */
     add(asset) {
-        const index = this._assets.push(asset) - 1;
-        let url;
+        if (this._assets.has(asset)) return;
 
-        // id cache
-        this._cache[asset.id] = index;
-        if (!this._names[asset.name])
-            this._names[asset.name] = [];
+        this._assets.add(asset);
 
-        // name cache
-        this._names[asset.name].push(index);
+        this._idToAsset.set(asset.id, asset);
+
         if (asset.file) {
-            url = asset.file.url;
-            this._urls[url] = index;
+            this._urlToAsset.set(asset.file.url, asset);
         }
+
         asset.registry = this;
 
         // tags cache
@@ -237,8 +249,8 @@ class AssetRegistry extends EventHandler {
 
         this.fire('add', asset);
         this.fire('add:' + asset.id, asset);
-        if (url)
-            this.fire('add:url:' + url, asset);
+        if (asset.file)
+            this.fire('add:url:' + asset.file.url, asset);
 
         if (asset.preload)
             this.load(asset);
@@ -254,79 +266,52 @@ class AssetRegistry extends EventHandler {
      * app.assets.remove(asset);
      */
     remove(asset) {
-        const idx = this._cache[asset.id];
-        const url = asset.file ? asset.file.url : null;
+        if (!this._assets.has(asset)) return false;
 
-        if (idx !== undefined) {
-            // remove from list
-            this._assets.splice(idx, 1);
+        this._assets.delete(asset);
 
-            // remove id -> index cache
-            delete this._cache[asset.id];
+        this._idToAsset.delete(asset.id);
 
-            // name cache needs to be completely rebuilt
-            this._names = {};
-
-            // urls cache needs to be completely rebuilt
-            this._urls = [];
-
-            // update id cache and rebuild name cache
-            for (let i = 0, l = this._assets.length; i < l; i++) {
-                const a = this._assets[i];
-
-                this._cache[a.id] = i;
-                if (!this._names[a.name]) {
-                    this._names[a.name] = [];
-                }
-                this._names[a.name].push(i);
-
-                if (a.file) {
-                    this._urls[a.file.url] = i;
-                }
-            }
-
-            // tags cache
-            this._tags.removeItem(asset);
-            asset.tags.off('add', this._onTagAdd, this);
-            asset.tags.off('remove', this._onTagRemove, this);
-
-            asset.fire('remove', asset);
-            this.fire('remove', asset);
-            this.fire('remove:' + asset.id, asset);
-            if (url)
-                this.fire('remove:url:' + url, asset);
-
-            return true;
+        if (asset.file) {
+            this._urlToAsset.delete(asset.file.url);
         }
 
-        // asset not in registry
-        return false;
+        // tags cache
+        this._tags.removeItem(asset);
+        asset.tags.off('add', this._onTagAdd, this);
+        asset.tags.off('remove', this._onTagRemove, this);
+
+        asset.fire('remove', asset);
+        this.fire('remove', asset);
+        this.fire('remove:' + asset.id, asset);
+        if (asset.file)
+            this.fire('remove:url:' + asset.file.url, asset);
+
+        return true;
     }
 
     /**
      * Retrieve an asset from the registry by its id field.
      *
      * @param {number} id - The id of the asset to get.
-     * @returns {Asset} The asset.
+     * @returns {Asset|undefined} The asset.
      * @example
      * const asset = app.assets.get(100);
      */
     get(id) {
-        const idx = this._cache[id];
-        return this._assets[idx];
+        return this._idToAsset.get(id);
     }
 
     /**
      * Retrieve an asset from the registry by its file's URL field.
      *
      * @param {string} url - The url of the asset to get.
-     * @returns {Asset} The asset.
+     * @returns {Asset|undefined} The asset.
      * @example
      * const asset = app.assets.getByUrl("../path/to/image.jpg");
      */
     getByUrl(url) {
-        const idx = this._urls[url];
-        return this._assets[idx];
+        return this._urlToAsset.get(url);
     }
 
     /**
@@ -590,35 +575,6 @@ class AssetRegistry extends EventHandler {
         }
     }
 
-    /**
-     * Return all Assets with the specified name and type found in the registry.
-     *
-     * @param {string} name - The name of the Assets to find.
-     * @param {string} [type] - The type of the Assets to find.
-     * @returns {Asset[]} A list of all Assets found.
-     * @example
-     * const assets = app.assets.findAll("myTextureAsset", "texture");
-     * console.log("Found " + assets.length + " assets called " + name);
-     */
-    findAll(name, type) {
-        const idxs = this._names[name];
-        if (idxs) {
-            const assets = idxs.map((idx) => {
-                return this._assets[idx];
-            });
-
-            if (type) {
-                return assets.filter((asset) => {
-                    return (asset.type === type);
-                });
-            }
-
-            return assets;
-        }
-
-        return [];
-    }
-
     _onTagAdd(tag, asset) {
         this._tags.add(tag, asset);
     }
@@ -665,7 +621,7 @@ class AssetRegistry extends EventHandler {
      * console.log("Found " + assets.length + " assets, where names contains 'monster'");
      */
     filter(callback) {
-        return this._assets.filter(asset => callback(asset));
+        return Array.from(this._assets).filter(asset => callback(asset));
     }
 
     /**
@@ -673,15 +629,26 @@ class AssetRegistry extends EventHandler {
      *
      * @param {string} name - The name of the Asset to find.
      * @param {string} [type] - The type of the Asset to find.
-     * @returns {Asset|null} A single Asset or null if no Asset is found.
+     * @returns {Asset|undefined} A single Asset or null if no Asset is found.
      * @example
      * const asset = app.assets.find("myTextureAsset", "texture");
      */
     find(name, type) {
-        // findAll returns an empty array the if the asset cannot be found so `asset` is
-        // never null/undefined
-        const asset = this.findAll(name, type);
-        return asset.length > 0 ? asset[0] : null;
+        return Array.from(this._assets).find(asset => asset.name === name && (!type || asset.type === type));
+    }
+
+    /**
+     * Return all Assets with the specified name and type found in the registry.
+     *
+     * @param {string} name - The name of the Assets to find.
+     * @param {string} [type] - The type of the Assets to find.
+     * @returns {Asset[]} A list of all Assets found.
+     * @example
+     * const assets = app.assets.findAll("myTextureAsset", "texture");
+     * console.log("Found " + assets.length + " assets called " + name);
+     */
+    findAll(name, type) {
+        return Array.from(this._assets).filter(asset => asset.name === name && (!type || asset.type === type));
     }
 }
 

--- a/src/framework/asset/asset-registry.js
+++ b/src/framework/asset/asset-registry.js
@@ -631,7 +631,7 @@ class AssetRegistry extends EventHandler {
      *
      * @param {string} name - The name of the Asset to find.
      * @param {string} [type] - The type of the Asset to find.
-     * @returns {Asset|undefined} A single Asset or null if no Asset is found.
+     * @returns {Asset|undefined} A single Asset or undefined if no Asset is found.
      * @example
      * const asset = app.assets.find("myTextureAsset", "texture");
      */

--- a/src/framework/asset/asset-registry.js
+++ b/src/framework/asset/asset-registry.js
@@ -236,7 +236,7 @@ class AssetRegistry extends EventHandler {
 
         this._idToAsset.set(asset.id, asset);
 
-        if (asset.file) {
+        if (asset.file?.url) {
             this._urlToAsset.set(asset.file.url, asset);
         }
 
@@ -249,8 +249,9 @@ class AssetRegistry extends EventHandler {
 
         this.fire('add', asset);
         this.fire('add:' + asset.id, asset);
-        if (asset.file?.url)
+        if (asset.file?.url) {
             this.fire('add:url:' + asset.file.url, asset);
+        }
 
         if (asset.preload)
             this.load(asset);
@@ -284,8 +285,9 @@ class AssetRegistry extends EventHandler {
         asset.fire('remove', asset);
         this.fire('remove', asset);
         this.fire('remove:' + asset.id, asset);
-        if (asset.file)
+        if (asset.file?.url) {
             this.fire('remove:url:' + asset.file.url, asset);
+        }
 
         return true;
     }

--- a/src/framework/asset/asset-registry.js
+++ b/src/framework/asset/asset-registry.js
@@ -629,12 +629,12 @@ class AssetRegistry extends EventHandler {
      *
      * @param {string} name - The name of the Asset to find.
      * @param {string} [type] - The type of the Asset to find.
-     * @returns {Asset|undefined} A single Asset or undefined if no Asset is found.
+     * @returns {Asset|null} A single Asset or null if no Asset is found.
      * @example
      * const asset = app.assets.find("myTextureAsset", "texture");
      */
     find(name, type) {
-        return Array.from(this._assets).find(asset => asset.name === name && (!type || asset.type === type));
+        return Array.from(this._assets).find(asset => asset.name === name && (!type || asset.type === type)) ?? null;
     }
 
     /**

--- a/src/framework/asset/asset.js
+++ b/src/framework/asset/asset.js
@@ -145,7 +145,7 @@ class Asset extends EventHandler {
         /**
          * The asset registry that this Asset belongs to.
          *
-         * @type {import('./asset-registry.js').AssetRegistry}
+         * @type {import('./asset-registry.js').AssetRegistry|null}
          */
         this.registry = null;
 


### PR DESCRIPTION
The `AssetRegistry` class is incredibly inefficient. This PR massively optimizes it.

Before (~62ms to collapse a node in the 3D Tiles engine):

![image](https://github.com/playcanvas/engine/assets/697563/72178302-0fff-4fe1-bc12-9b13ce64ac95)

After (~3ms to collapse a node in the 3D Tiles engine):

![image](https://github.com/playcanvas/engine/assets/697563/a4696dee-c3c9-4daf-b121-c743d548a1cc)

Note, there is an API change here. `AssetRegistry#find` now returns `undefined` instead of `null` if no match is found. This matches how `Array#find` works.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
