### PR TITLE
feat(build): clean build folder before rebuilding all targets

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -1,9 +1,7 @@
 import { execSync } from 'child_process';
-import fs from 'fs';
-import path from 'path';
+import fs from 'node:fs';
 
 // 1st party Rollup plugins
-import { createFilter } from '@rollup/pluginutils';
 import { babel } from '@rollup/plugin-babel';
 import resolve from '@rollup/plugin-node-resolve';
 import strip from '@rollup/plugin-strip';
@@ -13,10 +11,13 @@ import terser from '@rollup/plugin-terser';
 import dts from 'rollup-plugin-dts';
 import jscc from 'rollup-plugin-jscc';
 import { visualizer } from 'rollup-plugin-visualizer';
+
+// custom Rollup plugins
 import { shaderChunks } from './utils/rollup-shader-chunks.mjs';
+import { engineLayerImportValidation } from './utils/rollup-import-validation.mjs';
+import { spacesToTabs } from './utils/rollup-spaces-to-tabs.mjs';
 
 /** @typedef {import('rollup').RollupOptions} RollupOptions */
-/** @typedef {import('rollup').Plugin} Plugin */
 /** @typedef {import('rollup').OutputOptions} OutputOptions */
 /** @typedef {import('@rollup/plugin-babel').RollupBabelInputPluginOptions} RollupBabelInputPluginOptions */
 /** @typedef {import('@rollup/plugin-strip').RollupStripOptions} RollupStripOptions */
@@ -61,93 +62,6 @@ function getBanner(config) {
         ' * Copyright 2011-' + new Date().getFullYear() + ' PlayCanvas Ltd. All rights reserved.',
         ' */'
     ].join('\n');
