### PR TITLE
Better handling of gltf blend materials

### DIFF
--- a/src/framework/parsers/glb-parser.js
+++ b/src/framework/parsers/glb-parser.js
@@ -1038,14 +1038,14 @@ const extensionUnlit = (data, material, textures) => {
 
 const extensionSpecular = (data, material, textures) => {
     material.useMetalnessSpecularColor = true;
+
     if (data.hasOwnProperty('specularColorTexture')) {
         material.specularEncoding = 'srgb';
         material.specularMap = textures[data.specularColorTexture.index];
         material.specularMapChannel = 'rgb';
-
         extractTextureTransform(data.specularColorTexture, material, ['specular']);
-
     }
+
     if (data.hasOwnProperty('specularColorFactor')) {
         const color = data.specularColorFactor;
         material.specular.set(Math.pow(color[0], 1 / 2.2), Math.pow(color[1], 1 / 2.2), Math.pow(color[2], 1 / 2.2));
@@ -1058,6 +1058,7 @@ const extensionSpecular = (data, material, textures) => {
     } else {
         material.specularityFactor = 1;
     }
+
     if (data.hasOwnProperty('specularTexture')) {
         material.specularityFactorMapChannel = 'a';
         material.specularityFactorMap = textures[data.specularTexture.index];
@@ -1272,9 +1273,10 @@ const createMaterial = (gltfMaterial, textures, flipV) => {
                 }
                 break;
             case 'BLEND':
+                // Blended materials will be rendered back to front, but continue to write depth
+                // along with alpha test. This helps to composite the scene.
                 material.blendType = BLEND_NORMAL;
-                // note: by default don't write depth on semitransparent materials
-                material.depthWrite = false;
+                material.alphaTest = 1.0 / 255.0;
                 break;
             default:
             case 'OPAQUE':


### PR DESCRIPTION
Instead of completely disabling depth-write for semitransparent gltf materials, we write depth and enable alpha test on fragment alpha > 0 instead. This results in much better handling of complex semi-transparent scenes. See the comparison  screenshots below:

|Before|After|
|---|---|
| <img width="1364" alt="Screenshot 2023-10-03 at 13 41 14" src="https://github.com/playcanvas/engine/assets/11276292/6c6635c2-cd93-45c8-8540-43d710a4551d"> | <img width="1364" alt="Screenshot 2023-10-03 at 13 42 15" src="https://github.com/playcanvas/engine/assets/11276292/8f81e156-a2c4-4e97-88e2-92c169d6cd6a"> |

(This was discovered while investigating https://github.com/playcanvas/engine/issues/5700).