### PR TITLE
[Fix] Workaround for shader compile issue on iOS 15 related to MRT

### DIFF
--- a/src/core/preprocessor.js
+++ b/src/core/preprocessor.js
@@ -98,7 +98,8 @@ class Preprocessor {
      *
      * @param {string} source - The source code to work on.
      * @param {Map<string, string>} defines - Supplied defines which are used in addition to those
-     * defined in the source code. Maps a define name to its value.
+     * defined in the source code. Maps a define name to its value. Note that the map is modified
+     * by the function.
      * @returns {string} Returns preprocessed source code.
      */
     static _preprocess(source, defines = new Map()) {
@@ -110,7 +111,6 @@ class Preprocessor {
 
         // true if the function encounter a problem
         let error = false;
-        defines = new Map(defines);
 
         let match;
         while ((match = KEYWORD.exec(source)) !== null) {

--- a/src/platform/graphics/shader-chunks/frag/gles3.js
+++ b/src/platform/graphics/shader-chunks/frag/gles3.js
@@ -1,32 +1,46 @@
 export default /* glsl */`
 layout(location = 0) out highp vec4 pc_fragColor;
 
+#ifndef REMOVE_COLOR_ATTACHMENT_1
 #if COLOR_ATTACHMENT_1
 layout(location = 1) out highp vec4 pc_fragColor1;
 #endif
+#endif
 
+#ifndef REMOVE_COLOR_ATTACHMENT_2
 #if COLOR_ATTACHMENT_2
 layout(location = 2) out highp vec4 pc_fragColor2;
 #endif
+#endif
 
+#ifndef REMOVE_COLOR_ATTACHMENT_3
 #if COLOR_ATTACHMENT_3
 layout(location = 3) out highp vec4 pc_fragColor3;
 #endif
+#endif
 
+#ifndef REMOVE_COLOR_ATTACHMENT_4
 #if COLOR_ATTACHMENT_4
 layout(location = 4) out highp vec4 pc_fragColor4;
 #endif
+#endif
 
+#ifndef REMOVE_COLOR_ATTACHMENT_5
 #if COLOR_ATTACHMENT_5
 layout(location = 5) out highp vec4 pc_fragColor5;
 #endif
+#endif
 
+#ifndef REMOVE_COLOR_ATTACHMENT_6
 #if COLOR_ATTACHMENT_6
 layout(location = 6) out highp vec4 pc_fragColor6;
 #endif
+#endif
 
+#ifndef REMOVE_COLOR_ATTACHMENT_7
 #if COLOR_ATTACHMENT_7
 layout(location = 7) out highp vec4 pc_fragColor7;
+#endif
 #endif
 
 #define gl_FragColor pc_fragColor

--- a/src/platform/graphics/shader.js
+++ b/src/platform/graphics/shader.js
@@ -86,7 +86,7 @@ class Shader {
 
         // pre-process shader sources
         definition.vshader = Preprocessor.run(definition.vshader);
-        definition.fshader = Preprocessor.run(definition.fshader);
+        definition.fshader = Preprocessor.run(definition.fshader, graphicsDevice.webgl2);
 
         this.init();
 


### PR DESCRIPTION
Fixes https://github.com/playcanvas/engine/issues/5452

We add outputs for MRT to shaders like this:
```
layout(location = 3) out highp vec4 pc_fragColor3;
```

But iOS / MacOS 15 seems to have a bug, and when fragment shader does not write to some of these, we get 'failed to link metal shader error', even though this output should have been simply ignored. In OS 16 this has been fixed, so we just need a workaround for 15. 

In the workaround we detect if those attachments `pc_fragColor3` are written to, and if not, we add a define to our existing shader processing to remove those.