### PR TITLE
chore(examples): address eslint warnings

### DIFF
--- a/examples/package.json
+++ b/examples/package.json
@@ -33,6 +33,7 @@
       "@typescript-eslint/ban-ts-comment": 0,
       "@typescript-eslint/no-explicit-any": 0,
       "@typescript-eslint/explicit-module-boundary-types": 0,
+      "radix": 0,
       "lines-between-class-members": [
         "error",
         "always",

--- a/examples/package.json
+++ b/examples/package.json
@@ -40,6 +40,13 @@
           "exceptAfterSingleLine": true
         }
       ]
+    },
+    "settings": {
+      "import/resolver": {
+        "node": {
+          "extensions": [".js", ".jsx", ".ts", ".tsx"]
+        }
+      }
     }
   },
   "eslintIgnore": [

--- a/examples/src/app/example.tsx
+++ b/examples/src/app/example.tsx
@@ -19,7 +19,7 @@ const controlsObserver = new Observer();
 
 const Controls = (props: any) => {
     const controlsFunction = (document.getElementsByTagName('iframe')[0] as any).contentWindow.Example.prototype.controls || null;
-    // on desktop dont show the control panel when no controls are present
+    // on desktop don't show the control panel when no controls are present
     if (!controlsFunction && window.top.innerWidth >= MIN_DESKTOP_WIDTH) return null;
     return <ControlPanel controls={controlsFunction} files={props.files} />;
 };

--- a/examples/src/app/sidebar.tsx
+++ b/examples/src/app/sidebar.tsx
@@ -4,7 +4,7 @@ import { BindingTwoWay, BooleanInput, Container, Label, LabelGroup, Panel, TextI
 import { Link } from "react-router-dom";
 import { Observer } from '@playcanvas/observer';
 import examples from './helpers/example-data.mjs';
-import { MIN_DESKTOP_WIDTH } from './constants.js';
+import { MIN_DESKTOP_WIDTH } from './constants';
 
 const toggleSideBar = () => {
     const sideBar = document.getElementById('sideBar');

--- a/examples/src/examples/animation/locomotion.tsx
+++ b/examples/src/examples/animation/locomotion.tsx
@@ -37,7 +37,7 @@ class LocomotionExample {
                 'walkAnim': new pc.Asset('walkAnim', 'container', { url: '/static/assets/animations/bitmoji/walk.glb' }),
                 'jogAnim': new pc.Asset('jogAnim', 'container', { url: '/static/assets/animations/bitmoji/run.glb' }),
                 'jumpAnim': new pc.Asset('jumpAnim', 'container', { url: '/static/assets/animations/bitmoji/jump-flip.glb' }),
-                helipad: new pc.Asset('helipad-env-atlas', 'texture', { url: '/static/assets/cubemaps/helipad-env-atlas.png' }, { type: pc.TEXTURETYPE_RGBP, mipmaps: false }),
+                helipad: new pc.Asset('helipad-env-atlas', 'texture', { url: '/static/assets/cubemaps/helipad-env-atlas.png' }, { type: pc.TEXTURETYPE_RGBP, mipmaps: false })
             };
 
             const gfxOptions = {

--- a/examples/src/examples/graphics/area-picker.tsx
+++ b/examples/src/examples/graphics/area-picker.tsx
@@ -8,7 +8,7 @@ class AreaPickerExample {
 
         const assets = {
             'bloom': new pc.Asset('bloom', 'script', { url: '/static/scripts/posteffects/posteffect-bloom.js' }),
-            helipad: new pc.Asset('helipad-env-atlas', 'texture', { url: '/static/assets/cubemaps/helipad-env-atlas.png' }, { type: pc.TEXTURETYPE_RGBP, mipmaps: false }),
+            helipad: new pc.Asset('helipad-env-atlas', 'texture', { url: '/static/assets/cubemaps/helipad-env-atlas.png' }, { type: pc.TEXTURETYPE_RGBP, mipmaps: false })
         };
 
         const gfxOptions = {

--- a/examples/src/examples/graphics/contact-hardening-shadows.tsx
+++ b/examples/src/examples/graphics/contact-hardening-shadows.tsx
@@ -199,7 +199,7 @@ class ContactHardeningShadowsExample {
                     occluder.anim.assignAnimation('Idle', assets.asset.resource.animations[0].resource);
                     occluder.anim.baseLayer.weight = 1.0;
                     occluder.anim.speed = 0.1;
-                    //const animLayer = occluder.anim.addLayer('Idle', 1.0, )
+                    // const animLayer = occluder.anim.addLayer('Idle', 1.0, )
 
                     app.scene.envAtlas = assets.helipad.resource;
 

--- a/examples/src/examples/graphics/ground-fog.tsx
+++ b/examples/src/examples/graphics/ground-fog.tsx
@@ -114,7 +114,7 @@ class GroundFogExample {
         const gfxOptions = {
             deviceTypes: [deviceType],
             glslangUrl: '/static/lib/glslang/glslang.js',
-            twgslUrl: '/static/lib/twgsl/twgsl.js',
+            twgslUrl: '/static/lib/twgsl/twgsl.js'
         };
 
         pc.createGraphicsDevice(canvas, gfxOptions).then((device: pc.GraphicsDevice) => {

--- a/examples/src/examples/graphics/mesh-decals.tsx
+++ b/examples/src/examples/graphics/mesh-decals.tsx
@@ -245,7 +245,7 @@ class MeshDecalsExample {
                     }
 
                     // fade out all vertex colors once a second
-                    if (Math.round(time) != Math.round(previousTime)) {
+                    if (Math.round(time) !== Math.round(previousTime)) {
                         for (let i = 0; i < colors.length; i++)
                             colors[i] -= 2;
 

--- a/examples/src/examples/graphics/shader-compile.tsx
+++ b/examples/src/examples/graphics/shader-compile.tsx
@@ -7,7 +7,7 @@ class ShaderCompileExample {
 
     example(canvas: HTMLCanvasElement, deviceType: string): void {
 
-        // This example servers as a test framework for large shader compilation speed test. Enable tracking for it.
+        // This example serves as a test framework for large shader compilation speed test. Enable tracking for it.
         pc.Tracing.set(pc.TRACEID_SHADER_COMPILE, true);
 
         const assets = {

--- a/examples/src/examples/graphics/shader-compile.tsx
+++ b/examples/src/examples/graphics/shader-compile.tsx
@@ -15,7 +15,7 @@ class ShaderCompileExample {
             'normal': new pc.Asset('normal', 'texture', { url: '/static/assets/textures/seaside-rocks01-normal.jpg' }),
             'gloss': new pc.Asset('gloss', 'texture', { url: '/static/assets/textures/seaside-rocks01-gloss.jpg' }),
             'luts': new pc.Asset('luts', 'json', { url: '/static/assets/json/area-light-luts.json' }),
-            helipad: new pc.Asset('helipad-env-atlas', 'texture', { url: '/static/assets/cubemaps/helipad-env-atlas.png' }, { type: pc.TEXTURETYPE_RGBP, mipmaps: false }),
+            helipad: new pc.Asset('helipad-env-atlas', 'texture', { url: '/static/assets/cubemaps/helipad-env-atlas.png' }, { type: pc.TEXTURETYPE_RGBP, mipmaps: false })
         };
 
         const gfxOptions = {

--- a/examples/src/examples/graphics/texture-basis.tsx
+++ b/examples/src/examples/graphics/texture-basis.tsx
@@ -22,7 +22,7 @@ class TextureBasisExample {
             'color': new pc.Asset('color', 'texture', { url: '/static/assets/textures/seaside-rocks01-color.basis' }),
             'gloss': new pc.Asset('gloss', 'texture', { url: '/static/assets/textures/seaside-rocks01-gloss.basis' }),
             'normal': new pc.Asset('normal', 'texture', { url: '/static/assets/textures/seaside-rocks01-normal.basis' }, { type: pc.TEXTURETYPE_SWIZZLEGGGR }),
-            'helipad': new pc.Asset('helipad-env-atlas', 'texture', { url: '/static/assets/cubemaps/helipad-env-atlas.png' }, { type: pc.TEXTURETYPE_RGBP, mipmaps: false }),
+            'helipad': new pc.Asset('helipad-env-atlas', 'texture', { url: '/static/assets/cubemaps/helipad-env-atlas.png' }, { type: pc.TEXTURETYPE_RGBP, mipmaps: false })
         };
 
         const gfxOptions = {

--- a/examples/src/examples/physics/offset-collision.tsx
+++ b/examples/src/examples/physics/offset-collision.tsx
@@ -18,9 +18,9 @@ class OffsetCollisionExample {
         function demo() {
 
             const assets = {
-                'model': new pc.Asset('model', 'container', {url: '/static/assets/models/bitmoji.glb'}),
-                'idleAnim': new pc.Asset('idleAnim', 'container', {url: '/static/assets/animations/bitmoji/idle.glb'}),
-                helipad: new pc.Asset('helipad-env-atlas', 'texture', { url: '/static/assets/cubemaps/helipad-env-atlas.png' }, { type: pc.TEXTURETYPE_RGBP, mipmaps: false }),
+                'model': new pc.Asset('model', 'container', { url: '/static/assets/models/bitmoji.glb' }),
+                'idleAnim': new pc.Asset('idleAnim', 'container', { url: '/static/assets/animations/bitmoji/idle.glb' }),
+                helipad: new pc.Asset('helipad-env-atlas', 'texture', { url: '/static/assets/cubemaps/helipad-env-atlas.png' }, { type: pc.TEXTURETYPE_RGBP, mipmaps: false })
             };
 
             const gfxOptions = {


### PR DESCRIPTION
Address eslint warnings in examples.
Fixes some small typos.
configures eslint it to resolve modules as typescipt will do during build (resolving warnings)

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
