### PR TITLE
Example ModelOutline works on WebGPU now

### DIFF
--- a/examples/src/examples/graphics/model-outline.tsx
+++ b/examples/src/examples/graphics/model-outline.tsx
@@ -3,6 +3,7 @@ import * as pc from '../../../../';
 class ModelOutlineExample {
     static CATEGORY = 'Graphics';
     static NAME = 'Model Outline';
+    static WEBGPU_ENABLED = true;
 
     example(canvas: HTMLCanvasElement, deviceType: string): void {
 


### PR DESCRIPTION
- it got fixed by some other recent change, so enabling it.