### PR TITLE
Cubemap with the new prefiltered data is ignored when it's used by a …

### DIFF
--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -818,6 +818,14 @@ class StandardMaterial extends Material {
 
         const isPhong = this.shadingModel === SPECULAR_PHONG;
 
+        if (this._prefilteredCubemaps && this._prefilteredCubemaps[0]) {
+            const isOtherTexturesNull = this._prefilteredCubemaps.slice(1).every(cubemap => !cubemap);
+
+            if (isOtherTexturesNull) {
+                this.envAtlas = this._prefilteredCubemaps[0];
+            }
+        }
+
         // set overridden environment textures
         if (this.envAtlas && this.cubeMap && !isPhong) {
             this._setParameter('texture_envAtlas', this.envAtlas);


### PR DESCRIPTION
…material.

Fixes #

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).

The old style prefiltered cubemap which uses dds for the faces is causing problem on 'restoring webgl context.

https://forum.playcanvas.com/t/what-cause-webgl-context-lost/32886/2?u=sooyong_kim

The suggestion is to switch prefiltered data with the new type that uses 'png'

It works fine with skybox, but it's not working when the cubemap is used by a material.

![image](https://github.com/playcanvas/engine/assets/13344642/cc816fe1-19de-4bec-be46-d4c523df8767)

The new type of prefiltered data only uses a spherical texture. Not like old prefiltered cubemap which passes 6 textures for each x, y, and z, it only passes one texture, the rests are marked as null.