### PR TITLE
[Examples] Fix shader code indentation

### DIFF
--- a/examples/src/app/helpers/strings.mjs
+++ b/examples/src/app/helpers/strings.mjs
@@ -65,9 +65,17 @@ function countLeadingSpaces(str) {
  * @returns {string} Same code, but removed reduddant spaces.
  */
 function removeRedundantSpaces(code) {
-    const n = Math.min(...code.split('\n').filter(Boolean).map(countLeadingSpaces));
+    const lines = code
+        .split('\n')
+        .slice(0, -1) // ignore last line - it's just used for nice template-string indentation
+        .filter(_ => Boolean(_.trim())) // ignore spaces-only lines
+        .map(countLeadingSpaces);
+    if (!lines.length) {
+        return code;
+    }
+    const n = Math.min(...lines);
     const removeSpacesRegExp = new RegExp(' '.repeat(n), 'g');
-    const prettyCode = code.replace(removeSpacesRegExp, '');
+    const prettyCode = code.replace(removeSpacesRegExp, '').trim() + '\n';
     return prettyCode;
 }
 


### PR DESCRIPTION
I was just testing the latest Gaussian Splat example and figured the shader code received a wrong indentation:

![image](https://github.com/playcanvas/engine/assets/5236548/c036c09b-1747-4a98-9f64-ecf05df1775c)

Basically it happened through the last line here:

![image](https://github.com/playcanvas/engine/assets/5236548/fb1976ec-9966-4943-83c0-9551f8712a2d)

It happens to fit twice and then the spaces-replacement would catch a line twice. I'm sure we could also use a multiline-replacement-regex searching for "start of line", but I don't know how well supported that is across browser etc., so I just kept it somewhat simple.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
