### PR TITLE
chore: include localised readmes in npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,8 @@
     "LICENSE",
     "package.json",
     "README.md",
+    "README-ja.md",
+    "README-kr.md",
     "README-zh.md"
   ],
   "devDependencies": {


### PR DESCRIPTION
include korean and japanese version of the readme in npm package

Fixes a possible omission.

referenced: #5541

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
