### PR TITLE
Update tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "compilerOptions": {
         "baseUrl": ".",
+        "outDir": "./types",
         "allowJs": true,
         "checkJs": true,
         "module": "es6",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "baseUrl": ".",
-        "outDir": "./types",
+        "outDir": "types",
         "allowJs": true,
         "checkJs": true,
         "module": "es6",


### PR DESCRIPTION
Add default `outDir`

Removes 700 error messages from vscode warning that files will be overwritten.  The warnings make type / error checking unusable.

This is the same value used in `npm run build:dts`.  All other commands that use `tsc` override `outDir` at the command line. 
Practical type generation is unchanged, future commands will have a safe / documented location to default to.

From the tsc docs:

> Compiler options specified on the command line override those specified in the tsconfig.json file. -- https://www.typescriptlang.org/docs/handbook/tsconfig-json.html

Fixes contributors using vscode.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
