### PR TITLE
Typedoc: assign categories to classes

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,15 @@
     "parser": "@babel/eslint-parser",
     "parserOptions": {
       "requireConfigFile": false
+    },
+    "rules": {
+      "jsdoc/check-tag-names": [
+        "error", {
+          "definedTags": [
+            "category"
+          ]
+        }
+      ]
     }
   },
   "eslintIgnore": [

--- a/src/core/math/color.js
+++ b/src/core/math/color.js
@@ -2,6 +2,8 @@ import { math } from './math.js';
 
 /**
  * Representation of an RGBA color.
+ *
+ * @category Math
  */
 class Color {
     /**

--- a/src/core/math/curve-set.js
+++ b/src/core/math/curve-set.js
@@ -4,6 +4,8 @@ import { CurveEvaluator } from './curve-evaluator.js';
 
 /**
  * A curve set is a collection of curves.
+ *
+ * @category Math
  */
 class CurveSet {
     curves = [];

--- a/src/core/math/curve.js
+++ b/src/core/math/curve.js
@@ -6,6 +6,8 @@ import { CurveEvaluator } from './curve-evaluator.js';
 /**
  * A curve is a collection of keys (time/value pairs). The shape of the curve is defined by its
  * type that specifies an interpolation scheme for the keys.
+ *
+ * @category Math
  */
 class Curve {
     keys = [];

--- a/src/core/math/mat3.js
+++ b/src/core/math/mat3.js
@@ -2,6 +2,8 @@ import { Vec3 } from './vec3.js';
 
 /**
  * A 3x3 matrix.
+ *
+ * @category Math
  */
 class Mat3 {
     /**

--- a/src/core/math/mat4.js
+++ b/src/core/math/mat4.js
@@ -11,6 +11,8 @@ const scale = new Vec3();
 
 /**
  * A 4x4 matrix.
+ *
+ * @category Math
  */
 class Mat4 {
     /**

--- a/src/core/math/quat.js
+++ b/src/core/math/quat.js
@@ -3,6 +3,8 @@ import { Vec3 } from './vec3.js';
 
 /**
  * A quaternion.
+ *
+ * @category Math
  */
 class Quat {
     /**

--- a/src/core/math/vec2.js
+++ b/src/core/math/vec2.js
@@ -1,5 +1,7 @@
 /**
  * A 2-dimensional vector.
+ *
+ * @category Math
  */
 class Vec2 {
     /**

--- a/src/core/math/vec3.js
+++ b/src/core/math/vec3.js
@@ -1,5 +1,7 @@
 /**
  * 3-dimensional vector.
+ *
+ * @category Math
  */
 class Vec3 {
     /**

--- a/src/core/math/vec4.js
+++ b/src/core/math/vec4.js
@@ -1,5 +1,7 @@
 /**
  * A 4-dimensional vector.
+ *
+ * @category Math
  */
 class Vec4 {
     /**

--- a/src/core/shape/bounding-box.js
+++ b/src/core/shape/bounding-box.js
@@ -9,6 +9,8 @@ const tmpVecE = new Vec3();
 
 /**
  * Axis-Aligned Bounding Box.
+ *
+ * @category Math
  */
 class BoundingBox {
     /**

--- a/src/core/shape/bounding-sphere.js
+++ b/src/core/shape/bounding-sphere.js
@@ -6,6 +6,8 @@ const tmpVecB = new Vec3();
 
 /**
  * A bounding sphere is a volume for facilitating fast intersection testing.
+ *
+ * @category Math
  */
 class BoundingSphere {
     /**

--- a/src/core/shape/frustum.js
+++ b/src/core/shape/frustum.js
@@ -2,6 +2,8 @@
  * A frustum is a shape that defines the viewing space of a camera. It can be used to determine
  * visibility of points and bounding spheres. Typically, you would not create a Frustum shape
  * directly, but instead query {@link CameraComponent#frustum}.
+ *
+ * @category Math
  */
 class Frustum {
     planes = [];

--- a/src/core/shape/oriented-box.js
+++ b/src/core/shape/oriented-box.js
@@ -13,6 +13,8 @@ const tmpMat4 = new Mat4();
 
 /**
  * Oriented Box.
+ *
+ * @category Math
  */
 class OrientedBox {
     halfExtents;

--- a/src/core/shape/plane.js
+++ b/src/core/shape/plane.js
@@ -3,6 +3,8 @@ import { Vec3 } from '../math/vec3.js';
 /**
  * An infinite plane. Internally it's represented in a parametric equation form:
  * ax + by + cz + distance = 0.
+ *
+ * @category Math
  */
 class Plane {
     /**

--- a/src/core/shape/ray.js
+++ b/src/core/shape/ray.js
@@ -2,6 +2,8 @@ import { Vec3 } from '../math/vec3.js';
 
 /**
  * An infinite ray.
+ *
+ * @category Math
  */
 class Ray {
     /**

--- a/src/framework/anim/evaluator/anim-curve.js
+++ b/src/framework/anim/evaluator/anim-curve.js
@@ -1,6 +1,8 @@
 /**
  * Animation curve links an input data set to an output data set and defines the interpolation
  * method to use.
+ *
+ * @category Animation
  */
 class AnimCurve {
     /**

--- a/src/framework/anim/evaluator/anim-data.js
+++ b/src/framework/anim/evaluator/anim-data.js
@@ -1,5 +1,7 @@
 /**
  * Wraps a set of data used in animation.
+ *
+ * @category Animation
  */
 class AnimData {
     /**

--- a/src/framework/anim/evaluator/anim-events.js
+++ b/src/framework/anim/evaluator/anim-events.js
@@ -1,6 +1,8 @@
 /**
  * AnimEvents stores a sorted array of animation events which should fire sequentially during the
  * playback of an pc.AnimTrack.
+ *
+ * @category Animation
  */
 class AnimEvents {
     /**

--- a/src/framework/anim/evaluator/anim-track.js
+++ b/src/framework/anim/evaluator/anim-track.js
@@ -3,6 +3,8 @@ import { AnimEvents } from './anim-events.js';
 /**
  * An AnimTrack stores the curve data necessary to animate a set of target nodes. It can be linked
  * to the nodes it should animate using the {@link AnimComponent#assignAnimation} method.
+ *
+ * @category Animation
  */
 class AnimTrack {
     /**

--- a/src/framework/anim/state-graph/anim-state-graph.js
+++ b/src/framework/anim/state-graph/anim-state-graph.js
@@ -9,6 +9,8 @@
  * entity.addComponent('anim');
  * entity.anim.loadStateGraph(animStateGraph);
  * ```
+ *
+ * @category Animation
  */
 class AnimStateGraph {
     /**

--- a/src/framework/components/anim/component-layer.js
+++ b/src/framework/components/anim/component-layer.js
@@ -7,6 +7,8 @@ import { ANIM_LAYER_OVERWRITE } from '../../anim/controller/constants.js';
 
 /**
  * The Anim Component Layer allows managers a single layer of the animation state graph.
+ *
+ * @category Animation
  */
 class AnimComponentLayer {
     /**

--- a/src/framework/components/anim/component.js
+++ b/src/framework/components/anim/component.js
@@ -19,6 +19,7 @@ import { AnimTrack } from '../../anim/evaluator/anim-track.js';
  * The Anim Component allows an Entity to playback animations on models and entity properties.
  *
  * @augments Component
+ * @category Animation
  */
 class AnimComponent extends Component {
     /**

--- a/src/framework/components/anim/system.js
+++ b/src/framework/components/anim/system.js
@@ -13,6 +13,7 @@ const _schema = [
  * The AnimComponentSystem manages creating and deleting AnimComponents.
  *
  * @augments ComponentSystem
+ * @category Animation
  */
 class AnimComponentSystem extends ComponentSystem {
     /**

--- a/src/framework/components/animation/component.js
+++ b/src/framework/components/animation/component.js
@@ -15,6 +15,7 @@ import { Component } from '../component.js';
  * The Animation Component allows an Entity to playback animations on models.
  *
  * @augments Component
+ * @category Animation
  */
 class AnimationComponent extends Component {
     /**

--- a/src/framework/components/animation/system.js
+++ b/src/framework/components/animation/system.js
@@ -12,6 +12,7 @@ const _schema = [
  * The AnimationComponentSystem manages creating and deleting AnimationComponents.
  *
  * @augments ComponentSystem
+ * @category Animation
  */
 class AnimationComponentSystem extends ComponentSystem {
     /**

--- a/src/framework/components/audio-listener/component.js
+++ b/src/framework/components/audio-listener/component.js
@@ -5,6 +5,7 @@ import { Component } from '../component.js';
  * correctly.
  *
  * @augments Component
+ * @category Sound
  */
 class AudioListenerComponent extends Component {
     /**

--- a/src/framework/components/audio-listener/system.js
+++ b/src/framework/components/audio-listener/system.js
@@ -12,6 +12,7 @@ const _schema = ['enabled'];
  * Component System for adding and removing {@link AudioListenerComponent} objects to Entities.
  *
  * @augments ComponentSystem
+ * @category Sound
  */
 class AudioListenerComponentSystem extends ComponentSystem {
     /**

--- a/src/framework/components/button/component.js
+++ b/src/framework/components/button/component.js
@@ -62,6 +62,7 @@ STATES_TO_SPRITE_FRAME_NAMES[VisualState.INACTIVE] = 'inactiveSpriteFrame';
  * button image when the button is not interactive.
  * @property {number} inactiveSpriteFrame Frame to be used from the inactive sprite.
  * @augments Component
+ * @category User Interface
  */
 class ButtonComponent extends Component {
     /**

--- a/src/framework/components/button/system.js
+++ b/src/framework/components/button/system.js
@@ -26,6 +26,7 @@ const _schema = [
  * Manages creation of {@link ButtonComponent}s.
  *
  * @augments ComponentSystem
+ * @category User Interface
  */
 class ButtonComponentSystem extends ComponentSystem {
     /**

--- a/src/framework/components/camera/component.js
+++ b/src/framework/components/camera/component.js
@@ -38,6 +38,7 @@ import { PostEffectQueue } from './post-effect-queue.js';
  * ```
  *
  * @augments Component
+ * @category Graphics
  */
 class CameraComponent extends Component {
     /**

--- a/src/framework/components/camera/post-effect-queue.js
+++ b/src/framework/components/camera/post-effect-queue.js
@@ -16,6 +16,8 @@ class PostEffect {
 
 /**
  * Used to manage multiple post effects for a camera.
+ *
+ * @category Graphics
  */
 class PostEffectQueue {
     /**

--- a/src/framework/components/camera/system.js
+++ b/src/framework/components/camera/system.js
@@ -15,6 +15,7 @@ const _schema = ['enabled'];
  * active cameras.
  *
  * @augments ComponentSystem
+ * @category Graphics
  */
 class CameraComponentSystem extends ComponentSystem {
     /**

--- a/src/framework/components/collision/component.js
+++ b/src/framework/components/collision/component.js
@@ -56,6 +56,7 @@ const _quat = new Quat();
  * @property {import('../../../scene/model.js').Model} model The model that is added to the scene
  * graph for the mesh collision volume.
  * @augments Component
+ * @category Physics
  */
 class CollisionComponent extends Component {
     /**

--- a/src/framework/components/collision/system.js
+++ b/src/framework/components/collision/system.js
@@ -567,6 +567,7 @@ class CollisionCompoundSystemImpl extends CollisionSystemImpl {
  * Manages creation of {@link CollisionComponent}s.
  *
  * @augments ComponentSystem
+ * @category Physics
  */
 class CollisionComponentSystem extends ComponentSystem {
     /**

--- a/src/framework/components/element/component.js
+++ b/src/framework/components/element/component.js
@@ -170,6 +170,7 @@ const matD = new Mat4();
  * @property {boolean} mask Switch Image Element into a mask. Masks do not render into the scene,
  * but instead limit child elements to only be rendered where this element is rendered.
  * @augments Component
+ * @category User Interface
  */
 class ElementComponent extends Component {
     /**

--- a/src/framework/components/element/element-drag-helper.js
+++ b/src/framework/components/element/element-drag-helper.js
@@ -26,6 +26,7 @@ const OPPOSITE_AXIS = {
  * Helper class that makes it easy to create Elements that can be dragged by the mouse or touch.
  *
  * @augments EventHandler
+ * @category User Interface
  */
 class ElementDragHelper extends EventHandler {
     /**

--- a/src/framework/components/element/system.js
+++ b/src/framework/components/element/system.js
@@ -23,6 +23,7 @@ const _schema = ['enabled'];
  * Manages creation of {@link ElementComponent}s.
  *
  * @augments ComponentSystem
+ * @category User Interface
  */
 class ElementComponentSystem extends ComponentSystem {
     /**

--- a/src/framework/components/layout-child/component.js
+++ b/src/framework/components/layout-child/component.js
@@ -5,6 +5,7 @@ import { Component } from '../component.js';
  * {@link LayoutGroupComponent}.
  *
  * @augments Component
+ * @category User Interface
  */
 class LayoutChildComponent extends Component {
     /**

--- a/src/framework/components/layout-child/system.js
+++ b/src/framework/components/layout-child/system.js
@@ -10,6 +10,7 @@ const _schema = ['enabled'];
  * Manages creation of {@link LayoutChildComponent}s.
  *
  * @augments ComponentSystem
+ * @category User Interface
  */
 class LayoutChildComponentSystem extends ComponentSystem {
     /**

--- a/src/framework/components/layout-group/component.js
+++ b/src/framework/components/layout-group/component.js
@@ -21,6 +21,7 @@ function isEnabledAndHasEnabledElement(entity) {
  * according to configurable layout rules.
  *
  * @augments Component
+ * @category User Interface
  */
 class LayoutGroupComponent extends Component {
     /**

--- a/src/framework/components/layout-group/system.js
+++ b/src/framework/components/layout-group/system.js
@@ -15,6 +15,7 @@ const MAX_ITERATIONS = 100;
  * Manages creation of {@link LayoutGroupComponent}s.
  *
  * @augments ComponentSystem
+ * @category User Interface
  */
 class LayoutGroupComponentSystem extends ComponentSystem {
     /**

--- a/src/framework/components/light/component.js
+++ b/src/framework/components/light/component.js
@@ -158,6 +158,7 @@ const _lightPropsDefault = [];
  * belong. Don't push/pop/splice or modify this array, if you want to change it - set a new one
  * instead.
  * @augments Component
+ * @category Graphics
  */
 class LightComponent extends Component {
     /**

--- a/src/framework/components/light/system.js
+++ b/src/framework/components/light/system.js
@@ -13,6 +13,7 @@ import { LightComponentData } from './data.js';
  * A Light Component is used to dynamically light the scene.
  *
  * @augments ComponentSystem
+ * @category Graphics
  */
 class LightComponentSystem extends ComponentSystem {
     /**

--- a/src/framework/components/model/component.js
+++ b/src/framework/components/model/component.js
@@ -17,6 +17,7 @@ import { Component } from '../component.js';
  * model geometry in to the scene graph below the Entity.
  *
  * @augments Component
+ * @category Graphics
  */
 class ModelComponent extends Component {
     /**

--- a/src/framework/components/model/system.js
+++ b/src/framework/components/model/system.js
@@ -21,6 +21,7 @@ const _schema = ['enabled'];
  * cone etc.
  *
  * @augments ComponentSystem
+ * @category Graphics
  */
 class ModelComponentSystem extends ComponentSystem {
     /**

--- a/src/framework/components/particle-system/component.js
+++ b/src/framework/components/particle-system/component.js
@@ -253,6 +253,7 @@ let depthLayer;
  * system should belong. Don't push/pop/splice or modify this array, if you want to change it - set
  * a new one instead.
  * @augments Component
+ * @category Graphics
  */
 class ParticleSystemComponent extends Component {
     /** @private */

--- a/src/framework/components/particle-system/system.js
+++ b/src/framework/components/particle-system/system.js
@@ -82,6 +82,7 @@ const _schema = [
  * Allows an Entity to render a particle system.
  *
  * @augments ComponentSystem
+ * @category Graphics
  */
 class ParticleSystemComponentSystem extends ComponentSystem {
     /**

--- a/src/framework/components/render/component.js
+++ b/src/framework/components/render/component.js
@@ -21,6 +21,7 @@ import { EntityReference } from '../../utils/entity-reference.js';
  * @property {import('../../entity.js').Entity} rootBone A reference to the entity to be used as
  * the root bone for any skinned meshes that are rendered by this component.
  * @augments Component
+ * @category Graphics
  */
 class RenderComponent extends Component {
     /** @private */

--- a/src/framework/components/render/system.js
+++ b/src/framework/components/render/system.js
@@ -38,6 +38,7 @@ const _properties = [
  * cone etc.
  *
  * @augments ComponentSystem
+ * @category Graphics
  */
 class RenderComponentSystem extends ComponentSystem {
     /**

--- a/src/framework/components/rigid-body/component.js
+++ b/src/framework/components/rigid-body/component.js
@@ -52,6 +52,7 @@ const _vec3 = new Vec3();
  * - [Vehicle physics](http://playcanvas.github.io/#physics/vehicle)
  *
  * @augments Component
+ * @category Physics
  */
 class RigidBodyComponent extends Component {
     /** @private */

--- a/src/framework/components/rigid-body/system.js
+++ b/src/framework/components/rigid-body/system.js
@@ -15,6 +15,8 @@ let ammoRayStart, ammoRayEnd;
 
 /**
  * Object holding the result of a successful raycast hit.
+ *
+ * @category Physics
  */
 class RaycastResult {
     /**
@@ -61,6 +63,8 @@ class RaycastResult {
 
 /**
  * Object holding the result of a contact between two rigid bodies.
+ *
+ * @category Physics
  */
 class SingleContactResult {
     /**
@@ -144,6 +148,8 @@ class SingleContactResult {
 
 /**
  * Object holding the result of a contact between two Entities.
+ *
+ * @category Physics
  */
 class ContactPoint {
     /**
@@ -210,6 +216,8 @@ class ContactPoint {
 
 /**
  * Object holding the result of a contact between two Entities.
+ *
+ * @category Physics
  */
 class ContactResult {
     /**
@@ -246,6 +254,7 @@ const _schema = ['enabled'];
  * settings for your project.
  *
  * @augments ComponentSystem
+ * @category Physics
  */
 class RigidBodyComponentSystem extends ComponentSystem {
     /**

--- a/src/framework/components/screen/component.js
+++ b/src/framework/components/screen/component.js
@@ -15,6 +15,7 @@ const _transform = new Mat4();
  * positions in the ScreenComponent's space.
  *
  * @augments Component
+ * @category User Interface
  */
 class ScreenComponent extends Component {
     /**

--- a/src/framework/components/screen/system.js
+++ b/src/framework/components/screen/system.js
@@ -14,6 +14,7 @@ const _schema = ['enabled'];
  * Manages creation of {@link ScreenComponent}s.
  *
  * @augments ComponentSystem
+ * @category User Interface
  */
 class ScreenComponentSystem extends ComponentSystem {
     /**

--- a/src/framework/components/scroll-view/component.js
+++ b/src/framework/components/scroll-view/component.js
@@ -55,6 +55,7 @@ const _tempScrollValue = new Vec2();
  * @property {import('../../entity.js').Entity} verticalScrollbarEntity The entity to be used as
  * the vertical scrollbar. This entity must have a Scrollbar component.
  * @augments Component
+ * @category User Interface
  */
 class ScrollViewComponent extends Component {
     /**

--- a/src/framework/components/scroll-view/system.js
+++ b/src/framework/components/scroll-view/system.js
@@ -30,6 +30,7 @@ const DEFAULT_DRAG_THRESHOLD = 10;
  * Manages creation of {@link ScrollViewComponent}s.
  *
  * @augments ComponentSystem
+ * @category User Interface
  */
 class ScrollViewComponentSystem extends ComponentSystem {
     /**

--- a/src/framework/components/scrollbar/component.js
+++ b/src/framework/components/scrollbar/component.js
@@ -25,6 +25,7 @@ import { EntityReference } from '../../utils/entity-reference.js';
  * @property {import('../../entity.js').Entity} handleEntity The entity to be used as the scrollbar
  * handle. This entity must have a Scrollbar component.
  * @augments Component
+ * @category User Interface
  */
 class ScrollbarComponent extends Component {
     /**

--- a/src/framework/components/scrollbar/system.js
+++ b/src/framework/components/scrollbar/system.js
@@ -16,6 +16,7 @@ const _schema = [
  * Manages creation of {@link ScrollbarComponent}s.
  *
  * @augments ComponentSystem
+ * @category User Interface
  */
 class ScrollbarComponentSystem extends ComponentSystem {
     /**

--- a/src/framework/components/sound/component.js
+++ b/src/framework/components/sound/component.js
@@ -10,6 +10,7 @@ import { SoundSlot } from './slot.js';
  * The Sound Component controls playback of {@link Sound}s.
  *
  * @augments Component
+ * @category Sound
  */
 class SoundComponent extends Component {
     /**

--- a/src/framework/components/sound/slot.js
+++ b/src/framework/components/sound/slot.js
@@ -32,6 +32,7 @@ const instanceOptions = {
  * The SoundSlot controls playback of an audio asset.
  *
  * @augments EventHandler
+ * @category Sound
  */
 class SoundSlot extends EventHandler {
     /**

--- a/src/framework/components/sound/system.js
+++ b/src/framework/components/sound/system.js
@@ -14,6 +14,7 @@ const _schema = ['enabled'];
  * Manages creation of {@link SoundComponent}s.
  *
  * @augments ComponentSystem
+ * @category Sound
  */
 class SoundComponentSystem extends ComponentSystem {
     /**

--- a/src/framework/components/sprite/component.js
+++ b/src/framework/components/sprite/component.js
@@ -31,6 +31,7 @@ const PARAM_ATLAS_RECT = 'atlasRect';
  * Enables an Entity to render a simple static sprite or sprite animations.
  *
  * @augments Component
+ * @category Graphics
  */
 class SpriteComponent extends Component {
     /**

--- a/src/framework/components/sprite/sprite-animation-clip.js
+++ b/src/framework/components/sprite/sprite-animation-clip.js
@@ -10,6 +10,7 @@ import { SPRITE_RENDERMODE_SIMPLE } from '../../../scene/constants.js';
  * Handles playing of sprite animations and loading of relevant sprite assets.
  *
  * @augments EventHandler
+ * @category Graphics
  */
 class SpriteAnimationClip extends EventHandler {
     /**

--- a/src/framework/components/sprite/system.js
+++ b/src/framework/components/sprite/system.js
@@ -21,6 +21,7 @@ const _schema = ['enabled'];
  * Manages creation of {@link SpriteComponent}s.
  *
  * @augments ComponentSystem
+ * @category Graphics
  */
 class SpriteComponentSystem extends ComponentSystem {
     /**

--- a/src/framework/font/font.js
+++ b/src/framework/font/font.js
@@ -2,6 +2,8 @@ import { FONT_MSDF } from './constants.js';
 
 /**
  * Represents the resource of a font asset.
+ *
+ * @category User Interface
  */
 class Font {
     /**

--- a/src/framework/graphics/picker.js
+++ b/src/framework/graphics/picker.js
@@ -31,6 +31,8 @@ const clearDepthOptions = {
  * @property {number} height Height of the pick buffer in pixels (read-only).
  * @property {RenderTarget} renderTarget The render target used by the picker internally
  * (read-only).
+ *
+ * @category Graphics
  */
 class Picker {
     // internal render target

--- a/src/framework/handlers/animation.js
+++ b/src/framework/handlers/animation.js
@@ -16,6 +16,7 @@ import { GlbParser } from '../parsers/glb-parser.js';
  * Resource handler used for loading {@link Animation} resources.
  *
  * @implements {ResourceHandler}
+ * @category Animation
  */
 class AnimationHandler {
     /**

--- a/src/framework/handlers/audio.js
+++ b/src/framework/handlers/audio.js
@@ -48,6 +48,7 @@ const supportedExtensions = [
  * Resource handler used for loading {@link Sound} resources.
  *
  * @implements {ResourceHandler}
+ * @category Sound
  */
 class AudioHandler {
     /**

--- a/src/framework/handlers/container.js
+++ b/src/framework/handlers/container.js
@@ -12,6 +12,7 @@ import { GlbContainerParser } from '../parsers/glb-container-parser.js';
  * @property {import('../asset/asset.js').Asset[]} materials An array of {@link Material} and/or {@link StandardMaterial} assets.
  * @property {import('../asset/asset.js').Asset[]} textures An array of the {@link Texture} assets.
  * @property {import('../asset/asset.js').Asset[]} animations An array of the {@link Animation} assets.
+ * @category Graphics
  */
 class ContainerResource {
     /**
@@ -162,6 +163,7 @@ class ContainerResource {
  * ```
  *
  * @implements {ResourceHandler}
+ * @category Graphics
  */
 class ContainerHandler {
     /**

--- a/src/framework/handlers/cubemap.js
+++ b/src/framework/handlers/cubemap.js
@@ -12,6 +12,7 @@ import { Asset } from '../asset/asset.js';
  * Resource handler used for loading cubemap {@link Texture} resources.
  *
  * @implements {ResourceHandler}
+ * @category Graphics
  */
 class CubemapHandler {
     /**

--- a/src/framework/handlers/font.js
+++ b/src/framework/handlers/font.js
@@ -35,6 +35,7 @@ function upgradeDataSchema(data) {
  * Resource handler used for loading {@link Font} resources.
  *
  * @implements {ResourceHandler}
+ * @category User Interface
  */
 class FontHandler {
     /**

--- a/src/framework/handlers/material.js
+++ b/src/framework/handlers/material.js
@@ -36,6 +36,7 @@ const PLACEHOLDER_MAP = {
  * Resource handler used for loading {@link Material} resources.
  *
  * @implements {ResourceHandler}
+ * @category Graphics
  */
 class MaterialHandler {
     /**

--- a/src/framework/handlers/model.js
+++ b/src/framework/handlers/model.js
@@ -23,6 +23,7 @@ import { JsonModelParser } from '../parsers/json-model.js';
  * Resource handler used for loading {@link Model} resources.
  *
  * @implements {ResourceHandler}
+ * @category Graphics
  */
 class ModelHandler {
     /**

--- a/src/framework/handlers/render.js
+++ b/src/framework/handlers/render.js
@@ -45,6 +45,7 @@ function onContainerAssetRemoved(containerAsset) {
  * Resource handler used for loading {@link Render} resources.
  *
  * @implements {ResourceHandler}
+ * @category Graphics
  */
 class RenderHandler {
     /**

--- a/src/framework/handlers/scene.js
+++ b/src/framework/handlers/scene.js
@@ -7,6 +7,7 @@ import { SceneParser } from '../parsers/scene.js';
  * Resource handler used for loading {@link Scene} resources.
  *
  * @implements {ResourceHandler}
+ * @category Graphics
  */
 class SceneHandler {
     /**

--- a/src/framework/handlers/sprite.js
+++ b/src/framework/handlers/sprite.js
@@ -24,6 +24,7 @@ function onTextureAtlasAdded(atlasAsset) {
  * Resource handler used for loading {@link Sprite} resources.
  *
  * @implements {ResourceHandler}
+ * @category Graphics
  */
 class SpriteHandler {
     /**

--- a/src/framework/handlers/texture-atlas.js
+++ b/src/framework/handlers/texture-atlas.js
@@ -34,6 +34,7 @@ const regexFrame = /^data\.frames\.(\d+)$/;
  * Resource handler used for loading {@link TextureAtlas} resources.
  *
  * @implements {ResourceHandler}
+ * @category Graphics
  */
 class TextureAtlasHandler {
     /**

--- a/src/framework/handlers/texture.js
+++ b/src/framework/handlers/texture.js
@@ -46,6 +46,8 @@ const JSON_TEXTURE_TYPE = {
  * @name TextureParser
  * @description Interface to a texture parser. Implementations of this interface handle the loading
  * and opening of texture assets.
+ *
+ * @category Graphics
  */
 class TextureParser {
     /* eslint-disable jsdoc/require-returns-check */
@@ -157,6 +159,7 @@ const _completePartialMipmapChain = function (texture) {
  * Resource handler used for loading 2D and 3D {@link Texture} resources.
  *
  * @implements {ResourceHandler}
+ * @category Graphics
  */
 class TextureHandler {
     /**

--- a/src/framework/input/element-input.js
+++ b/src/framework/input/element-input.js
@@ -109,6 +109,8 @@ function intersectLineQuad(p, q, corners) {
 /**
  * Represents an input event fired on a {@link ElementComponent}. When an event is raised on an
  * ElementComponent it bubbles up to its parent ElementComponents unless we call stopPropagation().
+ *
+ * @category User Interface
  */
 class ElementInputEvent {
     /**
@@ -163,6 +165,7 @@ class ElementInputEvent {
  * Represents a Mouse event fired on a {@link ElementComponent}.
  *
  * @augments ElementInputEvent
+ * @category User Interface
  */
 class ElementMouseEvent extends ElementInputEvent {
     /**
@@ -257,6 +260,7 @@ class ElementMouseEvent extends ElementInputEvent {
  * Represents a TouchEvent fired on a {@link ElementComponent}.
  *
  * @augments ElementInputEvent
+ * @category User Interface
  */
 class ElementTouchEvent extends ElementInputEvent {
     /**
@@ -303,6 +307,7 @@ class ElementTouchEvent extends ElementInputEvent {
  * Represents a XRInputSourceEvent fired on a {@link ElementComponent}.
  *
  * @augments ElementInputEvent
+ * @category User Interface
  */
 class ElementSelectEvent extends ElementInputEvent {
     /**
@@ -331,6 +336,8 @@ class ElementSelectEvent extends ElementInputEvent {
 /**
  * Handles mouse and touch events for {@link ElementComponent}s. When input events occur on an
  * ElementComponent this fires the appropriate events on the ElementComponent.
+ *
+ * @category User Interface
  */
 class ElementInput {
     /**

--- a/src/framework/lightmapper/lightmapper.js
+++ b/src/framework/lightmapper/lightmapper.js
@@ -56,6 +56,8 @@ const tempVec = new Vec3();
 
 /**
  * The lightmapper is used to bake scene lights into textures.
+ *
+ * @category Graphics
  */
 class Lightmapper {
     /**

--- a/src/framework/scene-registry-item.js
+++ b/src/framework/scene-registry-item.js
@@ -1,5 +1,7 @@
 /**
  * Item to be stored in the {@link SceneRegistry}.
+ *
+ * @category Graphics
  */
 class SceneRegistryItem {
     /**

--- a/src/framework/scene-registry.js
+++ b/src/framework/scene-registry.js
@@ -47,6 +47,8 @@ import { SceneRegistryItem } from './scene-registry-item.js';
 /**
  * Container for storing and loading of scenes. An instance of the registry is created on the
  * {@link AppBase} object as {@link AppBase#scenes}.
+ *
+ * @category Graphics
  */
 class SceneRegistry {
     /**

--- a/src/framework/xr/xr-depth-sensing.js
+++ b/src/framework/xr/xr-depth-sensing.js
@@ -63,6 +63,7 @@ import { XRDEPTHSENSINGUSAGE_CPU, XRDEPTHSENSINGUSAGE_GPU } from './constants.js
  * ```
  *
  * @augments EventHandler
+ * @category XR
  */
 class XrDepthSensing extends EventHandler {
     /**

--- a/src/framework/xr/xr-dom-overlay.js
+++ b/src/framework/xr/xr-dom-overlay.js
@@ -20,6 +20,8 @@ import { platform } from '../../core/platform.js';
  *     evt.preventDefault();
  * });
  * ```
+ *
+ * @category XR
  */
 class XrDomOverlay {
     /**

--- a/src/framework/xr/xr-finger.js
+++ b/src/framework/xr/xr-finger.js
@@ -1,5 +1,7 @@
 /**
  * Represents finger with related joints and index.
+ *
+ * @category XR
  */
 class XrFinger {
     /**

--- a/src/framework/xr/xr-hand.js
+++ b/src/framework/xr/xr-hand.js
@@ -31,6 +31,7 @@ if (platform.browser && window.XRHand) {
  * Represents a hand with fingers and joints.
  *
  * @augments EventHandler
+ * @category XR
  */
 class XrHand extends EventHandler {
     /**

--- a/src/framework/xr/xr-hit-test-source.js
+++ b/src/framework/xr/xr-hit-test-source.js
@@ -19,6 +19,7 @@ const poolQuat = [];
  * AR session.
  *
  * @augments EventHandler
+ * @category XR
  */
 class XrHitTestSource extends EventHandler {
     /**

--- a/src/framework/xr/xr-hit-test.js
+++ b/src/framework/xr/xr-hit-test.js
@@ -18,6 +18,7 @@ import { XrHitTestSource } from './xr-hit-test-source.js';
  * representation of real world geometry by underlying AR system.
  *
  * @augments EventHandler
+ * @category XR
  */
 class XrHitTest extends EventHandler {
     /**

--- a/src/framework/xr/xr-image-tracking.js
+++ b/src/framework/xr/xr-image-tracking.js
@@ -8,6 +8,7 @@ import { XrTrackedImage } from './xr-tracked-image.js';
  * their estimated sizes.
  *
  * @augments EventHandler
+ * @category XR
  */
 class XrImageTracking extends EventHandler {
     /**

--- a/src/framework/xr/xr-input-source.js
+++ b/src/framework/xr/xr-input-source.js
@@ -16,6 +16,7 @@ let ids = 0;
  * that operate on the viewer's pose.
  *
  * @augments EventHandler
+ * @category XR
  */
 class XrInputSource extends EventHandler {
     /**

--- a/src/framework/xr/xr-input.js
+++ b/src/framework/xr/xr-input.js
@@ -6,6 +6,7 @@ import { XrInputSource } from './xr-input-source.js';
  * Provides access to input sources for WebXR.
  *
  * @augments EventHandler
+ * @category XR
  */
 class XrInput extends EventHandler {
     /**

--- a/src/framework/xr/xr-joint.js
+++ b/src/framework/xr/xr-joint.js
@@ -19,6 +19,8 @@ for (let i = 0; i < tipJointIds.length; i++) {
 
 /**
  * Represents the joint of a finger.
+ *
+ * @category XR
  */
 class XrJoint {
     /**

--- a/src/framework/xr/xr-light-estimation.js
+++ b/src/framework/xr/xr-light-estimation.js
@@ -19,6 +19,7 @@ const mat4B = new Mat4();
  * directional light, its rotation, intensity and color.
  *
  * @augments EventHandler
+ * @category XR
  */
 class XrLightEstimation extends EventHandler {
     /**

--- a/src/framework/xr/xr-manager.js
+++ b/src/framework/xr/xr-manager.js
@@ -28,6 +28,7 @@ import { XrPlaneDetection } from './xr-plane-detection.js';
  * Manage and update XR session and its states.
  *
  * @augments EventHandler
+ * @category XR
  */
 class XrManager extends EventHandler {
     /**

--- a/src/framework/xr/xr-plane-detection.js
+++ b/src/framework/xr/xr-plane-detection.js
@@ -18,6 +18,8 @@ import { XrPlane } from './xr-plane.js';
  *     // new plane been added
  * });
  * ```
+ *
+ * @category XR
  */
 class XrPlaneDetection extends EventHandler {
     /**

--- a/src/framework/xr/xr-plane.js
+++ b/src/framework/xr/xr-plane.js
@@ -7,6 +7,8 @@ let ids = 0;
 /**
  * Detected Plane instance that provides position, rotation and polygon points. Plane is a subject
  * to change during its lifetime.
+ *
+ * @category XR
  */
 class XrPlane extends EventHandler {
     /**

--- a/src/framework/xr/xr-tracked-image.js
+++ b/src/framework/xr/xr-tracked-image.js
@@ -8,6 +8,7 @@ import { Quat } from '../../core/math/quat.js';
  * well as the position and rotation of the tracked image.
  *
  * @augments EventHandler
+ * @category XR
  */
 class XrTrackedImage extends EventHandler {
     /**

--- a/src/platform/graphics/blend-state.js
+++ b/src/platform/graphics/blend-state.js
@@ -28,6 +28,8 @@ const allWriteShift = redWriteShift;
  *
  * For the best performance, do not modify blend state after it has been created, but create
  * multiple blend states and assign them to the material or graphics device as needed.
+ *
+ * @category Graphics
  */
 class BlendState {
     /**

--- a/src/platform/graphics/depth-state.js
+++ b/src/platform/graphics/depth-state.js
@@ -17,6 +17,8 @@ const writeShift = 3;      // 03 - 03 (1bit)
  *
  * For the best performance, do not modify depth state after it has been created, but create
  * multiple depth states and assign them to the material or graphics device as needed.
+ *
+ * @category Graphics
  */
 class DepthState {
     /**

--- a/src/platform/graphics/graphics-device.js
+++ b/src/platform/graphics/graphics-device.js
@@ -25,6 +25,7 @@ import { StencilParameters } from './stencil-parameters.js';
  * create a new graphics device against each.
  *
  * @augments EventHandler
+ * @category Graphics
  */
 class GraphicsDevice extends EventHandler {
     /**

--- a/src/platform/graphics/index-buffer.js
+++ b/src/platform/graphics/index-buffer.js
@@ -11,6 +11,8 @@ let id = 0;
  * can normally utilize less memory that unindexed primitives (if vertices are shared).
  *
  * Typically, index buffers are set on {@link Mesh} objects.
+ *
+ * @category Graphics
  */
 class IndexBuffer {
     /**

--- a/src/platform/graphics/render-target.js
+++ b/src/platform/graphics/render-target.js
@@ -8,6 +8,8 @@ let id = 0;
 
 /**
  * A render target is a rectangular rendering surface.
+ *
+ * @category Graphics
  */
 class RenderTarget {
     /** @type {string} */

--- a/src/platform/graphics/scope-id.js
+++ b/src/platform/graphics/scope-id.js
@@ -2,6 +2,8 @@ import { VersionedObject } from './versioned-object.js';
 
 /**
  * The scope for a variable.
+ *
+ * @category Graphics
  */
 class ScopeId {
     /**

--- a/src/platform/graphics/scope-space.js
+++ b/src/platform/graphics/scope-space.js
@@ -2,6 +2,8 @@ import { ScopeId } from './scope-id.js';
 
 /**
  * The scope for variables.
+ *
+ * @category Graphics
  */
 class ScopeSpace {
     /**

--- a/src/platform/graphics/shader.js
+++ b/src/platform/graphics/shader.js
@@ -12,6 +12,8 @@ let id = 0;
  * the code is GLSL (or more specifically ESSL, the OpenGL ES Shading Language). The shader
  * definition also describes how the PlayCanvas engine should map vertex buffer elements onto the
  * attributes specified in the vertex shader code.
+ *
+ * @category Graphics
  */
 class Shader {
     /**

--- a/src/platform/graphics/stencil-parameters.js
+++ b/src/platform/graphics/stencil-parameters.js
@@ -5,6 +5,8 @@ const stringIds = new StringIds();
 
 /**
  * Holds stencil test settings.
+ *
+ * @category Graphics
  */
 class StencilParameters {
     /** @type {number} */

--- a/src/platform/graphics/texture.js
+++ b/src/platform/graphics/texture.js
@@ -23,6 +23,8 @@ let id = 0;
 /**
  * A texture is a container for texel data that can be utilized in a fragment shader. Typically,
  * the texel data represents an image that is mapped over geometry.
+ *
+ * @category Graphics
  */
 class Texture {
     /**

--- a/src/platform/graphics/transform-feedback.js
+++ b/src/platform/graphics/transform-feedback.js
@@ -71,6 +71,8 @@ import { ShaderUtils } from './shader-utils.js';
  *     this.tf.process(this.shader);
  * };
  * ```
+ *
+ * @category Graphics
  */
 class TransformFeedback {
     /**

--- a/src/platform/graphics/vertex-buffer.js
+++ b/src/platform/graphics/vertex-buffer.js
@@ -7,6 +7,8 @@ let id = 0;
 /**
  * A vertex buffer is the mechanism via which the application specifies vertex data to the graphics
  * hardware.
+ *
+ * @category Graphics
  */
 class VertexBuffer {
     /**

--- a/src/platform/graphics/vertex-format.js
+++ b/src/platform/graphics/vertex-format.js
@@ -55,6 +55,7 @@ const stringIds = new StringIds();
  * @property {number} elements[].stride The number of total bytes that are between the start of one
  * vertex, and the start of the next.
  * @property {number} elements[].size The size of the attribute in bytes.
+ * @category Graphics
  */
 class VertexFormat {
     /**

--- a/src/platform/graphics/vertex-iterator.js
+++ b/src/platform/graphics/vertex-iterator.js
@@ -69,6 +69,8 @@ function arrayGet4(offset, outputArray, outputIndex) {
 
 /**
  * Helps with accessing a specific vertex attribute.
+ *
+ * @category Graphics
  */
 class VertexIteratorAccessor {
     /**
@@ -211,6 +213,8 @@ class VertexIteratorAccessor {
 
 /**
  * A vertex iterator simplifies the process of writing vertex data to a vertex buffer.
+ *
+ * @category Graphics
  */
 class VertexIterator {
     /**

--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -247,6 +247,7 @@ function testTextureFloatHighPrecision(device) {
  * create a new graphics device against each.
  *
  * @augments GraphicsDevice
+ * @category Graphics
  */
 class WebglGraphicsDevice extends GraphicsDevice {
     /**

--- a/src/platform/input/controller.js
+++ b/src/platform/input/controller.js
@@ -12,6 +12,8 @@ import { Mouse } from './mouse.js';
 /**
  * A general input handler which handles both mouse and keyboard input assigned to named actions.
  * This allows you to define input handlers separately to defining keyboard/mouse configurations.
+ *
+ * @category Input
  */
 class Controller {
     /**

--- a/src/platform/input/game-pads.js
+++ b/src/platform/input/game-pads.js
@@ -265,6 +265,8 @@ function sleep(ms) {
 
 /**
  * A GamePadButton stores information about a button from the Gamepad API.
+ *
+ * @category Input
  */
 class GamePadButton {
     /**
@@ -364,6 +366,8 @@ const dummyButton = Object.freeze(new GamePadButton(0));
 
 /**
  * A GamePad stores information about a gamepad from the Gamepad API.
+ *
+ * @category Input
  */
 class GamePad {
     /**
@@ -768,6 +772,7 @@ class GamePad {
  * Input handler for accessing GamePad input.
  *
  * @augments EventHandler
+ * @category Input
  */
 class GamePads extends EventHandler {
     /**

--- a/src/platform/input/keyboard-event.js
+++ b/src/platform/input/keyboard-event.js
@@ -1,6 +1,8 @@
 /**
  * The KeyboardEvent is passed into all event callbacks from the {@link Keyboard}. It corresponds
  * to a key press or release.
+ *
+ * @category Input
  */
 class KeyboardEvent {
     /**

--- a/src/platform/input/keyboard.js
+++ b/src/platform/input/keyboard.js
@@ -57,6 +57,7 @@ const _keyCodeToKeyIdentifier = {
  * that the Keyboard object must be attached to an Element before it can detect any key presses.
  *
  * @augments EventHandler
+ * @category Input
  */
 class Keyboard extends EventHandler {
     /**

--- a/src/platform/input/mouse-event.js
+++ b/src/platform/input/mouse-event.js
@@ -12,6 +12,8 @@ function isMousePointerLocked() {
 
 /**
  * MouseEvent object that is passed to events 'mousemove', 'mouseup', 'mousedown' and 'mousewheel'.
+ *
+ * @category Input
  */
 class MouseEvent {
     /**

--- a/src/platform/input/mouse.js
+++ b/src/platform/input/mouse.js
@@ -14,6 +14,7 @@ import { isMousePointerLocked, MouseEvent } from './mouse-event.js';
  * A Mouse Device, bound to a DOM Element.
  *
  * @augments EventHandler
+ * @category Input
  */
 class Mouse extends EventHandler {
     /**

--- a/src/platform/input/touch-device.js
+++ b/src/platform/input/touch-device.js
@@ -7,6 +7,7 @@ import { TouchEvent } from './touch-event.js';
  * touched. See also {@link Touch} and {@link TouchEvent}.
  *
  * @augments EventHandler
+ * @category Input
  */
 class TouchDevice extends EventHandler {
     /**

--- a/src/platform/input/touch-event.js
+++ b/src/platform/input/touch-event.js
@@ -29,6 +29,8 @@ function getTouchTargetCoords(touch) {
 
 /**
  * A instance of a single point touch on a {@link TouchDevice}.
+ *
+ * @category Input
  */
 class Touch {
     /**
@@ -78,6 +80,8 @@ class Touch {
 /**
  * A Event corresponding to touchstart, touchend, touchmove or touchcancel. TouchEvent wraps the
  * standard browser event and provides lists of {@link Touch} objects.
+ *
+ * @category Input
  */
 class TouchEvent {
     /**

--- a/src/platform/sound/instance.js
+++ b/src/platform/sound/instance.js
@@ -24,6 +24,7 @@ function capTime(time, duration) {
  * A SoundInstance plays a {@link Sound}.
  *
  * @augments EventHandler
+ * @category Sound
  */
 class SoundInstance extends EventHandler {
     /**

--- a/src/platform/sound/instance3d.js
+++ b/src/platform/sound/instance3d.js
@@ -14,6 +14,7 @@ const MAX_DISTANCE = 10000;
  * A SoundInstance3d plays a {@link Sound} in 3D.
  *
  * @augments SoundInstance
+ * @category Sound
  */
 class SoundInstance3d extends SoundInstance {
     /**

--- a/src/platform/sound/manager.js
+++ b/src/platform/sound/manager.js
@@ -23,6 +23,7 @@ const USER_INPUT_EVENTS = [
  * global volume, suspend and resume.
  *
  * @augments EventHandler
+ * @category Sound
  */
 class SoundManager extends EventHandler {
     /**

--- a/src/platform/sound/sound.js
+++ b/src/platform/sound/sound.js
@@ -1,5 +1,7 @@
 /**
  * Represents the resource of an audio asset.
+ *
+ * @category Sound
  */
 class Sound {
     /**

--- a/src/scene/animation/animation.js
+++ b/src/scene/animation/animation.js
@@ -9,6 +9,8 @@ class Key {
 
 /**
  * A animation node has a name and contains an array of keyframes.
+ *
+ * @category Animation
  */
 class Node {
     /**
@@ -23,6 +25,8 @@ class Node {
 /**
  * An animation is a sequence of keyframe arrays which map to the nodes of a skeletal hierarchy. It
  * controls how the nodes of the hierarchy are transformed over time.
+ *
+ * @category Animation
  */
 class Animation {
     /**

--- a/src/scene/animation/skeleton.js
+++ b/src/scene/animation/skeleton.js
@@ -28,6 +28,8 @@ class InterpolatedKey {
 
 /**
  * Represents a skeleton used to play animations.
+ *
+ * @category Animation
  */
 class Skeleton {
     /**

--- a/src/scene/batching/batch-group.js
+++ b/src/scene/batching/batch-group.js
@@ -2,6 +2,8 @@ import { LAYERID_WORLD } from '../constants.js';
 
 /**
  * Holds mesh batching settings and a unique id. Created via {@link BatchManager#addGroup}.
+ *
+ * @category Graphics
  */
 class BatchGroup {
     /** @private */

--- a/src/scene/batching/batch-manager.js
+++ b/src/scene/batching/batch-manager.js
@@ -70,6 +70,8 @@ function getScaleSign(mi) {
 
 /**
  * Glues many mesh instances into a single one for better performance.
+ *
+ * @category Graphics
  */
 class BatchManager {
     /**

--- a/src/scene/batching/batch.js
+++ b/src/scene/batching/batch.js
@@ -2,6 +2,8 @@ import { BoundingBox } from '../../core/shape/bounding-box.js';
 
 /**
  * Holds information about batched mesh instances. Created in {@link BatchManager#create}.
+ *
+ * @category Graphics
  */
 class Batch {
     /** @private */

--- a/src/scene/composition/layer-composition.js
+++ b/src/scene/composition/layer-composition.js
@@ -23,6 +23,7 @@ const tempClusterArray = [];
  * rendering order.
  *
  * @augments EventHandler
+ * @category Graphics
  */
 class LayerComposition extends EventHandler {
     // Composition can hold only 2 sublayers of each layer

--- a/src/scene/graphics/post-effect.js
+++ b/src/scene/graphics/post-effect.js
@@ -8,6 +8,8 @@ const _viewport = new Vec4();
  * Base class for all post effects. Post effects take a a render target as input apply effects to
  * it and then render the result to an output render target or the screen if no output is
  * specified.
+ *
+ * @category Graphics
  */
 class PostEffect {
     /**

--- a/src/scene/graphics/quad-render.js
+++ b/src/scene/graphics/quad-render.js
@@ -28,6 +28,8 @@ const _tempScissor = new Vec4();
  * quad.render();
  * quad.destroy();
  * ```
+ *
+ * @category Graphics
  */
 class QuadRender {
     /**

--- a/src/scene/layer.js
+++ b/src/scene/layer.js
@@ -94,6 +94,8 @@ class InstanceList {
  * A Layer represents a renderable subset of the scene. It can contain a list of mesh instances,
  * lights and cameras, their render settings and also defines custom callbacks before, after or
  * during rendering. Layers are organized inside {@link LayerComposition} in a desired order.
+ *
+ * @category Graphics
  */
 class Layer {
     /**

--- a/src/scene/lighting/lighting-params.js
+++ b/src/scene/lighting/lighting-params.js
@@ -5,6 +5,8 @@ import { SHADOW_PCF3 } from '../constants.js';
 /**
  * Lighting parameters, allow configuration of the global lighting parameters. For details see
  * [Clustered Lighting](https://developer.playcanvas.com/en/user-manual/graphics/lighting/clustered-lighting/).
+ *
+ * @category Graphics
  */
 class LightingParams {
     /** @private */

--- a/src/scene/materials/basic-material.js
+++ b/src/scene/materials/basic-material.js
@@ -16,6 +16,7 @@ import { Material } from './material.js';
  * modulated with a color.
  *
  * @augments Material
+ * @category Graphics
  */
 class BasicMaterial extends Material {
     /**

--- a/src/scene/materials/custom-material.js
+++ b/src/scene/materials/custom-material.js
@@ -11,7 +11,6 @@ import { custom } from '../shader-lib/programs/custom.js';
  *
  * @ignore
  */
-
 class CustomMaterial extends Material {
     _litOptions = new LitOptions();
 

--- a/src/scene/materials/lit-options.js
+++ b/src/scene/materials/lit-options.js
@@ -6,6 +6,8 @@ import {
 /**
  * The lit options determines how the lit-shader gets generated. It specifies a set of
  * parameters which triggers different fragment and vertex shader generation in the backend.
+ *
+ * @category Graphics
  */
 class LitOptions {
     hasTangents = false;

--- a/src/scene/materials/material.js
+++ b/src/scene/materials/material.js
@@ -39,6 +39,8 @@ let id = 0;
 /**
  * A material determines how a particular mesh instance is rendered. It specifies the shader and
  * render state that is set before the mesh instance is submitted to the graphics device.
+ *
+ * @category Graphics
  */
 class Material {
     /**

--- a/src/scene/materials/standard-material-options.js
+++ b/src/scene/materials/standard-material-options.js
@@ -3,6 +3,8 @@ import { LitOptions } from "./lit-options.js";
 /**
  * The standard material options define a set of options used to control the shader frontend shader
  * generation, such as textures, tints and multipliers.
+ *
+ * @category Graphics
  */
 class StandardMaterialOptions {
     /** @private */

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -532,6 +532,7 @@ let _params = new Set();
  * standard material options are {@link StandardMaterialOptions} and the options for the lit options
  * are {@link LitOptions}.
  * @augments Material
+ * @category Graphics
  */
 class StandardMaterial extends Material {
     static TEXTURE_PARAMETERS = standardMaterialTextureParameters;

--- a/src/scene/mesh-instance.js
+++ b/src/scene/mesh-instance.js
@@ -73,6 +73,8 @@ class Command {
 /**
  * An instance of a {@link Mesh}. A single mesh can be referenced by many mesh instances that can
  * have different transforms and materials.
+ *
+ * @category Graphics
  */
 class MeshInstance {
     /**

--- a/src/scene/mesh.js
+++ b/src/scene/mesh.js
@@ -158,6 +158,8 @@ class GeometryVertexStream {
  * This allows greater flexibility, but is more complex to use. It allows more advanced setups, for
  * example sharing a Vertex or Index Buffer between multiple meshes. See {@link VertexBuffer},
  * {@link IndexBuffer} and {@link VertexFormat} for details.
+ *
+ * @category Graphics
  */
 class Mesh extends RefCountedObject {
     /**

--- a/src/scene/model.js
+++ b/src/scene/model.js
@@ -6,6 +6,8 @@ import { SkinInstance } from './skin-instance.js';
 /**
  * A model is a graphical object that can be added to or removed from a scene. It contains a
  * hierarchy and any number of mesh instances.
+ *
+ * @category Graphics
  */
 class Model {
     /**

--- a/src/scene/morph-instance.js
+++ b/src/scene/morph-instance.js
@@ -23,6 +23,8 @@ const blendStateAdditive = new BlendState(true, BLENDEQUATION_ADD, BLENDMODE_ONE
 /**
  * An instance of {@link Morph}. Contains weights to assign to every {@link MorphTarget}, manages
  * selection of active morph targets.
+ *
+ * @category Graphics
  */
 class MorphInstance {
     /**

--- a/src/scene/morph-target.js
+++ b/src/scene/morph-target.js
@@ -9,6 +9,8 @@ import { VertexFormat } from '../platform/graphics/vertex-format.js';
  * A Morph Target (also known as Blend Shape) contains deformation data to apply to existing mesh.
  * Multiple morph targets can be blended together on a mesh. This is useful for effects that are
  * hard to achieve with conventional animation and skinning.
+ *
+ * @category Graphics
  */
 class MorphTarget {
     /**

--- a/src/scene/morph.js
+++ b/src/scene/morph.js
@@ -15,6 +15,8 @@ import { GraphicsDeviceAccess } from '../platform/graphics/graphics-device-acces
 
 /**
  * Contains a list of {@link MorphTarget}, a combined delta AABB and some associated data.
+ *
+ * @category Graphics
  */
 class Morph extends RefCountedObject {
     /** @type {BoundingBox} */

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -21,6 +21,7 @@ import { EnvLighting } from './graphics/env-lighting.js';
  * graphical objects, lights, and scene-wide properties.
  *
  * @augments EventHandler
+ * @category Graphics
  */
 class Scene extends EventHandler {
     /**

--- a/src/scene/skin-instance.js
+++ b/src/scene/skin-instance.js
@@ -10,6 +10,8 @@ const _invMatrix = new Mat4();
 /**
  * A skin instance is responsible for generating the matrix palette that is used to skin vertices
  * from object space to world space.
+ *
+ * @category Graphics
  */
 class SkinInstance {
     /**

--- a/src/scene/skin.js
+++ b/src/scene/skin.js
@@ -2,6 +2,8 @@
  * A skin contains data about the bones in a hierarchy that drive a skinned mesh animation.
  * Specifically, the skin stores the bone name and inverse bind matrix and for each bone. Inverse
  * bind matrices are instrumental in the mathematics of vertex skinning.
+ *
+ * @category Graphics
  */
 class Skin {
     /**

--- a/src/scene/sprite.js
+++ b/src/scene/sprite.js
@@ -24,6 +24,7 @@ const spriteIndices = [
  * animation.
  *
  * @augments EventHandler
+ * @category Graphics
  */
 class Sprite extends EventHandler {
     /**

--- a/src/scene/texture-atlas.js
+++ b/src/scene/texture-atlas.js
@@ -5,6 +5,7 @@ import { EventHandler } from '../core/event-handler.js';
  * texture. The TextureAtlas is referenced by {@link Sprite}s.
  *
  * @augments EventHandler
+ * @category Graphics
  */
 class TextureAtlas extends EventHandler {
     /**


### PR DESCRIPTION
The API reference manual doesn't make any attempt to group related API into categories. Doing so enables developers to more easily find what they're looking forward if they are working in a specific area (e.g. physics, animation, graphics, etc).

So this PR updates the top-level landing page from this:

![Screenshot 2023-07-22 at 09-49-11 PlayCanvas Engine API](https://github.com/playcanvas/engine/assets/697563/09a02520-f925-4602-ba6e-cd3b383f95d9)

To this:

![Screenshot 2023-07-22 at 09-48-02 PlayCanvas Engine API](https://github.com/playcanvas/engine/assets/697563/ee083f19-5625-4da6-baa0-17b587aa1bdb)

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
