### PR TITLE
Material prefiltered cubemap fix

### DIFF
--- a/src/framework/handlers/cubemap.js
+++ b/src/framework/handlers/cubemap.js
@@ -137,6 +137,9 @@ class CubemapHandler {
                 } else {
                     // prefiltered data is an env atlas
                     tex.type = TEXTURETYPE_RGBP;
+                    tex.addressU = ADDRESS_CLAMP_TO_EDGE;
+                    tex.addressV = ADDRESS_CLAMP_TO_EDGE;
+                    tex.mipmaps = false;
                     resources[1] = tex;
                 }
             }

--- a/src/framework/handlers/material.js
+++ b/src/framework/handlers/material.js
@@ -208,7 +208,12 @@ class MaterialHandler {
 
         // set prefiltered textures
         if (parameterName === 'cubeMap') {
-            materialAsset.resource.prefilteredCubemaps = textures.slice(1);
+            const prefiltered = textures.slice(1);
+            if (prefiltered.every(t => t)) {
+                materialAsset.resource.prefilteredCubemaps = prefiltered;
+            } else if (prefiltered[0]) {
+                materialAsset.resource.envAtlas = prefiltered[0];
+            }
         }
     }
 


### PR DESCRIPTION
Fixes https://forum.playcanvas.com/t/what-cause-webgl-context-lost/32886

There were two issues with material prefiltered cubemap overrides:
- the material loader wasn't handling envAtlas cubemap data correctly - it was incorrectly setting 'prefilteredCubemaps' even when loading an envAtlas
- the cubemap loader wasn't correctly initialisng the envAtlas render states