### PR TITLE
[Fix] Calling CameraComponent.onRemove when the entity with camera is destroyed

### DIFF
--- a/src/framework/components/camera/system.js
+++ b/src/framework/components/camera/system.js
@@ -144,6 +144,8 @@ class CameraComponentSystem extends ComponentSystem {
 
     onBeforeRemove(entity, component) {
         this.removeCamera(component);
+
+        component.onRemove();
     }
 
     onUpdate(dt) {


### PR DESCRIPTION
small fix, needed more in the follow up PR

This now matches the behaviour of LightComponent.onRemove.