### PR TITLE
Fixes Adreno 610 and 618 bugs

### DIFF
--- a/examples/src/examples/graphics/mrt.tsx
+++ b/examples/src/examples/graphics/mrt.tsx
@@ -12,10 +12,10 @@ class MrtExample {
         'output.frag': /* glsl */`
             #ifdef MYMRT_PASS
                 // output world normal to target 1
-                pcFragColor1 = vec4(litShaderArgs.worldNormal * 0.5 + 0.5, 1.0);
+                pcFragColor1 = vec4(litShaderArgs_worldNormal * 0.5 + 0.5, 1.0);
 
                 // output gloss to target 2
-                pcFragColor2 = vec4(vec3(litShaderArgs.gloss) , 1.0);
+                pcFragColor2 = vec4(vec3(litShaderArgs_gloss) , 1.0);
             #endif
         `
     };

--- a/examples/src/examples/graphics/mrt.tsx
+++ b/examples/src/examples/graphics/mrt.tsx
@@ -12,10 +12,10 @@ class MrtExample {
         'output.frag': /* glsl */`
             #ifdef MYMRT_PASS
                 // output world normal to target 1
-                pcFragColor1 = vec4(litShaderArgs_worldNormal * 0.5 + 0.5, 1.0);
+                pcFragColor1 = vec4(litArgs_worldNormal * 0.5 + 0.5, 1.0);
 
                 // output gloss to target 2
-                pcFragColor2 = vec4(vec3(litShaderArgs_gloss) , 1.0);
+                pcFragColor2 = vec4(vec3(litArgs_gloss) , 1.0);
             #endif
         `
     };

--- a/src/platform/graphics/constants.js
+++ b/src/platform/graphics/constants.js
@@ -1326,3 +1326,4 @@ export const CHUNKAPI_1_57 = '1.57';
 export const CHUNKAPI_1_58 = '1.58';
 export const CHUNKAPI_1_60 = '1.60';
 export const CHUNKAPI_1_62 = '1.62';
+export const CHUNKAPI_1_65 = '1.65';

--- a/src/scene/shader-lib/chunks/chunk-validation.js
+++ b/src/scene/shader-lib/chunks/chunk-validation.js
@@ -1,4 +1,4 @@
-import { CHUNKAPI_1_51, CHUNKAPI_1_55, CHUNKAPI_1_56, CHUNKAPI_1_57, CHUNKAPI_1_60, CHUNKAPI_1_62 } from '../../../platform/graphics/constants.js';
+import { CHUNKAPI_1_51, CHUNKAPI_1_55, CHUNKAPI_1_56, CHUNKAPI_1_57, CHUNKAPI_1_60, CHUNKAPI_1_62, CHUNKAPI_1_65 } from '../../../platform/graphics/constants.js';
 import { Debug } from '../../../core/debug.js';
 import { shaderChunks } from './chunks.js';
 
