### PR TITLE
NullGraphicsDevice implementation allowing to run the application without rendering

### DIFF
--- a/examples/src/app/example.tsx
+++ b/examples/src/app/example.tsx
@@ -3,7 +3,7 @@ import { withRouter } from 'react-router-dom';
 import { Container, Spinner, SelectInput, Panel } from '@playcanvas/pcui/react';
 import { SelectInput as SelectInputClass } from '@playcanvas/pcui';
 import { Observer } from '@playcanvas/observer';
-import { DEVICETYPE_WEBGL1, DEVICETYPE_WEBGL2, DEVICETYPE_WEBGPU } from '../../../build/playcanvas.js';
+import { DEVICETYPE_WEBGL1, DEVICETYPE_WEBGL2, DEVICETYPE_WEBGPU, DEVICETYPE_NULL } from '../../../build/playcanvas.js';
 import { File } from './helpers/types';
 import examples from './helpers/example-data.mjs';
 import ControlPanel from './control-panel';
@@ -12,7 +12,8 @@ import { MIN_DESKTOP_WIDTH } from './constants';
 const deviceTypeNames = {
     [DEVICETYPE_WEBGL1]: 'WebGL 1',
     [DEVICETYPE_WEBGL2]: 'WebGL 2',
-    [DEVICETYPE_WEBGPU]: 'WebGPU'
+    [DEVICETYPE_WEBGPU]: 'WebGPU',
+    [DEVICETYPE_NULL]: 'NULL'
 };
 
 const controlsObserver = new Observer();
@@ -149,7 +150,7 @@ class Example extends Component <ExampleProps, ExampleState> {
             this.deviceTypeSelectInput.value = value;
         }
         this.setDisabledOptions(this.preferredGraphicsDevice, value);
-        document.getElementById('showMiniStatsButton').ui.enabled = value !== DEVICETYPE_WEBGPU;
+        document.getElementById('showMiniStatsButton').ui.enabled = (value !== DEVICETYPE_WEBGPU) && (value !== DEVICETYPE_NULL);
     };
 
     onSetPreferredGraphicsDevice = (value: string) => {
@@ -190,7 +191,8 @@ class Example extends Component <ExampleProps, ExampleState> {
                     options={[
                         { t: deviceTypeNames[DEVICETYPE_WEBGL1], v: DEVICETYPE_WEBGL1 },
                         { t: deviceTypeNames[DEVICETYPE_WEBGL2], v: DEVICETYPE_WEBGL2 },
-                        { t: deviceTypeNames[DEVICETYPE_WEBGPU], v: DEVICETYPE_WEBGPU }
+                        { t: deviceTypeNames[DEVICETYPE_WEBGPU], v: DEVICETYPE_WEBGPU },
+                        { t: deviceTypeNames[DEVICETYPE_NULL], v: DEVICETYPE_NULL }
                     ]}
                     onSelect={this.onSetPreferredGraphicsDevice}
                     prefix='Active Device: '

--- a/examples/src/app/example.tsx
+++ b/examples/src/app/example.tsx
@@ -13,7 +13,7 @@ const deviceTypeNames = {
     [DEVICETYPE_WEBGL1]: 'WebGL 1',
     [DEVICETYPE_WEBGL2]: 'WebGL 2',
     [DEVICETYPE_WEBGPU]: 'WebGPU',
-    [DEVICETYPE_NULL]: 'NULL'
+    [DEVICETYPE_NULL]: 'Null'
 };
 
 const controlsObserver = new Observer();

--- a/examples/src/iframe/index.html
+++ b/examples/src/iframe/index.html
@@ -131,7 +131,8 @@
                 }).observe(canvasContainerElement);
             }
 
