### PR TITLE
Handle case of gl.getSupportedExtrentions returning null

### DIFF
--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -861,8 +861,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
      */
     initializeExtensions() {
         const gl = this.gl;
-        const supportedExtensions = gl.getSupportedExtensions();
-        this.supportedExtensions = supportedExtensions;
+        this.supportedExtensions = gl.getSupportedExtensions() ?? [];
         this._extDisjointTimerQuery = null;
 
         if (this.webgl2) {


### PR DESCRIPTION
It seems `gl.getSupportedExtrentions` can return null / undefined on some devices, which we access without testing (WebGl specs says it should always return an array though). This triggers these errors (when the device is lost it seems):

```
TypeError: null is not an object (evaluating 'this.supportedExtensions.indexOf')
undefined is not an object (evaluating 'this.gpuProfiler.loseContext')
```

This is a fix without a repro, and so unconfirmed.
Seen by customers on iPhone 11, Version:16.6.
