### PR TITLE
Optimization of the render pipeline cache access on WebGPU

### DIFF
--- a/src/core/array-utils.js
+++ b/src/core/array-utils.js
@@ -1,0 +1,18 @@
+const array = {
+
+    // helper function to compare two arrays for equality
+    equals: function (arr1, arr2) {
+
+        if (arr1.size !== arr2.size) {
+            return false;
+        }
+        for (let i = 0; i < arr1.length; i++) {
+            if (arr1[i] !== arr2[i]) {
+                return false;
+            }
+        }
+        return true;
+    }
+};
+
+export { array };

--- a/src/core/hash.js
+++ b/src/core/hash.js
@@ -15,4 +15,22 @@ function hashCode(str) {
     return hash;
 }
 
-export { hashCode };
+/**
+ * Calculates simple hash value of an array of numbers. Designed for performance, but provides good
+ * distribution with small number of collisions
+ *.
+ * @param {Uint32Array} typedArray - Array of numbers to hash.
+ * @returns {number} Hash value.
+ */
+function fnv1aHashUint32Array(typedArray) {
+    const prime = 16777619;
+    let hash = 2166136261;
+
+    for (let i = 0; i < typedArray.length; i++) {
+        hash ^= typedArray[i];
+        hash *= prime;
+    }
+    return hash >>> 0; // Ensure non-negative integer
+}
+
+export { hashCode, fnv1aHashUint32Array };

