### PR TITLE
Add equalsApprox to vec2, vec3, vec4 (and tests)

### DIFF
--- a/src/core/math/vec2.js
+++ b/src/core/math/vec2.js
@@ -268,6 +268,23 @@ class Vec2 {
     }
 
     /**
+     * Reports whether two vectors are equal using an absolute error tolerance.
+     *
+     * @param {Vec2} rhs - The vector to be compared against.
+     * @param {number} [epsilon] - The maximum difference between each component of the two
+     * vectors. Defaults to 1e-6.
+     * @returns {boolean} True if the vectors are equal and false otherwise.
+     * @example
+     * const a = new pc.Vec2();
+     * const b = new pc.Vec2();
+     * console.log("The two vectors are approximately " + (a.equalsApprox(b, 1e-9) ? "equal" : "different"));
+     */
+    equalsApprox(rhs, epsilon = 1e-6) {
+        return (Math.abs(this.x - rhs.x) < epsilon) &&
+            (Math.abs(this.y - rhs.y) < epsilon);
+    }
+
+    /**
      * Returns the magnitude of the specified 2-dimensional vector.
      *
      * @returns {number} The magnitude of the specified 2-dimensional vector.

--- a/src/core/math/vec3.js
+++ b/src/core/math/vec3.js
@@ -295,6 +295,24 @@ class Vec3 {
     }
 
     /**
+     * Reports whether two vectors are equal using an absolute error tolerance.
+     *
+     * @param {Vec3} rhs - The vector to be compared against.
+     * @param {number} [epsilon] - The maximum difference between each component of the two
+     * vectors. Defaults to 1e-6.
+     * @returns {boolean} True if the vectors are equal and false otherwise.
+     * @example
+     * const a = new pc.Vec3();
+     * const b = new pc.Vec3();
+     * console.log("The two vectors are approximately " + (a.equalsApprox(b, 1e-9) ? "equal" : "different"));
+     */
+    equalsApprox(rhs, epsilon = 1e-6) {
+        return (Math.abs(this.x - rhs.x) < epsilon) &&
+            (Math.abs(this.y - rhs.y) < epsilon) &&
+            (Math.abs(this.z - rhs.z) < epsilon);
+    }
+
+    /**
      * Returns the magnitude of the specified 3-dimensional vector.
      *
      * @returns {number} The magnitude of the specified 3-dimensional vector.

--- a/src/core/math/vec4.js
+++ b/src/core/math/vec4.js
@@ -265,6 +265,25 @@ class Vec4 {
     }
 
     /**
+     * Reports whether two vectors are equal using an absolute error tolerance.
+     *
+     * @param {Vec4} rhs - The vector to be compared against.
+     * @param {number} [epsilon] - The maximum difference between each component of the two
+     * vectors. Defaults to 1e-6.
+     * @returns {boolean} True if the vectors are equal and false otherwise.
+     * @example
+     * const a = new pc.Vec4();
+     * const b = new pc.Vec4();
+     * console.log("The two vectors are approximately " + (a.equalsApprox(b, 1e-9) ? "equal" : "different"));
+     */
+    equalsApprox(rhs, epsilon = 1e-6) {
+        return (Math.abs(this.x - rhs.x) < epsilon) &&
+            (Math.abs(this.y - rhs.y) < epsilon) &&
+            (Math.abs(this.z - rhs.z) < epsilon) &&
+            (Math.abs(this.w - rhs.w) < epsilon);
+    }
+
+    /**
      * Returns the magnitude of the specified 4-dimensional vector.
      *
      * @returns {number} The magnitude of the specified 4-dimensional vector.

--- a/test/core/math/quat.test.mjs
+++ b/test/core/math/quat.test.mjs
@@ -95,7 +95,7 @@ describe('Quat', function () {
             expect(q1.equals(q2)).to.be.false;
         });
 
-        it('checks for equality of two different quaternions that are close enough', function () {
+        it('checks for equality of different quaternions that are close enough', function () {
             const q1 = new Quat(0.1, 0.2, 0.3, 0.4);
             const q2 = new Quat(0.10000000000000001, 0.2, 0.3, 0.4);
             const epsilon = 0.000001;

--- a/test/core/math/vec2.test.mjs
+++ b/test/core/math/vec2.test.mjs
@@ -243,6 +243,20 @@ describe('Vec2', function () {
             expect(v1.equals(v2)).to.be.false;
         });
 
+        it('checks for equality of different vectors that are close enough', function () {
+            const v1 = new Vec2(0.1, 0.2);
+            const v2 = new Vec2(0.10000000000000001, 0.2);
+            const epsilon = 0.000001;
+            expect(v1.equalsApprox(v2, epsilon)).to.be.true;
+            expect(v1.equalsApprox(v2)).to.be.true;
+
+            const v3 = new Vec2(0.1 + epsilon - Number.EPSILON, 0.2);
+            expect(v1.equalsApprox(v3, epsilon)).to.be.true;
+
+            const v4 = new Vec2(0.1 + epsilon + Number.EPSILON, 0.2);
+            expect(v1.equalsApprox(v4, epsilon)).to.be.false;
+        });
+
     });
 
     describe('#floor', function () {

--- a/test/core/math/vec3.test.mjs
+++ b/test/core/math/vec3.test.mjs
@@ -282,6 +282,20 @@ describe('Vec3', function () {
             expect(v1.equals(v2)).to.be.false;
         });
 
+        it('checks for equality of different vectors that are close enough', function () {
+            const v1 = new Vec3(0.1, 0.2, 0.3);
+            const v2 = new Vec3(0.10000000000000001, 0.2, 0.3);
+            const epsilon = 0.000001;
+            expect(v1.equalsApprox(v2, epsilon)).to.be.true;
+            expect(v1.equalsApprox(v2)).to.be.true;
+
+            const v3 = new Vec3(0.1 + epsilon - Number.EPSILON, 0.2, 0.3);
+            expect(v1.equalsApprox(v3, epsilon)).to.be.true;
+
+            const v4 = new Vec3(0.1 + epsilon + Number.EPSILON, 0.2, 0.3);
+            expect(v1.equalsApprox(v4, epsilon)).to.be.false;
+        });
+
     });
 
     describe('#floor', function () {

--- a/test/core/math/vec4.test.mjs
+++ b/test/core/math/vec4.test.mjs
@@ -252,6 +252,20 @@ describe('Vec4', function () {
             expect(v1.equals(v2)).to.be.false;
         });
 
+        it('checks for equality of different vectors that are close enough', function () {
+            const v1 = new Vec4(0.1, 0.2, 0.3, 0.4);
+            const v2 = new Vec4(0.10000000000000001, 0.2, 0.3, 0.4);
+            const epsilon = 0.000001;
+            expect(v1.equalsApprox(v2, epsilon)).to.be.true;
+            expect(v1.equalsApprox(v2)).to.be.true;
+
+            const v3 = new Vec4(0.1 + epsilon - Number.EPSILON, 0.2, 0.3, 0.4);
+            expect(v1.equalsApprox(v3, epsilon)).to.be.true;
+
+            const v4 = new Vec4(0.1 + epsilon + Number.EPSILON, 0.2, 0.3, 0.4);
+            expect(v1.equalsApprox(v4, epsilon)).to.be.false;
+        });
+
     });
 
     describe('#floor', function () {


### PR DESCRIPTION
The PR adds equalsApprox to vec2, vec3, vec4 and fixes the 4 point of [this review comment](https://github.com/playcanvas/engine/pull/5145#issuecomment-1465164912)

> No other math class (like Vec3) offers the capability either

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
