### PR TITLE
When the context is lost, silently ignore failed shader compilation

### DIFF
--- a/src/platform/graphics/webgl/webgl-shader.js
+++ b/src/platform/graphics/webgl/webgl-shader.js
@@ -149,13 +149,18 @@ class WebglShader {
         if (this.glProgram)
             return;
 
+        // if the device is lost, silently ignore
+        const gl = device.gl;
+        if (gl.isContextLost()) {
+            return;
+        }
+
         let startTime = 0;
         Debug.call(() => {
             this.compileDuration = 0;
             startTime = now();
         });
 
-        const gl = device.gl;
         const glProgram = gl.createProgram();
         this.glProgram = glProgram;
 
@@ -235,6 +240,11 @@ class WebglShader {
 
             glShader = gl.createShader(isVertexShader ? gl.VERTEX_SHADER : gl.FRAGMENT_SHADER);
 
+            // if the device is lost, silently ignore
+            if (!glShader && gl.isContextLost()) {
+                return glShader;
+            }
+
             gl.shaderSource(glShader, src);
             gl.compileShader(glShader);
 
@@ -268,11 +278,16 @@ class WebglShader {
      */
     finalize(device, shader) {
 
+        // if the device is lost, silently ignore
+        const gl = device.gl;
+        if (gl.isContextLost()) {
+            return true;
+        }
+
         // if the program wasn't linked yet (shader was not created in batch)
         if (!this.glProgram)
             this.link(device, shader);
 
-        const gl = device.gl;
         const glProgram = this.glProgram;
         const definition = shader.definition;
 


### PR DESCRIPTION
When the context is lost, all gl functionality should silently work, but `gl.createShader` returns null (which documentation of the function does not mentioned). This generates an error in the application.

The solution in this PR is to silently ignore shader compilation / linking errors when the device is lost, as those are compiled again when the device is restored, avoiding logging errors without real error message.

Related to https://forum.playcanvas.com/t/what-cause-webgl-context-lost/32886

Tested using CompileShader example, modified to compile a shader each frame - the errors are gone and all works correctly when the context is restored.