### PR TITLE
[Fix] Make sure the non-clustered shadow allocates shadow map even when not rendered

### DIFF
--- a/src/scene/renderer/renderer.js
+++ b/src/scene/renderer/renderer.js
@@ -930,6 +930,14 @@ class Renderer {
                     if (light.atlasSlotUpdated && light.shadowUpdateMode === SHADOWUPDATE_NONE) {
                         light.shadowUpdateMode = SHADOWUPDATE_THISFRAME;
                     }
+                } else {
+
+                    // force rendering shadow at least once to allocate the shadow map needed by the shaders
+                    if (light.shadowUpdateMode === SHADOWUPDATE_NONE && light.castShadows) {
+                        if (!light.getRenderData(null, 0).shadowCamera.renderTarget) {
+                            light.shadowUpdateMode = SHADOWUPDATE_THISFRAME;
+                        }
+                    }
                 }
 
                 if (light.visibleThisFrame && light.castShadows && light.shadowUpdateMode !== SHADOWUPDATE_NONE) {


### PR DESCRIPTION
Fixes https://github.com/playcanvas/engine/issues/5595

When shadow map rendering is set to `SHADOWUPDATE_NONE` but it was not rendered to before, change it to SHADOWUPDATE_THISFRAME to render it one time, as the shader needs a shadow map.

Workaround in the meantime - set the shadow update mode to SHADOWUPDATE_THISFRAME, but not to SHADOWUPDATE_NONE.