### PR TITLE
build(es5): drop UMD-IIFE pattern for plain IIFE pattern

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -198,9 +198,9 @@ function buildTarget(buildType, moduleFormat) {
         es6: '.mjs'
     };
 
-    /** @type {Record<string, 'umd'|'es'>} */
+    /** @type {Record<string, 'iife'|'es'>} */
     const outputFormat = {
-        es5: 'umd',
+        es5: 'iife',
         es6: 'es'
     };
 
@@ -288,7 +288,7 @@ function scriptTarget(name, input, output) {
             name: name,
             banner: getBanner(''),
             file: output || input.replace('.mjs', '.js'),
-            format: 'umd',
+            format: 'iife',
             indent: '\t',
             globals: { playcanvas: 'pc' }
         },


### PR DESCRIPTION
Drops umd-iife pattern for plain iife pattern.

The UMD pattern (not standardised) adds "if statements" to an IIFE wrapper for commonjs, AMD runtime loaders, and plain IIFE.

- commonjs is not required: this library will is not designed to run in a node context. All currently supported version of node support ES modules.
- AMD is not required: it requires a runtime loader, library already publishes an ES module format which produces smaller builds, all browsers natively support ES modules, ES modules provide real language and runtime level isolation from conflicts.
- IIFE format provides a clean single file, which is required for this project's ES5 builds and its use-cases for simple browser deployment via script tag.  This is the only code path that is currently used when it comes to the ES5 distribution formats.

All tools code and projects in the ecosystem rely on the IIFE format presentation.  The other formats and code paths are unused.  The other major libraries have already dropped the UMD format.

The practical changes to the ES5 formats (a nickname used in this project to refer to a single file IIFE distributions wrapped in a global variable called "pc", the language level is not strictly ES5) are as follows:

The following wrapper at the top of each file generated by rollup:

```js 
(function (global, factory) {
	typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
	typeof define === 'function' && define.amd ? define(['exports'], factory) :
	(global = typeof globalThis !== 'undefined' ? globalThis : global || self, factory(global.pc = {}));
})(this, (function (exports) { 'use strict';
```

becomes the equivalent:

```js
var pc = (function (exports) {
	'use strict';
```

See: https://rollupjs.org/configuration-options/#output-format

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