-            if (app.graphicsDevice.deviceType !== 'webgpu' && !Example.MINISTATS) {
+            const deviceType = app.graphicsDevice.deviceType;
+            if (deviceType !== 'webgpu' && deviceType !== 'null' && !Example.MINISTATS) {
                 // set up miniStats
                 var miniStats = new pcx.MiniStats(app);
                 if (urlParams.get('miniStats') === 'false') {

--- a/src/index.js
+++ b/src/index.js
@@ -78,6 +78,9 @@ export { WebglGraphicsDevice } from './platform/graphics/webgl/webgl-graphics-de
 // PLATFORM / GRAPHICS / webgpu
 export { WebgpuGraphicsDevice } from './platform/graphics/webgpu/webgpu-graphics-device.js';
 
+// PLATFORM / GRAPHICS / null
+export { NullGraphicsDevice } from './platform/graphics/null/null-graphics-device.js';
+
 // PLATFORM / INPUT
 export * from './platform/input/constants.js';
 export { Controller } from './platform/input/controller.js';

--- a/src/platform/graphics/constants.js
+++ b/src/platform/graphics/constants.js
@@ -1236,6 +1236,13 @@ export const DEVICETYPE_WEBGL2 = 'webgl2';
  */
 export const DEVICETYPE_WEBGPU = 'webgpu';
 
+/**
+ * A Null device type.
+ *
+ * @type {string}
+ */
+export const DEVICETYPE_NULL = 'null';
+
 // (bit-flags) shader stages for resource visibility on the GPU
 export const SHADERSTAGE_VERTEX = 1;
 export const SHADERSTAGE_FRAGMENT = 2;

--- a/src/platform/graphics/graphics-device-create.js
+++ b/src/platform/graphics/graphics-device-create.js
@@ -1,9 +1,10 @@
 import { Debug } from '../../core/debug.js';
 import { platform } from '../../core/platform.js';
 
+import { DEVICETYPE_WEBGL2, DEVICETYPE_WEBGL1, DEVICETYPE_WEBGPU, DEVICETYPE_NULL } from './constants.js';
 import { WebgpuGraphicsDevice } from './webgpu/webgpu-graphics-device.js';
-import { DEVICETYPE_WEBGL2, DEVICETYPE_WEBGL1, DEVICETYPE_WEBGPU } from './constants.js';
 import { WebglGraphicsDevice } from './webgl/webgl-graphics-device.js';
+import { NullGraphicsDevice } from './null/null-graphics-device.js';
 
 /**
  * Creates a graphics device.
@@ -48,6 +49,9 @@ function createGraphicsDevice(canvas, options = {}) {
     if (!deviceTypes.includes(DEVICETYPE_WEBGL1)) {
         deviceTypes.push(DEVICETYPE_WEBGL1);
     }
+    if (!deviceTypes.includes(DEVICETYPE_NULL)) {
+        deviceTypes.push(DEVICETYPE_NULL);
+    }
 
     // XR compatibility if not specified
     if (platform.browser && !!navigator.xr) {
@@ -63,9 +67,14 @@ function createGraphicsDevice(canvas, options = {}) {
             return device.initWebGpu(options.glslangUrl, options.twgslUrl);
         }
 
-        if (deviceType !== DEVICETYPE_WEBGPU) {
+        if (deviceType === DEVICETYPE_WEBGL1 || deviceType === DEVICETYPE_WEBGL2) {
             options.preferWebGl2 = deviceType === DEVICETYPE_WEBGL2;
             device = new WebglGraphicsDevice(canvas, options);
+            return Promise.resolve(device);
+        }
+
+        if (deviceType === DEVICETYPE_NULL) {
+            device = new NullGraphicsDevice(canvas, options);
             return Promise.resolve(device);
         }
     }

--- a/src/platform/graphics/null/null-graphics-device.js
+++ b/src/platform/graphics/null/null-graphics-device.js
@@ -1,0 +1,173 @@
+import { Debug } from '../../../core/debug.js';
+import {
+    PIXELFORMAT_RGBA8, DEVICETYPE_NULL
+} from '../constants.js';
+import { GraphicsDevice } from '../graphics-device.js';
+
+import { NullIndexBuffer } from './null-index-buffer.js';
+import { NullRenderTarget } from './null-render-target.js';
+import { NullShader } from './null-shader.js';
+import { NullTexture } from './null-texture.js';
+import { NullVertexBuffer } from './null-vertex-buffer.js';
+
+class NullGraphicsDevice extends GraphicsDevice {
+    constructor(canvas, options = {}) {
+        super(canvas, options);
+        options = this.initOptions;
+
+        this.isNull = true;
+        this._deviceType = DEVICETYPE_NULL;
+        this.samples = 1;
+
+        Debug.log('NullGraphicsDevice');
+    }
+
+    destroy() {
+        super.destroy();
+    }
+
+    initDeviceCaps() {
+
+        this.disableParticleSystem = true;
+        this.precision = 'highp';
+        this.maxPrecision = 'highp';
+        this.maxSamples = 4;
+        this.maxTextures = 16;
+        this.maxTextureSize = 4096;
+        this.maxCubeMapSize = 4096;
+        this.maxVolumeSize = 4096;
+        this.maxColorAttachments = 8;
+        this.maxPixelRatio = 1;
+        this.maxAnisotropy = 16;
+        this.supportsInstancing = true;
+        this.supportsUniformBuffers = false;
+        this.supportsVolumeTextures = true;
+        this.supportsBoneTextures = true;
+        this.supportsMorphTargetTexturesCore = true;
+        this.supportsAreaLights = true;
+        this.supportsDepthShadow = true;
+        this.supportsGpuParticles = false;
+        this.supportsMrt = true;
+        this.extUintElement = true;
+        this.extTextureFloat = true;
+        this.textureFloatRenderable = true;
+        this.extTextureHalfFloat = true;
+        this.textureHalfFloatRenderable = true;
+        this.textureHalfFloatUpdatable = true;
+        this.boneLimit = 1024;
+        this.supportsImageBitmap = true;
+        this.extStandardDerivatives = true;
+        this.extBlendMinmax = true;
+        this.areaLightLutFormat = PIXELFORMAT_RGBA8;
+        this.supportsTextureFetch = true;
+    }
+
+    postInit() {
+        super.postInit();
+    }
+
+    resizeCanvas(width, height) {
+        this._width = width;
+        this._height = height;
+    }
+
+    frameStart() {
+        super.frameStart();
+    }
+
+    frameEnd() {
+        super.frameEnd();
+    }
+
+    createVertexBufferImpl(vertexBuffer, format) {
+        return new NullVertexBuffer(vertexBuffer, format);
+    }
+
+    createIndexBufferImpl(indexBuffer) {
+        return new NullIndexBuffer(indexBuffer);
+    }
+
+    createShaderImpl(shader) {
+        return new NullShader(shader);
+    }
+
+    createTextureImpl(texture) {
+        return new NullTexture(texture);
+    }
+
+    createRenderTargetImpl(renderTarget) {
+        return new NullRenderTarget(renderTarget);
+    }
+
+    draw(primitive, numInstances = 1, keepBuffers) {
+    }
+
+    setShader(shader) {
+        return true;
+    }
+
+    setBlendState(blendState) {
+    }
+
+    setDepthState(depthState) {
+    }
+
+    setStencilState(stencilFront, stencilBack) {
+    }
+
+    setBlendColor(r, g, b, a) {
+    }
+
+    setCullMode(cullMode) {
+    }
+
+    setAlphaToCoverage(state) {
+    }
+
+    initializeContextCaches() {
+        super.initializeContextCaches();
+    }
+
+    startPass(renderPass) {
+    }
+
+    endPass(renderPass) {
+    }
+
+    clear(options) {
+    }
+
+    get width() {
+        return this._width;
+    }
+
+    get height() {
+        return this._height;
+    }
+
+    setDepthBias(on) {
+    }
+
+    setDepthBiasValues(constBias, slopeBias) {
+    }
+
+    setViewport(x, y, w, h) {
+    }
+
+    setScissor(x, y, w, h) {
+    }
+
+    copyRenderTarget(source, dest, color, depth) {
+        return true;
+    }
+
+    // #if _DEBUG
+    pushMarker(name) {
+    }
+
+    popMarker() {
+    }
+    // #endif
+}
+
+export { NullGraphicsDevice };

--- a/src/platform/graphics/null/null-index-buffer.js
+++ b/src/platform/graphics/null/null-index-buffer.js
@@ -1,0 +1,11 @@
+/**
+ * A Null implementation of the IndexBuffer.
+ *
+ * @ignore
+ */
+class NullIndexBuffer {
+    unlock(indexBuffer) {
+    }
+}
+
+export { NullIndexBuffer };

--- a/src/platform/graphics/null/null-render-target.js
+++ b/src/platform/graphics/null/null-render-target.js
@@ -1,0 +1,20 @@
+/**
+ * A Null implementation of the RenderTarget.
+ *
+ * @ignore
+ */
+class NullRenderTarget {
+    destroy(device) {
+    }
+
+    init(device, renderTarget) {
+    }
+
+    loseContext() {
+    }
+
+    resolve(device, target, color, depth) {
+    }
+}
+
+export { NullRenderTarget };

--- a/src/platform/graphics/null/null-shader.js
+++ b/src/platform/graphics/null/null-shader.js
@@ -1,0 +1,17 @@
+/**
+ * A Null implementation of the Shader.
+ *
+ * @ignore
+ */
+class NullShader {
+    destroy(shader) {
+    }
+
+    loseContext() {
+    }
+
+    restoreContext(device, shader) {
+    }
+}
+
+export { NullShader };

--- a/src/platform/graphics/null/null-texture.js
+++ b/src/platform/graphics/null/null-texture.js
@@ -1,0 +1,17 @@
+/**
+ * A NULL implementation of the Texture.
+ *
+ * @ignore
+ */
+class NullTexture {
+    destroy(device) {
+    }
+
+    propertyChanged(flag) {
+    }
+
+    loseContext() {
+    }
+}
+
+export { NullTexture };

--- a/src/platform/graphics/null/null-vertex-buffer.js
+++ b/src/platform/graphics/null/null-vertex-buffer.js
@@ -1,0 +1,14 @@
+/**
+ * A Null implementation of the VertexBuffer.
+ *
+ * @ignore
+ */
+class NullVertexBuffer {
+    destroy(device) {
+    }
+
+    unlock(vertexBuffer) {
+    }
+}
+
+export { NullVertexBuffer };

--- a/src/scene/graphics/scene-grab.js
+++ b/src/scene/graphics/scene-grab.js
@@ -54,6 +54,18 @@ class SceneGrab {
         // create depth layer
         this.layer = null;
 
+        // null device does not support scene grab
+        if (this.device.isNull) {
+
+            this.layer = new Layer({
+                enabled: false,
+                name: "Depth",
+                id: LAYERID_DEPTH
+            });
+
+            return;
+        }
+
         // create a depth layer, which is a default depth layer, but also a template used
         // to patch application created depth layers to behave as one
         if (this.device.webgl2 || this.device.isWebGPU) {


### PR DESCRIPTION
- a NullGraphicsDevice implementation that allows to run PlayCanvas engine without graphics output (server environment for example). 
- engine examples framework is updated to add NULL option as a graphics device - examples all work but output nothing.


<img width="548" alt="Screenshot 2023-08-15 at 12 49 21" src="https://github.com/playcanvas/engine/assets/59932779/5f74dbd5-7fcb-40d9-947a-d5d6263c1f59">
