### PR TITLE
Cubemap on material is ignored

### DIFF
--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -818,6 +818,14 @@ class StandardMaterial extends Material {
 
         const isPhong = this.shadingModel === SPECULAR_PHONG;
 
+        if (this._prefilteredCubemaps && this._prefilteredCubemaps[0]) {
+            const isOtherTexturesNull = this._prefilteredCubemaps.slice(1).every(cubemap => !cubemap);
+
+            if (isOtherTexturesNull) {
+                this.envAtlas = this._prefilteredCubemaps[0];
+            }
+        }
+
         // set overridden environment textures
         if (this.envAtlas && this.cubeMap && !isPhong) {
             this._setParameter('texture_envAtlas', this.envAtlas);
@@ -841,11 +849,13 @@ class StandardMaterial extends Material {
     }
 
     updateEnvUniforms(device, scene) {
+
         const isPhong = this.shadingModel === SPECULAR_PHONG;
         const hasLocalEnvOverride = (this.envAtlas && !isPhong) || this.cubeMap || this.sphereMap;
 
         if (!hasLocalEnvOverride && this.useSkybox) {
             if (scene.envAtlas && scene.skybox && !isPhong) {
+
                 this._setParameter('texture_envAtlas', scene.envAtlas);
                 this._setParameter('texture_cubeMap', scene.skybox);
             } else if (scene.envAtlas && !isPhong) {
@@ -1269,7 +1279,6 @@ function _defineMaterialProps() {
     // prefiltered cubemap setter
     const setterFunc = function (value) {
         const cubemaps = this._prefilteredCubemaps;
-
         value = value || [];
 
         let changed = false;
@@ -1280,9 +1289,9 @@ function _defineMaterialProps() {
                 cubemaps[i] = v;
                 changed = true;
             }
+
             complete = complete && (!!cubemaps[i]);
         }
-
         if (changed) {
             if (complete) {
                 this.envAtlas = EnvLighting.generatePrefilteredAtlas(cubemaps, {


### PR DESCRIPTION
Fixes #

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).

The old style prefiltered cubemap which uses dds for the faces is causing problem on 'restoring webgl context.

https://forum.playcanvas.com/t/what-cause-webgl-context-lost/32886/2?u=sooyong_kim

The suggestion is to switch prefiltered data with the new type that uses 'png'

It works fine with skybox, but it's not working when the cubemap is used by a material.

![image](https://github.com/playcanvas/engine/assets/13344642/0f69319b-b938-4e38-a464-e4b6136e189d)

The new type of prefiltered data only uses a spherical texture. Not like old prefiltered cubemap which passes 6 textures for each x, y, and z, it only passes one texture, the rests are marked as null.


