### PR TITLE
fix(examples): ensure examples commands work on windows

### DIFF
--- a/examples/package.json
+++ b/examples/package.json
@@ -14,8 +14,8 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "lint": "eslint . --ext .js,.ts,.tsx",
     "watch": "npm run build:example:data && npm run build:directory && cross-env concurrently --kill-others \"npm run rollup:watch\"",
-    "watch:debug": "ENGINE_PATH=../build/playcanvas.dbg.js npm run watch",
-    "watch:profiler": "ENGINE_PATH=../build/playcanvas.prf.js npm run watch",
+    "watch:debug": "cross-env ENGINE_PATH=../build/playcanvas.dbg.js npm run watch",
+    "watch:profiler": "cross-env ENGINE_PATH=../build/playcanvas.prf.js npm run watch",
     "develop": "cross-env concurrently --kill-others \"npm run watch\" \"npm run serve\""
   },
   "eslintConfig": {


### PR DESCRIPTION
Ensure the npm commands in examples, "watch:debug" and  "watch:profiler", run when testing on Windows.  

npx will set environment variables on Mac and linux by putting them at the start but needs the cross-env so that they are set on Windows.

Fixes some dev commands related to examples.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
