### PR TITLE
Optimize AssetRegistry.find and findAll

### DIFF
--- a/src/framework/asset/asset-registry.js
+++ b/src/framework/asset/asset-registry.js
@@ -52,6 +52,12 @@ class AssetRegistry extends EventHandler {
     _urlToAsset = new Map();
 
     /**
+     * @type {Map<string, Set<Asset>>}
+     * @private
+     */
+    _nameToAsset = new Map();
+
+    /**
      * Index for looking up by tags.
      *
      * @private
@@ -240,6 +246,13 @@ class AssetRegistry extends EventHandler {
             this._urlToAsset.set(asset.file.url, asset);
         }
 
+        if (!this._nameToAsset.has(asset.name))
+            this._nameToAsset.set(asset.name, new Set());
+
+        this._nameToAsset.get(asset.name).add(asset);
+
+        asset.on('name', this._onNameChange, this);
+
         asset.registry = this;
 
         // tags cache
@@ -275,6 +288,16 @@ class AssetRegistry extends EventHandler {
 
         if (asset.file?.url) {
             this._urlToAsset.delete(asset.file.url);
+        }
+
+        asset.off('name', this._onNameChange, this);
+
+        if (this._nameToAsset.has(asset.name)) {
+            const items = this._nameToAsset.get(asset.name);
+            items.delete(asset);
+            if (items.size === 0) {
+                this._nameToAsset.delete(asset.name);
+            }
         }
 
         // tags cache
@@ -586,6 +609,23 @@ class AssetRegistry extends EventHandler {
         this._tags.remove(tag, asset);
     }
 
+    _onNameChange(asset, name, nameOld) {
+        // remove
+        if (this._nameToAsset.has(nameOld)) {
+            const items = this._nameToAsset.get(nameOld);
+            items.delete(asset);
+            if (items.size === 0) {
+                this._nameToAsset.delete(nameOld);
+            }
+        }
+
+        // add
+        if (!this._nameToAsset.has(asset.name))
+            this._nameToAsset.set(asset.name, new Set());
+
+        this._nameToAsset.get(asset.name).add(asset);
+    }
+
     /**
      * Return all Assets that satisfy the search query. Query can be simply a string, or comma
      * separated strings, to have inclusive results of assets that match at least one query. A
@@ -635,7 +675,16 @@ class AssetRegistry extends EventHandler {
      * const asset = app.assets.find("myTextureAsset", "texture");
      */
     find(name, type) {
-        return Array.from(this._assets).find(asset => asset.name === name && (!type || asset.type === type)) ?? null;
+        const items = this._nameToAsset.get(name);
+        if (!items) return null;
+
+        for (const asset of items) {
+            if (!type || asset.type === type) {
+                return asset;
+            }
+        }
+
+        return null;
     }
 
     /**
@@ -649,7 +698,11 @@ class AssetRegistry extends EventHandler {
      * console.log(`Found ${assets.length} texture assets named 'brick'`);
      */
     findAll(name, type) {
-        return Array.from(this._assets).filter(asset => asset.name === name && (!type || asset.type === type));
+        const items = this._nameToAsset.get(name);
+        if (!items) return [];
+        let results = Array.from(items);
+        if (!type) return results;
+        return results.filter(asset => asset.type === type);
     }
 }
 

