### PR TITLE
Converted Picker to use render pass internally

### DIFF
--- a/examples/src/examples/graphics/area-picker.tsx
+++ b/examples/src/examples/graphics/area-picker.tsx
@@ -148,6 +148,10 @@ class AreaPickerExample {
                 // array of highlighted materials
                 const highlights: pc.StandardMaterial[] = [];
 
+                // the layers picker renders
+                const worldLayer = app.scene.layers.getLayerByName("World");
+                const pickerLayers = [worldLayer];
+
                 // update each frame
                 let time = 0;
                 app.on("update", function (dt: number) {
@@ -171,7 +175,7 @@ class AreaPickerExample {
                     // Make sure the picker is the right size, and prepare it, which renders meshes into its render target
                     if (picker) {
                         picker.resize(canvas.clientWidth * pickerScale, canvas.clientHeight * pickerScale);
-                        picker.prepare(camera.camera, app.scene);
+                        picker.prepare(camera.camera, app.scene, pickerLayers);
                     }
 
                     // areas we want to sample - two larger rectangles, one small square, and one pixel at a mouse position

--- a/src/deprecated/deprecated.js
+++ b/src/deprecated/deprecated.js
@@ -67,7 +67,7 @@ import { GraphNode } from '../scene/graph-node.js';
 import { Material } from '../scene/materials/material.js';
 import { Mesh } from '../scene/mesh.js';
 import { Morph } from '../scene/morph.js';
-import { MeshInstance, Command } from '../scene/mesh-instance.js';
+import { MeshInstance } from '../scene/mesh-instance.js';
 import { Model } from '../scene/model.js';
 import { ParticleEmitter } from '../scene/particle-system/particle-emitter.js';
 import { Picker } from '../framework/graphics/picker.js';
@@ -731,7 +731,6 @@ export const scene = {
         createBox: createBox
     },
     BasicMaterial: BasicMaterial,
-    Command: Command,
     ForwardRenderer: ForwardRenderer,
     GraphNode: GraphNode,
     Material: Material,

--- a/src/framework/graphics/picker.js
+++ b/src/framework/graphics/picker.js
@@ -52,6 +52,8 @@ class Picker {
             Debug.deprecated('pc.Picker now takes pc.AppBase as first argument. Passing pc.GraphicsDevice is deprecated.');
         }
 
+        // Note: The only reason this class needs the app is to access the renderer. Ideally we remove this dependency and move
+        // the Picker from framework to the scene level, or even the extras.
         this.renderer = app.renderer;
         this.device = app.graphicsDevice;
 

--- a/src/framework/graphics/picker.js
+++ b/src/framework/graphics/picker.js
@@ -1,28 +1,22 @@
 import { Color } from '../../core/math/color.js';
 
-import { ADDRESS_CLAMP_TO_EDGE, CLEARFLAG_DEPTH, FILTER_NEAREST, PIXELFORMAT_RGBA8 } from '../../platform/graphics/constants.js';
+import { ADDRESS_CLAMP_TO_EDGE, FILTER_NEAREST, PIXELFORMAT_RGBA8 } from '../../platform/graphics/constants.js';
 import { GraphicsDevice } from '../../platform/graphics/graphics-device.js';
 import { RenderTarget } from '../../platform/graphics/render-target.js';
 import { Texture } from '../../platform/graphics/texture.js';
 import { DebugGraphics } from '../../platform/graphics/debug-graphics.js';
 
-import { SHADER_PICK, SORTMODE_NONE } from '../../scene/constants.js';
+import { SHADER_PICK } from '../../scene/constants.js';
 import { Camera } from '../../scene/camera.js';
-import { Command } from '../../scene/mesh-instance.js';
 import { Layer } from '../../scene/layer.js';
-import { LayerComposition } from '../../scene/composition/layer-composition.js';
 
 import { getApplication } from '../globals.js';
-import { Entity } from '../entity.js';
-import { Debug } from '../../core/debug.js';
+import { Debug, DebugHelper } from '../../core/debug.js';
 import { BlendState } from '../../platform/graphics/blend-state.js';
+import { RenderPass } from '../../platform/graphics/render-pass.js';
 
 const tempSet = new Set();
-
-const clearDepthOptions = {
-    depth: 1.0,
-    flags: CLEARFLAG_DEPTH
-};
+const tempMeshInstances = [];
 
 /**
  * Picker object used to select mesh instances from screen coordinates.
@@ -38,6 +32,12 @@ class Picker {
     // internal render target
     renderTarget = null;
 
+    // uniform for the mesh index encoded into rgba
+    pickColor = new Float32Array(4);
+
+    // mapping table from ids to meshInstances
+    mapping = new Map();
+
     /**
      * Create a new Picker instance.
      *
@@ -52,27 +52,8 @@ class Picker {
             Debug.deprecated('pc.Picker now takes pc.AppBase as first argument. Passing pc.GraphicsDevice is deprecated.');
         }
 
-        this.app = app;
+        this.renderer = app.renderer;
         this.device = app.graphicsDevice;
-
-        // uniform for the mesh index encoded into rgba
-        this.pickColor = new Float32Array(4);
-        this.pickColor[3] = 1;
-
-        // mapping table from ids to meshInstances
-        this.mapping = [];
-
-        // create layer composition with the layer and camera
-        this.cameraEntity = null;
-        this.layer = null;
-        this.layerComp = null;
-        this.initLayerComposition();
-
-        // clear command user to simulate layer clearing, required due to storing meshes from multiple layers on a singe layer
-        const device = this.device;
-        this.clearDepthCommand = new Command(0, 0, function () {
-            device.clear(clearDepthOptions);
-        });
 
         this.width = 0;
         this.height = 0;
@@ -100,7 +81,7 @@ class Picker {
         const device = this.device;
 
         if (typeof x === 'object') {
-            Debug.deprecated('Picker.getSelection:param \'rect\' is deprecated, use \'x, y, width, height\' instead.');
+            Debug.deprecated(`Picker.getSelection:param 'rect' is deprecated, use 'x, y, width, height' instead.`);
 
             const rect = x;
             x = rect.x;
@@ -117,12 +98,7 @@ class Picker {
         width = Math.floor(Math.max(width || 1, 1));
         height = Math.floor(Math.max(height || 1, 1));
 
-        // backup active render target
-        const origRenderTarget = device.renderTarget;
-
-        DebugGraphics.pushGpuMarker(device, 'PICKER');
-
-        // Ready the device for rendering to the pick buffer
+        // read pixels from the render target
         device.setRenderTarget(this.renderTarget);
         device.updateBegin();
 
@@ -131,21 +107,17 @@ class Picker {
 
         device.updateEnd();
 
-        // Restore render target
-        device.setRenderTarget(origRenderTarget);
-
-        DebugGraphics.popGpuMarker(device);
-
         const mapping = this.mapping;
         for (let i = 0; i < width * height; i++) {
             const r = pixels[4 * i + 0];
             const g = pixels[4 * i + 1];
             const b = pixels[4 * i + 2];
-            const index = r << 16 | g << 8 | b;
+            const a = pixels[4 * i + 3];
+            const index = a << 24 | r << 16 | g << 8 | b;
 
             // White is 'no selection'
-            if (index !== 0xffffff) {
-                tempSet.add(mapping[index]);
+            if (index !== 0xffffffff) {
+                tempSet.add(mapping.get(index));
             }
         }
 
@@ -178,50 +150,11 @@ class Picker {
     }
 
     releaseRenderTarget() {
-
-        // unset it from the camera
-        this.cameraEntity.camera.renderTarget = null;
-
         if (this.renderTarget) {
             this.renderTarget.destroyTextureBuffers();
             this.renderTarget.destroy();
             this.renderTarget = null;
         }
-    }
-
-    initLayerComposition() {
-
-        const device = this.device;
-        const self = this;
-        const pickColorId = device.scope.resolve('uColor');
-
-        // camera
-        this.cameraEntity = new Entity();
-        this.cameraEntity.addComponent('camera');
-
-        // layer all meshes rendered for picking at added to
-        this.layer = new Layer({
-            name: 'Picker',
-            shaderPass: SHADER_PICK,
-            opaqueSortMode: SORTMODE_NONE,
-
-            // executes just before the mesh is rendered. And index encoded in rgb is assigned to it
-            onDrawCall: function (meshInstance, index) {
-                self.pickColor[0] = ((index >> 16) & 0xff) / 255;
-                self.pickColor[1] = ((index >> 8) & 0xff) / 255;
-                self.pickColor[2] = (index & 0xff) / 255;
-                pickColorId.setValue(self.pickColor);
-                device.setBlendState(BlendState.NOBLEND);
-
-                // keep the index -> meshInstance index mapping
-                self.mapping[index] = meshInstance;
-            }
-        });
-        this.layer.addCamera(this.cameraEntity.camera);
-
-        // composition
-        this.layerComp = new LayerComposition('picker');
-        this.layerComp.pushOpaque(this.layer);
     }
 
     /**
@@ -250,99 +183,91 @@ class Picker {
             layers = [layers];
         }
 
-        // populate the layer with meshes and depth clear commands
-        this.layer.clearMeshInstances();
-        const destMeshInstances = this.layer.meshInstances;
-
-        // source mesh instances
-        const srcLayers = scene.layers.layerList;
-        const subLayerEnabled = scene.layers.subLayerEnabled;
-        const isTransparent = scene.layers.subLayerList;
-
-        for (let i = 0; i < srcLayers.length; i++) {
-            const srcLayer = srcLayers[i];
-
-            // skip the layer if it does not match the provided ones
-            if (layers && layers.indexOf(srcLayer) < 0) {
-                continue;
-            }
-
-            if (srcLayer.enabled && subLayerEnabled[i]) {
-
-                // if the layer is rendered by the camera
-                const layerCamId = srcLayer.cameras.indexOf(camera);
-                if (layerCamId >= 0) {
-
-                    // if the layer clears the depth, add command to clear it
-                    if (srcLayer._clearDepthBuffer) {
-                        destMeshInstances.push(this.clearDepthCommand);
-                    }
-
-                    // copy all pickable mesh instances
-                    const transparent = isTransparent[i];
-                    const meshInstances = srcLayer.meshInstances;
-                    for (let j = 0; j < meshInstances.length; j++) {
-                        const meshInstance = meshInstances[j];
-                        if (meshInstance.pick && meshInstance.transparent === transparent) {
-
-                            // as we only render opaque meshes on our internal meshes, mark this mesh as opaque
-                            if (meshInstance.transparent) {
-                                meshInstance.transparent = false;
-                                tempSet.add(meshInstance);
-                            }
-
-                            destMeshInstances.push(meshInstance);
-                        }
-                    }
-                }
-            }
-        }
-
         // make the render target the right size
         if (!this.renderTarget || (this.width !== this.renderTarget.width || this.height !== this.renderTarget.height)) {
             this.releaseRenderTarget();
             this.allocateRenderTarget();
         }
 
-        // prepare the rendering camera
-        this.updateCamera(camera);
-
         // clear registered meshes mapping
-        this.mapping.length = 0;
+        this.mapping.clear();
 
-        // render
-        this.app.renderComposition(this.layerComp);
+        // create a render pass
+        const device = this.device;
+        const renderPass = new RenderPass(device, () => {
 
-        // mark all meshes as transparent again
-        tempSet.forEach((meshInstance) => {
-            meshInstance.transparent = true;
+            DebugGraphics.pushGpuMarker(device, 'PICKER');
+
+            const renderer = this.renderer;
+            const srcLayers = scene.layers.layerList;
+            const subLayerEnabled = scene.layers.subLayerEnabled;
+            const isTransparent = scene.layers.subLayerList;
+
+            const pickColorId = device.scope.resolve('uColor');
+            const pickColor = this.pickColor;
+
+            for (let i = 0; i < srcLayers.length; i++) {
+                const srcLayer = srcLayers[i];
+
+                // skip the layer if it does not match the provided ones
+                if (layers && layers.indexOf(srcLayer) < 0) {
+                    continue;
+                }
+
+                if (srcLayer.enabled && subLayerEnabled[i]) {
+
+                    // if the layer is rendered by the camera
+                    const layerCamId = srcLayer.cameras.indexOf(camera);
+                    if (layerCamId >= 0) {
+
+                        // if the layer clears the depth
+                        if (srcLayer._clearDepthBuffer) {
+                            renderer.clear(camera.camera, false, true, false);
+                        }
+
+                        const culledInstances = srcLayer.getCulledInstances(camera.camera);
+                        const meshInstances = isTransparent[i] ? culledInstances.transparent : culledInstances.opaque;
+
+                        // only need mesh instances with a pick flag
+                        for (let j = 0; j < meshInstances.length; j++) {
+                            const meshInstance = meshInstances[j];
+                            if (meshInstance.pick) {
+                                tempMeshInstances.push(meshInstance);
+
+                                // keep the index -> meshInstance index mapping
+                                this.mapping.set(meshInstance.id, meshInstance);
+                            }
+                        }
+
+                        const lights = [[], [], []];
+                        renderer.renderForward(camera.camera, tempMeshInstances, lights, SHADER_PICK, (meshInstance) => {
+                            const miId = meshInstance.id;
+                            pickColor[0] = ((miId >> 16) & 0xff) / 255;
+                            pickColor[1] = ((miId >> 8) & 0xff) / 255;
+                            pickColor[2] = (miId & 0xff) / 255;
+                            pickColor[3] = ((miId >> 24) & 0xff) / 255;
+                            pickColorId.setValue(pickColor);
+                            device.setBlendState(BlendState.NOBLEND);
+                        });
+
+                        tempMeshInstances.length = 0;
+                    }
+                }
+            }
+
+            DebugGraphics.popGpuMarker(device);
         });
-        tempSet.clear();
-    }
 
-    updateCamera(srcCamera) {
-
-        // copy transform
-        this.cameraEntity.copy(srcCamera.entity);
-        this.cameraEntity.name = 'PickerCamera';
-
-        // copy camera component properties - which overwrites few properties we change to what is needed later
-        const destCamera = this.cameraEntity.camera;
-        destCamera.copy(srcCamera);
+        DebugHelper.setName(renderPass, `RenderPass-Picker`);
+        renderPass.init(this.renderTarget);
 
         // set up clears
-        destCamera.clearColorBuffer = true;
-        destCamera.clearDepthBuffer = true;
-        destCamera.clearStencilBuffer = true;
-        destCamera.clearColor = Color.WHITE;
+        renderPass.colorOps.clearValue = Color.WHITE;
+        renderPass.colorOps.clear = true;
+        renderPass.depthStencilOps.clearDepth = true;
 
-        // render target
-        destCamera.renderTarget = this.renderTarget;
-
-        // layers
-        this.layer.clearCameras();
-        this.layer.addCamera(destCamera);
-        destCamera.layers = [this.layer.id];
+        // render the pass to update the render target
+        renderPass.render();
     }
 
     /**

--- a/src/index.js
+++ b/src/index.js
@@ -122,7 +122,7 @@ export { LightingParams } from './scene/lighting/lighting-params.js';
 export { LitShaderOptions } from './scene/shader-lib/programs/lit-shader-options.js';
 export { Material } from './scene/materials/material.js';
 export { Mesh } from './scene/mesh.js';
-export { MeshInstance, Command } from './scene/mesh-instance.js';
+export { MeshInstance } from './scene/mesh-instance.js';
 export { Model } from './scene/model.js';
 export { Morph } from './scene/morph.js';
 export { MorphInstance } from './scene/morph-instance.js';

--- a/src/scene/layer.js
+++ b/src/scene/layer.js
@@ -869,7 +869,6 @@ class Layer {
     _calculateSortDistances(drawCalls, drawCallsCount, camPos, camFwd) {
         for (let i = 0; i < drawCallsCount; i++) {
             const drawCall = drawCalls[i];
-            if (drawCall.command) continue;
             if (drawCall.layer <= LAYER_FX) continue; // Only alpha sort mesh instances in the main world (backwards comp)
             if (drawCall.calculateSortDistance) {
                 drawCall.zdist = drawCall.calculateSortDistance(drawCall, camPos, camFwd);

--- a/src/scene/mesh-instance.js
+++ b/src/scene/mesh-instance.js
@@ -21,6 +21,7 @@ import { GraphNode } from './graph-node.js';
 import { getDefaultMaterial } from './materials/default-material.js';
 import { LightmapCache } from './graphics/lightmap-cache.js';
 
+let id = 0;
 const _tmpAabb = new BoundingBox();
 const _tempBoneAabb = new BoundingBox();
 const _tempSphere = new BoundingSphere();
@@ -40,22 +41,6 @@ class InstancingData {
      */
     constructor(numObjects) {
         this.count = numObjects;
-    }
-}
-
-class Command {
-    constructor(layer, blendType, command) {
-        this._key = [];
-        this._key[SORTKEY_FORWARD] = getKey(layer, blendType, true, 0);
-        this.command = command;
-    }
-
-    set key(val) {
-        this._key[SORTKEY_FORWARD] = val;
-    }
-
-    get key() {
-        return this._key[SORTKEY_FORWARD];
     }
 }
 
@@ -194,8 +179,20 @@ class MeshInstance {
      * value stores all shaders and bind groups for the shader pass for various light combinations.
      *
      * @type {Array<ShaderCacheEntry|null>}
+     * @private
      */
     _shaderCache = [];
+
+    /** @ignore */
+    id = id++;
+
+    /**
+     * True if the mesh instance is pickable by the {@link Picker}. Defaults to true.
+     *
+     * @type {boolean}
+     * @ignore
+     */
+    pick = true;
 
     /**
      * Create a new MeshInstance instance.
@@ -263,14 +260,6 @@ class MeshInstance {
          * @type {boolean}
          */
         this.cull = true;
-
-        /**
-         * True if the mesh instance is pickable by the {@link Picker}. Defaults to true.
-         *
-         * @type {boolean}
-         * @ignore
-         */
-        this.pick = true;
 
         this._updateAabb = true;
         this._updateAabbFunc = null;
@@ -775,11 +764,36 @@ class MeshInstance {
         return false;
     }
 
+    _getKey(layer, blendType, isCommand, materialId) {
+        // Key definition:
+        // Bit
+        // 31      : sign bit (leave)
+        // 27 - 30 : layer
+        // 26      : translucency type (opaque/transparent)
+        // 25      : unused
+        // 0 - 24  : Material ID (if opaque) or 0 (if transparent - will be depth)
+        return ((layer & 0x0f) << 27) |
+               ((blendType === BLEND_NONE ? 1 : 0) << 26) |
+               ((materialId & 0x1ffffff) << 0);
+    }
+
     updateKey() {
+
+        // render alphatest/atoc after opaque
         const material = this.material;
-        this._key[SORTKEY_FORWARD] = getKey(this.layer,
-                                            (material.alphaToCoverage || material.alphaTest) ? BLEND_NORMAL : material.blendType, // render alphatest/atoc after opaque
-                                            false, material.id);
+        const blendType = (material.alphaToCoverage || material.alphaTest) ? BLEND_NORMAL : material.blendType;
+
+        // Key definition:
+        // Bit
+        // 31      : sign bit (leave)
+        // 27 - 30 : layer
+        // 26      : translucency type (opaque/transparent)
+        // 25      : unused
+        // 0 - 24  : Material ID (if opaque) or 0 (if transparent - will be depth)
+        this._key[SORTKEY_FORWARD] =
+            ((this.layer & 0x0f) << 27) |
+            ((blendType === BLEND_NONE ? 1 : 0) << 26) |
+            ((material.id & 0x1ffffff) << 0);
     }
 
     /**
@@ -957,18 +971,4 @@ class MeshInstance {
     }
 }
 
-function getKey(layer, blendType, isCommand, materialId) {
-    // Key definition:
-    // Bit
-    // 31      : sign bit (leave)
-    // 27 - 30 : layer
-    // 26      : translucency type (opaque/transparent)
-    // 25      : Command bit (1: this key is for a command, 0: it's a mesh instance)
-    // 0 - 24  : Material ID (if opaque) or 0 (if transparent - will be depth)
-    return ((layer & 0x0f) << 27) |
-           ((blendType === BLEND_NONE ? 1 : 0) << 26) |
-           ((isCommand ? 1 : 0) << 25) |
-           ((materialId & 0x1ffffff) << 0);
-}
-
-export { Command, MeshInstance };
+export { MeshInstance };

--- a/src/scene/mesh-instance.js
+++ b/src/scene/mesh-instance.js
@@ -764,19 +764,6 @@ class MeshInstance {
         return false;
     }
 
-    _getKey(layer, blendType, isCommand, materialId) {
-        // Key definition:
-        // Bit
-        // 31      : sign bit (leave)
-        // 27 - 30 : layer
-        // 26      : translucency type (opaque/transparent)
-        // 25      : unused
-        // 0 - 24  : Material ID (if opaque) or 0 (if transparent - will be depth)
-        return ((layer & 0x0f) << 27) |
-               ((blendType === BLEND_NONE ? 1 : 0) << 26) |
-               ((materialId & 0x1ffffff) << 0);
-    }
-
     updateKey() {
 
         // render alphatest/atoc after opaque

--- a/src/scene/renderer/renderer.js
+++ b/src/scene/renderer/renderer.js
@@ -859,14 +859,7 @@ class Renderer {
 
         for (let i = 0; i < count; i++) {
             const drawCall = drawCalls[i];
-            if (drawCall.command) {
-
-                // commands are always visible in both opaque and transparent buckets
-                drawCall.visibleThisFrame = true;
-                opaque.push(drawCall);
-                transparent.push(drawCall);
-
-            } else if (drawCall.visible) {
+            if (drawCall.visible) {
 
                 const visible = !doCull || drawCall._isVisible(camera);
                 if (visible) {


### PR DESCRIPTION
- Picked no longer uses custom LayerComposition with a Layer which gets mesh instances added to, but instead using Rendered and RenderPass to render visible meshes for the camera.
- this also removes Command class, as the only use for it was to clear the depth by the Picker

Note: hide whitespaces when diffing.
