### PR TITLE
Add MeshInstance.transparent to optimize access to it

### DIFF
--- a/src/scene/composition/layer-composition.js
+++ b/src/scene/composition/layer-composition.js
@@ -245,7 +245,7 @@ class LayerComposition extends EventHandler {
         function moveByBlendType(dest, src, moveTransparent) {
             for (let s = 0; s < src.length;) {
 
-                if (src[s].material?.transparent === moveTransparent) {
+                if (src[s].transparent === moveTransparent) {
 
                     // add it to dest
                     dest.push(src[s]);

--- a/src/scene/materials/material.js
+++ b/src/scene/materials/material.js
@@ -233,6 +233,14 @@ class Material {
         return this._blendState.blend;
     }
 
+    _updateTransparency() {
+        const transparent = this.transparent;
+        const meshInstances = this.meshInstances;
+        for (let i = 0; i < meshInstances.length; i++) {
+            meshInstances[i].transparent = transparent;
+        }
+    }
+
     // called when material changes transparency, for layer composition to add it to appropriate
     // queue (opaque or transparent)
     _markBlendDirty() {
@@ -252,6 +260,7 @@ class Material {
      */
     set blendState(value) {
         if (this._blendState.blend !== value.blend) {
+            this._updateTransparency();
             this._markBlendDirty();
         }
         this._blendState.copy(value);
@@ -298,6 +307,7 @@ class Material {
         const blend = type !== BLEND_NONE;
         if (this._blendState.blend !== blend) {
             this._blendState.blend = blend;
+            this._updateTransparency();
             this._markBlendDirty();
         }
         this._updateMeshInstanceKeys();

--- a/src/scene/mesh-instance.js
+++ b/src/scene/mesh-instance.js
@@ -97,6 +97,14 @@ class MeshInstance {
     castShadow = false;
 
     /**
+     * True if the material of the mesh instance is transparent. Optimization to avoid accessing the
+     * material. Updated by the material instance itself.
+     *
+     * @ignore
+     */
+    transparent = false;
+
+    /**
      * @type {import('./materials/material.js').Material}
      * @private
      */


### PR DESCRIPTION
- meshInstance.transparent as a fast way to access meshInstance.material.transparent. This is set by the material on all mesh instances that use it.
- not much win for now, but is needed in follow up PRs as this will be access per frame during culling