### PR TITLE
WebXR manual room capture

### DIFF
--- a/src/framework/xr/xr-manager.js
+++ b/src/framework/xr/xr-manager.js
@@ -26,6 +26,13 @@ import { XrAnchors } from './xr-anchors.js';
  */
 
 /**
+ * Callback used by manual room capturing.
+ *
+ * @callback XrRoomCapture
+ * @param {Error|null} err - The Error object or null if manual room capture was successful.
+ */
+
+/**
  * Manage and update XR session and its states.
  *
  * @augments EventHandler
@@ -549,6 +556,40 @@ class XrManager extends EventHandler {
         for (const key in this._available) {
             this._sessionSupportCheck(key);
         }
+    }
+
+    /**
+     * Initiate manual room capture. If the underlying XR system supports manual capture of the
+     * room, it will start the capturing process, which can affect plane and mesh detection,
+     * and improve hit-test quality against real-world geometry.
+     *
+     * @param {XrRoomCapture} callback - Callback that will be fired once capture is complete
+     * or failed.
+     *
+     * @example
+     * this.app.xr.initiateRoomCapture((err) => {
+     *     if (err) {
+     *         // capture failed
+     *         return;
+     *     }
+     *     // capture was successful
+     * });
+     */
+    initiateRoomCapture(callback) {
+        if (!this._session) {
+            callback(new Error('Session is not active'));
+            return;
+        }
+        if (!this._session.initiateRoomCapture) {
+            callback(new Error('Session does not support manual room capture'));
+            return;
+        }
+
+        this._session.initiateRoomCapture().then(() => {
+            if (callback) callback(null);
+        }).catch((err) => {
+            if (callback) callback(err);
+        });
     }
 
     /**

--- a/src/framework/xr/xr-manager.js
+++ b/src/framework/xr/xr-manager.js
@@ -28,7 +28,7 @@ import { XrAnchors } from './xr-anchors.js';
 /**
  * Callback used by manual room capturing.
  *
- * @callback XrRoomCapture
+ * @callback XrRoomCaptureCallback
  * @param {Error|null} err - The Error object or null if manual room capture was successful.
  */
 
@@ -563,7 +563,7 @@ class XrManager extends EventHandler {
      * room, it will start the capturing process, which can affect plane and mesh detection,
      * and improve hit-test quality against real-world geometry.
      *
-     * @param {XrRoomCapture} callback - Callback that will be fired once capture is complete
+     * @param {XrRoomCaptureCallback} callback - Callback that will be fired once capture is complete
      * or failed.
      *
      * @example


### PR DESCRIPTION
With Quest 3 and similar devices, environment is captured at the special time instead of real-time like for Android devices.
So the extension to the [WebXR Plane Detection Specs](https://immersive-web.github.io/real-world-geometry/plane-detection.html#dom-xrsession-initiateroomcapture) provides a new method for XRSession to initiate manual room capture.

This can be useful when developer want to use AR with Plane Detection or Real-World Meshes, and needs an up to date information, or user might have not pre-captured their environment at all. So developer can provide an option to trigger manual capture right from the AR session.
Our current API integration design takes asynchronous nature of real-world objects like planes into the account, so changes in underlying data will be reflected immediately without a need to refresh a page.

### New APIs:
```javascript
// pc.XrManager
xr.initiateRoomCapture((err) => { })
// Start manual room capture.
// If such feature is not supported, error with according message will be provided in callback.
// If capture was a successful, then callback will fire without an error.
```

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
