### PR TITLE
Handle vertex formats in GLB files that are not supported on WebGPU

### DIFF
--- a/examples/src/examples/graphics/asset-viewer.tsx
+++ b/examples/src/examples/graphics/asset-viewer.tsx
@@ -7,6 +7,7 @@ import { Observer } from '@playcanvas/observer';
 class AssetViewerExample {
     static CATEGORY = 'Graphics';
     static NAME = 'Asset Viewer';
+    static WEBGPU_ENABLED = true;
 
     controls(data: Observer) {
         return <>

--- a/src/framework/parsers/glb-parser.js
+++ b/src/framework/parsers/glb-parser.js
@@ -491,12 +491,20 @@ const createVertexBufferInternal = (device, sourceDesc, flipV) => {
     const vertexDesc = [];
     for (const semantic in sourceDesc) {
         if (sourceDesc.hasOwnProperty(semantic)) {
-            vertexDesc.push({
+            const element = {
                 semantic: semantic,
                 components: sourceDesc[semantic].components,
                 type: sourceDesc[semantic].type,
                 normalize: !!sourceDesc[semantic].normalize
-            });
+            };
+
+            if (!VertexFormat.isElementValid(device, element)) {
+                // WebGP does not support some formats and we need to remap it to one larger, for example int16x3 -> int16x4
+                // TODO: this might need the actual data changes if this element is the last one in the vertex, as it might
+                // try to read outside of the vertex buffer.
+                element.components++;
+            }
+            vertexDesc.push(element);
         }
     }
 

--- a/src/platform/graphics/vertex-format.js
+++ b/src/platform/graphics/vertex-format.js
@@ -10,6 +10,7 @@ import {
 } from './constants.js';
 
 const stringIds = new StringIds();
+const webgpuValidElementSizes = [2, 4, 8, 12, 16];
 
 /**
  * A vertex format is a descriptor that defines the layout of vertex data inside a
@@ -144,7 +145,7 @@ class VertexFormat {
             elementSize = elementDesc.components * typedArrayTypesByteSize[elementDesc.type];
 
             // WebGPU has limited element size support (for example uint16x3 is not supported)
-            Debug.assert(!graphicsDevice.isWebGPU || [2, 4, 8, 12, 16].includes(elementSize),
+            Debug.assert(VertexFormat.isElementValid(graphicsDevice, elementDesc),
                          `WebGPU does not support the format of vertex element ${elementDesc.semantic} : ${vertexTypesNames[elementDesc.type]} x ${elementDesc.components}`);
 
             // align up the offset to elementSize (when vertexCount is specified only - case of non-interleaved format)
@@ -222,6 +223,13 @@ class VertexFormat {
         }
 
         return VertexFormat._defaultInstancingFormat;
+    }
+
+    static isElementValid(graphicsDevice, elementDesc) {
+        const elementSize = elementDesc.components * typedArrayTypesByteSize[elementDesc.type];
+        if (graphicsDevice.isWebGPU && !webgpuValidElementSizes.includes(elementSize))
+            return false;
+        return true;
     }
 
     /**


### PR DESCRIPTION
WebGPU does not support all vertex formats. Here's a supported list:
<img width="231" alt="Screenshot 2023-10-04 at 15 47 11" src="https://github.com/playcanvas/engine/assets/59932779/954e4e72-64f3-47f8-8f10-8581771c9ef8">

Note that for example `uint16x3` format is not supported, which is often used to store positions / normals in glb files.

We work around this by mapping it to `uint16x4` which overlaps with some other element in the vertex buffer, but as the shader does not use it, it should be harmless.

There's a risk that if the last element is fixed this way, we might read outside of the vertex buffer space - if that happens, we might need a better fix.

This now works on WebGPU:
![Screenshot 2023-10-04 at 15 45 02](https://github.com/playcanvas/engine/assets/59932779/632637e3-0b09-486d-929b-53f6570fafc8)
