### PR TITLE
[Fix] Fixes to picker to properly set up camera

### DIFF
--- a/src/framework/graphics/picker.js
+++ b/src/framework/graphics/picker.js
@@ -113,7 +113,7 @@ class Picker {
             const index = a << 24 | r << 16 | g << 8 | b;
 
             // White is 'no selection'
-            if (index !== 0xffffffff) {
+            if (index !== -1) {
                 tempSet.add(mapping.get(index));
             }
         }

--- a/src/framework/graphics/render-pass-picker.js
+++ b/src/framework/graphics/render-pass-picker.js
@@ -32,7 +32,7 @@ class RenderPassPicker extends RenderPass {
         const device = this.device;
         DebugGraphics.pushGpuMarker(device, 'PICKER');
 
-        const { renderer, camera, scene, layers, mapping } = this;
+        const { renderer, camera, scene, layers, mapping, renderTarget } = this;
         const srcLayers = scene.layers.layerList;
         const subLayerEnabled = scene.layers.subLayerEnabled;
         const isTransparent = scene.layers.subLayerList;
@@ -53,6 +53,9 @@ class RenderPassPicker extends RenderPass {
                 // if the layer is rendered by the camera
                 if (srcLayer.camerasSet.has(camera.camera)) {
 
+                    const transparent = isTransparent[i];
+                    DebugGraphics.pushGpuMarker(device, `${srcLayer.name}(${transparent ? 'TRANSP' : 'OPAQUE'})`);
+
                     // if the layer clears the depth
                     if (srcLayer._clearDepthBuffer) {
                         renderer.clear(camera.camera, false, true, false);
@@ -61,7 +64,6 @@ class RenderPassPicker extends RenderPass {
                     // Use mesh instances from the layer. Ideally we'd just pick culled instances for the camera,
                     // but we have no way of knowing if culling has been performed since changes to the layer.
                     // Disadvantage here is that we render all mesh instances, even those not visible by the camera.
-                    const transparent = isTransparent[i];
                     const meshInstances = srcLayer.meshInstances;
 
                     // only need mesh instances with a pick flag
@@ -75,17 +77,23 @@ class RenderPassPicker extends RenderPass {
                         }
                     }
 
-                    renderer.renderForward(camera.camera, tempMeshInstances, lights, SHADER_PICK, (meshInstance) => {
-                        const miId = meshInstance.id;
-                        pickColor[0] = ((miId >> 16) & 0xff) / 255;
-                        pickColor[1] = ((miId >> 8) & 0xff) / 255;
-                        pickColor[2] = (miId & 0xff) / 255;
-                        pickColor[3] = ((miId >> 24) & 0xff) / 255;
-                        pickColorId.setValue(pickColor);
-                        device.setBlendState(BlendState.NOBLEND);
-                    });
+                    if (tempMeshInstances.length > 0) {
 
-                    tempMeshInstances.length = 0;
+                        renderer.setCameraUniforms(camera.camera, renderTarget);
+                        renderer.renderForward(camera.camera, tempMeshInstances, lights, SHADER_PICK, (meshInstance) => {
+                            const miId = meshInstance.id;
+                            pickColor[0] = ((miId >> 16) & 0xff) / 255;
+                            pickColor[1] = ((miId >> 8) & 0xff) / 255;
+                            pickColor[2] = (miId & 0xff) / 255;
+                            pickColor[3] = ((miId >> 24) & 0xff) / 255;
+                            pickColorId.setValue(pickColor);
+                            device.setBlendState(BlendState.NOBLEND);
+                        });
+
+                        tempMeshInstances.length = 0;
+                    }
+
+                    DebugGraphics.popGpuMarker(device);
                 }
             }
         }

--- a/src/platform/graphics/webgl/webgl-render-target.js
+++ b/src/platform/graphics/webgl/webgl-render-target.js
@@ -340,6 +340,9 @@ class WebglRenderTarget {
 
         Debug.assert(src !== dst, 'Source and destination framebuffers must be different when blitting.');
 
+        // blit is affected by scissor test, so make it full size
+        device.setScissor(0, 0, target.width, target.height);
+
         const gl = device.gl;
         gl.bindFramebuffer(gl.READ_FRAMEBUFFER, src);
         gl.bindFramebuffer(gl.DRAW_FRAMEBUFFER, dst);

--- a/src/scene/renderer/render-pass-render-actions.js
+++ b/src/scene/renderer/render-pass-render-actions.js
@@ -137,7 +137,7 @@ class RenderPassRenderActions extends RenderPass {
         const cameraPass = layerComposition.camerasMap.get(camera);
 
         DebugGraphics.pushGpuMarker(this.device, camera ? camera.entity.name : 'noname');
-        DebugGraphics.pushGpuMarker(this.device, layer.name);
+        DebugGraphics.pushGpuMarker(this.device, `${layer.name}(${transparent ? 'TRANSP' : 'OPAQUE'})`);
 
         // #if _PROFILER
         const drawTime = now();


### PR DESCRIPTION
Fixes https://github.com/playcanvas/editor/issues/1072

- recent refactor introduced an issue where picker was not setting up camera uniforms, and so was rendering with whatever the previous camera was
- few other small cleanup / improvements