### PR TITLE
WebXR fix Hit Test providing multiple results

### DIFF
--- a/examples/src/examples/xr/ar-hit-test.mjs
+++ b/examples/src/examples/xr/ar-hit-test.mjs
@@ -157,7 +157,6 @@ async function example({ canvas }) {
                         hitTestSource.on('result', (position, rotation, item) => {
                             target.setPosition(position);
                             target.setRotation(rotation);
-                            console.log(inputSource.id, item.id);
                         });
 
                         hitTestSource.once('remove', () => {

--- a/examples/src/examples/xr/ar-hit-test.mjs
+++ b/examples/src/examples/xr/ar-hit-test.mjs
@@ -61,7 +61,7 @@ async function example({ canvas }) {
     target.addComponent("render", {
         type: "cylinder"
     });
-    target.setLocalScale(0.5, 0.01, 0.5);
+    target.setLocalScale(0.1, 0.01, 0.1);
     app.root.addChild(target);
 
     if (app.xr.supported) {
@@ -151,10 +151,10 @@ async function example({ canvas }) {
                         target.addComponent("render", {
                             type: "cylinder"
                         });
-                        target.setLocalScale(0.5, 0.01, 0.5);
+                        target.setLocalScale(0.1, 0.01, 0.1);
                         app.root.addChild(target);
 
-                        hitTestSource.on('result', (position, rotation, item) => {
+                        hitTestSource.on('result', (position, rotation) => {
                             target.setPosition(position);
                             target.setRotation(rotation);
                         });

--- a/examples/src/examples/xr/ar-hit-test.mjs
+++ b/examples/src/examples/xr/ar-hit-test.mjs
@@ -140,6 +140,35 @@ async function example({ canvas }) {
             }
         });
 
+        if (app.xr.hitTest.supported) {
+            app.xr.input.on('add', (inputSource) => {
+                inputSource.hitTestStart({
+                    entityTypes: [pc.XRTRACKABLE_POINT, pc.XRTRACKABLE_PLANE],
+                    callback: (err, hitTestSource) => {
+                        if (err) return;
+
+                        let target = new pc.Entity();
+                        target.addComponent("render", {
+                            type: "cylinder"
+                        });
+                        target.setLocalScale(0.5, 0.01, 0.5);
+                        app.root.addChild(target);
+
+                        hitTestSource.on('result', (position, rotation, item) => {
+                            target.setPosition(position);
+                            target.setRotation(rotation);
+                            console.log(inputSource.id, item.id);
+                        });
+
+                        hitTestSource.once('remove', () => {
+                            target.destroy();
+                            target = null;
+                        });
+                    }
+                });
+            });
+        }
+
         if (!app.xr.isAvailable(pc.XRTYPE_AR)) {
             message("Immersive AR is not available");
         } else if (!app.xr.hitTest.supported) {

--- a/src/framework/xr/xr-hit-test-source.js
+++ b/src/framework/xr/xr-hit-test-source.js
@@ -132,26 +132,44 @@ class XrHitTestSource extends EventHandler {
      * @private
      */
     updateHitResults(results, inputSource) {
-        if (inputSource && inputSource.hitTestSourcesSet.has(this))
+        if (inputSource && !inputSource.hitTestSourcesSet.has(this))
             return;
+
+        let origin = poolVec3.pop();
+        if (!origin) origin = new Vec3();
+
+        if (inputSource) {
+            origin.copy(inputSource.getOrigin());
+        } else {
+            origin.copy(this.manager.camera.getPosition());
+        }
+
+        let candidateDistance = Infinity;
+
+        let position = poolVec3.pop();
+        if (!position) position = new Vec3();
+
+        let rotation = poolQuat.pop();
+        if (!rotation) rotation = new Quat();
 
         for (let i = 0; i < results.length; i++) {
             const pose = results[i].getPose(this.manager._referenceSpace);
 
-            let position = poolVec3.pop();
-            if (!position) position = new Vec3();
+            const distance = origin.distance(pose.transform.position);
+            if (distance >= candidateDistance)
+                continue;
+
+            candidateDistance = distance;
             position.copy(pose.transform.position);
-
-            let rotation = poolQuat.pop();
-            if (!rotation) rotation = new Quat();
             rotation.copy(pose.transform.orientation);
-
-            this.fire('result', position, rotation, inputSource);
-            this.manager.hitTest.fire('result', this, position, rotation, inputSource);
-
-            poolVec3.push(position);
-            poolQuat.push(rotation);
         }
+
+        this.fire('result', position, rotation, inputSource);
+        this.manager.hitTest.fire('result', this, position, rotation, inputSource);
+
+        poolVec3.push(origin);
+        poolVec3.push(position);
+        poolQuat.push(rotation);
     }
 }
 

--- a/src/framework/xr/xr-hit-test-source.js
+++ b/src/framework/xr/xr-hit-test-source.js
@@ -135,8 +135,7 @@ class XrHitTestSource extends EventHandler {
         if (inputSource && !inputSource.hitTestSourcesSet.has(this))
             return;
 
-        let origin = poolVec3.pop();
-        if (!origin) origin = new Vec3();
+        const origin = poolVec3.pop() ?? new Vec3();
 
         if (inputSource) {
             origin.copy(inputSource.getOrigin());
@@ -146,11 +145,8 @@ class XrHitTestSource extends EventHandler {
 
         let candidateDistance = Infinity;
 
-        let position = poolVec3.pop();
-        if (!position) position = new Vec3();
-
-        let rotation = poolQuat.pop();
-        if (!rotation) rotation = new Quat();
+        const position = poolVec3.pop() ?? new Vec3();
+        const rotation = poolQuat.pop() ?? new Quat();
 
         for (let i = 0; i < results.length; i++) {
             const pose = results[i].getPose(this.manager._referenceSpace);

--- a/src/framework/xr/xr-hit-test-source.js
+++ b/src/framework/xr/xr-hit-test-source.js
@@ -132,6 +132,9 @@ class XrHitTestSource extends EventHandler {
      * @private
      */
     updateHitResults(results, inputSource) {
+        if (inputSource && inputSource.hitTestSourcesSet.has(this))
+            return;
+
         for (let i = 0; i < results.length; i++) {
             const pose = results[i].getPose(this.manager._referenceSpace);
 

--- a/src/framework/xr/xr-input-source.js
+++ b/src/framework/xr/xr-input-source.js
@@ -140,6 +140,12 @@ class XrInputSource extends EventHandler {
     _hitTestSources = [];
 
     /**
+     * @type {Set<import('./xr-hit-test-source.js').XrHitTestSource>}
+     * @ignore
+     */
+    hitTestSourcesSet = new Set();
+
+    /**
      * Create a new XrInputSource instance.
      *
      * @param {import('./xr-manager.js').XrManager} manager - WebXR Manager.
@@ -610,6 +616,7 @@ class XrInputSource extends EventHandler {
      * @private
      */
     onHitTestSourceAdd(hitTestSource) {
+        this.hitTestSourcesSet.add(hitTestSource);
         this._hitTestSources.push(hitTestSource);
 
         this.fire('hittest:add', hitTestSource);
@@ -632,6 +639,7 @@ class XrInputSource extends EventHandler {
      * @private
      */
     onHitTestSourceRemove(hitTestSource) {
+        this.hitTestSourcesSet.delete(hitTestSource);
         const ind = this._hitTestSources.indexOf(hitTestSource);
         if (ind !== -1) this._hitTestSources.splice(ind, 1);
     }


### PR DESCRIPTION
Based on WebXR specs, it is possible to query hit test results for specific input sources, but it is done using `profile` array string. As left / right controllers have the same profile string, then hit test source can report information from various input sources. This PR fixes that, and ensures that HitTestSource fires `result` event only for the input source it is related to.

Additionally underlying systems can provide multiple results per hit test source as ray can pass through multiple planes. Previously only devices with a single result were present, so this PR updates that, and ensures that single (closest) result is returned. If there will be a need for returning multiple results, then additional PR with `resultsAll` callback probably can be made.

Example with AR Hit Test is updated to include additional input sources (screen taps, controllers and hands).

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
