### PR TITLE
Small cleanup to the way antialiasing set up is handled

### DIFF
--- a/src/platform/graphics/graphics-device.js
+++ b/src/platform/graphics/graphics-device.js
@@ -61,6 +61,11 @@ class GraphicsDevice extends EventHandler {
     backBufferFormat;
 
     /**
+     * True if the back buffer should use anti-aliasing.
+     */
+    backBufferAntialias = false;
+
+    /**
      * True if the deviceType is WebGPU
      *
      * @type {boolean}

--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -86,11 +86,9 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
         super(canvas, options);
         options = this.initOptions;
 
+        this.backBufferAntialias = options.antialias ?? false;
         this.isWebGPU = true;
         this._deviceType = DEVICETYPE_WEBGPU;
-
-        // WebGPU currently only supports 1 and 4 samples
-        this.samples = options.antialias ? 4 : 1;
 
         this.setupPassEncoderDefaults();
     }
@@ -151,6 +149,9 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
         this.extBlendMinmax = true;
         this.areaLightLutFormat = this.floatFilterable ? PIXELFORMAT_RGBA32F : PIXELFORMAT_RGBA8;
         this.supportsTextureFetch = true;
+
+        // WebGPU currently only supports 1 and 4 samples
+        this.samples = this.backBufferAntialias ? 4 : 1;
     }
 
     async initWebGpu(glslangUrl, twgslUrl) {


### PR DESCRIPTION
Fixes https://github.com/playcanvas/engine/issues/5455

- more unified across devices
- no longer read backbuffer samples, as we always request single-sampled back-buffer, and handle multi-sampling internally.