### PR TITLE
Add RenderTarget|null typing + remove dead code

### DIFF
--- a/src/framework/components/camera/component.js
+++ b/src/framework/components/camera/component.js
@@ -891,7 +891,7 @@ class CameraComponent extends Component {
     /**
      * Calculates aspect ratio value for a given render target.
      *
-     * @param {import('../../../platform/graphics/render-target.js').RenderTarget} [rt] - Optional
+     * @param {import('../../../platform/graphics/render-target.js').RenderTarget|null} [rt] - Optional
      * render target. If unspecified, the backbuffer is used.
      * @returns {number} The aspect ratio of the render target (or backbuffer).
      */
@@ -905,7 +905,7 @@ class CameraComponent extends Component {
     /**
      * Prepare the camera for frame rendering.
      *
-     * @param {import('../../../platform/graphics/render-target.js').RenderTarget} rt - Render
+     * @param {import('../../../platform/graphics/render-target.js').RenderTarget|null} rt - Render
      * target to which rendering will be performed. Will affect camera's aspect ratio, if
      * aspectRatioMode is {@link ASPECT_AUTO}.
      * @ignore

--- a/src/platform/graphics/render-pass.js
+++ b/src/platform/graphics/render-pass.js
@@ -192,15 +192,15 @@ class RenderPass {
     }
 
     /**
-     * @param {import('../graphics/render-target.js').RenderTarget|null} renderTarget - The render
+     * @param {import('../graphics/render-target.js').RenderTarget|null} [renderTarget] - The render
      * target to render into (output). This function should be called only for render passes which
      * use render target, or passes which render directly into the default framebuffer, in which
      * case a null or undefined render target is expected.
      */
-    init(renderTarget) {
+    init(renderTarget = null) {
 
         // null represents the default framebuffer
-        this.renderTarget = renderTarget || null;
+        this.renderTarget = renderTarget;
 
         // defaults depend on multisampling
         this.samples = Math.max(this.renderTarget ? this.renderTarget.samples : this.device.samples, 1);

--- a/src/platform/graphics/render-pass.js
+++ b/src/platform/graphics/render-pass.js
@@ -93,7 +93,13 @@ class RenderPass {
     /** @type {string} */
     name;
 
-    /** @type {import('../graphics/render-target.js').RenderTarget|null|undefined} */
+    /**
+     * The render target for this render pass:
+     *  - `undefined`: render pass does not render to any render target
+     *  - `null`: render pass renders to the backbuffer
+     *  - Otherwise, renders to the provided RT.
+     * @type {import('../graphics/render-target.js').RenderTarget|null|undefined}
+     */
     renderTarget;
 
     /**

--- a/src/platform/graphics/render-pass.js
+++ b/src/platform/graphics/render-pass.js
@@ -93,7 +93,7 @@ class RenderPass {
     /** @type {string} */
     name;
 
-    /** @type {import('../graphics/render-target.js').RenderTarget} */
+    /** @type {import('../graphics/render-target.js').RenderTarget|null} */
     renderTarget;
 
     /**
@@ -186,7 +186,7 @@ class RenderPass {
     }
 
     /**
-     * @param {import('../graphics/render-target.js').RenderTarget} renderTarget - The render
+     * @param {import('../graphics/render-target.js').RenderTarget|null} renderTarget - The render
      * target to render into (output). This function should be called only for render passes which
      * use render target, or passes which render directly into the default framebuffer, in which
      * case a null or undefined render target is expected.

--- a/src/platform/graphics/render-pass.js
+++ b/src/platform/graphics/render-pass.js
@@ -93,7 +93,7 @@ class RenderPass {
     /** @type {string} */
     name;
 
-    /** @type {import('../graphics/render-target.js').RenderTarget|null} */
+    /** @type {import('../graphics/render-target.js').RenderTarget|null|undefined} */
     renderTarget;
 
     /**

--- a/src/scene/graphics/post-effect.js
+++ b/src/scene/graphics/post-effect.js
@@ -67,10 +67,10 @@ class PostEffect {
     /**
      * Draw a screen-space rectangle in a render target, using a specified shader.
      *
-     * @param {import('../../platform/graphics/render-target.js').RenderTarget} target - The output
-     * render target.
-     * @param {import('../../platform/graphics/shader.js').Shader} shader - The shader to be used for
-     * drawing the rectangle.
+     * @param {import('../../platform/graphics/render-target.js').RenderTarget|null} target - The
+     * output render target.
+     * @param {import('../../platform/graphics/shader.js').Shader} shader - The shader to be used
+     * for drawing the rectangle.
      * @param {import('../../core/math/vec4.js').Vec4} [rect] - The normalized screen-space position
      * (rect.x, rect.y) and size (rect.z, rect.w) of the rectangle. Default is [0, 0, 1, 1].
      */

--- a/src/scene/graphics/quad-render-utils.js
+++ b/src/scene/graphics/quad-render-utils.js
@@ -68,8 +68,7 @@ function drawQuadWithShader(device, target, shader, rect, scissorRect) {
     // the same framebuffer. The workaround here is to store multi-sampled color buffer, instead of only resolving it, which is wasted
     // memory bandwidth. Without this we end up with a black result (or just UI), as multi-sampled color buffer is never written to.
     if (device.isWebGPU && target === null) {
-        const { samples } = device;
-        if (samples > 1)
+        if (device.samples > 1)
             renderPass.colorOps.store = true;
     }
 

--- a/src/scene/graphics/quad-render-utils.js
+++ b/src/scene/graphics/quad-render-utils.js
@@ -14,7 +14,7 @@ const _tempRect = new Vec4();
  *
  * @param {import('../../platform/graphics/graphics-device.js').GraphicsDevice} device - The graphics device used to draw
  * the quad.
- * @param {import('../../platform/graphics/render-target.js').RenderTarget|undefined} target - The destination render
+ * @param {import('../../platform/graphics/render-target.js').RenderTarget|null} target - The destination render
  * target. If undefined, target is the frame buffer.
  * @param {import('../../platform/graphics/shader.js').Shader} shader - The shader used for rendering the quad. Vertex
  * shader should contain `attribute vec2 vertex_position`.
@@ -68,7 +68,7 @@ function drawQuadWithShader(device, target, shader, rect, scissorRect) {
     // the same framebuffer. The workaround here is to store multi-sampled color buffer, instead of only resolving it, which is wasted
     // memory bandwidth. Without this we end up with a black result (or just UI), as multi-sampled color buffer is never written to.
     if (device.isWebGPU && target === null) {
-        const samples = target?.samples ?? device.samples;
+        const { samples } = device;
         if (samples > 1)
             renderPass.colorOps.store = true;
     }

--- a/src/scene/graphics/quad-render-utils.js
+++ b/src/scene/graphics/quad-render-utils.js
@@ -67,9 +67,8 @@ function drawQuadWithShader(device, target, shader, rect, scissorRect) {
     // in a separate render pass B (e.g. rendering UI). Those two render passes need to be merged into one, as they both render into
     // the same framebuffer. The workaround here is to store multi-sampled color buffer, instead of only resolving it, which is wasted
     // memory bandwidth. Without this we end up with a black result (or just UI), as multi-sampled color buffer is never written to.
-    if (device.isWebGPU && target === null) {
-        if (device.samples > 1)
-            renderPass.colorOps.store = true;
+    if (device.isWebGPU && target === null && device.samples > 1) {
+        renderPass.colorOps.store = true;
     }
 
     renderPass.render();


### PR DESCRIPTION
This fixes a few of type issues, since `RenderTarget` is `null` in many situations, and then it goes on and on to e.g. `drawQuadWithShader` which doesn't need a `target`, e.g. example with bloom:

![image](https://github.com/playcanvas/engine/assets/5236548/49f8c857-a613-423e-8daa-3121feb806b1)

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
