### PR TITLE
Refactored shadow casting directional lights collection

### DIFF
--- a/src/scene/composition/layer-composition.js
+++ b/src/scene/composition/layer-composition.js
@@ -251,9 +251,6 @@ class LayerComposition extends EventHandler {
 
                 // if the camera renders any layers.
                 if (cameraFirstRenderActionIndex < renderActionCount) {
-                    // based on all layers this camera renders, prepare a list of directional lights the camera needs to render shadow for
-                    // and set these up on the first render action for the camera.
-                    this._renderActions[cameraFirstRenderActionIndex].collectDirectionalLights(cameraLayers, this._splitLights[LIGHTTYPE_DIRECTIONAL], this._lights);
 
                     // mark the last render action as last one using the camera
                     lastRenderAction.lastCameraUse = true;
@@ -313,8 +310,6 @@ class LayerComposition extends EventHandler {
                 }
             }
 
-            // split layer lights lists by type
-            this._splitLightsArray(layer);
             layer._dirtyLights = false;
         }
 

--- a/src/scene/composition/render-action.js
+++ b/src/scene/composition/render-action.js
@@ -43,10 +43,7 @@ class RenderAction {
         // true if this is the last render action using this camera
         this.lastCameraUse = false;
 
-        // directional lights that needs to update their shadows for this render action, stored as a set
-        this.directionalLightsSet = new Set();
-
-        // and also store them as an array
+        // directional lights that needs to update their shadows for this render action
         this.directionalLights = [];
 
         // an array of view bind groups (the number of these corresponds to the number of views when XR is used)
@@ -70,7 +67,6 @@ class RenderAction {
     // prepares render action for re-use
     reset() {
         this.lightClusters = null;
-        this.directionalLightsSet.clear();
         this.directionalLights.length = 0;
     }
 
@@ -82,31 +78,6 @@ class RenderAction {
     isLayerEnabled(layerComposition) {
         const layer = layerComposition.layerList[this.layerIndex];
         return layer.enabled && layerComposition.subLayerEnabled[this.layerIndex];
-    }
-
-    // store directional lights that are needed for this camera based on layers it renders
-    collectDirectionalLights(cameraLayers, dirLights, allLights) {
-
-        this.directionalLightsSet.clear();
-        this.directionalLights.length = 0;
-
-        for (let i = 0; i < dirLights.length; i++) {
-            const light = dirLights[i];
-
-            // only shadow casting lights
-            if (light.castShadows) {
-                for (let l = 0; l < cameraLayers.length; l++) {
-
-                    // if layer has the light
-                    if (cameraLayers[l]._lightsSet.has(light)) {
-                        if (!this.directionalLightsSet.has(light)) {
-                            this.directionalLightsSet.add(light);
-                            this.directionalLights.push(light);
-                        }
-                    }
-                }
-            }
-        }
     }
 }
 

--- a/src/scene/layer.js
+++ b/src/scene/layer.js
@@ -2,7 +2,7 @@ import { Debug } from '../core/debug.js';
 import { hash32Fnv1a } from '../core/hash.js';
 
 import {
-    LIGHTTYPE_DIRECTIONAL, LIGHTTYPE_OMNI, LIGHTTYPE_SPOT,
+    LIGHTTYPE_DIRECTIONAL,
     LAYER_FX,
     SHADER_FORWARD,
     SORTKEY_FORWARD,

--- a/src/scene/layer.js
+++ b/src/scene/layer.js
@@ -2,7 +2,7 @@ import { Debug } from '../core/debug.js';
 import { hash32Fnv1a } from '../core/hash.js';
 
 import {
-    LIGHTTYPE_DIRECTIONAL,
+    LIGHTTYPE_DIRECTIONAL, LIGHTTYPE_OMNI, LIGHTTYPE_SPOT,
     LAYER_FX,
     SHADER_FORWARD,
     SORTKEY_FORWARD,
@@ -129,8 +129,26 @@ class Layer {
     _clusteredLightsSet = new Set();
 
     /**
-     * True if the objects rendered on the layer require light cube (emitters with lighting do).
+     * Lights separated by light type. Lights in the individual arrays are sorted by the key,
+     * to match their order in _lightIdHash, so that their order matches the order expected by the
+     * generated shader code.
+     *
+     * @type {import('./light.js').Light[][]}
+     * @private
+     */
+    _splitLights = [[], [], []];
+
+    /**
+     * True if _splitLights needs to be updated, which means if lights were added or removed from
+     * the layer, or their key changed.
+     *
      * @type {boolean}
+     * @private
+     */
+    _splitLightsDirty = true;
+
+    /**
+     * True if the objects rendered on the layer require light cube (emitters with lighting do).
      */
     requiresLightCube = false;
 
@@ -376,20 +394,14 @@ class Layer {
         this.customCalculateSortValues = null;
 
         /**
-         * Lights separated by light type.
-         *
-         * @type {import('./light.js').Light[][]}
-         * @ignore
-         */
-        this._splitLights = [[], [], []];
-
-        /**
          * @type {import('../framework/components/camera/component.js').CameraComponent[]}
          * @ignore
          */
         this.cameras = [];
 
+        // TODO: remove this when composition no longer updates lights
         this._dirtyLights = false;
+
         this._dirtyCameras = false;
 
         // light hash based on the light keys
@@ -675,6 +687,7 @@ class Layer {
         this._dirtyLights = true;
         this._lightHashDirty = true;
         this._lightIdHashDirty = true;
+        this._splitLightsDirty = true;
     }
 
     /**
@@ -732,6 +745,32 @@ class Layer {
         this._clusteredLightsSet.clear();
         this._lights.length = 0;
         this.markLightsDirty();
+    }
+
+    get splitLights() {
+
+        if (this._splitLightsDirty) {
+            this._splitLightsDirty = false;
+
+            const splitLights = this._splitLights;
+            for (let i = 0; i < splitLights.length; i++)
+                splitLights[i].length = 0;
+
+            const lights = this._lights;
+            for (let i = 0; i < lights.length; i++) {
+                const light = lights[i];
+                if (light.enabled) {
+                    splitLights[light._type].push(light);
+                }
+            }
+
+            // sort the lights by their key, as the order of lights is used to generate shader generation key,
+            // and this avoids new shaders being generated when lights are reordered
+            for (let i = 0; i < splitLights.length; i++)
+                splitLights[i].sort((a, b) => a.key - b.key);
+        }
+
+        return this._splitLights;
     }
 
     evaluateLightHash(localLights, directionalLights, useIds) {

--- a/src/scene/light.js
+++ b/src/scene/light.js
@@ -889,6 +889,7 @@ class Light {
     layersDirty() {
         this.layers.forEach((layer) => {
             layer._dirtyLights = true;
+            layer._splitLightsDirty = true;
         });
     }
 

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -848,7 +848,7 @@ class ForwardRenderer extends Renderer {
 
             // directional shadows get re-rendered for each camera
             if (renderAction.hasDirectionalShadowLights && camera) {
-                this._shadowRendererDirectional.buildFrameGraph(frameGraph, renderAction, camera);
+                this._shadowRendererDirectional.buildFrameGraph(frameGraph, renderAction.directionalLights, camera);
             }
 
             // start of block of render actions rendering to the same render target
@@ -1125,7 +1125,7 @@ class ForwardRenderer extends Renderer {
             const draws = this._forwardDrawCalls;
             this.renderForward(camera.camera,
                                visible,
-                               layer._splitLights,
+                               layer.splitLights,
                                shaderPass,
                                layer.onDrawCall,
                                layer,

--- a/src/scene/renderer/renderer.js
+++ b/src/scene/renderer/renderer.js
@@ -951,18 +951,20 @@ class Renderer {
                 const cameraLayers = camera.layers;
                 for (let l = 0; l < cameraLayers.length; l++) {
                     const cameraLayer = comp.getLayerById(cameraLayers[l]);
-                    const layerDirLights = cameraLayer.splitLights[LIGHTTYPE_DIRECTIONAL];
+                    if (cameraLayer) {
+                        const layerDirLights = cameraLayer.splitLights[LIGHTTYPE_DIRECTIONAL];
 
-                    for (let j = 0; j < layerDirLights.length; j++) {
-                        const light = layerDirLights[j];
+                        for (let j = 0; j < layerDirLights.length; j++) {
+                            const light = layerDirLights[j];
 
-                        // unique shadow casting lights
-                        if (light.castShadows && !_tempSet.has(light)) {
-                            _tempSet.add(light);
-                            renderAction.directionalLights.push(light);
+                            // unique shadow casting lights
+                            if (light.castShadows && !_tempSet.has(light)) {
+                                _tempSet.add(light);
+                                renderAction.directionalLights.push(light);
 
-                            // frustum culling for the directional shadow when rendering the camera
-                            this._shadowRendererDirectional.cull(light, comp, camera);
+                                // frustum culling for the directional shadow when rendering the camera
+                                this._shadowRendererDirectional.cull(light, comp, camera);
+                            }
                         }
                     }
                 }

--- a/src/scene/renderer/shadow-renderer-directional.js
+++ b/src/scene/renderer/shadow-renderer-directional.js
@@ -247,16 +247,15 @@ class ShadowRendererDirectional {
      * Builds a frame graph for rendering of directional shadows for the render action.
      *
      * @param {import('../frame-graph.js').FrameGraph} frameGraph - The frame-graph that is built.
-     * @param {import('../composition/render-action.js').RenderAction} renderAction - The render
-     * action.
+     * @param {import('../light.js').Light[]} directionalLights - The
+     * directional lights.
      * @param {import('../../framework/components/camera/component.js').CameraComponent} camera - The camera.
      */
-    buildFrameGraph(frameGraph, renderAction, camera) {
+    buildFrameGraph(frameGraph, directionalLights, camera) {
 
         // create required render passes per light
-        const lights = renderAction.directionalLights;
-        for (let i = 0; i < lights.length; i++) {
-            const light = lights[i];
+        for (let i = 0; i < directionalLights.length; i++) {
+            const light = directionalLights[i];
             Debug.assert(light && light._type === LIGHTTYPE_DIRECTIONAL);
 
             if (this.shadowRenderer.needsShadowRendering(light)) {


### PR DESCRIPTION
Those lights used to be collected during composition update, but now are obtained from layers at runtime, to avoid composition update when any lights / light properties change