--- a/src/core/hash.js
+++ b/src/core/hash.js
@@ -17,7 +17,7 @@ function hashCode(str) {
 
 /**
  * Calculates simple hash value of an array of numbers. Designed for performance, but provides good
- * distribution with small number of collisions
+ * distribution with small number of collisions.
  *.
  * @param {Uint32Array} typedArray - Array of numbers to hash.
  * @returns {number} Hash value.

--- a/src/core/string-ids.js
+++ b/src/core/string-ids.js
@@ -1,0 +1,31 @@
+/**
+ * A cache for assigning unique numerical ids to strings.
+ *
+ * @ignore
+ */
+class StringIds {
+    /** @type {Map<string, number>} */
+    map = new Map();
+
+    /** @type {number} */
+    id = 0;
+
+    /**
+     * Get the id for the given name. If the name has not been seen before, it will be assigned a new
+     * id.
+     *
+     * @param {string} name - The name to get the id for.
+     * @returns {number} The id for the given name.
+     */
+    get(name) {
+        let value = this.map.get(name);
+        if (value === undefined) {
+            value = this.id++;
+            this.map.set(name, value);
+        }
+
+        return value;
+    }
+}
+
+export { StringIds };

--- a/src/platform/graphics/stencil-parameters.js
+++ b/src/platform/graphics/stencil-parameters.js
@@ -1,4 +1,7 @@
 import { FUNC_ALWAYS, STENCILOP_KEEP } from './constants.js';
+import { StringIds } from '../../core/string-ids.js';
+
+const stringIds = new StringIds();
 
 /**
  * Holds stencil test settings.
@@ -97,7 +100,8 @@ class StencilParameters {
     // BitField to store the parameters and to speed up the key generation.
     get key() {
         const { func, ref, fail, zfail, zpass, readMask, writeMask } = this;
-        return `${func},${ref},${fail},${zfail},${zpass},${readMask},${writeMask}`;
+        const key = `${func},${ref},${fail},${zfail},${zpass},${readMask},${writeMask}`;
+        return stringIds.get(key);
     }
 
     /**

--- a/src/platform/graphics/vertex-format.js
+++ b/src/platform/graphics/vertex-format.js
@@ -2,11 +2,14 @@ import { Debug } from '../../core/debug.js';
 import { hashCode } from '../../core/hash.js';
 
 import { math } from '../../core/math/math.js';
+import { StringIds } from '../../core/string-ids.js';
 
 import {
     SEMANTIC_TEXCOORD0, SEMANTIC_TEXCOORD1, SEMANTIC_ATTR12, SEMANTIC_ATTR13, SEMANTIC_ATTR14, SEMANTIC_ATTR15,
     SEMANTIC_COLOR, SEMANTIC_TANGENT, TYPE_FLOAT32, typedArrayTypesByteSize, vertexTypesNames
 } from './constants.js';
+
+const stringIds = new StringIds();
 
 /**
  * A vertex format is a descriptor that defines the layout of vertex data inside a
@@ -266,7 +269,7 @@ class VertexFormat {
 
         // rendering hash
         this.renderingHashString = stringElementsRender.join('_');
-        this.renderingHash = hashCode(this.renderingHashString);
+        this.renderingHash = stringIds.get(this.renderingHashString);
     }
 }
 

--- a/src/platform/graphics/webgpu/webgpu-bind-group-format.js
+++ b/src/platform/graphics/webgpu/webgpu-bind-group-format.js
@@ -1,4 +1,5 @@
 import { Debug, DebugHelper } from '../../../core/debug.js';
+import { StringIds } from '../../../core/string-ids.js';
 import { SAMPLETYPE_FLOAT, SAMPLETYPE_UNFILTERABLE_FLOAT, SAMPLETYPE_DEPTH } from '../constants.js';
 
 import { WebgpuUtils } from './webgpu-utils.js';
@@ -12,6 +13,8 @@ const sampleTypes = [];
 sampleTypes[SAMPLETYPE_FLOAT] = 'float';
 sampleTypes[SAMPLETYPE_UNFILTERABLE_FLOAT] = 'unfilterable-float';
 sampleTypes[SAMPLETYPE_DEPTH] = 'depth';
+
+const stringIds = new StringIds();
 
 /**
  * A WebGPU implementation of the BindGroupFormat, which is a wrapper over GPUBindGroupLayout.
@@ -32,9 +35,9 @@ class WebgpuBindGroupFormat {
         /**
          * Unique key, used for caching
          *
-         * @type {string}
+         * @type {number}
          */
-        this.key = key;
+        this.key = stringIds.get(key);
 
         // keep descr in debug mode
         Debug.call(() => {

--- a/src/platform/graphics/webgpu/webgpu-render-pipeline.js
+++ b/src/platform/graphics/webgpu/webgpu-render-pipeline.js
@@ -74,12 +74,13 @@ const _stencilOps = [
 // temp array to avoid allocation
 const _bindGroupLayouts = [];
 
-/** @private */
+/** @ignore */
 class CacheEntry {
     /**
      * Render pipeline
      *
      * @type {GPURenderPipeline}
+     * @private
      */
     pipeline;
 
@@ -116,7 +117,7 @@ class WebgpuRenderPipeline {
         this.cache = new Map();
     }
 
-
+    /** @private */
     get(primitive, vertexFormat0, vertexFormat1, shader, renderTarget, bindGroupFormats, blendState,
         depthState, cullMode, stencilEnabled, stencilFront, stencilBack) {
 

--- a/src/platform/graphics/webgpu/webgpu-render-pipeline.js
+++ b/src/platform/graphics/webgpu/webgpu-render-pipeline.js
@@ -1,4 +1,6 @@
 import { Debug, DebugHelper } from "../../../core/debug.js";
+import { fnv1aHashUint32Array } from "../../../core/hash.js";
+import { array } from "../../../core/array-utils.js";
 import { TRACEID_RENDERPIPELINE_ALLOC, TRACEID_PIPELINELAYOUT_ALLOC } from "../../../core/constants.js";
 
 import { WebgpuVertexBufferLayout } from "./webgpu-vertex-buffer-layout.js";
@@ -72,10 +74,29 @@ const _stencilOps = [
 // temp array to avoid allocation
 const _bindGroupLayouts = [];
 
+/** @private */
+class CacheEntry {
+    /**
+     * Render pipeline
+     *
+     * @type {GPURenderPipeline}
+     */
+    pipeline;
+
+    /**
+     * The full array of hashes used to lookup the pipeline, used in case of hash collision.
+     *
+     * @type {Uint32Array}
+     */
+    hashes;
+}
+
 /**
  * @ignore
  */
 class WebgpuRenderPipeline {
+    lookupHashes = new Uint32Array(13);
+
     constructor(device) {
         /** @type {import('./webgpu-graphics-device.js').WebgpuGraphicsDevice} */
         this.device = device;
@@ -90,58 +111,72 @@ class WebgpuRenderPipeline {
         /**
          * The cache of render pipelines
          *
-         * @type {Map<string, object>}
+         * @type {Map<number, CacheEntry[]>}
          */
         this.cache = new Map();
     }
 
+
     get(primitive, vertexFormat0, vertexFormat1, shader, renderTarget, bindGroupFormats, blendState,
         depthState, cullMode, stencilEnabled, stencilFront, stencilBack) {
 
-        // render pipeline unique key
-        const key = this.getKey(primitive, vertexFormat0, vertexFormat1, shader, renderTarget, bindGroupFormats,
-                                blendState, depthState, cullMode, stencilEnabled, stencilFront, stencilBack);
+        Debug.assert(bindGroupFormats.length <= 3);
+
+        // render pipeline unique hash
+        const lookupHashes = this.lookupHashes;
+        lookupHashes[0] = primitive.type;
+        lookupHashes[1] = shader.id;
+        lookupHashes[2] = cullMode;
+        lookupHashes[3] = depthState.key;
+        lookupHashes[4] = blendState.key;
+        lookupHashes[5] = vertexFormat0?.renderingHash ?? 0;
+        lookupHashes[6] = vertexFormat1?.renderingHash ?? 0;
+        lookupHashes[7] = renderTarget.impl.key;
+        lookupHashes[8] = bindGroupFormats[0]?.key ?? 0;
+        lookupHashes[9] = bindGroupFormats[1]?.key ?? 0;
+        lookupHashes[10] = bindGroupFormats[2]?.key ?? 0;
+        lookupHashes[11] = stencilEnabled ? stencilFront.key : 0;
+        lookupHashes[12] = stencilEnabled ? stencilBack.key : 0;
+        const hash = fnv1aHashUint32Array(lookupHashes);
 
         // cached pipeline
-        let pipeline = this.cache.get(key);
-        if (!pipeline) {
+        let cacheEntries = this.cache.get(hash);
 
-            const primitiveTopology = _primitiveTopology[primitive.type];
-            Debug.assert(primitiveTopology, `Unsupported primitive topology`, primitive);
-
-            // pipeline layout
-            const pipelineLayout = this.getPipelineLayout(bindGroupFormats);
-
-            // vertex buffer layout
-            const vertexBufferLayout = this.vertexBufferLayout.get(vertexFormat0, vertexFormat1);
-
-            // pipeline
-            pipeline = this.create(primitiveTopology, shader, renderTarget, pipelineLayout, blendState,
-                                   depthState, vertexBufferLayout, cullMode, stencilEnabled, stencilFront, stencilBack);
-            this.cache.set(key, pipeline);
+        // if we have cache entries, find the exact match, as hash collision can occur
+        if (cacheEntries) {
+            for (let i = 0; i < cacheEntries.length; i++) {
+                const entry = cacheEntries[i];
+                if (array.equals(entry.hashes, lookupHashes)) {
+                    return entry.pipeline;
+                }
+            }
         }
 
-        return pipeline;
-    }
+        // no match or a hash collision, so create a new pipeline
+        const primitiveTopology = _primitiveTopology[primitive.type];
+        Debug.assert(primitiveTopology, `Unsupported primitive topology`, primitive);
 
-    /**
-     * Generate a unique key for the render pipeline. Keep this function as lean as possible,
-     * as it executes for each draw call.
-     */
-    getKey(primitive, vertexFormat0, vertexFormat1, shader, renderTarget, bindGroupFormats,
-        blendState, depthState, cullMode, stencilEnabled, stencilFront, stencilBack) {
+        // pipeline layout
+        const pipelineLayout = this.getPipelineLayout(bindGroupFormats);
 
-        let bindGroupKey = '';
-        for (let i = 0; i < bindGroupFormats.length; i++) {
-            bindGroupKey += bindGroupFormats[i].key;
+        // vertex buffer layout
+        const vertexBufferLayout = this.vertexBufferLayout.get(vertexFormat0, vertexFormat1);
+
+        // pipeline
+        const cacheEntry = new CacheEntry();
+        cacheEntry.hashes = new Uint32Array(lookupHashes);
+        cacheEntry.pipeline = this.create(primitiveTopology, shader, renderTarget, pipelineLayout, blendState,
+                                          depthState, vertexBufferLayout, cullMode, stencilEnabled, stencilFront, stencilBack);
+
+        // add to cache
+        if (cacheEntries) {
+            cacheEntries.push(cacheEntry);
+        } else {
+            cacheEntries = [cacheEntry];
         }
+        this.cache.set(hash, cacheEntries);
 
-        const vertexBufferLayoutKey = this.vertexBufferLayout.getKey(vertexFormat0, vertexFormat1);
-        const renderTargetKey = renderTarget.impl.key;
-        const stencilKey = stencilEnabled ? stencilFront.key + stencilBack.key : '';
-
-        return vertexBufferLayoutKey + shader.impl.vertexCode + shader.impl.fragmentCode +
-            renderTargetKey + primitive.type + bindGroupKey + blendState.key + depthState.key + cullMode + stencilKey;
+        return cacheEntry.pipeline;
     }
 
     // TODO: this could be cached using bindGroupKey

--- a/src/platform/graphics/webgpu/webgpu-render-target.js
+++ b/src/platform/graphics/webgpu/webgpu-render-target.js
@@ -1,5 +1,8 @@
 import { Debug, DebugHelper } from '../../../core/debug.js';
+import { StringIds } from '../../../core/string-ids.js';
 import { WebgpuDebug } from './webgpu-debug.js';
+
+const stringIds = new StringIds();
 
 /**
  * Private class storing info about color buffer.
@@ -37,7 +40,7 @@ class WebgpuRenderTarget {
     /**
      * Unique key used by render pipeline creation
      *
-     * @type {string}
+     * @type {number}
      */
     key;
 
@@ -127,11 +130,13 @@ class WebgpuRenderTarget {
         const rt = this.renderTarget;
 
         // key used by render pipeline creation
-        this.key = '';
-        this.colorAttachments.forEach((colorAttachment, index) => {
-            this.key += `${index}:${colorAttachment.format}-`;
+        let key = `${rt.samples}:${rt.depth ? this.depthFormat : 'nodepth'}`;
+        this.colorAttachments.forEach((colorAttachment) => {
+            key += `:${colorAttachment.format}`;
         });
-        this.key += `${rt.depth ? this.depthFormat : ''}-${rt.samples}`;
+
+        // convert string to a unique number
+        this.key = stringIds.get(key);
     }
 
     setDepthFormat(depthFormat) {

--- a/src/platform/graphics/webgpu/webgpu-vertex-buffer-layout.js
+++ b/src/platform/graphics/webgpu/webgpu-vertex-buffer-layout.js
@@ -51,7 +51,7 @@ class WebgpuVertexBufferLayout {
     }
 
     getKey(vertexFormat0, vertexFormat1 = null) {
-        return `VB[${vertexFormat0?.renderingHashString}, ${vertexFormat1?.renderingHashString}]`;
+        return `${vertexFormat0?.renderingHashString}-${vertexFormat1?.renderingHashString}`;
     }
 
     /**


### PR DESCRIPTION
The initial render pipeline cache was a string concatenation based and its performance was not ideal due to longer strings getting constructed / compared for each draw call.

This PR switches the unique ID from string to an array of numbers, which gets hashed to a single number for the cache lookup. To handle the hash collisions (which are pretty much non existing when testing with less than 100k unique arrays), the array compare is used as well.

Performance improvement in Hierarchy engine examples with over 5k draw calls:

![tweet](https://github.com/playcanvas/engine/assets/59932779/a3bf2165-98ff-41ca-b14f-f374dcddeab3)
