### PR TITLE
Fix script hotreload

### DIFF
--- a/src/framework/handlers/script.js
+++ b/src/framework/handlers/script.js
@@ -1,5 +1,6 @@
 import { script } from '../script.js';
 import { ScriptTypes } from '../script/script-types.js';
+import { ResourceLoader } from './loader.js';
 
 /** @typedef {import('./handler.js').ResourceHandler} ResourceHandler */
 
@@ -71,7 +72,7 @@ class ScriptHandler {
                     callback(null, obj, extra);
 
                     // no cache for scripts
-                    delete self._loader._cache[url + 'script'];
+                    delete self._loader._cache[ResourceLoader.makeKey(url, 'script')];
                 }
             } else {
                 callback(err);


### PR DESCRIPTION
Fixes https://forum.playcanvas.com/t/script-swapping-feature-doesnt-work-anymore/32000

PR https://github.com/playcanvas/engine/pull/5412 changed the internal format of loader cache keys, but script asset was building these itself.

Result was scripts were being cached and hot reload didn't work.