### PR TITLE
DOCS: Add missing TONEMAP_ACES2 to JSDocs

### DIFF
--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -638,6 +638,7 @@ class Scene extends EventHandler {
      * - {@link TONEMAP_FILMIC}
      * - {@link TONEMAP_HEJL}
      * - {@link TONEMAP_ACES}
+     * - {@link TONEMAP_ACES2}
      *
      * Defaults to {@link TONEMAP_LINEAR}.
      *


### PR DESCRIPTION
Add missing valid parameter for `Scene#toneMapping`.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
