### PR TITLE
Add .js to three import's

### DIFF
--- a/src/scene/materials/custom-material.js
+++ b/src/scene/materials/custom-material.js
@@ -1,7 +1,7 @@
 import { ShaderProcessorOptions } from '../../platform/graphics/shader-processor-options.js';
-import { LIGHTTYPE_DIRECTIONAL, LIGHTTYPE_OMNI, LIGHTTYPE_SPOT, MASK_AFFECT_DYNAMIC, SHADERDEF_INSTANCING, SHADERDEF_MORPH_NORMAL, SHADERDEF_MORPH_POSITION, SHADERDEF_MORPH_TEXTURE_BASED, SHADERDEF_SCREENSPACE, SHADERDEF_SKIN } from "../constants";
-import { getProgramLibrary } from "../shader-lib/get-program-library";
-import { LitOptions } from "./lit-options";
+import { LIGHTTYPE_DIRECTIONAL, LIGHTTYPE_OMNI, LIGHTTYPE_SPOT, MASK_AFFECT_DYNAMIC, SHADERDEF_INSTANCING, SHADERDEF_MORPH_NORMAL, SHADERDEF_MORPH_POSITION, SHADERDEF_MORPH_TEXTURE_BASED, SHADERDEF_SCREENSPACE, SHADERDEF_SKIN } from "../constants.js";
+import { getProgramLibrary } from "../shader-lib/get-program-library.js";
+import { LitOptions } from "./lit-options.js";
 import { collectLights } from "./lit-material-common.js";
 import { Material } from './material.js';
 import { custom } from '../shader-lib/programs/custom.js';


### PR DESCRIPTION
I consume the engine mostly via importmaps and

```html
<script type="module">
  // ...
</script>
```

and these three missing file extensions broke it.

I also created an ESLint rule here: https://github.com/playcanvas/playcanvas-eslint-config/pull/14

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
