### PR TITLE
Cookie renderer refactored to use a single render pass

### DIFF
--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -801,8 +801,7 @@ class ForwardRenderer extends Renderer {
                 const renderPass = new RenderPass(this.device, () => {
                     // render cookies for all local visible lights
                     if (this.scene.lighting.cookiesEnabled) {
-                        this.renderCookies(layerComposition._splitLights[LIGHTTYPE_SPOT]);
-                        this.renderCookies(layerComposition._splitLights[LIGHTTYPE_OMNI]);
+                        this.renderCookies(layerComposition._lights);
                     }
                 });
                 renderPass.requiresCubemaps = false;

--- a/src/scene/renderer/renderer.js
+++ b/src/scene/renderer/renderer.js
@@ -1055,21 +1055,8 @@ class Renderer {
     }
 
     renderCookies(lights) {
-
         const cookieRenderTarget = this.lightTextureAtlas.cookieRenderTarget;
-        for (let i = 0; i < lights.length; i++) {
-            const light = lights[i];
-
-            // skip clustered cookies with no assigned atlas slot
-            if (!light.atlasViewportAllocated)
-                continue;
-
-            // only render cookie when the slot is reassigned (assuming the cookie texture is static)
-            if (!light.atlasSlotUpdated)
-                continue;
-
-            this._cookieRenderer.render(light, cookieRenderTarget);
-        }
+        this._cookieRenderer.render(cookieRenderTarget, lights);
     }
 
     /**


### PR DESCRIPTION
In the first implementation, the clustered cookie atlas renderer just used the renderQuadWithShader to render cookie for each light into an atlas. This was creating a render pass / or 6 for cubemap, which is not efficient.

This PR creates a single render pass directly, and renders quads to it, to avoid all that.