### PR TITLE
Extract the color grab functionality to a render pass

### DIFF
--- a/src/framework/components/camera/component.js
+++ b/src/framework/components/camera/component.js
@@ -707,6 +707,8 @@ class CameraComponent extends Component {
         if (!ok) {
             Debug.warnOnce('CameraComponent.requestSceneColorMap was called, but the camera does not have a Depth layer, ignoring.');
         }
+
+        this.camera._enableColorGrabPass(this.system.app.graphicsDevice, this.renderSceneColorMap);
     }
 
     /**

--- a/src/platform/graphics/render-pass.js
+++ b/src/platform/graphics/render-pass.js
@@ -176,6 +176,9 @@ class RenderPass {
         this._execute = execute;
     }
 
+    destroy() {
+    }
+
     /**
      * @param {import('../graphics/render-target.js').RenderTarget} renderTarget - The render
      * target to render into (output). This function should be called only for render passes which

--- a/src/scene/camera.js
+++ b/src/scene/camera.js
@@ -1,3 +1,4 @@
+import { Debug } from '../core/debug.js';
 import { Color } from '../core/math/color.js';
 import { Mat4 } from '../core/math/mat4.js';
 import { Vec3 } from '../core/math/vec3.js';
@@ -10,6 +11,7 @@ import {
     ASPECT_AUTO, PROJECTION_PERSPECTIVE,
     LAYERID_WORLD, LAYERID_DEPTH, LAYERID_SKYBOX, LAYERID_UI, LAYERID_IMMEDIATE
 } from './constants.js';
+import { RenderPassColorGrab } from './graphics/render-pass-color-grab.js';
 
 // pre-allocated temp variables
 const _deviceCoord = new Vec3();
@@ -27,7 +29,12 @@ class Camera {
     /**
      * @type {import('./shader-pass.js').ShaderPassInfo|null}
      */
