### PR TITLE
Deprecate device.webgl2 in favor of device.isWebGL2

### DIFF
--- a/examples/src/examples/graphics/transform-feedback.tsx
+++ b/examples/src/examples/graphics/transform-feedback.tsx
@@ -159,7 +159,7 @@ void main(void)
             const directionSampler = app.graphicsDevice.scope.resolve("directionSampler");
 
             // @ts-ignore engine-tsd
-            if (app.graphicsDevice.webgl2) {
+            if (app.graphicsDevice.isWebGl2) {
 
                 // simulated particles
                 const maxNumPoints = 200000;

--- a/examples/src/examples/graphics/transform-feedback.tsx
+++ b/examples/src/examples/graphics/transform-feedback.tsx
@@ -159,7 +159,7 @@ void main(void)
             const directionSampler = app.graphicsDevice.scope.resolve("directionSampler");
 
             // @ts-ignore engine-tsd
-            if (app.graphicsDevice.isWebGl2) {
+            if (app.graphicsDevice.isWebGL2) {
 
                 // simulated particles
                 const maxNumPoints = 200000;

--- a/scripts/posteffects/posteffect-ssao.js
+++ b/scripts/posteffects/posteffect-ssao.js
@@ -196,7 +196,7 @@ function SSAOEffect(graphicsDevice, ssaoScript) {
         "    float occlusion = 0.0;",
 
         // webgl1 does not handle non-constant loop, work around it
-        graphicsDevice.webgl2 ? (
+        graphicsDevice.isWebGl2 ? (
             "    for (float i = 0.0; i < uSampleCount.x; i += 1.0) {"
         ) : (
             "   const float maxSampleCount = 256.0;" +
@@ -290,7 +290,7 @@ function SSAOEffect(graphicsDevice, ssaoScript) {
         "",
 
         // webgl1 does not handle non-constant loop, work around it
-        graphicsDevice.webgl2 ? (
+        graphicsDevice.isWebGl2 ? (
             "    for (int x = -uBilatSampleCount; x <= uBilatSampleCount; x++) {" +
             "       for (int y = -uBilatSampleCount; y < uBilatSampleCount; y++) {"
         ) : (

--- a/scripts/posteffects/posteffect-ssao.js
+++ b/scripts/posteffects/posteffect-ssao.js
@@ -196,7 +196,7 @@ function SSAOEffect(graphicsDevice, ssaoScript) {
         "    float occlusion = 0.0;",
 
         // webgl1 does not handle non-constant loop, work around it
-        graphicsDevice.isWebGl2 ? (
+        graphicsDevice.isWebGL2 ? (
             "    for (float i = 0.0; i < uSampleCount.x; i += 1.0) {"
         ) : (
             "   const float maxSampleCount = 256.0;" +
@@ -290,7 +290,7 @@ function SSAOEffect(graphicsDevice, ssaoScript) {
         "",
 
         // webgl1 does not handle non-constant loop, work around it
-        graphicsDevice.isWebGl2 ? (
+        graphicsDevice.isWebGL2 ? (
             "    for (int x = -uBilatSampleCount; x <= uBilatSampleCount; x++) {" +
             "       for (int y = -uBilatSampleCount; y < uBilatSampleCount; y++) {"
         ) : (

--- a/src/deprecated/deprecated.js
+++ b/src/deprecated/deprecated.js
@@ -614,8 +614,8 @@ Object.defineProperties(Texture.prototype, {
 
 Object.defineProperty(GraphicsDevice.prototype, 'webgl2', {
     get: function () {
-        Debug.deprecated('pc.GraphicsDevice#webgl2 is deprecated, use pc.GraphicsDevice#isWebGl2 instead.');
-        return this.isWebGl2;
+        Debug.deprecated('pc.GraphicsDevice#webgl2 is deprecated, use pc.GraphicsDevice#isWebGL2 instead.');
+        return this.isWebGL2;
     }
 });
 

--- a/src/deprecated/deprecated.js
+++ b/src/deprecated/deprecated.js
@@ -612,6 +612,13 @@ Object.defineProperties(Texture.prototype, {
     }
 });
 
+Object.defineProperty(GraphicsDevice.prototype, 'webgl2', {
+    get: function () {
+        Debug.deprecated('pc.GraphicsDevice#webgl2 is deprecated, use pc.GraphicsDevice#isWebGl2 instead.');
+        return this.isWebGl2;
+    }
+});
+
 GraphicsDevice.prototype.getProgramLibrary = function () {
     Debug.deprecated(`pc.GraphicsDevice#getProgramLibrary is deprecated.`);
     return getProgramLibrary(this);

--- a/src/framework/handlers/basis.js
+++ b/src/framework/handlers/basis.js
@@ -334,7 +334,7 @@ function basisTranscode(device, url, data, callback, options) {
 
     if (!deviceDetails) {
         deviceDetails = {
-            webgl2: device.isWebGl2,
+            webgl2: device.isWebGL2,
             formats: getCompressionFormats(device)
         };
     }

--- a/src/framework/handlers/basis.js
+++ b/src/framework/handlers/basis.js
@@ -334,7 +334,7 @@ function basisTranscode(device, url, data, callback, options) {
 
     if (!deviceDetails) {
         deviceDetails = {
-            webgl2: device.webgl2,
+            webgl2: device.isWebGl2,
             formats: getCompressionFormats(device)
         };
     }

--- a/src/platform/graphics/graphics-device.js
+++ b/src/platform/graphics/graphics-device.js
@@ -74,7 +74,7 @@ class GraphicsDevice extends EventHandler {
      * @type {boolean}
      * @readonly
      */
-    isWebGl1 = false;
+    isWebGL1 = false;
 
     /**
      * True if the deviceType is WebGL2
@@ -82,7 +82,7 @@ class GraphicsDevice extends EventHandler {
      * @type {boolean}
      * @readonly
      */
-    isWebGl2 = false;
+    isWebGL2 = false;
 
     /**
      * The scope namespace for shader attributes and variables.

--- a/src/platform/graphics/shader-utils.js
+++ b/src/platform/graphics/shader-utils.js
@@ -60,7 +60,7 @@ class ShaderUtils {
         const getDefines = (gpu, gl2, gl1, isVertex) => {
 
             const deviceIntro = device.isWebGPU ? gpu :
-                (device.webgl2 ? gl2 : ShaderUtils.gl1Extensions(device, options) + gl1);
+                (device.isWebGl2 ? gl2 : ShaderUtils.gl1Extensions(device, options) + gl1);
 
             // a define per supported color attachment, which strips out unsupported output definitions in the deviceIntro
             let attachmentsDefine = '';
@@ -140,7 +140,7 @@ class ShaderUtils {
         if (device.isWebGPU) {
             return '#version 450\n';
         }
-        return device.webgl2 ? "#version 300 es\n" : "";
+        return device.isWebGl2 ? "#version 300 es\n" : "";
     }
 
     static precisionCode(device, forcePrecision) {
@@ -166,7 +166,7 @@ class ShaderUtils {
 
             code = `precision ${precision} float;\n`;
 
-            if (device.webgl2) {
+            if (device.isWebGl2) {
                 code += `precision ${precision} sampler2DShadow;\n`;
             }
 

--- a/src/platform/graphics/shader-utils.js
+++ b/src/platform/graphics/shader-utils.js
@@ -60,7 +60,7 @@ class ShaderUtils {
         const getDefines = (gpu, gl2, gl1, isVertex) => {
 
             const deviceIntro = device.isWebGPU ? gpu :
-                (device.isWebGl2 ? gl2 : ShaderUtils.gl1Extensions(device, options) + gl1);
+                (device.isWebGL2 ? gl2 : ShaderUtils.gl1Extensions(device, options) + gl1);
 
             // a define per supported color attachment, which strips out unsupported output definitions in the deviceIntro
             let attachmentsDefine = '';
@@ -140,7 +140,7 @@ class ShaderUtils {
         if (device.isWebGPU) {
             return '#version 450\n';
         }
-        return device.isWebGl2 ? "#version 300 es\n" : "";
+        return device.isWebGL2 ? "#version 300 es\n" : "";
     }
 
     static precisionCode(device, forcePrecision) {
@@ -166,7 +166,7 @@ class ShaderUtils {
 
             code = `precision ${precision} float;\n`;
 
-            if (device.isWebGl2) {
+            if (device.isWebGL2) {
                 code += `precision ${precision} sampler2DShadow;\n`;
             }
 

--- a/src/platform/graphics/shader.js
+++ b/src/platform/graphics/shader.js
@@ -95,7 +95,7 @@ class Shader {
 
         // pre-process shader sources
         definition.vshader = Preprocessor.run(definition.vshader);
-        definition.fshader = Preprocessor.run(definition.fshader, graphicsDevice.isWebGl2);
+        definition.fshader = Preprocessor.run(definition.fshader, graphicsDevice.isWebGL2);
 
         this.init();
 

--- a/src/platform/graphics/shader.js
+++ b/src/platform/graphics/shader.js
@@ -95,7 +95,7 @@ class Shader {
 
         // pre-process shader sources
         definition.vshader = Preprocessor.run(definition.vshader);
-        definition.fshader = Preprocessor.run(definition.fshader, graphicsDevice.webgl2);
+        definition.fshader = Preprocessor.run(definition.fshader, graphicsDevice.isWebGl2);
 
         this.init();
 

--- a/src/platform/graphics/transform-feedback.js
+++ b/src/platform/graphics/transform-feedback.js
@@ -10,7 +10,7 @@ import { ShaderUtils } from './shader-utils.js';
  * This object allows you to configure and use the transform feedback feature (WebGL2 only). How to
  * use:
  *
- * 1. First, check that you're on WebGL2, by looking at the `app.graphicsDevice.isWebGl2`` value.
+ * 1. First, check that you're on WebGL2, by looking at the `app.graphicsDevice.isWebGL2`` value.
  * 2. Define the outputs in your vertex shader. The syntax is `out vec3 out_vertex_position`,
  * note that there must be out_ in the name. You can then simply assign values to these outputs in
  * VS. The order and size of shader outputs must match the output buffer layout.
@@ -60,14 +60,14 @@ import { ShaderUtils } from './shader-utils.js';
  *     app.root.addChild(entity);
  *
  *     // if webgl2 is not supported, transform-feedback is not available
- *     if (!device.isWebGl2) return;
+ *     if (!device.isWebGL2) return;
  *     const inputBuffer = mesh.vertexBuffer;
  *     this.tf = new pc.TransformFeedback(inputBuffer);
  *     this.shader = pc.TransformFeedback.createShader(device, this.shaderCode.resource, "tfMoveUp");
  * };
  *
  * TransformExample.prototype.update = function(dt) {
- *     if (!this.app.graphicsDevice.isWebGl2) return;
+ *     if (!this.app.graphicsDevice.isWebGL2) return;
  *     this.tf.process(this.shader);
  * };
  * ```

--- a/src/platform/graphics/transform-feedback.js
+++ b/src/platform/graphics/transform-feedback.js
@@ -10,7 +10,7 @@ import { ShaderUtils } from './shader-utils.js';
  * This object allows you to configure and use the transform feedback feature (WebGL2 only). How to
  * use:
  *
- * 1. First, check that you're on WebGL2, by looking at the `app.graphicsDevice.webgl2`` value.
+ * 1. First, check that you're on WebGL2, by looking at the `app.graphicsDevice.isWebGl2`` value.
  * 2. Define the outputs in your vertex shader. The syntax is `out vec3 out_vertex_position`,
  * note that there must be out_ in the name. You can then simply assign values to these outputs in
  * VS. The order and size of shader outputs must match the output buffer layout.
@@ -60,14 +60,14 @@ import { ShaderUtils } from './shader-utils.js';
  *     app.root.addChild(entity);
  *
  *     // if webgl2 is not supported, transform-feedback is not available
- *     if (!device.webgl2) return;
+ *     if (!device.isWebGl2) return;
  *     const inputBuffer = mesh.vertexBuffer;
  *     this.tf = new pc.TransformFeedback(inputBuffer);
  *     this.shader = pc.TransformFeedback.createShader(device, this.shaderCode.resource, "tfMoveUp");
  * };
  *
  * TransformExample.prototype.update = function(dt) {
- *     if (!this.app.graphicsDevice.webgl2) return;
+ *     if (!this.app.graphicsDevice.isWebGl2) return;
  *     this.tf.process(this.shader);
  * };
  * ```

--- a/src/platform/graphics/webgl/webgl-buffer.js
+++ b/src/platform/graphics/webgl/webgl-buffer.js
@@ -42,7 +42,7 @@ class WebglBuffer {
                 glUsage = gl.STREAM_DRAW;
                 break;
             case BUFFER_GPUDYNAMIC:
-                glUsage = device.isWebGl2 ? gl.DYNAMIC_COPY : gl.STATIC_DRAW;
+                glUsage = device.isWebGL2 ? gl.DYNAMIC_COPY : gl.STATIC_DRAW;
                 break;
         }
 

--- a/src/platform/graphics/webgl/webgl-buffer.js
+++ b/src/platform/graphics/webgl/webgl-buffer.js
@@ -42,11 +42,7 @@ class WebglBuffer {
                 glUsage = gl.STREAM_DRAW;
                 break;
             case BUFFER_GPUDYNAMIC:
-                if (device.webgl2) {
-                    glUsage = gl.DYNAMIC_COPY;
-                } else {
-                    glUsage = gl.STATIC_DRAW;
-                }
+                glUsage = device.isWebGl2 ? gl.DYNAMIC_COPY : gl.STATIC_DRAW;
                 break;
         }
 

--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -375,9 +375,9 @@ class WebglGraphicsDevice extends GraphicsDevice {
         }
 
         this.gl = gl;
-        this.isWebGl2 = typeof WebGL2RenderingContext !== 'undefined' && gl instanceof WebGL2RenderingContext;
-        this.isWebGl1 = !this.isWebGl2;
-        this._deviceType = this.isWebGl2 ? DEVICETYPE_WEBGL2 : DEVICETYPE_WEBGL1;
+        this.isWebGL2 = typeof WebGL2RenderingContext !== 'undefined' && gl instanceof WebGL2RenderingContext;
+        this.isWebGL1 = !this.isWebGL2;
+        this._deviceType = this.isWebGL2 ? DEVICETYPE_WEBGL2 : DEVICETYPE_WEBGL1;
 
         // pixel format of the framebuffer
         const alphaBits = gl.getParameter(gl.ALPHA_BITS);
@@ -394,7 +394,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
         this._tempMacChromeBlitFramebufferWorkaround = isMac && isChrome && !options.alpha;
 
         // init polyfill for VAOs under webgl1
-        if (!this.isWebGl2) {
+        if (!this.isWebGL2) {
             setupVertexArrayObject(gl);
         }
 
@@ -407,7 +407,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
         this.initializeContextCaches();
 
         // handle anti-aliasing internally
-        this.samples = this.isWebGl2 && antialias ? 4 : 1;
+        this.samples = this.isWebGL2 && antialias ? 4 : 1;
         this.createBackbuffer(null);
 
         // only enable ImageBitmap on chrome
@@ -423,8 +423,8 @@ class WebglGraphicsDevice extends GraphicsDevice {
             gl.FUNC_ADD,
             gl.FUNC_SUBTRACT,
             gl.FUNC_REVERSE_SUBTRACT,
-            this.isWebGl2 ? gl.MIN : this.extBlendMinmax ? this.extBlendMinmax.MIN_EXT : gl.FUNC_ADD,
-            this.isWebGl2 ? gl.MAX : this.extBlendMinmax ? this.extBlendMinmax.MAX_EXT : gl.FUNC_ADD
+            this.isWebGL2 ? gl.MIN : this.extBlendMinmax ? this.extBlendMinmax.MIN_EXT : gl.FUNC_ADD,
+            this.isWebGL2 ? gl.MAX : this.extBlendMinmax ? this.extBlendMinmax.MAX_EXT : gl.FUNC_ADD
         ];
 
         this.glBlendFunctionColor = [
@@ -546,7 +546,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
         this.pcUniformType[gl.FLOAT_MAT4]   = UNIFORMTYPE_MAT4;
         this.pcUniformType[gl.SAMPLER_2D]   = UNIFORMTYPE_TEXTURE2D;
         this.pcUniformType[gl.SAMPLER_CUBE] = UNIFORMTYPE_TEXTURECUBE;
-        if (this.isWebGl2) {
+        if (this.isWebGL2) {
             this.pcUniformType[gl.SAMPLER_2D_SHADOW]   = UNIFORMTYPE_TEXTURE2D_SHADOW;
             this.pcUniformType[gl.SAMPLER_CUBE_SHADOW] = UNIFORMTYPE_TEXTURECUBE_SHADOW;
             this.pcUniformType[gl.SAMPLER_3D]          = UNIFORMTYPE_TEXTURE3D;
@@ -697,7 +697,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
         this.constantTexSource = this.scope.resolve("source");
 
         if (this.extTextureFloat) {
-            if (this.isWebGl2) {
+            if (this.isWebGL2) {
                 // In WebGL2 float texture renderability is dictated by the EXT_color_buffer_float extension
                 this.textureFloatRenderable = !!this.extColorBufferFloat;
             } else {
@@ -712,7 +712,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
         if (this.extColorBufferHalfFloat) {
             this.textureHalfFloatRenderable = !!this.extColorBufferHalfFloat;
         } else if (this.extTextureHalfFloat) {
-            if (this.isWebGl2) {
+            if (this.isWebGL2) {
                 // EXT_color_buffer_float should affect both float and halffloat formats
                 this.textureHalfFloatRenderable = !!this.extColorBufferFloat;
             } else {
@@ -724,7 +724,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
         }
 
         this.supportsMorphTargetTexturesCore = (this.maxPrecision === "highp" && this.maxVertexTextures >= 2);
-        this.supportsDepthShadow = this.isWebGl2;
+        this.supportsDepthShadow = this.isWebGL2;
 
         this._textureFloatHighPrecision = undefined;
         this._textureHalfFloatUpdatable = undefined;
@@ -753,7 +753,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
         super.destroy();
         const gl = this.gl;
 
-        if (this.isWebGl2 && this.feedback) {
+        if (this.isWebGL2 && this.feedback) {
             gl.deleteTransformFeedback(this.feedback);
         }
 
@@ -891,7 +891,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
     get extDisjointTimerQuery() {
         // lazy evaluation as this is not typically used
         if (!this._extDisjointTimerQuery) {
-            if (this.isWebGl2) {
+            if (this.isWebGL2) {
                 // Note that Firefox exposes EXT_disjoint_timer_query under WebGL2 rather than EXT_disjoint_timer_query_webgl2
                 this._extDisjointTimerQuery = this.getExtension('EXT_disjoint_timer_query_webgl2', 'EXT_disjoint_timer_query');
             }
@@ -909,7 +909,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
         this.supportedExtensions = gl.getSupportedExtensions() ?? [];
         this._extDisjointTimerQuery = null;
 
-        if (this.isWebGl2) {
+        if (this.isWebGL2) {
             this.extBlendMinmax = true;
             this.extDrawBuffers = true;
             this.drawBuffers = gl.drawBuffers.bind(gl);
@@ -998,7 +998,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
         this.maxVertexTextures = gl.getParameter(gl.MAX_VERTEX_TEXTURE_IMAGE_UNITS);
         this.vertexUniformsCount = gl.getParameter(gl.MAX_VERTEX_UNIFORM_VECTORS);
         this.fragmentUniformsCount = gl.getParameter(gl.MAX_FRAGMENT_UNIFORM_VECTORS);
-        if (this.isWebGl2) {
+        if (this.isWebGL2) {
             this.maxDrawBuffers = gl.getParameter(gl.MAX_DRAW_BUFFERS);
             this.maxColorAttachments = gl.getParameter(gl.MAX_COLOR_ATTACHMENTS);
             this.maxVolumeSize = gl.getParameter(gl.MAX_3D_TEXTURE_SIZE);
@@ -1034,13 +1034,13 @@ class WebglGraphicsDevice extends GraphicsDevice {
         this.maxAnisotropy = ext ? gl.getParameter(ext.MAX_TEXTURE_MAX_ANISOTROPY_EXT) : 1;
 
         this.samples = gl.getParameter(gl.SAMPLES);
-        this.maxSamples = this.isWebGl2 && !this.forceDisableMultisampling ? gl.getParameter(gl.MAX_SAMPLES) : 1;
+        this.maxSamples = this.isWebGL2 && !this.forceDisableMultisampling ? gl.getParameter(gl.MAX_SAMPLES) : 1;
 
         // Don't allow area lights on old android devices, they often fail to compile the shader, run it incorrectly or are very slow.
-        this.supportsAreaLights = this.isWebGl2 || !platform.android;
+        this.supportsAreaLights = this.isWebGL2 || !platform.android;
 
         // supports texture fetch instruction
-        this.supportsTextureFetch = this.isWebGl2;
+        this.supportsTextureFetch = this.isWebGL2;
 
         // Also do not allow them when we only have small number of texture units
         if (this.maxTextures <= 8) {
@@ -1095,7 +1095,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
 
         this.alphaToCoverage = false;
         this.raster = true;
-        if (this.isWebGl2) {
+        if (this.isWebGL2) {
             gl.disable(gl.SAMPLE_ALPHA_TO_COVERAGE);
             gl.disable(gl.RASTERIZER_DISCARD);
         }
@@ -1112,7 +1112,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
         this.clearStencil = 0;
         gl.clearStencil(0);
 
-        if (this.isWebGl2) {
+        if (this.isWebGL2) {
             gl.hint(gl.FRAGMENT_SHADER_DERIVATIVE_HINT, gl.NICEST);
         } else {
             if (this.extStandardDerivatives) {
@@ -1286,7 +1286,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
             source = null;
         }
 
-        if (!this.isWebGl2 && depth) {
+        if (!this.isWebGL2 && depth) {
             Debug.error("Depth is not copyable on WebGL 1.0");
             return false;
         }
@@ -1324,7 +1324,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
 
         DebugGraphics.pushGpuMarker(this, 'COPY-RT');
 
-        if (this.isWebGl2 && dest) {
+        if (this.isWebGL2 && dest) {
             const prevRt = this.renderTarget;
             this.renderTarget = dest;
             this.updateBegin();
@@ -1470,7 +1470,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
         if (target) {
 
             // invalidate buffers to stop them being written to on tiled architectures
-            if (this.isWebGl2) {
+            if (this.isWebGL2) {
                 invalidateAttachments.length = 0;
                 const gl = this.gl;
 
@@ -1506,7 +1506,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
 
             // resolve the color buffer (this resolves all MRT color buffers at once)
             if (renderPass.colorOps?.resolve) {
-                if (this.isWebGl2 && renderPass.samples > 1 && target.autoResolve) {
+                if (this.isWebGL2 && renderPass.samples > 1 && target.autoResolve) {
                     target.resolve(true, false);
                 }
             }
@@ -1516,7 +1516,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
                 const colorOps = renderPass.colorArrayOps[i];
                 if (colorOps.mipmaps) {
                     const colorBuffer = target._colorBuffers[i];
-                    if (colorBuffer && colorBuffer.impl._glTexture && colorBuffer.mipmaps && (colorBuffer.pot || this.isWebGl2)) {
+                    if (colorBuffer && colorBuffer.impl._glTexture && colorBuffer.mipmaps && (colorBuffer.pot || this.isWebGL2)) {
 
                         DebugGraphics.pushGpuMarker(this, `MIPS${i}`);
 
@@ -1601,13 +1601,13 @@ class WebglGraphicsDevice extends GraphicsDevice {
         const target = this.renderTarget;
         if (target && target !== this.backBuffer) {
             // Resolve MSAA if needed
-            if (this.isWebGl2 && target._samples > 1 && target.autoResolve) {
+            if (this.isWebGL2 && target._samples > 1 && target.autoResolve) {
                 target.resolve();
             }
 
             // If the active render target is auto-mipmapped, generate its mip chain
             const colorBuffer = target._colorBuffer;
-            if (colorBuffer && colorBuffer.impl._glTexture && colorBuffer.mipmaps && (colorBuffer.pot || this.isWebGl2)) {
+            if (colorBuffer && colorBuffer.impl._glTexture && colorBuffer.mipmaps && (colorBuffer.pot || this.isWebGL2)) {
                 // FIXME: if colorBuffer is a cubemap currently we're re-generating mipmaps after
                 // updating each face!
                 this.activeTexture(this.maxCombinedTextures - 1);
@@ -1718,7 +1718,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
 
         if (flags & 1) {
             let filter = texture._minFilter;
-            if ((!texture.pot && !this.isWebGl2) || !texture._mipmaps || (texture._compressed && texture._levels.length === 1)) {
+            if ((!texture.pot && !this.isWebGL2) || !texture._mipmaps || (texture._compressed && texture._levels.length === 1)) {
                 if (filter === FILTER_NEAREST_MIPMAP_NEAREST || filter === FILTER_NEAREST_MIPMAP_LINEAR) {
                     filter = FILTER_NEAREST;
                 } else if (filter === FILTER_LINEAR_MIPMAP_NEAREST || filter === FILTER_LINEAR_MIPMAP_LINEAR) {
@@ -1731,7 +1731,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
             gl.texParameteri(target, gl.TEXTURE_MAG_FILTER, this.glFilter[texture._magFilter]);
         }
         if (flags & 4) {
-            if (this.isWebGl2) {
+            if (this.isWebGL2) {
                 gl.texParameteri(target, gl.TEXTURE_WRAP_S, this.glAddress[texture._addressU]);
             } else {
                 // WebGL1 doesn't support all addressing modes with NPOT textures
@@ -1739,7 +1739,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
             }
         }
         if (flags & 8) {
-            if (this.isWebGl2) {
+            if (this.isWebGL2) {
                 gl.texParameteri(target, gl.TEXTURE_WRAP_T, this.glAddress[texture._addressV]);
             } else {
                 // WebGL1 doesn't support all addressing modes with NPOT textures
@@ -1747,17 +1747,17 @@ class WebglGraphicsDevice extends GraphicsDevice {
             }
         }
         if (flags & 16) {
-            if (this.isWebGl2) {
+            if (this.isWebGL2) {
                 gl.texParameteri(target, gl.TEXTURE_WRAP_R, this.glAddress[texture._addressW]);
             }
         }
         if (flags & 32) {
-            if (this.isWebGl2) {
+            if (this.isWebGL2) {
                 gl.texParameteri(target, gl.TEXTURE_COMPARE_MODE, texture._compareOnRead ? gl.COMPARE_REF_TO_TEXTURE : gl.NONE);
             }
         }
         if (flags & 64) {
-            if (this.isWebGl2) {
+            if (this.isWebGL2) {
                 gl.texParameteri(target, gl.TEXTURE_COMPARE_FUNC, this.glComparison[texture._compareFunc]);
             }
         }
@@ -2060,7 +2060,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
             }
         }
 
-        if (this.isWebGl2 && this.transformFeedbackBuffer) {
+        if (this.isWebGL2 && this.transformFeedbackBuffer) {
             // Enable TF, start writing to out buffer
             gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 0, this.transformFeedbackBuffer.impl.bufferId);
             gl.beginTransformFeedback(gl.POINTS);
@@ -2091,7 +2091,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
             }
         }
 
-        if (this.isWebGl2 && this.transformFeedbackBuffer) {
+        if (this.isWebGL2 && this.transformFeedbackBuffer) {
             // disable TF
             gl.endTransformFeedback();
             gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 0, null);
@@ -2226,7 +2226,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
     async readPixelsAsync(x, y, w, h, pixels) {
         const gl = this.gl;
 
-        if (!this.isWebGl2) {
+        if (!this.isWebGL2) {
             // async fences aren't supported on webgl1
             this.readPixels(x, y, w, h, pixels);
             return;
@@ -2281,7 +2281,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
      * @ignore
      */
     setAlphaToCoverage(state) {
-        if (this.isWebGl1) return;
+        if (this.isWebGL1) return;
         if (this.alphaToCoverage === state) return;
         this.alphaToCoverage = state;
 
@@ -2305,7 +2305,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
 
         this.transformFeedbackBuffer = tf;
 
-        if (this.isWebGl2) {
+        if (this.isWebGL2) {
             const gl = this.gl;
             if (tf) {
                 if (!this.feedback) {
@@ -2330,7 +2330,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
 
         this.raster = on;
 
-        if (this.isWebGl2) {
+        if (this.isWebGL2) {
             if (on) {
                 this.gl.disable(this.gl.RASTERIZER_DISCARD);
             } else {
@@ -2742,7 +2742,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
      */
     get textureHalfFloatUpdatable() {
         if (this._textureHalfFloatUpdatable === undefined) {
-            if (this.isWebGl2) {
+            if (this.isWebGL2) {
                 this._textureHalfFloatUpdatable = true;
             } else {
                 this._textureHalfFloatUpdatable = testTextureHalfFloatUpdatable(this.gl, this.extTextureHalfFloat.HALF_FLOAT_OES);

--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -375,7 +375,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
         }
 
         this.gl = gl;
-        this.isWebGl2 = typeof WebGL2RenderingContext !== 'undefined' && gl instanceof WebGL2RenderingContext;;
+        this.isWebGl2 = typeof WebGL2RenderingContext !== 'undefined' && gl instanceof WebGL2RenderingContext;
         this.isWebGl1 = !this.isWebGl2;
         this._deviceType = this.isWebGl2 ? DEVICETYPE_WEBGL2 : DEVICETYPE_WEBGL1;
 

--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -262,15 +262,6 @@ class WebglGraphicsDevice extends GraphicsDevice {
     gl;
 
     /**
-     * True if the WebGL context of this device is using the WebGL 2.0 API. If false, WebGL 1.0 is
-     * being used.
-     *
-     * @type {boolean}
-     * @ignore
-     */
-    webgl2;
-
-    /**
      * WebGLFramebuffer object that represents the backbuffer of the device for a rendering frame.
      * When null, this is a framebuffer created when the device was created, otherwise it is a
      * framebuffer supplied by the XR session.
@@ -384,10 +375,9 @@ class WebglGraphicsDevice extends GraphicsDevice {
         }
 
         this.gl = gl;
-        this.webgl2 = typeof WebGL2RenderingContext !== 'undefined' && gl instanceof WebGL2RenderingContext;
-        this.isWebGl2 = this.webgl2;
-        this.isWebGl1 = !this.webgl2;
-        this._deviceType = this.webgl2 ? DEVICETYPE_WEBGL2 : DEVICETYPE_WEBGL1;
+        this.isWebGl2 = typeof WebGL2RenderingContext !== 'undefined' && gl instanceof WebGL2RenderingContext;;
+        this.isWebGl1 = !this.isWebGl2;
+        this._deviceType = this.isWebGl2 ? DEVICETYPE_WEBGL2 : DEVICETYPE_WEBGL1;
 
         // pixel format of the framebuffer
         const alphaBits = gl.getParameter(gl.ALPHA_BITS);
@@ -404,7 +394,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
         this._tempMacChromeBlitFramebufferWorkaround = isMac && isChrome && !options.alpha;
 
         // init polyfill for VAOs under webgl1
-        if (!this.webgl2) {
+        if (!this.isWebGl2) {
             setupVertexArrayObject(gl);
         }
 
@@ -433,8 +423,8 @@ class WebglGraphicsDevice extends GraphicsDevice {
             gl.FUNC_ADD,
             gl.FUNC_SUBTRACT,
             gl.FUNC_REVERSE_SUBTRACT,
-            this.webgl2 ? gl.MIN : this.extBlendMinmax ? this.extBlendMinmax.MIN_EXT : gl.FUNC_ADD,
-            this.webgl2 ? gl.MAX : this.extBlendMinmax ? this.extBlendMinmax.MAX_EXT : gl.FUNC_ADD
+            this.isWebGl2 ? gl.MIN : this.extBlendMinmax ? this.extBlendMinmax.MIN_EXT : gl.FUNC_ADD,
+            this.isWebGl2 ? gl.MAX : this.extBlendMinmax ? this.extBlendMinmax.MAX_EXT : gl.FUNC_ADD
         ];
 
         this.glBlendFunctionColor = [
@@ -556,7 +546,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
         this.pcUniformType[gl.FLOAT_MAT4]   = UNIFORMTYPE_MAT4;
         this.pcUniformType[gl.SAMPLER_2D]   = UNIFORMTYPE_TEXTURE2D;
         this.pcUniformType[gl.SAMPLER_CUBE] = UNIFORMTYPE_TEXTURECUBE;
-        if (this.webgl2) {
+        if (this.isWebGl2) {
             this.pcUniformType[gl.SAMPLER_2D_SHADOW]   = UNIFORMTYPE_TEXTURE2D_SHADOW;
             this.pcUniformType[gl.SAMPLER_CUBE_SHADOW] = UNIFORMTYPE_TEXTURECUBE_SHADOW;
             this.pcUniformType[gl.SAMPLER_3D]          = UNIFORMTYPE_TEXTURE3D;
@@ -707,7 +697,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
         this.constantTexSource = this.scope.resolve("source");
 
         if (this.extTextureFloat) {
-            if (this.webgl2) {
+            if (this.isWebGl2) {
                 // In WebGL2 float texture renderability is dictated by the EXT_color_buffer_float extension
                 this.textureFloatRenderable = !!this.extColorBufferFloat;
             } else {
@@ -722,7 +712,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
         if (this.extColorBufferHalfFloat) {
             this.textureHalfFloatRenderable = !!this.extColorBufferHalfFloat;
         } else if (this.extTextureHalfFloat) {
-            if (this.webgl2) {
+            if (this.isWebGl2) {
                 // EXT_color_buffer_float should affect both float and halffloat formats
                 this.textureHalfFloatRenderable = !!this.extColorBufferFloat;
             } else {
@@ -734,7 +724,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
         }
 
         this.supportsMorphTargetTexturesCore = (this.maxPrecision === "highp" && this.maxVertexTextures >= 2);
-        this.supportsDepthShadow = this.webgl2;
+        this.supportsDepthShadow = this.isWebGl2;
 
         this._textureFloatHighPrecision = undefined;
         this._textureHalfFloatUpdatable = undefined;
@@ -763,7 +753,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
         super.destroy();
         const gl = this.gl;
 
-        if (this.webgl2 && this.feedback) {
+        if (this.isWebGl2 && this.feedback) {
             gl.deleteTransformFeedback(this.feedback);
         }
 
@@ -901,7 +891,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
     get extDisjointTimerQuery() {
         // lazy evaluation as this is not typically used
         if (!this._extDisjointTimerQuery) {
-            if (this.webgl2) {
+            if (this.isWebGl2) {
                 // Note that Firefox exposes EXT_disjoint_timer_query under WebGL2 rather than EXT_disjoint_timer_query_webgl2
                 this._extDisjointTimerQuery = this.getExtension('EXT_disjoint_timer_query_webgl2', 'EXT_disjoint_timer_query');
             }
@@ -919,7 +909,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
         this.supportedExtensions = gl.getSupportedExtensions() ?? [];
         this._extDisjointTimerQuery = null;
 
-        if (this.webgl2) {
+        if (this.isWebGl2) {
             this.extBlendMinmax = true;
             this.extDrawBuffers = true;
             this.drawBuffers = gl.drawBuffers.bind(gl);
@@ -1008,7 +998,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
         this.maxVertexTextures = gl.getParameter(gl.MAX_VERTEX_TEXTURE_IMAGE_UNITS);
         this.vertexUniformsCount = gl.getParameter(gl.MAX_VERTEX_UNIFORM_VECTORS);
         this.fragmentUniformsCount = gl.getParameter(gl.MAX_FRAGMENT_UNIFORM_VECTORS);
-        if (this.webgl2) {
+        if (this.isWebGl2) {
             this.maxDrawBuffers = gl.getParameter(gl.MAX_DRAW_BUFFERS);
             this.maxColorAttachments = gl.getParameter(gl.MAX_COLOR_ATTACHMENTS);
             this.maxVolumeSize = gl.getParameter(gl.MAX_3D_TEXTURE_SIZE);
@@ -1044,13 +1034,13 @@ class WebglGraphicsDevice extends GraphicsDevice {
         this.maxAnisotropy = ext ? gl.getParameter(ext.MAX_TEXTURE_MAX_ANISOTROPY_EXT) : 1;
 
         this.samples = gl.getParameter(gl.SAMPLES);
-        this.maxSamples = this.webgl2 && !this.forceDisableMultisampling ? gl.getParameter(gl.MAX_SAMPLES) : 1;
+        this.maxSamples = this.isWebGl2 && !this.forceDisableMultisampling ? gl.getParameter(gl.MAX_SAMPLES) : 1;
 
         // Don't allow area lights on old android devices, they often fail to compile the shader, run it incorrectly or are very slow.
-        this.supportsAreaLights = this.webgl2 || !platform.android;
+        this.supportsAreaLights = this.isWebGl2 || !platform.android;
 
         // supports texture fetch instruction
-        this.supportsTextureFetch = this.webgl2;
+        this.supportsTextureFetch = this.isWebGl2;
 
         // Also do not allow them when we only have small number of texture units
         if (this.maxTextures <= 8) {
@@ -1105,7 +1095,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
 
         this.alphaToCoverage = false;
         this.raster = true;
-        if (this.webgl2) {
+        if (this.isWebGl2) {
             gl.disable(gl.SAMPLE_ALPHA_TO_COVERAGE);
             gl.disable(gl.RASTERIZER_DISCARD);
         }
@@ -1122,7 +1112,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
         this.clearStencil = 0;
         gl.clearStencil(0);
 
-        if (this.webgl2) {
+        if (this.isWebGl2) {
             gl.hint(gl.FRAGMENT_SHADER_DERIVATIVE_HINT, gl.NICEST);
         } else {
             if (this.extStandardDerivatives) {
@@ -1296,7 +1286,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
             source = null;
         }
 
-        if (!this.webgl2 && depth) {
+        if (!this.isWebGl2 && depth) {
             Debug.error("Depth is not copyable on WebGL 1.0");
             return false;
         }
@@ -1334,7 +1324,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
 
         DebugGraphics.pushGpuMarker(this, 'COPY-RT');
 
-        if (this.webgl2 && dest) {
+        if (this.isWebGl2 && dest) {
             const prevRt = this.renderTarget;
             this.renderTarget = dest;
             this.updateBegin();
@@ -1480,7 +1470,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
         if (target) {
 
             // invalidate buffers to stop them being written to on tiled architectures
-            if (this.webgl2) {
+            if (this.isWebGl2) {
                 invalidateAttachments.length = 0;
                 const gl = this.gl;
 
@@ -1516,7 +1506,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
 
             // resolve the color buffer (this resolves all MRT color buffers at once)
             if (renderPass.colorOps?.resolve) {
-                if (this.webgl2 && renderPass.samples > 1 && target.autoResolve) {
+                if (this.isWebGl2 && renderPass.samples > 1 && target.autoResolve) {
                     target.resolve(true, false);
                 }
             }
@@ -1526,7 +1516,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
                 const colorOps = renderPass.colorArrayOps[i];
                 if (colorOps.mipmaps) {
                     const colorBuffer = target._colorBuffers[i];
-                    if (colorBuffer && colorBuffer.impl._glTexture && colorBuffer.mipmaps && (colorBuffer.pot || this.webgl2)) {
+                    if (colorBuffer && colorBuffer.impl._glTexture && colorBuffer.mipmaps && (colorBuffer.pot || this.isWebGl2)) {
 
                         DebugGraphics.pushGpuMarker(this, `MIPS${i}`);
 
@@ -1611,13 +1601,13 @@ class WebglGraphicsDevice extends GraphicsDevice {
         const target = this.renderTarget;
         if (target && target !== this.backBuffer) {
             // Resolve MSAA if needed
-            if (this.webgl2 && target._samples > 1 && target.autoResolve) {
+            if (this.isWebGl2 && target._samples > 1 && target.autoResolve) {
                 target.resolve();
             }
 
             // If the active render target is auto-mipmapped, generate its mip chain
             const colorBuffer = target._colorBuffer;
-            if (colorBuffer && colorBuffer.impl._glTexture && colorBuffer.mipmaps && (colorBuffer.pot || this.webgl2)) {
+            if (colorBuffer && colorBuffer.impl._glTexture && colorBuffer.mipmaps && (colorBuffer.pot || this.isWebGl2)) {
                 // FIXME: if colorBuffer is a cubemap currently we're re-generating mipmaps after
                 // updating each face!
                 this.activeTexture(this.maxCombinedTextures - 1);
@@ -1728,7 +1718,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
 
         if (flags & 1) {
             let filter = texture._minFilter;
-            if ((!texture.pot && !this.webgl2) || !texture._mipmaps || (texture._compressed && texture._levels.length === 1)) {
+            if ((!texture.pot && !this.isWebGl2) || !texture._mipmaps || (texture._compressed && texture._levels.length === 1)) {
                 if (filter === FILTER_NEAREST_MIPMAP_NEAREST || filter === FILTER_NEAREST_MIPMAP_LINEAR) {
                     filter = FILTER_NEAREST;
                 } else if (filter === FILTER_LINEAR_MIPMAP_NEAREST || filter === FILTER_LINEAR_MIPMAP_LINEAR) {
@@ -1741,7 +1731,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
             gl.texParameteri(target, gl.TEXTURE_MAG_FILTER, this.glFilter[texture._magFilter]);
         }
         if (flags & 4) {
-            if (this.webgl2) {
+            if (this.isWebGl2) {
                 gl.texParameteri(target, gl.TEXTURE_WRAP_S, this.glAddress[texture._addressU]);
             } else {
                 // WebGL1 doesn't support all addressing modes with NPOT textures
@@ -1749,7 +1739,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
             }
         }
         if (flags & 8) {
-            if (this.webgl2) {
+            if (this.isWebGl2) {
                 gl.texParameteri(target, gl.TEXTURE_WRAP_T, this.glAddress[texture._addressV]);
             } else {
                 // WebGL1 doesn't support all addressing modes with NPOT textures
@@ -1757,17 +1747,17 @@ class WebglGraphicsDevice extends GraphicsDevice {
             }
         }
         if (flags & 16) {
-            if (this.webgl2) {
+            if (this.isWebGl2) {
                 gl.texParameteri(target, gl.TEXTURE_WRAP_R, this.glAddress[texture._addressW]);
             }
         }
         if (flags & 32) {
-            if (this.webgl2) {
+            if (this.isWebGl2) {
                 gl.texParameteri(target, gl.TEXTURE_COMPARE_MODE, texture._compareOnRead ? gl.COMPARE_REF_TO_TEXTURE : gl.NONE);
             }
         }
         if (flags & 64) {
-            if (this.webgl2) {
+            if (this.isWebGl2) {
                 gl.texParameteri(target, gl.TEXTURE_COMPARE_FUNC, this.glComparison[texture._compareFunc]);
             }
         }
@@ -2070,7 +2060,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
             }
         }
 
-        if (this.webgl2 && this.transformFeedbackBuffer) {
+        if (this.isWebGl2 && this.transformFeedbackBuffer) {
             // Enable TF, start writing to out buffer
             gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 0, this.transformFeedbackBuffer.impl.bufferId);
             gl.beginTransformFeedback(gl.POINTS);
@@ -2101,7 +2091,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
             }
         }
 
-        if (this.webgl2 && this.transformFeedbackBuffer) {
+        if (this.isWebGl2 && this.transformFeedbackBuffer) {
             // disable TF
             gl.endTransformFeedback();
             gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 0, null);
@@ -2236,7 +2226,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
     async readPixelsAsync(x, y, w, h, pixels) {
         const gl = this.gl;
 
-        if (!this.webgl2) {
+        if (!this.isWebGl2) {
             // async fences aren't supported on webgl1
             this.readPixels(x, y, w, h, pixels);
             return;
@@ -2291,7 +2281,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
      * @ignore
      */
     setAlphaToCoverage(state) {
-        if (!this.webgl2) return;
+        if (this.isWebGl1) return;
         if (this.alphaToCoverage === state) return;
         this.alphaToCoverage = state;
 
@@ -2315,7 +2305,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
 
         this.transformFeedbackBuffer = tf;
 
-        if (this.webgl2) {
+        if (this.isWebGl2) {
             const gl = this.gl;
             if (tf) {
                 if (!this.feedback) {
@@ -2340,7 +2330,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
 
         this.raster = on;
 
-        if (this.webgl2) {
+        if (this.isWebGl2) {
             if (on) {
                 this.gl.disable(this.gl.RASTERIZER_DISCARD);
             } else {
@@ -2752,7 +2742,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
      */
     get textureHalfFloatUpdatable() {
         if (this._textureHalfFloatUpdatable === undefined) {
-            if (this.webgl2) {
+            if (this.isWebGl2) {
                 this._textureHalfFloatUpdatable = true;
             } else {
                 this._textureHalfFloatUpdatable = testTextureHalfFloatUpdatable(this.gl, this.extTextureHalfFloat.HALF_FLOAT_OES);

--- a/src/platform/graphics/webgl/webgl-render-target.js
+++ b/src/platform/graphics/webgl/webgl-render-target.js
@@ -122,7 +122,7 @@ class WebglRenderTarget {
 
             // --- Init the provided color buffer (optional) ---
             const colorBufferCount = target._colorBuffers?.length ?? 0;
-            const attachmentBaseConstant = device.webgl2 ? gl.COLOR_ATTACHMENT0 : (device.extDrawBuffers?.COLOR_ATTACHMENT0_WEBGL ?? gl.COLOR_ATTACHMENT0);
+            const attachmentBaseConstant = device.isWebGl2 ? gl.COLOR_ATTACHMENT0 : (device.extDrawBuffers?.COLOR_ATTACHMENT0_WEBGL ?? gl.COLOR_ATTACHMENT0);
             for (let i = 0; i < colorBufferCount; ++i) {
                 const colorBuffer = target.getColorBuffer(i);
                 if (colorBuffer) {
@@ -171,7 +171,7 @@ class WebglRenderTarget {
             } else if (target._depth) {
                 // --- Init a new depth/stencil buffer (optional) ---
                 // if device is a MSAA RT, and no buffer to resolve to, skip creating non-MSAA depth
-                const willRenderMsaa = target._samples > 1 && device.webgl2;
+                const willRenderMsaa = target._samples > 1 && device.isWebGl2;
                 if (!willRenderMsaa) {
                     if (!this._glDepthBuffer) {
                         this._glDepthBuffer = gl.createRenderbuffer();
@@ -181,7 +181,7 @@ class WebglRenderTarget {
                         gl.renderbufferStorage(gl.RENDERBUFFER, gl.DEPTH_STENCIL, target.width, target.height);
                         gl.framebufferRenderbuffer(gl.FRAMEBUFFER, gl.DEPTH_STENCIL_ATTACHMENT, gl.RENDERBUFFER, this._glDepthBuffer);
                     } else {
-                        const depthFormat = device.webgl2 ? gl.DEPTH_COMPONENT32F : gl.DEPTH_COMPONENT16;
+                        const depthFormat = device.isWebGl2 ? gl.DEPTH_COMPONENT32F : gl.DEPTH_COMPONENT16;
                         gl.renderbufferStorage(gl.RENDERBUFFER, depthFormat, target.width, target.height);
                         gl.framebufferRenderbuffer(gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT, gl.RENDERBUFFER, this._glDepthBuffer);
                     }
@@ -193,7 +193,7 @@ class WebglRenderTarget {
         }
 
         // ##### Create MSAA FBO (WebGL2 only) #####
-        if (device.webgl2 && target._samples > 1) {
+        if (device.isWebGl2 && target._samples > 1) {
 
             // Use previous FBO for resolves
             this._glResolveFrameBuffer = this._glFrameBuffer;
@@ -347,7 +347,7 @@ class WebglRenderTarget {
     }
 
     resolve(device, target, color, depth) {
-        if (device.webgl2) {
+        if (device.isWebGl2) {
 
             const gl = device.gl;
 

--- a/src/platform/graphics/webgl/webgl-render-target.js
+++ b/src/platform/graphics/webgl/webgl-render-target.js
@@ -122,7 +122,7 @@ class WebglRenderTarget {
 
             // --- Init the provided color buffer (optional) ---
             const colorBufferCount = target._colorBuffers?.length ?? 0;
-            const attachmentBaseConstant = device.isWebGl2 ? gl.COLOR_ATTACHMENT0 : (device.extDrawBuffers?.COLOR_ATTACHMENT0_WEBGL ?? gl.COLOR_ATTACHMENT0);
+            const attachmentBaseConstant = device.isWebGL2 ? gl.COLOR_ATTACHMENT0 : (device.extDrawBuffers?.COLOR_ATTACHMENT0_WEBGL ?? gl.COLOR_ATTACHMENT0);
             for (let i = 0; i < colorBufferCount; ++i) {
                 const colorBuffer = target.getColorBuffer(i);
                 if (colorBuffer) {
@@ -171,7 +171,7 @@ class WebglRenderTarget {
             } else if (target._depth) {
                 // --- Init a new depth/stencil buffer (optional) ---
                 // if device is a MSAA RT, and no buffer to resolve to, skip creating non-MSAA depth
-                const willRenderMsaa = target._samples > 1 && device.isWebGl2;
+                const willRenderMsaa = target._samples > 1 && device.isWebGL2;
                 if (!willRenderMsaa) {
                     if (!this._glDepthBuffer) {
                         this._glDepthBuffer = gl.createRenderbuffer();
@@ -181,7 +181,7 @@ class WebglRenderTarget {
                         gl.renderbufferStorage(gl.RENDERBUFFER, gl.DEPTH_STENCIL, target.width, target.height);
                         gl.framebufferRenderbuffer(gl.FRAMEBUFFER, gl.DEPTH_STENCIL_ATTACHMENT, gl.RENDERBUFFER, this._glDepthBuffer);
                     } else {
-                        const depthFormat = device.isWebGl2 ? gl.DEPTH_COMPONENT32F : gl.DEPTH_COMPONENT16;
+                        const depthFormat = device.isWebGL2 ? gl.DEPTH_COMPONENT32F : gl.DEPTH_COMPONENT16;
                         gl.renderbufferStorage(gl.RENDERBUFFER, depthFormat, target.width, target.height);
                         gl.framebufferRenderbuffer(gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT, gl.RENDERBUFFER, this._glDepthBuffer);
                     }
@@ -193,7 +193,7 @@ class WebglRenderTarget {
         }
 
         // ##### Create MSAA FBO (WebGL2 only) #####
-        if (device.isWebGl2 && target._samples > 1) {
+        if (device.isWebGL2 && target._samples > 1) {
 
             // Use previous FBO for resolves
             this._glResolveFrameBuffer = this._glFrameBuffer;
@@ -347,7 +347,7 @@ class WebglRenderTarget {
     }
 
     resolve(device, target, color, depth) {
-        if (device.isWebGl2) {
+        if (device.isWebGL2) {
 
             const gl = device.gl;
 

--- a/src/platform/graphics/webgl/webgl-shader.js
+++ b/src/platform/graphics/webgl/webgl-shader.js
@@ -169,7 +169,7 @@ class WebglShader {
 
         const definition = shader.definition;
         const attrs = definition.attributes;
-        if (device.isWebGl2 && definition.useTransformFeedback) {
+        if (device.isWebGL2 && definition.useTransformFeedback) {
             // Collect all "out_" attributes and use them for output
             const outNames = [];
             for (const attr in attrs) {
@@ -363,7 +363,7 @@ class WebglShader {
             const shaderInput = new WebglShaderInput(device, info.name, device.pcUniformType[info.type], location);
 
             if (info.type === gl.SAMPLER_2D || info.type === gl.SAMPLER_CUBE ||
-                (device.isWebGl2 && (info.type === gl.SAMPLER_2D_SHADOW || info.type === gl.SAMPLER_CUBE_SHADOW || info.type === gl.SAMPLER_3D))
+                (device.isWebGL2 && (info.type === gl.SAMPLER_2D_SHADOW || info.type === gl.SAMPLER_CUBE_SHADOW || info.type === gl.SAMPLER_3D))
             ) {
                 this.samplers.push(shaderInput);
             } else {

--- a/src/platform/graphics/webgl/webgl-shader.js
+++ b/src/platform/graphics/webgl/webgl-shader.js
@@ -169,7 +169,7 @@ class WebglShader {
 
         const definition = shader.definition;
         const attrs = definition.attributes;
-        if (device.webgl2 && definition.useTransformFeedback) {
+        if (device.isWebGl2 && definition.useTransformFeedback) {
             // Collect all "out_" attributes and use them for output
             const outNames = [];
             for (const attr in attrs) {
@@ -363,7 +363,7 @@ class WebglShader {
             const shaderInput = new WebglShaderInput(device, info.name, device.pcUniformType[info.type], location);
 
             if (info.type === gl.SAMPLER_2D || info.type === gl.SAMPLER_CUBE ||
-                (device.webgl2 && (info.type === gl.SAMPLER_2D_SHADOW || info.type === gl.SAMPLER_CUBE_SHADOW || info.type === gl.SAMPLER_3D))
+                (device.isWebGl2 && (info.type === gl.SAMPLER_2D_SHADOW || info.type === gl.SAMPLER_CUBE_SHADOW || info.type === gl.SAMPLER_3D))
             ) {
                 this.samplers.push(shaderInput);
             } else {

--- a/src/platform/graphics/webgl/webgl-texture.js
+++ b/src/platform/graphics/webgl/webgl-texture.js
@@ -130,12 +130,12 @@ class WebglTexture {
                 break;
             case PIXELFORMAT_RGB8:
                 this._glFormat = gl.RGB;
-                this._glInternalFormat = device.webgl2 ? gl.RGB8 : gl.RGB;
+                this._glInternalFormat = device.isWebGl2 ? gl.RGB8 : gl.RGB;
                 this._glPixelType = gl.UNSIGNED_BYTE;
                 break;
             case PIXELFORMAT_RGBA8:
                 this._glFormat = gl.RGBA;
-                this._glInternalFormat = device.webgl2 ? gl.RGBA8 : gl.RGBA;
+                this._glInternalFormat = device.isWebGl2 ? gl.RGBA8 : gl.RGBA;
                 this._glPixelType = gl.UNSIGNED_BYTE;
                 break;
             case PIXELFORMAT_DXT1:
@@ -193,7 +193,7 @@ class WebglTexture {
             case PIXELFORMAT_RGB16F:
                 // definition varies between WebGL1 and 2
                 this._glFormat = gl.RGB;
-                if (device.webgl2) {
+                if (device.isWebGl2) {
                     this._glInternalFormat = gl.RGB16F;
                     this._glPixelType = gl.HALF_FLOAT;
                 } else {
@@ -204,7 +204,7 @@ class WebglTexture {
             case PIXELFORMAT_RGBA16F:
                 // definition varies between WebGL1 and 2
                 this._glFormat = gl.RGBA;
-                if (device.webgl2) {
+                if (device.isWebGl2) {
                     this._glInternalFormat = gl.RGBA16F;
                     this._glPixelType = gl.HALF_FLOAT;
                 } else {
@@ -215,7 +215,7 @@ class WebglTexture {
             case PIXELFORMAT_RGB32F:
                 // definition varies between WebGL1 and 2
                 this._glFormat = gl.RGB;
-                if (device.webgl2) {
+                if (device.isWebGl2) {
                     this._glInternalFormat = gl.RGB32F;
                 } else {
                     this._glInternalFormat = gl.RGB;
@@ -225,7 +225,7 @@ class WebglTexture {
             case PIXELFORMAT_RGBA32F:
                 // definition varies between WebGL1 and 2
                 this._glFormat = gl.RGBA;
-                if (device.webgl2) {
+                if (device.isWebGl2) {
                     this._glInternalFormat = gl.RGBA32F;
                 } else {
                     this._glInternalFormat = gl.RGBA;
@@ -238,7 +238,7 @@ class WebglTexture {
                 this._glPixelType = gl.FLOAT;
                 break;
             case PIXELFORMAT_DEPTH:
-                if (device.webgl2) {
+                if (device.isWebGl2) {
                     // native WebGL2
                     this._glFormat = gl.DEPTH_COMPONENT;
                     this._glInternalFormat = gl.DEPTH_COMPONENT32F; // should allow 16/24 bits?
@@ -252,7 +252,7 @@ class WebglTexture {
                 break;
             case PIXELFORMAT_DEPTHSTENCIL:
                 this._glFormat = gl.DEPTH_STENCIL;
-                if (device.webgl2) {
+                if (device.isWebGl2) {
                     this._glInternalFormat = gl.DEPTH24_STENCIL8;
                     this._glPixelType = gl.UNSIGNED_INT_24_8;
                 } else {
@@ -484,7 +484,7 @@ class WebglTexture {
             }
         }
 
-        if (!texture._compressed && texture._mipmaps && texture._needsMipmapsUpload && (texture.pot || device.webgl2) && texture._levels.length === 1) {
+        if (!texture._compressed && texture._mipmaps && texture._needsMipmapsUpload && (texture.pot || device.isWebGl2) && texture._levels.length === 1) {
             gl.generateMipmap(this._glTarget);
             texture._mipmapsUploaded = true;
         }

--- a/src/platform/graphics/webgl/webgl-texture.js
+++ b/src/platform/graphics/webgl/webgl-texture.js
@@ -130,12 +130,12 @@ class WebglTexture {
                 break;
             case PIXELFORMAT_RGB8:
                 this._glFormat = gl.RGB;
-                this._glInternalFormat = device.isWebGl2 ? gl.RGB8 : gl.RGB;
+                this._glInternalFormat = device.isWebGL2 ? gl.RGB8 : gl.RGB;
                 this._glPixelType = gl.UNSIGNED_BYTE;
                 break;
             case PIXELFORMAT_RGBA8:
                 this._glFormat = gl.RGBA;
-                this._glInternalFormat = device.isWebGl2 ? gl.RGBA8 : gl.RGBA;
+                this._glInternalFormat = device.isWebGL2 ? gl.RGBA8 : gl.RGBA;
                 this._glPixelType = gl.UNSIGNED_BYTE;
                 break;
             case PIXELFORMAT_DXT1:
@@ -193,7 +193,7 @@ class WebglTexture {
             case PIXELFORMAT_RGB16F:
                 // definition varies between WebGL1 and 2
                 this._glFormat = gl.RGB;
-                if (device.isWebGl2) {
+                if (device.isWebGL2) {
                     this._glInternalFormat = gl.RGB16F;
                     this._glPixelType = gl.HALF_FLOAT;
                 } else {
@@ -204,7 +204,7 @@ class WebglTexture {
             case PIXELFORMAT_RGBA16F:
                 // definition varies between WebGL1 and 2
                 this._glFormat = gl.RGBA;
-                if (device.isWebGl2) {
+                if (device.isWebGL2) {
                     this._glInternalFormat = gl.RGBA16F;
                     this._glPixelType = gl.HALF_FLOAT;
                 } else {
@@ -215,7 +215,7 @@ class WebglTexture {
             case PIXELFORMAT_RGB32F:
                 // definition varies between WebGL1 and 2
                 this._glFormat = gl.RGB;
-                if (device.isWebGl2) {
+                if (device.isWebGL2) {
                     this._glInternalFormat = gl.RGB32F;
                 } else {
                     this._glInternalFormat = gl.RGB;
@@ -225,7 +225,7 @@ class WebglTexture {
             case PIXELFORMAT_RGBA32F:
                 // definition varies between WebGL1 and 2
                 this._glFormat = gl.RGBA;
-                if (device.isWebGl2) {
+                if (device.isWebGL2) {
                     this._glInternalFormat = gl.RGBA32F;
                 } else {
                     this._glInternalFormat = gl.RGBA;
@@ -238,7 +238,7 @@ class WebglTexture {
                 this._glPixelType = gl.FLOAT;
                 break;
             case PIXELFORMAT_DEPTH:
-                if (device.isWebGl2) {
+                if (device.isWebGL2) {
                     // native WebGL2
                     this._glFormat = gl.DEPTH_COMPONENT;
                     this._glInternalFormat = gl.DEPTH_COMPONENT32F; // should allow 16/24 bits?
@@ -252,7 +252,7 @@ class WebglTexture {
                 break;
             case PIXELFORMAT_DEPTHSTENCIL:
                 this._glFormat = gl.DEPTH_STENCIL;
-                if (device.isWebGl2) {
+                if (device.isWebGL2) {
                     this._glInternalFormat = gl.DEPTH24_STENCIL8;
                     this._glPixelType = gl.UNSIGNED_INT_24_8;
                 } else {
@@ -484,7 +484,7 @@ class WebglTexture {
             }
         }
 
-        if (!texture._compressed && texture._mipmaps && texture._needsMipmapsUpload && (texture.pot || device.isWebGl2) && texture._levels.length === 1) {
+        if (!texture._compressed && texture._mipmaps && texture._needsMipmapsUpload && (texture.pot || device.isWebGL2) && texture._levels.length === 1) {
             gl.generateMipmap(this._glTarget);
             texture._mipmapsUploaded = true;
         }

--- a/src/scene/camera.js
+++ b/src/scene/camera.js
@@ -457,7 +457,7 @@ class Camera {
     _enableRenderPassDepthGrab(device, renderer, enable) {
         if (enable) {
             if (!this.renderPassDepthGrab) {
-                this.renderPassDepthGrab = device.isWebGl1 ?
+                this.renderPassDepthGrab = device.isWebGL1 ?
                     new RenderPassDepth(device, renderer, this) :
                     new RenderPassDepthGrab(device, this);
             }

--- a/src/scene/graphics/render-pass-color-grab.js
+++ b/src/scene/graphics/render-pass-color-grab.js
@@ -48,7 +48,7 @@ class RenderPassColorGrab extends RenderPass {
     allocateRenderTarget(renderTarget, sourceRenderTarget, device, format) {
 
         // allocate texture buffer
-        const mipmaps = device.isWebGl2;
+        const mipmaps = device.isWebGL2;
         const texture = new Texture(device, {
             name: _colorUniformNames[0],
             format,
@@ -126,7 +126,7 @@ class RenderPassColorGrab extends RenderPass {
             // generate mipmaps
             device.mipmapRenderer.generate(this.colorRenderTarget.colorBuffer.impl);
 
-        } else if (device.isWebGl2) {
+        } else if (device.isWebGL2) {
 
             device.copyRenderTarget(device.renderTarget, this.colorRenderTarget, true, false);
 

--- a/src/scene/graphics/render-pass-color-grab.js
+++ b/src/scene/graphics/render-pass-color-grab.js
@@ -48,7 +48,7 @@ class RenderPassColorGrab extends RenderPass {
     allocateRenderTarget(renderTarget, sourceRenderTarget, device, format) {
 
         // allocate texture buffer
-        const mipmaps = device.webgl2;
+        const mipmaps = device.isWebGl2;
         const texture = new Texture(device, {
             name: _colorUniformNames[0],
             format,
@@ -126,7 +126,7 @@ class RenderPassColorGrab extends RenderPass {
             // generate mipmaps
             device.mipmapRenderer.generate(this.colorRenderTarget.colorBuffer.impl);
 
-        } else if (device.webgl2) {
+        } else if (device.isWebGl2) {
 
             device.copyRenderTarget(device.renderTarget, this.colorRenderTarget, true, false);
 

--- a/src/scene/graphics/render-pass-depth-grab.js
+++ b/src/scene/graphics/render-pass-depth-grab.js
@@ -125,7 +125,7 @@ class RenderPassDepthGrab extends RenderPass {
 
         // WebGL2 multisampling depth handling: we resolve multi-sampled depth buffer to a single-sampled destination buffer.
         // We could use existing API and resolve depth first and then blit it to destination, but this avoids the extra copy.
-        if (device.isWebGl2 && device.renderTarget.samples > 1) {
+        if (device.isWebGL2 && device.renderTarget.samples > 1) {
 
             // multi-sampled buffer
             const src = device.renderTarget.impl._glFrameBuffer;

--- a/src/scene/light.js
+++ b/src/scene/light.js
@@ -788,7 +788,7 @@ class Light {
                     tmpBiases.bias = -0.00001 * 20;
                 } else {
                     tmpBiases.bias = this.shadowBias * 20; // approx remap from old bias values
-                    if (this.device.isWebGl1 && this.device.extStandardDerivatives) tmpBiases.bias *= -100;
+                    if (this.device.isWebGL1 && this.device.extStandardDerivatives) tmpBiases.bias *= -100;
                 }
                 tmpBiases.normalBias = this._isVsm ? this.vsmBias / (this.attenuationEnd / 7.0) : this._normalOffsetBias;
                 break;
@@ -799,7 +799,7 @@ class Light {
                     tmpBiases.bias = -0.00001 * 20;
                 } else {
                     tmpBiases.bias = (this.shadowBias / farClip) * 100;
-                    if (this.device.isWebGl1 && this.device.extStandardDerivatives) tmpBiases.bias *= -100;
+                    if (this.device.isWebGL1 && this.device.extStandardDerivatives) tmpBiases.bias *= -100;
                 }
                 tmpBiases.normalBias = this._isVsm ? this.vsmBias / (farClip / 7.0) : this._normalOffsetBias;
                 break;

--- a/src/scene/light.js
+++ b/src/scene/light.js
@@ -788,7 +788,7 @@ class Light {
                     tmpBiases.bias = -0.00001 * 20;
                 } else {
                     tmpBiases.bias = this.shadowBias * 20; // approx remap from old bias values
-                    if (!this.device.webgl2 && this.device.extStandardDerivatives) tmpBiases.bias *= -100;
+                    if (this.device.isWebGl1 && this.device.extStandardDerivatives) tmpBiases.bias *= -100;
                 }
                 tmpBiases.normalBias = this._isVsm ? this.vsmBias / (this.attenuationEnd / 7.0) : this._normalOffsetBias;
                 break;
@@ -799,7 +799,7 @@ class Light {
                     tmpBiases.bias = -0.00001 * 20;
                 } else {
                     tmpBiases.bias = (this.shadowBias / farClip) * 100;
-                    if (!this.device.webgl2 && this.device.extStandardDerivatives) tmpBiases.bias *= -100;
+                    if (this.device.isWebGl1 && this.device.extStandardDerivatives) tmpBiases.bias *= -100;
                 }
                 tmpBiases.normalBias = this._isVsm ? this.vsmBias / (farClip / 7.0) : this._normalOffsetBias;
                 break;

--- a/src/scene/lighting/light-texture-atlas.js
+++ b/src/scene/lighting/light-texture-atlas.js
@@ -143,7 +143,7 @@ class LightTextureAtlas {
         // shadow atlas texture
         const isShadowFilterPcf = true;
         const rt = this.shadowAtlas.renderTargets[0];
-        const isDepthShadow = (this.device.isWebGPU || this.device.webgl2) && isShadowFilterPcf;
+        const isDepthShadow = !this.device.isWebGl1 && isShadowFilterPcf;
         const shadowBuffer = isDepthShadow ? rt.depthBuffer : rt.colorBuffer;
         this._shadowAtlasTextureId.setValue(shadowBuffer);
 

--- a/src/scene/lighting/light-texture-atlas.js
+++ b/src/scene/lighting/light-texture-atlas.js
@@ -143,7 +143,7 @@ class LightTextureAtlas {
         // shadow atlas texture
         const isShadowFilterPcf = true;
         const rt = this.shadowAtlas.renderTargets[0];
-        const isDepthShadow = !this.device.isWebGl1 && isShadowFilterPcf;
+        const isDepthShadow = !this.device.isWebGL1 && isShadowFilterPcf;
         const shadowBuffer = isDepthShadow ? rt.depthBuffer : rt.colorBuffer;
         this._shadowAtlasTextureId.setValue(shadowBuffer);
 

--- a/src/scene/lighting/lights-buffer.js
+++ b/src/scene/lighting/lights-buffer.js
@@ -99,7 +99,7 @@ class LightsBuffer {
     // active light texture format, initialized at app start
     static lightTextureFormat = LightsBuffer.FORMAT_8BIT;
 
-    // on webgl2 we use texelFetch instruction to read data textures
+    // on webgl2 and WebGPU we use texelFetch instruction to read data textures
     static useTexelFetch = false;
 
     // defines used for unpacking of light textures to allow CPU packing to match the GPU unpacking

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -727,7 +727,7 @@ class ForwardRenderer extends Renderer {
     buildFrameGraph(frameGraph, layerComposition) {
 
         const clusteredLightingEnabled = this.scene.clusteredLightingEnabled;
-        const webgl1 = this.device.isWebGl1;
+        const webgl1 = this.device.isWebGL1;
         frameGraph.reset();
 
         this.update(layerComposition);

--- a/src/scene/renderer/shadow-map.js
+++ b/src/scene/renderer/shadow-map.js
@@ -54,7 +54,7 @@ class ShadowMap {
             return PIXELFORMAT_DEPTH;
         } else if ((shadowType === SHADOW_PCF1 || shadowType === SHADOW_PCF3) && device.supportsDepthShadow) {
             return PIXELFORMAT_DEPTH;
-        } else if ((shadowType === SHADOW_PCSS) && (device.webgl2 || device.isWebGPU)) {
+        } else if ((shadowType === SHADOW_PCSS) && !device.isWebGl1) {
             return PIXELFORMAT_R32F;
         }
 
@@ -147,7 +147,7 @@ class ShadowMap {
 
     static createCubemap(device, size, shadowType) {
 
-        const format = (shadowType === SHADOW_PCSS && (device.webgl2 || device.isWebGPU)) ? PIXELFORMAT_R32F : PIXELFORMAT_RGBA8;
+        const format = (shadowType === SHADOW_PCSS && !device.isWebGl1) ? PIXELFORMAT_R32F : PIXELFORMAT_RGBA8;
         const cubemap = new Texture(device, {
             // #if _PROFILER
             profilerHint: TEXHINT_SHADOWMAP,

--- a/src/scene/renderer/shadow-map.js
+++ b/src/scene/renderer/shadow-map.js
@@ -54,7 +54,7 @@ class ShadowMap {
             return PIXELFORMAT_DEPTH;
         } else if ((shadowType === SHADOW_PCF1 || shadowType === SHADOW_PCF3) && device.supportsDepthShadow) {
             return PIXELFORMAT_DEPTH;
-        } else if ((shadowType === SHADOW_PCSS) && !device.isWebGl1) {
+        } else if ((shadowType === SHADOW_PCSS) && !device.isWebGL1) {
             return PIXELFORMAT_R32F;
         }
 
@@ -147,7 +147,7 @@ class ShadowMap {
 
     static createCubemap(device, size, shadowType) {
 
-        const format = (shadowType === SHADOW_PCSS && !device.isWebGl1) ? PIXELFORMAT_R32F : PIXELFORMAT_RGBA8;
+        const format = (shadowType === SHADOW_PCSS && !device.isWebGL1) ? PIXELFORMAT_R32F : PIXELFORMAT_RGBA8;
         const cubemap = new Texture(device, {
             // #if _PROFILER
             profilerHint: TEXHINT_SHADOWMAP,

--- a/src/scene/renderer/shadow-renderer.js
+++ b/src/scene/renderer/shadow-renderer.js
@@ -209,7 +209,7 @@ class ShadowRenderer {
         const isClustered = this.renderer.scene.clusteredLightingEnabled;
 
         // depth bias
-        if (device.isWebGl2 || device.isWebGPU) {
+        if (device.isWebGL2 || device.isWebGPU) {
             if (light._type === LIGHTTYPE_OMNI && !isClustered) {
                 device.setDepthBias(false);
             } else {
@@ -229,7 +229,7 @@ class ShadowRenderer {
         }
 
         // Set standard shadowmap states
-        const gpuOrGl2 = device.isWebGl2 || device.isWebGPU;
+        const gpuOrGl2 = device.isWebGL2 || device.isWebGPU;
         const useShadowSampler = isClustered ?
             light._isPcf && gpuOrGl2 :     // both spot and omni light are using shadow sampler on webgl2 when clustered
             light._isPcf && gpuOrGl2 && light._type !== LIGHTTYPE_OMNI;    // for non-clustered, point light is using depth encoded in color buffer (should change to shadow sampler)
@@ -241,7 +241,7 @@ class ShadowRenderer {
 
     restoreRenderState(device) {
 
-        if (device.isWebGl2 || device.isWebGPU) {
+        if (device.isWebGL2 || device.isWebGPU) {
             device.setDepthBias(false);
         } else if (device.extStandardDerivatives) {
             this.polygonOffset[0] = 0;

--- a/src/scene/renderer/shadow-renderer.js
+++ b/src/scene/renderer/shadow-renderer.js
@@ -209,7 +209,7 @@ class ShadowRenderer {
         const isClustered = this.renderer.scene.clusteredLightingEnabled;
 
         // depth bias
-        if (device.webgl2 || device.isWebGPU) {
+        if (device.isWebGl2 || device.isWebGPU) {
             if (light._type === LIGHTTYPE_OMNI && !isClustered) {
                 device.setDepthBias(false);
             } else {
@@ -229,7 +229,7 @@ class ShadowRenderer {
         }
 
         // Set standard shadowmap states
-        const gpuOrGl2 = device.webgl2 || device.isWebGPU;
+        const gpuOrGl2 = device.isWebGl2 || device.isWebGPU;
         const useShadowSampler = isClustered ?
             light._isPcf && gpuOrGl2 :     // both spot and omni light are using shadow sampler on webgl2 when clustered
             light._isPcf && gpuOrGl2 && light._type !== LIGHTTYPE_OMNI;    // for non-clustered, point light is using depth encoded in color buffer (should change to shadow sampler)
@@ -241,7 +241,7 @@ class ShadowRenderer {
 
     restoreRenderState(device) {
 
-        if (device.webgl2 || device.isWebGPU) {
+        if (device.isWebGl2 || device.isWebGPU) {
             device.setDepthBias(false);
         } else if (device.extStandardDerivatives) {
             this.polygonOffset[0] = 0;

--- a/src/scene/shader-lib/programs/lit-shader.js
+++ b/src/scene/shader-lib/programs/lit-shader.js
@@ -467,7 +467,7 @@ class LitShader {
 
         let code = this._fsGetBeginCode();
 
-        if (device.extStandardDerivatives && !device.webgl2 && !device.isWebGPU) {
+        if (device.extStandardDerivatives && device.isWebGl1) {
             code += 'uniform vec2 polygonOffset;\n';
         }
 
@@ -514,7 +514,7 @@ class LitShader {
         code += this.frontendFunc;
 
         const isVsm = shadowType === SHADOW_VSM8 || shadowType === SHADOW_VSM16 || shadowType === SHADOW_VSM32;
-        const applySlopeScaleBias = !device.webgl2 && device.extStandardDerivatives && !device.isWebGPU;
+        const applySlopeScaleBias = device.isWebGl1 && device.extStandardDerivatives;
 
         // Use perspective depth for:
         // Directional: Always since light has no position
@@ -850,7 +850,7 @@ class LitShader {
             if (shadowTypeUsed[SHADOW_PCF1] || shadowTypeUsed[SHADOW_PCF3]) {
                 func.append(chunks.shadowStandardPS);
             }
-            if (shadowTypeUsed[SHADOW_PCF5] && (device.webgl2 || device.isWebGPU)) {
+            if (shadowTypeUsed[SHADOW_PCF5] && !device.isWebGl1) {
                 func.append(chunks.shadowStandardGL2PS);
             }
             if (useVsm) {
@@ -870,7 +870,7 @@ class LitShader {
                 func.append(chunks.shadowPCSSPS);
             }
 
-            if (!(device.webgl2 || device.extStandardDerivatives || device.isWebGPU)) {
+            if (!(device.isWebGl2 || device.isWebGPU || device.extStandardDerivatives)) {
                 func.append(chunks.biasConstPS);
             }
         }
@@ -1262,8 +1262,7 @@ class LitShader {
                         if (lightType === LIGHTTYPE_DIRECTIONAL) {
                             func.append("#define SHADOW_SAMPLE_ORTHO");
                         }
-                        if ((pcfShadows || pcssShadows) &&
-                            device.webgl2 || device.extStandardDerivatives || device.isWebGPU) {
+                        if ((pcfShadows || pcssShadows) && device.isWebGl2 || device.isWebGPU || device.extStandardDerivatives) {
                             func.append("#define SHADOW_SAMPLE_SOURCE_ZBUFFER");
                         }
                         if (lightType === LIGHTTYPE_OMNI) {

--- a/src/scene/shader-lib/programs/lit-shader.js
+++ b/src/scene/shader-lib/programs/lit-shader.js
@@ -467,7 +467,7 @@ class LitShader {
 
         let code = this._fsGetBeginCode();
 
-        if (device.extStandardDerivatives && device.isWebGl1) {
+        if (device.extStandardDerivatives && device.isWebGL1) {
             code += 'uniform vec2 polygonOffset;\n';
         }
 
@@ -514,7 +514,7 @@ class LitShader {
         code += this.frontendFunc;
 
         const isVsm = shadowType === SHADOW_VSM8 || shadowType === SHADOW_VSM16 || shadowType === SHADOW_VSM32;
-        const applySlopeScaleBias = device.isWebGl1 && device.extStandardDerivatives;
+        const applySlopeScaleBias = device.isWebGL1 && device.extStandardDerivatives;
 
         // Use perspective depth for:
         // Directional: Always since light has no position
@@ -850,7 +850,7 @@ class LitShader {
             if (shadowTypeUsed[SHADOW_PCF1] || shadowTypeUsed[SHADOW_PCF3]) {
                 func.append(chunks.shadowStandardPS);
             }
-            if (shadowTypeUsed[SHADOW_PCF5] && !device.isWebGl1) {
+            if (shadowTypeUsed[SHADOW_PCF5] && !device.isWebGL1) {
                 func.append(chunks.shadowStandardGL2PS);
             }
             if (useVsm) {
@@ -870,7 +870,7 @@ class LitShader {
                 func.append(chunks.shadowPCSSPS);
             }
 
-            if (!(device.isWebGl2 || device.isWebGPU || device.extStandardDerivatives)) {
+            if (!(device.isWebGL2 || device.isWebGPU || device.extStandardDerivatives)) {
                 func.append(chunks.biasConstPS);
             }
         }
@@ -1262,7 +1262,7 @@ class LitShader {
                         if (lightType === LIGHTTYPE_DIRECTIONAL) {
                             func.append("#define SHADOW_SAMPLE_ORTHO");
                         }
-                        if ((pcfShadows || pcssShadows) && device.isWebGl2 || device.isWebGPU || device.extStandardDerivatives) {
+                        if ((pcfShadows || pcssShadows) && device.isWebGL2 || device.isWebGPU || device.extStandardDerivatives) {
                             func.append("#define SHADOW_SAMPLE_SOURCE_ZBUFFER");
                         }
                         if (lightType === LIGHTTYPE_OMNI) {


### PR DESCRIPTION
The consistent API on Graphics device is now:
```
isWebGPU
isWebGL2
isWebGL1
```

`.webgl2` is still function, but logs a one time warning message
