### PR TITLE
Add/use pc.call for scripts/posteffects/*.js

### DIFF
--- a/scripts/posteffects/posteffect-blend.js
+++ b/scripts/posteffects/posteffect-blend.js
@@ -10,7 +10,7 @@
  * @property {number} mixRatio The amount of blending between the input and the blendMap. Ranges from 0 to 1.
  */
 function BlendEffect(graphicsDevice) {
-    pc.PostEffect.call(this, graphicsDevice);
+    pc.call(pc.PostEffect, this, graphicsDevice);
 
     var fshader = [
         "uniform float uMixRatio;",

--- a/scripts/posteffects/posteffect-bloom.js
+++ b/scripts/posteffects/posteffect-bloom.js
@@ -62,7 +62,7 @@ function calculateBlurValues(sampleWeights, sampleOffsets, dx, dy, blurAmount) {
  * @property {number} bloomIntensity The intensity of the effect.
  */
 function BloomEffect(graphicsDevice) {
-    pc.PostEffect.call(this, graphicsDevice);
+    pc.call(pc.PostEffect, this, graphicsDevice);
 
     // Shaders
     var attributes = {

--- a/scripts/posteffects/posteffect-bokeh.js
+++ b/scripts/posteffects/posteffect-bokeh.js
@@ -11,7 +11,7 @@
  * @property {number} focus Controls the focus of the effect.
  */
 function BokehEffect(graphicsDevice) {
-    pc.PostEffect.call(this, graphicsDevice);
+    pc.call(pc.PostEffect, this, graphicsDevice);
 
     this.needsDepthBuffer = true;
 

--- a/scripts/posteffects/posteffect-brightnesscontrast.js
+++ b/scripts/posteffects/posteffect-brightnesscontrast.js
@@ -10,7 +10,7 @@
  * @property {number} contrast Controls the contrast of the render target. Ranges from -1 to 1 (-1 is solid gray, 0 no change, 1 maximum contrast).
  */
 function BrightnessContrastEffect(graphicsDevice) {
-    pc.PostEffect.call(this, graphicsDevice);
+    pc.call(pc.PostEffect, this, graphicsDevice);
 
     // Shader author: tapio / http://tapio.github.com/
     var fshader = [

--- a/scripts/posteffects/posteffect-edgedetect.js
+++ b/scripts/posteffects/posteffect-edgedetect.js
@@ -8,7 +8,7 @@
  * @param {GraphicsDevice} graphicsDevice - The graphics device of the application.
  */
 function EdgeDetectEffect(graphicsDevice) {
-    pc.PostEffect.call(this, graphicsDevice);
+    pc.call(pc.PostEffect, this, graphicsDevice);
 
     var fshader = [
         "uniform sampler2D uColorBuffer;",

--- a/scripts/posteffects/posteffect-fxaa.js
+++ b/scripts/posteffects/posteffect-fxaa.js
@@ -8,7 +8,7 @@
  * @param {GraphicsDevice} graphicsDevice - The graphics device of the application.
  */
 function FxaaEffect(graphicsDevice) {
-    pc.PostEffect.call(this, graphicsDevice);
+    pc.call(pc.PostEffect, this, graphicsDevice);
 
     // Shaders
     // TODO: this shader does not use UV coordinates from vertex shader, and might render upside down on WebGPU. Needs to be fixed.

--- a/scripts/posteffects/posteffect-horizontaltiltshift.js
+++ b/scripts/posteffects/posteffect-horizontaltiltshift.js
@@ -9,7 +9,7 @@
  * @property {number} focus Controls where the "focused" vertical line lies.
  */
 function HorizontalTiltShiftEffect(graphicsDevice) {
-    pc.PostEffect.call(this, graphicsDevice);
+    pc.call(pc.PostEffect, this, graphicsDevice);
 
     // Shader author: alteredq / http://alteredqualia.com/
     var fshader = [

--- a/scripts/posteffects/posteffect-huesaturation.js
+++ b/scripts/posteffects/posteffect-huesaturation.js
@@ -10,7 +10,7 @@
  * @property {number} saturation Controls the saturation. Ranges from -1 to 1 (-1 is solid gray, 0 no change, 1 maximum saturation).
  */
 function HueSaturationEffect(graphicsDevice) {
-    pc.PostEffect.call(this, graphicsDevice);
+    pc.call(pc.PostEffect, this, graphicsDevice);
 
     // Shader author: tapio / http://tapio.github.com/
     var fshader = [

--- a/scripts/posteffects/posteffect-luminosity.js
+++ b/scripts/posteffects/posteffect-luminosity.js
@@ -8,7 +8,7 @@
  * @param {GraphicsDevice} graphicsDevice - The graphics device of the application.
  */
 function LuminosityEffect(graphicsDevice) {
-    pc.PostEffect.call(this, graphicsDevice);
+    pc.call(pc.PostEffect, this, graphicsDevice);
 
     var fshader = [
         "uniform sampler2D uColorBuffer;",

--- a/scripts/posteffects/posteffect-outline.js
+++ b/scripts/posteffects/posteffect-outline.js
@@ -11,7 +11,7 @@
  * @property {Color} color The outline color.
  */
 function OutlineEffect(graphicsDevice, thickness) {
-    pc.PostEffect.call(this, graphicsDevice);
+    pc.call(pc.PostEffect, this, graphicsDevice);
 
     var fshader = [
         "#define THICKNESS " + (thickness ? thickness.toFixed(0) : 1),

--- a/scripts/posteffects/posteffect-sepia.js
+++ b/scripts/posteffects/posteffect-sepia.js
@@ -9,7 +9,7 @@
  * @property {number} amount Controls the intensity of the effect. Ranges from 0 to 1.
  */
 function SepiaEffect(graphicsDevice) {
-    pc.PostEffect.call(this, graphicsDevice);
+    pc.call(pc.PostEffect, this, graphicsDevice);
 
     var fshader = [
         "uniform float uAmount;",

--- a/scripts/posteffects/posteffect-ssao.js
+++ b/scripts/posteffects/posteffect-ssao.js
@@ -12,7 +12,7 @@
  * @param {any} ssaoScript - The script using the effect.
  */
 function SSAOEffect(graphicsDevice, ssaoScript) {
-    pc.PostEffect.call(this, graphicsDevice);
+    pc.call(pc.PostEffect, this, graphicsDevice);
 
     this.ssaoScript = ssaoScript;
     this.needsDepthBuffer = true;

--- a/scripts/posteffects/posteffect-verticaltiltshift.js
+++ b/scripts/posteffects/posteffect-verticaltiltshift.js
@@ -9,7 +9,7 @@
  * @property {number} focus Controls where the "focused" horizontal line lies.
  */
 function VerticalTiltShiftEffect(graphicsDevice) {
-    pc.PostEffect.call(this, graphicsDevice);
+    pc.call(pc.PostEffect, this, graphicsDevice);
 
     // Shader author: alteredq / http://alteredqualia.com/
     var fshader = [

--- a/scripts/posteffects/posteffect-vignette.js
+++ b/scripts/posteffects/posteffect-vignette.js
@@ -10,7 +10,7 @@
  * @property {number} darkness Controls the darkness of the effect.
  */
 function VignetteEffect(graphicsDevice) {
-    pc.PostEffect.call(this, graphicsDevice);
+    pc.call(pc.PostEffect, this, graphicsDevice);
 
     // Shaders
     var luminosityFrag = [

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -84,7 +84,7 @@ function type(obj) {
  * @param {...*} args - Arguments to constructor function
  */
 function call(func, thisArg, ...args) {
-    Object.assign(thisArg, new func(...args))
+    Object.assign(thisArg, new func(...args));
 }
 
 /**

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -58,6 +58,36 @@ function type(obj) {
 }
 
 /**
+ * Allows to call a function AND a class constructor to allow for ES5 style inheritance required
+ * due to ES6 regression. The assumption that "classes are just syntactic sugar for functions"
+ * is wrong and I hope it will work again in a later ES version. Until then, we have to deal with
+ * ES6 limitations.
+ *
+ * Old style: pc.PostEffect.call(this, graphicsDevice); // fails when pc.PostEffect is an ES6 class
+ * New Style: Object.assign(this, new pc.PostEffect(graphicsDevice)); // works in ES5 and ES6
+ *
+ * @example
+ *   class AddClass { constructor(a, b) { this.ret = a + b; } }
+ *   function AddFunc(a, b) { this.ret = a + b; }
+ *   function TestClass() {
+ *      pc.call(AddClass, this, 10, 20)
+ *   }
+ *   function TestFunc() {
+ *      pc.call(AddFunc, this, 10, 20)
+ *   }
+ *   const testClass = new TestClass();
+ *   const testFunc = new TestFunc();
+ *   console.assert(testClass.ret === 30, "should be 30");
+ *   console.assert(testFunc.ret === 30, "should be 30");
+ * @param {Function} func - Function or class
+ * @param {object} thisArg - Existing object with added properties
+ * @param {...*} args - Arguments to constructor function
+ */
+function call(func, thisArg, ...args) {
+    Object.assign(thisArg, new func(...args))
+}
+
+/**
  * Merge the contents of two objects into a single object.
  *
  * @param {object} target - The target object of the merge.
@@ -98,4 +128,4 @@ function extend(target, ex) {
     return target;
 }
 
-export { apps, common, config, data, extend, revision, type, version };
+export { apps, common, config, data, call, extend, revision, type, version };

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ import './polyfill/OESVertexArrayObject.js';
 
 // CORE
 export * from './core/constants.js';
-export { apps, common, config, data, extend, revision, type, version } from './core/core.js';
+export * from './core/core.js';
 export { events } from './core/events.js';
 export { guid } from './core/guid.js';
 export { path } from './core/path.js';


### PR DESCRIPTION
Partly fixes issues described in https://github.com/playcanvas/engine/issues/5399

This allows us to keep using ES5 scripts, which extend ES6 classes (required for some examples in the Examples browser)

(I don't wanna add engine changes in https://github.com/playcanvas/engine/pull/5555 and it depends on this)

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
