### PR TITLE
Make `npm run build` also trigger `npm run build:types`

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -353,7 +353,7 @@ const target_types = {
 function buildTypes() {
     const start = Date.now();
     const child = exec('npm run build:types');
-    child.on('exit', function() {
+    child.on('exit', function () {
         const end = Date.now();
         const delta = (end - start) / 1000;
         console.log(`created build/playcanvas.d.ts in ${delta}s`);

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -1,6 +1,5 @@
-import { execSync } from 'node:child_process';
+import { exec, execSync } from 'node:child_process';
 import * as fs from 'node:fs';
-import { exec } from 'node:child_process';
 
 // 1st party Rollup plugins
 import { babel } from '@rollup/plugin-babel';


### PR DESCRIPTION
Since we rimraf `/build/` we don't rebuild the types, which makes `cd examples && npm run build` fail (because Monaco editor depends on `build/playcanvas.d.ts`).

Solution is quite easy (simply trigger `npm run build:types`), but side-effects for example could be increased RAM usage, so the build could fail on cheap/overused VPS servers (which struggle with RAM).

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
