### PR TITLE
docs: update drawTexture typedoc

### DIFF
--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -1368,7 +1368,6 @@ class WebglGraphicsDevice extends GraphicsDevice {
      *
      * @returns {Shader} The copy shader (based on `fullscreenQuadVS` and `outputTex2DPS` in
      * `shaderChunks`).
-     * @ignore
      */
     getCopyShader() {
         if (!this._copyShader) {

--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -1368,6 +1368,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
      *
      * @returns {Shader} The copy shader (based on `fullscreenQuadVS` and `outputTex2DPS` in
      * `shaderChunks`).
+     * @ignore
      */
     getCopyShader() {
         if (!this._copyShader) {

--- a/src/scene/graphics/quad-render-utils.js
+++ b/src/scene/graphics/quad-render-utils.js
@@ -81,7 +81,7 @@ function drawQuadWithShader(device, target, shader, rect, scissorRect) {
 /**
  * Draws a texture in screen-space. Mostly used by post-effects.
  *
- * @param {import('../../platform/graphics/webgl/webgl-graphics-device.js').WebglGraphicsDevice} device - The graphics device used to draw
+ * @param {import('../../platform/graphics/graphics-device.js').GraphicsDevice} device - The graphics device used to draw
  * the texture.
  * @param {import('../../platform/graphics/texture.js').Texture} texture - The source texture to be drawn. Accessible as
  * `uniform sampler2D * source` in shader.

--- a/src/scene/graphics/quad-render-utils.js
+++ b/src/scene/graphics/quad-render-utils.js
@@ -81,14 +81,14 @@ function drawQuadWithShader(device, target, shader, rect, scissorRect) {
 /**
  * Draws a texture in screen-space. Mostly used by post-effects.
  *
- * @param {import('../../platform/graphics/graphics-device.js').GraphicsDevice} device - The graphics device used to draw
+ * @param {import('../../platform/graphics/webgl/webgl-graphics-device.js').WebglGraphicsDevice} device - The graphics device used to draw
  * the texture.
  * @param {import('../../platform/graphics/texture.js').Texture} texture - The source texture to be drawn. Accessible as
  * `uniform sampler2D * source` in shader.
  * @param {import('../../platform/graphics/render-target.js').RenderTarget} [target] - The destination render target.
  * Defaults to the frame buffer.
  * @param {import('../../platform/graphics/shader.js').Shader} [shader] - The shader used for rendering the texture.
- * Defaults to {@link GraphicsDevice#getCopyShader}.
+ * Defaults to {@link WebglGraphicsDevice#getCopyShader}.
  * @param {import('../../core/math/vec4.js').Vec4} [rect] - The viewport rectangle to use for the
  * texture, in pixels. Defaults to fullscreen (`0, 0, target.width, target.height`).
  * @param {import('../../core/math/vec4.js').Vec4} [scissorRect] - The scissor rectangle to use for
@@ -100,7 +100,7 @@ function drawTexture(device, texture, target, shader, rect, scissorRect) {
     const useBlend = arguments[6];
     Debug.call(() => {
         if (useBlend !== undefined) {
-            Debug.warnOnce('pc.drawTexture no longer accepts useBlend parameter, and blending state needs to be set up using GraphicsDevice.setBlendState.');
+            Debug.warnOnce('pc.drawTexture no longer accepts useBlend parameter, and blending state needs to be set up using WebglGraphicsDevice.setBlendState.');
         }
     });
 

--- a/src/scene/graphics/quad-render-utils.js
+++ b/src/scene/graphics/quad-render-utils.js
@@ -99,7 +99,7 @@ function drawTexture(device, texture, target, shader, rect, scissorRect) {
     const useBlend = arguments[6];
     Debug.call(() => {
         if (useBlend !== undefined) {
-            Debug.warnOnce('pc.drawTexture no longer accepts useBlend parameter, and blending state needs to be set up using WebglGraphicsDevice.setBlendState.');
+            Debug.warnOnce('pc.drawTexture no longer accepts useBlend parameter, and blending state needs to be set up using GraphicsDevice.setBlendState.');
         }
     });
 

--- a/src/scene/graphics/quad-render-utils.js
+++ b/src/scene/graphics/quad-render-utils.js
@@ -87,8 +87,7 @@ function drawQuadWithShader(device, target, shader, rect, scissorRect) {
  * `uniform sampler2D * source` in shader.
  * @param {import('../../platform/graphics/render-target.js').RenderTarget} [target] - The destination render target.
  * Defaults to the frame buffer.
- * @param {import('../../platform/graphics/shader.js').Shader} [shader] - The shader used for rendering the texture.
- * Defaults to {@link WebglGraphicsDevice#getCopyShader}.
+ * @param {import('../../platform/graphics/shader.js').Shader} [shader] - The optional custom shader used for rendering the texture.
  * @param {import('../../core/math/vec4.js').Vec4} [rect] - The viewport rectangle to use for the
  * texture, in pixels. Defaults to fullscreen (`0, 0, target.width, target.height`).
  * @param {import('../../core/math/vec4.js').Vec4} [scissorRect] - The scissor rectangle to use for


### PR DESCRIPTION
This is a small test PR to ensure the process / method is correct.

Addresses warning:

```
[warning] Failed to resolve link to "GraphicsDevice#getCopyShader" in comment for drawTexture.shader.
```

Jsdocs location: pc.drawTexture
Typedocs location: drawTexture

The reference does not exist on GraphicsDevice.  On WebglGraphicsDevice, it's marked as ignored so links do not work in jsdocs or typedocs.  

This assumes the link should be kept.  Removing the "ignore" documents "getCopyShader" in both tools.
Should the "ignore" be honoured and link removed ?

It is documenting the default value.

Notes:


- getCopyShader only exists on WebglGraphicsDevice
- drawTexture only supports WebGL device
- The link reference only works if it is not ignored.

Fixes jsdoc link, typedoc link, removes typedoc warning.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
