### PR TITLE
[Fix] Don’t delete the framebuffer owned by the context

### DIFF
--- a/src/platform/graphics/webgl/webgl-render-target.js
+++ b/src/platform/graphics/webgl/webgl-render-target.js
@@ -70,7 +70,8 @@ class WebglRenderTarget {
         this._isInitialized = false;
 
         if (this._glFrameBuffer) {
-            gl.deleteFramebuffer(this._glFrameBuffer);
+            if (this._glFrameBuffer !== this.suppliedColorFramebuffer)
+                gl.deleteFramebuffer(this._glFrameBuffer);
             this._glFrameBuffer = null;
         }
 
@@ -80,7 +81,8 @@ class WebglRenderTarget {
         }
 
         if (this._glResolveFrameBuffer) {
-            gl.deleteFramebuffer(this._glResolveFrameBuffer);
+            if (this._glResolveFrameBuffer !== this.suppliedColorFramebuffer)
+                gl.deleteFramebuffer(this._glResolveFrameBuffer);
             this._glResolveFrameBuffer = null;
         }
 
@@ -98,6 +100,7 @@ class WebglRenderTarget {
             gl.deleteRenderbuffer(this._glMsaaDepthBuffer);
             this._glMsaaDepthBuffer = null;
         }
+        this.suppliedColorFramebuffer = undefined;
     }
 
     get initialized() {


### PR DESCRIPTION
- we wrap it in our RenderTarget, but do not own it so avoid destroying it.
- this was creating an error when exiting from the XR
![image](https://github.com/playcanvas/engine/assets/59932779/f89db009-8130-41d4-b4f2-b1f2552bd847)
