### PR TITLE
Don't try to normalize depth

### DIFF
--- a/src/scene/shader-lib/programs/lit-shader.js
+++ b/src/scene/shader-lib/programs/lit-shader.js
@@ -527,11 +527,6 @@ class LitShader {
             hasModifiedDepth = true;
         }
 
-        if (usePerspectiveDepth && usePackedDepth) {
-            code += "    depth *= 1.0 / (camera_params.y - camera_params.z);\n";
-            hasModifiedDepth = true;
-        }
-
         if (usePackedDepth) {
             code += "    gl_FragColor = packFloat(depth);\n";
         } else if (!isVsm) {


### PR DESCRIPTION
This was residual from the PCSS implementation and should no longer be there. It's also causing compile issues on GL1. 