### PR TITLE
Small internal refactor of the way camera is passed around for rendering

### DIFF
--- a/src/scene/composition/render-action.js
+++ b/src/scene/composition/render-action.js
@@ -13,9 +13,6 @@ class RenderAction {
         // the layer
         this.layer = null;
 
-        // index into a camera array of the layer, stored in Layer.cameras
-        this.cameraIndex = 0;
-
         // camera of type CameraComponent
         this.camera = null;
 

--- a/src/scene/layer.js
+++ b/src/scene/layer.js
@@ -151,8 +151,17 @@ class Layer {
      * True if the objects rendered on the layer require light cube (emitters with lighting do).
      *
      * @type {boolean}
+     * @ignore
      */
     requiresLightCube = false;
+
+    /**
+     * @type {import('../framework/components/camera/component.js').CameraComponent[]}
+     * @ignore
+     */
+    cameras = [];
+
+    _dirtyCameras = false;
 
     /**
      * Create a new Layer instance.
@@ -275,6 +284,7 @@ class Layer {
          * @type {Function}
          */
         this.onPreCull = options.onPreCull;
+
         /**
          * Custom function that is called before this layer is rendered. Useful, for example, for
          * reacting on screen size changes. This function is called before the first occurrence of
@@ -285,6 +295,7 @@ class Layer {
          * @type {Function}
          */
         this.onPreRender = options.onPreRender;
+
         /**
          * Custom function that is called before opaque mesh instances (not semi-transparent) in
          * this layer are rendered. This function will receive camera index as the only argument.
@@ -294,6 +305,7 @@ class Layer {
          * @type {Function}
          */
         this.onPreRenderOpaque = options.onPreRenderOpaque;
+
         /**
          * Custom function that is called before semi-transparent mesh instances in this layer are
          * rendered. This function will receive camera index as the only argument. You can get the
@@ -313,6 +325,7 @@ class Layer {
          * @type {Function}
          */
         this.onPostCull = options.onPostCull;
+
         /**
          * Custom function that is called after this layer is rendered. Useful to revert changes
          * made in {@link Layer#onPreRender}. This function is called after the last occurrence of this
@@ -323,6 +336,7 @@ class Layer {
          * @type {Function}
          */
         this.onPostRender = options.onPostRender;
+
         /**
          * Custom function that is called after opaque mesh instances (not semi-transparent) in
          * this layer are rendered. This function will receive camera index as the only argument.
@@ -332,6 +346,7 @@ class Layer {
          * @type {Function}
          */
         this.onPostRenderOpaque = options.onPostRenderOpaque;
+
         /**
          * Custom function that is called after semi-transparent mesh instances in this layer are
          * rendered. This function will receive camera index as the only argument. You can get the
@@ -349,6 +364,7 @@ class Layer {
          * @type {Function}
          */
         this.onDrawCall = options.onDrawCall;
+
         /**
          * Custom function that is called after the layer has been enabled. This happens when:
          *
@@ -361,6 +377,7 @@ class Layer {
          * @type {Function}
          */
         this.onEnable = options.onEnable;
+
         /**
          * Custom function that is called after the layer has been disabled. This happens when:
          *
@@ -394,14 +411,6 @@ class Layer {
          * @ignore
          */
         this.customCalculateSortValues = null;
-
-        /**
-         * @type {import('../framework/components/camera/component.js').CameraComponent[]}
-         * @ignore
-         */
-        this.cameras = [];
-
-        this._dirtyCameras = false;
 
         // light hash based on the light keys
         this._lightHash = 0;

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -785,7 +785,7 @@ class ForwardRenderer extends Renderer {
 
             const renderAction = renderActions[i];
             const layer = layerComposition.layerList[renderAction.layerIndex];
-            const camera = layer.cameras[renderAction.cameraIndex];
+            const camera = renderAction.camera;
 
             // skip disabled layers
             if (!renderAction.isLayerEnabled(layerComposition)) {
@@ -835,7 +835,7 @@ class ForwardRenderer extends Renderer {
                 // postprocessing
                 if (renderAction.triggerPostprocess && camera?.onPostprocessing) {
                     const renderPass = new RenderPass(this.device, () => {
-                        this.renderPassPostprocessing(renderAction, layerComposition);
+                        this.renderPassPostprocessing(renderAction);
                     });
                     renderPass.requiresCubemaps = false;
                     DebugHelper.setName(renderPass, `Postprocess`);
@@ -863,8 +863,7 @@ class ForwardRenderer extends Renderer {
         const renderActions = layerComposition._renderActions;
         const startRenderAction = renderActions[startIndex];
         const endRenderAction = renderActions[endIndex];
-        const startLayer = layerComposition.layerList[startRenderAction.layerIndex];
-        const camera = startLayer.cameras[startRenderAction.cameraIndex];
+        const camera = startRenderAction.camera;
 
         if (camera) {
 
@@ -948,10 +947,9 @@ class ForwardRenderer extends Renderer {
         this.gpuUpdate(this.processingMeshInstances);
     }
 
-    renderPassPostprocessing(renderAction, layerComposition) {
+    renderPassPostprocessing(renderAction) {
 
-        const layer = layerComposition.layerList[renderAction.layerIndex];
-        const camera = layer.cameras[renderAction.cameraIndex];
+        const camera = renderAction.camera;
         Debug.assert(renderAction.triggerPostprocess && camera.onPostprocessing);
 
         // trigger postprocessing for camera
@@ -990,8 +988,8 @@ class ForwardRenderer extends Renderer {
         const layer = comp.layerList[layerIndex];
         const transparent = comp.subLayerList[layerIndex];
 
-        const cameraPass = renderAction.cameraIndex;
-        const camera = layer.cameras[cameraPass];
+        const camera = renderAction.camera;
+        const cameraPass = comp.camerasMap.get(camera);
 
         if (!renderAction.isLayerEnabled(comp)) {
             return;

--- a/src/scene/renderer/renderer.js
+++ b/src/scene/renderer/renderer.js
@@ -1082,9 +1082,8 @@ class Renderer {
             if (!layer.enabled || !comp.subLayerEnabled[layerIndex]) continue;
 
             // camera
-            const cameraPass = renderAction.cameraIndex;
             /** @type {import('../../framework/components/camera/component.js').CameraComponent} */
-            const camera = layer.cameras[cameraPass];
+            const camera = renderAction.camera;
 
             if (camera) {
 
@@ -1101,13 +1100,15 @@ class Renderer {
                 this.cullLights(camera.camera, layer._lights);
 
                 // cull mesh instances
-                layer.onPreCull?.(cameraPass);
+                if (layer.onPreCull)
+                    layer.onPreCull(comp.camerasMap.get(camera));
 
                 const culledInstances = layer.getCulledInstances(camera.camera);
                 const drawCalls = layer.meshInstances;
                 this.cull(camera.camera, drawCalls, culledInstances);
 
-                layer.onPostCull?.(cameraPass);
+                if (layer.onPostCull)
+                    layer.onPostCull(comp.camerasMap.get(camera));
             }
         }
 


### PR DESCRIPTION
Instead of render action storing the camera index, and accessing camera in a complicated way using this index, we use the camera directly. When the index is needed for callbacks (why index instead of camera directly!), we look it up in a map