### PR TITLE
rollup-shader-chunks.mjs: simplify + fix template string bug

### DIFF
--- a/utils/rollup-shader-chunks.mjs
+++ b/utils/rollup-shader-chunks.mjs
@@ -30,17 +30,15 @@ export function shaderChunks({
         transform(source, shader) {
             if (!enabled || !filter(shader)) return;
 
-            source = source.replace(/\/\* *glsl *\*\/\s*`(.*?)`/gs, function (match, glsl) {
-                return JSON.stringify(
-                    glsl
-                        .trim() // trim whitespace
-                        .replace(/\r/g, '') // Remove carriage returns
-                        .replace(/ {4}/g, '\t') // 4 spaces to tabs
-                        .replace(/[ \t]*\/\/.*\n/g, '') // remove single line comments
-                        .replace(/[ \t]*\/\*[\s\S]*?\*\//g, '') // remove multi line comments
-                        .concat('\n') // ensure final new line
-                        .replace(/\n{2,}/g, '\n') // condense 2 or more empty lines to 1
-                );
+            source = source.replace(/\/\* *glsl *\*\/\s*(`.*?`)/gs, function (match, glsl) {
+                return glsl
+                    .trim() // trim whitespace
+                    .replace(/\r/g, '') // Remove carriage returns
+                    .replace(/ {4}/g, '\t') // 4 spaces to tabs
+                    .replace(/[ \t]*\/\/.*\n/g, '') // remove single line comments
+                    .replace(/[ \t]*\/\*[\s\S]*?\*\//g, '') // remove multi line comments
+                    .concat('\n') // ensure final new line
+                    .replace(/\n{2,}/g, '\n'); // condense 2 or more empty lines to 1
             });
 
             return {


### PR DESCRIPTION
Fixes bug indirectly introduced via https://github.com/playcanvas/engine/pull/5602 (it wasn't a bug before because the filter was broken :sweat_smile: ):

![image](https://github.com/playcanvas/engine/assets/5236548/dccb3106-4185-4b9f-9944-33c27ef135a5)

The reasoning is quite simple, we used `JSON.stringify` to add `"` around the string, but that renders every occurance of `${...}` useless afterwards (hence they landed in the build folder like `" ... ${decode} ..."`.

Affects every build target:

![image](https://github.com/playcanvas/engine/assets/5236548/23f96a48-4cfe-4bab-ac73-1f8fd34a5480)

Fixes examples: Paint Mesh + Reflection Box

@epreston If you have time, can you review?

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
