### PR TITLE
[Fix] Fix texture / render target resize on WebGL2

### DIFF
--- a/src/platform/graphics/webgl/webgl-texture.js
+++ b/src/platform/graphics/webgl/webgl-texture.js
@@ -345,7 +345,7 @@ class WebglTexture {
                         device.setUnpackFlipY(false);
                         device.setUnpackPremultiplyAlpha(texture._premultiplyAlpha);
 
-                        if (texture._glCreated) {
+                        if (this._glCreated) {
                             gl.texSubImage2D(
                                 gl.TEXTURE_CUBE_MAP_POSITIVE_X + face,
                                 mipLevel,
@@ -374,7 +374,7 @@ class WebglTexture {
 
                         const texData = mipObject[face];
                         if (texture._compressed) {
-                            if (texture._glCreated) {
+                            if (this._glCreated) {
                                 gl.compressedTexSubImage2D(
                                     gl.TEXTURE_CUBE_MAP_POSITIVE_X + face,
                                     mipLevel,
@@ -397,7 +397,7 @@ class WebglTexture {
                         } else {
                             device.setUnpackFlipY(false);
                             device.setUnpackPremultiplyAlpha(texture._premultiplyAlpha);
-                            if (texture._glCreated) {
+                            if (this._glCreated) {
                                 gl.texSubImage2D(
                                     gl.TEXTURE_CUBE_MAP_POSITIVE_X + face,
                                     mipLevel,
@@ -469,7 +469,7 @@ class WebglTexture {
                     // Upload the image, canvas or video
                     device.setUnpackFlipY(texture._flipY);
                     device.setUnpackPremultiplyAlpha(texture._premultiplyAlpha);
-                    if (texture._glCreated && mipObject.width === texture._width && mipObject.height === texture._height) {
+                    if (this._glCreated && mipObject.width === texture._width && mipObject.height === texture._height) {
                         gl.texSubImage2D(
                             gl.TEXTURE_2D,
                             mipLevel,
@@ -492,7 +492,7 @@ class WebglTexture {
                     // Upload the byte array
                     resMult = 1 / Math.pow(2, mipLevel);
                     if (texture._compressed) {
-                        if (texture._glCreated) {
+                        if (this._glCreated) {
                             gl.compressedTexSubImage2D(
                                 gl.TEXTURE_2D,
                                 mipLevel,
@@ -516,7 +516,7 @@ class WebglTexture {
                     } else {
                         device.setUnpackFlipY(false);
                         device.setUnpackPremultiplyAlpha(texture._premultiplyAlpha);
-                        if (texture._glCreated) {
+                        if (this._glCreated) {
                             gl.texSubImage2D(
                                 gl.TEXTURE_2D,
                                 mipLevel,
@@ -574,7 +574,7 @@ class WebglTexture {
         texture._gpuSize = texture.gpuSize;
         texture.adjustVramSizeTracking(device._vram, texture._gpuSize);
 
-        texture._glCreated = true;
+        texture.this = true;
     }
 }
 

--- a/src/platform/graphics/webgl/webgl-texture.js
+++ b/src/platform/graphics/webgl/webgl-texture.js
@@ -574,7 +574,7 @@ class WebglTexture {
         texture._gpuSize = texture.gpuSize;
         texture.adjustVramSizeTracking(device._vram, texture._gpuSize);
 
-        texture.this = true;
+        this._glCreated = true;
     }
 }
 


### PR DESCRIPTION
- recent optimization in #5759 introduced the error by storing the data on an incorrect object (Texture vs WebglTexture)