### PR TITLE
tools: add check typedocs command

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
     "build:types:extras": "tsc extras/index.js --allowJs --declaration --emitDeclarationOnly --outDir build/playcanvas-extras.mjs",
     "build:sourcemaps": "npm run build -- -m",
     "build:publish": "npm run build && npm run build:types",
-    "check:jsdocs": "tsc src/index.js --allowJs --checkJs --noEmit --target ES6",
+    "check:tsdocs": "tsc src/index.js --allowJs --checkJs --noEmit --target ES6",
     "watch": "npm run build -- -w",
     "watch:release": "npm run build:release -- -w",
     "watch:debug": "npm run build:debug -- -w",

--- a/package.json
+++ b/package.json
@@ -144,6 +144,7 @@
     "build:types:extras": "tsc extras/index.js --allowJs --declaration --emitDeclarationOnly --outDir build/playcanvas-extras.mjs",
     "build:sourcemaps": "npm run build -- -m",
     "build:publish": "npm run build && npm run build:types",
+    "check:jsdocs": "tsc src/index.js --allowJs --checkJs --noEmit --target ES6",
     "watch": "npm run build -- -w",
     "watch:release": "npm run build:release -- -w",
     "watch:debug": "npm run build:debug -- -w",


### PR DESCRIPTION
Edit: Correct references to jsdoc

Generates detailed and summary report of tsdoc and type issues related to tsdocs in Javascript files.  Output is to the console.

Running the following from the root of the project will produce a report.  
(run with `npx` at beginning if typescript is not installed globally)

```bash
tsc src/index.js --allowJs --checkJs --noEmit --target ES6
```

This PR wraps this into a command in the `package.json`.  `npx` is not required here, it will run against the version of typescript installed by this project.

```json
{
  "scripts": {
    "check:tsdocs": "tsc src/index.js --allowJs --checkJs --noEmit --target ES6",
  },
}
```

The same command can be added as a step in the github checks in the future.
(see `./github/workflows/ci.yml`)

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
