### PR TITLE
fix(docs): remove type-error warning

### DIFF
--- a/src/scene/layer.js
+++ b/src/scene/layer.js
@@ -130,6 +130,7 @@ class Layer {
 
     /**
      * True if the objects rendered on the layer require light cube (emitters with lighting do).
+     * @type {boolean}
      */
     requiresLightCube = false;
 


### PR DESCRIPTION
address warning when building docs:

`Can't generate type link. Search output for {{TYPE-ERROR}}`

Fixes type link in docs.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
