### PR TITLE
[Fix] Fix the Picker not restoring transparency flag

### DIFF
--- a/src/framework/graphics/picker.js
+++ b/src/framework/graphics/picker.js
@@ -315,7 +315,7 @@ class Picker {
 
         // mark all meshes as transparent again
         tempSet.forEach((meshInstance) => {
-            meshInstance.transparent = false;
+            meshInstance.transparent = true;
         });
         tempSet.clear();
     }


### PR DESCRIPTION
issue introduced here: https://github.com/playcanvas/engine/pull/5536

The comment is correct, but copy & pasted code was not. 

Problem: Transparent meshes in the Editor would be rendered in Opaque sub-layers when mouse-over.