### PR TITLE
Update mesh.js

### DIFF
--- a/src/scene/mesh.js
+++ b/src/scene/mesh.js
@@ -723,7 +723,7 @@ class Mesh extends RefCountedObject {
             } else {
                 // destination data is array
                 indices.length = 0;
-                indices.push(streamIndices);
+                indices.push(...streamIndices);
             }
         } else {
             // get data from IndexBuffer


### PR DESCRIPTION
Fix bug in getIndices which incorrectly modifies an array to have an array in the first element instead of setting the array to the numbers.

Fixes #

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
