### PR TITLE
Support for storage textures on WebGPU platform

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -57,6 +57,7 @@ export * from './platform/audio/constants.js';
 // PLATFORM / GRAPHICS
 export * from './platform/graphics/constants.js';
 export { createGraphicsDevice } from './platform/graphics/graphics-device-create.js';
+export { BindGroupFormat, BindBufferFormat, BindTextureFormat, BindStorageTextureFormat } from './platform/graphics/bind-group-format.js';
 export { BlendState } from './platform/graphics/blend-state.js';
 export { Compute } from './platform/graphics/compute.js';
 export { DepthState } from './platform/graphics/depth-state.js';

--- a/src/platform/graphics/texture.js
+++ b/src/platform/graphics/texture.js
@@ -58,6 +58,9 @@ class Texture {
      */
     renderVersionDirty = 0;
 
+    /** @protected */
+    _storage = false;
+
     /**
      * Create a new Texture instance.
      *
@@ -157,7 +160,10 @@ class Texture {
      * - {@link FUNC_NOTEQUAL}
      *
      * Defaults to {@link FUNC_LESS}.
-     * @param {Uint8Array[]|HTMLCanvasElement[]|HTMLImageElement[]|HTMLVideoElement[]} [options.levels] - Array of Uint8Array or other supported browser interface.
+     * @param {Uint8Array[]|HTMLCanvasElement[]|HTMLImageElement[]|HTMLVideoElement[]} [options.levels]
+     * - Array of Uint8Array or other supported browser interface.
+     * @param {boolean} [options.storage] - Defines if texture can be used as a storage texture by
+     * a compute shader. Defaults to false.
      * @example
      * // Create a 8x8x24-bit texture
      * const texture = new pc.Texture(graphicsDevice, {
@@ -201,6 +207,7 @@ class Texture {
             this._depth = 1;
         }
 
+        this._storage = options.storage ?? false;
         this._cubemap = options.cubemap ?? false;
         this.fixCubemapSeams = options.fixCubemapSeams ?? false;
         this._flipY = options.flipY ?? false;
@@ -544,6 +551,15 @@ class Texture {
 
     get mipmaps() {
         return this._mipmaps;
+    }
+
+    /**
+     * Defines if texture can be used as a storage texture by a compute shader.
+     *
+     * @type {boolean}
+     */
+    get storage() {
+        return this._storage;
     }
 
     /**

--- a/src/platform/graphics/webgpu/constants.js
+++ b/src/platform/graphics/webgpu/constants.js
@@ -1,0 +1,44 @@
+import {
+    PIXELFORMAT_A8, PIXELFORMAT_L8, PIXELFORMAT_LA8, PIXELFORMAT_RGB565, PIXELFORMAT_RGBA5551, PIXELFORMAT_RGBA4,
+    PIXELFORMAT_RGB8, PIXELFORMAT_RGBA8, PIXELFORMAT_DXT1, PIXELFORMAT_DXT3, PIXELFORMAT_DXT5,
+    PIXELFORMAT_RGB16F, PIXELFORMAT_RGBA16F, PIXELFORMAT_RGB32F, PIXELFORMAT_RGBA32F, PIXELFORMAT_R32F, PIXELFORMAT_DEPTH,
+    PIXELFORMAT_DEPTHSTENCIL, PIXELFORMAT_111110F, PIXELFORMAT_SRGB, PIXELFORMAT_SRGBA, PIXELFORMAT_ETC1,
+    PIXELFORMAT_ETC2_RGB, PIXELFORMAT_ETC2_RGBA, PIXELFORMAT_PVRTC_2BPP_RGB_1, PIXELFORMAT_PVRTC_2BPP_RGBA_1,
+    PIXELFORMAT_PVRTC_4BPP_RGB_1, PIXELFORMAT_PVRTC_4BPP_RGBA_1, PIXELFORMAT_ASTC_4x4, PIXELFORMAT_ATC_RGB,
+    PIXELFORMAT_ATC_RGBA, PIXELFORMAT_BGRA8
+} from '../constants.js';
+
+// map of PIXELFORMAT_*** to GPUTextureFormat
+export const gpuTextureFormats = [];
+gpuTextureFormats[PIXELFORMAT_A8] = '';
+gpuTextureFormats[PIXELFORMAT_L8] = 'r8unorm';
+gpuTextureFormats[PIXELFORMAT_LA8] = 'rg8unorm';
+gpuTextureFormats[PIXELFORMAT_RGB565] = '';
+gpuTextureFormats[PIXELFORMAT_RGBA5551] = '';
+gpuTextureFormats[PIXELFORMAT_RGBA4] = '';
+gpuTextureFormats[PIXELFORMAT_RGB8] = 'rgba8unorm';
+gpuTextureFormats[PIXELFORMAT_RGBA8] = 'rgba8unorm';
+gpuTextureFormats[PIXELFORMAT_DXT1] = 'bc1-rgba-unorm';
+gpuTextureFormats[PIXELFORMAT_DXT3] = 'bc2-rgba-unorm';
+gpuTextureFormats[PIXELFORMAT_DXT5] = 'bc3-rgba-unorm';
+gpuTextureFormats[PIXELFORMAT_RGB16F] = '';
+gpuTextureFormats[PIXELFORMAT_RGBA16F] = 'rgba16float';
+gpuTextureFormats[PIXELFORMAT_RGB32F] = '';
+gpuTextureFormats[PIXELFORMAT_RGBA32F] = 'rgba32float';
+gpuTextureFormats[PIXELFORMAT_R32F] = 'r32float';
+gpuTextureFormats[PIXELFORMAT_DEPTH] = 'depth32float';
+gpuTextureFormats[PIXELFORMAT_DEPTHSTENCIL] = 'depth24plus-stencil8';
+gpuTextureFormats[PIXELFORMAT_111110F] = 'rg11b10ufloat';
+gpuTextureFormats[PIXELFORMAT_SRGB] = '';
+gpuTextureFormats[PIXELFORMAT_SRGBA] = '';
+gpuTextureFormats[PIXELFORMAT_ETC1] = '';
+gpuTextureFormats[PIXELFORMAT_ETC2_RGB] = 'etc2-rgb8unorm';
+gpuTextureFormats[PIXELFORMAT_ETC2_RGBA] = 'etc2-rgba8unorm';
+gpuTextureFormats[PIXELFORMAT_PVRTC_2BPP_RGB_1] = '';
+gpuTextureFormats[PIXELFORMAT_PVRTC_2BPP_RGBA_1] = '';
+gpuTextureFormats[PIXELFORMAT_PVRTC_4BPP_RGB_1] = '';
+gpuTextureFormats[PIXELFORMAT_PVRTC_4BPP_RGBA_1] = '';
+gpuTextureFormats[PIXELFORMAT_ASTC_4x4] = 'astc-4x4-unorm';
+gpuTextureFormats[PIXELFORMAT_ATC_RGB] = '';
+gpuTextureFormats[PIXELFORMAT_ATC_RGBA] = '';
+gpuTextureFormats[PIXELFORMAT_BGRA8] = 'bgra8unorm';

--- a/src/platform/graphics/webgpu/webgpu-bind-group-format.js
+++ b/src/platform/graphics/webgpu/webgpu-bind-group-format.js
@@ -3,6 +3,7 @@ import { StringIds } from '../../../core/string-ids.js';
 import { SAMPLETYPE_FLOAT, SAMPLETYPE_UNFILTERABLE_FLOAT, SAMPLETYPE_DEPTH } from '../constants.js';
 
 import { WebgpuUtils } from './webgpu-utils.js';
+import { gpuTextureFormats } from './constants.js';
 
 const samplerTypes = [];
 samplerTypes[SAMPLETYPE_FLOAT] = 'filtering';
@@ -77,6 +78,9 @@ class WebgpuBindGroupFormat {
      * @returns {any} Returns the bind group descriptor.
      */
     createDescriptor(bindGroupFormat) {
+
+        const { compute } = bindGroupFormat;
+
         // all WebGPU bindings:
         // - buffer: GPUBufferBindingLayout, resource type is GPUBufferBinding
         // - sampler: GPUSamplerBindingLayout, resource type is GPUSampler
@@ -87,8 +91,9 @@ class WebgpuBindGroupFormat {
 
         // generate unique key
         let key = '';
-
         let index = 0;
+
+        // buffers
         bindGroupFormat.bufferFormats.forEach((bufferFormat) => {
 
             const visibility = WebgpuUtils.shaderStage(bufferFormat.visibility);
@@ -112,6 +117,7 @@ class WebgpuBindGroupFormat {
             });
         });
 
+        // textures
         bindGroupFormat.textureFormats.forEach((textureFormat) => {
 
             const visibility = WebgpuUtils.shaderStage(textureFormat.visibility);
@@ -126,6 +132,7 @@ class WebgpuBindGroupFormat {
 
             key += `#${index}T:${visibility}-${gpuSampleType}-${viewDimension}-${multisampled}`;
 
+            // texture
             entries.push({
                 binding: index++,
                 visibility: visibility,
@@ -156,6 +163,31 @@ class WebgpuBindGroupFormat {
                     // Indicates the required type of a sampler bound to this bindings
                     // 'filtering', 'non-filtering', 'comparison'
                     type: gpuSamplerType
+                }
+            });
+        });
+
+        // storage textures
+        bindGroupFormat.storageTextureFormats.forEach((textureFormat) => {
+
+            const { format, textureDimension } = textureFormat;
+            key += `#${index}ST:${format}-${textureDimension}`;
+
+            // storage texture
+            entries.push({
+                binding: index++,
+                visibility: GPUShaderStage.COMPUTE,
+                storageTexture: {
+
+                    // The access mode for this binding, indicating readability and writability.
+                    access: 'write-only', // only single option currently, more in the future
+
+                    // The required format of texture views bound to this binding.
+                    format: gpuTextureFormats[format],
+
+                    // Indicates the required dimension for texture views bound to this binding.
+                    // "1d", "2d", "2d-array", "cube", "cube-array", "3d"
+                    viewDimension: textureDimension
                 }
             });
         });

--- a/src/platform/graphics/webgpu/webgpu-bind-group-format.js
+++ b/src/platform/graphics/webgpu/webgpu-bind-group-format.js
@@ -79,8 +79,6 @@ class WebgpuBindGroupFormat {
      */
     createDescriptor(bindGroupFormat) {
 
-        const { compute } = bindGroupFormat;
-
         // all WebGPU bindings:
         // - buffer: GPUBufferBindingLayout, resource type is GPUBufferBinding
         // - sampler: GPUSamplerBindingLayout, resource type is GPUSampler

--- a/src/platform/graphics/webgpu/webgpu-bind-group.js
+++ b/src/platform/graphics/webgpu/webgpu-bind-group.js
@@ -109,6 +109,25 @@ class WebgpuBindGroup {
             });
         });
 
+        // storage textures
+        bindGroup.storageTextures.forEach((tex, textureIndex) => {
+
+            /** @type {import('./webgpu-texture.js').WebgpuTexture} */
+            const wgpuTexture = tex.impl;
+
+            // texture
+            const view = wgpuTexture.getView(device);
+            Debug.assert(view, 'NULL texture view cannot be used by the bind group');
+            Debug.call(() => {
+                this.debugFormat += `${index}: ${bindGroup.format.storageTextureFormats[textureIndex].name}\n`;
+            });
+
+            entries.push({
+                binding: index++,
+                resource: view
+            });
+        });
+
         const descr = {
             layout: bindGroup.format.impl.bindGroupLayout,
             entries: entries

--- a/src/platform/graphics/webgpu/webgpu-compute-pipeline.js
+++ b/src/platform/graphics/webgpu/webgpu-compute-pipeline.js
@@ -1,26 +1,27 @@
 import { Debug, DebugHelper } from "../../../core/debug.js";
 import { TRACEID_COMPUTEPIPELINE_ALLOC } from "../../../core/constants.js";
 import { WebgpuDebug } from "./webgpu-debug.js";
+import { WebgpuPipeline } from "./webgpu-pipeline.js";
 
 let _pipelineId = 0;
 
 /**
  * @ignore
  */
-class WebgpuComputePipeline {
-    constructor(device) {
-        /** @type {import('./webgpu-graphics-device.js').WebgpuGraphicsDevice} */
-        this.device = device;
-    }
-
+class WebgpuComputePipeline extends WebgpuPipeline {
     /** @private */
-    get(shader) {
+    get(shader, bindGroupFormat) {
 
-        const pipeline = this.create(shader);
+        // pipeline layout
+        const pipelineLayout = this.getPipelineLayout([bindGroupFormat.impl]);
+
+        // TODO: this could be cached
+
+        const pipeline = this.create(shader, pipelineLayout);
         return pipeline;
     }
 
-    create(shader) {
+    create(shader, pipelineLayout) {
 
         const wgpu = this.device.wgpu;
 
@@ -35,7 +36,7 @@ class WebgpuComputePipeline {
             },
 
             // uniform / texture binding layout
-            layout: 'auto'
+            layout: pipelineLayout
         };
 
         WebgpuDebug.validate(this.device);

--- a/src/platform/graphics/webgpu/webgpu-pipeline.js
+++ b/src/platform/graphics/webgpu/webgpu-pipeline.js
@@ -1,0 +1,50 @@
+import { TRACEID_PIPELINELAYOUT_ALLOC } from '../../../core/constants.js';
+import { Debug, DebugHelper } from '../../../core/debug.js';
+
+let _layoutId = 0;
+
+/**
+ * Base class for render and compute pipelines.
+ *
+ * @ignore
+ */
+class WebgpuPipeline {
+    constructor(device) {
+        /** @type {import('./webgpu-graphics-device.js').WebgpuGraphicsDevice} */
+        this.device = device;
+    }
+
+    // TODO: this could be cached using bindGroupKey
+
+    /**
+     * @param {import('../bind-group-format.js').BindGroupFormat[]} bindGroupFormats - An array
+     * of bind group formats.
+     * @returns {any} Returns the pipeline layout.
+     */
+    getPipelineLayout(bindGroupFormats) {
+
+        const bindGroupLayouts = [];
+        bindGroupFormats.forEach((format) => {
+            bindGroupLayouts.push(format.bindGroupLayout);
+        });
+
+        const descr = {
+            bindGroupLayouts: bindGroupLayouts
+        };
+
+        _layoutId++;
+        DebugHelper.setLabel(descr, `PipelineLayoutDescr-${_layoutId}`);
+
+        /** @type {GPUPipelineLayout} */
+        const pipelineLayout = this.device.wgpu.createPipelineLayout(descr);
+        DebugHelper.setLabel(pipelineLayout, `PipelineLayout-${_layoutId}`);
+        Debug.trace(TRACEID_PIPELINELAYOUT_ALLOC, `Alloc: Id ${_layoutId}`, {
+            descr,
+            bindGroupFormats
+        });
+
+        return pipelineLayout;
+    }
+}
+
+export { WebgpuPipeline };

--- a/src/platform/graphics/webgpu/webgpu-render-pipeline.js
+++ b/src/platform/graphics/webgpu/webgpu-render-pipeline.js
@@ -1,13 +1,13 @@
 import { Debug, DebugHelper } from "../../../core/debug.js";
 import { hash32Fnv1a } from "../../../core/hash.js";
 import { array } from "../../../core/array-utils.js";
-import { TRACEID_RENDERPIPELINE_ALLOC, TRACEID_PIPELINELAYOUT_ALLOC } from "../../../core/constants.js";
+import { TRACEID_RENDERPIPELINE_ALLOC } from "../../../core/constants.js";
 
 import { WebgpuVertexBufferLayout } from "./webgpu-vertex-buffer-layout.js";
 import { WebgpuDebug } from "./webgpu-debug.js";
+import { WebgpuPipeline } from "./webgpu-pipeline.js";
 
 let _pipelineId = 0;
-let _layoutId = 0;
 
 const _primitiveTopology = [
     'point-list',       // PRIMITIVE_POINTS
@@ -71,9 +71,6 @@ const _stencilOps = [
     'invert'                // STENCILOP_INVERT
 ];
 
-// temp array to avoid allocation
-const _bindGroupLayouts = [];
-
 /** @ignore */
 class CacheEntry {
     /**
@@ -95,12 +92,11 @@ class CacheEntry {
 /**
  * @ignore
  */
-class WebgpuRenderPipeline {
+class WebgpuRenderPipeline extends WebgpuPipeline {
     lookupHashes = new Uint32Array(13);
 
     constructor(device) {
-        /** @type {import('./webgpu-graphics-device.js').WebgpuGraphicsDevice} */
-        this.device = device;
+        super(device);
 
         /**
          * The cache of vertex buffer layouts
@@ -178,39 +174,6 @@ class WebgpuRenderPipeline {
         this.cache.set(hash, cacheEntries);
 
         return cacheEntry.pipeline;
-    }
-
-    // TODO: this could be cached using bindGroupKey
-
-    /**
-     * @param {import('../bind-group-format.js').BindGroupFormat[]} bindGroupFormats - An array
-     * of bind group formats.
-     * @returns {any} Returns the pipeline layout.
-     */
-    getPipelineLayout(bindGroupFormats) {
-
-        bindGroupFormats.forEach((format) => {
-            _bindGroupLayouts.push(format.bindGroupLayout);
-        });
-
-        const descr = {
-            bindGroupLayouts: _bindGroupLayouts
-        };
-
-        _layoutId++;
-        DebugHelper.setLabel(descr, `PipelineLayoutDescr-${_layoutId}`);
-
-        /** @type {GPUPipelineLayout} */
-        const pipelineLayout = this.device.wgpu.createPipelineLayout(descr);
-        DebugHelper.setLabel(pipelineLayout, `PipelineLayout-${_layoutId}`);
-        Debug.trace(TRACEID_PIPELINELAYOUT_ALLOC, `Alloc: Id ${_layoutId}`, {
-            descr,
-            bindGroupFormats
-        });
-
-        _bindGroupLayouts.length = 0;
-
-        return pipelineLayout;
     }
 
     getBlend(blendState) {

--- a/src/platform/graphics/webgpu/webgpu-texture.js
+++ b/src/platform/graphics/webgpu/webgpu-texture.js
@@ -5,52 +5,14 @@ import { math } from '../../../core/math/math.js';
 import {
     pixelFormatInfo, isCompressedPixelFormat,
     ADDRESS_REPEAT, ADDRESS_CLAMP_TO_EDGE, ADDRESS_MIRRORED_REPEAT,
-    PIXELFORMAT_A8, PIXELFORMAT_L8, PIXELFORMAT_LA8, PIXELFORMAT_RGB565, PIXELFORMAT_RGBA5551, PIXELFORMAT_RGBA4,
-    PIXELFORMAT_RGB8, PIXELFORMAT_RGBA8, PIXELFORMAT_DXT1, PIXELFORMAT_DXT3, PIXELFORMAT_DXT5,
-    PIXELFORMAT_RGB16F, PIXELFORMAT_RGBA16F, PIXELFORMAT_RGB32F, PIXELFORMAT_RGBA32F, PIXELFORMAT_R32F, PIXELFORMAT_DEPTH,
-    PIXELFORMAT_DEPTHSTENCIL, PIXELFORMAT_111110F, PIXELFORMAT_SRGB, PIXELFORMAT_SRGBA, PIXELFORMAT_ETC1,
-    PIXELFORMAT_ETC2_RGB, PIXELFORMAT_ETC2_RGBA, PIXELFORMAT_PVRTC_2BPP_RGB_1, PIXELFORMAT_PVRTC_2BPP_RGBA_1,
-    PIXELFORMAT_PVRTC_4BPP_RGB_1, PIXELFORMAT_PVRTC_4BPP_RGBA_1, PIXELFORMAT_ASTC_4x4, PIXELFORMAT_ATC_RGB,
-    PIXELFORMAT_ATC_RGBA, PIXELFORMAT_BGRA8, SAMPLETYPE_UNFILTERABLE_FLOAT, SAMPLETYPE_DEPTH,
-    FILTER_NEAREST, FILTER_LINEAR, FILTER_NEAREST_MIPMAP_NEAREST, FILTER_NEAREST_MIPMAP_LINEAR, FILTER_LINEAR_MIPMAP_NEAREST, FILTER_LINEAR_MIPMAP_LINEAR
+    PIXELFORMAT_RGBA16F, PIXELFORMAT_RGBA32F, PIXELFORMAT_DEPTHSTENCIL,
+    SAMPLETYPE_UNFILTERABLE_FLOAT, SAMPLETYPE_DEPTH,
+    FILTER_NEAREST, FILTER_LINEAR, FILTER_NEAREST_MIPMAP_NEAREST, FILTER_NEAREST_MIPMAP_LINEAR,
+    FILTER_LINEAR_MIPMAP_NEAREST, FILTER_LINEAR_MIPMAP_LINEAR
 } from '../constants.js';
 import { TextureUtils } from '../texture-utils.js';
 import { WebgpuDebug } from './webgpu-debug.js';
-
-// map of PIXELFORMAT_*** to GPUTextureFormat
-const gpuTextureFormats = [];
-gpuTextureFormats[PIXELFORMAT_A8] = '';
-gpuTextureFormats[PIXELFORMAT_L8] = 'r8unorm';
-gpuTextureFormats[PIXELFORMAT_LA8] = 'rg8unorm';
-gpuTextureFormats[PIXELFORMAT_RGB565] = '';
-gpuTextureFormats[PIXELFORMAT_RGBA5551] = '';
-gpuTextureFormats[PIXELFORMAT_RGBA4] = '';
-gpuTextureFormats[PIXELFORMAT_RGB8] = 'rgba8unorm';
-gpuTextureFormats[PIXELFORMAT_RGBA8] = 'rgba8unorm';
-gpuTextureFormats[PIXELFORMAT_DXT1] = 'bc1-rgba-unorm';
-gpuTextureFormats[PIXELFORMAT_DXT3] = 'bc2-rgba-unorm';
-gpuTextureFormats[PIXELFORMAT_DXT5] = 'bc3-rgba-unorm';
-gpuTextureFormats[PIXELFORMAT_RGB16F] = '';
-gpuTextureFormats[PIXELFORMAT_RGBA16F] = 'rgba16float';
-gpuTextureFormats[PIXELFORMAT_RGB32F] = '';
-gpuTextureFormats[PIXELFORMAT_RGBA32F] = 'rgba32float';
-gpuTextureFormats[PIXELFORMAT_R32F] = 'r32float';
-gpuTextureFormats[PIXELFORMAT_DEPTH] = 'depth32float';
-gpuTextureFormats[PIXELFORMAT_DEPTHSTENCIL] = 'depth24plus-stencil8';
-gpuTextureFormats[PIXELFORMAT_111110F] = 'rg11b10ufloat';
-gpuTextureFormats[PIXELFORMAT_SRGB] = '';
-gpuTextureFormats[PIXELFORMAT_SRGBA] = '';
-gpuTextureFormats[PIXELFORMAT_ETC1] = '';
-gpuTextureFormats[PIXELFORMAT_ETC2_RGB] = 'etc2-rgb8unorm';
-gpuTextureFormats[PIXELFORMAT_ETC2_RGBA] = 'etc2-rgba8unorm';
-gpuTextureFormats[PIXELFORMAT_PVRTC_2BPP_RGB_1] = '';
-gpuTextureFormats[PIXELFORMAT_PVRTC_2BPP_RGBA_1] = '';
-gpuTextureFormats[PIXELFORMAT_PVRTC_4BPP_RGB_1] = '';
-gpuTextureFormats[PIXELFORMAT_PVRTC_4BPP_RGBA_1] = '';
-gpuTextureFormats[PIXELFORMAT_ASTC_4x4] = 'astc-4x4-unorm';
-gpuTextureFormats[PIXELFORMAT_ATC_RGB] = '';
-gpuTextureFormats[PIXELFORMAT_ATC_RGBA] = '';
-gpuTextureFormats[PIXELFORMAT_BGRA8] = 'bgra8unorm';
+import { gpuTextureFormats } from './constants.js';
 
 // map of ADDRESS_*** to GPUAddressMode
 const gpuAddressModes = [];
@@ -142,7 +104,9 @@ class WebgpuTexture {
             // TODO: use only required usage flags
             // COPY_SRC - probably only needed on render target textures, to support copyRenderTarget (grab pass needs it)
             // RENDER_ATTACHMENT - needed for mipmap generation
-            usage: GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.COPY_DST | (isCompressedPixelFormat(texture.format) ? 0 : GPUTextureUsage.RENDER_ATTACHMENT) | GPUTextureUsage.COPY_SRC
+            usage: GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC |
+                (isCompressedPixelFormat(texture.format) ? 0 : GPUTextureUsage.RENDER_ATTACHMENT) |
+                (texture.storage ? GPUTextureUsage.STORAGE_BINDING : 0)
         };
 
         WebgpuDebug.validate(device);


### PR DESCRIPTION
Support for storage textures, which represent textures that can be written to by a compute shader.

### New API:
`Texture.constructor` takes `options.storage` as an optional parameter, to construct a texture that is useable as a storage texture for compute shader. Ignored on WebGL.

### Example
Using compute shader to fill texture with a single color:

```
const texture = new Texture(app.graphicsDevice, {
    name: 'outputTexture',
    width: 128,
    height: 128,
    format: PIXELFORMAT_RGBA8,
    mipmaps: false,
    storage: true
});

device.scope.resolve("outTexture").setValue(texture);

const shader = new Shader(device, {
    name: 'ComputeShader',
    shaderLanguage: SHADERLANGUAGE_WGSL,
    cshader: `

        @group(0) @binding(0) var outputTexture: texture_storage_2d<rgba8unorm, write>;

        @compute @workgroup_size(1, 1, 1)
        fn main(@builtin(global_invocation_id) global_id : vec3u) {

            let clearColor: vec4<f32> = vec4<f32>(1.0, 0.0, 0.0, 1.0);
            textureStore(outputTexture, vec2<i32>(global_id.xy), clearColor);
        }
    `
});

// data biding for the shader using a single storage texture (no UBs nor other textures)
// Note: the API here is temporary (the `impl`)
shader.impl.computeBindGroupFormat = new BindGroupFormat(device,[], [], [
    new BindStorageTextureFormat('outTexture', PIXELFORMAT_RGBA8, TEXTUREDIMENSION_2D),
], {
    compute: true
});

const compute = new Compute(device, this.shader);

// run the compute shader
compute.dispatch(texture.width, texture.height);

```