### PR TITLE
WorldClusters allocation is now dynamic, removed from composition update

### DIFF
--- a/src/framework/lightmapper/lightmapper.js
+++ b/src/framework/lightmapper/lightmapper.js
@@ -918,7 +918,7 @@ class Lightmapper {
         this.setupScene();
 
         // update layer composition
-        comp._update(device, clusteredLightingEnabled);
+        comp._update();
 
         // compute bounding boxes for nodes
         this.computeNodesBounds(bakeNodes);

--- a/src/scene/composition/layer-composition.js
+++ b/src/scene/composition/layer-composition.js
@@ -2,7 +2,6 @@ import { TRACEID_RENDER_ACTION } from '../../core/constants.js';
 import { Debug } from '../../core/debug.js';
 import { Tracing } from '../../core/tracing.js';
 import { EventHandler } from '../../core/event-handler.js';
-import { set } from '../../core/set-utils.js';
 import { sortPriority } from '../../core/sort.js';
 
 import {
@@ -12,10 +11,8 @@ import {
 } from '../constants.js';
 
 import { RenderAction } from './render-action.js';
-import { WorldClusters } from '../lighting/world-clusters.js';
 
 const tempSet = new Set();
-const tempClusterArray = [];
 
 /**
  * Layer Composition is a collection of {@link Layer} that is fed to {@link Scene#layers} to define
@@ -109,45 +106,12 @@ class LayerComposition extends EventHandler {
 
         // _lights split into arrays per type of light, indexed by LIGHTTYPE_*** constants
         this._splitLights = [[], [], []];
-
-        // all currently created light clusters, that need to be updated before rendering
-        this._worldClusters = [];
-
-        // empty cluster with no lights
-        this._emptyWorldClusters = null;
     }
 
     destroy() {
-        // empty light cluster
-        if (this._emptyWorldClusters) {
-            this._emptyWorldClusters.destroy();
-            this._emptyWorldClusters = null;
-        }
-
-        // all other clusters
-        this._worldClusters.forEach((cluster) => {
-            cluster.destroy();
-        });
-        this._worldClusters = null;
-
         // render actions
         this._renderActions.forEach(ra => ra.destroy());
         this._renderActions = null;
-    }
-
-    // returns an empty light cluster object to be used when no lights are used
-    getEmptyWorldClusters(device) {
-        if (!this._emptyWorldClusters) {
-
-            // create cluster structure with no lights
-            this._emptyWorldClusters = new WorldClusters(device);
-            this._emptyWorldClusters.name = 'ClusterEmpty';
-
-            // update it once to avoid doing it each frame
-            this._emptyWorldClusters.update([], false, null);
-        }
-
-        return this._emptyWorldClusters;
     }
 
     // function which splits list of lights on a a target object into separate lists of lights based on light type
@@ -173,7 +137,7 @@ class LayerComposition extends EventHandler {
         splitLights[LIGHTTYPE_SPOT].sort((a, b) => a.key - b.key);
     }
 
-    _update(device, clusteredLightingEnabled = false) {
+    _update() {
         const len = this.layerList.length;
         let result = 0;
 
@@ -314,15 +278,6 @@ class LayerComposition extends EventHandler {
             this._renderActions.length = renderActionCount;
         }
 
-        // allocate light clusters if lights or meshes or cameras are modified
-        if (result & (COMPUPDATED_CAMERAS | COMPUPDATED_LIGHTS)) {
-
-            // prepare clustered lighting for render actions
-            if (clusteredLightingEnabled) {
-                this.allocateLightClusters(device);
-            }
-        }
-
         if (result & (COMPUPDATED_LIGHTS | COMPUPDATED_LIGHTS)) {
             this._logRenderActions();
         }
@@ -367,96 +322,6 @@ class LayerComposition extends EventHandler {
 
         // split light list by type
         this._splitLightsArray(this);
-    }
-
-    // find existing light cluster that is compatible with specified layer
-    findCompatibleCluster(layer, renderActionCount, emptyWorldClusters) {
-
-        // check already set up render actions
-        for (let i = 0; i < renderActionCount; i++) {
-            const ra = this._renderActions[i];
-            const raLayer = this.layerList[ra.layerIndex];
-
-            // only reuse clusters if not empty
-            if (ra.lightClusters !== emptyWorldClusters) {
-
-                // if layer is the same (but different sublayer), cluster can be used directly as lights are the same
-                if (layer === raLayer) {
-                    return ra.lightClusters;
-                }
-
-                if (ra.lightClusters) {
-                    // if the layer has exactly the same set of lights, use the same cluster
-                    if (set.equals(layer._clusteredLightsSet, raLayer._clusteredLightsSet)) {
-                        return ra.lightClusters;
-                    }
-                }
-            }
-        }
-
-        // no match
-        return null;
-    }
-
-    // assign light clusters to render actions that need it
-    allocateLightClusters(device) {
-
-        // reuse previously allocated clusters
-        tempClusterArray.push(...this._worldClusters);
-
-        // the cluster with no lights
-        const emptyWorldClusters = this.getEmptyWorldClusters(device);
-
-        // start with no clusters
-        this._worldClusters.length = 0;
-
-        // process all render actions
-        const count = this._renderActions.length;
-        for (let i = 0; i < count; i++) {
-            const ra = this._renderActions[i];
-            const layer = this.layerList[ra.layerIndex];
-
-            ra.lightClusters = null;
-
-            // if the layer has lights used by clusters
-            if (layer.hasClusteredLights) {
-
-                // and if the layer has meshes
-                if (layer.meshInstances.length) {
-
-                    // reuse cluster that was already set up and is compatible
-                    let clusters = this.findCompatibleCluster(layer, i, emptyWorldClusters);
-                    if (!clusters) {
-
-                        // use already allocated cluster from before
-                        if (tempClusterArray.length) {
-                            clusters = tempClusterArray.pop();
-                        }
-
-                        // create new cluster
-                        if (!clusters) {
-                            clusters = new WorldClusters(device);
-                        }
-
-                        clusters.name = 'Cluster-' + this._worldClusters.length;
-                        this._worldClusters.push(clusters);
-                    }
-
-                    ra.lightClusters = clusters;
-                }
-            }
-
-            // no clustered lights, use the cluster with no lights
-            if (!ra.lightClusters) {
-                ra.lightClusters = emptyWorldClusters;
-            }
-        }
-
-        // delete leftovers
-        tempClusterArray.forEach((item) => {
-            item.destroy();
-        });
-        tempClusterArray.length = 0;
     }
 
     // function adds new render action to a list, while trying to limit allocation and reuse already allocated objects
@@ -510,6 +375,7 @@ class LayerComposition extends EventHandler {
         renderAction.reset();
         renderAction.triggerPostprocess = false;
         renderAction.layerIndex = layerIndex;
+        renderAction.layer = layer;
         renderAction.cameraIndex = cameraIndex;
         renderAction.camera = camera;
         renderAction.renderTarget = rt;
@@ -579,8 +445,8 @@ class LayerComposition extends EventHandler {
                     ' Meshes: ', ('?' + layer.meshInstances.length).padStart(5) +
                     (' RT: ' + (ra.renderTarget ? ra.renderTarget.name : '-')).padEnd(30, ' ') +
                     ' Clear: ' + clear +
-                    ' Lights: (' + layer._clusteredLightsSet.size + '/' + layer._lightsSet.size + ')' +
-                    ' ' + (ra.lightClusters !== this._emptyWorldClusters ? (ra.lightClusters.name) : '').padEnd(10, ' ') +
+                    // ' Lights: (' + layer._clusteredLightsSet.size + '/' + layer._lightsSet.size + ')' +
+                    // ' ' + (ra.lightClusters !== this._emptyWorldClusters ? (ra.lightClusters.name) : '').padEnd(10, ' ') +
                     (ra.firstCameraUse ? ' CAM-FIRST' : '') +
                     (ra.lastCameraUse ? ' CAM-LAST' : '') +
                     (ra.triggerPostprocess ? ' POSTPROCESS' : '') +

--- a/src/scene/composition/layer-composition.js
+++ b/src/scene/composition/layer-composition.js
@@ -442,11 +442,8 @@ class LayerComposition extends EventHandler {
                     (' Lay: ' + layer.name).padEnd(22, ' ') +
                     (transparent ? ' TRANSP' : ' OPAQUE') +
                     (enabled ? ' ENABLED ' : ' DISABLED') +
-                    ' Meshes: ', ('?' + layer.meshInstances.length).padStart(5) +
                     (' RT: ' + (ra.renderTarget ? ra.renderTarget.name : '-')).padEnd(30, ' ') +
                     ' Clear: ' + clear +
-                    // ' Lights: (' + layer._clusteredLightsSet.size + '/' + layer._lightsSet.size + ')' +
-                    // ' ' + (ra.lightClusters !== this._emptyWorldClusters ? (ra.lightClusters.name) : '').padEnd(10, ' ') +
                     (ra.firstCameraUse ? ' CAM-FIRST' : '') +
                     (ra.lastCameraUse ? ' CAM-LAST' : '') +
                     (ra.triggerPostprocess ? ' POSTPROCESS' : '') +

--- a/src/scene/composition/render-action.js
+++ b/src/scene/composition/render-action.js
@@ -14,6 +14,9 @@ class RenderAction {
         // index into a layer stored in LayerComposition.layerList
         this.layerIndex = 0;
 
+        // the layer
+        this.layer = null;
+
         // index into a camera array of the layer, stored in Layer.cameras
         this.cameraIndex = 0;
 

--- a/src/scene/layer.js
+++ b/src/scene/layer.js
@@ -37,11 +37,14 @@ function sortLights(lightA, lightB) {
     return lightB.key - lightA.key;
 }
 
+function sortLightsIds(lightA, lightB) {
+    return lightB.id - lightA.id;
+}
+
 // Layers
 let layerCounter = 0;
 
 const lightKeys = [];
-
 const _tempMaterials = new Set();
 
 class CulledInstances {
@@ -107,6 +110,31 @@ class Layer {
      * @private
      */
     _visibleInstances = new WeakMap();
+
+    /**
+     * All lights assigned to a layer.
+     *
+     * @type {import('./light.js').Light[]}
+     * @private
+     */
+    _lights = [];
+
+    /**
+     * All lights assigned to a layer stored in a set.
+     *
+     * @type {Set<import('./light.js').Light>}
+     * @private
+     */
+
+    _lightsSet = new Set();
+
+    /**
+     * Set of light used by clustered lighting (omni and spot, but no directional).
+     *
+     * @type {Set<import('./light.js').Light>}
+     * @private
+     */
+    _clusteredLightsSet = new Set();
 
     /**
      * Create a new Layer instance.
@@ -350,25 +378,6 @@ class Layer {
         this.customCalculateSortValues = null;
 
         /**
-         * @type {import('./light.js').Light[]}
-         * @private
-         */
-        this._lights = [];
-        /**
-         * @type {Set<import('./light.js').Light>}
-         * @private
-         */
-        this._lightsSet = new Set();
-
-        /**
-         * Set of light used by clustered lighting (omni and spot, but no directional).
-         *
-         * @type {Set<import('./light.js').Light>}
-         * @private
-         */
-        this._clusteredLightsSet = new Set();
-
-        /**
          * Lights separated by light type.
          *
          * @type {import('./light.js').Light[][]}
@@ -385,8 +394,13 @@ class Layer {
         this._dirtyLights = false;
         this._dirtyCameras = false;
 
+        // light hash based on the light keys
         this._lightHash = 0;
         this._lightHashDirty = false;
+
+        // light hash based on light ids
+        this._lightIdHash = 0;
+        this._lightIdHashDirty = false;
 
         // #if _PROFILER
         this.skipRenderAfter = Number.MAX_VALUE;
@@ -404,16 +418,6 @@ class Layer {
          * @ignore
          */
         this._lightCube = null;
-    }
-
-    /**
-     * True if the layer contains omni or spot lights
-     *
-     * @type {boolean}
-     * @ignore
-     */
-    get hasClusteredLights() {
-        return this._clusteredLightsSet.size > 0;
     }
 
     /**
@@ -478,6 +482,16 @@ class Layer {
 
     get clearStencilBuffer() {
         return this._clearStencilBuffer;
+    }
+
+    /**
+     * True if the layer contains omni or spot lights
+     *
+     * @type {boolean}
+     * @ignore
+     */
+    get hasClusteredLights() {
+        return this._clusteredLightsSet.size > 0;
     }
 
     /**
@@ -665,6 +679,12 @@ class Layer {
         }
     }
 
+    markLightDirty() {
+        this._dirtyLights = true;
+        this._lightHashDirty = true;
+        this._lightIdHashDirty = true;
+    }
+
     /**
      * Adds a light to this layer.
      *
@@ -679,8 +699,7 @@ class Layer {
             this._lightsSet.add(l);
 
             this._lights.push(l);
-            this._dirtyLights = true;
-            this._lightHashDirty = true;
+            this.markLightDirty();
         }
 
         if (l.type !== LIGHTTYPE_DIRECTIONAL) {
@@ -701,8 +720,7 @@ class Layer {
             this._lightsSet.delete(l);
 
             this._lights.splice(this._lights.indexOf(l), 1);
-            this._dirtyLights = true;
-            this._lightHashDirty = true;
+            this.markLightDirty();
         }
 
         if (l.type !== LIGHTTYPE_DIRECTIONAL) {
@@ -717,37 +735,60 @@ class Layer {
         this._lightsSet.clear();
         this._clusteredLightsSet.clear();
         this._lights.length = 0;
-        this._dirtyLights = true;
+        this.markLightDirty();
     }
+
+    evaluateLightHash(localLights, directionalLights, useIds) {
+
+        let hash = 0;
+
+        const lights = this._lights;
+        if (lights.length > 0) {
+            lights.sort(useIds ? sortLightsIds : sortLights);
+
+            for (let i = 0; i < lights.length; i++) {
+
+                const isLocalLight = lights[i].type !== LIGHTTYPE_DIRECTIONAL;
+
+                if ((localLights && isLocalLight) || (directionalLights && !isLocalLight)) {
+                    lightKeys.push(useIds ? lights[i].id : lights[i].key);
+                }
+            }
+
+            if (lightKeys.length > 0) {
+                hash = hash32Fnv1a(lightKeys);
+                lightKeys.length = 0;
+            }
+        }
+
+        return hash;
+    }
+
 
     getLightHash(isClustered) {
         if (this._lightHashDirty) {
             this._lightHashDirty = false;
 
-            // generate hash to check if layers have the same set of lights independent of their order
-            this._lightHash = 0;
-
-            const lights = this._lights;
-            if (lights.length > 0) {
-                lights.sort(sortLights);
-
-                for (let i = 0; i < lights.length; i++) {
-
-                    // only directional lights affect the shader generation for clustered lighting
-                    if (isClustered && lights[i].type !== LIGHTTYPE_DIRECTIONAL)
-                        continue;
-
-                    lightKeys.push(lights[i].key);
-                }
-
-                if (lightKeys.length > 0) {
-                    this._lightHash = hash32Fnv1a(lightKeys);
-                    lightKeys.length = 0;
-                }
-            }
+            // Generate hash to check if layers have the same set of lights independent of their order.
+            // Always use directional lights. Additionally use local lights if clustered lighting is disabled.
+            // (only directional lights affect the shader generation for clustered lighting)
+            this._lightHash = this.evaluateLightHash(!isClustered, true, false);
         }
 
         return this._lightHash;
+    }
+
+    // This is only used in clustered lighting mode
+    getLightIdHash() {
+        if (this._lightIdHashDirty) {
+            this._lightIdHashDirty = false;
+
+            // Generate hash based on Ids of lights sorted by ids, to check if the layers have the same set of lights
+            // Only use local lights (directional lights are not used for clustered lighting)
+            this._lightIdHash = this.evaluateLightHash(true, false, true);
+        }
+
+        return this._lightIdHash;
     }
 
     /**

--- a/src/scene/layer.js
+++ b/src/scene/layer.js
@@ -679,7 +679,7 @@ class Layer {
         }
     }
 
-    markLightDirty() {
+    markLightsDirty() {
         this._dirtyLights = true;
         this._lightHashDirty = true;
         this._lightIdHashDirty = true;
@@ -699,7 +699,7 @@ class Layer {
             this._lightsSet.add(l);
 
             this._lights.push(l);
-            this.markLightDirty();
+            this.markLightsDirty();
         }
 
         if (l.type !== LIGHTTYPE_DIRECTIONAL) {
@@ -720,7 +720,7 @@ class Layer {
             this._lightsSet.delete(l);
 
             this._lights.splice(this._lights.indexOf(l), 1);
-            this.markLightDirty();
+            this.markLightsDirty();
         }
 
         if (l.type !== LIGHTTYPE_DIRECTIONAL) {
@@ -735,7 +735,7 @@ class Layer {
         this._lightsSet.clear();
         this._clusteredLightsSet.clear();
         this._lights.length = 0;
-        this.markLightDirty();
+        this.markLightsDirty();
     }
 
     evaluateLightHash(localLights, directionalLights, useIds) {

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -475,7 +475,7 @@ class ForwardRenderer extends Renderer {
         const device = this.device;
         const scene = this.scene;
         const clusteredLightingEnabled = scene.clusteredLightingEnabled;
-        const lightHash = layer ? layer.getLightHash(clusteredLightingEnabled) : 0;
+        const lightHash = layer?.getLightHash(clusteredLightingEnabled) ?? 0;
         let prevMaterial = null, prevObjDefs, prevLightMask;
 
         const drawCallsCount = drawCalls.length;

--- a/src/scene/renderer/world-clusters-allocator.js
+++ b/src/scene/renderer/world-clusters-allocator.js
@@ -97,17 +97,18 @@ class WorldClustersAllocator {
             const layer = ra.layer;
             if (layer.hasClusteredLights && layer.meshInstances.length) {
 
-                // reuse cluster that is already used by a render action
+                // use existing clusters if the lights on the layer are the same
                 const hash = layer.getLightIdHash();
                 const existingRenderAction = this._clusters.get(hash);
                 let clusters = existingRenderAction?.lightClusters;
 
+                // no match, needs new clusters
                 if (!clusters) {
 
-                    // use already allocated cluster from before, or create a new one
+                    // use already allocated cluster from last frame, or create a new one
                     clusters = tempClusterArray.pop() ?? new WorldClusters(this.device);
-
                     DebugHelper.setName(clusters, `Cluster-${this._allocated.length}`);
+
                     this._allocated.push(clusters);
                     this._clusters.set(hash, ra);
                 }

--- a/src/scene/renderer/world-clusters-allocator.js
+++ b/src/scene/renderer/world-clusters-allocator.js
@@ -1,0 +1,143 @@
+import { DebugHelper } from '../../core/debug.js';
+import { WorldClusters } from '../lighting/world-clusters.js';
+
+const tempClusterArray = [];
+
+/**
+ * A class managing instances of world clusters used by the renderer for layers with
+ * unique sets of clustered lights.
+ *
+ * @ignore
+ */
+class WorldClustersAllocator {
+    /**
+     * Empty cluster with no lights.
+     *
+     * @type {WorldClusters|null}
+     */
+    _empty = null;
+
+    /**
+     * All allocated clusters
+     *
+     * @type {WorldClusters[]}
+     */
+    _allocated = [];
+
+    /**
+     * Render actions with all unique light clusters. The key is the hash of lights on a layer, the
+     * value is a render action with unique light clusters.
+     *
+     * @type {Map<number, import('../composition/render-action.js').RenderAction>}
+     */
+    _clusters = new Map();
+
+    /**
+     * Create a new instance.
+     *
+     * @param {import('../../platform/graphics/graphics-device.js').GraphicsDevice} graphicsDevice -
+     * The graphics device.
+     */
+    constructor(graphicsDevice) {
+        this.device = graphicsDevice;
+    }
+
+    destroy() {
+
+        // empty light cluster
+        if (this._empty) {
+            this._empty.destroy();
+            this._empty = null;
+        }
+
+        // all other clusters
+        this._allocated.forEach((cluster) => {
+            cluster.destroy();
+        });
+        this._allocated.length = 0;
+    }
+
+    get count() {
+        return this._allocated.length;
+    }
+
+    // returns an empty light cluster object to be used when no lights are used
+    get empty() {
+        if (!this._empty) {
+
+            // create cluster structure with no lights
+            const empty = new WorldClusters(this.device);
+            empty.name = 'ClusterEmpty';
+
+            // update it once to avoid doing it each frame
+            empty.update([], false, null);
+            this._empty = empty;
+        }
+
+        return this._empty;
+    }
+
+    // assign light clusters to render actions that need it
+    assign(renderActions) {
+
+        const empty = this.empty;
+
+        // reuse previously allocated clusters
+        tempClusterArray.push(...this._allocated);
+        this._allocated.length = 0;
+        this._clusters.clear();
+
+        // process all render actions
+        const count = renderActions.length;
+        for (let i = 0; i < count; i++) {
+            const ra = renderActions[i];
+            ra.lightClusters = null;
+
+            // if the layer has lights used by clusters, and meshes
+            const layer = ra.layer;
+            if (layer.hasClusteredLights && layer.meshInstances.length) {
+
+                // reuse cluster that is already used by a render action
+                const hash = layer.getLightIdHash();
+                const existingRenderAction = this._clusters.get(hash);
+                let clusters = existingRenderAction?.lightClusters;
+
+                if (!clusters) {
+
+                    // use already allocated cluster from before, or create a new one
+                    clusters = tempClusterArray.pop() ?? new WorldClusters(this.device);
+
+                    DebugHelper.setName(clusters, `Cluster-${this._allocated.length}`);
+                    this._allocated.push(clusters);
+                    this._clusters.set(hash, ra);
+                }
+
+                ra.lightClusters = clusters;
+            }
+
+            // no clustered lights, use the cluster with no lights
+            if (!ra.lightClusters) {
+                ra.lightClusters = empty;
+            }
+        }
+
+        // delete leftovers
+        tempClusterArray.forEach(item => item.destroy());
+        tempClusterArray.length = 0;
+    }
+
+    update(renderActions, gammaCorrection, lighting) {
+
+        // assign clusters to render actions
+        this.assign(renderActions);
+
+        // update all unique clusters
+        this._clusters.forEach((renderAction) => {
+            const layer = renderAction.layer;
+            const cluster = renderAction.lightClusters;
+            cluster.update(layer.clusteredLightsSet, gammaCorrection, lighting);
+        });
+    }
+}
+
+export { WorldClustersAllocator };


### PR DESCRIPTION
Refactoring to limit the amount of LayerComposition updates.

Before: When a light was added / removed from the layer, the expensive composition update would execute. Part of the update was to assign world clusters (textures storing clustered lights) to individual layers based on their lights.

Now: The world clusters assignment takes place at the start of the frame. The layers lazily update their light hash values and world clusters are shared between layers based on this hash.

The is still a cost of computing a hash for a layer on frames lights are added / removed on it - but this is reasonably cheap.
Note that this is needed specifically for WebGL1 path, on other platforms we could use bitflag to encode layers and reject lights from a single clusters structure at runtime. One day.

Note that the composition still updates when lights are added / removed, and further refactoring is needed, this PR only addresses the clustered part of it.