### PR TITLE
Examples: Use actual component to hide spinner

### DIFF
--- a/examples/src/app/code-editor.mjs
+++ b/examples/src/app/code-editor.mjs
@@ -78,14 +78,12 @@ class CodeEditor extends TypedComponent {
         /** @type {Record<string, string>} */
         const files = event.files;
         this.mergeState({ files, selectedFile: 'example.mjs' });
-        document.querySelector(".spin").style.display = 'none';
     }
 
     handleExampleLoading(event) {
         this.mergeState({
             files: {'example.mjs': '// reloading'}
         });
-        document.querySelector(".spin").style.display = '';
     }
 
     handleRequestedFiles(event) {

--- a/examples/src/app/example.mjs
+++ b/examples/src/app/example.mjs
@@ -303,13 +303,13 @@ class Example extends TypedComponent {
 
     render() {
         const { iframePath } = this;
-        const { orientation } = this.state;
+        const { orientation, exampleLoaded } = this.state;
         // console.log("Example#render", JSON.stringify(this.state, null, 2));
         return jsx(Container,
             {
                 id: "canvas-container"
             },
-            jsx(Spinner, { size: 50 }),
+            !exampleLoaded && jsx(Spinner, { size: 50 }),
             jsx("iframe", {
                 id: "exampleIframe",
                 key: iframePath,


### PR DESCRIPTION
Fixes #5781

(I would still like some feedback from @Maksims about which example/OS was affected to test this on my side, in the meantime I will update the live browser so we can easily test it)

Edit:

This PR doesn't just `display:none` but removing it from the DOM. Testable via `document.getElementsByClassName("spin")`:

![image](https://github.com/playcanvas/engine/assets/5236548/60cee7af-6b9f-4972-90bd-219cb899619f)

Updated Examples browser for this PR: https://examples.killtube.org/#/misc/hello-world

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
