### PR TITLE
Remove string.toBool function

### DIFF
--- a/src/core/string.js
+++ b/src/core/string.js
@@ -141,32 +141,6 @@ const string = {
     },
 
     /**
-     * Convert a string value to a boolean. In non-strict mode (the default), 'true' is converted
-     * to true, all other values are converted to false. In strict mode, 'true' is converted to
-     * true, 'false' is converted to false, all other values will throw an Exception.
-     *
-     * @param {string} s - The string to convert.
-     * @param {boolean} [strict] - In strict mode an Exception is thrown if s is not an accepted
-     * string value. Defaults to false.
-     * @returns {boolean} The converted value.
-     */
-    toBool: function (s, strict = false) {
-        if (s === 'true') {
-            return true;
-        }
-
-        if (strict) {
-            if (s === 'false') {
-                return false;
-            }
-
-            throw new TypeError('Not a boolean string');
-        }
-
-        return false;
-    },
-
-    /**
      * Get the code point number for a character in a string. Polyfill for
      * [`codePointAt`]{@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/codePointAt}.
      *

--- a/test/core/string.test.mjs
+++ b/test/core/string.test.mjs
@@ -29,25 +29,6 @@ describe('string', function () {
 
     });
 
-    describe('#toBool', function () {
-
-        it('handles strict conversion', function () {
-            expect(string.toBool('true', true)).to.be.true;
-            expect(string.toBool('false', true)).to.be.false;
-            expect(function () {
-                string.toBool('abc', true);
-            }).to.throw;
-        });
-
-        it('handles non-strict conversion', function () {
-            expect(string.toBool('true')).to.be.true;
-            expect(string.toBool('false')).to.be.false;
-            expect(string.toBool('abc')).to.be.false;
-            expect(string.toBool(undefined)).to.be.false;
-        });
-
-    });
-
     describe('#getSymbols', function () {
 
         it('returns an array of the expected length', function () {


### PR DESCRIPTION
it’s not used by the engine nor the editor