--- a/src/framework/asset/asset-registry.js
+++ b/src/framework/asset/asset-registry.js
@@ -700,7 +700,7 @@ class AssetRegistry extends EventHandler {
     findAll(name, type) {
         const items = this._nameToAsset.get(name);
         if (!items) return [];
-        let results = Array.from(items);
+        const results = Array.from(items);
         if (!type) return results;
         return results.filter(asset => asset.type === type);
     }

--- a/src/framework/asset/asset.js
+++ b/src/framework/asset/asset.js
@@ -85,13 +85,7 @@ class Asset extends EventHandler {
         super();
 
         this._id = assetIdCounter--;
-
-        /**
-         * The name of the asset.
-         *
-         * @type {string}
-         */
-        this.name = name || '';
+        this._name = name || '';
 
         /**
          * The type of the asset. One of ["animation", "audio", "binary", "container", "cubemap",
@@ -220,6 +214,23 @@ class Asset extends EventHandler {
 
     get id() {
         return this._id;
+    }
+
+    /**
+     * The asset name.
+     *
+     * @type {string}
+     */
+    set name(value) {
+        if (this._name === value)
+            return;
+        const old = this._name;
+        this._name = value;
+        this.fire('name', this, this._name, old);
+    }
+
+    get name() {
+        return this._name;
     }
 
     /**

--- a/test/framework/asset/asset-registry.test.mjs
+++ b/test/framework/asset/asset-registry.test.mjs
@@ -80,6 +80,81 @@ describe('AssetRegistry', function () {
 
     });
 
+    describe('#find + rename', function () {
+
+        it('works after renaming an asset', function () {
+            const asset1 = new Asset('Asset 1', 'text', {
+                url: 'fake/one/file.txt'
+            });
+
+            app.assets.add(asset1);
+
+            asset1.name = 'Asset 1 renamed';
+
+            expect(app.assets.find('Asset 1')).to.equal(null);
+            expect(app.assets.find('Asset 1 renamed')).to.equal(asset1);
+
+            app.assets.remove(asset1);
+            asset1.name = 'Asset 1 renamed again';
+
+            expect(app.assets.find('Asset 1')).to.equal(null);
+            expect(app.assets.find('Asset 1 renamed')).to.equal(null);
+            expect(app.assets.find('Asset 1 renamed again')).to.equal(null);
+        });
+
+    });
+
+    describe('#find + type', function () {
+
+        it('finds assets by name filtered by type', function () {
+            const asset1 = new Asset('Asset 1', 'text', {
+                url: 'fake/one/file.txt'
+            });
+            const asset2 = new Asset('Asset 1', 'json', {
+                url: 'fake/two/file.json'
+            });
+
+            app.assets.add(asset1);
+            app.assets.add(asset2);
+
+            expect(app.assets.find('Asset 1', 'text')).to.equal(asset1);
+            expect(app.assets.find('Asset 1', 'json')).to.equal(asset2);
+        });
+
+    });
+
+    describe('#findAll + type', function () {
+
+        it('finds all assets by name filtered by type', function () {
+            const asset1 = new Asset('Asset 1', 'text', {
+                url: 'fake/one/file.txt'
+            });
+            const asset2 = new Asset('Asset 1', 'json', {
+                url: 'fake/two/file.json'
+            });
+            const asset3 = new Asset('Asset 1', 'text', {
+                url: 'fake/two/file.txt'
+            });
+            const asset4 = new Asset('Asset 1', 'text', {
+                url: 'fake/two/file.txt'
+            });
+
+            app.assets.add(asset1);
+            app.assets.add(asset2);
+            app.assets.add(asset3);
+            app.assets.add(asset4);
+
+            // ensure renaming updates indexes
+            asset3.name = 'Asset 1 renamed';
+
+            // ensure removing updates indexes
+            app.assets.remove(asset4);
+
+            expect(app.assets.findAll('Asset 1', 'text').length).to.equal(1);
+        });
+
+    });
+
     describe('#get', function () {
 
         it('retrieves an asset by id', function () {


### PR DESCRIPTION
Improves `AssetRegistry.find` and `findAll` performance, by building and managing internal index of assets by names. And avoids casting large asset lists to arrays during these methods to avoid GC stalls.

In a project with around 2.5k of assets, calling `find` was taking around 0.04ms per request. With this patch it takes around 0.00006ms. This is around ~666 times improvement.
`findAll` used to take 0.04ms per request also, now it takes 0.0006ms. ~66 times improvement.

**In specific project, during custom scene loaders that reference assets by names, it used to take around 200ms just finding assets, now it takes 0.25ms.**

_Timings are just a relative measurement and based on hardware._
_It only highlights the performance change between versions._
_Tested on high-end computer, so on mid/low/mobile it is even more apparent improvement._

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
