### PR TITLE
MiniStats render on UI layer

### DIFF
--- a/examples/src/examples/graphics/model-outline.tsx
+++ b/examples/src/examples/graphics/model-outline.tsx
@@ -100,8 +100,9 @@ class ModelOutlineExample {
                 const outlineLayer = new pc.Layer({ name: "OutlineLayer" });
                 app.scene.layers.insert(outlineLayer, 0);
 
-                // get world layer
+                // get existing layers
                 const worldLayer = app.scene.layers.getLayerByName("World");
+                const uiLayer = app.scene.layers.getLayerByName("UI");
 
                 // create ground plane and 3 primitives, visible in both layers
                 createPrimitive("plane", new pc.Vec3(0, 0, 0), new pc.Vec3(20, 20, 20), new pc.Color(0.3, 0.5, 0.3), [worldLayer.id]);
@@ -113,7 +114,7 @@ class ModelOutlineExample {
                 const camera = new pc.Entity();
                 camera.addComponent("camera", {
                     clearColor: new pc.Color(0.2, 0.2, 0.4),
-                    layers: [worldLayer.id]
+                    layers: [worldLayer.id, uiLayer.id]
                 });
                 camera.translate(0, 20, 25);
                 camera.lookAt(pc.Vec3.ZERO);

--- a/examples/src/examples/graphics/mrt.tsx
+++ b/examples/src/examples/graphics/mrt.tsx
@@ -89,9 +89,10 @@ class MrtExample {
                 app.scene.toneMapping = pc.TONEMAP_ACES;
 
 
-                // get world and skybox layers
+                // get existing layers
                 const worldLayer = app.scene.layers.getLayerByName("World");
                 const skyboxLayer = app.scene.layers.getLayerByName("Skybox");
+                const uiLayer = app.scene.layers.getLayerByName("UI");
 
                 // create a layer for object that render into texture, add it right after the world layer
                 const rtLayer = new pc.Layer({ name: "RTLayer" });
@@ -170,7 +171,7 @@ class MrtExample {
                 // Create an Entity with a camera component
                 const camera: any = new pc.Entity();
                 camera.addComponent("camera", {
-                    layers: [worldLayer.id, skyboxLayer.id]
+                    layers: [worldLayer.id, skyboxLayer.id, uiLayer.id]
                 });
                 app.root.addChild(camera);
 

--- a/examples/src/examples/graphics/portal.tsx
+++ b/examples/src/examples/graphics/portal.tsx
@@ -140,6 +140,8 @@ class PortalExample {
                 // find skybox layer - to enable it for the camera
                 const skyboxLayer = app.scene.layers.getLayerByName("Skybox");
 
+                const uiLayer = app.scene.layers.getLayerByName("UI");
+
                 // portal layer - this is where the portal geometry is written to the stencil
                 // buffer, and this needs to render first, so insert it before the world layer
                 const portalLayer = new pc.Layer({ name: "Portal" });
@@ -149,7 +151,7 @@ class PortalExample {
                 // this camera renders both world and portal layers
                 const camera = new pc.Entity();
                 camera.addComponent('camera', {
-                    layers: [worldLayer.id, portalLayer.id, skyboxLayer.id]
+                    layers: [worldLayer.id, portalLayer.id, skyboxLayer.id, uiLayer.id]
                 });
                 camera.setLocalPosition(7, 5.5, 7.1);
                 camera.setLocalEulerAngles(-27, 45, 0);

--- a/examples/src/examples/graphics/reflection-box.tsx
+++ b/examples/src/examples/graphics/reflection-box.tsx
@@ -96,12 +96,13 @@ class ReflectionBoxExample {
                     reflectivity: 0.5
                 });
 
+                // get existing layers
+                const worldLayer = app.scene.layers.getLayerByName("World");
+                const uiLayer = app.scene.layers.getLayerByName("UI");
+
                 // create a layer for object that do not render into reflection cubemap
                 const excludedLayer = new pc.Layer({ name: "Excluded" });
-                app.scene.layers.push(excludedLayer);
-
-                // get world layer
-                const worldLayer = app.scene.layers.getLayerByName("World");
+                app.scene.layers.insert(excludedLayer, app.scene.layers.getTransparentIndex(worldLayer) + 1);
 
                 // create an envAtlas texture, which will hold a prefiltered lighting generated from the cubemap.
                 // This represents a reflection prefiltered for different levels of roughness
@@ -270,10 +271,10 @@ class ReflectionBoxExample {
                 app.root.addChild(lightOmni);
 
                 // create an Entity with a camera component
-                const camera = new pc.Entity();
+                const camera = new pc.Entity("MainCamera");
                 camera.addComponent("camera", {
                     fov: 100,
-                    layers: [worldLayer.id, excludedLayer.id],
+                    layers: [worldLayer.id, excludedLayer.id, uiLayer.id],
                     farClip: 1500
                 });
                 camera.setLocalPosition(270, 90, -260);
@@ -292,7 +293,7 @@ class ReflectionBoxExample {
                 app.root.addChild(camera);
 
                 // create a probe object with cubemapRenderer script which takes care of rendering dynamic cubemap
-                const probe = new pc.Entity();
+                const probe = new pc.Entity('probeCamera');
                 probe.addComponent('script');
 
                 // add camera component to the probe - this defines camera properties for cubemap rendering

--- a/examples/src/examples/graphics/reflection-cubemap.tsx
+++ b/examples/src/examples/graphics/reflection-cubemap.tsx
@@ -106,6 +106,12 @@ class ReflectionCubemapExample {
                     return primitive;
                 }
 
+                // get existing layers
+                const worldLayer = app.scene.layers.getLayerByName("World");
+                const skyboxLayer = app.scene.layers.getLayerByName("Skybox");
+                const immediateLayer = app.scene.layers.getLayerByName("Immediate");
+                const uiLayer = app.scene.layers.getLayerByName("UI");
+
                 // create a layer for object that do not render into texture
                 const excludedLayer = new pc.Layer({ name: "Excluded" });
                 app.scene.layers.push(excludedLayer);
@@ -117,11 +123,6 @@ class ReflectionCubemapExample {
                 const shinyBall = createHighQualitySphere(shinyMat, [excludedLayer.id]);
                 shinyBall.setLocalPosition(0, 0, 0);
                 shinyBall.setLocalScale(10, 10, 10);
-
-                // get world and skybox layers
-                const worldLayer = app.scene.layers.getLayerByName("World");
-                const skyboxLayer = app.scene.layers.getLayerByName("Skybox");
-                const immediateLayer = app.scene.layers.getLayerByName("Immediate");
 
                 // add camera component to shiny ball - this defines camera properties for cubemap rendering
                 shinyBall.addComponent('camera', {
@@ -179,7 +180,7 @@ class ReflectionCubemapExample {
                 const camera = new pc.Entity("MainCamera");
                 camera.addComponent("camera", {
                     fov: 60,
-                    layers: [worldLayer.id, excludedLayer.id, skyboxLayer.id, immediateLayer.id]
+                    layers: [worldLayer.id, excludedLayer.id, skyboxLayer.id, immediateLayer.id, uiLayer.id]
                 });
                 app.root.addChild(camera);
 

--- a/examples/src/examples/graphics/reflection-planar.tsx
+++ b/examples/src/examples/graphics/reflection-planar.tsx
@@ -127,9 +127,10 @@ class ReflectionPlanarExample {
                 const excludedLayer = new pc.Layer({ name: "Excluded" });
                 app.scene.layers.push(excludedLayer);
 
-                // get world and skybox layers
+                // get existing layers
                 const worldLayer = app.scene.layers.getLayerByName("World");
                 const skyboxLayer = app.scene.layers.getLayerByName("Skybox");
+                const uiLayer = app.scene.layers.getLayerByName("UI");
 
                 // Create the shader from the vertex and fragment shaders
                 const shader = pc.createShaderFromCode(app.graphicsDevice, files['shader.vert'], files['shader.frag'], 'myShader', {
@@ -160,7 +161,7 @@ class ReflectionPlanarExample {
                 const camera = new pc.Entity("MainCamera");
                 camera.addComponent("camera", {
                     fov: 60,
-                    layers: [worldLayer.id, excludedLayer.id, skyboxLayer.id]
+                    layers: [worldLayer.id, excludedLayer.id, skyboxLayer.id, uiLayer.id]
                 });
                 app.root.addChild(camera);
 

--- a/examples/src/examples/graphics/render-to-texture.tsx
+++ b/examples/src/examples/graphics/render-to-texture.tsx
@@ -152,9 +152,10 @@ class RenderToTextureExample {
                 const excludedLayer = new pc.Layer({ name: "Excluded" });
                 app.scene.layers.insert(excludedLayer, 1);
 
-                // get world and skybox layers
+                // get existing layers
                 const worldLayer = app.scene.layers.getLayerByName("World");
                 const skyboxLayer = app.scene.layers.getLayerByName("Skybox");
+                const uiLayer = app.scene.layers.getLayerByName("UI");
 
                 // create ground plane and 3 primitives, visible in world layer
                 const plane = createPrimitive("plane", new pc.Vec3(0, 0, 0), new pc.Vec3(20, 20, 20), new pc.Color(3, 4, 2), [worldLayer.id]);
@@ -177,7 +178,7 @@ class RenderToTextureExample {
                 const camera = new pc.Entity("Camera");
                 camera.addComponent("camera", {
                     fov: 100,
-                    layers: [worldLayer.id, excludedLayer.id, skyboxLayer.id]
+                    layers: [worldLayer.id, excludedLayer.id, skyboxLayer.id, uiLayer.id]
                 });
                 camera.translate(0, 9, 15);
                 camera.lookAt(1, 4, 0);

--- a/extras/mini-stats/mini-stats.js
+++ b/extras/mini-stats/mini-stats.js
@@ -1,5 +1,6 @@
 import {
     FILTER_NEAREST,
+    LAYERID_UI,
     math,
     Color,
     Texture
@@ -16,6 +17,8 @@ class MiniStats {
     constructor(app, options) {
 
         this.app = app;
+        this.drawLayer = app.scene.layers.getLayerById(LAYERID_UI);
+
         const device = app.graphicsDevice;
 
         // handle context lost
@@ -315,7 +318,7 @@ class MiniStats {
             }
         }
 
-        render2d.render(this.app, this.texture, this.clr, height);
+        render2d.render(this.app, this.drawLayer, this.texture, this.clr, height);
     }
 
     resize(width, height, showGraphs) {

--- a/extras/mini-stats/render2d.js
+++ b/extras/mini-stats/render2d.js
@@ -159,7 +159,7 @@ class Render2d {
         this.quads = 0;
     }
 
-    render(app, texture, clr, height) {
+    render(app, layer, texture, clr, height) {
 
         // set vertex data (swap storage)
         this.buffer.setData(this.data.buffer);
@@ -184,7 +184,7 @@ class Render2d {
 
         this.material.setParameter('data', texture);
 
-        app.drawMeshInstance(this.meshInstance);
+        app.drawMeshInstance(this.meshInstance, layer);
     }
 }
 


### PR DESCRIPTION
- updated mini-stats to render on the UI instead of IMMEDIATE layer where it was added during refactoring recently, to avoid mini-stats getting post-processed in a typical case
- updated few examples to include UI layer in their cameras to render mini-stats