### PR TITLE
Fallback Webgl1 solution for depth grab is replaced by a RenderPassDepth

### DIFF
--- a/src/framework/components/camera/component.js
+++ b/src/framework/components/camera/component.js
@@ -724,6 +724,8 @@ class CameraComponent extends Component {
         if (!ok) {
             Debug.warnOnce('CameraComponent.requestSceneDepthMap was called, but the camera does not have a Depth layer, ignoring.');
         }
+
+        this.camera._enableRenderPassDepthGrab(this.system.app.graphicsDevice, this.system.app.renderer, this.renderSceneDepthMap);
     }
 
     dirtyLayerCompositionCameras() {
@@ -882,6 +884,8 @@ class CameraComponent extends Component {
     onRemove() {
         this.onDisable();
         this.off();
+
+        this.camera.destroy();
     }
 
     /**

--- a/src/framework/graphics/render-pass-picker.js
+++ b/src/framework/graphics/render-pass-picker.js
@@ -5,6 +5,7 @@ import { RenderPass } from '../../platform/graphics/render-pass.js';
 import { SHADER_PICK } from '../../scene/constants.js';
 
 const tempMeshInstances = [];
+const lights = [[], [], []];
 
 /**
  * A render pass implementing rendering of mesh instances into a pick buffer.
@@ -50,8 +51,7 @@ class RenderPassPicker extends RenderPass {
             if (srcLayer.enabled && subLayerEnabled[i]) {
 
                 // if the layer is rendered by the camera
-                const layerCamId = srcLayer.cameras.indexOf(camera);
-                if (layerCamId >= 0) {
+                if (srcLayer.camerasSet.has(camera.camera)) {
 
                     // if the layer clears the depth
                     if (srcLayer._clearDepthBuffer) {
@@ -72,7 +72,6 @@ class RenderPassPicker extends RenderPass {
                         }
                     }
 
-                    const lights = [[], [], []];
                     renderer.renderForward(camera.camera, tempMeshInstances, lights, SHADER_PICK, (meshInstance) => {
                         const miId = meshInstance.id;
                         pickColor[0] = ((miId >> 16) & 0xff) / 255;

--- a/src/framework/lightmapper/lightmapper.js
+++ b/src/framework/lightmapper/lightmapper.js
@@ -120,6 +120,9 @@ class Lightmapper {
         this.scene = null;
         this.renderer = null;
         this.assets = null;
+
+        this.camera?.destroy();
+        this.camera = null;
     }
 
     initBake(device) {

--- a/src/platform/graphics/graphics-device.js
+++ b/src/platform/graphics/graphics-device.js
@@ -69,6 +69,22 @@ class GraphicsDevice extends EventHandler {
     isWebGPU = false;
 
     /**
+     * True if the deviceType is WebGL1
+     *
+     * @type {boolean}
+     * @readonly
+     */
+    isWebGl1 = false;
+
+    /**
+     * True if the deviceType is WebGL2
+     *
+     * @type {boolean}
+     * @readonly
+     */
+    isWebGl2 = false;
+
+    /**
      * The scope namespace for shader attributes and variables.
      *
      * @type {ScopeSpace}

--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -385,6 +385,8 @@ class WebglGraphicsDevice extends GraphicsDevice {
 
         this.gl = gl;
         this.webgl2 = typeof WebGL2RenderingContext !== 'undefined' && gl instanceof WebGL2RenderingContext;
+        this.isWebGl2 = this.webgl2;
+        this.isWebGl1 = !this.webgl2;
         this._deviceType = this.webgl2 ? DEVICETYPE_WEBGL2 : DEVICETYPE_WEBGL1;
 
         // pixel format of the framebuffer

--- a/src/scene/camera.js
+++ b/src/scene/camera.js
@@ -12,6 +12,7 @@ import {
     LAYERID_WORLD, LAYERID_DEPTH, LAYERID_SKYBOX, LAYERID_UI, LAYERID_IMMEDIATE
 } from './constants.js';
 import { RenderPassColorGrab } from './graphics/render-pass-color-grab.js';
+import { RenderPassDepth } from './graphics/render-pass-depth.js';
 
 // pre-allocated temp variables
 const _deviceCoord = new Vec3();
@@ -35,6 +36,11 @@ class Camera {
      * @type {RenderPassColorGrab|null}
      */
     renderPassColorGrab = null;
+
+    /**
+     * @type {RenderPassDepth|null}
+     */
+    renderPassDepthGrab = null;
 
     constructor() {
         this._aspectRatio = 16 / 9;
@@ -86,6 +92,15 @@ class Camera {
             farClip: this._farClip,
             nearClip: this._nearClip
         };
+    }
+
+    destroy() {
+
+        this.renderPassColorGrab?.destroy();
+        this.renderPassColorGrab = null;
+
+        this.renderPassDepthGrab?.destroy();
+        this.renderPassDepthGrab = null;
     }
 
     /**
@@ -435,6 +450,17 @@ class Camera {
         } else {
             this.renderPassColorGrab?.destroy();
             this.renderPassColorGrab = null;
+        }
+    }
+
+    _enableRenderPassDepthGrab(device, renderer, enable) {
+        if (enable) {
+            Debug.assert(!this.renderPassDepthGrab);
+            if (device.isWebGl1)
+                this.renderPassDepthGrab = new RenderPassDepth(device, renderer, this);
+        } else {
+            this.renderPassDepthGrab?.destroy();
+            this.renderPassDepthGrab = null;
         }
     }
 

--- a/src/scene/graphics/render-pass-depth.js
+++ b/src/scene/graphics/render-pass-depth.js
@@ -14,7 +14,7 @@ const lights = [[], [], []];
 const _depthUniformNames = ['uSceneDepthMap', 'uDepthMap'];
 
 /**
- * A render pass implementing rendering a depth. In current implementation, the depth is encoded in
+ * A render pass implementing rendering of depth. In current implementation, the depth is encoded in
  * RGBA8 texture, and is used on WebGL1 devices as a fallback for missing depth grab functionality.
  *
  * @ignore

--- a/src/scene/graphics/render-pass-depth.js
+++ b/src/scene/graphics/render-pass-depth.js
@@ -1,0 +1,164 @@
+import { Color } from "../../core/math/color.js";
+import { ADDRESS_CLAMP_TO_EDGE, FILTER_NEAREST, PIXELFORMAT_RGBA8 } from "../../platform/graphics/constants.js";
+import { Texture } from "../../platform/graphics/texture.js";
+import { RenderPass } from "../../platform/graphics/render-pass.js";
+import { BlendState } from "../../platform/graphics/blend-state.js";
+import { RenderTarget } from "../../platform/graphics/render-target.js";
+import { LAYERID_DEPTH, SHADER_DEPTH } from "../constants.js";
+
+const webgl1DepthClearColor = new Color(254.0 / 255, 254.0 / 255, 254.0 / 255, 254.0 / 255);
+const tempMeshInstances = [];
+const lights = [[], [], []];
+
+// uniform names (first is current name, second one is deprecated name for compatibility)
+const _depthUniformNames = ['uSceneDepthMap', 'uDepthMap'];
+
+/**
+ * A render pass implementing rendering a depth. In current implementation, the depth is encoded in
+ * RGBA8 texture, and is used on WebGL1 devices as a fallback for missing depth grab functionality.
+ *
+ * @ignore
+ */
+class RenderPassDepth extends RenderPass {
+    constructor(device, renderer, camera) {
+        super(device);
+        this.renderer = renderer;
+        this.camera = camera;
+    }
+
+    destroy() {
+        super.destroy();
+        this.releaseRenderTarget(this.renderTarget);
+    }
+
+    update(scene) {
+        this.scene = scene;
+    }
+
+    shouldReallocate(targetRT, sourceRT) {
+
+        // need to reallocate if dimensions don't match
+        const width = sourceRT.width;
+        const height = sourceRT.height;
+        return !targetRT || width !== targetRT.width || height !== targetRT.height;
+    }
+
+    allocateRenderTarget(renderTarget, sourceRT, device) {
+
+        // allocate texture buffer
+        const texture = new Texture(device, {
+            name: _depthUniformNames[0],
+            format: PIXELFORMAT_RGBA8,
+            width: sourceRT?.width ?? this.device.width,
+            height: sourceRT?.height ?? this.device.height,
+            mipmaps: false,
+            minFilter: FILTER_NEAREST,
+            magFilter: FILTER_NEAREST,
+            addressU: ADDRESS_CLAMP_TO_EDGE,
+            addressV: ADDRESS_CLAMP_TO_EDGE
+        });
+
+        if (renderTarget) {
+
+            // if reallocating RT size, release previous framebuffer
+            renderTarget.destroyFrameBuffers();
+
+            // assign new texture
+            renderTarget._colorBuffer = texture;
+            renderTarget._colorBuffers = [texture];
+
+        } else {
+
+            // create new render target with the texture
+            renderTarget = new RenderTarget({
+                name: `${_depthUniformNames[0]}RT}`,
+                colorBuffer: texture,
+                depth: true,
+                stencil: false
+            });
+        }
+
+        return renderTarget;
+    }
+
+    releaseRenderTarget(rt) {
+
+        if (rt) {
+            rt.destroyTextureBuffers();
+            rt.destroy();
+        }
+    }
+
+    before() {
+
+        const camera = this.camera;
+        const device = this.device;
+        const sourceRT = camera.renderTarget ?? device.backBuffer;
+
+        // reallocate RT if needed
+        if (this.shouldReallocate(this.renderTarget, sourceRT)) {
+            this.renderTarget?.destroyTextureBuffers();
+            const renderTarget = this.allocateRenderTarget(this.renderTarget, camera.renderTarget, device);
+
+            if (!this.renderTarget) {
+                this.init(renderTarget);
+
+                // webgl1 depth rendering clear values
+                this.setClearColor(webgl1DepthClearColor);
+                this.setClearDepth(1.0);
+
+            } else {
+                this.renderTarget = renderTarget;
+            }
+        }
+
+        // assign uniform
+        const colorBuffer = this.renderTarget.colorBuffer;
+        _depthUniformNames.forEach(name => device.scope.resolve(name).setValue(colorBuffer));
+    }
+
+    execute() {
+
+        const { device, renderer, camera, scene, renderTarget } = this;
+        const layers = scene.layers.layerList;
+        const subLayerEnabled = scene.layers.subLayerEnabled;
+        const isTransparent = scene.layers.subLayerList;
+
+        for (let i = 0; i < layers.length; i++) {
+            const layer = layers[i];
+
+            if (layer.enabled && subLayerEnabled[i]) {
+
+                // if the layer is rendered by the camera
+                if (layer.camerasSet.has(camera)) {
+
+                    // only render the layers before the depth layer
+                    if (layer.id === LAYERID_DEPTH)
+                        break;
+
+                    const culledInstances = layer.getCulledInstances(camera);
+                    const meshInstances = isTransparent[i] ? culledInstances.transparent : culledInstances.opaque;
+
+                    for (let j = 0; j < meshInstances.length; j++) {
+                        const meshInstance = meshInstances[j];
+
+                        // only collect meshes that update the depth
+                        if (meshInstance.material?.depthWrite && !meshInstance._noDepthDrawGl1) {
+                            tempMeshInstances.push(meshInstance);
+                        }
+                    }
+
+                    renderer.setCameraUniforms(camera, renderTarget);
+                    renderer.renderForward(camera, tempMeshInstances, lights, SHADER_DEPTH, (meshInstance) => {
+                        // writing depth to color render target, force no blending and writing to all channels
+                        device.setBlendState(BlendState.NOBLEND);
+                    }, layer);
+
+                    tempMeshInstances.length = 0;
+                }
+            }
+        }
+    }
+}
+
+export { RenderPassDepth };

--- a/src/scene/layer.js
+++ b/src/scene/layer.js
@@ -161,6 +161,12 @@ class Layer {
      */
     cameras = [];
 
+    /**
+     * @type {Set<import('./camera.js').Camera>}
+     * @ignore
+     */
+    camerasSet = new Set();
+
     _dirtyCameras = false;
 
     /**
@@ -841,9 +847,11 @@ class Layer {
      * {@link CameraComponent}.
      */
     addCamera(camera) {
-        if (this.cameras.indexOf(camera) >= 0) return;
-        this.cameras.push(camera);
-        this._dirtyCameras = true;
+        if (!this.camerasSet.has(camera.camera)) {
+            this.camerasSet.add(camera.camera);
+            this.cameras.push(camera);
+            this._dirtyCameras = true;
+        }
     }
 
     /**
@@ -853,8 +861,9 @@ class Layer {
      * {@link CameraComponent}.
      */
     removeCamera(camera) {
-        const index = this.cameras.indexOf(camera);
-        if (index >= 0) {
+        if (this.camerasSet.has(camera.camera)) {
+            this.camerasSet.delete(camera.camera);
+            const index = this.cameras.indexOf(camera);
             this.cameras.splice(index, 1);
             this._dirtyCameras = true;
         }
@@ -865,6 +874,7 @@ class Layer {
      */
     clearCameras() {
         this.cameras.length = 0;
+        this.camerasSet.clear();
         this._dirtyCameras = true;
     }
 

--- a/src/scene/renderer/renderer.js
+++ b/src/scene/renderer/renderer.js
@@ -401,11 +401,11 @@ class Renderer {
      *
      * @param {import('../camera.js').Camera} camera - The camera supplying the value to clear to.
      * @param {boolean} [clearColor] - True if the color buffer should be cleared. Uses the value
-     * from the camra if not supplied.
+     * from the camera if not supplied.
      * @param {boolean} [clearDepth] - True if the depth buffer should be cleared. Uses the value
-     * from the camra if not supplied.
+     * from the camera if not supplied.
      * @param {boolean} [clearStencil] - True if the stencil buffer should be cleared. Uses the
-     * value from the camra if not supplied.
+     * value from the camera if not supplied.
      */
     clear(camera, clearColor, clearDepth, clearStencil) {
 


### PR DESCRIPTION
For WebGL1, we no longer use a custom Depth layer with render target and some manual handling of visible mesh instances under the hood, but have a render pass that is scheduled to run before the camera's render pass to render the depth.

- The main camera's render pass is no longer split into two, saving performance
- This removes last warning of this type inside the engine: `DEPRECATED: pc.Layer#renderTarget`
- new RenderPassDepth will be extended in the future to provide depth rendering before the camera for other effects, such as https://github.com/playcanvas/engine/issues/4844

### New public API:
```
GraphicsDevice.isWebGL1
GraphicsDevice.isWebGL2
```

to match existing
```
GraphicsDevice.isWebGPU
```
