### PR TITLE
Refactor EventHandler class

### DIFF
--- a/src/core/event-handler.js
+++ b/src/core/event-handler.js
@@ -51,10 +51,10 @@ class EventHandler {
     _addCallback(name, callback, scope, once) {
         if (!name || typeof name !== 'string' || typeof callback !== 'function')
             return;
-    
+
         if (!this._callbacks.has(name))
             this._callbacks.set(name, []);
-    
+
         this._callbacks.get(name).push({ callback, scope, once });
     }
 
@@ -123,10 +123,10 @@ class EventHandler {
             this._callbacks.clear();
             return this;
         }
-    
+
         const handlers = this._callbacks.get(name);
         if (!handlers) return this;
-    
+
         if (callback) {
             let i = handlers.length;
             while (i--) {
@@ -140,10 +140,10 @@ class EventHandler {
         } else {
             this._callbacks.delete(name);
         }
-    
+
         return this;
     }
-    
+
     /**
      * Fire an event, all additional arguments are passed on to the event listener.
      *
@@ -155,24 +155,24 @@ class EventHandler {
      */
     fire(name, ...args) {
         if (!name || !this._callbacks.has(name)) return this;
-    
-        let handlers = this._callbacks.get(name);
+
+        const handlers = this._callbacks.get(name);
         if (!handlers) return this;
-    
+
         for (let i = 0; i < handlers.length; i++) {
             const handler = handlers[i];
             handler.callback.apply(handler.scope, args);
-    
+
             if (handler.once) {
                 handlers.splice(i, 1);
                 i--; // Adjust the index after removing an item to keep the correct order
             }
         }
-    
+
         if (handlers.length === 0) {
             this._callbacks.delete(name);
         }
-    
+
         return this;
     }
 

--- a/src/core/event-handler.js
+++ b/src/core/event-handler.js
@@ -118,7 +118,7 @@ class EventHandler {
      * obj.off('test', handler); // Removes all handler functions, called 'test'
      * obj.off('test', handler, this); // Removes all handler functions, called 'test' with scope this
      */
-    off(name, callback, scope) {
+    off(name, callback, scope = this) {
         if (!name) {
             this._callbacks.clear();
             return this;

--- a/src/core/event-handler.js
+++ b/src/core/event-handler.js
@@ -22,7 +22,7 @@
  */
 class EventHandler {
     /**
-     * @type {Map<string, {callback: HandleEventCallback, scope: object, once: boolean}[]>}
+     * @type {Map<string, object[]>}
      * @private
      */
     _callbacks = new Map();

--- a/src/core/events.js
+++ b/src/core/events.js
@@ -20,7 +20,6 @@ const events = {
         target.once = ev.once;
         target.hasEvent = ev.hasEvent;
         target._callbacks = { };
-        target._callbackActive = { };
         return target;
     },
 

--- a/src/core/events.js
+++ b/src/core/events.js
@@ -19,7 +19,7 @@ const events = {
         target.fire = ev.fire;
         target.once = ev.once;
         target.hasEvent = ev.hasEvent;
-        target._callbacks = { };
+        target._callbacks = new Map();
         return target;
     },
 

--- a/test/core/event-handler.test.mjs
+++ b/test/core/event-handler.test.mjs
@@ -32,7 +32,7 @@ describe('EventHandler', function () {
             expect(called).to.be.true;
         });
 
-        it('calls handler with up to 8 arguments on fire', function () {
+        it('can handle over 8 arguments on fire', function () {
             const e = new EventHandler();
             let called = false;
             e.on('test', (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) => {
@@ -45,7 +45,7 @@ describe('EventHandler', function () {
                 expect(arg6).to.equal(6);
                 expect(arg7).to.equal(7);
                 expect(arg8).to.equal(8);
-                expect(arg9).to.be.undefined;
+                expect(arg9).to.equal(9);
             });
             e.fire('test', 1, 2, 3, 4, 5, 6, 7, 8, 9);
             expect(called).to.be.true;

--- a/test/framework/asset/asset-localized.test.mjs
+++ b/test/framework/asset/asset-localized.test.mjs
@@ -127,14 +127,14 @@ describe('LocalizedAsset', function () {
         expect(asset.hasEvent('remove')).to.equal(true);
         // there should be 2 remove events one for the defaultAsset
         // and one for the localizedAsset
-        expect(asset._callbacks.remove.length).to.equal(2);
+        expect(asset._callbacks.get('remove').length).to.equal(2);
 
         app.i18n.locale = 'fr';
 
         expect(asset.hasEvent('load')).to.equal(false);
         expect(asset.hasEvent('change')).to.equal(false);
         // there should now be only 1 remove event for the defaultAsset
-        expect(asset._callbacks.remove.length).to.equal(1);
+        expect(asset._callbacks.get('remove').length).to.equal(1);
 
         expect(asset2.hasEvent('load')).to.equal(true);
         expect(asset2.hasEvent('change')).to.equal(true);

--- a/test/framework/components/model/component.test.mjs
+++ b/test/framework/components/model/component.test.mjs
@@ -230,7 +230,7 @@ describe('ModelComponent', function () {
         e.destroy();
 
         expect(assets.material.hasEvent('load')).to.be.false;
-        expect(assets.material._callbacks.unload.length).to.equal(1);
+        expect(assets.material._callbacks.get('unload').length).to.equal(1);
         expect(assets.material.hasEvent('change')).to.be.false;
         expect(assets.material.hasEvent('remove')).to.be.false;
     });
@@ -253,7 +253,7 @@ describe('ModelComponent', function () {
         expect(assets.material.hasEvent('load')).to.be.false;
         expect(assets.material.hasEvent('remove')).to.be.false;
         expect(assets.material.hasEvent('change')).to.be.false;
-        expect(assets.material._callbacks.unload.length).to.equal(1);
+        expect(assets.material._callbacks.get('unload').length).to.equal(1);
     });
 
     it('Materials applied when loading asynchronously', function (done) {

--- a/test/framework/utils/entity-reference.test.mjs
+++ b/test/framework/utils/entity-reference.test.mjs
@@ -55,15 +55,15 @@ describe('EntityReference', function () {
     function getTotalEventListeners(entity) {
         let total = 0;
 
-        Object.keys(entity._callbacks || {}).forEach(function (eventName) {
-            total += entity._callbacks[eventName].length;
-        });
+        for (const entry of entity._callbacks) {
+            total += entry[1].length;
+        }
 
         return total;
     }
 
     function getNumListenersForEvent(entity, eventName) {
-        return (entity._callbacks && entity._callbacks[eventName] && entity._callbacks[eventName].length) || 0;
+        return (entity._callbacks && entity._callbacks.get(eventName) && entity._callbacks.get(eventName).length) || 0;
     }
 
     it('provides a reference to the entity once the guid is populated', function () {

--- a/tests/framework/components/element/test_imageelement.js
+++ b/tests/framework/components/element/test_imageelement.js
@@ -997,7 +997,7 @@ describe('pc.ImageElement', function () {
             e.element.spriteAsset = null;
 
             // check that no event listeners come from this image element
-            app.assets._callbacks['load:' + textureAtlasAsset.id].forEach(function (callback) {
+            app.assets._callbacks.get('load:' + textureAtlasAsset.id).forEach(function (callback) {
                 expect(callback.scope).to.not.equal(e.element._image);
             });
 


### PR DESCRIPTION
This PR refactors the `EventHandler` class. It gets rid of the `_callbacksActive` property and generally simplifies the code but maintains the same behavior and (hopefully) the same performance.

It also lifts the limit on passing 8 arguments to an event handler.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
