### PR TITLE
[Fix] avoid null/undefined access on iOS when the context is lost

### DIFF
--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -816,16 +816,19 @@ class WebglGraphicsDevice extends GraphicsDevice {
             const fragmentShaderPrecisionHighpFloat = gl.getShaderPrecisionFormat(gl.FRAGMENT_SHADER, gl.HIGH_FLOAT);
             const fragmentShaderPrecisionMediumpFloat = gl.getShaderPrecisionFormat(gl.FRAGMENT_SHADER, gl.MEDIUM_FLOAT);
 
-            const highpAvailable = vertexShaderPrecisionHighpFloat.precision > 0 && fragmentShaderPrecisionHighpFloat.precision > 0;
-            const mediumpAvailable = vertexShaderPrecisionMediumpFloat.precision > 0 && fragmentShaderPrecisionMediumpFloat.precision > 0;
+            if (vertexShaderPrecisionHighpFloat && vertexShaderPrecisionMediumpFloat && fragmentShaderPrecisionHighpFloat && fragmentShaderPrecisionMediumpFloat) {
 
-            if (!highpAvailable) {
-                if (mediumpAvailable) {
-                    precision = "mediump";
-                    Debug.warn("WARNING: highp not supported, using mediump");
-                } else {
-                    precision = "lowp";
-                    Debug.warn("WARNING: highp and mediump not supported, using lowp");
+                const highpAvailable = vertexShaderPrecisionHighpFloat.precision > 0 && fragmentShaderPrecisionHighpFloat.precision > 0;
+                const mediumpAvailable = vertexShaderPrecisionMediumpFloat.precision > 0 && fragmentShaderPrecisionMediumpFloat.precision > 0;
+
+                if (!highpAvailable) {
+                    if (mediumpAvailable) {
+                        precision = "mediump";
+                        Debug.warn("WARNING: highp not supported, using mediump");
+                    } else {
+                        precision = "lowp";
+                        Debug.warn("WARNING: highp and mediump not supported, using lowp");
+                    }
                 }
             }
         }
@@ -1134,7 +1137,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
             target.loseContext();
         }
 
-        this.gpuProfiler.loseContext();
+        this.gpuProfiler?.loseContext();
     }
 
     /**
@@ -1158,7 +1161,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
             buffer.unlock();
         }
 
-        this.gpuProfiler.restoreContext();
+        this.gpuProfiler?.restoreContext();
     }
 
     /**


### PR DESCRIPTION
it seems on iOS we're occasionally getting null from getShaderPrecisionFormat, and also sometimes a newly created device might be lost already, and so try to avoid null / undefined access in those cases.

Two error reports this could help fix:
```
undefined is not an object (evaluating 'this.gpuProfiler.restoreContext')
```
```
TypeError: null is not an object (evaluating 's.precision')
```