### PR TITLE
WebGPU texture anisotropy validation fix

### DIFF
--- a/src/platform/graphics/webgpu/webgpu-texture.js
+++ b/src/platform/graphics/webgpu/webgpu-texture.js
@@ -284,9 +284,12 @@ class WebgpuTexture {
                 }
             }
 
-            // ensure anisotropy is only used only when filtering is correctly
+            // ensure anisotropic filtering is only set when filtering is correctly
             // set up
-            descr.maxAnisotropy = (descr.minFilter === 'linear' && descr.magFilter === 'linear') ?
+            const allLinear = (descr.minFilter === 'linear' &&
+                               descr.magFilter === 'linear' &&
+                               descr.mipmapFilter === 'linear');
+            descr.maxAnisotropy = allLinear ?
                 math.clamp(Math.round(texture._anisotropy), 1, device.maxTextureAnisotropy) :
                 1;
 

--- a/src/platform/graphics/webgpu/webgpu-texture.js
+++ b/src/platform/graphics/webgpu/webgpu-texture.js
@@ -240,8 +240,7 @@ class WebgpuTexture {
             const descr = {
                 addressModeU: gpuAddressModes[texture.addressU],
                 addressModeV: gpuAddressModes[texture.addressV],
-                addressModeW: gpuAddressModes[texture.addressW],
-                maxAnisotropy: math.clamp(Math.round(texture._anisotropy), 1, device.maxTextureAnisotropy)
+                addressModeW: gpuAddressModes[texture.addressW]
             };
 
             // default for compare sampling of texture
@@ -284,6 +283,12 @@ class WebgpuTexture {
                     });
                 }
             }
+
+            // ensure anisotropy is only used only when filtering is correctly
+            // set up
+            descr.maxAnisotropy = (descr.minFilter === 'linear' && descr.magFilter === 'linear') ?
+                math.clamp(Math.round(texture._anisotropy), 1, device.maxTextureAnisotropy) :
+                1;
 
             sampler = device.wgpu.createSampler(descr);
             DebugHelper.setLabel(sampler, label);


### PR DESCRIPTION
According to the WebGPU spec anisotropy can only be enabled when filtering is linear for both min and mag.

This PR adds changes the WebGPU sampler builder to only set valid anisotropy value.