### PR TITLE
[Fix] When clustered shadows are disabled, Lightmapper does not render their shadows

### DIFF
--- a/src/framework/lightmapper/lightmapper.js
+++ b/src/framework/lightmapper/lightmapper.js
@@ -843,7 +843,7 @@ class Lightmapper {
 
         const light = bakeLight.light;
         const isClustered = this.scene.clusteredLightingEnabled;
-        const castShadow = light.castShadows && (isClustered ? this.scene.lighting.shadowsEnabled : true);
+        const castShadow = light.castShadows && (!isClustered || this.scene.lighting.shadowsEnabled);
 
         if (!shadowMapRendered && castShadow) {
 

--- a/src/framework/lightmapper/lightmapper.js
+++ b/src/framework/lightmapper/lightmapper.js
@@ -843,8 +843,9 @@ class Lightmapper {
 
         const light = bakeLight.light;
         const isClustered = this.scene.clusteredLightingEnabled;
+        const castShadow = light.castShadows && (isClustered ? this.scene.lighting.shadowsEnabled : true);
 
-        if (!shadowMapRendered && light.castShadows) {
+        if (!shadowMapRendered && castShadow) {
 
             // allocate shadow map from the cache to avoid per light allocation
             if (!light.shadowMap && !isClustered) {


### PR DESCRIPTION
Fixes https://github.com/playcanvas/engine/issues/5789

When clustered lighting is enabled, but shadow casting is disabled, do not render shadows by Lightmapper to honour the flag.

