### PR TITLE
Fix AssetRegistry#get to support string ids

### DIFF
--- a/src/framework/asset/asset-registry.js
+++ b/src/framework/asset/asset-registry.js
@@ -301,7 +301,8 @@ class AssetRegistry extends EventHandler {
      * const asset = app.assets.get(100);
      */
     get(id) {
-        return this._idToAsset.get(id);
+        // Since some apps incorrectly pass the id as a string, force a conversion to a number
+        return this._idToAsset.get(Number(id));
     }
 
     /**


### PR DESCRIPTION
Allow `AssetRegistry#get` to accept strings for the purpose of backwards compatibility.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
