### PR TITLE
Refactored the way LightComponent changes notify the LayerComposition

### DIFF
--- a/src/framework/components/light/component.js
+++ b/src/framework/components/light/component.js
@@ -183,6 +183,7 @@ class LightComponent extends Component {
             const layer = this.system.app.scene.layers.getLayerById(this.layers[i]);
             if (layer) {
                 layer.addLight(this);
+                this.light.addLayer(layer);
             }
         }
     }
@@ -192,6 +193,7 @@ class LightComponent extends Component {
             const layer = this.system.app.scene.layers.getLayerById(this.layers[i]);
             if (layer) {
                 layer.removeLight(this);
+                this.light.removeLayer(layer);
             }
         }
     }
@@ -210,6 +212,7 @@ class LightComponent extends Component {
         const index = this.layers.indexOf(layer.id);
         if (index >= 0 && this.enabled && this.entity.enabled) {
             layer.addLight(this);
+            this.light.addLayer(layer);
         }
     }
 
@@ -217,6 +220,7 @@ class LightComponent extends Component {
         const index = this.layers.indexOf(layer.id);
         if (index >= 0) {
             layer.removeLight(this);
+            this.light.removeLayer(layer);
         }
     }
 
@@ -558,12 +562,14 @@ function _defineProps() {
             const layer = this.system.app.scene.layers.getLayerById(oldValue[i]);
             if (!layer) continue;
             layer.removeLight(this);
+            this.light.removeLayer(layer);
         }
         for (let i = 0; i < newValue.length; i++) {
             const layer = this.system.app.scene.layers.getLayerById(newValue[i]);
             if (!layer) continue;
             if (this.enabled && this.entity.enabled) {
                 layer.addLight(this);
+                this.light.addLayer(layer);
             }
         }
     });

--- a/src/framework/components/light/system.js
+++ b/src/framework/components/light/system.js
@@ -73,7 +73,6 @@ class LightComponentSystem extends ComponentSystem {
         const light = new Light(this.app.graphicsDevice);
         light.type = lightTypes[data.type];
         light._node = component.entity;
-        light._scene = this.app.scene;
         component.data.light = light;
 
         super.initializeComponentData(component, data, properties);

--- a/src/scene/layer.js
+++ b/src/scene/layer.js
@@ -724,6 +724,10 @@ class Layer {
      * Removes all lights from this layer.
      */
     clearLights() {
+
+        // notify lights
+        this._lightsSet.forEach(light => light.removeLayer(this));
+
         this._lightsSet.clear();
         this._clusteredLightsSet.clear();
         this._lights.length = 0;

--- a/src/scene/light.js
+++ b/src/scene/light.js
@@ -40,7 +40,11 @@ const directionalCascades = [
 
 let id = 0;
 
-// Class storing shadow rendering related private information
+/**
+ * Class storing shadow rendering related private information
+ *
+ * @ignore
+ */
 class LightRenderData {
     constructor(device, camera, face, light) {
 
@@ -114,6 +118,13 @@ class LightRenderData {
  * @ignore
  */
 class Light {
+    /**
+     * The Layers the light is on.
+     *
+     * @type {Set<import('./layer.js').Layer>}
+     */
+    layers = new Set();
+
     constructor(graphicsDevice) {
         this.device = graphicsDevice;
         this.id = id++;
@@ -205,7 +216,6 @@ class Light {
         this.atlasSlotIndex = 0;    // allocated slot index, used for more persistent slot allocation
         this.atlasSlotUpdated = false;  // true if the atlas slot was reassigned this frame (and content needs to be updated)
 
-        this._scene = null;
         this._node = null;
 
         // private rendering data
@@ -235,6 +245,14 @@ class Light {
 
             this._renderData.length = 0;
         }
+    }
+
+    addLayer(layer) {
+        this.layers.add(layer);
+    }
+
+    removeLayer(layer) {
+        this.layers.delete(layer);
     }
 
     set numCascades(value) {
@@ -869,11 +887,16 @@ class Light {
     }
 
     layersDirty() {
-        if (this._scene?.layers) {
-            this._scene.layers._dirtyLights = true;
-        }
+        this.layers.forEach((layer) => {
+            layer._dirtyLights = true;
+        });
     }
 
+    /**
+     * Updates a integer key for the light. The key is used to identify all shader related features
+     * of the light, and so needs to have all properties that modify the generated shader encoded.
+     * Properties without an effect on the shader (color, shadow intensity) should not be encoded.
+     */
     updateKey() {
         // Key definition:
         // Bit
@@ -911,9 +934,8 @@ class Light {
             key |= (chanId[this._cookieChannel.charAt(2)] << 14);
         }
 
-        if (key !== this.key && this._scene !== null) {
-            // TODO: most of the changes to the key should not invalidate the composition,
-            // probably only _type and _castShadows
+        if (key !== this.key) {
+            // The layer maintains lights split and sorted by the key, notify it when the key changes
             this.layersDirty();
         }
 


### PR DESCRIPTION
Before, the light would store a pointer to the scene, to mark lights in its layer composition dirty. This is now replaced by a light storing a Set of layers it is on, allowing it to notify only the affected layers of the change. No large benefit here yet, but there will be follow up PRs, allowing only affected layers to be updated instead of the whole composition.