### PR TITLE
Don't drop newline of single line comments

### DIFF
--- a/utils/rollup-shader-chunks.mjs
+++ b/utils/rollup-shader-chunks.mjs
@@ -35,7 +35,7 @@ export function shaderChunks({
                     .trim() // trim whitespace
                     .replace(/\r/g, '') // Remove carriage returns
                     .replace(/ {4}/g, '\t') // 4 spaces to tabs
-                    .replace(/[ \t]*\/\/.*\n/g, '') // remove single line comments
+                    .replace(/[ \t]*\/\/.*/g, '') // remove single line comments
                     .replace(/[ \t]*\/\*[\s\S]*?\*\//g, '') // remove multi line comments
                     .concat('\n') // ensure final new line
                     .replace(/\n{2,}/g, '\n'); // condense 2 or more empty lines to 1


### PR DESCRIPTION
Fixes #5614

Introduced by https://github.com/playcanvas/engine/pull/5602

Sorry @epreston for bringing this PR up again, but it caused another bug because you rewrote the RegExp.

You can't just remove newlines because the internal C-style `Preprocessor` depends on them, e.g.

For example code like this:

```c
#ifndef LINEARIZE_DEPTH
#ifndef CAMERAPLANES
#define CAMERAPLANES
uniform vec4 camera_params; // x: 1 / camera_far,      y: camera_far,     z: camera_near,        w: is_ortho
#endif
```

Turns into:

```c
#ifndef LINEARIZE_DEPTH
#ifndef CAMERAPLANES
#define CAMERAPLANES
uniform vec4 camera_params;#endif
```

Or code like this:

```c
#else // GL2
#ifndef UNPACKFLOAT
```

Turns into:

```c
#else#ifndef UNPACKFLOAT
```

Examples from:

https://github.com/playcanvas/engine/blob/1fcdbd804e23efb5387f9cfe53ba339ae8bb295a/src/scene/shader-lib/chunks/common/frag/screenDepth.js#L16-L37

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