-}
-
-/**
- * This plugin converts every two spaces into one tab. Two spaces is the default the babel plugin
- * outputs, which is independent of the four spaces of the code base.
- *
- * @param {boolean} enable - Enable or disable the plugin.
- * @returns {Plugin} The plugin.
- */
-function spacesToTabs(enable) {
-    const filter = createFilter([
-        '**/*.js'
-    ], []);
-
-    return {
-        name: "spacesToTabs",
-        transform(code, id) {
-            if (!enable || !filter(id)) return undefined;
-            // ^    = start of line
-            // " +" = one or more spaces
-            // gm   = find all + multiline
-            const regex = /^ +/gm;
-            code = code.replace(
-                regex,
-                startSpaces => startSpaces.replace(/ {2}/g, '\t')
-            );
-            return {
-                code,
-                map: null
-            };
-        }
-    };
-}
-
-/**
- * Validate and print warning if an engine module on a lower level imports module on a higher level
- *
- * @param {string} rootFile - The root file, typically `src/index.js`.
- * @param {boolean} enable - Enable or disable the plugin.
- * @returns {Plugin} The plugin.
- */
-function engineLayerImportValidation(rootFile, enable) {
-
-    const folderLevels = {
-        'core': 0,
-        'platform': 1,
-        'scene': 2,
-        'framework': 3
-    };
-
-    let rootPath;
-
-    return {
-        name: 'engineLayerImportValidation',
-
-        buildStart() {
-            rootPath = path.parse(path.resolve(rootFile)).dir;
-        },
-
-        resolveId(imported, importer) {
-            if (enable) {
-
-                // skip non-relative paths, those are not our imports, for example 'rollupPluginBabelHelpers.js'
-                if (importer && imported && imported.includes('./')) {
-
-                    // convert importer path
-                    const importerDir = path.parse(importer).dir;
-                    const relImporter = path.dirname(path.relative(rootPath, importer));
-                    const folderImporter = relImporter.split(path.sep)[0];
-                    const levelImporter = folderLevels[folderImporter];
-
-                    // convert imported path
-                    const absImported = path.resolve(path.join(importerDir, imported));
-                    const relImported = path.dirname(path.relative(rootPath, absImported));
-                    const folderImported = relImported.split(path.sep)[0];
-                    const levelImported = folderLevels[folderImported];
-
-                    if (levelImporter < levelImported) {
-                        console.log(`(!) Incorrect import: [${path.relative(rootPath, importer)}] -> [${imported}]`);
-                    }
-                }
-            }
-
-            // we don't process imports, return null to allow chaining
-            return null;
-        }
-    };
 }
 
 /**

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -1,5 +1,5 @@
-import { execSync } from 'child_process';
-import fs from 'node:fs';
+import { execSync } from 'node:child_process';
+import * as fs from 'node:fs';
 
 // 1st party Rollup plugins
 import { babel } from '@rollup/plugin-babel';
@@ -354,6 +354,12 @@ export default (args) => {
     let targets = [];
 
     const envTarget = process.env.target ? process.env.target.toLowerCase() : null;
+
+    if ((envTarget === null) && fs.existsSync('build')) {
+        // no targets specified, clean build directory
+        fs.rmSync('build', { recursive: true });
+    }
+
     if (envTarget === 'types') {
         targets.push(target_types);
     } else if (envTarget === 'extras') {

--- a/utils/rollup-import-validation.mjs
+++ b/utils/rollup-import-validation.mjs
@@ -1,0 +1,58 @@
+import path from 'node:path';
+
+/** @typedef {import('rollup').Plugin} Plugin */
+
+/**
+ * Validate and print warning if an engine module on a lower level imports module on a higher level
+ *
+ * @param {string} rootFile - The root file, typically `src/index.js`.
+ * @param {boolean} enable - Enable or disable the plugin.
+ * @returns {Plugin} The plugin.
+ */
+export function engineLayerImportValidation(rootFile, enable) {
+
+    const folderLevels = {
+        'core': 0,
+        'platform': 1,
+        'scene': 2,
+        'framework': 3
+    };
+
+    let rootPath;
+
+    return {
+        name: 'engineLayerImportValidation',
+
+        buildStart() {
+            rootPath = path.parse(path.resolve(rootFile)).dir;
+        },
+
+        resolveId(imported, importer) {
+            if (enable) {
+
+                // skip non-relative paths, those are not our imports, for example 'rollupPluginBabelHelpers.js'
+                if (importer && imported && imported.includes('./')) {
+
+                    // convert importer path
+                    const importerDir = path.parse(importer).dir;
+                    const relImporter = path.dirname(path.relative(rootPath, importer));
+                    const folderImporter = relImporter.split(path.sep)[0];
+                    const levelImporter = folderLevels[folderImporter];
+
+                    // convert imported path
+                    const absImported = path.resolve(path.join(importerDir, imported));
+                    const relImported = path.dirname(path.relative(rootPath, absImported));
+                    const folderImported = relImported.split(path.sep)[0];
+                    const levelImported = folderLevels[folderImported];
+
+                    if (levelImporter < levelImported) {
+                        console.log(`(!) Incorrect import: [${path.relative(rootPath, importer)}] -> [${imported}]`);
+                    }
+                }
+            }
+
+            // we don't process imports, return null to allow chaining
+            return null;
+        }
+    };
+}

--- a/utils/rollup-spaces-to-tabs.mjs
+++ b/utils/rollup-spaces-to-tabs.mjs
@@ -1,0 +1,35 @@
+import { createFilter } from '@rollup/pluginutils';
+
+/** @typedef {import('rollup').Plugin} Plugin */
+
+/**
+ * This plugin converts every two spaces into one tab. Two spaces is the default the babel plugin
+ * outputs, which is independent of the four spaces of the code base.
+ *
+ * @param {boolean} enable - Enable or disable the plugin.
+ * @returns {Plugin} The plugin.
+ */
+export function spacesToTabs(enable) {
+    const filter = createFilter([
+        '**/*.js'
+    ], []);
+
+    return {
+        name: "spacesToTabs",
+        transform(code, id) {
+            if (!enable || !filter(id)) return undefined;
+            // ^    = start of line
+            // " +" = one or more spaces
+            // gm   = find all + multiline
+            const regex = /^ +/gm;
+            code = code.replace(
+                regex,
+                startSpaces => startSpaces.replace(/ {2}/g, '\t')
+            );
+            return {
+                code,
+                map: null
+            };
+        }
+    };
+}


### PR DESCRIPTION
Cleans the "Build" directory before rebuilding all targets.  

Normally, the expectation is that:
- building one or specific set of targets - do not clear
- building all targets - rimraf (clear) the build directory before building

Resolves the edge cases described in linked issue.

This improves the readability of the build logic by separating custom rollup plugins into reusable units.  Moving them into the "utils" folder and out of the root of the project.

Fixes: #5588

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
