### PR TITLE
Fix scroll view touch events

### DIFF
--- a/src/framework/input/element-input.js
+++ b/src/framework/input/element-input.js
@@ -631,8 +631,6 @@ class ElementInput {
             delete this._touchedElements[touch.identifier];
             delete this._touchesForWhichTouchLeaveHasFired[touch.identifier];
 
-            this._fireEvent(event.type, new ElementTouchEvent(event, element, camera, x, y, touch));
-
             // check if touch was released over previously touch
             // element in order to fire click event
             const coords = this._calcTouchCoords(touch);
@@ -648,6 +646,8 @@ class ElementInput {
 
                 }
             }
+
+            this._fireEvent(event.type, new ElementTouchEvent(event, element, camera, x, y, touch));
         }
     }
 


### PR DESCRIPTION
Fixes #5672

The issue was that this line is reporting `touchend`, which in turn makes Scroll View component to activate all its input elements, including the buttons (via`_enableContentInput()`). As a result the next loop can see the buttons as well and reports that the element under touch matches. The fix is to move the `touchend` event fire after the check, to keep the buttons disabled.


I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
