### PR TITLE
When 0 size render target is used, print a warning

### DIFF
--- a/src/platform/graphics/webgl/webgl-render-target.js
+++ b/src/platform/graphics/webgl/webgl-render-target.js
@@ -198,6 +198,12 @@ class WebglRenderTarget {
         // ##### Create MSAA FBO (WebGL2 only) #####
         if (device.isWebGL2 && target._samples > 1) {
 
+            Debug.call(() => {
+                if (target.width <= 0 || target.height <= 0) {
+                    Debug.warnOnce(`Invalid render target size: ${target.width} x ${target.height}`, target);
+                }
+            });
+
             // Use previous FBO for resolves
             this._glResolveFrameBuffer = this._glFrameBuffer;
 


### PR DESCRIPTION
Fixes https://github.com/playcanvas/engine/issues/5806

This make it easier to understand what and when happens. Instead of just the WebGL error (last line), we get additional info:

![Screenshot 2023-11-10 at 11 39 28](https://github.com/playcanvas/engine/assets/59932779/633dd147-bafd-4a8c-b25b-bccf08050c89)
