### PR TITLE
Support for FLOAT16 (half) vertex attribute format on WebGL2 and WebGPU

### DIFF
--- a/src/core/math/float-packing.js
+++ b/src/core/math/float-packing.js
@@ -8,8 +8,6 @@ const int32View = new Int32Array(floatView.buffer);
 /**
  * Utility static class providing functionality to pack float values to various storage
  * representations.
- *
- * @ignore
  */
 class FloatPacking {
     /**
@@ -71,6 +69,8 @@ class FloatPacking {
      * @param {Uint8ClampedArray} array - The array to store the packed value in.
      * @param {number} offset - The start offset in the array to store the packed value at.
      * @param {number} numBytes - The number of bytes to pack the value to.
+     *
+     * @ignore
      */
     static float2Bytes(value, array, offset, numBytes) {
         const enc1 = (255.0 * value) % 1;
@@ -101,6 +101,8 @@ class FloatPacking {
      * @param {number} min - Range minimum.
      * @param {number} max - Range maximum.
      * @param {number} numBytes - The number of bytes to pack the value to.
+     *
+     * @ignore
      */
     static float2BytesRange(value, array, offset, min, max, numBytes) {
         // #if _DEBUG
@@ -124,6 +126,8 @@ class FloatPacking {
      * @param {Uint8ClampedArray} array - The array to store the packed value in.
      * @param {number} offset - The start offset in the array to store the packed value at.
      * @param {number} numBytes - The number of bytes to pack the value to.
+     *
+     * @ignore
      */
     static float2MantissaExponent(value, array, offset, numBytes) {
         // exponent is increased by one, so that 2^exponent is larger than the value

--- a/src/index.js
+++ b/src/index.js
@@ -36,6 +36,7 @@ export { math } from './core/math/math.js';
 export { Color } from './core/math/color.js';
 export { Curve } from './core/math/curve.js';
 export { CurveSet } from './core/math/curve-set.js';
+export { FloatPacking } from './core/math/float-packing.js';
 export { Mat3 } from './core/math/mat3.js';
 export { Mat4 } from './core/math/mat4.js';
 export { Quat } from './core/math/quat.js';

--- a/src/platform/graphics/constants.js
+++ b/src/platform/graphics/constants.js
@@ -1162,6 +1162,13 @@ export const TYPE_UINT32 = 5;
  */
 export const TYPE_FLOAT32 = 6;
 
+/**
+ * 16-bit floating point vertex element type (not supported by WebGL1).
+ *
+ * @type {number}
+ */
+export const TYPE_FLOAT16 = 7;
+
 export const UNIFORMTYPE_BOOL = 0;
 export const UNIFORMTYPE_INT = 1;
 export const UNIFORMTYPE_FLOAT = 2;
@@ -1260,9 +1267,9 @@ export const bindGroupNames = ['mesh', 'view'];
 export const UNIFORM_BUFFER_DEFAULT_SLOT_NAME = 'default';
 
 // map of engine TYPE_*** enums to their corresponding typed array constructors and byte sizes
-export const typedArrayTypes = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array, Float32Array];
-export const typedArrayTypesByteSize = [1, 1, 2, 2, 4, 4, 4];
-export const vertexTypesNames = ['INT8', 'UINT8', 'INT16', 'UINT16', 'INT32', 'UINT32', 'FLOAT32'];
+export const typedArrayTypes = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array, Float32Array, Uint16Array];
+export const typedArrayTypesByteSize = [1, 1, 2, 2, 4, 4, 4, 2];
+export const vertexTypesNames = ['INT8', 'UINT8', 'INT16', 'UINT16', 'INT32', 'UINT32', 'FLOAT32', 'FLOAT16'];
 
 // map of typed array to engine TYPE_***
 export const typedArrayToType = {

--- a/src/platform/graphics/shader-processor.js
+++ b/src/platform/graphics/shader-processor.js
@@ -5,7 +5,7 @@ import {
     UNIFORM_BUFFER_DEFAULT_SLOT_NAME,
     SAMPLETYPE_FLOAT, SAMPLETYPE_DEPTH, SAMPLETYPE_UNFILTERABLE_FLOAT,
     TEXTUREDIMENSION_2D, TEXTUREDIMENSION_2D_ARRAY, TEXTUREDIMENSION_CUBE, TEXTUREDIMENSION_3D,
-    TYPE_FLOAT32, TYPE_INT8, TYPE_INT16, TYPE_INT32
+    TYPE_FLOAT32, TYPE_INT8, TYPE_INT16, TYPE_INT32, TYPE_FLOAT16
 } from './constants.js';
 import { UniformFormat, UniformBufferFormat } from './uniform-buffer-format.js';
 import { BindGroupFormat, BindBufferFormat, BindTextureFormat } from './bind-group-format.js';
@@ -387,7 +387,7 @@ class ShaderProcessor {
                 const element = processingOptions.getVertexElement(semantic);
                 if (element) {
                     const dataType = element.dataType;
-                    if (dataType !== TYPE_FLOAT32 && !element.normalize) {
+                    if (dataType !== TYPE_FLOAT32 && dataType !== TYPE_FLOAT16 && !element.normalize) {
 
                         const attribNumElements = ShaderProcessor.getTypeCount(type);
                         const newName = `_private_${name}`;

--- a/src/platform/graphics/vertex-format.js
+++ b/src/platform/graphics/vertex-format.js
@@ -48,6 +48,7 @@ const webgpuValidElementSizes = [2, 4, 8, 12, 16];
  * - {@link TYPE_INT32}
  * - {@link TYPE_UINT32}
  * - {@link TYPE_FLOAT32}
+ * - {@link TYPE_FLOAT16}
  * @property {boolean} elements[].normalize If true, vertex attribute data will be mapped from a 0
  * to 255 range down to 0 to 1 when fed to a shader. If false, vertex attribute data is left
  * unchanged. If this property is unspecified, false is assumed.

--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -526,7 +526,8 @@ class WebglGraphicsDevice extends GraphicsDevice {
             gl.UNSIGNED_SHORT,
             gl.INT,
             gl.UNSIGNED_INT,
-            gl.FLOAT
+            gl.FLOAT,
+            gl.HALF_FLOAT
         ];
 
         this.pcUniformType = {};

--- a/src/platform/graphics/webgpu/webgpu-vertex-buffer-layout.js
+++ b/src/platform/graphics/webgpu/webgpu-vertex-buffer-layout.js
@@ -1,6 +1,6 @@
 import {
     semanticToLocation,
-    TYPE_INT8, TYPE_UINT8, TYPE_INT16, TYPE_UINT16, TYPE_INT32, TYPE_UINT32, TYPE_FLOAT32
+    TYPE_INT8, TYPE_UINT8, TYPE_INT16, TYPE_UINT16, TYPE_INT32, TYPE_UINT32, TYPE_FLOAT32, TYPE_FLOAT16
 } from '../constants.js';
 
 // map of TYPE_*** to GPUVertexFormat
@@ -12,6 +12,7 @@ gpuVertexFormats[TYPE_UINT16] = 'uint16';
 gpuVertexFormats[TYPE_INT32] = 'sint32';
 gpuVertexFormats[TYPE_UINT32] = 'uint32';
 gpuVertexFormats[TYPE_FLOAT32] = 'float32';
+gpuVertexFormats[TYPE_FLOAT16] = 'float16';
 
 const gpuVertexFormatsNormalized = [];
 gpuVertexFormatsNormalized[TYPE_INT8] = 'snorm8';
@@ -21,6 +22,7 @@ gpuVertexFormatsNormalized[TYPE_UINT16] = 'unorm16';
 gpuVertexFormatsNormalized[TYPE_INT32] = 'sint32';     // there is no 32bit normalized signed int
 gpuVertexFormatsNormalized[TYPE_UINT32] = 'uint32';    // there is no 32bit normalized unsigned int
 gpuVertexFormatsNormalized[TYPE_FLOAT32] = 'float32';  // there is no 32bit normalized float
+gpuVertexFormatsNormalized[TYPE_FLOAT16] = 'float16';  // there is no 16bit normalized half-float
 
 /**
  * @ignore


### PR DESCRIPTION
- new TYPE_FLOAT16 type that can be used in VertexFormat on WebGL2 and WebGPU (no fallback on WebGL1, it's not supported)
- made `pc.FloatPacking.float2Half` public to allow easy float -> half conversion

Example of it's used (tested as part of mesh-decals.mjs)
```
const uvs = new Uint16Array(numDecals * 8);
        const halfZero = pc.FloatPacking.float2Half(0);
        const halfOne = pc.FloatPacking.float2Half(1);
        for (let i = 0; i < numDecals; i += 8) {
            uvs[i + 0] = halfZero;
            uvs[i + 1] = halfZero;
            uvs[i + 2] = halfZero;
            uvs[i + 3] = halfOne;
            uvs[i + 4] = halfOne;
            uvs[i + 5] = halfOne;
            uvs[i + 6] = halfOne;
            uvs[i + 7] = halfZero;
        }

mesh.setVertexStream(pc.SEMANTIC_TEXCOORD0, uvs, 2, undefined, pc.TYPE_FLOAT16, false);
```
