### PR TITLE
Initial framework for compute shaders on WebGPU

### DIFF
--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -105,6 +105,13 @@ export const TRACEID_BINDGROUPFORMAT_ALLOC = 'BindGroupFormatAlloc';
 export const TRACEID_RENDERPIPELINE_ALLOC = 'RenderPipelineAlloc';
 
 /**
+ * Logs the creation of compute pipelines. WebBPU only.
+ *
+ * @type {string}
+ */
+export const TRACEID_COMPUTEPIPELINE_ALLOC = 'ComputePipelineAlloc';
+
+/**
  * Logs the creation of pipeline layouts. WebBPU only.
  *
  * @type {string}

--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -105,7 +105,7 @@ export const TRACEID_BINDGROUPFORMAT_ALLOC = 'BindGroupFormatAlloc';
 export const TRACEID_RENDERPIPELINE_ALLOC = 'RenderPipelineAlloc';
 
 /**
- * Logs the creation of compute pipelines. WebBPU only.
+ * Logs the creation of compute pipelines. WebGPU only.
  *
  * @type {string}
  */

--- a/src/core/tracing.js
+++ b/src/core/tracing.js
@@ -37,6 +37,7 @@ class Tracing {
      * - {@link TRACEID_VRAM_VB}
      * - {@link TRACEID_VRAM_IB}
      * - {@link TRACEID_RENDERPIPELINE_ALLOC}
+     * - {@link TRACEID_COMPUTEPIPELINE_ALLOC}
      * - {@link TRACEID_PIPELINELAYOUT_ALLOC}
      * - {@link TRACEID_TEXTURES}
      * - {@link TRACEID_GPU_TIMINGS}

--- a/src/index.js
+++ b/src/index.js
@@ -58,6 +58,7 @@ export * from './platform/audio/constants.js';
 export * from './platform/graphics/constants.js';
 export { createGraphicsDevice } from './platform/graphics/graphics-device-create.js';
 export { BlendState } from './platform/graphics/blend-state.js';
+export { Compute } from './platform/graphics/compute.js';
 export { DepthState } from './platform/graphics/depth-state.js';
 export { GraphicsDevice } from './platform/graphics/graphics-device.js';
 export { IndexBuffer } from './platform/graphics/index-buffer.js';

--- a/src/platform/graphics/compute.js
+++ b/src/platform/graphics/compute.js
@@ -1,0 +1,44 @@
+/**
+ * A representation of a compute shader with the associated data, that can be executed on the GPU.
+ *
+ * @ignore
+ */
+class Compute {
+    /**
+     * A compute shader.
+     *
+     * @type {import('./shader.js').Shader|null}
+     * @ignore
+     */
+    shader = null;
+
+    /**
+     * Create a compute instance. Note that this is supported on WebGPU only and is a no-op on
+     * other platforms.
+     *
+     * @param {import('./graphics-device.js').GraphicsDevice} graphicsDevice -
+     * The graphics device.
+     * @param {import('./shader.js').Shader} shader - The compute shader.
+     */
+    constructor(graphicsDevice, shader) {
+        this.device = graphicsDevice;
+        this.shader = shader;
+
+        if (graphicsDevice.supportsCompute) {
+            this.impl = graphicsDevice.createComputeImpl(this);
+        }
+    }
+
+    /**
+     * Dispatch the compute work.
+     *
+     * @param {number} x - X dimension of the grid of work-groups to dispatch.
+     * @param {number} [y] - Y dimension of the grid of work-groups to dispatch.
+     * @param {number} [z] - Z dimension of the grid of work-groups to dispatch.
+     */
+    dispatch(x, y, z) {
+        this.impl?.dispatch(x, y, z);
+    }
+}
+
+export { Compute };

--- a/src/platform/graphics/graphics-device.js
+++ b/src/platform/graphics/graphics-device.js
@@ -188,6 +188,14 @@ class GraphicsDevice extends EventHandler {
     supportsVolumeTextures = false;
 
     /**
+     * True if the device supports compute shaders.
+     *
+     * @readonly
+     * @type {boolean}
+     */
+    supportsCompute = false;
+
+    /**
      * Currently active render target.
      *
      * @type {import('./render-target.js').RenderTarget|null}
@@ -751,6 +759,18 @@ class GraphicsDevice extends EventHandler {
      */
     setBoneLimit(maxBones) {
         this.boneLimit = maxBones;
+    }
+
+    startRenderPass(renderPass) {
+    }
+
+    endRenderPass(renderPass) {
+    }
+
+    startComputePass() {
+    }
+
+    endComputePass() {
     }
 
     /**

--- a/src/platform/graphics/null/null-graphics-device.js
+++ b/src/platform/graphics/null/null-graphics-device.js
@@ -123,12 +123,6 @@ class NullGraphicsDevice extends GraphicsDevice {
         super.initializeContextCaches();
     }
 
-    startPass(renderPass) {
-    }
-
-    endPass(renderPass) {
-    }
-
     clear(options) {
     }
 

--- a/src/platform/graphics/render-pass.js
+++ b/src/platform/graphics/render-pass.js
@@ -286,13 +286,13 @@ class RenderPass {
             if (this.executeEnabled) {
 
                 if (realPass) {
-                    device.startPass(this);
+                    device.startRenderPass(this);
                 }
 
                 this.execute();
 
                 if (realPass) {
-                    device.endPass(this);
+                    device.endRenderPass(this);
                 }
             }
 

--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -1408,7 +1408,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
      * @param {import('../render-pass.js').RenderPass} renderPass - The render pass to start.
      * @ignore
      */
-    startPass(renderPass) {
+    startRenderPass(renderPass) {
 
         DebugGraphics.pushGpuMarker(this, `START-PASS`);
 
@@ -1470,7 +1470,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
      * @param {import('../render-pass.js').RenderPass} renderPass - The render pass to end.
      * @ignore
      */
-    endPass(renderPass) {
+    endRenderPass(renderPass) {
 
         DebugGraphics.pushGpuMarker(this, `END-PASS`);
 

--- a/src/platform/graphics/webgpu/webgpu-compute-pipeline.js
+++ b/src/platform/graphics/webgpu/webgpu-compute-pipeline.js
@@ -1,0 +1,61 @@
+import { Debug, DebugHelper } from "../../../core/debug.js";
+import { TRACEID_COMPUTEPIPELINE_ALLOC } from "../../../core/constants.js";
+import { WebgpuDebug } from "./webgpu-debug.js";
+
+let _pipelineId = 0;
+
+/**
+ * @ignore
+ */
+class WebgpuComputePipeline {
+    constructor(device) {
+        /** @type {import('./webgpu-graphics-device.js').WebgpuGraphicsDevice} */
+        this.device = device;
+    }
+
+    /** @private */
+    get(shader) {
+
+        const pipeline = this.create(shader);
+        return pipeline;
+    }
+
+    create(shader) {
+
+        const wgpu = this.device.wgpu;
+
+        /** @type {import('./webgpu-shader.js').WebgpuShader} */
+        const webgpuShader = shader.impl;
+
+        /** @type {GPUComputePipelineDescriptor} */
+        const descr = {
+            compute: {
+                module: webgpuShader.getComputeShaderModule(),
+                entryPoint: webgpuShader.computeEntryPoint
+            },
+
+            // uniform / texture binding layout
+            layout: 'auto'
+        };
+
+        WebgpuDebug.validate(this.device);
+
+        _pipelineId++;
+        DebugHelper.setLabel(descr, `ComputePipelineDescr-${_pipelineId}`);
+
+        const pipeline = wgpu.createComputePipeline(descr);
+
+        DebugHelper.setLabel(pipeline, `ComputePipeline-${_pipelineId}`);
+        Debug.trace(TRACEID_COMPUTEPIPELINE_ALLOC, `Alloc: Id ${_pipelineId}`, descr);
+
+        WebgpuDebug.end(this.device, {
+            computePipeline: this,
+            descr,
+            shader
+        });
+
+        return pipeline;
+    }
+}
+
+export { WebgpuComputePipeline };

--- a/src/platform/graphics/webgpu/webgpu-compute.js
+++ b/src/platform/graphics/webgpu/webgpu-compute.js
@@ -1,0 +1,30 @@
+/**
+ * A WebGPU implementation of the Compute.
+ *
+ * @ignore
+ */
+class WebgpuCompute {
+    constructor(compute) {
+        this.compute = compute;
+
+        const { device, shader } = compute;
+        this.pipeline = device.computePipeline.get(shader);
+    }
+
+    dispatch(x, y, z) {
+
+        // TODO: currently each dispatch is a separate compute pass, which is not optimal, and we should
+        // batch multiple dispatches into a single compute pass
+        const device = this.compute.device;
+        device.startComputePass();
+
+        // dispatch
+        const passEncoder = device.passEncoder;
+        passEncoder.setPipeline(this.pipeline);
+        passEncoder.dispatchWorkgroups(x, y, z);
+
+        device.endComputePass();
+    }
+}
+
+export { WebgpuCompute };

--- a/src/platform/graphics/webgpu/webgpu-shader.js
+++ b/src/platform/graphics/webgpu/webgpu-shader.js
@@ -13,16 +13,23 @@ class WebgpuShader {
     /**
      * Transpiled vertex shader code.
      *
-     * @type {Uint32Array | string}
+     * @type {string|null}
      */
-    _vertexCode;
+    _vertexCode = null;
 
     /**
      * Transpiled fragment shader code.
      *
-     * @type {Uint32Array | string}
+     * @type {string|null}
      */
-    _fragmentCode;
+    _fragmentCode = null;
+
+    /**
+     * Compute shader code.
+     *
+     * @type {string|null}
+     */
+    _computeCode = null;
 
     /**
      * Name of the vertex entry point function.
@@ -33,6 +40,11 @@ class WebgpuShader {
      * Name of the fragment entry point function.
      */
     fragmentEntryPoint = 'main';
+
+    /**
+     * Name of the compute entry point function.
+     */
+    computeEntryPoint = 'main';
 
     /**
      * @param {import('../shader.js').Shader} shader - The shader.
@@ -46,8 +58,9 @@ class WebgpuShader {
 
         if (definition.shaderLanguage === SHADERLANGUAGE_WGSL) {
 
-            this._vertexCode = definition.vshader;
-            this._fragmentCode = definition.fshader;
+            this._vertexCode = definition.vshader ?? null;
+            this._fragmentCode = definition.fshader ?? null;
+            this._computeCode = definition.cshader ?? null;
             this.vertexEntryPoint = 'vertexMain';
             this.fragmentEntryPoint = 'fragmentMain';
             shader.ready = true;
@@ -96,6 +109,10 @@ class WebgpuShader {
 
     getFragmentShaderModule() {
         return this.createShaderModule(this._fragmentCode, 'Fragment');
+    }
+
+    getComputeShaderModule() {
+        return this.createShaderModule(this._computeCode, 'Compute');
     }
 
     process() {


### PR DESCRIPTION
Initial framework, allowing creation and dispatch of WebGPU computer shaders. Note that support for passing data in / out of the compute shader is not yet supported.

All API is currently private, but expected public API:
- `Shader` options object passed to constructor accepts compute shader source code
- `Compute` - new class wrapping an instance of the compute shader along with its parameters (buffers, textures)

Example of its use:
```
const shader = new Shader(device, {
    name: 'ComputeShader',
    shaderLanguage: SHADERLANGUAGE_WGSL,
    cshader: `
        @compute @workgroup_size(8, 8)
        fn main(@builtin(global_invocation_id) global_id : vec3u) {
        }
    `
});

const compute = new Compute(device, shader);
compute.dispatch(4);
```