### PR TITLE
Handle null gl.getContextAttributes() when context is lost

### DIFF
--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -992,8 +992,8 @@ class WebglGraphicsDevice extends GraphicsDevice {
         this.maxPrecision = this.precision = this.getPrecision();
 
         const contextAttribs = gl.getContextAttributes();
-        this.supportsMsaa = contextAttribs.antialias;
-        this.supportsStencil = contextAttribs.stencil;
+        this.supportsMsaa = contextAttribs?.antialias ?? false;
+        this.supportsStencil = contextAttribs?.stencil ?? false;
 
         this.supportsInstancing = !!this.extInstancing;
 


### PR DESCRIPTION
I'm seeing this issue happen with iOS 17 devices where context is lost and gl.getContextAttributes() returns null. This change prevents a crash by handling the case where null is returned.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
