### PR TITLE
JSDocs update - the device is non-optional parameter to the Mesh constructor

### DIFF
--- a/src/scene/mesh.js
+++ b/src/scene/mesh.js
@@ -172,9 +172,8 @@ class Mesh extends RefCountedObject {
     /**
      * Create a new Mesh instance.
      *
-     * @param {import('../platform/graphics/graphics-device.js').GraphicsDevice} [graphicsDevice] -
-     * The graphics device used to manage this mesh. If it is not provided, a device is obtained
-     * from the {@link Application}.
+     * @param {import('../platform/graphics/graphics-device.js').GraphicsDevice} graphicsDevice -
+     * The graphics device used to manage this mesh.
      */
     constructor(graphicsDevice) {
         super();


### PR DESCRIPTION
We handle it missing, but that is for compatibility, in reality it is not optional.