### PR TITLE
chore: "no-else-return" lint warning in release.cjs

### DIFF
--- a/release.cjs
+++ b/release.cjs
@@ -204,11 +204,12 @@ const run = () => {
         } else if (curBranch.startsWith(releaseBranchName)) {
             finalizeRelease(curBranch);
             return 0;
-        } else {
-            console.error(`error: unrecognized branch '${curBranch}.`);
-            printUsage();
-            return 1;
         }
+
+        console.error(`error: unrecognized branch '${curBranch}.`);
+        printUsage();
+        return 1;
+
     } else if (process.argv.length === 3) {
         // operation specified as arg
         const operation = process.argv[2];


### PR DESCRIPTION
Remove "no-else-return" lint warning.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