-    shaderPassInfo;
+    shaderPassInfo = null;
+
+    /**
+     * @type {RenderPassColorGrab|null}
+     */
+    colorGrabPass = null;
 
     constructor() {
         this._aspectRatio = 16 / 9;
@@ -419,6 +426,16 @@ class Camera {
         this._projMatDirty = true;
 
         return this;
+    }
+
+    _enableColorGrabPass(device, enable) {
+        if (enable) {
+            Debug.assert(!this.colorGrabPass);
+            this.colorGrabPass = new RenderPassColorGrab(device, this);
+        } else {
+            this.colorGrabPass?.destroy();
+            this.colorGrabPass = null;
+        }
     }
 
     _updateViewProjMat() {

--- a/src/scene/frame-graph.js
+++ b/src/scene/frame-graph.js
@@ -1,3 +1,5 @@
+import { Debug } from '../core/debug.js';
+
 /**
  * A frame graph represents a single rendering frame as a sequence of render passes.
  *
@@ -21,6 +23,7 @@ class FrameGraph {
      * pass to add.
      */
     addRenderPass(renderPass) {
+        Debug.assert(renderPass);
         this.renderPasses.push(renderPass);
     }
 

--- a/src/scene/graphics/render-pass-color-grab.js
+++ b/src/scene/graphics/render-pass-color-grab.js
@@ -1,0 +1,159 @@
+import { ADDRESS_CLAMP_TO_EDGE, FILTER_LINEAR, FILTER_LINEAR_MIPMAP_LINEAR } from "../../platform/graphics/constants.js";
+import { DebugGraphics } from "../../platform/graphics/debug-graphics.js";
+import { RenderPass } from "../../platform/graphics/render-pass.js";
+import { RenderTarget } from "../../platform/graphics/render-target.js";
+import { Texture } from "../../platform/graphics/texture.js";
+
+// uniform names (first is current name, second one is deprecated name for compatibility)
+const _colorUniformNames = ['uSceneColorMap', 'texture_grabPass'];
+
+/**
+ * A render pass implementing grab of a color buffer.
+ *
+ * TODO: implement mipmapped color buffer support for WebGL 1 as well, which requires
+ * the texture to be a power of two, by first downscaling the captured framebuffer
+ * texture to smaller power of 2 texture, and then generate mipmaps and use it for rendering
+ * TODO: or even better, implement blur filter to have smoother lower levels
+ *
+ * @ignore
+ */
+class RenderPassColorGrab extends RenderPass {
+    colorRenderTarget = null;
+
+    camera = null;
+
+    constructor(device, camera) {
+        super(device);
+        this.camera = camera;
+    }
+
+    destroy() {
+        super.destroy();
+        this.releaseRenderTarget(this.colorRenderTarget);
+    }
+
+    shouldReallocate(targetRT, sourceTexture, sourceFormat) {
+
+        // need to reallocate if format does not match
+        const targetFormat = targetRT?.colorBuffer.format;
+        if (targetFormat !== sourceFormat)
+            return true;
+
+        // need to reallocate if dimensions don't match
+        const width = sourceTexture?.width || this.device.width;
+        const height = sourceTexture?.height || this.device.height;
+        return !targetRT || width !== targetRT.width || height !== targetRT.height;
+    }
+
+    allocateRenderTarget(renderTarget, sourceRenderTarget, device, format) {
+
+        // allocate texture buffer
+        const mipmaps = device.webgl2;
+        const texture = new Texture(device, {
+            name: _colorUniformNames[0],
+            format,
+            width: sourceRenderTarget ? sourceRenderTarget.colorBuffer.width : device.width,
+            height: sourceRenderTarget ? sourceRenderTarget.colorBuffer.height : device.height,
+            mipmaps,
+            minFilter: mipmaps ? FILTER_LINEAR_MIPMAP_LINEAR : FILTER_LINEAR,
+            magFilter: FILTER_LINEAR,
+            addressU: ADDRESS_CLAMP_TO_EDGE,
+            addressV: ADDRESS_CLAMP_TO_EDGE
+        });
+
+        if (renderTarget) {
+
+            // if reallocating RT size, release previous framebuffer
+            renderTarget.destroyFrameBuffers();
+
+            // assign new texture
+            renderTarget._colorBuffer = texture;
+            renderTarget._colorBuffers = [texture];
+        } else {
+
+            // create new render target with the texture
+            renderTarget = new RenderTarget({
+                name: 'ColorGrabRT',
+                colorBuffer: texture,
+                depth: false,
+                stencil: false,
+                autoResolve: false
+            });
+        }
+
+        return renderTarget;
+    }
+
+    releaseRenderTarget(rt) {
+
+        if (rt) {
+            rt.destroyTextureBuffers();
+            rt.destroy();
+        }
+    }
+
+    before() {
+
+        const camera = this.camera;
+        const device = this.device;
+
+        // based on the RT the camera renders to, otherwise framebuffer
+        const sourceFormat = camera.renderTarget?.colorBuffer.format ?? this.device.backBufferFormat;
+
+        // allocate / resize existing RT as needed
+        if (this.shouldReallocate(this.colorRenderTarget, camera.renderTarget?.colorBuffer, sourceFormat)) {
+            this.releaseRenderTarget(this.colorRenderTarget);
+            this.colorRenderTarget = this.allocateRenderTarget(this.colorRenderTarget, camera.renderTarget, device, sourceFormat);
+        }
+
+        // assign uniform
+        const colorBuffer = this.colorRenderTarget.colorBuffer;
+        _colorUniformNames.forEach(name => device.scope.resolve(name).setValue(colorBuffer));
+    }
+
+    execute() {
+
+        // copy color from the current render target
+        const device = this.device;
+        DebugGraphics.pushGpuMarker(device, 'GRAB-COLOR');
+
+        const colorBuffer = this.colorRenderTarget.colorBuffer;
+
+        if (device.isWebGPU) {
+
+            device.copyRenderTarget(this.camera.renderTarget, this.colorRenderTarget, true, false);
+
+            // generate mipmaps
+            device.mipmapRenderer.generate(this.colorRenderTarget.colorBuffer.impl);
+
+        } else if (device.webgl2) {
+
+            device.copyRenderTarget(device.renderTarget, this.colorRenderTarget, true, false);
+
+            // generate mipmaps
+            device.activeTexture(device.maxCombinedTextures - 1);
+            device.bindTexture(colorBuffer);
+            device.gl.generateMipmap(colorBuffer.impl._glTarget);
+
+        } else { // webgl 1
+
+            // initialize the texture
+            if (!colorBuffer.impl._glTexture) {
+                colorBuffer.impl.initialize(device, colorBuffer);
+            }
+
+            // copy framebuffer to it
+            device.bindTexture(colorBuffer);
+            const gl = device.gl;
+            gl.copyTexImage2D(gl.TEXTURE_2D, 0, colorBuffer.impl._glFormat, 0, 0, colorBuffer.width, colorBuffer.height, 0);
+
+            // stop the device from updating this texture further
+            colorBuffer._needsUpload = false;
+            colorBuffer._needsMipmapsUpload = false;
+        }
+
+        DebugGraphics.popGpuMarker(device);
+    }
+}
+
+export { RenderPassColorGrab };

--- a/src/scene/graphics/scene-grab.js
+++ b/src/scene/graphics/scene-grab.js
@@ -2,7 +2,7 @@ import { Debug } from '../../core/debug.js';
 
 import {
     ADDRESS_CLAMP_TO_EDGE,
-    FILTER_NEAREST, FILTER_LINEAR, FILTER_LINEAR_MIPMAP_LINEAR,
+    FILTER_NEAREST,
     PIXELFORMAT_DEPTHSTENCIL, PIXELFORMAT_R32F, PIXELFORMAT_RGBA8
 } from '../../platform/graphics/constants.js';
 
@@ -20,18 +20,11 @@ import { Layer } from '../layer.js';
 
 // uniform names (first is current name, second one is deprecated name for compatibility)
 const _depthUniformNames = ['uSceneDepthMap', 'uDepthMap'];
-const _colorUniformNames = ['uSceneColorMap', 'texture_grabPass'];
 
 /**
- * Internal class abstracting the access to the depth and color texture of the scene.
- * color frame buffer is copied to a texture
+ * Internal class abstracting the access to the depth texture of the scene.
  * For webgl 2 devices, the depth buffer is copied to a texture
  * for webgl 1 devices, the scene's depth is rendered to a separate RGBA texture
- *
- * TODO: implement mipmapped color buffer support for WebGL 1 as well, which requires
- * the texture to be a power of two, by first downscaling the captured framebuffer
- * texture to smaller power of 2 texture, and then generate mipmaps and use it for rendering
- * TODO: or even better, implement blur filter to have smoother lower levels
  *
  * @ignore
  */
@@ -94,14 +87,13 @@ class SceneGrab {
         return camera.renderSceneDepthMap;
     }
 
-    setupUniform(device, depth, buffer) {
+    setupUniform(device, buffer) {
 
         // assign it to scopes to expose it to shaders
-        const names = depth ? _depthUniformNames : _colorUniformNames;
-        names.forEach(name => device.scope.resolve(name).setValue(buffer));
+        _depthUniformNames.forEach(name => device.scope.resolve(name).setValue(buffer));
     }
 
-    allocateTexture(device, source, name, format, isDepth, mipmaps) {
+    allocateTexture(device, source, name, format) {
 
         // allocate texture that will store the depth
         return new Texture(device, {
@@ -109,9 +101,9 @@ class SceneGrab {
             format,
             width: source ? source.colorBuffer.width : device.width,
             height: source ? source.colorBuffer.height : device.height,
-            mipmaps,
-            minFilter: isDepth ? FILTER_NEAREST : (mipmaps ? FILTER_LINEAR_MIPMAP_LINEAR : FILTER_LINEAR),
-            magFilter: isDepth ? FILTER_NEAREST : FILTER_LINEAR,
+            mipmaps: false,
+            minFilter: FILTER_NEAREST,
+            magFilter: FILTER_NEAREST,
             addressU: ADDRESS_CLAMP_TO_EDGE,
             addressV: ADDRESS_CLAMP_TO_EDGE
         });
@@ -123,15 +115,7 @@ class SceneGrab {
         return texture?.format ?? this.device.backBufferFormat;
     }
 
-    shouldReallocate(targetRT, sourceTexture, testFormat) {
-
-        // need to reallocate if format does not match
-        if (testFormat) {
-            const targetFormat = targetRT?.colorBuffer.format;
-            const sourceFormat = this.getSourceColorFormat(sourceTexture);
-            if (targetFormat !== sourceFormat)
-                return true;
-        }
+    shouldReallocate(targetRT, sourceTexture) {
 
         // need to reallocate if dimensions don't match
         const width = sourceTexture?.width || this.device.width;
@@ -139,13 +123,10 @@ class SceneGrab {
         return !targetRT || width !== targetRT.width || height !== targetRT.height;
     }
 
-    allocateRenderTarget(renderTarget, sourceRenderTarget, device, format, isDepth, mipmaps, isDepthUniforms) {
-
-        // texture / uniform names: new one (first), as well as old one  (second) for compatibility
-        const names = isDepthUniforms ? _depthUniformNames : _colorUniformNames;
+    allocateRenderTarget(renderTarget, sourceRenderTarget, device, format, isDepth) {
 
         // allocate texture buffer
-        const buffer = this.allocateTexture(device, sourceRenderTarget, names[0], format, isDepth, mipmaps);
+        const buffer = this.allocateTexture(device, sourceRenderTarget, _depthUniformNames[0], format);
 
         if (renderTarget) {
 
@@ -198,52 +179,12 @@ class SceneGrab {
             onDisable: function () {
                 self.releaseRenderTarget(this.depthRenderTarget);
                 this.depthRenderTarget = null;
-
-                self.releaseRenderTarget(this.colorRenderTarget);
-                this.colorRenderTarget = null;
             },
 
             onPreRenderOpaque: function (cameraPass) { // resize depth map if needed
 
                 /** @type {import('../../framework/components/camera/component.js').CameraComponent} */
                 const camera = this.cameras[cameraPass];
-
-                if (camera.renderSceneColorMap) {
-
-                    // allocate / resize existing RT as needed
-                    if (self.shouldReallocate(this.colorRenderTarget, camera.renderTarget?.colorBuffer, true)) {
-                        self.releaseRenderTarget(this.colorRenderTarget);
-                        const format = self.getSourceColorFormat(camera.renderTarget?.colorBuffer);
-                        this.colorRenderTarget = self.allocateRenderTarget(this.colorRenderTarget, camera.renderTarget, device, format, false, true, false);
-                    }
-
-                    // copy color from the current render target
-                    DebugGraphics.pushGpuMarker(device, 'GRAB-COLOR');
-
-                    const colorBuffer = this.colorRenderTarget.colorBuffer;
-
-                    if (device.isWebGPU) {
-
-                        device.copyRenderTarget(camera.renderTarget, this.colorRenderTarget, true, false);
-
-                        // generate mipmaps
-                        device.mipmapRenderer.generate(this.colorRenderTarget.colorBuffer.impl);
-
-                    } else {
-
-                        device.copyRenderTarget(device.renderTarget, this.colorRenderTarget, true, false);
-
-                        // generate mipmaps
-                        device.activeTexture(device.maxCombinedTextures - 1);
-                        device.bindTexture(colorBuffer);
-                        device.gl.generateMipmap(colorBuffer.impl._glTarget);
-                    }
-
-                    DebugGraphics.popGpuMarker(device);
-
-                    // assign unifrom
-                    self.setupUniform(device, false, colorBuffer);
-                }
 
                 if (camera.renderSceneDepthMap) {
 
@@ -265,7 +206,7 @@ class SceneGrab {
                     // reallocate RT if needed
                     if (self.shouldReallocate(this.depthRenderTarget, sourceTexture)) {
                         self.releaseRenderTarget(this.depthRenderTarget);
-                        this.depthRenderTarget = self.allocateRenderTarget(this.depthRenderTarget, camera.renderTarget, device, format, useDepthBuffer, false, true);
+                        this.depthRenderTarget = self.allocateRenderTarget(this.depthRenderTarget, camera.renderTarget, device, format, useDepthBuffer);
                     }
 
                     // WebGL2 multisampling depth handling: we resolve multi-sampled depth buffer to a single-sampled destination buffer.
@@ -291,7 +232,7 @@ class SceneGrab {
                     }
 
                     // assign uniform
-                    self.setupUniform(device, true, useDepthBuffer ? this.depthRenderTarget.depthBuffer : this.depthRenderTarget.colorBuffer);
+                    self.setupUniform(device, useDepthBuffer ? this.depthRenderTarget.depthBuffer : this.depthRenderTarget.colorBuffer);
                 }
             },
 
@@ -335,9 +276,6 @@ class SceneGrab {
                 // only release depth texture, but not the render target itself
                 this.depthRenderTarget.destroyTextureBuffers();
                 this.renderTarget = null;
-
-                self.releaseRenderTarget(this.colorRenderTarget);
-                this.colorRenderTarget = null;
             },
 
             onPostCull: function (cameraPass) {
@@ -352,7 +290,7 @@ class SceneGrab {
                     // reallocate RT if needed
                     if (!this.depthRenderTarget?.colorBuffer || self.shouldReallocate(this.depthRenderTarget, sourceTexture)) {
                         this.depthRenderTarget?.destroyTextureBuffers();
-                        this.depthRenderTarget = self.allocateRenderTarget(this.depthRenderTarget, camera.renderTarget, device, PIXELFORMAT_RGBA8, false, false, true);
+                        this.depthRenderTarget = self.allocateRenderTarget(this.depthRenderTarget, camera.renderTarget, device, PIXELFORMAT_RGBA8, false);
 
                         // assign it so the render actions knows to render to it
                         // TODO: avoid this as this API is deprecated
@@ -406,42 +344,9 @@ class SceneGrab {
                 /** @type {import('../../framework/components/camera/component.js').CameraComponent} */
                 const camera = this.cameras[cameraPass];
 
-                if (camera.renderSceneColorMap) {
-
-                    // reallocate RT if needed
-                    if (self.shouldReallocate(this.colorRenderTarget, camera.renderTarget?.colorBuffer)) {
-                        self.releaseRenderTarget(this.colorRenderTarget);
-                        const format = self.getSourceColorFormat(camera.renderTarget?.colorBuffer);
-                        this.colorRenderTarget = self.allocateRenderTarget(this.colorRenderTarget, camera.renderTarget, device, format, false, false, false);
-                    }
-
-                    // copy out the color buffer
-                    DebugGraphics.pushGpuMarker(device, 'GRAB-COLOR');
-
-                    // initialize the texture
-                    const colorBuffer = this.colorRenderTarget._colorBuffer;
-                    if (!colorBuffer.impl._glTexture) {
-                        colorBuffer.impl.initialize(device, colorBuffer);
-                    }
-
-                    // copy framebuffer to it
-                    device.bindTexture(colorBuffer);
-                    const gl = device.gl;
-                    gl.copyTexImage2D(gl.TEXTURE_2D, 0, colorBuffer.impl._glFormat, 0, 0, colorBuffer.width, colorBuffer.height, 0);
-
-                    // stop the device from updating this texture further
-                    colorBuffer._needsUpload = false;
-                    colorBuffer._needsMipmapsUpload = false;
-
-                    DebugGraphics.popGpuMarker(device);
-
-                    // assign unifrom
-                    self.setupUniform(device, false, colorBuffer);
-                }
-
                 if (camera.renderSceneDepthMap) {
                     // assign unifrom
-                    self.setupUniform(device, true, this.depthRenderTarget.colorBuffer);
+                    self.setupUniform(device, this.depthRenderTarget.colorBuffer);
                 }
             },
 

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -822,8 +822,15 @@ class ForwardRenderer extends Renderer {
             if (!nextRenderAction || nextRenderAction.renderTarget !== renderTarget ||
                 nextRenderAction.hasDirectionalShadowLights || isNextLayerGrabPass || isGrabPass) {
 
-                // render the render actions in the range
-                this.addMainRenderPass(frameGraph, layerComposition, renderTarget, startIndex, i, isGrabPass);
+                if (isDepthLayer && camera.renderSceneColorMap) {
+
+                    frameGraph.addRenderPass(camera.camera.colorGrabPass);
+
+                } else {
+
+                    // render the render actions in the range
+                    this.addMainRenderPass(frameGraph, layerComposition, renderTarget, startIndex, i, isGrabPass);
+                }
 
                 // postprocessing
                 if (renderAction.triggerPostprocess && camera?.onPostprocessing) {


### PR DESCRIPTION
- standalone `RenderPassColorGrab` which implements color grab on all platforms
- simplified integration - does not depend on layer callbacks to do things, and is scheduled at the right time as a render pass in the render graph
- camera creates / owns the render pass, which is allocated when the color grab is enabled on the camera. This solves the issue with the layer solution, where if we needed more than a single color grab per scene (two or more cameras), render target would be re-allocate (to match the size) each frame per camera. Now each camera owns one.