### PR TITLE
[Fix] Fix issue with local lights using ‘static’ flag

### DIFF
--- a/src/scene/materials/lit-material-options-builder.js
+++ b/src/scene/materials/lit-material-options-builder.js
@@ -158,11 +158,6 @@ class LitMaterialOptionsBuilder {
             const light = lights[i];
             if (light.enabled) {
                 if (light.mask & mask) {
-                    if (lType !== LIGHTTYPE_DIRECTIONAL) {
-                        if (light.isStatic) {
-                            continue;
-                        }
-                    }
                     lightsFiltered.push(light);
                 }
             }


### PR DESCRIPTION
- static lights were removed in v164, but one bit was missed, which would cause lights used to generate shader not match the lights used for rendering, causing rendering errors (missing spot light texture in this specific case)
- fixes Space Base project rendering