### PR TITLE
Guards against zero canvas size

### DIFF
--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -797,7 +797,8 @@ class WebglGraphicsDevice extends GraphicsDevice {
     updateBackbuffer() {
 
         const resolutionChanged = this.canvas.width !== this.backBufferSize.x || this.canvas.height !== this.backBufferSize.y;
-        if (this._defaultFramebufferChanged || resolutionChanged) {
+        const isCanvasNonZero = this.canvas.width > 0 && this.canvas.height > 0;
+        if (isCanvasNonZero && (this._defaultFramebufferChanged || resolutionChanged)) {
 
             // if the default framebuffer changes (entering or exiting XR for example)
             if (this._defaultFramebufferChanged) {


### PR DESCRIPTION
This adds a guard to not update the back buffer when the canvas size is 0, which happens when the css display is set to 'hidden'

Fixes #5806

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
