### PR TITLE
Fix collision initialization for container assets.

### DIFF
--- a/src/framework/components/collision/system.js
+++ b/src/framework/components/collision/system.js
@@ -442,21 +442,36 @@ class CollisionMeshSystemImpl extends CollisionSystemImpl {
         const data = component.data;
         const assets = this.system.app.assets;
 
+        const onAssetFullyReady = (asset) => {
+            data[property] = asset.resource;
+            this.doRecreatePhysicalShape(component);
+        };
+
+        const loadAndHandleAsset = (asset) => {
+            asset.ready((asset) => {
+                if (asset.data.containerAsset) {
+                    const containerAsset = assets.get(asset.data.containerAsset);
+                    if (containerAsset.loaded) {
+                        onAssetFullyReady(asset);
+                    } else {
+                        containerAsset.ready(() => {
+                            onAssetFullyReady(asset);
+                        });
+                        assets.load(containerAsset);
+                    }
+                } else {
+                    onAssetFullyReady(asset);
+                }
+            });
+
+            assets.load(asset);
+        };
+
         const asset = assets.get(id);
         if (asset) {
-            asset.ready((asset) => {
-                data[property] = asset.resource;
-                this.doRecreatePhysicalShape(component);
-            });
-            assets.load(asset);
+            loadAndHandleAsset(asset);
         } else {
-            assets.once('add:' + id, (asset) => {
-                asset.ready((asset) => {
-                    data[property] = asset.resource;
-                    this.doRecreatePhysicalShape(component);
-                });
-                assets.load(asset);
-            });
+            assets.once('add:' + id, loadAndHandleAsset);
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/playcanvas/engine/issues/3638 and https://github.com/playcanvas/engine/issues/3974.

This PR implements an additional check when using Assets that have a Container Asset on Collision components. The new code will check if the asset's `containerAsset` is also loaded, and if not, load it. As noted in the linked Issues, this is required so that the `meshInstances` are actually loaded on the asset.

For use-cases where the Asset does not have a containerAsset or if it's already loaded, there's no change.

Sample Project with bug: https://playcanvas.com/editor/scene/1894310

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
