### PR TITLE
Refactor - do not create cookies render pass each time but reuse one

### DIFF
--- a/examples/src/examples/graphics/clustered-spot-shadows.tsx
+++ b/examples/src/examples/graphics/clustered-spot-shadows.tsx
@@ -13,8 +13,11 @@ class ClusteredSpotShadowsExample {
     controls(data: Observer) {
         return <>
             <Panel headerText='Atlas'>
-                <LabelGroup text='Resolution'>
+                <LabelGroup text='Shadow Res'>
                     <SliderInput binding={new BindingTwoWay()} link={{ observer: data, path: 'settings.shadowAtlasResolution' }} min={256} max={4096} precision={0}/>
+                </LabelGroup>
+                <LabelGroup text='Cookie Res'>
+                    <SliderInput binding={new BindingTwoWay()} link={{ observer: data, path: 'settings.cookieAtlasResolution' }} min={128} max={4096} precision={0}/>
                 </LabelGroup>
                 {<LabelGroup text='Split'>
                     <SelectInput binding={new BindingTwoWay()} link={{ observer: data, path: 'settings.atlasSplit' }} type="number" options={[
@@ -116,6 +119,7 @@ class ClusteredSpotShadowsExample {
 
                 data.set('settings', {
                     shadowAtlasResolution: 1024,     // shadow map resolution storing all shadows
+                    cookieAtlasResolution: 1024,     // cookie map resolution storing all cookies
                     shadowType: pc.SHADOW_PCF3,      // shadow filter type
                     shadowsEnabled: true,
                     cookiesEnabled: true,
@@ -153,7 +157,7 @@ class ClusteredSpotShadowsExample {
 
                 // resolution of the shadow and cookie atlas
                 lighting.shadowAtlasResolution = data.get('settings.shadowAtlasResolution');
-                lighting.cookieAtlasResolution = 1500;
+                lighting.cookieAtlasResolution = data.get('settings.cookieAtlasResolution');;
 
                 const splitOptions = [
                     null,               // automatic - split atlas each frame to give all required lights an equal size

--- a/src/scene/lighting/light-texture-atlas.js
+++ b/src/scene/lighting/light-texture-atlas.js
@@ -35,9 +35,13 @@ class LightTextureAtlas {
         // This needs to be a pixel more than a shadow filter needs to access.
         this.shadowEdgePixels = 3;
 
-        this.cookieAtlasResolution = 2048;
-        this.cookieAtlas = null;
-        this.cookieRenderTarget = null;
+        this.cookieAtlasResolution = 4;
+        this.cookieAtlas = CookieRenderer.createTexture(this.device, this.cookieAtlasResolution);
+        this.cookieRenderTarget = new RenderTarget({
+            colorBuffer: this.cookieAtlas,
+            depth: false,
+            flipY: true
+        });
 
         // available slots (of type Slot)
         this.slots = [];
@@ -69,24 +73,20 @@ class LightTextureAtlas {
     }
 
     destroyShadowAtlas() {
-        if (this.shadowAtlas) {
-            this.shadowAtlas.destroy();
-            this.shadowAtlas = null;
-        }
+        this.shadowAtlas?.destroy();
+        this.shadowAtlas = null;
     }
 
     destroyCookieAtlas() {
-        if (this.cookieAtlas) {
-            this.cookieAtlas.destroy();
-            this.cookieAtlas = null;
-        }
-        if (this.cookieRenderTarget) {
-            this.cookieRenderTarget.destroy();
-            this.cookieRenderTarget = null;
-        }
+        this.cookieAtlas?.destroy();
+        this.cookieAtlas = null;
+
+        this.cookieRenderTarget?.destroy();
+        this.cookieRenderTarget = null;
     }
 
     allocateShadowAtlas(resolution) {
+
         if (!this.shadowAtlas || this.shadowAtlas.texture.width !== resolution) {
 
             // content of atlas is lost, force re-render of static shadows
@@ -106,19 +106,14 @@ class LightTextureAtlas {
     }
 
     allocateCookieAtlas(resolution) {
-        if (!this.cookieAtlas || this.cookieAtlas.width !== resolution) {
+
+        // resize atlas
+        if (this.cookieAtlas.width !== resolution) {
+
+            this.cookieRenderTarget.resize(resolution, resolution);
 
             // content of atlas is lost, force re-render of static cookies
             this.version++;
-
-            this.destroyCookieAtlas();
-            this.cookieAtlas = CookieRenderer.createTexture(this.device, resolution);
-
-            this.cookieRenderTarget = new RenderTarget({
-                colorBuffer: this.cookieAtlas,
-                depth: false,
-                flipY: true
-            });
         }
     }
 

--- a/src/scene/renderer/cookie-renderer.js
+++ b/src/scene/renderer/cookie-renderer.js
@@ -1,4 +1,4 @@
-import { DebugHelper } from '../../core/debug.js';
+import { Debug, DebugHelper } from '../../core/debug.js';
 import { Vec4 } from '../../core/math/vec4.js';
 import { Mat4 } from '../../core/math/mat4.js';
 
@@ -60,6 +60,8 @@ class CookieRenderer {
 
         this.blitTextureId = this.device.scope.resolve('blitTexture');
         this.invViewProjId = this.device.scope.resolve('invViewProj');
+
+        this.renderPass = this.createRenderPass(lightTextureAtlas.cookieRenderTarget);
     }
 
     destroy() {
@@ -143,12 +145,9 @@ class CookieRenderer {
         }
     }
 
-    render(renderTarget, lights) {
+    createRenderPass(renderTarget) {
 
-        // pick lights we need to update the cookies for
-        this.filter(lights);
-        if (_filteredLights.length <= 0)
-            return;
+        Debug.assert(renderTarget);
 
         // prepare a single render pass to render all quads to the render target
         const device = this.device;
@@ -208,10 +207,20 @@ class CookieRenderer {
         renderPass.colorOps.clear = false;
         renderPass.depthStencilOps.clearDepth = false;
 
-        // render the pass
-        renderPass.render();
+        return renderPass;
+    }
 
-        _filteredLights.length = 0;
+    render(lights) {
+
+        // pick lights we need to update the cookies for
+        this.filter(lights);
+        if (_filteredLights.length > 0) {
+
+            // render the pass
+            this.renderPass.render();
+
+            _filteredLights.length = 0;
+        }
     }
 }
 

--- a/src/scene/renderer/renderer.js
+++ b/src/scene/renderer/renderer.js
@@ -1159,8 +1159,7 @@ class Renderer {
     }
 
     renderCookies(lights) {
-        const cookieRenderTarget = this.lightTextureAtlas.cookieRenderTarget;
-        this._cookieRenderer.render(cookieRenderTarget, lights);
+        this._cookieRenderer.render(lights);
     }
 
     /**


### PR DESCRIPTION
- small refactor to avoid the pass getting created each time. Uses recently added support for render target resizing.
- used as a test bed for further render pass refactoring to avoid their allocation each frame
- exposed cookie atlas size in the example for testing