### PR TITLE
Fix WebGL depth texture support

### DIFF
--- a/src/platform/graphics/texture-utils.js
+++ b/src/platform/graphics/texture-utils.js
@@ -26,30 +26,32 @@ class TextureUtils {
      *
      * @param {number} width - Texture's width.
      * @param {number} height - Texture's height.
+     * @param {number} depth - Texture's depth.
      * @param {number} format - Texture's pixel format PIXELFORMAT_***.
      * @returns {number} The number of bytes of GPU memory required for the texture.
      * @ignore
      */
-    static calcLevelGpuSize(width, height, format) {
+    static calcLevelGpuSize(width, height, depth, format) {
 
         const formatInfo = pixelFormatInfo.get(format);
         Debug.assert(formatInfo !== undefined, `Invalid pixel format ${format}`);
 
         const pixelSize = pixelFormatInfo.get(format)?.size ?? 0;
         if (pixelSize > 0) {
-            return width * height * pixelSize;
+            return width * height * depth * pixelSize;
         }
 
         const blockSize = formatInfo.blockSize ?? 0;
         let blockWidth = Math.floor((width + 3) / 4);
         const blockHeight = Math.floor((height + 3) / 4);
+        const blockDepth = Math.floor((depth + 3) / 4);
 
         if (format === PIXELFORMAT_PVRTC_2BPP_RGB_1 ||
             format === PIXELFORMAT_PVRTC_2BPP_RGBA_1) {
             blockWidth = Math.max(Math.floor(blockWidth / 2), 1);
         }
 
-        return blockWidth * blockHeight * blockSize;
+        return blockWidth * blockHeight * blockDepth * blockSize;
     }
 
     /**
@@ -68,7 +70,7 @@ class TextureUtils {
         let result = 0;
 
         while (1) {
-            result += TextureUtils.calcLevelGpuSize(width, height, format);
+            result += TextureUtils.calcLevelGpuSize(width, height, depth, format);
 
             // we're done if mipmaps aren't required or we've calculated the smallest mipmap level
             if (!mipmaps || ((width === 1) && (height === 1) && (depth === 1))) {

--- a/src/platform/graphics/texture.js
+++ b/src/platform/graphics/texture.js
@@ -700,7 +700,8 @@ class Texture {
             // allocate storage for this mip level
             const width = Math.max(1, this._width >> options.level);
             const height = Math.max(1, this._height >> options.level);
-            const data = new ArrayBuffer(TextureUtils.calcLevelGpuSize(width, height, this._format));
+            const depth = Math.max(1, this._depth >> options.level);
+            const data = new ArrayBuffer(TextureUtils.calcLevelGpuSize(width, height, depth, this._format));
             levels[options.level] = new (getPixelFormatArrayType(this._format))(data);
         }
 

--- a/src/platform/graphics/webgpu/webgpu-texture.js
+++ b/src/platform/graphics/webgpu/webgpu-texture.js
@@ -432,7 +432,7 @@ class WebgpuTexture {
         const height = TextureUtils.calcLevelDimension(texture.height, mipLevel);
 
         // data sizes
-        const byteSize = TextureUtils.calcLevelGpuSize(width, height, texture.format);
+        const byteSize = TextureUtils.calcLevelGpuSize(width, height, 1, texture.format);
         Debug.assert(byteSize === data.byteLength,
                      `Error uploading data to texture, the data byte size of ${data.byteLength} does not match required ${byteSize}`, texture);
 


### PR DESCRIPTION
This PR fixes depth texture support on WebGL.

I am using `texture.lock()` to generate custom 3D textures, and noticed that this stopped working because the texture size passed to `texImage3D` is calculated incorrectly. I believe this may have changed in #5372.
 
I have tested this change on a WebGL-only project that uses a variety of textures including 2D, 3D, and cubemap, with and without mipmaps.

Depth textures are not currently not supported in WebGPU, so we can just pass `depth=1` for all WebGPU textures.

---
I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).