### PR TITLE
chore: update jsdoc comment

### DIFF
--- a/src/scene/renderer/renderer.js
+++ b/src/scene/renderer/renderer.js
@@ -92,14 +92,14 @@ class Renderer {
     /**
      * A list of all unique lights in the layer composition.
      *
-     * @type {import('../lighting/light.js').Light[]}
+     * @type {import('../light.js').Light[]}
      */
     lights = [];
 
     /**
      * A list of all unique local lights (spot & omni) in the layer composition.
      *
-     * @type {import('../lighting/light.js').Light[]}
+     * @type {import('../light.js').Light[]}
      */
     localLights = [];
 


### PR DESCRIPTION
update location for `light.js` in jsdoc type declaration

Fixes a jsdoc comment.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