@@ -53,8 +53,7 @@ const chunkVersions = {
     lightSpecularPhongPS: CHUNKAPI_1_62,
     lightmapAddPS: CHUNKAPI_1_62,
     lightmapDirAddPS: CHUNKAPI_1_62,
-    ltcPS: CHUNKAPI_1_62,
-    metalnessModulatePS: CHUNKAPI_1_62,
+    ltcPS: CHUNKAPI_1_62,    
     outputAlphaPS: CHUNKAPI_1_62,
     outputAlphaPremulPS: CHUNKAPI_1_62,
     reflDirPS: CHUNKAPI_1_62,
@@ -80,7 +79,9 @@ const chunkVersions = {
     TBNPS: CHUNKAPI_1_62,
     TBNObjectSpacePS: CHUNKAPI_1_62,
     TBNderivativePS: CHUNKAPI_1_62,
-    TBNfastPS: CHUNKAPI_1_62
+    TBNfastPS: CHUNKAPI_1_62,
+
+    metalnessModulatePS: CHUNKAPI_1_65
 };
 
 // removed

--- a/src/scene/shader-lib/chunks/chunk-validation.js
+++ b/src/scene/shader-lib/chunks/chunk-validation.js
@@ -41,7 +41,6 @@ const chunkVersions = {
     clusteredLightPS: CHUNKAPI_1_62,
     clusteredLightShadowPS: CHUNKAPI_1_62,
     combinePS: CHUNKAPI_1_62,
-    endPS: CHUNKAPI_1_62,
     falloffInvSquaredPS: CHUNKAPI_1_62,
     falloffLinearPS: CHUNKAPI_1_62,
     fresnelSchlickPS: CHUNKAPI_1_62,
@@ -54,8 +53,6 @@ const chunkVersions = {
     lightmapAddPS: CHUNKAPI_1_62,
     lightmapDirAddPS: CHUNKAPI_1_62,
     ltcPS: CHUNKAPI_1_62,
-    outputAlphaPS: CHUNKAPI_1_62,
-    outputAlphaPremulPS: CHUNKAPI_1_62,
     reflDirPS: CHUNKAPI_1_62,
     reflDirAnisoPS: CHUNKAPI_1_62,
     reflectionCCPS: CHUNKAPI_1_62,
@@ -81,7 +78,10 @@ const chunkVersions = {
     TBNderivativePS: CHUNKAPI_1_62,
     TBNfastPS: CHUNKAPI_1_62,
 
-    metalnessModulatePS: CHUNKAPI_1_65
+    endPS: CHUNKAPI_1_65,
+    metalnessModulatePS: CHUNKAPI_1_65,
+    outputAlphaPS: CHUNKAPI_1_65,
+    outputAlphaPremulPS: CHUNKAPI_1_65
 };
 
 // removed

--- a/src/scene/shader-lib/chunks/chunk-validation.js
+++ b/src/scene/shader-lib/chunks/chunk-validation.js
@@ -53,7 +53,7 @@ const chunkVersions = {
     lightSpecularPhongPS: CHUNKAPI_1_62,
     lightmapAddPS: CHUNKAPI_1_62,
     lightmapDirAddPS: CHUNKAPI_1_62,
-    ltcPS: CHUNKAPI_1_62,    
+    ltcPS: CHUNKAPI_1_62,
     outputAlphaPS: CHUNKAPI_1_62,
     outputAlphaPremulPS: CHUNKAPI_1_62,
     reflDirPS: CHUNKAPI_1_62,

--- a/src/scene/shader-lib/chunks/lit/frag/clusteredLight.js
+++ b/src/scene/shader-lib/chunks/lit/frag/clusteredLight.js
@@ -333,9 +333,10 @@ void evaluateLight(
 #if defined(LIT_IRIDESCENCE)
     vec3 iridescenceFresnel,
 #endif
-    ClearcoatArgs clearcoat, 
-    SheenArgs sheen, 
-    IridescenceArgs iridescence
+    vec3 clearcoat_worldNormal,
+    float clearcoat_gloss,
+    float sheen_gloss,
+    float iridescence_intensity
 ) {
 
     vec3 cookieAttenuation = vec3(1.0);
@@ -524,11 +525,11 @@ void evaluateLight(
                     float areaLightSpecularCC;
 
                     if (isClusteredLightRect(light)) {
-                        areaLightSpecularCC = getRectLightSpecular(clearcoat.worldNormal, viewDir);
+                        areaLightSpecularCC = getRectLightSpecular(clearcoat_worldNormal, viewDir);
                     } else if (isClusteredLightDisk(light)) {
-                        areaLightSpecularCC = getDiskLightSpecular(clearcoat.worldNormal, viewDir);
+                        areaLightSpecularCC = getDiskLightSpecular(clearcoat_worldNormal, viewDir);
                     } else { // sphere
-                        areaLightSpecularCC = getSphereLightSpecular(clearcoat.worldNormal, viewDir);
+                        areaLightSpecularCC = getSphereLightSpecular(clearcoat_worldNormal, viewDir);
                     }
 
                     ccSpecularLight += ccLTCSpecFres * areaLightSpecularCC * falloffAttenuation * light.color  * cookieAttenuation;
@@ -573,7 +574,7 @@ void evaluateLight(
                             specularity
                         #if defined(LIT_IRIDESCENCE)
                             , iridescenceFresnel,
-                            iridescence
+                            iridescence_intensity
                         #endif
                             );
                 #else
@@ -582,14 +583,14 @@ void evaluateLight(
 
                 #ifdef LIT_CLEARCOAT
                     #ifdef LIT_SPECULAR_FRESNEL
-                        ccSpecularLight += getLightSpecular(halfDir, clearcoatReflectionDir, clearcoat.worldNormal, viewDir, dLightDirNormW, clearcoat.gloss, tbn) * falloffAttenuation * light.color * cookieAttenuation * getFresnelCC(dot(viewDir, halfDir));
+                        ccSpecularLight += getLightSpecular(halfDir, clearcoatReflectionDir, clearcoat_worldNormal, viewDir, dLightDirNormW, clearcoat_gloss, tbn) * falloffAttenuation * light.color * cookieAttenuation * getFresnelCC(dot(viewDir, halfDir));
                     #else
-                        ccSpecularLight += getLightSpecular(halfDir, clearcoatReflectionDir, clearcoat.worldNormal, viewDir, dLightDirNormW, clearcoat.gloss, tbn) * falloffAttenuation * light.color * cookieAttenuation; 
+                        ccSpecularLight += getLightSpecular(halfDir, clearcoatReflectionDir, clearcoat_worldNormal, viewDir, dLightDirNormW, clearcoat_gloss, tbn) * falloffAttenuation * light.color * cookieAttenuation; 
                     #endif
                 #endif
 
                 #ifdef LIT_SHEEN
-                    sSpecularLight += getLightSpecularSheen(halfDir, worldNormal, viewDir, dLightDirNormW, sheen.gloss) * falloffAttenuation * light.color * cookieAttenuation;
+                    sSpecularLight += getLightSpecularSheen(halfDir, worldNormal, viewDir, dLightDirNormW, sheen_gloss) * falloffAttenuation * light.color * cookieAttenuation;
                 #endif
 
             #endif
@@ -617,9 +618,10 @@ void evaluateClusterLight(
 #if defined(LIT_IRIDESCENCE)
     vec3 iridescenceFresnel,
 #endif
-    ClearcoatArgs clearcoat, 
-    SheenArgs sheen, 
-    IridescenceArgs iridescence
+    vec3 clearcoat_worldNormal,
+    float clearcoat_gloss,
+    float sheen_gloss,
+    float iridescence_intensity
 ) {
 
     // decode core light data from textures
@@ -643,9 +645,10 @@ void evaluateClusterLight(
 #if defined(LIT_IRIDESCENCE)
             iridescenceFresnel,
 #endif
-            clearcoat, 
-            sheen, 
-            iridescence
+            clearcoat_worldNormal,
+            clearcoat_gloss,
+            sheen_gloss,
+            iridescence_intensity
         );
 }
 
@@ -663,9 +666,10 @@ void addClusteredLights(
 #if defined(LIT_IRIDESCENCE)
     vec3 iridescenceFresnel,
 #endif
-    ClearcoatArgs clearcoat, 
-    SheenArgs sheen, 
-    IridescenceArgs iridescence
+    vec3 clearcoat_worldNormal,
+    float clearcoat_gloss,
+    float sheen_gloss,
+    float iridescence_intensity
 ) {
 
     // skip lights if no lights at all
@@ -711,9 +715,10 @@ void addClusteredLights(
 #if defined(LIT_IRIDESCENCE)
                     iridescenceFresnel,
 #endif
-                    clearcoat, 
-                    sheen, 
-                    iridescence
+                    clearcoat_worldNormal,
+                    clearcoat_gloss,
+                    sheen_gloss,
+                    iridescence_intensity
                 ); 
             }
 
@@ -745,9 +750,10 @@ void addClusteredLights(
 #if defined(LIT_IRIDESCENCE)
                     iridescenceFresnel,
 #endif
-                    clearcoat, 
-                    sheen, 
-                    iridescence
+                    clearcoat_worldNormal,
+                    clearcoat_gloss,
+                    sheen_gloss,
+                    iridescence_intensity
                 ); 
                 // end of the cell array
                 if (lightCellIndex >= clusterMaxCells) {

--- a/src/scene/shader-lib/chunks/lit/frag/debug-output.js
+++ b/src/scene/shader-lib/chunks/lit/frag/debug-output.js
@@ -1,37 +1,37 @@
 export default /* glsl */`
 #ifdef DEBUG_ALBEDO_PASS
-gl_FragColor = vec4(gammaCorrectOutput(litShaderArgs_albedo), 1.0);
+gl_FragColor = vec4(gammaCorrectOutput(litArgs_albedo), 1.0);
 #endif
 
 #ifdef DEBUG_UV0_PASS
-gl_FragColor = vec4(litShaderArgs_albedo , 1.0);
+gl_FragColor = vec4(litArgs_albedo , 1.0);
 #endif
 
 #ifdef DEBUG_WORLD_NORMAL_PASS
-gl_FragColor = vec4(litShaderArgs_worldNormal * 0.5 + 0.5, 1.0);
+gl_FragColor = vec4(litArgs_worldNormal * 0.5 + 0.5, 1.0);
 #endif
 
 #ifdef DEBUG_OPACITY_PASS
-gl_FragColor = vec4(vec3(litShaderArgs_opacity) , 1.0);
+gl_FragColor = vec4(vec3(litArgs_opacity) , 1.0);
 #endif
 
 #ifdef DEBUG_SPECULARITY_PASS
-gl_FragColor = vec4(litShaderArgs_specularity, 1.0);
+gl_FragColor = vec4(litArgs_specularity, 1.0);
 #endif
 
 #ifdef DEBUG_GLOSS_PASS
-gl_FragColor = vec4(vec3(litShaderArgs_gloss) , 1.0);
+gl_FragColor = vec4(vec3(litArgs_gloss) , 1.0);
 #endif
 
 #ifdef DEBUG_METALNESS_PASS
-gl_FragColor = vec4(vec3(litShaderArgs_metalness) , 1.0);
+gl_FragColor = vec4(vec3(litArgs_metalness) , 1.0);
 #endif
 
 #ifdef DEBUG_AO_PASS
-gl_FragColor = vec4(vec3(litShaderArgs_ao) , 1.0);
+gl_FragColor = vec4(vec3(litArgs_ao) , 1.0);
 #endif
 
 #ifdef DEBUG_EMISSION_PASS
-gl_FragColor = vec4(gammaCorrectOutput(litShaderArgs_emission), 1.0);
+gl_FragColor = vec4(gammaCorrectOutput(litArgs_emission), 1.0);
 #endif
 `;

--- a/src/scene/shader-lib/chunks/lit/frag/debug-output.js
+++ b/src/scene/shader-lib/chunks/lit/frag/debug-output.js
@@ -1,37 +1,37 @@
 export default /* glsl */`
 #ifdef DEBUG_ALBEDO_PASS
-gl_FragColor = vec4(gammaCorrectOutput(litShaderArgs.albedo), 1.0);
+gl_FragColor = vec4(gammaCorrectOutput(litShaderArgs_albedo), 1.0);
 #endif
 
 #ifdef DEBUG_UV0_PASS
-gl_FragColor = vec4(litShaderArgs.albedo , 1.0);
+gl_FragColor = vec4(litShaderArgs_albedo , 1.0);
 #endif
 
 #ifdef DEBUG_WORLD_NORMAL_PASS
-gl_FragColor = vec4(litShaderArgs.worldNormal * 0.5 + 0.5, 1.0);
+gl_FragColor = vec4(litShaderArgs_worldNormal * 0.5 + 0.5, 1.0);
 #endif
 
 #ifdef DEBUG_OPACITY_PASS
-gl_FragColor = vec4(vec3(litShaderArgs.opacity) , 1.0);
+gl_FragColor = vec4(vec3(litShaderArgs_opacity) , 1.0);
 #endif
 
 #ifdef DEBUG_SPECULARITY_PASS
-gl_FragColor = vec4(litShaderArgs.specularity, 1.0);
+gl_FragColor = vec4(litShaderArgs_specularity, 1.0);
 #endif
 
 #ifdef DEBUG_GLOSS_PASS
-gl_FragColor = vec4(vec3(litShaderArgs.gloss) , 1.0);
+gl_FragColor = vec4(vec3(litShaderArgs_gloss) , 1.0);
 #endif
 
 #ifdef DEBUG_METALNESS_PASS
-gl_FragColor = vec4(vec3(litShaderArgs.metalness) , 1.0);
+gl_FragColor = vec4(vec3(litShaderArgs_metalness) , 1.0);
 #endif
 
 #ifdef DEBUG_AO_PASS
-gl_FragColor = vec4(vec3(litShaderArgs.ao) , 1.0);
+gl_FragColor = vec4(vec3(litShaderArgs_ao) , 1.0);
 #endif
 
 #ifdef DEBUG_EMISSION_PASS
-gl_FragColor = vec4(gammaCorrectOutput(litShaderArgs.emission), 1.0);
+gl_FragColor = vec4(gammaCorrectOutput(litShaderArgs_emission), 1.0);
 #endif
 `;

--- a/src/scene/shader-lib/chunks/lit/frag/debug-process-frontend.js
+++ b/src/scene/shader-lib/chunks/lit/frag/debug-process-frontend.js
@@ -1,13 +1,13 @@
 export default /* glsl */`
 #ifdef DEBUG_LIGHTING_PASS
-litShaderArgs_albedo = vec3(0.5);
+litArgs_albedo = vec3(0.5);
 #endif
 
 #ifdef DEBUG_UV0_PASS
 #ifdef VARYING_VUV0
-litShaderArgs_albedo = vec3(vUv0, 0);
+litArgs_albedo = vec3(vUv0, 0);
 #else
-litShaderArgs_albedo = vec3(0);
+litArgs_albedo = vec3(0);
 #endif
 #endif
 `;

--- a/src/scene/shader-lib/chunks/lit/frag/debug-process-frontend.js
+++ b/src/scene/shader-lib/chunks/lit/frag/debug-process-frontend.js
@@ -1,13 +1,13 @@
 export default /* glsl */`
 #ifdef DEBUG_LIGHTING_PASS
-litShaderArgs.albedo = vec3(0.5);
+litShaderArgs_albedo = vec3(0.5);
 #endif
 
 #ifdef DEBUG_UV0_PASS
 #ifdef VARYING_VUV0
-litShaderArgs.albedo = vec3(vUv0, 0);
+litShaderArgs_albedo = vec3(vUv0, 0);
 #else
-litShaderArgs.albedo = vec3(0);
+litShaderArgs_albedo = vec3(0);
 #endif
 #endif
 `;

--- a/src/scene/shader-lib/chunks/lit/frag/end.js
+++ b/src/scene/shader-lib/chunks/lit/frag/end.js
@@ -1,7 +1,7 @@
 export default /* glsl */`
-    gl_FragColor.rgb = combineColor(litShaderArgs_albedo, litShaderArgs_sheen_specularity, litShaderArgs_clearcoat_specularity);
+    gl_FragColor.rgb = combineColor(litArgs_albedo, litArgs_sheen_specularity, litArgs_clearcoat_specularity);
 
-    gl_FragColor.rgb += litShaderArgs_emission;
+    gl_FragColor.rgb += litArgs_emission;
     gl_FragColor.rgb = addFog(gl_FragColor.rgb);
 
     #ifndef HDR

--- a/src/scene/shader-lib/chunks/lit/frag/end.js
+++ b/src/scene/shader-lib/chunks/lit/frag/end.js
@@ -1,7 +1,7 @@
 export default /* glsl */`
-    gl_FragColor.rgb = combineColor(litShaderArgs.albedo, litShaderArgs.sheen.specularity, litShaderArgs.clearcoat.specularity);
+    gl_FragColor.rgb = combineColor(litShaderArgs_albedo, litShaderArgs_sheen_specularity, litShaderArgs_clearcoat_specularity);
 
-    gl_FragColor.rgb += litShaderArgs.emission;
+    gl_FragColor.rgb += litShaderArgs_emission;
     gl_FragColor.rgb = addFog(gl_FragColor.rgb);
 
     #ifndef HDR

--- a/src/scene/shader-lib/chunks/lit/frag/metalnessModulate.js
+++ b/src/scene/shader-lib/chunks/lit/frag/metalnessModulate.js
@@ -2,9 +2,12 @@ export default /* glsl */`
 
 uniform float material_f0;
 
-void getMetalnessModulate(inout LitShaderArguments litShaderArgs) {
-    vec3 dielectricF0 = material_f0 * litShaderArgs.specularity;
-    litShaderArgs.specularity = mix(dielectricF0, litShaderArgs.albedo, litShaderArgs.metalness);
-    litShaderArgs.albedo *= 1.0 - litShaderArgs.metalness;
+vec3 getSpecularModulate(in vec3 specularity, in vec3 albedo, in float metalness) {
+    vec3 dielectricF0 = material_f0 * specularity;
+    return mix(dielectricF0, albedo, metalness);
+}
+
+vec3 getAlbedoModulate(in vec3 albedo, in float metalness) {
+    return albedo * (1.0 - metalness);
 }
 `;

--- a/src/scene/shader-lib/chunks/lit/frag/outputAlpha.js
+++ b/src/scene/shader-lib/chunks/lit/frag/outputAlpha.js
@@ -1,3 +1,3 @@
 export default /* glsl */`
-gl_FragColor.a = litShaderArgs.opacity;
+gl_FragColor.a = litShaderArgs_opacity;
 `;

--- a/src/scene/shader-lib/chunks/lit/frag/outputAlpha.js
+++ b/src/scene/shader-lib/chunks/lit/frag/outputAlpha.js
@@ -1,3 +1,3 @@
 export default /* glsl */`
-gl_FragColor.a = litShaderArgs_opacity;
+gl_FragColor.a = litArgs_opacity;
 `;

--- a/src/scene/shader-lib/chunks/lit/frag/outputAlphaPremul.js
+++ b/src/scene/shader-lib/chunks/lit/frag/outputAlphaPremul.js
@@ -1,4 +1,4 @@
 export default /* glsl */`
-gl_FragColor.rgb *= litShaderArgs_opacity;
-gl_FragColor.a = litShaderArgs_opacity;
+gl_FragColor.rgb *= litArgs_opacity;
+gl_FragColor.a = litArgs_opacity;
 `;

--- a/src/scene/shader-lib/chunks/lit/frag/outputAlphaPremul.js
+++ b/src/scene/shader-lib/chunks/lit/frag/outputAlphaPremul.js
@@ -1,4 +1,4 @@
 export default /* glsl */`
-gl_FragColor.rgb *= litShaderArgs.opacity;
-gl_FragColor.a = litShaderArgs.opacity;
+gl_FragColor.rgb *= litShaderArgs_opacity;
+gl_FragColor.a = litShaderArgs_opacity;
 `;

--- a/src/scene/shader-lib/chunks/standard/frag/litShaderArgs.js
+++ b/src/scene/shader-lib/chunks/standard/frag/litShaderArgs.js
@@ -1,24 +1,63 @@
 export default /* glsl */`
 
+// Normal direction in world space
 vec3 litShaderArgs_worldNormal;
+
+// Transparency
 float litShaderArgs_opacity;
+
+// Surface albedo absorbance
 vec3 litShaderArgs_albedo;
+
+// Transmission factor (refraction), range [0..1]
 float litShaderArgs_transmission;
+
+// The f0 specularity factor
 vec3 litShaderArgs_specularity;
+
+// Uniform thickness of medium, used by transmission, range [0..inf]
 float litShaderArgs_thickness;
+
+// Emission color
 vec3 litShaderArgs_emission;
+
+// Ambient occlusion amount, range [0..1]
 float litShaderArgs_ao;
+
+// Light map color
 vec3 litShaderArgs_lightmap;
+
+// Specularity intensity factor, range [0..1]
 float litShaderArgs_specularityFactor;
+
+// Light map direction
 vec3 litShaderArgs_lightmapDir;
+
+// The microfacet glossiness factor, range [0..1]
 float litShaderArgs_gloss;
+
+// Iridescence effect intensity, range [0..1]
 float litShaderArgs_iridescence_intensity;
+
+// Thickness of the iridescent microfilm layer, value is in nanometers, range [0..1000]
 float litShaderArgs_iridescence_thickness;
+
+// The normal used for the clearcoat layer
 vec3 litShaderArgs_clearcoat_worldNormal;
+
+// Intensity of the clearcoat layer, range [0..1]
 float litShaderArgs_clearcoat_specularity;
+
+// Glossiness of clearcoat layer, range [0..1]
 float litShaderArgs_clearcoat_gloss;
+
+// Surface metalness factor, range [0..1]
 float litShaderArgs_metalness;
+
+// The color of the f0 specularity factor for the sheen layer
 vec3 litShaderArgs_sheen_specularity;
+
+// Glossiness of the sheen layer, range [0..1]
 float litShaderArgs_sheen_gloss;
 
 `;

--- a/src/scene/shader-lib/chunks/standard/frag/litShaderArgs.js
+++ b/src/scene/shader-lib/chunks/standard/frag/litShaderArgs.js
@@ -1,63 +1,63 @@
 export default /* glsl */`
 
 // Normal direction in world space
-vec3 litShaderArgs_worldNormal;
+vec3 litArgs_worldNormal;
 
 // Transparency
-float litShaderArgs_opacity;
+float litArgs_opacity;
 
 // Surface albedo absorbance
-vec3 litShaderArgs_albedo;
+vec3 litArgs_albedo;
 
 // Transmission factor (refraction), range [0..1]
-float litShaderArgs_transmission;
+float litArgs_transmission;
 
 // The f0 specularity factor
-vec3 litShaderArgs_specularity;
+vec3 litArgs_specularity;
 
 // Uniform thickness of medium, used by transmission, range [0..inf]
-float litShaderArgs_thickness;
+float litArgs_thickness;
 
 // Emission color
-vec3 litShaderArgs_emission;
+vec3 litArgs_emission;
 
 // Ambient occlusion amount, range [0..1]
-float litShaderArgs_ao;
+float litArgs_ao;
 
 // Light map color
-vec3 litShaderArgs_lightmap;
+vec3 litArgs_lightmap;
 
 // Specularity intensity factor, range [0..1]
-float litShaderArgs_specularityFactor;
+float litArgs_specularityFactor;
 
 // Light map direction
-vec3 litShaderArgs_lightmapDir;
+vec3 litArgs_lightmapDir;
 
 // The microfacet glossiness factor, range [0..1]
-float litShaderArgs_gloss;
+float litArgs_gloss;
 
 // Iridescence effect intensity, range [0..1]
-float litShaderArgs_iridescence_intensity;
+float litArgs_iridescence_intensity;
 
 // Thickness of the iridescent microfilm layer, value is in nanometers, range [0..1000]
-float litShaderArgs_iridescence_thickness;
+float litArgs_iridescence_thickness;
 
 // The normal used for the clearcoat layer
-vec3 litShaderArgs_clearcoat_worldNormal;
+vec3 litArgs_clearcoat_worldNormal;
 
 // Intensity of the clearcoat layer, range [0..1]
-float litShaderArgs_clearcoat_specularity;
+float litArgs_clearcoat_specularity;
 
 // Glossiness of clearcoat layer, range [0..1]
-float litShaderArgs_clearcoat_gloss;
+float litArgs_clearcoat_gloss;
 
 // Surface metalness factor, range [0..1]
-float litShaderArgs_metalness;
+float litArgs_metalness;
 
 // The color of the f0 specularity factor for the sheen layer
-vec3 litShaderArgs_sheen_specularity;
+vec3 litArgs_sheen_specularity;
 
 // Glossiness of the sheen layer, range [0..1]
-float litShaderArgs_sheen_gloss;
+float litArgs_sheen_gloss;
 
 `;

--- a/src/scene/shader-lib/chunks/standard/frag/litShaderArgs.js
+++ b/src/scene/shader-lib/chunks/standard/frag/litShaderArgs.js
@@ -1,82 +1,24 @@
 export default /* glsl */`
 
-struct IridescenceArgs
-{
-    // Iridescence effect intensity, range [0..1]
-    float intensity;
+vec3 litShaderArgs_worldNormal;
+float litShaderArgs_opacity;
+vec3 litShaderArgs_albedo;
+float litShaderArgs_transmission;
+vec3 litShaderArgs_specularity;
+float litShaderArgs_thickness;
+vec3 litShaderArgs_emission;
+float litShaderArgs_ao;
+vec3 litShaderArgs_lightmap;
+float litShaderArgs_specularityFactor;
+vec3 litShaderArgs_lightmapDir;
+float litShaderArgs_gloss;
+float litShaderArgs_iridescence_intensity;
+float litShaderArgs_iridescence_thickness;
+vec3 litShaderArgs_clearcoat_worldNormal;
+float litShaderArgs_clearcoat_specularity;
+float litShaderArgs_clearcoat_gloss;
+float litShaderArgs_metalness;
+vec3 litShaderArgs_sheen_specularity;
+float litShaderArgs_sheen_gloss;
 
-    // Thickness of the iridescent microfilm layer, value is in nanometers, range [0..1000]
-    float thickness;
-};
-
-struct ClearcoatArgs
-{
-    // The normal used for the clearcoat layer
-    vec3 worldNormal;
-
-    // Intensity of the clearcoat layer, range [0..1]
-    float specularity;
-
-    // Glossiness of clearcoat layer, range [0..1]
-    float gloss;
-};
-
-struct SheenArgs
-{
-    // The color of the f0 specularity factor for the sheen layer
-    vec3 specularity;
-
-    // Glossiness of the sheen layer, range [0..1]
-    float gloss;
-};
-
-struct LitShaderArguments {
-    // Normal direction in world space
-    vec3 worldNormal;
-
-    // Transparency
-    float opacity;
-
-    // Surface albedo absorbance
-    vec3 albedo;
-
-    // Transmission factor (refraction), range [0..1]
-    float transmission;
-
-    // The f0 specularity factor
-    vec3 specularity;
-
-    // Uniform thickness of medium, used by transmission, range [0..inf]
-    float thickness;
-
-    // Emission color
-    vec3 emission;
-
-    // Ambient occlusion amount, range [0..1]
-    float ao;
-
-    // Light map color
-    vec3 lightmap;
-
-    // Specularity intensity factor, range [0..1]
-    float specularityFactor;
-
-    // Light map direction
-    vec3 lightmapDir;
-
-    // The microfacet glossiness factor, range [0..1]
-    float gloss;
-
-    // Iridescence extension arguments
-    IridescenceArgs iridescence;
-
-    // Clearcoat extension arguments
-    ClearcoatArgs clearcoat;
-
-    // Surface metalness factor, range [0..1]
-    float metalness;
-
-    // Sheen extension arguments
-    SheenArgs sheen;
-};
 `;

--- a/src/scene/shader-lib/programs/lit-shader.js
+++ b/src/scene/shader-lib/programs/lit-shader.js
@@ -1017,28 +1017,29 @@ class LitShader {
         // transform tangent space normals to world space
         if (this.needsNormal) {
             if (options.useSpecular) {
-                backend.append("    getReflDir(litShaderArgs.worldNormal, dViewDirW, litShaderArgs.gloss, dTBN);");
+                backend.append("    getReflDir(litShaderArgs_worldNormal, dViewDirW, litShaderArgs_gloss, dTBN);");
             }
 
             if (options.useClearCoat) {
-                backend.append("    ccReflDirW = normalize(-reflect(dViewDirW, litShaderArgs.clearcoat.worldNormal));");
+                backend.append("    ccReflDirW = normalize(-reflect(dViewDirW, litShaderArgs_clearcoat_worldNormal));");
             }
         }
 
         if ((this.lighting && options.useSpecular) || this.reflections) {
             if (options.useMetalness) {
-                backend.append("    getMetalnessModulate(litShaderArgs);");
+                backend.append("    litShaderArgs_specularity = getSpecularModulate(litShaderArgs_specularity, litShaderArgs_albedo, litShaderArgs_metalness);");
+                backend.append("    litShaderArgs_albedo = getAlbedoModulate(litShaderArgs_albedo, litShaderArgs_metalness);");
             }
 
             if (options.useIridescence) {
-                backend.append("    vec3 iridescenceFresnel = getIridescence(saturate(dot(dViewDirW, litShaderArgs.worldNormal)), litShaderArgs.specularity, litShaderArgs.iridescence);");
+                backend.append("    vec3 iridescenceFresnel = getIridescence(saturate(dot(dViewDirW, litShaderArgs_worldNormal)), litShaderArgs_specularity, litShaderArgs_iridescence);");
             }
         }
 
         if (addAmbient) {
-            backend.append("    addAmbient(litShaderArgs.worldNormal);");
+            backend.append("    addAmbient(litShaderArgs_worldNormal);");
             if (options.conserveEnergy && options.useSpecular) {
-                backend.append(`   dDiffuseLight = dDiffuseLight * (1.0 - litShaderArgs.specularity);`);
+                backend.append(`   dDiffuseLight = dDiffuseLight * (1.0 - litShaderArgs_specularity);`);
             }
 
             // move ambient color out of diffuse (used by Lightmapper, to multiply ambient color by accumulated AO)
@@ -1055,23 +1056,23 @@ class LitShader {
         }
 
         if (useAo && !options.occludeDirect) {
-            backend.append("    occludeDiffuse(litShaderArgs.ao);");
+            backend.append("    occludeDiffuse(litShaderArgs_ao);");
         }
 
         if (options.lightMapEnabled || options.useLightMapVertexColors) {
             backend.append(`    addLightMap(
-                litShaderArgs.lightmap, 
-                litShaderArgs.lightmapDir, 
-                litShaderArgs.worldNormal, 
+                litShaderArgs_lightmap, 
+                litShaderArgs_lightmapDir, 
+                litShaderArgs_worldNormal, 
                 dViewDirW, 
                 dReflDirW, 
-                litShaderArgs.gloss, 
-                litShaderArgs.specularity, 
+                litShaderArgs_gloss, 
+                litShaderArgs_specularity, 
                 dVertexNormalW,
                 dTBN
             #if defined(LIT_IRIDESCENCE)
                 , iridescenceFresnel,
-                litShaderArgs.iridescence
+                litShaderArgs_iridescence
             #endif
                 );`);
         }
@@ -1079,52 +1080,52 @@ class LitShader {
         if (this.lighting || this.reflections) {
             if (this.reflections) {
                 if (options.useClearCoat) {
-                    backend.append("    addReflectionCC(ccReflDirW, litShaderArgs.clearcoat.gloss);");
+                    backend.append("    addReflectionCC(ccReflDirW, litShaderArgs_clearcoat_gloss);");
                     if (options.fresnelModel > 0) {
-                        backend.append("    ccFresnel = getFresnelCC(dot(dViewDirW, litShaderArgs.clearcoat.worldNormal));");
+                        backend.append("    ccFresnel = getFresnelCC(dot(dViewDirW, litShaderArgs_clearcoat_worldNormal));");
                         backend.append("    ccReflection.rgb *= ccFresnel;");
                     } else {
                         backend.append("    ccFresnel = 0.0;");
                     }
                 }
                 if (options.useSpecularityFactor) {
-                    backend.append("    ccReflection.rgb *= litShaderArgs.specularityFactor;");
+                    backend.append("    ccReflection.rgb *= litShaderArgs_specularityFactor;");
                 }
 
                 if (options.useSheen) {
-                    backend.append("    addReflectionSheen(litShaderArgs.worldNormal, dViewDirW, litShaderArgs.sheen.gloss);");
+                    backend.append("    addReflectionSheen(litShaderArgs_worldNormal, dViewDirW, litShaderArgs_sheen_gloss);");
                 }
 
                 // Fresnel has to be applied to reflections
-                backend.append("    addReflection(dReflDirW, litShaderArgs.gloss);");
+                backend.append("    addReflection(dReflDirW, litShaderArgs_gloss);");
 
                 if (options.fresnelModel > 0) {
                     backend.append(`    dReflection.rgb *= 
                         getFresnel(
-                            dot(dViewDirW, litShaderArgs.worldNormal), 
-                            litShaderArgs.gloss, 
-                            litShaderArgs.specularity
+                            dot(dViewDirW, litShaderArgs_worldNormal), 
+                            litShaderArgs_gloss, 
+                            litShaderArgs_specularity
                         #if defined(LIT_IRIDESCENCE)
                             , iridescenceFresnel,
-                            litShaderArgs.iridescence
+                            litShaderArgs_iridescence
                         #endif
                             );`);
                 } else {
-                    backend.append("    dReflection.rgb *= litShaderArgs.specularity;");
+                    backend.append("    dReflection.rgb *= litShaderArgs_specularity;");
                 }
                 if (options.useSpecularityFactor) {
-                    backend.append("    dReflection.rgb *= litShaderArgs.specularityFactor;");
+                    backend.append("    dReflection.rgb *= litShaderArgs_specularityFactor;");
                 }
             }
 
             if (hasAreaLights) {
                 // specular has to be accumulated differently if we want area lights to look correct
-                backend.append("    dSpecularLight *= litShaderArgs.specularity;");
+                backend.append("    dSpecularLight *= litShaderArgs_specularity;");
                 // code += "    float roughness = max((1.0 - dGlossiness) * (1.0 - dGlossiness), 0.001);\n";
 
                 // evaluate material based area lights data, shared by all area lights
                 if (options.useSpecular) {
-                    backend.append("    calcLTCLightValues(litShaderArgs.gloss, litShaderArgs.worldNormal, dViewDirW, litShaderArgs.specularity, litShaderArgs.clearcoat.gloss, litShaderArgs.clearcoat.worldNormal, litShaderArgs.clearcoat.specularity);");
+                    backend.append("    calcLTCLightValues(litShaderArgs_gloss, litShaderArgs_worldNormal, dViewDirW, litShaderArgs_specularity, litShaderArgs_clearcoat_gloss, litShaderArgs_clearcoat_worldNormal, litShaderArgs_clearcoat_specularity);");
                 }
             }
 
@@ -1209,13 +1210,13 @@ class LitShader {
                 if (lightShape !== LIGHTSHAPE_PUNCTUAL) {
                     if (lightType === LIGHTTYPE_DIRECTIONAL) {
                         // NB: A better aproximation perhaps using wrap lighting could be implemented here
-                        backend.append("    dAttenD = getLightDiffuse(litShaderArgs.worldNormal, dViewDirW, dLightDirW, dLightDirNormW);");
+                        backend.append("    dAttenD = getLightDiffuse(litShaderArgs_worldNormal, dViewDirW, dLightDirW, dLightDirNormW);");
                     } else {
                         // 16.0 is a constant that is in getFalloffInvSquared()
-                        backend.append("    dAttenD = get" + shapeString + "LightDiffuse(litShaderArgs.worldNormal, dViewDirW, dLightDirW, dLightDirNormW) * 16.0;");
+                        backend.append("    dAttenD = get" + shapeString + "LightDiffuse(litShaderArgs_worldNormal, dViewDirW, dLightDirW, dLightDirNormW) * 16.0;");
                     }
                 } else {
-                    backend.append("    dAtten *= getLightDiffuse(litShaderArgs.worldNormal, dViewDirW, dLightDirW, dLightDirNormW);");
+                    backend.append("    dAtten *= getLightDiffuse(litShaderArgs_worldNormal, dViewDirW, dLightDirW, dLightDirNormW);");
                 }
 
                 if (light.castShadows && !options.noShadow) {
@@ -1334,7 +1335,7 @@ class LitShader {
 
                     // punctual light
                     if (hasAreaLights && options.conserveEnergy && options.useSpecular) {
-                        backend.append("    dDiffuseLight += (dAtten * light" + i + "_color" + (usesCookieNow ? " * dAtten3" : "") + ") * (1.0 - litShaderArgs.specularity);");
+                        backend.append("    dDiffuseLight += (dAtten * light" + i + "_color" + (usesCookieNow ? " * dAtten3" : "") + ") * (1.0 - litShaderArgs_specularity);");
                     } else {
                         backend.append("    dDiffuseLight += dAtten * light" + i + "_color" + (usesCookieNow ? " * dAtten3" : "") + ";");
                     }
@@ -1350,10 +1351,10 @@ class LitShader {
 
                         // area light
                         if (options.useClearCoat) {
-                            backend.append(`    ccSpecularLight += ccLTCSpecFres * get${shapeString}LightSpecular(litShaderArgs.clearcoat.worldNormal, dViewDirW) * dAtten * light${i}_color` + (usesCookieNow ? " * dAtten3" : "") + ";");
+                            backend.append(`    ccSpecularLight += ccLTCSpecFres * get${shapeString}LightSpecular(litShaderArgs_clearcoat_worldNormal, dViewDirW) * dAtten * light${i}_color` + (usesCookieNow ? " * dAtten3" : "") + ";");
                         }
                         if (options.useSpecular) {
-                            backend.append(`    dSpecularLight += dLTCSpecFres * get${shapeString}LightSpecular(litShaderArgs.worldNormal, dViewDirW) * dAtten * light${i}_color` + (usesCookieNow ? " * dAtten3" : "") + ";");
+                            backend.append(`    dSpecularLight += dLTCSpecFres * get${shapeString}LightSpecular(litShaderArgs_worldNormal, dViewDirW) * dAtten * light${i}_color` + (usesCookieNow ? " * dAtten3" : "") + ";");
                         }
 
                     } else {
@@ -1364,27 +1365,27 @@ class LitShader {
 
                         // if LTC lights are present, specular must be accumulated with specularity (specularity is pre multiplied by punctual light fresnel)
                         if (options.useClearCoat) {
-                            backend.append(`    ccSpecularLight += getLightSpecular(dHalfDirW, ccReflDirW, litShaderArgs.clearcoat.worldNormal, dViewDirW, dLightDirNormW, litShaderArgs.clearcoat.gloss, dTBN) * dAtten * light${i}_color` +
+                            backend.append(`    ccSpecularLight += getLightSpecular(dHalfDirW, ccReflDirW, litShaderArgs_clearcoat_worldNormal, dViewDirW, dLightDirNormW, litShaderArgs_clearcoat_gloss, dTBN) * dAtten * light${i}_color` +
                                 (usesCookieNow ? " * dAtten3" : "") +
                                 (calcFresnel ? " * getFresnelCC(dot(dViewDirW, dHalfDirW));" : ";"));
                         }
                         if (options.useSheen) {
-                            backend.append(`    sSpecularLight += getLightSpecularSheen(dHalfDirW, litShaderArgs.worldNormal, dViewDirW, dLightDirNormW, litShaderArgs.sheen.gloss) * dAtten * light${i}_color` +
+                            backend.append(`    sSpecularLight += getLightSpecularSheen(dHalfDirW, litShaderArgs_worldNormal, dViewDirW, dLightDirNormW, litShaderArgs_sheen_gloss) * dAtten * light${i}_color` +
                                 (usesCookieNow ? " * dAtten3;" : ";"));
                         }
                         if (options.useSpecular) {
-                            backend.append(`    dSpecularLight += getLightSpecular(dHalfDirW, dReflDirW, litShaderArgs.worldNormal, dViewDirW, dLightDirNormW, litShaderArgs.gloss, dTBN) * dAtten * light${i}_color` +
+                            backend.append(`    dSpecularLight += getLightSpecular(dHalfDirW, dReflDirW, litShaderArgs_worldNormal, dViewDirW, dLightDirNormW, litShaderArgs_gloss, dTBN) * dAtten * light${i}_color` +
                                 (usesCookieNow ? " * dAtten3" : "") +
                                 (calcFresnel ? ` 
                                     * getFresnel(
                                         dot(dViewDirW, dHalfDirW), 
-                                        litShaderArgs.gloss, 
-                                        litShaderArgs.specularity
+                                        litShaderArgs_gloss, 
+                                        litShaderArgs_specularity
                                     #if defined(LIT_IRIDESCENCE)
                                         , iridescenceFresnel, 
-                                        litShaderArgs.iridescence
+                                        litShaderArgs_iridescence
                                     #endif
-                                    );` : `* litShaderArgs.specularity;`));
+                                    );` : `* litShaderArgs_specularity;`));
                         }
                     }
                 }
@@ -1400,47 +1401,48 @@ class LitShader {
                 usesInvSquaredFalloff = true;
                 hasPointLights = true;
                 backend.append(`    addClusteredLights(
-                                        litShaderArgs.worldNormal, 
+                                        litShaderArgs_worldNormal, 
                                         dViewDirW, 
                                         dReflDirW,
                                 #if defined(LIT_CLEARCOAT)
                                         ccReflDirW,
                                 #endif
-                                        litShaderArgs.gloss, 
-                                        litShaderArgs.specularity, 
+                                        litShaderArgs_gloss, 
+                                        litShaderArgs_specularity, 
                                         dVertexNormalW, 
                                         dTBN, 
                                 #if defined(LIT_IRIDESCENCE)
                                         iridescenceFresnel,
                                 #endif
-                                        litShaderArgs.clearcoat, 
-                                        litShaderArgs.sheen, 
-                                        litShaderArgs.iridescence
+                                        litShaderArgs_clearcoat_worldNormal, 
+                                        litShaderArgs_clearcoat_gloss,
+                                        litShaderArgs_sheen_gloss,
+                                        litShaderArgs_iridescence_intensity
                                     );`);
             }
 
             if (hasAreaLights) {
                 // specular has to be accumulated differently if we want area lights to look correct
                 if (options.useClearCoat) {
-                    backend.append("    litShaderArgs.clearcoat.specularity = 1.0;");
+                    backend.append("    litShaderArgs_clearcoat_specularity = 1.0;");
                 }
                 if (options.useSpecular) {
-                    backend.append("    litShaderArgs.specularity = vec3(1);");
+                    backend.append("    litShaderArgs_specularity = vec3(1);");
                 }
             }
 
             if (options.useRefraction) {
                 backend.append(`    addRefraction(
-                        litShaderArgs.worldNormal, 
+                        litShaderArgs_worldNormal, 
                         dViewDirW, 
-                        litShaderArgs.thickness, 
-                        litShaderArgs.gloss, 
-                        litShaderArgs.specularity, 
-                        litShaderArgs.albedo, 
-                        litShaderArgs.transmission
+                        litShaderArgs_thickness, 
+                        litShaderArgs_gloss, 
+                        litShaderArgs_specularity, 
+                        litShaderArgs_albedo, 
+                        litShaderArgs_transmission
                     #if defined(LIT_IRIDESCENCE)
                         , iridescenceFresnel, 
-                        litShaderArgs.iridescence
+                        litShaderArgs_iridescence
                     #endif
                     );`);
             }
@@ -1448,24 +1450,24 @@ class LitShader {
 
         if (useAo) {
             if (options.occludeDirect) {
-                backend.append("    occludeDiffuse(litShaderArgs.ao);");
+                backend.append("    occludeDiffuse(litShaderArgs_ao);");
             }
             if (options.occludeSpecular === SPECOCC_AO || options.occludeSpecular === SPECOCC_GLOSSDEPENDENT) {
-                backend.append("    occludeSpecular(litShaderArgs.gloss, litShaderArgs.ao, litShaderArgs.worldNormal, dViewDirW);");
+                backend.append("    occludeSpecular(litShaderArgs_gloss, litShaderArgs_ao, litShaderArgs_worldNormal, dViewDirW);");
             }
         }
 
         if (options.useSpecularityFactor) {
-            backend.append("    dSpecularLight *= litShaderArgs.specularityFactor;");
+            backend.append("    dSpecularLight *= litShaderArgs_specularityFactor;");
         }
 
         if (options.opacityFadesSpecular === false) {
             if (options.blendType === BLEND_NORMAL || options.blendType === BLEND_PREMULTIPLIED) {
                 backend.append("float specLum = dot((dSpecularLight + dReflection.rgb * dReflection.a), vec3( 0.2126, 0.7152, 0.0722 ));");
-                backend.append("#ifdef LIT_CLEARCOAT\n specLum += dot(ccSpecularLight * litShaderArgs.clearcoat.specularity + ccReflection.rgb * litShaderArgs.clearcoat.specularity, vec3( 0.2126, 0.7152, 0.0722 ));\n#endif");
-                backend.append("litShaderArgs.opacity = clamp(litShaderArgs.opacity + gammaCorrectInput(specLum), 0.0, 1.0);");
+                backend.append("#ifdef LIT_CLEARCOAT\n specLum += dot(ccSpecularLight * litShaderArgs_clearcoat_specularity + ccReflection.rgb * litShaderArgs_clearcoat_specularity, vec3( 0.2126, 0.7152, 0.0722 ));\n#endif");
+                backend.append("litShaderArgs_opacity = clamp(litShaderArgs_opacity + gammaCorrectInput(specLum), 0.0, 1.0);");
             }
-            backend.append("litShaderArgs.opacity *= material_alphaFade;");
+            backend.append("litShaderArgs_opacity *= material_alphaFade;");
         }
 
         backend.append(chunks.endPS);
@@ -1502,12 +1504,12 @@ class LitShader {
         }
         let structCode = "";
 
-        const backendCode = `void evaluateBackend(LitShaderArguments litShaderArgs) {\n${backend.code}\n}`;
+        const backendCode = `void evaluateBackend() {\n${backend.code}\n}`;
         func.append(backendCode);
 
         code.append(chunks.debugProcessFrontendPS);
 
-        code.append("    evaluateBackend(litShaderArgs);");
+        code.append("    evaluateBackend();");
 
         code.append(end());
 

--- a/src/scene/shader-lib/programs/standard.js
+++ b/src/scene/shader-lib/programs/standard.js
@@ -331,7 +331,7 @@ const standard = {
                 decl.append("float dAlpha;");
                 code.append(this._addMap("opacity", "opacityPS", options, litShader.chunks, textureMapping));
                 func.append("getOpacity();");
-                args.append("litShaderArgs_opacity = dAlpha;");
+                args.append("litArgs_opacity = dAlpha;");
                 if (options.litOptions.alphaTest) {
                     code.append(litShader.chunks.alphaTestPS);
                     func.append("alphaTest(dAlpha);");
@@ -357,7 +357,7 @@ const standard = {
                 code.append(this._addMap("normalDetail", "normalDetailMapPS", options, litShader.chunks, textureMapping));
                 code.append(this._addMap("normal", "normalMapPS", options, litShader.chunks, textureMapping));
                 func.append("getNormal();");
-                args.append("litShaderArgs_worldNormal = dNormalW;");
+                args.append("litArgs_worldNormal = dNormalW;");
             }
 
             if (litShader.needsSceneColor) {
@@ -378,30 +378,30 @@ const standard = {
             }
             code.append(this._addMap("diffuse", "diffusePS", options, litShader.chunks, textureMapping, options.diffuseEncoding));
             func.append("getAlbedo();");
-            args.append("litShaderArgs_albedo = dAlbedo;");
+            args.append("litArgs_albedo = dAlbedo;");
 
             if (options.litOptions.useRefraction) {
                 decl.append("float dTransmission;");
                 code.append(this._addMap("refraction", "transmissionPS", options, litShader.chunks, textureMapping));
                 func.append("getRefraction();");
-                args.append("litShaderArgs_transmission = dTransmission;");
+                args.append("litArgs_transmission = dTransmission;");
 
                 decl.append("float dThickness;");
                 code.append(this._addMap("thickness", "thicknessPS", options, litShader.chunks, textureMapping));
                 func.append("getThickness();");
-                args.append("litShaderArgs_thickness = dThickness;");
+                args.append("litArgs_thickness = dThickness;");
             }
 
             if (options.litOptions.useIridescence) {
                 decl.append("float dIridescence;");
                 code.append(this._addMap("iridescence", "iridescencePS", options, litShader.chunks, textureMapping));
                 func.append("getIridescence();");
-                args.append("litShaderArgs_iridescence_intensity = dIridescence;");
+                args.append("litArgs_iridescence_intensity = dIridescence;");
 
                 decl.append("float dIridescenceThickness;");
                 code.append(this._addMap("iridescenceThickness", "iridescenceThicknessPS", options, litShader.chunks, textureMapping));
                 func.append("getIridescenceThickness();");
-                args.append("litShaderArgs_iridescence_thickness = dIridescenceThickness;");
+                args.append("litArgs_iridescence_thickness = dIridescenceThickness;");
             }
 
             // specularity & glossiness
@@ -412,24 +412,24 @@ const standard = {
                     decl.append("vec3 sSpecularity;");
                     code.append(this._addMap("sheen", "sheenPS", options, litShader.chunks, textureMapping, options.sheenEncoding));
                     func.append("getSheen();");
-                    args.append("litShaderArgs_sheen_specularity = sSpecularity;");
+                    args.append("litArgs_sheen_specularity = sSpecularity;");
 
                     decl.append("float sGlossiness;");
                     code.append(this._addMap("sheenGloss", "sheenGlossPS", options, litShader.chunks, textureMapping));
                     func.append("getSheenGlossiness();");
-                    args.append("litShaderArgs_sheen_gloss = sGlossiness;");
+                    args.append("litArgs_sheen_gloss = sGlossiness;");
                 }
                 if (options.litOptions.useMetalness) {
                     decl.append("float dMetalness;");
                     code.append(this._addMap("metalness", "metalnessPS", options, litShader.chunks, textureMapping));
                     func.append("getMetalness();");
-                    args.append("litShaderArgs_metalness = dMetalness;");
+                    args.append("litArgs_metalness = dMetalness;");
                 }
                 if (options.litOptions.useSpecularityFactor) {
                     decl.append("float dSpecularityFactor;");
                     code.append(this._addMap("specularityFactor", "specularityFactorPS", options, litShader.chunks, textureMapping));
                     func.append("getSpecularityFactor();");
-                    args.append("litShaderArgs_specularityFactor = dSpecularityFactor;");
+                    args.append("litArgs_specularityFactor = dSpecularityFactor;");
                 }
                 if (options.litOptions.useSpecularColor) {
                     code.append(this._addMap("specular", "specularPS", options, litShader.chunks, textureMapping, options.specularEncoding));
@@ -439,8 +439,8 @@ const standard = {
                 code.append(this._addMap("gloss", "glossPS", options, litShader.chunks, textureMapping));
                 func.append("getGlossiness();");
                 func.append("getSpecularity();");
-                args.append("litShaderArgs_specularity = dSpecularity;");
-                args.append("litShaderArgs_gloss = dGlossiness;");
+                args.append("litArgs_specularity = dSpecularity;");
+                args.append("litArgs_gloss = dGlossiness;");
             } else {
                 decl.append("vec3 dSpecularity = vec3(0.0);");
                 decl.append("float dGlossiness = 0.0;");
@@ -454,14 +454,14 @@ const standard = {
                 decl.append("float dAo;");
                 code.append(this._addMap("ao", "aoPS", options, litShader.chunks, textureMapping));
                 func.append("getAO();");
-                args.append("litShaderArgs_ao = dAo;");
+                args.append("litArgs_ao = dAo;");
             }
 
             // emission
             decl.append("vec3 dEmission;");
             code.append(this._addMap("emissive", "emissivePS", options, litShader.chunks, textureMapping, options.emissiveEncoding));
             func.append("getEmission();");
-            args.append("litShaderArgs_emission = dEmission;");
+            args.append("litArgs_emission = dEmission;");
 
             // clearcoat
             if (options.litOptions.useClearCoat) {
@@ -477,9 +477,9 @@ const standard = {
                 func.append("getClearCoatGlossiness();");
                 func.append("getClearCoatNormal();");
 
-                args.append("litShaderArgs_clearcoat_specularity = ccSpecularity;");
-                args.append("litShaderArgs_clearcoat_gloss = ccGlossiness;");
-                args.append("litShaderArgs_clearcoat_worldNormal = ccNormalW;");
+                args.append("litArgs_clearcoat_specularity = ccSpecularity;");
+                args.append("litArgs_clearcoat_gloss = ccGlossiness;");
+                args.append("litArgs_clearcoat_worldNormal = ccNormalW;");
             }
 
             // lightmap
@@ -492,9 +492,9 @@ const standard = {
                 }
                 code.append(this._addMap("light", lightmapChunkPropName, options, litShader.chunks, textureMapping, options.lightMapEncoding));
                 func.append("getLightMap();");
-                args.append("litShaderArgs_lightmap = dLightmap;");
+                args.append("litArgs_lightmap = dLightmap;");
                 if (lightmapDir) {
-                    args.append("litShaderArgs_lightmapDir = dLightmapDir;");
+                    args.append("litArgs_lightmapDir = dLightmapDir;");
                 }
             }
 
@@ -514,7 +514,7 @@ const standard = {
                 code.append(litShader.chunks.alphaTestPS);
                 func.append("getOpacity();");
                 func.append("alphaTest(dAlpha);");
-                args.append("litShaderArgs_opacity = dAlpha;");
+                args.append("litArgs_opacity = dAlpha;");
             }
         }
 

--- a/src/scene/shader-lib/programs/standard.js
+++ b/src/scene/shader-lib/programs/standard.js
@@ -331,7 +331,7 @@ const standard = {
                 decl.append("float dAlpha;");
                 code.append(this._addMap("opacity", "opacityPS", options, litShader.chunks, textureMapping));
                 func.append("getOpacity();");
-                args.append("_litShaderArgs.opacity = dAlpha;");
+                args.append("litShaderArgs_opacity = dAlpha;");
                 if (options.litOptions.alphaTest) {
                     code.append(litShader.chunks.alphaTestPS);
                     func.append("alphaTest(dAlpha);");
@@ -357,7 +357,7 @@ const standard = {
                 code.append(this._addMap("normalDetail", "normalDetailMapPS", options, litShader.chunks, textureMapping));
                 code.append(this._addMap("normal", "normalMapPS", options, litShader.chunks, textureMapping));
                 func.append("getNormal();");
-                args.append("_litShaderArgs.worldNormal = dNormalW;");
+                args.append("litShaderArgs_worldNormal = dNormalW;");
             }
 
             if (litShader.needsSceneColor) {
@@ -378,30 +378,30 @@ const standard = {
             }
             code.append(this._addMap("diffuse", "diffusePS", options, litShader.chunks, textureMapping, options.diffuseEncoding));
             func.append("getAlbedo();");
-            args.append("_litShaderArgs.albedo = dAlbedo;");
+            args.append("litShaderArgs_albedo = dAlbedo;");
 
             if (options.litOptions.useRefraction) {
                 decl.append("float dTransmission;");
                 code.append(this._addMap("refraction", "transmissionPS", options, litShader.chunks, textureMapping));
                 func.append("getRefraction();");
-                args.append("_litShaderArgs.transmission = dTransmission;");
+                args.append("litShaderArgs_transmission = dTransmission;");
 
                 decl.append("float dThickness;");
                 code.append(this._addMap("thickness", "thicknessPS", options, litShader.chunks, textureMapping));
                 func.append("getThickness();");
-                args.append("_litShaderArgs.thickness = dThickness;");
+                args.append("litShaderArgs_thickness = dThickness;");
             }
 
             if (options.litOptions.useIridescence) {
                 decl.append("float dIridescence;");
                 code.append(this._addMap("iridescence", "iridescencePS", options, litShader.chunks, textureMapping));
                 func.append("getIridescence();");
-                args.append("_litShaderArgs.iridescence.intensity = dIridescence;");
+                args.append("litShaderArgs_iridescence_intensity = dIridescence;");
 
                 decl.append("float dIridescenceThickness;");
                 code.append(this._addMap("iridescenceThickness", "iridescenceThicknessPS", options, litShader.chunks, textureMapping));
                 func.append("getIridescenceThickness();");
-                args.append("_litShaderArgs.iridescence.thickness = dIridescenceThickness;");
+                args.append("litShaderArgs_iridescence_thickness = dIridescenceThickness;");
             }
 
             // specularity & glossiness
@@ -412,24 +412,24 @@ const standard = {
                     decl.append("vec3 sSpecularity;");
                     code.append(this._addMap("sheen", "sheenPS", options, litShader.chunks, textureMapping, options.sheenEncoding));
                     func.append("getSheen();");
-                    args.append("_litShaderArgs.sheen.specularity = sSpecularity;");
+                    args.append("litShaderArgs_sheen_specularity = sSpecularity;");
 
                     decl.append("float sGlossiness;");
                     code.append(this._addMap("sheenGloss", "sheenGlossPS", options, litShader.chunks, textureMapping));
                     func.append("getSheenGlossiness();");
-                    args.append("_litShaderArgs.sheen.gloss = sGlossiness;");
+                    args.append("litShaderArgs_sheen_gloss = sGlossiness;");
                 }
                 if (options.litOptions.useMetalness) {
                     decl.append("float dMetalness;");
                     code.append(this._addMap("metalness", "metalnessPS", options, litShader.chunks, textureMapping));
                     func.append("getMetalness();");
-                    args.append("_litShaderArgs.metalness = dMetalness;");
+                    args.append("litShaderArgs_metalness = dMetalness;");
                 }
                 if (options.litOptions.useSpecularityFactor) {
                     decl.append("float dSpecularityFactor;");
                     code.append(this._addMap("specularityFactor", "specularityFactorPS", options, litShader.chunks, textureMapping));
                     func.append("getSpecularityFactor();");
-                    args.append("_litShaderArgs.specularityFactor = dSpecularityFactor;");
+                    args.append("litShaderArgs_specularityFactor = dSpecularityFactor;");
                 }
                 if (options.litOptions.useSpecularColor) {
                     code.append(this._addMap("specular", "specularPS", options, litShader.chunks, textureMapping, options.specularEncoding));
@@ -439,8 +439,8 @@ const standard = {
                 code.append(this._addMap("gloss", "glossPS", options, litShader.chunks, textureMapping));
                 func.append("getGlossiness();");
                 func.append("getSpecularity();");
-                args.append("_litShaderArgs.specularity = dSpecularity;");
-                args.append("_litShaderArgs.gloss = dGlossiness;");
+                args.append("litShaderArgs_specularity = dSpecularity;");
+                args.append("litShaderArgs_gloss = dGlossiness;");
             } else {
                 decl.append("vec3 dSpecularity = vec3(0.0);");
                 decl.append("float dGlossiness = 0.0;");
@@ -454,14 +454,14 @@ const standard = {
                 decl.append("float dAo;");
                 code.append(this._addMap("ao", "aoPS", options, litShader.chunks, textureMapping));
                 func.append("getAO();");
-                args.append("_litShaderArgs.ao = dAo;");
+                args.append("litShaderArgs_ao = dAo;");
             }
 
             // emission
             decl.append("vec3 dEmission;");
             code.append(this._addMap("emissive", "emissivePS", options, litShader.chunks, textureMapping, options.emissiveEncoding));
             func.append("getEmission();");
-            args.append("_litShaderArgs.emission = dEmission;");
+            args.append("litShaderArgs_emission = dEmission;");
 
             // clearcoat
             if (options.litOptions.useClearCoat) {
@@ -477,9 +477,9 @@ const standard = {
                 func.append("getClearCoatGlossiness();");
                 func.append("getClearCoatNormal();");
 
-                args.append("_litShaderArgs.clearcoat.specularity = ccSpecularity;");
-                args.append("_litShaderArgs.clearcoat.gloss = ccGlossiness;");
-                args.append("_litShaderArgs.clearcoat.worldNormal = ccNormalW;");
+                args.append("litShaderArgs_clearcoat_specularity = ccSpecularity;");
+                args.append("litShaderArgs_clearcoat_gloss = ccGlossiness;");
+                args.append("litShaderArgs_clearcoat_worldNormal = ccNormalW;");
             }
 
             // lightmap
@@ -492,9 +492,9 @@ const standard = {
                 }
                 code.append(this._addMap("light", lightmapChunkPropName, options, litShader.chunks, textureMapping, options.lightMapEncoding));
                 func.append("getLightMap();");
-                args.append("_litShaderArgs.lightmap = dLightmap;");
+                args.append("litShaderArgs_lightmap = dLightmap;");
                 if (lightmapDir) {
-                    args.append("_litShaderArgs.lightmapDir = dLightmapDir;");
+                    args.append("litShaderArgs_lightmapDir = dLightmapDir;");
                 }
             }
 
@@ -514,13 +514,13 @@ const standard = {
                 code.append(litShader.chunks.alphaTestPS);
                 func.append("getOpacity();");
                 func.append("alphaTest(dAlpha);");
-                args.append("_litShaderArgs.opacity = dAlpha;");
+                args.append("litShaderArgs_opacity = dAlpha;");
             }
         }
 
         decl.append(litShader.chunks.litShaderArgsPS);
-        code.append(`LitShaderArguments evaluateFrontend() { LitShaderArguments _litShaderArgs; \n${func.code}\n${args.code}\n return _litShaderArgs;\n }\n`);
-        func.code = `LitShaderArguments litShaderArgs = evaluateFrontend();`;
+        code.append(`void evaluateFrontend() { \n${func.code}\n${args.code}\n }\n`);
+        func.code = `evaluateFrontend();`;
 
         for (const texture in textureMapping) {
             decl.append(`uniform sampler2D ${textureMapping[texture]};`);


### PR DESCRIPTION
Moves the lit shader arguments out of the struct and in to globals. The retain the same naming strategy, with litShaderArgs being the first level, and the clearcoat/sheen/iridescence extensions being another layer, so for example litShaderArgs_sheen_gloss gets the sheen gloss value.

Also splits the metalness modulate into two functions, one for albedo and one for specular.

For whatever reason, the Adreno 610 and 618 devices we have tested has some bug which is provoked by having the lit shader arguments in structs instead of globals. Why this happens is not clear, but it seems to be caused by a bug in the shader compiler on the target, rather than the shader we generate. The issue in question is demonstrated here: https://forum.playcanvas.com/t/strange-rendering-in-android-13/31622/20.

This PR brings with it some chunk changes, but they should be rather minor since we rarely pass the entire LitShaderArgs struct around.
