### PR TITLE
Refactor the internals of antialiasing / backbuffer on WebGL device

### DIFF
--- a/src/framework/xr/xr-manager.js
+++ b/src/framework/xr/xr-manager.js
@@ -630,7 +630,10 @@ class XrManager extends EventHandler {
             alpha: true,
             depth: true,
             stencil: true,
-            framebufferScaleFactor: framebufferScaleFactor
+            framebufferScaleFactor: framebufferScaleFactor,
+
+            // request a single-sampled buffer. We allocate multi-sampled buffer internally and resolve to this buffer.
+            antialias: false
         });
 
         session.updateRenderState({

--- a/src/platform/graphics/graphics-device.js
+++ b/src/platform/graphics/graphics-device.js
@@ -50,7 +50,7 @@ class GraphicsDevice extends EventHandler {
      *
      * @ignore
      */
-    backBufferDimensions = new Vec2();
+    backBufferSize = new Vec2();
 
     /**
      * True if the deviceType is WebGPU

--- a/src/platform/graphics/graphics-device.js
+++ b/src/platform/graphics/graphics-device.js
@@ -2,6 +2,7 @@ import { Debug } from '../../core/debug.js';
 import { EventHandler } from '../../core/event-handler.js';
 import { platform } from '../../core/platform.js';
 import { now } from '../../core/time.js';
+import { Vec2 } from '../../core/math/vec2.js';
 import { Tracing } from '../../core/tracing.js';
 import { TRACEID_TEXTURES } from '../../core/constants.js';
 
@@ -35,6 +36,21 @@ class GraphicsDevice extends EventHandler {
      * @readonly
      */
     canvas;
+
+    /**
+     * The render target representing the main back-buffer.
+     *
+     * @type {import('./render-target.js').RenderTarget|null}
+     * @ignore
+     */
+    backBuffer = null;
+
+    /**
+     * The dimensions of the back buffer.
+     *
+     * @ignore
+     */
+    backBufferDimensions = new Vec2();
 
     /**
      * True if the deviceType is WebGPU

--- a/src/platform/graphics/render-pass.js
+++ b/src/platform/graphics/render-pass.js
@@ -3,7 +3,6 @@ import { Tracing } from '../../core/tracing.js';
 import { Color } from '../../core/math/color.js';
 import { TRACEID_RENDER_PASS, TRACEID_RENDER_PASS_DETAIL } from '../../core/constants.js';
 import { DebugGraphics } from '../graphics/debug-graphics.js';
-import { GraphicsDeviceAccess } from './graphics-device-access.js';
 
 class ColorAttachmentOps {
     /**

--- a/src/platform/graphics/render-pass.js
+++ b/src/platform/graphics/render-pass.js
@@ -3,6 +3,7 @@ import { Tracing } from '../../core/tracing.js';
 import { Color } from '../../core/math/color.js';
 import { TRACEID_RENDER_PASS, TRACEID_RENDER_PASS_DETAIL } from '../../core/constants.js';
 import { DebugGraphics } from '../graphics/debug-graphics.js';
+import { GraphicsDeviceAccess } from './graphics-device-access.js';
 
 class ColorAttachmentOps {
     /**
@@ -284,11 +285,9 @@ class RenderPass {
     log(device, index) {
         if (Tracing.get(TRACEID_RENDER_PASS) || Tracing.get(TRACEID_RENDER_PASS_DETAIL)) {
 
-            let rt = this.renderTarget;
-            if (rt === null && device.isWebGPU) {
-                rt = device.frameBuffer;
-            }
-            const numColor = rt?._colorBuffers?.length ?? (rt?.impl.assignedColorTexture ? 1 : 0);
+            const rt = this.renderTarget === null ? this.renderTarget ?? device.backBuffer : null;
+            const isBackBuffer = !!rt?.impl.assignedColorTexture || rt?.impl.suppliedColorFramebuffer !== undefined;
+            const numColor = rt?._colorBuffers?.length ?? (isBackBuffer ? 1 : 0);
             const hasDepth = rt?.depth;
             const hasStencil = rt?.stencil;
             const rtInfo = rt === undefined ? '' : ` RT: ${(rt ? rt.name : 'NULL')} ` +

--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -272,8 +272,8 @@ class WebglGraphicsDevice extends GraphicsDevice {
 
     /**
      * WebGLFramebuffer object that represents the backbuffer of the device for a rendering frame.
-     * When null, this is a framebuffer created when the device was created (rep), otherwise it is
-     * a framebuffer supplied by the XR session.
+     * When null, this is a framebuffer created when the device was created, otherwise it is a
+     * framebuffer supplied by the XR session.
      *
      * @ignore
      */

--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -1,5 +1,6 @@
 import { setupVertexArrayObject } from '../../../polyfill/OESVertexArrayObject.js';
 import { math } from '../../../core/math/math.js';
+import { Vec2 } from '../../../core/math/vec2.js';
 import { Debug } from '../../../core/debug.js';
 import { platform } from '../../../core/platform.js';
 import { Color } from '../../../core/math/color.js';
@@ -795,8 +796,10 @@ class WebglGraphicsDevice extends GraphicsDevice {
 
     updateBackbuffer() {
 
-        if (this._defaultFramebufferChanged) {
+        const resolutionChanged = this.canvas.width !== this.backBufferDimensions.x || this.canvas.height !== this.backBufferDimensions.y;
+        if (this._defaultFramebufferChanged || resolutionChanged) {
             this._defaultFramebufferChanged = false;
+            this.backBufferDimensions.set(this.canvas.width, this.canvas.height);
 
             // recreate the backbuffer with newly supplied framebuffer
             this.backBuffer.destroy();

--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -1334,7 +1334,9 @@ class WebglGraphicsDevice extends GraphicsDevice {
             this.renderTarget = dest;
             this.updateBegin();
 
-            const src = source ? source.impl._glFrameBuffer : null;
+            // copy from single sampled framebuffer
+            const src = source ? source.impl._glFrameBuffer : this.backBuffer?.impl._glFrameBuffer;
+
             const dst = dest.impl._glFrameBuffer;
             Debug.assert(src !== dst, 'Source and destination framebuffers must be different when blitting.');
 
@@ -1347,9 +1349,6 @@ class WebglGraphicsDevice extends GraphicsDevice {
                                0, 0, w, h,
                                (color ? gl.COLOR_BUFFER_BIT : 0) | (depth ? gl.DEPTH_BUFFER_BIT : 0),
                                gl.NEAREST);
-
-
-
 
             // TODO: not sure we need to restore the prev target, as this only should run in-between render passes
             this.renderTarget = prevRt;

--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -796,10 +796,10 @@ class WebglGraphicsDevice extends GraphicsDevice {
 
     updateBackbuffer() {
 
-        const resolutionChanged = this.canvas.width !== this.backBufferDimensions.x || this.canvas.height !== this.backBufferDimensions.y;
+        const resolutionChanged = this.canvas.width !== this.backBufferSize.x || this.canvas.height !== this.backBufferSize.y;
         if (this._defaultFramebufferChanged || resolutionChanged) {
             this._defaultFramebufferChanged = false;
-            this.backBufferDimensions.set(this.canvas.width, this.canvas.height);
+            this.backBufferSize.set(this.canvas.width, this.canvas.height);
 
             // recreate the backbuffer with newly supplied framebuffer
             this.backBuffer.destroy();

--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -1,6 +1,5 @@
 import { setupVertexArrayObject } from '../../../polyfill/OESVertexArrayObject.js';
 import { math } from '../../../core/math/math.js';
-import { Vec2 } from '../../../core/math/vec2.js';
 import { Debug } from '../../../core/debug.js';
 import { platform } from '../../../core/platform.js';
 import { Color } from '../../../core/math/color.js';

--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -2681,16 +2681,10 @@ class WebglGraphicsDevice extends GraphicsDevice {
         this._height = height;
 
         const ratio = Math.min(this._maxPixelRatio, platform.browser ? window.devicePixelRatio : 1);
-
-        console.log("client sizes: ", width, height, "ratio", ratio);
-
         width = Math.floor(width * ratio);
         height = Math.floor(height * ratio);
 
         if (this.canvas.width !== width || this.canvas.height !== height) {
-
-            console.warn("resizeCanvas", this.canvas.width, this.canvas.height, "=>", width, height, "frame", this.renderVersion);
-            this._defaultFramebufferChanged = true;
 
             this.canvas.width = width;
             this.canvas.height = height;

--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -2675,8 +2675,8 @@ class WebglGraphicsDevice extends GraphicsDevice {
     resizeCanvas(width, height) {
 
         // store the client sizes in CSS pixels, without pixel ratio applied
-        this._height = height;
         this._width = width;
+        this._height = height;
 
         const ratio = Math.min(this._maxPixelRatio, platform.browser ? window.devicePixelRatio : 1);
 

--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -271,6 +271,22 @@ class WebglGraphicsDevice extends GraphicsDevice {
     webgl2;
 
     /**
+     * WebGLFramebuffer object that represents the backbuffer of the device for a rendering frame.
+     * When null, this is a framebuffer created when the device was created (rep), otherwise it is
+     * a framebuffer supplied by the XR session.
+     *
+     * @ignore
+     */
+    _defaultFramebuffer = null;
+
+    /**
+     * True if the default framebuffer has changed since the last frame.
+     *
+     * @ignore
+     */
+    _defaultFramebufferChanged = false;
+
+    /**
      * Creates a new WebglGraphicsDevice instance.
      *
      * @param {HTMLCanvasElement} canvas - The canvas to which the graphics device will render.
@@ -315,8 +331,6 @@ class WebglGraphicsDevice extends GraphicsDevice {
         super(canvas, options);
         options = this.initOptions;
 
-        this.defaultFramebuffer = null;
-
         this.updateClientRect();
 
         // Add handlers for when the WebGL context is lost or restored
@@ -346,6 +360,10 @@ class WebglGraphicsDevice extends GraphicsDevice {
         }
 
         let gl = null;
+
+        // we always allocate the default framebuffer without antialiasing, so remove that option
+        const antialias = options.antialias;
+        options.antialias = false;
 
         // Retrieve the WebGL context
         if (options.gl) {
@@ -395,6 +413,10 @@ class WebglGraphicsDevice extends GraphicsDevice {
         this.initializeCapabilities();
         this.initializeRenderState();
         this.initializeContextCaches();
+
+        // handle anti-aliasing internally
+        this.samples = antialias ? 4 : 1;
+        this.createBackbuffer(null);
 
         // only enable ImageBitmap on chrome
         this.supportsImageBitmap = !isSafari && typeof ImageBitmap !== 'undefined';
@@ -754,6 +776,32 @@ class WebglGraphicsDevice extends GraphicsDevice {
         this.gl = null;
 
         super.postDestroy();
+    }
+
+    createBackbuffer(frameBuffer) {
+        this.supportsStencil = this.initOptions.stencil;
+
+        this.backBuffer = new RenderTarget({
+            name: 'WebglFramebuffer',
+            graphicsDevice: this,
+            depth: this.initOptions.depth,
+            stencil: this.supportsStencil,
+            samples: this.samples
+        });
+
+        // use the default WebGL framebuffer for rendering
+        this.backBuffer.impl.suppliedColorFramebuffer = frameBuffer;
+    }
+
+    updateBackbuffer() {
+
+        if (this._defaultFramebufferChanged) {
+            this._defaultFramebufferChanged = false;
+
+            // recreate the backbuffer with newly supplied framebuffer
+            this.backBuffer.destroy();
+            this.createBackbuffer(this._defaultFramebuffer);
+        }
     }
 
     // provide webgl implementation for the vertex buffer
@@ -1235,6 +1283,11 @@ class WebglGraphicsDevice extends GraphicsDevice {
     copyRenderTarget(source, dest, color, depth) {
         const gl = this.gl;
 
+        // if copying from the backbuffer
+        if (source === this.backBuffer) {
+            source = null;
+        }
+
         if (!this.webgl2 && depth) {
             Debug.error("Depth is not copyable on WebGL 1.0");
             return false;
@@ -1277,14 +1330,25 @@ class WebglGraphicsDevice extends GraphicsDevice {
             const prevRt = this.renderTarget;
             this.renderTarget = dest;
             this.updateBegin();
-            gl.bindFramebuffer(gl.READ_FRAMEBUFFER, source ? source.impl._glFrameBuffer : null);
-            gl.bindFramebuffer(gl.DRAW_FRAMEBUFFER, dest.impl._glFrameBuffer);
+
+            const src = source ? source.impl._glFrameBuffer : null;
+            const dst = dest.impl._glFrameBuffer;
+            Debug.assert(src !== dst, 'Source and destination framebuffers must be different when blitting.');
+
+            gl.bindFramebuffer(gl.READ_FRAMEBUFFER, src);
+            gl.bindFramebuffer(gl.DRAW_FRAMEBUFFER, dst);
             const w = source ? source.width : dest.width;
             const h = source ? source.height : dest.height;
+
             gl.blitFramebuffer(0, 0, w, h,
                                0, 0, w, h,
                                (color ? gl.COLOR_BUFFER_BIT : 0) | (depth ? gl.DEPTH_BUFFER_BIT : 0),
                                gl.NEAREST);
+
+
+
+
+            // TODO: not sure we need to restore the prev target, as this only should run in-between render passes
             this.renderTarget = prevRt;
             gl.bindFramebuffer(gl.FRAMEBUFFER, prevRt ? prevRt.impl._glFrameBuffer : null);
         } else {
@@ -1318,6 +1382,9 @@ class WebglGraphicsDevice extends GraphicsDevice {
 
     frameStart() {
         super.frameStart();
+
+        this.updateBackbuffer();
+
         this.gpuProfiler.frameStart();
     }
 
@@ -1338,7 +1405,10 @@ class WebglGraphicsDevice extends GraphicsDevice {
         DebugGraphics.pushGpuMarker(this, `START-PASS`);
 
         // set up render target
-        this.setRenderTarget(renderPass.renderTarget);
+        const rt = renderPass.renderTarget || this.backBuffer;
+        this.renderTarget = rt;
+        Debug.assert(rt);
+
         this.updateBegin();
 
         // clear the render target
@@ -1465,6 +1535,17 @@ class WebglGraphicsDevice extends GraphicsDevice {
         DebugGraphics.popGpuMarker(this);
     }
 
+    set defaultFramebuffer(value) {
+        if (this._defaultFramebuffer !== value) {
+            this._defaultFramebuffer = value;
+            this._defaultFramebufferChanged = true;
+        }
+    }
+
+    get defaultFramebuffer() {
+        return this._defaultFramebuffer;
+    }
+
     /**
      * Marks the beginning of a block of rendering. Internally, this function binds the render
      * target currently set on the device. This function should be matched with a call to
@@ -1497,7 +1578,8 @@ class WebglGraphicsDevice extends GraphicsDevice {
                 this.setFramebuffer(target.impl._glFrameBuffer);
             }
         } else {
-            this.setFramebuffer(this.defaultFramebuffer);
+            // rendering to the default WebGL frame buffer
+            this.setFramebuffer(null);
         }
 
         DebugGraphics.popGpuMarker(this);
@@ -1518,7 +1600,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
 
         // Unset the render target
         const target = this.renderTarget;
-        if (target) {
+        if (target && target !== this.backBuffer) {
             // Resolve MSAA if needed
             if (this.webgl2 && target._samples > 1 && target.autoResolve) {
                 target.resolve();
@@ -2589,16 +2671,25 @@ class WebglGraphicsDevice extends GraphicsDevice {
 
     resizeCanvas(width, height) {
 
-        this._width = width;
+        // store the client sizes in CSS pixels, without pixel ratio applied
         this._height = height;
+        this._width = width;
 
         const ratio = Math.min(this._maxPixelRatio, platform.browser ? window.devicePixelRatio : 1);
+
+        console.log("client sizes: ", width, height, "ratio", ratio);
+
         width = Math.floor(width * ratio);
         height = Math.floor(height * ratio);
 
         if (this.canvas.width !== width || this.canvas.height !== height) {
+
+            console.warn("resizeCanvas", this.canvas.width, this.canvas.height, "=>", width, height, "frame", this.renderVersion);
+            this._defaultFramebufferChanged = true;
+
             this.canvas.width = width;
             this.canvas.height = height;
+
             this.fire(GraphicsDevice.EVENT_RESIZE, width, height);
         }
     }

--- a/src/platform/graphics/webgl/webgl-render-target.js
+++ b/src/platform/graphics/webgl/webgl-render-target.js
@@ -1,4 +1,5 @@
 import { Debug } from "../../../core/debug.js";
+import { PIXELFORMAT_RGBA8 } from "../constants.js";
 import { DebugGraphics } from "../debug-graphics.js";
 
 /**
@@ -55,8 +56,19 @@ class WebglRenderTarget {
 
     _glMsaaDepthBuffer = null;
 
+    /**
+     * The supplied single-sampled framebuffer for rendering. Undefined represents no supplied
+     * framebuffer. Null represents the default framebuffer. A value represents a user-supplied
+     * framebuffer.
+     */
+    suppliedColorFramebuffer = undefined;
+
+    _isInitialized = false;
+
     destroy(device) {
         const gl = device.gl;
+        this._isInitialized = false;
+
         if (this._glFrameBuffer) {
             gl.deleteFramebuffer(this._glFrameBuffer);
             this._glFrameBuffer = null;
@@ -89,87 +101,96 @@ class WebglRenderTarget {
     }
 
     get initialized() {
-        return this._glFrameBuffer !== null;
+        return this._isInitialized;
     }
 
     init(device, target) {
         const gl = device.gl;
 
-        // ##### Create main FBO #####
-        this._glFrameBuffer = gl.createFramebuffer();
-        device.setFramebuffer(this._glFrameBuffer);
-
-        // --- Init the provided color buffer (optional) ---
-        const colorBufferCount = target._colorBuffers?.length ?? 0;
-        const attachmentBaseConstant = device.webgl2 ? gl.COLOR_ATTACHMENT0 : (device.extDrawBuffers?.COLOR_ATTACHMENT0_WEBGL ?? gl.COLOR_ATTACHMENT0);
+        this._isInitialized = true;
         const buffers = [];
-        for (let i = 0; i < colorBufferCount; ++i) {
-            const colorBuffer = target.getColorBuffer(i);
-            if (colorBuffer) {
-                if (!colorBuffer.impl._glTexture) {
+
+        if (this.suppliedColorFramebuffer !== undefined) {
+
+            this._glFrameBuffer = this.suppliedColorFramebuffer;
+
+        } else {
+
+            // ##### Create main FBO #####
+            this._glFrameBuffer = gl.createFramebuffer();
+            device.setFramebuffer(this._glFrameBuffer);
+
+            // --- Init the provided color buffer (optional) ---
+            const colorBufferCount = target._colorBuffers?.length ?? 0;
+            const attachmentBaseConstant = device.webgl2 ? gl.COLOR_ATTACHMENT0 : (device.extDrawBuffers?.COLOR_ATTACHMENT0_WEBGL ?? gl.COLOR_ATTACHMENT0);
+            for (let i = 0; i < colorBufferCount; ++i) {
+                const colorBuffer = target.getColorBuffer(i);
+                if (colorBuffer) {
+                    if (!colorBuffer.impl._glTexture) {
+                        // Clamp the render buffer size to the maximum supported by the device
+                        colorBuffer._width = Math.min(colorBuffer.width, device.maxRenderBufferSize);
+                        colorBuffer._height = Math.min(colorBuffer.height, device.maxRenderBufferSize);
+                        device.setTexture(colorBuffer, 0);
+                    }
+                    // Attach the color buffer
+                    gl.framebufferTexture2D(
+                        gl.FRAMEBUFFER,
+                        attachmentBaseConstant + i,
+                        colorBuffer._cubemap ? gl.TEXTURE_CUBE_MAP_POSITIVE_X + target._face : gl.TEXTURE_2D,
+                        colorBuffer.impl._glTexture,
+                        0
+                    );
+
+                    buffers.push(attachmentBaseConstant + i);
+                }
+            }
+
+            if (device.drawBuffers) {
+                device.drawBuffers(buffers);
+            }
+
+            const depthBuffer = target._depthBuffer;
+            if (depthBuffer) {
+                // --- Init the provided depth/stencil buffer (optional, WebGL2 only) ---
+                if (!depthBuffer.impl._glTexture) {
                     // Clamp the render buffer size to the maximum supported by the device
-                    colorBuffer._width = Math.min(colorBuffer.width, device.maxRenderBufferSize);
-                    colorBuffer._height = Math.min(colorBuffer.height, device.maxRenderBufferSize);
-                    device.setTexture(colorBuffer, 0);
+                    depthBuffer._width = Math.min(depthBuffer.width, device.maxRenderBufferSize);
+                    depthBuffer._height = Math.min(depthBuffer.height, device.maxRenderBufferSize);
+                    device.setTexture(depthBuffer, 0);
                 }
-                // Attach the color buffer
-                gl.framebufferTexture2D(
-                    gl.FRAMEBUFFER,
-                    attachmentBaseConstant + i,
-                    colorBuffer._cubemap ? gl.TEXTURE_CUBE_MAP_POSITIVE_X + target._face : gl.TEXTURE_2D,
-                    colorBuffer.impl._glTexture,
-                    0
-                );
-
-                buffers.push(attachmentBaseConstant + i);
-            }
-        }
-
-        if (device.drawBuffers) {
-            device.drawBuffers(buffers);
-        }
-
-        const depthBuffer = target._depthBuffer;
-        if (depthBuffer) {
-            // --- Init the provided depth/stencil buffer (optional, WebGL2 only) ---
-            if (!depthBuffer.impl._glTexture) {
-                // Clamp the render buffer size to the maximum supported by the device
-                depthBuffer._width = Math.min(depthBuffer.width, device.maxRenderBufferSize);
-                depthBuffer._height = Math.min(depthBuffer.height, device.maxRenderBufferSize);
-                device.setTexture(depthBuffer, 0);
-            }
-            // Attach
-            if (target._stencil) {
-                gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.DEPTH_STENCIL_ATTACHMENT,
-                                        depthBuffer._cubemap ? gl.TEXTURE_CUBE_MAP_POSITIVE_X + target._face : gl.TEXTURE_2D,
-                                        target._depthBuffer.impl._glTexture, 0);
-            } else {
-                gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT,
-                                        depthBuffer._cubemap ? gl.TEXTURE_CUBE_MAP_POSITIVE_X + target._face : gl.TEXTURE_2D,
-                                        target._depthBuffer.impl._glTexture, 0);
-            }
-        } else if (target._depth) {
-            // --- Init a new depth/stencil buffer (optional) ---
-            // if device is a MSAA RT, and no buffer to resolve to, skip creating non-MSAA depth
-            const willRenderMsaa = target._samples > 1 && device.webgl2;
-            if (!willRenderMsaa) {
-                if (!this._glDepthBuffer) {
-                    this._glDepthBuffer = gl.createRenderbuffer();
-                }
-                gl.bindRenderbuffer(gl.RENDERBUFFER, this._glDepthBuffer);
+                // Attach
                 if (target._stencil) {
-                    gl.renderbufferStorage(gl.RENDERBUFFER, gl.DEPTH_STENCIL, target.width, target.height);
-                    gl.framebufferRenderbuffer(gl.FRAMEBUFFER, gl.DEPTH_STENCIL_ATTACHMENT, gl.RENDERBUFFER, this._glDepthBuffer);
+                    gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.DEPTH_STENCIL_ATTACHMENT,
+                                            depthBuffer._cubemap ? gl.TEXTURE_CUBE_MAP_POSITIVE_X + target._face : gl.TEXTURE_2D,
+                                            target._depthBuffer.impl._glTexture, 0);
                 } else {
-                    const depthFormat = device.webgl2 ? gl.DEPTH_COMPONENT32F : gl.DEPTH_COMPONENT16;
-                    gl.renderbufferStorage(gl.RENDERBUFFER, depthFormat, target.width, target.height);
-                    gl.framebufferRenderbuffer(gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT, gl.RENDERBUFFER, this._glDepthBuffer);
+                    gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT,
+                                            depthBuffer._cubemap ? gl.TEXTURE_CUBE_MAP_POSITIVE_X + target._face : gl.TEXTURE_2D,
+                                            target._depthBuffer.impl._glTexture, 0);
                 }
-                gl.bindRenderbuffer(gl.RENDERBUFFER, null);
+            } else if (target._depth) {
+                // --- Init a new depth/stencil buffer (optional) ---
+                // if device is a MSAA RT, and no buffer to resolve to, skip creating non-MSAA depth
+                const willRenderMsaa = target._samples > 1 && device.webgl2;
+                if (!willRenderMsaa) {
+                    if (!this._glDepthBuffer) {
+                        this._glDepthBuffer = gl.createRenderbuffer();
+                    }
+                    gl.bindRenderbuffer(gl.RENDERBUFFER, this._glDepthBuffer);
+                    if (target._stencil) {
+                        gl.renderbufferStorage(gl.RENDERBUFFER, gl.DEPTH_STENCIL, target.width, target.height);
+                        gl.framebufferRenderbuffer(gl.FRAMEBUFFER, gl.DEPTH_STENCIL_ATTACHMENT, gl.RENDERBUFFER, this._glDepthBuffer);
+                    } else {
+                        const depthFormat = device.webgl2 ? gl.DEPTH_COMPONENT32F : gl.DEPTH_COMPONENT16;
+                        gl.renderbufferStorage(gl.RENDERBUFFER, depthFormat, target.width, target.height);
+                        gl.framebufferRenderbuffer(gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT, gl.RENDERBUFFER, this._glDepthBuffer);
+                    }
+                    gl.bindRenderbuffer(gl.RENDERBUFFER, null);
+                }
             }
-        }
 
-        Debug.call(() => this._checkFbo(device, target));
+            Debug.call(() => this._checkFbo(device, target));
+        }
 
         // ##### Create MSAA FBO (WebGL2 only) #####
         if (device.webgl2 && target._samples > 1) {
@@ -182,17 +203,31 @@ class WebglRenderTarget {
             device.setFramebuffer(this._glFrameBuffer);
 
             // Create an optional MSAA color buffers
-
             const colorBufferCount = target._colorBuffers?.length ?? 0;
-            for (let i = 0; i < colorBufferCount; ++i) {
-                const colorBuffer = target.getColorBuffer(i);
-                if (colorBuffer) {
-                    const buffer = gl.createRenderbuffer();
-                    this._glMsaaColorBuffers.push(buffer);
 
-                    gl.bindRenderbuffer(gl.RENDERBUFFER, buffer);
-                    gl.renderbufferStorageMultisample(gl.RENDERBUFFER, target._samples, colorBuffer.impl._glInternalFormat, target.width, target.height);
-                    gl.framebufferRenderbuffer(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0 + i, gl.RENDERBUFFER, buffer);
+            if (this.suppliedColorFramebuffer !== undefined) {
+
+                const buffer = gl.createRenderbuffer();
+                this._glMsaaColorBuffers.push(buffer);
+
+                const internalFormat = device.framebufferFormat === PIXELFORMAT_RGBA8 ? gl.RGBA8 : gl.RGB8;
+
+                gl.bindRenderbuffer(gl.RENDERBUFFER, buffer);
+                gl.renderbufferStorageMultisample(gl.RENDERBUFFER, target._samples, internalFormat, target.width, target.height);
+                gl.framebufferRenderbuffer(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.RENDERBUFFER, buffer);
+
+            } else {
+
+                for (let i = 0; i < colorBufferCount; ++i) {
+                    const colorBuffer = target.getColorBuffer(i);
+                    if (colorBuffer) {
+                        const buffer = gl.createRenderbuffer();
+                        this._glMsaaColorBuffers.push(buffer);
+
+                        gl.bindRenderbuffer(gl.RENDERBUFFER, buffer);
+                        gl.renderbufferStorageMultisample(gl.RENDERBUFFER, target._samples, colorBuffer.impl._glInternalFormat, target.width, target.height);
+                        gl.framebufferRenderbuffer(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0 + i, gl.RENDERBUFFER, buffer);
+                    }
                 }
             }
 
@@ -294,9 +329,13 @@ class WebglRenderTarget {
         this._glMsaaColorBuffers.length = 0;
         this._glMsaaDepthBuffer = null;
         this.colorMrtFramebuffers = null;
+        this.suppliedColorFramebuffer = undefined;
+        this._isInitialized = false;
     }
 
     internalResolve(device, src, dst, target, mask) {
+
+        Debug.assert(src !== dst, 'Source and destination framebuffers must be different when blitting.');
 
         const gl = device.gl;
         gl.bindFramebuffer(gl.READ_FRAMEBUFFER, src);

--- a/src/platform/graphics/webgl/webgl-render-target.js
+++ b/src/platform/graphics/webgl/webgl-render-target.js
@@ -61,7 +61,7 @@ class WebglRenderTarget {
      * framebuffer. Null represents the default framebuffer. A value represents a user-supplied
      * framebuffer.
      */
-    suppliedColorFramebuffer = undefined;
+    suppliedColorFramebuffer;
 
     _isInitialized = false;
 

--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -28,15 +28,6 @@ import { WebgpuResolver } from './webgpu-resolver.js';
 
 class WebgpuGraphicsDevice extends GraphicsDevice {
     /**
-     * The render target representing the main back-buffer.
-     *
-     * @type {RenderTarget}
-     */
-    backBuffer;
-
-    backBufferDimensions = new Vec2();
-
-    /**
      * Object responsible for caching and creation of render pipelines.
      */
     renderPipeline = new WebgpuRenderPipeline(this);

--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -333,9 +333,9 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
         DebugHelper.setLabel(outColorBuffer, `${this.backBuffer.name}`);
 
         // reallocate framebuffer if dimensions change, to match the output texture
-        if (this.backBufferDimensions.x !== outColorBuffer.width || this.backBufferDimensions.y !== outColorBuffer.height) {
+        if (this.backBufferSize.x !== outColorBuffer.width || this.backBufferSize.y !== outColorBuffer.height) {
 
-            this.backBufferDimensions.set(outColorBuffer.width, outColorBuffer.height);
+            this.backBufferDimebackBufferSizensions.set(outColorBuffer.width, outColorBuffer.height);
 
             this.backBuffer.destroy();
             this.backBuffer = null;

--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -335,7 +335,7 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
         // reallocate framebuffer if dimensions change, to match the output texture
         if (this.backBufferSize.x !== outColorBuffer.width || this.backBufferSize.y !== outColorBuffer.height) {
 
-            this.backBufferDimebackBufferSizensions.set(outColorBuffer.width, outColorBuffer.height);
+            this.backBufferSize.set(outColorBuffer.width, outColorBuffer.height);
 
             this.backBuffer.destroy();
             this.backBuffer = null;

--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -1,6 +1,5 @@
 import { TRACEID_RENDER_QUEUE } from '../../../core/constants.js';
 import { Debug, DebugHelper } from '../../../core/debug.js';
-import { Vec2 } from '../../../core/math/vec2.js';
 
 import {
     PIXELFORMAT_RGBA32F, PIXELFORMAT_RGBA8, PIXELFORMAT_BGRA8, DEVICETYPE_WEBGPU

--- a/src/scene/frame-graph.js
+++ b/src/scene/frame-graph.js
@@ -36,7 +36,7 @@ class FrameGraph {
             const renderPass = renderPasses[i];
             const renderTarget = renderPass.renderTarget;
 
-            // if using a target, or null which represents the default framebuffer
+            // if using a target, or null which represents the default back-buffer
             if (renderTarget !== undefined) {
 
                 // previous pass using the same render target
@@ -98,6 +98,7 @@ class FrameGraph {
             }
         }
 
+        /*
         // handle what's left in the map - last passes rendering to each render target
         renderTargetMap.forEach((renderPass, renderTarget) => {
 
@@ -112,6 +113,7 @@ class FrameGraph {
                 renderPass.colorOps.mipmaps = false;
             }
         });
+        */
 
         renderTargetMap.clear();
     }

--- a/src/scene/frame-graph.js
+++ b/src/scene/frame-graph.js
@@ -98,23 +98,6 @@ class FrameGraph {
             }
         }
 
-        /*
-        // handle what's left in the map - last passes rendering to each render target
-        renderTargetMap.forEach((renderPass, renderTarget) => {
-
-            // default framebuffer
-            if (renderTarget === null) {
-
-                // store the multisampled buffer
-                renderPass.colorOps.store = true;
-
-                // no resolve, no mipmaps
-                renderPass.colorOps.resolve = false;
-                renderPass.colorOps.mipmaps = false;
-            }
-        });
-        */
-
         renderTargetMap.clear();
     }
 

--- a/src/scene/graphics/scene-grab.js
+++ b/src/scene/graphics/scene-grab.js
@@ -266,10 +266,27 @@ class SceneGrab {
                         this.depthRenderTarget = self.allocateRenderTarget(this.depthRenderTarget, camera.renderTarget, device, format, useDepthBuffer, false, true);
                     }
 
-                    // copy depth
-                    DebugGraphics.pushGpuMarker(device, 'GRAB-DEPTH');
-                    device.copyRenderTarget(device.renderTarget, this.depthRenderTarget, false, true);
-                    DebugGraphics.popGpuMarker(device);
+                    // WebGL2 multisampling depth handling: we resolve multi-sampled depth buffer to a single-sampled destination buffer.
+                    // We could use existing API and resolve depth first and then blit it to destination, but this avoids the extra copy.
+                    if (device.webgl2 && device.renderTarget.samples > 1) {
+
+                        // multi-sampled buffer
+                        const src = device.renderTarget.impl._glFrameBuffer;
+
+                        // single sampled destination buffer
+                        const dest = this.depthRenderTarget;
+                        device.renderTarget = dest;
+                        device.updateBegin();
+
+                        this.depthRenderTarget.impl.internalResolve(device, src, dest.impl._glFrameBuffer, this.depthRenderTarget, device.gl.DEPTH_BUFFER_BIT);
+
+                    } else {
+
+                        // copy depth
+                        DebugGraphics.pushGpuMarker(device, 'GRAB-DEPTH');
+                        device.copyRenderTarget(device.renderTarget, this.depthRenderTarget, false, true);
+                        DebugGraphics.popGpuMarker(device);
+                    }
 
                     // assign uniform
                     self.setupUniform(device, true, useDepthBuffer ? this.depthRenderTarget.depthBuffer : this.depthRenderTarget.colorBuffer);


### PR DESCRIPTION
Before, the antialiasing was handled by requesting multi-sampled buffer from the context, and rendering to it. Browser's composer would later resolve this buffer to a single-sampled, and use it to render the web page.

The problem is that this approach took away the control of when the final resolve takes place from us, and even if part of the frame (post-effects for example) is single sampled, we still needed to write it back to multi-sampled surface, costing us a lot of memory bandwidth on tiled devices, which the composer needs to later resolve again for no reason at all, burning even more bandwidth.

This PR changes this, and we always obtain a single-sampled buffer from the context, which includes XR mode. We then allocate a multi-sampled framebuffer for it, and use the context's buffer as its resolve target. 

This also unifies how this is done between WebGL and WebGPU, making further render pass modifications (incoming soon) a lot simpler / unified, and could allow further optimizations, for example only multi-sampling opaque rendering, then resolve, grab-pass color buffer, but stay on a single sampled-from then on.

Performance impact on Pixel 6 (GPU time):
- blend-trees-1d example: 4.6ms -> 4.2ms, so about 10% gain, related to postprocessing not having to be copied back to multisampled buffer.
- ground-fog example: 4.5ms->4.8ms. Many examples are now seemingly slower, just like this one. The reason as I understand is that we now measure the final resolve time as well, as it's done by us, instead of by the browser's composer later on. So even though the GPU time we report is larger, we just made this cost visible by our profiler, instead of hidden in the browser's use of the GPU.

