### PR TITLE
Implement/use `GraphNode#remove`

### DIFF
--- a/src/framework/components/sprite/component.js
+++ b/src/framework/components/sprite/component.js
@@ -596,11 +596,8 @@ class SpriteComponent extends Component {
         this._hideModel();
         this._model = null;
 
-        if (this._node) {
-            if (this._node.parent)
-                this._node.parent.removeChild(this._node);
-            this._node = null;
-        }
+        this._node?.remove();
+        this._node = null;
 
         if (this._meshInstance) {
             // make sure we decrease the ref counts materials and meshes

--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -490,7 +490,7 @@ class GraphNode extends EventHandler {
      */
     destroy() {
         // Detach from parent
-        this._parent?.removeChild(this);
+        this.remove();
 
         // Recursively destroy all children
         const children = this._children;
@@ -956,17 +956,20 @@ class GraphNode extends EventHandler {
     }
 
     /**
+     * Remove graph node from current parent.
+     */
+    remove() {
+        this._parent?.removeChild(this);
+    }
+
+    /**
      * Remove graph node from current parent and add as child to new parent.
      *
      * @param {GraphNode} parent - New parent to attach graph node to.
      * @param {number} [index] - The child index where the child node should be placed.
      */
     reparent(parent, index) {
-        const current = this._parent;
-
-        if (current)
-            current.removeChild(this);
-
+        this.remove();
         if (parent) {
             if (index >= 0) {
                 parent.insertChild(this, index);
@@ -1294,9 +1297,7 @@ class GraphNode extends EventHandler {
     _prepareInsertChild(node) {
 
         // remove it from the existing parent
-        if (node._parent) {
-            node._parent.removeChild(node);
-        }
+        node.remove();
 
         Debug.assert(node !== this, `GraphNode ${node?.name} cannot be a child of itself`);
         Debug.assert(!this.isDescendantOf(node), `GraphNode ${node?.name} cannot add an ancestor as a child`);

--- a/test/scene/graph-node.test.mjs
+++ b/test/scene/graph-node.test.mjs
@@ -634,6 +634,19 @@ describe('GraphNode', function () {
 
     });
 
+    describe('#remove', function () {
+
+        it('removes the node from its parent, unparenting it', function () {
+            const node = new GraphNode();
+            const child = new GraphNode();
+            node.addChild(child);
+            child.remove();
+            expect(node.children).to.be.an('array').with.lengthOf(0);
+            expect(child.parent).to.equal(null);
+        });
+
+    });
+
     describe('#removeChild()', function () {
 
         it('removes a child node', function () {


### PR DESCRIPTION
This is a follow-up of this PR, to make it a bit cleaner/shorter:

https://github.com/playcanvas/engine/pull/5414#issuecomment-1598473727

`GraphNode#remove` works just like `HTMLElement#remove`:

```js
const div = document.createElement("div");
div.remove();
div.remove();
document.body.append(div);
div.remove(); // only call which does something
div.remove();
```

Equivalent API:

```js
const ent = new pc.Entity();
ent.remove();
ent.remove();
pc.app.root.addChild(ent);
ent.remove(); // only call which does something
ent.remove();
```



I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
