### PR TITLE
Update time.js

### DIFF
--- a/src/core/time.js
+++ b/src/core/time.js
@@ -5,7 +5,7 @@
  * @returns {number} The time in milliseconds.
  * @ignore
  */
-const now = (typeof window !== 'undefined') && window.performance && window.performance.now && window.performance.timing ?
+const now = (typeof window !== 'undefined') && window.performance && window.performance.now ?
     performance.now.bind(performance) :
     Date.now;
 


### PR DESCRIPTION
Remove deprecated "window.performance.timing".

Fixes future browsers and  current deno users.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
