### PR TITLE
Handle ios 17 basis wasm regression

### DIFF
--- a/src/framework/handlers/basis-worker.js
+++ b/src/framework/handlers/basis-worker.js
@@ -326,9 +326,18 @@ function BasisWorker() {
             const dst = new Uint8Array(dstSize);
 
             if (!basisFile.transcodeImage(dst, 0, mip, basisFormat, 0, 0)) {
-                basisFile.close();
-                basisFile.delete();
-                throw new Error('Failed to transcode image url=' + url);
+                if (mip === levels - 1 && dstSize === levelData[mip - 1].buffer.byteLength) {
+                    // https://github.com/BinomialLLC/basis_universal/issues/358
+                    // there is a regression on iOS/safari 17 where the last mipmap level
+                    // fails to transcode. this is a workaround which copies the previous mip
+                    // level data instead of failing.
+                    dst.set(new Uint8Array(levelData[mip - 1].buffer));
+                    console.warn('Failed to transcode last mipmap level, using previous level instead url=' + url);
+                } else {
+                    basisFile.close();
+                    basisFile.delete();
+                    throw new Error('Failed to transcode image url=' + url);
+                }
             }
 
             const is16BitFormat = (basisFormat === BASIS_FORMAT.cTFRGB565 || basisFormat === BASIS_FORMAT.cTFRGBA4444);


### PR DESCRIPTION
iOS 17 introduced a wasm regression which results in some basis files failing to transcode (see https://bugs.webkit.org/show_bug.cgi?id=260252 for more context).

It appears the transcode only fails on images containing mipmaps (which have no alpha channel) and it's always the very last mipmap that fails to transcode.

This PR modifies the basis transcode logic to handle this specific failure case by copying the texture data from the second last mipmap level instead of completely failing the image transcode.

The resulting final mipmap will be very slightly incorrect, but the difference should be unnoticeable.
