### PR TITLE
[Fix] Avoid additional shaders creation caused by out of order lights

### DIFF
--- a/src/platform/graphics/shader-processor-options.js
+++ b/src/platform/graphics/shader-processor-options.js
@@ -75,7 +75,7 @@ class ShaderProcessorOptions {
     }
 
     /**
-     * Generate unique key represending the processing options.
+     * Generate unique key representing the processing options.
      *
      * @returns {string} - Returns the key.
      */

--- a/src/platform/graphics/shader-processor-options.js
+++ b/src/platform/graphics/shader-processor-options.js
@@ -77,14 +77,20 @@ class ShaderProcessorOptions {
     /**
      * Generate unique key representing the processing options.
      *
+     * @param {import('./graphics-device.js').GraphicsDevice} device - The device.
      * @returns {string} - Returns the key.
      */
-    generateKey() {
+    generateKey(device) {
         // TODO: Optimize. Uniform and BindGroup formats should have their keys evaluated in their
         // constructors, and here we should simply concatenate those.
-        return JSON.stringify(this.uniformFormats) +
-        JSON.stringify(this.bindGroupFormats) +
-        this.vertexFormat?.renderingHashString;
+        let key = JSON.stringify(this.uniformFormats) + JSON.stringify(this.bindGroupFormats);
+
+        // WebGPU shaders are processes per vertex format
+        if (device.isWebGPU) {
+            key += this.vertexFormat?.renderingHashString;
+        }
+
+        return key;
     }
 }
 

--- a/src/platform/graphics/shader-processor-options.js
+++ b/src/platform/graphics/shader-processor-options.js
@@ -85,7 +85,7 @@ class ShaderProcessorOptions {
         // constructors, and here we should simply concatenate those.
         let key = JSON.stringify(this.uniformFormats) + JSON.stringify(this.bindGroupFormats);
 
-        // WebGPU shaders are processes per vertex format
+        // WebGPU shaders are processed per vertex format
         if (device.isWebGPU) {
             key += this.vertexFormat?.renderingHashString;
         }

--- a/src/scene/composition/layer-composition.js
+++ b/src/scene/composition/layer-composition.js
@@ -157,17 +157,25 @@ class LayerComposition extends EventHandler {
 
     // function which splits list of lights on a a target object into separate lists of lights based on light type
     _splitLightsArray(target) {
-        const lights = target._lights;
-        target._splitLights[LIGHTTYPE_DIRECTIONAL].length = 0;
-        target._splitLights[LIGHTTYPE_OMNI].length = 0;
-        target._splitLights[LIGHTTYPE_SPOT].length = 0;
 
+        const splitLights = target._splitLights;
+        splitLights[LIGHTTYPE_DIRECTIONAL].length = 0;
+        splitLights[LIGHTTYPE_OMNI].length = 0;
+        splitLights[LIGHTTYPE_SPOT].length = 0;
+
+        const lights = target._lights;
         for (let i = 0; i < lights.length; i++) {
             const light = lights[i];
             if (light.enabled) {
-                target._splitLights[light._type].push(light);
+                splitLights[light._type].push(light);
             }
         }
+
+        // sort the lights by their key, as the order of lights is used to generate shader generation key,
+        // and this avoids new shaders being generated when lights are reordered
+        splitLights[LIGHTTYPE_DIRECTIONAL].sort((a, b) => a.key - b.key);
+        splitLights[LIGHTTYPE_OMNI].sort((a, b) => a.key - b.key);
+        splitLights[LIGHTTYPE_SPOT].sort((a, b) => a.key - b.key);
     }
 
     _update(device, clusteredLightingEnabled = false) {

--- a/src/scene/shader-lib/program-library.js
+++ b/src/scene/shader-lib/program-library.js
@@ -123,7 +123,7 @@ class ProgramLibrary {
         const generationKeyString = generator.generateKey(options);
         const generationKey = hashCode(generationKeyString);
 
-        const processingKeyString = processingOptions.generateKey();
+        const processingKeyString = processingOptions.generateKey(this._device);
         const processingKey = hashCode(processingKeyString);
 
         const totalKey = `${generationKey}#${processingKey}`;

--- a/src/scene/shader-lib/program-library.js
+++ b/src/scene/shader-lib/program-library.js
@@ -6,6 +6,7 @@ import { Shader } from '../../platform/graphics/shader.js';
 import { SHADER_FORWARD, SHADER_DEPTH, SHADER_PICK, SHADER_SHADOW } from '../constants.js';
 import { ShaderPass } from '../shader-pass.js';
 import { StandardMaterialOptions } from '../materials/standard-material-options.js';
+import { hashCode } from '../../core/hash.js';
 
 /**
  * A class responsible for creation and caching of required shaders.
@@ -119,8 +120,12 @@ class ProgramLibrary {
 
         // we have a key for shader source code generation, a key for its further processing to work with
         // uniform buffers, and a final key to get the processed shader from the cache
-        const generationKey = generator.generateKey(options);
-        const processingKey = processingOptions.generateKey();
+        const generationKeyString = generator.generateKey(options);
+        const generationKey = hashCode(generationKeyString);
+
+        const processingKeyString = processingOptions.generateKey();
+        const processingKey = hashCode(processingKeyString);
+
         const totalKey = `${generationKey}#${processingKey}`;
 
         // do we have final processed shader
@@ -158,6 +163,13 @@ class ProgramLibrary {
 
             // add new shader to the processed cache
             processedShader = new Shader(this._device, shaderDefinition);
+
+            // keep the keys in the debug mode
+            Debug.call(() => {
+                processedShader._generationKey = generationKeyString;
+                processedShader._processingKey = processingKeyString;
+            });
+
             this.setCachedShader(totalKey, processedShader);
         }
 

--- a/src/scene/shader-lib/program-library.js
+++ b/src/scene/shader-lib/program-library.js
@@ -1,4 +1,5 @@
 import { Debug } from '../../core/debug.js';
+import { hashCode } from '../../core/hash.js';
 import { version, revision } from '../../core/core.js';
 
 import { Shader } from '../../platform/graphics/shader.js';
@@ -6,7 +7,6 @@ import { Shader } from '../../platform/graphics/shader.js';
 import { SHADER_FORWARD, SHADER_DEPTH, SHADER_PICK, SHADER_SHADOW } from '../constants.js';
 import { ShaderPass } from '../shader-pass.js';
 import { StandardMaterialOptions } from '../materials/standard-material-options.js';
-import { hashCode } from '../../core/hash.js';
 
 /**
  * A class responsible for creation and caching of required shaders.

--- a/src/scene/shader-lib/programs/lit-options-utils.js
+++ b/src/scene/shader-lib/programs/lit-options-utils.js
@@ -14,17 +14,17 @@ const LitOptionsUtils = {
                 }
                 return key + options[key];
             })
-            .join("");
+            .join("\n");
     },
 
     generateLightsKey(options) {
-        return options.lights.map((light) => {
-            return (!options.clusteredLightingEnabled || light._type === LIGHTTYPE_DIRECTIONAL) ? light.key : "";
+        return 'lights:' + options.lights.map((light) => {
+            return (!options.clusteredLightingEnabled || light._type === LIGHTTYPE_DIRECTIONAL) ? `${light.key},` : '';
         }).join("");
     },
 
     generateChunksKey(options) {
-        return Object.keys(options.chunks ?? {})
+        return 'chunks:\n' + Object.keys(options.chunks ?? {})
             .sort()
             .map(key => key + options.chunks[key])
             .join("");

--- a/src/scene/shader-lib/programs/lit.js
+++ b/src/scene/shader-lib/programs/lit.js
@@ -1,4 +1,3 @@
-import { hashCode } from '../../../core/hash.js';
 import { ChunkBuilder } from '../chunk-builder.js';
 import { LitShader } from './lit-shader.js';
 import { LitOptionsUtils } from './lit-options-utils.js';
@@ -19,7 +18,7 @@ const lit = {
             options.shaderChunk +
             LitOptionsUtils.generateKey(options.litOptions);
 
-        return hashCode(key);
+        return key;
     },
 
     /**

--- a/src/scene/shader-lib/programs/standard.js
+++ b/src/scene/shader-lib/programs/standard.js
@@ -1,4 +1,3 @@
-import { hashCode } from '../../../core/hash.js';
 import { Debug } from '../../../core/debug.js';
 
 import {
@@ -40,11 +39,11 @@ const standard = {
             props = buildPropertiesList(options);
         }
 
-        const key = "standard" +
-            props.map(prop => prop + options[prop]).join("") +
+        const key = "standard:\n" +
+            props.map(prop => prop + options[prop]).join('\n') +
             LitOptionsUtils.generateKey(options.litOptions);
 
-        return hashCode(key);
+        return key;
     },
 
     // get the value to replace $UV with in Map Shader functions


### PR DESCRIPTION
Fixes https://github.com/playcanvas/engine/issues/5542

When lights stored by the Layer were in different order, a different key would be generated causing new shaders to be created.

To avoid this, the lights the Layer stores are sorted by their key.

Additionally, small refactor related to shader key generation has been done, making those multiline and easier to read, and storing those on the Shader instance in debug mode, to allow us to easily compare why a shader was generated (see the generation and processing keys)

![Screenshot 2023-08-04 at 14 25 05](https://github.com/playcanvas/engine/assets/59932779/929fb434-becf-4656-a462-52a1d4432439)
