### PR TITLE
Fix some consistent-return lint errors

### DIFF
--- a/src/framework/components/element/component.js
+++ b/src/framework/components/element/component.js
@@ -1144,7 +1144,8 @@ class ElementComponent extends Component {
                 element._worldCornersDirty = true;
             }
 
-            return Entity.prototype._sync.call(this);
+            Entity.prototype._sync.call(this);
+            return;
         }
 
 

--- a/src/framework/handlers/basis-worker.js
+++ b/src/framework/handlers/basis-worker.js
@@ -182,6 +182,7 @@ function BasisWorker() {
                 // https://www.khronos.org/registry/webgl/extensions/rejected/WEBGL_compressed_texture_atc/
                 return true;
         }
+        return false;
     };
 
     const transcodeKTX2 = (url, data, options) => {

--- a/src/framework/handlers/font.js
+++ b/src/framework/handlers/font.js
@@ -75,12 +75,14 @@ class FontHandler {
                 if (!err) {
                     const data = upgradeDataSchema(response);
                     self._loadTextures(url.load.replace('.json', '.png'), data, function (err, textures) {
-                        if (err) return callback(err);
-
-                        callback(null, {
-                            data: data,
-                            textures: textures
-                        });
+                        if (err) {
+                            callback(err);
+                        } else {
+                            callback(null, {
+                                data: data,
+                                textures: textures
+                            });
+                        }
                     });
                 } else {
                     callback(`Error loading font resource: ${url.original} [${err}]`);
@@ -110,7 +112,8 @@ class FontHandler {
 
                 if (err) {
                     error = err;
-                    return callback(err);
+                    callback(err);
+                    return;
                 }
 
                 texture.upload();

--- a/src/framework/handlers/texture-atlas.js
+++ b/src/framework/handlers/texture-atlas.js
@@ -92,7 +92,7 @@ class TextureAtlasHandler {
                 }
             });
         } else {
-            return handler.load(url, callback);
+            handler.load(url, callback);
         }
     }
 

--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -2141,7 +2141,8 @@ class WebglGraphicsDevice extends GraphicsDevice {
 
         if (!this.webgl2) {
             // async fences aren't supported on webgl1
-            return this.readPixels(x, y, w, h, pixels);
+            this.readPixels(x, y, w, h, pixels);
+            return;
         }
 
         const clientWaitAsync = (flags, interval_ms) => {


### PR DESCRIPTION
This PR fixes several ESLint errors reported by the rule [`consistent-return`](https://eslint.org/docs/latest/rules/consistent-return). This rule is not yet enabled in our config, but I think it points out some weird quirky mistakes in our codebase, so I've preemptively fixed some of the problems. 8 still remain.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
