### PR TITLE
Don't create WebglShaderInput if there is no attribute

### DIFF
--- a/src/platform/graphics/webgl/webgl-shader.js
+++ b/src/platform/graphics/webgl/webgl-shader.js
@@ -346,11 +346,10 @@ class WebglShader {
             if (definition.attributes[info.name] === undefined) {
                 console.error(`Vertex shader attribute "${info.name}" is not mapped to a semantic in shader definition, shader [${shader.label}]`, shader);
                 shader.failed = true;
+            } else {
+                const shaderInput = new WebglShaderInput(device, definition.attributes[info.name], device.pcUniformType[info.type], location);
+                this.attributes.push(shaderInput);
             }
-
-            const shaderInput = new WebglShaderInput(device, definition.attributes[info.name], device.pcUniformType[info.type], location);
-
-            this.attributes.push(shaderInput);
         }
 
         // Query the program for each shader state (GLSL 'uniform')


### PR DESCRIPTION
`webgl-shader.js` has this check:

```js
if (definition.attributes[info.name] === undefined) {
    console.error(`Vertex shader attribute "${info.name}" is not mapped to a semantic in shader definition, shader [${shader.label}]`, shader);
    shader.failed = true;
}
```

Right after that if statement, regardless of if the attribute is defiend or not, it calls:

```js
const shaderInput = new WebglShaderInput(device, definition.attributes[info.name], device.pcUniformType[info.type], location);
```

We've aleady established `definition.attributes[info.name]` is undefined, so this line probably shouldn't be called. Inside `WebglShaderInput`, `definition.attributes[info.name]` becomes the `name` parameter, and the function tries to call
`name.substring(name.length - 3)`, which errors.

This whole code path can fire if you define a custom vertex shader with the code

```glsl
in vec2 vertex_texCoord0;
```

And no diffuse map set, so PlayCanvas doesn't think there's an attribute in the shader definition, and tries to error looping over the attributes returned from webgl.

Fixes #

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).

This PR prevents the runtime Javascript error. Playcanvas already logs an error in this case, but then the existing code path crashes.