### PR TITLE
[Fix] Webgpu sets up render pipeline format for multi-sampled buffer

### DIFF
--- a/src/platform/graphics/webgpu/webgpu-render-pipeline.js
+++ b/src/platform/graphics/webgpu/webgpu-render-pipeline.js
@@ -272,12 +272,6 @@ class WebgpuRenderPipeline extends WebgpuPipeline {
                 buffers: vertexBufferLayout
             },
 
-            fragment: {
-                module: webgpuShader.getFragmentShaderModule(),
-                entryPoint: webgpuShader.fragmentEntryPoint,
-                targets: []
-            },
-
             primitive: {
                 topology: primitiveTopology,
                 frontFace: 'ccw',
@@ -296,6 +290,12 @@ class WebgpuRenderPipeline extends WebgpuPipeline {
 
         const colorAttachments = renderTarget.impl.colorAttachments;
         if (colorAttachments.length > 0) {
+
+            descr.fragment = {
+                module: webgpuShader.getFragmentShaderModule(),
+                entryPoint: webgpuShader.fragmentEntryPoint,
+                targets: []
+            };
 
             // the same write mask is used by all color buffers, to match the WebGL behavior
             let writeMask = 0;

--- a/src/platform/graphics/webgpu/webgpu-render-target.js
+++ b/src/platform/graphics/webgpu/webgpu-render-target.js
@@ -331,7 +331,7 @@ class WebgpuRenderTarget {
             // allocate multi-sampled color buffer
             const multisampledColorBuffer = wgpu.createTexture(multisampledTextureDesc);
             DebugHelper.setLabel(multisampledColorBuffer, `${renderTarget.name}.multisampledColor`);
-            this.setColorAttachment(index, multisampledColorBuffer);
+            this.setColorAttachment(index, multisampledColorBuffer, multisampledTextureDesc.format);
 
             colorAttachment.view = multisampledColorBuffer.createView();
             DebugHelper.setLabel(colorAttachment.view, `${renderTarget.name}.multisampledColorView`);


### PR DESCRIPTION
- some example (for example blend-trees-2d-cartesian) were failing on WebGPU, but I'm not entirely sure how come there were not failing for a long time.