### PR TITLE
Fixes RigidBody remove component

### DIFF
--- a/src/framework/components/rigid-body/component.js
+++ b/src/framework/components/rigid-body/component.js
@@ -503,8 +503,12 @@ class RigidBodyComponent extends Component {
         }
 
         if (shape) {
-            if (this._body)
-                this.system.onRemove(entity, this);
+            if (this._body) {
+                this.system.removeBody(this._body);
+                this.system.destroyBody(this._body);
+
+                this._body = null;
+            }
 
             const mass = this._type === BODYTYPE_DYNAMIC ? this._mass : 0;
 

--- a/src/framework/components/rigid-body/system.js
+++ b/src/framework/components/rigid-body/system.js
@@ -332,7 +332,6 @@ class RigidBodyComponentSystem extends ComponentSystem {
         this.frameCollisions = {};
 
         this.on('beforeremove', this.onBeforeRemove, this);
-        this.on('remove', this.onRemove, this);
     }
 
     /**
@@ -433,16 +432,9 @@ class RigidBodyComponentSystem extends ComponentSystem {
         if (component.enabled) {
             component.enabled = false;
         }
-    }
 
-    onRemove(entity, component) {
-        const body = component.body;
-        if (body) {
-            this.removeBody(body);
-            this.destroyBody(body);
-
-            component.body = null;
-        }
+        this.destroyBody(component.body);
+        component.body = null;
     }
 
     addBody(body, group, mask) {

--- a/src/framework/components/rigid-body/system.js
+++ b/src/framework/components/rigid-body/system.js
@@ -433,8 +433,10 @@ class RigidBodyComponentSystem extends ComponentSystem {
             component.enabled = false;
         }
 
-        this.destroyBody(component.body);
-        component.body = null;
+        if (component.body) {
+            this.destroyBody(component.body);
+            component.body = null;
+        }
     }
 
     addBody(body, group, mask) {


### PR DESCRIPTION
This PR fixes #4145 and #5801 where the RigidBodyComponentSystem would never remove a rigid body from Ammo when `removeComponent` was called

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
