### PR TITLE
Fire ‘shader:generate’ when a shader code gets generated

### DIFF
--- a/src/scene/materials/basic-material.js
+++ b/src/scene/materials/basic-material.js
@@ -115,7 +115,7 @@ class BasicMaterial extends Material {
         const library = getProgramLibrary(device);
         library.register('basic', basic);
 
-        return library.getProgram('basic', options, processingOptions);
+        return library.getProgram('basic', options, processingOptions, this.userId);
     }
 }
 

--- a/src/scene/materials/lit-material.js
+++ b/src/scene/materials/lit-material.js
@@ -94,7 +94,7 @@ class LitMaterial extends Material {
         const processingOptions = new ShaderProcessorOptions(viewUniformFormat, viewBindGroupFormat, vertexFormat);
         const library = getProgramLibrary(device);
         library.register('lit', lit);
-        const shader = library.getProgram('lit', options, processingOptions);
+        const shader = library.getProgram('lit', options, processingOptions, this.userId);
         return shader;
     }
 }

--- a/src/scene/materials/material.js
+++ b/src/scene/materials/material.js
@@ -69,7 +69,9 @@ class Material {
     name = 'Untitled';
 
     /**
-     * A unique id the user can assign to the material.
+     * A unique id the user can assign to the material. The engine internally does not use this for
+     * anything, and the user can assign a value to this id for any purpose they like. Defaults to
+     * an empty string.
      *
      * @type {string}
      */

--- a/src/scene/materials/material.js
+++ b/src/scene/materials/material.js
@@ -68,6 +68,13 @@ class Material {
      */
     name = 'Untitled';
 
+    /**
+     * A unique id the user can assign to the material.
+     *
+     * @type {string}
+     */
+    userId = '';
+
     id = id++;
 
     variants = {};

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -865,7 +865,7 @@ class StandardMaterial extends Material {
 
         const library = getProgramLibrary(device);
         library.register('standard', standard);
-        const shader = library.getProgram('standard', options, processingOptions);
+        const shader = library.getProgram('standard', options, processingOptions, this.userId);
 
         this._dirtyShader = false;
         return shader;


### PR DESCRIPTION
The event `shader:generate` is fired on the GraphicsDevice when the shader definition is generated, just before the shader is compiled, to allow the user to inspect / modify the generated shader. Note that there is a further processing happening after this step, where defines are process (unused code is removed), a shader is converted to uniform format on some platforms (currently on WebGPU) and similar.

Typical use case:

- give materials a userId to recognise when its shader is getting compiled:
```
myMaterial.userId = 'redMaterial';
```

- listen to shader:generated events:
```
app.graphicsDevice.on('shader:generate', (info) => {
    if (info.userMaterialId)
        console.log('shader:generate', info);
});
```

This is the expected output, in this case the shader is compiled for a shadow pass and a forward pass. You can find relevant info in the `info.shaderPassInfo'. Note that there could be multiple shader compilations based on material settings / vertex format it's used on and similar.

![Screenshot 2023-07-31 at 12 26 29](https://github.com/playcanvas/engine/assets/59932779/1f961e3d-ef99-483f-a624-3b998929378a)

