### PR TITLE
chore(examples): fix lint warnings

### DIFF
--- a/examples/src/examples/.eslintrc.json
+++ b/examples/src/examples/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+    "rules": {
+        "@typescript-eslint/no-unused-vars": 0
+    }
+}

--- a/examples/src/examples/.eslintrc.json
+++ b/examples/src/examples/.eslintrc.json
@@ -1,5 +1,5 @@
 {
     "rules": {
-        "@typescript-eslint/no-unused-vars": 0
+        "@typescript-eslint/no-unused-vars": ["error", { "args": "none" }]
     }
 }


### PR DESCRIPTION
Examples implement a common signature in their functions:

```js
example(canvas: HTMLCanvasElement, deviceType: string): void
```

@typescript-eslint doesn't understand the "deviceType" parameter may be used when experimenting with the example (when its running in the browser) and warns of unused variables.

Fixes 20 lint warnings in examples.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
