### PR TITLE
Specify type definitions as dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,10 @@
       "name": "playcanvas",
       "version": "1.67.0-dev",
       "license": "MIT",
+      "dependencies": {
+        "@types/webxr": "^0.5.5",
+        "@webgpu/types": "^0.1.35"
+      },
       "devDependencies": {
         "@babel/core": "^7.23.0",
         "@babel/eslint-parser": "^7.22.15",
@@ -20,8 +24,6 @@
         "@rollup/plugin-strip": "^3.0.2",
         "@rollup/plugin-terser": "^0.4.3",
         "@rollup/pluginutils": "^5.0.4",
-        "@types/webxr": "^0.5.5",
-        "@webgpu/types": "^0.1.35",
         "c8": "^8.0.0",
         "chai": "^4.3.10",
         "eslint": "^8.50.0",
@@ -2280,14 +2282,12 @@
     "node_modules/@types/webxr": {
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.5.tgz",
-      "integrity": "sha512-HVOsSRTQYx3zpVl0c0FBmmmcY/60BkQLzVnpE9M1aG4f2Z0aKlBWfj4XZ2zr++XNBfkQWYcwhGlmuu44RJPDqg==",
-      "dev": true
+      "integrity": "sha512-HVOsSRTQYx3zpVl0c0FBmmmcY/60BkQLzVnpE9M1aG4f2Z0aKlBWfj4XZ2zr++XNBfkQWYcwhGlmuu44RJPDqg=="
     },
     "node_modules/@webgpu/types": {
       "version": "0.1.37",
       "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.37.tgz",
-      "integrity": "sha512-hfndFDYk5AlZUE/qZ1kSuZHLobxzsbn7/jdJEJfmn4kg3rTM0+A+5TC/+z7lg3L74tSNEtZUVk7ojXw31wzeFw==",
-      "dev": true
+      "integrity": "sha512-hfndFDYk5AlZUE/qZ1kSuZHLobxzsbn7/jdJEJfmn4kg3rTM0+A+5TC/+z7lg3L74tSNEtZUVk7ojXw31wzeFw=="
     },
     "node_modules/@zeit/schemas": {
       "version": "2.29.0",
@@ -10034,14 +10034,12 @@
     "@types/webxr": {
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.5.tgz",
-      "integrity": "sha512-HVOsSRTQYx3zpVl0c0FBmmmcY/60BkQLzVnpE9M1aG4f2Z0aKlBWfj4XZ2zr++XNBfkQWYcwhGlmuu44RJPDqg==",
-      "dev": true
+      "integrity": "sha512-HVOsSRTQYx3zpVl0c0FBmmmcY/60BkQLzVnpE9M1aG4f2Z0aKlBWfj4XZ2zr++XNBfkQWYcwhGlmuu44RJPDqg=="
     },
     "@webgpu/types": {
       "version": "0.1.37",
       "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.37.tgz",
-      "integrity": "sha512-hfndFDYk5AlZUE/qZ1kSuZHLobxzsbn7/jdJEJfmn4kg3rTM0+A+5TC/+z7lg3L74tSNEtZUVk7ojXw31wzeFw==",
-      "dev": true
+      "integrity": "sha512-hfndFDYk5AlZUE/qZ1kSuZHLobxzsbn7/jdJEJfmn4kg3rTM0+A+5TC/+z7lg3L74tSNEtZUVk7ojXw31wzeFw=="
     },
     "@zeit/schemas": {
       "version": "2.29.0",

--- a/package.json
+++ b/package.json
@@ -92,6 +92,10 @@
     "README-kr.md",
     "README-zh.md"
   ],
+  "dependencies": {
+    "@types/webxr": "^0.5.5",
+    "@webgpu/types": "^0.1.35"
+  },
   "devDependencies": {
     "@babel/core": "^7.23.0",
     "@babel/eslint-parser": "^7.22.15",
@@ -104,8 +108,6 @@
     "@rollup/plugin-strip": "^3.0.2",
     "@rollup/plugin-terser": "^0.4.3",
     "@rollup/pluginutils": "^5.0.4",
-    "@types/webxr": "^0.5.5",
-    "@webgpu/types": "^0.1.35",
     "c8": "^8.0.0",
     "chai": "^4.3.10",
     "eslint": "^8.50.0",


### PR DESCRIPTION
We ship type definitions for the engine that contain references to WebXR types. This means that TS projects now have to specify `@types/webxr` as a dependency:

https://github.com/playcanvas/playcanvas-editor-ts-template/pull/12/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R34

This would be unnecessary if we just made types `dependencies` instead of `devDependencies`.

I believe the WebGPU types don't need to be `dependencies` but, for consistency, I'm moving those to `dependencies` too. It will avoid any potential future issues around WebGPU type dependencies.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
