### PR TITLE
Buffer update speedup

### DIFF
--- a/src/platform/graphics/webgl/webgl-buffer.js
+++ b/src/platform/graphics/webgl/webgl-buffer.js
@@ -26,33 +26,28 @@ class WebglBuffer {
     unlock(device, usage, target, storage) {
         const gl = device.gl;
 
-        let glUsage;
-        switch (usage) {
-            case BUFFER_STATIC:
-                glUsage = gl.STATIC_DRAW;
-                break;
-            case BUFFER_DYNAMIC:
-                glUsage = gl.DYNAMIC_DRAW;
-                break;
-            case BUFFER_STREAM:
-                glUsage = gl.STREAM_DRAW;
-                break;
-            case BUFFER_GPUDYNAMIC:
-                glUsage = device.isWebGL2 ? gl.DYNAMIC_COPY : gl.STATIC_DRAW;
-                break;
-        }
+        if (!this.bufferId) {
+            let glUsage;
+            switch (usage) {
+                case BUFFER_STATIC:
+                    glUsage = gl.STATIC_DRAW;
+                    break;
+                case BUFFER_DYNAMIC:
+                    glUsage = gl.DYNAMIC_DRAW;
+                    break;
+                case BUFFER_STREAM:
+                    glUsage = gl.STREAM_DRAW;
+                    break;
+                case BUFFER_GPUDYNAMIC:
+                    glUsage = device.isWebGL2 ? gl.DYNAMIC_COPY : gl.STATIC_DRAW;
+                    break;
+            }
 
-        const newBuffer = !this.bufferId;
-
-        if (newBuffer) {
             this.bufferId = gl.createBuffer();
-        }
-
-        gl.bindBuffer(target, this.bufferId);
-
-        if (newBuffer) {
+            gl.bindBuffer(target, this.bufferId);
             gl.bufferData(target, storage, glUsage);
         } else {
+            gl.bindBuffer(target, this.bufferId);
             gl.bufferSubData(target, 0, storage);
         }
     }

--- a/src/platform/graphics/webgl/webgl-buffer.js
+++ b/src/platform/graphics/webgl/webgl-buffer.js
@@ -26,10 +26,6 @@ class WebglBuffer {
     unlock(device, usage, target, storage) {
         const gl = device.gl;
 
-        if (!this.bufferId) {
-            this.bufferId = gl.createBuffer();
-        }
-
         let glUsage;
         switch (usage) {
             case BUFFER_STATIC:
@@ -46,8 +42,19 @@ class WebglBuffer {
                 break;
         }
 
+        const newBuffer = !this.bufferId;
+
+        if (newBuffer) {
+            this.bufferId = gl.createBuffer();
+        }
+
         gl.bindBuffer(target, this.bufferId);
-        gl.bufferData(target, storage, glUsage);
+
+        if (newBuffer) {
+            gl.bufferData(target, storage, glUsage);
+        } else {
+            gl.bufferSubData(target, 0, storage);
+        }
     }
 }
 


### PR DESCRIPTION
When updating an existing GL buffer it is faster to call `bufferSubData` instead of `bufferData` (which creates a new gl-side buffer each time).

This change roughly halves the time taken to update splat buffers.