### PR TITLE
Support for Integer vertex attributes on WebGL2

### DIFF
--- a/extras/splat/splat-instance.js
+++ b/extras/splat/splat-instance.js
@@ -58,7 +58,7 @@ class SplatInstance {
         // initialize index data
         const numSplats = splat.numSplats;
         let indexData;
-        if (device.isWebGPU) {
+        if (!device.isWebGL1) {
             indexData = new Uint32Array(numSplats);
             for (let i = 0; i < numSplats; ++i) {
                 indexData[i] = i;
@@ -84,7 +84,7 @@ class SplatInstance {
         this.meshInstance.splatInstance = this;
 
         this.sorter = new SplatSorter();
-        this.sorter.init(this.vb, this.splat.centers, this.splat.device.isWebGPU);
+        this.sorter.init(this.vb, this.splat.centers, !this.splat.device.isWebGL1);
 
         // if camera entity is provided, automatically use it to sort splats
         const cameraEntity = options.cameraEntity;

--- a/extras/splat/splat-material.js
+++ b/extras/splat/splat-material.js
@@ -49,7 +49,7 @@ const splatCoreVS = `
     uniform highp sampler2D splatRotation;
     uniform highp sampler2D splatCenter;
 
-    #ifdef WEBGPU
+    #ifdef INT_INDICES
 
         attribute uint vertex_id;
         ivec2 dataUV;
@@ -60,7 +60,7 @@ const splatCoreVS = `
             vec2 invTextureSize = tex_params.zw;
 
             int gridV = int(float(vertex_id) * invTextureSize.x);
-            int gridU = int(vertex_id - gridV * textureSize.x);
+            int gridU = int(vertex_id) - gridV * textureSize.x;
             dataUV = ivec2(gridU, gridV);
         }
 
@@ -99,19 +99,19 @@ const splatCoreVS = `
         }
 
         vec4 getColor() {
-            return texture(splatColor, dataUV);
+            return texture2D(splatColor, dataUV);
         }
 
         vec3 getScale() {
-            return texture(splatScale, dataUV).xyz;
+            return texture2D(splatScale, dataUV).xyz;
         }
 
         vec3 getRotation() {
-            return texture(splatRotation, dataUV).xyz;
+            return texture2D(splatRotation, dataUV).xyz;
         }
 
         vec3 getCenter() {
-            return texture(splatCenter, dataUV).xyz;
+            return texture2D(splatCenter, dataUV).xyz;
         }
 
     #endif
@@ -267,7 +267,8 @@ const createSplatMaterial = (device, options = {}) => {
     result.blendType = BLEND_NORMAL;
     result.depthWrite = false;
 
-    const defines = debugRender ? '#define DEBUG_RENDER\n' : '';
+    const defines = (debugRender ? '#define DEBUG_RENDER\n' : '') +
+        (device.isWebGL1 ? '' : '#define INT_INDICES\n');
     const vs = defines + splatCoreVS + (options.vertex ?? splatMainVS);
     const fs = defines + splatCoreFS + (options.fragment ?? splatMainFS);
 

--- a/extras/splat/splat.js
+++ b/extras/splat/splat.js
@@ -44,7 +44,7 @@ class Splat {
         this.aabb = aabb;
 
         this.vertexFormat = new VertexFormat(device, [
-            { semantic: SEMANTIC_ATTR13, components: 1, type: device.isWebGPU ? TYPE_UINT32 : TYPE_FLOAT32 }
+            { semantic: SEMANTIC_ATTR13, components: 1, type: device.isWebGL1 ? TYPE_FLOAT32 : TYPE_UINT32, asInt: !device.isWebGL1 }
         ]);
 
         // create data textures

--- a/src/platform/graphics/shader-processor.js
+++ b/src/platform/graphics/shader-processor.js
@@ -387,7 +387,7 @@ class ShaderProcessor {
                 const element = processingOptions.getVertexElement(semantic);
                 if (element) {
                     const dataType = element.dataType;
-                    if (dataType !== TYPE_FLOAT32 && dataType !== TYPE_FLOAT16 && !element.normalize) {
+                    if (dataType !== TYPE_FLOAT32 && dataType !== TYPE_FLOAT16 && !element.normalize && !element.asInt) {
 
                         const attribNumElements = ShaderProcessor.getTypeCount(type);
                         const newName = `_private_${name}`;

--- a/src/platform/graphics/vertex-format.js
+++ b/src/platform/graphics/vertex-format.js
@@ -96,11 +96,16 @@ class VertexFormat {
      * - {@link TYPE_UINT16}
      * - {@link TYPE_INT32}
      * - {@link TYPE_UINT32}
+     * - {@link TYPE_FLOAT16}
      * - {@link TYPE_FLOAT32}
      *
      * @param {boolean} [description[].normalize] - If true, vertex attribute data will be mapped
      * from a 0 to 255 range down to 0 to 1 when fed to a shader. If false, vertex attribute data
-     * is left unchanged. If this property is unspecified, false is assumed.
+     * is left unchanged. If this property is unspecified, false is assumed. This property is
+     * ignored when asInt is true.
+     * @param {boolean} [description[].asInt] - If true, vertex attribute data will be accessible
+     * as integer numbers in shader code. Defaults to false, which means that vertex attribute data
+     * will be accessible as floating point numbers. Can be only used with INT and UINT data types.
      * @param {number} [vertexCount] - When specified, vertex format will be set up for
      * non-interleaved format with a specified number of vertices. (example: PPPPNNNNCCCC), where
      * arrays of individual attributes will be stored one right after the other (subject to
@@ -159,14 +164,17 @@ class VertexFormat {
                              `Non-interleaved vertex format with element size not multiple of 4 can have performance impact on some platforms. Element size: ${elementSize}`);
             }
 
+            const asInt = elementDesc.asInt ?? false;
+            const normalize = asInt ? false : (elementDesc.normalize ?? false);
             const element = {
                 name: elementDesc.semantic,
                 offset: (vertexCount ? offset : (elementDesc.hasOwnProperty('offset') ? elementDesc.offset : offset)),
                 stride: (vertexCount ? elementSize : (elementDesc.hasOwnProperty('stride') ? elementDesc.stride : this.size)),
                 dataType: elementDesc.type,
                 numComponents: elementDesc.components,
-                normalize: elementDesc.normalize ?? false,
-                size: elementSize
+                normalize: normalize,
+                size: elementSize,
+                asInt: asInt
             };
             this._elements.push(element);
 

--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -1882,7 +1882,12 @@ class WebglGraphicsDevice extends GraphicsDevice {
                         locZero = true;
                     }
 
-                    gl.vertexAttribPointer(loc, e.numComponents, this.glType[e.dataType], e.normalize, e.stride, e.offset);
+                    if (e.asInt) {
+                        gl.vertexAttribIPointer(loc, e.numComponents, this.glType[e.dataType], e.stride, e.offset);
+                    } else {
+                        gl.vertexAttribPointer(loc, e.numComponents, this.glType[e.dataType], e.normalize, e.stride, e.offset);
+                    }
+
                     gl.enableVertexAttribArray(loc);
 
                     if (vertexBuffer.format.instancing) {


### PR DESCRIPTION
Fixes https://github.com/playcanvas/engine/issues/3930

- Int/uint attributes are now supported - which makes them available in shader as int/uint numbers, instead of as floats.
- This is also used on Splats, WebGL2 uses integer splat IDs to match WebGPU. Only WebGL1 uses floats.

New API
- `VertexFormat.description[].asInt` - true to interpret as int attribute, false as float (default)

example:
```
        const vertexFormat = new VertexFormat(device, [
            { semantic: SEMANTIC_ATTR13, components: 1, type: TYPE_UINT32, asInt: true }
        ]);

```