### PR TITLE
[Fix] WebGPU can give us async mapped buffer after the device was destroyed, handle it

### DIFF
--- a/src/platform/graphics/webgpu/webgpu-dynamic-buffers.js
+++ b/src/platform/graphics/webgpu/webgpu-dynamic-buffers.js
@@ -81,8 +81,11 @@ class WebgpuDynamicBuffers extends DynamicBuffers {
             for (let i = 0; i < count; i++) {
                 const stagingBuffer = this.pendingStagingBuffers[i];
                 stagingBuffer.buffer.mapAsync(GPUMapMode.WRITE).then(() => {
-                    stagingBuffer.onAvailable();
-                    this.stagingBuffers.push(stagingBuffer);
+                    // the buffer can be mapped after the device has been destroyed, so test for that
+                    if (this.stagingBuffers) {
+                        stagingBuffer.onAvailable();
+                        this.stagingBuffers.push(stagingBuffer);
+                    }
                 });
             }
             this.pendingStagingBuffers.length = 0;


### PR DESCRIPTION
Fixes https://github.com/playcanvas/engine/issues/5729

after we destroyed a device, gpu use buffers can be async mapped back to us, and the code uses null array pointer - so avoid this and simply ignore the buffer.