### PR TITLE
[Fix] Posteffect render targets were not resized correctly

### DIFF
--- a/src/framework/components/camera/post-effect-queue.js
+++ b/src/framework/components/camera/post-effect-queue.js
@@ -72,7 +72,7 @@ class PostEffectQueue {
      */
     _allocateColorBuffer(format, name) {
         const rect = this.camera.rect;
-        const renderTarget = this.camera.renderTarget;
+        const renderTarget = this.destinationRenderTarget;
         const device = this.app.graphicsDevice;
 
         const width = Math.floor(rect.z * (renderTarget?.width ?? device.width));
@@ -348,7 +348,7 @@ class PostEffectQueue {
      */
     _onCanvasResized(width, height) {
         const rect = this.camera.rect;
-        const renderTarget = this.camera.renderTarget;
+        const renderTarget = this.destinationRenderTarget;
 
         width = renderTarget?.width ?? width;
         height = renderTarget?.height ?? height;
@@ -360,7 +360,7 @@ class PostEffectQueue {
 
     resizeRenderTargets() {
         const device = this.app.graphicsDevice;
-        const renderTarget = this.camera.renderTarget;
+        const renderTarget = this.destinationRenderTarget;
         const width = renderTarget?.width ?? device.width;
         const height = renderTarget?.height ?? device.height;
 


### PR DESCRIPTION
Internal render targets need to be resized based on the original render target of the camera, and not the current target which is allocated by posteffects to temporarily render the data to, otherwise we compare target size with itself and never resize it.

Fixes: https://github.com/playcanvas/engine/issues/5722
Introduced in: https://github.com/playcanvas/engine/pull/5651