### PR TITLE
Typedoc: Ensure both setters and getters appear in docs

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,29 @@
         },
         "entryPoints": [ "./src/index.js" ],
         "excludeNotDocumented": true,
+        "excludeNotDocumentedKinds": [
+            "Module",
+            "Namespace",
+            "Enum",
+            // "EnumMember", // Not enabled by default
+            "Variable",
+            "Function",
+            "Class",
+            "Interface",
+            "Constructor",
+            "Property",
+            "Method",
+            "CallSignature",
+            "IndexSignature",
+            "ConstructorSignature",
+            "Accessor",
+            // We only document getters/setters with one JSDoc block so if there is a setter,
+            // the getter will appear undocumented (setters always appear before getters).
+            // "GetSignature",
+            "SetSignature",
+            "TypeAlias",
+            "Reference"
+        ],
         "name": "PlayCanvas Engine API",
         "out": "typedocs",
         "plugin": [


### PR DESCRIPTION
Because we configure Typedoc to exclude undocumented interface from the API ref manual, this causes a problem:

```javascript
    /**
     * Enable or disable a GraphNode. If one of the GraphNode's parents is disabled there will be
     * no other side effects. If all the parents are enabled then the new value will activate or
     * deactivate all the enabled children of the GraphNode.
     *
     * @type {boolean}
     */
    set enabled(enabled) {
        if (this._enabled !== enabled) {
            this._enabled = enabled;

            // if enabling entity, make all children enabled in hierarchy only when the parent is as well
            // if disabling entity, make all children disabled in hierarchy in all cases
            if (enabled && this._parent?.enabled || !enabled) {
                this._notifyHierarchyStateChanged(this, enabled);
            }
        }
    }

    get enabled() {
        // make sure to check this._enabled too because if that
        // was false when a parent was updated the _enabledInHierarchy
        // flag may not have been updated for optimization purposes
        return this._enabled && this._enabledInHierarchy;
    }
```

You'll notice that for a getter/setter pair, we only have a single JSDoc block. [This is what seems to be the recommended way](https://github.com/jsdoc/jsdoc/issues/973#issuecomment-90274714).

But, in the case of Typedoc, it would drop the getter from the generated docs:

![image](https://github.com/playcanvas/engine/assets/697563/cb32e5f9-df55-4915-87ed-942dc0452d20)

By using the Typedoc options `excludeNotDocumentedKinds`, we can exclude getters from being dropped in the generation process:

![image](https://github.com/playcanvas/engine/assets/697563/fdb34c9f-c587-4e31-b92c-e39ced589634)

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
