### PR TITLE
[Fix] Fixed calling CameraComponent.onPostRender

### DIFF
--- a/scripts/utils/cubemap-renderer.js
+++ b/scripts/utils/cubemap-renderer.js
@@ -109,7 +109,7 @@ CubemapRenderer.prototype.initialize = function () {
         // set up its rotation
         e.setRotation(cameraRotations[i]);
 
-        // Before the first camera renders, trigger onCubemapPostRender event on the entity.
+        // Before the first camera renders, trigger onCubemapPreRender event on the entity.
         if (i === 0) {
             e.camera.onPreRender = () => {
                 this.entity.fire('onCubemapPreRender');

--- a/src/scene/renderer/render-pass-render-actions.js
+++ b/src/scene/renderer/render-pass-render-actions.js
@@ -94,7 +94,7 @@ class RenderPassRenderActions extends RenderPass {
 
             // callback on the camera component before rendering with this camera for the first time
             const ra = renderActions[0];
-            if (ra.firstCameraUse && ra.camera.onPreRender) {
+            if (ra.camera.onPreRender && ra.firstCameraUse) {
                 ra.camera.onPreRender();
             }
         }
@@ -113,10 +113,9 @@ class RenderPassRenderActions extends RenderPass {
     after() {
         const { renderActions } = this;
         if (renderActions.length) {
-
             // callback on the camera component when we're done rendering with this camera
-            const ra = renderActions[0];
-            if (ra.lastCameraUse && ra.camera.onPostRender) {
+            const ra = renderActions[renderActions.length - 1];
+            if (ra.camera.onPostRender && ra.lastCameraUse) {
                 ra.camera.onPostRender();
             }
         }


### PR DESCRIPTION
Fixed issue introduced few days ago (unreleased) in #5734 by checking first instead of last render action.

Fixes ReflectionBox engine example not generating reflection envAtlas.