### PR TITLE
Workaround for webpack not building

### DIFF
--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -167,8 +167,8 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
         Debug.log("WebgpuGraphicsDevice initialization ..");
 
         const results = await Promise.all([
-            import(twgslUrl).then(module => twgsl(twgslUrl.replace('.js', '.wasm'))),
-            import(glslangUrl).then(module => module.default())
+            import(`${twgslUrl}`).then(module => twgsl(twgslUrl.replace('.js', '.wasm'))),
+            import(`${glslangUrl}`).then(module => module.default())
         ]);
 
         this.twgsl = results[0];


### PR DESCRIPTION
Fixes #5730

Webpack was failing to build correctly after recent changes to WebGPU wasm handling.

This PR changes the glue import statement to really _really_ dynamic so webpack will leave it be.