### PR TITLE
Fix to splats frustum culling

### DIFF
--- a/extras/splat/splat-container-resource.js
+++ b/extras/splat/splat-container-resource.js
@@ -87,13 +87,12 @@ class SplatContainerResource extends ContainerResource {
         });
 
         // set custom aabb
-        entity.render.customAabb = this.customAabb;
+        entity.render.customAabb = splat.aabb.clone();
 
         // when the render component gets deleted, destroy the splat instance
         entity.render.system.on('beforeremove', (entity, component) => {
             splatInstance.destroy();
         }, this);
-
 
         return entity;
     }

--- a/extras/splat/splat-instance.js
+++ b/extras/splat/splat-instance.js
@@ -79,7 +79,7 @@ class SplatInstance {
         this.vb = vb;
 
         this.meshInstance = new MeshInstance(this.mesh, this.material);
-        this.meshInstance.setInstancing(vb);
+        this.meshInstance.setInstancing(vb, true);
         this.meshInstance.splatInstance = this;
 
         this.sorter = new SplatSorter();

--- a/src/scene/mesh-instance.js
+++ b/src/scene/mesh-instance.js
@@ -788,10 +788,15 @@ class MeshInstance {
     /**
      * Sets up {@link MeshInstance} to be rendered using Hardware Instancing.
      *
-     * @param {import('../platform/graphics/vertex-buffer.js').VertexBuffer|null} vertexBuffer - Vertex buffer to hold per-instance vertex data
-     * (usually world matrices). Pass null to turn off hardware instancing.
+     * @param {import('../platform/graphics/vertex-buffer.js').VertexBuffer|null} vertexBuffer -
+     * Vertex buffer to hold per-instance vertex data (usually world matrices). Pass null to turn
+     * off hardware instancing.
+     * @param {boolean} cull - Whether to perform frustum culling on this instance. If true, the whole
+     * instance will be culled by the  camera frustum. This often involves setting
+     * {@link RenderComponent#customAabb} containing all instances. Defaults to false, which means
+     * the whole instance is always rendered.
      */
-    setInstancing(vertexBuffer) {
+    setInstancing(vertexBuffer, cull = false) {
         if (vertexBuffer) {
             this.instancingData = new InstancingData(vertexBuffer.numVertices);
             this.instancingData.vertexBuffer = vertexBuffer;
@@ -799,8 +804,8 @@ class MeshInstance {
             // mark vertex buffer as instancing data
             vertexBuffer.format.instancing = true;
 
-            // turn off culling - we do not do per-instance culling, all instances are submitted to GPU
-            this.cull = false;
+            // set up culling
+            this.cull = cull;
         } else {
             this.instancingData = null;
             this.cull = true;


### PR DESCRIPTION
- Instancing used to turn off frustum culling of the mesh instance. The API now has additional parameter to control this. If the case a user sets up a customAabb on the render / model component, they can enable culling for the mesh instancing. Note that there is no culling per instance, but a single custom aabb is used to cull all instances.
- this is used by gaussian splat rendering to skip rendering when splat is off-screen

### Changed API:

```
// note the new cull parameter, which defaults to false which was the original behaviour
MeshInstance.setInstancing(vertexBuffer, cull = false)
```