### PR TITLE
Optimize LayerComposition layer lookup by name and id using Maps

### DIFF
--- a/src/scene/composition/layer-composition.js
+++ b/src/scene/composition/layer-composition.js
@@ -1017,7 +1017,7 @@ class LayerComposition extends EventHandler {
     /**
      * Update maps of layer IDs and names to match the layer list.
      *
-     * @ignore
+     * @private
      */
     _updateLayerMaps() {
         this.layerIdMap.clear();


### PR DESCRIPTION
- This being O(1) will be used in follow up PRs for fast access.
- The maps get update each time a list changes, instead of being lazy updated, as this is a very low frequency operations and avoid testing the dirty flag on each access later