### PR TITLE
Fix the number of samples detection code for WebGL1

### DIFF
--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -417,7 +417,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
         this.initializeContextCaches();
 
         // handle anti-aliasing internally
-        this.samples = antialias ? 4 : 1;
+        this.samples = this.isWebGl2 && antialias ? 4 : 1;
         this.createBackbuffer(null);
 
         // only enable ImageBitmap on chrome


### PR DESCRIPTION
introduced very recently, related to refactoring of the backbuffer on webgl. Only used for logging on webgl1, so no real impact.

<img width="862" alt="Screenshot 2023-09-26 at 12 42 44" src="https://github.com/playcanvas/engine/assets/59932779/7d94aa94-334d-4a48-b7f7-ba54222adcd3">
