### PR TITLE
Use subimage versions during texture update

### DIFF
--- a/src/platform/graphics/webgl/webgl-texture.js
+++ b/src/platform/graphics/webgl/webgl-texture.js
@@ -475,7 +475,7 @@ class WebglTexture {
                             0, 0,
                             this._glFormat,
                             this._glPixelType,
-                            mipObject                            
+                            mipObject
                         );
                     } else {
                         gl.texImage2D(


### PR DESCRIPTION
This PR updates the texture upload logic similar to #5758.

Updating the data of an existing gl-side texture is relatively slow using `gl.texImage2D` because a new gl-side texture is created every time. It's faster to use `gl.texSubImage2D` instead, which will update the existing texture data.

This PR requires thorough testing, especially with editor projects, to ensure edge cases are correctly covered.

Testing Notes:
- each creation and update path needs testing: 2d and cubemap, pixel data and browser interface sources