### PR TITLE
Fix to restoring lost context on WebGL related to very recent backbuffer refactoring

### DIFF
--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -346,8 +346,8 @@ class WebglGraphicsDevice extends GraphicsDevice {
 
         this._contextRestoredHandler = () => {
             Debug.log('pc.GraphicsDevice: WebGL context restored.');
-            this.restoreContext();
             this.contextLost = false;
+            this.restoreContext();
             this.fire('devicerestored');
         };
 
@@ -1165,6 +1165,10 @@ class WebglGraphicsDevice extends GraphicsDevice {
      * @ignore
      */
     loseContext() {
+
+        // force the backbuffer to be recreated on restore
+        this.backBufferSize.set(-1, -1);
+
         // release shaders
         for (const shader of this.shaders) {
             shader.loseContext();


### PR DESCRIPTION
restoring lost context now works - the backbuffer is restored