### PR TITLE
Fire destroy event in AppBase#destroy

### DIFF
--- a/src/framework/app-base.js
+++ b/src/framework/app-base.js
@@ -2037,6 +2037,7 @@ class AppBase extends EventHandler {
 
         this.tick = null;
 
+        this.fire('destroy', this); // fire destroy event
         this.off(); // remove all events
 
         this._soundManager?.destroy();

--- a/src/framework/app-base.js
+++ b/src/framework/app-base.js
@@ -1922,6 +1922,7 @@ class AppBase extends EventHandler {
 
         const canvasId = this.graphicsDevice.canvas.id;
 
+        this.fire('destroy', this); // fire destroy event
         this.off('librariesloaded');
 
         if (typeof document !== 'undefined') {
@@ -2037,7 +2038,6 @@ class AppBase extends EventHandler {
 
         this.tick = null;
 
-        this.fire('destroy', this); // fire destroy event
         this.off(); // remove all events
 
         this._soundManager?.destroy();


### PR DESCRIPTION
Provides a solution for https://github.com/playcanvas/engine/pull/5555#issuecomment-1739243685

I was a bit surprised that we didn't have this yet. :thinking:

With this PR we have a simple/intuitive way to clean up events:

```js
function resize() {
    app.resizeCanvas(canvas.width, canvas.height);
}
window.addEventListener("resize", resize);
app.on('destroy', () => {
    window.removeEventListener("resize", resize);
});
```

List of stuff we always need to clean: window events, setInterval id's

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
