### PR TITLE
Refactoring to LayerComposition internal implementation

### DIFF
--- a/src/deprecated/deprecated.js
+++ b/src/deprecated/deprecated.js
@@ -805,7 +805,7 @@ Object.defineProperty(Layer.prototype, 'renderTarget', {
     set: function (rt) {
         Debug.deprecated(`pc.Layer#renderTarget is deprecated. Set the render target on the camera instead.`);
         this._renderTarget = rt;
-        this._dirtyCameras = true;
+        this._dirtyComposition = true;
     },
     get: function () {
         return this._renderTarget;

--- a/src/framework/components/camera/component.js
+++ b/src/framework/components/camera/component.js
@@ -731,7 +731,7 @@ class CameraComponent extends Component {
     dirtyLayerCompositionCameras() {
         // layer composition needs to update order
         const layerComp = this.system.app.scene.layers;
-        layerComp._dirtyCameras = true;
+        layerComp._dirty = true;
     }
 
     /**

--- a/src/scene/composition/layer-composition.js
+++ b/src/scene/composition/layer-composition.js
@@ -40,6 +40,22 @@ class LayerComposition extends EventHandler {
     layerNameMap = new Map();
 
     /**
+     * A mapping of {@link Layer} to its opaque index in {@link LayerComposition#layerList}.
+     *
+     * @type {Map<import('../layer.js').Layer, number>}
+     * @ignore
+     */
+    layerOpaqueIndexMap = new Map();
+
+    /**
+     * A mapping of {@link Layer} to its transparent index in {@link LayerComposition#layerList}.
+     *
+     * @type {Map<import('../layer.js').Layer, number>}
+     * @ignore
+     */
+    layerTransparentIndexMap = new Map();
+
+    /**
      * A read-only array of boolean values, matching {@link LayerComposition#layerList}. True means only
      * semi-transparent objects are rendered, and false means opaque.
      *
@@ -82,6 +98,13 @@ class LayerComposition extends EventHandler {
     _renderActions = [];
 
     /**
+     * True if the composition needs to be updated before rendering.
+     *
+     * @ignore
+     */
+    _dirty = false;
+
+    /**
      * Create a new layer composition.
      *
      * @param {string} [name] - Optional non-unique name of the layer composition. Defaults to
@@ -94,8 +117,6 @@ class LayerComposition extends EventHandler {
 
         this._opaqueOrder = {};
         this._transparentOrder = {};
-
-        this._dirtyCameras = false;
     }
 
     destroy() {
@@ -108,24 +129,24 @@ class LayerComposition extends EventHandler {
         const len = this.layerList.length;
 
         // if composition dirty flag is not set, test if layers are marked dirty
-        if (!this._dirtyCameras) {
+        if (!this._dirty) {
             for (let i = 0; i < len; i++) {
-                if (this.layerList[i]._dirtyCameras) {
-                    this._dirtyCameras = true;
+                if (this.layerList[i]._dirtyComposition) {
+                    this._dirty = true;
                     break;
                 }
             }
         }
 
-        if (this._dirtyCameras) {
+        if (this._dirty) {
 
-            this._dirtyCameras = false;
+            this._dirty = false;
 
             // walk the layers and build an array of unique cameras from all layers
             this.cameras.length = 0;
             for (let i = 0; i < len; i++) {
                 const layer = this.layerList[i];
-                layer._dirtyCameras = false;
+                layer._dirtyComposition = false;
 
                 // for all cameras in the layer
                 for (let j = 0; j < layer.cameras.length; j++) {
@@ -172,8 +193,8 @@ class LayerComposition extends EventHandler {
                 for (let j = 0; j < len; j++) {
 
                     const layer = this.layerList[j];
-                    const isLayerEnabled = this.subLayerEnabled[j];
-                    if (layer && isLayerEnabled) {
+                    const isLayerEnabled = layer.enabled && this.subLayerEnabled[j];
+                    if (isLayerEnabled) {
 
                         // if layer needs to be rendered
                         if (layer.cameras.length > 0) {
@@ -196,7 +217,8 @@ class LayerComposition extends EventHandler {
                                 }
 
                                 // add render action to describe rendering step
-                                lastRenderAction = this.addRenderAction(this._renderActions, renderActionCount, layer, j, camera,
+                                const isTransparent = this.subLayerList[j];
+                                lastRenderAction = this.addRenderAction(this._renderActions, renderActionCount, layer, isTransparent, camera,
                                                                         cameraFirstRenderAction, postProcessMarked);
                                 renderActionCount++;
                                 cameraFirstRenderAction = false;
@@ -235,7 +257,7 @@ class LayerComposition extends EventHandler {
     }
 
     // function adds new render action to a list, while trying to limit allocation and reuse already allocated objects
-    addRenderAction(renderActions, renderActionIndex, layer, layerIndex, camera, cameraFirstRenderAction, postProcessMarked) {
+    addRenderAction(renderActions, renderActionIndex, layer, isTransparent, camera, cameraFirstRenderAction, postProcessMarked) {
 
         // try and reuse object, otherwise allocate new
         /** @type {RenderAction} */
@@ -281,8 +303,8 @@ class LayerComposition extends EventHandler {
 
         // store the properties - write all as we reuse previously allocated class instances
         renderAction.triggerPostprocess = false;
-        renderAction.layerIndex = layerIndex;
         renderAction.layer = layer;
+        renderAction.transparent = isTransparent;
         renderAction.camera = camera;
         renderAction.renderTarget = rt;
         renderAction.clearColor = clearColor;
@@ -301,7 +323,7 @@ class LayerComposition extends EventHandler {
         for (let a = startIndex; a >= 0; a--) {
 
             const ra = this._renderActions[a];
-            const layer = this.layerList[ra.layerIndex];
+            const layer = ra.layer;
 
             // if we hit render action with a render target (other than depth layer), that marks the end of camera stack
             // TODO: refactor this as part of depth layer refactoring
@@ -335,17 +357,15 @@ class LayerComposition extends EventHandler {
             Debug.trace(TRACEID_RENDER_ACTION, 'Render Actions for composition: ' + this.name);
             for (let i = 0; i < this._renderActions.length; i++) {
                 const ra = this._renderActions[i];
-                const layerIndex = ra.layerIndex;
-                const layer = this.layerList[layerIndex];
-                const enabled = layer.enabled && this.subLayerEnabled[layerIndex];
-                const transparent = this.subLayerList[layerIndex];
+                const layer = ra.layer;
+                const enabled = layer.enabled && this.isEnabled(layer, ra.transparent);
                 const camera = ra.camera;
                 const clear = (ra.clearColor ? 'Color ' : '..... ') + (ra.clearDepth ? 'Depth ' : '..... ') + (ra.clearStencil ? 'Stencil' : '.......');
 
                 Debug.trace(TRACEID_RENDER_ACTION, i +
                     (' Cam: ' + (camera ? camera.entity.name : '-')).padEnd(22, ' ') +
                     (' Lay: ' + layer.name).padEnd(22, ' ') +
-                    (transparent ? ' TRANSP' : ' OPAQUE') +
+                    (ra.transparent ? ' TRANSP' : ' OPAQUE') +
                     (enabled ? ' ENABLED ' : ' DISABLED') +
                     (' RT: ' + (ra.renderTarget ? ra.renderTarget.name : '-')).padEnd(30, ' ') +
                     ' Clear: ' + clear +
@@ -365,11 +385,10 @@ class LayerComposition extends EventHandler {
     }
 
     _isSublayerAdded(layer, transparent) {
-        for (let i = 0; i < this.layerList.length; i++) {
-            if (this.layerList[i] === layer && this.subLayerList[i] === transparent) {
-                Debug.error(`Sublayer ${layer.name}, transparent: ${transparent} is already added.`);
-                return true;
-            }
+        const map = transparent ? this.layerTransparentIndexMap : this.layerOpaqueIndexMap;
+        if (map.get(layer) !== undefined) {
+            Debug.error(`Sublayer ${layer.name}, transparent: ${transparent} is already added.`);
+            return true;
         }
         return false;
     }
@@ -392,7 +411,7 @@ class LayerComposition extends EventHandler {
         this.subLayerEnabled.push(true);
 
         this._updateLayerMaps();
-        this._dirtyCameras = true;
+        this._dirty = true;
         this.fire('add', layer);
     }
 
@@ -415,7 +434,7 @@ class LayerComposition extends EventHandler {
         this.subLayerEnabled.splice(index, 0, true, true);
 
         this._updateLayerMaps();
-        this._dirtyCameras = true;
+        this._dirty = true;
         this.fire('add', layer);
     }
 
@@ -436,7 +455,7 @@ class LayerComposition extends EventHandler {
             this.subLayerList.splice(id, 1);
             this.subLayerEnabled.splice(id, 1);
             id = this.layerList.indexOf(layer);
-            this._dirtyCameras = true;
+            this._dirty = true;
             this.fire('remove', layer);
         }
 
@@ -463,7 +482,7 @@ class LayerComposition extends EventHandler {
         this.subLayerEnabled.push(true);
 
         this._updateLayerMaps();
-        this._dirtyCameras = true;
+        this._dirty = true;
         this.fire('add', layer);
     }
 
@@ -486,7 +505,7 @@ class LayerComposition extends EventHandler {
         this.subLayerEnabled.splice(index, 0, true);
 
         this._updateLayerMaps();
-        this._dirtyCameras = true;
+        this._dirty = true;
         this.fire('add', layer);
     }
 
@@ -507,7 +526,7 @@ class LayerComposition extends EventHandler {
                 this._updateOpaqueOrder(i, len - 1);
 
                 this.subLayerEnabled.splice(i, 1);
-                this._dirtyCameras = true;
+                this._dirty = true;
                 if (this.layerList.indexOf(layer) < 0) {
                     this.fire('remove', layer); // no sublayers left
                 }
@@ -530,7 +549,7 @@ class LayerComposition extends EventHandler {
         this.subLayerEnabled.push(true);
 
         this._updateLayerMaps();
-        this._dirtyCameras = true;
+        this._dirty = true;
         this.fire('add', layer);
     }
 
@@ -552,7 +571,7 @@ class LayerComposition extends EventHandler {
         this.subLayerEnabled.splice(index, 0, true);
 
         this._updateLayerMaps();
-        this._dirtyCameras = true;
+        this._dirty = true;
         this.fire('add', layer);
     }
 
@@ -572,7 +591,7 @@ class LayerComposition extends EventHandler {
                 this._updateTransparentOrder(i, len - 1);
 
                 this.subLayerEnabled.splice(i, 1);
-                this._dirtyCameras = true;
+                this._dirty = true;
                 if (this.layerList.indexOf(layer) < 0) {
                     this.fire('remove', layer); // no sublayers left
                 }
@@ -582,39 +601,32 @@ class LayerComposition extends EventHandler {
         this._updateLayerMaps();
     }
 
-    _getSublayerIndex(layer, transparent) {
-        // find sublayer index in the composition array
-        let id = this.layerList.indexOf(layer);
-        if (id < 0) return -1;
-
-        if (this.subLayerList[id] !== transparent) {
-            id = this.layerList.indexOf(layer, id + 1);
-            if (id < 0) return -1;
-            if (this.subLayerList[id] !== transparent) {
-                return -1;
-            }
-        }
-        return id;
-    }
-
     /**
      * Gets index of the opaque part of the supplied layer in the {@link LayerComposition#layerList}.
      *
      * @param {import('../layer.js').Layer} layer - A {@link Layer} to find index of.
-     * @returns {number} The index of the opaque part of the specified layer.
+     * @returns {number} The index of the opaque part of the specified layer, or -1 if it is not
+     * part of the composition.
      */
     getOpaqueIndex(layer) {
-        return this._getSublayerIndex(layer, false);
+        return this.layerOpaqueIndexMap.get(layer) ?? -1;
     }
 
     /**
      * Gets index of the semi-transparent part of the supplied layer in the {@link LayerComposition#layerList}.
      *
      * @param {import('../layer.js').Layer} layer - A {@link Layer} to find index of.
-     * @returns {number} The index of the semi-transparent part of the specified layer.
+     * @returns {number} The index of the semi-transparent part of the specified layer, or -1 if it
+     * is not part of the composition.
      */
     getTransparentIndex(layer) {
-        return this._getSublayerIndex(layer, true);
+        return this.layerTransparentIndexMap.get(layer) ?? -1;
+    }
+
+    isEnabled(layer, transparent) {
+        const index = transparent ? this.getTransparentIndex(layer) : this.getOpaqueIndex(layer);
+        Debug.assert(index >= 0, `${transparent ? 'Transparent' : 'Opaque'} layer ${layer.name} is not part of the composition.`);
+        return this.subLayerEnabled[index];
     }
 
     /**
@@ -625,10 +637,16 @@ class LayerComposition extends EventHandler {
     _updateLayerMaps() {
         this.layerIdMap.clear();
         this.layerNameMap.clear();
+        this.layerOpaqueIndexMap.clear();
+        this.layerTransparentIndexMap.clear();
+
         for (let i = 0; i < this.layerList.length; i++) {
             const layer = this.layerList[i];
             this.layerIdMap.set(layer.id, layer);
             this.layerNameMap.set(layer.name, layer);
+
+            const subLayerIndexMap = this.subLayerList[i] ? this.layerTransparentIndexMap : this.layerOpaqueIndexMap;
+            subLayerIndexMap.set(layer, i);
         }
     }
 

--- a/src/scene/composition/render-action.js
+++ b/src/scene/composition/render-action.js
@@ -8,7 +8,7 @@ class RenderAction {
     constructor() {
 
         // the layer
-        /** @type {import('../layer.js').Layer} */
+        /** @type {import('../layer.js').Layer|null} */
         this.layer = null;
 
         // true if this uses transparent sublayer, opaque otherwise

--- a/src/scene/composition/render-action.js
+++ b/src/scene/composition/render-action.js
@@ -7,11 +7,12 @@
 class RenderAction {
     constructor() {
 
-        // index into a layer stored in LayerComposition.layerList
-        this.layerIndex = 0;
-
         // the layer
+        /** @type {import('../layer.js').Layer} */
         this.layer = null;
+
+        // true if this uses transparent sublayer, opaque otherwise
+        this.transparent = false;
 
         // camera of type CameraComponent
         this.camera = null;
@@ -60,16 +61,6 @@ class RenderAction {
 
     get hasDirectionalShadowLights() {
         return this.directionalLights.length > 0;
-    }
-
-    /**
-     * @param {import('./layer-composition.js').LayerComposition} layerComposition - The layer
-     * composition.
-     * @returns {boolean} - True if the layer / sublayer referenced by the render action is enabled
-     */
-    isLayerEnabled(layerComposition) {
-        const layer = layerComposition.layerList[this.layerIndex];
-        return layer.enabled && layerComposition.subLayerEnabled[this.layerIndex];
     }
 }
 

--- a/src/scene/layer.js
+++ b/src/scene/layer.js
@@ -167,7 +167,12 @@ class Layer {
      */
     camerasSet = new Set();
 
-    _dirtyCameras = false;
+    /**
+     * True if the composition is invalidated.
+     *
+     * @ignore
+     */
+    _dirtyComposition = false;
 
     /**
      * Create a new Layer instance.
@@ -445,6 +450,7 @@ class Layer {
      */
     set enabled(val) {
         if (val !== this._enabled) {
+            this._dirtyComposition = true;
             this._enabled = val;
             if (val) {
                 this.incrementCounter();
@@ -467,7 +473,7 @@ class Layer {
      */
     set clearColorBuffer(val) {
         this._clearColorBuffer = val;
-        this._dirtyCameras = true;
+        this._dirtyComposition = true;
     }
 
     get clearColorBuffer() {
@@ -481,7 +487,7 @@ class Layer {
      */
     set clearDepthBuffer(val) {
         this._clearDepthBuffer = val;
-        this._dirtyCameras = true;
+        this._dirtyComposition = true;
     }
 
     get clearDepthBuffer() {
@@ -495,7 +501,7 @@ class Layer {
      */
     set clearStencilBuffer(val) {
         this._clearStencilBuffer = val;
-        this._dirtyCameras = true;
+        this._dirtyComposition = true;
     }
 
     get clearStencilBuffer() {
@@ -850,7 +856,7 @@ class Layer {
         if (!this.camerasSet.has(camera.camera)) {
             this.camerasSet.add(camera.camera);
             this.cameras.push(camera);
-            this._dirtyCameras = true;
+            this._dirtyComposition = true;
         }
     }
 
@@ -865,7 +871,7 @@ class Layer {
             this.camerasSet.delete(camera.camera);
             const index = this.cameras.indexOf(camera);
             this.cameras.splice(index, 1);
-            this._dirtyCameras = true;
+            this._dirtyComposition = true;
         }
     }
 
@@ -875,7 +881,7 @@ class Layer {
     clearCameras() {
         this.cameras.length = 0;
         this.camerasSet.clear();
-        this._dirtyCameras = true;
+        this._dirtyComposition = true;
     }
 
     /**

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -774,8 +774,7 @@ class ForwardRenderer extends Renderer {
         for (let i = startIndex; i < renderActions.length; i++) {
 
             const renderAction = renderActions[i];
-            const layer = layerComposition.layerList[renderAction.layerIndex];
-            const camera = renderAction.camera;
+            const { layer, camera } = renderAction;
 
             // on webgl1, depth pass renders ahead of the main camera instead of the middle of the frame
             const depthPass = camera.camera.renderPassDepthGrab;
@@ -783,11 +782,6 @@ class ForwardRenderer extends Renderer {
 
                 depthPass.update(this.scene);
                 frameGraph.addRenderPass(depthPass);
-            }
-
-            // skip disabled layers
-            if (!renderAction.isLayerEnabled(layerComposition)) {
-                continue;
             }
 
             const isDepthLayer = layer.id === LAYERID_DEPTH;
@@ -810,15 +804,9 @@ class ForwardRenderer extends Renderer {
                 renderTarget = renderAction.renderTarget;
             }
 
-            // find the next enabled render action
-            let nextIndex = i + 1;
-            while (renderActions[nextIndex] && !renderActions[nextIndex].isLayerEnabled(layerComposition)) {
-                nextIndex++;
-            }
-
             // info about the next render action
-            const nextRenderAction = renderActions[nextIndex];
-            const isNextLayerDepth = nextRenderAction ? layerComposition.layerList[nextRenderAction.layerIndex].id === LAYERID_DEPTH : false;
+            const nextRenderAction = renderActions[i + 1];
+            const isNextLayerDepth = nextRenderAction ? nextRenderAction.layer.id === LAYERID_DEPTH : false;
             const isNextLayerGrabPass = isNextLayerDepth && (camera.renderSceneColorMap || camera.renderSceneDepthMap) && !webgl1;
 
             // end of the block using the same render target

--- a/src/scene/renderer/render-pass-render-actions.js
+++ b/src/scene/renderer/render-pass-render-actions.js
@@ -84,7 +84,7 @@ class RenderPassRenderActions extends RenderPass {
         const { layerComposition, renderActions } = this;
         for (let i = 0; i < renderActions.length; i++) {
             const ra = renderActions[i];
-            if (ra.isLayerEnabled(layerComposition)) {
+            if (layerComposition.isEnabled(ra.layer, ra.transparent)) {
                 this.renderRenderAction(ra, i === 0);
             }
         }
@@ -114,11 +114,7 @@ class RenderPassRenderActions extends RenderPass {
         const device = renderer.device;
 
         // layer
-        const layerIndex = renderAction.layerIndex;
-        const layer = layerComposition.layerList[layerIndex];
-        const transparent = layerComposition.subLayerList[layerIndex];
-
-        const camera = renderAction.camera;
+        const { layer, transparent, camera } = renderAction;
         const cameraPass = layerComposition.camerasMap.get(camera);
 
         DebugGraphics.pushGpuMarker(this.device, camera ? camera.entity.name : 'noname');
@@ -251,16 +247,14 @@ class RenderPassRenderActions extends RenderPass {
             const { layerComposition } = this;
             this.renderActions.forEach((ra, index) => {
 
-                const layerIndex = ra.layerIndex;
-                const layer = layerComposition.layerList[layerIndex];
-                const enabled = layer.enabled && layerComposition.subLayerEnabled[layerIndex];
-                const transparent = layerComposition.subLayerList[layerIndex];
+                const layer = ra.layer;
+                const enabled = layer.enabled && layerComposition.isEnabled(layer, ra.transparent);
                 const camera = ra.camera;
 
                 Debug.trace(TRACEID_RENDER_PASS_DETAIL, `    ${index}:` +
                     (' Cam: ' + (camera ? camera.entity.name : '-')).padEnd(22, ' ') +
                     (' Lay: ' + layer.name).padEnd(22, ' ') +
-                    (transparent ? ' TRANSP' : ' OPAQUE') +
+                    (ra.transparent ? ' TRANSP' : ' OPAQUE') +
                     (enabled ? ' ENABLED' : ' DISABLED') +
                     (' Meshes: ' + layer.meshInstances.length).padEnd(5, ' ')
                 );

--- a/src/scene/renderer/renderer.js
+++ b/src/scene/renderer/renderer.js
@@ -1076,10 +1076,10 @@ class Renderer {
             const renderAction = renderActions[i];
 
             // layer
-            const layerIndex = renderAction.layerIndex;
-            /** @type {import('../layer.js').Layer} */
-            const layer = comp.layerList[layerIndex];
-            if (!layer.enabled || !comp.subLayerEnabled[layerIndex]) continue;
+            const { layer, transparent } = renderAction;
+            const subLayerEnabled = comp.isEnabled(layer, transparent);
+            if (!layer.enabled || !subLayerEnabled)
+                continue;
 
             // camera
             /** @type {import('../../framework/components/camera/component.js').CameraComponent} */


### PR DESCRIPTION
- LayerCompositions has additional maps to look up index of sublayers, plus few related optimisations
- RenderAction no longer stores sublayer index
- LayerComposition is updated when a layer.enable state changes - so we no longer need to handle this during rendering
- Mesh Instance culling using cameras / layers directly instead of composition / RenderActions, to be easy to use with custom RenderPassRenderAction instances that are not part of the composition.