### PR TITLE
Fix to lightmapper when no baking lights

### DIFF
--- a/src/framework/lightmapper/lightmapper.js
+++ b/src/framework/lightmapper/lightmapper.js
@@ -918,7 +918,7 @@ class Lightmapper {
         this.setupScene();
 
         // update layer composition
-        comp._update();
+        comp._update(device, clusteredLightingEnabled);
 
         // compute bounding boxes for nodes
         this.computeNodesBounds(bakeNodes);


### PR DESCRIPTION
Fixes https://github.com/playcanvas/engine/issues/5553

Fit to make sure the lightmapper passes the 'is clustered lighting' flag to composition properly, to assign world clusters data.